### PR TITLE
feat(craft): move a compose sandbox by replacing its container

### DIFF
--- a/backend/onyx/background/celery/tasks/build/tasks.py
+++ b/backend/onyx/background/celery/tasks/build/tasks.py
@@ -26,6 +26,9 @@ from onyx.server.features.build.session.sandbox_lifecycle import (
     list_snapshotable_session_workspaces,
     sleep_sandbox,
 )
+from onyx.server.features.build.session.sandbox_recycle import (
+    recycle_sandboxes_on_stale_images,
+)
 
 # 100 minutes - snapshotting can take time
 TIMEOUT_SECONDS = 6000
@@ -43,7 +46,8 @@ SNAPSHOT_INTERVAL_DIVISOR = 4
     ignore_result=True,
 )
 def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa: ARG001
-    """Sweep RUNNING sandboxes: background-snapshot sessions, sleep idle ones.
+    """Sweep RUNNING sandboxes: background-snapshot sessions, sleep idle ones,
+    move ones left behind onto the current sandbox image.
 
     Background snapshots bound data loss from ungraceful pod death (kubelet
     eviction, node loss, spot reclaim) to ~idle_timeout/SNAPSHOT_INTERVAL_DIVISOR:
@@ -53,6 +57,9 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
     The reap itself is ``sleep_sandbox`` (sandbox lifecycle), which stays
     fail-closed: snapshot failure on a reachable pod keeps the sandbox
     RUNNING for retry next sweep.
+
+    Image recycling rides the same tick: same rows, same "is anyone using this?"
+    question, and one lock keeps a reap and a recycle off the same pod.
     """
     task_logger.info(f"cleanup_idle_sandboxes_task starting for tenant {tenant_id}")
 
@@ -114,6 +121,16 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                         exc_info=True,
                     )
                     db_session.rollback()
+
+            # After the idle reaps: no point restarting a sandbox about to be
+            # reclaimed, and reclaiming pods is the time-sensitive half.
+            try:
+                recycle_sandboxes_on_stale_images(
+                    db_session, sandbox_manager, redis_client, tenant_id
+                )
+            except Exception:
+                task_logger.exception("Sandbox image recycling failed")
+                db_session.rollback()
 
             for sandbox in non_idle_sandboxes:
                 sandbox_id = sandbox.id

--- a/backend/onyx/db/scheduled_task.py
+++ b/backend/onyx/db/scheduled_task.py
@@ -355,6 +355,33 @@ def has_in_flight_run_for_task(
     return db_session.execute(stmt).first() is not None
 
 
+def get_unfinished_run_for_user(
+    *,
+    db_session: Session,
+    user_id: UUID,
+) -> ScheduledTaskRun | None:
+    """The user's oldest run that has not reached a terminal status, if any.
+
+    "Unfinished" deliberately includes ``AWAITING_APPROVAL`` alongside QUEUED
+    and RUNNING: a run parked on an approval gate still owns the user's sandbox
+    and will resume in it, so anything asking "is this sandbox committed to
+    work?" has to count it.
+    """
+    stmt = (
+        select(ScheduledTaskRun)
+        .join(ScheduledTask, ScheduledTaskRun.task_id == ScheduledTask.id)
+        .where(
+            ScheduledTask.user_id == user_id,
+            ScheduledTaskRun.status.notin_(
+                [s for s in ScheduledTaskRunStatus if s.is_terminal()]
+            ),
+        )
+        .order_by(ScheduledTaskRun.started_at)
+        .limit(1)
+    )
+    return db_session.execute(stmt).scalars().first()
+
+
 def insert_run(
     *,
     db_session: Session,

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -203,6 +203,26 @@ def get_empty_session_for_user(
     )
 
 
+def get_active_session_ids_for_user(
+    user_id: UUID,
+    db_session: Session,
+) -> list[UUID]:
+    """IDs of the user's ACTIVE sessions, whatever their origin.
+
+    ACTIVE is the only status a turn can be in flight under — sessions are
+    marked IDLE when their sandbox sleeps — so this bounds the set of sessions
+    worth asking the turn cache about.
+    """
+    return list(
+        db_session.scalars(
+            select(BuildSession.id).where(
+                BuildSession.user_id == user_id,
+                BuildSession.status == BuildSessionStatus.ACTIVE,
+            )
+        )
+    )
+
+
 def update_session_activity(
     session_id: UUID,
     db_session: Session,

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -36,10 +36,13 @@ from onyx.server.features.build.sandbox.models import (
     FatalWriteError,
     FileSet,
     FilesystemEntry,
+    ImageMoveOutcome,
     PromptAttachment,
     PushFailure,
     PushResult,
     RetriableWriteError,
+    SandboxImageState,
+    SandboxImageTarget,
     SandboxInfo,
     SnapshotResult,
 )
@@ -355,6 +358,27 @@ class SandboxManager(_ServeMixin, ABC):
             True if sandbox is healthy, False otherwise
         """
         ...
+
+    def get_image_state(self) -> SandboxImageState:
+        """The image sandboxes should run and the image each one is running.
+
+        One call for the whole fleet, keyed by the sandbox-id label both backends
+        already set. Reporting nothing known produces no work.
+        """
+        return SandboxImageState(target=None, live_digests={})
+
+    def move_to_image(
+        self,
+        sandbox_id: UUID,  # noqa: ARG002
+        target: SandboxImageTarget,  # noqa: ARG002
+    ) -> ImageMoveOutcome:
+        """Move a live sandbox onto ``target``, preserving as much as possible.
+
+        ``target`` must be one :meth:`get_image_state` vouched for: a sandbox
+        restarted onto an image its host lacks cannot serve anything. Only safe
+        when no chat work is in flight, which the caller owns.
+        """
+        return ImageMoveOutcome.UNSUPPORTED
 
     def send_message(
         self,

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -124,8 +124,11 @@ from onyx.server.features.build.sandbox.models import (
     CraftMCPServerConfig,
     FileSet,
     FilesystemEntry,
+    SandboxImageState,
+    SandboxImageTarget,
     SandboxInfo,
     SnapshotResult,
+    sandbox_image_digest,
 )
 from onyx.server.features.build.sandbox.nextjs_dev import build_nextjs_start_script
 from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
@@ -1024,6 +1027,64 @@ class DockerSandboxManager(SandboxManager):
             return False
         state = (container.attrs or {}).get("State") or {}
         return state.get("Status") == "running"
+
+    def get_image_state(self) -> SandboxImageState:
+        """One local-store lookup for the target, one daemon call for the fleet."""
+        return SandboxImageState(
+            target=self._current_image_target(),
+            live_digests=self._live_sandbox_digests(),
+        )
+
+    def _current_image_target(self) -> SandboxImageTarget | None:
+        """Whatever the local store holds for the configured ref right now.
+
+        Local IDs on both sides, so a repointed mutable tag is caught without
+        pinning, and an ID resolves only once a pull has finished. Uncached: an
+        out-of-process ``docker compose pull`` is what we want to notice.
+        """
+        try:
+            image_id = self._docker.images.get(self._image).id
+        except (APIError, NotFound) as e:
+            logger.debug("Could not resolve local image %s: %s", self._image, e)
+            return None
+
+        digest = sandbox_image_digest(image_id)
+        # The ref stays configured: there is no live spec to patch a digest onto.
+        return SandboxImageTarget(ref=self._image, digest=digest) if digest else None
+
+    def _live_sandbox_digests(self) -> dict[UUID, str]:
+        """One daemon call for the whole fleet, keyed by the sandbox-id label.
+
+        Stopped containers included: ``_reuse_existing_container`` restarts an
+        exited one, so it would come back on its superseded image.
+        """
+        try:
+            containers = self._docker.containers.list(
+                all=True,
+                filters={"label": f"{LABEL_COMPONENT}={LABEL_COMPONENT_VALUE}"},
+            )
+        except APIError as e:
+            logger.warning("Could not list sandbox containers: %s", e)
+            return {}
+
+        digests: dict[UUID, str] = {}
+        for container in containers:
+            attrs = container.attrs or {}
+            raw_id = (attrs.get("Labels") or {}).get(LABEL_SANDBOX_ID)
+            # `list` reports the resolved image as ImageID; `inspect` nests the
+            # ref under Config, so the two shapes are not interchangeable.
+            digest = sandbox_image_digest(attrs.get("ImageID"))
+            if not raw_id or digest is None:
+                continue
+            try:
+                digests[UUID(raw_id)] = digest
+            except ValueError:
+                logger.warning(
+                    "Sandbox container %s carries an unparseable id label %r",
+                    container.name,
+                    raw_id,
+                )
+        return digests
 
     def _render_agents_md(
         self,

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -124,6 +124,7 @@ from onyx.server.features.build.sandbox.models import (
     CraftMCPServerConfig,
     FileSet,
     FilesystemEntry,
+    ImageMoveOutcome,
     SandboxImageState,
     SandboxImageTarget,
     SandboxInfo,
@@ -989,6 +990,45 @@ class DockerSandboxManager(SandboxManager):
                 logger.info("Sandbox container %s already exists, reusing.", sandbox_id)
                 return self._require_container(sandbox_id), False
             raise RuntimeError(f"Failed to create sandbox container: {e}") from e
+
+    def move_to_image(
+        self,
+        sandbox_id: UUID,
+        target: SandboxImageTarget,  # noqa: ARG002
+    ) -> ImageMoveOutcome:
+        """Remove the container, leaving the named volume for provisioning to
+        adopt, so the workspaces survive a move onto a new image.
+
+        A container's image is fixed at creation, so compose replaces the
+        container rather than swapping under it — hence ``NEEDS_PROVISION``,
+        which only the caller can do. ``target`` is unused: provisioning reads
+        the configured image, which is the one the state read vouched for.
+
+        Everything outside the volume goes, opencode history included, so callers
+        capture that first.
+        """
+        self._close_all_sandbox_buses(sandbox_id)
+
+        container = self._get_container(sandbox_id)
+        if container is None:
+            return ImageMoveOutcome.NEEDS_PROVISION
+
+        try:
+            container.remove(force=True, v=False)
+        except NotFound:
+            return ImageMoveOutcome.NEEDS_PROVISION
+        except APIError as e:
+            logger.warning(
+                "Could not remove sandbox container %s: %s", container.name, e
+            )
+            return ImageMoveOutcome.UNSUPPORTED
+
+        logger.info(
+            "Removed sandbox container %s, keeping volume %s",
+            container.name,
+            _sandbox_volume_name(sandbox_id),
+        )
+        return ImageMoveOutcome.NEEDS_PROVISION
 
     def terminate(self, sandbox_id: UUID) -> None:
         self._close_all_sandbox_buses(sandbox_id)

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -113,6 +113,7 @@ from onyx.server.features.build.sandbox.models import (
     FatalWriteError,
     FileSet,
     FilesystemEntry,
+    ImageMoveOutcome,
     RetriableWriteError,
     SandboxImageState,
     SandboxImageTarget,
@@ -191,6 +192,10 @@ _PREPULLER_CONTAINER_NAME = "prepuller"
 # Short-lived: the point is to notice a new image, but it is read every pass.
 _IMAGE_TARGET_TTL_SECONDS = 60.0
 
+# Covers a container restart plus opencode-serve and the sidecar coming back
+# against an image the node already holds — not a download.
+_IMAGE_SWAP_TIMEOUT_SECONDS = 60.0
+_IMAGE_SWAP_POLL_SECONDS = 2.0
 
 # Per-session egress tagging plugin, baked into the sandbox image (see
 # docker/Dockerfile). Path must match the COPY destination there.
@@ -686,6 +691,106 @@ class KubernetesSandboxManager(SandboxManager):
         ref = next(iter(refs))
         digest = next(iter(digests))
         return SandboxImageTarget(ref=_pinned_ref(ref, digest), digest=digest)
+
+    def move_to_image(
+        self, sandbox_id: UUID, target: SandboxImageTarget
+    ) -> ImageMoveOutcome:
+        """Patch the image and let the kubelet restart just that container.
+
+        The pod survives, so the ``workspace`` and ``opencode-data`` emptyDirs do
+        too: no snapshot, no restore, no re-provision, and the sandbox never
+        leaves RUNNING. Verified on a real cluster, since the pod is
+        ``restartPolicy: Never`` and a replacement container was not a given.
+
+        Agent and sidecar go in one patch — a half-swapped pod would pair a new
+        agent with an old daemon. Never ``NEEDS_PROVISION``: the workspaces are
+        emptyDirs that die with the pod, so they cannot outlive it.
+        """
+        pod_name = self._get_pod_name(str(sandbox_id))
+        try:
+            pod = self._core_api.read_namespaced_pod(
+                name=pod_name, namespace=self._namespace
+            )
+        except ApiException as e:
+            logger.info("Cannot swap sandbox %s: %s", sandbox_id, e)
+            return ImageMoveOutcome.UNSUPPORTED
+
+        # The reported image, not the spec: the patch updates the spec at once,
+        # so a spec check would pass while the old process is still serving.
+        status = _container_status(pod, _SANDBOX_CONTAINER_NAME)
+        before_digest = sandbox_image_digest(status.image_id if status else None)
+
+        try:
+            self._core_api.patch_namespaced_pod(
+                name=pod_name,
+                namespace=self._namespace,
+                body={
+                    "spec": {
+                        "containers": [
+                            {"name": _SANDBOX_CONTAINER_NAME, "image": target.ref}
+                        ],
+                        # sandbox-init keeps its ref; it has already run.
+                        "initContainers": [
+                            {"name": _SIDECAR_CONTAINER_NAME, "image": target.ref}
+                        ],
+                    }
+                },
+            )
+        except ApiException as e:
+            logger.warning(
+                "Sandbox %s image swap to %s was refused: %s",
+                sandbox_id,
+                target.ref,
+                e,
+            )
+            return ImageMoveOutcome.UNSUPPORTED
+
+        logger.info("Swapping sandbox %s onto %s", sandbox_id, target.ref)
+        if self._wait_for_swapped_container(
+            sandbox_id, pod_name, before_digest=before_digest
+        ):
+            return ImageMoveOutcome.MOVED
+        return ImageMoveOutcome.UNSUPPORTED
+
+    def _wait_for_swapped_container(
+        self,
+        sandbox_id: UUID,
+        pod_name: str,
+        *,
+        before_digest: str | None,
+    ) -> bool:
+        """Wait until the container reports the new digest *and* is serving:
+        without readiness the caller gets a sandbox that cannot take a turn."""
+        deadline = time.monotonic() + _IMAGE_SWAP_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            time.sleep(_IMAGE_SWAP_POLL_SECONDS)
+            try:
+                pod = self._core_api.read_namespaced_pod(
+                    name=pod_name, namespace=self._namespace
+                )
+            except ApiException as e:
+                logger.warning("Lost sight of sandbox %s mid-swap: %s", sandbox_id, e)
+                return False
+
+            status = _container_status(pod, _SANDBOX_CONTAINER_NAME)
+            digest = sandbox_image_digest(status.image_id if status else None)
+            if digest is None or digest == before_digest:
+                continue
+            if not self._sandbox_container_is_ready(pod):
+                continue
+            if not self._sidecar_client.is_healthy(
+                sandbox_id=sandbox_id, timeout_seconds=_IMAGE_SWAP_POLL_SECONDS
+            ):
+                continue
+            logger.info("Sandbox %s is serving %s", sandbox_id, digest)
+            return True
+
+        logger.warning(
+            "Sandbox %s did not come back on the new image within %.0fs",
+            sandbox_id,
+            _IMAGE_SWAP_TIMEOUT_SECONDS,
+        )
+        return False
 
     def _live_sandbox_digests(self) -> dict[UUID, str]:
         """One list call for the whole fleet, keyed by the sandbox-id label."""

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -51,6 +51,7 @@ import threading
 import time
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
+from itertools import chain
 from pathlib import Path
 from typing import cast
 from uuid import UUID
@@ -113,8 +114,11 @@ from onyx.server.features.build.sandbox.models import (
     FileSet,
     FilesystemEntry,
     RetriableWriteError,
+    SandboxImageState,
+    SandboxImageTarget,
     SandboxInfo,
     SnapshotResult,
+    sandbox_image_digest,
 )
 from onyx.server.features.build.sandbox.nextjs_dev import build_nextjs_start_script
 from onyx.server.features.build.sandbox.serve_transport import (
@@ -178,6 +182,15 @@ _SIDECAR_CONTAINER_NAME = "sidecar"
 
 # Helm-rendered PodTemplate carrying the static sandbox pod shape.
 _PODTEMPLATE_NAME = "sandbox-pod"
+
+# The prepull DaemonSet runs the same ref as the sandbox pods and re-resolves it
+# on a timer; its pods are the only window onto what the nodes hold.
+_PREPULLER_LABEL_SELECTOR = "app.kubernetes.io/component=sandbox-image-prepuller"
+_PREPULLER_CONTAINER_NAME = "prepuller"
+
+# Short-lived: the point is to notice a new image, but it is read every pass.
+_IMAGE_TARGET_TTL_SECONDS = 60.0
+
 
 # Per-session egress tagging plugin, baked into the sandbox image (see
 # docker/Dockerfile). Path must match the COPY destination there.
@@ -261,6 +274,34 @@ def _build_targz(files: FileSet) -> tuple[bytes, str]:
     return raw, hashlib.sha256(raw).hexdigest()
 
 
+def _container_status(pod: client.V1Pod, name: str) -> client.V1ContainerStatus | None:
+    """The runtime's report for one container, app or init."""
+    if pod.status is None:
+        return None
+    statuses = chain(
+        pod.status.container_statuses or [], pod.status.init_container_statuses or []
+    )
+    return next((status for status in statuses if status.name == name), None)
+
+
+def _labelled_sandbox_id(pod: client.V1Pod) -> UUID | None:
+    """The sandbox this pod belongs to, or None if it cannot be tied to one."""
+    raw = ((pod.metadata.labels if pod.metadata else None) or {}).get(LABEL_SANDBOX_ID)
+    try:
+        return UUID(raw) if raw else None
+    except ValueError:
+        logger.warning("Sandbox pod carries an unparseable id label %r", raw)
+        return None
+
+
+def _pinned_ref(ref: str, digest: str) -> str:
+    """``ref`` with its tag replaced by ``digest``, so it can be patched onto a
+    live pod. A colon before the final slash is a registry port, not a tag."""
+    registry, _, name = ref.split("@", 1)[0].rpartition("/")
+    repository = f"{registry}/{name.rsplit(':', 1)[0]}" if registry else name
+    return f"{repository}@{digest}"
+
+
 class KubernetesSandboxManager(SandboxManager):
     """Kubernetes-based sandbox manager for production deployments.
 
@@ -279,6 +320,9 @@ class KubernetesSandboxManager(SandboxManager):
 
     _instance: "KubernetesSandboxManager | None" = None
     _lock = threading.Lock()
+
+    # (target, expiry). Unlocked: a race just resolves the same image twice.
+    _image_target_cache: tuple[SandboxImageTarget | None, float] | None = None
 
     def __new__(cls) -> "KubernetesSandboxManager":
         if cls._instance is None:
@@ -578,6 +622,90 @@ class KubernetesSandboxManager(SandboxManager):
             f"The PodTemplate and api-server versions are likely out of sync — "
             f"apply the matching sandbox PodTemplate."
         )
+
+    def get_image_state(self) -> SandboxImageState:
+        """One prepuller read for the target, one pod list for the fleet."""
+        return SandboxImageState(
+            target=self._current_image_target(),
+            live_digests=self._live_sandbox_digests(),
+        )
+
+    def _current_image_target(self) -> SandboxImageTarget | None:
+        """The image every prepuller pod agrees it has pulled, or None.
+
+        Those pods are the only node-local view the api-server has, and a kubelet
+        reports a digest only for an image it finished pulling — so agreement
+        means "current *and* present on every node a sandbox can land on".
+        Not the PodTemplate: it names a tag, not what the nodes hold.
+        """
+        now = time.monotonic()
+        cached = self._image_target_cache
+        if cached is not None and now < cached[1]:
+            return cached[0]
+
+        target = self._resolve_prepulled_image()
+        self._image_target_cache = (target, now + _IMAGE_TARGET_TTL_SECONDS)
+        return target
+
+    def _resolve_prepulled_image(self) -> SandboxImageTarget | None:
+        try:
+            pods = self._core_api.list_namespaced_pod(
+                namespace=self._namespace,
+                label_selector=_PREPULLER_LABEL_SELECTOR,
+            )
+        except ApiException as e:
+            logger.warning("Could not read prepuller pods: %s", e)
+            return None
+
+        if not pods.items:
+            # sandboxImagePrepull.enabled=false: nothing can vouch for a node.
+            logger.debug("No prepuller pods; cannot confirm a sandbox image")
+            return None
+
+        # From the runtime's report, not the spec: the spec holds the tag it was
+        # told to run, the status holds what that tag resolved to.
+        refs: set[str] = set()
+        digests: set[str] = set()
+        for pod in pods.items:
+            status = _container_status(pod, _PREPULLER_CONTAINER_NAME)
+            digest = sandbox_image_digest(status.image_id if status else None)
+            if status is None or status.image is None or digest is None:
+                return None  # A node that hasn't reported can't be vouched for.
+            refs.add(status.image)
+            digests.add(digest)
+
+        if len(refs) != 1 or len(digests) != 1:
+            logger.info(
+                "Prepuller pods disagree on the sandbox image (%s refs, %s digests); "
+                "waiting for the rollout to settle",
+                len(refs),
+                len(digests),
+            )
+            return None
+
+        ref = next(iter(refs))
+        digest = next(iter(digests))
+        return SandboxImageTarget(ref=_pinned_ref(ref, digest), digest=digest)
+
+    def _live_sandbox_digests(self) -> dict[UUID, str]:
+        """One list call for the whole fleet, keyed by the sandbox-id label."""
+        try:
+            pods = self._core_api.list_namespaced_pod(
+                namespace=self._namespace,
+                label_selector=(f"{LABEL_K8S_COMPONENT}={LABEL_K8S_COMPONENT_SANDBOX}"),
+            )
+        except ApiException as e:
+            logger.warning("Could not list sandbox pods: %s", e)
+            return {}
+
+        digests: dict[UUID, str] = {}
+        for pod in pods.items:
+            sandbox_id = _labelled_sandbox_id(pod)
+            status = _container_status(pod, _SANDBOX_CONTAINER_NAME)
+            digest = sandbox_image_digest(status.image_id if status else None)
+            if sandbox_id is not None and digest is not None:
+                digests[sandbox_id] = digest
+        return digests
 
     def _create_sandbox_service(
         self,

--- a/backend/onyx/server/features/build/sandbox/models.py
+++ b/backend/onyx/server/features/build/sandbox/models.py
@@ -1,6 +1,7 @@
 """Pydantic models for sandbox module communication."""
 
 from datetime import datetime
+from enum import Enum
 from typing import TypeAlias
 from uuid import UUID
 
@@ -54,6 +55,58 @@ class SandboxInfo(BaseModel):
     directory_path: str
     status: SandboxStatus
     last_heartbeat: datetime | None
+
+
+class ImageMoveOutcome(str, Enum):
+    """How far a backend got moving a sandbox onto a new image."""
+
+    MOVED = "moved"
+    # Runtime discarded, workspace kept; only the caller can provision.
+    NEEDS_PROVISION = "needs_provision"
+    UNSUPPORTED = "unsupported"
+
+
+class SandboxImageTarget(BaseModel):
+    """The image sandboxes should run, confirmed present where they run.
+
+    ``ref`` must be digest-pinned: patching a tag onto a pod already running
+    that tag is not a change, so a swap would silently do nothing.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    ref: str
+    digest: str
+
+
+class SandboxImageState(BaseModel):
+    """What sandboxes should run and what they are running, as one snapshot.
+
+    ``target`` is None when the backend cannot confirm an image is both current
+    and present where sandboxes run; that means "don't act", never "nothing to
+    do". Sandboxes whose runtime hasn't reported are absent from
+    ``live_digests`` rather than guessed at.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    target: SandboxImageTarget | None
+    live_digests: dict[UUID, str]
+
+    def stale_sandbox_ids(self) -> set[UUID]:
+        """Sandboxes running something other than the target, if one is known."""
+        if self.target is None:
+            return set()
+        return {
+            sandbox_id
+            for sandbox_id, digest in self.live_digests.items()
+            if digest != self.target.digest
+        }
+
+
+def sandbox_image_digest(image: str | None) -> str | None:
+    """The digest of an image reference, with or without a repository prefix."""
+    return image.rpartition("@")[-1] if image else None
 
 
 class SnapshotResult(BaseModel):

--- a/backend/onyx/server/features/build/session/sandbox_busy.py
+++ b/backend/onyx/server/features/build/session/sandbox_busy.py
@@ -1,0 +1,96 @@
+"""Is a sandbox committed to work right now?
+
+Work reaches a shared sandbox by two routes that share no state: interactive
+chats in the turn cache, and scheduled runs in Postgres. The scheduled executor
+registers no interactive turn, so a turn-only check is blind to it.
+
+Claims carry a reason rather than a bool: a recycle blocked for an hour is a
+support question, and "blocked by a scheduled run awaiting approval" answers it.
+
+A prompt already streaming is out of scope — ``prompt_slot`` serialises those, so
+a caller about to disturb a sandbox should acquire them rather than poll.
+"""
+
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.orm import Session as DBSession
+
+from onyx.cache.factory import get_cache_backend
+from onyx.cache.interface import CacheBackend
+from onyx.db.models import Sandbox
+from onyx.db.scheduled_task import get_unfinished_run_for_user
+from onyx.server.features.build.db.build_session import (
+    get_active_session_ids_for_user,
+)
+from onyx.server.features.build.interactive_turns.state import get_active_turn
+
+
+class SandboxBusyKind(str, Enum):
+    """What kind of work holds the sandbox."""
+
+    INTERACTIVE_TURN = "interactive_turn"
+    SCHEDULED_RUN = "scheduled_run"
+
+
+class SandboxBusyClaim(BaseModel):
+    """Work that makes a sandbox unsafe to disturb, and why."""
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: SandboxBusyKind
+    detail: str
+
+
+def sandbox_busy_claim(
+    db_session: DBSession,
+    sandbox: Sandbox,
+    *,
+    cache: CacheBackend | None = None,
+) -> SandboxBusyClaim | None:
+    """The first claim found on this sandbox, cheapest probe first, or None."""
+    cache = cache or get_cache_backend()
+    for probe in (_interactive_turn_claim, _scheduled_run_claim):
+        claim = probe(db_session, sandbox, cache)
+        if claim is not None:
+            return claim
+    return None
+
+
+def _interactive_turn_claim(
+    db_session: DBSession,
+    sandbox: Sandbox,
+    cache: CacheBackend,
+) -> SandboxBusyClaim | None:
+    """A queued or running turn on any of the user's sessions.
+
+    Queued counts: the user has already been told the message was accepted.
+    """
+    for session_id in get_active_session_ids_for_user(sandbox.user_id, db_session):
+        turn = get_active_turn(
+            cache=cache,
+            session_id=session_id,
+            user_id=sandbox.user_id,
+        )
+        if turn is not None:
+            return SandboxBusyClaim(
+                kind=SandboxBusyKind.INTERACTIVE_TURN,
+                detail=f"session {session_id} turn {turn.turn_id} is {turn.status}",
+            )
+    return None
+
+
+def _scheduled_run_claim(
+    db_session: DBSession,
+    sandbox: Sandbox,
+    cache: CacheBackend,  # noqa: ARG001
+) -> SandboxBusyClaim | None:
+    """A scheduled run that has not finished, including one awaiting approval —
+    that one waits on a person and will resume in this sandbox."""
+    run = get_unfinished_run_for_user(db_session=db_session, user_id=sandbox.user_id)
+    if run is None:
+        return None
+    return SandboxBusyClaim(
+        kind=SandboxBusyKind.SCHEDULED_RUN,
+        detail=f"run {run.id} is {run.status.value}",
+    )

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -3,6 +3,8 @@ interactive (``create_session__no_commit``) and headless
 (``ensure_sandbox_running``) flows."""
 
 import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from uuid import UUID
@@ -523,21 +525,77 @@ def list_snapshotable_session_workspaces(
     return existing_session_ids
 
 
+@contextmanager
+def _exclude_session_creation(lock: RedisLock) -> Iterator[bool]:
+    """Hold the session-creation lock, yielding whether it was acquired. Never
+    blocks: a session being created is a reason to skip, not to wait."""
+    acquired = lock.acquire(blocking=False)
+    try:
+        yield acquired
+    finally:
+        if acquired and lock.owned():
+            lock.release()
+
+
+@contextmanager
+def sandbox_mutation_window(
+    db_session: DBSession,
+    sandbox: Sandbox,
+    session_creation_lock: RedisLock,
+    *,
+    still_eligible: Callable[[], bool],
+) -> Iterator[bool]:
+    """The exclusive window in which a live sandbox may be mutated, yielding
+    whether the caller may proceed.
+
+    Deciding and acting can be minutes apart, so all three preconditions are
+    checked here: session creation excluded for the whole block, the row still
+    RUNNING, and the caller's own reason still valid. ``still_eligible`` owns its
+    logging — only the caller knows what it was waiting for.
+    """
+    with _exclude_session_creation(session_creation_lock) as excluded:
+        if not excluded:
+            logger.info(
+                "Sandbox %s has a session creation in progress; skipping",
+                sandbox.id,
+            )
+            yield False
+            return
+
+        db_session.refresh(sandbox)
+        if sandbox.status != SandboxStatus.RUNNING:
+            logger.info(
+                "Sandbox %s is %s rather than RUNNING; skipping",
+                sandbox.id,
+                sandbox.status.value,
+            )
+            yield False
+            return
+
+        yield still_eligible()
+
+
 def sleep_sandbox(
     db_session: DBSession,
     sandbox_manager: SandboxManager,
     sandbox: Sandbox,
     tenant_id: str,
     session_creation_lock: RedisLock,
-) -> None:
-    """Snapshot an idle ``RUNNING`` sandbox, terminate its pod, and mark it
+    *,
+    still_eligible: Callable[[], bool] | None = None,
+) -> bool:
+    """Snapshot a ``RUNNING`` sandbox, terminate its pod, and mark it
     ``SLEEPING``. Commits on success; on abort the sandbox stays ``RUNNING``.
+    Returns whether it slept.
 
     Invariant: snapshot before terminate, fail-closed — a snapshot failure on
     a reachable pod aborts the reap so the next sweep retries, while an
     unreachable pod is terminated anyway (its workspace is unrecoverable;
-    never pin it RUNNING forever). Idleness is re-checked right before the
-    kill since snapshotting can take minutes.
+    never pin it RUNNING forever).
+
+    Snapshotting can take minutes, so ``still_eligible`` re-checks the reason for
+    sleeping right before the kill. It defaults to idleness; a caller sleeping a
+    sandbox that is *not* idle — one being recycled — passes its own.
     """
     sandbox_id = sandbox.id
 
@@ -556,7 +614,7 @@ def sleep_sandbox(
                     sandbox_id,
                     e,
                 )
-                return
+                return False
             logger.warning(
                 "Sandbox %s pod unreachable; sleeping "
                 "without a fresh opencode history snapshot: %s",
@@ -564,22 +622,19 @@ def sleep_sandbox(
                 e,
             )
 
-    if not session_creation_lock.acquire(blocking=False):
-        logger.info(
-            "Skipping idle sandbox %s while a session is being created",
-            sandbox_id,
-        )
-        return
-    try:
+    with _exclude_session_creation(session_creation_lock) as excluded:
+        if not excluded:
+            logger.info(
+                "Skipping sandbox %s while a session is being created",
+                sandbox_id,
+            )
+            return False
         session_ids = list_snapshotable_session_workspaces(
             db_session,
             sandbox_manager,
             sandbox,
             session_creation_lock,
         )
-    finally:
-        if session_creation_lock.owned():
-            session_creation_lock.release()
 
     snapshot_failed = False
     for session_id in session_ids:
@@ -624,7 +679,7 @@ def sleep_sandbox(
                 "leaving it RUNNING to retry next cycle",
                 sandbox_id,
             )
-            return
+            return False
         pod_unreachable = True
         logger.warning(
             "Sandbox %s pod is unreachable; "
@@ -633,15 +688,9 @@ def sleep_sandbox(
             sandbox_id,
         )
 
-    # Do not block session creation during snapshots. Reacquire its lock before
-    # the final check so a workspace cannot appear between the rescan and kill.
-    if not session_creation_lock.acquire(blocking=False):
-        logger.info(
-            "Sandbox %s has a session creation in progress; skipping reap",
-            sandbox_id,
-        )
-        return
-    try:
+    def still_reapable() -> bool:
+        """A workspace can appear while the unlocked snapshotting runs, and
+        whatever made this sandbox reapable may have stopped being true."""
         if not pod_unreachable:
             current_session_ids = list_snapshotable_session_workspaces(
                 db_session,
@@ -657,16 +706,23 @@ def sleep_sandbox(
                     sandbox_id,
                     len(new_session_ids),
                 )
-                return
+                return False
 
-        # Snapshotting above can take minutes; re-check idleness right before
-        # the kill.
-        db_session.refresh(sandbox)
-        if sandbox.status != SandboxStatus.RUNNING or not is_sandbox_idle(
-            sandbox, datetime.now(timezone.utc)
-        ):
+        if still_eligible is not None:
+            return still_eligible()
+        if not is_sandbox_idle(sandbox, datetime.now(timezone.utc)):
             logger.info("Sandbox %s went active mid-sweep; skipping reap", sandbox_id)
-            return
+            return False
+        return True
+
+    with sandbox_mutation_window(
+        db_session,
+        sandbox,
+        session_creation_lock,
+        still_eligible=still_reapable,
+    ) as may_reap:
+        if not may_reap:
+            return False
 
         # Terminate the pod (but keep the sandbox record).
         sandbox_manager.terminate(sandbox_id)
@@ -683,9 +739,7 @@ def sleep_sandbox(
         update_sandbox_status__no_commit(db_session, sandbox_id, SandboxStatus.SLEEPING)
         db_session.commit()
         logger.info("Sandbox %s is now sleeping", sandbox_id)
-    finally:
-        if session_creation_lock.owned():
-            session_creation_lock.release()
+        return True
 
 
 def mark_sandbox_provisioning(db_session: DBSession, sandbox: Sandbox) -> None:

--- a/backend/onyx/server/features/build/session/sandbox_recycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_recycle.py
@@ -1,0 +1,208 @@
+"""Moving live sandboxes onto the current image.
+
+Sandboxes are owned by no controller, so a deploy leaves every running one on the
+old image indefinitely. Which ones are behind is derived from what is actually
+running, not recorded, so there is nothing to drift and a restart loses nothing.
+
+Two moments protect a chat: a sandbox with work queued or running is skipped, and
+the prompt slots for its sessions are held across the move so one starting in
+between is caught rather than interrupted. A busy sandbox just waits for the next
+pass — recycling is never urgent enough to interrupt someone.
+"""
+
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+
+from redis.lock import Lock as RedisLock
+from sqlalchemy.orm import Session as DBSession
+
+from onyx.db.models import Sandbox
+from onyx.redis.tenant_redis_client import TenantRedisClient
+from onyx.server.features.build.db.build_session import (
+    get_active_session_ids_for_user,
+)
+from onyx.server.features.build.db.sandbox import get_running_sandboxes
+from onyx.server.features.build.sandbox.base import SandboxManager
+from onyx.server.features.build.sandbox.models import (
+    ImageMoveOutcome,
+    SandboxImageTarget,
+)
+from onyx.server.features.build.session.locks import get_session_creation_lock
+from onyx.server.features.build.session.sandbox_busy import sandbox_busy_claim
+from onyx.server.features.build.session.sandbox_lifecycle import sleep_sandbox
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Bounds a rollout to a trickle of restarts per pass. Evaluation is deliberately
+# unbounded: skipping is not recycling, so busy sandboxes at the front of a stable
+# ordering would otherwise starve the ones behind them.
+_MAX_RECYCLES_PER_PASS = 10
+
+
+def recycle_sandboxes_on_stale_images(
+    db_session: DBSession,
+    sandbox_manager: SandboxManager,
+    redis_client: TenantRedisClient,
+    tenant_id: str,
+) -> None:
+    """Move as many sandboxes onto the current image as is safe right now.
+
+    Safe on any cadence and from any process: everything is recomputed from live
+    state, so a dropped, duplicated, or half-finished pass costs only time.
+    """
+    state = sandbox_manager.get_image_state()
+    target = state.target
+    stale_ids = state.stale_sandbox_ids()
+    if target is None or not stale_ids:
+        return
+
+    stale = [
+        sandbox
+        for sandbox in get_running_sandboxes(db_session)
+        if sandbox.id in stale_ids
+    ]
+    if not stale:
+        return
+
+    logger.info("%s sandbox(es) are behind image %s", len(stale), target.digest[:19])
+
+    recycled = 0
+    for sandbox in stale:
+        if recycled >= _MAX_RECYCLES_PER_PASS:
+            logger.info(
+                "Reached the per-pass recycle limit; %s sandbox(es) left for the "
+                "next pass",
+                len(stale) - recycled,
+            )
+            break
+
+        claim = sandbox_busy_claim(db_session, sandbox)
+        if claim is not None:
+            logger.info(
+                "Leaving sandbox %s on the old image: %s", sandbox.id, claim.detail
+            )
+            continue
+
+        if _recycle_sandbox(
+            db_session, sandbox_manager, redis_client, sandbox, target, tenant_id
+        ):
+            recycled += 1
+
+
+def _recycle_sandbox(
+    db_session: DBSession,
+    sandbox_manager: SandboxManager,
+    redis_client: TenantRedisClient,
+    sandbox: Sandbox,
+    target: SandboxImageTarget,
+    tenant_id: str,
+) -> bool:
+    """Ask the backend to move the sandbox, and finish whatever it started.
+
+    Backends preserve different amounts — Kubernetes swaps the image under a live
+    pod, compose replaces the container but keeps the workspace volume — so this
+    reacts to what was done rather than choosing a strategy per backend. Anything
+    the backend cannot do falls through to rebuilding from snapshots.
+    """
+    outcome = ImageMoveOutcome.UNSUPPORTED
+    try:
+        with _no_prompts_in_flight(db_session, sandbox_manager, sandbox) as held:
+            if not held:
+                logger.info(
+                    "Sandbox %s started a prompt as we moved to recycle it; "
+                    "leaving it for the next pass",
+                    sandbox.id,
+                )
+                return False
+            outcome = sandbox_manager.move_to_image(sandbox.id, target)
+    except Exception:
+        logger.warning(
+            "Moving sandbox %s onto %s failed; falling back to rebuilding it",
+            sandbox.id,
+            target.digest[:19],
+            exc_info=True,
+        )
+        outcome = ImageMoveOutcome.UNSUPPORTED
+
+    if outcome is ImageMoveOutcome.MOVED:
+        logger.info("Recycled sandbox %s in place", sandbox.id)
+        return True
+
+    return _rebuild_sandbox(
+        db_session, sandbox_manager, redis_client, sandbox, target, tenant_id
+    )
+
+
+def _rebuild_sandbox(
+    db_session: DBSession,
+    sandbox_manager: SandboxManager,
+    redis_client: TenantRedisClient,
+    sandbox: Sandbox,
+    target: SandboxImageTarget,
+    tenant_id: str,
+) -> bool:
+    """Snapshot and sleep, so the user's next request provisions a fresh sandbox.
+
+    The last resort, and the same path the idle reaper uses. Deliberately outside
+    the prompt barrier: snapshotting takes minutes, and ``sleep_sandbox``
+    re-checks eligibility under its own lock before the kill anyway.
+    """
+    lock: RedisLock = get_session_creation_lock(redis_client, sandbox.user_id)
+
+    def still_worth_rebuilding() -> bool:
+        """Minutes have passed: only kill a sandbox still stale and still free."""
+        claim = sandbox_busy_claim(db_session, sandbox)
+        if claim is not None:
+            logger.info(
+                "Sandbox %s took on work mid-rebuild: %s", sandbox.id, claim.detail
+            )
+            return False
+        digest = sandbox_manager.get_image_state().live_digests.get(sandbox.id)
+        if digest is None or digest == target.digest:
+            logger.info(
+                "Sandbox %s is no longer behind; skipping the rebuild", sandbox.id
+            )
+            return False
+        return True
+
+    slept = sleep_sandbox(
+        db_session,
+        sandbox_manager,
+        sandbox,
+        tenant_id,
+        lock,
+        still_eligible=still_worth_rebuilding,
+    )
+    if slept:
+        logger.info(
+            "Sandbox %s slept; its next request will provision on %s",
+            sandbox.id,
+            target.digest[:19],
+        )
+    return slept
+
+
+@contextmanager
+def _no_prompts_in_flight(
+    db_session: DBSession,
+    sandbox_manager: SandboxManager,
+    sandbox: Sandbox,
+) -> Iterator[bool]:
+    """Hold every prompt slot the sandbox's sessions use, yielding whether they
+    were all free.
+
+    The same lock the chat path takes, so it is both check and barrier with no
+    window between, and a prompt path added later is covered for free. Fails
+    *closed*: an unreachable cache cannot tell us a prompt is not running.
+    """
+    session_ids = get_active_session_ids_for_user(sandbox.user_id, db_session)
+    with ExitStack() as stack:
+        yield all(
+            stack.enter_context(
+                sandbox_manager.prompt_slot(
+                    sandbox.id, session_id, acquire_timeout=0.0, fail_open=False
+                )
+            ).acquired
+            for session_id in session_ids
+        )

--- a/backend/onyx/server/features/build/session/sandbox_recycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_recycle.py
@@ -17,6 +17,7 @@ from redis.lock import Lock as RedisLock
 from sqlalchemy.orm import Session as DBSession
 
 from onyx.db.models import Sandbox
+from onyx.db.users import fetch_user_by_id
 from onyx.redis.tenant_redis_client import TenantRedisClient
 from onyx.server.features.build.db.build_session import (
     get_active_session_ids_for_user,
@@ -29,7 +30,10 @@ from onyx.server.features.build.sandbox.models import (
 )
 from onyx.server.features.build.session.locks import get_session_creation_lock
 from onyx.server.features.build.session.sandbox_busy import sandbox_busy_claim
-from onyx.server.features.build.session.sandbox_lifecycle import sleep_sandbox
+from onyx.server.features.build.session.sandbox_lifecycle import (
+    provision_sandbox,
+    sleep_sandbox,
+)
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -115,6 +119,16 @@ def _recycle_sandbox(
                     sandbox.id,
                 )
                 return False
+            # Compose discards the runtime, and opencode history lives in it.
+            if not _history_captured(sandbox_manager, sandbox, tenant_id):
+                return _rebuild_sandbox(
+                    db_session,
+                    sandbox_manager,
+                    redis_client,
+                    sandbox,
+                    target,
+                    tenant_id,
+                )
             outcome = sandbox_manager.move_to_image(sandbox.id, target)
     except Exception:
         logger.warning(
@@ -129,9 +143,75 @@ def _recycle_sandbox(
         logger.info("Recycled sandbox %s in place", sandbox.id)
         return True
 
+    if outcome is ImageMoveOutcome.NEEDS_PROVISION:
+        return _provision_after_move(db_session, sandbox_manager, sandbox, tenant_id)
+
     return _rebuild_sandbox(
         db_session, sandbox_manager, redis_client, sandbox, target, tenant_id
     )
+
+
+def _history_captured(
+    sandbox_manager: SandboxManager,
+    sandbox: Sandbox,
+    tenant_id: str,
+) -> bool:
+    """Snapshot the opencode history so a discarded runtime cannot take the chat
+    log with it. Fail closed: rebuilding snapshots anyway, so it keeps it."""
+    if not sandbox_manager.supports_opencode_history_persistence:
+        return False
+    try:
+        sandbox_manager.create_opencode_history_snapshot(sandbox.id, tenant_id)
+        return True
+    except Exception:
+        logger.warning(
+            "Could not capture opencode history for sandbox %s; leaving it in place",
+            sandbox.id,
+            exc_info=True,
+        )
+        return False
+
+
+def _provision_after_move(
+    db_session: DBSession,
+    sandbox_manager: SandboxManager,
+    sandbox: Sandbox,
+    tenant_id: str,
+) -> bool:
+    """Provision a sandbox whose runtime was discarded but whose workspace was
+    kept.
+
+    Reuses ``provision_sandbox`` verbatim, so the sandbox returns with a fresh
+    PAT, restored history, and managed content re-pushed against the new image.
+    """
+    user = fetch_user_by_id(db_session, sandbox.user_id)
+    if user is None:
+        logger.error(
+            "Sandbox %s has no user row and no runtime; the readiness path will "
+            "recover it",
+            sandbox.id,
+        )
+        return False
+
+    # No runtime from here: a failure leaves the row RUNNING with nothing behind
+    # it, which the readiness path recovers on the user's next request.
+    try:
+        provision_sandbox(
+            db_session, sandbox_manager, sandbox, user, sandbox.user_id, tenant_id
+        )
+        db_session.commit()
+    except Exception:
+        logger.error(
+            "Sandbox %s lost its runtime and could not be provisioned again; the "
+            "readiness path will recover it",
+            sandbox.id,
+            exc_info=True,
+        )
+        db_session.rollback()
+        return False
+
+    logger.info("Replaced sandbox %s runtime, keeping its workspaces", sandbox.id)
+    return True
 
 
 def _rebuild_sandbox(

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_busy_claims.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_busy_claims.py
@@ -1,0 +1,120 @@
+"""Busy-ness claims against real Postgres.
+
+The interactive-turn probe is covered by unit tests (its state lives in the
+cache), but the scheduled-run probe is a join plus a "not terminal" filter — the
+kind of query mocks will happily agree with while it is wrong. This exercises it
+for real.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+from sqlalchemy.orm import Session
+
+import onyx.server.features.build.session.sandbox_busy as sandbox_busy
+from onyx.db.enums import (
+    ScheduledTaskRunStatus,
+    ScheduledTaskStatus,
+    ScheduledTaskTriggerSource,
+)
+from onyx.db.models import ScheduledTask, ScheduledTaskRun, User
+from onyx.server.features.build.session.sandbox_busy import (
+    SandboxBusyKind,
+    sandbox_busy_claim,
+)
+from tests.external_dependency_unit.craft.db_helpers import make_sandbox, make_user
+
+
+@pytest.fixture(autouse=True)
+def _no_interactive_turns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate the scheduled-run probe: with no ACTIVE sessions the turn probe
+    can't fire, so any claim here comes from Postgres."""
+    monkeypatch.setattr(
+        sandbox_busy, "get_active_session_ids_for_user", lambda *_a, **_kw: []
+    )
+
+
+def _seed_run(
+    db_session: Session, user: User, status: ScheduledTaskRunStatus
+) -> ScheduledTaskRun:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    task = ScheduledTask(
+        user_id=user.id,
+        name="nightly-report",
+        prompt="Summarise yesterday's events",
+        cron_expression="0 9 * * *",
+        editor_mode="advanced",
+        status=ScheduledTaskStatus.ACTIVE,
+        next_run_at=now + datetime.timedelta(days=1),
+    )
+    db_session.add(task)
+    db_session.flush()
+    run = ScheduledTaskRun(
+        task_id=task.id,
+        status=status,
+        trigger_source=ScheduledTaskTriggerSource.SCHEDULED,
+        started_at=now,
+    )
+    db_session.add(run)
+    db_session.commit()
+    db_session.refresh(run)
+    return run
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        ScheduledTaskRunStatus.QUEUED,
+        ScheduledTaskRunStatus.RUNNING,
+        ScheduledTaskRunStatus.AWAITING_APPROVAL,
+    ],
+)
+def test_unfinished_run_claims_the_sandbox(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+    status: ScheduledTaskRunStatus,
+) -> None:
+    user = make_user(db_session)
+    sandbox = make_sandbox(db_session, user)
+    run = _seed_run(db_session, user, status)
+
+    claim = sandbox_busy_claim(db_session, sandbox)
+
+    assert claim is not None
+    assert claim.kind is SandboxBusyKind.SCHEDULED_RUN
+    assert str(run.id) in claim.detail
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        ScheduledTaskRunStatus.SUCCEEDED,
+        ScheduledTaskRunStatus.FAILED,
+        ScheduledTaskRunStatus.SKIPPED,
+    ],
+)
+def test_finished_run_leaves_the_sandbox_free(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+    status: ScheduledTaskRunStatus,
+) -> None:
+    user = make_user(db_session)
+    sandbox = make_sandbox(db_session, user)
+    _seed_run(db_session, user, status)
+
+    assert sandbox_busy_claim(db_session, sandbox) is None
+
+
+def test_another_users_run_does_not_claim_this_sandbox(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    """Sandboxes are per user; the join is what keeps one tenant's busy
+    scheduled task from freezing everyone else's recycles."""
+    owner = make_user(db_session)
+    sandbox = make_sandbox(db_session, owner)
+    _seed_run(db_session, make_user(db_session), ScheduledTaskRunStatus.RUNNING)
+
+    assert sandbox_busy_claim(db_session, sandbox) is None

--- a/backend/tests/external_dependency_unit/craft_helm/test_pod_spec.py
+++ b/backend/tests/external_dependency_unit/craft_helm/test_pod_spec.py
@@ -120,6 +120,18 @@ def _helm_template_cmd(extra_args: list[str] | None = None) -> list[str]:
     ]
 
 
+def _render_template(template: str, extra_args: list[str] | None = None) -> str:
+    """Render one chart template, for assertions that aren't about the pod."""
+    result = subprocess.run(
+        [*_helm_template_cmd(extra_args), "--show-only", template],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        _skip_or_fail(f"helm template failed (chart deps?): {result.stderr.strip()}")
+    return result.stdout
+
+
 def _render_pod_template_yaml(extra_args: list[str] | None = None) -> str:
     """Render the sandbox-pod PodTemplate from the chart."""
     cmd = [
@@ -654,3 +666,28 @@ def test_service_exposes_push_daemon_port() -> None:
         tenant_id="t-1",
     )
     assert PUSH_DAEMON_PORT in {p.port for p in svc.spec.ports}
+
+
+def test_sandbox_manager_can_patch_pods() -> None:
+    """`swap_to_image` moves a live sandbox onto a new image by mutating its
+    container images, which restarts them in place and leaves the pod — and so
+    the session workspace — intact.
+
+    Without `patch` the api-server silently loses that path and falls back to
+    destroying and rebuilding the sandbox, costing the user a re-provision and a
+    restore. Silent degradation is why this is asserted here.
+    """
+    docs = yaml.safe_load_all(_render_template("templates/sandbox-rbac.yaml"))
+    pod_verbs = {
+        verb
+        for doc in docs
+        if doc
+        and doc["kind"] == "Role"
+        and doc["metadata"]["labels"].get("app.kubernetes.io/component")
+        == "sandbox-manager"
+        for rule in doc["rules"]
+        if "pods" in rule["resources"]
+        for verb in rule["verbs"]
+    }
+
+    assert "patch" in pod_verbs

--- a/backend/tests/external_dependency_unit/craft_helm/test_sandbox_image_prepuller.py
+++ b/backend/tests/external_dependency_unit/craft_helm/test_sandbox_image_prepuller.py
@@ -172,35 +172,79 @@ def test_prepuller_scheduling_matches_the_sandbox_pod() -> None:
     assert prepuller["tolerations"] == sandbox["tolerations"]
 
 
-def test_prepuller_stays_running_to_pin_layers() -> None:
-    """The kubelet only exempts images referenced by a *running* pod from image
-    GC, so a one-shot pull would leave the layers evictable.
+def test_prepuller_exits_periodically_to_re_resolve_the_tag() -> None:
+    """The restart *is* the image check.
 
-    The command must also be portable: `sleep infinity` is a GNU coreutils
-    extension that dies on busybox/alpine, and a CrashLooping prepuller unpins
-    the image silently.
+    A kubelet re-resolves a tag to a digest only when it starts a container, so a
+    prepuller that never exits never asks the registry whether a mutable tag has
+    moved — and on the default deployment (`global.version: latest`) no node
+    would ever notice new content.
+
+    Two properties have to hold together: it exits on a timer (so the tag gets
+    re-resolved), and it spends essentially all its time running (so the kubelet
+    keeps exempting the image from GC). Also portable: `sleep infinity` is a GNU
+    coreutils extension that dies on busybox/alpine.
     """
     container = _prepuller_pod_spec()["containers"][0]
-    assert container["command"] == ["sh", "-c", "while :; do sleep 86400; done"]
+    assert container["command"] == ["sh", "-c", "sleep 900"]
 
 
-def test_prepuller_pull_policy_matches_the_sandbox_pod() -> None:
-    """Pinning the prepuller to IfNotPresent while the sandbox pods run Always
-    is the tag drift this template exists to prevent, just one level down: on a
-    mutable tag the sandboxes fetch the new digest and the prepuller holds the
-    old one resident and GC-exempt, with nothing to restart it."""
-    args = ["--set", "configMap.SANDBOX_IMAGE_PULL_POLICY=Always"]
+def test_prepuller_recheck_interval_is_configurable() -> None:
+    container = _prepuller_pod_spec(
+        ["--set", "sandboxImagePrepull.recheckIntervalSeconds=1800"]
+    )["containers"][0]
+    assert container["command"] == ["sh", "-c", "sleep 1800"]
+
+
+def test_prepuller_recheck_interval_is_floored() -> None:
+    """The kubelet backs off restarts and only resets the backoff counter once a
+    container has run for ~10 minutes, so a shorter interval stretches itself out
+    anyway — noisily, and with the image briefly unpinned each time."""
+    container = _prepuller_pod_spec(
+        ["--set", "sandboxImagePrepull.recheckIntervalSeconds=30"]
+    )["containers"][0]
+    assert container["command"] == ["sh", "-c", "sleep 600"]
+
+
+def test_prepuller_always_pulls_regardless_of_the_sandbox_pull_policy() -> None:
+    """The prepuller deliberately diverges from the shared pull policy.
+
+    It is the only thing in the deployment that asks the registry whether a
+    mutable tag has moved, and a kubelet only re-resolves on a pull it is told to
+    make. IfNotPresent here would leave every node pinned to the first digest it
+    ever pulled, which is precisely the drift the recheck exists to catch.
+
+    Sandbox pods keep the configured policy: they are created from a ref the
+    api-server has already resolved, so they have nothing to re-resolve.
+    """
+    args = ["--set", "configMap.SANDBOX_IMAGE_PULL_POLICY=IfNotPresent"]
     prepuller = _prepuller_pod_spec(args)["containers"][0]
     sandbox = yaml.safe_load(_render(_PODTEMPLATE_TEMPLATE, args))["template"]["spec"]
 
     assert prepuller["imagePullPolicy"] == "Always"
-    assert {c["imagePullPolicy"] for c in sandbox["containers"]} == {"Always"}
+    assert {c["imagePullPolicy"] for c in sandbox["containers"]} == {"IfNotPresent"}
 
 
-def test_prepuller_pull_policy_defaults_to_if_not_present() -> None:
-    """The chart default must not re-pull on every restart."""
-    container = _prepuller_pod_spec()["containers"][0]
-    assert container["imagePullPolicy"] == "IfNotPresent"
+def test_prepuller_identity_matches_what_the_api_server_queries() -> None:
+    """The api-server reads the current sandbox image off these pods: it lists
+    them by component label and matches the container by name to learn which
+    digest a node resolved. Renaming either silently turns image-driven recycling
+    off, since "no prepuller pods" is deliberately read as "cannot confirm".
+    """
+    pod_template = _prepuller()["spec"]["template"]
+
+    assert (
+        pod_template["metadata"]["labels"]["app.kubernetes.io/component"]
+        == "sandbox-image-prepuller"
+    )
+    assert [c["name"] for c in pod_template["spec"]["containers"]] == ["prepuller"]
+
+
+def test_sandbox_pod_pull_policy_defaults_to_if_not_present() -> None:
+    """Sandbox pods keep the conservative default — they are created from a ref
+    the api-server already resolved, so re-pulling on every start buys nothing."""
+    sandbox = yaml.safe_load(_render(_PODTEMPLATE_TEMPLATE))["template"]["spec"]
+    assert {c["imagePullPolicy"] for c in sandbox["containers"]} == {"IfNotPresent"}
 
 
 def test_prepuller_requests_ephemeral_storage() -> None:

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_image_swap.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_image_swap.py
@@ -1,0 +1,147 @@
+"""Moving a live sandbox onto a new image without rebuilding it.
+
+Cluster behaviour was verified separately on kind (k8s 1.35): the container
+restarts even under ``restartPolicy: Never``, the emptyDir survives, and the
+sidecar can be patched. These cover what that can't tell us — that we watch the
+right signal for "the swap took", and that every refusal declines.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import pytest
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+
+import onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager as ksm
+from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
+    KubernetesSandboxManager,
+)
+from onyx.server.features.build.sandbox.models import (
+    ImageMoveOutcome,
+    SandboxImageTarget,
+)
+
+SANDBOX_ID = UUID("12345678-1234-1234-1234-1234567890ab")
+OLD_DIGEST = "sha256:" + "a" * 64
+NEW_DIGEST = "sha256:" + "b" * 64
+TARGET = SandboxImageTarget(
+    ref=f"docker.io/onyxdotapp/sandbox@{NEW_DIGEST}", digest=NEW_DIGEST
+)
+
+
+@pytest.fixture(autouse=True)
+def _fast_swap_polling(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the give-up path from taking the production minute."""
+    monkeypatch.setattr(ksm, "_IMAGE_SWAP_TIMEOUT_SECONDS", 0.3)
+    monkeypatch.setattr(ksm, "_IMAGE_SWAP_POLL_SECONDS", 0.01)
+
+
+def _pod(*, digest: str, ready: bool = True) -> client.V1Pod:
+    pod = SimpleNamespace(
+        status=SimpleNamespace(
+            container_statuses=[
+                SimpleNamespace(
+                    name="sandbox",
+                    image="docker.io/onyxdotapp/sandbox:latest",
+                    image_id=f"docker.io/onyxdotapp/sandbox@{digest}",
+                    ready=ready,
+                    state=SimpleNamespace(running=object() if ready else None),
+                )
+            ],
+            init_container_statuses=[],
+        ),
+    )
+    return cast(client.V1Pod, pod)
+
+
+def _manager(
+    *, pods: list[client.V1Pod], sidecar_healthy: bool = True
+) -> tuple[KubernetesSandboxManager, MagicMock]:
+    """A manager whose pod reads walk ``pods``, holding the last one."""
+    core_api = MagicMock()
+    reads = list(pods)
+
+    def next_pod(*_a: Any, **_kw: Any) -> client.V1Pod:
+        return reads.pop(0) if len(reads) > 1 else reads[0]
+
+    core_api.read_namespaced_pod.side_effect = next_pod
+    mgr: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
+    mgr._core_api = core_api  # type: ignore[attr-defined]
+    mgr._namespace = "sandbox-test"  # type: ignore[attr-defined]
+    mgr._sidecar_client = MagicMock()  # type: ignore[attr-defined]
+    mgr._sidecar_client.is_healthy.return_value = sidecar_healthy
+    return mgr, core_api
+
+
+def test_swap_patches_both_live_containers() -> None:
+    """One patch, so a refusal can't leave a new agent on an old daemon."""
+    mgr, core_api = _manager(pods=[_pod(digest=OLD_DIGEST), _pod(digest=NEW_DIGEST)])
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is ImageMoveOutcome.MOVED
+
+    body = core_api.patch_namespaced_pod.call_args.kwargs["body"]
+    assert body["spec"]["containers"] == [{"name": "sandbox", "image": TARGET.ref}]
+    assert body["spec"]["initContainers"] == [{"name": "sidecar", "image": TARGET.ref}]
+
+
+def test_swap_waits_for_the_runtime_not_the_spec() -> None:
+    """The spec updates at once; only the reported digest means the kubelet
+    actually restarted the container."""
+    mgr, _ = _manager(pods=[_pod(digest=OLD_DIGEST)])
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is ImageMoveOutcome.UNSUPPORTED
+
+
+def test_swap_waits_for_readiness() -> None:
+    """A restarted container that isn't ready cannot take a turn."""
+    mgr, _ = _manager(pods=[_pod(digest=NEW_DIGEST, ready=False)])
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is ImageMoveOutcome.UNSUPPORTED
+
+
+def test_swap_waits_for_the_sidecar() -> None:
+    mgr, _ = _manager(pods=[_pod(digest=NEW_DIGEST)], sidecar_healthy=False)
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is ImageMoveOutcome.UNSUPPORTED
+
+
+@pytest.mark.parametrize("status", [403, 422])
+def test_swap_declines_when_the_cluster_refuses(status: int) -> None:
+    """No `patch` permission, or a cluster rejecting the mutation. Both fall
+    back to rebuilding rather than raising."""
+    mgr, core_api = _manager(pods=[_pod(digest=OLD_DIGEST)])
+    core_api.patch_namespaced_pod.side_effect = ApiException(status=status)
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is ImageMoveOutcome.UNSUPPORTED
+
+
+def test_swap_declines_when_the_pod_is_gone() -> None:
+    mgr, core_api = _manager(pods=[_pod(digest=OLD_DIGEST)])
+    core_api.read_namespaced_pod.side_effect = ApiException(status=404)
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is ImageMoveOutcome.UNSUPPORTED
+    core_api.patch_namespaced_pod.assert_not_called()
+
+
+def test_swap_declines_when_the_pod_vanishes_mid_swap() -> None:
+    """Evicted between the patch and the restart."""
+    mgr, core_api = _manager(pods=[_pod(digest=OLD_DIGEST)])
+    core_api.read_namespaced_pod.side_effect = [
+        _pod(digest=OLD_DIGEST),
+        ApiException(status=404),
+    ]
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is ImageMoveOutcome.UNSUPPORTED
+
+
+def test_kubernetes_never_asks_the_caller_to_provision() -> None:
+    """Workspaces are emptyDirs that die with the pod, so they cannot outlive
+    a discarded runtime."""
+    mgr, _ = _manager(pods=[_pod(digest=OLD_DIGEST)])
+
+    assert mgr.move_to_image(SANDBOX_ID, TARGET) is not ImageMoveOutcome.NEEDS_PROVISION

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_image_target.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_image_target.py
@@ -1,0 +1,303 @@
+"""Establishing which image sandboxes should run, and which are behind.
+
+The load-bearing subtlety: "should run" has to mean *and already downloaded*.
+Restarting a sandbox onto an image its host lacks is worse than leaving it a
+version behind, so anything unconfirmed declines.
+"""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import pytest
+from docker.errors import APIError, NotFound
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+
+import onyx.server.features.build.sandbox.docker.docker_sandbox_manager as dsm
+from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
+    KubernetesSandboxManager,
+)
+from onyx.server.features.build.sandbox.models import sandbox_image_digest
+
+TAG_REF = "docker.io/onyxdotapp/sandbox:latest"
+DIGEST_A = "sha256:" + "a" * 64
+DIGEST_B = "sha256:" + "b" * 64
+SANDBOX_A = UUID(int=1)
+SANDBOX_B = UUID(int=2)
+
+
+# --- digest normalisation ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "reported,expected",
+    [
+        (f"docker.io/onyxdotapp/sandbox@{DIGEST_A}", DIGEST_A),
+        (DIGEST_A, DIGEST_A),
+        (None, None),
+        ("", None),
+    ],
+)
+def test_only_the_digest_is_comparable(
+    reported: str | None, expected: str | None
+) -> None:
+    """Runtimes differ on prefixing the repository; only the digest is shared."""
+    assert sandbox_image_digest(reported) == expected
+
+
+# --- Kubernetes: the target comes from the prepuller ------------------------
+
+
+def _prepuller_pod(ref: str, image_id: str | None) -> client.V1Pod:
+    pod = SimpleNamespace(
+        metadata=SimpleNamespace(name="prepuller-abc", labels={}),
+        spec=SimpleNamespace(containers=[SimpleNamespace(name="prepuller", image=ref)]),
+        status=SimpleNamespace(
+            container_statuses=[
+                SimpleNamespace(name="prepuller", image=ref, image_id=image_id)
+            ],
+            init_container_statuses=[],
+        ),
+    )
+    return cast(client.V1Pod, pod)
+
+
+def _sandbox_pod(sandbox_id: UUID | str, image_id: str | None) -> client.V1Pod:
+    pod = SimpleNamespace(
+        metadata=SimpleNamespace(
+            name="sandbox-abc", labels={"onyx.app/sandbox-id": str(sandbox_id)}
+        ),
+        spec=SimpleNamespace(
+            containers=[SimpleNamespace(name="sandbox", image=TAG_REF)]
+        ),
+        status=SimpleNamespace(
+            container_statuses=[
+                SimpleNamespace(name="sandbox", image=TAG_REF, image_id=image_id)
+            ],
+            init_container_statuses=[],
+        ),
+    )
+    return cast(client.V1Pod, pod)
+
+
+def _k8s(prepullers: list[client.V1Pod], sandboxes: list[client.V1Pod] | None = None):
+    core_api = MagicMock()
+
+    def listed(*_a: Any, **kwargs: Any) -> SimpleNamespace:
+        selector = kwargs.get("label_selector", "")
+        items = prepullers if "prepuller" in selector else (sandboxes or [])
+        return SimpleNamespace(items=items)
+
+    core_api.list_namespaced_pod.side_effect = listed
+    mgr: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
+    mgr._core_api = core_api  # type: ignore[attr-defined]
+    mgr._namespace = "sandbox-test"  # type: ignore[attr-defined]
+    mgr._image_target_cache = None  # type: ignore[attr-defined]
+    return mgr, core_api
+
+
+def test_agreed_prepull_gives_a_digest_pinned_target() -> None:
+    """Agreement is what confirms the image is current *and* present. Pinned,
+    because patching a tag onto a pod already running it is not a change."""
+    mgr, _ = _k8s(
+        [_prepuller_pod(TAG_REF, f"docker.io/onyxdotapp/sandbox@{DIGEST_A}")] * 3
+    )
+
+    target = mgr.get_image_state().target
+
+    assert target is not None
+    assert target.digest == DIGEST_A
+    assert target.ref == f"docker.io/onyxdotapp/sandbox@{DIGEST_A}"
+
+
+def test_bare_digest_report_is_repaired_into_a_pinned_ref() -> None:
+    """A runtime reporting a bare digest gets its repository from the ref."""
+    mgr, _ = _k8s([_prepuller_pod(TAG_REF, DIGEST_A)])
+
+    target = mgr.get_image_state().target
+
+    assert target is not None
+    assert target.ref == f"docker.io/onyxdotapp/sandbox@{DIGEST_A}"
+
+
+def test_disagreeing_nodes_yield_no_target() -> None:
+    """Mid-rollout: acting now sends some sandboxes to an image they lack."""
+    mgr, _ = _k8s(
+        [
+            _prepuller_pod(TAG_REF, DIGEST_A),
+            _prepuller_pod(TAG_REF, DIGEST_B),
+        ]
+    )
+
+    assert mgr.get_image_state().target is None
+
+
+def test_node_still_pulling_yields_no_target() -> None:
+    """No reported image ID means that node's pull is unfinished."""
+    mgr, _ = _k8s([_prepuller_pod(TAG_REF, DIGEST_A), _prepuller_pod(TAG_REF, None)])
+
+    assert mgr.get_image_state().target is None
+
+
+def test_absent_prepuller_yields_no_target() -> None:
+    """sandboxImagePrepull.enabled=false: nothing can vouch for a node."""
+    mgr, _ = _k8s([])
+
+    assert mgr.get_image_state().target is None
+
+
+def test_unreadable_prepuller_yields_no_target() -> None:
+    mgr, core_api = _k8s([])
+    core_api.list_namespaced_pod.side_effect = ApiException(status=403)
+
+    assert mgr.get_image_state().target is None
+
+
+def test_target_is_cached_across_calls() -> None:
+    """Read every pass. The fleet read is deliberately not cached: a stale view
+    of what sandboxes run would produce wrong work."""
+    mgr, core_api = _k8s([_prepuller_pod(TAG_REF, DIGEST_A)])
+
+    for _ in range(3):
+        mgr.get_image_state()
+
+    prepuller_reads = [
+        call
+        for call in core_api.list_namespaced_pod.call_args_list
+        if "prepuller" in call.kwargs.get("label_selector", "")
+    ]
+    assert len(prepuller_reads) == 1
+
+
+# --- Kubernetes: what the fleet is running ----------------------------------
+
+
+def test_fleet_digests_come_from_one_list_call() -> None:
+    mgr, core_api = _k8s(
+        [_prepuller_pod(TAG_REF, DIGEST_B)],
+        [_sandbox_pod(SANDBOX_A, DIGEST_A), _sandbox_pod(SANDBOX_B, DIGEST_B)],
+    )
+
+    digests = mgr.get_image_state().live_digests
+
+    assert digests == {SANDBOX_A: DIGEST_A, SANDBOX_B: DIGEST_B}
+    # One list for the fleet, one for the prepuller — not a call per sandbox.
+    assert core_api.list_namespaced_pod.call_count == 2
+
+
+def test_fleet_digests_skip_pods_that_cannot_be_tied_to_a_sandbox() -> None:
+    """A malformed label is not actionable and must not fail the whole scan."""
+    mgr, _ = _k8s(
+        [],
+        [
+            _sandbox_pod("not-a-uuid", DIGEST_A),
+            _sandbox_pod(SANDBOX_B, DIGEST_B),
+        ],
+    )
+
+    assert mgr.get_image_state().live_digests == {SANDBOX_B: DIGEST_B}
+
+
+def test_fleet_digests_omit_pods_that_have_not_reported() -> None:
+    """A pod still starting is already on the image it was created with."""
+    mgr, _ = _k8s([], [_sandbox_pod(SANDBOX_A, None)])
+
+    assert mgr.get_image_state().live_digests == {}
+
+
+def test_fleet_digests_survive_an_unlistable_namespace() -> None:
+    mgr, core_api = _k8s([], [])
+    core_api.list_namespaced_pod.side_effect = ApiException(status=403)
+
+    assert mgr.get_image_state().live_digests == {}
+
+
+# --- Docker -----------------------------------------------------------------
+
+
+def _docker(image: str = "onyxdotapp/sandbox:latest"):
+    mgr: dsm.DockerSandboxManager = object.__new__(dsm.DockerSandboxManager)
+    docker = MagicMock()
+    mgr._docker = docker  # type: ignore[attr-defined]
+    mgr._image = image  # type: ignore[attr-defined]
+    mgr._image_checked = False  # type: ignore[attr-defined]
+    mgr._image_check_lock = threading.Lock()  # type: ignore[attr-defined]
+    # Resolvable by default: the state read always resolves a target alongside
+    # the fleet, so a test about the fleet shouldn't have to care.
+    docker.images.get.return_value = SimpleNamespace(id=DIGEST_B)
+    docker.containers.list.return_value = []
+    return mgr, docker
+
+
+def _listed_container(sandbox_id: UUID | str, image_id: str) -> MagicMock:
+    container = MagicMock()
+    container.name = "sandbox-abc"
+    container.attrs = {
+        "Image": "onyxdotapp/sandbox:latest",
+        "ImageID": image_id,
+        "Labels": {"onyx.app/sandbox-id": str(sandbox_id)},
+    }
+    return container
+
+
+def test_docker_target_is_the_local_image() -> None:
+    """Local IDs on both sides catch a repointed tag without pinning."""
+    mgr, docker = _docker()
+    docker.images.get.return_value = SimpleNamespace(id=DIGEST_B)
+
+    target = mgr.get_image_state().target
+
+    assert target is not None
+    assert target.digest == DIGEST_B
+    assert target.ref == "onyxdotapp/sandbox:latest"
+
+
+def test_docker_unpulled_image_yields_no_target() -> None:
+    """An ID resolves only after a pull, so mid-pull declines for free."""
+    mgr, docker = _docker()
+    docker.images.get.side_effect = NotFound("absent")
+
+    assert mgr.get_image_state().target is None
+
+
+def test_docker_fleet_digests_use_the_list_shape() -> None:
+    """`list` reports ImageID; `inspect` nests the ref under Config."""
+    mgr, docker = _docker()
+    docker.containers.list.return_value = [_listed_container(SANDBOX_A, DIGEST_A)]
+
+    assert mgr.get_image_state().live_digests == {SANDBOX_A: DIGEST_A}
+    assert docker.containers.list.call_args.kwargs["all"] is True
+
+
+def test_docker_fleet_digests_survive_a_daemon_error() -> None:
+    mgr, docker = _docker()
+    docker.containers.list.side_effect = APIError("daemon is unwell")
+
+    assert mgr.get_image_state().live_digests == {}
+
+
+# --- comparing the two ------------------------------------------------------
+
+
+def test_state_names_only_the_sandboxes_that_are_behind() -> None:
+    mgr, _ = _k8s(
+        [_prepuller_pod(TAG_REF, DIGEST_B)],
+        [_sandbox_pod(SANDBOX_A, DIGEST_A), _sandbox_pod(SANDBOX_B, DIGEST_B)],
+    )
+
+    assert mgr.get_image_state().stale_sandbox_ids() == {SANDBOX_A}
+
+
+def test_state_produces_no_work_without_a_target() -> None:
+    """An unconfirmed image must not make the whole fleet look stale."""
+    mgr, _ = _k8s([], [_sandbox_pod(SANDBOX_A, DIGEST_A)])
+
+    state = mgr.get_image_state()
+
+    assert state.target is None
+    assert state.stale_sandbox_ids() == set()

--- a/backend/tests/unit/onyx/server/features/craft/session/test_sandbox_busy.py
+++ b/backend/tests/unit/onyx/server/features/craft/session/test_sandbox_busy.py
@@ -1,0 +1,134 @@
+"""Whether a sandbox is committed to work, and why.
+
+The "why" is the point: a recycle blocked for an hour is a support question, so
+each probe names what holds the sandbox rather than just declining.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+import onyx.server.features.build.session.sandbox_busy as sandbox_busy
+from onyx.db.enums import ScheduledTaskRunStatus
+from onyx.db.models import Sandbox
+from onyx.server.features.build.session.sandbox_busy import (
+    SandboxBusyKind,
+    sandbox_busy_claim,
+)
+
+USER_ID = uuid4()
+
+
+def _sandbox() -> Sandbox:
+    return Sandbox(id=UUID("12345678-1234-1234-1234-1234567890ab"), user_id=USER_ID)
+
+
+def _turn(status: str = "RUNNING") -> MagicMock:
+    turn = MagicMock()
+    turn.turn_id = uuid4()
+    turn.status = status
+    return turn
+
+
+@pytest.fixture
+def no_work(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neither route holds the sandbox; tests re-patch one probe to fire."""
+    monkeypatch.setattr(
+        sandbox_busy, "get_active_session_ids_for_user", lambda *_a, **_kw: []
+    )
+    monkeypatch.setattr(sandbox_busy, "get_unfinished_run_for_user", lambda **_kw: None)
+
+
+@pytest.mark.usefixtures("no_work")
+def test_free_sandbox_has_no_claim() -> None:
+    assert sandbox_busy_claim(MagicMock(), _sandbox(), cache=MagicMock()) is None
+
+
+@pytest.mark.usefixtures("no_work")
+@pytest.mark.parametrize("status", ["QUEUED", "RUNNING"])
+def test_interactive_turn_claims_the_sandbox(
+    monkeypatch: pytest.MonkeyPatch, status: str
+) -> None:
+    """Queued counts: the user was already told the message was accepted."""
+    session_id = uuid4()
+    monkeypatch.setattr(
+        sandbox_busy, "get_active_session_ids_for_user", lambda *_a, **_kw: [session_id]
+    )
+    monkeypatch.setattr(
+        sandbox_busy, "get_active_turn", lambda **_kw: _turn(status=status)
+    )
+
+    claim = sandbox_busy_claim(MagicMock(), _sandbox(), cache=MagicMock())
+
+    assert claim is not None
+    assert claim.kind is SandboxBusyKind.INTERACTIVE_TURN
+    assert str(session_id) in claim.detail
+    assert status in claim.detail
+
+
+@pytest.mark.usefixtures("no_work")
+def test_every_session_of_the_user_is_checked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One sandbox serves all a user's sessions, so any turn protects it."""
+    sessions = [uuid4(), uuid4(), uuid4()]
+    busy_session = sessions[-1]
+    monkeypatch.setattr(
+        sandbox_busy, "get_active_session_ids_for_user", lambda *_a, **_kw: sessions
+    )
+
+    def fake_get_active_turn(*, session_id: UUID, **_kw: Any) -> MagicMock | None:
+        return _turn() if session_id == busy_session else None
+
+    monkeypatch.setattr(sandbox_busy, "get_active_turn", fake_get_active_turn)
+
+    claim = sandbox_busy_claim(MagicMock(), _sandbox(), cache=MagicMock())
+
+    assert claim is not None
+    assert str(busy_session) in claim.detail
+
+
+@pytest.mark.usefixtures("no_work")
+@pytest.mark.parametrize(
+    "status",
+    [
+        ScheduledTaskRunStatus.QUEUED,
+        ScheduledTaskRunStatus.RUNNING,
+        ScheduledTaskRunStatus.AWAITING_APPROVAL,
+    ],
+)
+def test_unfinished_scheduled_run_claims_the_sandbox(
+    monkeypatch: pytest.MonkeyPatch, status: ScheduledTaskRunStatus
+) -> None:
+    """The scheduled executor registers no turn, so only this probe sees it.
+    AWAITING_APPROVAL waits on a person and still owns the sandbox."""
+    run = MagicMock()
+    run.id = uuid4()
+    run.status = status
+    monkeypatch.setattr(sandbox_busy, "get_unfinished_run_for_user", lambda **_kw: run)
+
+    claim = sandbox_busy_claim(MagicMock(), _sandbox(), cache=MagicMock())
+
+    assert claim is not None
+    assert claim.kind is SandboxBusyKind.SCHEDULED_RUN
+    assert status.value in claim.detail
+
+
+@pytest.mark.usefixtures("no_work")
+def test_interactive_turn_short_circuits_the_scheduled_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One reason is enough, and the DB query is the costlier probe."""
+    monkeypatch.setattr(
+        sandbox_busy, "get_active_session_ids_for_user", lambda *_a, **_kw: [uuid4()]
+    )
+    monkeypatch.setattr(sandbox_busy, "get_active_turn", lambda **_kw: _turn())
+    scheduled_probe = MagicMock(return_value=None)
+    monkeypatch.setattr(sandbox_busy, "get_unfinished_run_for_user", scheduled_probe)
+
+    assert sandbox_busy_claim(MagicMock(), _sandbox(), cache=MagicMock()) is not None
+    scheduled_probe.assert_not_called()

--- a/backend/tests/unit/onyx/server/features/craft/session/test_sandbox_recycle.py
+++ b/backend/tests/unit/onyx/server/features/craft/session/test_sandbox_recycle.py
@@ -246,3 +246,152 @@ def test_busy_sandboxes_do_not_consume_the_budget(
 
     swapped = {call.args[0] for call in manager.move_to_image.call_args_list}
     assert swapped == {rows[2].id, rows[3].id}
+
+
+# --- what each backend can preserve -----------------------------------------
+
+
+@pytest.fixture
+def provisioned(monkeypatch: pytest.MonkeyPatch) -> list[UUID]:
+    """Sandboxes provisioned again after their runtime was replaced."""
+    done: list[UUID] = []
+
+    def fake_provision(
+        _db: Any, _mgr: Any, sandbox: Sandbox, *_a: Any, **_kw: Any
+    ) -> None:
+        done.append(sandbox.id)
+
+    monkeypatch.setattr(recycle, "provision_sandbox", fake_provision)
+    monkeypatch.setattr(recycle, "fetch_user_by_id", lambda *_a: MagicMock())
+    return done
+
+
+def _compose_manager(
+    *,
+    outcome: ImageMoveOutcome = ImageMoveOutcome.NEEDS_PROVISION,
+    history: bool = True,
+) -> MagicMock:
+    """Compose: cannot swap an image, but keeps workspaces outside the runtime."""
+    manager = _manager(live={}, outcome=outcome)
+    manager.supports_opencode_history_persistence = history
+    return manager
+
+
+def test_compose_replaces_the_runtime_and_keeps_the_workspace(
+    sandboxes: list[Sandbox], provisioned: list[UUID], rebuilt: list[UUID]
+) -> None:
+    """The workspace lives in a volume the container doesn't own."""
+    sandbox = _sandbox()
+    sandboxes.append(sandbox)
+    manager = _compose_manager()
+    manager.get_image_state.return_value = SandboxImageState(
+        target=TARGET, live_digests={sandbox.id: OLD_DIGEST}
+    )
+
+    _run(manager)
+
+    manager.move_to_image.assert_called_once_with(sandbox.id, TARGET)
+    assert provisioned == [sandbox.id]
+    assert rebuilt == []
+
+
+def test_history_is_captured_before_the_runtime_goes(
+    sandboxes: list[Sandbox], provisioned: list[UUID]
+) -> None:
+    """History lives in the discarded layer, so it is snapshotted first."""
+    sandbox = _sandbox()
+    sandboxes.append(sandbox)
+    manager = _compose_manager()
+    manager.get_image_state.return_value = SandboxImageState(
+        target=TARGET, live_digests={sandbox.id: OLD_DIGEST}
+    )
+    order: list[str] = []
+    manager.create_opencode_history_snapshot.side_effect = lambda *_a, **_kw: (
+        order.append("snapshot")
+    )
+    manager.move_to_image.side_effect = lambda *_a: (
+        order.append("move") or ImageMoveOutcome.NEEDS_PROVISION
+    )
+
+    _run(manager)
+
+    assert order == ["snapshot", "move"]
+    assert provisioned == [sandbox.id]
+
+
+def test_failed_history_capture_falls_through_to_rebuilding(
+    sandboxes: list[Sandbox], provisioned: list[UUID], rebuilt: list[UUID]
+) -> None:
+    """Fail closed: without the snapshot the history would be silently lost."""
+    sandbox = _sandbox()
+    sandboxes.append(sandbox)
+    manager = _compose_manager()
+    manager.get_image_state.return_value = SandboxImageState(
+        target=TARGET, live_digests={sandbox.id: OLD_DIGEST}
+    )
+    manager.create_opencode_history_snapshot.side_effect = RuntimeError("no filestore")
+
+    _run(manager)
+
+    manager.move_to_image.assert_not_called()
+    assert provisioned == []
+    assert rebuilt == [sandbox.id]
+
+
+@pytest.mark.usefixtures("provisioned")
+def test_backend_without_history_persistence_rebuilds_instead(
+    sandboxes: list[Sandbox], rebuilt: list[UUID]
+) -> None:
+    """Nothing would restore the history a discarded runtime holds."""
+    sandbox = _sandbox()
+    sandboxes.append(sandbox)
+    manager = _compose_manager(history=False)
+    manager.get_image_state.return_value = SandboxImageState(
+        target=TARGET, live_digests={sandbox.id: OLD_DIGEST}
+    )
+
+    _run(manager)
+
+    manager.move_to_image.assert_not_called()
+    assert rebuilt == [sandbox.id]
+
+
+def test_unsupported_move_falls_through_to_rebuilding(
+    sandboxes: list[Sandbox], provisioned: list[UUID], rebuilt: list[UUID]
+) -> None:  # noqa: ARG001
+    """A move that can't happen still has to get the sandbox off the old image."""
+    sandbox = _sandbox()
+    sandboxes.append(sandbox)
+    manager = _compose_manager(outcome=ImageMoveOutcome.UNSUPPORTED)
+    manager.get_image_state.return_value = SandboxImageState(
+        target=TARGET, live_digests={sandbox.id: OLD_DIGEST}
+    )
+
+    _run(manager)
+
+    assert provisioned == []
+    assert rebuilt == [sandbox.id]
+
+
+def test_provisioning_failure_does_not_then_rebuild(
+    sandboxes: list[Sandbox], monkeypatch: pytest.MonkeyPatch, rebuilt: list[UUID]
+) -> None:
+    """Rebuilding here would destroy what the move preserved: with no runtime to
+    snapshot, the rebuild path terminates and takes the workspace volume with it.
+    Stopping leaves it for the readiness path instead."""
+    sandbox = _sandbox()
+    sandboxes.append(sandbox)
+    manager = _compose_manager()
+    manager.get_image_state.return_value = SandboxImageState(
+        target=TARGET, live_digests={sandbox.id: OLD_DIGEST}
+    )
+    monkeypatch.setattr(recycle, "fetch_user_by_id", lambda *_a: MagicMock())
+
+    def boom(*_a: Any, **_kw: Any) -> None:
+        raise RuntimeError("daemon refused")
+
+    monkeypatch.setattr(recycle, "provision_sandbox", boom)
+
+    _run(manager)
+
+    assert rebuilt == []

--- a/backend/tests/unit/onyx/server/features/craft/session/test_sandbox_recycle.py
+++ b/backend/tests/unit/onyx/server/features/craft/session/test_sandbox_recycle.py
@@ -1,0 +1,248 @@
+"""Deciding which sandboxes get moved onto the current image, and how.
+
+Almost every case is a refusal: a sandbox a version behind still works, so
+anything uncertain leaves it alone and tries again next pass.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Iterator
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+import onyx.server.features.build.session.sandbox_recycle as recycle
+from onyx.db.models import Sandbox
+from onyx.server.features.build.sandbox.models import (
+    ImageMoveOutcome,
+    SandboxImageState,
+    SandboxImageTarget,
+)
+from onyx.server.features.build.session.sandbox_busy import (
+    SandboxBusyClaim,
+    SandboxBusyKind,
+)
+
+TARGET = SandboxImageTarget(
+    ref="docker.io/onyxdotapp/sandbox@sha256:" + "b" * 64,
+    digest="sha256:" + "b" * 64,
+)
+OLD_DIGEST = "sha256:" + "a" * 64
+
+
+def _sandbox() -> Sandbox:
+    return Sandbox(id=uuid4(), user_id=uuid4())
+
+
+def _manager(
+    *,
+    target: SandboxImageTarget | None = TARGET,
+    live: dict[UUID, str] | None = None,
+    outcome: ImageMoveOutcome = ImageMoveOutcome.MOVED,
+) -> MagicMock:
+    """Kubernetes-shaped: moves a sandbox or can't, never NEEDS_PROVISION."""
+    manager = MagicMock()
+    manager.get_image_state.return_value = SandboxImageState(
+        target=target, live_digests=live or {}
+    )
+    manager.move_to_image.return_value = outcome
+    return manager
+
+
+@pytest.fixture
+def sandboxes(monkeypatch: pytest.MonkeyPatch) -> list[Sandbox]:
+    """The RUNNING rows the drain works from; tests append to it."""
+    rows: list[Sandbox] = []
+    monkeypatch.setattr(recycle, "get_running_sandboxes", lambda *_a, **_kw: rows)
+    return rows
+
+
+@pytest.fixture(autouse=True)
+def _free_and_quiet(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No chat work, every slot free; tests override one to force a refusal."""
+    monkeypatch.setattr(recycle, "sandbox_busy_claim", lambda *_a, **_kw: None)
+
+    @contextmanager
+    def all_free(*_a: Any, **_kw: Any) -> Iterator[bool]:
+        yield True
+
+    monkeypatch.setattr(recycle, "_no_prompts_in_flight", all_free)
+    monkeypatch.setattr(recycle, "get_active_session_ids_for_user", lambda *_a: [])
+
+
+@pytest.fixture
+def rebuilt(monkeypatch: pytest.MonkeyPatch) -> list[UUID]:
+    """Sandboxes sent down the slow path."""
+    slept: list[UUID] = []
+
+    def fake_sleep(_db: Any, _mgr: Any, sandbox: Sandbox, *_a: Any, **_kw: Any) -> bool:
+        slept.append(sandbox.id)
+        return True
+
+    monkeypatch.setattr(recycle, "sleep_sandbox", fake_sleep)
+    return slept
+
+
+def _run(manager: MagicMock) -> None:
+    recycle.recycle_sandboxes_on_stale_images(
+        MagicMock(), manager, MagicMock(), "tenant"
+    )
+
+
+def test_stale_sandbox_is_swapped_in_place(sandboxes: list[Sandbox]) -> None:
+    sandbox = _sandbox()
+    sandboxes.append(sandbox)
+    manager = _manager(live={sandbox.id: OLD_DIGEST})
+
+    _run(manager)
+
+    manager.move_to_image.assert_called_once_with(sandbox.id, TARGET)
+
+
+def test_current_sandbox_is_left_alone(sandboxes: list[Sandbox]) -> None:
+    sandbox = _sandbox()
+    sandboxes.append(sandbox)
+    manager = _manager(live={sandbox.id: TARGET.digest})
+
+    _run(manager)
+
+    manager.move_to_image.assert_not_called()
+
+
+def test_nothing_happens_without_a_confirmed_target(
+    sandboxes: list[Sandbox],
+) -> None:
+    """Restarting onto an image the host lacks would leave it unable to serve."""
+    sandbox = _sandbox()
+    sandboxes.append(sandbox)
+    manager = _manager(target=None, live={sandbox.id: OLD_DIGEST})
+
+    _run(manager)
+
+    manager.move_to_image.assert_not_called()
+
+
+def test_unreported_sandbox_is_left_alone(sandboxes: list[Sandbox]) -> None:
+    """A pod that hasn't reported is either starting or already gone."""
+    sandbox = _sandbox()
+    sandboxes.append(sandbox)
+    manager = _manager(live={})
+
+    _run(manager)
+
+    manager.move_to_image.assert_not_called()
+
+
+def test_busy_sandbox_is_left_on_the_old_image(
+    sandboxes: list[Sandbox], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A move restarts opencode-serve, dropping a turn or a queued message."""
+    sandbox = _sandbox()
+    sandboxes.append(sandbox)
+    monkeypatch.setattr(
+        recycle,
+        "sandbox_busy_claim",
+        lambda *_a, **_kw: SandboxBusyClaim(
+            kind=SandboxBusyKind.INTERACTIVE_TURN, detail="turn running"
+        ),
+    )
+    manager = _manager(live={sandbox.id: OLD_DIGEST})
+
+    _run(manager)
+
+    manager.move_to_image.assert_not_called()
+
+
+def test_a_prompt_starting_first_defers_the_recycle(
+    sandboxes: list[Sandbox], monkeypatch: pytest.MonkeyPatch, rebuilt: list[UUID]
+) -> None:
+    """A prompt can start between the gate and the move; the barrier catches it."""
+    sandbox = _sandbox()
+    sandboxes.append(sandbox)
+
+    @contextmanager
+    def slot_taken(*_a: Any, **_kw: Any) -> Iterator[bool]:
+        yield False
+
+    monkeypatch.setattr(recycle, "_no_prompts_in_flight", slot_taken)
+    manager = _manager(live={sandbox.id: OLD_DIGEST})
+
+    _run(manager)
+
+    manager.move_to_image.assert_not_called()
+    assert rebuilt == []
+
+
+def test_backend_that_cannot_swap_falls_back_to_rebuilding(
+    sandboxes: list[Sandbox], rebuilt: list[UUID]
+) -> None:
+    """Either way the sandbox still has to leave the old image."""
+    sandbox = _sandbox()
+    sandboxes.append(sandbox)
+    manager = _manager(
+        live={sandbox.id: OLD_DIGEST}, outcome=ImageMoveOutcome.UNSUPPORTED
+    )
+
+    _run(manager)
+
+    assert rebuilt == [sandbox.id]
+
+
+def test_a_swap_that_raises_falls_back_to_rebuilding(
+    sandboxes: list[Sandbox], rebuilt: list[UUID]
+) -> None:
+    sandbox = _sandbox()
+    sandboxes.append(sandbox)
+    manager = _manager(live={sandbox.id: OLD_DIGEST})
+    manager.move_to_image.side_effect = RuntimeError("api server said no")
+
+    _run(manager)
+
+    assert rebuilt == [sandbox.id]
+
+
+def test_recycles_are_bounded_per_pass(
+    sandboxes: list[Sandbox], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rollout must not become a fleet-wide stampede of restarts."""
+    monkeypatch.setattr(recycle, "_MAX_RECYCLES_PER_PASS", 2)
+    live = {}
+    for _ in range(5):
+        sandbox = _sandbox()
+        sandboxes.append(sandbox)
+        live[sandbox.id] = OLD_DIGEST
+    manager = _manager(live=live)
+
+    _run(manager)
+
+    assert manager.move_to_image.call_count == 2
+
+
+def test_busy_sandboxes_do_not_consume_the_budget(
+    sandboxes: list[Sandbox], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Skipping is not recycling, so busy sandboxes must not starve the rest."""
+    monkeypatch.setattr(recycle, "_MAX_RECYCLES_PER_PASS", 2)
+    live = {}
+    rows = [_sandbox() for _ in range(4)]
+    for sandbox in rows:
+        sandboxes.append(sandbox)
+        live[sandbox.id] = OLD_DIGEST
+    busy = {rows[0].id, rows[1].id}
+    monkeypatch.setattr(
+        recycle,
+        "sandbox_busy_claim",
+        lambda _db, sandbox, **_kw: (
+            SandboxBusyClaim(kind=SandboxBusyKind.SCHEDULED_RUN, detail="run")
+            if sandbox.id in busy
+            else None
+        ),
+    )
+    manager = _manager(live=live)
+
+    _run(manager)
+
+    swapped = {call.args[0] for call in manager.move_to_image.call_args_list}
+    assert swapped == {rows[2].id, rows[3].id}

--- a/deployment/helm/charts/onyx/templates/sandbox-image-prepuller.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-image-prepuller.yaml
@@ -11,6 +11,10 @@ PriorityClass; see the docs above before adding one back.
 {{- $mem := $res.memory | default "32Mi" }}
 {{- $eph := $res.ephemeralStorage | default "64Mi" }}
 {{- $maxUnavailable := $prepull.updateMaxUnavailable | default "25%" }}
+{{/* Floored: the kubelet backs off restarts, and the backoff counter only
+resets once a container has run for ~10 minutes. A shorter interval would
+stretch itself out anyway, and noisily. */}}
+{{- $recheck := max (int ($prepull.recheckIntervalSeconds | default 900)) 600 }}
 {{- if and (eq (include "onyx.craftEnabled" .) "true") $prepull.enabled }}
 {{- $cm := .Values.configMap }}
 {{- $sandboxNs := $cm.SANDBOX_NAMESPACE | default "onyx-sandboxes" }}
@@ -69,13 +73,18 @@ spec:
       containers:
         - name: prepuller
           image: {{ $image }}
-          {{- /* Shared with the sandbox pods: pinning this to IfNotPresent
-          would hold a stale digest on a mutable tag. */}}
-          imagePullPolicy: {{ $pullPolicy }}
-          {{- /* Portable idle loop, not `sleep infinity` (a GNU coreutils
-          extension that dies on busybox/alpine). The pod must stay running:
-          kubelet only exempts images a running pod references from image GC. */}}
-          command: ["sh", "-c", "while :; do sleep 86400; done"]
+          {{- /* Always, deliberately not the shared $pullPolicy: a kubelet
+          re-resolves a tag to a digest only when it starts a container, and
+          this is the only thing in the deployment that ever asks the registry
+          whether a mutable tag has moved. IfNotPresent here would mean no node
+          ever notices new content published behind the tag. */}}
+          imagePullPolicy: Always
+          {{- /* Exits on purpose, so the kubelet restarts it and re-resolves
+          the tag — that restart *is* the periodic image check. It still spends
+          essentially all its time running, which is what keeps the kubelet
+          exempting the image from GC. Plain `sleep`, not `sleep infinity` (a
+          GNU coreutils extension that dies on busybox/alpine). */}}
+          command: ["sh", "-c", "sleep {{ $recheck }}"]
           resources:
             requests:
               cpu: {{ $cpu | quote }}

--- a/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
@@ -31,9 +31,12 @@ metadata:
     app.kubernetes.io/component: sandbox-manager
 rules:
   # watch is required: _wait_for_pod_ready streams pod events during provision.
+  # patch is required: swap_to_image moves a live sandbox onto a new image by
+  # mutating its container images, which restarts them in place and leaves the
+  # pod — and so the session workspace — intact.
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["get", "list", "watch", "create", "delete"]
+    verbs: ["get", "list", "watch", "create", "patch", "delete"]
   # _create_sandbox_pod reads the sandbox-pod PodTemplate to build the pod.
   - apiGroups: [""]
     resources: ["podtemplates"]

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1681,6 +1681,15 @@ sandboxImagePrepull:
   # this at a low/negative class if you want a pending sandbox pod to be able to
   # preempt the prepuller.
   priorityClassName: ""
+  # How often each node re-asks the registry whether the sandbox image tag has
+  # moved. This is the only thing that makes a deployment on a mutable tag
+  # (the default) ever notice new content, and every check is a manifest
+  # request per node — raise it for a large pool, lower it to pick up images
+  # sooner. Floored at 600s by the template, since the kubelet's restart
+  # backoff makes anything shorter both ineffective and noisy. Deployments
+  # that pin an immutable tag or digest per release don't depend on this at
+  # all; their rollout replaces the prepuller outright.
+  recheckIntervalSeconds: 900
   # Nodes that repull at once on a tag bump. Raise to warm a large pool faster,
   # at the cost of a thundering herd against the registry.
   updateMaxUnavailable: "25%"


### PR DESCRIPTION
## Description

Stacked on #13648. The second implementation of `move_to_image` — no new interface members, just the other backend answering the same request.

A container's image is fixed at creation, so compose can't swap one under a running sandbox the way Kubernetes can. What it *can* do is much cheaper than rebuilding: session workspaces live in a per-sandbox **named volume** rather than the container, and `provision` already adopts an existing volume. So removing the container and provisioning again lands the sandbox on the current image with the user's work still there — no workspace snapshot, no restore, and no wake latency on their next message.

Before this, compose fell all the way through to snapshotting *every* session workspace and sleeping the sandbox. That's the multi-GB part, and it turns out to be avoidable.

### Why it reports `NEEDS_PROVISION` rather than `MOVED`

Because the sandbox genuinely has no runtime until someone provisions it, and only the caller can — the manager may not touch the database. The drain finishes with `provision_sandbox` verbatim, so the sandbox returns with a fresh PAT, restored opencode history, and managed content re-pushed against the new image, all on the path provisioning already exercises. Reassembling a container from its own config would have duplicated a slice of provisioning inside the manager and drifted from it.

### Two safety properties worth review

**History is captured first, fail-closed.** The opencode history lives in the writable layer being discarded (`/workspace/.opencode-data` isn't in the named volume). If that snapshot fails — or the backend can't persist history at all — the move is skipped for the slower route that keeps it. A test asserts the *ordering*, not just that both happen.

**A failed provision deliberately does not then rebuild.** The runtime is already gone, so the rebuild path can't reach the sandbox to snapshot it, takes its unreachable-pod branch, and terminates — which on compose removes the very volume the move preserved. Stopping and letting the readiness path re-provision on the user's next request keeps it. This one was a live bug in the earlier shape of this change; restructuring the drain around the outcome enum is what surfaced it.

## How Has This Been Tested?

6 unit tests: compose takes the cheap route and keeps the workspace, history is snapshotted before the move (ordering asserted), a failed history capture falls through to rebuilding, a backend without history persistence skips it, an unsupported move falls through, and a provisioning failure does *not* rebuild.

717 craft unit tests, 399 external-dependency + helm tests (4 pre-existing failures unrelated to this work: missing Celery broker/OpenSearch).

**Not covered:** the compose integration lane. The container-replacement path is unit-tested against a mocked daemon, not exercised against a real one, and the failure it guards is workspace loss — that wants a real run before this comes off draft.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)