### PR TITLE
fix(craft): disable remote OpenCode model fetches

### DIFF
--- a/backend/onyx/server/features/build/sandbox/image/Dockerfile
+++ b/backend/onyx/server/features/build/sandbox/image/Dockerfile
@@ -181,6 +181,9 @@ RUN cd /workspace/templates/outputs/web && \
 USER root
 
 ENV PATH="/home/sandbox/.opencode/bin:${PATH}"
+# Onyx provides an explicit gateway provider and model catalog, so OpenCode
+# does not need to refresh the generic models.dev catalog at runtime.
+ENV OPENCODE_DISABLE_MODELS_FETCH=1
 
 COPY --exclude=__pycache__ sandbox_daemon/ /workspace/sandbox_daemon/
 COPY entrypoint.sh /workspace/entrypoint.sh


### PR DESCRIPTION
## Description

Disable OpenCode's runtime `models.dev` refresh in Craft sandbox images. Onyx already supplies an explicit gateway provider and model catalog, so this remote fetch is redundant and can block first-session startup when proxy identity is not yet available.

## How Has This Been Tested?

Built the sandbox image for `linux/arm64`, loaded it into the local `kind-onyx-dev` cluster, and provisioned a fresh headless Craft session through `http://localhost:3000/api/build/sessions` while authenticated as the local development user. Verified:

- the session creation request returned HTTP 200;
- the new sandbox pod ran the rebuilt image and exposed `OPENCODE_DISABLE_MODELS_FETCH=1`;
- OpenCode 1.15.7 bootstrapped the workspace and created its internal session;
- neither the sandbox logs nor the sandbox-proxy logs contained a `models.dev` request during the run.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables OpenCode’s runtime `models.dev` fetch in Craft sandbox images by setting `OPENCODE_DISABLE_MODELS_FETCH=1`. This removes a redundant network call, prevents first-session startup blocks when proxy identity isn’t ready, and relies on Onyx’s explicit gateway provider and model catalog.

<sup>Written for commit 6ad07f6f10a2db7d876708cfb8cf9404e1742f00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

