### PR TITLE
fix: knowledge pane query filters

### DIFF
--- a/backend/ee/onyx/db/hierarchy.py
+++ b/backend/ee/onyx/db/hierarchy.py
@@ -8,19 +8,16 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql.elements import ColumnElement
 
 from onyx.configs.constants import DocumentSource
+from onyx.db.connector_credential_pair import build_user_cc_pair_access_filter
 from onyx.db.enums import (
-    AccessType,
     ConnectorCredentialPairStatus,
     HierarchyNodeType,
 )
 from onyx.db.hierarchy import HIERARCHY_NODE_SEARCH_LIMIT, escape_like_pattern
 from onyx.db.models import (
     ConnectorCredentialPair,
-    Credential,
     HierarchyNode,
     HierarchyNodeByConnectorCredentialPair,
-    User__UserGroup,
-    UserGroup__ConnectorCredentialPair,
 )
 
 
@@ -28,8 +25,6 @@ def _build_connector_access_filter(user_id: UUID) -> ColumnElement[bool]:
     """Grant the connector-level access applied to indexed documents."""
     node_cc_pair = HierarchyNodeByConnectorCredentialPair
     cc_pair = ConnectorCredentialPair
-    group_cc_pair = UserGroup__ConnectorCredentialPair
-    user_group = User__UserGroup
 
     stmt = (
         select(1)
@@ -41,34 +36,10 @@ def _build_connector_access_filter(user_id: UUID) -> ColumnElement[bool]:
                 cc_pair.credential_id == node_cc_pair.credential_id,
             ),
         )
-        .join(Credential, Credential.id == cc_pair.credential_id)
-        .outerjoin(
-            group_cc_pair,
-            and_(
-                group_cc_pair.cc_pair_id == cc_pair.id,
-                group_cc_pair.is_current.is_(True),
-            ),
-        )
-        .outerjoin(
-            user_group,
-            and_(
-                user_group.user_group_id == group_cc_pair.user_group_id,
-                user_group.user_id == user_id,
-            ),
-        )
         .where(
             node_cc_pair.hierarchy_node_id == HierarchyNode.id,
             cc_pair.status != ConnectorCredentialPairStatus.DELETING,
-            or_(
-                cc_pair.access_type == AccessType.PUBLIC,
-                and_(
-                    cc_pair.access_type != AccessType.SYNC,
-                    or_(
-                        Credential.user_id == user_id,
-                        user_group.user_id == user_id,
-                    ),
-                ),
-            ),
+            build_user_cc_pair_access_filter(user_id),
         )
     )
     return stmt.exists()

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -1,11 +1,13 @@
 from datetime import datetime
 from enum import Enum
 from typing import TypeVarTuple
+from uuid import UUID
 
 from fastapi import HTTPException
 from pydantic import BaseModel
-from sqlalchemy import Select, delete, desc, exists, func, select, update
+from sqlalchemy import Select, and_, delete, desc, exists, func, or_, select, update
 from sqlalchemy.orm import Session, aliased, joinedload, selectinload
+from sqlalchemy.sql.elements import ColumnElement
 
 from onyx.configs.constants import DEFAULT_CC_PAIR_ID, DocumentSource
 from onyx.db.connector import fetch_connector_by_id
@@ -38,6 +40,44 @@ logger = setup_logger()
 
 R = TypeVarTuple("R")
 _CONNECTOR_STATE_QUERY_TIMEOUT = "7s"
+
+
+def build_user_cc_pair_access_filter(user_id: UUID) -> ColumnElement[bool]:
+    """Grant public, credential-owner, or current user-group connector access."""
+    credential_owner = (
+        select(1)
+        .select_from(Credential)
+        .where(
+            Credential.id == ConnectorCredentialPair.credential_id,
+            Credential.user_id == user_id,
+        )
+        .correlate(ConnectorCredentialPair)
+        .exists()
+    )
+    current_group_member = (
+        select(1)
+        .select_from(User__UserGroup)
+        .join(
+            UserGroup__ConnectorCredentialPair,
+            and_(
+                UserGroup__ConnectorCredentialPair.user_group_id
+                == User__UserGroup.user_group_id,
+                UserGroup__ConnectorCredentialPair.cc_pair_id
+                == ConnectorCredentialPair.id,
+                UserGroup__ConnectorCredentialPair.is_current.is_(True),
+            ),
+        )
+        .where(User__UserGroup.user_id == user_id)
+        .correlate(ConnectorCredentialPair)
+        .exists()
+    )
+    return or_(
+        ConnectorCredentialPair.access_type == AccessType.PUBLIC,
+        and_(
+            ConnectorCredentialPair.access_type != AccessType.SYNC,
+            or_(credential_owner, current_group_member),
+        ),
+    )
 
 
 class ConnectorType(str, Enum):

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -565,6 +565,7 @@ def get_accessible_documents_for_hierarchy_node_paginated(
     parent_hierarchy_node_id: int,
     user_email: str | None,
     external_group_ids: list[str],
+    user_id: UUID | None,
     limit: int,
     # Sort options
     sort_by_name: bool = False,
@@ -580,7 +581,9 @@ def get_accessible_documents_for_hierarchy_node_paginated(
     stmt = select(DbDocument).where(
         DbDocument.parent_hierarchy_node_id == parent_hierarchy_node_id
     )
-    stmt = apply_document_access_filter(stmt, user_email, external_group_ids)
+    stmt = apply_document_access_filter(
+        stmt, user_email, external_group_ids, user_id=user_id
+    )
 
     # Apply cursor filter based on sort type and direction
     if sort_by_name:

--- a/backend/onyx/db/document_access.py
+++ b/backend/onyx/db/document_access.py
@@ -1,20 +1,13 @@
-"""
-Document access filtering utilities.
+"""SQL filters matching indexed document visibility."""
 
-This module provides reusable access filtering logic for documents based on:
-- Connector access type (PUBLIC vs SYNC)
-- Document-level public flag
-- User email matching external_user_emails
-- User group overlap with external_user_group_ids
-
-This is a standalone module to avoid circular imports between document.py and persona.py.
-"""
+from uuid import UUID
 
 from sqlalchemy import Select, String, and_, any_, cast, or_, select
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.elements import ColumnElement
 
+from onyx.db.connector_credential_pair import build_user_cc_pair_access_filter
 from onyx.db.enums import AccessType, ConnectorCredentialPairStatus
 from onyx.db.models import (
     ConnectorCredentialPair,
@@ -27,24 +20,9 @@ def apply_document_access_filter(
     stmt: Select,
     user_email: str | None,
     external_group_ids: list[str],
+    user_id: UUID | None = None,
 ) -> Select:
-    """
-    Apply document access filtering to a query.
-
-    This joins with DocumentByConnectorCredentialPair and ConnectorCredentialPair to:
-    1. Check if the document is from a PUBLIC connector (access_type = PUBLIC)
-    2. Check document-level permissions (is_public, external_user_emails, external_user_group_ids)
-    3. Exclude documents from cc_pairs that are being deleted
-
-    Args:
-        stmt: The SELECT statement to modify (must be selecting from Document)
-        user_email: The user's email for permission checking
-        external_group_ids: List of external group IDs the user belongs to
-
-    Returns:
-        Modified SELECT statement with access filtering applied
-    """
-    # Join to get cc_pair info for each document
+    """Filter documents by source ACL or associated connector access."""
     stmt = stmt.join(
         DocumentByConnectorCredentialPair,
         Document.id == DocumentByConnectorCredentialPair.id,
@@ -58,16 +36,12 @@ def apply_document_access_filter(
         ),
     )
 
-    # Exclude documents from cc_pairs that are being deleted
     stmt = stmt.where(
         ConnectorCredentialPair.status != ConnectorCredentialPairStatus.DELETING
     )
 
-    # Build access filters
     access_filters: list[ColumnElement[bool]] = [
-        # Document is from a PUBLIC connector
         ConnectorCredentialPair.access_type == AccessType.PUBLIC,
-        # Document is marked as public (e.g., "Anyone with link" in source)
         Document.is_public.is_(True),
     ]
     if user_email:
@@ -78,9 +52,10 @@ def apply_document_access_filter(
                 cast(postgresql.array(external_group_ids), postgresql.ARRAY(String))
             )
         )
+    if user_id:
+        access_filters.append(build_user_cc_pair_access_filter(user_id))
 
-    stmt = stmt.where(or_(*access_filters))
-    return stmt
+    return stmt.where(or_(*access_filters))
 
 
 def get_accessible_documents_by_ids(
@@ -88,30 +63,15 @@ def get_accessible_documents_by_ids(
     document_ids: list[str],
     user_email: str | None,
     external_group_ids: list[str],
+    user_id: UUID | None = None,
 ) -> list[Document]:
-    """
-    Fetch documents by IDs, filtering to only those the user has access to.
-
-    Uses the same access filtering logic as other document queries:
-    - Documents from PUBLIC connectors
-    - Documents marked as public (e.g., "Anyone with link")
-    - Documents where user email matches external_user_emails
-    - Documents where user's groups overlap with external_user_group_ids
-
-    Args:
-        db_session: Database session
-        document_ids: List of document IDs to fetch
-        user_email: User's email for permission checking
-        external_group_ids: List of external group IDs the user belongs to
-
-    Returns:
-        List of Document objects from the input that the user has access to
-    """
+    """Return requested documents allowed by the retrieval-time access policy."""
     if not document_ids:
         return []
 
     stmt = select(Document).where(Document.id.in_(document_ids))
-    stmt = apply_document_access_filter(stmt, user_email, external_group_ids)
-    # Use distinct to avoid duplicates when a document belongs to multiple cc_pairs
+    stmt = apply_document_access_filter(
+        stmt, user_email, external_group_ids, user_id=user_id
+    )
     stmt = stmt.distinct()
     return list(db_session.execute(stmt).scalars().all())

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -1458,6 +1458,7 @@ def upsert_persona(
             document_ids=document_ids,
             user_email=user_email,
             external_group_ids=external_group_ids,
+            user_id=user.id if user else None,
         )
         if not attached_documents and document_ids:
             raise ValueError("documents not found or not accessible")

--- a/backend/onyx/server/features/hierarchy/api.py
+++ b/backend/onyx/server/features/hierarchy/api.py
@@ -113,6 +113,7 @@ def list_accessible_hierarchy_node_documents(
         parent_hierarchy_node_id=documents_request.parent_hierarchy_node_id,
         user_email=user_email,
         external_group_ids=external_group_ids,
+        user_id=user.id,
         limit=DOCUMENT_PAGE_SIZE + 1,
         sort_by_name=sort_by_name,
         sort_ascending=sort_ascending,

--- a/backend/tests/external_dependency_unit/hierarchy/test_hierarchy_access_filter.py
+++ b/backend/tests/external_dependency_unit/hierarchy/test_hierarchy_access_filter.py
@@ -1,4 +1,4 @@
-"""Tests hierarchy visibility through node and connector permissions."""
+"""Tests hierarchy node and document visibility through connector permissions."""
 
 from collections.abc import Generator
 from uuid import UUID, uuid4
@@ -11,16 +11,20 @@ from sqlalchemy.orm import Session
 from ee.onyx.db.hierarchy import _get_accessible_hierarchy_nodes_for_source
 from onyx.auth.schemas import UserRole
 from onyx.configs.constants import DocumentSource
+from onyx.db.document import get_accessible_documents_for_hierarchy_node_paginated
 from onyx.db.enums import AccessType, AccountType, HierarchyNodeType
 from onyx.db.hierarchy import get_source_hierarchy_node
 from onyx.db.models import (
     Credential,
+    Document,
+    DocumentByConnectorCredentialPair,
     HierarchyNode,
     HierarchyNodeByConnectorCredentialPair,
     User__UserGroup,
     UserGroup,
     UserGroup__ConnectorCredentialPair,
 )
+from onyx.kg.models import KGStage
 from tests.external_dependency_unit.indexing_helpers import make_cc_pair
 
 
@@ -28,6 +32,7 @@ class ConnectorAccessSeed(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     node: HierarchyNode
+    document_id: str
     owner_id: UUID
     owner_email: str
     member_id: UUID
@@ -149,11 +154,24 @@ def connector_access_seed(
         raw_node_id=f"connector_private_{tag}",
         display_name=f"Connector Private Folder {tag}",
     )
+    document = Document(
+        id=f"connector_private_document_{tag}",
+        semantic_id=f"Connector Private Document {tag}",
+        parent_hierarchy_node_id=None,
+        kg_stage=KGStage.NOT_STARTED,
+    )
     group = UserGroup(name=f"hierarchy-access-group-{tag}")
-    db_session.add_all([node, group])
+    db_session.add_all([node, document, group])
     db_session.flush()
+    document.parent_hierarchy_node_id = node.id
     db_session.add_all(
         [
+            DocumentByConnectorCredentialPair(
+                id=document.id,
+                connector_id=cc_pair.connector_id,
+                credential_id=cc_pair.credential_id,
+                has_been_indexed=True,
+            ),
             HierarchyNodeByConnectorCredentialPair(
                 hierarchy_node_id=node.id,
                 connector_id=cc_pair.connector_id,
@@ -171,6 +189,7 @@ def connector_access_seed(
 
     yield ConnectorAccessSeed(
         node=node,
+        document_id=document.id,
         owner_id=owner.id,
         owner_email=owner.email,
         member_id=member.id,
@@ -246,6 +265,58 @@ def test_connector_user_group_member_can_access_node(
 
     assert seed.node.id in {node.id for node in member_results}
     assert seed.node.id not in {node.id for node in outsider_results}
+
+
+def test_connector_credential_owner_can_access_hierarchy_document(
+    db_session: Session,
+    connector_access_seed: ConnectorAccessSeed,
+) -> None:
+    seed = connector_access_seed
+    owner_results = get_accessible_documents_for_hierarchy_node_paginated(
+        db_session=db_session,
+        parent_hierarchy_node_id=seed.node.id,
+        user_email=seed.owner_email,
+        external_group_ids=[],
+        user_id=seed.owner_id,
+        limit=10,
+    )
+    outsider_results = get_accessible_documents_for_hierarchy_node_paginated(
+        db_session=db_session,
+        parent_hierarchy_node_id=seed.node.id,
+        user_email=seed.outsider_email,
+        external_group_ids=[],
+        user_id=seed.outsider_id,
+        limit=10,
+    )
+
+    assert seed.document_id in {document.id for document in owner_results}
+    assert seed.document_id not in {document.id for document in outsider_results}
+
+
+def test_connector_user_group_member_can_access_hierarchy_document(
+    db_session: Session,
+    connector_access_seed: ConnectorAccessSeed,
+) -> None:
+    seed = connector_access_seed
+    member_results = get_accessible_documents_for_hierarchy_node_paginated(
+        db_session=db_session,
+        parent_hierarchy_node_id=seed.node.id,
+        user_email=seed.member_email,
+        external_group_ids=[],
+        user_id=seed.member_id,
+        limit=10,
+    )
+    outsider_results = get_accessible_documents_for_hierarchy_node_paginated(
+        db_session=db_session,
+        parent_hierarchy_node_id=seed.node.id,
+        user_email=seed.outsider_email,
+        external_group_ids=[],
+        user_id=seed.outsider_id,
+        limit=10,
+    )
+
+    assert seed.document_id in {document.id for document in member_results}
+    assert seed.document_id not in {document.id for document in outsider_results}
 
 
 def test_email_filter(


### PR DESCRIPTION
## Description

Documents were still not showing up in the agent knowledge pane for private connectors, as their retrieval only worked for public and permission-synced data. The new logic retrieves documents to be selected if the user is also a member of a user group with access to the private connector.

Also improves the query pattern for hierarchynodes so we're only doing indexed joins

## How Has This Been Tested?

added tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed knowledge pane document visibility for private connectors by honoring credential ownership and current user-group membership. Applied a unified connector access filter to hierarchy nodes and document queries.

- **Bug Fixes**
  - Added `build_user_cc_pair_access_filter` and used it across hierarchy and document access filters.
  - Document retrieval now accepts `user_id` and respects connector-level access for private connectors.
  - Passed `user_id` through the hierarchy API and persona document attachment.
  - Added tests for owner and user-group member access to nodes and documents.

<sup>Written for commit d8db795c722ae88ec9e74e3df2c16a0a11d8907b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

