### PR TITLE
Feat/agent include citations toggle

### DIFF
--- a/backend/alembic/versions/b3d9f1a2c4e7_add_include_citations_to_persona.py
+++ b/backend/alembic/versions/b3d9f1a2c4e7_add_include_citations_to_persona.py
@@ -1,0 +1,32 @@
+"""Add include_citations to persona
+
+Revision ID: b3d9f1a2c4e7
+Revises: 366c05b6f485
+Create Date: 2026-05-27 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b3d9f1a2c4e7"
+down_revision = "f57f35403f6c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "persona",
+        sa.Column(
+            "include_citations",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("persona", "include_citations")

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1263,6 +1263,12 @@ def _run_models(
                     f"Forced tool {setup.forced_tool_id} not found in tools"
                 )
 
+            # Citations are emitted only when both the request allows them
+            # and the agent (persona) is configured to include them.
+            include_citations = setup.new_msg_req.include_citations and (
+                setup.persona.include_citations if setup.persona else True
+            )
+
             # Per-thread copy: run_llm_loop mutates simple_chat_history in-place.
             if n_models == 1 and setup.new_msg_req.deep_research:
                 if setup.chat_session.project_id:
@@ -1280,6 +1286,7 @@ def _run_models(
                     user_identity=setup.user_identity,
                     chat_session_id=str(setup.chat_session.id),
                     all_injected_file_metadata=setup.all_injected_file_metadata,
+                    include_citations=include_citations,
                 )
             else:
                 run_llm_loop(
@@ -1298,12 +1305,7 @@ def _run_models(
                     chat_session_id=str(setup.chat_session.id),
                     chat_files=setup.chat_files_for_tools,
                     reasoning_effort=setup.reasoning_effort,
-                    # Citations are emitted only when both the request allows them
-                    # and the agent (persona) is configured to include them.
-                    include_citations=(
-                        setup.new_msg_req.include_citations
-                        and (setup.persona.include_citations if setup.persona else True)
-                    ),
+                    include_citations=include_citations,
                     all_injected_file_metadata=setup.all_injected_file_metadata,
                     inject_memories_in_prompt=user.use_memories,
                 )

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1298,7 +1298,12 @@ def _run_models(
                     chat_session_id=str(setup.chat_session.id),
                     chat_files=setup.chat_files_for_tools,
                     reasoning_effort=setup.reasoning_effort,
-                    include_citations=setup.new_msg_req.include_citations,
+                    # Citations are emitted only when both the request allows them
+                    # and the agent (persona) is configured to include them.
+                    include_citations=(
+                        setup.new_msg_req.include_citations
+                        and (setup.persona.include_citations if setup.persona else True)
+                    ),
                     all_injected_file_metadata=setup.all_injected_file_metadata,
                     inject_memories_in_prompt=user.use_memories,
                 )

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1265,7 +1265,7 @@ def _run_models(
 
             # Citations are emitted only when both the request allows them
             # and the agent (persona) is configured to include them.
-            include_citations = setup.new_msg_req.include_citations and (
+            include_citations: bool = setup.new_msg_req.include_citations and (
                 setup.persona.include_citations if setup.persona else True
             )
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4038,6 +4038,11 @@ class Persona(Base):
         String(length=PROMPT_LENGTH), nullable=True
     )
     datetime_aware: Mapped[bool] = mapped_column(Boolean, default=True)
+    # Controls whether the agent's answers include inline citations ([[1]](...))
+    # and a sources list. Defaults to True (citations shown).
+    include_citations: Mapped[bool] = mapped_column(
+        Boolean, default=True, server_default="true", nullable=False
+    )
 
     uploaded_image_id: Mapped[str | None] = mapped_column(String, nullable=True)
     icon_name: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -396,6 +396,7 @@ def create_update_persona(
             search_start_date=create_persona_request.search_start_date,
             label_ids=create_persona_request.label_ids,
             is_featured=create_persona_request.is_featured,
+            include_citations=create_persona_request.include_citations,
             user_file_ids=converted_user_file_ids,
             commit=False,
             hierarchy_node_ids=create_persona_request.hierarchy_node_ids,
@@ -1285,6 +1286,7 @@ def upsert_persona(
     search_start_date: datetime | None = None,
     builtin_persona: bool = False,
     is_featured: bool | None = None,
+    include_citations: bool | None = None,
     label_ids: list[int] | None = None,
     user_file_ids: list[UUID] | None = None,
     hierarchy_node_ids: list[int] | None = None,
@@ -1500,6 +1502,12 @@ def upsert_persona(
             existing_persona.is_listed = is_listed
         if is_featured is not None and user_can_set_admin_flags:
             existing_persona.is_featured = is_featured
+        # Not an admin-only flag: any editor who can save the agent can set it.
+        existing_persona.include_citations = (
+            include_citations
+            if include_citations is not None
+            else existing_persona.include_citations
+        )
         # Update embedded prompt fields if provided
         if system_prompt is not None:
             existing_persona.system_prompt = system_prompt
@@ -1566,6 +1574,9 @@ def upsert_persona(
             is_listed=(is_listed if is_listed is not None else True),
             search_start_date=search_start_date,
             is_featured=(is_featured if is_featured is not None else False),
+            include_citations=(
+                include_citations if include_citations is not None else True
+            ),
             user_files=user_files or [],
             labels=labels or [],
             hierarchy_nodes=hierarchy_nodes or [],

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -8,7 +8,11 @@ from collections.abc import Callable
 from typing import cast
 
 from onyx.chat.chat_state import ChatStateContainer
-from onyx.chat.citation_processor import CitationMapping, DynamicCitationProcessor
+from onyx.chat.citation_processor import (
+    CitationMapping,
+    CitationMode,
+    DynamicCitationProcessor,
+)
 from onyx.chat.emitter import Emitter
 from onyx.chat.llm_loop import construct_message_history
 from onyx.chat.llm_step import run_llm_step, run_llm_step_pkt_generator
@@ -114,6 +118,7 @@ def generate_final_report(
     saved_reasoning: str | None = None,
     pre_answer_processing_time: float | None = None,
     all_injected_file_metadata: dict[str, FileToolMetadata] | None = None,
+    include_citations: bool = True,
 ) -> bool:
     """Generate the final research report.
 
@@ -147,7 +152,14 @@ def generate_final_report(
             all_injected_file_metadata=all_injected_file_metadata,
         )
 
-        citation_processor = DynamicCitationProcessor()
+        # When include_citations is False (the persona has citations disabled),
+        # use REMOVE mode so the final report strips citation markers and emits no
+        # sources, mirroring run_llm_loop's behavior for the non-deep-research path.
+        citation_processor = DynamicCitationProcessor(
+            citation_mode=(
+                CitationMode.HYPERLINK if include_citations else CitationMode.REMOVE
+            )
+        )
         citation_processor.update_citation_mapping(citation_mapping)
 
         # Only passing in the cited documents as the whole list would be too long
@@ -210,6 +222,7 @@ def run_deep_research_llm_loop(
     user_identity: LLMUserIdentity | None = None,
     chat_session_id: str | None = None,
     all_injected_file_metadata: dict[str, FileToolMetadata] | None = None,
+    include_citations: bool = True,
 ) -> None:
     with trace(
         "run_deep_research_llm_loop",
@@ -465,6 +478,7 @@ def run_deep_research_llm_loop(
                         reasoning_effort=reasoning_effort,
                         pre_answer_processing_time=elapsed_seconds,
                         all_injected_file_metadata=all_injected_file_metadata,
+                        include_citations=include_citations,
                     )
                     final_turn_index = report_turn_index + (1 if report_reasoned else 0)
                     break
@@ -571,6 +585,7 @@ def run_deep_research_llm_loop(
                         pre_answer_processing_time=time.monotonic()
                         - processing_start_time,
                         all_injected_file_metadata=all_injected_file_metadata,
+                        include_citations=include_citations,
                     )
                     final_turn_index = report_turn_index + (1 if report_reasoned else 0)
                     break
@@ -594,6 +609,7 @@ def run_deep_research_llm_loop(
                         pre_answer_processing_time=time.monotonic()
                         - processing_start_time,
                         all_injected_file_metadata=all_injected_file_metadata,
+                        include_citations=include_citations,
                     )
                     final_turn_index = report_turn_index + (1 if report_reasoned else 0)
                     break
@@ -668,6 +684,7 @@ def run_deep_research_llm_loop(
                             pre_answer_processing_time=time.monotonic()
                             - processing_start_time,
                             all_injected_file_metadata=all_injected_file_metadata,
+                            include_citations=include_citations,
                         )
                         final_turn_index = report_turn_index + (
                             1 if report_reasoned else 0

--- a/backend/onyx/onyxbot/discord/api_client.py
+++ b/backend/onyx/onyxbot/discord/api_client.py
@@ -1,8 +1,12 @@
 """Async HTTP client for communicating with Onyx API pods."""
 
+from collections.abc import Sequence
+
 import aiohttp
 
 from onyx.chat.models import ChatFullResponse
+from onyx.file_store.models import FileDescriptor
+from onyx.onyxbot.discord.attachments import MessageAttachment
 from onyx.onyxbot.discord.constants import API_REQUEST_TIMEOUT
 from onyx.onyxbot.discord.exceptions import (
     APIConnectionError,
@@ -10,6 +14,7 @@ from onyx.onyxbot.discord.exceptions import (
     APITimeoutError,
 )
 from onyx.server.query_and_chat.models import (
+    ChatFileUploadResponse,
     ChatSessionCreationRequest,
     MessageOrigin,
     SendMessageRequest,
@@ -92,11 +97,58 @@ class OnyxAPIClient:
         """Check if the session is initialized."""
         return self._session is not None
 
+    @staticmethod
+    async def _raise_for_error_status(response: aiohttp.ClientResponse) -> None:
+        """Translate an error response into the matching APIResponseError."""
+        if response.status == 401:
+            raise APIResponseError(
+                "Authentication failed - invalid API key",
+                status_code=401,
+            )
+        elif response.status == 403:
+            raise APIResponseError(
+                "Access denied - insufficient permissions",
+                status_code=403,
+            )
+        elif response.status == 404:
+            raise APIResponseError(
+                "API endpoint not found",
+                status_code=404,
+            )
+        elif response.status >= 500:
+            error_text = await response.text()
+            raise APIResponseError(
+                f"Server error: {error_text}",
+                status_code=response.status,
+            )
+        elif response.status >= 400:
+            error_text = await response.text()
+            raise APIResponseError(
+                f"Request error: {error_text}",
+                status_code=response.status,
+            )
+
+    def _translate_transport_error(self, e: Exception) -> Exception:
+        """Wrap an aiohttp transport failure in the matching APIError."""
+        if isinstance(e, aiohttp.ClientConnectorError):
+            logger.error("Failed to connect to API: %s", e)
+            return APIConnectionError(
+                f"Failed to connect to API at {self._base_url}: {e}"
+            )
+
+        if isinstance(e, TimeoutError):
+            logger.error("API request timed out after %ss", self._timeout)
+            return APITimeoutError(f"Request timed out after {self._timeout} seconds")
+
+        logger.error("HTTP client error: %s", e)
+        return APIConnectionError(f"HTTP client error: {e}")
+
     async def send_chat_message(
         self,
         message: str,
         api_key: str,
         persona_id: int | None = None,
+        file_descriptors: list[FileDescriptor] | None = None,
     ) -> ChatFullResponse:
         """Send a chat message to the Onyx API server and get a response.
 
@@ -107,6 +159,8 @@ class OnyxAPIClient:
             message: The user's message to process.
             api_key: The API key for authentication.
             persona_id: Optional persona ID to use for the response.
+            file_descriptors: Files to attach to the message, as returned by
+                `upload_chat_files`.
 
         Returns:
             ChatFullResponse containing the answer, citations, and metadata.
@@ -128,6 +182,7 @@ class OnyxAPIClient:
             message=message,
             stream=False,
             origin=MessageOrigin.DISCORDBOT,
+            file_descriptors=file_descriptors or [],
             chat_session_info=ChatSessionCreationRequest(
                 persona_id=persona_id if persona_id is not None else 0,
             ),
@@ -145,33 +200,7 @@ class OnyxAPIClient:
                 json=request.model_dump(mode="json"),
                 headers=headers,
             ) as response:
-                if response.status == 401:
-                    raise APIResponseError(
-                        "Authentication failed - invalid API key",
-                        status_code=401,
-                    )
-                elif response.status == 403:
-                    raise APIResponseError(
-                        "Access denied - insufficient permissions",
-                        status_code=403,
-                    )
-                elif response.status == 404:
-                    raise APIResponseError(
-                        "API endpoint not found",
-                        status_code=404,
-                    )
-                elif response.status >= 500:
-                    error_text = await response.text()
-                    raise APIResponseError(
-                        f"Server error: {error_text}",
-                        status_code=response.status,
-                    )
-                elif response.status >= 400:
-                    error_text = await response.text()
-                    raise APIResponseError(
-                        f"Request error: {error_text}",
-                        status_code=response.status,
-                    )
+                await self._raise_for_error_status(response)
 
                 # Parse successful response
                 data = await response.json()
@@ -184,21 +213,70 @@ class OnyxAPIClient:
 
                 return response_obj
 
-        except aiohttp.ClientConnectorError as e:
-            logger.error("Failed to connect to API: %s", e)
+        except (aiohttp.ClientError, TimeoutError) as e:
+            raise self._translate_transport_error(e) from e
+
+    async def upload_chat_files(
+        self,
+        files: Sequence[MessageAttachment],
+        api_key: str,
+    ) -> list[FileDescriptor]:
+        """Upload files to Onyx so they can be attached to a chat message.
+
+        Args:
+            files: The downloaded attachments to upload.
+            api_key: The API key for authentication.
+
+        Returns:
+            Descriptors for the accepted files, to pass to `send_chat_message`.
+            Files the server rejected (e.g. over its size limit) are logged and
+            omitted, so this can be shorter than `files`.
+
+        Raises:
+            APIConnectionError: If unable to connect to the API.
+            APITimeoutError: If the request times out.
+            APIResponseError: If the API returns an error response.
+        """
+        if self._session is None:
             raise APIConnectionError(
-                f"Failed to connect to API at {self._base_url}: {e}"
-            ) from e
+                "API client not initialized. Call initialize() first."
+            )
 
-        except TimeoutError as e:
-            logger.error("API request timed out after %ss", self._timeout)
-            raise APITimeoutError(
-                f"Request timed out after {self._timeout} seconds"
-            ) from e
+        if not files:
+            return []
 
-        except aiohttp.ClientError as e:
-            logger.error("HTTP client error: %s", e)
-            raise APIConnectionError(f"HTTP client error: {e}") from e
+        url = f"{self._base_url}/chat/file"
+
+        form = aiohttp.FormData()
+        for file in files:
+            form.add_field(
+                "files",
+                file.data,
+                filename=file.filename,
+                content_type=file.content_type,
+            )
+
+        # Content-Type is set by aiohttp so the multipart boundary matches.
+        headers = {"Authorization": f"Bearer {api_key}"}
+
+        try:
+            async with self._session.post(url, data=form, headers=headers) as response:
+                await self._raise_for_error_status(response)
+
+                data = await response.json()
+                upload_response = ChatFileUploadResponse.model_validate(data)
+
+                for rejected in upload_response.rejected_files:
+                    logger.warning(
+                        "Onyx rejected attachment '%s': %s",
+                        rejected.filename,
+                        rejected.reason,
+                    )
+
+                return upload_response.files
+
+        except (aiohttp.ClientError, TimeoutError) as e:
+            raise self._translate_transport_error(e) from e
 
     async def health_check(self) -> bool:
         """Check if the API server is healthy.

--- a/backend/onyx/onyxbot/discord/attachments.py
+++ b/backend/onyx/onyxbot/discord/attachments.py
@@ -1,0 +1,201 @@
+"""Extraction of user-posted attachments from Discord messages.
+
+Discord users routinely paste a screenshot or drop a PDF into a channel with
+little or no accompanying text. This module pulls those attachments off the
+message and downloads them so they can be forwarded to Onyx as chat files, which
+is what makes them visible to the agent (see `OnyxAPIClient.upload_chat_files`).
+
+Only the formats Onyx accepts as chat files are downloaded — anything else would
+be rejected server-side (or, worse, mis-classified), so it is reported as skipped
+instead. Images become `ChatFileType.IMAGE` and are passed to the model as image
+content; PDFs become `ChatFileType.DOC` and have their extracted text injected
+into the prompt, so they work regardless of whether the model supports vision.
+"""
+
+import os
+
+import discord
+from pydantic import BaseModel
+
+from onyx.file_processing.file_types import PDF_MIME_TYPE
+from onyx.onyxbot.discord.constants import (
+    MAX_ATTACHMENT_BYTES,
+    MAX_ATTACHMENTS_PER_MESSAGE,
+    MAX_TOTAL_ATTACHMENT_BYTES,
+)
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+PDF_EXTENSION = ".pdf"
+
+# The media type sent to Onyx for each extension we forward.
+#
+# Derived from the extension rather than trusted from Discord because the two
+# signals have to agree server-side: the upload endpoint accepts or rejects by
+# extension, while the resulting descriptor's `ChatFileType` comes from the
+# content type. Discord's `content_type` is optional and occasionally generic, so
+# taking it at face value would drop legitimately-named files or classify them as
+# the wrong `ChatFileType`. `test_attachments.py` pins the keys to the extensions
+# Onyx accepts and the values to media types it recognises.
+_EXTENSION_CONTENT_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    PDF_EXTENSION: PDF_MIME_TYPE,
+}
+
+
+class MessageAttachment(BaseModel):
+    """A downloaded Discord attachment, ready to upload to Onyx."""
+
+    filename: str
+    content_type: str
+    data: bytes
+
+
+class CollectedAttachments(BaseModel):
+    """Attachments pulled off a Discord message, plus what had to be left out.
+
+    `skipped_filenames` covers attachments Onyx could have used but that could
+    not be included (unsupported format, too large, or a failed download).
+    Callers surface these to the agent so it doesn't answer as if it had seen
+    everything the user posted.
+    """
+
+    files: list[MessageAttachment] = []
+    skipped_filenames: list[str] = []
+
+
+def _normalized_content_type(attachment: discord.Attachment) -> str:
+    """Lowercased media type with any parameters (e.g. `; charset=`) stripped."""
+    if not attachment.content_type:
+        return ""
+    return attachment.content_type.split(";")[0].strip().lower()
+
+
+def _file_extension(filename: str) -> str:
+    """Lowercased extension, matching the server's `get_file_ext`.
+
+    Must stay equivalent to it: an attachment we call supported here is one the
+    upload endpoint has to classify the same way. `splitext` (rather than
+    splitting on the last dot) is what makes an extensionless name like "pdf"
+    yield "" on both sides.
+    """
+    return os.path.splitext(filename)[1].lower()
+
+
+def is_forwardable_attachment(attachment: discord.Attachment) -> bool:
+    """Whether this is the kind of attachment the bot tries to forward at all.
+
+    Deliberately broader than `is_supported_attachment` — by either signal — so
+    that a pasted GIF, or a PDF whose name lost its extension, is reported as
+    skipped rather than silently ignored. Attachment kinds outside this set
+    (spreadsheets, archives, source files) are left alone.
+    """
+    content_type = _normalized_content_type(attachment)
+    return (
+        is_supported_attachment(attachment)
+        or content_type.startswith("image/")
+        or content_type == PDF_MIME_TYPE
+    )
+
+
+def is_supported_attachment(attachment: discord.Attachment) -> bool:
+    """Whether Onyx will accept this attachment as a chat file.
+
+    Keyed on the extension because that is what the upload endpoint accepts or
+    rejects on; `upload_content_type` then supplies a matching media type.
+    """
+    return _file_extension(attachment.filename) in _EXTENSION_CONTENT_TYPES
+
+
+def upload_content_type(attachment: discord.Attachment) -> str:
+    """The media type to send to Onyx for a supported attachment."""
+    return _EXTENSION_CONTENT_TYPES[_file_extension(attachment.filename)]
+
+
+async def collect_attachments(message: discord.Message) -> CollectedAttachments:
+    """Download the supported attachments on a Discord message.
+
+    Never raises: a message whose attachments can't be fetched still gets
+    answered on its text alone.
+    """
+    candidates = [
+        attachment
+        for attachment in message.attachments
+        if is_forwardable_attachment(attachment)
+    ]
+    if not candidates:
+        return CollectedAttachments()
+
+    collected = CollectedAttachments()
+    total_bytes = 0
+
+    for attachment in candidates:
+        if len(collected.files) >= MAX_ATTACHMENTS_PER_MESSAGE:
+            logger.warning(
+                "Skipping attachment '%s': more than %s attachments on one message",
+                attachment.filename,
+                MAX_ATTACHMENTS_PER_MESSAGE,
+            )
+            collected.skipped_filenames.append(attachment.filename)
+            continue
+
+        if not is_supported_attachment(attachment):
+            logger.info(
+                "Skipping attachment '%s' (%s): unsupported format",
+                attachment.filename,
+                _normalized_content_type(attachment) or "unknown type",
+            )
+            collected.skipped_filenames.append(attachment.filename)
+            continue
+
+        if attachment.size > MAX_ATTACHMENT_BYTES:
+            logger.warning(
+                "Skipping attachment '%s': %s bytes exceeds the %s byte limit",
+                attachment.filename,
+                attachment.size,
+                MAX_ATTACHMENT_BYTES,
+            )
+            collected.skipped_filenames.append(attachment.filename)
+            continue
+
+        if total_bytes + attachment.size > MAX_TOTAL_ATTACHMENT_BYTES:
+            logger.warning(
+                "Skipping attachment '%s': would exceed the %s byte per-message limit",
+                attachment.filename,
+                MAX_TOTAL_ATTACHMENT_BYTES,
+            )
+            collected.skipped_filenames.append(attachment.filename)
+            continue
+
+        try:
+            data = await attachment.read()
+        except Exception as e:
+            # Broad on purpose: a CDN hiccup surfaces as a DiscordException, a
+            # raw aiohttp error, or a timeout depending on where it fails, and
+            # none of them should stop the bot from answering the message text.
+            logger.warning(
+                "Failed to download attachment '%s': %s", attachment.filename, e
+            )
+            collected.skipped_filenames.append(attachment.filename)
+            continue
+
+        total_bytes += len(data)
+        collected.files.append(
+            MessageAttachment(
+                filename=attachment.filename,
+                content_type=upload_content_type(attachment),
+                data=data,
+            )
+        )
+
+    logger.debug(
+        "Collected %s attachment(s) (%s skipped) from message %s",
+        len(collected.files),
+        len(collected.skipped_filenames),
+        message.id,
+    )
+    return collected

--- a/backend/onyx/onyxbot/discord/constants.py
+++ b/backend/onyx/onyxbot/discord/constants.py
@@ -14,6 +14,17 @@ THINKING_EMOJI: str = "🤔"  # U+1F914 - Thinking Face
 SUCCESS_EMOJI: str = "✅"  # U+2705 - White Heavy Check Mark
 ERROR_EMOJI: str = "❌"  # U+274C - Cross Mark
 
+# Attachment settings
+# Discord allows at most 10 attachments per message, so this never truncates a
+# single real message; it only bounds work if that limit ever changes.
+MAX_ATTACHMENTS_PER_MESSAGE: int = 10
+# Per-file and per-message download budgets. The bot is a single replica that
+# buffers attachments in memory before forwarding them, so these caps exist to
+# protect the bot process, independently of the (larger) server-side upload
+# limit. Boosted guilds allow uploads well beyond this.
+MAX_ATTACHMENT_BYTES: int = 20 * 1024 * 1024  # 20 MB
+MAX_TOTAL_ATTACHMENT_BYTES: int = 40 * 1024 * 1024  # 40 MB
+
 # Command prefix
 REGISTER_COMMAND: str = "register"
 SYNC_CHANNELS_COMMAND: str = "sync-channels"

--- a/backend/onyx/onyxbot/discord/handle_message.py
+++ b/backend/onyx/onyxbot/discord/handle_message.py
@@ -1,6 +1,7 @@
 """Discord bot message handling and response logic."""
 
 import asyncio
+from collections import Counter
 
 import discord
 from pydantic import BaseModel
@@ -12,7 +13,9 @@ from onyx.db.discord_bot import (
 )
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.models import DiscordChannelConfig, DiscordGuildConfig
+from onyx.file_store.models import ChatFileType, FileDescriptor
 from onyx.onyxbot.discord.api_client import OnyxAPIClient
+from onyx.onyxbot.discord.attachments import collect_attachments
 from onyx.onyxbot.discord.constants import (
     MAX_CONTEXT_MESSAGES,
     MAX_MESSAGE_LENGTH,
@@ -180,6 +183,13 @@ async def process_chat_message(
         # Build conversation context
         context = await _build_conversation_context(message, bot_user)
 
+        # Forward any pasted images / PDFs so the agent gets them with the text
+        file_descriptors, unavailable_files = await _prepare_attachments(
+            message=message,
+            api_key=api_key,
+            api_client=api_client,
+        )
+
         # Prepare full message content
         parts = []
         if context:
@@ -191,11 +201,13 @@ async def process_chat_message(
             f"Current message from @{message.author.display_name}: {format_message_content(message)}"
         )
 
-        # Send to API
-        response = await api_client.send_chat_message(
-            message="\n\n".join(parts),
+        response = await _request_answer(
+            api_client=api_client,
             api_key=api_key,
             persona_id=persona_id,
+            parts=parts,
+            file_descriptors=file_descriptors,
+            unavailable_files=unavailable_files,
         )
 
         # Format response with citations
@@ -215,6 +227,136 @@ async def process_chat_message(
     except Exception as e:
         logger.exception("Error processing chat message: %s", e)
         await send_error_response(message, bot_user)
+
+
+def _build_message_text(parts: list[str], unavailable_files: list[str]) -> str:
+    """Join the message parts, naming any attachments the agent won't see."""
+    if not unavailable_files:
+        return "\n\n".join(parts)
+
+    return "\n\n".join(
+        parts
+        + [
+            "Note: these attachments could not be read and are not "
+            f"available to you: {', '.join(unavailable_files)}"
+        ]
+    )
+
+
+def _is_image(descriptor: FileDescriptor) -> bool:
+    return descriptor.get("type") == ChatFileType.IMAGE
+
+
+async def _request_answer(
+    api_client: OnyxAPIClient,
+    api_key: str,
+    persona_id: int | None,
+    parts: list[str],
+    file_descriptors: list[FileDescriptor],
+    unavailable_files: list[str],
+) -> ChatFullResponse:
+    """Ask Onyx for an answer, retrying without the images if they can't be used.
+
+    Not every model accepts image input, and a provider-side rejection would
+    otherwise turn an answerable question into an error reply. Retrying without
+    them degrades to the behaviour from before images were forwarded at all, and
+    tells the agent what it is missing. Documents are kept on the retry — their
+    text is injected into the prompt, so no model can refuse them. Only retried
+    when the first attempt produced no answer at all, so a partial answer with a
+    warning is never thrown away.
+    """
+    images = [descriptor for descriptor in file_descriptors if _is_image(descriptor)]
+
+    if not images:
+        # Nothing the model can refuse outright, so there is no lighter request
+        # to fall back to.
+        return await api_client.send_chat_message(
+            message=_build_message_text(parts, unavailable_files),
+            api_key=api_key,
+            persona_id=persona_id,
+            file_descriptors=file_descriptors,
+        )
+
+    failure: str | None
+    try:
+        response = await api_client.send_chat_message(
+            message=_build_message_text(parts, unavailable_files),
+            api_key=api_key,
+            persona_id=persona_id,
+            file_descriptors=file_descriptors,
+        )
+        if response.answer.strip() or not response.error_msg:
+            return response
+        failure = response.error_msg
+    except APIError as e:
+        failure = str(e)
+
+    logger.warning(
+        "Chat request with %s image(s) failed (%s); retrying without them",
+        len(images),
+        failure,
+    )
+
+    return await api_client.send_chat_message(
+        message=_build_message_text(
+            parts,
+            unavailable_files
+            + [descriptor.get("name") or "image" for descriptor in images],
+        ),
+        api_key=api_key,
+        persona_id=persona_id,
+        file_descriptors=[
+            descriptor for descriptor in file_descriptors if not _is_image(descriptor)
+        ],
+    )
+
+
+async def _prepare_attachments(
+    message: discord.Message,
+    api_key: str,
+    api_client: OnyxAPIClient,
+) -> tuple[list[FileDescriptor], list[str]]:
+    """Download attachments posted with the message and upload them to Onyx.
+
+    Returns the descriptors to attach to the chat request plus the filenames of
+    attachments that couldn't be included. Failing to forward them never fails
+    the message: the agent answers on the text and is told what it is missing.
+    """
+    collected = await collect_attachments(message)
+    if not collected.files:
+        return [], collected.skipped_filenames
+
+    try:
+        file_descriptors = await api_client.upload_chat_files(
+            files=collected.files,
+            api_key=api_key,
+        )
+    except APIError as e:
+        logger.error("Failed to upload %s attachment(s): %s", len(collected.files), e)
+        return [], collected.skipped_filenames + [
+            file.filename for file in collected.files
+        ]
+
+    # The server can reject individual files (e.g. an unreadable or
+    # password-protected PDF, or one over its token limit); those are absent from
+    # the descriptors it returns. Counted rather than set-matched because pasted
+    # screenshots routinely share the name "image.png".
+    uploaded_counts = Counter(descriptor.get("name") for descriptor in file_descriptors)
+    rejected_names: list[str] = []
+    for file in collected.files:
+        if uploaded_counts[file.filename] > 0:
+            uploaded_counts[file.filename] -= 1
+        else:
+            rejected_names.append(file.filename)
+
+    logger.info(
+        "Attached %s file(s) to Discord message %s (%s unavailable)",
+        len(file_descriptors),
+        message.id,
+        len(collected.skipped_filenames) + len(rejected_names),
+    )
+
+    return file_descriptors, collected.skipped_filenames + rejected_names
 
 
 async def _build_conversation_context(
@@ -397,7 +539,9 @@ def _format_messages_as_context(
 
     return (
         "You are a Discord bot named OnyxBot.\n"
-        'Always assume that [user] is the same as the "Current message" author.'
+        'Always assume that [user] is the same as the "Current message" author.\n'
+        "Attachments named in the conversation history are not available to you; "
+        "only attachments on the current message are.\n"
         "Conversation history:\n"
         "---\n" + "\n".join(formatted) + "\n---"
     )
@@ -409,7 +553,12 @@ def _format_messages_as_context(
 
 
 def format_message_content(message: discord.Message) -> str:
-    """Format message content with readable mentions."""
+    """Format message content with readable mentions and attachment markers.
+
+    Attachments are named inline because a Discord message can consist of
+    nothing but a pasted screenshot — without a marker such a message would read
+    as empty text to the agent.
+    """
     content = message.content
 
     for user in message.mentions:
@@ -421,6 +570,12 @@ def format_message_content(message: discord.Message) -> str:
 
     for channel in message.channel_mentions:
         content = content.replace(f"<#{channel.id}>", f"#{channel.name}")
+
+    markers = [
+        f"[attachment: {attachment.filename}]" for attachment in message.attachments
+    ]
+    if markers:
+        content = " ".join([content.strip(), *markers]).strip()
 
     return content
 

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -192,8 +192,9 @@ class PersonaUpsertRequest(BaseModel):
     replace_base_system_prompt: bool = False
     task_prompt: str
     datetime_aware: bool
-    # When False, the agent's answers omit inline citations and the sources list
-    include_citations: bool = True
+    # When False, the agent's answers omit inline citations and the sources list.
+    # None means "leave unchanged" on update; upsert_persona defaults it to True on create.
+    include_citations: bool | None = None
 
 
 class MinimalPersonaSnapshot(BaseModel):

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -192,6 +192,8 @@ class PersonaUpsertRequest(BaseModel):
     replace_base_system_prompt: bool = False
     task_prompt: str
     datetime_aware: bool
+    # When False, the agent's answers omit inline citations and the sources list
+    include_citations: bool = True
 
 
 class MinimalPersonaSnapshot(BaseModel):
@@ -344,6 +346,7 @@ class PersonaSnapshot(BaseModel):
     replace_base_system_prompt: bool = False
     task_prompt: str | None = None
     datetime_aware: bool = True
+    include_citations: bool = True
 
     @classmethod
     def from_model(cls, persona: Persona) -> "PersonaSnapshot":
@@ -398,6 +401,7 @@ class PersonaSnapshot(BaseModel):
             replace_base_system_prompt=persona.replace_base_system_prompt,
             task_prompt=persona.task_prompt,
             datetime_aware=persona.datetime_aware,
+            include_citations=persona.include_citations,
         )
 
 
@@ -473,6 +477,7 @@ class FullPersonaSnapshot(PersonaSnapshot):
             replace_base_system_prompt=persona.replace_base_system_prompt,
             task_prompt=persona.task_prompt,
             datetime_aware=persona.datetime_aware,
+            include_citations=persona.include_citations,
         )
 
 

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -5,7 +5,17 @@ from collections.abc import Generator
 from datetime import timedelta
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    File,
+    HTTPException,
+    Query,
+    Request,
+    Response,
+    UploadFile,
+)
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
@@ -36,7 +46,7 @@ from onyx.chat.process_message import (
 from onyx.chat.prompt_utils import get_default_base_system_prompt
 from onyx.chat.stop_signal_checker import set_fence
 from onyx.chat.stream_buffer import has_stream_buffer, read_stream_chunks
-from onyx.configs.app_configs import WEB_DOMAIN
+from onyx.configs.app_configs import DISABLE_VECTOR_DB, WEB_DOMAIN
 from onyx.configs.chat_configs import (
     CHAT_HEARTBEAT_INTERVAL_S,
     CHAT_RESUME_POLL_INTERVAL_S,
@@ -64,11 +74,13 @@ from onyx.db.enums import Permission
 from onyx.db.feedback import create_chat_message_feedback, remove_chat_message_feedback
 from onyx.db.models import ChatMessage, ChatSessionSharedStatus, Persona, User
 from onyx.db.persona import get_persona_by_id
+from onyx.db.projects import upload_files_to_user_files_with_indexing
 from onyx.db.usage import UsageType, increment_usage
 from onyx.db.user_file import get_file_id_by_user_file_id
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
+from onyx.file_store.models import FileDescriptor
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.factory import get_llm_for_persona, get_llm_token_counter
 from onyx.llm.models import (
@@ -85,10 +97,13 @@ from onyx.server.api_key_usage import check_api_key_usage
 from onyx.server.middleware.rate_limiting import get_feedback_rate_limiters
 from onyx.server.query_and_chat.chat_utils import (
     is_spreadsheet_mime_type,
+    mime_type_to_chat_file_type,
     parse_spreadsheet_for_preview,
 )
 from onyx.server.query_and_chat.models import (
     ChatFeedbackRequest,
+    ChatFileRejection,
+    ChatFileUploadResponse,
     ChatMessageIdentifier,
     ChatRenameRequest,
     ChatSearchResponse,
@@ -964,6 +979,47 @@ def seed_chat_from_slack(
 
     return SeedChatFromSlackResponse(
         redirect_url=f"{WEB_DOMAIN}/chat?chatId={new_chat_session.id}"
+    )
+
+
+@router.post("/file", tags=PUBLIC_API_TAGS)
+def upload_chat_files(
+    bg_tasks: BackgroundTasks,
+    files: list[UploadFile] = File(...),
+    user: User = Depends(require_permission(Permission.WRITE_CHAT)),
+    db_session: Session = Depends(get_session),
+) -> ChatFileUploadResponse:
+    """Upload files to attach to a subsequent chat message.
+
+    Same server-side handling as `POST /user/projects/file/upload`, but gated on
+    the chat scope so chat-only clients (e.g. the Discord bot's service account,
+    or a `write:chat` PAT) can attach files without being granted the broader
+    `basic` permission. Uploaded files are owned by the calling user and are not
+    linked to any project.
+    """
+    result = upload_files_to_user_files_with_indexing(
+        files=files,
+        project_id=None,
+        user=user,
+        temp_id_map=None,
+        db_session=db_session,
+        background_tasks=bg_tasks if DISABLE_VECTOR_DB else None,
+    )
+
+    return ChatFileUploadResponse(
+        files=[
+            FileDescriptor(
+                id=user_file.file_id,
+                type=mime_type_to_chat_file_type(user_file.content_type),
+                name=user_file.name,
+                user_file_id=str(user_file.id),
+            )
+            for user_file in result.user_files
+        ],
+        rejected_files=[
+            ChatFileRejection(filename=rejected.filename, reason=rejected.reason)
+            for rejected in result.rejected_files
+        ],
     )
 
 

--- a/backend/onyx/server/query_and_chat/models.py
+++ b/backend/onyx/server/query_and_chat/models.py
@@ -166,6 +166,25 @@ class ChatMessageIdentifier(BaseModel):
     message_id: int
 
 
+class ChatFileRejection(BaseModel):
+    """A file that could not be accepted, with a human-readable reason."""
+
+    filename: str
+    reason: str
+
+
+class ChatFileUploadResponse(BaseModel):
+    """Result of uploading files intended for a chat message.
+
+    `files` can be passed straight through as `SendMessageRequest.file_descriptors`.
+    Rejections are reported per-file rather than failing the whole upload, so a
+    caller attaching several files still gets the ones that were accepted.
+    """
+
+    files: list[FileDescriptor]
+    rejected_files: list[ChatFileRejection]
+
+
 class ChatRenameRequest(BaseModel):
     chat_session_id: UUID
     name: str | None = None

--- a/backend/tests/external_dependency_unit/answer/test_persona_include_citations.py
+++ b/backend/tests/external_dependency_unit/answer/test_persona_include_citations.py
@@ -1,0 +1,139 @@
+"""External-dependency-unit tests for the persona-level `include_citations` flag.
+
+These verify that an agent (persona) configured with `include_citations=False`
+turns citations off for its answers, and that the persona flag combines with the
+per-request `SendMessageRequest.include_citations` flag via a logical AND.
+
+Why we assert on the value passed into `run_llm_loop` rather than only on the
+rendered answer: the citation processor only produces inline `[[n]]` links and
+`CitationInfo` packets for citation numbers that resolve to a *real* document in
+the citation mapping. Populating that mapping deterministically requires a
+multi-cycle search-tool flow (LLM emits a tool call -> search returns docs ->
+LLM emits an answer that cites them), which is brittle to drive without exact
+packet-sequence assertions. Instead we run a single-cycle answer and spy on the
+effective `include_citations` value handed to `run_llm_loop` (which selects the
+`DynamicCitationProcessor` mode). That value is the single decision point that
+governs whether any citation / sources output is emitted, so it is the precise
+thing this feature changes. For the disabled case we additionally confirm the
+`ChatFullResponse`-shape behavior the feature promises: no `CitationInfo` is
+emitted and the `[n]` marker is stripped from the rendered answer.
+"""
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.chat import process_message
+from onyx.db.chat import create_chat_session
+from onyx.db.persona import upsert_persona
+from onyx.server.query_and_chat.models import SendMessageRequest
+from onyx.server.query_and_chat.streaming_models import AgentResponseDelta
+from onyx.server.query_and_chat.streaming_models import CitationInfo
+from onyx.server.query_and_chat.streaming_models import Packet
+from tests.external_dependency_unit.answer.conftest import ensure_default_llm_provider
+from tests.external_dependency_unit.answer.stream_test_utils import tokenise
+from tests.external_dependency_unit.conftest import create_test_user
+from tests.external_dependency_unit.mock_llm import LLMAnswerResponse
+from tests.external_dependency_unit.mock_llm import use_mock_llm
+
+
+@pytest.mark.parametrize(
+    "persona_include_citations, request_include_citations, expected_effective",
+    [
+        # Agent config disables citations -> off regardless of the request flag.
+        (False, True, False),
+        # Request disables citations -> off even when the agent allows them (AND).
+        (True, False, False),
+        # Both allow citations -> on.
+        (True, True, True),
+    ],
+)
+def test_persona_include_citations_controls_citation_generation(
+    db_session: Session,
+    full_deployment_setup: None,  # noqa: ARG001
+    mock_external_deps: None,  # noqa: ARG001
+    persona_include_citations: bool,
+    request_include_citations: bool,
+    expected_effective: bool,
+) -> None:
+    ensure_default_llm_provider(db_session)
+    test_user = create_test_user(db_session, email_prefix="test_include_citations")
+
+    persona = upsert_persona(
+        user=None,  # system persona
+        name=f"Citations Persona {uuid.uuid4()}",
+        description="Persona for include_citations behavior test",
+        starter_messages=None,
+        system_prompt=None,
+        task_prompt=None,
+        datetime_aware=None,
+        is_public=True,
+        db_session=db_session,
+        tool_ids=[],  # no tools -> single LLM answer cycle
+        document_set_ids=None,
+        is_listed=True,
+        default_model_configuration_id=None,
+        include_citations=persona_include_citations,
+    )
+
+    # Persist the configured flag exactly as requested.
+    assert persona.include_citations is persona_include_citations
+
+    chat_session = create_chat_session(
+        db_session=db_session,
+        description="include_citations test",
+        user_id=test_user.id,
+        persona_id=persona.id,
+    )
+
+    # The answer contains a citation marker so we can confirm it is stripped when
+    # citations are disabled.
+    answer_tokens = tokenise("Onyx is great [1].")
+
+    with (
+        use_mock_llm() as mock_llm,
+        patch.object(
+            process_message,
+            "run_llm_loop",
+            wraps=process_message.run_llm_loop,
+        ) as spy_run_llm_loop,
+    ):
+        mock_llm.add_response(LLMAnswerResponse(answer_tokens=answer_tokens))
+
+        request = SendMessageRequest(
+            message="Tell me about Onyx",
+            chat_session_id=chat_session.id,
+            include_citations=request_include_citations,
+        )
+
+        answer_stream = process_message.handle_stream_message_objects(
+            new_msg_req=request,
+            user=test_user,
+        )
+
+        # The message-id packet is emitted before the LLM stream is consumed.
+        next(answer_stream)
+        mock_llm.forward_till_end()
+
+        answer_text = ""
+        citation_infos: list[CitationInfo] = []
+        for part in answer_stream:
+            obj = part.obj if isinstance(part, Packet) else part
+            if isinstance(obj, AgentResponseDelta) and obj.content:
+                answer_text += obj.content
+            elif isinstance(obj, CitationInfo):
+                citation_infos.append(obj)
+
+    # The persona and request flags must combine (logical AND) into the value
+    # passed to run_llm_loop, which selects the DynamicCitationProcessor mode.
+    assert spy_run_llm_loop.call_args is not None
+    assert spy_run_llm_loop.call_args.kwargs["include_citations"] is expected_effective
+
+    if not expected_effective:
+        # Citations disabled -> no CitationInfo packets and the [n] marker is
+        # stripped from the rendered answer (no inline citation, no sources).
+        assert citation_infos == []
+        assert "[1]" not in answer_text
+        assert "[[" not in answer_text

--- a/backend/tests/external_dependency_unit/answer/test_persona_include_citations.py
+++ b/backend/tests/external_dependency_unit/answer/test_persona_include_citations.py
@@ -29,14 +29,15 @@ from onyx.chat import process_message
 from onyx.db.chat import create_chat_session
 from onyx.db.persona import upsert_persona
 from onyx.server.query_and_chat.models import SendMessageRequest
-from onyx.server.query_and_chat.streaming_models import AgentResponseDelta
-from onyx.server.query_and_chat.streaming_models import CitationInfo
-from onyx.server.query_and_chat.streaming_models import Packet
+from onyx.server.query_and_chat.streaming_models import (
+    AgentResponseDelta,
+    CitationInfo,
+    Packet,
+)
 from tests.external_dependency_unit.answer.conftest import ensure_default_llm_provider
 from tests.external_dependency_unit.answer.stream_test_utils import tokenise
 from tests.external_dependency_unit.conftest import create_test_user
-from tests.external_dependency_unit.mock_llm import LLMAnswerResponse
-from tests.external_dependency_unit.mock_llm import use_mock_llm
+from tests.external_dependency_unit.mock_llm import LLMAnswerResponse, use_mock_llm
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/external_dependency_unit/discord_bot/conftest.py
+++ b/backend/tests/external_dependency_unit/discord_bot/conftest.py
@@ -59,6 +59,7 @@ def mock_api_client() -> MagicMock:
     mock_response.error_msg = None
 
     client.send_chat_message = AsyncMock(return_value=mock_response)
+    client.upload_chat_files = AsyncMock(return_value=[])
     client.health_check = AsyncMock(return_value=True)
     return client
 
@@ -124,6 +125,7 @@ def mock_discord_message(mock_discord_guild: MagicMock) -> MagicMock:
     msg.role_mentions = []
     msg.channel_mentions = []
     msg.reference = None
+    msg.attachments = []
     msg.add_reaction = AsyncMock()
     msg.remove_reaction = AsyncMock()
     msg.reply = AsyncMock()

--- a/backend/tests/integration/common_utils/managers/file.py
+++ b/backend/tests/integration/common_utils/managers/file.py
@@ -2,6 +2,8 @@ import io
 import mimetypes
 from typing import IO, List, Tuple, cast
 
+import httpx
+
 from onyx.file_store.models import FileDescriptor
 from onyx.server.documents.models import FileUploadResponse
 from tests.integration.common_utils.constants import API_SERVER_URL
@@ -54,6 +56,33 @@ class FileManager:
                 }
             )
         return file_descriptors, ""
+
+    @staticmethod
+    def upload_chat_files(
+        files: List[Tuple[str, IO]],
+        headers: dict[str, str],
+    ) -> "httpx.Response":
+        """Upload files via the chat-scoped `POST /chat/file` endpoint.
+
+        Takes raw headers rather than a `DATestUser` so chat-scoped API keys
+        (e.g. the Discord bot's service account) can be exercised. Returns the
+        raw response so callers can assert on status codes.
+        """
+        # Content-Type must be left to httpx so the multipart boundary matches.
+        headers = {k: v for k, v in headers.items() if k.lower() != "content-type"}
+
+        files_param = []
+        for filename, file_obj in files:
+            mime_type, _ = mimetypes.guess_type(filename)
+            if mime_type is None:
+                mime_type = "application/octet-stream"
+            files_param.append(("files", (filename, file_obj, mime_type)))
+
+        return client.post(
+            f"{API_SERVER_URL}/chat/file",
+            files=files_param,
+            headers=headers,
+        )
 
     @staticmethod
     def fetch_uploaded_file(

--- a/backend/tests/integration/common_utils/test_file_utils.py
+++ b/backend/tests/integration/common_utils/test_file_utils.py
@@ -27,6 +27,50 @@ def create_test_image(
     return image_file
 
 
+def create_test_pdf(text: str = "Hello from the test PDF") -> io.BytesIO:
+    """Create a minimal single-page PDF whose text `pypdf` can extract.
+
+    Hand-assembled rather than generated with a PDF library so the fixture stays
+    a few hundred bytes and pulls in no extra dependency. `text` must be plain
+    ASCII without parentheses or backslashes, which would need escaping inside
+    the content stream.
+
+    Returns:
+        A BytesIO object containing the PDF, positioned at the start.
+    """
+    content = f"BT /F1 24 Tf 72 720 Td ({text}) Tj ET".encode("ascii")
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+        b"/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+        b"<< /Length "
+        + str(len(content)).encode("ascii")
+        + b" >>\nstream\n"
+        + content
+        + b"\nendstream",
+    ]
+
+    out = bytearray(b"%PDF-1.4\n")
+    offsets = []
+    for number, body in enumerate(objects, start=1):
+        offsets.append(len(out))
+        out += f"{number} 0 obj\n".encode("ascii") + body + b"\nendobj\n"
+
+    xref_offset = len(out)
+    out += f"xref\n0 {len(objects) + 1}\n".encode("ascii")
+    out += b"0000000000 65535 f \n"
+    for offset in offsets:
+        out += f"{offset:010d} 00000 n \n".encode("ascii")
+    out += (
+        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\n"
+        f"startxref\n{xref_offset}\n%%EOF\n"
+    ).encode("ascii")
+
+    return io.BytesIO(bytes(out))
+
+
 def create_test_text_file(content: str | bytes) -> io.BytesIO:
     """Create a test text file in memory for file attachment testing.
 

--- a/backend/tests/integration/tests/streaming_endpoints/test_chat_file_upload.py
+++ b/backend/tests/integration/tests/streaming_endpoints/test_chat_file_upload.py
@@ -1,0 +1,185 @@
+"""Integration tests for `POST /chat/file`.
+
+This endpoint exists so chat-only clients can attach files. The Discord bot's
+service account holds `write:chat` and nothing more, which is not enough for
+`POST /user/projects/file/upload`, so images and PDFs posted in Discord had no
+way to reach the agent.
+"""
+
+import io
+
+from onyx.auth.schemas import UserRole
+from onyx.configs.constants import MessageType
+from onyx.server.query_and_chat.models import MessageOrigin
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.api_key import APIKeyManager
+from tests.integration.common_utils.managers.file import FileManager
+from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
+from tests.integration.common_utils.test_file_utils import create_test_image
+from tests.integration.common_utils.test_file_utils import create_test_pdf
+from tests.integration.common_utils.test_models import DATestAPIKey
+from tests.integration.common_utils.test_models import DATestUser
+
+_DUMMY_OPENAI_API_KEY = "sk-mock-chat-file-upload-tests"
+_MOCK_ANSWER = "I can see the attachment."
+
+
+def _chat_only_key_headers(
+    admin_user: DATestUser, name: str
+) -> tuple[DATestAPIKey, dict[str, str]]:
+    """Create a LIMITED service-account key — the Discord bot's exact grant.
+
+    LIMITED keys get `write:chat` (which implies `read:chat`) and nothing else.
+    The headers are copied because `APIKeyManager` hands back a shared dict that
+    later key creations overwrite.
+    """
+    api_key = APIKeyManager.create(
+        api_key_role=UserRole.LIMITED,
+        user_performing_action=admin_user,
+        name=name,
+    )
+    return api_key, {"Authorization": str(api_key.headers["Authorization"])}
+
+
+def test_chat_file_upload_returns_image_descriptor(admin_user: DATestUser) -> None:
+    """An uploaded PNG comes back as an attachable image descriptor."""
+    response = FileManager.upload_chat_files(
+        files=[("screenshot.png", create_test_image(width=8, height=8, color="blue"))],
+        headers=admin_user.headers,
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["rejected_files"] == []
+    assert len(body["files"]) == 1
+
+    descriptor = body["files"][0]
+    assert descriptor["type"] == "image"
+    assert descriptor["name"] == "screenshot.png"
+    assert descriptor["id"]
+    assert descriptor["user_file_id"]
+
+
+def test_chat_file_upload_returns_pdf_descriptor(admin_user: DATestUser) -> None:
+    """An uploaded PDF comes back as a document descriptor.
+
+    Documents reach the LLM as extracted text rather than image content, so the
+    `document` type is what makes a PDF usable on any model.
+    """
+    response = FileManager.upload_chat_files(
+        files=[("report.pdf", create_test_pdf("Quarterly revenue grew 12 percent"))],
+        headers=admin_user.headers,
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["rejected_files"] == []
+    assert len(body["files"]) == 1
+
+    descriptor = body["files"][0]
+    assert descriptor["type"] == "document"
+    assert descriptor["name"] == "report.pdf"
+    assert descriptor["id"]
+    assert descriptor["user_file_id"]
+
+
+def test_chat_file_upload_reports_rejections_per_file(admin_user: DATestUser) -> None:
+    """A rejected file must not take the acceptable ones down with it.
+
+    The Discord bot relies on this to tell the agent what it is missing.
+    """
+    response = FileManager.upload_chat_files(
+        files=[
+            ("good.png", create_test_image(width=8, height=8)),
+            ("good.pdf", create_test_pdf()),
+            # Named .png but not actually an image — rejected on content.
+            ("broken.png", io.BytesIO(b"definitely not a png")),
+            # Named .pdf but has no extractable text — rejected on content.
+            ("broken.pdf", io.BytesIO(b"definitely not a pdf")),
+        ],
+        headers=admin_user.headers,
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert [file["name"] for file in body["files"]] == ["good.png", "good.pdf"]
+    assert [file["filename"] for file in body["rejected_files"]] == [
+        "broken.png",
+        "broken.pdf",
+    ]
+
+
+def test_chat_scoped_key_can_upload_and_attach(admin_user: DATestUser) -> None:
+    """A `write:chat`-only service account can upload files and attach them.
+
+    This is the Discord bot's flow end to end: authenticate with the service
+    key, upload the posted image and PDF, then send a non-streaming chat message
+    referencing the returned descriptors.
+    """
+    LLMProviderManager.create(
+        user_performing_action=admin_user,
+        api_key=_DUMMY_OPENAI_API_KEY,
+    )
+    _, headers = _chat_only_key_headers(admin_user, "chat_file_upload")
+
+    upload_response = FileManager.upload_chat_files(
+        files=[
+            ("pasted.png", create_test_image(width=8, height=8, color="red")),
+            ("pasted.pdf", create_test_pdf("Quarterly revenue grew 12 percent")),
+        ],
+        headers=headers,
+    )
+    assert upload_response.status_code == 200, upload_response.text
+    file_descriptors = upload_response.json()["files"]
+    assert len(file_descriptors) == 2
+
+    send_response = client.post(
+        f"{API_SERVER_URL}/chat/send-chat-message",
+        json={
+            "message": "What is in these attachments?",
+            "stream": False,
+            "origin": MessageOrigin.DISCORDBOT.value,
+            "file_descriptors": file_descriptors,
+            "chat_session_info": {"persona_id": 0},
+            "mock_llm_response": _MOCK_ANSWER,
+        },
+        headers=headers,
+    )
+
+    assert send_response.status_code == 200, send_response.text
+    body = send_response.json()
+    assert body.get("error_msg") is None
+    assert body["answer"].strip() == _MOCK_ANSWER
+
+    # Both files are recorded on the persisted user message, which is what makes
+    # them visible to the LLM on this turn and any follow-up.
+    session_response = client.get(
+        f"{API_SERVER_URL}/chat/get-chat-session/{body['chat_session_id']}",
+        headers=headers,
+    )
+    assert session_response.status_code == 200, session_response.text
+    user_messages = [
+        message
+        for message in session_response.json()["messages"]
+        if message["message_type"] == MessageType.USER.value
+    ]
+    assert len(user_messages) == 1
+    attached = user_messages[0]["files"]
+    assert {file["name"]: file["type"] for file in attached} == {
+        "pasted.png": "image",
+        "pasted.pdf": "document",
+    }
+
+
+def test_chat_scoped_key_denied_on_project_upload(admin_user: DATestUser) -> None:
+    """The projects upload endpoint stays gated on `basic`."""
+    _, headers = _chat_only_key_headers(admin_user, "chat_file_upload_denied")
+
+    response = client.post(
+        f"{API_SERVER_URL}/user/projects/file/upload",
+        files=[("files", ("pasted.png", create_test_image(), "image/png"))],
+        headers=headers,
+    )
+
+    assert response.status_code == 403, response.text

--- a/backend/tests/integration/tests/streaming_endpoints/test_chat_file_upload.py
+++ b/backend/tests/integration/tests/streaming_endpoints/test_chat_file_upload.py
@@ -16,10 +16,11 @@ from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.file import FileManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
-from tests.integration.common_utils.test_file_utils import create_test_image
-from tests.integration.common_utils.test_file_utils import create_test_pdf
-from tests.integration.common_utils.test_models import DATestAPIKey
-from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.common_utils.test_file_utils import (
+    create_test_image,
+    create_test_pdf,
+)
+from tests.integration.common_utils.test_models import DATestAPIKey, DATestUser
 
 _DUMMY_OPENAI_API_KEY = "sk-mock-chat-file-upload-tests"
 _MOCK_ANSWER = "I can see the attachment."

--- a/backend/tests/unit/onyx/deep_research/test_dr_citations.py
+++ b/backend/tests/unit/onyx/deep_research/test_dr_citations.py
@@ -1,0 +1,77 @@
+"""Unit tests for per-persona `include_citations` gating in the deep-research path.
+
+The deep-research loop only emits user-facing citations from the final report
+(`generate_final_report`). That step is the single decision point that selects
+the `DynamicCitationProcessor` mode, mirroring `run_llm_loop` for the regular
+path: HYPERLINK when citations are enabled, REMOVE when the persona disabled
+them. These tests spy on the `citation_processor` handed to `run_llm_step` to
+confirm the mode is chosen from `include_citations`, rather than driving the
+full multi-cycle loop (which is brittle to set up).
+"""
+
+from contextlib import contextmanager
+from typing import Any
+from typing import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.chat.citation_processor import CitationMode
+from onyx.chat.citation_processor import DynamicCitationProcessor
+from onyx.chat.models import LlmStepResult
+from onyx.deep_research import dr_loop
+
+
+@contextmanager
+def _noop_span(*_args: Any, **_kwargs: Any) -> Iterator[MagicMock]:
+    yield MagicMock()
+
+
+@pytest.mark.parametrize(
+    "include_citations, expected_mode",
+    [
+        (True, CitationMode.HYPERLINK),
+        (False, CitationMode.REMOVE),
+    ],
+)
+def test_generate_final_report_citation_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    include_citations: bool,
+    expected_mode: CitationMode,
+) -> None:
+    captured: dict[str, DynamicCitationProcessor | None] = {"processor": None}
+
+    def fake_run_llm_step(*_args: Any, **kwargs: Any) -> tuple[LlmStepResult, bool]:
+        captured["processor"] = kwargs["citation_processor"]
+        result = LlmStepResult(
+            reasoning=None,
+            answer="Final report body.",
+            tool_calls=None,
+        )
+        return result, False
+
+    # Isolate the decision point: skip tracing, history construction, and the LLM call.
+    monkeypatch.setattr(dr_loop, "run_llm_step", fake_run_llm_step)
+    monkeypatch.setattr(dr_loop, "construct_message_history", lambda *a, **k: [])
+    monkeypatch.setattr(dr_loop, "function_span", _noop_span)
+
+    llm = MagicMock()
+    llm.config.max_input_tokens = 100_000
+
+    has_reasoned = dr_loop.generate_final_report(
+        history=[],
+        research_plan="plan",
+        llm=llm,
+        token_counter=len,
+        state_container=MagicMock(),
+        emitter=MagicMock(),
+        turn_index=1,
+        citation_mapping={},
+        user_identity=None,
+        include_citations=include_citations,
+    )
+
+    assert has_reasoned is False
+    processor = captured["processor"]
+    assert isinstance(processor, DynamicCitationProcessor)
+    assert processor.citation_mode is expected_mode

--- a/backend/tests/unit/onyx/deep_research/test_dr_citations.py
+++ b/backend/tests/unit/onyx/deep_research/test_dr_citations.py
@@ -10,14 +10,12 @@ full multi-cycle loop (which is brittle to set up).
 """
 
 from contextlib import contextmanager
-from typing import Any
-from typing import Iterator
+from typing import Any, Iterator
 from unittest.mock import MagicMock
 
 import pytest
 
-from onyx.chat.citation_processor import CitationMode
-from onyx.chat.citation_processor import DynamicCitationProcessor
+from onyx.chat.citation_processor import CitationMode, DynamicCitationProcessor
 from onyx.chat.models import LlmStepResult
 from onyx.deep_research import dr_loop
 
@@ -52,7 +50,9 @@ def test_generate_final_report_citation_mode(
 
     # Isolate the decision point: skip tracing, history construction, and the LLM call.
     monkeypatch.setattr(dr_loop, "run_llm_step", fake_run_llm_step)
-    monkeypatch.setattr(dr_loop, "construct_message_history", lambda *a, **k: [])
+    monkeypatch.setattr(
+        dr_loop, "construct_message_history", lambda *_args, **_kwargs: []
+    )
     monkeypatch.setattr(dr_loop, "function_span", _noop_span)
 
     llm = MagicMock()

--- a/backend/tests/unit/onyx/onyxbot/discord/conftest.py
+++ b/backend/tests/unit/onyx/onyxbot/discord/conftest.py
@@ -27,6 +27,25 @@ class AsyncIteratorMock:
         return item
 
 
+def mock_attachment(
+    filename: str = "screenshot.png",
+    content_type: str | None = "image/png",
+    size: int = 1024,
+    data: bytes = b"fake-image-bytes",
+    read_error: Exception | None = None,
+) -> MagicMock:
+    """Helper to create a mock Discord attachment."""
+    attachment = MagicMock(spec=discord.Attachment)
+    attachment.filename = filename
+    attachment.content_type = content_type
+    attachment.size = size
+    attachment.read = AsyncMock(
+        side_effect=read_error if read_error else None,
+        return_value=data,
+    )
+    return attachment
+
+
 def mock_message(
     content: str = "Test message",
     author_bot: bool = False,
@@ -35,6 +54,7 @@ def mock_message(
     message_id: int | None = None,
     author_id: int | None = None,
     author_display_name: str | None = None,
+    attachments: list[MagicMock] | None = None,
 ) -> MagicMock:
     """Helper to create mock Discord messages."""
     msg = MagicMock(spec=discord.Message)
@@ -49,6 +69,7 @@ def mock_message(
     msg.mentions = []
     msg.role_mentions = []
     msg.channel_mentions = []
+    msg.attachments = attachments or []
     return msg
 
 
@@ -113,6 +134,7 @@ def mock_discord_message(mock_bot_user: MagicMock) -> MagicMock:  # noqa: ARG001
     msg.role_mentions = []
     msg.channel_mentions = []
     msg.reference = None
+    msg.attachments = []
     return msg
 
 
@@ -251,6 +273,7 @@ def mock_message_with_bot_mention(mock_bot_user: MagicMock) -> MagicMock:
     msg.channel.id = 111111111
     msg.role_mentions = []
     msg.channel_mentions = []
+    msg.attachments = []
     return msg
 
 

--- a/backend/tests/unit/onyx/onyxbot/discord/test_api_client.py
+++ b/backend/tests/unit/onyx/onyxbot/discord/test_api_client.py
@@ -10,7 +10,9 @@ import aiohttp
 import pytest
 
 from onyx.chat.models import ChatFullResponse
+from onyx.file_store.models import ChatFileType, FileDescriptor
 from onyx.onyxbot.discord.api_client import OnyxAPIClient
+from onyx.onyxbot.discord.attachments import MessageAttachment
 from onyx.onyxbot.discord.constants import API_REQUEST_TIMEOUT
 from onyx.onyxbot.discord.exceptions import (
     APIConnectionError,
@@ -257,6 +259,274 @@ class TestSendChatMessage:
             await client.send_chat_message("Hello", "api_key")
 
         assert exc_info.value.status_code == 500
+
+
+class TestUploadChatFiles:
+    """Tests for upload_chat_files functionality."""
+
+    @staticmethod
+    def _image(filename: str = "shot.png") -> MessageAttachment:
+        return MessageAttachment(
+            filename=filename, content_type="image/png", data=b"png-bytes"
+        )
+
+    @staticmethod
+    def _pdf(filename: str = "report.pdf") -> MessageAttachment:
+        return MessageAttachment(
+            filename=filename, content_type="application/pdf", data=b"%PDF-1.7"
+        )
+
+    @pytest.mark.asyncio
+    async def test_upload_not_initialized(self) -> None:
+        """upload_chat_files() before initialize() raises APIConnectionError."""
+        client = OnyxAPIClient()
+
+        with pytest.raises(APIConnectionError) as exc_info:
+            await client.upload_chat_files([self._image()], "api_key")
+
+        assert "not initialized" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_no_files_skips_request(self) -> None:
+        """Uploading nothing makes no HTTP call."""
+        client = OnyxAPIClient()
+        mock_session = MagicMock()
+        client._session = mock_session
+
+        assert await client.upload_chat_files([], "api_key") == []
+        mock_session.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_upload_posts_multipart_to_chat_file(self) -> None:
+        """Files are posted as multipart form data with the bearer token."""
+        client = OnyxAPIClient()
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "files": [
+                    {
+                        "id": "file-store-id",
+                        "type": "image",
+                        "name": "shot.png",
+                        "user_file_id": "user-file-id",
+                    }
+                ],
+                "rejected_files": [],
+            }
+        )
+
+        mock_session = MagicMock()
+        mock_post = MagicMock(
+            return_value=MockAsyncContextManager(return_value=mock_response)
+        )
+        mock_session.post = mock_post
+        client._session = mock_session
+
+        descriptors = await client.upload_chat_files([self._image()], "api_key_123")
+
+        assert descriptors == [
+            {
+                "id": "file-store-id",
+                "type": ChatFileType.IMAGE,
+                "name": "shot.png",
+                "user_file_id": "user-file-id",
+            }
+        ]
+
+        url = mock_post.call_args.args[0]
+        assert url.endswith("/chat/file")
+        kwargs = mock_post.call_args.kwargs
+        assert isinstance(kwargs["data"], aiohttp.FormData)
+        # Content-Type is left to aiohttp so the multipart boundary matches.
+        assert kwargs["headers"] == {"Authorization": "Bearer api_key_123"}
+
+    @pytest.mark.asyncio
+    async def test_pdf_comes_back_as_a_document_descriptor(self) -> None:
+        """PDFs are classified server-side as documents, not images."""
+        client = OnyxAPIClient()
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "files": [
+                    {
+                        "id": "file-store-id",
+                        "type": "document",
+                        "name": "report.pdf",
+                        "user_file_id": "user-file-id",
+                    }
+                ],
+                "rejected_files": [],
+            }
+        )
+
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(
+            return_value=MockAsyncContextManager(return_value=mock_response)
+        )
+        client._session = mock_session
+
+        descriptors = await client.upload_chat_files([self._pdf()], "api_key")
+
+        assert descriptors == [
+            {
+                "id": "file-store-id",
+                "type": ChatFileType.DOC,
+                "name": "report.pdf",
+                "user_file_id": "user-file-id",
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_rejected_files_are_omitted(self) -> None:
+        """Server-side rejections come back empty-handed, not as an error."""
+        client = OnyxAPIClient()
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "files": [],
+                "rejected_files": [{"filename": "huge.png", "reason": "too large"}],
+            }
+        )
+
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(
+            return_value=MockAsyncContextManager(return_value=mock_response)
+        )
+        client._session = mock_session
+
+        assert await client.upload_chat_files([self._image("huge.png")], "key") == []
+
+    @pytest.mark.asyncio
+    async def test_upload_403_error(self) -> None:
+        """A key without chat scope raises APIResponseError with 403."""
+        client = OnyxAPIClient()
+
+        mock_response = MagicMock()
+        mock_response.status = 403
+
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(
+            return_value=MockAsyncContextManager(return_value=mock_response)
+        )
+        client._session = mock_session
+
+        with pytest.raises(APIResponseError) as exc_info:
+            await client.upload_chat_files([self._image()], "key")
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_upload_timeout(self) -> None:
+        """Request timeout raises APITimeoutError."""
+        client = OnyxAPIClient()
+
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(
+            return_value=MockAsyncContextManager(
+                enter_side_effect=TimeoutError("Timeout")
+            )
+        )
+        client._session = mock_session
+
+        with pytest.raises(APITimeoutError):
+            await client.upload_chat_files([self._image()], "key")
+
+    @pytest.mark.asyncio
+    async def test_upload_connection_error(self) -> None:
+        """Network failure raises APIConnectionError."""
+        client = OnyxAPIClient()
+
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(
+            return_value=MockAsyncContextManager(
+                enter_side_effect=aiohttp.ClientConnectorError(
+                    MagicMock(), OSError("Connection refused")
+                )
+            )
+        )
+        client._session = mock_session
+
+        with pytest.raises(APIConnectionError):
+            await client.upload_chat_files([self._image()], "key")
+
+
+class TestSendChatMessageFileDescriptors:
+    """file_descriptors must reach the send-chat-message payload."""
+
+    @pytest.mark.asyncio
+    async def test_descriptors_are_included_in_payload(self) -> None:
+        client = OnyxAPIClient()
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={"answer": "ok", "citations": [], "error_msg": None}
+        )
+
+        mock_session = MagicMock()
+        mock_post = MagicMock(
+            return_value=MockAsyncContextManager(return_value=mock_response)
+        )
+        mock_session.post = mock_post
+        client._session = mock_session
+
+        descriptor = FileDescriptor(
+            id="file-store-id",
+            type=ChatFileType.IMAGE,
+            name="shot.png",
+            user_file_id="user-file-id",
+        )
+
+        with patch.object(
+            ChatFullResponse,
+            "model_validate",
+            return_value=MagicMock(answer="ok", error_msg=None),
+        ):
+            await client.send_chat_message(
+                "Hello", "api_key", file_descriptors=[descriptor]
+            )
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["file_descriptors"] == [
+            {
+                "id": "file-store-id",
+                "type": "image",
+                "name": "shot.png",
+                "user_file_id": "user-file-id",
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_payload_defaults_to_no_files(self) -> None:
+        client = OnyxAPIClient()
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={"answer": "ok", "citations": [], "error_msg": None}
+        )
+
+        mock_session = MagicMock()
+        mock_post = MagicMock(
+            return_value=MockAsyncContextManager(return_value=mock_response)
+        )
+        mock_session.post = mock_post
+        client._session = mock_session
+
+        with patch.object(
+            ChatFullResponse,
+            "model_validate",
+            return_value=MagicMock(answer="ok", error_msg=None),
+        ):
+            await client.send_chat_message("Hello", "api_key")
+
+        assert mock_post.call_args.kwargs["json"]["file_descriptors"] == []
 
 
 class TestHealthCheck:

--- a/backend/tests/unit/onyx/onyxbot/discord/test_attachment_forwarding.py
+++ b/backend/tests/unit/onyx/onyxbot/discord/test_attachment_forwarding.py
@@ -1,0 +1,440 @@
+"""Unit tests for forwarding Discord attachments to the Onyx chat API.
+
+Covers `_prepare_attachments` (upload + bookkeeping of what didn't make it), the
+fallback that drops images when a model can't use them, and the attachment
+markers `format_message_content` adds so an attachment-only message doesn't read
+as empty text.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from onyx.file_store.models import ChatFileType, FileDescriptor
+from onyx.onyxbot.discord.exceptions import APIResponseError
+from onyx.onyxbot.discord.handle_message import (
+    _prepare_attachments,
+    _request_answer,
+    format_message_content,
+)
+from tests.unit.onyx.onyxbot.discord.conftest import mock_attachment, mock_message
+
+
+def _descriptor(
+    name: str, file_type: ChatFileType = ChatFileType.IMAGE
+) -> FileDescriptor:
+    return FileDescriptor(
+        id=f"file-store-id-{name}",
+        type=file_type,
+        name=name,
+        user_file_id=f"user-file-id-{name}",
+    )
+
+
+def _doc_descriptor(name: str) -> FileDescriptor:
+    return _descriptor(name, file_type=ChatFileType.DOC)
+
+
+def _api_client(
+    descriptors: list[FileDescriptor] | None = None,
+    error: Exception | None = None,
+) -> MagicMock:
+    client = MagicMock()
+    client.upload_chat_files = AsyncMock(
+        side_effect=error, return_value=descriptors or []
+    )
+    return client
+
+
+def _chat_response(answer: str = "hello", error_msg: str | None = None) -> MagicMock:
+    response = MagicMock()
+    response.answer = answer
+    response.error_msg = error_msg
+    return response
+
+
+def _sending_client(*responses: Any) -> MagicMock:
+    """Client whose send_chat_message yields `responses` in order.
+
+    Values that are exceptions are raised instead of returned.
+    """
+    client = MagicMock()
+    client.send_chat_message = AsyncMock(side_effect=list(responses))
+    return client
+
+
+class TestPrepareAttachments:
+    """Tests for _prepare_attachments."""
+
+    @pytest.mark.asyncio
+    async def test_no_attachments_skips_upload(self) -> None:
+        api_client = _api_client()
+
+        descriptors, unavailable = await _prepare_attachments(
+            message=mock_message(),
+            api_key="key",
+            api_client=api_client,
+        )
+
+        assert descriptors == []
+        assert unavailable == []
+        api_client.upload_chat_files.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_images_are_uploaded_and_returned(self) -> None:
+        api_client = _api_client([_descriptor("bug.png")])
+        message = mock_message(
+            content="see attached", attachments=[mock_attachment(filename="bug.png")]
+        )
+
+        descriptors, unavailable = await _prepare_attachments(
+            message=message,
+            api_key="key",
+            api_client=api_client,
+        )
+
+        assert descriptors == [_descriptor("bug.png")]
+        assert unavailable == []
+        upload_kwargs = api_client.upload_chat_files.call_args.kwargs
+        assert upload_kwargs["api_key"] == "key"
+        assert [file.filename for file in upload_kwargs["files"]] == ["bug.png"]
+
+    @pytest.mark.asyncio
+    async def test_pdfs_are_uploaded_and_returned(self) -> None:
+        api_client = _api_client([_doc_descriptor("report.pdf")])
+        message = mock_message(
+            content="summarise this",
+            attachments=[
+                mock_attachment(filename="report.pdf", content_type="application/pdf")
+            ],
+        )
+
+        descriptors, unavailable = await _prepare_attachments(
+            message=message,
+            api_key="key",
+            api_client=api_client,
+        )
+
+        assert descriptors == [_doc_descriptor("report.pdf")]
+        assert unavailable == []
+        upload_kwargs = api_client.upload_chat_files.call_args.kwargs
+        assert [file.filename for file in upload_kwargs["files"]] == ["report.pdf"]
+        assert [file.content_type for file in upload_kwargs["files"]] == [
+            "application/pdf"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_upload_failure_degrades_to_text_only(self) -> None:
+        """An upload error must not fail the message — only lose the files."""
+        api_client = _api_client(error=APIResponseError("boom", status_code=500))
+        message = mock_message(
+            attachments=[
+                mock_attachment(filename="bug.png"),
+                mock_attachment(filename="report.pdf", content_type="application/pdf"),
+            ]
+        )
+
+        descriptors, unavailable = await _prepare_attachments(
+            message=message,
+            api_key="key",
+            api_client=api_client,
+        )
+
+        assert descriptors == []
+        assert unavailable == ["bug.png", "report.pdf"]
+
+    @pytest.mark.asyncio
+    async def test_server_rejected_file_is_reported_unavailable(self) -> None:
+        """The server omits rejected files from its response.
+
+        A password-protected or unreadable PDF is the common case.
+        """
+        api_client = _api_client([_doc_descriptor("good.pdf")])
+        message = mock_message(
+            attachments=[
+                mock_attachment(filename="good.pdf", content_type="application/pdf"),
+                mock_attachment(filename="locked.pdf", content_type="application/pdf"),
+            ]
+        )
+
+        descriptors, unavailable = await _prepare_attachments(
+            message=message,
+            api_key="key",
+            api_client=api_client,
+        )
+
+        assert descriptors == [_doc_descriptor("good.pdf")]
+        assert unavailable == ["locked.pdf"]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_filenames_are_counted_not_deduplicated(self) -> None:
+        """Pasted screenshots routinely share the name "image.png"."""
+        api_client = _api_client([_descriptor("image.png")])
+        message = mock_message(
+            attachments=[
+                mock_attachment(filename="image.png"),
+                mock_attachment(filename="image.png"),
+            ]
+        )
+
+        descriptors, unavailable = await _prepare_attachments(
+            message=message,
+            api_key="key",
+            api_client=api_client,
+        )
+
+        assert len(descriptors) == 1
+        assert unavailable == ["image.png"]
+
+    @pytest.mark.asyncio
+    async def test_locally_skipped_files_are_reported(self) -> None:
+        """An unsupported format never reaches the server but is still reported."""
+        api_client = _api_client([_descriptor("good.png")])
+        message = mock_message(
+            attachments=[
+                mock_attachment(filename="good.png"),
+                mock_attachment(filename="clip.gif", content_type="image/gif"),
+            ]
+        )
+
+        descriptors, unavailable = await _prepare_attachments(
+            message=message,
+            api_key="key",
+            api_client=api_client,
+        )
+
+        assert descriptors == [_descriptor("good.png")]
+        assert unavailable == ["clip.gif"]
+        assert [
+            file.filename
+            for file in api_client.upload_chat_files.call_args.kwargs["files"]
+        ] == ["good.png"]
+
+
+class TestRequestAnswer:
+    """Tests for the image-dropping fallback in _request_answer."""
+
+    _PARTS = ["Current message from @User: look at this [attachment: shot.png]"]
+
+    @pytest.mark.asyncio
+    async def test_files_are_sent_on_the_first_attempt(self) -> None:
+        api_client = _sending_client(_chat_response())
+
+        response = await _request_answer(
+            api_client=api_client,
+            api_key="key",
+            persona_id=7,
+            parts=self._PARTS,
+            file_descriptors=[_descriptor("shot.png")],
+            unavailable_files=[],
+        )
+
+        assert response.answer == "hello"
+        api_client.send_chat_message.assert_called_once()
+        kwargs = api_client.send_chat_message.call_args.kwargs
+        assert kwargs["file_descriptors"] == [_descriptor("shot.png")]
+        assert kwargs["persona_id"] == 7
+        assert "could not be read" not in kwargs["message"]
+
+    @pytest.mark.asyncio
+    async def test_no_attachments_sends_once(self) -> None:
+        api_client = _sending_client(_chat_response())
+
+        await _request_answer(
+            api_client=api_client,
+            api_key="key",
+            persona_id=None,
+            parts=self._PARTS,
+            file_descriptors=[],
+            unavailable_files=[],
+        )
+
+        api_client.send_chat_message.assert_called_once()
+        assert api_client.send_chat_message.call_args.kwargs["file_descriptors"] == []
+
+    @pytest.mark.asyncio
+    async def test_pdf_only_failure_is_not_retried(self) -> None:
+        """Document text is injected as plain text, so no model can refuse it.
+
+        There is no lighter request to fall back to, and retrying identically
+        would just burn a second LLM call.
+        """
+        api_client = _sending_client(_chat_response(answer="", error_msg="boom"))
+
+        response = await _request_answer(
+            api_client=api_client,
+            api_key="key",
+            persona_id=None,
+            parts=self._PARTS,
+            file_descriptors=[_doc_descriptor("report.pdf")],
+            unavailable_files=[],
+        )
+
+        assert response.error_msg == "boom"
+        api_client.send_chat_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_answerless_error_retries_without_images(self) -> None:
+        """A model that can't accept images must not cost the user their answer."""
+        api_client = _sending_client(
+            _chat_response(answer="", error_msg="model does not support image input"),
+            _chat_response(answer="answered from the text"),
+        )
+
+        response = await _request_answer(
+            api_client=api_client,
+            api_key="key",
+            persona_id=None,
+            parts=self._PARTS,
+            file_descriptors=[_descriptor("shot.png")],
+            unavailable_files=[],
+        )
+
+        assert response.answer == "answered from the text"
+        assert api_client.send_chat_message.call_count == 2
+        retry_kwargs = api_client.send_chat_message.call_args.kwargs
+        assert retry_kwargs["file_descriptors"] == []
+        assert "shot.png" in retry_kwargs["message"]
+        assert "could not be read" in retry_kwargs["message"]
+
+    @pytest.mark.asyncio
+    async def test_retry_keeps_documents_and_drops_only_images(self) -> None:
+        """A PDF's text is still usable even when the images have to go."""
+        api_client = _sending_client(
+            _chat_response(answer="", error_msg="model does not support image input"),
+            _chat_response(answer="answered from the pdf"),
+        )
+
+        response = await _request_answer(
+            api_client=api_client,
+            api_key="key",
+            persona_id=None,
+            parts=self._PARTS,
+            file_descriptors=[
+                _descriptor("shot.png"),
+                _doc_descriptor("report.pdf"),
+            ],
+            unavailable_files=[],
+        )
+
+        assert response.answer == "answered from the pdf"
+        retry_kwargs = api_client.send_chat_message.call_args.kwargs
+        assert retry_kwargs["file_descriptors"] == [_doc_descriptor("report.pdf")]
+        assert "shot.png" in retry_kwargs["message"]
+        assert (
+            "report.pdf" not in retry_kwargs["message"].split("could not be read")[-1]
+        )
+
+    @pytest.mark.asyncio
+    async def test_api_error_retries_without_images(self) -> None:
+        api_client = _sending_client(
+            APIResponseError("bad request", status_code=400),
+            _chat_response(answer="answered from the text"),
+        )
+
+        response = await _request_answer(
+            api_client=api_client,
+            api_key="key",
+            persona_id=None,
+            parts=self._PARTS,
+            file_descriptors=[_descriptor("shot.png")],
+            unavailable_files=[],
+        )
+
+        assert response.answer == "answered from the text"
+        assert api_client.send_chat_message.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_partial_answer_with_warning_is_kept(self) -> None:
+        """An answer plus a warning is a success — retrying would discard it."""
+        api_client = _sending_client(
+            _chat_response(answer="partial answer", error_msg="some warning")
+        )
+
+        response = await _request_answer(
+            api_client=api_client,
+            api_key="key",
+            persona_id=None,
+            parts=self._PARTS,
+            file_descriptors=[_descriptor("shot.png")],
+            unavailable_files=[],
+        )
+
+        assert response.answer == "partial answer"
+        api_client.send_chat_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_second_attempt_error_propagates(self) -> None:
+        """The retry gets no special treatment — a real failure still surfaces."""
+        api_client = _sending_client(
+            APIResponseError("bad request", status_code=400),
+            APIResponseError("still broken", status_code=500),
+        )
+
+        with pytest.raises(APIResponseError) as exc_info:
+            await _request_answer(
+                api_client=api_client,
+                api_key="key",
+                persona_id=None,
+                parts=self._PARTS,
+                file_descriptors=[_descriptor("shot.png")],
+                unavailable_files=[],
+            )
+
+        assert exc_info.value.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_unavailable_files_are_named_for_the_agent(self) -> None:
+        api_client = _sending_client(_chat_response())
+
+        await _request_answer(
+            api_client=api_client,
+            api_key="key",
+            persona_id=None,
+            parts=self._PARTS,
+            file_descriptors=[],
+            unavailable_files=["clip.gif", "locked.pdf"],
+        )
+
+        message = api_client.send_chat_message.call_args.kwargs["message"]
+        assert "could not be read" in message
+        assert "clip.gif" in message
+        assert "locked.pdf" in message
+
+
+class TestAttachmentMarkers:
+    """Tests for the attachment markers format_message_content adds."""
+
+    def test_image_only_message_is_not_empty(self) -> None:
+        message = mock_message(
+            content="", attachments=[mock_attachment(filename="shot.png")]
+        )
+
+        assert format_message_content(message) == "[attachment: shot.png]"
+
+    def test_marker_is_appended_after_text(self) -> None:
+        message = mock_message(
+            content="what is this?", attachments=[mock_attachment(filename="shot.png")]
+        )
+
+        assert format_message_content(message) == "what is this? [attachment: shot.png]"
+
+    def test_every_attachment_is_named(self) -> None:
+        message = mock_message(
+            content="",
+            attachments=[
+                mock_attachment(filename="one.png"),
+                mock_attachment(filename="notes.pdf", content_type="application/pdf"),
+            ],
+        )
+
+        assert (
+            format_message_content(message)
+            == "[attachment: one.png] [attachment: notes.pdf]"
+        )
+
+    def test_message_without_attachments_is_unchanged(self) -> None:
+        message = mock_message(content="just text")
+
+        assert format_message_content(message) == "just text"

--- a/backend/tests/unit/onyx/onyxbot/discord/test_attachments.py
+++ b/backend/tests/unit/onyx/onyxbot/discord/test_attachments.py
@@ -1,0 +1,321 @@
+"""Unit tests for Discord attachment collection.
+
+Covers which attachments get forwarded to Onyx as chat files (images and PDFs)
+and which are reported as skipped so the agent can be told what it is missing.
+"""
+
+from unittest.mock import MagicMock
+
+import discord
+import pytest
+
+from onyx.file_processing.extract_file_text import get_file_ext
+from onyx.file_processing.file_types import (
+    PDF_MIME_TYPE,
+    OnyxFileExtensions,
+    OnyxMimeTypes,
+)
+from onyx.onyxbot.discord import attachments
+from onyx.onyxbot.discord.attachments import (
+    collect_attachments,
+    is_forwardable_attachment,
+    is_supported_attachment,
+    upload_content_type,
+)
+from onyx.onyxbot.discord.constants import (
+    MAX_ATTACHMENT_BYTES,
+    MAX_ATTACHMENTS_PER_MESSAGE,
+)
+from tests.unit.onyx.onyxbot.discord.conftest import mock_attachment, mock_message
+
+
+class TestSupportedExtensionMap:
+    """The extension→media-type map must stay aligned with what Onyx accepts."""
+
+    def test_covers_every_image_extension_onyx_accepts(self) -> None:
+        """If Onyx adds an image format, this map has to learn about it."""
+        assert set(attachments._EXTENSION_CONTENT_TYPES) == (
+            OnyxFileExtensions.IMAGE_EXTENSIONS | {attachments.PDF_EXTENSION}
+        )
+
+    def test_every_media_type_is_one_onyx_recognises(self) -> None:
+        """A media type Onyx doesn't know maps to the wrong ChatFileType."""
+        recognised = OnyxMimeTypes.IMAGE_MIME_TYPES | {PDF_MIME_TYPE}
+        assert set(attachments._EXTENSION_CONTENT_TYPES.values()) <= recognised
+
+
+class TestAttachmentClassification:
+    """Tests for is_forwardable_attachment / is_supported_attachment."""
+
+    def test_png_is_supported(self) -> None:
+        attachment = mock_attachment(filename="shot.png", content_type="image/png")
+        assert is_forwardable_attachment(attachment)
+        assert is_supported_attachment(attachment)
+
+    def test_pdf_is_supported(self) -> None:
+        attachment = mock_attachment(
+            filename="report.pdf", content_type="application/pdf"
+        )
+        assert is_forwardable_attachment(attachment)
+        assert is_supported_attachment(attachment)
+
+    def test_uppercase_extension_is_supported(self) -> None:
+        attachment = mock_attachment(filename="REPORT.PDF", content_type=None)
+        assert is_supported_attachment(attachment)
+
+    def test_gif_is_forwardable_but_not_supported(self) -> None:
+        attachment = mock_attachment(filename="clip.gif", content_type="image/gif")
+        assert is_forwardable_attachment(attachment)
+        assert not is_supported_attachment(attachment)
+
+    def test_missing_content_type_still_works_from_the_extension(self) -> None:
+        """Discord's content_type is optional; the extension is authoritative."""
+        for filename in ("shot.png", "report.pdf"):
+            attachment = mock_attachment(filename=filename, content_type=None)
+            assert is_forwardable_attachment(attachment), filename
+            assert is_supported_attachment(attachment), filename
+
+    def test_generic_content_type_still_works_from_the_extension(self) -> None:
+        attachment = mock_attachment(
+            filename="report.pdf", content_type="application/octet-stream"
+        )
+        assert is_supported_attachment(attachment)
+
+    def test_content_type_parameters_are_ignored(self) -> None:
+        """Discord occasionally appends parameters to the media type."""
+        attachment = mock_attachment(
+            filename="clip.gif", content_type="Image/GIF; charset=utf-8"
+        )
+        assert is_forwardable_attachment(attachment)
+        assert not is_supported_attachment(attachment)
+
+    @pytest.mark.parametrize(
+        "filename",
+        ["shot.png", "report.pdf", "pdf", "png", "noext", ".pdf", "a.b.PDF"],
+    )
+    def test_extension_matches_the_server(self, filename: str) -> None:
+        """Client and server must classify extensions identically.
+
+        A mismatch means uploading a file the server then rejects — e.g. an
+        attachment literally named "pdf", which has no extension by `splitext`.
+        """
+        assert attachments._file_extension(filename) == get_file_ext(filename)
+
+    def test_extensionless_name_is_reported_not_forwarded(self) -> None:
+        """The server keys on extension, so "pdf" is unusable — but say so."""
+        attachment = mock_attachment(filename="pdf", content_type="application/pdf")
+        assert is_forwardable_attachment(attachment)
+        assert not is_supported_attachment(attachment)
+
+    def test_other_document_types_are_left_alone(self) -> None:
+        """Only images and PDFs are in scope; a .docx is not forwarded."""
+        attachment = mock_attachment(
+            filename="notes.docx",
+            content_type=(
+                "application/vnd.openxmlformats-officedocument"
+                ".wordprocessingml.document"
+            ),
+        )
+        assert not is_forwardable_attachment(attachment)
+
+
+class TestUploadContentType:
+    """Tests for the media type sent to Onyx."""
+
+    @pytest.mark.parametrize(
+        "filename,expected",
+        [
+            ("shot.png", "image/png"),
+            ("shot.JPG", "image/jpeg"),
+            ("shot.jpeg", "image/jpeg"),
+            ("shot.webp", "image/webp"),
+            ("report.pdf", "application/pdf"),
+        ],
+    )
+    def test_media_type_comes_from_the_extension(
+        self, filename: str, expected: str
+    ) -> None:
+        attachment = mock_attachment(filename=filename, content_type=None)
+        assert upload_content_type(attachment) == expected
+
+    def test_discord_content_type_is_not_trusted(self) -> None:
+        """A generic type from Discord would classify the file wrongly."""
+        attachment = mock_attachment(
+            filename="report.pdf", content_type="application/octet-stream"
+        )
+        assert upload_content_type(attachment) == "application/pdf"
+
+
+class TestCollectAttachments:
+    """Tests for collect_attachments."""
+
+    @pytest.mark.asyncio
+    async def test_no_attachments(self) -> None:
+        collected = await collect_attachments(mock_message())
+        assert collected.files == []
+        assert collected.skipped_filenames == []
+
+    @pytest.mark.asyncio
+    async def test_supported_image_is_downloaded(self) -> None:
+        message = mock_message(
+            content="what's wrong here?",
+            attachments=[mock_attachment(filename="bug.png", data=b"png-bytes")],
+        )
+
+        collected = await collect_attachments(message)
+
+        assert len(collected.files) == 1
+        file = collected.files[0]
+        assert file.filename == "bug.png"
+        assert file.content_type == "image/png"
+        assert file.data == b"png-bytes"
+        assert collected.skipped_filenames == []
+
+    @pytest.mark.asyncio
+    async def test_pdf_is_downloaded(self) -> None:
+        message = mock_message(
+            content="summarise this",
+            attachments=[
+                mock_attachment(
+                    filename="report.pdf",
+                    content_type="application/pdf",
+                    data=b"%PDF-1.7 bytes",
+                )
+            ],
+        )
+
+        collected = await collect_attachments(message)
+
+        assert len(collected.files) == 1
+        file = collected.files[0]
+        assert file.filename == "report.pdf"
+        assert file.content_type == "application/pdf"
+        assert file.data == b"%PDF-1.7 bytes"
+        assert collected.skipped_filenames == []
+
+    @pytest.mark.asyncio
+    async def test_mixed_image_and_pdf_preserve_order(self) -> None:
+        message = mock_message(
+            attachments=[
+                mock_attachment(filename="one.png", data=b"one"),
+                mock_attachment(
+                    filename="two.pdf", content_type="application/pdf", data=b"two"
+                ),
+                mock_attachment(filename="three.jpg", content_type="image/jpeg"),
+            ]
+        )
+
+        collected = await collect_attachments(message)
+
+        assert [file.filename for file in collected.files] == [
+            "one.png",
+            "two.pdf",
+            "three.jpg",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_out_of_scope_attachments_are_ignored(self) -> None:
+        """Spreadsheets and the like are neither forwarded nor reported."""
+        message = mock_message(
+            attachments=[mock_attachment(filename="data.csv", content_type="text/csv")]
+        )
+
+        collected = await collect_attachments(message)
+
+        assert collected.files == []
+        assert collected.skipped_filenames == []
+
+    @pytest.mark.asyncio
+    async def test_unsupported_image_format_is_skipped(self) -> None:
+        message = mock_message(
+            attachments=[mock_attachment(filename="clip.gif", content_type="image/gif")]
+        )
+
+        collected = await collect_attachments(message)
+
+        assert collected.files == []
+        assert collected.skipped_filenames == ["clip.gif"]
+
+    @pytest.mark.asyncio
+    async def test_oversized_file_is_skipped_without_downloading(self) -> None:
+        attachment = mock_attachment(
+            filename="huge.pdf",
+            content_type="application/pdf",
+            size=MAX_ATTACHMENT_BYTES + 1,
+        )
+        message = mock_message(attachments=[attachment])
+
+        collected = await collect_attachments(message)
+
+        assert collected.files == []
+        assert collected.skipped_filenames == ["huge.pdf"]
+        attachment.read.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_per_message_byte_budget_is_enforced(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Once the per-message budget is spent, later attachments are skipped."""
+        monkeypatch.setattr(attachments, "MAX_TOTAL_ATTACHMENT_BYTES", 10)
+        message = mock_message(
+            attachments=[
+                mock_attachment(filename="first.png", size=8, data=b"12345678"),
+                mock_attachment(filename="second.png", size=8, data=b"12345678"),
+            ]
+        )
+
+        collected = await collect_attachments(message)
+
+        assert [file.filename for file in collected.files] == ["first.png"]
+        assert collected.skipped_filenames == ["second.png"]
+
+    @pytest.mark.asyncio
+    async def test_per_message_count_limit_is_enforced(self) -> None:
+        over_limit = MAX_ATTACHMENTS_PER_MESSAGE + 2
+        message = mock_message(
+            attachments=[
+                mock_attachment(filename=f"shot{index}.png")
+                for index in range(over_limit)
+            ]
+        )
+
+        collected = await collect_attachments(message)
+
+        assert len(collected.files) == MAX_ATTACHMENTS_PER_MESSAGE
+        assert len(collected.skipped_filenames) == 2
+
+    @pytest.mark.asyncio
+    async def test_failed_download_is_skipped(self) -> None:
+        message = mock_message(
+            attachments=[
+                mock_attachment(
+                    filename="gone.png",
+                    read_error=discord.NotFound(MagicMock(), "gone"),
+                ),
+                mock_attachment(filename="fine.png"),
+            ]
+        )
+
+        collected = await collect_attachments(message)
+
+        assert [file.filename for file in collected.files] == ["fine.png"]
+        assert collected.skipped_filenames == ["gone.png"]
+
+    @pytest.mark.asyncio
+    async def test_non_discord_download_error_is_skipped(self) -> None:
+        """A CDN failure can surface as a raw transport error, not a DiscordException."""
+        message = mock_message(
+            attachments=[
+                mock_attachment(
+                    filename="slow.pdf",
+                    content_type="application/pdf",
+                    read_error=TimeoutError("timeout"),
+                ),
+                mock_attachment(filename="fine.png"),
+            ]
+        )
+
+        collected = await collect_attachments(message)
+
+        assert [file.filename for file in collected.files] == ["fine.png"]
+        assert collected.skipped_filenames == ["slow.pdf"]

--- a/web/src/app/app/shared/[chatId]/page.tsx
+++ b/web/src/app/app/shared/[chatId]/page.tsx
@@ -29,6 +29,7 @@ export function constructMiniFiedPersona(name: string, id: number): Agent {
     task_prompt: null,
     datetime_aware: true,
     replace_base_system_prompt: false,
+    include_citations: true,
   };
 }
 

--- a/web/src/lib/agents/svc.ts
+++ b/web/src/lib/agents/svc.ts
@@ -27,6 +27,7 @@ function buildAgentUpsertRequest(
     remove_image: params.remove_image,
     search_start_date: params.search_start_date,
     datetime_aware: params.datetime_aware,
+    include_citations: params.include_citations ?? true,
     is_featured: params.is_featured ?? false,
     default_model_configuration_id:
       params.default_model_configuration_id ?? null,

--- a/web/src/lib/agents/svc.ts
+++ b/web/src/lib/agents/svc.ts
@@ -27,7 +27,7 @@ function buildAgentUpsertRequest(
     remove_image: params.remove_image,
     search_start_date: params.search_start_date,
     datetime_aware: params.datetime_aware,
-    include_citations: params.include_citations ?? true,
+    include_citations: params.include_citations,
     is_featured: params.is_featured ?? false,
     default_model_configuration_id:
       params.default_model_configuration_id ?? null,

--- a/web/src/lib/agents/types.ts
+++ b/web/src/lib/agents/types.ts
@@ -90,6 +90,7 @@ export interface Agent extends MinimalAgent {
   replace_base_system_prompt: boolean;
   task_prompt: string | null;
   datetime_aware: boolean;
+  include_citations: boolean;
 }
 
 export interface FullAgent extends Agent {
@@ -111,6 +112,7 @@ export interface AgentUpsertParameters {
   replace_base_system_prompt: boolean;
   task_prompt: string;
   datetime_aware: boolean;
+  include_citations: boolean;
   document_set_ids: number[];
   // Sharing fields: omit on update — the share dialog owns sharing for
   // saved agents and the backend treats absent as "leave unchanged"
@@ -137,6 +139,7 @@ export interface AgentUpsertRequest {
   system_prompt: string;
   task_prompt: string;
   datetime_aware: boolean;
+  include_citations: boolean;
   document_set_ids: number[];
   is_public?: boolean;
   default_model_configuration_id: number | null;

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -727,6 +727,7 @@ export default function AgentEditorPage({
       : null,
     replace_base_system_prompt:
       existingAgent?.replace_base_system_prompt ?? false,
+    include_citations: existingAgent?.include_citations ?? true,
     reminders: existingAgent?.task_prompt ?? "",
     // For new agents, default to false for optional tools to avoid
     // "Tool not available" errors when the tool isn't configured.
@@ -849,6 +850,7 @@ export default function AgentEditorPage({
         (value) => !value || !isDateInFuture(value)
       ),
     replace_base_system_prompt: Yup.boolean(),
+    include_citations: Yup.boolean(),
     reminders: Yup.string().optional(),
 
     // MCP servers - dynamically add validation for each server with nested tool validation
@@ -977,6 +979,7 @@ export default function AgentEditorPage({
         replace_base_system_prompt: values.replace_base_system_prompt,
         task_prompt: values.reminders || "",
         datetime_aware: existingAgent ? existingAgent.datetime_aware : false,
+        include_citations: values.include_citations,
       };
 
       // Call API
@@ -1776,6 +1779,13 @@ export default function AgentEditorPage({
                                   description='Remove the base system prompt which includes useful instructions (e.g. "You can use Markdown tables"). This may affect response quality.'
                                 >
                                   <SwitchField name="replace_base_system_prompt" />
+                                </InputHorizontal>
+                                <InputHorizontal
+                                  withLabel="include_citations"
+                                  title="Include Citations"
+                                  description="Show inline citations and a sources list pointing to the documents used in the answer. Turn off to hide sources from responses."
+                                >
+                                  <SwitchField name="include_citations" />
                                 </InputHorizontal>
                               </GeneralLayouts.Section>
                             </Card>


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-agent “Include citations” toggle that hides inline citations and sources when disabled, and applies it to deep research. Also adds a chat-scoped file upload endpoint and forwards Discord images/PDFs to the agent with safe fallbacks and size limits.

- **New Features**
  - Backend: added `Persona.include_citations` (DB migration, default true). Exposed in persona snapshots and optional `PersonaUpsertRequest` (omit to keep existing). Added `POST /chat/file` (WRITE_CHAT) returning `ChatFileUploadResponse` with accepted `FileDescriptor`s and per-file rejections.
  - Runtime: derive `include_citations` as request.include_citations AND persona.include_citations; pass to `run_llm_loop` and deep research `generate_final_report`, switching `DynamicCitationProcessor` mode (`HYPERLINK` vs `REMOVE`).
  - Discord: collect and upload message attachments (images, PDFs) via `POST /chat/file`; attach accepted files; list skipped/rejected filenames; retry once without images if the model can’t accept them; add inline markers for attachment-only messages; enforce caps (10 files, 20 MB/file, 40 MB total).
  - Frontend: Agent Editor switch for citations; types/service include the field; shared chat stub includes `include_citations: true`.
  - Tests: coverage for the AND logic and deep-research citation mode; integration tests for `POST /chat/file`; unit tests for Discord attachment collection/forwarding.

- **Migration**
  - Run DB migrations to add the new column.
  - Existing agents default to showing citations; set `include_citations=false` per agent to hide them.
  - Upsert API: send `include_citations` to change it; omit to preserve the current value.

<sup>Written for commit abf0048713e4ddbd3bec6c672be49372d1ec0458. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

