### PR TITLE
feat(gateway): native Anthropic passthrough for /v1/messages

### DIFF
--- a/backend/onyx/server/gateway/anthropic_passthrough.py
+++ b/backend/onyx/server/gateway/anthropic_passthrough.py
@@ -1,0 +1,504 @@
+"""Native Anthropic passthrough for the gateway's Messages API.
+
+When the resolved provider is Anthropic itself, the OpenAI-shaped translation
+path (api.py) cannot carry server-side tools, thinking-block signatures,
+``pause_turn``, or fine-grained streaming. This module proxies the request
+nearly verbatim to Anthropic over httpx instead of going through LiteLLM's
+anthropic_messages surface, which reconstructs the body from a fixed param
+list and drops unknown fields.
+"""
+
+import hashlib
+import json
+import queue
+import threading
+from contextlib import ExitStack
+from typing import Any
+
+import httpx
+from fastapi import Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.llm.factory import llm_from_provider
+from onyx.llm.interfaces import LLM
+from onyx.llm.model_response import Usage
+from onyx.llm.multi_llm import LitellmLLM
+from onyx.server.gateway.configs import (
+    ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED,
+    ANTHROPIC_PASSTHROUGH_CONNECT_TIMEOUT_SECONDS,
+    ANTHROPIC_PASSTHROUGH_READ_TIMEOUT_SECONDS,
+)
+from onyx.server.gateway.models import (
+    AnthropicCountTokensRequest,
+    AnthropicErrorEvent,
+    AnthropicMessagesRequest,
+)
+from onyx.server.gateway.stream_bridge import (
+    _put_stream_item,
+    _sse_response,
+    _stream_worker_guard,
+    _StreamAccumulator,
+)
+from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
+from onyx.tracing.flows import LLMFlow
+from onyx.tracing.framework.create import trace
+from onyx.tracing.framework.traces import Trace
+from onyx.tracing.llm_utils import llm_generation_span, record_llm_span_output
+from onyx.utils.headers import build_llm_extra_headers
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Forwarded verbatim to the client: these describe the request/upstream state,
+# not our credential. Everything else (401/403 describe OUR credential; other
+# 5xx are opaque) is sanitized.
+_FORWARDABLE_STATUSES = {400, 404, 413, 429, 529}
+
+# Client-supplied anthropic-beta values we forward; anything else is silently
+# dropped rather than passed through to a provider we don't control.
+_ANTHROPIC_BETA_PREFIX_ALLOWLIST = (
+    "interleaved-thinking",
+    "fine-grained-tool-streaming",
+    "prompt-caching",
+    "extended-cache-ttl",
+    "token-efficient-tools",
+    "context-management",
+    "output-",
+    "claude-code",
+)
+
+_SANITIZED_ERROR = ("The upstream LLM request failed.", "api_error")
+_TIMEOUT_ERROR = ("The selected model did not respond in time.", "api_error")
+
+
+class AnthropicPassthroughUnavailable(Exception):
+    """Raised when the passthrough transport itself fails (connect/read
+    timeout, DNS, etc.), distinct from the upstream returning an error
+    response. Callers may degrade to a local approximation instead of
+    failing the request outright (see the count_tokens fallback)."""
+
+
+def is_anthropic_passthrough_eligible(provider: LLMProviderView) -> bool:
+    # v1 is direct-Anthropic only; bedrock/vertex are phase 2.
+    return ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED and provider.provider == "anthropic"
+
+
+def _base_url(provider: LLMProviderView) -> str:
+    return (provider.api_base or "https://api.anthropic.com").rstrip("/")
+
+
+def _messages_url(provider: LLMProviderView) -> str:
+    return _base_url(provider) + "/v1/messages"
+
+
+def _count_tokens_url(provider: LLMProviderView) -> str:
+    return _base_url(provider) + "/v1/messages/count_tokens"
+
+
+def _timeout() -> httpx.Timeout:
+    return httpx.Timeout(
+        ANTHROPIC_PASSTHROUGH_READ_TIMEOUT_SECONDS,
+        connect=ANTHROPIC_PASSTHROUGH_CONNECT_TIMEOUT_SECONDS,
+    )
+
+
+def _build_upstream_request(
+    request: AnthropicMessagesRequest | AnthropicCountTokensRequest,
+    model_name: str,
+    user_id: str,
+    stream: bool | None,
+) -> dict[str, Any]:
+    # exclude_unset + extra="allow" means tolerated-unknown client fields
+    # forward verbatim.
+    body = request.model_dump(exclude_unset=True)
+    if "mcp_servers" in body:
+        # mcp_servers instructs Anthropic's own servers to connect to
+        # arbitrary URLs under our account; refuse rather than forward.
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "mcp_servers is not supported by the Onyx gateway.",
+        )
+    body["model"] = model_name
+    if stream is not None:
+        # Always overwrite: opaque provider-side abuse attribution, never a
+        # client-supplied identifier.
+        body["metadata"] = {"user_id": hashlib.sha256(user_id.encode()).hexdigest()}
+        body["stream"] = stream
+    else:
+        # count_tokens rejects metadata/stream/max_tokens outright.
+        body.pop("metadata", None)
+        body.pop("stream", None)
+        body.pop("max_tokens", None)
+    return body
+
+
+def _build_upstream_headers(
+    provider: LLMProviderView, http_request: Request
+) -> dict[str, str]:
+    # Fresh dict only — never copy client headers wholesale; the inbound
+    # Authorization header is an Onyx PAT, not an Anthropic key.
+    if not provider.api_key:
+        raise OnyxError(
+            OnyxErrorCode.BAD_GATEWAY,
+            "The selected provider has no credential configured.",
+        )
+    # Server-configured proxy/routing headers (LITELLM_EXTRA_HEADERS) that the
+    # translation path sends on every provider call; the passthrough's own
+    # entries below always win on collision.
+    headers = build_llm_extra_headers()
+    headers.update(
+        {
+            "x-api-key": provider.api_key,
+            "content-type": "application/json",
+            "anthropic-version": http_request.headers.get(
+                "anthropic-version", "2023-06-01"
+            ),
+        }
+    )
+    beta_raw = http_request.headers.get("anthropic-beta")
+    if beta_raw:
+        entries = [entry.strip() for entry in beta_raw.split(",") if entry.strip()]
+        allowed = [e for e in entries if e.startswith(_ANTHROPIC_BETA_PREFIX_ALLOWLIST)]
+        dropped = [e for e in entries if e not in allowed]
+        if dropped:
+            logger.debug(
+                "Anthropic passthrough dropped anthropic-beta entries: %s", dropped
+            )
+        if allowed:
+            headers["anthropic-beta"] = ",".join(allowed)
+    return headers
+
+
+def _usage_from_anthropic_wire(usage: dict[str, Any]) -> Usage:
+    # Exact inverse of AnthropicUsagePayload.from_usage: the ledger assumes
+    # LiteLLM-normalized accounting, where prompt_tokens INCLUDES cache
+    # tokens, while Anthropic's own input_tokens excludes both.
+    input_tokens = usage.get("input_tokens") or 0
+    cache_read = usage.get("cache_read_input_tokens") or 0
+    cache_creation = usage.get("cache_creation_input_tokens") or 0
+    output_tokens = usage.get("output_tokens") or 0
+    prompt_tokens = input_tokens + cache_read + cache_creation
+    return Usage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=output_tokens,
+        total_tokens=prompt_tokens + output_tokens,
+        cache_creation_input_tokens=cache_creation,
+        cache_read_input_tokens=cache_read,
+    )
+
+
+def _error_type_and_message(body: bytes) -> tuple[str, str]:
+    try:
+        parsed = json.loads(body)
+    except (json.JSONDecodeError, TypeError, UnicodeDecodeError):
+        return "api_error", "Upstream returned a non-JSON error."
+    error = parsed.get("error") if isinstance(parsed, dict) else None
+    if isinstance(error, dict):
+        return (
+            str(error.get("type") or "api_error"),
+            str(error.get("message") or "Upstream error."),
+        )
+    return "api_error", "Upstream error."
+
+
+def _non_streaming_error_response(response: httpx.Response) -> JSONResponse:
+    if response.status_code in _FORWARDABLE_STATUSES:
+        try:
+            content = response.json()
+        except ValueError:
+            content = {"error": {"type": "api_error", "message": response.text[:2000]}}
+        return JSONResponse(status_code=response.status_code, content=content)
+    logger.warning(
+        "Anthropic passthrough upstream error (sanitized): status=%s",
+        response.status_code,
+    )
+    message, _ = _SANITIZED_ERROR
+    raise OnyxError(OnyxErrorCode.BAD_GATEWAY, message)
+
+
+def _streaming_error_event(status_code: int, body: bytes) -> AnthropicErrorEvent:
+    if status_code in _FORWARDABLE_STATUSES:
+        error_type, message = _error_type_and_message(body)
+        return AnthropicErrorEvent.create(message=message, error_type=error_type)
+    logger.warning(
+        "Anthropic passthrough upstream stream error (sanitized): status=%s",
+        status_code,
+    )
+    message, error_type = _SANITIZED_ERROR
+    return AnthropicErrorEvent.create(message=message, error_type=error_type)
+
+
+def _gateway_trace(flow: LLMFlow, model: str) -> Trace:
+    return trace("llm_gateway", metadata={"flow": flow.value, "model": model})
+
+
+def handle_anthropic_passthrough(
+    request: AnthropicMessagesRequest,
+    provider: LLMProviderView,
+    model_config: ModelConfigurationView,
+    flow: LLMFlow,
+    http_request: Request,
+    user: User,
+) -> JSONResponse | StreamingResponse:
+    body = _build_upstream_request(
+        request, model_config.name, str(user.id), request.stream
+    )
+    headers = _build_upstream_headers(provider, http_request)
+    url = _messages_url(provider)
+    # llm is built only for tracing config (model/provider metadata); the
+    # actual call goes straight over httpx, never through llm.invoke/stream.
+    llm = llm_from_provider(model_name=model_config.name, llm_provider=provider)
+
+    if request.stream:
+        return _sse_response(
+            _passthrough_stream_worker,
+            {
+                "url": url,
+                "headers": headers,
+                "body": body,
+                "llm": llm,
+                "flow": flow,
+                "input_messages": request.messages,
+                "tools": request.tools,
+                "model": request.model,
+            },
+        )
+
+    with (
+        _gateway_trace(flow, llm.config.model_name),
+        llm_generation_span(
+            llm, flow=flow, input_messages=request.messages, tools=request.tools
+        ) as span,
+    ):
+        try:
+            with httpx.Client(timeout=_timeout()) as client:
+                response = client.post(url, json=body, headers=headers)
+        except httpx.TimeoutException as e:
+            if span is not None:
+                span.set_error({"message": f"{type(e).__name__}: {e}", "data": None})
+            logger.warning(
+                "Anthropic passthrough request timed out for model %s", request.model
+            )
+            raise OnyxError(OnyxErrorCode.BAD_GATEWAY, _TIMEOUT_ERROR[0]) from e
+        except httpx.HTTPError as e:
+            if span is not None:
+                span.set_error({"message": f"{type(e).__name__}: {e}", "data": None})
+            # Exception repr carries the request URL, which for custom
+            # api_base values can embed query credentials; log the type only.
+            logger.warning(
+                "Anthropic passthrough transport error for model %s: %s",
+                request.model,
+                type(e).__name__,
+            )
+            raise OnyxError(OnyxErrorCode.BAD_GATEWAY, _SANITIZED_ERROR[0]) from e
+
+        if response.status_code != 200:
+            if span is not None:
+                span.set_error(
+                    {
+                        "message": f"upstream status {response.status_code}",
+                        "data": None,
+                    }
+                )
+            return _non_streaming_error_response(response)
+
+        response_body = response.json()
+        usage = response_body.get("usage")
+        content_blocks = response_body.get("content") or []
+        text = "\n\n".join(
+            block.get("text", "")
+            for block in content_blocks
+            if isinstance(block, dict) and block.get("type") == "text"
+        )
+        converted_usage = _usage_from_anthropic_wire(usage) if usage else None
+        if converted_usage is not None and isinstance(llm, LitellmLLM):
+            # Managed-key cost accounting normally happens inside
+            # LLM.invoke/stream, which this path bypasses.
+            llm._track_llm_cost(converted_usage)
+        if span is not None:
+            record_llm_span_output(
+                span,
+                output=text or None,
+                usage=converted_usage,
+                reasoning=None,
+                tool_calls=None,
+            )
+            server_tool_use = (usage or {}).get("server_tool_use")
+            if server_tool_use:
+                # No dedicated Usage slot for per-search pricing (that's the
+                # cost-tracking project); attach it to model_config so it is
+                # at least visible in traces.
+                span.span_data.model_config = {
+                    **(span.span_data.model_config or {}),
+                    "server_tool_use": server_tool_use,
+                }
+
+    # Forward Anthropic's own response verbatim, including its own id.
+    return JSONResponse(content=response_body)
+
+
+def _passthrough_stream_worker(
+    url: str,
+    headers: dict[str, str],
+    body: dict[str, Any],
+    llm: LLM,
+    flow: LLMFlow,
+    input_messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None,
+    model: str,
+    out: "queue.Queue[Any]",
+    cancelled: threading.Event,
+) -> None:
+    def emit(event: AnthropicErrorEvent) -> bool:
+        payload = event.to_wire()
+        return _put_stream_item(
+            out, f"event: {payload['type']}\ndata: {json.dumps(payload)}\n\n", cancelled
+        )
+
+    def emit_error(*, message: str, error_type: str) -> None:
+        emit(AnthropicErrorEvent.create(message=message, error_type=error_type))
+
+    # Runs on its own thread after the endpoint has returned the
+    # StreamingResponse, so the trace must be opened here rather than in the
+    # endpoint for the generation span to see an active trace.
+    with (
+        _gateway_trace(flow, llm.config.model_name),
+        llm_generation_span(
+            llm, flow=flow, input_messages=input_messages, tools=tools
+        ) as span,
+    ):
+        state = _StreamAccumulator()
+        with _stream_worker_guard(
+            span,
+            model,
+            state,
+            label="anthropic passthrough stream",
+            emit_error=emit_error,
+            out=out,
+            cancelled=cancelled,
+        ):
+            # ExitStack becomes state.upstream so the guard's finally can
+            # close both the response and the client via one .close() call.
+            stack = ExitStack()
+            state.upstream = stack
+            client = stack.enter_context(httpx.Client(timeout=_timeout()))
+            response = stack.enter_context(
+                client.stream("POST", url, json=body, headers=headers)
+            )
+            # A disconnected client only sets `cancelled`; a blocking
+            # iter_lines() read would otherwise hold the worker thread and the
+            # upstream request until the next SSE line or the read timeout.
+            # Closing the stack from a watchdog raises in the reader
+            # immediately; ExitStack.close is idempotent w.r.t. the guard's
+            # own teardown.
+            threading.Thread(
+                target=lambda: (cancelled.wait(), stack.close()),
+                name="anthropic-passthrough-cancel-watchdog",
+                daemon=True,
+            ).start()
+
+            if response.status_code != 200:
+                response.read()
+                error_type, message = _error_type_and_message(response.content)
+                if response.status_code not in _FORWARDABLE_STATUSES:
+                    logger.warning(
+                        "Anthropic passthrough upstream stream error (sanitized): "
+                        "status=%s",
+                        response.status_code,
+                    )
+                    message, error_type = _SANITIZED_ERROR
+                if span is not None:
+                    span.set_error(
+                        {
+                            "message": f"upstream status {response.status_code}",
+                            "data": None,
+                        }
+                    )
+                emit_error(message=message, error_type=error_type)
+                return
+
+            usage_parts: dict[str, Any] = {}
+            frame_lines: list[str] = []
+            for line in response.iter_lines():
+                if cancelled.is_set():
+                    break
+                if line == "":
+                    if frame_lines:
+                        frame_text = "\n".join(frame_lines)
+                        frame_lines = []
+                        if not _put_stream_item(out, frame_text + "\n\n", cancelled):
+                            break
+                    continue
+                frame_lines.append(line)
+                if not line.startswith("data: "):
+                    continue
+                raw_data = line[len("data: ") :]
+                try:
+                    event = json.loads(raw_data)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "Anthropic passthrough: unparsable SSE data line, "
+                        "forwarding verbatim"
+                    )
+                    continue
+                event_type = event.get("type")
+                if event_type == "content_block_delta":
+                    delta = event.get("delta") or {}
+                    if delta.get("type") == "text_delta":
+                        state.content.append(delta.get("text", ""))
+                elif event_type == "message_start":
+                    message_usage = (event.get("message") or {}).get("usage")
+                    if isinstance(message_usage, dict):
+                        usage_parts.update(message_usage)
+                elif event_type == "message_delta":
+                    delta_usage = event.get("usage")
+                    if isinstance(delta_usage, dict):
+                        server_tool_use = delta_usage.get("server_tool_use")
+                        if server_tool_use and span is not None:
+                            # No dedicated Usage slot for per-search pricing
+                            # (that's the cost-tracking project); attach it to
+                            # model_config so it is at least visible in traces.
+                            span.span_data.model_config = {
+                                **(span.span_data.model_config or {}),
+                                "server_tool_use": server_tool_use,
+                            }
+                        usage_parts.update(delta_usage)
+                if event_type in ("message_start", "message_delta") and usage_parts:
+                    state.usage = _usage_from_anthropic_wire(usage_parts)
+            if frame_lines and not cancelled.is_set():
+                _put_stream_item(out, "\n".join(frame_lines) + "\n\n", cancelled)
+            # Managed-key cost accounting normally happens inside
+            # LLM.invoke/stream, which this path bypasses.
+            if state.usage is not None and isinstance(llm, LitellmLLM):
+                llm._track_llm_cost(state.usage)
+
+
+def handle_anthropic_count_tokens_passthrough(
+    request: AnthropicCountTokensRequest,
+    provider: LLMProviderView,
+    model_config: ModelConfigurationView,
+    http_request: Request,
+    user: User,
+) -> JSONResponse:
+    body = _build_upstream_request(request, model_config.name, str(user.id), None)
+    headers = _build_upstream_headers(provider, http_request)
+    url = _count_tokens_url(provider)
+    try:
+        with httpx.Client(timeout=_timeout()) as client:
+            response = client.post(url, json=body, headers=headers)
+    except httpx.HTTPError as e:
+        # Transport failure, not an upstream error response: let the caller
+        # degrade to its local token estimate instead of failing the request.
+        logger.warning(
+            "Anthropic passthrough count_tokens transport error for model %s: %s",
+            request.model,
+            type(e).__name__,
+        )
+        raise AnthropicPassthroughUnavailable() from e
+
+    if response.status_code != 200:
+        return _non_streaming_error_response(response)
+    return JSONResponse(content=response.json())

--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -3,11 +3,10 @@ import queue
 import threading
 import time
 import uuid
-from collections.abc import Callable, Iterator
-from contextlib import closing, contextmanager
+from contextlib import closing
 from functools import partial
 from itertools import count
-from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, cast
 
 from fastapi import APIRouter, Depends, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -26,12 +25,7 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.llm.factory import llm_from_provider
 from onyx.llm.interfaces import LLM
-from onyx.llm.model_response import (
-    ChatCompletionDeltaToolCall,
-    ChatCompletionMessageToolCall,
-    ModelResponseStream,
-    Usage,
-)
+from onyx.llm.model_response import ChatCompletionMessageToolCall
 from onyx.llm.models import (
     AnyThinkingBlock,
     AssistantMessage,
@@ -48,8 +42,14 @@ from onyx.llm.models import (
 )
 from onyx.llm.multi_llm import LLMRateLimitError, LLMTimeoutError
 from onyx.llm.prompt_cache.processor import process_with_prompt_cache
-from onyx.llm.tracing_wrap import _finalize_tool_calls, _merge_tool_call_delta
+from onyx.llm.tracing_wrap import _finalize_tool_calls
 from onyx.server.features.build.craft_gateway import gateway_request_flow
+from onyx.server.gateway.anthropic_passthrough import (
+    AnthropicPassthroughUnavailable,
+    handle_anthropic_count_tokens_passthrough,
+    handle_anthropic_passthrough,
+    is_anthropic_passthrough_eligible,
+)
 from onyx.server.gateway.configs import GATEWAY_PATH_PREFIX
 from onyx.server.gateway.model_catalog import build_gateway_model_catalog
 from onyx.server.gateway.models import (
@@ -98,20 +98,20 @@ from onyx.server.gateway.models import (
     ResponsesOutputTextPart,
     ResponsesRequest,
 )
+from onyx.server.gateway.stream_bridge import (
+    _RATE_LIMIT_ERROR,
+    _put_stream_item,
+    _sse_response,
+    _stream_worker_guard,
+    _StreamAccumulator,
+)
 from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
 from onyx.server.query_and_chat.token_limit import check_token_rate_limits
 from onyx.tracing.flows import LLMFlow
 from onyx.tracing.framework.create import trace
-from onyx.tracing.framework.span_data import GenerationSpanData
-from onyx.tracing.framework.spans import Span
 from onyx.tracing.framework.traces import Trace
-from onyx.tracing.llm_utils import (
-    llm_generation_span,
-    record_llm_response,
-    record_llm_span_output,
-)
+from onyx.tracing.llm_utils import llm_generation_span, record_llm_response
 from onyx.utils.logger import setup_logger
-from onyx.utils.threadpool_concurrency import start_thread_with_context
 
 if TYPE_CHECKING:
     from litellm.types.llms.anthropic import (
@@ -286,30 +286,6 @@ def _parse_tool_choice(raw: Any) -> ToolChoice | None:
     )
 
 
-_STREAM_END = object()
-
-
-@runtime_checkable
-class _ClosableStream(Protocol):
-    """LLM.stream is declared Iterator, which carries no close(); every real
-    implementation is a generator, and an abandoned one must be closed so the
-    provider connection is released."""
-
-    def close(self) -> None: ...
-
-
-def _put_stream_item(
-    out: "queue.Queue[Any]", item: Any, cancelled: threading.Event
-) -> bool:
-    while not cancelled.is_set():
-        try:
-            out.put(item, timeout=0.1)
-            return True
-        except queue.Full:
-            continue
-    return False
-
-
 def _emit_stream_error(
     out: "queue.Queue[Any]",
     cancelled: threading.Event,
@@ -320,88 +296,6 @@ def _emit_stream_error(
     error_payload = {"error": {"message": message, "type": error_type}}
     _put_stream_item(out, f"data: {json.dumps(error_payload)}\n\n", cancelled)
     _put_stream_item(out, "data: [DONE]\n\n", cancelled)
-
-
-class _StreamAccumulator:
-    def __init__(self) -> None:
-        self.content: list[str] = []
-        self.reasoning: list[str] = []
-        self.usage: Usage | None = None
-        self.tool_call_buffer: dict[int, ChatCompletionDeltaToolCall] = {}
-        self.upstream: Iterator[ModelResponseStream] | None = None
-
-    def observe(self, chunk: ModelResponseStream) -> None:
-        if chunk.usage:
-            self.usage = chunk.usage
-        if chunk.choice.delta.content:
-            self.content.append(chunk.choice.delta.content)
-        if chunk.choice.delta.reasoning_content:
-            self.reasoning.append(chunk.choice.delta.reasoning_content)
-        for delta_tc in chunk.choice.delta.tool_calls:
-            _merge_tool_call_delta(self.tool_call_buffer, delta_tc)
-
-    @property
-    def text(self) -> str:
-        return "".join(self.content)
-
-
-_RATE_LIMIT_ERROR = (
-    "The selected model is temporarily rate limited.",
-    "rate_limit_error",
-)
-_TIMEOUT_ERROR = ("The selected model did not respond in time.", "timeout_error")
-_UPSTREAM_ERROR = ("The upstream LLM request failed.", "upstream_error")
-
-
-@contextmanager
-def _stream_worker_guard(
-    span: Span[GenerationSpanData] | None,
-    model: str,
-    state: _StreamAccumulator,
-    *,
-    label: str,
-    emit_error: Callable[..., None],
-    out: "queue.Queue[Any]",
-    cancelled: threading.Event,
-) -> Iterator[None]:
-    """The HTTP status is already sent by the time a worker runs, so upstream
-    failures surface in-band as a protocol error frame rather than raising."""
-    try:
-        yield
-    except Exception as exc:
-        if isinstance(exc, LLMRateLimitError):
-            message, error_type = _RATE_LIMIT_ERROR
-        elif isinstance(exc, LLMTimeoutError):
-            message, error_type = _TIMEOUT_ERROR
-        else:
-            message, error_type = _UPSTREAM_ERROR
-        if span is not None:
-            span.set_error({"message": f"{type(exc).__name__}: {exc}", "data": None})
-        logger.exception(
-            "LLM gateway %s failed (%s) for model %s", label, error_type, model
-        )
-        emit_error(message=message, error_type=error_type)
-    finally:
-        try:
-            if isinstance(state.upstream, _ClosableStream):
-                state.upstream.close()
-        except Exception:
-            logger.exception("LLM gateway %s cleanup failed for model %s", label, model)
-        try:
-            if span is not None:
-                record_llm_span_output(
-                    span,
-                    output=state.text or None,
-                    usage=state.usage,
-                    reasoning="".join(state.reasoning) or None,
-                    tool_calls=_finalize_tool_calls(state.tool_call_buffer),
-                )
-        except Exception:
-            logger.exception(
-                "LLM gateway %s span cleanup failed for model %s", label, model
-            )
-        finally:
-            _put_stream_item(out, _STREAM_END, cancelled)
 
 
 def _stream_worker(
@@ -459,52 +353,6 @@ def _stream_worker(
                     break
             else:
                 _put_stream_item(out, "data: [DONE]\n\n", cancelled)
-
-
-def _run_bridged_stream(
-    worker: Callable[..., None], worker_kwargs: dict[str, Any]
-) -> Iterator[str]:
-    """Bridge a stream worker through a queue so the whole consumption —
-    including the generation span's ContextVar enter/exit — happens on ONE
-    thread. Yielding directly from a sync generator breaks under Starlette,
-    which resumes the generator on varying threadpool threads (ContextVar
-    tokens can't be reset across contexts)."""
-    out: "queue.Queue[Any]" = queue.Queue(maxsize=256)
-    cancelled = threading.Event()
-    worker_thread = start_thread_with_context(
-        worker,
-        name="llm-gateway-stream",
-        daemon=True,
-        kwargs={**worker_kwargs, "out": out, "cancelled": cancelled},
-    )
-    try:
-        while True:
-            if worker_thread.is_alive():
-                try:
-                    item = out.get(timeout=0.5)
-                except queue.Empty:
-                    continue
-            else:
-                # Worker died before signalling: drain, or the stream truncates.
-                try:
-                    item = out.get_nowait()
-                except queue.Empty:
-                    return
-            if item is _STREAM_END:
-                return
-            yield item
-    finally:
-        cancelled.set()
-
-
-def _sse_response(
-    worker: Callable[..., None], worker_kwargs: dict[str, Any]
-) -> StreamingResponse:
-    return StreamingResponse(
-        _run_bridged_stream(worker, worker_kwargs),
-        media_type="text/event-stream",
-        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
-    )
 
 
 def handle_chat_completion(
@@ -1606,6 +1454,15 @@ def gateway_anthropic_messages(
     check_token_rate_limits(user)
     with closing(db_session):
         provider, model_config = resolve_gateway_model(db_session, user, request.model)
+    if is_anthropic_passthrough_eligible(provider):
+        return handle_anthropic_passthrough(
+            request=request,
+            provider=provider,
+            model_config=model_config,
+            flow=flow,
+            http_request=http_request,
+            user=user,
+        )
     result = handle_anthropic_messages(
         request=request,
         provider=provider,
@@ -1629,7 +1486,22 @@ def gateway_anthropic_count_tokens(
     # No token rate limit check: nothing is generated by this endpoint.
     _authorize_gateway_request(http_request, user)
     with closing(db_session):
-        _provider, model_config = resolve_gateway_model(db_session, user, request.model)
+        provider, model_config = resolve_gateway_model(db_session, user, request.model)
+    if is_anthropic_passthrough_eligible(provider):
+        try:
+            return handle_anthropic_count_tokens_passthrough(
+                request=request,
+                provider=provider,
+                model_config=model_config,
+                http_request=http_request,
+                user=user,
+            )
+        except AnthropicPassthroughUnavailable:
+            logger.warning(
+                "Anthropic passthrough count_tokens unavailable for model %s; "
+                "falling back to the local estimate",
+                request.model,
+            )
     raw_messages = _anthropic_messages_to_raw_messages(request.messages, request.system)
     tools = _anthropic_tools(request.tools)
     from onyx.llm.litellm_singleton import litellm

--- a/backend/onyx/server/gateway/configs.py
+++ b/backend/onyx/server/gateway/configs.py
@@ -1,1 +1,11 @@
+import os
+
 GATEWAY_PATH_PREFIX = "/gateway"
+
+# Kill switch, default ON: set to "false" to send Anthropic-backed providers
+# back through the translation path (losing server tools / thinking fidelity).
+ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED = (
+    os.environ.get("ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED", "").lower() != "false"
+)
+ANTHROPIC_PASSTHROUGH_CONNECT_TIMEOUT_SECONDS = 10
+ANTHROPIC_PASSTHROUGH_READ_TIMEOUT_SECONDS = 600

--- a/backend/onyx/server/gateway/stream_bridge.py
+++ b/backend/onyx/server/gateway/stream_bridge.py
@@ -1,0 +1,183 @@
+"""Shared SSE-over-thread streaming primitives for the LLM gateway.
+
+Moved verbatim out of ``onyx.server.gateway.api`` so both the translation
+path (api.py) and the Anthropic native passthrough path
+(anthropic_passthrough.py) can share them without a circular import.
+"""
+
+import queue
+import threading
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import Any, Protocol, runtime_checkable
+
+from fastapi.responses import StreamingResponse
+
+from onyx.llm.model_response import (
+    ChatCompletionDeltaToolCall,
+    ModelResponseStream,
+    Usage,
+)
+from onyx.llm.multi_llm import LLMRateLimitError, LLMTimeoutError
+from onyx.llm.tracing_wrap import _finalize_tool_calls, _merge_tool_call_delta
+from onyx.tracing.framework.span_data import GenerationSpanData
+from onyx.tracing.framework.spans import Span
+from onyx.tracing.llm_utils import record_llm_span_output
+from onyx.utils.logger import setup_logger
+from onyx.utils.threadpool_concurrency import start_thread_with_context
+
+logger = setup_logger()
+
+_STREAM_END = object()
+
+
+@runtime_checkable
+class _ClosableStream(Protocol):
+    """LLM.stream is declared Iterator, which carries no close(); every real
+    implementation is a generator, and an abandoned one must be closed so the
+    provider connection is released."""
+
+    def close(self) -> None: ...
+
+
+def _put_stream_item(
+    out: "queue.Queue[Any]", item: Any, cancelled: threading.Event
+) -> bool:
+    while not cancelled.is_set():
+        try:
+            out.put(item, timeout=0.1)
+            return True
+        except queue.Full:
+            continue
+    return False
+
+
+class _StreamAccumulator:
+    def __init__(self) -> None:
+        self.content: list[str] = []
+        self.reasoning: list[str] = []
+        self.usage: Usage | None = None
+        self.tool_call_buffer: dict[int, ChatCompletionDeltaToolCall] = {}
+        # Iterator[ModelResponseStream] for LLM.stream(); an ExitStack for the
+        # Anthropic passthrough, which must close both the httpx response and
+        # client. Only the presence of .close() (_ClosableStream) is relied on.
+        self.upstream: Iterator[ModelResponseStream] | _ClosableStream | None = None
+
+    def observe(self, chunk: ModelResponseStream) -> None:
+        if chunk.usage:
+            self.usage = chunk.usage
+        if chunk.choice.delta.content:
+            self.content.append(chunk.choice.delta.content)
+        if chunk.choice.delta.reasoning_content:
+            self.reasoning.append(chunk.choice.delta.reasoning_content)
+        for delta_tc in chunk.choice.delta.tool_calls:
+            _merge_tool_call_delta(self.tool_call_buffer, delta_tc)
+
+    @property
+    def text(self) -> str:
+        return "".join(self.content)
+
+
+_RATE_LIMIT_ERROR = (
+    "The selected model is temporarily rate limited.",
+    "rate_limit_error",
+)
+_TIMEOUT_ERROR = ("The selected model did not respond in time.", "timeout_error")
+_UPSTREAM_ERROR = ("The upstream LLM request failed.", "upstream_error")
+
+
+@contextmanager
+def _stream_worker_guard(
+    span: Span[GenerationSpanData] | None,
+    model: str,
+    state: _StreamAccumulator,
+    *,
+    label: str,
+    emit_error: Callable[..., None],
+    out: "queue.Queue[Any]",
+    cancelled: threading.Event,
+) -> Iterator[None]:
+    """The HTTP status is already sent by the time a worker runs, so upstream
+    failures surface in-band as a protocol error frame rather than raising."""
+    try:
+        yield
+    except Exception as exc:
+        if isinstance(exc, LLMRateLimitError):
+            message, error_type = _RATE_LIMIT_ERROR
+        elif isinstance(exc, LLMTimeoutError):
+            message, error_type = _TIMEOUT_ERROR
+        else:
+            message, error_type = _UPSTREAM_ERROR
+        if span is not None:
+            span.set_error({"message": f"{type(exc).__name__}: {exc}", "data": None})
+        logger.exception(
+            "LLM gateway %s failed (%s) for model %s", label, error_type, model
+        )
+        emit_error(message=message, error_type=error_type)
+    finally:
+        try:
+            if isinstance(state.upstream, _ClosableStream):
+                state.upstream.close()
+        except Exception:
+            logger.exception("LLM gateway %s cleanup failed for model %s", label, model)
+        try:
+            if span is not None:
+                record_llm_span_output(
+                    span,
+                    output=state.text or None,
+                    usage=state.usage,
+                    reasoning="".join(state.reasoning) or None,
+                    tool_calls=_finalize_tool_calls(state.tool_call_buffer),
+                )
+        except Exception:
+            logger.exception(
+                "LLM gateway %s span cleanup failed for model %s", label, model
+            )
+        finally:
+            _put_stream_item(out, _STREAM_END, cancelled)
+
+
+def _run_bridged_stream(
+    worker: Callable[..., None], worker_kwargs: dict[str, Any]
+) -> Iterator[str]:
+    """Bridge a stream worker through a queue so the whole consumption —
+    including the generation span's ContextVar enter/exit — happens on ONE
+    thread. Yielding directly from a sync generator breaks under Starlette,
+    which resumes the generator on varying threadpool threads (ContextVar
+    tokens can't be reset across contexts)."""
+    out: "queue.Queue[Any]" = queue.Queue(maxsize=256)
+    cancelled = threading.Event()
+    worker_thread = start_thread_with_context(
+        worker,
+        name="llm-gateway-stream",
+        daemon=True,
+        kwargs={**worker_kwargs, "out": out, "cancelled": cancelled},
+    )
+    try:
+        while True:
+            if worker_thread.is_alive():
+                try:
+                    item = out.get(timeout=0.5)
+                except queue.Empty:
+                    continue
+            else:
+                # Worker died before signalling: drain, or the stream truncates.
+                try:
+                    item = out.get_nowait()
+                except queue.Empty:
+                    return
+            if item is _STREAM_END:
+                return
+            yield item
+    finally:
+        cancelled.set()
+
+
+def _sse_response(
+    worker: Callable[..., None], worker_kwargs: dict[str, Any]
+) -> StreamingResponse:
+    return StreamingResponse(
+        _run_bridged_stream(worker, worker_kwargs),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/backend/tests/unit/onyx/server/gateway/test_anthropic_messages_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_anthropic_messages_api.py
@@ -40,6 +40,7 @@ from onyx.llm.models import (
 )
 from onyx.llm.multi_llm import LLMRateLimitError, LLMTimeoutError
 from onyx.server.gateway import api as gateway_api
+from onyx.server.gateway import stream_bridge
 from onyx.server.gateway.api import _MESSAGES_ADAPTER
 from onyx.server.gateway.models import (
     AnthropicCountTokensRequest,
@@ -542,7 +543,7 @@ def _anthropic_stream_events(
 ) -> list[dict[str, Any]]:
     with patch.object(gateway_api, "llm_generation_span", return_value=nullcontext()):
         frames = list(
-            gateway_api._run_bridged_stream(
+            stream_bridge._run_bridged_stream(
                 gateway_api._anthropic_stream_worker,
                 {
                     "llm": llm,
@@ -782,6 +783,9 @@ def test_anthropic_messages_endpoint_threads_authorized_flow_to_handler() -> Non
             gateway_api,
             "resolve_gateway_model",
             return_value=(provider, model_config),
+        ),
+        patch.object(
+            gateway_api, "is_anthropic_passthrough_eligible", return_value=False
         ),
         patch.object(gateway_api, "handle_anthropic_messages") as handle,
     ):

--- a/backend/tests/unit/onyx/server/gateway/test_anthropic_passthrough.py
+++ b/backend/tests/unit/onyx/server/gateway/test_anthropic_passthrough.py
@@ -1,0 +1,1000 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from contextlib import contextmanager, nullcontext
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.llm.interfaces import LLMConfig
+from onyx.server.gateway import anthropic_passthrough, stream_bridge
+from onyx.server.gateway import api as gateway_api
+from onyx.server.gateway.anthropic_passthrough import (
+    AnthropicPassthroughUnavailable,
+    _build_upstream_headers,
+    _build_upstream_request,
+    _non_streaming_error_response,
+    _streaming_error_event,
+    _usage_from_anthropic_wire,
+    handle_anthropic_count_tokens_passthrough,
+    handle_anthropic_passthrough,
+    is_anthropic_passthrough_eligible,
+)
+from onyx.server.gateway.models import (
+    AnthropicCountTokensRequest,
+    AnthropicMessagesRequest,
+    AnthropicUsagePayload,
+)
+from onyx.tracing.flows import LLMFlow
+from tests.unit.onyx.server.gateway.test_llm_gateway_api import (
+    _ConfigOnlyLLM,
+    _model,
+    _provider,
+)
+
+
+def _anthropic_llm() -> _ConfigOnlyLLM:
+    return _ConfigOnlyLLM(
+        LLMConfig(
+            model_provider="anthropic",
+            model_name="claude-sonnet-4-6",
+            temperature=0,
+            max_input_tokens=1_000,
+        )
+    )
+
+
+def _fake_httpx_module(client_factory: Any) -> MagicMock:
+    """A stand-in for the ``httpx`` module reference held by
+    anthropic_passthrough, preserving the real exception/Timeout classes so
+    the module's own exception handling still works."""
+    return MagicMock(
+        Client=client_factory,
+        Timeout=httpx.Timeout,
+        HTTPError=httpx.HTTPError,
+        TimeoutException=httpx.TimeoutException,
+        ConnectError=httpx.ConnectError,
+    )
+
+
+def test_is_anthropic_passthrough_eligible_true_for_anthropic_provider() -> None:
+    provider = _provider(1, "anthropic", [_model("test")])
+    with patch.object(
+        anthropic_passthrough, "ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED", True
+    ):
+        assert is_anthropic_passthrough_eligible(provider) is True
+
+
+def test_is_anthropic_passthrough_eligible_false_for_openai_provider() -> None:
+    provider = _provider(1, "openai", [_model("test")])
+    with patch.object(
+        anthropic_passthrough, "ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED", True
+    ):
+        assert is_anthropic_passthrough_eligible(provider) is False
+
+
+def test_is_anthropic_passthrough_eligible_false_when_kill_switch_off() -> None:
+    provider = _provider(1, "anthropic", [_model("test")])
+    with patch.object(
+        anthropic_passthrough, "ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED", False
+    ):
+        assert is_anthropic_passthrough_eligible(provider) is False
+
+
+def test_build_upstream_request_swaps_model_name() -> None:
+    request = AnthropicMessagesRequest(
+        model="1/claude-code-alias",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=100,
+    )
+
+    body = _build_upstream_request(request, "claude-sonnet-4-6", "user-1", True)
+
+    assert body["model"] == "claude-sonnet-4-6"
+
+
+def test_build_upstream_request_always_overwrites_metadata() -> None:
+    request = AnthropicMessagesRequest(
+        model="1/test",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=100,
+        metadata={"user_id": "client-supplied-id"},
+    )
+
+    body = _build_upstream_request(request, "claude-sonnet-4-6", "user-1", True)
+
+    assert body["metadata"] == {"user_id": hashlib.sha256(b"user-1").hexdigest()}
+    assert body["metadata"]["user_id"] != "client-supplied-id"
+
+
+def test_build_upstream_request_preserves_unknown_top_level_fields() -> None:
+    request = AnthropicMessagesRequest.model_validate(
+        {
+            "model": "1/test",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+            "output_config": {"effort": "high"},
+            "container": {"id": "container_123"},
+            "future_field": {"anything": True},
+        }
+    )
+
+    body = _build_upstream_request(request, "claude-sonnet-4-6", "user-1", True)
+
+    assert body["output_config"] == {"effort": "high"}
+    assert body["container"] == {"id": "container_123"}
+    assert body["future_field"] == {"anything": True}
+
+
+def test_build_upstream_request_rejects_mcp_servers() -> None:
+    request = AnthropicMessagesRequest.model_validate(
+        {
+            "model": "1/test",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+            "mcp_servers": [{"type": "url", "url": "https://evil.example"}],
+        }
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        _build_upstream_request(request, "claude-sonnet-4-6", "user-1", True)
+
+    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
+
+
+@pytest.mark.parametrize("stream_flag", [True, False])
+def test_build_upstream_request_sets_stream_explicitly(stream_flag: bool) -> None:
+    request = AnthropicMessagesRequest(
+        model="1/test",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=100,
+        stream=stream_flag,
+    )
+
+    body = _build_upstream_request(request, "claude-sonnet-4-6", "user-1", stream_flag)
+
+    assert body["stream"] is stream_flag
+
+
+def test_build_upstream_request_count_tokens_strips_stream_and_max_tokens() -> None:
+    request = AnthropicCountTokensRequest(
+        model="1/test", messages=[{"role": "user", "content": "hi"}]
+    )
+
+    body = _build_upstream_request(request, "claude-sonnet-4-6", "user-1", None)
+
+    assert "stream" not in body
+    assert "max_tokens" not in body
+
+
+def _http_request(headers: dict[str, str]) -> Request:
+    scope = {
+        "type": "http",
+        "headers": [
+            (key.lower().encode(), value.encode()) for key, value in headers.items()
+        ],
+    }
+    return Request(scope)
+
+
+def test_build_upstream_headers_never_forwards_inbound_authorization() -> None:
+    provider = _provider(1, "anthropic", [_model("test")])
+    http_request = _http_request({"authorization": "Bearer onyx_pat_x"})
+
+    headers = _build_upstream_headers(provider, http_request)
+
+    assert not {k.lower() for k in headers} & {"authorization"}
+    assert headers["x-api-key"] == provider.api_key
+
+
+def test_build_upstream_headers_forwards_anthropic_version_when_present() -> None:
+    provider = _provider(1, "anthropic", [_model("test")])
+    http_request = _http_request({"anthropic-version": "2024-01-01"})
+
+    headers = _build_upstream_headers(provider, http_request)
+
+    assert headers["anthropic-version"] == "2024-01-01"
+
+
+def test_build_upstream_headers_defaults_anthropic_version_when_absent() -> None:
+    provider = _provider(1, "anthropic", [_model("test")])
+    http_request = _http_request({})
+
+    headers = _build_upstream_headers(provider, http_request)
+
+    assert headers["anthropic-version"] == "2023-06-01"
+
+
+def test_build_upstream_headers_filters_beta_allowlist() -> None:
+    provider = _provider(1, "anthropic", [_model("test")])
+    http_request = _http_request(
+        {
+            "anthropic-beta": (
+                "interleaved-thinking-2025-05-14,evil-beta-2026,claude-code-20250219"
+            )
+        }
+    )
+
+    headers = _build_upstream_headers(provider, http_request)
+
+    assert headers["anthropic-beta"] == (
+        "interleaved-thinking-2025-05-14,claude-code-20250219"
+    )
+
+
+def test_build_upstream_headers_omits_beta_header_when_all_dropped() -> None:
+    provider = _provider(1, "anthropic", [_model("test")])
+    http_request = _http_request({"anthropic-beta": "evil-beta-2026"})
+
+    headers = _build_upstream_headers(provider, http_request)
+
+    assert "anthropic-beta" not in headers
+
+
+def test_build_upstream_headers_merges_server_configured_extra_headers() -> None:
+    provider = _provider(1, "anthropic", [_model("test")])
+    http_request = _http_request({})
+    with patch.object(
+        anthropic_passthrough,
+        "build_llm_extra_headers",
+        return_value={"x-proxy-auth": "secret", "x-api-key": "must-lose"},
+    ):
+        headers = _build_upstream_headers(provider, http_request)
+
+    assert headers["x-proxy-auth"] == "secret"
+    assert headers["x-api-key"] == provider.api_key
+
+
+def test_build_upstream_headers_rejects_provider_without_api_key() -> None:
+    provider = _provider(1, "anthropic", [_model("test")])
+    provider.api_key = None
+    http_request = _http_request({})
+
+    with pytest.raises(OnyxError) as exc_info:
+        _build_upstream_headers(provider, http_request)
+
+    assert exc_info.value.error_code is OnyxErrorCode.BAD_GATEWAY
+
+
+def test_usage_from_anthropic_wire_round_trips_input_tokens() -> None:
+    wire_usage = {
+        "input_tokens": 100,
+        "cache_read_input_tokens": 30,
+        "cache_creation_input_tokens": 20,
+        "output_tokens": 42,
+    }
+
+    usage = _usage_from_anthropic_wire(wire_usage)
+    payload = AnthropicUsagePayload.from_usage(usage)
+
+    assert payload.input_tokens == 100
+    assert payload.output_tokens == 42
+    assert payload.cache_read_input_tokens == 30
+    assert payload.cache_creation_input_tokens == 20
+
+
+def test_usage_from_anthropic_wire_missing_keys_default_zero() -> None:
+    usage = _usage_from_anthropic_wire({})
+
+    assert usage.prompt_tokens == 0
+    assert usage.completion_tokens == 0
+    assert usage.cache_read_input_tokens == 0
+    assert usage.cache_creation_input_tokens == 0
+
+
+def test_usage_from_anthropic_wire_tolerates_none_values() -> None:
+    usage = _usage_from_anthropic_wire(
+        {
+            "input_tokens": None,
+            "cache_read_input_tokens": None,
+            "cache_creation_input_tokens": None,
+            "output_tokens": None,
+        }
+    )
+
+    assert usage.prompt_tokens == 0
+    assert usage.completion_tokens == 0
+
+
+@pytest.mark.parametrize("status_code", [400, 429, 529])
+def test_non_streaming_error_response_forwards_body_verbatim(status_code: int) -> None:
+    body = {"type": "error", "error": {"type": "overloaded_error", "message": "busy"}}
+    response = httpx.Response(status_code=status_code, json=body)
+
+    result = _non_streaming_error_response(response)
+
+    assert isinstance(result, JSONResponse)
+    assert result.status_code == status_code
+    assert json.loads(bytes(result.body)) == body
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_non_streaming_error_response_sanitizes_credential_errors(
+    status_code: int,
+) -> None:
+    response = httpx.Response(
+        status_code=status_code,
+        json={"error": {"type": "authentication_error", "message": "bad key xyz"}},
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        _non_streaming_error_response(response)
+
+    assert exc_info.value.error_code is OnyxErrorCode.BAD_GATEWAY
+    assert "bad key xyz" not in str(exc_info.value.detail)
+
+
+def test_non_streaming_error_response_wraps_non_json_forwardable_body() -> None:
+    response = httpx.Response(status_code=400, content=b"not json at all")
+
+    result = _non_streaming_error_response(response)
+
+    payload = json.loads(bytes(result.body))
+    assert payload["error"]["type"] == "api_error"
+    assert "not json at all" in payload["error"]["message"]
+
+
+def test_streaming_error_event_carries_upstream_type_and_message() -> None:
+    body = json.dumps(
+        {"error": {"type": "invalid_request_error", "message": "bad request"}}
+    ).encode()
+
+    event = _streaming_error_event(400, body)
+
+    assert event.error.type == "invalid_request_error"
+    assert event.error.message == "bad request"
+
+
+def test_streaming_error_event_sanitizes_credential_errors() -> None:
+    body = json.dumps(
+        {"error": {"type": "authentication_error", "message": "leaked-key"}}
+    ).encode()
+
+    event = _streaming_error_event(401, body)
+
+    assert event.error.type == "api_error"
+    assert "leaked-key" not in event.error.message
+
+
+_SSE_FRAMES: list[tuple[str, dict[str, Any]]] = [
+    (
+        "message_start",
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_1",
+                "usage": {
+                    "input_tokens": 100,
+                    "cache_read_input_tokens": 30,
+                    "cache_creation_input_tokens": 20,
+                    "output_tokens": 1,
+                },
+            },
+        },
+    ),
+    ("ping", {"type": "ping"}),
+    (
+        "content_block_start",
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "type": "server_tool_use",
+                "id": "srvtoolu_1",
+                "name": "web_search",
+                "input": {},
+            },
+        },
+    ),
+    (
+        "content_block_delta",
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "input_json_delta", "partial_json": '{"query":"x"}'},
+        },
+    ),
+    ("content_block_stop", {"type": "content_block_stop", "index": 0}),
+    (
+        "content_block_start",
+        {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {"type": "text", "text": ""},
+        },
+    ),
+    (
+        "content_block_delta",
+        {
+            "type": "content_block_delta",
+            "index": 1,
+            "delta": {"type": "text_delta", "text": "hi there"},
+        },
+    ),
+    ("content_block_stop", {"type": "content_block_stop", "index": 1}),
+    (
+        "message_delta",
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {"output_tokens": 42},
+        },
+    ),
+    ("message_stop", {"type": "message_stop"}),
+]
+
+
+def _sse_lines(frames: list[tuple[str, dict[str, Any]]]) -> list[str]:
+    lines: list[str] = []
+    for event_type, data in frames:
+        lines.append(f"event: {event_type}")
+        lines.append(f"data: {json.dumps(data)}")
+        lines.append("")
+    return lines
+
+
+def _expected_sse_text(frames: list[tuple[str, dict[str, Any]]]) -> str:
+    """Mirrors the worker's own framing: each frame is its lines joined by
+    ``\\n``, terminated by a blank line (``\\n\\n``)."""
+    return "".join(
+        f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+        for event_type, data in frames
+    )
+
+
+class _FakeStreamResponse:
+    def __init__(
+        self, status_code: int, lines: list[str], content: bytes = b""
+    ) -> None:
+        self.status_code = status_code
+        self._lines = lines
+        self.content = content
+        self.closed = False
+
+    def iter_lines(self) -> list[str]:
+        return self._lines
+
+    def read(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeStreamContext:
+    def __init__(self, response: _FakeStreamResponse) -> None:
+        self._response = response
+
+    def __enter__(self) -> _FakeStreamResponse:
+        return self._response
+
+    def __exit__(self, *exc_info: object) -> None:
+        self._response.close()
+
+
+class _FakeHttpxClient:
+    def __init__(self, response: _FakeStreamResponse) -> None:
+        self._response = response
+        self.closed = False
+
+    def __enter__(self) -> "_FakeHttpxClient":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self.closed = True
+
+    def stream(self, *args: object, **kwargs: object) -> _FakeStreamContext:
+        del args, kwargs
+        return _FakeStreamContext(self._response)
+
+
+_STREAM_WORKER_KWARGS = {
+    "url": "https://api.anthropic.com/v1/messages",
+    "headers": {"x-api-key": "k"},
+    "body": {"model": "claude-sonnet-4-6"},
+    "flow": LLMFlow.CRAFT_LLM_GENERATION,
+    "input_messages": [{"role": "user", "content": "hi"}],
+    "tools": None,
+    "model": "claude-sonnet-4-6",
+}
+
+
+def _run_passthrough_stream(
+    response: _FakeStreamResponse,
+    *,
+    llm_generation_span_patch: Any = None,
+) -> tuple[list[str], _FakeHttpxClient]:
+    fake_client = _FakeHttpxClient(response)
+    span_patch = llm_generation_span_patch or (lambda *a, **k: nullcontext())  # noqa: ARG005
+    with (
+        patch.object(
+            anthropic_passthrough,
+            "httpx",
+            _fake_httpx_module(MagicMock(return_value=fake_client)),
+        ),
+        patch.object(anthropic_passthrough, "llm_generation_span", span_patch),
+    ):
+        frames = list(
+            stream_bridge._run_bridged_stream(
+                anthropic_passthrough._passthrough_stream_worker,
+                {**_STREAM_WORKER_KWARGS, "llm": _anthropic_llm()},
+            )
+        )
+    return frames, fake_client
+
+
+def test_passthrough_stream_forwards_frames_byte_identical() -> None:
+    lines = _sse_lines(_SSE_FRAMES)
+    # Non-canonical (but valid) JSON must survive byte-exactly: the worker
+    # parses data lines for snooping but forwards the ORIGINAL text.
+    lines[-3:-3] = ["event: ping", 'data: { "type" :  "ping" }', ""]
+    response = _FakeStreamResponse(200, lines)
+
+    frames, _ = _run_passthrough_stream(response)
+
+    assert "".join(frames) == "".join(f"{line}\n" for line in lines)
+    assert 'data: { "type" :  "ping" }' in "".join(frames)
+    assert "server_tool_use" in "".join(frames)
+
+
+def test_passthrough_stream_forwards_malformed_data_line_verbatim() -> None:
+    lines = ["event: weird", "data: not json at all", ""]
+    response = _FakeStreamResponse(200, lines)
+
+    frames, _ = _run_passthrough_stream(response)
+
+    assert "".join(frames) == "event: weird\ndata: not json at all\n\n"
+
+
+def test_passthrough_stream_upstream_error_emits_single_error_frame() -> None:
+    error_body = json.dumps(
+        {"error": {"type": "invalid_request_error", "message": "bad request"}}
+    ).encode()
+    response = _FakeStreamResponse(400, [], content=error_body)
+
+    frames, _ = _run_passthrough_stream(response)
+
+    assert len(frames) == 1
+    assert frames[0].startswith("event: error")
+    data = json.loads(frames[0].split("data: ", 1)[1])
+    assert data["error"]["type"] == "invalid_request_error"
+    assert data["error"]["message"] == "bad request"
+
+
+def test_passthrough_stream_closes_exitstack_resources() -> None:
+    lines = _sse_lines(_SSE_FRAMES)
+    response = _FakeStreamResponse(200, lines)
+
+    _frames, fake_client = _run_passthrough_stream(response)
+
+    assert fake_client.closed is True
+    assert response.closed is True
+
+
+def test_passthrough_stream_records_usage_on_span() -> None:
+    lines = _sse_lines(_SSE_FRAMES)
+    response = _FakeStreamResponse(200, lines)
+    mock_span = MagicMock()
+
+    @contextmanager
+    def _span_ctx(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        del args, kwargs
+        yield mock_span
+
+    with patch.object(stream_bridge, "record_llm_span_output") as record_output:
+        _run_passthrough_stream(response, llm_generation_span_patch=_span_ctx)
+
+    record_output.assert_called_once()
+    usage = record_output.call_args.kwargs["usage"]
+    assert usage.prompt_tokens == 150
+    assert usage.completion_tokens == 42
+
+
+_UPSTREAM_MESSAGE: dict[str, Any] = {
+    "id": "msg_upstream_abc123",
+    "type": "message",
+    "role": "assistant",
+    "model": "claude-sonnet-4-6",
+    "content": [
+        {
+            "type": "server_tool_use",
+            "id": "srvtoolu_1",
+            "name": "web_search",
+            "input": {"query": "x"},
+        },
+        {"type": "text", "text": "hi"},
+    ],
+    "stop_reason": "end_turn",
+    "stop_sequence": None,
+    "usage": {
+        "input_tokens": 100,
+        "cache_read_input_tokens": 30,
+        "cache_creation_input_tokens": 20,
+        "output_tokens": 42,
+    },
+}
+
+
+class _FakePostClient:
+    def __init__(self, response: httpx.Response) -> None:
+        self._response = response
+
+    def __enter__(self) -> "_FakePostClient":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        pass
+
+    def post(self, *args: object, **kwargs: object) -> httpx.Response:
+        del args, kwargs
+        return self._response
+
+
+def _non_streaming_request() -> AnthropicMessagesRequest:
+    return AnthropicMessagesRequest(
+        model="1/claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=100,
+        stream=False,
+    )
+
+
+def _run_non_streaming_passthrough(
+    upstream_response: httpx.Response,
+    *,
+    llm_generation_span_patch: Any = None,
+) -> JSONResponse:
+    provider = _provider(1, "anthropic", [_model("claude-sonnet-4-6")])
+    model_config = provider.model_configurations[0]
+    span_patch = llm_generation_span_patch or (lambda *a, **k: nullcontext())  # noqa: ARG005
+
+    with (
+        patch.object(
+            anthropic_passthrough,
+            "httpx",
+            _fake_httpx_module(
+                MagicMock(return_value=_FakePostClient(upstream_response))
+            ),
+        ),
+        patch.object(
+            anthropic_passthrough, "llm_from_provider", return_value=_anthropic_llm()
+        ),
+        patch.object(anthropic_passthrough, "llm_generation_span", span_patch),
+    ):
+        result = handle_anthropic_passthrough(
+            request=_non_streaming_request(),
+            provider=provider,
+            model_config=model_config,
+            flow=LLMFlow.CRAFT_LLM_GENERATION,
+            http_request=_http_request({}),
+            user=MagicMock(id="user-1"),
+        )
+        # Non-streaming always yields JSONResponse; narrow instead of cast.
+        assert isinstance(result, JSONResponse)
+        return result
+
+
+def test_handle_anthropic_passthrough_non_streaming_forwards_body_verbatim() -> None:
+    fake_response = httpx.Response(200, json=_UPSTREAM_MESSAGE)
+
+    result = _run_non_streaming_passthrough(fake_response)
+
+    assert isinstance(result, JSONResponse)
+    payload = json.loads(bytes(result.body))
+    assert payload == _UPSTREAM_MESSAGE
+    assert payload["id"] == "msg_upstream_abc123"
+
+
+def test_handle_anthropic_passthrough_non_streaming_records_usage() -> None:
+    fake_response = httpx.Response(200, json=_UPSTREAM_MESSAGE)
+    mock_span = MagicMock()
+
+    @contextmanager
+    def _span_ctx(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        del args, kwargs
+        yield mock_span
+
+    with patch.object(anthropic_passthrough, "record_llm_span_output") as record_output:
+        _run_non_streaming_passthrough(
+            fake_response, llm_generation_span_patch=_span_ctx
+        )
+
+    record_output.assert_called_once()
+    usage = record_output.call_args.kwargs["usage"]
+    assert usage.prompt_tokens == 150
+    assert usage.completion_tokens == 42
+
+
+def test_handle_anthropic_passthrough_non_streaming_upstream_error_marks_span() -> None:
+    fake_response = httpx.Response(
+        429, json={"type": "error", "error": {"type": "rate_limit_error"}}
+    )
+    mock_span = MagicMock()
+
+    @contextmanager
+    def _span_ctx(*args: object, **kwargs: object):
+        del args, kwargs
+        yield mock_span
+
+    result = _run_non_streaming_passthrough(
+        fake_response, llm_generation_span_patch=_span_ctx
+    )
+
+    assert result.status_code == 429
+    mock_span.set_error.assert_called_once()
+    assert "429" in mock_span.set_error.call_args.args[0]["message"]
+
+
+def test_passthrough_stream_upstream_error_marks_span() -> None:
+    response = _FakeStreamResponse(500, [])
+    mock_span = MagicMock()
+
+    @contextmanager
+    def _span_ctx(*args: object, **kwargs: object):
+        del args, kwargs
+        yield mock_span
+
+    _run_passthrough_stream(response, llm_generation_span_patch=_span_ctx)
+
+    mock_span.set_error.assert_called_once()
+    assert "500" in mock_span.set_error.call_args.args[0]["message"]
+
+
+def _count_tokens_request() -> AnthropicCountTokensRequest:
+    return AnthropicCountTokensRequest(
+        model="1/claude-sonnet-4-6", messages=[{"role": "user", "content": "hi"}]
+    )
+
+
+def _count_tokens_provider() -> Any:
+    provider = _provider(1, "anthropic", [_model("claude-sonnet-4-6")])
+    return provider, provider.model_configurations[0]
+
+
+def test_count_tokens_passthrough_forwards_200_verbatim() -> None:
+    upstream_body = {"input_tokens": 55}
+    fake_response = httpx.Response(200, json=upstream_body)
+    provider, model_config = _count_tokens_provider()
+
+    with patch.object(
+        anthropic_passthrough,
+        "httpx",
+        _fake_httpx_module(MagicMock(return_value=_FakePostClient(fake_response))),
+    ):
+        result = handle_anthropic_count_tokens_passthrough(
+            request=_count_tokens_request(),
+            provider=provider,
+            model_config=model_config,
+            http_request=_http_request({}),
+            user=MagicMock(id="user-1"),
+        )
+
+    assert json.loads(bytes(result.body)) == upstream_body
+
+
+def test_count_tokens_passthrough_transport_error_raises_unavailable() -> None:
+    class _FailingClient:
+        def __enter__(self) -> "_FailingClient":
+            return self
+
+        def __exit__(self, *exc_info: object) -> None:
+            pass
+
+        def post(self, *args: object, **kwargs: object) -> httpx.Response:
+            del args, kwargs
+            raise httpx.ConnectError("connection refused")
+
+    provider, model_config = _count_tokens_provider()
+
+    with (
+        patch.object(
+            anthropic_passthrough,
+            "httpx",
+            _fake_httpx_module(MagicMock(return_value=_FailingClient())),
+        ),
+        pytest.raises(AnthropicPassthroughUnavailable),
+    ):
+        handle_anthropic_count_tokens_passthrough(
+            request=_count_tokens_request(),
+            provider=provider,
+            model_config=model_config,
+            http_request=_http_request({}),
+            user=MagicMock(id="user-1"),
+        )
+
+
+def test_count_tokens_passthrough_forwards_error_status_and_body() -> None:
+    error_body = {"error": {"type": "invalid_request_error", "message": "bad"}}
+    fake_response = httpx.Response(400, json=error_body)
+    provider, model_config = _count_tokens_provider()
+
+    with patch.object(
+        anthropic_passthrough,
+        "httpx",
+        _fake_httpx_module(MagicMock(return_value=_FakePostClient(fake_response))),
+    ):
+        result = handle_anthropic_count_tokens_passthrough(
+            request=_count_tokens_request(),
+            provider=provider,
+            model_config=model_config,
+            http_request=_http_request({}),
+            user=MagicMock(id="user-1"),
+        )
+
+    assert result.status_code == 400
+    assert json.loads(bytes(result.body)) == error_body
+
+
+def _anthropic_request(**overrides: Any) -> AnthropicMessagesRequest:
+    defaults: dict[str, Any] = {
+        "model": "1/test",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 1024,
+    }
+    defaults.update(overrides)
+    return AnthropicMessagesRequest(**defaults)
+
+
+def test_gateway_anthropic_messages_routes_to_passthrough_for_anthropic_provider() -> (
+    None
+):
+    provider = _provider(1, "anthropic", [_model("test")])
+    request = _anthropic_request()
+    passthrough_response = JSONResponse(content={"id": "msg_1"})
+
+    with (
+        patch.object(
+            gateway_api,
+            "_authorize_gateway_request",
+            return_value=LLMFlow.CRAFT_LLM_GENERATION,
+        ),
+        patch.object(gateway_api, "check_token_rate_limits"),
+        patch.object(
+            gateway_api,
+            "resolve_gateway_model",
+            return_value=(provider, provider.model_configurations[0]),
+        ),
+        patch.object(
+            gateway_api,
+            "handle_anthropic_passthrough",
+            return_value=passthrough_response,
+        ) as handle_passthrough,
+        patch.object(gateway_api, "handle_anthropic_messages") as handle_translation,
+        patch.object(
+            anthropic_passthrough, "ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED", True
+        ),
+    ):
+        result = gateway_api.gateway_anthropic_messages(
+            request=request,
+            http_request=MagicMock(spec=Request),
+            user=MagicMock(),
+            db_session=MagicMock(),
+        )
+
+    assert result is passthrough_response
+    handle_passthrough.assert_called_once()
+    handle_translation.assert_not_called()
+
+
+def test_gateway_anthropic_messages_uses_translation_path_for_openai_provider() -> None:
+    provider = _provider(1, "openai", [_model("test")])
+    request = _anthropic_request()
+
+    with (
+        patch.object(
+            gateway_api,
+            "_authorize_gateway_request",
+            return_value=LLMFlow.CRAFT_LLM_GENERATION,
+        ),
+        patch.object(gateway_api, "check_token_rate_limits"),
+        patch.object(
+            gateway_api,
+            "resolve_gateway_model",
+            return_value=(provider, provider.model_configurations[0]),
+        ),
+        patch.object(gateway_api, "handle_anthropic_passthrough") as handle_passthrough,
+        patch.object(gateway_api, "handle_anthropic_messages") as handle_translation,
+        patch.object(
+            anthropic_passthrough, "ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED", True
+        ),
+    ):
+        handle_translation.return_value.to_wire.return_value = {"id": "msg_1"}
+        gateway_api.gateway_anthropic_messages(
+            request=request,
+            http_request=MagicMock(spec=Request),
+            user=MagicMock(),
+            db_session=MagicMock(),
+        )
+
+    handle_passthrough.assert_not_called()
+    handle_translation.assert_called_once()
+
+
+def test_gateway_anthropic_count_tokens_routes_to_passthrough_for_anthropic_provider() -> (
+    None
+):
+    provider = _provider(1, "anthropic", [_model("test")])
+    request = AnthropicCountTokensRequest(
+        model="1/test", messages=[{"role": "user", "content": "hi"}]
+    )
+    passthrough_response = JSONResponse(content={"input_tokens": 42})
+
+    with (
+        patch.object(
+            gateway_api,
+            "_authorize_gateway_request",
+            return_value=LLMFlow.CRAFT_LLM_GENERATION,
+        ),
+        patch.object(
+            gateway_api,
+            "resolve_gateway_model",
+            return_value=(provider, provider.model_configurations[0]),
+        ),
+        patch.object(
+            gateway_api,
+            "handle_anthropic_count_tokens_passthrough",
+            return_value=passthrough_response,
+        ) as handle_passthrough,
+        patch.object(
+            anthropic_passthrough, "ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED", True
+        ),
+    ):
+        result = gateway_api.gateway_anthropic_count_tokens(
+            request=request,
+            http_request=MagicMock(spec=Request),
+            user=MagicMock(),
+            db_session=MagicMock(),
+        )
+
+    assert result is passthrough_response
+    handle_passthrough.assert_called_once()
+
+
+def test_gateway_anthropic_count_tokens_falls_back_to_local_estimate_on_unavailable() -> (
+    None
+):
+    provider = _provider(1, "anthropic", [_model("test")])
+    request = AnthropicCountTokensRequest(
+        model="1/test", messages=[{"role": "user", "content": "hi"}]
+    )
+
+    with (
+        patch.object(
+            gateway_api,
+            "_authorize_gateway_request",
+            return_value=LLMFlow.CRAFT_LLM_GENERATION,
+        ),
+        patch.object(
+            gateway_api,
+            "resolve_gateway_model",
+            return_value=(provider, provider.model_configurations[0]),
+        ),
+        patch.object(
+            gateway_api,
+            "handle_anthropic_count_tokens_passthrough",
+            side_effect=AnthropicPassthroughUnavailable(),
+        ),
+        patch.object(
+            anthropic_passthrough, "ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED", True
+        ),
+        patch("onyx.llm.litellm_singleton.litellm.token_counter", return_value=123),
+    ):
+        result = gateway_api.gateway_anthropic_count_tokens(
+            request=request,
+            http_request=MagicMock(spec=Request),
+            user=MagicMock(),
+            db_session=MagicMock(),
+        )
+
+    payload = json.loads(bytes(result.body))
+    assert payload["input_tokens"] == 123

--- a/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
@@ -51,6 +51,7 @@ from onyx.server.auth_check import check_router_auth
 from onyx.server.features.build import craft_gateway
 from onyx.server.features.build.craft_gateway import gateway_request_flow
 from onyx.server.gateway import api as gateway_api
+from onyx.server.gateway import stream_bridge
 from onyx.server.gateway.api import _MESSAGES_ADAPTER
 from onyx.server.gateway.configs import GATEWAY_PATH_PREFIX
 from onyx.server.gateway.models import (
@@ -263,7 +264,7 @@ class _RaisingCloseLLM(_ConfigOnlyLLM):
 
 
 def _gateway_stream(llm: LLM):
-    return gateway_api._run_bridged_stream(
+    return stream_bridge._run_bridged_stream(
         gateway_api._stream_worker,
         {
             "llm": llm,
@@ -617,7 +618,7 @@ def _reasoning_stream_llm() -> _ChunkStreamLLM:
 def test_stream_records_accumulated_reasoning_on_span() -> None:
     with (
         patch.object(gateway_api, "llm_generation_span"),
-        patch.object(gateway_api, "record_llm_span_output") as record,
+        patch.object(stream_bridge, "record_llm_span_output") as record,
     ):
         frames = list(_gateway_stream(_reasoning_stream_llm()))
 
@@ -1439,7 +1440,7 @@ def _responses_stream_events(
         gateway_api, "llm_generation_span", return_value=nullcontext(span)
     ):
         frames = list(
-            gateway_api._run_bridged_stream(
+            stream_bridge._run_bridged_stream(
                 gateway_api._responses_stream_worker,
                 {
                     "llm": llm,
@@ -1721,7 +1722,7 @@ def test_responses_stream_validates_against_openai_sdk_models() -> None:
 def test_responses_stream_disconnect_closes_upstream_and_omits_completed() -> None:
     closed = threading.Event()
     with patch.object(gateway_api, "llm_generation_span", return_value=nullcontext()):
-        stream = gateway_api._run_bridged_stream(
+        stream = stream_bridge._run_bridged_stream(
             gateway_api._responses_stream_worker,
             {
                 "llm": _StreamingLLM(closed),
@@ -1749,7 +1750,7 @@ def test_responses_stream_records_output_usage_and_reasoning_on_span() -> None:
     silently, because the worker skips all span recording."""
     span = MagicMock()
 
-    with patch.object(gateway_api, "record_llm_span_output") as record:
+    with patch.object(stream_bridge, "record_llm_span_output") as record:
         _responses_stream_events(
             _reasoning_stream_llm(), span=span, response_id="resp_span"
         )
@@ -1759,7 +1760,7 @@ def test_responses_stream_records_output_usage_and_reasoning_on_span() -> None:
     assert record.call_args.kwargs["reasoning"] == "thinking hard"
     assert record.call_args.kwargs["output"] == "done"
 
-    with patch.object(gateway_api, "record_llm_span_output") as record:
+    with patch.object(stream_bridge, "record_llm_span_output") as record:
         _responses_stream_events(
             _ChunkStreamLLM(_TEXT_CHUNKS), span=span, response_id="resp_usage"
         )

--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
@@ -378,6 +378,10 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # LINEAR_CLIENT_SECRET=
 
 ## Miscellaneous
+# Kill switch for the gateway's native Anthropic passthrough (server tools,
+# thinking-block signatures, fine-grained streaming); default on. Set to false
+# to send Anthropic-backed providers back through the OpenAI-translation path.
+# ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED=false
 # ONYX_QUERY_HISTORY_TYPE=
 # Hide the Query History page from the admin sidebar (visibility-only; the history
 # APIs + recording keep working, unlike ONYX_QUERY_HISTORY_TYPE=disabled).

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -378,6 +378,10 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # LINEAR_CLIENT_SECRET=
 
 ## Miscellaneous
+# Kill switch for the gateway's native Anthropic passthrough (server tools,
+# thinking-block signatures, fine-grained streaming); default on. Set to false
+# to send Anthropic-backed providers back through the OpenAI-translation path.
+# ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED=false
 # ONYX_QUERY_HISTORY_TYPE=
 # Hide the Query History page from the admin sidebar (visibility-only; the history
 # APIs + recording keep working, unlike ONYX_QUERY_HISTORY_TYPE=disabled).


### PR DESCRIPTION
## Description

When the resolved provider is Anthropic itself, the gateway's `/v1/messages` translation pipeline (Anthropic → OpenAI → internal → LiteLLM) is pure loss: **server-side tools** (`web_search`, code execution), **thinking-block signatures**, `pause_turn`, and fine-grained streaming cannot survive the round-trip. This PR adds **native passthrough**: Anthropic-backed providers are proxied nearly verbatim over httpx; every other provider keeps the translation path. The two paths never silently fall back to each other — a request is served by exactly one, chosen from the resolved provider.

- **Transport**: direct httpx (deliberately not litellm's `anthropic_messages` surface — it rebuilds the body from a fixed param list and drops fields like `output_config`). Bedrock/Vertex Claude are phase 2.
- **Field policy**: request forwards verbatim except `model` (swapped to the provider model name), `metadata.user_id` (always overwritten with a hashed Onyx user id), `mcp_servers` (refused — it dials arbitrary URLs under our provider account), and `anthropic-beta` (prefix allowlist). Outbound headers are built fresh; the inbound Authorization (an Onyx PAT) never reaches the provider.
- **Metering**: usage is inverse-converted into LiteLLM-normalized accounting for the ledger (`prompt_tokens` includes cache tokens) while client-facing bytes stay untouched; `server_tool_use` counts are recorded on the generation span (per-search *pricing* belongs to the cost-tracking project).
- **count_tokens** proxies for exact counts, degrading to the local estimate on transport failure.
- **Streaming** reuses the queue/one-thread bridge (moved verbatim from api.py to `stream_bridge.py` so both paths share it without an import cycle) and forwards upstream SSE frames byte-verbatim while snooping usage.
- **Kill switch**: `ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED=false` reverts Anthropic-backed providers to the translation path (default on).

## How Has This Been Tested?

- 41 new unit tests (`test_anthropic_passthrough.py`): eligibility/kill switch, field policy incl. unknown-field passthrough and mcp_servers refusal, fresh-header construction (no PAT leak) + beta allowlist, usage inverse-conversion round-trip, error-policy matrix (forward 400/429/529 verbatim, sanitize 401/403), byte-identical stream forwarding incl. a `server_tool_use` block, ExitStack cleanup, span usage recording, endpoint routing, count_tokens fallback. 597 pass across the gateway + llm suites; existing suites green against the moved stream bridge.
- **Live against real Anthropic** (local instance): hosted `web_search` turn returns `server_tool_use` + `web_search_tool_result` blocks and per-search usage (previously a hard 400); thinking-enabled streaming delivers thinking deltas **with `signature_delta`**; exact count_tokens (live test caught and fixed a `metadata`-rejection bug); usage lands in the `user_usage` ledger with cost; **real Claude Code session using WebSearch through the gateway succeeds with cited sources**.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

**Stack:**
1. [gateway-anthropic-messages #13687](https://github.com/onyx-dot-app/onyx/pull/13687)
2. [gateway-named-tool-choice #13692](https://github.com/onyx-dot-app/onyx/pull/13692)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native passthrough for Anthropic on `/v1/messages` and `/v1/messages/count_tokens` to preserve server tools, thinking signatures, `pause_turn`, and exact streaming. All other providers stay on the translation path with no silent fallback.

- **New Features**
  - Direct `httpx` passthrough for Anthropic only; no fallback to translation.
  - Field/header policy: swap to provider model; hash `metadata.user_id`; block `mcp_servers`; prefix‑allowlist `anthropic-beta`; never forward inbound Authorization; merge `build_llm_extra_headers`.
  - Streaming: forward upstream SSE frames byte‑for‑byte while recording usage; attach `server_tool_use` to the generation span; shared SSE bridge moved to `stream_bridge.py`.
  - Errors: forward 400/404/413/429/529 verbatim; sanitize 401/403.
  - Metering: convert Anthropic usage to our ledger and track managed‑key cost; `count_tokens` proxies exact counts and falls back to the local estimate on transport errors.
  - Ops: 10s connect / 600s read timeouts; kill switch `ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED=false`.

- **Bug Fixes**
  - Cancel watchdog closes the upstream `httpx` stack on client disconnects to prevent hanging streams.

<sup>Written for commit ce1f7cc0a4090d36ddca59c662f4b16b95ba5905. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

