### PR TITLE
fix(scripts): account for Craft in tenant cleanup

### DIFF
--- a/backend/scripts/tenant_cleanup/QUICK_START_NO_BASTION.md
+++ b/backend/scripts/tenant_cleanup/QUICK_START_NO_BASTION.md
@@ -108,7 +108,8 @@ kubectl get po | grep celery-worker-user-file-processing | grep Running
 
 - `tenant_data_YYYYMMDD_HHMMSS.json` - Raw per-tenant data. **Contains real user chat message
   text** (`last_query_text`); keep it out of the repo and off shared storage.
-- `gated_tenants_no_query_3mo_YYYYMMDD_HHMMSS.csv` - List of tenants to clean
+- `gated_tenants_no_query_3mo_YYYYMMDD_HHMMSS.csv` - List of tenants with no recent chat or
+  Craft activity to clean (the filename is retained for compatibility)
 - `cleaned_tenants.csv` - Successfully cleaned tenants with timestamps. Appended across runs, and
   the only record of what was deleted - needed for any later search-index sweep.
 

--- a/backend/scripts/tenant_cleanup/README.md
+++ b/backend/scripts/tenant_cleanup/README.md
@@ -16,6 +16,9 @@ python scripts/tenant_cleanup/analyze_current_tenants.py
 ```
 
 This will create a `.csv` called something like `gated_tenants_no_query_3mo_20251012_161102.csv` in the `backend` dir.
+Despite the legacy filename, tenants are eligible only when both their latest chat query and latest
+Craft session activity are at least three months old. Cached tenant data from before Craft activity
+was collected is ignored automatically.
 
 
 ### Delete all documents within these tenants

--- a/backend/scripts/tenant_cleanup/activity_utils.py
+++ b/backend/scripts/tenant_cleanup/activity_utils.py
@@ -1,0 +1,52 @@
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+
+CRAFT_ACTIVITY_FIELD = "last_craft_activity_time"
+ACTIVITY_CSV_FIELDNAMES = (
+    "last_query_time",
+    CRAFT_ACTIVITY_FIELD,
+    "last_activity_time",
+    "days_since_last_activity",
+)
+
+
+def _parse_activity_time(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def get_last_activity_time(tenant: Mapping[str, object]) -> datetime | None:
+    activity_times = [
+        activity_time
+        for field in ("last_query_time", CRAFT_ACTIVITY_FIELD)
+        if (activity_time := _parse_activity_time(tenant.get(field))) is not None
+    ]
+    return max(activity_times, default=None)
+
+
+def get_activity_csv_values(
+    tenant: Mapping[str, object], now: datetime
+) -> dict[str, object]:
+    last_activity_time = get_last_activity_time(tenant)
+    return {
+        "last_query_time": tenant.get("last_query_time") or "Never",
+        CRAFT_ACTIVITY_FIELD: tenant.get(CRAFT_ACTIVITY_FIELD) or "Never",
+        "last_activity_time": (
+            last_activity_time.isoformat()
+            if last_activity_time is not None
+            else "Never"
+        ),
+        "days_since_last_activity": (
+            str((now - last_activity_time).days)
+            if last_activity_time is not None
+            else "Never"
+        ),
+    }
+
+
+def tenant_data_includes_craft_activity(
+    tenants: Sequence[Mapping[str, object]],
+) -> bool:
+    return all(CRAFT_ACTIVITY_FIELD in tenant for tenant in tenants)

--- a/backend/scripts/tenant_cleanup/analyze_current_tenants.py
+++ b/backend/scripts/tenant_cleanup/analyze_current_tenants.py
@@ -16,6 +16,12 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from scripts.tenant_cleanup.activity_utils import (
+    ACTIVITY_CSV_FIELDNAMES,
+    get_activity_csv_values,
+    get_last_activity_time,
+    tenant_data_includes_craft_activity,
+)
 from scripts.tenant_cleanup.cleanup_utils import find_worker_pod
 
 
@@ -135,7 +141,7 @@ def collect_control_plane_data() -> list[dict[str, Any]]:
 def analyze_tenants(
     tenants: list[dict[str, Any]], control_plane_data: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
-    """Analyze tenant activity data and return gated tenants with no query in last 3 months."""
+    """Return gated tenants with no chat or Craft activity in the last 3 months."""
 
     print(f"\n{'=' * 80}")
     print(f"TENANT ANALYSIS REPORT - {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
@@ -157,68 +163,62 @@ def analyze_tenants(
     three_month_cutoff = datetime.now(timezone.utc) - timedelta(days=90)
 
     # Categorize tenants into 4 groups
-    gated_no_query_3_months = []  # GATED_ACCESS + no query in last 3 months
-    gated_query_1_3_months = []  # GATED_ACCESS + query between 1-3 months
-    gated_query_1_month = []  # GATED_ACCESS + query in last 1 month
+    gated_no_activity_3_months = []
+    gated_activity_1_3_months = []
+    gated_activity_1_month = []
     everyone_else = []  # All other tenants
 
     for tenant in tenants:
         tenant_id = tenant.get("tenant_id")
-        last_query_time = tenant.get("last_query_time")
         tenant_status = control_plane_lookup.get(tenant_id, "UNKNOWN")
 
         is_gated = tenant_status == "GATED_ACCESS"
-
-        # Parse last query time
-        if last_query_time:
-            query_time = datetime.fromisoformat(last_query_time.replace("Z", "+00:00"))
-        else:
-            query_time = None
+        last_activity_time = get_last_activity_time(tenant)
 
         # Categorize
         if is_gated:
-            if query_time is None or query_time <= three_month_cutoff:
-                gated_no_query_3_months.append(tenant)
-            elif query_time <= one_month_cutoff:
-                gated_query_1_3_months.append(tenant)
-            else:  # query_time > one_month_cutoff
-                gated_query_1_month.append(tenant)
+            if last_activity_time is None or last_activity_time <= three_month_cutoff:
+                gated_no_activity_3_months.append(tenant)
+            elif last_activity_time <= one_month_cutoff:
+                gated_activity_1_3_months.append(tenant)
+            else:
+                gated_activity_1_month.append(tenant)
         else:
             everyone_else.append(tenant)
 
     # Calculate document counts for each group
-    gated_no_query_docs = sum(
-        t.get("num_documents", 0) for t in gated_no_query_3_months
+    gated_no_activity_docs = sum(
+        t.get("num_documents", 0) for t in gated_no_activity_3_months
     )
     gated_1_3_month_docs = sum(
-        t.get("num_documents", 0) for t in gated_query_1_3_months
+        t.get("num_documents", 0) for t in gated_activity_1_3_months
     )
-    gated_1_month_docs = sum(t.get("num_documents", 0) for t in gated_query_1_month)
+    gated_1_month_docs = sum(t.get("num_documents", 0) for t in gated_activity_1_month)
     everyone_else_docs = sum(t.get("num_documents", 0) for t in everyone_else)
 
     print("=" * 80)
     print("TENANT CATEGORIZATION BY GATED ACCESS STATUS AND ACTIVITY")
     print("=" * 80)
 
-    print("\n1. GATED_ACCESS + No query in last 3 months:")
-    print(f"   Count: {len(gated_no_query_3_months):,}")
-    print(f"   Total documents: {gated_no_query_docs:,}")
+    print("\n1. GATED_ACCESS + No chat or Craft activity in last 3 months:")
+    print(f"   Count: {len(gated_no_activity_3_months):,}")
+    print(f"   Total documents: {gated_no_activity_docs:,}")
     print(
-        f"   Avg documents per tenant: {gated_no_query_docs / len(gated_no_query_3_months) if gated_no_query_3_months else 0:.2f}"
+        f"   Avg documents per tenant: {gated_no_activity_docs / len(gated_no_activity_3_months) if gated_no_activity_3_months else 0:.2f}"
     )
 
-    print("\n2. GATED_ACCESS + Query between 1-3 months ago:")
-    print(f"   Count: {len(gated_query_1_3_months):,}")
+    print("\n2. GATED_ACCESS + Activity between 1-3 months ago:")
+    print(f"   Count: {len(gated_activity_1_3_months):,}")
     print(f"   Total documents: {gated_1_3_month_docs:,}")
     print(
-        f"   Avg documents per tenant: {gated_1_3_month_docs / len(gated_query_1_3_months) if gated_query_1_3_months else 0:.2f}"
+        f"   Avg documents per tenant: {gated_1_3_month_docs / len(gated_activity_1_3_months) if gated_activity_1_3_months else 0:.2f}"
     )
 
-    print("\n3. GATED_ACCESS + Query in last 1 month:")
-    print(f"   Count: {len(gated_query_1_month):,}")
+    print("\n3. GATED_ACCESS + Activity in last 1 month:")
+    print(f"   Count: {len(gated_activity_1_month):,}")
     print(f"   Total documents: {gated_1_month_docs:,}")
     print(
-        f"   Avg documents per tenant: {gated_1_month_docs / len(gated_query_1_month) if gated_query_1_month else 0:.2f}"
+        f"   Avg documents per tenant: {gated_1_month_docs / len(gated_activity_1_month) if gated_activity_1_month else 0:.2f}"
     )
 
     print("\n4. Everyone else (non-GATED_ACCESS):")
@@ -229,7 +229,7 @@ def analyze_tenants(
     )
 
     total_docs = (
-        gated_no_query_docs
+        gated_no_activity_docs
         + gated_1_3_month_docs
         + gated_1_month_docs
         + everyone_else_docs
@@ -249,7 +249,7 @@ def analyze_tenants(
     top_100 = sorted_tenants[:100]
 
     print(
-        f"\n{'Rank':<6} {'Tenant ID':<45} {'Documents':>12} {'Users':>8} {'Last Query':<12} {'Group'}"
+        f"\n{'Rank':<6} {'Tenant ID':<45} {'Documents':>12} {'Users':>8} {'Last Activity':<13} {'Group'}"
     )
     print("-" * 130)
 
@@ -257,36 +257,31 @@ def analyze_tenants(
         tenant_id = tenant.get("tenant_id", "Unknown")
         num_docs = tenant.get("num_documents", 0)
         num_users = tenant.get("num_users", 0)
-        last_query = tenant.get("last_query_time", "Never")
+        last_activity_time = get_last_activity_time(tenant)
         tenant_status = control_plane_lookup.get(tenant_id, "UNKNOWN")
 
-        # Format the last query time
-        if last_query and last_query != "Never":
-            try:
-                query_dt = datetime.fromisoformat(last_query.replace("Z", "+00:00"))
-                last_query_str = query_dt.strftime("%Y-%m-%d")
-            except Exception:
-                last_query_str = last_query[:10] if len(last_query) > 10 else last_query
-        else:
-            last_query_str = "Never"
+        last_activity_str = (
+            last_activity_time.strftime("%Y-%m-%d")
+            if last_activity_time is not None
+            else "Never"
+        )
 
         # Determine group
         if tenant_status == "GATED_ACCESS":
-            if last_query and last_query != "Never":
-                query_time = datetime.fromisoformat(last_query.replace("Z", "+00:00"))
-                if query_time <= three_month_cutoff:
-                    group = "Gated - No query (3mo)"
-                elif query_time <= one_month_cutoff:
-                    group = "Gated - Query (1-3mo)"
+            if last_activity_time is not None:
+                if last_activity_time <= three_month_cutoff:
+                    group = "Gated - No activity (3mo)"
+                elif last_activity_time <= one_month_cutoff:
+                    group = "Gated - Activity (1-3mo)"
                 else:
-                    group = "Gated - Query (1mo)"
+                    group = "Gated - Activity (1mo)"
             else:
-                group = "Gated - No query (3mo)"
+                group = "Gated - No activity (3mo)"
         else:
             group = f"Other ({tenant_status})"
 
         print(
-            f"{idx:<6} {tenant_id:<45} {num_docs:>12,} {num_users:>8} {last_query_str:<12} {group}"
+            f"{idx:<6} {tenant_id:<45} {num_docs:>12,} {num_users:>8} {last_activity_str:<13} {group}"
         )
 
     # Summary stats for top 100
@@ -326,7 +321,7 @@ def analyze_tenants(
         print(f"  99th percentile: {doc_counts[int(len(doc_counts) * 0.99)]:,}")
         print(f"  Max: {doc_counts[-1]:,}")
 
-    return gated_no_query_3_months
+    return gated_no_activity_3_months
 
 
 def find_recent_tenant_data() -> tuple[list[dict[str, Any]] | None, str | None]:
@@ -354,6 +349,12 @@ def find_recent_tenant_data() -> tuple[list[dict[str, Any]] | None, str | None]:
         with open(most_recent, "r") as f:
             tenant_data = json.load(f)
 
+        if not tenant_data_includes_craft_activity(tenant_data):
+            print(
+                f"\n⚠ Ignoring cached tenant data without Craft activity: {most_recent.name}"
+            )
+            return None, None
+
         return tenant_data, str(most_recent)
 
     return None, None
@@ -362,7 +363,7 @@ def find_recent_tenant_data() -> tuple[list[dict[str, Any]] | None, str | None]:
 def main() -> None:
     # Parse command-line arguments
     parser = argparse.ArgumentParser(
-        description="Analyze tenant data and identify gated tenants with no recent queries"
+        description="Identify gated tenants with no recent chat or Craft activity"
     )
     parser.add_argument(
         "--skip-cache",
@@ -402,8 +403,8 @@ def main() -> None:
                 json.dump(tenant_data, f, indent=2, default=str)
             print(f"\n✓ Raw data saved to: {output_file}")
 
-        # Step 3: Analyze the data and get gated tenants without recent queries
-        gated_no_query_3_months = analyze_tenants(tenant_data, control_plane_data)
+        # Step 3: Analyze the data and get gated tenants without recent activity
+        inactive_tenants = analyze_tenants(tenant_data, control_plane_data)
 
         # Step 4: Export to CSV (sorted by num_documents descending)
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -411,7 +412,7 @@ def main() -> None:
 
         # Sort by num_documents in descending order
         sorted_tenants = sorted(
-            gated_no_query_3_months,
+            inactive_tenants,
             key=lambda t: t.get("num_documents", 0),
             reverse=True,
         )
@@ -421,40 +422,25 @@ def main() -> None:
                 "tenant_id",
                 "num_documents",
                 "num_users",
-                "last_query_time",
-                "days_since_last_query",
+                *ACTIVITY_CSV_FIELDNAMES,
             ]
             writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
             writer.writeheader()
 
             now = datetime.now(timezone.utc)
             for tenant in sorted_tenants:
-                # Calculate days since last query
-                last_query_time = tenant.get("last_query_time")
-                if last_query_time:
-                    try:
-                        query_dt = datetime.fromisoformat(
-                            last_query_time.replace("Z", "+00:00")
-                        )
-                        days_since = str((now - query_dt).days)
-                    except Exception:
-                        days_since = "N/A"
-                else:
-                    days_since = "Never"
-
                 writer.writerow(
                     {
                         "tenant_id": tenant.get("tenant_id", ""),
                         "num_documents": tenant.get("num_documents", 0),
                         "num_users": tenant.get("num_users", 0),
-                        "last_query_time": last_query_time or "Never",
-                        "days_since_last_query": days_since,
+                        **get_activity_csv_values(tenant, now),
                     }
                 )
 
         print(f"\n✓ CSV exported to: {csv_file}")
         print(
-            f"  Total gated tenants with no query in last 3 months: {len(gated_no_query_3_months)}"
+            f"  Total gated tenants with no chat or Craft activity in last 3 months: {len(inactive_tenants)}"
         )
 
     except subprocess.CalledProcessError as e:

--- a/backend/scripts/tenant_cleanup/no_bastion_analyze_tenants.py
+++ b/backend/scripts/tenant_cleanup/no_bastion_analyze_tenants.py
@@ -19,6 +19,12 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from scripts.tenant_cleanup.activity_utils import (
+    ACTIVITY_CSV_FIELDNAMES,
+    get_activity_csv_values,
+    get_last_activity_time,
+    tenant_data_includes_craft_activity,
+)
 from scripts.tenant_cleanup.no_bastion_cleanup_utils import (
     find_background_pod,
     find_worker_pod,
@@ -166,7 +172,7 @@ with engine.connect() as conn:
 def analyze_tenants(
     tenants: list[dict[str, Any]], control_plane_data: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
-    """Analyze tenant activity data and return gated tenants with no query in last 3 months."""
+    """Return gated tenants with no chat or Craft activity in the last 3 months."""
 
     print(f"\n{'=' * 80}")
     print(f"TENANT ANALYSIS REPORT - {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
@@ -186,68 +192,62 @@ def analyze_tenants(
     three_month_cutoff = datetime.now(timezone.utc) - timedelta(days=90)
 
     # Categorize tenants into 4 groups
-    gated_no_query_3_months = []  # GATED_ACCESS + no query in last 3 months
-    gated_query_1_3_months = []  # GATED_ACCESS + query between 1-3 months
-    gated_query_1_month = []  # GATED_ACCESS + query in last 1 month
+    gated_no_activity_3_months = []
+    gated_activity_1_3_months = []
+    gated_activity_1_month = []
     everyone_else = []  # All other tenants
 
     for tenant in tenants:
         tenant_id = tenant.get("tenant_id")
-        last_query_time = tenant.get("last_query_time")
         tenant_status = control_plane_lookup.get(tenant_id, "UNKNOWN")
 
         is_gated = tenant_status == "GATED_ACCESS"
-
-        # Parse last query time
-        if last_query_time:
-            query_time = datetime.fromisoformat(last_query_time.replace("Z", "+00:00"))
-        else:
-            query_time = None
+        last_activity_time = get_last_activity_time(tenant)
 
         # Categorize
         if is_gated:
-            if query_time is None or query_time <= three_month_cutoff:
-                gated_no_query_3_months.append(tenant)
-            elif query_time <= one_month_cutoff:
-                gated_query_1_3_months.append(tenant)
-            else:  # query_time > one_month_cutoff
-                gated_query_1_month.append(tenant)
+            if last_activity_time is None or last_activity_time <= three_month_cutoff:
+                gated_no_activity_3_months.append(tenant)
+            elif last_activity_time <= one_month_cutoff:
+                gated_activity_1_3_months.append(tenant)
+            else:
+                gated_activity_1_month.append(tenant)
         else:
             everyone_else.append(tenant)
 
     # Calculate document counts for each group
-    gated_no_query_docs = sum(
-        t.get("num_documents", 0) for t in gated_no_query_3_months
+    gated_no_activity_docs = sum(
+        t.get("num_documents", 0) for t in gated_no_activity_3_months
     )
     gated_1_3_month_docs = sum(
-        t.get("num_documents", 0) for t in gated_query_1_3_months
+        t.get("num_documents", 0) for t in gated_activity_1_3_months
     )
-    gated_1_month_docs = sum(t.get("num_documents", 0) for t in gated_query_1_month)
+    gated_1_month_docs = sum(t.get("num_documents", 0) for t in gated_activity_1_month)
     everyone_else_docs = sum(t.get("num_documents", 0) for t in everyone_else)
 
     print("=" * 80)
     print("TENANT CATEGORIZATION BY GATED ACCESS STATUS AND ACTIVITY")
     print("=" * 80)
 
-    print("\n1. GATED_ACCESS + No query in last 3 months:")
-    print(f"   Count: {len(gated_no_query_3_months):,}")
-    print(f"   Total documents: {gated_no_query_docs:,}")
+    print("\n1. GATED_ACCESS + No chat or Craft activity in last 3 months:")
+    print(f"   Count: {len(gated_no_activity_3_months):,}")
+    print(f"   Total documents: {gated_no_activity_docs:,}")
     print(
-        f"   Avg documents per tenant: {gated_no_query_docs / len(gated_no_query_3_months) if gated_no_query_3_months else 0:.2f}"
+        f"   Avg documents per tenant: {gated_no_activity_docs / len(gated_no_activity_3_months) if gated_no_activity_3_months else 0:.2f}"
     )
 
-    print("\n2. GATED_ACCESS + Query between 1-3 months ago:")
-    print(f"   Count: {len(gated_query_1_3_months):,}")
+    print("\n2. GATED_ACCESS + Activity between 1-3 months ago:")
+    print(f"   Count: {len(gated_activity_1_3_months):,}")
     print(f"   Total documents: {gated_1_3_month_docs:,}")
     print(
-        f"   Avg documents per tenant: {gated_1_3_month_docs / len(gated_query_1_3_months) if gated_query_1_3_months else 0:.2f}"
+        f"   Avg documents per tenant: {gated_1_3_month_docs / len(gated_activity_1_3_months) if gated_activity_1_3_months else 0:.2f}"
     )
 
-    print("\n3. GATED_ACCESS + Query in last 1 month:")
-    print(f"   Count: {len(gated_query_1_month):,}")
+    print("\n3. GATED_ACCESS + Activity in last 1 month:")
+    print(f"   Count: {len(gated_activity_1_month):,}")
     print(f"   Total documents: {gated_1_month_docs:,}")
     print(
-        f"   Avg documents per tenant: {gated_1_month_docs / len(gated_query_1_month) if gated_query_1_month else 0:.2f}"
+        f"   Avg documents per tenant: {gated_1_month_docs / len(gated_activity_1_month) if gated_activity_1_month else 0:.2f}"
     )
 
     print("\n4. Everyone else (non-GATED_ACCESS):")
@@ -258,7 +258,7 @@ def analyze_tenants(
     )
 
     total_docs = (
-        gated_no_query_docs
+        gated_no_activity_docs
         + gated_1_3_month_docs
         + gated_1_month_docs
         + everyone_else_docs
@@ -278,7 +278,7 @@ def analyze_tenants(
     top_100 = sorted_tenants[:100]
 
     print(
-        f"\n{'Rank':<6} {'Tenant ID':<45} {'Documents':>12} {'Users':>8} {'Last Query':<12} {'Group'}"
+        f"\n{'Rank':<6} {'Tenant ID':<45} {'Documents':>12} {'Users':>8} {'Last Activity':<13} {'Group'}"
     )
     print("-" * 130)
 
@@ -286,36 +286,31 @@ def analyze_tenants(
         tenant_id = tenant.get("tenant_id", "Unknown")
         num_docs = tenant.get("num_documents", 0)
         num_users = tenant.get("num_users", 0)
-        last_query = tenant.get("last_query_time", "Never")
+        last_activity_time = get_last_activity_time(tenant)
         tenant_status = control_plane_lookup.get(tenant_id, "UNKNOWN")
 
-        # Format the last query time
-        if last_query and last_query != "Never":
-            try:
-                query_dt = datetime.fromisoformat(last_query.replace("Z", "+00:00"))
-                last_query_str = query_dt.strftime("%Y-%m-%d")
-            except Exception:
-                last_query_str = last_query[:10] if len(last_query) > 10 else last_query
-        else:
-            last_query_str = "Never"
+        last_activity_str = (
+            last_activity_time.strftime("%Y-%m-%d")
+            if last_activity_time is not None
+            else "Never"
+        )
 
         # Determine group
         if tenant_status == "GATED_ACCESS":
-            if last_query and last_query != "Never":
-                query_time = datetime.fromisoformat(last_query.replace("Z", "+00:00"))
-                if query_time <= three_month_cutoff:
-                    group = "Gated - No query (3mo)"
-                elif query_time <= one_month_cutoff:
-                    group = "Gated - Query (1-3mo)"
+            if last_activity_time is not None:
+                if last_activity_time <= three_month_cutoff:
+                    group = "Gated - No activity (3mo)"
+                elif last_activity_time <= one_month_cutoff:
+                    group = "Gated - Activity (1-3mo)"
                 else:
-                    group = "Gated - Query (1mo)"
+                    group = "Gated - Activity (1mo)"
             else:
-                group = "Gated - No query (3mo)"
+                group = "Gated - No activity (3mo)"
         else:
             group = f"Other ({tenant_status})"
 
         print(
-            f"{idx:<6} {tenant_id:<45} {num_docs:>12,} {num_users:>8} {last_query_str:<12} {group}"
+            f"{idx:<6} {tenant_id:<45} {num_docs:>12,} {num_users:>8} {last_activity_str:<13} {group}"
         )
 
     # Summary stats for top 100
@@ -355,7 +350,7 @@ def analyze_tenants(
         print(f"  99th percentile: {doc_counts[int(len(doc_counts) * 0.99)]:,}")
         print(f"  Max: {doc_counts[-1]:,}")
 
-    return gated_no_query_3_months
+    return gated_no_activity_3_months
 
 
 def find_recent_tenant_data() -> tuple[list[dict[str, Any]] | None, str | None]:
@@ -382,6 +377,12 @@ def find_recent_tenant_data() -> tuple[list[dict[str, Any]] | None, str | None]:
 
         with open(most_recent, "r") as f:
             tenant_data = json.load(f)
+
+        if not tenant_data_includes_craft_activity(tenant_data):
+            print(
+                f"\n⚠ Ignoring cached tenant data without Craft activity: {most_recent.name}"
+            )
+            return None, None
 
         return tenant_data, str(most_recent)
 
@@ -450,8 +451,8 @@ def main() -> None:
             control_plane_pod, args.control_plane_context
         )
 
-        # Step 3: Analyze the data and get gated tenants without recent queries
-        gated_no_query_3_months = analyze_tenants(tenant_data, control_plane_data)
+        # Step 3: Analyze the data and get gated tenants without recent activity
+        inactive_tenants = analyze_tenants(tenant_data, control_plane_data)
 
         # Step 4: Export to CSV (sorted by num_documents descending)
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -459,7 +460,7 @@ def main() -> None:
 
         # Sort by num_documents in descending order
         sorted_tenants = sorted(
-            gated_no_query_3_months,
+            inactive_tenants,
             key=lambda t: t.get("num_documents", 0),
             reverse=True,
         )
@@ -469,40 +470,25 @@ def main() -> None:
                 "tenant_id",
                 "num_documents",
                 "num_users",
-                "last_query_time",
-                "days_since_last_query",
+                *ACTIVITY_CSV_FIELDNAMES,
             ]
             writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
             writer.writeheader()
 
             now = datetime.now(timezone.utc)
             for tenant in sorted_tenants:
-                # Calculate days since last query
-                last_query_time = tenant.get("last_query_time")
-                if last_query_time:
-                    try:
-                        query_dt = datetime.fromisoformat(
-                            last_query_time.replace("Z", "+00:00")
-                        )
-                        days_since = str((now - query_dt).days)
-                    except Exception:
-                        days_since = "N/A"
-                else:
-                    days_since = "Never"
-
                 writer.writerow(
                     {
                         "tenant_id": tenant.get("tenant_id", ""),
                         "num_documents": tenant.get("num_documents", 0),
                         "num_users": tenant.get("num_users", 0),
-                        "last_query_time": last_query_time or "Never",
-                        "days_since_last_query": days_since,
+                        **get_activity_csv_values(tenant, now),
                     }
                 )
 
         print(f"\n✓ CSV exported to: {csv_file}")
         print(
-            f"  Total gated tenants with no query in last 3 months: {len(gated_no_query_3_months)}"
+            f"  Total gated tenants with no chat or Craft activity in last 3 months: {len(inactive_tenants)}"
         )
 
     except subprocess.CalledProcessError as e:

--- a/backend/scripts/tenant_cleanup/on_pod_scripts/understand_tenants.py
+++ b/backend/scripts/tenant_cleanup/on_pod_scripts/understand_tenants.py
@@ -10,7 +10,7 @@ from onyx.db.engine.sql_engine import SqlEngine, get_session_with_shared_schema
 
 
 def get_tenant_activity_summary(session: Session) -> list[dict[str, Any]]:
-    """Return a list of dicts, one per tenant, with last query info, doc count, and user count."""
+    """Return chat/Craft activity, document count, and user count per tenant."""
 
     # Step 1: fetch all tenant schemas
     tenant_schemas = [
@@ -29,6 +29,19 @@ def get_tenant_activity_summary(session: Session) -> list[dict[str, Any]]:
 
     print(f"Found {len(tenant_schemas)} tenant schemas", file=sys.stderr)
 
+    schemas_with_build_sessions = {
+        row[0]
+        for row in session.execute(
+            text("""
+            SELECT schemaname
+            FROM pg_tables
+            WHERE tablename = 'build_session'
+                AND schemaname = ANY(:tenant_schemas)
+            """),
+            {"tenant_schemas": tenant_schemas},
+        )
+    }
+
     summaries = []
 
     # Step 2: loop through each tenant schema
@@ -37,6 +50,12 @@ def get_tenant_activity_summary(session: Session) -> list[dict[str, Any]]:
             print(f"Processing tenant {idx}/{len(tenant_schemas)}", file=sys.stderr)
 
         try:
+            craft_activity_select = (
+                f'(SELECT MAX(last_activity_at) FROM "{schema}".build_session)'
+                if schema in schemas_with_build_sessions
+                else "NULL::timestamptz"
+            )
+
             # Use a single query to get all data at once
             query = text(f"""
                 SELECT
@@ -55,6 +74,7 @@ def get_tenant_activity_summary(session: Session) -> list[dict[str, Any]]:
                         ORDER BY time_sent DESC
                         LIMIT 1
                     ) AS last_query_text,
+                    {craft_activity_select} AS last_craft_activity_time,
                     (SELECT COUNT(*) FROM "{schema}".document) AS num_documents,
                     (SELECT COUNT(*) FROM "{schema}".user) AS num_users
             """)


### PR DESCRIPTION
## Description

Tenant cleanup previously treated the latest chat query as the tenant's only activity signal. This could classify a Craft-only tenant as inactive.

- Collect the latest Craft session activity from `build_session.last_activity_at`.
- Classify tenants using the newest chat or Craft activity timestamp.
- Ignore legacy cached snapshots that do not contain Craft activity data.
- Include chat, Craft, and combined activity timestamps in the cleanup CSV.
- Preserve compatibility with schemas that predate the Craft tables and retain the existing CSV filename.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tenant cleanup to consider both chat and Craft activity, so Craft-only tenants are no longer incorrectly flagged as inactive. The CSV output now includes clear activity timestamps to support safer cleanup decisions.

- **Bug Fixes**
  - Collect Craft session activity from `build_session.last_activity_at`.
  - Classify tenants using the newest of chat or Craft activity.
  - Ignore cached tenant snapshots that lack Craft activity data.
  - Add `last_craft_activity_time`, combined `last_activity_time`, and `days_since_last_activity` to the cleanup CSV.
  - Keep the legacy CSV filename (`gated_tenants_no_query_3mo_*.csv`) for compatibility.
  - Preserve compatibility with schemas that predate Craft by checking for `build_session` before querying.

<sup>Written for commit 80692b01cb44d0643987a1f5ea226a234d0c905e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

