### PR TITLE
feat(craft): persist model picker selection and recommended-only toggle in localStorage

### DIFF
--- a/web/src/app/craft/components/BuildLLMPopover.test.tsx
+++ b/web/src/app/craft/components/BuildLLMPopover.test.tsx
@@ -9,6 +9,10 @@ jest.mock("@/lib/hooks/useLLMProviderOptions", () => ({
   useLLMProviderOptions: () => ({ llmProviderOptions: [] }),
 }));
 
+jest.mock("@/providers/UserProvider", () => ({
+  useUser: () => ({ user: { id: "test-user" } }),
+}));
+
 Element.prototype.scrollIntoView = jest.fn();
 
 function model(
@@ -72,5 +76,29 @@ describe("BuildLLMPopover recommended models", () => {
     expect(screen.getByText("GPT-5.6 Sol")).toBeInTheDocument();
     expect(screen.getByText("GPT-5.5")).toBeInTheDocument();
     expect(screen.queryByText("GPT-5 Mini")).not.toBeInTheDocument();
+  });
+
+  it("still lists a non-recommended model when it is the current selection", () => {
+    render(
+      <BuildLLMPopover
+        currentSelection={{
+          providerId: 13,
+          providerName: "OpenAI Team",
+          provider: "openai_compatible",
+          modelName: "gpt-5-mini",
+        }}
+        onSelectionChange={jest.fn()}
+        llmProviders={providers}
+      >
+        <button>Choose model</button>
+      </BuildLLMPopover>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose model" }));
+
+    // The selected provider's group auto-expands, revealing the active model
+    // alongside the recommended ones.
+    expect(screen.getByText("GPT-5 Mini")).toBeInTheDocument();
+    expect(screen.getByText("GPT-5.6 Sol")).toBeInTheDocument();
   });
 });

--- a/web/src/app/craft/components/BuildLLMPopover.tsx
+++ b/web/src/app/craft/components/BuildLLMPopover.tsx
@@ -60,14 +60,14 @@ export function BuildLLMPopover({
 }: BuildLLMPopoverProps) {
   const { user } = useUser();
   const userId = user?.id;
-  const [showRecommendedOnly, setShowRecommendedOnly] = useState(() =>
-    getStoredRecommendedModelsOnly(userId)
-  );
-
-  // The user loads asynchronously; re-read their persisted toggle once known.
-  useEffect(() => {
-    setShowRecommendedOnly(getStoredRecommendedModelsOnly(userId));
-  }, [userId]);
+  // Storage is the source of truth for the toggle (the user id it's keyed by
+  // loads asynchronously, so derive at render); state only tracks an
+  // in-session flip, which also writes through to storage.
+  const [recommendedOnlyFlip, setRecommendedOnlyFlip] = useState<
+    boolean | null
+  >(null);
+  const showRecommendedOnly =
+    recommendedOnlyFlip ?? getStoredRecommendedModelsOnly(userId);
   const [isOpen, setIsOpen] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const selectedItemRef = useRef<HTMLDivElement>(null);
@@ -178,7 +178,7 @@ export function BuildLLMPopover({
 
   const handleRecommendedOnlyChange = useCallback(
     (checked: boolean) => {
-      setShowRecommendedOnly(checked);
+      setRecommendedOnlyFlip(checked);
       setStoredRecommendedModelsOnly(userId, checked);
     },
     [userId]

--- a/web/src/app/craft/components/BuildLLMPopover.tsx
+++ b/web/src/app/craft/components/BuildLLMPopover.tsx
@@ -13,6 +13,12 @@ import {
   craftProviderDisplayName,
   isCraftRecommendedModel,
 } from "@/app/craft/onboarding/constants";
+import {
+  getStoredRecommendedModelsOnly,
+  setStoredLlmSelection,
+  setStoredRecommendedModelsOnly,
+} from "@/app/craft/utils/llmPreferences";
+import { useUser } from "@/providers/UserProvider";
 import { getModelIcon } from "@/lib/languageModels";
 import { Section } from "@/layouts/general-layouts";
 import {
@@ -52,7 +58,16 @@ export function BuildLLMPopover({
   children,
   disabled = false,
 }: BuildLLMPopoverProps) {
-  const [showRecommendedOnly, setShowRecommendedOnly] = useState(true);
+  const { user } = useUser();
+  const userId = user?.id;
+  const [showRecommendedOnly, setShowRecommendedOnly] = useState(() =>
+    getStoredRecommendedModelsOnly(userId)
+  );
+
+  // The user loads asynchronously; re-read their persisted toggle once known.
+  useEffect(() => {
+    setShowRecommendedOnly(getStoredRecommendedModelsOnly(userId));
+  }, [userId]);
   const [isOpen, setIsOpen] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const selectedItemRef = useRef<HTMLDivElement>(null);
@@ -62,8 +77,17 @@ export function BuildLLMPopover({
     const options: ModelOption[] = [];
 
     llmProviders?.forEach((provider) => {
+      // Recommended-only still lists the active model so the current pick
+      // (e.g. restored from a stored preference) is never invisible.
+      const isCurrent = (model: ModelConfiguration): boolean =>
+        currentSelection?.providerId === provider.id &&
+        currentSelection.modelName === model.name;
       const models = showRecommendedOnly
-        ? provider.model_configurations.filter(isCraftRecommendedModel)
+        ? provider.model_configurations.filter(
+            (model) =>
+              model.is_visible &&
+              (isCraftRecommendedModel(model) || isCurrent(model))
+          )
         : provider.model_configurations.filter((model) => model.is_visible);
       models.forEach((model) => {
         options.push({
@@ -80,7 +104,7 @@ export function BuildLLMPopover({
     });
 
     return options;
-  }, [showRecommendedOnly, llmProviders]);
+  }, [showRecommendedOnly, llmProviders, currentSelection]);
 
   // Group options by provider
   const groupedOptions = useMemo(() => {
@@ -152,17 +176,27 @@ export function BuildLLMPopover({
     setExpandedGroups(value);
   };
 
+  const handleRecommendedOnlyChange = useCallback(
+    (checked: boolean) => {
+      setShowRecommendedOnly(checked);
+      setStoredRecommendedModelsOnly(userId, checked);
+    },
+    [userId]
+  );
+
   const applySelection = useCallback(
     (option: ModelOption) => {
-      onSelectionChange({
+      const selection: BuildLlmSelection = {
         providerId: option.providerId,
         providerName: option.providerName,
         provider: option.providerKey,
         modelName: option.modelName,
-      });
+      };
+      setStoredLlmSelection(userId, selection);
+      onSelectionChange(selection);
       setIsOpen(false);
     },
-    [onSelectionChange]
+    [userId, onSelectionChange]
   );
 
   const handlePopoverOpenChange = (open: boolean) => {
@@ -219,7 +253,7 @@ export function BuildLLMPopover({
               </Text>
               <Switch
                 checked={showRecommendedOnly}
-                onCheckedChange={setShowRecommendedOnly}
+                onCheckedChange={handleRecommendedOnlyChange}
               />
             </div>
 

--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -43,10 +43,11 @@ import ModelPickerButton from "@/app/craft/components/ModelPickerButton";
 import { useLLMProviders } from "@/lib/languageModels/hooks";
 import {
   BuildLlmSelection,
-  getDefaultLlmSelection,
   hasSupportedCraftProvider,
   resolveSessionLlmSelection,
 } from "@/app/craft/onboarding/constants";
+import { getPreferredLlmSelection } from "@/app/craft/utils/llmPreferences";
+import { useUser } from "@/providers/UserProvider";
 import ScheduledRunBanner, {
   useScheduledRunContext,
 } from "@/app/craft/components/ScheduledRunBanner";
@@ -126,7 +127,9 @@ export default function BuildChatPanel({
   // exists (the model picker stays enabled so admins can connect from it).
   const hasProvider = hasSupportedCraftProvider(llmProviders);
   // Picker shows the session's stored model unless the user picks another.
-  // The pick is keyed by session so it can't leak across sessions.
+  // The pick is keyed by session so it can't leak across sessions; only when
+  // neither exists does the user's persisted preference (or the recommended
+  // default) apply.
   const sessionModel = useMemo<BuildLlmSelection | null>(
     () =>
       resolveSessionLlmSelection(
@@ -139,10 +142,14 @@ export default function BuildChatPanel({
   const [modelBySession, setModelBySession] = useState<
     Record<string, BuildLlmSelection>
   >({});
-  const selectedModel =
-    (sessionId ? modelBySession[sessionId] : undefined) ??
-    sessionModel ??
-    getDefaultLlmSelection(llmProviders);
+  const { user } = useUser();
+  const selectedModel = useMemo(
+    () =>
+      (sessionId ? modelBySession[sessionId] : undefined) ??
+      sessionModel ??
+      getPreferredLlmSelection(user?.id, llmProviders),
+    [sessionId, modelBySession, sessionModel, user?.id, llmProviders]
+  );
 
   const contextUsage = useMemo(() => {
     const usage = session?.contextUsage;

--- a/web/src/app/craft/components/ModelPickerButton.tsx
+++ b/web/src/app/craft/components/ModelPickerButton.tsx
@@ -5,10 +5,9 @@ import { SelectButton } from "@opal/components";
 import { BuildLLMPopover } from "@/app/craft/components/BuildLLMPopover";
 import { useLLMProviders } from "@/lib/languageModels/hooks";
 import { getModelIcon } from "@/lib/languageModels";
-import {
-  BuildLlmSelection,
-  getDefaultLlmSelection,
-} from "@/app/craft/onboarding/constants";
+import { BuildLlmSelection } from "@/app/craft/onboarding/constants";
+import { getPreferredLlmSelection } from "@/app/craft/utils/llmPreferences";
+import { useUser } from "@/providers/UserProvider";
 
 interface ModelPickerButtonProps {
   // null → show the recommended default.
@@ -24,10 +23,11 @@ export default function ModelPickerButton({
   disabled = false,
 }: ModelPickerButtonProps) {
   const { llmProviders } = useLLMProviders();
+  const { user } = useUser();
 
   const effective = useMemo(
-    () => selection ?? getDefaultLlmSelection(llmProviders),
-    [selection, llmProviders]
+    () => selection ?? getPreferredLlmSelection(user?.id, llmProviders),
+    [selection, user?.id, llmProviders]
   );
 
   const displayName = useMemo(() => {

--- a/web/src/app/craft/onboarding/constants.ts
+++ b/web/src/app/craft/onboarding/constants.ts
@@ -3,6 +3,10 @@
 // =============================================================================
 
 import { ModelConfiguration } from "@/lib/languageModels/types";
+import {
+  readStorageItem,
+  writeStorageItem,
+} from "@/app/craft/utils/localStorage";
 
 export interface BuildLlmSelection {
   providerId: number;
@@ -31,12 +35,33 @@ export const CRAFT_PROVIDERS: ProviderKey[] = [
 
 const CRAFT_PROVIDER_KEYS = new Set<string>(CRAFT_PROVIDERS);
 
-interface MinimalLlmProvider {
+export interface MinimalLlmProvider {
   id: number;
   name: string | null;
   provider: string;
   provider_display_name?: string | null;
   model_configurations: ModelConfiguration[];
+}
+
+export function providerHasVisibleModel(
+  provider: MinimalLlmProvider,
+  modelName: string
+): boolean {
+  return provider.model_configurations.some(
+    (model) => model.is_visible && model.name === modelName
+  );
+}
+
+export function toLlmSelection(
+  provider: MinimalLlmProvider,
+  modelName: string
+): BuildLlmSelection {
+  return {
+    providerId: provider.id,
+    providerName: provider.name ?? "",
+    provider: provider.provider,
+    modelName,
+  };
 }
 
 export function craftProviderDisplayName(provider: {
@@ -81,12 +106,7 @@ export function getDefaultLlmSelection(
       isCraftRecommendedModel
     )?.name;
     if (!modelName) continue;
-    return {
-      providerId: provider.id,
-      providerName: provider.name ?? "",
-      provider: provider.provider,
-      modelName,
-    };
+    return toLlmSelection(provider, modelName);
   }
 
   // Must mirror the backend's _select_gateway_default fallback so the picker
@@ -98,12 +118,7 @@ export function getDefaultLlmSelection(
       .map((model) => model.name)
       .sort()[0];
     if (!modelName) continue;
-    return {
-      providerId: provider.id,
-      providerName: provider.name ?? "",
-      provider: provider.provider,
-      modelName,
-    };
+    return toLlmSelection(provider, modelName);
   }
 
   return null;
@@ -130,21 +145,14 @@ export function resolveSessionLlmSelection(
     : (llmProviders.find(
         (candidate) =>
           candidate.provider === agentProvider &&
-          candidate.model_configurations.some(
-            (model) => model.is_visible && model.name === agentModel
-          )
+          providerHasVisibleModel(candidate, agentModel)
       ) ??
       llmProviders.find((candidate) => candidate.provider === agentProvider));
   if (!provider) return null;
   const modelName = isGatewayModel
     ? agentModel.slice(separatorIndex + 1)
     : agentModel;
-  if (
-    isGatewayModel &&
-    !provider.model_configurations.some(
-      (model) => model.is_visible && model.name === modelName
-    )
-  ) {
+  if (isGatewayModel && !providerHasVisibleModel(provider, modelName)) {
     return null;
   }
 
@@ -167,24 +175,10 @@ function craftOnboardingSeenKey(userId: string): string {
   return `onyx:craftOnboardingSeen:${userId}`;
 }
 
-// localStorage access throws when the browser blocks site data; treat that
-// as "not seen" rather than crashing the page.
 export function getCraftOnboardingSeen(userId: string): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    return (
-      window.localStorage.getItem(craftOnboardingSeenKey(userId)) === "true"
-    );
-  } catch {
-    return false;
-  }
+  return readStorageItem(craftOnboardingSeenKey(userId)) === "true";
 }
 
 export function setCraftOnboardingSeen(userId: string): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(craftOnboardingSeenKey(userId), "true");
-  } catch {
-    // Storage unavailable — the intro will re-show next visit.
-  }
+  writeStorageItem(craftOnboardingSeenKey(userId), "true");
 }

--- a/web/src/app/craft/utils/llmPreferences.test.ts
+++ b/web/src/app/craft/utils/llmPreferences.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  getPreferredLlmSelection,
+  getStoredRecommendedModelsOnly,
+  setStoredLlmSelection,
+  setStoredRecommendedModelsOnly,
+} from "@/app/craft/utils/llmPreferences";
+import { ModelConfiguration } from "@/lib/languageModels/types";
+
+const USER = "user-1";
+
+function model(
+  name: string,
+  opts: { visible?: boolean; craft?: boolean } = {}
+): ModelConfiguration {
+  return {
+    name,
+    is_visible: opts.visible ?? true,
+    is_recommended_default: opts.craft ?? false,
+    max_input_tokens: null,
+    supports_image_input: false,
+    supports_reasoning: false,
+    effectiveDisplayName: name,
+  };
+}
+
+function provider(
+  providerType: string,
+  models: ModelConfiguration[],
+  id: number = 1
+) {
+  return {
+    id,
+    name: providerType,
+    provider: providerType,
+    model_configurations: models,
+  };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("recommended-only toggle", () => {
+  it("defaults to true and round-trips", () => {
+    expect(getStoredRecommendedModelsOnly(USER)).toBe(true);
+    setStoredRecommendedModelsOnly(USER, false);
+    expect(getStoredRecommendedModelsOnly(USER)).toBe(false);
+    setStoredRecommendedModelsOnly(USER, true);
+    expect(getStoredRecommendedModelsOnly(USER)).toBe(true);
+  });
+
+  it("is scoped per user", () => {
+    setStoredRecommendedModelsOnly(USER, false);
+    expect(getStoredRecommendedModelsOnly("user-2")).toBe(true);
+  });
+});
+
+describe("getPreferredLlmSelection", () => {
+  it("prefers the stored selection when still available", () => {
+    setStoredLlmSelection(USER, {
+      providerId: 2,
+      providerName: "openai",
+      provider: "openai",
+      modelName: "gpt-4o",
+    });
+    const result = getPreferredLlmSelection(USER, [
+      provider("anthropic", [model("claude-opus-5", { craft: true })], 1),
+      provider("openai", [model("gpt-4o")], 2),
+    ]);
+    expect(result?.modelName).toBe("gpt-4o");
+  });
+
+  it("does not leak one user's pick to another", () => {
+    setStoredLlmSelection(USER, {
+      providerId: 2,
+      providerName: "openai",
+      provider: "openai",
+      modelName: "gpt-4o",
+    });
+    const result = getPreferredLlmSelection("user-2", [
+      provider("anthropic", [model("claude-opus-5", { craft: true })], 1),
+      provider("openai", [model("gpt-4o")], 2),
+    ]);
+    expect(result?.modelName).toBe("claude-opus-5");
+  });
+
+  it("falls back to the recommended default when the stored model is gone", () => {
+    setStoredLlmSelection(USER, {
+      providerId: 2,
+      providerName: "openai",
+      provider: "openai",
+      modelName: "removed-model",
+    });
+    const result = getPreferredLlmSelection(USER, [
+      provider("anthropic", [model("claude-opus-5", { craft: true })], 1),
+    ]);
+    expect(result?.modelName).toBe("claude-opus-5");
+  });
+
+  it("ignores corrupt stored values, including parseable non-objects", () => {
+    const providers = [
+      provider("anthropic", [model("claude-opus-5", { craft: true })], 1),
+    ];
+    for (const raw of ["not json", "null", '"gpt-4o"', "42"]) {
+      window.localStorage.setItem(`onyx:craftLlmSelection:${USER}`, raw);
+      expect(getPreferredLlmSelection(USER, providers)?.modelName).toBe(
+        "claude-opus-5"
+      );
+    }
+  });
+
+  it("uses the default when no user id is known", () => {
+    const result = getPreferredLlmSelection(undefined, [
+      provider("anthropic", [model("claude-opus-5", { craft: true })], 1),
+    ]);
+    expect(result?.modelName).toBe("claude-opus-5");
+  });
+});

--- a/web/src/app/craft/utils/llmPreferences.ts
+++ b/web/src/app/craft/utils/llmPreferences.ts
@@ -1,0 +1,84 @@
+import {
+  BuildLlmSelection,
+  getDefaultLlmSelection,
+  MinimalLlmProvider,
+  providerHasVisibleModel,
+  toLlmSelection,
+} from "@/app/craft/onboarding/constants";
+import {
+  readStorageItem,
+  writeStorageItem,
+} from "@/app/craft/utils/localStorage";
+
+// Model-picker preferences are keyed per user (mirroring the onboarding-seen
+// flag) so picks don't leak across accounts on a shared browser. Without a
+// user id, reads fall back to defaults and writes are dropped.
+
+function llmSelectionKey(userId: string): string {
+  return `onyx:craftLlmSelection:${userId}`;
+}
+
+function recommendedOnlyKey(userId: string): string {
+  return `onyx:craftRecommendedModelsOnly:${userId}`;
+}
+
+export function getStoredRecommendedModelsOnly(
+  userId: string | undefined
+): boolean {
+  if (!userId) return true;
+  return readStorageItem(recommendedOnlyKey(userId)) !== "false";
+}
+
+export function setStoredRecommendedModelsOnly(
+  userId: string | undefined,
+  value: boolean
+): void {
+  if (!userId) return;
+  writeStorageItem(recommendedOnlyKey(userId), String(value));
+}
+
+export function setStoredLlmSelection(
+  userId: string | undefined,
+  selection: BuildLlmSelection
+): void {
+  if (!userId) return;
+  writeStorageItem(llmSelectionKey(userId), JSON.stringify(selection));
+}
+
+function getStoredLlmSelection(
+  userId: string,
+  llmProviders: MinimalLlmProvider[]
+): BuildLlmSelection | null {
+  const raw = readStorageItem(llmSelectionKey(userId));
+  if (!raw) return null;
+  let stored: unknown;
+  try {
+    stored = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof stored !== "object" || stored === null) return null;
+  const { providerId, provider, modelName } =
+    stored as Partial<BuildLlmSelection>;
+  if (typeof modelName !== "string") return null;
+  // Only honor the stored pick if it's still among the user's options.
+  const match = llmProviders.find(
+    (candidate) =>
+      candidate.id === providerId &&
+      candidate.provider === provider &&
+      providerHasVisibleModel(candidate, modelName)
+  );
+  return match ? toLlmSelection(match, modelName) : null;
+}
+
+// The user's last pick when still available, else the recommended default.
+export function getPreferredLlmSelection(
+  userId: string | undefined,
+  llmProviders: MinimalLlmProvider[] | undefined
+): BuildLlmSelection | null {
+  if (!llmProviders) return null;
+  return (
+    (userId ? getStoredLlmSelection(userId, llmProviders) : null) ??
+    getDefaultLlmSelection(llmProviders)
+  );
+}

--- a/web/src/app/craft/utils/localStorage.ts
+++ b/web/src/app/craft/utils/localStorage.ts
@@ -1,0 +1,20 @@
+// localStorage access throws when the browser blocks site data (and is absent
+// during SSR); treat storage as best-effort rather than crashing.
+
+export function readStorageItem(key: string): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function writeStorageItem(key: string, value: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Storage unavailable — the value just won't persist.
+  }
+}


### PR DESCRIPTION
## Description

The Craft model picker now remembers user preferences across visits, stored in localStorage keyed per user (mirroring the existing `craftOnboardingSeen` pattern so picks don't leak across accounts on a shared browser):

- The "Recommended Models Only" toggle persists.
- The last-picked model persists and is used as the default for new sessions — but only if it's still among the user's available (visible) models; otherwise it falls back to the recommended default as before.
- Precedence is unchanged otherwise: an explicit in-session pick wins, then the session's own stored model, then the persisted preference, then the recommended default.

Implementation notes:

- New `craft/utils/llmPreferences.ts` holds the persistence + `getPreferredLlmSelection` resolver; new `craft/utils/localStorage.ts` provides shared SSR-safe/try-catch storage access, which the pre-existing onboarding-seen helpers now also use.
- Extracted `providerHasVisibleModel` / `toLlmSelection` in `onboarding/constants.ts` to dedupe the visibility predicate and selection literal.
- The recommended-only popover list always includes the currently active model, so a restored non-recommended pick is never invisible.
- Corrupt/foreign stored values (bad JSON, `null`, wrong shape) are ignored and fall back to the default.

## How Has This Been Tested?

- New jest suite `craft/utils/llmPreferences.test.ts`: toggle round-trip, per-user scoping, stored-pick preference, fallback when the stored model is gone, corrupt-value handling.
- New `BuildLLMPopover` test: a non-recommended current selection stays visible in recommended-only mode.
- All 31 craft jest suites (228 tests) pass; pre-commit (oxfmt, oxlint, tsc) clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the Craft model picker preferences per user in localStorage so the last selected model and the “Recommended models only” toggle stick across sessions. If a saved model is no longer available, we fall back to the recommended default, and the current model remains visible even in recommended-only mode.

- New Features
  - Persist the “Recommended models only” toggle per user; derive it directly from storage at render and write through on toggle.
  - Persist the last selected model per user; use it only if still visible, otherwise use the recommended default.

- Refactors
  - Added `craft/utils/llmPreferences.ts` with persistence helpers and `getPreferredLlmSelection`; integrated in `ChatPanel` and `ModelPickerButton`.
  - Added SSR-safe `craft/utils/localStorage.ts` and updated onboarding storage; extracted `providerHasVisibleModel` and `toLlmSelection` in onboarding constants.

<sup>Written for commit 7ddc7cbdd441d3209b0442eacc753af9dc0af4bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

