### PR TITLE
feat(usage): add admin per-user usage reporting

### DIFF
--- a/web/src/app/ee/admin/performance/usage/page.tsx
+++ b/web/src/app/ee/admin/performance/usage/page.tsx
@@ -7,6 +7,7 @@ import { QueryPerformanceChart } from "@/app/ee/admin/performance/usage/QueryPer
 import { PersonaMessagesChart } from "@/app/ee/admin/performance/usage/PersonaMessagesChart";
 import { useTimeRange } from "@/app/ee/admin/performance/lib";
 import UsageReports from "@/app/ee/admin/performance/usage/UsageReports";
+import PerUserUsagePanel from "@/views/admin/PerUserUsagePanel";
 import { Divider } from "@opal/components";
 import { useAdminAgents } from "@/lib/agents/hooks";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
@@ -33,6 +34,8 @@ export default function AnalyticsPage() {
           availablePersonas={agents}
           timeRange={timeRange}
         />
+        <Divider />
+        <PerUserUsagePanel />
         <Divider />
         <UsageReports />
       </SettingsLayouts.Body>

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -44,6 +44,8 @@ export const SWR_KEYS = {
   llmContextualCost: "/api/admin/llm/provider-contextual-cost",
   userUsage: (days: number) => `/api/user/usage?days=${days}`,
   costOverrides: "/api/admin/cost-overrides",
+  adminUsageExport: "/api/admin/usage/export",
+  adminUsageReset: "/api/admin/usage/reset",
 
   // ── Image Generation ──────────────────────────────────────────────────────
   imageGenConfig: "/api/admin/image-generation/config",

--- a/web/src/lib/usage/userUsage.ts
+++ b/web/src/lib/usage/userUsage.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import useSWR from "swr";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
+
+export interface UsageExportTotals {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cost_cents: number;
+}
+
+export interface UsageExportUser {
+  email: string;
+  totals: UsageExportTotals;
+}
+
+export interface UsageExportResponse {
+  start: string;
+  end: string;
+  users: UsageExportUser[];
+}
+
+/** Company-wide per-user usage with a revalidation callback. */
+export function useUsageExport() {
+  const { data, error, isLoading, mutate } = useSWR<UsageExportResponse>(
+    SWR_KEYS.adminUsageExport,
+    errorHandlingFetcher,
+    { revalidateOnFocus: false }
+  );
+
+  return { usage: data, isLoading, error, refetch: mutate };
+}
+
+/** Clears a user's current UTC-day usage bucket. */
+export async function resetUserUsage(userEmail: string): Promise<void> {
+  const response = await fetch(SWR_KEYS.adminUsageReset, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user_email: userEmail }),
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => null);
+    throw new Error(data?.detail || data?.error_code || response.statusText);
+  }
+}

--- a/web/src/lib/usage/userUsage.ts
+++ b/web/src/lib/usage/userUsage.ts
@@ -33,7 +33,7 @@ export function useUsageExport() {
   return { usage: data, isLoading, error, refetch: mutate };
 }
 
-/** Clears a user's current UTC-day usage bucket. */
+/** Clears a user's usage across active enforcement windows. */
 export async function resetUserUsage(userEmail: string): Promise<void> {
   const response = await fetch(SWR_KEYS.adminUsageReset, {
     method: "POST",

--- a/web/src/views/admin/PerUserUsagePanel.tsx
+++ b/web/src/views/admin/PerUserUsagePanel.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Button, Card, InputTypeIn, MessageCard, Text } from "@opal/components";
+import { SvgChevronLeft, SvgChevronRight, SvgX } from "@opal/icons";
+import { PageLoader, toast } from "@opal/layouts";
+import {
+  resetUserUsage,
+  useUsageExport,
+  UsageExportUser,
+} from "@/lib/usage/userUsage";
+
+const PAGE_SIZE = 10;
+
+type SortKey =
+  | "email"
+  | "input_tokens"
+  | "output_tokens"
+  | "cache_read_tokens"
+  | "cost_cents";
+type SortDir = "asc" | "desc";
+
+function formatTokens(n: number): string {
+  return n.toLocaleString();
+}
+
+function formatCost(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function sortValue(user: UsageExportUser, key: SortKey): number | string {
+  if (key === "email") return user.email.toLowerCase();
+  return user.totals[key];
+}
+
+interface UsageRowProps {
+  user: UsageExportUser;
+  onReset: () => void;
+}
+
+function UsageRow({ user, onReset }: UsageRowProps) {
+  const [resetting, setResetting] = useState(false);
+  const totals = user.totals;
+
+  async function handleReset() {
+    setResetting(true);
+    try {
+      await resetUserUsage(user.email);
+      toast.success(`Reset usage for ${user.email}.`);
+      onReset();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "unknown error";
+      toast.error(`Failed to reset usage: ${message}`);
+    } finally {
+      setResetting(false);
+    }
+  }
+
+  return (
+    <div
+      className="flex flex-row items-center gap-4 py-2"
+      data-testid={`usage-row-${user.email}`}
+    >
+      <div className="flex-1 truncate">
+        <Text font="main-ui-body">{user.email}</Text>
+      </div>
+      <div className="w-24 text-right">
+        <Text font="main-ui-body" color="text-03">
+          {formatTokens(totals.input_tokens)}
+        </Text>
+      </div>
+      <div className="w-24 text-right">
+        <Text font="main-ui-body" color="text-03">
+          {formatTokens(totals.output_tokens)}
+        </Text>
+      </div>
+      <div className="w-24 text-right">
+        <Text font="main-ui-body" color="text-03">
+          {formatTokens(totals.cache_read_tokens)}
+        </Text>
+      </div>
+      <div className="w-24 text-right">
+        <Text font="main-ui-body">{formatCost(totals.cost_cents)}</Text>
+      </div>
+      <Button
+        variant="default"
+        prominence="tertiary"
+        size="sm"
+        disabled={resetting}
+        onClick={handleReset}
+      >
+        Reset
+      </Button>
+    </div>
+  );
+}
+
+interface SortHeaderProps {
+  label: string;
+  sortKey: SortKey;
+  activeKey: SortKey;
+  dir: SortDir;
+  onSort: (key: SortKey) => void;
+  align: "left" | "right";
+}
+
+function SortHeader({
+  label,
+  sortKey,
+  activeKey,
+  dir,
+  onSort,
+  align,
+}: SortHeaderProps) {
+  const active = activeKey === sortKey;
+  const indicator = active ? (dir === "desc" ? " ↓" : " ↑") : "";
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => onSort(sortKey)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSort(sortKey);
+        }
+      }}
+      className={`cursor-pointer select-none ${
+        align === "right" ? "w-24 text-right" : "flex-1"
+      }`}
+    >
+      <Text font="main-ui-action" color={active ? "text-05" : "text-03"}>
+        {`${label}${indicator}`}
+      </Text>
+    </div>
+  );
+}
+
+/** Searchable, sortable admin per-user usage totals. */
+export default function PerUserUsagePanel() {
+  const { usage, isLoading, error, refetch } = useUsageExport();
+  const [page, setPage] = useState(0);
+  const [query, setQuery] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("cost_cents");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  const users = usage?.users ?? [];
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const filtered = q
+      ? users.filter((u) => u.email.toLowerCase().includes(q))
+      : users;
+    return [...filtered].sort((a, b) => {
+      const av = sortValue(a, sortKey);
+      const bv = sortValue(b, sortKey);
+      const cmp =
+        typeof av === "string" && typeof bv === "string"
+          ? av.localeCompare(bv)
+          : (av as number) - (bv as number);
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+  }, [users, query, sortKey, sortDir]);
+
+  const pageCount = Math.max(1, Math.ceil(visible.length / PAGE_SIZE));
+
+  // Jump back to the first page whenever the filter or sort reshapes the list.
+  useEffect(() => {
+    setPage(0);
+  }, [query, sortKey, sortDir]);
+
+  // Clamp the page when the list shrinks (e.g. a reset drops a user off).
+  useEffect(() => {
+    if (page > pageCount - 1) setPage(pageCount - 1);
+  }, [page, pageCount]);
+
+  function handleSort(key: SortKey) {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      // Numeric columns lead high→low (leaderboard); email reads A→Z.
+      setSortDir(key === "email" ? "asc" : "desc");
+    }
+  }
+
+  if (isLoading) return <PageLoader />;
+  if (error) {
+    return (
+      <MessageCard
+        variant="error"
+        icon={SvgX}
+        title="Failed to load per-user usage."
+      />
+    );
+  }
+
+  const pageUsers = visible.slice(
+    page * PAGE_SIZE,
+    page * PAGE_SIZE + PAGE_SIZE
+  );
+
+  return (
+    <Card border="solid" rounding="lg" padding="sm">
+      <div className="flex flex-col gap-2">
+        <Text font="heading-h3">Per-user usage</Text>
+        <Text font="secondary-body" color="text-03">
+          Tokens (input, output, cache reads) and cost per user over the report
+          window. Click a column to rank by it, or search by email. Reset clears
+          the user&apos;s current UTC-day usage; prior days are kept.
+        </Text>
+
+        <InputTypeIn
+          value={query}
+          placeholder="Search users by email…"
+          onChange={(e) => setQuery(e.target.value)}
+        />
+
+        {users.length === 0 ? (
+          <Text font="main-ui-body" color="text-03">
+            No usage recorded yet.
+          </Text>
+        ) : visible.length === 0 ? (
+          <Text font="main-ui-body" color="text-03">
+            {`No users match "${query}".`}
+          </Text>
+        ) : (
+          <>
+            <div className="overflow-x-auto">
+              <div className="min-w-[740px] flex flex-col divide-y divide-border-01">
+                <div className="flex flex-row items-center gap-4 py-2">
+                  <SortHeader
+                    label="User"
+                    sortKey="email"
+                    activeKey={sortKey}
+                    dir={sortDir}
+                    onSort={handleSort}
+                    align="left"
+                  />
+                  <SortHeader
+                    label="Input"
+                    sortKey="input_tokens"
+                    activeKey={sortKey}
+                    dir={sortDir}
+                    onSort={handleSort}
+                    align="right"
+                  />
+                  <SortHeader
+                    label="Output"
+                    sortKey="output_tokens"
+                    activeKey={sortKey}
+                    dir={sortDir}
+                    onSort={handleSort}
+                    align="right"
+                  />
+                  <SortHeader
+                    label="Cache"
+                    sortKey="cache_read_tokens"
+                    activeKey={sortKey}
+                    dir={sortDir}
+                    onSort={handleSort}
+                    align="right"
+                  />
+                  <SortHeader
+                    label="Cost"
+                    sortKey="cost_cents"
+                    activeKey={sortKey}
+                    dir={sortDir}
+                    onSort={handleSort}
+                    align="right"
+                  />
+                  <div className="w-[68px]" />
+                </div>
+                {pageUsers.map((user) => (
+                  <UsageRow key={user.email} user={user} onReset={refetch} />
+                ))}
+              </div>
+            </div>
+
+            {pageCount > 1 && (
+              <div className="flex flex-row items-center justify-end gap-3 pt-2">
+                <Button
+                  variant="default"
+                  prominence="tertiary"
+                  size="sm"
+                  icon={SvgChevronLeft}
+                  tooltip="Previous page"
+                  aria-label="Previous page"
+                  disabled={page === 0}
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                />
+                <Text font="main-ui-body" color="text-03">
+                  {`Page ${page + 1} of ${pageCount} · ${visible.length} users`}
+                </Text>
+                <Button
+                  variant="default"
+                  prominence="tertiary"
+                  size="sm"
+                  icon={SvgChevronRight}
+                  tooltip="Next page"
+                  aria-label="Next page"
+                  disabled={page >= pageCount - 1}
+                  onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+                />
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/web/src/views/admin/PerUserUsagePanel.tsx
+++ b/web/src/views/admin/PerUserUsagePanel.tsx
@@ -207,7 +207,7 @@ export default function PerUserUsagePanel() {
         <Text font="secondary-body" color="text-03">
           Tokens (input, output, cache reads) and cost per user over the report
           window. Click a column to rank by it, or search by email. Reset clears
-          the user&apos;s current UTC-day usage; prior days are kept.
+          usage from every currently active limit window.
         </Text>
 
         <InputTypeIn

--- a/web/tests/e2e/admin/per_user_usage.spec.ts
+++ b/web/tests/e2e/admin/per_user_usage.spec.ts
@@ -1,5 +1,6 @@
 import { test } from "@playwright/test";
 import { ChatPage } from "@tests/e2e/chat/ChatPage";
+import { TEST_ADMIN_CREDENTIALS } from "@tests/e2e/constants";
 import { AdminUsagePage } from "@tests/e2e/pages/AdminUsagePage";
 
 /**
@@ -21,6 +22,6 @@ test.describe("admin per-user usage table + reset", () => {
 
     const usage = new AdminUsagePage(page);
     await usage.goto();
-    await usage.resetFirstUser();
+    await usage.resetUser(TEST_ADMIN_CREDENTIALS.email);
   });
 });

--- a/web/tests/e2e/admin/per_user_usage.spec.ts
+++ b/web/tests/e2e/admin/per_user_usage.spec.ts
@@ -1,0 +1,26 @@
+import { test } from "@playwright/test";
+import { ChatPage } from "@tests/e2e/chat/ChatPage";
+import { AdminUsagePage } from "@tests/e2e/pages/AdminUsagePage";
+
+/**
+ * Admin per-user usage table + Reset. Real e2e (no mocking): the admin sends a
+ * chat to accrue usage, then the Usage Statistics page must list that usage per
+ * user, and the Reset action must clear it. Requires a working LLM provider in
+ * the e2e environment so the chat records token usage.
+ */
+test.use({ storageState: "admin_auth.json" });
+
+test.describe("admin per-user usage table + reset", () => {
+  test("usage shows per user and Reset clears it", async ({ page }) => {
+    // 1) Accrue usage by sending a chat as the admin.
+    const chat = new ChatPage(page);
+    await chat.goto();
+    await chat.inputBar.fill("hello there");
+    await chat.inputBar.send();
+    await chat.aiMessage(0).waitFor({ state: "visible", timeout: 60_000 });
+
+    const usage = new AdminUsagePage(page);
+    await usage.goto();
+    await usage.resetFirstUser();
+  });
+});

--- a/web/tests/e2e/pages/AdminUsagePage.ts
+++ b/web/tests/e2e/pages/AdminUsagePage.ts
@@ -16,8 +16,9 @@ export class AdminUsagePage {
     await expect(this.usageRows.first()).toBeVisible({ timeout: 15_000 });
   }
 
-  async resetFirstUser(): Promise<void> {
-    const row = this.usageRows.first();
+  async resetUser(email: string): Promise<void> {
+    const row = this.page.getByTestId(`usage-row-${email}`);
+    await expect(row).toBeVisible();
     const responsePromise = this.page.waitForResponse(
       (response) =>
         response.url().includes(RESET_ENDPOINT) &&
@@ -26,7 +27,7 @@ export class AdminUsagePage {
 
     await row.getByRole("button", { name: "Reset" }).click();
     expect((await responsePromise).ok()).toBeTruthy();
-    await expect(this.page.getByText(/reset usage for/i)).toBeVisible({
+    await expect(this.page.getByText(`Reset usage for ${email}.`)).toBeVisible({
       timeout: 10_000,
     });
   }

--- a/web/tests/e2e/pages/AdminUsagePage.ts
+++ b/web/tests/e2e/pages/AdminUsagePage.ts
@@ -1,0 +1,33 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+const RESET_ENDPOINT = "/api/admin/usage/reset";
+
+export class AdminUsagePage {
+  readonly page: Page;
+  readonly usageRows: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.usageRows = page.locator('[data-testid^="usage-row-"]');
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto("/admin/performance/usage");
+    await expect(this.usageRows.first()).toBeVisible({ timeout: 15_000 });
+  }
+
+  async resetFirstUser(): Promise<void> {
+    const row = this.usageRows.first();
+    const responsePromise = this.page.waitForResponse(
+      (response) =>
+        response.url().includes(RESET_ENDPOINT) &&
+        response.request().method() === "POST"
+    );
+
+    await row.getByRole("button", { name: "Reset" }).click();
+    expect((await responsePromise).ok()).toBeTruthy();
+    await expect(this.page.getByText(/reset usage for/i)).toBeVisible({
+      timeout: 10_000,
+    });
+  }
+}


### PR DESCRIPTION
## Description

- Extracted without functional changes from #12568 (`feat/usage-4-frontend`).
- Adds searchable, sortable, paginated per-user token and cost totals to Usage Statistics.
- Lets admins reset a user's current UTC-day usage bucket.

What it looks like:
<img width="1800" height="438" alt="Populated_per-user_usage_13603" src="https://github.com/user-attachments/assets/c911b9b3-719f-4a9c-8969-841286677f66" />
<img width="1842" height="882" alt="Admin_usage_reporting_13603" src="https://github.com/user-attachments/assets/361f695b-119b-4b5a-a2cd-931c0b9b8680" />


## How Has This Been Tested?

- `bun run playwright tests/e2e/admin/per_user_usage.spec.ts --workers=1`
- `bun run types:check`
- Repository pre-commit hooks
- Manually verified the per-user usage panel against the local Onyx stack with Playwright MCP

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-user usage report to the Admin Usage page with search, sort, and pagination. Admins can reset a user’s usage across all currently active limit windows.

- **New Features**
  - Added `PerUserUsagePanel` to `/admin/performance/usage`. Shows input/output/cache tokens and cost per user. Click-to-sort, email search, pagination.
  - Added `useUsageExport` and `resetUserUsage` using `SWR_KEYS.adminUsageExport` (`/api/admin/usage/export`) and `SWR_KEYS.adminUsageReset` (`/api/admin/usage/reset`).
  - Per-row Reset clears the selected user’s usage across all active windows, then refetches. UI copy and docs clarify the reset window.
  - Updated e2e to accrue usage as the admin and verify the Reset targets that user and posts successfully.

<sup>Written for commit 413869750fe9bbaf6c663952938a65d9850a8517. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



