### PR TITLE
feat(gateway): pass extended thinking through the Anthropic Messages API

### DIFF
--- a/backend/onyx/llm/model_response.py
+++ b/backend/onyx/llm/model_response.py
@@ -5,6 +5,9 @@ from typing import TYPE_CHECKING, Any, List
 from pydantic import BaseModel, Field
 
 from onyx.llm.models import AnyThinkingBlock, RedactedThinkingBlock, ThinkingBlock
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
 
 
 class FunctionCall(BaseModel):
@@ -124,6 +127,9 @@ def _parse_thinking_blocks(
     parsed: list[AnyThinkingBlock] = []
     for block in thinking_blocks:
         if not isinstance(block, dict):
+            logger.warning(
+                "Dropping malformed thinking block of type %s", type(block).__name__
+            )
             continue
         if block.get("type") == "redacted_thinking":
             parsed.append(RedactedThinkingBlock(data=block.get("data") or ""))

--- a/backend/onyx/llm/model_response.py
+++ b/backend/onyx/llm/model_response.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING, Any, List
 
 from pydantic import BaseModel, Field
 
+from onyx.llm.models import AnyThinkingBlock, RedactedThinkingBlock, ThinkingBlock
+
 
 class FunctionCall(BaseModel):
     arguments: str | None = None
@@ -26,6 +28,7 @@ class ChatCompletionDeltaToolCall(BaseModel):
 class Delta(BaseModel):
     content: str | None = None
     reasoning_content: str | None = None
+    thinking_blocks: List[AnyThinkingBlock] | None = None
     tool_calls: List[ChatCompletionDeltaToolCall] = Field(default_factory=list)
 
 
@@ -59,6 +62,7 @@ class Message(BaseModel):
     role: str = "assistant"
     tool_calls: List[ChatCompletionMessageToolCall] | None = None
     reasoning_content: str | None = None
+    thinking_blocks: List[AnyThinkingBlock] | None = None
 
 
 class Choice(BaseModel):
@@ -109,6 +113,28 @@ def _parse_delta_tool_calls(
             )
         )
     return parsed_tool_calls
+
+
+def _parse_thinking_blocks(
+    thinking_blocks: list[dict[str, Any]] | None,
+) -> list[AnyThinkingBlock] | None:
+    if not thinking_blocks:
+        return None
+
+    parsed: list[AnyThinkingBlock] = []
+    for block in thinking_blocks:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "redacted_thinking":
+            parsed.append(RedactedThinkingBlock(data=block.get("data") or ""))
+        else:
+            parsed.append(
+                ThinkingBlock(
+                    thinking=block.get("thinking") or "",
+                    signature=block.get("signature"),
+                )
+            )
+    return parsed or None
 
 
 def _parse_message_tool_calls(
@@ -190,6 +216,7 @@ def from_litellm_model_response_stream(
     parsed_delta = Delta(
         content=delta_data.get("content"),
         reasoning_content=delta_data.get("reasoning_content"),
+        thinking_blocks=_parse_thinking_blocks(delta_data.get("thinking_blocks")),
         tool_calls=_parse_delta_tool_calls(delta_data.get("tool_calls")),
     )
 
@@ -226,6 +253,7 @@ def from_litellm_model_response(
         role=message_data.get("role", "assistant"),
         tool_calls=parsed_tool_calls if parsed_tool_calls else None,
         reasoning_content=message_data.get("reasoning_content"),
+        thinking_blocks=_parse_thinking_blocks(message_data.get("thinking_blocks")),
     )
 
     choice = Choice(

--- a/backend/onyx/llm/models.py
+++ b/backend/onyx/llm/models.py
@@ -112,6 +112,22 @@ class ImageContentPart(BaseModel):
 ContentPart = TextContentPart | ImageContentPart
 
 
+# The signature is minted by the provider and must be round-tripped unmodified
+# for replay to be accepted.
+class ThinkingBlock(BaseModel):
+    type: Literal["thinking"] = "thinking"
+    thinking: str = ""
+    signature: str | None = None
+
+
+class RedactedThinkingBlock(BaseModel):
+    type: Literal["redacted_thinking"] = "redacted_thinking"
+    data: str
+
+
+AnyThinkingBlock = ThinkingBlock | RedactedThinkingBlock
+
+
 # Tool call structures
 class FunctionCall(BaseModel):
     name: str
@@ -147,6 +163,7 @@ class AssistantMessage(CacheableMessage):
     role: Literal["assistant"] = "assistant"
     content: str | None = None
     tool_calls: list[ToolCall] | None = None
+    thinking_blocks: list[AnyThinkingBlock] | None = None
 
 
 class ToolMessage(CacheableMessage):

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -854,7 +854,13 @@ class LitellmLLM(LLM):
 
             messages = _prompt_to_dicts(prompt)
 
-            if self._model_provider not in _THINKING_BLOCK_PROVIDERS:
+            if not (
+                is_claude_model
+                and (
+                    self._model_provider in _THINKING_BLOCK_PROVIDERS
+                    or self._api_surface is LlmApiSurface.ANTHROPIC_MESSAGES
+                )
+            ):
                 messages = _strip_thinking_blocks_from_messages(messages)
 
             # Bedrock's Converse API requires toolConfig when messages

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -171,6 +171,25 @@ def _normalize_content(raw: Any) -> str:
     return str(raw)
 
 
+# Providers not in this set forward the unknown `thinking_blocks` key verbatim,
+# so strip it for them.
+_THINKING_BLOCK_PROVIDERS = {
+    LlmProviderNames.ANTHROPIC,
+    LlmProviderNames.BEDROCK,
+    LlmProviderNames.BEDROCK_CONVERSE,
+    LlmProviderNames.VERTEX_AI,
+}
+
+
+def _strip_thinking_blocks_from_messages(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    return [
+        {key: value for key, value in msg.items() if key != "thinking_blocks"}
+        for msg in messages
+    ]
+
+
 def _strip_tool_content_from_messages(
     messages: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -834,6 +853,9 @@ class LitellmLLM(LLM):
                 passthrough_kwargs["api_key"] = self._api_key or None
 
             messages = _prompt_to_dicts(prompt)
+
+            if self._model_provider not in _THINKING_BLOCK_PROVIDERS:
+                messages = _strip_thinking_blocks_from_messages(messages)
 
             # Bedrock's Converse API requires toolConfig when messages
             # contain toolUse/toolResult content blocks. When no tools are

--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -33,10 +33,13 @@ from onyx.llm.model_response import (
     Usage,
 )
 from onyx.llm.models import (
+    AnyThinkingBlock,
     AssistantMessage,
     ChatCompletionMessage,
     ReasoningEffort,
+    RedactedThinkingBlock,
     TextContentPart,
+    ThinkingBlock,
     ToolCall,
     ToolChoiceOptions,
     UserMessage,
@@ -62,9 +65,13 @@ from onyx.server.gateway.models import (
     AnthropicMessageStartEvent,
     AnthropicMessageStopEvent,
     AnthropicPingEvent,
+    AnthropicRedactedThinkingBlock,
+    AnthropicSignatureDelta,
     AnthropicStreamEvent,
     AnthropicTextBlock,
     AnthropicTextDelta,
+    AnthropicThinkingBlock,
+    AnthropicThinkingDelta,
     AnthropicToolUseBlock,
     AnthropicUsagePayload,
     ChatCompletionChunk,
@@ -201,7 +208,11 @@ def _drop_empty_text(message: ChatCompletionMessage) -> ChatCompletionMessage | 
     if isinstance(message, AssistantMessage):
         if isinstance(message.content, str) and not message.content.strip():
             message = message.model_copy(update={"content": None})
-        if message.content is None and not message.tool_calls:
+        if (
+            message.content is None
+            and not message.tool_calls
+            and not message.thinking_blocks
+        ):
             return None
         return message
     if isinstance(message, UserMessage):
@@ -435,7 +446,7 @@ def _stream_worker(
             )
             for chunk in state.upstream:
                 if cancelled.is_set():
-                    return
+                    break
                 state.observe(chunk)
                 payload = ChatCompletionChunk.from_stream_chunk(
                     chunk, model, include_role=not sent_role
@@ -444,8 +455,9 @@ def _stream_worker(
                 if not _put_stream_item(
                     out, f"data: {json.dumps(payload.to_wire())}\n\n", cancelled
                 ):
-                    return
-            _put_stream_item(out, "data: [DONE]\n\n", cancelled)
+                    break
+            else:
+                _put_stream_item(out, "data: [DONE]\n\n", cancelled)
 
 
 def _run_bridged_stream(
@@ -774,7 +786,7 @@ def _responses_stream_worker(
             )
             for chunk in state.upstream:
                 if cancelled.is_set():
-                    return
+                    break
                 state.observe(chunk)
                 if not chunk.choice.delta.content:
                     continue
@@ -789,7 +801,7 @@ def _responses_stream_worker(
                             ),
                         )
                     ):
-                        return
+                        break
                     if not emit(
                         ResponsesContentPartAddedEvent.create(
                             item_id=message_item_id,
@@ -797,7 +809,7 @@ def _responses_stream_worker(
                             part=ResponsesOutputTextPart.create(text=""),
                         )
                     ):
-                        return
+                        break
                     text_item_open = True
                 if not emit(
                     ResponsesOutputTextDeltaEvent.create(
@@ -805,56 +817,58 @@ def _responses_stream_worker(
                         delta=chunk.choice.delta.content,
                     )
                 ):
-                    return
-            # Build each item once and reuse it below: re-deriving items
-            # for the terminal payload remints ids the client never saw.
-            completed_items: list[ResponsesOutputItem] = []
-            if text_item_open:
-                completed_items.append(close_text_item("completed"))
-            # Filter before enumerating, or a dropped nameless call leaves
-            # a hole in the output_index sequence.
-            call_items = [
-                item
-                for item in (
-                    _function_call_item(tool_call)
-                    for tool_call in _finalize_tool_calls(state.tool_call_buffer) or []
-                )
-                if item is not None
-            ]
-            for tool_index, call_item in enumerate(
-                call_items, start=len(completed_items)
-            ):
-                completed_items.append(call_item)
+                    break
+            else:
+                # Build each item once and reuse it below: re-deriving items
+                # for the terminal payload remints ids the client never saw.
+                completed_items: list[ResponsesOutputItem] = []
+                if text_item_open:
+                    completed_items.append(close_text_item("completed"))
+                # Filter before enumerating, or a dropped nameless call leaves
+                # a hole in the output_index sequence.
+                call_items = [
+                    item
+                    for item in (
+                        _function_call_item(tool_call)
+                        for tool_call in _finalize_tool_calls(state.tool_call_buffer)
+                        or []
+                    )
+                    if item is not None
+                ]
+                for tool_index, call_item in enumerate(
+                    call_items, start=len(completed_items)
+                ):
+                    completed_items.append(call_item)
+                    emit(
+                        ResponsesOutputItemAddedEvent.create(
+                            output_index=tool_index, item=call_item
+                        )
+                    )
+                    emit(
+                        ResponsesFunctionCallArgumentsDoneEvent.create(
+                            item_id=call_item.id,
+                            output_index=tool_index,
+                            arguments=call_item.arguments,
+                            name=call_item.name,
+                        )
+                    )
+                    emit(
+                        ResponsesOutputItemDoneEvent.create(
+                            output_index=tool_index, item=call_item
+                        )
+                    )
                 emit(
-                    ResponsesOutputItemAddedEvent.create(
-                        output_index=tool_index, item=call_item
+                    ResponsesCompletedEvent.create(
+                        ResponsesObjectPayload.from_parts(
+                            response_id=response_id,
+                            created_at=created_at,
+                            model=model,
+                            status="completed",
+                            output=completed_items,
+                            usage=state.usage,
+                        )
                     )
                 )
-                emit(
-                    ResponsesFunctionCallArgumentsDoneEvent.create(
-                        item_id=call_item.id,
-                        output_index=tool_index,
-                        arguments=call_item.arguments,
-                        name=call_item.name,
-                    )
-                )
-                emit(
-                    ResponsesOutputItemDoneEvent.create(
-                        output_index=tool_index, item=call_item
-                    )
-                )
-            emit(
-                ResponsesCompletedEvent.create(
-                    ResponsesObjectPayload.from_parts(
-                        response_id=response_id,
-                        created_at=created_at,
-                        model=model,
-                        status="completed",
-                        output=completed_items,
-                        usage=state.usage,
-                    )
-                )
-            )
 
 
 def handle_responses_request(
@@ -967,6 +981,31 @@ def _anthropic_system_to_raw_message(
     return None
 
 
+def _replayable_thinking_blocks(
+    raw_blocks: Any,
+) -> list[dict[str, Any]] | None:
+    """Unsigned thinking blocks would be rejected by Anthropic's signature
+    check, so they are dropped rather than forwarded."""
+    if not isinstance(raw_blocks, list):
+        return None
+    kept: list[dict[str, Any]] = []
+    for block in raw_blocks:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "redacted_thinking" and block.get("data"):
+            kept.append({"type": "redacted_thinking", "data": block["data"]})
+        elif block_type == "thinking" and block.get("signature"):
+            kept.append(
+                {
+                    "type": "thinking",
+                    "thinking": block.get("thinking") or "",
+                    "signature": block["signature"],
+                }
+            )
+    return kept or None
+
+
 def _anthropic_messages_to_raw_messages(
     messages: list[dict[str, Any]], system: str | list[dict[str, Any]] | None
 ) -> list[dict[str, Any]]:
@@ -1009,6 +1048,10 @@ def _anthropic_messages_to_raw_messages(
     for message in translated:
         message_dict: dict[str, Any] = dict(message)
         role = message_dict.get("role")
+        if role == "assistant":
+            message_dict["thinking_blocks"] = _replayable_thinking_blocks(
+                message_dict.get("thinking_blocks")
+            )
         if role in ("system", "tool") and isinstance(message_dict.get("content"), list):
             message_dict["content"] = _flatten_text_content(message_dict["content"])
         elif role == "assistant" and isinstance(message_dict.get("content"), list):
@@ -1108,11 +1151,33 @@ def _anthropic_stop_reason(finish_reason: str | None, has_tool_use: bool) -> str
     if mapped == "max_tokens":
         return mapped
     # Otherwise tool calls dominate: providers routinely report finish_reason
-    # "stop" on tool-call turns, and reporting end_turn would make clients
-    # treat the turn as final and drop the tool calls.
+    # "stop" on tool-call turns.
     if has_tool_use:
         return "tool_use"
     return mapped
+
+
+def _anthropic_thinking_content_blocks(
+    thinking_blocks: list[AnyThinkingBlock] | None,
+    reasoning_content: str | None,
+) -> list[AnthropicContentBlock]:
+    """Unsigned fallback blocks are safe to emit because the input path drops
+    unsigned blocks on replay, so they can never reach a signature check."""
+    blocks: list[AnthropicContentBlock] = []
+    for block in thinking_blocks or []:
+        if isinstance(block, RedactedThinkingBlock):
+            blocks.append(AnthropicRedactedThinkingBlock.create(data=block.data))
+        elif block.thinking or block.signature:
+            blocks.append(
+                AnthropicThinkingBlock.create(
+                    thinking=block.thinking, signature=block.signature or ""
+                )
+            )
+    if not blocks and reasoning_content:
+        blocks.append(
+            AnthropicThinkingBlock.create(thinking=reasoning_content, signature="")
+        )
+    return blocks
 
 
 def _anthropic_tool_use_blocks(
@@ -1186,7 +1251,76 @@ def _anthropic_stream_worker(
         ) as span,
     ):
         state = _StreamAccumulator()
-        text_block_open = False
+        open_kind: str | None = None
+        open_index: int | None = None
+        next_index = 0
+
+        def close_open_block() -> bool:
+            nonlocal open_kind, open_index
+            if open_index is None:
+                return True
+            index = open_index
+            open_kind = None
+            open_index = None
+            return emit(AnthropicContentBlockStopEvent.create(index=index))
+
+        def ensure_block_open(kind: str) -> bool:
+            nonlocal open_kind, open_index, next_index
+            if open_kind == kind:
+                return True
+            if not close_open_block():
+                return False
+            content_block: AnthropicContentBlock = (
+                AnthropicThinkingBlock.create(thinking="", signature="")
+                if kind == "thinking"
+                else AnthropicTextBlock.create(text="")
+            )
+            open_kind = kind
+            open_index = next_index
+            next_index += 1
+            return emit(
+                AnthropicContentBlockStartEvent.create(
+                    index=open_index, content_block=content_block
+                )
+            )
+
+        def emit_thinking_deltas(blocks: list[AnyThinkingBlock]) -> bool:
+            nonlocal next_index
+            for block in blocks:
+                if isinstance(block, RedactedThinkingBlock):
+                    if not close_open_block():
+                        return False
+                    index = next_index
+                    next_index += 1
+                    if not emit(
+                        AnthropicContentBlockStartEvent.create(
+                            index=index,
+                            content_block=AnthropicRedactedThinkingBlock.create(
+                                data=block.data
+                            ),
+                        )
+                    ) or not emit(AnthropicContentBlockStopEvent.create(index=index)):
+                        return False
+                    continue
+                if not ensure_block_open("thinking"):
+                    return False
+                assert open_index is not None
+                if block.thinking and not emit(
+                    AnthropicContentBlockDeltaEvent.create(
+                        index=open_index,
+                        delta=AnthropicThinkingDelta.create(thinking=block.thinking),
+                    )
+                ):
+                    return False
+                if block.signature and not emit(
+                    AnthropicContentBlockDeltaEvent.create(
+                        index=open_index,
+                        delta=AnthropicSignatureDelta.create(signature=block.signature),
+                    )
+                ):
+                    return False
+            return True
+
         with _stream_worker_guard(
             span,
             model,
@@ -1206,72 +1340,74 @@ def _anthropic_stream_worker(
             finish_reason: str | None = None
             for chunk in state.upstream:
                 if cancelled.is_set():
-                    return
+                    break
                 state.observe(chunk)
                 if chunk.choice.finish_reason is not None:
                     finish_reason = chunk.choice.finish_reason
-                if chunk.choice.delta.content:
-                    if not text_block_open:
-                        if not emit(
-                            AnthropicContentBlockStartEvent.create(
-                                index=0,
-                                content_block=AnthropicTextBlock.create(text=""),
-                            )
-                        ):
-                            return
-                        text_block_open = True
+                delta = chunk.choice.delta
+                # Anthropic-family chunks carry reasoning_content mirroring
+                # thinking_blocks, so only one of the two may be emitted.
+                if delta.thinking_blocks:
+                    if not emit_thinking_deltas(delta.thinking_blocks):
+                        break
+                elif delta.reasoning_content:
+                    if not emit_thinking_deltas(
+                        [ThinkingBlock(thinking=delta.reasoning_content)]
+                    ):
+                        break
+                if delta.content:
+                    if not ensure_block_open("text"):
+                        break
+                    assert open_index is not None
                     if not emit(
                         AnthropicContentBlockDeltaEvent.create(
-                            index=0,
-                            delta=AnthropicTextDelta.create(
-                                text=chunk.choice.delta.content
-                            ),
+                            index=open_index,
+                            delta=AnthropicTextDelta.create(text=delta.content),
                         )
                     ):
-                        return
-            if text_block_open:
-                emit(AnthropicContentBlockStopEvent.create(index=0))
-            finalized_tool_calls = _finalize_tool_calls(state.tool_call_buffer)
-            tool_blocks = _anthropic_tool_use_blocks(finalized_tool_calls)
-            named_tool_calls = [
-                tc for tc in finalized_tool_calls or [] if tc.function.name
-            ]
-            index = 1 if text_block_open else 0
-            for tool_index, (tool_block, tool_call) in enumerate(
-                zip(tool_blocks, named_tool_calls), start=index
-            ):
-                emit(
-                    AnthropicContentBlockStartEvent.create(
-                        index=tool_index,
-                        content_block=AnthropicToolUseBlock.create(
-                            id=tool_block.id, name=tool_block.name, input={}
-                        ),
-                    )
-                )
-                emit(
-                    AnthropicContentBlockDeltaEvent.create(
-                        index=tool_index,
-                        delta=AnthropicInputJsonDelta.create(
-                            partial_json=tool_call.function.arguments or "{}"
-                        ),
-                    )
-                )
-                emit(AnthropicContentBlockStopEvent.create(index=tool_index))
-            emit(
-                AnthropicMessageDeltaEvent.create(
-                    delta=AnthropicMessageDeltaPayload.create(
-                        stop_reason=_anthropic_stop_reason(
-                            finish_reason, bool(tool_blocks)
+                        break
+            else:
+                close_open_block()
+                finalized_tool_calls = _finalize_tool_calls(state.tool_call_buffer)
+                tool_blocks = _anthropic_tool_use_blocks(finalized_tool_calls)
+                named_tool_calls = [
+                    tc for tc in finalized_tool_calls or [] if tc.function.name
+                ]
+                for tool_index, (tool_block, tool_call) in enumerate(
+                    zip(tool_blocks, named_tool_calls), start=next_index
+                ):
+                    emit(
+                        AnthropicContentBlockStartEvent.create(
+                            index=tool_index,
+                            content_block=AnthropicToolUseBlock.create(
+                                id=tool_block.id, name=tool_block.name, input={}
+                            ),
                         )
-                    ),
-                    usage=(
-                        AnthropicUsagePayload.from_usage(state.usage)
-                        if state.usage
-                        else AnthropicUsagePayload.zero()
-                    ),
+                    )
+                    emit(
+                        AnthropicContentBlockDeltaEvent.create(
+                            index=tool_index,
+                            delta=AnthropicInputJsonDelta.create(
+                                partial_json=tool_call.function.arguments or "{}"
+                            ),
+                        )
+                    )
+                    emit(AnthropicContentBlockStopEvent.create(index=tool_index))
+                emit(
+                    AnthropicMessageDeltaEvent.create(
+                        delta=AnthropicMessageDeltaPayload.create(
+                            stop_reason=_anthropic_stop_reason(
+                                finish_reason, bool(tool_blocks)
+                            )
+                        ),
+                        usage=(
+                            AnthropicUsagePayload.from_usage(state.usage)
+                            if state.usage
+                            else AnthropicUsagePayload.zero()
+                        ),
+                    )
                 )
-            )
-            emit(AnthropicMessageStopEvent.create())
+                emit(AnthropicMessageStopEvent.create())
 
 
 def handle_anthropic_messages(
@@ -1351,7 +1487,10 @@ def handle_anthropic_messages(
         if span is not None:
             record_llm_response(span, response)
 
-    content: list[AnthropicContentBlock] = []
+    content: list[AnthropicContentBlock] = _anthropic_thinking_content_blocks(
+        response.choice.message.thinking_blocks,
+        response.choice.message.reasoning_content,
+    )
     if response.choice.message.content:
         content.append(AnthropicTextBlock.create(text=response.choice.message.content))
     try:

--- a/backend/onyx/server/gateway/models.py
+++ b/backend/onyx/server/gateway/models.py
@@ -603,7 +603,31 @@ class AnthropicToolUseBlock(_WireModel):
         return cls(type="tool_use", id=id, name=name, input=input)
 
 
-AnthropicContentBlock: TypeAlias = AnthropicTextBlock | AnthropicToolUseBlock
+class AnthropicThinkingBlock(_WireModel):
+    type: Literal["thinking"] = "thinking"
+    thinking: str
+    signature: str
+
+    @classmethod
+    def create(cls, *, thinking: str, signature: str) -> "AnthropicThinkingBlock":
+        return cls(type="thinking", thinking=thinking, signature=signature)
+
+
+class AnthropicRedactedThinkingBlock(_WireModel):
+    type: Literal["redacted_thinking"] = "redacted_thinking"
+    data: str
+
+    @classmethod
+    def create(cls, *, data: str) -> "AnthropicRedactedThinkingBlock":
+        return cls(type="redacted_thinking", data=data)
+
+
+AnthropicContentBlock: TypeAlias = (
+    AnthropicTextBlock
+    | AnthropicToolUseBlock
+    | AnthropicThinkingBlock
+    | AnthropicRedactedThinkingBlock
+)
 
 
 class AnthropicUsagePayload(_WireModel):
@@ -720,14 +744,40 @@ class AnthropicInputJsonDelta(_WireModel):
         return cls(type="input_json_delta", partial_json=partial_json)
 
 
+class AnthropicThinkingDelta(_WireModel):
+    type: Literal["thinking_delta"] = "thinking_delta"
+    thinking: str
+
+    @classmethod
+    def create(cls, *, thinking: str) -> "AnthropicThinkingDelta":
+        return cls(type="thinking_delta", thinking=thinking)
+
+
+class AnthropicSignatureDelta(_WireModel):
+    type: Literal["signature_delta"] = "signature_delta"
+    signature: str
+
+    @classmethod
+    def create(cls, *, signature: str) -> "AnthropicSignatureDelta":
+        return cls(type="signature_delta", signature=signature)
+
+
+AnthropicContentDelta: TypeAlias = (
+    AnthropicTextDelta
+    | AnthropicInputJsonDelta
+    | AnthropicThinkingDelta
+    | AnthropicSignatureDelta
+)
+
+
 class AnthropicContentBlockDeltaEvent(_WireModel):
     type: Literal["content_block_delta"] = "content_block_delta"
     index: int
-    delta: AnthropicTextDelta | AnthropicInputJsonDelta
+    delta: AnthropicContentDelta
 
     @classmethod
     def create(
-        cls, *, index: int, delta: AnthropicTextDelta | AnthropicInputJsonDelta
+        cls, *, index: int, delta: AnthropicContentDelta
     ) -> "AnthropicContentBlockDeltaEvent":
         return cls(type="content_block_delta", index=index, delta=delta)
 

--- a/backend/tests/unit/onyx/server/gateway/test_anthropic_messages_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_anthropic_messages_api.py
@@ -29,7 +29,9 @@ from onyx.llm.model_response import (
 from onyx.llm.models import (
     AssistantMessage,
     ReasoningEffort,
+    RedactedThinkingBlock,
     SystemMessage,
+    ThinkingBlock,
     ToolChoiceOptions,
     ToolMessage,
     UserMessage,
@@ -799,4 +801,233 @@ def test_gateway_anthropic_count_tokens_includes_tools() -> None:
                 },
             }
         ],
+    )
+
+
+def test_anthropic_signed_thinking_blocks_survive_input_translation() -> None:
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "hmm", "signature": "sig-1"},
+                {"type": "redacted_thinking", "data": "opaque"},
+                {"type": "thinking", "thinking": "unsigned", "signature": ""},
+                {"type": "text", "text": "sure"},
+            ],
+        },
+        {"role": "user", "content": "go on"},
+    ]
+
+    raw = gateway_api._anthropic_messages_to_raw_messages(messages, None)
+
+    assistant_message = next(m for m in raw if m["role"] == "assistant")
+    assert assistant_message["thinking_blocks"] == [
+        {"type": "thinking", "thinking": "hmm", "signature": "sig-1"},
+        {"type": "redacted_thinking", "data": "opaque"},
+    ]
+
+    validated = _MESSAGES_ADAPTER.validate_python(raw)
+    validated_assistant = next(m for m in validated if isinstance(m, AssistantMessage))
+    assert validated_assistant.thinking_blocks is not None
+    thinking, redacted = validated_assistant.thinking_blocks
+    assert isinstance(thinking, ThinkingBlock)
+    assert thinking.signature == "sig-1"
+    assert isinstance(redacted, RedactedThinkingBlock)
+    assert redacted.data == "opaque"
+    dumped = validated_assistant.model_dump(exclude_none=True)
+    assert dumped["thinking_blocks"][0]["signature"] == "sig-1"
+
+
+def test_thinking_only_assistant_message_is_not_dropped() -> None:
+    message = AssistantMessage(
+        content=None,
+        thinking_blocks=[ThinkingBlock(thinking="hmm", signature="sig-1")],
+    )
+    assert gateway_api._drop_empty_text(message) is message
+
+
+def test_handle_anthropic_messages_prepends_thinking_blocks() -> None:
+    response = ModelResponse(
+        id="msg-1",
+        created="1784577999",
+        choice=Choice(
+            finish_reason="stop",
+            message=Message(
+                content="Sure thing",
+                thinking_blocks=[
+                    ThinkingBlock(thinking="let me see", signature="sig-1"),
+                    RedactedThinkingBlock(data="opaque"),
+                ],
+            ),
+        ),
+        usage=None,
+    )
+
+    with patch.object(
+        gateway_api, "llm_from_provider", return_value=_InvokeLLM(response)
+    ):
+        result = _handle_anthropic_call(_anthropic_request())
+
+    assert isinstance(result, AnthropicMessageResponse)
+    assert result.to_wire()["content"] == [
+        {"type": "thinking", "thinking": "let me see", "signature": "sig-1"},
+        {"type": "redacted_thinking", "data": "opaque"},
+        {"type": "text", "text": "Sure thing"},
+    ]
+
+
+def test_handle_anthropic_messages_reasoning_content_becomes_unsigned_thinking() -> (
+    None
+):
+    response = ModelResponse(
+        id="msg-1",
+        created="1784577999",
+        choice=Choice(
+            finish_reason="stop",
+            message=Message(content="Hi", reasoning_content="pondering"),
+        ),
+        usage=None,
+    )
+
+    with patch.object(
+        gateway_api, "llm_from_provider", return_value=_InvokeLLM(response)
+    ):
+        result = _handle_anthropic_call(_anthropic_request())
+
+    assert isinstance(result, AnthropicMessageResponse)
+    assert result.to_wire()["content"] == [
+        {"type": "thinking", "thinking": "pondering", "signature": ""},
+        {"type": "text", "text": "Hi"},
+    ]
+
+
+_THINKING_TEXT_AND_TOOL_CHUNKS = [
+    ModelResponseStream(
+        id="a3",
+        created="0",
+        choice=StreamingChoice(
+            delta=Delta(
+                reasoning_content="I ",
+                thinking_blocks=[ThinkingBlock(thinking="I ")],
+            )
+        ),
+    ),
+    ModelResponseStream(
+        id="a3",
+        created="0",
+        choice=StreamingChoice(
+            delta=Delta(
+                reasoning_content="think",
+                thinking_blocks=[ThinkingBlock(thinking="think")],
+            )
+        ),
+    ),
+    ModelResponseStream(
+        id="a3",
+        created="0",
+        choice=StreamingChoice(
+            delta=Delta(thinking_blocks=[ThinkingBlock(signature="sig-1")])
+        ),
+    ),
+    ModelResponseStream(
+        id="a3", created="0", choice=StreamingChoice(delta=Delta(content="Hi"))
+    ),
+    ModelResponseStream(
+        id="a3",
+        created="0",
+        choice=StreamingChoice(
+            delta=Delta(
+                tool_calls=[
+                    ChatCompletionDeltaToolCall(
+                        id="call_1",
+                        index=0,
+                        function=FunctionCall(name="Bash", arguments='{"cmd":"ls"}'),
+                    )
+                ]
+            )
+        ),
+    ),
+    ModelResponseStream(
+        id="a3",
+        created="0",
+        choice=StreamingChoice(finish_reason="tool_calls", delta=Delta()),
+    ),
+]
+
+
+def test_anthropic_stream_emits_thinking_block_before_text_and_tools() -> None:
+    events = _anthropic_stream_events(_ChunkStreamLLM(_THINKING_TEXT_AND_TOOL_CHUNKS))
+
+    thinking_start = next(
+        e
+        for e in events
+        if e["type"] == "content_block_start"
+        and e["content_block"]["type"] == "thinking"
+    )
+    assert thinking_start["index"] == 0
+    assert thinking_start["content_block"] == {
+        "type": "thinking",
+        "thinking": "",
+        "signature": "",
+    }
+
+    content_deltas = [e for e in events if e["type"] == "content_block_delta"]
+    assert [d["delta"]["type"] for d in content_deltas] == [
+        "thinking_delta",
+        "thinking_delta",
+        "signature_delta",
+        "text_delta",
+        "input_json_delta",
+    ]
+    assert [d["index"] for d in content_deltas] == [0, 0, 0, 1, 2]
+    assert content_deltas[0]["delta"]["thinking"] == "I "
+    assert content_deltas[2]["delta"]["signature"] == "sig-1"
+
+    text_start = next(
+        e
+        for e in events
+        if e["type"] == "content_block_start" and e["content_block"]["type"] == "text"
+    )
+    assert text_start["index"] == 1
+    tool_start = next(
+        e
+        for e in events
+        if e["type"] == "content_block_start"
+        and e["content_block"]["type"] == "tool_use"
+    )
+    assert tool_start["index"] == 2
+
+    stop_indexes = [e["index"] for e in events if e["type"] == "content_block_stop"]
+    assert stop_indexes == [0, 1, 2]
+
+    message_delta = next(e for e in events if e["type"] == "message_delta")
+    assert message_delta["delta"]["stop_reason"] == "tool_use"
+
+
+def test_anthropic_stream_reasoning_content_fallback_emits_unsigned_thinking() -> None:
+    chunks = [
+        ModelResponseStream(
+            id="a4",
+            created="0",
+            choice=StreamingChoice(delta=Delta(reasoning_content="pondering")),
+        ),
+        ModelResponseStream(
+            id="a4", created="0", choice=StreamingChoice(delta=Delta(content="Hi"))
+        ),
+        ModelResponseStream(
+            id="a4",
+            created="0",
+            choice=StreamingChoice(finish_reason="stop", delta=Delta()),
+        ),
+    ]
+    events = _anthropic_stream_events(_ChunkStreamLLM(chunks))
+
+    delta_types = [
+        e["delta"]["type"] for e in events if e["type"] == "content_block_delta"
+    ]
+    assert delta_types == ["thinking_delta", "text_delta"]
+    assert not any(
+        e["type"] == "content_block_delta" and e["delta"]["type"] == "signature_delta"
+        for e in events
     )


### PR DESCRIPTION
## Description

Stacked on #13687. The Anthropic Messages endpoint previously dropped thinking in both directions: the internal LLM layer only carried a plain `reasoning_content` string (no signed blocks), and the wire models only knew `text` and `tool_use`. This PR threads signed thinking blocks end to end:

- **Internal LLM layer**: `ThinkingBlock` / `RedactedThinkingBlock` models; `AssistantMessage.thinking_blocks` on input, `Delta.thinking_blocks` / `Message.thinking_blocks` parsed from LiteLLM on output. `multi_llm` strips the field for providers whose LiteLLM transforms do not consume it (everything outside Anthropic/Bedrock/Vertex).
- **Gateway output**: streaming emits a proper thinking content-block lifecycle (`content_block_start` with `thinking`, `thinking_delta`, `signature_delta`, `content_block_stop`) with dynamic block indices; non-streaming prepends thinking blocks to `content`. Upstreams that only expose `reasoning_content` (e.g. OpenAI reasoning models) get an unsigned thinking block so clients still render thinking.
- **Gateway input**: replayed thinking blocks survive message translation. Unsigned blocks are dropped on the way in, so a signature check upstream can never see a block the provider did not mint; signed blocks and redacted thinking pass through unmodified.

This restores the reasoning chain across tool-use turns for Claude Code pointed at the gateway with an Anthropic upstream.

## How Has This Been Tested?

- New unit tests covering: signed/redacted block input passthrough with unsigned blocks dropped, thinking-only assistant messages not being discarded, non-streaming content ordering (thinking before text), `reasoning_content` fallback producing an unsigned thinking block, and the streaming block lifecycle with shifted indices (thinking at 0, text at 1, tool_use at 2).
- `uv run pytest tests/unit/onyx/server/gateway/` (140 passed) and `tests/unit/onyx/llm` (408 passed).
- `pre-commit` (ty, ruff, ruff format) green on touched files.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check