### PR TITLE
feat(usage): add model cost overrides

### DIFF
--- a/web/src/lib/languageModels/costOverrides.ts
+++ b/web/src/lib/languageModels/costOverrides.ts
@@ -1,0 +1,114 @@
+"use client";
+
+import useSWR from "swr";
+import type { ScopedMutator } from "swr";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
+
+/**
+ * Admin-set negotiated per-model rate, overriding the built-in price book.
+ * Rates are USD per MILLION tokens. Keyed on (provider, model); provider is ""
+ * for a provider-agnostic override.
+ */
+export interface CostOverride {
+  model: string;
+  provider: string;
+  input_cost_per_mtok: number;
+  output_cost_per_mtok: number;
+  cache_read_cost_per_mtok: number | null; // null = bill cache at the input rate
+  updated_at: string | null;
+}
+
+/** PUT body — an idempotent upsert keyed on (provider, model). */
+export interface CostOverrideUpsert {
+  model: string;
+  provider?: string; // "" / omitted = provider-agnostic
+  input_cost_per_mtok: number;
+  output_cost_per_mtok: number;
+  cache_read_cost_per_mtok: number | null;
+}
+
+/**
+ * Lists existing cost overrides via `GET /api/admin/cost-overrides` (admin).
+ * Mutate `SWR_KEYS.costOverrides` after a write to revalidate.
+ */
+export function useCostOverrides() {
+  const { data, error, isLoading, mutate } = useSWR<CostOverride[]>(
+    SWR_KEYS.costOverrides,
+    errorHandlingFetcher,
+    { revalidateOnFocus: false }
+  );
+
+  return {
+    costOverrides: data,
+    isLoading,
+    error,
+    refetch: mutate,
+  };
+}
+
+/**
+ * Upserts a cost override. PUT is idempotent — re-sending an existing model
+ * updates its rates rather than erroring.
+ * @throws Error with the API detail message on failure.
+ */
+export async function upsertCostOverride(
+  body: CostOverrideUpsert
+): Promise<CostOverride> {
+  const response = await fetch(SWR_KEYS.costOverrides, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(await extractError(response));
+  }
+
+  return response.json();
+}
+
+/**
+ * Deletes a cost override by model name. A 404 (already gone) is swallowed —
+ * the caller's intent (override absent) is satisfied either way.
+ * @throws Error with the API detail message on non-404 failures.
+ */
+export async function deleteCostOverride(
+  model: string,
+  provider: string = ""
+): Promise<void> {
+  // Keep "/" as real path separators (backend route is {model:path}) but encode
+  // each segment, so slash-containing model ids (e.g. "bedrock/...") delete.
+  const encodedModel = model
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  const query = provider ? `?provider=${encodeURIComponent(provider)}` : "";
+  const response = await fetch(
+    `${SWR_KEYS.costOverrides}/${encodedModel}${query}`,
+    { method: "DELETE" }
+  );
+
+  if (response.ok || response.status === 404) {
+    return;
+  }
+
+  throw new Error(await extractError(response));
+}
+
+/** Revalidate the overrides list after a mutation. */
+export async function refreshCostOverrides(
+  mutate: ScopedMutator
+): Promise<void> {
+  await mutate(SWR_KEYS.costOverrides);
+}
+
+/** Pull the backend's `detail`/`error_code`, falling back to the status text. */
+async function extractError(response: Response): Promise<string> {
+  try {
+    const data = await response.json();
+    return data.detail || data.error_code || response.statusText;
+  } catch {
+    return response.statusText;
+  }
+}

--- a/web/src/lib/languageModels/options.test.ts
+++ b/web/src/lib/languageModels/options.test.ts
@@ -71,3 +71,18 @@ describe("llmOptionKey", () => {
     );
   });
 });
+
+describe("buildLlmOptions", () => {
+  it("includes hidden models when requested by an admin picker", () => {
+    const hiddenModel = {
+      ...makeModelConfiguration(11, "hidden-model"),
+      is_visible: false,
+    };
+    const providers = [makeProvider(1, "OpenAI", "openai", [hiddenModel])];
+
+    expect(buildLlmOptions(providers)).toHaveLength(0);
+    expect(buildLlmOptions(providers, undefined, true)).toEqual([
+      expect.objectContaining({ modelName: "hidden-model" }),
+    ]);
+  });
+});

--- a/web/src/lib/languageModels/options.ts
+++ b/web/src/lib/languageModels/options.ts
@@ -4,6 +4,11 @@ import { LLMProviderDescriptor } from "@/lib/languageModels/types";
 import { getModelIcon, getProvider } from "@/lib/languageModels";
 import { AGGREGATOR_PROVIDERS } from "@/lib/languageModels/svc";
 
+export type ModelOptionProvider = Pick<
+  LLMProviderDescriptor,
+  "id" | "name" | "provider" | "model_configurations"
+>;
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -73,13 +78,13 @@ export function llmOptionKey(option: {
 
 /**
  * Flattens an array of provider descriptors into a deduplicated list of
- * selectable model options. Hidden models are excluded unless their name
- * matches `currentModelName` (so an already-selected hidden model still
- * appears in the list).
+ * selectable model options. Hidden models require an existing selection or
+ * an explicit admin opt-in.
  */
 export function buildLlmOptions(
-  llmProviders: LLMProviderDescriptor[] | undefined,
-  currentModelName?: string
+  llmProviders: ModelOptionProvider[] | undefined,
+  currentModelName?: string,
+  includeHiddenModels = false
 ): LLMOption[] {
   if (!llmProviders) return [];
 
@@ -88,7 +93,10 @@ export function buildLlmOptions(
 
   llmProviders.forEach((llmProvider) => {
     llmProvider.model_configurations
-      .filter((mc) => mc.is_visible || mc.name === currentModelName)
+      .filter(
+        (mc) =>
+          includeHiddenModels || mc.is_visible || mc.name === currentModelName
+      )
       .forEach((mc) => {
         const key =
           mc.id != null ? `id:${mc.id}` : `${llmProvider.provider}:${mc.name}`;

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -43,6 +43,7 @@ export const SWR_KEYS = {
     `/api/admin/llm/built-in/options/${providerEndpoint}`,
   llmContextualCost: "/api/admin/llm/provider-contextual-cost",
   userUsage: (days: number) => `/api/user/usage?days=${days}`,
+  costOverrides: "/api/admin/cost-overrides",
 
   // ── Image Generation ──────────────────────────────────────────────────────
   imageGenConfig: "/api/admin/image-generation/config",

--- a/web/src/sections/model-selector/ModelSelector.tsx
+++ b/web/src/sections/model-selector/ModelSelector.tsx
@@ -6,6 +6,7 @@ import { getModelIcon } from "@/lib/languageModels";
 import {
   GLOBAL_DEFAULT_LLM_OPTION,
   LLMOption,
+  ModelOptionProvider,
 } from "@/lib/languageModels/options";
 import { useCurrentAgentLLMProviders } from "@/lib/languageModels/hooks";
 import ModelSelectorContent, {
@@ -18,6 +19,8 @@ export interface ModelSelectorProps {
   /** The currently selected model, identified by model_configuration_id. */
   value: number | null;
   onChange: (option: LLMOption) => void;
+  providerOptions?: ModelOptionProvider[];
+  includeHiddenModels?: boolean;
   requiresImageInput?: boolean;
 
   /**
@@ -52,6 +55,8 @@ export interface ModelSelectorProps {
 export default function ModelSelector({
   value,
   onChange,
+  providerOptions,
+  includeHiddenModels = false,
   requiresImageInput,
   renderTrigger,
   temperatureManager,
@@ -60,7 +65,9 @@ export default function ModelSelector({
   includeGlobalDefault = false,
   side = "top",
 }: ModelSelectorProps) {
-  const { llmProviders, defaultText } = useCurrentAgentLLMProviders();
+  const { llmProviders: currentAgentProviderOptions, defaultText } =
+    useCurrentAgentLLMProviders();
+  const llmProviders = providerOptions ?? currentAgentProviderOptions;
   const [open, setOpen] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
@@ -143,6 +150,8 @@ export default function ModelSelector({
       <Popover.Content side={side} align="end" width="xl" sticky="partial">
         <ModelSelectorContent
           currentModelName={currentOption?.modelName}
+          providerOptions={providerOptions}
+          includeHiddenModels={includeHiddenModels}
           requiresImageInput={requiresImageInput}
           onSelect={handleSelect}
           isSelected={isSelected}

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -26,6 +26,7 @@ import { Disabled, Hoverable, Interactive } from "@opal/core";
 import {
   GLOBAL_DEFAULT_LLM_OPTION,
   LLMOption,
+  ModelOptionProvider,
   buildLlmOptions,
   groupLlmOptions,
   llmOptionKey,
@@ -463,6 +464,8 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
 
 export interface ModelSelectorContentProps {
   currentModelName?: string;
+  providerOptions?: ModelOptionProvider[];
+  includeHiddenModels?: boolean;
   requiresImageInput?: boolean;
   onSelect: (option: LLMOption) => void;
   isSelected: (option: LLMOption) => boolean;
@@ -476,6 +479,8 @@ export interface ModelSelectorContentProps {
 
 export default function ModelSelectorContent({
   currentModelName,
+  providerOptions,
+  includeHiddenModels = false,
   requiresImageInput,
   onSelect,
   isSelected,
@@ -485,8 +490,14 @@ export default function ModelSelectorContent({
   modelDetail,
 }: ModelSelectorContentProps) {
   const [detailOption, setDetailOption] = useState<LLMOption | null>(null);
-  const { llmProviders, isLoading, defaultText } =
-    useCurrentAgentLLMProviders();
+  const {
+    llmProviders: currentAgentProviderOptions,
+    isLoading: currentAgentProvidersLoading,
+    defaultText,
+  } = useCurrentAgentLLMProviders();
+  const llmProviders = providerOptions ?? currentAgentProviderOptions;
+  const isLoading =
+    providerOptions === undefined && currentAgentProvidersLoading;
 
   const globalDefaultDisplayName = useMemo(() => {
     if (!defaultText || !llmProviders) return null;
@@ -501,8 +512,8 @@ export default function ModelSelectorContent({
   const scrollContainerRef = externalScrollRef ?? internalScrollRef;
 
   const llmOptions = useMemo(
-    () => buildLlmOptions(llmProviders, currentModelName),
-    [llmProviders, currentModelName]
+    () => buildLlmOptions(llmProviders, currentModelName, includeHiddenModels),
+    [llmProviders, currentModelName, includeHiddenModels]
   );
 
   const filteredOptions = useMemo(() => {

--- a/web/src/views/admin/CostOverridesPanel.test.tsx
+++ b/web/src/views/admin/CostOverridesPanel.test.tsx
@@ -44,6 +44,10 @@ jest.mock("@/lib/languageModels/costOverrides", () => ({
   upsertCostOverride: (...args: unknown[]) => mockUpsertCostOverride(...args),
 }));
 
+jest.mock("@/lib/languageModels/hooks", () => ({
+  useAdminLLMProviders: () => ({ llmProviders: [] }),
+}));
+
 jest.mock("@/sections/model-selector/ModelSelector", () => ({
   __esModule: true,
   default: ({

--- a/web/src/views/admin/CostOverridesPanel.test.tsx
+++ b/web/src/views/admin/CostOverridesPanel.test.tsx
@@ -1,0 +1,147 @@
+import type { ReactNode } from "react";
+import { render, screen, setupUser, waitFor } from "@tests/setup/test-utils";
+import CostOverridesPanel from "@/views/admin/CostOverridesPanel";
+import type { CostOverride } from "@/lib/languageModels/costOverrides";
+
+const mockMutate = jest.fn();
+const mockRefreshCostOverrides = jest.fn();
+const mockUpsertCostOverride = jest.fn();
+
+const costOverrides: CostOverride[] = [
+  {
+    model: "shared-model",
+    provider: "openai",
+    input_cost_per_mtok: 0.001,
+    output_cost_per_mtok: 2,
+    cache_read_cost_per_mtok: null,
+    updated_at: null,
+  },
+  {
+    model: "shared-model",
+    provider: "anthropic",
+    input_cost_per_mtok: 3,
+    output_cost_per_mtok: 4,
+    cache_read_cost_per_mtok: null,
+    updated_at: null,
+  },
+];
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  ...jest.requireActual("swr"),
+  useSWRConfig: () => ({ mutate: mockMutate }),
+}));
+
+jest.mock("@/lib/languageModels/costOverrides", () => ({
+  useCostOverrides: () => ({
+    costOverrides,
+    isLoading: false,
+    error: undefined,
+  }),
+  deleteCostOverride: jest.fn(),
+  refreshCostOverrides: (...args: unknown[]) =>
+    mockRefreshCostOverrides(...args),
+  upsertCostOverride: (...args: unknown[]) => mockUpsertCostOverride(...args),
+}));
+
+jest.mock("@/sections/model-selector/ModelSelector", () => ({
+  __esModule: true,
+  default: ({
+    onChange,
+    renderTrigger,
+  }: {
+    onChange: (option: {
+      modelName: string;
+      provider: string;
+      modelConfigurationId: number;
+    }) => void;
+    renderTrigger: () => ReactNode;
+  }) => (
+    <>
+      {renderTrigger()}
+      <button
+        onClick={() =>
+          onChange({
+            modelName: "shared-model",
+            provider: "anthropic",
+            modelConfigurationId: 1,
+          })
+        }
+      >
+        Choose Anthropic model
+      </button>
+    </>
+  ),
+}));
+
+describe("CostOverridesPanel", () => {
+  beforeEach(() => {
+    mockRefreshCostOverrides.mockResolvedValue(undefined);
+    mockUpsertCostOverride.mockResolvedValue(costOverrides[1]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("distinguishes the same model under different providers", () => {
+    render(<CostOverridesPanel />);
+
+    expect(screen.getByText(/OpenAI · In \$0.001/)).toBeInTheDocument();
+    expect(screen.getByText(/Anthropic · In \$3.00/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Edit Anthropic override for shared-model",
+      })
+    ).toBeInTheDocument();
+  });
+
+  test("preserves the provider when editing an override", async () => {
+    const user = setupUser();
+    render(<CostOverridesPanel />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Edit Anthropic override for shared-model",
+      })
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockUpsertCostOverride).toHaveBeenCalledWith({
+        model: "shared-model",
+        provider: "anthropic",
+        input_cost_per_mtok: 3,
+        output_cost_per_mtok: 4,
+        cache_read_cost_per_mtok: null,
+      });
+    });
+  });
+
+  test("saves the selected provider when adding an override", async () => {
+    const user = setupUser();
+    render(<CostOverridesPanel />);
+
+    await user.click(screen.getByRole("button", { name: "Add override" }));
+    await user.click(
+      screen.getByRole("button", { name: "Choose Anthropic model" })
+    );
+
+    await user.type(screen.getByPlaceholderText("3.00"), "3");
+    await user.type(screen.getByPlaceholderText("15.00"), "4");
+    const submitButton = screen.getAllByRole("button", {
+      name: "Add override",
+    })[1] as HTMLElement;
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockUpsertCostOverride).toHaveBeenCalledWith({
+        model: "shared-model",
+        provider: "anthropic",
+        input_cost_per_mtok: 3,
+        output_cost_per_mtok: 4,
+        cache_read_cost_per_mtok: null,
+      });
+    });
+  });
+});

--- a/web/src/views/admin/CostOverridesPanel.tsx
+++ b/web/src/views/admin/CostOverridesPanel.tsx
@@ -1,0 +1,355 @@
+"use client";
+
+import { ChangeEvent, useState } from "react";
+import { useSWRConfig } from "swr";
+import { ContentAction, PageLoader, toast } from "@opal/layouts";
+import {
+  Button,
+  Card,
+  InputTypeIn,
+  MessageCard,
+  OpenButton,
+  Text,
+} from "@opal/components";
+import { Hoverable } from "@opal/core";
+import { SvgCheck, SvgEdit, SvgPlus, SvgTrash, SvgX } from "@opal/icons";
+import { markdown } from "@opal/utils";
+import ModelSelector from "@/sections/model-selector/ModelSelector";
+import { getProvider } from "@/lib/languageModels";
+import { LLMOption } from "@/lib/languageModels/options";
+import * as GeneralLayouts from "@/layouts/general-layouts";
+import {
+  CostOverride,
+  deleteCostOverride,
+  refreshCostOverrides,
+  upsertCostOverride,
+  useCostOverrides,
+} from "@/lib/languageModels/costOverrides";
+
+const RATE_UNIT_LABEL = "USD per 1M tokens";
+const ALL_PROVIDERS_LABEL = "All providers";
+
+function getProviderDisplayName(provider: string): string {
+  return provider ? getProvider(provider).companyName : ALL_PROVIDERS_LABEL;
+}
+
+// Accepts integers/decimals only; "" is allowed mid-edit, validated on submit.
+function parseRate(raw: string): number | null {
+  if (raw.trim() === "") return null;
+  if (!/^\d*\.?\d+$/.test(raw.trim())) return null;
+  const value = Number(raw);
+  return Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function formatRate(value: number): string {
+  return `$${value.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 20,
+  })}`;
+}
+
+// Shared add/edit form for the idempotent upsert.
+
+interface OverrideFormProps {
+  // Editing an existing row locks the model name (it's the upsert key).
+  existing?: CostOverride;
+  onDone: () => void;
+}
+
+function OverrideForm({ existing, onDone }: OverrideFormProps) {
+  const { mutate } = useSWRConfig();
+  const [model, setModel] = useState(existing?.model ?? "");
+  const [provider, setProvider] = useState(existing?.provider ?? "");
+  const [inputRate, setInputRate] = useState(
+    existing ? String(existing.input_cost_per_mtok) : ""
+  );
+  const [outputRate, setOutputRate] = useState(
+    existing ? String(existing.output_cost_per_mtok) : ""
+  );
+  const [cacheRate, setCacheRate] = useState(
+    existing?.cache_read_cost_per_mtok != null
+      ? String(existing.cache_read_cost_per_mtok)
+      : ""
+  );
+  const [submitting, setSubmitting] = useState(false);
+
+  // The override keys on the model name; track the picked config id too so the
+  // selector can highlight the current choice.
+  const [modelConfigId, setModelConfigId] = useState<number | null>(null);
+
+  const isEdit = existing !== undefined;
+  const parsedInput = parseRate(inputRate);
+  const parsedOutput = parseRate(outputRate);
+  // Empty cache rate is valid (bill cache reads at the input rate); a non-empty
+  // but unparseable value must block submit, not silently drop to null.
+  const parsedCache = parseRate(cacheRate);
+  const cacheValid = cacheRate.trim() === "" || parsedCache !== null;
+  const modelLabel = model
+    ? `${getProviderDisplayName(provider)} · ${model}`
+    : "";
+  const canSubmit =
+    model.trim() !== "" &&
+    parsedInput !== null &&
+    parsedOutput !== null &&
+    cacheValid;
+
+  async function handleSubmit() {
+    if (!canSubmit || parsedInput === null || parsedOutput === null) return;
+    setSubmitting(true);
+    try {
+      await upsertCostOverride({
+        model: model.trim(),
+        provider,
+        input_cost_per_mtok: parsedInput,
+        output_cost_per_mtok: parsedOutput,
+        // Empty cache rate => null (cache reads bill at the input rate).
+        cache_read_cost_per_mtok: parsedCache,
+      });
+      await refreshCostOverrides(mutate);
+      toast.success(`Saved rate for ${model.trim()}.`);
+      onDone();
+    } catch (e) {
+      console.error("Failed to save cost override", e);
+      const message = e instanceof Error ? e.message : "Unknown error";
+      toast.error(`Failed to save override: ${message}`);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Card border="solid" rounding="lg">
+      <GeneralLayouts.Section
+        gap={0.75}
+        height="fit"
+        alignItems="stretch"
+        justifyContent="start"
+      >
+        <div className="flex flex-col gap-1">
+          <Text font="secondary-action" color="text-03">
+            Model
+          </Text>
+          {isEdit ? (
+            <InputTypeIn value={modelLabel} variant="readOnly" />
+          ) : (
+            <ModelSelector
+              value={modelConfigId}
+              onChange={(opt: LLMOption) => {
+                setModel(opt.modelName);
+                setProvider(opt.provider);
+                setModelConfigId(opt.modelConfigurationId ?? null);
+              }}
+              renderTrigger={() => (
+                <OpenButton>{modelLabel || "Select a model"}</OpenButton>
+              )}
+              side="bottom"
+            />
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-2">
+          <div className="flex flex-col gap-1">
+            <Text font="secondary-action" color="text-03">
+              {`Input rate (${RATE_UNIT_LABEL})`}
+            </Text>
+            <InputTypeIn
+              value={inputRate}
+              prefixText="$"
+              inputMode="decimal"
+              placeholder="3.00"
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setInputRate(e.target.value)
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <Text font="secondary-action" color="text-03">
+              {`Output rate (${RATE_UNIT_LABEL})`}
+            </Text>
+            <InputTypeIn
+              value={outputRate}
+              prefixText="$"
+              inputMode="decimal"
+              placeholder="15.00"
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setOutputRate(e.target.value)
+              }
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <Text font="secondary-action" color="text-03">
+            {`Cache-read rate (${RATE_UNIT_LABEL}, optional)`}
+          </Text>
+          <InputTypeIn
+            value={cacheRate}
+            prefixText="$"
+            inputMode="decimal"
+            placeholder="defaults to input rate"
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setCacheRate(e.target.value)
+            }
+          />
+        </div>
+
+        <div className="flex flex-row gap-2 justify-end">
+          <Button prominence="tertiary" onClick={onDone} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            icon={SvgCheck}
+            onClick={handleSubmit}
+            disabled={!canSubmit || submitting}
+          >
+            {isEdit ? "Save" : "Add override"}
+          </Button>
+        </div>
+      </GeneralLayouts.Section>
+    </Card>
+  );
+}
+
+// One configured override with edit and delete actions.
+
+interface OverrideRowProps {
+  override: CostOverride;
+}
+
+function OverrideRow({ override }: OverrideRowProps) {
+  const { mutate } = useSWRConfig();
+  const [editing, setEditing] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const providerDisplayName = getProviderDisplayName(override.provider);
+
+  async function handleDelete() {
+    setDeleting(true);
+    try {
+      await deleteCostOverride(override.model, override.provider);
+      await refreshCostOverrides(mutate);
+      toast.success(`Removed override for ${override.model}.`);
+    } catch (e) {
+      console.error("Failed to remove cost override", e);
+      const message = e instanceof Error ? e.message : "Unknown error";
+      toast.error(`Failed to remove override: ${message}`);
+      setDeleting(false);
+    }
+  }
+
+  if (editing) {
+    return (
+      <OverrideForm existing={override} onDone={() => setEditing(false)} />
+    );
+  }
+
+  return (
+    <Hoverable.Root group="OverrideRow">
+      <Card border="solid" rounding="lg" padding="sm">
+        <div className="flex flex-row items-center justify-between gap-2 p-2">
+          <div className="flex flex-col gap-0.5 min-w-0">
+            <Text font="main-ui-action" color="text-04" nowrap>
+              {override.model}
+            </Text>
+            <Text font="secondary-body" color="text-03">
+              {`${providerDisplayName} · In ${formatRate(
+                override.input_cost_per_mtok
+              )} · Out ${formatRate(override.output_cost_per_mtok)}${
+                override.cache_read_cost_per_mtok != null
+                  ? ` · Cache ${formatRate(override.cache_read_cost_per_mtok)}`
+                  : ""
+              } · ${RATE_UNIT_LABEL}`}
+            </Text>
+            {override.updated_at && (
+              <Text font="secondary-body" color="text-02">
+                {`Updated ${new Date(override.updated_at).toLocaleString()}`}
+              </Text>
+            )}
+          </div>
+
+          <div className="flex flex-row">
+            <Button
+              icon={SvgEdit}
+              prominence="tertiary"
+              aria-label={`Edit ${providerDisplayName} override for ${override.model}`}
+              disabled={deleting}
+              onClick={() => setEditing(true)}
+            />
+            <Hoverable.Item group="OverrideRow" variant="appear-on-hover">
+              <Button
+                icon={SvgTrash}
+                prominence="tertiary"
+                aria-label={`Delete ${providerDisplayName} override for ${override.model}`}
+                disabled={deleting}
+                onClick={handleDelete}
+              />
+            </Hoverable.Item>
+          </div>
+        </div>
+      </Card>
+    </Hoverable.Root>
+  );
+}
+
+// Section embedded on the Language Models page.
+
+export default function CostOverridesPanel() {
+  const { costOverrides, isLoading, error } = useCostOverrides();
+  const [adding, setAdding] = useState(false);
+
+  return (
+    <GeneralLayouts.Section
+      gap={0.75}
+      height="fit"
+      alignItems="stretch"
+      justifyContent="start"
+    >
+      <ContentAction
+        title="Cost Overrides"
+        description={markdown(
+          `Set negotiated per-model rates in **${RATE_UNIT_LABEL}**. These override the built-in price book for usage cost calculations.`
+        )}
+        sizePreset="main-content"
+        variant="section"
+        rightChildren={
+          <Button
+            icon={SvgPlus}
+            prominence="secondary"
+            disabled={adding}
+            onClick={() => setAdding(true)}
+          >
+            Add override
+          </Button>
+        }
+      />
+
+      {adding && <OverrideForm onDone={() => setAdding(false)} />}
+
+      {error ? (
+        <MessageCard
+          variant="error"
+          icon={SvgX}
+          title="Failed to load cost overrides."
+        />
+      ) : isLoading ? (
+        <PageLoader />
+      ) : costOverrides && costOverrides.length > 0 ? (
+        <div className="flex flex-col gap-2">
+          {costOverrides.map((override) => (
+            <OverrideRow
+              key={`${override.provider}:${override.model}`}
+              override={override}
+            />
+          ))}
+        </div>
+      ) : (
+        !adding && (
+          <MessageCard
+            variant="info"
+            title="No cost overrides set."
+            description={`Add one to apply a negotiated rate (${RATE_UNIT_LABEL}) for a model.`}
+          />
+        )
+      )}
+    </GeneralLayouts.Section>
+  );
+}

--- a/web/src/views/admin/CostOverridesPanel.tsx
+++ b/web/src/views/admin/CostOverridesPanel.tsx
@@ -17,6 +17,7 @@ import { markdown } from "@opal/utils";
 import ModelSelector from "@/sections/model-selector/ModelSelector";
 import { getProvider } from "@/lib/languageModels";
 import { LLMOption } from "@/lib/languageModels/options";
+import { useAdminLLMProviders } from "@/lib/languageModels/hooks";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import {
   CostOverride,
@@ -58,6 +59,7 @@ interface OverrideFormProps {
 
 function OverrideForm({ existing, onDone }: OverrideFormProps) {
   const { mutate } = useSWRConfig();
+  const { llmProviders } = useAdminLLMProviders();
   const [model, setModel] = useState(existing?.model ?? "");
   const [provider, setProvider] = useState(existing?.provider ?? "");
   const [inputRate, setInputRate] = useState(
@@ -134,6 +136,8 @@ function OverrideForm({ existing, onDone }: OverrideFormProps) {
           ) : (
             <ModelSelector
               value={modelConfigId}
+              providerOptions={llmProviders ?? []}
+              includeHiddenModels
               onChange={(opt: LLMOption) => {
                 setModel(opt.modelName);
                 setProvider(opt.provider);

--- a/web/src/views/admin/LanguageModelsPage.tsx
+++ b/web/src/views/admin/LanguageModelsPage.tsx
@@ -31,6 +31,7 @@ import { LLMProviderName, LLMProviderView } from "@/lib/languageModels/types";
 import { Section } from "@/layouts/general-layouts";
 import { markdown } from "@opal/utils";
 import { usePHFeatureFlag, PHFeatureFlag } from "@/lib/analytics/hooks";
+import CostOverridesPanel from "@/views/admin/CostOverridesPanel";
 
 const route = ADMIN_ROUTES.LLM_MODELS;
 
@@ -509,6 +510,11 @@ export default function LanguageModelsPage() {
             ))}
           </div>
         </Disabled>
+
+        <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+
+        {/* ── Cost Overrides — negotiated per-model rates for usage costing ── */}
+        <CostOverridesPanel />
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>
   );


### PR DESCRIPTION
## Description

- Extracted without functional changes from #12568 (`feat/usage-4-frontend`).
- Adds provider-specific negotiated model-rate overrides to Language Models settings.
- Supports input, output, and optional cache-read rates with add, edit, and delete flows.

What it looks like:
<img width="1268" height="544" alt="Populated_cost_overrides_13602" src="https://github.com/user-attachments/assets/237ac1ac-281c-433a-a878-b67737c46000" />
<img width="1842" height="882" alt="Cost_overrides_13602" src="https://github.com/user-attachments/assets/8222d386-0c69-461b-bf85-faeb506e74dc" />


## How Has This Been Tested?

- `CostOverridesPanel.test.tsx`
- `bun run types:check`
- Repository pre-commit hooks
- Manually verified the Cost Overrides panel against the local Onyx stack with Playwright MCP

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds provider-specific model cost overrides in Admin > Language Models so usage costs match negotiated pricing. Supports add, edit, and delete for input, output, and optional cache-read rates.

- **New Features**
  - New “Cost Overrides” panel on the Language Models page with a model picker and per-provider entries; same model names are handled separately per provider.
  - API: `GET/PUT/DELETE /api/admin/cost-overrides` with idempotent upsert and 404-tolerant delete.
  - Client: `useCostOverrides`, `upsertCostOverride`, `deleteCostOverride`, `refreshCostOverrides` using `SWR_KEYS.costOverrides`.
  - Rates are USD per 1M tokens; cache-read can be omitted to default to the input rate.

- **Bug Fixes**
  - Admin model picker now includes hidden models (uses the full admin provider catalog) so overrides can be set for hidden or agent-inaccessible models.

<sup>Written for commit e901f99bc69aa8fe1433bd3e7c9904f80a991085. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



