### PR TITLE
fix(craft): preserve requested session names

### DIFF
--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -139,6 +139,7 @@ def create_session(
             session_manager = SessionManager(db_session)
             build_session = session_manager.get_or_create_empty_session(
                 user.id,
+                name=request.name,
                 headless=request.headless,
             )
             sandbox = get_sandbox_by_user_id(db_session, user.id)

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -555,6 +555,7 @@ class SessionManager:
     def get_or_create_empty_session(
         self,
         user_id: UUID,
+        name: str | None = None,
         headless: bool = False,
     ) -> BuildSession:
         """Get or create the user's empty (pre-provisioned) session.
@@ -566,6 +567,11 @@ class SessionManager:
         otherwise it is repaired in place — returned to ``INITIALIZING`` and
         its workspace rebuilt under the same committed session ID (never
         deleted and replaced).
+
+        Args:
+            user_id: The user whose empty session should be reserved.
+            name: Optional name to apply to a new or reused empty session.
+            headless: Skip reserving a Next.js preview port when true.
 
         Raises:
             ValueError: If the user is missing
@@ -590,6 +596,7 @@ class SessionManager:
             session = create_build_session__no_commit(
                 user_id,
                 self._db_session,
+                name=name,
                 agent_provider=llm_config.provider,
                 agent_model=llm_config.model_name,
             )
@@ -602,6 +609,8 @@ class SessionManager:
             return session
 
         session = existing
+        if name is not None:
+            session.name = name
         self._db_session.commit()
         logger.info(
             "Found existing empty session %s (status=%s) for user %s",

--- a/backend/tests/integration/tests/craft/test_sessions_api.py
+++ b/backend/tests/integration/tests/craft/test_sessions_api.py
@@ -38,6 +38,33 @@ def test_create_session_returns_200_with_session_and_sandbox_shape(
     assert body["sandbox"] is not None
 
 
+def test_create_session_preserves_requested_name(admin_user: DATestUser) -> None:
+    requested_name = f"Named Craft session {uuid4().hex[:8]}"
+
+    session = BuildSessionManager.create(admin_user, name=requested_name)
+
+    assert session.name == requested_name
+
+
+def test_create_session_names_reused_pre_provisioned_session(
+    admin_user: DATestUser,
+) -> None:
+    initial_session = BuildSessionManager.create(admin_user)
+    requested_name = f"Named pre-provisioned session {uuid4().hex[:8]}"
+
+    response = client.post(
+        f"{API_SERVER_URL}/build/sessions",
+        json={"name": requested_name, "headless": True},
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+
+    assert response.status_code == 200
+    renamed_session = response.json()
+    assert renamed_session["id"] == initial_session.id
+    assert renamed_session["name"] == requested_name
+
+
 def test_set_sharing_scope_changes_webapp_visibility(
     admin_user: DATestUser,
     basic_user: DATestUser,


### PR DESCRIPTION
## Description

Preserve the optional name supplied to `POST /build/sessions` for both newly reserved sessions and reused pre-provisioned empty sessions.

The request schema exposed a `name` field, but the API only forwarded `headless` to the session manager, so callers received a session with a null or stale name. This threads the requested name through the existing locked reservation path without changing unnamed pre-provisioning behavior.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the requested session name when creating or reusing an empty pre-provisioned build session. Clients now receive the correct name from POST /build/sessions instead of null or stale values.

- **Bug Fixes**
  - Thread `name` from the API to the session manager and apply it on new or reused empty sessions.
  - Added integration tests for name preservation and renaming of reused pre-provisioned sessions.

<sup>Written for commit 999a7e2d3b7fbd48743d4c7819d049e4f17dc879. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

