### PR TITLE
feat(connector-stability): stricter verdict aggregation and no trivial pass fallbacks

### DIFF
--- a/backend/ee/onyx/connectors/capability_checks.py
+++ b/backend/ee/onyx/connectors/capability_checks.py
@@ -72,9 +72,9 @@ def get_perm_sync_capability_checks(source: DocumentSource) -> list[CapabilityCh
     ``validate_perm_sync`` fallback -- but only for probe-bearing sources,
     derived from that blob's own dispatch table via
     ``source_has_perm_sync_probe``. Sync-capable sources where the blob is a
-    no-op get no perm-sync checks at all until named ones are registered;
-    their verdict renders as "no checks available yet" rather than a trivial
-    PASSED built on a no-op probe.
+    no-op get no perm-sync checks at all until named ones are registered; their
+    verdict renders as "no checks available yet" rather than a trivial PASSED
+    built on a no-op probe.
     """
     applicable = get_applicable_perm_sync_capabilities(source)
     registered_by_capability: dict[CredentialCapability, list[CapabilityCheck]] = {

--- a/backend/ee/onyx/connectors/capability_checks.py
+++ b/backend/ee/onyx/connectors/capability_checks.py
@@ -6,6 +6,7 @@ implementations stay in the OSS connector modules, mirroring the
 ``perm_sync_valid.py`` pattern.
 """
 
+from ee.onyx.connectors.perm_sync_valid import source_has_perm_sync_probe
 from ee.onyx.external_permissions.sync_params import (
     source_requires_doc_sync,
     source_requires_external_group_sync,
@@ -22,18 +23,6 @@ from onyx.connectors.capability_checks.models import (
 _DOC_PERMISSION_SYNC_CHECKS_BY_SOURCE: dict[DocumentSource, list[CapabilityCheck]] = {}
 
 _EXTERNAL_GROUP_SYNC_CHECKS_BY_SOURCE: dict[DocumentSource, list[CapabilityCheck]] = {}
-
-# Sources whose legacy ``validate_perm_sync`` dispatch reaches a real probe;
-# keep in lockstep with ``ee/onyx/connectors/perm_sync_valid.py``. For every
-# other source that blob is a no-op, and a no-op must not produce a check: a
-# PASSED perm-sync verdict built on it would be a lie.
-_PERM_SYNC_PROBE_SOURCES = {
-    DocumentSource.BOX,
-    DocumentSource.CANVAS,
-    DocumentSource.CONFLUENCE,
-    DocumentSource.GOOGLE_DRIVE,
-    DocumentSource.SHAREPOINT,
-}
 
 
 class _PermSyncFallbackCheck(CapabilityCheck):
@@ -80,10 +69,12 @@ def get_perm_sync_capability_checks(source: DocumentSource) -> list[CapabilityCh
     """Returns the perm-sync capability checks for a source.
 
     Applicable capabilities with no registered named checks get the shared
-    ``validate_perm_sync`` fallback -- but only for probe-bearing sources
-    (``_PERM_SYNC_PROBE_SOURCES``). Sync-capable sources without a real legacy
-    probe get no perm-sync checks at all until named ones are registered; their
-    verdict renders as "no checks available yet" rather than a trivial PASSED.
+    ``validate_perm_sync`` fallback -- but only for probe-bearing sources,
+    derived from that blob's own dispatch table via
+    ``source_has_perm_sync_probe``. Sync-capable sources where the blob is a
+    no-op get no perm-sync checks at all until named ones are registered;
+    their verdict renders as "no checks available yet" rather than a trivial
+    PASSED built on a no-op probe.
     """
     applicable = get_applicable_perm_sync_capabilities(source)
     registered_by_capability: dict[CredentialCapability, list[CapabilityCheck]] = {
@@ -98,6 +89,6 @@ def get_perm_sync_capability_checks(source: DocumentSource) -> list[CapabilityCh
     for capability, registered in registered_by_capability.items():
         if registered:
             checks.extend(registered)
-        elif capability in applicable and source in _PERM_SYNC_PROBE_SOURCES:
+        elif capability in applicable and source_has_perm_sync_probe(source):
             checks.append(_PermSyncFallbackCheck(source, capability))
     return checks

--- a/backend/ee/onyx/connectors/capability_checks.py
+++ b/backend/ee/onyx/connectors/capability_checks.py
@@ -23,6 +23,18 @@ _DOC_PERMISSION_SYNC_CHECKS_BY_SOURCE: dict[DocumentSource, list[CapabilityCheck
 
 _EXTERNAL_GROUP_SYNC_CHECKS_BY_SOURCE: dict[DocumentSource, list[CapabilityCheck]] = {}
 
+# Sources whose legacy ``validate_perm_sync`` dispatch reaches a real probe;
+# keep in lockstep with ``ee/onyx/connectors/perm_sync_valid.py``. For every
+# other source that blob is a no-op, and a no-op must not produce a check: a
+# PASSED perm-sync verdict built on it would be a lie.
+_PERM_SYNC_PROBE_SOURCES = {
+    DocumentSource.BOX,
+    DocumentSource.CANVAS,
+    DocumentSource.CONFLUENCE,
+    DocumentSource.GOOGLE_DRIVE,
+    DocumentSource.SHAREPOINT,
+}
+
 
 class _PermSyncFallbackCheck(CapabilityCheck):
     """
@@ -68,8 +80,10 @@ def get_perm_sync_capability_checks(source: DocumentSource) -> list[CapabilityCh
     """Returns the perm-sync capability checks for a source.
 
     Applicable capabilities with no registered named checks get the shared
-    ``validate_perm_sync`` fallback so every sync-capable source has day-one
-    coverage.
+    ``validate_perm_sync`` fallback -- but only for probe-bearing sources
+    (``_PERM_SYNC_PROBE_SOURCES``). Sync-capable sources without a real legacy
+    probe get no perm-sync checks at all until named ones are registered; their
+    verdict renders as "no checks available yet" rather than a trivial PASSED.
     """
     applicable = get_applicable_perm_sync_capabilities(source)
     registered_by_capability: dict[CredentialCapability, list[CapabilityCheck]] = {
@@ -84,6 +98,6 @@ def get_perm_sync_capability_checks(source: DocumentSource) -> list[CapabilityCh
     for capability, registered in registered_by_capability.items():
         if registered:
             checks.extend(registered)
-        elif capability in applicable:
+        elif capability in applicable and source in _PERM_SYNC_PROBE_SOURCES:
             checks.append(_PermSyncFallbackCheck(source, capability))
     return checks

--- a/backend/ee/onyx/connectors/perm_sync_valid.py
+++ b/backend/ee/onyx/connectors/perm_sync_valid.py
@@ -67,9 +67,9 @@ def validate_sharepoint_perm_sync(connector: SharepointConnector) -> None:
     connector.probe_group_members_permission()
 
 
-# The single source of truth for which connectors carry a real perm-sync
-# probe: ``validate_perm_sync`` dispatches through it, and the capability
-# check framework derives probe-bearing sources from it via
+# The single source of truth for which connectors carry a real perm-sync probe:
+# ``validate_perm_sync`` dispatches through it, and the capability check
+# framework derives probe-bearing sources from it via
 # ``source_has_perm_sync_probe``. Values take the matching connector subclass;
 # ``Any`` because a heterogeneous dict cannot express the per-entry pairing.
 _VALIDATOR_BY_CONNECTOR_CLASS: dict[type[BaseConnector], Callable[[Any], None]] = {
@@ -98,10 +98,9 @@ def source_has_perm_sync_probe(source: DocumentSource) -> bool:
     """
     Returns whether ``validate_perm_sync`` reaches a real probe for a source.
 
-    Mirrors the isinstance dispatch above (``issubclass``, so a connector
-    class deriving from a probe-bearing one counts the same way). Only
-    meaningful for sources with a connector class; callers gate on
-    sync-capability first.
+    Mirrors the isinstance dispatch above (``issubclass``, so a connector class
+    deriving from a probe-bearing one counts the same way). Only meaningful for
+    sources with a connector class; callers gate on sync-capability first.
     """
     connector_class = identify_connector_class(source)
     return any(

--- a/backend/ee/onyx/connectors/perm_sync_valid.py
+++ b/backend/ee/onyx/connectors/perm_sync_valid.py
@@ -1,6 +1,11 @@
+from collections.abc import Callable
+from typing import Any
+
+from onyx.configs.constants import DocumentSource
 from onyx.connectors.box.connector import BoxConnector
 from onyx.connectors.canvas.connector import CanvasConnector
 from onyx.connectors.confluence.connector import ConfluenceConnector
+from onyx.connectors.factory import identify_connector_class
 from onyx.connectors.google_drive.connector import GoogleDriveConnector
 from onyx.connectors.interfaces import BaseConnector
 from onyx.connectors.sharepoint.connector import SharepointConnector
@@ -62,6 +67,20 @@ def validate_sharepoint_perm_sync(connector: SharepointConnector) -> None:
     connector.probe_group_members_permission()
 
 
+# The single source of truth for which connectors carry a real perm-sync
+# probe: ``validate_perm_sync`` dispatches through it, and the capability
+# check framework derives probe-bearing sources from it via
+# ``source_has_perm_sync_probe``. Values take the matching connector subclass;
+# ``Any`` because a heterogeneous dict cannot express the per-entry pairing.
+_VALIDATOR_BY_CONNECTOR_CLASS: dict[type[BaseConnector], Callable[[Any], None]] = {
+    BoxConnector: validate_box_perm_sync,
+    CanvasConnector: validate_canvas_perm_sync,
+    ConfluenceConnector: validate_confluence_perm_sync,
+    GoogleDriveConnector: validate_drive_perm_sync,
+    SharepointConnector: validate_sharepoint_perm_sync,
+}
+
+
 def validate_perm_sync(connector: BaseConnector) -> None:
     """
     Override this if your connector needs to validate permissions syncing.
@@ -69,13 +88,23 @@ def validate_perm_sync(connector: BaseConnector) -> None:
 
     Default is a no-op (always successful).
     """
-    if isinstance(connector, BoxConnector):
-        validate_box_perm_sync(connector)
-    elif isinstance(connector, CanvasConnector):
-        validate_canvas_perm_sync(connector)
-    elif isinstance(connector, ConfluenceConnector):
-        validate_confluence_perm_sync(connector)
-    elif isinstance(connector, GoogleDriveConnector):
-        validate_drive_perm_sync(connector)
-    elif isinstance(connector, SharepointConnector):
-        validate_sharepoint_perm_sync(connector)
+    for connector_class, validator in _VALIDATOR_BY_CONNECTOR_CLASS.items():
+        if isinstance(connector, connector_class):
+            validator(connector)
+            return
+
+
+def source_has_perm_sync_probe(source: DocumentSource) -> bool:
+    """
+    Returns whether ``validate_perm_sync`` reaches a real probe for a source.
+
+    Mirrors the isinstance dispatch above (``issubclass``, so a connector
+    class deriving from a probe-bearing one counts the same way). Only
+    meaningful for sources with a connector class; callers gate on
+    sync-capability first.
+    """
+    connector_class = identify_connector_class(source)
+    return any(
+        issubclass(connector_class, probe_class)
+        for probe_class in _VALIDATOR_BY_CONNECTOR_CLASS
+    )

--- a/backend/onyx/connectors/capability_checks/models.py
+++ b/backend/onyx/connectors/capability_checks/models.py
@@ -129,13 +129,13 @@ def aggregate_capability_verdict(
 ) -> CapabilityVerdict:
     """Rolls the per-check results of one capability up into a single verdict.
 
-    Pure function. Required checks gate the verdict: a required failure is
-    FAILED, and a required indeterminate is INDETERMINATE, since the
-    capability's core is unverified and no PASSED claim can be made.
-    Non-required outcomes only downgrade: failures to PASSED_WITH_WARNINGS
-    (definite, stable, actionable), indeterminates to INDETERMINATE when no
-    warning outranks them (transient, self-resolves on re-run). An empty result
-    list aggregates to SKIPPED.
+    Pure function, evaluated in strict precedence order. Required checks gate
+    the verdict: a required FAILED is FAILED, and a required INDETERMINATE or
+    SKIPPED leaves the capability's core unverified, so no pass-ish claim may be
+    made. Non-required failures and indeterminates only downgrade to
+    PASSED_WITH_WARNINGS (partial capability); non-required skips do not
+    downgrade at all. An empty result list aggregates to SKIPPED: a capability
+    is never PASSED on the basis of having checked nothing.
     """
     if not applicable:
         return CapabilityVerdict.NOT_APPLICABLE
@@ -149,10 +149,17 @@ def aggregate_capability_verdict(
         for result in results
     ):
         return CapabilityVerdict.INDETERMINATE
-    if any(result.status == CapabilityCheckStatus.FAILED for result in results):
+    if any(
+        result.status == CapabilityCheckStatus.SKIPPED and result.required
+        for result in results
+    ):
+        return CapabilityVerdict.SKIPPED
+    if any(
+        result.status
+        in (CapabilityCheckStatus.FAILED, CapabilityCheckStatus.INDETERMINATE)
+        for result in results
+    ):
         return CapabilityVerdict.PASSED_WITH_WARNINGS
-    if any(result.status == CapabilityCheckStatus.INDETERMINATE for result in results):
-        return CapabilityVerdict.INDETERMINATE
     if all(result.status == CapabilityCheckStatus.SKIPPED for result in results):
         return CapabilityVerdict.SKIPPED
     return CapabilityVerdict.PASSED

--- a/backend/tests/unit/ee/onyx/connectors/test_ee_capability_checks.py
+++ b/backend/tests/unit/ee/onyx/connectors/test_ee_capability_checks.py
@@ -48,20 +48,65 @@ def test_censoring_only_source_has_no_perm_sync_capabilities() -> None:
     assert get_applicable_perm_sync_capabilities(DocumentSource.SALESFORCE) == set()
 
 
-def test_fallback_synthesis_respects_applicability() -> None:
+def test_probeless_sync_source_gets_no_fallback() -> None:
     """
-    Verifies only applicable capabilities get a fallback (Slack has no group
-    sync by design, so only the doc-sync fallback is synthesized).
+    Verifies the no-trivial-pass rule: Slack and Gmail are sync-capable, but
+    their legacy ``validate_perm_sync`` dispatch is a no-op, so no fallback is
+    synthesized and no verdict can pass on the basis of a no-op probe.
     """
+    # Under test and postcondition.
+    assert get_perm_sync_capability_checks(DocumentSource.SLACK) == []
+    assert get_perm_sync_capability_checks(DocumentSource.GMAIL) == []
+
+
+def test_fallback_synthesis_respects_applicability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Verifies a probe-bearing source only gets fallbacks for its applicable
+    capabilities.
+    """
+    # Precondition.
+    # Every probe-bearing source supports both sync capabilities today, so pin
+    # applicability to doc sync only.
+    monkeypatch.setattr(
+        ee_capability_checks,
+        "get_applicable_perm_sync_capabilities",
+        lambda _source: {CredentialCapability.DOC_PERMISSION_SYNC},
+    )
+
     # Under test.
-    checks = get_perm_sync_capability_checks(DocumentSource.SLACK)
+    checks = get_perm_sync_capability_checks(DocumentSource.GOOGLE_DRIVE)
 
     # Postcondition.
     assert [check.capability for check in checks] == [
         CredentialCapability.DOC_PERMISSION_SYNC
     ]
     assert checks[0].is_fallback is True
-    assert checks[0].check_id == "slack_perm_sync"
+    assert checks[0].check_id == "google_drive_perm_sync"
+
+
+def test_named_checks_ignore_the_probe_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Verifies the allowlist gates only fallback synthesis: a probe-less source
+    with registered named checks still returns them.
+    """
+    # Precondition.
+    named_check = _NamedCheck(
+        capability=CredentialCapability.DOC_PERMISSION_SYNC,
+        check_id="slack_named_check",
+        display_name="Named check",
+    )
+    monkeypatch.setitem(
+        ee_capability_checks._DOC_PERMISSION_SYNC_CHECKS_BY_SOURCE,
+        DocumentSource.SLACK,
+        [named_check],
+    )
+
+    # Under test and postcondition.
+    assert get_perm_sync_capability_checks(DocumentSource.SLACK) == [named_check]
 
 
 def test_unregistered_sync_source_gets_shared_fallback_checks() -> None:

--- a/backend/tests/unit/ee/onyx/connectors/test_perm_sync_valid.py
+++ b/backend/tests/unit/ee/onyx/connectors/test_perm_sync_valid.py
@@ -1,0 +1,59 @@
+from unittest.mock import MagicMock
+
+from ee.onyx.connectors.perm_sync_valid import (
+    source_has_perm_sync_probe,
+    validate_perm_sync,
+)
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.canvas.connector import CanvasConnector
+from onyx.connectors.interfaces import BaseConnector
+
+
+def test_probe_bearing_sources_derive_from_the_dispatch_table() -> None:
+    """
+    Verifies the predicate mirrors ``validate_perm_sync``'s dispatch for every
+    sync-capable source: True iff the blob reaches a real probe.
+    """
+    # Under test and postcondition.
+    probe_bearing = {
+        source
+        for source in (
+            DocumentSource.BOX,
+            DocumentSource.CANVAS,
+            DocumentSource.CONFLUENCE,
+            DocumentSource.GITHUB,
+            DocumentSource.GMAIL,
+            DocumentSource.GOOGLE_DRIVE,
+            DocumentSource.JIRA,
+            DocumentSource.SHAREPOINT,
+            DocumentSource.SLACK,
+            DocumentSource.TEAMS,
+        )
+        if source_has_perm_sync_probe(source)
+    }
+    assert probe_bearing == {
+        DocumentSource.BOX,
+        DocumentSource.CANVAS,
+        DocumentSource.CONFLUENCE,
+        DocumentSource.GOOGLE_DRIVE,
+        DocumentSource.SHAREPOINT,
+    }
+
+
+def test_dispatch_reaches_the_matching_validator() -> None:
+    """Verifies the dict dispatch preserves the old isinstance behavior."""
+    # Precondition.
+    connector = MagicMock(spec=CanvasConnector)
+
+    # Under test.
+    validate_perm_sync(connector)
+
+    # Postcondition.
+    connector.probe_course_user_email_visibility.assert_called_once_with()
+    connector.probe_account_user_listing_permission.assert_called_once_with()
+
+
+def test_dispatch_is_a_noop_for_probeless_connectors() -> None:
+    """Verifies connectors outside the dispatch table validate as a no-op."""
+    # Under test and postcondition (nothing raises, nothing is probed).
+    validate_perm_sync(MagicMock(spec=BaseConnector))

--- a/backend/tests/unit/onyx/connectors/capability_checks/test_verdict_aggregation.py
+++ b/backend/tests/unit/onyx/connectors/capability_checks/test_verdict_aggregation.py
@@ -152,8 +152,8 @@ def test_required_skip_blocks_pass() -> None:
 
 def test_required_skip_outranks_optional_failure() -> None:
     """
-    Verifies precedence: an unverified required core blocks the warnings
-    verdict a non-required failure would otherwise produce.
+    Verifies precedence: an unverified required core blocks the warnings verdict
+    a non-required failure would otherwise produce.
     """
     # Precondition.
     results = [

--- a/backend/tests/unit/onyx/connectors/capability_checks/test_verdict_aggregation.py
+++ b/backend/tests/unit/onyx/connectors/capability_checks/test_verdict_aggregation.py
@@ -82,10 +82,10 @@ def test_required_indeterminate_outranks_optional_failure() -> None:
     )
 
 
-def test_optional_failure_outranks_optional_indeterminate() -> None:
+def test_mixed_optional_degradations_pass_with_warnings() -> None:
     """
-    Verifies that with the required core verified, a definite warning outranks
-    a transient non-required indeterminate.
+    Verifies that with the required core verified, non-required failures and
+    indeterminates together downgrade to a single warnings verdict.
     """
     # Precondition.
     results = [
@@ -135,16 +135,64 @@ def test_empty_results_yield_skipped() -> None:
     assert aggregate_capability_verdict(True, []) == CapabilityVerdict.SKIPPED
 
 
-def test_skipped_mixed_with_passed_yields_passed() -> None:
-    """Verifies that partial skips do not mask passing required checks."""
+def test_required_skip_blocks_pass() -> None:
+    """
+    Verifies that a skipped required check blocks any pass-ish claim: the
+    capability's core is unverified until the check actually runs.
+    """
     # Precondition.
     results = [
         _result(CapabilityCheckStatus.PASSED),
-        _result(CapabilityCheckStatus.SKIPPED),
+        _result(CapabilityCheckStatus.SKIPPED, required=True),
+    ]
+
+    # Under test and postcondition.
+    assert aggregate_capability_verdict(True, results) == CapabilityVerdict.SKIPPED
+
+
+def test_required_skip_outranks_optional_failure() -> None:
+    """
+    Verifies precedence: an unverified required core blocks the warnings
+    verdict a non-required failure would otherwise produce.
+    """
+    # Precondition.
+    results = [
+        _result(CapabilityCheckStatus.FAILED, required=False),
+        _result(CapabilityCheckStatus.SKIPPED, required=True),
+    ]
+
+    # Under test and postcondition.
+    assert aggregate_capability_verdict(True, results) == CapabilityVerdict.SKIPPED
+
+
+def test_optional_skip_does_not_downgrade() -> None:
+    """Verifies that a skipped non-required check leaves PASSED intact."""
+    # Precondition.
+    results = [
+        _result(CapabilityCheckStatus.PASSED),
+        _result(CapabilityCheckStatus.SKIPPED, required=False),
     ]
 
     # Under test and postcondition.
     assert aggregate_capability_verdict(True, results) == CapabilityVerdict.PASSED
+
+
+def test_lone_optional_indeterminate_warns() -> None:
+    """
+    Verifies that a non-required indeterminate downgrades to warnings rather
+    than escalating to INDETERMINATE: the required core is verified.
+    """
+    # Precondition.
+    results = [
+        _result(CapabilityCheckStatus.PASSED),
+        _result(CapabilityCheckStatus.INDETERMINATE, required=False),
+    ]
+
+    # Under test and postcondition.
+    assert (
+        aggregate_capability_verdict(True, results)
+        == CapabilityVerdict.PASSED_WITH_WARNINGS
+    )
 
 
 def test_all_passed_yields_passed() -> None:


### PR DESCRIPTION
## Description

Two badge-honesty amendments to the capability-check framework (#13519). No production call sites yet.

- Verdict aggregation: a required check that was SKIPPED now blocks pass-ish verdicts (the capability's core is unverified), and non-required failures/indeterminates downgrade to PASSED_WITH_WARNINGS instead of an optional check's transient error escalating the whole capability to INDETERMINATE. Full precedence order is in the `aggregate_capability_verdict` docstring.

- Perm-sync fallback synthesis is restricted to sources whose legacy validate_perm_sync actually probes (Box, Canvas, Confluence, GDrive, SharePoint). For the other sync-capable sources the blob is a no-op, and a PASSED verdict built on a no-op is a lie; they now get no perm-sync checks until named ones are registered. Named-check registration is unaffected.

## How Has This Been Tested?

Added and adjusted automated tests.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens capability verdict rules and limits perm-sync fallbacks to real-probe sources to prevent trivial PASS results.

- **Refactors**
  - Verdict aggregation: required FAILED => FAILED; required INDETERMINATE or SKIPPED blocks any pass-ish verdict; optional FAILED/INDETERMINATE => PASSED_WITH_WARNINGS; optional SKIPPED doesn’t downgrade; empty results => SKIPPED.
  - Perm-sync fallback: synthesized only for Box, Canvas, Confluence, Google Drive, and SharePoint, gated by `source_has_perm_sync_probe` derived from `validate_perm_sync`’s shared dispatch table; probe-less sources (e.g., Slack, Gmail) get no fallback until named checks are registered; named checks remain unaffected.
  - Tests: expanded to cover the dispatch table, the probe predicate, no-fallback behavior for probe-less sources, and the new aggregation precedence cases.

<sup>Written for commit 90805660e4d448463ba6d11e35943f0f105d82e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

