### PR TITLE
feat(craft): move a Kubernetes sandbox by swapping its image in place

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -112,6 +112,7 @@ from onyx.server.features.build.sandbox.models import (
     FatalWriteError,
     FileSet,
     FilesystemEntry,
+    ImageMoveOutcome,
     RetriableWriteError,
     SandboxImageState,
     SandboxImageTarget,
@@ -178,6 +179,10 @@ _PREPULLER_CONTAINER_NAME = "prepuller"
 # Short-lived: the point is to notice a new image, but it is read every pass.
 _IMAGE_TARGET_TTL_SECONDS = 60.0
 
+# Covers a container restart plus opencode-serve and the sidecar coming back
+# against an image the node already holds — not a download.
+_IMAGE_SWAP_TIMEOUT_SECONDS = 60.0
+_IMAGE_SWAP_POLL_SECONDS = 2.0
 
 # Per-session egress tagging plugin, baked into the sandbox image (see
 # docker/Dockerfile). Path must match the COPY destination there.
@@ -685,6 +690,134 @@ class KubernetesSandboxManager(SandboxManager):
             target=SandboxImageTarget(ref=_pinned_ref(ref, digest), digest=digest),
             confirmed_nodes=frozenset(reported),
         )
+
+    def move_to_image(
+        self, sandbox_id: UUID, target: SandboxImageTarget
+    ) -> ImageMoveOutcome:
+        """Patch the image and let the kubelet restart just that container.
+
+        The pod survives, so the ``workspace`` and ``opencode-data`` emptyDirs do
+        too: no snapshot, no restore, no re-provision, and the sandbox never
+        leaves RUNNING. Verified on a real cluster, since the pod is
+        ``restartPolicy: Never`` and a replacement container was not a given.
+
+        Agent and sidecar go in one patch — a half-swapped pod would pair a new
+        agent with an old daemon. Never ``NEEDS_PROVISION``: the workspaces are
+        emptyDirs that die with the pod, so they cannot outlive it.
+        """
+        pod_name = self._get_pod_name(str(sandbox_id))
+        try:
+            self._core_api.patch_namespaced_pod(
+                name=pod_name,
+                namespace=self._namespace,
+                body={
+                    "spec": {
+                        "containers": [
+                            {"name": _SANDBOX_CONTAINER_NAME, "image": target.ref}
+                        ],
+                        # sandbox-init keeps its ref; it has already run.
+                        "initContainers": [
+                            {"name": _SIDECAR_CONTAINER_NAME, "image": target.ref}
+                        ],
+                    }
+                },
+            )
+        except ApiException as e:
+            logger.warning(
+                "Sandbox %s image swap to %s was refused: %s",
+                sandbox_id,
+                target.ref,
+                e,
+            )
+            return ImageMoveOutcome.UNSUPPORTED
+
+        logger.info("Swapping sandbox %s onto %s", sandbox_id, target.ref)
+        deadline = time.monotonic() + _IMAGE_SWAP_TIMEOUT_SECONDS
+        if self._wait_for_swap(sandbox_id, pod_name, target, deadline):
+            return ImageMoveOutcome.MOVED
+        return ImageMoveOutcome.UNSUPPORTED
+
+    def _wait_for_swap(
+        self,
+        sandbox_id: UUID,
+        pod_name: str,
+        target: SandboxImageTarget,
+        deadline: float,
+    ) -> bool:
+        """Three waits sharing one budget, each only meaningful once the previous
+        holds: the container reports the target image, the pod goes Ready, and the
+        sidecar answers.
+        """
+        if not self._wait_for_reported_image(pod_name, deadline, target.digest):
+            logger.warning(
+                "Sandbox %s did not come up on %s within %.0fs",
+                sandbox_id,
+                target.digest[:19],
+                _IMAGE_SWAP_TIMEOUT_SECONDS,
+            )
+            return False
+
+        try:
+            if not self._wait_for_pod_ready(pod_name, deadline):
+                return False
+        except RuntimeError as e:
+            # Deleted, or the new container cannot start.
+            logger.warning(
+                "Sandbox %s did not come back after the swap: %s", sandbox_id, e
+            )
+            return False
+
+        return self._wait_for_sidecar(sandbox_id, deadline)
+
+    def _wait_for_reported_image(
+        self, pod_name: str, deadline: float, digest: str
+    ) -> bool:
+        """Poll until the agent container reports it is running ``digest``.
+
+        Compared against the target, not against what it ran before: a status
+        that has not reported yet would let the *old* digest count as a change,
+        and a sandbox already on the target would wait for a change that never
+        comes.
+
+        Polled rather than watched: this is not a pod condition, so it cannot ride
+        ``_wait_for_pod_ready``'s predicate, and the wait is short — the kubelet
+        only has to stop one container and start another from a local image.
+        """
+        while True:
+            try:
+                pod = self._core_api.read_namespaced_pod(
+                    name=pod_name, namespace=self._namespace
+                )
+            except ApiException as e:
+                logger.warning("Lost sight of pod %s mid-swap: %s", pod_name, e)
+                return False
+
+            status = _container_status(pod, _SANDBOX_CONTAINER_NAME)
+            if sandbox_image_digest(status.image_id if status else None) == digest:
+                return True
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(_IMAGE_SWAP_POLL_SECONDS)
+
+    def _wait_for_sidecar(self, sandbox_id: UUID, deadline: float) -> bool:
+        """Poll the sidecar for the rest of the budget.
+
+        It restarts on its own schedule and has no readiness probe, so the pod can
+        report Ready before the push daemon has bound its port. One probe would
+        send a completed swap down the rebuild path, which snapshots and
+        terminates a sandbox that was already fine.
+        """
+        while True:
+            if self._sidecar_client.is_healthy(
+                sandbox_id=sandbox_id, timeout_seconds=_IMAGE_SWAP_POLL_SECONDS
+            ):
+                return True
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    "Sandbox %s sidecar did not answer after the swap", sandbox_id
+                )
+                return False
+            time.sleep(_IMAGE_SWAP_POLL_SECONDS)
 
     def _movable_sandbox_digests(
         self, confirmed_nodes: frozenset[str]

--- a/backend/tests/external_dependency_unit/craft_helm/test_pod_spec.py
+++ b/backend/tests/external_dependency_unit/craft_helm/test_pod_spec.py
@@ -120,6 +120,18 @@ def _helm_template_cmd(extra_args: list[str] | None = None) -> list[str]:
     ]
 
 
+def _render_template(template: str, extra_args: list[str] | None = None) -> str:
+    """Render one chart template, for assertions that aren't about the pod."""
+    result = subprocess.run(
+        [*_helm_template_cmd(extra_args), "--show-only", template],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        _skip_or_fail(f"helm template failed (chart deps?): {result.stderr.strip()}")
+    return result.stdout
+
+
 def _render_pod_template_yaml(extra_args: list[str] | None = None) -> str:
     """Render the sandbox-pod PodTemplate from the chart."""
     cmd = [
@@ -655,3 +667,28 @@ def test_service_exposes_push_daemon_port() -> None:
         tenant_id="t-1",
     )
     assert PUSH_DAEMON_PORT in {p.port for p in svc.spec.ports}
+
+
+def test_sandbox_manager_can_patch_pods() -> None:
+    """`swap_to_image` moves a live sandbox onto a new image by mutating its
+    container images, which restarts them in place and leaves the pod — and so
+    the session workspace — intact.
+
+    Without `patch` the api-server silently loses that path and falls back to
+    destroying and rebuilding the sandbox, costing the user a re-provision and a
+    restore. Silent degradation is why this is asserted here.
+    """
+    docs = yaml.safe_load_all(_render_template("templates/sandbox-rbac.yaml"))
+    pod_verbs = {
+        verb
+        for doc in docs
+        if doc
+        and doc["kind"] == "Role"
+        and doc["metadata"]["labels"].get("app.kubernetes.io/component")
+        == "sandbox-manager"
+        for rule in doc["rules"]
+        if "pods" in rule["resources"]
+        for verb in rule["verbs"]
+    }
+
+    assert "patch" in pod_verbs

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_image_swap.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_image_swap.py
@@ -1,0 +1,216 @@
+"""Moving a live sandbox onto a new image without rebuilding it.
+
+Cluster behaviour was verified separately on kind (k8s 1.35): the container
+restarts even under ``restartPolicy: Never``, the emptyDir survives, and the
+sidecar can be patched. These cover what that can't tell us — that we watch the
+right signal for "the swap took", and that every refusal declines.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import pytest
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+
+import onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager as ksm
+from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
+    KubernetesSandboxManager,
+)
+from onyx.server.features.build.sandbox.models import (
+    ImageMoveOutcome,
+    SandboxImageTarget,
+)
+
+SANDBOX_ID = UUID("12345678-1234-1234-1234-1234567890ab")
+OLD_DIGEST = "sha256:" + "a" * 64
+NEW_DIGEST = "sha256:" + "b" * 64
+TARGET = SandboxImageTarget(
+    ref=f"docker.io/onyxdotapp/sandbox@{NEW_DIGEST}", digest=NEW_DIGEST
+)
+
+
+@pytest.fixture(autouse=True)
+def _fast_swap_polling(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the give-up path from taking the production minute."""
+    monkeypatch.setattr(ksm, "_IMAGE_SWAP_TIMEOUT_SECONDS", 0.3)
+    monkeypatch.setattr(ksm, "_IMAGE_SWAP_POLL_SECONDS", 0.01)
+
+
+def _pod(*, digest: str | None, ready: bool = True) -> client.V1Pod:
+    """Enough of a pod for both the digest check and the real readiness waiter."""
+    pod = SimpleNamespace(
+        metadata=SimpleNamespace(name="sandbox-abc", resource_version="1"),
+        spec=SimpleNamespace(init_containers=[]),
+        status=SimpleNamespace(
+            phase="Running",
+            conditions=[
+                SimpleNamespace(type="Ready", status="True" if ready else "False")
+            ],
+            container_statuses=[
+                SimpleNamespace(
+                    name="sandbox",
+                    image="docker.io/onyxdotapp/sandbox:latest",
+                    image_id=(
+                        f"docker.io/onyxdotapp/sandbox@{digest}" if digest else None
+                    ),
+                    ready=ready,
+                    state=SimpleNamespace(running=object() if ready else None),
+                )
+            ],
+            init_container_statuses=[],
+        ),
+    )
+    return cast(client.V1Pod, pod)
+
+
+def _manager(
+    *, pods: list[client.V1Pod], sidecar_healthy: bool = True
+) -> tuple[KubernetesSandboxManager, MagicMock, MagicMock]:
+    """A manager whose pod reads walk ``pods``, holding the last one."""
+    core_api = MagicMock()
+    reads = list(pods)
+
+    def next_pod(*_a: Any, **_kw: Any) -> client.V1Pod:
+        return reads.pop(0) if len(reads) > 1 else reads[0]
+
+    core_api.read_namespaced_pod.side_effect = next_pod
+    mgr: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
+    mgr._core_api = core_api  # type: ignore[attr-defined]
+    mgr._namespace = "sandbox-test"  # type: ignore[attr-defined]
+    sidecar = MagicMock()
+    sidecar.is_healthy.return_value = sidecar_healthy
+    mgr._sidecar_client = sidecar  # type: ignore[attr-defined]
+    return mgr, core_api, sidecar
+
+
+def test_swap_patches_both_live_containers() -> None:
+    """One patch, so a refusal can't leave a new agent on an old daemon."""
+    mgr, core_api, _sidecar = _manager(
+        pods=[_pod(digest=OLD_DIGEST), _pod(digest=NEW_DIGEST)]
+    )
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is ImageMoveOutcome.MOVED
+
+    body = core_api.patch_namespaced_pod.call_args.kwargs["body"]
+    assert body["spec"]["containers"] == [{"name": "sandbox", "image": TARGET.ref}]
+    assert body["spec"]["initContainers"] == [{"name": "sidecar", "image": TARGET.ref}]
+
+
+def test_swap_waits_for_the_runtime_not_the_spec() -> None:
+    """The spec updates at once; only the reported digest means the kubelet
+    actually restarted the container."""
+    mgr, _, sidecar = _manager(pods=[_pod(digest=OLD_DIGEST)])
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is ImageMoveOutcome.UNSUPPORTED
+
+
+def test_swap_waits_for_readiness() -> None:
+    """A restarted container that isn't ready cannot take a turn."""
+    mgr, _, sidecar = _manager(pods=[_pod(digest=NEW_DIGEST, ready=False)])
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is ImageMoveOutcome.UNSUPPORTED
+
+
+def test_swap_waits_for_the_sidecar() -> None:
+    mgr, _, sidecar = _manager(pods=[_pod(digest=NEW_DIGEST)], sidecar_healthy=False)
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is ImageMoveOutcome.UNSUPPORTED
+
+
+@pytest.mark.parametrize("status", [403, 422])
+def test_swap_declines_when_the_cluster_refuses(status: int) -> None:
+    """No `patch` permission, or a cluster rejecting the mutation. Both fall
+    back to rebuilding rather than raising."""
+    mgr, core_api, _sidecar = _manager(pods=[_pod(digest=OLD_DIGEST)])
+    core_api.patch_namespaced_pod.side_effect = ApiException(status=status)
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is ImageMoveOutcome.UNSUPPORTED
+
+
+def test_swap_declines_when_the_pod_is_gone() -> None:
+    mgr, core_api, _sidecar = _manager(pods=[_pod(digest=OLD_DIGEST)])
+    core_api.patch_namespaced_pod.side_effect = ApiException(status=404)
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is ImageMoveOutcome.UNSUPPORTED
+
+
+def test_swap_declines_when_the_pod_vanishes_mid_swap() -> None:
+    """Evicted between the patch and the restart."""
+    mgr, core_api, _sidecar = _manager(pods=[_pod(digest=OLD_DIGEST)])
+    core_api.read_namespaced_pod.side_effect = [
+        _pod(digest=OLD_DIGEST),
+        ApiException(status=404),
+    ]
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is ImageMoveOutcome.UNSUPPORTED
+
+
+def test_kubernetes_never_asks_the_caller_to_provision() -> None:
+    """Workspaces are emptyDirs that die with the pod, so they cannot outlive
+    a discarded runtime."""
+    mgr, _, sidecar = _manager(pods=[_pod(digest=OLD_DIGEST)])
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is not ImageMoveOutcome.NEEDS_PROVISION
+
+
+def test_swap_probes_the_sidecar_once_ready_not_on_every_poll() -> None:
+    """The sidecar probe is an HTTP call into the pod; polling it while waiting
+    for the restart would hit it dozens of times per swap."""
+    mgr, _, sidecar = _manager(
+        pods=[
+            _pod(digest=OLD_DIGEST),
+            _pod(digest=OLD_DIGEST),
+            _pod(digest=NEW_DIGEST),
+        ]
+    )
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is ImageMoveOutcome.MOVED
+
+    assert sidecar.is_healthy.call_count == 1
+
+
+def test_swap_checks_the_digest_before_sleeping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A container that has already restarted must not cost a poll interval."""
+    slept: list[float] = []
+    monkeypatch.setattr(ksm.time, "sleep", lambda seconds: slept.append(seconds))
+    mgr, _, sidecar = _manager(pods=[_pod(digest=NEW_DIGEST)])
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is ImageMoveOutcome.MOVED
+    assert slept == []
+
+
+def test_swap_requires_the_target_digest_not_merely_a_change() -> None:
+    """A status that has not reported yet leaves nothing to compare against, so
+    "different from before" would let the *old* image count as a successful swap.
+    """
+    mgr, _, _sidecar = _manager(
+        pods=[_pod(digest=None), _pod(digest=OLD_DIGEST), _pod(digest=OLD_DIGEST)]
+    )
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is ImageMoveOutcome.UNSUPPORTED
+
+
+def test_swap_accepts_a_sandbox_already_on_the_target() -> None:
+    """Comparing against the target rather than a change also stops a correct
+    sandbox from being reported UNSUPPORTED and rebuilt for no reason."""
+    mgr, _, _sidecar = _manager(pods=[_pod(digest=NEW_DIGEST)])
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is ImageMoveOutcome.MOVED
+
+
+def test_swap_gives_the_sidecar_the_rest_of_the_budget() -> None:
+    """It restarts on its own schedule and has no readiness probe, so the pod can
+    report Ready before the push daemon has bound its port. One probe would send a
+    completed swap down the rebuild path."""
+    mgr, _, sidecar = _manager(pods=[_pod(digest=NEW_DIGEST)])
+    sidecar.is_healthy.side_effect = [False, False, True]
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is ImageMoveOutcome.MOVED
+    assert sidecar.is_healthy.call_count == 3

--- a/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
@@ -31,9 +31,12 @@ metadata:
     app.kubernetes.io/component: sandbox-manager
 rules:
   # watch is required: _wait_for_pod_ready streams pod events during provision.
+  # patch is required: swap_to_image moves a live sandbox onto a new image by
+  # mutating its container images, which restarts them in place and leaves the
+  # pod — and so the session workspace — intact.
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["get", "list", "watch", "create", "delete"]
+    verbs: ["get", "list", "watch", "create", "patch", "delete"]
   # _create_sandbox_pod reads the sandbox-pod PodTemplate to build the pod.
   - apiGroups: [""]
     resources: ["podtemplates"]


### PR DESCRIPTION
## Description

Stacked on #13636. Adds the mechanism for moving a sandbox onto a new image; #13642 decides when to use it.

Recycling a sandbox onto a new image doesn't have to mean rebuilding it. A pod's container image is mutable, and the kubelet responds by restarting just that container — the pod survives, so the `workspace` and `opencode-data` emptyDirs survive with it. **No snapshot, no restore, no re-provision, no new pod IP, no port reallocation, and the sandbox never leaves `RUNNING`.** Against an image the node has already pulled it costs a container restart instead of tens of seconds plus a data-loss window.

### Verified against a real cluster, not assumed

The sandbox pod is `restartPolicy: Never`, and it was genuinely unclear whether a kubelet starts a replacement container after an image patch under that policy — the whole approach rested on it. Spiked on kind (k8s 1.35) with a pod mirroring the sandbox's shape:

| Question | Result |
|---|---|
| Container restarts after an image patch under `restartPolicy: Never`? | Yes — `restartCount` 0→1, pod stayed Running/Ready |
| Does the `emptyDir` survive? | Yes — a file written via `exec` (so not recreated by the container's own command) survived two swaps |
| Can the restartable init container (sidecar) be patched? | Yes, ~30s to take effect vs ~10s for the app container |

### Design points worth review

- **The wait watches the reported digest, not the spec.** Patching updates the spec immediately, so a spec-based check reports success while the old process is still serving. It also waits for container readiness and sidecar health, since a restarted container that can't take a turn isn't a completed swap.
- **Agent and sidecar go in one patch.** They share one image by design. A cluster that refuses to mutate the restartable init container's image fails the whole patch and declines — a half-swapped pod pairs a new agent with an old daemon, the exact skew recycling exists to remove. (Chart render tests pin k8s 1.33 while the spike ran on 1.35, so treat init-container mutability as version-sensitive; declining beats half-succeeding.)
- **It takes a target the backend has already vouched for** as present on the nodes (#13636). A sandbox restarted onto an image its host lacks can't serve anything — worse than leaving it a version behind.
- **Every refusal declines rather than raising**, so the caller can fall back to rebuilding: no `patch` permission, a cluster that rejects the mutation, a pod that's gone or vanishes mid-swap. Docker has no in-place path (a container's image is fixed at creation) and inherits the declining default, which is what sends compose down the rebuild fallback.
- **Only safe with no chat work in flight.** That gate is #13642's job; this PR is the mechanism.

Adds `patch` on pods to the sandbox-manager Role. Losing that verb degrades silently to the slow path rather than failing, so there's a render test asserting it with the reason attached.

## How Has This Been Tested?

The cluster spike above for the behaviour Kubernetes owns, plus 9 unit tests for the parts it doesn't: both live containers patched together, the wait keying on the runtime signal rather than the spec, readiness and sidecar health required, and each refusal path declining. A chart render test covers the RBAC verb.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check