### PR TITLE
chore: add refusal reasons (#13628) to release v4.4

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -107,10 +107,29 @@ class EmptyLLMResponseError(ClassifiedLLMError):
         self.finish_reason = finish_reason
 
 
-# LiteLLM normalizes provider refusal stop reasons (e.g. Anthropic's
-# stop_reason="refusal", Gemini's SAFETY) to "content_filter". Some
-# OpenAI-compatible gateways forward the raw provider value instead.
-_REFUSAL_FINISH_REASONS = {"content_filter", "refusal"}
+# LiteLLM maps these native policy blocks to content_filter, but gateways may
+# forward the provider value unchanged.
+_REFUSAL_FINISH_REASONS = {
+    "BLOCKLIST",
+    "CONTENT_BLOCKED",
+    "ERROR_TOXIC",
+    "IMAGE_OTHER",
+    "IMAGE_PROHIBITED_CONTENT",
+    "IMAGE_RECITATION",
+    "IMAGE_SAFETY",
+    "LANGUAGE",
+    "MODEL_ARMOR",
+    "OTHER",
+    "PROHIBITED_CONTENT",
+    "RECITATION",
+    "SAFETY",
+    "SPII",
+    "content_filter",
+    "content_filtered",
+    "guardrail_intervened",
+    "refusal",
+    "sensitive",
+}
 
 
 def _build_empty_llm_response_error(

--- a/backend/tests/unit/onyx/chat/test_llm_loop.py
+++ b/backend/tests/unit/onyx/chat/test_llm_loop.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 import pytest
 
 from onyx.chat.llm_loop import (
+    _REFUSAL_FINISH_REASONS,
     EmptyLLMResponseError,
     _build_empty_llm_response_error,
     _try_fallback_tool_extraction,
@@ -1329,11 +1330,11 @@ class TestEmptyLlmResponseClassification:
         # Anthropic-specific fallback suggestion from the issue.
         assert "Claude Opus 4.8" in err.client_error_msg
 
-    def test_raw_refusal_finish_reason_takes_precedence_over_budget_heuristic(
-        self, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.parametrize("finish_reason", sorted(_REFUSAL_FINISH_REASONS))
+    def test_refusal_finish_reasons_take_precedence_over_budget_heuristic(
+        self, monkeypatch: pytest.MonkeyPatch, finish_reason: str
     ) -> None:
-        """Gateways may forward the raw "refusal" value; it must be recognized
-        and must win over the OpenAI empty-stream quota heuristic."""
+        """Native provider refusal reasons may pass through gateways unchanged."""
         monkeypatch.setattr("onyx.chat.llm_loop.is_true_openai_model", lambda *_: True)
 
         err = _build_empty_llm_response_error(
@@ -1343,13 +1344,14 @@ class TestEmptyLlmResponseClassification:
                 answer=None,
                 tool_calls=None,
                 raw_answer=None,
-                finish_reason="refusal",
+                finish_reason=finish_reason,
             ),
             tool_choice=ToolChoiceOptions.AUTO,
         )
 
         assert err.error_code == "MODEL_REFUSAL"
         assert err.is_retryable is False
+        assert err.finish_reason == finish_reason
         assert "Claude Opus 4.8" not in err.client_error_msg
 
 


### PR DESCRIPTION
Cherry-pick of commit 374f2f11369566ce315a9d7f40530717caa6fbb5 to release/v4.4 branch.

Original PR: #13628

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand finish-reason handling to recognize more provider refusal values, even when gateways don’t normalize them. This prevents false “quota/budget” errors and correctly returns non-retryable model refusal errors.

- **Bug Fixes**
  - Recognize a wider set of native provider refusal reasons (e.g., SAFETY, PROHIBITED_CONTENT, guardrail_intervened, content_filter, refusal).
  - Ensure refusal reasons take precedence over the empty-stream/usage heuristic for OpenAI-compatible gateways.

<sup>Written for commit c9cf1b9c420e302b0ba30cbb0e2f4941f1f4d984. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

