### PR TITLE
fix(usage): retain user_usage rows when a user is deleted

### DIFF
--- a/backend/alembic/versions/0d9c7b6a5e4f_retain_user_usage_after_user_deletion.py
+++ b/backend/alembic/versions/0d9c7b6a5e4f_retain_user_usage_after_user_deletion.py
@@ -1,0 +1,47 @@
+"""retain user usage after user deletion
+
+Revision ID: 0d9c7b6a5e4f
+Revises: f57f35403f6c
+Create Date: 2026-07-28 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0d9c7b6a5e4f"
+down_revision = "f57f35403f6c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # CASCADE erased a deleted user's spend history, so historical org totals
+    # shrank on every offboard. API-key principals are user rows too, so
+    # deleting a key erased its spend as well.
+    op.drop_constraint("user_usage_user_id_fkey", "user_usage", type_="foreignkey")
+    op.alter_column("user_usage", "user_id", existing_type=sa.UUID(), nullable=True)
+    op.create_foreign_key(
+        "user_usage_user_id_fkey",
+        "user_usage",
+        "user",
+        ["user_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("user_usage_user_id_fkey", "user_usage", type_="foreignkey")
+    # Orphaned rows cannot satisfy the NOT NULL constraint being restored.
+    op.execute("DELETE FROM user_usage WHERE user_id IS NULL")
+    op.alter_column("user_usage", "user_id", existing_type=sa.UUID(), nullable=False)
+    op.create_foreign_key(
+        "user_usage_user_id_fkey",
+        "user_usage",
+        "user",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5829,8 +5829,8 @@ class UserUsage(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
 
     # No index=True: uq_user_usage_dims (user_id-first) covers user-only lookups.
-    user_id: Mapped[UUID] = mapped_column(
-        ForeignKey("user.id", ondelete="CASCADE"), nullable=False
+    user_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
 
     window_start: Mapped[datetime.datetime] = mapped_column(

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -25,6 +25,8 @@ USER_USAGE_BUCKET_SECONDS = 24 * 60 * 60
 USER_USAGE_BUCKET_HOURS = USER_USAGE_BUCKET_SECONDS // (60 * 60)
 TOKEN_BUDGET_PERIOD_ERROR = "Token budget periods must be whole UTC days"
 COST_BUDGET_PERIOD_ERROR = "Cost budget periods must be whole UTC days"
+# Not email-shaped on purpose: it can never collide with a real address.
+DELETED_USER_EXPORT_EMAIL = "(deleted user)"
 _CONFLICT_COLS = ["user_id", "window_start", "model", "flow", "provider"]
 
 
@@ -216,11 +218,13 @@ def get_usage_export(
 ) -> list[UsageExportRow]:
     """Tenant-wide usage by email, model, and UTC day."""
     utc_day = func.date(func.timezone("UTC", UserUsage.window_start))
+    # Deleted users/API keys leave user_id NULL but keep their spend. An inner
+    # join would hide that spend here while the tenant-wide totals still count
+    # it, so the export would silently stop reconciling with them.
+    email_label = func.coalesce(User.email, DELETED_USER_EXPORT_EMAIL)
     query = (
-        # User.email comes from the fastapi-users base; ty mis-resolves it as a
-        # non-column role, so the multi-column select overload doesn't match.
-        select(  # ty: ignore[no-matching-overload]
-            User.email,
+        select(
+            email_label,
             UserUsage.model,
             utc_day.label("day"),
             func.sum(UserUsage.input_tokens),
@@ -228,13 +232,15 @@ def get_usage_export(
             func.sum(UserUsage.cache_read_tokens),
             func.sum(UserUsage.cost_cents),
         )
-        .join(User, User.id == UserUsage.user_id)
+        # UserUsage.user_id on the left: User.id comes from the fastapi-users
+        # base, which ty resolves as a plain value rather than a column.
+        .outerjoin(User, UserUsage.user_id == User.id)
         .where(
             UserUsage.window_start >= start,
             UserUsage.window_start < end,
         )
-        .group_by(User.email, UserUsage.model, utc_day)
-        .order_by(User.email, utc_day, UserUsage.model)
+        .group_by(email_label, UserUsage.model, utc_day)
+        .order_by(email_label, utc_day, UserUsage.model)
     )
     if model is not None:
         query = query.where(UserUsage.model == model)

--- a/backend/tests/unit/onyx/db/test_user_usage.py
+++ b/backend/tests/unit/onyx/db/test_user_usage.py
@@ -12,7 +12,8 @@ from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
-from sqlalchemy import Table, create_engine, event
+from sqlalchemy import Table, create_engine, event, text
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.engine import Engine
@@ -148,8 +149,6 @@ class TestRecordUserUsage:
         mock_session.flush.assert_called_once()
 
     def test_null_provider_stored_as_empty_string(self) -> None:
-        from sqlalchemy.dialects import postgresql
-
         mock_session = MagicMock()
         window = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
 
@@ -169,6 +168,39 @@ class TestRecordUserUsage:
         stmt = mock_session.execute.call_args[0][0]
         compiled = stmt.compile(dialect=postgresql.dialect())
         assert compiled.params["provider"] == ""
+
+    def test_user_deletion_retains_usage_row_with_null_user_id(self) -> None:
+        engine: Engine = create_engine("sqlite://")
+
+        @event.listens_for(engine, "connect")
+        def _enable_foreign_keys(dbapi_connection: object, _: object) -> None:
+            cast(sqlite3.Connection, dbapi_connection).execute("PRAGMA foreign_keys=ON")
+
+        with engine.begin() as conn:
+            conn.exec_driver_sql(
+                'CREATE TABLE "user" (id CHAR(36) PRIMARY KEY, email VARCHAR)'
+            )
+        cast(Table, UserUsage.__table__).create(bind=engine)
+        SessionLocal = sessionmaker(bind=engine)
+        session = SessionLocal()
+        user_id = str(uuid4())
+        window = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+        try:
+            session.execute(
+                text('INSERT INTO "user" (id, email) VALUES (:id, :email)'),
+                {"id": user_id, "email": "api-key@example.com"},
+            )
+            _seed_usage(session, user_id, "m", "CHAT", None, 1, 1, 0, 1.0, window)
+            session.commit()
+
+            session.execute(text('DELETE FROM "user" WHERE id = :id'), {"id": user_id})
+            session.commit()
+
+            row = session.query(UserUsage).one()
+            assert row.user_id is None
+            assert row.cost_cents == pytest.approx(1.0)
+        finally:
+            session.close()
 
 
 class TestAggregation:

--- a/backend/tests/unit/onyx/db/test_user_usage.py
+++ b/backend/tests/unit/onyx/db/test_user_usage.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from onyx.db.models import User__UserGroup, UserUsage
 from onyx.db.user_usage import (
+    DELETED_USER_EXPORT_EMAIL,
     TokenUsageBucket,
     UserUsageByDay,
     get_cost_window_start,
@@ -31,6 +32,7 @@ from onyx.db.user_usage import (
     get_total_cost_cents_buckets_since,
     get_total_cost_cents_since,
     get_total_token_buckets_since,
+    get_usage_export,
     get_user_cost_cents_buckets_since,
     get_user_cost_cents_in_window,
     get_user_cost_cents_since,
@@ -115,6 +117,12 @@ def db_session() -> Generator[Session, None, None]:
             "timezone", 2, lambda _tz, value: value
         )
 
+    # Minimal stand-in for the real fastapi-users table: only id/email are ever
+    # referenced by these queries, and User.__table__ drags in unrelated FKs.
+    with engine.begin() as conn:
+        conn.exec_driver_sql(
+            'CREATE TABLE "user" (id CHAR(36) PRIMARY KEY, email VARCHAR)'
+        )
     cast(Table, UserUsage.__table__).create(bind=engine)
     SessionLocal = sessionmaker(bind=engine)
     session = SessionLocal()
@@ -201,6 +209,72 @@ class TestRecordUserUsage:
             assert row.cost_cents == pytest.approx(1.0)
         finally:
             session.close()
+
+
+class TestUsageExport:
+    def test_orphaned_usage_is_exported_and_reconciles_with_total(
+        self, db_session: Session
+    ) -> None:
+        """Spend left behind by a deleted user/API key must still export, and the
+        export must still add up to the tenant-wide total used for enforcement."""
+        live_user = str(uuid4())
+        window = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+        db_session.execute(
+            text('INSERT INTO "user" (id, email) VALUES (:id, :email)'),
+            {"id": live_user, "email": "live@example.com"},
+        )
+        _seed_usage(db_session, live_user, "m", "CHAT", None, 10, 5, 0, 3.0, window)
+        # user_id NULL is what SET NULL leaves behind after the user is deleted.
+        db_session.add(
+            UserUsage(
+                user_id=None,
+                window_start=window,
+                model="m",
+                flow="CHAT",
+                provider="",
+                input_tokens=20,
+                output_tokens=7,
+                cache_read_tokens=0,
+                cost_cents=4.0,
+            )
+        )
+        db_session.flush()
+
+        rows = get_usage_export(db_session, window, window + datetime.timedelta(days=1))
+
+        by_email = {row.email: row for row in rows}
+        assert set(by_email) == {"live@example.com", DELETED_USER_EXPORT_EMAIL}
+        assert by_email[DELETED_USER_EXPORT_EMAIL].cost_cents == pytest.approx(4.0)
+        assert by_email[DELETED_USER_EXPORT_EMAIL].input_tokens == 20
+        assert sum(row.cost_cents for row in rows) == pytest.approx(
+            get_total_cost_cents_since(db_session, window)
+        )
+
+    def test_orphaned_rows_collapse_into_one_bucket_per_model_and_day(
+        self, db_session: Session
+    ) -> None:
+        window = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+        for cost in (1.0, 2.5):
+            db_session.add(
+                UserUsage(
+                    user_id=None,
+                    window_start=window,
+                    model="m",
+                    flow="CHAT",
+                    provider="",
+                    input_tokens=1,
+                    output_tokens=1,
+                    cache_read_tokens=0,
+                    cost_cents=cost,
+                )
+            )
+        db_session.flush()
+
+        rows = get_usage_export(db_session, window, window + datetime.timedelta(days=1))
+
+        assert len(rows) == 1
+        assert rows[0].email == DELETED_USER_EXPORT_EMAIL
+        assert rows[0].cost_cents == pytest.approx(3.5)
 
 
 class TestAggregation:


### PR DESCRIPTION
## Description

Deleting a user erased their `user_usage` rows, so historical org spend silently shrank on every offboard. `user_usage.user_id` was `NOT NULL` with `ondelete="CASCADE"`, so the rollup rows went with the user.

This is worse than it sounds for API keys: an API-key principal *is* a `User` row (the synthetic service account), so revoking a key deleted its entire spend history too.

**1. Retain the rows.** `user_id` becomes nullable and the FK swaps to `ondelete="SET NULL"`. Cost rows are orphaned rather than deleted, so period totals stay stable across user and key deletion. Per-user attribution for a deleted user is intentionally lost — the row keeps its tokens, cost, model, flow, provider, and window, just not the identity.

**2. Keep the retained rows visible.** `get_usage_export` inner-joined `User`, so orphaned rows would have dropped out of the admin export. That would have been a worse bug than the one being fixed: the tenant-wide aggregates (`get_total_cost_cents_since`, which global cost-budget enforcement reads) are plain `SUM(cost_cents)` with no join, so they *do* count orphaned spend. An org could be rate-limited on spend that appears nowhere in the export an admin pulls to investigate. The export now outer-joins and labels orphaned rows `(deleted user)`, collapsing them into one bucket per model/day.

No new columns and no index changes; `uq_user_usage_dims` is untouched.

### Note for reviewers

`UsageExportRow.email` can now be the non-email sentinel `(deleted user)`. That is a deliberate contract change — flagging it in case any downstream CSV consumer assumes the column always parses as an email address.

Group rollups (`get_group_cost_cents_since` and friends) still inner-join `User__UserGroup` and therefore still exclude orphaned rows. That is intended: a deleted user's group-membership rows go away with them, so there is no group left to attribute the spend to.

## How Has This Been Tested?

New unit tests in `backend/tests/unit/onyx/db/test_user_usage.py`:

- `test_user_deletion_retains_usage_row_with_null_user_id` — SQLite with `PRAGMA foreign_keys=ON`; deletes the user and asserts the usage row survives with `user_id IS NULL` and `cost_cents` intact.
- `test_orphaned_usage_is_exported_and_reconciles_with_total` — asserts orphaned spend appears in the export under `(deleted user)` **and** that the export sums to `get_total_cost_cents_since`, which is the invariant that was broken.
- `test_orphaned_rows_collapse_into_one_bucket_per_model_and_day` — multiple orphaned rows aggregate into a single export row.

Both export tests were confirmed to fail against the old inner join and pass with the outer join.

Also:

- Full `test_user_usage.py`, `test_user_usage_processor.py`, and `server/features/usage/` suites pass (61 tests).
- Migration exercised against a live Postgres and round-tripped: `upgrade` → `user_id` nullable with `confdeltype='n'`, 12 columns, `uq_user_usage_dims` unchanged; `downgrade` → back to `NOT NULL` + `confdeltype='c'`; re-`upgrade` clean.
- `ty` + ruff + ruff-format clean.

**Note for deploy:** the FK swap takes an `ACCESS EXCLUSIVE` lock on `user_usage`. While testing I reproducibly saw it queue for minutes behind `idle in transaction` sessions held by the running app. Worth running with a `lock_timeout` and retry rather than letting it block a startup probe.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check