### PR TITLE
fix(craft): disable the sandbox image prepuller in values-localdev

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.7
+version: 0.8.8
 appVersion: latest
 annotations:
   category: Productivity
@@ -16,6 +16,12 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
+    - kind: changed
+      description: values-localdev.yaml now disables the sandbox image prepuller.
+        Local kind clusters side-load the sandbox image (kind load + IfNotPresent),
+        so there is no registry pull to front-run, and with the localdev defaults
+        (:edge, pullPolicy Always) the prepuller would eagerly pull the ~3.3 GB
+        image from Docker Hub onto the kind node. Production values are unchanged.
     - kind: fixed
       description: Fixed "helm upgrade" failing with 'PriorityClass ... value: Forbidden;
         may not be changed in an update' after the sandbox image prepuller landed in

--- a/deployment/helm/charts/onyx/values-localdev.yaml
+++ b/deployment/helm/charts/onyx/values-localdev.yaml
@@ -93,6 +93,12 @@ sandboxProxy:
       cpu: 250m
       memory: 512Mi
 
+# The sandbox image is `kind load`ed with pullPolicy IfNotPresent, so there is
+# no registry pull to front-run — and without the local image overrides the
+# prepuller would eagerly pull the ~3.3 GB :edge image from Docker Hub.
+sandboxImagePrepull:
+  enabled: false
+
 # ---- Secrets ----
 
 auth:


### PR DESCRIPTION
## Description

Disables `sandboxImagePrepull` (on by default since #13490) in the local-dev overlay, and bumps the chart to 0.8.8.

On kind clusters the sandbox image is side-loaded (`kind load` + `IfNotPresent`), so there is no registry pull for the prepuller to front-run — the DaemonSet pod would just idle. Worse, on a plain `k8s-up.sh` install without the local image overrides, the image helper falls back to `onyxdotapp/sandbox:edge` with `pullPolicy: Always`, so the prepuller would eagerly pull the ~3.3 GB image from Docker Hub onto the kind node the moment the chart lands. Production values are unchanged.

## How Has This Been Tested?

`helm template` with the localdev overlay renders nothing from `sandbox-image-prepuller.yaml`; without the overlay it still renders the DaemonSet + NetworkPolicy. The prepuller render tests (`backend/tests/external_dependency_unit/craft_helm/test_sandbox_image_prepuller.py`) use `values-ci.yaml` and are unaffected.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
