### PR TITLE
fix(gateway): open a trace so gateway LLM calls are metered

### DIFF
--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -75,11 +75,8 @@ _MESSAGES_ADAPTER: TypeAdapter[list[ChatCompletionMessage]] = TypeAdapter(
 )
 
 
-def _gateway_trace(flow: LLMFlow, llm: LLM) -> Trace:
-    return trace(
-        "llm_gateway",
-        metadata={"flow": flow.value, "model": llm.config.model_name},
-    )
+def _gateway_trace(flow: LLMFlow, model: str) -> Trace:
+    return trace("llm_gateway", metadata={"flow": flow.value, "model": model})
 
 
 def resolve_gateway_model(
@@ -245,7 +242,7 @@ def _stream_worker(
     # StreamingResponse, so the trace must be opened here rather than in the
     # endpoint for the generation span to see an active trace.
     with (
-        _gateway_trace(flow, llm),
+        _gateway_trace(flow, llm.config.model_name),
         llm_generation_span(
             llm, flow=flow, input_messages=messages, tools=tools
         ) as span,
@@ -435,7 +432,7 @@ def handle_chat_completion(
         )
 
     with (
-        _gateway_trace(flow, llm),
+        _gateway_trace(flow, llm.config.model_name),
         llm_generation_span(
             llm,
             flow=flow,

--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -2,6 +2,7 @@ import json
 import queue
 import threading
 from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from typing import Any
 
 from fastapi import APIRouter, Depends, Request, Response
@@ -49,6 +50,7 @@ from onyx.server.gateway.models import (
 from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
 from onyx.server.query_and_chat.token_limit import check_token_rate_limits
 from onyx.tracing.flows import LLMFlow
+from onyx.tracing.framework.create import trace
 from onyx.tracing.llm_utils import (
     llm_generation_span,
     record_llm_response,
@@ -67,9 +69,16 @@ _FLOW_ACCESS_CHECKS: dict[LLMFlow, Callable[[Request, User], bool]] = {
     LLMFlow.CRAFT_LLM_GENERATION: is_gateway_request,
 }
 
+
 _MESSAGES_ADAPTER: TypeAdapter[list[ChatCompletionMessage]] = TypeAdapter(
     list[ChatCompletionMessage]
 )
+
+
+@contextmanager
+def _gateway_trace(flow: LLMFlow, model: str) -> Iterator[None]:
+    with trace("llm_gateway", metadata={"flow": flow.value, "model": model}):
+        yield
 
 
 def resolve_gateway_model(
@@ -231,9 +240,15 @@ def _stream_worker(
     out: "queue.Queue[Any]",
     cancelled: threading.Event,
 ) -> None:
-    with llm_generation_span(
-        llm, flow=flow, input_messages=messages, tools=tools
-    ) as span:
+    # Runs on its own thread after the endpoint has returned the
+    # StreamingResponse, so the trace must be opened here rather than in the
+    # endpoint for the generation span to see an active trace.
+    with (
+        _gateway_trace(flow, model),
+        llm_generation_span(
+            llm, flow=flow, input_messages=messages, tools=tools
+        ) as span,
+    ):
         accumulated_content: list[str] = []
         accumulated_reasoning: list[str] = []
         final_usage: Usage | None = None
@@ -418,12 +433,15 @@ def handle_chat_completion(
             headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
         )
 
-    with llm_generation_span(
-        llm,
-        flow=flow,
-        input_messages=messages,
-        tools=request.tools,
-    ) as span:
+    with (
+        _gateway_trace(flow, request.model),
+        llm_generation_span(
+            llm,
+            flow=flow,
+            input_messages=messages,
+            tools=request.tools,
+        ) as span,
+    ):
         try:
             response = llm.invoke(
                 prompt=messages,

--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -2,7 +2,6 @@ import json
 import queue
 import threading
 from collections.abc import Callable, Iterator
-from contextlib import contextmanager
 from typing import Any
 
 from fastapi import APIRouter, Depends, Request, Response
@@ -51,6 +50,7 @@ from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationVie
 from onyx.server.query_and_chat.token_limit import check_token_rate_limits
 from onyx.tracing.flows import LLMFlow
 from onyx.tracing.framework.create import trace
+from onyx.tracing.framework.traces import Trace
 from onyx.tracing.llm_utils import (
     llm_generation_span,
     record_llm_response,
@@ -75,10 +75,11 @@ _MESSAGES_ADAPTER: TypeAdapter[list[ChatCompletionMessage]] = TypeAdapter(
 )
 
 
-@contextmanager
-def _gateway_trace(flow: LLMFlow, model: str) -> Iterator[None]:
-    with trace("llm_gateway", metadata={"flow": flow.value, "model": model}):
-        yield
+def _gateway_trace(flow: LLMFlow, llm: LLM) -> Trace:
+    return trace(
+        "llm_gateway",
+        metadata={"flow": flow.value, "model": llm.config.model_name},
+    )
 
 
 def resolve_gateway_model(
@@ -244,7 +245,7 @@ def _stream_worker(
     # StreamingResponse, so the trace must be opened here rather than in the
     # endpoint for the generation span to see an active trace.
     with (
-        _gateway_trace(flow, model),
+        _gateway_trace(flow, llm),
         llm_generation_span(
             llm, flow=flow, input_messages=messages, tools=tools
         ) as span,
@@ -434,7 +435,7 @@ def handle_chat_completion(
         )
 
     with (
-        _gateway_trace(flow, request.model),
+        _gateway_trace(flow, llm),
         llm_generation_span(
             llm,
             flow=flow,

--- a/backend/onyx/tracing/processors/user_usage_processor.py
+++ b/backend/onyx/tracing/processors/user_usage_processor.py
@@ -115,8 +115,9 @@ class UserUsageTracingProcessor(TracingProcessor):
 
         user_id = get_current_user_id()
         if user_id is None:
-            # No user id → skip (undercount, never wrong-user). Only chat
-            # endpoints set the var today.
+            # No user id → skip (undercount, never wrong-user). The
+            # optional_user dependency sets this for any authenticated request,
+            # so it is absent only for work started outside one (e.g. Celery).
             return None
 
         model = data.model

--- a/backend/tests/integration/tests/streaming_endpoints/test_gateway_usage_tracking.py
+++ b/backend/tests/integration/tests/streaming_endpoints/test_gateway_usage_tracking.py
@@ -7,11 +7,12 @@ from tests.integration.common_utils.managers.llm_provider import LLMProviderMana
 from tests.integration.common_utils.managers.pat import PATManager
 from tests.integration.common_utils.test_models import DATestUser
 
+_GATEWAY_MODEL = "gpt-5-mini"
 # Drain thread flushes on a ~2s interval; give it generous headroom.
 _POLL_TIMEOUT_SECONDS = 45
 
 
-def _usage_token_total(user: DATestUser) -> int:
+def _usage_tokens_for_model(user: DATestUser, model: str) -> int:
     """Tokens, not cost: they are recorded regardless of whether the model is
     priced, so this is robust to the deployment's default-cost config."""
     resp = client.get(
@@ -22,43 +23,49 @@ def _usage_token_total(user: DATestUser) -> int:
     resp.raise_for_status()
     body = resp.json()
     return sum(
-        row["input_tokens"] + row["output_tokens"] for row in body["per_day_by_model"]
+        row["input_tokens"] + row["output_tokens"]
+        for row in body["per_day_by_model"]
+        if row["model"] == model
     )
 
 
-def _wait_for_usage_increase(user: DATestUser, baseline_tokens: int) -> int:
+def _wait_for_usage_increase(user: DATestUser, model: str, baseline_tokens: int) -> int:
     latest_tokens = baseline_tokens
     deadline = time.monotonic() + _POLL_TIMEOUT_SECONDS
     while time.monotonic() < deadline:
-        latest_tokens = _usage_token_total(user)
+        latest_tokens = _usage_tokens_for_model(user, model)
         if latest_tokens > baseline_tokens:
             break
         time.sleep(1)
     return latest_tokens
 
 
-def test_gateway_streamed_completion_records_per_user_usage(
-    admin_user: DATestUser,
-) -> None:
-    provider = LLMProviderManager.create(user_performing_action=admin_user)
+def _gateway_pat(user: DATestUser, name: str) -> str:
     pat = PATManager.create(
-        name="gateway-usage-streaming",
+        name=name,
         expiration_days=None,
-        user_performing_action=admin_user,
+        user_performing_action=user,
         scopes=[Permission.USE_LLM_GATEWAY],
     )
     assert pat.token, "PAT creation did not return a raw token"
+    return pat.token
 
-    assert provider.default_model_name, "provider has no default model to route to"
-    model_id = f"{provider.id}/{provider.default_model_name}"
 
-    baseline_tokens = _usage_token_total(admin_user)
+def test_gateway_streamed_completion_records_per_user_usage(
+    admin_user: DATestUser,
+) -> None:
+    provider = LLMProviderManager.create(
+        default_model_name=_GATEWAY_MODEL, user_performing_action=admin_user
+    )
+    token = _gateway_pat(admin_user, "gateway-usage-streaming")
+
+    baseline_tokens = _usage_tokens_for_model(admin_user, _GATEWAY_MODEL)
 
     response = client.post(
         f"{API_SERVER_URL}/gateway/v1/chat/completions",
-        headers={"Authorization": f"Bearer {pat.token}"},
+        headers={"Authorization": f"Bearer {token}"},
         json={
-            "model": model_id,
+            "model": f"{provider.id}/{_GATEWAY_MODEL}",
             "messages": [{"role": "user", "content": "Reply with a single word."}],
             "stream": True,
         },
@@ -68,50 +75,57 @@ def test_gateway_streamed_completion_records_per_user_usage(
     # The generation span is opened on a worker thread spawned after the
     # StreamingResponse is returned, so usage is only recorded once that
     # thread finishes -- the SSE body must be fully drained first.
-    list(response.iter_lines())
+    frames = [line for line in response.iter_lines() if line]
 
-    latest_tokens = _wait_for_usage_increase(admin_user, baseline_tokens)
+    # An upstream failure is an in-band SSE error frame on a 200, which would
+    # otherwise surface as a misleading "no usage was recorded".
+    assert "data: [DONE]" in frames, f"stream did not complete: {frames[-3:]}"
+    assert not any('"error"' in frame for frame in frames), (
+        f"gateway returned an in-band stream error: {frames[:3]}"
+    )
+
+    latest_tokens = _wait_for_usage_increase(
+        admin_user, _GATEWAY_MODEL, baseline_tokens
+    )
 
     assert latest_tokens > baseline_tokens, (
-        "expected the PAT owner's windowed token usage to increase after a "
-        f"streamed gateway completion (baseline={baseline_tokens}, "
-        f"latest={latest_tokens}); the gateway usage recorder never landed a row"
+        f"expected the PAT owner's windowed {_GATEWAY_MODEL} token usage to "
+        f"increase after a streamed gateway completion (baseline="
+        f"{baseline_tokens}, latest={latest_tokens}); the gateway usage "
+        "recorder never landed a row"
     )
 
 
 def test_gateway_non_streaming_completion_records_per_user_usage(
     admin_user: DATestUser,
 ) -> None:
-    provider = LLMProviderManager.create(user_performing_action=admin_user)
-    pat = PATManager.create(
-        name="gateway-usage-non-streaming",
-        expiration_days=None,
-        user_performing_action=admin_user,
-        scopes=[Permission.USE_LLM_GATEWAY],
+    provider = LLMProviderManager.create(
+        default_model_name=_GATEWAY_MODEL, user_performing_action=admin_user
     )
-    assert pat.token, "PAT creation did not return a raw token"
+    token = _gateway_pat(admin_user, "gateway-usage-non-streaming")
 
-    assert provider.default_model_name, "provider has no default model to route to"
-    model_id = f"{provider.id}/{provider.default_model_name}"
-
-    baseline_tokens = _usage_token_total(admin_user)
+    baseline_tokens = _usage_tokens_for_model(admin_user, _GATEWAY_MODEL)
 
     response = client.post(
         f"{API_SERVER_URL}/gateway/v1/chat/completions",
-        headers={"Authorization": f"Bearer {pat.token}"},
+        headers={"Authorization": f"Bearer {token}"},
         json={
-            "model": model_id,
+            "model": f"{provider.id}/{_GATEWAY_MODEL}",
             "messages": [{"role": "user", "content": "Reply with a single word."}],
             "stream": False,
         },
         timeout=60,
     )
     response.raise_for_status()
+    assert response.json()["usage"]["total_tokens"] > 0
 
-    latest_tokens = _wait_for_usage_increase(admin_user, baseline_tokens)
+    latest_tokens = _wait_for_usage_increase(
+        admin_user, _GATEWAY_MODEL, baseline_tokens
+    )
 
     assert latest_tokens > baseline_tokens, (
-        "expected the PAT owner's windowed token usage to increase after a "
-        f"non-streamed gateway completion (baseline={baseline_tokens}, "
-        f"latest={latest_tokens}); the gateway usage recorder never landed a row"
+        f"expected the PAT owner's windowed {_GATEWAY_MODEL} token usage to "
+        f"increase after a non-streamed gateway completion (baseline="
+        f"{baseline_tokens}, latest={latest_tokens}); the gateway usage "
+        "recorder never landed a row"
     )

--- a/backend/tests/integration/tests/streaming_endpoints/test_gateway_usage_tracking.py
+++ b/backend/tests/integration/tests/streaming_endpoints/test_gateway_usage_tracking.py
@@ -1,19 +1,3 @@
-"""End-to-end: a call through the OpenAI-compatible LLM gateway
-(POST /gateway/v1/chat/completions), authenticated with a scoped PAT rather
-than a session, must flow through the same per-user usage seam as chat: a
-generation span recorded inside an active tracing trace -> the tracing
-processor -> the background drain thread -> a user_usage rollup -> readable
-back through GET /user/usage, attributed to the PAT's owning user.
-
-The gateway previously opened no trace at all, so its generation spans
-degraded to NoOpSpan and the processor never saw them -- zero usage was
-recorded for every gateway call. Unit tests mock the trace/span seam and
-cannot catch that; this test exercises the real wiring, for both the
-non-streaming path and the streaming path (whose generation span runs on a
-worker thread spawned only after the endpoint has already returned the
-StreamingResponse -- the case most likely to regress silently).
-"""
-
 import time
 
 from onyx.db.enums import Permission
@@ -28,10 +12,8 @@ _POLL_TIMEOUT_SECONDS = 45
 
 
 def _usage_token_total(user: DATestUser) -> int:
-    """Caller's total (input + output) tokens in the current window, summed over
-    the per-model breakdown returned by GET /user/usage. Token counts are
-    recorded regardless of whether the model is priced, so this is robust to the
-    deployment's default-cost config."""
+    """Tokens, not cost: they are recorded regardless of whether the model is
+    priced, so this is robust to the deployment's default-cost config."""
     resp = client.get(
         f"{API_SERVER_URL}/user/usage",
         headers=user.headers,

--- a/backend/tests/integration/tests/streaming_endpoints/test_gateway_usage_tracking.py
+++ b/backend/tests/integration/tests/streaming_endpoints/test_gateway_usage_tracking.py
@@ -1,0 +1,135 @@
+"""End-to-end: a call through the OpenAI-compatible LLM gateway
+(POST /gateway/v1/chat/completions), authenticated with a scoped PAT rather
+than a session, must flow through the same per-user usage seam as chat: a
+generation span recorded inside an active tracing trace -> the tracing
+processor -> the background drain thread -> a user_usage rollup -> readable
+back through GET /user/usage, attributed to the PAT's owning user.
+
+The gateway previously opened no trace at all, so its generation spans
+degraded to NoOpSpan and the processor never saw them -- zero usage was
+recorded for every gateway call. Unit tests mock the trace/span seam and
+cannot catch that; this test exercises the real wiring, for both the
+non-streaming path and the streaming path (whose generation span runs on a
+worker thread spawned only after the endpoint has already returned the
+StreamingResponse -- the case most likely to regress silently).
+"""
+
+import time
+
+from onyx.db.enums import Permission
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
+from tests.integration.common_utils.managers.pat import PATManager
+from tests.integration.common_utils.test_models import DATestUser
+
+# Drain thread flushes on a ~2s interval; give it generous headroom.
+_POLL_TIMEOUT_SECONDS = 45
+
+
+def _usage_token_total(user: DATestUser) -> int:
+    """Caller's total (input + output) tokens in the current window, summed over
+    the per-model breakdown returned by GET /user/usage. Token counts are
+    recorded regardless of whether the model is priced, so this is robust to the
+    deployment's default-cost config."""
+    resp = client.get(
+        f"{API_SERVER_URL}/user/usage",
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+    resp.raise_for_status()
+    body = resp.json()
+    return sum(
+        row["input_tokens"] + row["output_tokens"] for row in body["per_day_by_model"]
+    )
+
+
+def _wait_for_usage_increase(user: DATestUser, baseline_tokens: int) -> int:
+    latest_tokens = baseline_tokens
+    deadline = time.monotonic() + _POLL_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        latest_tokens = _usage_token_total(user)
+        if latest_tokens > baseline_tokens:
+            break
+        time.sleep(1)
+    return latest_tokens
+
+
+def test_gateway_streamed_completion_records_per_user_usage(
+    admin_user: DATestUser,
+) -> None:
+    provider = LLMProviderManager.create(user_performing_action=admin_user)
+    pat = PATManager.create(
+        name="gateway-usage-streaming",
+        expiration_days=None,
+        user_performing_action=admin_user,
+        scopes=[Permission.USE_LLM_GATEWAY],
+    )
+    assert pat.token, "PAT creation did not return a raw token"
+
+    assert provider.default_model_name, "provider has no default model to route to"
+    model_id = f"{provider.id}/{provider.default_model_name}"
+
+    baseline_tokens = _usage_token_total(admin_user)
+
+    response = client.post(
+        f"{API_SERVER_URL}/gateway/v1/chat/completions",
+        headers={"Authorization": f"Bearer {pat.token}"},
+        json={
+            "model": model_id,
+            "messages": [{"role": "user", "content": "Reply with a single word."}],
+            "stream": True,
+        },
+        timeout=60,
+    )
+    response.raise_for_status()
+    # The generation span is opened on a worker thread spawned after the
+    # StreamingResponse is returned, so usage is only recorded once that
+    # thread finishes -- the SSE body must be fully drained first.
+    list(response.iter_lines())
+
+    latest_tokens = _wait_for_usage_increase(admin_user, baseline_tokens)
+
+    assert latest_tokens > baseline_tokens, (
+        "expected the PAT owner's windowed token usage to increase after a "
+        f"streamed gateway completion (baseline={baseline_tokens}, "
+        f"latest={latest_tokens}); the gateway usage recorder never landed a row"
+    )
+
+
+def test_gateway_non_streaming_completion_records_per_user_usage(
+    admin_user: DATestUser,
+) -> None:
+    provider = LLMProviderManager.create(user_performing_action=admin_user)
+    pat = PATManager.create(
+        name="gateway-usage-non-streaming",
+        expiration_days=None,
+        user_performing_action=admin_user,
+        scopes=[Permission.USE_LLM_GATEWAY],
+    )
+    assert pat.token, "PAT creation did not return a raw token"
+
+    assert provider.default_model_name, "provider has no default model to route to"
+    model_id = f"{provider.id}/{provider.default_model_name}"
+
+    baseline_tokens = _usage_token_total(admin_user)
+
+    response = client.post(
+        f"{API_SERVER_URL}/gateway/v1/chat/completions",
+        headers={"Authorization": f"Bearer {pat.token}"},
+        json={
+            "model": model_id,
+            "messages": [{"role": "user", "content": "Reply with a single word."}],
+            "stream": False,
+        },
+        timeout=60,
+    )
+    response.raise_for_status()
+
+    latest_tokens = _wait_for_usage_increase(admin_user, baseline_tokens)
+
+    assert latest_tokens > baseline_tokens, (
+        "expected the PAT owner's windowed token usage to increase after a "
+        f"non-streamed gateway completion (baseline={baseline_tokens}, "
+        f"latest={latest_tokens}); the gateway usage recorder never landed a row"
+    )

--- a/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
@@ -618,9 +618,6 @@ def test_stream_records_accumulated_reasoning_on_span() -> None:
 
 
 def test_stream_worker_opens_trace_so_generation_span_is_real() -> None:
-    """The stream worker runs on its own thread after the endpoint has
-    returned; the generation span is only real if the worker itself opens
-    the trace (a trace opened in the endpoint would not be visible there)."""
     with patch.object(gateway_api, "record_llm_span_output") as record:
         frames = list(_gateway_stream(_ReasoningStreamLLM()))
 

--- a/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import json
 import threading
-from collections.abc import Awaitable, Callable
-from contextlib import nullcontext
+from collections.abc import Awaitable, Callable, Iterator
+from contextlib import contextmanager, nullcontext
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
@@ -54,7 +54,7 @@ from onyx.server.gateway.models import (
 )
 from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
 from onyx.tracing.flows import LLMFlow
-from onyx.tracing.framework.spans import NoOpSpan
+from onyx.tracing.framework.create import get_current_trace
 
 
 def _pat_request(token_scopes: list[Permission] | None) -> Request:
@@ -617,14 +617,37 @@ def test_stream_records_accumulated_reasoning_on_span() -> None:
     assert record.call_args.kwargs["output"] == "done"
 
 
-def test_stream_worker_opens_trace_so_generation_span_is_real() -> None:
-    with patch.object(gateway_api, "record_llm_span_output") as record:
+@contextmanager
+def _capture_trace_at_generation_span(captured: list[Any]) -> Iterator[None]:
+    real_span = gateway_api.llm_generation_span
+
+    @contextmanager
+    def _recording_span(*args: Any, **kwargs: Any) -> Iterator[Any]:
+        captured.append(get_current_trace())
+        with real_span(*args, **kwargs) as span:
+            yield span
+
+    with patch.object(gateway_api, "llm_generation_span", _recording_span):
+        yield
+
+
+def _assert_gateway_trace(active: Any) -> None:
+    assert active is not None, "no trace was active when the generation span opened"
+    assert active.name == "llm_gateway"
+    assert active.metadata == {
+        "flow": LLMFlow.CRAFT_LLM_GENERATION.value,
+        "model": "test",
+    }
+
+
+def test_stream_worker_opens_trace_before_generation_span() -> None:
+    traces: list[Any] = []
+    with _capture_trace_at_generation_span(traces):
         frames = list(_gateway_stream(_ReasoningStreamLLM()))
 
     assert frames[-1] == "data: [DONE]\n\n"
-    record.assert_called_once()
-    span = record.call_args.args[0]
-    assert not isinstance(span, NoOpSpan)
+    (active,) = traces
+    _assert_gateway_trace(active)
 
 
 class _RaisingInvokeLLM(_ConfigOnlyLLM):
@@ -704,7 +727,7 @@ def test_handle_chat_completion_happy_path_serializes_response() -> None:
     assert payload["usage"]["total_tokens"] == 150
 
 
-def test_non_streaming_opens_trace_so_generation_span_is_real() -> None:
+def test_non_streaming_opens_trace_before_generation_span() -> None:
     request = ChatCompletionRequest(
         model="1/test",
         messages=[{"role": "user", "content": "hi"}],
@@ -719,19 +742,19 @@ def test_non_streaming_opens_trace_so_generation_span_is_real() -> None:
         usage=_wire_usage(),
     )
 
+    traces: list[Any] = []
     with (
         patch.object(
             gateway_api,
             "llm_from_provider",
             return_value=_InvokeLLM(response),
         ),
-        patch.object(gateway_api, "record_llm_response") as record,
+        _capture_trace_at_generation_span(traces),
     ):
         _handle_completion_call(request)
 
-    record.assert_called_once()
-    span = record.call_args.args[0]
-    assert not isinstance(span, NoOpSpan)
+    (active,) = traces
+    _assert_gateway_trace(active)
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
@@ -54,6 +54,7 @@ from onyx.server.gateway.models import (
 )
 from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
 from onyx.tracing.flows import LLMFlow
+from onyx.tracing.framework.spans import NoOpSpan
 
 
 def _pat_request(token_scopes: list[Permission] | None) -> Request:
@@ -616,6 +617,19 @@ def test_stream_records_accumulated_reasoning_on_span() -> None:
     assert record.call_args.kwargs["output"] == "done"
 
 
+def test_stream_worker_opens_trace_so_generation_span_is_real() -> None:
+    """The stream worker runs on its own thread after the endpoint has
+    returned; the generation span is only real if the worker itself opens
+    the trace (a trace opened in the endpoint would not be visible there)."""
+    with patch.object(gateway_api, "record_llm_span_output") as record:
+        frames = list(_gateway_stream(_ReasoningStreamLLM()))
+
+    assert frames[-1] == "data: [DONE]\n\n"
+    record.assert_called_once()
+    span = record.call_args.args[0]
+    assert not isinstance(span, NoOpSpan)
+
+
 class _RaisingInvokeLLM(_ConfigOnlyLLM):
     def __init__(self, exc: Exception) -> None:
         super().__init__(
@@ -691,6 +705,36 @@ def test_handle_chat_completion_happy_path_serializes_response() -> None:
     assert payload["choices"][0]["message"]["role"] == "assistant"
     assert payload["choices"][0]["finish_reason"] == "stop"
     assert payload["usage"]["total_tokens"] == 150
+
+
+def test_non_streaming_opens_trace_so_generation_span_is_real() -> None:
+    request = ChatCompletionRequest(
+        model="1/test",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    response = ModelResponse(
+        id="chatcmpl-3",
+        created="1784577999",
+        choice=Choice(
+            finish_reason="stop",
+            message=Message(content="hello there"),
+        ),
+        usage=_wire_usage(),
+    )
+
+    with (
+        patch.object(
+            gateway_api,
+            "llm_from_provider",
+            return_value=_InvokeLLM(response),
+        ),
+        patch.object(gateway_api, "record_llm_response") as record,
+    ):
+        _handle_completion_call(request)
+
+    record.assert_called_once()
+    span = record.call_args.args[0]
+    assert not isinstance(span, NoOpSpan)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

**Gateway LLM calls currently record zero usage and produce no traces.** This is live on `main` today — #13604 shipped the gateway, and Craft's opencode integration runs against it.

Cause: the gateway never opens a tracing *trace*. `backend/onyx/tracing/framework/provider.py` returns a `NoOpSpan` when `Scope.get_current_trace()` is `None`, so the `llm_generation_span(...)` calls in the gateway were no-ops, `on_span_end` never fired, and `UserUsageTracingProcessor` never saw a span. The chat path is unaffected because `backend/onyx/chat/llm_loop.py:718` wraps its work in `with trace(...)`; the gateway had no equivalent.

The fix is a `_gateway_trace(flow, llm)` helper applied at both LLM execution sites:

- `handle_chat_completion`'s non-streaming branch, wrapping the existing generation span.
- `_stream_worker`, opened **inside the worker**. This is the non-obvious part: the worker runs on its own thread, spawned after the endpoint has already returned the `StreamingResponse`, so a trace opened in the endpoint would have exited before the span was ever created.

Call sites pass `llm.config.model_name`, so trace metadata records the resolved model name and agrees with the child generation span. The wire identifier `<provider_id>/<model_name>` stays what it was — it still populates the SSE `model` field and the log lines, and is deliberately not reused for telemetry. The helper keeps its `(flow, model: str)` signature specifically so the stacked Responses-API branches, which call `_gateway_trace(flow, request.model)`, stay source-compatible: their copies of these commits drop on rebase with no conflict (identical `patch-id`), so a signature change would have surfaced only as an `AttributeError` at request time on `/gateway/v1/responses`. Those branches may want to pass the resolved name too, but nothing breaks if they don't.

### Gateway traffic now counts against existing limits

`check_token_rate_limits(user)` was already enforced on this endpoint and reads the same `user_usage` table this fix finally writes. So on any tenant with an enabled `TokenRateLimit`, Craft/gateway consumption now counts against the same per-user, per-group and global token and `cost_budget_cents` windows as chat. Two consequences worth a conscious ack before merge: gateway requests can now be 429'd where they never were, and heavy gateway use can exhaust a budget and start blocking that user's *chat*. That's the intent of the fix, but budgets sized while gateway traffic was free may now be undersized.

### How this went unnoticed

`backend/tests/integration/tests/streaming_endpoints/test_user_usage_tracking.py` covers streamed **chat** only. Nothing asserted that a gateway call lands a usage row, so the gap was invisible to CI. This PR adds the gateway equivalent end to end, for both the streaming and non-streaming paths, authenticated with a gateway-scoped PAT so per-user attribution is covered too.

The diagnosis was originally mis-attributed to `CURRENT_USER_ID_CONTEXTVAR` not being set on the gateway path. That's false — `optional_user` (`backend/onyx/auth/users.py:2190`) sets it for any authenticated request, gateway included, and the stale comment at `user_usage_processor.py` claiming "Only chat endpoints set the var today" is corrected here since it actively misdirected this bug's diagnosis.

## How Has This Been Tested?

- **Unit** (`backend/tests/unit/onyx/server/gateway/`, 50 pass): two tests assert that a trace named `llm_gateway` is active at the moment the generation span opens, one per path, and pin its metadata to the resolved model name. Verified in both directions — deleting the two `_gateway_trace(flow, llm)` lines fails exactly these two tests.
  - These originally asserted `not isinstance(span, NoOpSpan)` and **failed in CI while passing locally**: a span created inside a real trace *still* degrades to `NoOpSpan` when a leaked `NoOpSpan` is the current span, which the full-suite ordering produces. Rewritten to assert the invariant rather than global tracing state; confirmed the new assertions hold even with a `NoOpTrace` + `NoOpSpan` deliberately leaked into the scope.
- **Integration**: `tests/integration/tests/streaming_endpoints/test_gateway_usage_tracking.py` drives a real gateway completion (streaming and non-streaming) with a gateway-scoped PAT and polls `GET /user/usage` until the owning user's windowed token total **for the gateway's own model row** increases — exercising span → processor → drain thread → `user_usage` rollup, with no mocking of the trace/span seam. The streamed case also asserts the SSE stream reached `[DONE]` with no in-band error frame, so an upstream provider failure can't masquerade as "usage was never recorded".
- Confirmed empirically before the fix: ~8 real gateway calls (streaming, non-streaming, tool-calling, live provider) produced **0** rows in `user_usage`, while the existing streamed-chat usage test passed against the same stack and wrote a row — isolating the gateway path.
- `ty`, `mypy-check`, and `pre-commit` clean.
- Reviewed by a four-lens agent review (correctness, security, tests, regressions).

### Known minor items left for the reviewer

- **Test coverage uses the wrong PAT shape for production.** Both integration tests use `scopes=[Permission.USE_LLM_GATEWAY]`, which takes the direct-grant branch of `is_gateway_request`. Real sandboxes present a `CRAFT_SANDBOX`-scoped PAT, which takes the other branch and adds an `is_craft_enabled_for_user` gate — so the metering path that actually runs in production is still untested.
- **Pre-existing suite pollution**, surfaced by the CI failure above: some unit test enters a span outside a trace and leaves the resulting `NoOpSpan` as the current span, which silently degrades spans in tests that run after it. Not introduced here and not fixed here, but it will keep biasing any test that asserts on span realness.
- **Helper duplication with the chat usage test.** `_wait_for_usage_increase` and the poll loop are near-copies of `test_user_usage_tracking.py`'s. Left as-is rather than refactoring a passing test in a bug-fix PR; worth hoisting into `common_utils/` next time either is touched.
- `_gateway_trace` uses `trace()` rather than `ensure_trace()`. Considered and deliberately kept: `ensure_trace` discards the supplied name and metadata when a trace is already active, and `trace()` is the codebase's idiom for a root workflow (`llm_loop.py:718`). The gateway is a root workflow; there is no enclosing trace on this path today.
- Enabling traces here means gateway prompt content now reaches Langfuse/Braintrust on tenants that have them configured, exactly as the chat path already does. Consistent with existing behavior, but it's the first time sandbox agent prompts (which routinely contain workspace file contents) take that path — worth a conscious ack from whoever owns Craft.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check