### PR TITLE
fix(files): transcode vision-unsupported embedded images (TIFF) to PNG

### DIFF
--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -393,12 +393,24 @@ def read_pdf_file(
                         break
 
                     image = Image.open(io.BytesIO(image_file_object.data))
+                    # Store in a format vision APIs and browsers accept —
+                    # scanned PDFs typically embed pages as CCITT TIFFs.
+                    image_format = (
+                        image.format
+                        if image.format in ("PNG", "JPEG", "GIF", "WEBP")
+                        else "PNG"
+                    )
                     img_byte_arr = io.BytesIO()
-                    image.save(img_byte_arr, format=image.format)
+                    try:
+                        image.save(img_byte_arr, format=image_format)
+                    except (OSError, ValueError):
+                        # Modes the target format can't store (e.g. CMYK)
+                        image_format = "PNG"
+                        img_byte_arr = io.BytesIO()
+                        image.convert("RGB").save(img_byte_arr, format=image_format)
                     img_bytes = img_byte_arr.getvalue()
 
-                    image_format = image.format.lower() if image.format else "png"
-                    image_name = f"page_{page_num + 1}_image_{image_file_object.name}.{image_format}"
+                    image_name = f"page_{page_num + 1}_image_{image_file_object.name}.{image_format.lower()}"
                     if image_callback is not None:
                         # Stream image out immediately
                         image_callback(img_bytes, image_name)

--- a/backend/onyx/file_processing/image_summarization.py
+++ b/backend/onyx/file_processing/image_summarization.py
@@ -21,7 +21,7 @@ from onyx.llm.utils import llm_response_to_string
 from onyx.server.metrics.image_processing import track_image_summarization
 from onyx.tracing.flows import LLMFlow
 from onyx.tracing.llm_utils import llm_generation_span, record_llm_response
-from onyx.utils.b64 import get_image_type_from_bytes
+from onyx.utils.b64 import normalize_image_for_llm
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -164,9 +164,13 @@ def _summarize_image(
 
 
 def _encode_image_for_llm_prompt(image_data: bytes) -> str:
-    """Prepare a data URL with the correct MIME type for the LLM message."""
+    """Prepare a data URL with the correct MIME type for the LLM message.
+
+    Transcodes formats vision APIs reject (e.g. TIFF page images already
+    stored by older extraction code) to PNG rather than failing them.
+    """
     try:
-        mime_type = get_image_type_from_bytes(image_data)
+        image_data, mime_type = normalize_image_for_llm(image_data)
     except ValueError as exc:
         raise UnsupportedImageFormatError(
             "Unsupported image format for summarization"

--- a/backend/onyx/utils/b64.py
+++ b/backend/onyx/utils/b64.py
@@ -23,3 +23,37 @@ def get_image_type_from_bytes(raw_b64_bytes: bytes) -> str:
 def get_image_type(raw_b64_string: str) -> str:
     binary_data = base64.b64decode(raw_b64_string)
     return get_image_type_from_bytes(binary_data)
+
+
+def normalize_image_for_llm(image_data: bytes) -> tuple[bytes, str]:
+    """Return image bytes and MIME type in a vision-LLM-supported format.
+
+    Vision APIs accept only PNG/JPEG/GIF/WEBP, but document extraction can
+    surface other formats — scanned PDFs typically embed their pages as
+    CCITT-compressed TIFFs. Anything PIL can decode is transcoded to PNG;
+    undecodable data raises ValueError like get_image_type_from_bytes.
+    """
+    try:
+        return image_data, get_image_type_from_bytes(image_data)
+    except ValueError:
+        pass
+
+    import io
+
+    from PIL import Image
+
+    try:
+        with Image.open(io.BytesIO(image_data)) as img:
+            output = io.BytesIO()
+            try:
+                img.save(output, format="PNG")
+            except (OSError, ValueError):
+                # Modes PNG can't store directly (e.g. CMYK)
+                output = io.BytesIO()
+                img.convert("RGB").save(output, format="PNG")
+    except Exception as exc:
+        raise ValueError(
+            "Unsupported image format - could not identify or transcode to PNG."
+        ) from exc
+
+    return output.getvalue(), "image/png"

--- a/backend/tests/unit/onyx/file_processing/test_image_normalization.py
+++ b/backend/tests/unit/onyx/file_processing/test_image_normalization.py
@@ -1,0 +1,89 @@
+"""Transcoding of vision-API-unsupported image formats (e.g. scanned-PDF TIFFs).
+
+Scanned PDFs embed their pages as 1-bit CCITT TIFFs; vision APIs only accept
+PNG/JPEG/GIF/WEBP. These tests pin the normalize-to-PNG behavior end to end:
+the helper itself, the summarization encode path, and the wrapper no longer
+silently skipping such images.
+"""
+
+import io
+from unittest.mock import MagicMock
+
+import pytest
+from PIL import Image
+
+from onyx.file_processing.image_summarization import (
+    _encode_image_for_llm_prompt,
+    summarize_image_with_error_handling,
+)
+from onyx.utils.b64 import get_image_type_from_bytes, normalize_image_for_llm
+
+
+def _make_image_bytes(mode: str, fmt: str, size: tuple[int, int] = (40, 40)) -> bytes:
+    buf = io.BytesIO()
+    Image.new(mode, size, color=1 if mode == "1" else 0).save(buf, format=fmt)
+    return buf.getvalue()
+
+
+def test_bilevel_tiff_is_transcoded_to_png() -> None:
+    # Mode "1" TIFF mirrors what scanned-PDF extraction produces.
+    tiff_bytes = _make_image_bytes("1", "TIFF")
+    with pytest.raises(ValueError):
+        get_image_type_from_bytes(tiff_bytes)
+
+    normalized, mime_type = normalize_image_for_llm(tiff_bytes)
+
+    assert mime_type == "image/png"
+    assert get_image_type_from_bytes(normalized) == "image/png"
+    with Image.open(io.BytesIO(normalized)) as img:
+        assert img.format == "PNG"
+        assert img.size == (40, 40)
+
+
+def test_supported_formats_pass_through_unchanged() -> None:
+    png_bytes = _make_image_bytes("RGB", "PNG")
+
+    normalized, mime_type = normalize_image_for_llm(png_bytes)
+
+    assert normalized is png_bytes
+    assert mime_type == "image/png"
+
+
+def test_cmyk_tiff_converts_via_rgb() -> None:
+    # PNG can't store CMYK — the helper must fall back to an RGB convert.
+    cmyk_bytes = _make_image_bytes("CMYK", "TIFF")
+
+    normalized, mime_type = normalize_image_for_llm(cmyk_bytes)
+
+    assert mime_type == "image/png"
+    with Image.open(io.BytesIO(normalized)) as img:
+        assert img.format == "PNG"
+        assert img.mode == "RGB"
+
+
+def test_undecodable_bytes_raise_value_error() -> None:
+    with pytest.raises(ValueError):
+        normalize_image_for_llm(b"\x00\x01\x02\x03 not an image")
+
+
+def test_encode_for_llm_prompt_transcodes_tiff() -> None:
+    tiff_bytes = _make_image_bytes("1", "TIFF")
+
+    data_url = _encode_image_for_llm_prompt(tiff_bytes)
+
+    assert data_url.startswith("data:image/png;base64,")
+
+
+def test_summarize_wrapper_no_longer_skips_tiff() -> None:
+    # Before the transcode fix this returned None (silent skip); the LLM must
+    # now actually be invoked and its summary returned.
+    tiff_bytes = _make_image_bytes("1", "TIFF")
+    mock_llm = MagicMock()
+    mock_llm.invoke.return_value.choice.message.content = "a scanned page"
+
+    result = summarize_image_with_error_handling(
+        llm=mock_llm, image_data=tiff_bytes, context_name="page_1.tiff"
+    )
+
+    assert mock_llm.invoke.called
+    assert result is not None


### PR DESCRIPTION
## Description

Scanned PDFs embed their pages as 1-bit CCITT **TIFF** images. Two compounding gaps made every such page silently unusable:

1. PDF extraction re-saves embedded images in their original format (`image.save(..., format=image.format)`) — TIFF stays TIFF.
2. The summarization path's magic-byte sniff (`get_image_type_from_bytes`) only recognizes PNG/JPEG/GIF/WEBP, so each page image raises `UnsupportedImageFormatError`, which `summarize_image_with_error_handling` treats as a silent per-image skip.

Net effect: a scanned 32-page PDF "indexes" as 32 `[Image could not be summarized]` placeholders in ~8 seconds, even with a healthy vision LLM configured — the model then tells the user it can't read the document. Hit in the wild by a customer on v4.4.6 (scanned patent document); PIL decodes these TIFFs without issue, we just refused to send them.

Fix, two layers:
- **`normalize_image_for_llm` (`onyx/utils/b64.py`)** — sniff first (supported formats pass through untouched); anything else PIL can decode is transcoded to PNG, with an RGB-convert fallback for modes PNG can't store (e.g. CMYK). `_encode_image_for_llm_prompt` now uses it, so **already-stored** TIFF blobs summarize correctly without reprocessing.
- **PDF extraction** stores embedded images in a supported format going forward (keeps PNG/JPEG/GIF/WEBP as-is, converts the rest to PNG) — also makes the stored files renderable in the browser preview.

Verified end-to-end against the affected deployment's actual stored page image: TIFF → PNG transcode + `summarize_image_pipeline` through the customer's Azure Foundry claude-sonnet-4-6 returns a real page summary where the pipeline previously emitted a placeholder.

## How Has This Been Tested?

- New unit suite `tests/unit/onyx/file_processing/test_image_normalization.py` (6 tests): bilevel-TIFF transcode, supported-format passthrough, CMYK fallback, undecodable rejection, data-URL encode, and the wrapper no longer silently skipping TIFFs.
- Full `tests/unit/onyx/file_processing/` suite passes (106).
- Live verification on the affected v4.4.6 deployment as described above.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Transcodes vision-unsupported embedded images (e.g., TIFF from scanned PDFs) to PNG so image summarization works and previews render. Prevents silent skips and “[Image could not be summarized]” placeholders for scanned pages, covering both new extractions and previously stored blobs.

- **Bug Fixes**
  - Added `normalize_image_for_llm` in `onyx/utils/b64.py`: pass through PNG/JPEG/GIF/WEBP; transcode others via `PIL` to PNG with RGB fallback; `_encode_image_for_llm_prompt` now uses it.
  - Updated PDF image extraction to store supported formats: keep PNG/JPEG/GIF/WEBP as-is; convert others (e.g., TIFF) to PNG; handles CMYK with RGB convert.
  - Added unit tests in `tests/unit/onyx/file_processing/test_image_normalization.py` to cover transcode, passthrough, fallback, and wrapper behavior.

<sup>Written for commit de507ff34648b08229c83e5c784901395323912f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

