### PR TITLE
feat(gateway): serve the OpenAI Responses API for Codex CLI (non-streaming)

### DIFF
--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -525,9 +525,7 @@ def _responses_input_to_raw_messages(request: ResponsesRequest) -> list[dict[str
     )
     raw: list[dict[str, Any]] = []
     for message in litellm_messages:
-        message_dict = cast(
-            dict[str, Any], message if isinstance(message, dict) else dict(message)
-        )
+        message_dict: dict[str, Any] = dict(message)
         role = message_dict.get("role")
         if role in ("system", "developer"):
             raw.append(

--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -1,8 +1,10 @@
 import json
 import queue
 import threading
+import time
+import uuid
 from collections.abc import Callable, Iterator
-from typing import Any
+from typing import Any, cast
 
 from fastapi import APIRouter, Depends, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -23,6 +25,7 @@ from onyx.llm.factory import llm_from_provider
 from onyx.llm.interfaces import LLM
 from onyx.llm.model_response import (
     ChatCompletionDeltaToolCall,
+    ChatCompletionMessageToolCall,
     ModelResponseStream,
     Usage,
 )
@@ -31,6 +34,7 @@ from onyx.llm.models import (
     ChatCompletionMessage,
     ReasoningEffort,
     TextContentPart,
+    ToolCall,
     ToolChoiceOptions,
     UserMessage,
 )
@@ -45,6 +49,12 @@ from onyx.server.gateway.models import (
     ChatCompletionRequest,
     ChatCompletionResponse,
     ModelListResponse,
+    ResponsesFunctionCallItem,
+    ResponsesMessageItem,
+    ResponsesObjectPayload,
+    ResponsesOutputItem,
+    ResponsesOutputTextPart,
+    ResponsesRequest,
 )
 from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
 from onyx.server.query_and_chat.token_limit import check_token_rate_limits
@@ -77,6 +87,16 @@ _MESSAGES_ADAPTER: TypeAdapter[list[ChatCompletionMessage]] = TypeAdapter(
 
 def _gateway_trace(flow: LLMFlow, model: str) -> Trace:
     return trace("llm_gateway", metadata={"flow": flow.value, "model": model})
+
+
+def _authorize_gateway_request(http_request: Request, user: User) -> LLMFlow:
+    flow = LLMFlow.CRAFT_LLM_GENERATION
+    if not _FLOW_ACCESS_CHECKS[flow](http_request, user):
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "This credential is not authorized to use the Onyx LLM gateway.",
+        )
+    return flow
 
 
 def resolve_gateway_model(
@@ -356,7 +376,7 @@ def _stream_sse(
     reasoning_effort: ReasoningEffort,
     model: str,
 ) -> Iterator[str]:
-    """Bridge the LLM stream through a queue so the whole consumption —
+    """Bridge the worker through a queue so the whole stream consumption —
     including the generation span's ContextVar enter/exit — happens on ONE
     thread. Yielding directly from a sync generator breaks under Starlette,
     which resumes the generator on varying threadpool threads (ContextVar
@@ -473,18 +493,202 @@ def handle_chat_completion(
     return ChatCompletionResponse.from_model_response(response, request.model)
 
 
+def _new_id(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex}"
+
+
+def _flatten_text_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n\n".join(
+            part.get("text", "")
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        )
+    return ""
+
+
+def _responses_input_to_raw_messages(request: ResponsesRequest) -> list[dict[str, Any]]:
+    """LiteLLM's Responses->Chat bridge emits an OpenAI 'developer' role and
+    list-of-parts system/developer content; our ChatCompletionMessage union has
+    no developer role and SystemMessage.content is str-only, so collapse both."""
+    from litellm.responses.litellm_completion_transformation.transformation import (
+        LiteLLMCompletionResponsesConfig,
+    )
+
+    litellm_messages = (
+        LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
+            input=cast(Any, request.input),
+            responses_api_request=cast(Any, {"instructions": request.instructions}),
+        )
+    )
+    raw: list[dict[str, Any]] = []
+    for message in litellm_messages:
+        message_dict = cast(
+            dict[str, Any], message if isinstance(message, dict) else dict(message)
+        )
+        role = message_dict.get("role")
+        if role in ("system", "developer"):
+            raw.append(
+                {
+                    "role": "system",
+                    "content": _flatten_text_content(message_dict.get("content")),
+                }
+            )
+        elif role == "assistant" and isinstance(message_dict.get("content"), list):
+            # AssistantMessage.content is str, but LiteLLM emits parts here.
+            raw.append(
+                {
+                    **message_dict,
+                    "content": _flatten_text_content(message_dict["content"]) or None,
+                }
+            )
+        else:
+            raw.append(message_dict)
+    return raw
+
+
+def _responses_tools(request: ResponsesRequest) -> list[dict[str, Any]] | None:
+    from litellm.responses.litellm_completion_transformation.transformation import (
+        LiteLLMCompletionResponsesConfig,
+    )
+
+    tools, _ = (
+        LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            cast(Any, request.tools)
+        )
+    )
+    return cast(list[dict[str, Any]], tools) or None
+
+
+def _function_call_item(
+    tool_call: ToolCall | ChatCompletionMessageToolCall,
+) -> ResponsesFunctionCallItem | None:
+    # A nameless tool call has no valid function_call representation.
+    name = tool_call.function.name
+    if not name:
+        return None
+    return ResponsesFunctionCallItem.create(
+        id=_new_id("fc"),
+        call_id=tool_call.id,
+        name=name,
+        arguments=tool_call.function.arguments or "",
+    )
+
+
+def _build_responses_output_items(
+    content: str | None,
+    tool_calls: list[ToolCall] | list[ChatCompletionMessageToolCall] | None,
+    message_item_id: str,
+) -> list[ResponsesOutputItem]:
+    items: list[ResponsesOutputItem] = []
+    if content:
+        items.append(
+            ResponsesMessageItem.create(
+                id=message_item_id,
+                status="completed",
+                content=[ResponsesOutputTextPart.create(content)],
+            )
+        )
+    items.extend(
+        item
+        for item in (_function_call_item(tc) for tc in tool_calls or [])
+        if item is not None
+    )
+    return items
+
+
+def handle_responses_request(
+    request: ResponsesRequest,
+    db_session: Session,
+    provider: LLMProviderView,
+    model_config: ModelConfigurationView,
+    flow: LLMFlow,
+) -> ResponsesObjectPayload:
+    if request.stream:
+        raise OnyxError(
+            OnyxErrorCode.NOT_IMPLEMENTED,
+            "Streaming is not yet supported on the Responses API.",
+        )
+    llm = llm_from_provider(
+        model_name=model_config.name,
+        llm_provider=provider,
+        temperature=request.temperature,
+    )
+    raw_messages = _responses_input_to_raw_messages(request)
+    messages = _prepare_messages(llm, raw_messages)
+    tools = _responses_tools(request)
+    tool_choice = _parse_tool_choice(request.tool_choice)
+    reasoning_effort = _parse_reasoning_effort(
+        request.reasoning.get("effort") if request.reasoning else None
+    )
+    max_tokens = request.max_output_tokens
+    response_id = _new_id("resp")
+    created_at = int(time.time())
+    db_session.close()
+
+    with (
+        _gateway_trace(flow, llm.config.model_name),
+        llm_generation_span(
+            llm,
+            flow=flow,
+            input_messages=messages,
+            tools=tools,
+        ) as span,
+    ):
+        try:
+            response = llm.invoke(
+                prompt=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                max_tokens=max_tokens,
+                reasoning_effort=reasoning_effort,
+            )
+        except LLMRateLimitError as e:
+            raise OnyxError(
+                OnyxErrorCode.RATE_LIMITED,
+                "The selected model is temporarily rate limited.",
+            ) from e
+        except LLMTimeoutError as e:
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                "The selected model did not respond in time.",
+            ) from e
+        except Exception as e:
+            if span is not None:
+                span.set_error({"message": f"{type(e).__name__}: {e}", "data": None})
+            logger.exception(
+                "LLM gateway responses invoke failed for model %s", request.model
+            )
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                "The upstream LLM request failed.",
+            ) from e
+        if span is not None:
+            record_llm_response(span, response)
+
+    return ResponsesObjectPayload.from_parts(
+        response_id=response_id,
+        created_at=created_at,
+        model=request.model,
+        status="completed",
+        output=_build_responses_output_items(
+            response.choice.message.content,
+            response.choice.message.tool_calls,
+            _new_id("msg"),
+        ),
+        usage=response.usage,
+    )
+
+
 @router.get("/v1/models")
 def gateway_list_models(
     http_request: Request,
     user: User = Depends(require_permission(Permission.USE_LLM_GATEWAY)),
     db_session: Session = Depends(get_session),
 ) -> Response:
-    flow = LLMFlow.CRAFT_LLM_GENERATION
-    if not _FLOW_ACCESS_CHECKS[flow](http_request, user):
-        raise OnyxError(
-            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-            "This credential is not authorized to use the Onyx LLM gateway.",
-        )
+    _authorize_gateway_request(http_request, user)
     providers = fetch_all_accessible_llm_providers(db_session, user)
     catalog = build_gateway_model_catalog(providers)
     return JSONResponse(content=ModelListResponse.from_catalog(catalog).to_wire())
@@ -497,12 +701,7 @@ def gateway_chat_completions(
     user: User = Depends(require_permission(Permission.USE_LLM_GATEWAY)),
     db_session: Session = Depends(get_session),
 ) -> Response:
-    flow = LLMFlow.CRAFT_LLM_GENERATION
-    if not _FLOW_ACCESS_CHECKS[flow](http_request, user):
-        raise OnyxError(
-            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-            "This credential is not authorized to use the Onyx LLM gateway.",
-        )
+    flow = _authorize_gateway_request(http_request, user)
     check_token_rate_limits(user)
     provider, model_config = resolve_gateway_model(db_session, user, request.model)
     result = handle_chat_completion(
@@ -516,4 +715,24 @@ def gateway_chat_completions(
         return result
     # Serialize explicitly: FastAPI's default model serialization would emit
     # unset fields as nulls, violating the wire contract's presence semantics.
+    return JSONResponse(content=result.to_wire())
+
+
+@router.post("/v1/responses")
+def gateway_responses(
+    request: ResponsesRequest,
+    http_request: Request,
+    user: User = Depends(require_permission(Permission.USE_LLM_GATEWAY)),
+    db_session: Session = Depends(get_session),
+) -> Response:
+    flow = _authorize_gateway_request(http_request, user)
+    check_token_rate_limits(user)
+    provider, model_config = resolve_gateway_model(db_session, user, request.model)
+    result = handle_responses_request(
+        request=request,
+        db_session=db_session,
+        provider=provider,
+        model_config=model_config,
+        flow=flow,
+    )
     return JSONResponse(content=result.to_wire())

--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -4,6 +4,7 @@ import threading
 import time
 import uuid
 from collections.abc import Callable, Iterator
+from contextlib import closing
 from typing import Any, cast
 
 from fastapi import APIRouter, Depends, Request, Response
@@ -418,7 +419,6 @@ def _stream_sse(
 
 def handle_chat_completion(
     request: ChatCompletionRequest,
-    db_session: Session,
     provider: LLMProviderView,
     model_config: ModelConfigurationView,
     flow: LLMFlow,
@@ -432,7 +432,6 @@ def handle_chat_completion(
     tool_choice = _parse_tool_choice(request.tool_choice)
     reasoning_effort = _parse_reasoning_effort(request.reasoning_effort)
     max_tokens = request.max_completion_tokens or request.max_tokens
-    db_session.close()
 
     if request.stream:
         return StreamingResponse(
@@ -599,7 +598,6 @@ def _build_responses_output_items(
 
 def handle_responses_request(
     request: ResponsesRequest,
-    db_session: Session,
     provider: LLMProviderView,
     model_config: ModelConfigurationView,
     flow: LLMFlow,
@@ -624,7 +622,6 @@ def handle_responses_request(
     max_tokens = request.max_output_tokens
     response_id = _new_id("resp")
     created_at = int(time.time())
-    db_session.close()
 
     with (
         _gateway_trace(flow, llm.config.model_name),
@@ -701,10 +698,10 @@ def gateway_chat_completions(
 ) -> Response:
     flow = _authorize_gateway_request(http_request, user)
     check_token_rate_limits(user)
-    provider, model_config = resolve_gateway_model(db_session, user, request.model)
+    with closing(db_session):
+        provider, model_config = resolve_gateway_model(db_session, user, request.model)
     result = handle_chat_completion(
         request=request,
-        db_session=db_session,
         provider=provider,
         model_config=model_config,
         flow=flow,
@@ -725,10 +722,10 @@ def gateway_responses(
 ) -> Response:
     flow = _authorize_gateway_request(http_request, user)
     check_token_rate_limits(user)
-    provider, model_config = resolve_gateway_model(db_session, user, request.model)
+    with closing(db_session):
+        provider, model_config = resolve_gateway_model(db_session, user, request.model)
     result = handle_responses_request(
         request=request,
-        db_session=db_session,
         provider=provider,
         model_config=model_config,
         flow=flow,

--- a/backend/onyx/server/gateway/models.py
+++ b/backend/onyx/server/gateway/models.py
@@ -226,3 +226,120 @@ class ModelListResponse(_WireModel):
             object="list",
             data=[ModelListEntry.from_descriptor(d) for d in catalog],
         )
+
+
+class ResponsesRequest(BaseModel):
+    """Codex sends ``store: false`` and no ``previous_response_id``, so
+    conversation persistence is intentionally not implemented."""
+
+    model_config = ConfigDict(extra="allow")
+
+    model: str
+    input: str | list[dict[str, Any]] = Field(default_factory=list)
+    instructions: str | None = None
+    tools: list[dict[str, Any]] | None = None
+    tool_choice: Any = None
+    stream: bool = False
+    max_output_tokens: int | None = None
+    temperature: float | None = None
+    reasoning: dict[str, Any] | None = None
+
+
+class ResponsesOutputTextPart(_WireModel):
+    type: Literal["output_text"] = "output_text"
+    text: str
+    annotations: list[Any] = Field(default_factory=list)
+
+    @classmethod
+    def create(cls, text: str) -> "ResponsesOutputTextPart":
+        return cls(type="output_text", text=text, annotations=[])
+
+
+class ResponsesMessageItem(_WireModel):
+    type: Literal["message"] = "message"
+    id: str
+    status: str
+    role: Literal["assistant"] = "assistant"
+    content: list[ResponsesOutputTextPart]
+
+    @classmethod
+    def create(
+        cls, *, id: str, status: str, content: list[ResponsesOutputTextPart]
+    ) -> "ResponsesMessageItem":
+        return cls(
+            type="message", id=id, status=status, role="assistant", content=content
+        )
+
+
+class ResponsesFunctionCallItem(_WireModel):
+    type: Literal["function_call"] = "function_call"
+    id: str
+    call_id: str
+    name: str
+    arguments: str
+    status: str = "completed"
+
+    @classmethod
+    def create(
+        cls, *, id: str, call_id: str, name: str, arguments: str
+    ) -> "ResponsesFunctionCallItem":
+        return cls(
+            type="function_call",
+            id=id,
+            call_id=call_id,
+            name=name,
+            arguments=arguments,
+            status="completed",
+        )
+
+
+ResponsesOutputItem: TypeAlias = ResponsesMessageItem | ResponsesFunctionCallItem
+
+
+class ResponsesUsagePayload(_WireModel):
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+
+    @classmethod
+    def from_usage(cls, usage: Usage) -> "ResponsesUsagePayload":
+        return cls(
+            input_tokens=usage.prompt_tokens,
+            output_tokens=usage.completion_tokens,
+            total_tokens=usage.total_tokens,
+        )
+
+
+class ResponsesObjectPayload(_WireModel):
+    id: str
+    object: Literal["response"] = "response"
+    created_at: int
+    status: str
+    model: str
+    output: list[ResponsesOutputItem]
+    usage: ResponsesUsagePayload | None = None
+    error: dict[str, Any] | None = None
+
+    @classmethod
+    def from_parts(
+        cls,
+        *,
+        response_id: str,
+        created_at: int,
+        model: str,
+        status: str,
+        output: list[ResponsesOutputItem],
+        usage: Usage | None = None,
+    ) -> "ResponsesObjectPayload":
+        kwargs: dict[str, Any] = {}
+        if usage is not None:
+            kwargs["usage"] = ResponsesUsagePayload.from_usage(usage)
+        return cls(
+            id=response_id,
+            object="response",
+            created_at=created_at,
+            status=status,
+            model=model,
+            output=output,
+            **kwargs,
+        )

--- a/backend/tests/unit/onyx/server/gateway/fixtures/codex_responses_request.json
+++ b/backend/tests/unit/onyx/server/gateway/fixtures/codex_responses_request.json
@@ -1,0 +1,347 @@
+{
+  "include": [
+    "reasoning.encrypted_content"
+  ],
+  "input": [
+    {
+      "content": [
+        {
+          "text": "<permissions instructions>\nFilesystem sandboxing defines which files can be read or written. `sandbox_mode` is `read-only`: The sandbox only permits reading files. Network access is restricted.\nApproval policy is currently never. Do not provide the `sandbox_permissions` for any reason, commands will be rejected.\n</permissions instructions>",
+          "type": "input_text"
+        },
+        {
+          "text": "<skills_instructions>\n(elided: Codex injects ~16KB of skill descriptions here)\n</skills_instructions>",
+          "type": "input_text"
+        }
+      ],
+      "role": "developer",
+      "type": "message"
+    },
+    {
+      "content": [
+        {
+          "text": "<environment_context>\n  <cwd>/private/tmp/claude-501/-Users-rohoswagger--superconductor-worktrees-onyx-onyx-router/1d263b21-078b-46b4-b89d-12b4a2800b04/scratchpad/codex-spike</cwd>\n  <shell>zsh</shell>\n  <current_date>2026-07-29</current_date>\n  <timezone>America/Los_Angeles</timezone>\n  <filesystem><workspace_roots><root>/private/tmp/claude-501/-Users-rohoswagger--superconductor-worktrees-onyx-onyx-router/1d263b21-078b-46b4-b89d-12b4a2800b04/scratchpad/codex-spike</root></workspace_roots><permission_profile type=\"managed\"><file_system type=\"restricted\"><entry access=\"read\"><special>:root</special></entry></file_system></permission_profile></filesystem>\n</environment_context>",
+          "type": "input_text"
+        }
+      ],
+      "role": "user",
+      "type": "message"
+    },
+    {
+      "content": [
+        {
+          "text": "say hi",
+          "type": "input_text"
+        }
+      ],
+      "role": "user",
+      "type": "message"
+    }
+  ],
+  "instructions": "You are a coding agent running in the Codex CLI, a terminal-based coding assistant. Codex CLI is an open source project led by OpenAI. You are expected to be precise, safe, and helpful.\n\nYour capabilities:\n\n- Receive user prompts and other context provided by the harness, such as files in the workspace.\n- Communicate with the user by streaming thinking & responses, and by making & updating plans.\n",
+  "model": "1/test-model",
+  "parallel_tool_calls": false,
+  "prompt_cache_key": "00000000-0000-0000-0000-000000000000",
+  "reasoning": {
+    "summary": "auto"
+  },
+  "store": false,
+  "stream": true,
+  "tool_choice": "auto",
+  "tools": [
+    {
+      "description": "Runs a command in a PTY, returning output or a session ID for ongoing interaction.",
+      "name": "exec_command",
+      "parameters": {
+        "additionalProperties": false,
+        "properties": {
+          "cmd": {
+            "description": "Shell command to execute.",
+            "type": "string"
+          },
+          "justification": {
+            "description": "User-facing approval question for `require_escalated`; omit otherwise.",
+            "type": "string"
+          },
+          "login": {
+            "description": "True runs the shell with -l/-i semantics; false disables them. Defaults to true.",
+            "type": "boolean"
+          },
+          "max_output_tokens": {
+            "description": "Output token budget. Defaults to 10000 tokens; larger requests may be capped by policy.",
+            "type": "number"
+          },
+          "prefix_rule": {
+            "description": "Reusable approval prefix for `cmd`, only with `sandbox_permissions: \"require_escalated\"`; for example [\"git\", \"pull\"].",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sandbox_permissions": {
+            "description": "Per-command sandbox override. Defaults to `use_default`; use `require_escalated` for unsandboxed execution.",
+            "enum": [
+              "use_default",
+              "require_escalated"
+            ],
+            "type": "string"
+          },
+          "shell": {
+            "description": "Shell binary to launch. Defaults to the user's default shell.",
+            "type": "string"
+          },
+          "tty": {
+            "description": "True allocates a PTY for the command; false or omitted uses plain pipes.",
+            "type": "boolean"
+          },
+          "workdir": {
+            "description": "Working directory for the command. Defaults to the turn cwd.",
+            "type": "string"
+          },
+          "yield_time_ms": {
+            "description": "Wait before yielding output. Defaults to 10000 ms; effective range is 250-30000 ms.",
+            "type": "number"
+          }
+        },
+        "required": [
+          "cmd"
+        ],
+        "type": "object"
+      },
+      "strict": false,
+      "type": "function"
+    },
+    {
+      "description": "Writes characters to an existing unified exec session and returns recent output.",
+      "name": "write_stdin",
+      "parameters": {
+        "additionalProperties": false,
+        "properties": {
+          "chars": {
+            "description": "Bytes to write to stdin. Defaults to empty, which polls without writing.",
+            "type": "string"
+          },
+          "max_output_tokens": {
+            "description": "Output token budget. Defaults to 10000 tokens; larger requests may be capped by policy.",
+            "type": "number"
+          },
+          "session_id": {
+            "description": "Identifier of the running unified exec session.",
+            "type": "number"
+          },
+          "yield_time_ms": {
+            "description": "Wait before yielding output. Non-empty writes default to 250 ms and cap at 30000 ms; empty polls wait 5000-300000 ms by default.",
+            "type": "number"
+          }
+        },
+        "required": [
+          "session_id"
+        ],
+        "type": "object"
+      },
+      "strict": false,
+      "type": "function"
+    },
+    {
+      "description": "Updates the task plan.\nProvide an optional explanation and a list of plan items, each with a step and status.\nAt most one step can be in_progress at a time.\n",
+      "name": "update_plan",
+      "parameters": {
+        "additionalProperties": false,
+        "properties": {
+          "explanation": {
+            "description": "Optional explanation for this plan update.",
+            "type": "string"
+          },
+          "plan": {
+            "description": "The list of steps",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "status": {
+                  "description": "Step status.",
+                  "enum": [
+                    "pending",
+                    "in_progress",
+                    "completed"
+                  ],
+                  "type": "string"
+                },
+                "step": {
+                  "description": "Task step text.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "step",
+                "status"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "plan"
+        ],
+        "type": "object"
+      },
+      "strict": false,
+      "type": "function"
+    },
+    {
+      "description": "Request user input for one to three short questions and wait for the response. Set autoResolutionMs, from 60000 to 240000 milliseconds, only when the question is useful but non-blocking and continuing with best judgment is acceptable if the user does not answer; omit it when explicit user input is required. This tool is only available in Plan mode.",
+      "name": "request_user_input",
+      "parameters": {
+        "additionalProperties": false,
+        "properties": {
+          "autoResolutionMs": {
+            "description": "Optional auto-resolution window in milliseconds, from 60000 to 240000. Include this only when the question is useful but non-blocking and continuing with best judgment is acceptable if the user does not answer; omit it when explicit user input is required before continuing. Use 60000 for lightly helpful context and up to 240000 when the answer would materially unblock better work.",
+            "type": "number"
+          },
+          "questions": {
+            "description": "Questions to show the user. Prefer 1 and do not exceed 3",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "header": {
+                  "description": "Short header label shown in the UI (12 or fewer chars).",
+                  "type": "string"
+                },
+                "id": {
+                  "description": "Stable identifier for mapping answers (snake_case).",
+                  "type": "string"
+                },
+                "options": {
+                  "description": "Provide 2-3 mutually exclusive choices. Put the recommended option first and suffix its label with \"(Recommended)\". Do not include an \"Other\" option in this list; the client will add a free-form \"Other\" option automatically.",
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "description": {
+                        "description": "One short sentence explaining impact/tradeoff if selected.",
+                        "type": "string"
+                      },
+                      "label": {
+                        "description": "User-facing label (1-5 words).",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "label",
+                      "description"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "question": {
+                  "description": "Single-sentence prompt shown to the user.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "header",
+                "question",
+                "options"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "questions"
+        ],
+        "type": "object"
+      },
+      "strict": false,
+      "type": "function"
+    },
+    {
+      "description": "View a local image file from the filesystem when visual inspection is needed. Use this for images already available on disk.",
+      "name": "view_image",
+      "parameters": {
+        "additionalProperties": false,
+        "properties": {
+          "path": {
+            "description": "Local filesystem path to an image file.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      },
+      "strict": false,
+      "type": "function"
+    },
+    {
+      "type": "namespace",
+      "name": "multi_agent_v1",
+      "description": "(elided: ~10KB of nested sub-tool schemas)"
+    },
+    {
+      "description": "Get the current goal for this thread, including status, budgets, token and elapsed-time usage, and remaining token budget.",
+      "name": "get_goal",
+      "parameters": {
+        "additionalProperties": false,
+        "properties": {},
+        "required": [],
+        "type": "object"
+      },
+      "strict": false,
+      "type": "function"
+    },
+    {
+      "description": "Create a goal only when explicitly requested by the user or system/developer instructions; do not infer goals from ordinary tasks.\nSet token_budget only when an explicit token budget is requested. Fails if an unfinished goal exists; use update_goal only for status.",
+      "name": "create_goal",
+      "parameters": {
+        "additionalProperties": false,
+        "properties": {
+          "objective": {
+            "description": "Required. The concrete objective to start pursuing. This starts a new active goal when no goal exists or replaces the current goal when it is complete.",
+            "type": "string"
+          },
+          "token_budget": {
+            "description": "Positive token budget for the new goal. Omit unless explicitly requested.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "objective"
+        ],
+        "type": "object"
+      },
+      "strict": false,
+      "type": "function"
+    },
+    {
+      "description": "Update the existing goal.\nUse this tool only to mark the goal achieved or genuinely blocked.\nSet status to `complete` only when the objective has actually been achieved and no required work remains.\nSet status to `blocked` only when the same blocking condition has repeated for at least three consecutive goal turns, counting the original/user-triggered turn and any automatic continuations, and the agent cannot make meaningful progress without user input or an external-state change.\nIf the user resumes a goal that was previously marked `blocked`, treat the resumed run as a fresh blocked audit. If the same blocking condition then repeats for at least three consecutive resumed goal turns, set status to `blocked` again.\nOnce the blocked threshold is satisfied, do not keep reporting that you are still blocked while leaving the goal active; set status to `blocked`.\nDo not use `blocked` merely because the work is hard, slow, uncertain, incomplete, or would benefit from clarification.\nDo not mark a goal complete merely because its budget is nearly exhausted or because you are stopping work.\nYou cannot use this tool to pause, resume, budget-limit, or usage-limit a goal; those status changes are controlled by the user or system.\nWhen marking a budgeted goal achieved with status `complete`, report the final token usage from the tool result to the user.",
+      "name": "update_goal",
+      "parameters": {
+        "additionalProperties": false,
+        "properties": {
+          "status": {
+            "description": "Required. Set to `complete` only when the objective is achieved and no required work remains. Set to `blocked` only after the same blocking condition has recurred for at least three consecutive goal turns and the agent is at an impasse. After a previously blocked goal is resumed, the resumed run starts a fresh blocked audit.",
+            "enum": [
+              "complete",
+              "blocked"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "type": "object"
+      },
+      "strict": false,
+      "type": "function"
+    },
+    {
+      "external_web_access": false,
+      "type": "web_search"
+    }
+  ]
+}

--- a/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
@@ -4,6 +4,7 @@ import json
 import threading
 from collections.abc import Awaitable, Callable, Iterator
 from contextlib import contextmanager, nullcontext
+from pathlib import Path
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
@@ -47,10 +48,12 @@ from onyx.server.auth_check import check_router_auth
 from onyx.server.features.build import craft_gateway
 from onyx.server.features.build.craft_gateway import is_gateway_request
 from onyx.server.gateway import api as gateway_api
+from onyx.server.gateway.api import _MESSAGES_ADAPTER
 from onyx.server.gateway.configs import GATEWAY_PATH_PREFIX
 from onyx.server.gateway.models import (
     ChatCompletionRequest,
     ChatCompletionResponse,
+    ResponsesRequest,
 )
 from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
 from onyx.tracing.flows import LLMFlow
@@ -1119,6 +1122,286 @@ def test_list_models_rejects_non_gateway_credentials() -> None:
     assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
 
 
+def test_responses_input_instructions_become_system_message() -> None:
+    request = ResponsesRequest(
+        model="1/test",
+        instructions="You are a coding agent.",
+        input=[{"type": "message", "role": "user", "content": "say hi"}],
+    )
+
+    raw = gateway_api._responses_input_to_raw_messages(request)
+
+    assert raw[0] == {"role": "system", "content": "You are a coding agent."}
+    assert raw[-1]["role"] == "user"
+
+
+def test_responses_developer_role_collapses_into_system_message() -> None:
+    """Our ChatCompletionMessage union has no 'developer' role and
+    SystemMessage.content is str-only, so both must collapse to 'system'."""
+    request = ResponsesRequest(
+        model="1/test",
+        input=[
+            {
+                "type": "message",
+                "role": "developer",
+                "content": [{"type": "text", "text": "be terse"}],
+            },
+            {"type": "message", "role": "user", "content": "say hi"},
+        ],
+    )
+
+    raw = gateway_api._responses_input_to_raw_messages(request)
+
+    assert raw[0] == {"role": "system", "content": "be terse"}
+
+
+def test_responses_input_items_become_messages() -> None:
+    request = ResponsesRequest(
+        model="1/test",
+        input=[
+            {"type": "message", "role": "user", "content": "hello there"},
+        ],
+    )
+
+    raw = gateway_api._responses_input_to_raw_messages(request)
+    llm = _ConfigOnlyLLM(
+        LLMConfig(
+            model_provider="openai",
+            model_name="test",
+            temperature=0,
+            max_input_tokens=1_000,
+        )
+    )
+    messages = gateway_api._prepare_messages(llm, raw)
+
+    assert messages == [UserMessage(content="hello there")]
+
+
+def test_responses_request_tolerates_unknown_top_level_fields() -> None:
+    """Codex sends fields like prompt_cache_key/client_metadata/include that
+    the gateway doesn't act on; these must be accepted, not rejected."""
+    request = ResponsesRequest.model_validate(
+        {
+            "model": "1/test",
+            "input": [{"type": "message", "role": "user", "content": "hi"}],
+            "store": False,
+            "prompt_cache_key": "019fb050-bf28-7812-8a84-5331b2ed60b0",
+            "client_metadata": {"turn_id": "abc"},
+            "include": ["reasoning.encrypted_content"],
+            "parallel_tool_calls": False,
+        }
+    )
+
+    assert request.model == "1/test"
+
+
+def test_responses_tools_drop_namespace_entries() -> None:
+    """Codex's multi-agent 'namespace' tool has no Chat Completions
+    equivalent; it must be silently dropped rather than erroring."""
+    request = ResponsesRequest(
+        model="1/test",
+        input="hi",
+        tools=[
+            {"type": "function", "name": "exec_command", "parameters": {}},
+            {"type": "namespace", "name": "multi_agent_v1", "tools": []},
+        ],
+    )
+
+    tools = gateway_api._responses_tools(request)
+
+    assert tools is not None
+    assert len(tools) == 1
+    assert tools[0]["function"]["name"] == "exec_command"
+
+
+def _handle_responses_call(request: ResponsesRequest) -> Any:
+    provider = _provider(1, "openai", [_model("test")])
+    return gateway_api.handle_responses_request(
+        request=request,
+        db_session=cast(Session, MagicMock(spec=Session)),
+        provider=provider,
+        model_config=provider.model_configurations[0],
+        flow=LLMFlow.CRAFT_LLM_GENERATION,
+    )
+
+
+def test_handle_responses_request_non_streaming_returns_completed_response() -> None:
+    request = ResponsesRequest(model="1/test", input="say hi")
+    response = ModelResponse(
+        id="chatcmpl-1",
+        created="1784577999",
+        choice=Choice(finish_reason="stop", message=Message(content="hello there")),
+        usage=_wire_usage(),
+    )
+
+    with patch.object(
+        gateway_api, "llm_from_provider", return_value=_InvokeLLM(response)
+    ):
+        result = _handle_responses_call(request)
+
+    assert isinstance(result, gateway_api.ResponsesObjectPayload)
+    payload = result.to_wire()
+    assert payload["object"] == "response"
+    assert payload["status"] == "completed"
+    assert payload["output"][0]["type"] == "message"
+    assert payload["output"][0]["content"][0]["text"] == "hello there"
+    assert payload["usage"]["input_tokens"] == 120
+
+
+def test_handle_responses_request_rejects_streaming() -> None:
+    request = ResponsesRequest(model="1/test", input="say hi", stream=True)
+
+    with pytest.raises(OnyxError) as exc_info:
+        _handle_responses_call(request)
+
+    assert exc_info.value.error_code is OnyxErrorCode.NOT_IMPLEMENTED
+
+
+def test_responses_gateway_route_carries_same_permission_dependency() -> None:
+    application = FastAPI(openapi_url=None, docs_url=None, redoc_url=None)
+    application.include_router(gateway_api.router)
+    responses_route = cast(
+        APIRoute,
+        next(
+            route
+            for route in application.routes
+            if getattr(route, "path", None) == f"{GATEWAY_PATH_PREFIX}/v1/responses"
+        ),
+    )
+    auth_dependencies = [
+        dependency.call
+        for dependency in responses_route.dependant.dependencies
+        if getattr(dependency.call, "_is_require_permission", False)
+    ]
+    assert len(auth_dependencies) == 1
+
+
+def test_responses_endpoint_rejects_non_gateway_credentials() -> None:
+    request = ResponsesRequest(model="1/test", input="hi")
+    with (
+        patch.dict(
+            gateway_api._FLOW_ACCESS_CHECKS,
+            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=False)},
+        ),
+        pytest.raises(OnyxError) as exc_info,
+    ):
+        gateway_api.gateway_responses(
+            request=request,
+            http_request=cast(Request, MagicMock(spec=Request)),
+            user=cast(User, MagicMock(spec=User)),
+            db_session=cast(Session, MagicMock(spec=Session)),
+        )
+    assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+
+
+def test_responses_endpoint_rejects_unrestricted_pat() -> None:
+    """An unrestricted PAT (scopes=None) must never be treated as
+    gateway-capable, mirroring the chat completions route."""
+    user = MagicMock()
+    user.effective_permissions = ["basic"]
+    request = ResponsesRequest(model="1/test", input="hi")
+
+    with pytest.raises(OnyxError) as exc_info:
+        gateway_api.gateway_responses(
+            request=request,
+            http_request=_pat_request(None),
+            user=cast(User, user),
+            db_session=cast(Session, MagicMock(spec=Session)),
+        )
+    assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+
+
+def test_responses_endpoint_enforces_token_rate_limits_before_calling_provider() -> (
+    None
+):
+    """Same token/cost budget enforcement as the chat route: an over-budget
+    caller must never reach model resolution or the provider."""
+    request = ResponsesRequest(model="1/test", input="hi")
+    db_session = cast(Session, MagicMock(spec=Session))
+    user = cast(User, MagicMock(spec=User))
+    http_request = cast(Request, MagicMock(spec=Request))
+
+    rate_limited = OnyxError(OnyxErrorCode.RATE_LIMITED, "over budget")
+    with (
+        patch.dict(
+            gateway_api._FLOW_ACCESS_CHECKS,
+            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=True)},
+        ),
+        patch.object(
+            gateway_api, "check_token_rate_limits", side_effect=rate_limited
+        ) as rate_check,
+        patch.object(gateway_api, "resolve_gateway_model") as resolve_model,
+        patch.object(gateway_api, "handle_responses_request") as handle,
+        pytest.raises(OnyxError) as exc_info,
+    ):
+        gateway_api.gateway_responses(
+            request=request,
+            http_request=http_request,
+            user=user,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.RATE_LIMITED
+    rate_check.assert_called_once_with(user)
+    resolve_model.assert_not_called()
+    handle.assert_not_called()
+
+
+def test_responses_endpoint_resolves_model_same_way_as_chat_route() -> None:
+    request = ResponsesRequest(model="1/test", input="hi")
+    provider = _provider(1, "openai", [_model("test")])
+    model_config = provider.model_configurations[0]
+    db_session = cast(Session, MagicMock(spec=Session))
+    user = cast(User, MagicMock(spec=User))
+    http_request = cast(Request, MagicMock(spec=Request))
+
+    with (
+        patch.dict(
+            gateway_api._FLOW_ACCESS_CHECKS,
+            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=True)},
+        ),
+        patch.object(
+            gateway_api,
+            "resolve_gateway_model",
+            return_value=(provider, model_config),
+        ) as resolve_model,
+        patch.object(gateway_api, "handle_responses_request") as handle,
+        patch.object(gateway_api, "check_token_rate_limits"),
+    ):
+        handle.return_value.to_wire.return_value = {}
+        gateway_api.gateway_responses(
+            request=request,
+            http_request=http_request,
+            user=user,
+            db_session=db_session,
+        )
+
+    resolve_model.assert_called_once_with(db_session, user, "1/test")
+    handle.assert_called_once_with(
+        request=request,
+        db_session=db_session,
+        provider=provider,
+        model_config=model_config,
+        flow=LLMFlow.CRAFT_LLM_GENERATION,
+    )
+
+
+def test_responses_model_not_found_matches_chat_route_behavior() -> None:
+    provider = _provider(1, "anthropic", [_model("visible-model")])
+    with (
+        patch.object(
+            gateway_api, "fetch_accessible_llm_provider_by_id", return_value=provider
+        ),
+        pytest.raises(OnyxError) as exc_info,
+    ):
+        gateway_api.resolve_gateway_model(
+            cast(Session, MagicMock(spec=Session)),
+            cast(User, MagicMock(spec=User)),
+            "1/does-not-exist",
+        )
+    assert exc_info.value.status_code == 404
+
+
 def test_models_route_has_single_permission_dependency() -> None:
     application = FastAPI(openapi_url=None, docs_url=None, redoc_url=None)
     application.include_router(gateway_api.router)
@@ -1136,3 +1419,67 @@ def test_models_route_has_single_permission_dependency() -> None:
         if getattr(dependency.call, "_is_require_permission", False)
     ]
     assert len(auth_dependencies) == 1
+
+
+def _codex_fixture() -> dict[str, Any]:
+    path = Path(__file__).parent / "fixtures" / "codex_responses_request.json"
+    return cast(dict[str, Any], json.loads(path.read_text()))
+
+
+def test_codex_capture_converts_without_rejecting_input() -> None:
+    """Replay of a real Codex CLI request. Our own synthetic payloads all
+    passed while Codex was failing, so the shapes it actually sends
+    (top-level instructions, function_call/reasoning items, namespace and
+    web_search tools) are pinned here rather than invented."""
+    request = ResponsesRequest.model_validate(_codex_fixture())
+
+    raw_messages = gateway_api._responses_input_to_raw_messages(request)
+    _MESSAGES_ADAPTER.validate_python(raw_messages)
+
+    assert raw_messages[0]["role"] == "system"
+    assert {m["role"] for m in raw_messages} <= {"system", "user", "assistant", "tool"}
+
+    tools = gateway_api._responses_tools(request)
+    assert tools is not None
+    assert {t["type"] for t in tools} == {"function"}
+    assert len(tools) < len(request.tools or [])
+
+
+def test_responses_tool_round_trip_assistant_content_is_flattened() -> None:
+    """Regression: on a tool round-trip the prior assistant turn comes back
+    with list-of-parts content, but AssistantMessage.content is str-only, so
+    the whole turn 400'd with "Invalid messages". Only reachable on the second
+    turn, which is why first-turn tests missed it."""
+    request = ResponsesRequest.model_validate(
+        {
+            "model": "1/test",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "run it"}],
+                },
+                {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "call_1",
+                    "name": "exec_command",
+                    "arguments": '{"cmd":"cat probe.txt"}',
+                    "status": "completed",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "hello",
+                },
+            ],
+        }
+    )
+
+    raw = gateway_api._responses_input_to_raw_messages(request)
+    _MESSAGES_ADAPTER.validate_python(raw)
+
+    assistant = [m for m in raw if m.get("role") == "assistant"]
+    assert assistant, raw
+    for message in assistant:
+        assert not isinstance(message["content"], list)

--- a/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
@@ -691,7 +691,6 @@ def _handle_completion_call(request: ChatCompletionRequest) -> Any:
     provider = _provider(1, "openai", [_model("test")])
     return gateway_api.handle_chat_completion(
         request=request,
-        db_session=cast(Session, MagicMock(spec=Session)),
         provider=provider,
         model_config=provider.model_configurations[0],
         flow=LLMFlow.CRAFT_LLM_GENERATION,
@@ -888,7 +887,6 @@ def test_endpoint_applies_craft_policy() -> None:
     resolve_model.assert_called_once_with(db_session, user, "1/test")
     handle.assert_called_once_with(
         request=request,
-        db_session=db_session,
         provider=provider,
         model_config=model_config,
         flow=LLMFlow.CRAFT_LLM_GENERATION,
@@ -1218,7 +1216,6 @@ def _handle_responses_call(request: ResponsesRequest) -> Any:
     provider = _provider(1, "openai", [_model("test")])
     return gateway_api.handle_responses_request(
         request=request,
-        db_session=cast(Session, MagicMock(spec=Session)),
         provider=provider,
         model_config=provider.model_configurations[0],
         flow=LLMFlow.CRAFT_LLM_GENERATION,
@@ -1379,7 +1376,6 @@ def test_responses_endpoint_resolves_model_same_way_as_chat_route() -> None:
     resolve_model.assert_called_once_with(db_session, user, "1/test")
     handle.assert_called_once_with(
         request=request,
-        db_session=db_session,
         provider=provider,
         model_config=model_config,
         flow=LLMFlow.CRAFT_LLM_GENERATION,


### PR DESCRIPTION
## Description

Adds `POST /gateway/v1/responses` so OpenAI Codex CLI can use the Onyx gateway. **Non-streaming only** — the streaming lifecycle is split into a follow-up PR so its event ordering can be reviewed on its own. `stream: true` returns 501 until that lands.

**Why this is required, not a nicety.** Codex 0.145 has *removed* Chat Completions support. Setting `wire_api = "chat"` is a hard config error ("no longer supported"), and with `wire_api = "responses"` it POSTs to `/responses`. Our gateway spoke only chat completions, so Codex could not talk to Onyx at all.

**Translation is not hand-rolled.** litellm 1.93.0 — already a dependency — ships a server-side Responses↔ChatCompletions bridge (`LiteLLMCompletionResponsesConfig`). This PR wires that onto the existing execution path rather than building a second inference stack.

**No conversation persistence.** Codex sends `store: false` and no `previous_response_id`, so this is pure request/response translation with no server-side session storage.

**Auth is unchanged.** The route reuses the `USE_LLM_GATEWAY` permission, the gateway credential check, `check_token_rate_limits`, and `resolve_gateway_model` from the parent PR — no new authorization surface.

### Two glue points where LiteLLM and Onyx disagree

Both are covered by tests:

- LiteLLM's bridge emits an OpenAI `developer` role and list-of-parts content; `ChatCompletionMessage` has no `developer` role and `SystemMessage.content` is str-only, so both collapse to `system`.
- On tool round-trips the prior assistant turn comes back with list-of-parts content, but `AssistantMessage.content` is `str | None`. This produced an intermittent `Invalid messages` 400 that only ever appeared on the *second* turn, which is why first-turn tests missed it.

## How Has This Been Tested?

- `backend/tests/unit/onyx/server/gateway/` — 64 tests pass. New coverage: instructions/`developer`-role collapsing, input-item conversion, tool conversion (unsupported `namespace` tools dropped), tolerance of unknown top-level Codex fields, the assistant-content flattening regression, the non-streaming completed payload with usage, `stream: true` → 501, and auth/rate-limit/model-resolution parity with the chat route.
- One test replays a **real captured Codex request** (20KB `instructions`, 10 tool definitions, `function_call`/`reasoning` items) rather than synthetic input, since synthetic payloads passed while Codex was failing.
- `pre-commit` clean, `ty` clean (litellm is imported lazily per repo convention).
- End-to-end verification against real Codex CLI 0.145 is in the follow-up streaming PR — Codex always streams, so it cannot exercise this PR alone.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

**Stack:**
1. [gateway-external-access #13604](https://github.com/onyx-dot-app/onyx/pull/13604)