### PR TITLE
feat(auth): add oauth account and prior-email schema

### DIFF
--- a/backend/alembic/versions/4662f8c3e038_add_prior_emails_to_user.py
+++ b/backend/alembic/versions/4662f8c3e038_add_prior_emails_to_user.py
@@ -1,0 +1,34 @@
+"""add prior emails to user
+
+Revision ID: 4662f8c3e038
+Revises: 0d9c7b6a5e4f
+Create Date: 2026-07-28 22:17:13.333593
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4662f8c3e038"
+down_revision = "b3f1c9a27d84"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user",
+        sa.Column(
+            "prior_emails",
+            postgresql.ARRAY(sa.String()),
+            nullable=False,
+            server_default="{}",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user", "prior_emails")

--- a/backend/alembic_tenants/versions/8f3d2c7b91ae_add_user_tenant_mapping_oauth_account.py
+++ b/backend/alembic_tenants/versions/8f3d2c7b91ae_add_user_tenant_mapping_oauth_account.py
@@ -1,0 +1,53 @@
+"""add user tenant mapping oauth account table
+
+Revision ID: 8f3d2c7b91ae
+Revises: b1c4e9d72f38
+Create Date: 2026-07-29 20:14:03.117204
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "8f3d2c7b91ae"
+down_revision = "b1c4e9d72f38"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_tenant_mapping_oauth_account",
+        sa.Column("oauth_name", sa.String(length=100), nullable=False),
+        sa.Column("account_id", sa.String(length=320), nullable=False),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("tenant_id", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["email", "tenant_id"],
+            [
+                "public.user_tenant_mapping.email",
+                "public.user_tenant_mapping.tenant_id",
+            ],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("oauth_name", "account_id"),
+        schema="public",
+    )
+    op.create_index(
+        "ix_user_tenant_mapping_oauth_account_mapping",
+        "user_tenant_mapping_oauth_account",
+        ["email", "tenant_id"],
+        schema="public",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_user_tenant_mapping_oauth_account_mapping",
+        table_name="user_tenant_mapping_oauth_account",
+        schema="public",
+    )
+    op.drop_table("user_tenant_mapping_oauth_account", schema="public")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -339,6 +339,14 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
         Boolean, nullable=True, default=None
     )
 
+    # Addresses this user was renamed away from, until each one's ACL repair
+    # completes. Never grants access. An entry lets a later login re-submit a
+    # lost repair and reserves the address against another user claiming it
+    # mid-repair. `expire_prior_emails` closes entries out.
+    prior_emails: Mapped[list[str]] = mapped_column(
+        postgresql.ARRAY(String), nullable=False, default=list, server_default="{}"
+    )
+
     """
     Preferences probably should be in a separate table at some point, but for now
     putting here for simpicity
@@ -5404,6 +5412,39 @@ class UserTenantMapping(PublicBase):
     @validates("email")
     def validate_email(self, key: str, value: str) -> str:  # noqa: ARG002
         return value.lower() if value else value
+
+
+class UserTenantMappingOAuthAccount(PublicBase):
+    """Copy of an `OAuthAccount` subject, which survives an email change at the
+    provider, keyed to the mapping row it authenticates. The primary key holds
+    one mapping per subject. ON UPDATE CASCADE follows an email rekey, and ON
+    DELETE CASCADE drops the link with its membership. Widths mirror the source
+    columns."""
+
+    __tablename__ = "user_tenant_mapping_oauth_account"
+
+    oauth_name: Mapped[str] = mapped_column(
+        String(length=100), nullable=False, primary_key=True
+    )
+    account_id: Mapped[str] = mapped_column(
+        String(length=320), nullable=False, primary_key=True
+    )
+    email: Mapped[str] = mapped_column(String, nullable=False)
+    tenant_id: Mapped[str] = mapped_column(String, nullable=False)
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["email", "tenant_id"],
+            [
+                "public.user_tenant_mapping.email",
+                "public.user_tenant_mapping.tenant_id",
+            ],
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+        ),
+        Index("ix_user_tenant_mapping_oauth_account_mapping", "email", "tenant_id"),
+        {"schema": "public"},
+    )
 
 
 class AvailableTenant(PublicBase):


### PR DESCRIPTION
## Description

First layer of the fix for #13553 (IdP email change strands Cloud users in a fresh empty tenant).

Adds `public.user_tenant_mapping_oauth_account`, keying each stable IdP subject to the mapping row it authenticates. The primary key holds one mapping per subject, so users who sign in through more than one provider get one link each. CASCADE follows an email rekey and drops the link with its membership.

Also adds `User.prior_emails`, the addresses a user was renamed away from. #13581 makes them match indexed ACLs that still name them.

Nothing reads or writes either yet. No backfill and no deploy-time step: the next PR links the subject on every OAuth login and resolution falls back to email until then, so coverage converges as users log in.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check