### PR TITLE
feat(llm): admin-selectable API mode for Bifrost (#13642) to release v4.4

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -49,6 +49,8 @@ from onyx.llm.well_known_providers.constants import (
     AWS_REGION_NAME_KWARG_ENV_VAR_FORMAT,
     AWS_SECRET_ACCESS_KEY_KWARG,
     AWS_SECRET_ACCESS_KEY_KWARG_ENV_VAR_FORMAT,
+    BIFROST_API_MODE_CONFIG_KEY,
+    BIFROST_API_MODE_RESPONSES,
     LM_STUDIO_API_KEY_CONFIG_KEY,
     OLLAMA_API_KEY_CONFIG_KEY,
     VERTEX_AUTH_METHOD_KWARG,
@@ -657,6 +659,13 @@ class LitellmLLM(LLM):
             # We use custom_llm_provider="openai" so LiteLLM doesn't try
             # to route based on the provider prefix.
             model = self.config.deployment_name or self.config.model_name
+            if (
+                self._model_provider == LlmProviderNames.BIFROST
+                and (self._custom_config or {}).get(BIFROST_API_MODE_CONFIG_KEY)
+                == BIFROST_API_MODE_RESPONSES
+            ):
+                # Drives LiteLLM's completions -> responses bridge.
+                model = f"responses/{model}"
         else:
             model = f"{model_provider}/{self.config.deployment_name or self.config.model_name}"
 

--- a/backend/onyx/llm/well_known_providers/constants.py
+++ b/backend/onyx/llm/well_known_providers/constants.py
@@ -14,6 +14,11 @@ LM_STUDIO_API_KEY_CONFIG_KEY = "LM_STUDIO_API_KEY"
 LITELLM_PROXY_PROVIDER_NAME = "litellm_proxy"
 
 BIFROST_PROVIDER_NAME = "bifrost"
+# Which API surface a Bifrost provider targets; stored in custom_config.
+BIFROST_API_MODE_CONFIG_KEY = "bifrost_api_mode"
+BIFROST_API_MODE_CHAT_COMPLETIONS = "chat_completions"
+BIFROST_API_MODE_RESPONSES = "responses"
+BIFROST_DEFAULT_API_MODE = BIFROST_API_MODE_CHAT_COMPLETIONS
 
 OPENAI_COMPATIBLE_PROVIDER_NAME = "openai_compatible"
 

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -62,6 +62,7 @@ from onyx.llm.well_known_providers.auto_update_service import (
     fetch_llm_recommendations_from_github,
 )
 from onyx.llm.well_known_providers.constants import (
+    BIFROST_API_MODE_CONFIG_KEY,
     LM_STUDIO_API_KEY_CONFIG_KEY,
     VERTEX_AUTH_METHOD_KWARG,
     VERTEX_AUTH_METHOD_SERVICE_ACCOUNT,
@@ -316,9 +317,19 @@ def _validate_llm_provider_change(
     normalized_new_api_base = new_api_base or None
 
     api_base_changed = normalized_new_api_base != normalized_existing_api_base
-    custom_config_changed = (
-        new_custom_config and new_custom_config != existing_custom_config
-    )
+
+    # Surface-mode keys only pick a path on the same api_base and cannot
+    # redirect the stored key, so they must not force key re-entry.
+    def _without_surface_keys(config: dict[str, str] | None) -> dict[str, str]:
+        return {
+            k: v for k, v in (config or {}).items() if k != BIFROST_API_MODE_CONFIG_KEY
+        }
+
+    # Gate on the raw config (empty submissions are never persisted); compare
+    # stripped dicts so dropping stored non-surface entries is still rejected.
+    custom_config_changed = bool(new_custom_config) and _without_surface_keys(
+        new_custom_config
+    ) != _without_surface_keys(existing_custom_config)
 
     if api_base_changed or custom_config_changed:
         raise OnyxError(

--- a/backend/tests/unit/onyx/llm/test_bifrost_routing.py
+++ b/backend/tests/unit/onyx/llm/test_bifrost_routing.py
@@ -1,0 +1,80 @@
+"""Unit tests for Bifrost's two API-mode routing in LitellmLLM.
+
+The surface is selected via a `bifrost_api_mode` value persisted in
+custom_config; the routing difference is the model= string, which drives
+litellm's completions->responses bridge. These tests lock that mapping down.
+"""
+
+from unittest.mock import patch
+
+from onyx.llm.constants import LlmProviderNames
+from onyx.llm.models import LanguageModelInput, UserMessage
+from onyx.llm.multi_llm import LitellmLLM
+from onyx.llm.well_known_providers.constants import BIFROST_API_MODE_CONFIG_KEY
+
+
+def _make_bifrost_llm(
+    mode: str | None,
+    api_base: str = "https://bifrost.example.com/v1",
+    model_name: str = "openai.gpt-5.6-sol",
+) -> LitellmLLM:
+    custom_config = {BIFROST_API_MODE_CONFIG_KEY: mode} if mode is not None else None
+    return LitellmLLM(
+        api_key="bf-test-key",
+        timeout=30,
+        model_provider=LlmProviderNames.BIFROST,
+        model_name=model_name,
+        max_input_tokens=128_000,
+        api_base=api_base,
+        custom_config=custom_config,
+    )
+
+
+def _completion_kwargs(llm: LitellmLLM) -> dict:
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages))
+        return dict(mock_completion.call_args.kwargs)
+
+
+def test_chat_completions_mode_routes_via_openai_with_v1_base() -> None:
+    llm = _make_bifrost_llm("chat_completions")
+    assert llm._custom_llm_provider == "openai"
+    assert llm._api_base == "https://bifrost.example.com/v1"
+
+    kwargs = _completion_kwargs(llm)
+    assert kwargs["custom_llm_provider"] == "openai"
+    assert kwargs["base_url"] == "https://bifrost.example.com/v1"
+    # OpenAI-compatible proxies send a bare model name.
+    assert kwargs["model"] == "openai.gpt-5.6-sol"
+
+
+def test_chat_completions_mode_coerces_bare_base_to_v1() -> None:
+    llm = _make_bifrost_llm("chat_completions", api_base="https://bifrost.example.com")
+    assert llm._api_base == "https://bifrost.example.com/v1"
+
+
+def test_default_mode_is_chat_completions() -> None:
+    # No mode key (every pre-existing provider) -> old behavior preserved.
+    llm = _make_bifrost_llm(None)
+    kwargs = _completion_kwargs(llm)
+    assert kwargs["model"] == "openai.gpt-5.6-sol"
+
+
+def test_unknown_mode_falls_back_to_chat_completions() -> None:
+    llm = _make_bifrost_llm("not-a-real-mode")
+    kwargs = _completion_kwargs(llm)
+    assert kwargs["model"] == "openai.gpt-5.6-sol"
+
+
+def test_responses_mode_prefixes_model_and_keeps_v1_base() -> None:
+    llm = _make_bifrost_llm("responses")
+    assert llm._custom_llm_provider == "openai"
+    assert llm._api_base == "https://bifrost.example.com/v1"
+
+    kwargs = _completion_kwargs(llm)
+    assert kwargs["custom_llm_provider"] == "openai"
+    assert kwargs["base_url"] == "https://bifrost.example.com/v1"
+    # The prefix drives litellm's bridge; it is stripped before the wire call.
+    assert kwargs["model"] == "responses/openai.gpt-5.6-sol"

--- a/backend/tests/unit/onyx/server/manage/llm/test_provider_change_validation.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_provider_change_validation.py
@@ -1,0 +1,80 @@
+"""Tests for _validate_llm_provider_change's custom_config comparison.
+
+Surface-mode keys pick a path on the same api_base, so changing them alone
+must not force key re-entry; everything else still must.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from onyx.error_handling.exceptions import OnyxError
+from onyx.llm.well_known_providers.constants import BIFROST_API_MODE_CONFIG_KEY
+from onyx.server.manage.llm.api import _validate_llm_provider_change
+
+_BASE = "https://bifrost.example.com/v1"
+
+
+def _validate(
+    existing_custom_config: dict[str, str] | None,
+    new_custom_config: dict[str, str] | None,
+    new_api_base: str = _BASE,
+) -> None:
+    _validate_llm_provider_change(
+        existing_api_base=_BASE,
+        existing_custom_config=existing_custom_config,
+        new_api_base=new_api_base,
+        new_custom_config=new_custom_config,
+        api_key_changed=False,
+    )
+
+
+@patch("onyx.server.manage.llm.api.MULTI_TENANT", True)
+def test_surface_mode_only_change_is_allowed() -> None:
+    _validate(None, {BIFROST_API_MODE_CONFIG_KEY: "responses"})
+    _validate(
+        {BIFROST_API_MODE_CONFIG_KEY: "chat_completions"},
+        {BIFROST_API_MODE_CONFIG_KEY: "responses"},
+    )
+
+
+@patch("onyx.server.manage.llm.api.MULTI_TENANT", True)
+def test_mode_change_alongside_unchanged_entries_is_allowed() -> None:
+    _validate(
+        {BIFROST_API_MODE_CONFIG_KEY: "chat_completions", "extra": "kept"},
+        {BIFROST_API_MODE_CONFIG_KEY: "responses", "extra": "kept"},
+    )
+
+
+@patch("onyx.server.manage.llm.api.MULTI_TENANT", True)
+def test_other_custom_config_change_still_rejected() -> None:
+    with pytest.raises(OnyxError):
+        _validate(
+            {BIFROST_API_MODE_CONFIG_KEY: "responses"},
+            {BIFROST_API_MODE_CONFIG_KEY: "responses", "some_credential": "x"},
+        )
+
+
+@patch("onyx.server.manage.llm.api.MULTI_TENANT", True)
+def test_mode_only_submission_dropping_stored_entries_is_rejected() -> None:
+    # The submitted dict is persisted wholesale; dropped entries must reject.
+    with pytest.raises(OnyxError):
+        _validate(
+            {BIFROST_API_MODE_CONFIG_KEY: "chat_completions", "extra": "stored"},
+            {BIFROST_API_MODE_CONFIG_KEY: "responses"},
+        )
+
+
+@patch("onyx.server.manage.llm.api.MULTI_TENANT", True)
+def test_api_base_change_still_rejected() -> None:
+    with pytest.raises(OnyxError):
+        _validate(
+            {BIFROST_API_MODE_CONFIG_KEY: "responses"},
+            {BIFROST_API_MODE_CONFIG_KEY: "responses"},
+            new_api_base="https://attacker.example.com/v1",
+        )
+
+
+def test_single_tenant_skips_validation() -> None:
+    # MULTI_TENANT is False in unit tests: everything passes.
+    _validate(None, {"anything": "goes"})

--- a/web/src/lib/languageModels/types.ts
+++ b/web/src/lib/languageModels/types.ts
@@ -48,6 +48,8 @@ export enum LLMProviderName {
   CUSTOM = "custom",
 }
 
+export type BifrostApiMode = "chat_completions" | "responses";
+
 export interface SimpleKnownModel {
   name: string;
   display_name: string | null;

--- a/web/src/sections/modals/languageModels/BifrostModal.tsx
+++ b/web/src/sections/modals/languageModels/BifrostModal.tsx
@@ -4,7 +4,9 @@ import { markdown } from "@opal/utils";
 import { useSWRConfig } from "swr";
 import { useFormikContext } from "formik";
 import { InputDivider, toast } from "@opal/layouts";
+import { Tabs, Text } from "@opal/components";
 import {
+  BifrostApiMode,
   LLMProviderFormProps,
   LLMProviderName,
   LLMProviderView,
@@ -28,6 +30,26 @@ import {
 } from "@/sections/modals/languageModels/shared";
 import { refreshLlmProviderCaches } from "@/lib/languageModels/cache";
 
+const DEFAULT_API_MODE: BifrostApiMode = "chat_completions";
+const BIFROST_API_MODE_KEY = "bifrost_api_mode";
+
+const API_MODE_TABS: {
+  value: BifrostApiMode;
+  title: string;
+  subtitle: string;
+}[] = [
+  {
+    value: "chat_completions",
+    title: "Chat Completions API",
+    subtitle: "/v1/chat/completions",
+  },
+  {
+    value: "responses",
+    title: "Responses API",
+    subtitle: "/v1/responses",
+  },
+];
+
 interface BifrostModalValues extends BaseLLMFormValues {
   api_key: string;
   api_base: string;
@@ -43,6 +65,12 @@ function BifrostModalInternals({
   isOnboarding,
 }: BifrostModalInternalsProps) {
   const formikProps = useFormikContext<BifrostModalValues>();
+  const { setFieldValue, values } = formikProps;
+
+  const mode =
+    (values.custom_config?.[BIFROST_API_MODE_KEY] as
+      | BifrostApiMode
+      | undefined) ?? DEFAULT_API_MODE;
 
   const isFetchDisabled = !formikProps.values.api_base;
 
@@ -66,6 +94,31 @@ function BifrostModalInternals({
 
   return (
     <>
+      <Tabs
+        value={mode}
+        onValueChange={(next) =>
+          setFieldValue("custom_config", {
+            ...values.custom_config,
+            [BIFROST_API_MODE_KEY]: next as BifrostApiMode,
+          })
+        }
+      >
+        <Tabs.List>
+          {API_MODE_TABS.map((tab) => (
+            <Tabs.Trigger key={tab.value} value={tab.value}>
+              <div className="flex flex-col items-start">
+                <Text font="main-ui-action" color="inherit">
+                  {tab.title}
+                </Text>
+                <Text font="secondary-body" color="text-03">
+                  {tab.subtitle}
+                </Text>
+              </div>
+            </Tabs.Trigger>
+          ))}
+        </Tabs.List>
+      </Tabs>
+
       <APIBaseField
         subDescription="Paste your Bifrost gateway endpoint URL (including API version)."
         placeholder="https://your-bifrost-gateway.com/v1"
@@ -119,6 +172,17 @@ export default function BifrostModal({
     LLMProviderName.BIFROST,
     existingLlmProvider
   ) as BifrostModalValues;
+
+  // useInitialValues drops custom_config, so seed it for submitProvider's
+  // custom_config_changed diff, preserving any other stored entries.
+  const initialMode =
+    (existingLlmProvider?.custom_config?.[BIFROST_API_MODE_KEY] as
+      | BifrostApiMode
+      | undefined) ?? DEFAULT_API_MODE;
+  initialValues.custom_config = {
+    ...existingLlmProvider?.custom_config,
+    [BIFROST_API_MODE_KEY]: initialMode,
+  };
 
   const validationSchema = buildValidationSchema(isOnboarding, {
     apiBase: true,


### PR DESCRIPTION
## Description

Backport of the Bifrost admin-selectable API mode (#13642) to `release/v4.4`, for a customer whose Bifrost gateway exposes Responses-API-only models (Bedrock GPT-5.6 family) that fail on the chat-completions surface.

This is a **minimal hand-port, Bifrost only** — it does NOT bring the #12965 API-surface machinery (or the Portkey provider) to v4.4. Single commit, 7 files, +254/−3:

- `bifrost_api_mode` custom_config key (`chat_completions` | `responses`); when set to `responses` on a Bifrost provider, the model is sent as `responses/<model>`, driving LiteLLM's completions→responses bridge to `POST <base>/v1/responses` (prefix stripped on the wire).
- Mode tabs in `BifrostModal.tsx` + `BifrostApiMode` type.
- The mode key is exempt from the multi-tenant custom-config-change guard (it picks a path on the same `api_base`); submissions dropping other stored entries are still rejected.
- Default stays `chat_completions` and existing providers have no mode key — behavior unchanged on upgrade, no migration.

Differences vs main's implementation (main routes via the #12965 `_SELECTABLE_SURFACES` registry; v4.4 lacks it): the mode check lives inline in `multi_llm.py`'s existing `is_openai_compatible_proxy` branch, and the guard exemption uses the Bifrost key directly. The env-injection exemption from main doesn't apply — v4.4 has no UI-only config filtering, so the mode key harmlessly rides along in `temporary_env_and_lock` like every other custom_config key.

## How Has This Been Tested?

- `test_bifrost_routing.py` (adapted to v4.4: behavioral asserts on the litellm kwargs) and `test_provider_change_validation.py` — 11 passed on this branch.
- The mechanics were E2E-verified for #13642 on main (mock responses-only gateway reproducing the exact customer error, then real Bifrost gateway, both modes); the `responses/<model>` + `custom_llm_provider=openai` path was additionally verified against v4.4's `multi_llm.py` shape and its litellm 1.93.0 pin (bridge present) during the original investigation.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)