### PR TITLE
ci(golang): run go tests with the race detector

### DIFF
--- a/.github/workflows/pr-golang-tests.yml
+++ b/.github/workflows/pr-golang-tests.yml
@@ -53,5 +53,5 @@ jobs:
       - run: git diff --exit-code go.mod go.sum
         working-directory: ${{ matrix.modules }}
 
-      - run: go test ./...
+      - run: go test -race ./...
         working-directory: ${{ matrix.modules }}

--- a/cli/internal/deploy/install/install_test.go
+++ b/cli/internal/deploy/install/install_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,13 +19,19 @@ import (
 	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
 )
 
-// fakeRunner scripts every external command RunInstall issues.
+// fakeRunner scripts every external command RunInstall issues. The installer
+// runs commands from concurrent goroutines (preflight, tag fallback), so Run
+// serializes itself — including the handler, which tests write as closures
+// over unsynchronized locals.
 type fakeRunner struct {
+	mu      sync.Mutex
 	calls   []dockercmd.Command
 	handler func(c dockercmd.Command) (dockercmd.Result, error)
 }
 
 func (f *fakeRunner) Run(_ context.Context, c dockercmd.Command) (dockercmd.Result, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.calls = append(f.calls, c)
 	if f.handler != nil {
 		return f.handler(c)


### PR DESCRIPTION
## Summary

- Run `go test -race ./...` in the Golang Tests workflow so data races are caught on every PR.
- Fix the one race this immediately surfaces: `fakeRunner` in `cli/internal/deploy/install` recorded calls without synchronization while the installer legitimately invokes its runner from concurrent goroutines (preflight probe + tag fallback). The fake now serializes `Run` — including the scripted handler, since tests write handlers as closures over unsynchronized locals.

## Cost

Measured locally: `cli` ~2s → ~7s, `tools/ods` ~25s → ~67s. Both fit comfortably in the job's 10-minute timeout. `-race` needs cgo + a C toolchain, which `ubuntu-latest` provides; the workflow never sets `CGO_ENABLED=0`.

Other Go sanitizers (`-asan`, `-msan`) were considered and skipped: they only catch memory errors in cgo/`unsafe` code, and neither module uses cgo.

## Test plan

- `go test -race ./...` passes in both `cli` and `tools/ods` (the `tools/ods/internal/git` failures seen in the devcontainer are a local git-signing config artifact, present without `-race` too)
- `go test -race -count=5 ./internal/deploy/install/` passes (previously racy package, stressed)
- pre-commit (zizmor, actionlint, golangci-lint) passes on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the Go race detector in CI and fix a test-only data race in the installer fake. This catches concurrent access issues in PRs and makes tests deterministic.

- **New Features**
  - CI runs `go test -race ./...` for all Go modules.

- **Bug Fixes**
  - `cli/internal/deploy/install`: serialize `fakeRunner.Run` with a mutex (including handler closures) to handle concurrent command invocations.

<sup>Written for commit 4d51005c96e2c3b06268c8e5dfe6ef576eb7937f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

