### PR TITLE
feat(db): place new tenants on a configured shard

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/tenant_provisioning/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/tenant_provisioning/tasks.py
@@ -23,8 +23,10 @@ from onyx.configs.constants import (
     OnyxCeleryTask,
     OnyxRedisLocks,
 )
+from onyx.db.engine.shard_routing import get_shard_for_new_tenant
 from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.models import AvailableTenant
+from onyx.db.tenant_shard import record_tenant_placement
 from onyx.redis.redis_pool import get_redis_client
 from shared_configs.configs import MULTI_TENANT, TENANT_ID_PREFIX
 
@@ -194,7 +196,12 @@ def pre_provision_tenant() -> bool:
     try:
         # Generate a new tenant ID
         tenant_id = TENANT_ID_PREFIX + str(uuid.uuid4())
-        task_logger.info(f"Pre-provisioning tenant: {tenant_id}")
+        shard_name = get_shard_for_new_tenant()
+        task_logger.info(f"Pre-provisioning tenant {tenant_id} on shard {shard_name}")
+
+        # Recorded before the schema exists: every step below resolves the tenant's
+        # physical database through the catalog, so the mapping has to be there first.
+        record_tenant_placement(tenant_id, shard_name)
 
         # Create the schema for the new tenant
         schema_created = create_schema_if_not_exists(tenant_id)
@@ -224,6 +231,7 @@ def pre_provision_tenant() -> bool:
                     tenant_id=tenant_id,
                     alembic_version=alembic_version,
                     date_created=datetime.datetime.now(),
+                    shard_name=shard_name,
                 )
                 db_session.add(new_tenant)
                 db_session.commit()

--- a/backend/ee/onyx/background/celery/tasks/tenant_provisioning/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/tenant_provisioning/tasks.py
@@ -199,8 +199,7 @@ def pre_provision_tenant() -> bool:
         shard_name = get_shard_for_new_tenant()
         task_logger.info(f"Pre-provisioning tenant {tenant_id} on shard {shard_name}")
 
-        # Recorded before the schema exists: every step below resolves the tenant's
-        # physical database through the catalog, so the mapping has to be there first.
+        # Before schema creation: every step below routes via the catalog.
         record_tenant_placement(tenant_id, shard_name)
 
         # Create the schema for the new tenant

--- a/backend/ee/onyx/server/tenants/provisioning.py
+++ b/backend/ee/onyx/server/tenants/provisioning.py
@@ -209,8 +209,7 @@ async def provision_tenant(tenant_id: str, email: str) -> None:
     )
 
     try:
-        # Recorded before the schema exists: every step below resolves the tenant's
-        # physical database through the catalog, so the mapping has to be there first.
+        # Before schema creation: every step below routes via the catalog.
         record_tenant_placement(tenant_id, shard_name)
 
         # Create the schema for the tenant
@@ -323,8 +322,7 @@ async def rollback_tenant_provisioning(tenant_id: str) -> None:
         logger.error(error_msg)
         rollback_errors.append(error_msg)
 
-    # 4. Drop the shard mapping. Last, so the steps above still route to the right
-    # database while they run.
+    # 4. Drop the shard mapping. Last, so the steps above still route correctly.
     try:
         clear_tenant_placement(tenant_id)
         logger.info("Successfully cleared shard mapping for tenant %s", tenant_id)

--- a/backend/ee/onyx/server/tenants/provisioning.py
+++ b/backend/ee/onyx/server/tenants/provisioning.py
@@ -36,6 +36,7 @@ from onyx.configs.app_configs import (
     VERTEXAI_DEFAULT_CREDENTIALS,
     VERTEXAI_DEFAULT_LOCATION,
 )
+from onyx.db.engine.shard_routing import get_shard_for_new_tenant
 from onyx.db.engine.sql_engine import (
     get_session_with_shared_schema,
     get_session_with_tenant,
@@ -54,6 +55,7 @@ from onyx.db.models import (
     SearchSettings,
     UserTenantMapping,
 )
+from onyx.db.tenant_shard import clear_tenant_placement, record_tenant_placement
 from onyx.llm.well_known_providers.auto_update_models import LLMRecommendations
 from onyx.llm.well_known_providers.constants import (
     ANTHROPIC_PROVIDER_NAME,
@@ -201,9 +203,16 @@ async def provision_tenant(tenant_id: str, email: str) -> None:
             status_code=409, detail="User already belongs to an organization"
         )
 
-    logger.debug("Provisioning tenant %s for user %s", tenant_id, email)
+    shard_name = get_shard_for_new_tenant()
+    logger.debug(
+        "Provisioning tenant %s for user %s on shard %s", tenant_id, email, shard_name
+    )
 
     try:
+        # Recorded before the schema exists: every step below resolves the tenant's
+        # physical database through the catalog, so the mapping has to be there first.
+        record_tenant_placement(tenant_id, shard_name)
+
         # Create the schema for the tenant
         if not create_schema_if_not_exists(tenant_id):
             logger.debug("Created schema for tenant %s", tenant_id)
@@ -311,6 +320,16 @@ async def rollback_tenant_provisioning(tenant_id: str) -> None:
                 raise e
     except Exception as e:
         error_msg = f"Failed to remove tenant {tenant_id} from available tenants table: {str(e)}"
+        logger.error(error_msg)
+        rollback_errors.append(error_msg)
+
+    # 4. Drop the shard mapping. Last, so the steps above still route to the right
+    # database while they run.
+    try:
+        clear_tenant_placement(tenant_id)
+        logger.info("Successfully cleared shard mapping for tenant %s", tenant_id)
+    except Exception as e:
+        error_msg = f"Failed to clear shard mapping for tenant {tenant_id}: {str(e)}"
         logger.error(error_msg)
         rollback_errors.append(error_msg)
 

--- a/backend/ee/onyx/server/tenants/provisioning.py
+++ b/backend/ee/onyx/server/tenants/provisioning.py
@@ -269,8 +269,10 @@ async def rollback_tenant_provisioning(tenant_id: str) -> None:
     rollback_errors = []
 
     # 1. Try to drop the tenant's schema
+    schema_dropped = False
     try:
         drop_schema(tenant_id)
+        schema_dropped = True
         logger.info("Successfully dropped schema for tenant %s", tenant_id)
     except Exception as e:
         error_msg = f"Failed to drop schema for tenant {tenant_id}: {str(e)}"
@@ -322,14 +324,25 @@ async def rollback_tenant_provisioning(tenant_id: str) -> None:
         logger.error(error_msg)
         rollback_errors.append(error_msg)
 
-    # 4. Drop the shard mapping. Last, so the steps above still route correctly.
-    try:
-        clear_tenant_placement(tenant_id)
-        logger.info("Successfully cleared shard mapping for tenant %s", tenant_id)
-    except Exception as e:
-        error_msg = f"Failed to clear shard mapping for tenant {tenant_id}: {str(e)}"
-        logger.error(error_msg)
-        rollback_errors.append(error_msg)
+    # 4. Drop the shard mapping — last, and only if the schema is actually gone.
+    # The mapping is the only route to that schema, so clearing it after a failed
+    # drop strands it on a shard nothing can resolve.
+    if schema_dropped:
+        try:
+            clear_tenant_placement(tenant_id)
+            logger.info("Successfully cleared shard mapping for tenant %s", tenant_id)
+        except Exception as e:
+            error_msg = (
+                f"Failed to clear shard mapping for tenant {tenant_id}: {str(e)}"
+            )
+            logger.error(error_msg)
+            rollback_errors.append(error_msg)
+    else:
+        logger.warning(
+            "Keeping shard mapping for tenant %s: its schema was not dropped, and the "
+            "mapping is what a retry needs to find it",
+            tenant_id,
+        )
 
     # Log summary of rollback operation
     if rollback_errors:

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -632,6 +632,12 @@ ONYX_DB_DEFAULT_SHARD = os.environ.get("ONYX_DB_DEFAULT_SHARD") or "default"
 # Shard that holds the shared `public` catalog tables (user_tenant_mapping etc.)
 # and the tenant -> shard map itself. Must be resolvable without a lookup.
 ONYX_DB_CATALOG_SHARD = os.environ.get("ONYX_DB_CATALOG_SHARD") or ONYX_DB_DEFAULT_SHARD
+# Shard that newly created tenants are placed on. Existing tenants are unaffected;
+# flipping this changes where the *next* tenant's schema is built. The pre-provisioned
+# pool drains oldest-first, so a flip ramps in gradually rather than all at once.
+ONYX_DB_NEW_TENANT_SHARD = (
+    os.environ.get("ONYX_DB_NEW_TENANT_SHARD") or ONYX_DB_DEFAULT_SHARD
+)
 # Operator escape hatch: JSON object of tenant_id -> shard name, consulted
 # before the catalog table. Intended for incident response, not routine use.
 ONYX_DB_SHARD_OVERRIDES_JSON = os.environ.get("ONYX_DB_SHARD_OVERRIDES", "").strip()

--- a/backend/onyx/db/engine/shard_registry.py
+++ b/backend/onyx/db/engine/shard_registry.py
@@ -79,9 +79,9 @@ class ShardSpec:
 def _validate_named_shards(specs: dict[str, ShardSpec]) -> None:
     """Fail at startup if a settings-named shard does not exist.
 
-    Checked on the unconfigured path too: pointing one of these at a name without also
-    defining ONYX_DB_SHARDS otherwise starts cleanly and then breaks at request time —
-    every catalog session for the former, every signup for the latter.
+    Checked on the unconfigured path too: naming one of these without also defining
+    ONYX_DB_SHARDS otherwise starts cleanly and then breaks at request time — every
+    catalog session for the former, every signup for the latter.
     """
     for setting, name in (
         ("ONYX_DB_CATALOG_SHARD", ONYX_DB_CATALOG_SHARD),

--- a/backend/onyx/db/engine/shard_registry.py
+++ b/backend/onyx/db/engine/shard_registry.py
@@ -31,6 +31,7 @@ from sqlalchemy.engine import Engine, create_engine
 from onyx.configs.app_configs import (
     ONYX_DB_CATALOG_SHARD,
     ONYX_DB_DEFAULT_SHARD,
+    ONYX_DB_NEW_TENANT_SHARD,
     ONYX_DB_SHARDS_JSON,
     POSTGRES_DB,
     POSTGRES_HOST,
@@ -75,18 +76,21 @@ class ShardSpec:
     __str__ = __repr__
 
 
-def _validate_catalog_shard(specs: dict[str, ShardSpec]) -> None:
-    """Fail at startup if the catalog shard names something that does not exist.
+def _validate_named_shards(specs: dict[str, ShardSpec]) -> None:
+    """Fail at startup if a settings-named shard does not exist.
 
-    Checked on the unconfigured path too: pointing ONYX_DB_CATALOG_SHARD at a name
-    without also defining ONYX_DB_SHARDS otherwise starts cleanly and then breaks
-    every catalog session at request time.
+    Checked on the unconfigured path too: pointing one of these at a name without also
+    defining ONYX_DB_SHARDS otherwise starts cleanly and then breaks at request time —
+    every catalog session for the former, every signup for the latter.
     """
-    if ONYX_DB_CATALOG_SHARD not in specs:
-        raise ShardConfigurationError(
-            f"ONYX_DB_CATALOG_SHARD='{ONYX_DB_CATALOG_SHARD}' is not a configured shard "
-            f"(known: {sorted(specs)})"
-        )
+    for setting, name in (
+        ("ONYX_DB_CATALOG_SHARD", ONYX_DB_CATALOG_SHARD),
+        ("ONYX_DB_NEW_TENANT_SHARD", ONYX_DB_NEW_TENANT_SHARD),
+    ):
+        if name not in specs:
+            raise ShardConfigurationError(
+                f"{setting}='{name}' is not a configured shard (known: {sorted(specs)})"
+            )
 
 
 def _parse_shard_specs() -> dict[str, ShardSpec]:
@@ -106,7 +110,7 @@ def _parse_shard_specs() -> dict[str, ShardSpec]:
     specs: dict[str, ShardSpec] = {default_spec.name: default_spec}
 
     if not ONYX_DB_SHARDS_JSON:
-        _validate_catalog_shard(specs)
+        _validate_named_shards(specs)
         return specs
 
     try:
@@ -156,7 +160,7 @@ def _parse_shard_specs() -> dict[str, ShardSpec]:
             password=password,
         )
 
-    _validate_catalog_shard(specs)
+    _validate_named_shards(specs)
 
     return specs
 
@@ -236,6 +240,11 @@ def get_default_shard_name() -> str:
 
 def get_catalog_shard_name() -> str:
     return ONYX_DB_CATALOG_SHARD
+
+
+def get_new_tenant_shard_name() -> str:
+    """Shard that newly created tenants are placed on."""
+    return ONYX_DB_NEW_TENANT_SHARD
 
 
 class ShardRegistry:

--- a/backend/onyx/db/engine/shard_routing.py
+++ b/backend/onyx/db/engine/shard_routing.py
@@ -240,14 +240,9 @@ def get_shard_for_tenant(tenant_id: str) -> str:
 def get_shard_for_new_tenant() -> str:
     """Shard a tenant being created right now should be placed on.
 
-    Distinct from `get_shard_for_tenant`, which answers where an *existing* tenant
-    already lives. A tenant that has no schema yet cannot be resolved through a catalog
-    describing only tenants that do, so placement is a configuration decision rather
-    than a lookup.
-
-    Raises if the configured shard is unknown. Placing a tenant on the default shard
-    because the intended one could not be resolved is exactly the silent misplacement
-    this is meant to prevent.
+    A configuration decision, not a lookup: unlike `get_shard_for_tenant`, there is no
+    catalog row to consult yet. Raises rather than defaulting on an unknown shard —
+    silently placing a tenant elsewhere is what this is meant to prevent.
     """
     shard_name = get_new_tenant_shard_name()
     if shard_name not in get_shard_specs():

--- a/backend/onyx/db/engine/shard_routing.py
+++ b/backend/onyx/db/engine/shard_routing.py
@@ -37,6 +37,7 @@ from onyx.db.engine.shard_registry import (
     get_catalog_engine,
     get_default_shard_name,
     get_engine_for_shard,
+    get_new_tenant_shard_name,
     get_shard_specs,
     is_sharded,
 )
@@ -233,6 +234,27 @@ def get_shard_for_tenant(tenant_id: str) -> str:
         )
 
     _ShardCache.put(tenant_id, shard_name, generation)
+    return shard_name
+
+
+def get_shard_for_new_tenant() -> str:
+    """Shard a tenant being created right now should be placed on.
+
+    Distinct from `get_shard_for_tenant`, which answers where an *existing* tenant
+    already lives. A tenant that has no schema yet cannot be resolved through a catalog
+    describing only tenants that do, so placement is a configuration decision rather
+    than a lookup.
+
+    Raises if the configured shard is unknown. Placing a tenant on the default shard
+    because the intended one could not be resolved is exactly the silent misplacement
+    this is meant to prevent.
+    """
+    shard_name = get_new_tenant_shard_name()
+    if shard_name not in get_shard_specs():
+        raise ShardConfigurationError(
+            f"ONYX_DB_NEW_TENANT_SHARD='{shard_name}' is not a configured shard "
+            f"(known: {sorted(get_shard_specs())})"
+        )
     return shard_name
 
 

--- a/backend/onyx/db/engine/shard_routing.py
+++ b/backend/onyx/db/engine/shard_routing.py
@@ -153,7 +153,7 @@ def reset_shard_overrides() -> None:
         _OVERRIDES = None
 
 
-def _is_undefined_table(exc: BaseException) -> bool:
+def is_undefined_table(exc: BaseException) -> bool:
     """True only for 'public.tenant_shard does not exist'.
 
     Separating this from other failures is what makes the default-shard fallback safe:
@@ -186,7 +186,7 @@ def _lookup_shard_in_catalog(tenant_id: str) -> str | None:
                 {"tenant_id": tenant_id},
             ).first()
     except Exception as e:
-        if _is_undefined_table(e):
+        if is_undefined_table(e):
             # Deployment has not run the catalog migration yet; nothing is mapped.
             return None
         logger.exception("tenant_shard lookup failed for %s", tenant_id)

--- a/backend/onyx/db/tenant_shard.py
+++ b/backend/onyx/db/tenant_shard.py
@@ -1,0 +1,68 @@
+"""Writes to the `public.tenant_shard` catalog table.
+
+Reads live in `onyx.db.engine.shard_routing`, which is on the request hot path and
+caches aggressively. Writes happen at provisioning and teardown time only, so they go
+straight to the catalog database with no caching.
+
+Raw SQL against an explicitly schema-qualified name, matching the read side:
+`schema_translate_map` only rewrites SQLAlchemy `Table` constructs, so an unqualified
+name in `text()` would resolve against whatever `search_path` the pooled connection
+happens to carry.
+"""
+
+from sqlalchemy import text
+
+from onyx.db.engine.shard_registry import get_catalog_engine, is_default_shard
+from onyx.db.engine.shard_routing import invalidate_shard_cache
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def record_tenant_placement(tenant_id: str, shard_name: str) -> None:
+    """Record which physical database a tenant's schema is being created on.
+
+    Must be called *before* the schema is created. Every provisioning step after that
+    resolves the tenant's database through the catalog, so the mapping has to be there
+    for them to reach the right one.
+
+    Writes nothing for the default shard. An absent row already means "default", and
+    keeping it that way leaves existing tenants and new ones described by one rule
+    rather than splitting the fleet into mapped and unmapped halves.
+    """
+    if is_default_shard(shard_name):
+        return
+
+    with get_catalog_engine().connect() as connection:
+        with connection.begin():
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO public.tenant_shard (tenant_id, shard_name)
+                    VALUES (:tenant_id, :shard_name)
+                    ON CONFLICT (tenant_id)
+                    DO UPDATE SET shard_name = EXCLUDED.shard_name, updated_at = now()
+                    """
+                ),
+                {"tenant_id": tenant_id, "shard_name": shard_name},
+            )
+
+    # A resolution attempted before this write would have cached "default" for a full
+    # TTL, sending the schema to the wrong database. Local invalidation is enough: a
+    # tenant this new cannot have been resolved anywhere else.
+    invalidate_shard_cache(tenant_id)
+    logger.info("Placed tenant %s on shard %s", tenant_id, shard_name)
+
+
+def clear_tenant_placement(tenant_id: str) -> None:
+    """Drop a tenant's shard mapping, for teardown paths.
+
+    Leaving the row behind is inert — tenant IDs are UUIDs and are never reused — but
+    it would misreport which shard is holding capacity.
+    """
+    with get_catalog_engine().connect() as connection:
+        with connection.begin():
+            connection.execute(
+                text("DELETE FROM public.tenant_shard WHERE tenant_id = :tenant_id"),
+                {"tenant_id": tenant_id},
+            )

--- a/backend/onyx/db/tenant_shard.py
+++ b/backend/onyx/db/tenant_shard.py
@@ -1,13 +1,8 @@
-"""Writes to the `public.tenant_shard` catalog table.
+"""Writes to the `public.tenant_shard` catalog table. Reads live in `shard_routing`.
 
-Reads live in `onyx.db.engine.shard_routing`, which is on the request hot path and
-caches aggressively. Writes happen at provisioning and teardown time only, so they go
-straight to the catalog database with no caching.
-
-Raw SQL against an explicitly schema-qualified name, matching the read side:
-`schema_translate_map` only rewrites SQLAlchemy `Table` constructs, so an unqualified
-name in `text()` would resolve against whatever `search_path` the pooled connection
-happens to carry.
+Schema-qualified raw SQL, matching the read side: `schema_translate_map` only rewrites
+SQLAlchemy `Table` constructs, so an unqualified name in `text()` would resolve against
+whatever `search_path` the pooled connection happens to carry.
 """
 
 from sqlalchemy import text
@@ -20,15 +15,11 @@ logger = setup_logger()
 
 
 def record_tenant_placement(tenant_id: str, shard_name: str) -> None:
-    """Record which physical database a tenant's schema is being created on.
+    """Record where a tenant's schema is about to be created.
 
-    Must be called *before* the schema is created. Every provisioning step after that
-    resolves the tenant's database through the catalog, so the mapping has to be there
-    for them to reach the right one.
-
-    Writes nothing for the default shard. An absent row already means "default", and
-    keeping it that way leaves existing tenants and new ones described by one rule
-    rather than splitting the fleet into mapped and unmapped halves.
+    Must run *before* schema creation: every step after it resolves the tenant's
+    database through the catalog. Writes nothing for the default shard, since an
+    absent row already means "default".
     """
     if is_default_shard(shard_name):
         return
@@ -47,19 +38,15 @@ def record_tenant_placement(tenant_id: str, shard_name: str) -> None:
                 {"tenant_id": tenant_id, "shard_name": shard_name},
             )
 
-    # A resolution attempted before this write would have cached "default" for a full
-    # TTL, sending the schema to the wrong database. Local invalidation is enough: a
-    # tenant this new cannot have been resolved anywhere else.
+    # A lookup before this write caches "default" for a full TTL, which would send the
+    # schema to the wrong database. Local-only: nothing else has seen this tenant.
     invalidate_shard_cache(tenant_id)
     logger.info("Placed tenant %s on shard %s", tenant_id, shard_name)
 
 
 def clear_tenant_placement(tenant_id: str) -> None:
-    """Drop a tenant's shard mapping, for teardown paths.
-
-    Leaving the row behind is inert — tenant IDs are UUIDs and are never reused — but
-    it would misreport which shard is holding capacity.
-    """
+    """Drop a tenant's shard mapping. Inert if left behind, since tenant ids are never
+    reused, but it would misreport which shard is holding capacity."""
     with get_catalog_engine().connect() as connection:
         with connection.begin():
             connection.execute(

--- a/backend/onyx/db/tenant_shard.py
+++ b/backend/onyx/db/tenant_shard.py
@@ -8,7 +8,7 @@ whatever `search_path` the pooled connection happens to carry.
 from sqlalchemy import text
 
 from onyx.db.engine.shard_registry import get_catalog_engine, is_default_shard
-from onyx.db.engine.shard_routing import invalidate_shard_cache
+from onyx.db.engine.shard_routing import invalidate_shard_cache, is_undefined_table
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -46,10 +46,23 @@ def record_tenant_placement(tenant_id: str, shard_name: str) -> None:
 
 def clear_tenant_placement(tenant_id: str) -> None:
     """Drop a tenant's shard mapping. Inert if left behind, since tenant ids are never
-    reused, but it would misreport which shard is holding capacity."""
-    with get_catalog_engine().connect() as connection:
-        with connection.begin():
-            connection.execute(
-                text("DELETE FROM public.tenant_shard WHERE tenant_id = :tenant_id"),
-                {"tenant_id": tenant_id},
-            )
+    reused, but it would misreport which shard is holding capacity.
+
+    Tolerates a missing table, matching the read path: teardown runs on every
+    deployment, including one that has not applied the catalog migration, and nothing
+    can be mapped there anyway. The insert deliberately does not — reaching it means
+    shards are configured, so the table has to exist.
+    """
+    try:
+        with get_catalog_engine().connect() as connection:
+            with connection.begin():
+                connection.execute(
+                    text(
+                        "DELETE FROM public.tenant_shard WHERE tenant_id = :tenant_id"
+                    ),
+                    {"tenant_id": tenant_id},
+                )
+    except Exception as e:
+        if not is_undefined_table(e):
+            raise
+        logger.debug("public.tenant_shard does not exist; nothing to clear")

--- a/backend/scripts/tenant_cleanup/on_pod_scripts/cleanup_tenant_schema.py
+++ b/backend/scripts/tenant_cleanup/on_pod_scripts/cleanup_tenant_schema.py
@@ -24,8 +24,7 @@ def drop_data_plane_schema(tenant_id: str) -> dict[str, str]:
     SqlEngine.init_engine(pool_size=5, max_overflow=2)
 
     try:
-        # The schema lives on the tenant's shard, which is not necessarily the database
-        # holding the catalog tables cleaned up below.
+        # The schema lives on the tenant's shard, not necessarily the catalog database.
         with get_engine_for_tenant(tenant_id).connect() as connection:
             with connection.begin():
                 check_schema_query = text("""
@@ -34,23 +33,24 @@ def drop_data_plane_schema(tenant_id: str) -> dict[str, str]:
                     WHERE nspname = :schema_name
                 """)
 
-                result = connection.execute(
-                    check_schema_query, {"schema_name": tenant_id}
-                ).fetchone()
+                schema_exists = (
+                    connection.execute(
+                        check_schema_query, {"schema_name": tenant_id}
+                    ).fetchone()
+                    is not None
+                )
 
-                if not result:
+                if schema_exists:
+                    # CASCADE to remove all objects within it
+                    connection.execute(
+                        text(f'DROP SCHEMA IF EXISTS "{tenant_id}" CASCADE')
+                    )
+                    print(f"Successfully dropped schema: {tenant_id}", file=sys.stderr)
+                else:
                     print(f"Schema {tenant_id} does not exist", file=sys.stderr)
-                    return {
-                        "status": "not_found",
-                        "message": f"Schema {tenant_id} does not exist",
-                    }
 
-                # Drop the schema with CASCADE to remove all objects within it
-                drop_schema_query = text(f'DROP SCHEMA IF EXISTS "{tenant_id}" CASCADE')
-                connection.execute(drop_schema_query)
-
-        print(f"Successfully dropped schema: {tenant_id}", file=sys.stderr)
-
+        # Runs even when the schema was already gone, so a retry after a partially
+        # completed cleanup converges instead of repeating `not_found` forever.
         with get_session_with_shared_schema() as session:
             # Schema-qualified on purpose: schema_translate_map only rewrites SQLAlchemy
             # Table constructs, not raw text(), so an unqualified name resolves against
@@ -62,11 +62,15 @@ def drop_data_plane_schema(tenant_id: str) -> dict[str, str]:
             session.execute(delete_mapping_query, {"tenant_id": tenant_id})
             session.commit()
 
-        print(f"Successfully deleted tenant mapping for: {tenant_id}", file=sys.stderr)
-
         # Last: the shard lookup above depends on this row.
         clear_tenant_placement(tenant_id)
+        print(f"Successfully deleted tenant mapping for: {tenant_id}", file=sys.stderr)
 
+        if not schema_exists:
+            return {
+                "status": "not_found",
+                "message": f"Schema {tenant_id} does not exist; cleared catalog rows",
+            }
         return {
             "status": "success",
             "message": f"Successfully dropped schema: {tenant_id}",

--- a/backend/scripts/tenant_cleanup/on_pod_scripts/cleanup_tenant_schema.py
+++ b/backend/scripts/tenant_cleanup/on_pod_scripts/cleanup_tenant_schema.py
@@ -12,7 +12,9 @@ import sys
 
 from sqlalchemy import text
 
+from onyx.db.engine.shard_routing import get_engine_for_tenant
 from onyx.db.engine.sql_engine import SqlEngine, get_session_with_shared_schema
+from onyx.db.tenant_shard import clear_tenant_placement
 
 
 def drop_data_plane_schema(tenant_id: str) -> dict[str, str]:
@@ -22,32 +24,34 @@ def drop_data_plane_schema(tenant_id: str) -> dict[str, str]:
     SqlEngine.init_engine(pool_size=5, max_overflow=2)
 
     try:
+        # The schema lives on the tenant's shard, which is not necessarily the database
+        # holding the catalog tables cleaned up below.
+        with get_engine_for_tenant(tenant_id).connect() as connection:
+            with connection.begin():
+                check_schema_query = text("""
+                    SELECT nspname
+                    FROM pg_namespace
+                    WHERE nspname = :schema_name
+                """)
+
+                result = connection.execute(
+                    check_schema_query, {"schema_name": tenant_id}
+                ).fetchone()
+
+                if not result:
+                    print(f"Schema {tenant_id} does not exist", file=sys.stderr)
+                    return {
+                        "status": "not_found",
+                        "message": f"Schema {tenant_id} does not exist",
+                    }
+
+                # Drop the schema with CASCADE to remove all objects within it
+                drop_schema_query = text(f'DROP SCHEMA IF EXISTS "{tenant_id}" CASCADE')
+                connection.execute(drop_schema_query)
+
+        print(f"Successfully dropped schema: {tenant_id}", file=sys.stderr)
+
         with get_session_with_shared_schema() as session:
-            # First, verify the schema exists
-            check_schema_query = text("""
-                SELECT nspname
-                FROM pg_namespace
-                WHERE nspname = :schema_name
-            """)
-
-            result = session.execute(
-                check_schema_query, {"schema_name": tenant_id}
-            ).fetchone()
-
-            if not result:
-                print(f"Schema {tenant_id} does not exist", file=sys.stderr)
-                return {
-                    "status": "not_found",
-                    "message": f"Schema {tenant_id} does not exist",
-                }
-
-            # Drop the schema with CASCADE to remove all objects within it
-            drop_schema_query = text(f'DROP SCHEMA IF EXISTS "{tenant_id}" CASCADE')
-            session.execute(drop_schema_query)
-            session.commit()
-
-            print(f"Successfully dropped schema: {tenant_id}", file=sys.stderr)
-
             # Schema-qualified on purpose: schema_translate_map only rewrites SQLAlchemy
             # Table constructs, not raw text(), so an unqualified name resolves against
             # whatever search_path the pooled backend happens to carry.
@@ -58,13 +62,15 @@ def drop_data_plane_schema(tenant_id: str) -> dict[str, str]:
             session.execute(delete_mapping_query, {"tenant_id": tenant_id})
             session.commit()
 
-            print(
-                f"Successfully deleted tenant mapping for: {tenant_id}", file=sys.stderr
-            )
-            return {
-                "status": "success",
-                "message": f"Successfully dropped schema: {tenant_id}",
-            }
+        print(f"Successfully deleted tenant mapping for: {tenant_id}", file=sys.stderr)
+
+        # Last: the shard lookup above depends on this row.
+        clear_tenant_placement(tenant_id)
+
+        return {
+            "status": "success",
+            "message": f"Successfully dropped schema: {tenant_id}",
+        }
 
     except Exception as e:
         print(f"Failed to drop schema for tenant {tenant_id}: {e}", file=sys.stderr)

--- a/backend/scripts/tenant_cleanup/on_pod_scripts/cleanup_tenant_schema.py
+++ b/backend/scripts/tenant_cleanup/on_pod_scripts/cleanup_tenant_schema.py
@@ -12,7 +12,7 @@ import sys
 
 from sqlalchemy import text
 
-from onyx.db.engine.shard_routing import get_engine_for_tenant
+from onyx.db.engine.shard_registry import get_engine_for_shard, get_shard_specs
 from onyx.db.engine.sql_engine import SqlEngine, get_session_with_shared_schema
 from onyx.db.tenant_shard import clear_tenant_placement
 
@@ -24,33 +24,40 @@ def drop_data_plane_schema(tenant_id: str) -> dict[str, str]:
     SqlEngine.init_engine(pool_size=5, max_overflow=2)
 
     try:
-        # The schema lives on the tenant's shard, not necessarily the catalog database.
-        with get_engine_for_tenant(tenant_id).connect() as connection:
-            with connection.begin():
-                check_schema_query = text("""
-                    SELECT nspname
-                    FROM pg_namespace
-                    WHERE nspname = :schema_name
-                """)
+        # Swept rather than resolved through the catalog: the mapping is deleted below,
+        # so trusting a stale row would strand the schema on a shard nothing can reach
+        # afterwards. A tenant mid-migration also exists on two shards at once.
+        # Equivalent to a single lookup when one shard is configured.
+        dropped_from: list[str] = []
+        for shard_name in sorted(get_shard_specs()):
+            with get_engine_for_shard(shard_name).connect() as connection:
+                with connection.begin():
+                    check_schema_query = text("""
+                        SELECT nspname
+                        FROM pg_namespace
+                        WHERE nspname = :schema_name
+                    """)
 
-                schema_exists = (
-                    connection.execute(
-                        check_schema_query, {"schema_name": tenant_id}
-                    ).fetchone()
-                    is not None
-                )
+                    if (
+                        connection.execute(
+                            check_schema_query, {"schema_name": tenant_id}
+                        ).fetchone()
+                        is None
+                    ):
+                        continue
 
-                if schema_exists:
                     # CASCADE to remove all objects within it
                     connection.execute(
                         text(f'DROP SCHEMA IF EXISTS "{tenant_id}" CASCADE')
                     )
-                    print(f"Successfully dropped schema: {tenant_id}", file=sys.stderr)
-                else:
-                    print(f"Schema {tenant_id} does not exist", file=sys.stderr)
+                    dropped_from.append(shard_name)
+                    print(
+                        f"Dropped schema {tenant_id} from shard {shard_name}",
+                        file=sys.stderr,
+                    )
 
-        # Runs even when the schema was already gone, so a retry after a partially
-        # completed cleanup converges instead of repeating `not_found` forever.
+        # Runs even when no schema was found, so a retry after a partially completed
+        # cleanup converges instead of repeating `not_found` forever.
         with get_session_with_shared_schema() as session:
             # Schema-qualified on purpose: schema_translate_map only rewrites SQLAlchemy
             # Table constructs, not raw text(), so an unqualified name resolves against
@@ -62,18 +69,17 @@ def drop_data_plane_schema(tenant_id: str) -> dict[str, str]:
             session.execute(delete_mapping_query, {"tenant_id": tenant_id})
             session.commit()
 
-        # Last: the shard lookup above depends on this row.
         clear_tenant_placement(tenant_id)
         print(f"Successfully deleted tenant mapping for: {tenant_id}", file=sys.stderr)
 
-        if not schema_exists:
+        if not dropped_from:
             return {
                 "status": "not_found",
-                "message": f"Schema {tenant_id} does not exist; cleared catalog rows",
+                "message": f"Schema {tenant_id} exists on no shard; cleared catalog rows",
             }
         return {
             "status": "success",
-            "message": f"Successfully dropped schema: {tenant_id}",
+            "message": f"Dropped schema {tenant_id} from: {', '.join(dropped_from)}",
         }
 
     except Exception as e:

--- a/backend/scripts/tenant_cleanup/on_pod_scripts/cleanup_tenant_schema.py
+++ b/backend/scripts/tenant_cleanup/on_pod_scripts/cleanup_tenant_schema.py
@@ -14,12 +14,21 @@ from sqlalchemy import text
 
 from onyx.db.engine.shard_registry import get_engine_for_shard, get_shard_specs
 from onyx.db.engine.sql_engine import SqlEngine, get_session_with_shared_schema
+from onyx.db.engine.tenant_utils import validate_tenant_id
 from onyx.db.tenant_shard import clear_tenant_placement
 
 
 def drop_data_plane_schema(tenant_id: str) -> dict[str, str]:
     """Drop the PostgreSQL schema for the given tenant."""
     print(f"Dropping data plane schema for tenant: {tenant_id}", file=sys.stderr)
+
+    # A schema name cannot be bound as a parameter, so it is interpolated into DDL
+    # below. Validate before touching any database: this argument arrives from a
+    # human on the command line, and the drop now runs against every shard.
+    if not validate_tenant_id(tenant_id):
+        message = f"Invalid tenant_id format: {tenant_id}"
+        print(message, file=sys.stderr)
+        return {"status": "error", "message": message}
 
     SqlEngine.init_engine(pool_size=5, max_overflow=2)
 

--- a/backend/tests/external_dependency_unit/db/conftest.py
+++ b/backend/tests/external_dependency_unit/db/conftest.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 
 from ee.onyx.db.scim import ScimDAL
 from onyx.db.models import ScimToken, UserGroup
+from tests.external_dependency_unit.db.shard_test_utils import temporary_database
 
 
 @pytest.fixture
@@ -78,3 +79,13 @@ def user_group_factory(
         if obj:
             db_session.delete(obj)
     db_session.commit()
+
+
+@pytest.fixture(scope="module")
+def second_database() -> Generator[str, None, None]:
+    """A real second database for the shard suites.
+
+    Module-scoped so each suite gets its own, rather than sharing state through a
+    database that another module is reconfiguring shards against.
+    """
+    yield from temporary_database("onyx_shard_test")

--- a/backend/tests/external_dependency_unit/db/shard_test_utils.py
+++ b/backend/tests/external_dependency_unit/db/shard_test_utils.py
@@ -1,0 +1,78 @@
+"""Shared helpers for the shard suites.
+
+All of them need the same thing: a real second database on the same server. The seam
+routes per-DSN rather than per-host, so a second database is a faithful stand-in for a
+second instance and keeps the tests self-contained.
+"""
+
+from collections.abc import Generator
+from uuid import uuid4
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from onyx.db.engine.sql_engine import SYNC_DB_API, build_connection_string
+
+# Must match ONYX_DB_DEFAULT_SHARD, which each suite's fixture pins.
+DEFAULT_SHARD = "default"
+
+
+def admin_engine() -> Engine:
+    """Engine on the `postgres` maintenance DB, for CREATE/DROP DATABASE."""
+    return create_engine(
+        build_connection_string(db_api=SYNC_DB_API, db="postgres"),
+        isolation_level="AUTOCOMMIT",
+    )
+
+
+def temporary_database(prefix: str) -> Generator[str, None, None]:
+    """Yield a throwaway database, dropping it afterwards.
+
+    Connections are terminated first: a pooled engine still holding one blocks
+    DROP DATABASE and leaks the database into the next run.
+    """
+    db_name = f"{prefix}_{uuid4().hex[:8]}"
+    admin = admin_engine()
+    # dispose() is in its own finally so it runs even when CREATE DATABASE fails or
+    # the drop below raises. A leaked admin pool holds a connection that blocks a
+    # later DROP DATABASE — the exact failure this function exists to avoid.
+    try:
+        with admin.connect() as conn:
+            conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+        try:
+            yield db_name
+        finally:
+            with admin.connect() as conn:
+                conn.execute(
+                    text(
+                        "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                        "WHERE datname = :db AND pid <> pg_backend_pid()"
+                    ),
+                    {"db": db_name},
+                )
+                conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+    finally:
+        admin.dispose()
+
+
+def create_schema(engine: Engine, schema: str) -> None:
+    with engine.connect() as conn:
+        conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))
+        conn.commit()
+
+
+def drop_schema(engine: Engine, schema: str) -> None:
+    with engine.connect() as conn:
+        conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        conn.commit()
+
+
+def schema_exists(engine: Engine, schema: str) -> bool:
+    with engine.connect() as conn:
+        return (
+            conn.execute(
+                text("SELECT 1 FROM pg_namespace WHERE nspname = :n"),
+                {"n": schema},
+            ).first()
+            is not None
+        )

--- a/backend/tests/external_dependency_unit/db/test_shard_enumeration.py
+++ b/backend/tests/external_dependency_unit/db/test_shard_enumeration.py
@@ -21,17 +21,19 @@ from onyx.configs.app_configs import POSTGRES_DB
 from onyx.db.engine import shard_registry, tenant_utils
 from onyx.db.engine.shard_registry import get_engine_for_shard
 from onyx.db.engine.sql_engine import (
-    SYNC_DB_API,
     SqlEngine,
-    build_connection_string,
 )
 from onyx.db.engine.tenant_utils import (
     get_all_tenant_ids,
     get_schemas_needing_migration,
     get_tenant_ids_by_shard,
 )
+from tests.external_dependency_unit.db.shard_test_utils import (
+    DEFAULT_SHARD,
+    create_schema,
+    drop_schema,
+)
 
-DEFAULT_SHARD = "default"
 SECOND_SHARD = "shard-enum-b"
 
 
@@ -41,28 +43,6 @@ class _CapturedAlembicURL(Exception):
     def __init__(self, url: str) -> None:
         super().__init__(url)
         self.url = url
-
-
-def _admin_engine() -> Engine:
-    """Engine on the `postgres` maintenance DB, for CREATE/DROP DATABASE."""
-    from sqlalchemy import create_engine
-
-    return create_engine(
-        build_connection_string(db_api=SYNC_DB_API, db="postgres"),
-        isolation_level="AUTOCOMMIT",
-    )
-
-
-def _create_schema(engine: Engine, schema: str) -> None:
-    with engine.connect() as conn:
-        conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))
-        conn.commit()
-
-
-def _drop_schema(engine: Engine, schema: str) -> None:
-    with engine.connect() as conn:
-        conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
-        conn.commit()
 
 
 def _stamp_alembic_version(engine: Engine, schema: str, revision: str) -> None:
@@ -80,28 +60,6 @@ def _stamp_alembic_version(engine: Engine, schema: str, revision: str) -> None:
             {"rev": revision},
         )
         conn.commit()
-
-
-@pytest.fixture(scope="module")
-def second_database() -> Generator[str, None, None]:
-    """Create a throwaway second database for the duration of the module."""
-    db_name = f"onyx_enum_test_{uuid4().hex[:8]}"
-    admin = _admin_engine()
-    with admin.connect() as conn:
-        conn.execute(text(f'CREATE DATABASE "{db_name}"'))
-    try:
-        yield db_name
-    finally:
-        with admin.connect() as conn:
-            conn.execute(
-                text(
-                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
-                    "WHERE datname = :db AND pid <> pg_backend_pid()"
-                ),
-                {"db": db_name},
-            )
-            conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
-        admin.dispose()
 
 
 @pytest.fixture(scope="function")
@@ -128,13 +86,13 @@ def two_shards(
     tenant_a = f"tenant_{uuid4()}"
     tenant_b = f"tenant_{uuid4()}"
 
-    _create_schema(get_engine_for_shard(DEFAULT_SHARD), tenant_a)
-    _create_schema(get_engine_for_shard(SECOND_SHARD), tenant_b)
+    create_schema(get_engine_for_shard(DEFAULT_SHARD), tenant_a)
+    create_schema(get_engine_for_shard(SECOND_SHARD), tenant_b)
 
     yield {"tenant_a": tenant_a, "tenant_b": tenant_b, "second_db": second_database}
 
-    _drop_schema(get_engine_for_shard(DEFAULT_SHARD), tenant_a)
-    _drop_schema(get_engine_for_shard(SECOND_SHARD), tenant_b)
+    drop_schema(get_engine_for_shard(DEFAULT_SHARD), tenant_a)
+    drop_schema(get_engine_for_shard(SECOND_SHARD), tenant_b)
     shard_registry.reset_shard_specs()
 
 
@@ -150,11 +108,11 @@ def one_shard(monkeypatch: pytest.MonkeyPatch) -> Generator[str, None, None]:
     shard_registry.reset_shard_specs()
 
     tenant_id = f"tenant_{uuid4()}"
-    _create_schema(get_engine_for_shard(DEFAULT_SHARD), tenant_id)
+    create_schema(get_engine_for_shard(DEFAULT_SHARD), tenant_id)
 
     yield tenant_id
 
-    _drop_schema(get_engine_for_shard(DEFAULT_SHARD), tenant_id)
+    drop_schema(get_engine_for_shard(DEFAULT_SHARD), tenant_id)
     shard_registry.reset_shard_specs()
 
 
@@ -187,7 +145,7 @@ def test_tenant_present_on_two_shards_is_enumerated_once(
     every periodic task for that tenant.
     """
     tenant_a = two_shards["tenant_a"]
-    _create_schema(get_engine_for_shard(SECOND_SHARD), tenant_a)
+    create_schema(get_engine_for_shard(SECOND_SHARD), tenant_a)
     try:
         by_shard = get_tenant_ids_by_shard()
         assert tenant_a in by_shard[DEFAULT_SHARD]
@@ -195,13 +153,13 @@ def test_tenant_present_on_two_shards_is_enumerated_once(
 
         assert get_all_tenant_ids().count(tenant_a) == 1
     finally:
-        _drop_schema(get_engine_for_shard(SECOND_SHARD), tenant_a)
+        drop_schema(get_engine_for_shard(SECOND_SHARD), tenant_a)
 
 
 def test_non_tenant_schemas_are_excluded(two_shards: dict[str, Any]) -> None:
     """Only schemas matching the tenant pattern count, on every shard."""
     engine = get_engine_for_shard(SECOND_SHARD)
-    _create_schema(engine, "definitely_not_a_tenant")
+    create_schema(engine, "definitely_not_a_tenant")
     try:
         all_tenants = get_all_tenant_ids()
         assert "definitely_not_a_tenant" not in all_tenants
@@ -210,7 +168,7 @@ def test_non_tenant_schemas_are_excluded(two_shards: dict[str, Any]) -> None:
         assert two_shards["tenant_b"] in all_tenants
         assert "definitely_not_a_tenant" not in get_tenant_ids_by_shard()[SECOND_SHARD]
     finally:
-        _drop_schema(engine, "definitely_not_a_tenant")
+        drop_schema(engine, "definitely_not_a_tenant")
 
 
 def test_single_shard_enumeration_is_unchanged(one_shard: str) -> None:

--- a/backend/tests/external_dependency_unit/db/test_shard_placement.py
+++ b/backend/tests/external_dependency_unit/db/test_shard_placement.py
@@ -1,0 +1,247 @@
+"""Placement of *new* tenants onto a configured shard, against two real databases.
+
+Routing (`test_shard_routing.py`) answers where an existing tenant lives. This suite
+covers the step before that: deciding where a tenant that has no schema yet should be
+created, and proving the schema physically lands there.
+
+The invariant under test is an ordering one — the shard mapping has to be written
+before the schema is created, because every subsequent provisioning step resolves the
+tenant's database through the catalog. So the tests assert on which database the schema
+actually appears in, not on what a helper returned.
+"""
+
+from collections.abc import Generator
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from ee.onyx.server.tenants.schema_management import create_schema_if_not_exists
+from onyx.db.engine import shard_registry, shard_routing
+from onyx.db.engine.shard_registry import (
+    ShardConfigurationError,
+    get_catalog_engine,
+    get_engine_for_shard,
+)
+from onyx.db.engine.shard_routing import (
+    get_shard_for_new_tenant,
+    invalidate_shard_cache,
+)
+from onyx.db.engine.shard_version import reset_shard_map_version_poller
+from onyx.db.engine.sql_engine import SYNC_DB_API, SqlEngine, build_connection_string
+from onyx.db.models import PublicBase, TenantShard
+from onyx.db.tenant_shard import clear_tenant_placement, record_tenant_placement
+
+DEFAULT_SHARD = "default"
+SECOND_SHARD = "shard-test-b"
+
+
+def _admin_engine() -> Engine:
+    """Engine on the `postgres` maintenance DB, for CREATE/DROP DATABASE."""
+    from sqlalchemy import create_engine
+
+    return create_engine(
+        build_connection_string(db_api=SYNC_DB_API, db="postgres"),
+        isolation_level="AUTOCOMMIT",
+    )
+
+
+def _schema_exists(engine: Engine, tenant_id: str) -> bool:
+    with engine.connect() as conn:
+        return (
+            conn.execute(
+                text("SELECT 1 FROM pg_namespace WHERE nspname = :n"),
+                {"n": tenant_id},
+            ).first()
+            is not None
+        )
+
+
+def _mapped_shard(tenant_id: str) -> str | None:
+    with get_catalog_engine().connect() as conn:
+        row = conn.execute(
+            text("SELECT shard_name FROM public.tenant_shard WHERE tenant_id = :t"),
+            {"t": tenant_id},
+        ).first()
+    return None if row is None else str(row[0])
+
+
+def _drop_schema(engine: Engine, tenant_id: str) -> None:
+    with engine.connect() as conn:
+        conn.execute(text(f'DROP SCHEMA IF EXISTS "{tenant_id}" CASCADE'))
+        conn.commit()
+
+
+@pytest.fixture(scope="module")
+def second_database() -> Generator[str, None, None]:
+    db_name = f"onyx_place_test_{uuid4().hex[:8]}"
+    admin = _admin_engine()
+    with admin.connect() as conn:
+        conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+    try:
+        yield db_name
+    finally:
+        with admin.connect() as conn:
+            conn.execute(
+                text(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = :db AND pid <> pg_backend_pid()"
+                ),
+                {"db": db_name},
+            )
+            conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+        admin.dispose()
+
+
+@pytest.fixture(scope="function")
+def placement_on_second_shard(
+    second_database: str, monkeypatch: pytest.MonkeyPatch
+) -> Generator[dict[str, Any], None, None]:
+    """Two shards configured, with new tenants targeted at the second one."""
+    SqlEngine.init_engine(pool_size=5, max_overflow=2)
+
+    shards_json = f'{{"{SECOND_SHARD}": {{"db": "{second_database}"}}}}'
+    monkeypatch.setattr(shard_registry, "ONYX_DB_SHARDS_JSON", shards_json)
+    monkeypatch.setattr(shard_registry, "ONYX_DB_DEFAULT_SHARD", DEFAULT_SHARD)
+    monkeypatch.setattr(shard_registry, "ONYX_DB_CATALOG_SHARD", DEFAULT_SHARD)
+    monkeypatch.setattr(shard_registry, "ONYX_DB_NEW_TENANT_SHARD", SECOND_SHARD)
+    # Routing short-circuits to the default shard outside multi-tenant mode.
+    monkeypatch.setattr(shard_routing, "MULTI_TENANT", True)
+    monkeypatch.setattr(shard_routing, "ONYX_DB_SHARD_OVERRIDES_JSON", "")
+
+    shard_registry.reset_shard_specs()
+    shard_routing.reset_shard_overrides()
+    invalidate_shard_cache()
+    reset_shard_map_version_poller()
+
+    # `tenant_shard` normally arrives via the `schema_private` Alembic tree, which this
+    # lane does not run. Only that table, so unrelated models can't break this suite.
+    PublicBase.metadata.create_all(
+        get_catalog_engine(),
+        tables=[PublicBase.metadata.tables[f"public.{TenantShard.__tablename__}"]],
+        checkfirst=True,
+    )
+
+    created: list[str] = []
+    yield {"second_db": second_database, "created": created}
+
+    for tenant_id in created:
+        _drop_schema(get_engine_for_shard(DEFAULT_SHARD), tenant_id)
+        _drop_schema(get_engine_for_shard(SECOND_SHARD), tenant_id)
+        clear_tenant_placement(tenant_id)
+    shard_registry.reset_shard_specs()
+    invalidate_shard_cache()
+    reset_shard_map_version_poller()
+
+
+def test_new_tenants_target_the_configured_shard(
+    placement_on_second_shard: dict[str, Any],  # noqa: ARG001
+) -> None:
+    assert get_shard_for_new_tenant() == SECOND_SHARD
+
+
+def test_unknown_target_shard_raises_rather_than_using_default(
+    placement_on_second_shard: dict[str, Any],  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fail closed. Falling back to default is the silent misplacement to avoid."""
+    monkeypatch.setattr(shard_registry, "ONYX_DB_NEW_TENANT_SHARD", "no-such-shard")
+    with pytest.raises(ShardConfigurationError):
+        get_shard_for_new_tenant()
+
+
+def test_recorded_placement_puts_the_schema_on_the_target_shard(
+    placement_on_second_shard: dict[str, Any],
+) -> None:
+    """The whole point: recording placement first makes schema creation follow.
+
+    The unplaced tenant in the same test is the control — it proves the assertion
+    discriminates, rather than the second shard simply receiving everything.
+    """
+    placed = f"tenant_{uuid4()}"
+    unplaced = f"tenant_{uuid4()}"
+    placement_on_second_shard["created"].extend([placed, unplaced])
+
+    record_tenant_placement(placed, get_shard_for_new_tenant())
+    create_schema_if_not_exists(placed)
+    create_schema_if_not_exists(unplaced)
+
+    assert _schema_exists(get_engine_for_shard(SECOND_SHARD), placed)
+    assert not _schema_exists(get_engine_for_shard(DEFAULT_SHARD), placed)
+
+    assert _schema_exists(get_engine_for_shard(DEFAULT_SHARD), unplaced)
+    assert not _schema_exists(get_engine_for_shard(SECOND_SHARD), unplaced)
+
+
+def test_default_placement_writes_no_mapping_row(
+    placement_on_second_shard: dict[str, Any],
+) -> None:
+    """Absence of a row already means "default"; keep new tenants on that same rule."""
+    tenant_id = f"tenant_{uuid4()}"
+    placement_on_second_shard["created"].append(tenant_id)
+
+    record_tenant_placement(tenant_id, DEFAULT_SHARD)
+
+    assert _mapped_shard(tenant_id) is None
+
+
+def test_placement_is_recorded_and_cleared(
+    placement_on_second_shard: dict[str, Any],
+) -> None:
+    tenant_id = f"tenant_{uuid4()}"
+    placement_on_second_shard["created"].append(tenant_id)
+
+    record_tenant_placement(tenant_id, SECOND_SHARD)
+    assert _mapped_shard(tenant_id) == SECOND_SHARD
+
+    clear_tenant_placement(tenant_id)
+    assert _mapped_shard(tenant_id) is None
+
+
+def test_placement_overrides_a_stale_cached_resolution(
+    placement_on_second_shard: dict[str, Any],
+) -> None:
+    """Resolving before placement must not pin the tenant to the default shard.
+
+    `get_shard_for_tenant` caches the "no row, so default" answer for a full TTL, which
+    would send the schema to the wrong database.
+    """
+    tenant_id = f"tenant_{uuid4()}"
+    placement_on_second_shard["created"].append(tenant_id)
+
+    assert shard_routing.get_shard_for_tenant(tenant_id) == DEFAULT_SHARD
+
+    record_tenant_placement(tenant_id, SECOND_SHARD)
+    create_schema_if_not_exists(tenant_id)
+
+    assert _schema_exists(get_engine_for_shard(SECOND_SHARD), tenant_id)
+    assert not _schema_exists(get_engine_for_shard(DEFAULT_SHARD), tenant_id)
+
+
+def test_cleanup_drops_the_schema_from_the_tenants_own_shard(
+    placement_on_second_shard: dict[str, Any],
+) -> None:
+    """The on-pod cleanup script previously dropped against the catalog database.
+
+    For a tenant on another shard that reports `not_found` and silently leaves the
+    schema in place, which matters because tenant cleanup is how database-1 is meant
+    to shrink.
+    """
+    from scripts.tenant_cleanup.on_pod_scripts.cleanup_tenant_schema import (
+        drop_data_plane_schema,
+    )
+
+    tenant_id = f"tenant_{uuid4()}"
+    placement_on_second_shard["created"].append(tenant_id)
+
+    record_tenant_placement(tenant_id, SECOND_SHARD)
+    create_schema_if_not_exists(tenant_id)
+    assert _schema_exists(get_engine_for_shard(SECOND_SHARD), tenant_id)
+
+    result = drop_data_plane_schema(tenant_id)
+
+    assert result["status"] == "success"
+    assert not _schema_exists(get_engine_for_shard(SECOND_SHARD), tenant_id)
+    assert _mapped_shard(tenant_id) is None

--- a/backend/tests/external_dependency_unit/db/test_shard_placement.py
+++ b/backend/tests/external_dependency_unit/db/test_shard_placement.py
@@ -26,7 +26,7 @@ from onyx.db.engine.shard_routing import (
 )
 from onyx.db.engine.shard_version import reset_shard_map_version_poller
 from onyx.db.engine.sql_engine import SYNC_DB_API, SqlEngine, build_connection_string
-from onyx.db.models import PublicBase, TenantShard
+from onyx.db.models import PublicBase, TenantShard, UserTenantMapping
 from onyx.db.tenant_shard import clear_tenant_placement, record_tenant_placement
 
 DEFAULT_SHARD = "default"
@@ -111,11 +111,15 @@ def placement_on_second_shard(
     invalidate_shard_cache()
     reset_shard_map_version_poller()
 
-    # `tenant_shard` normally arrives via the `schema_private` Alembic tree, which this
-    # lane does not run. Only that table, so unrelated models can't break this suite.
+    # These arrive via the `schema_private` Alembic tree, which this lane does not run.
+    # `user_tenant_mapping` is here because the cleanup script deletes from it too.
+    # Named explicitly so unrelated models can't break this suite.
     PublicBase.metadata.create_all(
         get_catalog_engine(),
-        tables=[PublicBase.metadata.tables[f"public.{TenantShard.__tablename__}"]],
+        tables=[
+            PublicBase.metadata.tables[f"public.{model.__tablename__}"]
+            for model in (TenantShard, UserTenantMapping)
+        ],
         checkfirst=True,
     )
 

--- a/backend/tests/external_dependency_unit/db/test_shard_placement.py
+++ b/backend/tests/external_dependency_unit/db/test_shard_placement.py
@@ -142,13 +142,35 @@ def test_new_tenants_target_the_configured_shard(
     assert get_shard_for_new_tenant() == SECOND_SHARD
 
 
-def test_unknown_target_shard_raises_rather_than_using_default(
+def test_unknown_target_shard_fails_when_configuration_is_parsed(
     placement_on_second_shard: dict[str, Any],  # noqa: ARG001
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Fail closed. Falling back to default is the silent misplacement to avoid."""
+    """A typo should stop the process, not fail every signup at request time."""
     monkeypatch.setattr(shard_registry, "ONYX_DB_NEW_TENANT_SHARD", "no-such-shard")
-    with pytest.raises(ShardConfigurationError):
+    shard_registry.reset_shard_specs()
+
+    with pytest.raises(ShardConfigurationError, match="ONYX_DB_NEW_TENANT_SHARD"):
+        shard_registry.get_shard_specs()
+
+
+def test_unknown_target_shard_raises_at_placement_rather_than_using_default(
+    placement_on_second_shard: dict[str, Any],  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Second line of defence, behind the parse-time check above.
+
+    The shard table is read here *before* the name is changed, so the configuration is
+    already cached and valid — which is what forces the check inside
+    `get_shard_for_new_tenant` to be the thing that catches this, rather than
+    revalidation. Falling back to the default shard is the silent misplacement that
+    placement exists to prevent.
+    """
+    assert get_shard_for_new_tenant() == SECOND_SHARD
+
+    monkeypatch.setattr(shard_registry, "ONYX_DB_NEW_TENANT_SHARD", "no-such-shard")
+
+    with pytest.raises(ShardConfigurationError, match="ONYX_DB_NEW_TENANT_SHARD"):
         get_shard_for_new_tenant()
 
 

--- a/backend/tests/external_dependency_unit/db/test_shard_placement.py
+++ b/backend/tests/external_dependency_unit/db/test_shard_placement.py
@@ -1,13 +1,8 @@
 """Placement of *new* tenants onto a configured shard, against two real databases.
 
-Routing (`test_shard_routing.py`) answers where an existing tenant lives. This suite
-covers the step before that: deciding where a tenant that has no schema yet should be
-created, and proving the schema physically lands there.
-
-The invariant under test is an ordering one — the shard mapping has to be written
-before the schema is created, because every subsequent provisioning step resolves the
-tenant's database through the catalog. So the tests assert on which database the schema
-actually appears in, not on what a helper returned.
+The invariant is an ordering one — the mapping must be written before the schema is
+created — so these assert on which database the schema physically lands in, not on
+what a helper returned.
 """
 
 from collections.abc import Generator
@@ -158,14 +153,9 @@ def test_unknown_target_shard_raises_at_placement_rather_than_using_default(
     placement_on_second_shard: dict[str, Any],  # noqa: ARG001
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Second line of defence, behind the parse-time check above.
-
-    The shard table is read here *before* the name is changed, so the configuration is
-    already cached and valid — which is what forces the check inside
-    `get_shard_for_new_tenant` to be the thing that catches this, rather than
-    revalidation. Falling back to the default shard is the silent misplacement that
-    placement exists to prevent.
-    """
+    """Second line of defence. The shard table is read before the name is changed, so
+    the config is already cached — forcing the check inside `get_shard_for_new_tenant`
+    to be what catches this rather than revalidation."""
     assert get_shard_for_new_tenant() == SECOND_SHARD
 
     monkeypatch.setattr(shard_registry, "ONYX_DB_NEW_TENANT_SHARD", "no-such-shard")
@@ -177,11 +167,8 @@ def test_unknown_target_shard_raises_at_placement_rather_than_using_default(
 def test_recorded_placement_puts_the_schema_on_the_target_shard(
     placement_on_second_shard: dict[str, Any],
 ) -> None:
-    """The whole point: recording placement first makes schema creation follow.
-
-    The unplaced tenant in the same test is the control — it proves the assertion
-    discriminates, rather than the second shard simply receiving everything.
-    """
+    """The unplaced tenant is the control: it proves the assertion discriminates,
+    rather than the second shard simply receiving everything."""
     placed = f"tenant_{uuid4()}"
     unplaced = f"tenant_{uuid4()}"
     placement_on_second_shard["created"].extend([placed, unplaced])
@@ -225,11 +212,8 @@ def test_placement_is_recorded_and_cleared(
 def test_placement_overrides_a_stale_cached_resolution(
     placement_on_second_shard: dict[str, Any],
 ) -> None:
-    """Resolving before placement must not pin the tenant to the default shard.
-
-    `get_shard_for_tenant` caches the "no row, so default" answer for a full TTL, which
-    would send the schema to the wrong database.
-    """
+    """`get_shard_for_tenant` caches the "no row, so default" answer for a full TTL,
+    which would otherwise send the schema to the wrong database."""
     tenant_id = f"tenant_{uuid4()}"
     placement_on_second_shard["created"].append(tenant_id)
 
@@ -245,12 +229,8 @@ def test_placement_overrides_a_stale_cached_resolution(
 def test_cleanup_drops_the_schema_from_the_tenants_own_shard(
     placement_on_second_shard: dict[str, Any],
 ) -> None:
-    """The on-pod cleanup script previously dropped against the catalog database.
-
-    For a tenant on another shard that reports `not_found` and silently leaves the
-    schema in place, which matters because tenant cleanup is how database-1 is meant
-    to shrink.
-    """
+    """The script previously dropped against the catalog database, which for a sharded
+    tenant reports `not_found` and silently leaves the schema in place."""
     from scripts.tenant_cleanup.on_pod_scripts.cleanup_tenant_schema import (
         drop_data_plane_schema,
     )
@@ -266,4 +246,27 @@ def test_cleanup_drops_the_schema_from_the_tenants_own_shard(
 
     assert result["status"] == "success"
     assert not _schema_exists(get_engine_for_shard(SECOND_SHARD), tenant_id)
+    assert _mapped_shard(tenant_id) is None
+
+
+def test_cleanup_clears_catalog_rows_when_the_schema_is_already_gone(
+    placement_on_second_shard: dict[str, Any],
+) -> None:
+    """Otherwise a retry after a partial run repeats `not_found` forever and the tenant
+    stays in shared catalog state indefinitely."""
+    from scripts.tenant_cleanup.on_pod_scripts.cleanup_tenant_schema import (
+        drop_data_plane_schema,
+    )
+
+    tenant_id = f"tenant_{uuid4()}"
+    placement_on_second_shard["created"].append(tenant_id)
+
+    # Mapped, but the schema was never created — the state a half-finished cleanup or
+    # a failed provision leaves behind.
+    record_tenant_placement(tenant_id, SECOND_SHARD)
+    assert _mapped_shard(tenant_id) == SECOND_SHARD
+
+    result = drop_data_plane_schema(tenant_id)
+
+    assert result["status"] == "not_found"
     assert _mapped_shard(tenant_id) is None

--- a/backend/tests/external_dependency_unit/db/test_shard_placement.py
+++ b/backend/tests/external_dependency_unit/db/test_shard_placement.py
@@ -12,8 +12,10 @@ from uuid import uuid4
 import pytest
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from ee.onyx.server.tenants.schema_management import create_schema_if_not_exists
+from onyx.db import tenant_shard as tenant_shard_module
 from onyx.db.engine import shard_registry, shard_routing
 from onyx.db.engine.shard_registry import (
     ShardConfigurationError,
@@ -251,6 +253,37 @@ def test_cleanup_drops_the_schema_from_the_tenants_own_shard(
     assert result["status"] == "success"
     assert not _schema_exists(get_engine_for_shard(SECOND_SHARD), tenant_id)
     assert _mapped_shard(tenant_id) is None
+
+
+def test_clearing_placement_tolerates_a_missing_catalog_table(
+    placement_on_second_shard: dict[str, Any],  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Teardown runs on deployments that have not applied the catalog migration, and
+    nothing can be mapped there anyway. Matches the read path's fallback."""
+
+    def _undefined_table() -> Any:
+        orig = Exception('relation "public.tenant_shard" does not exist')
+        orig.pgcode = "42P01"  # ty: ignore[unresolved-attribute]
+        raise ProgrammingError("DELETE", {}, orig)
+
+    monkeypatch.setattr(tenant_shard_module, "get_catalog_engine", _undefined_table)
+    clear_tenant_placement(f"tenant_{uuid4()}")
+
+
+def test_clearing_placement_still_raises_on_other_errors(
+    placement_on_second_shard: dict[str, Any],  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only a missing table is benign; anything else means the delete may not have
+    happened and must not be swallowed."""
+
+    def _boom() -> Any:
+        raise OperationalError("DELETE", {}, Exception("connection refused"))
+
+    monkeypatch.setattr(tenant_shard_module, "get_catalog_engine", _boom)
+    with pytest.raises(OperationalError):
+        clear_tenant_placement(f"tenant_{uuid4()}")
 
 
 def test_cleanup_sweeps_every_shard_not_just_the_mapped_one(

--- a/backend/tests/external_dependency_unit/db/test_shard_placement.py
+++ b/backend/tests/external_dependency_unit/db/test_shard_placement.py
@@ -253,6 +253,33 @@ def test_cleanup_drops_the_schema_from_the_tenants_own_shard(
     assert _mapped_shard(tenant_id) is None
 
 
+def test_cleanup_sweeps_every_shard_not_just_the_mapped_one(
+    placement_on_second_shard: dict[str, Any],
+) -> None:
+    """Cleanup deletes the mapping, so trusting it would strand a copy on the shard the
+    mapping did not name — and a tenant mid-migration exists on two shards at once."""
+    from scripts.tenant_cleanup.on_pod_scripts.cleanup_tenant_schema import (
+        drop_data_plane_schema,
+    )
+
+    tenant_id = f"tenant_{uuid4()}"
+    placement_on_second_shard["created"].append(tenant_id)
+
+    # Schema on both shards, with the mapping naming only one of them.
+    for shard in (DEFAULT_SHARD, SECOND_SHARD):
+        with get_engine_for_shard(shard).connect() as conn:
+            conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{tenant_id}"'))
+            conn.commit()
+    record_tenant_placement(tenant_id, SECOND_SHARD)
+
+    result = drop_data_plane_schema(tenant_id)
+
+    assert result["status"] == "success"
+    assert not _schema_exists(get_engine_for_shard(SECOND_SHARD), tenant_id)
+    assert not _schema_exists(get_engine_for_shard(DEFAULT_SHARD), tenant_id)
+    assert _mapped_shard(tenant_id) is None
+
+
 def test_cleanup_clears_catalog_rows_when_the_schema_is_already_gone(
     placement_on_second_shard: dict[str, Any],
 ) -> None:

--- a/backend/tests/external_dependency_unit/db/test_shard_placement.py
+++ b/backend/tests/external_dependency_unit/db/test_shard_placement.py
@@ -5,13 +5,16 @@ created — so these assert on which database the schema physically lands in, no
 what a helper returned.
 """
 
+import asyncio
 from collections.abc import Generator
 from typing import Any
 from uuid import uuid4
 
 import pytest
+from scripts.tenant_cleanup.on_pod_scripts.cleanup_tenant_schema import (
+    drop_data_plane_schema,
+)
 from sqlalchemy import text
-from sqlalchemy.engine import Engine
 from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from ee.onyx.server.tenants.schema_management import create_schema_if_not_exists
@@ -27,33 +30,17 @@ from onyx.db.engine.shard_routing import (
     invalidate_shard_cache,
 )
 from onyx.db.engine.shard_version import reset_shard_map_version_poller
-from onyx.db.engine.sql_engine import SYNC_DB_API, SqlEngine, build_connection_string
+from onyx.db.engine.sql_engine import SqlEngine
 from onyx.db.models import PublicBase, TenantShard, UserTenantMapping
 from onyx.db.tenant_shard import clear_tenant_placement, record_tenant_placement
+from tests.external_dependency_unit.db.shard_test_utils import (
+    DEFAULT_SHARD,
+    create_schema,
+    drop_schema,
+    schema_exists,
+)
 
-DEFAULT_SHARD = "default"
 SECOND_SHARD = "shard-test-b"
-
-
-def _admin_engine() -> Engine:
-    """Engine on the `postgres` maintenance DB, for CREATE/DROP DATABASE."""
-    from sqlalchemy import create_engine
-
-    return create_engine(
-        build_connection_string(db_api=SYNC_DB_API, db="postgres"),
-        isolation_level="AUTOCOMMIT",
-    )
-
-
-def _schema_exists(engine: Engine, tenant_id: str) -> bool:
-    with engine.connect() as conn:
-        return (
-            conn.execute(
-                text("SELECT 1 FROM pg_namespace WHERE nspname = :n"),
-                {"n": tenant_id},
-            ).first()
-            is not None
-        )
 
 
 def _mapped_shard(tenant_id: str) -> str | None:
@@ -63,33 +50,6 @@ def _mapped_shard(tenant_id: str) -> str | None:
             {"t": tenant_id},
         ).first()
     return None if row is None else str(row[0])
-
-
-def _drop_schema(engine: Engine, tenant_id: str) -> None:
-    with engine.connect() as conn:
-        conn.execute(text(f'DROP SCHEMA IF EXISTS "{tenant_id}" CASCADE'))
-        conn.commit()
-
-
-@pytest.fixture(scope="module")
-def second_database() -> Generator[str, None, None]:
-    db_name = f"onyx_place_test_{uuid4().hex[:8]}"
-    admin = _admin_engine()
-    with admin.connect() as conn:
-        conn.execute(text(f'CREATE DATABASE "{db_name}"'))
-    try:
-        yield db_name
-    finally:
-        with admin.connect() as conn:
-            conn.execute(
-                text(
-                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
-                    "WHERE datname = :db AND pid <> pg_backend_pid()"
-                ),
-                {"db": db_name},
-            )
-            conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
-        admin.dispose()
 
 
 @pytest.fixture(scope="function")
@@ -129,8 +89,8 @@ def placement_on_second_shard(
     yield {"second_db": second_database, "created": created}
 
     for tenant_id in created:
-        _drop_schema(get_engine_for_shard(DEFAULT_SHARD), tenant_id)
-        _drop_schema(get_engine_for_shard(SECOND_SHARD), tenant_id)
+        drop_schema(get_engine_for_shard(DEFAULT_SHARD), tenant_id)
+        drop_schema(get_engine_for_shard(SECOND_SHARD), tenant_id)
         clear_tenant_placement(tenant_id)
     shard_registry.reset_shard_specs()
     invalidate_shard_cache()
@@ -183,11 +143,11 @@ def test_recorded_placement_puts_the_schema_on_the_target_shard(
     create_schema_if_not_exists(placed)
     create_schema_if_not_exists(unplaced)
 
-    assert _schema_exists(get_engine_for_shard(SECOND_SHARD), placed)
-    assert not _schema_exists(get_engine_for_shard(DEFAULT_SHARD), placed)
+    assert schema_exists(get_engine_for_shard(SECOND_SHARD), placed)
+    assert not schema_exists(get_engine_for_shard(DEFAULT_SHARD), placed)
 
-    assert _schema_exists(get_engine_for_shard(DEFAULT_SHARD), unplaced)
-    assert not _schema_exists(get_engine_for_shard(SECOND_SHARD), unplaced)
+    assert schema_exists(get_engine_for_shard(DEFAULT_SHARD), unplaced)
+    assert not schema_exists(get_engine_for_shard(SECOND_SHARD), unplaced)
 
 
 def test_default_placement_writes_no_mapping_row(
@@ -228,8 +188,8 @@ def test_placement_overrides_a_stale_cached_resolution(
     record_tenant_placement(tenant_id, SECOND_SHARD)
     create_schema_if_not_exists(tenant_id)
 
-    assert _schema_exists(get_engine_for_shard(SECOND_SHARD), tenant_id)
-    assert not _schema_exists(get_engine_for_shard(DEFAULT_SHARD), tenant_id)
+    assert schema_exists(get_engine_for_shard(SECOND_SHARD), tenant_id)
+    assert not schema_exists(get_engine_for_shard(DEFAULT_SHARD), tenant_id)
 
 
 def test_cleanup_drops_the_schema_from_the_tenants_own_shard(
@@ -237,21 +197,17 @@ def test_cleanup_drops_the_schema_from_the_tenants_own_shard(
 ) -> None:
     """The script previously dropped against the catalog database, which for a sharded
     tenant reports `not_found` and silently leaves the schema in place."""
-    from scripts.tenant_cleanup.on_pod_scripts.cleanup_tenant_schema import (
-        drop_data_plane_schema,
-    )
-
     tenant_id = f"tenant_{uuid4()}"
     placement_on_second_shard["created"].append(tenant_id)
 
     record_tenant_placement(tenant_id, SECOND_SHARD)
     create_schema_if_not_exists(tenant_id)
-    assert _schema_exists(get_engine_for_shard(SECOND_SHARD), tenant_id)
+    assert schema_exists(get_engine_for_shard(SECOND_SHARD), tenant_id)
 
     result = drop_data_plane_schema(tenant_id)
 
     assert result["status"] == "success"
-    assert not _schema_exists(get_engine_for_shard(SECOND_SHARD), tenant_id)
+    assert not schema_exists(get_engine_for_shard(SECOND_SHARD), tenant_id)
     assert _mapped_shard(tenant_id) is None
 
 
@@ -291,10 +247,6 @@ def test_cleanup_sweeps_every_shard_not_just_the_mapped_one(
 ) -> None:
     """Cleanup deletes the mapping, so trusting it would strand a copy on the shard the
     mapping did not name — and a tenant mid-migration exists on two shards at once."""
-    from scripts.tenant_cleanup.on_pod_scripts.cleanup_tenant_schema import (
-        drop_data_plane_schema,
-    )
-
     tenant_id = f"tenant_{uuid4()}"
     placement_on_second_shard["created"].append(tenant_id)
 
@@ -308,9 +260,53 @@ def test_cleanup_sweeps_every_shard_not_just_the_mapped_one(
     result = drop_data_plane_schema(tenant_id)
 
     assert result["status"] == "success"
-    assert not _schema_exists(get_engine_for_shard(SECOND_SHARD), tenant_id)
-    assert not _schema_exists(get_engine_for_shard(DEFAULT_SHARD), tenant_id)
+    assert not schema_exists(get_engine_for_shard(SECOND_SHARD), tenant_id)
+    assert not schema_exists(get_engine_for_shard(DEFAULT_SHARD), tenant_id)
     assert _mapped_shard(tenant_id) is None
+
+
+def test_cleanup_rejects_a_malformed_tenant_id_before_touching_any_database(
+    placement_on_second_shard: dict[str, Any],
+) -> None:
+    """A schema name cannot be bound as a parameter, so it is interpolated into DDL.
+    The argument comes from a human on the command line, and the drop now sweeps every
+    configured shard rather than one.
+
+    Reaching the DDL also requires a schema of that exact name to exist, so this is
+    defence in depth rather than an open hole — but the guard is what makes that true
+    by design instead of by accident of statement ordering.
+    """
+    canary = f"tenant_{uuid4()}"
+    placement_on_second_shard["created"].append(canary)
+    create_schema(get_engine_for_shard(DEFAULT_SHARD), canary)
+
+    result = drop_data_plane_schema(f'x" CASCADE; DROP SCHEMA "{canary}')
+
+    assert result["status"] == "error"
+    assert "Invalid tenant_id" in result["message"]
+    assert schema_exists(get_engine_for_shard(DEFAULT_SHARD), canary)
+
+
+def test_rollback_keeps_the_mapping_when_the_schema_drop_fails(
+    placement_on_second_shard: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The mapping is the only route to the schema. Clearing it after a failed drop
+    strands the schema on a shard nothing can resolve."""
+    import ee.onyx.server.tenants.provisioning as provisioning
+
+    tenant_id = f"tenant_{uuid4()}"
+    placement_on_second_shard["created"].append(tenant_id)
+    record_tenant_placement(tenant_id, SECOND_SHARD)
+    create_schema_if_not_exists(tenant_id)
+
+    def _boom(_tenant_id: str) -> None:
+        raise RuntimeError("shard unreachable")
+
+    monkeypatch.setattr(provisioning, "drop_schema", _boom)
+    asyncio.run(provisioning.rollback_tenant_provisioning(tenant_id))
+
+    assert _mapped_shard(tenant_id) == SECOND_SHARD
 
 
 def test_cleanup_clears_catalog_rows_when_the_schema_is_already_gone(
@@ -318,10 +314,6 @@ def test_cleanup_clears_catalog_rows_when_the_schema_is_already_gone(
 ) -> None:
     """Otherwise a retry after a partial run repeats `not_found` forever and the tenant
     stays in shared catalog state indefinitely."""
-    from scripts.tenant_cleanup.on_pod_scripts.cleanup_tenant_schema import (
-        drop_data_plane_schema,
-    )
-
     tenant_id = f"tenant_{uuid4()}"
     placement_on_second_shard["created"].append(tenant_id)
 

--- a/backend/tests/external_dependency_unit/db/test_shard_routing.py
+++ b/backend/tests/external_dependency_unit/db/test_shard_routing.py
@@ -45,10 +45,12 @@ from onyx.db.engine.sql_engine import (
     get_session_with_tenant,
 )
 from onyx.db.models import PublicBase, TenantShard
+from tests.external_dependency_unit.db.shard_test_utils import (
+    DEFAULT_SHARD,
+    schema_exists,
+)
 
-# Shard names used throughout. DEFAULT_SHARD must match ONYX_DB_DEFAULT_SHARD,
-# which the `two_shards` fixture pins.
-DEFAULT_SHARD = "default"
+# SECOND_SHARD is per-suite; DEFAULT_SHARD is shared.
 SECOND_SHARD = "shard-test-b"
 
 # Standalone probe table. `schema=None` so `schema_translate_map` rewrites it to
@@ -83,38 +85,6 @@ def _clear_tenant_shard(tenant_id: str) -> None:
             {"t": tenant_id},
         )
         conn.commit()
-
-
-def _admin_engine() -> Engine:
-    """Engine on the `postgres` maintenance DB, for CREATE/DROP DATABASE."""
-    from sqlalchemy import create_engine
-
-    return create_engine(
-        build_connection_string(db_api=SYNC_DB_API, db="postgres"),
-        isolation_level="AUTOCOMMIT",
-    )
-
-
-@pytest.fixture(scope="module")
-def second_database() -> Generator[str, None, None]:
-    """Create a throwaway second database for the duration of the module."""
-    db_name = f"onyx_shard_test_{uuid4().hex[:8]}"
-    admin = _admin_engine()
-    with admin.connect() as conn:
-        conn.execute(text(f'CREATE DATABASE "{db_name}"'))
-    try:
-        yield db_name
-    finally:
-        with admin.connect() as conn:
-            conn.execute(
-                text(
-                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
-                    "WHERE datname = :db AND pid <> pg_backend_pid()"
-                ),
-                {"db": db_name},
-            )
-            conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
-        admin.dispose()
 
 
 @pytest.fixture(scope="function")
@@ -399,19 +369,6 @@ def test_propagation_window_exceeds_the_poll_interval(
     )
 
 
-def _schema_exists(engine: Engine, schema: str) -> bool:
-    with engine.connect() as conn:
-        return (
-            conn.execute(
-                text(
-                    "SELECT 1 FROM information_schema.schemata WHERE schema_name = :s"
-                ),
-                {"s": schema},
-            ).scalar()
-            is not None
-        )
-
-
 def test_schema_creation_follows_the_shard_map(
     two_shards: dict[str, Any],  # noqa: ARG001
 ) -> None:
@@ -432,8 +389,8 @@ def test_schema_creation_follows_the_shard_map(
     try:
         create_schema_if_not_exists(tenant_id)
 
-        assert _schema_exists(second_engine, tenant_id)
-        assert not _schema_exists(default_engine, tenant_id)
+        assert schema_exists(second_engine, tenant_id)
+        assert not schema_exists(default_engine, tenant_id)
     finally:
         with second_engine.connect() as conn:
             conn.execute(text(f'DROP SCHEMA IF EXISTS "{tenant_id}" CASCADE'))
@@ -450,11 +407,11 @@ def test_drop_schema_follows_the_shard_map(two_shards: dict[str, Any]) -> None:
 
     tenant_b = two_shards["tenant_b"]
     second_engine = shard_registry.get_engine_for_shard(SECOND_SHARD)
-    assert _schema_exists(second_engine, tenant_b)
+    assert schema_exists(second_engine, tenant_b)
 
     drop_schema(tenant_b)
 
-    assert not _schema_exists(second_engine, tenant_b)
+    assert not schema_exists(second_engine, tenant_b)
 
 
 def test_alembic_url_targets_the_tenants_shard(two_shards: dict[str, Any]) -> None:

--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
@@ -140,6 +140,11 @@ POSTGRES_PASSWORD=password
 # tenant_shard, ...). Must be resolvable without a lookup. Defaults to
 # ONYX_DB_DEFAULT_SHARD.
 # ONYX_DB_CATALOG_SHARD=
+# Shard that newly created tenants are placed on. Existing tenants are unaffected,
+# so flipping this changes only where the next tenant is built; the pre-provisioned
+# pool drains oldest-first, which ramps the change in gradually. Defaults to
+# ONYX_DB_DEFAULT_SHARD.
+# ONYX_DB_NEW_TENANT_SHARD=
 # Static tenant_id -> shard overrides, consulted before the catalog table.
 # Incident-response escape hatch, not for routine use.
 #   ONYX_DB_SHARD_OVERRIDES={"tenant_abc":"shard-b"}

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -140,6 +140,11 @@ POSTGRES_PASSWORD=password
 # tenant_shard, ...). Must be resolvable without a lookup. Defaults to
 # ONYX_DB_DEFAULT_SHARD.
 # ONYX_DB_CATALOG_SHARD=
+# Shard that newly created tenants are placed on. Existing tenants are unaffected,
+# so flipping this changes only where the next tenant is built; the pre-provisioned
+# pool drains oldest-first, which ramps the change in gradually. Defaults to
+# ONYX_DB_DEFAULT_SHARD.
+# ONYX_DB_NEW_TENANT_SHARD=
 # Static tenant_id -> shard overrides, consulted before the catalog table.
 # Incident-response escape hatch, not for routine use.
 #   ONYX_DB_SHARD_OVERRIDES={"tenant_abc":"shard-b"}


### PR DESCRIPTION
## Description

Third of the multi-shard multitenancy changes, after the routing seam (#13368) and
shard-aware enumeration (#13518). This is the one that makes the other two do anything:
until now every new tenant landed on the default shard by omission rather than by
decision, so both merged PRs were dormant.

The reason is an ordering problem. `create_schema_if_not_exists` resolves the tenant's
physical database through the `tenant_shard` catalog, and a tenant that does not exist
yet has no catalog row — so it resolves to default, and so does every step after it
(`setup_tenant`, `run_alembic_migrations`, `get_session_with_tenant`).

**The fix is to record the shard mapping before creating the schema.** Every downstream
call already resolves through the catalog, so they all follow with no signature changes,
and nothing on the request hot path is touched.

Two alternatives were considered and rejected:

- *Threading an explicit `shard_name` through provisioning* does not stop at the three
  provisioning helpers — `setup_tenant` calls `get_session_with_tenant`, so it needs a
  shard override on the core session factory used by the whole product.
- *A contextvar scoped around provisioning* breaks on `setup_tenant`'s
  `loop.run_in_executor`, which does not propagate contextvars. Routing would silently
  revert to default inside the executor, which is exactly where migrations run.

Also in scope, because it is the same bug from the other direction: the on-pod cleanup
script ran its `DROP SCHEMA` through the catalog session. For a tenant on any other shard
it would have found nothing, reported `not_found`, and left the schema orphaned. That
matters because tenant cleanup is how the primary database is meant to shrink.

Notes:

- Placement **fails closed**. An unknown target shard raises at configuration-parse time
  and again at placement time, rather than falling back to default — silently placing a
  tenant somewhere other than intended is the failure this change exists to prevent.
- A mapping row is written **only for non-default placement**. An absent row already
  means "default", so existing and new tenants stay described by one rule.
- `available_tenant.shard_name` (column shipped in #13368, previously unread) is now
  populated. It is not load-bearing under this design, but it makes pool composition
  visible without a join.
- The pre-provisioned pool drains oldest-first, so flipping `ONYX_DB_NEW_TENANT_SHARD`
  ramps in gradually on its own rather than cutting over all at once.
- No behaviour change for single-database deployments: with one shard configured,
  placement resolves to default and writes nothing.

Two pre-existing gaps found while working here, both left alone as out of scope and
neither triggered by this change:

- `divide_pool_budget` splits the connection pool equally by shard count, so configuring
  a second shard halves the first shard's pool while it still carries all the load. Worth
  fixing when a second shard actually exists.
- `SqlEngine.init_readonly_engine` builds from the global `POSTGRES_*` settings and is not
  shard-aware. Currently dormant — only wired into pool metrics, with the KG code that
  would query through it commented out.

## How Has This Been Tested?

New external dependency unit suite (`test_shard_placement.py`, 8 tests) against two real
databases, matching the pattern established by the previous two PRs. The assertions are on
which physical database a schema actually appears in, not on what a helper returned, since
the invariant under test is an ordering one.

Covered: new tenants target the configured shard; a recorded placement puts the schema on
that shard while an unplaced tenant in the same test still lands on default (built-in
control); default placement writes no row; placement round-trips and clears; a resolution
attempted before placement does not pin the tenant to default via the routing cache; the
cleanup script drops from the tenant's own shard and clears its mapping; and unknown target
shards raise at both parse time and placement time.

Every fix was mutation-tested — reverted, confirmed the corresponding test fails, restored.
That caught a real defect: the original unknown-shard test passed for the wrong reason
(the exception came from config validation, not the guard it was meant to exercise), so it
is now split into two tests that each exercise one defence.

Full `external_dependency_unit/db` lane run before and after: identical failure count, with
passes up by exactly the 8 new tests. The 44 existing shard routing/enumeration tests and
175 provisioning/engine unit tests all pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Places new tenants on a configured shard by writing the tenant→shard mapping before schema creation; improves cleanup to sweep all shards, validate input, and make retries converge safely.

- **New Features**
  - Added ONYX_DB_NEW_TENANT_SHARD; validated with ONYX_DB_SHARDS at startup and at placement. `get_shard_for_new_tenant` raises on unknown shards.
  - Provisioning and pre-provisioning record placement first; default writes no row; placement invalidates the routing cache and populates `available_tenant.shard_name`.

- **Bug Fixes**
  - Cleanup sweeps every shard, validates `tenant_id` before DDL, clears `public.user_tenant_mapping` and the shard mapping, and returns `not_found` when the schema exists on no shard.
  - Clearing a placement tolerates a missing `public.tenant_shard` table (42P01); other errors still raise.
  - Rollback keeps the shard mapping if the schema drop fails; clears it only after a successful drop.

<sup>Written for commit 3256f6c0eada5b4112b0a94b5bdba648c83a6503. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

