### PR TITLE
feat(gateway): refuse gateway params we cannot honor

### DIFF
--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -225,13 +225,23 @@ def _prepare_messages(
 
 
 def _parse_tool_choice(raw: Any) -> ToolChoiceOptions | None:
+    if raw is None:
+        return None
     if isinstance(raw, str):
         try:
             return ToolChoiceOptions(raw)
-        except ValueError:
-            return None
-    # Named-function tool_choice objects are not supported; fall back to auto.
-    return None
+        except ValueError as e:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                f"Unsupported tool_choice {raw!r}; expected one of "
+                f"{', '.join(option.value for option in ToolChoiceOptions)}.",
+            ) from e
+    # Silently downgrading to auto would let the model ignore a tool the caller
+    # required, so refuse instead of guessing.
+    raise OnyxError(
+        OnyxErrorCode.INVALID_INPUT,
+        "Named-function tool_choice is not supported by the Onyx gateway.",
+    )
 
 
 _STREAM_END = object()
@@ -826,6 +836,12 @@ def handle_responses_request(
     model_config: ModelConfigurationView,
     flow: LLMFlow,
 ) -> StreamingResponse | ResponsesObjectPayload:
+    if request.previous_response_id is not None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_IMPLEMENTED,
+            "The Onyx gateway does not store responses; send the full "
+            "conversation in `input` instead of `previous_response_id`.",
+        )
     llm = llm_from_provider(
         model_name=model_config.name,
         llm_provider=provider,

--- a/backend/onyx/server/gateway/models.py
+++ b/backend/onyx/server/gateway/models.py
@@ -229,8 +229,13 @@ class ModelListResponse(_WireModel):
 
 
 class ResponsesRequest(BaseModel):
-    """Codex sends ``store: false`` and no ``previous_response_id``, so
-    conversation persistence is intentionally not implemented."""
+    """Conversation persistence is not implemented: every request must carry its
+    own history. ``previous_response_id`` is declared so it is refused rather
+    than silently ignored by ``extra="allow"``.
+
+    ``store`` stays tolerated-and-ignored on purpose — the retrieval endpoint it
+    implies does not exist, so a caller cannot be misled into trusting stored
+    state mid-turn, and OpenAI's own default is ``true``."""
 
     model_config = ConfigDict(extra="allow")
 
@@ -243,6 +248,7 @@ class ResponsesRequest(BaseModel):
     max_output_tokens: int | None = None
     temperature: float | None = None
     reasoning: dict[str, Any] | None = None
+    previous_response_id: str | None = None
 
 
 # Subset of the Responses error enum we can actually produce; the schema has

--- a/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
@@ -819,13 +819,25 @@ def test_handle_chat_completion_sanitizes_generic_invoke_failure() -> None:
         ("auto", ToolChoiceOptions.AUTO),
         ("required", ToolChoiceOptions.REQUIRED),
         ("none", ToolChoiceOptions.NONE),
-        ("bogus", None),
-        ({"type": "function", "function": {"name": "bash"}}, None),
         (None, None),
     ],
 )
 def test_parse_tool_choice(raw: object, expected: ToolChoiceOptions | None) -> None:
     assert gateway_api._parse_tool_choice(raw) is expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["bogus", {"type": "function", "function": {"name": "bash"}}],
+)
+def test_parse_tool_choice_refuses_unsupported(raw: object) -> None:
+    """A tool_choice we cannot honor must fail loudly. Downgrading to auto lets
+    the model skip a tool the caller required, with nothing in the response to
+    say the constraint was dropped."""
+    with pytest.raises(OnyxError) as exc_info:
+        gateway_api._parse_tool_choice(raw)
+
+    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
 
 
 def test_gateway_route_exposes_standard_auth_dependency() -> None:
@@ -1667,6 +1679,37 @@ async def test_handle_responses_request_streaming_returns_event_stream() -> None
             assert event["item_id"] in open_items, (
                 f"{event['type']} referenced unopened item {event['item_id']}"
             )
+
+
+def test_handle_responses_request_refuses_previous_response_id() -> None:
+    """We store nothing, so honoring previous_response_id would silently drop
+    the conversation history the caller believes we are holding."""
+    request = ResponsesRequest(
+        model="1/test", input="say hi", previous_response_id="resp_abc"
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        _handle_responses_call(request)
+
+    assert exc_info.value.error_code is OnyxErrorCode.NOT_IMPLEMENTED
+
+
+def test_responses_request_still_tolerates_codex_session_fields() -> None:
+    """Guards the refusals above from over-reaching: Codex sends `store: false`
+    and `reasoning.summary`, and both must stay accepted. Reasoning summaries
+    are an unimplemented output, not a rejected input."""
+    request = ResponsesRequest.model_validate(
+        {
+            "model": "1/test",
+            "input": "hi",
+            "store": False,
+            "reasoning": {"summary": "auto"},
+            "tool_choice": "auto",
+        }
+    )
+
+    assert request.previous_response_id is None
+    assert gateway_api._parse_tool_choice(request.tool_choice) is ToolChoiceOptions.AUTO
 
 
 def test_responses_gateway_route_carries_same_permission_dependency() -> None:


### PR DESCRIPTION
## Description

Two request parameters were accepted and then quietly not honored. Both now fail loudly.

**`previous_response_id`** — the gateway stores nothing, and this field was absorbed by `ResponsesRequest`'s `extra="allow"`. A client that sent it believed we were holding its conversation history; instead the turn ran with only what was in `input`. It is now a declared field and returns 501 with a message pointing at `input`.

**Named-function `tool_choice`** — `_parse_tool_choice` returned `None` for anything that was not `auto`/`required`/`none`. Traced end to end, `None` does not mean "auto": `multi_llm.py:861-864` omits the parameter from the upstream provider call entirely, so the model was genuinely free to ignore a tool the caller had demanded, with nothing in the response indicating the constraint had been dropped. Unmappable values now return 400.

The common thread: both failures produced a *plausible* answer, which is worse than an error, because nothing downstream can detect them.

### What stays tolerated, deliberately

- **`store`** — the retrieval endpoint it implies (`GET /v1/responses/{id}`) does not exist, so a caller cannot be misled into trusting stored state mid-turn, and OpenAI's own default is `true`. Refusing it would break clients that set it without caring.
- **`reasoning.summary`** — Codex sends `{"summary": "auto"}`. Not emitting summary events is an unimplemented *output*, not a bad input; refusing it would break the client this gateway exists to serve. A test pins both of these so the refusals above cannot creep.

## Blast radius

`_parse_tool_choice` is shared, so the `tool_choice` refusal applies to `/gateway/v1/chat/completions` as well as `/gateway/v1/responses`. Chat completions already has live consumers, so I traced every caller rather than assuming.

**Every consumer of these endpoints, and what each sends:**

| Consumer | Sends | Affected? |
|---|---|---|
| Craft sandbox `opencode` (`llm_config.py:135-136` → `opencode_config.py:150-156`) | `"required"` or omitted | No |
| Codex CLI via `/v1/responses` | `"auto"` | No |
| `test_gateway_usage_tracking.py:76,118` | no `tool_choice` key | No |

**opencode verified against the binary, not assumed.** It has exactly one `streamText` call site, which passes `toolChoice: input.toolChoice`; `input.toolChoice` is set in exactly one place, to `format.type === "json_schema" ? "required" : undefined`. Grepping for any construction of the AI SDK's named-function form (`{type: "tool", toolName: ...}`) returns zero hits — every `toolChoice.toolName` reference in the bundle is a provider adapter *reading* the field, never opencode writing it. Two near-misses that look relevant but aren't: `ChatCompletionToolChoiceSchema` (which does include the named-function union) belongs to the OpenRouter provider, and opencode's own `ToolChoiceSchema` is `{mode: "auto"|"required"|"none"}` from the MCP sampling spec.

So no in-repo or in-product caller can trip the new 400. The remaining exposure is external OpenAI-compatible clients, which is the case this refusal exists for.

**The refusal is pre-stream.** `_parse_tool_choice` is called before the `if request.stream:` branch in both handlers, so even `stream: true` requests get a clean 400 with no SSE bytes emitted — not a half-open stream or a truncated turn.

### Known gap, not addressed here

The 400/501 bodies are Onyx-shaped (`{"error_code": ..., "detail": ...}`), not OpenAI-shaped (`{"error": {"message": ..., "type": ...}}`). An `openai` SDK client will raise a generic API error carrying the raw body rather than surfacing the message. This is pre-existing behavior for every synchronous `OnyxError` the gateway raises — `_emit_stream_error` already uses the OpenAI envelope, but only for mid-stream failures. Worth a follow-up if an external client reports it; out of scope here.

### What this does not add

Named-function `tool_choice` remains unsupported, and this PR does not change that — it only stops the gateway from silently pretending otherwise. The limitation is Onyx-wide, not gateway-specific: `ToolChoiceOptions` (`onyx/llm/models.py:13-16`) is a three-member enum with no representation for "call this specific function," so the LLM layer beneath the gateway cannot express it either. Callers needing a hard restriction can send a single tool with `tool_choice: "required"`, which covers the structured-extraction case.

## How Has This Been Tested?

- `backend/tests/unit/onyx/server/gateway/` — 77 tests pass. New: `previous_response_id` → 501, unsupported `tool_choice` (unknown string and named-function object) → 400, and a guard test asserting `store: false` + `reasoning.summary` + `tool_choice: "auto"` are all still accepted.
- The captured-Codex-request tests still pass unchanged, which is the real check that these refusals don't over-reach — that fixture carries `store: false` and `reasoning: {"summary": "auto"}`.
- Caller analysis above, including reading opencode's compiled bundle to confirm the values it can emit.
- `pre-commit` and `ty` clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

**Stack:**
1. [gateway-external-access #13604](https://github.com/onyx-dot-app/onyx/pull/13604)
2. [gateway-responses-api #13605](https://github.com/onyx-dot-app/onyx/pull/13605)
3. [gateway-responses-streaming #13624](https://github.com/onyx-dot-app/onyx/pull/13624)