### PR TITLE
fix: hierarchynodes accessible private connectors

### DIFF
--- a/backend/ee/onyx/db/hierarchy.py
+++ b/backend/ee/onyx/db/hierarchy.py
@@ -1,32 +1,85 @@
-"""EE version of hierarchy node access control.
+"""EE hierarchy access control for source and connector permissions."""
 
-This module provides permission-aware hierarchy node access for Enterprise Edition.
-It filters hierarchy nodes based on user email and external group membership.
-"""
+from uuid import UUID
 
-from sqlalchemy import String, any_, cast, or_, select
+from sqlalchemy import String, and_, any_, cast, or_, select
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.elements import ColumnElement
 
 from onyx.configs.constants import DocumentSource
-from onyx.db.enums import HierarchyNodeType
+from onyx.db.enums import (
+    AccessType,
+    ConnectorCredentialPairStatus,
+    HierarchyNodeType,
+)
 from onyx.db.hierarchy import HIERARCHY_NODE_SEARCH_LIMIT, escape_like_pattern
-from onyx.db.models import HierarchyNode
+from onyx.db.models import (
+    ConnectorCredentialPair,
+    Credential,
+    HierarchyNode,
+    HierarchyNodeByConnectorCredentialPair,
+    User__UserGroup,
+    UserGroup__ConnectorCredentialPair,
+)
+
+
+def _build_connector_access_filter(user_id: UUID) -> ColumnElement[bool]:
+    """Grant the connector-level access applied to indexed documents."""
+    node_cc_pair = HierarchyNodeByConnectorCredentialPair
+    cc_pair = ConnectorCredentialPair
+    group_cc_pair = UserGroup__ConnectorCredentialPair
+    user_group = User__UserGroup
+
+    stmt = (
+        select(1)
+        .select_from(node_cc_pair)
+        .join(
+            cc_pair,
+            and_(
+                cc_pair.connector_id == node_cc_pair.connector_id,
+                cc_pair.credential_id == node_cc_pair.credential_id,
+            ),
+        )
+        .join(Credential, Credential.id == cc_pair.credential_id)
+        .outerjoin(
+            group_cc_pair,
+            and_(
+                group_cc_pair.cc_pair_id == cc_pair.id,
+                group_cc_pair.is_current.is_(True),
+            ),
+        )
+        .outerjoin(
+            user_group,
+            and_(
+                user_group.user_group_id == group_cc_pair.user_group_id,
+                user_group.user_id == user_id,
+            ),
+        )
+        .where(
+            node_cc_pair.hierarchy_node_id == HierarchyNode.id,
+            cc_pair.status != ConnectorCredentialPairStatus.DELETING,
+            or_(
+                cc_pair.access_type == AccessType.PUBLIC,
+                and_(
+                    cc_pair.access_type != AccessType.SYNC,
+                    or_(
+                        Credential.user_id == user_id,
+                        user_group.user_id == user_id,
+                    ),
+                ),
+            ),
+        )
+    )
+    return stmt.exists()
 
 
 def _build_hierarchy_access_filter(
     user_email: str,
     external_group_ids: list[str],
+    user_id: UUID | None = None,
 ) -> ColumnElement[bool]:
-    """Build SQLAlchemy filter for hierarchy node access.
-
-    A user can access a hierarchy node if any of the following are true:
-    - The node is the SOURCE root for its source (always visible as the tree root)
-    - The node is marked as public (is_public=True)
-    - The user's email is in the node's external_user_emails list
-    - Any of the user's external group IDs overlap with the node's external_user_group_ids
-    """
+    """Grant access through the node ACL or an associated connector."""
     access_filters: list[ColumnElement[bool]] = [
         HierarchyNode.node_type == HierarchyNodeType.SOURCE,
         HierarchyNode.is_public.is_(True),
@@ -39,6 +92,8 @@ def _build_hierarchy_access_filter(
                 cast(postgresql.array(external_group_ids), postgresql.ARRAY(String))
             )
         )
+    if user_id:
+        access_filters.append(_build_connector_access_filter(user_id))
     return or_(*access_filters)
 
 
@@ -47,13 +102,16 @@ def _get_accessible_hierarchy_nodes_for_source(
     source: DocumentSource,
     user_email: str,
     external_group_ids: list[str],
+    user_id: UUID | None = None,
 ) -> list[HierarchyNode]:
     """EE version: hierarchy nodes the user can access, always including the SOURCE root."""
     stmt = select(HierarchyNode).where(
         HierarchyNode.source == source,
         HierarchyNode.node_type != HierarchyNodeType.STUB,
     )
-    stmt = stmt.where(_build_hierarchy_access_filter(user_email, external_group_ids))
+    stmt = stmt.where(
+        _build_hierarchy_access_filter(user_email, external_group_ids, user_id)
+    )
     stmt = stmt.order_by(HierarchyNode.display_name)
     return list(db_session.execute(stmt).scalars().all())
 
@@ -65,6 +123,7 @@ def _search_accessible_hierarchy_nodes(
     user_email: str,
     external_group_ids: list[str],
     limit: int = HIERARCHY_NODE_SEARCH_LIMIT,
+    user_id: UUID | None = None,
 ) -> list[HierarchyNode]:
     """EE version: ACL-filtered case-insensitive display_name search."""
     pattern = f"%{escape_like_pattern(query)}%"
@@ -75,7 +134,7 @@ def _search_accessible_hierarchy_nodes(
                 [HierarchyNodeType.STUB, HierarchyNodeType.SOURCE]
             ),
             HierarchyNode.display_name.ilike(pattern, escape="\\"),
-            _build_hierarchy_access_filter(user_email, external_group_ids),
+            _build_hierarchy_access_filter(user_email, external_group_ids, user_id),
         )
         .order_by(HierarchyNode.display_name)
         .limit(limit)
@@ -90,8 +149,11 @@ def _filter_accessible_hierarchy_node_ids(
     node_ids: list[int],
     user_email: str,
     external_group_ids: list[str],
+    user_id: UUID | None = None,
 ) -> set[int]:
     """EE version: keep only the node ids the user can access."""
     stmt = select(HierarchyNode.id).where(HierarchyNode.id.in_(node_ids))
-    stmt = stmt.where(_build_hierarchy_access_filter(user_email, external_group_ids))
+    stmt = stmt.where(
+        _build_hierarchy_access_filter(user_email, external_group_ids, user_id)
+    )
     return set(db_session.execute(stmt).scalars().all())

--- a/backend/onyx/db/hierarchy.py
+++ b/backend/onyx/db/hierarchy.py
@@ -1,6 +1,7 @@
 """CRUD operations for HierarchyNode."""
 
 from collections import defaultdict
+from uuid import UUID
 
 from sqlalchemy import delete, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -541,23 +542,9 @@ def _get_accessible_hierarchy_nodes_for_source(
     source: DocumentSource,
     user_email: str,  # noqa: ARG001
     external_group_ids: list[str],  # noqa: ARG001
+    user_id: UUID | None = None,  # noqa: ARG001
 ) -> list[HierarchyNode]:
-    """
-    MIT version: Returns all hierarchy nodes for the source without permission filtering.
-
-    In the MIT version, permission checks are not performed on hierarchy nodes.
-    The EE version overrides this to apply permission filtering based on user
-    email and external group IDs.
-
-    Args:
-        db_session: SQLAlchemy session
-        source: Document source type
-        user_email: User's email (unused in MIT version)
-        external_group_ids: User's external group IDs (unused in MIT version)
-
-    Returns:
-        List of all HierarchyNode objects for the source
-    """
+    """MIT version: return all non-stub nodes for the source."""
     stmt = select(HierarchyNode).where(
         HierarchyNode.source == source,
         HierarchyNode.node_type != HierarchyNodeType.STUB,
@@ -571,18 +558,18 @@ def get_accessible_hierarchy_nodes_for_source(
     source: DocumentSource,
     user_email: str,
     external_group_ids: list[str],
+    user_id: UUID | None = None,
 ) -> list[HierarchyNode]:
-    """
-    Get hierarchy nodes for a source that are accessible to the user.
+    """Get source nodes allowed by the edition-specific access policy.
 
-    Uses fetch_versioned_implementation to get the appropriate version:
-    - MIT version: Returns all nodes (no permission filtering)
-    - EE version: Filters based on user email and external group IDs
+    EE combines node ACLs with associated connector permissions; MIT returns all.
     """
     versioned_fn = fetch_versioned_implementation(
         "onyx.db.hierarchy", "_get_accessible_hierarchy_nodes_for_source"
     )
-    return versioned_fn(db_session, source, user_email, external_group_ids)
+    return versioned_fn(
+        db_session, source, user_email, external_group_ids, user_id=user_id
+    )
 
 
 HIERARCHY_NODE_SEARCH_LIMIT = 30
@@ -600,6 +587,7 @@ def _search_accessible_hierarchy_nodes(
     user_email: str,  # noqa: ARG001
     external_group_ids: list[str],  # noqa: ARG001
     limit: int = HIERARCHY_NODE_SEARCH_LIMIT,
+    user_id: UUID | None = None,  # noqa: ARG001
 ) -> list[HierarchyNode]:
     """MIT version: case-insensitive display_name search without ACL filtering."""
     pattern = f"%{escape_like_pattern(query)}%"
@@ -626,6 +614,7 @@ def search_accessible_hierarchy_nodes(
     user_email: str,
     external_group_ids: list[str],
     limit: int = HIERARCHY_NODE_SEARCH_LIMIT,
+    user_id: UUID | None = None,
 ) -> list[HierarchyNode]:
     """Search hierarchy nodes by display_name substring, ACL-gated.
 
@@ -636,7 +625,13 @@ def search_accessible_hierarchy_nodes(
         "onyx.db.hierarchy", "_search_accessible_hierarchy_nodes"
     )
     return versioned_fn(
-        db_session, query, sources, user_email, external_group_ids, limit
+        db_session,
+        query,
+        sources,
+        user_email,
+        external_group_ids,
+        limit,
+        user_id=user_id,
     )
 
 
@@ -645,6 +640,7 @@ def _filter_accessible_hierarchy_node_ids(
     node_ids: list[int],
     user_email: str,  # noqa: ARG001
     external_group_ids: list[str],  # noqa: ARG001
+    user_id: UUID | None = None,  # noqa: ARG001
 ) -> set[int]:
     """MIT version: hierarchy nodes carry no permission filtering — all
     requested ids pass. The EE version applies the access filter."""
@@ -656,6 +652,7 @@ def filter_accessible_hierarchy_node_ids(
     node_ids: list[int],
     user_email: str,
     external_group_ids: list[str],
+    user_id: UUID | None = None,
 ) -> set[int]:
     """Return the subset of ``node_ids`` the user can access (EE filters,
     MIT passes everything through)."""
@@ -664,7 +661,9 @@ def filter_accessible_hierarchy_node_ids(
     versioned_fn = fetch_versioned_implementation(
         "onyx.db.hierarchy", "_filter_accessible_hierarchy_node_ids"
     )
-    return versioned_fn(db_session, node_ids, user_email, external_group_ids)
+    return versioned_fn(
+        db_session, node_ids, user_email, external_group_ids, user_id=user_id
+    )
 
 
 def get_document_parent_hierarchy_node_ids(

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -1439,6 +1439,7 @@ def upsert_persona(
                 list(added_node_ids),
                 user.email,
                 get_user_external_group_ids(db_session, user),
+                user_id=user.id,
             )
             if added_node_ids - accessible_node_ids:
                 raise ValueError(

--- a/backend/onyx/server/features/hierarchy/api.py
+++ b/backend/onyx/server/features/hierarchy/api.py
@@ -78,6 +78,7 @@ def list_accessible_hierarchy_nodes(
         source=source,
         user_email=user_email,
         external_group_ids=external_group_ids,
+        user_id=user.id,
     )
     return HierarchyNodesResponse(
         nodes=[
@@ -163,6 +164,7 @@ def search_hierarchy_nodes(
         user_email=user_email,
         external_group_ids=external_group_ids,
         limit=HIERARCHY_NODE_SEARCH_LIMIT,
+        user_id=user.id,
     )
     return HierarchyNodeSearchResponse(
         nodes=[

--- a/backend/tests/external_dependency_unit/hierarchy/test_hierarchy_access_filter.py
+++ b/backend/tests/external_dependency_unit/hierarchy/test_hierarchy_access_filter.py
@@ -1,21 +1,50 @@
-"""Tests for hierarchy node access filtering.
-
-Validates that the overlap operator on external_user_group_ids works correctly
-with PostgreSQL's VARCHAR[] column type. This specifically tests the fix for
-the `character varying[] && text[]` type mismatch error.
-"""
+"""Tests hierarchy visibility through node and connector permissions."""
 
 from collections.abc import Generator
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import text, update
 from sqlalchemy.orm import Session
 
 from ee.onyx.db.hierarchy import _get_accessible_hierarchy_nodes_for_source
+from onyx.auth.schemas import UserRole
 from onyx.configs.constants import DocumentSource
-from onyx.db.enums import HierarchyNodeType
+from onyx.db.enums import AccessType, AccountType, HierarchyNodeType
 from onyx.db.hierarchy import get_source_hierarchy_node
-from onyx.db.models import HierarchyNode
+from onyx.db.models import (
+    Credential,
+    HierarchyNode,
+    HierarchyNodeByConnectorCredentialPair,
+    User__UserGroup,
+    UserGroup,
+    UserGroup__ConnectorCredentialPair,
+)
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+
+class ConnectorAccessSeed(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    node: HierarchyNode
+    owner_id: UUID
+    owner_email: str
+    member_id: UUID
+    member_email: str
+    outsider_id: UUID
+    outsider_email: str
+
+
+class UserSeed(BaseModel):
+    id: UUID
+    email: str
+    hashed_password: str
+    is_active: bool
+    is_superuser: bool
+    is_verified: bool
+    role: UserRole
+    account_type: AccountType
 
 
 def _make_node(
@@ -39,7 +68,7 @@ def _make_node(
 
 @pytest.fixture()
 def seeded_nodes(db_session: Session) -> Generator[list[HierarchyNode], None, None]:
-    """Seed hierarchy nodes with various permission configurations."""
+    """Seed nodes covering external ACL variants."""
     tag = uuid4().hex[:8]
     nodes = [
         _make_node(
@@ -74,15 +103,89 @@ def seeded_nodes(db_session: Session) -> Generator[list[HierarchyNode], None, No
     db_session.commit()
 
 
+@pytest.fixture()
+def connector_access_seed(
+    db_session: Session,
+) -> Generator[ConnectorAccessSeed, None, None]:
+    tag = uuid4().hex[:8]
+    user_rows = [
+        UserSeed(
+            id=uuid4(),
+            email=f"{kind}_{tag}@example.com",
+            hashed_password="unused",
+            is_active=True,
+            is_superuser=False,
+            is_verified=True,
+            role=UserRole.BASIC,
+            account_type=AccountType.STANDARD,
+        )
+        for kind in ("owner", "member", "outsider")
+    ]
+    db_session.execute(
+        text(
+            'INSERT INTO "user" '
+            "(id, email, hashed_password, is_active, is_superuser, is_verified, "
+            "role, account_type) "
+            "VALUES (:id, :email, :hashed_password, :is_active, :is_superuser, "
+            ":is_verified, :role, :account_type)"
+        ),
+        [user.model_dump(mode="json") for user in user_rows],
+    )
+    owner, member, outsider = user_rows
+
+    cc_pair = make_cc_pair(
+        db_session,
+        source=DocumentSource.GOOGLE_DRIVE,
+        commit=False,
+    )
+    cc_pair.access_type = AccessType.PRIVATE
+    db_session.execute(
+        update(Credential)
+        .where(Credential.id == cc_pair.credential_id)
+        .values(user_id=owner.id)
+    )
+
+    node = _make_node(
+        raw_node_id=f"connector_private_{tag}",
+        display_name=f"Connector Private Folder {tag}",
+    )
+    group = UserGroup(name=f"hierarchy-access-group-{tag}")
+    db_session.add_all([node, group])
+    db_session.flush()
+    db_session.add_all(
+        [
+            HierarchyNodeByConnectorCredentialPair(
+                hierarchy_node_id=node.id,
+                connector_id=cc_pair.connector_id,
+                credential_id=cc_pair.credential_id,
+            ),
+            User__UserGroup(user_group_id=group.id, user_id=member.id),
+            UserGroup__ConnectorCredentialPair(
+                user_group_id=group.id,
+                cc_pair_id=cc_pair.id,
+                is_current=True,
+            ),
+        ]
+    )
+    db_session.flush()
+
+    yield ConnectorAccessSeed(
+        node=node,
+        owner_id=owner.id,
+        owner_email=owner.email,
+        member_id=member.id,
+        member_email=member.email,
+        outsider_id=outsider.id,
+        outsider_email=outsider.email,
+    )
+    db_session.rollback()
+
+
 def test_group_overlap_filter(
     db_session: Session,
     seeded_nodes: list[HierarchyNode],
 ) -> None:
-    """The overlap (&&) operator must work on the VARCHAR[] column.
-
-    This is the core regression test: before the cast fix, PostgreSQL raised
-    `operator does not exist: character varying[] && text[]`.
-    """
+    """External group overlap grants node access."""
     results = _get_accessible_hierarchy_nodes_for_source(
         db_session,
         source=DocumentSource.GOOGLE_DRIVE,
@@ -95,6 +198,54 @@ def test_group_overlap_filter(
     assert public_node.raw_node_id in result_ids
     assert group_node.raw_node_id in result_ids
     assert private_node.raw_node_id not in result_ids
+
+
+def test_connector_credential_owner_can_access_node(
+    db_session: Session,
+    connector_access_seed: ConnectorAccessSeed,
+) -> None:
+    seed = connector_access_seed
+    owner_results = _get_accessible_hierarchy_nodes_for_source(
+        db_session,
+        source=DocumentSource.GOOGLE_DRIVE,
+        user_email=seed.owner_email,
+        external_group_ids=[],
+        user_id=seed.owner_id,
+    )
+    outsider_results = _get_accessible_hierarchy_nodes_for_source(
+        db_session,
+        source=DocumentSource.GOOGLE_DRIVE,
+        user_email=seed.outsider_email,
+        external_group_ids=[],
+        user_id=seed.outsider_id,
+    )
+
+    assert seed.node.id in {node.id for node in owner_results}
+    assert seed.node.id not in {node.id for node in outsider_results}
+
+
+def test_connector_user_group_member_can_access_node(
+    db_session: Session,
+    connector_access_seed: ConnectorAccessSeed,
+) -> None:
+    seed = connector_access_seed
+    member_results = _get_accessible_hierarchy_nodes_for_source(
+        db_session,
+        source=DocumentSource.GOOGLE_DRIVE,
+        user_email=seed.member_email,
+        external_group_ids=[],
+        user_id=seed.member_id,
+    )
+    outsider_results = _get_accessible_hierarchy_nodes_for_source(
+        db_session,
+        source=DocumentSource.GOOGLE_DRIVE,
+        user_email=seed.outsider_email,
+        external_group_ids=[],
+        user_id=seed.outsider_id,
+    )
+
+    assert seed.node.id in {node.id for node in member_results}
+    assert seed.node.id not in {node.id for node in outsider_results}
 
 
 def test_email_filter(


### PR DESCRIPTION
## Description

Previously hierarchynode accessibility only accounted for public and permission synced connectors. Now, when a connector is Private and a user has access to it via usergroups, the hierarchynode is visible to the user.

## How Has This Been Tested?

added tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hierarchy node visibility for Private connectors: users now see nodes linked to connectors they own or access via user groups; SYNC-only connectors remain excluded. Adds a connector-aware access check in EE and threads `user_id` through hierarchy APIs and persona validation.

- **Bug Fixes**
  - Added connector permission filter: allow `PUBLIC` or `PRIVATE` when user is the credential owner or in a granted user group; ignore cc_pairs in `DELETING` state.
  - Applied the filter to list, search, and ID filtering by passing `user_id` through the server API and persona upsert.
  - Kept MIT behavior unchanged (no ACL filtering).
  - Added tests for external group overlap and connector owner/group member access.

<sup>Written for commit 9991314feb7ecd1c7ebecde0ccd249e12a13b043. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

