### PR TITLE
fix(install): persist ~/.local/bin on PATH for non-root installs

### DIFF
--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -14,6 +14,10 @@
 #   ONYX_CLI_BIN_DIR  where the binary is installed. Defaults to
 #                     /usr/local/bin when running as root, else ~/.local/bin.
 #
+# When the install directory isn't already on PATH, the script persists it via
+# the user's shell profile (~/.bashrc, ~/.zshrc, or fish's config.fish) so the
+# follow-up `onyx-cli deploy ...` commands work in new shells.
+#
 # This script must remain compatible with bash 3.2 — macOS still ships
 # 3.2.57 by default and the curl-pipe installer is invoked with /bin/bash.
 # Avoid bash 4+ features (associative arrays, ${var,,}, etc.).
@@ -267,6 +271,73 @@ chmod +x "${TMP_DIR}/onyx-cli"
 mv -f "${TMP_DIR}/onyx-cli" "$BIN_PATH"
 print_success "onyx-cli installed to ${BIN_PATH}"
 
+# --- Make sure follow-up `onyx-cli` commands resolve ---
+# The rc file PATH entries should be added to for the user's shell; empty when
+# the shell isn't one this script knows how to configure.
+shell_profile() {
+    case "${SHELL##*/}" in
+        zsh)
+            echo "${ZDOTDIR:-$HOME}/.zshrc"
+            ;;
+        bash)
+            # macOS terminals open login shells, which skip .bashrc.
+            if [[ "$OS" == "darwin" ]]; then
+                echo "${HOME}/.bash_profile"
+            else
+                echo "${HOME}/.bashrc"
+            fi
+            ;;
+        fish)
+            echo "${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish"
+            ;;
+    esac
+}
+
+# Persist BIN_DIR on PATH via the user's shell profile so the follow-up
+# commands this script and the CLI advertise (onyx-cli deploy status, logs,
+# upgrade, ...) don't die with "command not found" in new shells. Returns 1
+# when the shell is unrecognized or the profile can't be written; the caller
+# then falls back to printing manual instructions.
+persist_path() {
+    local profile line bin_dir_ref
+    profile="$(shell_profile)"
+    if [[ -z "$profile" ]]; then
+        return 1
+    fi
+
+    # Reference $HOME symbolically so the entry reads the way users write it
+    # by hand and survives a renamed home directory.
+    bin_dir_ref="$BIN_DIR"
+    case "$BIN_DIR" in
+        "$HOME"/*)
+            bin_dir_ref="\$HOME${BIN_DIR#"$HOME"}"
+            ;;
+    esac
+
+    if [[ "$profile" == */fish/* ]]; then
+        line="fish_add_path -g \"${bin_dir_ref}\""
+    else
+        line="export PATH=\"${bin_dir_ref}:\$PATH\""
+    fi
+
+    if [[ -f "$profile" ]] && grep -qF "$line" "$profile"; then
+        # A previous install already added the entry; this shell just predates
+        # it.
+        print_info "PATH entry for ${BIN_DIR} already in ${profile} — open a new shell to pick it up."
+        return 0
+    fi
+
+    if ! mkdir -p "$(dirname "$profile")" 2>/dev/null; then
+        return 1
+    fi
+    if ! printf '\n# Added by the Onyx installer\n%s\n' "$line" >> "$profile" 2>/dev/null; then
+        return 1
+    fi
+    print_success "Added ${BIN_DIR} to PATH in ${profile}"
+    print_info "Open a new shell (or run 'source ${profile}') before using onyx-cli directly."
+    return 0
+}
+
 case ":${PATH}:" in
     *":${BIN_DIR}:"*)
         # An onyx-cli earlier in PATH (e.g. a pip install) would shadow the one
@@ -278,8 +349,13 @@ case ":${PATH}:" in
         fi
         ;;
     *)
-        print_warning "${BIN_DIR} is not in your PATH — add it to run onyx-cli directly:"
-        echo -e "   ${BOLD}export PATH=\"${BIN_DIR}:\$PATH\"${NC}"
+        if ! persist_path; then
+            print_warning "${BIN_DIR} is not in your PATH — add it to run onyx-cli directly:"
+            echo -e "   ${BOLD}export PATH=\"${BIN_DIR}:\$PATH\"${NC}"
+        fi
+        # Either way, the CLI this script execs into (and anything it spawns)
+        # should resolve onyx-cli by name during this run.
+        export PATH="${BIN_DIR}:${PATH}"
         ;;
 esac
 

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -275,13 +275,23 @@ print_success "onyx-cli installed to ${BIN_PATH}"
 # The rc file PATH entries should be added to for the user's shell; empty when
 # the shell isn't one this script knows how to configure.
 shell_profile() {
+    local p
     case "${SHELL##*/}" in
         zsh)
             echo "${ZDOTDIR:-$HOME}/.zshrc"
             ;;
         bash)
-            # macOS terminals open login shells, which skip .bashrc.
+            # macOS terminals open login shells, which skip .bashrc and read
+            # only the FIRST of these files that exists — append to that one.
+            # Creating .bash_profile above an existing .profile would shadow
+            # it and silently drop the user's setup.
             if [[ "$OS" == "darwin" ]]; then
+                for p in "${HOME}/.bash_profile" "${HOME}/.bash_login" "${HOME}/.profile"; do
+                    if [[ -f "$p" ]]; then
+                        echo "$p"
+                        return 0
+                    fi
+                done
                 echo "${HOME}/.bash_profile"
             else
                 echo "${HOME}/.bashrc"
@@ -299,9 +309,18 @@ shell_profile() {
 # when the shell is unrecognized or the profile can't be written; the caller
 # then falls back to printing manual instructions.
 persist_path() {
-    local profile line bin_dir_ref
+    local profile line bin_dir_ref unsafe
     profile="$(shell_profile)"
     if [[ -z "$profile" ]]; then
+        return 1
+    fi
+
+    # The directory is embedded in profile syntax, where quotes, dollars,
+    # backticks, backslashes, and newlines are shell-active rather than inert
+    # data. A path carrying any of those goes through the manual instructions
+    # instead of being written out as code.
+    unsafe="\"'\\\`\$"
+    if [[ "$BIN_DIR" == *["$unsafe"]* ]] || [[ "$BIN_DIR" == *$'\n'* ]]; then
         return 1
     fi
 


### PR DESCRIPTION
## Description

`deployment/docker_compose/install.sh` installs onyx-cli to `~/.local/bin` for non-root users and, when that directory isn't on PATH, only printed a warning. The install itself was unaffected (the script execs the binary by absolute path), but every follow-up command the help text advertises (`onyx-cli deploy status | logs | upgrade | uninstall`) ended in "command not found".

The installer now persists the bin directory on PATH instead of just warning:

- **Shell profile persistence.** When `BIN_DIR` isn't on PATH, a new `persist_path` function appends `export PATH="$HOME/.local/bin:$PATH"` to the profile matching `$SHELL`: `~/.bashrc` for bash (`~/.bash_profile` on macOS, where terminals open login shells), `${ZDOTDIR:-$HOME}/.zshrc` for zsh, and `fish_add_path -g` in `config.fish` for fish. Paths under `$HOME` are written symbolically; a custom `ONYX_CLI_BIN_DIR` outside it is written literally.
- **Idempotent.** A re-run detects the existing line and reminds the user to open a new shell instead of appending a duplicate.
- **Fallback preserved.** Unrecognized shells (or an unwritable profile) still get the previous manual `export PATH=...` instructions.
- **Current run also fixed.** The updated PATH is exported before `exec`ing the CLI, so anything the CLI spawns can resolve `onyx-cli` by name during the install itself.

The Windows installer (`install.ps1`) already refreshes PATH its own way and is untouched. The new code sticks to bash-3.2-safe constructs per the script's macOS compatibility note.

## How Has This Been Tested?

- End-to-end harness running the real script with a stub `curl` serving locally built release fixtures (valid checksums) and a stub `onyx-cli` echoing its argv and PATH. 18 checks across seven scenarios pass: fresh bash install, idempotent re-run, zsh with `ZDOTDIR`, fish, unknown-shell fallback, dir already on PATH (no writes), and a custom bin dir outside `$HOME`.
- Confirmed the appended profile line resolves correctly when sourced in a clean environment.
- `pre-commit run --files deployment/docker_compose/install.sh` passes, including shellcheck.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist `~/.local/bin` on PATH for non-root installs so `onyx-cli` works in new shells without manual steps. Also fixes macOS bash login-file selection and avoids writing unsafe `BIN_DIR` values into profiles.

- **Bug Fixes**
  - Adds a PATH entry to the right shell profile: bash (non-macOS) `~/.bashrc`; bash (macOS) first existing of `~/.bash_profile`, `~/.bash_login`, or `~/.profile`; zsh `${ZDOTDIR:-$HOME}/.zshrc`; fish via `fish_add_path -g` in `~/.config/fish/config.fish`.
  - Idempotent updates; falls back to manual `export PATH=...` for unknown shells, unwritable profiles, or unsafe `BIN_DIR` values (quotes, $, backticks, backslashes, newlines).
  - Exports the updated PATH before `exec` so subprocesses resolve `onyx-cli` during install.
  - Windows `install.ps1` unchanged.

<sup>Written for commit 31ec596fbeef6d062678df87df8ff72b51766f34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

