### PR TITLE
feat(gateway): serve the Anthropic Messages API for Claude Code

### DIFF
--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -62,6 +62,7 @@ from onyx.server.gateway.models import (
     AnthropicMessageStartEvent,
     AnthropicMessageStopEvent,
     AnthropicPingEvent,
+    AnthropicStreamEvent,
     AnthropicTextBlock,
     AnthropicTextDelta,
     AnthropicToolUseBlock,
@@ -104,7 +105,15 @@ from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import start_thread_with_context
 
 if TYPE_CHECKING:
+    from litellm.types.llms.anthropic import (
+        AnthopicMessagesAssistantMessageParam,
+        AnthropicMessagesUserMessageParam,
+    )
     from litellm.types.llms.openai import ChatCompletionToolParam
+
+    _AnthropicAdapterMessage = (
+        AnthropicMessagesUserMessageParam | AnthopicMessagesAssistantMessageParam
+    )
 
 logger = setup_logger()
 
@@ -994,7 +1003,7 @@ def _anthropic_messages_to_raw_messages(
 
     adapter = LiteLLMAnthropicMessagesAdapter()
     translated = adapter.translate_anthropic_messages_to_openai(
-        messages=cast(Any, messages)
+        messages=cast("list[_AnthropicAdapterMessage]", messages)
     )
     raw: list[dict[str, Any]] = []
     system_message = _anthropic_system_to_raw_message(system)
@@ -1137,7 +1146,7 @@ def _anthropic_stream_worker(
     out: "queue.Queue[Any]",
     cancelled: threading.Event,
 ) -> None:
-    def emit(event: Any) -> bool:
+    def emit(event: AnthropicStreamEvent) -> bool:
         payload = event.to_wire()
         return _put_stream_item(
             out, f"event: {payload['type']}\ndata: {json.dumps(payload)}\n\n", cancelled

--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -1105,11 +1105,17 @@ _ANTHROPIC_STOP_REASONS = {
 
 
 def _anthropic_stop_reason(finish_reason: str | None, has_tool_use: bool) -> str:
-    # Tool calls dominate: providers routinely report finish_reason "stop" on
-    # tool-call turns.
+    mapped = _ANTHROPIC_STOP_REASONS.get(finish_reason or "", "end_turn")
+    # Truncation dominates: a generation cut off mid-tool-call must not be
+    # reported as a completed tool_use turn (matches Anthropic's own API).
+    if mapped == "max_tokens":
+        return mapped
+    # Otherwise tool calls dominate: providers routinely report finish_reason
+    # "stop" on tool-call turns, and reporting end_turn would make clients
+    # treat the turn as final and drop the tool calls.
     if has_tool_use:
         return "tool_use"
-    return _ANTHROPIC_STOP_REASONS.get(finish_reason or "", "end_turn")
+    return mapped
 
 
 def _anthropic_tool_use_blocks(
@@ -1227,6 +1233,11 @@ def _anthropic_stream_worker(
                     ):
                         break
             else:
+                # Intentional for-else, matching the sibling stream workers:
+                # the completion frames below must be emitted ONLY when the
+                # upstream stream exhausted cleanly — any break above
+                # (cancellation, failed emit) must skip straight to the
+                # guard's teardown.
                 if text_block_open:
                     emit(AnthropicContentBlockStopEvent.create(index=0))
                 finalized_tool_calls = _finalize_tool_calls(state.tool_call_buffer)

--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Iterator
 from contextlib import closing, contextmanager
 from functools import partial
 from itertools import count
-from typing import Any, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
 from fastapi import APIRouter, Depends, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -48,6 +48,24 @@ from onyx.server.features.build.craft_gateway import is_gateway_request
 from onyx.server.gateway.configs import GATEWAY_PATH_PREFIX
 from onyx.server.gateway.model_catalog import build_gateway_model_catalog
 from onyx.server.gateway.models import (
+    AnthropicContentBlock,
+    AnthropicContentBlockDeltaEvent,
+    AnthropicContentBlockStartEvent,
+    AnthropicContentBlockStopEvent,
+    AnthropicCountTokensRequest,
+    AnthropicErrorEvent,
+    AnthropicInputJsonDelta,
+    AnthropicMessageDeltaEvent,
+    AnthropicMessageDeltaPayload,
+    AnthropicMessageResponse,
+    AnthropicMessagesRequest,
+    AnthropicMessageStartEvent,
+    AnthropicMessageStopEvent,
+    AnthropicPingEvent,
+    AnthropicTextBlock,
+    AnthropicTextDelta,
+    AnthropicToolUseBlock,
+    AnthropicUsagePayload,
     ChatCompletionChunk,
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -84,6 +102,9 @@ from onyx.tracing.llm_utils import (
 )
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import start_thread_with_context
+
+if TYPE_CHECKING:
+    from litellm.types.llms.openai import ChatCompletionToolParam
 
 logger = setup_logger()
 
@@ -929,6 +950,422 @@ def handle_responses_request(
     )
 
 
+def _anthropic_system_to_raw_message(
+    system: str | list[dict[str, Any]] | None,
+) -> dict[str, Any] | None:
+    if isinstance(system, str):
+        return {"role": "system", "content": system} if system.strip() else None
+    if isinstance(system, list):
+        text = _flatten_text_content(system)
+        return {"role": "system", "content": text} if text else None
+    return None
+
+
+def _anthropic_messages_to_raw_messages(
+    messages: list[dict[str, Any]], system: str | list[dict[str, Any]] | None
+) -> list[dict[str, Any]]:
+    """LiteLLM's Anthropic adapter handles text/image/tool_use/tool_result block
+    translation; system is prepended separately, and any residual list-of-parts
+    content on system/tool messages is collapsed because our SystemMessage/
+    ToolMessage content is str-only."""
+    from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
+        LiteLLMAnthropicMessagesAdapter,
+    )
+
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "tool_result":
+                continue
+            tool_result_content = block.get("content")
+            if not isinstance(tool_result_content, list):
+                continue
+            if any(
+                not isinstance(part, dict) or part.get("type") != "text"
+                for part in tool_result_content
+            ):
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    "Multimodal tool_result content is not supported by the "
+                    "Onyx gateway.",
+                )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    translated = adapter.translate_anthropic_messages_to_openai(
+        messages=cast(Any, messages)
+    )
+    raw: list[dict[str, Any]] = []
+    system_message = _anthropic_system_to_raw_message(system)
+    if system_message is not None:
+        raw.append(system_message)
+    for message in translated:
+        message_dict: dict[str, Any] = dict(message)
+        role = message_dict.get("role")
+        if role in ("system", "tool") and isinstance(message_dict.get("content"), list):
+            message_dict["content"] = _flatten_text_content(message_dict["content"])
+        elif role == "assistant" and isinstance(message_dict.get("content"), list):
+            message_dict["content"] = (
+                _flatten_text_content(message_dict["content"]) or None
+            )
+        raw.append(message_dict)
+    return raw
+
+
+def _anthropic_tools(
+    raw_tools: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]] | None:
+    if not raw_tools:
+        return None
+    tools: list[dict[str, Any]] = []
+    for tool in raw_tools:
+        name = tool.get("name")
+        input_schema = tool.get("input_schema")
+        if not name or input_schema is None:
+            identifier = name or tool.get("type") or "<unknown>"
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                f"Tool {identifier!r} is not supported by the Onyx gateway; "
+                "only client tools with an input_schema are accepted.",
+            )
+        function: dict[str, Any] = {"name": name, "parameters": input_schema}
+        if "description" in tool:
+            function["description"] = tool["description"]
+        tools.append({"type": "function", "function": function})
+    return tools
+
+
+def _anthropic_tool_choice(raw: dict[str, Any] | None) -> ToolChoiceOptions | None:
+    if raw is None:
+        return None
+    choice_type = raw.get("type")
+    if choice_type == "auto":
+        return ToolChoiceOptions.AUTO
+    if choice_type == "any":
+        return ToolChoiceOptions.REQUIRED
+    if choice_type == "none":
+        return ToolChoiceOptions.NONE
+    if choice_type == "tool":
+        # Silently downgrading to auto would let the model ignore a tool the
+        # caller required, so refuse instead of guessing.
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Named-function tool_choice is not supported by the Onyx gateway.",
+        )
+    raise OnyxError(
+        OnyxErrorCode.INVALID_INPUT,
+        f"Unsupported tool_choice type {choice_type!r}; expected one of "
+        "auto, any, none.",
+    )
+
+
+def _anthropic_reasoning_effort(
+    thinking: dict[str, Any] | None, output_config: dict[str, Any] | None
+) -> ReasoningEffort:
+    """Anthropic has two thinking APIs: legacy ``thinking.type=enabled`` with
+    ``budget_tokens``, and adaptive ``thinking.type=adaptive`` where effort
+    lives in top-level ``output_config.effort``. The downstream LLM layer
+    re-derives the right API per model from the single ReasoningEffort, so
+    both request shapes must map faithfully here."""
+    if thinking is not None and thinking.get("type") == "disabled":
+        return ReasoningEffort.OFF
+    effort_raw = (output_config or {}).get("effort")
+    if isinstance(effort_raw, str):
+        return _parse_reasoning_effort(effort_raw)
+    if thinking is None or thinking.get("type") == "adaptive":
+        # Adaptive without an explicit effort: leave it to the downstream
+        # adaptive default rather than pinning an effort tier.
+        return ReasoningEffort.AUTO
+    from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
+        LiteLLMAnthropicMessagesAdapter,
+    )
+
+    effort = LiteLLMAnthropicMessagesAdapter.translate_anthropic_thinking_to_reasoning_effort(
+        thinking
+    )
+    return _parse_reasoning_effort(effort)
+
+
+_ANTHROPIC_STOP_REASONS = {
+    "stop": "end_turn",
+    "length": "max_tokens",
+    "tool_calls": "tool_use",
+    "content_filter": "refusal",
+}
+
+
+def _anthropic_stop_reason(finish_reason: str | None, has_tool_use: bool) -> str:
+    # Tool calls dominate: providers routinely report finish_reason "stop" on
+    # tool-call turns.
+    if has_tool_use:
+        return "tool_use"
+    return _ANTHROPIC_STOP_REASONS.get(finish_reason or "", "end_turn")
+
+
+def _anthropic_tool_use_blocks(
+    tool_calls: list[ToolCall] | list[ChatCompletionMessageToolCall] | None,
+) -> list[AnthropicToolUseBlock]:
+    blocks: list[AnthropicToolUseBlock] = []
+    for tool_call in tool_calls or []:
+        name = tool_call.function.name
+        if not name:
+            continue
+        arguments = tool_call.function.arguments
+        try:
+            parsed_input = json.loads(arguments) if arguments else {}
+        except json.JSONDecodeError as e:
+            raise ValueError("Upstream tool arguments are not valid JSON") from e
+        if not isinstance(parsed_input, dict):
+            raise ValueError("Upstream tool arguments must be a JSON object")
+        blocks.append(
+            AnthropicToolUseBlock.create(id=tool_call.id, name=name, input=parsed_input)
+        )
+    return blocks
+
+
+def _anthropic_stream_worker(
+    llm: LLM,
+    flow: LLMFlow,
+    messages: list[ChatCompletionMessage],
+    tools: list[dict[str, Any]] | None,
+    tool_choice: ToolChoiceOptions | None,
+    max_tokens: int,
+    reasoning_effort: ReasoningEffort,
+    model: str,
+    message_id: str,
+    out: "queue.Queue[Any]",
+    cancelled: threading.Event,
+) -> None:
+    def emit(event: Any) -> bool:
+        payload = event.to_wire()
+        return _put_stream_item(
+            out, f"event: {payload['type']}\ndata: {json.dumps(payload)}\n\n", cancelled
+        )
+
+    emit(
+        AnthropicMessageStartEvent.create(
+            AnthropicMessageResponse.from_parts(
+                message_id=message_id,
+                model=model,
+                content=[],
+                stop_reason=None,
+                usage=AnthropicUsagePayload.zero(),
+            )
+        )
+    )
+    emit(AnthropicPingEvent.create())
+
+    def emit_error(*, message: str, error_type: str) -> None:
+        anthropic_error_type = (
+            "rate_limit_error" if error_type == "rate_limit_error" else "api_error"
+        )
+        emit(
+            AnthropicErrorEvent.create(message=message, error_type=anthropic_error_type)
+        )
+
+    # Runs on its own thread after the endpoint has returned the
+    # StreamingResponse, so the trace must be opened here rather than in the
+    # endpoint for the generation span to see an active trace.
+    with (
+        _gateway_trace(flow, llm.config.model_name),
+        llm_generation_span(
+            llm, flow=flow, input_messages=messages, tools=tools
+        ) as span,
+    ):
+        state = _StreamAccumulator()
+        text_block_open = False
+        with _stream_worker_guard(
+            span,
+            model,
+            state,
+            label="anthropic stream",
+            emit_error=emit_error,
+            out=out,
+            cancelled=cancelled,
+        ):
+            state.upstream = llm.stream(
+                prompt=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                max_tokens=max_tokens,
+                reasoning_effort=reasoning_effort,
+            )
+            finish_reason: str | None = None
+            for chunk in state.upstream:
+                if cancelled.is_set():
+                    break
+                state.observe(chunk)
+                if chunk.choice.finish_reason is not None:
+                    finish_reason = chunk.choice.finish_reason
+                if chunk.choice.delta.content:
+                    if not text_block_open:
+                        if not emit(
+                            AnthropicContentBlockStartEvent.create(
+                                index=0,
+                                content_block=AnthropicTextBlock.create(text=""),
+                            )
+                        ):
+                            break
+                        text_block_open = True
+                    if not emit(
+                        AnthropicContentBlockDeltaEvent.create(
+                            index=0,
+                            delta=AnthropicTextDelta.create(
+                                text=chunk.choice.delta.content
+                            ),
+                        )
+                    ):
+                        break
+            else:
+                if text_block_open:
+                    emit(AnthropicContentBlockStopEvent.create(index=0))
+                finalized_tool_calls = _finalize_tool_calls(state.tool_call_buffer)
+                tool_blocks = _anthropic_tool_use_blocks(finalized_tool_calls)
+                named_tool_calls = [
+                    tc for tc in finalized_tool_calls or [] if tc.function.name
+                ]
+                index = 1 if text_block_open else 0
+                for tool_index, (tool_block, tool_call) in enumerate(
+                    zip(tool_blocks, named_tool_calls), start=index
+                ):
+                    emit(
+                        AnthropicContentBlockStartEvent.create(
+                            index=tool_index,
+                            content_block=AnthropicToolUseBlock.create(
+                                id=tool_block.id, name=tool_block.name, input={}
+                            ),
+                        )
+                    )
+                    emit(
+                        AnthropicContentBlockDeltaEvent.create(
+                            index=tool_index,
+                            delta=AnthropicInputJsonDelta.create(
+                                partial_json=tool_call.function.arguments or "{}"
+                            ),
+                        )
+                    )
+                    emit(AnthropicContentBlockStopEvent.create(index=tool_index))
+                emit(
+                    AnthropicMessageDeltaEvent.create(
+                        delta=AnthropicMessageDeltaPayload.create(
+                            stop_reason=_anthropic_stop_reason(
+                                finish_reason, bool(tool_blocks)
+                            )
+                        ),
+                        usage=(
+                            AnthropicUsagePayload.from_usage(state.usage)
+                            if state.usage
+                            else AnthropicUsagePayload.zero()
+                        ),
+                    )
+                )
+                emit(AnthropicMessageStopEvent.create())
+
+
+def handle_anthropic_messages(
+    request: AnthropicMessagesRequest,
+    provider: LLMProviderView,
+    model_config: ModelConfigurationView,
+    flow: LLMFlow,
+) -> StreamingResponse | AnthropicMessageResponse:
+    llm = llm_from_provider(
+        model_name=model_config.name,
+        llm_provider=provider,
+        temperature=request.temperature,
+    )
+    raw_messages = _anthropic_messages_to_raw_messages(request.messages, request.system)
+    messages = _prepare_messages(llm, raw_messages)
+    tools = _anthropic_tools(request.tools)
+    tool_choice = _anthropic_tool_choice(request.tool_choice)
+    reasoning_effort = _anthropic_reasoning_effort(
+        request.thinking, request.output_config
+    )
+    max_tokens = request.max_tokens
+    message_id = _new_id("msg")
+
+    if request.stream:
+        return _sse_response(
+            _anthropic_stream_worker,
+            {
+                "llm": llm,
+                "flow": flow,
+                "messages": messages,
+                "tools": tools,
+                "tool_choice": tool_choice,
+                "max_tokens": max_tokens,
+                "reasoning_effort": reasoning_effort,
+                "model": request.model,
+                "message_id": message_id,
+            },
+        )
+
+    with (
+        _gateway_trace(flow, llm.config.model_name),
+        llm_generation_span(
+            llm,
+            flow=flow,
+            input_messages=messages,
+            tools=tools,
+        ) as span,
+    ):
+        try:
+            response = llm.invoke(
+                prompt=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                max_tokens=max_tokens,
+                reasoning_effort=reasoning_effort,
+            )
+        except LLMRateLimitError as e:
+            raise OnyxError(
+                OnyxErrorCode.RATE_LIMITED,
+                "The selected model is temporarily rate limited.",
+            ) from e
+        except LLMTimeoutError as e:
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                "The selected model did not respond in time.",
+            ) from e
+        except Exception as e:
+            if span is not None:
+                span.set_error({"message": f"{type(e).__name__}: {e}", "data": None})
+            logger.exception(
+                "LLM gateway anthropic invoke failed for model %s", request.model
+            )
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                "The upstream LLM request failed.",
+            ) from e
+        if span is not None:
+            record_llm_response(span, response)
+
+    content: list[AnthropicContentBlock] = []
+    if response.choice.message.content:
+        content.append(AnthropicTextBlock.create(text=response.choice.message.content))
+    try:
+        tool_blocks = _anthropic_tool_use_blocks(response.choice.message.tool_calls)
+    except ValueError as e:
+        raise OnyxError(
+            OnyxErrorCode.BAD_GATEWAY,
+            "The upstream LLM returned invalid tool arguments.",
+        ) from e
+    content.extend(tool_blocks)
+    return AnthropicMessageResponse.from_parts(
+        message_id=message_id,
+        model=request.model,
+        content=content,
+        stop_reason=_anthropic_stop_reason(
+            response.choice.finish_reason, bool(tool_blocks)
+        ),
+        usage=(
+            AnthropicUsagePayload.from_usage(response.usage)
+            if response.usage
+            else AnthropicUsagePayload.zero()
+        ),
+    )
+
+
 @router.get("/v1/models")
 def gateway_list_models(
     http_request: Request,
@@ -985,3 +1422,59 @@ def gateway_responses(
     if isinstance(result, StreamingResponse):
         return result
     return JSONResponse(content=result.to_wire())
+
+
+@router.post("/v1/messages")
+def gateway_anthropic_messages(
+    request: AnthropicMessagesRequest,
+    http_request: Request,
+    user: User = Depends(require_permission(Permission.USE_LLM_GATEWAY)),
+    db_session: Session = Depends(get_session),
+) -> Response:
+    flow = _authorize_gateway_request(http_request, user)
+    check_token_rate_limits(user)
+    with closing(db_session):
+        provider, model_config = resolve_gateway_model(db_session, user, request.model)
+    result = handle_anthropic_messages(
+        request=request,
+        provider=provider,
+        model_config=model_config,
+        flow=flow,
+    )
+    if isinstance(result, StreamingResponse):
+        return result
+    # Serialize explicitly: FastAPI's default model serialization would emit
+    # unset fields as nulls, violating the wire contract's presence semantics.
+    return JSONResponse(content=result.to_wire())
+
+
+@router.post("/v1/messages/count_tokens")
+def gateway_anthropic_count_tokens(
+    request: AnthropicCountTokensRequest,
+    http_request: Request,
+    user: User = Depends(require_permission(Permission.USE_LLM_GATEWAY)),
+    db_session: Session = Depends(get_session),
+) -> Response:
+    # No token rate limit check: nothing is generated by this endpoint.
+    _authorize_gateway_request(http_request, user)
+    with closing(db_session):
+        _provider, model_config = resolve_gateway_model(db_session, user, request.model)
+    raw_messages = _anthropic_messages_to_raw_messages(request.messages, request.system)
+    tools = _anthropic_tools(request.tools)
+    from onyx.llm.litellm_singleton import litellm
+
+    try:
+        input_tokens = litellm.token_counter(
+            model=model_config.name,
+            messages=raw_messages,
+            tools=cast("list[ChatCompletionToolParam] | None", tools),
+        )
+    except Exception:
+        logger.exception("LLM gateway token count failed for model %s", request.model)
+        # Rough fallback so Claude Code's context tracking degrades instead of
+        # breaking.
+        countable_input: dict[str, Any] = {"messages": raw_messages}
+        if tools is not None:
+            countable_input["tools"] = tools
+        input_tokens = len(json.dumps(countable_input)) // 4
+    return JSONResponse(content={"input_tokens": input_tokens})

--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -435,7 +435,7 @@ def _stream_worker(
             )
             for chunk in state.upstream:
                 if cancelled.is_set():
-                    break
+                    return
                 state.observe(chunk)
                 payload = ChatCompletionChunk.from_stream_chunk(
                     chunk, model, include_role=not sent_role
@@ -444,9 +444,8 @@ def _stream_worker(
                 if not _put_stream_item(
                     out, f"data: {json.dumps(payload.to_wire())}\n\n", cancelled
                 ):
-                    break
-            else:
-                _put_stream_item(out, "data: [DONE]\n\n", cancelled)
+                    return
+            _put_stream_item(out, "data: [DONE]\n\n", cancelled)
 
 
 def _run_bridged_stream(
@@ -775,7 +774,7 @@ def _responses_stream_worker(
             )
             for chunk in state.upstream:
                 if cancelled.is_set():
-                    break
+                    return
                 state.observe(chunk)
                 if not chunk.choice.delta.content:
                     continue
@@ -790,7 +789,7 @@ def _responses_stream_worker(
                             ),
                         )
                     ):
-                        break
+                        return
                     if not emit(
                         ResponsesContentPartAddedEvent.create(
                             item_id=message_item_id,
@@ -798,7 +797,7 @@ def _responses_stream_worker(
                             part=ResponsesOutputTextPart.create(text=""),
                         )
                     ):
-                        break
+                        return
                     text_item_open = True
                 if not emit(
                     ResponsesOutputTextDeltaEvent.create(
@@ -806,58 +805,56 @@ def _responses_stream_worker(
                         delta=chunk.choice.delta.content,
                     )
                 ):
-                    break
-            else:
-                # Build each item once and reuse it below: re-deriving items
-                # for the terminal payload remints ids the client never saw.
-                completed_items: list[ResponsesOutputItem] = []
-                if text_item_open:
-                    completed_items.append(close_text_item("completed"))
-                # Filter before enumerating, or a dropped nameless call leaves
-                # a hole in the output_index sequence.
-                call_items = [
-                    item
-                    for item in (
-                        _function_call_item(tool_call)
-                        for tool_call in _finalize_tool_calls(state.tool_call_buffer)
-                        or []
-                    )
-                    if item is not None
-                ]
-                for tool_index, call_item in enumerate(
-                    call_items, start=len(completed_items)
-                ):
-                    completed_items.append(call_item)
-                    emit(
-                        ResponsesOutputItemAddedEvent.create(
-                            output_index=tool_index, item=call_item
-                        )
-                    )
-                    emit(
-                        ResponsesFunctionCallArgumentsDoneEvent.create(
-                            item_id=call_item.id,
-                            output_index=tool_index,
-                            arguments=call_item.arguments,
-                            name=call_item.name,
-                        )
-                    )
-                    emit(
-                        ResponsesOutputItemDoneEvent.create(
-                            output_index=tool_index, item=call_item
-                        )
-                    )
+                    return
+            # Build each item once and reuse it below: re-deriving items
+            # for the terminal payload remints ids the client never saw.
+            completed_items: list[ResponsesOutputItem] = []
+            if text_item_open:
+                completed_items.append(close_text_item("completed"))
+            # Filter before enumerating, or a dropped nameless call leaves
+            # a hole in the output_index sequence.
+            call_items = [
+                item
+                for item in (
+                    _function_call_item(tool_call)
+                    for tool_call in _finalize_tool_calls(state.tool_call_buffer) or []
+                )
+                if item is not None
+            ]
+            for tool_index, call_item in enumerate(
+                call_items, start=len(completed_items)
+            ):
+                completed_items.append(call_item)
                 emit(
-                    ResponsesCompletedEvent.create(
-                        ResponsesObjectPayload.from_parts(
-                            response_id=response_id,
-                            created_at=created_at,
-                            model=model,
-                            status="completed",
-                            output=completed_items,
-                            usage=state.usage,
-                        )
+                    ResponsesOutputItemAddedEvent.create(
+                        output_index=tool_index, item=call_item
                     )
                 )
+                emit(
+                    ResponsesFunctionCallArgumentsDoneEvent.create(
+                        item_id=call_item.id,
+                        output_index=tool_index,
+                        arguments=call_item.arguments,
+                        name=call_item.name,
+                    )
+                )
+                emit(
+                    ResponsesOutputItemDoneEvent.create(
+                        output_index=tool_index, item=call_item
+                    )
+                )
+            emit(
+                ResponsesCompletedEvent.create(
+                    ResponsesObjectPayload.from_parts(
+                        response_id=response_id,
+                        created_at=created_at,
+                        model=model,
+                        status="completed",
+                        output=completed_items,
+                        usage=state.usage,
+                    )
+                )
+            )
 
 
 def handle_responses_request(
@@ -1209,7 +1206,7 @@ def _anthropic_stream_worker(
             finish_reason: str | None = None
             for chunk in state.upstream:
                 if cancelled.is_set():
-                    break
+                    return
                 state.observe(chunk)
                 if chunk.choice.finish_reason is not None:
                     finish_reason = chunk.choice.finish_reason
@@ -1221,7 +1218,7 @@ def _anthropic_stream_worker(
                                 content_block=AnthropicTextBlock.create(text=""),
                             )
                         ):
-                            break
+                            return
                         text_block_open = True
                     if not emit(
                         AnthropicContentBlockDeltaEvent.create(
@@ -1231,56 +1228,50 @@ def _anthropic_stream_worker(
                             ),
                         )
                     ):
-                        break
-            else:
-                # Intentional for-else, matching the sibling stream workers:
-                # the completion frames below must be emitted ONLY when the
-                # upstream stream exhausted cleanly — any break above
-                # (cancellation, failed emit) must skip straight to the
-                # guard's teardown.
-                if text_block_open:
-                    emit(AnthropicContentBlockStopEvent.create(index=0))
-                finalized_tool_calls = _finalize_tool_calls(state.tool_call_buffer)
-                tool_blocks = _anthropic_tool_use_blocks(finalized_tool_calls)
-                named_tool_calls = [
-                    tc for tc in finalized_tool_calls or [] if tc.function.name
-                ]
-                index = 1 if text_block_open else 0
-                for tool_index, (tool_block, tool_call) in enumerate(
-                    zip(tool_blocks, named_tool_calls), start=index
-                ):
-                    emit(
-                        AnthropicContentBlockStartEvent.create(
-                            index=tool_index,
-                            content_block=AnthropicToolUseBlock.create(
-                                id=tool_block.id, name=tool_block.name, input={}
-                            ),
-                        )
-                    )
-                    emit(
-                        AnthropicContentBlockDeltaEvent.create(
-                            index=tool_index,
-                            delta=AnthropicInputJsonDelta.create(
-                                partial_json=tool_call.function.arguments or "{}"
-                            ),
-                        )
-                    )
-                    emit(AnthropicContentBlockStopEvent.create(index=tool_index))
+                        return
+            if text_block_open:
+                emit(AnthropicContentBlockStopEvent.create(index=0))
+            finalized_tool_calls = _finalize_tool_calls(state.tool_call_buffer)
+            tool_blocks = _anthropic_tool_use_blocks(finalized_tool_calls)
+            named_tool_calls = [
+                tc for tc in finalized_tool_calls or [] if tc.function.name
+            ]
+            index = 1 if text_block_open else 0
+            for tool_index, (tool_block, tool_call) in enumerate(
+                zip(tool_blocks, named_tool_calls), start=index
+            ):
                 emit(
-                    AnthropicMessageDeltaEvent.create(
-                        delta=AnthropicMessageDeltaPayload.create(
-                            stop_reason=_anthropic_stop_reason(
-                                finish_reason, bool(tool_blocks)
-                            )
-                        ),
-                        usage=(
-                            AnthropicUsagePayload.from_usage(state.usage)
-                            if state.usage
-                            else AnthropicUsagePayload.zero()
+                    AnthropicContentBlockStartEvent.create(
+                        index=tool_index,
+                        content_block=AnthropicToolUseBlock.create(
+                            id=tool_block.id, name=tool_block.name, input={}
                         ),
                     )
                 )
-                emit(AnthropicMessageStopEvent.create())
+                emit(
+                    AnthropicContentBlockDeltaEvent.create(
+                        index=tool_index,
+                        delta=AnthropicInputJsonDelta.create(
+                            partial_json=tool_call.function.arguments or "{}"
+                        ),
+                    )
+                )
+                emit(AnthropicContentBlockStopEvent.create(index=tool_index))
+            emit(
+                AnthropicMessageDeltaEvent.create(
+                    delta=AnthropicMessageDeltaPayload.create(
+                        stop_reason=_anthropic_stop_reason(
+                            finish_reason, bool(tool_blocks)
+                        )
+                    ),
+                    usage=(
+                        AnthropicUsagePayload.from_usage(state.usage)
+                        if state.usage
+                        else AnthropicUsagePayload.zero()
+                    ),
+                )
+            )
+            emit(AnthropicMessageStopEvent.create())
 
 
 def handle_anthropic_messages(

--- a/backend/onyx/server/gateway/models.py
+++ b/backend/onyx/server/gateway/models.py
@@ -770,10 +770,34 @@ class AnthropicMessageStopEvent(_WireModel):
         return cls(type="message_stop")
 
 
+class AnthropicErrorPayload(_WireModel):
+    type: str
+    message: str
+
+    @classmethod
+    def create(cls, *, error_type: str, message: str) -> "AnthropicErrorPayload":
+        return cls(type=error_type, message=message)
+
+
 class AnthropicErrorEvent(_WireModel):
     type: Literal["error"] = "error"
-    error: dict[str, Any]
+    error: AnthropicErrorPayload
 
     @classmethod
     def create(cls, *, message: str, error_type: str) -> "AnthropicErrorEvent":
-        return cls(type="error", error={"type": error_type, "message": message})
+        return cls(
+            type="error",
+            error=AnthropicErrorPayload.create(error_type=error_type, message=message),
+        )
+
+
+AnthropicStreamEvent: TypeAlias = (
+    AnthropicMessageStartEvent
+    | AnthropicPingEvent
+    | AnthropicContentBlockStartEvent
+    | AnthropicContentBlockDeltaEvent
+    | AnthropicContentBlockStopEvent
+    | AnthropicMessageDeltaEvent
+    | AnthropicMessageStopEvent
+    | AnthropicErrorEvent
+)

--- a/backend/onyx/server/gateway/models.py
+++ b/backend/onyx/server/gateway/models.py
@@ -544,3 +544,236 @@ class ResponsesFailedEvent(_WireModel):
     @classmethod
     def create(cls, response: ResponsesObjectPayload) -> "ResponsesFailedEvent":
         return cls(type="response.failed", response=response)
+
+
+class AnthropicMessagesRequest(BaseModel):
+    """Anthropic Messages API request. ``extra="allow"`` so unknown params
+    (new client fields, provider-specific extensions) are tolerated rather
+    than rejected. ``stop_sequences`` is declared but tolerated-and-ignored:
+    the LLM interface has no stop support, and refusing the request would
+    block Claude Code outright — a dropped stop sequence degrades output
+    shape but cannot corrupt the conversation. ``top_p``/``top_k`` stay
+    tolerated (undeclared) for the same reason: dropping them only shapes
+    sampling. ``metadata`` is accepted and unused."""
+
+    model_config = ConfigDict(extra="allow")
+
+    model: str
+    messages: list[dict[str, Any]]
+    max_tokens: int
+    system: str | list[dict[str, Any]] | None = None
+    tools: list[dict[str, Any]] | None = None
+    tool_choice: dict[str, Any] | None = None
+    stream: bool = False
+    temperature: float | None = None
+    thinking: dict[str, Any] | None = None
+    output_config: dict[str, Any] | None = None
+    stop_sequences: list[str] | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class AnthropicCountTokensRequest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    model: str
+    messages: list[dict[str, Any]]
+    system: str | list[dict[str, Any]] | None = None
+    tools: list[dict[str, Any]] | None = None
+
+
+class AnthropicTextBlock(_WireModel):
+    type: Literal["text"] = "text"
+    text: str
+
+    @classmethod
+    def create(cls, *, text: str) -> "AnthropicTextBlock":
+        return cls(type="text", text=text)
+
+
+class AnthropicToolUseBlock(_WireModel):
+    type: Literal["tool_use"] = "tool_use"
+    id: str
+    name: str
+    input: dict[str, Any]
+
+    @classmethod
+    def create(
+        cls, *, id: str, name: str, input: dict[str, Any]
+    ) -> "AnthropicToolUseBlock":
+        return cls(type="tool_use", id=id, name=name, input=input)
+
+
+AnthropicContentBlock: TypeAlias = AnthropicTextBlock | AnthropicToolUseBlock
+
+
+class AnthropicUsagePayload(_WireModel):
+    input_tokens: int
+    output_tokens: int
+    cache_creation_input_tokens: int
+    cache_read_input_tokens: int
+
+    @classmethod
+    def from_usage(cls, usage: Usage) -> "AnthropicUsagePayload":
+        # LiteLLM normalizes usage to OpenAI accounting, where prompt_tokens
+        # INCLUDES cache reads/writes; Anthropic's input_tokens EXCLUDES both.
+        input_tokens = max(
+            usage.prompt_tokens
+            - usage.cache_read_input_tokens
+            - usage.cache_creation_input_tokens,
+            0,
+        )
+        return cls(
+            input_tokens=input_tokens,
+            output_tokens=usage.completion_tokens,
+            cache_creation_input_tokens=usage.cache_creation_input_tokens,
+            cache_read_input_tokens=usage.cache_read_input_tokens,
+        )
+
+    @classmethod
+    def zero(cls) -> "AnthropicUsagePayload":
+        return cls(
+            input_tokens=0,
+            output_tokens=0,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
+        )
+
+
+class AnthropicMessageResponse(_WireModel):
+    id: str
+    type: Literal["message"] = "message"
+    role: Literal["assistant"] = "assistant"
+    model: str
+    content: list[AnthropicContentBlock]
+    stop_reason: str | None
+    stop_sequence: str | None
+    usage: AnthropicUsagePayload
+
+    @classmethod
+    def from_parts(
+        cls,
+        *,
+        message_id: str,
+        model: str,
+        content: list[AnthropicContentBlock],
+        stop_reason: str | None,
+        usage: AnthropicUsagePayload,
+    ) -> "AnthropicMessageResponse":
+        # stop_sequence is assigned explicitly (present-and-null) — exclude_unset
+        # would otherwise drop it, but the wire contract always carries the key.
+        return cls(
+            id=message_id,
+            type="message",
+            role="assistant",
+            model=model,
+            content=content,
+            stop_reason=stop_reason,
+            stop_sequence=None,
+            usage=usage,
+        )
+
+
+class AnthropicMessageStartEvent(_WireModel):
+    type: Literal["message_start"] = "message_start"
+    message: AnthropicMessageResponse
+
+    @classmethod
+    def create(cls, message: AnthropicMessageResponse) -> "AnthropicMessageStartEvent":
+        return cls(type="message_start", message=message)
+
+
+class AnthropicPingEvent(_WireModel):
+    type: Literal["ping"] = "ping"
+
+    @classmethod
+    def create(cls) -> "AnthropicPingEvent":
+        return cls(type="ping")
+
+
+class AnthropicContentBlockStartEvent(_WireModel):
+    type: Literal["content_block_start"] = "content_block_start"
+    index: int
+    content_block: AnthropicContentBlock
+
+    @classmethod
+    def create(
+        cls, *, index: int, content_block: AnthropicContentBlock
+    ) -> "AnthropicContentBlockStartEvent":
+        return cls(type="content_block_start", index=index, content_block=content_block)
+
+
+class AnthropicTextDelta(_WireModel):
+    type: Literal["text_delta"] = "text_delta"
+    text: str
+
+    @classmethod
+    def create(cls, *, text: str) -> "AnthropicTextDelta":
+        return cls(type="text_delta", text=text)
+
+
+class AnthropicInputJsonDelta(_WireModel):
+    type: Literal["input_json_delta"] = "input_json_delta"
+    partial_json: str
+
+    @classmethod
+    def create(cls, *, partial_json: str) -> "AnthropicInputJsonDelta":
+        return cls(type="input_json_delta", partial_json=partial_json)
+
+
+class AnthropicContentBlockDeltaEvent(_WireModel):
+    type: Literal["content_block_delta"] = "content_block_delta"
+    index: int
+    delta: AnthropicTextDelta | AnthropicInputJsonDelta
+
+    @classmethod
+    def create(
+        cls, *, index: int, delta: AnthropicTextDelta | AnthropicInputJsonDelta
+    ) -> "AnthropicContentBlockDeltaEvent":
+        return cls(type="content_block_delta", index=index, delta=delta)
+
+
+class AnthropicContentBlockStopEvent(_WireModel):
+    type: Literal["content_block_stop"] = "content_block_stop"
+    index: int
+
+    @classmethod
+    def create(cls, *, index: int) -> "AnthropicContentBlockStopEvent":
+        return cls(type="content_block_stop", index=index)
+
+
+class AnthropicMessageDeltaPayload(_WireModel):
+    stop_reason: str | None
+    stop_sequence: str | None
+
+    @classmethod
+    def create(cls, *, stop_reason: str | None) -> "AnthropicMessageDeltaPayload":
+        return cls(stop_reason=stop_reason, stop_sequence=None)
+
+
+class AnthropicMessageDeltaEvent(_WireModel):
+    type: Literal["message_delta"] = "message_delta"
+    delta: AnthropicMessageDeltaPayload
+    usage: AnthropicUsagePayload
+
+    @classmethod
+    def create(
+        cls, *, delta: AnthropicMessageDeltaPayload, usage: AnthropicUsagePayload
+    ) -> "AnthropicMessageDeltaEvent":
+        return cls(type="message_delta", delta=delta, usage=usage)
+
+
+class AnthropicMessageStopEvent(_WireModel):
+    type: Literal["message_stop"] = "message_stop"
+
+    @classmethod
+    def create(cls) -> "AnthropicMessageStopEvent":
+        return cls(type="message_stop")
+
+
+class AnthropicErrorEvent(_WireModel):
+    type: Literal["error"] = "error"
+    error: dict[str, Any]
+
+    @classmethod
+    def create(cls, *, message: str, error_type: str) -> "AnthropicErrorEvent":
+        return cls(type="error", error={"type": error_type, "message": message})

--- a/backend/tests/unit/onyx/server/gateway/test_anthropic_messages_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_anthropic_messages_api.py
@@ -298,7 +298,6 @@ def test_anthropic_reasoning_effort_output_config_alone_is_honored() -> None:
     [
         ("stop", False, "end_turn"),
         ("length", False, "max_tokens"),
-        # Truncation dominates even when tool calls were accumulated.
         ("length", True, "max_tokens"),
         ("tool_calls", True, "tool_use"),
         ("stop", True, "tool_use"),

--- a/backend/tests/unit/onyx/server/gateway/test_anthropic_messages_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_anthropic_messages_api.py
@@ -1,0 +1,806 @@
+from __future__ import annotations
+
+import json
+import threading
+from contextlib import nullcontext
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import Request
+from sqlalchemy.orm import Session
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.llm.model_response import (
+    ChatCompletionDeltaToolCall,
+    ChatCompletionMessageToolCall,
+    Choice,
+    Delta,
+    FunctionCall,
+    Message,
+    ModelResponse,
+    ModelResponseStream,
+    StreamingChoice,
+    Usage,
+)
+from onyx.llm.models import (
+    AssistantMessage,
+    ReasoningEffort,
+    SystemMessage,
+    ToolChoiceOptions,
+    ToolMessage,
+    UserMessage,
+)
+from onyx.llm.multi_llm import LLMRateLimitError, LLMTimeoutError
+from onyx.server.gateway import api as gateway_api
+from onyx.server.gateway.api import _MESSAGES_ADAPTER
+from onyx.server.gateway.models import (
+    AnthropicCountTokensRequest,
+    AnthropicMessagesRequest,
+)
+from onyx.tracing.flows import LLMFlow
+from tests.unit.onyx.server.gateway.test_llm_gateway_api import (
+    _InvokeLLM,
+    _model,
+    _provider,
+    _RaisingInvokeLLM,
+    _StreamingLLM,
+)
+
+
+def test_anthropic_messages_to_raw_messages_converts_full_turn() -> None:
+    system = [
+        {
+            "type": "text",
+            "text": "You are Claude Code.",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "sure"},
+                {
+                    "type": "tool_use",
+                    "id": "call_1",
+                    "name": "Bash",
+                    "input": {"cmd": "ls"},
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call_1",
+                    "content": [
+                        {"type": "text", "text": "part1"},
+                        {"type": "text", "text": "part2"},
+                    ],
+                }
+            ],
+        },
+    ]
+
+    raw = gateway_api._anthropic_messages_to_raw_messages(messages, system)
+
+    assert raw[0] == {"role": "system", "content": "You are Claude Code."}
+    tool_message = next(m for m in raw if m["role"] == "tool")
+    assert isinstance(tool_message["content"], str)
+    assistant_message = next(m for m in raw if m["role"] == "assistant")
+    assert assistant_message["tool_calls"][0]["function"]["name"] == "Bash"
+    parsed_args = json.loads(
+        assistant_message["tool_calls"][0]["function"]["arguments"]
+    )
+    assert parsed_args == {"cmd": "ls"}
+
+    validated = _MESSAGES_ADAPTER.validate_python(raw)
+    assert [type(m) for m in validated] == [
+        SystemMessage,
+        UserMessage,
+        AssistantMessage,
+        ToolMessage,
+    ]
+
+
+def test_anthropic_system_string_becomes_system_message() -> None:
+    raw = gateway_api._anthropic_messages_to_raw_messages(
+        [{"role": "user", "content": "hi"}], "You are terse."
+    )
+    assert raw[0] == {"role": "system", "content": "You are terse."}
+
+
+def test_anthropic_messages_reject_multimodal_tool_results() -> None:
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call_1",
+                    "content": [
+                        {"type": "text", "text": "screenshot"},
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": "abc",
+                            },
+                        },
+                    ],
+                }
+            ],
+        }
+    ]
+
+    with pytest.raises(OnyxError) as exc_info:
+        gateway_api._anthropic_messages_to_raw_messages(messages, None)
+
+    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
+
+
+@pytest.mark.parametrize("system", [None, "", "   ", []])
+def test_anthropic_blank_system_produces_no_system_message(
+    system: str | list[dict[str, Any]] | None,
+) -> None:
+    raw = gateway_api._anthropic_messages_to_raw_messages(
+        [{"role": "user", "content": "hi"}], system
+    )
+    assert all(m["role"] != "system" for m in raw)
+
+
+def test_anthropic_tools_converts_custom_tool() -> None:
+    request = AnthropicMessagesRequest(
+        model="1/test",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=100,
+        tools=[
+            {
+                "name": "Bash",
+                "description": "run",
+                "input_schema": {"type": "object", "properties": {}},
+            }
+        ],
+    )
+
+    tools = gateway_api._anthropic_tools(request.tools)
+
+    assert tools == [
+        {
+            "type": "function",
+            "function": {
+                "name": "Bash",
+                "parameters": {"type": "object", "properties": {}},
+                "description": "run",
+            },
+        }
+    ]
+
+
+def test_anthropic_tools_rejects_hosted_tool_without_input_schema() -> None:
+    request = AnthropicMessagesRequest(
+        model="1/test",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=100,
+        tools=[{"type": "web_search_20250305", "name": "web_search"}],
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        gateway_api._anthropic_tools(request.tools)
+
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
+
+
+def test_anthropic_tools_none_when_absent() -> None:
+    request = AnthropicMessagesRequest(
+        model="1/test",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=100,
+    )
+    assert gateway_api._anthropic_tools(request.tools) is None
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, None),
+        ({"type": "auto"}, ToolChoiceOptions.AUTO),
+        ({"type": "any"}, ToolChoiceOptions.REQUIRED),
+        ({"type": "none"}, ToolChoiceOptions.NONE),
+    ],
+)
+def test_anthropic_tool_choice(
+    raw: dict[str, Any] | None, expected: ToolChoiceOptions | None
+) -> None:
+    assert gateway_api._anthropic_tool_choice(raw) is expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [{"type": "tool", "name": "Bash"}, {"type": "bogus"}],
+)
+def test_anthropic_tool_choice_refuses_unsupported(raw: dict[str, Any]) -> None:
+    with pytest.raises(OnyxError) as exc_info:
+        gateway_api._anthropic_tool_choice(raw)
+    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
+
+
+def test_anthropic_reasoning_effort_defaults_to_auto_when_absent() -> None:
+    assert gateway_api._anthropic_reasoning_effort(None, None) is ReasoningEffort.AUTO
+
+
+def test_anthropic_reasoning_effort_disabled_maps_to_off() -> None:
+    assert (
+        gateway_api._anthropic_reasoning_effort({"type": "disabled"}, None)
+        is ReasoningEffort.OFF
+    )
+
+
+def test_anthropic_reasoning_effort_disabled_wins_over_output_config() -> None:
+    assert (
+        gateway_api._anthropic_reasoning_effort(
+            {"type": "disabled"}, {"effort": "high"}
+        )
+        is ReasoningEffort.OFF
+    )
+
+
+def test_anthropic_reasoning_effort_enabled_maps_to_a_real_effort() -> None:
+    effort = gateway_api._anthropic_reasoning_effort(
+        {"type": "enabled", "budget_tokens": 8000}, None
+    )
+    assert effort in (ReasoningEffort.LOW, ReasoningEffort.MEDIUM, ReasoningEffort.HIGH)
+
+
+@pytest.mark.parametrize(
+    ("effort_raw", "expected"),
+    [
+        ("low", ReasoningEffort.LOW),
+        ("medium", ReasoningEffort.MEDIUM),
+        ("high", ReasoningEffort.HIGH),
+        ("xhigh", ReasoningEffort.XHIGH),
+    ],
+)
+def test_anthropic_reasoning_effort_adaptive_honors_output_config_effort(
+    effort_raw: str, expected: ReasoningEffort
+) -> None:
+    effort = gateway_api._anthropic_reasoning_effort(
+        {"type": "adaptive"}, {"effort": effort_raw}
+    )
+    assert effort is expected
+
+
+def test_anthropic_reasoning_effort_adaptive_without_effort_stays_auto() -> None:
+    assert (
+        gateway_api._anthropic_reasoning_effort({"type": "adaptive"}, None)
+        is ReasoningEffort.AUTO
+    )
+
+
+def test_anthropic_reasoning_effort_output_config_alone_is_honored() -> None:
+    assert (
+        gateway_api._anthropic_reasoning_effort(None, {"effort": "high"})
+        is ReasoningEffort.HIGH
+    )
+
+
+@pytest.mark.parametrize(
+    ("finish_reason", "has_tool_use", "expected"),
+    [
+        ("stop", False, "end_turn"),
+        ("length", False, "max_tokens"),
+        ("tool_calls", True, "tool_use"),
+        ("stop", True, "tool_use"),
+        ("content_filter", False, "refusal"),
+        (None, False, "end_turn"),
+    ],
+)
+def test_anthropic_stop_reason(
+    finish_reason: str | None, has_tool_use: bool, expected: str
+) -> None:
+    assert gateway_api._anthropic_stop_reason(finish_reason, has_tool_use) == expected
+
+
+def _tool_call(
+    arguments: str, *, name: str | None = "Bash"
+) -> ChatCompletionMessageToolCall:
+    return ChatCompletionMessageToolCall(
+        id="call_1", function=FunctionCall(name=name, arguments=arguments)
+    )
+
+
+def test_anthropic_tool_use_blocks_parses_valid_json() -> None:
+    blocks = gateway_api._anthropic_tool_use_blocks([_tool_call('{"cmd":"ls"}')])
+    assert blocks[0].input == {"cmd": "ls"}
+
+
+def test_anthropic_tool_use_blocks_empty_arguments_become_empty_dict() -> None:
+    blocks = gateway_api._anthropic_tool_use_blocks([_tool_call("")])
+    assert blocks[0].input == {}
+
+
+@pytest.mark.parametrize("arguments", ["{not json", "[1]"])
+def test_anthropic_tool_use_blocks_rejects_invalid_input(arguments: str) -> None:
+    with pytest.raises(ValueError):
+        gateway_api._anthropic_tool_use_blocks([_tool_call(arguments)])
+
+
+def test_anthropic_tool_use_blocks_skips_nameless_call() -> None:
+    blocks = gateway_api._anthropic_tool_use_blocks([_tool_call("{}", name=None)])
+    assert blocks == []
+
+
+def test_anthropic_messages_request_tolerates_unknown_top_level_fields() -> None:
+    request = AnthropicMessagesRequest.model_validate(
+        {
+            "model": "1/test",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+            "anthropic_version": "2023-06-01",
+            "extra_thing": 1,
+        }
+    )
+    assert request.model == "1/test"
+
+
+def _handle_anthropic_call(request: AnthropicMessagesRequest) -> Any:
+    provider = _provider(1, "openai", [_model("test")])
+    return gateway_api.handle_anthropic_messages(
+        request=request,
+        provider=provider,
+        model_config=provider.model_configurations[0],
+        flow=LLMFlow.CRAFT_LLM_GENERATION,
+    )
+
+
+def _anthropic_request(**overrides: Any) -> AnthropicMessagesRequest:
+    defaults: dict[str, Any] = {
+        "model": "1/test",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 1024,
+    }
+    defaults.update(overrides)
+    return AnthropicMessagesRequest(**defaults)
+
+
+def test_handle_anthropic_messages_happy_path_serializes_response() -> None:
+    response = ModelResponse(
+        id="msg-1",
+        created="1784577999",
+        choice=Choice(
+            finish_reason="tool_calls",
+            message=Message(
+                content="Sure thing",
+                tool_calls=[
+                    ChatCompletionMessageToolCall(
+                        id="call_1",
+                        function=FunctionCall(name="Bash", arguments='{"cmd":"ls"}'),
+                    )
+                ],
+            ),
+        ),
+        usage=Usage(
+            prompt_tokens=100,
+            completion_tokens=10,
+            total_tokens=110,
+            cache_creation_input_tokens=20,
+            cache_read_input_tokens=30,
+        ),
+    )
+
+    with patch.object(
+        gateway_api, "llm_from_provider", return_value=_InvokeLLM(response)
+    ):
+        result = _handle_anthropic_call(_anthropic_request())
+
+    payload = result.to_wire()
+    assert payload["type"] == "message"
+    assert payload["role"] == "assistant"
+    assert payload["content"] == [
+        {"type": "text", "text": "Sure thing"},
+        {"type": "tool_use", "id": "call_1", "name": "Bash", "input": {"cmd": "ls"}},
+    ]
+    assert payload["stop_reason"] == "tool_use"
+    assert "stop_sequence" in payload
+    assert payload["stop_sequence"] is None
+    assert payload["usage"] == {
+        "input_tokens": 50,
+        "output_tokens": 10,
+        "cache_creation_input_tokens": 20,
+        "cache_read_input_tokens": 30,
+    }
+
+
+def test_handle_anthropic_messages_rejects_invalid_upstream_tool_arguments() -> None:
+    response = ModelResponse(
+        id="msg-1",
+        created="1784577999",
+        choice=Choice(
+            finish_reason="tool_calls",
+            message=Message(
+                tool_calls=[
+                    ChatCompletionMessageToolCall(
+                        id="call_1",
+                        function=FunctionCall(name="Bash", arguments="{not json"),
+                    )
+                ]
+            ),
+        ),
+    )
+
+    with (
+        patch.object(
+            gateway_api, "llm_from_provider", return_value=_InvokeLLM(response)
+        ),
+        pytest.raises(OnyxError) as exc_info,
+    ):
+        _handle_anthropic_call(_anthropic_request())
+
+    assert exc_info.value.error_code is OnyxErrorCode.BAD_GATEWAY
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected_code"),
+    [
+        (LLMRateLimitError("slow down"), OnyxErrorCode.RATE_LIMITED),
+        (LLMTimeoutError("too slow"), OnyxErrorCode.BAD_GATEWAY),
+    ],
+)
+def test_handle_anthropic_messages_maps_provider_errors_to_onyx_codes(
+    exc: Exception, expected_code: OnyxErrorCode
+) -> None:
+    with (
+        patch.object(
+            gateway_api, "llm_from_provider", return_value=_RaisingInvokeLLM(exc)
+        ),
+        pytest.raises(OnyxError) as exc_info,
+    ):
+        _handle_anthropic_call(_anthropic_request())
+
+    assert exc_info.value.error_code == expected_code
+
+
+def test_handle_anthropic_messages_sanitizes_generic_invoke_failure() -> None:
+    with (
+        patch.object(
+            gateway_api,
+            "llm_from_provider",
+            return_value=_RaisingInvokeLLM(ValueError("secret-url?key=abc")),
+        ),
+        pytest.raises(OnyxError) as exc_info,
+    ):
+        _handle_anthropic_call(_anthropic_request())
+
+    assert exc_info.value.error_code == OnyxErrorCode.BAD_GATEWAY
+    assert "secret" not in str(exc_info.value.detail)
+    assert "abc" not in str(exc_info.value.detail)
+
+
+def _anthropic_stream_events(
+    llm: Any,
+    *,
+    tools: list[dict[str, Any]] | None = None,
+    model: str = "1/test",
+    message_id: str = "msg_1",
+) -> list[dict[str, Any]]:
+    with patch.object(gateway_api, "llm_generation_span", return_value=nullcontext()):
+        frames = list(
+            gateway_api._run_bridged_stream(
+                gateway_api._anthropic_stream_worker,
+                {
+                    "llm": llm,
+                    "flow": LLMFlow.CRAFT_LLM_GENERATION,
+                    "messages": [UserMessage(content="hi")],
+                    "tools": tools,
+                    "tool_choice": None,
+                    "max_tokens": 1024,
+                    "reasoning_effort": ReasoningEffort.AUTO,
+                    "model": model,
+                    "message_id": message_id,
+                },
+            )
+        )
+
+    events: list[dict[str, Any]] = []
+    for frame in frames:
+        assert frame.endswith("\n\n")
+        event_line, data_line = frame[:-2].split("\n", 1)
+        assert event_line.startswith("event: ")
+        assert data_line.startswith("data: ")
+        data = json.loads(data_line.removeprefix("data: "))
+        assert data["type"] == event_line.removeprefix("event: ")
+        events.append(data)
+    return events
+
+
+class _AnthropicChunkStreamLLM(_StreamingLLM):
+    def __init__(self, chunks: list[ModelResponseStream]) -> None:
+        super().__init__(threading.Event())
+        self._chunks = chunks
+
+    def stream(self, *args: object, **kwargs: object) -> Any:  # type: ignore[override]
+        del args, kwargs
+        yield from self._chunks
+
+
+_TEXT_AND_TOOL_CALL_CHUNKS = [
+    ModelResponseStream(
+        id="a1", created="0", choice=StreamingChoice(delta=Delta(content="Hi"))
+    ),
+    ModelResponseStream(
+        id="a1", created="0", choice=StreamingChoice(delta=Delta(content=" there"))
+    ),
+    ModelResponseStream(
+        id="a1",
+        created="0",
+        choice=StreamingChoice(
+            delta=Delta(
+                tool_calls=[
+                    ChatCompletionDeltaToolCall(
+                        id="call_1",
+                        index=0,
+                        function=FunctionCall(name="Bash", arguments=""),
+                    )
+                ]
+            )
+        ),
+    ),
+    ModelResponseStream(
+        id="a1",
+        created="0",
+        choice=StreamingChoice(
+            delta=Delta(
+                tool_calls=[
+                    ChatCompletionDeltaToolCall(
+                        index=0,
+                        function=FunctionCall(arguments='{"cmd":"ls"}'),
+                    )
+                ]
+            )
+        ),
+    ),
+    ModelResponseStream(
+        id="a1",
+        created="0",
+        choice=StreamingChoice(finish_reason="tool_calls", delta=Delta()),
+        usage=Usage(
+            prompt_tokens=100,
+            completion_tokens=10,
+            total_tokens=110,
+            cache_creation_input_tokens=20,
+            cache_read_input_tokens=30,
+        ),
+    ),
+]
+
+
+def test_anthropic_stream_emits_text_then_tool_use_then_stop_in_order() -> None:
+    events = _anthropic_stream_events(
+        _AnthropicChunkStreamLLM(_TEXT_AND_TOOL_CALL_CHUNKS)
+    )
+    event_types = [e["type"] for e in events]
+
+    assert event_types == [
+        "message_start",
+        "ping",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_delta",
+        "content_block_stop",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+
+    message_start = events[0]
+    assert message_start["message"]["content"] == []
+    assert message_start["message"]["usage"] == {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+    }
+
+    text_block_start = events[2]
+    assert text_block_start["index"] == 0
+    assert text_block_start["content_block"] == {"type": "text", "text": ""}
+    assert [e["delta"]["text"] for e in events[3:5]] == ["Hi", " there"]
+    assert events[5]["index"] == 0
+
+    tool_block_start = events[6]
+    assert tool_block_start["index"] == 1
+    assert tool_block_start["content_block"]["type"] == "tool_use"
+    assert tool_block_start["content_block"]["id"] == "call_1"
+    assert tool_block_start["content_block"]["name"] == "Bash"
+    assert tool_block_start["content_block"]["input"] == {}
+
+    tool_delta = events[7]
+    assert tool_delta["index"] == 1
+    assert tool_delta["delta"]["type"] == "input_json_delta"
+    assert tool_delta["delta"]["partial_json"] == '{"cmd":"ls"}'
+    assert events[8]["index"] == 1
+
+    message_delta = events[9]
+    assert message_delta["delta"]["stop_reason"] == "tool_use"
+    assert message_delta["usage"] == {
+        "input_tokens": 50,
+        "output_tokens": 10,
+        "cache_creation_input_tokens": 20,
+        "cache_read_input_tokens": 30,
+    }
+
+
+_TEXT_ONLY_CHUNKS = [
+    ModelResponseStream(
+        id="a2", created="0", choice=StreamingChoice(delta=Delta(content="Hi"))
+    ),
+    ModelResponseStream(
+        id="a2",
+        created="0",
+        choice=StreamingChoice(finish_reason="stop", delta=Delta()),
+    ),
+]
+
+
+def test_anthropic_stream_text_only_ends_with_end_turn() -> None:
+    events = _anthropic_stream_events(_AnthropicChunkStreamLLM(_TEXT_ONLY_CHUNKS))
+
+    message_delta = next(e for e in events if e["type"] == "message_delta")
+    assert message_delta["delta"]["stop_reason"] == "end_turn"
+    assert not any(
+        e["type"] == "content_block_start" and e["content_block"]["type"] == "tool_use"
+        for e in events
+    )
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected_error_type"),
+    [
+        (RuntimeError("secret-provider-response"), "api_error"),
+        (LLMRateLimitError("slow down"), "rate_limit_error"),
+    ],
+)
+def test_anthropic_stream_upstream_failure_emits_single_error_frame(
+    exc: Exception, expected_error_type: str
+) -> None:
+    events = _anthropic_stream_events(
+        _StreamingLLM(threading.Event(), fail=True, exc=exc)
+    )
+
+    assert events[-1]["type"] == "error"
+    assert events[-1]["error"]["type"] == expected_error_type
+    assert "secret-provider-response" not in json.dumps(events)
+    assert not any(e["type"] == "message_stop" for e in events)
+    assert sum(1 for e in events if e["type"] == "error") == 1
+
+
+def test_anthropic_messages_endpoint_rejects_non_gateway_credentials() -> None:
+    request = _anthropic_request()
+    with (
+        patch.dict(
+            gateway_api._FLOW_ACCESS_CHECKS,
+            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=False)},
+        ),
+        pytest.raises(OnyxError) as exc_info,
+    ):
+        gateway_api.gateway_anthropic_messages(
+            request=request,
+            http_request=MagicMock(spec=Request),
+            user=MagicMock(),
+            db_session=MagicMock(spec=Session),
+        )
+    assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+
+
+def test_anthropic_messages_endpoint_enforces_token_rate_limits() -> None:
+    request = _anthropic_request()
+    user = MagicMock()
+    rate_limited = OnyxError(OnyxErrorCode.RATE_LIMITED, "over budget")
+
+    with (
+        patch.dict(
+            gateway_api._FLOW_ACCESS_CHECKS,
+            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=True)},
+        ),
+        patch.object(
+            gateway_api, "check_token_rate_limits", side_effect=rate_limited
+        ) as rate_check,
+        patch.object(gateway_api, "resolve_gateway_model") as resolve_model,
+        patch.object(gateway_api, "handle_anthropic_messages") as handle,
+        pytest.raises(OnyxError) as exc_info,
+    ):
+        gateway_api.gateway_anthropic_messages(
+            request=request,
+            http_request=MagicMock(spec=Request),
+            user=user,
+            db_session=MagicMock(spec=Session),
+        )
+
+    assert exc_info.value.error_code is OnyxErrorCode.RATE_LIMITED
+    rate_check.assert_called_once_with(user)
+    resolve_model.assert_not_called()
+    handle.assert_not_called()
+
+
+def test_anthropic_count_tokens_endpoint_rejects_non_gateway_credentials() -> None:
+    request = AnthropicCountTokensRequest(
+        model="1/test", messages=[{"role": "user", "content": "hi"}]
+    )
+    with (
+        patch.dict(
+            gateway_api._FLOW_ACCESS_CHECKS,
+            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=False)},
+        ),
+        pytest.raises(OnyxError) as exc_info,
+    ):
+        gateway_api.gateway_anthropic_count_tokens(
+            request=request,
+            http_request=MagicMock(spec=Request),
+            user=MagicMock(),
+            db_session=MagicMock(spec=Session),
+        )
+    assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+
+
+def test_gateway_anthropic_count_tokens_includes_tools() -> None:
+    provider = _provider(1, "openai", [_model("test")])
+    model_config = provider.model_configurations[0]
+    request = AnthropicCountTokensRequest(
+        model="1/test",
+        messages=[{"role": "user", "content": "hello"}],
+        system="Be terse.",
+        tools=[
+            {
+                "name": "Bash",
+                "description": "run",
+                "input_schema": {"type": "object", "properties": {}},
+            }
+        ],
+    )
+    with (
+        patch.dict(
+            gateway_api._FLOW_ACCESS_CHECKS,
+            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=True)},
+        ),
+        patch.object(
+            gateway_api,
+            "resolve_gateway_model",
+            return_value=(provider, model_config),
+        ),
+        patch(
+            "onyx.llm.litellm_singleton.litellm.token_counter", return_value=123
+        ) as token_counter,
+    ):
+        response = gateway_api.gateway_anthropic_count_tokens(
+            request=request,
+            http_request=MagicMock(spec=Request),
+            user=MagicMock(),
+            db_session=MagicMock(spec=Session),
+        )
+
+    payload = json.loads(bytes(response.body))
+    assert payload == {"input_tokens": 123}
+    token_counter.assert_called_once_with(
+        model=model_config.name,
+        messages=[
+            {"role": "system", "content": "Be terse."},
+            {"role": "user", "content": "hello"},
+        ],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "Bash",
+                    "description": "run",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    )

--- a/backend/tests/unit/onyx/server/gateway/test_anthropic_messages_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_anthropic_messages_api.py
@@ -298,6 +298,8 @@ def test_anthropic_reasoning_effort_output_config_alone_is_honored() -> None:
     [
         ("stop", False, "end_turn"),
         ("length", False, "max_tokens"),
+        # Truncation dominates even when tool calls were accumulated.
+        ("length", True, "max_tokens"),
         ("tool_calls", True, "tool_use"),
         ("stop", True, "tool_use"),
         ("content_filter", False, "refusal"),

--- a/backend/tests/unit/onyx/server/gateway/test_anthropic_messages_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_anthropic_messages_api.py
@@ -8,10 +8,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import Request
+from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.llm.interfaces import LLM
 from onyx.llm.model_response import (
     ChatCompletionDeltaToolCall,
     ChatCompletionMessageToolCall,
@@ -37,10 +39,12 @@ from onyx.server.gateway import api as gateway_api
 from onyx.server.gateway.api import _MESSAGES_ADAPTER
 from onyx.server.gateway.models import (
     AnthropicCountTokensRequest,
+    AnthropicMessageResponse,
     AnthropicMessagesRequest,
 )
 from onyx.tracing.flows import LLMFlow
 from tests.unit.onyx.server.gateway.test_llm_gateway_api import (
+    _ChunkStreamLLM,
     _InvokeLLM,
     _model,
     _provider,
@@ -348,7 +352,9 @@ def test_anthropic_messages_request_tolerates_unknown_top_level_fields() -> None
     assert request.model == "1/test"
 
 
-def _handle_anthropic_call(request: AnthropicMessagesRequest) -> Any:
+def _handle_anthropic_call(
+    request: AnthropicMessagesRequest,
+) -> StreamingResponse | AnthropicMessageResponse:
     provider = _provider(1, "openai", [_model("test")])
     return gateway_api.handle_anthropic_messages(
         request=request,
@@ -398,6 +404,7 @@ def test_handle_anthropic_messages_happy_path_serializes_response() -> None:
     ):
         result = _handle_anthropic_call(_anthropic_request())
 
+    assert isinstance(result, AnthropicMessageResponse)
     payload = result.to_wire()
     assert payload["type"] == "message"
     assert payload["role"] == "assistant"
@@ -482,7 +489,7 @@ def test_handle_anthropic_messages_sanitizes_generic_invoke_failure() -> None:
 
 
 def _anthropic_stream_events(
-    llm: Any,
+    llm: LLM,
     *,
     tools: list[dict[str, Any]] | None = None,
     model: str = "1/test",
@@ -516,16 +523,6 @@ def _anthropic_stream_events(
         assert data["type"] == event_line.removeprefix("event: ")
         events.append(data)
     return events
-
-
-class _AnthropicChunkStreamLLM(_StreamingLLM):
-    def __init__(self, chunks: list[ModelResponseStream]) -> None:
-        super().__init__(threading.Event())
-        self._chunks = chunks
-
-    def stream(self, *args: object, **kwargs: object) -> Any:  # type: ignore[override]
-        del args, kwargs
-        yield from self._chunks
 
 
 _TEXT_AND_TOOL_CALL_CHUNKS = [
@@ -580,9 +577,7 @@ _TEXT_AND_TOOL_CALL_CHUNKS = [
 
 
 def test_anthropic_stream_emits_text_then_tool_use_then_stop_in_order() -> None:
-    events = _anthropic_stream_events(
-        _AnthropicChunkStreamLLM(_TEXT_AND_TOOL_CALL_CHUNKS)
-    )
+    events = _anthropic_stream_events(_ChunkStreamLLM(_TEXT_AND_TOOL_CALL_CHUNKS))
     event_types = [e["type"] for e in events]
 
     assert event_types == [
@@ -650,7 +645,7 @@ _TEXT_ONLY_CHUNKS = [
 
 
 def test_anthropic_stream_text_only_ends_with_end_turn() -> None:
-    events = _anthropic_stream_events(_AnthropicChunkStreamLLM(_TEXT_ONLY_CHUNKS))
+    events = _anthropic_stream_events(_ChunkStreamLLM(_TEXT_ONLY_CHUNKS))
 
     message_delta = next(e for e in events if e["type"] == "message_delta")
     assert message_delta["delta"]["stop_reason"] == "end_turn"


### PR DESCRIPTION
## Description

Adds the Anthropic Messages API to the Onyx LLM gateway so Claude Code (and other Anthropic-native clients) can use it via `ANTHROPIC_BASE_URL`:

- `POST /gateway/v1/messages` — streaming (Anthropic SSE `event:` framing: `message_start`/`ping`/`content_block_*`/`message_delta`/`message_stop`, in-band `error` events) and non-streaming.
- `POST /gateway/v1/messages/count_tokens` — Claude Code calls this for context tracking; falls back to a rough estimate rather than failing.

Design, following the Responses-API precedent in this stack:
- Input translation reuses LiteLLM's Anthropic→OpenAI adapter; system/tool list-content is collapsed to fit our str-only message fields; tools are hand-mapped (`input_schema` → function `parameters`).
- Output is hand-rolled frozen `_WireModel` payloads. Text streams live; `tool_use` blocks emit at end-of-stream as one `input_json_delta` (same tradeoff as the Responses endpoint).
- Usage converts back to Anthropic accounting: `input_tokens` excludes cache reads/writes (LiteLLM folds them into `prompt_tokens`).
- Both Anthropic thinking APIs are supported off a single `ReasoningEffort`: legacy `thinking.type=enabled` + `budget_tokens` and adaptive `thinking.type=adaptive` + `output_config.effort`; the LLM layer re-derives the right API per model.
- Refused (can't be honored): server-side/hosted tools, named-tool `tool_choice`, multimodal `tool_result` content. Tolerated-and-ignored (dropping only shapes output): `stop_sequences`, `top_p`/`top_k`, `metadata`.
- Thinking blocks replayed in history are stripped (signatures can't round-trip through the internal abstraction) — deliberate, matches existing chat-path behavior.

Auth is the existing gateway model: Bearer PAT with `USE_LLM_GATEWAY` scope (`ANTHROPIC_AUTH_TOKEN`; `ANTHROPIC_API_KEY`/x-api-key is not supported), model id `<provider_id>/<model_name>` via `ANTHROPIC_MODEL`.

## How Has This Been Tested?

- 52 new unit tests in `test_anthropic_messages_api.py` (conversion, refusals, thinking/effort matrix, stop reasons, non-streaming shape, streaming event order/framing, stream errors, usage math incl. cache subtraction, auth gating, count_tokens) — 129 pass in the gateway suite.
- Live end-to-end against a local instance with a real Anthropic provider: curl (non-streaming, streaming tool-use, count_tokens) and real Claude Code CLI turns through the gateway — plain text turn and a 4-turn agentic tool-use session (`ls` + file read), including prompt-cache hits (cache_read ≈ full prefix on later turns) and correct cost attribution in the usage ledger.
- 4-lens review pass (correctness / security / tests / regressions): no critical/high findings; regressions lens verified the diff is purely additive.

### Known minor items (for the reviewer, deliberately not fixed here)

- Precedence when a client sends BOTH legacy `thinking.budget_tokens` and `output_config.effort`: `output_config.effort` wins. Debatable; real clients target one API per model generation, so the combination should be rare.
- `count_tokens` runs the tokenizer without a token-budget check (nothing is generated); an authorized user could burn CPU on it. Body-size limits still apply.
- Test gaps flagged by review: no per-route single-permission-dependency tests for the two new routes (the blanket router auth test does cover them), no test for the usage clamp actually clamping, none for the count_tokens fallback branch or the hosted-tool identifier fallback when `name` is absent.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

**Stack:**
1. [gateway-reject-unsupported-params #13650](https://github.com/onyx-dot-app/onyx/pull/13650)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Anthropic Messages API support in the LLM gateway so Claude Code and Anthropic-native clients can use `ANTHROPIC_BASE_URL`. Includes SSE streaming and token counting with Anthropic-accurate usage and stop reasons, plus a small stream-loop refactor for clearer cancellation and completion.

- **New Features**
  - Added `POST /gateway/v1/messages` (streaming SSE: `message_start`/`ping`/`content_block_*`/`message_delta`/`message_stop`, and non-streaming) and `POST /gateway/v1/messages/count_tokens` (falls back to a rough estimate).
  - Translates Anthropic requests via `litellm`; collapses system/tool content to strings; maps tools (`input_schema` → function `parameters`); rejects multimodal `tool_result`.
  - Supports both thinking APIs via one `ReasoningEffort`; converts usage to Anthropic accounting (`input_tokens` excludes cache reads/writes). Ignores `stop_sequences` and sampling params.

- **Bug Fixes**
  - Correct stop reason mapping: report `max_tokens` over `tool_use` when a tool-call turn truncates.
  - Rejects hosted/server-side tools and named-tool `tool_choice`; validates `tool_choice` values.
  - Streaming: emit a single in-band `error` and close upstream; replace for-else loops with early returns to improve cancellation and final-frame handling, with tighter typing for stream events and the adapter.

<sup>Written for commit 07cbb781cecf35283b0145a8fb62b1e4b9500e88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

