### PR TITLE
feat(auth): treat a user's prior addresses as the same principal

### DIFF
--- a/backend/ee/onyx/db/scim.py
+++ b/backend/ee/onyx/db/scim.py
@@ -43,6 +43,7 @@ from onyx.db.models import (
     UserGroup,
     UserRole,
 )
+from onyx.db.users import reconcile_user_email__no_commit
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -250,9 +251,14 @@ class ScimDAL(DAL):
         role: UserRole | None = None,
         account_type: AccountType | None = None,
     ) -> None:
-        """Update user attributes. Only sets fields that are provided."""
+        """Update user attributes. Only sets fields that are provided.
+
+        A rename runs the same reconciliation a login-driven one does, so the
+        replaced address keeps reaching documents whose indexed ACLs still name
+        it and every other row keyed by the address moves with it.
+        """
         if email is not None:
-            user.email = email
+            reconcile_user_email__no_commit(user.id, email, self._session)
         if is_active is not None:
             user.is_active = is_active
         if personal_name is not None:

--- a/backend/onyx/access/access.py
+++ b/backend/onyx/access/access.py
@@ -121,10 +121,18 @@ def _get_acl_for_user(
     matches one entry in the returned set.
 
     Anonymous users only have access to public documents.
+
+    Addresses the user was renamed away from match too. Indexed ACLs keep
+    naming the old one until the source system re-syncs, and the alias is
+    revoked as soon as the address belongs to somebody else.
     """
     if user.is_anonymous:
         return {PUBLIC_DOC_PAT}
-    return {prefix_user_email(user.email), PUBLIC_DOC_PAT}
+    return {
+        prefix_user_email(user.email),
+        *(prefix_user_email(email) for email in user.prior_emails),
+        PUBLIC_DOC_PAT,
+    }
 
 
 def get_acl_for_user(user: User, db_session: Session | None = None) -> set[str]:

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -30,12 +30,15 @@ from sqlalchemy import (
     desc,
     event,
     func,
+    inspect,
     text,
     true,
+    update,
 )
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.engine import Connection
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.orm import (
     DeclarativeBase,
@@ -339,10 +342,9 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
         Boolean, nullable=True, default=None
     )
 
-    # Addresses this user was renamed away from, until each one's ACL repair
-    # completes. Never grants access. An entry lets a later login re-submit a
-    # lost repair and reserves the address against another user claiming it
-    # mid-repair. `expire_prior_emails` closes entries out.
+    # Addresses this user was renamed away from. They still match indexed ACLs
+    # that name them, so each one grants access until another identity claims
+    # the address.
     prior_emails: Mapped[list[str]] = mapped_column(
         postgresql.ARRAY(String), nullable=False, default=list, server_default="{}"
     )
@@ -4520,6 +4522,46 @@ class KVStore(Base):
     encrypted_value: Mapped[SensitiveValue[dict[str, Any]] | None] = mapped_column(
         EncryptedJson(), nullable=True, deferred=True
     )
+
+
+def _release_prior_email_claim(
+    email: str, connection: Connection, *, user_id: UUID | None = None
+) -> None:
+    """Revoke the alias grant when a different identity takes the address.
+
+    A prior address keeps granting its former holder access, so it has to stop
+    the moment it legitimately belongs to someone else.
+    """
+    normalized_email = email.lower()
+    release = (
+        update(User)
+        .where(User.prior_emails.contains([normalized_email]))
+        .values(prior_emails=func.array_remove(User.prior_emails, normalized_email))
+    )
+    if user_id is not None:
+        release = release.where(User.id != user_id)  # ty: ignore[invalid-argument-type]
+
+    connection.execute(release)
+
+
+# Claiming an address anywhere revokes it as anyone else's alias.
+@event.listens_for(User, "before_insert")
+def _release_inserted_user_email(
+    mapper: Mapper,  # noqa: ARG001
+    connection: Connection,
+    target: User,
+) -> None:
+    _release_prior_email_claim(target.email, connection)
+
+
+@event.listens_for(User, "before_update")
+def _release_updated_user_email(
+    mapper: Mapper,  # noqa: ARG001
+    connection: Connection,
+    target: User,
+) -> None:
+    if inspect(target).attrs.email.history.has_changes():
+        _release_prior_email_claim(target.email, connection, user_id=target.id)
 
 
 class EncryptedKeyValueStore(Base):

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -4,7 +4,8 @@ from uuid import UUID
 
 from fastapi import HTTPException
 from fastapi_users.password import PasswordHelper
-from sqlalchemy import Select, case, func, select
+from sqlalchemy import Select, case, delete, func, literal, select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, lazyload, selectinload
 from sqlalchemy.sql import expression
@@ -23,11 +24,14 @@ from onyx.db.enums import AccountType
 from onyx.db.models import (
     DocumentSet,
     DocumentSet__User,
+    MCPConnectionConfig,
+    MCPServer,
     OAuthAccount,
     Persona,
     Persona__User,
     SamlAccount,
     User,
+    User__ExternalUserGroupId,
     User__UserGroup,
     UserGroup,
 )
@@ -356,6 +360,123 @@ def get_user_by_oauth_account(
         )
         .first()
     )
+
+
+def build_email_reconcile_update(user: User, new_email: str) -> dict[str, Any] | None:
+    """Fields that move `user` onto `new_email`, or None when they already match
+    case-insensitively.
+
+    The replaced address is kept in `prior_emails`, which keeps matching the
+    documents whose indexed ACLs still name it.
+    """
+    current_email = user.email.lower()
+    new_email = new_email.lower()
+    if current_email == new_email:
+        return None
+
+    # Re-adopting an old address makes it current, so it stops being an alias.
+    kept = [
+        email.lower()
+        for email in user.prior_emails
+        if email.lower() not in (new_email, current_email)
+    ]
+    return {"email": new_email, "prior_emails": [*kept, current_email]}
+
+
+def reconcile_user_email__no_commit(
+    user_id: UUID, new_email: str, db_session: Session
+) -> tuple[str, list[str]] | None:
+    """Move a user and their email-keyed rows in one transaction.
+
+    Rows are locked so a concurrent login builds `prior_emails` from the latest
+    address. Returns None when the address was already current, which does not
+    mean nothing changed: a shadow user may still have been merged in.
+    """
+    normalized_new_email = new_email.lower()
+    users = (
+        db_session.query(User)
+        .filter(
+            or_(
+                User.id == user_id,  # ty: ignore[invalid-argument-type]
+                func.lower(User.email) == normalized_new_email,
+            )
+        )
+        .order_by(User.id)  # ty: ignore[invalid-argument-type]
+        .populate_existing()
+        .with_for_update(of=User)
+        .all()
+    )
+    user = next((candidate for candidate in users if candidate.id == user_id), None)
+    if user is None:
+        raise ValueError(f"User {user_id} disappeared during email reconciliation")
+
+    shadow_user = next(
+        (
+            candidate
+            for candidate in users
+            if candidate.id != user_id
+            and candidate.account_type == AccountType.EXT_PERM_USER
+            and candidate.role == UserRole.EXT_PERM_USER
+            and not candidate.oauth_accounts
+        ),
+        None,
+    )
+    if shadow_user is not None:
+        membership_insert = pg_insert(User__ExternalUserGroupId).from_select(
+            ["user_id", "external_user_group_id", "cc_pair_id", "stale"],
+            select(
+                literal(user_id),
+                User__ExternalUserGroupId.external_user_group_id,
+                User__ExternalUserGroupId.cc_pair_id,
+                User__ExternalUserGroupId.stale,
+            ).where(User__ExternalUserGroupId.user_id == shadow_user.id),
+        )
+        db_session.execute(
+            membership_insert.on_conflict_do_update(
+                index_elements=[
+                    User__ExternalUserGroupId.user_id,
+                    User__ExternalUserGroupId.external_user_group_id,
+                    User__ExternalUserGroupId.cc_pair_id,
+                ],
+                set_={
+                    "stale": User__ExternalUserGroupId.stale
+                    & membership_insert.excluded.stale
+                },
+            )
+        )
+        db_session.execute(
+            delete(User__ExternalUserGroupId).where(
+                User__ExternalUserGroupId.user_id == shadow_user.id
+            )
+        )
+        db_session.delete(shadow_user)
+        db_session.flush()
+        logger.info(
+            "Merged external-permission shadow user %s into user %s",
+            shadow_user.id,
+            user_id,
+        )
+
+    email_update = build_email_reconcile_update(user, normalized_new_email)
+    if email_update is None:
+        return None
+
+    old_email = user.email
+    prior_emails = list(email_update["prior_emails"])
+
+    user.email = normalized_new_email
+    user.prior_emails = prior_emails
+    db_session.execute(
+        update(MCPServer)
+        .where(MCPServer.owner == old_email)
+        .values(owner=normalized_new_email)
+    )
+    db_session.execute(
+        update(MCPConnectionConfig)
+        .where(MCPConnectionConfig.user_email == old_email)
+        .values(user_email=normalized_new_email)
+    )
+    return old_email, prior_emails
 
 
 def fetch_user_by_id(

--- a/backend/tests/external_dependency_unit/db/test_prior_email_claim_release.py
+++ b/backend/tests/external_dependency_unit/db/test_prior_email_claim_release.py
@@ -1,0 +1,150 @@
+"""Guards the alias release against real rows rather than mocked calls.
+
+A prior address keeps granting its former holder access to documents whose
+indexed ACLs still name it. That grant is only safe while the address belongs to
+nobody else, so claiming it has to strip it from every other user in the same
+flush. These read the other user's row back from Postgres, which is the only way
+to catch the listener firing on the wrong statement or the `array_remove` and
+`contains` predicates disagreeing about case.
+"""
+
+from collections.abc import Generator
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.auth.schemas import UserRole
+from onyx.db.enums import AccountType
+from onyx.db.models import User
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+@pytest.fixture
+def users_to_clean(db_session: Session) -> Generator[list[User], None, None]:
+    created: list[User] = []
+    yield created
+    for user in created:
+        db_session.delete(user)
+    db_session.commit()
+
+
+def _aliased_user(db_session: Session, prefix: str, prior_emails: list[str]) -> User:
+    user = create_test_user(db_session, prefix)
+    user.prior_emails = prior_emails
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_inserting_a_user_strips_the_address_from_other_aliases(
+    db_session: Session, users_to_clean: list[User]
+) -> None:
+    retired = f"retired_{uuid4().hex[:8]}@example.com"
+    former_holder = _aliased_user(db_session, "former", [retired])
+    users_to_clean.append(former_holder)
+
+    claimant = User(
+        id=uuid4(),
+        email=retired,
+        hashed_password="unused",
+        is_active=True,
+        is_verified=True,
+        role=UserRole.BASIC,
+        account_type=AccountType.STANDARD,
+    )
+    db_session.add(claimant)
+    users_to_clean.append(claimant)
+    db_session.commit()
+
+    db_session.refresh(former_holder)
+    assert former_holder.prior_emails == []
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_renaming_onto_the_address_strips_it_from_other_aliases(
+    db_session: Session, users_to_clean: list[User]
+) -> None:
+    retired = f"retired_{uuid4().hex[:8]}@example.com"
+    former_holder = _aliased_user(db_session, "former", [retired])
+    claimant = create_test_user(db_session, "claimant")
+    users_to_clean.extend([former_holder, claimant])
+
+    claimant.email = retired
+    db_session.commit()
+
+    db_session.refresh(former_holder)
+    assert former_holder.prior_emails == []
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_a_claim_keeps_the_claimants_own_aliases(
+    db_session: Session, users_to_clean: list[User]
+) -> None:
+    """The update excludes the claiming row, or a user renaming back to an
+    address they already hold as an alias would erase their own history."""
+    retired = f"retired_{uuid4().hex[:8]}@example.com"
+    readopted = f"readopted_{uuid4().hex[:8]}@example.com"
+    claimant = _aliased_user(db_session, "claimant", [retired, readopted])
+    users_to_clean.append(claimant)
+
+    claimant.email = readopted
+    db_session.commit()
+
+    db_session.refresh(claimant)
+    assert claimant.prior_emails == [retired, readopted]
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_only_the_claimed_address_is_released(
+    db_session: Session, users_to_clean: list[User]
+) -> None:
+    claimed = f"claimed_{uuid4().hex[:8]}@example.com"
+    untouched = f"untouched_{uuid4().hex[:8]}@example.com"
+    former_holder = _aliased_user(db_session, "former", [untouched, claimed])
+    claimant = create_test_user(db_session, "claimant")
+    users_to_clean.extend([former_holder, claimant])
+
+    claimant.email = claimed
+    db_session.commit()
+
+    db_session.refresh(former_holder)
+    assert former_holder.prior_emails == [untouched]
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_the_release_is_case_insensitive(
+    db_session: Session, users_to_clean: list[User]
+) -> None:
+    """Aliases are stored lowercased, so a claim arriving in mixed case still
+    has to match. `@validates` normalizes the claimant, and the release
+    lowercases before comparing."""
+    retired = f"retired_{uuid4().hex[:8]}@example.com"
+    former_holder = _aliased_user(db_session, "former", [retired])
+    claimant = create_test_user(db_session, "claimant")
+    users_to_clean.extend([former_holder, claimant])
+
+    claimant.email = retired.upper()
+    db_session.commit()
+
+    db_session.refresh(former_holder)
+    assert former_holder.prior_emails == []
+    db_session.refresh(claimant)
+    assert claimant.email == retired
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_an_unrelated_rename_releases_nothing(
+    db_session: Session, users_to_clean: list[User]
+) -> None:
+    retired = f"retired_{uuid4().hex[:8]}@example.com"
+    former_holder = _aliased_user(db_session, "former", [retired])
+    claimant = create_test_user(db_session, "claimant")
+    users_to_clean.extend([former_holder, claimant])
+
+    claimant.email = f"elsewhere_{uuid4().hex[:8]}@example.com"
+    db_session.commit()
+
+    db_session.refresh(former_holder)
+    assert former_holder.prior_emails == [retired]

--- a/backend/tests/unit/onyx/access/test_acl_prior_emails.py
+++ b/backend/tests/unit/onyx/access/test_acl_prior_emails.py
@@ -1,0 +1,67 @@
+"""Guards that a renamed user keeps matching their old address.
+
+Indexed ACLs keep naming the address the source system knew, so matching only
+the current one locks a renamed user out of their own documents until every
+connector re-syncs. Treating prior addresses as the same principal is what
+makes a rename invisible to search. It is safe only because the address stops
+being an alias the moment another identity claims it.
+"""
+
+from types import SimpleNamespace
+from typing import cast
+
+from sqlalchemy.orm import Session
+
+from onyx.access.access import _get_acl_for_user
+from onyx.access.utils import prefix_user_email
+from onyx.configs.constants import PUBLIC_DOC_PAT
+from onyx.db.models import User
+
+
+def _user(email: str, prior_emails: list[str], is_anonymous: bool = False) -> User:
+    return cast(
+        User,
+        SimpleNamespace(
+            email=email, prior_emails=prior_emails, is_anonymous=is_anonymous
+        ),
+    )
+
+
+def _acl(user: User) -> set[str]:
+    return _get_acl_for_user(user, cast(Session, None))
+
+
+def test_the_current_address_always_matches() -> None:
+    assert _acl(_user("current@example.com", [])) == {
+        prefix_user_email("current@example.com"),
+        PUBLIC_DOC_PAT,
+    }
+
+
+def test_a_replaced_address_still_matches() -> None:
+    """The rename case: documents indexed before the rename carry the old
+    address and must stay reachable without waiting on a re-sync."""
+    assert _acl(_user("new@example.com", ["old@example.com"])) == {
+        prefix_user_email("new@example.com"),
+        prefix_user_email("old@example.com"),
+        PUBLIC_DOC_PAT,
+    }
+
+
+def test_every_address_the_user_has_held_matches() -> None:
+    acl = _acl(_user("third@example.com", ["first@example.com", "second@example.com"]))
+
+    assert acl == {
+        prefix_user_email("third@example.com"),
+        prefix_user_email("first@example.com"),
+        prefix_user_email("second@example.com"),
+        PUBLIC_DOC_PAT,
+    }
+
+
+def test_an_anonymous_user_gets_only_public_documents() -> None:
+    """Checked before anything else, so a populated prior_emails on an
+    anonymous principal cannot widen the set."""
+    assert _acl(_user("anon@example.com", ["old@example.com"], is_anonymous=True)) == {
+        PUBLIC_DOC_PAT
+    }

--- a/backend/tests/unit/onyx/db/test_email_reconcile.py
+++ b/backend/tests/unit/onyx/db/test_email_reconcile.py
@@ -1,0 +1,148 @@
+"""Guards how a user is moved onto a new address after an IdP rename.
+
+The replaced address has to land in `prior_emails`, or the user loses every
+document whose indexed ACL still names it until its connector re-syncs.
+"""
+
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from onyx.auth.schemas import UserRole
+from onyx.db.enums import AccountType
+from onyx.db.models import User
+from onyx.db.users import (
+    build_email_reconcile_update,
+    reconcile_user_email__no_commit,
+)
+
+
+def _user(
+    email: str,
+    prior_emails: list[str] | None = None,
+    account_type: AccountType = AccountType.STANDARD,
+) -> User:
+    return cast(
+        User,
+        SimpleNamespace(
+            email=email,
+            prior_emails=prior_emails if prior_emails is not None else [],
+            account_type=account_type,
+            role=(
+                UserRole.EXT_PERM_USER
+                if account_type == AccountType.EXT_PERM_USER
+                else UserRole.BASIC
+            ),
+            oauth_accounts=[],
+        ),
+    )
+
+
+def test_no_update_when_the_address_is_unchanged() -> None:
+    assert (
+        build_email_reconcile_update(_user("same@example.com"), "same@example.com")
+        is None
+    )
+
+
+def test_case_only_difference_is_not_a_change() -> None:
+    assert (
+        build_email_reconcile_update(_user("User@example.com"), "user@example.com")
+        is None
+    )
+
+
+def test_replaced_address_is_retained() -> None:
+    update = build_email_reconcile_update(_user("old@example.com"), "new@example.com")
+
+    assert update == {
+        "email": "new@example.com",
+        "prior_emails": ["old@example.com"],
+    }
+
+
+def test_earlier_addresses_are_kept_alongside() -> None:
+    update = build_email_reconcile_update(
+        _user("second@example.com", ["first@example.com"]), "third@example.com"
+    )
+
+    assert update is not None
+    assert update["prior_emails"] == ["first@example.com", "second@example.com"]
+
+
+def test_a_readopted_address_is_not_duplicated() -> None:
+    update = build_email_reconcile_update(
+        _user("b@example.com", ["a@example.com"]), "a@example.com"
+    )
+
+    assert update is not None
+    assert update == {
+        "email": "a@example.com",
+        "prior_emails": ["b@example.com"],
+    }
+
+
+def test_new_address_is_canonicalized() -> None:
+    update = build_email_reconcile_update(_user("old@example.com"), "NEW@Example.com")
+
+    assert update is not None
+    assert update["email"] == "new@example.com"
+
+
+def test_prior_emails_list_is_rebuilt_not_mutated() -> None:
+    original: list[str] = []
+    user = _user("old@example.com", original)
+
+    build_email_reconcile_update(user, "new@example.com")
+
+    assert original == []
+
+
+def test_reconcile_locks_and_rekeys_email_state_without_committing() -> None:
+    user_id = uuid4()
+    stored_user = _user("second@example.com", ["first@example.com"])
+    stored_user.id = user_id
+    db_session = MagicMock(spec=Session)
+    query = db_session.query.return_value.filter.return_value.order_by.return_value
+    query.populate_existing.return_value.with_for_update.return_value.all.return_value = [
+        stored_user
+    ]
+
+    result = reconcile_user_email__no_commit(user_id, "Third@Example.com", db_session)
+
+    assert result == (
+        "second@example.com",
+        ["first@example.com", "second@example.com"],
+    )
+    assert stored_user.email == "third@example.com"
+    assert stored_user.prior_emails == ["first@example.com", "second@example.com"]
+    query.populate_existing.assert_called_once_with()
+    query.populate_existing.return_value.with_for_update.assert_called_once_with(
+        of=User
+    )
+    assert db_session.execute.call_count == 2
+    db_session.commit.assert_not_called()
+
+
+def test_reconcile_adopts_an_external_permission_shadow() -> None:
+    user_id = uuid4()
+    stored_user = _user("old@example.com")
+    stored_user.id = user_id
+    shadow_user = _user("new@example.com", account_type=AccountType.EXT_PERM_USER)
+    shadow_user.id = uuid4()
+    db_session = MagicMock(spec=Session)
+    query = db_session.query.return_value.filter.return_value.order_by.return_value
+    query.populate_existing.return_value.with_for_update.return_value.all.return_value = [
+        stored_user,
+        shadow_user,
+    ]
+
+    result = reconcile_user_email__no_commit(user_id, "new@example.com", db_session)
+
+    assert result == ("old@example.com", ["old@example.com"])
+    db_session.delete.assert_called_once_with(shadow_user)
+    db_session.flush.assert_called_once_with()
+    assert db_session.execute.call_count == 4

--- a/backend/tests/unit/onyx/db/test_scim_dal.py
+++ b/backend/tests/unit/onyx/db/test_scim_dal.py
@@ -1,11 +1,11 @@
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
 
 from ee.onyx.db.scim import ScimDAL
-from onyx.db.models import ScimGroupMapping, ScimToken, ScimUserMapping
+from onyx.db.models import ScimGroupMapping, ScimToken, ScimUserMapping, User
 from tests.unit.onyx.db.conftest import model_attrs
 
 
@@ -187,3 +187,49 @@ class TestScimDALGroupMappings:
 
         mock_db_session.delete.assert_not_called()
         assert "SCIM group mapping 999 not found" in caplog.text
+
+
+class TestScimDALUserRename:
+    """A SCIM rename goes through the same reconciliation a login-driven one does.
+
+    Rebuilding `prior_emails` from the request's own `User` snapshot loses an
+    alias when two renames overlap, and it leaves the other address-keyed rows
+    behind. The shared path locks and moves them.
+    """
+
+    _RECONCILE = "ee.onyx.db.scim.reconcile_user_email__no_commit"
+
+    def test_a_rename_delegates_to_the_locking_reconcile(
+        self, scim_dal: ScimDAL, mock_db_session: MagicMock
+    ) -> None:
+        user = User(id=uuid4(), email="old@example.com")
+
+        with patch(self._RECONCILE) as reconcile:
+            scim_dal.update_user(user, email="New@Example.com")
+
+        reconcile.assert_called_once_with(user.id, "New@Example.com", mock_db_session)
+
+    def test_the_alias_math_is_not_reimplemented_here(
+        self, scim_dal: ScimDAL, mock_db_session: MagicMock
+    ) -> None:
+        """A case-only change is a no-op, and deciding that is the shared path's
+        job. Pre-filtering here would drift from the login path."""
+        user = User(id=uuid4(), email="user@example.com", prior_emails=["old@e.com"])
+
+        with patch(self._RECONCILE) as reconcile:
+            scim_dal.update_user(user, email="User@Example.com")
+
+        reconcile.assert_called_once_with(user.id, "User@Example.com", mock_db_session)
+        assert user.prior_emails == ["old@e.com"]
+
+    def test_updating_other_fields_never_touches_the_address(
+        self, scim_dal: ScimDAL
+    ) -> None:
+        user = User(id=uuid4(), email="user@example.com", prior_emails=["old@e.com"])
+
+        with patch(self._RECONCILE) as reconcile:
+            scim_dal.update_user(user, is_active=False)
+
+        reconcile.assert_not_called()
+        assert user.email == "user@example.com"
+        assert user.prior_emails == ["old@e.com"]

--- a/backend/tests/unit/onyx/db/test_user_email_alias_release.py
+++ b/backend/tests/unit/onyx/db/test_user_email_alias_release.py
@@ -1,0 +1,82 @@
+"""Guards that claiming an address revokes it as anyone else's alias.
+
+A prior address keeps granting its former holder access to documents whose
+indexed ACLs still name it. That grant is only safe while the address belongs
+to nobody else, so every `User` email write has to release it.
+"""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from sqlalchemy import event
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.engine import Connection
+from sqlalchemy.orm import attributes
+
+from onyx.db import models
+from onyx.db.models import User
+
+
+def test_a_new_user_releases_the_address_from_every_former_holder() -> None:
+    user = User(email="Recycled@Example.com", hashed_password="unused")
+    connection = MagicMock(spec=Connection)
+
+    models._release_inserted_user_email(MagicMock(), connection, user)
+
+    release = connection.execute.call_args.args[0]
+    sql = str(
+        release.compile(
+            dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+        )
+    )
+    assert "array_remove" in sql
+    assert "prior_emails @>" in sql
+    assert "'recycled@example.com'" in sql
+    # A fresh row has no id to exclude, so every holder is released.
+    assert '"user".id !=' not in sql
+
+
+def test_a_rename_releases_the_address_without_touching_the_renamer() -> None:
+    user = User(id=uuid4(), email="old@example.com", hashed_password="unused")
+    attributes.set_committed_value(user, "email", "old@example.com")
+    user.email = "Taken@Example.com"
+    connection = MagicMock(spec=Connection)
+
+    models._release_updated_user_email(MagicMock(), connection, user)
+
+    release = connection.execute.call_args.args[0]
+    sql = str(
+        release.compile(
+            dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+        )
+    )
+    assert "array_remove" in sql
+    assert "'taken@example.com'" in sql
+    assert '"user".id !=' in sql
+
+
+def test_an_unchanged_email_releases_nothing() -> None:
+    user = User(id=uuid4(), email="same@example.com", hashed_password="unused")
+    attributes.set_committed_value(user, "email", "same@example.com")
+    connection = MagicMock(spec=Connection)
+
+    models._release_updated_user_email(MagicMock(), connection, user)
+
+    connection.execute.assert_not_called()
+
+
+def test_both_listeners_are_registered() -> None:
+    """An unregistered listener leaves a stale alias granting access, and nothing
+    else in the flush path would notice."""
+    assert event.contains(User, "before_insert", models._release_inserted_user_email)
+    assert event.contains(User, "before_update", models._release_updated_user_email)
+
+
+def test_an_inserted_address_is_released_from_everyone() -> None:
+    user = User(email="claimed@example.com", hashed_password="unused")
+    connection = MagicMock(spec=Connection)
+
+    with patch.object(models, "_release_prior_email_claim") as release:
+        models._release_inserted_user_email(MagicMock(), connection, user)
+
+    release.assert_called_once_with("claimed@example.com", connection)


### PR DESCRIPTION
## Description

Fourth layer for #13553, stacked on #13580.

Indexed document ACLs name whatever address the source system knew, so after an IdP rename they still name the old one. Matching only the current address locks the user out of their own documents until every connector re-syncs, which can be hours or, for a paused connector, never.

A user's ACL set now includes the addresses they were renamed away from, so a rename is invisible to search. No rewrite, no background repair, no window where access is wrong.

Safe because an alias ends when the address changes hands: inserting or renaming any user onto an address strips it from every other user's `prior_emails` in the same transaction as the claim. Nothing is written into document ACLs, so nothing can drift.

This PR owns the whole lifecycle. `reconcile_user_email__no_commit` records the replaced address under a row lock and moves the rows still keyed by it, `access.py` reads it, and the model listeners release it. SCIM renames go through that same path. The OAuth login path calls it in #13564.

**Replaces the rewrite approach.** Earlier revisions rewrote every indexed ACL onto the new address via a Celery task. That design could not answer which entries belonged to the renamed user once the old address was reassigned. Aliasing removes the premise, and deletes the repair task, the ACL swap, the retry lifecycle, the sync gating, and the email mutex.

**Known limit:** if the external directory reassigns the address and a connector syncs grants under it before any Onyx user claims it, the former holder still matches those documents. Bounded by the new holder's first appearance in Onyx.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
