### PR TITLE
[ENH] Add Google Chat connector

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -226,6 +226,7 @@ class DocumentSource(str, Enum):
     SLACK = "slack"
     WEB = "web"
     GOOGLE_DRIVE = "google_drive"
+    GOOGLE_CHAT = "google_chat"
     GMAIL = "gmail"
     GITHUB = "github"
     GITBOOK = "gitbook"
@@ -726,6 +727,7 @@ DocumentSourceDescription: dict[DocumentSource, str] = {
     DocumentSource.SLACK: "Team messages and channel discussions",
     DocumentSource.WEB: "Indexed web pages",
     DocumentSource.GOOGLE_DRIVE: "Documents, spreadsheets, and presentations",
+    DocumentSource.GOOGLE_CHAT: "Messages and conversations in Google Chat spaces",
     DocumentSource.GMAIL: "Email conversations and threads",
     DocumentSource.GITHUB: "Pull requests, issues, and code reviews",
     DocumentSource.GITBOOK: "Documentation and knowledge base pages",

--- a/backend/onyx/connectors/google_chat/__init__.py
+++ b/backend/onyx/connectors/google_chat/__init__.py
@@ -1,0 +1,1 @@
+"""Google Chat connector."""

--- a/backend/onyx/connectors/google_chat/connector.py
+++ b/backend/onyx/connectors/google_chat/connector.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from typing import Any, Protocol, cast
+
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.exceptions import CredentialInvalidError
+from onyx.connectors.interfaces import (
+    GenerateDocumentsOutput,
+    LoadConnector,
+    PollConnector,
+    SecondsSinceUnixEpoch,
+)
+from onyx.connectors.models import (
+    BasicExpertInfo,
+    ConnectorMissingCredentialError,
+    Document,
+    HierarchyNode,
+    TextSection,
+)
+
+_GOOGLE_CHAT_SCOPES = (
+    "https://www.googleapis.com/auth/chat.bot",
+    "https://www.googleapis.com/auth/chat.app.messages.readonly",
+)
+_GOOGLE_CHAT_DOC_ID_PREFIX = "GOOGLE_CHAT_"
+_GOOGLE_CHAT_PAGE_SIZE = 1000
+_SNIPPET_LENGTH = 80
+
+
+class _ExecutableRequest(Protocol):
+    def execute(self) -> dict[str, Any]: ...
+
+
+class _GoogleChatMessagesResource(Protocol):
+    def list(
+        self,
+        *,
+        parent: str,
+        pageSize: int,
+        pageToken: str | None,
+        filter: str | None,
+        orderBy: str,
+    ) -> _ExecutableRequest: ...
+
+
+class _GoogleChatSpacesResource(Protocol):
+    def list(
+        self,
+        *,
+        pageSize: int,
+        pageToken: str | None = None,
+    ) -> _ExecutableRequest: ...
+
+    def messages(self) -> _GoogleChatMessagesResource: ...
+
+
+class _GoogleChatService(Protocol):
+    def spaces(self) -> _GoogleChatSpacesResource: ...
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _format_timestamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _message_link(space_name: str) -> str:
+    space_id = space_name.removeprefix("spaces/")
+    return f"https://chat.google.com/room/{space_id}"
+
+
+def _message_to_document(message: dict[str, Any], space: dict[str, Any]) -> Document:
+    message_name = str(message["name"])
+    space_name = str(space["name"])
+    space_display_name = str(space.get("displayName") or space_name)
+    sender = message.get("sender") or {}
+    sender_name = str(sender.get("displayName") or "Google Chat user")
+    text = str(message.get("text") or message.get("formattedText") or "").strip()
+    snippet = text[:_SNIPPET_LENGTH].rstrip()
+    if len(text) > _SNIPPET_LENGTH:
+        snippet += "..."
+
+    metadata: dict[str, str | list[str]] = {
+        "Space": space_display_name,
+        "Sender": sender_name,
+    }
+    thread_name = str((message.get("thread") or {}).get("name") or "")
+    if thread_name:
+        metadata["Thread"] = thread_name
+
+    return Document(
+        id=f"{_GOOGLE_CHAT_DOC_ID_PREFIX}{message_name}",
+        source=DocumentSource.GOOGLE_CHAT,
+        semantic_identifier=f"{sender_name} in {space_display_name}: {snippet}",
+        title=space_display_name,
+        sections=[
+            TextSection(
+                text=text,
+                link=_message_link(space_name),
+            )
+        ],
+        metadata=metadata,
+        doc_created_at=_parse_timestamp(message.get("createTime")),
+        doc_updated_at=_parse_timestamp(
+            message.get("lastUpdateTime") or message.get("createTime")
+        ),
+        primary_owners=[BasicExpertInfo(display_name=sender_name)],
+    )
+
+
+class GoogleChatConnector(PollConnector, LoadConnector):
+    def __init__(
+        self,
+        space_names: list[str] = [],
+        start_date: str | None = None,
+        batch_size: int = INDEX_BATCH_SIZE,
+    ) -> None:
+        self.space_names = {
+            name.strip().casefold() for name in space_names if name.strip()
+        }
+        self.start_date = (
+            datetime.strptime(start_date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+            if start_date
+            else None
+        )
+        self.batch_size = batch_size
+        self._service_account_info: dict[str, Any] | None = None
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        raw_service_account = credentials.get("google_chat_service_account_secret")
+        if isinstance(raw_service_account, str):
+            try:
+                service_account_info = json.loads(raw_service_account)
+            except json.JSONDecodeError as error:
+                raise CredentialInvalidError(
+                    "Google Chat service account key must be valid JSON."
+                ) from error
+        elif isinstance(raw_service_account, dict):
+            service_account_info = raw_service_account
+        else:
+            raise CredentialInvalidError(
+                "Google Chat service account key must be a JSON object."
+            )
+
+        self._service_account_info = service_account_info
+        return None
+
+    def _chat_service(self) -> _GoogleChatService:
+        if self._service_account_info is None:
+            raise ConnectorMissingCredentialError("Google Chat")
+        try:
+            credentials = service_account.Credentials.from_service_account_info(
+                self._service_account_info,
+                scopes=_GOOGLE_CHAT_SCOPES,
+            )
+            return cast(
+                _GoogleChatService,
+                build(
+                    "chat",
+                    "v1",
+                    credentials=credentials,
+                    cache_discovery=False,
+                ),
+            )
+        except (ValueError, TypeError) as error:
+            raise CredentialInvalidError(
+                f"Invalid Google Chat service account key: {error}"
+            ) from error
+
+    def validate_connector_settings(self) -> None:
+        try:
+            self._chat_service().spaces().list(pageSize=1).execute()
+        except HttpError as error:
+            raise CredentialInvalidError(
+                f"Unable to access Google Chat spaces: {error}"
+            ) from error
+
+    def _selected_spaces(
+        self, chat_service: _GoogleChatService
+    ) -> Iterator[dict[str, Any]]:
+        page_token: str | None = None
+        while True:
+            response = (
+                chat_service.spaces()
+                .list(pageSize=_GOOGLE_CHAT_PAGE_SIZE, pageToken=page_token)
+                .execute()
+            )
+            for space in response.get("spaces", []):
+                resource_name = str(space.get("name") or "").casefold()
+                display_name = str(space.get("displayName") or "").casefold()
+                if self.space_names and not {
+                    resource_name,
+                    display_name,
+                }.intersection(self.space_names):
+                    continue
+                yield space
+
+            page_token = response.get("nextPageToken")
+            if not page_token:
+                break
+
+    def _messages(
+        self,
+        chat_service: _GoogleChatService,
+        space: dict[str, Any],
+        start: datetime | None,
+        end: datetime | None,
+    ) -> Iterator[dict[str, Any]]:
+        filters: list[str] = []
+        if start:
+            filters.append(f'createTime > "{_format_timestamp(start)}"')
+        if end:
+            filters.append(f'createTime < "{_format_timestamp(end)}"')
+
+        page_token: str | None = None
+        while True:
+            response = (
+                chat_service.spaces()
+                .messages()
+                .list(
+                    parent=space["name"],
+                    pageSize=_GOOGLE_CHAT_PAGE_SIZE,
+                    pageToken=page_token,
+                    filter=" AND ".join(filters) or None,
+                    orderBy="ASC",
+                )
+                .execute()
+            )
+            for message in response.get("messages", []):
+                if message.get("text") or message.get("formattedText"):
+                    yield message
+
+            page_token = response.get("nextPageToken")
+            if not page_token:
+                break
+
+    def _generate_documents(
+        self,
+        start: datetime | None,
+        end: datetime | None,
+    ) -> GenerateDocumentsOutput:
+        effective_start = (
+            max(start, self.start_date)
+            if start is not None and self.start_date is not None
+            else start or self.start_date
+        )
+        chat_service = self._chat_service()
+        batch: list[Document | HierarchyNode] = []
+
+        for space in self._selected_spaces(chat_service):
+            for message in self._messages(
+                chat_service,
+                space,
+                effective_start,
+                end,
+            ):
+                batch.append(_message_to_document(message, space))
+                if len(batch) >= self.batch_size:
+                    yield batch
+                    batch = []
+
+        if batch:
+            yield batch
+
+    def poll_source(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+    ) -> GenerateDocumentsOutput:
+        return self._generate_documents(
+            datetime.fromtimestamp(start, tz=timezone.utc),
+            datetime.fromtimestamp(end, tz=timezone.utc),
+        )
+
+    def load_from_state(self) -> GenerateDocumentsOutput:
+        return self._generate_documents(None, None)

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -44,6 +44,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.google_drive.connector",
         class_name="GoogleDriveConnector",
     ),
+    DocumentSource.GOOGLE_CHAT: ConnectorMapping(
+        module_path="onyx.connectors.google_chat.connector",
+        class_name="GoogleChatConnector",
+    ),
     DocumentSource.BOOKSTACK: ConnectorMapping(
         module_path="onyx.connectors.bookstack.connector",
         class_name="BookstackConnector",

--- a/backend/onyx/onyxbot/slack/icons.py
+++ b/backend/onyx/onyxbot/slack/icons.py
@@ -10,6 +10,7 @@ _SOURCE_IMAGE_FILENAMES: Mapping[DocumentSource, str] = {
     DocumentSource.SLACK: "Slack.png",
     DocumentSource.WEB: "Web.png",
     DocumentSource.GOOGLE_DRIVE: "GoogleDrive.png",
+    DocumentSource.GOOGLE_CHAT: _DEFAULT_SOURCE_IMAGE_FILENAME,
     DocumentSource.GMAIL: "Gmail.png",
     DocumentSource.GITHUB: "Github.png",
     DocumentSource.GITBOOK: "Gitbook.png",

--- a/backend/tests/unit/onyx/connectors/google_chat/test_connector.py
+++ b/backend/tests/unit/onyx/connectors/google_chat/test_connector.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import patch
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.google_chat.connector import (
+    GoogleChatConnector,
+    _message_to_document,
+)
+from onyx.connectors.models import Document
+
+
+class _FakeRequest:
+    def __init__(self, response: dict[str, Any]) -> None:
+        self.response = response
+
+    def execute(self) -> dict[str, Any]:
+        return self.response
+
+
+class _FakeMessages:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def list(self, **kwargs: Any) -> _FakeRequest:
+        self.calls.append(kwargs)
+        page_token = kwargs.get("pageToken")
+        if page_token == "messages-page-2":
+            return _FakeRequest(
+                {
+                    "messages": [
+                        {
+                            "name": "spaces/AAA/messages/second",
+                            "text": "Second message",
+                            "createTime": "2026-01-02T12:00:00Z",
+                            "sender": {"displayName": "Grace"},
+                        }
+                    ]
+                }
+            )
+        return _FakeRequest(
+            {
+                "messages": [
+                    {
+                        "name": "spaces/AAA/messages/first",
+                        "text": "First message",
+                        "createTime": "2026-01-02T10:00:00Z",
+                        "sender": {"displayName": "Ada"},
+                    },
+                    {
+                        "name": "spaces/AAA/messages/card-only",
+                        "createTime": "2026-01-02T11:00:00Z",
+                    },
+                ],
+                "nextPageToken": "messages-page-2",
+            }
+        )
+
+
+class _FakeSpaces:
+    def __init__(self) -> None:
+        self.messages_api = _FakeMessages()
+        self.calls: list[dict[str, Any]] = []
+
+    def list(self, **kwargs: Any) -> _FakeRequest:
+        self.calls.append(kwargs)
+        if kwargs.get("pageToken") == "spaces-page-2":
+            return _FakeRequest(
+                {"spaces": [{"name": "spaces/BBB", "displayName": "Support"}]}
+            )
+        return _FakeRequest(
+            {
+                "spaces": [{"name": "spaces/AAA", "displayName": "Engineering"}],
+                "nextPageToken": "spaces-page-2",
+            }
+        )
+
+    def messages(self) -> _FakeMessages:
+        return self.messages_api
+
+
+class _FakeChatService:
+    def __init__(self) -> None:
+        self.spaces_api = _FakeSpaces()
+
+    def spaces(self) -> _FakeSpaces:
+        return self.spaces_api
+
+
+def test_message_to_document_preserves_searchable_context() -> None:
+    document = _message_to_document(
+        {
+            "name": "spaces/AAA/messages/BBB",
+            "text": "A deployment note",
+            "createTime": "2026-01-02T10:00:00Z",
+            "lastUpdateTime": "2026-01-02T10:05:00Z",
+            "sender": {"displayName": "Ada"},
+            "thread": {"name": "spaces/AAA/threads/CCC"},
+        },
+        {"name": "spaces/AAA", "displayName": "Engineering"},
+    )
+
+    assert document.id == "GOOGLE_CHAT_spaces/AAA/messages/BBB"
+    assert document.source == DocumentSource.GOOGLE_CHAT
+    assert document.semantic_identifier == "Ada in Engineering: A deployment note"
+    assert document.title == "Engineering"
+    assert document.sections[0].text == "A deployment note"
+    assert document.sections[0].link == "https://chat.google.com/room/AAA"
+    assert document.metadata == {
+        "Space": "Engineering",
+        "Sender": "Ada",
+        "Thread": "spaces/AAA/threads/CCC",
+    }
+    assert document.doc_created_at == datetime(2026, 1, 2, 10, 0, tzinfo=timezone.utc)
+    assert document.doc_updated_at == datetime(2026, 1, 2, 10, 5, tzinfo=timezone.utc)
+
+
+def test_connector_paginates_and_filters_spaces_and_messages() -> None:
+    connector = GoogleChatConnector(
+        space_names=["Engineering"],
+        start_date="2026-01-01",
+        batch_size=1,
+    )
+    fake_service = _FakeChatService()
+
+    with patch.object(connector, "_chat_service", return_value=fake_service):
+        batches = list(
+            connector.poll_source(
+                datetime(2025, 12, 1, tzinfo=timezone.utc).timestamp(),
+                datetime(2026, 2, 1, tzinfo=timezone.utc).timestamp(),
+            )
+        )
+
+    documents = [document for batch in batches for document in batch]
+    assert all(isinstance(document, Document) for document in documents)
+    assert [
+        document.id for document in documents if isinstance(document, Document)
+    ] == [
+        "GOOGLE_CHAT_spaces/AAA/messages/first",
+        "GOOGLE_CHAT_spaces/AAA/messages/second",
+    ]
+    assert len(fake_service.spaces_api.calls) == 2
+    assert len(fake_service.spaces_api.messages_api.calls) == 2
+    first_message_call = fake_service.spaces_api.messages_api.calls[0]
+    assert first_message_call["parent"] == "spaces/AAA"
+    assert first_message_call["filter"] == (
+        'createTime > "2026-01-01T00:00:00Z" AND createTime < "2026-02-01T00:00:00Z"'
+    )
+    assert first_message_call["orderBy"] == "ASC"

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -1763,6 +1763,30 @@ For example, specifying .*-alerts as a "channel to exclude" will cause the conne
       },
     ],
   },
+  google_chat: {
+    description: "Configure Google Chat connector",
+    values: [],
+    advanced_values: [
+      {
+        type: "list",
+        query: "Enter Google Chat spaces to include:",
+        label: "Spaces",
+        name: "space_names",
+        description:
+          "Optionally list exact space resource names (spaces/...) or display names. Leave empty to index public messages from every space the Chat app has joined. Workspace administrator approval is required for message access.",
+        optional: true,
+      },
+      {
+        type: "text",
+        query: "Enter the Start Date:",
+        label: "Start Date",
+        name: "start_date",
+        description:
+          "Only messages after this date will be indexed. Format: YYYY-MM-DD",
+        optional: true,
+      },
+    ],
+  },
   freshdesk: {
     description: "Configure Freshdesk connector",
     values: [],

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -253,6 +253,10 @@ export interface DiscordCredentialJson {
   discord_bot_token: string;
 }
 
+export interface GoogleChatCredentialJson {
+  google_chat_service_account_secret: string;
+}
+
 export interface FreshdeskCredentialJson {
   freshdesk_domain: string;
   freshdesk_api_key: string;
@@ -507,6 +511,9 @@ export const credentialTemplates: Record<ValidSources, any> = {
   ingestion_api: null,
   federated_slack: null,
   discord: { discord_bot_token: "" } as DiscordCredentialJson,
+  google_chat: {
+    google_chat_service_account_secret: "",
+  } as GoogleChatCredentialJson,
 
   // NOTE: These are Special Cases
   google_drive: { google_tokens: "" } as GoogleDriveCredentialJson,
@@ -569,6 +576,7 @@ export const credentialDisplayNames: Record<string, string> = {
 
   // Discord
   discord_bot_token: "Discord Bot Token",
+  google_chat_service_account_secret: "Google Chat Service Account JSON",
 
   // Gmail and Google Drive
   google_tokens: "Google Oauth Tokens",

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -10,7 +10,13 @@ import { SourceCategory, SourceMetadata } from "@/lib/search/interfaces";
 import { Agent } from "@/lib/agents/types";
 import React from "react";
 import { DOCS_ADMINS_PATH, DOCS_BASE_URL } from "@/lib/constants";
-import { SvgFileText, SvgGlobe, SvgUploadCloud, SvgMail } from "@opal/icons";
+import {
+  SvgBubbleText,
+  SvgFileText,
+  SvgGlobe,
+  SvgUploadCloud,
+  SvgMail,
+} from "@opal/icons";
 import {
   SvgAirtable,
   SvgAsana,
@@ -327,6 +333,11 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     displayName: "Gmail",
     category: SourceCategory.Messaging,
     docs: `${DOCS_ADMINS_PATH}/connectors/official/gmail/overview`,
+  },
+  google_chat: {
+    icon: SvgBubbleText,
+    displayName: "Google Chat",
+    category: SourceCategory.Messaging,
   },
   drupal_wiki: {
     icon: SvgDrupal,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -551,6 +551,7 @@ export enum ValidSources {
   GitLab = "gitlab",
   Slack = "slack",
   GoogleDrive = "google_drive",
+  GoogleChat = "google_chat",
   Gmail = "gmail",
   Bookstack = "bookstack",
   Outline = "outline",


### PR DESCRIPTION
## Summary

Closes #518.

Adds a Google Chat connector using service-account authentication.

## Changes

- Indexes public text messages from spaces joined by the Chat app
- Supports pagination, date filtering, and space filtering
- Adds frontend credential and connector configuration
- Adds unit tests for message conversion and retrieval behavior

## Testing

- 80 backend tests passed
- Python type, lint, and formatting checks passed
- Frontend TypeScript, lint, and formatting checks passed

## Reviewer focus

Please review the authentication scopes, message metadata, pagination behavior, and connector configuration.

## Notes

Google Workspace administrator approval is required for the read-only app scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `google_chat` connector that indexes public messages from spaces the Chat app has joined using service-account auth. Implements #518 to make Google Chat content searchable.

- **New Features**
  - Backend: new Google Chat connector with service-account scopes, pagination, date window, and space filtering.
  - Source wiring: added `GOOGLE_CHAT` in enums/registry and a default icon mapping.
  - Frontend: new `google_chat` source with credential `google_chat_service_account_secret`, optional `space_names`, and `start_date`.
  - Tests: unit tests for message conversion, pagination, and filtering.

- **Migration**
  - Create a Google service account with Chat read-only scopes and upload its JSON to `google_chat_service_account_secret`.
  - Ensure the Chat app is installed in target spaces and approved by a Workspace admin for message access.

<sup>Written for commit b397c8f83fbd44b46153fe91ef4e89389f5957e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

