### PR TITLE
fix(usage): persist and price cache-write tokens

### DIFF
--- a/backend/alembic/versions/8d1297b43210_add_cache_creation_tokens_to_user_usage.py
+++ b/backend/alembic/versions/8d1297b43210_add_cache_creation_tokens_to_user_usage.py
@@ -1,7 +1,7 @@
 """add cache creation tokens to user usage
 
 Revision ID: 8d1297b43210
-Revises: 3debc2b55899
+Revises: 3350a25df58e
 Create Date: 2026-07-31 15:45:02.165673
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "8d1297b43210"
-down_revision = "3debc2b55899"
+down_revision = "3350a25df58e"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/8d1297b43210_add_cache_creation_tokens_to_user_usage.py
+++ b/backend/alembic/versions/8d1297b43210_add_cache_creation_tokens_to_user_usage.py
@@ -1,0 +1,32 @@
+"""add cache creation tokens to user usage
+
+Revision ID: 8d1297b43210
+Revises: 3debc2b55899
+Create Date: 2026-07-31 15:45:02.165673
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "8d1297b43210"
+down_revision = "3debc2b55899"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_usage",
+        sa.Column(
+            "cache_creation_tokens",
+            sa.BigInteger(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_usage", "cache_creation_tokens")

--- a/backend/ee/onyx/server/reporting/usage_export_generation.py
+++ b/backend/ee/onyx/server/reporting/usage_export_generation.py
@@ -159,6 +159,7 @@ def generate_usage_breakdown_report(
                 "input_tokens",
                 "output_tokens",
                 "cache_read_tokens",
+                "cache_creation_tokens",
                 "cost_cents",
             ]
         )
@@ -175,6 +176,7 @@ def generate_usage_breakdown_report(
                     row.input_tokens,
                     row.output_tokens,
                     row.cache_read_tokens,
+                    row.cache_creation_tokens,
                     row.cost_cents,
                 ]
             )

--- a/backend/ee/onyx/server/reporting/usage_report_data.py
+++ b/backend/ee/onyx/server/reporting/usage_report_data.py
@@ -42,6 +42,7 @@ class UsageReportData(BaseModel):
     total_input_tokens: int
     total_output_tokens: int
     total_cache_read_tokens: int
+    total_cache_creation_tokens: int
 
     licensed_users: int
     # Everyone who used it, including people since deactivated, so this can
@@ -107,6 +108,7 @@ def build_usage_report_data(
     total_input = 0
     total_output = 0
     total_cache_read = 0
+    total_cache_creation = 0
     active_emails: set[str] = set()
 
     for row in rows:
@@ -129,6 +131,7 @@ def build_usage_report_data(
         total_input += row.input_tokens
         total_output += row.output_tokens
         total_cache_read += row.cache_read_tokens
+        total_cache_creation += row.cache_creation_tokens
 
         daily_cost[row.day] += row.cost_cents
         # Their spend still counts toward totals so the pack reconciles with the
@@ -160,6 +163,7 @@ def build_usage_report_data(
         total_input_tokens=total_input,
         total_output_tokens=total_output,
         total_cache_read_tokens=total_cache_read,
+        total_cache_creation_tokens=total_cache_creation,
         licensed_users=len(seat_emails),
         active_users=len(active_emails),
         seated_active_users=len(active_emails & seat_emails),

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -6032,6 +6032,9 @@ class UserUsage(Base):
     cache_read_tokens: Mapped[int] = mapped_column(
         BigInteger, nullable=False, default=0
     )
+    cache_creation_tokens: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0
+    )
     cost_cents: Mapped[float] = mapped_column(
         Numeric(18, 6, asdecimal=False), nullable=False, default=0.0
     )

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -120,6 +120,7 @@ class UserUsageByDay(BaseModel):
     input_tokens: int
     output_tokens: int
     cache_read_tokens: int
+    cache_creation_tokens: int
     cost_cents: float
 
 
@@ -133,6 +134,7 @@ class UsageExportRow(BaseModel):
     input_tokens: int
     output_tokens: int
     cache_read_tokens: int
+    cache_creation_tokens: int
     cost_cents: float
 
 
@@ -148,6 +150,8 @@ def record_user_usage(
     cost_cents: float,
     window_start: datetime,
     incognito: bool = False,
+    *,
+    cache_creation_tokens: int = 0,
 ) -> None:
     """Atomically accumulate into the ledger (Postgres upsert). Caller commits."""
     # Store "" rather than NULL for a missing provider so the dedup unique index
@@ -163,6 +167,7 @@ def record_user_usage(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         cache_read_tokens=cache_read_tokens,
+        cache_creation_tokens=cache_creation_tokens,
         cost_cents=cost_cents,
     )
     stmt = stmt.on_conflict_do_update(
@@ -172,6 +177,8 @@ def record_user_usage(
             "output_tokens": UserUsage.output_tokens + stmt.excluded.output_tokens,
             "cache_read_tokens": UserUsage.cache_read_tokens
             + stmt.excluded.cache_read_tokens,
+            "cache_creation_tokens": UserUsage.cache_creation_tokens
+            + stmt.excluded.cache_creation_tokens,
             "cost_cents": UserUsage.cost_cents + stmt.excluded.cost_cents,
         },
     )
@@ -194,6 +201,7 @@ def get_user_usage_by_day_and_model(
             func.sum(UserUsage.input_tokens),
             func.sum(UserUsage.output_tokens),
             func.sum(UserUsage.cache_read_tokens),
+            func.sum(UserUsage.cache_creation_tokens),
             func.sum(UserUsage.cost_cents),
         )
         .where(
@@ -211,10 +219,19 @@ def get_user_usage_by_day_and_model(
             model=model,
             input_tokens=int(in_tok or 0),
             output_tokens=int(out_tok or 0),
-            cache_read_tokens=int(cache_tok or 0),
+            cache_read_tokens=int(cache_read_tok or 0),
+            cache_creation_tokens=int(cache_creation_tok or 0),
             cost_cents=float(cost or 0.0),
         )
-        for day, model, in_tok, out_tok, cache_tok, cost in rows
+        for (
+            day,
+            model,
+            in_tok,
+            out_tok,
+            cache_read_tok,
+            cache_creation_tok,
+            cost,
+        ) in rows
     ]
 
 
@@ -239,6 +256,7 @@ def _get_usage_export_query(
             func.sum(UserUsage.input_tokens),
             func.sum(UserUsage.output_tokens),
             func.sum(UserUsage.cache_read_tokens),
+            func.sum(UserUsage.cache_creation_tokens),
             func.sum(UserUsage.cost_cents),
         )
         # UserUsage.user_id on the left: User.id comes from the fastapi-users
@@ -291,7 +309,8 @@ def iter_usage_export(
         day,
         in_tok,
         out_tok,
-        cache_tok,
+        cache_read_tok,
+        cache_creation_tok,
         cost,
     ) in result:
         yield UsageExportRow(
@@ -303,7 +322,8 @@ def iter_usage_export(
             day=str(day),
             input_tokens=int(in_tok or 0),
             output_tokens=int(out_tok or 0),
-            cache_read_tokens=int(cache_tok or 0),
+            cache_read_tokens=int(cache_read_tok or 0),
+            cache_creation_tokens=int(cache_creation_tok or 0),
             cost_cents=float(cost or 0.0),
         )
 

--- a/backend/onyx/llm/cost.py
+++ b/backend/onyx/llm/cost.py
@@ -104,15 +104,20 @@ def _override_cost_cents(
     input_tokens: int,
     output_tokens: int,
     cache_read_tokens: int,
+    cache_creation_tokens: int = 0,
 ) -> tuple[float, float]:
     """Apply admin per-Mtok rates. Cache reads bill at the admin cache rate when
-    set, otherwise at the input rate. Cache cost is folded into the input half."""
+    set, otherwise at the input rate. Cache cost is folded into the input half.
+
+    There is no admin cache-write rate, so cache creation bills at the input
+    rate. It still has to be counted here: callers pass uncached input only, so
+    omitting it would bill those tokens at zero."""
     input_per_mtok = rates.input_cost_per_mtok
     output_per_mtok = rates.output_cost_per_mtok
     cache_per_mtok = rates.cache_read_cost_per_mtok
     cache_rate = cache_per_mtok if cache_per_mtok is not None else input_per_mtok
     input_cents = (
-        input_tokens / 1_000_000 * input_per_mtok * 100
+        (input_tokens + cache_creation_tokens) / 1_000_000 * input_per_mtok * 100
         + cache_read_tokens / 1_000_000 * cache_rate * 100
     )
     output_cents = output_tokens / 1_000_000 * output_per_mtok * 100
@@ -128,6 +133,8 @@ def compute_cost_cents(
     flow: LLMFlow | str | None = None,
     image_count: int = 1,
     db_session: Session | None = None,
+    *,
+    cache_creation_tokens: int = 0,
 ) -> tuple[float, float]:
     """Return (input_cost_cents, output_cost_cents) for an LLM call.
 
@@ -144,7 +151,11 @@ def compute_cost_cents(
             rates = None
         if rates is not None:
             return _override_cost_cents(
-                rates, input_tokens, output_tokens, cache_read_tokens
+                rates,
+                input_tokens,
+                output_tokens,
+                cache_read_tokens,
+                cache_creation_tokens,
             )
 
     try:
@@ -153,14 +164,16 @@ def compute_cost_cents(
         # custom_llm_provider is required for non-self-identifying model names
         # (bedrock/vertex/anthropic-plain) — without it litellm raises and we'd
         # record $0 for entire provider classes.
-        # input_tokens are non-cached; cache reads are additional prompt tokens
-        # billed at the model's (discounted) cache-read rate, never as output.
+        # input_tokens are non-cached; cache reads and cache writes are
+        # additional prompt tokens that litellm re-prices at the model's own
+        # cache rates (reads discounted, writes at a premium), never as output.
         prompt_cost_usd, completion_cost_usd = litellm.cost_per_token(
             model=model,
             custom_llm_provider=provider,
-            prompt_tokens=input_tokens + cache_read_tokens,
+            prompt_tokens=input_tokens + cache_read_tokens + cache_creation_tokens,
             completion_tokens=output_tokens,
             cache_read_input_tokens=cache_read_tokens,
+            cache_creation_input_tokens=cache_creation_tokens,
         )
         return prompt_cost_usd * 100, completion_cost_usd * 100
     except Exception:
@@ -172,7 +185,7 @@ def compute_cost_cents(
             provider,
             exc_info=True,
         )
-        billed_input = input_tokens + cache_read_tokens
+        billed_input = input_tokens + cache_read_tokens + cache_creation_tokens
         input_cents = billed_input / 1_000_000 * DEFAULT_LLM_INPUT_COST_PER_MTOK * 100
         output_cents = (
             output_tokens / 1_000_000 * DEFAULT_LLM_OUTPUT_COST_PER_MTOK * 100
@@ -184,3 +197,32 @@ def compute_cost_cents(
                 provider,
             )
         return input_cents, output_cents
+
+
+def compute_cost_cents_from_usage(
+    model: str,
+    provider: str | None,
+    prompt_tokens: int,
+    completion_tokens: int,
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
+    flow: LLMFlow | str | None = None,
+    image_count: int = 1,
+    db_session: Session | None = None,
+) -> tuple[float, float]:
+    """Price cache-inclusive usage reported by an LLM provider."""
+    non_cached_input = max(
+        prompt_tokens - cache_read_tokens - cache_creation_tokens,
+        0,
+    )
+    return compute_cost_cents(
+        model=model,
+        provider=provider,
+        input_tokens=non_cached_input,
+        output_tokens=completion_tokens,
+        cache_read_tokens=cache_read_tokens,
+        cache_creation_tokens=cache_creation_tokens,
+        flow=flow,
+        image_count=image_count,
+        db_session=db_session,
+    )

--- a/backend/onyx/llm/cost.py
+++ b/backend/onyx/llm/cost.py
@@ -101,47 +101,61 @@ def _image_cost_cents(model: str, provider: str | None) -> float:
 
 def _override_cost_cents(
     rates: cost_overrides.CostOverrideRates,
-    input_tokens: int,
-    output_tokens: int,
+    prompt_tokens: int,
+    completion_tokens: int,
     cache_read_tokens: int,
-    cache_creation_tokens: int = 0,
 ) -> tuple[float, float]:
     """Apply admin per-Mtok rates. Cache reads bill at the admin cache rate when
     set, otherwise at the input rate. Cache cost is folded into the input half.
 
-    There is no admin cache-write rate, so cache creation bills at the input
-    rate. It still has to be counted here: callers pass uncached input only, so
-    omitting it would bill those tokens at zero."""
+    There is no admin cache-write rate, so cache writes bill at the input
+    rate."""
     input_per_mtok = rates.input_cost_per_mtok
     output_per_mtok = rates.output_cost_per_mtok
     cache_per_mtok = rates.cache_read_cost_per_mtok
     cache_rate = cache_per_mtok if cache_per_mtok is not None else input_per_mtok
+    non_cached_prompt = max(prompt_tokens - cache_read_tokens, 0)
     input_cents = (
-        (input_tokens + cache_creation_tokens) / 1_000_000 * input_per_mtok * 100
+        non_cached_prompt / 1_000_000 * input_per_mtok * 100
         + cache_read_tokens / 1_000_000 * cache_rate * 100
     )
-    output_cents = output_tokens / 1_000_000 * output_per_mtok * 100
+    output_cents = completion_tokens / 1_000_000 * output_per_mtok * 100
     return input_cents, output_cents
 
 
 def compute_cost_cents(
     model: str,
     provider: str | None,
-    input_tokens: int,
-    output_tokens: int,
+    prompt_tokens: int,
+    completion_tokens: int,
+    *,
     cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
     flow: LLMFlow | str | None = None,
     image_count: int = 1,
     db_session: Session | None = None,
-    *,
-    cache_creation_tokens: int = 0,
 ) -> tuple[float, float]:
     """Return (input_cost_cents, output_cost_cents) for an LLM call.
+
+    prompt_tokens is the cache-inclusive provider total; the cache counts are
+    subsets of it, not additions to it.
 
     Resolution order: image pricing → admin override → litellm → default
     fallback rates (0 unless set). Never raises (usage hot path)."""
     if flow in IMAGE_FLOWS:
         return 0.0, _image_cost_cents(model, provider) * max(image_count, 1)
+
+    if cache_read_tokens + cache_creation_tokens > prompt_tokens:
+        logger.warning(
+            "Cache subsets exceed the reported prompt total for model %s "
+            "(provider %s): %d read + %d write > %d prompt. Pricing the "
+            "reported total; cost may be understated.",
+            model,
+            provider,
+            cache_read_tokens,
+            cache_creation_tokens,
+            prompt_tokens,
+        )
 
     if db_session is not None:
         try:
@@ -152,10 +166,9 @@ def compute_cost_cents(
         if rates is not None:
             return _override_cost_cents(
                 rates,
-                input_tokens,
-                output_tokens,
+                prompt_tokens,
+                completion_tokens,
                 cache_read_tokens,
-                cache_creation_tokens,
             )
 
     try:
@@ -164,14 +177,13 @@ def compute_cost_cents(
         # custom_llm_provider is required for non-self-identifying model names
         # (bedrock/vertex/anthropic-plain) — without it litellm raises and we'd
         # record $0 for entire provider classes.
-        # input_tokens are non-cached; cache reads and cache writes are
-        # additional prompt tokens that litellm re-prices at the model's own
+        # litellm re-prices the cache subsets of prompt_tokens at the model's own
         # cache rates (reads discounted, writes at a premium), never as output.
         prompt_cost_usd, completion_cost_usd = litellm.cost_per_token(
             model=model,
             custom_llm_provider=provider,
-            prompt_tokens=input_tokens + cache_read_tokens + cache_creation_tokens,
-            completion_tokens=output_tokens,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
             cache_read_input_tokens=cache_read_tokens,
             cache_creation_input_tokens=cache_creation_tokens,
         )
@@ -185,10 +197,9 @@ def compute_cost_cents(
             provider,
             exc_info=True,
         )
-        billed_input = input_tokens + cache_read_tokens + cache_creation_tokens
-        input_cents = billed_input / 1_000_000 * DEFAULT_LLM_INPUT_COST_PER_MTOK * 100
+        input_cents = prompt_tokens / 1_000_000 * DEFAULT_LLM_INPUT_COST_PER_MTOK * 100
         output_cents = (
-            output_tokens / 1_000_000 * DEFAULT_LLM_OUTPUT_COST_PER_MTOK * 100
+            completion_tokens / 1_000_000 * DEFAULT_LLM_OUTPUT_COST_PER_MTOK * 100
         )
         if not (DEFAULT_LLM_INPUT_COST_PER_MTOK or DEFAULT_LLM_OUTPUT_COST_PER_MTOK):
             logger.warning(
@@ -197,32 +208,3 @@ def compute_cost_cents(
                 provider,
             )
         return input_cents, output_cents
-
-
-def compute_cost_cents_from_usage(
-    model: str,
-    provider: str | None,
-    prompt_tokens: int,
-    completion_tokens: int,
-    cache_read_tokens: int = 0,
-    cache_creation_tokens: int = 0,
-    flow: LLMFlow | str | None = None,
-    image_count: int = 1,
-    db_session: Session | None = None,
-) -> tuple[float, float]:
-    """Price cache-inclusive usage reported by an LLM provider."""
-    non_cached_input = max(
-        prompt_tokens - cache_read_tokens - cache_creation_tokens,
-        0,
-    )
-    return compute_cost_cents(
-        model=model,
-        provider=provider,
-        input_tokens=non_cached_input,
-        output_tokens=completion_tokens,
-        cache_read_tokens=cache_read_tokens,
-        cache_creation_tokens=cache_creation_tokens,
-        flow=flow,
-        image_count=image_count,
-        db_session=db_session,
-    )

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -24,7 +24,7 @@ from onyx.llm.api_surfaces import (
     resolve_api_surface,
 )
 from onyx.llm.constants import MODEL_PREFIX_TO_VENDOR, LlmProviderNames
-from onyx.llm.cost import compute_cost_cents
+from onyx.llm.cost import compute_cost_cents_from_usage
 from onyx.llm.custom_config_mapping import (
     UI_ONLY_CONFIG_KEYS,
     map_custom_config_to_model_kwargs,
@@ -620,19 +620,17 @@ class LitellmLLM(LLM):
         from onyx.db.engine.sql_engine import get_session_with_current_tenant
         from onyx.db.usage import UsageType, increment_usage
 
-        cache_read = usage.cache_read_input_tokens
-        # prompt_tokens is cache-inclusive; price non-cached + cache separately.
-        non_cached_input = max(usage.prompt_tokens - cache_read, 0)
         provider = self._custom_llm_provider or self._model_provider
 
         try:
             with get_session_with_current_tenant() as db_session:
-                input_cents, output_cents = compute_cost_cents(
-                    self._model_version,
-                    provider,
-                    non_cached_input,
-                    usage.completion_tokens,
-                    cache_read_tokens=cache_read,
+                input_cents, output_cents = compute_cost_cents_from_usage(
+                    model=self._model_version,
+                    provider=provider,
+                    prompt_tokens=usage.prompt_tokens,
+                    completion_tokens=usage.completion_tokens,
+                    cache_read_tokens=usage.cache_read_input_tokens,
+                    cache_creation_tokens=usage.cache_creation_input_tokens,
                     db_session=db_session,
                 )
                 cost_cents = input_cents + output_cents

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -24,7 +24,7 @@ from onyx.llm.api_surfaces import (
     resolve_api_surface,
 )
 from onyx.llm.constants import MODEL_PREFIX_TO_VENDOR, LlmProviderNames
-from onyx.llm.cost import compute_cost_cents_from_usage
+from onyx.llm.cost import compute_cost_cents
 from onyx.llm.custom_config_mapping import (
     UI_ONLY_CONFIG_KEYS,
     map_custom_config_to_model_kwargs,
@@ -624,7 +624,7 @@ class LitellmLLM(LLM):
 
         try:
             with get_session_with_current_tenant() as db_session:
-                input_cents, output_cents = compute_cost_cents_from_usage(
+                input_cents, output_cents = compute_cost_cents(
                     model=self._model_version,
                     provider=provider,
                     prompt_tokens=usage.prompt_tokens,

--- a/backend/onyx/server/features/usage/api.py
+++ b/backend/onyx/server/features/usage/api.py
@@ -330,6 +330,7 @@ def export_usage(
                 input_tokens=sum(r.input_tokens for r in records),
                 output_tokens=sum(r.output_tokens for r in records),
                 cache_read_tokens=sum(r.cache_read_tokens for r in records),
+                cache_creation_tokens=sum(r.cache_creation_tokens for r in records),
                 cost_cents=sum(r.cost_cents for r in records),
             ),
             records=records,

--- a/backend/onyx/server/features/usage/models.py
+++ b/backend/onyx/server/features/usage/models.py
@@ -48,6 +48,7 @@ class UsageExportRecord(BaseModel):
     input_tokens: int
     output_tokens: int
     cache_read_tokens: int
+    cache_creation_tokens: int
     cost_cents: float
 
 
@@ -55,6 +56,7 @@ class UsageExportTotals(BaseModel):
     input_tokens: int
     output_tokens: int
     cache_read_tokens: int
+    cache_creation_tokens: int
     cost_cents: float
 
 

--- a/backend/onyx/tracing/braintrust_tracing_processor.py
+++ b/backend/onyx/tracing/braintrust_tracing_processor.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 import braintrust
 from braintrust import NOOP_SPAN
 
-from onyx.llm.cost import compute_cost_cents
+from onyx.llm.cost import compute_cost_cents_from_usage
 from onyx.tracing.flows import IMAGE_FLOWS
 from onyx.tracing.incognito import suppresses_external_traces
 
@@ -186,15 +186,16 @@ class BraintrustTracingProcessor(TracingProcessor):
             or flow in IMAGE_FLOWS
         ):
             cache_read = int(usage.get("cache_read_input_tokens") or 0)
+            cache_creation = int(usage.get("cache_creation_input_tokens") or 0)
             input_tokens = int(prompt_tokens or 0)
             output_tokens = int(completion_tokens or 0)
-            non_cached_input = max(input_tokens - cache_read, 0)
-            input_cents, output_cents = compute_cost_cents(
-                model_name,
-                provider,
-                non_cached_input,
-                output_tokens,
+            input_cents, output_cents = compute_cost_cents_from_usage(
+                model=model_name,
+                provider=provider,
+                prompt_tokens=input_tokens,
+                completion_tokens=output_tokens,
                 cache_read_tokens=cache_read,
+                cache_creation_tokens=cache_creation,
                 flow=flow,
                 image_count=span.span_data.image_count or 1,
             )

--- a/backend/onyx/tracing/braintrust_tracing_processor.py
+++ b/backend/onyx/tracing/braintrust_tracing_processor.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 import braintrust
 from braintrust import NOOP_SPAN
 
-from onyx.llm.cost import compute_cost_cents_from_usage
+from onyx.llm.cost import compute_cost_cents
 from onyx.tracing.flows import IMAGE_FLOWS
 from onyx.tracing.incognito import suppresses_external_traces
 
@@ -189,7 +189,7 @@ class BraintrustTracingProcessor(TracingProcessor):
             cache_creation = int(usage.get("cache_creation_input_tokens") or 0)
             input_tokens = int(prompt_tokens or 0)
             output_tokens = int(completion_tokens or 0)
-            input_cents, output_cents = compute_cost_cents_from_usage(
+            input_cents, output_cents = compute_cost_cents(
                 model=model_name,
                 provider=provider,
                 prompt_tokens=input_tokens,

--- a/backend/onyx/tracing/langfuse_tracing_processor.py
+++ b/backend/onyx/tracing/langfuse_tracing_processor.py
@@ -91,7 +91,7 @@ class LangfuseTracingProcessor(TracingProcessor):
     def _calculate_cost(self, data: GenerationSpanData) -> Optional[float]:
         """Calculate LLM cost for this generation span (USD for Langfuse)."""
         try:
-            from onyx.llm.cost import compute_cost_cents
+            from onyx.llm.cost import compute_cost_cents_from_usage
 
             usage = data.usage or {}
             input_tokens = int(
@@ -101,6 +101,7 @@ class LangfuseTracingProcessor(TracingProcessor):
                 usage.get("output_tokens") or usage.get("completion_tokens") or 0
             )
             cache_read = int(usage.get("cache_read_input_tokens") or 0)
+            cache_creation = int(usage.get("cache_creation_input_tokens") or 0)
             model_config = data.model_config or {}
             provider = model_config.get("model_provider")
             flow = model_config.get("flow")
@@ -109,13 +110,13 @@ class LangfuseTracingProcessor(TracingProcessor):
             ):
                 return None
 
-            non_cached_input = max(input_tokens - cache_read, 0)
-            input_cents, output_cents = compute_cost_cents(
-                data.model,
-                provider,
-                non_cached_input,
-                output_tokens,
+            input_cents, output_cents = compute_cost_cents_from_usage(
+                model=data.model,
+                provider=provider,
+                prompt_tokens=input_tokens,
+                completion_tokens=output_tokens,
                 cache_read_tokens=cache_read,
+                cache_creation_tokens=cache_creation,
                 flow=flow,
                 image_count=data.image_count or 1,
             )

--- a/backend/onyx/tracing/langfuse_tracing_processor.py
+++ b/backend/onyx/tracing/langfuse_tracing_processor.py
@@ -91,7 +91,7 @@ class LangfuseTracingProcessor(TracingProcessor):
     def _calculate_cost(self, data: GenerationSpanData) -> Optional[float]:
         """Calculate LLM cost for this generation span (USD for Langfuse)."""
         try:
-            from onyx.llm.cost import compute_cost_cents_from_usage
+            from onyx.llm.cost import compute_cost_cents
 
             usage = data.usage or {}
             input_tokens = int(
@@ -110,7 +110,7 @@ class LangfuseTracingProcessor(TracingProcessor):
             ):
                 return None
 
-            input_cents, output_cents = compute_cost_cents_from_usage(
+            input_cents, output_cents = compute_cost_cents(
                 model=data.model,
                 provider=provider,
                 prompt_tokens=input_tokens,

--- a/backend/onyx/tracing/processors/user_usage_processor.py
+++ b/backend/onyx/tracing/processors/user_usage_processor.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.enums import IncognitoRecordMode
 from onyx.db.user_usage import USER_USAGE_BUCKET_SECONDS, record_user_usage
-from onyx.llm.cost import compute_cost_cents_from_usage
+from onyx.llm.cost import compute_cost_cents
 from onyx.tracing.flows import IMAGE_FLOWS
 from onyx.tracing.framework.processor_interface import TracingProcessor
 from onyx.tracing.framework.span_data import GenerationSpanData
@@ -249,7 +249,7 @@ class UserUsageTracingProcessor(TracingProcessor):
 
     @staticmethod
     def _write_record(db_session: Session, record: _UsageRecord) -> None:
-        input_cost, output_cost = compute_cost_cents_from_usage(
+        input_cost, output_cost = compute_cost_cents(
             model=record.model,
             provider=record.provider,
             prompt_tokens=record.input_tokens,

--- a/backend/onyx/tracing/processors/user_usage_processor.py
+++ b/backend/onyx/tracing/processors/user_usage_processor.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.enums import IncognitoRecordMode
 from onyx.db.user_usage import USER_USAGE_BUCKET_SECONDS, record_user_usage
-from onyx.llm.cost import compute_cost_cents
+from onyx.llm.cost import compute_cost_cents_from_usage
 from onyx.tracing.flows import IMAGE_FLOWS
 from onyx.tracing.framework.processor_interface import TracingProcessor
 from onyx.tracing.framework.span_data import GenerationSpanData
@@ -57,6 +57,7 @@ class _UsageRecord:
     input_tokens: int
     output_tokens: int
     cache_read_tokens: int
+    cache_creation_tokens: int
     image_count: int
     window_start: datetime
 
@@ -131,6 +132,7 @@ class UserUsageTracingProcessor(TracingProcessor):
         input_tokens = _usage_field(usage, "input_tokens", "prompt_tokens")
         output_tokens = _usage_field(usage, "output_tokens", "completion_tokens")
         cache_read_tokens = _usage_field(usage, "cache_read_input_tokens")
+        cache_creation_tokens = _usage_field(usage, "cache_creation_input_tokens")
         provider = model_config.get("model_provider")
 
         window_start = get_window_start(
@@ -152,6 +154,7 @@ class UserUsageTracingProcessor(TracingProcessor):
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             cache_read_tokens=cache_read_tokens,
+            cache_creation_tokens=cache_creation_tokens,
             image_count=data.image_count or 1,
             window_start=window_start,
         )
@@ -227,6 +230,9 @@ class UserUsageTracingProcessor(TracingProcessor):
                 input_tokens=current.input_tokens + record.input_tokens,
                 output_tokens=current.output_tokens + record.output_tokens,
                 cache_read_tokens=current.cache_read_tokens + record.cache_read_tokens,
+                cache_creation_tokens=(
+                    current.cache_creation_tokens + record.cache_creation_tokens
+                ),
                 image_count=current.image_count + record.image_count,
             )
         return list(aggregated.values())
@@ -243,13 +249,13 @@ class UserUsageTracingProcessor(TracingProcessor):
 
     @staticmethod
     def _write_record(db_session: Session, record: _UsageRecord) -> None:
-        non_cached_input = max(record.input_tokens - record.cache_read_tokens, 0)
-        input_cost, output_cost = compute_cost_cents(
-            record.model,
-            record.provider,
-            non_cached_input,
-            record.output_tokens,
+        input_cost, output_cost = compute_cost_cents_from_usage(
+            model=record.model,
+            provider=record.provider,
+            prompt_tokens=record.input_tokens,
+            completion_tokens=record.output_tokens,
             cache_read_tokens=record.cache_read_tokens,
+            cache_creation_tokens=record.cache_creation_tokens,
             flow=record.flow,
             image_count=record.image_count,
             db_session=db_session,
@@ -263,6 +269,7 @@ class UserUsageTracingProcessor(TracingProcessor):
             input_tokens=record.input_tokens,
             output_tokens=record.output_tokens,
             cache_read_tokens=record.cache_read_tokens,
+            cache_creation_tokens=record.cache_creation_tokens,
             cost_cents=input_cost + output_cost,
             window_start=record.window_start,
             incognito=record.incognito,

--- a/backend/tests/integration/tests/reporting/test_usage_export_api.py
+++ b/backend/tests/integration/tests/reporting/test_usage_export_api.py
@@ -313,6 +313,7 @@ class TestUsageExportAPI:
                     "input_tokens",
                     "output_tokens",
                     "cache_read_tokens",
+                    "cache_creation_tokens",
                     "cost_cents",
                 }
                 actual_columns = set(csv_reader.fieldnames or [])

--- a/backend/tests/unit/ee/onyx/server/reporting/test_usage_report_data.py
+++ b/backend/tests/unit/ee/onyx/server/reporting/test_usage_report_data.py
@@ -46,6 +46,7 @@ def _row(
         input_tokens=100,
         output_tokens=50,
         cache_read_tokens=10,
+        cache_creation_tokens=5,
         cost_cents=cost,
     )
 

--- a/backend/tests/unit/onyx/db/test_user_usage.py
+++ b/backend/tests/unit/onyx/db/test_user_usage.py
@@ -89,6 +89,7 @@ def _seed_usage(
     cache_read_tokens: int,
     cost_cents: float,
     window_start: datetime.datetime,
+    cache_creation_tokens: int = 0,
 ) -> None:
     """Insert a ledger row without going through the Postgres upsert path."""
     db_session.add(
@@ -101,6 +102,7 @@ def _seed_usage(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             cache_read_tokens=cache_read_tokens,
+            cache_creation_tokens=cache_creation_tokens,
             cost_cents=cost_cents,
         )
     )
@@ -149,12 +151,21 @@ class TestRecordUserUsage:
             input_tokens=100,
             output_tokens=50,
             cache_read_tokens=10,
+            cache_creation_tokens=25,
             cost_cents=1.5,
             window_start=window,
         )
 
         mock_session.execute.assert_called_once()
         mock_session.flush.assert_called_once()
+        stmt = mock_session.execute.call_args[0][0]
+        compiled = stmt.compile(dialect=postgresql.dialect())
+        assert compiled.params["cache_creation_tokens"] == 25
+        assert (
+            "cache_creation_tokens = "
+            "(user_usage.cache_creation_tokens + excluded.cache_creation_tokens)"
+            in str(compiled)
+        )
 
     def test_null_provider_stored_as_empty_string(self) -> None:
         mock_session = MagicMock()
@@ -309,7 +320,17 @@ class TestAggregation:
         day2 = datetime.datetime(2026, 6, 2, tzinfo=datetime.timezone.utc)
 
         _seed_usage(
-            db_session, user_id, "model-a", "CHAT", "anthropic", 100, 50, 0, 1.0, day1
+            db_session,
+            user_id,
+            "model-a",
+            "CHAT",
+            "anthropic",
+            100,
+            50,
+            0,
+            1.0,
+            day1,
+            cache_creation_tokens=7,
         )
         _seed_usage(
             db_session, user_id, "model-b", "CHAT", "anthropic", 200, 60, 0, 2.0, day1
@@ -331,6 +352,7 @@ class TestAggregation:
                 input_tokens=100,
                 output_tokens=50,
                 cache_read_tokens=0,
+                cache_creation_tokens=7,
                 cost_cents=1.0,
             ),
             UserUsageByDay(
@@ -339,6 +361,7 @@ class TestAggregation:
                 input_tokens=200,
                 output_tokens=60,
                 cache_read_tokens=0,
+                cache_creation_tokens=0,
                 cost_cents=2.0,
             ),
             UserUsageByDay(
@@ -347,6 +370,7 @@ class TestAggregation:
                 input_tokens=300,
                 output_tokens=70,
                 cache_read_tokens=0,
+                cache_creation_tokens=0,
                 cost_cents=3.0,
             ),
         ]

--- a/backend/tests/unit/onyx/llm/test_cost.py
+++ b/backend/tests/unit/onyx/llm/test_cost.py
@@ -1,5 +1,6 @@
 """Unit tests for split input/output cost and admin per-model overrides (SQLite)."""
 
+import logging
 from collections.abc import Generator
 from typing import cast
 
@@ -14,7 +15,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from onyx.db.models import ModelCostOverride
 from onyx.llm import cost as cost_mod
 from onyx.llm import cost_overrides
-from onyx.llm.cost import compute_cost_cents, compute_cost_cents_from_usage
+from onyx.llm.cost import compute_cost_cents
 from onyx.tracing.flows import LLMFlow
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
@@ -57,8 +58,8 @@ class TestComputeCostCents:
         in_cents, out_cents = compute_cost_cents(
             model="gpt-4o",
             provider="openai",
-            input_tokens=1000,
-            output_tokens=1000,
+            prompt_tokens=1000,
+            completion_tokens=1000,
         )
         assert in_cents == pytest.approx(0.25)
         assert out_cents == pytest.approx(1.0)
@@ -67,8 +68,8 @@ class TestComputeCostCents:
         result = compute_cost_cents(
             model="totally-made-up-model-xyz",
             provider="nobody",
-            input_tokens=1000,
-            output_tokens=1000,
+            prompt_tokens=1000,
+            completion_tokens=1000,
         )
         assert result == (0.0, 0.0)
 
@@ -80,22 +81,21 @@ class TestComputeCostCents:
         in_cents, out_cents = compute_cost_cents(
             model="totally-made-up-model-xyz",
             provider="nobody",
-            input_tokens=1_000_000,
-            output_tokens=1_000_000,
+            prompt_tokens=1_000_000,
+            completion_tokens=1_000_000,
             cache_read_tokens=0,
         )
         assert in_cents == pytest.approx(200.0)  # 1M * $2/Mtok = $2.00 = 200c
         assert out_cents == pytest.approx(600.0)  # 1M * $6/Mtok = $6.00 = 600c
 
     def test_cache_read_tokens_priced_as_input(self) -> None:
-        # gpt-4o: $2.50/Mtok input, $1.25/Mtok cache-read. 1000 non-cached +
-        # 2000 cache-read = 1000*2.5e-6 + 2000*1.25e-6 = $0.005 = 0.5 cents.
-        # Pinned exactly to catch double-counting cached tokens at full rate.
+        # gpt-4o $2.50/Mtok in, $1.25/Mtok cache-read:
+        # 1000*2.5e-6 + 2000*1.25e-6 = $0.005 = 0.5c
         cache_in, cache_out = compute_cost_cents(
             "gpt-4o",
             "openai",
-            input_tokens=1000,
-            output_tokens=500,
+            prompt_tokens=3000,
+            completion_tokens=500,
             cache_read_tokens=2000,
         )
         assert cache_in == pytest.approx(0.5)
@@ -103,33 +103,49 @@ class TestComputeCostCents:
         assert cache_out == pytest.approx(0.5)
 
     def test_cache_creation_tokens_priced_at_the_write_premium(self) -> None:
-        # claude-sonnet-4-5: $3/Mtok input, $3.75/Mtok cache-write (1.25x).
-        # 1000 uncached + 2000 written = 1000*3e-6 + 2000*3.75e-6 = $0.0105.
-        # Pinned exactly: billing writes at the plain input rate yields 0.9c,
-        # which is the bug this guards.
+        # claude-sonnet-4-5 $3/Mtok in, $3.75/Mtok cache-write:
+        # 1000*3e-6 + 2000*3.75e-6 = $0.0105 = 1.05c. The plain input rate
+        # would yield 0.9c.
         cents_in, _ = compute_cost_cents(
             "claude-sonnet-4-5",
             "anthropic",
-            input_tokens=1000,
-            output_tokens=0,
+            prompt_tokens=3000,
+            completion_tokens=0,
             cache_creation_tokens=2000,
         )
         assert cents_in == pytest.approx(1.05)
 
     def test_cache_write_costs_more_than_an_equivalent_read(self) -> None:
-        """Direction check that survives a price-table refresh: on Anthropic a
-        written token costs strictly more than a read one."""
+        """Asserts a direction, not exact cents, so a price-table refresh
+        cannot break it."""
         write_cents, _ = compute_cost_cents(
-            "claude-sonnet-4-5", "anthropic", 0, 0, cache_creation_tokens=1000
+            "claude-sonnet-4-5", "anthropic", 1000, 0, cache_creation_tokens=1000
         )
         read_cents, _ = compute_cost_cents(
-            "claude-sonnet-4-5", "anthropic", 0, 0, cache_read_tokens=1000
+            "claude-sonnet-4-5", "anthropic", 1000, 0, cache_read_tokens=1000
         )
         plain_cents, _ = compute_cost_cents("claude-sonnet-4-5", "anthropic", 1000, 0)
         assert write_cents > plain_cents > read_cents > 0
 
-    def test_usage_pricing_normalizes_both_cache_segments(self) -> None:
-        input_cents, output_cents = compute_cost_cents_from_usage(
+    def test_inconsistent_cache_counts_warn_instead_of_billing_silently(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.WARNING):
+            compute_cost_cents(
+                "claude-sonnet-4-5",
+                "anthropic",
+                100,
+                0,
+                cache_read_tokens=80,
+                cache_creation_tokens=80,
+            )
+
+        assert "Cache subsets exceed the reported prompt total" in caplog.text
+
+    def test_cache_inclusive_prompt_total_prices_each_segment(self) -> None:
+        # 1000 fresh, 1000 read, 2000 written:
+        # 1000*3e-6 + 1000*0.30e-6 + 2000*3.75e-6 = $0.0108 = 1.08c
+        input_cents, output_cents = compute_cost_cents(
             model="claude-sonnet-4-5",
             provider="anthropic",
             prompt_tokens=4000,
@@ -141,21 +157,6 @@ class TestComputeCostCents:
         assert input_cents == pytest.approx(1.08)
         assert output_cents == 0
 
-    def test_existing_optional_arguments_keep_their_positional_order(self) -> None:
-        input_cents, output_cents = compute_cost_cents(
-            "dall-e-3",
-            "openai",
-            0,
-            0,
-            0,
-            LLMFlow.IMAGE_GENERATION,
-            2,
-            None,
-        )
-
-        assert input_cents == 0
-        assert output_cents == pytest.approx(8.0)
-
     def test_bedrock_model_priced_via_provider(self) -> None:
         # Bedrock names aren't self-identifying — without custom_llm_provider
         # litellm raises and the cost silently collapses to $0. Haiku:
@@ -163,8 +164,8 @@ class TestComputeCostCents:
         in_cents, out_cents = compute_cost_cents(
             model="anthropic.claude-3-haiku-20240307-v1:0",
             provider="bedrock",
-            input_tokens=1000,
-            output_tokens=1000,
+            prompt_tokens=1000,
+            completion_tokens=1000,
         )
         assert in_cents == pytest.approx(0.025)
         assert out_cents == pytest.approx(0.125)
@@ -176,8 +177,8 @@ class TestImageFlow:
         in_cents, out_cents = compute_cost_cents(
             model="dall-e-3",
             provider="openai",
-            input_tokens=0,
-            output_tokens=0,
+            prompt_tokens=0,
+            completion_tokens=0,
             flow=LLMFlow.IMAGE_GENERATION,
         )
         assert (in_cents + out_cents) == pytest.approx(4.0)
@@ -186,8 +187,8 @@ class TestImageFlow:
         in_cents, out_cents = compute_cost_cents(
             model="some-unpriced-image-model",
             provider="nobody",
-            input_tokens=0,
-            output_tokens=0,
+            prompt_tokens=0,
+            completion_tokens=0,
             flow=LLMFlow.IMAGE_EDIT,
         )
         from onyx.configs.app_configs import DEFAULT_IMAGE_COST_CENTS
@@ -198,8 +199,8 @@ class TestImageFlow:
         in_cents, out_cents = compute_cost_cents(
             model="dall-e-3",
             provider="openai",
-            input_tokens=0,
-            output_tokens=0,
+            prompt_tokens=0,
+            completion_tokens=0,
             flow=LLMFlow.IMAGE_GENERATION,
             image_count=3,
         )
@@ -220,8 +221,8 @@ class TestImageFlow:
         in_cents, out_cents = compute_cost_cents(
             model="dall-e-3",
             provider="openai",
-            input_tokens=0,
-            output_tokens=0,
+            prompt_tokens=0,
+            completion_tokens=0,
             flow=LLMFlow.IMAGE_GENERATION,
             db_session=db_session,
         )
@@ -242,8 +243,8 @@ class TestOverride:
         in_cents, out_cents = compute_cost_cents(
             model="gpt-4o",
             provider="openai",
-            input_tokens=1_000_000,
-            output_tokens=1_000_000,
+            prompt_tokens=1_000_000,
+            completion_tokens=1_000_000,
             db_session=db_session,
         )
         # $1.00 = 100 cents in, $2.00 = 200 cents out.
@@ -263,13 +264,35 @@ class TestOverride:
         in_cents, _ = compute_cost_cents(
             model="gpt-4o",
             provider="openai",
-            input_tokens=500_000,
-            output_tokens=0,
+            prompt_tokens=1_000_000,
+            completion_tokens=0,
             cache_read_tokens=500_000,
             db_session=db_session,
         )
-        # (500k + 500k) tok at $1/Mtok = $1.00 = 100 cents.
         assert in_cents == pytest.approx(100.0)
+
+    def test_override_bills_cache_writes_at_the_input_rate(
+        self, db_session: Session
+    ) -> None:
+        db_session.add(
+            ModelCostOverride(
+                model="gpt-4o",
+                input_cost_per_mtok=1.0,
+                output_cost_per_mtok=2.0,
+                cache_read_cost_per_mtok=0.1,
+            )
+        )
+        db_session.commit()
+
+        in_cents, _ = compute_cost_cents(
+            model="gpt-4o",
+            provider="openai",
+            prompt_tokens=2_000_000,
+            completion_tokens=0,
+            cache_creation_tokens=1_000_000,
+            db_session=db_session,
+        )
+        assert in_cents == pytest.approx(200.0)
 
     def test_override_cache_rate_applied_when_set(self, db_session: Session) -> None:
         db_session.add(
@@ -285,12 +308,12 @@ class TestOverride:
         in_cents, _ = compute_cost_cents(
             model="gpt-4o",
             provider="openai",
-            input_tokens=1_000_000,
-            output_tokens=0,
+            prompt_tokens=2_000_000,
+            completion_tokens=0,
             cache_read_tokens=1_000_000,
             db_session=db_session,
         )
-        # 1M input @ $1 = 100c + 1M cache @ $0.10 = 10c = 110 cents.
+        # 1M non-cached @ $1 = 100c + 1M cache reads @ $0.10 = 10c = 110 cents.
         assert in_cents == pytest.approx(110.0)
 
     def test_override_cache_is_tenant_scoped(self) -> None:
@@ -313,8 +336,8 @@ class TestOverride:
             a_in, a_out = compute_cost_cents(
                 "gpt-4o",
                 "openai",
-                input_tokens=1_000_000,
-                output_tokens=1_000_000,
+                prompt_tokens=1_000_000,
+                completion_tokens=1_000_000,
                 db_session=tenant_a,
             )
         finally:
@@ -326,8 +349,8 @@ class TestOverride:
             b_in, b_out = compute_cost_cents(
                 "gpt-4o",
                 "openai",
-                input_tokens=1_000_000,
-                output_tokens=1_000_000,
+                prompt_tokens=1_000_000,
+                completion_tokens=1_000_000,
                 db_session=tenant_b,
             )
         finally:

--- a/backend/tests/unit/onyx/llm/test_cost.py
+++ b/backend/tests/unit/onyx/llm/test_cost.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from onyx.db.models import ModelCostOverride
 from onyx.llm import cost as cost_mod
 from onyx.llm import cost_overrides
-from onyx.llm.cost import compute_cost_cents
+from onyx.llm.cost import compute_cost_cents, compute_cost_cents_from_usage
 from onyx.tracing.flows import LLMFlow
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
@@ -101,6 +101,60 @@ class TestComputeCostCents:
         assert cache_in == pytest.approx(0.5)
         # Output (500 tok @ $10/Mtok) is unaffected by cache reads.
         assert cache_out == pytest.approx(0.5)
+
+    def test_cache_creation_tokens_priced_at_the_write_premium(self) -> None:
+        # claude-sonnet-4-5: $3/Mtok input, $3.75/Mtok cache-write (1.25x).
+        # 1000 uncached + 2000 written = 1000*3e-6 + 2000*3.75e-6 = $0.0105.
+        # Pinned exactly: billing writes at the plain input rate yields 0.9c,
+        # which is the bug this guards.
+        cents_in, _ = compute_cost_cents(
+            "claude-sonnet-4-5",
+            "anthropic",
+            input_tokens=1000,
+            output_tokens=0,
+            cache_creation_tokens=2000,
+        )
+        assert cents_in == pytest.approx(1.05)
+
+    def test_cache_write_costs_more_than_an_equivalent_read(self) -> None:
+        """Direction check that survives a price-table refresh: on Anthropic a
+        written token costs strictly more than a read one."""
+        write_cents, _ = compute_cost_cents(
+            "claude-sonnet-4-5", "anthropic", 0, 0, cache_creation_tokens=1000
+        )
+        read_cents, _ = compute_cost_cents(
+            "claude-sonnet-4-5", "anthropic", 0, 0, cache_read_tokens=1000
+        )
+        plain_cents, _ = compute_cost_cents("claude-sonnet-4-5", "anthropic", 1000, 0)
+        assert write_cents > plain_cents > read_cents > 0
+
+    def test_usage_pricing_normalizes_both_cache_segments(self) -> None:
+        input_cents, output_cents = compute_cost_cents_from_usage(
+            model="claude-sonnet-4-5",
+            provider="anthropic",
+            prompt_tokens=4000,
+            completion_tokens=0,
+            cache_read_tokens=1000,
+            cache_creation_tokens=2000,
+        )
+
+        assert input_cents == pytest.approx(1.08)
+        assert output_cents == 0
+
+    def test_existing_optional_arguments_keep_their_positional_order(self) -> None:
+        input_cents, output_cents = compute_cost_cents(
+            "dall-e-3",
+            "openai",
+            0,
+            0,
+            0,
+            LLMFlow.IMAGE_GENERATION,
+            2,
+            None,
+        )
+
+        assert input_cents == 0
+        assert output_cents == pytest.approx(8.0)
 
     def test_bedrock_model_priced_via_provider(self) -> None:
         # Bedrock names aren't self-identifying — without custom_llm_provider

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -1,8 +1,10 @@
 import os
 import threading
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import litellm
 import pytest
@@ -14,7 +16,7 @@ from onyx.configs.app_configs import MOCK_LLM_RESPONSE
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.interfaces import LLMUserIdentity
 from onyx.llm.model_capabilities import get_max_input_tokens
-from onyx.llm.model_response import ModelResponse, ModelResponseStream
+from onyx.llm.model_response import ModelResponse, ModelResponseStream, Usage
 from onyx.llm.models import (
     AssistantMessage,
     FunctionCall,
@@ -3119,3 +3121,48 @@ def test_policy_extra_body_keeps_deployment_siblings_under_the_same_key() -> Non
         "allow_fallbacks": False,
         "data_collection": "deny",
     }
+
+
+def test_track_llm_cost_prices_cache_creation_at_write_rate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    llm = LitellmLLM(
+        api_key="managed-key",
+        timeout=30,
+        model_provider=LlmProviderNames.ANTHROPIC,
+        model_name="claude-sonnet-4-5",
+        max_input_tokens=200000,
+    )
+    db_session = MagicMock()
+
+    @contextmanager
+    def _fake_session() -> Iterator[Any]:
+        yield db_session
+
+    monkeypatch.setattr(
+        "onyx.server.usage_limits.is_usage_limits_enabled", lambda: True
+    )
+    monkeypatch.setattr(
+        "onyx.server.usage_limits.is_onyx_managed_api_key", lambda _key: True
+    )
+    monkeypatch.setattr(
+        "onyx.db.engine.sql_engine.get_session_with_current_tenant", _fake_session
+    )
+    monkeypatch.setattr(
+        "onyx.llm.cost.cost_overrides.get_override",
+        lambda _session, _model, _provider: None,
+    )
+    increment_usage = MagicMock()
+    monkeypatch.setattr("onyx.db.usage.increment_usage", increment_usage)
+
+    llm._track_llm_cost(
+        Usage(
+            prompt_tokens=3000,
+            completion_tokens=0,
+            total_tokens=3000,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens=2000,
+        )
+    )
+
+    assert increment_usage.call_args.args[2] == pytest.approx(1.05)

--- a/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
@@ -107,6 +107,7 @@ def _seed_usage(
     cache_read_tokens: int,
     cost_cents: float,
     window_start: datetime.datetime,
+    cache_creation_tokens: int = 0,
 ) -> None:
     db_session.add(
         UserUsage(
@@ -118,6 +119,7 @@ def _seed_usage(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             cache_read_tokens=cache_read_tokens,
+            cache_creation_tokens=cache_creation_tokens,
             cost_cents=cost_cents,
         )
     )
@@ -128,7 +130,19 @@ def _seed_two_users(db_session: Session) -> tuple[str, str]:
     alice = _add_user(db_session, "alice@example.com")
     bob = _add_user(db_session, "bob@example.com")
 
-    _seed_usage(db_session, alice, "model-a", "CHAT", "openai", 100, 50, 5, 1.0, _W1)
+    _seed_usage(
+        db_session,
+        alice,
+        "model-a",
+        "CHAT",
+        "openai",
+        100,
+        50,
+        5,
+        1.0,
+        _W1,
+        cache_creation_tokens=7,
+    )
     _seed_usage(db_session, alice, "model-b", "CHAT", "openai", 200, 60, 0, 2.0, _W1)
     _seed_usage(db_session, alice, "model-a", "CHAT", "openai", 300, 70, 0, 3.0, _W2)
     _seed_usage(db_session, bob, "model-a", "CHAT", "anthropic", 400, 80, 0, 4.0, _W2)
@@ -155,6 +169,7 @@ class TestGetUsageExportHelper:
                 input_tokens=100,
                 output_tokens=50,
                 cache_read_tokens=5,
+                cache_creation_tokens=7,
                 cost_cents=1.0,
             ),
             UsageExportRow(
@@ -167,6 +182,7 @@ class TestGetUsageExportHelper:
                 input_tokens=200,
                 output_tokens=60,
                 cache_read_tokens=0,
+                cache_creation_tokens=0,
                 cost_cents=2.0,
             ),
             UsageExportRow(
@@ -179,6 +195,7 @@ class TestGetUsageExportHelper:
                 input_tokens=300,
                 output_tokens=70,
                 cache_read_tokens=0,
+                cache_creation_tokens=0,
                 cost_cents=3.0,
             ),
             UsageExportRow(
@@ -191,6 +208,7 @@ class TestGetUsageExportHelper:
                 input_tokens=400,
                 output_tokens=80,
                 cache_read_tokens=0,
+                cache_creation_tokens=0,
                 cost_cents=4.0,
             ),
         ]
@@ -283,6 +301,7 @@ class TestExportEndpoint:
         assert alice["totals"]["input_tokens"] == 600  # 100 + 200 + 300
         assert alice["totals"]["output_tokens"] == 180  # 50 + 60 + 70
         assert alice["totals"]["cache_read_tokens"] == 5
+        assert alice["totals"]["cache_creation_tokens"] == 7
         assert alice["totals"]["cost_cents"] == pytest.approx(6.0)
 
         bob = users["bob@example.com"]

--- a/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
@@ -138,6 +138,7 @@ def _seed_usage(
     cache_read_tokens: int,
     cost_cents: float,
     window_start: datetime.datetime,
+    cache_creation_tokens: int = 0,
 ) -> None:
     db_session.add(
         UserUsage(
@@ -149,6 +150,7 @@ def _seed_usage(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             cache_read_tokens=cache_read_tokens,
+            cache_creation_tokens=cache_creation_tokens,
             cost_cents=cost_cents,
         )
     )
@@ -193,7 +195,17 @@ def test_returns_only_callers_rows_and_aggregates(
     window = _seed_current_window(db_session, caller)
     # Same window, distinct model -> second per-day row for the caller.
     _seed_usage(
-        db_session, caller, "claude-3", "CHAT", "anthropic", 200, 60, 5, 2.0, window
+        db_session,
+        caller,
+        "claude-3",
+        "CHAT",
+        "anthropic",
+        200,
+        60,
+        5,
+        2.0,
+        window,
+        cache_creation_tokens=7,
     )
     # Another user's usage must never surface.
     _seed_usage(
@@ -213,6 +225,7 @@ def test_returns_only_callers_rows_and_aggregates(
     assert models["gpt-4o"]["input_tokens"] == 100
     assert models["claude-3"]["output_tokens"] == 60
     assert models["claude-3"]["cache_read_tokens"] == 5
+    assert models["claude-3"]["cache_creation_tokens"] == 7
     # No row leaks the other user's 999s.
     assert all(r["input_tokens"] != 999 for r in body["per_day_by_model"])
 

--- a/backend/tests/unit/onyx/tracing/test_braintrust_tracing_processor.py
+++ b/backend/tests/unit/onyx/tracing/test_braintrust_tracing_processor.py
@@ -1,0 +1,31 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from onyx.tracing.framework.span_data import GenerationSpanData
+
+# The connector tests also define a top-level package named braintrust. Stub the
+# optional SDK so full-suite collection cannot bind this import to that package.
+with patch.dict(sys.modules, {"braintrust": MagicMock()}):
+    from onyx.tracing.braintrust_tracing_processor import BraintrustTracingProcessor
+
+
+def test_generation_cost_prices_cache_creation_at_write_rate() -> None:
+    span = MagicMock()
+    span.started_at = None
+    span.ended_at = None
+    span.span_data = GenerationSpanData(
+        model="claude-sonnet-4-5",
+        model_config={"model_provider": "anthropic"},
+        usage={
+            "input_tokens": 3000,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": 2000,
+        },
+    )
+
+    processor = BraintrustTracingProcessor()
+    metrics = processor._generation_log_data(span)["metrics"]
+
+    assert metrics["cost_cents"] == pytest.approx(1.05)

--- a/backend/tests/unit/onyx/tracing/test_langfuse_tracing_processor.py
+++ b/backend/tests/unit/onyx/tracing/test_langfuse_tracing_processor.py
@@ -4,6 +4,9 @@ from collections.abc import Mapping
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
+from onyx.tracing.framework.span_data import GenerationSpanData
 from onyx.tracing.langfuse_tracing_processor import LangfuseTracingProcessor
 
 
@@ -69,3 +72,18 @@ def test_on_trace_start_coerces_non_string_user_id() -> None:
 
     kwargs = observation.update_trace.call_args.kwargs
     assert kwargs["user_id"] == "7"
+
+
+def test_calculate_cost_prices_cache_creation_at_write_rate() -> None:
+    processor = LangfuseTracingProcessor(client=MagicMock())
+    data = GenerationSpanData(
+        model="claude-sonnet-4-5",
+        model_config={"model_provider": "anthropic"},
+        usage={
+            "input_tokens": 3000,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": 2000,
+        },
+    )
+
+    assert processor._calculate_cost(data) == pytest.approx(0.0105)

--- a/backend/tests/unit/onyx/tracing/test_user_usage_processor.py
+++ b/backend/tests/unit/onyx/tracing/test_user_usage_processor.py
@@ -73,9 +73,7 @@ def processor(
         recorded_calls.append(kwargs)
 
     monkeypatch.setattr(proc_mod, "get_session_with_tenant", _fake_session)
-    monkeypatch.setattr(
-        proc_mod, "compute_cost_cents_from_usage", lambda *_a, **_k: (1.0, 2.0)
-    )
+    monkeypatch.setattr(proc_mod, "compute_cost_cents", lambda *_a, **_k: (1.0, 2.0))
     monkeypatch.setattr(proc_mod, "record_user_usage", _capture_record)
 
     p = UserUsageTracingProcessor(flush_interval_seconds=0.05)
@@ -317,7 +315,7 @@ def test_passes_cache_inclusive_usage_to_shared_pricing(
     def _capture_record(db_session: Any, **kwargs: Any) -> None:  # noqa: ARG001
         recorded_calls.append(kwargs)
 
-    monkeypatch.setattr(proc_mod, "compute_cost_cents_from_usage", _capture_cost)
+    monkeypatch.setattr(proc_mod, "compute_cost_cents", _capture_cost)
     monkeypatch.setattr(proc_mod, "record_user_usage", _capture_record)
 
     p = UserUsageTracingProcessor(flush_interval_seconds=0.05)

--- a/backend/tests/unit/onyx/tracing/test_user_usage_processor.py
+++ b/backend/tests/unit/onyx/tracing/test_user_usage_processor.py
@@ -73,7 +73,9 @@ def processor(
         recorded_calls.append(kwargs)
 
     monkeypatch.setattr(proc_mod, "get_session_with_tenant", _fake_session)
-    monkeypatch.setattr(proc_mod, "compute_cost_cents", lambda *_a, **_k: (1.0, 2.0))
+    monkeypatch.setattr(
+        proc_mod, "compute_cost_cents_from_usage", lambda *_a, **_k: (1.0, 2.0)
+    )
     monkeypatch.setattr(proc_mod, "record_user_usage", _capture_record)
 
     p = UserUsageTracingProcessor(flush_interval_seconds=0.05)
@@ -166,6 +168,38 @@ def test_batch_aggregates_matching_ledger_dimensions(
     assert aggregated[0].output_tokens == 5
 
 
+def test_batch_aggregates_cache_creation_tokens(
+    processor: UserUsageTracingProcessor,
+) -> None:
+    token = CURRENT_USER_ID_CONTEXTVAR.set(str(uuid4()))
+    try:
+        first = processor._capture(
+            _generation_span(
+                usage={
+                    "input_tokens": 30,
+                    "cache_creation_input_tokens": 10,
+                }
+            )
+        )
+        second = processor._capture(
+            _generation_span(
+                usage={
+                    "input_tokens": 50,
+                    "cache_creation_input_tokens": 20,
+                }
+            )
+        )
+    finally:
+        CURRENT_USER_ID_CONTEXTVAR.reset(token)
+
+    assert first is not None
+    assert second is not None
+    aggregated = processor._aggregate_batch([first, second])
+    assert len(aggregated) == 1
+    assert aggregated[0].input_tokens == 80
+    assert aggregated[0].cache_creation_tokens == 30
+
+
 def test_no_record_when_user_id_unset(
     processor: UserUsageTracingProcessor, recorded_calls: list[dict[str, Any]]
 ) -> None:
@@ -250,7 +284,7 @@ def test_on_span_end_never_raises_on_internal_error(
     assert recorded_calls == []
 
 
-def test_excludes_cache_reads_from_priced_input(
+def test_passes_cache_inclusive_usage_to_shared_pricing(
     monkeypatch: pytest.MonkeyPatch, recorded_calls: list[dict[str, Any]]
 ) -> None:
     @contextmanager
@@ -259,23 +293,31 @@ def test_excludes_cache_reads_from_priced_input(
 
     monkeypatch.setattr(proc_mod, "get_session_with_tenant", _fake_session)
 
-    priced: list[tuple[int, int, int]] = []
+    priced: list[tuple[int, int, int, int]] = []
 
     def _capture_cost(
-        _model: str,
-        _provider: Any,
-        input_tokens: int,
-        output_tokens: int,
+        model: str,  # noqa: ARG001
+        provider: Any,  # noqa: ARG001
+        prompt_tokens: int,
+        completion_tokens: int,
         cache_read_tokens: int = 0,
+        cache_creation_tokens: int = 0,
         **_kw: Any,
     ) -> tuple[float, float]:
-        priced.append((input_tokens, output_tokens, cache_read_tokens))
+        priced.append(
+            (
+                prompt_tokens,
+                completion_tokens,
+                cache_read_tokens,
+                cache_creation_tokens,
+            )
+        )
         return (0.0, 0.0)
 
     def _capture_record(db_session: Any, **kwargs: Any) -> None:  # noqa: ARG001
         recorded_calls.append(kwargs)
 
-    monkeypatch.setattr(proc_mod, "compute_cost_cents", _capture_cost)
+    monkeypatch.setattr(proc_mod, "compute_cost_cents_from_usage", _capture_cost)
     monkeypatch.setattr(proc_mod, "record_user_usage", _capture_record)
 
     p = UserUsageTracingProcessor(flush_interval_seconds=0.05)
@@ -289,6 +331,7 @@ def test_excludes_cache_reads_from_priced_input(
                         "input_tokens": 3000,
                         "output_tokens": 500,
                         "cache_read_input_tokens": 2000,
+                        "cache_creation_input_tokens": 500,
                     }
                 )
             )
@@ -298,10 +341,11 @@ def test_excludes_cache_reads_from_priced_input(
     finally:
         p.shutdown()
 
-    assert priced == [(1000, 500, 2000)]
+    assert priced == [(3000, 500, 2000, 500)]
     assert len(recorded_calls) == 1
     assert recorded_calls[0]["input_tokens"] == 3000
     assert recorded_calls[0]["cache_read_tokens"] == 2000
+    assert recorded_calls[0]["cache_creation_tokens"] == 500
 
 
 def test_flush_swallows_record_errors(

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -46,6 +46,7 @@ const COLLAPSED_USAGE_ROW_COUNT = 3;
 function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
   const [showAll, setShowAll] = useState(false);
   const hasCache = rows.some((row) => row.cache_read_tokens > 0);
+  const hasCacheWrites = rows.some((row) => row.cache_creation_tokens > 0);
   const modelRows = useMemo(() => {
     const byModel = new Map<string, Omit<UsagePerDayByModel, "day">>();
     for (const row of rows) {
@@ -54,11 +55,13 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
         input_tokens: 0,
         output_tokens: 0,
         cache_read_tokens: 0,
+        cache_creation_tokens: 0,
         cost_cents: 0,
       };
       model.input_tokens += row.input_tokens;
       model.output_tokens += row.output_tokens;
       model.cache_read_tokens += row.cache_read_tokens;
+      model.cache_creation_tokens += row.cache_creation_tokens;
       model.cost_cents += row.cost_cents;
       byModel.set(row.model, model);
     }
@@ -142,7 +145,13 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
                       row.output_tokens
                     )} out${
                       hasCache
-                        ? ` · ${formatTokens(row.cache_read_tokens)} cache`
+                        ? ` · ${formatTokens(row.cache_read_tokens)} cache reads`
+                        : ""
+                    }${
+                      hasCacheWrites
+                        ? ` · ${formatTokens(
+                            row.cache_creation_tokens
+                          )} cache writes`
                         : ""
                     }`}
                   </Text>

--- a/web/src/app/app/settings/usage/lib.ts
+++ b/web/src/app/app/settings/usage/lib.ts
@@ -12,6 +12,7 @@ export interface UsagePerDayByModel {
   input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;
+  cache_creation_tokens: number;
   cost_cents: number;
 }
 

--- a/web/src/lib/usage/userUsage.ts
+++ b/web/src/lib/usage/userUsage.ts
@@ -28,6 +28,7 @@ export interface UsageExportRecord {
   input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;
+  cache_creation_tokens: number;
   cost_cents: number;
 }
 

--- a/web/src/lib/usage/userUsage.ts
+++ b/web/src/lib/usage/userUsage.ts
@@ -10,6 +10,7 @@ export interface UsageExportTotals {
   input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;
+  cache_creation_tokens: number;
   cost_cents: number;
 }
 

--- a/web/src/sections/usage/SpendByUserTable.test.tsx
+++ b/web/src/sections/usage/SpendByUserTable.test.tsx
@@ -13,6 +13,7 @@ test("opens a user from the keyboard", () => {
             input_tokens: 1_000,
             output_tokens: 200,
             cache_read_tokens: 100,
+            cache_creation_tokens: 50,
             cost_cents: 25,
           },
           records: [],

--- a/web/src/sections/usage/SpendByUserTable.tsx
+++ b/web/src/sections/usage/SpendByUserTable.tsx
@@ -22,6 +22,7 @@ export interface SpendRow {
   input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;
+  cache_creation_tokens: number;
 }
 
 function emptyTotals(): UsageExportTotals {
@@ -29,6 +30,7 @@ function emptyTotals(): UsageExportTotals {
     input_tokens: 0,
     output_tokens: 0,
     cache_read_tokens: 0,
+    cache_creation_tokens: 0,
     cost_cents: 0,
   };
 }
@@ -56,6 +58,8 @@ function filteredRow(
       input_tokens: sum.input_tokens + record.input_tokens,
       output_tokens: sum.output_tokens + record.output_tokens,
       cache_read_tokens: sum.cache_read_tokens + record.cache_read_tokens,
+      cache_creation_tokens:
+        sum.cache_creation_tokens + record.cache_creation_tokens,
       cost_cents: sum.cost_cents + record.cost_cents,
     }),
     emptyTotals()

--- a/web/src/sections/usage/UserUsageDetailModal.tsx
+++ b/web/src/sections/usage/UserUsageDetailModal.tsx
@@ -295,6 +295,12 @@ export default function UserUsageDetailModal({
                   value={formatTokens(totals.cache_read_tokens)}
                 />
               </div>
+              <div className="basis-1/2 sm:basis-1/4">
+                <StatCell
+                  label="Cache writes"
+                  value={formatTokens(totals.cache_creation_tokens)}
+                />
+              </div>
             </div>
 
             <DailySpendStrip days={days} />


### PR DESCRIPTION
## Description

Provider cache-write usage was available as `cache_creation_input_tokens`, but the value disappeared before persistence and pricing normalized cache-inclusive prompt totals inconsistently. This PR now carries cache writes through pricing, storage, APIs, and the usage UI.

### What changed

- Add a `user_usage.cache_creation_tokens` bigint column with a zero default for existing rows.
- Persist and atomically aggregate provider-reported cache-write tokens alongside input, output, and cache-read usage.
- Expose cache writes separately in self-service per-day usage and admin per-user reports/totals.
- Display distinct cache-read and cache-write metrics in both usage UIs.
- Add `compute_cost_cents_from_usage` as the shared normalization path for cache-inclusive provider totals.
- Route per-user usage, managed usage limits, Braintrust, and Langfuse through that helper.
- Pass cache creation to LiteLLM so provider-specific write rates are applied.

`input_tokens` intentionally remains the provider-reported prompt total. `cache_creation_tokens` is a separately persisted and reported subset, not an additional token count to add when reporting total prompt usage. Providers that do not report cache writes persist zero. Existing rows are backfilled to zero by the migration default.

The admin override schema has no separate cache-write rate, so cache writes use the configured input rate in that path.

## Review hardening

- Fixed the Greptile P1 finding that batch aggregation dropped cache-write counts from later records.
- Preserved the existing positional `compute_cost_cents` contract by making the low-level cache-write argument keyword-only.
- Added regression coverage for persistence/upsert accumulation, both reporting APIs, managed usage limits, per-user usage, Braintrust, and Langfuse.

## How Has This Been Tested?

- `uv run pytest -q backend/tests/unit/onyx/llm backend/tests/unit/onyx/tracing backend/tests/unit/onyx/db backend/tests/unit/onyx/server/features/usage backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py` — 716 passed.
- `pre-commit run --files <all changed files>` — all applicable checks passed, including `ty`, Ruff, formatting, secret scanning, Oxlint, and Next.js TypeScript.
- Alembic upgrade and downgrade SQL compiled successfully; `2e04b438a346` is the single migration head.
- Regression-first verification confirmed the new persistence and API assertions failed before the implementation and passed afterward.

## Known limitation

- Live provider billing responses were not exercised against every supported LLM provider; provider cache-write extraction uses LiteLLM’s normalized `cache_creation_input_tokens` field.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
