### PR TITLE
feat(auth): capture per-credential identity for usage attribution

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -2019,10 +2019,6 @@ async def _resolve_optional_user(
     user: User | None,
     user_manager: BaseUserManager[User, uuid.UUID],
 ) -> User | None:
-    # A cookie-session user (password / OAuth / SAML) is already resolved here;
-    # anything else is credential-less until whichever branch authenticates it
-    # claims it. Each branch stamps its own type, so no caller has to infer the
-    # mechanism from the absence of another one.
     if user is not None:
         request.state.usage_credential = UsageCredentialIdentity(
             UsageCredentialType.SESSION

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -116,7 +116,7 @@ from onyx.configs.constants import (
     MilestoneRecordType,
     OnyxRedisLocks,
 )
-from onyx.db.api_key import fetch_user_for_api_key
+from onyx.db.api_key import fetch_api_key_auth_result
 from onyx.db.auth import (
     SQLAlchemyUserAdminDB,
     get_access_token_db,
@@ -168,7 +168,9 @@ from shared_configs.configs import (
 )
 from shared_configs.contextvars import (
     CURRENT_TENANT_ID_CONTEXTVAR,
+    CURRENT_USAGE_CREDENTIAL_CONTEXTVAR,
     CURRENT_USER_ID_CONTEXTVAR,
+    UsageCredentialIdentity,
     get_current_tenant_id,
 )
 
@@ -2012,6 +2014,8 @@ async def _resolve_optional_user(
     user: User | None,
     user_manager: BaseUserManager[User, uuid.UUID],
 ) -> User | None:
+    request.state.usage_credential = UsageCredentialIdentity("session")
+
     if user := await _check_for_saml_and_jwt(request, user, async_db_session):
         # If user is already set, _check_for_saml_and_jwt returns the same user object
         await _maybe_refresh_oauth_tokens(user, async_db_session, user_manager)
@@ -2025,8 +2029,22 @@ async def _resolve_optional_user(
                 # Expose the token's scopes so require_permission can cap the
                 # request to them.
                 request.state.token_scopes = pat.scopes
+                request.state.usage_credential = UsageCredentialIdentity(
+                    "pat",
+                    str(pat.pat_id),
+                    pat.pat_name,
+                    pat.pat_display,
+                )
         elif hashed_api_key := get_hashed_api_key_from_request(request):
-            user = await fetch_user_for_api_key(hashed_api_key, async_db_session)
+            api_key = await fetch_api_key_auth_result(hashed_api_key, async_db_session)
+            if api_key is not None:
+                user = api_key.user
+                request.state.usage_credential = UsageCredentialIdentity(
+                    "api_key",
+                    str(api_key.api_key_id),
+                    api_key.api_key_name,
+                    api_key.api_key_display,
+                )
     except ValueError:
         logger.warning("Issue with validating authentication token")
         return None
@@ -2060,9 +2078,13 @@ async def optional_user(
         user_manager,
     )
     token = CURRENT_USER_ID_CONTEXTVAR.set(str(user.id) if user is not None else None)
+    credential_token = CURRENT_USAGE_CREDENTIAL_CONTEXTVAR.set(
+        getattr(request.state, "usage_credential", None)
+    )
     try:
         yield user
     finally:
+        CURRENT_USAGE_CREDENTIAL_CONTEXTVAR.reset(credential_token)
         CURRENT_USER_ID_CONTEXTVAR.reset(token)
 
 

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -2014,10 +2014,16 @@ async def _resolve_optional_user(
     user: User | None,
     user_manager: BaseUserManager[User, uuid.UUID],
 ) -> User | None:
-    request.state.usage_credential = UsageCredentialIdentity("session")
+    # A cookie-session user (password / OAuth / SAML) is already resolved here;
+    # anything else is credential-less until one of the branches below claims it.
+    had_session_user = user is not None
+    if had_session_user:
+        request.state.usage_credential = UsageCredentialIdentity("session")
 
     if user := await _check_for_saml_and_jwt(request, user, async_db_session):
         # If user is already set, _check_for_saml_and_jwt returns the same user object
+        if not had_session_user:
+            request.state.usage_credential = UsageCredentialIdentity("jwt")
         await _maybe_refresh_oauth_tokens(user, async_db_session, user_manager)
         return user
 

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -132,7 +132,7 @@ from onyx.db.engine.sql_engine import (
     get_session_with_current_tenant,
     get_session_with_tenant,
 )
-from onyx.db.enums import AccountType, Permission
+from onyx.db.enums import AccountType, PatType, Permission
 from onyx.db.models import AccessToken, OAuthAccount, Persona, User
 from onyx.db.pat import resolve_pat
 from onyx.db.users import (
@@ -2035,8 +2035,11 @@ async def _resolve_optional_user(
                 # Expose the token's scopes so require_permission can cap the
                 # request to them.
                 request.state.token_scopes = pat.scopes
+                # Craft sandbox tokens are agent-driven and carry the owning
+                # human's user_id, so they need their own credential type to
+                # stay separable from interactive PAT usage.
                 request.state.usage_credential = UsageCredentialIdentity(
-                    "pat",
+                    "craft_pat" if pat.pat_type == PatType.CRAFT else "pat",
                     str(pat.pat_id),
                     pat.pat_name,
                     pat.pat_display,

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -173,6 +173,7 @@ from shared_configs.contextvars import (
     UsageCredentialIdentity,
     get_current_tenant_id,
 )
+from shared_configs.enums import UsageCredentialType
 
 logger = setup_logger()
 
@@ -1945,6 +1946,10 @@ async def _check_for_saml_and_jwt(
                 user = await _get_or_create_user_from_jwt(
                     payload, request, async_db_session
                 )
+                if user is not None:
+                    request.state.usage_credential = UsageCredentialIdentity(
+                        UsageCredentialType.JWT
+                    )
 
     return user
 
@@ -2015,15 +2020,16 @@ async def _resolve_optional_user(
     user_manager: BaseUserManager[User, uuid.UUID],
 ) -> User | None:
     # A cookie-session user (password / OAuth / SAML) is already resolved here;
-    # anything else is credential-less until one of the branches below claims it.
-    had_session_user = user is not None
-    if had_session_user:
-        request.state.usage_credential = UsageCredentialIdentity("session")
+    # anything else is credential-less until whichever branch authenticates it
+    # claims it. Each branch stamps its own type, so no caller has to infer the
+    # mechanism from the absence of another one.
+    if user is not None:
+        request.state.usage_credential = UsageCredentialIdentity(
+            UsageCredentialType.SESSION
+        )
 
     if user := await _check_for_saml_and_jwt(request, user, async_db_session):
         # If user is already set, _check_for_saml_and_jwt returns the same user object
-        if not had_session_user:
-            request.state.usage_credential = UsageCredentialIdentity("jwt")
         await _maybe_refresh_oauth_tokens(user, async_db_session, user_manager)
         return user
 
@@ -2035,11 +2041,12 @@ async def _resolve_optional_user(
                 # Expose the token's scopes so require_permission can cap the
                 # request to them.
                 request.state.token_scopes = pat.scopes
-                # Craft sandbox tokens are agent-driven and carry the owning
-                # human's user_id, so they need their own credential type to
-                # stay separable from interactive PAT usage.
                 request.state.usage_credential = UsageCredentialIdentity(
-                    "craft_pat" if pat.pat_type == PatType.CRAFT else "pat",
+                    (
+                        UsageCredentialType.CRAFT_PAT
+                        if pat.pat_type == PatType.CRAFT
+                        else UsageCredentialType.PAT
+                    ),
                     str(pat.pat_id),
                     pat.pat_name,
                     pat.pat_display,
@@ -2049,7 +2056,7 @@ async def _resolve_optional_user(
             if api_key is not None:
                 user = api_key.user
                 request.state.usage_credential = UsageCredentialIdentity(
-                    "api_key",
+                    UsageCredentialType.API_KEY,
                     str(api_key.api_key_id),
                     api_key.api_key_name,
                     api_key.api_key_display,

--- a/backend/onyx/db/api_key.py
+++ b/backend/onyx/db/api_key.py
@@ -1,9 +1,10 @@
 import uuid
+from typing import NamedTuple
 
 from fastapi_users.password import PasswordHelper
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session, contains_eager, joinedload
 
 from onyx.auth.api_key import (
     ApiKeyDescriptor,
@@ -26,6 +27,13 @@ from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
+
+
+class ApiKeyAuthResult(NamedTuple):
+    user: User
+    api_key_id: int
+    api_key_name: str | None
+    api_key_display: str
 
 
 def get_api_key_email_pattern() -> str:
@@ -63,6 +71,33 @@ async def fetch_user_for_api_key(
         select(User)
         .join(ApiKey, ApiKey.user_id == User.id)
         .where(ApiKey.hashed_api_key == hashed_api_key)
+    )
+
+
+async def fetch_api_key_auth_result(
+    hashed_api_key: str, async_db_session: AsyncSession
+) -> ApiKeyAuthResult | None:
+    row = (
+        (
+            await async_db_session.execute(
+                select(ApiKey)
+                .join(ApiKey.user)
+                # a lazy row.user under an AsyncSession raises MissingGreenlet
+                .options(contains_eager(ApiKey.user))
+                .where(ApiKey.hashed_api_key == hashed_api_key)
+            )
+        )
+        .scalars()
+        .unique()
+        .one_or_none()
+    )
+    if row is None:
+        return None
+    return ApiKeyAuthResult(
+        user=row.user,
+        api_key_id=row.id,
+        api_key_name=row.name,
+        api_key_display=row.api_key_display,
     )
 
 

--- a/backend/onyx/db/pat.py
+++ b/backend/onyx/db/pat.py
@@ -33,6 +33,7 @@ class PatAuthResult(NamedTuple):
     pat_id: int
     pat_name: str
     pat_display: str
+    pat_type: PatType
 
 
 async def resolve_pat(
@@ -79,6 +80,7 @@ async def resolve_pat(
         pat_id=pat.id,
         pat_name=pat.name,
         pat_display=pat.token_display,
+        pat_type=pat.pat_type,
     )
 
 

--- a/backend/onyx/db/pat.py
+++ b/backend/onyx/db/pat.py
@@ -30,6 +30,9 @@ class PatAuthResult(NamedTuple):
 
     user: User
     scopes: list[Permission] | None
+    pat_id: int
+    pat_name: str
+    pat_display: str
 
 
 async def resolve_pat(
@@ -70,7 +73,13 @@ async def resolve_pat(
     _schedule_pat_last_used_update(hashed_token, now)
     # None (no scopes) = unrestricted; a stored list is parsed to Permissions.
     scopes = parse_permission_values(pat.scopes) if pat.scopes is not None else None
-    return PatAuthResult(user=pat.user, scopes=scopes)
+    return PatAuthResult(
+        user=pat.user,
+        scopes=scopes,
+        pat_id=pat.id,
+        pat_name=pat.name,
+        pat_display=pat.token_display,
+    )
 
 
 def _schedule_pat_last_used_update(hashed_token: str, now: datetime) -> None:

--- a/backend/shared_configs/contextvars.py
+++ b/backend/shared_configs/contextvars.py
@@ -2,6 +2,7 @@ import contextvars
 from typing import NamedTuple
 
 from shared_configs.configs import MULTI_TENANT, POSTGRES_DEFAULT_SCHEMA
+from shared_configs.enums import UsageCredentialType
 
 # Context variable for the current tenant id
 CURRENT_TENANT_ID_CONTEXTVAR: contextvars.ContextVar[str | None] = (
@@ -37,7 +38,7 @@ CURRENT_USER_ID_CONTEXTVAR: contextvars.ContextVar[str | None] = contextvars.Con
 
 
 class UsageCredentialIdentity(NamedTuple):
-    credential_type: str
+    credential_type: UsageCredentialType
     credential_id: str | None = None
     credential_name: str | None = None
     credential_display: str | None = None

--- a/backend/shared_configs/contextvars.py
+++ b/backend/shared_configs/contextvars.py
@@ -1,4 +1,5 @@
 import contextvars
+from typing import NamedTuple
 
 from shared_configs.configs import MULTI_TENANT, POSTGRES_DEFAULT_SCHEMA
 
@@ -35,6 +36,18 @@ CURRENT_USER_ID_CONTEXTVAR: contextvars.ContextVar[str | None] = contextvars.Con
 )
 
 
+class UsageCredentialIdentity(NamedTuple):
+    credential_type: str
+    credential_id: str | None = None
+    credential_name: str | None = None
+    credential_display: str | None = None
+
+
+CURRENT_USAGE_CREDENTIAL_CONTEXTVAR: contextvars.ContextVar[
+    UsageCredentialIdentity | None
+] = contextvars.ContextVar("current_usage_credential", default=None)
+
+
 def get_current_tenant_id() -> str:
     tenant_id = CURRENT_TENANT_ID_CONTEXTVAR.get()
     if tenant_id is None:
@@ -55,3 +68,7 @@ def get_current_tenant_id() -> str:
 def get_current_user_id() -> str | None:
     """Requesting user's id, or None outside a per-request context."""
     return CURRENT_USER_ID_CONTEXTVAR.get()
+
+
+def get_current_usage_credential() -> UsageCredentialIdentity | None:
+    return CURRENT_USAGE_CREDENTIAL_CONTEXTVAR.get()

--- a/backend/shared_configs/enums.py
+++ b/backend/shared_configs/enums.py
@@ -40,3 +40,17 @@ class WebContentProviderType(str, Enum):
 class TracingProviderType(str, Enum):
     BRAINTRUST = "braintrust"
     LANGFUSE = "langfuse"
+
+
+class UsageCredentialType(str, Enum):
+    """The kind of credential that authenticated a request.
+
+    CRAFT_PAT is split from PAT because Craft sandbox tokens are agent-driven
+    yet carry the owning human's user_id.
+    """
+
+    SESSION = "session"
+    JWT = "jwt"
+    PAT = "pat"
+    CRAFT_PAT = "craft_pat"
+    API_KEY = "api_key"

--- a/backend/shared_configs/enums.py
+++ b/backend/shared_configs/enums.py
@@ -43,11 +43,8 @@ class TracingProviderType(str, Enum):
 
 
 class UsageCredentialType(str, Enum):
-    """The kind of credential that authenticated a request.
-
-    CRAFT_PAT is split from PAT because Craft sandbox tokens are agent-driven
-    yet carry the owning human's user_id.
-    """
+    """CRAFT_PAT is separate from PAT because Craft sandbox tokens are
+    agent-driven yet carry the owning human's user_id."""
 
     SESSION = "session"
     JWT = "jwt"

--- a/backend/tests/external_dependency_unit/db/test_api_key_auth_result.py
+++ b/backend/tests/external_dependency_unit/db/test_api_key_auth_result.py
@@ -1,0 +1,39 @@
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.auth.api_key import hash_api_key
+from onyx.auth.schemas import UserRole
+from onyx.db.api_key import fetch_api_key_auth_result, insert_api_key, remove_api_key
+from onyx.db.engine.async_sql_engine import get_async_session_context_manager
+from onyx.server.api_key.models import APIKeyArgs
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("tenant_context")
+async def test_fetch_api_key_auth_result_loads_user(db_session: Session) -> None:
+    descriptor = insert_api_key(
+        db_session, APIKeyArgs(name="auth-result", role=UserRole.BASIC), user_id=None
+    )
+    assert descriptor.api_key is not None
+
+    try:
+        async with get_async_session_context_manager() as async_session:
+            result = await fetch_api_key_auth_result(
+                hash_api_key(descriptor.api_key), async_session
+            )
+
+        assert result is not None
+        # Accessed outside the async session: only possible if eagerly loaded.
+        assert result.user.id == descriptor.user_id
+        assert result.user.role == UserRole.BASIC
+        assert result.api_key_id == descriptor.api_key_id
+        assert result.api_key_name == "auth-result"
+        assert result.api_key_display == descriptor.api_key_display
+
+        async with get_async_session_context_manager() as async_session:
+            assert (
+                await fetch_api_key_auth_result("not-a-real-hash", async_session)
+                is None
+            )
+    finally:
+        remove_api_key(db_session, descriptor.api_key_id)

--- a/backend/tests/unit/onyx/auth/test_usage_credential_identity.py
+++ b/backend/tests/unit/onyx/auth/test_usage_credential_identity.py
@@ -8,10 +8,13 @@ from onyx.db.enums import PatType
 from onyx.db.models import User
 from onyx.db.pat import PatAuthResult
 from shared_configs.contextvars import UsageCredentialIdentity
+from shared_configs.enums import UsageCredentialType
 
 
-def _bare_request() -> Request:
-    return Request({"type": "http", "method": "GET", "path": "/", "headers": []})
+def _bare_request(headers: list[tuple[bytes, bytes]] | None = None) -> Request:
+    return Request(
+        {"type": "http", "method": "GET", "path": "/", "headers": headers or []}
+    )
 
 
 async def _no_oauth_refresh(*_: Any, **__: Any) -> None:
@@ -39,7 +42,9 @@ async def test_cookie_session_user_is_session_credential() -> None:
     user = cast(User, object())
 
     assert await _resolve(request, user) is user
-    assert request.state.usage_credential == UsageCredentialIdentity("session")
+    assert request.state.usage_credential == UsageCredentialIdentity(
+        UsageCredentialType.SESSION
+    )
 
 
 @pytest.mark.asyncio
@@ -52,13 +57,16 @@ async def test_unauthenticated_request_has_no_credential() -> None:
 
 @pytest.mark.parametrize(
     "pat_type, expected_credential_type",
-    [(PatType.USER, "pat"), (PatType.CRAFT, "craft_pat")],
+    [
+        (PatType.USER, UsageCredentialType.PAT),
+        (PatType.CRAFT, UsageCredentialType.CRAFT_PAT),
+    ],
 )
 @pytest.mark.asyncio
 async def test_pat_type_selects_credential_type(
     monkeypatch: pytest.MonkeyPatch,
     pat_type: PatType,
-    expected_credential_type: str,
+    expected_credential_type: UsageCredentialType,
 ) -> None:
     pat_user = cast(User, object())
     pat = PatAuthResult(
@@ -87,13 +95,22 @@ async def test_pat_type_selects_credential_type(
 async def test_external_jwt_user_is_jwt_credential(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Exercises the real _check_for_saml_and_jwt, since that is what stamps the
+    credential — stubbing it out would test nothing."""
     jwt_user = cast(User, object())
 
-    async def fake_check(*_: Any, **__: Any) -> User:
+    async def fake_verify(_: str) -> dict[str, str]:
+        return {"sub": "someone"}
+
+    async def fake_get_or_create(*_: Any, **__: Any) -> User:
         return jwt_user
 
-    monkeypatch.setattr(users, "_check_for_saml_and_jwt", fake_check)
-    request = _bare_request()
+    monkeypatch.setattr(users, "JWT_PUBLIC_KEY_URL", "https://idp.example/jwks")
+    monkeypatch.setattr(users, "verify_jwt_token", fake_verify)
+    monkeypatch.setattr(users, "_get_or_create_user_from_jwt", fake_get_or_create)
+    request = _bare_request([(b"authorization", b"Bearer some-token")])
 
     assert await _resolve(request, None) is jwt_user
-    assert request.state.usage_credential == UsageCredentialIdentity("jwt")
+    assert request.state.usage_credential == UsageCredentialIdentity(
+        UsageCredentialType.JWT
+    )

--- a/backend/tests/unit/onyx/auth/test_usage_credential_identity.py
+++ b/backend/tests/unit/onyx/auth/test_usage_credential_identity.py
@@ -4,7 +4,9 @@ import pytest
 from fastapi import Request
 
 from onyx.auth import users
+from onyx.db.enums import PatType
 from onyx.db.models import User
+from onyx.db.pat import PatAuthResult
 from shared_configs.contextvars import UsageCredentialIdentity
 
 
@@ -46,6 +48,39 @@ async def test_unauthenticated_request_has_no_credential() -> None:
 
     assert await _resolve(request, None) is None
     assert getattr(request.state, "usage_credential", None) is None
+
+
+@pytest.mark.parametrize(
+    "pat_type, expected_credential_type",
+    [(PatType.USER, "pat"), (PatType.CRAFT, "craft_pat")],
+)
+@pytest.mark.asyncio
+async def test_pat_type_selects_credential_type(
+    monkeypatch: pytest.MonkeyPatch,
+    pat_type: PatType,
+    expected_credential_type: str,
+) -> None:
+    pat_user = cast(User, object())
+    pat = PatAuthResult(
+        user=pat_user,
+        scopes=None,
+        pat_id=7,
+        pat_name="my-token",
+        pat_display="onyx_pat_...abcd",
+        pat_type=pat_type,
+    )
+
+    async def fake_resolve_pat(*_: Any, **__: Any) -> PatAuthResult:
+        return pat
+
+    monkeypatch.setattr(users, "get_hashed_pat_from_request", lambda _: "hashed")
+    monkeypatch.setattr(users, "resolve_pat", fake_resolve_pat)
+    request = _bare_request()
+
+    assert await _resolve(request, None) is pat_user
+    assert request.state.usage_credential == UsageCredentialIdentity(
+        expected_credential_type, "7", "my-token", "onyx_pat_...abcd"
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/onyx/auth/test_usage_credential_identity.py
+++ b/backend/tests/unit/onyx/auth/test_usage_credential_identity.py
@@ -95,8 +95,7 @@ async def test_pat_type_selects_credential_type(
 async def test_external_jwt_user_is_jwt_credential(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Exercises the real _check_for_saml_and_jwt, since that is what stamps the
-    credential — stubbing it out would test nothing."""
+    """Drives the real _check_for_saml_and_jwt — stubbing it out tests nothing."""
     jwt_user = cast(User, object())
 
     async def fake_verify(_: str) -> dict[str, str]:

--- a/backend/tests/unit/onyx/auth/test_usage_credential_identity.py
+++ b/backend/tests/unit/onyx/auth/test_usage_credential_identity.py
@@ -1,0 +1,64 @@
+from typing import Any, cast
+
+import pytest
+from fastapi import Request
+
+from onyx.auth import users
+from onyx.db.models import User
+from shared_configs.contextvars import UsageCredentialIdentity
+
+
+def _bare_request() -> Request:
+    return Request({"type": "http", "method": "GET", "path": "/", "headers": []})
+
+
+async def _no_oauth_refresh(*_: Any, **__: Any) -> None:
+    return None
+
+
+async def _resolve(request: Request, user: User | None) -> User | None:
+    return await users._resolve_optional_user(
+        request,
+        cast(Any, None),
+        user,
+        cast(Any, None),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _patch_auth_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(users, "_maybe_refresh_oauth_tokens", _no_oauth_refresh)
+    monkeypatch.setattr(users, "JWT_PUBLIC_KEY_URL", None)
+
+
+@pytest.mark.asyncio
+async def test_cookie_session_user_is_session_credential() -> None:
+    request = _bare_request()
+    user = cast(User, object())
+
+    assert await _resolve(request, user) is user
+    assert request.state.usage_credential == UsageCredentialIdentity("session")
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_request_has_no_credential() -> None:
+    request = _bare_request()
+
+    assert await _resolve(request, None) is None
+    assert getattr(request.state, "usage_credential", None) is None
+
+
+@pytest.mark.asyncio
+async def test_external_jwt_user_is_jwt_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    jwt_user = cast(User, object())
+
+    async def fake_check(*_: Any, **__: Any) -> User:
+        return jwt_user
+
+    monkeypatch.setattr(users, "_check_for_saml_and_jwt", fake_check)
+    request = _bare_request()
+
+    assert await _resolve(request, None) is jwt_user
+    assert request.state.usage_credential == UsageCredentialIdentity("jwt")


### PR DESCRIPTION
## Description

Precursor to the LLM gateway stack, split out because it is an auth-layer change with a blast radius unrelated to the gateway feature that sits on top of it.

**What it adds.** A `UsageCredentialIdentity` contextvar (`CURRENT_USAGE_CREDENTIAL_CONTEXTVAR`), set once per request in `optional_user` alongside the existing `CURRENT_USER_ID_CONTEXTVAR`, so a request can be attributed to the exact credential that made it rather than only to the resolved user. Five credential types — `session`, `jwt`, `pat`, `craft_pat`, `api_key` — each carrying the credential's id, user-supplied name, and masked display string where one exists.

Why a credential axis is needed on top of user id:

- **PATs share a user.** `PersonalAccessToken.user_id` FKs the real human, so every one of a user's tokens resolves to the same `CURRENT_USER_ID_CONTEXTVAR`. Per-user attribution alone cannot say which token made a call.
- **API keys were unique but illegible.** `insert_api_key` mints a synthetic `SERVICE_ACCOUNT` user per key, so per-key granularity already existed — as an opaque UUID behind a dummy email. The credential tuple names the key instead.
- **Craft sandbox tokens are agent-driven.** `PatType.CRAFT` PATs carry the owning human's `user_id`, so autonomous sandbox usage would silently blend into that person's interactive total. They get their own `craft_pat` type to stay separable.

Supporting db changes: `PatAuthResult` gains `pat_id` / `pat_name` / `pat_display` / `pat_type`; new `fetch_api_key_auth_result` returns the equivalent for API keys, alongside the existing `fetch_user_for_api_key`.

**Bug fixed: `MissingGreenlet` on every API-key-authenticated request.** Swapping `fetch_user_for_api_key` for the richer `fetch_api_key_auth_result` introduced a `.join(ApiKey.user)` with no eager-load option. `ApiKey.user` is a plain relationship with the default `lazy="select"`, so reading `row.user` under the `AsyncSession` in `_resolve_optional_user` was an implicit lazy load with no greenlet context. Fixed with the `contains_eager` + `.unique()` pattern `resolve_pat` already uses — `.unique()` is required because `User.oauth_accounts` is itself `lazy="joined"`, and that one-to-many JOIN multiplies rows.

That failure mode is the reason this is its own PR: it has nothing to do with gateway access, and reviewing it inside a feature PR titled "let external clients use the gateway" is how it slipped past in the first place (it was caught by Greptile, not a human).

**Bug fixed: credential claimed before authentication.** `_resolve_optional_user` stamped `session` as its first statement and nothing ever cleared it, so anonymous/unauthenticated requests — and external-JWT requests, which are a distinct credential kind — both reported `session`. The stamp is now conditional on a cookie-session user already resolved upstream by `optional_fastapi_current_user`; JWT gets its own type; an unauthenticated request leaves `request.state.usage_credential` unset so the contextvar holds `None`. Also caught by Greptile.

### Reviewer notes

**This code has no consumer yet.** Nothing in this PR reads `UsageCredentialIdentity`. It is the foundation for per-credential attribution in the gateway work stacked above, and is landing separately so the auth change can be judged on its own. If you would rather not carry unused code, the alternative is to hold this until a consumer exists — say so and I'll defer it.

**Why there is no `GATEWAY` credential type.** Credential identity answers *who authenticated*; it cannot answer *which surface spent the tokens*, because one PAT scoped with `USE_LLM_GATEWAY` can hit both the gateway and in-product endpoints. That second axis is already `LLMFlow`, which every LLM call must carry. Separating gateway from in-product cost is therefore a new `LLMFlow` value upstack, not a new `PatType` here.

## How Has This Been Tested?

- `backend/tests/unit/onyx/auth/` plus `tests/unit/shared_configs/test_user_id_contextvar.py`: 344 passed, 1 skipped.
- New `tests/unit/onyx/auth/test_usage_credential_identity.py` — covers cookie session → `session`, unauthenticated → `None`, external JWT → `jwt`, and parametrized `PatType.USER` → `pat` / `PatType.CRAFT` → `craft_pat`.
- New `tests/external_dependency_unit/db/test_api_key_auth_result.py` reproduces the `MissingGreenlet` against a real Postgres and pins the eager load: it asserts `result.user.id` *outside* the closed session, so a regression to lazy loading cannot pass silently.
- `pre-commit` clean (lazy imports, ty, ruff, ruff format).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capture the exact credential used for each request via a new contextvar and per-credential auth results, including a separate `craft_pat` type. Fix `MissingGreenlet` in API key auth and only stamp a usage credential once that mechanism actually authenticates (JWT is stamped where it resolves).

- **New Features**
  - Added `UsageCredentialIdentity` and `CURRENT_USAGE_CREDENTIAL_CONTEXTVAR`; sets `request.state.usage_credential` for `session`, `jwt`, `pat`, `craft_pat`, and `api_key` (includes id/name/display).
  - Introduced `UsageCredentialType` enum and `get_current_usage_credential()`; JWT credential is set inside the SAML/JWT path where the user is resolved.
  - Extended `PatAuthResult` with `pat_id`, `pat_name`, `pat_display`, `pat_type`; added `fetch_api_key_auth_result` returning the API key’s user/id/name/display for attribution.

- **Bug Fixes**
  - Eager-load `ApiKey.user` with `contains_eager(...).unique()` in `fetch_api_key_auth_result` to prevent `MissingGreenlet`; tests pin the behavior.
  - Only assign a usage credential after successful auth; unauthenticated requests leave it unset, and a `session` credential is preserved over JWT fallback.

<sup>Written for commit f1495622449de84311d6f9cf94251bd70c708d45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

