### PR TITLE
perf(llm): invalidate provider listing cache on persona edits, TTL to 600s

### DIFF
--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -71,6 +71,7 @@ from onyx.server.features.persona.models import (
     PersonaUpsertRequest,
 )
 from onyx.server.manage.llm.api import get_valid_model_configuration_ids_for_persona
+from onyx.server.manage.llm.provider_cache import invalidate_provider_listing_cache
 from onyx.server.models import DisplayPriorityRequest
 from onyx.server.settings.store import load_settings
 from onyx.utils.logger import setup_logger
@@ -362,6 +363,9 @@ def update_persona(
         user=user,
         db_session=db_session,
     )
+    # The persona's default model is baked into the cached LLM provider listing
+    # (see onyx/server/manage/llm/provider_cache.py), so edits must drop it.
+    invalidate_provider_listing_cache()
     return persona_snapshot
 
 

--- a/backend/onyx/server/manage/llm/provider_cache.py
+++ b/backend/onyx/server/manage/llm/provider_cache.py
@@ -9,8 +9,9 @@ load, so the final response is memoized here.
 Entries are keyed by everything that can change the response for a user
 (persona, admin status, group memberships) and namespaced by a per-tenant
 version token, so a single token rewrite invalidates every entry at once.
-Provider mutations bump the token explicitly; changes that bypass the LLM
-provider API (e.g. persona default-model edits) are bounded by the entry TTL.
+Provider mutations and persona edits bump the token explicitly; changes that
+bypass the API layer (e.g. seed-time or Slack-channel persona upserts) are
+bounded by the entry TTL.
 
 Cache failures are non-fatal: readers fall through to Postgres.
 """
@@ -30,9 +31,9 @@ logger = setup_logger()
 _VERSION_KEY = "llm_provider_listing:version"
 _ENTRY_KEY_PREFIX = "llm_provider_listing:entry"
 # Staleness bound only for changes that bypass explicit invalidation (see module
-# docstring); provider mutations rewrite the version token immediately. Keep this
-# high enough that steady-state traffic rarely rebuilds the payload cold.
-ENTRY_TTL_SECONDS = 300
+# docstring); user-facing mutations rewrite the version token immediately. Keep
+# this high enough that steady-state traffic rarely rebuilds the payload cold.
+ENTRY_TTL_SECONDS = 600
 
 
 class ProviderListingCacheLookup(BaseModel):

--- a/backend/tests/integration/tests/llm_provider/test_provider_listing_cache.py
+++ b/backend/tests/integration/tests/llm_provider/test_provider_listing_cache.py
@@ -1,0 +1,63 @@
+"""
+Integration tests for the LLM provider listing cache.
+
+The listing endpoints are memoized in Redis (see
+onyx/server/manage/llm/provider_cache.py) with a long TTL, so mutations that
+change the payload must invalidate explicitly for edits to show up promptly.
+"""
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
+from tests.integration.common_utils.managers.persona import PersonaManager
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def _get_persona_default_text(user: DATestUser, persona_id: int) -> dict | None:
+    response = client.get(
+        f"{API_SERVER_URL}/llm/persona/{persona_id}/providers",
+        headers=user.headers,
+    )
+    response.raise_for_status()
+    return response.json()["default_text"]
+
+
+def test_persona_default_model_edit_invalidates_listing_cache(
+    new_admin_user: DATestUser,
+) -> None:
+    """A persona default-model edit must be visible on the very next listing
+    read; the cached entry filled by the first read may not be served stale."""
+    provider_a = LLMProviderManager.create(
+        user_performing_action=new_admin_user,
+        api_key="test-key",
+        default_model_name="gpt-4o-mini",
+        set_as_default=True,
+    )
+    provider_b = LLMProviderManager.create(
+        user_performing_action=new_admin_user,
+        api_key="test-key",
+        default_model_name="gpt-4o",
+        set_as_default=False,
+    )
+
+    persona = PersonaManager.create(
+        user_performing_action=new_admin_user,
+        default_model_configuration_id=provider_a.model_configuration_ids[0],
+    )
+
+    # Fills the cache for this (persona, user) key.
+    default_text = _get_persona_default_text(new_admin_user, persona.id)
+    assert default_text is not None
+    assert default_text["provider_id"] == provider_a.id
+    assert default_text["model_name"] == "gpt-4o-mini"
+
+    PersonaManager.edit(
+        persona=persona,
+        user_performing_action=new_admin_user,
+        default_model_configuration_id=provider_b.model_configuration_ids[0],
+    )
+
+    default_text = _get_persona_default_text(new_admin_user, persona.id)
+    assert default_text is not None
+    assert default_text["provider_id"] == provider_b.id
+    assert default_text["model_name"] == "gpt-4o"


### PR DESCRIPTION
## Description

Follow-up to #13659. That PR raised the provider-listing cache TTL from 60s to 300s but was capped there because persona default-model edits bypassed explicit invalidation: `list_llm_providers_for_persona` bakes `persona.default_model_configuration_id` into `default_text`, so a persona edit could serve a stale default model for up to a full TTL.

This PR closes that gap and then raises the TTL to 600s:

- `update_persona` (PATCH `/persona/{persona_id}`) now calls `invalidate_provider_listing_cache()` after the update, matching the existing invalidation pattern in `llm/api.py` and `image_generation/api.py`. Persona *creates* don't need it — the persona id is part of the cache key, so a new persona can't hit a stale entry.
- `ENTRY_TTL_SECONDS` 300 → 600. With persona edits now invalidating explicitly, the TTL is a pure backstop for paths that bypass the API layer (seed-time and Slack-channel-config persona upserts), where minutes-level staleness is acceptable.
- Module docstring updated to reflect the new invalidation contract.

## How Has This Been Tested?

- New integration test `tests/integration/tests/llm_provider/test_provider_listing_cache.py`: creates two providers, points a persona's default model at provider A, reads `/llm/persona/{id}/providers` to fill the cache, edits the persona's default to provider B, and asserts the very next read returns B. Red/green verified: with the `invalidate_provider_listing_cache()` call removed, the test fails by serving the stale provider A.
- Existing provider-cache unit tests (8) pass; pre-commit clean on all touched files.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Invalidate the LLM provider listing cache on persona edits and raise the cache TTL to 600s. This fixes stale default models after edits and reduces cache rebuilds.

- **Bug Fixes**
  - Persona updates (`PATCH /persona/{persona_id}`) now invalidate the provider listing cache so the next read reflects the new default model.
  - Increased `ENTRY_TTL_SECONDS` from 300 to 600 for changes that bypass explicit invalidation (e.g., seeding, Slack channel persona upserts).

<sup>Written for commit 860b41bd713b5f822d08cf113fbc0ae6fce7f974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

