### PR TITLE
feat(gateway): let external OpenAI-compatible clients use the LLM gateway

### DIFF
--- a/backend/onyx/auth/permissions.py
+++ b/backend/onyx/auth/permissions.py
@@ -50,6 +50,7 @@ IMPLIED_PERMISSIONS: dict[str, set[str]] = {
         Permission.READ_CHAT.value,
         Permission.WRITE_CHAT.value,
         Permission.GENERATE_IMAGE.value,
+        Permission.USE_LLM_GATEWAY.value,
     },
     Permission.WRITE_CHAT.value: {Permission.READ_CHAT.value},
     Permission.CRAFT_SANDBOX.value: {

--- a/backend/onyx/server/features/build/craft_gateway.py
+++ b/backend/onyx/server/features/build/craft_gateway.py
@@ -17,3 +17,15 @@ def is_craft_gateway_request(request: Request, user: User) -> bool:
         in resolve_effective_permissions({s.value for s in token_scopes})
     )
     return token_grants_gateway and is_craft_enabled_for_user(user)
+
+
+def is_gateway_request(request: Request, user: User) -> bool:
+    """A CRAFT_SANDBOX token must stay on the Craft policy, craft-enabled
+    requirement included; only a directly granted USE_LLM_GATEWAY skips it."""
+    token_scopes: list[Permission] | None = getattr(request.state, "token_scopes", None)
+    if token_scopes is None:
+        return False
+    raw_scopes = {s.value for s in token_scopes}
+    if Permission.CRAFT_SANDBOX.value in raw_scopes:
+        return is_craft_gateway_request(request, user)
+    return Permission.USE_LLM_GATEWAY.value in resolve_effective_permissions(raw_scopes)

--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -12,7 +12,10 @@ from sqlalchemy.orm import Session
 from onyx.auth.permissions import require_permission
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
-from onyx.db.llm import fetch_accessible_llm_provider_by_id
+from onyx.db.llm import (
+    fetch_accessible_llm_provider_by_id,
+    fetch_all_accessible_llm_providers,
+)
 from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -34,14 +37,17 @@ from onyx.llm.models import (
 from onyx.llm.multi_llm import LLMRateLimitError, LLMTimeoutError
 from onyx.llm.prompt_cache.processor import process_with_prompt_cache
 from onyx.llm.tracing_wrap import _finalize_tool_calls, _merge_tool_call_delta
-from onyx.server.features.build.craft_gateway import is_craft_gateway_request
+from onyx.server.features.build.craft_gateway import is_gateway_request
 from onyx.server.gateway.configs import GATEWAY_PATH_PREFIX
+from onyx.server.gateway.model_catalog import build_gateway_model_catalog
 from onyx.server.gateway.models import (
     ChatCompletionChunk,
     ChatCompletionRequest,
     ChatCompletionResponse,
+    ModelListResponse,
 )
 from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
+from onyx.server.query_and_chat.token_limit import check_token_rate_limits
 from onyx.tracing.flows import LLMFlow
 from onyx.tracing.llm_utils import (
     llm_generation_span,
@@ -58,7 +64,7 @@ router = APIRouter(prefix=GATEWAY_PATH_PREFIX)
 # Callers never supply the flow; the endpoint picks it and this mapping
 # enforces the matching credential.
 _FLOW_ACCESS_CHECKS: dict[LLMFlow, Callable[[Request, User], bool]] = {
-    LLMFlow.CRAFT_LLM_GENERATION: is_craft_gateway_request,
+    LLMFlow.CRAFT_LLM_GENERATION: is_gateway_request,
 }
 
 _MESSAGES_ADAPTER: TypeAdapter[list[ChatCompletionMessage]] = TypeAdapter(
@@ -147,6 +153,13 @@ def _prepare_messages(
     try:
         messages = _MESSAGES_ADAPTER.validate_python(raw_messages)
     except ValidationError as e:
+        # Shapes only: message content is user data the gateway does not persist.
+        logger.warning(
+            "LLM gateway rejected %d message(s): roles=%s errors=%s",
+            len(raw_messages),
+            [m.get("role") for m in raw_messages if isinstance(m, dict)],
+            [(tuple(err["loc"][:4]), err["type"]) for err in e.errors()[:10]],
+        )
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT, f"Invalid messages: {e.error_count()} errors"
         ) from e
@@ -444,11 +457,10 @@ def handle_chat_completion(
     return ChatCompletionResponse.from_model_response(response, request.model)
 
 
-@router.post("/v1/chat/completions")
-def gateway_chat_completions(
-    request: ChatCompletionRequest,
+@router.get("/v1/models")
+def gateway_list_models(
     http_request: Request,
-    user: User = Depends(require_permission(Permission.READ_SEARCH)),
+    user: User = Depends(require_permission(Permission.USE_LLM_GATEWAY)),
     db_session: Session = Depends(get_session),
 ) -> Response:
     flow = LLMFlow.CRAFT_LLM_GENERATION
@@ -457,6 +469,25 @@ def gateway_chat_completions(
             OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
             "This credential is not authorized to use the Onyx LLM gateway.",
         )
+    providers = fetch_all_accessible_llm_providers(db_session, user)
+    catalog = build_gateway_model_catalog(providers)
+    return JSONResponse(content=ModelListResponse.from_catalog(catalog).to_wire())
+
+
+@router.post("/v1/chat/completions")
+def gateway_chat_completions(
+    request: ChatCompletionRequest,
+    http_request: Request,
+    user: User = Depends(require_permission(Permission.USE_LLM_GATEWAY)),
+    db_session: Session = Depends(get_session),
+) -> Response:
+    flow = LLMFlow.CRAFT_LLM_GENERATION
+    if not _FLOW_ACCESS_CHECKS[flow](http_request, user):
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "This credential is not authorized to use the Onyx LLM gateway.",
+        )
+    check_token_rate_limits(user)
     provider, model_config = resolve_gateway_model(db_session, user, request.model)
     result = handle_chat_completion(
         request=request,

--- a/backend/onyx/server/gateway/models.py
+++ b/backend/onyx/server/gateway/models.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import Any, Literal, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -200,4 +201,28 @@ class ChatCompletionChunk(_WireModel):
                 )
             ],
             **chunk_kwargs,
+        )
+
+
+class ModelListEntry(_WireModel):
+    id: str
+    object: Literal["model"] = "model"
+    owned_by: str
+
+    @classmethod
+    def from_descriptor(cls, descriptor: GatewayModelDescriptor) -> "ModelListEntry":
+        return cls(id=descriptor.id, object="model", owned_by=descriptor.provider)
+
+
+class ModelListResponse(_WireModel):
+    object: Literal["list"] = "list"
+    data: list[ModelListEntry]
+
+    @classmethod
+    def from_catalog(
+        cls, catalog: Sequence[GatewayModelDescriptor]
+    ) -> "ModelListResponse":
+        return cls(
+            object="list",
+            data=[ModelListEntry.from_descriptor(d) for d in catalog],
         )

--- a/backend/onyx/server/pat/models.py
+++ b/backend/onyx/server/pat/models.py
@@ -45,6 +45,12 @@ _ASSIGNABLE_SCOPES: list[PatScopeOption] = [
         label="Write",
         description="Create sessions and send messages.",
     ),
+    PatScopeOption(
+        scope=Permission.USE_LLM_GATEWAY,
+        group_label="LLM Gateway",
+        label="Use",
+        description="Call the LLM gateway from external tools.",
+    ),
 ]
 
 SELECTABLE_PAT_SCOPES: dict[Permission, PatScopeOption] = {

--- a/backend/tests/external_dependency_unit/db/test_api_key_auth_result.py
+++ b/backend/tests/external_dependency_unit/db/test_api_key_auth_result.py
@@ -4,7 +4,10 @@ from sqlalchemy.orm import Session
 from onyx.auth.api_key import hash_api_key
 from onyx.auth.schemas import UserRole
 from onyx.db.api_key import fetch_api_key_auth_result, insert_api_key, remove_api_key
-from onyx.db.engine.async_sql_engine import get_async_session_context_manager
+from onyx.db.engine.async_sql_engine import (
+    get_async_session_context_manager,
+    reset_sqlalchemy_async_engine,
+)
 from onyx.server.api_key.models import APIKeyArgs
 
 
@@ -37,3 +40,6 @@ async def test_fetch_api_key_auth_result_loads_user(db_session: Session) -> None
             )
     finally:
         remove_api_key(db_session, descriptor.api_key_id)
+        # Async pools are bound to this test's event loop; leaving them open
+        # makes a later async test fail depending on selection order.
+        await reset_sqlalchemy_async_engine()

--- a/backend/tests/integration/tests/permissions/test_pat_scope_assignment.py
+++ b/backend/tests/integration/tests/permissions/test_pat_scope_assignment.py
@@ -9,6 +9,7 @@ EXPECTED_SELECTABLE_SCOPES = {
     Permission.READ_SEARCH.value,
     Permission.READ_CHAT.value,
     Permission.WRITE_CHAT.value,
+    Permission.USE_LLM_GATEWAY.value,
 }
 
 
@@ -28,6 +29,7 @@ def test_scope_implications(permission_basic_user: DATestUser) -> None:
     ]
     assert by_scope[Permission.READ_CHAT.value]["implies"] == []
     assert by_scope[Permission.READ_SEARCH.value]["implies"] == []
+    assert by_scope[Permission.USE_LLM_GATEWAY.value]["implies"] == []
 
 
 def test_scopes_round_trip(permission_basic_user: DATestUser) -> None:

--- a/backend/tests/unit/onyx/auth/test_permissions.py
+++ b/backend/tests/unit/onyx/auth/test_permissions.py
@@ -52,6 +52,7 @@ class TestResolveEffectivePermissions:
             "read:chat",
             "write:chat",
             "generate:image",
+            "use:llm_gateway",
         }
 
     def test_write_chat_implies_read_chat(self) -> None:
@@ -119,6 +120,7 @@ class TestResolveEffectivePermissions:
             "read:chat",
             "write:chat",
             "generate:image",
+            "use:llm_gateway",
             "add:agents",
             "read:agents",
             "manage:connectors",
@@ -182,6 +184,7 @@ class TestGetEffectivePermissions:
             Permission.READ_CHAT,
             Permission.WRITE_CHAT,
             Permission.GENERATE_IMAGE,
+            Permission.USE_LLM_GATEWAY,
         }
 
     def test_empty_column(self) -> None:
@@ -334,6 +337,7 @@ class TestAnonymousUserPermissions:
             Permission.READ_CHAT,
             Permission.WRITE_CHAT,
             Permission.GENERATE_IMAGE,
+            Permission.USE_LLM_GATEWAY,
         }
 
     @pytest.mark.asyncio
@@ -388,6 +392,7 @@ class TestApiSurfaceScopeRegistration:
             "read:chat",
             "write:chat",
             "generate:image",
+            "use:llm_gateway",
         }
         assert IMPLIED_PERMISSIONS["write:chat"] == {"read:chat"}
         # The craft role scope grants company-search and image generation, never

--- a/backend/tests/unit/onyx/server/features/craft/test_craft_gateway.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_craft_gateway.py
@@ -8,7 +8,10 @@ from fastapi import Request
 from onyx.db.enums import Permission
 from onyx.db.models import User
 from onyx.server.features.build import craft_gateway
-from onyx.server.features.build.craft_gateway import is_craft_gateway_request
+from onyx.server.features.build.craft_gateway import (
+    is_craft_gateway_request,
+    is_gateway_request,
+)
 
 
 def _request(token_scopes: list[Permission] | None) -> Request:
@@ -22,7 +25,9 @@ def test_gateway_requires_gateway_capable_token_scope() -> None:
     user = cast(User, MagicMock(spec=User))
     with patch.object(craft_gateway, "is_craft_enabled_for_user", return_value=True):
         assert not is_craft_gateway_request(_request(None), user)
-        assert not is_craft_gateway_request(_request([Permission.BASIC_ACCESS]), user)
+        # Not BASIC_ACCESS: it now implies USE_LLM_GATEWAY, so a basic-scoped
+        # token is gateway-capable and would make this assertion vacuous.
+        assert not is_craft_gateway_request(_request([Permission.READ_CHAT]), user)
 
 
 def test_gateway_accepts_enabled_craft_sandbox() -> None:
@@ -41,3 +46,29 @@ def test_gateway_rejects_craft_sandbox_scope_when_craft_disabled() -> None:
     user = cast(User, MagicMock(spec=User))
     with patch.object(craft_gateway, "is_craft_enabled_for_user", return_value=False):
         assert not is_craft_gateway_request(_request([Permission.CRAFT_SANDBOX]), user)
+
+
+def test_general_gateway_rejects_no_token_scopes() -> None:
+    user = cast(User, MagicMock(spec=User))
+    assert not is_gateway_request(_request(None), user)
+
+
+def test_general_gateway_rejects_scope_without_gateway_grant() -> None:
+    user = cast(User, MagicMock(spec=User))
+    assert not is_gateway_request(_request([Permission.READ_SEARCH]), user)
+
+
+def test_general_gateway_accepts_plain_gateway_scope_without_craft() -> None:
+    user = cast(User, MagicMock(spec=User))
+    with patch.object(craft_gateway, "is_craft_enabled_for_user", return_value=False):
+        assert is_gateway_request(
+            _request([Permission.READ_SEARCH, Permission.USE_LLM_GATEWAY]), user
+        )
+
+
+def test_general_gateway_defers_craft_sandbox_scope_to_craft_policy() -> None:
+    user = cast(User, MagicMock(spec=User))
+    with patch.object(craft_gateway, "is_craft_enabled_for_user", return_value=True):
+        assert is_gateway_request(_request([Permission.CRAFT_SANDBOX]), user)
+    with patch.object(craft_gateway, "is_craft_enabled_for_user", return_value=False):
+        assert not is_gateway_request(_request([Permission.CRAFT_SANDBOX]), user)

--- a/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import threading
+from collections.abc import Awaitable, Callable
 from contextlib import nullcontext
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
@@ -11,6 +12,7 @@ from fastapi import FastAPI, Request
 from fastapi.routing import APIRoute
 from sqlalchemy.orm import Session
 
+from onyx.db.enums import Permission
 from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -42,7 +44,8 @@ from onyx.llm.models import (
 from onyx.llm.models import FunctionCall as ToolFunctionCall
 from onyx.llm.multi_llm import LLMRateLimitError, LLMTimeoutError
 from onyx.server.auth_check import check_router_auth
-from onyx.server.features.build.craft_gateway import is_craft_gateway_request
+from onyx.server.features.build import craft_gateway
+from onyx.server.features.build.craft_gateway import is_gateway_request
 from onyx.server.gateway import api as gateway_api
 from onyx.server.gateway.configs import GATEWAY_PATH_PREFIX
 from onyx.server.gateway.models import (
@@ -51,6 +54,34 @@ from onyx.server.gateway.models import (
 )
 from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
 from onyx.tracing.flows import LLMFlow
+
+
+def _pat_request(token_scopes: list[Permission] | None) -> Request:
+    request = Request({"type": "http", "headers": []})
+    if token_scopes is not None:
+        request.state.token_scopes = token_scopes
+    return request
+
+
+def _route_permission_dependency(path: str) -> Callable[..., Awaitable[User]]:
+    # Pulled off the live route rather than rebuilt, so these tests follow the
+    # permission the endpoint actually enforces.
+    application = FastAPI(openapi_url=None, docs_url=None, redoc_url=None)
+    application.include_router(gateway_api.router)
+    route = cast(
+        APIRoute,
+        next(
+            route
+            for route in application.routes
+            if getattr(route, "path", None) == f"{GATEWAY_PATH_PREFIX}{path}"
+        ),
+    )
+    dependency = next(
+        dep.call
+        for dep in route.dependant.dependencies
+        if getattr(dep.call, "_is_require_permission", False)
+    )
+    return cast("Callable[..., Awaitable[User]]", dependency)
 
 
 def _model(
@@ -776,6 +807,7 @@ def test_endpoint_applies_craft_policy() -> None:
             return_value=(provider, model_config),
         ) as resolve_model,
         patch.object(gateway_api, "handle_chat_completion") as handle,
+        patch.object(gateway_api, "check_token_rate_limits"),
     ):
         handle.return_value.to_wire.return_value = {}
         gateway_api.gateway_chat_completions(
@@ -796,10 +828,45 @@ def test_endpoint_applies_craft_policy() -> None:
     )
 
 
-def test_craft_flow_is_gated_by_craft_credential_check() -> None:
+def test_endpoint_enforces_token_rate_limits_before_calling_provider() -> None:
+    request = ChatCompletionRequest(
+        model="1/test",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    db_session = cast(Session, MagicMock(spec=Session))
+    user = cast(User, MagicMock(spec=User))
+    http_request = cast(Request, MagicMock(spec=Request))
+
+    rate_limited = OnyxError(OnyxErrorCode.RATE_LIMITED, "over budget")
+    with (
+        patch.dict(
+            gateway_api._FLOW_ACCESS_CHECKS,
+            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=True)},
+        ),
+        patch.object(
+            gateway_api, "check_token_rate_limits", side_effect=rate_limited
+        ) as rate_check,
+        patch.object(gateway_api, "resolve_gateway_model") as resolve_model,
+        patch.object(gateway_api, "handle_chat_completion") as handle,
+        pytest.raises(OnyxError) as exc_info,
+    ):
+        gateway_api.gateway_chat_completions(
+            request=request,
+            http_request=http_request,
+            user=user,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.RATE_LIMITED
+    rate_check.assert_called_once_with(user)
+    resolve_model.assert_not_called()
+    handle.assert_not_called()
+
+
+def test_craft_flow_is_gated_by_general_gateway_credential_check() -> None:
     assert (
         gateway_api._FLOW_ACCESS_CHECKS[LLMFlow.CRAFT_LLM_GENERATION]
-        is is_craft_gateway_request
+        is is_gateway_request
     )
 
 
@@ -822,3 +889,186 @@ def test_endpoint_rejects_non_gateway_credentials() -> None:
             db_session=cast(Session, MagicMock(spec=Session)),
         )
     assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+
+
+class TestGatewayAuthComposition:
+    @staticmethod
+    def _basic_user() -> User:
+        user = MagicMock()
+        user.effective_permissions = ["basic"]
+        return cast(User, user)
+
+    @staticmethod
+    def _base_dep() -> Callable[..., Awaitable[User]]:
+        return _route_permission_dependency("/v1/chat/completions")
+
+    @pytest.mark.asyncio
+    async def test_plain_gateway_scoped_pat_is_accepted(self) -> None:
+        user = self._basic_user()
+        request = _pat_request([Permission.READ_SEARCH, Permission.USE_LLM_GATEWAY])
+        base_dep = self._base_dep()
+
+        assert await base_dep(request=request, user=user) is user
+        with patch.object(
+            craft_gateway, "is_craft_enabled_for_user", return_value=False
+        ):
+            assert is_gateway_request(request, user)
+
+    @pytest.mark.asyncio
+    async def test_craft_sandbox_pat_still_works_unchanged(self) -> None:
+        user = self._basic_user()
+        request = _pat_request([Permission.CRAFT_SANDBOX])
+        base_dep = self._base_dep()
+
+        assert await base_dep(request=request, user=user) is user
+        with patch.object(
+            craft_gateway, "is_craft_enabled_for_user", return_value=True
+        ):
+            assert is_gateway_request(request, user)
+        with patch.object(
+            craft_gateway, "is_craft_enabled_for_user", return_value=False
+        ):
+            assert not is_gateway_request(request, user)
+
+    @pytest.mark.asyncio
+    async def test_unrestricted_pat_is_rejected(self) -> None:
+        """scopes=None is an unrestricted PAT, not a scope-less one."""
+        user = self._basic_user()
+        request = _pat_request(None)
+
+        assert not is_gateway_request(request, user)
+
+    @pytest.mark.asyncio
+    async def test_session_and_api_key_auth_are_rejected(self) -> None:
+        """Session auth and plain API keys never set token_scopes."""
+        user = self._basic_user()
+        request = Request({"type": "http", "headers": []})
+
+        assert not is_gateway_request(request, user)
+
+    @pytest.mark.asyncio
+    async def test_gateway_scope_alone_passes_both_gates(self) -> None:
+        user = self._basic_user()
+        request = _pat_request([Permission.USE_LLM_GATEWAY])
+        base_dep = self._base_dep()
+
+        assert await base_dep(request=request, user=user) is user
+        with patch.object(
+            craft_gateway, "is_craft_enabled_for_user", return_value=False
+        ):
+            assert is_gateway_request(request, user)
+
+    @pytest.mark.asyncio
+    async def test_read_search_scope_alone_fails_base_permission_gate(self) -> None:
+        user = self._basic_user()
+        request = _pat_request([Permission.READ_SEARCH])
+        base_dep = self._base_dep()
+
+        with pytest.raises(OnyxError) as exc_info:
+            await base_dep(request=request, user=user)
+        assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+        with patch.object(
+            craft_gateway, "is_craft_enabled_for_user", return_value=False
+        ):
+            assert not is_gateway_request(request, user)
+
+
+def _catalog_provider() -> LLMProviderView:
+    return _provider(
+        7,
+        "openai",
+        [_model("gpt-5-mini"), _model("hidden", is_visible=False)],
+    )
+
+
+def test_list_models_returns_openai_shape_excluding_hidden_models() -> None:
+    provider = _catalog_provider()
+    with (
+        patch.dict(
+            gateway_api._FLOW_ACCESS_CHECKS,
+            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=True)},
+        ),
+        patch.object(
+            gateway_api,
+            "fetch_all_accessible_llm_providers",
+            return_value=[provider],
+        ) as fetch_providers,
+    ):
+        response = gateway_api.gateway_list_models(
+            http_request=cast(Request, MagicMock(spec=Request)),
+            user=cast(User, MagicMock(spec=User)),
+            db_session=cast(Session, MagicMock(spec=Session)),
+        )
+        fetch_providers.assert_called_once()
+
+    payload = json.loads(bytes(response.body))
+    assert payload["object"] == "list"
+    assert [m["id"] for m in payload["data"]] == ["7/gpt-5-mini"]
+    assert payload["data"][0]["object"] == "model"
+    assert payload["data"][0]["owned_by"] == "openai"
+
+
+def test_list_models_ids_round_trip_through_resolve_gateway_model() -> None:
+    provider = _catalog_provider()
+    with (
+        patch.dict(
+            gateway_api._FLOW_ACCESS_CHECKS,
+            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=True)},
+        ),
+        patch.object(
+            gateway_api, "fetch_all_accessible_llm_providers", return_value=[provider]
+        ),
+    ):
+        response = gateway_api.gateway_list_models(
+            http_request=cast(Request, MagicMock(spec=Request)),
+            user=cast(User, MagicMock(spec=User)),
+            db_session=cast(Session, MagicMock(spec=Session)),
+        )
+    model_id = json.loads(bytes(response.body))["data"][0]["id"]
+
+    with patch.object(
+        gateway_api, "fetch_accessible_llm_provider_by_id", return_value=provider
+    ):
+        resolved_provider, resolved_model = gateway_api.resolve_gateway_model(
+            cast(Session, MagicMock(spec=Session)),
+            cast(User, MagicMock(spec=User)),
+            model_id,
+        )
+
+    assert resolved_provider is provider
+    assert resolved_model.name == "gpt-5-mini"
+
+
+def test_list_models_rejects_non_gateway_credentials() -> None:
+    with (
+        patch.dict(
+            gateway_api._FLOW_ACCESS_CHECKS,
+            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=False)},
+        ),
+        pytest.raises(OnyxError) as exc_info,
+    ):
+        gateway_api.gateway_list_models(
+            http_request=cast(Request, MagicMock(spec=Request)),
+            user=cast(User, MagicMock(spec=User)),
+            db_session=cast(Session, MagicMock(spec=Session)),
+        )
+    assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+
+
+def test_models_route_has_single_permission_dependency() -> None:
+    application = FastAPI(openapi_url=None, docs_url=None, redoc_url=None)
+    application.include_router(gateway_api.router)
+    models_route = cast(
+        APIRoute,
+        next(
+            route
+            for route in application.routes
+            if getattr(route, "path", None) == f"{GATEWAY_PATH_PREFIX}/v1/models"
+        ),
+    )
+    auth_dependencies = [
+        dependency.call
+        for dependency in models_route.dependant.dependencies
+        if getattr(dependency.call, "_is_require_permission", False)
+    ]
+    assert len(auth_dependencies) == 1


### PR DESCRIPTION
## Description

> Stacked on #13606. Review that one first.

Opens the Onyx LLM gateway to external OpenAI-compatible clients. Until now the only caller it accepted was a Craft sandbox PAT.

Three changes:

**A self-mintable gateway scope.** `USE_LLM_GATEWAY` is added to the user-selectable PAT scopes, so a developer can create a token for external tools. `CRAFT_SANDBOX` is deliberately *not* made selectable — it implies gateway access but also confers sandbox powers, so exposing it would be the wrong grant.

**A split access policy.** `is_gateway_request` sits alongside the existing `is_craft_gateway_request`. A token whose raw scopes include `CRAFT_SANDBOX` still goes through the Craft policy unchanged, craft-enabled requirement included; any other token granting `USE_LLM_GATEWAY` may call the gateway with no Craft requirement. Requests with no token scopes at all — session auth, plain API keys, and unrestricted PATs — are still rejected.

**Model discovery.** `GET /gateway/v1/models` returns the standard OpenAI list shape, backed by the existing `build_gateway_model_catalog`, filtered to providers the caller can access and models marked visible.

### Two things worth reviewer attention

**The gateway routes no longer require `READ_SEARCH`.** They used it as a stand-in for "is an ordinary user", which forced every gateway token to also carry document-search access. This was not theoretical: a token with the scopes the UI told you to create could call `POST /search` and get a 200. The routes now require `USE_LLM_GATEWAY`, which `BASIC_ACCESS` implies so ordinary users still pass. The permission could not simply be dropped — `_scoped_pat_permitted_on_route` is fail-closed and locks scoped PATs out of any route lacking a `require_permission` guard.

`check_token_rate_limits` is now applied to the chat-completions route. Without it the gateway was an unmetered path to the org's provider credentials while the chat routes were capped. This gap pre-dates the PR (it already applied to Craft tokens), but implying the scope from `BASIC_ACCESS` widens who can reach it.

**Open decision, deliberately left as-is:** any user can mint a gateway token; an admin cannot withhold it from a subset of users. Making it group-toggleable means dropping `USE_LLM_GATEWAY` from `Permission.IMPLIED` and `BASIC_ACCESS` (Craft is unaffected — `CRAFT_SANDBOX` implies it directly). Left universal on the grounds that gateway traffic is now metered by the same budgets as chat.

Stacked on #13606, which carries the credential-identity plumbing and an async API-key auth fix. That was split out because it is an auth-layer change unrelated to gateway access.

## How Has This Been Tested?

- 1043 unit tests pass (`tests/unit/onyx/server/gateway`, `tests/unit/onyx/server/features/craft`, `tests/unit/onyx/auth`), including new coverage for: a plain gateway-scoped PAT being accepted without Craft, Craft sandbox tokens behaving exactly as before, and unrestricted PATs / session auth / plain API keys still being rejected.
- Verified live against a local instance with a real PAT and no session cookie: `GET /v1/models` → 200 with `<provider_id>/<model_name>` ids, chat completions → 200 non-streaming, 274 discrete SSE chunks streaming.
- Verified the over-grant is closed: before this change a gateway token got 200 from `POST /search`; a `USE_LLM_GATEWAY`-only token now gets 403 there while both gateway endpoints return 200.
- `pre-commit` clean (lazy imports, ty, ruff, ruff format).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

**Stack:**
1. [gateway-auth-credential-identity #13606](https://github.com/onyx-dot-app/onyx/pull/13606)