### PR TITLE
feat(metrics): publish tenant count per shard

### DIFF
--- a/backend/onyx/background/celery/apps/monitoring.py
+++ b/backend/onyx/background/celery/apps/monitoring.py
@@ -89,17 +89,28 @@ def _setup_prometheus_collectors(sender: Any) -> bool:
 
         setup_indexing_pipeline_metrics(sender.app)
         logger.info("Prometheus indexing pipeline collectors registered")
+        return True
+    except Exception:
+        logger.exception("Failed to register Prometheus indexing pipeline collectors")
+        return False
 
+
+def _setup_shard_capacity_collector() -> None:
+    """Register the shard capacity collector.
+
+    Isolated from the indexing-pipeline registration on purpose: that one gates
+    `start_metrics_server`, so letting a failure here fall into its handler would take
+    every metric off this worker rather than just this collector's.
+    """
+    try:
         from prometheus_client.registry import REGISTRY
 
         from onyx.server.metrics.shard_capacity import ShardCapacityCollector
 
         REGISTRY.register(ShardCapacityCollector())
         logger.info("Prometheus shard capacity collector registered")
-        return True
     except Exception:
-        logger.exception("Failed to register Prometheus indexing pipeline collectors")
-        return False
+        logger.exception("Failed to register the Prometheus shard capacity collector")
 
 
 @worker_ready.connect
@@ -107,6 +118,7 @@ def on_worker_ready(sender: Any, **kwargs: Any) -> None:
     if _prometheus_collectors_ok:
         from onyx.server.metrics.metrics_server import start_metrics_server
 
+        _setup_shard_capacity_collector()
         start_metrics_server("monitoring")
     else:
         logger.warning(

--- a/backend/onyx/background/celery/apps/monitoring.py
+++ b/backend/onyx/background/celery/apps/monitoring.py
@@ -89,6 +89,13 @@ def _setup_prometheus_collectors(sender: Any) -> bool:
 
         setup_indexing_pipeline_metrics(sender.app)
         logger.info("Prometheus indexing pipeline collectors registered")
+
+        from prometheus_client.registry import REGISTRY
+
+        from onyx.server.metrics.shard_capacity import ShardCapacityCollector
+
+        REGISTRY.register(ShardCapacityCollector())
+        logger.info("Prometheus shard capacity collector registered")
         return True
     except Exception:
         logger.exception("Failed to register Prometheus indexing pipeline collectors")

--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -33,7 +33,10 @@ from onyx.db.engine.sql_engine import (
     get_session_with_current_tenant,
     get_session_with_shared_schema,
 )
-from onyx.db.engine.tenant_utils import get_all_tenant_ids, validate_tenant_id
+from onyx.db.engine.tenant_utils import (
+    get_all_tenant_ids,
+    validate_tenant_id,
+)
 from onyx.db.engine.time_utils import get_db_current_time
 from onyx.db.enums import IndexingStatus, SyncStatus, SyncType
 from onyx.db.models import (

--- a/backend/onyx/db/engine/tenant_utils.py
+++ b/backend/onyx/db/engine/tenant_utils.py
@@ -141,6 +141,16 @@ def _tenant_schemas_on(engine: Engine) -> list[str]:
         return [row[0] for row in result if validate_tenant_id(row[0])]
 
 
+def count_tenant_schemas_on_shard(shard_name: str) -> int:
+    """How many tenant schemas one shard is holding.
+
+    Counted per shard rather than through `get_tenant_ids_by_shard` so a caller can
+    isolate a failure to the shard that caused it, instead of losing every count when
+    one database is unreachable.
+    """
+    return len(_tenant_schemas_on(get_engine_for_shard(shard_name)))
+
+
 def get_tenant_ids_by_shard() -> dict[str, list[str]]:
     """Tenant schemas on each configured shard, keyed by shard name.
 

--- a/backend/onyx/server/metrics/shard_capacity.py
+++ b/backend/onyx/server/metrics/shard_capacity.py
@@ -42,24 +42,27 @@ class ShardCapacityCollector(Collector):
         self._expires_at = 0.0
 
     def _tenant_counts(self) -> dict[str, int]:
+        # The refresh runs under the lock, not just the cache read. Releasing it around
+        # the scan would let concurrent scrapes each run their own, and let a slower
+        # older refresh overwrite a newer result on the way out. A scrape that arrives
+        # mid-refresh waits and then reads the fresh value.
         with self._lock:
             if time.monotonic() < self._expires_at:
                 return self._counts
 
-        counts: dict[str, int] = {}
-        for shard_name in sorted(get_shard_specs()):
-            try:
-                counts[shard_name] = count_tenant_schemas_on_shard(shard_name)
-            except Exception:
-                # Per shard: one unreachable database must not suppress the others.
-                # A capacity alert that goes blank during an unrelated outage is worse
-                # than one missing a single series.
-                logger.exception("Failed counting tenants on shard %s", shard_name)
+            counts: dict[str, int] = {}
+            for shard_name in sorted(get_shard_specs()):
+                try:
+                    counts[shard_name] = count_tenant_schemas_on_shard(shard_name)
+                except Exception:
+                    # Per shard: one unreachable database must not suppress the others.
+                    # A capacity alert that goes blank during an unrelated outage is
+                    # worse than one missing a single series.
+                    logger.exception("Failed counting tenants on shard %s", shard_name)
 
-        with self._lock:
             self._counts = counts
             self._expires_at = time.monotonic() + self._ttl
-        return counts
+            return counts
 
     def collect(self) -> Iterator[Metric]:
         gauge = GaugeMetricFamily(

--- a/backend/onyx/server/metrics/shard_capacity.py
+++ b/backend/onyx/server/metrics/shard_capacity.py
@@ -1,0 +1,73 @@
+"""How many tenant schemas each physical database is holding.
+
+Schema-per-tenant is bounded by catalog size rather than disk: every tenant adds
+~110 tables, so the table count — and with it migration wall-clock and autovacuum
+pressure — scales with tenants, not bytes. This is the signal for when to move new
+signups onto another shard.
+"""
+
+import threading
+import time
+from collections.abc import Iterator
+
+from prometheus_client.core import GaugeMetricFamily, Metric
+from prometheus_client.registry import Collector
+
+from onyx.db.engine.shard_registry import get_shard_specs
+from onyx.db.engine.tenant_utils import count_tenant_schemas_on_shard
+from onyx.utils.logger import setup_logger
+from shared_configs.configs import MULTI_TENANT
+
+logger = setup_logger()
+
+_CACHE_TTL_SECONDS = 300.0
+
+
+class ShardCapacityCollector(Collector):
+    """Publishes the tenant count per shard, computed on scrape.
+
+    Deliberately not a periodic task. Beat dispatches a task to exactly one worker,
+    so only that replica's process would hold the value while the other monitoring
+    pods published nothing — and replacing that pod would blank the series until the
+    next run. Collecting on scrape keeps every replica current, so the alert cannot
+    go blind on a rollout.
+
+    Cached so the scrape interval does not drive database load.
+    """
+
+    def __init__(self, ttl_seconds: float = _CACHE_TTL_SECONDS) -> None:
+        self._ttl = ttl_seconds
+        self._lock = threading.Lock()
+        self._counts: dict[str, int] = {}
+        self._expires_at = 0.0
+
+    def _tenant_counts(self) -> dict[str, int]:
+        with self._lock:
+            if time.monotonic() < self._expires_at:
+                return self._counts
+
+        counts: dict[str, int] = {}
+        for shard_name in sorted(get_shard_specs()):
+            try:
+                counts[shard_name] = count_tenant_schemas_on_shard(shard_name)
+            except Exception:
+                # Per shard: one unreachable database must not suppress the others.
+                # A capacity alert that goes blank during an unrelated outage is worse
+                # than one missing a single series.
+                logger.exception("Failed counting tenants on shard %s", shard_name)
+
+        with self._lock:
+            self._counts = counts
+            self._expires_at = time.monotonic() + self._ttl
+        return counts
+
+    def collect(self) -> Iterator[Metric]:
+        gauge = GaugeMetricFamily(
+            "onyx_shard_tenant_count",
+            "Tenant schemas physically present on a shard",
+            labels=["shard"],
+        )
+        if MULTI_TENANT:
+            for shard_name, count in self._tenant_counts().items():
+                gauge.add_metric([shard_name], count)
+        yield gauge

--- a/backend/tests/external_dependency_unit/db/test_shard_capacity_metric.py
+++ b/backend/tests/external_dependency_unit/db/test_shard_capacity_metric.py
@@ -5,31 +5,28 @@ physically live — a mapping that disagrees with reality must not be able to hi
 capacity from the alert.
 """
 
+import time
 from collections.abc import Generator
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from uuid import uuid4
 
 import pytest
-from sqlalchemy import create_engine, text
-from sqlalchemy.engine import Engine
 from sqlalchemy.exc import OperationalError
 
 from onyx.db.engine import shard_registry, shard_routing, tenant_utils
 from onyx.db.engine.shard_registry import get_engine_for_shard
 from onyx.db.engine.shard_routing import invalidate_shard_cache
-from onyx.db.engine.sql_engine import SYNC_DB_API, SqlEngine, build_connection_string
+from onyx.db.engine.sql_engine import SqlEngine
 from onyx.server.metrics import shard_capacity
 from onyx.server.metrics.shard_capacity import ShardCapacityCollector
+from tests.external_dependency_unit.db.shard_test_utils import (
+    DEFAULT_SHARD,
+    create_schema,
+    drop_schema,
+)
 
-DEFAULT_SHARD = "default"
 SECOND_SHARD = "shard-test-b"
-
-
-def _admin_engine() -> Engine:
-    return create_engine(
-        build_connection_string(db_api=SYNC_DB_API, db="postgres"),
-        isolation_level="AUTOCOMMIT",
-    )
 
 
 def _counts(collector: ShardCapacityCollector) -> dict[str, float]:
@@ -39,27 +36,6 @@ def _counts(collector: ShardCapacityCollector) -> dict[str, float]:
         for metric in collector.collect()
         for sample in metric.samples
     }
-
-
-@pytest.fixture(scope="module")
-def second_database() -> Generator[str, None, None]:
-    db_name = f"onyx_capacity_test_{uuid4().hex[:8]}"
-    admin = _admin_engine()
-    with admin.connect() as conn:
-        conn.execute(text(f'CREATE DATABASE "{db_name}"'))
-    try:
-        yield db_name
-    finally:
-        with admin.connect() as conn:
-            conn.execute(
-                text(
-                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
-                    "WHERE datname = :db AND pid <> pg_backend_pid()"
-                ),
-                {"db": db_name},
-            )
-            conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
-        admin.dispose()
 
 
 @pytest.fixture(scope="function")
@@ -85,18 +61,14 @@ def two_shards(
     yield {"created": created}
 
     for shard, tenant_id in created:
-        with get_engine_for_shard(shard).connect() as conn:
-            conn.execute(text(f'DROP SCHEMA IF EXISTS "{tenant_id}" CASCADE'))
-            conn.commit()
+        drop_schema(get_engine_for_shard(shard), tenant_id)
     shard_registry.reset_shard_specs()
     invalidate_shard_cache()
 
 
 def _make_tenant(two_shards: dict[str, Any], shard: str) -> str:
     tenant_id = f"tenant_{uuid4()}"
-    with get_engine_for_shard(shard).connect() as conn:
-        conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{tenant_id}"'))
-        conn.commit()
+    create_schema(get_engine_for_shard(shard), tenant_id)
     two_shards["created"].append((shard, tenant_id))
     return tenant_id
 
@@ -154,6 +126,32 @@ def test_an_unreachable_shard_does_not_suppress_the_others(
     counts = _counts(ShardCapacityCollector())
 
     assert counts == {SECOND_SHARD: 7}
+
+
+def test_concurrent_scrapes_refresh_once(
+    two_shards: dict[str, Any],  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prometheus can scrape a replica while a refresh is in flight. Without the lock
+    held across the scan, each scrape runs its own, and a slower older one can overwrite
+    a newer result on the way out."""
+    scans = 0
+
+    def _count(shard_name: str) -> int:  # noqa: ARG001
+        nonlocal scans
+        scans += 1
+        time.sleep(0.05)
+        return 3
+
+    monkeypatch.setattr(shard_capacity, "count_tenant_schemas_on_shard", _count)
+    collector = ShardCapacityCollector()
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(lambda _: _counts(collector), range(4)))
+
+    # Two shards, scanned once each — not once per concurrent scrape.
+    assert scans == 2
+    assert all(r == results[0] for r in results)
 
 
 def test_no_series_outside_multi_tenant_mode(

--- a/backend/tests/external_dependency_unit/db/test_shard_capacity_metric.py
+++ b/backend/tests/external_dependency_unit/db/test_shard_capacity_metric.py
@@ -1,0 +1,165 @@
+"""The per-shard tenant count that drives the capacity alert.
+
+Counted against two real databases, because the value has to reflect where schemas
+physically live — a mapping that disagrees with reality must not be able to hide
+capacity from the alert.
+"""
+
+from collections.abc import Generator
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import OperationalError
+
+from onyx.db.engine import shard_registry, shard_routing, tenant_utils
+from onyx.db.engine.shard_registry import get_engine_for_shard
+from onyx.db.engine.shard_routing import invalidate_shard_cache
+from onyx.db.engine.sql_engine import SYNC_DB_API, SqlEngine, build_connection_string
+from onyx.server.metrics import shard_capacity
+from onyx.server.metrics.shard_capacity import ShardCapacityCollector
+
+DEFAULT_SHARD = "default"
+SECOND_SHARD = "shard-test-b"
+
+
+def _admin_engine() -> Engine:
+    return create_engine(
+        build_connection_string(db_api=SYNC_DB_API, db="postgres"),
+        isolation_level="AUTOCOMMIT",
+    )
+
+
+def _counts(collector: ShardCapacityCollector) -> dict[str, float]:
+    """Sample the collector directly rather than through the global registry."""
+    return {
+        sample.labels["shard"]: sample.value
+        for metric in collector.collect()
+        for sample in metric.samples
+    }
+
+
+@pytest.fixture(scope="module")
+def second_database() -> Generator[str, None, None]:
+    db_name = f"onyx_capacity_test_{uuid4().hex[:8]}"
+    admin = _admin_engine()
+    with admin.connect() as conn:
+        conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+    try:
+        yield db_name
+    finally:
+        with admin.connect() as conn:
+            conn.execute(
+                text(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = :db AND pid <> pg_backend_pid()"
+                ),
+                {"db": db_name},
+            )
+            conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+        admin.dispose()
+
+
+@pytest.fixture(scope="function")
+def two_shards(
+    second_database: str, monkeypatch: pytest.MonkeyPatch
+) -> Generator[dict[str, Any], None, None]:
+    SqlEngine.init_engine(pool_size=5, max_overflow=2)
+
+    shards_json = f'{{"{SECOND_SHARD}": {{"db": "{second_database}"}}}}'
+    monkeypatch.setattr(shard_registry, "ONYX_DB_SHARDS_JSON", shards_json)
+    monkeypatch.setattr(shard_registry, "ONYX_DB_DEFAULT_SHARD", DEFAULT_SHARD)
+    monkeypatch.setattr(shard_registry, "ONYX_DB_CATALOG_SHARD", DEFAULT_SHARD)
+    monkeypatch.setattr(shard_routing, "MULTI_TENANT", True)
+    monkeypatch.setattr(shard_capacity, "MULTI_TENANT", True)
+    # Enumeration short-circuits to a single fake tenant outside multi-tenant mode.
+    monkeypatch.setattr(tenant_utils, "MULTI_TENANT", True)
+
+    shard_registry.reset_shard_specs()
+    shard_routing.reset_shard_overrides()
+    invalidate_shard_cache()
+
+    created: list[tuple[str, str]] = []
+    yield {"created": created}
+
+    for shard, tenant_id in created:
+        with get_engine_for_shard(shard).connect() as conn:
+            conn.execute(text(f'DROP SCHEMA IF EXISTS "{tenant_id}" CASCADE'))
+            conn.commit()
+    shard_registry.reset_shard_specs()
+    invalidate_shard_cache()
+
+
+def _make_tenant(two_shards: dict[str, Any], shard: str) -> str:
+    tenant_id = f"tenant_{uuid4()}"
+    with get_engine_for_shard(shard).connect() as conn:
+        conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{tenant_id}"'))
+        conn.commit()
+    two_shards["created"].append((shard, tenant_id))
+    return tenant_id
+
+
+def test_counts_are_reported_per_shard(two_shards: dict[str, Any]) -> None:
+    """Each shard reports the schemas physically on it, not what a catalog claims."""
+    collector = ShardCapacityCollector()
+    before = _counts(collector)
+
+    _make_tenant(two_shards, DEFAULT_SHARD)
+    _make_tenant(two_shards, SECOND_SHARD)
+    _make_tenant(two_shards, SECOND_SHARD)
+
+    # A fresh collector, since the previous one has the pre-change counts cached.
+    after = _counts(ShardCapacityCollector())
+
+    assert after[DEFAULT_SHARD] == before.get(DEFAULT_SHARD, 0) + 1
+    assert after[SECOND_SHARD] == before.get(SECOND_SHARD, 0) + 2
+
+
+def test_every_replica_reports_without_coordination(
+    two_shards: dict[str, Any],  # noqa: ARG001
+) -> None:
+    """Collected on scrape precisely so each monitoring replica is self-sufficient.
+
+    A beat task reaches one worker, so only that replica would hold a value and
+    replacing it would blank the series until the next run.
+    """
+    first = _counts(ShardCapacityCollector())
+    second = _counts(ShardCapacityCollector())
+
+    assert first == second
+    assert set(first) == {DEFAULT_SHARD, SECOND_SHARD}
+
+
+def test_an_unreachable_shard_does_not_suppress_the_others(
+    two_shards: dict[str, Any],  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One database outage must not blank capacity data for unrelated shards.
+
+    The *first* shard collected is the one made to fail: shards are walked in sorted
+    order, so a version that aborts the whole loop still reports everything ahead of
+    the failure and would pass otherwise.
+    """
+
+    def _count(shard_name: str) -> int:
+        if shard_name == DEFAULT_SHARD:
+            raise OperationalError("SELECT 1", {}, Exception("connection refused"))
+        return 7
+
+    monkeypatch.setattr(shard_capacity, "count_tenant_schemas_on_shard", _count)
+
+    assert sorted(shard_registry.get_shard_specs())[0] == DEFAULT_SHARD
+    counts = _counts(ShardCapacityCollector())
+
+    assert counts == {SECOND_SHARD: 7}
+
+
+def test_no_series_outside_multi_tenant_mode(
+    two_shards: dict[str, Any],  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Single-database deployments have no shards to report on."""
+    monkeypatch.setattr(shard_capacity, "MULTI_TENANT", False)
+    assert _counts(ShardCapacityCollector()) == {}


### PR DESCRIPTION
## Description

Publishes how many tenant schemas each physical database is holding, as
`onyx_shard_tenant_count{shard="..."}`. This is the capacity signal for deciding when
new signups should move onto another shard.

Schema-per-tenant is bounded by **catalog size, not disk**. Every tenant adds ~110
tables, so table count — and with it migration wall-clock and autovacuum pressure —
scales with tenants rather than bytes. Storage is not the constraint: the primary
database holds roughly 765 GiB of actual data while carrying ~8.5k tenants and ~930k
tables.

Counted from the schemas **physically present** on each database rather than from the
`tenant_shard` catalog, so a mapping that disagrees with reality cannot hide capacity
from the alert. That is also the honest answer during a migration, when a tenant
legitimately exists on two shards at once.

### Collected on scrape, not published by a task

The first version used an hourly beat task writing to a process-local `Gauge`. That is
wrong here, and Greptile was right to flag it: **the monitoring deployment runs 3
replicas**, and beat dispatches a task to exactly one consumer. Two of three replicas
would publish nothing at any moment, and replacing the one holding the value blanks the
series until the next run — `max by (shard)` over an empty set is no data, so the alert
could not fire during that window. A capacity alert that goes blind on a rollout is
worse than no alert.

Now a `Collector` in the shape already used by `connector_state_metrics`, so every
replica is self-sufficient. A 5-minute in-process cache keeps the scrape interval from
driving database load.

Counts are gathered **per shard**, so one unreachable database costs that series rather
than all of them.

**No manifest change needed.** The monitoring worker already declares
`containerPort: 9096`, and 9096 is not in `pod_exporter`'s drop list, so the metric is
already scraped into AMP. I verified the scrape path rather than assuming it.

Independent of the tenant-placement PR (#13661) — this only needs the enumeration
primitive from #13518, which is already merged. The alert rule itself lives in the infra
repo (onyx-infra#729).

## How Has This Been Tested?

External dependency unit tests against two real databases:

- Each shard reports the schemas physically on it.
- Two independently constructed collectors agree, which is the property that makes
  every replica self-sufficient.
- An unreachable shard does not suppress the others.
- No series at all outside multi-tenant mode.

Mutation-tested. Worth calling out that the failure-isolation test did **not**
discriminate on the first attempt: shards are walked in sorted order, so failing the
*second* shard still let an aborting implementation report the first, and the mutation
passed. The test now fails the first shard collected.

72 existing background/celery unit tests pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check