### PR TITLE
fix(celery): launch beat watchdog as module

### DIFF
--- a/backend/onyx/utils/platform_utils.py
+++ b/backend/onyx/utils/platform_utils.py
@@ -1,8 +1,5 @@
-# Named `platform_utils` (not `platform`) because `supervisord_watchdog.py` in this
-# same directory is launched as a script (`python onyx/utils/supervisord_watchdog.py`),
-# which puts this directory on `sys.path[0]`. A module named `platform.py` here would
-# then shadow the stdlib `platform`, breaking `uuid` (which calls `platform.system()`)
-# and any transitive import of it (e.g. `redis`). See issue #10975.
+# Named `platform_utils` (not `platform`) so direct execution of a utility from this
+# directory cannot shadow the stdlib `platform`. See issue #10975.
 import os
 import warnings
 

--- a/backend/supervisord.conf
+++ b/backend/supervisord.conf
@@ -135,7 +135,7 @@ stopasgroup=true
 # supervisord only restarts the process if it's dead
 # make sure this key matches ONYX_CELERY_BEAT_HEARTBEAT_KEY
 [program:supervisord_watchdog_celery_beat]
-command=python onyx/utils/supervisord_watchdog.py
+command=python -m onyx.utils.supervisord_watchdog
     --conf /etc/supervisor/conf.d/supervisord.conf
     --key "onyx:celery:beat:heartbeat"
     --program celery_beat


### PR DESCRIPTION
## Description

Launch the Celery Beat watchdog with Python's module entrypoint instead of executing its file path directly.

Direct execution places `onyx/utils` at the front of the import path, allowing local utility modules such as `datetime.py` to shadow Python standard-library modules during watchdog startup. Running `python -m onyx.utils.supervisord_watchdog` uses the application root as the import boundary and restores watchdog startup without changing its runtime behavior.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the Celery Beat watchdog as a module (`python -m onyx.utils.supervisord_watchdog`) to avoid stdlib shadowing and ensure reliable startup. No runtime behavior change.

- **Bug Fixes**
  - Update `supervisord.conf` to use the module entrypoint for `supervisord_watchdog_celery_beat`.
  - Clarify the comment in `platform_utils.py` about avoiding stdlib `platform` shadowing.

<sup>Written for commit 5a0d2692bc0968e9afe0c922945a7326b37ea547. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

