### PR TITLE
fix(usage): sort per-model usage breakdown by cost descending

### DIFF
--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -48,6 +48,10 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
     0
   );
   const hasCache = rows.some((row) => row.cache_read_tokens > 0);
+  const sortedRows = useMemo(
+    () => [...rows].sort((a, b) => b.cost_cents - a.cost_cents),
+    [rows]
+  );
 
   return (
     <Section gap={0.75} justifyContent="start">
@@ -68,7 +72,7 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
         />
       ) : (
         <Card>
-          {rows.map((row, index) => (
+          {sortedRows.map((row, index) => (
             <div key={`${row.day}-${row.model}`}>
               {index > 0 && <Divider />}
               <Section gap={0.5} alignItems="start" justifyContent="start">


### PR DESCRIPTION
## Description

On `/app/settings/usage`, the "Usage this period" per-model breakdown rendered rows in whatever order the API returned them. This sorts the rows by cost descending, so the most expensive (most used) model/day rows appear at the top and the cheapest at the bottom.

Purely presentational — the source `rows` array is copied before sorting, and the cost-bar scaling, totals, and row keys are unchanged.

## How Has This Been Tested?

`pre-commit run --files web/src/app/app/settings/usage/UsageSettings.tsx` — oxfmt, oxlint, and the TypeScript type check all pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sorts the per-model daily usage rows by cost (descending) on the Usage settings page so the most expensive entries appear first. Visual-only change: uses a memoized copy of the rows; totals, cost-bar scaling, and row keys are unchanged.

<sup>Written for commit f00ad03b3ed252152a99e6658f820d800d705536. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

