### PR TITLE
fix(craft): remove hardcoded reasoningEffort high from opencode config

### DIFF
--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -173,8 +173,6 @@ def _build_provider_block(
         }
         if capabilities.supports_interleaved_reasoning:
             entry["interleaved"] = True
-        if capabilities.supports_reasoning:
-            entry["options"] = {"reasoningEffort": "high"}
         if model.max_input_tokens is not None and model.max_output_tokens is not None:
             # OpenCode 1.15.x subtracts output from context when input is absent.
             # LiteLLM reports input and output budgets independently, so include

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_opencode_config.py
@@ -95,7 +95,6 @@ def test_gateway_is_the_only_enabled_provider() -> None:
             "input": ["text", "image"],
             "output": ["text"],
         },
-        "options": {"reasoningEffort": "high"},
         "limit": {
             "context": 200_000,
             "input": 200_000,

--- a/backend/tests/unit/onyx/server/features/craft/test_session_gateway_config.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_session_gateway_config.py
@@ -168,7 +168,7 @@ def test_gateway_model_capabilities_reach_opencode_catalog() -> None:
     }
     assert vision_model["attachment"] is True
     assert vision_model["reasoning"] is True
-    assert vision_model["options"] == {"reasoningEffort": "high"}
+    assert "options" not in vision_model
 
     text_model = opencode_models["3/claude-text-only"]
     assert text_model["modalities"] == {


### PR DESCRIPTION
## Description

Removes the hardcoded `reasoningEffort: "high"` that the per-session `opencode.json` set on every reasoning-capable model in the Craft gateway provider catalog.

With the option absent, opencode omits `reasoning_effort` from its gateway requests, so the gateway falls back to `ReasoningEffort.AUTO` — which maps to medium-tier reasoning per provider (`medium` for OpenAI and adaptive Claude, `budget_tokens: 2048` for legacy Claude thinking).

## How Has This Been Tested?

Updated the opencode-config unit tests to pin the new catalog shape (no `options` block on reasoning models); `test_opencode_config.py` and `test_session_gateway_config.py` pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the hardcoded `reasoningEffort: "high"` from the per-session `opencode` catalog. Gateway requests no longer force high reasoning and now use provider AUTO defaults.

- **Bug Fixes**
  - Stop sending `reasoning_effort` in gateway requests; rely on provider AUTO behavior.
  - Update unit tests to remove the `options` block and assert it is absent on reasoning models.

<sup>Written for commit eb32f8b1e740c375f67720b7f18e248250726517. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

