### PR TITLE
feat(craft): report what work holds a sandbox

### DIFF
--- a/backend/onyx/db/scheduled_task.py
+++ b/backend/onyx/db/scheduled_task.py
@@ -355,6 +355,33 @@ def has_in_flight_run_for_task(
     return db_session.execute(stmt).first() is not None
 
 
+def get_unfinished_run_for_user(
+    *,
+    db_session: Session,
+    user_id: UUID,
+) -> ScheduledTaskRun | None:
+    """The user's oldest run that has not reached a terminal status, if any.
+
+    "Unfinished" deliberately includes ``AWAITING_APPROVAL`` alongside QUEUED
+    and RUNNING: a run parked on an approval gate still owns the user's sandbox
+    and will resume in it, so anything asking "is this sandbox committed to
+    work?" has to count it.
+    """
+    stmt = (
+        select(ScheduledTaskRun)
+        .join(ScheduledTask, ScheduledTaskRun.task_id == ScheduledTask.id)
+        .where(
+            ScheduledTask.user_id == user_id,
+            ScheduledTaskRun.status.notin_(
+                [s for s in ScheduledTaskRunStatus if s.is_terminal()]
+            ),
+        )
+        .order_by(ScheduledTaskRun.started_at)
+        .limit(1)
+    )
+    return db_session.execute(stmt).scalars().first()
+
+
 def insert_run(
     *,
     db_session: Session,

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -203,6 +203,26 @@ def get_empty_session_for_user(
     )
 
 
+def get_active_session_ids_for_user(
+    user_id: UUID,
+    db_session: Session,
+) -> list[UUID]:
+    """IDs of the user's ACTIVE sessions, whatever their origin.
+
+    ACTIVE is the only status a turn can be in flight under — sessions are
+    marked IDLE when their sandbox sleeps — so this bounds the set of sessions
+    worth asking the turn cache about.
+    """
+    return list(
+        db_session.scalars(
+            select(BuildSession.id).where(
+                BuildSession.user_id == user_id,
+                BuildSession.status == BuildSessionStatus.ACTIVE,
+            )
+        )
+    )
+
+
 def update_session_activity(
     session_id: UUID,
     db_session: Session,

--- a/backend/onyx/server/features/build/session/sandbox_busy.py
+++ b/backend/onyx/server/features/build/session/sandbox_busy.py
@@ -1,0 +1,122 @@
+"""Is a sandbox committed to work right now?
+
+A sandbox is shared by all of a user's sessions, so anything that disturbs one
+— recycling it onto a new image, reaping it, restarting a container under it —
+has to know whether work is queued or in flight. Heartbeat cannot answer that:
+an open tab beats identically whether the agent is mid-turn or the user is
+reading the last answer.
+
+The answer comes from two places, because work reaches a sandbox by two routes
+that share no state:
+
+- interactive chats, tracked in the turn cache (``interactive_turns.state``),
+  where a *queued* turn counts — a message submitted a moment ago is work the
+  sandbox owes even though nothing has started;
+- scheduled runs, tracked in Postgres, which never register an interactive turn
+  and are therefore invisible to the cache.
+
+Claims are returned rather than a bool. A drain that has been stuck for an hour
+is a support question, and "blocked by a scheduled run awaiting approval" answers
+it while ``False`` does not.
+
+Not covered here: a prompt already streaming to opencode. That is what
+``prompt_slot`` serialises, and a caller about to mutate a sandbox should acquire
+those slots rather than poll them — holding the same lock the chat path takes is
+both the check and the barrier, with no window in between. This module answers
+the cheaper question that comes first.
+"""
+
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.orm import Session as DBSession
+
+from onyx.cache.factory import get_cache_backend
+from onyx.cache.interface import CacheBackend
+from onyx.db.models import Sandbox
+from onyx.db.scheduled_task import get_unfinished_run_for_user
+from onyx.server.features.build.db.build_session import (
+    get_active_session_ids_for_user,
+)
+from onyx.server.features.build.interactive_turns.state import get_active_turn
+
+
+class SandboxBusyKind(str, Enum):
+    """What kind of work holds the sandbox."""
+
+    INTERACTIVE_TURN = "interactive_turn"
+    SCHEDULED_RUN = "scheduled_run"
+
+
+class SandboxBusyClaim(BaseModel):
+    """Work that makes a sandbox unsafe to disturb, and enough detail to say so
+    in a log line or a support answer."""
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: SandboxBusyKind
+    detail: str
+
+
+def sandbox_busy_claim(
+    db_session: DBSession,
+    sandbox: Sandbox,
+    *,
+    cache: CacheBackend | None = None,
+) -> SandboxBusyClaim | None:
+    """The first claim found on this sandbox, or None if it is free.
+
+    Cheapest probe first, and it stops at the first hit: callers only ever need
+    to know *that* the sandbox is busy plus one reason to report.
+    """
+    cache = cache or get_cache_backend()
+    for probe in (_interactive_turn_claim, _scheduled_run_claim):
+        claim = probe(db_session, sandbox, cache)
+        if claim is not None:
+            return claim
+    return None
+
+
+def _interactive_turn_claim(
+    db_session: DBSession,
+    sandbox: Sandbox,
+    cache: CacheBackend,
+) -> SandboxBusyClaim | None:
+    """A queued or running turn on any of the user's sessions.
+
+    Terminating a pod mid-turn drops the turn with no recovery, and killing one
+    with a message queued loses a request the user has already been told was
+    accepted.
+    """
+    for session_id in get_active_session_ids_for_user(sandbox.user_id, db_session):
+        turn = get_active_turn(
+            cache=cache,
+            session_id=session_id,
+            user_id=sandbox.user_id,
+        )
+        if turn is not None:
+            return SandboxBusyClaim(
+                kind=SandboxBusyKind.INTERACTIVE_TURN,
+                detail=f"session {session_id} turn {turn.turn_id} is {turn.status}",
+            )
+    return None
+
+
+def _scheduled_run_claim(
+    db_session: DBSession,
+    sandbox: Sandbox,
+    cache: CacheBackend,  # noqa: ARG001
+) -> SandboxBusyClaim | None:
+    """A scheduled run that has not finished.
+
+    The scheduled-task executor drives the sandbox without registering an
+    interactive turn, so nothing above sees it. A run in ``AWAITING_APPROVAL``
+    counts too — it is waiting on a person and will resume in this sandbox.
+    """
+    run = get_unfinished_run_for_user(db_session=db_session, user_id=sandbox.user_id)
+    if run is None:
+        return None
+    return SandboxBusyClaim(
+        kind=SandboxBusyKind.SCHEDULED_RUN,
+        detail=f"run {run.id} is {run.status.value}",
+    )

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_busy_claims.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_busy_claims.py
@@ -1,0 +1,120 @@
+"""Busy-ness claims against real Postgres.
+
+The interactive-turn probe is covered by unit tests (its state lives in the
+cache), but the scheduled-run probe is a join plus a "not terminal" filter — the
+kind of query mocks will happily agree with while it is wrong. This exercises it
+for real.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+from sqlalchemy.orm import Session
+
+import onyx.server.features.build.session.sandbox_busy as sandbox_busy
+from onyx.db.enums import (
+    ScheduledTaskRunStatus,
+    ScheduledTaskStatus,
+    ScheduledTaskTriggerSource,
+)
+from onyx.db.models import ScheduledTask, ScheduledTaskRun, User
+from onyx.server.features.build.session.sandbox_busy import (
+    SandboxBusyKind,
+    sandbox_busy_claim,
+)
+from tests.external_dependency_unit.craft.db_helpers import make_sandbox, make_user
+
+
+@pytest.fixture(autouse=True)
+def _no_interactive_turns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate the scheduled-run probe: with no ACTIVE sessions the turn probe
+    can't fire, so any claim here comes from Postgres."""
+    monkeypatch.setattr(
+        sandbox_busy, "get_active_session_ids_for_user", lambda *_a, **_kw: []
+    )
+
+
+def _seed_run(
+    db_session: Session, user: User, status: ScheduledTaskRunStatus
+) -> ScheduledTaskRun:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    task = ScheduledTask(
+        user_id=user.id,
+        name="nightly-report",
+        prompt="Summarise yesterday's events",
+        cron_expression="0 9 * * *",
+        editor_mode="advanced",
+        status=ScheduledTaskStatus.ACTIVE,
+        next_run_at=now + datetime.timedelta(days=1),
+    )
+    db_session.add(task)
+    db_session.flush()
+    run = ScheduledTaskRun(
+        task_id=task.id,
+        status=status,
+        trigger_source=ScheduledTaskTriggerSource.SCHEDULED,
+        started_at=now,
+    )
+    db_session.add(run)
+    db_session.commit()
+    db_session.refresh(run)
+    return run
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        ScheduledTaskRunStatus.QUEUED,
+        ScheduledTaskRunStatus.RUNNING,
+        ScheduledTaskRunStatus.AWAITING_APPROVAL,
+    ],
+)
+def test_unfinished_run_claims_the_sandbox(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+    status: ScheduledTaskRunStatus,
+) -> None:
+    user = make_user(db_session)
+    sandbox = make_sandbox(db_session, user)
+    run = _seed_run(db_session, user, status)
+
+    claim = sandbox_busy_claim(db_session, sandbox)
+
+    assert claim is not None
+    assert claim.kind is SandboxBusyKind.SCHEDULED_RUN
+    assert str(run.id) in claim.detail
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        ScheduledTaskRunStatus.SUCCEEDED,
+        ScheduledTaskRunStatus.FAILED,
+        ScheduledTaskRunStatus.SKIPPED,
+    ],
+)
+def test_finished_run_leaves_the_sandbox_free(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+    status: ScheduledTaskRunStatus,
+) -> None:
+    user = make_user(db_session)
+    sandbox = make_sandbox(db_session, user)
+    _seed_run(db_session, user, status)
+
+    assert sandbox_busy_claim(db_session, sandbox) is None
+
+
+def test_another_users_run_does_not_claim_this_sandbox(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    """Sandboxes are per user; the join is what keeps one tenant's busy
+    scheduled task from freezing everyone else's recycles."""
+    owner = make_user(db_session)
+    sandbox = make_sandbox(db_session, owner)
+    _seed_run(db_session, make_user(db_session), ScheduledTaskRunStatus.RUNNING)
+
+    assert sandbox_busy_claim(db_session, sandbox) is None

--- a/backend/tests/unit/onyx/server/features/craft/session/test_sandbox_busy.py
+++ b/backend/tests/unit/onyx/server/features/craft/session/test_sandbox_busy.py
@@ -1,0 +1,140 @@
+"""Whether a sandbox is committed to work, and why.
+
+The "why" is the point: a recycle or reap that has been blocked for an hour is a
+support question, so each probe has to name what is holding the sandbox rather
+than just declining.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+import onyx.server.features.build.session.sandbox_busy as sandbox_busy
+from onyx.db.enums import ScheduledTaskRunStatus
+from onyx.db.models import Sandbox
+from onyx.server.features.build.session.sandbox_busy import (
+    SandboxBusyKind,
+    sandbox_busy_claim,
+)
+
+USER_ID = uuid4()
+
+
+def _sandbox() -> Sandbox:
+    return Sandbox(id=UUID("12345678-1234-1234-1234-1234567890ab"), user_id=USER_ID)
+
+
+def _turn(status: str = "RUNNING") -> MagicMock:
+    turn = MagicMock()
+    turn.turn_id = uuid4()
+    turn.status = status
+    return turn
+
+
+@pytest.fixture
+def no_work(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neither route holds the sandbox. Individual tests re-patch one probe's
+    inputs to make it fire."""
+    monkeypatch.setattr(
+        sandbox_busy, "get_active_session_ids_for_user", lambda *_a, **_kw: []
+    )
+    monkeypatch.setattr(sandbox_busy, "get_unfinished_run_for_user", lambda **_kw: None)
+
+
+@pytest.mark.usefixtures("no_work")
+def test_free_sandbox_has_no_claim() -> None:
+    assert sandbox_busy_claim(MagicMock(), _sandbox(), cache=MagicMock()) is None
+
+
+@pytest.mark.usefixtures("no_work")
+@pytest.mark.parametrize("status", ["QUEUED", "RUNNING"])
+def test_interactive_turn_claims_the_sandbox(
+    monkeypatch: pytest.MonkeyPatch, status: str
+) -> None:
+    """A queued turn counts: the user has already been told the message was
+    accepted, so losing it is as bad as interrupting a running one."""
+    session_id = uuid4()
+    monkeypatch.setattr(
+        sandbox_busy, "get_active_session_ids_for_user", lambda *_a, **_kw: [session_id]
+    )
+    monkeypatch.setattr(
+        sandbox_busy, "get_active_turn", lambda **_kw: _turn(status=status)
+    )
+
+    claim = sandbox_busy_claim(MagicMock(), _sandbox(), cache=MagicMock())
+
+    assert claim is not None
+    assert claim.kind is SandboxBusyKind.INTERACTIVE_TURN
+    assert str(session_id) in claim.detail
+    assert status in claim.detail
+
+
+@pytest.mark.usefixtures("no_work")
+def test_every_session_of_the_user_is_checked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One sandbox serves all of a user's sessions, so a turn on any of them
+    protects it."""
+    sessions = [uuid4(), uuid4(), uuid4()]
+    busy_session = sessions[-1]
+    monkeypatch.setattr(
+        sandbox_busy, "get_active_session_ids_for_user", lambda *_a, **_kw: sessions
+    )
+
+    def fake_get_active_turn(*, session_id: UUID, **_kw: Any) -> MagicMock | None:
+        return _turn() if session_id == busy_session else None
+
+    monkeypatch.setattr(sandbox_busy, "get_active_turn", fake_get_active_turn)
+
+    claim = sandbox_busy_claim(MagicMock(), _sandbox(), cache=MagicMock())
+
+    assert claim is not None
+    assert str(busy_session) in claim.detail
+
+
+@pytest.mark.usefixtures("no_work")
+@pytest.mark.parametrize(
+    "status",
+    [
+        ScheduledTaskRunStatus.QUEUED,
+        ScheduledTaskRunStatus.RUNNING,
+        ScheduledTaskRunStatus.AWAITING_APPROVAL,
+    ],
+)
+def test_unfinished_scheduled_run_claims_the_sandbox(
+    monkeypatch: pytest.MonkeyPatch, status: ScheduledTaskRunStatus
+) -> None:
+    """The scheduled executor registers no interactive turn, so this is the only
+    probe that sees it. AWAITING_APPROVAL waits on a person and still owns the
+    sandbox."""
+    run = MagicMock()
+    run.id = uuid4()
+    run.status = status
+    monkeypatch.setattr(sandbox_busy, "get_unfinished_run_for_user", lambda **_kw: run)
+
+    claim = sandbox_busy_claim(MagicMock(), _sandbox(), cache=MagicMock())
+
+    assert claim is not None
+    assert claim.kind is SandboxBusyKind.SCHEDULED_RUN
+    assert status.value in claim.detail
+
+
+@pytest.mark.usefixtures("no_work")
+def test_interactive_turn_short_circuits_the_scheduled_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Callers need one reason, not all of them, and the DB query is the more
+    expensive of the two."""
+    monkeypatch.setattr(
+        sandbox_busy, "get_active_session_ids_for_user", lambda *_a, **_kw: [uuid4()]
+    )
+    monkeypatch.setattr(sandbox_busy, "get_active_turn", lambda **_kw: _turn())
+    scheduled_probe = MagicMock(return_value=None)
+    monkeypatch.setattr(sandbox_busy, "get_unfinished_run_for_user", scheduled_probe)
+
+    assert sandbox_busy_claim(MagicMock(), _sandbox(), cache=MagicMock()) is not None
+    scheduled_probe.assert_not_called()


### PR DESCRIPTION
## Description

Stacked on #13637. Adds the gate the image-recycle work is built on; no caller yet.

Anything that disturbs a live sandbox — recycling it onto a new image, reaping it, restarting a container under it — first has to know whether work is queued or in flight, and no existing check answers that. Work reaches a sandbox by two routes that share no state:

- **interactive chats** in the turn cache, where a *queued* turn counts as much as a running one (the user has already been told the message was accepted);
- **scheduled runs** in Postgres, which never register an interactive turn — so a turn-only check is blind to them and would happily kill a pod mid-run.

`sandbox_busy_claim` probes both, cheapest first, stopping at the first hit. A scheduled run counts while `AWAITING_APPROVAL`: it is waiting on a person and will resume in this sandbox.

It returns the claim rather than a bool because the interesting case is the one that lasts — a recycle blocked for an hour is a support question, and "blocked by run X awaiting approval" answers it where `False` does not.

A prompt already streaming to opencode is deliberately out of scope, with the reasoning recorded in the module docstring: that is what `prompt_slot` serialises, and a caller about to mutate a sandbox should *acquire* those slots rather than poll them, so the same lock is both check and barrier with no window in between.

## How Has This Been Tested?

Split deliberately by what each layer can actually catch:

- 8 unit tests for the cache-backed turn probe (queued and running, all of a user's sessions, short-circuiting).
- 7 external-dependency tests against real Postgres for the scheduled-run probe. That query is a join plus a "not terminal" filter — exactly the kind mocks agree with while it is wrong — including the cross-user case where a missing join would let one user's stuck task freeze everyone else's recycles.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `sandbox_busy_claim` to report if a sandbox is busy and why, so recycle/reap operations don’t interrupt work. It checks the turn cache and scheduled runs and returns a structured claim.

- **New Features**
  - `sandbox_busy_claim` probes interactive turns first, then Postgres scheduled runs, and short-circuits on first hit.
  - Counts `QUEUED`, `RUNNING`, and `AWAITING_APPROVAL` as holding work; checks all ACTIVE sessions for the user.
  - Added `get_unfinished_run_for_user` and `get_active_session_ids_for_user` helpers to back the probes.

<sup>Written for commit 5d3a3aa75a78c9fb26e5251b2a7167e7927848c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

