### PR TITLE
feat(db): optional FOR UPDATE on fetch_user_by_id

### DIFF
--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -6,7 +6,7 @@ from fastapi import HTTPException
 from fastapi_users.password import PasswordHelper
 from sqlalchemy import Select, case, func, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session, selectinload
+from sqlalchemy.orm import Session, lazyload, selectinload
 from sqlalchemy.sql import expression
 from sqlalchemy.sql.elements import ColumnElement, KeyedColumnElement
 from sqlalchemy.sql.expression import or_
@@ -337,12 +337,20 @@ def get_user_by_email(email: str, db_session: Session) -> User | None:
     return user
 
 
-def fetch_user_by_id(db_session: Session, user_id: UUID) -> User | None:
-    return (
-        db_session.query(User)
-        .filter(User.id == user_id)  # ty: ignore[invalid-argument-type]
-        .first()
+def fetch_user_by_id(
+    db_session: Session, user_id: UUID, for_update: bool = False
+) -> User | None:
+    """``for_update`` adds ``SELECT ... FOR UPDATE``, serializing concurrent
+    transactions that use the user row as a reservation boundary (e.g. Craft
+    sandbox/session reservation). Hold only for a short transaction."""
+    query = db_session.query(User).filter(
+        User.id == user_id  # ty: ignore[invalid-argument-type]
     )
+    if for_update:
+        # oauth_accounts is lazy="joined"; Postgres forbids FOR UPDATE on the
+        # nullable side of an outer join, so defer it when locking.
+        query = query.options(lazyload(User.oauth_accounts)).with_for_update()
+    return query.first()
 
 
 def _generate_password_hash() -> str:


### PR DESCRIPTION
## Description

Adds a `for_update` kwarg to `fetch_user_by_id` (`SELECT ... FOR UPDATE`), so callers can use the user row as a serialization boundary for short reservation transactions. Includes the `lazyload(oauth_accounts)` option required to make the lock legal — Postgres forbids `FOR UPDATE` on the nullable side of the relationship's eager outer join.

No behavior change for existing callers. First layer of the durable Craft provisioning stack (reference: #13598); used by the top PR to serialize sandbox/session reservations per user.

## How Has This Been Tested?

Exercised heavily by the EDU suites in the top PR of the stack; no behavior change for existing callers (`ty`, ruff, pre-commit clean).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional row lock to `fetch_user_by_id` via a `for_update` flag. This lets callers serialize short per-user reservation transactions (e.g., Craft sandbox/session) without changing existing behavior.

- **New Features**
  - Add `for_update` to `fetch_user_by_id` to issue `SELECT ... FOR UPDATE`.
  - When locking, defer `oauth_accounts` with `lazyload` to avoid Postgres outer-join lock errors.

<sup>Written for commit ead4ed33354fbad1b92df6f62ab3822cd26280fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

