### PR TITLE
fix(notifications): make notification creation race-safe

### DIFF
--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -63,12 +63,11 @@ def create_notification(
                 db_session.commit()
         return notification
 
-    # PostgreSQL considers NULL user IDs distinct, so the unique index cannot
-    # arbitrate global-notification duplicates. Preserve their existing lookup.
-    if user_id is None:
-        existing_notification = existing_notification_query.first()
-        if existing_notification is not None:
-            return return_existing(existing_notification)
+    # Avoid an insert attempt (and sequence consumption) on the common
+    # idempotent path. The conflict-safe insert below still arbitrates races.
+    existing_notification = existing_notification_query.first()
+    if existing_notification is not None:
+        return return_existing(existing_notification)
 
     stmt = (
         insert(Notification)

--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -38,46 +38,64 @@ def create_notification(
     autocommit: bool = True,
     refresh_existing: bool = True,
 ) -> Notification:
-    # Previously, we only matched the first identical, undismissed notification
-    # Now, we assume some uniqueness to notifications
-    # If we previously issued a notification that was dismissed, we no longer issue a new one
+    """Create or return a notification without racing concurrent user inserts."""
 
     # Normalize additional_data to match the unique index behavior
     # The index uses COALESCE(additional_data, '{}'::jsonb)
     # We need to match this logic in our query
     additional_data_normalized = additional_data if additional_data is not None else {}
 
-    existing_notification = (
+    existing_notification_query = (
         db_session.query(Notification)
         .filter_by(user_id=user_id, notif_type=notif_type)
         .filter(
             func.coalesce(Notification.additional_data, cast({}, postgresql.JSONB))
             == additional_data_normalized
         )
-        .first()
     )
 
-    if existing_notification:
+    def return_existing(notification: Notification) -> Notification:
         # Read-triggered ensure paths should not mutate existing rows: changing
         # last_shown makes notification GET responses differ on every request.
-        if refresh_existing and not existing_notification.dismissed:
-            existing_notification.last_shown = func.now()
+        if refresh_existing and not notification.dismissed:
+            notification.last_shown = func.now()
             if autocommit:
                 db_session.commit()
-        return existing_notification
+        return notification
 
-    # Create a new notification if none exists
-    notification = Notification(
-        user_id=user_id,
-        notif_type=notif_type,
-        title=title,
-        description=description,
-        dismissed=False,
-        last_shown=func.now(),
-        first_shown=func.now(),
-        additional_data=additional_data,
+    # PostgreSQL considers NULL user IDs distinct, so the unique index cannot
+    # arbitrate global-notification duplicates. Preserve their existing lookup.
+    if user_id is None:
+        existing_notification = existing_notification_query.first()
+        if existing_notification is not None:
+            return return_existing(existing_notification)
+
+    stmt = (
+        insert(Notification)
+        .values(
+            user_id=user_id,
+            notif_type=notif_type,
+            title=title,
+            description=description,
+            dismissed=False,
+            last_shown=func.now(),
+            first_shown=func.now(),
+            additional_data=additional_data,
+        )
+        .on_conflict_do_nothing()
+        .returning(Notification.id)
     )
-    db_session.add(notification)
+    inserted_id = db_session.execute(stmt).scalar_one_or_none()
+
+    if inserted_id is None:
+        existing_notification = existing_notification_query.first()
+        if existing_notification is None:
+            raise RuntimeError("Notification insert conflicted but no row was found")
+        return return_existing(existing_notification)
+
+    notification = db_session.get(Notification, inserted_id)
+    if notification is None:
+        raise RuntimeError("Inserted notification could not be loaded")
     if autocommit:
         db_session.commit()
     return notification

--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from uuid import UUID
 
-from sqlalchemy import cast, select, update
+from sqlalchemy import JSON, cast, select, update
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
@@ -11,6 +11,17 @@ from sqlalchemy.sql.elements import ColumnElement
 from onyx.auth.schemas import UserRole
 from onyx.configs.constants import NotificationType
 from onyx.db.models import Notification, User
+
+
+def _notification_additional_data_key() -> ColumnElement[dict]:
+    """Normalize legacy JSON null and SQL NULL values to the empty-object key."""
+    return func.coalesce(
+        func.nullif(
+            Notification.additional_data,
+            cast(JSON.NULL, postgresql.JSONB),
+        ),
+        cast({}, postgresql.JSONB),
+    )
 
 
 def _notification_filters(
@@ -40,23 +51,17 @@ def create_notification(
 ) -> Notification:
     """Create or return a notification without racing concurrent user inserts."""
 
-    # Normalize additional_data to match the unique index behavior
-    # The index uses COALESCE(additional_data, '{}'::jsonb)
-    # We need to match this logic in our query
     additional_data_normalized = additional_data if additional_data is not None else {}
 
     existing_notification_query = (
         db_session.query(Notification)
         .filter_by(user_id=user_id, notif_type=notif_type)
-        .filter(
-            func.coalesce(Notification.additional_data, cast({}, postgresql.JSONB))
-            == additional_data_normalized
-        )
+        .filter(_notification_additional_data_key() == additional_data_normalized)
     )
 
     def return_existing(notification: Notification) -> Notification:
-        # Read-triggered ensure paths should not mutate existing rows: changing
-        # last_shown makes notification GET responses differ on every request.
+        # Read-triggered ensure callers opt out so repeated GETs do not change
+        # last_shown and produce different responses.
         if refresh_existing and not notification.dismissed:
             notification.last_shown = func.now()
             if autocommit:
@@ -79,22 +84,19 @@ def create_notification(
             dismissed=False,
             last_shown=func.now(),
             first_shown=func.now(),
-            additional_data=additional_data,
+            additional_data=additional_data_normalized,
         )
         .on_conflict_do_nothing()
-        .returning(Notification.id)
+        .returning(Notification)
     )
-    inserted_id = db_session.execute(stmt).scalar_one_or_none()
+    notification = db_session.scalars(stmt).one_or_none()
 
-    if inserted_id is None:
+    if notification is None:
         existing_notification = existing_notification_query.first()
         if existing_notification is None:
             raise RuntimeError("Notification insert conflicted but no row was found")
         return return_existing(existing_notification)
 
-    notification = db_session.get(Notification, inserted_id)
-    if notification is None:
-        raise RuntimeError("Inserted notification could not be loaded")
     if autocommit:
         db_session.commit()
     return notification
@@ -112,8 +114,7 @@ def delete_notifications_by_additional_data(
     additional_data_normalized = additional_data if additional_data is not None else {}
     db_session.query(Notification).filter(
         Notification.notif_type == notif_type,
-        func.coalesce(Notification.additional_data, cast({}, postgresql.JSONB))
-        == additional_data_normalized,
+        _notification_additional_data_key() == additional_data_normalized,
     ).delete(synchronize_session=False)
 
 

--- a/backend/onyx/server/features/notifications/utils.py
+++ b/backend/onyx/server/features/notifications/utils.py
@@ -37,9 +37,7 @@ def ensure_system_announcement_notification(user: User, db_session: Session) -> 
         db_session=db_session,
         title=banner.title,
         description=banner.content,
-        # Empty dict, not None: create_notification stores None as JSONB null,
-        # which the COALESCE(additional_data, '{}') dedup won't match, so every
-        # read would re-insert and hit the unique index.
+        # The stable empty object is this announcement's deduplication key.
         additional_data={},
         refresh_existing=False,
     )

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -164,6 +164,65 @@ def test_create_notification_can_preserve_existing_last_shown(
     assert existing_notification.last_shown == original_last_shown
 
 
+def test_create_notification_normalizes_missing_additional_data(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = create_test_user(db_session, "notification_missing_data")
+
+    first = create_notification(
+        user_id=user.id,
+        notif_type=NotificationType.FEATURE_ANNOUNCEMENT,
+        db_session=db_session,
+        title="No additional data",
+    )
+    second = create_notification(
+        user_id=user.id,
+        notif_type=NotificationType.FEATURE_ANNOUNCEMENT,
+        db_session=db_session,
+        title="No additional data",
+    )
+
+    assert second.id == first.id
+    assert second.additional_data == {}
+    matching_ids = db_session.scalars(
+        select(Notification.id).where(
+            Notification.user_id == user.id,
+            Notification.notif_type == NotificationType.FEATURE_ANNOUNCEMENT,
+        )
+    ).all()
+    assert matching_ids == [first.id]
+
+
+def test_create_notification_matches_legacy_json_null_additional_data(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = create_test_user(db_session, "notification_legacy_json_null")
+    now = datetime.now(timezone.utc)
+    legacy_notification = Notification(
+        user_id=user.id,
+        notif_type=NotificationType.FEATURE_ANNOUNCEMENT,
+        dismissed=False,
+        last_shown=now,
+        first_shown=now,
+        title="Legacy JSON null",
+        additional_data=None,
+    )
+    db_session.add(legacy_notification)
+    db_session.commit()
+    legacy_notification_id = legacy_notification.id
+
+    existing = create_notification(
+        user_id=user.id,
+        notif_type=NotificationType.FEATURE_ANNOUNCEMENT,
+        db_session=db_session,
+        title="Legacy JSON null",
+    )
+
+    assert existing.id == legacy_notification_id
+
+
 def test_create_notification_handles_concurrent_insert(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -1,4 +1,6 @@
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -160,6 +162,60 @@ def test_create_notification_can_preserve_existing_last_shown(
 
     assert existing_notification.id == notification.id
     assert existing_notification.last_shown == original_last_shown
+
+
+def test_create_notification_handles_concurrent_insert(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = create_test_user(db_session, "notification_concurrent_insert")
+    additional_data = {"test": "concurrent_insert"}
+
+    def create_competing_notification() -> int:
+        with Session(bind=db_session.get_bind()) as competing_session:
+            notification = create_notification(
+                user_id=user.id,
+                notif_type=NotificationType.FEATURE_ANNOUNCEMENT,
+                db_session=competing_session,
+                title="Competing notification",
+                additional_data=additional_data,
+            )
+            return notification.id
+
+    with Session(bind=db_session.get_bind()) as winning_session:
+        winning_notification = Notification(
+            user_id=user.id,
+            notif_type=NotificationType.FEATURE_ANNOUNCEMENT,
+            dismissed=False,
+            last_shown=datetime.now(timezone.utc),
+            first_shown=datetime.now(timezone.utc),
+            title="Winning notification",
+            additional_data=additional_data,
+        )
+        winning_session.add(winning_notification)
+        winning_session.flush()
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            competing_result = executor.submit(create_competing_notification)
+            with pytest.raises(FutureTimeoutError):
+                competing_result.result(timeout=0.2)
+
+            winning_session.commit()
+            competing_notification_id = competing_result.result(timeout=5)
+
+    assert competing_notification_id == winning_notification.id
+    matching_notifications = list(
+        db_session.scalars(
+            select(Notification).where(
+                Notification.user_id == user.id,
+                Notification.notif_type == NotificationType.FEATURE_ANNOUNCEMENT,
+                Notification.additional_data == additional_data,
+            )
+        ).all()
+    )
+    assert [notification.id for notification in matching_notifications] == [
+        winning_notification.id
+    ]
 
 
 def test_get_notifications_api_returns_paginated_response(

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -194,6 +194,7 @@ def test_create_notification_handles_concurrent_insert(
         )
         winning_session.add(winning_notification)
         winning_session.flush()
+        winning_notification_id = winning_notification.id
 
         with ThreadPoolExecutor(max_workers=1) as executor:
             competing_result = executor.submit(create_competing_notification)
@@ -203,7 +204,7 @@ def test_create_notification_handles_concurrent_insert(
             winning_session.commit()
             competing_notification_id = competing_result.result(timeout=5)
 
-    assert competing_notification_id == winning_notification.id
+    assert competing_notification_id == winning_notification_id
     matching_notifications = list(
         db_session.scalars(
             select(Notification).where(
@@ -214,7 +215,7 @@ def test_create_notification_handles_concurrent_insert(
         ).all()
     )
     assert [notification.id for notification in matching_notifications] == [
-        winning_notification.id
+        winning_notification_id
     ]
 
 

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_gate_claim_arbiter.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_gate_claim_arbiter.py
@@ -1,8 +1,7 @@
-"""External-dependency-unit tests for `_claim_expired_or_read_winner`.
+"""External-dependency-unit tests for GateAddon persistence and race behavior.
 
-Run against real Postgres rows: stubbing `try_record_decision` /
-`get_action_approval` would pass even if the conditional UPDATE became
-unconditional, so the race behaviour is pinned against the real DB.
+Run against real Postgres rows so transaction visibility and conditional
+updates are tested rather than inferred from mocked session calls.
 """
 
 from __future__ import annotations
@@ -11,17 +10,38 @@ import datetime as dt
 from typing import Any
 from uuid import UUID, uuid4
 
+import pytest
+from redis.exceptions import RedisError
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from onyx.db.enums import ApprovalDecision, BuildSessionStatus
-from onyx.db.models import ActionApproval, BuildSession
+from onyx.cache.factory import get_cache_backend
+from onyx.configs.constants import NotificationType
+from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.enums import (
+    ApprovalDecision,
+    BuildSessionStatus,
+    EndpointPolicy,
+    GatedAppKind,
+)
+from onyx.db.models import ActionApproval, BuildSession, Notification
+from onyx.external_apps.matching.engine import (
+    AllMatchedActions,
+    GatedTarget,
+    MatchedAction,
+)
+from onyx.sandbox_proxy import approval_cache
 from onyx.sandbox_proxy.addons.gate import GateAddon, _IdentityResolver
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
-from onyx.sandbox_proxy.identity import ResolvedSandbox
+from onyx.sandbox_proxy.identity import ResolvedSandbox, SessionContext
 from onyx.sandbox_proxy.request_evaluator import RequestEvaluator
 from shared_configs.contextvars import POSTGRES_DEFAULT_SCHEMA
 from tests.common.craft.payloads import action_entry
 from tests.external_dependency_unit.conftest import create_test_user
+from tests.external_dependency_unit.craft.db_helpers import (
+    make_external_app,
+    make_skill,
+)
 
 
 def _seed_build_session(db_session: Session) -> UUID:
@@ -86,10 +106,8 @@ class _UnusedMatcher(RequestEvaluator):
         raise AssertionError("request_evaluator.evaluate unexpectedly used")
 
 
-def _build_addon() -> GateAddon:
-    """`GateAddon` for the claim arbiter; it opens its own tenant session via
-    `get_session_with_tenant`, so the identity/matcher/cache deps are
-    obvious-fail stubs the arbiter never touches."""
+def _build_addon(cache_factory: Any | None = None) -> GateAddon:
+    """`GateAddon` for DB-focused tests with unused request-path dependencies."""
 
     def _factory_raises(tenant_id: str) -> Any:  # noqa: ARG001
         raise AssertionError("cache_factory unexpectedly used")
@@ -97,10 +115,112 @@ def _build_addon() -> GateAddon:
     return GateAddon(
         identity=_UnusedResolver(),
         request_evaluator=_UnusedMatcher(),
-        cache_factory=_factory_raises,
+        cache_factory=cache_factory or _factory_raises,
         proxy_instance_id="proxy-test",
         credential_dispatcher=CredentialInjectionDispatcher([]),
     )
+
+
+@pytest.mark.parametrize("announce_fails", [False, True], ids=["success", "failure"])
+def test_persist_approval_row_commits_before_announce_and_notifies(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+    announce_fails: bool,
+) -> None:
+    """The approval is visible before announce, and a Redis failure does not
+    undo persistence or prevent the notification side effect."""
+    session_id = _seed_build_session(db_session)
+    build_session = db_session.get(BuildSession, session_id)
+    assert build_session is not None
+    assert build_session.user_id is not None
+    user_id = build_session.user_id
+
+    skill = make_skill(db_session, author_user_id=user_id)
+    external_app = make_external_app(db_session, skill=skill, auth_template={})
+    db_session.commit()
+
+    matched_actions = AllMatchedActions(
+        actions=(
+            MatchedAction(
+                action_type="slack.messages.write",
+                display_name="Post a message",
+                description="Post a message to a channel or conversation.",
+                policy=EndpointPolicy.ASK,
+            ),
+        ),
+        target=GatedTarget(
+            kind=GatedAppKind.EXTERNAL_APP,
+            id=external_app.id,
+            app_name=external_app.name,
+        ),
+        payload={"text": "hi"},
+    )
+    ctx = SessionContext(
+        session_id=session_id,
+        user_id=user_id,
+        sandbox_id=uuid4(),
+        tenant_id=POSTGRES_DEFAULT_SCHEMA,
+        sandbox_name="sandbox-gate-persistence",
+        sandbox_ip="10.0.0.1",
+    )
+
+    announced: list[tuple[UUID, UUID]] = []
+    cache = get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA)
+    real_announce = approval_cache.announce_approval
+
+    def _announce(
+        approval_id: UUID, announced_session_id: UUID, announcement_cache: Any
+    ) -> None:
+        assert announcement_cache is cache
+        with get_session_with_tenant(tenant_id=POSTGRES_DEFAULT_SCHEMA) as probe:
+            persisted = probe.get(ActionApproval, approval_id)
+            assert persisted is not None
+            assert persisted.session_id == session_id
+            assert persisted.payload == matched_actions.payload
+        announced.append((approval_id, announced_session_id))
+        if announce_fails:
+            raise RedisError("connection refused")
+        real_announce(approval_id, announced_session_id, announcement_cache)
+
+    monkeypatch.setattr(approval_cache, "announce_approval", _announce)
+    addon = _build_addon(cache_factory=lambda _tenant_id: cache)
+
+    approval_id = addon._persist_approval_row(ctx, matched_actions)
+
+    assert announced == [(approval_id, session_id)]
+    if not announce_fails:
+        assert (
+            approval_cache.pop_announcement(session_id, timeout_s=1, cache=cache)
+            == approval_id
+        )
+    assert dict(addon._parked.snapshot()) == {POSTGRES_DEFAULT_SCHEMA: {approval_id}}
+
+    db_session.expire_all()
+    persisted = db_session.get(ActionApproval, approval_id)
+    assert persisted is not None
+    assert persisted.actions == [
+        action.model_dump(mode="json") for action in matched_actions.actions
+    ]
+    assert persisted.app_name == external_app.name
+    assert persisted.payload == matched_actions.payload
+
+    notification = db_session.scalar(
+        select(Notification).where(
+            Notification.user_id == user_id,
+            Notification.notif_type == NotificationType.APPROVAL_REQUESTED,
+        )
+    )
+    assert notification is not None
+    assert notification.title == "Craft is requesting approval"
+    assert notification.additional_data == {
+        "approval_id": str(approval_id),
+        "session_id": str(session_id),
+        "action_type": matched_actions.governing_action.action_type,
+        "action_count": len(matched_actions.actions),
+        "app_name": external_app.name,
+        "link": f"/craft/v1?sessionId={session_id}",
+    }
 
 
 def test_claim_succeeds_when_pending(

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -15,8 +15,7 @@ import asyncio
 import base64
 import json
 import logging
-from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import AbstractSet, Any
 from unittest.mock import MagicMock
@@ -26,7 +25,9 @@ import pytest
 from mitmproxy import connection, http
 from mitmproxy.proxy import server_hooks
 from redis.exceptions import RedisError
+from sqlalchemy.orm import Session
 
+from onyx.cache.interface import CacheBackend
 from onyx.db.enums import (
     ApprovalDecidedVia,
     ApprovalDecision,
@@ -108,9 +109,13 @@ def _ctx(
 @pytest.fixture(autouse=True)
 def _patch_gate_session(monkeypatch: pytest.MonkeyPatch) -> None:
     """The gate opens tenant sessions via `gate.get_session_with_tenant`.
-    Default it to a dummy MagicMock-yielding session; tests asserting on
-    session-open ordering re-patch it with `_recorder_db_factory(ops)`."""
-    monkeypatch.setattr(gate, "get_session_with_tenant", _recorder_db_factory([]))
+    Unit tests treat the session as an opaque collaborator; persistence and
+    transaction behavior are covered by external-dependency tests."""
+    monkeypatch.setattr(
+        gate,
+        "get_session_with_tenant",
+        lambda **_kwargs: nullcontext(MagicMock(spec=Session)),
+    )
     # The stub sessions can't answer the target → gated_app_id lookup.
     monkeypatch.setattr(gate, "get_gated_app_id", lambda _db, _kind, _target_id: 1)
     monkeypatch.setattr(
@@ -1436,173 +1441,6 @@ def test_parked_approvals_remove_last_cleans_tenant_entry() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _persist_approval_row
-# ---------------------------------------------------------------------------
-
-
-class _RecorderSession:
-    """Records the ordered DB ops so a test can pin commit-before-announce."""
-
-    def __init__(self, ops: list[str]) -> None:
-        self._ops = ops
-
-    def add(self, obj: Any) -> None:  # noqa: ARG002
-        self._ops.append("add")
-
-    def flush(self) -> None:
-        self._ops.append("flush")
-
-    def commit(self) -> None:
-        self._ops.append("commit")
-
-    # Chained query for create_notification's idempotency check; first()
-    # returns None to force the create-new-row path.
-    def query(self, *_args: Any, **_kwargs: Any) -> "_RecorderSession":
-        return self
-
-    def filter_by(self, *_args: Any, **_kwargs: Any) -> "_RecorderSession":
-        return self
-
-    def filter(self, *_args: Any, **_kwargs: Any) -> "_RecorderSession":
-        return self
-
-    def first(self) -> None:
-        return None
-
-
-def _recorder_db_factory(ops: list[str]) -> Any:
-    @contextmanager
-    def factory(tenant_id: str) -> Iterator[_RecorderSession]:  # noqa: ARG001
-        yield _RecorderSession(ops)
-
-    return factory
-
-
-class _RecorderCache:
-    """Stub `CacheBackend` recording the rpush/expire that announce uses."""
-
-    def __init__(self, ops: list[str], rpush_raises: Exception | None = None) -> None:
-        self._ops = ops
-        self._rpush_raises = rpush_raises
-        self.rpush_calls: list[tuple[str, Any]] = []
-        self.expire_calls: list[tuple[str, int]] = []
-
-    def rpush(self, key: str, value: Any) -> None:
-        if self._rpush_raises is not None:
-            raise self._rpush_raises
-        self._ops.append(f"rpush:{key}")
-        self.rpush_calls.append((key, value))
-
-    def expire(self, key: str, ttl: int) -> None:
-        self._ops.append(f"expire:{key}")
-        self.expire_calls.append((key, ttl))
-
-
-def test_persist_approval_row_commits_announces_notifies(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Pin the commit path: row committed before announce, announce
-    RPUSHed onto `approval:announce:{session_id}`, and the id registered
-    with the parked-approvals drain."""
-    ops: list[str] = []
-    approval_id = UUID("22222222-2222-2222-2222-222222222222")
-
-    # Stub insert to return a fixed id so the side effects can be pinned.
-    inserted_payload: dict[str, Any] = {}
-
-    def _fake_insert(
-        db: Any,  # noqa: ARG001
-        **kwargs: Any,
-    ) -> Any:
-        inserted_payload.update(kwargs)
-        ops.append("insert")
-        return MagicMock(approval_id=approval_id)
-
-    monkeypatch.setattr(gate.action_approval, "insert_action_approval", _fake_insert)
-
-    cache = _RecorderCache(ops)
-    monkeypatch.setattr(gate, "get_session_with_tenant", _recorder_db_factory(ops))
-    addon = _build(
-        resolver=StubResolver(),
-        matcher=_StubMatcher(),
-        cache_factory=lambda tenant_id: cache,  # noqa: ARG005
-    )
-
-    ctx = _ctx(tenant_id="tenant-1")
-    returned = addon._persist_approval_row(ctx, _MATCH)
-
-    assert returned == approval_id
-    assert inserted_payload == {
-        "session_id": ctx.session_id,
-        "actions": [a.model_dump(mode="json") for a in _MATCH.actions],
-        "app_name": _MATCH.app_name,
-        "payload": _MATCH.payload,
-        "target": _MATCH.target.key,
-    }
-
-    # insert -> commit -> rpush: announce must not precede the commit,
-    # or the FE could read the row before it's persisted.
-    insert_at = ops.index("insert")
-    commit_at = ops.index("commit")
-    rpush_at = next(i for i, op in enumerate(ops) if op.startswith("rpush:"))
-    assert insert_at < commit_at < rpush_at, ops
-
-    # Announce key is the session-specific list the merger BLPOPs on.
-    assert cache.rpush_calls == [
-        (f"approval:announce:{ctx.session_id}", str(approval_id))
-    ]
-    # Registered for the SIGTERM drain.
-    assert dict(addon._parked.snapshot()) == {"tenant-1": {approval_id}}
-
-
-def test_persist_approval_row_announce_failure_is_swallowed(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A Redis blip on announce must not roll back the row or skip the
-    notify dispatch; the sub-steps run independently."""
-    approval_id = UUID("33333333-3333-3333-3333-333333333333")
-    ops: list[str] = []
-
-    def _fake_insert(
-        db: Any,  # noqa: ARG001
-        **kwargs: Any,  # noqa: ARG001
-    ) -> Any:
-        ops.append("insert")
-        return MagicMock(approval_id=approval_id)
-
-    monkeypatch.setattr(gate.action_approval, "insert_action_approval", _fake_insert)
-
-    cache = _RecorderCache(ops, rpush_raises=RedisError("connection refused"))
-    monkeypatch.setattr(gate, "get_session_with_tenant", _recorder_db_factory(ops))
-    addon = _build(
-        resolver=StubResolver(),
-        matcher=_StubMatcher(),
-        cache_factory=lambda tenant_id: cache,  # noqa: ARG005
-    )
-
-    notify_calls: list[tuple[UUID, SessionContext, AllMatchedActions]] = []
-
-    def _fake_notify(
-        _self: Any, aid: UUID, ctx_arg: SessionContext, match_arg: AllMatchedActions
-    ) -> None:
-        notify_calls.append((aid, ctx_arg, match_arg))
-
-    monkeypatch.setattr(GateAddon, "_notify_approval_requested", _fake_notify)
-
-    ctx = _ctx(tenant_id="tenant-1")
-    # Must not propagate the RedisError.
-    returned = addon._persist_approval_row(ctx, _MATCH)
-    assert returned == approval_id
-    assert dict(addon._parked.snapshot()) == {"tenant-1": {approval_id}}
-
-    # Failed announce must not short-circuit the notify dispatch.
-    assert notify_calls == [(approval_id, ctx, _MATCH)]
-    assert ops.index("insert") < ops.index("commit")
-    # rpush raised before recording, so no rpush op is present.
-    assert not any(op.startswith("rpush:") for op in ops)
-
-
-# ---------------------------------------------------------------------------
 # _await_decision
 # ---------------------------------------------------------------------------
 
@@ -1623,7 +1461,7 @@ async def test_await_decision_wake_received_returns_decision(
 
     monkeypatch.setattr(gate.approval_cache, "wait_for_wake", _fake_wait_for_wake)
 
-    cache = _RecorderCache([])
+    cache = MagicMock(spec=CacheBackend)
     addon = _build(
         resolver=StubResolver(),
         matcher=_StubMatcher(),
@@ -1652,7 +1490,7 @@ async def test_await_decision_timeout_claims_expired(
 
     monkeypatch.setattr(gate.approval_cache, "wait_for_wake", _fake_wait_for_wake)
 
-    cache = _RecorderCache([])
+    cache = MagicMock(spec=CacheBackend)
     addon = _build(
         resolver=StubResolver(),
         matcher=_StubMatcher(),
@@ -1691,7 +1529,7 @@ async def test_await_decision_cancelled_claims_expired_and_reraises(
 
     monkeypatch.setattr(gate.approval_cache, "wait_for_wake", _fake_wait_for_wake)
 
-    cache = _RecorderCache([])
+    cache = MagicMock(spec=CacheBackend)
     addon = _build(
         resolver=StubResolver(),
         matcher=_StubMatcher(),
@@ -1726,9 +1564,9 @@ async def test_drain_inflight_walks_parked_per_tenant(
     """Drain wakes every parked approval on its own tenant's cache, never
     cross-tenant, and leaves `_parked` untouched (removal is owned by
     `_await_decision.finally`)."""
-    cache_t1 = _RecorderCache([])
-    cache_t2 = _RecorderCache([])
-    per_tenant_caches: dict[str, _RecorderCache] = {
+    cache_t1 = MagicMock(spec=CacheBackend)
+    cache_t2 = MagicMock(spec=CacheBackend)
+    per_tenant_caches: dict[str, CacheBackend] = {
         "tenant-1": cache_t1,
         "tenant-2": cache_t2,
     }
@@ -1754,7 +1592,7 @@ async def test_drain_inflight_walks_parked_per_tenant(
         lambda _aid, _tid: ApprovalDecision.EXPIRED,
     )
 
-    send_wake_calls: list[tuple[UUID, ApprovalDecision, _RecorderCache]] = []
+    send_wake_calls: list[tuple[UUID, ApprovalDecision, CacheBackend]] = []
 
     def _fake_send_wake(aid: UUID, decision: ApprovalDecision, cache: Any) -> None:
         send_wake_calls.append((aid, decision, cache))
@@ -1782,9 +1620,9 @@ async def test_drain_inflight_completes_when_inflight_set_empty() -> None:
     """Nothing parked or inflight: drain returns immediately."""
     cache_factory_calls: list[str] = []
 
-    def _tracking_cache_factory(tenant_id: str) -> _RecorderCache:
+    def _tracking_cache_factory(tenant_id: str) -> CacheBackend:
         cache_factory_calls.append(tenant_id)
-        return _RecorderCache([])
+        return MagicMock(spec=CacheBackend)
 
     addon = _build(
         resolver=StubResolver(),
@@ -1816,7 +1654,7 @@ def test_terminalize_happy_path_writes_wake(
     The wake carries the arbiter's decision (APPROVED here if the API
     won the race), not unconditionally EXPIRED."""
     approval_id = uuid4()
-    cache = _RecorderCache([])
+    cache = MagicMock(spec=CacheBackend)
     addon = _build(
         resolver=StubResolver(),
         matcher=_StubMatcher(),
@@ -1847,7 +1685,7 @@ def test_terminalize_db_failure_skips_wake(
     """If the claim raises, there's no decision to forward, so send_wake
     must not be called; the exception is swallowed."""
     approval_id = uuid4()
-    cache = _RecorderCache([])
+    cache = MagicMock(spec=CacheBackend)
     addon = _build(
         resolver=StubResolver(),
         matcher=_StubMatcher(),
@@ -1879,7 +1717,7 @@ def test_terminalize_wake_failure_swallowed(
     """send_wake raising must not propagate; the parked BLPOP times out
     and re-reads the already-terminal row from Postgres."""
     approval_id = uuid4()
-    cache = _RecorderCache([])
+    cache = MagicMock(spec=CacheBackend)
     addon = _build(
         resolver=StubResolver(),
         matcher=_StubMatcher(),


### PR DESCRIPTION
## Description

Make per-user notification creation race-safe under concurrent requests while preserving the efficient existing-notification path.

The previous check-then-insert flow allowed parallel first-load requests to both observe no row. One insert then violated `ix_notification_user_type_data`, leaving the losing SQLAlchemy session in a failed transaction and causing follow-on notification queries to raise `PendingRollbackError`.

After the initial lookup misses, notification creation now uses PostgreSQL `INSERT ... ON CONFLICT DO NOTHING` and returns either the newly inserted row or the concurrent winner. The initial lookup remains the common path so repeated ensure calls do not consume notification sequence values or perform unnecessary insert/index work.

The regression coverage now uses real PostgreSQL transaction visibility and the configured cache backend for sandbox approval notification delivery. It verifies that the approval is committed before announcement, that successful announcements round-trip through the cache, and that an announcement failure does not prevent notification persistence. Bespoke SQLAlchemy and cache recorder implementations were removed.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check