### PR TITLE
feat(mobile): reasoning renderer + full-text reader for the agent timeline

### DIFF
--- a/docs/mobile-chat/9b-timeline/03-detailed-design.md
+++ b/docs/mobile-chat/9b-timeline/03-detailed-design.md
@@ -279,10 +279,17 @@ mobile/src/
 - **`ReasoningRenderer.tsx`** — `constructCurrentReasoningState(packets)` (hasStart/hasEnd/content=join deltas),
   `extractFirstParagraph(content)` (markdown-heading → step title, ≤60 chars), 500 ms min-thinking gate
   (`useState(start)` + timer ref in effect; `animate` gates the floor), then
-  `children([{ icon: SvgCircle, status: title ?? "Thinking", content: <ReasoningTextWindow .../>, noPaddingRight:true, supportsCollapsible:true }])`.
-- **`ReasoningTextWindow.tsx`** — maxHeight 192px (8×24) overflow-hidden `View` wrapping `StreamingMarkdown
-  content={displayContent} isStreaming={!hasEnd} variant="muted"`. (Web's pixel-perfect translateY auto-scroll +
-  copy/download modal are **not** ported in 9b — §8.)
+  `children([{ icon: SvgCircle, status: title || "Thinking", content: <ReasoningTextWindow .../>, noPaddingRight:true }])`.
+  **As built:** `supportsCollapsible` is left unset (owner call, strict web parity) — web's ReasoningRenderer
+  doesn't set it, `StepContainer` never gates its body on `isExpanded`, and web's
+  `hideHeader = isSingleStep && !supportsCollapsible` intentionally drops the step header on a reasoning-only turn.
+- **`ReasoningTextWindow.tsx`** — 192px-tall (8×24) `ScrollView` wrapping `StreamingMarkdown
+  content={displayContent} isStreaming={!hasEnd} variant="muted"`; auto-scrolls to the newest lines while
+  streaming (`onContentSizeChange` → `scrollToEnd`), `scrollEnabled` only once closed, and reveals a
+  "View full text" button when the content overflows. A clipping `View` cannot work here — see §8(c).
+- **`ReasoningTextSheet.tsx`** — the ExpandableTextDisplay modal analog, on 9a's `CitedSourcesSheet` shape
+  (RN `Modal` + `ScrollView`): full reasoning (heading included), byte-size subtitle, line count, **Copy**
+  (`expo-clipboard`). Mounted only while open. Web's Download is dropped.
 - **`findRenderer.ts`** — the full priority chain (chat → deep-research → research-agent → coding-agent →
   web-search → internal-search → image → python → file-reader → custom-tool → fetch → memory → **reasoning
   last**). For 9b only **chat→MessageTextRenderer** and **reasoning→ReasoningRenderer** are wired; the other 11
@@ -353,8 +360,11 @@ mobile/src/
 8. **Documented, intentional divergences from web (per the WEB-PARITY PRINCIPLE — the "as-built" note must list
    these):** (a) the two restructured hooks (§1) — behavior-preserving; (b) shimmer = reanimated **opacity pulse**,
    not web's `background-clip:text` gradient (no RN equivalent) — reuse the existing 9a `ThinkingLabel`; (c)
-   `ReasoningTextWindow` = fixed **maxHeight window**, not web's pixel-perfect `translateY` auto-scroll; copy/
-   download modal deferred; (d) **`ParallelTimelineTabs`/`ParallelStreamingHeader` dormant** — parallel turns
+   `ReasoningTextWindow` = fixed-height **ScrollView** (auto-scrolls to follow the stream, user-scrollable once
+   closed), not web's pixel-perfect `translateY` auto-scroll; a clipping `View` is **not** an option — the markdown
+   is a native measure leaf and both platforms clamp its height to Yoga's `AtMost` constraint, so it can never
+   overflow and no `justifyContent` trick shifts it. `ReasoningTextSheet` ports the ExpandableTextDisplay modal
+   (full text + size + line count + **Copy**); web's **Download** is dropped (no mobile analog); (d) **`ParallelTimelineTabs`/`ParallelStreamingHeader` dormant** — parallel turns
    **linearized** into a sequential list for 9b (no `@opal` pill Tabs on mobile); (e) SEARCH header sub-labels
    generic until the search phase; (f) entrance/`transition-colors` CSS animations optional (reanimated
    `FadeIn`/`Layout` or dropped); (g) memory tooltip/modal dropped (memory renderer is a later phase); (h) `expandedText`

--- a/docs/mobile-chat/9b-timeline/05-pr-roadmap.md
+++ b/docs/mobile-chat/9b-timeline/05-pr-roadmap.md
@@ -151,9 +151,11 @@ that changes the timeline on screen.
 ## PR 9b.6 — Reasoning renderer
 - **Goal:** The one wired step renderer — streamed reasoning with heading, 500 ms min-thinking, markdown body.
 - **Scope (in):** `reasoningState.ts` (pure `extractFirstParagraph` + `constructCurrentReasoningState`);
-  `ReasoningRenderer.tsx` (render-prop; 500 ms gate; icon `circle`; `noPaddingRight`; `supportsCollapsible`);
-  `ReasoningTextWindow.tsx` (maxHeight markdown window); register reasoning in `findRenderer`.
-- **Out of scope:** `AgentTimeline` composition (9b.7); the copy/download modal + translateY auto-scroll (deferred).
+  `ReasoningRenderer.tsx` (render-prop; 500 ms gate; icon `circle`; `noPaddingRight`; **no** `supportsCollapsible`
+  — owner call, strict web parity); `ReasoningTextWindow.tsx` (fixed-height auto-following `ScrollView`);
+  `ReasoningTextSheet.tsx` (full-text + Copy, via `expo-clipboard`); register reasoning in `findRenderer`, with
+  the 11 unwired tool predicates restored ahead of it so the last slot can't claim every closed tool group.
+- **Out of scope:** `AgentTimeline` composition (9b.7); web's Download button (no mobile analog).
 - **Files:**
   | File | New/Modified | Slice |
   |------|--------------|-------|

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -20,6 +20,7 @@
         "clsx": "^2.1.1",
         "expo": "~56.0.9",
         "expo-build-properties": "~56.0.17",
+        "expo-clipboard": "~56.0.4",
         "expo-constants": "~56.0.17",
         "expo-crypto": "~56.0.4",
         "expo-dev-client": "~56.0.19",
@@ -1088,6 +1089,8 @@
     "expo-asset": ["expo-asset@56.0.16", "", { "dependencies": { "@expo/image-utils": "^0.10.1", "expo-constants": "~56.0.17" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-iIxPo6C6+/d8JxGV74ZKZbIcCz2s8//dVl7oBAj124NcPMFhzdwycFBpMqq5LUxin+lVy5cCoEjv2LD8ulnkiQ=="],
 
     "expo-build-properties": ["expo-build-properties@56.0.17", "", { "dependencies": { "@expo/schema-utils": "^56.0.0", "resolve-from": "^5.0.0", "semver": "^7.6.0" }, "peerDependencies": { "expo": "*" } }, "sha512-qt12qdaxV4FEeFH+X4tM4uoeKNytqJahpmb74VVV/cSKX47RzBRtCyEIAW+tgI6BUTZjnDtBZj0PTyBdlZbB6Q=="],
+
+    "expo-clipboard": ["expo-clipboard@56.0.4", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-qb4DYlkiowHYHaUYVT2FN9nk/nI1xShXOUYsI7J9dVpQCOHcGFjCBPX1VAvEW4Ye4/Aagd6IuhOVAq/+scBOiA=="],
 
     "expo-constants": ["expo-constants@56.0.17", "", { "dependencies": { "@expo/env": "~2.3.0" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-bU8iU1+7cI7QzfGQVnz2C1nlbXD08YPwD6h8ZEuNspgUuD2prXfmrhrdLe1GjCPYGw4hB3BNjWPjpenNyyymfQ=="],
 

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -18,6 +18,7 @@
     "clsx": "^2.1.1",
     "expo": "~56.0.9",
     "expo-build-properties": "~56.0.17",
+    "expo-clipboard": "~56.0.4",
     "expo-constants": "~56.0.17",
     "expo-crypto": "~56.0.4",
     "expo-dev-client": "~56.0.19",

--- a/mobile/src/chat/messageProcessor.ts
+++ b/mobile/src/chat/messageProcessor.ts
@@ -90,7 +90,7 @@ export function createInitialState(nodeId: number): ProcessedMessageState {
   };
 }
 
-function getGroupKey(packet: Packet): string {
+export function getGroupKey(packet: Packet): string {
   const turnIndex = packet.placement.turn_index;
   const tabIndex = packet.placement.tab_index ?? 0;
   return `${turnIndex}-${tabIndex}`;

--- a/mobile/src/chat/timeline/__tests__/reasoningState.test.ts
+++ b/mobile/src/chat/timeline/__tests__/reasoningState.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { type Packet } from "@/chat/streamingModels";
+import {
+  constructCurrentReasoningState,
+  extractFirstParagraph,
+  resolveGroupReasoning,
+} from "@/chat/timeline/reasoningState";
+
+import { makePacket } from "../../__tests__/fixtures";
+
+const delta = (reasoning: string) =>
+  makePacket({ type: "reasoning_delta", reasoning });
+
+describe("extractFirstParagraph", () => {
+  it("promotes a leading markdown heading to the title and drops it from the body", () => {
+    expect(extractFirstParagraph("## Checking the docs\n\nbody text")).toEqual({
+      title: "Checking the docs",
+      remainingContent: "body text",
+    });
+  });
+
+  it("accepts any heading level", () => {
+    expect(extractFirstParagraph("#### Deep\nrest").title).toBe("Deep");
+  });
+
+  it("leaves plain prose as body with no title", () => {
+    const content = "Checking the docs\n\nbody text";
+    expect(extractFirstParagraph(content)).toEqual({
+      title: null,
+      remainingContent: content,
+    });
+  });
+
+  it("requires whitespace after the hashes (a bare #tag is not a heading)", () => {
+    const content = "#tag not a heading";
+    expect(extractFirstParagraph(content).title).toBeNull();
+  });
+
+  it("rejects a heading longer than 60 characters and keeps the full content", () => {
+    const longHeading = `# ${"a".repeat(61)}`;
+    const content = `${longHeading}\n\nbody`;
+    expect(extractFirstParagraph(content)).toEqual({
+      title: null,
+      remainingContent: content,
+    });
+  });
+
+  it("accepts a heading of exactly 60 characters (boundary is inclusive)", () => {
+    const title = "a".repeat(60);
+    expect(extractFirstParagraph(`# ${title}\n\nbody`).title).toBe(title);
+  });
+
+  it("returns no title for empty or whitespace-only content", () => {
+    expect(extractFirstParagraph("")).toEqual({
+      title: null,
+      remainingContent: "",
+    });
+    expect(extractFirstParagraph("   \n  ")).toEqual({
+      title: null,
+      remainingContent: "   \n  ",
+    });
+  });
+
+  it("returns an empty body when the heading is the entire content", () => {
+    expect(extractFirstParagraph("# Only a heading")).toEqual({
+      title: "Only a heading",
+      remainingContent: "",
+    });
+  });
+
+  it("splits on a single newline as well as a paragraph break", () => {
+    expect(extractFirstParagraph("# Title\nline two")).toEqual({
+      title: "Title",
+      remainingContent: "line two",
+    });
+  });
+});
+
+describe("constructCurrentReasoningState", () => {
+  it("joins reasoning deltas in packet order with no separator", () => {
+    const state = constructCurrentReasoningState([
+      makePacket({ type: "reasoning_start" }),
+      delta("Let me "),
+      delta("think "),
+      delta("about it."),
+    ]);
+    expect(state).toEqual({
+      hasStart: true,
+      hasEnd: false,
+      content: "Let me think about it.",
+    });
+  });
+
+  it("ignores non-reasoning packets when accumulating content", () => {
+    const state = constructCurrentReasoningState([
+      makePacket({ type: "reasoning_start" }),
+      delta("kept"),
+      makePacket({ type: "message_delta", content: "dropped" }),
+    ]);
+    expect(state.content).toBe("kept");
+  });
+
+  it.each([
+    ["section_end", makePacket({ type: "section_end" })],
+    ["error", makePacket({ type: "error", message: "boom" })],
+    ["reasoning_done", makePacket({ type: "reasoning_done" })],
+  ])("treats %s as the end of the reasoning step", (_label, terminator) => {
+    const state = constructCurrentReasoningState([
+      makePacket({ type: "reasoning_start" }),
+      delta("thinking"),
+      terminator,
+    ]);
+    expect(state.hasEnd).toBe(true);
+  });
+
+  it("reports an end without a start (history hydrated mid-step)", () => {
+    const state = constructCurrentReasoningState([
+      delta("thinking"),
+      makePacket({ type: "section_end" }),
+    ]);
+    expect(state).toEqual({
+      hasStart: false,
+      hasEnd: true,
+      content: "thinking",
+    });
+  });
+
+  it("returns the empty state for no packets", () => {
+    expect(constructCurrentReasoningState([])).toEqual({
+      hasStart: false,
+      hasEnd: false,
+      content: "",
+    });
+  });
+});
+
+describe("resolveGroupReasoning", () => {
+  function mapWith(...reasoning: string[]): Map<string, Packet[]> {
+    return new Map([
+      [
+        "0-0",
+        [makePacket({ type: "reasoning_start" }), ...reasoning.map(delta)],
+      ],
+      ["1-0", [makePacket({ type: "search_tool_start" })]],
+    ]);
+  }
+
+  it("returns null when no reader is open", () => {
+    expect(resolveGroupReasoning(mapWith("thinking"), null)).toBeNull();
+  });
+
+  it("returns the named group's reasoning, not another step's", () => {
+    expect(resolveGroupReasoning(mapWith("thinking"), "0-0")).toBe("thinking");
+    expect(resolveGroupReasoning(mapWith("thinking"), "1-0")).toBe("");
+  });
+
+  // The point of resolving by key: re-running against a grown map must yield the grown text. A
+  // snapshot taken when the reader opened would freeze here, and Copy would truncate.
+  it("tracks the stream as the group's packets grow", () => {
+    expect(resolveGroupReasoning(mapWith("first "), "0-0")).toBe("first ");
+    expect(resolveGroupReasoning(mapWith("first ", "second"), "0-0")).toBe(
+      "first second",
+    );
+  });
+
+  it("returns null for a key with no group (history reset)", () => {
+    expect(resolveGroupReasoning(mapWith("thinking"), "9-9")).toBeNull();
+  });
+});

--- a/mobile/src/chat/timeline/__tests__/textStats.test.ts
+++ b/mobile/src/chat/timeline/__tests__/textStats.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  countLines,
+  formatContentSize,
+  utf8ByteLength,
+} from "@/chat/timeline/textStats";
+
+describe("utf8ByteLength", () => {
+  it("counts ASCII as one byte each", () => {
+    expect(utf8ByteLength("hello")).toBe(5);
+  });
+
+  it("counts multi-byte code points by their UTF-8 width", () => {
+    expect(utf8ByteLength("é")).toBe(2);
+    expect(utf8ByteLength("→")).toBe(3);
+  });
+
+  it("counts a surrogate pair once, as four bytes", () => {
+    // "😀" is two UTF-16 units; naively summing per-unit would give 6.
+    expect(utf8ByteLength("😀")).toBe(4);
+    expect(utf8ByteLength("a😀b")).toBe(6);
+  });
+
+  it("is zero for empty text", () => {
+    expect(utf8ByteLength("")).toBe(0);
+  });
+});
+
+describe("formatContentSize", () => {
+  it("reports bytes below 1KB", () => {
+    expect(formatContentSize("hello")).toBe("5 Bytes");
+  });
+
+  it("switches to KB at the boundary", () => {
+    expect(formatContentSize("a".repeat(1023))).toBe("1023 Bytes");
+    expect(formatContentSize("a".repeat(1024))).toBe("1.00 KB");
+    expect(formatContentSize("a".repeat(2560))).toBe("2.50 KB");
+  });
+});
+
+describe("countLines", () => {
+  it("counts a single line with no newline", () => {
+    expect(countLines("one line")).toBe(1);
+  });
+
+  it("counts blank lines between paragraphs", () => {
+    expect(countLines("# Heading\n\nbody")).toBe(3);
+  });
+
+  it("counts a trailing newline as opening another line", () => {
+    expect(countLines("a\n")).toBe(2);
+  });
+
+  it("counts empty text as one line", () => {
+    expect(countLines("")).toBe(1);
+  });
+});

--- a/mobile/src/chat/timeline/reasoningState.ts
+++ b/mobile/src/chat/timeline/reasoningState.ts
@@ -1,0 +1,78 @@
+// Ported from web's `ReasoningRenderer` helpers; kept out of the renderer so it stays
+// reanimated-free and unit-testable.
+import { Packet, PacketType, ReasoningDelta } from "@/chat/streamingModels";
+
+// Longer headings are prose, not titles, and overflow the step header.
+const MAX_TITLE_LENGTH = 60;
+
+export interface ReasoningState {
+  hasStart: boolean;
+  hasEnd: boolean;
+  content: string;
+}
+
+export interface FirstParagraph {
+  // Set only when the reasoning opens with a short markdown heading.
+  title: string | null;
+  remainingContent: string;
+}
+
+export function extractFirstParagraph(content: string): FirstParagraph {
+  if (!content || content.trim().length === 0) {
+    return { title: null, remainingContent: content };
+  }
+
+  const trimmed = content.trim();
+  const firstLine = trimmed.split(/\n\n|\n/)[0]?.trim();
+  if (!firstLine) {
+    return { title: null, remainingContent: content };
+  }
+
+  if (!/^#+\s/.test(firstLine)) {
+    return { title: null, remainingContent: content };
+  }
+
+  const cleanTitle = firstLine.replace(/^#+\s*/, "").trim();
+  if (cleanTitle.length > MAX_TITLE_LENGTH) {
+    return { title: null, remainingContent: content };
+  }
+
+  return {
+    title: cleanTitle,
+    remainingContent: trimmed.slice(firstLine.length).replace(/^\n+/, ""),
+  };
+}
+
+// Resolves one step's reasoning text from the processor's grouped packets. The message row re-runs
+// this every flush so an open full-text reader tracks the stream instead of freezing at open time.
+export function resolveGroupReasoning(
+  groupedPacketsMap: Map<string, Packet[]>,
+  groupKey: string | null,
+): string | null {
+  if (groupKey === null) {
+    return null;
+  }
+  const group = groupedPacketsMap.get(groupKey);
+  return group ? constructCurrentReasoningState(group).content : null;
+}
+
+export function constructCurrentReasoningState(
+  packets: Packet[],
+): ReasoningState {
+  const hasStart = packets.some(
+    (packet) => packet.obj.type === PacketType.REASONING_START,
+  );
+  // section_end is client-synthesized and closes most groups; reasoning_done is the backend's own.
+  const hasEnd = packets.some(
+    (packet) =>
+      packet.obj.type === PacketType.SECTION_END ||
+      packet.obj.type === PacketType.ERROR ||
+      packet.obj.type === PacketType.REASONING_DONE,
+  );
+  const content = packets
+    .filter((packet) => packet.obj.type === PacketType.REASONING_DELTA)
+    .map((packet) => (packet.obj as ReasoningDelta).reasoning)
+    .join("");
+
+  return { hasStart, hasEnd, content };
+}

--- a/mobile/src/chat/timeline/textStats.ts
+++ b/mobile/src/chat/timeline/textStats.ts
@@ -1,0 +1,35 @@
+// Kept out of the sheet so they stay reanimated-free and unit-testable — the sheet pulls
+// StreamingMarkdown → worklets, which crashes jest.
+const BYTES_PER_KB = 1024;
+
+// Hermes has no TextEncoder, so count UTF-8 bytes directly to match web's `new Blob([text]).size`.
+export function utf8ByteLength(text: string): number {
+  let bytes = 0;
+  for (let index = 0; index < text.length; index += 1) {
+    const code = text.charCodeAt(index);
+    if (code < 0x80) {
+      bytes += 1;
+    } else if (code < 0x800) {
+      bytes += 2;
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      // Surrogate pair: 4 bytes total, and the low half is consumed here.
+      bytes += 4;
+      index += 1;
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}
+
+export function formatContentSize(text: string): string {
+  const bytes = utf8ByteLength(text);
+  if (bytes < BYTES_PER_KB) {
+    return `${bytes} Bytes`;
+  }
+  return `${(bytes / BYTES_PER_KB).toFixed(2)} KB`;
+}
+
+export function countLines(text: string): number {
+  return text.split("\n").length;
+}

--- a/mobile/src/components/chat/MessageRow.tsx
+++ b/mobile/src/components/chat/MessageRow.tsx
@@ -4,6 +4,7 @@ import { View } from "react-native";
 
 import { selectSources } from "@/chat/citations";
 import { Message } from "@/chat/interfaces";
+import { resolveGroupReasoning } from "@/chat/timeline/reasoningState";
 import { MinimalAgent } from "@/chat/agents";
 import { getErrorTitle } from "@/chat/errorHelpers";
 import { fileDescriptorToDisplayFile } from "@/chat/fileDescriptors";
@@ -16,6 +17,7 @@ import {
 import { FileCard } from "@/components/chat/FileCard";
 import { RendererComponent } from "@/components/chat/renderers/RendererComponent";
 import type { FullChatState } from "@/components/chat/renderers/registry";
+import { ReasoningTextSheet } from "@/components/chat/timeline/ReasoningTextSheet";
 import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/text";
 import SvgAlertCircle from "@/icons/alert-circle";
@@ -78,9 +80,20 @@ function AssistantMessage({
   node: Message;
   agent: MinimalAgent | null;
 }) {
-  const { packets, processed, hasRenderer } = usePacketDisplay(node);
+  const { packets, processed, hasDisplayContent } = usePacketDisplay(node);
   const [sourcesOpen, setSourcesOpen] = useState(false);
-  const hasContent = hasRenderer && packets.length > 0;
+  // Which step's text the full-text reader is showing. Owned here, not in the step: the timeline
+  // auto-collapses when the answer starts, which would unmount the step mid-read.
+  const [fullTextKey, setFullTextKey] = useState<string | null>(null);
+  const hasContent = hasDisplayContent && packets.length > 0;
+
+  // Re-derived every flush so the reader stays live while the step streams on — parking the string
+  // at open time would freeze the body and make Copy yield a truncated prefix. Reasoning is the only
+  // renderer using the reader today; other long-form steps would resolve their own group here.
+  const fullText = useMemo(
+    () => resolveGroupReasoning(processed.groupedPacketsMap, fullTextKey),
+    [fullTextKey, processed],
+  );
 
   // Only after the answer completes, to avoid mid-stream layout shift.
   const sources = useMemo(
@@ -96,6 +109,7 @@ function AssistantMessage({
       citations: processed.citationMap,
       documentMap: processed.documentMap,
       openSource,
+      openFullText: setFullTextKey,
     }),
     [agent, processed.citationMap, processed.documentMap],
   );
@@ -142,6 +156,13 @@ function AssistantMessage({
             sources={sources}
           />
         </View>
+      ) : null}
+      {fullText !== null ? (
+        <ReasoningTextSheet
+          visible
+          onClose={() => setFullTextKey(null)}
+          content={fullText}
+        />
       ) : null}
     </View>
   );

--- a/mobile/src/components/chat/renderers/ReasoningRenderer.tsx
+++ b/mobile/src/components/chat/renderers/ReasoningRenderer.tsx
@@ -1,0 +1,126 @@
+// Streamed reasoning as a heading + windowed markdown. Headless: it hands a RendererResult to
+// `children` rather than returning a tree — the step frame belongs to StepContainer.
+import { useEffect, useMemo, useRef } from "react";
+import { View } from "react-native";
+
+import { getGroupKey } from "@/chat/messageProcessor";
+import { Packet } from "@/chat/streamingModels";
+import {
+  constructCurrentReasoningState,
+  extractFirstParagraph,
+} from "@/chat/timeline/reasoningState";
+import { timelineTokens } from "@/components/chat/timeline/primitives/timelineTokens";
+import { ReasoningTextWindow } from "@/components/chat/timeline/ReasoningTextWindow";
+import SvgCircle from "@/icons/circle";
+
+import type { FullChatState, MessageRenderer } from "./timelineContract";
+
+// Floor on the "Thinking" state so a fast reasoning burst doesn't flash past.
+const THINKING_MIN_DURATION_MS = 500;
+const THINKING_STATUS = "Thinking";
+
+// Module-level: this re-renders on every stream flush, so don't rebuild the style object each time.
+const bodyStyle = { paddingLeft: timelineTokens.timelineCommonTextPadding };
+
+// `supportsCollapsible` is deliberately unset, matching web: no per-step collapse control, and a
+// reasoning-only turn therefore renders with no step header.
+export const ReasoningRenderer: MessageRenderer<Packet, FullChatState> = ({
+  packets,
+  state,
+  onComplete,
+  animate,
+  children,
+}) => {
+  const { hasStart, hasEnd, content } = useMemo(
+    () => constructCurrentReasoningState(packets),
+    [packets],
+  );
+  const { title, remainingContent } = useMemo(
+    () => extractFirstParagraph(content),
+    [content],
+  );
+
+  // `||`, not `??`: an empty heading ("# " alone) extracts as "" and must still fall back.
+  const displayStatus = title || THINKING_STATUS;
+  const displayContent = title ? remainingContent : content;
+
+  // The reader is opened by group key so the row can re-derive the text as the step streams on.
+  const openFullText = state.openFullText;
+  const firstPacket = packets[0];
+  const handleExpand =
+    openFullText && firstPacket
+      ? () => openFullText(getGroupKey(firstPacket))
+      : undefined;
+
+  // Web holds the start time in state across two effects; mobile's lint forbids setState in an
+  // effect, so it's a ref written and read inside the one effect that needs it. Same timing, one
+  // commit instead of a cascading render.
+  const startTimeRef = useRef<number | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const completionHandledRef = useRef(false);
+
+  useEffect(() => {
+    if (startTimeRef.current === null && (hasStart || hasEnd)) {
+      startTimeRef.current = Date.now();
+    }
+    if (
+      !hasEnd ||
+      startTimeRef.current === null ||
+      completionHandledRef.current
+    ) {
+      return;
+    }
+    completionHandledRef.current = true;
+
+    // Historical messages replay with animate=false and skip the floor.
+    const minimumThinkingDuration = animate ? THINKING_MIN_DURATION_MS : 0;
+    const elapsedTime = Date.now() - startTimeRef.current;
+    if (elapsedTime >= minimumThinkingDuration) {
+      onComplete();
+      return;
+    }
+    timeoutRef.current = setTimeout(
+      onComplete,
+      minimumThinkingDuration - elapsedTime,
+    );
+  }, [hasStart, hasEnd, animate, onComplete]);
+
+  useEffect(
+    () => () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  if (!hasStart && !hasEnd && content.length === 0) {
+    return children([
+      {
+        icon: SvgCircle,
+        status: THINKING_STATUS,
+        content: <></>,
+        noPaddingRight: true,
+      },
+    ]);
+  }
+
+  return children([
+    {
+      icon: SvgCircle,
+      status: displayStatus,
+      content: (
+        <View style={bodyStyle}>
+          <ReasoningTextWindow
+            displayContent={displayContent}
+            isStreaming={!hasEnd}
+            onExpand={handleExpand}
+          />
+        </View>
+      ),
+      noPaddingRight: true,
+    },
+  ]);
+};
+
+export default ReasoningRenderer;

--- a/mobile/src/components/chat/renderers/__tests__/ReasoningRenderer.test.tsx
+++ b/mobile/src/components/chat/renderers/__tests__/ReasoningRenderer.test.tsx
@@ -1,0 +1,341 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import { act, render, screen } from "@testing-library/react-native";
+import { Fragment } from "react";
+
+import { makePacket } from "@/chat/__tests__/fixtures";
+import { StepContainer } from "@/components/chat/timeline/StepContainer";
+import SvgCircle from "@/icons/circle";
+
+import { ReasoningRenderer } from "../ReasoningRenderer";
+import { RenderType, type RendererOutput } from "../timelineContract";
+
+// StreamingMarkdown pulls a native markdown module; capture its props instead of rendering it.
+let mockMarkdownProps: { content: string; isStreaming: boolean } | null = null;
+jest.mock("@/components/chat/StreamingMarkdown", () => ({
+  StreamingMarkdown: (props: { content: string; isStreaming: boolean }) => {
+    mockMarkdownProps = props;
+    return null;
+  },
+}));
+
+// The StepContainer smoke test renders a Button, which navigates via expo-router's `router`.
+jest.mock("expo-router", () => ({ router: { navigate: jest.fn() } }));
+
+const reasoningStart = makePacket({ type: "reasoning_start" });
+const sectionEnd = makePacket({ type: "section_end" });
+const delta = (reasoning: string) =>
+  makePacket({ type: "reasoning_delta", reasoning });
+
+function renderResults(results: RendererOutput) {
+  return (
+    <>
+      {results.map((result, index) => (
+        <Fragment key={index}>{result.content}</Fragment>
+      ))}
+    </>
+  );
+}
+
+interface RenderOptions {
+  packets?: ReturnType<typeof makePacket>[];
+  animate?: boolean;
+  onComplete?: () => void;
+  children?: (results: RendererOutput) => React.ReactElement;
+}
+
+function renderReasoning({
+  packets = [reasoningStart, delta("thinking")],
+  animate = true,
+  onComplete = () => {},
+  children = renderResults,
+}: RenderOptions = {}) {
+  return render(
+    <ReasoningRenderer
+      packets={packets}
+      state={{ agent: null }}
+      onComplete={onComplete}
+      renderType={RenderType.FULL}
+      animate={animate}
+      stopPacketSeen={false}
+    >
+      {children}
+    </ReasoningRenderer>,
+  );
+}
+
+// Captures the emitted results *and* mounts their content, so `mockMarkdownProps` reflects the body.
+function captureResults(packets: ReturnType<typeof makePacket>[]) {
+  let captured: RendererOutput | null = null;
+  renderReasoning({
+    packets,
+    children: (results) => {
+      captured = results;
+      return renderResults(results);
+    },
+  });
+  return captured as unknown as RendererOutput;
+}
+
+describe("ReasoningRenderer", () => {
+  beforeEach(() => {
+    mockMarkdownProps = null;
+  });
+
+  it("renders the default status and no body before any reasoning arrives", () => {
+    const results = captureResults([]);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.status).toBe("Thinking");
+    expect(results[0]!.icon).toBe(SvgCircle);
+    expect(results[0]!.noPaddingRight).toBe(true);
+    // The empty branch emits a fragment, so the markdown window never mounts.
+    expect(mockMarkdownProps).toBeNull();
+  });
+
+  it("streams accumulated deltas under the default status", () => {
+    renderReasoning({
+      packets: [reasoningStart, delta("Let me "), delta("go")],
+    });
+    expect(mockMarkdownProps?.content).toBe("Let me go");
+    expect(mockMarkdownProps?.isStreaming).toBe(true);
+  });
+
+  it("promotes a leading markdown heading to the status and lifts it out of the body", () => {
+    const results = captureResults([
+      reasoningStart,
+      delta("## Reading the docs\n\n"),
+      delta("body text"),
+    ]);
+    expect(results[0]!.status).toBe("Reading the docs");
+    expect(mockMarkdownProps?.content).toBe("body text");
+  });
+
+  it("keeps plain prose in the body and falls back to the default status", () => {
+    const results = captureResults([reasoningStart, delta("Reading the docs")]);
+    expect(results[0]!.status).toBe("Thinking");
+    expect(mockMarkdownProps?.content).toBe("Reading the docs");
+  });
+
+  it("falls back to the default status when the heading extracts to an empty title", () => {
+    // "# " is a syntactically valid heading whose text is empty; the status must not go blank.
+    const results = captureResults([reasoningStart, delta("# \n\nbody text")]);
+    expect(results[0]!.status).toBe("Thinking");
+  });
+
+  it("stops streaming once the step is closed", () => {
+    renderReasoning({
+      packets: [reasoningStart, delta("done thinking"), sectionEnd],
+    });
+    expect(mockMarkdownProps?.isStreaming).toBe(false);
+  });
+
+  it("does not expose a per-step collapse control (web parity)", () => {
+    const results = captureResults([reasoningStart, delta("thinking")]);
+    expect(results[0]!.supportsCollapsible).toBeUndefined();
+  });
+
+  it("drops the right gutter on both the empty and populated branches", () => {
+    expect(captureResults([])[0]!.noPaddingRight).toBe(true);
+    expect(
+      captureResults([reasoningStart, delta("thinking")])[0]!.noPaddingRight,
+    ).toBe(true);
+  });
+
+  // A hydrated group can arrive with no reasoning_start, so the renderer keys off content/end.
+  describe("start-less groups (hydrated history)", () => {
+    it("renders accumulated deltas with no reasoning_start packet", () => {
+      renderReasoning({ packets: [delta("recalled thinking"), sectionEnd] });
+      expect(mockMarkdownProps?.content).toBe("recalled thinking");
+      expect(mockMarkdownProps?.isStreaming).toBe(false);
+    });
+
+    it("takes the closed-but-empty branch for a section_end-only group", () => {
+      const results = captureResults([sectionEnd]);
+      expect(results[0]!.status).toBe("Thinking");
+      // hasEnd is true, so this is NOT the empty branch: an (empty) window still mounts.
+      expect(mockMarkdownProps?.content).toBe("");
+      expect(mockMarkdownProps?.isStreaming).toBe(false);
+    });
+  });
+
+  describe("minimum thinking duration", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("withholds completion for 500ms when reasoning ends immediately", () => {
+      let calls = 0;
+      renderReasoning({
+        packets: [reasoningStart, delta("fast"), sectionEnd],
+        onComplete: () => {
+          calls += 1;
+        },
+      });
+      act(() => jest.advanceTimersByTime(499));
+      expect(calls).toBe(0);
+      act(() => jest.advanceTimersByTime(1));
+      expect(calls).toBe(1);
+    });
+
+    it("completes immediately when reasoning already ran past the floor", () => {
+      let calls = 0;
+      const props = {
+        state: { agent: null },
+        onComplete: () => {
+          calls += 1;
+        },
+        renderType: RenderType.FULL,
+        animate: true,
+        stopPacketSeen: false,
+      } as const;
+      const { rerender } = render(
+        <ReasoningRenderer {...props} packets={[reasoningStart, delta("slow")]}>
+          {renderResults}
+        </ReasoningRenderer>,
+      );
+      act(() => jest.advanceTimersByTime(600));
+      expect(calls).toBe(0);
+
+      rerender(
+        <ReasoningRenderer
+          {...props}
+          packets={[reasoningStart, delta("slow"), sectionEnd]}
+        >
+          {renderResults}
+        </ReasoningRenderer>,
+      );
+      expect(calls).toBe(1);
+    });
+
+    it("stamps the start time from the end packet alone when no start ever arrived", () => {
+      // Without the `|| hasEnd` half of the stamp, startTimeRef stays null and onComplete never fires.
+      let calls = 0;
+      renderReasoning({
+        packets: [delta("recalled"), sectionEnd],
+        onComplete: () => {
+          calls += 1;
+        },
+      });
+      act(() => jest.advanceTimersByTime(500));
+      expect(calls).toBe(1);
+    });
+
+    it("serves only the remainder of the floor when reasoning ran part of it", () => {
+      // Pins `minimumThinkingDuration - elapsedTime`: 300ms elapsed leaves 200ms, not a fresh 500ms.
+      let calls = 0;
+      const props = {
+        state: { agent: null },
+        onComplete: () => {
+          calls += 1;
+        },
+        renderType: RenderType.FULL,
+        animate: true,
+        stopPacketSeen: false,
+      } as const;
+      const { rerender } = render(
+        <ReasoningRenderer {...props} packets={[reasoningStart, delta("mid")]}>
+          {renderResults}
+        </ReasoningRenderer>,
+      );
+      act(() => jest.advanceTimersByTime(300));
+      rerender(
+        <ReasoningRenderer
+          {...props}
+          packets={[reasoningStart, delta("mid"), sectionEnd]}
+        >
+          {renderResults}
+        </ReasoningRenderer>,
+      );
+      act(() => jest.advanceTimersByTime(199));
+      expect(calls).toBe(0);
+      act(() => jest.advanceTimersByTime(1));
+      expect(calls).toBe(1);
+    });
+
+    it("skips the floor entirely for historical messages (animate=false)", () => {
+      let calls = 0;
+      renderReasoning({
+        packets: [reasoningStart, delta("replayed"), sectionEnd],
+        animate: false,
+        onComplete: () => {
+          calls += 1;
+        },
+      });
+      expect(calls).toBe(1);
+    });
+
+    it("completes once even as onComplete's identity churns across re-renders", () => {
+      let calls = 0;
+      const packets = [reasoningStart, delta("fast"), sectionEnd];
+      const props = {
+        packets,
+        state: { agent: null },
+        renderType: RenderType.FULL,
+        animate: false,
+        stopPacketSeen: false,
+      } as const;
+      const onComplete = () => {
+        calls += 1;
+      };
+      const { rerender } = render(
+        <ReasoningRenderer {...props} onComplete={onComplete}>
+          {renderResults}
+        </ReasoningRenderer>,
+      );
+      rerender(
+        <ReasoningRenderer {...props} onComplete={() => calls++}>
+          {renderResults}
+        </ReasoningRenderer>,
+      );
+      rerender(
+        <ReasoningRenderer {...props} onComplete={() => calls++}>
+          {renderResults}
+        </ReasoningRenderer>,
+      );
+      expect(calls).toBe(1);
+    });
+
+    it("does not complete after unmount", () => {
+      let calls = 0;
+      const { unmount } = renderReasoning({
+        packets: [reasoningStart, delta("fast"), sectionEnd],
+        onComplete: () => {
+          calls += 1;
+        },
+      });
+      unmount();
+      act(() => jest.advanceTimersByTime(1000));
+      expect(calls).toBe(0);
+    });
+  });
+
+  it("composes into a StepContainer with a header and no collapse control", () => {
+    renderReasoning({
+      packets: [reasoningStart, delta("## Planning\n\nthe body")],
+      children: (results) => (
+        <StepContainer
+          stepIcon={results[0]!.icon ?? undefined}
+          header={results[0]!.status}
+          supportsCollapsible={results[0]!.supportsCollapsible}
+          noPaddingRight={results[0]!.noPaddingRight}
+          onToggle={() => {}}
+        >
+          {results[0]!.content}
+        </StepContainer>
+      ),
+    });
+    expect(screen.getByText("Planning")).toBeTruthy();
+    expect(screen.UNSAFE_queryByType(SvgCircle)).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(mockMarkdownProps?.content).toBe("the body");
+  });
+});

--- a/mobile/src/components/chat/renderers/__tests__/findRenderer.test.ts
+++ b/mobile/src/components/chat/renderers/__tests__/findRenderer.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it, jest } from "@jest/globals";
 
 import { makeMessageStartPacket, makePacket } from "@/chat/__tests__/fixtures";
+import { type Packet } from "@/chat/streamingModels";
 
 import { findRenderer } from "../findRenderer";
 import { MessageTextRenderer } from "../MessageTextRenderer";
+import { ReasoningRenderer } from "../ReasoningRenderer";
 
 // findRenderer transitively imports StreamingMarkdown, whose react-native-streamdown (worklets) crashes
-// under jest. Stub the leaf; dispatch still returns the real MessageTextRenderer.
+// under jest. Stub the leaf; dispatch still returns the real renderers.
 jest.mock("@/components/chat/StreamingMarkdown", () => ({
   StreamingMarkdown: () => null,
 }));
@@ -29,19 +31,86 @@ describe("findRenderer", () => {
     expect(findRenderer(packets)).toBe(MessageTextRenderer);
   });
 
-  it("returns null for reasoning-only packets (renderer wired in 9b.6)", () => {
+  it("routes reasoning-only packets to the reasoning renderer", () => {
     const packets = [
       makePacket({ type: "reasoning_start" }),
       makePacket({ type: "reasoning_delta", reasoning: "thinking" }),
     ];
-    expect(findRenderer(packets)).toBeNull();
+    expect(findRenderer(packets)).toBe(ReasoningRenderer);
   });
 
-  it("returns null for section-end / error-only packets", () => {
-    expect(findRenderer([makePacket({ type: "section_end" })])).toBeNull();
-    expect(
-      findRenderer([makePacket({ type: "error", message: "boom" })]),
-    ).toBeNull();
+  it.each([
+    ["reasoning_start", makePacket({ type: "reasoning_start" })],
+    [
+      "reasoning_delta",
+      makePacket({ type: "reasoning_delta", reasoning: "thinking" }),
+    ],
+  ])("routes a group carrying only %s to the reasoning renderer", (_l, p) => {
+    expect(findRenderer([p])).toBe(ReasoningRenderer);
+  });
+
+  // Each unwired tool slot must still decline ahead of reasoning: every closed group carries a
+  // synthesized section_end, which the reasoning predicate would otherwise match.
+  describe("unwired tool slots decline before reasoning", () => {
+    const toolStarts: [string, Packet][] = [
+      ["image generation", makePacket({ type: "image_generation_start" })],
+      ["internal search", makePacket({ type: "search_tool_start" })],
+      [
+        "web search",
+        makePacket({ type: "search_tool_start", is_internet_search: true }),
+      ],
+      ["python", makePacket({ type: "python_tool_start", code: "print(1)" })],
+      ["file reader", makePacket({ type: "file_reader_start" })],
+      [
+        "custom tool",
+        makePacket({ type: "custom_tool_start", tool_name: "t" }),
+      ],
+      // The fetch tool's wire type is "open_url_start", not "fetch_tool_start".
+      ["fetch", makePacket({ type: "open_url_start" })],
+      ["memory", makePacket({ type: "memory_tool_start" })],
+      ["deep research plan", makePacket({ type: "deep_research_plan_start" })],
+      [
+        "research agent",
+        makePacket({ type: "research_agent_start", research_task: "dig" }),
+      ],
+      [
+        "coding agent",
+        makePacket({ type: "coding_agent_start", query: "fix", repo: null }),
+      ],
+    ];
+
+    it.each(toolStarts)(
+      "returns null for a closed %s group rather than the reasoning renderer",
+      (_label, start) => {
+        expect(
+          findRenderer([start, makePacket({ type: "section_end" })]),
+        ).toBeNull();
+      },
+    );
+
+    it("declines an image group even when the turn also carried reasoning", () => {
+      // MessageRow hands the renderer the node's whole flat packet list, so both turns arrive
+      // together and image must win over the reasoning packets alongside it.
+      expect(
+        findRenderer([
+          makePacket({ type: "reasoning_start" }),
+          makePacket({ type: "reasoning_delta", reasoning: "picking a style" }),
+          makePacket({ type: "image_generation_start" }, 1),
+          makePacket({ type: "section_end" }, 1),
+        ]),
+      ).toBeNull();
+    });
+  });
+
+  // With no tool slot claiming it, a bare section_end/error falls through to reasoning, which
+  // treats it as a closed, empty step.
+  it("falls through to the reasoning renderer for section-end / error-only packets", () => {
+    expect(findRenderer([makePacket({ type: "section_end" })])).toBe(
+      ReasoningRenderer,
+    );
+    expect(findRenderer([makePacket({ type: "error", message: "boom" })])).toBe(
+      ReasoningRenderer,
+    );
   });
 
   it("returns null for an empty packet list", () => {

--- a/mobile/src/components/chat/renderers/findRenderer.ts
+++ b/mobile/src/components/chat/renderers/findRenderer.ts
@@ -1,9 +1,23 @@
-// Priority-ordered renderer dispatch, mirroring web `renderMessageComponent`. First match wins. Only the
-// chat slot is wired in 9b.4; each tool slot below is a one-line wire-up in a later phase — the ordering
-// is already baked in so those phases never touch the priority logic.
-import { Packet, PacketType } from "@/chat/streamingModels";
+// Priority-ordered renderer dispatch, mirroring web `renderMessageComponent`. First match wins.
+//
+// Only chat and reasoning are wired; the tool slots between them return null on purpose. Reasoning
+// sits last and matches section_end/error, which in web are already claimed by whichever tool group
+// they close — delete the intervening predicates and reasoning inherits every closed tool group,
+// painting a search or image step as a bogus "Thinking" body. Adding a renderer swaps one `null`.
+import {
+  CODE_INTERPRETER_TOOL_TYPES,
+  Packet,
+  PacketType,
+  ToolCallArgumentDelta,
+} from "@/chat/streamingModels";
+import {
+  isCodingAgentPackets,
+  isDeepResearchPlanPackets,
+  isMemoryToolPackets,
+} from "@/chat/timeline/packetHelpers";
 
 import { MessageTextRenderer } from "./MessageTextRenderer";
+import { ReasoningRenderer } from "./ReasoningRenderer";
 import type { DispatchRenderer } from "./timelineContract";
 
 function isChatPacket(packet: Packet): boolean {
@@ -14,8 +28,44 @@ function isChatPacket(packet: Packet): boolean {
   );
 }
 
-// A reasoning group is closed by a section_end (or error), so those types fall to it once the
-// higher-priority slots above have had their turn.
+function isResearchAgentPacket(packet: Packet): boolean {
+  return (
+    packet.obj.type === PacketType.RESEARCH_AGENT_START ||
+    packet.obj.type === PacketType.INTERMEDIATE_REPORT_START ||
+    packet.obj.type === PacketType.INTERMEDIATE_REPORT_DELTA ||
+    packet.obj.type === PacketType.INTERMEDIATE_REPORT_CITED_DOCS
+  );
+}
+
+function isSearchToolPacket(packet: Packet): boolean {
+  return packet.obj.type === PacketType.SEARCH_TOOL_START;
+}
+
+function isImageToolPacket(packet: Packet): boolean {
+  return packet.obj.type === PacketType.IMAGE_GENERATION_TOOL_START;
+}
+
+function isPythonToolPacket(packet: Packet): boolean {
+  return (
+    packet.obj.type === PacketType.PYTHON_TOOL_START ||
+    (packet.obj.type === PacketType.TOOL_CALL_ARGUMENT_DELTA &&
+      (packet.obj as ToolCallArgumentDelta).tool_type ===
+        CODE_INTERPRETER_TOOL_TYPES.PYTHON)
+  );
+}
+
+function isFileReaderToolPacket(packet: Packet): boolean {
+  return packet.obj.type === PacketType.FILE_READER_START;
+}
+
+function isCustomToolPacket(packet: Packet): boolean {
+  return packet.obj.type === PacketType.CUSTOM_TOOL_START;
+}
+
+function isFetchToolPacket(packet: Packet): boolean {
+  return packet.obj.type === PacketType.FETCH_TOOL_START;
+}
+
 function isReasoningPacket(packet: Packet): boolean {
   return (
     packet.obj.type === PacketType.REASONING_START ||
@@ -30,14 +80,42 @@ export function findRenderer(packets: Packet[]): DispatchRenderer | null {
     return MessageTextRenderer;
   }
 
-  // Tool renderers land in follow-up phases, in web's priority order:
-  //   deep-research plan → research-agent → coding-agent          // PR 9x
-  //   web-search → internal-search                                 // PR 9x
-  //   image → python → file-reader → custom-tool → fetch → memory  // PR 9x
+  // Deep research first: its groups can also carry reasoning/fetch packets.
+  if (isDeepResearchPlanPackets(packets)) {
+    return null; // PR 9x: deep-research plan
+  }
+  if (packets.some(isResearchAgentPacket)) {
+    return null; // PR 9x: research agent
+  }
+  if (isCodingAgentPackets(packets)) {
+    return null; // PR 9x: coding agent
+  }
 
-  // Reasoning is wired in 9b.6; the slot is present (returns null) so the priority ordering is correct.
+  // Web splits this on `is_internet_search`; both slots are unwired, so one predicate covers the pair.
+  if (packets.some(isSearchToolPacket)) {
+    return null; // PR 9x: web search / internal search
+  }
+  if (packets.some(isImageToolPacket)) {
+    return null; // PR 9e: image generation
+  }
+  if (packets.some(isPythonToolPacket)) {
+    return null; // PR 9x: python
+  }
+  if (packets.some(isFileReaderToolPacket)) {
+    return null; // PR 9x: file reader
+  }
+  if (packets.some(isCustomToolPacket)) {
+    return null; // PR 9x: custom tool
+  }
+  if (packets.some(isFetchToolPacket)) {
+    return null; // PR 9x: fetch
+  }
+  if (isMemoryToolPackets(packets)) {
+    return null; // PR 9x: memory
+  }
+
   if (packets.some(isReasoningPacket)) {
-    return null;
+    return ReasoningRenderer;
   }
 
   return null;

--- a/mobile/src/components/chat/renderers/timelineContract.ts
+++ b/mobile/src/components/chat/renderers/timelineContract.ts
@@ -45,6 +45,11 @@ export interface FullChatState {
   documentMap?: Map<string, SearchDoc>;
   // Opens a cited source (9a); used by later source-row renderers.
   openSource?: (doc: SearchDoc) => void;
+  // Opens the long-form reader the message row owns, identified by the step's packet-group key.
+  // Two reasons it takes a key rather than the text: the timeline auto-collapses when the answer
+  // starts, so a reader owned inside the step would be unmounted mid-read; and a snapshot string
+  // would freeze while the step keeps streaming, so the row re-derives the text on every flush.
+  openFullText?: (groupKey: string) => void;
 }
 
 export type MessageRenderer<

--- a/mobile/src/components/chat/timeline/ReasoningTextSheet.tsx
+++ b/mobile/src/components/chat/timeline/ReasoningTextSheet.tsx
@@ -1,0 +1,113 @@
+// Web's ExpandableTextDisplay modal, on the same RN Modal + ScrollView bottom sheet as 9a's
+// CitedSourcesSheet. Download is dropped (no mobile analog for a .txt download); Copy is labelled
+// rather than icon-only because mobile has no tooltip to explain a bare glyph.
+import * as Clipboard from "expo-clipboard";
+import {
+  Modal,
+  Pressable,
+  ScrollView,
+  useWindowDimensions,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { countLines, formatContentSize } from "@/chat/timeline/textStats";
+import { StreamingMarkdown } from "@/components/chat/StreamingMarkdown";
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
+import { toast } from "@/hooks/useToast";
+import SvgX from "@/icons/x";
+
+// Reasoning is long-form prose, so the body takes most of the screen — unlike 9a's Sources sheet,
+// which wraps a short list. Capping the body (not the sheet) keeps a short reasoning sheet
+// shrink-wrapped instead of stretching to a fixed height.
+const BODY_MAX_SCREEN_FRACTION = 0.7;
+
+export interface ReasoningTextSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  // Full reasoning, heading included — the window above shows it with the heading lifted out.
+  content: string;
+}
+
+export function ReasoningTextSheet({
+  visible,
+  onClose,
+  content,
+}: ReasoningTextSheetProps) {
+  const insets = useSafeAreaInsets();
+  const { height: screenHeight } = useWindowDimensions();
+  const lineCount = countLines(content);
+
+  async function handleCopy() {
+    await Clipboard.setStringAsync(content);
+    toast.success("Copied");
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+      statusBarTranslucent
+    >
+      {/* Semantic tokens are bare CSS vars with no alpha, so the dimming scrim needs a raw rgba. */}
+      <Pressable
+        className="flex-1 justify-end"
+        style={{ backgroundColor: "rgba(0, 0, 0, 0.4)" }}
+        onPress={onClose}
+      >
+        {/* Stop taps inside the sheet from dismissing it. */}
+        <Pressable
+          onPress={() => {}}
+          className="rounded-t-20 border-t border-border-01 bg-background-tint-00 px-16 pt-16"
+          style={{ paddingBottom: insets.bottom + 16 }}
+        >
+          <View className="mb-8 flex-row items-start justify-between">
+            <View className="flex-1">
+              <Text font="main-content-emphasis" color="text-04">
+                Full text
+              </Text>
+              <Text font="secondary-body" color="text-03">
+                {formatContentSize(content)}
+              </Text>
+            </View>
+            <Button
+              icon={SvgX}
+              prominence="tertiary"
+              size="sm"
+              accessibilityLabel="Close"
+              onPress={onClose}
+            />
+          </View>
+
+          <ScrollView
+            style={{
+              maxHeight: Math.round(screenHeight * BODY_MAX_SCREEN_FRACTION),
+            }}
+            keyboardShouldPersistTaps="handled"
+            contentContainerClassName="pb-8"
+          >
+            <StreamingMarkdown
+              content={content}
+              isStreaming={false}
+              variant="muted"
+            />
+          </ScrollView>
+
+          <View className="mt-8 flex-row items-center justify-between">
+            <Text font="main-ui-muted" color="text-03">
+              {lineCount} {lineCount === 1 ? "line" : "lines"}
+            </Text>
+            <Button prominence="tertiary" size="sm" onPress={handleCopy}>
+              Copy
+            </Button>
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+export default ReasoningTextSheet;

--- a/mobile/src/components/chat/timeline/ReasoningTextWindow.tsx
+++ b/mobile/src/components/chat/timeline/ReasoningTextWindow.tsx
@@ -1,0 +1,90 @@
+// Mobile's port of web's ExpandableTextDisplay — the collapsed half. The expanded reader is
+// ReasoningTextSheet, which the message row owns (see `onExpand`).
+//
+// Must be a ScrollView, not a clipping View: the markdown is a native measure leaf and both
+// platforms clamp its height to Yoga's AtMost constraint (iOS `ENRMClampMeasuredSize`, Android
+// `MeasurementStore` AT_MOST), so it never overflows and no `justifyContent` trick shifts it.
+// A ScrollView measures its content unbounded, which is what makes following the stream possible.
+import { useCallback, useRef, useState } from "react";
+import { ScrollView, View } from "react-native";
+
+import { StreamingMarkdown } from "@/components/chat/StreamingMarkdown";
+import { Button } from "@/components/ui/button";
+import SvgExpand from "@/icons/expand";
+
+// Web's box is maxLines × 1.5rem even though its muted body renders at 20px — so 192 matches web's
+// box, not 8 lines of mobile text.
+const MAX_LINES = 8;
+const LINE_HEIGHT = 24;
+export const REASONING_WINDOW_MAX_HEIGHT = MAX_LINES * LINE_HEIGHT;
+
+export interface ReasoningTextWindowProps {
+  // Heading lifted out (it became the step title) — the window shows only this.
+  displayContent: string;
+  isStreaming: boolean;
+  // Opens the full-text reader, which the message row owns and keeps live. The window deliberately
+  // never handles the full text itself.
+  onExpand?: () => void;
+}
+
+export function ReasoningTextWindow({
+  displayContent,
+  isStreaming,
+  onExpand,
+}: ReasoningTextWindowProps) {
+  const scrollRef = useRef<ScrollView>(null);
+  const [overflows, setOverflows] = useState(false);
+
+  // Only take the gesture when there is genuinely something to scroll. An enabled ScrollView whose
+  // content fits still wins the pan on iOS (RN defaults alwaysBounceVertical to true), so a short
+  // finished step would become a band where the conversation refuses to scroll.
+  const canScroll = overflows && !isStreaming;
+
+  const handleContentSizeChange = useCallback(
+    (_width: number, height: number) => {
+      setOverflows(height > REASONING_WINDOW_MAX_HEIGHT);
+      if (isStreaming) {
+        scrollRef.current?.scrollToEnd({ animated: false });
+      }
+    },
+    [isStreaming],
+  );
+
+  return (
+    <View>
+      <ScrollView
+        ref={scrollRef}
+        style={{ maxHeight: REASONING_WINDOW_MAX_HEIGHT }}
+        onContentSizeChange={handleContentSizeChange}
+        // While streaming the window follows the newest lines, so a user pan would fight it.
+        scrollEnabled={canScroll}
+        // Belt and braces with canScroll: stops iOS rubber-banding a window whose content fits.
+        alwaysBounceVertical={false}
+        // Android needs this for a ScrollView nested in the chat list to receive pans at all.
+        nestedScrollEnabled
+        showsVerticalScrollIndicator={canScroll}
+      >
+        <StreamingMarkdown
+          content={displayContent}
+          isStreaming={isStreaming}
+          variant="muted"
+        />
+      </ScrollView>
+
+      {overflows && onExpand ? (
+        <View className="mt-4 flex-row justify-end">
+          <Button
+            prominence="tertiary"
+            size="sm"
+            rightIcon={SvgExpand}
+            onPress={onExpand}
+          >
+            View full text
+          </Button>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+export default ReasoningTextWindow;

--- a/mobile/src/components/chat/timeline/__tests__/ReasoningTextSheet.test.tsx
+++ b/mobile/src/components/chat/timeline/__tests__/ReasoningTextSheet.test.tsx
@@ -1,0 +1,94 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import { act, fireEvent, render, screen } from "@testing-library/react-native";
+import { ScrollView } from "react-native";
+
+import { ReasoningTextSheet } from "@/components/chat/timeline/ReasoningTextSheet";
+import { toast } from "@/hooks/useToast";
+
+let mockMarkdownProps: { content: string; isStreaming: boolean } | null = null;
+jest.mock("@/components/chat/StreamingMarkdown", () => ({
+  StreamingMarkdown: (props: { content: string; isStreaming: boolean }) => {
+    mockMarkdownProps = props;
+    return null;
+  },
+}));
+
+jest.mock("expo-router", () => ({ router: { navigate: jest.fn() } }));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 34, left: 0, right: 0 }),
+}));
+
+// jest-expo reports a 750x1334 window, so screen-relative sizing is assertable.
+const SCREEN_HEIGHT = 1334;
+
+const mockSetString = jest.fn(async (_text: string) => true);
+jest.mock("expo-clipboard", () => ({
+  setStringAsync: (text: string) => mockSetString(text),
+}));
+
+const CONTENT = "# Planning\n\nthe body";
+
+function renderSheet(onClose = jest.fn()) {
+  return render(
+    <ReasoningTextSheet visible onClose={onClose} content={CONTENT} />,
+  );
+}
+
+describe("ReasoningTextSheet", () => {
+  beforeEach(() => {
+    mockMarkdownProps = null;
+    mockSetString.mockClear();
+  });
+
+  // The copy toast holds a 4s dismissal timer that would otherwise outlive the run.
+  afterEach(() => {
+    toast.clearAll();
+  });
+
+  it("renders the full reasoning, heading included", () => {
+    renderSheet();
+    expect(mockMarkdownProps?.content).toBe(CONTENT);
+    // The reader is never mid-stream; it always shows a settled snapshot.
+    expect(mockMarkdownProps?.isStreaming).toBe(false);
+  });
+
+  it("titles the sheet and reports size and line count", () => {
+    renderSheet();
+    expect(screen.getByText("Full text")).toBeTruthy();
+    expect(screen.getByText("20 Bytes")).toBeTruthy();
+    // "# Planning" / "" / "the body"
+    expect(screen.getByText("3 lines")).toBeTruthy();
+  });
+
+  // Reasoning is long-form, so the body takes most of the screen — unlike 9a's short Sources list.
+  it("sizes the body to most of the screen, not a fixed 420px", () => {
+    renderSheet();
+    const body = screen.UNSAFE_getAllByType(ScrollView)[0]!;
+    const maxHeight = (body.props.style as { maxHeight: number }).maxHeight;
+    expect(maxHeight).toBe(Math.round(SCREEN_HEIGHT * 0.7));
+    expect(maxHeight).toBeGreaterThan(420);
+  });
+
+  it("copies the full reasoning", async () => {
+    renderSheet();
+    await act(async () => {
+      fireEvent.press(screen.getByText("Copy"));
+    });
+    expect(mockSetString).toHaveBeenCalledWith(CONTENT);
+  });
+
+  it("closes on the close control", () => {
+    const onClose = jest.fn();
+    renderSheet(onClose);
+    fireEvent.press(screen.getByLabelText("Close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/components/chat/timeline/__tests__/ReasoningTextWindow.test.tsx
+++ b/mobile/src/components/chat/timeline/__tests__/ReasoningTextWindow.test.tsx
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { act, fireEvent, render, screen } from "@testing-library/react-native";
+import { ScrollView } from "react-native";
+
+import {
+  REASONING_WINDOW_MAX_HEIGHT,
+  ReasoningTextWindow,
+} from "@/components/chat/timeline/ReasoningTextWindow";
+
+// StreamingMarkdown wraps a native markdown module; capture its props instead of rendering it.
+let mockMarkdownProps: {
+  content: string;
+  isStreaming: boolean;
+  variant?: string;
+} | null = null;
+jest.mock("@/components/chat/StreamingMarkdown", () => ({
+  StreamingMarkdown: (props: {
+    content: string;
+    isStreaming: boolean;
+    variant?: string;
+  }) => {
+    mockMarkdownProps = props;
+    return null;
+  },
+}));
+
+// The "View full text" Button navigates via expo-router's `router`.
+jest.mock("expo-router", () => ({ router: { navigate: jest.fn() } }));
+
+const DISPLAYED = "the body";
+
+function renderWindow(isStreaming = false, onExpand?: () => void) {
+  return render(
+    <ReasoningTextWindow
+      displayContent={DISPLAYED}
+      isStreaming={isStreaming}
+      onExpand={onExpand}
+    />,
+  );
+}
+
+function windowScroll() {
+  return screen.UNSAFE_getAllByType(ScrollView)[0]!;
+}
+
+function growContentTo(height: number) {
+  act(() => {
+    windowScroll().props.onContentSizeChange(320, height);
+  });
+}
+
+describe("ReasoningTextWindow", () => {
+  beforeEach(() => {
+    mockMarkdownProps = null;
+  });
+
+  it("caps the window at the fixed height", () => {
+    renderWindow();
+    expect(windowScroll().props.style).toEqual(
+      expect.objectContaining({ maxHeight: REASONING_WINDOW_MAX_HEIGHT }),
+    );
+  });
+
+  it("shows the heading-stripped body in the muted variant", () => {
+    renderWindow(true);
+    expect(mockMarkdownProps?.content).toBe(DISPLAYED);
+    expect(mockMarkdownProps?.variant).toBe("muted");
+    expect(mockMarkdownProps?.isStreaming).toBe(true);
+  });
+
+  describe("auto-follow", () => {
+    it("scrolls to the newest lines while streaming", () => {
+      renderWindow(true);
+      const scroll = windowScroll();
+      const scrollToEnd = jest.fn();
+      // The ref target is the same instance the component holds.
+      scroll.instance.scrollToEnd = scrollToEnd;
+      growContentTo(500);
+      expect(scrollToEnd).toHaveBeenCalledWith({ animated: false });
+    });
+
+    it("does not yank the view once the stream has ended", () => {
+      renderWindow(false);
+      const scroll = windowScroll();
+      const scrollToEnd = jest.fn();
+      scroll.instance.scrollToEnd = scrollToEnd;
+      growContentTo(500);
+      expect(scrollToEnd).not.toHaveBeenCalled();
+    });
+
+    it("locks user scrolling while streaming and unlocks after, once content overflows", () => {
+      renderWindow(true);
+      growContentTo(500);
+      expect(windowScroll().props.scrollEnabled).toBe(false);
+
+      renderWindow(false);
+      growContentTo(500);
+      expect(windowScroll().props.scrollEnabled).toBe(true);
+    });
+
+    // An enabled ScrollView wins the pan on iOS even with nothing to scroll, so a short finished
+    // step would become a band where the conversation refuses to scroll.
+    it("stays inert when the finished reasoning fits in the window", () => {
+      renderWindow(false);
+      growContentTo(REASONING_WINDOW_MAX_HEIGHT - 1);
+      expect(windowScroll().props.scrollEnabled).toBe(false);
+      expect(windowScroll().props.alwaysBounceVertical).toBe(false);
+    });
+  });
+
+  describe("handing off to the full-text reader", () => {
+    it("offers the affordance only once the reasoning overflows", () => {
+      renderWindow(false, jest.fn());
+      expect(screen.queryByText("View full text")).toBeNull();
+      growContentTo(REASONING_WINDOW_MAX_HEIGHT + 1);
+      expect(screen.getByText("View full text")).toBeTruthy();
+    });
+
+    // The window hands up only a request. It never sees the full text, so it cannot hand up a
+    // snapshot that would freeze while the step keeps streaming.
+    it("asks the row to open the reader, carrying no text of its own", () => {
+      const onExpand = jest.fn();
+      renderWindow(false, onExpand);
+      growContentTo(500);
+      fireEvent.press(screen.getByText("View full text"));
+      expect(onExpand).toHaveBeenCalledTimes(1);
+      expect(onExpand).toHaveBeenCalledWith();
+    });
+
+    // The reader lives above the timeline, so a step that has no way to reach it must not offer one.
+    it("hides the affordance when no reader is wired up", () => {
+      renderWindow(false);
+      growContentTo(500);
+      expect(screen.queryByText("View full text")).toBeNull();
+    });
+
+    // The window never mounts a Modal itself; auto-collapse would destroy it mid-read.
+    it("renders no sheet of its own", () => {
+      renderWindow(false, jest.fn());
+      growContentTo(500);
+      expect(screen.queryByText("Full text")).toBeNull();
+      expect(screen.queryByText("Copy")).toBeNull();
+    });
+  });
+});

--- a/mobile/src/hooks/__tests__/usePacketDisplay.test.ts
+++ b/mobile/src/hooks/__tests__/usePacketDisplay.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "@jest/globals";
+import { renderHook } from "@testing-library/react-native";
+
+import { makeMessageStartPacket, makePacket } from "@/chat/__tests__/fixtures";
+import { type Message } from "@/chat/interfaces";
+import { type Packet } from "@/chat/streamingModels";
+import { usePacketDisplay } from "@/hooks/usePacketDisplay";
+
+function makeAssistantNode(packets: Packet[]): Message {
+  return {
+    nodeId: 1,
+    parentNodeId: 0,
+    type: "assistant",
+    message: "",
+    files: [],
+    packets,
+  };
+}
+
+const reasoningPackets: Packet[] = [
+  makePacket({ type: "reasoning_start" }),
+  makePacket({ type: "reasoning_delta", reasoning: "thinking hard" }),
+  makePacket({ type: "reasoning_done" }),
+];
+
+describe("usePacketDisplay", () => {
+  it("reports no display content before the answer starts", () => {
+    const { result } = renderHook(() =>
+      usePacketDisplay(makeAssistantNode([])),
+    );
+    expect(result.current.hasDisplayContent).toBe(false);
+  });
+
+  // Keying the gate on "findRenderer matched something" instead would put raw reasoning text in the
+  // answer slot and kill the loader — reasoning and tool groups belong above the answer, not in it.
+  it("stays closed for a reasoning-only node", () => {
+    const { result } = renderHook(() =>
+      usePacketDisplay(makeAssistantNode(reasoningPackets)),
+    );
+    expect(result.current.hasDisplayContent).toBe(false);
+  });
+
+  it("opens once the answer's message_start arrives in the next turn", () => {
+    const { result } = renderHook(() =>
+      usePacketDisplay(
+        // The backend increments turn_index before the answer, so the answer is always its own
+        // group (backend/onyx/chat/llm_step.py).
+        makeAssistantNode([
+          ...reasoningPackets,
+          { ...makeMessageStartPacket(), placement: { turn_index: 1 } },
+        ]),
+      ),
+    );
+    expect(result.current.hasDisplayContent).toBe(true);
+  });
+
+  it("still exposes the processed state consumers read (citations, completion)", () => {
+    const { result } = renderHook(() =>
+      usePacketDisplay(
+        makeAssistantNode([
+          makeMessageStartPacket(),
+          makePacket({ type: "message_delta", content: "hi" }),
+          makePacket({ type: "message_end" }),
+        ]),
+      ),
+    );
+    expect(result.current.processed.isComplete).toBe(true);
+    expect(result.current.packets).toHaveLength(3);
+  });
+});

--- a/mobile/src/hooks/usePacketDisplay.ts
+++ b/mobile/src/hooks/usePacketDisplay.ts
@@ -1,6 +1,4 @@
-// Derives a node's processed message state (citations, documents, completion) and whether any renderer
-// matches its packets. Reprocesses on each stream flush (packet-array identity changes); cheap at chat
-// scale.
+// Reprocesses on each stream flush (the packet array's identity changes); cheap at chat scale.
 import { useMemo } from "react";
 
 import { Message } from "@/chat/interfaces";
@@ -10,13 +8,13 @@ import {
   processPackets,
 } from "@/chat/messageProcessor";
 import { Packet } from "@/chat/streamingModels";
-import { findRenderer } from "@/components/chat/renderers/registry";
 
 export interface PacketDisplay {
   packets: Packet[];
   processed: ProcessedMessageState;
-  // Drives the answer-vs-loader gate in MessageRow.
-  hasRenderer: boolean;
+  // Drives the answer-vs-loader gate in MessageRow. Keyed on display groups, not on "some renderer
+  // matches": a reasoning or tool group matches one too, but belongs above the answer, not in it.
+  hasDisplayContent: boolean;
 }
 
 export function usePacketDisplay(node: Message): PacketDisplay {
@@ -24,10 +22,10 @@ export function usePacketDisplay(node: Message): PacketDisplay {
     () => processPackets(createInitialState(node.nodeId), node.packets),
     [node.nodeId, node.packets],
   );
-  const hasRenderer = useMemo(
-    () => findRenderer(node.packets) != null,
-    [node.packets],
-  );
 
-  return { packets: node.packets, processed, hasRenderer };
+  return {
+    packets: node.packets,
+    processed,
+    hasDisplayContent: processed.potentialDisplayGroups.length > 0,
+  };
 }


### PR DESCRIPTION
## Description

Ports web's `ReasoningRenderer` and `ExpandableTextDisplay` to the mobile agent timeline (PR 9b.6), landing dark until 9b.7 mounts the timeline. A reasoning step now renders a fixed-height window that follows the stream, plus a full-text reader with Copy that `MessageRow` owns and re-derives by group key on every flush — so it survives the timeline auto-collapsing and never freezes mid-stream (web's Download is dropped, having no mobile analog). Also wires the reasoning slot in `findRenderer` and restores the 11 unwired tool predicates ahead of it, without which the last slot would claim every closed tool group, since they all carry a synthesized `section_end`. Fixes one latent regression in the already-shipped answer path: the answer-vs-loader gate now keys on display groups rather than "some renderer matched", which would otherwise have rendered raw reasoning text where the answer belongs.

## How Has This Been Tested?

558 Jest tests across 73 suites, plus `tsc`, lint and prettier clean; on-device verification is still owed and rolls into 9b.7, and note `expo-clipboard` is a new native dependency so it needs a rebuild.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a mobile reasoning renderer and a full‑text reader for the agent timeline, ported from web and landing dark until 9b.7 mounts the timeline. Wires reasoning dispatch and restores tool priorities to avoid misrouted closed tool groups; fixes the answer gate to keep reasoning out of the answer slot.

- **New Features**
  - `ReasoningRenderer` with heading extraction (≤60 chars), 500ms min-thinking, and a fixed-height `ReasoningTextWindow` that auto-follows while streaming; enables scroll after close and shows “View full text” on overflow.
  - `ReasoningTextSheet` shows the full reasoning with Copy via `expo-clipboard`, plus size and line count. Owned by `MessageRow` and re-derived by group key so it stays live while streaming and through auto-collapse (Download dropped).
  - Reasoning wired in `findRenderer`; `supportsCollapsible` intentionally unset for web parity.

- **Bug Fixes**
  - Restored 11 tool predicates ahead of reasoning and wired reasoning last, so closed tool groups (with `section_end`/`error`) aren’t claimed by reasoning; bare `section_end`/`error` now fall through to reasoning as an empty step.
  - Answer-vs-loader gate now keys on display groups (not “some renderer matched”), preventing raw reasoning from rendering in the answer slot.

<sup>Written for commit 9996441ab15c74044b5e7dc4e1652876d48f084a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



