### PR TITLE
fix(slack): correct link, email, code and list rendering in bot answers

### DIFF
--- a/backend/onyx/connectors/slack/utils.py
+++ b/backend/onyx/connectors/slack/utils.py
@@ -19,10 +19,15 @@ basic_retry_wrapper = retry_builder(tries=7)
 # number of messages we request per page when fetching paginated slack messages
 _SLACK_LIMIT = 900
 
+# An @ that starts a token, i.e. a mention rather than part of an email or URL
+_MENTION_AT_PATTERN = re.compile(r"(?<!\w)@")
+
+# Regions where an @ must survive defanging: link tokens and code
 _NON_INTERACTIVE_SLACK_TEXT_PATTERN = re.compile(
     r"<(?P<url>(?:https?://|mailto:)[^|<>]+)(?:\|(?P<label>[^<>]*))?>"
     r"|(?P<code>```[\s\S]*?```|`[^`\n]*`)"
 )
+# replace_special_catchall handles the labelled form. This also catches <!subteam^ID>
 _SUBTEAM_MENTION_PATTERN = re.compile(
     r"<!subteam\^(?P<id>[^<>|]+)(?:\|(?P<label>[^<>]*))?>"
 )
@@ -333,10 +338,17 @@ class SlackTextCleaner:
 
     @staticmethod
     def add_zero_width_whitespace_after_tag(message: str) -> str:
-        """Defang plain-text mentions without changing link destinations or code."""
+        """Defang plain-text mentions without changing link destinations or code.
+
+        A mailto token whose label is its own address is left whole, so its raw
+        @ survives.
+        """
 
         def defang(text: str) -> str:
-            return text.replace("@", "@\u200b")
+            # Only an @ starting a token is a mention. One preceded by a word
+            # character belongs to an email or URL userinfo, where the
+            # zero-width space would split the address.
+            return _MENTION_AT_PATTERN.sub("@\u200b", text)
 
         result: list[str] = []
         cursor = 0

--- a/backend/onyx/connectors/slack/utils.py
+++ b/backend/onyx/connectors/slack/utils.py
@@ -19,6 +19,9 @@ basic_retry_wrapper = retry_builder(tries=7)
 # number of messages we request per page when fetching paginated slack messages
 _SLACK_LIMIT = 900
 
+# An @ that starts a token, i.e. a mention rather than part of an email or URL
+_MENTION_AT_PATTERN = re.compile(r"(?<!\w)@")
+
 # used to serialize access to the retry TTL
 ONYX_SLACK_LOCK_TTL = 1800  # how long the lock is allowed to idle before it expires
 ONYX_SLACK_LOCK_BLOCKING_TIMEOUT = 60  # how long to wait for the lock per wait attempt
@@ -322,5 +325,9 @@ class SlackTextCleaner:
 
     @staticmethod
     def add_zero_width_whitespace_after_tag(message: str) -> str:
-        """Add a 0 width whitespace after every @"""
-        return message.replace("@", "@\u200b")
+        """Defang mention-shaped text by inserting a zero-width space after the @.
+
+        An @ preceded by a word character belongs to an email or URL userinfo,
+        where the zero-width space would split the address and break the link.
+        """
+        return _MENTION_AT_PATTERN.sub("@\u200b", message)

--- a/backend/onyx/connectors/slack/utils.py
+++ b/backend/onyx/connectors/slack/utils.py
@@ -20,11 +20,11 @@ basic_retry_wrapper = retry_builder(tries=7)
 _SLACK_LIMIT = 900
 
 _NON_INTERACTIVE_SLACK_TEXT_PATTERN = re.compile(
-    r"<(?P<url>(?:https?://|mailto:)[^|>]+)(?:\|(?P<label>[^>]*))?>"
+    r"<(?P<url>(?:https?://|mailto:)[^|<>]+)(?:\|(?P<label>[^<>]*))?>"
     r"|(?P<code>```[\s\S]*?```|`[^`\n]*`)"
 )
 _SUBTEAM_MENTION_PATTERN = re.compile(
-    r"<!subteam\^(?P<id>[^>|]+)(?:\|(?P<label>[^>]*))?>"
+    r"<!subteam\^(?P<id>[^<>|]+)(?:\|(?P<label>[^<>]*))?>"
 )
 
 # used to serialize access to the retry TTL

--- a/backend/onyx/connectors/slack/utils.py
+++ b/backend/onyx/connectors/slack/utils.py
@@ -19,8 +19,13 @@ basic_retry_wrapper = retry_builder(tries=7)
 # number of messages we request per page when fetching paginated slack messages
 _SLACK_LIMIT = 900
 
-# An @ that starts a token, i.e. a mention rather than part of an email or URL
-_MENTION_AT_PATTERN = re.compile(r"(?<!\w)@")
+_NON_INTERACTIVE_SLACK_TEXT_PATTERN = re.compile(
+    r"<(?P<url>(?:https?://|mailto:)[^|>]+)(?:\|(?P<label>[^>]*))?>"
+    r"|(?P<code>```[\s\S]*?```|`[^`\n]*`)"
+)
+_SUBTEAM_MENTION_PATTERN = re.compile(
+    r"<!subteam\^(?P<id>[^>|]+)(?:\|(?P<label>[^>]*))?>"
+)
 
 # used to serialize access to the retry TTL
 ONYX_SLACK_LOCK_TTL = 1800  # how long the lock is allowed to idle before it expires
@@ -312,6 +317,9 @@ class SlackTextCleaner:
         message = message.replace("<!channel>", "@channel")
         message = message.replace("<!here>", "@here")
         message = message.replace("<!everyone>", "@everyone")
+        message = _SUBTEAM_MENTION_PATTERN.sub(
+            lambda match: match.group("label") or f"@{match.group('id')}", message
+        )
         return message
 
     @staticmethod
@@ -325,9 +333,23 @@ class SlackTextCleaner:
 
     @staticmethod
     def add_zero_width_whitespace_after_tag(message: str) -> str:
-        """Defang mention-shaped text by inserting a zero-width space after the @.
+        """Defang plain-text mentions without changing link destinations or code."""
 
-        An @ preceded by a word character belongs to an email or URL userinfo,
-        where the zero-width space would split the address and break the link.
-        """
-        return _MENTION_AT_PATTERN.sub("@\u200b", message)
+        def defang(text: str) -> str:
+            return text.replace("@", "@\u200b")
+
+        result: list[str] = []
+        cursor = 0
+        for match in _NON_INTERACTIVE_SLACK_TEXT_PATTERN.finditer(message):
+            result.append(defang(message[cursor : match.start()]))
+            url = match.group("url")
+            label = match.group("label")
+            if url is None or label is None:
+                result.append(match.group(0))
+            elif url.startswith("mailto:") and label == url.removeprefix("mailto:"):
+                result.append(match.group(0))
+            else:
+                result.append(f"<{url}|{defang(label)}>")
+            cursor = match.end()
+        result.append(defang(message[cursor:]))
+        return "".join(result)

--- a/backend/onyx/connectors/slack/utils.py
+++ b/backend/onyx/connectors/slack/utils.py
@@ -19,18 +19,25 @@ basic_retry_wrapper = retry_builder(tries=7)
 # number of messages we request per page when fetching paginated slack messages
 _SLACK_LIMIT = 900
 
-# An @ that starts a token, i.e. a mention rather than part of an email or URL
+# Skips an @ preceded by a word character, where a zero-width space would
+# split an address rather than defang a mention
 _MENTION_AT_PATTERN = re.compile(r"(?<!\w)@")
 
-# Regions where an @ must survive defanging: link tokens and code
-_NON_INTERACTIVE_SLACK_TEXT_PATTERN = re.compile(
+# Regions needing special handling: only a link destination and code are exempt
+# from defanging, a link label is not
+_DEFANG_EXEMPT_REGION_PATTERN = re.compile(
     r"<(?P<url>(?:https?://|mailto:)[^|<>]+)(?:\|(?P<label>[^<>]*))?>"
     r"|(?P<code>```[\s\S]*?```|`[^`\n]*`)"
 )
-# replace_special_catchall handles the labelled form. This also catches <!subteam^ID>
+# Optional label group, so the labelled form resolves to its label not the raw ID
 _SUBTEAM_MENTION_PATTERN = re.compile(
     r"<!subteam\^(?P<id>[^<>|]+)(?:\|(?P<label>[^<>]*))?>"
 )
+
+
+def _defang_mentions(text: str) -> str:
+    return _MENTION_AT_PATTERN.sub("@​", text)
+
 
 # used to serialize access to the retry TTL
 ONYX_SLACK_LOCK_TTL = 1800  # how long the lock is allowed to idle before it expires
@@ -344,16 +351,10 @@ class SlackTextCleaner:
         @ survives.
         """
 
-        def defang(text: str) -> str:
-            # Only an @ starting a token is a mention. One preceded by a word
-            # character belongs to an email or URL userinfo, where the
-            # zero-width space would split the address.
-            return _MENTION_AT_PATTERN.sub("@\u200b", text)
-
         result: list[str] = []
         cursor = 0
-        for match in _NON_INTERACTIVE_SLACK_TEXT_PATTERN.finditer(message):
-            result.append(defang(message[cursor : match.start()]))
+        for match in _DEFANG_EXEMPT_REGION_PATTERN.finditer(message):
+            result.append(_defang_mentions(message[cursor : match.start()]))
             url = match.group("url")
             label = match.group("label")
             if url is None or label is None:
@@ -361,7 +362,7 @@ class SlackTextCleaner:
             elif url.startswith("mailto:") and label == url.removeprefix("mailto:"):
                 result.append(match.group(0))
             else:
-                result.append(f"<{url}|{defang(label)}>")
+                result.append(f"<{url}|{_defang_mentions(label)}>")
             cursor = match.end()
-        result.append(defang(message[cursor:]))
+        result.append(_defang_mentions(message[cursor:]))
         return "".join(result)

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -100,8 +100,8 @@ def _split_text(text: str, limit: int = 3000) -> list[str]:
 
 
 def _clean_markdown_link_text(text: str) -> str:
-    # Remove any newlines within the text
-    return format_slack_message(text).replace("\n", " ").strip()
+    # Result is interpolated into a <link|label>, so it must stay link-free
+    return format_slack_message(text, autolink=False).replace("\n", " ").strip()
 
 
 def _build_qa_feedback_block(

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -35,7 +35,7 @@ from onyx.onyxbot.slack.constants import (
     LIKE_BLOCK_ACTION_ID,
     SHOW_EVERYONE_ACTION_ID,
 )
-from onyx.onyxbot.slack.formatting import format_slack_message
+from onyx.onyxbot.slack.formatting import format_slack_link_url, format_slack_message
 from onyx.onyxbot.slack.icons import source_to_github_img_link
 from onyx.onyxbot.slack.models import (
     ActionValuesEphemeralMessage,
@@ -64,6 +64,7 @@ def _format_doc_updated_at(updated_at: datetime | None) -> str | None:
 
 
 def get_feedback_reminder_blocks(thread_link: str, include_followup: bool) -> Block:
+    thread_link = format_slack_link_url(thread_link)
     text = (
         f"Please provide feedback on <{thread_link}|this answer>. "
         "This is essential to help us to improve the quality of the answers. "
@@ -101,7 +102,7 @@ def _split_text(text: str, limit: int = 3000) -> list[str]:
 
 def _clean_markdown_link_text(text: str) -> str:
     # Result is interpolated into a <link|label>, so it must stay link-free
-    return format_slack_message(text, autolink=False).replace("\n", " ").strip()
+    return format_slack_message(text, render_links=False).replace("\n", " ").strip()
 
 
 def _build_qa_feedback_block(
@@ -279,6 +280,7 @@ def _build_sources_blocks(
         )
 
         document_title = _clean_markdown_link_text(doc_sem_id)
+        document_link = format_slack_link_url(d.link) if d.link else None
         img_link = source_to_github_img_link(d.source_type)
 
         section_blocks.append(
@@ -289,10 +291,11 @@ def _build_sources_blocks(
                         alt_text=f"{d.source_type.value} logo",
                     ),
                     (
-                        MarkdownTextObject(text=f"{document_title}")
-                        if d.link == ""
+                        MarkdownTextObject(text=document_title, verbatim=True)
+                        if document_link is None
                         else MarkdownTextObject(
-                            text=f"*<{d.link}|[{citation_num}] {document_title}>*\n{final_metadata_str}"
+                            text=f"*<{document_link}|[{citation_num}] {document_title}>*\n{final_metadata_str}",
+                            verbatim=True,
                         )
                     ),
                 ]

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -274,9 +274,11 @@ def _build_sources_blocks(
 
         owner_str = f"By {d.primary_owners[0]}" if d.primary_owners else None
         days_ago_str = _format_doc_updated_at(d.updated_at)
-        final_metadata_str = " | ".join(
-            ([owner_str] if owner_str else [])
-            + ([days_ago_str] if days_ago_str else [])
+        final_metadata_str = _clean_markdown_link_text(
+            " | ".join(
+                ([owner_str] if owner_str else [])
+                + ([days_ago_str] if days_ago_str else [])
+            )
         )
 
         document_title = _clean_markdown_link_text(doc_sem_id)

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -101,7 +101,7 @@ def _split_text(text: str, limit: int = 3000) -> list[str]:
 
 
 def _clean_markdown_link_text(text: str) -> str:
-    # Result is interpolated into a <link|label>, so it must stay link-free
+    # Must emit no Slack link syntax: callers may nest the result in a <url|label>
     return format_slack_message(text, render_links=False).replace("\n", " ").strip()
 
 
@@ -285,6 +285,8 @@ def _build_sources_blocks(
         document_link = format_slack_link_url(d.link) if d.link else None
         img_link = source_to_github_img_link(d.source_type)
 
+        # verbatim stops Slack auto-linking indexed document text, which would
+        # otherwise absorb the surrounding * and > into a URL it detected
         section_blocks.append(
             ContextBlock(
                 elements=[

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -35,7 +35,11 @@ from onyx.onyxbot.slack.constants import (
     LIKE_BLOCK_ACTION_ID,
     SHOW_EVERYONE_ACTION_ID,
 )
-from onyx.onyxbot.slack.formatting import format_slack_link_url, format_slack_message
+from onyx.onyxbot.slack.formatting import (
+    escape_slack_specials,
+    format_slack_link_url,
+    format_slack_message,
+)
 from onyx.onyxbot.slack.icons import source_to_github_img_link
 from onyx.onyxbot.slack.models import (
     ActionValuesEphemeralMessage,
@@ -274,7 +278,9 @@ def _build_sources_blocks(
 
         owner_str = f"By {d.primary_owners[0]}" if d.primary_owners else None
         days_ago_str = _format_doc_updated_at(d.updated_at)
-        final_metadata_str = _clean_markdown_link_text(
+        # Sits outside the link, so it needs escaping rather than a markdown
+        # pass that would reinterpret punctuation in an owner's name
+        final_metadata_str = escape_slack_specials(
             " | ".join(
                 ([owner_str] if owner_str else [])
                 + ([days_ago_str] if days_ago_str else [])

--- a/backend/onyx/onyxbot/slack/formatting.py
+++ b/backend/onyx/onyxbot/slack/formatting.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from mistune import HTMLRenderer, create_markdown
+from mistune.plugins import Plugin
 
 if TYPE_CHECKING:
     from mistune.core import InlineState
@@ -33,6 +34,9 @@ _MARKDOWN_LINK_PATTERN = re.compile(r"\[(?:[^\[\]]|\[[^\]]*\])*\]\(")
 # mailto: is included because mistune parses <mailto:a@b.com|label> as a single
 # autolink and percent-encodes the pipe into the address.
 _SLACK_LINK_PATTERN = re.compile(r"<((?:https?://|mailto:)[^|>]+)\|([^>]+)>")
+_RENDERED_SLACK_LINK_PATTERN = re.compile(
+    r"<((?:https?://|mailto:)[^|>]+)(?:\|([^>]*))?>"
+)
 
 # Bare URLs and emails are emitted explicitly because Slack's auto-linker can
 # absorb an adjacent emphasis delimiter into the href.
@@ -45,6 +49,24 @@ _EMAIL_LINK_PATTERN = (
     r"(?![a-zA-Z0-9-])"
 )
 _URL_TRAILING_PUNCTUATION = ".,:;\"'*_~"
+_SLACK_SPECIALS: dict[str, str] = {"&": "&amp;", "<": "&lt;", ">": "&gt;"}
+
+
+def _escape_slack_specials(text: str) -> str:
+    for special, replacement in _SLACK_SPECIALS.items():
+        text = text.replace(special, replacement)
+    return text
+
+
+def format_slack_link_url(url: str) -> str:
+    return _escape_slack_specials(url.replace("|", "%7C"))
+
+
+def _format_slack_link_label(text: str) -> str:
+    text = _RENDERED_SLACK_LINK_PATTERN.sub(
+        lambda match: match.group(2) or match.group(1), text
+    )
+    return text.replace("<", "&lt;").replace(">", "&gt;")
 
 
 def _sanitize_html(text: str) -> str:
@@ -149,7 +171,7 @@ def _append_autolink(
     url: str,
     end_pos: int,
 ) -> int:
-    if state.in_link:
+    if state.in_link or state.in_image:
         inline.process_text(label, state)
     else:
         state.append_token(
@@ -196,7 +218,7 @@ def _parse_email_link(
     )
 
 
-def slack_autolink(md: "Markdown") -> None:
+def _slack_autolink(md: "Markdown") -> None:
     """Mistune plugin turning bare URLs and emails into link tokens.
 
     Registering at the inline-parser level means code spans, fenced blocks and
@@ -207,21 +229,23 @@ def slack_autolink(md: "Markdown") -> None:
     md.inline.register("email_link", _EMAIL_LINK_PATTERN, _parse_email_link)
 
 
-def format_slack_message(message: str | None, autolink: bool = True) -> str:
+def format_slack_message(message: str | None, render_links: bool = True) -> str:
     """Render markdown as Slack mrkdwn.
 
     Callers embedding the result inside a Slack link label must pass
-    autolink=False, since a nested <...> would terminate the outer link.
+    render_links=False, since a nested <...> would terminate the outer link.
     """
     if message is None:
         return ""
     message = _transform_outside_code_blocks(message, _sanitize_html)
     message = _convert_slack_links_to_markdown(message)
     normalized_message = _normalize_link_destinations(message)
-    plugins: list[Any] = ["strikethrough", "table"]
-    if autolink:
-        plugins.append(slack_autolink)
-    md = create_markdown(renderer=SlackRenderer(), plugins=plugins)
+    plugins: list[str | Plugin] = ["strikethrough", "table"]
+    if render_links:
+        plugins.append(_slack_autolink)
+    md = create_markdown(
+        renderer=SlackRenderer(render_links=render_links), plugins=plugins
+    )
     result = md(normalized_message)
     # With HTMLRenderer, result is always str (not AST list)
     assert isinstance(result, str)
@@ -235,17 +259,14 @@ class SlackRenderer(HTMLRenderer):
     no raw HTML ever appears in Slack messages.
     """
 
-    SPECIALS: dict[str, str] = {"&": "&amp;", "<": "&lt;", ">": "&gt;"}
-
-    def __init__(self) -> None:
+    def __init__(self, render_links: bool = True) -> None:
         super().__init__()
+        self._render_links = render_links
         self._table_headers: list[str] = []
         self._current_row_cells: list[str] = []
 
     def escape_special(self, text: str) -> str:
-        for special, replacement in self.SPECIALS.items():
-            text = text.replace(special, replacement)
-        return text
+        return _escape_slack_specials(text)
 
     def heading(self, text: str, level: int, **attrs: Any) -> str:  # noqa: ARG002
         return f"*{text}*\n\n"
@@ -273,16 +294,23 @@ class SlackRenderer(HTMLRenderer):
         return f"li: {text}\n"
 
     def link(self, text: str, url: str, title: str | None = None) -> str:
-        escaped_url = self.escape_special(url)
+        escaped_url = format_slack_link_url(url)
         # A label identical to the href is what an autolinked bare URL produces
-        label = text or title
+        label = text or (self.escape_special(title) if title else None)
+        if not self._render_links:
+            return _format_slack_link_label(label or self.escape_special(url))
         if label and label != escaped_url:
-            return f"<{escaped_url}|{label}>"
+            return f"<{escaped_url}|{_format_slack_link_label(label)}>"
         return f"<{escaped_url}>"
 
     def image(self, text: str, url: str, title: str | None = None) -> str:
-        escaped_url = self.escape_special(url)
-        display_text = title or text
+        escaped_url = format_slack_link_url(url)
+        display_text = self.escape_special(title) if title else text
+        display_text = _format_slack_link_label(
+            display_text or self.escape_special(url)
+        )
+        if not self._render_links:
+            return display_text
         return f"<{escaped_url}|{display_text}>" if display_text else f"<{escaped_url}>"
 
     def codespan(self, text: str) -> str:

--- a/backend/onyx/onyxbot/slack/formatting.py
+++ b/backend/onyx/onyxbot/slack/formatting.py
@@ -34,15 +34,17 @@ _MARKDOWN_LINK_PATTERN = re.compile(r"\[(?:[^\[\]]|\[[^\]]*\])*\]\(")
 # autolink and percent-encodes the pipe into the address.
 _SLACK_LINK_PATTERN = re.compile(r"<((?:https?://|mailto:)[^|>]+)\|([^>]+)>")
 
-# Slack's auto-linker absorbs an adjacent emphasis delimiter into the href, so
-# bare URLs and emails get emitted as explicit links. The trailing class excludes
-# * _ ~ to leave the closing emphasis marker for the emphasis rule.
-_URL_LINK_PATTERN = r"""https?://[^\s<]+[^<>|.,:;"')\]\s*_~]"""
+# Bare URLs and emails are emitted explicitly because Slack's auto-linker can
+# absorb an adjacent emphasis delimiter into the href.
+_URL_LINK_PATTERN = r"https?://[^\s<>|]+"
 _EMAIL_LINK_PATTERN = (
-    r"[a-zA-Z0-9.!#$%&'*+/=?^_`{}~-]+"
+    r"(?<![a-zA-Z0-9])"
+    r"[a-zA-Z0-9.!#$%&'*+/=?^_`{}~-]{1,64}"
     r"@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?"
     r"(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+"
+    r"(?![a-zA-Z0-9-])"
 )
+_URL_TRAILING_PUNCTUATION = ".,:;\"'*_~"
 
 
 def _sanitize_html(text: str) -> str:
@@ -141,9 +143,12 @@ def _convert_slack_links_to_markdown(message: str) -> str:
 
 
 def _append_autolink(
-    inline: "InlineParser", m: re.Match[str], state: "InlineState", url: str
+    inline: "InlineParser",
+    state: "InlineState",
+    label: str,
+    url: str,
+    end_pos: int,
 ) -> int:
-    label = m.group(0)
     if state.in_link:
         inline.process_text(label, state)
     else:
@@ -154,19 +159,41 @@ def _append_autolink(
                 "attrs": {"url": url},
             }
         )
-    return m.end()
+    return end_pos
+
+
+def _trim_url_trailing_punctuation(url: str) -> str:
+    url = url.rstrip(_URL_TRAILING_PUNCTUATION)
+    for opening, closing in (("(", ")"), ("[", "]")):
+        while url.endswith(closing) and url.count(closing) > url.count(opening):
+            url = url[:-1]
+    return url
 
 
 def _parse_url_link(
     inline: "InlineParser", m: re.Match[str], state: "InlineState"
 ) -> int:
-    return _append_autolink(inline, m, state, m.group(0))
+    url = _trim_url_trailing_punctuation(m.group(0))
+    return _append_autolink(
+        inline,
+        state,
+        label=url,
+        url=url,
+        end_pos=m.start() + len(url),
+    )
 
 
 def _parse_email_link(
     inline: "InlineParser", m: re.Match[str], state: "InlineState"
 ) -> int:
-    return _append_autolink(inline, m, state, f"mailto:{m.group(0)}")
+    email = m.group(0)
+    return _append_autolink(
+        inline,
+        state,
+        label=email,
+        url=f"mailto:{email}",
+        end_pos=m.end(),
+    )
 
 
 def slack_autolink(md: "Markdown") -> None:

--- a/backend/onyx/onyxbot/slack/formatting.py
+++ b/backend/onyx/onyxbot/slack/formatting.py
@@ -33,9 +33,9 @@ _MARKDOWN_LINK_PATTERN = re.compile(r"\[(?:[^\[\]]|\[[^\]]*\])*\]\(")
 # brackets and Slack would render them as literal text instead of links.
 # mailto: is included because mistune parses <mailto:a@b.com|label> as a single
 # autolink and percent-encodes the pipe into the address.
-_SLACK_LINK_PATTERN = re.compile(r"<((?:https?://|mailto:)[^|>]+)\|([^>]+)>")
+_SLACK_LINK_PATTERN = re.compile(r"<((?:https?://|mailto:)[^|<>]+)\|([^<>]+)>")
 _RENDERED_SLACK_LINK_PATTERN = re.compile(
-    r"<((?:https?://|mailto:)[^|>]+)(?:\|([^>]*))?>"
+    r"<((?:https?://|mailto:)[^|<>]+)(?:\|([^<>]*))?>"
 )
 
 # Bare URLs and emails are emitted explicitly because Slack's auto-linker can

--- a/backend/onyx/onyxbot/slack/formatting.py
+++ b/backend/onyx/onyxbot/slack/formatting.py
@@ -3,12 +3,12 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from mistune import HTMLRenderer, create_markdown
-from mistune.plugins import Plugin
 
 if TYPE_CHECKING:
     from mistune.core import InlineState
     from mistune.inline_parser import InlineParser
     from mistune.markdown import Markdown
+    from mistune.plugins import PluginRef
 
 # Tags that should be replaced with a newline (line-break and block-level elements)
 _HTML_NEWLINE_TAG_PATTERN = re.compile(
@@ -28,18 +28,17 @@ _FENCED_CODE_BLOCK_PATTERN = re.compile(r"```[\s\S]*?```")
 # The inner group handles nested brackets for citation links like [[1]](.
 _MARKDOWN_LINK_PATTERN = re.compile(r"\[(?:[^\[\]]|\[[^\]]*\])*\]\(")
 
-# Matches Slack-style links <url|text> that LLMs sometimes output directly.
-# Mistune doesn't recognise this syntax, so text() would escape the angle
-# brackets and Slack would render them as literal text instead of links.
-# mailto: is included because mistune parses <mailto:a@b.com|label> as a single
-# autolink and percent-encodes the pipe into the address.
+# Slack-style <url|text> links that LLMs sometimes emit directly. Mistune parses
+# <mailto:a@b.com|label> as one autolink and percent-encodes the pipe, so mailto
+# has to be recognised here rather than left to the parser.
 _SLACK_LINK_PATTERN = re.compile(r"<((?:https?://|mailto:)[^|<>]+)\|([^<>]+)>")
+# Same shape against already-rendered output, where the label may be absent
 _RENDERED_SLACK_LINK_PATTERN = re.compile(
     r"<((?:https?://|mailto:)[^|<>]+)(?:\|([^<>]*))?>"
 )
 
-# Bare URLs and emails are emitted explicitly because Slack's auto-linker can
-# absorb an adjacent emphasis delimiter into the href.
+# Bare URLs and emails are emitted explicitly because Slack's auto-linker absorbs
+# an adjacent emphasis delimiter into the href (observed in Block Kit Builder).
 _URL_LINK_PATTERN = r"https?://[^\s<>|]+"
 _EMAIL_LOCAL_CHARACTER_CLASS = r"a-zA-Z0-9.!#$%&'*+/=?^_`{}~-"
 _EMAIL_LOCAL_CHARACTER_PATTERN = re.compile(rf"[{_EMAIL_LOCAL_CHARACTER_CLASS}]")
@@ -180,6 +179,9 @@ def _append_autolink(
     url: str,
     end_pos: int,
 ) -> int:
+    # in_link is load-bearing beyond nesting: SlackRenderer.link compares the
+    # label to the href before flattening, so a nested autolink would defeat
+    # the redundant-label collapse.
     if state.in_link or state.in_image:
         inline.process_text(label, state)
     else:
@@ -194,13 +196,17 @@ def _append_autolink(
 
 
 def _trim_url_trailing_punctuation(url: str) -> str:
+    """Give back trailing sentence punctuation and unbalanced closers.
+
+    Shortening the match is what leaves a closing emphasis marker for the
+    emphasis rule, so _URL_TRAILING_PUNCTUATION carries * _ ~ as well.
+    """
     url = url.rstrip(_URL_TRAILING_PUNCTUATION)
     for opening, closing in (("(", ")"), ("[", "]")):
-        excess_closings = max(0, url.count(closing) - url.count(opening))
-        trailing_closings = len(url) - len(url.rstrip(closing))
-        trim_count = min(excess_closings, trailing_closings)
-        if trim_count:
-            url = url[:-trim_count]
+        excess = url.count(closing) - url.count(opening)
+        while excess > 0 and url.endswith(closing):
+            url = url[:-1]
+            excess -= 1
     return url
 
 
@@ -236,7 +242,12 @@ def _parse_email_link(
 def _email_match_starts_inside_local_part(
     m: re.Match[str], state: "InlineState"
 ) -> bool:
-    """Reject suffix matches unless preceding local chars are Markdown delimiters."""
+    """True when the match is a truncated local part rather than a whole address.
+
+    A preceding local-part character normally means the regex started mid-address.
+    The exception is an emphasis run that brackets the match on both sides with
+    the same delimiter at the same length, which makes it markup rather than text.
+    """
     match_start, match_end = m.span()
     if match_start == 0:
         return False
@@ -249,30 +260,24 @@ def _email_match_starts_inside_local_part(
     if delimiter_lengths is None or m.group(0).startswith(preceding_character):
         return True
 
+    before = state.src[:match_start]
+    opening_run = len(before) - len(before.rstrip(preceding_character))
     minimum_length, maximum_length = delimiter_lengths
-    return not any(
-        match_start >= length
-        and state.src.startswith(
-            preceding_character * length, match_start - length, match_start
-        )
-        and (
-            match_start == length
-            or state.src[match_start - length - 1] != preceding_character
-        )
-        and state.src.startswith(preceding_character * length, match_end)
-        for length in range(minimum_length, maximum_length + 1)
+    return not (
+        minimum_length <= opening_run <= maximum_length
+        and state.src.startswith(preceding_character * opening_run, match_end)
     )
 
 
 def _slack_autolink(md: "Markdown") -> None:
     """Mistune plugin turning bare URLs and emails into link tokens.
 
-    Registering at the inline-parser level means code spans, fenced blocks and
-    existing link labels are skipped for free, and the emphasis rules still see
-    their own delimiters.
+    Inline registration only buys code-span and fenced-block skipping. Link and
+    image labels still reach these rules, so nesting is prevented by the
+    in_link/in_image guard in _append_autolink.
     """
-    md.inline.register("url_link", _URL_LINK_PATTERN, _parse_url_link)
-    md.inline.register("email_link", _EMAIL_LINK_PATTERN, _parse_email_link)
+    md.inline.register("slack_url_link", _URL_LINK_PATTERN, _parse_url_link)
+    md.inline.register("slack_email_link", _EMAIL_LINK_PATTERN, _parse_email_link)
 
 
 def format_slack_message(message: str | None, render_links: bool = True) -> str:
@@ -286,7 +291,7 @@ def format_slack_message(message: str | None, render_links: bool = True) -> str:
     message = _transform_outside_code_blocks(message, _sanitize_html)
     message = _convert_slack_links_to_markdown(message)
     normalized_message = _normalize_link_destinations(message)
-    plugins: list[str | Plugin] = ["strikethrough", "table"]
+    plugins: list["PluginRef"] = ["strikethrough", "table"]
     if render_links:
         plugins.append(_slack_autolink)
     md = create_markdown(

--- a/backend/onyx/onyxbot/slack/formatting.py
+++ b/backend/onyx/onyxbot/slack/formatting.py
@@ -41,9 +41,12 @@ _RENDERED_SLACK_LINK_PATTERN = re.compile(
 # Bare URLs and emails are emitted explicitly because Slack's auto-linker can
 # absorb an adjacent emphasis delimiter into the href.
 _URL_LINK_PATTERN = r"https?://[^\s<>|]+"
+_EMAIL_LOCAL_CHARACTER_CLASS = r"a-zA-Z0-9.!#$%&'*+/=?^_`{}~-"
+_EMAIL_LOCAL_CHARACTER_PATTERN = re.compile(rf"[{_EMAIL_LOCAL_CHARACTER_CLASS}]")
+_EMAIL_MARKDOWN_DELIMITER_LENGTHS = {"*": (1, 3), "_": (1, 3), "~": (2, 2)}
 _EMAIL_LINK_PATTERN = (
     r"(?<![a-zA-Z0-9])"
-    r"[a-zA-Z0-9.!#$%&'*+/=?^_`{}~-]{1,64}"
+    rf"[{_EMAIL_LOCAL_CHARACTER_CLASS}]{{1,64}}"
     r"@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?"
     r"(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+"
     r"(?![a-zA-Z0-9-])"
@@ -218,12 +221,46 @@ def _parse_email_link(
     inline: "InlineParser", m: re.Match[str], state: "InlineState"
 ) -> int:
     email = m.group(0)
+    if _email_match_starts_inside_local_part(m, state):
+        inline.process_text(email, state)
+        return m.end()
     return _append_autolink(
         inline,
         state,
         label=email,
         url=f"mailto:{email}",
         end_pos=m.end(),
+    )
+
+
+def _email_match_starts_inside_local_part(
+    m: re.Match[str], state: "InlineState"
+) -> bool:
+    """Reject suffix matches unless preceding local chars are Markdown delimiters."""
+    match_start, match_end = m.span()
+    if match_start == 0:
+        return False
+
+    preceding_character = state.src[match_start - 1]
+    if _EMAIL_LOCAL_CHARACTER_PATTERN.fullmatch(preceding_character) is None:
+        return False
+
+    delimiter_lengths = _EMAIL_MARKDOWN_DELIMITER_LENGTHS.get(preceding_character)
+    if delimiter_lengths is None or m.group(0).startswith(preceding_character):
+        return True
+
+    minimum_length, maximum_length = delimiter_lengths
+    return not any(
+        match_start >= length
+        and state.src.startswith(
+            preceding_character * length, match_start - length, match_start
+        )
+        and (
+            match_start == length
+            or state.src[match_start - length - 1] != preceding_character
+        )
+        and state.src.startswith(preceding_character * length, match_end)
+        for length in range(minimum_length, maximum_length + 1)
     )
 
 

--- a/backend/onyx/onyxbot/slack/formatting.py
+++ b/backend/onyx/onyxbot/slack/formatting.py
@@ -187,8 +187,11 @@ def _append_autolink(
 def _trim_url_trailing_punctuation(url: str) -> str:
     url = url.rstrip(_URL_TRAILING_PUNCTUATION)
     for opening, closing in (("(", ")"), ("[", "]")):
-        while url.endswith(closing) and url.count(closing) > url.count(opening):
-            url = url[:-1]
+        excess_closings = max(0, url.count(closing) - url.count(opening))
+        trailing_closings = len(url) - len(url.rstrip(closing))
+        trim_count = min(excess_closings, trailing_closings)
+        if trim_count:
+            url = url[:-trim_count]
     return url
 
 

--- a/backend/onyx/onyxbot/slack/formatting.py
+++ b/backend/onyx/onyxbot/slack/formatting.py
@@ -62,6 +62,10 @@ def format_slack_link_url(url: str) -> str:
     return _escape_slack_specials(url.replace("|", "%7C"))
 
 
+def _escape_markdown_link_destination(url: str) -> str:
+    return url.replace("|", "%7C").replace("<", "&lt;").replace(">", "&gt;")
+
+
 def _format_slack_link_label(text: str) -> str:
     text = _RENDERED_SLACK_LINK_PATTERN.sub(
         lambda match: match.group(2) or match.group(1), text
@@ -140,9 +144,11 @@ def _normalize_link_destinations(message: str) -> str:
             normalized_parts.append(message[destination_start:])
             return "".join(normalized_parts)
 
-        already_wrapped = destination.startswith("<") and destination.endswith(">")
-        if destination and not already_wrapped:
-            destination = f"<{destination}>"
+        if destination:
+            already_wrapped = destination.startswith("<") and destination.endswith(">")
+            if already_wrapped:
+                destination = destination[1:-1]
+            destination = f"<{_escape_markdown_link_destination(destination)}>"
 
         normalized_parts.append(destination)
         normalized_parts.append(")")

--- a/backend/onyx/onyxbot/slack/formatting.py
+++ b/backend/onyx/onyxbot/slack/formatting.py
@@ -1,8 +1,13 @@
 import re
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from mistune import HTMLRenderer, create_markdown
+
+if TYPE_CHECKING:
+    from mistune.core import InlineState
+    from mistune.inline_parser import InlineParser
+    from mistune.markdown import Markdown
 
 # Tags that should be replaced with a newline (line-break and block-level elements)
 _HTML_NEWLINE_TAG_PATTERN = re.compile(
@@ -25,7 +30,19 @@ _MARKDOWN_LINK_PATTERN = re.compile(r"\[(?:[^\[\]]|\[[^\]]*\])*\]\(")
 # Matches Slack-style links <url|text> that LLMs sometimes output directly.
 # Mistune doesn't recognise this syntax, so text() would escape the angle
 # brackets and Slack would render them as literal text instead of links.
-_SLACK_LINK_PATTERN = re.compile(r"<(https?://[^|>]+)\|([^>]+)>")
+# mailto: is included because mistune parses <mailto:a@b.com|label> as a single
+# autolink and percent-encodes the pipe into the address.
+_SLACK_LINK_PATTERN = re.compile(r"<((?:https?://|mailto:)[^|>]+)\|([^>]+)>")
+
+# Slack's auto-linker absorbs an adjacent emphasis delimiter into the href, so
+# bare URLs and emails get emitted as explicit links. The trailing class excludes
+# * _ ~ to leave the closing emphasis marker for the emphasis rule.
+_URL_LINK_PATTERN = r"""https?://[^\s<]+[^<>|.,:;"')\]\s*_~]"""
+_EMAIL_LINK_PATTERN = (
+    r"[a-zA-Z0-9.!#$%&'*+/=?^_`{}~-]+"
+    r"@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?"
+    r"(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+"
+)
 
 
 def _sanitize_html(text: str) -> str:
@@ -123,13 +140,61 @@ def _convert_slack_links_to_markdown(message: str) -> str:
     )
 
 
-def format_slack_message(message: str | None) -> str:
+def _append_autolink(
+    inline: "InlineParser", m: re.Match[str], state: "InlineState", url: str
+) -> int:
+    label = m.group(0)
+    if state.in_link:
+        inline.process_text(label, state)
+    else:
+        state.append_token(
+            {
+                "type": "link",
+                "children": [{"type": "text", "raw": label}],
+                "attrs": {"url": url},
+            }
+        )
+    return m.end()
+
+
+def _parse_url_link(
+    inline: "InlineParser", m: re.Match[str], state: "InlineState"
+) -> int:
+    return _append_autolink(inline, m, state, m.group(0))
+
+
+def _parse_email_link(
+    inline: "InlineParser", m: re.Match[str], state: "InlineState"
+) -> int:
+    return _append_autolink(inline, m, state, f"mailto:{m.group(0)}")
+
+
+def slack_autolink(md: "Markdown") -> None:
+    """Mistune plugin turning bare URLs and emails into link tokens.
+
+    Registering at the inline-parser level means code spans, fenced blocks and
+    existing link labels are skipped for free, and the emphasis rules still see
+    their own delimiters.
+    """
+    md.inline.register("url_link", _URL_LINK_PATTERN, _parse_url_link)
+    md.inline.register("email_link", _EMAIL_LINK_PATTERN, _parse_email_link)
+
+
+def format_slack_message(message: str | None, autolink: bool = True) -> str:
+    """Render markdown as Slack mrkdwn.
+
+    Callers embedding the result inside a Slack link label must pass
+    autolink=False, since a nested <...> would terminate the outer link.
+    """
     if message is None:
         return ""
     message = _transform_outside_code_blocks(message, _sanitize_html)
     message = _convert_slack_links_to_markdown(message)
     normalized_message = _normalize_link_destinations(message)
-    md = create_markdown(renderer=SlackRenderer(), plugins=["strikethrough", "table"])
+    plugins: list[Any] = ["strikethrough", "table"]
+    if autolink:
+        plugins.append(slack_autolink)
+    md = create_markdown(renderer=SlackRenderer(), plugins=plugins)
     result = md(normalized_message)
     # With HTMLRenderer, result is always str (not AST list)
     assert isinstance(result, str)
@@ -182,10 +247,10 @@ class SlackRenderer(HTMLRenderer):
 
     def link(self, text: str, url: str, title: str | None = None) -> str:
         escaped_url = self.escape_special(url)
-        if text:
-            return f"<{escaped_url}|{text}>"
-        if title:
-            return f"<{escaped_url}|{title}>"
+        # A label identical to the href is what an autolinked bare URL produces
+        label = text or title
+        if label and label != escaped_url:
+            return f"<{escaped_url}|{label}>"
         return f"<{escaped_url}>"
 
     def image(self, text: str, url: str, title: str | None = None) -> str:

--- a/backend/onyx/onyxbot/slack/formatting.py
+++ b/backend/onyx/onyxbot/slack/formatting.py
@@ -1,14 +1,16 @@
 import re
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from mistune import HTMLRenderer, create_markdown
-
-if TYPE_CHECKING:
-    from mistune.core import InlineState
-    from mistune.inline_parser import InlineParser
-    from mistune.markdown import Markdown
-    from mistune.plugins import PluginRef
+from mistune import (
+    BlockState,
+    HTMLRenderer,
+    InlineParser,
+    InlineState,
+    Markdown,
+    PluginRef,
+    create_markdown,
+)
 
 # Tags that should be replaced with a newline (line-break and block-level elements)
 _HTML_NEWLINE_TAG_PATTERN = re.compile(
@@ -29,8 +31,8 @@ _CODE_PATTERN = re.compile(r"```[\s\S]*?```|`[^`\n]*`")
 _MARKDOWN_LINK_PATTERN = re.compile(r"\[(?:[^\[\]]|\[[^\]]*\])*\]\(")
 
 # Slack-style <url|text> links that LLMs sometimes emit directly. Mistune parses
-# <mailto:a@b.com|label> as one autolink and percent-encodes the pipe, so mailto
-# has to be recognised here rather than left to the parser.
+# <scheme:...|label> as one autolink and percent-encodes the pipe, so these are
+# rewritten before the parser sees them.
 _SLACK_LINK_PATTERN = re.compile(r"<((?:https?://|mailto:)[^|<>]+)\|([^<>]+)>")
 # Same shape against already-rendered output, where the label may be absent
 _RENDERED_SLACK_LINK_PATTERN = re.compile(
@@ -54,14 +56,15 @@ _URL_TRAILING_PUNCTUATION = ".,:;\"'*_~"
 _SLACK_SPECIALS: dict[str, str] = {"&": "&amp;", "<": "&lt;", ">": "&gt;"}
 
 
-def _escape_slack_specials(text: str) -> str:
+def escape_slack_specials(text: str) -> str:
+    """Make text safe to drop into mrkdwn without rendering it as markup."""
     for special, replacement in _SLACK_SPECIALS.items():
         text = text.replace(special, replacement)
     return text
 
 
 def format_slack_link_url(url: str) -> str:
-    return _escape_slack_specials(url.replace("|", "%7C"))
+    return escape_slack_specials(url.replace("|", "%7C"))
 
 
 def _escape_markdown_link_destination(url: str) -> str:
@@ -89,7 +92,7 @@ def _sanitize_html(text: str) -> str:
 def _transform_outside_code_blocks(
     message: str, transform: Callable[[str], str]
 ) -> str:
-    """Apply *transform* only where markdown does not keep the text literal."""
+    """Apply *transform* outside code spans and fenced blocks."""
     parts = _CODE_PATTERN.split(message)
     code_blocks = _CODE_PATTERN.findall(message)
 
@@ -173,15 +176,14 @@ def _convert_slack_links_to_markdown(message: str) -> str:
 
 
 def _append_autolink(
-    inline: "InlineParser",
-    state: "InlineState",
+    inline: InlineParser,
+    state: InlineState,
     label: str,
     url: str,
     end_pos: int,
 ) -> int:
-    # in_link is load-bearing beyond nesting: SlackRenderer.link compares the
-    # label to the href before flattening, so a nested autolink would defeat
-    # the redundant-label collapse.
+    # link() compares label to href before flattening, so a nested autolink
+    # would defeat the redundant-label collapse
     if state.in_link or state.in_image:
         inline.process_text(label, state)
     else:
@@ -210,9 +212,7 @@ def _trim_url_trailing_punctuation(url: str) -> str:
     return url
 
 
-def _parse_url_link(
-    inline: "InlineParser", m: re.Match[str], state: "InlineState"
-) -> int:
+def _parse_url_link(inline: InlineParser, m: re.Match[str], state: InlineState) -> int:
     url = _trim_url_trailing_punctuation(m.group(0))
     return _append_autolink(
         inline,
@@ -224,7 +224,7 @@ def _parse_url_link(
 
 
 def _parse_email_link(
-    inline: "InlineParser", m: re.Match[str], state: "InlineState"
+    inline: InlineParser, m: re.Match[str], state: InlineState
 ) -> int:
     email = m.group(0)
     if _email_match_starts_inside_local_part(m, state):
@@ -239,9 +239,7 @@ def _parse_email_link(
     )
 
 
-def _email_match_starts_inside_local_part(
-    m: re.Match[str], state: "InlineState"
-) -> bool:
+def _email_match_starts_inside_local_part(m: re.Match[str], state: InlineState) -> bool:
     """True when the match is a truncated local part rather than a whole address.
 
     A preceding local-part character normally means the regex started mid-address.
@@ -269,12 +267,11 @@ def _email_match_starts_inside_local_part(
     )
 
 
-def _slack_autolink(md: "Markdown") -> None:
+def _slack_autolink(md: Markdown) -> None:
     """Mistune plugin turning bare URLs and emails into link tokens.
 
-    Inline registration only buys code-span and fenced-block skipping. Link and
-    image labels still reach these rules, so nesting is prevented by the
-    in_link/in_image guard in _append_autolink.
+    Link and image labels still reach these rules, so nesting is prevented by
+    the in_link/in_image guard in _append_autolink.
     """
     md.inline.register("slack_url_link", _URL_LINK_PATTERN, _parse_url_link)
     md.inline.register("slack_email_link", _EMAIL_LINK_PATTERN, _parse_email_link)
@@ -293,7 +290,7 @@ def format_slack_message(message: str | None, render_links: bool = True) -> str:
     normalized_message = _transform_outside_code_blocks(
         message, _normalize_link_destinations
     )
-    plugins: list["PluginRef"] = ["strikethrough", "table"]
+    plugins: list[PluginRef] = ["strikethrough", "table"]
     if render_links:
         plugins.append(_slack_autolink)
     md = create_markdown(
@@ -317,9 +314,21 @@ class SlackRenderer(HTMLRenderer):
         self._render_links = render_links
         self._table_headers: list[str] = []
         self._current_row_cells: list[str] = []
+        self._list_depth = 0
+
+    def render_token(self, token: dict[str, Any], state: BlockState) -> str:
+        # attrs["depth"] counts every block container, so a list inside a
+        # blockquote reports depth 1. Only list ancestry may indent.
+        if token["type"] != "list":
+            return super().render_token(token, state)
+        self._list_depth += 1
+        try:
+            return super().render_token(token, state)
+        finally:
+            self._list_depth -= 1
 
     def escape_special(self, text: str) -> str:
-        return _escape_slack_specials(text)
+        return escape_slack_specials(text)
 
     def heading(self, text: str, level: int, **attrs: Any) -> str:  # noqa: ARG002
         return f"*{text}*\n\n"
@@ -334,10 +343,10 @@ class SlackRenderer(HTMLRenderer):
         return f"~{text}~"
 
     def list(self, text: str, ordered: bool, **attrs: Any) -> str:
-        depth = attrs.get("depth", 0)
-        # A fenced block or blank line closes a list, so the remaining items
-        # arrive as a fresh list carrying the number they have to resume from
-        number = attrs.get("start", 1)
+        depth: int = self._list_depth - 1
+        # An interrupting block splits a list, so the tail arrives as a fresh
+        # list carrying the number it has to resume from
+        number: int = attrs.get("start", 1)
         lines = text.split("\n")
         for i, line in enumerate(lines):
             if not line.startswith("li: "):

--- a/backend/onyx/onyxbot/slack/formatting.py
+++ b/backend/onyx/onyxbot/slack/formatting.py
@@ -21,8 +21,8 @@ _HTML_TAG_PATTERN = re.compile(
     r"<(?!https?://|mailto:)/?[a-zA-Z][^>]*>",
 )
 
-# Matches fenced code blocks (``` ... ```) so we can skip sanitization inside them
-_FENCED_CODE_BLOCK_PATTERN = re.compile(r"```[\s\S]*?```")
+# Fenced blocks before inline spans, so a fence wins over its own backticks
+_CODE_PATTERN = re.compile(r"```[\s\S]*?```|`[^`\n]*`")
 
 # Matches the start of any markdown link: [text]( or [[n]](
 # The inner group handles nested brackets for citation links like [[1]](.
@@ -89,9 +89,9 @@ def _sanitize_html(text: str) -> str:
 def _transform_outside_code_blocks(
     message: str, transform: Callable[[str], str]
 ) -> str:
-    """Apply *transform* only to text outside fenced code blocks."""
-    parts = _FENCED_CODE_BLOCK_PATTERN.split(message)
-    code_blocks = _FENCED_CODE_BLOCK_PATTERN.findall(message)
+    """Apply *transform* only where markdown does not keep the text literal."""
+    parts = _CODE_PATTERN.split(message)
+    code_blocks = _CODE_PATTERN.findall(message)
 
     result: list[str] = []
     for i, part in enumerate(parts):
@@ -290,7 +290,9 @@ def format_slack_message(message: str | None, render_links: bool = True) -> str:
         return ""
     message = _transform_outside_code_blocks(message, _sanitize_html)
     message = _convert_slack_links_to_markdown(message)
-    normalized_message = _normalize_link_destinations(message)
+    normalized_message = _transform_outside_code_blocks(
+        message, _normalize_link_destinations
+    )
     plugins: list["PluginRef"] = ["strikethrough", "table"]
     if render_links:
         plugins.append(_slack_autolink)
@@ -331,15 +333,24 @@ class SlackRenderer(HTMLRenderer):
     def strikethrough(self, text: str) -> str:
         return f"~{text}~"
 
-    def list(self, text: str, ordered: bool, **attrs: Any) -> str:  # noqa: ARG002
+    def list(self, text: str, ordered: bool, **attrs: Any) -> str:
+        depth = attrs.get("depth", 0)
+        # A fenced block or blank line closes a list, so the remaining items
+        # arrive as a fresh list carrying the number they have to resume from
+        number = attrs.get("start", 1)
         lines = text.split("\n")
-        count = 0
         for i, line in enumerate(lines):
-            if line.startswith("li: "):
-                count += 1
-                prefix = f"{count}. " if ordered else "• "
-                lines[i] = f"{prefix}{line[4:]}"
-        return "\n".join(lines) + "\n"
+            if not line.startswith("li: "):
+                continue
+            prefix = f"{number}. " if ordered else "• "
+            lines[i] = f"{'  ' * depth}{prefix}{line[4:]}"
+            number += 1
+
+        rendered = "\n".join(lines)
+        if not depth:
+            return rendered + "\n"
+        # A nested list is appended to its parent item's text, mid-line
+        return "\n" + rendered.rstrip("\n")
 
     def list_item(self, text: str) -> str:
         return f"li: {text}\n"

--- a/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
@@ -9,13 +9,17 @@ from onyx.context.search.models import SavedSearchDoc
 from onyx.onyxbot.slack.blocks import _build_sources_blocks
 
 
-def _make_saved_doc(updated_at: datetime | None) -> SavedSearchDoc:
+def _make_saved_doc(
+    updated_at: datetime | None,
+    semantic_identifier: str = "Example Doc",
+    link: str | None = "https://example.com",
+) -> SavedSearchDoc:
     return SavedSearchDoc(
         db_doc_id=1,
         document_id="doc-1",
         chunk_ind=0,
-        semantic_identifier="Example Doc",
-        link="https://example.com",
+        semantic_identifier=semantic_identifier,
+        link=link,
         blurb="Some blurb",
         source_type=DocumentSource.FILE,
         boost=0,
@@ -64,8 +68,34 @@ def test_build_sources_blocks_formats_naive_timestamp(
         f"By user@example.com | {captured['result']}"
     )
     assert context_block["elements"][1]["text"] == expected_text
+    assert context_block["elements"][1]["verbatim"] is True
 
     assert "doc" in captured
     formatted_timestamp: datetime = captured["doc"]
     expected_timestamp: datetime = naive_timestamp.replace(tzinfo=pytz.utc)
     assert formatted_timestamp == expected_timestamp
+
+
+def test_build_sources_blocks_keeps_link_syntax_flat() -> None:
+    document = _make_saved_doc(
+        updated_at=None,
+        semantic_identifier="Run [portal](https://n.e) <https://a.e>",
+        link="https://example.com/a|b>c",
+    )
+
+    blocks = _build_sources_blocks(cited_documents=[(1, document)])
+
+    text = blocks[1].to_dict()["elements"][1]["text"]
+    assert "*<https://example.com/a%7Cb&gt;c|[1] Run portal https://a.e>*" in text
+    assert text.count("<") == 1
+    assert text.count(">") == 1
+
+
+def test_build_sources_blocks_handles_missing_document_link() -> None:
+    document = _make_saved_doc(updated_at=None, link=None)
+
+    blocks = _build_sources_blocks(cited_documents=[(1, document)])
+
+    markdown = blocks[1].to_dict()["elements"][1]
+    assert markdown["text"] == "Example Doc"
+    assert markdown["verbatim"] is True

--- a/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
@@ -13,6 +13,7 @@ def _make_saved_doc(
     updated_at: datetime | None,
     semantic_identifier: str = "Example Doc",
     link: str | None = "https://example.com",
+    primary_owner: str = "user@example.com",
 ) -> SavedSearchDoc:
     return SavedSearchDoc(
         db_doc_id=1,
@@ -28,7 +29,7 @@ def _make_saved_doc(
         score=0.0,
         match_highlights=[],
         updated_at=updated_at,
-        primary_owners=["user@example.com"],
+        primary_owners=[primary_owner],
         secondary_owners=None,
         is_relevant=None,
         relevance_explanation=None,
@@ -99,3 +100,15 @@ def test_build_sources_blocks_handles_missing_document_link() -> None:
     markdown = blocks[1].to_dict()["elements"][1]
     assert markdown["text"] == "Example Doc"
     assert markdown["verbatim"] is True
+
+
+def test_build_sources_blocks_defangs_owner_mentions() -> None:
+    document = _make_saved_doc(
+        updated_at=None,
+        primary_owner="<@U123> <!channel> @here",
+    )
+
+    blocks = _build_sources_blocks(cited_documents=[(1, document)])
+
+    text = blocks[1].to_dict()["elements"][1]["text"]
+    assert "By &lt;@U123&gt; &lt;!channel&gt; @here" in text

--- a/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
@@ -285,6 +285,12 @@ def test_link_label_text_is_not_autolinked() -> None:
     )
 
 
+def test_markdown_link_keeps_nested_url_label_flat() -> None:
+    rendered = _render("[outer https://nested.example](https://outer.example/a|b>c)")
+
+    assert "<https://outer.example/a%7Cb%3Ec|outer https://nested.example>" == rendered
+
+
 def test_image_labels_cannot_nest_slack_links() -> None:
     assert "<https://images.example/a.png|https://alt.example>" == _render(
         "![https://alt.example](https://images.example/a.png)"

--- a/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
@@ -302,7 +302,7 @@ def test_trailing_punctuation_excluded_from_url() -> None:
 
 def test_balanced_url_parentheses_stay_inside_the_link() -> None:
     assert "<https://onyx.app/docs_(v2)>" == _render("https://onyx.app/docs_(v2)")
-    assert "<https://onyx.app/docs>)" == _render("https://onyx.app/docs)")
+    assert "<https://onyx.app/docs>)))" == _render("https://onyx.app/docs)))")
 
 
 def test_url_delimiters_and_short_hosts_do_not_break_slack_links() -> None:

--- a/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
@@ -1,3 +1,4 @@
+from onyx.onyxbot.slack.blocks import _clean_markdown_link_text
 from onyx.onyxbot.slack.formatting import (
     _convert_slack_links_to_markdown,
     _normalize_link_destinations,
@@ -176,3 +177,74 @@ def test_table_empty_first_column_no_bare_asterisks() -> None:
     # Empty title should not produce "**" (bare asterisks)
     assert "**" not in formatted
     assert "  • Status: Done" in formatted
+
+
+def _render(message: str) -> str:
+    """Run the full onyxbot answer path, i.e. the bytes Slack actually receives."""
+    return decode_escapes(remove_slack_text_interactions(format_slack_message(message)))
+
+
+def test_bold_url_delimiters_stay_outside_the_link() -> None:
+    rendered = _render("See **https://onyx.app/docs** for details.")
+
+    # A bare URL lets Slack's greedy auto-linker pull the closing * into the
+    # href, which breaks the link and orphans the opening * as literal text.
+    assert "See *<https://onyx.app/docs>* for details." == rendered
+
+
+def test_italic_and_strikethrough_urls_stay_intact() -> None:
+    assert "_<https://onyx.app>_" == _render("_https://onyx.app_")
+    assert "~<https://onyx.app>~" == _render("~~https://onyx.app~~")
+
+
+def test_bold_email_renders_as_mailto_link() -> None:
+    rendered = _render("Contact **support@onyx.app** for help.")
+
+    assert "Contact *<mailto:support@onyx.app|support@onyx.app>* for help." == rendered
+
+
+def test_bare_email_is_not_split_by_zero_width_space() -> None:
+    rendered = _render("plain support@onyx.app plain")
+
+    assert "​" not in rendered
+    assert "<mailto:support@onyx.app|support@onyx.app>" in rendered
+
+
+def test_mentions_are_still_defanged() -> None:
+    rendered = _render("Ping <@U123> and @channel please")
+
+    assert "@​U123" in rendered
+    assert "@​channel" in rendered
+
+
+def test_slack_style_mailto_link_survives_formatting() -> None:
+    message = "<mailto:support@onyx.app|support@onyx.app>"
+
+    assert message == _render(message)
+
+
+def test_urls_and_emails_in_code_are_left_alone() -> None:
+    assert "```\nhttps://onyx.app and a@b.com\n```" == _render(
+        "```\nhttps://onyx.app and a@b.com\n```"
+    )
+    assert "code `a@b.com` span" == _render("code `a@b.com` span")
+
+
+def test_url_link_drops_redundant_label() -> None:
+    assert "<https://onyx.app>" == _render("[https://onyx.app](https://onyx.app)")
+
+
+def test_link_label_text_is_not_autolinked() -> None:
+    # A nested <...> would terminate the citation link that wraps this title
+    title = _clean_markdown_link_text("Runbook for https://onyx.app/docs")
+
+    assert "Runbook for https://onyx.app/docs" == title
+    assert "Contact support@onyx.app" == _clean_markdown_link_text(
+        "Contact support@onyx.app"
+    )
+
+
+def test_trailing_punctuation_excluded_from_url() -> None:
+    assert "trailing <https://onyx.app/docs>. Done" == _render(
+        "trailing https://onyx.app/docs. Done"
+    )

--- a/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
@@ -206,7 +206,7 @@ def test_bold_email_renders_as_mailto_link() -> None:
 def test_bare_email_is_not_split_by_zero_width_space() -> None:
     rendered = _render("plain support@onyx.app plain")
 
-    assert "​" not in rendered
+    assert "\u200b" not in rendered
     assert "<mailto:support@onyx.app|support@onyx.app>" in rendered
 
 

--- a/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
@@ -213,8 +213,43 @@ def test_bare_email_is_not_split_by_zero_width_space() -> None:
 def test_mentions_are_still_defanged() -> None:
     rendered = _render("Ping <@U123> and @channel please")
 
-    assert "@​U123" in rendered
-    assert "@​channel" in rendered
+    assert "@\u200bU123" in rendered
+    assert "@\u200bchannel" in rendered
+
+
+def test_all_slack_notification_shapes_are_defanged() -> None:
+    message = (
+        "<@U123> <@W123> <@B123> <!here> <!channel> <!everyone> "
+        "<!subteam^S123> <!subteam^S456|@ops> @group"
+    )
+
+    cleaned = remove_slack_text_interactions(message)
+
+    for mention in (
+        "U123",
+        "W123",
+        "B123",
+        "here",
+        "channel",
+        "everyone",
+        "S123",
+        "ops",
+        "group",
+    ):
+        assert f"@\u200b{mention}" in cleaned
+    assert "<!" not in cleaned
+
+
+def test_email_specials_and_url_userinfo_survive_mention_defanging() -> None:
+    email = "support!@onyx.app"
+    url = "https://support!@onyx.app/docs"
+
+    rendered = _render(f"{email} {url} `{email}`")
+
+    assert f"<mailto:{email}|{email}>" in rendered
+    assert f"<{url}>" in rendered
+    assert f"`{email}`" in rendered
+    assert "\u200b" not in rendered
 
 
 def test_slack_style_mailto_link_survives_formatting() -> None:

--- a/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
@@ -248,3 +248,19 @@ def test_trailing_punctuation_excluded_from_url() -> None:
     assert "trailing <https://onyx.app/docs>. Done" == _render(
         "trailing https://onyx.app/docs. Done"
     )
+
+
+def test_balanced_url_parentheses_stay_inside_the_link() -> None:
+    assert "<https://onyx.app/docs_(v2)>" == _render("https://onyx.app/docs_(v2)")
+    assert "<https://onyx.app/docs>)" == _render("https://onyx.app/docs)")
+
+
+def test_url_delimiters_and_short_hosts_do_not_break_slack_links() -> None:
+    assert "<https://x>" == _render("https://x")
+    assert "<https://onyx.app>|label" == _render("https://onyx.app|label")
+
+
+def test_email_autolinking_does_not_match_an_overlong_local_part() -> None:
+    message = f"{'a' * 65}@example.com"
+
+    assert "mailto:" not in format_slack_message(message)

--- a/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
@@ -242,6 +242,21 @@ def test_link_label_text_is_not_autolinked() -> None:
     assert "Contact support@onyx.app" == _clean_markdown_link_text(
         "Contact support@onyx.app"
     )
+    assert "Read the portal" == _clean_markdown_link_text(
+        "Read the [portal](https://onyx.app)"
+    )
+    assert "Visit https://onyx.app" == _clean_markdown_link_text(
+        "Visit <https://onyx.app>"
+    )
+
+
+def test_image_labels_cannot_nest_slack_links() -> None:
+    assert "<https://images.example/a.png|https://alt.example>" == _render(
+        "![https://alt.example](https://images.example/a.png)"
+    )
+    assert "<https://images.example/a.png|https://alt.example>" == _render(
+        "![<https://alt.example>](https://images.example/a.png)"
+    )
 
 
 def test_trailing_punctuation_excluded_from_url() -> None:

--- a/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
@@ -196,16 +196,20 @@ def test_table_empty_first_column_no_bare_asterisks() -> None:
 
 
 def _render(message: str) -> str:
-    """Run the full onyxbot answer path, i.e. the bytes Slack actually receives."""
+    """Mirror the answer-block render path in blocks.py."""
     return decode_escapes(remove_slack_text_interactions(format_slack_message(message)))
 
 
 def test_bold_url_delimiters_stay_outside_the_link() -> None:
     rendered = _render("See **https://onyx.app/docs** for details.")
 
-    # A bare URL lets Slack's greedy auto-linker pull the closing * into the
-    # href, which breaks the link and orphans the opening * as literal text.
     assert "See *<https://onyx.app/docs>* for details." == rendered
+
+
+def test_unlinked_email_is_still_not_split_by_zero_width_space() -> None:
+    # Rejected as a truncated local part, so it stays plain text and the
+    # mention defanging is the only thing left that could corrupt it
+    assert "a *support@onyx.app" == _render("a *support@onyx.app")
 
 
 def test_italic_and_strikethrough_urls_stay_intact() -> None:

--- a/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
@@ -1,5 +1,11 @@
+from onyx.connectors.slack.utils import (
+    _NON_INTERACTIVE_SLACK_TEXT_PATTERN,
+    _SUBTEAM_MENTION_PATTERN,
+)
 from onyx.onyxbot.slack.blocks import _clean_markdown_link_text
 from onyx.onyxbot.slack.formatting import (
+    _RENDERED_SLACK_LINK_PATTERN,
+    _SLACK_LINK_PATTERN,
     _convert_slack_links_to_markdown,
     _normalize_link_destinations,
     _sanitize_html,
@@ -70,6 +76,16 @@ def test_slack_style_links_preserved_inside_code_blocks() -> None:
     converted = _convert_slack_links_to_markdown(message)
 
     assert "<https://example.com|click>" in converted
+
+
+def test_slack_token_patterns_stop_at_nested_openers() -> None:
+    nested_link = "<https://outer|label<https://nested>"
+    nested_subteam = "<!subteam^S1<!subteam^S2>"
+
+    assert _SLACK_LINK_PATTERN.fullmatch(nested_link) is None
+    assert _RENDERED_SLACK_LINK_PATTERN.fullmatch(nested_link) is None
+    assert _NON_INTERACTIVE_SLACK_TEXT_PATTERN.fullmatch(nested_link) is None
+    assert _SUBTEAM_MENTION_PATTERN.fullmatch(nested_subteam) is None
 
 
 def test_html_tags_stripped_outside_code_blocks() -> None:

--- a/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
@@ -217,6 +217,12 @@ def test_bold_email_renders_as_mailto_link() -> None:
     rendered = _render("Contact **support@onyx.app** for help.")
 
     assert "Contact *<mailto:support@onyx.app|support@onyx.app>* for help." == rendered
+    assert "_<mailto:support@onyx.app|support@onyx.app>_" == _render(
+        "_support@onyx.app_"
+    )
+    assert "~<mailto:support@onyx.app|support@onyx.app>~" == _render(
+        "~~support@onyx.app~~"
+    )
 
 
 def test_bare_email_is_not_split_by_zero_width_space() -> None:
@@ -333,6 +339,8 @@ def test_url_delimiters_and_short_hosts_do_not_break_slack_links() -> None:
 
 
 def test_email_autolinking_does_not_match_an_overlong_local_part() -> None:
-    message = f"{'a' * 65}@example.com"
-
-    assert "mailto:" not in format_slack_message(message)
+    repeated_specials = [character * 65 for character in ("a", "!", ".", "*", "_", "~")]
+    mixed_specials = [character + "a" * 64 for character in ("!", "*", "_", "~")]
+    for local_part in repeated_specials + mixed_specials:
+        message = f"{local_part}@example.com"
+        assert "mailto:" not in format_slack_message(message)

--- a/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
@@ -291,6 +291,35 @@ def test_urls_and_emails_in_code_are_left_alone() -> None:
     assert "code `a@b.com` span" == _render("code `a@b.com` span")
 
 
+def test_ordered_list_resumes_numbering_after_a_fenced_block() -> None:
+    # The fence closes the list, so the tail arrives as a separate list that
+    # has to pick up where the first one stopped
+    message = "1. one\n2. two:\n\n```\ncode\n```\n\n3. three"
+
+    assert message == format_slack_message(message)
+
+
+def test_nested_list_opens_an_indented_line_of_its_own() -> None:
+    assert "1. one\n2. two:\n  • a\n  • b\n3. three" == format_slack_message(
+        "1. one\n2. two:\n   - a\n   - b\n3. three"
+    )
+
+
+def test_code_is_left_literal_by_every_pre_parse_transform() -> None:
+    # Link conversion, HTML stripping and destination normalization all run
+    # before mistune sees the text, so each has to honor the code guard
+    for snippet in (
+        "`<mailto:admin@onyx.app|admin@onyx.app>`",
+        "`<https://onyx.app/docs|onyx.app/docs>`",
+        "`<div>hi</div>`",
+        "`[label](https://onyx.app/x)`",
+    ):
+        assert f"see {snippet} here" == format_slack_message(f"see {snippet} here")
+
+    fenced = "```\n[label](https://onyx.app/x)\n```"
+    assert fenced == format_slack_message(fenced)
+
+
 def test_url_link_drops_redundant_label() -> None:
     assert "<https://onyx.app>" == _render("[https://onyx.app](https://onyx.app)")
 

--- a/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_formatting.py
@@ -1,5 +1,5 @@
 from onyx.connectors.slack.utils import (
-    _NON_INTERACTIVE_SLACK_TEXT_PATTERN,
+    _DEFANG_EXEMPT_REGION_PATTERN,
     _SUBTEAM_MENTION_PATTERN,
 )
 from onyx.onyxbot.slack.blocks import _clean_markdown_link_text
@@ -84,7 +84,7 @@ def test_slack_token_patterns_stop_at_nested_openers() -> None:
 
     assert _SLACK_LINK_PATTERN.fullmatch(nested_link) is None
     assert _RENDERED_SLACK_LINK_PATTERN.fullmatch(nested_link) is None
-    assert _NON_INTERACTIVE_SLACK_TEXT_PATTERN.fullmatch(nested_link) is None
+    assert _DEFANG_EXEMPT_REGION_PATTERN.fullmatch(nested_link) is None
     assert _SUBTEAM_MENTION_PATTERN.fullmatch(nested_subteam) is None
 
 
@@ -297,6 +297,13 @@ def test_ordered_list_resumes_numbering_after_a_fenced_block() -> None:
     message = "1. one\n2. two:\n\n```\ncode\n```\n\n3. three"
 
     assert message == format_slack_message(message)
+
+
+def test_blockquoted_list_is_not_treated_as_nested() -> None:
+    # mistune counts every block container in attrs["depth"], so only list
+    # ancestry may indent
+    assert ">1. alpha\n>2. beta" == format_slack_message("> 1. alpha\n> 2. beta")
+    assert ">• a\n>• b" == format_slack_message("> - a\n> - b")
 
 
 def test_nested_list_opens_an_indented_line_of_its_own() -> None:


### PR DESCRIPTION
## Description

**Bug:** In Slack bot answers, bold URLs render with a stray `*`, emails are never clickable and are silently corrupted, inline code gets rewritten, and ordered lists restart at 1.

**Cause:**

- `SlackRenderer` emitted bare URLs and emails as plain text, leaving linking to Slack's server-side auto-linker. It is greedy, so `*https://onyx.app/docs*` puts the closing `*` inside the href. Slack also never auto-links a bare address in a section block.
- `add_zero_width_whitespace_after_tag` ran `replace("@", "@​")` over every answer, splitting every email address, including inside code. Unchanged since #473 (Sep 2023).
- The pre-parse transforms guarded fenced blocks only, so they rewrote inline code spans. Destination normalization was not guarded at all.
- `SlackRenderer.list` discarded mistune's `attrs` behind a `noqa`, dropping both `start` and nesting.

**Fix:**

- A mistune inline plugin emits bare URLs and emails as link tokens, so they reach Slack as `<url>` / `<mailto:addr|addr>`. Link and image labels still reach these rules, so nesting is blocked by an explicit `in_link`/`in_image` guard. Callers embedding output in a `<url|label>` pass `render_links=False`.
- The URL pattern drops trailing `* _ ~` so emphasis markers stay available to the emphasis rule. Mistune's own `url` plugin keeps them and swallows the closing marker on the pinned 3.3.0.
- Defanging targets only an `@` that starts a token, and exempts link destinations and code. Broadcast shapes stay dead.
- The code guard now covers inline spans, and destination normalization runs through it.
- Ordered lists honor `start`. Indentation keys off list ancestry rather than `attrs["depth"]`, which counts every block container and would indent a list inside a blockquote.
- Source metadata is escaped instead of re-rendered, so punctuation in an owner's name is not reinterpreted.

Also bounds the autolink regexes against quadratic backtracking and escapes `|`/`>` in link destinations.

## How Has This Been Tested?

**Live, against the dev Slack bot.** A 16-case message covering bold/italic/strikethrough URLs, a trailing period, a query string, parenthesised paths, three email shapes including `sales+eu@`, two code spans, a markdown link, `@channel`/`@here`, a bulleted list and a fenced block. All 16 correct, verified from the LLM answer text captured in `onyx_debug.log` through to the rendered message.

**Against Slack's own renderer.** Block Kit Builder confirms the mechanism:

| mrkdwn sent | Renders as |
| --- | --- |
| `*https://onyx.app/docs*` (before) | trailing `*` **inside** the href, leading one orphaned |
| `*support@onyx.app*` (before) | bold, not a link |
| `*<https://onyx.app/docs>*` (after) | clean bold link |
| `*<mailto:support@onyx.app\|support@onyx.app>*` (after) | clean bold email link |

**Regression tests proven to fail first.** Each new test was run against the unfixed source before being kept.

**Checks:**

- `uv run ruff format --check` → `27 files already formatted`
- `uv run ruff check` → `All checks passed!`
- `uv run ty check` (project-wide) → `All checks passed!`
- `uv run pytest -xv` on both affected test files → `44 passed`
- `uv run pytest -q backend/tests/unit` → `9 failed, 7322 passed`. All 9 are in `backend/tests/unit/onyx/utils/test_process_isolation.py` and reproduce identically on a clean `origin/main` tree, so they are unrelated.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
