### PR TITLE
fix(box): map OAuth 400s to actionable credential errors

### DIFF
--- a/backend/onyx/connectors/box/connector.py
+++ b/backend/onyx/connectors/box/connector.py
@@ -161,16 +161,12 @@ def box_api_status_code(error: BoxAPIError) -> int | None:
     return error.response_info.status_code
 
 
-# Box token-endpoint OAuth error codes that mean the app credentials themselves
-# are wrong, rather than a transient/unexpected failure.
+# Box returns these in an HTTP 400 body when the app credentials are wrong.
 _BOX_CREDENTIAL_OAUTH_ERRORS = frozenset({"invalid_client", "unauthorized_client"})
 
 
 def box_oauth_error(error: BoxAPIError) -> tuple[str | None, str | None]:
-    """Extract the OAuth ``error`` / ``error_description`` from a Box token
-    failure. Box returns these in the response body on HTTP 400 (e.g.
-    ``invalid_client`` for a bad secret, ``unauthorized_client`` when the app
-    is not enterprise-authorized), which is where the actionable detail lives."""
+    """Return the OAuth ``(error, error_description)`` from a Box failure body."""
     body = error.response_info.body if error.response_info else None
     if not isinstance(body, dict):
         return None, None

--- a/backend/onyx/connectors/box/connector.py
+++ b/backend/onyx/connectors/box/connector.py
@@ -27,6 +27,7 @@ from onyx.connectors.cross_connector_utils.miscellaneous_utils import datetime_t
 from onyx.connectors.exceptions import (
     ConnectorValidationError,
     CredentialExpiredError,
+    CredentialInvalidError,
     InsufficientPermissionsError,
     UnexpectedValidationError,
 )
@@ -158,6 +159,22 @@ def box_api_status_code(error: BoxAPIError) -> int | None:
     if error.response_info is None:
         return None
     return error.response_info.status_code
+
+
+def box_oauth_error(error: BoxAPIError) -> tuple[str | None, str | None]:
+    """Extract the OAuth ``error`` / ``error_description`` from a Box token
+    failure. Box returns these in the response body on HTTP 400 (e.g.
+    ``invalid_client`` for a bad secret, ``unauthorized_client`` when the app
+    is not enterprise-authorized), which is where the actionable detail lives."""
+    body = error.response_info.body if error.response_info else None
+    if not isinstance(body, dict):
+        return None, None
+    code = body.get("error")
+    description = body.get("error_description")
+    return (
+        code if isinstance(code, str) else None,
+        description if isinstance(description, str) else None,
+    )
 
 
 def _to_utc(dt: datetime | None) -> datetime | None:
@@ -843,6 +860,17 @@ class BoxConnector(
                 raise InsufficientPermissionsError(
                     "The Box app lacks the scopes needed to authenticate (HTTP 403)."
                 ) from e
+            if status == 400:
+                code, description = box_oauth_error(e)
+                if code in ("invalid_client", "unauthorized_client"):
+                    raise CredentialInvalidError(
+                        f"Box rejected the app credentials ({code}): "
+                        f"{description or e.message}. Verify the Client ID and "
+                        "Client Secret belong to the same app and are current "
+                        "(re-fetch the secret in the Box Developer Console), that "
+                        "App Access Level is 'App + Enterprise Access', and that a "
+                        "Box admin has authorized the app."
+                    ) from e
             raise UnexpectedValidationError(
                 f"Unexpected Box API error during validation (status={status}): "
                 f"{e.message}"

--- a/backend/onyx/connectors/box/connector.py
+++ b/backend/onyx/connectors/box/connector.py
@@ -161,6 +161,11 @@ def box_api_status_code(error: BoxAPIError) -> int | None:
     return error.response_info.status_code
 
 
+# Box token-endpoint OAuth error codes that mean the app credentials themselves
+# are wrong, rather than a transient/unexpected failure.
+_BOX_CREDENTIAL_OAUTH_ERRORS = frozenset({"invalid_client", "unauthorized_client"})
+
+
 def box_oauth_error(error: BoxAPIError) -> tuple[str | None, str | None]:
     """Extract the OAuth ``error`` / ``error_description`` from a Box token
     failure. Box returns these in the response body on HTTP 400 (e.g.
@@ -862,7 +867,7 @@ class BoxConnector(
                 ) from e
             if status == 400:
                 code, description = box_oauth_error(e)
-                if code in ("invalid_client", "unauthorized_client"):
+                if code in _BOX_CREDENTIAL_OAUTH_ERRORS:
                     raise CredentialInvalidError(
                         f"Box rejected the app credentials ({code}): "
                         f"{description or e.message}. Verify the Client ID and "

--- a/backend/tests/unit/onyx/connectors/box/fake_box_client.py
+++ b/backend/tests/unit/onyx/connectors/box/fake_box_client.py
@@ -18,7 +18,9 @@ from box_sdk_gen.schemas.user_mini import UserMini
 from box_sdk_gen.schemas.users import Users
 
 
-def make_box_api_error(status_code: int) -> BoxAPIError:
+def make_box_api_error(
+    status_code: int, body: dict[str, object] | None = None
+) -> BoxAPIError:
     return BoxAPIError(
         request_info=RequestInfo(
             method="GET",
@@ -26,7 +28,9 @@ def make_box_api_error(status_code: int) -> BoxAPIError:
             query_params={},
             headers={},
         ),
-        response_info=ResponseInfo(status_code=status_code, headers={}),
+        response_info=ResponseInfo(
+            status_code=status_code, headers={}, body=body or {}
+        ),
         message=f"fake box error (status={status_code})",
     )
 

--- a/backend/tests/unit/onyx/connectors/box/test_box_connector.py
+++ b/backend/tests/unit/onyx/connectors/box/test_box_connector.py
@@ -22,6 +22,7 @@ from onyx.connectors.box.models import BoxFolderFrontierEntry
 from onyx.connectors.exceptions import (
     ConnectorValidationError,
     CredentialExpiredError,
+    CredentialInvalidError,
     InsufficientPermissionsError,
     UnexpectedValidationError,
 )
@@ -574,6 +575,41 @@ def test_identity_validation_preserves_box_api_error(
         connector.validate_connector_settings()
 
     assert exc_info.value.__cause__ is box_error
+
+
+@pytest.mark.parametrize("oauth_error", ["invalid_client", "unauthorized_client"])
+def test_identity_validation_maps_oauth_400_to_credential_invalid(
+    oauth_error: str,
+) -> None:
+    connector = BoxConnector()
+    client = MagicMock()
+    box_error = make_box_api_error(
+        400,
+        body={"error": oauth_error, "error_description": "boom"},
+    )
+    client.users.get_user_me.side_effect = box_error
+    connector._auth = cast(BoxCCGAuth, MagicMock())
+    connector._content_client = cast(BoxClient, client)
+
+    with pytest.raises(CredentialInvalidError) as exc_info:
+        connector.validate_connector_settings()
+
+    assert exc_info.value.__cause__ is box_error
+    message = str(exc_info.value)
+    assert oauth_error in message
+    assert "boom" in message
+
+
+def test_identity_validation_unrecognized_400_stays_unexpected() -> None:
+    connector = BoxConnector()
+    client = MagicMock()
+    box_error = make_box_api_error(400, body={"error": "something_else"})
+    client.users.get_user_me.side_effect = box_error
+    connector._auth = cast(BoxCCGAuth, MagicMock())
+    connector._content_client = cast(BoxClient, client)
+
+    with pytest.raises(UnexpectedValidationError):
+        connector.validate_connector_settings()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

When a Box connector fails to validate because the app credentials are wrong, Box's token endpoint returns an HTTP 400 with an OAuth error body (`invalid_client` for a bad/mismatched secret, `unauthorized_client` when the app is not authorized for enterprise access). Previously `BoxConnector.validate_connector_settings` lumped every non-401/403/404 `BoxAPIError` into a generic `UnexpectedValidationError` — so the admin saw "Unexpected Box API error during validation" and the connector was treated as a transient failure rather than a bad credential.

This maps those two OAuth 400s to `CredentialInvalidError` with a message that quotes Box's own `error` / `error_description` and states the fix (matching current Client ID + Secret from the same app, App + Enterprise Access, admin authorization). Because `CredentialInvalidError` is a `ConnectorValidationError` subclass, the failure now surfaces as a clean, specific 400 in the UI, is caught by the connector-creation handler instead of escaping as a 500, and correctly marks the credential invalid. Other 400s intentionally stay `UnexpectedValidationError`.

Prompted by a managed-services customer hitting both errors in sequence during Box setup.

## How Has This Been Tested?

- `uv run pytest backend/tests/unit/onyx/connectors/box/test_box_connector.py` — 41 passed, including 3 new cases (both OAuth codes map to `CredentialInvalidError` with the code + description in the message; an unrecognized 400 still falls through to `UnexpectedValidationError`).
- `pre-commit run --files` on the changed files — `ty`, ruff, ruff-format all pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Maps Box OAuth 400s to clear credential errors so admins see actionable messages instead of a generic failure. Bad credentials now surface as a specific 400 in the UI and are handled without a 500.

- **Bug Fixes**
  - In `BoxConnector.validate_connector_settings`, map 400 `invalid_client` and `unauthorized_client` to `CredentialInvalidError` with Box’s error and short fix guidance (match Client ID/Secret, enable App + Enterprise Access, get admin authorization).
  - Leave other 400s as `UnexpectedValidationError`.
  - Add unit tests for both mappings and the fallback; update the fake client to include response bodies.

- **Refactors**
  - Hoisted recognized OAuth error codes to a `frozenset` and added `box_oauth_error` to extract OAuth fields.
  - Trimmed inline comments for brevity.

<sup>Written for commit 2a703a17df0bc4f3aa4d832822ddf4f25b916dce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

