### PR TITLE
feat(mobile): render-prop renderer contract + answer migration

### DIFF
--- a/mobile/src/components/chat/MessageRow.tsx
+++ b/mobile/src/components/chat/MessageRow.tsx
@@ -1,5 +1,5 @@
 // Memoized on packet count, not array identity: a row re-renders only when its own packets grow.
-import { memo, useMemo, useState } from "react";
+import { Fragment, memo, useMemo, useState } from "react";
 import { View } from "react-native";
 
 import { selectSources } from "@/chat/citations";
@@ -7,16 +7,22 @@ import { Message } from "@/chat/interfaces";
 import { MinimalAgent } from "@/chat/agents";
 import { getErrorTitle } from "@/chat/errorHelpers";
 import { fileDescriptorToDisplayFile } from "@/chat/fileDescriptors";
+import { openSource } from "@/chat/openSource";
 import { AgentTimeline } from "@/components/chat/AgentTimeline";
 import {
   CitedSourcesBar,
   CitedSourcesSheet,
 } from "@/components/chat/CitedSources";
 import { FileCard } from "@/components/chat/FileCard";
+import { RendererComponent } from "@/components/chat/renderers/RendererComponent";
+import type { FullChatState } from "@/components/chat/renderers/registry";
 import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/text";
 import SvgAlertCircle from "@/icons/alert-circle";
 import { usePacketDisplay } from "@/hooks/usePacketDisplay";
+
+// The renderer's onComplete drives the timeline pacing gate (9b.7); nothing consumes it in PR4.
+const NOOP = (): void => {};
 
 function UserMessage({ node }: { node: Message }) {
   const files = node.files.map(fileDescriptorToDisplayFile);
@@ -30,7 +36,7 @@ function UserMessage({ node }: { node: Message }) {
         </View>
       ) : null}
       {node.message.length > 0 ? (
-        // Web parity: HumanMessage bubble with asymmetric corners (square bottom-right).
+        // Web HumanMessage bubble: squared bottom-right corner.
         <View className="max-w-[85%] rounded-t-16 rounded-bl-16 bg-background-tint-02 px-12 py-8">
           {/* 14px body: deliberate reduction from web's 16px, which reads oversized on a phone. */}
           <Text font="main-ui-body" color="text-05">
@@ -42,7 +48,7 @@ function UserMessage({ node }: { node: Message }) {
   );
 }
 
-// Web parity: ErrorBanner — code-derived title + raw error. Single alert icon; no regenerate yet.
+// Web ErrorBanner. No regenerate action yet.
 function ErrorMessage({ node }: { node: Message }) {
   return (
     <View className="py-6">
@@ -72,19 +78,29 @@ function AssistantMessage({
   node: Message;
   agent: MinimalAgent | null;
 }) {
-  const { renderer, packets, processed } = usePacketDisplay(node);
+  const { packets, processed, hasRenderer } = usePacketDisplay(node);
   const [sourcesOpen, setSourcesOpen] = useState(false);
-  const Renderer = renderer?.Component;
-  const hasContent = Renderer != null && packets.length > 0;
+  const hasContent = hasRenderer && packets.length > 0;
 
-  // Sources appear only once the answer completes (web parity; avoids mid-stream layout shift).
-  // Memoized on `processed` so toggling the sheet open/closed doesn't re-run the selector.
+  // Only after the answer completes, to avoid mid-stream layout shift.
   const sources = useMemo(
     () => (processed.isComplete ? selectSources(processed) : null),
     [processed],
   );
 
-  // Web AgentMessage: timeline (avatar + status) above the answer; the timeline owns the loader.
+  // Context a renderer may read. This identity churns each flush, but RendererComponent's memo keys on
+  // agent.id, not this object, so that's harmless.
+  const chatState = useMemo<FullChatState>(
+    () => ({
+      agent,
+      citations: processed.citationMap,
+      documentMap: processed.documentMap,
+      openSource,
+    }),
+    [agent, processed.citationMap, processed.documentMap],
+  );
+
+  // Web AgentMessage: the timeline (above) owns the loader; answer and sources sit below.
   return (
     <View className="gap-12 py-6">
       <AgentTimeline
@@ -92,9 +108,25 @@ function AssistantMessage({
         isLoading={!hasContent && !processed.isComplete}
       />
       {hasContent ? (
-        // Inset (px-12) aligns the answer under the avatar rail, matching web's px-3.
+        // px-12 aligns the answer under the avatar rail (web's px-3).
         <View className="px-12">
-          <Renderer packets={packets} processed={processed} />
+          <RendererComponent
+            packets={packets}
+            chatState={chatState}
+            messageNodeId={node.nodeId}
+            onComplete={NOOP}
+            animate={!processed.isComplete}
+            stopPacketSeen={processed.stopPacketSeen}
+            stopReason={processed.stopReason}
+          >
+            {(results) => (
+              <>
+                {results.map((result, index) => (
+                  <Fragment key={index}>{result.content}</Fragment>
+                ))}
+              </>
+            )}
+          </RendererComponent>
         </View>
       ) : null}
       {sources && sources.hasSources ? (
@@ -136,8 +168,6 @@ export const MessageRow = memo(
     prev.node.messageId === next.node.messageId &&
     prev.node.errorCode === next.node.errorCode &&
     prev.node.packets.length === next.node.packets.length &&
-    // user attachment chips: re-render if the files array is replaced
     prev.node.files === next.node.files &&
-    // assistant avatar: re-render if the session's agent changes
     prev.agent === next.agent,
 );

--- a/mobile/src/components/chat/renderers/MessageTextRenderer.tsx
+++ b/mobile/src/components/chat/renderers/MessageTextRenderer.tsx
@@ -1,5 +1,6 @@
-// Reveals concatenated stream content at a steady pace (useTypewriter) so bursty responses still animate in.
-import { useMemo, useState } from "react";
+// The final-answer renderer: reveals concatenated stream content via useTypewriter, then hands the
+// markdown to `children`. 9a inline citations ride along as `[[n]](url)` markers opened by openUrl.
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
   MessageDelta,
@@ -11,15 +12,7 @@ import { openUrl } from "@/chat/openSource";
 import { StreamingMarkdown } from "@/components/chat/StreamingMarkdown";
 import { useTypewriter } from "@/hooks/useTypewriter";
 
-import type { MessageRenderer, MessageRendererProps } from "./registry";
-
-function isChatPacket(packet: Packet): boolean {
-  return (
-    packet.obj.type === PacketType.MESSAGE_START ||
-    packet.obj.type === PacketType.MESSAGE_DELTA ||
-    packet.obj.type === PacketType.MESSAGE_END
-  );
-}
+import type { FullChatState, MessageRenderer } from "./timelineContract";
 
 function accumulateContent(packets: Packet[]): string {
   let content = "";
@@ -35,23 +28,55 @@ function accumulateContent(packets: Packet[]): string {
   return content;
 }
 
-function MessageText({ packets, processed }: MessageRendererProps) {
-  const isComplete = processed.isComplete;
+export const MessageTextRenderer: MessageRenderer<Packet, FullChatState> = ({
+  packets,
+  onComplete,
+  animate,
+  stopPacketSeen,
+  children,
+}) => {
   // Stable across packet flushes so the typewriter target grows only when content does.
   const content = useMemo(() => accumulateContent(packets), [packets]);
-  // Captured once at mount: live messages animate; historical ones mount complete and snap.
-  const [animate] = useState(() => !isComplete);
-  const { displayed } = useTypewriter(content, animate, isComplete);
-  return (
-    <StreamingMarkdown
-      content={displayed}
-      isStreaming={!isComplete}
-      onLinkPress={openUrl}
-    />
-  );
-}
 
-export const MessageTextRenderer: MessageRenderer = {
-  matches: (packets) => packets.some(isChatPacket),
-  Component: MessageText,
+  // Reproduces the processor's `isComplete` (MESSAGE_END or STOP) from the contract props — the signal
+  // that tells the typewriter to drain to the end and snap.
+  const messageEndSeen = useMemo(
+    () => packets.some((packet) => packet.obj.type === PacketType.MESSAGE_END),
+    [packets],
+  );
+  const isStreamFinished = stopPacketSeen || messageEndSeen;
+
+  // Captured once at mount: live messages animate; historical ones snap.
+  const [animateAtMount] = useState(() => animate);
+  const { displayed } = useTypewriter(
+    content,
+    animateAtMount,
+    isStreamFinished,
+  );
+
+  // Timeline pacing gate (9b.7): fire once when the answer is fully shown. Ref-guarded because
+  // `onComplete`'s identity changes each parent render.
+  const streamFullyDisplayed =
+    isStreamFinished && displayed.length >= content.length;
+  const onCompleteFiredRef = useRef(false);
+  useEffect(() => {
+    if (streamFullyDisplayed && !onCompleteFiredRef.current) {
+      onCompleteFiredRef.current = true;
+      onComplete();
+    }
+  }, [streamFullyDisplayed, onComplete]);
+
+  return children([
+    {
+      icon: null,
+      status: null,
+      content: (
+        <StreamingMarkdown
+          content={displayed}
+          isStreaming={!isStreamFinished}
+          onLinkPress={openUrl}
+        />
+      ),
+    },
+  ]);
 };

--- a/mobile/src/components/chat/renderers/RendererComponent.tsx
+++ b/mobile/src/components/chat/renderers/RendererComponent.tsx
@@ -1,0 +1,94 @@
+// Picks the renderer for a group's packets, invokes it at FULL, and forwards its `RendererResult[]` to
+// `children` (web `renderMessageComponent`). Memoized on packet identity so parent streaming re-renders
+// don't churn the answer subtree unless these packets grew.
+import { memo } from "react";
+import type { ComponentProps, ReactElement } from "react";
+
+import { Packet, StopReason } from "@/chat/streamingModels";
+
+import { findRenderer } from "./findRenderer";
+import { RenderType } from "./timelineContract";
+import type {
+  DispatchRenderer,
+  FullChatState,
+  RendererOutput,
+} from "./timelineContract";
+
+// Renders the dispatched renderer via a prop, not a call-result directly in JSX — the latter trips
+// react-hooks/static-components (same shape `Icon` uses for `as`). Identical to web's `<RendererFn/>`.
+function DispatchedRenderer({
+  renderer: Renderer,
+  ...rendererProps
+}: { renderer: DispatchRenderer } & ComponentProps<DispatchRenderer>) {
+  return <Renderer {...rendererProps} />;
+}
+
+interface RendererComponentProps {
+  packets: Packet[];
+  chatState: FullChatState;
+  messageNodeId?: number;
+  hasTimelineThinking?: boolean;
+  onComplete: () => void;
+  animate: boolean;
+  stopPacketSeen: boolean;
+  stopReason?: StopReason;
+  children: (result: RendererOutput) => ReactElement;
+}
+
+function RendererComponentImpl({
+  packets,
+  chatState,
+  messageNodeId,
+  hasTimelineThinking,
+  onComplete,
+  animate,
+  stopPacketSeen,
+  stopReason,
+  children,
+}: RendererComponentProps) {
+  // 9e: web splits mixed chat+image groups via a MixedContentHandler. No image renderer yet, so mixed
+  // groups fall through to the chat renderer (image dropped) until then.
+  const RendererFn = findRenderer(packets);
+
+  if (!RendererFn) {
+    return children([{ icon: null, status: null, content: <></> }]);
+  }
+
+  return (
+    <DispatchedRenderer
+      renderer={RendererFn}
+      packets={packets}
+      state={chatState}
+      messageNodeId={messageNodeId}
+      hasTimelineThinking={hasTimelineThinking}
+      onComplete={onComplete}
+      animate={animate}
+      renderType={RenderType.FULL}
+      stopPacketSeen={stopPacketSeen}
+      stopReason={stopReason}
+    >
+      {children}
+    </DispatchedRenderer>
+  );
+}
+
+// Skips `onComplete`/`children` (unstable identities) and `chatState` identity; `agent.id` covers the
+// only chatState change that affects output.
+function areRendererPropsEqual(
+  prev: RendererComponentProps,
+  next: RendererComponentProps,
+): boolean {
+  return (
+    prev.packets === next.packets &&
+    prev.stopPacketSeen === next.stopPacketSeen &&
+    prev.stopReason === next.stopReason &&
+    prev.animate === next.animate &&
+    prev.chatState.agent?.id === next.chatState.agent?.id &&
+    prev.messageNodeId === next.messageNodeId
+  );
+}
+
+export const RendererComponent = memo(
+  RendererComponentImpl,
+  areRendererPropsEqual,
+);

--- a/mobile/src/components/chat/renderers/__tests__/MessageTextRenderer.test.tsx
+++ b/mobile/src/components/chat/renderers/__tests__/MessageTextRenderer.test.tsx
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { render } from "@testing-library/react-native";
+import { Fragment } from "react";
+
+import { makePacket } from "@/chat/__tests__/fixtures";
+
+import { MessageTextRenderer } from "../MessageTextRenderer";
+import { RenderType, type RendererOutput } from "../timelineContract";
+
+// StreamingMarkdown pulls a native markdown module; capture its props instead of rendering. Capturing
+// `isStreaming` lets tests pin the completion signal directly, not just via onComplete.
+let mockMarkdownProps: { content: string; isStreaming: boolean } | null = null;
+jest.mock("@/components/chat/StreamingMarkdown", () => ({
+  StreamingMarkdown: (props: { content: string; isStreaming: boolean }) => {
+    mockMarkdownProps = props;
+    return null;
+  },
+}));
+
+const chatPackets = [
+  makePacket({
+    type: "message_start",
+    id: "m",
+    content: "Hello ",
+    final_documents: null,
+  }),
+  makePacket({ type: "message_delta", content: "world" }),
+];
+
+function renderResults(results: RendererOutput) {
+  return (
+    <>
+      {results.map((result, index) => (
+        <Fragment key={index}>{result.content}</Fragment>
+      ))}
+    </>
+  );
+}
+
+describe("MessageTextRenderer", () => {
+  beforeEach(() => {
+    mockMarkdownProps = null;
+  });
+
+  it("accumulates message_start + delta content and snaps historical messages to full", () => {
+    render(
+      <MessageTextRenderer
+        packets={chatPackets}
+        state={{ agent: null }}
+        onComplete={() => {}}
+        renderType={RenderType.FULL}
+        animate={false}
+        stopPacketSeen={true}
+      >
+        {renderResults}
+      </MessageTextRenderer>,
+    );
+    // animate=false snaps the typewriter to full immediately.
+    expect(mockMarkdownProps?.content).toBe("Hello world");
+    expect(mockMarkdownProps?.isStreaming).toBe(false);
+  });
+
+  it("emits a single render-prop result with no icon or status", () => {
+    let captured: RendererOutput | null = null;
+    render(
+      <MessageTextRenderer
+        packets={chatPackets}
+        state={{ agent: null }}
+        onComplete={() => {}}
+        renderType={RenderType.FULL}
+        animate={false}
+        stopPacketSeen={true}
+      >
+        {(results) => {
+          captured = results;
+          return <></>;
+        }}
+      </MessageTextRenderer>,
+    );
+    expect(captured).toHaveLength(1);
+    expect(captured![0].icon).toBeNull();
+    expect(captured![0].status).toBeNull();
+  });
+
+  it("treats a MESSAGE_END packet as complete even without a STOP (messageEndSeen branch)", () => {
+    // stopPacketSeen=false → only the messageEndSeen half of isStreamFinished can drive completion.
+    const endedPackets = [
+      makePacket({
+        type: "message_start",
+        id: "m",
+        content: "Hello ",
+        final_documents: null,
+      }),
+      makePacket({ type: "message_delta", content: "world" }),
+      makePacket({ type: "message_end" }),
+    ];
+    let calls = 0;
+    render(
+      <MessageTextRenderer
+        packets={endedPackets}
+        state={{ agent: null }}
+        onComplete={() => {
+          calls += 1;
+        }}
+        renderType={RenderType.FULL}
+        animate={false}
+        stopPacketSeen={false}
+      >
+        {renderResults}
+      </MessageTextRenderer>,
+    );
+    expect(mockMarkdownProps?.content).toBe("Hello world");
+    expect(mockMarkdownProps?.isStreaming).toBe(false);
+    expect(calls).toBe(1);
+  });
+
+  it("fires onComplete exactly once even as onComplete's identity churns across re-renders", () => {
+    let calls = 0;
+    const props = {
+      packets: chatPackets,
+      state: { agent: null },
+      renderType: RenderType.FULL,
+      animate: false,
+      stopPacketSeen: true,
+    } as const;
+    const { rerender } = render(
+      <MessageTextRenderer
+        {...props}
+        onComplete={() => {
+          calls += 1;
+        }}
+      >
+        {renderResults}
+      </MessageTextRenderer>,
+    );
+    // A fresh onComplete arrow each time changes the effect's dependency; the ref guard must still
+    // suppress re-firing.
+    rerender(
+      <MessageTextRenderer
+        {...props}
+        onComplete={() => {
+          calls += 1;
+        }}
+      >
+        {renderResults}
+      </MessageTextRenderer>,
+    );
+    rerender(
+      <MessageTextRenderer
+        {...props}
+        onComplete={() => {
+          calls += 1;
+        }}
+      >
+        {renderResults}
+      </MessageTextRenderer>,
+    );
+    expect(calls).toBe(1);
+  });
+
+  it("reveals content gradually and withholds onComplete while streaming (live path)", () => {
+    // animate=true + no MESSAGE_END/STOP → the typewriter starts empty and reveals over rAF.
+    const streaming = [
+      makePacket({
+        type: "message_start",
+        id: "m",
+        content: "",
+        final_documents: null,
+      }),
+      makePacket({ type: "message_delta", content: "A".repeat(60) }),
+    ];
+    let calls = 0;
+    render(
+      <MessageTextRenderer
+        packets={streaming}
+        state={{ agent: null }}
+        onComplete={() => {
+          calls += 1;
+        }}
+        renderType={RenderType.FULL}
+        animate={true}
+        stopPacketSeen={false}
+      >
+        {renderResults}
+      </MessageTextRenderer>,
+    );
+    // A snap-to-full regression (content={content}) would show all 60 chars at once; the live typewriter
+    // shows far fewer, stays streaming, and withholds onComplete until completion.
+    expect((mockMarkdownProps?.content ?? "").length).toBeLessThan(60);
+    expect(mockMarkdownProps?.isStreaming).toBe(true);
+    expect(calls).toBe(0);
+  });
+});

--- a/mobile/src/components/chat/renderers/__tests__/RendererComponent.test.tsx
+++ b/mobile/src/components/chat/renderers/__tests__/RendererComponent.test.tsx
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { render } from "@testing-library/react-native";
+import { Fragment } from "react";
+
+import { makePacket } from "@/chat/__tests__/fixtures";
+
+import { RendererComponent } from "../RendererComponent";
+import { type RendererOutput } from "../timelineContract";
+
+let mockMarkdownContent: string | null = null;
+jest.mock("@/components/chat/StreamingMarkdown", () => ({
+  StreamingMarkdown: (props: { content: string }) => {
+    mockMarkdownContent = props.content;
+    return null;
+  },
+}));
+
+function renderResults(results: RendererOutput) {
+  return (
+    <>
+      {results.map((result, index) => (
+        <Fragment key={index}>{result.content}</Fragment>
+      ))}
+    </>
+  );
+}
+
+describe("RendererComponent", () => {
+  beforeEach(() => {
+    mockMarkdownContent = null;
+  });
+
+  it("dispatches chat packets to the final-answer renderer", () => {
+    render(
+      <RendererComponent
+        packets={[
+          makePacket({
+            type: "message_start",
+            id: "m",
+            content: "Hello ",
+            final_documents: null,
+          }),
+          makePacket({ type: "message_delta", content: "world" }),
+        ]}
+        chatState={{ agent: null }}
+        onComplete={() => {}}
+        animate={false}
+        stopPacketSeen={true}
+      >
+        {renderResults}
+      </RendererComponent>,
+    );
+    expect(mockMarkdownContent).toBe("Hello world");
+  });
+
+  it("hands children an empty result when no renderer matches", () => {
+    let captured: RendererOutput | null = null;
+    render(
+      <RendererComponent
+        packets={[]}
+        chatState={{ agent: null }}
+        onComplete={() => {}}
+        animate={false}
+        stopPacketSeen={false}
+      >
+        {(results) => {
+          captured = results;
+          return <></>;
+        }}
+      </RendererComponent>,
+    );
+    expect(captured).toHaveLength(1);
+    expect(captured![0].icon).toBeNull();
+    expect(captured![0].status).toBeNull();
+    // No renderer ran, so the markdown stub was never invoked.
+    expect(mockMarkdownContent).toBeNull();
+  });
+});

--- a/mobile/src/components/chat/renderers/__tests__/findRenderer.test.ts
+++ b/mobile/src/components/chat/renderers/__tests__/findRenderer.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+import { makeMessageStartPacket, makePacket } from "@/chat/__tests__/fixtures";
+
+import { findRenderer } from "../findRenderer";
+import { MessageTextRenderer } from "../MessageTextRenderer";
+
+// findRenderer transitively imports StreamingMarkdown, whose react-native-streamdown (worklets) crashes
+// under jest. Stub the leaf; dispatch still returns the real MessageTextRenderer.
+jest.mock("@/components/chat/StreamingMarkdown", () => ({
+  StreamingMarkdown: () => null,
+}));
+
+describe("findRenderer", () => {
+  it("routes chat packets to the message text renderer", () => {
+    const packets = [
+      makeMessageStartPacket(),
+      makePacket({ type: "message_delta", content: "hello" }),
+    ];
+    expect(findRenderer(packets)).toBe(MessageTextRenderer);
+  });
+
+  it("prioritizes chat over reasoning when both are present", () => {
+    const packets = [
+      makePacket({ type: "reasoning_start" }),
+      makePacket({ type: "reasoning_delta", reasoning: "thinking" }),
+      makeMessageStartPacket(),
+    ];
+    expect(findRenderer(packets)).toBe(MessageTextRenderer);
+  });
+
+  it("returns null for reasoning-only packets (renderer wired in 9b.6)", () => {
+    const packets = [
+      makePacket({ type: "reasoning_start" }),
+      makePacket({ type: "reasoning_delta", reasoning: "thinking" }),
+    ];
+    expect(findRenderer(packets)).toBeNull();
+  });
+
+  it("returns null for section-end / error-only packets", () => {
+    expect(findRenderer([makePacket({ type: "section_end" })])).toBeNull();
+    expect(
+      findRenderer([makePacket({ type: "error", message: "boom" })]),
+    ).toBeNull();
+  });
+
+  it("returns null for an empty packet list", () => {
+    expect(findRenderer([])).toBeNull();
+  });
+});

--- a/mobile/src/components/chat/renderers/findRenderer.ts
+++ b/mobile/src/components/chat/renderers/findRenderer.ts
@@ -1,0 +1,44 @@
+// Priority-ordered renderer dispatch, mirroring web `renderMessageComponent`. First match wins. Only the
+// chat slot is wired in 9b.4; each tool slot below is a one-line wire-up in a later phase — the ordering
+// is already baked in so those phases never touch the priority logic.
+import { Packet, PacketType } from "@/chat/streamingModels";
+
+import { MessageTextRenderer } from "./MessageTextRenderer";
+import type { DispatchRenderer } from "./timelineContract";
+
+function isChatPacket(packet: Packet): boolean {
+  return (
+    packet.obj.type === PacketType.MESSAGE_START ||
+    packet.obj.type === PacketType.MESSAGE_DELTA ||
+    packet.obj.type === PacketType.MESSAGE_END
+  );
+}
+
+// A reasoning group is closed by a section_end (or error), so those types fall to it once the
+// higher-priority slots above have had their turn.
+function isReasoningPacket(packet: Packet): boolean {
+  return (
+    packet.obj.type === PacketType.REASONING_START ||
+    packet.obj.type === PacketType.REASONING_DELTA ||
+    packet.obj.type === PacketType.SECTION_END ||
+    packet.obj.type === PacketType.ERROR
+  );
+}
+
+export function findRenderer(packets: Packet[]): DispatchRenderer | null {
+  if (packets.some(isChatPacket)) {
+    return MessageTextRenderer;
+  }
+
+  // Tool renderers land in follow-up phases, in web's priority order:
+  //   deep-research plan → research-agent → coding-agent          // PR 9x
+  //   web-search → internal-search                                 // PR 9x
+  //   image → python → file-reader → custom-tool → fetch → memory  // PR 9x
+
+  // Reasoning is wired in 9b.6; the slot is present (returns null) so the priority ordering is correct.
+  if (packets.some(isReasoningPacket)) {
+    return null;
+  }
+
+  return null;
+}

--- a/mobile/src/components/chat/renderers/registry.ts
+++ b/mobile/src/components/chat/renderers/registry.ts
@@ -1,27 +1,10 @@
-// Packet-renderer dispatch seam. PR 9 adds rich renderers to RENDERERS; each is matched by the packet
-// types in its group.
-import type { ComponentType } from "react";
-
-import { ProcessedMessageState } from "@/chat/messageProcessor";
-import { Packet } from "@/chat/streamingModels";
-
-import { MessageTextRenderer } from "./MessageTextRenderer";
-
-export interface MessageRendererProps {
-  packets: Packet[];
-  // Processed packet state (citations, documents, completion). `processed.isComplete` is true once
-  // message_end / stop is seen.
-  processed: ProcessedMessageState;
-}
-
-export interface MessageRenderer {
-  matches: (packets: Packet[]) => boolean;
-  Component: ComponentType<MessageRendererProps>;
-}
-
-// first match wins
-const RENDERERS: MessageRenderer[] = [MessageTextRenderer];
-
-export function findRenderer(packets: Packet[]): MessageRenderer | null {
-  return RENDERERS.find((renderer) => renderer.matches(packets)) ?? null;
-}
+// Renderer dispatch barrel; the render-prop contract lives in `timelineContract`.
+export { findRenderer } from "./findRenderer";
+export { RenderType } from "./timelineContract";
+export type {
+  DispatchRenderer,
+  FullChatState,
+  MessageRenderer,
+  RendererOutput,
+  RendererResult,
+} from "./timelineContract";

--- a/mobile/src/components/chat/renderers/timelineContract.ts
+++ b/mobile/src/components/chat/renderers/timelineContract.ts
@@ -1,0 +1,81 @@
+// Render-prop renderer contract, ported from web `messageComponents/interfaces.ts` (docs 9b-timeline/03
+// §4). A renderer is headless: it computes a `RendererResult[]` and hands it to `children(results)`; the
+// parent owns the tree. Mobile drops web's `isHover` and the dead `expandedText`, and narrows
+// `FullChatState` to the fields mobile renderers read.
+import type { ComponentType, ReactElement } from "react";
+
+import { MinimalAgent } from "@/chat/agents";
+import { CitationMap, SearchDoc } from "@/chat/contracts/documents";
+import { Packet, StopReason } from "@/chat/streamingModels";
+import type { IconFunctionComponent } from "@/icons/types";
+
+export enum RenderType {
+  HIGHLIGHT = "highlight",
+  FULL = "full",
+  COMPACT = "compact",
+  INLINE = "inline",
+}
+
+// "timeline": parent wraps the result in a StepContainer. "content": renderer carries its own layout.
+export type TimelineLayout = "timeline" | "content";
+
+// Surface behind a timeline step's body; "error" for auth/tool failures.
+export type TimelineSurfaceBackground = "tint" | "transparent" | "error";
+
+export interface RendererResult {
+  icon: IconFunctionComponent | null;
+  status: string | ReactElement | null;
+  content: ReactElement;
+  supportsCollapsible?: boolean;
+  // Collapsible even when it's the only step in the timeline.
+  alwaysCollapsible?: boolean;
+  timelineLayout?: TimelineLayout;
+  // Long-form content (reasoning, deep research, memory) drops right padding.
+  noPaddingRight?: boolean;
+  surfaceBackground?: TimelineSurfaceBackground;
+}
+
+// Single-step renderers return a 1-element array.
+export type RendererOutput = RendererResult[];
+
+// Mobile's subset of web's FullChatState — the context a renderer may read.
+export interface FullChatState {
+  agent: MinimalAgent | null;
+  citations?: CitationMap;
+  documentMap?: Map<string, SearchDoc>;
+  // Opens a cited source (9a); used by later source-row renderers.
+  openSource?: (doc: SearchDoc) => void;
+}
+
+export type MessageRenderer<
+  T extends Packet,
+  S extends Partial<FullChatState>,
+> = ComponentType<{
+  packets: T[];
+  state: S;
+  messageNodeId?: number;
+  // True when timeline/thinking UI is already shown above this block.
+  hasTimelineThinking?: boolean;
+  onComplete: () => void;
+  renderType: RenderType;
+  animate: boolean;
+  stopPacketSeen: boolean;
+  stopReason?: StopReason;
+  // Last step in the timeline (connector-line decisions).
+  isLastStep?: boolean;
+  children: (result: RendererOutput) => ReactElement;
+}>;
+
+// The dispatch surface. `findRenderer` returns this widened form; concrete renderers narrow their packet
+// type internally instead of exposing `any` at the boundary.
+export type DispatchRenderer = MessageRenderer<Packet, FullChatState>;
+
+// RendererResult plus per-step expand/collapse state (produced by TimelineRendererComponent in 9b.5).
+// Present now so the contract is complete; unused until the timeline UI lands.
+export interface TimelineRendererResult extends RendererResult {
+  isExpanded: boolean;
+  onToggle: () => void;
+  renderType: RenderType;
+  isLastStep: boolean;
+  timelineLayout: TimelineLayout;
+}

--- a/mobile/src/hooks/usePacketDisplay.ts
+++ b/mobile/src/hooks/usePacketDisplay.ts
@@ -1,7 +1,6 @@
-// Picks a renderer for a node's packets and derives the processed message state (citations,
-// documents, completion). A full pass over the node's packets runs whenever the array changes; the
-// array's identity changes each stream flush, so this recomputes as packets arrive. Cheap at chat
-// scale — the processor itself stays incremental-capable for 9b, which can host it differently.
+// Derives a node's processed message state (citations, documents, completion) and whether any renderer
+// matches its packets. Reprocesses on each stream flush (packet-array identity changes); cheap at chat
+// scale.
 import { useMemo } from "react";
 
 import { Message } from "@/chat/interfaces";
@@ -11,15 +10,13 @@ import {
   processPackets,
 } from "@/chat/messageProcessor";
 import { Packet } from "@/chat/streamingModels";
-import {
-  findRenderer,
-  MessageRenderer,
-} from "@/components/chat/renderers/registry";
+import { findRenderer } from "@/components/chat/renderers/registry";
 
 export interface PacketDisplay {
-  renderer: MessageRenderer | null;
   packets: Packet[];
   processed: ProcessedMessageState;
+  // Drives the answer-vs-loader gate in MessageRow.
+  hasRenderer: boolean;
 }
 
 export function usePacketDisplay(node: Message): PacketDisplay {
@@ -27,7 +24,10 @@ export function usePacketDisplay(node: Message): PacketDisplay {
     () => processPackets(createInitialState(node.nodeId), node.packets),
     [node.nodeId, node.packets],
   );
-  const renderer = useMemo(() => findRenderer(node.packets), [node.packets]);
+  const hasRenderer = useMemo(
+    () => findRenderer(node.packets) != null,
+    [node.packets],
+  );
 
-  return { renderer, packets: node.packets, processed };
+  return { packets: node.packets, processed, hasRenderer };
 }


### PR DESCRIPTION
## Description

- Adopt web's render-prop `MessageRenderer` contract on mobile (new `timelineContract` / `findRenderer` / `RendererComponent`) and route the final answer through it, so the later timeline and tool renderers are a one-line wire-up on the same seam.
- Migrate `MessageTextRenderer` onto the contract with no change to the shipped answer path (streamed markdown, inline 9a citations, typewriter, loader gating, cited sources).
- This is 9b.4 of the agentic reasoning timeline and lands "dark" — nothing renders differently yet; the timeline itself lights up in 9b.7.

## How Has This Been Tested?

- `tsc`, lint, and jest all green (383 tests, 12 new and mutation-verified); the manual on-device gate (streamed answer + 9a sources unchanged) is still owed.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
