### PR TITLE
feat(mobile): timeline state hooks

### DIFF
--- a/mobile/src/hooks/timeline/__tests__/testHelpers.ts
+++ b/mobile/src/hooks/timeline/__tests__/testHelpers.ts
@@ -1,0 +1,39 @@
+// Shared builders for the timeline hook tests (not a suite — no `.test.` suffix, so jest skips it).
+
+import { Packet, PacketType } from "@/chat/streamingModels";
+import { TransformedStep, TurnGroup } from "@/chat/timeline/transformers";
+
+export function makePacket(
+  type: PacketType,
+  placement: {
+    turn_index: number;
+    tab_index?: number;
+    sub_turn_index?: number | null;
+  } = { turn_index: 0 },
+  extra: Record<string, unknown> = {},
+): Packet {
+  return {
+    placement: { tab_index: 0, ...placement },
+    obj: { type, ...extra } as unknown as Packet["obj"],
+  };
+}
+
+export function makeStep(
+  turnIndex: number,
+  tabIndex: number,
+  packets: Packet[],
+): TransformedStep {
+  return {
+    key: `${turnIndex}-${tabIndex}`,
+    turnIndex,
+    tabIndex,
+    packets,
+  };
+}
+
+export function makeTurn(
+  turnIndex: number,
+  steps: TransformedStep[],
+): TurnGroup {
+  return { turnIndex, steps, isParallel: steps.length > 1 };
+}

--- a/mobile/src/hooks/timeline/__tests__/useStreamingDuration.test.ts
+++ b/mobile/src/hooks/timeline/__tests__/useStreamingDuration.test.ts
@@ -72,4 +72,20 @@ describe("useStreamingDuration", () => {
     act(() => jest.advanceTimersByTime(3000));
     expect(result.current).toBe(0);
   });
+
+  it("does not carry the prior stream's duration to a new startTime", () => {
+    const start = Date.now();
+    const { result, rerender } = renderHook(
+      ({ s, streaming }: { s: number; streaming: boolean }) =>
+        useStreamingDuration(streaming, s),
+      { initialProps: { s: start, streaming: true } },
+    );
+    act(() => jest.advanceTimersByTime(3000));
+    expect(result.current).toBe(3);
+
+    // New stream while the timer is off: the effect won't reconcile, so the render-phase reset is
+    // what prevents the old 3s from leaking into the new stream.
+    rerender({ s: Date.now() + 500, streaming: false });
+    expect(result.current).toBe(0);
+  });
 });

--- a/mobile/src/hooks/timeline/__tests__/useStreamingDuration.test.ts
+++ b/mobile/src/hooks/timeline/__tests__/useStreamingDuration.test.ts
@@ -1,0 +1,75 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import { act, renderHook } from "@testing-library/react-native";
+
+import { useStreamingDuration } from "@/hooks/timeline/useStreamingDuration";
+
+// Modern fake timers mock Date.now() too, so elapsed advances with the fake clock as the poll fires.
+describe("useStreamingDuration", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("starts at 0 and ticks once per whole second", () => {
+    const start = Date.now();
+    const { result } = renderHook(() => useStreamingDuration(true, start));
+    expect(result.current).toBe(0);
+
+    act(() => jest.advanceTimersByTime(1000));
+    expect(result.current).toBe(1);
+
+    act(() => jest.advanceTimersByTime(2000));
+    expect(result.current).toBe(3);
+  });
+
+  it("does not re-tick within the same second", () => {
+    const start = Date.now();
+    const { result } = renderHook(() => useStreamingDuration(true, start));
+    act(() => jest.advanceTimersByTime(500));
+    expect(result.current).toBe(0);
+    act(() => jest.advanceTimersByTime(499));
+    expect(result.current).toBe(0);
+    act(() => jest.advanceTimersByTime(1));
+    expect(result.current).toBe(1);
+  });
+
+  it("freezes at the backend duration when provided", () => {
+    const start = Date.now();
+    const { result } = renderHook(() => useStreamingDuration(true, start, 42));
+    expect(result.current).toBe(42);
+    act(() => jest.advanceTimersByTime(5000));
+    expect(result.current).toBe(42);
+  });
+
+  it("stops advancing when streaming ends but keeps the last value", () => {
+    const start = Date.now();
+    const { result, rerender } = renderHook(
+      ({ streaming }: { streaming: boolean }) =>
+        useStreamingDuration(streaming, start),
+      { initialProps: { streaming: true } },
+    );
+    act(() => jest.advanceTimersByTime(2000));
+    expect(result.current).toBe(2);
+
+    rerender({ streaming: false });
+    act(() => jest.advanceTimersByTime(5000));
+    // Preserved, not reset, because startTime is still defined.
+    expect(result.current).toBe(2);
+  });
+
+  it("resets to 0 when there is no start time", () => {
+    const { result } = renderHook(() => useStreamingDuration(true, undefined));
+    expect(result.current).toBe(0);
+    act(() => jest.advanceTimersByTime(3000));
+    expect(result.current).toBe(0);
+  });
+});

--- a/mobile/src/hooks/timeline/__tests__/useTimelineExpansion.test.ts
+++ b/mobile/src/hooks/timeline/__tests__/useTimelineExpansion.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "@jest/globals";
+import { act, renderHook } from "@testing-library/react-native";
+
+import { TurnGroup } from "@/chat/timeline/transformers";
+import { useTimelineExpansion } from "@/hooks/timeline/useTimelineExpansion";
+
+import { makeStep, makeTurn } from "./testHelpers";
+
+// Only handleToggle can expand (and it sets userHasToggled), so auto-collapse (which only sets
+// isExpanded=false) is a no-op from the collapsed default — its observable job is to not fight a
+// user who manually expanded.
+
+const parallelTurn = makeTurn(0, [makeStep(0, 0, []), makeStep(0, 1, [])]);
+const parallelTurnB = makeTurn(1, [makeStep(1, 0, []), makeStep(1, 1, [])]);
+
+describe("useTimelineExpansion", () => {
+  it("starts collapsed and toggles on user action", () => {
+    const { result } = renderHook(() =>
+      useTimelineExpansion(false, undefined, false),
+    );
+    expect(result.current.isExpanded).toBe(false);
+
+    act(() => result.current.handleToggle());
+    expect(result.current.isExpanded).toBe(true);
+
+    act(() => result.current.handleToggle());
+    expect(result.current.isExpanded).toBe(false);
+  });
+
+  it("stays collapsed through stop / display when untouched", () => {
+    const { result, rerender } = renderHook(
+      ({ stop, display }: { stop: boolean; display: boolean }) =>
+        useTimelineExpansion(stop, undefined, display),
+      { initialProps: { stop: false, display: false } },
+    );
+    expect(result.current.isExpanded).toBe(false);
+    rerender({ stop: true, display: false });
+    expect(result.current.isExpanded).toBe(false);
+    rerender({ stop: true, display: true });
+    expect(result.current.isExpanded).toBe(false);
+  });
+
+  it("respects user intent — a manual expand survives the stop packet", () => {
+    const { result, rerender } = renderHook(
+      ({ stop }: { stop: boolean }) =>
+        useTimelineExpansion(stop, undefined, false),
+      { initialProps: { stop: false } },
+    );
+    act(() => result.current.handleToggle());
+    expect(result.current.isExpanded).toBe(true);
+    rerender({ stop: true });
+    expect(result.current.isExpanded).toBe(true);
+  });
+
+  it("respects user intent — a manual expand survives the final message starting", () => {
+    const { result, rerender } = renderHook(
+      ({ display }: { display: boolean }) =>
+        useTimelineExpansion(false, undefined, display),
+      { initialProps: { display: false } },
+    );
+    act(() => result.current.handleToggle());
+    expect(result.current.isExpanded).toBe(true);
+    rerender({ display: true });
+    expect(result.current.isExpanded).toBe(true);
+  });
+
+  it("selects the first tab of a parallel turn group and re-syncs when it changes", () => {
+    const { result, rerender } = renderHook(
+      ({ turn }: { turn: TurnGroup | undefined }) =>
+        useTimelineExpansion(false, turn, false),
+      { initialProps: { turn: undefined as TurnGroup | undefined } },
+    );
+    expect(result.current.parallelActiveTab).toBe("");
+
+    rerender({ turn: parallelTurn });
+    expect(result.current.parallelActiveTab).toBe("0-0");
+
+    rerender({ turn: parallelTurnB });
+    expect(result.current.parallelActiveTab).toBe("1-0");
+  });
+
+  it("leaves a valid selected tab untouched when the same turn re-renders", () => {
+    const { result, rerender } = renderHook(
+      ({ turn }: { turn: TurnGroup | undefined }) =>
+        useTimelineExpansion(false, turn, false),
+      { initialProps: { turn: parallelTurn as TurnGroup | undefined } },
+    );
+    expect(result.current.parallelActiveTab).toBe("0-0");
+    act(() => result.current.setParallelActiveTab("0-1"));
+    expect(result.current.parallelActiveTab).toBe("0-1");
+    rerender({ turn: parallelTurn });
+    expect(result.current.parallelActiveTab).toBe("0-1");
+  });
+});

--- a/mobile/src/hooks/timeline/__tests__/useTimelineHeader.test.ts
+++ b/mobile/src/hooks/timeline/__tests__/useTimelineHeader.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "@jest/globals";
+import { renderHook } from "@testing-library/react-native";
+
+import { PacketType, StopReason } from "@/chat/streamingModels";
+import { TurnGroup } from "@/chat/timeline/transformers";
+import { useTimelineHeader } from "@/hooks/timeline/useTimelineHeader";
+
+import { makePacket, makeStep, makeTurn } from "./testHelpers";
+
+function headerFor(
+  type: PacketType,
+  extra: Record<string, unknown> = {},
+): string {
+  const turn: TurnGroup = makeTurn(0, [
+    makeStep(0, 0, [makePacket(type, { turn_index: 0 }, extra)]),
+  ]);
+  return renderHook(() => useTimelineHeader([turn])).result.current.headerText;
+}
+
+describe("useTimelineHeader — text map", () => {
+  it("shows Thinking... before any packets arrive", () => {
+    const { result } = renderHook(() => useTimelineHeader([]));
+    expect(result.current.headerText).toBe("Thinking...");
+    expect(result.current.hasPackets).toBe(false);
+  });
+
+  it("shows the image header when generating with no tool packets", () => {
+    const { result } = renderHook(() => useTimelineHeader([], undefined, true));
+    expect(result.current.headerText).toBe("Generating image...");
+  });
+
+  it("maps each activity packet type to its label", () => {
+    expect(headerFor(PacketType.REASONING_START)).toBe("Thinking");
+    expect(headerFor(PacketType.FETCH_TOOL_START)).toBe("Reading");
+    expect(headerFor(PacketType.PYTHON_TOOL_START)).toBe("Executing code");
+    expect(headerFor(PacketType.IMAGE_GENERATION_TOOL_START)).toBe(
+      "Generating images",
+    );
+    expect(headerFor(PacketType.FILE_READER_START)).toBe("Reading file");
+    expect(headerFor(PacketType.MEMORY_TOOL_START)).toBe("Updating memory...");
+    expect(headerFor(PacketType.MEMORY_TOOL_NO_ACCESS)).toBe(
+      "Updating memory...",
+    );
+    expect(headerFor(PacketType.DEEP_RESEARCH_PLAN_START)).toBe(
+      "Generating plan",
+    );
+    expect(headerFor(PacketType.RESEARCH_AGENT_START)).toBe("Researching");
+  });
+
+  it("degrades search to a generic label (search sub-labels land with the search phase)", () => {
+    expect(headerFor(PacketType.SEARCH_TOOL_START)).toBe("Searching");
+  });
+
+  it("names the custom tool when provided, else a generic tool label", () => {
+    expect(headerFor(PacketType.CUSTOM_TOOL_START, { tool_name: "Jira" })).toBe(
+      "Executing Jira",
+    );
+    expect(headerFor(PacketType.CUSTOM_TOOL_START)).toBe("Executing tool");
+  });
+
+  it("falls back to Thinking... for an unmapped first packet", () => {
+    expect(headerFor(PacketType.TOP_LEVEL_BRANCHING)).toBe("Thinking...");
+  });
+});
+
+describe("useTimelineHeader — userStopped", () => {
+  it("flags userStopped only on USER_CANCELLED", () => {
+    const turn = makeTurn(0, [
+      makeStep(0, 0, [makePacket(PacketType.REASONING_START)]),
+    ]);
+    expect(
+      renderHook(() => useTimelineHeader([turn], StopReason.USER_CANCELLED))
+        .result.current.userStopped,
+    ).toBe(true);
+    expect(
+      renderHook(() => useTimelineHeader([turn], StopReason.FINISHED)).result
+        .current.userStopped,
+    ).toBe(false);
+    expect(
+      renderHook(() => useTimelineHeader([turn])).result.current.userStopped,
+    ).toBe(false);
+  });
+});

--- a/mobile/src/hooks/timeline/__tests__/useTimelineMetrics.test.ts
+++ b/mobile/src/hooks/timeline/__tests__/useTimelineMetrics.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "@jest/globals";
+import { renderHook } from "@testing-library/react-native";
+
+import { PacketType } from "@/chat/streamingModels";
+import { TurnGroup } from "@/chat/timeline/transformers";
+import { useTimelineMetrics } from "@/hooks/timeline/useTimelineMetrics";
+
+import { makePacket, makeStep, makeTurn } from "./testHelpers";
+
+function run(turnGroups: TurnGroup[], userStopped = false) {
+  return renderHook(() => useTimelineMetrics(turnGroups, userStopped)).result
+    .current;
+}
+
+const reasoning = makeStep(0, 0, [makePacket(PacketType.REASONING_START)]);
+const researchAgent = makeStep(1, 0, [
+  makePacket(PacketType.RESEARCH_AGENT_START, { turn_index: 1 }),
+]);
+const codingAgent = makeStep(1, 0, [
+  makePacket(PacketType.CODING_AGENT_START, { turn_index: 1 }),
+]);
+
+describe("useTimelineMetrics", () => {
+  it("returns zeros for an empty timeline", () => {
+    const m = run([]);
+    expect(m.totalSteps).toBe(0);
+    expect(m.isSingleStep).toBe(false);
+    expect(m.lastTurnGroup).toBeUndefined();
+    expect(m.lastStep).toBeUndefined();
+    expect(m.lastStepIsResearchAgent).toBe(false);
+    expect(m.lastStepIsCodingAgent).toBe(false);
+    expect(m.lastStepSupportsCollapsedStreaming).toBe(false);
+  });
+
+  it("counts a single reasoning step as a single step", () => {
+    const m = run([makeTurn(0, [reasoning])]);
+    expect(m.totalSteps).toBe(1);
+    expect(m.isSingleStep).toBe(true);
+    expect(m.lastStep).toBe(reasoning);
+    expect(m.lastStepSupportsCollapsedStreaming).toBe(true);
+    expect(m.lastStepIsResearchAgent).toBe(false);
+    expect(m.lastStepIsCodingAgent).toBe(false);
+  });
+
+  it("isSingleStep is false when the user stopped", () => {
+    expect(run([makeTurn(0, [reasoning])], true).isSingleStep).toBe(false);
+  });
+
+  it("sums steps across turns and analyzes the last step", () => {
+    const m = run([makeTurn(0, [reasoning]), makeTurn(1, [researchAgent])]);
+    expect(m.totalSteps).toBe(2);
+    expect(m.isSingleStep).toBe(false);
+    expect(m.lastTurnGroup?.turnIndex).toBe(1);
+    expect(m.lastStep).toBe(researchAgent);
+    expect(m.lastStepIsResearchAgent).toBe(true);
+    expect(m.lastStepIsCodingAgent).toBe(false);
+  });
+
+  it("flags a coding-agent last step", () => {
+    const m = run([makeTurn(0, [reasoning]), makeTurn(1, [codingAgent])]);
+    expect(m.lastStepIsCodingAgent).toBe(true);
+    expect(m.lastStepIsResearchAgent).toBe(false);
+  });
+
+  it("counts every step of a parallel turn", () => {
+    const parallel = makeTurn(0, [
+      makeStep(0, 0, [makePacket(PacketType.SEARCH_TOOL_START)]),
+      makeStep(0, 1, [makePacket(PacketType.PYTHON_TOOL_START)]),
+    ]);
+    expect(run([parallel]).totalSteps).toBe(2);
+  });
+});

--- a/mobile/src/hooks/timeline/__tests__/useTimelineStepState.test.ts
+++ b/mobile/src/hooks/timeline/__tests__/useTimelineStepState.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "@jest/globals";
+import { renderHook } from "@testing-library/react-native";
+
+import { PacketType } from "@/chat/streamingModels";
+import { TurnGroup } from "@/chat/timeline/transformers";
+import { useTimelineStepState } from "@/hooks/timeline/useTimelineStepState";
+
+import { makePacket, makeStep, makeTurn } from "./testHelpers";
+
+function run(turnGroups: TurnGroup[]) {
+  return renderHook(() => useTimelineStepState(turnGroups)).result.current;
+}
+
+const memoryStep = makeStep(0, 0, [makePacket(PacketType.MEMORY_TOOL_START)]);
+const reasoningStep = makeStep(0, 0, [makePacket(PacketType.REASONING_START)]);
+
+describe("useTimelineStepState (dormant in 9b)", () => {
+  it("leaves memory content null until the memory renderer phase", () => {
+    const s = run([makeTurn(0, [memoryStep])]);
+    expect(s.memoryText).toBeNull();
+    expect(s.memoryOperation).toBeNull();
+    expect(s.memoryId).toBeNull();
+    expect(s.memoryIndex).toBeNull();
+  });
+
+  it("isMemoryOnly true when every step is a memory step", () => {
+    expect(run([makeTurn(0, [memoryStep])]).isMemoryOnly).toBe(true);
+    expect(
+      run([
+        makeTurn(0, [memoryStep]),
+        makeTurn(1, [
+          makeStep(1, 0, [
+            makePacket(PacketType.MEMORY_TOOL_NO_ACCESS, { turn_index: 1 }),
+          ]),
+        ]),
+      ]).isMemoryOnly,
+    ).toBe(true);
+  });
+
+  it("isMemoryOnly false when any step is non-memory", () => {
+    expect(
+      run([makeTurn(0, [memoryStep]), makeTurn(1, [reasoningStep])])
+        .isMemoryOnly,
+    ).toBe(false);
+  });
+
+  it("isMemoryOnly false for an empty timeline", () => {
+    expect(run([]).isMemoryOnly).toBe(false);
+  });
+});

--- a/mobile/src/hooks/timeline/__tests__/useTimelineUIState.test.ts
+++ b/mobile/src/hooks/timeline/__tests__/useTimelineUIState.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "@jest/globals";
+import { renderHook } from "@testing-library/react-native";
+
+import { PacketType } from "@/chat/streamingModels";
+import {
+  TimelineUIState,
+  TimelineUIStateInput,
+  useTimelineUIState,
+} from "@/hooks/timeline/useTimelineUIState";
+
+import { makePacket, makeStep, makeTurn } from "./testHelpers";
+
+const sequentialTurn = makeTurn(0, [
+  makeStep(0, 0, [makePacket(PacketType.REASONING_START)]),
+]);
+const parallelTurn = makeTurn(0, [
+  makeStep(0, 0, [makePacket(PacketType.SEARCH_TOOL_START)]),
+  makeStep(0, 1, [makePacket(PacketType.PYTHON_TOOL_START)]),
+]);
+
+function baseInput(
+  overrides: Partial<TimelineUIStateInput> = {},
+): TimelineUIStateInput {
+  return {
+    stopPacketSeen: false,
+    hasPackets: false,
+    hasDisplayContent: false,
+    userStopped: false,
+    isExpanded: false,
+    lastTurnGroup: undefined,
+    lastStep: undefined,
+    lastStepSupportsCollapsedStreaming: false,
+    lastStepHasCollapsedContent: false,
+    lastStepIsResearchAgent: false,
+    parallelActiveStepSupportsCollapsedStreaming: false,
+    parallelActiveStepHasCollapsedContent: false,
+    isGeneratingImage: false,
+    finalAnswerComing: false,
+    ...overrides,
+  };
+}
+
+function run(overrides: Partial<TimelineUIStateInput> = {}) {
+  return renderHook(() => useTimelineUIState(baseInput(overrides))).result
+    .current;
+}
+
+describe("useTimelineUIState — the 7 states", () => {
+  it("EMPTY when nothing has arrived", () => {
+    expect(run().uiState).toBe(TimelineUIState.EMPTY);
+  });
+
+  it("DISPLAY_CONTENT_ONLY when only the final message streamed (no tools)", () => {
+    expect(run({ hasDisplayContent: true }).uiState).toBe(
+      TimelineUIState.DISPLAY_CONTENT_ONLY,
+    );
+  });
+
+  it("STREAMING_SEQUENTIAL for an active single-step turn", () => {
+    expect(
+      run({ hasPackets: true, lastTurnGroup: sequentialTurn }).uiState,
+    ).toBe(TimelineUIState.STREAMING_SEQUENTIAL);
+  });
+
+  it("STREAMING_PARALLEL for an active parallel turn", () => {
+    expect(run({ hasPackets: true, lastTurnGroup: parallelTurn }).uiState).toBe(
+      TimelineUIState.STREAMING_PARALLEL,
+    );
+  });
+
+  it("STOPPED when the user cancelled without display content", () => {
+    expect(
+      run({ stopPacketSeen: true, hasPackets: true, userStopped: true })
+        .uiState,
+    ).toBe(TimelineUIState.STOPPED);
+  });
+
+  it("COMPLETED_EXPANDED when done and expanded", () => {
+    expect(
+      run({ stopPacketSeen: true, hasPackets: true, isExpanded: true }).uiState,
+    ).toBe(TimelineUIState.COMPLETED_EXPANDED);
+  });
+
+  it("COMPLETED_COLLAPSED when done and collapsed", () => {
+    expect(run({ stopPacketSeen: true, hasPackets: true }).uiState).toBe(
+      TimelineUIState.COMPLETED_COLLAPSED,
+    );
+  });
+
+  it("stays streaming while generating an image even with display content", () => {
+    // isGeneratingImage keeps it in the streaming branch instead of DISPLAY_CONTENT_ONLY.
+    expect(
+      run({
+        hasPackets: true,
+        hasDisplayContent: true,
+        isGeneratingImage: true,
+        lastTurnGroup: sequentialTurn,
+      }).uiState,
+    ).toBe(TimelineUIState.STREAMING_SEQUENTIAL);
+  });
+});
+
+describe("useTimelineUIState — convenience booleans", () => {
+  it("isStreaming true only for streaming states", () => {
+    expect(
+      run({ hasPackets: true, lastTurnGroup: sequentialTurn }).isStreaming,
+    ).toBe(true);
+    expect(run({ stopPacketSeen: true, hasPackets: true }).isStreaming).toBe(
+      false,
+    );
+  });
+
+  it("isCompleted true for both completed states and stopped", () => {
+    expect(run({ stopPacketSeen: true, hasPackets: true }).isCompleted).toBe(
+      true,
+    );
+    expect(
+      run({ stopPacketSeen: true, hasPackets: true, isExpanded: true })
+        .isCompleted,
+    ).toBe(true);
+    expect(
+      run({ stopPacketSeen: true, hasPackets: true, userStopped: true })
+        .isCompleted,
+    ).toBe(true);
+    expect(run().isCompleted).toBe(false);
+  });
+
+  it("isActivelyExecuting tracks tool execution", () => {
+    expect(
+      run({ hasPackets: true, lastTurnGroup: sequentialTurn })
+        .isActivelyExecuting,
+    ).toBe(true);
+    expect(
+      run({ stopPacketSeen: true, hasPackets: true }).isActivelyExecuting,
+    ).toBe(false);
+  });
+});
+
+describe("useTimelineUIState — display + styling flags", () => {
+  it("showParallelTabs only while collapsed-streaming a parallel turn", () => {
+    expect(
+      run({ hasPackets: true, lastTurnGroup: parallelTurn }).showParallelTabs,
+    ).toBe(true);
+    expect(
+      run({ hasPackets: true, lastTurnGroup: parallelTurn, isExpanded: true })
+        .showParallelTabs,
+    ).toBe(false);
+    expect(
+      run({ hasPackets: true, lastTurnGroup: sequentialTurn }).showParallelTabs,
+    ).toBe(false);
+  });
+
+  it("showCollapsedCompact requires a supporting last step with content", () => {
+    const on = run({
+      hasPackets: true,
+      lastTurnGroup: sequentialTurn,
+      lastStep: sequentialTurn.steps[0],
+      lastStepSupportsCollapsedStreaming: true,
+      lastStepHasCollapsedContent: true,
+    });
+    expect(on.showCollapsedCompact).toBe(true);
+    const off = run({
+      hasPackets: true,
+      lastTurnGroup: sequentialTurn,
+      lastStep: sequentialTurn.steps[0],
+      lastStepSupportsCollapsedStreaming: true,
+      lastStepHasCollapsedContent: false,
+    });
+    expect(off.showCollapsedCompact).toBe(false);
+  });
+
+  it("showCollapsedParallel requires parallel tabs + active parallel content", () => {
+    expect(
+      run({
+        hasPackets: true,
+        lastTurnGroup: parallelTurn,
+        parallelActiveStepSupportsCollapsedStreaming: true,
+        parallelActiveStepHasCollapsedContent: true,
+      }).showCollapsedParallel,
+    ).toBe(true);
+  });
+
+  it("showDoneStep on final-answer-coming while expanded", () => {
+    expect(
+      run({ finalAnswerComing: true, hasPackets: true, isExpanded: true })
+        .showDoneStep,
+    ).toBe(true);
+    // Collapsed → no done step even when finalAnswerComing.
+    expect(
+      run({ finalAnswerComing: true, hasPackets: true }).showDoneStep,
+    ).toBe(false);
+  });
+
+  it("showStoppedStep only when user-stopped, expanded, no display content", () => {
+    expect(
+      run({
+        stopPacketSeen: true,
+        hasPackets: true,
+        userStopped: true,
+        isExpanded: true,
+      }).showStoppedStep,
+    ).toBe(true);
+    expect(
+      run({
+        stopPacketSeen: true,
+        hasPackets: true,
+        userStopped: true,
+        isExpanded: true,
+        hasDisplayContent: true,
+      }).showStoppedStep,
+    ).toBe(false);
+  });
+
+  it("hasDoneIndicator excludes research-agent last steps", () => {
+    expect(
+      run({ stopPacketSeen: true, hasPackets: true, isExpanded: true })
+        .hasDoneIndicator,
+    ).toBe(true);
+    expect(
+      run({
+        stopPacketSeen: true,
+        hasPackets: true,
+        isExpanded: true,
+        lastStepIsResearchAgent: true,
+      }).hasDoneIndicator,
+    ).toBe(false);
+  });
+
+  it("showTintedBackground while executing or expanded; showRoundedBottom otherwise", () => {
+    const streaming = run({ hasPackets: true, lastTurnGroup: sequentialTurn });
+    expect(streaming.showTintedBackground).toBe(true);
+    expect(streaming.showRoundedBottom).toBe(true);
+
+    const collapsedCompact = run({
+      hasPackets: true,
+      lastTurnGroup: sequentialTurn,
+      lastStep: sequentialTurn.steps[0],
+      lastStepSupportsCollapsedStreaming: true,
+      lastStepHasCollapsedContent: true,
+    });
+    expect(collapsedCompact.showRoundedBottom).toBe(false);
+
+    const completedCollapsed = run({ stopPacketSeen: true, hasPackets: true });
+    expect(completedCollapsed.showTintedBackground).toBe(false);
+    expect(completedCollapsed.showRoundedBottom).toBe(true);
+  });
+});

--- a/mobile/src/hooks/timeline/useStreamingDuration.ts
+++ b/mobile/src/hooks/timeline/useStreamingDuration.ts
@@ -13,9 +13,17 @@ export function useStreamingDuration(
   backendDuration?: number,
 ): number {
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [trackedStart, setTrackedStart] = useState(startTime);
 
   // A backend duration freezes the timer, so don't run it once one is present.
   const shouldRunTimer = isStreaming && backendDuration === undefined;
+
+  // A new startTime is a new stream: reset now (adjust-state-during-render) so we never carry the
+  // previous stream's elapsed — including when the timer isn't running and the effect won't reconcile.
+  if (startTime !== trackedStart) {
+    setTrackedStart(startTime);
+    setElapsedSeconds(0);
+  }
 
   useEffect(() => {
     if (!shouldRunTimer || !startTime) {
@@ -35,8 +43,7 @@ export function useStreamingDuration(
   if (backendDuration !== undefined) {
     return backendDuration;
   }
-  // No start time resets to 0; a paused timer (startTime still set) keeps its last value. Derived
-  // here rather than reset in the effect (react-hooks/set-state-in-effect).
+  // No start time → 0; a paused timer (startTime unchanged) keeps its last value.
   if (!startTime) {
     return 0;
   }

--- a/mobile/src/hooks/timeline/useStreamingDuration.ts
+++ b/mobile/src/hooks/timeline/useStreamingDuration.ts
@@ -1,0 +1,44 @@
+// Live elapsed-seconds timer for the streaming header. Port of web's useStreamingDuration, with the
+// RAF loop swapped for a setInterval poll — deterministic under jest fake timers, and RN gains
+// nothing from RAF here.
+
+import { useEffect, useState } from "react";
+
+// Poll faster than 1s so the whole-second boundary stays crisp (web's RAF was ~16ms).
+const DURATION_TICK_MS = 250;
+
+export function useStreamingDuration(
+  isStreaming: boolean,
+  startTime: number | undefined,
+  backendDuration?: number,
+): number {
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+
+  // A backend duration freezes the timer, so don't run it once one is present.
+  const shouldRunTimer = isStreaming && backendDuration === undefined;
+
+  useEffect(() => {
+    if (!shouldRunTimer || !startTime) {
+      return;
+    }
+
+    const updateElapsed = () => {
+      const elapsed = Math.floor((Date.now() - startTime) / 1000);
+      setElapsedSeconds((prev) => (prev === elapsed ? prev : elapsed));
+    };
+
+    updateElapsed();
+    const intervalId = setInterval(updateElapsed, DURATION_TICK_MS);
+    return () => clearInterval(intervalId);
+  }, [shouldRunTimer, startTime]);
+
+  if (backendDuration !== undefined) {
+    return backendDuration;
+  }
+  // No start time resets to 0; a paused timer (startTime still set) keeps its last value. Derived
+  // here rather than reset in the effect (react-hooks/set-state-in-effect).
+  if (!startTime) {
+    return 0;
+  }
+  return elapsedSeconds;
+}

--- a/mobile/src/hooks/timeline/useTimelineExpansion.ts
+++ b/mobile/src/hooks/timeline/useTimelineExpansion.ts
@@ -1,0 +1,61 @@
+// Timeline expansion state (collapse + auto-collapse + parallel-tab sync). Port of web's
+// useTimelineExpansion. userHasToggled is written/read only in callbacks/effects, never during
+// render, to satisfy react-hooks/refs.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { TurnGroup } from "@/chat/timeline/transformers";
+
+export interface TimelineExpansionState {
+  isExpanded: boolean;
+  handleToggle: () => void;
+  parallelActiveTab: string;
+  setParallelActiveTab: (tab: string) => void;
+}
+
+export function useTimelineExpansion(
+  stopPacketSeen: boolean,
+  lastTurnGroup: TurnGroup | undefined,
+  hasDisplayContent: boolean = false,
+): TimelineExpansionState {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [parallelActiveTab, setParallelActiveTab] = useState<string>("");
+  const userHasToggled = useRef(false);
+
+  const handleToggle = useCallback(() => {
+    userHasToggled.current = true;
+    setIsExpanded((prev) => !prev);
+  }, []);
+
+  // Auto-collapse on completion or when the answer starts, unless the user manually toggled.
+  useEffect(() => {
+    if ((stopPacketSeen || hasDisplayContent) && !userHasToggled.current) {
+      setIsExpanded(false);
+    }
+  }, [stopPacketSeen, hasDisplayContent]);
+
+  // Keep the active parallel tab valid. Adjusting state during render (not an effect) avoids
+  // react-hooks/set-state-in-effect and converges in one pass. Dormant in 9b (parallel turns are
+  // linearized); kept for the parallel-tab phase.
+  const validTabKeys = useMemo(
+    () =>
+      lastTurnGroup?.isParallel && lastTurnGroup.steps.length > 0
+        ? lastTurnGroup.steps.map((s) => s.key)
+        : null,
+    [lastTurnGroup],
+  );
+  if (
+    validTabKeys &&
+    validTabKeys[0] &&
+    !validTabKeys.includes(parallelActiveTab)
+  ) {
+    setParallelActiveTab(validTabKeys[0]);
+  }
+
+  return {
+    isExpanded,
+    handleToggle,
+    parallelActiveTab,
+    setParallelActiveTab,
+  };
+}

--- a/mobile/src/hooks/timeline/useTimelineHeader.ts
+++ b/mobile/src/hooks/timeline/useTimelineHeader.ts
@@ -1,0 +1,105 @@
+// Timeline header text derivation (packet-type → activity label). Port of web's useTimelineHeader.
+// Search degrades to a generic "Searching" until the search phase ports constructCurrentSearchState
+// (web's "Reading"/"Searching the web" sub-labels need it); every other branch is 1:1.
+
+import { useMemo } from "react";
+
+import {
+  CustomToolStart,
+  PacketType,
+  StopReason,
+} from "@/chat/streamingModels";
+import { TurnGroup } from "@/chat/timeline/transformers";
+
+export interface TimelineHeaderResult {
+  headerText: string;
+  hasPackets: boolean;
+  userStopped: boolean;
+}
+
+export function useTimelineHeader(
+  turnGroups: TurnGroup[],
+  stopReason?: StopReason,
+  isGeneratingImage?: boolean,
+): TimelineHeaderResult {
+  return useMemo(() => {
+    const hasPackets = turnGroups.length > 0;
+    const userStopped = stopReason === StopReason.USER_CANCELLED;
+
+    if (isGeneratingImage && !hasPackets) {
+      return { headerText: "Generating image...", hasPackets, userStopped };
+    }
+
+    if (!hasPackets) {
+      return { headerText: "Thinking...", hasPackets, userStopped };
+    }
+
+    const currentTurn = turnGroups[turnGroups.length - 1];
+    if (!currentTurn) {
+      return { headerText: "Thinking...", hasPackets, userStopped };
+    }
+
+    const currentStep = currentTurn.steps[0];
+    if (!currentStep?.packets?.length) {
+      return { headerText: "Thinking...", hasPackets, userStopped };
+    }
+
+    const firstPacket = currentStep.packets[0];
+    if (!firstPacket) {
+      return { headerText: "Thinking...", hasPackets, userStopped };
+    }
+
+    const packetType = firstPacket.obj.type;
+
+    if (packetType === PacketType.SEARCH_TOOL_START) {
+      // generic until the search phase (see file header)
+      return { headerText: "Searching", hasPackets, userStopped };
+    }
+
+    if (packetType === PacketType.FETCH_TOOL_START) {
+      return { headerText: "Reading", hasPackets, userStopped };
+    }
+
+    if (packetType === PacketType.PYTHON_TOOL_START) {
+      return { headerText: "Executing code", hasPackets, userStopped };
+    }
+
+    if (packetType === PacketType.IMAGE_GENERATION_TOOL_START) {
+      return { headerText: "Generating images", hasPackets, userStopped };
+    }
+
+    if (packetType === PacketType.FILE_READER_START) {
+      return { headerText: "Reading file", hasPackets, userStopped };
+    }
+
+    if (packetType === PacketType.CUSTOM_TOOL_START) {
+      const toolName = (firstPacket.obj as CustomToolStart).tool_name;
+      return {
+        headerText: toolName ? `Executing ${toolName}` : "Executing tool",
+        hasPackets,
+        userStopped,
+      };
+    }
+
+    if (
+      packetType === PacketType.MEMORY_TOOL_START ||
+      packetType === PacketType.MEMORY_TOOL_NO_ACCESS
+    ) {
+      return { headerText: "Updating memory...", hasPackets, userStopped };
+    }
+
+    if (packetType === PacketType.REASONING_START) {
+      return { headerText: "Thinking", hasPackets, userStopped };
+    }
+
+    if (packetType === PacketType.DEEP_RESEARCH_PLAN_START) {
+      return { headerText: "Generating plan", hasPackets, userStopped };
+    }
+
+    if (packetType === PacketType.RESEARCH_AGENT_START) {
+      return { headerText: "Researching", hasPackets, userStopped };
+    }
+
+    return { headerText: "Thinking...", hasPackets, userStopped };
+  }, [turnGroups, stopReason, isGeneratingImage]);
+}

--- a/mobile/src/hooks/timeline/useTimelineMetrics.ts
+++ b/mobile/src/hooks/timeline/useTimelineMetrics.ts
@@ -1,0 +1,55 @@
+// Derived timeline metrics (step count + last-step flags). Pure port of web's useTimelineMetrics.
+
+import { useMemo } from "react";
+
+import {
+  isCodingAgentPackets,
+  isResearchAgentPackets,
+  stepSupportsCollapsedStreaming,
+} from "@/chat/timeline/packetHelpers";
+import { TransformedStep, TurnGroup } from "@/chat/timeline/transformers";
+
+export interface TimelineMetrics {
+  totalSteps: number;
+  isSingleStep: boolean;
+  lastTurnGroup: TurnGroup | undefined;
+  lastStep: TransformedStep | undefined;
+  lastStepIsResearchAgent: boolean;
+  lastStepIsCodingAgent: boolean;
+  lastStepSupportsCollapsedStreaming: boolean;
+}
+
+export function useTimelineMetrics(
+  turnGroups: TurnGroup[],
+  userStopped: boolean,
+): TimelineMetrics {
+  return useMemo(() => {
+    let totalSteps = 0;
+    for (const tg of turnGroups) {
+      totalSteps += tg.steps.length;
+    }
+
+    const lastTurnGroup = turnGroups[turnGroups.length - 1];
+    const lastStep = lastTurnGroup?.steps[lastTurnGroup.steps.length - 1];
+
+    const lastStepIsResearchAgent = lastStep
+      ? isResearchAgentPackets(lastStep.packets)
+      : false;
+    const lastStepIsCodingAgent = lastStep
+      ? isCodingAgentPackets(lastStep.packets)
+      : false;
+    const lastStepSupportsCollapsedStreaming = lastStep
+      ? stepSupportsCollapsedStreaming(lastStep.packets)
+      : false;
+
+    return {
+      totalSteps,
+      isSingleStep: totalSteps === 1 && !userStopped,
+      lastTurnGroup,
+      lastStep,
+      lastStepIsResearchAgent,
+      lastStepIsCodingAgent,
+      lastStepSupportsCollapsedStreaming,
+    };
+  }, [turnGroups, userStopped]);
+}

--- a/mobile/src/hooks/timeline/useTimelineStepState.ts
+++ b/mobile/src/hooks/timeline/useTimelineStepState.ts
@@ -1,0 +1,40 @@
+// Memory-only extraction for the timeline. Port of web's useTimelineStepState, DORMANT in 9b: only
+// isMemoryOnly is derived (the shell uses it for collapse gating); the memory text/operation/id/index
+// stay null until the memory renderer phase wires constructCurrentMemoryState (03 §8(g)).
+
+import { useMemo } from "react";
+
+import { isMemoryToolPackets } from "@/chat/timeline/packetHelpers";
+import { TurnGroup } from "@/chat/timeline/transformers";
+
+export interface MemoryStepState {
+  memoryText: string | null;
+  memoryOperation: "add" | "update" | null;
+  memoryId: number | null;
+  memoryIndex: number | null;
+  isMemoryOnly: boolean;
+}
+
+export function useTimelineStepState(turnGroups: TurnGroup[]): MemoryStepState {
+  return useMemo(() => {
+    let totalSteps = 0;
+    let allMemory = true;
+
+    for (const tg of turnGroups) {
+      for (const step of tg.steps) {
+        totalSteps++;
+        if (!isMemoryToolPackets(step.packets)) {
+          allMemory = false;
+        }
+      }
+    }
+
+    return {
+      memoryText: null,
+      memoryOperation: null,
+      memoryId: null,
+      memoryIndex: null,
+      isMemoryOnly: totalSteps > 0 && allMemory,
+    };
+  }, [turnGroups]);
+}

--- a/mobile/src/hooks/timeline/useTimelineUIState.ts
+++ b/mobile/src/hooks/timeline/useTimelineUIState.ts
@@ -1,0 +1,150 @@
+// Timeline UI state machine + derived show/style booleans. Pure port of web's useTimelineUIState.
+
+import { useMemo } from "react";
+
+import { TransformedStep, TurnGroup } from "@/chat/timeline/transformers";
+
+export enum TimelineUIState {
+  EMPTY = "EMPTY",
+  DISPLAY_CONTENT_ONLY = "DISPLAY_CONTENT_ONLY",
+  STREAMING_SEQUENTIAL = "STREAMING_SEQUENTIAL",
+  STREAMING_PARALLEL = "STREAMING_PARALLEL",
+  STOPPED = "STOPPED",
+  COMPLETED_COLLAPSED = "COMPLETED_COLLAPSED",
+  COMPLETED_EXPANDED = "COMPLETED_EXPANDED",
+}
+
+export interface TimelineUIStateInput {
+  stopPacketSeen: boolean;
+  hasPackets: boolean;
+  hasDisplayContent: boolean;
+  userStopped: boolean;
+  isExpanded: boolean;
+  lastTurnGroup: TurnGroup | undefined;
+  lastStep: TransformedStep | undefined;
+  lastStepSupportsCollapsedStreaming: boolean;
+  lastStepHasCollapsedContent: boolean;
+  lastStepIsResearchAgent: boolean;
+  parallelActiveStepSupportsCollapsedStreaming: boolean;
+  parallelActiveStepHasCollapsedContent: boolean;
+  isGeneratingImage: boolean;
+  finalAnswerComing: boolean;
+}
+
+export interface TimelineUIStateResult {
+  uiState: TimelineUIState;
+  isStreaming: boolean;
+  isCompleted: boolean;
+  isActivelyExecuting: boolean;
+  showCollapsedCompact: boolean;
+  showCollapsedParallel: boolean;
+  showParallelTabs: boolean;
+  showDoneStep: boolean;
+  showStoppedStep: boolean;
+  hasDoneIndicator: boolean;
+  showTintedBackground: boolean;
+  showRoundedBottom: boolean;
+}
+
+export function useTimelineUIState(
+  input: TimelineUIStateInput,
+): TimelineUIStateResult {
+  return useMemo(() => {
+    const {
+      stopPacketSeen,
+      hasPackets,
+      hasDisplayContent,
+      userStopped,
+      isExpanded,
+      lastTurnGroup,
+      lastStep,
+      lastStepSupportsCollapsedStreaming,
+      lastStepHasCollapsedContent,
+      lastStepIsResearchAgent,
+      parallelActiveStepSupportsCollapsedStreaming,
+      parallelActiveStepHasCollapsedContent,
+      isGeneratingImage,
+      finalAnswerComing,
+    } = input;
+
+    let uiState: TimelineUIState;
+    if (!hasPackets && !hasDisplayContent && !stopPacketSeen) {
+      uiState = TimelineUIState.EMPTY;
+    } else if (hasDisplayContent && !hasPackets && !isGeneratingImage) {
+      uiState = TimelineUIState.DISPLAY_CONTENT_ONLY;
+    } else if (!stopPacketSeen && (!hasDisplayContent || isGeneratingImage)) {
+      uiState = lastTurnGroup?.isParallel
+        ? TimelineUIState.STREAMING_PARALLEL
+        : TimelineUIState.STREAMING_SEQUENTIAL;
+    } else if (userStopped) {
+      uiState = TimelineUIState.STOPPED;
+    } else if (isExpanded) {
+      uiState = TimelineUIState.COMPLETED_EXPANDED;
+    } else {
+      uiState = TimelineUIState.COMPLETED_COLLAPSED;
+    }
+
+    const isStreaming =
+      uiState === TimelineUIState.STREAMING_SEQUENTIAL ||
+      uiState === TimelineUIState.STREAMING_PARALLEL;
+    const isCompleted =
+      uiState === TimelineUIState.COMPLETED_COLLAPSED ||
+      uiState === TimelineUIState.COMPLETED_EXPANDED ||
+      uiState === TimelineUIState.STOPPED;
+    const isActivelyExecuting =
+      !stopPacketSeen && (!hasDisplayContent || isGeneratingImage);
+
+    const showParallelTabs =
+      uiState === TimelineUIState.STREAMING_PARALLEL &&
+      !isExpanded &&
+      !!lastTurnGroup?.isParallel &&
+      (lastTurnGroup?.steps.length ?? 0) > 0;
+
+    const showCollapsedCompact =
+      uiState === TimelineUIState.STREAMING_SEQUENTIAL &&
+      !isExpanded &&
+      !!lastStep &&
+      !lastTurnGroup?.isParallel &&
+      lastStepSupportsCollapsedStreaming &&
+      lastStepHasCollapsedContent;
+
+    const showCollapsedParallel =
+      showParallelTabs &&
+      !isExpanded &&
+      parallelActiveStepSupportsCollapsedStreaming &&
+      parallelActiveStepHasCollapsedContent;
+
+    const showDoneStep =
+      (stopPacketSeen || finalAnswerComing) &&
+      isExpanded &&
+      (!userStopped || hasDisplayContent);
+
+    const showStoppedStep =
+      stopPacketSeen && isExpanded && userStopped && !hasDisplayContent;
+
+    const hasDoneIndicator =
+      (stopPacketSeen || finalAnswerComing) &&
+      isExpanded &&
+      !userStopped &&
+      !lastStepIsResearchAgent;
+
+    const showTintedBackground = isActivelyExecuting || isExpanded;
+    const showRoundedBottom =
+      !isExpanded && !showCollapsedCompact && !showCollapsedParallel;
+
+    return {
+      uiState,
+      isStreaming,
+      isCompleted,
+      isActivelyExecuting,
+      showCollapsedCompact,
+      showCollapsedParallel,
+      showParallelTabs,
+      showDoneStep,
+      showStoppedStep,
+      hasDoneIndicator,
+      showTintedBackground,
+      showRoundedBottom,
+    };
+  }, [input]);
+}


### PR DESCRIPTION
## Description

- Adds the six timeline UI-state hooks (7-state machine, expansion/auto-collapse, header labels, live duration timer, metrics, dormant memory) under `mobile/src/hooks/timeline/`, ported 1:1 from web — PR 9b.3 of the mobile-chat agent-timeline roadmap.
- Lands "dark": unit-tested but not yet mounted; the composition PR (9b.7) turns the timeline on.
- Behavior-preserving divergences from web: generic search header until the search phase, a `setInterval` timer instead of RAF, dormant memory extraction, and two `react-hooks` lint restructures (refs / set-state-in-effect).

## How Has This Been Tested?

- 46 Jest unit tests across the six hooks (all 7 UI states + derived booleans, auto-collapse, header map, duration tick/freeze, metrics, memory-only); `bun run typecheck` and `bun run lint` clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
