### PR TITLE
fix(auth): adopt the provider's address on login

### DIFF
--- a/backend/ee/onyx/db/user_tenant_mapping.py
+++ b/backend/ee/onyx/db/user_tenant_mapping.py
@@ -103,20 +103,29 @@ def resolve_tenant_id(
     """Tenant this login belongs to, or None when it maps nowhere.
 
     An active subject membership wins because only the subject survives an
-    address change. A superseded one is the last resort, since an active email
-    membership names a workspace the user was deliberately moved into.
+    address change. A superseded one ranks behind an active email membership,
+    which is where an admin-initiated workspace move lands, and ahead of an
+    address that maps nowhere or to several pending invitations.
     """
+    superseded_tenant_id: str | None = None
     if oauth_name and account_id:
         tenant_id = get_tenant_id_for_oauth_account(oauth_name, account_id)
         if tenant_id:
             return tenant_id
+        superseded_tenant_id = get_superseded_tenant_id_for_oauth_account(
+            oauth_name, account_id
+        )
 
     try:
         return get_tenant_id_for_email(email)
     except exceptions.UserNotExists:
-        if not (oauth_name and account_id):
-            return None
-        return get_superseded_tenant_id_for_oauth_account(oauth_name, account_id)
+        return superseded_tenant_id
+    except OnyxError:
+        # A linked subject names exactly one workspace, so it settles an address
+        # the caller would otherwise have to disambiguate.
+        if superseded_tenant_id is None:
+            raise
+        return superseded_tenant_id
 
 
 def _oauth_account_tenant_id(
@@ -269,6 +278,24 @@ def rekey_user_mapping_email(
 
     normalized_new_email = new_email.lower()
     with get_catalog_session() as db_session:
+        # uq_user_active_email_idx spans tenants, so the address may already be
+        # held. Moving the row onto it anyway would make the other tenant's row
+        # answer this user's next login, and the subject link still resolves it.
+        held_elsewhere = db_session.scalar(
+            select(UserTenantMapping.tenant_id).where(
+                UserTenantMapping.email == normalized_new_email,
+                UserTenantMapping.tenant_id != tenant_id,
+                UserTenantMapping.active == True,  # noqa: E712
+            )
+        )
+        if held_elsewhere is not None:
+            logger.warning(
+                "Renamed address is active in another workspace, leaving the "
+                "tenant %s mapping under its current address",
+                tenant_id,
+            )
+            return
+
         matched_mappings = (
             db_session.query(UserTenantMapping)
             .filter(

--- a/backend/ee/onyx/db/user_tenant_mapping.py
+++ b/backend/ee/onyx/db/user_tenant_mapping.py
@@ -244,6 +244,101 @@ def _association_ownership_filter(
     )
 
 
+def rekey_user_mapping_email(
+    new_email: str,
+    tenant_id: str,
+    oauth_identities: Sequence[tuple[str, str]],
+) -> None:
+    """Collapse this tenant's membership rows for the user's linked subjects
+    onto their new address, keeping one row and deleting the rest.
+
+    Otherwise a row keeps routing the old address and leaves the new one
+    unmapped, which is the state that provisions a second tenant.
+
+    Ownership is matched by any linked subject, since the provider used for
+    this login may not be the one that linked the row. Subject links are moved
+    to the surviving row before the others are deleted.
+
+    No-op outside multi-tenant, where the mapping tables are not provisioned.
+    """
+    if not MULTI_TENANT:
+        return
+
+    identities = list(dict.fromkeys(oauth_identities))
+    if not identities:
+        logger.warning("No linked OAuth identity to rekey in tenant %s", tenant_id)
+        return
+
+    normalized_new_email = new_email.lower()
+    with get_catalog_session() as db_session:
+        matched_mappings = (
+            db_session.query(UserTenantMapping)
+            .filter(
+                UserTenantMapping.tenant_id == tenant_id,
+                _association_ownership_filter(identities),
+            )
+            .with_for_update()
+            .all()
+        )
+        if not matched_mappings:
+            logger.warning("No mapping row to rekey in tenant %s", tenant_id)
+            return
+
+        destination = (
+            db_session.query(UserTenantMapping)
+            .filter(
+                UserTenantMapping.tenant_id == tenant_id,
+                UserTenantMapping.email == normalized_new_email,
+            )
+            .with_for_update()
+            .one_or_none()
+        )
+        identity_source = next(
+            (mapping for mapping in matched_mappings if mapping.active),
+            matched_mappings[0],
+        )
+
+        if destination is None:
+            destination = identity_source
+            destination.email = normalized_new_email
+
+        source_mappings = [
+            mapping for mapping in matched_mappings if mapping is not destination
+        ]
+        if source_mappings:
+            association_accounts = (
+                db_session.query(UserTenantMappingOAuthAccount)
+                .filter(
+                    tuple_(
+                        UserTenantMappingOAuthAccount.email,
+                        UserTenantMappingOAuthAccount.tenant_id,
+                    ).in_(
+                        [
+                            (mapping.email, mapping.tenant_id)
+                            for mapping in source_mappings
+                        ]
+                    )
+                )
+                .with_for_update()
+                .all()
+            )
+            for account in association_accounts:
+                account.email = destination.email
+                account.tenant_id = destination.tenant_id
+
+            # Move association FKs before their source mappings are deleted,
+            # or ON DELETE CASCADE takes the links with them.
+            db_session.flush()
+
+        destination.active = destination.active or any(
+            mapping.active for mapping in matched_mappings
+        )
+        for mapping in source_mappings:
+            db_session.delete(mapping)
+
+        db_session.commit()
+
+
 def add_users_to_tenant(emails: list[str], tenant_id: str) -> None:
     """
     Add users to a tenant. If a user has an active mapping elsewhere,
@@ -252,7 +347,7 @@ def add_users_to_tenant(emails: list[str], tenant_id: str) -> None:
     Calls ``enforce_cloud_seat_limit`` before inserting any new active
     mapping so Stripe auto-billing fails the request closed on decline.
     """
-    unique_emails = set(emails)
+    unique_emails = {email.lower() for email in emails}
     if not unique_emails:
         return
 
@@ -331,12 +426,13 @@ def add_users_to_tenant(emails: list[str], tenant_id: str) -> None:
 
 
 def remove_users_from_tenant(emails: list[str], tenant_id: str) -> None:
+    normalized_emails = [email.lower() for email in emails]
     with get_catalog_session() as db_session:
         try:
             mappings_to_delete = (
                 db_session.query(UserTenantMapping)
                 .filter(
-                    UserTenantMapping.email.in_(emails),
+                    UserTenantMapping.email.in_(normalized_emails),
                     UserTenantMapping.tenant_id == tenant_id,
                 )
                 .all()
@@ -572,6 +668,7 @@ def deny_user_invite(email: str, tenant_id: str) -> None:
     Deny an invitation to join a tenant.
     This removes the user's mapping to the tenant.
     """
+    email = email.lower()
     with get_catalog_session() as db_session:
         # Delete the mapping for this user and tenant
         result = (
@@ -652,6 +749,7 @@ def get_tenant_invitation(email: str) -> TenantSnapshot | None:
     """
     Get the first tenant invitation for this user
     """
+    email = email.lower()
     with get_catalog_session() as db_session:
         # Get the first tenant invitation for this user
         invitation = (

--- a/backend/ee/onyx/db/user_tenant_mapping.py
+++ b/backend/ee/onyx/db/user_tenant_mapping.py
@@ -252,12 +252,10 @@ def rekey_user_mapping_email(
     """Collapse this tenant's membership rows for the user's linked subjects
     onto their new address, keeping one row and deleting the rest.
 
-    Otherwise a row keeps routing the old address and leaves the new one
-    unmapped, which is the state that provisions a second tenant.
-
-    Ownership is matched by any linked subject, since the provider used for
-    this login may not be the one that linked the row. Subject links are moved
-    to the surviving row before the others are deleted.
+    An unmapped new address links no further subjects and resolves nowhere for
+    a login that presents none, which is what provisions a second tenant.
+    Ownership is matched by any linked subject, since the provider used for this
+    login may not be the one that linked the row.
 
     No-op outside multi-tenant, where the mapping tables are not provisioned.
     """
@@ -293,13 +291,12 @@ def rekey_user_mapping_email(
             .with_for_update()
             .one_or_none()
         )
-        identity_source = next(
-            (mapping for mapping in matched_mappings if mapping.active),
-            matched_mappings[0],
-        )
-
         if destination is None:
-            destination = identity_source
+            # Prefer the active row so the surviving membership keeps its state.
+            destination = next(
+                (mapping for mapping in matched_mappings if mapping.active),
+                matched_mappings[0],
+            )
             destination.email = normalized_new_email
 
         source_mappings = [
@@ -326,12 +323,12 @@ def rekey_user_mapping_email(
                 account.email = destination.email
                 account.tenant_id = destination.tenant_id
 
-            # Move association FKs before their source mappings are deleted,
-            # or ON DELETE CASCADE takes the links with them.
+            # Land the FK moves before the source mappings are deleted, or
+            # ON DELETE CASCADE takes the links with them.
             db_session.flush()
 
         destination.active = destination.active or any(
-            mapping.active for mapping in matched_mappings
+            mapping.active for mapping in source_mappings
         )
         for mapping in source_mappings:
             db_session.delete(mapping)

--- a/backend/ee/onyx/db/user_tenant_mapping.py
+++ b/backend/ee/onyx/db/user_tenant_mapping.py
@@ -257,6 +257,7 @@ def rekey_user_mapping_email(
     new_email: str,
     tenant_id: str,
     oauth_identities: Sequence[tuple[str, str]],
+    previous_email: str | None = None,
 ) -> None:
     """Collapse this tenant's membership rows for the user's linked subjects
     onto their new address, keeping one row and deleting the rest.
@@ -264,7 +265,8 @@ def rekey_user_mapping_email(
     An unmapped new address links no further subjects and resolves nowhere for
     a login that presents none, which is what provisions a second tenant.
     Ownership is matched by any linked subject, since the provider used for this
-    login may not be the one that linked the row.
+    login may not be the one that linked the row. ``previous_email`` names the
+    row the caller is moving, since a tenant can hold several of this user's.
 
     No-op outside multi-tenant, where the mapping tables are not provisioned.
     """
@@ -319,8 +321,17 @@ def rekey_user_mapping_email(
             .one_or_none()
         )
         if destination is None:
-            # Prefer the active row so the surviving membership keeps its state.
+            normalized_previous = previous_email.lower() if previous_email else None
             destination = next(
+                (
+                    mapping
+                    for mapping in matched_mappings
+                    if mapping.email == normalized_previous
+                ),
+                None,
+            ) or next(
+                # No caller-named row, so fall back to keeping an active
+                # membership active rather than reviving a retired one.
                 (mapping for mapping in matched_mappings if mapping.active),
                 matched_mappings[0],
             )
@@ -341,7 +352,14 @@ def rekey_user_mapping_email(
                             (mapping.email, mapping.tenant_id)
                             for mapping in source_mappings
                         ]
-                    )
+                    ),
+                    # A row can carry a stranger's subject, so scope the move to
+                    # this user's. `identities` is every provider they have
+                    # linked, not just the one used today, so none is stranded.
+                    tuple_(
+                        UserTenantMappingOAuthAccount.oauth_name,
+                        UserTenantMappingOAuthAccount.account_id,
+                    ).in_(identities),
                 )
                 .with_for_update()
                 .all()

--- a/backend/ee/onyx/db/user_tenant_mapping.py
+++ b/backend/ee/onyx/db/user_tenant_mapping.py
@@ -320,6 +320,31 @@ def rekey_user_mapping_email(
             .with_for_update()
             .one_or_none()
         )
+        # A row carries someone else's subject once a declined rekey parks it
+        # and an invite hands the address on. Renaming one promotes them into a
+        # workspace, and deleting one cascades their membership away.
+        candidate_keys = {(row.email, row.tenant_id) for row in matched_mappings}
+        if destination is not None:
+            candidate_keys.add((destination.email, destination.tenant_id))
+        if db_session.scalar(
+            select(UserTenantMappingOAuthAccount.account_id).where(
+                tuple_(
+                    UserTenantMappingOAuthAccount.email,
+                    UserTenantMappingOAuthAccount.tenant_id,
+                ).in_(list(candidate_keys)),
+                ~tuple_(
+                    UserTenantMappingOAuthAccount.oauth_name,
+                    UserTenantMappingOAuthAccount.account_id,
+                ).in_(identities),
+            )
+        ):
+            logger.warning(
+                "Mapping rows in tenant %s carry another identity's subject, "
+                "leaving them as they are",
+                tenant_id,
+            )
+            return
+
         if destination is None:
             normalized_previous = previous_email.lower() if previous_email else None
             destination = next(

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -342,13 +342,34 @@ def verify_email_is_invited(email: str) -> None:
 def remove_user_from_invited_users_after_login(
     email: str, user_id: uuid.UUID, tenant_id: str
 ) -> None:
-    """Best-effort invite cleanup for an already-authenticated login."""
+    """Best-effort invite cleanup. A leftover entry is inert once the user is a
+    member, so a failure must not fail the login."""
     try:
         remove_user_from_invited_users(email)
     except Exception:
         logger.warning(
             "Invite cleanup failed after login: user_id=%s tenant=%s",
             user_id,
+            tenant_id,
+            exc_info=True,
+        )
+
+
+def rekey_tenant_mapping_after_login(
+    email: str, tenant_id: str, oauth_identities: list[tuple[str, str]]
+) -> None:
+    """Best-effort catalog rekey for a login that has already succeeded.
+
+    Tenant resolution routes by linked subject, so a membership row left under
+    the old address still reaches the right workspace and the next login retries.
+    """
+    try:
+        fetch_ee_implementation_or_noop(
+            "onyx.db.user_tenant_mapping", "rekey_user_mapping_email", None
+        )(email, tenant_id, oauth_identities)
+    except Exception:
+        logger.warning(
+            "Tenant mapping rekey failed after login: tenant=%s",
             tenant_id,
             exc_info=True,
         )
@@ -1052,24 +1073,21 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
             assert user is not None
 
-            # Keyed on the stored email rather than the one the IdP just sent:
-            # that is the address this user's membership row is filed under.
+            # Keyed on the stored email rather than the one the IdP just sent.
+            # The membership row moves onto the new address at the rekey below.
             fetch_ee_implementation_or_noop(
                 "onyx.db.user_tenant_mapping", "record_oauth_identity", None
             )(user.email, tenant_id, oauth_name, account_id)
 
             # The provider is authoritative for the address, so adopt it when it
-            # has moved. Runs in every deployment: single-tenant reaches the
-            # right user by subject and so hits this with a stale email too.
-            oauth_user_id = user.id
+            # moves. Not gated on multi-tenant: single-tenant reaches the same
+            # user by subject and so arrives here with a stale email too.
             email_reconcile_result = await db_session.run_sync(
-                lambda sync_session: reconcile_user_email__no_commit(
-                    oauth_user_id, account_email, sync_session
-                )
+                partial(reconcile_user_email__no_commit, user.id, account_email)
             )
-            if email_reconcile_result:
-                await db_session.commit()
+            if email_reconcile_result is not None:
                 _, reconciled_prior_emails = email_reconcile_result
+                await db_session.commit()
                 user.email = account_email.lower()
                 user.prior_emails = reconciled_prior_emails
 
@@ -1078,22 +1096,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 for oauth_account in user.oauth_accounts
             ]
 
-            # Resolve by subject so a failed rekey is repaired on the next login
-            # even though `User.email` has already changed. Every linked subject
-            # is passed so a row another provider linked is still matched.
-            fetch_ee_implementation_or_noop(
-                "onyx.db.user_tenant_mapping", "rekey_user_mapping_email", None
-            )(
-                user.email,
-                tenant_id,
-                oauth_identities,
-            )
-
-            # An invite issued to a replaced address is still this user's.
-            for prior_email in user.prior_emails:
-                remove_user_from_invited_users_after_login(
-                    prior_email, user.id, tenant_id
-                )
+            rekey_tenant_mapping_after_login(user.email, tenant_id, oauth_identities)
 
             # NOTE: Most IdPs have very short expiry times, and we don't want to force the user to
             # re-authenticate that frequently, so by default this is disabled
@@ -1161,7 +1164,11 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             if user.oidc_expiry is not None and not track_external_idp_expiry:
                 await self.user_db.update(user, {"oidc_expiry": None})
                 user.oidc_expiry = None  # ty: ignore[invalid-assignment]
-            remove_user_from_invited_users_after_login(user.email, user.id, tenant_id)
+            # An invite issued to a replaced address is still this user's.
+            for invited_email in (user.email, *user.prior_emails):
+                remove_user_from_invited_users_after_login(
+                    invited_email, user.id, tenant_id
+                )
 
             return user
 

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1086,10 +1086,16 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 partial(reconcile_user_email__no_commit, user.id, account_email)
             )
             if email_reconcile_result is not None:
-                _, reconciled_prior_emails = email_reconcile_result
+                replaced_email, reconciled_prior_emails = email_reconcile_result
                 await db_session.commit()
                 user.email = account_email.lower()
                 user.prior_emails = reconciled_prior_emails
+                # Retire the invite this user joined with, once, at the rename.
+                # Retrying it on later logins would delete an invitation issued
+                # to whoever holds that address next.
+                remove_user_from_invited_users_after_login(
+                    replaced_email, user.id, tenant_id
+                )
 
             oauth_identities = [
                 (oauth_account.oauth_name, oauth_account.account_id)
@@ -1164,11 +1170,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             if user.oidc_expiry is not None and not track_external_idp_expiry:
                 await self.user_db.update(user, {"oidc_expiry": None})
                 user.oidc_expiry = None  # ty: ignore[invalid-assignment]
-            # An invite issued to a replaced address is still this user's.
-            for invited_email in (user.email, *user.prior_emails):
-                remove_user_from_invited_users_after_login(
-                    invited_email, user.id, tenant_id
-                )
+            remove_user_from_invited_users_after_login(user.email, user.id, tenant_id)
 
             return user
 

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -6,6 +6,7 @@ import secrets
 import string
 import uuid
 from collections.abc import AsyncGenerator, Sequence
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from functools import partial
 from typing import Any, Dict, List, Literal, Optional, Protocol, Tuple, TypeVar, cast
@@ -140,6 +141,7 @@ from onyx.db.users import (
     get_user_by_email,
     get_user_by_oauth_account,
     is_limited_user,
+    reconcile_user_email__no_commit,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import (
@@ -337,6 +339,21 @@ def verify_email_is_invited(email: str) -> None:
     )
 
 
+def remove_user_from_invited_users_after_login(
+    email: str, user_id: uuid.UUID, tenant_id: str
+) -> None:
+    """Best-effort invite cleanup for an already-authenticated login."""
+    try:
+        remove_user_from_invited_users(email)
+    except Exception:
+        logger.warning(
+            "Invite cleanup failed after login: user_id=%s tenant=%s",
+            user_id,
+            tenant_id,
+            exc_info=True,
+        )
+
+
 def verify_email_in_whitelist(
     email: str,
     tenant_id: str,
@@ -481,6 +498,18 @@ def _invalidate_license_cache_after_seat_change() -> None:
     fetch_ee_implementation_or_noop(
         "onyx.db.license", "invalidate_license_cache", None
     )()
+
+
+@asynccontextmanager
+async def _tenant_session_with_context(
+    tenant_id: str,
+) -> AsyncGenerator[AsyncSession, None]:
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
+    try:
+        async with get_async_session_context_manager(tenant_id) as db_session:
+            yield db_session
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
 
 
 class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
@@ -922,10 +951,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             raise HTTPException(status_code=401, detail="User not found")
 
         # Proceed with the tenant context
-        token = None
-        async with get_async_session_context_manager(tenant_id) as db_session:
-            token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
-
+        async with _tenant_session_with_context(tenant_id) as db_session:
             verify_email_in_whitelist(account_email, tenant_id, oauth_name, account_id)
             oauth_security_settings = get_security_settings()
             effective_valid_email_domains = (
@@ -1024,11 +1050,50 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                                 oauth_account_dict,
                             )
 
+            assert user is not None
+
             # Keyed on the stored email rather than the one the IdP just sent:
             # that is the address this user's membership row is filed under.
             fetch_ee_implementation_or_noop(
                 "onyx.db.user_tenant_mapping", "record_oauth_identity", None
             )(user.email, tenant_id, oauth_name, account_id)
+
+            # The provider is authoritative for the address, so adopt it when it
+            # has moved. Runs in every deployment: single-tenant reaches the
+            # right user by subject and so hits this with a stale email too.
+            oauth_user_id = user.id
+            email_reconcile_result = await db_session.run_sync(
+                lambda sync_session: reconcile_user_email__no_commit(
+                    oauth_user_id, account_email, sync_session
+                )
+            )
+            if email_reconcile_result:
+                await db_session.commit()
+                _, reconciled_prior_emails = email_reconcile_result
+                user.email = account_email.lower()
+                user.prior_emails = reconciled_prior_emails
+
+            oauth_identities = [
+                (oauth_account.oauth_name, oauth_account.account_id)
+                for oauth_account in user.oauth_accounts
+            ]
+
+            # Resolve by subject so a failed rekey is repaired on the next login
+            # even though `User.email` has already changed. Every linked subject
+            # is passed so a row another provider linked is still matched.
+            fetch_ee_implementation_or_noop(
+                "onyx.db.user_tenant_mapping", "rekey_user_mapping_email", None
+            )(
+                user.email,
+                tenant_id,
+                oauth_identities,
+            )
+
+            # An invite issued to a replaced address is still this user's.
+            for prior_email in user.prior_emails:
+                remove_user_from_invited_users_after_login(
+                    prior_email, user.id, tenant_id
+                )
 
             # NOTE: Most IdPs have very short expiry times, and we don't want to force the user to
             # re-authenticate that frequently, so by default this is disabled
@@ -1096,9 +1161,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             if user.oidc_expiry is not None and not track_external_idp_expiry:
                 await self.user_db.update(user, {"oidc_expiry": None})
                 user.oidc_expiry = None  # ty: ignore[invalid-assignment]
-            remove_user_from_invited_users(user.email)
-            if token:
-                CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+            remove_user_from_invited_users_after_login(user.email, user.id, tenant_id)
 
             return user
 

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -356,7 +356,10 @@ def remove_user_from_invited_users_after_login(
 
 
 def rekey_tenant_mapping_after_login(
-    email: str, tenant_id: str, oauth_identities: list[tuple[str, str]]
+    email: str,
+    tenant_id: str,
+    oauth_identities: list[tuple[str, str]],
+    previous_email: str | None = None,
 ) -> None:
     """Best-effort catalog rekey for a login that has already succeeded.
 
@@ -366,7 +369,7 @@ def rekey_tenant_mapping_after_login(
     try:
         fetch_ee_implementation_or_noop(
             "onyx.db.user_tenant_mapping", "rekey_user_mapping_email", None
-        )(email, tenant_id, oauth_identities)
+        )(email, tenant_id, oauth_identities, previous_email)
     except Exception:
         logger.warning(
             "Tenant mapping rekey failed after login: tenant=%s",
@@ -1085,24 +1088,25 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             email_reconcile_result = await db_session.run_sync(
                 partial(reconcile_user_email__no_commit, user.id, account_email)
             )
+            replaced_email: str | None = None
             if email_reconcile_result is not None:
                 replaced_email, reconciled_prior_emails = email_reconcile_result
+                # Retire the consumed invite before the rename commits. A failure
+                # afterwards leaves it able to authorize the address's next holder,
+                # and no later login reports that address again.
+                remove_user_from_invited_users(replaced_email)
                 await db_session.commit()
                 user.email = account_email.lower()
                 user.prior_emails = reconciled_prior_emails
-                # Retire the invite this user joined with, once, at the rename.
-                # Retrying it on later logins would delete an invitation issued
-                # to whoever holds that address next.
-                remove_user_from_invited_users_after_login(
-                    replaced_email, user.id, tenant_id
-                )
 
             oauth_identities = [
                 (oauth_account.oauth_name, oauth_account.account_id)
                 for oauth_account in user.oauth_accounts
             ]
 
-            rekey_tenant_mapping_after_login(user.email, tenant_id, oauth_identities)
+            rekey_tenant_mapping_after_login(
+                user.email, tenant_id, oauth_identities, replaced_email
+            )
 
             # NOTE: Most IdPs have very short expiry times, and we don't want to force the user to
             # re-authenticate that frequently, so by default this is disabled

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -588,7 +588,7 @@ def bulk_invite_users(
     if MULTI_TENANT:
         try:
             fetch_ee_implementation_or_noop(
-                "onyx.server.tenants.provisioning", "add_users_to_tenant", None
+                "onyx.db.user_tenant_mapping", "add_users_to_tenant", None
             )(new_invited_emails, tenant_id)
         except OnyxError:
             # Seat-limit / billing declines from the cloud check must reach

--- a/backend/tests/unit/ee/onyx/server/tenants/test_record_oauth_identity.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_record_oauth_identity.py
@@ -1,6 +1,5 @@
-"""Guards that `record_oauth_identity` only touches the mapping tables on cloud
-and never re-links a subject that already belongs to another mapping, and that
-invitation flows move subject links only with the authenticated user.
+"""Guards the mapping-table writers: cloud-only sessions, link-once semantics
+for subjects, and identity movement through rename and invitation flows.
 
 The `public.user_tenant_mapping*` tables are created by the `alembic_tenants`
 tree, which only multi-tenant deployments run. Opening a session against them
@@ -17,6 +16,7 @@ from ee.onyx.db.user_tenant_mapping import (
     accept_user_invite,
     approve_user_invite,
     record_oauth_identity,
+    rekey_user_mapping_email,
 )
 
 _MAPPING_MODULE = "ee.onyx.db.user_tenant_mapping"
@@ -108,6 +108,162 @@ def test_repeat_login_for_the_linked_mapping_is_idempotent() -> None:
     )
 
     db_session = session_ctx.return_value.__enter__.return_value
+    db_session.commit.assert_called_once()
+
+
+def test_rekey_resolves_the_mapping_by_oauth_subject() -> None:
+    with (
+        patch(f"{_MAPPING_MODULE}.MULTI_TENANT", True),
+        patch(f"{_MAPPING_MODULE}.get_catalog_session") as session_ctx,
+    ):
+        db_session = session_ctx.return_value.__enter__.return_value
+        mapping = SimpleNamespace(
+            email="old@example.com", tenant_id="tenant_abc", active=True
+        )
+        locked_query = db_session.query.return_value.filter.return_value.with_for_update.return_value
+        locked_query.all.return_value = [mapping]
+        locked_query.one_or_none.return_value = None
+        rekey_user_mapping_email(
+            new_email="New@Example.com",
+            tenant_id="tenant_abc",
+            oauth_identities=[("google", "sub-123")],
+        )
+
+    assert mapping.email == "new@example.com"
+    db_session.commit.assert_called_once()
+
+
+def test_rekey_moves_links_off_every_mapping_it_deletes() -> None:
+    """A second provider can be linked to a different mapping row in the same
+    tenant. That row is deleted here, so its link must move first or ON DELETE
+    CASCADE strands the subject and the next login provisions a new tenant."""
+    with (
+        patch(f"{_MAPPING_MODULE}.MULTI_TENANT", True),
+        patch(f"{_MAPPING_MODULE}.get_catalog_session") as session_ctx,
+    ):
+        db_session = session_ctx.return_value.__enter__.return_value
+        survivor = SimpleNamespace(
+            email="old@example.com", tenant_id="tenant_abc", active=True
+        )
+        doomed = SimpleNamespace(
+            email="other@example.com", tenant_id="tenant_abc", active=False
+        )
+        github_account = SimpleNamespace(
+            oauth_name="github",
+            account_id="sub-456",
+            email="other@example.com",
+            tenant_id="tenant_abc",
+        )
+        mapping_query = MagicMock()
+        locked_mapping_query = (
+            mapping_query.filter.return_value.with_for_update.return_value
+        )
+        locked_mapping_query.all.return_value = [survivor, doomed]
+        locked_mapping_query.one_or_none.return_value = None
+        account_query = MagicMock()
+        account_query.filter.return_value.with_for_update.return_value.all.return_value = [
+            github_account
+        ]
+        db_session.query.side_effect = [mapping_query, mapping_query, account_query]
+
+        rekey_user_mapping_email(
+            new_email="new@example.com",
+            tenant_id="tenant_abc",
+            oauth_identities=[("google", "sub-123"), ("github", "sub-456")],
+        )
+
+    assert (github_account.email, github_account.tenant_id) == (
+        "new@example.com",
+        "tenant_abc",
+    )
+    db_session.flush.assert_called_once_with()
+    db_session.delete.assert_called_once_with(doomed)
+    db_session.commit.assert_called_once()
+
+
+def test_rekey_accepts_a_different_linked_provider_identity() -> None:
+    """The row may have been linked by the first provider rather than the one
+    used for this login, so ownership must match any linked subject."""
+    with (
+        patch(f"{_MAPPING_MODULE}.MULTI_TENANT", True),
+        patch(f"{_MAPPING_MODULE}.get_catalog_session") as session_ctx,
+    ):
+        db_session = session_ctx.return_value.__enter__.return_value
+        mapping = SimpleNamespace(
+            email="old@example.com", tenant_id="tenant_abc", active=True
+        )
+        locked_query = db_session.query.return_value.filter.return_value.with_for_update.return_value
+        locked_query.all.return_value = [mapping]
+        locked_query.one_or_none.return_value = None
+        rekey_user_mapping_email(
+            new_email="new@example.com",
+            tenant_id="tenant_abc",
+            oauth_identities=[("oidc", "sub-999")],
+        )
+
+    assert mapping.email == "new@example.com"
+    ownership_filter = db_session.query.return_value.filter.call_args_list[0].args[-1]
+    sql = str(
+        ownership_filter.compile(
+            dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+        )
+    )
+    assert "user_tenant_mapping_oauth_account" in sql
+    assert "oidc" in sql
+    assert "sub-999" in sql
+    db_session.commit.assert_called_once()
+
+
+def test_rekey_merges_an_existing_destination_row() -> None:
+    with (
+        patch(f"{_MAPPING_MODULE}.MULTI_TENANT", True),
+        patch(f"{_MAPPING_MODULE}.get_catalog_session") as session_ctx,
+    ):
+        db_session = session_ctx.return_value.__enter__.return_value
+        source = SimpleNamespace(
+            email="old@example.com", tenant_id="tenant_abc", active=True
+        )
+        destination = SimpleNamespace(
+            email="new@example.com", tenant_id="tenant_abc", active=False
+        )
+        google_account = SimpleNamespace(
+            oauth_name="google",
+            account_id="sub-123",
+            email="old@example.com",
+            tenant_id="tenant_abc",
+        )
+        github_account = SimpleNamespace(
+            oauth_name="github",
+            account_id="sub-456",
+            email="old@example.com",
+            tenant_id="tenant_abc",
+        )
+        mapping_query = MagicMock()
+        locked_mapping_query = (
+            mapping_query.filter.return_value.with_for_update.return_value
+        )
+        locked_mapping_query.all.return_value = [source]
+        locked_mapping_query.one_or_none.return_value = destination
+        account_query = MagicMock()
+        account_query.filter.return_value.with_for_update.return_value.all.return_value = [
+            google_account,
+            github_account,
+        ]
+        db_session.query.side_effect = [mapping_query, mapping_query, account_query]
+
+        rekey_user_mapping_email(
+            new_email="new@example.com",
+            tenant_id="tenant_abc",
+            oauth_identities=[("google", "sub-123")],
+        )
+
+    assert destination.active is True
+    assert {
+        (account.email, account.tenant_id)
+        for account in (google_account, github_account)
+    } == {("new@example.com", "tenant_abc")}
+    db_session.flush.assert_called_once_with()
+    db_session.delete.assert_called_once_with(source)
     db_session.commit.assert_called_once()
 
 

--- a/backend/tests/unit/ee/onyx/server/tenants/test_record_oauth_identity.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_record_oauth_identity.py
@@ -271,6 +271,83 @@ def test_rekey_merges_an_existing_destination_row() -> None:
     db_session.commit.assert_called_once()
 
 
+def test_rekey_moves_the_row_the_caller_names() -> None:
+    """A tenant can hold several of this user's rows, and the active-email index
+    is per address rather than per tenant, so more than one can be active.
+    Choosing among them by `active` alone renames whichever row sorted first."""
+    other_active = SimpleNamespace(
+        email="other@example.com", tenant_id="tenant_abc", active=True
+    )
+    renamed = SimpleNamespace(
+        email="old@example.com", tenant_id="tenant_abc", active=True
+    )
+    with (
+        patch(f"{_MAPPING_MODULE}.MULTI_TENANT", True),
+        patch(f"{_MAPPING_MODULE}.get_catalog_session") as session_ctx,
+    ):
+        db_session = session_ctx.return_value.__enter__.return_value
+        db_session.scalar.return_value = None
+        mapping_query = MagicMock()
+        locked = mapping_query.filter.return_value.with_for_update.return_value
+        # The unrelated active row sorts first.
+        locked.all.return_value = [other_active, renamed]
+        locked.one_or_none.return_value = None
+        account_query = MagicMock()
+        account_query.filter.return_value.with_for_update.return_value.all.return_value = []
+        db_session.query.side_effect = [mapping_query, mapping_query, account_query]
+
+        rekey_user_mapping_email(
+            new_email="new@example.com",
+            tenant_id="tenant_abc",
+            oauth_identities=[("google", "sub-123")],
+            previous_email="old@example.com",
+        )
+
+    assert renamed.email == "new@example.com"
+    assert other_active.email == "other@example.com"
+
+
+def test_rekey_leaves_a_co_owners_subject_link_alone() -> None:
+    """Several subjects can share one mapping row and they are not always the
+    same person's, since a declined rekey parks a row under its old address and
+    an invite for the next holder reuses it."""
+    source = SimpleNamespace(
+        email="old@example.com", tenant_id="tenant_abc", active=True
+    )
+    with (
+        patch(f"{_MAPPING_MODULE}.MULTI_TENANT", True),
+        patch(f"{_MAPPING_MODULE}.get_catalog_session") as session_ctx,
+    ):
+        db_session = session_ctx.return_value.__enter__.return_value
+        db_session.scalar.return_value = None
+        mapping_query = MagicMock()
+        locked = mapping_query.filter.return_value.with_for_update.return_value
+        locked.all.return_value = [source]
+        locked.one_or_none.return_value = SimpleNamespace(
+            email="new@example.com", tenant_id="tenant_abc", active=False
+        )
+        account_query = MagicMock()
+        account_query.filter.return_value.with_for_update.return_value.all.return_value = []
+        db_session.query.side_effect = [mapping_query, mapping_query, account_query]
+
+        rekey_user_mapping_email(
+            new_email="new@example.com",
+            tenant_id="tenant_abc",
+            oauth_identities=[("google", "sub-123")],
+            previous_email="old@example.com",
+        )
+
+    # Mocks do not evaluate filters, so assert the association query is scoped by
+    # subject as well as by row. Without it a co-owner's link moves too.
+    sql = str(
+        account_query.filter.call_args.args[1].compile(
+            dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+        )
+    )
+    assert "oauth_name" in sql
+    assert "sub-123" in sql
+
+
 def test_rekey_declines_when_the_address_is_held_elsewhere() -> None:
     """uq_user_active_email_idx spans tenants. Moving the row onto a taken
     address makes the other tenant's row answer this user's next login, so the

--- a/backend/tests/unit/ee/onyx/server/tenants/test_record_oauth_identity.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_record_oauth_identity.py
@@ -111,7 +111,7 @@ def test_repeat_login_for_the_linked_mapping_is_idempotent() -> None:
     db_session.commit.assert_called_once()
 
 
-def test_rekey_resolves_the_mapping_by_oauth_subject() -> None:
+def test_rekey_normalizes_the_new_address_onto_the_matched_row() -> None:
     with (
         patch(f"{_MAPPING_MODULE}.MULTI_TENANT", True),
         patch(f"{_MAPPING_MODULE}.get_catalog_session") as session_ctx,

--- a/backend/tests/unit/ee/onyx/server/tenants/test_record_oauth_identity.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_record_oauth_identity.py
@@ -117,6 +117,7 @@ def test_rekey_normalizes_the_new_address_onto_the_matched_row() -> None:
         patch(f"{_MAPPING_MODULE}.get_catalog_session") as session_ctx,
     ):
         db_session = session_ctx.return_value.__enter__.return_value
+        db_session.scalar.return_value = None
         mapping = SimpleNamespace(
             email="old@example.com", tenant_id="tenant_abc", active=True
         )
@@ -142,6 +143,7 @@ def test_rekey_moves_links_off_every_mapping_it_deletes() -> None:
         patch(f"{_MAPPING_MODULE}.get_catalog_session") as session_ctx,
     ):
         db_session = session_ctx.return_value.__enter__.return_value
+        db_session.scalar.return_value = None
         survivor = SimpleNamespace(
             email="old@example.com", tenant_id="tenant_abc", active=True
         )
@@ -189,6 +191,7 @@ def test_rekey_accepts_a_different_linked_provider_identity() -> None:
         patch(f"{_MAPPING_MODULE}.get_catalog_session") as session_ctx,
     ):
         db_session = session_ctx.return_value.__enter__.return_value
+        db_session.scalar.return_value = None
         mapping = SimpleNamespace(
             email="old@example.com", tenant_id="tenant_abc", active=True
         )
@@ -220,6 +223,7 @@ def test_rekey_merges_an_existing_destination_row() -> None:
         patch(f"{_MAPPING_MODULE}.get_catalog_session") as session_ctx,
     ):
         db_session = session_ctx.return_value.__enter__.return_value
+        db_session.scalar.return_value = None
         source = SimpleNamespace(
             email="old@example.com", tenant_id="tenant_abc", active=True
         )
@@ -265,6 +269,27 @@ def test_rekey_merges_an_existing_destination_row() -> None:
     db_session.flush.assert_called_once_with()
     db_session.delete.assert_called_once_with(source)
     db_session.commit.assert_called_once()
+
+
+def test_rekey_declines_when_the_address_is_held_elsewhere() -> None:
+    """uq_user_active_email_idx spans tenants. Moving the row onto a taken
+    address makes the other tenant's row answer this user's next login, so the
+    membership stays under the address whose subject link still resolves it."""
+    with (
+        patch(f"{_MAPPING_MODULE}.MULTI_TENANT", True),
+        patch(f"{_MAPPING_MODULE}.get_catalog_session") as session_ctx,
+    ):
+        db_session = session_ctx.return_value.__enter__.return_value
+        db_session.scalar.return_value = "tenant_other"
+
+        rekey_user_mapping_email(
+            new_email="new@example.com",
+            tenant_id="tenant_abc",
+            oauth_identities=[("google", "sub-123")],
+        )
+
+    db_session.query.assert_not_called()
+    db_session.commit.assert_not_called()
 
 
 def test_accept_invite_moves_every_link_off_a_row_this_identity_owns() -> None:

--- a/backend/tests/unit/ee/onyx/server/tenants/test_record_oauth_identity.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_record_oauth_identity.py
@@ -348,6 +348,39 @@ def test_rekey_leaves_a_co_owners_subject_link_alone() -> None:
     assert "sub-123" in sql
 
 
+def test_rekey_declines_when_a_row_carries_another_identitys_subject() -> None:
+    """A parked row can pick up a second person's subject once an invite hands
+    the address on. Renaming it promotes them into this workspace, and deleting
+    it cascades their membership away, so touch neither."""
+    source = SimpleNamespace(
+        email="old@example.com", tenant_id="tenant_abc", active=True
+    )
+    with (
+        patch(f"{_MAPPING_MODULE}.MULTI_TENANT", True),
+        patch(f"{_MAPPING_MODULE}.get_catalog_session") as session_ctx,
+    ):
+        db_session = session_ctx.return_value.__enter__.return_value
+        mapping_query = MagicMock()
+        locked = mapping_query.filter.return_value.with_for_update.return_value
+        locked.all.return_value = [source]
+        locked.one_or_none.return_value = None
+        db_session.query.side_effect = [mapping_query, mapping_query]
+        # Address is free, but a subject outside this login's identities is
+        # attached to one of the candidate rows.
+        db_session.scalar.side_effect = [None, "someone-elses-sub"]
+
+        rekey_user_mapping_email(
+            new_email="new@example.com",
+            tenant_id="tenant_abc",
+            oauth_identities=[("google", "sub-123")],
+            previous_email="old@example.com",
+        )
+
+    assert source.email == "old@example.com"
+    db_session.delete.assert_not_called()
+    db_session.commit.assert_not_called()
+
+
 def test_rekey_declines_when_the_address_is_held_elsewhere() -> None:
     """uq_user_active_email_idx spans tenants. Moving the row onto a taken
     address makes the other tenant's row answer this user's next login, so the

--- a/backend/tests/unit/ee/onyx/server/tenants/test_tenant_resolution_by_oauth_account.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_tenant_resolution_by_oauth_account.py
@@ -60,12 +60,12 @@ def test_falls_back_to_email_when_subject_is_unstamped() -> None:
 
 def test_an_active_email_membership_outranks_a_superseded_subject() -> None:
     """An admin moving a member into another workspace deactivates the row their
-    subject is linked to. Following that link would undo the move."""
-    superseded = MagicMock()
+    subject is linked to. Preferring that link would undo the move."""
     with (
         patch(f"{_MAPPING_MODULE}.get_tenant_id_for_oauth_account", return_value=None),
         patch(
-            f"{_MAPPING_MODULE}.get_superseded_tenant_id_for_oauth_account", superseded
+            f"{_MAPPING_MODULE}.get_superseded_tenant_id_for_oauth_account",
+            return_value="tenant_left_behind",
         ),
         patch(
             f"{_MAPPING_MODULE}.get_tenant_id_for_email",
@@ -75,7 +75,41 @@ def test_an_active_email_membership_outranks_a_superseded_subject() -> None:
         tenant_id = resolve_tenant_id("current@example.com", "google", "sub-123")
 
     assert tenant_id == "tenant_from_email"
-    superseded.assert_not_called()
+
+
+def test_a_superseded_subject_settles_an_ambiguous_address() -> None:
+    """A rekey that cannot claim a taken address leaves an inactive row, which
+    can make the address ambiguous. The subject names one workspace, so the
+    caller is not asked to choose between rows that are all this user's."""
+    conflict = OnyxError(OnyxErrorCode.CONFLICT, "several pending invitations")
+    with (
+        patch(f"{_MAPPING_MODULE}.get_tenant_id_for_oauth_account", return_value=None),
+        patch(
+            f"{_MAPPING_MODULE}.get_superseded_tenant_id_for_oauth_account",
+            return_value="tenant_superseded",
+        ),
+        patch(f"{_MAPPING_MODULE}.get_tenant_id_for_email", side_effect=conflict),
+    ):
+        assert (
+            resolve_tenant_id("user@example.com", "google", "sub-123")
+            == "tenant_superseded"
+        )
+
+
+def test_an_ambiguous_address_still_conflicts_without_a_linked_subject() -> None:
+    conflict = OnyxError(OnyxErrorCode.CONFLICT, "several pending invitations")
+    with (
+        patch(f"{_MAPPING_MODULE}.get_tenant_id_for_oauth_account", return_value=None),
+        patch(
+            f"{_MAPPING_MODULE}.get_superseded_tenant_id_for_oauth_account",
+            return_value=None,
+        ),
+        patch(f"{_MAPPING_MODULE}.get_tenant_id_for_email", side_effect=conflict),
+    ):
+        with pytest.raises(OnyxError) as exc_info:
+            resolve_tenant_id("user@example.com", "google", "sub-123")
+
+    assert exc_info.value is conflict
 
 
 def test_a_superseded_subject_answers_when_the_address_maps_nowhere() -> None:

--- a/backend/tests/unit/onyx/auth/test_rekey_tenant_mapping_after_login.py
+++ b/backend/tests/unit/onyx/auth/test_rekey_tenant_mapping_after_login.py
@@ -1,0 +1,46 @@
+"""Guards that a catalog failure cannot fail a login that already succeeded.
+
+The provider's address is committed to the tenant database before the catalog
+rekey runs on a separate connection, so a raise here would fail the login over a
+row the linked subject still resolves under its old address.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from onyx.auth.users import rekey_tenant_mapping_after_login
+
+_AUTH_MODULE = "onyx.auth.users"
+_IDENTITIES = [("google", "sub-123"), ("github", "sub-456")]
+
+
+def test_a_catalog_failure_does_not_reach_the_caller() -> None:
+    with (
+        patch(
+            f"{_AUTH_MODULE}.fetch_ee_implementation_or_noop",
+            return_value=MagicMock(side_effect=RuntimeError("catalog is down")),
+        ),
+        patch(f"{_AUTH_MODULE}.logger") as logger,
+    ):
+        rekey_tenant_mapping_after_login("new@example.com", "tenant_a", _IDENTITIES)
+
+    assert logger.warning.call_count == 1
+    assert logger.warning.call_args.kwargs["exc_info"] is True
+
+
+def test_the_rekey_receives_the_adopted_address_and_every_subject() -> None:
+    rekey = MagicMock()
+    with patch(f"{_AUTH_MODULE}.fetch_ee_implementation_or_noop", return_value=rekey):
+        rekey_tenant_mapping_after_login("new@example.com", "tenant_a", _IDENTITIES)
+
+    rekey.assert_called_once_with("new@example.com", "tenant_a", _IDENTITIES)
+
+
+def test_a_keyboard_interrupt_is_not_swallowed() -> None:
+    with patch(
+        f"{_AUTH_MODULE}.fetch_ee_implementation_or_noop",
+        return_value=MagicMock(side_effect=KeyboardInterrupt),
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            rekey_tenant_mapping_after_login("new@example.com", "tenant_a", _IDENTITIES)

--- a/backend/tests/unit/onyx/auth/test_rekey_tenant_mapping_after_login.py
+++ b/backend/tests/unit/onyx/auth/test_rekey_tenant_mapping_after_login.py
@@ -34,7 +34,21 @@ def test_the_rekey_receives_the_adopted_address_and_every_subject() -> None:
     with patch(f"{_AUTH_MODULE}.fetch_ee_implementation_or_noop", return_value=rekey):
         rekey_tenant_mapping_after_login("new@example.com", "tenant_a", _IDENTITIES)
 
-    rekey.assert_called_once_with("new@example.com", "tenant_a", _IDENTITIES)
+    rekey.assert_called_once_with("new@example.com", "tenant_a", _IDENTITIES, None)
+
+
+def test_the_replaced_address_is_passed_through() -> None:
+    """A tenant can hold several of this user's rows, so the rekey needs the one
+    the caller is moving rather than picking among them."""
+    rekey = MagicMock()
+    with patch(f"{_AUTH_MODULE}.fetch_ee_implementation_or_noop", return_value=rekey):
+        rekey_tenant_mapping_after_login(
+            "new@example.com", "tenant_a", _IDENTITIES, "old@example.com"
+        )
+
+    rekey.assert_called_once_with(
+        "new@example.com", "tenant_a", _IDENTITIES, "old@example.com"
+    )
 
 
 def test_a_keyboard_interrupt_is_not_swallowed() -> None:


### PR DESCRIPTION
## Description

Final layer for #13553, stacked on #13581.

The provider is authoritative for a user's address, so the callback adopts it when it moves. `User.email` flips, the replaced address becomes an alias that #13581 makes match documents whose indexed ACLs still name it, and the rows keyed by the old address move with it. Access is continuous, so nothing is queued and nothing is awaited.

The tenant mapping row is rekeyed by linked subject, so a failed rekey is repaired on any later login even though `User.email` has already changed. The rekey declines outright when the new address is actively held in another workspace: `uq_user_active_email_idx` spans tenants, and moving the row anyway would make that workspace answer this user's next login.

A linked OAuth account counts as proof of membership in the invite-only check. The invite the user joined with is retired once, at the rename, so a later invitation to that address for someone else survives.

Runs in every deployment: single-tenant reaches the right user by subject and hits the same stale-address case.

**Deploy order for the stack:** migrations before code. No backfill or other manual step.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
