### PR TITLE
feat(gateway): stream the Responses API output-item lifecycle

### DIFF
--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -50,10 +50,20 @@ from onyx.server.gateway.models import (
     ChatCompletionRequest,
     ChatCompletionResponse,
     ModelListResponse,
+    ResponsesCompletedEvent,
+    ResponsesContentPartAddedEvent,
+    ResponsesContentPartDoneEvent,
+    ResponsesCreatedEvent,
+    ResponsesFailedEvent,
+    ResponsesFunctionCallArgumentsDoneEvent,
     ResponsesFunctionCallItem,
     ResponsesMessageItem,
     ResponsesObjectPayload,
     ResponsesOutputItem,
+    ResponsesOutputItemAddedEvent,
+    ResponsesOutputItemDoneEvent,
+    ResponsesOutputTextDeltaEvent,
+    ResponsesOutputTextDoneEvent,
     ResponsesOutputTextPart,
     ResponsesRequest,
 )
@@ -366,6 +376,37 @@ def _stream_worker(
                 _put_stream_item(out, _STREAM_END, cancelled)
 
 
+def _run_bridged_stream(
+    worker: Callable[..., None], worker_kwargs: dict[str, Any]
+) -> Iterator[str]:
+    """Bridge a stream worker through a queue so the whole consumption —
+    including the generation span's ContextVar enter/exit — happens on ONE
+    thread. Yielding directly from a sync generator breaks under Starlette,
+    which resumes the generator on varying threadpool threads (ContextVar
+    tokens can't be reset across contexts)."""
+    out: "queue.Queue[Any]" = queue.Queue(maxsize=256)
+    cancelled = threading.Event()
+    worker_thread = start_thread_with_context(
+        worker,
+        name="llm-gateway-stream",
+        daemon=True,
+        kwargs={**worker_kwargs, "out": out, "cancelled": cancelled},
+    )
+    try:
+        while True:
+            try:
+                item = out.get(timeout=0.5)
+            except queue.Empty:
+                if not worker_thread.is_alive():
+                    return
+                continue
+            if item is _STREAM_END:
+                return
+            yield item
+    finally:
+        cancelled.set()
+
+
 def _stream_sse(
     llm: LLM,
     flow: LLMFlow,
@@ -377,18 +418,9 @@ def _stream_sse(
     reasoning_effort: ReasoningEffort,
     model: str,
 ) -> Iterator[str]:
-    """Bridge the worker through a queue so the whole stream consumption —
-    including the generation span's ContextVar enter/exit — happens on ONE
-    thread. Yielding directly from a sync generator breaks under Starlette,
-    which resumes the generator on varying threadpool threads (ContextVar
-    tokens can't be reset across contexts)."""
-    out: "queue.Queue[Any]" = queue.Queue(maxsize=256)
-    cancelled = threading.Event()
-    worker = start_thread_with_context(
+    return _run_bridged_stream(
         _stream_worker,
-        name="llm-gateway-stream",
-        daemon=True,
-        kwargs={
+        {
             "llm": llm,
             "flow": flow,
             "messages": messages,
@@ -398,23 +430,8 @@ def _stream_sse(
             "max_tokens": max_tokens,
             "reasoning_effort": reasoning_effort,
             "model": model,
-            "out": out,
-            "cancelled": cancelled,
         },
     )
-    try:
-        while True:
-            try:
-                item = out.get(timeout=0.5)
-            except queue.Empty:
-                if not worker.is_alive():
-                    return
-                continue
-            if item is _STREAM_END:
-                return
-            yield item
-    finally:
-        cancelled.set()
 
 
 def handle_chat_completion(
@@ -596,17 +613,249 @@ def _build_responses_output_items(
     return items
 
 
+def _responses_stream_worker(
+    llm: LLM,
+    flow: LLMFlow,
+    messages: list[ChatCompletionMessage],
+    tools: list[dict[str, Any]] | None,
+    tool_choice: ToolChoiceOptions | None,
+    max_tokens: int | None,
+    reasoning_effort: ReasoningEffort,
+    model: str,
+    response_id: str,
+    created_at: int,
+    out: "queue.Queue[Any]",
+    cancelled: threading.Event,
+) -> None:
+    def emit(event: Any) -> bool:
+        return _put_stream_item(
+            out, f"data: {json.dumps(event.to_wire())}\n\n", cancelled
+        )
+
+    emit(
+        ResponsesCreatedEvent.create(
+            ResponsesObjectPayload.from_parts(
+                response_id=response_id,
+                created_at=created_at,
+                model=model,
+                status="in_progress",
+                output=[],
+            )
+        )
+    )
+    message_item_id = _new_id("msg")
+    # Runs on its own thread after the endpoint has returned the
+    # StreamingResponse, so the trace must be opened here rather than in the
+    # endpoint for the generation span to see an active trace.
+    with (
+        _gateway_trace(flow, model),
+        llm_generation_span(
+            llm, flow=flow, input_messages=messages, tools=tools
+        ) as span,
+    ):
+        accumulated_content: list[str] = []
+        accumulated_reasoning: list[str] = []
+        final_usage: Usage | None = None
+        text_item_open = False
+        tool_call_buffer: dict[int, ChatCompletionDeltaToolCall] = {}
+        upstream: Iterator[ModelResponseStream] | None = None
+        try:
+            upstream = llm.stream(
+                prompt=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                max_tokens=max_tokens,
+                reasoning_effort=reasoning_effort,
+            )
+            for chunk in upstream:
+                if cancelled.is_set():
+                    break
+                if chunk.usage:
+                    final_usage = chunk.usage
+                if chunk.choice.delta.content:
+                    if not text_item_open:
+                        # Open the item before the first delta; Codex drops
+                        # deltas for items it has not seen added.
+                        if not emit(
+                            ResponsesOutputItemAddedEvent.create(
+                                output_index=0,
+                                item=ResponsesMessageItem.create(
+                                    id=message_item_id, status="in_progress", content=[]
+                                ),
+                            )
+                        ):
+                            break
+                        if not emit(
+                            ResponsesContentPartAddedEvent.create(
+                                item_id=message_item_id,
+                                output_index=0,
+                                part=ResponsesOutputTextPart.create(text=""),
+                            )
+                        ):
+                            break
+                        text_item_open = True
+                    accumulated_content.append(chunk.choice.delta.content)
+                    if not emit(
+                        ResponsesOutputTextDeltaEvent.create(
+                            item_id=message_item_id,
+                            delta=chunk.choice.delta.content,
+                        )
+                    ):
+                        break
+                if chunk.choice.delta.reasoning_content:
+                    accumulated_reasoning.append(chunk.choice.delta.reasoning_content)
+                for delta_tc in chunk.choice.delta.tool_calls:
+                    _merge_tool_call_delta(tool_call_buffer, delta_tc)
+            else:
+                final_tool_calls = _finalize_tool_calls(tool_call_buffer)
+                full_text = "".join(accumulated_content)
+                if text_item_open:
+                    completed_part = ResponsesOutputTextPart.create(text=full_text)
+                    emit(
+                        ResponsesOutputTextDoneEvent.create(
+                            item_id=message_item_id, output_index=0, text=full_text
+                        )
+                    )
+                    emit(
+                        ResponsesContentPartDoneEvent.create(
+                            item_id=message_item_id,
+                            output_index=0,
+                            part=completed_part,
+                        )
+                    )
+                    emit(
+                        ResponsesOutputItemDoneEvent.create(
+                            output_index=0,
+                            item=ResponsesMessageItem.create(
+                                id=message_item_id,
+                                status="completed",
+                                content=[completed_part],
+                            ),
+                        )
+                    )
+                for tool_index, tool_call in enumerate(
+                    final_tool_calls or [], start=1 if text_item_open else 0
+                ):
+                    call_item = _function_call_item(tool_call)
+                    if call_item is None:
+                        continue
+                    emit(
+                        ResponsesOutputItemAddedEvent.create(
+                            output_index=tool_index, item=call_item
+                        )
+                    )
+                    emit(
+                        ResponsesFunctionCallArgumentsDoneEvent.create(
+                            item_id=call_item.id,
+                            output_index=tool_index,
+                            arguments=call_item.arguments,
+                        )
+                    )
+                    emit(
+                        ResponsesOutputItemDoneEvent.create(
+                            output_index=tool_index, item=call_item
+                        )
+                    )
+                emit(
+                    ResponsesCompletedEvent.create(
+                        ResponsesObjectPayload.from_parts(
+                            response_id=response_id,
+                            created_at=created_at,
+                            model=model,
+                            status="completed",
+                            output=_build_responses_output_items(
+                                "".join(accumulated_content) or None,
+                                final_tool_calls,
+                                message_item_id,
+                            ),
+                            usage=final_usage,
+                        )
+                    )
+                )
+        except LLMRateLimitError as exc:
+            if span is not None:
+                span.set_error(
+                    {"message": f"{type(exc).__name__}: {exc}", "data": None}
+                )
+            logger.exception(
+                "LLM gateway responses stream rate limited for model %s", model
+            )
+            emit(
+                ResponsesFailedEvent.create(
+                    ResponsesObjectPayload.failed(
+                        response_id=response_id,
+                        created_at=created_at,
+                        model=model,
+                        message="The selected model is temporarily rate limited.",
+                    )
+                )
+            )
+        except LLMTimeoutError as exc:
+            if span is not None:
+                span.set_error(
+                    {"message": f"{type(exc).__name__}: {exc}", "data": None}
+                )
+            logger.exception(
+                "LLM gateway responses stream timed out for model %s", model
+            )
+            emit(
+                ResponsesFailedEvent.create(
+                    ResponsesObjectPayload.failed(
+                        response_id=response_id,
+                        created_at=created_at,
+                        model=model,
+                        message="The selected model did not respond in time.",
+                    )
+                )
+            )
+        except Exception as exc:
+            if span is not None:
+                span.set_error(
+                    {"message": f"{type(exc).__name__}: {exc}", "data": None}
+                )
+            logger.exception("LLM gateway responses stream failed for model %s", model)
+            emit(
+                ResponsesFailedEvent.create(
+                    ResponsesObjectPayload.failed(
+                        response_id=response_id,
+                        created_at=created_at,
+                        model=model,
+                        message="The upstream LLM request failed.",
+                    )
+                )
+            )
+        finally:
+            try:
+                close = getattr(upstream, "close", None)
+                if callable(close):
+                    close()
+            except Exception:
+                logger.exception(
+                    "LLM gateway responses stream cleanup failed for model %s", model
+                )
+            try:
+                if span is not None:
+                    record_llm_span_output(
+                        span,
+                        output="".join(accumulated_content) or None,
+                        usage=final_usage,
+                        reasoning="".join(accumulated_reasoning) or None,
+                        tool_calls=_finalize_tool_calls(tool_call_buffer),
+                    )
+            except Exception:
+                logger.exception(
+                    "LLM gateway responses span cleanup failed for model %s", model
+                )
+            finally:
+                _put_stream_item(out, _STREAM_END, cancelled)
+
+
 def handle_responses_request(
     request: ResponsesRequest,
     provider: LLMProviderView,
     model_config: ModelConfigurationView,
     flow: LLMFlow,
-) -> ResponsesObjectPayload:
-    if request.stream:
-        raise OnyxError(
-            OnyxErrorCode.NOT_IMPLEMENTED,
-            "Streaming is not yet supported on the Responses API.",
-        )
+) -> StreamingResponse | ResponsesObjectPayload:
     llm = llm_from_provider(
         model_name=model_config.name,
         llm_provider=provider,
@@ -622,6 +871,27 @@ def handle_responses_request(
     max_tokens = request.max_output_tokens
     response_id = _new_id("resp")
     created_at = int(time.time())
+
+    if request.stream:
+        return StreamingResponse(
+            _run_bridged_stream(
+                _responses_stream_worker,
+                {
+                    "llm": llm,
+                    "flow": flow,
+                    "messages": messages,
+                    "tools": tools,
+                    "tool_choice": tool_choice,
+                    "max_tokens": max_tokens,
+                    "reasoning_effort": reasoning_effort,
+                    "model": request.model,
+                    "response_id": response_id,
+                    "created_at": created_at,
+                },
+            ),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
 
     with (
         _gateway_trace(flow, llm.config.model_name),
@@ -730,4 +1000,6 @@ def gateway_responses(
         model_config=model_config,
         flow=flow,
     )
+    if isinstance(result, StreamingResponse):
+        return result
     return JSONResponse(content=result.to_wire())

--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -6,6 +6,7 @@ import uuid
 from collections.abc import Callable, Iterator
 from contextlib import closing, contextmanager
 from functools import partial
+from itertools import count
 from typing import Any, Protocol, cast, runtime_checkable
 
 from fastapi import APIRouter, Depends, Request, Response
@@ -55,6 +56,7 @@ from onyx.server.gateway.models import (
     ResponsesContentPartAddedEvent,
     ResponsesContentPartDoneEvent,
     ResponsesCreatedEvent,
+    ResponsesErrorCode,
     ResponsesFailedEvent,
     ResponsesFunctionCallArgumentsDoneEvent,
     ResponsesFunctionCallItem,
@@ -645,10 +647,13 @@ def _responses_stream_worker(
     out: "queue.Queue[Any]",
     cancelled: threading.Event,
 ) -> None:
+    sequence = count()
+
     def emit(event: Any) -> bool:
-        return _put_stream_item(
-            out, f"data: {json.dumps(event.to_wire())}\n\n", cancelled
-        )
+        # Stamped here rather than in the models so it always matches emission
+        # order and no event can be built without one.
+        payload = {**event.to_wire(), "sequence_number": next(sequence)}
+        return _put_stream_item(out, f"data: {json.dumps(payload)}\n\n", cancelled)
 
     emit(
         ResponsesCreatedEvent.create(
@@ -684,7 +689,11 @@ def _responses_stream_worker(
         return item
 
     def emit_error(*, message: str, error_type: str) -> None:
-        del error_type  # the Responses protocol carries only the message
+        code: ResponsesErrorCode = (
+            "rate_limit_exceeded"
+            if error_type == _RATE_LIMIT_ERROR[1]
+            else "server_error"
+        )
         if text_item_open:
             close_text_item("incomplete")
         emit(
@@ -694,6 +703,7 @@ def _responses_stream_worker(
                     created_at=created_at,
                     model=model,
                     message=message,
+                    code=code,
                 )
             )
         )
@@ -788,6 +798,7 @@ def _responses_stream_worker(
                             item_id=call_item.id,
                             output_index=tool_index,
                             arguments=call_item.arguments,
+                            name=call_item.name,
                         )
                     )
                     emit(

--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -662,9 +662,31 @@ def _responses_stream_worker(
         )
     )
     message_item_id = _new_id("msg")
+    state = _StreamAccumulator()
+    text_item_open = False
+
+    def close_text_item(status: str) -> ResponsesMessageItem:
+        part = ResponsesOutputTextPart.create(text=state.text)
+        item = ResponsesMessageItem.create(
+            id=message_item_id, status=status, content=[part]
+        )
+        emit(
+            ResponsesOutputTextDoneEvent.create(
+                item_id=message_item_id, output_index=0, text=state.text
+            )
+        )
+        emit(
+            ResponsesContentPartDoneEvent.create(
+                item_id=message_item_id, output_index=0, part=part
+            )
+        )
+        emit(ResponsesOutputItemDoneEvent.create(output_index=0, item=item))
+        return item
 
     def emit_error(*, message: str, error_type: str) -> None:
         del error_type  # the Responses protocol carries only the message
+        if text_item_open:
+            close_text_item("incomplete")
         emit(
             ResponsesFailedEvent.create(
                 ResponsesObjectPayload.failed(
@@ -685,8 +707,6 @@ def _responses_stream_worker(
             llm, flow=flow, input_messages=messages, tools=tools
         ) as span,
     ):
-        state = _StreamAccumulator()
-        text_item_open = False
         with _stream_worker_guard(
             span,
             model,
@@ -707,65 +727,42 @@ def _responses_stream_worker(
                 if cancelled.is_set():
                     break
                 state.observe(chunk)
-                if chunk.choice.delta.content:
-                    if not text_item_open:
-                        # Open the item before the first delta; Codex drops
-                        # deltas for items it has not seen added.
-                        if not emit(
-                            ResponsesOutputItemAddedEvent.create(
-                                output_index=0,
-                                item=ResponsesMessageItem.create(
-                                    id=message_item_id, status="in_progress", content=[]
-                                ),
-                            )
-                        ):
-                            break
-                        if not emit(
-                            ResponsesContentPartAddedEvent.create(
-                                item_id=message_item_id,
-                                output_index=0,
-                                part=ResponsesOutputTextPart.create(text=""),
-                            )
-                        ):
-                            break
-                        text_item_open = True
+                if not chunk.choice.delta.content:
+                    continue
+                if not text_item_open:
+                    # Open the item before the first delta; Codex drops
+                    # deltas for items it has not seen added.
                     if not emit(
-                        ResponsesOutputTextDeltaEvent.create(
-                            item_id=message_item_id,
-                            delta=chunk.choice.delta.content,
+                        ResponsesOutputItemAddedEvent.create(
+                            output_index=0,
+                            item=ResponsesMessageItem.create(
+                                id=message_item_id, status="in_progress", content=[]
+                            ),
                         )
                     ):
                         break
+                    if not emit(
+                        ResponsesContentPartAddedEvent.create(
+                            item_id=message_item_id,
+                            output_index=0,
+                            part=ResponsesOutputTextPart.create(text=""),
+                        )
+                    ):
+                        break
+                    text_item_open = True
+                if not emit(
+                    ResponsesOutputTextDeltaEvent.create(
+                        item_id=message_item_id,
+                        delta=chunk.choice.delta.content,
+                    )
+                ):
+                    break
             else:
                 # Build each item once and reuse it below: re-deriving items
                 # for the terminal payload remints ids the client never saw.
                 completed_items: list[ResponsesOutputItem] = []
                 if text_item_open:
-                    full_text = state.text
-                    completed_part = ResponsesOutputTextPart.create(text=full_text)
-                    message_item = ResponsesMessageItem.create(
-                        id=message_item_id,
-                        status="completed",
-                        content=[completed_part],
-                    )
-                    completed_items.append(message_item)
-                    emit(
-                        ResponsesOutputTextDoneEvent.create(
-                            item_id=message_item_id, output_index=0, text=full_text
-                        )
-                    )
-                    emit(
-                        ResponsesContentPartDoneEvent.create(
-                            item_id=message_item_id,
-                            output_index=0,
-                            part=completed_part,
-                        )
-                    )
-                    emit(
-                        ResponsesOutputItemDoneEvent.create(
-                            output_index=0, item=message_item
-                        )
-                    )
+                    completed_items.append(close_text_item("completed"))
                 # Filter before enumerating, or a dropped nameless call leaves
                 # a hole in the output_index sequence.
                 call_items = [

--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -6,7 +6,7 @@ import uuid
 from collections.abc import Callable, Iterator
 from contextlib import closing, contextmanager
 from functools import partial
-from typing import Any, cast
+from typing import Any, Protocol, cast, runtime_checkable
 
 from fastapi import APIRouter, Depends, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -72,6 +72,8 @@ from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationVie
 from onyx.server.query_and_chat.token_limit import check_token_rate_limits
 from onyx.tracing.flows import LLMFlow
 from onyx.tracing.framework.create import trace
+from onyx.tracing.framework.span_data import GenerationSpanData
+from onyx.tracing.framework.spans import Span
 from onyx.tracing.framework.traces import Trace
 from onyx.tracing.llm_utils import (
     llm_generation_span,
@@ -233,6 +235,15 @@ def _parse_tool_choice(raw: Any) -> ToolChoiceOptions | None:
 _STREAM_END = object()
 
 
+@runtime_checkable
+class _ClosableStream(Protocol):
+    """LLM.stream is declared Iterator, which carries no close(); every real
+    implementation is a generator, and an abandoned one must be closed so the
+    provider connection is released."""
+
+    def close(self) -> None: ...
+
+
 def _put_stream_item(
     out: "queue.Queue[Any]", item: Any, cancelled: threading.Event
 ) -> bool:
@@ -290,7 +301,7 @@ _UPSTREAM_ERROR = ("The upstream LLM request failed.", "upstream_error")
 
 @contextmanager
 def _stream_worker_guard(
-    span: Any,
+    span: Span[GenerationSpanData] | None,
     model: str,
     state: _StreamAccumulator,
     *,
@@ -318,9 +329,8 @@ def _stream_worker_guard(
         emit_error(message=message, error_type=error_type)
     finally:
         try:
-            close = getattr(state.upstream, "close", None)
-            if callable(close):
-                close()
+            if isinstance(state.upstream, _ClosableStream):
+                state.upstream.close()
         except Exception:
             logger.exception("LLM gateway %s cleanup failed for model %s", label, model)
         try:

--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -4,7 +4,8 @@ import threading
 import time
 import uuid
 from collections.abc import Callable, Iterator
-from contextlib import closing
+from contextlib import closing, contextmanager
+from functools import partial
 from typing import Any, cast
 
 from fastapi import APIRouter, Depends, Request, Response
@@ -256,6 +257,89 @@ def _emit_stream_error(
     _put_stream_item(out, "data: [DONE]\n\n", cancelled)
 
 
+class _StreamAccumulator:
+    def __init__(self) -> None:
+        self.content: list[str] = []
+        self.reasoning: list[str] = []
+        self.usage: Usage | None = None
+        self.tool_call_buffer: dict[int, ChatCompletionDeltaToolCall] = {}
+        self.upstream: Iterator[ModelResponseStream] | None = None
+
+    def observe(self, chunk: ModelResponseStream) -> None:
+        if chunk.usage:
+            self.usage = chunk.usage
+        if chunk.choice.delta.content:
+            self.content.append(chunk.choice.delta.content)
+        if chunk.choice.delta.reasoning_content:
+            self.reasoning.append(chunk.choice.delta.reasoning_content)
+        for delta_tc in chunk.choice.delta.tool_calls:
+            _merge_tool_call_delta(self.tool_call_buffer, delta_tc)
+
+    @property
+    def text(self) -> str:
+        return "".join(self.content)
+
+
+_RATE_LIMIT_ERROR = (
+    "The selected model is temporarily rate limited.",
+    "rate_limit_error",
+)
+_TIMEOUT_ERROR = ("The selected model did not respond in time.", "timeout_error")
+_UPSTREAM_ERROR = ("The upstream LLM request failed.", "upstream_error")
+
+
+@contextmanager
+def _stream_worker_guard(
+    span: Any,
+    model: str,
+    state: _StreamAccumulator,
+    *,
+    label: str,
+    emit_error: Callable[..., None],
+    out: "queue.Queue[Any]",
+    cancelled: threading.Event,
+) -> Iterator[None]:
+    """The HTTP status is already sent by the time a worker runs, so upstream
+    failures surface in-band as a protocol error frame rather than raising."""
+    try:
+        yield
+    except Exception as exc:
+        if isinstance(exc, LLMRateLimitError):
+            message, error_type = _RATE_LIMIT_ERROR
+        elif isinstance(exc, LLMTimeoutError):
+            message, error_type = _TIMEOUT_ERROR
+        else:
+            message, error_type = _UPSTREAM_ERROR
+        if span is not None:
+            span.set_error({"message": f"{type(exc).__name__}: {exc}", "data": None})
+        logger.exception(
+            "LLM gateway %s failed (%s) for model %s", label, error_type, model
+        )
+        emit_error(message=message, error_type=error_type)
+    finally:
+        try:
+            close = getattr(state.upstream, "close", None)
+            if callable(close):
+                close()
+        except Exception:
+            logger.exception("LLM gateway %s cleanup failed for model %s", label, model)
+        try:
+            if span is not None:
+                record_llm_span_output(
+                    span,
+                    output=state.text or None,
+                    usage=state.usage,
+                    reasoning="".join(state.reasoning) or None,
+                    tool_calls=_finalize_tool_calls(state.tool_call_buffer),
+                )
+        except Exception:
+            logger.exception(
+                "LLM gateway %s span cleanup failed for model %s", label, model
+            )
+        finally:
+            _put_stream_item(out, _STREAM_END, cancelled)
+
+
 def _stream_worker(
     llm: LLM,
     flow: LLMFlow,
@@ -278,14 +362,18 @@ def _stream_worker(
             llm, flow=flow, input_messages=messages, tools=tools
         ) as span,
     ):
-        accumulated_content: list[str] = []
-        accumulated_reasoning: list[str] = []
-        final_usage: Usage | None = None
-        tool_call_buffer: dict[int, ChatCompletionDeltaToolCall] = {}
+        state = _StreamAccumulator()
         sent_role = False
-        upstream: Iterator[ModelResponseStream] | None = None
-        try:
-            upstream = llm.stream(
+        with _stream_worker_guard(
+            span,
+            model,
+            state,
+            label="stream",
+            emit_error=partial(_emit_stream_error, out, cancelled),
+            out=out,
+            cancelled=cancelled,
+        ):
+            state.upstream = llm.stream(
                 prompt=messages,
                 tools=tools,
                 tool_choice=tool_choice,
@@ -293,17 +381,10 @@ def _stream_worker(
                 max_tokens=max_tokens,
                 reasoning_effort=reasoning_effort,
             )
-            for chunk in upstream:
+            for chunk in state.upstream:
                 if cancelled.is_set():
                     break
-                if chunk.usage:
-                    final_usage = chunk.usage
-                if chunk.choice.delta.content:
-                    accumulated_content.append(chunk.choice.delta.content)
-                if chunk.choice.delta.reasoning_content:
-                    accumulated_reasoning.append(chunk.choice.delta.reasoning_content)
-                for delta_tc in chunk.choice.delta.tool_calls:
-                    _merge_tool_call_delta(tool_call_buffer, delta_tc)
+                state.observe(chunk)
                 payload = ChatCompletionChunk.from_stream_chunk(
                     chunk, model, include_role=not sent_role
                 )
@@ -314,66 +395,6 @@ def _stream_worker(
                     break
             else:
                 _put_stream_item(out, "data: [DONE]\n\n", cancelled)
-        except LLMRateLimitError as exc:
-            if span is not None:
-                span.set_error(
-                    {"message": f"{type(exc).__name__}: {exc}", "data": None}
-                )
-            logger.exception("LLM gateway stream rate limited for model %s", model)
-            # The HTTP status is already sent; surface the failure in-band the
-            # way OpenAI-compatible servers do so the client fails the turn.
-            _emit_stream_error(
-                out,
-                cancelled,
-                message="The selected model is temporarily rate limited.",
-                error_type="rate_limit_error",
-            )
-        except LLMTimeoutError as exc:
-            if span is not None:
-                span.set_error(
-                    {"message": f"{type(exc).__name__}: {exc}", "data": None}
-                )
-            logger.exception("LLM gateway stream timed out for model %s", model)
-            _emit_stream_error(
-                out,
-                cancelled,
-                message="The selected model did not respond in time.",
-                error_type="timeout_error",
-            )
-        except Exception as exc:
-            if span is not None:
-                span.set_error(
-                    {"message": f"{type(exc).__name__}: {exc}", "data": None}
-                )
-            logger.exception("LLM gateway stream failed for model %s", model)
-            _emit_stream_error(
-                out,
-                cancelled,
-                message="The upstream LLM request failed.",
-                error_type="upstream_error",
-            )
-        finally:
-            try:
-                close = getattr(upstream, "close", None)
-                if callable(close):
-                    close()
-            except Exception:
-                logger.exception(
-                    "LLM gateway stream cleanup failed for model %s", model
-                )
-            try:
-                if span is not None:
-                    record_llm_span_output(
-                        span,
-                        output="".join(accumulated_content) or None,
-                        usage=final_usage,
-                        reasoning="".join(accumulated_reasoning) or None,
-                        tool_calls=_finalize_tool_calls(tool_call_buffer),
-                    )
-            except Exception:
-                logger.exception("LLM gateway span cleanup failed for model %s", model)
-            finally:
-                _put_stream_item(out, _STREAM_END, cancelled)
 
 
 def _run_bridged_stream(
@@ -394,12 +415,17 @@ def _run_bridged_stream(
     )
     try:
         while True:
-            try:
-                item = out.get(timeout=0.5)
-            except queue.Empty:
-                if not worker_thread.is_alive():
+            if worker_thread.is_alive():
+                try:
+                    item = out.get(timeout=0.5)
+                except queue.Empty:
+                    continue
+            else:
+                # Worker died before signalling: drain, or the stream truncates.
+                try:
+                    item = out.get_nowait()
+                except queue.Empty:
                     return
-                continue
             if item is _STREAM_END:
                 return
             yield item
@@ -407,30 +433,13 @@ def _run_bridged_stream(
         cancelled.set()
 
 
-def _stream_sse(
-    llm: LLM,
-    flow: LLMFlow,
-    messages: list[ChatCompletionMessage],
-    tools: list[dict[str, Any]] | None,
-    tool_choice: ToolChoiceOptions | None,
-    structured_response_format: dict[str, Any] | None,
-    max_tokens: int | None,
-    reasoning_effort: ReasoningEffort,
-    model: str,
-) -> Iterator[str]:
-    return _run_bridged_stream(
-        _stream_worker,
-        {
-            "llm": llm,
-            "flow": flow,
-            "messages": messages,
-            "tools": tools,
-            "tool_choice": tool_choice,
-            "structured_response_format": structured_response_format,
-            "max_tokens": max_tokens,
-            "reasoning_effort": reasoning_effort,
-            "model": model,
-        },
+def _sse_response(
+    worker: Callable[..., None], worker_kwargs: dict[str, Any]
+) -> StreamingResponse:
+    return StreamingResponse(
+        _run_bridged_stream(worker, worker_kwargs),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )
 
 
@@ -451,20 +460,19 @@ def handle_chat_completion(
     max_tokens = request.max_completion_tokens or request.max_tokens
 
     if request.stream:
-        return StreamingResponse(
-            _stream_sse(
-                llm=llm,
-                flow=flow,
-                messages=messages,
-                tools=request.tools,
-                tool_choice=tool_choice,
-                structured_response_format=request.response_format,
-                max_tokens=max_tokens,
-                reasoning_effort=reasoning_effort,
-                model=request.model,
-            ),
-            media_type="text/event-stream",
-            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        return _sse_response(
+            _stream_worker,
+            {
+                "llm": llm,
+                "flow": flow,
+                "messages": messages,
+                "tools": request.tools,
+                "tool_choice": tool_choice,
+                "structured_response_format": request.response_format,
+                "max_tokens": max_tokens,
+                "reasoning_effort": reasoning_effort,
+                "model": request.model,
+            },
         )
 
     with (
@@ -602,7 +610,7 @@ def _build_responses_output_items(
             ResponsesMessageItem.create(
                 id=message_item_id,
                 status="completed",
-                content=[ResponsesOutputTextPart.create(content)],
+                content=[ResponsesOutputTextPart.create(text=content)],
             )
         )
     items.extend(
@@ -644,34 +652,51 @@ def _responses_stream_worker(
         )
     )
     message_item_id = _new_id("msg")
+
+    def emit_error(*, message: str, error_type: str) -> None:
+        del error_type  # the Responses protocol carries only the message
+        emit(
+            ResponsesFailedEvent.create(
+                ResponsesObjectPayload.failed(
+                    response_id=response_id,
+                    created_at=created_at,
+                    model=model,
+                    message=message,
+                )
+            )
+        )
+
     # Runs on its own thread after the endpoint has returned the
     # StreamingResponse, so the trace must be opened here rather than in the
     # endpoint for the generation span to see an active trace.
     with (
-        _gateway_trace(flow, model),
+        _gateway_trace(flow, llm.config.model_name),
         llm_generation_span(
             llm, flow=flow, input_messages=messages, tools=tools
         ) as span,
     ):
-        accumulated_content: list[str] = []
-        accumulated_reasoning: list[str] = []
-        final_usage: Usage | None = None
+        state = _StreamAccumulator()
         text_item_open = False
-        tool_call_buffer: dict[int, ChatCompletionDeltaToolCall] = {}
-        upstream: Iterator[ModelResponseStream] | None = None
-        try:
-            upstream = llm.stream(
+        with _stream_worker_guard(
+            span,
+            model,
+            state,
+            label="responses stream",
+            emit_error=emit_error,
+            out=out,
+            cancelled=cancelled,
+        ):
+            state.upstream = llm.stream(
                 prompt=messages,
                 tools=tools,
                 tool_choice=tool_choice,
                 max_tokens=max_tokens,
                 reasoning_effort=reasoning_effort,
             )
-            for chunk in upstream:
+            for chunk in state.upstream:
                 if cancelled.is_set():
                     break
-                if chunk.usage:
-                    final_usage = chunk.usage
+                state.observe(chunk)
                 if chunk.choice.delta.content:
                     if not text_item_open:
                         # Open the item before the first delta; Codex drops
@@ -694,7 +719,6 @@ def _responses_stream_worker(
                         ):
                             break
                         text_item_open = True
-                    accumulated_content.append(chunk.choice.delta.content)
                     if not emit(
                         ResponsesOutputTextDeltaEvent.create(
                             item_id=message_item_id,
@@ -702,15 +726,19 @@ def _responses_stream_worker(
                         )
                     ):
                         break
-                if chunk.choice.delta.reasoning_content:
-                    accumulated_reasoning.append(chunk.choice.delta.reasoning_content)
-                for delta_tc in chunk.choice.delta.tool_calls:
-                    _merge_tool_call_delta(tool_call_buffer, delta_tc)
             else:
-                final_tool_calls = _finalize_tool_calls(tool_call_buffer)
-                full_text = "".join(accumulated_content)
+                # Build each item once and reuse it below: re-deriving items
+                # for the terminal payload remints ids the client never saw.
+                completed_items: list[ResponsesOutputItem] = []
                 if text_item_open:
+                    full_text = state.text
                     completed_part = ResponsesOutputTextPart.create(text=full_text)
+                    message_item = ResponsesMessageItem.create(
+                        id=message_item_id,
+                        status="completed",
+                        content=[completed_part],
+                    )
+                    completed_items.append(message_item)
                     emit(
                         ResponsesOutputTextDoneEvent.create(
                             item_id=message_item_id, output_index=0, text=full_text
@@ -725,20 +753,24 @@ def _responses_stream_worker(
                     )
                     emit(
                         ResponsesOutputItemDoneEvent.create(
-                            output_index=0,
-                            item=ResponsesMessageItem.create(
-                                id=message_item_id,
-                                status="completed",
-                                content=[completed_part],
-                            ),
+                            output_index=0, item=message_item
                         )
                     )
-                for tool_index, tool_call in enumerate(
-                    final_tool_calls or [], start=1 if text_item_open else 0
+                # Filter before enumerating, or a dropped nameless call leaves
+                # a hole in the output_index sequence.
+                call_items = [
+                    item
+                    for item in (
+                        _function_call_item(tool_call)
+                        for tool_call in _finalize_tool_calls(state.tool_call_buffer)
+                        or []
+                    )
+                    if item is not None
+                ]
+                for tool_index, call_item in enumerate(
+                    call_items, start=len(completed_items)
                 ):
-                    call_item = _function_call_item(tool_call)
-                    if call_item is None:
-                        continue
+                    completed_items.append(call_item)
                     emit(
                         ResponsesOutputItemAddedEvent.create(
                             output_index=tool_index, item=call_item
@@ -763,91 +795,11 @@ def _responses_stream_worker(
                             created_at=created_at,
                             model=model,
                             status="completed",
-                            output=_build_responses_output_items(
-                                "".join(accumulated_content) or None,
-                                final_tool_calls,
-                                message_item_id,
-                            ),
-                            usage=final_usage,
+                            output=completed_items,
+                            usage=state.usage,
                         )
                     )
                 )
-        except LLMRateLimitError as exc:
-            if span is not None:
-                span.set_error(
-                    {"message": f"{type(exc).__name__}: {exc}", "data": None}
-                )
-            logger.exception(
-                "LLM gateway responses stream rate limited for model %s", model
-            )
-            emit(
-                ResponsesFailedEvent.create(
-                    ResponsesObjectPayload.failed(
-                        response_id=response_id,
-                        created_at=created_at,
-                        model=model,
-                        message="The selected model is temporarily rate limited.",
-                    )
-                )
-            )
-        except LLMTimeoutError as exc:
-            if span is not None:
-                span.set_error(
-                    {"message": f"{type(exc).__name__}: {exc}", "data": None}
-                )
-            logger.exception(
-                "LLM gateway responses stream timed out for model %s", model
-            )
-            emit(
-                ResponsesFailedEvent.create(
-                    ResponsesObjectPayload.failed(
-                        response_id=response_id,
-                        created_at=created_at,
-                        model=model,
-                        message="The selected model did not respond in time.",
-                    )
-                )
-            )
-        except Exception as exc:
-            if span is not None:
-                span.set_error(
-                    {"message": f"{type(exc).__name__}: {exc}", "data": None}
-                )
-            logger.exception("LLM gateway responses stream failed for model %s", model)
-            emit(
-                ResponsesFailedEvent.create(
-                    ResponsesObjectPayload.failed(
-                        response_id=response_id,
-                        created_at=created_at,
-                        model=model,
-                        message="The upstream LLM request failed.",
-                    )
-                )
-            )
-        finally:
-            try:
-                close = getattr(upstream, "close", None)
-                if callable(close):
-                    close()
-            except Exception:
-                logger.exception(
-                    "LLM gateway responses stream cleanup failed for model %s", model
-                )
-            try:
-                if span is not None:
-                    record_llm_span_output(
-                        span,
-                        output="".join(accumulated_content) or None,
-                        usage=final_usage,
-                        reasoning="".join(accumulated_reasoning) or None,
-                        tool_calls=_finalize_tool_calls(tool_call_buffer),
-                    )
-            except Exception:
-                logger.exception(
-                    "LLM gateway responses span cleanup failed for model %s", model
-                )
-            finally:
-                _put_stream_item(out, _STREAM_END, cancelled)
 
 
 def handle_responses_request(
@@ -873,24 +825,20 @@ def handle_responses_request(
     created_at = int(time.time())
 
     if request.stream:
-        return StreamingResponse(
-            _run_bridged_stream(
-                _responses_stream_worker,
-                {
-                    "llm": llm,
-                    "flow": flow,
-                    "messages": messages,
-                    "tools": tools,
-                    "tool_choice": tool_choice,
-                    "max_tokens": max_tokens,
-                    "reasoning_effort": reasoning_effort,
-                    "model": request.model,
-                    "response_id": response_id,
-                    "created_at": created_at,
-                },
-            ),
-            media_type="text/event-stream",
-            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        return _sse_response(
+            _responses_stream_worker,
+            {
+                "llm": llm,
+                "flow": flow,
+                "messages": messages,
+                "tools": tools,
+                "tool_choice": tool_choice,
+                "max_tokens": max_tokens,
+                "reasoning_effort": reasoning_effort,
+                "model": request.model,
+                "response_id": response_id,
+                "created_at": created_at,
+            },
         )
 
     with (

--- a/backend/onyx/server/gateway/models.py
+++ b/backend/onyx/server/gateway/models.py
@@ -343,3 +343,170 @@ class ResponsesObjectPayload(_WireModel):
             output=output,
             **kwargs,
         )
+
+    @classmethod
+    def failed(
+        cls, *, response_id: str, created_at: int, model: str, message: str
+    ) -> "ResponsesObjectPayload":
+        return cls(
+            id=response_id,
+            object="response",
+            created_at=created_at,
+            status="failed",
+            model=model,
+            output=[],
+            error={"message": message, "type": "server_error"},
+        )
+
+
+class ResponsesCreatedEvent(_WireModel):
+    type: Literal["response.created"] = "response.created"
+    response: ResponsesObjectPayload
+
+    @classmethod
+    def create(cls, response: ResponsesObjectPayload) -> "ResponsesCreatedEvent":
+        return cls(type="response.created", response=response)
+
+
+class ResponsesOutputTextDeltaEvent(_WireModel):
+    type: Literal["response.output_text.delta"] = "response.output_text.delta"
+    item_id: str
+    output_index: int = 0
+    content_index: int = 0
+    delta: str
+
+    @classmethod
+    def create(cls, *, item_id: str, delta: str) -> "ResponsesOutputTextDeltaEvent":
+        return cls(
+            type="response.output_text.delta",
+            item_id=item_id,
+            output_index=0,
+            content_index=0,
+            delta=delta,
+        )
+
+
+class ResponsesOutputItemAddedEvent(_WireModel):
+    type: Literal["response.output_item.added"] = "response.output_item.added"
+    output_index: int = 0
+    item: ResponsesOutputItem
+
+    @classmethod
+    def create(
+        cls, *, output_index: int, item: ResponsesOutputItem
+    ) -> "ResponsesOutputItemAddedEvent":
+        return cls(
+            type="response.output_item.added", output_index=output_index, item=item
+        )
+
+
+class ResponsesOutputItemDoneEvent(_WireModel):
+    type: Literal["response.output_item.done"] = "response.output_item.done"
+    output_index: int = 0
+    item: ResponsesOutputItem
+
+    @classmethod
+    def create(
+        cls, *, output_index: int, item: ResponsesOutputItem
+    ) -> "ResponsesOutputItemDoneEvent":
+        return cls(
+            type="response.output_item.done", output_index=output_index, item=item
+        )
+
+
+class ResponsesContentPartAddedEvent(_WireModel):
+    type: Literal["response.content_part.added"] = "response.content_part.added"
+    item_id: str
+    output_index: int = 0
+    content_index: int = 0
+    part: ResponsesOutputTextPart
+
+    @classmethod
+    def create(
+        cls, *, item_id: str, output_index: int, part: ResponsesOutputTextPart
+    ) -> "ResponsesContentPartAddedEvent":
+        return cls(
+            type="response.content_part.added",
+            item_id=item_id,
+            output_index=output_index,
+            content_index=0,
+            part=part,
+        )
+
+
+class ResponsesContentPartDoneEvent(_WireModel):
+    type: Literal["response.content_part.done"] = "response.content_part.done"
+    item_id: str
+    output_index: int = 0
+    content_index: int = 0
+    part: ResponsesOutputTextPart
+
+    @classmethod
+    def create(
+        cls, *, item_id: str, output_index: int, part: ResponsesOutputTextPart
+    ) -> "ResponsesContentPartDoneEvent":
+        return cls(
+            type="response.content_part.done",
+            item_id=item_id,
+            output_index=output_index,
+            content_index=0,
+            part=part,
+        )
+
+
+class ResponsesOutputTextDoneEvent(_WireModel):
+    type: Literal["response.output_text.done"] = "response.output_text.done"
+    item_id: str
+    output_index: int = 0
+    content_index: int = 0
+    text: str
+
+    @classmethod
+    def create(
+        cls, *, item_id: str, output_index: int, text: str
+    ) -> "ResponsesOutputTextDoneEvent":
+        return cls(
+            type="response.output_text.done",
+            item_id=item_id,
+            output_index=output_index,
+            content_index=0,
+            text=text,
+        )
+
+
+class ResponsesFunctionCallArgumentsDoneEvent(_WireModel):
+    type: Literal["response.function_call_arguments.done"] = (
+        "response.function_call_arguments.done"
+    )
+    item_id: str
+    output_index: int = 0
+    arguments: str
+
+    @classmethod
+    def create(
+        cls, *, item_id: str, output_index: int, arguments: str
+    ) -> "ResponsesFunctionCallArgumentsDoneEvent":
+        return cls(
+            type="response.function_call_arguments.done",
+            item_id=item_id,
+            output_index=output_index,
+            arguments=arguments,
+        )
+
+
+class ResponsesCompletedEvent(_WireModel):
+    type: Literal["response.completed"] = "response.completed"
+    response: ResponsesObjectPayload
+
+    @classmethod
+    def create(cls, response: ResponsesObjectPayload) -> "ResponsesCompletedEvent":
+        return cls(type="response.completed", response=response)
+
+
+class ResponsesFailedEvent(_WireModel):
+    type: Literal["response.failed"] = "response.failed"
+    response: ResponsesObjectPayload
+
+    @classmethod
+    def create(cls, response: ResponsesObjectPayload) -> "ResponsesFailedEvent":
+        return cls(type="response.failed", response=response)

--- a/backend/onyx/server/gateway/models.py
+++ b/backend/onyx/server/gateway/models.py
@@ -245,6 +245,11 @@ class ResponsesRequest(BaseModel):
     reasoning: dict[str, Any] | None = None
 
 
+# Subset of the Responses error enum we can actually produce; the schema has
+# no timeout code, so timeouts report as server_error.
+ResponsesErrorCode: TypeAlias = Literal["server_error", "rate_limit_exceeded"]
+
+
 class ResponsesOutputTextPart(_WireModel):
     type: Literal["output_text"] = "output_text"
     text: str
@@ -317,6 +322,11 @@ class ResponsesObjectPayload(_WireModel):
     status: str
     model: str
     output: list[ResponsesOutputItem]
+    # Required by the Responses schema even when empty, so a strict SDK client
+    # can parse the object; we do not echo the request's tools.
+    parallel_tool_calls: bool = True
+    tool_choice: str = "auto"
+    tools: list[dict[str, Any]] = Field(default_factory=list)
     usage: ResponsesUsagePayload | None = None
     error: dict[str, Any] | None = None
 
@@ -341,12 +351,21 @@ class ResponsesObjectPayload(_WireModel):
             status=status,
             model=model,
             output=output,
+            parallel_tool_calls=True,
+            tool_choice="auto",
+            tools=[],
             **kwargs,
         )
 
     @classmethod
     def failed(
-        cls, *, response_id: str, created_at: int, model: str, message: str
+        cls,
+        *,
+        response_id: str,
+        created_at: int,
+        model: str,
+        message: str,
+        code: ResponsesErrorCode = "server_error",
     ) -> "ResponsesObjectPayload":
         return cls(
             id=response_id,
@@ -355,7 +374,10 @@ class ResponsesObjectPayload(_WireModel):
             status="failed",
             model=model,
             output=[],
-            error={"message": message, "type": "server_error"},
+            parallel_tool_calls=True,
+            tool_choice="auto",
+            tools=[],
+            error={"code": code, "message": message},
         )
 
 
@@ -374,6 +396,7 @@ class ResponsesOutputTextDeltaEvent(_WireModel):
     output_index: int = 0
     content_index: int = 0
     delta: str
+    logprobs: list[Any] = Field(default_factory=list)
 
     @classmethod
     def create(cls, *, item_id: str, delta: str) -> "ResponsesOutputTextDeltaEvent":
@@ -383,6 +406,7 @@ class ResponsesOutputTextDeltaEvent(_WireModel):
             output_index=0,
             content_index=0,
             delta=delta,
+            logprobs=[],
         )
 
 
@@ -460,6 +484,7 @@ class ResponsesOutputTextDoneEvent(_WireModel):
     output_index: int = 0
     content_index: int = 0
     text: str
+    logprobs: list[Any] = Field(default_factory=list)
 
     @classmethod
     def create(
@@ -471,6 +496,7 @@ class ResponsesOutputTextDoneEvent(_WireModel):
             output_index=output_index,
             content_index=0,
             text=text,
+            logprobs=[],
         )
 
 
@@ -481,16 +507,18 @@ class ResponsesFunctionCallArgumentsDoneEvent(_WireModel):
     item_id: str
     output_index: int = 0
     arguments: str
+    name: str
 
     @classmethod
     def create(
-        cls, *, item_id: str, output_index: int, arguments: str
+        cls, *, item_id: str, output_index: int, arguments: str, name: str
     ) -> "ResponsesFunctionCallArgumentsDoneEvent":
         return cls(
             type="response.function_call_arguments.done",
             item_id=item_id,
             output_index=output_index,
             arguments=arguments,
+            name=name,
         )
 
 

--- a/backend/onyx/server/gateway/models.py
+++ b/backend/onyx/server/gateway/models.py
@@ -251,7 +251,7 @@ class ResponsesOutputTextPart(_WireModel):
     annotations: list[Any] = Field(default_factory=list)
 
     @classmethod
-    def create(cls, text: str) -> "ResponsesOutputTextPart":
+    def create(cls, *, text: str) -> "ResponsesOutputTextPart":
         return cls(type="output_text", text=text, annotations=[])
 
 

--- a/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
@@ -1245,13 +1245,168 @@ def test_handle_responses_request_non_streaming_returns_completed_response() -> 
     assert payload["usage"]["input_tokens"] == 120
 
 
-def test_handle_responses_request_rejects_streaming() -> None:
-    request = ResponsesRequest(model="1/test", input="say hi", stream=True)
+class _ResponsesStreamLLM(_ConfigOnlyLLM):
+    """Replays a fixed chunk sequence through the responses stream."""
 
-    with pytest.raises(OnyxError) as exc_info:
-        _handle_responses_call(request)
+    def __init__(self, chunks: list[ModelResponseStream]) -> None:
+        super().__init__(
+            LLMConfig(
+                model_provider="openai",
+                model_name="test",
+                temperature=0,
+                max_input_tokens=1_000,
+            )
+        )
+        self._chunks = chunks
 
-    assert exc_info.value.error_code is OnyxErrorCode.NOT_IMPLEMENTED
+    def stream(self, *args: object, **kwargs: object):  # type: ignore[no-untyped-def,override]
+        del args, kwargs
+        yield from self._chunks
+
+
+_TEXT_CHUNKS = [
+    ModelResponseStream(
+        id="r1", created="0", choice=StreamingChoice(delta=Delta(content="Hi"))
+    ),
+    ModelResponseStream(
+        id="r1",
+        created="0",
+        choice=StreamingChoice(finish_reason="stop", delta=Delta()),
+        usage=_wire_usage(),
+    ),
+]
+
+_TOOL_CALL_CHUNKS = [
+    ModelResponseStream(
+        id="s1",
+        created="0",
+        choice=StreamingChoice(
+            delta=Delta(
+                tool_calls=[
+                    ChatCompletionDeltaToolCall(
+                        id="call_1",
+                        index=0,
+                        function=FunctionCall(name="bash", arguments='{"cmd":"ls"}'),
+                    )
+                ]
+            )
+        ),
+    ),
+    ModelResponseStream(
+        id="s1",
+        created="0",
+        choice=StreamingChoice(finish_reason="tool_calls", delta=Delta()),
+    ),
+]
+
+
+def _responses_stream_events(
+    chunks: list[ModelResponseStream],
+    *,
+    tools: list[dict[str, Any]] | None = None,
+    model: str = "1/test",
+    response_id: str = "resp_1",
+) -> list[dict[str, Any]]:
+    with patch.object(gateway_api, "llm_generation_span", return_value=nullcontext()):
+        frames = list(
+            gateway_api._run_bridged_stream(
+                gateway_api._responses_stream_worker,
+                {
+                    "llm": _ResponsesStreamLLM(chunks),
+                    "flow": LLMFlow.CRAFT_LLM_GENERATION,
+                    "messages": [UserMessage(content="hi")],
+                    "tools": tools,
+                    "tool_choice": None,
+                    "max_tokens": None,
+                    "reasoning_effort": ReasoningEffort.AUTO,
+                    "model": model,
+                    "response_id": response_id,
+                    "created_at": 100,
+                },
+            )
+        )
+    return [json.loads(frame.removeprefix("data: ")) for frame in frames]
+
+
+def test_responses_stream_emits_created_first_and_completed_last() -> None:
+    events = _responses_stream_events(_TEXT_CHUNKS)
+    assert events[0]["type"] == "response.created"
+    assert events[0]["response"]["status"] == "in_progress"
+    assert events[-1]["type"] == "response.completed"
+    assert events[-1]["response"]["status"] == "completed"
+    assert events[-1]["response"]["output"][0]["content"][0]["text"] == "Hi"
+    delta_events = [e for e in events if e["type"] == "response.output_text.delta"]
+    assert delta_events[0]["delta"] == "Hi"
+
+
+def test_responses_stream_emits_full_output_item_lifecycle_in_order() -> None:
+    """Regression test: Codex 0.145 rejects any output_text.delta whose item
+    was never opened ("OutputTextDelta without active item"). Every delta
+    must be bracketed by output_item.added/content_part.added before it and
+    output_text.done/content_part.done/output_item.done after, and every
+    lifecycle event's item_id must match the item opened in output_item.added."""
+    events = _responses_stream_events(_TEXT_CHUNKS)
+    event_types = [e["type"] for e in events]
+
+    assert event_types == [
+        "response.created",
+        "response.output_item.added",
+        "response.content_part.added",
+        "response.output_text.delta",
+        "response.output_text.done",
+        "response.content_part.done",
+        "response.output_item.done",
+        "response.completed",
+    ]
+
+    added_event = events[1]
+    assert added_event["item"]["type"] == "message"
+    assert added_event["item"]["status"] == "in_progress"
+    message_item_id = added_event["item"]["id"]
+
+    for event in events[2:7]:
+        item_id = (
+            event.get("item_id")
+            if "item_id" in event
+            else event.get("item", {}).get("id")
+        )
+        assert item_id == message_item_id
+
+    delta_event = events[3]
+    assert delta_event["delta"] == "Hi"
+    assert events[4]["text"] == "Hi"
+    assert events[5]["part"]["text"] == "Hi"
+    done_item_event = events[6]
+    assert done_item_event["item"]["status"] == "completed"
+    assert done_item_event["item"]["content"][0]["text"] == "Hi"
+
+
+def test_responses_stream_tool_call_gets_own_output_item_lifecycle() -> None:
+    """A text-free tool-call turn must still open/close a function_call
+    output item — no text item lifecycle should appear at all."""
+    events = _responses_stream_events(_TOOL_CALL_CHUNKS, response_id="resp_2")
+    event_types = [e["type"] for e in events]
+
+    assert event_types == [
+        "response.created",
+        "response.output_item.added",
+        "response.function_call_arguments.done",
+        "response.output_item.done",
+        "response.completed",
+    ]
+
+    added_event = events[1]
+    assert added_event["item"]["type"] == "function_call"
+    assert added_event["output_index"] == 0
+    call_item_id = added_event["item"]["id"]
+
+    args_done_event = events[2]
+    assert args_done_event["item_id"] == call_item_id
+    assert args_done_event["arguments"] == '{"cmd":"ls"}'
+
+    done_event = events[3]
+    assert done_event["item"]["id"] == call_item_id
+    assert done_event["item"]["status"] == "completed"
 
 
 def test_responses_gateway_route_carries_same_permission_dependency() -> None:
@@ -1439,6 +1594,35 @@ def test_codex_capture_converts_without_rejecting_input() -> None:
     assert tools is not None
     assert {t["type"] for t in tools} == {"function"}
     assert len(tools) < len(request.tools or [])
+
+
+def test_codex_capture_streams_valid_item_lifecycle() -> None:
+    """The invariant Codex enforces: no output_text.delta may reference an
+    item that was not previously opened by output_item.added."""
+    request = ResponsesRequest.model_validate(_codex_fixture())
+
+    events = _responses_stream_events(
+        _TEXT_CHUNKS,
+        tools=gateway_api._responses_tools(request),
+        model=request.model,
+        response_id="resp_replay",
+    )
+    assert events[0]["type"] == "response.created"
+    assert events[-1]["type"] == "response.completed"
+
+    open_items: set[str] = set()
+    for event in events:
+        if event["type"] == "response.output_item.added":
+            open_items.add(event["item"]["id"])
+        elif event["type"] in (
+            "response.output_text.delta",
+            "response.output_text.done",
+            "response.content_part.added",
+            "response.content_part.done",
+        ):
+            assert event["item_id"] in open_items, (
+                f"{event['type']} referenced unopened item {event['item_id']}"
+            )
 
 
 def test_responses_tool_round_trip_assistant_content_is_flattened() -> None:

--- a/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import threading
-from collections.abc import Awaitable, Callable, Iterator
+from collections.abc import Awaitable, Callable, Generator, Iterator
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from typing import Any, cast
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
 from fastapi.routing import APIRoute
 from sqlalchemy.orm import Session
 
@@ -131,6 +132,25 @@ class _ConfigOnlyLLM(LLM):
         return self._config
 
 
+class _ChunkStreamLLM(_ConfigOnlyLLM):
+    def __init__(
+        self, chunks: list[ModelResponseStream], provider: str = "openai"
+    ) -> None:
+        super().__init__(
+            LLMConfig(
+                model_provider=provider,
+                model_name="test",
+                temperature=0,
+                max_input_tokens=1_000,
+            )
+        )
+        self._chunks = chunks
+
+    def stream(self, *args: object, **kwargs: object):  # type: ignore[no-untyped-def,override]
+        del args, kwargs
+        yield from self._chunks
+
+
 def test_resolve_model_preserves_slashes_after_provider_id() -> None:
     model = _model("anthropic/claude-3.5-sonnet")
     provider = _provider(23, "openrouter", [model])
@@ -241,16 +261,19 @@ class _RaisingCloseLLM(_ConfigOnlyLLM):
 
 
 def _gateway_stream(llm: LLM):
-    return gateway_api._stream_sse(
-        llm=llm,
-        flow=LLMFlow.CRAFT_LLM_GENERATION,
-        messages=[UserMessage(content="hello")],
-        tools=None,
-        tool_choice=None,
-        structured_response_format=None,
-        max_tokens=None,
-        reasoning_effort=ReasoningEffort.AUTO,
-        model="1/test",
+    return gateway_api._run_bridged_stream(
+        gateway_api._stream_worker,
+        {
+            "llm": llm,
+            "flow": LLMFlow.CRAFT_LLM_GENERATION,
+            "messages": [UserMessage(content="hello")],
+            "tools": None,
+            "tool_choice": None,
+            "structured_response_format": None,
+            "max_tokens": None,
+            "reasoning_effort": ReasoningEffort.AUTO,
+            "model": "1/test",
+        },
     )
 
 
@@ -503,58 +526,47 @@ def test_completion_payload_serializes_openai_shape() -> None:
     }
 
 
-class _ToolCallStreamLLM(_ConfigOnlyLLM):
-    def __init__(self) -> None:
-        super().__init__(
-            LLMConfig(
-                model_provider="openai",
-                model_name="test",
-                temperature=0,
-                max_input_tokens=1_000,
+_TOOL_CALL_STREAM_CHUNKS = [
+    ModelResponseStream(
+        id="s1",
+        created="0",
+        choice=StreamingChoice(
+            delta=Delta(
+                tool_calls=[
+                    ChatCompletionDeltaToolCall(
+                        id="call_1",
+                        index=0,
+                        function=FunctionCall(name="bash", arguments=""),
+                    )
+                ]
             )
-        )
-
-    def stream(self, *args: object, **kwargs: object):
-        del args, kwargs
-        yield ModelResponseStream(
-            id="s1",
-            created="0",
-            choice=StreamingChoice(
-                delta=Delta(
-                    tool_calls=[
-                        ChatCompletionDeltaToolCall(
-                            id="call_1",
-                            index=0,
-                            function=FunctionCall(name="bash", arguments=""),
-                        )
-                    ]
-                )
-            ),
-        )
-        yield ModelResponseStream(
-            id="s1",
-            created="0",
-            choice=StreamingChoice(
-                delta=Delta(
-                    tool_calls=[
-                        ChatCompletionDeltaToolCall(
-                            index=0,
-                            function=FunctionCall(arguments='{"cmd":"ls"}'),
-                        )
-                    ]
-                )
-            ),
-        )
-        yield ModelResponseStream(
-            id="s1",
-            created="0",
-            choice=StreamingChoice(finish_reason="tool_calls", delta=Delta()),
-            usage=_wire_usage(),
-        )
+        ),
+    ),
+    ModelResponseStream(
+        id="s1",
+        created="0",
+        choice=StreamingChoice(
+            delta=Delta(
+                tool_calls=[
+                    ChatCompletionDeltaToolCall(
+                        index=0,
+                        function=FunctionCall(arguments='{"cmd":"ls"}'),
+                    )
+                ]
+            )
+        ),
+    ),
+    ModelResponseStream(
+        id="s1",
+        created="0",
+        choice=StreamingChoice(finish_reason="tool_calls", delta=Delta()),
+        usage=_wire_usage(),
+    ),
+]
 
 
 def test_stream_emits_openai_tool_call_deltas_and_usage() -> None:
-    frames = list(_gateway_stream(_ToolCallStreamLLM()))
+    frames = list(_gateway_stream(_ChunkStreamLLM(_TOOL_CALL_STREAM_CHUNKS)))
 
     assert frames[-1] == "data: [DONE]\n\n"
     payloads = [json.loads(frame.removeprefix("data: ")) for frame in frames[:-1]]
@@ -577,34 +589,27 @@ def test_stream_emits_openai_tool_call_deltas_and_usage() -> None:
     assert final["usage"]["prompt_tokens_details"]["cached_tokens"] == 100
 
 
-class _ReasoningStreamLLM(_ConfigOnlyLLM):
-    def __init__(self) -> None:
-        super().__init__(
-            LLMConfig(
-                model_provider="anthropic",
-                model_name="test",
-                temperature=0,
-                max_input_tokens=1_000,
-            )
-        )
+_REASONING_STREAM_CHUNKS = [
+    ModelResponseStream(
+        id="r1",
+        created="0",
+        choice=StreamingChoice(delta=Delta(reasoning_content="thinking ")),
+    ),
+    ModelResponseStream(
+        id="r1",
+        created="0",
+        choice=StreamingChoice(delta=Delta(reasoning_content="hard")),
+    ),
+    ModelResponseStream(
+        id="r1",
+        created="0",
+        choice=StreamingChoice(finish_reason="stop", delta=Delta(content="done")),
+    ),
+]
 
-    def stream(self, *args: object, **kwargs: object):
-        del args, kwargs
-        yield ModelResponseStream(
-            id="r1",
-            created="0",
-            choice=StreamingChoice(delta=Delta(reasoning_content="thinking ")),
-        )
-        yield ModelResponseStream(
-            id="r1",
-            created="0",
-            choice=StreamingChoice(delta=Delta(reasoning_content="hard")),
-        )
-        yield ModelResponseStream(
-            id="r1",
-            created="0",
-            choice=StreamingChoice(finish_reason="stop", delta=Delta(content="done")),
-        )
+
+def _reasoning_stream_llm() -> _ChunkStreamLLM:
+    return _ChunkStreamLLM(_REASONING_STREAM_CHUNKS, provider="anthropic")
 
 
 def test_stream_records_accumulated_reasoning_on_span() -> None:
@@ -612,7 +617,7 @@ def test_stream_records_accumulated_reasoning_on_span() -> None:
         patch.object(gateway_api, "llm_generation_span"),
         patch.object(gateway_api, "record_llm_span_output") as record,
     ):
-        frames = list(_gateway_stream(_ReasoningStreamLLM()))
+        frames = list(_gateway_stream(_reasoning_stream_llm()))
 
     assert frames[-1] == "data: [DONE]\n\n"
     record.assert_called_once()
@@ -646,7 +651,7 @@ def _assert_gateway_trace(active: Any) -> None:
 def test_stream_worker_opens_trace_before_generation_span() -> None:
     traces: list[Any] = []
     with _capture_trace_at_generation_span(traces):
-        frames = list(_gateway_stream(_ReasoningStreamLLM()))
+        frames = list(_gateway_stream(_reasoning_stream_llm()))
 
     assert frames[-1] == "data: [DONE]\n\n"
     (active,) = traces
@@ -1245,28 +1250,14 @@ def test_handle_responses_request_non_streaming_returns_completed_response() -> 
     assert payload["usage"]["input_tokens"] == 120
 
 
-class _ResponsesStreamLLM(_ConfigOnlyLLM):
-    """Replays a fixed chunk sequence through the responses stream."""
-
-    def __init__(self, chunks: list[ModelResponseStream]) -> None:
-        super().__init__(
-            LLMConfig(
-                model_provider="openai",
-                model_name="test",
-                temperature=0,
-                max_input_tokens=1_000,
-            )
-        )
-        self._chunks = chunks
-
-    def stream(self, *args: object, **kwargs: object):  # type: ignore[no-untyped-def,override]
-        del args, kwargs
-        yield from self._chunks
-
-
 _TEXT_CHUNKS = [
     ModelResponseStream(
         id="r1", created="0", choice=StreamingChoice(delta=Delta(content="Hi"))
+    ),
+    # Two content chunks: with one, a regression re-opening the output item
+    # per delta (Codex-fatal) would still pass.
+    ModelResponseStream(
+        id="r1", created="0", choice=StreamingChoice(delta=Delta(content=" there"))
     ),
     ModelResponseStream(
         id="r1",
@@ -1301,18 +1292,21 @@ _TOOL_CALL_CHUNKS = [
 
 
 def _responses_stream_events(
-    chunks: list[ModelResponseStream],
+    llm: LLM,
     *,
     tools: list[dict[str, Any]] | None = None,
     model: str = "1/test",
     response_id: str = "resp_1",
+    span: Any | None = None,
 ) -> list[dict[str, Any]]:
-    with patch.object(gateway_api, "llm_generation_span", return_value=nullcontext()):
+    with patch.object(
+        gateway_api, "llm_generation_span", return_value=nullcontext(span)
+    ):
         frames = list(
             gateway_api._run_bridged_stream(
                 gateway_api._responses_stream_worker,
                 {
-                    "llm": _ResponsesStreamLLM(chunks),
+                    "llm": llm,
                     "flow": LLMFlow.CRAFT_LLM_GENERATION,
                     "messages": [UserMessage(content="hi")],
                     "tools": tools,
@@ -1329,14 +1323,14 @@ def _responses_stream_events(
 
 
 def test_responses_stream_emits_created_first_and_completed_last() -> None:
-    events = _responses_stream_events(_TEXT_CHUNKS)
+    events = _responses_stream_events(_ChunkStreamLLM(_TEXT_CHUNKS))
     assert events[0]["type"] == "response.created"
     assert events[0]["response"]["status"] == "in_progress"
     assert events[-1]["type"] == "response.completed"
     assert events[-1]["response"]["status"] == "completed"
-    assert events[-1]["response"]["output"][0]["content"][0]["text"] == "Hi"
+    assert events[-1]["response"]["output"][0]["content"][0]["text"] == "Hi there"
     delta_events = [e for e in events if e["type"] == "response.output_text.delta"]
-    assert delta_events[0]["delta"] == "Hi"
+    assert [e["delta"] for e in delta_events] == ["Hi", " there"]
 
 
 def test_responses_stream_emits_full_output_item_lifecycle_in_order() -> None:
@@ -1345,13 +1339,14 @@ def test_responses_stream_emits_full_output_item_lifecycle_in_order() -> None:
     must be bracketed by output_item.added/content_part.added before it and
     output_text.done/content_part.done/output_item.done after, and every
     lifecycle event's item_id must match the item opened in output_item.added."""
-    events = _responses_stream_events(_TEXT_CHUNKS)
+    events = _responses_stream_events(_ChunkStreamLLM(_TEXT_CHUNKS))
     event_types = [e["type"] for e in events]
 
     assert event_types == [
         "response.created",
         "response.output_item.added",
         "response.content_part.added",
+        "response.output_text.delta",
         "response.output_text.delta",
         "response.output_text.done",
         "response.content_part.done",
@@ -1364,7 +1359,7 @@ def test_responses_stream_emits_full_output_item_lifecycle_in_order() -> None:
     assert added_event["item"]["status"] == "in_progress"
     message_item_id = added_event["item"]["id"]
 
-    for event in events[2:7]:
+    for event in events[2:-1]:
         item_id = (
             event.get("item_id")
             if "item_id" in event
@@ -1372,19 +1367,21 @@ def test_responses_stream_emits_full_output_item_lifecycle_in_order() -> None:
         )
         assert item_id == message_item_id
 
-    delta_event = events[3]
-    assert delta_event["delta"] == "Hi"
-    assert events[4]["text"] == "Hi"
-    assert events[5]["part"]["text"] == "Hi"
-    done_item_event = events[6]
+    assert [e["delta"] for e in events[3:5]] == ["Hi", " there"]
+    assert events[5]["text"] == "Hi there"
+    assert events[6]["part"]["text"] == "Hi there"
+    done_item_event = events[7]
     assert done_item_event["item"]["status"] == "completed"
-    assert done_item_event["item"]["content"][0]["text"] == "Hi"
+    assert done_item_event["item"]["content"][0]["text"] == "Hi there"
+    assert events[-1]["response"]["output"] == [done_item_event["item"]]
 
 
 def test_responses_stream_tool_call_gets_own_output_item_lifecycle() -> None:
     """A text-free tool-call turn must still open/close a function_call
     output item — no text item lifecycle should appear at all."""
-    events = _responses_stream_events(_TOOL_CALL_CHUNKS, response_id="resp_2")
+    events = _responses_stream_events(
+        _ChunkStreamLLM(_TOOL_CALL_CHUNKS), response_id="resp_2"
+    )
     event_types = [e["type"] for e in events]
 
     assert event_types == [
@@ -1407,6 +1404,175 @@ def test_responses_stream_tool_call_gets_own_output_item_lifecycle() -> None:
     done_event = events[3]
     assert done_event["item"]["id"] == call_item_id
     assert done_event["item"]["status"] == "completed"
+
+    assert [item["id"] for item in events[-1]["response"]["output"]] == [call_item_id]
+
+
+_TEXT_AND_TOOL_CALL_CHUNKS = [
+    ModelResponseStream(
+        id="m1", created="0", choice=StreamingChoice(delta=Delta(content="Running"))
+    ),
+    ModelResponseStream(
+        id="m1",
+        created="0",
+        choice=StreamingChoice(
+            delta=Delta(
+                tool_calls=[
+                    ChatCompletionDeltaToolCall(
+                        id="call_9",
+                        index=0,
+                        function=FunctionCall(name="bash", arguments='{"cmd":"ls"}'),
+                    )
+                ]
+            )
+        ),
+    ),
+    ModelResponseStream(
+        id="m1",
+        created="0",
+        choice=StreamingChoice(finish_reason="tool_calls", delta=Delta()),
+    ),
+]
+
+
+def test_responses_stream_text_and_tool_call_get_separate_output_indices() -> None:
+    """Reusing output_index 0 for both makes Codex reject the tool call."""
+    events = _responses_stream_events(
+        _ChunkStreamLLM(_TEXT_AND_TOOL_CALL_CHUNKS), response_id="resp_3"
+    )
+
+    message_id = events[1]["item"]["id"]
+    assert events[1]["output_index"] == 0
+
+    call_added = next(
+        e
+        for e in events
+        if e["type"] == "response.output_item.added"
+        and e["item"]["type"] == "function_call"
+    )
+    assert call_added["output_index"] == 1
+    assert call_added["item"]["id"] != message_id
+
+    args_done = next(
+        e for e in events if e["type"] == "response.function_call_arguments.done"
+    )
+    assert args_done["output_index"] == 1
+    assert args_done["item_id"] == call_added["item"]["id"]
+
+    output = events[-1]["response"]["output"]
+    assert [item["type"] for item in output] == ["message", "function_call"]
+    assert output[0]["content"][0]["text"] == "Running"
+    assert [item["id"] for item in output] == [message_id, call_added["item"]["id"]]
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        LLMRateLimitError("slow down"),
+        LLMTimeoutError("too slow"),
+        RuntimeError("secret-provider-response"),
+    ],
+)
+def test_responses_stream_upstream_failure_emits_response_failed(
+    exc: Exception,
+) -> None:
+    events = _responses_stream_events(
+        _StreamingLLM(threading.Event(), fail=True, exc=exc), response_id="resp_err"
+    )
+
+    assert events[0]["type"] == "response.created"
+    assert events[-1]["type"] == "response.failed"
+    assert events[-1]["response"]["status"] == "failed"
+    assert events[-1]["response"]["id"] == "resp_err"
+    assert "secret-provider-response" not in json.dumps(events)
+    assert not any(e["type"] == "response.completed" for e in events)
+
+
+def test_responses_stream_disconnect_closes_upstream_and_omits_completed() -> None:
+    closed = threading.Event()
+    with patch.object(gateway_api, "llm_generation_span", return_value=nullcontext()):
+        stream = gateway_api._run_bridged_stream(
+            gateway_api._responses_stream_worker,
+            {
+                "llm": _StreamingLLM(closed),
+                "flow": LLMFlow.CRAFT_LLM_GENERATION,
+                "messages": [UserMessage(content="hi")],
+                "tools": None,
+                "tool_choice": None,
+                "max_tokens": None,
+                "reasoning_effort": ReasoningEffort.AUTO,
+                "model": "1/test",
+                "response_id": "resp_gone",
+                "created_at": 100,
+            },
+        )
+        seen = [json.loads(next(stream).removeprefix("data: ")) for _ in range(2)]
+        cast(Generator[str, None, None], stream).close()
+
+    assert closed.wait(timeout=2)
+    assert seen[0]["type"] == "response.created"
+    assert not any(event["type"] == "response.completed" for event in seen)
+
+
+def test_responses_stream_records_output_usage_and_reasoning_on_span() -> None:
+    """The span must be truthy: with a null span every assertion here passes
+    silently, because the worker skips all span recording."""
+    span = MagicMock()
+
+    with patch.object(gateway_api, "record_llm_span_output") as record:
+        _responses_stream_events(
+            _reasoning_stream_llm(), span=span, response_id="resp_span"
+        )
+
+    record.assert_called_once()
+    assert record.call_args.args[0] is span
+    assert record.call_args.kwargs["reasoning"] == "thinking hard"
+    assert record.call_args.kwargs["output"] == "done"
+
+    with patch.object(gateway_api, "record_llm_span_output") as record:
+        _responses_stream_events(
+            _ChunkStreamLLM(_TEXT_CHUNKS), span=span, response_id="resp_usage"
+        )
+
+    usage = record.call_args.kwargs["usage"]
+    assert usage is not None and usage.prompt_tokens == 120
+
+
+@pytest.mark.asyncio
+async def test_handle_responses_request_streaming_returns_event_stream() -> None:
+    request = ResponsesRequest.model_validate({**_codex_fixture(), "stream": True})
+
+    with (
+        patch.object(
+            gateway_api, "llm_from_provider", return_value=_ChunkStreamLLM(_TEXT_CHUNKS)
+        ),
+        patch.object(gateway_api, "llm_generation_span", return_value=nullcontext()),
+    ):
+        result = _handle_responses_call(request)
+
+        assert isinstance(result, StreamingResponse)
+        assert result.media_type == "text/event-stream"
+        events = [
+            json.loads(frame.removeprefix("data: "))
+            async for frame in result.body_iterator
+        ]
+
+    # The invariant Codex enforces: no event may reference an unopened item.
+    assert events[0]["type"] == "response.created"
+    assert events[-1]["type"] == "response.completed"
+    open_items: set[str] = set()
+    for event in events:
+        if event["type"] == "response.output_item.added":
+            open_items.add(event["item"]["id"])
+        elif event["type"] in (
+            "response.output_text.delta",
+            "response.output_text.done",
+            "response.content_part.added",
+            "response.content_part.done",
+        ):
+            assert event["item_id"] in open_items, (
+                f"{event['type']} referenced unopened item {event['item_id']}"
+            )
 
 
 def test_responses_gateway_route_carries_same_permission_dependency() -> None:
@@ -1594,35 +1760,6 @@ def test_codex_capture_converts_without_rejecting_input() -> None:
     assert tools is not None
     assert {t["type"] for t in tools} == {"function"}
     assert len(tools) < len(request.tools or [])
-
-
-def test_codex_capture_streams_valid_item_lifecycle() -> None:
-    """The invariant Codex enforces: no output_text.delta may reference an
-    item that was not previously opened by output_item.added."""
-    request = ResponsesRequest.model_validate(_codex_fixture())
-
-    events = _responses_stream_events(
-        _TEXT_CHUNKS,
-        tools=gateway_api._responses_tools(request),
-        model=request.model,
-        response_id="resp_replay",
-    )
-    assert events[0]["type"] == "response.created"
-    assert events[-1]["type"] == "response.completed"
-
-    open_items: set[str] = set()
-    for event in events:
-        if event["type"] == "response.output_item.added":
-            open_items.add(event["item"]["id"])
-        elif event["type"] in (
-            "response.output_text.delta",
-            "response.output_text.done",
-            "response.content_part.added",
-            "response.content_part.done",
-        ):
-            assert event["item_id"] in open_items, (
-                f"{event['type']} referenced unopened item {event['item_id']}"
-            )
 
 
 def test_responses_tool_round_trip_assistant_content_is_flattened() -> None:

--- a/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
@@ -1528,6 +1528,60 @@ def test_responses_stream_failure_closes_the_open_text_item() -> None:
     assert events[-1]["response"]["status"] == "failed"
 
 
+def test_responses_stream_events_carry_monotonic_sequence_numbers() -> None:
+    """sequence_number is a required field on every Responses streaming event
+    in the OpenAI schema; strict SDK clients fail validation without it."""
+    events = _responses_stream_events(
+        _ChunkStreamLLM(_TEXT_AND_TOOL_CALL_CHUNKS), response_id="resp_seq"
+    )
+
+    assert [e["sequence_number"] for e in events] == list(range(len(events)))
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected_code"),
+    [
+        (LLMRateLimitError("slow down"), "rate_limit_exceeded"),
+        (LLMTimeoutError("too slow"), "server_error"),
+        (RuntimeError("secret-provider-response"), "server_error"),
+    ],
+)
+def test_responses_stream_failure_uses_schema_error_codes(
+    exc: Exception, expected_code: str
+) -> None:
+    """response.error must be {code, message} with code from the Responses
+    enum, and a rate limit must stay distinguishable for retry-aware clients."""
+    events = _responses_stream_events(
+        _StreamingLLM(threading.Event(), fail=True, exc=exc), response_id="resp_code"
+    )
+
+    error = events[-1]["response"]["error"]
+    assert error["code"] == expected_code
+    assert "type" not in error
+    assert "secret-provider-response" not in error["message"]
+
+
+def test_responses_stream_validates_against_openai_sdk_models() -> None:
+    """The whole emitted stream must parse with the real openai SDK event
+    models, which is what a strict client actually runs."""
+    from openai.types.responses import ResponseStreamEvent
+    from pydantic import TypeAdapter
+
+    adapter: TypeAdapter[Any] = TypeAdapter(ResponseStreamEvent)
+    streams = [
+        _responses_stream_events(
+            _ChunkStreamLLM(_TEXT_AND_TOOL_CALL_CHUNKS), response_id="resp_sdk"
+        ),
+        _responses_stream_events(
+            _FailAfterTextLLM(LLMRateLimitError("slow down")),
+            response_id="resp_sdk_err",
+        ),
+    ]
+    for events in streams:
+        for event in events:
+            adapter.validate_python(event)
+
+
 def test_responses_stream_disconnect_closes_upstream_and_omits_completed() -> None:
     closed = threading.Event()
     with patch.object(gateway_api, "llm_generation_span", return_value=nullcontext()):

--- a/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
@@ -1483,6 +1483,51 @@ def test_responses_stream_upstream_failure_emits_response_failed(
     assert not any(e["type"] == "response.completed" for e in events)
 
 
+class _FailAfterTextLLM(_ConfigOnlyLLM):
+    def __init__(self, exc: Exception) -> None:
+        super().__init__(
+            LLMConfig(
+                model_provider="openai",
+                model_name="test",
+                temperature=0,
+                max_input_tokens=1_000,
+            )
+        )
+        self._exc = exc
+
+    def stream(self, *args: object, **kwargs: object):  # type: ignore[no-untyped-def,override]
+        del args, kwargs
+        yield ModelResponseStream(
+            id="p1", created="0", choice=StreamingChoice(delta=Delta(content="partial"))
+        )
+        raise self._exc
+
+
+def test_responses_stream_failure_closes_the_open_text_item() -> None:
+    events = _responses_stream_events(
+        _FailAfterTextLLM(RuntimeError("boom")), response_id="resp_partial"
+    )
+    event_types = [e["type"] for e in events]
+
+    assert event_types == [
+        "response.created",
+        "response.output_item.added",
+        "response.content_part.added",
+        "response.output_text.delta",
+        "response.output_text.done",
+        "response.content_part.done",
+        "response.output_item.done",
+        "response.failed",
+    ]
+    item_id = events[1]["item"]["id"]
+    assert events[1]["item"]["status"] == "in_progress"
+    done_item = events[6]["item"]
+    assert done_item["id"] == item_id
+    assert done_item["status"] == "incomplete"
+    assert done_item["content"][0]["text"] == "partial"
+    assert events[-1]["response"]["status"] == "failed"
+
+
 def test_responses_stream_disconnect_closes_upstream_and_omits_completed() -> None:
     closed = threading.Event()
     with patch.object(gateway_api, "llm_generation_span", return_value=nullcontext()):

--- a/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
@@ -1334,11 +1334,8 @@ def test_responses_stream_emits_created_first_and_completed_last() -> None:
 
 
 def test_responses_stream_emits_full_output_item_lifecycle_in_order() -> None:
-    """Regression test: Codex 0.145 rejects any output_text.delta whose item
-    was never opened ("OutputTextDelta without active item"). Every delta
-    must be bracketed by output_item.added/content_part.added before it and
-    output_text.done/content_part.done/output_item.done after, and every
-    lifecycle event's item_id must match the item opened in output_item.added."""
+    """Codex 0.145 rejects any output_text.delta whose item was never opened
+    ("OutputTextDelta without active item")."""
     events = _responses_stream_events(_ChunkStreamLLM(_TEXT_CHUNKS))
     event_types = [e["type"] for e in events]
 
@@ -1377,8 +1374,6 @@ def test_responses_stream_emits_full_output_item_lifecycle_in_order() -> None:
 
 
 def test_responses_stream_tool_call_gets_own_output_item_lifecycle() -> None:
-    """A text-free tool-call turn must still open/close a function_call
-    output item — no text item lifecycle should appear at all."""
     events = _responses_stream_events(
         _ChunkStreamLLM(_TOOL_CALL_CHUNKS), response_id="resp_2"
     )


### PR DESCRIPTION
## Description

Adds streaming to `POST /gateway/v1/responses`. Stacked on #13605, which landed the route, the request translation, and the non-streaming path; this PR replaces that route's `stream: true` → 501 with the real SSE stream.

This is split out because the event ordering is the subtle part and deserves review on its own.

**The lifecycle contract.** Codex tracks an "active item" and rejects any `response.output_text.delta` whose item was never opened. Getting this wrong is nearly invisible — it consumes tokens, emits no text, and exits 0. The stream emits the full lifecycle:

`created` → `output_item.added` → `content_part.added` → `delta`× → `output_text.done` → `content_part.done` → `output_item.done` → `completed`

Tool calls open and close their own items at increasing `output_index`, each followed by `function_call_arguments.done`.

**Shared plumbing.** The queue/thread stream bridge is extracted from `_stream_sse` into `_run_bridged_stream` so both protocols share it. That bridge exists because tracing ContextVars cannot cross Starlette's threadpool, and the constraint applies equally to the Responses stream. The extraction is behavior-preserving.

**Errors stay in-band.** Rate limits, timeouts, and unexpected failures emit `response.failed` on the SSE channel rather than raising mid-stream, matching the existing chat-completions stream worker — a client that has already received `response.created` cannot be handed an HTTP error.

## How Has This Been Tested?

- `backend/tests/unit/onyx/server/gateway/` — 67 tests pass. New coverage: `created` first / `completed` last, the full ordered event sequence with a consistent `item_id` across every lifecycle event, tool-call items getting their own lifecycle with no stray text events, and a fixture-driven check that no delta ever references an unopened item.
- The lifecycle test was **mutation-tested**: reintroducing the original bug (skipping `output_item.added`) turns it red, and reverting turns it green — verified rather than assumed.
- Verified end to end against real Codex CLI 0.145 on a local instance: plain text turns and tool-using turns both complete (`cat probe.txt` executed through the gateway, contents returned correctly). This is the first point in the stack where Codex works end to end, since Codex always streams.
- `pre-commit` clean, `ty` clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

**Stack:**
1. [gateway-external-access #13604](https://github.com/onyx-dot-app/onyx/pull/13604)
2. [gateway-responses-api #13605](https://github.com/onyx-dot-app/onyx/pull/13605)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SSE streaming to POST `/gateway/v1/responses` with a full output-item lifecycle and strict `openai` Responses schema compliance. Validates unsupported inputs, closes any open text item as incomplete before `response.failed`, and improves stream cleanup for reliability.

- **New Features**
  - SSE for Responses; replaces `stream: true` → 501 with `StreamingResponse` and `Cache-Control: no-cache` / `X-Accel-Buffering: no`.
  - Emits full lifecycle: `response.created` → `response.output_item.added` → `response.content_part.added` → `response.output_text.delta`× → `response.output_text.done` → `response.content_part.done` → `response.output_item.done` → `response.completed`.
  - Tool calls open their own item and emit `response.function_call_arguments.done` with `name`.
  - Validates inputs: refuses `previous_response_id` and unsupported `tool_choice`; `store` and `reasoning.summary` stay tolerated.

- **Bug Fixes**
  - Schema compliance for strict clients: every event has a monotonic `sequence_number`; `response.error` is `{code, message}` with `rate_limit_exceeded` for rate limits; text delta/done include empty `logprobs`; response objects include `parallel_tool_calls`, `tool_choice`, `tools`. Stream output validates against `openai` SDK event models.
  - Failure handling: if text started, the open item is closed as `incomplete` (emits `output_text.done` / `content_part.done` / `output_item.done`) before `response.failed`.
  - Safer cleanup: upstream generators closed via `_ClosableStream`; stream guard span typed as `Span[GenerationSpanData] | None`.

<sup>Written for commit d436411d960a5e9ff6359fb82beb3213e3775b53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

