### PR TITLE
fix(admin): collapse LLM provider cards to one column on small screens

### DIFF
--- a/web/src/views/admin/LanguageModelsPage.tsx
+++ b/web/src/views/admin/LanguageModelsPage.tsx
@@ -472,7 +472,7 @@ export default function LanguageModelsPage() {
 
         {/* ── Add Provider groups (always visible) ── */}
         <Disabled disabled={isConfigurationDisabled}>
-          <div className="flex flex-col gap-8">
+          <div className="@container/providercards flex flex-col gap-8">
             {PROVIDER_GROUPS.map((group) => (
               <GeneralLayouts.Section
                 key={group.title}
@@ -494,7 +494,7 @@ export default function LanguageModelsPage() {
                   </Text>
                 )}
 
-                <div className="grid grid-cols-2 gap-2">
+                <div className="grid grid-cols-1 @xl/providercards:grid-cols-2 gap-2">
                   {group.providerNames.map((name) => (
                     <NewProviderCard
                       key={name}


### PR DESCRIPTION
## Description

The "Add Provider" card grids on `/admin/configuration/language-models` were fixed at two columns (`grid grid-cols-2`), which gets cramped on small screens. This makes them collapse to a single column when the content area is narrow, matching the onboarding flow's behavior.

The section wrapper is now a named Tailwind container (`@container/providercards`) and each group's grid is `grid-cols-1` by default, switching to two columns at the `@xl` (576px) container breakpoint — the same breakpoint the onboarding `LLMStep` uses for its provider cards. Container queries respond to actual content width rather than the viewport, which matters here since the admin sidebar changes how much room the content gets.

## How Has This Been Tested?

Verified in the running app at three viewport widths:

- 1440px — two-column grid, unchanged from before
- 700px — still two columns (content area is above the 576px threshold once the sidebar becomes an overlay)
- 540px — single column of full-width cards

`pre-commit` (oxfmt, oxlint, TypeScript type check) passes on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**before**
<img width="1902" height="2085" alt="20260731_15h40m32s_grim" src="https://github.com/user-attachments/assets/a869447b-9f05-45f9-9f14-baace9c21adc" />


**after**
<img width="1902" height="2085" alt="20260731_15h40m04s_grim" src="https://github.com/user-attachments/assets/d5a7bb37-7b00-40c9-ab57-454aed69434f" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapse the “Add Provider” cards on `/admin/configuration/language-models` to a single column on narrow content areas to improve readability. Uses a named Tailwind container with a container query (`@xl/providercards`) so grids are 1 column by default and switch to 2 columns at 576px, matching the onboarding flow.

<sup>Written for commit c7c6441ea41aad8dc13a66f2386245d30df88abb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

