### PR TITLE
fix(web): size the model picker list pane to its content

### DIFF
--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -143,8 +143,8 @@ function formatContextWindow(tokens: number): string {
   return tokens >= 1000 ? `${Math.round(tokens / 1000)}K` : `${tokens}`;
 }
 
-/** Both views render at this height so the popover never resizes. */
-const PANE_HEIGHT_CLASS = "h-[352px]";
+/** Fixed-height scroll box: the popover clips overflow instead of scrolling. */
+const DETAIL_PANE_HEIGHT_CLASS = "h-[352px]";
 
 const SLIDER_THUMB_CLASS =
   "block size-3 rounded-full bg-background-neutral-00 shadow-[0_0_2px_1px_rgba(0,0,0,0.15)] focus:outline-none";
@@ -335,7 +335,7 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
   return (
     <div
       className={cn(
-        PANE_HEIGHT_CLASS,
+        DETAIL_PANE_HEIGHT_CLASS,
         "flex w-full flex-col gap-1 overflow-y-auto"
       )}
     >
@@ -611,7 +611,7 @@ export default function ModelSelectorContent({
   }
 
   return (
-    <div className={cn(PANE_HEIGHT_CLASS, "flex w-full flex-col gap-1")}>
+    <Section gap={0.5}>
       <InputTypeIn
         searchIcon
         variant="internal"
@@ -723,6 +723,6 @@ export default function ModelSelectorContent({
                   })),
         ]}
       </PopoverMenu>
-    </div>
+    </Section>
   );
 }


### PR DESCRIPTION
## Description

Tenants with only a couple of models saw a model picker mostly full of empty space.

#13365 added `PANE_HEIGHT_CLASS = "h-[352px]"` and applied it to the model list pane as well as the detail pane, so the popover was pinned to 352px no matter how many models existed. `PopoverMenu` grows into that height via `flex-1`, and Opal `Section` centers by default, so the leftover space landed both above and below the rows.

The list pane goes back to the wrapper it had before #13365, a plain `<Section gap={0.5}>`. Long lists are still scroll-capped by `PopoverMenu`. The pinned height stays on the detail pane, which needs it because `Popover.Content` clips rather than scrolls.

Two visible consequences, both intended:

- The gap between the search field and the list returns to 8px from #13365's 4px.
- Drilling into the detail pane now resizes the popover, since the list pane is no longer pinned to the same height.

The popover can also flip below the trigger as provider groups expand. `git show c5c1d53c33^` confirms that predates #13365, which merely masked it by holding the height constant, so this PR leaves it alone.

Cloud only. It shipped in `v4.4.0-cloud.6` on 2026-07-24. Self-hosted stable through `v4.4.7` never had it.

## How Has This Been Tested?

Static checks only so far:

- `tsc --noEmit` clean, with the incremental cache cleared first
- `oxlint` clean, `oxfmt --check` reports no formatting change
- `pre-commit` on the changed file: ripsecrets, oxfmt, oxlint, TypeScript all pass
- `ty check` from the repo root: all checks passed
- codex-review, plus code-simplifier and comment-analyzer over the full diff, nothing above a nit
- none of the five model-selector e2e specs assert popover geometry, so none can break on this

The collapsed popover was confirmed to size to its content when run on a dev environment.

**Blocking follow-up: before and after screenshots are still owed here.** The rendered result has not been captured, so please treat the visual claims as unverified until they are attached. I will add both.

Separate follow-up worth considering: the detail pane keeps a hardcoded 352px while its content measures somewhere under that, so it likely carries a little dead space of its own. Moving it to `max-h-` needs a visual check that the popover does not visibly shrink when you open detail from a long list.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
