### PR TITLE
chore: [Running GitHub actions for #13693]

### DIFF
--- a/web/src/lib/azureTargetUri.test.ts
+++ b/web/src/lib/azureTargetUri.test.ts
@@ -1,0 +1,65 @@
+import {
+  buildTargetUri,
+  isValidAzureTargetUri,
+  parseAzureTargetUri,
+} from "@/lib/azureTargetUri";
+import { LLMProviderView } from "@/lib/languageModels/types";
+
+const baseProvider: LLMProviderView = {
+  id: 1,
+  name: "azure",
+  provider: "azure",
+  api_key: "sk-test",
+  api_base: "https://my-resource.openai.azure.com",
+  api_version: "2025-01-01-preview",
+  custom_config: null,
+  is_public: true,
+  is_auto_mode: true,
+  groups: [],
+  personas: [],
+  deployment_name: null,
+  model_configurations: [],
+};
+
+describe("buildTargetUri", () => {
+  it("returns an empty string when api_base or api_version is missing", () => {
+    expect(buildTargetUri(undefined)).toBe("");
+    expect(buildTargetUri({ ...baseProvider, api_base: null })).toBe("");
+    expect(buildTargetUri({ ...baseProvider, api_version: null })).toBe("");
+  });
+
+  it("does not fabricate a deployment for per-model-routing providers (#13590)", () => {
+    // A provider created with deployment_name === null routes each model to a
+    // deployment named after the model. Editing it must NOT invent a
+    // provider-level deployment, which previously produced the placeholder
+    // "your-deployment" and broke every model with Azure DeploymentNotFound.
+    const uri = buildTargetUri(baseProvider);
+
+    expect(uri).not.toContain("your-deployment");
+    expect(uri).not.toContain("/openai/deployments/");
+    expect(isValidAzureTargetUri(uri)).toBe(true);
+
+    // The reconstructed URI round-trips back to an empty deployment, so on save
+    // `processValues` keeps deployment_name null rather than fabricating one.
+    const parsed = parseAzureTargetUri(uri);
+    expect(parsed.deploymentName).toBe("");
+    expect(parsed.apiVersion).toBe("2025-01-01-preview");
+    expect(parsed.url.origin).toBe("https://my-resource.openai.azure.com");
+  });
+
+  it("round-trips a provider that has an explicit deployment_name", () => {
+    const provider: LLMProviderView = {
+      ...baseProvider,
+      deployment_name: "gpt-4o",
+    };
+    const uri = buildTargetUri(provider);
+
+    expect(uri).toContain("/openai/deployments/gpt-4o/chat/completions");
+    expect(isValidAzureTargetUri(uri)).toBe(true);
+
+    const parsed = parseAzureTargetUri(uri);
+    expect(parsed.deploymentName).toBe("gpt-4o");
+    expect(parsed.apiVersion).toBe("2025-01-01-preview");
+    expect(parsed.url.origin).toBe("https://my-resource.openai.azure.com");
+  });
+});

--- a/web/src/lib/azureTargetUri.ts
+++ b/web/src/lib/azureTargetUri.ts
@@ -1,3 +1,5 @@
+import { LLMProviderView } from "@/lib/languageModels/types";
+
 const getApiVersionParam = (url: URL): string => {
   const directApiVersion = url.searchParams.get("api-version");
   if (directApiVersion?.trim()) {
@@ -52,4 +54,33 @@ export const isValidAzureTargetUri = (rawUri: string): boolean => {
   } catch {
     return false;
   }
+};
+
+/**
+ * Reconstructs the Azure "target URI" that pre-fills the edit form for an
+ * existing provider.
+ *
+ * When the provider routes per-model (no provider-level `deployment_name`), we
+ * emit the deployment-less `/openai/responses` form instead of injecting a
+ * placeholder deployment. Fabricating a deployment here caused
+ * `parseAzureTargetUri` to persist that bogus value on save, routing every
+ * model to a non-existent deployment and breaking the provider with Azure
+ * `DeploymentNotFound` (issue #13590). The path is discarded on save
+ * (`processValues` keeps only `url.origin`); it exists solely so the parsed URI
+ * round-trips back to the same `api_base`, `api_version`, and deployment.
+ */
+export const buildTargetUri = (
+  existingLlmProvider?: LLMProviderView
+): string => {
+  if (!existingLlmProvider?.api_base || !existingLlmProvider?.api_version) {
+    return "";
+  }
+
+  const { api_base, api_version, deployment_name } = existingLlmProvider;
+
+  if (!deployment_name) {
+    return `${api_base}/openai/responses?api-version=${api_version}`;
+  }
+
+  return `${api_base}/openai/deployments/${deployment_name}/chat/completions?api-version=${api_version}`;
 };

--- a/web/src/sections/modals/languageModels/AzureModal.tsx
+++ b/web/src/sections/modals/languageModels/AzureModal.tsx
@@ -7,7 +7,6 @@ import { InputDivider, InputPadder, InputVertical, toast } from "@opal/layouts";
 import {
   LLMProviderFormProps,
   LLMProviderName,
-  LLMProviderView,
 } from "@/lib/languageModels/types";
 import * as Yup from "yup";
 import {
@@ -25,6 +24,7 @@ import {
   ModalWrapper,
 } from "@/sections/modals/languageModels/shared";
 import {
+  buildTargetUri,
   isValidAzureTargetUri,
   parseAzureTargetUri,
 } from "@/lib/azureTargetUri";
@@ -63,16 +63,6 @@ function AzureModelSelection() {
       }}
     />
   );
-}
-
-function buildTargetUri(existingLlmProvider?: LLMProviderView): string {
-  if (!existingLlmProvider?.api_base || !existingLlmProvider?.api_version) {
-    return "";
-  }
-
-  const deploymentName =
-    existingLlmProvider.deployment_name || "your-deployment";
-  return `${existingLlmProvider.api_base}/openai/deployments/${deploymentName}/chat/completions?api-version=${existingLlmProvider.api_version}`;
 }
 
 const processValues = (values: AzureModalValues): AzureModalValues => {


### PR DESCRIPTION
This PR runs GitHub Actions CI for #13693.

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent editing Azure providers from fabricating a deployment name. If a provider uses per‑model routing, we now build a deployment‑less target URI so saves keep deployment_name null and avoid Azure DeploymentNotFound errors.

- **Bug Fixes**
  - Stop injecting "your-deployment" for providers without a `deployment_name` by emitting `/openai/responses?api-version=...`. Fixes #13590.
  - Added unit tests for per-model routing and explicit deployment cases.

- **Refactors**
  - Moved `buildTargetUri` into `web/src/lib/azureTargetUri.ts` (beside its parser) and removed the duplicate from `AzureModal`, which now imports it.

<sup>Written for commit a320cee013f4d0446ad2dda60db3158182b282f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

