### PR TITLE
feat(mobile): timeline primitives + StepContainer

### DIFF
--- a/mobile/src/components/chat/StreamingMarkdown.tsx
+++ b/mobile/src/components/chat/StreamingMarkdown.tsx
@@ -5,31 +5,41 @@ import { StreamdownText } from "react-native-streamdown";
 import type { MarkdownStyle } from "react-native-enriched-markdown";
 import { textPresets, varsDark, varsLight } from "@onyx-ai/shared/native";
 
+// "muted": reasoning/secondary body — text-03 with a tighter paragraph rhythm.
+type StreamingMarkdownVariant = "default" | "muted";
+
 interface StreamingMarkdownProps {
   content: string;
   isStreaming: boolean;
   // Tap on any markdown link (incl. `[[n]](url)` citation markers) → the link's URL.
   onLinkPress?: (url: string) => void;
+  variant?: StreamingMarkdownVariant;
 }
 
 // 14px body: deliberate reduction from web's 16px, which reads oversized on a phone.
 const BODY = textPresets["main-ui-body"];
 const MONO = textPresets["main-content-mono"];
 
-function buildMarkdownStyle(scheme: "light" | "dark"): MarkdownStyle {
+function buildMarkdownStyle(
+  scheme: "light" | "dark",
+  variant: StreamingMarkdownVariant,
+): MarkdownStyle {
   const vars = scheme === "dark" ? varsDark : varsLight;
   const color = (token: string): string => vars[token] ?? "#000000";
   // Fenced code has no Onyx token; use Atom One's flat base color (no per-token highlighting).
   const codeBaseColor = scheme === "dark" ? "#e2e6eb" : "#383a42";
+  const muted = variant === "muted";
+  const bodyColor = color(muted ? "--text-03" : "--text-05");
+  const paragraphMarginBottom = muted ? 4 : 8;
   return {
     paragraph: {
-      color: color("--text-05"),
+      color: bodyColor,
       fontFamily: BODY.fontFamily,
       fontSize: BODY.fontSize,
       lineHeight: BODY.lineHeight,
-      // RN doesn't collapse margins: 0 top + 8 bottom gives an even 8px rhythm.
+      // RN doesn't collapse margins: 0 top + a bottom gap gives an even rhythm.
       marginTop: 0,
-      marginBottom: 8,
+      marginBottom: paragraphMarginBottom,
     },
     h1: {
       color: color("--text-05"),
@@ -63,7 +73,7 @@ function buildMarkdownStyle(scheme: "light" | "dark"): MarkdownStyle {
     em: { fontStyle: "italic" },
     link: { color: color("--action-selection-05"), underline: true },
     list: {
-      color: color("--text-05"),
+      color: bodyColor,
       markerColor: color("--text-03"),
       fontFamily: BODY.fontFamily,
       fontSize: BODY.fontSize,
@@ -114,9 +124,13 @@ export function StreamingMarkdown({
   content,
   isStreaming,
   onLinkPress,
+  variant = "default",
 }: StreamingMarkdownProps) {
   const scheme = useColorScheme() === "dark" ? "dark" : "light";
-  const markdownStyle = useMemo(() => buildMarkdownStyle(scheme), [scheme]);
+  const markdownStyle = useMemo(
+    () => buildMarkdownStyle(scheme, variant),
+    [scheme, variant],
+  );
   return (
     <StreamdownText
       markdown={content}

--- a/mobile/src/components/chat/timeline/StepContainer.tsx
+++ b/mobile/src/components/chat/timeline/StepContainer.tsx
@@ -1,0 +1,100 @@
+// Visual wrapper for one timeline step — rail icon + connector, tint/error surface, header, body.
+// Hover dropped: the node icon rests at text-02. The renderer supplies icon/header/content.
+import type { ReactNode } from "react";
+import { View } from "react-native";
+
+import { Icon } from "@/components/ui/icon";
+import type { TimelineSurfaceBackground } from "@/components/chat/renderers/timelineContract";
+import type { IconFunctionComponent } from "@/icons/types";
+
+import { timelineTokens } from "./primitives/timelineTokens";
+import { TimelineRow } from "./primitives/TimelineRow";
+import { TimelineStepContent } from "./primitives/TimelineStepContent";
+import { TimelineSurface } from "./primitives/TimelineSurface";
+
+export interface StepContainerProps {
+  children?: ReactNode;
+  stepIcon?: IconFunctionComponent;
+  header?: ReactNode;
+  buttonTitle?: string;
+  isExpanded?: boolean;
+  onToggle?: () => void;
+  collapsible?: boolean;
+  supportsCollapsible?: boolean;
+  isLastStep?: boolean;
+  isFirstStep?: boolean;
+  hideHeader?: boolean;
+  collapsedIcon?: IconFunctionComponent;
+  noPaddingRight?: boolean;
+  // Render without the rail (nested/parallel content).
+  withRail?: boolean;
+  surfaceBackground?: TimelineSurfaceBackground;
+}
+
+export function StepContainer({
+  children,
+  stepIcon: StepIconComponent,
+  header,
+  buttonTitle,
+  isExpanded = true,
+  onToggle,
+  collapsible = true,
+  supportsCollapsible = false,
+  isLastStep = false,
+  isFirstStep = false,
+  hideHeader = false,
+  collapsedIcon,
+  noPaddingRight = false,
+  withRail = true,
+  surfaceBackground,
+}: StepContainerProps) {
+  const iconNode = StepIconComponent ? (
+    <Icon
+      as={StepIconComponent}
+      size={timelineTokens.iconSize}
+      className="text-text-02"
+    />
+  ) : null;
+
+  const content = (
+    <TimelineSurface
+      className="flex-1"
+      roundedBottom={isLastStep}
+      background={surfaceBackground}
+    >
+      <TimelineStepContent
+        header={header}
+        buttonTitle={buttonTitle}
+        isExpanded={isExpanded}
+        onToggle={onToggle}
+        collapsible={collapsible}
+        supportsCollapsible={supportsCollapsible}
+        hideHeader={hideHeader}
+        collapsedIcon={collapsedIcon}
+        noPaddingRight={noPaddingRight}
+        surfaceBackground={surfaceBackground}
+      >
+        {children}
+      </TimelineStepContent>
+    </TimelineSurface>
+  );
+
+  if (!withRail) {
+    return <View className="w-full flex-row">{content}</View>;
+  }
+
+  return (
+    <TimelineRow
+      railVariant="rail"
+      icon={iconNode}
+      showIcon={!hideHeader && Boolean(StepIconComponent)}
+      iconRowVariant={hideHeader ? "compact" : "default"}
+      isFirst={isFirstStep}
+      isLast={isLastStep}
+    >
+      {content}
+    </TimelineRow>
+  );
+}
+
+export default StepContainer;

--- a/mobile/src/components/chat/timeline/TimelineRendererComponent.tsx
+++ b/mobile/src/components/chat/timeline/TimelineRendererComponent.tsx
@@ -26,7 +26,10 @@ export interface TimelineRendererComponentProps {
   children: (result: TimelineRendererResult[]) => ReactElement;
 }
 
-// Re-render only on meaningful changes (chatState is memoized upstream).
+// Omits `children` and `chatState` by design (faithful to web): both take a fresh identity on every
+// parent render, so comparing them would re-render on every stream tick and defeat the streaming perf
+// isolation. Caller contract (wired in 9b.7): pass a stable (useCallback) `children` whose captured
+// state is also surfaced through a compared prop below — otherwise that state can render stale.
 function arePropsEqual(
   prev: TimelineRendererComponentProps,
   next: TimelineRendererComponentProps,

--- a/mobile/src/components/chat/timeline/TimelineRendererComponent.tsx
+++ b/mobile/src/components/chat/timeline/TimelineRendererComponent.tsx
@@ -1,0 +1,108 @@
+// Owns one step's expand/collapse state, derives its RenderType, dispatches via `findRenderer`, and
+// hands the enhanced results to `children`. Drops web's `isHover`; packets are already `Packet` at the
+// dispatch boundary, so no `as any` is needed.
+import { memo, useCallback, useState, type ReactElement } from "react";
+
+import { findRenderer } from "@/components/chat/renderers/findRenderer";
+import {
+  RenderType,
+  type FullChatState,
+  type RendererOutput,
+  type RendererResult,
+  type TimelineRendererResult,
+} from "@/components/chat/renderers/timelineContract";
+import type { Packet, StopReason } from "@/chat/streamingModels";
+
+export interface TimelineRendererComponentProps {
+  packets: Packet[];
+  chatState: FullChatState;
+  animate: boolean;
+  stopPacketSeen: boolean;
+  stopReason?: StopReason;
+  defaultExpanded?: boolean;
+  isLastStep?: boolean;
+  // Override the derived type (else FULL expanded / COMPACT collapsed).
+  renderTypeOverride?: RenderType;
+  children: (result: TimelineRendererResult[]) => ReactElement;
+}
+
+// Re-render only on meaningful changes (chatState is memoized upstream).
+function arePropsEqual(
+  prev: TimelineRendererComponentProps,
+  next: TimelineRendererComponentProps,
+): boolean {
+  return (
+    prev.packets === next.packets &&
+    prev.stopPacketSeen === next.stopPacketSeen &&
+    prev.stopReason === next.stopReason &&
+    prev.animate === next.animate &&
+    prev.isLastStep === next.isLastStep &&
+    prev.defaultExpanded === next.defaultExpanded &&
+    prev.renderTypeOverride === next.renderTypeOverride
+  );
+}
+
+export const TimelineRendererComponent = memo(
+  function TimelineRendererComponent({
+    packets,
+    chatState,
+    animate,
+    stopPacketSeen,
+    stopReason,
+    defaultExpanded = true,
+    isLastStep,
+    renderTypeOverride,
+    children,
+  }: TimelineRendererComponentProps) {
+    const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+    const handleToggle = useCallback(() => setIsExpanded((prev) => !prev), []);
+    const RendererFn = findRenderer(packets);
+    const renderType =
+      renderTypeOverride ?? (isExpanded ? RenderType.FULL : RenderType.COMPACT);
+
+    if (!RendererFn) {
+      return children([
+        {
+          icon: null,
+          status: null,
+          content: <></>,
+          supportsCollapsible: false,
+          timelineLayout: "timeline",
+          isExpanded,
+          onToggle: handleToggle,
+          renderType,
+          isLastStep: isLastStep ?? true,
+        },
+      ]);
+    }
+
+    const enhanceResult = (result: RendererResult): TimelineRendererResult => ({
+      ...result,
+      isExpanded,
+      onToggle: handleToggle,
+      renderType,
+      isLastStep: isLastStep ?? true,
+      timelineLayout: result.timelineLayout ?? "timeline",
+    });
+
+    return (
+      <RendererFn
+        packets={packets}
+        state={chatState}
+        onComplete={() => {}}
+        animate={animate}
+        renderType={renderType}
+        stopPacketSeen={stopPacketSeen}
+        stopReason={stopReason}
+        isLastStep={isLastStep}
+      >
+        {(rendererOutput: RendererOutput) =>
+          children(rendererOutput.map(enhanceResult))
+        }
+      </RendererFn>
+    );
+  },
+  arePropsEqual,
+);
+
+export default TimelineRendererComponent;

--- a/mobile/src/components/chat/timeline/__tests__/StepContainer.test.tsx
+++ b/mobile/src/components/chat/timeline/__tests__/StepContainer.test.tsx
@@ -1,0 +1,144 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+import { View } from "react-native";
+
+import { StepContainer } from "@/components/chat/timeline/StepContainer";
+import { Text } from "@/components/ui/text";
+import SvgCircle from "@/icons/circle";
+import SvgXOctagon from "@/icons/x-octagon";
+
+// Button navigates via expo-router's `router`; stub it so the import resolves under jest.
+jest.mock("expo-router", () => ({ router: { navigate: jest.fn() } }));
+
+function Body() {
+  return (
+    <Text font="main-ui-body" color="text-05">
+      step body
+    </Text>
+  );
+}
+
+describe("StepContainer", () => {
+  it("renders the header status, body, and rail node icon (no error octagon)", () => {
+    render(
+      <StepContainer stepIcon={SvgCircle} header="Thinking">
+        <Body />
+      </StepContainer>,
+    );
+    expect(screen.getByText("Thinking")).toBeTruthy();
+    expect(screen.getByText("step body")).toBeTruthy();
+    expect(screen.UNSAFE_queryByType(SvgCircle)).toBeTruthy();
+    expect(screen.UNSAFE_queryByType(SvgXOctagon)).toBeNull();
+  });
+
+  it("shows the collapse control only when collapsible + supportsCollapsible + onToggle", () => {
+    const onToggle = jest.fn();
+    render(
+      <StepContainer
+        header="Thinking"
+        supportsCollapsible
+        isExpanded
+        onToggle={onToggle}
+      >
+        <Body />
+      </StepContainer>,
+    );
+    const toggle = screen.getByLabelText("Collapse");
+    fireEvent.press(toggle);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    // collapse control shown → the error-octagon branch isn't taken
+    expect(screen.UNSAFE_queryByType(SvgXOctagon)).toBeNull();
+  });
+
+  it("hides the collapse control when the renderer does not support collapsing", () => {
+    render(
+      <StepContainer header="Done" onToggle={jest.fn()}>
+        <Body />
+      </StepContainer>,
+    );
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("labels the toggle 'Expand' when collapsed", () => {
+    render(
+      <StepContainer
+        header="Thinking"
+        supportsCollapsible
+        isExpanded={false}
+        onToggle={jest.fn()}
+      >
+        <Body />
+      </StepContainer>,
+    );
+    expect(screen.getByLabelText("Expand")).toBeTruthy();
+  });
+
+  it("renders a labelled toggle button when buttonTitle is set", () => {
+    render(
+      <StepContainer
+        header="Sources"
+        supportsCollapsible
+        isExpanded
+        onToggle={jest.fn()}
+        buttonTitle="Show 3"
+      >
+        <Body />
+      </StepContainer>,
+    );
+    expect(screen.getByText("Show 3")).toBeTruthy();
+  });
+
+  it("shows the error octagon on an error surface with no collapse control", () => {
+    render(
+      <StepContainer header="Failed" surfaceBackground="error">
+        <Body />
+      </StepContainer>,
+    );
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.UNSAFE_queryByType(SvgXOctagon)).toBeTruthy();
+  });
+
+  it("omits the header and rail icon when hideHeader is set", () => {
+    render(
+      <StepContainer stepIcon={SvgCircle} header="Thinking" hideHeader>
+        <Body />
+      </StepContainer>,
+    );
+    expect(screen.queryByText("Thinking")).toBeNull();
+    expect(screen.getByText("step body")).toBeTruthy();
+    // showIcon = !hideHeader && Boolean(stepIcon) → false, so the rail icon drops
+    expect(screen.UNSAFE_queryByType(SvgCircle)).toBeNull();
+  });
+
+  it("drops the rail column entirely when withRail is false", () => {
+    render(
+      <StepContainer stepIcon={SvgCircle} header="Nested" withRail={false}>
+        <Body />
+      </StepContainer>,
+    );
+    // no rail → the node icon (rail-only) isn't rendered
+    expect(screen.UNSAFE_queryByType(SvgCircle)).toBeNull();
+    expect(screen.getByText("Nested")).toBeTruthy();
+    expect(screen.getByText("step body")).toBeTruthy();
+  });
+
+  it("renders a ReactElement header as-is (does not coerce it through Text)", () => {
+    // A ReactElement header renders directly; wrapping a View in RN Text would throw, so a clean
+    // render proves the element branch runs.
+    render(
+      <StepContainer
+        header={
+          <View testID="custom-header">
+            <Text font="main-ui-muted" color="text-04">
+              custom-status
+            </Text>
+          </View>
+        }
+      >
+        <Body />
+      </StepContainer>,
+    );
+    expect(screen.getByTestId("custom-header")).toBeTruthy();
+    expect(screen.getByText("custom-status")).toBeTruthy();
+  });
+});

--- a/mobile/src/components/chat/timeline/__tests__/TimelineRendererComponent.test.tsx
+++ b/mobile/src/components/chat/timeline/__tests__/TimelineRendererComponent.test.tsx
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { act, render } from "@testing-library/react-native";
+import type { Mock } from "jest-mock";
+import type { ComponentProps } from "react";
+
+import { findRenderer } from "@/components/chat/renderers/findRenderer";
+import {
+  RenderType,
+  type DispatchRenderer,
+  type TimelineRendererResult,
+} from "@/components/chat/renderers/timelineContract";
+import { TimelineRendererComponent } from "@/components/chat/timeline/TimelineRendererComponent";
+import type { Packet } from "@/chat/streamingModels";
+
+jest.mock("@/components/chat/renderers/findRenderer", () => ({
+  findRenderer: jest.fn(),
+}));
+
+const mockFindRenderer = findRenderer as unknown as Mock<
+  (packets: Packet[]) => DispatchRenderer | null
+>;
+
+// Stub renderer emitting one result. The RenderType it received surfaces as the enhanced result's
+// `renderType` (the component derives one value for both), so no render-time capture is needed.
+const MockRenderer: DispatchRenderer = (props) =>
+  props.children([
+    {
+      icon: null,
+      status: "S",
+      content: <></>,
+      supportsCollapsible: true,
+      timelineLayout: "content",
+    },
+  ]);
+
+// Omits the optional timelineLayout so enhanceResult's `?? "timeline"` default is exercised.
+const MockRendererNoLayout: DispatchRenderer = (props) =>
+  props.children([{ icon: null, status: "S", content: <></> }]);
+
+function renderTimeline(
+  extraProps: Partial<ComponentProps<typeof TimelineRendererComponent>> = {},
+) {
+  let captured: TimelineRendererResult[] | null = null;
+  render(
+    <TimelineRendererComponent
+      packets={[]}
+      chatState={{ agent: null }}
+      animate={false}
+      stopPacketSeen={false}
+      {...extraProps}
+    >
+      {(results) => {
+        captured = results;
+        return <></>;
+      }}
+    </TimelineRendererComponent>,
+  );
+  return () => captured!;
+}
+
+describe("TimelineRendererComponent", () => {
+  beforeEach(() => {
+    mockFindRenderer.mockReturnValue(MockRenderer);
+  });
+
+  it("derives FULL when expanded and COMPACT when collapsed", () => {
+    expect(renderTimeline({ defaultExpanded: true })()[0].renderType).toBe(
+      RenderType.FULL,
+    );
+    expect(renderTimeline({ defaultExpanded: false })()[0].renderType).toBe(
+      RenderType.COMPACT,
+    );
+  });
+
+  it("honors renderTypeOverride regardless of expand state", () => {
+    const results = renderTimeline({
+      defaultExpanded: false,
+      renderTypeOverride: RenderType.FULL,
+    })();
+    expect(results[0].renderType).toBe(RenderType.FULL);
+  });
+
+  it("enhances each result with the collapse/timeline fields", () => {
+    const results = renderTimeline({
+      defaultExpanded: true,
+      isLastStep: false,
+    })();
+    expect(results).toHaveLength(1);
+    const [result] = results;
+    expect(result.status).toBe("S");
+    expect(result.isExpanded).toBe(true);
+    expect(result.renderType).toBe(RenderType.FULL);
+    expect(result.isLastStep).toBe(false);
+    expect(result.timelineLayout).toBe("content");
+    expect(typeof result.onToggle).toBe("function");
+  });
+
+  it("toggles expand state, flipping the derived render type", () => {
+    const get = renderTimeline({ defaultExpanded: true });
+    expect(get()[0].renderType).toBe(RenderType.FULL);
+    act(() => {
+      get()[0].onToggle();
+    });
+    expect(get()[0].renderType).toBe(RenderType.COMPACT);
+  });
+
+  it("defaults timelineLayout to 'timeline' and isLastStep to true when both are unset", () => {
+    mockFindRenderer.mockReturnValue(MockRendererNoLayout);
+    // renderTimeline omits isLastStep → the `?? true` default runs.
+    const [result] = renderTimeline({ defaultExpanded: true })();
+    expect(result.timelineLayout).toBe("timeline");
+    expect(result.isLastStep).toBe(true);
+  });
+
+  it("hands an empty result to children when no renderer matches", () => {
+    mockFindRenderer.mockReturnValue(null);
+    const results = renderTimeline({
+      defaultExpanded: true,
+      isLastStep: true,
+    })();
+    expect(results).toHaveLength(1);
+    const [result] = results;
+    expect(result.icon).toBeNull();
+    expect(result.status).toBeNull();
+    expect(result.supportsCollapsible).toBe(false);
+    expect(result.timelineLayout).toBe("timeline");
+    expect(result.isExpanded).toBe(true);
+    expect(result.renderType).toBe(RenderType.FULL);
+    expect(result.isLastStep).toBe(true);
+  });
+});

--- a/mobile/src/components/chat/timeline/primitives/TimelineHeaderRow.tsx
+++ b/mobile/src/components/chat/timeline/primitives/TimelineHeaderRow.tsx
@@ -1,0 +1,32 @@
+// Rail-width cell (agent avatar) + header slot, so the header aligns with the step rail below it.
+import type { ReactNode } from "react";
+import { View } from "react-native";
+
+import { timelineTokens } from "./timelineTokens";
+
+export interface TimelineHeaderRowProps {
+  left?: ReactNode;
+  children?: ReactNode;
+}
+
+export function TimelineHeaderRow({ left, children }: TimelineHeaderRowProps) {
+  return (
+    <View
+      className="w-full flex-row"
+      style={{ height: timelineTokens.headerRowHeight }}
+    >
+      <View
+        className="items-center justify-center"
+        style={{
+          width: timelineTokens.railWidth,
+          height: timelineTokens.headerRowHeight,
+        }}
+      >
+        {left}
+      </View>
+      <View className="h-full min-w-0 flex-1">{children}</View>
+    </View>
+  );
+}
+
+export default TimelineHeaderRow;

--- a/mobile/src/components/chat/timeline/primitives/TimelineIconColumn.tsx
+++ b/mobile/src/components/chat/timeline/primitives/TimelineIconColumn.tsx
@@ -1,0 +1,76 @@
+// Left rail (connector + node icon). Hover dropped (no touch hover): connector rests at bg-border-01,
+// node icon at text-02 (set by the caller).
+import type { ReactNode } from "react";
+import { View } from "react-native";
+
+import { cn } from "@/lib/utils";
+
+import { timelineTokens } from "./timelineTokens";
+
+// spacer keeps the column width for alignment without drawing a rail.
+export type TimelineRailVariant = "rail" | "spacer";
+
+export interface TimelineIconColumnProps {
+  variant?: TimelineRailVariant;
+  isFirst?: boolean;
+  isLast?: boolean;
+  icon?: ReactNode;
+  showIcon?: boolean;
+  // compact = first-spacer height, for hidden headers; default = full step-header height.
+  iconRowVariant?: "default" | "compact";
+}
+
+export function TimelineIconColumn({
+  variant = "rail",
+  isFirst = false,
+  isLast = false,
+  icon,
+  showIcon = true,
+  iconRowVariant = "default",
+}: TimelineIconColumnProps) {
+  if (variant === "spacer") {
+    return <View style={{ width: timelineTokens.railWidth }} />;
+  }
+
+  return (
+    <View
+      className="relative items-center"
+      style={{ width: timelineTokens.railWidth }}
+    >
+      <View
+        className="w-full shrink-0 items-center"
+        style={{
+          height:
+            iconRowVariant === "compact"
+              ? timelineTokens.firstTopSpacerHeight
+              : timelineTokens.stepHeaderHeight,
+        }}
+      >
+        {iconRowVariant === "default" ? (
+          <>
+            <View
+              className={cn("w-[1px]", !isFirst && "bg-border-01")}
+              style={{ height: timelineTokens.stepTopPadding * 2 }}
+            />
+            <View
+              className="shrink-0 items-center justify-center"
+              style={{
+                height: timelineTokens.branchIconWrapperSize,
+                width: timelineTokens.branchIconWrapperSize,
+              }}
+            >
+              {showIcon ? icon : null}
+            </View>
+            <View className="w-[1px] flex-1 bg-border-01" />
+          </>
+        ) : (
+          <View className={cn("w-[1px] flex-1", !isFirst && "bg-border-01")} />
+        )}
+      </View>
+
+      {!isLast && <View className="w-[1px] flex-1 bg-border-01" />}
+    </View>
+  );
+}
+
+export default TimelineIconColumn;

--- a/mobile/src/components/chat/timeline/primitives/TimelineRoot.tsx
+++ b/mobile/src/components/chat/timeline/primitives/TimelineRoot.tsx
@@ -1,0 +1,19 @@
+// Web sets the token CSS vars here; mobile bakes them as constants, so this is just the column + left gutter.
+import type { ReactNode } from "react";
+import { View } from "react-native";
+
+import { timelineTokens } from "./timelineTokens";
+
+export interface TimelineRootProps {
+  children: ReactNode;
+}
+
+export function TimelineRoot({ children }: TimelineRootProps) {
+  return (
+    <View style={{ paddingLeft: timelineTokens.agentMessagePaddingLeft }}>
+      {children}
+    </View>
+  );
+}
+
+export default TimelineRoot;

--- a/mobile/src/components/chat/timeline/primitives/TimelineRow.tsx
+++ b/mobile/src/components/chat/timeline/primitives/TimelineRow.tsx
@@ -1,0 +1,50 @@
+// Base row: rail column + content column. Hover props dropped.
+import type { ReactNode } from "react";
+import { View } from "react-native";
+
+import {
+  TimelineIconColumn,
+  type TimelineRailVariant,
+} from "./TimelineIconColumn";
+
+// "none" omits the left column entirely (nested/parallel content).
+export type TimelineRowRailVariant = TimelineRailVariant | "none";
+
+export interface TimelineRowProps {
+  railVariant?: TimelineRowRailVariant;
+  icon?: ReactNode;
+  showIcon?: boolean;
+  // compact keeps rail alignment stable when the header is hidden.
+  iconRowVariant?: "default" | "compact";
+  isFirst?: boolean;
+  isLast?: boolean;
+  children?: ReactNode;
+}
+
+export function TimelineRow({
+  railVariant = "rail",
+  icon,
+  showIcon = true,
+  iconRowVariant = "default",
+  isFirst = false,
+  isLast = false,
+  children,
+}: TimelineRowProps) {
+  return (
+    <View className="w-full flex-row">
+      {railVariant !== "none" && (
+        <TimelineIconColumn
+          variant={railVariant === "spacer" ? "spacer" : "rail"}
+          icon={icon}
+          showIcon={showIcon}
+          iconRowVariant={iconRowVariant}
+          isFirst={isFirst}
+          isLast={isLast}
+        />
+      )}
+      <View className="min-w-0 flex-1">{children}</View>
+    </View>
+  );
+}
+
+export default TimelineRow;

--- a/mobile/src/components/chat/timeline/primitives/TimelineStepContent.tsx
+++ b/mobile/src/components/chat/timeline/primitives/TimelineStepContent.tsx
@@ -1,0 +1,127 @@
+// Step header (status + collapse control) + body. The collapse control reuses the mobile Button
+// (tertiary/md) — the parity primitive for web's tertiary icon button. No hover, so it's always
+// visible when the renderer supports collapsing. A string header wraps in Text; a ReactElement header
+// renders as-is (RN Text can't nest arbitrary views).
+import type { ReactNode } from "react";
+import { View } from "react-native";
+
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { Text } from "@/components/ui/text";
+import type { TimelineSurfaceBackground } from "@/components/chat/renderers/timelineContract";
+import SvgExpand from "@/icons/expand";
+import SvgFold from "@/icons/fold";
+import type { IconFunctionComponent } from "@/icons/types";
+import SvgXOctagon from "@/icons/x-octagon";
+
+import { timelineTokens } from "./timelineTokens";
+
+export interface TimelineStepContentProps {
+  children?: ReactNode;
+  header?: ReactNode;
+  buttonTitle?: string;
+  isExpanded?: boolean;
+  onToggle?: () => void;
+  collapsible?: boolean;
+  supportsCollapsible?: boolean;
+  hideHeader?: boolean;
+  collapsedIcon?: IconFunctionComponent;
+  noPaddingRight?: boolean;
+  surfaceBackground?: TimelineSurfaceBackground;
+}
+
+export function TimelineStepContent({
+  children,
+  header,
+  buttonTitle,
+  isExpanded = true,
+  onToggle,
+  collapsible = true,
+  supportsCollapsible = false,
+  hideHeader = false,
+  collapsedIcon: CollapsedIconComponent,
+  noPaddingRight = false,
+  surfaceBackground,
+}: TimelineStepContentProps) {
+  const showCollapseControls = collapsible && supportsCollapsible && !!onToggle;
+  const toggleIcon = isExpanded
+    ? SvgFold
+    : (CollapsedIconComponent ?? SvgExpand);
+
+  return (
+    <View className="px-4 pb-4">
+      {!hideHeader && header != null && (
+        <View
+          className="flex-row items-center justify-between pl-4"
+          style={{ height: timelineTokens.stepHeaderHeight }}
+        >
+          <View
+            className="flex-1"
+            style={{
+              paddingTop: timelineTokens.stepTopPadding,
+              paddingLeft: timelineTokens.timelineCommonTextPadding,
+            }}
+          >
+            {typeof header === "string" ? (
+              <Text font="main-ui-muted" color="text-04">
+                {header}
+              </Text>
+            ) : (
+              header
+            )}
+          </View>
+
+          <View
+            className="h-full flex-row items-center justify-end"
+            style={{ width: timelineTokens.stepHeaderRightSectionWidth }}
+          >
+            {showCollapseControls ? (
+              buttonTitle ? (
+                <Button
+                  prominence="tertiary"
+                  size="md"
+                  onPress={onToggle}
+                  rightIcon={toggleIcon}
+                >
+                  {buttonTitle}
+                </Button>
+              ) : (
+                <Button
+                  prominence="tertiary"
+                  size="md"
+                  onPress={onToggle}
+                  icon={toggleIcon}
+                  accessibilityLabel={isExpanded ? "Collapse" : "Expand"}
+                />
+              )
+            ) : surfaceBackground === "error" ? (
+              <View className="p-6">
+                <Icon
+                  as={SvgXOctagon}
+                  size={16}
+                  className="text-status-error-05"
+                />
+              </View>
+            ) : null}
+          </View>
+        </View>
+      )}
+
+      {children != null && (
+        <View
+          className="pb-4 pl-4"
+          style={{
+            paddingRight: noPaddingRight
+              ? undefined
+              : timelineTokens.stepHeaderRightSectionWidth,
+            paddingTop: hideHeader ? timelineTokens.stepTopPadding : undefined,
+          }}
+        >
+          {children}
+        </View>
+      )}
+    </View>
+  );
+}
+
+export default TimelineStepContent;

--- a/mobile/src/components/chat/timeline/primitives/TimelineSurface.tsx
+++ b/mobile/src/components/chat/timeline/primitives/TimelineSurface.tsx
@@ -1,0 +1,51 @@
+// Tint/error background + rounded corners for a step body. Hover + `transition-colors` dropped (no
+// touch hover; RN has no CSS transitions). `TimelineSurfaceBackground` reused from the contract.
+import React, { type ReactNode } from "react";
+import { View } from "react-native";
+
+import type { TimelineSurfaceBackground } from "@/components/chat/renderers/timelineContract";
+import { cn } from "@/lib/utils";
+
+export type { TimelineSurfaceBackground };
+
+export interface TimelineSurfaceProps {
+  children: ReactNode;
+  className?: string;
+  roundedTop?: boolean;
+  roundedBottom?: boolean;
+  background?: TimelineSurfaceBackground;
+}
+
+export function TimelineSurface({
+  children,
+  className,
+  roundedTop = false,
+  roundedBottom = false,
+  background = "tint",
+}: TimelineSurfaceProps) {
+  if (React.Children.count(children) === 0) {
+    return null;
+  }
+
+  const baseBackground =
+    background === "tint"
+      ? "bg-background-tint-00"
+      : background === "error"
+        ? "bg-status-error-00"
+        : "";
+
+  return (
+    <View
+      className={cn(
+        baseBackground,
+        roundedTop && "rounded-t-12",
+        roundedBottom && "rounded-b-12",
+        className,
+      )}
+    >
+      {children}
+    </View>
+  );
+}
+
+export default TimelineSurface;

--- a/mobile/src/components/chat/timeline/primitives/timelineTokens.ts
+++ b/mobile/src/components/chat/timeline/primitives/timelineTokens.ts
@@ -1,0 +1,22 @@
+// Web `timeline/primitives/tokens.ts` values baked to px (rem × 16): RN can't use rem/CSS vars for
+// dimensions, so these are plain numbers applied via inline `style` (colors/rounding stay classes).
+export const timelineTokens = {
+  railWidth: 36,
+  headerRowHeight: 36,
+  stepHeaderHeight: 32,
+  topConnectorHeight: 8,
+  firstTopSpacerHeight: 4,
+  iconSize: 12,
+  branchIconWrapperSize: 20,
+  branchIconSize: 12,
+  stepHeaderRightSectionWidth: 34,
+  headerPaddingLeft: 8,
+  headerPaddingRight: 4,
+  headerTextPaddingX: 6,
+  headerTextPaddingY: 2,
+  stepTopPadding: 4,
+  agentMessagePaddingLeft: 1.92,
+  timelineCommonTextPadding: 1.92,
+} as const;
+
+export type TimelineTokens = typeof timelineTokens;

--- a/mobile/src/icons/check-circle.tsx
+++ b/mobile/src/icons/check-circle.tsx
@@ -1,0 +1,30 @@
+import Svg, { ClipPath, Defs, G, Path, Rect } from "react-native-svg";
+
+import type { IconProps } from "@/icons/types";
+
+const SvgCheckCircle = ({ size = 16, ...props }: IconProps) => (
+  <Svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    {...props}
+  >
+    <G clipPath="url(#check-circle-clip)">
+      <Path
+        d="M14.6667 7.38668V8.00001C14.6658 9.43763 14.2003 10.8365 13.3396 11.9879C12.4788 13.1393 11.2689 13.9817 9.89023 14.3893C8.51162 14.7969 7.03817 14.7479 5.68964 14.2497C4.34112 13.7515 3.18976 12.8307 2.4073 11.6247C1.62484 10.4187 1.25319 8.99205 1.34778 7.55755C1.44237 6.12305 1.99813 4.75756 2.93218 3.66473C3.86623 2.57189 5.12852 1.81027 6.53079 1.49344C7.93306 1.17662 9.40017 1.32157 10.7133 1.90668M14.6667 2.66668L8 9.34001L6 7.34001"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </G>
+    <Defs>
+      <ClipPath id="check-circle-clip">
+        <Rect width={16} height={16} fill="white" />
+      </ClipPath>
+    </Defs>
+  </Svg>
+);
+
+export default SvgCheckCircle;

--- a/mobile/src/icons/circle.tsx
+++ b/mobile/src/icons/circle.tsx
@@ -1,0 +1,18 @@
+import Svg, { Circle } from "react-native-svg";
+
+import type { IconProps } from "@/icons/types";
+
+const SvgCircle = ({ size = 16, ...props }: IconProps) => (
+  <Svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    {...props}
+  >
+    <Circle cx={8} cy={8} r={4} strokeWidth={1.5} />
+  </Svg>
+);
+
+export default SvgCircle;

--- a/mobile/src/icons/expand.tsx
+++ b/mobile/src/icons/expand.tsx
@@ -1,0 +1,23 @@
+import Svg, { Path } from "react-native-svg";
+
+import type { IconProps } from "@/icons/types";
+
+const SvgExpand = ({ size = 16, ...props }: IconProps) => (
+  <Svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    {...props}
+  >
+    <Path
+      d="M4.99994 5.49995L7.52858 2.97131C7.78891 2.71098 8.21105 2.71098 8.47138 2.97131L11 5.49995M5.00024 10.5L7.5288 13.0286C7.78914 13.2889 8.21127 13.2889 8.4716 13.0286L11.0002 10.5"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </Svg>
+);
+
+export default SvgExpand;

--- a/mobile/src/icons/fold.tsx
+++ b/mobile/src/icons/fold.tsx
@@ -1,0 +1,23 @@
+import Svg, { Path } from "react-native-svg";
+
+import type { IconProps } from "@/icons/types";
+
+const SvgFold = ({ size = 16, ...props }: IconProps) => (
+  <Svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    {...props}
+  >
+    <Path
+      d="M11 3.25L8.47136 5.77857C8.21103 6.0389 7.78889 6.0389 7.52856 5.77857L4.99999 3.25M11 12.75L8.47136 10.2214C8.21103 9.96103 7.78889 9.96103 7.52856 10.2214L4.99999 12.75"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </Svg>
+);
+
+export default SvgFold;


### PR DESCRIPTION
## Description

Ports web's agent-timeline primitives + `StepContainer` to the mobile app (9b.5 of the reasoning-timeline roadmap; lands **dark** — nothing renders on screen until 9b.7 mounts the timeline): rail/surface/content primitives with web tokens baked to px and hover dropped for touch, `StepContainer`, `TimelineRendererComponent` (per-step expand + `renderType` derivation over the 9b.4 contract), the new `circle`/`fold`/`expand`/`check-circle` icons ported 1:1 from Opal, and an additive `muted` variant on `StreamingMarkdown`. Reuses the existing mobile `Button` for the tertiary collapse control (no new primitive).

## How Has This Been Tested?

Jest + RN Testing Library — StepContainer (collapse gating, error surface, rail-icon gate, `withRail`), `TimelineRendererComponent` (renderType derivation, null path, `enhanceResult` defaults, mutation-checked); full mobile suite green (typecheck/lint/jest, 477 tests).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
