### PR TITLE
feat(cli): keep the TUI up while Docker Desktop starts

### DIFF
--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -36,6 +36,10 @@ const (
 	minComposeVersion  = "2.24.0"
 	failureLogTail     = 30
 
+	// dockerDesktopWait bounds the wait for the macOS daemon to answer, and so
+	// also bounds how long its spinner can turn with nothing else on screen.
+	dockerDesktopWait = 120 * time.Second
+
 	// s3FilestoreProfile is the COMPOSE_PROFILES entry that runs MinIO: on in
 	// standard mode, off in lite. It is the only entry the CLI owns.
 	s3FilestoreProfile = "s3-filestore"
@@ -685,9 +689,9 @@ func (in *installer) resolveDockerProblems(ctx context.Context, pre preflight) e
 
 	if !in.docker.DaemonRunning(ctx) {
 		if runtime.GOOS == "darwin" {
-			in.infof("Docker daemon is not running. Starting Docker Desktop...")
-			if err := in.suspend(func() error {
-				return dockercmd.StartDockerDesktopDarwin(ctx, in.docker, in.deps.IOS.Out, 120*time.Second)
+			in.infof("Docker daemon is not running.")
+			if err := in.runTask("Starting Docker Desktop", func(progress io.Writer) error {
+				return dockercmd.StartDockerDesktopDarwin(ctx, in.docker, progress, dockerDesktopWait)
 			}); err != nil {
 				return exitcodes.Newf(exitcodes.General, "%v", err)
 			}

--- a/cli/internal/deploy/install/options.go
+++ b/cli/internal/deploy/install/options.go
@@ -5,6 +5,7 @@ package install
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/dockercmd"
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/paths"
@@ -315,4 +316,21 @@ func (in *installer) suspend(fn func() error) error {
 		return in.wiz.Suspend(fn)
 	}
 	return fn()
+}
+
+// runTask shows fn as a spinner phase rather than releasing the screen for it,
+// for steps that neither prompt nor report progress worth reading — the only
+// two things suspend() buys. Their narration ("Waiting for X to start...",
+// once every couple of seconds) is what the spinner and its elapsed counter
+// say instead, so under the wizard it is dropped rather than written to a
+// screen the wizard has taken over.
+func (in *installer) runTask(label string, fn func(progress io.Writer) error) error {
+	if in.wiz == nil || in.opts.Verbose {
+		in.infof("%s...", label)
+		return fn(in.deps.IOS.Out)
+	}
+	in.wiz.TaskStart(label)
+	err := fn(io.Discard)
+	in.wiz.TaskDone(err == nil)
+	return err
 }


### PR DESCRIPTION
## Description

When `onyx-cli deploy install` finds the Docker daemon down on macOS, it launches Docker Desktop and polls for up to two minutes. That poll ran inside `Wizard.Suspend`, so the installer tore down its full-screen UI and printed `Waiting for Docker Desktop to start...` every couple of seconds until the daemon answered — then brought the wizard back.

That's narration the wizard's own spinner and elapsed counter already give, so this runs the step as a wizard task instead. You now stay in the UI and watch `⠋ Starting Docker Desktop (37s)` count up, followed by a `✓` note when the daemon answers.

- `runTask` (`options.go`) is `suspend`'s counterpart for steps that neither prompt nor report progress worth reading — the only two things suspending the screen buys. Under the wizard it's `TaskStart` → run → `TaskDone` with the step's progress writer pointed at `io.Discard`; with no wizard, or under `--verbose`, it prints the label and streams to stdout exactly as before.
- The 120s bound is now a named `dockerDesktopWait` const, since it's the only thing capping how long the spinner can turn.
- `dockercmd` is untouched: `StartDockerDesktopDarwin` already took a `progress io.Writer` and just gets a different one.

**The three Linux provisioning paths deliberately keep suspending.** `sudo` reads its password straight from `/dev/tty`, not stdin, so under the alt screen in raw mode the prompt is invisible and the keystrokes get eaten — the install would hang on a spinner with no way to know why. Making those work in-TUI needs `sudo -n`/`sudo -v` pre-auth plus a stall watchdog, which isn't worth the new failure modes on a flow that runs once per machine.

No behavior change off macOS, and none when the daemon is already up.

## How Has This Been Tested?

- `go build ./...`, `go vet ./internal/deploy/...`, `go test ./internal/deploy/...` — all pass.
- `pre-commit run --files` on both touched files (golangci-lint) — passes.

Not tested on a real Mac — this was written in a Linux devcontainer, and the changed branch is `runtime.GOOS == "darwin"`-gated with Docker Desktop installed but stopped. The existing suite has no coverage of that path either (the wizard isn't driven in tests), so no test was added. Worth one manual check on macOS before merge: stop Docker Desktop, run `onyx-cli deploy install`, confirm the spinner appears and the `✓` lands.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the installer TUI visible while starting Docker Desktop on macOS. The wizard now shows a spinner with elapsed time instead of dropping to the console; no changes on Linux or when the daemon is already running.

- **Refactors**
  - Added runTask to run non-interactive steps as wizard tasks; falls back to stdout when no wizard or with --verbose.
  - Introduced dockerDesktopWait (120s) to bound macOS daemon wait and spinner duration.
  - Linux provisioning continues to use suspend due to sudo TTY prompts.

<sup>Written for commit f2590be30a59c4b330ec74b8f7a57e9d3d940abd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

