### PR TITLE
fix(web): open AccountPopover above its trigger on mobile

### DIFF
--- a/web/src/sections/sidebar/AccountPopover.tsx
+++ b/web/src/sections/sidebar/AccountPopover.tsx
@@ -27,6 +27,7 @@ import {
 import { Content, toast } from "@opal/layouts";
 import { Section } from "@/layouts/general-layouts";
 import useAppFocus from "@/hooks/useAppFocus";
+import useScreenSize from "@/hooks/useScreenSize";
 import { useSettings } from "@/lib/settings/hooks";
 import UserAvatar from "@/refresh-components/avatars/UserAvatar";
 import { useNotificationSummary } from "@/hooks/useNotifications";
@@ -199,6 +200,7 @@ export default function AccountPopover({
   >(undefined);
   const { user } = useUser();
   const appFocus = useAppFocus();
+  const { isMobile } = useScreenSize();
   const { vectorDbEnabled } = useSettings();
   const { undismissedCount, refresh: refreshNotificationSummary } =
     useNotificationSummary();
@@ -247,8 +249,8 @@ export default function AccountPopover({
       </Popover.Trigger>
 
       <Popover.Content
-        align="end"
-        side="right"
+        align={isMobile ? "start" : "end"}
+        side={isMobile ? "top" : "right"}
         width={popupState === "Notifications" ? "2xl" : "lg"}
       >
         {popupState === "Settings" && (


### PR DESCRIPTION
## Description

On mobile viewports (< 724px), the account popover in the sidebar opened to the right of its trigger button, which crams it against the viewport edge. This flips it to open above the button (left-aligned with the trigger) on mobile, using the existing `useScreenSize().isMobile` hook. Desktop behavior is unchanged (`side="right"`, `align="end"`).

## How Has This Been Tested?

Verified in the dev app via browser automation:
- 390×844 viewport: popover renders with `data-side="top"` / `data-align="start"`, sitting directly above the account button.
- 1280×800 viewport: popover still renders with `data-side="right"` / `data-align="end"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the AccountPopover placement on mobile. On small screens, it now opens above the trigger and left-aligned to avoid clipping; desktop still opens to the right with end alignment.

<sup>Written for commit 868605d945132f9096c26be1e34d8e441978e514. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

