### PR TITLE
feat(craft): durable reserve/reconcile/finalize sandbox provisioning lifecycle

### DIFF
--- a/backend/alembic/versions/3debc2b55899_durable_craft_provisioning_lifecycle.py
+++ b/backend/alembic/versions/3debc2b55899_durable_craft_provisioning_lifecycle.py
@@ -29,7 +29,7 @@ def upgrade() -> None:
     op.add_column(
         "sandbox",
         sa.Column(
-            "provisioning_generation",
+            "provisioning_attempt_number",
             sa.Integer(),
             nullable=False,
             server_default="0",
@@ -72,7 +72,7 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_index("uq_build_session_nextjs_port", table_name="build_session")
     op.drop_column("sandbox", "provisioning_started_at")
-    op.drop_column("sandbox", "provisioning_generation")
+    op.drop_column("sandbox", "provisioning_attempt_number")
     # Fold the statuses this revision introduced back into the old set before
     # shrinking the column (non-native enums persist member NAMES).
     op.execute(

--- a/backend/alembic/versions/3debc2b55899_durable_craft_provisioning_lifecycle.py
+++ b/backend/alembic/versions/3debc2b55899_durable_craft_provisioning_lifecycle.py
@@ -41,9 +41,11 @@ def upgrade() -> None:
     )
 
     # Port allocation previously had no uniqueness guarantee, so concurrent
-    # creates could have reserved the same port. Keep the oldest reservation
-    # per port (within a shared pod its dev server won the bind; later
-    # duplicates never served). A cleared session gets a fresh port on its
+    # creates could have reserved the same port. Ports only need to be unique
+    # within one user's sandbox (each user has their own pod/container), so
+    # scope the constraint per user. Keep the oldest reservation per
+    # (user, port) — within a shared pod its dev server won the bind; later
+    # duplicates never served. A cleared session gets a fresh port on its
     # next sleep/restore cycle.
     op.execute(
         """
@@ -51,7 +53,7 @@ def upgrade() -> None:
         WHERE id IN (
             SELECT id FROM (
                 SELECT id, ROW_NUMBER() OVER (
-                    PARTITION BY nextjs_port ORDER BY created_at ASC
+                    PARTITION BY user_id, nextjs_port ORDER BY created_at ASC
                 ) AS rn
                 FROM build_session
                 WHERE nextjs_port IS NOT NULL
@@ -63,7 +65,7 @@ def upgrade() -> None:
     op.create_index(
         "uq_build_session_nextjs_port",
         "build_session",
-        ["nextjs_port"],
+        ["user_id", "nextjs_port"],
         unique=True,
         postgresql_where=sa.text("nextjs_port IS NOT NULL"),
     )

--- a/backend/alembic/versions/3debc2b55899_durable_craft_provisioning_lifecycle.py
+++ b/backend/alembic/versions/3debc2b55899_durable_craft_provisioning_lifecycle.py
@@ -1,7 +1,7 @@
 """durable craft provisioning lifecycle
 
 Revision ID: 3debc2b55899
-Revises: 0d9c7b6a5e4f
+Revises: 4662f8c3e038
 Create Date: 2026-07-29 16:05:31.324630
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "3debc2b55899"
-down_revision = "0d9c7b6a5e4f"
+down_revision = "4662f8c3e038"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/3debc2b55899_durable_craft_provisioning_lifecycle.py
+++ b/backend/alembic/versions/3debc2b55899_durable_craft_provisioning_lifecycle.py
@@ -1,0 +1,64 @@
+"""durable craft provisioning lifecycle
+
+Revision ID: 3debc2b55899
+Revises: 0d9c7b6a5e4f
+Create Date: 2026-07-29 16:05:31.324630
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "3debc2b55899"
+down_revision = "0d9c7b6a5e4f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sandbox",
+        sa.Column(
+            "provisioning_generation",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.add_column(
+        "sandbox",
+        sa.Column("provisioning_started_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    # Port allocation previously had no uniqueness guarantee, so concurrent
+    # creates could have reserved the same port. Keep the newest reservation
+    # per port; ports are re-allocated on restore, so nulling is safe.
+    op.execute(
+        """
+        UPDATE build_session SET nextjs_port = NULL
+        WHERE id IN (
+            SELECT id FROM (
+                SELECT id, ROW_NUMBER() OVER (
+                    PARTITION BY nextjs_port ORDER BY created_at DESC
+                ) AS rn
+                FROM build_session
+                WHERE nextjs_port IS NOT NULL
+            ) ranked
+            WHERE ranked.rn > 1
+        )
+        """
+    )
+    op.create_index(
+        "uq_build_session_nextjs_port",
+        "build_session",
+        ["nextjs_port"],
+        unique=True,
+        postgresql_where=sa.text("nextjs_port IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_build_session_nextjs_port", table_name="build_session")
+    op.drop_column("sandbox", "provisioning_started_at")
+    op.drop_column("sandbox", "provisioning_generation")

--- a/backend/alembic/versions/3debc2b55899_durable_craft_provisioning_lifecycle.py
+++ b/backend/alembic/versions/3debc2b55899_durable_craft_provisioning_lifecycle.py
@@ -17,6 +17,15 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # The non-native status enum was sized to its longest member at creation
+    # ("active" → VARCHAR(6)); widen for the new INITIALIZING value.
+    op.alter_column(
+        "build_session",
+        "status",
+        type_=sa.String(length=12),
+        existing_type=sa.String(length=6),
+        existing_nullable=False,
+    )
     op.add_column(
         "sandbox",
         sa.Column(
@@ -64,3 +73,16 @@ def downgrade() -> None:
     op.drop_index("uq_build_session_nextjs_port", table_name="build_session")
     op.drop_column("sandbox", "provisioning_started_at")
     op.drop_column("sandbox", "provisioning_generation")
+    # Fold the statuses this revision introduced back into the old set before
+    # shrinking the column (non-native enums persist member NAMES).
+    op.execute(
+        "UPDATE build_session SET status = 'IDLE' "
+        "WHERE status IN ('INITIALIZING', 'FAILED')"
+    )
+    op.alter_column(
+        "build_session",
+        "status",
+        type_=sa.String(length=6),
+        existing_type=sa.String(length=12),
+        existing_nullable=False,
+    )

--- a/backend/alembic/versions/3debc2b55899_durable_craft_provisioning_lifecycle.py
+++ b/backend/alembic/versions/3debc2b55899_durable_craft_provisioning_lifecycle.py
@@ -32,15 +32,17 @@ def upgrade() -> None:
     )
 
     # Port allocation previously had no uniqueness guarantee, so concurrent
-    # creates could have reserved the same port. Keep the newest reservation
-    # per port; ports are re-allocated on restore, so nulling is safe.
+    # creates could have reserved the same port. Keep the oldest reservation
+    # per port (within a shared pod its dev server won the bind; later
+    # duplicates never served). A cleared session gets a fresh port on its
+    # next sleep/restore cycle.
     op.execute(
         """
         UPDATE build_session SET nextjs_port = NULL
         WHERE id IN (
             SELECT id FROM (
                 SELECT id, ROW_NUMBER() OVER (
-                    PARTITION BY nextjs_port ORDER BY created_at DESC
+                    PARTITION BY nextjs_port ORDER BY created_at ASC
                 ) AS rn
                 FROM build_session
                 WHERE nextjs_port IS NOT NULL

--- a/backend/onyx/background/celery/tasks/scheduled_tasks/tasks.py
+++ b/backend/onyx/background/celery/tasks/scheduled_tasks/tasks.py
@@ -51,8 +51,12 @@ from onyx.db.scheduled_task import (
     mark_run_status,
 )
 from onyx.server.features.build.scheduled_tasks.executor import (
-    DEFAULT_EXECUTOR_BUDGET_SECONDS,
     run_scheduled_task_logic,
+)
+from onyx.server.features.build.timeouts import (
+    QUEUE_RESIDENCY_SECONDS,
+    TURN_BUDGET_SECONDS,
+    TURN_RECLAIM_SLACK_SECONDS,
 )
 from onyx.server.features.build.utils import is_craft_enabled_for_user
 from onyx.server.settings.store import load_settings
@@ -65,19 +69,15 @@ from onyx.server.settings.store import load_settings
 # concurrent ticks just see "no rows" and exit.
 DISPATCH_BATCH_SIZE = 50
 
-# How long the executor message can sit on the `scheduled_tasks` queue
-# before Celery drops it. After 15 min we'd rather let the next beat tick
-# re-dispatch a new run row than execute a stale one.
-RUN_EXPIRES_SECONDS = 15 * 60
-
-# Stuck-run sweeper thresholds. The QUEUED threshold needs to comfortably
-# exceed the longest plausible queue wait + executor startup. The RUNNING
-# threshold should exceed the executor budget by enough margin that a
-# well-behaved run that hits its own budget gets there first and marks
-# itself FAILED (rather than the sweeper). Budget is 30 min by default;
-# 45 min gives 50% slack.
-STUCK_QUEUED_OLDER_THAN = timedelta(minutes=15)
-STUCK_RUNNING_OLDER_THAN = timedelta(seconds=DEFAULT_EXECUTOR_BUDGET_SECONDS + 15 * 60)
+# Celery expiry and the stuck-QUEUED sweep are one policy: a run that sat
+# queued past the residency limit is dropped unexecuted and its row reclaimed
+# by the same threshold. A RUNNING row is stuck only past budget + slack, so a
+# well-behaved run that hits its own budget always marks itself FAILED first.
+RUN_EXPIRES_SECONDS = QUEUE_RESIDENCY_SECONDS
+STUCK_QUEUED_OLDER_THAN = timedelta(seconds=QUEUE_RESIDENCY_SECONDS)
+STUCK_RUNNING_OLDER_THAN = timedelta(
+    seconds=TURN_BUDGET_SECONDS + TURN_RECLAIM_SLACK_SECONDS
+)
 
 
 # --- Dispatch ----------------------------------------------------------------

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -333,8 +333,20 @@ class OpenSearchTenantMigrationStatus(str, PyEnum):
 
 # Onyx Build Mode Enums
 class BuildSessionStatus(str, PyEnum):
+    """Lifecycle of a build session.
+
+    INITIALIZING: reserved identity committed; workspace/OpenCode setup is
+                  still reconciling (or was interrupted and is repairable).
+    ACTIVE:       workspace, config, and OpenCode session are usable.
+    IDLE:         sandbox slept; workspace must be restored before use.
+    FAILED:       initialization failed after the sandbox came up; the
+                  session identity is retained and repaired on retry.
+    """
+
+    INITIALIZING = "initializing"
     ACTIVE = "active"
     IDLE = "idle"
+    FAILED = "failed"
 
 
 class SessionOrigin(str, PyEnum):

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -6124,9 +6124,10 @@ class Sandbox(Base):
     # Attempt number: incremented (under the per-user reservation lock) each
     # time a new provisioning attempt is authorized. Every status write names
     # the attempt it belongs to and only applies while the row still holds
-    # that number, and backend deletes check the runtime's attempt label — so
-    # an old attempt can never overwrite a newer attempt's outcome or destroy
-    # its runtime.
+    # that number, so an old attempt can never overwrite a newer attempt's
+    # outcome. Backend runtime deletes are name-keyed and best-effort
+    # serialized by the provisioning lock; a wrongly deleted pod self-heals
+    # through unhealthy-RUNNING recovery.
     provisioning_attempt_number: Mapped[int] = mapped_column(
         Integer, nullable=False, default=0, server_default="0"
     )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -6075,6 +6075,14 @@ class BuildSession(Base):
             desc("created_at"),
         ),
         Index("ix_build_session_status", "status"),
+        # Durable port reservation: allocation retries on collision instead of
+        # trusting the application-level scan.
+        Index(
+            "uq_build_session_nextjs_port",
+            "nextjs_port",
+            unique=True,
+            postgresql_where=text("nextjs_port IS NOT NULL"),
+        ),
     )
 
 
@@ -6109,6 +6117,21 @@ class Sandbox(Base):
 
     encrypted_pat: Mapped[SensitiveValue[str] | None] = mapped_column(
         EncryptedString(), nullable=True
+    )
+
+    # Fencing token for external reconciliation: advanced (under the per-user
+    # reservation lock) each time a new provisioning attempt is authorized.
+    # Finalization is a compare-and-set on this value, so a stale attempt can
+    # never mark a newer generation RUNNING/FAILED or clean its resources.
+    provisioning_generation: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    # When the current attempt was authorized; a committed PROVISIONING row
+    # whose attempt is older than the managers' bounded waits is dead and may
+    # be taken over. Failure diagnostics live in logs (keyed by sandbox ID +
+    # generation), not here.
+    provisioning_started_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
     )
 
     # Relationships

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -783,8 +783,8 @@ class Persona__Tool(Base):
     """An entry in this table represents a tool that is **available** to a persona.
     It does NOT necessarily mean that the tool is actually usable to the persona.
 
-    For example, a persona may have the image attempt_number tool attached to it, even though
-    the image attempt_number tool is not set up / enabled. In this case, the tool should not
+    For example, a persona may have the image generation tool attached to it, even though
+    the image generation tool is not set up / enabled. In this case, the tool should not
     show up in the UI for the persona + it should not be usable by the persona in chat.
     """
 
@@ -3311,7 +3311,7 @@ class ToolCall(Base):
     # Only the top level tools (the ones with a parent_chat_message_id) have token counts that are counted
     # towards the session total.
     tool_call_tokens: Mapped[int] = mapped_column(Integer())
-    # For image attempt_number tool - stores GeneratedImage objects for replay
+    # For image generation tool - stores GeneratedImage objects for replay
     generated_images: Mapped[list[dict] | None] = mapped_column(
         postgresql.JSONB(), nullable=True
     )
@@ -4031,7 +4031,7 @@ class Persona(Base):
     description: Mapped[str] = mapped_column(String)
 
     # Canonical FK encoding both provider and model for the persona's LLM override.
-    # NOTE: only applied on actual response attempt_number — not used for auto-detected
+    # NOTE: only applied on actual response generation — not used for auto-detected
     # time filters, relevance filters, etc.
     default_model_configuration_id: Mapped[int | None] = mapped_column(
         Integer,
@@ -6076,9 +6076,11 @@ class BuildSession(Base):
         ),
         Index("ix_build_session_status", "status"),
         # Durable port reservation: allocation retries on collision instead of
-        # trusting the application-level scan.
+        # trusting the application-level scan. Scoped per user — ports only
+        # collide within one user's sandbox.
         Index(
             "uq_build_session_nextjs_port",
+            "user_id",
             "nextjs_port",
             unique=True,
             postgresql_where=text("nextjs_port IS NOT NULL"),
@@ -6122,15 +6124,16 @@ class Sandbox(Base):
     # Attempt number: incremented (under the per-user reservation lock) each
     # time a new provisioning attempt is authorized. Every status write names
     # the attempt it belongs to and only applies while the row still holds
-    # that number, so an old attempt can never overwrite a newer attempt's
-    # outcome or clean its resources.
+    # that number, and backend deletes check the runtime's attempt label — so
+    # an old attempt can never overwrite a newer attempt's outcome or destroy
+    # its runtime.
     provisioning_attempt_number: Mapped[int] = mapped_column(
         Integer, nullable=False, default=0, server_default="0"
     )
     # When the current attempt was authorized; a committed PROVISIONING row
     # whose attempt is older than the managers' bounded waits is dead and may
     # be taken over. Failure diagnostics live in logs (keyed by sandbox ID +
-    # attempt_number), not here.
+    # attempt number), not here.
     provisioning_started_at: Mapped[datetime.datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -783,8 +783,8 @@ class Persona__Tool(Base):
     """An entry in this table represents a tool that is **available** to a persona.
     It does NOT necessarily mean that the tool is actually usable to the persona.
 
-    For example, a persona may have the image generation tool attached to it, even though
-    the image generation tool is not set up / enabled. In this case, the tool should not
+    For example, a persona may have the image attempt_number tool attached to it, even though
+    the image attempt_number tool is not set up / enabled. In this case, the tool should not
     show up in the UI for the persona + it should not be usable by the persona in chat.
     """
 
@@ -3311,7 +3311,7 @@ class ToolCall(Base):
     # Only the top level tools (the ones with a parent_chat_message_id) have token counts that are counted
     # towards the session total.
     tool_call_tokens: Mapped[int] = mapped_column(Integer())
-    # For image generation tool - stores GeneratedImage objects for replay
+    # For image attempt_number tool - stores GeneratedImage objects for replay
     generated_images: Mapped[list[dict] | None] = mapped_column(
         postgresql.JSONB(), nullable=True
     )
@@ -4031,7 +4031,7 @@ class Persona(Base):
     description: Mapped[str] = mapped_column(String)
 
     # Canonical FK encoding both provider and model for the persona's LLM override.
-    # NOTE: only applied on actual response generation — not used for auto-detected
+    # NOTE: only applied on actual response attempt_number — not used for auto-detected
     # time filters, relevance filters, etc.
     default_model_configuration_id: Mapped[int | None] = mapped_column(
         Integer,
@@ -6119,17 +6119,18 @@ class Sandbox(Base):
         EncryptedString(), nullable=True
     )
 
-    # Fencing token for external reconciliation: advanced (under the per-user
-    # reservation lock) each time a new provisioning attempt is authorized.
-    # Finalization is a compare-and-set on this value, so a stale attempt can
-    # never mark a newer generation RUNNING/FAILED or clean its resources.
-    provisioning_generation: Mapped[int] = mapped_column(
+    # Attempt number: incremented (under the per-user reservation lock) each
+    # time a new provisioning attempt is authorized. Every status write names
+    # the attempt it belongs to and only applies while the row still holds
+    # that number, so an old attempt can never overwrite a newer attempt's
+    # outcome or clean its resources.
+    provisioning_attempt_number: Mapped[int] = mapped_column(
         Integer, nullable=False, default=0, server_default="0"
     )
     # When the current attempt was authorized; a committed PROVISIONING row
     # whose attempt is older than the managers' bounded waits is dead and may
     # be taken over. Failure diagnostics live in logs (keyed by sandbox ID +
-    # generation), not here.
+    # attempt_number), not here.
     provisioning_started_at: Mapped[datetime.datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -337,12 +337,18 @@ def get_user_by_email(email: str, db_session: Session) -> User | None:
     return user
 
 
-def fetch_user_by_id(db_session: Session, user_id: UUID) -> User | None:
-    return (
-        db_session.query(User)
-        .filter(User.id == user_id)  # ty: ignore[invalid-argument-type]
-        .first()
+def fetch_user_by_id(
+    db_session: Session, user_id: UUID, for_update: bool = False
+) -> User | None:
+    """``for_update`` adds ``SELECT ... FOR UPDATE``, serializing concurrent
+    transactions that use the user row as a reservation boundary (e.g. Craft
+    sandbox/session reservation). Hold only for a short transaction."""
+    query = db_session.query(User).filter(
+        User.id == user_id  # ty: ignore[invalid-argument-type]
     )
+    if for_update:
+        query = query.with_for_update()
+    return query.first()
 
 
 def _generate_password_hash() -> str:

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -6,7 +6,7 @@ from fastapi import HTTPException
 from fastapi_users.password import PasswordHelper
 from sqlalchemy import Select, case, func, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session, selectinload
+from sqlalchemy.orm import Session, lazyload, selectinload
 from sqlalchemy.sql import expression
 from sqlalchemy.sql.elements import ColumnElement, KeyedColumnElement
 from sqlalchemy.sql.expression import or_
@@ -347,7 +347,9 @@ def fetch_user_by_id(
         User.id == user_id  # ty: ignore[invalid-argument-type]
     )
     if for_update:
-        query = query.with_for_update()
+        # oauth_accounts is lazy="joined"; Postgres forbids FOR UPDATE on the
+        # nullable side of an outer join, so defer it when locking.
+        query = query.options(lazyload(User.oauth_accounts)).with_for_update()
     return query.first()
 
 

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -29,14 +29,16 @@ OPENCODE_DISABLED_TOOLS: list[str] = [
 SANDBOX_IDLE_TIMEOUT_SECONDS = int(
     os.environ.get("SANDBOX_IDLE_TIMEOUT_SECONDS", "3600")
 )
-SESSION_CREATE_LOCK_LEASE_SECONDS = 300
-SESSION_CREATE_LOCK_WAIT_SECONDS = 60
 SANDBOX_MAX_CONCURRENT_PER_ORG = int(
     os.environ.get("SANDBOX_MAX_CONCURRENT_PER_ORG", "10")
 )
 SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS = int(
     os.environ.get("SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS", "180")
 )
+# Margin a client-side wait must add over the approval window so a decision
+# landing at the wire never races the client's own timeout. Shared by the
+# AGENTS.md guidance and the inactivity-backstop default below.
+SANDBOX_APPROVAL_WAIT_MARGIN_SECONDS = 20
 SANDBOX_IDLE_CLEANUP_INTERVAL_SECONDS = int(
     os.environ.get("SANDBOX_IDLE_CLEANUP_INTERVAL_SECONDS", "60")
 )
@@ -168,17 +170,20 @@ SANDBOX_DOCKER_CPU_LIMIT = float(os.environ.get("SANDBOX_DOCKER_CPU_LIMIT", "1.0
 SSE_KEEPALIVE_INTERVAL = float(os.environ.get("SSE_KEEPALIVE_INTERVAL", "15.0"))
 
 # Maximum time opencode-serve may go without emitting a turn event. Coarse
-# liveness backstop only: it must stay above opencode's own per-tool timeouts
-# (bash defaults to 180s here, webfetch 120s) so it never pre-empts a healthy
-# long-running tool — it exists to catch stalls opencode does not bound itself
-# (LLM-stream hangs, non-bash/MCP tool hangs). The turn budget is the hard ceiling.
+# liveness backstop only: it must stay above every in-tool wait so it never
+# pre-empts a healthy long-running tool — opencode's bash tool defaults to
+# 180s, and a proxy-parked approval inside a tool call holds the stream
+# silent for the full approval window, hence the derivation. It exists to
+# catch stalls opencode does not bound itself (LLM-stream hangs, non-bash/MCP
+# tool hangs). The turn budget is the hard ceiling.
 OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS = float(
-    os.environ.get("OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS", "200.0")
+    os.environ.get(
+        "OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS",
+        str(
+            SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS + SANDBOX_APPROVAL_WAIT_MARGIN_SECONDS
+        ),
+    )
 )
-
-# Hard ceiling for background prompt-slot renewal, so a leaked holder cannot
-# retain mutual exclusion indefinitely.
-PROMPT_SLOT_KEEP_ALIVE_MAX_SECONDS = 30 * 60.0
 
 # Prompt-slot lock lease; renewed on every sandbox event/keepalive, so a dead
 # holder strands the slot for at most this long.
@@ -204,9 +209,11 @@ OPENCODE_SERVE_REQUEST_TIMEOUT = float(
     os.environ.get("OPENCODE_SERVE_REQUEST_TIMEOUT", "30.0")
 )
 # Idle timeout for /event SSE. The reader reconnects (with backoff) if the
-# stream is silent for this long.
+# stream is silent for this long. Derived from the keepalive cadence: the
+# stream carries a keepalive at least every SSE_KEEPALIVE_INTERVAL, so N
+# missed keepalives — not an independent number — is what "dead stream" means.
 OPENCODE_SERVE_EVENT_READ_TIMEOUT = float(
-    os.environ.get("OPENCODE_SERVE_EVENT_READ_TIMEOUT", "60.0")
+    os.environ.get("OPENCODE_SERVE_EVENT_READ_TIMEOUT", str(4 * SSE_KEEPALIVE_INTERVAL))
 )
 
 # ==============================================================================

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -1,11 +1,12 @@
 """Database operations for Build Mode sessions."""
 
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
-from sqlalchemy import column, desc, exists, select, values
+from sqlalchemy import column, desc, exists, select, update, values
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
@@ -34,13 +35,16 @@ def create_build_session__no_commit(
 ) -> BuildSession:
     """``flush()`` only — caller commits.
 
+    Sessions are born ``INITIALIZING``; only the reconcile that builds their
+    workspace and OpenCode session finalizes them to ``ACTIVE``.
+
     ``agent_provider`` / ``agent_model`` are nullable for legacy rows;
     the send-message path then falls back to opencode's startup default.
     """
     session = BuildSession(
         user_id=user_id,
         name=name,
-        status=BuildSessionStatus.ACTIVE,
+        status=BuildSessionStatus.INITIALIZING,
         origin=origin,
         agent_provider=agent_provider,
         agent_model=agent_model,
@@ -201,6 +205,46 @@ def get_empty_session_for_user(
         )
         .first()
     )
+
+
+def mark_session_initializing__no_commit(
+    db_session: Session,
+    session: BuildSession,
+) -> None:
+    """Return a reserved/repairable empty session to ``INITIALIZING`` so its
+    workspace can be (re)built under the committed session ID."""
+    session.status = BuildSessionStatus.INITIALIZING
+    db_session.flush()
+
+
+def finalize_session_initialization__no_commit(
+    db_session: Session,
+    session_id: UUID,
+    to_status: Literal[BuildSessionStatus.ACTIVE, BuildSessionStatus.FAILED],
+    opencode_session_id: str | None = None,
+    skills_hash: str | None = None,
+    mcp_config_hash: str | None = None,
+) -> bool:
+    """Compare-and-set ``INITIALIZING`` → ``ACTIVE``/``FAILED``. Returns False
+    when the session already left ``INITIALIZING`` (e.g. a concurrent repair
+    finished first), in which case the caller's runtime state must not be
+    recorded."""
+    values_map: dict[str, object] = {"status": to_status}
+    if opencode_session_id is not None:
+        values_map["opencode_session_id"] = opencode_session_id
+    if skills_hash is not None:
+        values_map["skills_hash"] = skills_hash
+    if mcp_config_hash is not None:
+        values_map["mcp_config_hash"] = mcp_config_hash
+    result = db_session.execute(
+        update(BuildSession)
+        .where(
+            BuildSession.id == session_id,
+            BuildSession.status == BuildSessionStatus.INITIALIZING,
+        )
+        .values(**values_map)
+    )
+    return result.rowcount == 1  # ty: ignore[unresolved-attribute]
 
 
 def update_session_activity(
@@ -529,35 +573,39 @@ def _is_port_available(port: int) -> bool:
     return True
 
 
-def allocate_nextjs_port(db_session: Session) -> int:
-    """Allocate an available port for a new session.
+def reserve_nextjs_port__no_commit(
+    db_session: Session,
+    build_session: BuildSession,
+) -> int:
+    """Reserve an available port on the session row.
 
-    Finds the first available port in the configured range by checking
-    both database allocations and system-level port availability.
-
-    Args:
-        db_session: Database session for querying allocated ports
-
-    Returns:
-        An available port number
+    Uniqueness is enforced by the partial unique index on ``nextjs_port``: each
+    candidate is flushed inside a savepoint, and a collision with a concurrent
+    reservation rolls back just that attempt and moves to the next port. The
+    OS bind probe additionally filters ports in use outside the database
+    (relevant for the local/Docker backend).
 
     Raises:
         OnyxError: If no ports are available in the configured range
     """
-    from onyx.db.models import BuildSession
-
-    # Get all currently allocated ports from active sessions
-    allocated_ports = set(
-        db_session.query(BuildSession.nextjs_port)
+    allocated_ports = {
+        port
+        for (port,) in db_session.query(BuildSession.nextjs_port)
         .filter(BuildSession.nextjs_port.isnot(None))
         .all()
-    )
-    allocated_ports = {port[0] for port in allocated_ports if port[0] is not None}
+        if port is not None
+    }
 
-    # Find first port that's not in DB and not currently bound
     for port in range(SANDBOX_NEXTJS_PORT_START, SANDBOX_NEXTJS_PORT_END):
-        if port not in allocated_ports and _is_port_available(port):
-            return port
+        if port in allocated_ports or not _is_port_available(port):
+            continue
+        try:
+            with db_session.begin_nested():
+                build_session.nextjs_port = port
+                db_session.flush()
+        except IntegrityError:
+            continue
+        return port
 
     raise OnyxError(
         OnyxErrorCode.SERVICE_UNAVAILABLE,

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -579,11 +579,12 @@ def reserve_nextjs_port__no_commit(
 ) -> int:
     """Reserve an available port on the session row.
 
-    Uniqueness is enforced by the partial unique index on ``nextjs_port``: each
-    candidate is flushed inside a savepoint, and a collision with a concurrent
-    reservation rolls back just that attempt and moves to the next port. The
-    OS bind probe additionally filters ports in use outside the database
-    (relevant for the local/Docker backend).
+    Ports only need to be unique within one user's sandbox, so both the scan
+    and the partial unique index on ``(user_id, nextjs_port)`` are per-user:
+    each candidate is flushed inside a savepoint, and a collision with a
+    concurrent reservation rolls back just that attempt and moves to the next
+    port. The OS bind probe additionally filters ports in use outside the
+    database (relevant for the local/Docker backend).
 
     Raises:
         OnyxError: If no ports are available in the configured range
@@ -591,7 +592,10 @@ def reserve_nextjs_port__no_commit(
     allocated_ports = {
         port
         for (port,) in db_session.query(BuildSession.nextjs_port)
-        .filter(BuildSession.nextjs_port.isnot(None))
+        .filter(
+            BuildSession.user_id == build_session.user_id,
+            BuildSession.nextjs_port.isnot(None),
+        )
         .all()
         if port is not None
     }

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -1,9 +1,10 @@
 """Database operations for CLI agent sandbox management."""
 
 import datetime
+from typing import Literal
 from uuid import UUID
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.orm import Session
 
 from onyx.auth.pat import hash_pat
@@ -87,6 +88,77 @@ def get_sandbox_by_user_id(db_session: Session, user_id: UUID) -> Sandbox | None
     """Get sandbox by user ID (primary lookup method)."""
     stmt = select(Sandbox).where(Sandbox.user_id == user_id)
     return db_session.execute(stmt).scalar_one_or_none()
+
+
+def begin_provisioning_attempt__no_commit(
+    db_session: Session,
+    sandbox: Sandbox,
+) -> int:
+    """Authorize a new external provisioning attempt: advance the fencing
+    generation and mark the sandbox ``PROVISIONING``. Must run inside the
+    per-user reservation transaction (user row locked) so concurrent
+    reservers serialize on generation assignment.
+
+    Returns the new generation, which the attempt must present to the
+    compare-and-set transitions below.
+    """
+    sandbox.status = SandboxStatus.PROVISIONING
+    sandbox.provisioning_generation += 1
+    sandbox.provisioning_started_at = datetime.datetime.now(datetime.timezone.utc)
+    db_session.flush()
+    return sandbox.provisioning_generation
+
+
+def begin_recovery_attempt_cas__no_commit(
+    db_session: Session,
+    sandbox_id: UUID,
+    expected_generation: int,
+) -> int | None:
+    """Compare-and-set takeover of an unhealthy ``RUNNING`` sandbox for a new
+    provisioning attempt (recovery happens outside the reservation lock).
+    Returns the new generation, or None when the row already moved on."""
+    result = db_session.execute(
+        update(Sandbox)
+        .where(
+            Sandbox.id == sandbox_id,
+            Sandbox.provisioning_generation == expected_generation,
+            Sandbox.status == SandboxStatus.RUNNING,
+        )
+        .values(
+            status=SandboxStatus.PROVISIONING,
+            provisioning_generation=expected_generation + 1,
+            provisioning_started_at=datetime.datetime.now(datetime.timezone.utc),
+        )
+    )
+    if result.rowcount != 1:  # ty: ignore[unresolved-attribute]
+        return None
+    return expected_generation + 1
+
+
+def finalize_provisioning_attempt__no_commit(
+    db_session: Session,
+    sandbox_id: UUID,
+    generation: int,
+    to_status: Literal[SandboxStatus.RUNNING, SandboxStatus.FAILED],
+) -> bool:
+    """Generation-guarded compare-and-set ``PROVISIONING`` → outcome.
+    Returns False when the attempt is stale (the row moved on or a newer
+    generation exists) — the caller's external work must not be recorded as
+    the current runtime. ``RUNNING`` also stamps the heartbeat so the fresh
+    pod gets a proper idle-timeout baseline."""
+    values: dict[str, object] = {"status": to_status}
+    if to_status == SandboxStatus.RUNNING:
+        values["last_heartbeat"] = datetime.datetime.now(datetime.timezone.utc)
+    result = db_session.execute(
+        update(Sandbox)
+        .where(
+            Sandbox.id == sandbox_id,
+            Sandbox.provisioning_generation == generation,
+            Sandbox.status == SandboxStatus.PROVISIONING,
+        )
+        .values(**values)
+    )
+    return result.rowcount == 1  # ty: ignore[unresolved-attribute]
 
 
 def get_sandbox_by_id(db_session: Session, sandbox_id: UUID) -> Sandbox | None:

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -109,7 +109,7 @@ def begin_provisioning_attempt__no_commit(
     return sandbox.provisioning_generation
 
 
-def begin_recovery_attempt_cas__no_commit(
+def begin_recovery_attempt__no_commit(
     db_session: Session,
     sandbox_id: UUID,
     expected_generation: int,
@@ -157,6 +157,27 @@ def finalize_provisioning_attempt__no_commit(
             Sandbox.status == SandboxStatus.PROVISIONING,
         )
         .values(**values)
+    )
+    return result.rowcount == 1  # ty: ignore[unresolved-attribute]
+
+
+def sleep_running_sandbox__no_commit(
+    db_session: Session,
+    sandbox_id: UUID,
+    generation: int,
+) -> bool:
+    """Generation-guarded compare-and-set ``RUNNING`` → ``SLEEPING`` for the
+    idle reaper. Returns False when the row moved on (a concurrent recovery or
+    create advanced the generation / left RUNNING), so the reaper must not
+    clobber that decision with an unconditional sleep."""
+    result = db_session.execute(
+        update(Sandbox)
+        .where(
+            Sandbox.id == sandbox_id,
+            Sandbox.provisioning_generation == generation,
+            Sandbox.status == SandboxStatus.RUNNING,
+        )
+        .values(status=SandboxStatus.SLEEPING)
     )
     return result.rowcount == 1  # ty: ignore[unresolved-attribute]
 

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -94,58 +94,59 @@ def begin_provisioning_attempt__no_commit(
     db_session: Session,
     sandbox: Sandbox,
 ) -> int:
-    """Authorize a new external provisioning attempt: advance the fencing
-    generation and mark the sandbox ``PROVISIONING``. Must run inside the
+    """Authorize a new external provisioning attempt: assign the next attempt
+    number and mark the sandbox ``PROVISIONING``. Must run inside the
     per-user reservation transaction (user row locked) so concurrent
-    reservers serialize on generation assignment.
+    reservers get distinct numbers.
 
-    Returns the new generation, which the attempt must present to the
-    compare-and-set transitions below.
+    Returns the new attempt number, which the attempt must present to the
+    conditional transitions below.
     """
     sandbox.status = SandboxStatus.PROVISIONING
-    sandbox.provisioning_generation += 1
+    sandbox.provisioning_attempt_number += 1
     sandbox.provisioning_started_at = datetime.datetime.now(datetime.timezone.utc)
     db_session.flush()
-    return sandbox.provisioning_generation
+    return sandbox.provisioning_attempt_number
 
 
 def begin_recovery_attempt__no_commit(
     db_session: Session,
     sandbox_id: UUID,
-    expected_generation: int,
+    expected_attempt_number: int,
 ) -> int | None:
-    """Compare-and-set takeover of an unhealthy ``RUNNING`` sandbox for a new
-    provisioning attempt (recovery happens outside the reservation lock).
-    Returns the new generation, or None when the row already moved on."""
+    """Take over an unhealthy ``RUNNING`` sandbox for a new provisioning
+    attempt — applied only if the row is still RUNNING under
+    ``expected_attempt_number`` (recovery happens outside the reservation lock).
+    Returns the new attempt number, or None when the row already moved on."""
     result = db_session.execute(
         update(Sandbox)
         .where(
             Sandbox.id == sandbox_id,
-            Sandbox.provisioning_generation == expected_generation,
+            Sandbox.provisioning_attempt_number == expected_attempt_number,
             Sandbox.status == SandboxStatus.RUNNING,
         )
         .values(
             status=SandboxStatus.PROVISIONING,
-            provisioning_generation=expected_generation + 1,
+            provisioning_attempt_number=expected_attempt_number + 1,
             provisioning_started_at=datetime.datetime.now(datetime.timezone.utc),
         )
     )
     if result.rowcount != 1:  # ty: ignore[unresolved-attribute]
         return None
-    return expected_generation + 1
+    return expected_attempt_number + 1
 
 
 def finalize_provisioning_attempt__no_commit(
     db_session: Session,
     sandbox_id: UUID,
-    generation: int,
+    attempt_number: int,
     to_status: Literal[SandboxStatus.RUNNING, SandboxStatus.FAILED],
 ) -> bool:
-    """Generation-guarded compare-and-set ``PROVISIONING`` → outcome.
-    Returns False when the attempt is stale (the row moved on or a newer
-    generation exists) — the caller's external work must not be recorded as
-    the current runtime. ``RUNNING`` also stamps the heartbeat so the fresh
-    pod gets a proper idle-timeout baseline."""
+    """Record the attempt's outcome — applied only if the row is still
+    ``PROVISIONING`` under this attempt's number. Returns False when a newer
+    attempt has taken over: the caller's external work must not be recorded
+    as the current runtime. ``RUNNING`` also stamps the heartbeat so the
+    fresh pod gets a proper idle-timeout baseline."""
     values: dict[str, object] = {"status": to_status}
     if to_status == SandboxStatus.RUNNING:
         values["last_heartbeat"] = datetime.datetime.now(datetime.timezone.utc)
@@ -153,7 +154,7 @@ def finalize_provisioning_attempt__no_commit(
         update(Sandbox)
         .where(
             Sandbox.id == sandbox_id,
-            Sandbox.provisioning_generation == generation,
+            Sandbox.provisioning_attempt_number == attempt_number,
             Sandbox.status == SandboxStatus.PROVISIONING,
         )
         .values(**values)
@@ -164,17 +165,17 @@ def finalize_provisioning_attempt__no_commit(
 def sleep_running_sandbox__no_commit(
     db_session: Session,
     sandbox_id: UUID,
-    generation: int,
+    attempt_number: int,
 ) -> bool:
-    """Generation-guarded compare-and-set ``RUNNING`` → ``SLEEPING`` for the
-    idle reaper. Returns False when the row moved on (a concurrent recovery or
-    create advanced the generation / left RUNNING), so the reaper must not
-    clobber that decision with an unconditional sleep."""
+    """``RUNNING`` → ``SLEEPING`` for the idle reaper — applied only if the
+    sandbox still belongs to attempt ``attempt_number``. Returns False when the
+    row moved on (a concurrent recovery or create started a newer attempt /
+    left RUNNING), so the reaper must not clobber that decision."""
     result = db_session.execute(
         update(Sandbox)
         .where(
             Sandbox.id == sandbox_id,
-            Sandbox.provisioning_generation == generation,
+            Sandbox.provisioning_attempt_number == attempt_number,
             Sandbox.status == SandboxStatus.RUNNING,
         )
         .values(status=SandboxStatus.SLEEPING)

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -236,34 +236,6 @@ def lock_sandbox_skills_hashes(
     return {sandbox_id: skills_hash for sandbox_id, skills_hash in rows}
 
 
-def update_sandbox_status__no_commit(
-    db_session: Session,
-    sandbox_id: UUID,
-    status: SandboxStatus,
-) -> Sandbox:
-    """Update sandbox status.
-
-    When transitioning to RUNNING, also sets last_heartbeat to now. This ensures
-    newly provisioned sandboxes have a proper idle timeout baseline (rather than
-    being immediately considered idle due to NULL heartbeat).
-
-    NOTE: This function uses flush() instead of commit(). The caller is
-    responsible for committing the transaction when ready.
-    """
-    sandbox = get_sandbox_by_id(db_session, sandbox_id)
-    if not sandbox:
-        raise ValueError(f"Sandbox {sandbox_id} not found")
-
-    sandbox.status = status
-
-    # Set heartbeat when sandbox becomes active to establish idle timeout baseline
-    if status == SandboxStatus.RUNNING:
-        sandbox.last_heartbeat = datetime.datetime.now(datetime.timezone.utc)
-
-    db_session.flush()
-    return sandbox
-
-
 def update_sandbox_heartbeat(db_session: Session, sandbox_id: UUID) -> Sandbox:
     """Update the heartbeat without committing the caller's transaction."""
     sandbox = get_sandbox_by_id(db_session, sandbox_id)
@@ -309,14 +281,18 @@ def user_has_stale_active_session(
     return db_session.execute(stmt).first() is not None
 
 
-def get_running_sandbox_count(
+def get_occupying_sandbox_count(
     db_session: Session,
 ) -> int:
-    """Get count of all running sandboxes (for limit enforcement).
+    """Count sandboxes that hold (or are about to hold) a runtime — RUNNING
+    plus PROVISIONING — for concurrency-limit enforcement. Counting only
+    RUNNING would let concurrent first-time creates all pass the check.
 
     Per-tenant by virtue of schema-scoped sessions on multi-tenant.
     """
-    stmt = select(func.count(Sandbox.id)).where(Sandbox.status == SandboxStatus.RUNNING)
+    stmt = select(func.count(Sandbox.id)).where(
+        Sandbox.status.in_((SandboxStatus.RUNNING, SandboxStatus.PROVISIONING))
+    )
     result = db_session.execute(stmt).scalar()
     return result or 0
 

--- a/backend/onyx/server/features/build/interactive_turns/api.py
+++ b/backend/onyx/server/features/build/interactive_turns/api.py
@@ -21,6 +21,7 @@ from onyx.db.enums import Permission
 from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.build.configs import SSE_KEEPALIVE_INTERVAL
 from onyx.server.features.build.db.build_session import get_build_session
 from onyx.server.features.build.interactive_turns.executor import (
     start_interactive_turn_runner,
@@ -33,15 +34,17 @@ from onyx.server.features.build.interactive_turns.state import (
 )
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.features.build.session.streaming import SSE_KEEPALIVE
+from onyx.server.features.build.timeouts import POLL_INTERVAL_SECONDS
 from onyx.utils.logger import setup_logger
 
 router = APIRouter()
 logger = setup_logger()
 
-LIVE_STREAM_READY_POLL_SECONDS = 0.25
-LIVE_STREAM_KEEPALIVE_SECONDS = 15.0
-LIVE_STREAM_RUNNER_RETRY_SECONDS = 5.0
 TERMINAL_STREAM_EVENT_TYPES = frozenset(("prompt_response", "error"))
+
+# Throttle on runner-claim retries from the attach stream; must be well under
+# RUNNER_STALE_AFTER_SECONDS so a stolen turn restarts promptly.
+LIVE_STREAM_RUNNER_RETRY_SECONDS = 5.0
 
 
 def _format_stream_error(detail: str) -> str:
@@ -194,7 +197,7 @@ def get_interactive_turn_events(
 
             yield SSE_KEEPALIVE
             maybe_start_runner()
-            time.sleep(LIVE_STREAM_READY_POLL_SECONDS)
+            time.sleep(POLL_INTERVAL_SECONDS)
 
         try:
             with get_session_with_current_tenant() as stream_db_session:
@@ -203,7 +206,7 @@ def get_interactive_turn_events(
                 for chunk in session_manager.subscribe_to_existing_session_events(
                     session_id,
                     user_id,
-                    keepalive_seconds=LIVE_STREAM_KEEPALIVE_SECONDS,
+                    keepalive_seconds=SSE_KEEPALIVE_INTERVAL,
                 ):
                     yield chunk
                     chunk_type = _stream_chunk_type(chunk)
@@ -229,8 +232,9 @@ def get_interactive_turn_events(
                         continue
                     terminal_error_detail = None
                     # Not redundant with the attach-time force start: a dead
-                    # runner's turn only becomes reclaimable 90s after its last
-                    # heartbeat; claim no-ops while the turn is healthy.
+                    # runner's turn only becomes reclaimable
+                    # RUNNER_STALE_AFTER_SECONDS after its last heartbeat;
+                    # claim no-ops while the turn is healthy.
                     maybe_start_runner()
                 if terminal_error_detail:
                     yield _format_stream_error(terminal_error_detail)

--- a/backend/onyx/server/features/build/interactive_turns/executor.py
+++ b/backend/onyx/server/features/build/interactive_turns/executor.py
@@ -224,7 +224,7 @@ def _drive_interactive_turn(
             return
 
         try:
-            # Re-fence after the (possibly long) slot wait: a reclaim acquire
+            # Re-check ownership after the (possibly long) slot wait: a reclaim acquire
             # can block past RUNNER_STALE_AFTER_SECONDS, letting another
             # runner steal the turn — it must not reach the prompt POST.
             if not touch_turn(cache=cache, turn_id=turn_id, runner_id=runner_id):

--- a/backend/onyx/server/features/build/interactive_turns/executor.py
+++ b/backend/onyx/server/features/build/interactive_turns/executor.py
@@ -31,10 +31,6 @@ from onyx.server.features.build.sandbox.event_schema import (
 )
 from onyx.server.features.build.sandbox.event_schema import Error as SandboxError
 from onyx.server.features.build.sandbox.models import PromptAttachment
-from onyx.server.features.build.sandbox.serve_transport import (
-    PROMPT_SLOT_FAST_FAIL_ACQUIRE_SECONDS,
-    PROMPT_SLOT_WAIT_OUT_ORPHAN_SECONDS,
-)
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.server.features.build.session.interrupt_signal import (
     clear_interrupt,
@@ -42,6 +38,11 @@ from onyx.server.features.build.session.interrupt_signal import (
 )
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.features.build.session.streaming import BuildStreamingState
+from onyx.server.features.build.timeouts import (
+    PROMPT_SLOT_FAST_FAIL_ACQUIRE_SECONDS,
+    PROMPT_SLOT_WAIT_OUT_ORPHAN_SECONDS,
+    TURN_BUDGET_SECONDS,
+)
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import (
     CURRENT_TENANT_ID_CONTEXTVAR,
@@ -49,8 +50,6 @@ from shared_configs.contextvars import (
 )
 
 logger = setup_logger()
-
-DEFAULT_INTERACTIVE_TURN_BUDGET_SECONDS = 30 * 60
 
 MAX_TIMEOUT_CONTINUATIONS = 2
 _TOOL_TIMEOUT_CONTINUATION_PROMPT = (
@@ -131,7 +130,7 @@ def start_interactive_turn_runner(turn_id: UUID) -> None:
 def run_claimed_interactive_build_turn(
     turn: InteractiveTurn,
     *,
-    budget_seconds: int = DEFAULT_INTERACTIVE_TURN_BUDGET_SECONDS,
+    budget_seconds: int = TURN_BUDGET_SECONDS,
 ) -> None:
     """Execute a turn that this runner has already claimed in CacheBackend."""
     cache = get_cache_backend()

--- a/backend/onyx/server/features/build/interactive_turns/state.py
+++ b/backend/onyx/server/features/build/interactive_turns/state.py
@@ -18,8 +18,8 @@ from onyx.server.features.build.timeouts import (
 from onyx.utils.datetime import datetime_to_utc
 
 # Turn-state mutex: guards a handful of Redis round-trips per mutation; the
-# lease only needs to exceed the longest critical section. Ownership is fenced
-# by the runner_id compare, never by this lease.
+# lease only needs to exceed the longest critical section. Ownership is
+# decided by the runner_id compare, never by this lease.
 TURN_LOCK_LEASE_SECONDS = 60.0
 TURN_LOCK_WAIT_SECONDS = 10.0
 

--- a/backend/onyx/server/features/build/interactive_turns/state.py
+++ b/backend/onyx/server/features/build/interactive_turns/state.py
@@ -10,7 +10,18 @@ from uuid import UUID, uuid4
 
 from onyx.cache.interface import CacheBackend, CacheLock
 from onyx.server.features.build.sandbox.models import PromptAttachment
+from onyx.server.features.build.timeouts import (
+    ACTIVE_TURN_TTL_SECONDS,
+    REQUEST_ID_TTL_SECONDS,
+    RUNNER_STALE_AFTER_SECONDS,
+)
 from onyx.utils.datetime import datetime_to_utc
+
+# Turn-state mutex: guards a handful of Redis round-trips per mutation; the
+# lease only needs to exceed the longest critical section. Ownership is fenced
+# by the runner_id compare, never by this lease.
+TURN_LOCK_LEASE_SECONDS = 60.0
+TURN_LOCK_WAIT_SECONDS = 10.0
 
 
 class InteractiveTurnStatus(StrEnum):
@@ -28,11 +39,6 @@ TURN_STATUS_FAILED = InteractiveTurnStatus.FAILED
 TURN_STATUS_CANCELLED = InteractiveTurnStatus.CANCELLED
 
 ACTIVE_TURN_STATUSES = frozenset((TURN_STATUS_QUEUED, TURN_STATUS_RUNNING))
-ACTIVE_TURN_TTL_SECONDS = 45 * 60
-REQUEST_ID_TTL_SECONDS = 60 * 60
-TURN_LOCK_LEASE_SECONDS = 60.0
-TURN_LOCK_WAIT_SECONDS = 10.0
-RUNNER_STALE_AFTER_SECONDS = 90.0
 
 
 class InteractiveTurnLockError(Exception):

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -142,10 +142,10 @@ class SandboxManager(_ServeMixin, ABC):
             tenant_id: Tenant identifier for multi-tenant isolation
             onyx_pat: Raw PAT token to inject as ONYX_PAT env var in the sandbox
             provisioning_attempt_number: This attempt's number; stamped onto
-                backend resources at creation so operators can attribute
-                orphans (never read programmatically — the attempt-number
-                condition on DB status writes is what blocks stale
-                attempts).
+                the runtime at creation (and restamped on reuse) so guarded
+                deletes never destroy a newer attempt's runtime, and so
+                operators can attribute orphans. DB status writes remain the
+                primary fence.
 
         Returns:
             SandboxInfo with the provisioned sandbox details
@@ -156,13 +156,24 @@ class SandboxManager(_ServeMixin, ABC):
         ...
 
     @abstractmethod
-    def terminate(self, sandbox_id: UUID) -> None:
+    def terminate(
+        self, sandbox_id: UUID, max_attempt_number: int | None = None
+    ) -> None:
         """Terminate a sandbox and clean up all resources. Destroys every
         session workspace; for one session use ``cleanup_session_workspace``.
+
+        When ``max_attempt_number`` is given, the runtime is destroyed only if
+        its provisioning-attempt label is at most that number — a superseded
+        caller can never delete a newer attempt's runtime. ``None`` destroys
+        unconditionally (session-delete flows, tests).
 
         Implementations MUST call ``self._close_all_sandbox_buses(sandbox_id)``
         before destroying the backend so late subscribes can't race a fresh
         bus in.
+
+        Raises:
+            SandboxProvisionContentionError: another provisioner currently
+                owns this sandbox's runtime (Kubernetes backend only).
         """
         ...
 

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -142,10 +142,10 @@ class SandboxManager(_ServeMixin, ABC):
             tenant_id: Tenant identifier for multi-tenant isolation
             onyx_pat: Raw PAT token to inject as ONYX_PAT env var in the sandbox
             provisioning_attempt_number: This attempt's number; stamped onto
-                the runtime at creation (and restamped on reuse) so guarded
-                deletes never destroy a newer attempt's runtime, and so
-                operators can attribute orphans. DB status writes remain the
-                primary fence.
+                backend resources at creation so operators can attribute
+                orphans (never read programmatically — the attempt-number
+                condition on DB status writes is what blocks stale
+                attempts).
 
         Returns:
             SandboxInfo with the provisioned sandbox details
@@ -156,24 +156,13 @@ class SandboxManager(_ServeMixin, ABC):
         ...
 
     @abstractmethod
-    def terminate(
-        self, sandbox_id: UUID, max_attempt_number: int | None = None
-    ) -> None:
+    def terminate(self, sandbox_id: UUID) -> None:
         """Terminate a sandbox and clean up all resources. Destroys every
         session workspace; for one session use ``cleanup_session_workspace``.
-
-        When ``max_attempt_number`` is given, the runtime is destroyed only if
-        its provisioning-attempt label is at most that number — a superseded
-        caller can never delete a newer attempt's runtime. ``None`` destroys
-        unconditionally (session-delete flows, tests).
 
         Implementations MUST call ``self._close_all_sandbox_buses(sandbox_id)``
         before destroying the backend so late subscribes can't race a fresh
         bus in.
-
-        Raises:
-            SandboxProvisionContentionError: another provisioner currently
-                owns this sandbox's runtime (Kubernetes backend only).
         """
         ...
 

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -45,6 +45,7 @@ from onyx.server.features.build.sandbox.models import (
 )
 from onyx.server.features.build.sandbox.serve_transport import _ServeMixin
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
+from onyx.server.features.build.timeouts import BULK_TRANSFER_TIMEOUT_SECONDS
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -297,7 +298,7 @@ class SandboxManager(_ServeMixin, ABC):
         self,
         sandbox_id: UUID,
         tenant_id: str,
-        timeout_seconds: float = 300.0,
+        timeout_seconds: float = BULK_TRANSFER_TIMEOUT_SECONDS,
     ) -> bool:
         """Snapshot sandbox-global opencode history if this backend supports it.
 
@@ -351,11 +352,12 @@ class SandboxManager(_ServeMixin, ABC):
         ...
 
     @abstractmethod
-    def health_check(self, sandbox_id: UUID, timeout: float = 60.0) -> bool:
+    def health_check(self, sandbox_id: UUID, timeout: float) -> bool:
         """Check if the sandbox is healthy.
 
         Args:
             sandbox_id: The sandbox ID to check
+            timeout: Probe timeout, chosen by the caller for its path.
 
         Returns:
             True if sandbox is healthy, False otherwise

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -118,9 +118,11 @@ class SandboxManager(_ServeMixin, ABC):
         sandbox_id: UUID,
         user_id: UUID,
         tenant_id: str,
-        onyx_pat: str | None = None,
+        onyx_pat: str | None,
+        provisioning_generation: int,
     ) -> SandboxInfo:
-        """Provision a new sandbox for a user.
+        """Provision a new sandbox for a user. Returns only once the sandbox
+        is RUNNING; every failure raises.
 
         Craft MCP servers and the gateway provider catalog are NOT registered
         here — they live in the per-session ``opencode.json`` (see
@@ -138,6 +140,10 @@ class SandboxManager(_ServeMixin, ABC):
             user_id: User identifier who owns this sandbox
             tenant_id: Tenant identifier for multi-tenant isolation
             onyx_pat: Raw PAT token to inject as ONYX_PAT env var in the sandbox
+            provisioning_generation: Committed fencing generation of the
+                attempt; stamped onto backend resources at creation for
+                operator-facing orphan attribution (never read
+                programmatically — the DB compare-and-set is the fence).
 
         Returns:
             SandboxInfo with the provisioned sandbox details

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -120,7 +120,7 @@ class SandboxManager(_ServeMixin, ABC):
         user_id: UUID,
         tenant_id: str,
         onyx_pat: str | None,
-        provisioning_generation: int,
+        provisioning_attempt_number: int,
     ) -> SandboxInfo:
         """Provision a new sandbox for a user. Returns only once the sandbox
         is RUNNING; every failure raises.
@@ -141,10 +141,11 @@ class SandboxManager(_ServeMixin, ABC):
             user_id: User identifier who owns this sandbox
             tenant_id: Tenant identifier for multi-tenant isolation
             onyx_pat: Raw PAT token to inject as ONYX_PAT env var in the sandbox
-            provisioning_generation: Committed fencing generation of the
-                attempt; stamped onto backend resources at creation for
-                operator-facing orphan attribution (never read
-                programmatically — the DB compare-and-set is the fence).
+            provisioning_attempt_number: This attempt's number; stamped onto
+                backend resources at creation so operators can attribute
+                orphans (never read programmatically — the attempt-number
+                condition on DB status writes is what blocks stale
+                attempts).
 
         Returns:
             SandboxInfo with the provisioned sandbox details

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -116,7 +116,7 @@ from onyx.server.features.build.sandbox.docker.internal.exec_helpers import (
 from onyx.server.features.build.sandbox.labels import (
     LABEL_K8S_MANAGED_BY,
     LABEL_K8S_MANAGED_BY_ONYX,
-    LABEL_PROVISIONING_GENERATION,
+    LABEL_PROVISIONING_ATTEMPT,
     LABEL_SANDBOX_ID,
     LABEL_TENANT_ID,
 )
@@ -348,7 +348,7 @@ def build_sandbox_labels(
     tenant_id: str,
     user_id: UUID | None,
     compose_project: str | None = None,
-    provisioning_generation: int | None = None,
+    provisioning_attempt_number: int | None = None,
 ) -> dict[str, str]:
     """Standard label set for sandbox-owned docker resources.
 
@@ -357,7 +357,7 @@ def build_sandbox_labels(
     api_server/postgres/redis/etc. Auto-detected by ``DockerSandboxManager``
     from its own container's labels.
 
-    ``provisioning_generation`` is stamped on containers (not the per-sandbox
+    ``provisioning_attempt_number`` is stamped on containers (not the per-sandbox
     volume, which persists across generations) for attribution.
     """
     labels: dict[str, str] = {
@@ -370,8 +370,8 @@ def build_sandbox_labels(
         labels[LABEL_USER_ID] = str(user_id)
     if compose_project:
         labels["com.docker.compose.project"] = compose_project
-    if provisioning_generation is not None:
-        labels[LABEL_PROVISIONING_GENERATION] = str(provisioning_generation)
+    if provisioning_attempt_number is not None:
+        labels[LABEL_PROVISIONING_ATTEMPT] = str(provisioning_attempt_number)
     return labels
 
 
@@ -472,7 +472,7 @@ def build_container_create_kwargs(
     cpu_limit: float,
     opencode_password: str,
     opencode_config_json: str,
-    provisioning_generation: int,
+    provisioning_attempt_number: int,
     compose_project: str | None = None,
     sandbox_proxy_host: str | None = None,
     proxy_ca_volume_name: str | None = None,
@@ -615,7 +615,7 @@ def build_container_create_kwargs(
             tenant_id,
             user_id,
             compose_project=compose_project,
-            provisioning_generation=provisioning_generation,
+            provisioning_attempt_number=provisioning_attempt_number,
         ),
         "user": user,
         "cap_drop": ["ALL"],
@@ -820,7 +820,7 @@ class DockerSandboxManager(SandboxManager):
         user_id: UUID,
         tenant_id: str,
         onyx_pat: str | None,
-        provisioning_generation: int,
+        provisioning_attempt_number: int,
     ) -> SandboxInfo:
         if not onyx_pat:
             raise ValueError("onyx_pat is required for Docker sandbox provisioning.")
@@ -873,7 +873,7 @@ class DockerSandboxManager(SandboxManager):
                 volume_name=volume_name,
                 opencode_password=opencode_password,
                 opencode_config_json=opencode_config_json,
-                provisioning_generation=provisioning_generation,
+                provisioning_attempt_number=provisioning_attempt_number,
             )
 
         if created_fresh:
@@ -969,7 +969,7 @@ class DockerSandboxManager(SandboxManager):
         volume_name: str,
         opencode_password: str,
         opencode_config_json: str,
-        provisioning_generation: int,
+        provisioning_attempt_number: int,
     ) -> tuple[Container, bool]:
         """
         Creates (not starts) the container; returns ``(container,
@@ -999,7 +999,7 @@ class DockerSandboxManager(SandboxManager):
             compose_project=self._compose_project,
             sandbox_proxy_host=proxy_host,
             proxy_ca_volume_name=(SANDBOX_PROXY_CA_VOLUME_NAME if proxy_host else None),
-            provisioning_generation=provisioning_generation,
+            provisioning_attempt_number=provisioning_attempt_number,
         )
         # create (not run) so the caller can put_archive history before start.
         # detach is run-only.

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -116,6 +116,7 @@ from onyx.server.features.build.sandbox.docker.internal.exec_helpers import (
 from onyx.server.features.build.sandbox.labels import (
     LABEL_K8S_MANAGED_BY,
     LABEL_K8S_MANAGED_BY_ONYX,
+    LABEL_PROVISIONING_GENERATION,
     LABEL_SANDBOX_ID,
     LABEL_TENANT_ID,
 )
@@ -129,6 +130,13 @@ from onyx.server.features.build.sandbox.models import (
 )
 from onyx.server.features.build.sandbox.nextjs_dev import build_nextjs_start_script
 from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
+from onyx.server.features.build.sandbox.session_workspace import (
+    MANAGED_SKILLS_PATH,
+    MANAGED_USER_LIBRARY_PATH,
+    SESSIONS_ROOT,
+    build_session_workspace_setup_script,
+    build_workspace_exists_check_script,
+)
 from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
 from onyx.server.features.build.sandbox.util.agent_instructions import (
     ATTACHMENTS_SECTION_CONTENT,
@@ -153,16 +161,12 @@ LABEL_USER_ID = "onyx.app/user-id"
 
 # Path conventions inside the sandbox container — must match the K8s image.
 WORKSPACE_ROOT = "/workspace"
-SESSIONS_ROOT = f"{WORKSPACE_ROOT}/sessions"
 # Opencode's data home (its XDG_DATA_HOME); matches entrypoint.sh's default. It
 # lives in the container writable layer, not the per-sandbox volume, so it is
 # durable only via the FileStore history snapshot. Its basename must equal the
 # daemon archive's root dir, so put_archive at WORKSPACE_ROOT lands the restored
 # tree here (see _maybe_restore_opencode_history).
 OPENCODE_DATA_DIR = f"{WORKSPACE_ROOT}/.opencode-data"
-TEMPLATES_OUTPUTS_PATH = f"{WORKSPACE_ROOT}/templates/outputs"
-MANAGED_SKILLS_PATH = f"{WORKSPACE_ROOT}/managed/skills"
-MANAGED_USER_LIBRARY_PATH = f"{WORKSPACE_ROOT}/managed/user_library"
 SANDBOX_EXEC_USER = "1000:1000"
 # Docker exec bypasses firewall-init.sh's setpriv environment workaround, so
 # sandbox-user execs must carry the uid/gid and user HOME together.
@@ -345,6 +349,7 @@ def build_sandbox_labels(
     tenant_id: str,
     user_id: UUID | None,
     compose_project: str | None = None,
+    provisioning_generation: int | None = None,
 ) -> dict[str, str]:
     """Standard label set for sandbox-owned docker resources.
 
@@ -352,6 +357,9 @@ def build_sandbox_labels(
     Desktop groups sandbox containers under the same "onyx" stack header as
     api_server/postgres/redis/etc. Auto-detected by ``DockerSandboxManager``
     from its own container's labels.
+
+    ``provisioning_generation`` is stamped on containers (not the per-sandbox
+    volume, which persists across generations) for attribution.
     """
     labels: dict[str, str] = {
         LABEL_COMPONENT: LABEL_COMPONENT_VALUE,
@@ -363,6 +371,8 @@ def build_sandbox_labels(
         labels[LABEL_USER_ID] = str(user_id)
     if compose_project:
         labels["com.docker.compose.project"] = compose_project
+    if provisioning_generation is not None:
+        labels[LABEL_PROVISIONING_GENERATION] = str(provisioning_generation)
     return labels
 
 
@@ -463,6 +473,7 @@ def build_container_create_kwargs(
     cpu_limit: float,
     opencode_password: str,
     opencode_config_json: str,
+    provisioning_generation: int,
     compose_project: str | None = None,
     sandbox_proxy_host: str | None = None,
     proxy_ca_volume_name: str | None = None,
@@ -601,7 +612,11 @@ def build_container_create_kwargs(
         "command": command,
         "detach": True,
         "labels": build_sandbox_labels(
-            sandbox_id, tenant_id, user_id, compose_project=compose_project
+            sandbox_id,
+            tenant_id,
+            user_id,
+            compose_project=compose_project,
+            provisioning_generation=provisioning_generation,
         ),
         "user": user,
         "cap_drop": ["ALL"],
@@ -804,7 +819,8 @@ class DockerSandboxManager(SandboxManager):
         sandbox_id: UUID,
         user_id: UUID,
         tenant_id: str,
-        onyx_pat: str | None = None,
+        onyx_pat: str | None,
+        provisioning_generation: int,
     ) -> SandboxInfo:
         if not onyx_pat:
             raise ValueError("onyx_pat is required for Docker sandbox provisioning.")
@@ -857,6 +873,7 @@ class DockerSandboxManager(SandboxManager):
                 volume_name=volume_name,
                 opencode_password=opencode_password,
                 opencode_config_json=opencode_config_json,
+                provisioning_generation=provisioning_generation,
             )
 
         if created_fresh:
@@ -945,6 +962,7 @@ class DockerSandboxManager(SandboxManager):
         volume_name: str,
         opencode_password: str,
         opencode_config_json: str,
+        provisioning_generation: int,
     ) -> tuple[Container, bool]:
         """
         Creates (not starts) the container; returns ``(container,
@@ -974,6 +992,7 @@ class DockerSandboxManager(SandboxManager):
             compose_project=self._compose_project,
             sandbox_proxy_host=proxy_host,
             proxy_ca_volume_name=(SANDBOX_PROXY_CA_VOLUME_NAME if proxy_host else None),
+            provisioning_generation=provisioning_generation,
         )
         # create (not run) so the caller can put_archive history before start.
         # detach is run-only.
@@ -1025,7 +1044,7 @@ class DockerSandboxManager(SandboxManager):
         state = (container.attrs or {}).get("State") or {}
         return state.get("Status") == "running"
 
-    def _render_agents_md(
+    def _build_agents_md(
         self,
         *,
         agent_provider: str | None,
@@ -1034,8 +1053,8 @@ class DockerSandboxManager(SandboxManager):
         connectable_apps_section: str,
         user_name: str | None = None,
     ) -> str:
-        """Shell-escaped AGENTS.md for ``printf '%s' '...'``."""
-        agent_instructions = generate_agent_instructions(
+        """Raw (unescaped) AGENTS.md content."""
+        return generate_agent_instructions(
             template_path=self._agent_instructions_template_path,
             connectable_apps_section=connectable_apps_section,
             provider=agent_provider,
@@ -1045,7 +1064,6 @@ class DockerSandboxManager(SandboxManager):
             user_name=user_name,
             organization_instructions=load_settings().craft_instructions,
         )
-        return agent_instructions.replace("'", "'\\''")
 
     def setup_session_workspace(
         self,
@@ -1059,7 +1077,7 @@ class DockerSandboxManager(SandboxManager):
     ) -> None:
         container = self._require_container(sandbox_id)
         session_path = f"{SESSIONS_ROOT}/{session_id}"
-        agents_md = self._render_agents_md(
+        agents_md = self._build_agents_md(
             agent_provider=llm_config.provider,
             agent_model=llm_config.model_name,
             nextjs_port=nextjs_port,
@@ -1074,48 +1092,12 @@ class DockerSandboxManager(SandboxManager):
                 session_id=str(session_id),
             )
         )
-        session_opencode_config_setup = (
-            f"printf '%s' {shlex.quote(session_opencode_config)} > "
-            f"{session_path}/opencode.json"
+        setup_script = build_session_workspace_setup_script(
+            session_path=session_path,
+            agents_md=agents_md,
+            session_opencode_config_json=session_opencode_config,
+            nextjs_port=nextjs_port,
         )
-
-        nextjs_start = (
-            build_nextjs_start_script(session_path, nextjs_port)
-            if nextjs_port is not None
-            else ""
-        )
-        setup_script = f"""
-set -e
-echo "Creating session directory: {session_path}"
-mkdir -p {session_path}/outputs {session_path}/attachments {session_path}/.opencode
-if [ -d {TEMPLATES_OUTPUTS_PATH} ]; then
-    cp -r {TEMPLATES_OUTPUTS_PATH}/* {session_path}/outputs/
-    # flock+sentinel: serialize concurrent session setups; .ready guards
-    # against a partial cp from a previous interrupted run.
-    (
-        flock -x 9
-        if [ ! -f {BUN_CACHE_DIR}/.ready ]; then
-            echo "Bootstrapping bun cache on workspace volume..."
-            rm -rf {BUN_CACHE_DIR}
-            cp -r {BUN_IMAGE_CACHE_DIR} {BUN_CACHE_DIR} \
-                || {{ echo "ERROR: bun cache bootstrap failed" >&2; exit 1; }}
-            touch {BUN_CACHE_DIR}/.ready
-        fi
-    ) 9>{BUN_CACHE_DIR}.lock
-    cd {session_path}/outputs/web && \
-        BUN_INSTALL_CACHE_DIR={BUN_CACHE_DIR} \
-        bun install --frozen-lockfile --backend=hardlink
-else
-    echo "Warning: outputs template not found at {TEMPLATES_OUTPUTS_PATH}"
-    mkdir -p {session_path}/outputs/web
-fi
-ln -sf {MANAGED_SKILLS_PATH} {session_path}/.opencode/skills
-ln -sf {MANAGED_USER_LIBRARY_PATH} {session_path}/user_library
-printf '%s' '{agents_md}' > {session_path}/AGENTS.md
-{session_opencode_config_setup}
-{nextjs_start}
-echo "Session workspace setup complete"
-"""
 
         logger.info(
             "Setting up session workspace %s in sandbox %s.", session_id, sandbox_id
@@ -1177,14 +1159,15 @@ echo "Session cleanup complete"
         container = self._get_container(sandbox_id)
         if container is None:
             return False
-        target = f"{SESSIONS_ROOT}/{session_id}/outputs"
         try:
             result = _run_in_container_as_sandbox_user(
                 container,
                 [
                     "/bin/sh",
                     "-c",
-                    f'[ -d "{target}" ] && echo "WORKSPACE_FOUND" || echo "WORKSPACE_MISSING"',
+                    build_workspace_exists_check_script(
+                        f"{SESSIONS_ROOT}/{session_id}"
+                    ),
                 ],
                 check=False,
             )
@@ -1516,7 +1499,7 @@ fi
         """Rewrite generated session configuration and managed symlinks."""
         container = self._require_container(sandbox_id)
         session_path = f"{SESSIONS_ROOT}/{session_id}"
-        agents_md = self._render_agents_md(
+        agents_md = self._build_agents_md(
             agent_provider=agent_provider,
             agent_model=agent_model,
             nextjs_port=nextjs_port,
@@ -1549,7 +1532,7 @@ set -e
 mkdir -p {session_path}/.opencode
 ln -sfn {MANAGED_SKILLS_PATH} {session_path}/.opencode/skills
 ln -sfn {MANAGED_USER_LIBRARY_PATH} {session_path}/user_library
-printf '%s' '{agents_md}' > {session_path}/AGENTS.md
+printf '%s' {shlex.quote(agents_md)} > {session_path}/AGENTS.md
 {session_opencode_config_setup}
 if [ -n "$(find {session_path}/attachments -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]; then
     printf '\n\n' >> {session_path}/AGENTS.md

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -149,6 +149,11 @@ from onyx.server.features.build.sandbox.util.opencode_config import (
     build_opencode_base_config,
     build_provider_opencode_config,
 )
+from onyx.server.features.build.timeouts import (
+    BULK_TRANSFER_TIMEOUT_SECONDS,
+    POLL_INTERVAL_SECONDS,
+    PROVISION_DEADLINE_SECONDS,
+)
 from onyx.server.settings.store import load_settings
 from onyx.utils.logger import setup_logger
 
@@ -173,12 +178,6 @@ SANDBOX_EXEC_USER = "1000:1000"
 SANDBOX_EXEC_ENV = {"HOME": "/home/sandbox", "USER": "sandbox"}
 SANDBOX_TMP_PATH = "/tmp"  # noqa: S108 - sandbox-local scratch mount.
 SANDBOX_TMPFS_OPTIONS = "rw,nosuid,nodev,size=5g,mode=1777"
-
-# Mirror the K8s constants in ``kubernetes_sandbox_manager`` (POD_READY_*),
-# which are also module-level and not env-tunable.
-CONTAINER_READY_TIMEOUT_SECONDS = 120
-CONTAINER_READY_POLL_INTERVAL_SECONDS = 1.0
-
 
 # Egress proxy file paths inside the sandbox container. Matched by
 # ``firewall-init.sh``: ``CA_SRC`` defaults to ``/sandbox-ca/ca.crt`` and
@@ -798,9 +797,10 @@ class DockerSandboxManager(SandboxManager):
             )
         return c
 
-    def _wait_for_container_running(self, container: Container) -> bool:
-        start_time = time.time()
-        while time.time() - start_time < CONTAINER_READY_TIMEOUT_SECONDS:
+    def _wait_for_container_running(
+        self, container: Container, deadline: float
+    ) -> bool:
+        while time.monotonic() < deadline:
             container.reload()
             state = (container.attrs or {}).get("State") or {}
             status = state.get("Status")
@@ -811,7 +811,7 @@ class DockerSandboxManager(SandboxManager):
                 raise RuntimeError(
                     f"Sandbox container {container.name} exited unexpectedly. Logs:\n{logs[:2000]}"
                 )
-            time.sleep(CONTAINER_READY_POLL_INTERVAL_SECONDS)
+            time.sleep(POLL_INTERVAL_SECONDS)
         return False
 
     def provision(
@@ -890,12 +890,19 @@ class DockerSandboxManager(SandboxManager):
                     f"Failed to provision sandbox container {container.name}: {e}"
                 ) from e
 
-        if not self._wait_for_container_running(container):
+        # One deadline shared by the readiness phases. Started here, after the
+        # image pull: a cold pull of the sandbox image can legitimately take
+        # minutes and must not eat the container's own startup budget.
+        deadline = time.monotonic() + PROVISION_DEADLINE_SECONDS
+
+        if not self._wait_for_container_running(container, deadline):
             raise RuntimeError(
                 f"Timeout waiting for sandbox container {container.name} to be running."
             )
 
-        if not self._wait_for_opencode_serve_ready(sandbox_id):
+        if not self._wait_for_opencode_serve_ready(
+            sandbox_id, timeout=deadline - time.monotonic()
+        ):
             raise RuntimeError(
                 f"opencode-serve never became ready in sandbox container {container.name}."
             )
@@ -1033,7 +1040,7 @@ class DockerSandboxManager(SandboxManager):
 
         logger.info("Terminated Docker sandbox %s.", sandbox_id)
 
-    def health_check(self, sandbox_id: UUID, timeout: float = 60.0) -> bool:  # noqa: ARG002
+    def health_check(self, sandbox_id: UUID, timeout: float) -> bool:  # noqa: ARG002
         container = self._get_container(sandbox_id)
         if container is None:
             return False
@@ -1275,7 +1282,7 @@ echo "Session cleanup complete"
         self,
         sandbox_id: UUID,
         tenant_id: str,
-        timeout_seconds: float = 300.0,  # noqa: ARG002 - exec uses the docker client timeout
+        timeout_seconds: float = BULK_TRANSFER_TIMEOUT_SECONDS,  # noqa: ARG002 - exec uses the docker client timeout
     ) -> bool:
         """Captures sandbox-global opencode history to the FileStore.
 

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -1013,29 +1013,10 @@ class DockerSandboxManager(SandboxManager):
                 return self._require_container(sandbox_id), False
             raise RuntimeError(f"Failed to create sandbox container: {e}") from e
 
-    def terminate(
-        self, sandbox_id: UUID, max_attempt_number: int | None = None
-    ) -> None:
+    def terminate(self, sandbox_id: UUID) -> None:
         self._close_all_sandbox_buses(sandbox_id)
 
         container = self._get_container(sandbox_id)
-        if container is not None and max_attempt_number is not None:
-            raw = ((container.attrs or {}).get("Config", {}).get("Labels") or {}).get(
-                LABEL_PROVISIONING_ATTEMPT
-            )
-            try:
-                container_attempt = int(raw) if raw is not None else None
-            except ValueError:
-                container_attempt = None
-            if container_attempt is not None and container_attempt > max_attempt_number:
-                logger.warning(
-                    "Skipping terminate of sandbox %s: container belongs to attempt "
-                    "%s, newer than caller's attempt %s",
-                    sandbox_id,
-                    container_attempt,
-                    max_attempt_number,
-                )
-                return
         if container is not None:
             try:
                 container.remove(force=True, v=False)

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -1013,10 +1013,29 @@ class DockerSandboxManager(SandboxManager):
                 return self._require_container(sandbox_id), False
             raise RuntimeError(f"Failed to create sandbox container: {e}") from e
 
-    def terminate(self, sandbox_id: UUID) -> None:
+    def terminate(
+        self, sandbox_id: UUID, max_attempt_number: int | None = None
+    ) -> None:
         self._close_all_sandbox_buses(sandbox_id)
 
         container = self._get_container(sandbox_id)
+        if container is not None and max_attempt_number is not None:
+            raw = ((container.attrs or {}).get("Config", {}).get("Labels") or {}).get(
+                LABEL_PROVISIONING_ATTEMPT
+            )
+            try:
+                container_attempt = int(raw) if raw is not None else None
+            except ValueError:
+                container_attempt = None
+            if container_attempt is not None and container_attempt > max_attempt_number:
+                logger.warning(
+                    "Skipping terminate of sandbox %s: container belongs to attempt "
+                    "%s, newer than caller's attempt %s",
+                    sandbox_id,
+                    container_attempt,
+                    max_attempt_number,
+                )
+                return
         if container is not None:
             try:
                 container.remove(force=True, v=False)

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -183,7 +183,7 @@ def _provisioning_lock_key(sandbox_id: UUID) -> str:
 
 
 @contextmanager
-def _provisioning_lock(sandbox_id: UUID, tenant_id: str | None) -> Iterator[None]:
+def _provisioning_lock(sandbox_id: UUID, tenant_id: str) -> Iterator[None]:
     """Serialize pod creation + startup restore for one sandbox across
     api-server replicas. Acquisition is non-blocking: the numbered-attempt
     reservation already guarantees at most one live attempt per sandbox, so a
@@ -1082,10 +1082,6 @@ class KubernetesSandboxManager(SandboxManager):
                         f"opencode-serve never became ready in existing sandbox pod {pod_name}"
                     )
 
-                # The reusing attempt owns the runtime now; the guarded
-                # deletes key off this label.
-                self._stamp_pod_attempt_number(pod_name, provisioning_attempt_number)
-
                 logger.info(
                     "Reusing existing Kubernetes sandbox %s, pod: %s",
                     sandbox_id,
@@ -1190,12 +1186,6 @@ class KubernetesSandboxManager(SandboxManager):
                         f"opencode-serve never became ready in sandbox pod {pod_name}"
                     )
 
-                if not created_pod:
-                    # 409 fallback adopted a pod another attempt created.
-                    self._stamp_pod_attempt_number(
-                        pod_name, provisioning_attempt_number
-                    )
-
                 logger.info(
                     "Provisioned Kubernetes sandbox %s, pod: %s (no sessions yet)",
                     sandbox_id,
@@ -1226,12 +1216,7 @@ class KubernetesSandboxManager(SandboxManager):
                         exc_info=True,
                     )
                     if created_pod:
-                        # Bounded to this attempt: the pod at this name may
-                        # already belong to a newer attempt.
-                        self._cleanup_kubernetes_resources(
-                            str(sandbox_id),
-                            max_attempt_number=provisioning_attempt_number,
-                        )
+                        self._cleanup_kubernetes_resources(str(sandbox_id))
                     else:
                         logger.warning(
                             "Not cleaning up sandbox %s after provisioning failure "
@@ -1302,44 +1287,10 @@ class KubernetesSandboxManager(SandboxManager):
         )
         return False
 
-    def _stamp_pod_attempt_number(self, pod_name: str, attempt_number: int) -> None:
-        """Mark the pod as owned by ``attempt_number`` when an attempt reuses
-        a pod it didn't create. Fail-closed: an unstamped adopted pod would
-        stay deletable by stale attempts, so a failure here fails the attempt
-        (the retry tears down and re-provisions) instead of finalizing RUNNING
-        on a hazard."""
-        self._core_api.patch_namespaced_pod(
-            name=pod_name,
-            namespace=self._namespace,
-            body={
-                "metadata": {
-                    "labels": {LABEL_PROVISIONING_ATTEMPT: str(attempt_number)}
-                }
-            },
-        )
-
-    def _pod_attempt_number(self, pod_name: str) -> int | None:
-        """The provisioning-attempt label of the live pod, or None when the
-        pod is gone or predates the label."""
-        try:
-            pod = self._core_api.read_namespaced_pod(
-                name=pod_name, namespace=self._namespace
-            )
-        except ApiException as e:
-            if e.status == 404:
-                return None
-            raise
-        raw = (pod.metadata.labels or {}).get(LABEL_PROVISIONING_ATTEMPT)
-        try:
-            return int(raw) if raw is not None else None
-        except ValueError:
-            return None
-
     def _cleanup_kubernetes_resources(
         self,
         sandbox_id: str,
         wait_for_deletion: bool = True,
-        max_attempt_number: int | None = None,
     ) -> None:
         """Clean up Kubernetes resources for a sandbox.
 
@@ -1348,28 +1299,12 @@ class KubernetesSandboxManager(SandboxManager):
             wait_for_deletion: If True, wait for resources to be fully deleted
                 before returning. This prevents 409 conflicts when immediately
                 re-provisioning with the same sandbox ID.
-            max_attempt_number: When set, skip ALL deletion if the live pod's
-                attempt label is newer — resources share one name per sandbox,
-                so without this a superseded attempt's cleanup could destroy
-                the runtime a newer attempt just created.
         """
         # Convert UUID objects to strings if needed (Kubernetes client requires strings)
         sandbox_id = str(sandbox_id)
 
         pod_name = self._get_pod_name(sandbox_id)
         service_name = self._get_pod_name(sandbox_id)
-
-        if max_attempt_number is not None:
-            pod_attempt = self._pod_attempt_number(pod_name)
-            if pod_attempt is not None and pod_attempt > max_attempt_number:
-                logger.warning(
-                    "Skipping cleanup of sandbox %s: pod belongs to attempt %s, "
-                    "newer than caller's attempt %s",
-                    sandbox_id,
-                    pod_attempt,
-                    max_attempt_number,
-                )
-                return
 
         # Delete in reverse order of creation
         service_deleted = False
@@ -1421,22 +1356,10 @@ class KubernetesSandboxManager(SandboxManager):
                     "pod", pod_name, RUNTIME_TEARDOWN_SECONDS
                 )
 
-    def terminate(
-        self, sandbox_id: UUID, max_attempt_number: int | None = None
-    ) -> None:
-        """Tear down event buses, then delete Service + Pod.
-
-        Holds the per-sandbox provisioning lock so destruction serializes
-        against a concurrent provision() on any replica — a wake that just
-        started reusing this pod either finishes first or provisions fresh
-        after the deletion. Raises SandboxProvisionContentionError if a
-        provisioner currently holds the lock.
-        """
+    def terminate(self, sandbox_id: UUID) -> None:
+        """Tear down event buses, then delete Service + Pod."""
         self._close_all_sandbox_buses(sandbox_id)
-        with _provisioning_lock(sandbox_id, tenant_id=None):
-            self._cleanup_kubernetes_resources(
-                str(sandbox_id), max_attempt_number=max_attempt_number
-            )
+        self._cleanup_kubernetes_resources(str(sandbox_id))
         logger.info("Terminated Kubernetes sandbox %s", sandbox_id)
 
     def setup_session_workspace(

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -101,7 +101,7 @@ from onyx.server.features.build.sandbox.labels import (
     LABEL_K8S_COMPONENT_SANDBOX,
     LABEL_K8S_MANAGED_BY,
     LABEL_K8S_MANAGED_BY_ONYX,
-    LABEL_PROVISIONING_GENERATION,
+    LABEL_PROVISIONING_ATTEMPT,
     LABEL_SANDBOX_ID,
     LABEL_TENANT_ID,
 )
@@ -185,9 +185,10 @@ def _provisioning_lock_key(sandbox_id: UUID) -> str:
 @contextmanager
 def _provisioning_lock(sandbox_id: UUID, tenant_id: str) -> Iterator[None]:
     """Serialize pod creation + startup restore for one sandbox across
-    api-server replicas. Acquisition is non-blocking: generation fencing
-    already guarantees one live attempt per sandbox, so a held lock means a
-    superseded attempt's tail — the caller retries rather than waiting it out.
+    api-server replicas. Acquisition is non-blocking: the numbered-attempt
+    reservation already guarantees at most one live attempt per sandbox, so a
+    held lock means a superseded attempt's tail — the caller retries rather
+    than waiting it out.
     TTL equals the provision deadline (the lock never outlives the work it
     guards); expiry falls open to provision()'s 409/pod-exists fallbacks.
     Fails open on cache outages."""
@@ -465,7 +466,7 @@ class KubernetesSandboxManager(SandboxManager):
         self,
         sandbox_id: str,
         tenant_id: str,
-        provisioning_generation: int,
+        provisioning_attempt_number: int,
     ) -> client.V1Pod:
         """Build the sandbox Pod from the Helm PodTemplate, overlaying the
         dynamic fields the template can't carry."""
@@ -500,7 +501,7 @@ class KubernetesSandboxManager(SandboxManager):
                     LABEL_K8S_MANAGED_BY: LABEL_K8S_MANAGED_BY_ONYX,
                     LABEL_SANDBOX_ID: sandbox_id,
                     LABEL_TENANT_ID: tenant_id,
-                    LABEL_PROVISIONING_GENERATION: str(provisioning_generation),
+                    LABEL_PROVISIONING_ATTEMPT: str(provisioning_attempt_number),
                 },
             ),
             spec=spec,
@@ -994,7 +995,7 @@ class KubernetesSandboxManager(SandboxManager):
         user_id: UUID,
         tenant_id: str,
         onyx_pat: str | None,
-        provisioning_generation: int,
+        provisioning_attempt_number: int,
     ) -> SandboxInfo:
         """Provision a new sandbox as a Kubernetes pod (user-level).
 
@@ -1052,8 +1053,8 @@ class KubernetesSandboxManager(SandboxManager):
             pod_name = self._get_pod_name(str(sandbox_id))
 
             # Idempotency check; also the pod-exists path a lock-expiry racer
-            # lands on. The generation label keeps its creating attempt's
-            # value — it is attribution metadata, never a correctness fence.
+            # lands on. The attempt-number label keeps its creating attempt's
+            # value — attribution metadata only, never used for correctness.
             if self._pod_exists_and_healthy(pod_name):
                 logger.info(
                     "Pod %s already exists and is healthy, reusing existing pod",
@@ -1120,7 +1121,7 @@ class KubernetesSandboxManager(SandboxManager):
                 pod = self._create_sandbox_pod(
                     sandbox_id=str(sandbox_id),
                     tenant_id=tenant_id,
-                    provisioning_generation=provisioning_generation,
+                    provisioning_attempt_number=provisioning_attempt_number,
                 )
                 try:
                     with time_provision_phase(SandboxProvisionPhase.POD_CREATE):

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -77,8 +77,6 @@ from onyx.server.features.build.configs import (
     SANDBOX_SERVICE_ACCOUNT_NAME,
 )
 from onyx.server.features.build.sandbox.base import (
-    BUN_CACHE_DIR,
-    BUN_IMAGE_CACHE_DIR,
     SandboxManager,
 )
 from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
@@ -103,6 +101,7 @@ from onyx.server.features.build.sandbox.labels import (
     LABEL_K8S_COMPONENT_SANDBOX,
     LABEL_K8S_MANAGED_BY,
     LABEL_K8S_MANAGED_BY_ONYX,
+    LABEL_PROVISIONING_GENERATION,
     LABEL_SANDBOX_ID,
     LABEL_TENANT_ID,
 )
@@ -120,6 +119,11 @@ from onyx.server.features.build.sandbox.nextjs_dev import build_nextjs_start_scr
 from onyx.server.features.build.sandbox.serve_transport import (
     OPENCODE_SERVE_READY_TIMEOUT_SECONDS,
     ServeConnectionInfo,
+)
+from onyx.server.features.build.sandbox.session_workspace import (
+    SESSIONS_ROOT,
+    build_session_workspace_setup_script,
+    build_workspace_exists_check_script,
 )
 from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
 from onyx.server.features.build.sandbox.util.agent_instructions import (
@@ -477,6 +481,7 @@ class KubernetesSandboxManager(SandboxManager):
         self,
         sandbox_id: str,
         tenant_id: str,
+        provisioning_generation: int,
     ) -> client.V1Pod:
         """Build the sandbox Pod from the Helm PodTemplate, overlaying the
         dynamic fields the template can't carry."""
@@ -511,6 +516,7 @@ class KubernetesSandboxManager(SandboxManager):
                     LABEL_K8S_MANAGED_BY: LABEL_K8S_MANAGED_BY_ONYX,
                     LABEL_SANDBOX_ID: sandbox_id,
                     LABEL_TENANT_ID: tenant_id,
+                    LABEL_PROVISIONING_GENERATION: str(provisioning_generation),
                 },
             ),
             spec=spec,
@@ -1000,7 +1006,8 @@ class KubernetesSandboxManager(SandboxManager):
         sandbox_id: UUID,
         user_id: UUID,
         tenant_id: str,
-        onyx_pat: str | None = None,
+        onyx_pat: str | None,
+        provisioning_generation: int,
     ) -> SandboxInfo:
         """Provision a new sandbox as a Kubernetes pod (user-level).
 
@@ -1052,7 +1059,9 @@ class KubernetesSandboxManager(SandboxManager):
             pod_name = self._get_pod_name(str(sandbox_id))
 
             # Idempotency check; also the lock-loser path (the pod the winner
-            # just provisioned is found here and reused).
+            # just provisioned is found here and reused). The generation label
+            # keeps its creating attempt's value — it is attribution metadata,
+            # never a correctness fence.
             if self._pod_exists_and_healthy(pod_name):
                 logger.info(
                     "Pod %s already exists and is healthy, reusing existing pod",
@@ -1117,6 +1126,7 @@ class KubernetesSandboxManager(SandboxManager):
                 pod = self._create_sandbox_pod(
                     sandbox_id=str(sandbox_id),
                     tenant_id=tenant_id,
+                    provisioning_generation=provisioning_generation,
                 )
                 try:
                     with time_provision_phase(SandboxProvisionPhase.POD_CREATE):
@@ -1387,7 +1397,7 @@ class KubernetesSandboxManager(SandboxManager):
             RuntimeError: If workspace setup fails
         """
         pod_name = self._get_pod_name(str(sandbox_id))
-        session_path = f"/workspace/sessions/{session_id}"
+        session_path = f"{SESSIONS_ROOT}/{session_id}"
 
         # Paths inside the pod (created during workspace setup below):
         # - {session_path}/attachments: user-uploaded files
@@ -1401,8 +1411,6 @@ class KubernetesSandboxManager(SandboxManager):
             disabled_tools=OPENCODE_DISABLED_TOOLS,
             user_name=user_name,
         )
-
-        agent_instructions_escaped = agent_instructions.replace("'", "'\\''")
         session_opencode_config = json.dumps(
             build_provider_opencode_config(
                 llm_config,
@@ -1411,79 +1419,12 @@ class KubernetesSandboxManager(SandboxManager):
                 session_id=str(session_id),
             )
         )
-        session_opencode_config_setup = (
-            f"printf '%s' {shlex.quote(session_opencode_config)} > "
-            f"{session_path}/opencode.json"
+        setup_script = build_session_workspace_setup_script(
+            session_path=session_path,
+            agents_md=agent_instructions,
+            session_opencode_config_json=session_opencode_config,
+            nextjs_port=nextjs_port,
         )
-
-        # Copy outputs template from baked-in location and install npm dependencies
-        outputs_setup = f"""
-echo "Copying outputs template"
-if [ -d /workspace/templates/outputs ]; then
-    cp -r /workspace/templates/outputs/* {session_path}/outputs/
-    # flock+sentinel: serialize concurrent session setups; .ready guards
-    # against a partial cp from a previous interrupted run.
-    (
-        flock -x 9
-        if [ ! -f {BUN_CACHE_DIR}/.ready ]; then
-            echo "Bootstrapping bun cache on workspace volume..."
-            rm -rf {BUN_CACHE_DIR}
-            cp -r {BUN_IMAGE_CACHE_DIR} {BUN_CACHE_DIR} \\
-                || {{ echo "ERROR: bun cache bootstrap failed" >&2; exit 1; }}
-            touch {BUN_CACHE_DIR}/.ready
-        fi
-    ) 9>{BUN_CACHE_DIR}.lock
-    cd {session_path}/outputs/web && \\
-        BUN_INSTALL_CACHE_DIR={BUN_CACHE_DIR} \\
-        bun install --frozen-lockfile --backend=hardlink
-else
-    echo "Warning: outputs template not found at /workspace/templates/outputs"
-    mkdir -p {session_path}/outputs/web
-fi
-"""
-
-        # Headless callers (scheduled tasks) pass nextjs_port=None — the
-        # agent's tools work without a dev server.
-        nextjs_start_script = (
-            build_nextjs_start_script(
-                session_path, nextjs_port, check_node_modules=False
-            )
-            if nextjs_port is not None
-            else ""
-        )
-
-        setup_script = f"""
-set -e
-
-# Create session directory structure
-echo "Creating session directory: {session_path}"
-mkdir -p {session_path}/outputs
-mkdir -p {session_path}/attachments
-
-# Setup outputs
-{outputs_setup}
-
-# DO NOT mkdir /workspace/managed/skills or /workspace/managed/user_library
-# here — the push daemon swaps these paths via os.rename(symlink, mount),
-# which fails if the mount is a real directory. Dangling until the first
-# push lands is fine; nothing reads these during the rest of setup.
-mkdir -p {session_path}/.opencode
-ln -sf /workspace/managed/skills {session_path}/.opencode/skills
-echo "Linked skills to /workspace/managed/skills"
-ln -sf /workspace/managed/user_library {session_path}/user_library
-echo "Linked user_library to /workspace/managed/user_library"
-
-# Write agent instructions
-echo "Writing AGENTS.md"
-printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
-
-{session_opencode_config_setup}
-
-# Start Next.js dev server
-{nextjs_start_script}
-
-echo "Session workspace setup complete"
-"""
 
         logger.info(
             "Setting up session workspace %s in sandbox %s", session_id, sandbox_id
@@ -1747,13 +1688,13 @@ echo "Session cleanup complete"
             True if the session workspace exists, False otherwise
         """
         pod_name = self._get_pod_name(str(sandbox_id))
-        session_path = f"/workspace/sessions/{session_id}/outputs"
+        session_path = f"{SESSIONS_ROOT}/{session_id}"
 
-        # Use exec to check if directory exists
+        # Use exec to check for a complete (not in-progress) workspace
         exec_command = [
             "/bin/sh",
             "-c",
-            f'[ -d "{session_path}" ] && echo "WORKSPACE_FOUND" || echo "WORKSPACE_MISSING"',
+            build_workspace_exists_check_script(session_path),
         ]
 
         try:

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -1304,23 +1304,19 @@ class KubernetesSandboxManager(SandboxManager):
 
     def _stamp_pod_attempt_number(self, pod_name: str, attempt_number: int) -> None:
         """Mark the pod as owned by ``attempt_number`` when an attempt reuses
-        a pod it didn't create. Best-effort: on failure the label is stale and
-        a guarded delete may destroy the reused pod — recoverable via the
-        normal unhealthy-RUNNING recovery."""
-        try:
-            self._core_api.patch_namespaced_pod(
-                name=pod_name,
-                namespace=self._namespace,
-                body={
-                    "metadata": {
-                        "labels": {LABEL_PROVISIONING_ATTEMPT: str(attempt_number)}
-                    }
-                },
-            )
-        except ApiException:
-            logger.warning(
-                "Failed to restamp attempt label on pod %s", pod_name, exc_info=True
-            )
+        a pod it didn't create. Fail-closed: an unstamped adopted pod would
+        stay deletable by stale attempts, so a failure here fails the attempt
+        (the retry tears down and re-provisions) instead of finalizing RUNNING
+        on a hazard."""
+        self._core_api.patch_namespaced_pod(
+            name=pod_name,
+            namespace=self._namespace,
+            body={
+                "metadata": {
+                    "labels": {LABEL_PROVISIONING_ATTEMPT: str(attempt_number)}
+                }
+            },
+        )
 
     def _pod_attempt_number(self, pod_name: str) -> int | None:
         """The provisioning-attempt label of the live pod, or None when the

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -113,15 +113,14 @@ from onyx.server.features.build.sandbox.models import (
     FilesystemEntry,
     RetriableWriteError,
     SandboxInfo,
+    SandboxProvisionContentionError,
     SnapshotResult,
 )
 from onyx.server.features.build.sandbox.nextjs_dev import build_nextjs_start_script
-from onyx.server.features.build.sandbox.serve_transport import (
-    OPENCODE_SERVE_READY_TIMEOUT_SECONDS,
-    ServeConnectionInfo,
-)
+from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
 from onyx.server.features.build.sandbox.session_workspace import (
     SESSIONS_ROOT,
+    WORKSPACE_SETUP_COMPLETE_SENTINEL,
     build_session_workspace_setup_script,
     build_workspace_exists_check_script,
 )
@@ -137,6 +136,14 @@ from onyx.server.features.build.sandbox.util.opencode_config import (
     build_opencode_base_config,
     build_provider_opencode_config,
 )
+from onyx.server.features.build.timeouts import (
+    BULK_TRANSFER_TIMEOUT_SECONDS,
+    POLL_INTERVAL_SECONDS,
+    PROVISION_DEADLINE_SECONDS,
+    RPC_TIMEOUT_SECONDS,
+    RUNTIME_TEARDOWN_SECONDS,
+    WORKSPACE_SETUP_DEADLINE_SECONDS,
+)
 from onyx.server.metrics.craft_sandbox import (
     SandboxProvisionPhase,
     time_provision_phase,
@@ -149,30 +156,6 @@ logger = setup_logger()
 # API server pod hostname — used to identify which replica is handling a
 # request. In K8s, HOSTNAME is set to the pod name (e.g., "api-server-dpgg7").
 _API_SERVER_HOSTNAME = os.environ.get("HOSTNAME", "unknown")
-
-POD_READY_TIMEOUT_SECONDS = 30
-
-# Shared deadline for IP assignment (scheduling + image pull) and the restore.
-OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS = 90.0
-POD_IP_POLL_INTERVAL_SECONDS = 0.5
-
-# Resource deletion timeout and polling interval
-# Kubernetes deletes are async - we need to wait for resources to actually be
-# gone.
-RESOURCE_DELETION_TIMEOUT_SECONDS = 30
-RESOURCE_DELETION_POLL_INTERVAL_SECONDS = 0.5
-
-# Lock TTL and waiter blocking timeout; the sum of every bounded wait a holder
-# can spend inside the lock (incl. a terminating-Service deletion wait in
-# _ensure_service_exists). Expiry falls open to provision()'s 409/pod-exists
-# fallbacks.
-PROVISION_LOCK_TIMEOUT_SECONDS = (
-    OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS
-    + POD_READY_TIMEOUT_SECONDS
-    + OPENCODE_SERVE_READY_TIMEOUT_SECONDS
-    + RESOURCE_DELETION_TIMEOUT_SECONDS
-)
-
 
 # Pinned to the proxy IP via pod hostAliases — the iptables lockdown blocks DNS,
 # so the sandbox can't resolve it on its own.
@@ -202,17 +185,18 @@ def _provisioning_lock_key(sandbox_id: UUID) -> str:
 @contextmanager
 def _provisioning_lock(sandbox_id: UUID, tenant_id: str) -> Iterator[None]:
     """Serialize pod creation + startup restore for one sandbox across
-    api-server replicas; losers block, then reuse the ready pod via the
-    pod-exists check in provision(). Fails open on cache outages."""
+    api-server replicas. Acquisition is non-blocking: generation fencing
+    already guarantees one live attempt per sandbox, so a held lock means a
+    superseded attempt's tail — the caller retries rather than waiting it out.
+    TTL equals the provision deadline (the lock never outlives the work it
+    guards); expiry falls open to provision()'s 409/pod-exists fallbacks.
+    Fails open on cache outages."""
     try:
         lock = get_cache_backend(tenant_id=tenant_id).lock(
             _provisioning_lock_key(sandbox_id),
-            timeout=PROVISION_LOCK_TIMEOUT_SECONDS,
+            timeout=PROVISION_DEADLINE_SECONDS,
         )
-        acquired = lock.acquire(
-            blocking=True,
-            blocking_timeout=PROVISION_LOCK_TIMEOUT_SECONDS,
-        )
+        acquired = lock.acquire(blocking=False)
     except CACHE_TRANSIENT_ERRORS as e:
         logger.warning(
             "Provisioning lock unavailable for sandbox %s (%s); "
@@ -224,8 +208,8 @@ def _provisioning_lock(sandbox_id: UUID, tenant_id: str) -> Iterator[None]:
         return
 
     if not acquired:
-        raise RuntimeError(
-            f"Timed out waiting for a concurrent provisioner of sandbox {sandbox_id}"
+        raise SandboxProvisionContentionError(
+            f"A concurrent provisioner holds the lock for sandbox {sandbox_id}"
         )
     try:
         yield
@@ -650,13 +634,15 @@ class KubernetesSandboxManager(SandboxManager):
         self,
         sandbox_id: UUID,
         tenant_id: str,
+        deadline: float,
     ) -> None:
         """Ensure a ClusterIP service exists for the sandbox pod.
 
         Handles the case where a service is in Terminating state (has a
-        deletion_timestamp) by waiting for deletion and recreating it.
-        This prevents a race condition where provision reuses an existing pod
-        but the old service is still being deleted.
+        deletion_timestamp) by waiting (up to the provision deadline) for
+        deletion and recreating it. This prevents a race condition where
+        provision reuses an existing pod but the old service is still being
+        deleted.
         """
         service_name = self._get_pod_name(str(sandbox_id))
 
@@ -670,7 +656,9 @@ class KubernetesSandboxManager(SandboxManager):
                 logger.info(
                     "Service %s is terminating, waiting for deletion", service_name
                 )
-                self._wait_for_resource_deletion("service", service_name)
+                self._wait_for_resource_deletion(
+                    "service", service_name, deadline - time.monotonic()
+                )
                 # Now create a fresh service
                 service = self._create_sandbox_service(sandbox_id, tenant_id)
                 self._core_api.create_namespaced_service(
@@ -861,16 +849,15 @@ class KubernetesSandboxManager(SandboxManager):
     def _wait_for_pod_ready(
         self,
         pod_name: str,
-        timeout: float = POD_READY_TIMEOUT_SECONDS,
+        deadline: float,
     ) -> bool:
-        """Block on a single-pod watch until Ready or timeout.
+        """Block on a single-pod watch until Ready or the monotonic deadline.
 
         Watching beats polling: the apiserver pushes status transitions as
         they happen, so we catch ``Ready`` within ~100ms instead of waiting
         for the next poll tick. A bounded retry loop covers ``410 Gone``
         (resource version aged out under us) by re-listing and resuming.
         """
-        start_time = time.time()
         field_selector = f"metadata.name={pod_name}"
 
         try:
@@ -887,7 +874,7 @@ class KubernetesSandboxManager(SandboxManager):
             raise
 
         while True:
-            remaining = timeout - (time.time() - start_time)
+            remaining = deadline - time.monotonic()
             if remaining <= 0:
                 break
 
@@ -898,7 +885,7 @@ class KubernetesSandboxManager(SandboxManager):
                     namespace=self._namespace,
                     field_selector=field_selector,
                     resource_version=resource_version,
-                    timeout_seconds=int(remaining),
+                    timeout_seconds=max(1, int(remaining)),
                 )
                 for event in stream:
                     event_type = event.get("type")
@@ -963,7 +950,7 @@ class KubernetesSandboxManager(SandboxManager):
             if pod.status.pod_ip:
                 logger.info("Pod %s assigned IP %s", pod_name, pod.status.pod_ip)
                 return True
-            time.sleep(POD_IP_POLL_INTERVAL_SECONDS)
+            time.sleep(POLL_INTERVAL_SECONDS)
 
         logger.warning("Timeout waiting for pod %s to be assigned an IP", pod_name)
         return False
@@ -1012,8 +999,9 @@ class KubernetesSandboxManager(SandboxManager):
         """Provision a new sandbox as a Kubernetes pod (user-level).
 
         This method is idempotent - if a pod already exists and is healthy,
-        it will be reused. Concurrent provisioners are serialized by a
-        per-sandbox lock; losers reuse the pod the winner created.
+        it will be reused. A concurrent provisioner holding the per-sandbox
+        lock raises ``SandboxProvisionContentionError`` (fail-fast; the
+        lifecycle layer retries).
 
         Creates pod with:
         1. Sessions/ directory for per-session workspaces
@@ -1056,23 +1044,27 @@ class KubernetesSandboxManager(SandboxManager):
             )
 
         with _provisioning_lock(sandbox_id, tenant_id):
+            # Every phase below (service churn, scheduling + image pull,
+            # history restore, readiness, opencode-serve bind) draws from this
+            # one deadline: slow phases leave less budget for later ones
+            # instead of stacking per-phase timeouts.
+            deadline = time.monotonic() + PROVISION_DEADLINE_SECONDS
             pod_name = self._get_pod_name(str(sandbox_id))
 
-            # Idempotency check; also the lock-loser path (the pod the winner
-            # just provisioned is found here and reused). The generation label
-            # keeps its creating attempt's value — it is attribution metadata,
-            # never a correctness fence.
+            # Idempotency check; also the pod-exists path a lock-expiry racer
+            # lands on. The generation label keeps its creating attempt's
+            # value — it is attribution metadata, never a correctness fence.
             if self._pod_exists_and_healthy(pod_name):
                 logger.info(
                     "Pod %s already exists and is healthy, reusing existing pod",
                     pod_name,
                 )
                 # Ensure service exists and is not terminating
-                self._ensure_service_exists(sandbox_id, tenant_id)
+                self._ensure_service_exists(sandbox_id, tenant_id, deadline)
 
                 # Wait for pod to be ready if it's still pending
                 logger.info("Waiting for existing pod %s to become ready...", pod_name)
-                if not self._wait_for_pod_ready(pod_name):
+                if not self._wait_for_pod_ready(pod_name, deadline):
                     raise RuntimeError(
                         f"Timeout waiting for existing sandbox pod {pod_name} to become ready"
                     )
@@ -1083,7 +1075,9 @@ class KubernetesSandboxManager(SandboxManager):
                 with self._event_buses_lock:
                     self._terminated_sandboxes.discard(sandbox_id)
 
-                if not self._wait_for_opencode_serve_ready(sandbox_id):
+                if not self._wait_for_opencode_serve_ready(
+                    sandbox_id, timeout=deadline - time.monotonic()
+                ):
                     raise RuntimeError(
                         f"opencode-serve never became ready in existing sandbox pod {pod_name}"
                     )
@@ -1161,36 +1155,33 @@ class KubernetesSandboxManager(SandboxManager):
                         raise
 
                 # 2. Create Service (handles terminating services)
-                self._ensure_service_exists(sandbox_id, tenant_id)
+                self._ensure_service_exists(sandbox_id, tenant_id, deadline)
 
                 # 3. Restore opencode history before the sandbox app container starts;
                 # the init sidecar serves the restore endpoint while its startup probe
-                # stays blocked, so opencode-serve can't open an empty DB first. The IP
-                # wait and the restore draw from one deadline so slow scheduling leaves
-                # less budget for the restore rather than stacking two full timeouts.
+                # stays blocked, so opencode-serve can't open an empty DB first.
                 if startup_restore_required:
-                    restore_deadline = (
-                        time.monotonic() + OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS
-                    )
-                    if not self._wait_for_pod_ip(pod_name, restore_deadline):
+                    if not self._wait_for_pod_ip(pod_name, deadline):
                         raise RuntimeError(
                             f"Timeout waiting for sandbox pod {pod_name} to be assigned an IP"
                         )
                     self.restore_opencode_history_snapshot(
                         sandbox_id,
                         tenant_id,
-                        timeout_seconds=restore_deadline - time.monotonic(),
+                        timeout_seconds=deadline - time.monotonic(),
                     )
 
                 # 4. Wait for pod to be ready
                 logger.info("Waiting for pod %s to become ready...", pod_name)
-                if not self._wait_for_pod_ready(pod_name):
+                if not self._wait_for_pod_ready(pod_name, deadline):
                     raise RuntimeError(
                         f"Timeout waiting for sandbox pod {pod_name} to become ready"
                     )
 
                 # 5. Wait for opencode-serve to bind :4096 .
-                if not self._wait_for_opencode_serve_ready(sandbox_id):
+                if not self._wait_for_opencode_serve_ready(
+                    sandbox_id, timeout=deadline - time.monotonic()
+                ):
                     raise RuntimeError(
                         f"opencode-serve never became ready in sandbox pod {pod_name}"
                     )
@@ -1238,7 +1229,7 @@ class KubernetesSandboxManager(SandboxManager):
         self,
         resource_type: str,
         name: str,
-        timeout: float = RESOURCE_DELETION_TIMEOUT_SECONDS,
+        timeout: float,
     ) -> bool:
         """Wait for a Kubernetes resource to be fully deleted.
 
@@ -1273,7 +1264,7 @@ class KubernetesSandboxManager(SandboxManager):
 
                 # Resource still exists, wait and retry
                 logger.debug("Waiting for %s %s to be deleted...", resource_type, name)
-                time.sleep(RESOURCE_DELETION_POLL_INTERVAL_SECONDS)
+                time.sleep(POLL_INTERVAL_SECONDS)
 
             except ApiException as e:
                 if e.status == 404:
@@ -1286,7 +1277,7 @@ class KubernetesSandboxManager(SandboxManager):
                 logger.warning(
                     "Error checking %s %s status: %s", resource_type, name, e
                 )
-                time.sleep(RESOURCE_DELETION_POLL_INTERVAL_SECONDS)
+                time.sleep(POLL_INTERVAL_SECONDS)
 
         logger.warning(
             "Timeout waiting for %s %s to be deleted after %ss",
@@ -1357,9 +1348,13 @@ class KubernetesSandboxManager(SandboxManager):
         # on immediate re-provisioning
         if wait_for_deletion:
             if service_deleted:
-                self._wait_for_resource_deletion("service", service_name)
+                self._wait_for_resource_deletion(
+                    "service", service_name, RUNTIME_TEARDOWN_SECONDS
+                )
             if pod_deleted:
-                self._wait_for_resource_deletion("pod", pod_name)
+                self._wait_for_resource_deletion(
+                    "pod", pod_name, RUNTIME_TEARDOWN_SECONDS
+                )
 
     def terminate(self, sandbox_id: UUID) -> None:
         """Tear down event buses, then delete Service + Pod."""
@@ -1431,7 +1426,10 @@ class KubernetesSandboxManager(SandboxManager):
         )
 
         try:
-            # Execute setup script in the pod
+            # Execute setup script in the pod. The exec client returns
+            # whatever output was buffered when _request_timeout lapses
+            # WITHOUT raising (the command keeps running in the pod), so
+            # success is the sentinel, not a clean return.
             exec_response = k8s_stream(
                 self._stream_core_api.connect_get_namespaced_pod_exec,
                 name=pod_name,
@@ -1442,9 +1440,16 @@ class KubernetesSandboxManager(SandboxManager):
                 stdin=False,
                 stdout=True,
                 tty=False,
+                _request_timeout=WORKSPACE_SETUP_DEADLINE_SECONDS,
             )
 
             logger.debug("Session setup output: %s", exec_response)
+            if WORKSPACE_SETUP_COMPLETE_SENTINEL not in exec_response:
+                raise RuntimeError(
+                    f"Workspace setup for session {session_id} did not complete "
+                    f"within {WORKSPACE_SETUP_DEADLINE_SECONDS:.0f}s (output tail: "
+                    f"{exec_response[-500:]!r})"
+                )
             logger.info(
                 "Set up session workspace %s in sandbox %s", session_id, sandbox_id
             )
@@ -1550,7 +1555,7 @@ echo "Session cleanup complete"
             body=body,
             content_type="application/json",
             operation_label="Snapshot create",
-            timeout_seconds=300.0,
+            timeout_seconds=BULK_TRANSFER_TIMEOUT_SECONDS,
         ) as snapshot_stream:
             if snapshot_stream is None:
                 logger.info("No outputs to snapshot for session %s", session_id)
@@ -1579,7 +1584,7 @@ echo "Session cleanup complete"
         self,
         sandbox_id: UUID,
         tenant_id: str,
-        timeout_seconds: float = 300.0,
+        timeout_seconds: float = BULK_TRANSFER_TIMEOUT_SECONDS,
     ) -> bool:
         with self._sidecar_client.request_and_stream_new_snapshot(
             sandbox_id=sandbox_id,
@@ -1616,7 +1621,7 @@ echo "Session cleanup complete"
         self,
         sandbox_id: UUID,
         tenant_id: str,
-        timeout_seconds: float = OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS,
+        timeout_seconds: float,
     ) -> bool:
         if not self._snapshot_manager.has_opencode_history_snapshot(
             tenant_id, str(sandbox_id)
@@ -1662,7 +1667,7 @@ echo "Session cleanup complete"
         self,
         *,
         sandbox_id: UUID,
-        timeout_seconds: float = OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS,
+        timeout_seconds: float,
     ) -> None:
         self._sidecar_client.post_empty(
             sandbox_id=sandbox_id,
@@ -1850,6 +1855,7 @@ echo "Session cleanup complete"
                     stdin=False,
                     stdout=True,
                     tty=False,
+                    _request_timeout=WORKSPACE_SETUP_DEADLINE_SECONDS,
                 )
         except ApiException as e:
             raise RuntimeError(f"Failed to restore snapshot: {e}") from e
@@ -1928,7 +1934,7 @@ fi
         )
         logger.info("Session configuration files regenerated")
 
-    def health_check(self, sandbox_id: UUID, timeout: float = 60.0) -> bool:
+    def health_check(self, sandbox_id: UUID, timeout: float) -> bool:
         """Check whether the agent container and sidecar are both healthy."""
         pod_name = self._get_pod_name(str(sandbox_id))
         try:
@@ -2586,7 +2592,7 @@ fi
                 archive=tar_bytes,
                 sha256_hex=sha256_hex,
                 operation_label=pod_name,
-                timeout_seconds=30.0,
+                timeout_seconds=RPC_TIMEOUT_SECONDS,
             )
         except SidecarRequestError as e:
             raise RetriableWriteError(f"Push to {pod_name} failed: {e}") from e

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -183,7 +183,7 @@ def _provisioning_lock_key(sandbox_id: UUID) -> str:
 
 
 @contextmanager
-def _provisioning_lock(sandbox_id: UUID, tenant_id: str) -> Iterator[None]:
+def _provisioning_lock(sandbox_id: UUID, tenant_id: str | None) -> Iterator[None]:
     """Serialize pod creation + startup restore for one sandbox across
     api-server replicas. Acquisition is non-blocking: the numbered-attempt
     reservation already guarantees at most one live attempt per sandbox, so a
@@ -1053,8 +1053,7 @@ class KubernetesSandboxManager(SandboxManager):
             pod_name = self._get_pod_name(str(sandbox_id))
 
             # Idempotency check; also the pod-exists path a lock-expiry racer
-            # lands on. The attempt-number label keeps its creating attempt's
-            # value — attribution metadata only, never used for correctness.
+            # lands on.
             if self._pod_exists_and_healthy(pod_name):
                 logger.info(
                     "Pod %s already exists and is healthy, reusing existing pod",
@@ -1082,6 +1081,10 @@ class KubernetesSandboxManager(SandboxManager):
                     raise RuntimeError(
                         f"opencode-serve never became ready in existing sandbox pod {pod_name}"
                     )
+
+                # The reusing attempt owns the runtime now; the guarded
+                # deletes key off this label.
+                self._stamp_pod_attempt_number(pod_name, provisioning_attempt_number)
 
                 logger.info(
                     "Reusing existing Kubernetes sandbox %s, pod: %s",
@@ -1187,6 +1190,12 @@ class KubernetesSandboxManager(SandboxManager):
                         f"opencode-serve never became ready in sandbox pod {pod_name}"
                     )
 
+                if not created_pod:
+                    # 409 fallback adopted a pod another attempt created.
+                    self._stamp_pod_attempt_number(
+                        pod_name, provisioning_attempt_number
+                    )
+
                 logger.info(
                     "Provisioned Kubernetes sandbox %s, pod: %s (no sessions yet)",
                     sandbox_id,
@@ -1217,7 +1226,12 @@ class KubernetesSandboxManager(SandboxManager):
                         exc_info=True,
                     )
                     if created_pod:
-                        self._cleanup_kubernetes_resources(str(sandbox_id))
+                        # Bounded to this attempt: the pod at this name may
+                        # already belong to a newer attempt.
+                        self._cleanup_kubernetes_resources(
+                            str(sandbox_id),
+                            max_attempt_number=provisioning_attempt_number,
+                        )
                     else:
                         logger.warning(
                             "Not cleaning up sandbox %s after provisioning failure "
@@ -1288,10 +1302,48 @@ class KubernetesSandboxManager(SandboxManager):
         )
         return False
 
+    def _stamp_pod_attempt_number(self, pod_name: str, attempt_number: int) -> None:
+        """Mark the pod as owned by ``attempt_number`` when an attempt reuses
+        a pod it didn't create. Best-effort: on failure the label is stale and
+        a guarded delete may destroy the reused pod — recoverable via the
+        normal unhealthy-RUNNING recovery."""
+        try:
+            self._core_api.patch_namespaced_pod(
+                name=pod_name,
+                namespace=self._namespace,
+                body={
+                    "metadata": {
+                        "labels": {LABEL_PROVISIONING_ATTEMPT: str(attempt_number)}
+                    }
+                },
+            )
+        except ApiException:
+            logger.warning(
+                "Failed to restamp attempt label on pod %s", pod_name, exc_info=True
+            )
+
+    def _pod_attempt_number(self, pod_name: str) -> int | None:
+        """The provisioning-attempt label of the live pod, or None when the
+        pod is gone or predates the label."""
+        try:
+            pod = self._core_api.read_namespaced_pod(
+                name=pod_name, namespace=self._namespace
+            )
+        except ApiException as e:
+            if e.status == 404:
+                return None
+            raise
+        raw = (pod.metadata.labels or {}).get(LABEL_PROVISIONING_ATTEMPT)
+        try:
+            return int(raw) if raw is not None else None
+        except ValueError:
+            return None
+
     def _cleanup_kubernetes_resources(
         self,
         sandbox_id: str,
         wait_for_deletion: bool = True,
+        max_attempt_number: int | None = None,
     ) -> None:
         """Clean up Kubernetes resources for a sandbox.
 
@@ -1300,12 +1352,28 @@ class KubernetesSandboxManager(SandboxManager):
             wait_for_deletion: If True, wait for resources to be fully deleted
                 before returning. This prevents 409 conflicts when immediately
                 re-provisioning with the same sandbox ID.
+            max_attempt_number: When set, skip ALL deletion if the live pod's
+                attempt label is newer — resources share one name per sandbox,
+                so without this a superseded attempt's cleanup could destroy
+                the runtime a newer attempt just created.
         """
         # Convert UUID objects to strings if needed (Kubernetes client requires strings)
         sandbox_id = str(sandbox_id)
 
         pod_name = self._get_pod_name(sandbox_id)
         service_name = self._get_pod_name(sandbox_id)
+
+        if max_attempt_number is not None:
+            pod_attempt = self._pod_attempt_number(pod_name)
+            if pod_attempt is not None and pod_attempt > max_attempt_number:
+                logger.warning(
+                    "Skipping cleanup of sandbox %s: pod belongs to attempt %s, "
+                    "newer than caller's attempt %s",
+                    sandbox_id,
+                    pod_attempt,
+                    max_attempt_number,
+                )
+                return
 
         # Delete in reverse order of creation
         service_deleted = False
@@ -1357,10 +1425,22 @@ class KubernetesSandboxManager(SandboxManager):
                     "pod", pod_name, RUNTIME_TEARDOWN_SECONDS
                 )
 
-    def terminate(self, sandbox_id: UUID) -> None:
-        """Tear down event buses, then delete Service + Pod."""
+    def terminate(
+        self, sandbox_id: UUID, max_attempt_number: int | None = None
+    ) -> None:
+        """Tear down event buses, then delete Service + Pod.
+
+        Holds the per-sandbox provisioning lock so destruction serializes
+        against a concurrent provision() on any replica — a wake that just
+        started reusing this pod either finishes first or provisions fresh
+        after the deletion. Raises SandboxProvisionContentionError if a
+        provisioner currently holds the lock.
+        """
         self._close_all_sandbox_buses(sandbox_id)
-        self._cleanup_kubernetes_resources(str(sandbox_id))
+        with _provisioning_lock(sandbox_id, tenant_id=None):
+            self._cleanup_kubernetes_resources(
+                str(sandbox_id), max_attempt_number=max_attempt_number
+            )
         logger.info("Terminated Kubernetes sandbox %s", sandbox_id)
 
     def setup_session_workspace(

--- a/backend/onyx/server/features/build/sandbox/kubernetes/sidecar_client.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/sidecar_client.py
@@ -25,6 +25,11 @@ from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
     FilesystemListResponse,
 )
 from onyx.server.features.build.sandbox.models import FilesystemEntry
+from onyx.server.features.build.timeouts import (
+    BULK_TRANSFER_TIMEOUT_SECONDS,
+    CONNECT_TIMEOUT_SECONDS,
+    RPC_TIMEOUT_SECONDS,
+)
 
 _SIDECAR_CHUNK_SIZE = 8 * 1024 * 1024
 
@@ -130,7 +135,7 @@ class SidecarClient:
         sandbox_id: UUID,
         session_id: UUID,
         path: str,
-        timeout_seconds: float = 30.0,
+        timeout_seconds: float = RPC_TIMEOUT_SECONDS,
     ) -> list[FilesystemEntry]:
         payload = FilesystemListRequest(session_id=session_id, path=path)
         body = payload.model_dump_json().encode()
@@ -222,7 +227,7 @@ class SidecarClient:
         archive_file: IO[bytes],
         sha256_hex: str,
         operation_label: str,
-        timeout_seconds: float = 300.0,
+        timeout_seconds: float = BULK_TRANSFER_TIMEOUT_SECONDS,
     ) -> None:
         def body() -> Iterator[bytes]:
             archive_file.seek(0)
@@ -248,7 +253,7 @@ class SidecarClient:
         sandbox_id: UUID,
         endpoint_path: str,
         operation_label: str,
-        timeout_seconds: float = 300.0,
+        timeout_seconds: float = BULK_TRANSFER_TIMEOUT_SECONDS,
     ) -> None:
         body = b""
         self._post(
@@ -350,7 +355,7 @@ class SidecarClient:
     def _timeout_for_post(remaining_seconds: float) -> httpx.Timeout:
         return httpx.Timeout(
             remaining_seconds,
-            connect=min(5.0, remaining_seconds),
+            connect=min(CONNECT_TIMEOUT_SECONDS, remaining_seconds),
             read=remaining_seconds,
             write=remaining_seconds,
         )

--- a/backend/onyx/server/features/build/sandbox/labels.py
+++ b/backend/onyx/server/features/build/sandbox/labels.py
@@ -1,8 +1,9 @@
 LABEL_SANDBOX_ID = "onyx.app/sandbox-id"
 LABEL_TENANT_ID = "onyx.app/tenant-id"
-# Provisioning attempt that created the resource. Operator-facing orphan
-# attribution only (kubectl/docker inspect) — never read programmatically;
-# correctness comes from the attempt-number condition on sandbox status writes.
+# Provisioning attempt that currently owns the runtime: stamped at creation
+# and restamped when a later attempt reuses the pod. Guarded deletes refuse to
+# destroy a runtime owned by a newer attempt; DB status writes remain the
+# primary fence. Also serves operator-facing orphan attribution.
 LABEL_PROVISIONING_ATTEMPT = "onyx.app/provisioning-attempt"
 LABEL_K8S_COMPONENT = "app.kubernetes.io/component"
 LABEL_K8S_COMPONENT_SANDBOX = "sandbox"

--- a/backend/onyx/server/features/build/sandbox/labels.py
+++ b/backend/onyx/server/features/build/sandbox/labels.py
@@ -1,5 +1,9 @@
 LABEL_SANDBOX_ID = "onyx.app/sandbox-id"
 LABEL_TENANT_ID = "onyx.app/tenant-id"
+# Provisioning attempt that created the resource. Operator-facing orphan
+# attribution only (kubectl/docker inspect) — never read programmatically;
+# correctness fencing is the generation compare-and-set on the sandbox row.
+LABEL_PROVISIONING_GENERATION = "onyx.app/provisioning-generation"
 LABEL_K8S_COMPONENT = "app.kubernetes.io/component"
 LABEL_K8S_COMPONENT_SANDBOX = "sandbox"
 LABEL_K8S_MANAGED_BY = "app.kubernetes.io/managed-by"

--- a/backend/onyx/server/features/build/sandbox/labels.py
+++ b/backend/onyx/server/features/build/sandbox/labels.py
@@ -2,8 +2,8 @@ LABEL_SANDBOX_ID = "onyx.app/sandbox-id"
 LABEL_TENANT_ID = "onyx.app/tenant-id"
 # Provisioning attempt that created the resource. Operator-facing orphan
 # attribution only (kubectl/docker inspect) — never read programmatically;
-# correctness fencing is the generation compare-and-set on the sandbox row.
-LABEL_PROVISIONING_GENERATION = "onyx.app/provisioning-generation"
+# correctness comes from the attempt-number condition on sandbox status writes.
+LABEL_PROVISIONING_ATTEMPT = "onyx.app/provisioning-attempt"
 LABEL_K8S_COMPONENT = "app.kubernetes.io/component"
 LABEL_K8S_COMPONENT_SANDBOX = "sandbox"
 LABEL_K8S_MANAGED_BY = "app.kubernetes.io/managed-by"

--- a/backend/onyx/server/features/build/sandbox/labels.py
+++ b/backend/onyx/server/features/build/sandbox/labels.py
@@ -1,9 +1,8 @@
 LABEL_SANDBOX_ID = "onyx.app/sandbox-id"
 LABEL_TENANT_ID = "onyx.app/tenant-id"
-# Provisioning attempt that currently owns the runtime: stamped at creation
-# and restamped when a later attempt reuses the pod. Guarded deletes refuse to
-# destroy a runtime owned by a newer attempt; DB status writes remain the
-# primary fence. Also serves operator-facing orphan attribution.
+# Provisioning attempt that created the resource. Operator-facing orphan
+# attribution only (kubectl/docker inspect) — never read programmatically;
+# correctness comes from the attempt-number condition on sandbox status writes.
 LABEL_PROVISIONING_ATTEMPT = "onyx.app/provisioning-attempt"
 LABEL_K8S_COMPONENT = "app.kubernetes.io/component"
 LABEL_K8S_COMPONENT_SANDBOX = "sandbox"

--- a/backend/onyx/server/features/build/sandbox/models.py
+++ b/backend/onyx/server/features/build/sandbox/models.py
@@ -104,3 +104,8 @@ class RetriableWriteError(Exception):
 
 class FatalWriteError(Exception):
     """Permanent failure in write_files_to_sandbox (validation, auth)."""
+
+
+class SandboxProvisionContentionError(Exception):
+    """Another provisioner holds this sandbox's provisioning lock. Retryable:
+    the lifecycle layer records the attempt FAILED and the caller re-reserves."""

--- a/backend/onyx/server/features/build/sandbox/nextjs_dev.py
+++ b/backend/onyx/server/features/build/sandbox/nextjs_dev.py
@@ -47,6 +47,11 @@ fi
 
     return f"""
 set -e
+# Replay safety: a live server already attached to this session keeps its
+# port; spawning a second one would fail to bind and leave a zombie.
+if [ -f {session_path}/nextjs.pid ] && kill -0 "$(cat {session_path}/nextjs.pid)" 2>/dev/null; then
+    echo "Next.js server already running (PID $(cat {session_path}/nextjs.pid)); reusing"
+else
 cd {session_path}/outputs/web
 {install_check}
 export ONYX_WEBAPP_BASE_PATH="/api/build/sessions/$(basename {session_path})/webapp"
@@ -80,4 +85,5 @@ nohup bun run dev -- -H 0.0.0.0 -p {nextjs_port} > {session_path}/nextjs.log 2>&
 NEXTJS_PID=$!
 echo "Next.js server started with PID $NEXTJS_PID"
 echo $NEXTJS_PID > {session_path}/nextjs.pid
+fi
 """

--- a/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import httpx
 
+from onyx.server.features.build.timeouts import CONNECT_TIMEOUT_SECONDS
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -52,7 +53,7 @@ class PodEventBus:
         auth: httpx.Auth | None,
         *,
         directory: str | None = None,
-        connect_timeout: float = 10.0,
+        connect_timeout: float = CONNECT_TIMEOUT_SECONDS,
         event_read_timeout: float | None = None,
         reload_auth: Callable[[], httpx.Auth | None] | None = None,
     ) -> None:

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -28,8 +28,8 @@ from onyx.server.features.build.configs import (
     OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS,
     OPENCODE_SERVE_EVENT_READ_TIMEOUT,
     OPENCODE_SERVER_USERNAME,
-    PROMPT_SLOT_KEEP_ALIVE_MAX_SECONDS,
     PROMPT_SLOT_LEASE_SECONDS,
+    SSE_KEEPALIVE_INTERVAL,
 )
 from onyx.server.features.build.db.sandbox import get_sandbox_by_id
 from onyx.server.features.build.sandbox.event_schema import (
@@ -48,6 +48,11 @@ from onyx.server.features.build.sandbox.opencode.serve_client import (
     translate_opencode_event,
 )
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
+from onyx.server.features.build.timeouts import (
+    POLL_INTERVAL_SECONDS,
+    PROMPT_SLOT_FAST_FAIL_ACQUIRE_SECONDS,
+    PROMPT_SLOT_KEEP_ALIVE_MAX_SECONDS,
+)
 from onyx.server.metrics.craft_sandbox import (
     SandboxProvisionPhase,
     time_provision_phase,
@@ -60,16 +65,6 @@ SandboxEvent = Any
 
 # Tags serve-transport logs with the api_server replica handling the prompt.
 _API_SERVER_HOSTNAME = os.environ.get("HOSTNAME", "unknown")
-
-# opencode-serve boot lags backend Ready by ~1–3s warm, up to ~15s cold.
-OPENCODE_SERVE_READY_TIMEOUT_SECONDS = 30
-OPENCODE_SERVE_READY_POLL_INTERVAL_SECONDS = 0.25
-
-# How long a new turn waits for the previous turn's slot before giving up.
-PROMPT_SLOT_FAST_FAIL_ACQUIRE_SECONDS = 10.0
-
-# Must exceed the lease so a reclaimed turn can wait out a dead holder's slot.
-PROMPT_SLOT_WAIT_OUT_ORPHAN_SECONDS = PROMPT_SLOT_LEASE_SECONDS + 10.0
 
 # Live attach streams are UI-facing. Coalesce adjacent text deltas just long
 # enough to avoid one React update per tiny opencode token burst, while keeping
@@ -347,7 +342,7 @@ class _ServeMixin:
     def _wait_for_opencode_serve_ready(
         self,
         sandbox_id: UUID,
-        timeout: float = OPENCODE_SERVE_READY_TIMEOUT_SECONDS,
+        timeout: float,
     ) -> bool:
         """Block until opencode-serve answers ``GET /doc`` with 200 (opencode
         binds :4096 a few seconds after the pod is Ready). Probes the Service
@@ -412,7 +407,7 @@ class _ServeMixin:
                         last_err = f"health_check returned status={status} for {url}"
                     except Exception as e:
                         last_err = f"{url}: {type(e).__name__}: {e}"
-                time.sleep(OPENCODE_SERVE_READY_POLL_INTERVAL_SECONDS)
+                time.sleep(POLL_INTERVAL_SECONDS)
         finally:
             for _, client in clients:
                 client.close()
@@ -808,7 +803,7 @@ class _ServeMixin:
         opencode_session_id: str,
         *,
         directory: str,
-        keepalive_seconds: float = 15.0,
+        keepalive_seconds: float = SSE_KEEPALIVE_INTERVAL,
     ) -> Generator[SandboxEvent, None, None]:
         """Stream translated sandbox events for an opencode session. Caller closes
         via ``GeneratorExit``. ``directory`` is required: opencode-serve scopes

--- a/backend/onyx/server/features/build/sandbox/session_workspace.py
+++ b/backend/onyx/server/features/build/sandbox/session_workspace.py
@@ -27,6 +27,12 @@ MANAGED_USER_LIBRARY_PATH = "/workspace/managed/user_library"
 # complete.
 SETUP_IN_PROGRESS_MARKER = ".setup-in-progress"
 
+# Last line the setup script prints. Callers MUST verify it in the exec
+# output: the Kubernetes exec client returns buffered output without raising
+# when its timeout lapses (and never raises on a nonzero exit), so the
+# sentinel is the only reliable success signal.
+WORKSPACE_SETUP_COMPLETE_SENTINEL = "ONYX_WORKSPACE_SETUP_COMPLETE"
+
 
 def build_workspace_exists_check_script(session_path: str) -> str:
     """Emit ``WORKSPACE_FOUND`` only for a complete workspace: the outputs
@@ -124,5 +130,5 @@ echo "Workspace materialization complete"
 
 # Start Next.js dev server (outside the setup lock; own pid-guard).
 {nextjs_start_script}
-echo "Session workspace setup complete"
+echo "{WORKSPACE_SETUP_COMPLETE_SENTINEL}"
 """

--- a/backend/onyx/server/features/build/sandbox/session_workspace.py
+++ b/backend/onyx/server/features/build/sandbox/session_workspace.py
@@ -1,0 +1,123 @@
+"""Shared session-workspace setup script for the Docker and Kubernetes
+sandbox managers.
+
+The script is replay-safe: the whole setup is serialized per session with an
+in-sandbox ``flock``, an in-progress marker distinguishes a partial directory
+from a complete workspace, and the Next.js dev server is only spawned when no
+live server is already attached to the session. Re-running the script after an
+interruption converges on the same completed workspace.
+"""
+
+import shlex
+
+from onyx.server.features.build.sandbox.base import (
+    BUN_CACHE_DIR,
+    BUN_IMAGE_CACHE_DIR,
+)
+from onyx.server.features.build.sandbox.nextjs_dev import build_nextjs_start_script
+
+SESSIONS_ROOT = "/workspace/sessions"
+TEMPLATES_OUTPUTS_PATH = "/workspace/templates/outputs"
+MANAGED_SKILLS_PATH = "/workspace/managed/skills"
+MANAGED_USER_LIBRARY_PATH = "/workspace/managed/user_library"
+
+# Present inside a session directory while setup is running; its presence on
+# an existing directory means the workspace is partial, not ready. Legacy
+# workspaces (created before the marker existed) have no marker and read as
+# complete.
+SETUP_IN_PROGRESS_MARKER = ".setup-in-progress"
+
+
+def build_workspace_exists_check_script(session_path: str) -> str:
+    """Emit ``WORKSPACE_FOUND`` only for a complete workspace: the outputs
+    directory exists and no in-progress marker is present."""
+    return (
+        f'if [ -d "{session_path}/outputs" ] && '
+        f'[ ! -f "{session_path}/{SETUP_IN_PROGRESS_MARKER}" ]; '
+        f'then echo "WORKSPACE_FOUND"; else echo "WORKSPACE_MISSING"; fi'
+    )
+
+
+def build_session_workspace_setup_script(
+    session_path: str,
+    agents_md: str,
+    session_opencode_config_json: str,
+    nextjs_port: int | None,
+) -> str:
+    """Build the shell script that creates a session workspace.
+
+    Headless callers (scheduled tasks) pass ``nextjs_port=None`` — the agent's
+    tools work without a dev server.
+    """
+    outputs_setup = f"""
+echo "Copying outputs template"
+if [ -d {TEMPLATES_OUTPUTS_PATH} ]; then
+    cp -r {TEMPLATES_OUTPUTS_PATH}/* {session_path}/outputs/
+    # flock+sentinel: serialize concurrent session setups; .ready guards
+    # against a partial cp from a previous interrupted run.
+    (
+        flock -x 9
+        if [ ! -f {BUN_CACHE_DIR}/.ready ]; then
+            echo "Bootstrapping bun cache on workspace volume..."
+            rm -rf {BUN_CACHE_DIR}
+            cp -r {BUN_IMAGE_CACHE_DIR} {BUN_CACHE_DIR} \\
+                || {{ echo "ERROR: bun cache bootstrap failed" >&2; exit 1; }}
+            touch {BUN_CACHE_DIR}/.ready
+        fi
+    ) 9>{BUN_CACHE_DIR}.lock
+    cd {session_path}/outputs/web && \\
+        BUN_INSTALL_CACHE_DIR={BUN_CACHE_DIR} \\
+        bun install --frozen-lockfile --backend=hardlink
+else
+    echo "Warning: outputs template not found at {TEMPLATES_OUTPUTS_PATH}"
+    mkdir -p {session_path}/outputs/web
+fi
+"""
+
+    nextjs_start_script = (
+        build_nextjs_start_script(session_path, nextjs_port, check_node_modules=False)
+        if nextjs_port is not None
+        else ""
+    )
+
+    return f"""
+set -e
+
+# Serialize the whole setup per session: a concurrent replay blocks here and
+# then re-runs over the completed workspace, converging instead of racing.
+(
+flock -x 8
+set -e
+
+echo "Creating session directory: {session_path}"
+mkdir -p {session_path}
+touch {session_path}/{SETUP_IN_PROGRESS_MARKER}
+mkdir -p {session_path}/outputs
+mkdir -p {session_path}/attachments
+
+# Setup outputs
+{outputs_setup}
+
+# DO NOT mkdir /workspace/managed/skills or /workspace/managed/user_library
+# here — the push daemon swaps these paths via os.rename(symlink, mount),
+# which fails if the mount is a real directory. Dangling until the first
+# push lands is fine; nothing reads these during the rest of setup.
+mkdir -p {session_path}/.opencode
+ln -sfn {MANAGED_SKILLS_PATH} {session_path}/.opencode/skills
+echo "Linked skills to {MANAGED_SKILLS_PATH}"
+ln -sfn {MANAGED_USER_LIBRARY_PATH} {session_path}/user_library
+echo "Linked user_library to {MANAGED_USER_LIBRARY_PATH}"
+
+# Write agent instructions
+echo "Writing AGENTS.md"
+printf '%s' {shlex.quote(agents_md)} > {session_path}/AGENTS.md
+
+printf '%s' {shlex.quote(session_opencode_config_json)} > {session_path}/opencode.json
+
+# Start Next.js dev server
+{nextjs_start_script}
+
+rm -f {session_path}/{SETUP_IN_PROGRESS_MARKER}
+echo "Session workspace setup complete"
+) 8>{session_path}.setup.lock
+"""

--- a/backend/onyx/server/features/build/sandbox/session_workspace.py
+++ b/backend/onyx/server/features/build/sandbox/session_workspace.py
@@ -83,8 +83,12 @@ fi
     return f"""
 set -e
 
-# Serialize the whole setup per session: a concurrent replay blocks here and
-# then re-runs over the completed workspace, converging instead of racing.
+# Serialize workspace *materialization* per session with an flock: a concurrent
+# replay blocks here and then re-runs over the completed workspace, converging
+# instead of racing. The dev-server launch is deliberately NOT inside this
+# subshell — a backgrounded server started here would inherit fd 8 and hold the
+# lock for its entire lifetime, deadlocking every later repair/restore. It runs
+# after the lock releases and has its own pid-guard for idempotency.
 (
 flock -x 8
 set -e
@@ -114,10 +118,11 @@ printf '%s' {shlex.quote(agents_md)} > {session_path}/AGENTS.md
 
 printf '%s' {shlex.quote(session_opencode_config_json)} > {session_path}/opencode.json
 
-# Start Next.js dev server
-{nextjs_start_script}
-
 rm -f {session_path}/{SETUP_IN_PROGRESS_MARKER}
-echo "Session workspace setup complete"
+echo "Workspace materialization complete"
 ) 8>{session_path}.setup.lock
+
+# Start Next.js dev server (outside the setup lock; own pid-guard).
+{nextjs_start_script}
+echo "Session workspace setup complete"
 """

--- a/backend/onyx/server/features/build/sandbox/user_library.py
+++ b/backend/onyx/server/features/build/sandbox/user_library.py
@@ -7,9 +7,8 @@ from sqlalchemy.orm import Session
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.features.build.db.sandbox import get_sandbox_user_map
 from onyx.server.features.build.db.user_library import list_user_files
-from onyx.server.features.build.sandbox.base import SandboxManager
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
-from onyx.server.features.build.sandbox.models import FileSet, PushResult
+from onyx.server.features.build.sandbox.models import FileSet
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -43,22 +42,6 @@ def build_user_library_fileset(user_id: UUID, db_session: Session) -> FileSet:
             )
 
     return files
-
-
-def hydrate_user_library(
-    sandbox_id: UUID,
-    user_id: UUID,
-    db_session: Session,
-    *,
-    sandbox_manager: SandboxManager,
-) -> PushResult:
-    """Push all user library files to a single sandbox (cold-start hydration)."""
-    files = build_user_library_fileset(user_id, db_session)
-    return sandbox_manager.push_to_sandbox(
-        sandbox_id=sandbox_id,
-        mount_path=USER_LIBRARY_MOUNT_PATH,
-        files=files,
-    )
 
 
 def sync_user_library_to_active_sandboxes(

--- a/backend/onyx/server/features/build/sandbox/util/agent_instructions.py
+++ b/backend/onyx/server/features/build/sandbox/util/agent_instructions.py
@@ -4,7 +4,10 @@ from collections.abc import Iterable
 from pathlib import Path
 
 from onyx.db.models import ExternalApp
-from onyx.server.features.build.configs import SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS
+from onyx.server.features.build.configs import (
+    SANDBOX_APPROVAL_WAIT_MARGIN_SECONDS,
+    SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS,
+)
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -156,7 +159,9 @@ def generate_agent_instructions(
     )
     content = content.replace(
         "{{APPROVAL_CLIENT_TIMEOUT_SECONDS}}",
-        str(SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS + 20),
+        str(
+            SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS + SANDBOX_APPROVAL_WAIT_MARGIN_SECONDS
+        ),
     )
     content = content.replace("{{DISABLED_TOOLS_SECTION}}", disabled_tools_section)
     content = content.replace("{{CONNECTABLE_APPS_LIST}}", connectable_apps_section)

--- a/backend/onyx/server/features/build/sandbox/util/api_url_check.py
+++ b/backend/onyx/server/features/build/sandbox/util/api_url_check.py
@@ -13,11 +13,10 @@ import httpx
 
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.build.timeouts import CONNECT_TIMEOUT_SECONDS
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
-
-_PROBE_TIMEOUT_SECONDS = 5.0
 
 _validated = False
 _validated_lock = threading.Lock()
@@ -28,7 +27,7 @@ def _probe_health(base_url: str) -> httpx.Response | None:
     try:
         return httpx.get(
             f"{base_url}/health",
-            timeout=_PROBE_TIMEOUT_SECONDS,
+            timeout=CONNECT_TIMEOUT_SECONDS,
             follow_redirects=True,
         )
     except httpx.HTTPError:

--- a/backend/onyx/server/features/build/scheduled_tasks/api.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/api.py
@@ -52,6 +52,7 @@ from onyx.server.features.build.scheduled_tasks.schedule import (
     human_readable,
     next_n_fires,
 )
+from onyx.server.features.build.timeouts import QUEUE_RESIDENCY_SECONDS
 from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id
@@ -62,11 +63,6 @@ logger = setup_logger()
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-
-# Number of seconds before a queued executor task is dropped. Mirrors
-# ``check-for-pruning`` and ``check-for-indexing`` — 15 minutes is plenty for
-# the worker to pick up the task; anything still queued past that is dead.
-EXECUTOR_TASK_EXPIRES_SECONDS = 900
 
 # Number of future fires returned by the detail endpoint for UI preview.
 NEXT_RUNS_PREVIEW_COUNT = 3
@@ -343,7 +339,7 @@ def _enqueue_executor(run_id: UUID) -> None:
         kwargs={"run_id": str(run_id), "tenant_id": tenant_id},
         queue=OnyxCeleryQueues.SCHEDULED_TASKS,
         priority=OnyxCeleryPriority.MEDIUM,
-        expires=EXECUTOR_TASK_EXPIRES_SECONDS,
+        expires=QUEUE_RESIDENCY_SECONDS,
     )
 
 

--- a/backend/onyx/server/features/build/scheduled_tasks/executor.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/executor.py
@@ -12,7 +12,7 @@ Lifecycle (see ``docs/craft/features/scheduled-tasks/overview.md``):
    marked it failed).
 2. Get the user's sandbox to a RUNNING state via
    ``SessionManager.ensure_sandbox_running`` — creates a sandbox if the
-   user has none, waits up to ``PROVISIONING_WAIT_SECONDS`` for any
+   user has none, waits up to ``PROVISION_WAIT_SECONDS`` for any
    concurrent provisioner, and wakes SLEEPING / TERMINATED / FAILED
    sandboxes in place. SKIP only if the wait window elapses with the
    sandbox still PROVISIONING (``sandbox_provisioning``); any other
@@ -60,22 +60,18 @@ from onyx.server.features.build.sandbox.event_schema import (
 from onyx.server.features.build.session.locks import session_creation_lock
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.features.build.session.streaming import BuildStreamingState
+from onyx.server.features.build.timeouts import (
+    PROVISION_WAIT_SECONDS,
+    TURN_BUDGET_SECONDS,
+)
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
 
-# Per-run wall-clock budget (monotonic). Tasks that blow past this are
-# marked ``failed (error_class=timeout)``. The stuck-run sweeper uses a
-# slightly larger threshold (45 min) so a hung run that fails to honor the
-# budget still gets cleaned up out-of-band.
-DEFAULT_EXECUTOR_BUDGET_SECONDS = 30 * 60
-
 # Summary length on the run row (per spec: ~120 chars of final agent
 # message).
 SUMMARY_MAX_CHARS = 120
-
-PROVISIONING_WAIT_SECONDS = 120
 
 
 def _clip_summary(text: str) -> str:
@@ -167,7 +163,7 @@ def _notify(
 def run_scheduled_task_logic(
     run_id: UUID,
     *,
-    budget_seconds: int = DEFAULT_EXECUTOR_BUDGET_SECONDS,
+    budget_seconds: int = TURN_BUDGET_SECONDS,
 ) -> None:
     """Execute a single scheduled-task run end-to-end.
 
@@ -222,15 +218,14 @@ def run_scheduled_task_logic(
         task_prompt = task.prompt
 
         # ensure_sandbox_running handles every state we care about:
-        # creates a sandbox if none exists, waits up to
-        # PROVISIONING_WAIT_SECONDS for any concurrent provisioner, wakes
-        # SLEEPING / TERMINATED / FAILED, and recovers a RUNNING-but-
-        # unhealthy pod.
+        # creates a sandbox if none exists, waits out any concurrent
+        # provisioner, wakes SLEEPING / TERMINATED / FAILED, and recovers a
+        # RUNNING-but-unhealthy pod.
         try:
             session_manager = SessionManager(db_session)
             sandbox = session_manager.ensure_sandbox_running(
                 task_user_id,
-                provisioning_wait_seconds=PROVISIONING_WAIT_SECONDS,
+                provisioning_wait_seconds=PROVISION_WAIT_SECONDS,
             )
             db_session.commit()
         except Exception as exc:
@@ -632,10 +627,3 @@ def _drive_agent(
             # approval gate, budget exceeded, exception). Matches the
             # interactive path's finally in _stream_cli_agent_response.
             prompt_slot_cm.__exit__(None, None, None)
-
-
-# Re-export for the Celery task wrapper.
-__all__ = [
-    "DEFAULT_EXECUTOR_BUDGET_SECONDS",
-    "run_scheduled_task_logic",
-]

--- a/backend/onyx/server/features/build/scheduled_tasks/executor.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/executor.py
@@ -349,7 +349,7 @@ def _drive_agent(
         with session_creation_lock(task_user_id):
             # Create the BuildSession. SCHEDULED origin keeps it out of the
             # Craft sidebar (see `get_user_build_sessions`).
-            build_session = session_manager.create_session__no_commit(
+            build_session = session_manager.create_session(
                 user_id=task_user_id,
                 origin=SessionOrigin.SCHEDULED,
                 name=f"Scheduled: {task_name}",

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -20,14 +20,15 @@ from onyx.db.enums import (
     SandboxStatus,
     ScheduledTaskRunStatus,
 )
+from onyx.db.external_app import get_connectable_apps_for_user
 from onyx.db.models import BuildMessage, Sandbox, User
 from onyx.db.scheduled_task import get_scheduled_run_context
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.db.build_session import (
-    allocate_nextjs_port,
     get_build_session,
+    reserve_nextjs_port__no_commit,
     session_runtime_stale,
     set_build_session_sharing_scope,
 )
@@ -39,10 +40,16 @@ from onyx.server.features.build.db.sandbox import (
 from onyx.server.features.build.models import UploadResponse
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.models import DirectoryListing
+from onyx.server.features.build.sandbox.util.agent_instructions import (
+    build_connectable_apps_list,
+)
 from onyx.server.features.build.sandbox.util.mcp_config import (
     resolve_craft_mcp_servers,
 )
-from onyx.server.features.build.session.errors import UploadLimitExceededError
+from onyx.server.features.build.session.errors import (
+    SandboxProvisioningInProgressError,
+    UploadLimitExceededError,
+)
 from onyx.server.features.build.session.locks import (
     SessionCreationLockAcquisitionError,
     session_creation_lock,
@@ -67,16 +74,14 @@ from onyx.server.features.build.session.models import (
     WebappInfo,
 )
 from onyx.server.features.build.session.sandbox_lifecycle import (
+    ProvisioningPolicy,
     create_session_snapshot_keep_latest,
-    hydrate_managed_content,
-    mark_sandbox_provisioning,
-    provision_sandbox,
-    recover_unhealthy_sandbox,
-    rollback_failed_provisioning,
+    ensure_sandbox_ready,
+    sync_managed_content,
 )
 from onyx.server.features.build.session.streaming import SSE_KEEPALIVE
 from onyx.server.features.build.utils import sanitize_filename, validate_file
-from onyx.skills.push import build_user_skills_payload
+from onyx.server.metrics.craft_sandbox import SandboxReadyOutcome
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id
 
@@ -117,14 +122,14 @@ def create_session(
     """
     Create or get an existing empty build session.
 
-    Creates a sandbox with the necessary file structure and returns a session ID.
-    Uses SessionManager for session and sandbox provisioning.
+    Reserve → reconcile → finalize: the sandbox and session identities are
+    committed before external provisioning, so a failed or interrupted
+    attempt leaves durable, repairable state (a later request converges on
+    the same IDs) rather than rolling back to nothing.
 
-    This endpoint is atomic - if sandbox provisioning fails, no database
-    records are created (transaction is rolled back).
-
-    Uses Redis lock to prevent race conditions when multiple requests try to
-    create/provision a session for the same user concurrently.
+    The Redis lock only reduces duplicate provisioning work for concurrent
+    requests; correctness comes from the committed reservation and
+    generation fencing.
     """
     try:
         with session_creation_lock(user.id):
@@ -146,6 +151,11 @@ def create_session(
     except SessionCreationLockAcquisitionError as e:
         db_session.rollback()
         raise OnyxError(OnyxErrorCode.SERVICE_UNAVAILABLE, str(e)) from e
+    except SandboxProvisioningInProgressError as e:
+        # A live attempt (another replica/request) owns the sandbox; the
+        # frontend retries.
+        db_session.rollback()
+        raise OnyxError(OnyxErrorCode.CONFLICT, str(e)) from e
     except OnyxError:
         # e.g. no provider exposes a supported model; let the global handler
         # return its own status code instead of collapsing to 429/500.
@@ -390,142 +400,118 @@ def restore_session(
         )
 
     try:
-        db_session.refresh(sandbox)
-
-        if sandbox.status == SandboxStatus.RUNNING:
-            is_healthy = sandbox_manager.health_check(sandbox.id, timeout=10.0)
-            if is_healthy and sandbox_manager.session_workspace_exists(
-                sandbox.id, session_id
-            ):
-                session.status = BuildSessionStatus.ACTIVE
-                if session_runtime_stale(session, sandbox):
-                    SessionManager(db_session).reload_session_skills(session_id, user)
-                else:
-                    update_sandbox_heartbeat(db_session, sandbox.id)
-                    db_session.commit()
-                base_response = SessionResponse.from_model(session, sandbox)
-                return DetailedSessionResponse.from_session_response(
-                    base_response, session_loaded_in_sandbox=True
-                )
-
-            if not is_healthy:
-                logger.warning(
-                    "Sandbox %s marked as RUNNING but pod is unhealthy/missing. Entering recovery mode.",
-                    sandbox.id,
-                )
-                recover_unhealthy_sandbox(
-                    db_session, sandbox_manager, sandbox, tenant_id
-                )
-                db_session.commit()
-                db_session.refresh(sandbox)
-
+        # Validate the model configuration before any external work; commit
+        # closes the read transaction without expiring loaded instances.
         llm_config = SessionManager(db_session).build_llm_configs(user)
+        db_session.commit()
 
-        if sandbox.status in (SandboxStatus.SLEEPING, SandboxStatus.TERMINATED):
-            mark_sandbox_provisioning(db_session, sandbox)
+        # The shared state machine handles every sandbox state: healthy
+        # RUNNING, unhealthy recovery, SLEEPING/TERMINATED/FAILED wake, and
+        # stale-PROVISIONING takeover, all with committed reservations and
+        # generation fencing.
+        sandbox, outcome = ensure_sandbox_ready(
+            db_session,
+            sandbox_manager,
+            user.id,
+            policy=ProvisioningPolicy.FAIL,
+        )
 
-            # Provisions, hydrates managed content, and stages the new status;
-            # a failure rolls the row back to SLEEPING in the handler below.
-            provision_sandbox(
-                db_session,
-                sandbox_manager,
-                sandbox,
-                user,
-                user.id,
-                tenant_id,
+        if sandbox_manager.session_workspace_exists(sandbox.id, session_id):
+            session.status = BuildSessionStatus.ACTIVE
+            if session_runtime_stale(session, sandbox):
+                SessionManager(db_session).reload_session_skills(session_id, user)
+            else:
+                update_sandbox_heartbeat(db_session, sandbox.id)
+                db_session.commit()
+            base_response = SessionResponse.from_model(session, sandbox)
+            return DetailedSessionResponse.from_session_response(
+                base_response, session_loaded_in_sandbox=True
             )
+
+        # Workspace missing: reserve a port, sync managed content, then
+        # restore the latest snapshot (or build a fresh template workspace).
+        if not session.nextjs_port:
+            reserve_nextjs_port__no_commit(db_session, session)
             db_session.commit()
 
-        if sandbox.status == SandboxStatus.RUNNING:
-            workspace_exists = sandbox_manager.session_workspace_exists(
-                sandbox.id, session_id
-            )
+        if outcome == SandboxReadyOutcome.ALREADY_RUNNING:
+            # A reused pod may be missing content pushed since it last
+            # synced; fresh provisioning already pushed managed content.
+            sync_managed_content(db_session, sandbox_manager, sandbox.id, user)
 
-            if not workspace_exists:
-                if not session.nextjs_port:
-                    session.nextjs_port = allocate_nextjs_port(db_session)
-                    db_session.commit()
+        snapshot = get_latest_snapshot_for_session(db_session, session_id)
+        connectable_apps_section = build_connectable_apps_list(
+            get_connectable_apps_for_user(db_session, user)
+        )
+        mcp_servers = resolve_craft_mcp_servers(db_session, user)
+        nextjs_port = session.nextjs_port
+        sandbox_skills_hash = sandbox.skills_hash
+        sandbox_mcp_config_hash = sandbox.mcp_config_hash
+        db_session.commit()
 
-                snapshot = get_latest_snapshot_for_session(db_session, session_id)
-
-                connectable_apps_section, skills_files = build_user_skills_payload(
-                    user, db_session
-                )
-                hydrate_managed_content(
-                    sandbox_manager,
-                    sandbox.id,
-                    user,
-                    db_session,
+        if snapshot:
+            try:
+                sandbox_manager.restore_snapshot(
+                    sandbox_id=sandbox.id,
+                    session_id=session_id,
+                    snapshot_storage_path=snapshot.storage_path,
+                    nextjs_port=nextjs_port,
+                    llm_config=llm_config,
                     connectable_apps_section=connectable_apps_section,
-                    skills_files=skills_files,
+                    mcp_servers=mcp_servers,
                 )
-                if snapshot:
-                    try:
-                        sandbox_manager.restore_snapshot(
-                            sandbox_id=sandbox.id,
-                            session_id=session_id,
-                            snapshot_storage_path=snapshot.storage_path,
-                            nextjs_port=session.nextjs_port,
-                            llm_config=llm_config,
-                            connectable_apps_section=connectable_apps_section,
-                            mcp_servers=resolve_craft_mcp_servers(db_session, user),
-                        )
-                        session.status = BuildSessionStatus.ACTIVE
-                        session.skills_hash = sandbox.skills_hash
-                        session.mcp_config_hash = sandbox.mcp_config_hash
-                        db_session.commit()
-                    except Exception as e:
-                        logger.error(
-                            "Snapshot restore failed for session %s: %s", session_id, e
-                        )
-                        session.nextjs_port = None
-                        db_session.commit()
-                        raise
-                else:
-                    sandbox_manager.setup_session_workspace(
-                        sandbox_id=sandbox.id,
-                        session_id=session_id,
-                        llm_config=llm_config,
-                        nextjs_port=session.nextjs_port,
-                        connectable_apps_section=connectable_apps_section,
-                        mcp_servers=resolve_craft_mcp_servers(db_session, user),
-                    )
-                    session.status = BuildSessionStatus.ACTIVE
-                    session.skills_hash = sandbox.skills_hash
-                    session.mcp_config_hash = sandbox.mcp_config_hash
-                    db_session.commit()
-
+            except Exception as e:
+                logger.error(
+                    "Snapshot restore failed for session %s: %s", session_id, e
+                )
+                db_session.rollback()
+                session.nextjs_port = None
+                db_session.commit()
+                raise
         else:
-            logger.warning(
-                "Sandbox %s status is %s after re-provision, expected RUNNING",
-                sandbox.id,
-                sandbox.status,
+            sandbox_manager.setup_session_workspace(
+                sandbox_id=sandbox.id,
+                session_id=session_id,
+                llm_config=llm_config,
+                nextjs_port=nextjs_port,
+                connectable_apps_section=connectable_apps_section,
+                mcp_servers=mcp_servers,
             )
 
+        session.status = BuildSessionStatus.ACTIVE
+        session.skills_hash = sandbox_skills_hash
+        session.mcp_config_hash = sandbox_mcp_config_hash
+        db_session.commit()
+
+    except SandboxProvisioningInProgressError as e:
+        db_session.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail=f"Sandbox is being provisioned by another request: {e}",
+        )
     except OnyxError:
         db_session.rollback()
         raise
     except Exception as e:
         logger.error("Failed to restore session %s: %s", session_id, e, exc_info=True)
-        # Recover so the next attempt isn't blocked by a half-finished state.
+        # Sandbox-level failures are already durably recorded (FAILED with
+        # generation metadata) by the state machine; only a partial workspace
+        # needs compensating cleanup so session_workspace_exists() doesn't
+        # later report it restored.
         try:
             db_session.rollback()
-            stuck = get_sandbox_by_user_id(db_session, user.id)
-            if stuck is not None and not rollback_failed_provisioning(
-                db_session, stuck
-            ):
-                if stuck.status == SandboxStatus.RUNNING:
-                    # Workspace load failed after provision — drop the partial dir
-                    # so session_workspace_exists() doesn't later report it restored.
-                    sandbox_manager.cleanup_session_workspace(stuck.id, session_id)
-                    logger.info(
-                        "Cleaned up partial workspace for session %s after failed restore",
-                        session_id,
-                    )
-        except Exception as rollback_err:
+            current = get_sandbox_by_user_id(db_session, user.id)
+            db_session.rollback()
+            if current is not None and current.status == SandboxStatus.RUNNING:
+                sandbox_manager.cleanup_session_workspace(current.id, session_id)
+                logger.info(
+                    "Cleaned up partial workspace for session %s after failed restore",
+                    session_id,
+                )
+        except Exception as cleanup_err:
             logger.warning(
-                "Failed to recover sandbox state after restore failure: %s",
-                rollback_err,
+                "Failed to clean up after restore failure: %s",
+                cleanup_err,
             )
         raise HTTPException(
             status_code=500,

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -26,6 +26,7 @@ from onyx.db.scheduled_task import get_scheduled_run_context
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_pool import get_redis_client
+from onyx.server.features.build.configs import SSE_KEEPALIVE_INTERVAL
 from onyx.server.features.build.db.build_session import (
     get_build_session,
     reserve_nextjs_port__no_commit,
@@ -80,6 +81,10 @@ from onyx.server.features.build.session.sandbox_lifecycle import (
     sync_managed_content,
 )
 from onyx.server.features.build.session.streaming import SSE_KEEPALIVE
+from onyx.server.features.build.timeouts import (
+    POLL_INTERVAL_SECONDS,
+    SESSION_FLOW_LOCK_LEASE_SECONDS,
+)
 from onyx.server.features.build.utils import sanitize_filename, validate_file
 from onyx.server.metrics.craft_sandbox import SandboxReadyOutcome
 from onyx.utils.logger import setup_logger
@@ -363,10 +368,6 @@ def delete_session(
     return Response(status_code=204)
 
 
-# Lock timeout should be longer than max restore time (5 minutes)
-RESTORE_LOCK_TIMEOUT_SECONDS = 300
-
-
 @router.post("/{session_id}/restore", response_model=DetailedSessionResponse)
 def restore_session(
     session_id: UUID,
@@ -389,7 +390,7 @@ def restore_session(
 
     redis_client = get_redis_client(tenant_id=tenant_id)
     lock_key = f"sandbox_restore:{sandbox.id}"
-    lock = redis_client.lock(lock_key, timeout=RESTORE_LOCK_TIMEOUT_SECONDS)
+    lock = redis_client.lock(lock_key, timeout=SESSION_FLOW_LOCK_LEASE_SECONDS)
 
     # 409 instead of blocking — the frontend retries.
     acquired = lock.acquire(blocking=False)
@@ -405,10 +406,6 @@ def restore_session(
         llm_config = SessionManager(db_session).build_llm_configs(user)
         db_session.commit()
 
-        # The shared state machine handles every sandbox state: healthy
-        # RUNNING, unhealthy recovery, SLEEPING/TERMINATED/FAILED wake, and
-        # stale-PROVISIONING takeover, all with committed reservations and
-        # generation fencing.
         sandbox, outcome = ensure_sandbox_ready(
             db_session,
             sandbox_manager,
@@ -428,8 +425,7 @@ def restore_session(
                 base_response, session_loaded_in_sandbox=True
             )
 
-        # Workspace missing: reserve a port, sync managed content, then
-        # restore the latest snapshot (or build a fresh template workspace).
+        # Workspace missing: rebuild it (snapshot restore or fresh template).
         if not session.nextjs_port:
             reserve_nextjs_port__no_commit(db_session, session)
             db_session.commit()
@@ -494,10 +490,9 @@ def restore_session(
         raise
     except Exception as e:
         logger.error("Failed to restore session %s: %s", session_id, e, exc_info=True)
-        # Sandbox-level failures are already durably recorded (FAILED with
-        # generation metadata) by the state machine; only a partial workspace
-        # needs compensating cleanup so session_workspace_exists() doesn't
-        # later report it restored.
+        # Sandbox-level failures are already durably recorded (FAILED) by the
+        # state machine; only a partial workspace needs compensating cleanup so
+        # session_workspace_exists() doesn't later report it restored.
         try:
             db_session.rollback()
             current = get_sandbox_by_user_id(db_session, user.id)
@@ -1012,10 +1007,6 @@ def get_session_scheduled_run_context(
     )
 
 
-LIVE_STREAM_READY_POLL_SECONDS = 1.0
-LIVE_STREAM_KEEPALIVE_SECONDS = 15.0
-
-
 def _scheduled_run_is_running(
     *,
     db_session: Session,
@@ -1080,7 +1071,7 @@ def get_session_scheduled_run_events(
                     break
 
             yield SSE_KEEPALIVE
-            time.sleep(LIVE_STREAM_READY_POLL_SECONDS)
+            time.sleep(POLL_INTERVAL_SECONDS)
 
         try:
             with get_session_with_current_tenant() as stream_db_session:
@@ -1088,7 +1079,7 @@ def get_session_scheduled_run_events(
                 for chunk in session_manager.subscribe_to_existing_session_events(
                     session_id,
                     user_id,
-                    keepalive_seconds=LIVE_STREAM_KEEPALIVE_SECONDS,
+                    keepalive_seconds=SSE_KEEPALIVE_INTERVAL,
                 ):
                     yield chunk
                     stream_db_session.expire_all()

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -485,10 +485,10 @@ def restore_session(
 
     except SandboxProvisioningInProgressError as e:
         db_session.rollback()
-        raise HTTPException(
-            status_code=409,
-            detail=f"Sandbox is being provisioned by another request: {e}",
-        )
+        raise OnyxError(
+            OnyxErrorCode.CONFLICT,
+            f"Sandbox is being provisioned by another request: {e}",
+        ) from e
     except OnyxError:
         db_session.rollback()
         raise

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -53,6 +53,7 @@ from onyx.server.features.build.session.errors import (
 )
 from onyx.server.features.build.session.locks import (
     SessionCreationLockAcquisitionError,
+    get_session_creation_lock,
     session_creation_lock,
 )
 from onyx.server.features.build.session.manager import SessionManager
@@ -81,10 +82,7 @@ from onyx.server.features.build.session.sandbox_lifecycle import (
     sync_managed_content,
 )
 from onyx.server.features.build.session.streaming import SSE_KEEPALIVE
-from onyx.server.features.build.timeouts import (
-    POLL_INTERVAL_SECONDS,
-    SESSION_FLOW_LOCK_LEASE_SECONDS,
-)
+from onyx.server.features.build.timeouts import POLL_INTERVAL_SECONDS
 from onyx.server.features.build.utils import sanitize_filename, validate_file
 from onyx.server.metrics.craft_sandbox import SandboxReadyOutcome
 from onyx.utils.logger import setup_logger
@@ -375,8 +373,8 @@ def restore_session(
     db_session: Session = Depends(get_session),
 ) -> DetailedSessionResponse:
     """Restore the sandbox (re-provisioning if asleep) and load the session
-    workspace. Serialized per-sandbox via a Redis lock; returns 409 if another
-    restore holds it."""
+    workspace. Serialized against create and reap via the per-user
+    session-flow lock; returns 409 if another flow holds it."""
     session = get_build_session(session_id, user.id, db_session)
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
@@ -389,8 +387,7 @@ def restore_session(
     tenant_id = get_current_tenant_id()
 
     redis_client = get_redis_client(tenant_id=tenant_id)
-    lock_key = f"sandbox_restore:{sandbox.id}"
-    lock = redis_client.lock(lock_key, timeout=SESSION_FLOW_LOCK_LEASE_SECONDS)
+    lock = get_session_creation_lock(redis_client, user.id)
 
     # 409 instead of blocking — the frontend retries.
     acquired = lock.acquire(blocking=False)

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -133,8 +133,8 @@ def create_session(
     the same IDs) rather than rolling back to nothing.
 
     The Redis lock only reduces duplicate provisioning work for concurrent
-    requests; correctness comes from the committed reservation and
-    generation fencing.
+    requests; correctness comes from the committed reservation and the
+    attempt-number condition on status writes.
     """
     try:
         with session_creation_lock(user.id):

--- a/backend/onyx/server/features/build/session/errors.py
+++ b/backend/onyx/server/features/build/session/errors.py
@@ -34,9 +34,9 @@ class SandboxProvisioningError(RuntimeError):
 
 class SandboxProvisioningInProgressError(SandboxProvisioningError):
     """A live provisioning attempt (recent committed ``PROVISIONING``
-    attempt_number) already owns the sandbox; the caller should retry shortly."""
+    attempt) already owns the sandbox; the caller should retry shortly."""
 
 
 class StaleProvisioningAttemptError(SandboxProvisioningError):
-    """This attempt's attempt_number was superseded before it could finalize;
+    """This attempt was superseded before it could finalize;
     its external work must not be recorded as the current runtime."""

--- a/backend/onyx/server/features/build/session/errors.py
+++ b/backend/onyx/server/features/build/session/errors.py
@@ -30,3 +30,13 @@ class UploadLimitExceededError(ValueError):
 class SandboxProvisioningError(RuntimeError):
     """Raised when a sandbox is mid-provision and the caller cannot wait
     it out."""
+
+
+class SandboxProvisioningInProgressError(SandboxProvisioningError):
+    """A live provisioning attempt (recent committed ``PROVISIONING``
+    generation) already owns the sandbox; the caller should retry shortly."""
+
+
+class StaleProvisioningAttemptError(SandboxProvisioningError):
+    """This attempt's generation was superseded before it could finalize;
+    its external work must not be recorded as the current runtime."""

--- a/backend/onyx/server/features/build/session/errors.py
+++ b/backend/onyx/server/features/build/session/errors.py
@@ -34,9 +34,9 @@ class SandboxProvisioningError(RuntimeError):
 
 class SandboxProvisioningInProgressError(SandboxProvisioningError):
     """A live provisioning attempt (recent committed ``PROVISIONING``
-    generation) already owns the sandbox; the caller should retry shortly."""
+    attempt_number) already owns the sandbox; the caller should retry shortly."""
 
 
 class StaleProvisioningAttemptError(SandboxProvisioningError):
-    """This attempt's generation was superseded before it could finalize;
+    """This attempt's attempt_number was superseded before it could finalize;
     its external work must not be recorded as the current runtime."""

--- a/backend/onyx/server/features/build/session/locks.py
+++ b/backend/onyx/server/features/build/session/locks.py
@@ -7,11 +7,11 @@ from redis.lock import Lock as RedisLock
 from onyx.configs.constants import OnyxRedisLocks
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.tenant_redis_client import TenantRedisClient
-from onyx.server.features.build.configs import (
-    SESSION_CREATE_LOCK_LEASE_SECONDS,
-    SESSION_CREATE_LOCK_WAIT_SECONDS,
-)
+from onyx.server.features.build.timeouts import SESSION_FLOW_LOCK_LEASE_SECONDS
 from shared_configs.contextvars import get_current_tenant_id
+
+# How long a creator blocks on another create/reap of the same user's sandbox.
+SESSION_FLOW_LOCK_WAIT_SECONDS = 60
 
 
 class SessionCreationLockAcquisitionError(RuntimeError):
@@ -24,7 +24,7 @@ def get_session_creation_lock(
 ) -> RedisLock:
     return redis_client.lock(
         f"{OnyxRedisLocks.SESSION_CREATE_LOCK_PREFIX}:{user_id}",
-        timeout=SESSION_CREATE_LOCK_LEASE_SECONDS,
+        timeout=SESSION_FLOW_LOCK_LEASE_SECONDS,
     )
 
 
@@ -35,7 +35,7 @@ def session_creation_lock(user_id: UUID) -> Generator[None, None, None]:
     lock = get_session_creation_lock(redis_client, user_id)
     if not lock.acquire(
         blocking=True,
-        blocking_timeout=SESSION_CREATE_LOCK_WAIT_SECONDS,
+        blocking_timeout=SESSION_FLOW_LOCK_WAIT_SECONDS,
     ):
         raise SessionCreationLockAcquisitionError(
             f"Timed out waiting to create a session for user {user_id}"

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -240,7 +240,7 @@ class SessionManager:
         """Mint and persist the OpenCode session before the first prompt.
 
         The caller owns the surrounding transaction. This keeps the empty Craft
-        session's runtime ID and acknowledged skills generation aligned.
+        session's runtime ID and acknowledged skills attempt_number aligned.
         """
         opencode_session_id = self._sandbox_manager.ensure_opencode_session(
             sandbox_id=sandbox.id,
@@ -445,7 +445,7 @@ class SessionManager:
         - No sandbox row: creates one and provisions it.
         - ``RUNNING`` + pod healthy: returns as-is.
         - ``RUNNING`` + pod missing/unhealthy: terminates and re-provisions
-          under a new generation.
+          under a new attempt_number.
         - ``SLEEPING`` / ``TERMINATED`` / ``FAILED``: re-provisions in place.
         - ``PROVISIONING``: a stale attempt is taken over; a live one is
           polled up to ``provisioning_wait_seconds`` (default 30s). Raises
@@ -661,7 +661,8 @@ class SessionManager:
         llm_config: CraftLLMProviderConfig,
     ) -> None:
         """Build the workspace and OpenCode session for a committed
-        ``INITIALIZING`` session, then compare-and-set it to ``ACTIVE``.
+        ``INITIALIZING`` session, then mark it ``ACTIVE`` (a no-op if the
+        session already moved on).
 
         All database reads happen up front; the workspace setup and OpenCode
         prewarm run with no open transaction. On failure the session is

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -240,7 +240,7 @@ class SessionManager:
         """Mint and persist the OpenCode session before the first prompt.
 
         The caller owns the surrounding transaction. This keeps the empty Craft
-        session's runtime ID and acknowledged skills attempt_number aligned.
+        session's runtime ID and acknowledged skills generation aligned.
         """
         opencode_session_id = self._sandbox_manager.ensure_opencode_session(
             sandbox_id=sandbox.id,
@@ -445,7 +445,7 @@ class SessionManager:
         - No sandbox row: creates one and provisions it.
         - ``RUNNING`` + pod healthy: returns as-is.
         - ``RUNNING`` + pod missing/unhealthy: terminates and re-provisions
-          under a new attempt_number.
+          under a new attempt number.
         - ``SLEEPING`` / ``TERMINATED`` / ``FAILED``: re-provisions in place.
         - ``PROVISIONING``: a stale attempt is taken over; a live one is
           polled up to ``provisioning_wait_seconds`` (default 30s). Raises
@@ -715,7 +715,18 @@ class SessionManager:
                 mcp_config_hash=sandbox_mcp_config_hash,
             )
             if not finalized:
+                # Another initializer got there first. If it converged on
+                # ACTIVE the session is healthy — this attempt's work was
+                # redundant, not wrong.
                 self._db_session.rollback()
+                self._db_session.refresh(session)
+                if session.status == BuildSessionStatus.ACTIVE:
+                    logger.info(
+                        "Session %s was finalized ACTIVE by a concurrent "
+                        "initializer; converged",
+                        session_id,
+                    )
+                    return
                 raise StaleProvisioningAttemptError(
                     f"Session {session_id} left INITIALIZING before this "
                     f"attempt finalized"

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -715,18 +715,7 @@ class SessionManager:
                 mcp_config_hash=sandbox_mcp_config_hash,
             )
             if not finalized:
-                # Another initializer got there first. If it converged on
-                # ACTIVE the session is healthy — this attempt's work was
-                # redundant, not wrong.
                 self._db_session.rollback()
-                self._db_session.refresh(session)
-                if session.status == BuildSessionStatus.ACTIVE:
-                    logger.info(
-                        "Session %s was finalized ACTIVE by a concurrent "
-                        "initializer; converged",
-                        session_id,
-                    )
-                    return
                 raise StaleProvisioningAttemptError(
                     f"Session {session_id} left INITIALIZING before this "
                     f"attempt finalized"

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -24,7 +24,7 @@ from sqlalchemy.orm import Session as DBSession
 
 from onyx.cache.factory import get_cache_backend
 from onyx.configs.app_configs import WEB_DOMAIN
-from onyx.db.enums import SandboxStatus, SessionOrigin
+from onyx.db.enums import BuildSessionStatus, SandboxStatus, SessionOrigin
 from onyx.db.external_app import get_connectable_apps_for_user
 from onyx.db.llm import fetch_all_accessible_llm_providers
 from onyx.db.models import BuildMessage, BuildSession, Sandbox, User
@@ -39,13 +39,15 @@ from onyx.server.features.build.configs import (
     PROMPT_SLOT_KEEP_ALIVE_MAX_SECONDS,
 )
 from onyx.server.features.build.db.build_session import (
-    allocate_nextjs_port,
     create_build_session__no_commit,
     delete_build_session__no_commit,
+    finalize_session_initialization__no_commit,
     get_build_session,
     get_empty_session_for_user,
     get_session_messages,
     get_user_build_sessions,
+    mark_session_initializing__no_commit,
+    reserve_nextjs_port__no_commit,
     session_runtime_stale,
     update_session_activity,
 )
@@ -79,6 +81,7 @@ from onyx.server.features.build.sandbox.util.opencode_config import (
 from onyx.server.features.build.session import streaming as _streaming
 from onyx.server.features.build.session.errors import (
     RateLimitError,
+    StaleProvisioningAttemptError,
     UploadLimitExceededError,
 )
 from onyx.server.features.build.session.interrupt_signal import request_interrupt
@@ -92,10 +95,10 @@ from onyx.server.features.build.session.naming import generate_session_name
 from onyx.server.features.build.session.sandbox_lifecycle import (
     ProvisioningPolicy,
     ensure_sandbox_ready,
-    hydrate_managed_content,
+    sync_managed_content,
 )
 from onyx.server.features.build.session.streaming import BuildStreamingState
-from onyx.skills.push import build_user_skills_payload
+from onyx.server.metrics.craft_sandbox import SandboxReadyOutcome
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import start_thread_with_context
 from shared_configs.configs import MULTI_TENANT
@@ -432,19 +435,16 @@ class SessionManager:
         """Ensure the user has a RUNNING sandbox, creating/waking as needed.
 
         Headless entry point for flows (e.g. scheduled tasks) that need the
-        sandbox up but aren't going through ``create_session__no_commit``.
-        Mirrors the sandbox-handling section of ``create_session__no_commit``
-        but without creating a session record. Falls back to the system
-        default LLM config since there is no user cookie context.
+        sandbox up but aren't going through ``create_session``.
 
         Behavior by current sandbox status:
         - No sandbox row: creates one and provisions it.
         - ``RUNNING`` + pod healthy: returns as-is.
-        - ``RUNNING`` + pod missing/unhealthy: terminates and re-provisions.
+        - ``RUNNING`` + pod missing/unhealthy: terminates and re-provisions
+          under a new generation.
         - ``SLEEPING`` / ``TERMINATED`` / ``FAILED``: re-provisions in place.
-        - ``PROVISIONING``: polls up to ``provisioning_wait_seconds`` (default
-          30s) for the concurrent provisioner to finish, then continues
-          based on the resulting status. Raises
+        - ``PROVISIONING``: a stale attempt is taken over; a live one is
+          polled up to ``provisioning_wait_seconds`` (default 30s). Raises
           ``SandboxProvisioningError`` only if the timeout elapses without
           a transition.
 
@@ -452,40 +452,54 @@ class SessionManager:
         any path that newly counts toward the running limit (creating a new
         sandbox or waking a SLEEPING / TERMINATED / FAILED one).
 
-        Caller is responsible for committing.
+        Commits its own short transactions; the database session must be at a
+        clean transaction boundary.
 
         Raises:
-            SandboxProvisioningError: Sandbox was still PROVISIONING after
-                the wait timeout elapsed.
+            SandboxProvisioningError: Provisioning failed, or the sandbox was
+                still PROVISIONING after the wait timeout elapsed.
             ValueError: Max concurrent sandboxes reached, or user missing.
-            RuntimeError: Sandbox manager failed to provision the pod.
         """
-        user = fetch_user_by_id(self._db_session, user_id)
-        if user is None:
-            raise ValueError(f"User {user_id} not found")
-        sandbox = ensure_sandbox_ready(
+        sandbox, _outcome = ensure_sandbox_ready(
             self._db_session,
             self._sandbox_manager,
             user_id,
             policy=ProvisioningPolicy.POLL,
             provisioning_wait_seconds=provisioning_wait_seconds,
-            user=user,
         )
         return sandbox
 
-    def create_session__no_commit(
+    def _ready_sandbox(self, user: User) -> tuple[Sandbox, SandboxReadyOutcome]:
+        """Ensure the user's sandbox is RUNNING with current managed content.
+
+        Fresh provisioning pushes managed content itself; a reused pod may be
+        missing content pushed since it last synced.
+        """
+        sandbox, outcome = ensure_sandbox_ready(
+            self._db_session,
+            self._sandbox_manager,
+            user.id,
+            policy=ProvisioningPolicy.FAIL,
+        )
+        if outcome == SandboxReadyOutcome.ALREADY_RUNNING:
+            sync_managed_content(
+                self._db_session, self._sandbox_manager, sandbox.id, user
+            )
+        return sandbox, outcome
+
+    def create_session(
         self,
         user_id: UUID,
         name: str | None = None,
         origin: SessionOrigin = SessionOrigin.INTERACTIVE,
-        headless: bool = False,
     ) -> BuildSession:
-        """
-        Create a new build session with a sandbox.
+        """Create a new build session with a ready sandbox.
 
-        NOTE: This method does NOT commit the transaction. The caller is
-        responsible for committing after this method returns successfully.
-        This allows the entire operation to be atomic at the endpoint level.
+        Reserve → reconcile → finalize: the session identity is committed as
+        ``INITIALIZING`` (with its port reservation) before any workspace
+        work, then flipped to ``ACTIVE`` only once the workspace and OpenCode
+        session are usable. Failed initialization leaves a durable ``FAILED``
+        row that a retry repairs under the same session ID.
 
         Args:
             user_id: The user ID
@@ -494,32 +508,26 @@ class SessionManager:
                 appear in the Craft sidebar; SCHEDULED (scheduled-tasks
                 executor) and SLACK (Slack bot) sessions are excluded.
 
-        Returns:
-            The created BuildSession model
-
         Raises:
-            ValueError: If max concurrent sandboxes reached or no LLM provider
-            RuntimeError: If sandbox provisioning fails
+            ValueError: If max concurrent sandboxes reached or user missing
+            OnyxError: If no LLM provider is accessible
+            SandboxProvisioningError: If sandbox provisioning fails
+            RuntimeError: If session initialization fails
         """
-        # Fetch user early — needed for provider access checks, PAT, AGENTS.md.
         user = fetch_user_by_id(self._db_session, user_id)
         if not user:
             raise ValueError(f"User {user_id} not found")
 
+        # Validate the model configuration before any reservation or
+        # external work; the commit closes the read transaction so
+        # ``ensure_sandbox_ready`` starts at a clean boundary.
         llm_config = self.build_llm_configs(user)
+        self._db_session.commit()
 
-        # Allocate port for this session (per-session port allocation).
-        # Both LOCAL and KUBERNETES backends use the same port allocation
-        # strategy. Skipped for non-interactive origins (SCHEDULED, SLACK):
-        # those sessions are headless, never attach a preview, and pile up
-        # fast enough to exhaust the [3010, 3100) range on a busy tenant.
-        nextjs_port: int | None
-        if origin != SessionOrigin.INTERACTIVE or headless:
-            nextjs_port = None
-        else:
-            nextjs_port = allocate_nextjs_port(self._db_session)
+        sandbox, _outcome = self._ready_sandbox(user)
 
-        # Create BuildSession record with allocated port (uses flush, caller commits)
+        # Reservation: commit the INITIALIZING identity and port before the
+        # workspace exists.
         build_session = create_build_session__no_commit(
             user_id,
             self._db_session,
@@ -528,62 +536,21 @@ class SessionManager:
             agent_provider=llm_config.provider,
             agent_model=llm_config.model_name,
         )
-        build_session.nextjs_port = nextjs_port
-        self._db_session.flush()
-        session_id = str(build_session.id)
+        # Port allocation is skipped for non-interactive origins (SCHEDULED,
+        # SLACK): those sessions are headless, never attach a preview, and
+        # pile up fast enough to exhaust the [3010, 3100) range on a busy
+        # tenant.
+        if origin == SessionOrigin.INTERACTIVE:
+            reserve_nextjs_port__no_commit(self._db_session, build_session)
+        self._db_session.commit()
         logger.info(
-            "Created build session %s for user %s (port: %s)",
-            session_id,
+            "Reserved build session %s for user %s (port: %s)",
+            build_session.id,
             user_id,
-            nextjs_port,
+            build_session.nextjs_port,
         )
 
-        # Ensure the user's sandbox is RUNNING. Interactive callers can't
-        # afford to wait through a concurrent provisioner, so we use the
-        # FAIL policy (raise RuntimeError if another request is mid-
-        # provision).
-        sandbox = ensure_sandbox_ready(
-            self._db_session,
-            self._sandbox_manager,
-            user_id,
-            policy=ProvisioningPolicy.FAIL,
-            user=user,
-        )
-
-        # Set up session workspace within the sandbox
-        logger.info(
-            "Setting up session workspace %s in sandbox %s", session_id, sandbox.id
-        )
-        user_name = user.personal_name
-
-        connectable_apps_section, skills_files = build_user_skills_payload(
-            user, self._db_session
-        )
-        hydrate_managed_content(
-            self._sandbox_manager,
-            sandbox.id,
-            user,
-            self._db_session,
-            connectable_apps_section=connectable_apps_section,
-            skills_files=skills_files,
-        )
-        self._sandbox_manager.setup_session_workspace(
-            sandbox_id=sandbox.id,
-            session_id=build_session.id,
-            llm_config=llm_config,
-            nextjs_port=nextjs_port,
-            connectable_apps_section=connectable_apps_section,
-            user_name=user_name,
-            mcp_servers=resolve_craft_mcp_servers(self._db_session, user),
-        )
-        self._prewarm_opencode_session(sandbox, build_session)
-
-        logger.info(
-            "Successfully created session %s with workspace in sandbox %s",
-            session_id,
-            sandbox.id,
-        )
-
+        self._reconcile_session(sandbox, build_session, user, llm_config)
         return build_session
 
     def get_or_create_empty_session(
@@ -591,86 +558,195 @@ class SessionManager:
         user_id: UUID,
         headless: bool = False,
     ) -> BuildSession:
-        """Get existing empty session or create a new one with provisioned sandbox.
+        """Get or create the user's empty (pre-provisioned) session.
 
-        Used for pre-provisioning sandboxes when user lands on /build/v1.
-        Returns existing recent empty session if one exists and has a healthy sandbox.
-        If an empty session exists but its sandbox is unhealthy/terminated/missing,
-        the stale session is deleted and a fresh one is created (which will handle
-        sandbox recovery/re-provisioning).
-
-        Args:
-            user_id: The user ID
-        Returns:
-            BuildSession (existing empty or newly created)
+        Used for pre-provisioning sandboxes when the user lands on /build/v1.
+        The empty-session identity is reserved (or reused) under the per-user
+        row lock, so concurrent pre-provisioners converge on one committed
+        session. An existing session with an intact workspace is reused;
+        otherwise it is repaired in place — returned to ``INITIALIZING`` and
+        its workspace rebuilt under the same committed session ID (never
+        deleted and replaced).
 
         Raises:
-            ValueError: If max concurrent sandboxes reached
-            RuntimeError: If sandbox provisioning fails
+            ValueError: If max concurrent sandboxes reached or user missing
+            OnyxError: If no LLM provider is accessible
+            SandboxProvisioningError: If sandbox provisioning fails
+            RuntimeError: If session initialization fails
         """
-        existing = get_empty_session_for_user(user_id, self._db_session)
-        if existing:
-            logger.info(
-                "Existing empty session %s found for user %s", existing.id, user_id
-            )
-            # Verify sandbox is healthy before returning existing session
-            sandbox = get_sandbox_by_user_id(self._db_session, user_id)
+        user = fetch_user_by_id(self._db_session, user_id)
+        if not user:
+            raise ValueError(f"User {user_id} not found")
 
-            if sandbox and sandbox.status.is_active():
-                # Quick health check to verify sandbox is actually responsive
-                # AND verify the session workspace still exists on disk
-                # (it may have been wiped if the sandbox was re-provisioned)
-                is_healthy = self._sandbox_manager.health_check(sandbox.id, timeout=5.0)
-                workspace_exists = (
-                    is_healthy
-                    and self._sandbox_manager.session_workspace_exists(
-                        sandbox.id, existing.id
-                    )
+        # Reservation: the user-row lock serializes concurrent
+        # pre-provisioners so exactly one empty-session identity exists.
+        locked_user = fetch_user_by_id(self._db_session, user_id, for_update=True)
+        if locked_user is None:
+            raise ValueError(f"User {user_id} not found")
+        existing = get_empty_session_for_user(user_id, self._db_session)
+
+        if existing is None:
+            # Validates the model configuration before any external work.
+            llm_config = self.build_llm_configs(user)
+            session = create_build_session__no_commit(
+                user_id,
+                self._db_session,
+                agent_provider=llm_config.provider,
+                agent_model=llm_config.model_name,
+            )
+            if not headless:
+                reserve_nextjs_port__no_commit(self._db_session, session)
+            self._db_session.commit()
+            logger.info("Reserved empty session %s for user %s", session.id, user_id)
+            sandbox, _outcome = self._ready_sandbox(user)
+            self._reconcile_session(sandbox, session, user, llm_config)
+            return session
+
+        session = existing
+        self._db_session.commit()
+        logger.info(
+            "Found existing empty session %s (status=%s) for user %s",
+            session.id,
+            session.status.value,
+            user_id,
+        )
+
+        sandbox, outcome = self._ready_sandbox(user)
+        workspace_intact = self._sandbox_manager.session_workspace_exists(
+            sandbox.id, session.id
+        )
+        if (
+            session.status == BuildSessionStatus.ACTIVE
+            and outcome == SandboxReadyOutcome.ALREADY_RUNNING
+            and workspace_intact
+        ):
+            # Light path: everything is already in place; refresh the
+            # session runtime and hand the session back.
+            self.reconcile_session_llm_config(sandbox, session, user)
+            self._prewarm_opencode_session(sandbox, session)
+            self._db_session.commit()
+            logger.info(
+                "Returning existing empty session %s for user %s",
+                session.id,
+                user_id,
+            )
+            return session
+
+        # Repair: return the committed session ID to INITIALIZING and
+        # rebuild its workspace, honoring its persisted model selection.
+        logger.info(
+            "Repairing empty session %s for user %s (status=%s, workspace %s)",
+            session.id,
+            user_id,
+            session.status.value,
+            "intact" if workspace_intact else "missing",
+        )
+        llm_config = self.session_llm_config(session, user)
+        mark_session_initializing__no_commit(self._db_session, session)
+        if session.nextjs_port is None and not headless:
+            reserve_nextjs_port__no_commit(self._db_session, session)
+        self._db_session.commit()
+
+        self._reconcile_session(sandbox, session, user, llm_config)
+        return session
+
+    def _reconcile_session(
+        self,
+        sandbox: Sandbox,
+        session: BuildSession,
+        user: User,
+        llm_config: CraftLLMProviderConfig,
+    ) -> None:
+        """Build the workspace and OpenCode session for a committed
+        ``INITIALIZING`` session, then compare-and-set it to ``ACTIVE``.
+
+        All database reads happen up front; the workspace setup and OpenCode
+        prewarm run with no open transaction. On failure the session is
+        durably marked ``FAILED`` (the sandbox stays ``RUNNING``) and the
+        error is re-raised; a later request repairs the same session ID.
+        """
+        session_id = session.id
+        try:
+            connectable_apps_section = build_connectable_apps_list(
+                get_connectable_apps_for_user(self._db_session, user)
+            )
+            mcp_servers = resolve_craft_mcp_servers(self._db_session, user)
+            nextjs_port = session.nextjs_port
+            opencode_session_id = session.opencode_session_id
+            user_name = user.personal_name
+            sandbox_skills_hash = sandbox.skills_hash
+            sandbox_mcp_config_hash = sandbox.mcp_config_hash
+            self._db_session.commit()
+
+            logger.info(
+                "Setting up session workspace %s in sandbox %s",
+                session_id,
+                sandbox.id,
+            )
+            self._sandbox_manager.setup_session_workspace(
+                sandbox_id=sandbox.id,
+                session_id=session_id,
+                llm_config=llm_config,
+                nextjs_port=nextjs_port,
+                connectable_apps_section=connectable_apps_section,
+                user_name=user_name,
+                mcp_servers=mcp_servers,
+            )
+            minted_opencode_session_id = self._sandbox_manager.ensure_opencode_session(
+                sandbox_id=sandbox.id,
+                session_id=session_id,
+                opencode_session_id=opencode_session_id,
+            )
+            if minted_opencode_session_id is None:
+                raise RuntimeError(
+                    f"Failed to prewarm opencode session for build session {session_id}"
                 )
-                if is_healthy and workspace_exists:
-                    user = fetch_user_by_id(self._db_session, user_id)
-                    if user is None:
-                        logger.warning("Cannot push skills: user %s not found", user_id)
-                    else:
-                        hydrate_managed_content(
-                            self._sandbox_manager, sandbox.id, user, self._db_session
-                        )
-                        self.reconcile_session_llm_config(sandbox, existing, user)
-                    self._prewarm_opencode_session(sandbox, existing)
-                    logger.info(
-                        "Returning existing empty session %s for user %s",
-                        existing.id,
-                        user_id,
-                    )
-                    return existing
-                elif not is_healthy:
-                    logger.warning(
-                        "Empty session %s has unhealthy sandbox %s. Deleting and creating fresh session.",
-                        existing.id,
-                        sandbox.id,
+
+            finalized = finalize_session_initialization__no_commit(
+                self._db_session,
+                session_id,
+                BuildSessionStatus.ACTIVE,
+                opencode_session_id=minted_opencode_session_id,
+                skills_hash=sandbox_skills_hash,
+                mcp_config_hash=sandbox_mcp_config_hash,
+            )
+            if not finalized:
+                self._db_session.rollback()
+                raise StaleProvisioningAttemptError(
+                    f"Session {session_id} left INITIALIZING before this "
+                    f"attempt finalized"
+                )
+            self._db_session.commit()
+            self._db_session.refresh(session)
+            logger.info(
+                "Successfully created session %s with workspace in sandbox %s",
+                session_id,
+                sandbox.id,
+            )
+        except StaleProvisioningAttemptError:
+            raise
+        except BaseException as e:
+            self._db_session.rollback()
+            try:
+                if finalize_session_initialization__no_commit(
+                    self._db_session, session_id, BuildSessionStatus.FAILED
+                ):
+                    self._db_session.commit()
+                    logger.error(
+                        "Session %s initialization failed; marked FAILED "
+                        "for repair on retry: %s",
+                        session_id,
+                        e,
                     )
                 else:
-                    logger.warning(
-                        "Empty session %s workspace missing in sandbox %s. Deleting and creating fresh session.",
-                        existing.id,
-                        sandbox.id,
-                    )
-            else:
-                logger.warning(
-                    "Empty session %s has no active sandbox (sandbox=%s). Deleting and creating fresh session.",
-                    existing.id,
-                    "missing" if not sandbox else sandbox.status,
+                    self._db_session.rollback()
+            except Exception:
+                self._db_session.rollback()
+                logger.exception(
+                    "Failed to record initialization failure for session %s",
+                    session_id,
                 )
-
-            # Delete through the normal session path. Opencode history is
-            # sandbox-global implementation data, so this removes the Onyx
-            # session row without trying to prune opencode's internal store.
-            self.delete_session(existing.id, user_id)
-
-        return self.create_session__no_commit(
-            user_id=user_id,
-            headless=headless,
-        )
+            raise
 
     def get_session(
         self,

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -36,7 +36,6 @@ from onyx.server.features.build.configs import (
     MAX_TOTAL_UPLOAD_SIZE_BYTES,
     MAX_UPLOAD_FILES_PER_SESSION,
     OPENCODE_DISABLED_TOOLS,
-    PROMPT_SLOT_KEEP_ALIVE_MAX_SECONDS,
 )
 from onyx.server.features.build.db.build_session import (
     create_build_session__no_commit,
@@ -64,10 +63,7 @@ from onyx.server.features.build.sandbox.models import (
     FilesystemEntry,
     PromptAttachment,
 )
-from onyx.server.features.build.sandbox.serve_transport import (
-    PROMPT_SLOT_FAST_FAIL_ACQUIRE_SECONDS,
-    PromptSlot,
-)
+from onyx.server.features.build.sandbox.serve_transport import PromptSlot
 from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
 from onyx.server.features.build.sandbox.util.agent_instructions import (
     build_connectable_apps_list,
@@ -98,6 +94,11 @@ from onyx.server.features.build.session.sandbox_lifecycle import (
     sync_managed_content,
 )
 from onyx.server.features.build.session.streaming import BuildStreamingState
+from onyx.server.features.build.timeouts import (
+    PROMPT_SLOT_FAST_FAIL_ACQUIRE_SECONDS,
+    PROMPT_SLOT_KEEP_ALIVE_MAX_SECONDS,
+    PROVISION_WAIT_SECONDS,
+)
 from onyx.server.metrics.craft_sandbox import SandboxReadyOutcome
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import start_thread_with_context
@@ -107,6 +108,9 @@ from shared_configs.contextvars import get_current_tenant_id
 logger = setup_logger()
 
 _DISPOSE_PENDING_TTL_SECONDS = 24 * 3600
+
+# Webapp-ready probe on the UI-poll hot path; any response (even 404) counts.
+_WEBAPP_PROBE_TIMEOUT_SECONDS = 2.0
 
 
 # Hidden directories/files to filter from listings
@@ -430,7 +434,7 @@ class SessionManager:
         self,
         user_id: UUID,
         *,
-        provisioning_wait_seconds: float = 30.0,
+        provisioning_wait_seconds: float = PROVISION_WAIT_SECONDS,
     ) -> Sandbox:
         """Ensure the user has a RUNNING sandbox, creating/waking as needed.
 
@@ -518,9 +522,8 @@ class SessionManager:
         if not user:
             raise ValueError(f"User {user_id} not found")
 
-        # Validate the model configuration before any reservation or
-        # external work; the commit closes the read transaction so
-        # ``ensure_sandbox_ready`` starts at a clean boundary.
+        # Validate the model config before any reservation or external work;
+        # the commit leaves the clean boundary ensure_sandbox_ready requires.
         llm_config = self.build_llm_configs(user)
         self._db_session.commit()
 
@@ -725,7 +728,7 @@ class SessionManager:
             )
         except StaleProvisioningAttemptError:
             raise
-        except BaseException as e:
+        except Exception as e:
             self._db_session.rollback()
             try:
                 if finalize_session_initialization__no_commit(
@@ -1507,7 +1510,7 @@ class SessionManager:
                 f"{internal_url}/api/build/sessions/{session_id}/webapp"
                 "/_next/static/onyx-ready-probe.js"
             )
-            with httpx.Client(timeout=2.0) as client:
+            with httpx.Client(timeout=_WEBAPP_PROBE_TIMEOUT_SECONDS) as client:
                 client.get(probe_url)
             return True
         except Exception:

--- a/backend/onyx/server/features/build/session/naming.py
+++ b/backend/onyx/server/features/build/session/naming.py
@@ -1,4 +1,4 @@
-"""Auto-generation of human-readable build-session names.
+"""Auto-attempt_number of human-readable build-session names.
 
 Given a session, pull its first user message and ask the default LLM to
 condense it into a short label. Falls back to a deterministic

--- a/backend/onyx/server/features/build/session/naming.py
+++ b/backend/onyx/server/features/build/session/naming.py
@@ -1,4 +1,4 @@
-"""Auto-attempt_number of human-readable build-session names.
+"""Auto-generation of human-readable build-session names.
 
 Given a session, pull its first user message and ask the default LLM to
 condense it into a short label. Falls back to a deterministic

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -591,14 +591,7 @@ def reconcile_sandbox(
             snapshot_opencode_history_before_recovery(
                 sandbox_manager, sandbox_id, tenant_id
             )
-            sandbox_manager.terminate(sandbox_id, max_attempt_number=attempt_number)
-        except SandboxProvisionContentionError as e:
-            db_session.rollback()
-            _record_provisioning_failure(db_session, sandbox_id, attempt_number, e)
-            raise SandboxProvisioningInProgressError(
-                f"Sandbox {sandbox_id} runtime is owned by a concurrent "
-                f"provisioner; retry"
-            ) from e
+            sandbox_manager.terminate(sandbox_id)
         except Exception as e:
             db_session.rollback()
             _record_provisioning_failure(db_session, sandbox_id, attempt_number, e)
@@ -608,7 +601,7 @@ def reconcile_sandbox(
 
     if reservation.terminate_before_provision:
         try:
-            sandbox_manager.terminate(sandbox_id, max_attempt_number=attempt_number)
+            sandbox_manager.terminate(sandbox_id)
         except Exception:
             logger.warning(
                 "Best-effort terminate of stale runtime for sandbox %s before "
@@ -981,10 +974,12 @@ def sleep_sandbox(
             return
         sleep_attempt_number = sandbox.provisioning_attempt_number
 
-        # Claim SLEEPING durably BEFORE destroying anything: once this commits,
-        # no other flow believes the runtime is theirs, so the kill below can
-        # never race a claim. The reverse order could destroy a runtime a
-        # concurrent recovery had just claimed.
+        # Terminate the pod (but keep the sandbox record).
+        sandbox_manager.terminate(sandbox_id)
+
+        # A recovery/create that started a newer attempt mid-terminate owns
+        # the sandbox now; only claim ports/sessions if the sleep write
+        # applies.
         if not sleep_running_sandbox__no_commit(
             db_session, sandbox_id, sleep_attempt_number
         ):
@@ -1005,30 +1000,6 @@ def sleep_sandbox(
         logger.debug("Marked %s sessions as IDLE for user %s", idled, sandbox.user_id)
 
         db_session.commit()
-
-        # Destroy the runtime (the sandbox record stays, as SLEEPING). The
-        # attempt bound plus the provisioning lock inside terminate() mean a
-        # wake that starts right after the commit either reuses the live pod
-        # first (terminate then skips) or provisions fresh after the deletion.
-        # A failed kill leaves an orphan runtime the next wake reuses or
-        # replaces — a leak is recoverable, a killed live runtime is not.
-        try:
-            sandbox_manager.terminate(
-                sandbox_id, max_attempt_number=sleep_attempt_number
-            )
-        except SandboxProvisionContentionError:
-            logger.info(
-                "Sandbox %s runtime is being provisioned by a concurrent flow; "
-                "leaving it to that owner",
-                sandbox_id,
-            )
-        except Exception:
-            logger.warning(
-                "Failed to terminate runtime of sleeping sandbox %s; the next "
-                "wake reuses or replaces it",
-                sandbox_id,
-                exc_info=True,
-            )
         logger.info("Sandbox %s is now sleeping", sandbox_id)
     finally:
         if session_creation_lock.owned():

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -499,6 +499,7 @@ def reconcile_sandbox(
     sandbox_id = reservation.sandbox_id
     tenant_id = reservation.tenant_id
     generation = reservation.generation
+    onyx_pat = reservation.onyx_pat
     outcome = (
         (
             SandboxReadyOutcome.REVIVED
@@ -522,10 +523,9 @@ def reconcile_sandbox(
             "Sandbox %s marked RUNNING but pod is unhealthy/missing; recovering.",
             sandbox_id,
         )
-        snapshot_opencode_history_before_recovery(
-            sandbox_manager, sandbox_id, tenant_id
-        )
-        sandbox_manager.terminate(sandbox_id)
+        # Claim the recovery generation BEFORE any destructive external work:
+        # a racing recoverer that loses this CAS must never terminate a
+        # runtime the winner is already rebuilding.
         new_generation = begin_recovery_attempt_cas__no_commit(
             db_session, sandbox_id, generation
         )
@@ -540,6 +540,27 @@ def reconcile_sandbox(
         generation = new_generation
         outcome = SandboxReadyOutcome.RECOVERED
 
+        try:
+            # A RUNNING reservation skips the PAT read; the re-provision below
+            # requires one.
+            sandbox = get_sandbox_by_id(db_session, sandbox_id)
+            if sandbox is None:
+                raise RuntimeError(f"Sandbox {sandbox_id} disappeared during recovery")
+            with time_provision_phase(SandboxProvisionPhase.ENSURE_PAT):
+                onyx_pat = ensure_sandbox_pat(db_session, sandbox, user)
+            db_session.commit()
+
+            snapshot_opencode_history_before_recovery(
+                sandbox_manager, sandbox_id, tenant_id
+            )
+            sandbox_manager.terminate(sandbox_id)
+        except Exception as e:
+            db_session.rollback()
+            _record_provisioning_failure(db_session, sandbox_id, generation, e)
+            raise SandboxProvisioningError(
+                f"Sandbox {sandbox_id} recovery failed: {e}"
+            ) from e
+
     # External provisioning against the committed identity. provision()
     # returns only once the sandbox is RUNNING; anything else raises.
     try:
@@ -548,7 +569,7 @@ def reconcile_sandbox(
                 sandbox_id=sandbox_id,
                 user_id=user.id,
                 tenant_id=tenant_id,
-                onyx_pat=reservation.onyx_pat,
+                onyx_pat=onyx_pat,
                 provisioning_generation=generation,
             )
     except Exception as e:
@@ -558,24 +579,35 @@ def reconcile_sandbox(
         ) from e
 
     # Managed content must land before the row reports RUNNING (turns
-    # dispatch the moment RUNNING is visible).
-    payload = build_managed_content_payload(user, db_session)
-    db_session.commit()
-    skills_hydrated = push_managed_content(sandbox_manager, sandbox_id, payload)
+    # dispatch the moment RUNNING is visible). Any failure here must still
+    # finalize the attempt as FAILED — the row cannot be left PROVISIONING
+    # until the stale-attempt threshold.
+    try:
+        payload = build_managed_content_payload(user, db_session)
+        db_session.commit()
+        skills_hydrated = push_managed_content(sandbox_manager, sandbox_id, payload)
 
-    finalized = finalize_provisioning_attempt__no_commit(
-        db_session, sandbox_id, generation, SandboxStatus.RUNNING
-    )
-    if not finalized:
-        db_session.rollback()
-        raise StaleProvisioningAttemptError(
-            f"Sandbox {sandbox_id} generation {generation} was superseded "
-            f"before finalization"
+        finalized = finalize_provisioning_attempt__no_commit(
+            db_session, sandbox_id, generation, SandboxStatus.RUNNING
         )
-    record_managed_content_hashes__no_commit(
-        db_session, sandbox_id, payload, skills_hydrated
-    )
-    db_session.commit()
+        if not finalized:
+            db_session.rollback()
+            raise StaleProvisioningAttemptError(
+                f"Sandbox {sandbox_id} generation {generation} was superseded "
+                f"before finalization"
+            )
+        record_managed_content_hashes__no_commit(
+            db_session, sandbox_id, payload, skills_hydrated
+        )
+        db_session.commit()
+    except StaleProvisioningAttemptError:
+        raise
+    except Exception as e:
+        db_session.rollback()
+        _record_provisioning_failure(db_session, sandbox_id, generation, e)
+        raise SandboxProvisioningError(
+            f"Sandbox {sandbox_id} provisioning failed: {e}"
+        ) from e
 
     return _get_sandbox_committed(db_session, sandbox_id), outcome
 

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -1,21 +1,24 @@
 """Sandbox readiness state machine: durable reservation, external
-reconciliation, and generation-fenced finalization. Shared between the
-interactive create/restore flows and headless callers
+reconciliation, and finalization that only the newest attempt can perform.
+Shared between the interactive create/restore flows and headless callers
 (``ensure_sandbox_running``).
+
+Every provisioning attempt gets a fresh number (``provisioning_attempt_number``),
+and every status write is conditional on the row still holding that number —
+so a superseded attempt's writes are no-ops, no matter when they land.
 
 The lifecycle is split into three parts so no database transaction ever spans
 external I/O:
 
 1. **Reserve** (short transaction): lock the user row, commit the sandbox
-   identity in ``PROVISIONING`` with an advanced fencing generation, and
-   commit the Craft PAT. Once committed, the proxy can resolve the pod's
-   owner and credentials from any connection — a bootstrapping pod's egress
-   works before the sandbox is ``RUNNING``.
+   identity in ``PROVISIONING`` under a new attempt number, and commit the
+   Craft PAT. Once committed, the proxy can resolve the pod's owner and
+   credentials from any connection — a bootstrapping pod's egress works
+   before the sandbox is ``RUNNING``.
 2. **Reconcile** (no transaction): create/reuse the pod and its resources
    idempotently, push sandbox-level managed content.
-3. **Finalize** (short transaction): generation-guarded compare-and-set to
-   ``RUNNING`` or ``FAILED``. A stale attempt cannot overwrite a newer
-   decision.
+3. **Finalize** (short transaction): record ``RUNNING`` or ``FAILED``, but
+   only if this is still the newest attempt.
 """
 
 import time
@@ -125,9 +128,9 @@ class SandboxReservation:
 
     sandbox_id: UUID
     tenant_id: str
-    generation: int
+    attempt_number: int
     # Set only when this reservation authorized external provisioning (the
-    # row is committed PROVISIONING at `generation`); None when the sandbox
+    # row is committed PROVISIONING at `attempt_number`); None when the sandbox
     # was already RUNNING and only needs a health check.
     onyx_pat: str | None
     requires_provisioning: bool
@@ -334,8 +337,8 @@ def _provisioning_attempt_is_stale(sandbox: Sandbox) -> bool:
     self-aborts at ``ATTEMPT_DEADLINE_SECONDS``, so past that age the attempt
     is dead or in its final in-flight phase. Rows without a start timestamp
     predate the attempt tracking and are always stale. Correctness never
-    depends on this — finalization is fenced by the generation
-    compare-and-set."""
+    depends on this — a dead attempt's writes are already no-ops (they carry
+    an old attempt number)."""
     if sandbox.provisioning_started_at is None:
         return True
     age = datetime.now(timezone.utc) - sandbox.provisioning_started_at
@@ -358,8 +361,8 @@ def reserve_sandbox__no_commit(
     db_session: DBSession,
     user: User,
 ) -> SandboxReservation:
-    """Reserve the user's sandbox for use, advancing the provisioning
-    generation when external reconciliation is required.
+    """Reserve the user's sandbox for use, starting a new numbered attempt
+    when external reconciliation is required.
 
     Must be called with the user's row locked (``fetch_user_by_id(for_update=True)``)
     in the current transaction so concurrent reservers serialize. ``flush``
@@ -378,16 +381,16 @@ def reserve_sandbox__no_commit(
     if sandbox is None:
         _enforce_tenant_concurrency_limit(db_session)
         sandbox = create_sandbox__no_commit(db_session=db_session, user_id=user.id)
-        generation = begin_provisioning_attempt__no_commit(db_session, sandbox)
+        attempt_number = begin_provisioning_attempt__no_commit(db_session, sandbox)
         requires_provisioning = True
         logger.info(
-            "Created sandbox %s for user %s (generation %s)",
+            "Created sandbox %s for user %s (attempt %s)",
             sandbox.id,
             user.id,
-            generation,
+            attempt_number,
         )
     elif sandbox.status == SandboxStatus.RUNNING:
-        generation = sandbox.provisioning_generation
+        attempt_number = sandbox.provisioning_attempt_number
         requires_provisioning = False
     elif sandbox.status in _REPROVISIONABLE_STATUSES:
         _enforce_tenant_concurrency_limit(db_session)
@@ -395,30 +398,30 @@ def reserve_sandbox__no_commit(
         # Only FAILED may have a leftover pod; SLEEPING/TERMINATED were
         # terminated on entry.
         terminate_before_provision = previous_status == SandboxStatus.FAILED
-        generation = begin_provisioning_attempt__no_commit(db_session, sandbox)
+        attempt_number = begin_provisioning_attempt__no_commit(db_session, sandbox)
         requires_provisioning = True
         logger.info(
-            "Reviving sandbox %s (was %s) for user %s (generation %s)",
+            "Reviving sandbox %s (was %s) for user %s (attempt %s)",
             sandbox.id,
             previous_status.value,
             user.id,
-            generation,
+            attempt_number,
         )
     elif sandbox.status == SandboxStatus.PROVISIONING:
         if not _provisioning_attempt_is_stale(sandbox):
             raise SandboxProvisioningInProgressError(
                 f"Sandbox {sandbox.id} is being provisioned by a live attempt "
-                f"(generation {sandbox.provisioning_generation})"
+                f"(attempt {sandbox.provisioning_attempt_number})"
             )
         _enforce_tenant_concurrency_limit(db_session)
         terminate_before_provision = True
-        generation = begin_provisioning_attempt__no_commit(db_session, sandbox)
+        attempt_number = begin_provisioning_attempt__no_commit(db_session, sandbox)
         requires_provisioning = True
         logger.warning(
-            "Taking over stale PROVISIONING sandbox %s for user %s (generation %s)",
+            "Taking over stale PROVISIONING sandbox %s for user %s (attempt %s)",
             sandbox.id,
             user.id,
-            generation,
+            attempt_number,
         )
     else:
         raise RuntimeError(
@@ -435,7 +438,7 @@ def reserve_sandbox__no_commit(
     return SandboxReservation(
         sandbox_id=sandbox.id,
         tenant_id=tenant_id,
-        generation=generation,
+        attempt_number=attempt_number,
         onyx_pat=onyx_pat,
         requires_provisioning=requires_provisioning,
         sandbox_preexisted=sandbox_preexisted,
@@ -446,33 +449,33 @@ def reserve_sandbox__no_commit(
 def _record_provisioning_failure(
     db_session: DBSession,
     sandbox_id: UUID,
-    generation: int,
+    attempt_number: int,
     error: BaseException,
 ) -> None:
-    """Durably mark a failed attempt FAILED (compare-and-set; a stale attempt
-    leaves newer state alone). The diagnostic detail lives in this log line,
-    keyed by sandbox ID + generation — not in the database. Never raises."""
+    """Durably mark a failed attempt FAILED; a no-op if a newer attempt
+    already owns the row. The diagnostic detail lives in this log line, keyed
+    by sandbox ID + attempt number — not in the database. Never raises."""
     try:
         if finalize_provisioning_attempt__no_commit(
             db_session,
             sandbox_id,
-            generation,
+            attempt_number,
             SandboxStatus.FAILED,
         ):
             db_session.commit()
             logger.error(
-                "Sandbox %s provisioning failed (generation %s): %s",
+                "Sandbox %s provisioning failed (attempt %s): %s",
                 sandbox_id,
-                generation,
+                attempt_number,
                 error,
             )
         else:
             db_session.rollback()
             logger.warning(
-                "Sandbox %s provisioning failed but generation %s is "
+                "Sandbox %s provisioning failed but attempt %s is "
                 "stale; leaving newer state untouched",
                 sandbox_id,
-                generation,
+                attempt_number,
             )
     except Exception:
         db_session.rollback()
@@ -494,17 +497,17 @@ def _get_sandbox_committed(db_session: DBSession, sandbox_id: UUID) -> Sandbox:
 
 
 def _check_attempt_deadline(
-    attempt_deadline: float, sandbox_id: UUID, generation: int
+    attempt_deadline: float, sandbox_id: UUID, attempt_number: int
 ) -> None:
     """Self-enforcement of the attempt deadline between external phases: the
     attempt aborts itself (finalizing FAILED via the caller's error handling)
     at the same age observers use to declare it stale. An in-flight phase can
     overrun the check; takeover safety comes from the provisioning lock and
-    the generation compare-and-set, not from this deadline."""
+    the attempt-number condition on status writes, not from this deadline."""
     if time.monotonic() >= attempt_deadline:
         raise TimeoutError(
-            f"Provisioning attempt for sandbox {sandbox_id} (generation "
-            f"{generation}) exceeded its {ATTEMPT_DEADLINE_SECONDS:.0f}s deadline"
+            f"Provisioning attempt for sandbox {sandbox_id} (attempt "
+            f"{attempt_number}) exceeded its {ATTEMPT_DEADLINE_SECONDS:.0f}s deadline"
         )
 
 
@@ -522,7 +525,7 @@ def reconcile_sandbox(
 
     Raises:
         SandboxProvisioningError: provisioning failed (recorded durably).
-        StaleProvisioningAttemptError: a newer generation superseded this
+        StaleProvisioningAttemptError: a newer attempt_number superseded this
             attempt before it could finalize.
         SandboxProvisioningInProgressError: lost a race to a concurrent
             lifecycle decision while recovering, or the provisioning lock is
@@ -530,7 +533,7 @@ def reconcile_sandbox(
     """
     sandbox_id = reservation.sandbox_id
     tenant_id = reservation.tenant_id
-    generation = reservation.generation
+    attempt_number = reservation.attempt_number
     onyx_pat = reservation.onyx_pat
     attempt_deadline = time.monotonic() + ATTEMPT_DEADLINE_SECONDS
     outcome = (
@@ -556,21 +559,21 @@ def reconcile_sandbox(
             "Sandbox %s marked RUNNING but pod is unhealthy/missing; recovering.",
             sandbox_id,
         )
-        # Claim the recovery generation BEFORE any destructive external work:
-        # a racing recoverer that loses this compare-and-set must never
-        # terminate a runtime the winner is already rebuilding.
-        new_generation = begin_recovery_attempt__no_commit(
-            db_session, sandbox_id, generation
+        # Claim a new attempt number BEFORE any destructive external work:
+        # a racing recoverer that loses this claim must never terminate a
+        # runtime the winner is already rebuilding.
+        new_attempt_number = begin_recovery_attempt__no_commit(
+            db_session, sandbox_id, attempt_number
         )
         db_session.commit()
-        if new_generation is None:
+        if new_attempt_number is None:
             # A concurrent lifecycle decision (reaper, another request) moved
             # the row mid-recovery; let the caller retry through a fresh
             # reservation, which handles every status.
             raise SandboxProvisioningInProgressError(
                 f"Sandbox {sandbox_id} state changed during recovery; retry"
             )
-        generation = new_generation
+        attempt_number = new_attempt_number
         outcome = SandboxReadyOutcome.RECOVERED
 
         try:
@@ -589,7 +592,7 @@ def reconcile_sandbox(
             sandbox_manager.terminate(sandbox_id)
         except Exception as e:
             db_session.rollback()
-            _record_provisioning_failure(db_session, sandbox_id, generation, e)
+            _record_provisioning_failure(db_session, sandbox_id, attempt_number, e)
             raise SandboxProvisioningError(
                 f"Sandbox {sandbox_id} recovery failed: {e}"
             ) from e
@@ -608,25 +611,25 @@ def reconcile_sandbox(
     # External provisioning against the committed identity. provision()
     # returns only once the sandbox is RUNNING; anything else raises.
     try:
-        _check_attempt_deadline(attempt_deadline, sandbox_id, generation)
+        _check_attempt_deadline(attempt_deadline, sandbox_id, attempt_number)
         with track_sandbox_provision_in_progress():
             sandbox_manager.provision(
                 sandbox_id=sandbox_id,
                 user_id=user.id,
                 tenant_id=tenant_id,
                 onyx_pat=onyx_pat,
-                provisioning_generation=generation,
+                provisioning_attempt_number=attempt_number,
             )
     except SandboxProvisionContentionError as e:
         # A superseded attempt's tail still holds the backend lock. Record
         # this attempt FAILED (so the row never idles as PROVISIONING) and
         # surface the retryable error; the caller re-reserves.
-        _record_provisioning_failure(db_session, sandbox_id, generation, e)
+        _record_provisioning_failure(db_session, sandbox_id, attempt_number, e)
         raise SandboxProvisioningInProgressError(
             f"Sandbox {sandbox_id} provisioning lock is contended; retry"
         ) from e
     except Exception as e:
-        _record_provisioning_failure(db_session, sandbox_id, generation, e)
+        _record_provisioning_failure(db_session, sandbox_id, attempt_number, e)
         raise SandboxProvisioningError(
             f"Sandbox {sandbox_id} provisioning failed: {e}"
         ) from e
@@ -636,18 +639,18 @@ def reconcile_sandbox(
     # finalize the attempt as FAILED — the row cannot be left PROVISIONING
     # until the stale-attempt threshold.
     try:
-        _check_attempt_deadline(attempt_deadline, sandbox_id, generation)
+        _check_attempt_deadline(attempt_deadline, sandbox_id, attempt_number)
         payload = build_managed_content_payload(user, db_session)
         db_session.commit()
         skills_hydrated = push_managed_content(sandbox_manager, sandbox_id, payload)
 
         finalized = finalize_provisioning_attempt__no_commit(
-            db_session, sandbox_id, generation, SandboxStatus.RUNNING
+            db_session, sandbox_id, attempt_number, SandboxStatus.RUNNING
         )
         if not finalized:
             db_session.rollback()
             raise StaleProvisioningAttemptError(
-                f"Sandbox {sandbox_id} generation {generation} was superseded "
+                f"Sandbox {sandbox_id} attempt {attempt_number} was superseded "
                 f"before finalization"
             )
         record_managed_content_hashes__no_commit(
@@ -658,7 +661,7 @@ def reconcile_sandbox(
         raise
     except Exception as e:
         db_session.rollback()
-        _record_provisioning_failure(db_session, sandbox_id, generation, e)
+        _record_provisioning_failure(db_session, sandbox_id, attempt_number, e)
         raise SandboxProvisioningError(
             f"Sandbox {sandbox_id} provisioning failed: {e}"
         ) from e
@@ -723,8 +726,8 @@ def ensure_sandbox_ready(
     - No sandbox row: reserve + provision.
     - ``RUNNING`` + pod healthy: return as-is (hot path).
     - ``RUNNING`` + pod missing/unhealthy: recover (terminate, new
-      generation, re-provision).
-    - ``SLEEPING`` / ``TERMINATED`` / ``FAILED``: new generation +
+      attempt_number, re-provision).
+    - ``SLEEPING`` / ``TERMINATED`` / ``FAILED``: new attempt_number +
       re-provision.
     - ``PROVISIONING`` (live attempt): ``POLL`` waits up to
       ``provisioning_wait_seconds`` then re-enters; ``FAIL`` raises
@@ -960,27 +963,27 @@ def sleep_sandbox(
                 return
 
         # Snapshotting above can take minutes; re-check idleness right before
-        # the kill and capture the generation the sleep is fenced against.
+        # the kill and capture the attempt number the sleep must still match.
         db_session.refresh(sandbox)
         if sandbox.status != SandboxStatus.RUNNING or not is_sandbox_idle(
             sandbox, datetime.now(timezone.utc)
         ):
             logger.info("Sandbox %s went active mid-sweep; skipping reap", sandbox_id)
             return
-        sleep_generation = sandbox.provisioning_generation
+        sleep_attempt_number = sandbox.provisioning_attempt_number
 
         # Terminate the pod (but keep the sandbox record).
         sandbox_manager.terminate(sandbox_id)
 
-        # A recovery/create that advanced the generation mid-terminate owns
-        # the sandbox now; only claim ports/sessions if this compare-and-set
-        # wins.
+        # A recovery/create that started a newer attempt mid-terminate owns
+        # the sandbox now; only claim ports/sessions if the sleep write
+        # applies.
         if not sleep_running_sandbox__no_commit(
-            db_session, sandbox_id, sleep_generation
+            db_session, sandbox_id, sleep_attempt_number
         ):
             db_session.rollback()
             logger.warning(
-                "Sandbox %s changed generation during reap; aborting sleep",
+                "Sandbox %s changed attempt_number during reap; aborting sleep",
                 sandbox_id,
             )
             return

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -51,7 +51,7 @@ from onyx.server.features.build.db.sandbox import (
     delete_snapshot__no_commit,
     ensure_sandbox_pat,
     finalize_provisioning_attempt__no_commit,
-    get_running_sandbox_count,
+    get_occupying_sandbox_count,
     get_sandbox_by_id,
     get_sandbox_by_user_id,
     get_sandbox_user_map,
@@ -130,7 +130,7 @@ class SandboxReservation:
     tenant_id: str
     attempt_number: int
     # Set only when this reservation authorized external provisioning (the
-    # row is committed PROVISIONING at `attempt_number`); None when the sandbox
+    # row is committed PROVISIONING at this attempt number); None when the sandbox
     # was already RUNNING and only needs a health check.
     onyx_pat: str | None
     requires_provisioning: bool
@@ -244,12 +244,14 @@ def push_managed_content(
     payload: ManagedContentPayload,
 ) -> bool:
     """Push managed skills + user library into a sandbox. External I/O only —
-    no database access. Push failures are logged, never raised.
+    no database access.
 
-    Must complete before the sandbox is reported RUNNING: turns dispatch as
-    soon as RUNNING is visible, and opencode scans the skills directory once
-    per instance, so a turn started mid-push permanently misses managed
-    skills.
+    Runs (not necessarily succeeds) before the sandbox is reported RUNNING:
+    turns dispatch as soon as RUNNING is visible, and opencode scans the
+    skills directory once per instance, so a turn started mid-push would
+    permanently miss managed skills. Push failures are logged, never raised —
+    the sandbox still becomes RUNNING, and because ``skills_hash`` is only
+    recorded on success the next session create/reload retries the push.
 
     Returns whether the skills push fully succeeded (gates recording
     ``skills_hash``).
@@ -350,8 +352,8 @@ def _enforce_tenant_concurrency_limit(db_session: DBSession) -> None:
     sandbox would exceed the per-tenant cap."""
     if not MULTI_TENANT:
         return
-    running_count = get_running_sandbox_count(db_session)
-    if running_count >= SANDBOX_MAX_CONCURRENT_PER_ORG:
+    occupying_count = get_occupying_sandbox_count(db_session)
+    if occupying_count >= SANDBOX_MAX_CONCURRENT_PER_ORG:
         raise ValueError(
             f"Maximum concurrent sandboxes ({SANDBOX_MAX_CONCURRENT_PER_ORG}) reached"
         )
@@ -525,7 +527,7 @@ def reconcile_sandbox(
 
     Raises:
         SandboxProvisioningError: provisioning failed (recorded durably).
-        StaleProvisioningAttemptError: a newer attempt_number superseded this
+        StaleProvisioningAttemptError: a newer attempt superseded this
             attempt before it could finalize.
         SandboxProvisioningInProgressError: lost a race to a concurrent
             lifecycle decision while recovering, or the provisioning lock is
@@ -589,7 +591,14 @@ def reconcile_sandbox(
             snapshot_opencode_history_before_recovery(
                 sandbox_manager, sandbox_id, tenant_id
             )
-            sandbox_manager.terminate(sandbox_id)
+            sandbox_manager.terminate(sandbox_id, max_attempt_number=attempt_number)
+        except SandboxProvisionContentionError as e:
+            db_session.rollback()
+            _record_provisioning_failure(db_session, sandbox_id, attempt_number, e)
+            raise SandboxProvisioningInProgressError(
+                f"Sandbox {sandbox_id} runtime is owned by a concurrent "
+                f"provisioner; retry"
+            ) from e
         except Exception as e:
             db_session.rollback()
             _record_provisioning_failure(db_session, sandbox_id, attempt_number, e)
@@ -599,7 +608,7 @@ def reconcile_sandbox(
 
     if reservation.terminate_before_provision:
         try:
-            sandbox_manager.terminate(sandbox_id)
+            sandbox_manager.terminate(sandbox_id, max_attempt_number=attempt_number)
         except Exception:
             logger.warning(
                 "Best-effort terminate of stale runtime for sandbox %s before "
@@ -972,18 +981,16 @@ def sleep_sandbox(
             return
         sleep_attempt_number = sandbox.provisioning_attempt_number
 
-        # Terminate the pod (but keep the sandbox record).
-        sandbox_manager.terminate(sandbox_id)
-
-        # A recovery/create that started a newer attempt mid-terminate owns
-        # the sandbox now; only claim ports/sessions if the sleep write
-        # applies.
+        # Claim SLEEPING durably BEFORE destroying anything: once this commits,
+        # no other flow believes the runtime is theirs, so the kill below can
+        # never race a claim. The reverse order could destroy a runtime a
+        # concurrent recovery had just claimed.
         if not sleep_running_sandbox__no_commit(
             db_session, sandbox_id, sleep_attempt_number
         ):
             db_session.rollback()
             logger.warning(
-                "Sandbox %s changed attempt_number during reap; aborting sleep",
+                "Sandbox %s started a newer attempt during reap; aborting sleep",
                 sandbox_id,
             )
             return
@@ -998,6 +1005,30 @@ def sleep_sandbox(
         logger.debug("Marked %s sessions as IDLE for user %s", idled, sandbox.user_id)
 
         db_session.commit()
+
+        # Destroy the runtime (the sandbox record stays, as SLEEPING). The
+        # attempt bound plus the provisioning lock inside terminate() mean a
+        # wake that starts right after the commit either reuses the live pod
+        # first (terminate then skips) or provisions fresh after the deletion.
+        # A failed kill leaves an orphan runtime the next wake reuses or
+        # replaces — a leak is recoverable, a killed live runtime is not.
+        try:
+            sandbox_manager.terminate(
+                sandbox_id, max_attempt_number=sleep_attempt_number
+            )
+        except SandboxProvisionContentionError:
+            logger.info(
+                "Sandbox %s runtime is being provisioned by a concurrent flow; "
+                "leaving it to that owner",
+                sandbox_id,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to terminate runtime of sleeping sandbox %s; the next "
+                "wake reuses or replaces it",
+                sandbox_id,
+                exc_info=True,
+            )
         logger.info("Sandbox %s is now sleeping", sandbox_id)
     finally:
         if session_creation_lock.owned():

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -1,8 +1,25 @@
-"""Sandbox readiness state machine + provisioning, shared between
-interactive (``create_session__no_commit``) and headless
-(``ensure_sandbox_running``) flows."""
+"""Sandbox readiness state machine: durable reservation, external
+reconciliation, and generation-fenced finalization. Shared between the
+interactive create/restore flows and headless callers
+(``ensure_sandbox_running``).
+
+The lifecycle is split into three parts so no database transaction ever spans
+external I/O:
+
+1. **Reserve** (short transaction): lock the user row, commit the sandbox
+   identity in ``PROVISIONING`` with an advanced fencing generation, and
+   commit the Craft PAT. Once committed, the proxy can resolve the pod's
+   owner and credentials from any connection — a bootstrapping pod's egress
+   works before the sandbox is ``RUNNING``.
+2. **Reconcile** (no transaction): create/reuse the pod and its resources
+   idempotently, push sandbox-level managed content.
+3. **Finalize** (short transaction): generation-guarded compare-and-set to
+   ``RUNNING`` or ``FAILED``. A stale attempt cannot overwrite a newer
+   decision.
+"""
 
 import time
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from uuid import UUID
@@ -24,11 +41,15 @@ from onyx.server.features.build.db.build_session import (
     mark_user_sessions_idle__no_commit,
 )
 from onyx.server.features.build.db.sandbox import (
+    begin_provisioning_attempt__no_commit,
+    begin_recovery_attempt_cas__no_commit,
     create_sandbox__no_commit,
     create_snapshot__no_commit,
     delete_snapshot__no_commit,
     ensure_sandbox_pat,
+    finalize_provisioning_attempt__no_commit,
     get_running_sandbox_count,
+    get_sandbox_by_id,
     get_sandbox_by_user_id,
     get_sandbox_user_map,
     get_snapshots_for_session,
@@ -42,12 +63,19 @@ from onyx.server.features.build.sandbox.models import (
     SnapshotResult,
 )
 from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
-from onyx.server.features.build.sandbox.user_library import hydrate_user_library
+from onyx.server.features.build.sandbox.user_library import (
+    USER_LIBRARY_MOUNT_PATH,
+    build_user_library_fileset,
+)
 from onyx.server.features.build.sandbox.util.mcp_config import (
     craft_mcp_fingerprint,
     resolve_craft_mcp_servers,
 )
-from onyx.server.features.build.session.errors import SandboxProvisioningError
+from onyx.server.features.build.session.errors import (
+    SandboxProvisioningError,
+    SandboxProvisioningInProgressError,
+    StaleProvisioningAttemptError,
+)
 from onyx.server.metrics.craft_sandbox import (
     SandboxProvisionPhase,
     SandboxReadyOutcome,
@@ -56,9 +84,9 @@ from onyx.server.metrics.craft_sandbox import (
     track_sandbox_provision_in_progress,
 )
 from onyx.skills.push import (
+    SKILLS_MOUNT_PATH,
     build_user_skills_payload,
     compute_skill_runtime_hash,
-    hydrate_sandbox_skills,
 )
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
@@ -69,6 +97,12 @@ logger = setup_logger()
 
 _HEALTHCHECK_TIMEOUT_SECONDS = 5.0
 
+# A committed PROVISIONING attempt older than this is considered dead: every
+# bounded wait in the sandbox managers (per-sandbox provisioning lock, pod/
+# opencode readiness) completes well within it, so a live attempt cannot still
+# be working. A newer reservation may take the generation over.
+PROVISIONING_ATTEMPT_STALE_SECONDS = 240.0
+
 # Statuses from which (re-)provisioning a pod is legal.
 _REPROVISIONABLE_STATUSES: frozenset[SandboxStatus] = frozenset(
     {
@@ -77,6 +111,35 @@ _REPROVISIONABLE_STATUSES: frozenset[SandboxStatus] = frozenset(
         SandboxStatus.FAILED,
     }
 )
+
+
+@dataclass(frozen=True)
+class SandboxReservation:
+    """Committed identity of a sandbox provisioning attempt. Carries plain
+    values only — never a live SQLAlchemy model or session — so external
+    reconciliation cannot touch the reservation transaction."""
+
+    sandbox_id: UUID
+    tenant_id: str
+    generation: int
+    # Set only when this reservation authorized external provisioning (the
+    # row is committed PROVISIONING at `generation`); None when the sandbox
+    # was already RUNNING and only needs a health check.
+    onyx_pat: str | None
+    requires_provisioning: bool
+    sandbox_preexisted: bool
+
+
+@dataclass(frozen=True)
+class ManagedContentPayload:
+    """Sandbox-level managed content, prebuilt from database state so the
+    external push runs without an open transaction."""
+
+    connectable_apps_section: str
+    skills_files: FileSet
+    skills_hash: str
+    mcp_fingerprint: str
+    library_files: FileSet
 
 
 def snapshot_opencode_history_before_recovery(
@@ -100,20 +163,6 @@ def snapshot_opencode_history_before_recovery(
             sandbox_id,
             exc_info=True,
         )
-
-
-def recover_unhealthy_sandbox(
-    db_session: DBSession,
-    sandbox_manager: SandboxManager,
-    sandbox: Sandbox,
-    tenant_id: str,
-) -> None:
-    """Tear down a RUNNING sandbox whose pod is unhealthy/missing: preserve
-    opencode history best-effort, terminate, mark TERMINATED so the caller
-    can re-provision. Caller is responsible for committing."""
-    snapshot_opencode_history_before_recovery(sandbox_manager, sandbox.id, tenant_id)
-    sandbox_manager.terminate(sandbox.id)
-    update_sandbox_status__no_commit(db_session, sandbox.id, SandboxStatus.TERMINATED)
 
 
 def create_session_snapshot_keep_latest(
@@ -155,79 +204,60 @@ def create_session_snapshot_keep_latest(
     return result
 
 
-def hydrate_managed_content(
+# =============================================================================
+# Managed content: build (DB reads) → push (external) → record (short tx)
+# =============================================================================
+
+
+def build_managed_content_payload(
+    user: User, db_session: DBSession
+) -> ManagedContentPayload:
+    """Read-only assembly of the skills/user-library payload and its hashes.
+    Callers must close the read transaction before pushing externally."""
+    connectable_apps_section, skills_files = build_user_skills_payload(user, db_session)
+    return ManagedContentPayload(
+        connectable_apps_section=connectable_apps_section,
+        skills_files=skills_files,
+        skills_hash=compute_skill_runtime_hash(skills_files, connectable_apps_section),
+        mcp_fingerprint=craft_mcp_fingerprint(
+            resolve_craft_mcp_servers(db_session, user)
+        ),
+        library_files=build_user_library_fileset(user.id, db_session),
+    )
+
+
+@time_provision_phase(SandboxProvisionPhase.HYDRATE_MANAGED_CONTENT)
+def push_managed_content(
     sandbox_manager: SandboxManager,
     sandbox_id: UUID,
-    user: User,
-    db_session: DBSession,
-    *,
-    connectable_apps_section: str | None = None,
-    skills_files: FileSet | None = None,
+    payload: ManagedContentPayload,
 ) -> bool:
-    """Push managed skills + user library into a sandbox.
+    """Push managed skills + user library into a sandbox. External I/O only —
+    no database access. Push failures are logged, never raised.
 
     Must complete before the sandbox is reported RUNNING: turns dispatch as
     soon as RUNNING is visible, and opencode scans the skills directory once
     per instance, so a turn started mid-push permanently misses managed
-    skills. The persisted hash also covers the connectable-app guidance used
-    to regenerate ``AGENTS.md`` on reload.
+    skills.
 
-    ``connectable_apps_section`` and ``skills_files`` must be supplied together
-    or both omitted; mismatched nullity is a programmer error and raises
-    ``ValueError`` eagerly. Runtime push failures are logged, never raised.
+    Returns whether the skills push fully succeeded (gates recording
+    ``skills_hash``).
     """
-    if (connectable_apps_section is None) != (skills_files is None):
-        raise ValueError(
-            "connectable_apps_section and skills_files must be provided together"
-        )
-    if connectable_apps_section is None or skills_files is None:
-        connectable_apps_section, skills_files = build_user_skills_payload(
-            user, db_session
-        )
-
-    # The sandbox's MCP fingerprint is its baseline for session staleness and is
-    # independent of the skill-file push (MCP config is written per session), so
-    # stamp it regardless of whether that push succeeds.
-    try:
-        with db_session.begin_nested():
-            set_sandbox_mcp_config_hashes__no_commit(
-                db_session,
-                {
-                    sandbox_id: craft_mcp_fingerprint(
-                        resolve_craft_mcp_servers(db_session, user)
-                    )
-                },
-            )
-    except Exception:
-        logger.warning(
-            "Failed to stamp MCP config hash for sandbox %s", sandbox_id, exc_info=True
-        )
-
     skills_hydrated = False
     try:
-        skills_hash = compute_skill_runtime_hash(skills_files, connectable_apps_section)
-        result = hydrate_sandbox_skills(
-            sandbox_id,
-            user,
-            db_session,
-            sandbox_manager=sandbox_manager,
-            files=skills_files,
+        result = sandbox_manager.push_to_sandbox(
+            sandbox_id=sandbox_id,
+            mount_path=SKILLS_MOUNT_PATH,
+            files=payload.skills_files,
         )
-        if result.succeeded == result.targets:
-            with db_session.begin_nested():
-                set_sandbox_skills_hashes__no_commit(
-                    db_session,
-                    {sandbox_id: skills_hash},
-                )
-            skills_hydrated = True
+        skills_hydrated = result.succeeded == result.targets
     except Exception:
         logger.warning("Failed to push skills to sandbox %s", sandbox_id, exc_info=True)
     try:
-        hydrate_user_library(
-            sandbox_id,
-            user.id,
-            db_session,
-            sandbox_manager=sandbox_manager,
+        sandbox_manager.push_to_sandbox(
+            sandbox_id=sandbox_id,
+            mount_path=USER_LIBRARY_MOUNT_PATH,
+            files=payload.library_files,
         )
     except Exception:
         logger.warning(
@@ -236,8 +266,49 @@ def hydrate_managed_content(
     return skills_hydrated
 
 
+def record_managed_content_hashes__no_commit(
+    db_session: DBSession,
+    sandbox_id: UUID,
+    payload: ManagedContentPayload,
+    skills_hydrated: bool,
+) -> None:
+    """Stamp the sandbox with the content state that was actually pushed.
+    The MCP fingerprint is recorded regardless of the skill push (MCP config
+    is written per session), the skills hash only when the push landed."""
+    set_sandbox_mcp_config_hashes__no_commit(
+        db_session, {sandbox_id: payload.mcp_fingerprint}
+    )
+    if skills_hydrated:
+        set_sandbox_skills_hashes__no_commit(
+            db_session, {sandbox_id: payload.skills_hash}
+        )
+
+
+def sync_managed_content(
+    db_session: DBSession,
+    sandbox_manager: SandboxManager,
+    sandbox_id: UUID,
+    user: User,
+) -> None:
+    """Build → push → record for an already-RUNNING sandbox. Commits; callers
+    must be at a clean transaction boundary."""
+    payload = build_managed_content_payload(user, db_session)
+    db_session.commit()
+    skills_hydrated = push_managed_content(sandbox_manager, sandbox_id, payload)
+    record_managed_content_hashes__no_commit(
+        db_session, sandbox_id, payload, skills_hydrated
+    )
+    db_session.commit()
+
+
+# =============================================================================
+# Reserve → reconcile → finalize
+# =============================================================================
+
+
 class ProvisioningPolicy(str, Enum):
-    """How to handle a sandbox already in ``PROVISIONING`` when we arrive.
+    """How to handle a sandbox already owned by a live ``PROVISIONING``
+    attempt when we arrive.
 
     - ``POLL``: wait for the concurrent provisioner to finish, then re-enter
       the state machine on the resulting status. Used by headless callers
@@ -250,77 +321,14 @@ class ProvisioningPolicy(str, Enum):
     FAIL = "fail"
 
 
-def provision_sandbox(
-    db_session: DBSession,
-    sandbox_manager: SandboxManager,
-    sandbox: Sandbox,
-    user: User,
-    user_id: UUID,
-    tenant_id: str,
-) -> None:
-    """
-
-    Managed content (skills, user library) is pushed before the row is
-    flipped to RUNNING so no turn can start against a pod that is still
-    receiving its skills.
-
-    Updates the sandbox row's status to whatever the manager returns.
-    Caller is responsible for committing.
-    """
-    with time_provision_phase(SandboxProvisionPhase.ENSURE_PAT):
-        onyx_pat = ensure_sandbox_pat(db_session, sandbox, user)
-    sandbox_info = sandbox_manager.provision(
-        sandbox_id=sandbox.id,
-        user_id=user_id,
-        tenant_id=tenant_id,
-        onyx_pat=onyx_pat,
-    )
-    if sandbox_info.status == SandboxStatus.RUNNING:
-        with time_provision_phase(SandboxProvisionPhase.HYDRATE_MANAGED_CONTENT):
-            hydrate_managed_content(sandbox_manager, sandbox.id, user, db_session)
-    update_sandbox_status__no_commit(db_session, sandbox.id, sandbox_info.status)
-
-
-@time_provision_phase(SandboxProvisionPhase.PROVISIONING_WAIT)
-def _wait_for_provisioning_to_complete(
-    db_session: DBSession,
-    sandbox: Sandbox,
-    wait_seconds: float,
-    *,
-    poll_interval_seconds: float = 1.0,
-) -> Sandbox:
-    """Poll a ``PROVISIONING`` sandbox until it transitions or we time out.
-
-    Relies on Postgres' READ COMMITTED isolation: ``session.refresh()``
-    issues a fresh SELECT each iteration, so commits from the concurrent
-    provisioner become visible.
-
-    Raises:
-        SandboxProvisioningError: deadline elapsed before the status
-            changed.
-    """
-    deadline = time.monotonic() + wait_seconds
-    started = time.monotonic()
-    logger.info(
-        "Waiting up to %.1fs for sandbox %s to finish provisioning",
-        wait_seconds,
-        sandbox.id,
-    )
-    while True:
-        db_session.refresh(sandbox)
-        if sandbox.status != SandboxStatus.PROVISIONING:
-            logger.info(
-                "Sandbox %s left PROVISIONING after %.1fs (now=%s)",
-                sandbox.id,
-                time.monotonic() - started,
-                sandbox.status.value,
-            )
-            return sandbox
-        if time.monotonic() >= deadline:
-            raise SandboxProvisioningError(
-                f"Sandbox {sandbox.id} still PROVISIONING after {wait_seconds}s"
-            )
-        time.sleep(poll_interval_seconds)
+def _provisioning_attempt_is_stale(sandbox: Sandbox) -> bool:
+    """A committed PROVISIONING row whose attempt can no longer be alive.
+    Rows without a start timestamp predate the attempt tracking and are
+    always stale."""
+    if sandbox.provisioning_started_at is None:
+        return True
+    age = datetime.now(timezone.utc) - sandbox.provisioning_started_at
+    return age.total_seconds() >= PROVISIONING_ATTEMPT_STALE_SECONDS
 
 
 def _enforce_tenant_concurrency_limit(db_session: DBSession) -> None:
@@ -335,6 +343,282 @@ def _enforce_tenant_concurrency_limit(db_session: DBSession) -> None:
         )
 
 
+def reserve_sandbox__no_commit(
+    db_session: DBSession,
+    user: User,
+) -> SandboxReservation:
+    """Reserve the user's sandbox for use, advancing the provisioning
+    generation when external reconciliation is required.
+
+    Must be called with the user's row locked (``fetch_user_by_id(for_update=True)``)
+    in the current transaction so concurrent reservers serialize. ``flush``
+    only — the caller commits, and MUST commit before any external work.
+
+    Raises:
+        SandboxProvisioningInProgressError: a live attempt owns the sandbox.
+        ValueError: tenant concurrency cap reached.
+    """
+    tenant_id = get_current_tenant_id()
+    sandbox = get_sandbox_by_user_id(db_session, user.id)
+    sandbox_preexisted = sandbox is not None
+    requires_provisioning: bool
+
+    if sandbox is None:
+        _enforce_tenant_concurrency_limit(db_session)
+        sandbox = create_sandbox__no_commit(db_session=db_session, user_id=user.id)
+        generation = begin_provisioning_attempt__no_commit(db_session, sandbox)
+        requires_provisioning = True
+        logger.info(
+            "Created sandbox %s for user %s (generation %s)",
+            sandbox.id,
+            user.id,
+            generation,
+        )
+    elif sandbox.status == SandboxStatus.RUNNING:
+        generation = sandbox.provisioning_generation
+        requires_provisioning = False
+    elif sandbox.status in _REPROVISIONABLE_STATUSES:
+        _enforce_tenant_concurrency_limit(db_session)
+        previous_status = sandbox.status
+        generation = begin_provisioning_attempt__no_commit(db_session, sandbox)
+        requires_provisioning = True
+        logger.info(
+            "Reviving sandbox %s (was %s) for user %s (generation %s)",
+            sandbox.id,
+            previous_status.value,
+            user.id,
+            generation,
+        )
+    elif sandbox.status == SandboxStatus.PROVISIONING:
+        if not _provisioning_attempt_is_stale(sandbox):
+            raise SandboxProvisioningInProgressError(
+                f"Sandbox {sandbox.id} is being provisioned by a live attempt "
+                f"(generation {sandbox.provisioning_generation})"
+            )
+        _enforce_tenant_concurrency_limit(db_session)
+        generation = begin_provisioning_attempt__no_commit(db_session, sandbox)
+        requires_provisioning = True
+        logger.warning(
+            "Taking over stale PROVISIONING sandbox %s for user %s (generation %s)",
+            sandbox.id,
+            user.id,
+            generation,
+        )
+    else:
+        raise RuntimeError(
+            f"Sandbox {sandbox.id} in unexpected status "
+            f"{sandbox.status.value}; refusing to provision"
+        )
+
+    # The PAT only matters when a pod is about to be created — the healthy
+    # hot path must not pay PAT reads per request.
+    onyx_pat: str | None = None
+    if requires_provisioning:
+        with time_provision_phase(SandboxProvisionPhase.ENSURE_PAT):
+            onyx_pat = ensure_sandbox_pat(db_session, sandbox, user)
+
+    return SandboxReservation(
+        sandbox_id=sandbox.id,
+        tenant_id=tenant_id,
+        generation=generation,
+        onyx_pat=onyx_pat,
+        requires_provisioning=requires_provisioning,
+        sandbox_preexisted=sandbox_preexisted,
+    )
+
+
+def _record_provisioning_failure(
+    db_session: DBSession,
+    sandbox_id: UUID,
+    generation: int,
+    error: BaseException,
+) -> None:
+    """Durably mark a failed attempt FAILED (compare-and-set; a stale attempt
+    leaves newer state alone). The diagnostic detail lives in this log line,
+    keyed by sandbox ID + generation — not in the database. Never raises."""
+    try:
+        if finalize_provisioning_attempt__no_commit(
+            db_session,
+            sandbox_id,
+            generation,
+            SandboxStatus.FAILED,
+        ):
+            db_session.commit()
+            logger.error(
+                "Sandbox %s provisioning failed (generation %s): %s",
+                sandbox_id,
+                generation,
+                error,
+            )
+        else:
+            db_session.rollback()
+            logger.warning(
+                "Sandbox %s provisioning failed but generation %s is "
+                "stale; leaving newer state untouched",
+                sandbox_id,
+                generation,
+            )
+    except Exception:
+        db_session.rollback()
+        logger.exception(
+            "Failed to record provisioning failure for sandbox %s", sandbox_id
+        )
+
+
+def _get_sandbox_committed(db_session: DBSession, sandbox_id: UUID) -> Sandbox:
+    """Fetch the sandbox and close the read transaction. The finalizers write
+    via core UPDATEs, which don't touch an already-loaded instance
+    (expire_on_commit=False), so refresh to the committed state."""
+    sandbox = get_sandbox_by_id(db_session, sandbox_id)
+    if sandbox is None:
+        raise RuntimeError(f"Sandbox {sandbox_id} disappeared during reconciliation")
+    db_session.refresh(sandbox)
+    db_session.commit()
+    return sandbox
+
+
+def reconcile_sandbox(
+    db_session: DBSession,
+    sandbox_manager: SandboxManager,
+    reservation: SandboxReservation,
+    user: User,
+) -> tuple[Sandbox, SandboxReadyOutcome]:
+    """Converge external state on the committed reservation and finalize.
+
+    The reservation MUST already be committed and ``db_session`` must be at a
+    clean transaction boundary; every database touch in here is a short
+    transaction that is committed or rolled back before external I/O resumes.
+
+    Raises:
+        SandboxProvisioningError: provisioning failed (recorded durably).
+        StaleProvisioningAttemptError: a newer generation superseded this
+            attempt before it could finalize.
+        SandboxProvisioningInProgressError: lost a race to a concurrent
+            lifecycle decision while recovering; the caller retries.
+    """
+    sandbox_id = reservation.sandbox_id
+    tenant_id = reservation.tenant_id
+    generation = reservation.generation
+    outcome = (
+        (
+            SandboxReadyOutcome.REVIVED
+            if reservation.sandbox_preexisted
+            else SandboxReadyOutcome.CREATED
+        )
+        if reservation.requires_provisioning
+        else SandboxReadyOutcome.ALREADY_RUNNING
+    )
+
+    if not reservation.requires_provisioning:
+        # Claimed RUNNING: verify the pod actually backs it.
+        with time_provision_phase(SandboxProvisionPhase.HEALTH_CHECK):
+            healthy = sandbox_manager.health_check(
+                sandbox_id, timeout=_HEALTHCHECK_TIMEOUT_SECONDS
+            )
+        if healthy:
+            return _get_sandbox_committed(db_session, sandbox_id), outcome
+
+        logger.warning(
+            "Sandbox %s marked RUNNING but pod is unhealthy/missing; recovering.",
+            sandbox_id,
+        )
+        snapshot_opencode_history_before_recovery(
+            sandbox_manager, sandbox_id, tenant_id
+        )
+        sandbox_manager.terminate(sandbox_id)
+        new_generation = begin_recovery_attempt_cas__no_commit(
+            db_session, sandbox_id, generation
+        )
+        db_session.commit()
+        if new_generation is None:
+            # A concurrent lifecycle decision (reaper, another request) moved
+            # the row mid-recovery; let the caller retry through a fresh
+            # reservation, which handles every status.
+            raise SandboxProvisioningInProgressError(
+                f"Sandbox {sandbox_id} state changed during recovery; retry"
+            )
+        generation = new_generation
+        outcome = SandboxReadyOutcome.RECOVERED
+
+    # External provisioning against the committed identity. provision()
+    # returns only once the sandbox is RUNNING; anything else raises.
+    try:
+        with track_sandbox_provision_in_progress():
+            sandbox_manager.provision(
+                sandbox_id=sandbox_id,
+                user_id=user.id,
+                tenant_id=tenant_id,
+                onyx_pat=reservation.onyx_pat,
+                provisioning_generation=generation,
+            )
+    except Exception as e:
+        _record_provisioning_failure(db_session, sandbox_id, generation, e)
+        raise SandboxProvisioningError(
+            f"Sandbox {sandbox_id} provisioning failed: {e}"
+        ) from e
+
+    # Managed content must land before the row reports RUNNING (turns
+    # dispatch the moment RUNNING is visible).
+    payload = build_managed_content_payload(user, db_session)
+    db_session.commit()
+    skills_hydrated = push_managed_content(sandbox_manager, sandbox_id, payload)
+
+    finalized = finalize_provisioning_attempt__no_commit(
+        db_session, sandbox_id, generation, SandboxStatus.RUNNING
+    )
+    if not finalized:
+        db_session.rollback()
+        raise StaleProvisioningAttemptError(
+            f"Sandbox {sandbox_id} generation {generation} was superseded "
+            f"before finalization"
+        )
+    record_managed_content_hashes__no_commit(
+        db_session, sandbox_id, payload, skills_hydrated
+    )
+    db_session.commit()
+
+    return _get_sandbox_committed(db_session, sandbox_id), outcome
+
+
+@time_provision_phase(SandboxProvisionPhase.PROVISIONING_WAIT)
+def _wait_for_provisioning_to_complete(
+    db_session: DBSession,
+    user_id: UUID,
+    deadline: float,
+    *,
+    poll_interval_seconds: float = 1.0,
+) -> None:
+    """Poll a ``PROVISIONING`` sandbox with short-lived reads until it
+    transitions, its attempt goes stale, or the deadline passes. No
+    transaction (or connection) is held while sleeping.
+
+    Raises:
+        SandboxProvisioningError: deadline elapsed before the status changed.
+    """
+    started = time.monotonic()
+    while True:
+        sandbox = get_sandbox_by_user_id(db_session, user_id)
+        still_provisioning = (
+            sandbox is not None
+            and sandbox.status == SandboxStatus.PROVISIONING
+            and not _provisioning_attempt_is_stale(sandbox)
+        )
+        db_session.rollback()
+        if not still_provisioning:
+            logger.info(
+                "Sandbox for user %s left live-PROVISIONING after %.1fs",
+                user_id,
+                time.monotonic() - started,
+            )
+            return
+        if time.monotonic() >= deadline:
+            raise SandboxProvisioningError(
+                f"Sandbox for user {user_id} still PROVISIONING after "
+                f"{time.monotonic() - started:.1f}s"
+            )
+        time.sleep(poll_interval_seconds)
+
+
 def ensure_sandbox_ready(
     db_session: DBSession,
     sandbox_manager: SandboxManager,
@@ -342,134 +626,60 @@ def ensure_sandbox_ready(
     *,
     policy: ProvisioningPolicy,
     provisioning_wait_seconds: float = 30.0,
-    user: User | None = None,
-) -> Sandbox:
-    """Return the sandbox for ``user_id``, creating, waking, or recovering
-    it as needed. Provisioning hydrates managed content before the row
-    reports RUNNING.
+) -> tuple[Sandbox, SandboxReadyOutcome]:
+    """Return the RUNNING sandbox for ``user_id`` (and how it got there),
+    creating, waking, or recovering it as needed via reserve → reconcile →
+    finalize.
+
+    ``db_session`` must be at a clean transaction boundary; this function
+    commits its own short transactions and leaves no transaction open across
+    external work.
 
     Branches by current sandbox status:
-    - No sandbox row: create + provision.
-    - ``RUNNING`` + pod healthy: return as-is (hot path; no extra writes).
-    - ``RUNNING`` + pod missing/unhealthy: terminate, mark TERMINATED,
+    - No sandbox row: reserve + provision.
+    - ``RUNNING`` + pod healthy: return as-is (hot path).
+    - ``RUNNING`` + pod missing/unhealthy: recover (terminate, new
+      generation, re-provision).
+    - ``SLEEPING`` / ``TERMINATED`` / ``FAILED``: new generation +
       re-provision.
-    - ``SLEEPING`` / ``TERMINATED`` / ``FAILED``: re-provision in place.
-    - ``PROVISIONING``: depends on ``policy`` —
-        - ``POLL``: wait up to ``provisioning_wait_seconds`` then re-enter
-          the state machine on the new status (raises
-          ``SandboxProvisioningError`` on timeout).
-        - ``FAIL``: raise ``RuntimeError`` immediately so the caller can
-          return a fast error to the user.
-
-    Honors ``SANDBOX_MAX_CONCURRENT_PER_ORG`` when ``MULTI_TENANT`` for any
-    path that newly counts toward the running limit (create + revive).
-    Caller is responsible for committing.
+    - ``PROVISIONING`` (live attempt): ``POLL`` waits up to
+      ``provisioning_wait_seconds`` then re-enters; ``FAIL`` raises
+      immediately. A stale attempt is taken over by either policy.
 
     Raises:
-        SandboxProvisioningError: Sandbox still ``PROVISIONING`` after the
-            wait window (POLL only).
-        ValueError: Concurrency cap reached, or user not found.
-        RuntimeError: Pod provisioning failed, or sandbox is mid-provision
-            under FAIL policy.
+        SandboxProvisioningInProgressError: live concurrent attempt (FAIL
+            policy, or still contended after waiting).
+        SandboxProvisioningError: provisioning failed or wait timed out.
+        ValueError: concurrency cap reached, or user not found.
     """
     started_at = time.monotonic()
     outcome = SandboxReadyOutcome.FAILED
     try:
-        sandbox, outcome = _resolve_ready_sandbox(
-            db_session,
-            sandbox_manager,
-            user_id,
-            policy=policy,
-            provisioning_wait_seconds=provisioning_wait_seconds,
-            user=user,
+        deadline = started_at + provisioning_wait_seconds
+        while True:
+            try:
+                user = fetch_user_by_id(db_session, user_id, for_update=True)
+                if user is None:
+                    raise ValueError(f"User {user_id} not found")
+                reservation = reserve_sandbox__no_commit(db_session, user)
+                db_session.commit()
+            except SandboxProvisioningInProgressError:
+                db_session.rollback()
+                if policy == ProvisioningPolicy.FAIL:
+                    raise
+                _wait_for_provisioning_to_complete(db_session, user_id, deadline)
+                continue
+            except BaseException:
+                db_session.rollback()
+                raise
+            break
+
+        sandbox, outcome = reconcile_sandbox(
+            db_session, sandbox_manager, reservation, user
         )
-        return sandbox
+        return sandbox, outcome
     finally:
         observe_sandbox_ready(outcome, time.monotonic() - started_at)
-
-
-def _resolve_ready_sandbox(
-    db_session: DBSession,
-    sandbox_manager: SandboxManager,
-    user_id: UUID,
-    *,
-    policy: ProvisioningPolicy,
-    provisioning_wait_seconds: float,
-    user: User | None,
-) -> tuple[Sandbox, SandboxReadyOutcome]:
-    """State machine behind ``ensure_sandbox_ready``, plus the path it took."""
-    sandbox = get_sandbox_by_user_id(db_session, user_id)
-    tenant_id = get_current_tenant_id()
-    recovered = False
-
-    # Resolve PROVISIONING upfront so the rest of the state machine sees a
-    # stable status (or knows there isn't one).
-    if sandbox is not None and sandbox.status == SandboxStatus.PROVISIONING:
-        if policy == ProvisioningPolicy.FAIL:
-            raise RuntimeError(
-                f"Sandbox {sandbox.id} has status PROVISIONING and is being "
-                f"created by another request"
-            )
-        sandbox = _wait_for_provisioning_to_complete(
-            db_session, sandbox, provisioning_wait_seconds
-        )
-
-    # Hot path: pod is up; nothing else to do.
-    if sandbox is not None and sandbox.status == SandboxStatus.RUNNING:
-        with time_provision_phase(SandboxProvisionPhase.HEALTH_CHECK):
-            healthy = sandbox_manager.health_check(
-                sandbox.id, timeout=_HEALTHCHECK_TIMEOUT_SECONDS
-            )
-        if healthy:
-            return sandbox, SandboxReadyOutcome.ALREADY_RUNNING
-        logger.warning(
-            "Sandbox %s marked RUNNING but pod is unhealthy/missing; recovering.",
-            sandbox.id,
-        )
-        recover_unhealthy_sandbox(db_session, sandbox_manager, sandbox, tenant_id)
-        # Falls through to re-provision, which cannot otherwise be told apart
-        # from an ordinary revive.
-        recovered = True
-
-    if sandbox is not None and sandbox.status not in _REPROVISIONABLE_STATUSES:
-        raise RuntimeError(
-            f"Sandbox {sandbox.id} in unexpected status "
-            f"{sandbox.status.value}; refusing to provision"
-        )
-
-    # Everything below provisions a pod, which adds to the per-tenant cap.
-    _enforce_tenant_concurrency_limit(db_session)
-
-    if user is None:
-        user = fetch_user_by_id(db_session, user_id)
-        if user is None:
-            raise ValueError(f"User {user_id} not found")
-
-    if sandbox is None:
-        sandbox = create_sandbox__no_commit(db_session=db_session, user_id=user_id)
-        logger.info("Created sandbox %s for user %s", sandbox.id, user_id)
-        outcome = SandboxReadyOutcome.CREATED
-    else:
-        logger.info(
-            "Reviving sandbox %s (status=%s) for user %s",
-            sandbox.id,
-            sandbox.status.value,
-            user_id,
-        )
-        outcome = (
-            SandboxReadyOutcome.RECOVERED if recovered else SandboxReadyOutcome.REVIVED
-        )
-
-    with track_sandbox_provision_in_progress():
-        provision_sandbox(
-            db_session,
-            sandbox_manager,
-            sandbox,
-            user,
-            user_id,
-            tenant_id,
-        )
-    return sandbox, outcome
 
 
 def is_sandbox_idle(sandbox: Sandbox, now: datetime) -> bool:
@@ -686,40 +896,6 @@ def sleep_sandbox(
     finally:
         if session_creation_lock.owned():
             session_creation_lock.release()
-
-
-def mark_sandbox_provisioning(db_session: DBSession, sandbox: Sandbox) -> None:
-    """Mark a re-provisionable sandbox as PROVISIONING before re-provisioning.
-
-    Commits deliberately so the transition is immediately visible to concurrent
-    pollers of the state machine (e.g. ``_wait_for_provisioning_to_complete``).
-
-    Raises:
-        RuntimeError: sandbox is not in a re-provisionable status (guards
-            against clobbering RUNNING or a concurrent PROVISIONING).
-    """
-    if sandbox.status not in _REPROVISIONABLE_STATUSES:
-        raise RuntimeError(
-            f"Sandbox {sandbox.id} in unexpected status "
-            f"{sandbox.status.value}; refusing to mark PROVISIONING"
-        )
-    update_sandbox_status__no_commit(db_session, sandbox.id, SandboxStatus.PROVISIONING)
-    db_session.commit()
-
-
-def rollback_failed_provisioning(db_session: DBSession, sandbox: Sandbox) -> bool:
-    """Compensating transition for provisioning that died mid-flight:
-    return the sandbox to ``SLEEPING`` (committed) so the stuck status
-    doesn't block the next attempt. Returns whether a rollback was applied.
-    """
-    if sandbox.status != SandboxStatus.PROVISIONING:
-        return False
-    update_sandbox_status__no_commit(db_session, sandbox.id, SandboxStatus.SLEEPING)
-    db_session.commit()
-    logger.info(
-        "Rolled sandbox %s back to SLEEPING after failed provisioning", sandbox.id
-    )
-    return True
 
 
 def refresh_mcp_config_hashes_for_users(

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -42,7 +42,7 @@ from onyx.server.features.build.db.build_session import (
 )
 from onyx.server.features.build.db.sandbox import (
     begin_provisioning_attempt__no_commit,
-    begin_recovery_attempt_cas__no_commit,
+    begin_recovery_attempt__no_commit,
     create_sandbox__no_commit,
     create_snapshot__no_commit,
     delete_snapshot__no_commit,
@@ -55,11 +55,12 @@ from onyx.server.features.build.db.sandbox import (
     get_snapshots_for_session,
     set_sandbox_mcp_config_hashes__no_commit,
     set_sandbox_skills_hashes__no_commit,
-    update_sandbox_status__no_commit,
+    sleep_running_sandbox__no_commit,
 )
 from onyx.server.features.build.sandbox.base import SandboxManager
 from onyx.server.features.build.sandbox.models import (
     FileSet,
+    SandboxProvisionContentionError,
     SnapshotResult,
 )
 from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
@@ -75,6 +76,12 @@ from onyx.server.features.build.session.errors import (
     SandboxProvisioningError,
     SandboxProvisioningInProgressError,
     StaleProvisioningAttemptError,
+)
+from onyx.server.features.build.timeouts import (
+    ATTEMPT_DEADLINE_SECONDS,
+    POLL_INTERVAL_SECONDS,
+    PROVISION_WAIT_SECONDS,
+    RECOVERY_HISTORY_SNAPSHOT_SECONDS,
 )
 from onyx.server.metrics.craft_sandbox import (
     SandboxProvisionPhase,
@@ -95,13 +102,10 @@ from shared_configs.contextvars import get_current_tenant_id
 logger = setup_logger()
 
 
-_HEALTHCHECK_TIMEOUT_SECONDS = 5.0
+# Liveness probe on the reconcile/reaper hot paths; tight so a dead pod can't
+# stall an interactive request.
+_HEALTH_PROBE_TIMEOUT_SECONDS = 5.0
 
-# A committed PROVISIONING attempt older than this is considered dead: every
-# bounded wait in the sandbox managers (per-sandbox provisioning lock, pod/
-# opencode readiness) completes well within it, so a live attempt cannot still
-# be working. A newer reservation may take the generation over.
-PROVISIONING_ATTEMPT_STALE_SECONDS = 240.0
 
 # Statuses from which (re-)provisioning a pod is legal.
 _REPROVISIONABLE_STATUSES: frozenset[SandboxStatus] = frozenset(
@@ -128,6 +132,10 @@ class SandboxReservation:
     onyx_pat: str | None
     requires_provisioning: bool
     sandbox_preexisted: bool
+    # A prior attempt (FAILED, or a taken-over stale PROVISIONING) may have
+    # left a wedged pod that ``provision`` would reuse instead of recreating;
+    # tear it down first so the retry gets a fresh runtime.
+    terminate_before_provision: bool
 
 
 @dataclass(frozen=True)
@@ -155,7 +163,7 @@ def snapshot_opencode_history_before_recovery(
         sandbox_manager.create_opencode_history_snapshot(
             sandbox_id,
             tenant_id,
-            timeout_seconds=30.0,
+            timeout_seconds=RECOVERY_HISTORY_SNAPSHOT_SECONDS,
         )
     except Exception:
         logger.warning(
@@ -322,13 +330,16 @@ class ProvisioningPolicy(str, Enum):
 
 
 def _provisioning_attempt_is_stale(sandbox: Sandbox) -> bool:
-    """A committed PROVISIONING row whose attempt can no longer be alive.
-    Rows without a start timestamp predate the attempt tracking and are
-    always stale."""
+    """A committed PROVISIONING row old enough to take over: reconcile
+    self-aborts at ``ATTEMPT_DEADLINE_SECONDS``, so past that age the attempt
+    is dead or in its final in-flight phase. Rows without a start timestamp
+    predate the attempt tracking and are always stale. Correctness never
+    depends on this — finalization is fenced by the generation
+    compare-and-set."""
     if sandbox.provisioning_started_at is None:
         return True
     age = datetime.now(timezone.utc) - sandbox.provisioning_started_at
-    return age.total_seconds() >= PROVISIONING_ATTEMPT_STALE_SECONDS
+    return age.total_seconds() >= ATTEMPT_DEADLINE_SECONDS
 
 
 def _enforce_tenant_concurrency_limit(db_session: DBSession) -> None:
@@ -362,6 +373,7 @@ def reserve_sandbox__no_commit(
     sandbox = get_sandbox_by_user_id(db_session, user.id)
     sandbox_preexisted = sandbox is not None
     requires_provisioning: bool
+    terminate_before_provision = False
 
     if sandbox is None:
         _enforce_tenant_concurrency_limit(db_session)
@@ -380,6 +392,9 @@ def reserve_sandbox__no_commit(
     elif sandbox.status in _REPROVISIONABLE_STATUSES:
         _enforce_tenant_concurrency_limit(db_session)
         previous_status = sandbox.status
+        # Only FAILED may have a leftover pod; SLEEPING/TERMINATED were
+        # terminated on entry.
+        terminate_before_provision = previous_status == SandboxStatus.FAILED
         generation = begin_provisioning_attempt__no_commit(db_session, sandbox)
         requires_provisioning = True
         logger.info(
@@ -396,6 +411,7 @@ def reserve_sandbox__no_commit(
                 f"(generation {sandbox.provisioning_generation})"
             )
         _enforce_tenant_concurrency_limit(db_session)
+        terminate_before_provision = True
         generation = begin_provisioning_attempt__no_commit(db_session, sandbox)
         requires_provisioning = True
         logger.warning(
@@ -410,8 +426,7 @@ def reserve_sandbox__no_commit(
             f"{sandbox.status.value}; refusing to provision"
         )
 
-    # The PAT only matters when a pod is about to be created — the healthy
-    # hot path must not pay PAT reads per request.
+    # Keep PAT reads off the healthy hot path.
     onyx_pat: str | None = None
     if requires_provisioning:
         with time_provision_phase(SandboxProvisionPhase.ENSURE_PAT):
@@ -424,6 +439,7 @@ def reserve_sandbox__no_commit(
         onyx_pat=onyx_pat,
         requires_provisioning=requires_provisioning,
         sandbox_preexisted=sandbox_preexisted,
+        terminate_before_provision=terminate_before_provision,
     )
 
 
@@ -477,6 +493,21 @@ def _get_sandbox_committed(db_session: DBSession, sandbox_id: UUID) -> Sandbox:
     return sandbox
 
 
+def _check_attempt_deadline(
+    attempt_deadline: float, sandbox_id: UUID, generation: int
+) -> None:
+    """Self-enforcement of the attempt deadline between external phases: the
+    attempt aborts itself (finalizing FAILED via the caller's error handling)
+    at the same age observers use to declare it stale. An in-flight phase can
+    overrun the check; takeover safety comes from the provisioning lock and
+    the generation compare-and-set, not from this deadline."""
+    if time.monotonic() >= attempt_deadline:
+        raise TimeoutError(
+            f"Provisioning attempt for sandbox {sandbox_id} (generation "
+            f"{generation}) exceeded its {ATTEMPT_DEADLINE_SECONDS:.0f}s deadline"
+        )
+
+
 def reconcile_sandbox(
     db_session: DBSession,
     sandbox_manager: SandboxManager,
@@ -494,12 +525,14 @@ def reconcile_sandbox(
         StaleProvisioningAttemptError: a newer generation superseded this
             attempt before it could finalize.
         SandboxProvisioningInProgressError: lost a race to a concurrent
-            lifecycle decision while recovering; the caller retries.
+            lifecycle decision while recovering, or the provisioning lock is
+            contended; the attempt is recorded FAILED and the caller retries.
     """
     sandbox_id = reservation.sandbox_id
     tenant_id = reservation.tenant_id
     generation = reservation.generation
     onyx_pat = reservation.onyx_pat
+    attempt_deadline = time.monotonic() + ATTEMPT_DEADLINE_SECONDS
     outcome = (
         (
             SandboxReadyOutcome.REVIVED
@@ -514,7 +547,7 @@ def reconcile_sandbox(
         # Claimed RUNNING: verify the pod actually backs it.
         with time_provision_phase(SandboxProvisionPhase.HEALTH_CHECK):
             healthy = sandbox_manager.health_check(
-                sandbox_id, timeout=_HEALTHCHECK_TIMEOUT_SECONDS
+                sandbox_id, timeout=_HEALTH_PROBE_TIMEOUT_SECONDS
             )
         if healthy:
             return _get_sandbox_committed(db_session, sandbox_id), outcome
@@ -524,9 +557,9 @@ def reconcile_sandbox(
             sandbox_id,
         )
         # Claim the recovery generation BEFORE any destructive external work:
-        # a racing recoverer that loses this CAS must never terminate a
-        # runtime the winner is already rebuilding.
-        new_generation = begin_recovery_attempt_cas__no_commit(
+        # a racing recoverer that loses this compare-and-set must never
+        # terminate a runtime the winner is already rebuilding.
+        new_generation = begin_recovery_attempt__no_commit(
             db_session, sandbox_id, generation
         )
         db_session.commit()
@@ -561,9 +594,21 @@ def reconcile_sandbox(
                 f"Sandbox {sandbox_id} recovery failed: {e}"
             ) from e
 
+    if reservation.terminate_before_provision:
+        try:
+            sandbox_manager.terminate(sandbox_id)
+        except Exception:
+            logger.warning(
+                "Best-effort terminate of stale runtime for sandbox %s before "
+                "re-provision failed; continuing",
+                sandbox_id,
+                exc_info=True,
+            )
+
     # External provisioning against the committed identity. provision()
     # returns only once the sandbox is RUNNING; anything else raises.
     try:
+        _check_attempt_deadline(attempt_deadline, sandbox_id, generation)
         with track_sandbox_provision_in_progress():
             sandbox_manager.provision(
                 sandbox_id=sandbox_id,
@@ -572,6 +617,14 @@ def reconcile_sandbox(
                 onyx_pat=onyx_pat,
                 provisioning_generation=generation,
             )
+    except SandboxProvisionContentionError as e:
+        # A superseded attempt's tail still holds the backend lock. Record
+        # this attempt FAILED (so the row never idles as PROVISIONING) and
+        # surface the retryable error; the caller re-reserves.
+        _record_provisioning_failure(db_session, sandbox_id, generation, e)
+        raise SandboxProvisioningInProgressError(
+            f"Sandbox {sandbox_id} provisioning lock is contended; retry"
+        ) from e
     except Exception as e:
         _record_provisioning_failure(db_session, sandbox_id, generation, e)
         raise SandboxProvisioningError(
@@ -583,6 +636,7 @@ def reconcile_sandbox(
     # finalize the attempt as FAILED — the row cannot be left PROVISIONING
     # until the stale-attempt threshold.
     try:
+        _check_attempt_deadline(attempt_deadline, sandbox_id, generation)
         payload = build_managed_content_payload(user, db_session)
         db_session.commit()
         skills_hydrated = push_managed_content(sandbox_manager, sandbox_id, payload)
@@ -617,8 +671,6 @@ def _wait_for_provisioning_to_complete(
     db_session: DBSession,
     user_id: UUID,
     deadline: float,
-    *,
-    poll_interval_seconds: float = 1.0,
 ) -> None:
     """Poll a ``PROVISIONING`` sandbox with short-lived reads until it
     transitions, its attempt goes stale, or the deadline passes. No
@@ -648,7 +700,7 @@ def _wait_for_provisioning_to_complete(
                 f"Sandbox for user {user_id} still PROVISIONING after "
                 f"{time.monotonic() - started:.1f}s"
             )
-        time.sleep(poll_interval_seconds)
+        time.sleep(POLL_INTERVAL_SECONDS)
 
 
 def ensure_sandbox_ready(
@@ -657,7 +709,7 @@ def ensure_sandbox_ready(
     user_id: UUID,
     *,
     policy: ProvisioningPolicy,
-    provisioning_wait_seconds: float = 30.0,
+    provisioning_wait_seconds: float = PROVISION_WAIT_SECONDS,
 ) -> tuple[Sandbox, SandboxReadyOutcome]:
     """Return the RUNNING sandbox for ``user_id`` (and how it got there),
     creating, waking, or recovering it as needed via reserve → reconcile →
@@ -695,21 +747,27 @@ def ensure_sandbox_ready(
                     raise ValueError(f"User {user_id} not found")
                 reservation = reserve_sandbox__no_commit(db_session, user)
                 db_session.commit()
+                # reconcile stays in the loop: a losing recovery takeover
+                # raises the retryable in-progress error, which POLL re-enters
+                # as a wait.
+                sandbox, outcome = reconcile_sandbox(
+                    db_session, sandbox_manager, reservation, user
+                )
+                return sandbox, outcome
             except SandboxProvisioningInProgressError:
                 db_session.rollback()
                 if policy == ProvisioningPolicy.FAIL:
                     raise
                 _wait_for_provisioning_to_complete(db_session, user_id, deadline)
+                # The wait returns early once the row leaves live-PROVISIONING
+                # (e.g. a contention retry just recorded FAILED); without this
+                # check the loop could spin past the caller's wait budget.
+                if time.monotonic() >= deadline:
+                    raise
                 continue
             except BaseException:
                 db_session.rollback()
                 raise
-            break
-
-        sandbox, outcome = reconcile_sandbox(
-            db_session, sandbox_manager, reservation, user
-        )
-        return sandbox, outcome
     finally:
         observe_sandbox_ready(outcome, time.monotonic() - started_at)
 
@@ -790,7 +848,7 @@ def sleep_sandbox(
             sandbox_manager.create_opencode_history_snapshot(sandbox_id, tenant_id)
         except Exception as e:
             if sandbox_manager.health_check(
-                sandbox_id, timeout=_HEALTHCHECK_TIMEOUT_SECONDS
+                sandbox_id, timeout=_HEALTH_PROBE_TIMEOUT_SECONDS
             ):
                 logger.error(
                     "opencode history snapshot failed for sandbox "
@@ -859,7 +917,7 @@ def sleep_sandbox(
     pod_unreachable = False
     if snapshot_failed:
         if sandbox_manager.health_check(
-            sandbox_id, timeout=_HEALTHCHECK_TIMEOUT_SECONDS
+            sandbox_id, timeout=_HEALTH_PROBE_TIMEOUT_SECONDS
         ):
             logger.error(
                 "Snapshot failed for sandbox %s; "
@@ -902,16 +960,30 @@ def sleep_sandbox(
                 return
 
         # Snapshotting above can take minutes; re-check idleness right before
-        # the kill.
+        # the kill and capture the generation the sleep is fenced against.
         db_session.refresh(sandbox)
         if sandbox.status != SandboxStatus.RUNNING or not is_sandbox_idle(
             sandbox, datetime.now(timezone.utc)
         ):
             logger.info("Sandbox %s went active mid-sweep; skipping reap", sandbox_id)
             return
+        sleep_generation = sandbox.provisioning_generation
 
         # Terminate the pod (but keep the sandbox record).
         sandbox_manager.terminate(sandbox_id)
+
+        # A recovery/create that advanced the generation mid-terminate owns
+        # the sandbox now; only claim ports/sessions if this compare-and-set
+        # wins.
+        if not sleep_running_sandbox__no_commit(
+            db_session, sandbox_id, sleep_generation
+        ):
+            db_session.rollback()
+            logger.warning(
+                "Sandbox %s changed generation during reap; aborting sleep",
+                sandbox_id,
+            )
+            return
 
         # Ports are no longer in use once the pod is gone.
         cleared = clear_nextjs_ports_for_user(db_session, sandbox.user_id)
@@ -922,7 +994,6 @@ def sleep_sandbox(
         idled = mark_user_sessions_idle__no_commit(db_session, sandbox.user_id)
         logger.debug("Marked %s sessions as IDLE for user %s", idled, sandbox.user_id)
 
-        update_sandbox_status__no_commit(db_session, sandbox_id, SandboxStatus.SLEEPING)
         db_session.commit()
         logger.info("Sandbox %s is now sleeping", sandbox_id)
     finally:

--- a/backend/onyx/server/features/build/session/streaming.py
+++ b/backend/onyx/server/features/build/session/streaming.py
@@ -32,7 +32,6 @@ from onyx.db.models import BuildSession
 from onyx.sandbox_proxy import approval_cache
 from onyx.server.features.build import connect_app
 from onyx.server.features.build.configs import (
-    PROMPT_SLOT_KEEP_ALIVE_MAX_SECONDS,
     SANDBOX_HEARTBEAT_REFRESH_INTERVAL_SECONDS,
 )
 from onyx.server.features.build.db.build_session import (
@@ -69,6 +68,7 @@ from onyx.server.features.build.sandbox.models import PromptAttachment
 from onyx.server.features.build.sandbox.opencode.serve_client import _merge_field_meta
 from onyx.server.features.build.sandbox.serve_transport import PromptSlot
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
+from onyx.server.features.build.timeouts import PROMPT_SLOT_KEEP_ALIVE_MAX_SECONDS
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import start_thread_with_context
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR

--- a/backend/onyx/server/features/build/timeouts.py
+++ b/backend/onyx/server/features/build/timeouts.py
@@ -136,24 +136,6 @@ RUNNER_STALE_AFTER_SECONDS = 6 * SSE_KEEPALIVE_INTERVAL
 QUEUE_RESIDENCY_SECONDS = 15 * 60
 
 # =============================================================================
-# Fixed kit — mutexes (critical-section leases, never budget-derived)
-# =============================================================================
-
-# Session create/restore flow lock: held across one full session-flow
-# operation (sandbox attempt + workspace materialization), so the lease is
-# the sum of those deadlines. Deletable once the flows are crash-safe
-# end-to-end without it.
-SESSION_FLOW_LOCK_LEASE_SECONDS = (
-    ATTEMPT_DEADLINE_SECONDS + WORKSPACE_SETUP_DEADLINE_SECONDS
-)
-
-# Prompt-slot acquire policy: a second turn racing a live one bounces fast
-# ("concurrent turn in flight") instead of queueing; a reclaimed turn must
-# instead wait out a dead holder's full lease before taking the slot.
-PROMPT_SLOT_FAST_FAIL_ACQUIRE_SECONDS = 10.0
-PROMPT_SLOT_WAIT_OUT_ORPHAN_SECONDS = PROMPT_SLOT_LEASE_SECONDS + 10.0
-
-# =============================================================================
 # Fixed kit — client I/O taxonomy
 # =============================================================================
 
@@ -170,6 +152,27 @@ RPC_TIMEOUT_SECONDS = 30.0
 # failure, so shrinking this converts slow-but-working snapshots into
 # never-sleeping sandboxes.
 BULK_TRANSFER_TIMEOUT_SECONDS = 300.0
+
+# =============================================================================
+# Fixed kit — mutexes (critical-section leases, never budget-derived)
+# =============================================================================
+
+# Session create/restore flow lock (one per-user lock shared by create,
+# restore, and the reaper): held across one full session-flow operation —
+# sandbox attempt + snapshot restore + workspace materialization — so the
+# lease is the sum of those bounds. Deletable once the flows are crash-safe
+# end-to-end without it.
+SESSION_FLOW_LOCK_LEASE_SECONDS = (
+    ATTEMPT_DEADLINE_SECONDS
+    + BULK_TRANSFER_TIMEOUT_SECONDS
+    + WORKSPACE_SETUP_DEADLINE_SECONDS
+)
+
+# Prompt-slot acquire policy: a second turn racing a live one bounces fast
+# ("concurrent turn in flight") instead of queueing; a reclaimed turn must
+# instead wait out a dead holder's full lease before taking the slot.
+PROMPT_SLOT_FAST_FAIL_ACQUIRE_SECONDS = 10.0
+PROMPT_SLOT_WAIT_OUT_ORPHAN_SECONDS = PROMPT_SLOT_LEASE_SECONDS + 10.0
 
 # =============================================================================
 # Cadences

--- a/backend/onyx/server/features/build/timeouts.py
+++ b/backend/onyx/server/features/build/timeouts.py
@@ -1,0 +1,179 @@
+"""Craft timeout registry.
+
+Every Craft time constant is one of four things:
+
+1. a **root** — a policy number a human chooses,
+2. a **derivation** — arithmetic over a root, encoded here so tuning the root
+   moves every dependent value with it,
+3. the **fixed kit** — genuinely independent short timeouts in a small
+   taxonomy (connect / RPC / bulk transfer / mutex lease), or
+4. a **cadence** — poll and retry intervals.
+
+Correctness never depends on any of these: sandbox ownership is fenced by the
+provisioning-generation compare-and-set, turn ownership by the ``runner_id``
+compare under the turn mutex. Timeouts here only detect failure, bound
+budgets, or pace polling.
+
+Residence rule: a constant lives here only if it is used by multiple files,
+is a derivation (or feeds one), or belongs to the shared client-I/O taxonomy.
+A single-file, free-standing constant is defined at its point of use.
+Env-tunable values (anything with its own ``os.environ`` read) live in
+``configs.py`` even when their default is derived (e.g.
+``OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS``); pure non-tunable derivations
+over those roots live here (e.g. ``RUNNER_STALE_AFTER_SECONDS``).
+
+Ordering invariants (asserted by
+``tests/unit/onyx/server/features/craft/test_timeout_registry.py``):
+
+    cadences < probes/connect < mutex leases < PROVISION_DEADLINE
+      < ATTEMPT_DEADLINE (== observer staleness threshold)
+      < QUEUE_RESIDENCY < TURN_BUDGET < ACTIVE_TURN_TTL < REQUEST_ID_TTL
+    RUNNER_STALE_AFTER == 6 x SSE_KEEPALIVE_INTERVAL
+    OPENCODE_SERVE_EVENT_READ == 4 x SSE_KEEPALIVE_INTERVAL (configs.py)
+    OPENCODE_PROMPT_INACTIVITY > SANDBOX_APPROVAL_WAIT (configs.py)
+    SANDBOX_HEARTBEAT_REFRESH << SANDBOX_IDLE_TIMEOUT (configs.py)
+
+The client-I/O taxonomy (connect / RPC / bulk) is orthogonal to the ordering
+chain — a bulk transfer legitimately outlasts a provision deadline.
+"""
+
+from onyx.server.features.build.configs import (
+    PROMPT_SLOT_LEASE_SECONDS,
+    SSE_KEEPALIVE_INTERVAL,
+)
+
+# =============================================================================
+# Provisioning family (root: PROVISION_DEADLINE_SECONDS)
+# =============================================================================
+
+# Max wall clock for one provision() call to converge a runtime. All internal
+# phases (pod/container scheduling, history restore, readiness, opencode-serve
+# bind, terminating-resource waits) draw from this one deadline. Also the
+# provisioning lock's TTL: the lock never outlives the work it guards.
+PROVISION_DEADLINE_SECONDS = 180.0
+
+# Session-workspace materialization (template copy + bun install) inside an
+# already-RUNNING sandbox. Enforced as an explicit exec deadline paired with a
+# completion sentinel — the Kubernetes exec client returns truncated output
+# without raising when its window lapses, so the sentinel is what
+# distinguishes success from truncation.
+WORKSPACE_SETUP_DEADLINE_SECONDS = PROVISION_DEADLINE_SECONDS
+
+# Best-effort opencode-history capture before terminating an unhealthy
+# sandbox. Small: recovery latency is user-facing and the history snapshot is
+# a nice-to-have, not a gate.
+RECOVERY_HISTORY_SNAPSHOT_SECONDS = 30.0
+
+# Teardown of a dead runtime (Kubernetes deletes are async; this bounds the
+# wait for resources to actually disappear).
+RUNTIME_TEARDOWN_SECONDS = 30.0
+
+# Everything a provisioning attempt spends outside provision() itself.
+ATTEMPT_OVERHEAD_SECONDS = RECOVERY_HISTORY_SNAPSHOT_SECONDS + RUNTIME_TEARDOWN_SECONDS
+
+# Self-enforced deadline of one provisioning attempt AND the observer-side
+# staleness threshold: reconcile aborts (finalizing FAILED) at the same age at
+# which reserve_sandbox declares a committed PROVISIONING row dead and takes
+# it over, so a crashed attempt blocks its sandbox for at most this long. The
+# check runs between external phases, so an in-flight phase can overrun it —
+# takeover safety comes from the provisioning lock and the generation
+# compare-and-set, never from this number.
+ATTEMPT_DEADLINE_SECONDS = PROVISION_DEADLINE_SECONDS + ATTEMPT_OVERHEAD_SECONDS
+
+# How long POLL-policy callers wait out a concurrent live attempt before
+# giving up. Sized to cover a typical full provision: failing earlier just
+# fails a turn the concurrent attempt was about to satisfy.
+PROVISION_WAIT_SECONDS = 120.0
+
+# =============================================================================
+# Turn family (root: TURN_BUDGET_SECONDS)
+# =============================================================================
+
+# Wall-clock budget of one agent turn, interactive or scheduled.
+TURN_BUDGET_SECONDS = 30 * 60
+
+# Margin past the budget before out-of-band cleanup (stuck-run sweeper, turn
+# TTL expiry) treats a run/turn as abandoned: a well-behaved turn that hits
+# its own budget must always finalize itself first.
+TURN_RECLAIM_SLACK_SECONDS = 15 * 60
+
+# Redis TTL of the turn record + active-turn pointer. Refreshed on every
+# heartbeat; the absolute floor is the budget plus slack so a live
+# budget-compliant turn's admission block never evaporates under it.
+ACTIVE_TURN_TTL_SECONDS = TURN_BUDGET_SECONDS + TURN_RECLAIM_SLACK_SECONDS
+
+# Post-terminal retention of the turn record and the client_request_id →
+# turn_id dedupe key: an idempotent send-message retry (or the attach stream
+# reading a FAILED turn's error) must still resolve after the turn finishes.
+TURN_RETENTION_SECONDS = 15 * 60
+REQUEST_ID_TTL_SECONDS = ACTIVE_TURN_TTL_SECONDS + TURN_RETENTION_SECONDS
+
+# Ceiling for background prompt-slot renewal by holders whose progress is
+# client-paced or opaque (session delete, subagent turns). It IS the turn
+# budget: a slot held longer than any turn may run is leaked.
+PROMPT_SLOT_KEEP_ALIVE_MAX_SECONDS = TURN_BUDGET_SECONDS
+
+# =============================================================================
+# Liveness cadence family (root: SSE_KEEPALIVE_INTERVAL, configs.py)
+# =============================================================================
+
+# A turn runner heartbeats on every consumed event, and the transport emits a
+# keepalive at least every SSE_KEEPALIVE_INTERVAL even while the agent is
+# silent — so the runner is dead after k missed keepalives, not after any
+# turn-length-derived time. Derived so env-tuning the keepalive moves this
+# with it; a fixed value would silently break turn recovery.
+RUNNER_STALE_AFTER_SECONDS = 6 * SSE_KEEPALIVE_INTERVAL
+
+# =============================================================================
+# Queue residency family (root: QUEUE_RESIDENCY_SECONDS)
+# =============================================================================
+
+# One policy, three enforcement points: how long a queued scheduled run may
+# sit before (a) Celery expires the message unexecuted and (b) the stuck-run
+# sweeper reclaims its QUEUED row. They must move together or
+# expired-but-unswept / swept-but-unexpired windows appear.
+QUEUE_RESIDENCY_SECONDS = 15 * 60
+
+# =============================================================================
+# Fixed kit — mutexes (critical-section leases, never budget-derived)
+# =============================================================================
+
+# Session create/restore flow lock: held across one full session-flow
+# operation (sandbox attempt + workspace materialization), so the lease is
+# the sum of those deadlines. Deletable once the flows are fenced end-to-end.
+SESSION_FLOW_LOCK_LEASE_SECONDS = (
+    ATTEMPT_DEADLINE_SECONDS + WORKSPACE_SETUP_DEADLINE_SECONDS
+)
+
+# Prompt-slot acquire policy: a second turn racing a live one bounces fast
+# ("concurrent turn in flight") instead of queueing; a reclaimed turn must
+# instead wait out a dead holder's full lease before taking the slot.
+PROMPT_SLOT_FAST_FAIL_ACQUIRE_SECONDS = 10.0
+PROMPT_SLOT_WAIT_OUT_ORPHAN_SECONDS = PROMPT_SLOT_LEASE_SECONDS + 10.0
+
+# =============================================================================
+# Fixed kit — client I/O taxonomy
+# =============================================================================
+
+# Establishing a connection to an in-cluster peer; also full-request probes
+# on hot paths, where any response counts.
+CONNECT_TIMEOUT_SECONDS = 5.0
+
+# Unary request/response calls with small payloads (sidecar directory
+# listings, managed-content pushes — the latter retried on failure).
+RPC_TIMEOUT_SECONDS = 30.0
+
+# Archive upload/download (session snapshots, opencode history). Sized to
+# "snapshotting can take minutes"; the reaper is fail-closed on snapshot
+# failure, so shrinking this converts slow-but-working snapshots into
+# never-sleeping sandboxes.
+BULK_TRANSFER_TIMEOUT_SECONDS = 300.0
+
+# =============================================================================
+# Cadences
+# =============================================================================
+
+# Shared interval for every poll-a-fast-local-resource loop (pod IP, container
+# running, opencode-serve bind, resource deletion, PROVISIONING status,
+# live-stream readiness).
+POLL_INTERVAL_SECONDS = 0.5

--- a/backend/onyx/server/features/build/timeouts.py
+++ b/backend/onyx/server/features/build/timeouts.py
@@ -9,10 +9,11 @@ Every Craft time constant is one of four things:
    taxonomy (connect / RPC / bulk transfer / mutex lease), or
 4. a **cadence** — poll and retry intervals.
 
-Correctness never depends on any of these: sandbox ownership is fenced by the
-provisioning-generation compare-and-set, turn ownership by the ``runner_id``
-compare under the turn mutex. Timeouts here only detect failure, bound
-budgets, or pace polling.
+Correctness never depends on any of these: a sandbox status write only
+applies while the row still holds the writer's attempt number
+(``provisioning_attempt_number``), and a turn write only applies for the owning
+``runner_id``. Timeouts here only detect failure, bound budgets, or pace
+polling.
 
 Residence rule: a constant lives here only if it is used by multiple files,
 is a derivation (or feeds one), or belongs to the shared client-I/O taxonomy.
@@ -76,8 +77,8 @@ ATTEMPT_OVERHEAD_SECONDS = RECOVERY_HISTORY_SNAPSHOT_SECONDS + RUNTIME_TEARDOWN_
 # which reserve_sandbox declares a committed PROVISIONING row dead and takes
 # it over, so a crashed attempt blocks its sandbox for at most this long. The
 # check runs between external phases, so an in-flight phase can overrun it —
-# takeover safety comes from the provisioning lock and the generation
-# compare-and-set, never from this number.
+# takeover safety comes from the provisioning lock and the attempt-number
+# condition on status writes, never from this number.
 ATTEMPT_DEADLINE_SECONDS = PROVISION_DEADLINE_SECONDS + ATTEMPT_OVERHEAD_SECONDS
 
 # How long POLL-policy callers wait out a concurrent live attempt before
@@ -140,7 +141,8 @@ QUEUE_RESIDENCY_SECONDS = 15 * 60
 
 # Session create/restore flow lock: held across one full session-flow
 # operation (sandbox attempt + workspace materialization), so the lease is
-# the sum of those deadlines. Deletable once the flows are fenced end-to-end.
+# the sum of those deadlines. Deletable once the flows are crash-safe
+# end-to-end without it.
 SESSION_FLOW_LOCK_LEASE_SECONDS = (
     ATTEMPT_DEADLINE_SECONDS + WORKSPACE_SETUP_DEADLINE_SECONDS
 )

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -28,9 +28,8 @@ from onyx.server.features.build.db.sandbox import (
     lock_sandbox_skills_hashes,
     set_sandbox_skills_hashes__no_commit,
 )
-from onyx.server.features.build.sandbox.base import SandboxManager
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
-from onyx.server.features.build.sandbox.models import FileSet, PushResult
+from onyx.server.features.build.sandbox.models import FileSet
 from onyx.server.features.build.sandbox.util.agent_instructions import (
     build_connectable_apps_list,
 )
@@ -252,24 +251,6 @@ def build_user_skills_payload(user: User, db_session: Session) -> tuple[str, Fil
         get_connectable_apps_for_user(db_session, user)
     )
     return connectable_apps_section, files
-
-
-def hydrate_sandbox_skills(
-    sandbox_id: UUID,
-    user: User,
-    db_session: Session,
-    *,
-    sandbox_manager: SandboxManager,
-    files: FileSet | None = None,
-) -> PushResult:
-    """Push all visible skills to a single sandbox (cold-start hydration)."""
-    if files is None:
-        files = build_skills_fileset_for_user(user, db_session)
-    return sandbox_manager.push_to_sandbox(
-        sandbox_id=sandbox_id,
-        mount_path=SKILLS_MOUNT_PATH,
-        files=files,
-    )
 
 
 def push_skill_to_affected_sandboxes(skill: Skill, db_session: Session) -> None:

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -285,7 +285,8 @@ class StubSandboxManager(SandboxManager):
         sandbox_id: UUID,
         user_id: UUID,
         tenant_id: str,
-        onyx_pat: str | None = None,
+        onyx_pat: str | None,
+        provisioning_generation: int,
     ) -> SandboxInfo:
         self.provision_count += 1
         self.last_provision_payload = {
@@ -293,6 +294,7 @@ class StubSandboxManager(SandboxManager):
             "user_id": user_id,
             "tenant_id": tenant_id,
             "onyx_pat": onyx_pat,
+            "provisioning_generation": provisioning_generation,
         }
         if self.provision_returns is None:
             raise _not_configured("provision")

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -227,7 +227,6 @@ class StubSandboxManager(SandboxManager):
 
         self.last_provision_payload: dict[str, Any] | None = None
         self.last_terminate_sandbox_id: UUID | None = None
-        self.last_terminate_max_attempt_number: int | None = None
         self.last_setup_session_workspace_payload: dict[str, Any] | None = None
         self.last_cleanup_session_workspace_payload: dict[str, Any] | None = None
         self.last_regenerate_session_config_payload: dict[str, Any] | None = None
@@ -301,12 +300,9 @@ class StubSandboxManager(SandboxManager):
             raise _not_configured("provision")
         return self.provision_returns
 
-    def terminate(
-        self, sandbox_id: UUID, max_attempt_number: int | None = None
-    ) -> None:
+    def terminate(self, sandbox_id: UUID) -> None:
         self.terminate_count += 1
         self.last_terminate_sandbox_id = sandbox_id
-        self.last_terminate_max_attempt_number = max_attempt_number
         self.terminated_sandbox_ids.append(sandbox_id)
         if not self.terminate_silent:
             raise _not_configured("terminate")

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -227,6 +227,7 @@ class StubSandboxManager(SandboxManager):
 
         self.last_provision_payload: dict[str, Any] | None = None
         self.last_terminate_sandbox_id: UUID | None = None
+        self.last_terminate_max_attempt_number: int | None = None
         self.last_setup_session_workspace_payload: dict[str, Any] | None = None
         self.last_cleanup_session_workspace_payload: dict[str, Any] | None = None
         self.last_regenerate_session_config_payload: dict[str, Any] | None = None
@@ -300,9 +301,12 @@ class StubSandboxManager(SandboxManager):
             raise _not_configured("provision")
         return self.provision_returns
 
-    def terminate(self, sandbox_id: UUID) -> None:
+    def terminate(
+        self, sandbox_id: UUID, max_attempt_number: int | None = None
+    ) -> None:
         self.terminate_count += 1
         self.last_terminate_sandbox_id = sandbox_id
+        self.last_terminate_max_attempt_number = max_attempt_number
         self.terminated_sandbox_ids.append(sandbox_id)
         if not self.terminate_silent:
             raise _not_configured("terminate")

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -460,7 +460,7 @@ class StubSandboxManager(SandboxManager):
             raise _not_configured("list_session_workspaces")
         return list(self.list_session_workspaces_returns)
 
-    def health_check(self, sandbox_id: UUID, timeout: float = 60.0) -> bool:
+    def health_check(self, sandbox_id: UUID, timeout: float) -> bool:
         self.health_check_count += 1
         self.last_health_check_payload = {
             "sandbox_id": sandbox_id,

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -286,7 +286,7 @@ class StubSandboxManager(SandboxManager):
         user_id: UUID,
         tenant_id: str,
         onyx_pat: str | None,
-        provisioning_generation: int,
+        provisioning_attempt_number: int,
     ) -> SandboxInfo:
         self.provision_count += 1
         self.last_provision_payload = {
@@ -294,7 +294,7 @@ class StubSandboxManager(SandboxManager):
             "user_id": user_id,
             "tenant_id": tenant_id,
             "onyx_pat": onyx_pat,
-            "provisioning_generation": provisioning_generation,
+            "provisioning_attempt_number": provisioning_attempt_number,
         }
         if self.provision_returns is None:
             raise _not_configured("provision")

--- a/backend/tests/external_dependency_unit/craft/conftest.py
+++ b/backend/tests/external_dependency_unit/craft/conftest.py
@@ -6,6 +6,7 @@ import hashlib
 import io
 import zipfile
 from collections.abc import Callable, Generator, Iterable
+from datetime import datetime, timezone
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -40,10 +41,7 @@ from onyx.db.models import (
 )
 from onyx.file_store.file_store import get_default_file_store
 from onyx.llm.constants import LlmProviderNames
-from onyx.server.features.build.db.sandbox import (
-    create_sandbox__no_commit,
-    update_sandbox_status__no_commit,
-)
+from onyx.server.features.build.db.sandbox import create_sandbox__no_commit
 from onyx.server.features.build.session import llm_config
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.manage.llm.models import (
@@ -215,7 +213,11 @@ def sandbox(
         owner = user or test_user
         row = create_sandbox__no_commit(db_session=db_session, user_id=owner.id)
         if status != SandboxStatus.PROVISIONING:
-            update_sandbox_status__no_commit(db_session, row.id, status)
+            # Raw seed of an arbitrary lifecycle state; production writes go
+            # through the attempt-numbered helpers.
+            row.status = status
+            if status == SandboxStatus.RUNNING:
+                row.last_heartbeat = datetime.now(timezone.utc)
         db_session.commit()
         db_session.refresh(row)
         return row

--- a/backend/tests/external_dependency_unit/craft/test_built_in_skill_seeding.py
+++ b/backend/tests/external_dependency_unit/craft/test_built_in_skill_seeding.py
@@ -109,7 +109,7 @@ class TestAvailabilityGate:
             )
             if s.built_in_skill_id is not None
         }
-        # Some built-ins gate on environment availability (e.g. image-generation
+        # Some built-ins gate on environment availability (e.g. image-attempt_number
         # needs a configured provider); only those available here must be visible.
         available_built_ins = {
             built_in_skill_id

--- a/backend/tests/external_dependency_unit/craft/test_built_in_skill_seeding.py
+++ b/backend/tests/external_dependency_unit/craft/test_built_in_skill_seeding.py
@@ -109,7 +109,7 @@ class TestAvailabilityGate:
             )
             if s.built_in_skill_id is not None
         }
-        # Some built-ins gate on environment availability (e.g. image-attempt_number
+        # Some built-ins gate on environment availability (e.g. image-generation
         # needs a configured provider); only those available here must be visible.
         available_built_ins = {
             built_in_skill_id

--- a/backend/tests/external_dependency_unit/craft/test_durable_provisioning.py
+++ b/backend/tests/external_dependency_unit/craft/test_durable_provisioning.py
@@ -3,13 +3,13 @@
 Pins the transaction-ordering contract with real PostgreSQL and a controlled
 sandbox-manager double:
 
-* the sandbox identity, owner, PAT, and generation are committed — and
+* the sandbox identity, owner, PAT, and attempt_number are committed — and
   visible to an independent database connection — before the first external
   provisioning call, with no transaction left open on the flow's session;
 * a simulated process death mid-provision leaves resumable committed state
-  that a retry converges on (same sandbox ID, advanced generation);
+  that a retry converges on (same sandbox ID, advanced attempt_number);
 * a death mid-session-initialization is repaired under the same session ID;
-* a stale generation cannot finalize a newer one;
+* a stale attempt_number cannot finalize a newer one;
 * session initialization failure marks only the session FAILED while the
   sandbox stays RUNNING;
 * concurrent creators converge on one sandbox and one empty session.
@@ -71,7 +71,7 @@ class _ReservationProbe:
     sandbox_visible: bool = False
     owner_user_id: UUID | None = None
     status: SandboxStatus | None = None
-    generation: int | None = None
+    attempt_number: int | None = None
     pat_present: bool = False
     pat_row_valid: bool = False
 
@@ -91,7 +91,7 @@ class _ProbingStub(StubSandboxManager):
         user_id: UUID,
         tenant_id: str,
         onyx_pat: str | None,
-        provisioning_generation: int,
+        provisioning_attempt_number: int,
     ) -> SandboxInfo:
         probe = _ReservationProbe(
             flow_session_in_transaction=self._flow_db_session.in_transaction(),
@@ -106,7 +106,7 @@ class _ProbingStub(StubSandboxManager):
             if row is not None:
                 probe.owner_user_id = row.user_id
                 probe.status = row.status
-                probe.generation = row.provisioning_generation
+                probe.attempt_number = row.provisioning_attempt_number
                 raw_pat = (
                     row.encrypted_pat.get_value(apply_mask=False)
                     if row.encrypted_pat
@@ -130,7 +130,7 @@ class _ProbingStub(StubSandboxManager):
             user_id,
             tenant_id,
             onyx_pat=onyx_pat,
-            provisioning_generation=provisioning_generation,
+            provisioning_attempt_number=provisioning_attempt_number,
         )
 
 
@@ -157,7 +157,7 @@ def test_reservation_committed_and_visible_before_first_external_call(
     assert stub.probe.sandbox_visible is True
     assert stub.probe.owner_user_id == test_user.id
     assert stub.probe.status == SandboxStatus.PROVISIONING
-    assert stub.probe.generation == 1
+    assert stub.probe.attempt_number == 1
     assert stub.probe.pat_present is True
     assert stub.probe.pat_row_valid is True
     assert stub.probe.flow_session_in_transaction is False
@@ -183,14 +183,14 @@ def test_interrupted_provision_resumes_same_sandbox_identity(
         interrupted_id = interrupted.id
         # Process death leaves the committed reservation, not FAILED.
         assert interrupted.status == SandboxStatus.PROVISIONING
-        assert interrupted.provisioning_generation == 1
+        assert interrupted.provisioning_attempt_number == 1
 
         # A live attempt is not taken over.
         with pytest.raises(SandboxProvisioningInProgressError):
             session_manager_with_stub.get_or_create_empty_session(user_id=test_user.id)
 
     # Once the attempt is stale, a retry resumes the same identity under a
-    # new generation.
+    # new attempt_number.
     db_session.rollback()
     interrupted.provisioning_started_at = datetime.now(timezone.utc) - timedelta(
         minutes=10
@@ -212,7 +212,7 @@ def test_interrupted_provision_resumes_same_sandbox_identity(
     assert len(rows) == 1
     assert rows[0].id == interrupted_id
     assert rows[0].status == SandboxStatus.RUNNING
-    assert rows[0].provisioning_generation == 2
+    assert rows[0].provisioning_attempt_number == 2
     db_session.refresh(result)
     assert result.status == BuildSessionStatus.ACTIVE
 
@@ -304,26 +304,26 @@ def test_stale_generation_cannot_finalize_newer_generation(
     sandbox: Callable[..., Sandbox],
 ) -> None:
     row = sandbox(user=test_user, status=SandboxStatus.SLEEPING)
-    stale_generation = begin_provisioning_attempt__no_commit(db_session, row)
+    stale_attempt_number = begin_provisioning_attempt__no_commit(db_session, row)
     db_session.commit()
 
     # A newer reservation takes over (e.g. the first attempt went stale).
-    newer_generation = begin_provisioning_attempt__no_commit(db_session, row)
+    newer_attempt_number = begin_provisioning_attempt__no_commit(db_session, row)
     db_session.commit()
-    assert newer_generation == stale_generation + 1
+    assert newer_attempt_number == stale_attempt_number + 1
 
     # The stale attempt's finalize must be a no-op.
     assert not finalize_provisioning_attempt__no_commit(
-        db_session, row.id, stale_generation, SandboxStatus.RUNNING
+        db_session, row.id, stale_attempt_number, SandboxStatus.RUNNING
     )
     db_session.commit()
     db_session.refresh(row)
     assert row.status == SandboxStatus.PROVISIONING
-    assert row.provisioning_generation == newer_generation
+    assert row.provisioning_attempt_number == newer_attempt_number
 
     # The current attempt finalizes normally.
     assert finalize_provisioning_attempt__no_commit(
-        db_session, row.id, newer_generation, SandboxStatus.RUNNING
+        db_session, row.id, newer_attempt_number, SandboxStatus.RUNNING
     )
     db_session.commit()
     db_session.refresh(row)
@@ -405,8 +405,8 @@ def test_concurrent_creators_converge_on_one_sandbox_and_session(
         thread.join(timeout=60)
 
     # Convergence: at least one creator succeeded; a loser may only fail
-    # with a retryable fencing signal (a live concurrent attempt, or its
-    # finalize losing the compare-and-set to the winner).
+    # retryably (a live concurrent attempt, or its finalize rejected because
+    # the winner's attempt superseded it).
     assert results, f"no creator succeeded; errors: {errors}"
     for error in errors:
         assert isinstance(

--- a/backend/tests/external_dependency_unit/craft/test_durable_provisioning.py
+++ b/backend/tests/external_dependency_unit/craft/test_durable_provisioning.py
@@ -1,0 +1,388 @@
+"""Durable provisioning lifecycle: reserve → reconcile → finalize.
+
+Pins the transaction-ordering contract with real PostgreSQL and a controlled
+sandbox-manager double:
+
+* the sandbox identity, owner, PAT, and generation are committed — and
+  visible to an independent database connection — before the first external
+  provisioning call, with no transaction left open on the flow's session;
+* a simulated process death mid-provision leaves resumable committed state
+  that a retry converges on (same sandbox ID, advanced generation);
+* a death mid-session-initialization is repaired under the same session ID;
+* a stale generation cannot finalize a newer one;
+* session initialization failure marks only the session FAILED while the
+  sandbox stays RUNNING;
+* concurrent creators converge on one sandbox and one empty session.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.auth.pat import hash_pat
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import BuildSessionStatus, Permission, SandboxStatus
+from onyx.db.models import BuildSession, PersonalAccessToken, Sandbox, User
+from onyx.server.features.build.db.sandbox import (
+    begin_provisioning_attempt__no_commit,
+    finalize_provisioning_attempt__no_commit,
+    get_sandbox_by_user_id,
+)
+from onyx.server.features.build.sandbox.models import SandboxInfo
+from onyx.server.features.build.session.errors import (
+    SandboxProvisioningInProgressError,
+    StaleProvisioningAttemptError,
+)
+from onyx.server.features.build.session.manager import SessionManager
+from onyx.utils.threadpool_concurrency import start_thread_with_context
+from tests.common.craft.stubs import StubSandboxManager
+
+
+class _SimulatedProcessDeath(BaseException):
+    """Escapes the ``except Exception`` failure recording, mimicking an API
+    process dying mid-call (no FAILED transition is written)."""
+
+
+def _running_info(sandbox_id: UUID) -> SandboxInfo:
+    return SandboxInfo(
+        sandbox_id=sandbox_id,
+        directory_path="/tmp/sandbox",
+        status=SandboxStatus.RUNNING,
+        last_heartbeat=None,
+    )
+
+
+@dataclass
+class _ReservationProbe:
+    """What an independent database connection could see mid-provision."""
+
+    flow_session_in_transaction: bool
+    sandbox_visible: bool = False
+    owner_user_id: UUID | None = None
+    status: SandboxStatus | None = None
+    generation: int | None = None
+    pat_present: bool = False
+    pat_row_valid: bool = False
+
+
+class _ProbingStub(StubSandboxManager):
+    """On ``provision``, inspects committed state through an independent
+    database connection and records what it could see."""
+
+    def __init__(self, flow_db_session: Session) -> None:
+        super().__init__()
+        self._flow_db_session = flow_db_session
+        self.probe: _ReservationProbe | None = None
+
+    def provision(
+        self,
+        sandbox_id: UUID,
+        user_id: UUID,
+        tenant_id: str,
+        onyx_pat: str | None,
+        provisioning_generation: int,
+    ) -> SandboxInfo:
+        probe = _ReservationProbe(
+            flow_session_in_transaction=self._flow_db_session.in_transaction(),
+        )
+        with get_session_with_current_tenant() as probe_session:
+            row = (
+                probe_session.query(Sandbox)
+                .filter(Sandbox.id == sandbox_id)
+                .one_or_none()
+            )
+            probe.sandbox_visible = row is not None
+            if row is not None:
+                probe.owner_user_id = row.user_id
+                probe.status = row.status
+                probe.generation = row.provisioning_generation
+                raw_pat = (
+                    row.encrypted_pat.get_value(apply_mask=False)
+                    if row.encrypted_pat
+                    else None
+                )
+                probe.pat_present = raw_pat is not None
+                if raw_pat is not None:
+                    pat_row = (
+                        probe_session.query(PersonalAccessToken)
+                        .filter(PersonalAccessToken.hashed_token == hash_pat(raw_pat))
+                        .one_or_none()
+                    )
+                    probe.pat_row_valid = (
+                        pat_row is not None
+                        and pat_row.user_id == user_id
+                        and pat_row.scopes == [Permission.CRAFT_SANDBOX.value]
+                    )
+        self.probe = probe
+        return super().provision(
+            sandbox_id,
+            user_id,
+            tenant_id,
+            onyx_pat=onyx_pat,
+            provisioning_generation=provisioning_generation,
+        )
+
+
+def test_reservation_committed_and_visible_before_first_external_call(
+    db_session: Session,
+    test_user: User,
+    session_manager_with_stub: SessionManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _ProbingStub(db_session)
+    stub.provision_returns = _running_info(uuid4())
+    stub.setup_session_workspace_silent = True
+    stub.write_files_to_sandbox_silent = True
+    stub.write_sandbox_file_silent = True
+    monkeypatch.setattr(session_manager_with_stub, "_sandbox_manager", stub)
+
+    session_manager_with_stub.get_or_create_empty_session(user_id=test_user.id)
+
+    assert stub.probe is not None
+    # The bootstrap identity was durable before the pod existed: another
+    # connection resolves the owner and validates the PAT (exactly what the
+    # egress proxy does for npm bootstrap), while the flow's own session
+    # holds no open transaction across the external call.
+    assert stub.probe.sandbox_visible is True
+    assert stub.probe.owner_user_id == test_user.id
+    assert stub.probe.status == SandboxStatus.PROVISIONING
+    assert stub.probe.generation == 1
+    assert stub.probe.pat_present is True
+    assert stub.probe.pat_row_valid is True
+    assert stub.probe.flow_session_in_transaction is False
+
+
+def test_interrupted_provision_resumes_same_sandbox_identity(
+    db_session: Session,
+    test_user: User,
+    stub_sandbox_manager: StubSandboxManager,
+    session_manager_with_stub: SessionManager,
+) -> None:
+    def _die(*_args: object, **_kwargs: object) -> SandboxInfo:
+        raise _SimulatedProcessDeath()
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(stub_sandbox_manager, "provision", _die)
+        with pytest.raises(_SimulatedProcessDeath):
+            session_manager_with_stub.get_or_create_empty_session(user_id=test_user.id)
+
+        db_session.rollback()
+        interrupted = get_sandbox_by_user_id(db_session, test_user.id)
+        assert interrupted is not None
+        interrupted_id = interrupted.id
+        # Process death leaves the committed reservation, not FAILED.
+        assert interrupted.status == SandboxStatus.PROVISIONING
+        assert interrupted.provisioning_generation == 1
+
+        # A live attempt is not taken over.
+        with pytest.raises(SandboxProvisioningInProgressError):
+            session_manager_with_stub.get_or_create_empty_session(user_id=test_user.id)
+
+    # Once the attempt is stale, a retry resumes the same identity under a
+    # new generation.
+    db_session.rollback()
+    interrupted.provisioning_started_at = datetime.now(timezone.utc) - timedelta(
+        minutes=10
+    )
+    db_session.commit()
+    stub_sandbox_manager.provision_returns = _running_info(interrupted_id)
+    stub_sandbox_manager.setup_session_workspace_silent = True
+    stub_sandbox_manager.write_files_to_sandbox_silent = True
+    stub_sandbox_manager.write_sandbox_file_silent = True
+
+    result = session_manager_with_stub.get_or_create_empty_session(user_id=test_user.id)
+
+    rows = db_session.query(Sandbox).filter(Sandbox.user_id == test_user.id).all()
+    assert len(rows) == 1
+    assert rows[0].id == interrupted_id
+    assert rows[0].status == SandboxStatus.RUNNING
+    assert rows[0].provisioning_generation == 2
+    db_session.refresh(result)
+    assert result.status == BuildSessionStatus.ACTIVE
+
+
+def test_interrupted_session_initialization_repaired_under_same_id(
+    db_session: Session,
+    test_user: User,
+    stub_sandbox_manager: StubSandboxManager,
+    session_manager_with_stub: SessionManager,
+) -> None:
+    stub_sandbox_manager.provision_returns = _running_info(uuid4())
+    stub_sandbox_manager.write_files_to_sandbox_silent = True
+    stub_sandbox_manager.write_sandbox_file_silent = True
+    stub_sandbox_manager.health_check_returns = True
+
+    def _die(*_args: object, **_kwargs: object) -> None:
+        raise _SimulatedProcessDeath()
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(stub_sandbox_manager, "setup_session_workspace", _die)
+        with pytest.raises(_SimulatedProcessDeath):
+            session_manager_with_stub.get_or_create_empty_session(user_id=test_user.id)
+
+    db_session.rollback()
+    reserved = (
+        db_session.query(BuildSession)
+        .filter(BuildSession.user_id == test_user.id)
+        .one()
+    )
+    # Death mid-initialization leaves the committed INITIALIZING identity
+    # (BaseException bypasses the FAILED recording, like a process crash).
+    assert reserved.status == BuildSessionStatus.INITIALIZING
+    reserved_id = reserved.id
+    reserved_port = reserved.nextjs_port
+    assert reserved_port is not None
+
+    stub_sandbox_manager.setup_session_workspace_silent = True
+    stub_sandbox_manager.session_workspace_exists_returns = False
+
+    repaired = session_manager_with_stub.get_or_create_empty_session(
+        user_id=test_user.id
+    )
+
+    # Same committed session identity and port, now finalized ACTIVE.
+    assert repaired.id == reserved_id
+    db_session.refresh(repaired)
+    assert repaired.status == BuildSessionStatus.ACTIVE
+    assert repaired.nextjs_port == reserved_port
+    rows = (
+        db_session.query(BuildSession)
+        .filter(BuildSession.user_id == test_user.id)
+        .all()
+    )
+    assert len(rows) == 1
+
+
+def test_stale_generation_cannot_finalize_newer_generation(
+    db_session: Session,
+    test_user: User,
+    sandbox: Callable[..., Sandbox],
+) -> None:
+    row = sandbox(user=test_user, status=SandboxStatus.SLEEPING)
+    stale_generation = begin_provisioning_attempt__no_commit(db_session, row)
+    db_session.commit()
+
+    # A newer reservation takes over (e.g. the first attempt went stale).
+    newer_generation = begin_provisioning_attempt__no_commit(db_session, row)
+    db_session.commit()
+    assert newer_generation == stale_generation + 1
+
+    # The stale attempt's finalize must be a no-op.
+    assert not finalize_provisioning_attempt__no_commit(
+        db_session, row.id, stale_generation, SandboxStatus.RUNNING
+    )
+    db_session.commit()
+    db_session.refresh(row)
+    assert row.status == SandboxStatus.PROVISIONING
+    assert row.provisioning_generation == newer_generation
+
+    # The current attempt finalizes normally.
+    assert finalize_provisioning_attempt__no_commit(
+        db_session, row.id, newer_generation, SandboxStatus.RUNNING
+    )
+    db_session.commit()
+    db_session.refresh(row)
+    assert row.status == SandboxStatus.RUNNING
+
+
+def test_session_failure_leaves_sandbox_running_session_failed(
+    db_session: Session,
+    test_user: User,
+    stub_sandbox_manager: StubSandboxManager,
+    session_manager_with_stub: SessionManager,
+) -> None:
+    stub_sandbox_manager.provision_returns = _running_info(uuid4())
+    stub_sandbox_manager.write_files_to_sandbox_silent = True
+    stub_sandbox_manager.write_sandbox_file_silent = True
+    # setup_session_workspace left unconfigured => raises on call.
+
+    with pytest.raises(RuntimeError):
+        session_manager_with_stub.get_or_create_empty_session(user_id=test_user.id)
+
+    db_session.rollback()
+    sandbox_row = get_sandbox_by_user_id(db_session, test_user.id)
+    session_row = (
+        db_session.query(BuildSession)
+        .filter(BuildSession.user_id == test_user.id)
+        .one()
+    )
+    # Sandbox readiness and session readiness are separate: the healthy
+    # sandbox stays RUNNING while only the session records the failure.
+    assert sandbox_row is not None
+    assert sandbox_row.status == SandboxStatus.RUNNING
+    assert session_row.status == BuildSessionStatus.FAILED
+    failed_id = session_row.id
+
+    # Retry repairs the same session ID.
+    stub_sandbox_manager.health_check_returns = True
+    stub_sandbox_manager.session_workspace_exists_returns = False
+    stub_sandbox_manager.setup_session_workspace_silent = True
+
+    repaired = session_manager_with_stub.get_or_create_empty_session(
+        user_id=test_user.id
+    )
+    assert repaired.id == failed_id
+    db_session.refresh(repaired)
+    assert repaired.status == BuildSessionStatus.ACTIVE
+
+
+def test_concurrent_creators_converge_on_one_sandbox_and_session(
+    db_session: Session,
+    test_user: User,
+    stub_sandbox_manager: StubSandboxManager,
+    session_manager_with_stub: SessionManager,  # noqa: ARG001 — patches the factory
+) -> None:
+    stub_sandbox_manager.provision_returns = _running_info(uuid4())
+    stub_sandbox_manager.health_check_returns = True
+    stub_sandbox_manager.session_workspace_exists_returns = True
+    stub_sandbox_manager.setup_session_workspace_silent = True
+    stub_sandbox_manager.write_files_to_sandbox_silent = True
+    stub_sandbox_manager.write_sandbox_file_silent = True
+    stub_sandbox_manager.read_file_returns = b"{}"
+    stub_sandbox_manager.regenerate_session_config_silent = True
+    stub_sandbox_manager.dispose_opencode_instance_silent = True
+
+    results: list[UUID] = []
+    errors: list[BaseException] = []
+
+    def _create() -> None:
+        try:
+            with get_session_with_current_tenant() as thread_session:
+                manager = SessionManager(thread_session)
+                manager._sandbox_manager = stub_sandbox_manager
+                created = manager.get_or_create_empty_session(user_id=test_user.id)
+                results.append(created.id)
+        except BaseException as e:  # noqa: BLE001 — collected for assertions
+            errors.append(e)
+
+    threads = [start_thread_with_context(_create) for _ in range(2)]
+    for thread in threads:
+        thread.join(timeout=60)
+
+    # Convergence: at least one creator succeeded; a loser may only fail
+    # with a retryable fencing signal (a live concurrent attempt, or its
+    # finalize losing the compare-and-set to the winner).
+    assert results, f"no creator succeeded; errors: {errors}"
+    for error in errors:
+        assert isinstance(
+            error,
+            (SandboxProvisioningInProgressError, StaleProvisioningAttemptError),
+        )
+
+    sandbox_rows = (
+        db_session.query(Sandbox).filter(Sandbox.user_id == test_user.id).all()
+    )
+    session_rows = (
+        db_session.query(BuildSession)
+        .filter(BuildSession.user_id == test_user.id)
+        .all()
+    )
+    assert len(sandbox_rows) == 1
+    assert len(session_rows) == 1
+    assert all(result == session_rows[0].id for result in results)

--- a/backend/tests/external_dependency_unit/craft/test_durable_provisioning.py
+++ b/backend/tests/external_dependency_unit/craft/test_durable_provisioning.py
@@ -36,10 +36,15 @@ from onyx.server.features.build.db.sandbox import (
 )
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.session.errors import (
+    SandboxProvisioningError,
     SandboxProvisioningInProgressError,
     StaleProvisioningAttemptError,
 )
 from onyx.server.features.build.session.manager import SessionManager
+from onyx.server.features.build.session.sandbox_lifecycle import (
+    ProvisioningPolicy,
+    ensure_sandbox_ready,
+)
 from onyx.utils.threadpool_concurrency import start_thread_with_context
 from tests.common.craft.stubs import StubSandboxManager
 
@@ -195,6 +200,11 @@ def test_interrupted_provision_resumes_same_sandbox_identity(
     stub_sandbox_manager.setup_session_workspace_silent = True
     stub_sandbox_manager.write_files_to_sandbox_silent = True
     stub_sandbox_manager.write_sandbox_file_silent = True
+    # Taking over a stale PROVISIONING attempt tears down its half-built
+    # runtime before re-provisioning.
+    stub_sandbox_manager.terminate_silent = True
+    # The reused empty session takes the workspace-missing repair path.
+    stub_sandbox_manager.session_workspace_exists_returns = False
 
     result = session_manager_with_stub.get_or_create_empty_session(user_id=test_user.id)
 
@@ -257,6 +267,35 @@ def test_interrupted_session_initialization_repaired_under_same_id(
         .all()
     )
     assert len(rows) == 1
+
+
+def test_attempt_self_deadline_finalizes_failed_before_external_work(
+    db_session: Session,
+    test_user: User,
+    stub_sandbox_manager: StubSandboxManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An attempt past ``ATTEMPT_DEADLINE_SECONDS`` aborts itself, recording
+    FAILED durably without ever reaching ``provision()`` — the same number
+    observers use to declare the attempt stale."""
+    monkeypatch.setattr(
+        "onyx.server.features.build.session.sandbox_lifecycle.ATTEMPT_DEADLINE_SECONDS",
+        -1.0,
+    )
+
+    with pytest.raises(SandboxProvisioningError):
+        ensure_sandbox_ready(
+            db_session,
+            stub_sandbox_manager,
+            test_user.id,
+            policy=ProvisioningPolicy.FAIL,
+        )
+
+    db_session.rollback()
+    sandbox = get_sandbox_by_user_id(db_session, test_user.id)
+    assert sandbox is not None
+    assert sandbox.status == SandboxStatus.FAILED
+    assert stub_sandbox_manager.provision_count == 0
 
 
 def test_stale_generation_cannot_finalize_newer_generation(

--- a/backend/tests/external_dependency_unit/craft/test_durable_provisioning.py
+++ b/backend/tests/external_dependency_unit/craft/test_durable_provisioning.py
@@ -3,13 +3,13 @@
 Pins the transaction-ordering contract with real PostgreSQL and a controlled
 sandbox-manager double:
 
-* the sandbox identity, owner, PAT, and attempt_number are committed — and
+* the sandbox identity, owner, PAT, and attempt number are committed — and
   visible to an independent database connection — before the first external
   provisioning call, with no transaction left open on the flow's session;
 * a simulated process death mid-provision leaves resumable committed state
-  that a retry converges on (same sandbox ID, advanced attempt_number);
+  that a retry converges on (same sandbox ID, new attempt number);
 * a death mid-session-initialization is repaired under the same session ID;
-* a stale attempt_number cannot finalize a newer one;
+* a superseded attempt cannot finalize over a newer one;
 * session initialization failure marks only the session FAILED while the
   sandbox stays RUNNING;
 * concurrent creators converge on one sandbox and one empty session.
@@ -190,7 +190,7 @@ def test_interrupted_provision_resumes_same_sandbox_identity(
             session_manager_with_stub.get_or_create_empty_session(user_id=test_user.id)
 
     # Once the attempt is stale, a retry resumes the same identity under a
-    # new attempt_number.
+    # new attempt number.
     db_session.rollback()
     interrupted.provisioning_started_at = datetime.now(timezone.utc) - timedelta(
         minutes=10

--- a/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
+++ b/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
@@ -231,7 +231,7 @@ def test_stale_provisioning_attempt_is_taken_over(
     session_manager_with_stub: SessionManager,
 ) -> None:
     """A committed PROVISIONING row whose attempt is dead (no live timestamp —
-    e.g. the provisioning process crashed) is resumed under a new generation
+    e.g. the provisioning process crashed) is resumed under a new attempt_number
     instead of being waited on or rejected."""
     existing = sandbox(user=test_user, status=SandboxStatus.PROVISIONING)
     assert existing.provisioning_started_at is None  # crashed-attempt shape

--- a/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
+++ b/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
@@ -20,6 +20,7 @@ manager method, so each test must declare the slice of the manager it uses.
 from __future__ import annotations
 
 from collections.abc import Callable
+from datetime import datetime, timezone
 from uuid import UUID, uuid4
 
 import pytest
@@ -153,6 +154,10 @@ def test_provisioning_transitions_to_running_during_wait(
     """A concurrent provisioner finishes mid-wait: re-enter the state machine on
     the new RUNNING status and return it without provisioning ourselves."""
     existing = sandbox(user=test_user, status=SandboxStatus.PROVISIONING)
+    # A recent attempt timestamp marks the concurrent provisioner as live —
+    # a stale (or NULL) timestamp would be taken over instead of waited on.
+    existing.provisioning_started_at = datetime.now(timezone.utc)
+    db_session.commit()
 
     # Simulate the "other" provisioner finishing: the poll loop's first
     # ``time.sleep`` flips the row to RUNNING and commits so the next
@@ -192,12 +197,14 @@ def test_provisioning_times_out_raises(
     stub_sandbox_manager: StubSandboxManager,
     session_manager_with_stub: SessionManager,
 ) -> None:
-    """Stuck PROVISIONING + 0s wait -> ``SandboxProvisioningError`` without provisioning.
+    """Live PROVISIONING + 0s wait -> ``SandboxProvisioningError`` without provisioning.
 
     This is the deterministic-timeout contract that
     ``test_scheduled_task_executor.py::test_run_fails_when_wake_fails`` relies on.
     """
     existing = sandbox(user=test_user, status=SandboxStatus.PROVISIONING)
+    existing.provisioning_started_at = datetime.now(timezone.utc)
+    db_session.commit()
 
     with pytest.raises(SandboxProvisioningError):
         session_manager_with_stub.ensure_sandbox_running(
@@ -212,3 +219,29 @@ def test_provisioning_times_out_raises(
     assert refreshed is not None
     assert refreshed.id == existing.id
     assert refreshed.status == SandboxStatus.PROVISIONING
+
+
+def test_stale_provisioning_attempt_is_taken_over(
+    db_session: Session,  # noqa: ARG001
+    test_user: User,
+    sandbox: Callable[..., Sandbox],
+    stub_sandbox_manager: StubSandboxManager,
+    session_manager_with_stub: SessionManager,
+) -> None:
+    """A committed PROVISIONING row whose attempt is dead (no live timestamp —
+    e.g. the provisioning process crashed) is resumed under a new generation
+    instead of being waited on or rejected."""
+    existing = sandbox(user=test_user, status=SandboxStatus.PROVISIONING)
+    assert existing.provisioning_started_at is None  # crashed-attempt shape
+
+    stub_sandbox_manager.provision_returns = _running_info(existing.id)
+    stub_sandbox_manager.write_files_to_sandbox_silent = True
+
+    result = session_manager_with_stub.ensure_sandbox_running(
+        test_user.id,
+        provisioning_wait_seconds=0.0,
+    )
+
+    assert result.id == existing.id
+    assert result.status == SandboxStatus.RUNNING
+    assert stub_sandbox_manager.provision_count == 1

--- a/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
+++ b/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
@@ -132,6 +132,8 @@ def test_wakes_dormant_sandbox(
     existing = sandbox(user=test_user, status=initial_status)
     stub_sandbox_manager.provision_returns = _running_info(existing.id)
     stub_sandbox_manager.write_files_to_sandbox_silent = True
+    # A FAILED revive tears down any wedged runtime before re-provisioning.
+    stub_sandbox_manager.terminate_silent = True
 
     result = session_manager_with_stub.ensure_sandbox_running(test_user.id)
     db_session.commit()
@@ -236,6 +238,8 @@ def test_stale_provisioning_attempt_is_taken_over(
 
     stub_sandbox_manager.provision_returns = _running_info(existing.id)
     stub_sandbox_manager.write_files_to_sandbox_silent = True
+    # Taking over a stale attempt tears down its half-built runtime first.
+    stub_sandbox_manager.terminate_silent = True
 
     result = session_manager_with_stub.ensure_sandbox_running(
         test_user.id,

--- a/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
+++ b/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
@@ -231,7 +231,7 @@ def test_stale_provisioning_attempt_is_taken_over(
     session_manager_with_stub: SessionManager,
 ) -> None:
     """A committed PROVISIONING row whose attempt is dead (no live timestamp —
-    e.g. the provisioning process crashed) is resumed under a new attempt_number
+    e.g. the provisioning process crashed) is resumed under a new attempt number
     instead of being waited on or rejected."""
     existing = sandbox(user=test_user, status=SandboxStatus.PROVISIONING)
     assert existing.provisioning_started_at is None  # crashed-attempt shape

--- a/backend/tests/external_dependency_unit/craft/test_provisioning_lock.py
+++ b/backend/tests/external_dependency_unit/craft/test_provisioning_lock.py
@@ -84,7 +84,12 @@ def _make_replica(
     def _provision_opencode_secret(sandbox_id: str, config_json: str) -> None:  # noqa: ARG001
         return None
 
-    def _create_sandbox_pod(*, sandbox_id: str, tenant_id: str) -> str:  # noqa: ARG001
+    def _create_sandbox_pod(
+        *,
+        sandbox_id: str,
+        tenant_id: str,  # noqa: ARG001
+        provisioning_attempt_number: int,  # noqa: ARG001
+    ) -> str:
         return m._get_pod_name(sandbox_id)
 
     def _wait_for_pod_ip(pod_name: str, deadline: float) -> bool:  # noqa: ARG001
@@ -155,7 +160,7 @@ def _provision(
         user_id=uuid4(),
         tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
         onyx_pat="test-pat",
-        provisioning_generation=1,
+        provisioning_attempt_number=1,
     )
 
 

--- a/backend/tests/external_dependency_unit/craft/test_provisioning_lock.py
+++ b/backend/tests/external_dependency_unit/craft/test_provisioning_lock.py
@@ -121,11 +121,6 @@ def _make_replica(
         return True
 
     monkeypatch.setattr(m, "_pod_exists_and_healthy", _pod_exists_and_healthy)
-    monkeypatch.setattr(
-        m,
-        "_stamp_pod_attempt_number",
-        lambda _pod_name, _attempt_number: None,
-    )
     monkeypatch.setattr(m, "_ensure_service_exists", _ensure_service_exists)
     monkeypatch.setattr(m, "_provision_opencode_secret", _provision_opencode_secret)
     monkeypatch.setattr(m, "_create_sandbox_pod", _create_sandbox_pod)

--- a/backend/tests/external_dependency_unit/craft/test_provisioning_lock.py
+++ b/backend/tests/external_dependency_unit/craft/test_provisioning_lock.py
@@ -2,15 +2,15 @@
 
 Two ``KubernetesSandboxManager`` instances stand in for two api_server
 replicas sharing one Redis. Exactly one replica may create the pod and run
-the startup restore handshake; a concurrent provisioner must wait on the
-per-sandbox lock and then reuse the ready pod — never stream a second
-restore into the same pod (the 08fe79d8 production race).
+the startup restore handshake; a concurrent provisioner fails fast with
+``SandboxProvisionContentionError`` (never streams a second restore into the
+same pod — the 08fe79d8 production race) and a later retry reuses the ready
+pod without re-restoring.
 """
 
 from __future__ import annotations
 
 import threading
-import time
 from collections.abc import Callable
 from uuid import UUID, uuid4
 
@@ -24,7 +24,10 @@ from onyx.server.features.build.sandbox.kubernetes import kubernetes_sandbox_man
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
     KubernetesSandboxManager,
 )
-from onyx.server.features.build.sandbox.models import SandboxInfo
+from onyx.server.features.build.sandbox.models import (
+    SandboxInfo,
+    SandboxProvisionContentionError,
+)
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 
 
@@ -71,7 +74,11 @@ def _make_replica(
         with cluster.lock:
             return pod_name in cluster.ready
 
-    def _ensure_service_exists(sandbox_id: UUID, tenant_id: str) -> None:  # noqa: ARG001
+    def _ensure_service_exists(
+        sandbox_id: UUID,  # noqa: ARG001
+        tenant_id: str,  # noqa: ARG001
+        deadline: float,  # noqa: ARG001
+    ) -> None:
         return None
 
     def _provision_opencode_secret(sandbox_id: str, config_json: str) -> None:  # noqa: ARG001
@@ -86,7 +93,7 @@ def _make_replica(
     def _restore_opencode_history_snapshot(
         sandbox_id: UUID,
         tenant_id: str,  # noqa: ARG001
-        timeout_seconds: float = 300.0,  # noqa: ARG001
+        timeout_seconds: float,  # noqa: ARG001
     ) -> bool:
         with cluster.lock:
             cluster.restores.append(sandbox_id)
@@ -94,7 +101,7 @@ def _make_replica(
             on_restore()
         return True
 
-    def _wait_for_pod_ready(pod_name: str, timeout: float = 60.0) -> bool:  # noqa: ARG001
+    def _wait_for_pod_ready(pod_name: str, deadline: float) -> bool:  # noqa: ARG001
         # Real pods flip Ready only after the sidecar handshake completes.
         with cluster.lock:
             if pod_name not in cluster.pods:
@@ -104,7 +111,7 @@ def _make_replica(
 
     def _wait_for_opencode_serve_ready(
         sandbox_id: UUID,  # noqa: ARG001
-        timeout: float = 30.0,  # noqa: ARG001
+        timeout: float,  # noqa: ARG001
     ) -> bool:
         return True
 
@@ -152,7 +159,7 @@ def _provision(
     )
 
 
-def test_concurrent_provision_runs_exactly_one_restore(
+def test_concurrent_provision_fails_fast_and_restore_runs_once(
     lock_env: None,  # noqa: ARG001
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -168,59 +175,7 @@ def test_concurrent_provision_runs_exactly_one_restore(
         assert release_restore.wait(timeout=10)
 
     winner = _make_replica(cluster, monkeypatch, on_restore=_hold_restore)
-    loser = _make_replica(cluster, monkeypatch)
-
-    results: dict[str, SandboxInfo] = {}
-    errors: list[BaseException] = []
-
-    def _run(name: str, replica: KubernetesSandboxManager) -> None:
-        try:
-            results[name] = _provision(replica, sandbox_id)
-        except BaseException as e:
-            errors.append(e)
-
-    t_winner = threading.Thread(target=_run, args=("winner", winner))
-    t_winner.start()
-    assert restore_entered.wait(timeout=10)
-
-    t_loser = threading.Thread(target=_run, args=("loser", loser))
-    t_loser.start()
-    time.sleep(0.5)
-
-    # Loser must be parked on the lock while the winner is mid-restore.
-    assert t_loser.is_alive()
-    assert "loser" not in results
-    assert cluster.pod_creates == [pod_name]
-    assert cluster.restores == [sandbox_id]
-
-    release_restore.set()
-    t_winner.join(timeout=10)
-    t_loser.join(timeout=10)
-    assert not t_winner.is_alive() and not t_loser.is_alive()
-
-    assert errors == []
-    assert results["winner"].status == SandboxStatus.RUNNING
-    assert results["loser"].status == SandboxStatus.RUNNING
-    assert cluster.pod_creates == [pod_name]
-    assert cluster.restores == [sandbox_id]
-
-
-def test_loser_times_out_while_winner_holds_lock(
-    lock_env: None,  # noqa: ARG001
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    cluster = _FakeCluster()
-    sandbox_id = uuid4()
-
-    restore_entered = threading.Event()
-    release_restore = threading.Event()
-
-    def _hold_restore() -> None:
-        restore_entered.set()
-        assert release_restore.wait(timeout=10)
-
-    winner = _make_replica(cluster, monkeypatch, on_restore=_hold_restore)
-    loser = _make_replica(cluster, monkeypatch)
+    contender = _make_replica(cluster, monkeypatch)
 
     winner_result: list[SandboxInfo] = []
     t_winner = threading.Thread(
@@ -228,20 +183,27 @@ def test_loser_times_out_while_winner_holds_lock(
     )
     t_winner.start()
     assert restore_entered.wait(timeout=10)
-    # Patch only after the winner acquires: the constant is also the TTL.
-    monkeypatch.setattr(
-        kubernetes_sandbox_manager, "PROVISION_LOCK_TIMEOUT_SECONDS", 0.5
-    )
 
+    # Contender bounces off the held lock instead of parking; the winner's
+    # restore stays the only one.
     try:
-        with pytest.raises(RuntimeError, match="Timed out waiting"):
-            _provision(loser, sandbox_id)
+        with pytest.raises(SandboxProvisionContentionError):
+            _provision(contender, sandbox_id)
+        assert cluster.pod_creates == [pod_name]
+        assert cluster.restores == [sandbox_id]
     finally:
         release_restore.set()
         t_winner.join(timeout=10)
+    assert not t_winner.is_alive()
 
     assert len(winner_result) == 1
     assert winner_result[0].status == SandboxStatus.RUNNING
+
+    # Retry after the winner finished: reuses the ready pod, no second
+    # create or restore.
+    retry_result = _provision(contender, sandbox_id)
+    assert retry_result.status == SandboxStatus.RUNNING
+    assert cluster.pod_creates == [pod_name]
     assert cluster.restores == [sandbox_id]
 
 
@@ -259,14 +221,12 @@ def test_lock_released_after_provision_failure(
         raise ApiException(status=500, reason="secret create failed")
 
     monkeypatch.setattr(failing, "_provision_opencode_secret", _boom)
-    # If the failed attempt orphaned the lock, the retry would time out.
-    monkeypatch.setattr(
-        kubernetes_sandbox_manager, "PROVISION_LOCK_TIMEOUT_SECONDS", 3.0
-    )
 
     with pytest.raises(ApiException):
         _provision(failing, sandbox_id)
 
+    # If the failed attempt orphaned the lock, this retry would raise
+    # SandboxProvisionContentionError instead of provisioning.
     retry = _make_replica(cluster, monkeypatch)
     info = _provision(retry, sandbox_id)
 

--- a/backend/tests/external_dependency_unit/craft/test_provisioning_lock.py
+++ b/backend/tests/external_dependency_unit/craft/test_provisioning_lock.py
@@ -148,6 +148,7 @@ def _provision(
         user_id=uuid4(),
         tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
         onyx_pat="test-pat",
+        provisioning_generation=1,
     )
 
 

--- a/backend/tests/external_dependency_unit/craft/test_provisioning_lock.py
+++ b/backend/tests/external_dependency_unit/craft/test_provisioning_lock.py
@@ -121,6 +121,11 @@ def _make_replica(
         return True
 
     monkeypatch.setattr(m, "_pod_exists_and_healthy", _pod_exists_and_healthy)
+    monkeypatch.setattr(
+        m,
+        "_stamp_pod_attempt_number",
+        lambda _pod_name, _attempt_number: None,
+    )
     monkeypatch.setattr(m, "_ensure_service_exists", _ensure_service_exists)
     monkeypatch.setattr(m, "_provision_opencode_secret", _provision_opencode_secret)
     monkeypatch.setattr(m, "_create_sandbox_pod", _create_sandbox_pod)

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
@@ -1,7 +1,7 @@
 """Sandbox lifecycle (status state machine), DB-only half.
 
 DB-bound tests that pin the reserve → reconcile → finalize state machine:
-PROVISIONING → RUNNING, durable failure state with attempt_number advancement on
+PROVISIONING → RUNNING, durable failure state with attempt-number advancement on
 retry, idempotent provisioning, the health-check failure -> re-provision
 recovery path, and the idle-selection query shape.
 
@@ -94,7 +94,7 @@ class TestDurableProvisionFailure:
     ) -> None:
         # No provision_returns => stub raises NotImplementedError on
         # provision(). The failure must be recorded durably — a FAILED row
-        # under the attempt's attempt_number — never rolled back to nothing.
+        # under the attempt's number — never rolled back to nothing.
         with pytest.raises(SandboxProvisioningError):
             ensure_sandbox_ready(
                 db_session,

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
@@ -1,9 +1,9 @@
 """Sandbox lifecycle (status state machine), DB-only half.
 
-DB-bound tests that pin the sandbox state machine: PROVISIONING → RUNNING,
-provision failures rolling back the row, idempotent provisioning, the
-health-check failure -> re-provision recovery path, and the idle-selection
-query shape.
+DB-bound tests that pin the reserve → reconcile → finalize state machine:
+PROVISIONING → RUNNING, durable failure state with generation advancement on
+retry, idempotent provisioning, the health-check failure -> re-provision
+recovery path, and the idle-selection query shape.
 
 The full ``cleanup_idle_sandboxes_task`` end-to-end behavior lives in
 ``test_idle_cleanup.py`` — this file only covers the selection query, not
@@ -24,7 +24,6 @@ from sqlalchemy.orm import Session
 from onyx.db.enums import BuildSessionStatus, SandboxStatus
 from onyx.db.models import BuildSession, Sandbox, User
 from onyx.server.features.build.db.sandbox import (
-    create_sandbox__no_commit,
     create_snapshot__no_commit,
     get_running_sandboxes,
 )
@@ -37,10 +36,12 @@ from onyx.server.features.build.sandbox.models import (
 )
 from onyx.server.features.build.sandbox.user_library import USER_LIBRARY_MOUNT_PATH
 from onyx.server.features.build.session.api import restore_session
+from onyx.server.features.build.session.errors import SandboxProvisioningError
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.features.build.session.sandbox_lifecycle import (
+    ProvisioningPolicy,
+    ensure_sandbox_ready,
     is_sandbox_idle,
-    provision_sandbox,
 )
 from onyx.skills.push import SKILLS_MOUNT_PATH
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
@@ -49,21 +50,15 @@ from tests.external_dependency_unit.craft.db_helpers import make_sandbox, make_u
 
 
 class TestProvisionTransitions:
-    def test_provision_transitions_provisioning_to_running(
+    def test_ensure_ready_creates_and_transitions_to_running(
         self,
         db_session: Session,
         test_user: User,
         stub_sandbox_manager: StubSandboxManager,
     ) -> None:
-        # Create a sandbox row in PROVISIONING (the state set by
-        # create_sandbox__no_commit before provision_sandbox is called).
-        sandbox = create_sandbox__no_commit(db_session, test_user.id)
-        db_session.commit()
-        assert sandbox.status == SandboxStatus.PROVISIONING
-
         # Stub returns RUNNING from provision().
         stub_sandbox_manager.provision_returns = SandboxInfo(
-            sandbox_id=sandbox.id,
+            sandbox_id=uuid4(),
             directory_path="/tmp/sandbox",
             status=SandboxStatus.RUNNING,
             last_heartbeat=None,
@@ -71,56 +66,91 @@ class TestProvisionTransitions:
         # Provisioning hydrates managed content (skills + user library).
         stub_sandbox_manager.write_files_to_sandbox_silent = True
 
-        provision_sandbox(
-            db_session=db_session,
-            sandbox_manager=stub_sandbox_manager,
-            sandbox=sandbox,
-            user=test_user,
-            user_id=test_user.id,
-            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
+        sandbox, _outcome = ensure_sandbox_ready(
+            db_session,
+            stub_sandbox_manager,
+            test_user.id,
+            policy=ProvisioningPolicy.FAIL,
         )
-        db_session.commit()
+
         db_session.refresh(sandbox)
-
-        # Observable outcome: the DB row reflects the new state. We deliberately
-        # do NOT assert on ``provision_count`` — that's a mechanism assertion
-        # (P1) and ``StubSandboxManager.provision`` already raises if called
-        # without ``provision_returns`` set, which itself proves the call ran.
+        # Observable outcome: the DB row reflects the new state, with the
+        # first attempt's fencing generation.
         assert sandbox.status == SandboxStatus.RUNNING
+        assert sandbox.provisioning_generation == 1
+        assert stub_sandbox_manager.last_provision_payload is not None
+        assert (
+            stub_sandbox_manager.last_provision_payload["provisioning_generation"] == 1
+        )
 
 
-class TestProvisionFailureRollback:
-    def test_provision_failure_rolls_back_db(
+class TestDurableProvisionFailure:
+    def test_provision_failure_leaves_durable_failed_state(
         self,
         db_session: Session,
         test_user: User,
         stub_sandbox_manager: StubSandboxManager,
     ) -> None:
-        # Mirror the endpoint pattern: create_sandbox__no_commit (flush only),
-        # then call provision_sandbox; if it raises, the caller rolls back so
-        # no Sandbox row persists.
-        sandbox = create_sandbox__no_commit(db_session, test_user.id)
-        sandbox_id = sandbox.id
-        # No provision_returns => stub raises NotImplementedError on provision().
-
-        with pytest.raises(NotImplementedError):
-            provision_sandbox(
-                db_session=db_session,
-                sandbox_manager=stub_sandbox_manager,
-                sandbox=sandbox,
-                user=test_user,
-                user_id=test_user.id,
-                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
+        # No provision_returns => stub raises NotImplementedError on
+        # provision(). The failure must be recorded durably — a FAILED row
+        # under the attempt's generation — never rolled back to nothing.
+        with pytest.raises(SandboxProvisioningError):
+            ensure_sandbox_ready(
+                db_session,
+                stub_sandbox_manager,
+                test_user.id,
+                policy=ProvisioningPolicy.FAIL,
             )
 
-        # The endpoint's exception handler rolls back. Simulate that here.
         db_session.rollback()
-
-        # No row persisted at the (pre-flush, uncommitted) sandbox id.
-        assert (
-            db_session.query(Sandbox).filter(Sandbox.id == sandbox_id).one_or_none()
-            is None
+        row = (
+            db_session.query(Sandbox)
+            .filter(Sandbox.user_id == test_user.id)
+            .one_or_none()
         )
+        assert row is not None
+        assert row.status == SandboxStatus.FAILED
+        assert row.provisioning_generation == 1
+
+    def test_retry_after_failure_reuses_sandbox_and_advances_generation(
+        self,
+        db_session: Session,
+        test_user: User,
+        stub_sandbox_manager: StubSandboxManager,
+    ) -> None:
+        with pytest.raises(SandboxProvisioningError):
+            ensure_sandbox_ready(
+                db_session,
+                stub_sandbox_manager,
+                test_user.id,
+                policy=ProvisioningPolicy.FAIL,
+            )
+        db_session.rollback()
+        failed_row = (
+            db_session.query(Sandbox).filter(Sandbox.user_id == test_user.id).one()
+        )
+        failed_id = failed_row.id
+
+        stub_sandbox_manager.provision_returns = SandboxInfo(
+            sandbox_id=failed_id,
+            directory_path="/tmp/sandbox",
+            status=SandboxStatus.RUNNING,
+            last_heartbeat=None,
+        )
+        stub_sandbox_manager.write_files_to_sandbox_silent = True
+
+        sandbox, _outcome = ensure_sandbox_ready(
+            db_session,
+            stub_sandbox_manager,
+            test_user.id,
+            policy=ProvisioningPolicy.FAIL,
+        )
+
+        # Retry converges on the same committed identity under a new fenced
+        # attempt.
+        assert sandbox.id == failed_id
+        assert sandbox.status == SandboxStatus.RUNNING
+        assert sandbox.provisioning_generation == 2
 
 
 class TestIdempotentProvision:
@@ -131,12 +161,11 @@ class TestIdempotentProvision:
         stub_sandbox_manager: StubSandboxManager,
         session_manager_with_stub: SessionManager,
     ) -> None:
-        # Drive the real ``SessionManager.create_session__no_commit`` twice
-        # and assert the second call observes the existing sandbox row
-        # instead of provisioning a new one. ``provision_returns`` is
-        # intentionally cleared between calls — the stub will raise if
-        # ``provision`` is invoked on the second pass, which would surface
-        # as a test failure.
+        # Drive the real ``SessionManager.create_session`` twice and assert
+        # the second call observes the existing sandbox row instead of
+        # provisioning a new one. ``provision_returns`` is intentionally
+        # cleared between calls — the stub will raise if ``provision`` is
+        # invoked on the second pass, which would surface as a test failure.
         stub_sandbox_manager.provision_returns = SandboxInfo(
             sandbox_id=uuid4(),
             directory_path="/tmp/sandbox",
@@ -149,8 +178,7 @@ class TestIdempotentProvision:
         stub_sandbox_manager.write_sandbox_file_silent = True
 
         # First call: provisions a new sandbox row.
-        session_manager_with_stub.create_session__no_commit(user_id=test_user.id)
-        db_session.commit()
+        session_manager_with_stub.create_session(user_id=test_user.id)
 
         first_rows = (
             db_session.query(Sandbox).filter(Sandbox.user_id == test_user.id).all()
@@ -165,8 +193,7 @@ class TestIdempotentProvision:
 
         # Second call: same user. Should reuse the existing sandbox row
         # via the health-check branch and never call ``provision``.
-        session_manager_with_stub.create_session__no_commit(user_id=test_user.id)
-        db_session.commit()
+        session_manager_with_stub.create_session(user_id=test_user.id)
 
         rows = db_session.query(Sandbox).filter(Sandbox.user_id == test_user.id).all()
         # Observable outcome: exactly one sandbox row for this user, and
@@ -530,9 +557,9 @@ class TestManagedContentPushOrdering:
         self,
         db_session: Session,
         test_user: User,
+        sandbox: Callable[..., Sandbox],
     ) -> None:
-        row = create_sandbox__no_commit(db_session, test_user.id)
-        db_session.commit()
+        row = sandbox(user=test_user, status=SandboxStatus.SLEEPING)
 
         stub = _PushRecordingStub(row)
         stub.provision_returns = SandboxInfo(
@@ -542,15 +569,12 @@ class TestManagedContentPushOrdering:
             last_heartbeat=None,
         )
 
-        provision_sandbox(
-            db_session=db_session,
-            sandbox_manager=stub,
-            sandbox=row,
-            user=test_user,
-            user_id=test_user.id,
-            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
+        ensure_sandbox_ready(
+            db_session,
+            stub,
+            test_user.id,
+            policy=ProvisioningPolicy.FAIL,
         )
-        db_session.commit()
         db_session.refresh(row)
 
         assert row.status == SandboxStatus.RUNNING
@@ -631,17 +655,13 @@ class TestManagedContentPushOrdering:
         assert refreshed.status == SandboxStatus.RUNNING
         assert stub.restore_snapshot_count == (1 if has_snapshot else 0)
         assert stub.setup_session_workspace_count == (0 if has_snapshot else 1)
-        # First pair lands while the committed status is still PROVISIONING
-        # (no turn can dispatch against an unhydrated pod); the second pair is
-        # a fresh managed-content push for the restored workspace, completed
-        # before the workspace is rendered.
+        # The push pair lands while the committed status is still PROVISIONING
+        # (no turn can dispatch against an unhydrated pod) and before the
+        # workspace is rendered. A fresh provision pushes exactly once — the
+        # restore branch reuses that hydration instead of re-pushing.
         assert stub.ops == [
-            f"push:{SKILLS_MOUNT_PATH}",
-            f"push:{USER_LIBRARY_MOUNT_PATH}",
             f"push:{SKILLS_MOUNT_PATH}",
             f"push:{USER_LIBRARY_MOUNT_PATH}",
             "render_workspace",
         ]
-        assert all(
-            status == SandboxStatus.PROVISIONING for _, status in stub.pushes[:2]
-        )
+        assert all(status == SandboxStatus.PROVISIONING for _, status in stub.pushes)

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
@@ -1,7 +1,7 @@
 """Sandbox lifecycle (status state machine), DB-only half.
 
 DB-bound tests that pin the reserve → reconcile → finalize state machine:
-PROVISIONING → RUNNING, durable failure state with generation advancement on
+PROVISIONING → RUNNING, durable failure state with attempt_number advancement on
 retry, idempotent provisioning, the health-check failure -> re-provision
 recovery path, and the idle-selection query shape.
 
@@ -75,12 +75,13 @@ class TestProvisionTransitions:
 
         db_session.refresh(sandbox)
         # Observable outcome: the DB row reflects the new state, with the
-        # first attempt's fencing generation.
+        # first attempt's number.
         assert sandbox.status == SandboxStatus.RUNNING
-        assert sandbox.provisioning_generation == 1
+        assert sandbox.provisioning_attempt_number == 1
         assert stub_sandbox_manager.last_provision_payload is not None
         assert (
-            stub_sandbox_manager.last_provision_payload["provisioning_generation"] == 1
+            stub_sandbox_manager.last_provision_payload["provisioning_attempt_number"]
+            == 1
         )
 
 
@@ -93,7 +94,7 @@ class TestDurableProvisionFailure:
     ) -> None:
         # No provision_returns => stub raises NotImplementedError on
         # provision(). The failure must be recorded durably — a FAILED row
-        # under the attempt's generation — never rolled back to nothing.
+        # under the attempt's attempt_number — never rolled back to nothing.
         with pytest.raises(SandboxProvisioningError):
             ensure_sandbox_ready(
                 db_session,
@@ -110,7 +111,7 @@ class TestDurableProvisionFailure:
         )
         assert row is not None
         assert row.status == SandboxStatus.FAILED
-        assert row.provisioning_generation == 1
+        assert row.provisioning_attempt_number == 1
 
     def test_retry_after_failure_reuses_sandbox_and_advances_generation(
         self,
@@ -148,11 +149,11 @@ class TestDurableProvisionFailure:
             policy=ProvisioningPolicy.FAIL,
         )
 
-        # Retry converges on the same committed identity under a new fenced
+        # Retry converges on the same committed identity under a new numbered
         # attempt.
         assert sandbox.id == failed_id
         assert sandbox.status == SandboxStatus.RUNNING
-        assert sandbox.provisioning_generation == 2
+        assert sandbox.provisioning_attempt_number == 2
 
 
 class TestIdempotentProvision:

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
@@ -138,6 +138,8 @@ class TestDurableProvisionFailure:
             last_heartbeat=None,
         )
         stub_sandbox_manager.write_files_to_sandbox_silent = True
+        # Reviving a FAILED sandbox tears down any wedged runtime first.
+        stub_sandbox_manager.terminate_silent = True
 
         sandbox, _outcome = ensure_sandbox_ready(
             db_session,

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_pat.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_pat.py
@@ -285,6 +285,7 @@ class TestEnsureSandboxPat:
                 user_id=uuid4(),
                 tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
                 onyx_pat="",
+                provisioning_generation=1,
             )
 
     @pytest.mark.xfail(

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_pat.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_pat.py
@@ -285,7 +285,7 @@ class TestEnsureSandboxPat:
                 user_id=uuid4(),
                 tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
                 onyx_pat="",
-                provisioning_generation=1,
+                provisioning_attempt_number=1,
             )
 
     @pytest.mark.xfail(

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
@@ -253,8 +253,8 @@ def test_cleanup_stuck_runs_marks_running_over_threshold_failed(
 ) -> None:
     """A RUNNING run older than the running threshold → ``cleanup_stuck_scheduled_runs`` marks it FAILED.
 
-    Production threshold is ``DEFAULT_EXECUTOR_BUDGET_SECONDS + 15 min`` (i.e.
-    45 min). Backdating ``started_at`` by 50 min puts the run past that.
+    Production threshold is ``TURN_BUDGET_SECONDS + TURN_RECLAIM_SLACK_SECONDS``
+    (i.e. 45 min). Backdating ``started_at`` by 50 min puts the run past that.
     """
     user = make_user(db_session)
     task = ScheduledTask(
@@ -527,7 +527,7 @@ def test_run_fails_when_wake_fails(
     backend is bound so SessionManager construction can't raise and satisfy the
     assertion via the same broad handler without exercising the timeout path."""
     monkeypatch.setattr(
-        "onyx.server.features.build.scheduled_tasks.executor.PROVISIONING_WAIT_SECONDS",
+        "onyx.server.features.build.scheduled_tasks.executor.PROVISION_WAIT_SECONDS",
         0,
     )
 

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
@@ -304,7 +304,7 @@ def test_timeout_error_event_marks_run_failed_with_timeout_class(
     """Regression for ENG-4234: terminal timeout Error → FAILED/timeout."""
     # Bypass skill-payload: encrypted ExternalApp creds break local MIT decryption.
     monkeypatch.setattr(
-        "onyx.server.features.build.session.manager.build_user_skills_payload",
+        "onyx.server.features.build.session.sandbox_lifecycle.build_user_skills_payload",
         lambda *_: ("", {}),
     )
 
@@ -341,7 +341,7 @@ def test_prompt_response_marks_run_succeeded(
     """Happy-path regression: clean PromptResponse → SUCCEEDED, not FAILED."""
     # Bypass skill-payload: encrypted ExternalApp creds break local MIT decryption.
     monkeypatch.setattr(
-        "onyx.server.features.build.session.manager.build_user_skills_payload",
+        "onyx.server.features.build.session.sandbox_lifecycle.build_user_skills_payload",
         lambda *_: ("", {}),
     )
 
@@ -379,7 +379,7 @@ def test_scheduled_run_threads_budget_as_turn_timeout(
     timeout so the generic 15-min prompt timeout can't undercut the run budget."""
     # Bypass skill-payload: encrypted ExternalApp creds break local MIT decryption.
     monkeypatch.setattr(
-        "onyx.server.features.build.session.manager.build_user_skills_payload",
+        "onyx.server.features.build.session.sandbox_lifecycle.build_user_skills_payload",
         lambda *_: ("", {}),
     )
 
@@ -421,7 +421,7 @@ def test_cancelled_prompt_response_marks_run_failed(
     """
     # Bypass skill-payload: encrypted ExternalApp creds break local MIT decryption.
     monkeypatch.setattr(
-        "onyx.server.features.build.session.manager.build_user_skills_payload",
+        "onyx.server.features.build.session.sandbox_lifecycle.build_user_skills_payload",
         lambda *_: ("", {}),
     )
 
@@ -456,7 +456,7 @@ def test_transport_error_event_marks_run_failed_with_agent_exception_class(
     """Non-timeout terminal Error → FAILED with error_class=agent_exception."""
     # Bypass skill-payload: encrypted ExternalApp creds break local MIT decryption.
     monkeypatch.setattr(
-        "onyx.server.features.build.session.manager.build_user_skills_payload",
+        "onyx.server.features.build.session.sandbox_lifecycle.build_user_skills_payload",
         lambda *_: ("", {}),
     )
 
@@ -493,7 +493,7 @@ def test_stream_without_prompt_response_marks_run_failed(
     """Stream ending with no PromptResponse (and no Error) → FAILED, not SUCCEEDED."""
     # Bypass skill-payload: encrypted ExternalApp creds break local MIT decryption.
     monkeypatch.setattr(
-        "onyx.server.features.build.session.manager.build_user_skills_payload",
+        "onyx.server.features.build.session.sandbox_lifecycle.build_user_skills_payload",
         lambda *_: ("", {}),
     )
 

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -10,11 +10,11 @@ from __future__ import annotations
 
 import io
 import logging
-from typing import Callable
-from uuid import uuid4
+from typing import Any, Callable
+from uuid import UUID, uuid4
 
 import pytest
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Query, Session
 
 from onyx.configs.constants import FileOrigin, MessageType
 from onyx.db.enums import ArtifactType, BuildSessionStatus, SandboxStatus, SessionOrigin
@@ -24,13 +24,16 @@ from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.db.build_session import (
-    allocate_nextjs_port,
     get_user_build_sessions,
+    reserve_nextjs_port__no_commit,
     session_runtime_stale,
 )
 from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.sandbox.models import SandboxInfo
-from onyx.server.features.build.sandbox.user_library import USER_LIBRARY_MOUNT_PATH
+from onyx.server.features.build.sandbox.user_library import (
+    USER_LIBRARY_MOUNT_PATH,
+    build_user_library_fileset,
+)
 from onyx.server.features.build.sandbox.util.mcp_config import (
     craft_mcp_fingerprint,
     resolve_craft_mcp_servers,
@@ -47,11 +50,42 @@ from onyx.server.features.build.session.locks import (
 )
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.features.build.session.sandbox_lifecycle import (
-    hydrate_managed_content,
+    ManagedContentPayload,
+    push_managed_content,
+    record_managed_content_hashes__no_commit,
     refresh_mcp_config_hashes_for_users,
 )
+from onyx.skills.push import compute_skill_runtime_hash
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.common.craft.stubs import StubSandboxManager
+
+
+def _hydrate_managed_content_for_test(
+    db_session: Session,
+    stub_sandbox_manager: StubSandboxManager,
+    sandbox_id: UUID,
+    user: User,
+    connectable_apps_section: str,
+    skills_files: dict[str, bytes],
+) -> bool:
+    """build → push → record with an explicit skills payload, mirroring the
+    production reconcile sequence."""
+    payload = ManagedContentPayload(
+        connectable_apps_section=connectable_apps_section,
+        skills_files=skills_files,
+        skills_hash=compute_skill_runtime_hash(skills_files, connectable_apps_section),
+        mcp_fingerprint=craft_mcp_fingerprint(
+            resolve_craft_mcp_servers(db_session, user)
+        ),
+        library_files=build_user_library_fileset(user.id, db_session),
+    )
+    db_session.commit()
+    skills_hydrated = push_managed_content(stub_sandbox_manager, sandbox_id, payload)
+    record_managed_content_hashes__no_commit(
+        db_session, sandbox_id, payload, skills_hydrated
+    )
+    return skills_hydrated
+
 
 # Built-in skill rows are seeded by ``setup_postgres`` (run once per
 # tenant in ``full_setup``) and persist across tests. The session
@@ -73,11 +107,11 @@ def test_warm_content_hash_change_marks_only_live_session_stale(
     sandbox_row = sandbox(user=test_user, status=SandboxStatus.RUNNING)
     stub_sandbox_manager.write_files_to_sandbox_silent = True
 
-    assert hydrate_managed_content(
+    assert _hydrate_managed_content_for_test(
+        db_session,
         stub_sandbox_manager,
         sandbox_row.id,
         test_user,
-        db_session,
         connectable_apps_section="first apps",
         skills_files={"first/SKILL.md": b"first"},
     )
@@ -99,11 +133,11 @@ def test_warm_content_hash_change_marks_only_live_session_stale(
     db_session.add_all([existing_session, new_session])
     db_session.commit()
 
-    assert hydrate_managed_content(
+    assert _hydrate_managed_content_for_test(
+        db_session,
         stub_sandbox_manager,
         sandbox_row.id,
         test_user,
-        db_session,
         connectable_apps_section="second apps",
         skills_files={"first/SKILL.md": b"first"},
     )
@@ -122,11 +156,11 @@ def test_mcp_config_hash_change_marks_session_stale_independent_of_skills(
     sandbox_row = sandbox(user=test_user, status=SandboxStatus.RUNNING)
     stub_sandbox_manager.write_files_to_sandbox_silent = True
 
-    assert hydrate_managed_content(
+    assert _hydrate_managed_content_for_test(
+        db_session,
         stub_sandbox_manager,
         sandbox_row.id,
         test_user,
-        db_session,
         connectable_apps_section="apps",
         skills_files={"a/SKILL.md": b"x"},
     )
@@ -195,15 +229,17 @@ class TestCreateSession:
         stub_sandbox_manager.write_sandbox_file_silent = True
 
         sm = session_manager_with_stub
-        build_session = sm.create_session__no_commit(user_id=test_user.id)
-        db_session.commit()
+        build_session = sm.create_session(user_id=test_user.id)
         db_session.refresh(build_session)
 
         sandbox_row = get_sandbox_by_user_id(db_session, test_user.id)
         assert sandbox_row is not None
         assert sandbox_row.user_id == test_user.id
-        # Status was set to RUNNING by _provision_sandbox.
+        # Reconciliation finalized the row at RUNNING.
         assert sandbox_row.status == SandboxStatus.RUNNING
+        # The session is finalized ACTIVE only after workspace + opencode
+        # setup completed.
+        assert build_session.status == BuildSessionStatus.ACTIVE
         # provision() was called exactly once for this first creation.
         assert stub_sandbox_manager.provision_count == 1
         assert build_session.user_id == test_user.id
@@ -241,8 +277,7 @@ class TestCreateSession:
         # provision_returns NOT configured — any provision() call would raise.
 
         sm = session_manager_with_stub
-        new_session = sm.create_session__no_commit(user_id=test_user.id)
-        db_session.commit()
+        new_session = sm.create_session(user_id=test_user.id)
         db_session.refresh(new_session)
 
         # Same single sandbox row for this user.
@@ -334,7 +369,7 @@ class TestEmptySessionReuse:
         assert reused_sandbox is not None
         assert sandbox_row.id == reused_sandbox.id
 
-    def test_stale_empty_session_replaced_when_workspace_missing(
+    def test_stale_empty_session_repaired_in_place_when_workspace_missing(
         self,
         db_session: Session,
         test_user: User,
@@ -342,9 +377,11 @@ class TestEmptySessionReuse:
         session_manager_with_stub: SessionManager,
         stub_sandbox_manager: StubSandboxManager,
     ) -> None:
-        # Regression for SHA ff3b82d15a: workspace missing on disk despite
-        # the sandbox row claiming RUNNING => delete stale empty session,
-        # create a fresh one (which reuses the still-healthy sandbox row).
+        # Workspace missing on disk despite the sandbox row claiming RUNNING
+        # => the committed empty-session identity is repaired in place: it
+        # returns to INITIALIZING, the workspace is rebuilt under the SAME
+        # session ID, and it finalizes back to ACTIVE. The row is never
+        # deleted and replaced.
         sandbox_row = sandbox(user=test_user, status=SandboxStatus.RUNNING)
         stale_empty = BuildSession(
             id=uuid4(),
@@ -359,38 +396,38 @@ class TestEmptySessionReuse:
 
         stub_sandbox_manager.health_check_returns = True
         stub_sandbox_manager.session_workspace_exists_returns = False
-        stub_sandbox_manager.supports_opencode_history_persistence = True
-        stub_sandbox_manager.cleanup_session_workspace_silent = True
         stub_sandbox_manager.setup_session_workspace_silent = True
         stub_sandbox_manager.write_files_to_sandbox_silent = True
         stub_sandbox_manager.write_sandbox_file_silent = True
 
         sm = session_manager_with_stub
-        new_session = sm.get_or_create_empty_session(user_id=test_user.id)
-        db_session.commit()
+        repaired = sm.get_or_create_empty_session(user_id=test_user.id)
 
-        # Stale session is gone; new one took its place.
+        # Same committed identity, rebuilt workspace, finalized ACTIVE.
+        assert repaired.id == stale_id
+        db_session.refresh(repaired)
+        assert repaired.status == BuildSessionStatus.ACTIVE
+        assert repaired.nextjs_port is not None
+        assert stub_sandbox_manager.setup_session_workspace_count == 1
         assert (
-            db_session.query(BuildSession)
-            .filter(BuildSession.id == stale_id)
-            .one_or_none()
-            is None
+            stub_sandbox_manager.last_setup_session_workspace_payload is not None
+            and stub_sandbox_manager.last_setup_session_workspace_payload["session_id"]
+            == stale_id
         )
-        assert new_session.id != stale_id
 
-        # Sandbox row reused (still RUNNING — health check passed at the
-        # create_session step too).
+        # Exactly one session row for the user — no replacement was created.
+        rows = (
+            db_session.query(BuildSession)
+            .filter(BuildSession.user_id == test_user.id)
+            .all()
+        )
+        assert len(rows) == 1
+
+        # Sandbox row reused, never re-provisioned.
         reused_sandbox = get_sandbox_by_user_id(db_session, test_user.id)
         assert reused_sandbox is not None
         assert reused_sandbox.id == sandbox_row.id
-        assert stub_sandbox_manager.delete_opencode_session_count == 1
-        assert stub_sandbox_manager.last_delete_opencode_session_payload == {
-            "sandbox_id": sandbox_row.id,
-            "session_id": stale_id,
-            "opencode_session_id": "stale-opencode-session",
-        }
-        assert stub_sandbox_manager.create_opencode_history_snapshot_count == 0
-        assert stub_sandbox_manager.cleanup_session_workspace_count == 1
+        assert stub_sandbox_manager.provision_count == 0
 
 
 # =============================================================================
@@ -982,10 +1019,19 @@ class TestPortAllocator:
                     nextjs_port=port,
                 )
             )
+        target = BuildSession(
+            id=uuid4(),
+            user_id=test_user.id,
+            name="wants-a-port",
+            status=BuildSessionStatus.INITIALIZING,
+        )
+        db_session.add(target)
         db_session.commit()
 
-        allocated = allocate_nextjs_port(db_session)
+        allocated = reserve_nextjs_port__no_commit(db_session, target)
+        db_session.commit()
         assert allocated == 50003
+        assert target.nextjs_port == 50003
 
     def test_nextjs_port_allocator_raises_when_range_exhausted(
         self,
@@ -1012,11 +1058,79 @@ class TestPortAllocator:
                     nextjs_port=port,
                 )
             )
+        target = BuildSession(
+            id=uuid4(),
+            user_id=test_user.id,
+            name="no-port-left",
+            status=BuildSessionStatus.INITIALIZING,
+        )
+        db_session.add(target)
         db_session.commit()
 
         with pytest.raises(OnyxError) as exc_info:
-            allocate_nextjs_port(db_session)
+            reserve_nextjs_port__no_commit(db_session, target)
         assert exc_info.value.error_code == OnyxErrorCode.SERVICE_UNAVAILABLE
+
+    def test_nextjs_port_reservation_retries_on_unique_collision(
+        self,
+        db_session: Session,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A port that the availability scan missed (e.g. reserved by a
+        # concurrent transaction) trips the partial unique index; the
+        # reservation must roll back just that attempt and take the next
+        # port instead of failing.
+        monkeypatch.setattr(
+            "onyx.server.features.build.db.build_session.SANDBOX_NEXTJS_PORT_START",
+            50200,
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.build.db.build_session.SANDBOX_NEXTJS_PORT_END",
+            50204,
+        )
+
+        occupant = BuildSession(
+            id=uuid4(),
+            user_id=test_user.id,
+            name="occupies-50200",
+            status=BuildSessionStatus.ACTIVE,
+            nextjs_port=50200,
+        )
+        target = BuildSession(
+            id=uuid4(),
+            user_id=test_user.id,
+            name="collides-then-retries",
+            status=BuildSessionStatus.INITIALIZING,
+        )
+        db_session.add_all([occupant, target])
+        db_session.commit()
+
+        # Hide the occupant from the availability scan so the first candidate
+        # collides on the unique index, exercising the savepoint retry.
+        # `Session.query` is a variadic overload set, so the interceptor's
+        # varargs cannot be typed more precisely than Any.
+        original_query = db_session.query
+        scan_hidden = False
+
+        def _scan_without_occupant(*entities: Any, **kwargs: Any) -> Query[Any]:
+            nonlocal scan_hidden
+            query = original_query(*entities, **kwargs)
+            if entities == (BuildSession.nextjs_port,):
+                scan_hidden = True
+                return query.filter(BuildSession.id != occupant.id)
+            return query
+
+        monkeypatch.setattr(db_session, "query", _scan_without_occupant)
+
+        allocated = reserve_nextjs_port__no_commit(db_session, target)
+        db_session.commit()
+
+        # Tripwire: if the reservation's scan changes shape, this test must
+        # fail loudly instead of silently no longer exercising the collision.
+        assert scan_hidden, "availability-scan hook never engaged"
+        assert allocated == 50201
+        assert target.nextjs_port == 50201
 
 
 # =============================================================================
@@ -1234,14 +1348,16 @@ class TestRestoreSession:
             lambda: stub_sandbox_manager,
         )
 
-        def _raise_port_exhausted(_db_session: Session) -> int:
+        def _raise_port_exhausted(
+            _db_session: Session, _build_session: BuildSession
+        ) -> int:
             raise OnyxError(
                 OnyxErrorCode.SERVICE_UNAVAILABLE,
                 "No available ports in configured range",
             )
 
         monkeypatch.setattr(
-            "onyx.server.features.build.session.api.allocate_nextjs_port",
+            "onyx.server.features.build.session.api.reserve_nextjs_port__no_commit",
             _raise_port_exhausted,
         )
 

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -14,10 +14,18 @@ from typing import Any, Callable
 from uuid import UUID, uuid4
 
 import pytest
+from fastapi_users.password import PasswordHelper
 from sqlalchemy.orm import Query, Session
 
+from onyx.auth.schemas import UserRole
 from onyx.configs.constants import FileOrigin, MessageType
-from onyx.db.enums import ArtifactType, BuildSessionStatus, SandboxStatus, SessionOrigin
+from onyx.db.enums import (
+    AccountType,
+    ArtifactType,
+    BuildSessionStatus,
+    SandboxStatus,
+    SessionOrigin,
+)
 from onyx.db.models import Artifact, BuildMessage, BuildSession, Sandbox, Snapshot, User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -1070,6 +1078,56 @@ class TestPortAllocator:
         with pytest.raises(OnyxError) as exc_info:
             reserve_nextjs_port__no_commit(db_session, target)
         assert exc_info.value.error_code == OnyxErrorCode.SERVICE_UNAVAILABLE
+
+    def test_nextjs_port_uniqueness_is_scoped_per_user(
+        self,
+        db_session: Session,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Ports only collide within one user's sandbox: another user holding
+        # the sole port in the range must not block this user's allocation.
+        monkeypatch.setattr(
+            "onyx.server.features.build.db.build_session.SANDBOX_NEXTJS_PORT_START",
+            50250,
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.build.db.build_session.SANDBOX_NEXTJS_PORT_END",
+            50251,
+        )
+
+        password_helper = PasswordHelper()
+        other_user = User(
+            id=uuid4(),
+            email=f"build_test_{uuid4().hex[:8]}@example.com",
+            hashed_password=password_helper.hash(password_helper.generate()),
+            is_active=True,
+            is_verified=True,
+            role=UserRole.EXT_PERM_USER,
+            account_type=AccountType.EXT_PERM_USER,
+        )
+        db_session.add(other_user)
+        db_session.add(
+            BuildSession(
+                id=uuid4(),
+                user_id=other_user.id,
+                name="other-user-occupies-50250",
+                status=BuildSessionStatus.ACTIVE,
+                nextjs_port=50250,
+            )
+        )
+        target = BuildSession(
+            id=uuid4(),
+            user_id=test_user.id,
+            name="same-port-different-user",
+            status=BuildSessionStatus.INITIALIZING,
+        )
+        db_session.add(target)
+        db_session.commit()
+
+        allocated = reserve_nextjs_port__no_commit(db_session, target)
+        db_session.commit()
+        assert allocated == 50250
 
     def test_nextjs_port_reservation_retries_on_unique_collision(
         self,

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -1153,7 +1153,7 @@ class TestConcurrentCreateLock:
 
         monkeypatch.setattr(
             session_locks,
-            "SESSION_CREATE_LOCK_WAIT_SECONDS",
+            "SESSION_FLOW_LOCK_WAIT_SECONDS",
             0.05,
         )
         try:

--- a/backend/tests/external_dependency_unit/craft/test_user_library_fileset.py
+++ b/backend/tests/external_dependency_unit/craft/test_user_library_fileset.py
@@ -19,8 +19,11 @@ from onyx.server.features.build.db.user_library import (
 from onyx.server.features.build.sandbox.user_library import (
     USER_LIBRARY_MOUNT_PATH,
     build_user_library_fileset,
-    hydrate_user_library,
     sync_user_library_to_active_sandboxes,
+)
+from onyx.server.features.build.session.sandbox_lifecycle import (
+    build_managed_content_payload,
+    push_managed_content,
 )
 from tests.common.craft.stubs import StubSandboxManager
 
@@ -94,28 +97,23 @@ class TestUserLibraryFileset:
 
         assert fileset == {"real_file.csv": b"data"}
 
-    def test_hydrate_user_library_pushes_current_fileset_to_one_sandbox(
+    def test_managed_content_push_delivers_current_library_fileset(
         self,
         db_session: Session,
         test_user: User,
         sandbox: Callable[..., Sandbox],
         stub_sandbox_manager: StubSandboxManager,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        # Cold-start hydration path: the reconcile payload carries the user's
+        # current library fileset and pushes it to the sandbox's mount.
         sandbox_row = sandbox(user=test_user, status=SandboxStatus.RUNNING)
         _seed_file(db_session, test_user, "docs/readme.md", b"hello")
         stub_sandbox_manager.write_files_to_sandbox_silent = True
-        _patch_user_library_manager(monkeypatch, stub_sandbox_manager)
 
-        result = hydrate_user_library(
-            sandbox_row.id,
-            test_user.id,
-            db_session,
-            sandbox_manager=stub_sandbox_manager,
-        )
+        payload = build_managed_content_payload(test_user, db_session)
+        push_managed_content(stub_sandbox_manager, sandbox_row.id, payload)
 
-        assert result.succeeded == 1
-        assert stub_sandbox_manager.write_files_to_sandbox_count == 1
+        assert payload.library_files == {"docs/readme.md": b"hello"}
         assert stub_sandbox_manager.last_write_files_to_sandbox_payload == {
             "sandbox_id": sandbox_row.id,
             "mount_path": USER_LIBRARY_MOUNT_PATH,

--- a/backend/tests/external_dependency_unit/craft_helm/test_pod_spec.py
+++ b/backend/tests/external_dependency_unit/craft_helm/test_pod_spec.py
@@ -313,6 +313,7 @@ def _build_pod() -> client.V1Pod:
     return mgr._create_sandbox_pod(  # type: ignore[attr-defined]
         sandbox_id="abc12345-abcd-abcd-abcd-abcdef123456",
         tenant_id="t-1",
+        provisioning_generation=1,
     )
 
 

--- a/backend/tests/external_dependency_unit/craft_helm/test_pod_spec.py
+++ b/backend/tests/external_dependency_unit/craft_helm/test_pod_spec.py
@@ -313,7 +313,7 @@ def _build_pod() -> client.V1Pod:
     return mgr._create_sandbox_pod(  # type: ignore[attr-defined]
         sandbox_id="abc12345-abcd-abcd-abcd-abcdef123456",
         tenant_id="t-1",
-        provisioning_generation=1,
+        provisioning_attempt_number=1,
     )
 
 

--- a/backend/tests/integration/tests/craft/docker_e2e/test_snapshot_roundtrip_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_snapshot_roundtrip_docker.py
@@ -24,8 +24,8 @@ from onyx.server.features.build.configs import SANDBOX_BACKEND, SandboxBackend
 from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
     OPENCODE_DATA_DIR,
     SANDBOX_EXEC_USER,
-    SESSIONS_ROOT,
 )
+from onyx.server.features.build.sandbox.session_workspace import SESSIONS_ROOT
 from tests.integration.common_utils.managers.build_session import BuildSessionManager
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser

--- a/backend/tests/integration/tests/craft/test_sessions_api.py
+++ b/backend/tests/integration/tests/craft/test_sessions_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from uuid import UUID, uuid4
 
+from onyx.configs.constants import OnyxRedisLocks
 from onyx.db.enums import SharingScope
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.timeouts import SESSION_FLOW_LOCK_LEASE_SECONDS
@@ -75,11 +76,13 @@ def test_restore_session_returns_409_when_lock_held(
     body = BuildSessionManager.create(admin_user)
     session_id = body.id
     assert body.sandbox is not None
-    sandbox_id = body.sandbox.id
+    assert body.user_id is not None
 
     redis_client = get_redis_client(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
+    # Restore shares the per-user session-flow lock with create and the reaper.
     lock = redis_client.lock(
-        f"sandbox_restore:{sandbox_id}", timeout=SESSION_FLOW_LOCK_LEASE_SECONDS
+        f"{OnyxRedisLocks.SESSION_CREATE_LOCK_PREFIX}:{body.user_id}",
+        timeout=SESSION_FLOW_LOCK_LEASE_SECONDS,
     )
     assert lock.acquire(blocking=False)
     try:

--- a/backend/tests/integration/tests/craft/test_sessions_api.py
+++ b/backend/tests/integration/tests/craft/test_sessions_api.py
@@ -6,7 +6,7 @@ from uuid import UUID, uuid4
 
 from onyx.db.enums import SharingScope
 from onyx.redis.redis_pool import get_redis_client
-from onyx.server.features.build.session.api import RESTORE_LOCK_TIMEOUT_SECONDS
+from onyx.server.features.build.timeouts import SESSION_FLOW_LOCK_LEASE_SECONDS
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
@@ -79,7 +79,7 @@ def test_restore_session_returns_409_when_lock_held(
 
     redis_client = get_redis_client(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     lock = redis_client.lock(
-        f"sandbox_restore:{sandbox_id}", timeout=RESTORE_LOCK_TIMEOUT_SECONDS
+        f"sandbox_restore:{sandbox_id}", timeout=SESSION_FLOW_LOCK_LEASE_SECONDS
     )
     assert lock.acquire(blocking=False)
     try:

--- a/backend/tests/unit/onyx/server/features/craft/interactive_turns/test_executor.py
+++ b/backend/tests/unit/onyx/server/features/craft/interactive_turns/test_executor.py
@@ -26,7 +26,7 @@ from onyx.server.features.build.sandbox.event_schema import (
     PromptResponse,
 )
 from onyx.server.features.build.sandbox.event_schema import Error as SandboxError
-from onyx.server.features.build.sandbox.serve_transport import (
+from onyx.server.features.build.timeouts import (
     PROMPT_SLOT_FAST_FAIL_ACQUIRE_SECONDS,
     PROMPT_SLOT_WAIT_OUT_ORPHAN_SECONDS,
 )

--- a/backend/tests/unit/onyx/server/features/craft/interactive_turns/test_state.py
+++ b/backend/tests/unit/onyx/server/features/craft/interactive_turns/test_state.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 from uuid import UUID, uuid4
 
 from onyx.server.features.build.interactive_turns.state import (
-    REQUEST_ID_TTL_SECONDS,
     TURN_STATUS_FAILED,
     TURN_STATUS_QUEUED,
     TURN_STATUS_RUNNING,
@@ -19,6 +18,7 @@ from onyx.server.features.build.interactive_turns.state import (
     touch_turn,
 )
 from onyx.server.features.build.sandbox.models import PromptAttachment
+from onyx.server.features.build.timeouts import REQUEST_ID_TTL_SECONDS
 from tests.unit.fakes import FakeCache
 
 

--- a/backend/tests/unit/onyx/server/features/craft/interactive_turns/test_turns_api.py
+++ b/backend/tests/unit/onyx/server/features/craft/interactive_turns/test_turns_api.py
@@ -122,7 +122,7 @@ def test_get_interactive_turn_events_waits_then_forwards_live_stream(
         ) -> Iterator[str]:
             assert session_id_arg == session_id
             assert user_id_arg == user_id
-            assert keepalive_seconds == turns_api.LIVE_STREAM_KEEPALIVE_SECONDS
+            assert keepalive_seconds == turns_api.SSE_KEEPALIVE_INTERVAL
             finish_turn(
                 cache=cache,
                 turn_id=turn_id,
@@ -286,7 +286,7 @@ def test_get_interactive_turn_events_yields_failed_turn_error_after_stream_chunk
         ) -> Iterator[str]:
             assert session_id_arg == session_id
             assert user_id_arg == user_id
-            assert keepalive_seconds == turns_api.LIVE_STREAM_KEEPALIVE_SECONDS
+            assert keepalive_seconds == turns_api.SSE_KEEPALIVE_INTERVAL
             finish_turn(
                 cache=cache,
                 turn_id=turn_id,
@@ -354,7 +354,7 @@ def test_get_interactive_turn_events_retries_runner_start_mid_stream(
         ) -> Iterator[str]:
             assert session_id_arg == session_id
             assert user_id_arg == user_id
-            assert keepalive_seconds == turns_api.LIVE_STREAM_KEEPALIVE_SECONDS
+            assert keepalive_seconds == turns_api.SSE_KEEPALIVE_INTERVAL
             for i in range(3):
                 yield (
                     "event: message\n"
@@ -429,7 +429,7 @@ def test_get_interactive_turn_events_rate_limits_runner_retry_within_window(
         ) -> Iterator[str]:
             assert session_id_arg == session_id
             assert user_id_arg == user_id
-            assert keepalive_seconds == turns_api.LIVE_STREAM_KEEPALIVE_SECONDS
+            assert keepalive_seconds == turns_api.SSE_KEEPALIVE_INTERVAL
             for i in range(3):
                 yield (
                     "event: message\n"

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_manager_config.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_manager_config.py
@@ -233,7 +233,7 @@ def kwargs() -> ContainerCreateKwargs:
         volume_name="onyx-craft-sandbox-12345678",
         memory_limit="2g",
         cpu_limit=1.0,
-        provisioning_generation=1,
+        provisioning_attempt_number=1,
         opencode_password=_OPENCODE_PASSWORD,
         opencode_config_json=_OPENCODE_CONFIG_JSON,
     )
@@ -261,7 +261,7 @@ def proxy_kwargs() -> ContainerCreateKwargs:
         volume_name="onyx-craft-sandbox-12345678",
         memory_limit="2g",
         cpu_limit=1.0,
-        provisioning_generation=1,
+        provisioning_attempt_number=1,
         opencode_password=_OPENCODE_PASSWORD,
         opencode_config_json=_OPENCODE_CONFIG_JSON,
         sandbox_proxy_host="sandbox-proxy",
@@ -427,7 +427,7 @@ def test_container_kwargs_publishes_serve_on_localhost_in_dev(
         volume_name="onyx-craft-sandbox-12345678",
         memory_limit="2g",
         cpu_limit=1.0,
-        provisioning_generation=1,
+        provisioning_attempt_number=1,
         opencode_password=_OPENCODE_PASSWORD,
         opencode_config_json=_OPENCODE_CONFIG_JSON,
     )
@@ -551,7 +551,7 @@ def test_container_kwargs_warns_on_internal_compose_host(
             volume_name="vol",
             memory_limit="2g",
             cpu_limit=1.0,
-            provisioning_generation=1,
+            provisioning_attempt_number=1,
             opencode_password=_OPENCODE_PASSWORD,
             opencode_config_json=_OPENCODE_CONFIG_JSON,
         )
@@ -579,7 +579,7 @@ def test_container_kwargs_no_warning_for_public_url(
             volume_name="vol",
             memory_limit="2g",
             cpu_limit=1.0,
-            provisioning_generation=1,
+            provisioning_attempt_number=1,
             opencode_password=_OPENCODE_PASSWORD,
             opencode_config_json=_OPENCODE_CONFIG_JSON,
         )
@@ -606,7 +606,7 @@ def test_container_kwargs_no_warning_for_craft_api_alias(
             volume_name="vol",
             memory_limit="2g",
             cpu_limit=1.0,
-            provisioning_generation=1,
+            provisioning_attempt_number=1,
             opencode_password=_OPENCODE_PASSWORD,
             opencode_config_json=_OPENCODE_CONFIG_JSON,
         )
@@ -845,7 +845,7 @@ def test_proxy_kwargs_requires_ca_volume() -> None:
             volume_name="vol",
             memory_limit="2g",
             cpu_limit=1.0,
-            provisioning_generation=1,
+            provisioning_attempt_number=1,
             opencode_password=_OPENCODE_PASSWORD,
             opencode_config_json=_OPENCODE_CONFIG_JSON,
             sandbox_proxy_host="sandbox-proxy",

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_manager_config.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_manager_config.py
@@ -233,6 +233,7 @@ def kwargs() -> ContainerCreateKwargs:
         volume_name="onyx-craft-sandbox-12345678",
         memory_limit="2g",
         cpu_limit=1.0,
+        provisioning_generation=1,
         opencode_password=_OPENCODE_PASSWORD,
         opencode_config_json=_OPENCODE_CONFIG_JSON,
     )
@@ -260,6 +261,7 @@ def proxy_kwargs() -> ContainerCreateKwargs:
         volume_name="onyx-craft-sandbox-12345678",
         memory_limit="2g",
         cpu_limit=1.0,
+        provisioning_generation=1,
         opencode_password=_OPENCODE_PASSWORD,
         opencode_config_json=_OPENCODE_CONFIG_JSON,
         sandbox_proxy_host="sandbox-proxy",
@@ -425,6 +427,7 @@ def test_container_kwargs_publishes_serve_on_localhost_in_dev(
         volume_name="onyx-craft-sandbox-12345678",
         memory_limit="2g",
         cpu_limit=1.0,
+        provisioning_generation=1,
         opencode_password=_OPENCODE_PASSWORD,
         opencode_config_json=_OPENCODE_CONFIG_JSON,
     )
@@ -548,6 +551,7 @@ def test_container_kwargs_warns_on_internal_compose_host(
             volume_name="vol",
             memory_limit="2g",
             cpu_limit=1.0,
+            provisioning_generation=1,
             opencode_password=_OPENCODE_PASSWORD,
             opencode_config_json=_OPENCODE_CONFIG_JSON,
         )
@@ -575,6 +579,7 @@ def test_container_kwargs_no_warning_for_public_url(
             volume_name="vol",
             memory_limit="2g",
             cpu_limit=1.0,
+            provisioning_generation=1,
             opencode_password=_OPENCODE_PASSWORD,
             opencode_config_json=_OPENCODE_CONFIG_JSON,
         )
@@ -601,6 +606,7 @@ def test_container_kwargs_no_warning_for_craft_api_alias(
             volume_name="vol",
             memory_limit="2g",
             cpu_limit=1.0,
+            provisioning_generation=1,
             opencode_password=_OPENCODE_PASSWORD,
             opencode_config_json=_OPENCODE_CONFIG_JSON,
         )
@@ -839,6 +845,7 @@ def test_proxy_kwargs_requires_ca_volume() -> None:
             volume_name="vol",
             memory_limit="2g",
             cpu_limit=1.0,
+            provisioning_generation=1,
             opencode_password=_OPENCODE_PASSWORD,
             opencode_config_json=_OPENCODE_CONFIG_JSON,
             sandbox_proxy_host="sandbox-proxy",

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_serve_plumbing.py
@@ -9,7 +9,7 @@ docker-sandbox-serve port — no Docker engine required. We use
   fallback URL or localhost-published URL + cleartext password from a mocked
   container's ``inspect`` data, yields a ``None`` password for legacy
   containers, and returns ``None`` when the container is gone.
-- ``_render_agents_md`` produces shell-escaped AGENTS.md content.
+- ``_build_agents_md`` renders AGENTS.md content.
 """
 
 from __future__ import annotations
@@ -240,11 +240,11 @@ def llm_config() -> CraftLLMProviderConfig:
     )
 
 
-def test_render_agents_md_returns_escaped_string(
+def test_build_agents_md_renders_instructions(
     llm_config: CraftLLMProviderConfig,
 ) -> None:
     mgr = _bare_manager()
-    agents_md = mgr._render_agents_md(
+    agents_md = mgr._build_agents_md(
         agent_provider=llm_config.provider,
         agent_model=llm_config.model_name,
         nextjs_port=None,
@@ -252,7 +252,6 @@ def test_render_agents_md_returns_escaped_string(
     )
     assert isinstance(agents_md, str)
     assert agents_md
-    assert "'" not in agents_md or "'\\''" in agents_md
     assert "## Skills" not in agents_md
     assert "{{AVAILABLE_SKILLS_SECTION}}" not in agents_md
 
@@ -273,7 +272,7 @@ def test_setup_writes_fresh_gateway_catalog_before_instance_start(
         manager, "_require_container", MagicMock(return_value=MagicMock())
     )
     monkeypatch.setattr(
-        manager, "_render_agents_md", MagicMock(return_value="instructions")
+        manager, "_build_agents_md", MagicMock(return_value="instructions")
     )
     gateway = CraftLLMProviderConfig(
         provider="onyx",
@@ -417,6 +416,7 @@ def test_provision_generates_fresh_password_and_injects_into_container_env(
         user_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
         tenant_id="tenant-abc",
         onyx_pat="pat-redacted",
+        provisioning_generation=1,
     )
 
     assert info.status.value == "running"
@@ -560,6 +560,7 @@ def test_provision_removes_container_when_history_restore_fails(
             user_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
             tenant_id="tenant-abc",
             onyx_pat="pat-redacted",
+            provisioning_generation=1,
         )
 
     # Half-provisioned container is force-removed; opencode never started.

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_serve_plumbing.py
@@ -416,7 +416,7 @@ def test_provision_generates_fresh_password_and_injects_into_container_env(
         user_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
         tenant_id="tenant-abc",
         onyx_pat="pat-redacted",
-        provisioning_generation=1,
+        provisioning_attempt_number=1,
     )
 
     assert info.status.value == "running"
@@ -560,7 +560,7 @@ def test_provision_removes_container_when_history_restore_fails(
             user_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
             tenant_id="tenant-abc",
             onyx_pat="pat-redacted",
-            provisioning_generation=1,
+            provisioning_attempt_number=1,
         )
 
     # Half-provisioned container is force-removed; opencode never started.

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_serve_plumbing.py
@@ -376,7 +376,7 @@ def test_provision_generates_fresh_password_and_injects_into_container_env(
     monkeypatch.setattr(
         DockerSandboxManager,
         "_wait_for_opencode_serve_ready",
-        lambda self, sandbox_id: True,  # noqa: ARG005 — patched callable
+        lambda self, sandbox_id, timeout: True,  # noqa: ARG005 — patched callable
     )
 
     mgr = _bare_manager()

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_event_bus_per_directory.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_event_bus_per_directory.py
@@ -159,7 +159,11 @@ def test_terminate_closes_every_per_directory_bus_for_sandbox(
     bus_other = mgr._get_or_create_event_bus(other_sandbox, _DIR_A)
 
     # Stub out the K8s teardown — we only care about the bus-close path.
-    monkeypatch.setattr(mgr, "_cleanup_kubernetes_resources", lambda _sandbox_str: None)
+    monkeypatch.setattr(
+        mgr,
+        "_cleanup_kubernetes_resources",
+        lambda _sandbox_str, max_attempt_number=None: None,  # noqa: ARG005
+    )
 
     mgr.terminate(sandbox_id)
 

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_event_bus_per_directory.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_event_bus_per_directory.py
@@ -159,11 +159,7 @@ def test_terminate_closes_every_per_directory_bus_for_sandbox(
     bus_other = mgr._get_or_create_event_bus(other_sandbox, _DIR_A)
 
     # Stub out the K8s teardown — we only care about the bus-close path.
-    monkeypatch.setattr(
-        mgr,
-        "_cleanup_kubernetes_resources",
-        lambda _sandbox_str, max_attempt_number=None: None,  # noqa: ARG005
-    )
+    monkeypatch.setattr(mgr, "_cleanup_kubernetes_resources", lambda _sandbox_str: None)
 
     mgr.terminate(sandbox_id)
 

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_k8s_push_error_mapping.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_k8s_push_error_mapping.py
@@ -796,7 +796,9 @@ def test_provision_cleans_up_pod_when_opencode_history_restore_fails(
             provisioning_attempt_number=1,
         )
 
-    cleanup_resources_mock.assert_called_once_with(str(sandbox_id))
+    cleanup_resources_mock.assert_called_once_with(
+        str(sandbox_id), max_attempt_number=1
+    )
 
 
 def test_provision_existing_healthy_pod_does_not_restore_opencode_history(

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_k8s_push_error_mapping.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_k8s_push_error_mapping.py
@@ -793,7 +793,7 @@ def test_provision_cleans_up_pod_when_opencode_history_restore_fails(
             user_id=_sandbox_id(),
             tenant_id="tenant-test",
             onyx_pat="pat",
-            provisioning_generation=1,
+            provisioning_attempt_number=1,
         )
 
     cleanup_resources_mock.assert_called_once_with(str(sandbox_id))
@@ -825,7 +825,7 @@ def test_provision_existing_healthy_pod_does_not_restore_opencode_history(
         user_id=_sandbox_id(),
         tenant_id="tenant-test",
         onyx_pat="pat",
-        provisioning_generation=1,
+        provisioning_attempt_number=1,
     )
 
     assert info.sandbox_id == sandbox_id
@@ -869,7 +869,7 @@ def test_provision_conflicting_healthy_pod_skips_startup_restore(
         user_id=_sandbox_id(),
         tenant_id="tenant-test",
         onyx_pat="pat",
-        provisioning_generation=1,
+        provisioning_attempt_number=1,
     )
 
     assert info.sandbox_id == sandbox_id
@@ -931,7 +931,7 @@ def test_provision_conflicting_not_ready_pod_runs_startup_restore(
         user_id=_sandbox_id(),
         tenant_id="tenant-test",
         onyx_pat="pat",
-        provisioning_generation=1,
+        provisioning_attempt_number=1,
     )
 
     assert info.sandbox_id == sandbox_id
@@ -974,7 +974,7 @@ def test_provision_conflicting_not_ready_pod_restore_failure_does_not_cleanup(
             user_id=_sandbox_id(),
             tenant_id="tenant-test",
             onyx_pat="pat",
-            provisioning_generation=1,
+            provisioning_attempt_number=1,
         )
 
     cleanup_resources_mock.assert_not_called()

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_k8s_push_error_mapping.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_k8s_push_error_mapping.py
@@ -784,6 +784,7 @@ def test_provision_cleans_up_pod_when_opencode_history_restore_fails(
             user_id=_sandbox_id(),
             tenant_id="tenant-test",
             onyx_pat="pat",
+            provisioning_generation=1,
         )
 
     cleanup_resources_mock.assert_called_once_with(str(sandbox_id))
@@ -815,6 +816,7 @@ def test_provision_existing_healthy_pod_does_not_restore_opencode_history(
         user_id=_sandbox_id(),
         tenant_id="tenant-test",
         onyx_pat="pat",
+        provisioning_generation=1,
     )
 
     assert info.sandbox_id == sandbox_id
@@ -858,6 +860,7 @@ def test_provision_conflicting_healthy_pod_skips_startup_restore(
         user_id=_sandbox_id(),
         tenant_id="tenant-test",
         onyx_pat="pat",
+        provisioning_generation=1,
     )
 
     assert info.sandbox_id == sandbox_id
@@ -915,6 +918,7 @@ def test_provision_conflicting_not_ready_pod_runs_startup_restore(
         user_id=_sandbox_id(),
         tenant_id="tenant-test",
         onyx_pat="pat",
+        provisioning_generation=1,
     )
 
     assert info.sandbox_id == sandbox_id
@@ -957,6 +961,7 @@ def test_provision_conflicting_not_ready_pod_restore_failure_does_not_cleanup(
             user_id=_sandbox_id(),
             tenant_id="tenant-test",
             onyx_pat="pat",
+            provisioning_generation=1,
         )
 
     cleanup_resources_mock.assert_not_called()

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_k8s_push_error_mapping.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_k8s_push_error_mapping.py
@@ -796,9 +796,7 @@ def test_provision_cleans_up_pod_when_opencode_history_restore_fails(
             provisioning_attempt_number=1,
         )
 
-    cleanup_resources_mock.assert_called_once_with(
-        str(sandbox_id), max_attempt_number=1
-    )
+    cleanup_resources_mock.assert_called_once_with(str(sandbox_id))
 
 
 def test_provision_existing_healthy_pod_does_not_restore_opencode_history(

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_k8s_push_error_mapping.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_k8s_push_error_mapping.py
@@ -41,7 +41,6 @@ from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
 )
 from onyx.server.features.build.sandbox.kubernetes import sidecar_client
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
-    OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS,
     KubernetesSandboxManager,
     _build_targz,
 )
@@ -705,14 +704,19 @@ def test_restore_opencode_history_posts_archive_to_sidecar(
         assert archive_file.read() == archive_body
         assert sha256_hex == hashlib.sha256(archive_body).hexdigest()
         assert operation_label == "opencode history restore"
-        assert timeout_seconds == OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS
+        assert timeout_seconds == 90.0
         calls.append("restore")
 
     sidecar_client = MagicMock()
     sidecar_client.post_archive.side_effect = fake_post_archive
     monkeypatch.setattr(mgr, "_sidecar_client", sidecar_client)
 
-    assert mgr.restore_opencode_history_snapshot(sandbox_id, "tenant-test") is True
+    assert (
+        mgr.restore_opencode_history_snapshot(
+            sandbox_id, "tenant-test", timeout_seconds=90.0
+        )
+        is True
+    )
 
     sidecar_client.post_archive.assert_called_once()
     assert calls == ["restore"]
@@ -739,13 +743,18 @@ def test_restore_opencode_history_marks_sidecar_ready_when_no_snapshot(
         assert sandbox_id == expected_sandbox_id
         assert endpoint_path == SIDECAR_OPENCODE_HISTORY_MARK_RESTORED_PATH
         assert operation_label == "opencode history restore marker"
-        assert timeout_seconds == OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS
+        assert timeout_seconds == 90.0
 
     sidecar_client = MagicMock()
     sidecar_client.post_empty.side_effect = fake_mark_restored
     monkeypatch.setattr(mgr, "_sidecar_client", sidecar_client)
 
-    assert mgr.restore_opencode_history_snapshot(sandbox_id, "tenant-test") is False
+    assert (
+        mgr.restore_opencode_history_snapshot(
+            sandbox_id, "tenant-test", timeout_seconds=90.0
+        )
+        is False
+    )
 
     sidecar_client.post_empty.assert_called_once()
 
@@ -903,13 +912,17 @@ def test_provision_conflicting_not_ready_pod_runs_startup_restore(
     monkeypatch.setattr(
         mgr,
         "_wait_for_pod_ready",
-        MagicMock(side_effect=lambda _pod_name: calls.append("pod-ready") or True),
+        MagicMock(
+            side_effect=lambda _pod_name, _deadline: calls.append("pod-ready") or True
+        ),
     )
     monkeypatch.setattr(
         mgr,
         "_wait_for_opencode_serve_ready",
         MagicMock(
-            side_effect=lambda _sandbox_id: calls.append("opencode-ready") or True
+            side_effect=lambda _sandbox_id, timeout: (  # noqa: ARG005
+                calls.append("opencode-ready") or True
+            )
         ),
     )
 

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_k8s_workspace_setup_sentinel.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_k8s_workspace_setup_sentinel.py
@@ -1,0 +1,81 @@
+"""K8s workspace setup must fail loudly without the completion sentinel.
+
+The Kubernetes exec client returns whatever output was buffered when
+``_request_timeout`` lapses WITHOUT raising, and never raises on a nonzero
+exit — so the sentinel in the exec output is the only reliable success
+signal for ``setup_session_workspace``.
+"""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+import onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager as ksm
+from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
+    KubernetesSandboxManager,
+)
+from onyx.server.features.build.sandbox.models import CraftLLMProviderConfig
+from onyx.server.features.build.sandbox.session_workspace import (
+    WORKSPACE_SETUP_COMPLETE_SENTINEL,
+)
+from onyx.server.features.build.timeouts import WORKSPACE_SETUP_DEADLINE_SECONDS
+
+_LLM_CONFIG = CraftLLMProviderConfig(
+    provider="openai",
+    model_name="gpt-test",
+    api_key=None,
+    api_base=None,
+)
+
+
+def _make_manager(monkeypatch: pytest.MonkeyPatch) -> KubernetesSandboxManager:
+    mgr: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
+    mgr._namespace = "sandbox-test"  # type: ignore[attr-defined]
+    mgr._stream_core_api = MagicMock()  # type: ignore[attr-defined]
+    monkeypatch.setattr(
+        mgr,
+        "_load_agent_instructions",
+        lambda **_kwargs: "agent instructions",
+        raising=False,
+    )
+    return mgr
+
+
+def _run_setup(monkeypatch: pytest.MonkeyPatch, exec_output: str) -> SimpleNamespace:
+    mgr = _make_manager(monkeypatch)
+    captured = SimpleNamespace(kwargs={})
+
+    def fake_stream(*_args: Any, **kwargs: Any) -> str:
+        captured.kwargs = kwargs
+        return exec_output
+
+    monkeypatch.setattr(ksm, "k8s_stream", fake_stream)
+    mgr.setup_session_workspace(
+        sandbox_id=uuid4(),
+        session_id=uuid4(),
+        llm_config=_LLM_CONFIG,
+        nextjs_port=None,
+        connectable_apps_section="",
+    )
+    return captured
+
+
+def test_setup_succeeds_with_sentinel_and_passes_exec_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _run_setup(
+        monkeypatch, f"setup output\n{WORKSPACE_SETUP_COMPLETE_SENTINEL}\n"
+    )
+    assert captured.kwargs["_request_timeout"] == WORKSPACE_SETUP_DEADLINE_SECONDS
+
+
+def test_setup_raises_when_output_lacks_sentinel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Truncated-at-timeout and failed-partway execs look identical: buffered
+    # output with no sentinel.
+    with pytest.raises(RuntimeError, match="did not complete"):
+        _run_setup(monkeypatch, "Copying outputs template\nbun install ...")

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_send_message_timeout_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_send_message_timeout_plumbing.py
@@ -8,13 +8,13 @@ from uuid import uuid4
 
 from onyx.server.features.build.configs import (
     OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS,
-    PROMPT_SLOT_KEEP_ALIVE_MAX_SECONDS,
 )
 from onyx.server.features.build.sandbox.event_schema import PromptResponse
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
     KubernetesSandboxManager,
 )
 from onyx.server.features.build.sandbox.models import PromptAttachment
+from onyx.server.features.build.timeouts import PROMPT_SLOT_KEEP_ALIVE_MAX_SECONDS
 
 
 class _FakeServeClient:

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_session_workspace_script.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_session_workspace_script.py
@@ -46,11 +46,19 @@ class TestSetupScriptReplaySafety:
         outputs_index = script.index("Copying outputs template")
         assert touch_index < outputs_index < remove_index
 
-    def test_whole_setup_serialized_with_session_flock(self) -> None:
+    def test_materialization_serialized_with_session_flock(self) -> None:
         script = _setup_script()
         assert f"8>{_SESSION_PATH}.setup.lock" in script
         # The flock must open before any workspace mutation.
         assert script.index("flock -x 8") < script.index("mkdir -p")
+
+    def test_dev_server_starts_outside_the_setup_lock(self) -> None:
+        # A backgrounded dev server inside the flock subshell would inherit
+        # fd 8 and hold the setup lock for its entire lifetime, deadlocking
+        # every later repair/restore. It must start after the lock releases.
+        script = _setup_script()
+        lock_close = script.index(f"8>{_SESSION_PATH}.setup.lock")
+        assert script.index("bun run dev") > lock_close
 
     def test_agents_md_is_shell_quoted(self) -> None:
         # Content with quotes must round-trip through printf without breaking

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_session_workspace_script.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_session_workspace_script.py
@@ -1,0 +1,85 @@
+"""Replay-safety contract of the generated session-workspace scripts."""
+
+import shlex
+from uuid import uuid4
+
+from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
+    build_sandbox_labels,
+)
+from onyx.server.features.build.sandbox.labels import LABEL_PROVISIONING_GENERATION
+from onyx.server.features.build.sandbox.nextjs_dev import build_nextjs_start_script
+from onyx.server.features.build.sandbox.session_workspace import (
+    SETUP_IN_PROGRESS_MARKER,
+    build_session_workspace_setup_script,
+    build_workspace_exists_check_script,
+)
+
+_SESSION_PATH = "/workspace/sessions/00000000-0000-0000-0000-000000000000"
+
+
+def _setup_script(nextjs_port: int | None = 3010) -> str:
+    return build_session_workspace_setup_script(
+        session_path=_SESSION_PATH,
+        agents_md='# Agent\'s "instructions"',
+        session_opencode_config_json='{"model": "x"}',
+        nextjs_port=nextjs_port,
+    )
+
+
+class TestWorkspaceExistsCheck:
+    def test_reports_missing_while_setup_in_progress(self) -> None:
+        # A partial directory (marker present) must never be mistaken for a
+        # ready workspace; a legacy directory (outputs, no marker) reads as
+        # complete.
+        script = build_workspace_exists_check_script(_SESSION_PATH)
+        assert f'[ -d "{_SESSION_PATH}/outputs" ]' in script
+        assert f'[ ! -f "{_SESSION_PATH}/{SETUP_IN_PROGRESS_MARKER}" ]' in script
+        assert "WORKSPACE_FOUND" in script
+        assert "WORKSPACE_MISSING" in script
+
+
+class TestSetupScriptReplaySafety:
+    def test_marker_brackets_the_setup(self) -> None:
+        script = _setup_script()
+        touch_index = script.index(f"touch {_SESSION_PATH}/{SETUP_IN_PROGRESS_MARKER}")
+        remove_index = script.index(f"rm -f {_SESSION_PATH}/{SETUP_IN_PROGRESS_MARKER}")
+        outputs_index = script.index("Copying outputs template")
+        assert touch_index < outputs_index < remove_index
+
+    def test_whole_setup_serialized_with_session_flock(self) -> None:
+        script = _setup_script()
+        assert f"8>{_SESSION_PATH}.setup.lock" in script
+        # The flock must open before any workspace mutation.
+        assert script.index("flock -x 8") < script.index("mkdir -p")
+
+    def test_agents_md_is_shell_quoted(self) -> None:
+        # Content with quotes must round-trip through printf without breaking
+        # out of the script.
+        script = _setup_script()
+        assert shlex.quote('# Agent\'s "instructions"') in script
+        assert f"> {_SESSION_PATH}/AGENTS.md" in script
+
+    def test_headless_omits_nextjs_start(self) -> None:
+        script = _setup_script(nextjs_port=None)
+        assert "bun run dev" not in script
+
+
+class TestNextjsStartReplaySafety:
+    def test_reuses_live_server_instead_of_spawning_duplicate(self) -> None:
+        script = build_nextjs_start_script(_SESSION_PATH, 3010)
+        pid_guard = script.index(f"[ -f {_SESSION_PATH}/nextjs.pid ]")
+        spawn = script.index("nohup bun run dev")
+        assert pid_guard < spawn
+        assert "kill -0" in script
+
+
+class TestDockerSandboxLabels:
+    def test_generation_label_stamped_when_provided(self) -> None:
+        labels = build_sandbox_labels(
+            uuid4(), "tenant", None, provisioning_generation=7
+        )
+        assert labels[LABEL_PROVISIONING_GENERATION] == "7"
+
+    def test_generation_label_omitted_for_generation_free_resources(self) -> None:
+        labels = build_sandbox_labels(uuid4(), "tenant", None)
+        assert LABEL_PROVISIONING_GENERATION not in labels

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_session_workspace_script.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_session_workspace_script.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
     build_sandbox_labels,
 )
-from onyx.server.features.build.sandbox.labels import LABEL_PROVISIONING_GENERATION
+from onyx.server.features.build.sandbox.labels import LABEL_PROVISIONING_ATTEMPT
 from onyx.server.features.build.sandbox.nextjs_dev import build_nextjs_start_script
 from onyx.server.features.build.sandbox.session_workspace import (
     SETUP_IN_PROGRESS_MARKER,
@@ -84,10 +84,10 @@ class TestNextjsStartReplaySafety:
 class TestDockerSandboxLabels:
     def test_generation_label_stamped_when_provided(self) -> None:
         labels = build_sandbox_labels(
-            uuid4(), "tenant", None, provisioning_generation=7
+            uuid4(), "tenant", None, provisioning_attempt_number=7
         )
-        assert labels[LABEL_PROVISIONING_GENERATION] == "7"
+        assert labels[LABEL_PROVISIONING_ATTEMPT] == "7"
 
     def test_generation_label_omitted_for_generation_free_resources(self) -> None:
         labels = build_sandbox_labels(uuid4(), "tenant", None)
-        assert LABEL_PROVISIONING_GENERATION not in labels
+        assert LABEL_PROVISIONING_ATTEMPT not in labels

--- a/backend/tests/unit/onyx/server/features/craft/session/test_sandbox_status_writers.py
+++ b/backend/tests/unit/onyx/server/features/craft/session/test_sandbox_status_writers.py
@@ -8,14 +8,13 @@ and forces a conscious decision: route the transition through
 
 from tests.common.paths import find_ancestor_containing
 
-# The status-mutation surface: the attempt-number-checked transition helpers
-# and the raw setter. Any of these constitutes a sandbox-status write.
+# The status-mutation surface: the attempt-number-checked transition helpers.
+# Any of these constitutes a sandbox-status write.
 STATUS_MUTATION_HELPERS: tuple[str, ...] = (
     "begin_provisioning_attempt__no_commit",
     "begin_recovery_attempt__no_commit",
     "finalize_provisioning_attempt__no_commit",
     "sleep_running_sandbox__no_commit",
-    "update_sandbox_status__no_commit",
 )
 
 # Modules that MUST reference the status mutation (the spec).

--- a/backend/tests/unit/onyx/server/features/craft/session/test_sandbox_status_writers.py
+++ b/backend/tests/unit/onyx/server/features/craft/session/test_sandbox_status_writers.py
@@ -8,8 +8,8 @@ and forces a conscious decision: route the transition through
 
 from tests.common.paths import find_ancestor_containing
 
-# The status-mutation surface: the generation-fenced transition helpers and
-# the raw setter. Any of these constitutes a sandbox-status write.
+# The status-mutation surface: the attempt-number-checked transition helpers
+# and the raw setter. Any of these constitutes a sandbox-status write.
 STATUS_MUTATION_HELPERS: tuple[str, ...] = (
     "begin_provisioning_attempt__no_commit",
     "begin_recovery_attempt__no_commit",

--- a/backend/tests/unit/onyx/server/features/craft/session/test_sandbox_status_writers.py
+++ b/backend/tests/unit/onyx/server/features/craft/session/test_sandbox_status_writers.py
@@ -1,16 +1,26 @@
 """Pins the invariant that Craft sandbox status transitions live exclusively
 in the lifecycle module (plus the db layer that implements the mutation).
 
-Any new module referencing ``update_sandbox_status__no_commit`` fails this
-test and forces a conscious decision: route the transition through
+Any new module referencing a sandbox-status mutation helper fails this test
+and forces a conscious decision: route the transition through
 ``sandbox_lifecycle`` instead, or (rarely) extend the allowed set here.
 """
 
 from tests.common.paths import find_ancestor_containing
 
+# The status-mutation surface: the generation-fenced transition helpers and
+# the raw setter. Any of these constitutes a sandbox-status write.
+STATUS_MUTATION_HELPERS: tuple[str, ...] = (
+    "begin_provisioning_attempt__no_commit",
+    "begin_recovery_attempt__no_commit",
+    "finalize_provisioning_attempt__no_commit",
+    "sleep_running_sandbox__no_commit",
+    "update_sandbox_status__no_commit",
+)
+
 # Modules that MUST reference the status mutation (the spec).
 ALLOWED_REFERENCES: set[str] = {
-    # Canonical DB mutation.
+    # Canonical DB mutations.
     "onyx/server/features/build/db/sandbox.py",
     # Substrate-invariant transitions + invariants.
     "onyx/server/features/build/session/sandbox_lifecycle.py",
@@ -26,7 +36,8 @@ def _modules_referencing_status_mutation() -> set[str]:
     found: set[str] = set()
     for root in scan_roots:
         for path in sorted(root.rglob("*.py")):
-            if "update_sandbox_status__no_commit" in path.read_text(encoding="utf-8"):
+            text = path.read_text(encoding="utf-8")
+            if any(helper in text for helper in STATUS_MUTATION_HELPERS):
                 found.add(path.relative_to(backend_dir).as_posix())
     return found
 
@@ -36,7 +47,7 @@ def test_sandbox_status_writers_confined_to_lifecycle_and_db_layer() -> None:
 
     unexpected = found - ALLOWED_REFERENCES
     assert not unexpected, (
-        "New module(s) reference update_sandbox_status__no_commit: "
+        f"New module(s) reference a sandbox-status mutation helper: "
         f"{sorted(unexpected)}. Sandbox status transitions must go through "
         "onyx/server/features/build/session/sandbox_lifecycle.py."
     )

--- a/backend/tests/unit/onyx/server/features/craft/test_opencode_serve_ready_password_reset.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_opencode_serve_ready_password_reset.py
@@ -112,7 +112,7 @@ def test_reuse_existing_pod_clears_stale_tombstone() -> None:
             user_id=uuid4(),
             tenant_id="public",
             onyx_pat="pat-test",
-            provisioning_generation=1,
+            provisioning_attempt_number=1,
         )
 
     assert info.sandbox_id == sandbox_id

--- a/backend/tests/unit/onyx/server/features/craft/test_opencode_serve_ready_password_reset.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_opencode_serve_ready_password_reset.py
@@ -106,6 +106,7 @@ def test_reuse_existing_pod_clears_stale_tombstone() -> None:
         mock.patch.object(mgr, "_ensure_service_exists"),
         mock.patch.object(mgr, "_wait_for_pod_ready", return_value=True),
         mock.patch.object(mgr, "_wait_for_opencode_serve_ready", return_value=True),
+        mock.patch.object(mgr, "_stamp_pod_attempt_number"),
     ):
         info = mgr.provision(
             sandbox_id=sandbox_id,

--- a/backend/tests/unit/onyx/server/features/craft/test_opencode_serve_ready_password_reset.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_opencode_serve_ready_password_reset.py
@@ -112,6 +112,7 @@ def test_reuse_existing_pod_clears_stale_tombstone() -> None:
             user_id=uuid4(),
             tenant_id="public",
             onyx_pat="pat-test",
+            provisioning_generation=1,
         )
 
     assert info.sandbox_id == sandbox_id

--- a/backend/tests/unit/onyx/server/features/craft/test_opencode_serve_ready_password_reset.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_opencode_serve_ready_password_reset.py
@@ -106,7 +106,6 @@ def test_reuse_existing_pod_clears_stale_tombstone() -> None:
         mock.patch.object(mgr, "_ensure_service_exists"),
         mock.patch.object(mgr, "_wait_for_pod_ready", return_value=True),
         mock.patch.object(mgr, "_wait_for_opencode_serve_ready", return_value=True),
-        mock.patch.object(mgr, "_stamp_pod_attempt_number"),
     ):
         info = mgr.provision(
             sandbox_id=sandbox_id,

--- a/backend/tests/unit/onyx/server/features/craft/test_timeout_registry.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_timeout_registry.py
@@ -1,0 +1,118 @@
+"""Pins the Craft timeout registry: root values, derivations, and the
+ordering invariants documented in ``onyx/server/features/build/timeouts.py``.
+
+Value pins are the spec (hardcoded, not re-derived); relationship asserts are
+the invariants that must survive any retuning of a root. Constants defined at
+their point of use (single-file, free-standing) are imported from there.
+"""
+
+from onyx.server.features.build.configs import (
+    OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS,
+    OPENCODE_SERVE_EVENT_READ_TIMEOUT,
+    PROMPT_SLOT_LEASE_SECONDS,
+    SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS,
+    SANDBOX_HEARTBEAT_REFRESH_INTERVAL_SECONDS,
+    SANDBOX_IDLE_TIMEOUT_SECONDS,
+    SSE_KEEPALIVE_INTERVAL,
+)
+from onyx.server.features.build.interactive_turns.api import (
+    LIVE_STREAM_RUNNER_RETRY_SECONDS,
+)
+from onyx.server.features.build.interactive_turns.state import (
+    TURN_LOCK_LEASE_SECONDS,
+    TURN_LOCK_WAIT_SECONDS,
+)
+from onyx.server.features.build.timeouts import (
+    ACTIVE_TURN_TTL_SECONDS,
+    ATTEMPT_DEADLINE_SECONDS,
+    ATTEMPT_OVERHEAD_SECONDS,
+    BULK_TRANSFER_TIMEOUT_SECONDS,
+    CONNECT_TIMEOUT_SECONDS,
+    POLL_INTERVAL_SECONDS,
+    PROMPT_SLOT_FAST_FAIL_ACQUIRE_SECONDS,
+    PROMPT_SLOT_KEEP_ALIVE_MAX_SECONDS,
+    PROMPT_SLOT_WAIT_OUT_ORPHAN_SECONDS,
+    PROVISION_DEADLINE_SECONDS,
+    PROVISION_WAIT_SECONDS,
+    QUEUE_RESIDENCY_SECONDS,
+    REQUEST_ID_TTL_SECONDS,
+    RPC_TIMEOUT_SECONDS,
+    RUNNER_STALE_AFTER_SECONDS,
+    SESSION_FLOW_LOCK_LEASE_SECONDS,
+    TURN_BUDGET_SECONDS,
+    WORKSPACE_SETUP_DEADLINE_SECONDS,
+)
+
+
+def test_root_values_pin_the_spec() -> None:
+    assert PROVISION_DEADLINE_SECONDS == 180.0
+    assert TURN_BUDGET_SECONDS == 30 * 60
+    assert QUEUE_RESIDENCY_SECONDS == 15 * 60
+
+
+def test_provisioning_derivations() -> None:
+    assert ATTEMPT_OVERHEAD_SECONDS == 60.0
+    assert ATTEMPT_DEADLINE_SECONDS == 240.0
+    assert WORKSPACE_SETUP_DEADLINE_SECONDS == 180.0
+    # The identity is the spec: workspace setup shares the provision budget.
+    assert WORKSPACE_SETUP_DEADLINE_SECONDS == PROVISION_DEADLINE_SECONDS
+    assert SESSION_FLOW_LOCK_LEASE_SECONDS == 420
+    assert PROVISION_WAIT_SECONDS == 120.0
+
+
+def test_turn_derivations() -> None:
+    assert ACTIVE_TURN_TTL_SECONDS == 45 * 60
+    assert REQUEST_ID_TTL_SECONDS == 60 * 60
+    assert REQUEST_ID_TTL_SECONDS > ACTIVE_TURN_TTL_SECONDS
+    # The identity is the spec: a slot held past any possible turn is leaked.
+    assert PROMPT_SLOT_KEEP_ALIVE_MAX_SECONDS == TURN_BUDGET_SECONDS
+
+
+def test_keepalive_derivations() -> None:
+    # The couplings ARE the spec: env-tuning the keepalive must move runner
+    # staleness and the SSE idle timeout with it — a fixed stale threshold
+    # under a raised keepalive steals turns from healthy silent tool calls,
+    # and a fixed read timeout turns the event stream into reconnect churn.
+    # The literals pin the multipliers and the default keepalive together.
+    assert RUNNER_STALE_AFTER_SECONDS == 6 * SSE_KEEPALIVE_INTERVAL
+    assert RUNNER_STALE_AFTER_SECONDS == 90.0
+    assert OPENCODE_SERVE_EVENT_READ_TIMEOUT == 4 * SSE_KEEPALIVE_INTERVAL
+    assert OPENCODE_SERVE_EVENT_READ_TIMEOUT == 60.0
+    assert LIVE_STREAM_RUNNER_RETRY_SECONDS < RUNNER_STALE_AFTER_SECONDS
+
+
+def test_approval_inactivity_coupling() -> None:
+    # A tool call parked at the approval proxy holds the event stream silent
+    # for the full approval window; the inactivity backstop must outlast it.
+    assert (
+        OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS
+        > SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS
+    )
+
+
+def test_lock_invariants() -> None:
+    assert PROMPT_SLOT_WAIT_OUT_ORPHAN_SECONDS > PROMPT_SLOT_LEASE_SECONDS
+    assert PROMPT_SLOT_FAST_FAIL_ACQUIRE_SECONDS < PROMPT_SLOT_LEASE_SECONDS
+    assert TURN_LOCK_WAIT_SECONDS < TURN_LOCK_LEASE_SECONDS
+
+
+def test_ordering_chain() -> None:
+    mutex_leases = (TURN_LOCK_LEASE_SECONDS, PROMPT_SLOT_LEASE_SECONDS)
+
+    assert POLL_INTERVAL_SECONDS < CONNECT_TIMEOUT_SECONDS
+    assert CONNECT_TIMEOUT_SECONDS < min(mutex_leases)
+    assert max(mutex_leases) < PROVISION_DEADLINE_SECONDS
+    assert PROVISION_DEADLINE_SECONDS < ATTEMPT_DEADLINE_SECONDS
+    assert ATTEMPT_DEADLINE_SECONDS < QUEUE_RESIDENCY_SECONDS
+    assert QUEUE_RESIDENCY_SECONDS < TURN_BUDGET_SECONDS
+    assert TURN_BUDGET_SECONDS < ACTIVE_TURN_TTL_SECONDS
+    assert ACTIVE_TURN_TTL_SECONDS < REQUEST_ID_TTL_SECONDS
+    assert RPC_TIMEOUT_SECONDS < BULK_TRANSFER_TIMEOUT_SECONDS
+
+
+def test_idle_family_invariants() -> None:
+    # Heartbeat refresh must be far under the idle timeout or live sandboxes
+    # read as idle between refreshes.
+    assert (
+        SANDBOX_HEARTBEAT_REFRESH_INTERVAL_SECONDS * 10 <= SANDBOX_IDLE_TIMEOUT_SECONDS
+    )

--- a/backend/tests/unit/onyx/server/features/craft/test_timeout_registry.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_timeout_registry.py
@@ -56,7 +56,7 @@ def test_provisioning_derivations() -> None:
     assert WORKSPACE_SETUP_DEADLINE_SECONDS == 180.0
     # The identity is the spec: workspace setup shares the provision budget.
     assert WORKSPACE_SETUP_DEADLINE_SECONDS == PROVISION_DEADLINE_SECONDS
-    assert SESSION_FLOW_LOCK_LEASE_SECONDS == 420
+    assert SESSION_FLOW_LOCK_LEASE_SECONDS == 720
     assert PROVISION_WAIT_SECONDS == 120.0
 
 

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -1495,11 +1495,13 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
       let sessionData = await fetchSession(sessionId);
 
       // Check if session needs to be restored:
-      // - Sandbox is sleeping or terminated
+      // - Sandbox is sleeping, terminated, or failed (the backend treats
+      //   failed as reprovisionable — restore retries the attempt)
       // - Sandbox is running but session workspace is not loaded
       const needsRestore =
         sessionData.sandbox?.status === "sleeping" ||
         sessionData.sandbox?.status === "terminated" ||
+        sessionData.sandbox?.status === "failed" ||
         (sessionData.sandbox?.status === "running" &&
           !sessionData.session_loaded_in_sandbox);
 

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -5,6 +5,7 @@ import { DELETE_SUCCESS_DISPLAY_DURATION_MS } from "@/app/craft/constants";
 
 import {
   ApiSandboxResponse,
+  ApiSessionResponse,
   Artifact,
   ArtifactType,
   BuildMessage,
@@ -531,6 +532,22 @@ function splitActiveTurnTranscript(
   }
 
   return { messages: settledMessages, streamItems: activeStreamItems };
+}
+
+function mapApiSessionStatus(
+  apiStatus: ApiSessionResponse["status"]
+): SessionStatus {
+  switch (apiStatus) {
+    case "active":
+      return "active";
+    case "initializing":
+      // Backend is still building the workspace (or a create was
+      // interrupted); the next create/restore repairs it.
+      return "creating";
+    default:
+      // "idle" and "failed" both recover through the restore flow.
+      return "idle";
+  }
 }
 
 // Re-export types for consumers
@@ -1542,9 +1559,7 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
           ? "running"
           : needsRestore
             ? "creating"
-            : sessionData.status === "active"
-              ? "active"
-              : "idle";
+            : mapApiSessionStatus(sessionData.status);
       const persistedMessages = useDbMessages
         ? consolidateMessagesIntoTurns(messages)
         : currentSession!.messages;
@@ -1609,7 +1624,7 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
         // Hold the chip on "restoring" (and poll webapp readiness) until the
         // webapp actually serves, then flip to the real status below.
         updateSessionData(sessionId, {
-          status: sessionData.status === "active" ? "active" : "idle",
+          status: mapApiSessionStatus(sessionData.status),
           sandbox: sessionData.sandbox
             ? { ...sessionData.sandbox, status: "restoring" }
             : sessionData.sandbox,

--- a/web/src/app/craft/types/streamingTypes.ts
+++ b/web/src/app/craft/types/streamingTypes.ts
@@ -178,7 +178,7 @@ export interface ApiSessionResponse {
   id: string;
   user_id: string | null;
   name: string | null;
-  status: "active" | "idle" | "archived";
+  status: "initializing" | "active" | "idle" | "failed";
   created_at: string;
   last_activity_at: string;
   sandbox: ApiSandboxResponse | null;


### PR DESCRIPTION
## Description

Craft provisioning ran as one giant DB transaction spanning minutes of Kubernetes work. Because the egress proxy authorizes pods from its own DB connection, a mid-create pod was invisible — first-user provisioning failed npm bootstrap with `unidentified_sandbox` — and any failure rolled back to nothing.

**Fix: reserve → reconcile → finalize.** Commit the sandbox (`PROVISIONING`), its PAT, and the session (`INITIALIZING`) *before* any external work; do the pod/workspace work with no transaction open; then record the outcome (`RUNNING`/`ACTIVE`, or durable `FAILED`). Every attempt gets a number (`sandbox.provisioning_attempt_number`), and status writes only apply while the row still holds that number — so crashed, slow, or superseded attempts can't clobber newer state, and retries repair the same sandbox/session IDs instead of starting over. Runtime deletes are deliberately *not* attempt-fenced: a rare stale delete just kills a pod that unhealthy-`RUNNING` recovery rebuilds.

Also in this PR:
- New session statuses `INITIALIZING`/`FAILED` (web maps them to `creating` / the restore flow); attempts older than 240s are treated as dead and taken over.
- Durable per-user port reservations: partial unique index on `(user_id, nextjs_port)` arbitrates concurrent allocation; ports clear when the sandbox sleeps.
- Replay-safe workspace setup (per-session flock, in-progress marker, dev-server pid guard) plus a completion sentinel on the exec — the k8s exec client silently truncates on timeout.
- Create, restore, and the reaper share one per-user lock (work-dedup only; correctness is the attempt-number writes).
- Timeout consolidation: ~40 scattered constants collapse into `timeouts.py` — three roots (provision 180s, turn 30 min, queue residency 15 min) plus encoded derivations, pinned by a unit test. Fixes two latent bugs: runner staleness and the SSE read timeout are now derived from the env-tunable keepalive instead of secretly assuming its default.
- Behavior deltas: dead-attempt threshold 480s → 240s; provisioning-lock acquisition blocking-180s → non-blocking; headless provisioning wait 30s → 120s; Docker's provision deadline starts after the image pull.

## How Has This Been Tested?

- New EDU suite pins the durability contract: identity/PAT visible to an independent connection before the first external call, crash-resume under the same IDs, superseded attempts can't finalize, concurrent creators converge, self-deadline records `FAILED`.
- New unit tests: timeout registry invariants, exec completion sentinel, workspace-script replay safety. Existing craft EDU/unit suites adapted.
- 682 craft unit tests + `ty`/ruff/pre-commit/`tsc` locally; EDU, integration, and the migration run in CI. Live 12-scenario end-to-end matrix (create/wake/recover/concurrent/takeover/repair) verified on a kind cluster.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes sandbox provisioning durable with a reserve → reconcile → finalize lifecycle fenced by attempt numbers, replacing long DB transactions. Also consolidates Craft timeouts into a shared registry and unifies session-flow locking for more predictable behavior.

- **New Features**
  - Reserve commits `PROVISIONING` under a new `provisioning_attempt_number` with PAT and an `INITIALIZING` session (plus `provisioning_started_at`) before any external work; the proxy can authorize immediately.
  - Finalize conditionally on the attempt number to `RUNNING` or session `FAILED`; dead-attempt threshold is 240s; per-user reservation locks the user row; the provisioning lock is non-blocking with fast retry.
  - Attempt-scoped runtime safety: pods/containers are labeled `onyx.app/provisioning-attempt` for operator attribution only; deletes no longer enforce labels; if an adopted pod can’t be restamped to the new attempt, the attempt is marked `FAILED`.
  - Replay-safe workspace setup for Docker/K8s via `flock`, an in-progress marker, a completion sentinel, and a Next.js PID guard; dev server starts outside the setup lock; Kubernetes execs have an explicit deadline and verify the sentinel.
  - Durable per-user Next.js port reservation with a partial unique index `(user_id, nextjs_port)` and reserve-and-retry; empty sessions are repaired in place; managed content (skills, user library, connectable apps) is pushed during reconcile.
  - Central timeout registry `onyx.server.features.build.timeouts`: shared budgets and derived timeouts; self-deadlining attempts; explicit exec/workspace deadlines; SSE/runner couplings; behavior deltas include non-blocking provisioning-lock and shorter dead-attempt window.
  - Unified per-user session-flow lock (create/restore/reaper share one lease); API/frontend expose `initializing` and `failed` (web maps them to `creating` and `idle`).

- **Migration**
  - Run Alembic to add `sandbox.provisioning_attempt_number`, `sandbox.provisioning_started_at`, widen `build_session.status` for `initializing`/`failed`, and add a partial unique index on `(user_id, nextjs_port)` (legacy duplicates are nulled).
  - Clients must handle session statuses: `initializing`, `active`, `idle`, `failed`.

<sup>Written for commit c1d04568c75d327d127be6e5bc7321de001f8f49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

