### PR TITLE
chore(devcontainer): playwright chromium for the MCP, self-healing ods web, dev-workflow docs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -97,8 +97,9 @@ RUN ln -s /usr/local/bin/bun /usr/local/bin/bunx
 # runner (web/tests/e2e) forks worker processes that require Node — running it
 # under bun alone hangs the runner. Daily JS tooling (Claude Code, opencode)
 # still runs under bun; Node is here only as the runtime for the test runner.
-# The chromium browser binary is installed at test time (web global-setup), not
-# baked here, so its version tracks web/package.json's floating @playwright/test.
+# The test runner's chromium binary is installed at test time, not baked here,
+# so its version tracks web/package.json's floating @playwright/test (the
+# chromium baked further down serves only the pinned Playwright MCP server).
 #
 # Copied from the official node image (digest-pinned in the node_source stage at the
 # top, routed through BASE_IMAGE_REGISTRY) instead of fetched from nodejs.org, so a
@@ -115,35 +116,27 @@ RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
 # the web-search open_url tool. The browser binary itself is downloaded
 # from the integration test conftest's _install_playwright fixture so
 # the version always matches the lockfile's playwright-python.
-#
-# Playwright doesn't ship Chromium builds for Ubuntu 26.04 yet, so spoof
-# the host platform to the binary-compatible Ubuntu 24.04 build. Arch
-# is detected from dpkg so both arm64 CI runners and x64 dev machines
-# work; we don't bake the override into ENV because that would leak
-# into interactive dev shells where it might mask real problems.
 RUN apt-get update \
-  && PW_ARCH=$(case $(dpkg --print-architecture) in amd64) echo x64;; arm64) echo arm64;; esac) \
-  && PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-${PW_ARCH} \
-       uvx --quiet --from playwright playwright install-deps chromium \
+  && uvx --quiet --from playwright playwright install-deps chromium \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install Google Chrome for the Playwright MCP server (.mcp.json), whose browser
-# tools default to the `chrome` channel and expect /opt/google/chrome/chrome.
-# Unlike Playwright's chromium builds — which must match the driver revision and
-# are therefore installed at test time — the Chrome stable channel is
-# version-independent, so baking it here doesn't fight any lockfile. Installed
-# from Google's direct deb (same source `playwright install chrome` uses).
-# Google ships no linux/arm64 Chrome, so the arm64 image (CI runners) skips it;
-# the MCP browser tools are only used interactively on x64 dev machines.
-RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
-    apt-get update \
-    && curl -fsSL -o /tmp/chrome.deb \
-      https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
-    && apt-get install -y --no-install-recommends /tmp/chrome.deb \
-    && rm -f /tmp/chrome.deb \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* \
-    && google-chrome --version; \
-  fi
+# Give Playwright's browser cache a fixed, user-independent path. The default
+# (~/.cache/ms-playwright) would be shadowed by the devcontainer's per-user
+# cache volume and differ between root and dev, so revisions baked below would
+# be invisible at runtime. Test-time installs (web e2e, the integration
+# conftest) land their own revisions alongside the baked one.
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
+
+# Bake the chromium build for the Playwright MCP server. Playwright browser
+# builds are revision-coupled to the playwright version that installs them, so
+# resolve the exact playwright the pinned MCP bundles and install with that —
+# a chromium installed by any other version would not be found. Keep the pin
+# in sync with .mcp.json. World-writable so test-time installs run as the dev
+# user can add their own revisions next to it.
+ARG PLAYWRIGHT_MCP_VERSION=0.0.78
+RUN PW_VERSION=$(npm view "@playwright/mcp@${PLAYWRIGHT_MCP_VERSION}" dependencies.playwright) \
+  && npx --yes "playwright@${PW_VERSION}" install chromium \
+  && chmod -R 777 /opt/ms-playwright
 
 # Install Python 3.13 via uv into a stable, image-level path so venvs
 # created in bind-mounted workspaces survive across `docker run`s.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -127,6 +127,24 @@ RUN apt-get update \
        uvx --quiet --from playwright playwright install-deps chromium \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Install Google Chrome for the Playwright MCP server (.mcp.json), whose browser
+# tools default to the `chrome` channel and expect /opt/google/chrome/chrome.
+# Unlike Playwright's chromium builds — which must match the driver revision and
+# are therefore installed at test time — the Chrome stable channel is
+# version-independent, so baking it here doesn't fight any lockfile. Installed
+# from Google's direct deb (same source `playwright install chrome` uses).
+# Google ships no linux/arm64 Chrome, so the arm64 image (CI runners) skips it;
+# the MCP browser tools are only used interactively on x64 dev machines.
+RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
+    apt-get update \
+    && curl -fsSL -o /tmp/chrome.deb \
+      https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+    && apt-get install -y --no-install-recommends /tmp/chrome.deb \
+    && rm -f /tmp/chrome.deb \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && google-chrome --version; \
+  fi
+
 # Install Python 3.13 via uv into a stable, image-level path so venvs
 # created in bind-mounted workspaces survive across `docker run`s.
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python

--- a/.devcontainer/claude-code/CLAUDE.md
+++ b/.devcontainer/claude-code/CLAUDE.md
@@ -34,15 +34,14 @@ handler at `web/src/app/api/[...path]/route.ts`), so **`localhost:3000` serves b
 `/api`** — no reverse proxy needed. You can also hit the backend directly at `localhost:8080` (note:
 **no** `/api` prefix there — e.g. `/health`, `/auth/type`).
 
-`ods web dev` runs `bun install --frozen-lockfile` first, but only when `web/node_modules` is
-missing or empty. Two gaps to know about:
-
-- A **stale** install (lockfile drifted since node_modules was populated) is not detected — if the
-  dev server fails on missing packages, run `cd web && bun install` yourself.
-- The workspace packages `@onyx-ai/shared` and `@onyx-ai/opal` are symlinks into `web/lib/*` whose
-  exports point at `dist/`, and `bun install` does not build them. If the dev server dies with an
-  export error like `Package path ./root.css is not exported`, build them (in this order):
-  `cd web/lib/shared && bun run build && cd ../opal && bun run build`.
+`ods web <script>` self-heals its prerequisites before running: it runs
+`bun install --frozen-lockfile` when `web/node_modules` is missing, empty, or was installed from a
+different `bun.lock` (tracked via a hash stamp inside node_modules), and rebuilds the workspace
+packages `web/lib/shared` / `web/lib/opal` when their `dist/` is missing or older than their
+sources. If an older `ods` build (it's compiled into `.venv/bin` — refresh with `uv sync`) hits
+these anyway, the symptoms and fixes: missing packages → `cd web && bun install`; export errors
+like `Package path ./root.css is not exported` →
+`cd web/lib/shared && bun run build && cd ../opal && bun run build`.
 
 **Stop the dev servers when you're finished with them** (backgrounded processes outlive your
 task otherwise):
@@ -52,14 +51,18 @@ task otherwise):
 
 ## Playwright / browser access
 
-- **Playwright MCP browser tools** (`browser_navigate` etc.) drive the `chrome` channel — Google
-  Chrome is baked into the image at `/opt/google/chrome/chrome`. If it's missing (container built
-  from an older image), install it once: `cd web && npx playwright install chrome`.
-- **Repo-pinned Playwright chromium** (the e2e runner in `web/tests/e2e`) is *not* baked — only its
-  system libraries are — so the binary can track the lockfile. If a run reports the browser
-  missing, install it with the Ubuntu 26.04 platform spoof (Playwright ships no 26.04 builds):
-  `PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-$(dpkg --print-architecture | sed s/amd64/x64/) npx playwright install chromium`
-  (run from `web/`). The backend integration conftest already does this itself for
-  playwright-python.
+Browsers live in the shared cache at `/opt/ms-playwright` (`PLAYWRIGHT_BROWSERS_PATH`). Playwright
+browser builds are revision-coupled to the playwright version that installs them, so "a" chromium
+being present doesn't mean *your* playwright can see it — always install with the version that
+will drive it:
+
+- **Playwright MCP browser tools** (`browser_navigate` etc.) run playwright chromium, baked into
+  the image for the `@playwright/mcp` version pinned in `.mcp.json`. If the tools report a missing
+  browser (container from an older image), install the matching revision once:
+  `npx -y playwright@"$(npm view @playwright/mcp@<pin from .mcp.json> dependencies.playwright)" install chromium`.
+- **The e2e runner** (`web/tests/e2e`) tracks `web/package.json`'s playwright, so its chromium is
+  installed at test time, not baked. If a run reports the browser missing:
+  `cd web && npx playwright install chromium`. The backend integration conftest handles its own
+  playwright-python install.
 
 Login credentials for driving the UI are in the root guide's KEY NOTES.

--- a/.devcontainer/claude-code/CLAUDE.md
+++ b/.devcontainer/claude-code/CLAUDE.md
@@ -34,35 +34,8 @@ handler at `web/src/app/api/[...path]/route.ts`), so **`localhost:3000` serves b
 `/api`** — no reverse proxy needed. You can also hit the backend directly at `localhost:8080` (note:
 **no** `/api` prefix there — e.g. `/health`, `/auth/type`).
 
-`ods web <script>` self-heals its prerequisites before running: it runs
-`bun install --frozen-lockfile` when `web/node_modules` is missing, empty, or was installed from a
-different `bun.lock` (tracked via a hash stamp inside node_modules), and rebuilds the workspace
-packages `web/lib/shared` / `web/lib/opal` when their `dist/` is missing or older than their
-sources. If an older `ods` build (it's compiled into `.venv/bin` — refresh with `uv sync`) hits
-these anyway, the symptoms and fixes: missing packages → `cd web && bun install`; export errors
-like `Package path ./root.css is not exported` →
-`cd web/lib/shared && bun run build && cd ../opal && bun run build`.
-
 **Stop the dev servers when you're finished with them** (backgrounded processes outlive your
 task otherwise):
 
 - frontend: `pkill -f "next dev"; pkill -f next-server`
 - backend: `pkill -f "uvicorn onyx.main:app"`
-
-## Playwright / browser access
-
-Browsers live in the shared cache at `/opt/ms-playwright` (`PLAYWRIGHT_BROWSERS_PATH`). Playwright
-browser builds are revision-coupled to the playwright version that installs them, so "a" chromium
-being present doesn't mean *your* playwright can see it — always install with the version that
-will drive it:
-
-- **Playwright MCP browser tools** (`browser_navigate` etc.) run playwright chromium, baked into
-  the image for the `@playwright/mcp` version pinned in `.mcp.json`. If the tools report a missing
-  browser (container from an older image), install the matching revision once:
-  `npx -y playwright@"$(npm view @playwright/mcp@<pin from .mcp.json> dependencies.playwright)" install chromium`.
-- **The e2e runner** (`web/tests/e2e`) tracks `web/package.json`'s playwright, so its chromium is
-  installed at test time, not baked. If a run reports the browser missing:
-  `cd web && npx playwright install chromium`. The backend integration conftest handles its own
-  playwright-python install.
-
-Login credentials for driving the UI are in the root guide's KEY NOTES.

--- a/.devcontainer/claude-code/CLAUDE.md
+++ b/.devcontainer/claude-code/CLAUDE.md
@@ -34,8 +34,7 @@ handler at `web/src/app/api/[...path]/route.ts`), so **`localhost:3000` serves b
 `/api`** — no reverse proxy needed. You can also hit the backend directly at `localhost:8080` (note:
 **no** `/api` prefix there — e.g. `/health`, `/auth/type`).
 
-**Stop the dev servers when you're finished with them** (backgrounded processes outlive your
-task otherwise):
+**Stop the dev servers when you're finished with them:**
 
 - frontend: `pkill -f "next dev"; pkill -f next-server`
 - backend: `pkill -f "uvicorn onyx.main:app"`

--- a/.devcontainer/claude-code/CLAUDE.md
+++ b/.devcontainer/claude-code/CLAUDE.md
@@ -33,3 +33,33 @@ In dev mode the frontend proxies `/api/*` straight to the backend (the dev-only 
 handler at `web/src/app/api/[...path]/route.ts`), so **`localhost:3000` serves both the UI and
 `/api`** — no reverse proxy needed. You can also hit the backend directly at `localhost:8080` (note:
 **no** `/api` prefix there — e.g. `/health`, `/auth/type`).
+
+`ods web dev` runs `bun install --frozen-lockfile` first, but only when `web/node_modules` is
+missing or empty. Two gaps to know about:
+
+- A **stale** install (lockfile drifted since node_modules was populated) is not detected — if the
+  dev server fails on missing packages, run `cd web && bun install` yourself.
+- The workspace packages `@onyx-ai/shared` and `@onyx-ai/opal` are symlinks into `web/lib/*` whose
+  exports point at `dist/`, and `bun install` does not build them. If the dev server dies with an
+  export error like `Package path ./root.css is not exported`, build them (in this order):
+  `cd web/lib/shared && bun run build && cd ../opal && bun run build`.
+
+**Stop the dev servers when you're finished with them** (backgrounded processes outlive your
+task otherwise):
+
+- frontend: `pkill -f "next dev"; pkill -f next-server`
+- backend: `pkill -f "uvicorn onyx.main:app"`
+
+## Playwright / browser access
+
+- **Playwright MCP browser tools** (`browser_navigate` etc.) drive the `chrome` channel — Google
+  Chrome is baked into the image at `/opt/google/chrome/chrome`. If it's missing (container built
+  from an older image), install it once: `cd web && npx playwright install chrome`.
+- **Repo-pinned Playwright chromium** (the e2e runner in `web/tests/e2e`) is *not* baked — only its
+  system libraries are — so the binary can track the lockfile. If a run reports the browser
+  missing, install it with the Ubuntu 26.04 platform spoof (Playwright ships no 26.04 builds):
+  `PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-$(dpkg --print-architecture | sed s/amd64/x64/) npx playwright install chromium`
+  (run from `web/`). The backend integration conftest already does this itself for
+  playwright-python.
+
+Login credentials for driving the UI are in the root guide's KEY NOTES.

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,13 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": ["@playwright/mcp@0.0.75", "--headless", "--isolated"]
+      "args": [
+        "@playwright/mcp@0.0.78",
+        "--headless",
+        "--isolated",
+        "--browser",
+        "chromium"
+      ]
     },
     "agent-wiki": {
       "type": "http",

--- a/tools/ods/cmd/web.go
+++ b/tools/ods/cmd/web.go
@@ -1,14 +1,18 @@
 package cmd
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -26,7 +30,7 @@ func NewWebCommand() *cobra.Command {
 		Use:   "web <script> [args...]",
 		Short: "Run web/package.json bun scripts",
 		Long:  webHelpDescription(),
-		Args: cobra.MinimumNArgs(1),
+		Args:  cobra.MinimumNArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) > 0 {
 				return nil, cobra.ShellCompDirectiveNoFileComp
@@ -48,8 +52,7 @@ func runWebScript(args []string) {
 		log.Fatalf("Failed to find web directory: %v", err)
 	}
 
-	nodeModules := filepath.Join(webDir, "node_modules")
-	if needsInstall, reason := nodeModulesNeedsInstall(nodeModules); needsInstall {
+	if needsInstall, reason := nodeModulesNeedsInstall(webDir); needsInstall {
 		log.Infof("%s, running bun install --frozen-lockfile...", reason)
 		installCmd := exec.Command("bun", "install", "--frozen-lockfile")
 		installCmd.Dir = webDir
@@ -59,7 +62,10 @@ func runWebScript(args []string) {
 		if err := installCmd.Run(); err != nil {
 			log.Fatalf("Failed to run bun install: %v", err)
 		}
+		writeLockStamp(webDir)
 	}
+
+	ensureWorkspaceLibsBuilt(webDir)
 
 	scriptName := args[0]
 	scriptArgs := args[1:]
@@ -94,10 +100,17 @@ func runWebScript(args []string) {
 	}
 }
 
+// lockStampName is the file inside node_modules recording the sha256 of the
+// bun.lock that produced it. node_modules lives in a persistent volume in the
+// devcontainer, so it routinely outlives lockfile updates in the workspace —
+// the stamp is what lets us notice.
+const lockStampName = ".ods-bun-lock-sha256"
+
 // nodeModulesNeedsInstall reports whether bun install should be run, along with
-// a human-readable reason. Install is needed when node_modules is missing or
-// exists but is empty.
-func nodeModulesNeedsInstall(nodeModules string) (bool, string) {
+// a human-readable reason. Install is needed when node_modules is missing,
+// empty, or was installed from a different bun.lock than the current one.
+func nodeModulesNeedsInstall(webDir string) (bool, string) {
+	nodeModules := filepath.Join(webDir, "node_modules")
 	entries, err := os.ReadDir(nodeModules)
 	if errors.Is(err, os.ErrNotExist) {
 		return true, "node_modules not found"
@@ -110,7 +123,120 @@ func nodeModulesNeedsInstall(nodeModules string) (bool, string) {
 	if len(entries) == 0 {
 		return true, "node_modules is empty"
 	}
+
+	lockHash, err := fileSHA256(filepath.Join(webDir, "bun.lock"))
+	if err != nil {
+		// No lockfile to compare against; nothing more we can check.
+		return false, ""
+	}
+	stamp, err := os.ReadFile(filepath.Join(nodeModules, lockStampName))
+	if err != nil || strings.TrimSpace(string(stamp)) != lockHash {
+		return true, "node_modules is stale (bun.lock changed since last install)"
+	}
 	return false, ""
+}
+
+// writeLockStamp records the current bun.lock hash after a successful install.
+// Best-effort: a failure only means the next run reinstalls, which is safe.
+func writeLockStamp(webDir string) {
+	lockHash, err := fileSHA256(filepath.Join(webDir, "bun.lock"))
+	if err != nil {
+		return
+	}
+	stampPath := filepath.Join(webDir, "node_modules", lockStampName)
+	if err := os.WriteFile(stampPath, []byte(lockHash+"\n"), 0o644); err != nil {
+		log.Debugf("Failed to write %s: %v", stampPath, err)
+	}
+}
+
+func fileSHA256(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// webLibPackages are the bun workspace packages whose exports point at their
+// dist/ build output. bun install links them into node_modules but never runs
+// their builds, so a fresh checkout (or an edit to their sources) leaves the
+// dev server failing on unresolvable exports. Order matters: opal's build
+// consumes shared's output.
+var webLibPackages = []string{"lib/shared", "lib/opal"}
+
+// ensureWorkspaceLibsBuilt builds each workspace library whose dist/ is
+// missing or older than its sources.
+func ensureWorkspaceLibsBuilt(webDir string) {
+	for _, rel := range webLibPackages {
+		pkgDir := filepath.Join(webDir, rel)
+		needsBuild, reason := libNeedsBuild(pkgDir)
+		if !needsBuild {
+			continue
+		}
+		log.Infof("web/%s %s, running bun run build...", rel, reason)
+		buildCmd := exec.Command("bun", "run", "build")
+		buildCmd.Dir = pkgDir
+		buildCmd.Stdout = os.Stdout
+		buildCmd.Stderr = os.Stderr
+		if err := buildCmd.Run(); err != nil {
+			log.Fatalf("Failed to build web/%s: %v", rel, err)
+		}
+	}
+}
+
+// libNeedsBuild reports whether a workspace library's dist/ is missing or
+// stale relative to its sources, along with a human-readable reason. The
+// staleness check compares newest mtimes, walking the package excluding its
+// build output, dependencies, and hidden entries — cheap enough (a few
+// thousand stats at most) to run before every script.
+func libNeedsBuild(pkgDir string) (bool, string) {
+	if _, err := os.Stat(pkgDir); err != nil {
+		// Not a checkout that has this package; nothing to do.
+		return false, ""
+	}
+	distNewest, err := newestMtime(filepath.Join(pkgDir, "dist"), nil)
+	if errors.Is(err, os.ErrNotExist) {
+		return true, "has no dist build"
+	}
+	if err != nil {
+		return true, fmt.Sprintf("dist is unreadable (%v)", err)
+	}
+	srcNewest, err := newestMtime(pkgDir, map[string]bool{"dist": true, "node_modules": true})
+	if err != nil {
+		return false, ""
+	}
+	if srcNewest.After(distNewest) {
+		return true, "dist build is older than its sources"
+	}
+	return false, ""
+}
+
+// newestMtime returns the newest modification time under root, skipping
+// directories named in excludeDirs and hidden entries.
+func newestMtime(root string, excludeDirs map[string]bool) (time.Time, error) {
+	var newest time.Time
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		name := d.Name()
+		if path != root && (excludeDirs[name] || strings.HasPrefix(name, ".")) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if info.ModTime().After(newest) {
+			newest = info.ModTime()
+		}
+		return nil
+	})
+	return newest, err
 }
 
 func webScriptNames() []string {

--- a/tools/ods/cmd/web.go
+++ b/tools/ods/cmd/web.go
@@ -138,14 +138,37 @@ func nodeModulesNeedsInstall(webDir string) (bool, string) {
 
 // writeLockStamp records the current bun.lock hash after a successful install.
 // Best-effort: a failure only means the next run reinstalls, which is safe.
+//
+// The stamp is replaced via temp file + rename rather than written in place:
+// the devcontainer's node_modules volume is shared across sessions that may
+// run as different users (root agent sessions, the dev user), and an in-place
+// write to a stamp owned by the other user fails — which would silently force
+// a reinstall on every run. Rename needs only directory write permission and
+// atomically replaces the previous owner's file.
 func writeLockStamp(webDir string) {
 	lockHash, err := fileSHA256(filepath.Join(webDir, "bun.lock"))
 	if err != nil {
 		return
 	}
-	stampPath := filepath.Join(webDir, "node_modules", lockStampName)
-	if err := os.WriteFile(stampPath, []byte(lockHash+"\n"), 0o644); err != nil {
-		log.Debugf("Failed to write %s: %v", stampPath, err)
+	nodeModules := filepath.Join(webDir, "node_modules")
+	stampPath := filepath.Join(nodeModules, lockStampName)
+	tmp, err := os.CreateTemp(nodeModules, lockStampName+".tmp-*")
+	if err != nil {
+		log.Debugf("Failed to create stamp temp file in %s: %v", nodeModules, err)
+		return
+	}
+	_, writeErr := tmp.WriteString(lockHash + "\n")
+	// World-readable so sessions running as other users can validate it.
+	chmodErr := tmp.Chmod(0o644)
+	closeErr := tmp.Close()
+	if writeErr != nil || chmodErr != nil || closeErr != nil {
+		_ = os.Remove(tmp.Name())
+		log.Debugf("Failed to write stamp temp file %s: %v/%v/%v", tmp.Name(), writeErr, chmodErr, closeErr)
+		return
+	}
+	if err := os.Rename(tmp.Name(), stampPath); err != nil {
+		_ = os.Remove(tmp.Name())
+		log.Debugf("Failed to replace %s: %v", stampPath, err)
 	}
 }
 

--- a/tools/ods/cmd/web_test.go
+++ b/tools/ods/cmd/web_test.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setMtime(t *testing.T, path string, mtime time.Time) {
+	t.Helper()
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNodeModulesNeedsInstall(t *testing.T) {
+	now := time.Now()
+
+	t.Run("missing node_modules", func(t *testing.T) {
+		webDir := t.TempDir()
+		needs, reason := nodeModulesNeedsInstall(webDir)
+		if !needs {
+			t.Fatal("expected install for missing node_modules")
+		}
+		if reason != "node_modules not found" {
+			t.Fatalf("unexpected reason: %q", reason)
+		}
+	})
+
+	t.Run("empty node_modules", func(t *testing.T) {
+		webDir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(webDir, "node_modules"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		needs, reason := nodeModulesNeedsInstall(webDir)
+		if !needs {
+			t.Fatal("expected install for empty node_modules")
+		}
+		if reason != "node_modules is empty" {
+			t.Fatalf("unexpected reason: %q", reason)
+		}
+	})
+
+	t.Run("populated without stamp is stale", func(t *testing.T) {
+		webDir := t.TempDir()
+		writeFile(t, filepath.Join(webDir, "bun.lock"), "lock-v1")
+		writeFile(t, filepath.Join(webDir, "node_modules", "pkg", "index.js"), "")
+		needs, _ := nodeModulesNeedsInstall(webDir)
+		if !needs {
+			t.Fatal("expected install when no stamp recorded")
+		}
+	})
+
+	t.Run("stamp matches lockfile", func(t *testing.T) {
+		webDir := t.TempDir()
+		writeFile(t, filepath.Join(webDir, "bun.lock"), "lock-v1")
+		writeFile(t, filepath.Join(webDir, "node_modules", "pkg", "index.js"), "")
+		writeLockStamp(webDir)
+		needs, reason := nodeModulesNeedsInstall(webDir)
+		if needs {
+			t.Fatalf("expected no install with matching stamp, got: %q", reason)
+		}
+	})
+
+	t.Run("lockfile changed after stamp", func(t *testing.T) {
+		webDir := t.TempDir()
+		writeFile(t, filepath.Join(webDir, "bun.lock"), "lock-v1")
+		writeFile(t, filepath.Join(webDir, "node_modules", "pkg", "index.js"), "")
+		writeLockStamp(webDir)
+		writeFile(t, filepath.Join(webDir, "bun.lock"), "lock-v2")
+		setMtime(t, filepath.Join(webDir, "bun.lock"), now)
+		needs, _ := nodeModulesNeedsInstall(webDir)
+		if !needs {
+			t.Fatal("expected install after lockfile change")
+		}
+	})
+
+	t.Run("no lockfile skips staleness check", func(t *testing.T) {
+		webDir := t.TempDir()
+		writeFile(t, filepath.Join(webDir, "node_modules", "pkg", "index.js"), "")
+		needs, _ := nodeModulesNeedsInstall(webDir)
+		if needs {
+			t.Fatal("expected no install without a lockfile to compare")
+		}
+	})
+}
+
+func TestLibNeedsBuild(t *testing.T) {
+	old := time.Now().Add(-time.Hour)
+	older := old.Add(-time.Hour)
+
+	t.Run("missing package is skipped", func(t *testing.T) {
+		needs, _ := libNeedsBuild(filepath.Join(t.TempDir(), "lib", "nope"))
+		if needs {
+			t.Fatal("expected missing package to be skipped")
+		}
+	})
+
+	t.Run("missing dist", func(t *testing.T) {
+		pkgDir := t.TempDir()
+		writeFile(t, filepath.Join(pkgDir, "src", "index.ts"), "")
+		needs, reason := libNeedsBuild(pkgDir)
+		if !needs {
+			t.Fatal("expected build for missing dist")
+		}
+		if reason != "has no dist build" {
+			t.Fatalf("unexpected reason: %q", reason)
+		}
+	})
+
+	t.Run("dist newer than sources", func(t *testing.T) {
+		pkgDir := t.TempDir()
+		src := filepath.Join(pkgDir, "src", "index.ts")
+		dist := filepath.Join(pkgDir, "dist", "index.js")
+		writeFile(t, src, "")
+		writeFile(t, dist, "")
+		setMtime(t, src, older)
+		setMtime(t, filepath.Join(pkgDir, "src"), older)
+		setMtime(t, pkgDir, older)
+		needs, reason := libNeedsBuild(pkgDir)
+		if needs {
+			t.Fatalf("expected no build when dist is fresh, got: %q", reason)
+		}
+	})
+
+	t.Run("source newer than dist", func(t *testing.T) {
+		pkgDir := t.TempDir()
+		src := filepath.Join(pkgDir, "src", "index.ts")
+		dist := filepath.Join(pkgDir, "dist", "index.js")
+		writeFile(t, src, "")
+		writeFile(t, dist, "")
+		setMtime(t, dist, older)
+		setMtime(t, filepath.Join(pkgDir, "dist"), older)
+		setMtime(t, src, old)
+		needs, _ := libNeedsBuild(pkgDir)
+		if !needs {
+			t.Fatal("expected build when a source is newer than dist")
+		}
+	})
+
+	t.Run("changes under excluded dirs are ignored", func(t *testing.T) {
+		pkgDir := t.TempDir()
+		src := filepath.Join(pkgDir, "src", "index.ts")
+		dist := filepath.Join(pkgDir, "dist", "index.js")
+		dep := filepath.Join(pkgDir, "node_modules", "dep", "index.js")
+		writeFile(t, src, "")
+		writeFile(t, dist, "")
+		writeFile(t, dep, "")
+		setMtime(t, src, older)
+		setMtime(t, filepath.Join(pkgDir, "src"), older)
+		setMtime(t, pkgDir, older)
+		needs, reason := libNeedsBuild(pkgDir)
+		if needs {
+			t.Fatalf("expected node_modules churn to be ignored, got: %q", reason)
+		}
+	})
+}

--- a/tools/ods/cmd/web_test.go
+++ b/tools/ods/cmd/web_test.go
@@ -86,6 +86,25 @@ func TestNodeModulesNeedsInstall(t *testing.T) {
 		}
 	})
 
+	t.Run("stamp replaces an existing file it cannot write in place", func(t *testing.T) {
+		// Sessions run as different users against the shared node_modules
+		// volume, so the previous stamp may not be writable — only
+		// replaceable via the directory. Simulate with a read-only stamp.
+		webDir := t.TempDir()
+		writeFile(t, filepath.Join(webDir, "bun.lock"), "lock-v2")
+		writeFile(t, filepath.Join(webDir, "node_modules", "pkg", "index.js"), "")
+		stampPath := filepath.Join(webDir, "node_modules", lockStampName)
+		writeFile(t, stampPath, "stale-hash")
+		if err := os.Chmod(stampPath, 0o444); err != nil {
+			t.Fatal(err)
+		}
+		writeLockStamp(webDir)
+		needs, reason := nodeModulesNeedsInstall(webDir)
+		if needs {
+			t.Fatalf("expected stamp to be replaced despite read-only file, got: %q", reason)
+		}
+	})
+
 	t.Run("no lockfile skips staleness check", func(t *testing.T) {
 		webDir := t.TempDir()
 		writeFile(t, filepath.Join(webDir, "node_modules", "pkg", "index.js"), "")


### PR DESCRIPTION
## Description

Follow-ups from an agent session in the devcontainer, in three parts:

**Consolidate browser automation on playwright chromium (no curl'd debs, no platform spoof).**
- Bump `@playwright/mcp` 0.0.75 → 0.0.78 in `.mcp.json` and pass `--browser chromium`. 0.0.75's bundled playwright predates Ubuntu 26.04 support (microsoft/playwright#40117, fixed for v1.61 via the distro-agnostic Chrome-for-Testing builds), so its chromium cannot install on the 26.04 image; 0.0.78's does natively.
- Bake that chromium revision into the image with a plain `playwright install chromium`, resolved from the MCP's own playwright dependency so the revision always matches (playwright browsers are revision-coupled to the installing version). `PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright` gives the cache a fixed path that isn't shadowed by the devcontainer's per-user cache volume; test-time installs (web e2e, integration conftest) land their own revisions alongside.
- Drop the `PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-*` spoof from the image build — `playwright install-deps` on latest playwright reports 26.04 supported natively. The integration conftest keeps its own override: playwright-python is pinned at 1.58, which still hard-fails on 26.04 (verified) — removable once that pin moves past 1.61.
- Works on both amd64 and arm64 (unlike the Google Chrome deb this replaces mid-PR).

**Self-healing `ods web <script>` (tools/ods).** The devcontainer mounts `web/node_modules` as a persistent volume, so it routinely outlives `bun.lock` updates — and `bun install` never builds the `web/lib/shared` / `web/lib/opal` workspace packages whose exports point at `dist/`. Both failure modes now repair automatically before any script runs:
- Reinstall when node_modules is missing, empty, or stale — staleness tracked by a sha256 stamp of `bun.lock` written into node_modules after each install.
- Rebuild each lib (shared before opal — build-order dependency) when its `dist/` is missing or older than its sources, via a newest-mtime walk that skips `dist`, `node_modules`, and hidden entries. Both checks cost milliseconds when clean.

**Claude Code overlay (`.devcontainer/claude-code/CLAUDE.md`).** One addition: stop backgrounded dev servers when finished (`pkill` is container-scoped — the container has its own PID namespace). Browser installs and node_modules/lib-build repair need no documentation since the image bake and `ods web` self-healing above make them just work.

After merge, dispatch the "Release Devcontainer" workflow — it publishes the image and auto-opens the digest-bump PR for `devcontainer.json`.

## How Has This Been Tested?

- End-to-end MCP proof on this 26.04 container: a scripted stdio session against `@playwright/mcp@0.0.78 --headless --isolated --browser chromium` successfully launched the natively-installed chromium (v1232) and navigated a page.
- Real (non-dry-run) `playwright install chromium` verified: succeeds with web's 1.61.1 and the MCP 0.0.78 playwright without any override; fails on the 0.0.75 alpha and python 1.58 — hence the MCP bump and the conftest override staying.
- `ods web`: unit tests for the staleness helpers (`go test ./cmd/`), plus a live two-run check — first run detects the unstamped node_modules volume, reinstalls, and stamps; second run skips straight to the script.
- `go build`, `go test`, and pre-commit (incl. golangci-lint) pass on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)