### PR TITLE
feat(web): default to full-width chat below md and hide the toggle

### DIFF
--- a/web/src/layouts/chromes/AppChrome.tsx
+++ b/web/src/layouts/chromes/AppChrome.tsx
@@ -468,14 +468,18 @@ function Header() {
                     >
                       Share
                     </Button>
-                    <Button
-                      icon={fullWidthChat ? SvgFitWidth : SvgFullWidth}
-                      prominence="tertiary"
-                      onClick={toggleFullWidthChat}
-                      tooltip={fullWidthChat ? "Fit width" : "Full width"}
-                      aria-label="Toggle full width chat"
-                      aria-pressed={fullWidthChat}
-                    />
+                    {/* Below md the reading-width cap never applies (chat is
+                        always full width), so the toggle has nothing to do. */}
+                    <span className="hidden md:flex">
+                      <Button
+                        icon={fullWidthChat ? SvgFitWidth : SvgFullWidth}
+                        prominence="tertiary"
+                        onClick={toggleFullWidthChat}
+                        tooltip={fullWidthChat ? "Fit width" : "Full width"}
+                        aria-label="Toggle full width chat"
+                        aria-pressed={fullWidthChat}
+                      />
+                    </span>
                     <SimplePopover
                       trigger={
                         <Button

--- a/web/src/sections/chat/ChatScrollContainer.tsx
+++ b/web/src/sections/chat/ChatScrollContainer.tsx
@@ -363,13 +363,14 @@ const ChatScrollContainer = React.memo(
             data-chat-scroll
             className={cn(
               "flex flex-col flex-1 min-h-0 overflow-y-auto overflow-x-hidden",
-              hideScrollbar ? "no-scrollbar" : "default-scrollbar"
+              hideScrollbar ? "no-scrollbar" : "default-scrollbar",
+              // Full-width (always the case below md) drops the reserved
+              // gutters so content sits flush with the chat edge; centered
+              // mode keeps both-edges to avoid shift.
+              !fullWidth && "md:[scrollbar-gutter:stable_both-edges]"
             )}
             onScroll={handleScroll}
             style={{
-              // Full-width drops the reserved gutters so content sits flush with
-              // the chat edge; centered mode keeps both-edges to avoid shift.
-              scrollbarGutter: fullWidth ? "auto" : "stable both-edges",
               // Apply mask to fade content opacity at edges
               maskImage: contentMask,
               WebkitMaskImage: contentMask,

--- a/web/src/sections/chat/ChatUI.tsx
+++ b/web/src/sections/chat/ChatUI.tsx
@@ -23,7 +23,10 @@ import {
 import { cn } from "@opal/utils";
 
 /** Width constraint for normal (non-multi-model) messages. */
-const MSG_MAX_W = "max-w-[720px] min-w-[400px]";
+// Reading-width cap only applies at md and up — below that the window is too
+// narrow for it to matter, so chat is always full width (and the top-bar
+// toggle is hidden).
+const MSG_MAX_W = "md:max-w-[720px] md:min-w-[400px]";
 
 export interface ChatUIProps {
   liveAgent: MinimalAgent;
@@ -166,7 +169,7 @@ const ChatUI = React.memo(
         <div
           className={cn(
             "flex flex-col w-full h-full pt-4 pb-8 gap-12",
-            !fullWidthChat && "pr-1"
+            !fullWidthChat && "md:pr-1"
           )}
         >
           {messages.map((message, i) => {

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -941,7 +941,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                       "relative w-full flex flex-col",
                       onboardingVisible && "min-h-0",
                       !fullWidthActive &&
-                        "max-w-(--app-page-main-content-width)"
+                        "md:max-w-(--app-page-main-content-width)"
                     )}
                   >
                     {/* Scroll to bottom button - positioned absolutely above AppInputBar */}


### PR DESCRIPTION
## Description

Below the `md` breakpoint (912px — where the sidebar switches to overlay mode), the 720px reading-width cap barely fits the window, so the full-width chat toggle does nothing useful. This makes full-width chat the default on small screens and hides the toggle there.

Implemented via responsive CSS rather than JS screen-size detection, so the first paint is correct before hydration (no button/layout flash on phones) and the breakpoint is defined once (Tailwind `md` = `MEDIUM_BREAKPOINT_PX`):

- `ChatUI`: reading-width cap is now `md:max-w-[720px] md:min-w-[400px]`; the centered-mode `pr-1` became `md:pr-1`. Gating `min-w-[400px]` to `md+` also stops horizontal overflow on sub-400px viewports.
- `ChatScrollContainer`: `scrollbar-gutter` moved from inline style to classes so it can be responsive — centered mode reserves gutters only at `md+`.
- `AppPage`: input-bar cap became `md:max-w-(--app-page-main-content-width)`.
- `AppChrome`: the toggle button is wrapped in `hidden md:flex` (Opal `Button` strips `className` by design, and the design system already uses this pattern internally for `responsiveHideText`).

`FullWidthChatProvider` is untouched — the persisted preference still governs behavior at `md+`.

## How Tested

Verified live with Playwright against the dev stack on a real chat session:

- 1400px: toggle visible, cap applies (720px), toggling drops the cap + gutters and toggles back cleanly, `aria-pressed` tracks state.
- 800px and 400px: toggle is `display:none`, messages and input bar span the full viewport minus padding, `scrollbar-gutter` is `auto`.
- Pre-commit hooks (oxfmt, oxlint, tsc) pass on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1902" height="2085" alt="20260731_12h02m52s_grim" src="https://github.com/user-attachments/assets/37bb0937-e772-468b-8878-3babd9fce239" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make chat full width by default below the `md` (912px) breakpoint and hide the full‑width toggle. Uses responsive CSS (`md:`-prefixed width and gutter rules) to avoid layout flash and horizontal overflow on small screens; the saved preference still applies at `md+`.

<sup>Written for commit 53183710d53ad8085ed8177045ba56db3a4fded3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

