### PR TITLE
fix(chat): classify model refusals instead of generic EmptyLLMResponseError (#13332) to release v4.5

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -43,6 +43,7 @@ from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.memory import UserMemoryContext, add_memory, update_memory_at_index
 from onyx.db.models import Persona
 from onyx.llm.constants import LlmProviderNames
+from onyx.llm.exceptions import ClassifiedLLMError
 from onyx.llm.interfaces import LLM, LLMUserIdentity, ToolChoiceOptions
 from onyx.llm.model_capabilities import is_true_openai_model
 from onyx.llm.models import ReasoningEffort
@@ -82,7 +83,7 @@ from shared_configs.contextvars import get_current_tenant_id
 logger = setup_logger()
 
 
-class EmptyLLMResponseError(RuntimeError):
+class EmptyLLMResponseError(ClassifiedLLMError):
     """Raised when the streamed LLM response completes without a usable answer."""
 
     def __init__(
@@ -94,14 +95,23 @@ class EmptyLLMResponseError(RuntimeError):
         client_error_msg: str,
         error_code: str = "EMPTY_LLM_RESPONSE",
         is_retryable: bool = True,
+        finish_reason: str | None = None,
     ) -> None:
-        super().__init__(client_error_msg)
+        super().__init__(
+            client_error_msg=client_error_msg,
+            error_code=error_code,
+            is_retryable=is_retryable,
+        )
         self.provider = provider
         self.model = model
         self.tool_choice = tool_choice
-        self.client_error_msg = client_error_msg
-        self.error_code = error_code
-        self.is_retryable = is_retryable
+        self.finish_reason = finish_reason
+
+
+# LiteLLM normalizes provider refusal stop reasons (e.g. Anthropic's
+# stop_reason="refusal", Gemini's SAFETY) to "content_filter". Some
+# OpenAI-compatible gateways forward the raw provider value instead.
+_REFUSAL_FINISH_REASONS = {"content_filter", "refusal"}
 
 
 def _build_empty_llm_response_error(
@@ -111,6 +121,29 @@ def _build_empty_llm_response_error(
 ) -> EmptyLLMResponseError:
     provider = llm.config.model_provider
     model = llm.config.model_name
+    finish_reason = llm_step_result.finish_reason
+
+    # A refusal/content-filter stop is a deliberate model decision (HTTP 200
+    # with no content), not a transport failure — retrying the same request
+    # against the same model will not help.
+    if finish_reason in _REFUSAL_FINISH_REASONS:
+        model_suggestion = (
+            " (e.g. Claude Opus 4.8)" if provider == LlmProviderNames.ANTHROPIC else ""
+        )
+        return EmptyLLMResponseError(
+            provider=provider,
+            model=model,
+            tool_choice=tool_choice,
+            client_error_msg=(
+                "The selected model declined to respond to this request and "
+                f"returned no content (finish_reason={finish_reason}). Try "
+                "rephrasing the request or switching to a different model"
+                f"{model_suggestion}."
+            ),
+            error_code="MODEL_REFUSAL",
+            is_retryable=False,
+            finish_reason=finish_reason,
+        )
 
     # OpenAI quota exhaustion has reached us as a streamed "stop" with zero content.
     # When the stream is completely empty and there is no reasoning/tool output, surface
@@ -132,6 +165,7 @@ def _build_empty_llm_response_error(
             ),
             error_code="BUDGET_EXCEEDED",
             is_retryable=False,
+            finish_reason=finish_reason,
         )
 
     return EmptyLLMResponseError(
@@ -143,6 +177,7 @@ def _build_empty_llm_response_error(
             "completed. No text or tool calls were received from the upstream "
             "provider."
         ),
+        finish_reason=finish_reason,
     )
 
 
@@ -228,6 +263,7 @@ def _try_fallback_tool_extraction(
                 answer=llm_step_result.answer,
                 tool_calls=extracted_tool_calls,
                 raw_answer=llm_step_result.raw_answer,
+                finish_reason=llm_step_result.finish_reason,
             ),
             True,
         )
@@ -707,6 +743,7 @@ def run_llm_loop(
             answer=None,
             tool_calls=None,
             raw_answer=None,
+            finish_reason=None,
         )
 
         # Hold back a margin below max_input_tokens: our tiktoken estimate can

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -1143,6 +1143,7 @@ def run_llm_step_pkt_generator(
     actionable_chunk_count = 0
     empty_chunk_count = 0
     finish_reasons: set[str] = set()
+    terminal_finish_reason: str | None = None
     xml_tool_call_content_filter = _XmlToolCallContentFilter()
 
     processor_state: Any = None
@@ -1291,6 +1292,7 @@ def run_llm_step_pkt_generator(
             finish_reason = packet.choice.finish_reason
             if finish_reason:
                 finish_reasons.add(str(finish_reason))
+                terminal_finish_reason = str(finish_reason)
             delta = packet.choice.delta
 
             # Weird behavior from some model providers, just log and ignore for now
@@ -1525,6 +1527,7 @@ def run_llm_step_pkt_generator(
             answer=accumulated_answer if accumulated_answer else None,
             tool_calls=tool_calls if tool_calls else None,
             raw_answer=accumulated_raw_answer if accumulated_raw_answer else None,
+            finish_reason=terminal_finish_reason,
         ),
         has_reasoned,
     )

--- a/backend/onyx/chat/models.py
+++ b/backend/onyx/chat/models.py
@@ -235,3 +235,7 @@ class LlmStepResult(BaseModel):
     # Raw LLM text before any display-oriented filtering/sanitization.
     # Used for fallback tool-call extraction when providers emit calls as text.
     raw_answer: str | None = None
+    # Terminal finish_reason from the stream, LiteLLM-normalized (e.g. "stop",
+    # "length", "tool_calls", "content_filter"). Lets downstream classification
+    # distinguish a model refusal from a genuinely empty provider response.
+    finish_reason: str | None = None

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1060,6 +1060,23 @@ _CANCEL_POLL_INTERVAL_S: Final[float] = 0.05
 _FENCE_REFRESH_INTERVAL_S: Final[float] = 60.0
 
 
+def _model_error_details(
+    error: Exception,
+    llm: LLM,
+    model_index: int,
+) -> dict[str, str | int | None]:
+    details: dict[str, str | int | None] = {
+        "model": llm.config.model_name,
+        "provider": llm.config.model_provider,
+        "model_index": model_index,
+    }
+    if isinstance(error, EmptyLLMResponseError):
+        details["tool_choice"] = error.tool_choice.value
+        details["finish_reason"] = error.finish_reason
+
+    return details
+
+
 def _run_models(
     setup: ChatTurnSetup,
     user: User,
@@ -1434,11 +1451,7 @@ def _run_models(
                             stack_trace=stack_trace,
                             error_code=info.error_code,
                             is_retryable=info.is_retryable,
-                            details={
-                                "model": model_llm.config.model_name,
-                                "provider": model_llm.config.model_provider,
-                                "model_index": model_idx,
-                            },
+                            details=_model_error_details(item, model_llm, model_idx),
                         )
                     )
                 elif isinstance(item, Packet):
@@ -1674,10 +1687,12 @@ def _stream_chat_turn(
     except EmptyLLMResponseError as e:
         stack_trace = traceback.format_exc()
         logger.warning(
-            "LLM returned an empty response (provider=%s, model=%s, tool_choice=%s)",
+            "LLM returned an empty response "
+            "(provider=%s, model=%s, tool_choice=%s, finish_reason=%s)",
             e.provider,
             e.model,
             e.tool_choice,
+            e.finish_reason,
         )
         yield StreamingError(
             error=e.client_error_msg,
@@ -1688,6 +1703,7 @@ def _stream_chat_turn(
                 "model": e.model,
                 "provider": e.provider,
                 "tool_choice": e.tool_choice.value,
+                "finish_reason": e.finish_reason,
             },
         )
 

--- a/backend/onyx/llm/exceptions.py
+++ b/backend/onyx/llm/exceptions.py
@@ -1,0 +1,12 @@
+class ClassifiedLLMError(RuntimeError):
+    def __init__(
+        self,
+        *,
+        client_error_msg: str,
+        error_code: str,
+        is_retryable: bool,
+    ) -> None:
+        super().__init__(client_error_msg)
+        self.client_error_msg = client_error_msg
+        self.error_code = error_code
+        self.is_retryable = is_retryable

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -15,6 +15,7 @@ from onyx.configs.app_configs import (
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import LLMModelFlowType
 from onyx.db.models import LLMProvider, ModelConfiguration
+from onyx.llm.exceptions import ClassifiedLLMError
 from onyx.llm.interfaces import LLM, LLMUserIdentity
 from onyx.llm.model_capabilities import (
     get_max_input_tokens,
@@ -148,6 +149,15 @@ def litellm_exception_to_error_msg(
     error_msg = str(core_exception)
     error_code = "UNKNOWN_ERROR"
     is_retryable = True
+
+    # This is raised by us in cases where we already have computed the stuff we
+    # normally pull out of litellm errors. Just send it through.
+    if isinstance(core_exception, ClassifiedLLMError):
+        return (
+            core_exception.client_error_msg,
+            core_exception.error_code,
+            core_exception.is_retryable,
+        )
 
     if custom_error_msg_mappings:
         for error_msg_pattern, custom_error_msg in custom_error_msg_mappings.items():

--- a/backend/tests/unit/onyx/chat/test_llm_loop.py
+++ b/backend/tests/unit/onyx/chat/test_llm_loop.py
@@ -1305,6 +1305,53 @@ class TestEmptyLlmResponseClassification:
         assert err.is_retryable is True
         assert "quota" not in err.client_error_msg.lower()
 
+    def test_refusal_finish_reason_is_classified_as_model_refusal(self) -> None:
+        """Anthropic refusal: HTTP 200, stop_reason="refusal" (normalized by
+        LiteLLM to "content_filter"), no text or tool calls. Must surface as a
+        refusal, not a generic empty-stream error."""
+        err = _build_empty_llm_response_error(
+            llm=self._make_llm(provider="anthropic", model="claude-fable-5"),
+            llm_step_result=LlmStepResult(
+                reasoning=None,
+                answer=None,
+                tool_calls=None,
+                raw_answer=None,
+                finish_reason="content_filter",
+            ),
+            tool_choice=ToolChoiceOptions.AUTO,
+        )
+
+        assert isinstance(err, EmptyLLMResponseError)
+        assert err.error_code == "MODEL_REFUSAL"
+        assert err.is_retryable is False
+        assert err.finish_reason == "content_filter"
+        assert "declined" in err.client_error_msg.lower()
+        # Anthropic-specific fallback suggestion from the issue.
+        assert "Claude Opus 4.8" in err.client_error_msg
+
+    def test_raw_refusal_finish_reason_takes_precedence_over_budget_heuristic(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Gateways may forward the raw "refusal" value; it must be recognized
+        and must win over the OpenAI empty-stream quota heuristic."""
+        monkeypatch.setattr("onyx.chat.llm_loop.is_true_openai_model", lambda *_: True)
+
+        err = _build_empty_llm_response_error(
+            llm=self._make_llm(),
+            llm_step_result=LlmStepResult(
+                reasoning=None,
+                answer=None,
+                tool_calls=None,
+                raw_answer=None,
+                finish_reason="refusal",
+            ),
+            tool_choice=ToolChoiceOptions.AUTO,
+        )
+
+        assert err.error_code == "MODEL_REFUSAL"
+        assert err.is_retryable is False
+        assert "Claude Opus 4.8" not in err.client_error_msg
+
 
 class TestSelectReminderText:
     """The open_url nudge must be suppressed when the open_url tool is disabled,

--- a/backend/tests/unit/onyx/chat/test_llm_step.py
+++ b/backend/tests/unit/onyx/chat/test_llm_step.py
@@ -974,3 +974,67 @@ class TestEmptyAnswerRecovery:
             p.obj.content for p in packets if isinstance(p.obj, AgentResponseDelta)
         )
         assert emitted == ""
+
+
+class TestFinishReasonPropagation:
+    """The terminal finish_reason must survive into LlmStepResult so run_llm_loop
+    can classify a model refusal (e.g. Anthropic stop_reason="refusal", which
+    LiteLLM normalizes to "content_filter") instead of raising a generic
+    EmptyLLMResponseError."""
+
+    @staticmethod
+    def _run_stream(chunks: list[tuple[str | None, str | None]]) -> Any:
+        from unittest.mock import MagicMock
+
+        from onyx.chat.llm_step import run_llm_step_pkt_generator
+        from onyx.llm.model_response import Delta, ModelResponseStream, StreamingChoice
+
+        llm = MagicMock()
+        llm.config = LLMConfig(
+            model_provider=LlmProviderNames.ANTHROPIC.value,
+            model_name="claude-fable-5",
+            temperature=0.0,
+            max_input_tokens=100_000,
+        )
+
+        def _gen(*_args: Any, **_kwargs: Any) -> Any:
+            for content, finish_reason in chunks:
+                yield ModelResponseStream(
+                    id="chunk",
+                    created="0",
+                    choice=StreamingChoice(
+                        finish_reason=finish_reason,
+                        delta=Delta(content=content),
+                    ),
+                )
+
+        llm.stream = _gen
+
+        gen = run_llm_step_pkt_generator(
+            history=[],
+            tool_definitions=[],
+            tool_choice=ToolChoiceOptions.AUTO,
+            llm=llm,
+            placement=Placement(turn_index=0),
+            state_container=None,
+            citation_processor=None,
+        )
+        while True:
+            try:
+                next(gen)
+            except StopIteration as stop:
+                llm_step_result, _ = stop.value
+                return llm_step_result
+
+    def test_refusal_stream_preserves_terminal_finish_reason(self) -> None:
+        """The exact shape from the bug report: HTTP 200, a terminal
+        content_filter finish reason, and zero content/tool calls."""
+        result = self._run_stream([(None, None), (None, "content_filter")])
+        assert result.finish_reason == "content_filter"
+        assert result.answer is None
+        assert result.tool_calls is None
+
+    def test_normal_stream_records_terminal_stop(self) -> None:
+        result = self._run_stream([("Hello", None), (" world", "stop")])
+        assert result.finish_reason == "stop"
+        assert result.answer == "Hello world"

--- a/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
+++ b/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
@@ -15,10 +15,12 @@ from uuid import uuid4
 import pytest
 from litellm.exceptions import ContextWindowExceededError
 
+from onyx.chat.llm_loop import EmptyLLMResponseError
 from onyx.chat.models import StreamingError
 from onyx.configs.constants import MessageType
 from onyx.db.chat import set_preferred_response
 from onyx.db.models import ChatMessage
+from onyx.llm.interfaces import ToolChoiceOptions
 from onyx.llm.override_models import LLMOverride
 from onyx.server.query_and_chat.models import SendMessageRequest
 from onyx.server.query_and_chat.placement import Placement
@@ -29,6 +31,9 @@ from onyx.server.query_and_chat.streaming_models import (
     ReasoningStart,
 )
 from onyx.utils.variable_functionality import global_version
+
+MODEL_REFUSAL_ERROR_CODE = "MODEL_REFUSAL"
+CONTENT_FILTER_FINISH_REASON = "content_filter"
 
 
 @pytest.fixture(autouse=True)
@@ -465,6 +470,38 @@ class TestRunModels:
         assert len(errors) == 1
         assert errors[0].error_code == "CONTEXT_TOO_LONG"
         assert errors[0].is_retryable is False
+
+    def test_model_refusal_preserves_error_classification(self) -> None:
+        refusal_message = "The selected model declined to respond."
+        refusal = EmptyLLMResponseError(
+            provider="anthropic",
+            model="claude-fable-5",
+            tool_choice=ToolChoiceOptions.AUTO,
+            client_error_msg=refusal_message,
+            error_code=MODEL_REFUSAL_ERROR_CODE,
+            is_retryable=False,
+            finish_reason=CONTENT_FILTER_FINISH_REASON,
+        )
+
+        with (
+            patch("onyx.chat.process_message.run_llm_loop", side_effect=refusal),
+            patch("onyx.chat.process_message.run_deep_research_llm_loop"),
+            patch("onyx.chat.process_message.construct_tools", return_value={}),
+            patch("onyx.chat.process_message.llm_loop_completion_handle"),
+            patch(
+                "onyx.chat.process_message.get_llm_token_counter",
+                return_value=lambda _: 0,
+            ),
+        ):
+            packets = _run_models_collect(_make_setup(n_models=1))
+
+        errors = [packet for packet in packets if isinstance(packet, StreamingError)]
+        assert len(errors) == 1
+        assert errors[0].error == refusal_message
+        assert errors[0].error_code == MODEL_REFUSAL_ERROR_CODE
+        assert errors[0].is_retryable is False
+        assert errors[0].details is not None
+        assert errors[0].details["finish_reason"] == CONTENT_FILTER_FINISH_REASON
 
     def test_one_model_error_does_not_stop_other_models(self) -> None:
         """A failing model yields StreamingError; the surviving model's packets still arrive."""

--- a/backend/tests/unit/onyx/llm/test_llm_utils_scrub.py
+++ b/backend/tests/unit/onyx/llm/test_llm_utils_scrub.py
@@ -6,6 +6,7 @@ from echoing API keys back through error messages.
 from collections.abc import Iterable
 from typing import Any
 
+from onyx.llm.exceptions import ClassifiedLLMError
 from onyx.llm.interfaces import LLM, LLMConfig
 from onyx.llm.utils import (
     collect_credential_values,
@@ -21,6 +22,7 @@ _SECRET_KEY = "sk-anthropic-supersecret-DO-NOT-LEAK-1234567890"
 _SECRET_VERTEX_BLOB = (
     '{"private_key":"-----BEGIN PRIVATE KEY-----abc-----END PRIVATE KEY-----"}'
 )
+_CLASSIFIED_ERROR_CODE = "MODEL_REFUSAL"
 
 
 class _StubLLM(LLM):
@@ -185,6 +187,22 @@ def test_safe_error_preserves_classification_and_redacts_fallback() -> None:
     assert custom_secret not in error_info.message
     assert error_info.error_code == "UNKNOWN_ERROR"
     assert error_info.is_retryable is True
+
+
+def test_safe_error_redacts_classified_error_without_losing_metadata() -> None:
+    llm = _StubLLM(_make_config())
+    error = ClassifiedLLMError(
+        client_error_msg=f"Provider declined request for key {_SECRET_KEY}",
+        error_code=_CLASSIFIED_ERROR_CODE,
+        is_retryable=False,
+    )
+
+    error_info = litellm_exception_to_safe_error(error, llm)
+
+    assert _SECRET_KEY not in error_info.message
+    assert "[REDACTED]" in error_info.message
+    assert error_info.error_code == _CLASSIFIED_ERROR_CODE
+    assert error_info.is_retryable is False
 
 
 # ---------------------------------------------------------------------------

--- a/web/src/app/app/message/errorHelpers.tsx
+++ b/web/src/app/app/message/errorHelpers.tsx
@@ -46,6 +46,8 @@ export const getErrorTitle = (errorCode?: string) => {
       return "Validation Error";
     case "BUDGET_EXCEEDED":
       return "Budget Exceeded";
+    case "MODEL_REFUSAL":
+      return "Model Declined to Respond";
     case "CONTENT_POLICY":
       return "Content Policy Violation";
     case "BAD_REQUEST":


### PR DESCRIPTION
Cherry-pick of commit 954c514a7d30c455bb47198dcdd39ec3507f80e6 to release/v4.5 branch.

Original PR: #13332

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies model refusals as a dedicated, non-retryable MODEL_REFUSAL instead of a generic empty response. Propagates the stream’s terminal finish_reason for clearer errors and updates the UI title.

- **Bug Fixes**
  - Treat finish_reason "content_filter" or "refusal" as a deliberate refusal; raise MODEL_REFUSAL with a clear message and an Anthropic-specific model switch suggestion.
  - Keep empty OpenAI streams mapped to BUDGET_EXCEEDED when quota is exhausted.
  - Add ClassifiedLLMError and make EmptyLLMResponseError extend it; pass classification through `llm.utils` and include finish_reason in error details and logs.
  - Capture terminal finish_reason in LlmStepResult and carry it through llm_step/llm_loop; UI maps MODEL_REFUSAL to "Model Declined to Respond".

<sup>Written for commit d5c9d05808112ae137d2fbbdad6f1d6a1b398fc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

