### PR TITLE
fix(llm): degrade and retry provider-rejected reasoning params (backport of #13378 to release/v4.4)

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -99,6 +99,36 @@ _VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG = (
 # still advertises temperature as supported).
 _ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION = (4, 7)
 
+# Best-effort tuning kwargs, never worth failing a chat over. _completion
+# retries provider rejections without them: reasoning keys first, then all.
+# Semantics-changing keys (tools, tool_choice, messages) are never stripped.
+_REASONING_KWARG_KEYS = frozenset(
+    {"thinking", "output_config", "reasoning", "reasoning_effort"}
+)
+_BEST_EFFORT_KWARG_KEYS = _REASONING_KWARG_KEYS | frozenset({"temperature"})
+
+# Substrings provider 400s use to name each strippable kwarg (errors may
+# cite only inner fields like budget_tokens or effort).
+_KWARG_ERROR_ALIASES: dict[str, tuple[str, ...]] = {
+    "thinking": ("thinking", "budget_tokens"),
+    "output_config": ("output_config", "effort"),
+    "reasoning": ("reasoning", "effort"),
+    "reasoning_effort": ("reasoning_effort", "effort"),
+    "temperature": ("temperature",),
+}
+
+
+def _rejection_names_strippable_kwargs(error: Exception, strippable: set[str]) -> bool:
+    """True when the 400's message names a kwarg a later attempt would drop.
+    Unrelated 400s (context length, malformed input) must not be retried."""
+    message = str(error).lower()
+    return any(
+        alias in message
+        for key in strippable
+        for alias in _KWARG_ERROR_ALIASES.get(key, (key,))
+    )
+
+
 # Named tiers spanning Claude's naming schemes, including the Claude 5 line whose
 # version digit can precede or follow the tier ("claude-sonnet-5" vs
 # "claude-5-sonnet").
@@ -542,7 +572,7 @@ class LitellmLLM(LLM):
         client: "HTTPHandler | None" = None,
     ) -> Union["ModelResponse", "CustomStreamWrapper"]:
         # Lazy loading to avoid memory bloat for non-inference flows
-        from litellm.exceptions import RateLimitError, Timeout
+        from litellm.exceptions import BadRequestError, RateLimitError, Timeout
 
         from onyx.llm.litellm_singleton import litellm
 
@@ -841,23 +871,54 @@ class LitellmLLM(LLM):
             if tools and tool_choice is not None:
                 optional_kwargs["tool_choice"] = tool_choice
 
-            with temporary_env_and_lock(self._custom_config or {}):
-                response = litellm.completion(
-                    mock_response=get_llm_mock_response() or MOCK_LLM_RESPONSE,
-                    model=model,
-                    base_url=self._api_base or None,
-                    api_version=api_version,
-                    custom_llm_provider=self._custom_llm_provider or None,
-                    messages=messages,
-                    tools=tools,
-                    stream=stream,
-                    timeout=timeout_override or self._timeout,
-                    max_tokens=max_tokens,
-                    client=client,
-                    **optional_kwargs,
-                    **passthrough_kwargs,
-                )
-            return response
+            def _call_litellm(opts: dict[str, Any]) -> Any:
+                # Built per attempt because the context manager is single-use.
+                with temporary_env_and_lock(self._custom_config or {}):
+                    return litellm.completion(
+                        mock_response=get_llm_mock_response() or MOCK_LLM_RESPONSE,
+                        model=model,
+                        base_url=self._api_base or None,
+                        api_version=api_version,
+                        custom_llm_provider=self._custom_llm_provider or None,
+                        messages=messages,
+                        tools=tools,
+                        stream=stream,
+                        timeout=timeout_override or self._timeout,
+                        max_tokens=max_tokens,
+                        client=client,
+                        **opts,
+                        **passthrough_kwargs,
+                    )
+
+            # Retry ladder for provider 400s: drop reasoning kwargs, then every
+            # best-effort kwarg. Unknown models or capability drift degrade to
+            # provider defaults with a warning instead of failing the message.
+            attempts = [optional_kwargs]
+            for strip_keys in (_REASONING_KWARG_KEYS, _BEST_EFFORT_KWARG_KEYS):
+                stripped = {
+                    k: v for k, v in optional_kwargs.items() if k not in strip_keys
+                }
+                if len(stripped) < len(attempts[-1]):
+                    attempts.append(stripped)
+
+            for i, opts in enumerate(attempts):
+                try:
+                    return _call_litellm(opts)
+                except BadRequestError as e:
+                    if i == len(attempts) - 1:
+                        raise
+                    # Only retry rejections a later attempt can strip away.
+                    remaining_strippable = set(opts) - set(attempts[-1])
+                    if not _rejection_names_strippable_kwargs(e, remaining_strippable):
+                        raise
+                    logger.warning(
+                        "Provider rejected request for model %s. Retrying "
+                        "without %s: %s",
+                        model,
+                        sorted(set(opts) - set(attempts[i + 1])),
+                        e,
+                    )
+            raise RuntimeError("unreachable: retry ladder always returns or raises")
         except Exception as e:
             # for break pointing
             if isinstance(e, Timeout):

--- a/backend/tests/unit/onyx/llm/test_reasoning_param_fallback.py
+++ b/backend/tests/unit/onyx/llm/test_reasoning_param_fallback.py
@@ -1,0 +1,174 @@
+"""Guards the degrade-and-retry behavior for provider-rejected reasoning params."""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from litellm.exceptions import BadRequestError, RateLimitError
+
+from onyx.llm.models import ReasoningEffort, UserMessage
+from onyx.llm.multi_llm import LitellmLLM, LLMRateLimitError
+
+_SENTINEL = object()
+
+
+def _make_llm(
+    model_name: str = "claude-sonnet-5", model_provider: str = "anthropic"
+) -> LitellmLLM:
+    return LitellmLLM(
+        api_key="test-key",
+        model_provider=model_provider,
+        model_name=model_name,
+        max_input_tokens=100000,
+    )
+
+
+def _bad_request(message: str = "effort not supported") -> BadRequestError:
+    return BadRequestError(message=message, model="m", llm_provider="anthropic")
+
+
+def _run(
+    llm: LitellmLLM, completion: Any, effort: ReasoningEffort, stream: bool = False
+) -> Any:
+    with patch("onyx.llm.litellm_singleton.litellm.completion", side_effect=completion):
+        return llm._completion(
+            prompt=[UserMessage(content="hello")],
+            tools=None,
+            tool_choice=None,
+            stream=stream,
+            parallel_tool_calls=False,
+            reasoning_effort=effort,
+        )
+
+
+def test_rejected_reasoning_params_are_stripped_and_retried() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        if "thinking" in kwargs or "output_config" in kwargs:
+            raise _bad_request()
+        return _SENTINEL
+
+    result = _run(_make_llm(), completion, ReasoningEffort.HIGH)
+
+    assert result is _SENTINEL
+    assert len(calls) == 2
+    assert "thinking" in calls[0] or "output_config" in calls[0]
+    for key in ("thinking", "output_config", "reasoning", "reasoning_effort"):
+        assert key not in calls[1]
+
+
+def test_bad_request_without_reasoning_params_raises() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        raise _bad_request("bad prompt")
+
+    # OFF sends no reasoning kwargs and claude-sonnet-5 omits temperature,
+    # so nothing is strippable.
+    with pytest.raises(BadRequestError):
+        _run(_make_llm(), completion, ReasoningEffort.OFF)
+    assert len(calls) == 1
+
+
+def test_bad_request_after_strip_propagates() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        raise _bad_request("thinking is not supported on this endpoint")
+
+    with pytest.raises(BadRequestError):
+        _run(_make_llm(), completion, ReasoningEffort.HIGH)
+    assert len(calls) == 2
+
+
+def test_unrelated_bad_request_is_not_retried() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        raise _bad_request("prompt is too long: 250000 tokens > 200000 maximum")
+
+    # The 400 names no strippable kwarg, so the ladder must not burn retries.
+    with pytest.raises(BadRequestError):
+        _run(_make_llm(), completion, ReasoningEffort.HIGH)
+    assert len(calls) == 1
+
+
+def test_ladder_strips_reasoning_then_all_best_effort_kwargs() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        if "reasoning" in kwargs:
+            raise _bad_request("reasoning is not supported with this model")
+        if "temperature" in kwargs:
+            raise _bad_request("temperature is not supported with this model")
+        return _SENTINEL
+
+    # gpt-5.4 sets both a reasoning kwarg and temperature, exercising the
+    # full three-attempt ladder.
+    result = _run(
+        _make_llm(model_name="gpt-5.4", model_provider="openai"),
+        completion,
+        ReasoningEffort.HIGH,
+    )
+
+    assert result is _SENTINEL
+    assert len(calls) == 3
+    assert "reasoning" in calls[0] and "temperature" in calls[0]
+    assert "reasoning" not in calls[1] and "temperature" in calls[1]
+    assert "reasoning" not in calls[2] and "temperature" not in calls[2]
+
+
+def test_rejected_sampling_params_retry_without_reasoning_tier() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        if "temperature" in kwargs:
+            raise _bad_request("temperature not supported")
+        return _SENTINEL
+
+    # A non-reasoning model sends temperature but no reasoning kwargs, so the
+    # ladder has exactly one fallback step.
+    result = _run(
+        _make_llm(model_name="gpt-4.1", model_provider="openai"),
+        completion,
+        ReasoningEffort.AUTO,
+    )
+
+    assert result is _SENTINEL
+    assert len(calls) == 2
+    assert "temperature" in calls[0]
+    assert "temperature" not in calls[1]
+
+
+def test_stream_options_rejection_is_not_retried() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        raise _bad_request("stream_options is not supported with this model")
+
+    # Only reasoning kwargs and temperature are strippable, so a 400 naming
+    # stream_options surfaces immediately.
+    with pytest.raises(BadRequestError):
+        _run(_make_llm(), completion, ReasoningEffort.OFF, stream=True)
+    assert len(calls) == 1
+    assert "stream_options" in calls[0]
+
+
+def test_rate_limit_is_not_retried() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        raise RateLimitError(message="slow down", model="m", llm_provider="anthropic")
+
+    with pytest.raises(LLMRateLimitError):
+        _run(_make_llm(), completion, ReasoningEffort.HIGH)
+    assert len(calls) == 1


### PR DESCRIPTION
## Description

Backports the provider-rejection retry ladder from #13378 to `release/v4.4`.

A self-hosted deployment on v4.4.6 hits hard failures on Azure OpenAI gpt-5.6 models (terra/luna/sol): Azure's `/openai/v1/responses` surface returns `400 unsupported_parameter` for `reasoning.effort` on those deployments even though the litellm registry (and Azure's own docs) say the family supports it. On the v4.4 line the 400 fails the entire chat message; on main, #13378's fallback strips the reasoning kwargs and retries, degrading to provider defaults.

This is a partial port — only the resilience mechanism:
- `_REASONING_KWARG_KEYS` / `_BEST_EFFORT_KWARG_KEYS` / `_KWARG_ERROR_ALIASES` + `_rejection_names_strippable_kwargs`
- the attempts ladder around `litellm.completion` in `_completion` (adapted to v4.4's `temporary_env_and_lock` call shape)
- the `test_reasoning_param_fallback.py` unit suite (XHIGH case adjusted to HIGH; that enum value doesn't exist on v4.4)

Deliberately excluded: the per-session reasoning-effort override feature + migration from #13378, and the `record_llm_request_params` tracing call (helper absent on v4.4).

## How Has This Been Tested?

- `tests/unit/onyx/llm/test_reasoning_param_fallback.py` — 8/8 pass on this branch
- Full `tests/unit/onyx/llm/` + `tests/unit/onyx/chat/` — 798 pass
- pre-commit clean on touched files

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backport the reasoning-param fallback to `release/v4.4` so chats don’t fail when providers reject these params. On provider 400s that name unsupported reasoning or temperature options, we strip them and retry, fixing failures on some Azure OpenAI gpt-5.6 deployments.

- **Bug Fixes**
  - Added a retry ladder around `litellm.completion`: first drop `thinking`, `output_config`, `reasoning`, `reasoning_effort`; then drop `temperature`.
  - Only retry when the 400 message names a strippable key; unrelated 400s and rate limits surface immediately.
  - Added unit tests for the fallback path and non-retry cases.

<sup>Written for commit 8561b5d1b0488c5f666702c9be293cf72f943bde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

