### PR TITLE
feat(craft): read the fleet's running sandbox images in one call

### DIFF
--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -40,6 +40,7 @@ from onyx.server.features.build.sandbox.models import (
     PushFailure,
     PushResult,
     RetriableWriteError,
+    SandboxImageIdentity,
     SandboxInfo,
     SandboxRuntimeState,
     SnapshotResult,
@@ -372,6 +373,22 @@ class SandboxManager(_ServeMixin, ABC):
         return SandboxRuntimeState(
             healthy=self.health_check(sandbox_id, timeout=timeout)
         )
+
+    def list_live_sandbox_images(self) -> dict[UUID, SandboxImageIdentity]:
+        """Image identity of every live sandbox on this backend, keyed by
+        sandbox id.
+
+        Answers "which sandboxes are running something other than what a new
+        one would get" in a single backend call for the whole fleet, rather than
+        one call per sandbox. Both backends already label their sandboxes with
+        the sandbox id, so the mapping needs no help from the caller — and the
+        answer is derived from what is actually running, so it needs no
+        bookkeeping to stay true.
+
+        Empty when the backend cannot report identity, which reads as "nothing
+        known to be stale" — never as "everything is current".
+        """
+        return {}
 
     def send_message(
         self,

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -1052,6 +1052,26 @@ class DockerSandboxManager(SandboxManager):
         precisely what we want to notice.
         """
         attrs = container.attrs or {}
+        # Inspect shape: the ref lives under Config, the resolved ID at the top.
+        return self._identity_for(
+            running_ref=(attrs.get("Config") or {}).get("Image"),
+            running_digest=attrs.get("Image"),
+        )
+
+    def _identity_for(
+        self,
+        *,
+        running_ref: str | None,
+        running_digest: str | None,
+    ) -> SandboxImageIdentity:
+        """Pair a container's image with the one a fresh container would use.
+
+        Takes the running side as values rather than a container because Docker
+        reports it under different keys depending on how it was fetched:
+        ``inspect`` nests the ref under ``Config`` while ``list`` returns
+        ``Image``/``ImageID`` at the top level. Resolving the desired side
+        stays here so it cannot drift between the two.
+        """
         desired_digest: str | None = None
         try:
             desired_digest = self._docker.images.get(self._image).id
@@ -1065,11 +1085,50 @@ class DockerSandboxManager(SandboxManager):
             )
 
         return SandboxImageIdentity(
-            running_ref=(attrs.get("Config") or {}).get("Image"),
-            running_digest=attrs.get("Image"),
+            running_ref=running_ref,
+            running_digest=running_digest,
             desired_ref=self._image,
             desired_digest=desired_digest,
         )
+
+    def list_live_sandbox_images(self) -> dict[UUID, SandboxImageIdentity]:
+        """One daemon call for the whole fleet, keyed by the sandbox-id label.
+
+        Includes stopped containers deliberately: ``_reuse_existing_container``
+        restarts an exited container rather than recreating it, so one built
+        from a superseded image would come back on that image. It is a recycle
+        candidate exactly like a running one.
+        """
+        try:
+            containers = self._docker.containers.list(
+                all=True,
+                filters={"label": f"{LABEL_COMPONENT}={LABEL_COMPONENT_VALUE}"},
+            )
+        except APIError as e:
+            logger.warning("Could not list sandbox containers: %s", e)
+            return {}
+
+        identities: dict[UUID, SandboxImageIdentity] = {}
+        for container in containers:
+            attrs = container.attrs or {}
+            raw_id = ((attrs.get("Labels") or {}) or {}).get(LABEL_SANDBOX_ID)
+            if raw_id is None:
+                continue
+            try:
+                sandbox_id = UUID(raw_id)
+            except ValueError:
+                logger.warning(
+                    "Sandbox container %s carries an unparseable id label %r",
+                    container.name,
+                    raw_id,
+                )
+                continue
+            # List shape: ref and resolved ID both sit at the top level.
+            identities[sandbox_id] = self._identity_for(
+                running_ref=attrs.get("Image"),
+                running_digest=attrs.get("ImageID"),
+            )
+        return identities
 
     def _render_agents_md(
         self,

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -676,6 +676,42 @@ class KubernetesSandboxManager(SandboxManager):
             desired_digest=desired_digest if pinned else None,
         )
 
+    def list_live_sandbox_images(self) -> dict[UUID, SandboxImageIdentity]:
+        """One API call for the whole fleet, keyed by the sandbox-id label.
+
+        The desired ref comes from the same short-TTL cache the per-pod path
+        uses, so a sweep over every sandbox costs one list and no extra reads.
+        """
+        try:
+            pods = self._core_api.list_namespaced_pod(
+                namespace=self._namespace,
+                label_selector=f"{LABEL_K8S_COMPONENT}={LABEL_K8S_COMPONENT_SANDBOX}",
+            )
+        except ApiException as e:
+            logger.warning("Could not list sandbox pods: %s", e)
+            return {}
+
+        identities: dict[UUID, SandboxImageIdentity] = {}
+        for pod in pods.items:
+            raw_id = ((pod.metadata.labels if pod.metadata else None) or {}).get(
+                LABEL_SANDBOX_ID
+            )
+            if raw_id is None:
+                continue
+            try:
+                sandbox_id = UUID(raw_id)
+            except ValueError:
+                logger.warning(
+                    "Sandbox pod %s carries an unparseable id label %r",
+                    pod.metadata.name if pod.metadata else "<unknown>",
+                    raw_id,
+                )
+                continue
+            identity = self._image_identity(pod)
+            if identity is not None:
+                identities[sandbox_id] = identity
+        return identities
+
     def _create_sandbox_service(
         self,
         sandbox_id: UUID,

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_image_identity.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_image_identity.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock
 from uuid import UUID
 
 import pytest
-from docker.errors import NotFound
+from docker.errors import APIError, NotFound
 from kubernetes import client
 from kubernetes.client.rest import ApiException
 
@@ -333,3 +333,146 @@ def test_docker_runtime_state_tracks_container_presence(
 
     assert state.healthy is not missing_container
     assert (state.image is None) is missing_container
+
+
+# --- fleet scan -------------------------------------------------------------
+#
+# "Which sandboxes are on a superseded image" is derived from what is actually
+# running rather than recorded when a new image lands, so it needs no
+# bookkeeping to stay true. That only pays off if the whole fleet costs one
+# backend call, which is what these pin.
+
+
+def _labelled_pod(sandbox_id: str, spec_image: str) -> SimpleNamespace:
+    pod = _pod(spec_image, None)
+    pod.metadata = SimpleNamespace(  # type: ignore[attr-defined]
+        name=f"sandbox-{sandbox_id[:8]}",
+        labels={"onyx.app/sandbox-id": sandbox_id},
+    )
+    return cast(SimpleNamespace, pod)
+
+
+def test_k8s_fleet_scan_costs_one_list_call() -> None:
+    ids = [str(UUID(int=i)) for i in range(3)]
+    core_api = MagicMock()
+    core_api.read_namespaced_pod_template.return_value = _podtemplate(NEW_TAG_REF)
+    mgr = _k8s_manager(core_api)
+    core_api.list_namespaced_pod.return_value = SimpleNamespace(
+        items=[_labelled_pod(i, TAG_REF) for i in ids]
+    )
+
+    identities = mgr.list_live_sandbox_images()
+
+    assert set(identities) == {UUID(i) for i in ids}
+    assert all(identity.is_stale for identity in identities.values())
+    # One list for the pods, one PodTemplate read shared across all of them.
+    assert core_api.list_namespaced_pod.call_count == 1
+    assert core_api.read_namespaced_pod_template.call_count == 1
+
+
+def test_k8s_fleet_scan_separates_current_from_superseded() -> None:
+    current, stale = str(UUID(int=1)), str(UUID(int=2))
+    core_api = MagicMock()
+    core_api.read_namespaced_pod_template.return_value = _podtemplate(NEW_TAG_REF)
+    mgr = _k8s_manager(core_api)
+    core_api.list_namespaced_pod.return_value = SimpleNamespace(
+        items=[
+            _labelled_pod(current, NEW_TAG_REF),
+            _labelled_pod(stale, TAG_REF),
+        ]
+    )
+
+    identities = mgr.list_live_sandbox_images()
+
+    assert identities[UUID(current)].is_stale is False
+    assert identities[UUID(stale)].is_stale is True
+
+
+def test_k8s_fleet_scan_skips_pods_without_a_usable_id() -> None:
+    """A pod that cannot be tied back to a sandbox row is not actionable, and a
+    malformed label must not take the whole scan down with it."""
+    good = str(UUID(int=7))
+    core_api = MagicMock()
+    core_api.read_namespaced_pod_template.return_value = _podtemplate(TAG_REF)
+    mgr = _k8s_manager(core_api)
+    unlabelled = _pod(TAG_REF, None)
+    unlabelled.metadata = SimpleNamespace(name="orphan", labels={})  # type: ignore[attr-defined]
+    core_api.list_namespaced_pod.return_value = SimpleNamespace(
+        items=[
+            unlabelled,
+            _labelled_pod("not-a-uuid", TAG_REF),
+            _labelled_pod(good, TAG_REF),
+        ]
+    )
+
+    assert set(mgr.list_live_sandbox_images()) == {UUID(good)}
+
+
+def test_k8s_fleet_scan_reports_nothing_when_the_desired_image_is_unknown() -> None:
+    """An unreadable PodTemplate must not make the fleet look stale."""
+    core_api = MagicMock()
+    core_api.read_namespaced_pod_template.side_effect = ApiException(status=403)
+    mgr = _k8s_manager(core_api)
+    core_api.list_namespaced_pod.return_value = SimpleNamespace(
+        items=[_labelled_pod(str(UUID(int=1)), TAG_REF)]
+    )
+
+    assert mgr.list_live_sandbox_images() == {}
+
+
+def test_k8s_fleet_scan_survives_an_unlistable_namespace() -> None:
+    core_api = MagicMock()
+    core_api.read_namespaced_pod_template.return_value = _podtemplate(TAG_REF)
+    mgr = _k8s_manager(core_api)
+    core_api.list_namespaced_pod.side_effect = ApiException(status=403)
+
+    assert mgr.list_live_sandbox_images() == {}
+
+
+def _listed_container(sandbox_id: str, image: str, image_id: str) -> MagicMock:
+    container = MagicMock()
+    container.name = f"sandbox-{sandbox_id[:8]}"
+    # List shape, not inspect shape: ref and resolved ID at the top level.
+    container.attrs = {
+        "Image": image,
+        "ImageID": image_id,
+        "Labels": {"onyx.app/sandbox-id": sandbox_id},
+    }
+    return container
+
+
+def test_docker_fleet_scan_uses_the_list_shape() -> None:
+    """`list` reports Image/ImageID at the top level while `inspect` nests the
+    ref under Config; reading the wrong pair yields a bogus comparison."""
+    sandbox_id = str(UUID(int=3))
+    mgr, docker = _docker_manager("onyxdotapp/sandbox:latest")
+    docker.images.get.return_value = SimpleNamespace(id=DIGEST_B)
+    docker.containers.list.return_value = [
+        _listed_container(sandbox_id, "onyxdotapp/sandbox:latest", DIGEST_A)
+    ]
+
+    identities = mgr.list_live_sandbox_images()
+
+    assert set(identities) == {UUID(sandbox_id)}
+    identity = identities[UUID(sandbox_id)]
+    assert identity.running_digest == DIGEST_A
+    assert identity.is_stale is True
+
+
+def test_docker_fleet_scan_includes_stopped_containers() -> None:
+    """A stopped container is restarted rather than recreated, so one built from
+    a superseded image would come back on it."""
+    mgr, docker = _docker_manager("onyxdotapp/sandbox:latest")
+    docker.images.get.return_value = SimpleNamespace(id=DIGEST_B)
+    docker.containers.list.return_value = []
+
+    mgr.list_live_sandbox_images()
+
+    assert docker.containers.list.call_args.kwargs["all"] is True
+
+
+def test_docker_fleet_scan_survives_a_daemon_error() -> None:
+    mgr, docker = _docker_manager("onyxdotapp/sandbox:latest")
+    docker.containers.list.side_effect = APIError("daemon is unwell")
+
+    assert mgr.list_live_sandbox_images() == {}


### PR DESCRIPTION
## Description

Stacked on #13638. Replaces #13639, which stored the same information in a new DB column — see that PR for why the column went away.

Which sandboxes are running a superseded image is a *fact about what is live*, not a decision worth recording. Comparing the running image against the one a new sandbox would get answers it from reality, so nothing has to be stamped, cleared, or kept in sync. That removes a class of drift (an entry for a sandbox already recycled; a missing entry for one that wasn't), makes the answer self-healing across restarts, and drops a migration.

The reason deriving is affordable: both backends already label sandboxes with their id and both return the running image in their *list* response, so the whole fleet costs one call.

- **K8s** lists pods by component label and reuses the short-TTL PodTemplate cache for the desired side — one list plus one cached read, no matter how many sandboxes.
- **Docker** lists containers by label and resolves the local image once.

Two things worth a reviewer's eye:

- Docker reports the running image under different keys depending on how it was fetched — `inspect` nests the ref under `Config`, `list` returns `Image`/`ImageID` at the top level. The desired-side resolution moved into one helper both call sites share rather than being written twice against different shapes, since reading the wrong pair yields a plausible-looking but bogus comparison.
- Stopped containers are included deliberately: `_reuse_existing_container` restarts an exited container rather than recreating it, so one built from a superseded image would come back on that image.

An empty result means "nothing known to be stale", never "everything is current" — an unreadable PodTemplate, an unlistable namespace, and a backend that can't report identity all decline rather than implying the fleet is up to date.

No caller yet; the drain lands on top.

## How Has This Been Tested?

9 new unit tests alongside the existing image-identity ones: the K8s scan costs exactly one list plus one shared PodTemplate read, current and superseded sandboxes are separated correctly, pods with a missing or malformed id label are skipped without taking the scan down, and both backends degrade to an empty result on API errors. The Docker pair pins the list-vs-inspect key shapes and the stopped-container decision.

Full craft unit suite (700 tests) passes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scan the entire sandbox fleet in a single backend call to detect sandboxes running a superseded image by comparing the running image to the desired image. Returns a map keyed by sandbox ID; an empty map means “nothing known to be stale” when identity can’t be read.

- **New Features**
  - Added fleet scan that returns image identity per sandbox for both Kubernetes and Docker backends.
  - Kubernetes: one `list` of pods by component label; desired image read once via the short‑TTL PodTemplate cache.
  - Docker: one `containers.list(all=True)` by label; desired image resolved once.
  - Includes stopped Docker containers so restarted sandboxes built from old images are flagged.
  - Skips items with missing/invalid sandbox-id labels; on API errors, returns an empty result instead of implying everything is current.

- **Refactors**
  - Consolidated Docker image identity resolution into a helper to handle `list` vs `inspect` key shapes (`Image`/`ImageID` vs `Config.Image`) and avoid bogus comparisons.

<sup>Written for commit 5424e7a27050321b06528a84e1f7f3fdbeb811ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

