### PR TITLE
feat(craft): add the sandbox recycle queue

### DIFF
--- a/backend/alembic/versions/28a2007a355a_add_sandbox_recycle_queue_column.py
+++ b/backend/alembic/versions/28a2007a355a_add_sandbox_recycle_queue_column.py
@@ -1,0 +1,41 @@
+"""add sandbox recycle queue column
+
+Revision ID: 28a2007a355a
+Revises: b3f1c9a27d84
+Create Date: 2026-07-30 15:13:36.568577
+
+Queue of live sandboxes waiting to be recycled onto a newer sandbox image.
+Nullable with no backfill: existing sandboxes are not retroactively queued, so
+the first enqueue after a new image lands is what starts a drain.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "28a2007a355a"
+down_revision = "b3f1c9a27d84"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sandbox",
+        sa.Column("recycle_requested_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    # Scan predicate for the drain: queued sandboxes, oldest request first. The
+    # partial index keeps it off every sandbox that is not waiting for anything,
+    # which is nearly all of them nearly all of the time.
+    op.create_index(
+        "ix_sandbox_recycle_requested",
+        "sandbox",
+        ["recycle_requested_at"],
+        unique=False,
+        postgresql_where=sa.text("recycle_requested_at IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_sandbox_recycle_requested", table_name="sandbox")
+    op.drop_column("sandbox", "recycle_requested_at")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -6066,6 +6066,13 @@ class Sandbox(Base):
     skills_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
     mcp_config_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
+    # Set when a newer sandbox image lands, cleared once this sandbox runs it.
+    # The drain is gated on the sandbox being free of chat work, so a queued
+    # sandbox keeps serving its old image until that is true.
+    recycle_requested_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     encrypted_pat: Mapped[SensitiveValue[str] | None] = mapped_column(
         EncryptedString(), nullable=True
     )

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -3,7 +3,7 @@
 import datetime
 from uuid import UUID
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.orm import Session
 
 from onyx.auth.pat import hash_pat
@@ -185,6 +185,84 @@ def get_running_sandboxes(db_session: Session) -> list[Sandbox]:
     """Get all RUNNING sandboxes (the sweep task's working set)."""
     stmt = select(Sandbox).where(Sandbox.status == SandboxStatus.RUNNING)
     return list(db_session.execute(stmt).scalars().all())
+
+
+def request_recycle_for_running_sandboxes__no_commit(
+    db_session: Session,
+    requested_at: datetime.datetime,
+) -> int:
+    """Queue every RUNNING sandbox for recycling, returning how many were newly
+    queued. Caller commits.
+
+    Called when a newer sandbox image becomes available. Queueing the whole
+    RUNNING set is correct by construction — every one of those was created
+    before the new image landed — which is what lets the enqueue be a single
+    statement rather than a per-sandbox interrogation of the backend.
+
+    Already-queued sandboxes keep their original timestamp so a second image
+    landing mid-drain cannot push them to the back of the queue.
+    """
+    result = db_session.execute(
+        update(Sandbox)
+        .where(
+            Sandbox.status == SandboxStatus.RUNNING,
+            Sandbox.recycle_requested_at.is_(None),
+        )
+        .values(recycle_requested_at=requested_at)
+    )
+    db_session.flush()
+    return result.rowcount or 0  # ty: ignore[unresolved-attribute]
+
+
+def get_sandboxes_awaiting_recycle(
+    db_session: Session,
+    limit: int | None = None,
+) -> list[Sandbox]:
+    """Queued RUNNING sandboxes, longest-waiting first.
+
+    ``limit`` bounds how many a single drain pass takes on, so a fleet-wide
+    rollout doesn't become one enormous unit of work.
+    """
+    stmt = (
+        select(Sandbox)
+        .where(
+            Sandbox.status == SandboxStatus.RUNNING,
+            Sandbox.recycle_requested_at.isnot(None),
+        )
+        .order_by(Sandbox.recycle_requested_at)
+    )
+    if limit is not None:
+        stmt = stmt.limit(limit)
+    return list(db_session.execute(stmt).scalars().all())
+
+
+def count_sandboxes_awaiting_recycle(db_session: Session) -> int:
+    """Queue depth. A drain that stalls behind long-lived chat work is
+    invisible without it."""
+    stmt = select(func.count()).where(
+        Sandbox.status == SandboxStatus.RUNNING,
+        Sandbox.recycle_requested_at.isnot(None),
+    )
+    return db_session.execute(stmt).scalar_one()
+
+
+def clear_recycle_request__no_commit(
+    db_session: Session,
+    sandbox_id: UUID,
+) -> None:
+    """Drop a sandbox from the queue. Caller commits.
+
+    Idempotent, and deliberately not conditional on the sandbox having reached
+    the new image: a sandbox that left RUNNING (slept, terminated, failed) will
+    be re-provisioned onto whatever is current, so it no longer needs recycling
+    either.
+    """
+    db_session.execute(
+        update(Sandbox)
+        .where(Sandbox.id == sandbox_id)
+        .values(recycle_requested_at=None)
+    )
+    db_session.flush()
 
 
 def user_has_stale_active_session(

--- a/backend/tests/external_dependency_unit/craft/test_recycle_queue.py
+++ b/backend/tests/external_dependency_unit/craft/test_recycle_queue.py
@@ -1,0 +1,156 @@
+"""The queue of sandboxes waiting to be recycled onto a newer image.
+
+Enqueue is one statement over the RUNNING set, which is only correct because of
+a timing argument (every RUNNING sandbox predates the image that just landed).
+These tests pin the parts that argument depends on: who gets queued, who is left
+alone, and that a second image landing mid-drain doesn't reorder the queue.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+from sqlalchemy import update
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import SandboxStatus
+from onyx.db.models import Sandbox, User
+from onyx.server.features.build.db.sandbox import (
+    clear_recycle_request__no_commit,
+    count_sandboxes_awaiting_recycle,
+    get_sandboxes_awaiting_recycle,
+    request_recycle_for_running_sandboxes__no_commit,
+)
+from tests.external_dependency_unit.craft.db_helpers import make_sandbox, make_user
+
+NOW = datetime.datetime(2026, 7, 30, 12, 0, 0, tzinfo=datetime.timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def _quiesce_leaked_sandboxes(db_session: Session) -> None:
+    """Park RUNNING sandboxes leaked by earlier tests.
+
+    Enqueue and queue depth are tenant-wide by design, so rows committed by
+    other tests in this directory would otherwise leak into the assertions.
+    """
+    db_session.execute(
+        update(Sandbox)
+        .where(Sandbox.status == SandboxStatus.RUNNING)
+        .values(status=SandboxStatus.TERMINATED, recycle_requested_at=None)
+    )
+    db_session.commit()
+
+
+def test_running_sandboxes_are_queued(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    sandbox = make_sandbox(db_session, make_user(db_session))
+
+    queued = request_recycle_for_running_sandboxes__no_commit(db_session, NOW)
+    db_session.commit()
+
+    assert queued >= 1
+    db_session.refresh(sandbox)
+    assert sandbox.recycle_requested_at == NOW
+    assert sandbox.id in {s.id for s in get_sandboxes_awaiting_recycle(db_session)}
+
+
+def test_sleeping_sandbox_is_not_queued(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    """A sandbox that is not running will be re-provisioned onto whatever image
+    is current when it wakes, so it needs no recycle."""
+    sandbox = make_sandbox(db_session, make_user(db_session))
+    sandbox.status = SandboxStatus.SLEEPING
+    db_session.commit()
+
+    request_recycle_for_running_sandboxes__no_commit(db_session, NOW)
+    db_session.commit()
+
+    db_session.refresh(sandbox)
+    assert sandbox.recycle_requested_at is None
+    assert sandbox.id not in {s.id for s in get_sandboxes_awaiting_recycle(db_session)}
+
+
+def test_second_image_does_not_reorder_the_queue(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    """Two deploys in quick succession must not starve whoever was waiting
+    first — the drain is longest-waiting-first."""
+    sandbox = make_sandbox(db_session, make_user(db_session))
+
+    request_recycle_for_running_sandboxes__no_commit(db_session, NOW)
+    db_session.commit()
+    later = request_recycle_for_running_sandboxes__no_commit(
+        db_session, NOW + datetime.timedelta(minutes=5)
+    )
+    db_session.commit()
+
+    db_session.refresh(sandbox)
+    assert later == 0
+    assert sandbox.recycle_requested_at == NOW
+
+
+def test_queue_is_ordered_longest_waiting_first(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    first = make_sandbox(db_session, make_user(db_session))
+    first.recycle_requested_at = NOW
+    second = make_sandbox(db_session, make_user(db_session))
+    second.recycle_requested_at = NOW + datetime.timedelta(minutes=1)
+    db_session.commit()
+
+    queued_ids = [s.id for s in get_sandboxes_awaiting_recycle(db_session)]
+
+    assert queued_ids.index(first.id) < queued_ids.index(second.id)
+
+
+def test_limit_bounds_a_drain_pass(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    """A fleet-wide rollout must be drainable in bounded chunks."""
+    for offset in range(3):
+        sandbox = make_sandbox(db_session, make_user(db_session))
+        sandbox.recycle_requested_at = NOW + datetime.timedelta(minutes=offset)
+    db_session.commit()
+
+    assert len(get_sandboxes_awaiting_recycle(db_session, limit=2)) == 2
+
+
+def test_clearing_removes_a_sandbox_from_the_queue(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    sandbox = make_sandbox(db_session, make_user(db_session))
+    request_recycle_for_running_sandboxes__no_commit(db_session, NOW)
+    db_session.commit()
+    before = count_sandboxes_awaiting_recycle(db_session)
+
+    clear_recycle_request__no_commit(db_session, sandbox.id)
+    db_session.commit()
+
+    db_session.refresh(sandbox)
+    assert sandbox.recycle_requested_at is None
+    assert count_sandboxes_awaiting_recycle(db_session) == before - 1
+
+
+def test_clearing_is_idempotent(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    """Every trigger path calls the same drain, so a double-clear has to be a
+    no-op rather than an error."""
+    sandbox = make_sandbox(db_session, make_user(db_session))
+
+    clear_recycle_request__no_commit(db_session, sandbox.id)
+    clear_recycle_request__no_commit(db_session, sandbox.id)
+    db_session.commit()
+
+    db_session.refresh(sandbox)
+    assert sandbox.recycle_requested_at is None


### PR DESCRIPTION
## Description

Stacked on #13638. Adds the queue; no writer yet — the enqueue and drain land on top.

When a newer sandbox image lands, live sandboxes on the old one have to wait for their users to be between chats before they can be recycled. That wait needs to be durable and inspectable: a drain stalled behind a long-running agent turn is otherwise indistinguishable from a drain that never started, and "how many sandboxes are still on the old image, and since when" is *the* question during a rollout.

A timestamp column on the sandbox row rather than a Redis list: it survives a cache flush, it orders the queue, and it makes queue depth a SQL query rather than a metric someone has to remember to emit. A partial index gives the drain its scan predicate, following the same shape as the index-reclaim migration.

Enqueue is one `UPDATE` over the RUNNING set. That is correct by construction rather than by interrogation — every RUNNING sandbox was created before the image that just landed — so a fleet-wide rollout costs one statement instead of a backend round trip per sandbox. Sandboxes already queued keep their original timestamp, so a second image landing mid-drain cannot push the longest waiter to the back.

Clearing is unconditional and idempotent: every trigger path runs the same drain, and a sandbox that has left RUNNING will be re-provisioned onto whatever is current anyway.

## How Has This Been Tested?

Migration applied against local Postgres, downgraded, and re-applied — column and partial index verified in `\d sandbox` both times.

7 external-dependency tests cover the behaviours the "correct by construction" argument rests on: RUNNING sandboxes get queued, non-RUNNING ones don't, a second enqueue doesn't reorder the queue, the drain is ordered longest-waiting-first, `limit` bounds a pass, and clearing is idempotent.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a durable recycle queue for live sandboxes using a `recycle_requested_at` timestamp and a partial index. This enables ordered, inspectable drains during new image rollouts.

- **New Features**
  - Alembic migration adds `recycle_requested_at` to `sandbox` and index `ix_sandbox_recycle_requested` (oldest first, queued-only).
  - Single-statement enqueue for all RUNNING sandboxes via `request_recycle_for_running_sandboxes__no_commit`, preserving existing timestamps across redeploys.
  - Drain helpers: `get_sandboxes_awaiting_recycle(limit)` (oldest-first, optional limit) and `count_sandboxes_awaiting_recycle` for queue depth.
  - Idempotent `clear_recycle_request__no_commit` to drop a sandbox from the queue; tests cover enqueue, ordering, limits, and clearing.

<sup>Written for commit b9eead7ff14440f456c3ca00683d960ea7a9ded1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

