### PR TITLE
fix(llm): harden litellm responses bridge for gateway streaming variants (#13668) to release v4.5

### DIFF
--- a/backend/onyx/llm/litellm_singleton/monkey_patches.py
+++ b/backend/onyx/llm/litellm_singleton/monkey_patches.py
@@ -20,7 +20,15 @@ Status checked against LiteLLM v1.93.0 (2026-07-20):
    - LiteLLM passes through reasoning_summary_text.delta content as-is without
      separating different summary_index sections
    - Our patch inserts "\\n\\n" when the summary_index changes
-   STATUS: STILL NEEDED - Upstream does not insert separators between summary sections.
+   - Also normalizes terminal events (response.completed/incomplete/failed)
+     whose response carries "output": null (newer Bifrost gateways, e.g.
+     fronting Bedrock) — upstream iterates output and raises TypeError
+   - Also turns empty function_call_arguments.delta events into no-op chunks;
+     Anthropic-backed gateways open tool-call streams with an empty delta and
+     upstream raises ValueError on falsy deltas
+   STATUS: STILL NEEDED - Upstream does not insert separators between summary sections,
+           does not guard against null output in terminal events, and rejects empty
+           tool-argument deltas.
 
 3. OpenAI Responses API Non-Streaming (_patch_openai_responses_transform_response):
    - LiteLLM's transform_response joins multiple reasoning summary parts with spaces
@@ -56,7 +64,21 @@ Status checked against LiteLLM v1.93.0 (2026-07-20):
    STATUS: STILL NEEDED - Upstream still mutates result.response.usage in place via
          setattr in v1.93.0. Our patch rebuilds the response via model_construct so the
          original ResponseAPIUsage object is preserved. Handles ResponseCompletedEvent,
-         ResponseIncompleteEvent, and ResponseFailedEvent (matching upstream).
+         ResponseIncompleteEvent, and ResponseFailedEvent (matching upstream), and
+         tolerates result.response being a plain dict (validation-fallback payloads
+         from gateways whose responses litellm cannot strictly parse).
+
+7. Explicit responses/ Prefix Ignored (_patch_responses_api_bridge_check):
+   - responses_api_bridge_check only engages the completions->responses bridge when
+     the model is unknown to LiteLLM's registry (model_info mode is None / lookup
+     raises). Gateway model ids like "anthropic/claude-haiku-4-5" resolve in the
+     registry (valid provider prefix + known tail, mode "chat"), so an explicit
+     "responses/" prefix is left attached and the request is sent to
+     /chat/completions with the mangled model name
+   - The prefix is only ever set deliberately (Onyx API-surface routing for
+     OpenAI-compatible gateways such as Bifrost and Portkey), so honor it
+     unconditionally and pass the remainder through as the literal model id
+   STATUS: STILL NEEDED - v1.93.0 consults the registry before honoring the prefix.
 """
 
 import time
@@ -291,6 +313,30 @@ def _patch_responses_reasoning_summary_newlines() -> None:
                         )
                     ]
                 )
+
+        # Gateways may open tool-call streams with an empty arguments delta;
+        # upstream raises on falsy deltas, so emit a no-op chunk instead.
+        if event_type == "response.function_call_arguments.delta" and not (
+            isinstance(parsed_chunk, dict) and parsed_chunk.get("delta")
+        ):
+            return ModelResponseStream(
+                choices=[StreamingChoices(index=0, delta=Delta(), finish_reason=None)]
+            )
+
+        # Terminal events may carry "output": null, which upstream iterates.
+        if (
+            event_type
+            in (
+                "response.completed",
+                "response.incomplete",
+                "response.failed",
+            )
+            and isinstance(parsed_chunk, dict)
+            and isinstance(parsed_chunk.get("response"), dict)
+            and parsed_chunk["response"].get("output") is None
+        ):
+            parsed_chunk["response"]["output"] = []
+            chunk = parsed_chunk
 
         # For all other event types, use the original upstream chunk_parser
         return _original_responses_chunk_parser(self, chunk)
@@ -545,15 +591,30 @@ def _patch_logging_assembled_streaming_response() -> None:
             result,
             (ResponseCompletedEvent, ResponseIncompleteEvent, ResponseFailedEvent),
         ):
-            # Get the original response data
+            # result.response stays a plain dict when the payload failed
+            # litellm's strict validation; handle both shapes.
             original_response = result.response
-            response_data = original_response.model_dump()
+            if isinstance(original_response, dict):
+                response_data = dict(original_response)
+                raw_usage = original_response.get("usage")
+                usage: ResponseAPIUsage | None = (
+                    ResponseAPIUsage.model_construct(**raw_usage)
+                    if isinstance(raw_usage, dict) and "input_tokens" in raw_usage
+                    else None
+                )
+            else:
+                response_data = original_response.model_dump()
+                usage = (
+                    original_response.usage
+                    if isinstance(original_response.usage, ResponseAPIUsage)
+                    else None
+                )
 
             # Transform usage if present
-            if isinstance(original_response.usage, ResponseAPIUsage):
+            if usage is not None:
                 transformed_usage = (
                     ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
-                        original_response.usage
+                        usage
                     )
                 )
                 # Put the transformed usage (in chat completion format) into response_data
@@ -583,6 +644,52 @@ def _patch_logging_assembled_streaming_response() -> None:
     )
 
 
+def _patch_responses_api_bridge_check() -> None:
+    """
+    Patches litellm.main.responses_api_bridge_check to honor an explicit
+    "responses/" model prefix unconditionally.
+
+    Upstream only bridges when its registry doesn't recognize the model, so
+    gateway ids like "anthropic/claude-haiku-4-5" (valid provider prefix +
+    registry-known tail) skip the bridge and hit /chat/completions with the
+    prefix still attached. The prefix is only ever set deliberately, so it
+    always wins; the remainder passes through as the literal model id.
+    """
+    import litellm.main as litellm_main
+
+    if (
+        getattr(litellm_main.responses_api_bridge_check, "__name__", "")
+        == "_patched_responses_api_bridge_check"
+    ):
+        return
+
+    original_bridge_check = litellm_main.responses_api_bridge_check
+
+    def _patched_responses_api_bridge_check(
+        model: str,
+        custom_llm_provider: str,
+        web_search_options: Optional[Any] = None,
+        tools: Optional[list[Any]] = None,
+        reasoning_effort: Optional[Any] = None,
+        reasoning_summary: Optional[Any] = None,
+    ) -> tuple[dict, str]:
+        if model.startswith("responses/"):
+            return {"mode": "responses"}, model.removeprefix("responses/")
+        return original_bridge_check(
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            web_search_options=web_search_options,
+            tools=tools,
+            reasoning_effort=reasoning_effort,
+            reasoning_summary=reasoning_summary,
+        )
+
+    _patched_responses_api_bridge_check.__name__ = "_patched_responses_api_bridge_check"
+    litellm_main.responses_api_bridge_check = (  # ty: ignore[invalid-assignment]
+        _patched_responses_api_bridge_check
+    )
+
+
 def apply_monkey_patches() -> None:
     """
     Apply all necessary monkey patches to LiteLLM for compatibility.
@@ -594,6 +701,7 @@ def apply_monkey_patches() -> None:
     - Patching AzureOpenAIResponsesAPIConfig.should_fake_stream to enable native streaming
     - Patching ResponsesAPIResponse.model_construct to fix usage format in all code paths
     - Patching Logging._get_assembled_streaming_response to avoid mutating original response
+    - Patching responses_api_bridge_check to always honor an explicit responses/ prefix
     """
     _patch_ollama_chunk_parser()
     _patch_responses_reasoning_summary_newlines()
@@ -601,3 +709,4 @@ def apply_monkey_patches() -> None:
     _patch_azure_responses_should_fake_stream()
     _patch_responses_api_usage_format()
     _patch_logging_assembled_streaming_response()
+    _patch_responses_api_bridge_check()

--- a/backend/tests/unit/onyx/llm/test_litellm_monkey_patches.py
+++ b/backend/tests/unit/onyx/llm/test_litellm_monkey_patches.py
@@ -1,8 +1,9 @@
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 
 from litellm.completion_extras.litellm_responses_transformation.transformation import (
     LiteLLMResponsesTransformationHandler,
+    OpenAiResponsesToChatCompletionStreamIterator,
 )
 from litellm.litellm_core_utils.litellm_logging import Logging
 from litellm.llms.ollama.chat.transformation import OllamaChatCompletionResponseIterator
@@ -189,3 +190,112 @@ def test_responses_transform_response_preserves_reasoning_summary_sections() -> 
     assert (
         result.choices[0].message.reasoning_content == "first section\n\nsecond section"
     )
+
+
+def _minimal_completed_response_dict() -> dict[str, Any]:
+    return {
+        "id": "resp_dict_1",
+        "object": "response",
+        "created_at": 0,
+        "status": "completed",
+        "model": "m",
+        "output": None,
+        "usage": {"input_tokens": 5, "output_tokens": 3, "total_tokens": 8},
+    }
+
+
+def test_responses_chunk_parser_normalizes_null_output_on_completed() -> None:
+    apply_monkey_patches()
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(
+        streaming_response=iter(()),
+        sync_stream=True,
+    )
+    parsed = iterator.chunk_parser(
+        {
+            "type": "response.completed",
+            "sequence_number": 9,
+            "response": _minimal_completed_response_dict(),
+        }
+    )
+    assert parsed.choices[0].finish_reason == "stop"
+
+
+def test_responses_chunk_parser_ignores_empty_tool_argument_delta() -> None:
+    apply_monkey_patches()
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(
+        streaming_response=iter(()),
+        sync_stream=True,
+    )
+    empty = iterator.chunk_parser(
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "toolu_1",
+            "output_index": 0,
+            "delta": "",
+            "sequence_number": 4,
+        }
+    )
+    assert empty.choices[0].delta.tool_calls is None
+
+    real = iterator.chunk_parser(
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "toolu_1",
+            "output_index": 0,
+            "delta": '{"query": "onboarding"}',
+            "sequence_number": 5,
+        }
+    )
+    tool_calls = real.choices[0].delta.tool_calls
+    assert tool_calls is not None
+    assert tool_calls[0].function.arguments == '{"query": "onboarding"}'
+
+
+def test_assembled_streaming_response_handles_dict_response() -> None:
+    from types import SimpleNamespace
+
+    from litellm.types.llms.openai import ResponseCompletedEvent
+
+    apply_monkey_patches()
+    event = ResponseCompletedEvent.model_construct(
+        type="response.completed",
+        response=_minimal_completed_response_dict(),
+    )
+    get_assembled = cast(Any, Logging._get_assembled_streaming_response)
+    assembled = get_assembled(
+        SimpleNamespace(stream=True),
+        event,
+        None,
+        None,
+        False,
+        [],
+    )
+    assert isinstance(assembled, ResponsesAPIResponse)
+    assert assembled.usage is not None
+    assert assembled.usage.input_tokens == 5
+    assert assembled.usage.output_tokens == 3
+
+
+def test_bridge_check_honors_prefix_for_registry_known_models() -> None:
+    # Registry-known compound ids must still bridge when the prefix is explicit.
+    import litellm.main as litellm_main
+
+    apply_monkey_patches()
+    model_info, model = litellm_main.responses_api_bridge_check(
+        model="responses/anthropic/claude-haiku-4-5",
+        custom_llm_provider="openai",
+    )
+    assert model_info["mode"] == "responses"
+    assert model == "anthropic/claude-haiku-4-5"
+
+
+def test_bridge_check_delegates_without_prefix() -> None:
+    import litellm.main as litellm_main
+
+    apply_monkey_patches()
+    model_info, model = litellm_main.responses_api_bridge_check(
+        model="gpt-4o",
+        custom_llm_provider="openai",
+    )
+    assert model_info.get("mode") != "responses"
+    assert model == "gpt-4o"


### PR DESCRIPTION
## Description

Clean cherry-pick of #13668 to `release/v4.5`. Companion to #13675 (the Bifrost API-mode selector) — without it, v4.5.0 ships responses mode where tool-using chats fail against Anthropic-style gateway streams, compound `provider/model` ids skip the bridge, and current-Bifrost terminal payloads crash chunk translation. Also fixes the same latent issues for Portkey's responses mode.

- Explicit `responses/` model prefix always engages the completions→responses bridge.
- Terminal events with `"output": null` no longer crash chunk translation.
- Dict-shaped terminal responses (strict-validation fallback payloads) handled.
- Empty `function_call_arguments.delta` events treated as no-ops.

## How Has This Been Tested?

- All 10 `test_litellm_monkey_patches.py` tests pass on this branch.
- On main, each fix was reproduced as a live E2E failure first (real Bifrost gateways — old build via bifrost.onyx.app and current build fronting AWS Bedrock), then verified green through Onyx chat including the full tool loop; regression-checked against real OpenAI responses-bridge external-dependency tests (6/6).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the `litellm` responses bridge and streaming parsers so gateway streaming variants (Anthropic-style via `Bifrost`, Bedrock, `Portkey`) work reliably in v4.5. Ensures explicit `responses/` models route through the bridge and prevents crashes in tool-call and terminal events.

- **Bug Fixes**
  - Always honor an explicit `responses/` model prefix; engages the bridge and forwards the remainder as the model id (e.g., `anthropic/claude-haiku-4-5`).
  - Normalize terminal events with `"output": null` to an empty list to avoid chunk translation crashes.
  - Treat empty `response.function_call_arguments.delta` as no-ops to prevent tool-call stream errors.
  - Handle dict-shaped terminal responses (validation fallback) when assembling the final response and usage.

<sup>Written for commit 719d4c050ffc0976ccfd6560f701ec443483a6c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

