### PR TITLE
feat(mobile): timeline processor + pacing hooks

### DIFF
--- a/mobile/src/hooks/timeline/__tests__/usePacedTurnGroups.test.ts
+++ b/mobile/src/hooks/timeline/__tests__/usePacedTurnGroups.test.ts
@@ -376,6 +376,28 @@ describe("usePacedTurnGroups", () => {
       rerender({ nodeId: 2 });
       expect(result.current.pacedTurnGroups.length).toBe(1);
     });
+
+    it("does not carry a prior node's revealed steps into a new node", () => {
+      const { result, rerender } = renderHook(
+        ({ turnGroups, nodeId }: { turnGroups: TurnGroup[]; nodeId: number }) =>
+          usePacedTurnGroups(turnGroups, [], false, nodeId, false),
+        {
+          initialProps: {
+            turnGroups: [createTurnGroup([createStep(0, 0)])],
+            nodeId: 1,
+          },
+        },
+      );
+      expect(result.current.pacedTurnGroups[0]?.steps[0]?.key).toBe("0-0");
+
+      // New node whose only step has a different key — the prior "0-0" must not leak through.
+      rerender({
+        turnGroups: [createTurnGroup([createStep(5, 0)])],
+        nodeId: 2,
+      });
+      expect(result.current.pacedTurnGroups.length).toBe(1);
+      expect(result.current.pacedTurnGroups[0]?.steps[0]?.key).toBe("5-0");
+    });
   });
 
   describe("timer cleanup", () => {

--- a/mobile/src/hooks/timeline/__tests__/usePacedTurnGroups.test.ts
+++ b/mobile/src/hooks/timeline/__tests__/usePacedTurnGroups.test.ts
@@ -1,0 +1,428 @@
+import { act, renderHook } from "@testing-library/react-native";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+import { GroupedPacket } from "@/chat/messageProcessor";
+import { PacketType, type Packet } from "@/chat/streamingModels";
+import { TransformedStep, TurnGroup } from "@/chat/timeline/transformers";
+import { usePacedTurnGroups } from "@/hooks/timeline/usePacedTurnGroups";
+
+function createStep(
+  turnIndex: number,
+  tabIndex: number,
+  type: PacketType = PacketType.SEARCH_TOOL_START,
+): TransformedStep {
+  return {
+    key: `${turnIndex}-${tabIndex}`,
+    turnIndex,
+    tabIndex,
+    packets: [
+      {
+        placement: { turn_index: turnIndex, tab_index: tabIndex },
+        obj: { type },
+      } as Packet,
+    ],
+  };
+}
+
+function createTurnGroup(steps: TransformedStep[]): TurnGroup {
+  return {
+    turnIndex: steps[0]!.turnIndex,
+    steps,
+    isParallel: steps.length > 1,
+  };
+}
+
+function createDisplayGroup(turnIndex: number): GroupedPacket {
+  return {
+    turn_index: turnIndex,
+    tab_index: 0,
+    packets: [
+      {
+        placement: { turn_index: turnIndex, tab_index: 0 },
+        obj: {
+          type: PacketType.MESSAGE_START,
+          id: "m",
+          content: "",
+          final_documents: null,
+        },
+      } as Packet,
+    ],
+  };
+}
+
+describe("usePacedTurnGroups", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("initial state", () => {
+    it("returns empty arrays with no turn groups", () => {
+      const { result } = renderHook(() =>
+        usePacedTurnGroups([], [], false, 1, false),
+      );
+      expect(result.current.pacedTurnGroups).toEqual([]);
+      expect(result.current.pacedDisplayGroups).toEqual([]);
+      expect(result.current.pacedFinalAnswerComing).toBe(false);
+    });
+  });
+
+  describe("history bypass", () => {
+    it("reveals everything immediately when stop is seen on first render", () => {
+      const turnGroups = [
+        createTurnGroup([createStep(0, 0)]),
+        createTurnGroup([createStep(1, 0)]),
+      ];
+      const displayGroups = [createDisplayGroup(2)];
+
+      const { result } = renderHook(() =>
+        usePacedTurnGroups(turnGroups, displayGroups, true, 1, true),
+      );
+
+      expect(result.current.pacedTurnGroups.length).toBe(2);
+      expect(result.current.pacedDisplayGroups.length).toBe(1);
+      expect(result.current.pacedFinalAnswerComing).toBe(true);
+    });
+  });
+
+  describe("step pacing", () => {
+    it("reveals the first step immediately", () => {
+      const { result } = renderHook(() =>
+        usePacedTurnGroups(
+          [createTurnGroup([createStep(0, 0)])],
+          [],
+          false,
+          1,
+          false,
+        ),
+      );
+      expect(result.current.pacedTurnGroups.length).toBe(1);
+      expect(result.current.pacedTurnGroups[0]?.steps[0]?.key).toBe("0-0");
+    });
+
+    it("reveals subsequent steps 200ms apart", () => {
+      const { result, rerender } = renderHook(
+        ({ turnGroups }: { turnGroups: TurnGroup[] }) =>
+          usePacedTurnGroups(turnGroups, [], false, 1, false),
+        { initialProps: { turnGroups: [createTurnGroup([createStep(0, 0)])] } },
+      );
+      expect(result.current.pacedTurnGroups.length).toBe(1);
+
+      rerender({
+        turnGroups: [
+          createTurnGroup([createStep(0, 0)]),
+          createTurnGroup([createStep(1, 0)]),
+          createTurnGroup([createStep(2, 0)]),
+        ],
+      });
+      // Second and third steps queued, not yet revealed.
+      expect(result.current.pacedTurnGroups.length).toBe(1);
+
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+      expect(result.current.pacedTurnGroups.length).toBe(2);
+
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+      expect(result.current.pacedTurnGroups.length).toBe(3);
+    });
+
+    it("paces same-type steps with a delay (does not batch)", () => {
+      const { result, rerender } = renderHook(
+        ({ turnGroups }: { turnGroups: TurnGroup[] }) =>
+          usePacedTurnGroups(turnGroups, [], false, 1, false),
+        {
+          initialProps: {
+            turnGroups: [
+              createTurnGroup([createStep(0, 0, PacketType.SEARCH_TOOL_START)]),
+            ],
+          },
+        },
+      );
+      rerender({
+        turnGroups: [
+          createTurnGroup([createStep(0, 0, PacketType.SEARCH_TOOL_START)]),
+          createTurnGroup([createStep(1, 0, PacketType.SEARCH_TOOL_START)]),
+        ],
+      });
+      expect(result.current.pacedTurnGroups.length).toBe(1);
+
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+      expect(result.current.pacedTurnGroups.length).toBe(2);
+    });
+  });
+
+  describe("stop packet", () => {
+    it("flushes all pending steps immediately", () => {
+      const { result, rerender } = renderHook(
+        ({
+          turnGroups,
+          stopPacketSeen,
+        }: {
+          turnGroups: TurnGroup[];
+          stopPacketSeen: boolean;
+        }) => usePacedTurnGroups(turnGroups, [], stopPacketSeen, 1, false),
+        {
+          initialProps: {
+            turnGroups: [createTurnGroup([createStep(0, 0)])],
+            stopPacketSeen: false,
+          },
+        },
+      );
+      expect(result.current.pacedTurnGroups.length).toBe(1);
+
+      rerender({
+        turnGroups: [
+          createTurnGroup([createStep(0, 0)]),
+          createTurnGroup([createStep(1, 0)]),
+          createTurnGroup([createStep(2, 0)]),
+        ],
+        stopPacketSeen: false,
+      });
+      expect(result.current.pacedTurnGroups.length).toBe(1);
+
+      rerender({
+        turnGroups: [
+          createTurnGroup([createStep(0, 0)]),
+          createTurnGroup([createStep(1, 0)]),
+          createTurnGroup([createStep(2, 0)]),
+        ],
+        stopPacketSeen: true,
+      });
+      expect(result.current.pacedTurnGroups.length).toBe(3);
+    });
+  });
+
+  describe("display groups", () => {
+    it("shows display groups only after tool pacing completes", () => {
+      const displayGroup = createDisplayGroup(1);
+      const { result, rerender } = renderHook(
+        ({ turnGroups }: { turnGroups: TurnGroup[] }) =>
+          usePacedTurnGroups(turnGroups, [displayGroup], false, 1, true),
+        { initialProps: { turnGroups: [createTurnGroup([createStep(0, 0)])] } },
+      );
+      expect(result.current.pacedTurnGroups.length).toBe(1);
+
+      rerender({
+        turnGroups: [
+          createTurnGroup([createStep(0, 0)]),
+          createTurnGroup([createStep(1, 0)]),
+        ],
+      });
+      expect(result.current.pacedDisplayGroups.length).toBe(0);
+
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+      expect(result.current.pacedTurnGroups.length).toBe(2);
+      expect(result.current.pacedDisplayGroups.length).toBe(1);
+    });
+
+    it("re-hides display when a new step queues after pacing had completed", () => {
+      // Regression: toolPacingComplete going true→false (a queued step) must publish, so the answer
+      // can't show through the pacing gap before the 200ms timer fires.
+      const displayGroup = createDisplayGroup(2);
+      const { result, rerender } = renderHook(
+        ({ turnGroups }: { turnGroups: TurnGroup[] }) =>
+          usePacedTurnGroups(turnGroups, [displayGroup], false, 1, true),
+        { initialProps: { turnGroups: [createTurnGroup([createStep(0, 0)])] } },
+      );
+
+      // Reveal a second step and let pacing complete → answer shown.
+      rerender({
+        turnGroups: [
+          createTurnGroup([createStep(0, 0)]),
+          createTurnGroup([createStep(1, 0)]),
+        ],
+      });
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+      expect(result.current.pacedDisplayGroups.length).toBe(1);
+
+      // A third step queues behind the timer — the answer must hide again immediately.
+      rerender({
+        turnGroups: [
+          createTurnGroup([createStep(0, 0)]),
+          createTurnGroup([createStep(1, 0)]),
+          createTurnGroup([createStep(2, 0)]),
+        ],
+      });
+      expect(result.current.pacedDisplayGroups.length).toBe(0);
+      expect(result.current.pacedFinalAnswerComing).toBe(false);
+
+      // Once it reveals, pacing completes and the answer returns.
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+      expect(result.current.pacedTurnGroups.length).toBe(3);
+      expect(result.current.pacedDisplayGroups.length).toBe(1);
+    });
+
+    it("shows display groups immediately when there are no tool steps", () => {
+      const { result } = renderHook(() =>
+        usePacedTurnGroups([], [createDisplayGroup(0)], false, 1, true),
+      );
+      expect(result.current.pacedDisplayGroups.length).toBe(1);
+      expect(result.current.pacedFinalAnswerComing).toBe(true);
+    });
+  });
+
+  describe("pacedFinalAnswerComing", () => {
+    it("is false until tool pacing completes", () => {
+      const { result, rerender } = renderHook(
+        ({ turnGroups }: { turnGroups: TurnGroup[] }) =>
+          usePacedTurnGroups(turnGroups, [], false, 1, true),
+        { initialProps: { turnGroups: [createTurnGroup([createStep(0, 0)])] } },
+      );
+      rerender({
+        turnGroups: [
+          createTurnGroup([createStep(0, 0)]),
+          createTurnGroup([createStep(1, 0)]),
+        ],
+      });
+      expect(result.current.pacedFinalAnswerComing).toBe(false);
+
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+      expect(result.current.pacedFinalAnswerComing).toBe(true);
+    });
+  });
+
+  describe("tool-after-message transition", () => {
+    it("re-hides display when the agent switches from message back to tools", () => {
+      const displayGroup = createDisplayGroup(0);
+      const { result, rerender } = renderHook(
+        ({
+          turnGroups,
+          finalAnswerComing,
+        }: {
+          turnGroups: TurnGroup[];
+          finalAnswerComing: boolean;
+        }) =>
+          usePacedTurnGroups(
+            turnGroups,
+            [displayGroup],
+            false,
+            1,
+            finalAnswerComing,
+          ),
+        {
+          initialProps: {
+            turnGroups: [] as TurnGroup[],
+            finalAnswerComing: true,
+          },
+        },
+      );
+      // No tools + answer coming → display shown.
+      expect(result.current.pacedDisplayGroups.length).toBe(1);
+      expect(result.current.pacedFinalAnswerComing).toBe(true);
+
+      // Answer retracted + a new tool starts → display hidden again.
+      rerender({
+        turnGroups: [createTurnGroup([createStep(0, 0)])],
+        finalAnswerComing: false,
+      });
+      expect(result.current.pacedTurnGroups.length).toBe(1);
+      expect(result.current.pacedDisplayGroups.length).toBe(0);
+
+      // Second tool step keeps pacing incomplete.
+      rerender({
+        turnGroups: [
+          createTurnGroup([createStep(0, 0)]),
+          createTurnGroup([createStep(1, 0)]),
+        ],
+        finalAnswerComing: false,
+      });
+      expect(result.current.pacedDisplayGroups.length).toBe(0);
+
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+      expect(result.current.pacedTurnGroups.length).toBe(2);
+      expect(result.current.pacedDisplayGroups.length).toBe(1);
+    });
+  });
+
+  describe("nodeId reset", () => {
+    it("resets pacing state when nodeId changes", () => {
+      const { result, rerender } = renderHook(
+        ({ nodeId }: { nodeId: number }) =>
+          usePacedTurnGroups(
+            [createTurnGroup([createStep(0, 0)])],
+            [],
+            false,
+            nodeId,
+            false,
+          ),
+        { initialProps: { nodeId: 1 } },
+      );
+      expect(result.current.pacedTurnGroups.length).toBe(1);
+
+      rerender({ nodeId: 2 });
+      expect(result.current.pacedTurnGroups.length).toBe(1);
+    });
+  });
+
+  describe("timer cleanup", () => {
+    it("clears the timer on unmount without throwing", () => {
+      const { rerender, unmount } = renderHook(
+        ({ turnGroups }: { turnGroups: TurnGroup[] }) =>
+          usePacedTurnGroups(turnGroups, [], false, 1, false),
+        { initialProps: { turnGroups: [createTurnGroup([createStep(0, 0)])] } },
+      );
+      rerender({
+        turnGroups: [
+          createTurnGroup([createStep(0, 0)]),
+          createTurnGroup([createStep(1, 0)]),
+        ],
+      });
+      unmount();
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+    });
+
+    it("clears a pending timer when nodeId changes", () => {
+      const { result, rerender } = renderHook(
+        ({ turnGroups, nodeId }: { turnGroups: TurnGroup[]; nodeId: number }) =>
+          usePacedTurnGroups(turnGroups, [], false, nodeId, false),
+        {
+          initialProps: {
+            turnGroups: [createTurnGroup([createStep(0, 0)])],
+            nodeId: 1,
+          },
+        },
+      );
+      rerender({
+        turnGroups: [
+          createTurnGroup([createStep(0, 0)]),
+          createTurnGroup([createStep(1, 0)]),
+        ],
+        nodeId: 1,
+      });
+      rerender({
+        turnGroups: [createTurnGroup([createStep(0, 0)])],
+        nodeId: 2,
+      });
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+      expect(result.current.pacedTurnGroups.length).toBe(1);
+    });
+  });
+});

--- a/mobile/src/hooks/timeline/__tests__/usePacketProcessor.test.ts
+++ b/mobile/src/hooks/timeline/__tests__/usePacketProcessor.test.ts
@@ -1,0 +1,289 @@
+import { act, renderHook } from "@testing-library/react-native";
+import { describe, expect, it } from "@jest/globals";
+
+import { StopReason, type Packet } from "@/chat/streamingModels";
+import { usePacketProcessor } from "@/hooks/timeline/usePacketProcessor";
+
+import { makePlacedPacket } from "../../../chat/__tests__/fixtures";
+
+// packet builders (mirror grouping.test.ts)
+const searchStart = (turn: number, tab = 0): Packet =>
+  makePlacedPacket(
+    { type: "search_tool_start", is_internet_search: false },
+    { turn_index: turn, tab_index: tab },
+  );
+const searchQueriesDelta = (turn: number, tab = 0): Packet =>
+  makePlacedPacket(
+    { type: "search_tool_queries_delta", queries: ["q"] },
+    { turn_index: turn, tab_index: tab },
+  );
+const sectionEnd = (turn: number, tab = 0): Packet =>
+  makePlacedPacket(
+    { type: "section_end" },
+    { turn_index: turn, tab_index: tab },
+  );
+const messageStart = (turn: number, preSeconds?: number): Packet =>
+  makePlacedPacket(
+    {
+      type: "message_start",
+      id: "m",
+      content: "",
+      final_documents: null,
+      ...(preSeconds !== undefined
+        ? { pre_answer_processing_seconds: preSeconds }
+        : {}),
+    },
+    { turn_index: turn },
+  );
+const messageDelta = (turn: number, content: string): Packet =>
+  makePlacedPacket({ type: "message_delta", content }, { turn_index: turn });
+const stopAt = (reason: StopReason = StopReason.FINISHED): Packet =>
+  makePlacedPacket({ type: "stop", stop_reason: reason }, { turn_index: 0 });
+const branching = (n: number, turn: number): Packet =>
+  makePlacedPacket(
+    { type: "top_level_branching", num_parallel_branches: n },
+    { turn_index: turn },
+  );
+const imageStart = (turn: number): Packet =>
+  makePlacedPacket({ type: "image_generation_start" }, { turn_index: turn });
+const imageFinal = (turn: number): Packet =>
+  makePlacedPacket(
+    {
+      type: "image_generation_final",
+      images: [{ file_id: "a", url: "u", revised_prompt: "p" }],
+    },
+    { turn_index: turn },
+  );
+
+describe("usePacketProcessor", () => {
+  describe("initial state", () => {
+    it("returns empty data with no packets", () => {
+      const { result } = renderHook(() => usePacketProcessor([], 1));
+      expect(result.current.toolGroups).toEqual([]);
+      expect(result.current.displayGroups).toEqual([]);
+      expect(result.current.toolTurnGroups).toEqual([]);
+      expect(result.current.citations).toEqual([]);
+      expect(result.current.citationMap).toEqual({});
+      expect(result.current.stopPacketSeen).toBe(false);
+      expect(result.current.isComplete).toBe(false);
+    });
+
+    it("provides stable callback references across rerenders", () => {
+      const { result, rerender } = renderHook(
+        ({ packets }: { packets: Packet[] }) => usePacketProcessor(packets, 1),
+        { initialProps: { packets: [] as Packet[] } },
+      );
+      const onRenderComplete1 = result.current.onRenderComplete;
+      const markAllToolsDisplayed1 = result.current.markAllToolsDisplayed;
+      rerender({ packets: [] as Packet[] });
+      expect(result.current.onRenderComplete).toBe(onRenderComplete1);
+      expect(result.current.markAllToolsDisplayed).toBe(markAllToolsDisplayed1);
+    });
+  });
+
+  describe("nodeId changes", () => {
+    it("resets derived data when nodeId changes", () => {
+      const { result, rerender } = renderHook(
+        ({ packets, nodeId }: { packets: Packet[]; nodeId: number }) =>
+          usePacketProcessor(packets, nodeId),
+        {
+          initialProps: {
+            packets: [searchStart(0), sectionEnd(0)],
+            nodeId: 1,
+          },
+        },
+      );
+      expect(result.current.toolGroups.length).toBe(1);
+
+      rerender({ packets: [] as Packet[], nodeId: 2 });
+      expect(result.current.toolGroups).toEqual([]);
+    });
+
+    it("processes new packets after a nodeId change", () => {
+      const { result, rerender } = renderHook(
+        ({ packets, nodeId }: { packets: Packet[]; nodeId: number }) =>
+          usePacketProcessor(packets, nodeId),
+        { initialProps: { packets: [searchStart(0)], nodeId: 1 } },
+      );
+      expect(result.current.toolGroups.length).toBe(1);
+
+      rerender({ packets: [messageStart(0)], nodeId: 2 });
+      expect(result.current.toolGroups.length).toBe(0);
+      expect(result.current.displayGroups.length).toBe(1);
+    });
+  });
+
+  describe("stream reset detection", () => {
+    it("rebuilds when the packets array shrinks", () => {
+      const { result, rerender } = renderHook(
+        ({ packets }: { packets: Packet[] }) => usePacketProcessor(packets, 1),
+        {
+          initialProps: {
+            packets: [searchStart(0), sectionEnd(0), messageStart(1)],
+          },
+        },
+      );
+      expect(result.current.finalAnswerComing).toBe(true);
+
+      rerender({ packets: [searchStart(0)] });
+      expect(result.current.finalAnswerComing).toBe(false);
+    });
+  });
+
+  describe("displayGroups derivation", () => {
+    it("hides display groups while tools exist and no answer is coming", () => {
+      const { result } = renderHook(() =>
+        usePacketProcessor([searchStart(0)], 1),
+      );
+      expect(result.current.toolGroups.length).toBe(1);
+      expect(result.current.finalAnswerComing).toBe(false);
+      expect(result.current.displayGroups.length).toBe(0);
+    });
+
+    it("shows display groups once the answer is coming", () => {
+      const { result } = renderHook(() =>
+        usePacketProcessor([searchStart(0), sectionEnd(0), messageStart(1)], 1),
+      );
+      expect(result.current.finalAnswerComing).toBe(true);
+      expect(result.current.displayGroups.length).toBe(1);
+    });
+
+    it("shows display groups immediately when there were no tools", () => {
+      const { result } = renderHook(() =>
+        usePacketProcessor([messageStart(0)], 1),
+      );
+      expect(result.current.toolGroups.length).toBe(0);
+      expect(result.current.displayGroups.length).toBe(1);
+    });
+  });
+
+  describe("tool-after-message transition", () => {
+    it("retracts finalAnswerComing when a real tool follows the message", () => {
+      const { result, rerender } = renderHook(
+        ({ packets }: { packets: Packet[] }) => usePacketProcessor(packets, 1),
+        { initialProps: { packets: [messageStart(0)] } },
+      );
+      expect(result.current.finalAnswerComing).toBe(true);
+
+      rerender({ packets: [messageStart(0), searchStart(1)] });
+      expect(result.current.finalAnswerComing).toBe(false);
+    });
+  });
+
+  describe("completion", () => {
+    it("sets isComplete only after onRenderComplete when final answer + stop seen", () => {
+      const { result } = renderHook(() =>
+        usePacketProcessor([messageStart(0), stopAt()], 1),
+      );
+      expect(result.current.finalAnswerComing).toBe(true);
+      expect(result.current.stopPacketSeen).toBe(true);
+      expect(result.current.isComplete).toBe(false);
+
+      act(() => {
+        result.current.onRenderComplete();
+      });
+      expect(result.current.isComplete).toBe(true);
+    });
+
+    it("does not complete when the final answer is not coming", () => {
+      const { result } = renderHook(() =>
+        usePacketProcessor([searchStart(0)], 1),
+      );
+      expect(result.current.finalAnswerComing).toBe(false);
+
+      act(() => {
+        result.current.onRenderComplete();
+      });
+      expect(result.current.isComplete).toBe(false);
+    });
+
+    it("stays incomplete when stop has not been seen", () => {
+      const { result } = renderHook(() =>
+        usePacketProcessor([messageStart(0)], 1),
+      );
+      act(() => {
+        result.current.onRenderComplete();
+      });
+      expect(result.current.stopPacketSeen).toBe(false);
+      expect(result.current.isComplete).toBe(false);
+    });
+  });
+
+  describe("hasSteps + branches", () => {
+    it("reports hasSteps false with no tool groups", () => {
+      const { result } = renderHook(() =>
+        usePacketProcessor([messageStart(0)], 1),
+      );
+      expect(result.current.hasSteps).toBe(false);
+    });
+
+    it("reports hasSteps true with tool groups", () => {
+      const { result } = renderHook(() =>
+        usePacketProcessor([searchStart(0)], 1),
+      );
+      expect(result.current.hasSteps).toBe(true);
+    });
+
+    it("groups parallel tools into one turn group and exposes branch metadata", () => {
+      const { result } = renderHook(() =>
+        usePacketProcessor(
+          [
+            branching(2, 0),
+            searchStart(0, 0),
+            searchStart(0, 1),
+            sectionEnd(0, 0),
+            sectionEnd(0, 1),
+          ],
+          1,
+        ),
+      );
+      expect(result.current.toolTurnGroups.length).toBe(1);
+      expect(result.current.toolTurnGroups[0]?.isParallel).toBe(true);
+      expect(result.current.toolTurnGroups[0]?.steps.length).toBe(2);
+      expect(result.current.expectedBranchesPerTurn.get(0)).toBe(2);
+    });
+  });
+
+  describe("full flows", () => {
+    it("tools → message → complete", () => {
+      const { result } = renderHook(() =>
+        usePacketProcessor(
+          [
+            searchStart(0),
+            searchQueriesDelta(0),
+            sectionEnd(0),
+            messageStart(1, 1.5),
+            messageDelta(1, "Result:"),
+            stopAt(StopReason.FINISHED),
+          ],
+          1,
+        ),
+      );
+      expect(result.current.toolGroups.length).toBe(1);
+      expect(result.current.displayGroups.length).toBe(1);
+      expect(result.current.hasSteps).toBe(true);
+      expect(result.current.stopPacketSeen).toBe(true);
+      expect(result.current.stopReason).toBe(StopReason.FINISHED);
+      expect(result.current.finalAnswerComing).toBe(true);
+      expect(result.current.toolProcessingDuration).toBe(1.5);
+
+      act(() => {
+        result.current.onRenderComplete();
+      });
+      expect(result.current.isComplete).toBe(true);
+    });
+
+    it("image generation flow", () => {
+      const { result } = renderHook(() =>
+        usePacketProcessor(
+          [imageStart(0), imageFinal(0), sectionEnd(0), stopAt()],
+          1,
+        ),
+      );
+      expect(result.current.isGeneratingImage).toBe(true);
+      expect(result.current.generatedImageCount).toBe(1);
+      expect(result.current.finalAnswerComing).toBe(true);
+      expect(result.current.displayGroups.length).toBe(1);
+    });
+  });
+});

--- a/mobile/src/hooks/timeline/usePacedTurnGroups.ts
+++ b/mobile/src/hooks/timeline/usePacedTurnGroups.ts
@@ -86,6 +86,16 @@ export function usePacedTurnGroups(
 
   const nodeIdStr = String(nodeId);
 
+  // Message switch: reset the published mirrors synchronously during render (React re-renders before
+  // commit), so the transition frame can't flash the previous node's revealed steps or answer. The
+  // ref + timer reset and reprocessing happen in the effect below.
+  const [prevNodeIdStr, setPrevNodeIdStr] = useState(nodeIdStr);
+  if (prevNodeIdStr !== nodeIdStr) {
+    setPrevNodeIdStr(nodeIdStr);
+    setRevealedStepKeys(new Set());
+    setToolPacingComplete(false);
+  }
+
   // Publish the ref's working set/flag to state so the next render reflects them.
   const publish = useCallback(() => {
     const state = stateRef.current;
@@ -132,21 +142,14 @@ export function usePacedTurnGroups(
 
   // Process incoming turn groups (reset → transition → stop-flush → reveal/queue).
   useEffect(() => {
-    // Reset on message switch (web did this during render); clear any pending timer. Republish empty
-    // only when the prior node had content, to avoid a spurious re-render on first mount.
+    // Reset the ref bookkeeping + timer on a message switch (the published mirrors were already
+    // cleared synchronously during render, above).
     if (stateRef.current.nodeId !== nodeIdStr) {
-      const hadContent =
-        stateRef.current.revealedStepKeys.size > 0 ||
-        stateRef.current.toolPacingComplete;
       if (stateRef.current.pacingTimer) {
         clearTimeout(stateRef.current.pacingTimer);
       }
       stateRef.current = createInitialPacingState();
       stateRef.current.nodeId = nodeIdStr;
-      if (hadContent) {
-        setRevealedStepKeys(new Set());
-        setToolPacingComplete(false);
-      }
     }
 
     const state = stateRef.current;

--- a/mobile/src/hooks/timeline/usePacedTurnGroups.ts
+++ b/mobile/src/hooks/timeline/usePacedTurnGroups.ts
@@ -1,0 +1,304 @@
+// 200ms staggered reveal of timeline steps during streaming, for visual breathing room.
+//
+// Restructured from web (which reads pacing refs during render): mobile's react-hooks/refs lint
+// forbids that, so the render-relevant fields (revealedStepKeys, toolPacingComplete) are useState
+// PUBLISHED by the effect/callback (replacing web's revealTrigger bump), while the internal
+// bookkeeping (pending queue, timer, flags) stays in a ref touched only in effects/callbacks.
+// Behavior-preserving; web's prevPacedRef stabilization is dropped.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { GroupedPacket } from "@/chat/messageProcessor";
+import { PacketType } from "@/chat/streamingModels";
+import { TransformedStep, TurnGroup } from "@/chat/timeline/transformers";
+
+const PACING_DELAY_MS = 200;
+
+const TOOL_START_PACKET_TYPES = new Set<PacketType>([
+  PacketType.SEARCH_TOOL_START,
+  PacketType.FETCH_TOOL_START,
+  PacketType.PYTHON_TOOL_START,
+  PacketType.CUSTOM_TOOL_START,
+  PacketType.FILE_READER_START,
+  PacketType.REASONING_START,
+  PacketType.IMAGE_GENERATION_TOOL_START,
+  PacketType.DEEP_RESEARCH_PLAN_START,
+  PacketType.RESEARCH_AGENT_START,
+  PacketType.MEMORY_TOOL_START,
+  PacketType.MEMORY_TOOL_NO_ACCESS,
+]);
+
+function getStepPacketType(step: TransformedStep): PacketType | null {
+  for (const packet of step.packets) {
+    if (TOOL_START_PACKET_TYPES.has(packet.obj.type as PacketType)) {
+      return packet.obj.type as PacketType;
+    }
+  }
+  return null;
+}
+
+// Internal pacing bookkeeping — lives in a ref, touched only inside effects/callbacks.
+interface PacingState {
+  revealedStepKeys: Set<string>;
+  lastRevealedPacketType: PacketType | null;
+  pendingSteps: TransformedStep[];
+  pacingTimer: ReturnType<typeof setTimeout> | null;
+  toolPacingComplete: boolean;
+  stopPacketSeen: boolean;
+  nodeId: string | null;
+}
+
+function createInitialPacingState(): PacingState {
+  return {
+    revealedStepKeys: new Set(),
+    lastRevealedPacketType: null,
+    pendingSteps: [],
+    pacingTimer: null,
+    toolPacingComplete: false,
+    stopPacketSeen: false,
+    nodeId: null,
+  };
+}
+
+export interface UsePacedTurnGroupsResult {
+  pacedTurnGroups: TurnGroup[];
+  pacedDisplayGroups: GroupedPacket[];
+  pacedFinalAnswerComing: boolean;
+}
+
+export function usePacedTurnGroups(
+  toolTurnGroups: TurnGroup[],
+  displayGroups: GroupedPacket[],
+  stopPacketSeen: boolean,
+  nodeId: number,
+  finalAnswerComing: boolean,
+): UsePacedTurnGroupsResult {
+  const stateRef = useRef<PacingState>(createInitialPacingState());
+
+  // Track previous finalAnswerComing to detect tool-after-message transitions (effect-only ref).
+  const prevFinalAnswerComingRef = useRef(finalAnswerComing);
+
+  // Published mirrors of the ref's render-relevant fields (web read the ref during render).
+  const [revealedStepKeys, setRevealedStepKeys] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [toolPacingComplete, setToolPacingComplete] = useState(false);
+
+  const nodeIdStr = String(nodeId);
+
+  // Publish the ref's working set/flag to state so the next render reflects them.
+  const publish = useCallback(() => {
+    const state = stateRef.current;
+    setRevealedStepKeys(new Set(state.revealedStepKeys));
+    setToolPacingComplete(state.toolPacingComplete);
+  }, []);
+
+  // Holds the latest reveal fn so the recursive timer can call it without a forward self-reference
+  // (mobile's react-hooks lint forbids referencing a value before it's declared).
+  const revealNextPendingStepRef = useRef<() => void>(() => {});
+
+  // Reveal one queued step per fire, then reschedule if more remain.
+  const revealNextPendingStep = useCallback(() => {
+    const state = stateRef.current;
+
+    if (state.pendingSteps.length > 0) {
+      const stepToReveal = state.pendingSteps.shift()!;
+      state.revealedStepKeys.add(stepToReveal.key);
+      state.lastRevealedPacketType = getStepPacketType(stepToReveal);
+
+      if (state.pendingSteps.length > 0) {
+        state.pacingTimer = setTimeout(
+          () => revealNextPendingStepRef.current(),
+          PACING_DELAY_MS,
+        );
+        publish();
+        return;
+      }
+    }
+
+    state.toolPacingComplete = true;
+    state.pacingTimer = null;
+    publish();
+  }, [publish]);
+
+  useEffect(() => {
+    revealNextPendingStepRef.current = revealNextPendingStep;
+  }, [revealNextPendingStep]);
+
+  // History reload: a message already complete on first render (stop seen, nothing revealed, steps
+  // exist) reveals everything at once and stays bypassed.
+  const shouldBypassPacing =
+    stopPacketSeen && revealedStepKeys.size === 0 && toolTurnGroups.length > 0;
+
+  // Process incoming turn groups (reset → transition → stop-flush → reveal/queue).
+  useEffect(() => {
+    // Reset on message switch (web did this during render); clear any pending timer. Republish empty
+    // only when the prior node had content, to avoid a spurious re-render on first mount.
+    if (stateRef.current.nodeId !== nodeIdStr) {
+      const hadContent =
+        stateRef.current.revealedStepKeys.size > 0 ||
+        stateRef.current.toolPacingComplete;
+      if (stateRef.current.pacingTimer) {
+        clearTimeout(stateRef.current.pacingTimer);
+      }
+      stateRef.current = createInitialPacingState();
+      stateRef.current.nodeId = nodeIdStr;
+      if (hadContent) {
+        setRevealedStepKeys(new Set());
+        setToolPacingComplete(false);
+      }
+    }
+
+    const state = stateRef.current;
+
+    // Recompute bypass from the (post-reset) ref rather than the render-time published value.
+    const bypassNow =
+      stopPacketSeen &&
+      state.revealedStepKeys.size === 0 &&
+      toolTurnGroups.length > 0;
+    if (bypassNow) return;
+
+    // Tool-after-message: hide the answer until the new tools finish pacing. Publish the flag, or the
+    // mirror lags the ref and the answer shows through the pacing gap (web re-reads the live ref).
+    if (prevFinalAnswerComingRef.current && !finalAnswerComing) {
+      state.toolPacingComplete = false;
+      setToolPacingComplete(false);
+    }
+    prevFinalAnswerComingRef.current = finalAnswerComing;
+
+    // STOP: flush every pending step immediately.
+    if (stopPacketSeen && !state.stopPacketSeen) {
+      state.stopPacketSeen = true;
+
+      if (state.pacingTimer) {
+        clearTimeout(state.pacingTimer);
+        state.pacingTimer = null;
+      }
+      for (const step of state.pendingSteps) {
+        state.revealedStepKeys.add(step.key);
+      }
+      state.pendingSteps = [];
+      state.toolPacingComplete = true;
+
+      publish();
+      return;
+    }
+
+    const allSteps: TransformedStep[] = [];
+    for (const turnGroup of toolTurnGroups) {
+      for (const step of turnGroup.steps) {
+        allSteps.push(step);
+      }
+    }
+
+    // New = not yet revealed and not already queued.
+    const pendingKeys = new Set(state.pendingSteps.map((s) => s.key));
+    const newSteps: TransformedStep[] = [];
+    for (const step of allSteps) {
+      if (!state.revealedStepKeys.has(step.key) && !pendingKeys.has(step.key)) {
+        newSteps.push(step);
+      }
+    }
+
+    if (newSteps.length === 0) {
+      // No tool steps — complete immediately so a tool-less answer can render.
+      if (allSteps.length === 0 && !state.toolPacingComplete) {
+        state.toolPacingComplete = true;
+        publish();
+        return;
+      }
+
+      // All steps revealed, nothing pending or timing — pacing complete.
+      if (
+        state.pendingSteps.length === 0 &&
+        !state.pacingTimer &&
+        allSteps.length > 0
+      ) {
+        const allRevealed = allSteps.every((s) =>
+          state.revealedStepKeys.has(s.key),
+        );
+        if (allRevealed && !state.toolPacingComplete) {
+          state.toolPacingComplete = true;
+          publish();
+        }
+      }
+      return;
+    }
+
+    for (const step of newSteps) {
+      const stepType = getStepPacketType(step);
+
+      // First step ever — reveal immediately.
+      if (
+        state.revealedStepKeys.size === 0 &&
+        state.pendingSteps.length === 0
+      ) {
+        state.revealedStepKeys.add(step.key);
+        state.lastRevealedPacketType = stepType;
+        publish();
+        continue;
+      }
+
+      state.pendingSteps.push(step);
+      if (!state.pacingTimer && state.pendingSteps.length === 1) {
+        state.pacingTimer = setTimeout(revealNextPendingStep, PACING_DELAY_MS);
+      }
+    }
+
+    if (state.pendingSteps.length > 0 || state.pacingTimer) {
+      // Steps still queued — publish the flag so the mirror doesn't lag the ref and show the answer
+      // through the pacing gap.
+      state.toolPacingComplete = false;
+      setToolPacingComplete(false);
+    }
+  }, [
+    toolTurnGroups,
+    stopPacketSeen,
+    finalAnswerComing,
+    nodeIdStr,
+    revealNextPendingStep,
+    publish,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      if (stateRef.current.pacingTimer) {
+        clearTimeout(stateRef.current.pacingTimer);
+      }
+    };
+  }, []);
+
+  const pacedTurnGroups = useMemo(() => {
+    if (shouldBypassPacing) return toolTurnGroups;
+
+    const result: TurnGroup[] = [];
+    for (const turnGroup of toolTurnGroups) {
+      const revealedSteps = turnGroup.steps.filter((step) =>
+        revealedStepKeys.has(step.key),
+      );
+      if (revealedSteps.length > 0) {
+        result.push({
+          turnIndex: turnGroup.turnIndex,
+          steps: revealedSteps,
+          isParallel: revealedSteps.length > 1,
+        });
+      }
+    }
+    return result;
+  }, [toolTurnGroups, revealedStepKeys, shouldBypassPacing]);
+
+  const pacedDisplayGroups = useMemo(
+    () =>
+      shouldBypassPacing || toolPacingComplete || stopPacketSeen
+        ? displayGroups
+        : [],
+    [shouldBypassPacing, toolPacingComplete, stopPacketSeen, displayGroups],
+  );
+
+  const pacedFinalAnswerComing = useMemo(
+    () => (shouldBypassPacing || toolPacingComplete) && finalAnswerComing,
+    [shouldBypassPacing, toolPacingComplete, finalAnswerComing],
+  );
+
+  return { pacedTurnGroups, pacedDisplayGroups, pacedFinalAnswerComing };
+}

--- a/mobile/src/hooks/timeline/usePacketProcessor.ts
+++ b/mobile/src/hooks/timeline/usePacketProcessor.ts
@@ -5,7 +5,7 @@
 // chat scale, re-optimizable to incremental later behind the same API. renderComplete/forceShowAnswer
 // are the only true UI state; everything else derives from the packets.
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import {
   CitationMap,
@@ -59,21 +59,24 @@ export function usePacketProcessor(
     [nodeId, rawPackets],
   );
 
-  // Reset transient UI state on a message switch or stream rewind — in an effect, not during render,
-  // so react-hooks/refs stays satisfied.
-  const prevNodeIdRef = useRef(nodeId);
-  const prevFinalAnswerComingRef = useRef(state.finalAnswerComing);
-  useEffect(() => {
-    if (prevNodeIdRef.current !== nodeId) {
-      setRenderComplete(false);
-      setForceShowAnswer(false);
-    } else if (prevFinalAnswerComingRef.current && !state.finalAnswerComing) {
-      // Tool-after-message: answer retracted, so the renderer must re-run — clear completion.
+  // Reset transient UI state synchronously during render (React re-renders before commit) so a
+  // message switch or a retracted answer can't briefly show the prior node's completion.
+  const [prevNodeId, setPrevNodeId] = useState(nodeId);
+  const [prevFinalAnswerComing, setPrevFinalAnswerComing] = useState(
+    state.finalAnswerComing,
+  );
+  if (prevNodeId !== nodeId) {
+    setPrevNodeId(nodeId);
+    setPrevFinalAnswerComing(state.finalAnswerComing);
+    setRenderComplete(false);
+    setForceShowAnswer(false);
+  } else if (prevFinalAnswerComing !== state.finalAnswerComing) {
+    setPrevFinalAnswerComing(state.finalAnswerComing);
+    // Tool-after-message: answer retracted, so the renderer must re-run — clear completion.
+    if (prevFinalAnswerComing && !state.finalAnswerComing) {
       setRenderComplete(false);
     }
-    prevNodeIdRef.current = nodeId;
-    prevFinalAnswerComingRef.current = state.finalAnswerComing;
-  }, [nodeId, state.finalAnswerComing]);
+  }
 
   const effectiveFinalAnswerComing = state.finalAnswerComing || forceShowAnswer;
   const displayGroups = useMemo(() => {

--- a/mobile/src/hooks/timeline/usePacketProcessor.ts
+++ b/mobile/src/hooks/timeline/usePacketProcessor.ts
@@ -1,0 +1,129 @@
+// Grouping reducer + derived timeline data for one assistant message.
+//
+// Restructured from web (which mutates a state ref during render): mobile's react-hooks/refs lint
+// forbids that, so processPackets runs as a full useMemo recompute per flush — O(n)/flush, fine at
+// chat scale, re-optimizable to incremental later behind the same API. renderComplete/forceShowAnswer
+// are the only true UI state; everything else derives from the packets.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  CitationMap,
+  SearchDoc,
+  StreamingCitation,
+} from "@/chat/contracts/documents";
+import {
+  GroupedPacket,
+  createInitialState,
+  processPackets,
+} from "@/chat/messageProcessor";
+import { Packet, StopReason } from "@/chat/streamingModels";
+import {
+  TurnGroup,
+  groupStepsByTurn,
+  transformPacketGroups,
+} from "@/chat/timeline/transformers";
+
+export interface UsePacketProcessorResult {
+  toolGroups: GroupedPacket[];
+  displayGroups: GroupedPacket[];
+  toolTurnGroups: TurnGroup[];
+  citations: StreamingCitation[];
+  citationMap: CitationMap;
+  documentMap: Map<string, SearchDoc>;
+
+  stopPacketSeen: boolean;
+  stopReason: StopReason | undefined;
+  hasSteps: boolean;
+  expectedBranchesPerTurn: Map<number, number>;
+  isGeneratingImage: boolean;
+  generatedImageCount: number;
+  finalAnswerComing: boolean;
+  toolProcessingDuration: number | undefined;
+
+  isComplete: boolean;
+
+  onRenderComplete: () => void;
+  markAllToolsDisplayed: () => void;
+}
+
+export function usePacketProcessor(
+  rawPackets: Packet[],
+  nodeId: number,
+): UsePacketProcessorResult {
+  const [renderComplete, setRenderComplete] = useState(false);
+  const [forceShowAnswer, setForceShowAnswer] = useState(false);
+
+  const state = useMemo(
+    () => processPackets(createInitialState(nodeId), rawPackets),
+    [nodeId, rawPackets],
+  );
+
+  // Reset transient UI state on a message switch or stream rewind — in an effect, not during render,
+  // so react-hooks/refs stays satisfied.
+  const prevNodeIdRef = useRef(nodeId);
+  const prevFinalAnswerComingRef = useRef(state.finalAnswerComing);
+  useEffect(() => {
+    if (prevNodeIdRef.current !== nodeId) {
+      setRenderComplete(false);
+      setForceShowAnswer(false);
+    } else if (prevFinalAnswerComingRef.current && !state.finalAnswerComing) {
+      // Tool-after-message: answer retracted, so the renderer must re-run — clear completion.
+      setRenderComplete(false);
+    }
+    prevNodeIdRef.current = nodeId;
+    prevFinalAnswerComingRef.current = state.finalAnswerComing;
+  }, [nodeId, state.finalAnswerComing]);
+
+  const effectiveFinalAnswerComing = state.finalAnswerComing || forceShowAnswer;
+  const displayGroups = useMemo(() => {
+    if (effectiveFinalAnswerComing || state.toolGroups.length === 0) {
+      return state.potentialDisplayGroups;
+    }
+    return [];
+  }, [
+    effectiveFinalAnswerComing,
+    state.toolGroups.length,
+    state.potentialDisplayGroups,
+  ]);
+
+  const toolTurnGroups = useMemo(
+    () => groupStepsByTurn(transformPacketGroups(state.toolGroups)),
+    [state.toolGroups],
+  );
+
+  // Read the current render's finalAnswerComing, not an effect-lagged mirror — so a renderer's
+  // onComplete fired in the same commit the answer begins isn't dropped.
+  const onRenderComplete = useCallback(() => {
+    if (state.finalAnswerComing) {
+      setRenderComplete(true);
+    }
+  }, [state.finalAnswerComing]);
+
+  const markAllToolsDisplayed = useCallback(() => {
+    setForceShowAnswer(true);
+  }, []);
+
+  return {
+    toolGroups: state.toolGroups,
+    displayGroups,
+    toolTurnGroups,
+    citations: state.citations,
+    citationMap: state.citationMap,
+    documentMap: state.documentMap,
+
+    stopPacketSeen: state.stopPacketSeen,
+    stopReason: state.stopReason,
+    hasSteps: toolTurnGroups.length > 0,
+    expectedBranchesPerTurn: state.expectedBranches,
+    isGeneratingImage: state.isGeneratingImage,
+    generatedImageCount: state.generatedImageCount,
+    finalAnswerComing: state.finalAnswerComing,
+    toolProcessingDuration: state.toolProcessingDuration,
+
+    isComplete: state.stopPacketSeen && renderComplete,
+
+    onRenderComplete,
+    markAllToolsDisplayed,
+  };
+}


### PR DESCRIPTION
## Description

PR 9b.2 of the mobile agent reasoning-timeline port: adds two restructured, unit-tested timeline hooks (`usePacketProcessor`, `usePacedTurnGroups`) that host the packet-grouping reducer and drive the 200ms staggered step reveal. They mirror web's behavior but hoist render-relevant state out of refs — into a `useMemo` recompute and effect-published `useState` — to satisfy mobile's `react-hooks/refs` lint. The hooks land dark: compiled and tested but not yet wired on screen (that happens in 9b.7).

## How Has This Been Tested?

31 Jest unit tests with fake timers (pacing cadence, stop-flush, history bypass, processor derivation); typecheck, lint, and the full mobile Jest suite pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
