### PR TITLE
perf(llm): raise provider listing cache TTL to 300s

### DIFF
--- a/backend/onyx/server/manage/llm/provider_cache.py
+++ b/backend/onyx/server/manage/llm/provider_cache.py
@@ -29,7 +29,10 @@ logger = setup_logger()
 
 _VERSION_KEY = "llm_provider_listing:version"
 _ENTRY_KEY_PREFIX = "llm_provider_listing:entry"
-ENTRY_TTL_SECONDS = 60
+# Staleness bound only for changes that bypass explicit invalidation (see module
+# docstring); provider mutations rewrite the version token immediately. Keep this
+# high enough that steady-state traffic rarely rebuilds the payload cold.
+ENTRY_TTL_SECONDS = 300
 
 
 class ProviderListingCacheLookup(BaseModel):


### PR DESCRIPTION
## Description

`GET /llm/provider` and `GET /llm/persona/{persona_id}/providers` (hit on every chat page load) show a cleanly bimodal latency profile: 12–98ms on cache hit vs 1.5–2.7s rebuilding cold, explained entirely by `ENTRY_TTL_SECONDS = 60` in `backend/onyx/server/manage/llm/provider_cache.py`.

The TTL is only a backstop: every real provider mutation already invalidates explicitly via the per-tenant version token (11 call sites across `llm/api.py` and `image_generation/api.py`). Per the module docstring, the TTL exists only for changes that bypass the provider API — in practice, persona default-model edits, which bake into the persona-scoped listing's `default_text`. Group-membership changes alter the cache key itself, so they never serve stale data.

Since cache keys are `(tenant, persona, is_admin, sorted_group_ids)`, a 60s TTL means the fleet is near-continuously rebuilding this payload on Cloud. Raising it to 300s cuts cold-path frequency 5× while keeping the bypass-path staleness bound at 5 minutes.

Follow-up (separate PR): add explicit invalidation on persona create/update, which would make the TTL a pure backstop and allow raising it further.

## How Has This Been Tested?

- `uv run pytest backend/tests/unit/onyx/server/manage/llm/test_provider_cache.py` — 8 passed (nothing asserts the TTL value; the fake cache ignores expiry, so no test changes needed)
- `pre-commit run --files backend/onyx/server/manage/llm/provider_cache.py` — clean

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise provider listing cache TTL from 60s to 300s to cut cold rebuilds on `GET /llm/provider` and `GET /llm/persona/{persona_id}/providers`, improving chat page load times. Provider mutations still invalidate via the per-tenant version token; only changes outside the provider API can be stale, now capped at 5 minutes.

<sup>Written for commit 74f300f921ea8c222cd425cf67fee448d5319a59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

