### PR TITLE
fix(web): make the folded sidebar logo open the sidebar

### DIFF
--- a/web/lib/opal/src/layouts/sidebar/components.tsx
+++ b/web/lib/opal/src/layouts/sidebar/components.tsx
@@ -11,8 +11,9 @@ import {
   useRef,
 } from "react";
 import { usePathname } from "next/navigation";
-import { Button, ShadowDiv, Spacer, Text } from "@opal/components";
-import { Disabled, Hoverable } from "@opal/core";
+import { Button, ShadowDiv, Spacer, Text, Tooltip } from "@opal/components";
+import { iconWrapper } from "@opal/components/buttons/icon-wrapper";
+import { Disabled, Hoverable, Interactive } from "@opal/core";
 import { SvgSidebar } from "@opal/icons";
 import type { IconFunctionComponent, RichStr } from "@opal/types";
 import { useSidebarState } from "@opal/layouts/root/components";
@@ -142,22 +143,59 @@ function SidebarHeader({
     [setFolded]
   );
 
+  const foldLabel = folded ? "Open Sidebar" : "Close Sidebar";
+
   const closeButton = useMemo(
     () => (
       <Button
         icon={SvgSidebar}
         prominence="tertiary"
-        tooltip={folded ? "Open Sidebar" : "Close Sidebar"}
+        aria-label={foldLabel}
+        tooltip={foldLabel}
         tooltipSide={folded ? "right" : "bottom"}
         size="md"
         onClick={toggleFolded}
       />
     ),
-    [folded, toggleFolded]
+    [folded, foldLabel, toggleFolded]
   );
 
   const Logo = renderAppLogo(foldable ? folded : false);
   const logoEl = <Logo size={SIDEBAR_LOGO_HEIGHT_PX} />;
+
+  // Folded: the logo *is* the unfold control. The fold icon swaps in on hover
+  // (and on keyboard focus), but the button underneath never changes, so the
+  // sidebar can still be opened where there is no hover to reveal anything —
+  // touch devices and keyboard navigation.
+  const foldedLogoButton = (
+    <Tooltip tooltip={foldLabel} side="right">
+      <Interactive.Stateless
+        prominence="tertiary"
+        type="button"
+        onClick={toggleFolded}
+      >
+        <Interactive.Container
+          type="button"
+          size="fit"
+          rounding="sm"
+          aria-label={foldLabel}
+        >
+          <div
+            className="opal-sidebar-header__logo-swap"
+            style={{
+              height: SIDEBAR_LOGO_HEIGHT_PX,
+              width: SIDEBAR_LOGO_HEIGHT_PX,
+            }}
+          >
+            <div className="opal-sidebar-header__logo-rest">{logoEl}</div>
+            <div className="opal-sidebar-header__logo-fold">
+              {iconWrapper(SvgSidebar, "md", false)}
+            </div>
+          </div>
+        </Interactive.Container>
+      </Interactive.Stateless>
+    </Tooltip>
+  );
 
   return (
     <div className="opal-sidebar-header">
@@ -165,11 +203,8 @@ function SidebarHeader({
         <div className="opal-sidebar-header__topbar-inner">
           {!foldable ? (
             logoEl
-          ) : folded && showLogoWhenFolded && logoEl ? (
-            <>
-              <div className="opal-sidebar-root__logo-default">{logoEl}</div>
-              <div className="opal-sidebar-root__logo-hover">{closeButton}</div>
-            </>
+          ) : folded && showLogoWhenFolded ? (
+            foldedLogoButton
           ) : folded ? (
             closeButton
           ) : (

--- a/web/lib/opal/src/layouts/sidebar/styles.css
+++ b/web/lib/opal/src/layouts/sidebar/styles.css
@@ -98,21 +98,31 @@
   @apply px-2;
 }
 
-/* Logo: visible by default, hidden on hover while folded */
-.opal-sidebar-root__logo-default {
-  display: block;
+/* Folded logo/unfold button: one control, two faces. The logo shows at rest and
+   the fold icon replaces it while the sidebar is hovered or the button holds
+   keyboard focus — pointerless input keeps the logo, which is clickable either
+   way. Sized by the caller so the swap never changes the button's footprint. */
+.opal-sidebar-header__logo-swap {
+  @apply flex items-center justify-center;
 }
-.opal-sidebar-root__overlay:hover .opal-sidebar-root__logo-default,
-.opal-sidebar-root__column:hover .opal-sidebar-root__logo-default {
+
+.opal-sidebar-header__logo-rest {
+  display: flex;
+}
+.opal-sidebar-header__logo-fold {
   display: none;
 }
 
-/* Fold button: hidden by default, revealed on hover while folded */
-.opal-sidebar-root__logo-hover {
+.opal-sidebar-root__overlay:hover .opal-sidebar-header__logo-rest,
+.opal-sidebar-root__column:hover .opal-sidebar-header__logo-rest,
+.opal-sidebar-header__topbar-inner:has(:focus-visible)
+  .opal-sidebar-header__logo-rest {
   display: none;
 }
-.opal-sidebar-root__overlay:hover .opal-sidebar-root__logo-hover,
-.opal-sidebar-root__column:hover .opal-sidebar-root__logo-hover {
+.opal-sidebar-root__overlay:hover .opal-sidebar-header__logo-fold,
+.opal-sidebar-root__column:hover .opal-sidebar-header__logo-fold,
+.opal-sidebar-header__topbar-inner:has(:focus-visible)
+  .opal-sidebar-header__logo-fold {
   display: flex;
 }
 

--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -686,6 +686,7 @@ export default function BuildChatPanel({
                 {isMobile && leftSidebarFolded && (
                   <OpalButton
                     icon={SvgSidebar}
+                    aria-label="Open Sidebar"
                     onClick={() => setLeftSidebarFolded(false)}
                     prominence="tertiary"
                     size="sm"

--- a/web/src/app/nrf/NRFChrome.tsx
+++ b/web/src/app/nrf/NRFChrome.tsx
@@ -90,6 +90,7 @@ export default function NRFChrome() {
             <Button
               prominence="internal"
               icon={SvgSidebar}
+              aria-label="Open Sidebar"
               onClick={() => setFolded(false)}
             />
           )}

--- a/web/src/layouts/chromes/AdminChrome.tsx
+++ b/web/src/layouts/chromes/AdminChrome.tsx
@@ -68,6 +68,7 @@ export default function AdminChrome({ children }: AdminChromeProps) {
               <Button
                 prominence="internal"
                 icon={SvgSidebar}
+                aria-label="Open Sidebar"
                 onClick={() => setFolded(false)}
               />
             </div>

--- a/web/src/layouts/chromes/AppChrome.tsx
+++ b/web/src/layouts/chromes/AppChrome.tsx
@@ -371,6 +371,7 @@ function Header() {
                   <Button
                     prominence="internal"
                     icon={SvgSidebar}
+                    aria-label="Open Sidebar"
                     onClick={() => setFolded(false)}
                   />
                 )}


### PR DESCRIPTION
## Problem

When the sidebar is collapsed, the logo swaps to a fold button on **hover**. That made reopening the sidebar pointer-only:

- **Touch devices have no hover**, so the swap never fires — tapping the logo did nothing, leaving no way to reopen the collapsed rail.
- The fold button lived behind `display: none`, which removes it from the tab order, so **keyboard users couldn't reach it either**. `Cmd/Ctrl+E` was the only route, and it isn't discoverable.

## Change

Make the folded logo *be* the unfold control instead of something the control hides behind. It's now a single `<button>` that renders the logo at rest and swaps in the fold icon on hover — or on keyboard focus, so the affordance shows up for tab users too. The button underneath never changes, so a tap or an <kbd>Enter</kbd> opens the sidebar regardless of whether anything swapped.

The hover-swap visual and the button's 28×28 footprint are unchanged, so nothing moves on hover.

Also added accessible names to the icon-only fold buttons, which previously announced as just "button" — a Radix tooltip sets `aria-describedby`, not an accessible name:

- the sidebar's fold/unfold button (`SidebarLayouts.Header`)
- the mobile open-sidebar buttons in `AppChrome`, `AdminChrome`, `NRFChrome`, and Craft's `ChatPanel`

## Testing

`tsc --noEmit` clean across `web/`; `oxfmt` / `oxlint` / type-check pre-commit hooks pass.

Verified by hand in the running app (`/app`, logged in as admin):

| Check | Result |
| --- | --- |
| Folded rail at rest | Logo renders as before; 28×28 `<button type="button" aria-label="Open Sidebar">` |
| Activate logo with no pointer over it (touch path) | `data-folded` flips `true` → `false` |
| Hover the collapsed rail | Fold icon still replaces the logo |
| <kbd>Tab</kbd> from top of page | Lands on the logo button (first tab stop), `:focus-visible` matches, fold icon swaps in, focus ring shown |
| <kbd>Enter</kbd> on it | Sidebar opens (width 240) |
| Small screen (820px, visible rail) | Same button, tap opens |
| Mobile (500px, rail off-screen) | `AppChrome` button now exposes `aria-label="Open Sidebar"` |
| Expanded sidebar | Fold button exposes `aria-label="Close Sidebar"` (was an unnamed button) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1902" height="2085" alt="20260731_14h10m25s_grim" src="https://github.com/user-attachments/assets/973317af-b3bc-44e5-b0ec-3137ebc8708e" />
