### PR TITLE
fix(craft): make waking a session reliable, not a race

### DIFF
--- a/backend/onyx/server/features/build/interactive_turns/api.py
+++ b/backend/onyx/server/features/build/interactive_turns/api.py
@@ -17,12 +17,13 @@ from onyx.cache.factory import get_cache_backend
 from onyx.cache.interface import CacheBackend
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session, get_session_with_current_tenant
-from onyx.db.enums import Permission
+from onyx.db.enums import Permission, SandboxStatus
 from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.configs import SSE_KEEPALIVE_INTERVAL
 from onyx.server.features.build.db.build_session import get_build_session
+from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.interactive_turns.executor import (
     start_interactive_turn_runner,
 )
@@ -192,7 +193,18 @@ def get_interactive_turn_events(
                 if session is None:
                     yield _format_stream_error("Session not found")
                     return
-                if session.opencode_session_id:
+                # Both conditions, because neither implies the other. The
+                # opencode session id outlives the pod that minted it, so after
+                # the sandbox has been reclaimed it is set from the previous
+                # incarnation while nothing is listening yet — and the runner
+                # is concurrently waking the sandbox, so the right answer is to
+                # keep the stream open and wait rather than fail the turn the
+                # user just sent.
+                sandbox = get_sandbox_by_user_id(stream_db_session, user_id)
+                runtime_ready = (
+                    sandbox is not None and sandbox.status == SandboxStatus.RUNNING
+                )
+                if session.opencode_session_id and runtime_ready:
                     break
 
             yield SSE_KEEPALIVE

--- a/backend/onyx/server/features/build/interactive_turns/api.py
+++ b/backend/onyx/server/features/build/interactive_turns/api.py
@@ -17,7 +17,7 @@ from onyx.cache.factory import get_cache_backend
 from onyx.cache.interface import CacheBackend
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session, get_session_with_current_tenant
-from onyx.db.enums import Permission, SandboxStatus
+from onyx.db.enums import Permission
 from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -193,18 +193,15 @@ def get_interactive_turn_events(
                 if session is None:
                     yield _format_stream_error("Session not found")
                     return
-                # Both conditions, because neither implies the other. The
-                # opencode session id outlives the pod that minted it, so after
-                # the sandbox has been reclaimed it is set from the previous
-                # incarnation while nothing is listening yet — and the runner
-                # is concurrently waking the sandbox, so the right answer is to
-                # keep the stream open and wait rather than fail the turn the
-                # user just sent.
+                # The opencode session id outlives the pod that minted it, so
+                # after a reap it is set while nothing is listening — and the
+                # runner is concurrently waking the sandbox. Wait for both.
                 sandbox = get_sandbox_by_user_id(stream_db_session, user_id)
-                runtime_ready = (
-                    sandbox is not None and sandbox.status == SandboxStatus.RUNNING
-                )
-                if session.opencode_session_id and runtime_ready:
+                if (
+                    session.opencode_session_id
+                    and sandbox is not None
+                    and sandbox.status.is_active()
+                ):
                     break
 
             yield SSE_KEEPALIVE

--- a/backend/onyx/server/features/build/interactive_turns/executor.py
+++ b/backend/onyx/server/features/build/interactive_turns/executor.py
@@ -198,6 +198,11 @@ def _ready_session_runtime(
     is rebuilt through the same path and the same lock the restore endpoint
     uses, blocking, because the turn has nothing to do until the workspace is
     there.
+
+    The pre-lock check is only a fast path: ``ensure_session_ready`` re-verifies
+    everything (pod liveness included) under the lock, so it stays with this
+    caller — its point is skipping the lock on the hot path, and lock
+    acquisition is caller policy (the turn blocks; restore 409s).
     """
     session = get_build_session(session_id, user_id, db_session)
     sandbox = get_sandbox_by_user_id(db_session, user_id)

--- a/backend/onyx/server/features/build/interactive_turns/executor.py
+++ b/backend/onyx/server/features/build/interactive_turns/executor.py
@@ -187,21 +187,14 @@ def _ready_session_runtime(
 ) -> Sandbox:
     """The sandbox this turn runs in, with the session's workspace present.
 
-    Ensuring the sandbox is not enough: a session whose workspace was reclaimed
-    needs it rebuilt, and rebuilding it concurrently with the prompt is what
-    leaves opencode pinned to a config that did not exist yet. So on anything
-    but the settled case we take the lock the restore endpoint holds and go
-    through the same path — blocking, because the turn has nothing to do until
-    the workspace is there.
-
-    The settled case is decided from the database alone. It is the common one,
-    and confirming a workspace costs an exec into the pod, so a turn on a live
-    session pays two reads and no lock.
+    A settled session returns straight away; anything else — a sandbox the
+    reaper took, a session never restored — is rebuilt through the same path and
+    the same lock the restore endpoint uses, blocking, because the turn has
+    nothing to do until the workspace is there.
     """
     session = get_build_session(session_id, user_id, db_session)
     sandbox = get_sandbox_by_user_id(db_session, user_id)
-    if session_runtime_intact(session, sandbox):
-        assert sandbox is not None
+    if sandbox is not None and session_runtime_intact(session, sandbox):
         return sandbox
 
     if session is None:

--- a/backend/onyx/server/features/build/interactive_turns/executor.py
+++ b/backend/onyx/server/features/build/interactive_turns/executor.py
@@ -19,7 +19,10 @@ from onyx.server.features.build.configs import (
     OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS,
 )
 from onyx.server.features.build.db.build_session import get_build_session
-from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
+from onyx.server.features.build.db.sandbox import (
+    get_sandbox_by_user_id,
+    update_sandbox_heartbeat,
+)
 from onyx.server.features.build.interactive_turns.state import (
     TURN_STATUS_CANCELLED,
     TURN_STATUS_FAILED,
@@ -44,6 +47,9 @@ from onyx.server.features.build.session.interrupt_signal import (
 )
 from onyx.server.features.build.session.locks import session_creation_lock
 from onyx.server.features.build.session.manager import SessionManager
+from onyx.server.features.build.session.sandbox_lifecycle import (
+    HEALTH_PROBE_TIMEOUT_SECONDS,
+)
 from onyx.server.features.build.session.session_ready import (
     ensure_session_ready,
     session_runtime_intact,
@@ -188,14 +194,28 @@ def _ready_session_runtime(
     """The sandbox this turn runs in, with the session's workspace present.
 
     A settled session returns straight away; anything else — a sandbox the
-    reaper took, a session never restored — is rebuilt through the same path and
-    the same lock the restore endpoint uses, blocking, because the turn has
-    nothing to do until the workspace is there.
+    reaper took, a session never restored, a pod that died under a live record —
+    is rebuilt through the same path and the same lock the restore endpoint
+    uses, blocking, because the turn has nothing to do until the workspace is
+    there.
     """
     session = get_build_session(session_id, user_id, db_session)
     sandbox = get_sandbox_by_user_id(db_session, user_id)
     if sandbox is not None and session_runtime_intact(session, sandbox):
-        return sandbox
+        # The reaper decides from this timestamp, and the stream only starts
+        # refreshing it after the prompt slot and the send.
+        update_sandbox_heartbeat(db_session, sandbox.id)
+        db_session.commit()
+        # RUNNING is a claim, not a fact: the reaper terminates the pod before
+        # it writes SLEEPING, and an evicted pod is never written down at all.
+        if get_sandbox_manager().health_check(
+            sandbox.id, timeout=HEALTH_PROBE_TIMEOUT_SECONDS
+        ):
+            return sandbox
+        logger.warning(
+            "Session %s claims a RUNNING sandbox with no live pod; waking it",
+            session_id,
+        )
 
     if session is None:
         raise RuntimeError(f"Build session {session_id} not found")

--- a/backend/onyx/server/features/build/interactive_turns/executor.py
+++ b/backend/onyx/server/features/build/interactive_turns/executor.py
@@ -8,13 +8,18 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from uuid import UUID
 
+from sqlalchemy.orm import Session
+
 from onyx.cache.factory import get_cache_backend
 from onyx.cache.interface import CACHE_TRANSIENT_ERRORS, CacheBackend
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.models import Sandbox
 from onyx.db.users import fetch_user_by_id
 from onyx.server.features.build.configs import (
     OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS,
 )
+from onyx.server.features.build.db.build_session import get_build_session
+from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.interactive_turns.state import (
     TURN_STATUS_CANCELLED,
     TURN_STATUS_FAILED,
@@ -30,13 +35,19 @@ from onyx.server.features.build.sandbox.event_schema import (
     PromptResponse,
 )
 from onyx.server.features.build.sandbox.event_schema import Error as SandboxError
+from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.models import PromptAttachment
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.server.features.build.session.interrupt_signal import (
     clear_interrupt,
     is_interrupt_requested,
 )
+from onyx.server.features.build.session.locks import session_creation_lock
 from onyx.server.features.build.session.manager import SessionManager
+from onyx.server.features.build.session.session_ready import (
+    ensure_session_ready,
+    session_runtime_intact,
+)
 from onyx.server.features.build.session.streaming import BuildStreamingState
 from onyx.server.features.build.timeouts import (
     INTERACTIVE_TURN_HARD_CAP_SECONDS,
@@ -171,6 +182,44 @@ def run_claimed_interactive_build_turn(
         )
 
 
+def _ready_session_runtime(
+    db_session: Session, session_id: UUID, user_id: UUID
+) -> Sandbox:
+    """The sandbox this turn runs in, with the session's workspace present.
+
+    Ensuring the sandbox is not enough: a session whose workspace was reclaimed
+    needs it rebuilt, and rebuilding it concurrently with the prompt is what
+    leaves opencode pinned to a config that did not exist yet. So on anything
+    but the settled case we take the lock the restore endpoint holds and go
+    through the same path — blocking, because the turn has nothing to do until
+    the workspace is there.
+
+    The settled case is decided from the database alone. It is the common one,
+    and confirming a workspace costs an exec into the pod, so a turn on a live
+    session pays two reads and no lock.
+    """
+    session = get_build_session(session_id, user_id, db_session)
+    sandbox = get_sandbox_by_user_id(db_session, user_id)
+    if session_runtime_intact(session, sandbox):
+        assert sandbox is not None
+        return sandbox
+
+    if session is None:
+        raise RuntimeError(f"Build session {session_id} not found")
+    user = fetch_user_by_id(db_session, user_id)
+    if user is None:
+        raise RuntimeError(f"User {user_id} not found")
+
+    logger.info(
+        "Interactive turn is waking session %s (session=%s sandbox=%s)",
+        session_id,
+        session.status.value,
+        sandbox.status.value if sandbox else "missing",
+    )
+    with session_creation_lock(user_id):
+        return ensure_session_ready(db_session, get_sandbox_manager(), session, user)
+
+
 def _drive_interactive_turn(
     *,
     turn_id: UUID,
@@ -186,7 +235,7 @@ def _drive_interactive_turn(
     cache = get_cache_backend()
     with get_session_with_current_tenant() as db_session:
         session_manager = SessionManager(db_session)
-        sandbox = session_manager.ensure_sandbox_running(user_id)
+        sandbox = _ready_session_runtime(db_session, session_id, user_id)
         db_session.commit()
 
         if not touch_turn(cache=cache, turn_id=turn_id, runner_id=runner_id):

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -15,12 +15,10 @@ from sqlalchemy.orm import Session
 from onyx.auth.permissions import require_permission
 from onyx.db.engine.sql_engine import get_session, get_session_with_current_tenant
 from onyx.db.enums import (
-    BuildSessionStatus,
     Permission,
     SandboxStatus,
     ScheduledTaskRunStatus,
 )
-from onyx.db.external_app import get_connectable_apps_for_user
 from onyx.db.models import BuildMessage, Sandbox, User
 from onyx.db.scheduled_task import get_scheduled_run_context
 from onyx.error_handling.error_codes import OnyxErrorCode
@@ -29,24 +27,15 @@ from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.configs import SSE_KEEPALIVE_INTERVAL
 from onyx.server.features.build.db.build_session import (
     get_build_session,
-    reserve_nextjs_port__no_commit,
-    session_runtime_stale,
     set_build_session_sharing_scope,
 )
 from onyx.server.features.build.db.sandbox import (
-    get_latest_snapshot_for_session,
     get_sandbox_by_user_id,
     update_sandbox_heartbeat,
 )
 from onyx.server.features.build.models import UploadResponse
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.models import DirectoryListing
-from onyx.server.features.build.sandbox.util.agent_instructions import (
-    build_connectable_apps_list,
-)
-from onyx.server.features.build.sandbox.util.mcp_config import (
-    resolve_craft_mcp_servers,
-)
 from onyx.server.features.build.session.errors import (
     SandboxProvisioningInProgressError,
     UploadLimitExceededError,
@@ -76,15 +65,12 @@ from onyx.server.features.build.session.models import (
     WebappInfo,
 )
 from onyx.server.features.build.session.sandbox_lifecycle import (
-    ProvisioningPolicy,
     create_session_snapshot_keep_latest,
-    ensure_sandbox_ready,
-    sync_managed_content,
 )
+from onyx.server.features.build.session.session_ready import ensure_session_ready
 from onyx.server.features.build.session.streaming import SSE_KEEPALIVE
 from onyx.server.features.build.timeouts import POLL_INTERVAL_SECONDS
 from onyx.server.features.build.utils import sanitize_filename, validate_file
-from onyx.server.metrics.craft_sandbox import SandboxReadyOutcome
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id
 
@@ -399,84 +385,7 @@ def restore_session(
         )
 
     try:
-        # Validate the model configuration before any external work; commit
-        # closes the read transaction without expiring loaded instances.
-        llm_config = SessionManager(db_session).build_llm_configs(user)
-        db_session.commit()
-
-        sandbox, outcome = ensure_sandbox_ready(
-            db_session,
-            sandbox_manager,
-            user.id,
-            policy=ProvisioningPolicy.FAIL,
-        )
-
-        if sandbox_manager.session_workspace_exists(sandbox.id, session_id):
-            session.status = BuildSessionStatus.ACTIVE
-            if session_runtime_stale(session, sandbox):
-                SessionManager(db_session).reload_session_skills(session_id, user)
-            else:
-                update_sandbox_heartbeat(db_session, sandbox.id)
-                db_session.commit()
-            base_response = SessionResponse.from_model(session, sandbox)
-            return DetailedSessionResponse.from_session_response(
-                base_response, session_loaded_in_sandbox=True
-            )
-
-        # Workspace missing: rebuild it (snapshot restore or fresh template).
-        if not session.nextjs_port:
-            reserve_nextjs_port__no_commit(db_session, session)
-            db_session.commit()
-
-        if outcome == SandboxReadyOutcome.ALREADY_RUNNING:
-            # A reused pod may be missing content pushed since it last
-            # synced; fresh provisioning already pushed managed content.
-            sync_managed_content(db_session, sandbox_manager, sandbox.id, user)
-
-        snapshot = get_latest_snapshot_for_session(db_session, session_id)
-        connectable_apps_section = build_connectable_apps_list(
-            get_connectable_apps_for_user(db_session, user)
-        )
-        mcp_servers = resolve_craft_mcp_servers(db_session, user)
-        nextjs_port = session.nextjs_port
-        sandbox_skills_hash = sandbox.skills_hash
-        sandbox_mcp_config_hash = sandbox.mcp_config_hash
-        db_session.commit()
-
-        if snapshot:
-            try:
-                sandbox_manager.restore_snapshot(
-                    sandbox_id=sandbox.id,
-                    session_id=session_id,
-                    snapshot_storage_path=snapshot.storage_path,
-                    nextjs_port=nextjs_port,
-                    llm_config=llm_config,
-                    connectable_apps_section=connectable_apps_section,
-                    mcp_servers=mcp_servers,
-                )
-            except Exception as e:
-                logger.error(
-                    "Snapshot restore failed for session %s: %s", session_id, e
-                )
-                db_session.rollback()
-                session.nextjs_port = None
-                db_session.commit()
-                raise
-        else:
-            sandbox_manager.setup_session_workspace(
-                sandbox_id=sandbox.id,
-                session_id=session_id,
-                llm_config=llm_config,
-                nextjs_port=nextjs_port,
-                connectable_apps_section=connectable_apps_section,
-                mcp_servers=mcp_servers,
-            )
-
-        session.status = BuildSessionStatus.ACTIVE
-        session.skills_hash = sandbox_skills_hash
-        session.mcp_config_hash = sandbox_mcp_config_hash
-        db_session.commit()
-
+        sandbox = ensure_session_ready(db_session, sandbox_manager, session, user)
     except SandboxProvisioningInProgressError as e:
         db_session.rollback()
         raise OnyxError(
@@ -488,24 +397,6 @@ def restore_session(
         raise
     except Exception as e:
         logger.error("Failed to restore session %s: %s", session_id, e, exc_info=True)
-        # Sandbox-level failures are already durably recorded (FAILED) by the
-        # state machine; only a partial workspace needs compensating cleanup so
-        # session_workspace_exists() doesn't later report it restored.
-        try:
-            db_session.rollback()
-            current = get_sandbox_by_user_id(db_session, user.id)
-            db_session.rollback()
-            if current is not None and current.status == SandboxStatus.RUNNING:
-                sandbox_manager.cleanup_session_workspace(current.id, session_id)
-                logger.info(
-                    "Cleaned up partial workspace for session %s after failed restore",
-                    session_id,
-                )
-        except Exception as cleanup_err:
-            logger.warning(
-                "Failed to clean up after restore failure: %s",
-                cleanup_err,
-            )
         raise HTTPException(
             status_code=500,
             detail=f"Failed to restore session: {e}",

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -114,15 +114,11 @@ def _dispose_pending_key(session_id: UUID) -> str:
 
 
 def mark_opencode_dispose_pending(session_id: UUID) -> None:
-    """Record that a session's ``opencode.json`` was rewritten while a running
-    opencode instance may still be holding the old one.
+    """Claim the dispose owed to a running instance after rewriting its config.
 
-    Anyone who writes that file owes the running instance a dispose, or it
-    serves the stale config until the pod dies. ``reconcile_session_llm_config``
-    performs the dispose on the next turn, but it short-circuits when the file
-    already matches what it would write — which it does after a workspace
-    rebuild — so this marker is the only thing that tells it the instance is
-    behind the file.
+    ``reconcile_session_llm_config`` performs it on the next turn, and needs the
+    marker because it short-circuits when the file already matches what it would
+    write — which it does after a workspace rebuild.
     """
     get_cache_backend().set(
         _dispose_pending_key(session_id), "1", ex=_DISPOSE_PENDING_TTL_SECONDS

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -108,6 +108,27 @@ logger = setup_logger()
 
 _DISPOSE_PENDING_TTL_SECONDS = 24 * 3600
 
+
+def _dispose_pending_key(session_id: UUID) -> str:
+    return f"craft:llm_config_dispose_pending:{session_id}"
+
+
+def mark_opencode_dispose_pending(session_id: UUID) -> None:
+    """Record that a session's ``opencode.json`` was rewritten while a running
+    opencode instance may still be holding the old one.
+
+    Anyone who writes that file owes the running instance a dispose, or it
+    serves the stale config until the pod dies. ``reconcile_session_llm_config``
+    performs the dispose on the next turn, but it short-circuits when the file
+    already matches what it would write — which it does after a workspace
+    rebuild — so this marker is the only thing that tells it the instance is
+    behind the file.
+    """
+    get_cache_backend().set(
+        _dispose_pending_key(session_id), "1", ex=_DISPOSE_PENDING_TTL_SECONDS
+    )
+
+
 # Webapp-ready probe on the UI-poll hot path; any response (even 404) counts.
 _WEBAPP_PROBE_TIMEOUT_SECONDS = 2.0
 
@@ -270,7 +291,7 @@ class SessionManager:
             current = None
 
         cache = get_cache_backend()
-        dispose_pending_key = f"craft:llm_config_dispose_pending:{session.id}"
+        dispose_pending_key = _dispose_pending_key(session.id)
         if current == expected:
             # A matching file does NOT prove the running opencode instance
             # picked it up: a prior reconcile may have written the file and

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -313,7 +313,7 @@ class SessionManager:
         # the next reconcile, so the marker is the only thing that tells it to
         # retry the missed dispose. Setting it after the write leaves that exact
         # window uncovered.
-        cache.set(dispose_pending_key, "1", ex=_DISPOSE_PENDING_TTL_SECONDS)
+        mark_opencode_dispose_pending(session.id)
         self._sandbox_manager.regenerate_session_config(
             sandbox_id=sandbox.id,
             session_id=session.id,

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -102,7 +102,7 @@ logger = setup_logger()
 
 # Liveness probe on the reconcile/reaper hot paths; tight so a dead pod can't
 # stall an interactive request.
-_HEALTH_PROBE_TIMEOUT_SECONDS = 5.0
+HEALTH_PROBE_TIMEOUT_SECONDS = 5.0
 
 
 # Statuses from which (re-)provisioning a pod is legal.
@@ -531,7 +531,7 @@ def reconcile_sandbox(
         # Claimed RUNNING: verify the pod actually backs it.
         with time_provision_phase(SandboxProvisionPhase.HEALTH_CHECK):
             healthy = sandbox_manager.health_check(
-                sandbox_id, timeout=_HEALTH_PROBE_TIMEOUT_SECONDS
+                sandbox_id, timeout=HEALTH_PROBE_TIMEOUT_SECONDS
             )
         if healthy:
             return _get_sandbox_committed(db_session, sandbox_id), outcome
@@ -832,7 +832,7 @@ def sleep_sandbox(
             sandbox_manager.create_opencode_history_snapshot(sandbox_id, tenant_id)
         except Exception as e:
             if sandbox_manager.health_check(
-                sandbox_id, timeout=_HEALTH_PROBE_TIMEOUT_SECONDS
+                sandbox_id, timeout=HEALTH_PROBE_TIMEOUT_SECONDS
             ):
                 logger.error(
                     "opencode history snapshot failed for sandbox "
@@ -901,7 +901,7 @@ def sleep_sandbox(
     pod_unreachable = False
     if snapshot_failed:
         if sandbox_manager.health_check(
-            sandbox_id, timeout=_HEALTH_PROBE_TIMEOUT_SECONDS
+            sandbox_id, timeout=HEALTH_PROBE_TIMEOUT_SECONDS
         ):
             logger.error(
                 "Snapshot failed for sandbox %s; "

--- a/backend/onyx/server/features/build/session/session_ready.py
+++ b/backend/onyx/server/features/build/session/session_ready.py
@@ -1,0 +1,202 @@
+"""Bringing a session's runtime up, for whoever needs it.
+
+Provisioning the sandbox and rebuilding the session workspace are one
+operation, not two. An opencode instance caches the config of the directory it
+is created for, so a turn that touches a session while its workspace is still
+being written pins the config that existed at that moment — for the life of the
+pod. Splitting the two let a turn provision the sandbox (``ensure_sandbox_running``)
+while the restore endpoint was still writing the workspace, which is how a
+session ends up answering "model not found" with a perfectly correct
+``opencode.json`` on disk.
+
+So the whole thing lives here, behind the user's session-creation lock, and both
+the restore endpoint and the interactive-turn runner go through it. That also
+retires an unwritten precondition of every turn: that the client called
+``/restore`` first and that it finished.
+"""
+
+from uuid import UUID
+
+from sqlalchemy.orm import Session as DBSession
+
+from onyx.db.enums import BuildSessionStatus, SandboxStatus
+from onyx.db.external_app import get_connectable_apps_for_user
+from onyx.db.models import BuildSession, Sandbox, User
+from onyx.server.features.build.db.build_session import (
+    reserve_nextjs_port__no_commit,
+    session_runtime_stale,
+)
+from onyx.server.features.build.db.sandbox import (
+    get_latest_snapshot_for_session,
+    get_sandbox_by_user_id,
+    update_sandbox_heartbeat,
+)
+from onyx.server.features.build.sandbox.base import SandboxManager
+from onyx.server.features.build.sandbox.util.agent_instructions import (
+    build_connectable_apps_list,
+)
+from onyx.server.features.build.sandbox.util.mcp_config import (
+    resolve_craft_mcp_servers,
+)
+from onyx.server.features.build.session.manager import (
+    SessionManager,
+    mark_opencode_dispose_pending,
+)
+from onyx.server.features.build.session.sandbox_lifecycle import (
+    ProvisioningPolicy,
+    SandboxReadyOutcome,
+    ensure_sandbox_ready,
+    sync_managed_content,
+)
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def session_runtime_intact(
+    session: BuildSession | None, sandbox: Sandbox | None
+) -> bool:
+    """Whether the recorded state says this session can be prompted right now.
+
+    Database-only on purpose: this is the per-turn fast path, and confirming a
+    workspace costs an exec into the pod. A session the reaper has put to sleep
+    fails it, which is the case that has to reach ``ensure_session_ready``.
+    """
+    return (
+        session is not None
+        and sandbox is not None
+        and session.status == BuildSessionStatus.ACTIVE
+        and sandbox.status == SandboxStatus.RUNNING
+    )
+
+
+def ensure_session_ready(
+    db_session: DBSession,
+    sandbox_manager: SandboxManager,
+    session: BuildSession,
+    user: User,
+) -> Sandbox:
+    """Return the user's RUNNING sandbox with ``session``'s workspace in place.
+
+    Provisions or wakes the sandbox, rebuilds the workspace from its latest
+    snapshot (or a fresh template) when the pod does not have it, and leaves the
+    session ACTIVE.
+
+    The caller must already hold the user's session-creation lock — this both
+    provisions and writes into the sandbox, so it must not interleave with a
+    reap, a second restore, or another turn doing the same thing.
+
+    Raises whatever provisioning raises; on a failed workspace rebuild the
+    partial workspace is removed so a later attempt does not mistake it for a
+    restored one.
+    """
+    session_id = session.id
+
+    # Validate the model configuration before any external work; the commit
+    # closes the read transaction without expiring loaded instances.
+    llm_config = SessionManager(db_session).build_llm_configs(user)
+    db_session.commit()
+
+    sandbox, outcome = ensure_sandbox_ready(
+        db_session,
+        sandbox_manager,
+        user.id,
+        policy=ProvisioningPolicy.FAIL,
+    )
+
+    if sandbox_manager.session_workspace_exists(sandbox.id, session_id):
+        session.status = BuildSessionStatus.ACTIVE
+        if session_runtime_stale(session, sandbox):
+            SessionManager(db_session).reload_session_skills(session_id, user)
+        else:
+            update_sandbox_heartbeat(db_session, sandbox.id)
+            db_session.commit()
+        return sandbox
+
+    # Workspace missing: rebuild it (snapshot restore or fresh template).
+    if not session.nextjs_port:
+        reserve_nextjs_port__no_commit(db_session, session)
+        db_session.commit()
+
+    if outcome == SandboxReadyOutcome.ALREADY_RUNNING:
+        # A reused pod may be missing content pushed since it last synced;
+        # fresh provisioning already pushed managed content.
+        sync_managed_content(db_session, sandbox_manager, sandbox.id, user)
+
+    snapshot = get_latest_snapshot_for_session(db_session, session_id)
+    connectable_apps_section = build_connectable_apps_list(
+        get_connectable_apps_for_user(db_session, user)
+    )
+    mcp_servers = resolve_craft_mcp_servers(db_session, user)
+    nextjs_port = session.nextjs_port
+    sandbox_skills_hash = sandbox.skills_hash
+    sandbox_mcp_config_hash = sandbox.mcp_config_hash
+    db_session.commit()
+
+    # Rebuilding the workspace rewrites opencode.json, but a running opencode
+    # instance for this session — one the restored history can bring back —
+    # keeps serving the config it started with. Claim the dispose before the
+    # write so the next turn's reconcile performs it.
+    mark_opencode_dispose_pending(session_id)
+
+    try:
+        if snapshot:
+            try:
+                sandbox_manager.restore_snapshot(
+                    sandbox_id=sandbox.id,
+                    session_id=session_id,
+                    snapshot_storage_path=snapshot.storage_path,
+                    nextjs_port=nextjs_port,
+                    llm_config=llm_config,
+                    connectable_apps_section=connectable_apps_section,
+                    mcp_servers=mcp_servers,
+                )
+            except Exception:
+                db_session.rollback()
+                session.nextjs_port = None
+                db_session.commit()
+                raise
+        else:
+            sandbox_manager.setup_session_workspace(
+                sandbox_id=sandbox.id,
+                session_id=session_id,
+                llm_config=llm_config,
+                nextjs_port=nextjs_port,
+                connectable_apps_section=connectable_apps_section,
+                mcp_servers=mcp_servers,
+            )
+    except Exception:
+        _discard_partial_workspace(db_session, sandbox_manager, user.id, session_id)
+        raise
+
+    session.status = BuildSessionStatus.ACTIVE
+    session.skills_hash = sandbox_skills_hash
+    session.mcp_config_hash = sandbox_mcp_config_hash
+    db_session.commit()
+    return sandbox
+
+
+def _discard_partial_workspace(
+    db_session: DBSession,
+    sandbox_manager: SandboxManager,
+    user_id: UUID,
+    session_id: UUID,
+) -> None:
+    """Best-effort cleanup after a failed rebuild.
+
+    Sandbox-level failures are already recorded durably by the state machine;
+    only a half-written workspace needs compensating, so ``session_workspace_exists``
+    doesn't later report it as restored.
+    """
+    try:
+        db_session.rollback()
+        current = get_sandbox_by_user_id(db_session, user_id)
+        db_session.rollback()
+        if current is not None and current.status == SandboxStatus.RUNNING:
+            sandbox_manager.cleanup_session_workspace(current.id, session_id)
+            logger.info(
+                "Cleaned up partial workspace for session %s after failed restore",
+                session_id,
+            )
+    except Exception:
+        logger.warning("Failed to clean up after restore failure", exc_info=True)

--- a/backend/onyx/server/features/build/session/session_ready.py
+++ b/backend/onyx/server/features/build/session/session_ready.py
@@ -1,25 +1,18 @@
 """Bringing a session's runtime up, for whoever needs it.
 
-Provisioning the sandbox and rebuilding the session workspace are one
-operation, not two. An opencode instance caches the config of the directory it
-is created for, so a turn that touches a session while its workspace is still
-being written pins the config that existed at that moment — for the life of the
-pod. Splitting the two let a turn provision the sandbox (``ensure_sandbox_running``)
-while the restore endpoint was still writing the workspace, which is how a
-session ends up answering "model not found" with a perfectly correct
-``opencode.json`` on disk.
-
-So the whole thing lives here, behind the user's session-creation lock, and both
-the restore endpoint and the interactive-turn runner go through it. That also
-retires an unwritten precondition of every turn: that the client called
-``/restore`` first and that it finished.
+Provisioning the sandbox and rebuilding the session workspace are one operation:
+an opencode instance caches the config of the directory it is created for, so a
+turn that touches a session while its workspace is still being written stays
+pinned to a config that did not exist yet, for the life of the pod. Both the
+restore endpoint and the interactive-turn runner come through here, under the
+user's session-creation lock, so the two cannot interleave.
 """
 
 from uuid import UUID
 
 from sqlalchemy.orm import Session as DBSession
 
-from onyx.db.enums import BuildSessionStatus, SandboxStatus
+from onyx.db.enums import BuildSessionStatus
 from onyx.db.external_app import get_connectable_apps_for_user
 from onyx.db.models import BuildSession, Sandbox, User
 from onyx.server.features.build.db.build_session import (
@@ -58,15 +51,14 @@ def session_runtime_intact(
 ) -> bool:
     """Whether the recorded state says this session can be prompted right now.
 
-    Database-only on purpose: this is the per-turn fast path, and confirming a
-    workspace costs an exec into the pod. A session the reaper has put to sleep
-    fails it, which is the case that has to reach ``ensure_session_ready``.
+    Database-only: this is the per-turn fast path, and confirming a workspace
+    costs an exec into the pod.
     """
     return (
         session is not None
         and sandbox is not None
         and session.status == BuildSessionStatus.ACTIVE
-        and sandbox.status == SandboxStatus.RUNNING
+        and sandbox.status.is_active()
     )
 
 
@@ -80,21 +72,19 @@ def ensure_session_ready(
 
     Provisions or wakes the sandbox, rebuilds the workspace from its latest
     snapshot (or a fresh template) when the pod does not have it, and leaves the
-    session ACTIVE.
+    session ACTIVE. A failed rebuild discards the partial workspace so a later
+    attempt does not mistake it for a restored one.
 
-    The caller must already hold the user's session-creation lock — this both
+    The caller must already hold the user's session-creation lock: this
     provisions and writes into the sandbox, so it must not interleave with a
     reap, a second restore, or another turn doing the same thing.
-
-    Raises whatever provisioning raises; on a failed workspace rebuild the
-    partial workspace is removed so a later attempt does not mistake it for a
-    restored one.
     """
     session_id = session.id
+    session_manager = SessionManager(db_session)
 
     # Validate the model configuration before any external work; the commit
     # closes the read transaction without expiring loaded instances.
-    llm_config = SessionManager(db_session).build_llm_configs(user)
+    llm_config = session_manager.build_llm_configs(user)
     db_session.commit()
 
     sandbox, outcome = ensure_sandbox_ready(
@@ -107,13 +97,12 @@ def ensure_session_ready(
     if sandbox_manager.session_workspace_exists(sandbox.id, session_id):
         session.status = BuildSessionStatus.ACTIVE
         if session_runtime_stale(session, sandbox):
-            SessionManager(db_session).reload_session_skills(session_id, user)
+            session_manager.reload_session_skills(session_id, user)
         else:
             update_sandbox_heartbeat(db_session, sandbox.id)
             db_session.commit()
         return sandbox
 
-    # Workspace missing: rebuild it (snapshot restore or fresh template).
     if not session.nextjs_port:
         reserve_nextjs_port__no_commit(db_session, session)
         db_session.commit()
@@ -133,29 +122,21 @@ def ensure_session_ready(
     sandbox_mcp_config_hash = sandbox.mcp_config_hash
     db_session.commit()
 
-    # Rebuilding the workspace rewrites opencode.json, but a running opencode
-    # instance for this session — one the restored history can bring back —
-    # keeps serving the config it started with. Claim the dispose before the
-    # write so the next turn's reconcile performs it.
+    # The rebuild rewrites opencode.json; claim the dispose before the write so
+    # the next turn's reconcile hands the running instance the new config.
     mark_opencode_dispose_pending(session_id)
 
     try:
         if snapshot:
-            try:
-                sandbox_manager.restore_snapshot(
-                    sandbox_id=sandbox.id,
-                    session_id=session_id,
-                    snapshot_storage_path=snapshot.storage_path,
-                    nextjs_port=nextjs_port,
-                    llm_config=llm_config,
-                    connectable_apps_section=connectable_apps_section,
-                    mcp_servers=mcp_servers,
-                )
-            except Exception:
-                db_session.rollback()
-                session.nextjs_port = None
-                db_session.commit()
-                raise
+            sandbox_manager.restore_snapshot(
+                sandbox_id=sandbox.id,
+                session_id=session_id,
+                snapshot_storage_path=snapshot.storage_path,
+                nextjs_port=nextjs_port,
+                llm_config=llm_config,
+                connectable_apps_section=connectable_apps_section,
+                mcp_servers=mcp_servers,
+            )
         else:
             sandbox_manager.setup_session_workspace(
                 sandbox_id=sandbox.id,
@@ -166,6 +147,11 @@ def ensure_session_ready(
                 mcp_servers=mcp_servers,
             )
     except Exception:
+        if snapshot:
+            # Release the port the restore reserved but never bound.
+            db_session.rollback()
+            session.nextjs_port = None
+            db_session.commit()
         _discard_partial_workspace(db_session, sandbox_manager, user.id, session_id)
         raise
 
@@ -182,17 +168,14 @@ def _discard_partial_workspace(
     user_id: UUID,
     session_id: UUID,
 ) -> None:
-    """Best-effort cleanup after a failed rebuild.
-
-    Sandbox-level failures are already recorded durably by the state machine;
-    only a half-written workspace needs compensating, so ``session_workspace_exists``
-    doesn't later report it as restored.
-    """
+    """Best-effort: drop a half-written workspace so ``session_workspace_exists``
+    doesn't later report it as restored. Sandbox-level failures are already
+    recorded durably by the state machine."""
     try:
         db_session.rollback()
         current = get_sandbox_by_user_id(db_session, user_id)
         db_session.rollback()
-        if current is not None and current.status == SandboxStatus.RUNNING:
+        if current is not None and current.status.is_active():
             sandbox_manager.cleanup_session_workspace(current.id, session_id)
             logger.info(
                 "Cleaned up partial workspace for session %s after failed restore",

--- a/backend/onyx/server/features/build/session/session_ready.py
+++ b/backend/onyx/server/features/build/session/session_ready.py
@@ -70,10 +70,12 @@ def ensure_session_ready(
 ) -> Sandbox:
     """Return the user's RUNNING sandbox with ``session``'s workspace in place.
 
-    Provisions or wakes the sandbox, rebuilds the workspace from its latest
-    snapshot (or a fresh template) when the pod does not have it, and leaves the
-    session ACTIVE. A failed rebuild discards the partial workspace so a later
-    attempt does not mistake it for a restored one.
+    Provisions or wakes the sandbox — a claimed-RUNNING pod is health-checked
+    and recovered inside ``ensure_sandbox_ready``, so no caller can skip that
+    verification — rebuilds the workspace from its latest snapshot (or a fresh
+    template) when the pod does not have it, and leaves the session ACTIVE. A
+    failed rebuild discards the partial workspace so a later attempt does not
+    mistake it for a restored one.
 
     The caller must already hold the user's session-creation lock: this
     provisions and writes into the sandbox, so it must not interleave with a
@@ -122,8 +124,12 @@ def ensure_session_ready(
     sandbox_mcp_config_hash = sandbox.mcp_config_hash
     db_session.commit()
 
-    # The rebuild rewrites opencode.json; claim the dispose before the write so
-    # the next turn's reconcile hands the running instance the new config.
+    # A reused pod may already hold an opencode instance for this session's
+    # directory — instances outlive the workspace and stay pinned to the config
+    # they saw at creation. The rebuild writes an opencode.json that already
+    # matches what the next turn's reconcile expects, so reconcile would
+    # short-circuit without disposing; claim the dispose up front instead
+    # (a no-op on a freshly provisioned pod).
     mark_opencode_dispose_pending(session_id)
 
     try:

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -1414,8 +1414,12 @@ class TestRestoreSession:
                 "No available ports in configured range",
             )
 
+        # Patched where the port is now reserved: restore and the turn runner
+        # both rebuild the workspace through ``ensure_session_ready``, so the
+        # endpoint no longer reserves it itself.
         monkeypatch.setattr(
-            "onyx.server.features.build.session.api.reserve_nextjs_port__no_commit",
+            "onyx.server.features.build.session.session_ready."
+            "reserve_nextjs_port__no_commit",
             _raise_port_exhausted,
         )
 

--- a/backend/tests/unit/onyx/server/features/craft/interactive_turns/test_executor.py
+++ b/backend/tests/unit/onyx/server/features/craft/interactive_turns/test_executor.py
@@ -218,6 +218,11 @@ def _run_turn_with_events(
     )
     monkeypatch.setattr(executor, "SessionManager", FakeSessionManager)
     monkeypatch.setattr(
+        executor,
+        "_ready_session_runtime",
+        lambda *_args, **_kwargs: SimpleNamespace(id=sandbox_id),
+    )
+    monkeypatch.setattr(
         executor, "fetch_user_by_id", lambda *_: SimpleNamespace(id=user_id)
     )
     monkeypatch.setattr(executor, "is_interrupt_requested", lambda *_: False)
@@ -534,6 +539,11 @@ def test_ownership_recheck_after_slot_acquire(
     )
     monkeypatch.setattr(executor, "SessionManager", FakeSessionManager)
     monkeypatch.setattr(
+        executor,
+        "_ready_session_runtime",
+        lambda *_args, **_kwargs: SimpleNamespace(id=sandbox_id),
+    )
+    monkeypatch.setattr(
         executor, "fetch_user_by_id", lambda *_: SimpleNamespace(id=user_id)
     )
     monkeypatch.setattr(executor, "is_interrupt_requested", lambda *_: False)
@@ -676,6 +686,11 @@ def test_prompt_slot_busy_does_not_finish_reclaimed_turn(
     )
     monkeypatch.setattr(executor, "SessionManager", FakeSessionManager)
     monkeypatch.setattr(
+        executor,
+        "_ready_session_runtime",
+        lambda *_args, **_kwargs: SimpleNamespace(id=sandbox_id),
+    )
+    monkeypatch.setattr(
         executor, "fetch_user_by_id", lambda *_: SimpleNamespace(id=user_id)
     )
 
@@ -788,6 +803,11 @@ def test_lost_runner_does_not_clear_reclaimed_turn_interrupt(
         lambda: _fake_db_scope(db_session),
     )
     monkeypatch.setattr(executor, "SessionManager", FakeSessionManager)
+    monkeypatch.setattr(
+        executor,
+        "_ready_session_runtime",
+        lambda *_args, **_kwargs: SimpleNamespace(id=sandbox_id),
+    )
     monkeypatch.setattr(
         executor, "fetch_user_by_id", lambda *_: SimpleNamespace(id=user_id)
     )
@@ -1004,6 +1024,11 @@ def _run_turn_with_batches(
         lambda: _fake_db_scope(db_session),
     )
     monkeypatch.setattr(executor, "SessionManager", FakeSessionManager)
+    monkeypatch.setattr(
+        executor,
+        "_ready_session_runtime",
+        lambda *_args, **_kwargs: SimpleNamespace(id=sandbox_id),
+    )
     monkeypatch.setattr(
         executor, "fetch_user_by_id", lambda *_: SimpleNamespace(id=user_id)
     )

--- a/backend/tests/unit/onyx/server/features/craft/interactive_turns/test_turns_api.py
+++ b/backend/tests/unit/onyx/server/features/craft/interactive_turns/test_turns_api.py
@@ -10,6 +10,7 @@ from uuid import UUID, uuid4
 import pytest
 from sqlalchemy.orm import Session
 
+from onyx.db.enums import SandboxStatus
 from onyx.db.models import User
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.interactive_turns import api as turns_api
@@ -48,6 +49,12 @@ def _fake_db_session_scope() -> Iterator[_FakeDbSession]:
     yield _FakeDbSession()
 
 
+def _running_sandbox(*_args: object, **_kwargs: object) -> SimpleNamespace:
+    """The wait loop consults the sandbox as well as the session; most tests
+    are about the session half, so hand them a live runtime."""
+    return SimpleNamespace(id=uuid4(), status=SandboxStatus.RUNNING)
+
+
 def _create_running_turn(
     cache: FakeCache,
     *,
@@ -81,6 +88,7 @@ def test_get_active_interactive_turn_returns_cache_marker(
         "get_build_session",
         lambda *_: SimpleNamespace(id=session_id),
     )
+    monkeypatch.setattr(turns_api, "get_sandbox_by_user_id", _running_sandbox)
 
     response = turns_api.get_active_interactive_turn(
         session_id=session_id,
@@ -150,6 +158,7 @@ def test_get_interactive_turn_events_waits_then_forwards_live_stream(
         _fake_db_session_scope,
     )
     monkeypatch.setattr(turns_api, "get_build_session", lambda *_: next(session_rows))
+    monkeypatch.setattr(turns_api, "get_sandbox_by_user_id", _running_sandbox)
 
     response = cast(
         _FakeStreamingResponse,
@@ -160,6 +169,7 @@ def test_get_interactive_turn_events_waits_then_forwards_live_stream(
             db_session=cast(Session, SimpleNamespace()),
         ),
     )
+    monkeypatch.setattr(turns_api, "get_sandbox_by_user_id", _running_sandbox)
 
     chunks = list(response.body)
 
@@ -193,6 +203,7 @@ def test_get_interactive_turn_events_streams_retained_failure(
         "get_build_session",
         lambda *_: SimpleNamespace(id=session_id),
     )
+    monkeypatch.setattr(turns_api, "get_sandbox_by_user_id", _running_sandbox)
 
     response = cast(
         _FakeStreamingResponse,
@@ -237,6 +248,7 @@ def test_get_interactive_turn_events_yields_failed_turn_error_before_ready(
         "get_build_session",
         lambda *_: SimpleNamespace(id=session_id, opencode_session_id=None),
     )
+    monkeypatch.setattr(turns_api, "get_sandbox_by_user_id", _running_sandbox)
 
     response = cast(
         _FakeStreamingResponse,
@@ -309,6 +321,7 @@ def test_get_interactive_turn_events_yields_failed_turn_error_after_stream_chunk
         "get_build_session",
         lambda *_: SimpleNamespace(id=session_id, opencode_session_id="opencode-1"),
     )
+    monkeypatch.setattr(turns_api, "get_sandbox_by_user_id", _running_sandbox)
 
     response = turns_api.get_interactive_turn_events(
         session_id=session_id,
@@ -384,6 +397,7 @@ def test_get_interactive_turn_events_retries_runner_start_mid_stream(
         "get_build_session",
         lambda *_: SimpleNamespace(id=session_id, opencode_session_id="opencode-1"),
     )
+    monkeypatch.setattr(turns_api, "get_sandbox_by_user_id", _running_sandbox)
 
     response = cast(
         _FakeStreamingResponse,
@@ -459,6 +473,7 @@ def test_get_interactive_turn_events_rate_limits_runner_retry_within_window(
         "get_build_session",
         lambda *_: SimpleNamespace(id=session_id, opencode_session_id="opencode-1"),
     )
+    monkeypatch.setattr(turns_api, "get_sandbox_by_user_id", _running_sandbox)
 
     response = cast(
         _FakeStreamingResponse,
@@ -490,6 +505,7 @@ def test_get_interactive_turn_events_requires_active_turn(
         "get_build_session",
         lambda *_: SimpleNamespace(id=session_id),
     )
+    monkeypatch.setattr(turns_api, "get_sandbox_by_user_id", _running_sandbox)
 
     with pytest.raises(OnyxError):
         turns_api.get_interactive_turn_events(
@@ -498,3 +514,81 @@ def test_get_interactive_turn_events_requires_active_turn(
             user=cast(User, SimpleNamespace(id=user_id)),
             db_session=cast(Session, SimpleNamespace()),
         )
+
+
+def test_get_interactive_turn_events_waits_out_a_reclaimed_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sandbox reclaimed between turns must not fail the next message.
+
+    ``opencode_session_id`` outlives the pod that minted it, so after a reap the
+    session still carries one while nothing is listening. Treating that alone as
+    "ready" attached to a sandbox that was still provisioning and surfaced
+    "Sandbox is not running" — for a turn whose own runner was, at that moment,
+    waking the sandbox. The stream has to hold the line instead.
+    """
+    cache = FakeCache()
+    session_id = uuid4()
+    user_id = uuid4()
+    turn_id = _create_running_turn(cache, session_id=session_id, user_id=user_id)
+
+    # The id is set from the previous incarnation the whole time.
+    session_row = SimpleNamespace(id=session_id, opencode_session_id="opencode-stale")
+    sandbox_states = iter(
+        [
+            SimpleNamespace(id=uuid4(), status=SandboxStatus.SLEEPING),
+            SimpleNamespace(id=uuid4(), status=SandboxStatus.PROVISIONING),
+            SimpleNamespace(id=uuid4(), status=SandboxStatus.RUNNING),
+        ]
+    )
+
+    class FakeSessionManager:
+        def __init__(self, db_session: object) -> None:
+            _ = db_session
+
+        def subscribe_to_existing_session_events(
+            self,
+            session_id_arg: UUID,
+            user_id_arg: UUID,
+            keepalive_seconds: float,
+        ) -> Iterator[str]:
+            _ = (session_id_arg, user_id_arg, keepalive_seconds)
+            finish_turn(cache=cache, turn_id=turn_id, status=TURN_STATUS_SUCCEEDED)
+            yield 'event: message\ndata: {"type":"text_chunk","text":"awake"}\n\n'
+
+    monkeypatch.setattr(turns_api, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(turns_api, "start_interactive_turn_runner", lambda _: False)
+    monkeypatch.setattr(turns_api, "StreamingResponse", _FakeStreamingResponse)
+    monkeypatch.setattr(
+        turns_api,
+        "time",
+        SimpleNamespace(sleep=lambda _: None, monotonic=real_time.monotonic),
+    )
+    monkeypatch.setattr(turns_api, "SessionManager", FakeSessionManager)
+    monkeypatch.setattr(
+        turns_api, "get_session_with_current_tenant", _fake_db_session_scope
+    )
+    monkeypatch.setattr(turns_api, "get_build_session", lambda *_: session_row)
+    monkeypatch.setattr(
+        turns_api, "get_sandbox_by_user_id", lambda *_: next(sandbox_states)
+    )
+
+    response = cast(
+        _FakeStreamingResponse,
+        turns_api.get_interactive_turn_events(
+            session_id=session_id,
+            turn_id=turn_id,
+            user=cast(User, SimpleNamespace(id=user_id)),
+            db_session=cast(Session, SimpleNamespace()),
+        ),
+    )
+
+    chunks = list(response.body)
+
+    # Two keepalives while the sandbox came back, then the turn's output — and
+    # no error packet anywhere.
+    assert chunks == [
+        turns_api.SSE_KEEPALIVE,
+        turns_api.SSE_KEEPALIVE,
+        'event: message\ndata: {"type":"text_chunk","text":"awake"}\n\n',
+    ]

--- a/backend/tests/unit/onyx/server/features/craft/session/test_session_ready.py
+++ b/backend/tests/unit/onyx/server/features/craft/session/test_session_ready.py
@@ -49,11 +49,12 @@ def test_only_a_settled_session_skips_the_ensure(
     assert session_runtime_intact(session, sandbox) is intact
 
 
-def test_settled_turn_takes_no_lock_and_does_not_touch_the_pod(
+def test_settled_turn_records_activity_and_does_not_exec(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The common case is every turn on a live session: two reads, no lock, and
-    no exec into the sandbox to confirm a workspace we already believe in."""
+    """Every turn on a live session: no lock, no exec to confirm a workspace we
+    already believe in — but it records the activity, or the next sweep reaps a
+    session in use."""
     session_id, user_id = uuid4(), uuid4()
     sandbox = _sandbox()
 
@@ -65,13 +66,60 @@ def test_settled_turn_takes_no_lock_and_does_not_touch_the_pod(
     ensure = MagicMock()
     monkeypatch.setattr(executor, "ensure_session_ready", ensure)
     manager = MagicMock()
+    manager.health_check.return_value = True
     monkeypatch.setattr(executor, "get_sandbox_manager", lambda: manager)
+    heartbeat = MagicMock()
+    monkeypatch.setattr(executor, "update_sandbox_heartbeat", heartbeat)
 
     assert executor._ready_session_runtime(MagicMock(), session_id, user_id) is sandbox
 
     lock_taken.assert_not_called()
     ensure.assert_not_called()
     manager.session_workspace_exists.assert_not_called()
+    assert heartbeat.call_args.args[1] == sandbox.id
+
+
+def test_turn_wakes_the_session_when_the_pod_is_gone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A record saying RUNNING must be verified before a prompt is posted into
+    it — the reaper terminates the pod before it writes SLEEPING. A failed
+    check wakes the session instead of using the dead pod."""
+    session_id, user_id = uuid4(), uuid4()
+    rebuilt = _sandbox()
+    order: list[str] = []
+
+    monkeypatch.setattr(executor, "get_build_session", lambda *_a: _session())
+    monkeypatch.setattr(executor, "get_sandbox_by_user_id", lambda *_a: _sandbox())
+    monkeypatch.setattr(executor, "fetch_user_by_id", lambda *_a: MagicMock())
+    monkeypatch.setattr(executor, "update_sandbox_heartbeat", MagicMock())
+
+    manager = MagicMock()
+    # What a terminated pod looks like from here.
+    manager.health_check.return_value = False
+    monkeypatch.setattr(executor, "get_sandbox_manager", lambda: manager)
+
+    class FakeLock:
+        def __init__(self, uid: object) -> None:
+            assert uid == user_id
+
+        def __enter__(self) -> None:
+            order.append("lock")
+
+        def __exit__(self, *_a: object) -> None:
+            order.append("unlock")
+
+    def fake_ensure(*_args: Any, **_kwargs: Any) -> Any:
+        order.append("ensure")
+        return rebuilt
+
+    monkeypatch.setattr(executor, "session_creation_lock", FakeLock)
+    monkeypatch.setattr(executor, "ensure_session_ready", fake_ensure)
+
+    assert executor._ready_session_runtime(MagicMock(), session_id, user_id) is rebuilt
+
+    # Rebuilt through the restore path rather than handed the doomed pod.
+    assert order == ["lock", "ensure", "unlock"]
 
 
 def test_reaped_session_is_rebuilt_under_the_restore_lock(

--- a/backend/tests/unit/onyx/server/features/craft/session/test_session_ready.py
+++ b/backend/tests/unit/onyx/server/features/craft/session/test_session_ready.py
@@ -1,0 +1,115 @@
+"""Getting a session's runtime up before a turn touches it.
+
+The bug these pin: provisioning the sandbox and rebuilding the session
+workspace used to be separate, so a turn could provision a pod and create an
+opencode instance for a session directory while the restore endpoint was still
+writing that directory's config. opencode caches the config it finds at
+instance creation, so the turn then ran against an empty provider catalog —
+"model not found", with a correct opencode.json sitting on disk.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+import onyx.server.features.build.interactive_turns.executor as executor
+from onyx.db.enums import BuildSessionStatus, SandboxStatus
+from onyx.server.features.build.session.session_ready import session_runtime_intact
+
+
+def _session(status: BuildSessionStatus = BuildSessionStatus.ACTIVE) -> Any:
+    return SimpleNamespace(id=uuid4(), status=status)
+
+
+def _sandbox(status: SandboxStatus = SandboxStatus.RUNNING) -> Any:
+    return SimpleNamespace(id=uuid4(), status=status)
+
+
+@pytest.mark.parametrize(
+    "session,sandbox,intact",
+    [
+        (_session(), _sandbox(), True),
+        (_session(BuildSessionStatus.IDLE), _sandbox(), False),
+        (_session(), _sandbox(SandboxStatus.SLEEPING), False),
+        (_session(), None, False),
+        (None, _sandbox(), False),
+    ],
+    ids=["settled", "session-idle", "sandbox-asleep", "no-sandbox", "no-session"],
+)
+def test_only_a_settled_session_skips_the_ensure(
+    session: Any, sandbox: Any, intact: bool
+) -> None:
+    """The fast path must be exactly "the records say this is live" — a reaped
+    sandbox or an idled session has to fall through to the full ensure."""
+    assert session_runtime_intact(session, sandbox) is intact
+
+
+def test_settled_turn_takes_no_lock_and_does_not_touch_the_pod(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The common case is every turn on a live session: two reads, no lock, and
+    no exec into the sandbox to confirm a workspace we already believe in."""
+    session_id, user_id = uuid4(), uuid4()
+    sandbox = _sandbox()
+
+    monkeypatch.setattr(executor, "get_build_session", lambda *_a: _session())
+    monkeypatch.setattr(executor, "get_sandbox_by_user_id", lambda *_a: sandbox)
+
+    lock_taken = MagicMock()
+    monkeypatch.setattr(executor, "session_creation_lock", lock_taken)
+    ensure = MagicMock()
+    monkeypatch.setattr(executor, "ensure_session_ready", ensure)
+    manager = MagicMock()
+    monkeypatch.setattr(executor, "get_sandbox_manager", lambda: manager)
+
+    assert executor._ready_session_runtime(MagicMock(), session_id, user_id) is sandbox
+
+    lock_taken.assert_not_called()
+    ensure.assert_not_called()
+    manager.session_workspace_exists.assert_not_called()
+
+
+def test_reaped_session_is_rebuilt_under_the_restore_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A turn arriving after the reaper took the sandbox must rebuild the
+    workspace through the same path and the same lock the restore endpoint
+    uses — not race it."""
+    session_id, user_id = uuid4(), uuid4()
+    session = _session(BuildSessionStatus.IDLE)
+    rebuilt = _sandbox()
+    order: list[str] = []
+
+    monkeypatch.setattr(executor, "get_build_session", lambda *_a: session)
+    monkeypatch.setattr(
+        executor, "get_sandbox_by_user_id", lambda *_a: _sandbox(SandboxStatus.SLEEPING)
+    )
+    monkeypatch.setattr(executor, "fetch_user_by_id", lambda *_a: MagicMock())
+    monkeypatch.setattr(executor, "get_sandbox_manager", lambda: MagicMock())
+
+    class FakeLock:
+        def __init__(self, uid: object) -> None:
+            assert uid == user_id
+
+        def __enter__(self) -> None:
+            order.append("lock")
+
+        def __exit__(self, *_a: object) -> None:
+            order.append("unlock")
+
+    def fake_ensure(*_args: Any, **_kwargs: Any) -> Any:
+        order.append("ensure")
+        return rebuilt
+
+    monkeypatch.setattr(executor, "session_creation_lock", FakeLock)
+    monkeypatch.setattr(executor, "ensure_session_ready", fake_ensure)
+
+    assert executor._ready_session_runtime(MagicMock(), session_id, user_id) is rebuilt
+
+    # The rebuild happens inside the lock, which is the whole point.
+    assert order == ["lock", "ensure", "unlock"]

--- a/backend/tests/unit/onyx/server/features/craft/test_session_gateway_config.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_session_gateway_config.py
@@ -594,3 +594,56 @@ def test_empty_gateway_session_restarts_instance_for_changed_catalog() -> None:
     )
     cache.set.assert_called_once()
     cache.delete.assert_called_once()
+
+
+def test_workspace_rebuild_claims_a_dispose_the_next_reconcile_honours() -> None:
+    """Restoring a session rewrites opencode.json but cannot dispose the
+    running instance itself; it claims the dispose and the next turn performs it.
+
+    Both halves go through the real cache key on purpose. The failure this pins
+    is silent: the rebuilt file matches what reconcile would write, so reconcile
+    short-circuits, the instance keeps the catalog it started with, and the
+    first turn after a wake dies with "model not found" while the config on
+    disk looks perfect.
+    """
+    config = _gateway_config()
+    manager, sandbox_manager, _ = _reconcile_manager(config)
+    expected = json.dumps(
+        build_provider_opencode_config(
+            config, disabled_tools=manager_module.OPENCODE_DISABLED_TOOLS
+        )
+    )
+    # Exactly the post-rebuild state: file already correct on disk.
+    sandbox_manager.read_file.return_value = expected.encode()
+
+    store: dict[str, str] = {}
+    cache = MagicMock()
+    cache.set.side_effect = lambda key, value, ex=None: store.__setitem__(  # noqa: ARG005
+        key, value
+    )
+    cache.get.side_effect = store.get
+    cache.delete.side_effect = lambda key: store.pop(key, None)
+
+    session = cast(
+        BuildSession,
+        MagicMock(
+            id=2,
+            agent_provider=None,
+            agent_model=None,
+            opencode_session_id="ses_restored",
+        ),
+    )
+
+    with patch.object(manager_module, "get_cache_backend", return_value=cache):
+        # What the restore path does after rebuilding the workspace.
+        manager_module.mark_opencode_dispose_pending(session.id)
+        assert store, "the claim must be recorded before the next turn runs"
+
+        manager.reconcile_session_llm_config(
+            cast(Sandbox, MagicMock(id=1)),
+            session,
+            cast(User, MagicMock(spec=User)),
+        )
+
+    sandbox_manager.dispose_opencode_instance.assert_called_once()
+    assert store == {}, "the claim must be cleared once the dispose succeeded"


### PR DESCRIPTION
## Description

**Replaces #13670**, which GitHub auto-closed as "merged" when its base branch was restacked. Nothing was merged — same branch, same commits, now correctly based on `main`.

Sleeping a Craft sandbox is rare today — an hour of inactivity — so the path that wakes a session is almost never walked while its user is still at the keyboard. Every defect below is reachable *right now* through the ordinary idle reaper; reclaiming sandboxes sooner (#13648) would make them routine.

**This depends on nothing else in the stack.** It touches only session and turn code, imports nothing from #13636, and can merge on its own.

### A turn ensures the sandbox, but not its session

`ensure_sandbox_running` provisions a pod. Nothing rebuilds the session workspace. So every turn carried an unwritten precondition — *the client called `/restore` first, and it finished* — with nothing enforcing it.

When it doesn't hold, the turn's `ensure_opencode_session` creates an opencode instance for a session directory whose `opencode.json` hasn't been written yet. opencode caches the config it finds at instance creation, so the turn runs against an empty provider catalog and dies with `ProviderModelNotFound` — while the config on disk is perfectly correct. It stays broken until the pod dies, because nothing disposes the instance. Observed on a live cluster: a message sent during a restore, `Model not found: onyx/6/claude-opus-5`, `suggestions: []`, and a 69-model catalog sitting in the file.

`ensure_session_ready` now owns provisioning *and* the workspace rebuild, and the restore endpoint and the turn runner both go through it under the same per-user session-creation lock.

**The fast path is preserved.** A turn on a settled session is recognised from the database alone (`session ACTIVE` + `sandbox RUNNING`) — no lock, and no exec into the pod to confirm a workspace we already believe in.

### RUNNING is a claim, not a fact

The fast path then *trusted* that claim, which nothing else in the system does. `reconcile_sandbox` says so outright: *"Claimed RUNNING: verify the pod actually backs it."* The reaper terminates a pod before it writes `SLEEPING`, and an evicted or OOM-killed pod is never written down at all — so a turn could be accepted against a sandbox already being killed and post its prompt into a dead pod.

It now health-checks and hands a failed check to the same wake path a reaped session takes. It also records the activity it represents: the heartbeat is refreshed by work alone, and the stream only starts refreshing it after the prompt slot and the send.

A window remains between the check and the send — the same one `ensure_sandbox_ready` has always had. Closing it needs a retry on send, or a reaper that claims the row before it touches the pod.

### Two smaller holes on the same path

- **Restore wrote `opencode.json` outside the dispose protocol.** `reconcile_session_llm_config` already retries a missed dispose when a marker says one is owed — its own comment explains that a matching file "does NOT prove the running opencode instance picked it up". Restore never set the marker, and its rewritten file matches what reconcile would write, so reconcile short-circuited and the instance stayed stale. Restore now claims the dispose before the write, through the same function that owns the marker.
- **The turn's event stream errored instead of waiting.** It treated `opencode_session_id` as proof of a live runtime, but that id outlives the pod that minted it — after a reap it is set while nothing is listening. The stream broke out of its wait loop, hit a `PROVISIONING` sandbox and returned "Sandbox is not running. Please wait for it to start." for a turn whose own runner was, at that moment, waking the sandbox.

The status indicator also stops asserting "running" when it doesn't know: with a session but no sandbox record it now says "Finding sandbox…". The composer is deliberately *not* disabled — with the stream fixed, sending during a wake works.

## How Has This Been Tested?

- Unit tests on the readiness split: which states count as settled (parametrized, including the two the reaper produces), that a settled turn takes no lock and never execs but *does* record the heartbeat, and that a reaped session is rebuilt *inside* the lock (asserted on ordering, not just on the call).
- A test that a record claiming RUNNING with no live pod wakes the session instead of using it.
- A regression test for the event stream: a reclaimed sandbox going `SLEEPING → PROVISIONING → RUNNING` under a stale opencode id must yield keepalives then output, never an error packet.
- A test that the dispose claim and the reconcile that honours it meet through the same cache key.
- Each was confirmed to fail with its fix reverted.

**Not covered:** no test drives `ensure_session_ready` end to end against a real sandbox — that wants the k8s lane.

**Known:** five tests in `backend/tests/external_dependency_unit/craft` still patch symbols this PR moved out of `session/api.py` (`reserve_nextjs_port__no_commit` and friends) and fail. They are being fixed separately.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make waking Craft sessions reliable and race-free. Turns now rebuild the session workspace when needed, verify pod liveness before sending, and the UI no longer claims “running” when we don’t know.

- **Bug Fixes**
  - Unified sandbox provisioning + workspace rebuild via `ensure_session_ready`; both the restore endpoint and the turn runner use the same per-user lock.
  - Verify RUNNING with a health check; if the pod is gone, wake and rebuild instead of posting into a dead pod. Record heartbeat on turn start.
  - Event stream waits for both `opencode_session_id` and an active sandbox, avoiding “Sandbox is not running” during wake.
  - Restore claims an opencode dispose before rewriting `opencode.json`, so the next reconcile hands the running instance the new config.
  - Status indicator: with a session but no sandbox record, show “loading” instead of “running”.

- **Refactors**
  - Extracted `session_ready.py`; reused `SandboxStatus.is_active()` and exported `HEALTH_PROBE_TIMEOUT_SECONDS`.
  - Moved Next.js port reservation into `ensure_session_ready` (shared by restore and turn paths).
  - `reconcile_session_llm_config` now uses `mark_opencode_dispose_pending`.
  - Added unit tests for settled vs. reaped session handling, health-check fallback, event stream waiting out a reclaimed sandbox, and the dispose marker handshake.

<sup>Written for commit 942d7a1742177cda3357c566095f4c2486937f96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

