### PR TITLE
fix(craft): hide interrupt affordance while a session is restoring

### DIFF
--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -115,6 +115,7 @@ export default function BuildChatPanel({
   const hasSession = useHasSession();
   const isRunning = useIsRunning();
   const displayIsRunning = isRunning || scheduledRunInFlight;
+  const hasInterruptibleTurn = session?.status === "running";
   const wasInterrupted = useWasInterrupted();
   const { setLeftSidebarFolded, leftSidebarFolded, videoBackgroundEnabled } =
     useBuildContext();
@@ -848,7 +849,9 @@ export default function BuildChatPanel({
                     isRunning={displayIsRunning}
                     isInterrupting={isInterrupting}
                     onInterrupt={
-                      scheduledRunInFlight ? undefined : handleInterrupt
+                      hasInterruptibleTurn && !scheduledRunInFlight
+                        ? handleInterrupt
+                        : undefined
                     }
                     disabled={
                       isViewingSubagent || scheduledRunInFlight || !hasProvider


### PR DESCRIPTION
## Description

While a session restores in the sandbox, the input bar showed the interrupt (stop) icon and the "esc to interrupt" helper text even though no stream is running. `loadSession` sets the session status to `"creating"` during restore, `useIsRunning()` counts `"creating"` as running, and ChatPanel passed `onInterrupt` unconditionally — so the interrupt affordance appeared with nothing to interrupt (`interruptStreaming` no-ops unless status is `"running"`).

ChatPanel now only passes `onInterrupt` when the session status is `"running"` (a live turn exists). This hides the stop icon, the helper text, and the Escape handler during restore — and during initial provisioning, where interrupt was equally a no-op. Restores that attach to a genuinely active turn still show the interrupt control, and the send path is unaffected since `streamMessage` sets `"running"` synchronously at submit.

## How Has This Been Tested?

- `pre-commit` (oxfmt, oxlint, TypeScript type check) passes on the touched file.
- Traced all status transitions: restore/provisioning (`"creating"`) hides the affordance; live turns, turn attach on reload, and scheduled-run streams (`"running"`) keep their existing behavior.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the interrupt control (stop icon, ESC hint, and Escape handler) while a session is restoring or provisioning so we don’t show a stop action when nothing is running. ChatPanel now enables interrupt only when `session.status === "running"` and no scheduled run is in flight; active turns are unchanged.

<sup>Written for commit 4c8b3c58467b5e6e56693de1cdc2764852e7bed6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

