### PR TITLE
fix(cli): craft is reachable by flag, not offered in the mode question

### DIFF
--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -1115,11 +1115,12 @@ func (in *installer) explainIncompleteStart(tag, prevTag string) {
 	case prevTag == "":
 		in.warnf("Keep %s: it holds the secrets any volumes created just now were initialized with.",
 			filepath.Join("deployment", ".env"))
-		in.infof("Fix the problem above and re-run `onyx-cli deploy install`, or start clean with `onyx-cli deploy uninstall`.")
+		in.infof("Fix the problem above and re-run %s, or start clean with %s.",
+			in.paint.Accent("onyx-cli deploy install"), in.paint.Accent("onyx-cli deploy uninstall"))
 	case prevTag != tag:
 		in.warnf("Partially deployed: services that started are on %s, the rest are still on %s.", tag, prevTag)
-		in.infof("`.env` stays on %s so a re-run finishes the move; to go back, run `onyx-cli deploy upgrade --tag %s`.",
-			tag, prevTag)
+		in.infof("`.env` stays on %s so a re-run finishes the move; to go back, run %s.",
+			tag, in.paint.Accent(fmt.Sprintf("onyx-cli deploy upgrade --tag %s", prevTag)))
 	}
 }
 
@@ -1251,9 +1252,10 @@ func (in *installer) printFailureDiagnosis(output string) {
 		in.plainf("")
 		in.warnf("This looks like a ulimit failure: the OpenSearch index container requests unlimited memlock, which rootless Docker (and some hosts) can't grant.")
 		in.infof("Fix one of these ways, then re-run:")
-		in.plainf("  • Raise the daemon limits: systemctl --user edit docker → [Service] LimitMEMLOCK=infinity, LimitNOFILE=1048576 → systemctl --user restart docker")
-		in.plainf("    (OpenSearch may also need: sudo sysctl -w vm.max_map_count=262144)")
-		in.plainf("  • Or deploy Lite mode (no OpenSearch): onyx-cli deploy install --lite")
+		in.plainf("  • Raise the daemon limits: %s → [Service] LimitMEMLOCK=infinity, LimitNOFILE=1048576 → %s",
+			in.paint.Accent("systemctl --user edit docker"), in.paint.Accent("systemctl --user restart docker"))
+		in.plainf("    (OpenSearch may also need: %s)", in.paint.Accent("sudo sysctl -w vm.max_map_count=262144"))
+		in.plainf("  • Or deploy Lite mode (no OpenSearch): %s", in.paint.Accent("onyx-cli deploy install --lite"))
 		return
 	}
 	if strings.Contains(lower, "address already in use") || strings.Contains(lower, "port is already allocated") {
@@ -1321,7 +1323,7 @@ func (in *installer) printSuccess(ctx context.Context, hostPort int) {
 	url := fmt.Sprintf("http://localhost:%d", hostPort)
 	headline := "Onyx is ready  →  " + ui.Accent(url)
 	if in.opts.NoWait {
-		headline = "Onyx containers started (still initializing — check: onyx-cli deploy status)"
+		headline = "Onyx containers started (still initializing — check: " + ui.Accent("onyx-cli deploy status") + ")"
 	}
 	lines := []string{
 		headline,

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -533,9 +533,12 @@ func (in *installer) askVersion(ctx context.Context, title, def string) (string,
 	}
 }
 
-// askModeQuestion is the single merged deployment-mode select (mode and
-// Craft in one question). Lite stays the default for new installs, matching
-// install.sh's interactive and --no-prompt behavior.
+// askModeQuestion is the deployment-mode select. Lite stays the default for
+// new installs, matching install.sh's interactive and --no-prompt behavior.
+// Craft is deliberately not offered here: it is reachable with
+// --include-craft, and installs it the same way, but it binds the docker
+// socket and is not yet something to put in front of someone who has not
+// gone looking for it.
 func (in *installer) askModeQuestion() error {
 	if in.opts.Lite {
 		in.infof("Deployment mode: Lite (set via --lite flag)")
@@ -548,15 +551,13 @@ func (in *installer) askModeQuestion() error {
 		[]ui.Option{
 			{Label: "Lite", Hint: "chat, tools, uploads, projects — no vector search (recommended)"},
 			{Label: "Standard", Hint: "full search, connectors, and RAG"},
-			{Label: "Standard + Craft", Hint: "adds AI web-app building (binds the docker socket)"},
 		}, 0)
 	if err != nil {
 		return err
 	}
 	in.lite = choice == 0
-	in.craft = choice == 2
 	if in.wiz != nil {
-		in.wiz.Answer("Mode", []string{"Lite", "Standard", "Std+Craft"}[choice])
+		in.wiz.Answer("Mode", []string{"Lite", "Standard"}[choice])
 	}
 	return nil
 }

--- a/cli/internal/deploy/install/install_test.go
+++ b/cli/internal/deploy/install/install_test.go
@@ -757,6 +757,32 @@ func TestInstallPullFailureRemovesFreshEnv(t *testing.T) {
 	}
 }
 
+// Craft binds the docker socket, so it is something to opt into rather than
+// something to be shown. --include-craft still installs it; the mode question
+// must not put it in front of someone who didn't ask.
+func TestModeQuestionDoesNotOfferCraft(t *testing.T) {
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	deps := testDeps(t, &fakeRunner{handler: healthyDockerHandler}, notFoundServer(t))
+	deps.IOS.IsStdinTTY, deps.IOS.IsStdoutTTY = true, true
+	deps.IOS.In = bytes.NewBufferString(strings.Repeat("\n", 8)) // accept every default
+
+	if err := RunInstall(context.Background(), deps, Options{
+		Dir: t.TempDir(), NoWait: true, Local: true,
+	}); err != nil {
+		t.Fatalf("RunInstall: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+	out := outBuf(deps).String()
+	_, asked, found := strings.Cut(out, "Deployment mode")
+	if !found {
+		t.Fatalf("the mode question was never asked:\n%s", out)
+	}
+	options, _, _ := strings.Cut(asked, "Choose an option")
+	if strings.Contains(options, "Craft") {
+		t.Errorf("the mode question still offers Craft:%s", options)
+	}
+}
+
 // Leaving lite mode has to undo lite's .env adjustments, or the "standard"
 // deployment keeps storing files in Postgres and never starts MinIO.
 func TestInstallRestoresStandardFileStoreWhenLeavingLite(t *testing.T) {

--- a/cli/internal/deploy/install/plan.go
+++ b/cli/internal/deploy/install/plan.go
@@ -13,7 +13,9 @@ func (in *installer) printPlan(defaultTag string) {
 	in.infof("Dry run mode — showing what would happen:")
 	in.plainf("  • Install root: %s (%s)", in.root.Dir, in.root.Source)
 	in.plainf("  • Lite mode: %t", in.lite)
-	in.plainf("  • Include Craft: %t", in.craft)
+	if in.craft {
+		in.plainf("  • Include Craft: true")
+	}
 	in.plainf("  • OS: %s/%s (WSL: %t)", runtime.GOOS, runtime.GOARCH, dockercmd.IsWSL())
 	switch {
 	case in.opts.Offline:

--- a/cli/internal/deploy/install/status.go
+++ b/cli/internal/deploy/install/status.go
@@ -77,7 +77,7 @@ func (in *installer) runStatus(ctx context.Context, jsonOut bool) error {
 		for _, alt := range in.root.Ambiguous {
 			in.infof("(another install exists at %s — pass --dir to inspect it)", alt)
 		}
-		in.infof("Install one with: onyx-cli deploy install")
+		in.infof("Install one with: %s", in.paint.Accent("onyx-cli deploy install"))
 		return exitcodes.New(exitcodes.NotAvailable, "not installed")
 	}
 	st.Installed = true
@@ -128,7 +128,7 @@ func (in *installer) runStatus(ctx context.Context, jsonOut bool) error {
 	in.plainf("  Version (running):  %s", in.orUnknown(st.RunningTag))
 	if drift(st.ManifestTag, st.EnvTag, st.RunningTag) {
 		in.warnf("Version drift detected — the manifest, .env, and running containers disagree.")
-		in.infof("A restart applies .env: onyx-cli deploy stop && onyx-cli deploy install")
+		in.infof("A restart applies .env: %s", in.paint.Accent("onyx-cli deploy stop && onyx-cli deploy install"))
 	}
 	in.plainf("")
 	if len(st.Services) == 0 {

--- a/cli/internal/deploy/install/stop.go
+++ b/cli/internal/deploy/install/stop.go
@@ -42,7 +42,7 @@ func (in *installer) runStop(ctx context.Context) error {
 	}
 	in.successf("Onyx containers stopped (paused)")
 	in.plainf("")
-	in.infof("Start them again with: onyx-cli deploy install")
+	in.infof("Start them again with: %s", in.paint.Accent("onyx-cli deploy install"))
 	return nil
 }
 

--- a/cli/internal/deploy/install/uninstall.go
+++ b/cli/internal/deploy/install/uninstall.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -93,8 +94,8 @@ func (in *installer) runUninstall(ctx context.Context) error {
 					"containers or volumes are still present — %s was left in place so you can retry; pass --force to delete it anyway",
 					in.root.Dir)
 			}
-			in.warnf("Deleting %s anyway (--force) — clean up leftovers with `docker compose -p %s down -v`",
-				in.root.Dir, dockercmd.ProjectName)
+			in.warnf("Deleting %s anyway (--force) — clean up leftovers with %s",
+				in.root.Dir, in.paint.Accent(fmt.Sprintf("docker compose -p %s down -v", dockercmd.ProjectName)))
 		} else {
 			in.successf("Onyx containers and volumes removed")
 		}

--- a/cli/internal/deploy/install/upgrade.go
+++ b/cli/internal/deploy/install/upgrade.go
@@ -132,7 +132,11 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 		} else {
 			in.plainf("  • Upgrade: %s → %s (config ref: %s)", installedTag, targetTag, release.ConfigRef(targetTag))
 		}
-		in.plainf("  • Lite mode: %t, Craft: %t", in.lite, in.craft)
+		craftNote := ""
+		if in.craft {
+			craftNote = ", Craft: true"
+		}
+		in.plainf("  • Lite mode: %t%s", in.lite, craftNote)
 		in.plainf("")
 		in.successf("Dry run complete (no changes made)")
 		return nil


### PR DESCRIPTION
## What

The deployment-mode select in `deploy install` now offers **Lite** and **Standard** only. The third option, "Standard + Craft", is gone.

Craft binds the docker socket. That is not something to put in front of someone who did not go looking for it, and the UI is not ready to make that offer yet.

## What still works

`--include-craft` is unchanged on both `deploy install` and `deploy upgrade`. It stays a documented flag, still implies standard mode, still short-circuits the mode question before the select is reached, and still writes `ENABLE_CRAFT`/`SANDBOX_BACKEND` and pulls in the Craft overlay.

Dropping the `in.craft = choice == 2` assignment is safe because that select is only reached when `opts.IncludeCraft` is false, so `in.craft` is already false at that point.

The dry-run summaries in `plan.go` and `upgrade.go` now name Craft only when it is actually on, instead of printing an `Include Craft: false` line that advertises a mode the UI no longer offers.

Three places still say "Craft" and are deliberately untouched — they report a deployment's real state rather than offering the mode: `status.go` appends `+ craft` only for installs that have it, `upgrade.go` sets the wizard mode to `Std+Craft` only when the deployment already runs it, and `sandbox.go` keeps the docker-socket security warning.

## Tests

`TestModeQuestionDoesNotOfferCraft` drives an interactive install and asserts the rendered option list carries no "Craft". The assertion is scoped to the slice between "Deployment mode" and "Choose an option" — matching against the whole output hits `t.TempDir()`, which embeds the test's own name.

`go build ./...`, `go test ./...`, and pre-commit (golangci-lint, ripsecrets) pass on the touched files.

Follow-up to #13522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide Craft from the `deploy install` mode prompt; only Lite and Standard are shown.
Craft stays opt-in via `--include-craft` on `deploy install` and `deploy upgrade`; dry-run mentions Craft only when enabled, and follow-up commands in install/stop/uninstall/status are now cyan-accented for consistency.

<sup>Written for commit c6294d89f36a05577961729f67ee06a8091dd198. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

