### PR TITLE
fix(sharepoint): index files synced in with back-dated modification times

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -293,6 +293,36 @@ def _site_page_in_time_window(
     )
 
 
+def _drive_item_in_time_window(
+    item: dict[str, Any],
+    start: datetime | None,
+    end: datetime | None,
+) -> bool:
+    """Return True if a drive item falls within [start, end].
+
+    Uses the later of `createdDateTime` and `lastModifiedDateTime`: a file
+    copied or synced into a drive keeps its original modification date, which
+    can predate the window even though the file is new to the drive. Items
+    carrying neither timestamp are kept.
+    """
+    if start is None and end is None:
+        return True
+
+    timestamps = [
+        ts
+        for ts in (
+            _parse_sharepoint_datetime(item.get("createdDateTime")),
+            _parse_sharepoint_datetime(item.get("lastModifiedDateTime")),
+        )
+        if ts is not None
+    ]
+    if not timestamps:
+        return True
+
+    item_ts = max(timestamps)
+    return (start is None or item_ts >= start) and (end is None or item_ts <= end)
+
+
 # Transport-level exceptions that indicate a transient network/server-side
 # problem rather than an HTTP error. These can occur both as bare exceptions
 # (older office365 SDK paths that don't wrap them) and as the underlying
@@ -2050,18 +2080,8 @@ class SharepointConnector(
                     # but still yield them — the downstream conversion handles filtering
                     # by extension / mime type.
 
-                    # NOTE: We are now including items without a lastModifiedDateTime,
-                    # and respecting when only one of start or end is set.
-                    if start is not None or end is not None:
-                        raw_ts = item.get("lastModifiedDateTime")
-                        if raw_ts:
-                            mod_dt = datetime.fromisoformat(
-                                raw_ts.replace("Z", "+00:00")
-                            )
-                            if start is not None and mod_dt < start:
-                                continue
-                            if end is not None and mod_dt > end:
-                                continue
+                    if not _drive_item_in_time_window(item, start, end):
+                        continue
 
                     yield DriveItemData.from_graph_json(item)
 
@@ -2145,14 +2165,8 @@ class SharepointConnector(
                 if "folder" in item or "deleted" in item:
                     continue
 
-                if start is not None or end is not None:
-                    raw_ts = item.get("lastModifiedDateTime")
-                    if raw_ts:
-                        mod_dt = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
-                        if start is not None and mod_dt < start:
-                            continue
-                        if end is not None and mod_dt > end:
-                            continue
+                if not _drive_item_in_time_window(item, start, end):
+                    continue
 
                 yield DriveItemData.from_graph_json(item)
 
@@ -2212,14 +2226,8 @@ class SharepointConnector(
         for item in data.get("value", []):
             if "folder" in item or "deleted" in item:
                 continue
-            if start is not None or end is not None:
-                raw_ts = item.get("lastModifiedDateTime")
-                if raw_ts:
-                    mod_dt = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
-                    if start is not None and mod_dt < start:
-                        continue
-                    if end is not None and mod_dt > end:
-                        continue
+            if not _drive_item_in_time_window(item, start, end):
+                continue
             items.append(DriveItemData.from_graph_json(item))
 
         next_url = data.get("@odata.nextLink")

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_time_window_filtering.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_time_window_filtering.py
@@ -1,0 +1,169 @@
+"""Tests for [start, end] filtering of drive items in the SharePoint connector.
+
+When a file is copied, moved, or synced into OneDrive/SharePoint, Microsoft
+Graph preserves the file's original modification date in
+``lastModifiedDateTime`` while setting ``createdDateTime`` to the moment the
+file landed in the drive.  Filtering on ``lastModifiedDateTime`` alone makes an
+incremental run discard those files, so they only ever show up after a manual
+full re-index.
+
+These tests pin the behaviour for all three item sources: the BFS children
+traversal, the streaming delta traversal, and the per-page delta fetch used by
+checkpointed runs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from onyx.connectors.sharepoint.connector import DriveItemData, SharepointConnector
+
+GRAPH_API_BASE = "https://graph.microsoft.com/v1.0"
+DRIVE_ID = "fake-drive-id"
+
+# The incremental window: "everything that changed since the last run".
+START = datetime(2026, 3, 1, tzinfo=timezone.utc)
+END = datetime(2026, 3, 2, tzinfo=timezone.utc)
+
+# A file synced in during the window, carrying its original (much older)
+# modification date from the user's local filesystem.
+SYNCED_IN_ITEM = {
+    "id": "synced-in",
+    "name": "old_report.pdf",
+    "webUrl": "https://example.sharepoint.com/old_report.pdf",
+    "file": {"mimeType": "application/pdf"},
+    "createdDateTime": "2026-03-01T10:00:00Z",
+    "lastModifiedDateTime": "2025-11-14T08:30:00Z",
+    "parentReference": {"driveId": DRIVE_ID, "path": "/drives/d1/root:"},
+}
+
+# A file that genuinely predates the window on both timestamps.
+UNCHANGED_ITEM = {
+    "id": "unchanged",
+    "name": "ancient.pdf",
+    "webUrl": "https://example.sharepoint.com/ancient.pdf",
+    "file": {"mimeType": "application/pdf"},
+    "createdDateTime": "2025-01-05T09:00:00Z",
+    "lastModifiedDateTime": "2025-02-06T09:00:00Z",
+    "parentReference": {"driveId": DRIVE_ID, "path": "/drives/d1/root:"},
+}
+
+# A file that landed after the window closed.
+AFTER_WINDOW_ITEM = {
+    "id": "after-window",
+    "name": "future.pdf",
+    "webUrl": "https://example.sharepoint.com/future.pdf",
+    "file": {"mimeType": "application/pdf"},
+    "createdDateTime": "2026-03-05T10:00:00Z",
+    "lastModifiedDateTime": "2026-03-05T10:00:00Z",
+    "parentReference": {"driveId": DRIVE_ID, "path": "/drives/d1/root:"},
+}
+
+
+def _connector(
+    monkeypatch: pytest.MonkeyPatch, payload: dict[str, Any]
+) -> SharepointConnector:
+    """A connector whose Graph calls always return ``payload``."""
+    connector = SharepointConnector()
+    connector.graph_api_base = GRAPH_API_BASE
+
+    def fake_get_json(
+        self: SharepointConnector,  # noqa: ARG001
+        url: str,  # noqa: ARG001
+        params: dict[str, str] | None = None,  # noqa: ARG001
+    ) -> dict[str, Any]:
+        return payload
+
+    monkeypatch.setattr(SharepointConnector, "_graph_api_get_json", fake_get_json)
+    return connector
+
+
+def _paged_ids(connector: SharepointConnector) -> list[str]:
+    return [
+        item.id
+        for item in connector._iter_drive_items_paged(
+            drive_id=DRIVE_ID, start=START, end=END
+        )
+    ]
+
+
+def _delta_pages_ids(connector: SharepointConnector) -> list[str]:
+    return [
+        item.id
+        for item in connector._iter_delta_pages(
+            initial_url=f"{GRAPH_API_BASE}/drives/{DRIVE_ID}/root/delta",
+            drive_id=DRIVE_ID,
+            start=START,
+            end=END,
+            page_size=200,
+            allow_full_resync=False,
+        )
+    ]
+
+
+def _one_delta_page_ids(connector: SharepointConnector) -> list[str]:
+    items, _ = connector._fetch_one_delta_page(
+        page_url=f"{GRAPH_API_BASE}/drives/{DRIVE_ID}/root/delta",
+        drive_id=DRIVE_ID,
+        start=START,
+        end=END,
+    )
+    return [item.id for item in items]
+
+
+# Each item source applies the same window filter, so they get the same cases.
+ITEM_SOURCES: list[tuple[str, Callable[[SharepointConnector], list[str]]]] = [
+    ("iter_drive_items_paged", _paged_ids),
+    ("iter_delta_pages", _delta_pages_ids),
+    ("fetch_one_delta_page", _one_delta_page_ids),
+]
+
+
+@pytest.mark.parametrize("source_name,collect_ids", ITEM_SOURCES)
+def test_file_synced_in_during_window_is_returned(
+    monkeypatch: pytest.MonkeyPatch,
+    source_name: str,  # noqa: ARG001
+    collect_ids: Callable[[SharepointConnector], list[str]],
+) -> None:
+    """A file added during the window counts as new even when its
+    lastModifiedDateTime was back-dated by the sync client."""
+    connector = _connector(monkeypatch, {"value": [SYNCED_IN_ITEM]})
+
+    assert collect_ids(connector) == ["synced-in"]
+
+
+@pytest.mark.parametrize("source_name,collect_ids", ITEM_SOURCES)
+def test_file_untouched_before_window_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+    source_name: str,  # noqa: ARG001
+    collect_ids: Callable[[SharepointConnector], list[str]],
+) -> None:
+    """Widening the filter must not drag in genuinely unchanged files."""
+    connector = _connector(monkeypatch, {"value": [UNCHANGED_ITEM]})
+
+    assert collect_ids(connector) == []
+
+
+@pytest.mark.parametrize("source_name,collect_ids", ITEM_SOURCES)
+def test_file_added_after_window_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+    source_name: str,  # noqa: ARG001
+    collect_ids: Callable[[SharepointConnector], list[str]],
+) -> None:
+    connector = _connector(monkeypatch, {"value": [AFTER_WINDOW_ITEM]})
+
+    assert collect_ids(connector) == []
+
+
+def test_created_datetime_is_parsed_onto_drive_item_data() -> None:
+    """The filter relies on createdDateTime surviving the JSON parse."""
+    item = DriveItemData.from_graph_json(SYNCED_IN_ITEM)
+
+    assert item.created_datetime == datetime(2026, 3, 1, 10, 0, tzinfo=timezone.utc)
+    assert item.last_modified_datetime == datetime(
+        2025, 11, 14, 8, 30, tzinfo=timezone.utc
+    )


### PR DESCRIPTION
## Description

Fixes #13583 (the timestamp half).

Drive items are now filtered on the later of `createdDateTime` and `lastModifiedDateTime`, so files synced in with a back-dated modification time aren't skipped by incremental runs. The same check was duplicated in `_iter_drive_items_paged`, `_iter_delta_pages`, and `_fetch_one_delta_page`; it's now one helper, `_drive_item_in_time_window`.

I didn't make the second suggested change (saving the delta link instead of the timestamp token). Graph [does accept a URL-encoded timestamp as a `token`](https://learn.microsoft.com/en-us/graph/api/driveitem-delta?view=graph-rest-1.0#example-4-retrieving-delta-results-using-a-timestamp) on OneDrive for Business and SharePoint, so there's no 410 and no fallback to full enumeration — the filter was the whole bug. Happy to revisit if you disagree.

## How Has This Been Tested?

New unit tests in `test_time_window_filtering.py`, run against all three item sources: a file added during the window with a back-dated `lastModifiedDateTime` is now returned (the test fails without this fix), while genuinely old files and files added after the window are still skipped.

I also reproduced the issue without a live SharePoint tenant. Since the bug stems entirely from Onyx's internal filtering where Graph returns the file but the connector discards it just mocking the HTTP response still tests the real code path (_fetch_one_delta_page, which handles scheduled polling).

```
# before
Graph returned : ['ancient.pdf', 'old_report.pdf']
Onyx indexed   : []

# after
Graph returned : ['ancient.pdf', 'old_report.pdf']
Onyx indexed   : ['old_report.pdf']
```

`old_report.pdf` is created inside the window but last modified four months earlier; `ancient.pdf` is untouched for a year and stays out of both runs.

154 passed in `backend/tests/unit/onyx/connectors/sharepoint/`, pre-commit clean. Not tested against live Graph.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incremental SharePoint indexing so files copied or synced into a drive during the window are included, even when their `lastModifiedDateTime` is older. We now filter on the later of `createdDateTime` and `lastModifiedDateTime`.

- **Bug Fixes**
  - Filter drive items by the later of `createdDateTime` and `lastModifiedDateTime` to avoid skipping back-dated files; items missing both timestamps are kept, and start-only or end-only windows still work.
  - Replaced duplicate checks with `_drive_item_in_time_window` used in `_iter_drive_items_paged`, `_iter_delta_pages`, and `_fetch_one_delta_page`; added unit tests to pin the behavior across all paths.

<sup>Written for commit eb2e0dda1d715756f3ed625bb6e2a1bc36ab2631. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

