### PR TITLE
fix(cli): pick the deploy palette for the terminal background

### DIFF
--- a/cli/internal/deploy/install/options.go
+++ b/cli/internal/deploy/install/options.go
@@ -54,6 +54,9 @@ type Deps struct {
 
 // NewDeps wires production dependencies.
 func NewDeps(ios *iostreams.IOStreams, cliVersion string) Deps {
+	// Before anything is styled or the wizard takes the terminal over: the
+	// accent color is picked by asking the terminal for its background.
+	ui.DetectBackground(ios)
 	return Deps{
 		IOS:        ios,
 		Runner:     dockercmd.ExecRunner{},

--- a/cli/internal/deploy/ui/ui.go
+++ b/cli/internal/deploy/ui/ui.go
@@ -25,52 +25,59 @@ import (
 	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
 )
 
-// The accent color follows the terminal's background. ANSI 6 (cyan) carries
-// the highlight on the dark terminals it was picked for but washes out on
-// light ones, where 256-color 25 (a dark blue) reads with the same weight.
-// The light choice is deliberately out of the first sixteen slots: those are
-// whatever the color scheme says they are, and a "blue" that a light theme
-// defines as pastel would put us back where we started.
+// The two colors that carry weight rather than meaning — the accent and the
+// grey everything secondary is written in — follow the terminal's background.
+// ANSI 6 (cyan) and ANSI 8 (bright black) were picked for dark terminals: on
+// a light one the cyan washes out and the grey, which most light schemes
+// define as a pale silver, drops close to the background. Their light
+// counterparts are deliberately out of the first sixteen slots, since those
+// are whatever the color scheme says they are: a "blue" a light theme defines
+// as pastel would put us back where we started. 25 is a dark blue that keeps
+// the accent's weight, and 243 is the lightest grey that still reads as text
+// on white.
 var (
 	accentDark  = lipgloss.Color("6")
 	accentLight = lipgloss.Color("25")
+	dimDark     = lipgloss.Color("8")
+	dimLight    = lipgloss.Color("243")
 )
 
 var (
 	accent   = lipgloss.NewStyle().Foreground(accentDark).Bold(true)
-	dim      = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	dim      = lipgloss.NewStyle().Foreground(dimDark)
 	okStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
 	warnSt   = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
 	errSt    = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
 	railOn   = lipgloss.NewStyle().Bold(true)
 	cardBox  = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(accentDark).Padding(0, 2)
-	paneBox  = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("8")).Padding(0, 1)
+	paneBox  = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(dimDark).Padding(0, 1)
 	spinners = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 )
 
-// BackgroundEnv forces which background the accent color is picked for
-// ("light" or "dark"), for terminals that don't answer the query or answer
-// it wrongly.
+// BackgroundEnv forces which background the colors are picked for ("light"
+// or "dark"), for terminals that don't answer the query or answer it wrongly.
 const BackgroundEnv = "ONYX_TERM_BACKGROUND"
 
 var detectOnce sync.Once
 
-// DetectBackground picks the accent color for this terminal, once per
-// process. Call it before any styled output and before the wizard starts:
-// asking the terminal means writing a query and reading the reply in raw
-// mode, which only works while nothing else owns the input.
+// DetectBackground picks the palette for this terminal, once per process.
+// Call it before any styled output and before the wizard starts: asking the
+// terminal means writing a query and reading the reply in raw mode, which
+// only works while nothing else owns the input.
 func DetectBackground(ios *iostreams.IOStreams) {
 	detectOnce.Do(func() { useBackground(darkBackground(ios)) })
 }
 
-// useBackground repaints the styles that carry the accent.
+// useBackground repaints the styles whose colors depend on the background.
 func useBackground(dark bool) {
-	c := accentLight
+	ac, dc := accentLight, dimLight
 	if dark {
-		c = accentDark
+		ac, dc = accentDark, dimDark
 	}
-	accent = accent.Foreground(c)
-	cardBox = cardBox.BorderForeground(c)
+	accent = accent.Foreground(ac)
+	cardBox = cardBox.BorderForeground(ac)
+	dim = dim.Foreground(dc)
+	paneBox = paneBox.BorderForeground(dc)
 }
 
 // darkBackground resolves the terminal's background, defaulting to dark —

--- a/cli/internal/deploy/ui/ui.go
+++ b/cli/internal/deploy/ui/ui.go
@@ -14,26 +14,87 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
+	"golang.org/x/term"
 
 	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
 )
 
+// The accent color follows the terminal's background. ANSI 6 (cyan) carries
+// the highlight on the dark terminals it was picked for but washes out on
+// light ones, where 256-color 25 (a dark blue) reads with the same weight.
+// The light choice is deliberately out of the first sixteen slots: those are
+// whatever the color scheme says they are, and a "blue" that a light theme
+// defines as pastel would put us back where we started.
 var (
-	accent   = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true)
+	accentDark  = lipgloss.Color("6")
+	accentLight = lipgloss.Color("25")
+)
+
+var (
+	accent   = lipgloss.NewStyle().Foreground(accentDark).Bold(true)
 	dim      = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
 	okStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
 	warnSt   = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
 	errSt    = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
 	railOn   = lipgloss.NewStyle().Bold(true)
-	cardBox  = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("6")).Padding(0, 2)
+	cardBox  = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(accentDark).Padding(0, 2)
 	paneBox  = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("8")).Padding(0, 1)
 	spinners = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 )
+
+// BackgroundEnv forces which background the accent color is picked for
+// ("light" or "dark"), for terminals that don't answer the query or answer
+// it wrongly.
+const BackgroundEnv = "ONYX_TERM_BACKGROUND"
+
+var detectOnce sync.Once
+
+// DetectBackground picks the accent color for this terminal, once per
+// process. Call it before any styled output and before the wizard starts:
+// asking the terminal means writing a query and reading the reply in raw
+// mode, which only works while nothing else owns the input.
+func DetectBackground(ios *iostreams.IOStreams) {
+	detectOnce.Do(func() { useBackground(darkBackground(ios)) })
+}
+
+// useBackground repaints the styles that carry the accent.
+func useBackground(dark bool) {
+	c := accentLight
+	if dark {
+		c = accentDark
+	}
+	accent = accent.Foreground(c)
+	cardBox = cardBox.BorderForeground(c)
+}
+
+// darkBackground resolves the terminal's background, defaulting to dark —
+// the assumption the palette was built on, and the safer one to be wrong
+// about since cyan on a light background is dull rather than invisible.
+func darkBackground(ios *iostreams.IOStreams) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(BackgroundEnv))) {
+	case "light":
+		return false
+	case "dark":
+		return true
+	}
+	// Only a real terminal on both ends can be asked, and the query has to go
+	// to the actual descriptors rather than whatever ios wraps. A terminal
+	// that stays silent (or sits behind a multiplexer that swallows the
+	// query) keeps the dark default; lipgloss pairs the query with a device
+	// attributes request every terminal answers, so a non-answer costs a
+	// round trip rather than the full timeout.
+	if !Color(ios) || !ios.IsStdinTTY ||
+		!term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stdout.Fd())) {
+		return true
+	}
+	return lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+}
 
 // promptMark heads a question. It is the dot the chat TUI marks its own turns
 // with (internal/tui), so being asked something looks the same across the CLI.
@@ -65,7 +126,7 @@ func (p Painter) Err(s string) string  { return p.render(errSt, s) }
 func (p Painter) Dim(s string) string  { return p.render(dim, s) }
 
 // Accent marks the thing to act on — a URL, or a command meant to be typed
-// next. It is the same cyan the wizard's summary card uses, and it earns its
+// next. It is the same color the wizard's summary card uses, and it earns its
 // place by being rare: a line that highlights everything highlights nothing.
 func (p Painter) Accent(s string) string { return p.render(accent, s) }
 

--- a/cli/internal/deploy/ui/ui_test.go
+++ b/cli/internal/deploy/ui/ui_test.go
@@ -269,10 +269,11 @@ func TestPainterFollowsTheStream(t *testing.T) {
 	}
 }
 
-// The accent color follows the terminal's background: the same text is
-// styled differently on a light terminal than on a dark one, and a stream
-// that can't be asked keeps the dark default rather than guessing.
-func TestAccentFollowsTheBackground(t *testing.T) {
+// The accent and the secondary grey follow the terminal's background: the
+// same text is styled differently on a light terminal than on a dark one,
+// and a stream that can't be asked keeps the dark default rather than
+// guessing.
+func TestColorsFollowTheBackground(t *testing.T) {
 	t.Cleanup(func() { useBackground(true) })
 	t.Setenv("TERM", "xterm-256color")
 	t.Setenv("NO_COLOR", "")
@@ -291,14 +292,21 @@ func TestAccentFollowsTheBackground(t *testing.T) {
 		t.Error("a stream that can't be queried should stay on the dark default")
 	}
 
+	const text = "onyx-cli deploy status"
 	useBackground(true)
-	dark := Accent("onyx-cli deploy status")
+	darkAccent, darkDim := Accent(text), dim.Render(text)
 	useBackground(false)
-	light := Accent("onyx-cli deploy status")
-	if dark == light {
-		t.Error("the accent should differ between light and dark backgrounds")
-	}
-	if ansi.Strip(light) != "onyx-cli deploy status" {
-		t.Errorf("styling changed the text: %q", ansi.Strip(light))
+	lightAccent, lightDim := Accent(text), dim.Render(text)
+
+	for _, c := range []struct{ what, dark, light string }{
+		{"accent", darkAccent, lightAccent},
+		{"dim", darkDim, lightDim},
+	} {
+		if c.dark == c.light {
+			t.Errorf("%s should differ between light and dark backgrounds", c.what)
+		}
+		if ansi.Strip(c.light) != text {
+			t.Errorf("%s styling changed the text: %q", c.what, ansi.Strip(c.light))
+		}
 	}
 }

--- a/cli/internal/deploy/ui/ui_test.go
+++ b/cli/internal/deploy/ui/ui_test.go
@@ -268,3 +268,37 @@ func TestPainterFollowsTheStream(t *testing.T) {
 		t.Errorf("NO_COLOR should stay plain, got %q", got)
 	}
 }
+
+// The accent color follows the terminal's background: the same text is
+// styled differently on a light terminal than on a dark one, and a stream
+// that can't be asked keeps the dark default rather than guessing.
+func TestAccentFollowsTheBackground(t *testing.T) {
+	t.Cleanup(func() { useBackground(true) })
+	t.Setenv("TERM", "xterm-256color")
+	t.Setenv("NO_COLOR", "")
+	tty := &iostreams.IOStreams{Out: &bytes.Buffer{}, IsStdinTTY: true, IsStdoutTTY: true}
+
+	t.Setenv(BackgroundEnv, "light")
+	if darkBackground(tty) {
+		t.Error("an explicit light background should be honored")
+	}
+	t.Setenv(BackgroundEnv, "Dark")
+	if !darkBackground(tty) {
+		t.Error("an explicit dark background should be honored")
+	}
+	t.Setenv(BackgroundEnv, "")
+	if !darkBackground(&iostreams.IOStreams{Out: &bytes.Buffer{}}) {
+		t.Error("a stream that can't be queried should stay on the dark default")
+	}
+
+	useBackground(true)
+	dark := Accent("onyx-cli deploy status")
+	useBackground(false)
+	light := Accent("onyx-cli deploy status")
+	if dark == light {
+		t.Error("the accent should differ between light and dark backgrounds")
+	}
+	if ansi.Strip(light) != "onyx-cli deploy status" {
+		t.Errorf("styling changed the text: %q", ansi.Strip(light))
+	}
+}


### PR DESCRIPTION
## Description

The deploy installer's highlights — URLs, the commands it tells you to run next, the prompt marks, the summary card border — were ANSI cyan (`lipgloss.Color("6")`), and everything secondary (hints, detail columns, the pane border, the help footer) was ANSI 8. Both were picked for dark terminals: on a light one the cyan washes out, and ANSI 8 is a pale silver in most light schemes, leaving the secondary text close to the background.

This asks the terminal for its background color once per run and picks both colors to match:

| | dark (unchanged) | light |
| --- | --- | --- |
| accent | ANSI 6 | 256-color 25 (`#005faf`), ~8:1 on white |
| secondary grey | ANSI 8 | 256-color 243 (`#767676`), the lightest grey that still reads as text on white |

The light choices are deliberately outside the first sixteen slots, since those are whatever the color scheme redefines them to be — a light theme's pastel "blue" would put us back where we started.

Detection is `lipgloss.HasDarkBackground`, which pairs the OSC 11 query with a device-attributes request, so a terminal that doesn't support OSC 11 still answers and ends the wait in a round trip rather than the 2s timeout. It is skipped entirely (defaulting to today's dark palette) when color is off, stdin isn't a TTY, or the real `os.Stdin`/`os.Stdout` aren't terminals — so piped runs and tests never emit a query. `ui.DetectBackground` runs from `install.NewDeps`, before anything is styled and before the wizard takes the terminal over, since the query needs sole ownership of stdin.

`ONYX_TERM_BACKGROUND=light|dark` overrides the query for terminals that don't answer or answer wrongly.

## How Has This Been Tested?

- New `TestColorsFollowTheBackground` in `cli/internal/deploy/ui/ui_test.go`: covers the env override both ways, that a non-queryable stream keeps the dark default, and that both the accent and the grey render differently on light vs dark without changing the text itself.
- `go build ./...`, `go vet ./internal/deploy/...`, and the full `cli` test suite pass.
- Confirmed both light colors emit indexed escapes (`\x1b[1;38;5;25m`, `\x1b[38;5;243m`), not truecolor, so 256-color terminals handle them.
- Not eyeballed against a live light terminal — no TTY in the environment this was written in. Worth a look in iTerm/Windows Terminal with a light profile before merge.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)