### PR TITLE
fix(mcp): persist credential edits from flag-less clients and masked replays

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -242,17 +242,21 @@ def _resolve_oauth_credentials(
     """
     resolved_id = request_client_id
     if not request_client_id_changed:
-        resolved_id = (
-            existing_client.client_id if existing_client else request_client_id
-        )
+        # A real (unmasked) value still wins without the flag — clients that
+        # predate the changed flags send only the edited value.
+        if existing_client and not (
+            request_client_id and not is_masked_credential(request_client_id)
+        ):
+            resolved_id = existing_client.client_id
     elif resolved_id:
         reject_masked_credentials({"oauth_client_id": resolved_id})
 
     resolved_secret = request_client_secret
     if not request_client_secret_changed:
-        resolved_secret = (
-            existing_client.client_secret if existing_client else request_client_secret
-        )
+        if existing_client and not (
+            request_client_secret and not is_masked_credential(request_client_secret)
+        ):
+            resolved_secret = existing_client.client_secret
     elif resolved_secret:
         reject_masked_credentials({"oauth_client_secret": resolved_secret})
 
@@ -278,7 +282,13 @@ def _resolve_admin_credentials(
             and existing_user_credentials
             and key in existing_user_credentials
         ):
-            resolved[key] = existing_user_credentials[key]
+            # Clients that predate the changed flags never set them, so a
+            # real (unmasked) value that differs from storage is still an
+            # edit and must win; only masked/absent replays reuse storage.
+            if request_value and not is_masked_credential(request_value):
+                resolved[key] = request_value
+            else:
+                resolved[key] = existing_user_credentials[key]
             continue
         if request_value:
             reject_masked_credentials({key: request_value})
@@ -1083,17 +1093,41 @@ def save_user_credentials(
 
     email = user.email
 
+    # The credentials modal seeds its inputs with masked stored values, so an
+    # edit of one field replays the untouched fields as masked literals.
+    # Resolve those against the user's stored substitutions; reject any mask
+    # that has no stored counterpart rather than persisting it as a real value.
+    existing_user_creds: dict[str, str] = {}
+    existing_user_config = get_user_connection_config(server_id, email, db_session)
+    if existing_user_config:
+        existing_user_dict = extract_connection_data(
+            existing_user_config, apply_mask=False
+        )
+        existing_user_creds = existing_user_dict.get(HEADER_SUBSTITUTIONS) or {}
+    credentials: dict[str, str] = {
+        field: (
+            existing_user_creds[field]
+            if is_masked_credential(value) and field in existing_user_creds
+            else value
+        )
+        for field, value in request.credentials.items()
+    }
+    try:
+        reject_masked_credentials(credentials)
+    except ValueError as e:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e))
+
     # Get the authentication template for this server
     auth_template = get_server_auth_template(server_id, db_session)
     if not auth_template:
         # Fallback to simple API key storage for servers without templates
-        if "api_key" not in request.credentials:
+        if "api_key" not in credentials:
             raise HTTPException(
                 status_code=400,
                 detail="No authentication template found and no api_key provided",
             )
         config_data = MCPConnectionData(
-            headers={"Authorization": f"Bearer {request.credentials['api_key']}"},
+            headers={"Authorization": f"Bearer {credentials['api_key']}"},
         )
     else:
         # Render via the shared helper so user + auto (`{user_email}`)
@@ -1105,10 +1139,8 @@ def save_user_credentials(
             )
             template = MCPAuthTemplate(headers=auth_template_dict.get("headers", {}))
             config_data = MCPConnectionData(
-                headers=_build_headers_from_template(
-                    template, request.credentials, email
-                ),
-                header_substitutions=request.credentials,
+                headers=_build_headers_from_template(template, credentials, email),
+                header_substitutions=credentials,
             )
             for oauth_field_key in MCPOAuthKeys:
                 field_key: Literal[
@@ -2000,6 +2032,20 @@ def _upsert_mcp_server(
                     OnyxErrorCode.INVALID_INPUT,
                     "A shared API token is required for admin-managed API-token servers.",
                 )
+            # Value-based change detection: clients that predate the
+            # `api_token_changed` flag send only the new token, so the flag
+            # alone can't be trusted to gate the config rewrite.
+            existing_shared_token: str | None = None
+            if mcp_server.admin_connection_config:
+                try:
+                    existing_shared_token = _extract_shared_api_token(
+                        existing_admin_config_dict
+                    )
+                except OnyxError:
+                    existing_shared_token = None
+            shared_api_token_value_changed = request.api_token != existing_shared_token
+        else:
+            shared_api_token_value_changed = False
         if (
             request.auth_type == MCPAuthenticationType.API_TOKEN
             and request.auth_performer == MCPAuthenticationPerformer.PER_USER
@@ -2082,7 +2128,9 @@ def _upsert_mcp_server(
                     or shared_api_token_template_changed
                     or (
                         request.auth_performer == MCPAuthenticationPerformer.ADMIN
-                        and request.api_token_changed
+                        and (
+                            request.api_token_changed or shared_api_token_value_changed
+                        )
                     )
                     or api_token_scheme_changed
                 )

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -229,11 +229,11 @@ def _resolve_oauth_credentials(
     """Pick the effective client_id / client_secret for an upsert/connect.
 
     Mirrors the LLM-provider `api_key_changed` pattern: when the frontend
-    flags a field as unchanged, ignore whatever value it sent (it is most
-    likely a masked placeholder) and reuse the stored value. When the
-    frontend flags a field as changed, take the request value as-is, but
-    defensively reject masked placeholders so a buggy client can't write
-    a mask to the database.
+    flags a field as changed, take the request value as-is, but defensively
+    reject masked placeholders so a buggy client can't write a mask to the
+    database. When flagged unchanged, reuse the stored value — unless the
+    request carries a real (unmasked) replacement, which clients predating
+    the changed flags send for genuine edits.
 
     When there is no stored client yet (`existing_client is None`), an
     unchanged flag means the user did not edit since load — still use the
@@ -242,8 +242,6 @@ def _resolve_oauth_credentials(
     """
     resolved_id = request_client_id
     if not request_client_id_changed:
-        # A real (unmasked) value still wins without the flag — clients that
-        # predate the changed flags send only the edited value.
         if existing_client and not (
             request_client_id and not is_masked_credential(request_client_id)
         ):
@@ -269,11 +267,10 @@ def _resolve_admin_credentials(
     request_credentials_changed: dict[str, bool],
     existing_user_credentials: dict[str, str] | None,
 ) -> dict[str, str]:
-    """Per-key analogue of ``_resolve_oauth_credentials``: reuse the
-    stored value when the changed flag is False, otherwise take the
-    request value and reject masked placeholders defensively. Stored
-    values are sourced from the editing admin's own per-user
-    ``header_substitutions``."""
+    """Per-key analogue of ``_resolve_oauth_credentials``: reuse the stored
+    value when the changed flag is False, otherwise take the request value
+    and reject masked placeholders defensively. Stored values are sourced
+    from the caller's own per-user ``header_substitutions``."""
     resolved: dict[str, str] = {}
     for key, request_value in request_credentials.items():
         changed = request_credentials_changed.get(key, False)
@@ -282,9 +279,8 @@ def _resolve_admin_credentials(
             and existing_user_credentials
             and key in existing_user_credentials
         ):
-            # Clients that predate the changed flags never set them, so a
-            # real (unmasked) value that differs from storage is still an
-            # edit and must win; only masked/absent replays reuse storage.
+            # Flag-less clients still send real edits: an unmasked value
+            # wins; masked/absent replays reuse storage.
             if request_value and not is_masked_credential(request_value):
                 resolved[key] = request_value
             else:
@@ -1093,10 +1089,9 @@ def save_user_credentials(
 
     email = user.email
 
-    # The credentials modal seeds its inputs with masked stored values, so an
-    # edit of one field replays the untouched fields as masked literals.
-    # Resolve those against the user's stored substitutions; reject any mask
-    # that has no stored counterpart rather than persisting it as a real value.
+    # The credentials modal seeds its inputs with masked stored values, so
+    # untouched fields replay as masked literals; resolve them against the
+    # user's stored substitutions.
     existing_user_creds: dict[str, str] = {}
     existing_user_config = get_user_connection_config(server_id, email, db_session)
     if existing_user_config:
@@ -1104,16 +1099,12 @@ def save_user_credentials(
             existing_user_config, apply_mask=False
         )
         existing_user_creds = existing_user_dict.get(HEADER_SUBSTITUTIONS) or {}
-    credentials: dict[str, str] = {
-        field: (
-            existing_user_creds[field]
-            if is_masked_credential(value) and field in existing_user_creds
-            else value
-        )
-        for field, value in request.credentials.items()
-    }
     try:
-        reject_masked_credentials(credentials)
+        credentials = _resolve_admin_credentials(
+            request_credentials=request.credentials,
+            request_credentials_changed=request.credentials_changed,
+            existing_user_credentials=existing_user_creds,
+        )
     except ValueError as e:
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e))
 
@@ -2032,9 +2023,8 @@ def _upsert_mcp_server(
                     OnyxErrorCode.INVALID_INPUT,
                     "A shared API token is required for admin-managed API-token servers.",
                 )
-            # Value-based change detection: clients that predate the
-            # `api_token_changed` flag send only the new token, so the flag
-            # alone can't be trusted to gate the config rewrite.
+            # Detect edits by value too — clients predating the
+            # `api_token_changed` flag send only the new token.
             existing_shared_token: str | None = None
             if mcp_server.admin_connection_config:
                 try:

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -538,6 +538,13 @@ class MCPUserCredentialsRequest(BaseModel):
     credentials: dict[str, str] = Field(
         ..., description="User-provided credentials (api_key, custom_token, etc.)"
     )
+    credentials_changed: dict[str, bool] = Field(
+        default_factory=dict,
+        description=(
+            "Per-field flags marking which credentials were edited; fields "
+            "without a flag fall back to masked-value detection"
+        ),
+    )
     transport: str = Field(..., description="Transport type")
 
 

--- a/backend/tests/external_dependency_unit/server/features/mcp/test_mcp_credential_edit_persistence.py
+++ b/backend/tests/external_dependency_unit/server/features/mcp/test_mcp_credential_edit_persistence.py
@@ -12,6 +12,7 @@ directly because API responses mask credential values."""
 from unittest.mock import patch
 from uuid import uuid4
 
+import pytest
 from sqlalchemy.orm import Session
 
 from onyx.auth.schemas import UserRole
@@ -22,6 +23,7 @@ from onyx.db.enums import (
 )
 from onyx.db.mcp import extract_connection_data, get_user_connection_config
 from onyx.db.models import MCPServer as DbMCPServer
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.mcp.api import (
     HEADER_SUBSTITUTIONS,
     _upsert_mcp_server,
@@ -289,6 +291,56 @@ class TestEndUserCredentialUpdate:
         cfg = dict(extract_connection_data(cfg_row, apply_mask=False))
         assert cfg["headers"]["X-Org"] == "org-12345-abcdef", cfg
         assert cfg["headers"]["Authorization"] == "Bearer USER-KEY-B-2222-3333", cfg
+
+    def test_user_flags_take_precedence_over_mask_heuristic(
+        self, db_session: Session
+    ) -> None:
+        """With explicit flags, an unchanged masked replay resolves to storage
+        and a flagged mask-shaped value errors loudly instead of being kept."""
+        admin = create_test_user(db_session, "admin_flagged_user", role=UserRole.ADMIN)
+        user = create_test_user(db_session, "basic_flagged_user")
+        server_id = self._make_per_user_server(db_session, admin)
+
+        with patch(
+            "onyx.server.features.mcp.api.test_mcp_server_credentials",
+            return_value=(True, "ok"),
+        ):
+            save_user_credentials(
+                MCPUserCredentialsRequest(
+                    server_id=server_id,
+                    credentials={"api_key": "USER-KEY-A-0000-1111"},
+                    transport="streamable_http",
+                ),
+                db_session,
+                user,
+            )
+            save_user_credentials(
+                MCPUserCredentialsRequest(
+                    server_id=server_id,
+                    credentials={"api_key": mask_string("USER-KEY-A-0000-1111")},
+                    credentials_changed={"api_key": False},
+                    transport="streamable_http",
+                ),
+                db_session,
+                user,
+            )
+            with pytest.raises(OnyxError):
+                save_user_credentials(
+                    MCPUserCredentialsRequest(
+                        server_id=server_id,
+                        credentials={"api_key": "abcd...wxyz"},
+                        credentials_changed={"api_key": True},
+                        transport="streamable_http",
+                    ),
+                    db_session,
+                    user,
+                )
+
+        db_session.expire_all()
+        cfg_row = get_user_connection_config(server_id, user.email, db_session)
+        assert cfg_row is not None
+        cfg = dict(extract_connection_data(cfg_row, apply_mask=False))
+        assert cfg["headers"]["Authorization"] == "Bearer USER-KEY-A-0000-1111"
 
 
 class TestFlaglessClientsPerUserAndOAuth:

--- a/backend/tests/external_dependency_unit/server/features/mcp/test_mcp_credential_edit_persistence.py
+++ b/backend/tests/external_dependency_unit/server/features/mcp/test_mcp_credential_edit_persistence.py
@@ -1,0 +1,410 @@
+"""Editing MCP credentials must persist the new values.
+
+Regression coverage for a customer report: changing the API key of an
+existing server and hitting Connect silently kept the old key. Change
+detection must be value-based — clients that predate the `*_changed`
+flags (older frontends, cached bundles after an upgrade, scripts) send
+only the new value — and the per-user modal's masked replays of
+untouched fields must never be persisted as literal credentials.
+Replays the exact payloads the frontend sends and inspects DB state
+directly because API responses mask credential values."""
+
+from unittest.mock import patch
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from onyx.auth.schemas import UserRole
+from onyx.db.enums import (
+    MCPAuthenticationPerformer,
+    MCPAuthenticationType,
+    MCPTransport,
+)
+from onyx.db.mcp import extract_connection_data, get_user_connection_config
+from onyx.db.models import MCPServer as DbMCPServer
+from onyx.server.features.mcp.api import (
+    HEADER_SUBSTITUTIONS,
+    _upsert_mcp_server,
+    save_user_credentials,
+)
+from onyx.server.features.mcp.models import (
+    MCPAuthTemplate,
+    MCPToolCreateRequest,
+    MCPUserCredentialsRequest,
+)
+from onyx.utils.encryption import mask_string
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+def _shared_token_request(
+    *,
+    server_name: str,
+    api_token: str | None,
+    api_token_changed: bool,
+    existing_server_id: int | None = None,
+    auth_template: MCPAuthTemplate | None = None,
+) -> MCPToolCreateRequest:
+    """Mirror MCPAuthenticationModal.constructServerData for the admin
+    shared-key tab."""
+    return MCPToolCreateRequest(
+        name=server_name,
+        description="credential edit persistence",
+        server_url="http://upstream.example.com/mcp",
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+        transport=MCPTransport.STREAMABLE_HTTP,
+        api_token=api_token,
+        api_token_changed=api_token_changed,
+        auth_template=auth_template,
+        existing_server_id=existing_server_id,
+    )
+
+
+def _read_admin_config(db_session: Session, server_id: int) -> dict:
+    # A fresh API request reads with a fresh session; drop identity-map state
+    # so the assertion sees committed rows, not this session's cached objects.
+    db_session.expire_all()
+    server = db_session.get(DbMCPServer, server_id)
+    assert server is not None and server.admin_connection_config is not None
+    return dict(
+        extract_connection_data(server.admin_connection_config, apply_mask=False)
+    )
+
+
+class TestAdminSharedTokenEdit:
+    def test_change_api_key_with_changed_flag(self, db_session: Session) -> None:
+        """Exact current-frontend payload: new token + api_token_changed=True."""
+        admin = create_test_user(db_session, "admin_shared_edit", role=UserRole.ADMIN)
+        name = f"shared-edit-{uuid4().hex[:8]}"
+
+        server = _upsert_mcp_server(
+            _shared_token_request(
+                server_name=name,
+                api_token="OLDKEY-aaaa-bbbb-cccc-1111",
+                api_token_changed=True,
+            ),
+            db_session,
+            admin,
+        )
+        assert (
+            _read_admin_config(db_session, server.id)["api_token"]
+            == "OLDKEY-aaaa-bbbb-cccc-1111"
+        )
+
+        # Edit: user pastes a new key; frontend computes changed=True.
+        _upsert_mcp_server(
+            _shared_token_request(
+                server_name=name,
+                api_token="NEWKEY-dddd-eeee-ffff-2222",
+                api_token_changed=True,
+                existing_server_id=server.id,
+            ),
+            db_session,
+            admin,
+        )
+        cfg = _read_admin_config(db_session, server.id)
+        assert cfg["api_token"] == "NEWKEY-dddd-eeee-ffff-2222", cfg
+        assert cfg["headers"]["Authorization"] == "Bearer NEWKEY-dddd-eeee-ffff-2222"
+
+    def test_change_api_key_without_changed_flag_old_client(
+        self, db_session: Session
+    ) -> None:
+        """Older frontend (pre-changed-flag): sends the new real token with no
+        flag. `_resolve_shared_api_token` should still take the real token."""
+        admin = create_test_user(db_session, "admin_shared_oldfe", role=UserRole.ADMIN)
+        name = f"shared-oldfe-{uuid4().hex[:8]}"
+
+        server = _upsert_mcp_server(
+            _shared_token_request(
+                server_name=name,
+                api_token="OLDKEY-aaaa-bbbb-cccc-1111",
+                api_token_changed=True,
+            ),
+            db_session,
+            admin,
+        )
+
+        _upsert_mcp_server(
+            _shared_token_request(
+                server_name=name,
+                api_token="NEWKEY-dddd-eeee-ffff-2222",
+                api_token_changed=False,
+                existing_server_id=server.id,
+            ),
+            db_session,
+            admin,
+        )
+        cfg = _read_admin_config(db_session, server.id)
+        assert cfg["api_token"] == "NEWKEY-dddd-eeee-ffff-2222", cfg
+
+    def test_masked_replay_with_no_edit_preserves_token(
+        self, db_session: Session
+    ) -> None:
+        """Reopening the modal and hitting Connect without editing replays the
+        masked token with changed=False; the stored token must survive."""
+        admin = create_test_user(db_session, "admin_shared_noop", role=UserRole.ADMIN)
+        name = f"shared-noop-{uuid4().hex[:8]}"
+
+        server = _upsert_mcp_server(
+            _shared_token_request(
+                server_name=name,
+                api_token="OLDKEY-aaaa-bbbb-cccc-1111",
+                api_token_changed=True,
+            ),
+            db_session,
+            admin,
+        )
+
+        _upsert_mcp_server(
+            _shared_token_request(
+                server_name=name,
+                api_token=mask_string("OLDKEY-aaaa-bbbb-cccc-1111"),
+                api_token_changed=False,
+                existing_server_id=server.id,
+            ),
+            db_session,
+            admin,
+        )
+        cfg = _read_admin_config(db_session, server.id)
+        assert cfg["api_token"] == "OLDKEY-aaaa-bbbb-cccc-1111", cfg
+
+
+class TestEndUserCredentialUpdate:
+    def _make_per_user_server(self, db_session: Session, admin) -> int:
+        req = MCPToolCreateRequest(
+            name=f"per-user-update-{uuid4().hex[:8]}",
+            description="credential edit persistence",
+            server_url="http://upstream.example.com/mcp",
+            auth_type=MCPAuthenticationType.API_TOKEN,
+            auth_performer=MCPAuthenticationPerformer.PER_USER,
+            transport=MCPTransport.STREAMABLE_HTTP,
+            auth_template=MCPAuthTemplate(
+                headers={"Authorization": "Bearer {api_key}"},
+                required_fields=["api_key"],
+            ),
+            admin_credentials={"api_key": "admin-seed-key"},
+            admin_credentials_changed={"api_key": True},
+        )
+        return _upsert_mcp_server(req, db_session, admin).id
+
+    def test_user_updates_their_api_key(self, db_session: Session) -> None:
+        """End user connects with key A then updates to key B via the
+        user-credentials modal. Key B must be stored."""
+        admin = create_test_user(db_session, "admin_enduser_upd", role=UserRole.ADMIN)
+        user = create_test_user(db_session, "basic_enduser_upd")
+        server_id = self._make_per_user_server(db_session, admin)
+
+        with patch(
+            "onyx.server.features.mcp.api.test_mcp_server_credentials",
+            return_value=(True, "ok"),
+        ):
+            save_user_credentials(
+                MCPUserCredentialsRequest(
+                    server_id=server_id,
+                    credentials={"api_key": "USER-KEY-A-0000-1111"},
+                    transport="streamable_http",
+                ),
+                db_session,
+                user,
+            )
+            save_user_credentials(
+                MCPUserCredentialsRequest(
+                    server_id=server_id,
+                    credentials={"api_key": "USER-KEY-B-2222-3333"},
+                    transport="streamable_http",
+                ),
+                db_session,
+                user,
+            )
+
+        db_session.expire_all()
+        cfg_row = get_user_connection_config(server_id, user.email, db_session)
+        assert cfg_row is not None
+        cfg = dict(extract_connection_data(cfg_row, apply_mask=False))
+        assert cfg.get(HEADER_SUBSTITUTIONS) == {"api_key": "USER-KEY-B-2222-3333"}, cfg
+        assert cfg["headers"]["Authorization"] == "Bearer USER-KEY-B-2222-3333"
+
+    def test_user_replays_masked_value_for_untouched_field(
+        self, db_session: Session
+    ) -> None:
+        """Multi-field template: the modal seeds inputs with MASKED existing
+        values; the user edits only one field and the other is submitted as the
+        masked literal. The stored value for the untouched field must not be
+        clobbered with the mask."""
+        admin = create_test_user(db_session, "admin_masked_replay", role=UserRole.ADMIN)
+        user = create_test_user(db_session, "basic_masked_replay")
+
+        req = MCPToolCreateRequest(
+            name=f"masked-replay-{uuid4().hex[:8]}",
+            description="credential edit persistence",
+            server_url="http://upstream.example.com/mcp",
+            auth_type=MCPAuthenticationType.API_TOKEN,
+            auth_performer=MCPAuthenticationPerformer.PER_USER,
+            transport=MCPTransport.STREAMABLE_HTTP,
+            auth_template=MCPAuthTemplate(
+                headers={
+                    "Authorization": "Bearer {api_key}",
+                    "X-Org": "{org_id}",
+                },
+                required_fields=["api_key", "org_id"],
+            ),
+            admin_credentials={"api_key": "seed", "org_id": "seed-org"},
+            admin_credentials_changed={"api_key": True, "org_id": True},
+        )
+        server_id = _upsert_mcp_server(req, db_session, admin).id
+
+        with patch(
+            "onyx.server.features.mcp.api.test_mcp_server_credentials",
+            return_value=(True, "ok"),
+        ):
+            save_user_credentials(
+                MCPUserCredentialsRequest(
+                    server_id=server_id,
+                    credentials={
+                        "api_key": "USER-KEY-A-0000-1111",
+                        "org_id": "org-12345-abcdef",
+                    },
+                    transport="streamable_http",
+                ),
+                db_session,
+                user,
+            )
+            # Modal replay: api_key edited, org_id left as the masked seed.
+            save_user_credentials(
+                MCPUserCredentialsRequest(
+                    server_id=server_id,
+                    credentials={
+                        "api_key": "USER-KEY-B-2222-3333",
+                        "org_id": mask_string("org-12345-abcdef"),
+                    },
+                    transport="streamable_http",
+                ),
+                db_session,
+                user,
+            )
+
+        db_session.expire_all()
+        cfg_row = get_user_connection_config(server_id, user.email, db_session)
+        assert cfg_row is not None
+        cfg = dict(extract_connection_data(cfg_row, apply_mask=False))
+        assert cfg["headers"]["X-Org"] == "org-12345-abcdef", cfg
+        assert cfg["headers"]["Authorization"] == "Bearer USER-KEY-B-2222-3333", cfg
+
+
+class TestFlaglessClientsPerUserAndOAuth:
+    """Clients that predate the `*_changed` flags send only the edited
+    values; a real (unmasked) differing value must still win."""
+
+    def test_per_user_admin_credentials_without_flags(
+        self, db_session: Session
+    ) -> None:
+        admin = create_test_user(db_session, "admin_flagless", role=UserRole.ADMIN)
+        name = f"flagless-{uuid4().hex[:8]}"
+        template = MCPAuthTemplate(
+            headers={"Authorization": "Bearer {api_key}"},
+            required_fields=["api_key"],
+        )
+
+        def mk(
+            credentials: dict[str, str], existing: int | None
+        ) -> MCPToolCreateRequest:
+            return MCPToolCreateRequest(
+                name=name,
+                description="credential edit persistence",
+                server_url="http://upstream.example.com/mcp",
+                auth_type=MCPAuthenticationType.API_TOKEN,
+                auth_performer=MCPAuthenticationPerformer.PER_USER,
+                transport=MCPTransport.STREAMABLE_HTTP,
+                auth_template=template,
+                admin_credentials=credentials,
+                admin_credentials_changed={},  # old client: no flags
+                existing_server_id=existing,
+            )
+
+        server = _upsert_mcp_server(
+            mk({"api_key": "ADMIN-KEY-A-0000-1111"}, None), db_session, admin
+        )
+        _upsert_mcp_server(
+            mk({"api_key": "ADMIN-KEY-B-2222-3333"}, server.id), db_session, admin
+        )
+
+        db_session.expire_all()
+        cfg_row = get_user_connection_config(server.id, admin.email, db_session)
+        assert cfg_row is not None
+        cfg = dict(extract_connection_data(cfg_row, apply_mask=False))
+        assert cfg.get(HEADER_SUBSTITUTIONS) == {"api_key": "ADMIN-KEY-B-2222-3333"}
+
+    def test_per_user_masked_replay_without_flags_preserved(
+        self, db_session: Session
+    ) -> None:
+        admin = create_test_user(db_session, "admin_flagless_mask", role=UserRole.ADMIN)
+        name = f"flagless-mask-{uuid4().hex[:8]}"
+        template = MCPAuthTemplate(
+            headers={"Authorization": "Bearer {api_key}"},
+            required_fields=["api_key"],
+        )
+
+        def mk(
+            credentials: dict[str, str], existing: int | None
+        ) -> MCPToolCreateRequest:
+            return MCPToolCreateRequest(
+                name=name,
+                description="credential edit persistence",
+                server_url="http://upstream.example.com/mcp",
+                auth_type=MCPAuthenticationType.API_TOKEN,
+                auth_performer=MCPAuthenticationPerformer.PER_USER,
+                transport=MCPTransport.STREAMABLE_HTTP,
+                auth_template=template,
+                admin_credentials=credentials,
+                admin_credentials_changed={},
+                existing_server_id=existing,
+            )
+
+        server = _upsert_mcp_server(
+            mk({"api_key": "ADMIN-KEY-A-0000-1111"}, None), db_session, admin
+        )
+        _upsert_mcp_server(
+            mk({"api_key": mask_string("ADMIN-KEY-A-0000-1111")}, server.id),
+            db_session,
+            admin,
+        )
+
+        db_session.expire_all()
+        cfg_row = get_user_connection_config(server.id, admin.email, db_session)
+        assert cfg_row is not None
+        cfg = dict(extract_connection_data(cfg_row, apply_mask=False))
+        assert cfg.get(HEADER_SUBSTITUTIONS) == {"api_key": "ADMIN-KEY-A-0000-1111"}
+
+    def test_oauth_resolver_flagless_real_value_wins(self) -> None:
+        from mcp.shared.auth import OAuthClientInformationFull
+        from pydantic import AnyUrl
+
+        from onyx.server.features.mcp.api import _resolve_oauth_credentials
+
+        existing = OAuthClientInformationFull(
+            client_id="stored-client-id-0000",
+            client_secret="stored-secret-1111",
+            redirect_uris=[AnyUrl("https://onyx.example.com/mcp/oauth/callback")],
+        )
+
+        # Old client edits the secret: real value, no flags.
+        resolved_id, resolved_secret = _resolve_oauth_credentials(
+            request_client_id=mask_string("stored-client-id-0000"),
+            request_client_id_changed=False,
+            request_client_secret="edited-secret-2222",
+            request_client_secret_changed=False,
+            existing_client=existing,
+        )
+        assert resolved_id == "stored-client-id-0000"
+        assert resolved_secret == "edited-secret-2222"
+
+        # Pure masked replay keeps storage.
+        resolved_id, resolved_secret = _resolve_oauth_credentials(
+            request_client_id=mask_string("stored-client-id-0000"),
+            request_client_id_changed=False,
+            request_client_secret=mask_string("stored-secret-1111"),
+            request_client_secret_changed=False,
+            existing_client=existing,
+        )
+        assert resolved_id == "stored-client-id-0000"
+        assert resolved_secret == "stored-secret-1111"

--- a/web/src/components/chat/MCPApiKeyModal.tsx
+++ b/web/src/components/chat/MCPApiKeyModal.tsx
@@ -19,10 +19,11 @@ interface MCPApiKeyModalProps {
   serverName: string;
   serverId: number;
   authTemplate?: MCPAuthTemplate;
-  onSubmit: (serverId: number, apiKey: string) => void;
+  onSubmit: (serverId: number, apiKey: string, apiKeyChanged: boolean) => void;
   onSubmitCredentials?: (
     serverId: number,
-    credentials: Record<string, string>
+    credentials: Record<string, string>,
+    credentialsChanged: Record<string, boolean>
   ) => void;
   onSuccess?: () => void;
   isAuthenticated?: boolean;
@@ -81,7 +82,15 @@ export default function MCPApiKeyModal({
       setIsSubmitting(true);
       try {
         if (onSubmitCredentials) {
-          await onSubmitCredentials(serverId, credentials);
+          // Fields are pre-filled with masked values; tell the backend which
+          // ones the user actually edited.
+          const credentialsChanged = Object.fromEntries(
+            Object.entries(credentials).map(([field, value]) => [
+              field,
+              value !== (existingCredentials?.[field] ?? ""),
+            ])
+          );
+          await onSubmitCredentials(serverId, credentials, credentialsChanged);
         }
         setCredentials({});
         if (onSuccess) {
@@ -106,7 +115,11 @@ export default function MCPApiKeyModal({
 
       setIsSubmitting(true);
       try {
-        await onSubmit(serverId, apiKey);
+        await onSubmit(
+          serverId,
+          apiKey,
+          apiKey !== (existingCredentials?.api_key ?? "")
+        );
         setApiKey("");
         if (onSuccess) {
           onSuccess();

--- a/web/src/lib/tools/mcpService.ts
+++ b/web/src/lib/tools/mcpService.ts
@@ -260,11 +260,14 @@ export async function startMCPUserOAuth(
   return res.json();
 }
 
-/** Save per-user credentials (API key / template fields) for an MCP server. */
+/** Save per-user credentials (API key / template fields) for an MCP server.
+ * `credentialsChanged` marks which fields the user edited; without it the
+ * backend falls back to masked-value detection. */
 export async function saveMCPUserCredentials(
   serverId: number,
   credentials: Record<string, string>,
-  transport: MCPTransportType = MCPTransportType.STREAMABLE_HTTP
+  transport: MCPTransportType = MCPTransportType.STREAMABLE_HTTP,
+  credentialsChanged?: Record<string, boolean>
 ): Promise<void> {
   const res = await fetch("/api/mcp/user-credentials", {
     method: "POST",
@@ -273,6 +276,9 @@ export async function saveMCPUserCredentials(
       server_id: serverId,
       credentials,
       transport,
+      ...(credentialsChanged
+        ? { credentials_changed: credentialsChanged }
+        : {}),
     }),
   });
   if (!res.ok) {

--- a/web/src/refresh-components/popovers/ActionsPopover/index.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/index.tsx
@@ -538,7 +538,11 @@ export default function ActionsPopover({
     }
   };
 
-  const handleMCPApiKeySubmit = async (serverId: number, apiKey: string) => {
+  const handleMCPApiKeySubmit = async (
+    serverId: number,
+    apiKey: string,
+    apiKeyChanged: boolean
+  ) => {
     try {
       const response = await fetch("/api/mcp/user-credentials", {
         method: "POST",
@@ -548,6 +552,7 @@ export default function ActionsPopover({
         body: JSON.stringify({
           server_id: serverId,
           credentials: { api_key: apiKey },
+          credentials_changed: { api_key: apiKeyChanged },
           transport: "streamable-http",
         }),
       });
@@ -565,7 +570,8 @@ export default function ActionsPopover({
 
   const handleMCPCredentialsSubmit = async (
     serverId: number,
-    credentials: Record<string, string>
+    credentials: Record<string, string>,
+    credentialsChanged: Record<string, boolean>
   ) => {
     try {
       const response = await fetch("/api/mcp/user-credentials", {
@@ -576,6 +582,7 @@ export default function ActionsPopover({
         body: JSON.stringify({
           server_id: serverId,
           credentials: credentials,
+          credentials_changed: credentialsChanged,
           transport: "streamable-http",
         }),
       });


### PR DESCRIPTION
## Description

Customer-reported (https://linear.app/onyx-app/issue/CS-84): editing an existing MCP server's API key and hitting Connect silently kept the old key — the only workaround was deleting the credentials and re-adding them.

Root cause: the connection-config rewrite for admin-managed shared-API-key servers is gated on change detection that trusts the client-sent `api_token_changed` flag (and before #13335, only looked at per-user/scheme signals, so shared-key edits never persisted at all). Any client that doesn't send the flag — an older or cached frontend bundle after a backend upgrade, or a script — sends the new token and has it silently dropped: `_resolve_shared_api_token` resolves the new value, but the gate never fires, so the resolved token is discarded.

This PR makes credential change detection value-based rather than flag-trusting:

- **Shared key (ADMIN + API_TOKEN):** compare the resolved token against the stored one and rewrite the connection config when they differ, regardless of the flag. The flag is still honored when sent.
- **Per-user admin credentials & OAuth client id/secret:** a real (unmasked) request value that differs from storage wins even when the changed flag is absent; masked/absent replays keep the stored value, preserving the masked-placeholder protection from #13335.
- **`save_user_credentials` (end-user modal):** the modal seeds its inputs with masked stored values, so editing one field of a multi-field template replays the untouched fields as masked literals (`abcd...wxyz`), which were persisted verbatim and corrupted those headers. Masked replays are now resolved against the user's stored substitutions, and a masked value with no stored counterpart is rejected with a 400 instead of being saved.

## How Has This Been Tested?

New external-dependency-unit tests (`test_mcp_credential_edit_persistence.py`) replay the exact frontend payloads and assert on decrypted DB state, since API responses mask credentials:

- shared-key edit with `api_token_changed=true` (current frontend) persists the new key
- shared-key edit **without** the flag (pre-#13335 / flag-less client) persists the new key — failed before this PR
- masked replay with no edit preserves the stored key (no config churn)
- end-user single-field key update persists
- end-user multi-field update with a masked replay for the untouched field preserves the real stored value — failed before this PR
- per-user admin-credential edits without flags persist; masked flag-less replays preserve storage
- OAuth resolver: flag-less real secret edit wins; pure masked replay keeps storage

Full MCP suites pass: `backend/tests/external_dependency_unit/server/features/mcp` + `backend/tests/unit/onyx/server/features/mcp` (139 tests).

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP credential edits not being saved when clients don’t send “changed” flags, and makes masked replays safe. Detection is now value-based, and the user credentials modal sends per-field `credentials_changed` flags so real edits persist and masks never overwrite stored secrets. Fixes Linear CS-84.

- **Bug Fixes**
  - Shared admin API token: compare resolved vs stored and rewrite when different, regardless of `api_token_changed`.
  - Per-user admin credentials and OAuth client id/secret: real unmasked values win without flags; pure masked replays keep storage.
  - End-user modal: sends `credentials_changed` per field; unchanged flags reuse storage, changed flags take real values and reject masks with 400; absent flags fall back to masked-value detection for older clients.
  - Added regression tests that replay current and pre-flag payloads and verify decrypted DB state.

<sup>Written for commit fff4c1d7af3e5ec8c0c2cbf32f102df9be9d8f0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

