### PR TITLE
fix(auth): resolve the tenant from the IdP subject before the email

### DIFF
--- a/backend/ee/onyx/db/user_tenant_mapping.py
+++ b/backend/ee/onyx/db/user_tenant_mapping.py
@@ -1,3 +1,10 @@
+"""Membership routing for the shared `public.user_tenant_mapping` catalog.
+
+"Subject" throughout this module means the OAuth subject: the provider-issued
+identifier for an account, which survives the user renaming their email address
+at that provider. It is the `(oauth_name, account_id)` pair.
+"""
+
 from collections.abc import Sequence
 
 from fastapi_users import exceptions
@@ -139,10 +146,11 @@ def get_tenant_id_for_oauth_account(oauth_name: str, account_id: str) -> str | N
 def get_superseded_tenant_id_for_oauth_account(
     oauth_name: str, account_id: str
 ) -> str | None:
-    """Workspace of a membership whose address was taken over by someone else.
+    """Workspace of a membership that yielded the email address it was filed under.
 
-    Leaving a workspace deletes the mapping, so an inactive linked row is a
-    standing membership that had to yield the address it was filed under.
+    Leaving a workspace deletes the mapping, so an inactive linked row is still a
+    real membership. It yields when its owner joins another workspace under the
+    same address, or when a different person takes that address over.
     """
     if not MULTI_TENANT:
         return None
@@ -374,15 +382,15 @@ def approve_user_invite(email: str, tenant_id: str) -> None:
             ),
             None,
         )
-        # Approving by address proves nothing about identity, since the address
-        # may have been reassigned. Rival rows are deactivated rather than
+        # Approving by email address proves nothing about identity, since that
+        # address may have been reassigned. Rival rows are deactivated rather than
         # deleted so their owner's subject links are not cascaded away.
         for mapping in existing_mappings:
             if mapping is not destination:
                 mapping.active = False
 
-        # uq_user_active_email_idx is immediate, so free the address before
-        # this tenant's row becomes active.
+        # uq_user_active_email_idx is immediate, so free the email address
+        # before this tenant's row becomes active.
         db_session.flush()
         if destination is None:
             # A fresh mapping starts unlinked: subjects attach on the next login.
@@ -442,7 +450,9 @@ def accept_user_invite(
                 (
                     candidate
                     for candidate in mappings
-                    if candidate.tenant_id == tenant_id and not candidate.active
+                    if candidate.email == email
+                    and candidate.tenant_id == tenant_id
+                    and not candidate.active
                 ),
                 None,
             )
@@ -469,8 +479,9 @@ def accept_user_invite(
                     (oauth_name, account_id)
                     for oauth_name, account_id, _, _ in presented_links
                 }
-                # An address-matched row can be a former holder's, so only rows
-                # a presented subject links to are provably this identity's.
+                # Rows this login's OAuth subjects are already linked to. Matching
+                # on the email address alone would also catch rows belonging to
+                # whoever held that address before this user.
                 owned_mapping_keys = {
                     (owner_email, owner_tenant_id)
                     for _, _, owner_email, owner_tenant_id in presented_links
@@ -506,21 +517,23 @@ def accept_user_invite(
                         if (oauth_name, account_id) not in linked_identities
                     ]
                 )
+                # Every subject presented today that was not already linked now
+                # links to the destination row.
                 db_session.flush()
 
                 for candidate in mappings:
                     if candidate is mapping or not candidate.active:
                         continue
-                    # One active row per address, so a rival yields. Rows this
-                    # identity does not own only deactivate: their subject links
-                    # belong to whoever held the address before.
+                    # One active row per email address, so a rival yields. A row
+                    # this user does not own is only deactivated, because its
+                    # OAuth subject links belong to that address's previous holder.
                     if (candidate.email, candidate.tenant_id) in owned_mapping_keys:
                         db_session.delete(candidate)
                     else:
                         candidate.active = False
 
-                # uq_user_active_email_idx is immediate, so free the address
-                # before the destination becomes active.
+                # uq_user_active_email_idx is immediate, so free the email
+                # address before the destination becomes active.
                 db_session.flush()
                 mapping.active = True
                 db_session.commit()

--- a/backend/ee/onyx/db/user_tenant_mapping.py
+++ b/backend/ee/onyx/db/user_tenant_mapping.py
@@ -47,7 +47,6 @@ def get_tenant_id_for_email(email: str) -> str:
 
     email = email.lower()
     with get_catalog_session() as db_session:
-        # First try to get an active tenant
         result = db_session.execute(
             select(UserTenantMapping.tenant_id).where(
                 UserTenantMapping.email == email,
@@ -56,9 +55,8 @@ def get_tenant_id_for_email(email: str) -> str:
         )
         tenant_id = result.scalar_one_or_none()
 
-        # Fall back to a pending invitation only when there is exactly one.
-        # Several stay pending: routing into any would join a workspace the
-        # user never accepted, so force the caller to make an explicit choice.
+        # Only auto-join a single pending invitation. Choosing among several
+        # would enroll the user in a workspace they never accepted.
         if tenant_id is None:
             inactive_tenant_ids = (
                 db_session.execute(
@@ -97,67 +95,59 @@ def resolve_tenant_id(
 ) -> str | None:
     """Tenant this login belongs to, or None when it maps nowhere.
 
-    An active subject mapping wins because only the subject survives an address
-    change. Inactive subject history may be overridden by a valid active email
-    membership, but still blocks provisioning when the email maps nowhere.
+    An active subject membership wins because only the subject survives an
+    address change. A superseded one is the last resort, since an active email
+    membership names a workspace the user was deliberately moved into.
     """
-    inactive_subject_error: OnyxError | None = None
     if oauth_name and account_id:
-        try:
-            tenant_id = get_tenant_id_for_oauth_account(oauth_name, account_id)
-            if tenant_id:
-                return tenant_id
-        except OnyxError as error:
-            if error.error_code is not OnyxErrorCode.CONFLICT:
-                raise
-            inactive_subject_error = error
+        tenant_id = get_tenant_id_for_oauth_account(oauth_name, account_id)
+        if tenant_id:
+            return tenant_id
 
     try:
         return get_tenant_id_for_email(email)
     except exceptions.UserNotExists:
-        if inactive_subject_error is not None:
-            raise inactive_subject_error
-        return None
+        if not (oauth_name and account_id):
+            return None
+        return get_superseded_tenant_id_for_oauth_account(oauth_name, account_id)
+
+
+def _oauth_account_tenant_id(
+    oauth_name: str, account_id: str, *, active: bool
+) -> str | None:
+    # A subject links to at most one mapping row, so this cannot be ambiguous.
+    with get_catalog_session() as db_session:
+        return db_session.scalar(
+            select(UserTenantMapping.tenant_id).where(
+                _oauth_identity_matches_mapping(oauth_name, account_id),
+                UserTenantMapping.active.is_(active),
+            )
+        )
 
 
 def get_tenant_id_for_oauth_account(oauth_name: str, account_id: str) -> str | None:
-    """Tenant for an IdP subject, or None when it maps nowhere.
+    """Active workspace of an IdP subject, or None when it maps nowhere.
 
-    An active subject mapping wins. Inactive subject links fail closed because
-    they represent historical membership, and following their old email could
-    route into a different person's workspace after address reassignment.
-
-    Returns the default schema outside multi-tenant, matching its siblings.
+    Returns the default schema outside multi-tenant.
     """
     if not MULTI_TENANT:
         return POSTGRES_DEFAULT_SCHEMA
 
-    with get_catalog_session() as db_session:
-        tenant_id = db_session.execute(
-            select(UserTenantMapping.tenant_id).where(
-                _oauth_identity_matches_mapping(oauth_name, account_id),
-                UserTenantMapping.active == True,  # noqa: E712
-            )
-        ).scalar_one_or_none()
+    return _oauth_account_tenant_id(oauth_name, account_id, active=True)
 
-        if tenant_id is None:
-            has_inactive_mapping = db_session.execute(
-                select(UserTenantMapping.tenant_id)
-                .where(
-                    _oauth_identity_matches_mapping(oauth_name, account_id),
-                    UserTenantMapping.active == False,  # noqa: E712
-                )
-                .limit(1)
-            ).scalar_one_or_none()
-            if has_inactive_mapping is not None:
-                logger.warning("Inactive OAuth identity has no active tenant mapping")
-                raise OnyxError(
-                    OnyxErrorCode.CONFLICT,
-                    "This identity has no active workspace. Explicit selection is "
-                    "required.",
-                )
 
-    return tenant_id
+def get_superseded_tenant_id_for_oauth_account(
+    oauth_name: str, account_id: str
+) -> str | None:
+    """Workspace of a membership whose address was taken over by someone else.
+
+    Leaving a workspace deletes the mapping, so an inactive linked row is a
+    standing membership that had to yield the address it was filed under.
+    """
+    if not MULTI_TENANT:
+        return None
+
+    return _oauth_account_tenant_id(oauth_name, account_id, active=False)
 
 
 def user_owns_a_tenant(email: str) -> bool:
@@ -391,11 +381,11 @@ def approve_user_invite(email: str, tenant_id: str) -> None:
             if mapping is not destination:
                 mapping.active = False
 
-        # The partial unique index on active emails is immediate. Flush every
-        # deactivation before this tenant's row becomes active.
+        # uq_user_active_email_idx is immediate, so free the address before
+        # this tenant's row becomes active.
         db_session.flush()
         if destination is None:
-            # OAuth subjects are linked only after an authenticated login.
+            # A fresh mapping starts unlinked: subjects attach on the next login.
             destination = UserTenantMapping(
                 email=email,
                 tenant_id=tenant_id,
@@ -425,9 +415,11 @@ def accept_user_invite(
     tenant_id: str,
     oauth_identities: Sequence[tuple[str, str]] = (),
 ) -> None:
-    """
-    Accept an invitation to join a tenant.
-    This activates the user's mapping to the tenant.
+    """Activate this user's invitation and retire their other memberships.
+
+    ``oauth_identities`` are the ``(oauth_name, account_id)`` subjects the caller
+    authenticated as. Only rows those already link to are provably this
+    identity's, since an address may have been reassigned.
     """
     email = email.lower()
     identities = list(dict.fromkeys(oauth_identities))
@@ -483,9 +475,8 @@ def accept_user_invite(
                     (owner_email, owner_tenant_id)
                     for _, _, owner_email, owner_tenant_id in presented_links
                 } - {(mapping.email, mapping.tenant_id)}
-                # Every link on such a row moves, not just the presented ones,
-                # or ON DELETE CASCADE strands the providers the user did not
-                # sign in with today.
+                # The owned row is deleted below, so all of its links move
+                # first or ON DELETE CASCADE takes the providers not presented.
                 association_accounts = (
                     db_session.query(UserTenantMappingOAuthAccount)
                     .filter(
@@ -520,18 +511,16 @@ def accept_user_invite(
                 for candidate in mappings:
                     if candidate is mapping or not candidate.active:
                         continue
-                    # Only one active row may hold an address, so a rival has
-                    # to yield. Deactivate rather than delete one this identity
-                    # does not own: it belongs to whoever held the address
-                    # before, and their subject links have to survive.
+                    # One active row per address, so a rival yields. Rows this
+                    # identity does not own only deactivate: their subject links
+                    # belong to whoever held the address before.
                     if (candidate.email, candidate.tenant_id) in owned_mapping_keys:
                         db_session.delete(candidate)
                     else:
                         candidate.active = False
 
-                # The partial unique index on active emails is immediate. Flush
-                # every prior membership change before the destination becomes
-                # active.
+                # uq_user_active_email_idx is immediate, so free the address
+                # before the destination becomes active.
                 db_session.flush()
                 mapping.active = True
                 db_session.commit()

--- a/backend/ee/onyx/db/user_tenant_mapping.py
+++ b/backend/ee/onyx/db/user_tenant_mapping.py
@@ -1,6 +1,9 @@
+from collections.abc import Sequence
+
 from fastapi_users import exceptions
-from sqlalchemy import select
+from sqlalchemy import or_, select, tuple_
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.sql.elements import ColumnElement
 
 from onyx.auth.invited_users import (
     get_invited_users,
@@ -13,6 +16,8 @@ from onyx.db.engine.sql_engine import (
     get_session_with_tenant,
 )
 from onyx.db.models import UserTenantMapping, UserTenantMappingOAuthAccount
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.manage.models import TenantSnapshot
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT, POSTGRES_DEFAULT_SCHEMA
@@ -21,42 +26,137 @@ from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 logger = setup_logger()
 
 
+def _oauth_identity_matches_mapping(
+    oauth_name: str, account_id: str
+) -> ColumnElement[bool]:
+    return (
+        select(UserTenantMappingOAuthAccount.oauth_name)
+        .where(
+            UserTenantMappingOAuthAccount.oauth_name == oauth_name,
+            UserTenantMappingOAuthAccount.account_id == account_id,
+            UserTenantMappingOAuthAccount.email == UserTenantMapping.email,
+            UserTenantMappingOAuthAccount.tenant_id == UserTenantMapping.tenant_id,
+        )
+        .exists()
+    )
+
+
 def get_tenant_id_for_email(email: str) -> str:
     if not MULTI_TENANT:
         return POSTGRES_DEFAULT_SCHEMA
-    # Implement logic to get tenant_id from the mapping table
-    try:
-        with get_catalog_session() as db_session:
-            # First try to get an active tenant
-            result = db_session.execute(
-                select(UserTenantMapping).where(
-                    UserTenantMapping.email == email,
-                    UserTenantMapping.active == True,  # noqa: E712
-                )
-            )
-            mapping = result.scalar_one_or_none()
-            tenant_id = mapping.tenant_id if mapping else None
 
-            # If no active tenant found, try to get the first inactive one
-            if tenant_id is None:
-                result = db_session.execute(
-                    select(UserTenantMapping).where(
+    email = email.lower()
+    with get_catalog_session() as db_session:
+        # First try to get an active tenant
+        result = db_session.execute(
+            select(UserTenantMapping.tenant_id).where(
+                UserTenantMapping.email == email,
+                UserTenantMapping.active == True,  # noqa: E712
+            )
+        )
+        tenant_id = result.scalar_one_or_none()
+
+        # Fall back to a pending invitation only when there is exactly one.
+        # Several stay pending: routing into any would join a workspace the
+        # user never accepted, so force the caller to make an explicit choice.
+        if tenant_id is None:
+            inactive_tenant_ids = (
+                db_session.execute(
+                    select(UserTenantMapping.tenant_id).where(
                         UserTenantMapping.email == email,
                         UserTenantMapping.active == False,  # noqa: E712
                     )
                 )
-                mapping = result.scalar_one_or_none()
-                if mapping:
-                    # Mark this mapping as active
-                    mapping.active = True
-                    db_session.commit()
-                    tenant_id = mapping.tenant_id
-    except Exception as e:
-        logger.exception("Error getting tenant id for email %s: %s", email, e)
-        raise exceptions.UserNotExists()
+                .scalars()
+                .all()
+            )
+            if len(inactive_tenant_ids) == 1:
+                tenant_id = inactive_tenant_ids[0]
+                db_session.query(UserTenantMapping).filter(
+                    UserTenantMapping.email == email,
+                    UserTenantMapping.tenant_id == tenant_id,
+                ).update({"active": True}, synchronize_session=False)
+                db_session.commit()
+            elif inactive_tenant_ids:
+                logger.warning(
+                    "Multiple pending invitations for one address require selection"
+                )
+                raise OnyxError(
+                    OnyxErrorCode.CONFLICT,
+                    "Multiple pending workspace invitations require an explicit "
+                    "selection.",
+                )
 
     if tenant_id is None:
         raise exceptions.UserNotExists()
+    return tenant_id
+
+
+def resolve_tenant_id(
+    email: str, oauth_name: str | None = None, account_id: str | None = None
+) -> str | None:
+    """Tenant this login belongs to, or None when it maps nowhere.
+
+    An active subject mapping wins because only the subject survives an address
+    change. Inactive subject history may be overridden by a valid active email
+    membership, but still blocks provisioning when the email maps nowhere.
+    """
+    inactive_subject_error: OnyxError | None = None
+    if oauth_name and account_id:
+        try:
+            tenant_id = get_tenant_id_for_oauth_account(oauth_name, account_id)
+            if tenant_id:
+                return tenant_id
+        except OnyxError as error:
+            if error.error_code is not OnyxErrorCode.CONFLICT:
+                raise
+            inactive_subject_error = error
+
+    try:
+        return get_tenant_id_for_email(email)
+    except exceptions.UserNotExists:
+        if inactive_subject_error is not None:
+            raise inactive_subject_error
+        return None
+
+
+def get_tenant_id_for_oauth_account(oauth_name: str, account_id: str) -> str | None:
+    """Tenant for an IdP subject, or None when it maps nowhere.
+
+    An active subject mapping wins. Inactive subject links fail closed because
+    they represent historical membership, and following their old email could
+    route into a different person's workspace after address reassignment.
+
+    Returns the default schema outside multi-tenant, matching its siblings.
+    """
+    if not MULTI_TENANT:
+        return POSTGRES_DEFAULT_SCHEMA
+
+    with get_catalog_session() as db_session:
+        tenant_id = db_session.execute(
+            select(UserTenantMapping.tenant_id).where(
+                _oauth_identity_matches_mapping(oauth_name, account_id),
+                UserTenantMapping.active == True,  # noqa: E712
+            )
+        ).scalar_one_or_none()
+
+        if tenant_id is None:
+            has_inactive_mapping = db_session.execute(
+                select(UserTenantMapping.tenant_id)
+                .where(
+                    _oauth_identity_matches_mapping(oauth_name, account_id),
+                    UserTenantMapping.active == False,  # noqa: E712
+                )
+                .limit(1)
+            ).scalar_one_or_none()
+            if has_inactive_mapping is not None:
+                logger.warning("Inactive OAuth identity has no active tenant mapping")
+                raise OnyxError(
+                    OnyxErrorCode.CONFLICT,
+                    "This identity has no active workspace. Explicit selection is "
+                    "required.",
+                )
+
     return tenant_id
 
 
@@ -127,6 +227,23 @@ def record_oauth_identity(
                 )
                 return
         db_session.commit()
+
+
+def _association_ownership_filter(
+    identities: Sequence[tuple[str, str]],
+) -> ColumnElement[bool]:
+    association_mapping_keys = select(
+        UserTenantMappingOAuthAccount.email,
+        UserTenantMappingOAuthAccount.tenant_id,
+    ).where(
+        tuple_(
+            UserTenantMappingOAuthAccount.oauth_name,
+            UserTenantMappingOAuthAccount.account_id,
+        ).in_(identities)
+    )
+    return tuple_(UserTenantMapping.email, UserTenantMapping.tenant_id).in_(
+        association_mapping_keys
+    )
 
 
 def add_users_to_tenant(emails: list[str], tenant_id: str) -> None:
@@ -249,17 +366,44 @@ def remove_all_users_from_tenant(tenant_id: str) -> None:
 def approve_user_invite(email: str, tenant_id: str) -> None:
     """
     Approve a user invite to a tenant.
-    This will delete all existing records for this email and create a new mapping entry for the user in this tenant.
+    This makes the user active in this tenant and inactive everywhere else.
     """
+    email = email.lower()
     with get_catalog_session() as db_session:
-        # Delete all existing records for this email
-        db_session.query(UserTenantMapping).filter(
-            UserTenantMapping.email == email
-        ).delete()
+        existing_mappings = (
+            db_session.query(UserTenantMapping)
+            .filter(UserTenantMapping.email == email)
+            .with_for_update()
+            .all()
+        )
+        destination = next(
+            (
+                candidate
+                for candidate in existing_mappings
+                if candidate.tenant_id == tenant_id
+            ),
+            None,
+        )
+        # Approving by address proves nothing about identity, since the address
+        # may have been reassigned. Rival rows are deactivated rather than
+        # deleted so their owner's subject links are not cascaded away.
+        for mapping in existing_mappings:
+            if mapping is not destination:
+                mapping.active = False
 
-        # Create a new mapping entry for the user in this tenant
-        new_mapping = UserTenantMapping(email=email, tenant_id=tenant_id, active=True)
-        db_session.add(new_mapping)
+        # The partial unique index on active emails is immediate. Flush every
+        # deactivation before this tenant's row becomes active.
+        db_session.flush()
+        if destination is None:
+            # OAuth subjects are linked only after an authenticated login.
+            destination = UserTenantMapping(
+                email=email,
+                tenant_id=tenant_id,
+                active=True,
+            )
+            db_session.add(destination)
+        else:
+            destination.active = True
         db_session.commit()
 
     # Also remove the user from pending users list
@@ -276,53 +420,119 @@ def approve_user_invite(email: str, tenant_id: str) -> None:
         write_invited_users(invited_users)
 
 
-def accept_user_invite(email: str, tenant_id: str) -> None:
+def accept_user_invite(
+    email: str,
+    tenant_id: str,
+    oauth_identities: Sequence[tuple[str, str]] = (),
+) -> None:
     """
     Accept an invitation to join a tenant.
     This activates the user's mapping to the tenant.
     """
+    email = email.lower()
+    identities = list(dict.fromkeys(oauth_identities))
+    ownership_filter = UserTenantMapping.email == email
+    if identities:
+        ownership_filter = or_(
+            ownership_filter,
+            _association_ownership_filter(identities),
+        )
+
     with get_catalog_session() as db_session:
         try:
-            # Lock the user's mappings first to prevent race conditions.
-            # This ensures no concurrent request can modify this user's mappings.
-            active_mapping = (
+            mappings = (
                 db_session.query(UserTenantMapping)
-                .filter(
-                    UserTenantMapping.email == email,
-                    UserTenantMapping.active == True,  # noqa: E712
-                )
+                .filter(ownership_filter)
                 .with_for_update()
-                .first()
+                .all()
             )
-
-            # If an active mapping exists, delete it
-            if active_mapping:
-                db_session.delete(active_mapping)
-                logger.info(
-                    "Deleted existing active mapping for user %s in tenant %s",
-                    email,
-                    tenant_id,
-                )
-
-            # Find the inactive mapping for this user and tenant
-            mapping = (
-                db_session.query(UserTenantMapping)
-                .filter(
-                    UserTenantMapping.email == email,
-                    UserTenantMapping.tenant_id == tenant_id,
-                    UserTenantMapping.active == False,  # noqa: E712
-                )
-                .first()
+            mapping = next(
+                (
+                    candidate
+                    for candidate in mappings
+                    if candidate.tenant_id == tenant_id and not candidate.active
+                ),
+                None,
             )
 
             if mapping:
-                # Set all other mappings for this user to inactive
-                db_session.query(UserTenantMapping).filter(
-                    UserTenantMapping.email == email,
-                    UserTenantMapping.active == True,  # noqa: E712
-                ).update({"active": False})
+                presented_links = (
+                    db_session.execute(
+                        select(
+                            UserTenantMappingOAuthAccount.oauth_name,
+                            UserTenantMappingOAuthAccount.account_id,
+                            UserTenantMappingOAuthAccount.email,
+                            UserTenantMappingOAuthAccount.tenant_id,
+                        ).where(
+                            tuple_(
+                                UserTenantMappingOAuthAccount.oauth_name,
+                                UserTenantMappingOAuthAccount.account_id,
+                            ).in_(identities)
+                        )
+                    ).all()
+                    if identities
+                    else []
+                )
+                linked_identities = {
+                    (oauth_name, account_id)
+                    for oauth_name, account_id, _, _ in presented_links
+                }
+                # An address-matched row can be a former holder's, so only rows
+                # a presented subject links to are provably this identity's.
+                owned_mapping_keys = {
+                    (owner_email, owner_tenant_id)
+                    for _, _, owner_email, owner_tenant_id in presented_links
+                } - {(mapping.email, mapping.tenant_id)}
+                # Every link on such a row moves, not just the presented ones,
+                # or ON DELETE CASCADE strands the providers the user did not
+                # sign in with today.
+                association_accounts = (
+                    db_session.query(UserTenantMappingOAuthAccount)
+                    .filter(
+                        tuple_(
+                            UserTenantMappingOAuthAccount.email,
+                            UserTenantMappingOAuthAccount.tenant_id,
+                        ).in_(list(owned_mapping_keys))
+                    )
+                    .with_for_update()
+                    .all()
+                    if owned_mapping_keys
+                    else []
+                )
+                for account in association_accounts:
+                    account.email = mapping.email
+                    account.tenant_id = mapping.tenant_id
 
-                # Activate this mapping
+                db_session.add_all(
+                    [
+                        UserTenantMappingOAuthAccount(
+                            oauth_name=oauth_name,
+                            account_id=account_id,
+                            email=mapping.email,
+                            tenant_id=mapping.tenant_id,
+                        )
+                        for oauth_name, account_id in identities
+                        if (oauth_name, account_id) not in linked_identities
+                    ]
+                )
+                db_session.flush()
+
+                for candidate in mappings:
+                    if candidate is mapping or not candidate.active:
+                        continue
+                    # Only one active row may hold an address, so a rival has
+                    # to yield. Deactivate rather than delete one this identity
+                    # does not own: it belongs to whoever held the address
+                    # before, and their subject links have to survive.
+                    if (candidate.email, candidate.tenant_id) in owned_mapping_keys:
+                        db_session.delete(candidate)
+                    else:
+                        candidate.active = False
+
+                # The partial unique index on active emails is immediate. Flush
+                # every prior membership change before the destination becomes
+                # active.
+                db_session.flush()
                 mapping.active = True
                 db_session.commit()
                 logger.info(

--- a/backend/ee/onyx/server/tenants/provisioning.py
+++ b/backend/ee/onyx/server/tenants/provisioning.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from ee.onyx.configs.app_configs import HUBSPOT_TRACKING_URL
 from ee.onyx.db.user_tenant_mapping import (
     add_users_to_tenant,
-    get_tenant_id_for_email,
+    resolve_tenant_id,
     user_owns_a_tenant,
 )
 from ee.onyx.server.tenants.access import generate_data_plane_token
@@ -25,7 +25,6 @@ from ee.onyx.server.tenants.schema_management import (
     drop_schema,
     run_alembic_migrations,
 )
-from onyx.auth.users import exceptions
 from onyx.configs.app_configs import (
     ANTHROPIC_DEFAULT_API_KEY,
     AUTO_PROVISION_DEFAULT_LLM_PROVIDERS,
@@ -90,11 +89,16 @@ async def get_or_provision_tenant(
     email: str,
     referral_source: str | None = None,
     request: Request | None = None,
+    oauth_name: str | None = None,
+    account_id: str | None = None,
 ) -> str:
     """
     Get existing tenant ID for an email or create a new tenant if none exists.
     This function should only be called after we have verified we want this user's tenant to exist.
     It returns the tenant ID associated with the email, creating a new tenant if necessary.
+
+    When the caller knows the IdP subject it is tried before the email, which is
+    what stops a renamed user being treated as a brand new signup.
     """
     # Early return for non-multi-tenant mode
     if not MULTI_TENANT:
@@ -103,14 +107,9 @@ async def get_or_provision_tenant(
     if referral_source and request:
         await submit_to_hubspot(email, referral_source, request)
 
-    # First, check if the user already has a tenant
-    tenant_id: str | None = None
-    try:
-        tenant_id = get_tenant_id_for_email(email)
+    tenant_id = resolve_tenant_id(email, oauth_name, account_id)
+    if tenant_id:
         return tenant_id
-    except exceptions.UserNotExists:
-        # User doesn't exist, so we need to create a new tenant or assign an existing one
-        pass
 
     try:
         # Try to get a pre-provisioned tenant

--- a/backend/ee/onyx/server/tenants/user_invitations_api.py
+++ b/backend/ee/onyx/server/tenants/user_invitations_api.py
@@ -80,7 +80,14 @@ async def accept_invite(
     Accept an invitation to join a tenant.
     """
     try:
-        accept_user_invite(user.email, invite_request.tenant_id)
+        accept_user_invite(
+            user.email,
+            invite_request.tenant_id,
+            [
+                (account.oauth_name, account.account_id)
+                for account in user.oauth_accounts
+            ],
+        )
     except Exception as e:
         logger.exception("Failed to accept invite: %s", str(e))
         raise HTTPException(status_code=500, detail="Failed to accept invitation")

--- a/backend/onyx/auth/login_claims_capture.py
+++ b/backend/onyx/auth/login_claims_capture.py
@@ -137,8 +137,12 @@ def _retain_richer_sources(
     return merged
 
 
-async def _store_claims_snapshot(email: str, snapshot: dict[str, Any]) -> None:
-    tenant_id = await _resolve_capture_tenant_id(email)
+async def _store_claims_snapshot(
+    email: str,
+    snapshot: dict[str, Any],
+    tenant_id: str | None = None,
+) -> None:
+    tenant_id = tenant_id or await _resolve_capture_tenant_id(email)
     if tenant_id is None:
         logger.debug(
             "Skipping claims capture for %s: tenant not yet resolved "
@@ -274,6 +278,8 @@ async def capture_oauth_login_claims(
     oauth_client: Any,
     email: str,
     token: dict[str, Any],
+    *,
+    tenant_id: str | None = None,
 ) -> None:
     """Snapshot the claims the IdP sent for this login into Redis.
 
@@ -287,7 +293,9 @@ async def capture_oauth_login_claims(
         return
     try:
         await asyncio.wait_for(
-            _capture_oauth_login_claims(oauth_client, email, token),
+            _capture_oauth_login_claims(
+                oauth_client, email, token, tenant_id=tenant_id
+            ),
             timeout=_IDP_CLAIMS_CAPTURE_TIMEOUT_SECONDS,
         )
     except asyncio.TimeoutError:
@@ -300,6 +308,8 @@ async def _capture_oauth_login_claims(
     oauth_client: Any,
     email: str,
     token: dict[str, Any],
+    *,
+    tenant_id: str | None = None,
 ) -> None:
     try:
         id_token_claims: dict[str, Any] = {}
@@ -356,7 +366,7 @@ async def _capture_oauth_login_claims(
             },
         }
 
-        await _store_claims_snapshot(email, snapshot)
+        await _store_claims_snapshot(email, snapshot, tenant_id)
     except Exception:
         logger.warning(
             "OAuth claims capture failed for %s (login unaffected)",

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -2483,8 +2483,8 @@ async def complete_login_flow(
 
     next_url = sanitize_next_url(state_data.get("next_url"))
     referral_source = state_data.get("referral_source", None)
-    # Drives the new_team redirect below, so it shares oauth_callback's resolver
-    # rather than restating the order. Disagreeing greets a returning user as new.
+    # Drives the new_team redirect below. Resolving differently from the login
+    # itself would greet a returning user as a brand new signup.
     tenant_id = fetch_ee_implementation_or_noop(
         "onyx.db.user_tenant_mapping", "resolve_tenant_id", None
     )(account_email, oauth_client.name, account_id)

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -138,6 +138,7 @@ from onyx.db.pat import resolve_pat
 from onyx.db.users import (
     assign_user_to_default_groups__no_commit,
     get_user_by_email,
+    get_user_by_oauth_account,
     is_limited_user,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
@@ -336,9 +337,18 @@ def verify_email_is_invited(email: str) -> None:
     )
 
 
-def verify_email_in_whitelist(email: str, tenant_id: str) -> None:
+def verify_email_in_whitelist(
+    email: str,
+    tenant_id: str,
+    oauth_name: str | None = None,
+    account_id: str | None = None,
+) -> None:
     with get_session_with_tenant(tenant_id=tenant_id) as db_session:
         user = get_user_by_email(email, db_session)
+        if user is None and oauth_name and account_id:
+            # A linked subject proves this is an existing member even when the
+            # provider has renamed their address since the previous login.
+            user = get_user_by_oauth_account(oauth_name, account_id, db_session)
         # A permission-sync placeholder is not a member: appearing in a
         # connector's ACLs must not satisfy invite-only, so the invite check
         # applies until the person actually joins.
@@ -904,6 +914,8 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             email=account_email,
             referral_source=referral_source,
             request=request,
+            oauth_name=oauth_name,
+            account_id=account_id,
         )
 
         if not tenant_id:
@@ -914,7 +926,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         async with get_async_session_context_manager(tenant_id) as db_session:
             token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
 
-            verify_email_in_whitelist(account_email, tenant_id)
+            verify_email_in_whitelist(account_email, tenant_id, oauth_name, account_id)
             oauth_security_settings = get_security_settings()
             effective_valid_email_domains = (
                 allowed_email_domains_override
@@ -1351,12 +1363,16 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         tenant_id: str | None = None
         try:
             tenant_id = fetch_ee_implementation_or_noop(
-                "onyx.server.tenants.provisioning",
+                "onyx.db.user_tenant_mapping",
                 "get_tenant_id_for_email",
                 POSTGRES_DEFAULT_SCHEMA,
             )(
                 email=email,
             )
+        except OnyxError:
+            # Ambiguous membership is actionable, so it has to reach the caller
+            # rather than be flattened into a generic credential failure.
+            raise
         except Exception as e:
             logger.warning(
                 "User attempted to login with invalid credentials: %s", str(e)
@@ -2465,19 +2481,20 @@ async def complete_login_flow(
             ErrorCode.OAUTH_NOT_AVAILABLE_EMAIL,
         )
 
-    # Snapshot the raw IdP claims for directory-profile enrichment and the
-    # admin "OAuth Test" page. Best-effort — never raises, no-op unless
-    # IDP_PROFILE_ENRICHMENT_ENABLED.
-    await capture_oauth_login_claims(oauth_client, account_email, token)
-
     next_url = sanitize_next_url(state_data.get("next_url"))
     referral_source = state_data.get("referral_source", None)
-    try:
-        tenant_id = fetch_ee_implementation_or_noop(
-            "onyx.db.user_tenant_mapping", "get_tenant_id_for_email", None
-        )(account_email)
-    except exceptions.UserNotExists:
-        tenant_id = None
+    # Drives the new_team redirect below, so it shares oauth_callback's resolver
+    # rather than restating the order. Disagreeing greets a returning user as new.
+    tenant_id = fetch_ee_implementation_or_noop(
+        "onyx.db.user_tenant_mapping", "resolve_tenant_id", None
+    )(account_email, oauth_client.name, account_id)
+
+    # Snapshot the raw IdP claims for directory-profile enrichment and the admin
+    # "OAuth Test" page. The subject-resolved tenant keeps capture working after
+    # an IdP rename. Never raises, no-op unless IDP_PROFILE_ENRICHMENT_ENABLED.
+    await capture_oauth_login_claims(
+        oauth_client, account_email, token, tenant_id=tenant_id
+    )
 
     request.state.referral_source = referral_source
 

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -337,6 +337,27 @@ def get_user_by_email(email: str, db_session: Session) -> User | None:
     return user
 
 
+def get_user_by_oauth_account(
+    oauth_name: str, account_id: str, db_session: Session
+) -> User | None:
+    """Find a user by the IdP subject their account is linked to.
+
+    Unlike the email lookup, this keeps working after an IdP rename.
+    """
+    return (
+        db_session.query(User)
+        .join(
+            OAuthAccount,
+            OAuthAccount.user_id == User.id,  # ty: ignore[invalid-argument-type]
+        )
+        .filter(
+            OAuthAccount.oauth_name == oauth_name,  # ty: ignore[invalid-argument-type]
+            OAuthAccount.account_id == account_id,  # ty: ignore[invalid-argument-type]
+        )
+        .first()
+    )
+
+
 def fetch_user_by_id(
     db_session: Session, user_id: UUID, for_update: bool = False
 ) -> User | None:

--- a/backend/tests/external_dependency_unit/auth/test_mobile_sso_bridge.py
+++ b/backend/tests/external_dependency_unit/auth/test_mobile_sso_bridge.py
@@ -145,7 +145,9 @@ def _callback(client: TestClient, state: str) -> httpx.Response:
     # Every callback test resolves the tenant the same way; centralize the patch.
     with patch(
         "onyx.auth.users.fetch_ee_implementation_or_noop",
-        return_value=lambda _email: "tenant_1",
+        # Dispatch arity varies by target. This test guards the mobile bridge,
+        # not the resolver signature.
+        return_value=lambda *_args: "tenant_1",
     ):
         return client.get(
             "/auth/oauth/callback",

--- a/backend/tests/unit/ee/onyx/server/tenants/test_record_oauth_identity.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_record_oauth_identity.py
@@ -234,6 +234,36 @@ def test_accept_invite_leaves_a_former_holders_links_alone() -> None:
     assert stranger_mapping.active is False
 
 
+def test_accept_invite_activates_the_row_for_the_accepted_address() -> None:
+    """A tenant can hold several rows for one user, keyed by different addresses.
+    The invitation belongs to the address being accepted, so selecting on the
+    tenant alone would activate whichever row the query happened to return."""
+    stale_same_tenant = SimpleNamespace(
+        email="old@example.com", tenant_id="tenant_new", active=False
+    )
+    invitation = SimpleNamespace(
+        email="new@example.com", tenant_id="tenant_new", active=False
+    )
+    with (
+        patch(f"{_MAPPING_MODULE}.get_catalog_session") as session_ctx,
+        patch(f"{_MAPPING_MODULE}.get_invited_users", return_value=[]),
+    ):
+        db_session = session_ctx.return_value.__enter__.return_value
+        mapping_query = MagicMock()
+        # The stale row sorts first, which is what the tenant-only predicate hit.
+        mapping_query.filter.return_value.with_for_update.return_value.all.return_value = [
+            stale_same_tenant,
+            invitation,
+        ]
+        db_session.query.side_effect = [mapping_query]
+        db_session.execute.return_value.all.return_value = []
+
+        accept_user_invite("new@example.com", "tenant_new", [("google", "sub-123")])
+
+    assert invitation.active is True
+    assert stale_same_tenant.active is False
+
+
 def test_accept_invite_links_subjects_that_were_never_linked() -> None:
     """A user can accept before their first OAuth login links anything, so
     acceptance itself must create the missing links on the destination."""

--- a/backend/tests/unit/ee/onyx/server/tenants/test_record_oauth_identity.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_record_oauth_identity.py
@@ -1,5 +1,6 @@
 """Guards that `record_oauth_identity` only touches the mapping tables on cloud
-and never re-links a subject that already belongs to another mapping.
+and never re-links a subject that already belongs to another mapping, and that
+invitation flows move subject links only with the authenticated user.
 
 The `public.user_tenant_mapping*` tables are created by the `alembic_tenants`
 tree, which only multi-tenant deployments run. Opening a session against them
@@ -7,9 +8,16 @@ anywhere else would raise on every OAuth login, so the `MULTI_TENANT` guard is
 load-bearing rather than an optimization.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from ee.onyx.db.user_tenant_mapping import record_oauth_identity
+from sqlalchemy.dialects import postgresql
+
+from ee.onyx.db.user_tenant_mapping import (
+    accept_user_invite,
+    approve_user_invite,
+    record_oauth_identity,
+)
 
 _MAPPING_MODULE = "ee.onyx.db.user_tenant_mapping"
 
@@ -42,8 +50,6 @@ def _run(
 
 
 def _compiled_insert_sql(session_ctx: MagicMock) -> str:
-    from sqlalchemy.dialects import postgresql
-
     db_session = session_ctx.return_value.__enter__.return_value
     statement = db_session.execute.call_args_list[0].args[0]
     return str(
@@ -103,3 +109,186 @@ def test_repeat_login_for_the_linked_mapping_is_idempotent() -> None:
 
     db_session = session_ctx.return_value.__enter__.return_value
     db_session.commit.assert_called_once()
+
+
+def test_accept_invite_moves_every_link_off_a_row_this_identity_owns() -> None:
+    """Links are selected by the row a presented subject already links to, then
+    ALL of that row's links move. Selecting by presented identity alone would
+    leave the siblings on a row that is then deleted, and ON DELETE CASCADE
+    strands them. The old membership is also flushed away before the
+    destination activates, because the active-email unique index is
+    immediate."""
+    old_mapping = SimpleNamespace(
+        email="renamed@example.com", tenant_id="tenant_old", active=True
+    )
+    destination = SimpleNamespace(
+        email="user@example.com", tenant_id="tenant_new", active=False
+    )
+    google_account = SimpleNamespace(
+        oauth_name="google",
+        account_id="sub-123",
+        email="renamed@example.com",
+        tenant_id="tenant_old",
+    )
+    # Never presented to accept_user_invite below, yet must still move.
+    github_account = SimpleNamespace(
+        oauth_name="github",
+        account_id="sub-456",
+        email="renamed@example.com",
+        tenant_id="tenant_old",
+    )
+    with (
+        patch(f"{_MAPPING_MODULE}.get_catalog_session") as session_ctx,
+        patch(f"{_MAPPING_MODULE}.get_invited_users", return_value=[]),
+    ):
+        db_session = session_ctx.return_value.__enter__.return_value
+        mapping_query = MagicMock()
+        mapping_query.filter.return_value.with_for_update.return_value.all.return_value = [
+            old_mapping,
+            destination,
+        ]
+        account_query = MagicMock()
+        account_query.filter.return_value.with_for_update.return_value.all.return_value = [
+            google_account,
+            github_account,
+        ]
+        db_session.query.side_effect = [mapping_query, account_query]
+        db_session.execute.return_value.all.return_value = [
+            ("google", "sub-123", "renamed@example.com", "tenant_old")
+        ]
+        events: list[tuple[str, object]] = []
+        db_session.delete.side_effect = lambda deleted: events.append(
+            ("delete", deleted)
+        )
+        db_session.flush.side_effect = lambda: events.append(
+            ("flush_destination_active", destination.active)
+        )
+        db_session.commit.side_effect = lambda: events.append(("commit", None))
+
+        accept_user_invite("User@Example.com", "tenant_new", [("google", "sub-123")])
+
+    # Mocks do not evaluate filters, so assert the association query is keyed by
+    # the owning row rather than by the presented identities. Keying by identity
+    # silently drops github below.
+    association_filter = account_query.filter.call_args.args[-1]
+    sql = str(
+        association_filter.compile(
+            dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+        )
+    )
+    assert "'renamed@example.com'" in sql and "'tenant_old'" in sql
+    assert "sub-123" not in sql
+
+    assert destination.active is True
+    assert {
+        (account.email, account.tenant_id)
+        for account in (google_account, github_account)
+    } == {("user@example.com", "tenant_new")}
+    assert db_session.add_all.call_args.args[0] == []
+    assert events == [
+        ("flush_destination_active", False),
+        ("delete", old_mapping),
+        ("flush_destination_active", False),
+        ("commit", None),
+    ]
+    db_session.delete.assert_called_once_with(old_mapping)
+
+
+def test_accept_invite_leaves_a_former_holders_links_alone() -> None:
+    """An address can be reassigned, so a mapping matched by address alone may
+    be a previous holder's. Moving its links would attach a stranger's subject
+    to this workspace, and subject-first resolution would then route them here."""
+    stranger_mapping = SimpleNamespace(
+        email="user@example.com", tenant_id="tenant_stranger", active=True
+    )
+    destination = SimpleNamespace(
+        email="user@example.com", tenant_id="tenant_new", active=False
+    )
+    with (
+        patch(f"{_MAPPING_MODULE}.get_catalog_session") as session_ctx,
+        patch(f"{_MAPPING_MODULE}.get_invited_users", return_value=[]),
+    ):
+        db_session = session_ctx.return_value.__enter__.return_value
+        mapping_query = MagicMock()
+        mapping_query.filter.return_value.with_for_update.return_value.all.return_value = [
+            stranger_mapping,
+            destination,
+        ]
+        account_query = MagicMock()
+        account_query.filter.return_value.with_for_update.return_value.all.return_value = []
+        db_session.query.side_effect = [mapping_query, account_query]
+        # The accepting user's subject links nowhere yet, so no row is provably
+        # theirs and nothing may be moved.
+        db_session.execute.return_value.all.return_value = []
+
+        accept_user_invite("user@example.com", "tenant_new", [("google", "sub-123")])
+
+    # The association table is never queried at all when no row is owned.
+    assert db_session.query.call_count == 1
+    created = db_session.add_all.call_args.args[0]
+    assert [(a.oauth_name, a.account_id) for a in created] == [("google", "sub-123")]
+    assert destination.active is True
+    # Deactivated to free the address, never deleted: the row and its subject
+    # links belong to whoever held the address before.
+    db_session.delete.assert_not_called()
+    assert stranger_mapping.active is False
+
+
+def test_accept_invite_links_subjects_that_were_never_linked() -> None:
+    """A user can accept before their first OAuth login links anything, so
+    acceptance itself must create the missing links on the destination."""
+    destination = SimpleNamespace(
+        email="user@example.com", tenant_id="tenant_new", active=False
+    )
+    with (
+        patch(f"{_MAPPING_MODULE}.get_catalog_session") as session_ctx,
+        patch(f"{_MAPPING_MODULE}.get_invited_users", return_value=[]),
+    ):
+        db_session = session_ctx.return_value.__enter__.return_value
+        mapping_query = MagicMock()
+        mapping_query.filter.return_value.with_for_update.return_value.all.return_value = [
+            destination
+        ]
+        account_query = MagicMock()
+        account_query.filter.return_value.with_for_update.return_value.all.return_value = []
+        db_session.query.side_effect = [mapping_query, account_query]
+        db_session.execute.return_value.all.return_value = []
+
+        accept_user_invite("user@example.com", "tenant_new", [("google", "sub-123")])
+
+    created = db_session.add_all.call_args.args[0]
+    assert [
+        (account.oauth_name, account.account_id, account.email, account.tenant_id)
+        for account in created
+    ] == [("google", "sub-123", "user@example.com", "tenant_new")]
+    assert destination.active is True
+
+
+def test_approve_invite_does_not_transfer_subjects_by_email() -> None:
+    """Approval is an email-level admin action: the address may have been
+    reassigned at the IdP, so it must never move another identity's links."""
+    existing_mapping = SimpleNamespace(
+        email="user@example.com", tenant_id="tenant_old", active=True
+    )
+    with (
+        patch(f"{_MAPPING_MODULE}.get_catalog_session") as session_ctx,
+        patch(f"{_MAPPING_MODULE}.get_pending_users", return_value=[]),
+        patch(f"{_MAPPING_MODULE}.get_invited_users", return_value=[]),
+        patch(f"{_MAPPING_MODULE}.write_invited_users"),
+    ):
+        db_session = session_ctx.return_value.__enter__.return_value
+        db_session.query.return_value.filter.return_value.with_for_update.return_value.all.return_value = [
+            existing_mapping
+        ]
+
+        approve_user_invite("User@Example.com", "tenant_new")
+
+    added_mapping = db_session.add.call_args.args[0]
+    assert added_mapping.email == "user@example.com"
+    assert added_mapping.tenant_id == "tenant_new"
+    assert db_session.query.call_count == 1
+    db_session.add_all.assert_not_called()
+    # Deleting would cascade away subject links this approval cannot prove are
+    # the approved user's, so the rival row is only deactivated.
+    db_session.delete.assert_not_called()
+    assert existing_mapping.active is False

--- a/backend/tests/unit/ee/onyx/server/tenants/test_tenant_resolution_by_oauth_account.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_tenant_resolution_by_oauth_account.py
@@ -6,6 +6,7 @@ If the order inverts, a renamed user resolves nowhere and `get_or_provision_tena
 hands them a newly provisioned empty workspace instead of the one they belong to.
 """
 
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -14,6 +15,9 @@ from sqlalchemy.dialects import postgresql
 
 from ee.onyx.db.user_tenant_mapping import (
     _oauth_identity_matches_mapping,
+    get_superseded_tenant_id_for_oauth_account,
+    get_tenant_id_for_email,
+    get_tenant_id_for_oauth_account,
     resolve_tenant_id,
 )
 from ee.onyx.server.tenants.provisioning import get_or_provision_tenant
@@ -54,16 +58,14 @@ def test_falls_back_to_email_when_subject_is_unstamped() -> None:
     assert tenant_id == "tenant_from_email"
 
 
-def test_active_email_membership_wins_over_inactive_subject_history() -> None:
-    """A stale subject stamp must not lock out the identity that currently owns
-    an active email membership."""
-    inactive_subject = OnyxError(
-        OnyxErrorCode.CONFLICT, "identity has no active workspace"
-    )
+def test_an_active_email_membership_outranks_a_superseded_subject() -> None:
+    """An admin moving a member into another workspace deactivates the row their
+    subject is linked to. Following that link would undo the move."""
+    superseded = MagicMock()
     with (
+        patch(f"{_MAPPING_MODULE}.get_tenant_id_for_oauth_account", return_value=None),
         patch(
-            f"{_MAPPING_MODULE}.get_tenant_id_for_oauth_account",
-            side_effect=inactive_subject,
+            f"{_MAPPING_MODULE}.get_superseded_tenant_id_for_oauth_account", superseded
         ),
         patch(
             f"{_MAPPING_MODULE}.get_tenant_id_for_email",
@@ -73,26 +75,26 @@ def test_active_email_membership_wins_over_inactive_subject_history() -> None:
         tenant_id = resolve_tenant_id("current@example.com", "google", "sub-123")
 
     assert tenant_id == "tenant_from_email"
+    superseded.assert_not_called()
 
 
-def test_inactive_subject_still_fails_closed_without_an_email_membership() -> None:
-    inactive_subject = OnyxError(
-        OnyxErrorCode.CONFLICT, "identity has no active workspace"
-    )
+def test_a_superseded_subject_answers_when_the_address_maps_nowhere() -> None:
+    """The renamed-and-reassigned case: the address now belongs to someone else,
+    so only the subject still names the workspace this user belongs to."""
     with (
+        patch(f"{_MAPPING_MODULE}.get_tenant_id_for_oauth_account", return_value=None),
         patch(
-            f"{_MAPPING_MODULE}.get_tenant_id_for_oauth_account",
-            side_effect=inactive_subject,
+            f"{_MAPPING_MODULE}.get_superseded_tenant_id_for_oauth_account",
+            return_value="tenant_superseded",
         ),
         patch(
             f"{_MAPPING_MODULE}.get_tenant_id_for_email",
             side_effect=exceptions.UserNotExists(),
         ),
     ):
-        with pytest.raises(OnyxError) as exc_info:
-            resolve_tenant_id("unmapped@example.com", "google", "sub-123")
+        tenant_id = resolve_tenant_id("renamed@example.com", "google", "sub-123")
 
-    assert exc_info.value is inactive_subject
+    assert tenant_id == "tenant_superseded"
 
 
 def test_password_login_skips_the_subject_lookup() -> None:
@@ -190,8 +192,6 @@ def test_several_pending_email_invitations_are_ambiguous() -> None:
         patch(f"{_MAPPING_MODULE}.MULTI_TENANT", True),
         patch(f"{_MAPPING_MODULE}.get_catalog_session", session_ctx),
     ):
-        from ee.onyx.db.user_tenant_mapping import get_tenant_id_for_email
-
         with pytest.raises(OnyxError) as exc_info:
             get_tenant_id_for_email("user@example.com")
 
@@ -200,55 +200,48 @@ def test_several_pending_email_invitations_are_ambiguous() -> None:
     db_session.commit.assert_not_called()
 
 
-def test_inactive_historical_subject_is_not_reactivated() -> None:
-    """A stamped inactive row is prior membership, not an invitation. Restoring
-    it would silently undo a removal from that workspace."""
+def _catalog_session(tenant_id: str | None) -> tuple[MagicMock, MagicMock]:
     session_ctx = MagicMock()
     db_session = session_ctx.return_value.__enter__.return_value
-    active_miss = MagicMock()
-    active_miss.scalar_one_or_none.return_value = None
-    inactive_hit = MagicMock()
-    inactive_hit.scalar_one_or_none.return_value = "tenant_inactive"
-    db_session.execute.side_effect = [active_miss, inactive_hit]
+    db_session.scalar.return_value = tenant_id
+    return session_ctx, db_session
+
+
+@pytest.mark.parametrize(
+    "lookup, expected_predicate",
+    [
+        (get_tenant_id_for_oauth_account, "active IS true"),
+        (get_superseded_tenant_id_for_oauth_account, "active IS false"),
+    ],
+)
+def test_each_lookup_filters_on_its_own_membership_state(
+    lookup: Callable[[str, str], str | None], expected_predicate: str
+) -> None:
+    """Both read one linked row, so the `active` predicate is the only thing
+    separating a live membership from one that yielded its address."""
+    session_ctx, db_session = _catalog_session("tenant_a")
 
     with (
         patch(f"{_MAPPING_MODULE}.MULTI_TENANT", True),
         patch(f"{_MAPPING_MODULE}.get_catalog_session", session_ctx),
     ):
-        from ee.onyx.db.user_tenant_mapping import get_tenant_id_for_oauth_account
+        assert lookup("google", "sub-123") == "tenant_a"
 
-        with pytest.raises(OnyxError) as exc_info:
-            get_tenant_id_for_oauth_account("google", "sub-123")
-
-    assert exc_info.value.error_code is OnyxErrorCode.CONFLICT
-    db_session.query.assert_not_called()
+    sql = str(
+        db_session.scalar.call_args[0][0].compile(
+            dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+        )
+    )
+    assert expected_predicate in sql
     db_session.commit.assert_not_called()
 
 
-def test_inactive_subject_does_not_follow_a_reassigned_email() -> None:
-    """The old address may now belong to a different person, so its active
-    mapping cannot prove anything about this subject."""
-    session_ctx = MagicMock()
-    db_session = session_ctx.return_value.__enter__.return_value
-    active_subject_miss = MagicMock()
-    active_subject_miss.scalar_one_or_none.return_value = None
-    inactive_subject_hit = MagicMock()
-    inactive_subject_hit.scalar_one_or_none.return_value = "tenant_old"
-    db_session.execute.side_effect = [
-        active_subject_miss,
-        inactive_subject_hit,
-    ]
+def test_an_unlinked_subject_maps_nowhere() -> None:
+    session_ctx, _ = _catalog_session(None)
 
     with (
         patch(f"{_MAPPING_MODULE}.MULTI_TENANT", True),
         patch(f"{_MAPPING_MODULE}.get_catalog_session", session_ctx),
     ):
-        from ee.onyx.db.user_tenant_mapping import get_tenant_id_for_oauth_account
-
-        with pytest.raises(OnyxError) as exc_info:
-            get_tenant_id_for_oauth_account("google", "sub-123")
-
-    assert exc_info.value.error_code is OnyxErrorCode.CONFLICT
-    assert db_session.execute.call_count == 2
-    db_session.query.assert_not_called()
-    db_session.commit.assert_not_called()
+        assert get_tenant_id_for_oauth_account("google", "sub-123") is None
+        assert get_superseded_tenant_id_for_oauth_account("google", "sub-1") is None

--- a/backend/tests/unit/ee/onyx/server/tenants/test_tenant_resolution_by_oauth_account.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_tenant_resolution_by_oauth_account.py
@@ -1,0 +1,254 @@
+"""Guards the resolution order that keeps a renamed user out of a fresh tenant.
+
+`resolve_tenant_id` must consult the IdP subject before the email, because the
+subject is the only identifier that survives an address change at the provider.
+If the order inverts, a renamed user resolves nowhere and `get_or_provision_tenant`
+hands them a newly provisioned empty workspace instead of the one they belong to.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi_users import exceptions
+from sqlalchemy.dialects import postgresql
+
+from ee.onyx.db.user_tenant_mapping import (
+    _oauth_identity_matches_mapping,
+    resolve_tenant_id,
+)
+from ee.onyx.server.tenants.provisioning import get_or_provision_tenant
+from onyx.db.models import UserTenantMapping
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+
+_MAPPING_MODULE = "ee.onyx.db.user_tenant_mapping"
+_PROVISIONING_MODULE = "ee.onyx.server.tenants.provisioning"
+
+
+def test_subject_wins_over_a_stale_email() -> None:
+    """The renamed-user case: the address maps nowhere but the subject still does."""
+    by_email = MagicMock(side_effect=exceptions.UserNotExists())
+    with (
+        patch(
+            f"{_MAPPING_MODULE}.get_tenant_id_for_oauth_account",
+            return_value="tenant_existing",
+        ),
+        patch(f"{_MAPPING_MODULE}.get_tenant_id_for_email", by_email),
+    ):
+        tenant_id = resolve_tenant_id("new-address@example.com", "google", "sub-123")
+
+    assert tenant_id == "tenant_existing"
+    by_email.assert_not_called()
+
+
+def test_falls_back_to_email_when_subject_is_unstamped() -> None:
+    with (
+        patch(f"{_MAPPING_MODULE}.get_tenant_id_for_oauth_account", return_value=None),
+        patch(
+            f"{_MAPPING_MODULE}.get_tenant_id_for_email",
+            return_value="tenant_from_email",
+        ),
+    ):
+        tenant_id = resolve_tenant_id("user@example.com", "google", "sub-123")
+
+    assert tenant_id == "tenant_from_email"
+
+
+def test_active_email_membership_wins_over_inactive_subject_history() -> None:
+    """A stale subject stamp must not lock out the identity that currently owns
+    an active email membership."""
+    inactive_subject = OnyxError(
+        OnyxErrorCode.CONFLICT, "identity has no active workspace"
+    )
+    with (
+        patch(
+            f"{_MAPPING_MODULE}.get_tenant_id_for_oauth_account",
+            side_effect=inactive_subject,
+        ),
+        patch(
+            f"{_MAPPING_MODULE}.get_tenant_id_for_email",
+            return_value="tenant_from_email",
+        ),
+    ):
+        tenant_id = resolve_tenant_id("current@example.com", "google", "sub-123")
+
+    assert tenant_id == "tenant_from_email"
+
+
+def test_inactive_subject_still_fails_closed_without_an_email_membership() -> None:
+    inactive_subject = OnyxError(
+        OnyxErrorCode.CONFLICT, "identity has no active workspace"
+    )
+    with (
+        patch(
+            f"{_MAPPING_MODULE}.get_tenant_id_for_oauth_account",
+            side_effect=inactive_subject,
+        ),
+        patch(
+            f"{_MAPPING_MODULE}.get_tenant_id_for_email",
+            side_effect=exceptions.UserNotExists(),
+        ),
+    ):
+        with pytest.raises(OnyxError) as exc_info:
+            resolve_tenant_id("unmapped@example.com", "google", "sub-123")
+
+    assert exc_info.value is inactive_subject
+
+
+def test_password_login_skips_the_subject_lookup() -> None:
+    by_subject = MagicMock()
+    with (
+        patch(f"{_MAPPING_MODULE}.get_tenant_id_for_oauth_account", by_subject),
+        patch(
+            f"{_MAPPING_MODULE}.get_tenant_id_for_email",
+            return_value="tenant_from_email",
+        ),
+    ):
+        tenant_id = resolve_tenant_id("user@example.com")
+
+    assert tenant_id == "tenant_from_email"
+    by_subject.assert_not_called()
+
+
+def test_returns_none_when_nothing_maps() -> None:
+    with (
+        patch(f"{_MAPPING_MODULE}.get_tenant_id_for_oauth_account", return_value=None),
+        patch(
+            f"{_MAPPING_MODULE}.get_tenant_id_for_email",
+            side_effect=exceptions.UserNotExists(),
+        ),
+    ):
+        assert resolve_tenant_id("nobody@example.com", "google", "sub-123") is None
+
+
+def test_subject_resolution_checks_every_linked_provider() -> None:
+    subject_filter = _oauth_identity_matches_mapping("github", "sub-456")
+    sql = str(
+        subject_filter.compile(
+            dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+        )
+    )
+
+    assert UserTenantMapping.__tablename__ in sql
+    assert "user_tenant_mapping_oauth_account" in sql
+    assert "github" in sql
+    assert "sub-456" in sql
+
+
+@pytest.mark.asyncio
+async def test_provisioning_is_skipped_when_the_login_already_resolves() -> None:
+    """A resolved tenant must short-circuit before any pool or control-plane call."""
+    available = MagicMock()
+    with (
+        patch(f"{_PROVISIONING_MODULE}.MULTI_TENANT", True),
+        patch(
+            f"{_PROVISIONING_MODULE}.resolve_tenant_id",
+            return_value="tenant_existing",
+        ),
+        patch(f"{_PROVISIONING_MODULE}.get_available_tenant", available),
+    ):
+        tenant_id = await get_or_provision_tenant(
+            email="new-address@example.com",
+            oauth_name="google",
+            account_id="sub-123",
+        )
+
+    assert tenant_id == "tenant_existing"
+    available.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_mapping_never_enters_provisioning() -> None:
+    available = MagicMock()
+    conflict = OnyxError(OnyxErrorCode.CONFLICT, "choose a workspace")
+    with (
+        patch(f"{_PROVISIONING_MODULE}.MULTI_TENANT", True),
+        patch(
+            f"{_PROVISIONING_MODULE}.resolve_tenant_id",
+            side_effect=conflict,
+        ),
+        patch(f"{_PROVISIONING_MODULE}.get_available_tenant", available),
+    ):
+        with pytest.raises(OnyxError) as exc_info:
+            await get_or_provision_tenant(email="user@example.com")
+
+    assert exc_info.value is conflict
+    assert exc_info.value.error_code is OnyxErrorCode.CONFLICT
+    available.assert_not_called()
+
+
+def test_several_pending_email_invitations_are_ambiguous() -> None:
+    session_ctx = MagicMock()
+    db_session = session_ctx.return_value.__enter__.return_value
+    active_miss = MagicMock()
+    active_miss.scalar_one_or_none.return_value = None
+    inactive_two = MagicMock()
+    inactive_two.scalars.return_value.all.return_value = ["tenant_a", "tenant_b"]
+    db_session.execute.side_effect = [active_miss, inactive_two]
+
+    with (
+        patch(f"{_MAPPING_MODULE}.MULTI_TENANT", True),
+        patch(f"{_MAPPING_MODULE}.get_catalog_session", session_ctx),
+    ):
+        from ee.onyx.db.user_tenant_mapping import get_tenant_id_for_email
+
+        with pytest.raises(OnyxError) as exc_info:
+            get_tenant_id_for_email("user@example.com")
+
+    assert exc_info.value.error_code is OnyxErrorCode.CONFLICT
+    db_session.query.assert_not_called()
+    db_session.commit.assert_not_called()
+
+
+def test_inactive_historical_subject_is_not_reactivated() -> None:
+    """A stamped inactive row is prior membership, not an invitation. Restoring
+    it would silently undo a removal from that workspace."""
+    session_ctx = MagicMock()
+    db_session = session_ctx.return_value.__enter__.return_value
+    active_miss = MagicMock()
+    active_miss.scalar_one_or_none.return_value = None
+    inactive_hit = MagicMock()
+    inactive_hit.scalar_one_or_none.return_value = "tenant_inactive"
+    db_session.execute.side_effect = [active_miss, inactive_hit]
+
+    with (
+        patch(f"{_MAPPING_MODULE}.MULTI_TENANT", True),
+        patch(f"{_MAPPING_MODULE}.get_catalog_session", session_ctx),
+    ):
+        from ee.onyx.db.user_tenant_mapping import get_tenant_id_for_oauth_account
+
+        with pytest.raises(OnyxError) as exc_info:
+            get_tenant_id_for_oauth_account("google", "sub-123")
+
+    assert exc_info.value.error_code is OnyxErrorCode.CONFLICT
+    db_session.query.assert_not_called()
+    db_session.commit.assert_not_called()
+
+
+def test_inactive_subject_does_not_follow_a_reassigned_email() -> None:
+    """The old address may now belong to a different person, so its active
+    mapping cannot prove anything about this subject."""
+    session_ctx = MagicMock()
+    db_session = session_ctx.return_value.__enter__.return_value
+    active_subject_miss = MagicMock()
+    active_subject_miss.scalar_one_or_none.return_value = None
+    inactive_subject_hit = MagicMock()
+    inactive_subject_hit.scalar_one_or_none.return_value = "tenant_old"
+    db_session.execute.side_effect = [
+        active_subject_miss,
+        inactive_subject_hit,
+    ]
+
+    with (
+        patch(f"{_MAPPING_MODULE}.MULTI_TENANT", True),
+        patch(f"{_MAPPING_MODULE}.get_catalog_session", session_ctx),
+    ):
+        from ee.onyx.db.user_tenant_mapping import get_tenant_id_for_oauth_account
+
+        with pytest.raises(OnyxError) as exc_info:
+            get_tenant_id_for_oauth_account("google", "sub-123")
+
+    assert exc_info.value.error_code is OnyxErrorCode.CONFLICT
+    assert db_session.execute.call_count == 2
+    db_session.query.assert_not_called()
+    db_session.commit.assert_not_called()

--- a/backend/tests/unit/onyx/auth/test_login_claims_capture.py
+++ b/backend/tests/unit/onyx/auth/test_login_claims_capture.py
@@ -480,6 +480,33 @@ async def test_multi_tenant_capture_keys_by_mapped_tenant(
 
 
 @pytest.mark.asyncio
+async def test_capture_uses_subject_resolved_tenant_after_email_rename(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(claims_capture, "MULTI_TENANT", True)
+    redis, pipe = _redis_with_pipeline()
+
+    with (
+        patch(
+            "onyx.auth.login_claims_capture.get_async_redis_connection",
+            return_value=redis,
+        ),
+        patch(
+            "onyx.auth.login_claims_capture.fetch_ee_implementation_or_noop"
+        ) as resolve_by_email,
+    ):
+        await capture_oauth_login_claims(
+            _FakeOAuthClient(),
+            "renamed@example.com",
+            _make_token({"sub": "abc"}),
+            tenant_id="tenant_from_subject",
+        )
+
+    assert "tenant_from_subject" in pipe.hset.call_args.args[0]
+    resolve_by_email.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_multi_tenant_capture_skips_unmapped_email(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/backend/tests/unit/onyx/auth/test_oidc_pkce.py
+++ b/backend/tests/unit/onyx/auth/test_oidc_pkce.py
@@ -315,7 +315,7 @@ def test_oidc_callback_uses_code_verifier_when_pkce_enabled() -> None:
 
     with patch(
         "onyx.auth.users.fetch_ee_implementation_or_noop",
-        return_value=lambda _email: "tenant_1",
+        return_value=lambda *_identity: "tenant_1",
     ):
         response = client.get(
             "/auth/oidc/callback",
@@ -337,7 +337,7 @@ def test_oidc_callback_works_without_pkce_when_flag_disabled() -> None:
 
     with patch(
         "onyx.auth.users.fetch_ee_implementation_or_noop",
-        return_value=lambda _email: "tenant_1",
+        return_value=lambda *_identity: "tenant_1",
     ):
         response = client.get(
             "/auth/oidc/callback",
@@ -362,7 +362,7 @@ def test_oidc_callback_pkce_preserves_redirect_when_backend_login_is_non_redirec
 
     with patch(
         "onyx.auth.users.fetch_ee_implementation_or_noop",
-        return_value=lambda _email: "tenant_1",
+        return_value=lambda *_identity: "tenant_1",
     ):
         response = client.get(
             "/auth/oidc/callback",

--- a/backend/tests/unit/onyx/auth/test_password_login_tenant_conflict.py
+++ b/backend/tests/unit/onyx/auth/test_password_login_tenant_conflict.py
@@ -1,0 +1,111 @@
+"""Guards that an ambiguous workspace reaches the password login caller.
+
+Resolution raises CONFLICT when an address has several pending invitations and
+no active membership, because picking one would join a workspace the user never
+accepted. That response tells them to choose. A blanket handler around the
+lookup would flatten it into a generic credential failure, leaving the user with
+no way to act and no signal that their account is fine.
+"""
+
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.security import OAuth2PasswordRequestForm
+
+from onyx.auth.users import UserManager
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+
+_AUTH_MODULE = "onyx.auth.users"
+
+
+def _credentials(username: str) -> OAuth2PasswordRequestForm:
+    return cast(
+        OAuth2PasswordRequestForm,
+        SimpleNamespace(username=username, password="unused"),
+    )
+
+
+def _manager() -> UserManager:
+    manager = UserManager.__new__(UserManager)
+    manager.password_helper = MagicMock()
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_membership_reaches_the_caller() -> None:
+    conflict = OnyxError(OnyxErrorCode.CONFLICT, "choose a workspace")
+    with (
+        patch(f"{_AUTH_MODULE}.MULTI_TENANT", True),
+        patch(
+            f"{_AUTH_MODULE}.fetch_ee_implementation_or_noop",
+            return_value=MagicMock(side_effect=conflict),
+        ),
+        patch(f"{_AUTH_MODULE}.emit_audit_event"),
+    ):
+        with pytest.raises(OnyxError) as exc_info:
+            await _manager().authenticate(_credentials("user@example.com"))
+
+    assert exc_info.value is conflict
+
+
+@pytest.mark.asyncio
+async def test_an_unmapped_address_is_still_a_generic_failure() -> None:
+    """Anything that is not an actionable conflict must stay indistinguishable
+    from a wrong password, so a caller cannot probe for known addresses."""
+    with (
+        patch(f"{_AUTH_MODULE}.MULTI_TENANT", True),
+        patch(
+            f"{_AUTH_MODULE}.fetch_ee_implementation_or_noop",
+            return_value=MagicMock(side_effect=RuntimeError("no mapping")),
+        ),
+        patch(f"{_AUTH_MODULE}.emit_audit_event"),
+        patch(f"{_AUTH_MODULE}.logger"),
+    ):
+        manager = _manager()
+        hasher = cast(MagicMock, manager.password_helper).hash
+        result = await manager.authenticate(_credentials("nobody@example.com"))
+
+    assert result is None
+    # The password is still hashed so timing does not leak whether the address
+    # is known.
+    hasher.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_a_disabled_password_login_is_rejected_before_resolution() -> None:
+    lookup = MagicMock()
+    with (
+        patch(f"{_AUTH_MODULE}.MULTI_TENANT", False),
+        patch(f"{_AUTH_MODULE}.get_security_settings") as settings,
+        patch(f"{_AUTH_MODULE}.fetch_ee_implementation_or_noop", return_value=lookup),
+        patch(f"{_AUTH_MODULE}.emit_audit_event"),
+    ):
+        settings.return_value.password_auth_enabled = False
+        with pytest.raises(Exception, match="PASSWORD_LOGIN_DISABLED"):
+            await _manager().authenticate(_credentials("user@example.com"))
+
+    lookup.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_asyncmock_is_not_required_for_the_lookup() -> None:
+    """The resolver is synchronous. Awaiting it would raise TypeError and be
+    swallowed as a credential failure, hiding every routing error."""
+    lookup = MagicMock(return_value="tenant_abc")
+    with (
+        patch(f"{_AUTH_MODULE}.MULTI_TENANT", True),
+        patch(f"{_AUTH_MODULE}.fetch_ee_implementation_or_noop", return_value=lookup),
+        patch(f"{_AUTH_MODULE}.emit_audit_event"),
+        patch(
+            f"{_AUTH_MODULE}.get_async_session_context_manager",
+            side_effect=RuntimeError("stop after resolution"),
+        ),
+        patch(f"{_AUTH_MODULE}.SQLAlchemyUserDatabase", AsyncMock()),
+    ):
+        with pytest.raises(RuntimeError, match="stop after resolution"):
+            await _manager().authenticate(_credentials("user@example.com"))
+
+    lookup.assert_called_once_with(email="user@example.com")

--- a/backend/tests/unit/onyx/auth/test_user_registration.py
+++ b/backend/tests/unit/onyx/auth/test_user_registration.py
@@ -45,6 +45,7 @@ def mock_async_session() -> MagicMock:
     session.scalar = AsyncMock()
     session.commit = AsyncMock()
     session.rollback = AsyncMock()
+    session.run_sync = AsyncMock(return_value=None)
     return session
 
 
@@ -584,7 +585,10 @@ class TestOAuthDottedGmail:
         mock_session_manager.return_value = _AsyncSessionContextManager(
             mock_async_session
         )
-        mock_fetch_ee.return_value = AsyncMock(return_value="test_tenant")
+        provision_tenant = AsyncMock(return_value="test_tenant")
+        mock_fetch_ee.side_effect = lambda _module, attribute, _default: (
+            provision_tenant if attribute == "get_or_provision_tenant" else MagicMock()
+        )
         mock_verify_domain.return_value = None
 
         user_manager = UserManager(MagicMock())
@@ -671,7 +675,10 @@ class TestOAuthPlaceholderPromotion:
         mock_session_manager.return_value = _AsyncSessionContextManager(
             mock_async_session
         )
-        mock_fetch_ee.return_value = AsyncMock(return_value="test_tenant")
+        provision_tenant = AsyncMock(return_value="test_tenant")
+        mock_fetch_ee.side_effect = lambda _module, attribute, _default: (
+            provision_tenant if attribute == "get_or_provision_tenant" else MagicMock()
+        )
 
         placeholder = MagicMock(id="placeholder-id", email="synced@corp.com")
         placeholder.account_type = AccountType.EXT_PERM_USER
@@ -915,3 +922,7 @@ class TestPasswordAuthKillSwitch:
             pass
 
         mock_fetch_ee.assert_called()
+        assert mock_fetch_ee.call_args_list[0].args[:2] == (
+            "onyx.db.user_tenant_mapping",
+            "get_tenant_id_for_email",
+        )

--- a/backend/tests/unit/onyx/auth/test_verify_email_invite.py
+++ b/backend/tests/unit/onyx/auth/test_verify_email_invite.py
@@ -93,6 +93,20 @@ def test_whitelist_skips_check_for_real_member(
     verify_email_in_whitelist("member@example.com", "public")
 
 
+def test_whitelist_recognizes_renamed_member_by_oauth_subject(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    member = MagicMock()
+    member.account_type = AccountType.STANDARD
+    _patch_whitelist_deps(monkeypatch, None)
+    by_subject = MagicMock(return_value=member)
+    monkeypatch.setattr(users, "get_user_by_oauth_account", by_subject)
+
+    verify_email_in_whitelist("renamed@example.com", "public", "google", "sub-123")
+
+    by_subject.assert_called_once()
+
+
 def test_whitelist_enforces_for_unknown_email(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Description

Third layer for #13553, stacked on #13579. The behavior fix for Cloud routing.

Tenant resolution tries the stable IdP subject before the email, via a single `resolve_tenant_id` shared by the login flow and the `new_team` redirect. Any provider the user ever authenticated with routes them to their workspace, so a renamed user resolves to their existing tenant instead of being provisioned an empty one. Email remains the fallback for password logins and unlinked rows.

A subject whose mapping was deactivated still resolves. Leaving a workspace deletes the row outright, so an inactive linked row is a standing membership that had to yield the address it was filed under. It ranks behind an active email membership, which is where an admin-initiated workspace move lands.

Several pending email invitations still fail closed, so a login never joins a workspace the user did not accept.

Invitation acceptance moves the authenticated user's subject links to the accepted workspace. Email-based approval never moves links, because approval does not prove the address still belongs to the same identity.

Also drops the blanket `except` in `get_tenant_id_for_email` that turned transient DB errors into tenant provisioning.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
