### PR TITLE
refactor(backend): remove obsolete mypy-era type: ignore directives

### DIFF
--- a/backend/onyx/chat/emitter.py
+++ b/backend/onyx/chat/emitter.py
@@ -49,7 +49,7 @@ class NullEmitter(Emitter):
 
     def __init__(self) -> None:
         self._model_idx = 0
-        self._merged_queue = None  # type: ignore[assignment]
+        self._merged_queue = None
         self._drain_done = None
 
     def emit(self, packet: Packet) -> None:

--- a/backend/onyx/file_store/models.py
+++ b/backend/onyx/file_store/models.py
@@ -127,7 +127,7 @@ class InMemoryChatFile(BaseModel):
         install_lazy_content_loader(inst, loader)
         return inst
 
-    def __getattribute__(self, name: str):  # type: ignore[no-untyped-def]
+    def __getattribute__(self, name: str):
         if name == "content":
             maybe_materialize_lazy_content(self)
         return object.__getattribute__(self, name)

--- a/backend/onyx/onyxbot/slack/utils.py
+++ b/backend/onyx/onyxbot/slack/utils.py
@@ -638,7 +638,8 @@ def slack_usage_report(action: str, sender_id: str | None, client: WebClient) ->
     sender_email = None
     try:
         resp = client.users_info(user=sender_id)  # ty: ignore[invalid-argument-type]
-        sender_email = resp.data["user"]["profile"]["email"]  # type: ignore
+        data = cast(dict[str, Any], resp.data)
+        sender_email = data["user"]["profile"]["email"]
     except Exception:
         logger.warning("Unable to find sender email")
 

--- a/backend/onyx/server/metrics/image_processing.py
+++ b/backend/onyx/server/metrics/image_processing.py
@@ -69,7 +69,7 @@ def track_image_summarization(
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         bound = inspect.signature(fn).bind(*args, **kwargs)
         bound.apply_defaults()
-        image_data: bytes | None = bound.arguments.get("image_data")  # type: ignore[assignment]
+        image_data: bytes | None = bound.arguments.get("image_data")
 
         labels: dict[str, str] = {
             "size_bucket": "unknown",

--- a/backend/onyx/tools/models.py
+++ b/backend/onyx/tools/models.py
@@ -215,7 +215,7 @@ class ChatFile(BaseModel):
         install_lazy_content_loader(inst, loader)
         return inst
 
-    def __getattribute__(self, name: str):  # type: ignore[no-untyped-def]
+    def __getattribute__(self, name: str):
         if name == "content":
             maybe_materialize_lazy_content(self)
         return object.__getattribute__(self, name)

--- a/backend/onyx/utils/logger.py
+++ b/backend/onyx/utils/logger.py
@@ -333,7 +333,7 @@ def setup_logger(
 
     _add_file_handlers(logger, formatter)
 
-    logger.notice = (  # type: ignore
+    logger.notice = (  # ty: ignore[unresolved-attribute]
         lambda msg, *args, **kwargs: logger.log(
             logging.getLevelName("NOTICE"), msg, *args, **kwargs
         )

--- a/backend/onyx/utils/threadpool_concurrency.py
+++ b/backend/onyx/utils/threadpool_concurrency.py
@@ -587,7 +587,7 @@ def parallel_yield(gens: list[Iterator[R]], max_workers: int = 10) -> Iterator[R
     for some extra generator code to run and not have the result(s) yielded.
     """
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        future_to_index: dict[Future[tuple[int, R | None]], int] = (  # type: ignore
+        future_to_index: dict[Future[tuple[int, R | None]], int] = (  # ty: ignore[invalid-assignment]
             {
                 executor.submit(_next_or_none, ind, gen): ind
                 for ind, gen in enumerate(gens)

--- a/backend/tests/external_dependency_unit/chat/test_lazy_chat_file_loading.py
+++ b/backend/tests/external_dependency_unit/chat/test_lazy_chat_file_loading.py
@@ -79,7 +79,7 @@ def read_counter(
     counter = _ReadCounter()
     real_read_file = file_store_module.S3BackedFileStore.read_file
 
-    def _counting_read_file(self, file_id, mode=None, use_tempfile=False):  # type: ignore[no-untyped-def]
+    def _counting_read_file(self, file_id, mode=None, use_tempfile=False):
         # Plaintext-cache reads use the ``plaintext_{file_id}`` naming
         # convention (see onyx.file_store.utils.plaintext_file_name_for_id).
         # These are by-design cheap and are not the OOM-relevant load — skip
@@ -407,7 +407,7 @@ class TestLoadAllChatFilesLazy:
 
         captured: dict[str, int] = {}
 
-        def _spy(funcs, **kwargs):  # type: ignore[no-untyped-def]
+        def _spy(funcs, **kwargs):
             captured["max_workers"] = kwargs.get("max_workers", -1)
             return [None] * len(funcs)
 

--- a/backend/tests/external_dependency_unit/craft/redis_helpers.py
+++ b/backend/tests/external_dependency_unit/craft/redis_helpers.py
@@ -10,7 +10,7 @@ from onyx.redis.tenant_redis_client import TenantRedisClient
 
 
 def assert_lock_serializes_two_threads(
-    redis_client: Redis | TenantRedisClient,  # type: ignore[type-arg]
+    redis_client: Redis | TenantRedisClient,
     lock_key: str,
 ) -> None:
     """Verify two concurrent acquirers contend on ``lock_key`` — one waits.

--- a/backend/tests/external_dependency_unit/craft/test_connect_app.py
+++ b/backend/tests/external_dependency_unit/craft/test_connect_app.py
@@ -15,7 +15,7 @@ def _cache() -> CacheBackend:
 def test_announcement_lifecycle() -> None:
     cache = _cache()
     session_id = f"connect-app-test-{uuid4()}"
-    cache.delete(connect_app._announce_key(session_id))  # type: ignore[attr-defined]
+    cache.delete(connect_app._announce_key(session_id))
 
     request = connect_app.ConnectAppRequest(
         request_id="req-1", external_app_id=17, reason="to schedule events"

--- a/backend/tests/external_dependency_unit/craft/test_mcp_config_resolution.py
+++ b/backend/tests/external_dependency_unit/craft/test_mcp_config_resolution.py
@@ -70,7 +70,7 @@ def craft_server(
     off = _server("Off Server", available_in_craft=False)
     db_session.commit()
 
-    yield craft, off  # type: ignore[misc]
+    yield craft, off
     db_session.rollback()
     for server in created:
         db_session.delete(server)

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
@@ -140,7 +140,7 @@ def test_dispatch_uses_skip_locked_to_avoid_dupes(
     # ``self.app`` is a property on the Celery-generated Task subclass;
     # we patch the property to return a fake whose ``send_task`` is a
     # no-op so the dispatcher never touches a broker.
-    task_instance = dispatch_due_scheduled_tasks.run.__self__  # type: ignore[attr-defined]
+    task_instance = dispatch_due_scheduled_tasks.run.__self__
 
     class _FakeApp:
         def send_task(

--- a/backend/tests/external_dependency_unit/craft_helm/test_pod_spec.py
+++ b/backend/tests/external_dependency_unit/craft_helm/test_pod_spec.py
@@ -309,9 +309,9 @@ def test_craft_helm_rejects_docker_sandbox_backend_override() -> None:
 def _build_pod() -> client.V1Pod:
     pod_template = _render_pod_template()
     mgr: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
-    mgr._namespace = "onyx-sandboxes"  # type: ignore[attr-defined]
-    mgr._core_api = _FakeCoreApi(pod_template)  # type: ignore[attr-defined]  # ty: ignore[invalid-assignment]
-    return mgr._create_sandbox_pod(  # type: ignore[attr-defined]
+    mgr._namespace = "onyx-sandboxes"
+    mgr._core_api = _FakeCoreApi(pod_template)  # ty: ignore[invalid-assignment]
+    return mgr._create_sandbox_pod(
         sandbox_id="abc12345-abcd-abcd-abcd-abcdef123456",
         tenant_id="t-1",
         provisioning_attempt_number=1,
@@ -650,8 +650,8 @@ def test_service_exposes_push_daemon_port() -> None:
     """push/snapshot/health reach the pod via the Service FQDN, so the
     push-daemon port must be exposed on the Service, not just the pod."""
     mgr: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
-    mgr._namespace = "onyx-sandboxes"  # type: ignore[attr-defined]
-    svc = mgr._create_sandbox_service(  # type: ignore[attr-defined]
+    mgr._namespace = "onyx-sandboxes"
+    svc = mgr._create_sandbox_service(
         sandbox_id=UUID("abc12345-abcd-abcd-abcd-abcdef123456"),
         tenant_id="t-1",
     )

--- a/backend/tests/external_dependency_unit/db/test_targeted_reindex_task.py
+++ b/backend/tests/external_dependency_unit/db/test_targeted_reindex_task.py
@@ -53,7 +53,7 @@ def _patch_processor(
     landed_doc_ids: set[str] | None = None,
     failed_doc_ids: set[str] | None = None,
     unsupported: bool = False,
-):  # type: ignore[no-untyped-def]
+):
     """Patch the per-cc-pair processor with a fixed result.
 
     Defaults to landing nothing / failing nothing (no-op) so the
@@ -301,7 +301,7 @@ def test_task_does_not_resolve_error_when_doc_landed_for_other_cc_pair(
         )
 
         # Processor lands shared-doc for cc_pair A, fails it for cc_pair B.
-        def _by_cc_pair(*_args, **kwargs):  # type: ignore[no-untyped-def]
+        def _by_cc_pair(*_args, **kwargs):
             from onyx.background.indexing.run_targeted_reindex import (
                 CCPairReindexResult,
             )

--- a/backend/tests/external_dependency_unit/db/test_userfile_port_execution.py
+++ b/backend/tests/external_dependency_unit/db/test_userfile_port_execution.py
@@ -195,7 +195,7 @@ def test_run_port_attempt_user_scope_survival_filter(
     captured: dict[str, set[str]] = {}
     mock_copier = MagicMock()
 
-    def _copy(ids: list[str], *, surviving_doc_ids=None, **_):  # type: ignore[no-untyped-def]
+    def _copy(ids: list[str], *, surviving_doc_ids=None, **_):
         captured["surviving"] = surviving_doc_ids() if surviving_doc_ids else set()
         return len(ids), False
 

--- a/backend/tests/external_dependency_unit/server/security/test_security_settings_store.py
+++ b/backend/tests/external_dependency_unit/server/security/test_security_settings_store.py
@@ -159,7 +159,7 @@ def test_effective_settings_are_frozen() -> None:
     """Cached SecuritySettings instances must be immutable from caller code."""
     settings = get_security_settings()
     with pytest.raises(ValidationError):
-        settings.user_directory_admin_only = True  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+        settings.user_directory_admin_only = True  # ty: ignore[invalid-assignment]
 
 
 def test_pre_tenant_returns_env_defaults_without_raising(

--- a/backend/tests/unit/ee/onyx/utils/test_telemetry_client_ip.py
+++ b/backend/tests/unit/ee/onyx/utils/test_telemetry_client_ip.py
@@ -6,7 +6,7 @@ from ee.onyx.utils import telemetry as ee_telemetry
 from onyx.utils import client_ip as client_ip_mod
 
 
-def test_event_telemetry_reads_client_ip_from_contextvar(monkeypatch):  # type: ignore[no-untyped-def]
+def test_event_telemetry_reads_client_ip_from_contextvar(monkeypatch):
     fake_posthog = MagicMock()
     monkeypatch.setattr(ee_telemetry, "posthog", fake_posthog)
 
@@ -27,7 +27,7 @@ def test_event_telemetry_reads_client_ip_from_contextvar(monkeypatch):  # type: 
     )
 
 
-def test_event_telemetry_omits_ip_when_contextvar_not_set(monkeypatch):  # type: ignore[no-untyped-def]
+def test_event_telemetry_omits_ip_when_contextvar_not_set(monkeypatch):
     fake_posthog = MagicMock()
     monkeypatch.setattr(ee_telemetry, "posthog", fake_posthog)
     # Contextvar defaults to None — no need to set it.
@@ -45,7 +45,7 @@ def test_event_telemetry_omits_ip_when_contextvar_not_set(monkeypatch):  # type:
     )
 
 
-def test_identify_user_reads_client_ip_from_contextvar(monkeypatch):  # type: ignore[no-untyped-def]
+def test_identify_user_reads_client_ip_from_contextvar(monkeypatch):
     fake_posthog = MagicMock()
     monkeypatch.setattr(ee_telemetry, "posthog", fake_posthog)
 

--- a/backend/tests/unit/external_apps/test_credentials.py
+++ b/backend/tests/unit/external_apps/test_credentials.py
@@ -55,7 +55,7 @@ def test_extra_credentials_are_ignored() -> None:
 
 def test_non_string_template_value_skipped() -> None:
     headers = build_auth_headers(
-        {"Authorization": "Bearer {t}", "Bad": 123},  # type: ignore[dict-item]
+        {"Authorization": "Bearer {t}", "Bad": 123},
         {"t": "x"},
     )
     assert headers == {"Authorization": "Bearer x"}

--- a/backend/tests/unit/external_apps/test_token_refresh.py
+++ b/backend/tests/unit/external_apps/test_token_refresh.py
@@ -258,7 +258,7 @@ def _cred(values: dict[str, Any]) -> MagicMock:
 
 
 @contextmanager
-def _noop_cm(*_a: Any, **_k: Any):  # type: ignore[no-untyped-def]
+def _noop_cm(*_a: Any, **_k: Any):
     yield MagicMock()
 
 

--- a/backend/tests/unit/onyx/auth/test_signup_rate_limit.py
+++ b/backend/tests/unit/onyx/auth/test_signup_rate_limit.py
@@ -39,7 +39,7 @@ def _fake_pipeline_redis(incr_return: int) -> MagicMock:
     pipeline.execute = AsyncMock(return_value=[incr_return, 1])
     redis = MagicMock()
     redis.pipeline = MagicMock(return_value=pipeline)
-    redis._pipeline = pipeline  # type: ignore[attr-defined]
+    redis._pipeline = pipeline
     return redis
 
 

--- a/backend/tests/unit/onyx/background/indexing/test_simple_job_terminate.py
+++ b/backend/tests/unit/onyx/background/indexing/test_simple_job_terminate.py
@@ -55,7 +55,7 @@ def _wait_for_ready_file(path: str, timeout: float = 5.0) -> None:
 
 
 @pytest.fixture()
-def ready_file(tmp_path) -> str:  # type: ignore[no-untyped-def]
+def ready_file(tmp_path) -> str:
     return str(tmp_path / "child_ready.txt")
 
 

--- a/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
@@ -370,15 +370,15 @@ def test_cql_paginate_all_expansions_handles_internal_pagination_error(
     # Ensure the result is correct
     # NOTE: size does not get updated during _traverse_and_update
     final_results = copy.deepcopy(top_level_raw_response)
-    final_results["results"][0]["child_items"]["results"] = [  # type: ignore
+    final_results["results"][0]["child_items"]["results"] = [  # ty: ignore[invalid-assignment, not-subscriptable]
         {"child_id": 101},
         {"child_id": 102},
     ]
-    final_results["results"][1]["child_items"]["results"] = [  # type: ignore
+    final_results["results"][1]["child_items"]["results"] = [  # ty: ignore[invalid-assignment, not-subscriptable]
         {"child_id": 201},
         {"child_id": 203},
     ]
-    final_results["results"][2]["child_items"]["results"] = [  # type: ignore
+    final_results["results"][2]["child_items"]["results"] = [  # ty: ignore[invalid-assignment, not-subscriptable]
         {"child_id": 301}
     ]
     assert result == final_results["results"]

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_fetch_site_pages.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_fetch_site_pages.py
@@ -367,7 +367,7 @@ class TestIsPerSiteGraphFailure:
         # ClientRequestException with response=None. The retry layer owns
         # those, so we treat None as "not per-site".
         exc = _make_client_request_exception(404)
-        exc.response = None  # type: ignore[assignment]
+        exc.response = None
         assert _is_per_site_graph_failure(exc) is False
 
     def test_itemnotfound_404_is_per_site(self) -> None:

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_cold_pod_retry.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_cold_pod_retry.py
@@ -54,8 +54,8 @@ def _make_client(
     )
     # Shrink the retry delay to 0 in tests — we're not testing the sleep,
     # we're testing the retry count.
-    client._COLD_POD_RETRIES = retries  # type: ignore[misc]
-    client._COLD_POD_BASE_DELAY = base_delay  # type: ignore[misc]
+    client._COLD_POD_RETRIES = retries
+    client._COLD_POD_BASE_DELAY = base_delay
     return client
 
 

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_manager_config.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_manager_config.py
@@ -57,10 +57,10 @@ EXPECTED_EXEC_ENV = {"HOME": "/home/sandbox", "USER": "sandbox"}
 def _bare_manager_with_image(image: str) -> tuple[dsm.DockerSandboxManager, MagicMock]:
     mgr: dsm.DockerSandboxManager = object.__new__(dsm.DockerSandboxManager)
     docker = MagicMock()
-    mgr._docker = docker  # type: ignore[attr-defined]
-    mgr._image = image  # type: ignore[attr-defined]
-    mgr._image_checked = False  # type: ignore[attr-defined]
-    mgr._image_check_lock = threading.Lock()  # type: ignore[attr-defined]
+    mgr._docker = docker
+    mgr._image = image
+    mgr._image_checked = False
+    mgr._image_check_lock = threading.Lock()
     return mgr, docker
 
 
@@ -105,7 +105,7 @@ def test_labels_omit_user_id_when_none() -> None:
 def test_immutable_sandbox_image_uses_cached_image_when_present() -> None:
     mgr, docker = _bare_manager_with_image("onyxdotapp/sandbox:v4.1.2")
 
-    mgr._ensure_sandbox_image()  # type: ignore[attr-defined]
+    mgr._ensure_sandbox_image()
 
     docker.images.get.assert_called_once_with("onyxdotapp/sandbox:v4.1.2")
     docker.images.pull.assert_not_called()
@@ -115,7 +115,7 @@ def test_immutable_sandbox_image_pulls_when_missing() -> None:
     mgr, docker = _bare_manager_with_image("onyxdotapp/sandbox:v4.1.2")
     docker.images.get.side_effect = dsm.NotFound("missing")
 
-    mgr._ensure_sandbox_image()  # type: ignore[attr-defined]
+    mgr._ensure_sandbox_image()
 
     docker.images.pull.assert_called_once_with("onyxdotapp/sandbox:v4.1.2")
 
@@ -123,8 +123,8 @@ def test_immutable_sandbox_image_pulls_when_missing() -> None:
 def test_mutable_sandbox_image_refreshes_once() -> None:
     mgr, docker = _bare_manager_with_image("onyxdotapp/sandbox:latest")
 
-    mgr._ensure_sandbox_image()  # type: ignore[attr-defined]
-    mgr._ensure_sandbox_image()  # type: ignore[attr-defined]
+    mgr._ensure_sandbox_image()
+    mgr._ensure_sandbox_image()
 
     docker.images.pull.assert_called_once_with("onyxdotapp/sandbox:latest")
     docker.images.get.assert_not_called()
@@ -142,9 +142,9 @@ def test_sandbox_image_refresh_is_thread_safe() -> None:
     docker.images.pull.side_effect = pull_image
 
     with ThreadPoolExecutor(max_workers=2) as executor:
-        first = executor.submit(mgr._ensure_sandbox_image)  # type: ignore[attr-defined]
+        first = executor.submit(mgr._ensure_sandbox_image)
         assert pull_started.wait(timeout=1)
-        second = executor.submit(mgr._ensure_sandbox_image)  # type: ignore[attr-defined]
+        second = executor.submit(mgr._ensure_sandbox_image)
         finish_pull.set()
         first.result(timeout=1)
         second.result(timeout=1)
@@ -156,7 +156,7 @@ def test_implicit_latest_sandbox_image_refreshes() -> None:
     image = "onyxdotapp/sandbox"
     mgr, docker = _bare_manager_with_image(image)
 
-    mgr._ensure_sandbox_image()  # type: ignore[attr-defined]
+    mgr._ensure_sandbox_image()
 
     docker.images.pull.assert_called_once_with(image)
     docker.images.get.assert_not_called()
@@ -168,8 +168,8 @@ def test_mutable_sandbox_image_uses_cache_once_if_refresh_fails() -> None:
     mgr, docker = _bare_manager_with_image("onyxdotapp/sandbox:edge")
     docker.images.pull.side_effect = dsm.APIError("registry unavailable")
 
-    mgr._ensure_sandbox_image()  # type: ignore[attr-defined]
-    mgr._ensure_sandbox_image()  # type: ignore[attr-defined]
+    mgr._ensure_sandbox_image()
+    mgr._ensure_sandbox_image()
 
     docker.images.pull.assert_called_once_with("onyxdotapp/sandbox:edge")
     docker.images.get.assert_called_once_with("onyxdotapp/sandbox:edge")
@@ -181,13 +181,13 @@ def test_mutable_sandbox_image_raises_if_refresh_fails_without_cache() -> None:
     docker.images.get.side_effect = dsm.NotFound("missing")
 
     with pytest.raises(RuntimeError, match="Failed to pull sandbox image"):
-        mgr._ensure_sandbox_image()  # type: ignore[attr-defined]
+        mgr._ensure_sandbox_image()
 
 
 def test_local_dev_sandbox_image_uses_cached_image_when_present() -> None:
     mgr, docker = _bare_manager_with_image("onyxdotapp/sandbox:dev")
 
-    mgr._ensure_sandbox_image()  # type: ignore[attr-defined]
+    mgr._ensure_sandbox_image()
 
     docker.images.get.assert_called_once_with("onyxdotapp/sandbox:dev")
     docker.images.pull.assert_not_called()
@@ -197,7 +197,7 @@ def test_registry_port_untagged_image_refreshes_as_implicit_latest() -> None:
     image = "localhost:5001/onyx-sandbox"
     mgr, docker = _bare_manager_with_image(image)
 
-    mgr._ensure_sandbox_image()  # type: ignore[attr-defined]
+    mgr._ensure_sandbox_image()
 
     docker.images.pull.assert_called_once_with(image)
     docker.images.get.assert_not_called()
@@ -207,7 +207,7 @@ def test_digest_sandbox_image_uses_cached_image_when_present() -> None:
     image = "onyxdotapp/sandbox@sha256:abc123"
     mgr, docker = _bare_manager_with_image(image)
 
-    mgr._ensure_sandbox_image()  # type: ignore[attr-defined]
+    mgr._ensure_sandbox_image()
 
     docker.images.get.assert_called_once_with(image)
     docker.images.pull.assert_not_called()

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_serve_plumbing.py
@@ -52,11 +52,11 @@ def _bare_manager() -> DockerSandboxManager:
     these tests.
     """
     mgr: DockerSandboxManager = object.__new__(DockerSandboxManager)
-    mgr._agent_instructions_template_path = (  # type: ignore[attr-defined]
+    mgr._agent_instructions_template_path = (
         dsm.Path(dsm.__file__).parent.parent.parent / "AGENTS.template.md"
     )
-    mgr._image_checked = True  # type: ignore[attr-defined]
-    mgr._image_check_lock = dsm.threading.Lock()  # type: ignore[attr-defined]
+    mgr._image_checked = True
+    mgr._image_check_lock = dsm.threading.Lock()
     mgr._init_serve_state()
     return mgr
 
@@ -66,7 +66,7 @@ def test_load_serve_connection_info_uses_container_name_and_port() -> None:
     mgr = _bare_manager()
     fake_container = MagicMock()
     fake_container.attrs = {"Config": {"Env": []}}
-    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+    mgr._docker = MagicMock()
     mgr._docker.containers.get.return_value = fake_container
 
     info = mgr._load_serve_connection_info(_SBX)
@@ -93,7 +93,7 @@ def test_load_serve_connection_info_prefers_localhost_published_port_in_dev(
             },
         },
     }
-    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+    mgr._docker = MagicMock()
     mgr._docker.containers.get.return_value = fake_container
 
     info = mgr._load_serve_connection_info(_SBX)
@@ -115,7 +115,7 @@ def test_load_serve_connection_info_ignores_published_port_outside_dev() -> None
             },
         },
     }
-    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+    mgr._docker = MagicMock()
     mgr._docker.containers.get.return_value = fake_container
 
     info = mgr._load_serve_connection_info(_SBX)
@@ -142,7 +142,7 @@ def test_load_serve_connection_info_normalizes_wildcard_host_ip_in_dev(
             },
         },
     }
-    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+    mgr._docker = MagicMock()
     mgr._docker.containers.get.return_value = fake_container
 
     info = mgr._load_serve_connection_info(_SBX)
@@ -167,7 +167,7 @@ def test_load_serve_connection_info_parses_password_from_container_env() -> None
             ]
         }
     }
-    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+    mgr._docker = MagicMock()
     mgr._docker.containers.get.return_value = fake_container
 
     info = mgr._load_serve_connection_info(_SBX)
@@ -186,7 +186,7 @@ def test_load_serve_connection_info_yields_none_password_for_legacy() -> None:
     fake_container.attrs = {
         "Config": {"Env": ["ONYX_PAT=pat", "ONYX_SERVER_URL=https://onyx.example.com"]}
     }
-    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+    mgr._docker = MagicMock()
     mgr._docker.containers.get.return_value = fake_container
 
     info = mgr._load_serve_connection_info(_SBX)
@@ -200,7 +200,7 @@ def test_load_serve_connection_info_returns_none_when_container_missing() -> Non
     gracefully, not raise.
     """
     mgr = _bare_manager()
-    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+    mgr._docker = MagicMock()
     mgr._docker.containers.get.side_effect = dsm.NotFound("gone")
 
     assert mgr._load_serve_connection_info(_SBX) is None
@@ -221,7 +221,7 @@ def test_load_serve_connection_info_handles_password_with_equals_sign() -> None:
             ]
         }
     }
-    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+    mgr._docker = MagicMock()
     mgr._docker.containers.get.return_value = fake_container
 
     info = mgr._load_serve_connection_info(_SBX)
@@ -380,12 +380,12 @@ def test_provision_generates_fresh_password_and_injects_into_container_env(
 
     mgr = _bare_manager()
     # Mock the Docker client surface used by provision().
-    mgr._docker = MagicMock()  # type: ignore[attr-defined]
-    mgr._image = "onyxdotapp/sandbox:test"  # type: ignore[attr-defined]
-    mgr._network_name = "onyx_craft_sandbox"  # type: ignore[attr-defined]
-    mgr._memory_limit = "2g"  # type: ignore[attr-defined]
-    mgr._cpu_limit = 1.0  # type: ignore[attr-defined]
-    mgr._compose_project = None  # type: ignore[attr-defined]
+    mgr._docker = MagicMock()
+    mgr._image = "onyxdotapp/sandbox:test"
+    mgr._network_name = "onyx_craft_sandbox"
+    mgr._memory_limit = "2g"
+    mgr._cpu_limit = 1.0
+    mgr._compose_project = None
     # No existing container.
     mgr._docker.containers.get.side_effect = dsm.NotFound("none")
     # _ensure_sandbox_network — pretend it exists already.
@@ -393,7 +393,7 @@ def test_provision_generates_fresh_password_and_injects_into_container_env(
     # _ensure_sandbox_volume — pretend it exists already.
     mgr._docker.volumes.get.return_value = MagicMock()
     # No durable opencode history, so the fresh-container restore is a no-op.
-    mgr._snapshot_manager = MagicMock()  # type: ignore[attr-defined]
+    mgr._snapshot_manager = MagicMock()
     mgr._snapshot_manager.has_opencode_history_snapshot.return_value = False
 
     # Provision creates the container stopped, restores history, then starts it;
@@ -458,7 +458,7 @@ def test_terminate_closes_event_bus_and_tombstones_sandbox() -> None:
     ``_terminated_sandboxes`` so a late subscribe can't race in.
     """
     mgr = _bare_manager()
-    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+    mgr._docker = MagicMock()
     mgr._docker.containers.get.return_value = None
     mgr._docker.volumes.get.side_effect = dsm.NotFound("none")
 
@@ -485,7 +485,7 @@ def test_reuse_existing_container_removes_created_state() -> None:
     opencode history -- starting it would skip the restore.
     """
     mgr = _bare_manager()
-    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+    mgr._docker = MagicMock()
 
     stranded = MagicMock()
     stranded.name = "sandbox-12345678"
@@ -505,7 +505,7 @@ def test_reuse_existing_container_starts_exited() -> None:
     populated; reuse should start it rather than discard it.
     """
     mgr = _bare_manager()
-    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+    mgr._docker = MagicMock()
 
     exited = MagicMock()
     exited.name = "sandbox-12345678"
@@ -533,18 +533,18 @@ def test_provision_removes_container_when_history_restore_fails(
     monkeypatch.setattr(dsm, "validate_sandbox_api_url", lambda *_: None)
 
     mgr = _bare_manager()
-    mgr._docker = MagicMock()  # type: ignore[attr-defined]
-    mgr._image = "onyxdotapp/sandbox:test"  # type: ignore[attr-defined]
-    mgr._network_name = "onyx_craft_sandbox"  # type: ignore[attr-defined]
-    mgr._memory_limit = "2g"  # type: ignore[attr-defined]
-    mgr._cpu_limit = 1.0  # type: ignore[attr-defined]
-    mgr._compose_project = None  # type: ignore[attr-defined]
+    mgr._docker = MagicMock()
+    mgr._image = "onyxdotapp/sandbox:test"
+    mgr._network_name = "onyx_craft_sandbox"
+    mgr._memory_limit = "2g"
+    mgr._cpu_limit = 1.0
+    mgr._compose_project = None
     mgr._docker.containers.get.side_effect = dsm.NotFound("none")
     mgr._docker.networks.get.return_value = MagicMock()
     mgr._docker.volumes.get.return_value = MagicMock()
 
     # FileStore lookup blows up partway through the history restore.
-    mgr._snapshot_manager = MagicMock()  # type: ignore[attr-defined]
+    mgr._snapshot_manager = MagicMock()
     mgr._snapshot_manager.has_opencode_history_snapshot.side_effect = RuntimeError(
         "filestore unavailable"
     )

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_ensure_opencode_session.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_ensure_opencode_session.py
@@ -73,8 +73,8 @@ def test_ensure_opencode_session_uses_unary_client_without_event_bus(
     def fail_if_bus_created(_: UUID, __: str) -> object:
         raise AssertionError("ensure_opencode_session should not create an event bus")
 
-    manager._load_serve_connection_info = load_connection_info  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
-    manager._get_or_create_event_bus = fail_if_bus_created  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+    manager._load_serve_connection_info = load_connection_info  # ty: ignore[invalid-assignment]
+    manager._get_or_create_event_bus = fail_if_bus_created  # ty: ignore[invalid-assignment]
     monkeypatch.setattr(
         serve_transport,
         "OpencodeServeClient",
@@ -101,8 +101,8 @@ def test_delete_opencode_session_uses_unary_client_without_event_bus(
     def fail_if_bus_created(_: UUID, __: str) -> object:
         raise AssertionError("delete_opencode_session should not create an event bus")
 
-    manager._load_serve_connection_info = load_connection_info  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
-    manager._get_or_create_event_bus = fail_if_bus_created  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+    manager._load_serve_connection_info = load_connection_info  # ty: ignore[invalid-assignment]
+    manager._get_or_create_event_bus = fail_if_bus_created  # ty: ignore[invalid-assignment]
     monkeypatch.setattr(
         serve_transport,
         "OpencodeServeClient",

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_event_bus.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_event_bus.py
@@ -589,9 +589,9 @@ def test_reader_self_closes_after_max_consecutive_failures() -> None:
         connect_timeout=0.1,
     )
     # Tighten the schedule so the test runs in <2s.
-    bus._RECONNECT_BACKOFF_INITIAL = 0.05  # type: ignore[misc]
-    bus._RECONNECT_BACKOFF_MAX = 0.05  # type: ignore[misc]
-    bus._RECONNECT_MAX_CONSECUTIVE_FAILURES = 3  # type: ignore[misc]
+    bus._RECONNECT_BACKOFF_INITIAL = 0.05
+    bus._RECONNECT_BACKOFF_MAX = 0.05
+    bus._RECONNECT_MAX_CONSECUTIVE_FAILURES = 3
     sub = bus.subscribe("ses_anything")
     try:
         # Wait up to 5s for the bus to give up and signal close.

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_event_bus_per_directory.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_event_bus_per_directory.py
@@ -68,7 +68,7 @@ def mgr(
     m: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
     m._init_serve_state()
 
-    m._load_serve_connection_info = (  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+    m._load_serve_connection_info = (  # ty: ignore[invalid-assignment]
         lambda sandbox_id: ServeConnectionInfo(
             base_url=f"http://{sandbox_id}.invalid:4096",
             password=None,

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_file_listing.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_file_listing.py
@@ -40,7 +40,7 @@ class _FakeSidecarClient:
 def test_kubernetes_list_directory_delegates_to_sidecar() -> None:
     manager: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
     sidecar_client = _FakeSidecarClient()
-    manager._sidecar_client = sidecar_client  # type: ignore[attr-defined]  # ty: ignore[invalid-assignment]
+    manager._sidecar_client = sidecar_client  # ty: ignore[invalid-assignment]
 
     entries = manager.list_directory(_SANDBOX_ID, _SESSION_ID, ".")
 
@@ -60,7 +60,7 @@ def test_kubernetes_list_directory_maps_sidecar_not_found() -> None:
             )
 
     manager: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
-    manager._sidecar_client = NotFoundSidecarClient()  # type: ignore[attr-defined]  # ty: ignore[invalid-assignment]
+    manager._sidecar_client = NotFoundSidecarClient()  # ty: ignore[invalid-assignment]
 
     with pytest.raises(ValueError, match="not found or not a directory"):
         manager.list_directory(_SANDBOX_ID, _SESSION_ID, "missing")
@@ -82,7 +82,7 @@ def test_kubernetes_list_directory_surfaces_unexpected_sidecar_errors(
             raise SidecarStatusError("filesystem list", status_code, body)
 
     manager: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
-    manager._sidecar_client = ErrorSidecarClient()  # type: ignore[attr-defined]  # ty: ignore[invalid-assignment]
+    manager._sidecar_client = ErrorSidecarClient()  # ty: ignore[invalid-assignment]
 
     with pytest.raises(RuntimeError, match="Failed to list directory"):
         manager.list_directory(_SANDBOX_ID, _SESSION_ID, "missing")

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_k8s_push_error_mapping.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_k8s_push_error_mapping.py
@@ -124,9 +124,9 @@ def _make_manager() -> KubernetesSandboxManager:
     ]
     core_api.read_namespaced_pod.return_value = pod_obj
 
-    mgr._core_api = core_api  # type: ignore[attr-defined]
-    mgr._namespace = "sandbox-test"  # type: ignore[attr-defined]
-    mgr._sidecar_client = SidecarClient(host=_service_host(mgr))  # type: ignore[attr-defined]
+    mgr._core_api = core_api
+    mgr._namespace = "sandbox-test"
+    mgr._sidecar_client = SidecarClient(host=_service_host(mgr))
     return mgr
 
 
@@ -656,7 +656,7 @@ def test_push_connect_error_is_retriable() -> None:
 def test_create_opencode_history_snapshot_204_preserves_stable_snapshot() -> None:
     mgr = _make_manager()
     snapshot_manager = MagicMock()
-    mgr._snapshot_manager = snapshot_manager  # type: ignore[attr-defined]
+    mgr._snapshot_manager = snapshot_manager
     resp = _resp(204)
 
     with patch(_HTTPX_CLIENT_PATH, _mock_httpx_stream_client(resp)):
@@ -688,7 +688,7 @@ def test_restore_opencode_history_posts_archive_to_sidecar(
         write_stream.write(archive_body)
 
     snapshot_manager.restore_snapshot_to_stream.side_effect = restore_to_stream
-    mgr._snapshot_manager = snapshot_manager  # type: ignore[attr-defined]
+    mgr._snapshot_manager = snapshot_manager
 
     def fake_post_archive(
         *,
@@ -731,7 +731,7 @@ def test_restore_opencode_history_marks_sidecar_ready_when_no_snapshot(
 
     snapshot_manager = MagicMock()
     snapshot_manager.has_opencode_history_snapshot.return_value = False
-    mgr._snapshot_manager = snapshot_manager  # type: ignore[attr-defined]
+    mgr._snapshot_manager = snapshot_manager
 
     def fake_mark_restored(
         *,

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_k8s_workspace_setup_sentinel.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_k8s_workspace_setup_sentinel.py
@@ -33,8 +33,8 @@ _LLM_CONFIG = CraftLLMProviderConfig(
 
 def _make_manager(monkeypatch: pytest.MonkeyPatch) -> KubernetesSandboxManager:
     mgr: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
-    mgr._namespace = "sandbox-test"  # type: ignore[attr-defined]
-    mgr._stream_core_api = MagicMock()  # type: ignore[attr-defined]
+    mgr._namespace = "sandbox-test"
+    mgr._stream_core_api = MagicMock()
     monkeypatch.setattr(
         mgr,
         "_load_agent_instructions",

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_resolve_proxy_ip.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_resolve_proxy_ip.py
@@ -19,9 +19,9 @@ from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager im
 
 def _mgr() -> tuple[KubernetesSandboxManager, MagicMock]:
     mgr: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
-    mgr._namespace = "onyx-sandboxes"  # type: ignore[attr-defined]
+    mgr._namespace = "onyx-sandboxes"
     core_api = MagicMock()
-    mgr._core_api = core_api  # type: ignore[attr-defined]
+    mgr._core_api = core_api
     return mgr, core_api
 
 

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_send_message_timeout_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_send_message_timeout_plumbing.py
@@ -59,7 +59,7 @@ def _manager_with(client: _FakeServeClient) -> KubernetesSandboxManager:
     def build_client(*_: Any, **__: Any) -> _FakeServeClient:
         return client
 
-    manager._build_serve_client = build_client  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+    manager._build_serve_client = build_client  # ty: ignore[invalid-assignment]
     return manager
 
 

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_serve_transport_live_coalescing.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_serve_transport_live_coalescing.py
@@ -34,7 +34,7 @@ def mgr(
 
     manager: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
     manager._init_serve_state()
-    manager._load_serve_connection_info = (  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+    manager._load_serve_connection_info = (  # ty: ignore[invalid-assignment]
         lambda sandbox_id: ServeConnectionInfo(
             base_url=f"http://{sandbox_id}.invalid:4096",
             password=None,

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_translate_opencode_event.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_translate_opencode_event.py
@@ -89,7 +89,7 @@ def test_text_delta_yields_agent_message_chunk() -> None:
     )
     assert len(out) == 1
     assert isinstance(out[0], AgentMessageChunk)
-    assert out[0].content.text == "hello"  # type: ignore[union-attr]
+    assert out[0].content.text == "hello"
     assert s.local_text == {"p1": "hello"}
 
 
@@ -292,7 +292,7 @@ def test_multi_assistant_message_turn_accepts_both() -> None:
     )
     assert len(out) == 1
     assert isinstance(out[0], AgentMessageChunk)
-    assert out[0].content.text == "Yuhong"  # type: ignore[union-attr]
+    assert out[0].content.text == "Yuhong"
 
 
 def test_step_part_delta_ignored() -> None:
@@ -699,7 +699,7 @@ def test_message_part_updated_text_with_more_text_fills_gap() -> None:
     )
     assert len(out) == 1
     assert isinstance(out[0], AgentMessageChunk)
-    assert out[0].content.text == "world!"  # type: ignore[union-attr]
+    assert out[0].content.text == "world!"
     assert s.local_text["p1"] == "Hello, world!"
 
 
@@ -844,7 +844,7 @@ def test_tool_subsequent_updates_emit_progress() -> None:
     assert out[0].raw_input == {"command": "ls"}
     assert out[0].raw_output is not None
     # Wrapped: {"output": "file1\nfile2\n"}
-    assert out[0].raw_output.get("output") == "file1\nfile2\n"  # type: ignore[union-attr]
+    assert out[0].raw_output.get("output") == "file1\nfile2\n"
 
 
 def test_tool_kind_mapping() -> None:
@@ -956,9 +956,9 @@ def test_edit_tool_propagates_through_translation() -> None:
     assert out[0].content is not None
     diff_block = out[0].content[0]
     # Pydantic deserialized into FileEditToolCallContent — check its fields
-    assert diff_block.type == "diff"  # type: ignore[union-attr]
-    assert diff_block.path == "/a.txt"  # type: ignore[union-attr]
-    assert diff_block.new_text == "y"  # type: ignore[union-attr]
+    assert diff_block.type == "diff"
+    assert diff_block.path == "/a.txt"
+    assert diff_block.new_text == "y"
 
 
 # ───────────────────────── status mapping ─────────────────────────
@@ -1411,7 +1411,7 @@ def test_child_text_delta_forwarded_and_tagged() -> None:
 
     assert len(out) == 1
     assert isinstance(out[0], AgentMessageChunk)
-    assert out[0].content.text == "child response"  # type: ignore[union-attr]
+    assert out[0].content.text == "child response"
     meta = out[0].field_meta
     assert meta is not None
     assert meta["sessionId"] == CHILD
@@ -1450,7 +1450,7 @@ def test_child_reasoning_part_forwarded_and_tagged() -> None:
 
     assert len(out) == 1
     assert isinstance(out[0], AgentThoughtChunk)
-    assert out[0].content.text == "child thinking"  # type: ignore[union-attr]
+    assert out[0].content.text == "child thinking"
     meta = out[0].field_meta
     assert meta is not None
     assert meta["sessionId"] == CHILD
@@ -1487,7 +1487,7 @@ def test_child_reasoning_delta_forwarded_and_tagged() -> None:
 
     assert len(out) == 1
     assert isinstance(out[0], AgentThoughtChunk)
-    assert out[0].content.text == "child thinking"  # type: ignore[union-attr]
+    assert out[0].content.text == "child thinking"
     meta = out[0].field_meta
     assert meta is not None
     assert meta["sessionId"] == CHILD
@@ -1574,7 +1574,7 @@ def test_child_part_type_does_not_collide_with_parent_part_id() -> None:
 
     assert len(parent_out) == 1
     assert isinstance(parent_out[0], AgentMessageChunk)
-    assert parent_out[0].content.text == "parent visible text"  # type: ignore[union-attr]
+    assert parent_out[0].content.text == "parent visible text"
 
 
 def test_child_tool_event_dropped_when_not_descendant() -> None:
@@ -1698,8 +1698,8 @@ def test_bash_completed_with_nonzero_exit_maps_to_failed() -> None:
     assert isinstance(out[0], ToolCallProgress)
     assert out[0].status == "failed"
     assert out[0].raw_output is not None
-    assert out[0].raw_output.get("output") == "permission denied"  # type: ignore[union-attr]
-    assert out[0].raw_output.get("metadata") == {"exit": 1}  # type: ignore[union-attr]
+    assert out[0].raw_output.get("output") == "permission denied"
+    assert out[0].raw_output.get("metadata") == {"exit": 1}
 
 
 def test_bash_first_sighting_completed_with_nonzero_exit_dual_emits_failed() -> None:
@@ -1764,7 +1764,7 @@ def test_tool_error_state_maps_to_failed_with_error_output() -> None:
     assert isinstance(out[0], ToolCallProgress)
     assert out[0].status == "failed"
     assert out[0].raw_output is not None
-    assert out[0].raw_output.get("output") == "sudo: a password is required"  # type: ignore[union-attr]
+    assert out[0].raw_output.get("output") == "sudo: a password is required"
 
 
 def _msg_updated(

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_workspace_cleanup_failure_propagation.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_workspace_cleanup_failure_propagation.py
@@ -19,8 +19,8 @@ def test_kubernetes_workspace_cleanup_failure_propagates(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     manager = object.__new__(KubernetesSandboxManager)
-    manager._stream_core_api = MagicMock()  # type: ignore[attr-defined]
-    manager._namespace = "sandbox-test"  # type: ignore[attr-defined]
+    manager._stream_core_api = MagicMock()
+    manager._namespace = "sandbox-test"
     monkeypatch.setattr(manager, "_close_session_buses", MagicMock())
     monkeypatch.setattr(
         kubernetes_module,

--- a/backend/tests/unit/onyx/server/features/craft/test_session_gateway_config.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_session_gateway_config.py
@@ -349,7 +349,7 @@ def test_manager_prefers_provider_recommended_default_in_provider_order() -> Non
         name="Alpha provider",
     )
     manager = SessionManager.__new__(SessionManager)
-    manager._db_session = cast(Session, MagicMock(spec=Session))  # type: ignore[attr-defined]
+    manager._db_session = cast(Session, MagicMock(spec=Session))
     user = cast(User, MagicMock(spec=User))
 
     with (
@@ -366,7 +366,7 @@ def test_manager_prefers_provider_recommended_default_in_provider_order() -> Non
     # default (bedrock-pro) wins over the alphabetically-first visible model.
     assert config.provider == "onyx"
     assert config.model_name == "7/bedrock-pro"
-    fetch_providers.assert_called_once_with(manager._db_session, user)  # type: ignore[attr-defined]
+    fetch_providers.assert_called_once_with(manager._db_session, user)
 
 
 def _gateway_config() -> CraftLLMProviderConfig:
@@ -407,9 +407,9 @@ def _reconcile_manager(
     manager = SessionManager.__new__(SessionManager)
     sandbox_manager = MagicMock()
     build_llm_configs = MagicMock(return_value=config)
-    manager._db_session = cast(Session, MagicMock(spec=Session))  # type: ignore[attr-defined]
-    manager._sandbox_manager = sandbox_manager  # type: ignore[attr-defined]
-    manager.build_llm_configs = build_llm_configs  # type: ignore[method-assign]
+    manager._db_session = cast(Session, MagicMock(spec=Session))
+    manager._sandbox_manager = sandbox_manager
+    manager.build_llm_configs = build_llm_configs
     return manager, sandbox_manager, build_llm_configs
 
 

--- a/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
@@ -194,7 +194,7 @@ class _StreamingLLM(_ConfigOnlyLLM):
         self._fail = fail
         self._exc = exc or RuntimeError("secret-provider-response")
 
-    def stream(self, *args: object, **kwargs: object):  # type: ignore[no-untyped-def,override]
+    def stream(self, *args: object, **kwargs: object):
         del args, kwargs
         try:
             if self._fail:
@@ -231,7 +231,7 @@ class _RaisingCloseStream:
 
 
 class _RaisingCloseLLM(_ConfigOnlyLLM):
-    def stream(self, *args: object, **kwargs: object) -> _RaisingCloseStream:  # type: ignore[override]
+    def stream(self, *args: object, **kwargs: object) -> _RaisingCloseStream:
         del args, kwargs
         return _RaisingCloseStream()
 
@@ -510,7 +510,7 @@ class _ToolCallStreamLLM(_ConfigOnlyLLM):
             )
         )
 
-    def stream(self, *args: object, **kwargs: object):  # type: ignore[no-untyped-def,override]
+    def stream(self, *args: object, **kwargs: object):
         del args, kwargs
         yield ModelResponseStream(
             id="s1",
@@ -584,7 +584,7 @@ class _ReasoningStreamLLM(_ConfigOnlyLLM):
             )
         )
 
-    def stream(self, *args: object, **kwargs: object):  # type: ignore[no-untyped-def,override]
+    def stream(self, *args: object, **kwargs: object):
         del args, kwargs
         yield ModelResponseStream(
             id="r1",
@@ -628,7 +628,7 @@ class _RaisingInvokeLLM(_ConfigOnlyLLM):
         )
         self._exc = exc
 
-    def invoke(self, *args: object, **kwargs: object):  # type: ignore[no-untyped-def,override]
+    def invoke(self, *args: object, **kwargs: object):
         del args, kwargs
         raise self._exc
 
@@ -645,7 +645,7 @@ class _InvokeLLM(_ConfigOnlyLLM):
         )
         self._response = response
 
-    def invoke(self, *args: object, **kwargs: object) -> ModelResponse:  # type: ignore[override]
+    def invoke(self, *args: object, **kwargs: object) -> ModelResponse:
         del args, kwargs
         return self._response
 

--- a/backend/tests/unit/onyx/server/scim/test_admin.py
+++ b/backend/tests/unit/onyx/server/scim/test_admin.py
@@ -82,7 +82,7 @@ class TestCreateToken:
 
         # Simulate one existing active token that should get revoked
         existing = _make_token(1, "old-token", is_active=True)
-        scim_dal._session.scalars.return_value.all.return_value = (  # type: ignore
+        scim_dal._session.scalars.return_value.all.return_value = (  # ty: ignore[unresolved-attribute]
             [existing]
         )
 

--- a/backend/tests/unit/onyx/tools/tool_implementations/python/test_python_tool_upload_cache.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/python/test_python_tool_upload_cache.py
@@ -296,7 +296,7 @@ def test_count_overflow_files_are_not_downloaded() -> None:
 
     download_counts = {f"f{i}.csv": 0 for i in range(5)}
 
-    def _make_loader(name: str):  # type: ignore[no-untyped-def]
+    def _make_loader(name: str):
         def _load() -> bytes:
             download_counts[name] += 1
             return b"data"
@@ -423,7 +423,7 @@ def test_referenced_old_file_read_unreferenced_recent_not() -> None:
 
     download_counts = {"old.csv": 0, "new.csv": 0}
 
-    def _make_loader(name: str):  # type: ignore[no-untyped-def]
+    def _make_loader(name: str):
         def _load() -> bytes:
             download_counts[name] += 1
             return b"data"

--- a/backend/tests/unit/server/documents/test_stage_metric_residual.py
+++ b/backend/tests/unit/server/documents/test_stage_metric_residual.py
@@ -118,7 +118,7 @@ def test_residual_uses_component_totals_not_averages() -> None:
     assert residual.avg_duration_ms == 500 / 4
 
 
-def test_warn_log_fires_when_components_exceed_total(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_warn_log_fires_when_components_exceed_total(monkeypatch) -> None:
     import onyx.server.documents.models as models_module
 
     calls: list[tuple] = []


### PR DESCRIPTION
## Description

Cleans up the 134 leftover mypy-era `# type: ignore` directives in `backend/`. mypy is no longer part of the toolchain — the `mypy-check` CI job keeps its name only for branch-protection compatibility and actually runs `ty check`.

**127 of them were inert.** `ty` honors a bare `# type: ignore`, but ignores one that carries a mypy error code (`# type: ignore[attr-defined]`, `[arg-type]`, …). Those 127 had been silently doing nothing. Removing all of them produces **zero** new diagnostics — nothing was relying on them.

**7 of them were live**, and each suppressed *every* rule on its line rather than a specific one. Between them they were hiding 10 diagnostics. Each is now either a targeted `# ty: ignore[<rule>]` naming exactly what it silences, or a real fix:

| Site | Resolution |
|---|---|
| `onyxbot/slack/utils.py` | **Real fix** — slack_sdk types `SlackResponse.data` as `bytes \| dict`; now `cast` to `dict[str, Any]` before subscripting |
| `utils/logger.py` | `# ty: ignore[unresolved-attribute]` — assigning the custom `notice` level onto the logger |
| `utils/threadpool_concurrency.py` | `# ty: ignore[invalid-assignment]` |
| `tests/unit/.../scim/test_admin.py` | `# ty: ignore[unresolved-attribute]` — mock attribute |
| `tests/unit/.../confluence/test_onyx_confluence.py` (×3) | `# ty: ignore[invalid-assignment, not-subscriptable]` — building nested fixture data |

After this, no legacy directives remain and every suppression in the backend names the rule it silences.

## How Has This Been Tested?

- `ty check` — All checks passed (`[tool.ty.rules] all = "error"`)
- `pre-commit run --files <42 changed files>` — all hooks pass
- `pytest backend/tests/unit` — `7427 passed`, same 9 pre-existing failures as `main` (verified against a clean tree)

Runtime behavior is unchanged: comments and one `cast` (a no-op at runtime).

## Additional Options

- [x] Override Linear Check
