### PR TITLE
fix(helm): let configMap override model server hosts without duplicate keys (chart 0.8.10)

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.9
+version: 0.8.10
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/configmap.yaml
@@ -21,9 +21,15 @@ data:
   # suffix — that suffix is only for RedisReplication CRs).
   REDIS_HOST: {{ .Values.redis.redisStandalone.name | default .Release.Name }}
   {{- end }}
+  {{- /* configMap overrides win (rendered by the range below) — emitting the
+  default too would produce a duplicate YAML key. */}}
+  {{- if not (index .Values.configMap "MODEL_SERVER_HOST") }}
   MODEL_SERVER_HOST: "{{ include "onyx.fullname" . }}-inference-model-service"
+  {{- end }}
   {{- if .Values.vectorDB.enabled }}
+  {{- if not (index .Values.configMap "INDEXING_MODEL_SERVER_HOST") }}
   INDEXING_MODEL_SERVER_HOST: "{{ include "onyx.fullname" . }}-indexing-model-service"
+  {{- end }}
   DISABLE_VECTOR_DB: "false"
   {{- else }}
   DISABLE_VECTOR_DB: "true"

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1471,6 +1471,9 @@ configMap:
   # Leave SANDBOX_PROXY_PORT unset; the chart owns the internal proxy port.
   # SANDBOX_PROXY_HOST defaults to the chart-managed Service DNS name and may be
   # overridden only if sandboxes must reach a different proxy host.
+  # MODEL_SERVER_HOST / INDEXING_MODEL_SERVER_HOST default to the chart-managed
+  # model Services; set them here to point at external model servers instead
+  # (the chart defaults are then not rendered).
   # See deployment/helm/README.md for the external-Redis / ElastiCache path.
 
   # Authentication is always enabled (email/password). SSO (Google/OIDC/SAML)


### PR DESCRIPTION
## Description

A user-reported Helm chart issue: `MODEL_SERVER_HOST` is rendered unconditionally (and `INDEXING_MODEL_SERVER_HOST` whenever `vectorDB.enabled`), and afterwards every entry from `.Values.configMap` is appended. Setting either key via `configMap` therefore rendered a ConfigMap with **duplicate YAML keys** — invalid YAML with parser-dependent behavior:

```yaml
data:
  MODEL_SERVER_HOST: "release-onyx-inference-model-service"
  INDEXING_MODEL_SERVER_HOST: "release-onyx-indexing-model-service"
  ...
  INDEXING_MODEL_SERVER_HOST: "external-indexing-server"
  MODEL_SERVER_HOST: "external-model-server"
```

These two keys are the only chart-computed ConfigMap entries with no override path at all: the other computed hosts (`POSTGRES_HOST`, `OPENSEARCH_HOST`, `REDIS_HOST`, `S3_ENDPOINT_URL`, …) disappear when the corresponding subchart is disabled, but `MODEL_SERVER_HOST` has no toggle and `INDEXING_MODEL_SERVER_HOST` is tied to `vectorDB.enabled`, which controls far more than the model service.

Fix: skip the chart-computed default when the key is set (non-empty) in `.Values.configMap`, so the user value renders exactly once and deployments can point at external inference/indexing model servers. Also documents the override in the `configMap:` comment block in `values.yaml` and bumps the chart to 0.8.10.

No behavior change when the keys are not set — the defaults render exactly as before (verified none of the bundled values files set them).

## How Has This Been Tested?

- `helm template` without overrides: defaults render unchanged.
- `helm template` with both keys set via `--set configMap....`: each key renders exactly once with the user value; full manifest passes a strict YAML parse that rejects duplicate keys.
- Partial override (only `INDEXING_MODEL_SERVER_HOST`) and `vectorDB.enabled=false` edge cases render correctly.
- `helm lint` passes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow overriding `MODEL_SERVER_HOST` and `INDEXING_MODEL_SERVER_HOST` via `configMap` without emitting duplicate keys. Ensures valid YAML and supports pointing to external model servers.

- **Bug Fixes**
  - Skip chart defaults when `configMap.MODEL_SERVER_HOST` or `configMap.INDEXING_MODEL_SERVER_HOST` is set; keep defaults when unset.
  - Preserve `INDEXING_MODEL_SERVER_HOST` behavior with `vectorDB.enabled`; partial overrides render correctly.
  - Document override in `values.yaml`; bump chart to 0.8.10.

<sup>Written for commit b838ba8d5f1a31a99fd9c7bcef434e39fd832e52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

