### PR TITLE
fix(web): avoid fabricating Azure deployment_name on provider edit

### DIFF
--- a/web/src/lib/azureTargetUri.test.ts
+++ b/web/src/lib/azureTargetUri.test.ts
@@ -1,0 +1,65 @@
+import {
+  buildTargetUri,
+  isValidAzureTargetUri,
+  parseAzureTargetUri,
+} from "@/lib/azureTargetUri";
+import { LLMProviderView } from "@/lib/languageModels/types";
+
+const baseProvider: LLMProviderView = {
+  id: 1,
+  name: "azure",
+  provider: "azure",
+  api_key: "sk-test",
+  api_base: "https://my-resource.openai.azure.com",
+  api_version: "2025-01-01-preview",
+  custom_config: null,
+  is_public: true,
+  is_auto_mode: true,
+  groups: [],
+  personas: [],
+  deployment_name: null,
+  model_configurations: [],
+};
+
+describe("buildTargetUri", () => {
+  it("returns an empty string when api_base or api_version is missing", () => {
+    expect(buildTargetUri(undefined)).toBe("");
+    expect(buildTargetUri({ ...baseProvider, api_base: null })).toBe("");
+    expect(buildTargetUri({ ...baseProvider, api_version: null })).toBe("");
+  });
+
+  it("does not fabricate a deployment for per-model-routing providers (#13590)", () => {
+    // A provider created with deployment_name === null routes each model to a
+    // deployment named after the model. Editing it must NOT invent a
+    // provider-level deployment, which previously produced the placeholder
+    // "your-deployment" and broke every model with Azure DeploymentNotFound.
+    const uri = buildTargetUri(baseProvider);
+
+    expect(uri).not.toContain("your-deployment");
+    expect(uri).not.toContain("/openai/deployments/");
+    expect(isValidAzureTargetUri(uri)).toBe(true);
+
+    // The reconstructed URI round-trips back to an empty deployment, so on save
+    // `processValues` keeps deployment_name null rather than fabricating one.
+    const parsed = parseAzureTargetUri(uri);
+    expect(parsed.deploymentName).toBe("");
+    expect(parsed.apiVersion).toBe("2025-01-01-preview");
+    expect(parsed.url.origin).toBe("https://my-resource.openai.azure.com");
+  });
+
+  it("round-trips a provider that has an explicit deployment_name", () => {
+    const provider: LLMProviderView = {
+      ...baseProvider,
+      deployment_name: "gpt-4o",
+    };
+    const uri = buildTargetUri(provider);
+
+    expect(uri).toContain("/openai/deployments/gpt-4o/chat/completions");
+    expect(isValidAzureTargetUri(uri)).toBe(true);
+
+    const parsed = parseAzureTargetUri(uri);
+    expect(parsed.deploymentName).toBe("gpt-4o");
+    expect(parsed.apiVersion).toBe("2025-01-01-preview");
+    expect(parsed.url.origin).toBe("https://my-resource.openai.azure.com");
+  });
+});

--- a/web/src/lib/azureTargetUri.ts
+++ b/web/src/lib/azureTargetUri.ts
@@ -1,3 +1,5 @@
+import { LLMProviderView } from "@/lib/languageModels/types";
+
 const getApiVersionParam = (url: URL): string => {
   const directApiVersion = url.searchParams.get("api-version");
   if (directApiVersion?.trim()) {
@@ -52,4 +54,33 @@ export const isValidAzureTargetUri = (rawUri: string): boolean => {
   } catch {
     return false;
   }
+};
+
+/**
+ * Reconstructs the Azure "target URI" that pre-fills the edit form for an
+ * existing provider.
+ *
+ * When the provider routes per-model (no provider-level `deployment_name`), we
+ * emit the deployment-less `/openai/responses` form instead of injecting a
+ * placeholder deployment. Fabricating a deployment here caused
+ * `parseAzureTargetUri` to persist that bogus value on save, routing every
+ * model to a non-existent deployment and breaking the provider with Azure
+ * `DeploymentNotFound` (issue #13590). The path is discarded on save
+ * (`processValues` keeps only `url.origin`); it exists solely so the parsed URI
+ * round-trips back to the same `api_base`, `api_version`, and deployment.
+ */
+export const buildTargetUri = (
+  existingLlmProvider?: LLMProviderView
+): string => {
+  if (!existingLlmProvider?.api_base || !existingLlmProvider?.api_version) {
+    return "";
+  }
+
+  const { api_base, api_version, deployment_name } = existingLlmProvider;
+
+  if (!deployment_name) {
+    return `${api_base}/openai/responses?api-version=${api_version}`;
+  }
+
+  return `${api_base}/openai/deployments/${deployment_name}/chat/completions?api-version=${api_version}`;
 };

--- a/web/src/sections/modals/languageModels/AzureModal.tsx
+++ b/web/src/sections/modals/languageModels/AzureModal.tsx
@@ -7,7 +7,6 @@ import { InputDivider, InputPadder, InputVertical, toast } from "@opal/layouts";
 import {
   LLMProviderFormProps,
   LLMProviderName,
-  LLMProviderView,
 } from "@/lib/languageModels/types";
 import * as Yup from "yup";
 import {
@@ -25,6 +24,7 @@ import {
   ModalWrapper,
 } from "@/sections/modals/languageModels/shared";
 import {
+  buildTargetUri,
   isValidAzureTargetUri,
   parseAzureTargetUri,
 } from "@/lib/azureTargetUri";
@@ -63,16 +63,6 @@ function AzureModelSelection() {
       }}
     />
   );
-}
-
-function buildTargetUri(existingLlmProvider?: LLMProviderView): string {
-  if (!existingLlmProvider?.api_base || !existingLlmProvider?.api_version) {
-    return "";
-  }
-
-  const deploymentName =
-    existingLlmProvider.deployment_name || "your-deployment";
-  return `${existingLlmProvider.api_base}/openai/deployments/${deploymentName}/chat/completions?api-version=${existingLlmProvider.api_version}`;
 }
 
 const processValues = (values: AzureModalValues): AzureModalValues => {


### PR DESCRIPTION
## Description

Fixes #13590.

Editing an existing Azure OpenAI LLM provider that uses **per-model deployment routing** (i.e. no provider-level `deployment_name`, so each model is routed to a deployment named after the model) silently broke every model on the provider with Azure `404 DeploymentNotFound`. The only workaround was to delete and recreate the provider.

**Root cause** — `AzureModal` reconstructs a "target URI" to pre-fill the edit form from the stored provider. When `deployment_name` was `null`, the builder fabricated a placeholder segment:

```ts
const deploymentName = existingLlmProvider.deployment_name || "your-deployment";
return `${api_base}/openai/deployments/${deploymentName}/chat/completions?api-version=${api_version}`;
```

On save, `processValues` runs that URI back through `parseAzureTargetUri`, which extracts `deploymentName = "your-deployment"` and persists it as the provider's `deployment_name`. The backend (`multi_llm.py`, `deployment_name or model_name`) then routes **all** models to the non-existent `your-deployment` deployment → `DeploymentNotFound` for every model, including ones that worked minutes earlier.

**Fix** — move `buildTargetUri` into `azureTargetUri.ts` beside its inverse `parseAzureTargetUri`, and when the provider has no `deployment_name`, emit the deployment-less `/openai/responses` form instead of inventing one. `processValues` keeps only `url.origin` from the parsed URI, so the reconstructed path is purely cosmetic; the `/openai/responses` shape is already a first-class valid target URI (`isValidAzureTargetUri`) and round-trips back to an empty deployment, so an edit preserves `deployment_name = null` rather than fabricating a value. Providers that *do* have an explicit `deployment_name` are unchanged.

Scope is limited to Azure — a grep confirmed the `"your-deployment"` fabrication existed only in `AzureModal`.

## How Has This Been Tested?

Added focused unit tests in `web/src/lib/azureTargetUri.test.ts` (jest, node/unit project — no DOM/mocks) covering the pure build↔parse round-trip:

- **Per-model routing (`deployment_name: null`)** — the built URI no longer contains `your-deployment` or any `/openai/deployments/` segment, is a valid target URI, and `parseAzureTargetUri(...).deploymentName === ""` (so `processValues` keeps the deployment null). This is the red→green assertion for #13590: the old builder yielded `your-deployment` here.
- **Explicit deployment** — a provider with `deployment_name: "gpt-4o"` still builds the `/openai/deployments/gpt-4o/chat/completions` URI and round-trips back to `"gpt-4o"` (no regression to the working path).
- **Missing `api_base`/`api_version`** — returns `""` as before.

```
$ bun run test src/lib/azureTargetUri.test.ts
Tests:       3 passed, 3 total
```

Full toolchain, all clean:
- `bun run lint` (oxlint) — no findings on changed files
- `oxfmt --check src` — formatted
- `bun run types:check` (`next typegen` + `tsc --noEmit`) — no errors
- `bun run test src/lib src/sections/modals/languageModels` — 25 suites / 240 tests pass, no regressions

Diff: 3 files, +97 / -11.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where editing an Azure OpenAI provider with per-model routing fabricated a provider-level deployment name, causing Azure 404s for all models. We now preserve null deployments by building a deployment-less target URI on edit; providers with explicit deployments are unchanged.

- **Bug Fixes**
  - Stop inserting a placeholder deployment when `deployment_name` is null, preserving per-model routing.
  - Move target URI construction into `azureTargetUri.ts` and use it from `AzureModal` for consistent build/parse behavior.
  - Add unit tests to verify round-trip behavior for both per-model and explicit-deployment providers.

<sup>Written for commit a320cee013f4d0446ad2dda60db3158182b282f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

