### PR TITLE
fix(craft): reconcile sandbox lifecycle transitions

### DIFF
--- a/web/src/app/craft/components/SandboxAsleepNotice.test.tsx
+++ b/web/src/app/craft/components/SandboxAsleepNotice.test.tsx
@@ -2,43 +2,31 @@
  * @jest-environment jsdom
  */
 import React from "react";
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@tests/setup/test-utils";
+import { act, fireEvent, render, screen } from "@tests/setup/test-utils";
 import SandboxAsleepNotice from "@/app/craft/components/SandboxAsleepNotice";
 import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
-import * as api from "@/app/craft/services/apiServices";
-import { ApiSandboxResponse } from "@/app/craft/types/streamingTypes";
-
-jest.mock("@/app/craft/services/apiServices");
-
-const mockedApi = api as jest.Mocked<typeof api>;
+import type { SandboxRuntimeState } from "@/app/craft/types/streamingTypes";
 
 const SESSION_A = "11111111-1111-1111-1111-111111111111";
 const SESSION_B = "22222222-2222-2222-2222-222222222222";
 const TITLE = "Your sandbox fell asleep";
 
 function sandbox(
-  overrides: Partial<ApiSandboxResponse> = {}
-): ApiSandboxResponse {
+  overrides: Partial<SandboxRuntimeState> = {}
+): SandboxRuntimeState {
   return {
     id: "sb1",
     status: "sleeping",
     container_id: null,
     created_at: "2026-07-01T00:00:00.000Z",
     last_heartbeat: "2026-07-01T00:00:00.000Z",
-    nextjs_port: null,
     ...overrides,
   };
 }
 
 function seedSession(
   sessionId: string,
-  sandboxState: ApiSandboxResponse
+  sandboxState: SandboxRuntimeState
 ): void {
   useBuildSessionStore.getState().createSession(sessionId, {
     status: "running",
@@ -58,16 +46,11 @@ describe("SandboxAsleepNotice", () => {
       currentSessionId: null,
       loadSession,
     } as never);
-    mockedApi.fetchSandboxStatus.mockResolvedValue({ status: "running" });
   });
 
-  it("renders nothing when the sandbox is running", async () => {
+  it("renders nothing when the sandbox is running", () => {
     seedSession(SESSION_A, sandbox({ status: "running" }));
     render(<SandboxAsleepNotice />);
-
-    await waitFor(() => {
-      expect(mockedApi.fetchSandboxStatus).toHaveBeenCalled();
-    });
 
     expect(screen.queryByText(TITLE)).toBeNull();
   });

--- a/web/src/app/craft/components/SandboxAsleepNotice.tsx
+++ b/web/src/app/craft/components/SandboxAsleepNotice.tsx
@@ -8,14 +8,11 @@ import {
   useSessionId,
   useBuildSessionStore,
 } from "@/app/craft/hooks/useBuildSessionStore";
-import { useSandboxSleepWatcher } from "@/app/craft/hooks/useSandboxSleepWatcher";
 import { Modal } from "@opal/components";
 
 // Waking is always user-initiated — never automatic — so we don't keep pods
 // alive forever and defeat idle reaping.
 export default function SandboxAsleepNotice() {
-  useSandboxSleepWatcher();
-
   const sessionId = useSessionId();
   const session = useSession();
   const loadSession = useBuildSessionStore((state) => state.loadSession);

--- a/web/src/app/craft/components/SandboxStatusIndicator.stories.tsx
+++ b/web/src/app/craft/components/SandboxStatusIndicator.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  SandboxStatusIndicatorView,
+  type SandboxDisplayStatus,
+} from "@/app/craft/components/SandboxStatusIndicator";
+
+const SANDBOX_STATUSES = [
+  "loading",
+  "provisioning",
+  "ready",
+  "running",
+  "sleeping",
+  "restoring",
+  "terminated",
+  "failed",
+] as const satisfies readonly SandboxDisplayStatus[];
+
+const meta: Meta<typeof SandboxStatusIndicatorView> = {
+  title: "Apps/Craft/Session/Sandbox Status Indicator",
+  component: SandboxStatusIndicatorView,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+  args: {
+    status: "running",
+  },
+  argTypes: {
+    status: {
+      control: "select",
+      options: SANDBOX_STATUSES,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SandboxStatusIndicatorView>;
+
+/** Inspect any display state using the status control. */
+export const Playground: Story = {};
+
+/** Every backend, client-runtime, and pre-provisioning display state. */
+export const AllStates: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center justify-center gap-3 max-w-[640px]">
+      {SANDBOX_STATUSES.map((status) => (
+        <SandboxStatusIndicatorView key={status} status={status} />
+      ))}
+    </div>
+  ),
+};

--- a/web/src/app/craft/components/SandboxStatusIndicator.test.tsx
+++ b/web/src/app/craft/components/SandboxStatusIndicator.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from "@tests/setup/test-utils";
+import SandboxStatusIndicator from "@/app/craft/components/SandboxStatusIndicator";
+import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
+
+const SESSION_ID = "11111111-1111-1111-1111-111111111111";
+
+describe("SandboxStatusIndicator", () => {
+  beforeEach(() => {
+    useBuildSessionStore.setState({
+      sessions: new Map(),
+      currentSessionId: null,
+      preProvisioning: { status: "idle" },
+    } as never);
+  });
+
+  it("shows a loading state until an existing session has sandbox data", () => {
+    useBuildSessionStore.getState().createSession(SESSION_ID);
+    useBuildSessionStore.getState().setCurrentSession(SESSION_ID);
+
+    render(<SandboxStatusIndicator />);
+
+    expect(screen.getByText("Finding sandbox...")).toBeInTheDocument();
+    expect(screen.queryByText("Sandbox running")).toBeNull();
+  });
+
+  it("shows the client-owned restoring state", () => {
+    useBuildSessionStore.getState().createSession(SESSION_ID, {
+      sandbox: {
+        id: "sb1",
+        status: "restoring",
+        container_id: null,
+        created_at: "2026-07-01T00:00:00.000Z",
+        last_heartbeat: null,
+      },
+    });
+    useBuildSessionStore.getState().setCurrentSession(SESSION_ID);
+
+    render(<SandboxStatusIndicator />);
+
+    expect(screen.getByText("Restoring session...")).toBeInTheDocument();
+  });
+
+  it("shows pre-provisioning readiness before a session is consumed", () => {
+    useBuildSessionStore.setState({
+      preProvisioning: {
+        status: "ready",
+        sessionId: SESSION_ID,
+      },
+    } as never);
+
+    render(<SandboxStatusIndicator />);
+
+    expect(screen.getByText("Sandbox ready")).toBeInTheDocument();
+  });
+});

--- a/web/src/app/craft/components/SandboxStatusIndicator.tsx
+++ b/web/src/app/craft/components/SandboxStatusIndicator.tsx
@@ -10,6 +10,15 @@ import {
   useIsPreProvisioningFailed,
 } from "@/app/craft/hooks/useBuildSessionStore";
 import { Text } from "@opal/components";
+import type { SandboxRuntimeStatus } from "@/app/craft/types/streamingTypes";
+
+type SandboxDisplayStatus = SandboxRuntimeStatus | "ready" | "loading";
+
+interface SandboxStatusConfig {
+  color: string;
+  pulse: boolean;
+  label: string;
+}
 
 const STATUS_CONFIG = {
   provisioning: {
@@ -22,7 +31,6 @@ const STATUS_CONFIG = {
     pulse: false,
     label: "Sandbox running",
   },
-  idle: { color: "bg-status-warning-05", pulse: false, label: "Sandbox idle" },
   sleeping: {
     color: "bg-status-info-05",
     pulse: false,
@@ -53,18 +61,14 @@ const STATUS_CONFIG = {
     pulse: true,
     label: "Finding sandbox...",
   },
-} as const;
-
-type Status = keyof typeof STATUS_CONFIG;
-
-interface SandboxStatusIndicatorProps {}
+} as const satisfies Record<SandboxDisplayStatus, SandboxStatusConfig>;
 
 /**
  * Derives the current sandbox status from session state or pre-provisioning state.
  *
  * Priority:
- * 1. Actual sandbox status from backend (if session has sandbox info)
- * 2. Session exists but no sandbox info → "running" (optimistic for consumed pre-provisioned sessions)
+ * 1. Session runtime status (backend status or client-owned restoration)
+ * 2. Session exists but no sandbox info → "loading"
  * 3. Pre-provisioning failed → "failed"
  * 4. Pre-provisioning in progress → "provisioning" (only when no session - welcome page)
  * 5. Pre-provisioning ready (not yet consumed) → "ready"
@@ -79,29 +83,23 @@ function deriveSandboxStatus(
   isPreProvisioning: boolean,
   isReady: boolean,
   isFailed: boolean
-): Status {
-  // 1. Backend is source of truth when available
+): SandboxDisplayStatus {
   if (session?.sandbox) {
-    return session.sandbox.status as Status;
+    return session.sandbox.status;
   }
-  // 2. Session exists but no sandbox info - assume running
-  // (This handles consumed pre-provisioned sessions before sandbox loads)
+  // A session without sandbox data has not established a runtime state yet.
   if (session) {
-    return "running";
+    return "loading";
   }
-  // 3. Pre-provisioning failed
   if (isFailed) {
     return "failed";
   }
-  // 4. No session - check pre-provisioning state (welcome page)
   if (isPreProvisioning) {
     return "provisioning";
   }
-  // 5. Pre-provisioning ready but not consumed
   if (isReady) {
     return "ready";
   }
-  // 6. No session, no pre-provisioning state - loading
   return "loading";
 }
 
@@ -111,9 +109,7 @@ function deriveSandboxStatus(
  * Shows actual sandbox state when a session exists, otherwise shows
  * pre-provisioning state (provisioning/ready).
  */
-export default function SandboxStatusIndicator(
-  _props: SandboxStatusIndicatorProps = {}
-) {
+export default function SandboxStatusIndicator() {
   const session = useSession();
   const isPreProvisioning = useIsPreProvisioning();
   const isReady = useIsPreProvisioningReady();

--- a/web/src/app/craft/components/SandboxStatusIndicator.tsx
+++ b/web/src/app/craft/components/SandboxStatusIndicator.tsx
@@ -12,7 +12,7 @@ import {
 import { Text } from "@opal/components";
 import type { SandboxRuntimeStatus } from "@/app/craft/types/streamingTypes";
 
-type SandboxDisplayStatus = SandboxRuntimeStatus | "ready" | "loading";
+export type SandboxDisplayStatus = SandboxRuntimeStatus | "ready" | "loading";
 
 interface SandboxStatusConfig {
   color: string;
@@ -62,6 +62,43 @@ const STATUS_CONFIG = {
     label: "Finding sandbox...",
   },
 } as const satisfies Record<SandboxDisplayStatus, SandboxStatusConfig>;
+
+interface SandboxStatusIndicatorViewProps {
+  status: SandboxDisplayStatus;
+}
+
+export function SandboxStatusIndicatorView({
+  status,
+}: SandboxStatusIndicatorViewProps) {
+  const { color, pulse, label } = STATUS_CONFIG[status];
+
+  return (
+    <motion.div layout transition={{ duration: 0.3, ease: "easeInOut" }}>
+      <div className="flex items-center gap-2 p-2 overflow-hidden rounded-12 border border-border-01 bg-background-neutral-00">
+        <div
+          className={cn(
+            "w-2 h-2 rounded-full shrink-0",
+            color,
+            pulse && "animate-pulse"
+          )}
+        />
+        <AnimatePresence mode="wait">
+          <motion.span
+            key={status}
+            initial={{ opacity: 0, y: 5 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -5 }}
+            transition={{ duration: 0.2 }}
+          >
+            <Text font="main-ui-body" color="text-05" nowrap>
+              {label}
+            </Text>
+          </motion.span>
+        </AnimatePresence>
+      </div>
+    </motion.div>
+  );
+}
 
 /**
  * Derives the current sandbox status from session state or pre-provisioning state.
@@ -121,32 +158,6 @@ export default function SandboxStatusIndicator() {
     isReady,
     isFailed
   );
-  const { color, pulse, label } = STATUS_CONFIG[status];
 
-  return (
-    <motion.div layout transition={{ duration: 0.3, ease: "easeInOut" }}>
-      <div className="flex items-center gap-2 p-2 overflow-hidden rounded-12 border border-border-01 bg-background-neutral-00">
-        <div
-          className={cn(
-            "w-2 h-2 rounded-full shrink-0",
-            color,
-            pulse && "animate-pulse"
-          )}
-        />
-        <AnimatePresence mode="wait">
-          <motion.span
-            key={status}
-            initial={{ opacity: 0, y: 5 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -5 }}
-            transition={{ duration: 0.2 }}
-          >
-            <Text font="main-ui-body" color="text-05" nowrap>
-              {label}
-            </Text>
-          </motion.span>
-        </AnimatePresence>
-      </div>
-    </motion.div>
-  );
+  return <SandboxStatusIndicatorView status={status} />;
 }

--- a/web/src/app/craft/hooks/loadSessionRestore.test.ts
+++ b/web/src/app/craft/hooks/loadSessionRestore.test.ts
@@ -11,22 +11,24 @@ const mockedApi = api as jest.Mocked<typeof api>;
 const SESSION_ID = "11111111-1111-1111-1111-111111111111";
 
 // Minimal DetailedSessionResponse shapes — loadSession only reads status,
-// session_loaded_in_sandbox, and sandbox.{status,nextjs_port}.
+// session_loaded_in_sandbox, nextjs_port, and sandbox.status.
 function sleepingSession(): unknown {
   return {
     id: SESSION_ID,
     status: "idle",
+    nextjs_port: null,
     session_loaded_in_sandbox: false,
-    sandbox: { id: "sb1", status: "sleeping", nextjs_port: null },
+    sandbox: { id: "sb1", status: "sleeping" },
   };
 }
 
-function runningSession(): unknown {
+function runningSession(nextjsPort: number | null = null): unknown {
   return {
     id: SESSION_ID,
     status: "active",
+    nextjs_port: nextjsPort,
     session_loaded_in_sandbox: true,
-    sandbox: { id: "sb1", status: "running", nextjs_port: null },
+    sandbox: { id: "sb1", status: "running" },
   };
 }
 
@@ -61,6 +63,17 @@ describe("loadSession restore status", () => {
 
     const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
     expect(session?.sandbox?.status).toBe("running");
+  });
+
+  it("builds the webapp URL from the session port", async () => {
+    mockedApi.fetchSession.mockResolvedValue(runningSession(3210) as never);
+    mockedApi.fetchArtifacts.mockResolvedValue([{ type: "web_app" }] as never);
+
+    await useBuildSessionStore.getState().loadSession(SESSION_ID);
+
+    expect(
+      useBuildSessionStore.getState().sessions.get(SESSION_ID)?.webappUrl
+    ).toBe("http://localhost:3210");
   });
 
   it("marks the sandbox failed when restore itself fails", async () => {

--- a/web/src/app/craft/hooks/useBuildSessionController.ts
+++ b/web/src/app/craft/hooks/useBuildSessionController.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
 import { usePreProvisionPolling } from "@/app/craft/hooks/usePreProvisionPolling";
+import { useSandboxStatusReconciler } from "@/app/craft/hooks/useSandboxStatusReconciler";
 import { CRAFT_SEARCH_PARAM_NAMES } from "@/app/craft/services/searchParams";
 import { CRAFT_PATH } from "@/app/craft/v1/constants";
 import { hasSupportedCraftProvider } from "@/app/craft/onboarding/constants";
@@ -36,6 +37,7 @@ export function useBuildSessionController({
   existingSessionId,
 }: UseBuildSessionControllerProps) {
   const router = useRouter();
+  useSandboxStatusReconciler();
 
   // Pre-provisioning gates only on having a visible configured model. When one
   // exists we start provisioning

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -4,7 +4,6 @@ import { create } from "zustand";
 import { DELETE_SUCCESS_DISPLAY_DURATION_MS } from "@/app/craft/constants";
 
 import {
-  ApiSandboxResponse,
   ApiSessionResponse,
   Artifact,
   ArtifactType,
@@ -14,6 +13,7 @@ import {
   SessionHistoryItem,
   SessionOrigin,
   SessionStatus,
+  SandboxRuntimeState,
 } from "@/app/craft/types/streamingTypes";
 
 import {
@@ -648,8 +648,8 @@ export interface BuildSessionData {
   turnGeneration: number;
   error: string | null;
   webappUrl: string | null;
-  /** Sandbox info from backend */
-  sandbox: ApiSandboxResponse | null;
+  /** Backend sandbox state plus transient client-owned lifecycle states. */
+  sandbox: SandboxRuntimeState | null;
   /** Model this session runs on (from the row); seeds the composer picker. */
   agentProvider: string | null;
   agentModel: string | null;
@@ -1544,8 +1544,8 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
       const hasWebapp = artifacts.some(
         (a) => a.type === "nextjs_app" || a.type === "web_app"
       );
-      if (hasWebapp && sessionData.sandbox?.nextjs_port) {
-        webappUrl = `http://localhost:${sessionData.sandbox.nextjs_port}`;
+      if (hasWebapp && sessionData.nextjs_port) {
+        webappUrl = `http://localhost:${sessionData.nextjs_port}`;
       }
 
       const resolvedActiveTurnId =

--- a/web/src/app/craft/hooks/useBuildStreaming.test.tsx
+++ b/web/src/app/craft/hooks/useBuildStreaming.test.tsx
@@ -960,8 +960,9 @@ describe("useBuildStreaming thinking packets", () => {
     jest.mocked(fetchSession).mockResolvedValue({
       id: sessionId,
       status: "active",
+      nextjs_port: null,
       session_loaded_in_sandbox: true,
-      sandbox: { id: "sandbox-1", status: "running", nextjs_port: null },
+      sandbox: { id: "sandbox-1", status: "running" },
       agent_provider: "openai",
       agent_model: "gpt-5-mini",
     } as never);

--- a/web/src/app/craft/hooks/useBuildStreaming.ts
+++ b/web/src/app/craft/hooks/useBuildStreaming.ts
@@ -649,8 +649,8 @@ export function useBuildStreaming() {
             if (isWebapp) {
               fetchSession(sessionId)
                 .then((sessionData) => {
-                  if (sessionData.sandbox?.nextjs_port) {
-                    const webappUrl = `http://localhost:${sessionData.sandbox.nextjs_port}`;
+                  if (sessionData.nextjs_port) {
+                    const webappUrl = `http://localhost:${sessionData.nextjs_port}`;
                     updateSessionData(sessionId, { webappUrl });
                   }
                 })

--- a/web/src/app/craft/hooks/useSandboxSleepWatcher.test.tsx
+++ b/web/src/app/craft/hooks/useSandboxSleepWatcher.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import React from "react";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { SWRConfig } from "swr";
 import { useSandboxSleepWatcher } from "@/app/craft/hooks/useSandboxSleepWatcher";
 import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
@@ -121,6 +121,34 @@ describe("useSandboxSleepWatcher", () => {
     await waitFor(() => {
       expect(loadSession).toHaveBeenCalledWith(SESSION_ID, { force: true });
     });
+  });
+
+  it("does not let a late poll overwrite workspace restoration", async () => {
+    seedSession(runningSandbox({ status: "provisioning" }));
+    let finishPoll: (value: { status: "running" }) => void = () => {};
+    mockedApi.fetchSandboxStatus.mockReturnValue(
+      new Promise((resolve) => {
+        finishPoll = resolve;
+      })
+    );
+
+    renderHook(() => useSandboxSleepWatcher(), { wrapper });
+
+    await waitFor(() => {
+      expect(mockedApi.fetchSandboxStatus).toHaveBeenCalledTimes(1);
+    });
+    act(() => {
+      useBuildSessionStore.getState().updateSessionData(SESSION_ID, {
+        sandbox: runningSandbox({ status: "restoring" }),
+      });
+      finishPoll({ status: "running" });
+    });
+
+    await waitFor(() => {
+      const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
+      expect(session?.sandbox?.status).toBe("restoring");
+    });
+    expect(loadSession).not.toHaveBeenCalled();
   });
 
   it("stops polling once the sandbox is asleep", async () => {

--- a/web/src/app/craft/hooks/useSandboxSleepWatcher.test.tsx
+++ b/web/src/app/craft/hooks/useSandboxSleepWatcher.test.tsx
@@ -46,11 +46,15 @@ function seedSession(sandbox: ApiSandboxResponse): void {
 }
 
 describe("useSandboxSleepWatcher", () => {
+  let loadSession: jest.Mock;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    loadSession = jest.fn().mockResolvedValue(undefined);
     useBuildSessionStore.setState({
       sessions: new Map(),
       currentSessionId: null,
+      loadSession,
     } as never);
   });
 
@@ -82,7 +86,7 @@ describe("useSandboxSleepWatcher", () => {
     });
   });
 
-  it("never polls when the sandbox is not running", async () => {
+  it("never polls when the sandbox is not active or provisioning", async () => {
     seedSession(runningSandbox({ status: "sleeping" }));
 
     renderHook(() => useSandboxSleepWatcher(), { wrapper });
@@ -90,6 +94,33 @@ describe("useSandboxSleepWatcher", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(mockedApi.fetchSandboxStatus).not.toHaveBeenCalled();
+  });
+
+  it("keeps polling while the sandbox is provisioning", async () => {
+    seedSession(runningSandbox({ status: "provisioning" }));
+    mockedApi.fetchSandboxStatus.mockResolvedValue({
+      status: "provisioning",
+    });
+
+    renderHook(() => useSandboxSleepWatcher(), { wrapper });
+
+    await waitFor(() => {
+      expect(mockedApi.fetchSandboxStatus).toHaveBeenCalledTimes(1);
+    });
+    expect(loadSession).not.toHaveBeenCalled();
+  });
+
+  it("reconciles the session workspace when provisioning finishes", async () => {
+    seedSession(runningSandbox({ status: "provisioning" }));
+    mockedApi.fetchSandboxStatus.mockResolvedValue({
+      status: "running",
+    });
+
+    renderHook(() => useSandboxSleepWatcher(), { wrapper });
+
+    await waitFor(() => {
+      expect(loadSession).toHaveBeenCalledWith(SESSION_ID, { force: true });
+    });
   });
 
   it("stops polling once the sandbox is asleep", async () => {

--- a/web/src/app/craft/hooks/useSandboxSleepWatcher.ts
+++ b/web/src/app/craft/hooks/useSandboxSleepWatcher.ts
@@ -55,6 +55,9 @@ export function useSandboxSleepWatcher(): void {
           return;
         }
 
+        // loadSession owns the frontend-only restoring state until it has
+        // reconciled the workspace and preview readiness.
+        if (sandbox.status === "restoring") return;
         if (sandbox.status === data.status) return;
         updateSessionData(sessionId, {
           sandbox: { ...sandbox, status: data.status },

--- a/web/src/app/craft/hooks/useSandboxSleepWatcher.ts
+++ b/web/src/app/craft/hooks/useSandboxSleepWatcher.ts
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import useSWR from "swr";
 import {
   useSessionId,
@@ -8,6 +9,7 @@ import { fetchSandboxStatus } from "@/app/craft/services/apiServices";
 import { ApiSandboxStatusResponse } from "@/app/craft/types/streamingTypes";
 
 export const SANDBOX_STATUS_POLL_INTERVAL_MS = 30_000;
+export const SANDBOX_PROVISIONING_POLL_INTERVAL_MS = 2_000;
 
 export function useSandboxSleepWatcher(): void {
   const sessionId = useSessionId();
@@ -15,16 +17,21 @@ export function useSandboxSleepWatcher(): void {
   const updateSessionData = useBuildSessionStore(
     (state) => state.updateSessionData
   );
+  const loadSession = useBuildSessionStore((state) => state.loadSession);
   const status = session?.sandbox?.status ?? null;
+  const reconcilingSessionIdRef = useRef<string | null>(null);
+  const shouldPoll = status === "running" || status === "provisioning";
 
   useSWR<ApiSandboxStatusResponse, unknown, [string, string] | null>(
-    sessionId && status === "running" ? ["sandbox-status", sessionId] : null,
+    sessionId && shouldPoll ? ["sandbox-status", sessionId] : null,
     ([, id]) => fetchSandboxStatus(id),
     {
-      refreshInterval: SANDBOX_STATUS_POLL_INTERVAL_MS,
+      refreshInterval:
+        status === "provisioning"
+          ? SANDBOX_PROVISIONING_POLL_INTERVAL_MS
+          : SANDBOX_STATUS_POLL_INTERVAL_MS,
       onSuccess: (data) => {
-        if (!sessionId) return;
-        if (data.status !== "sleeping" && data.status !== "terminated") return;
+        if (!sessionId || data.status === null) return;
         // Use onSuccess (not a useEffect over `data`) — SWR can serve a stale
         // cached "sleeping"/"terminated" result right when a key re-activates
         // (e.g. after a wake flips status back to running), and an effect
@@ -32,11 +39,26 @@ export function useSandboxSleepWatcher(): void {
         const sandbox = useBuildSessionStore
           .getState()
           .sessions.get(sessionId)?.sandbox;
-        if (sandbox && sandbox.status === "running") {
-          updateSessionData(sessionId, {
-            sandbox: { ...sandbox, status: data.status },
+        if (!sandbox) return;
+
+        if (sandbox.status === "provisioning" && data.status === "running") {
+          // A running sandbox does not prove this session's workspace exists.
+          // Re-run the workspace-aware load so it restores the session when
+          // another request was responsible for provisioning the sandbox.
+          if (reconcilingSessionIdRef.current === sessionId) return;
+          reconcilingSessionIdRef.current = sessionId;
+          void loadSession(sessionId, { force: true }).finally(() => {
+            if (reconcilingSessionIdRef.current === sessionId) {
+              reconcilingSessionIdRef.current = null;
+            }
           });
+          return;
         }
+
+        if (sandbox.status === data.status) return;
+        updateSessionData(sessionId, {
+          sandbox: { ...sandbox, status: data.status },
+        });
       },
     }
   );

--- a/web/src/app/craft/hooks/useSandboxStatusReconciler.test.tsx
+++ b/web/src/app/craft/hooks/useSandboxStatusReconciler.test.tsx
@@ -4,15 +4,14 @@
 import React from "react";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { SWRConfig } from "swr";
-import { useSandboxSleepWatcher } from "@/app/craft/hooks/useSandboxSleepWatcher";
+import { useSandboxStatusReconciler } from "@/app/craft/hooks/useSandboxStatusReconciler";
 import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
 import * as api from "@/app/craft/services/apiServices";
-import { ApiSandboxResponse } from "@/app/craft/types/streamingTypes";
+import type { SandboxRuntimeState } from "@/app/craft/types/streamingTypes";
 
 jest.mock("@/app/craft/services/apiServices");
 
 const mockedApi = api as jest.Mocked<typeof api>;
-
 const SESSION_ID = "11111111-1111-1111-1111-111111111111";
 
 function wrapper({ children }: { children: React.ReactNode }) {
@@ -23,29 +22,28 @@ function wrapper({ children }: { children: React.ReactNode }) {
   );
 }
 
-function runningSandbox(
-  overrides: Partial<ApiSandboxResponse> = {}
-): ApiSandboxResponse {
+function sandbox(
+  overrides: Partial<SandboxRuntimeState> = {}
+): SandboxRuntimeState {
   return {
     id: "sb1",
     status: "running",
     container_id: null,
     created_at: "2026-07-01T00:00:00.000Z",
     last_heartbeat: "2026-07-01T00:00:00.000Z",
-    nextjs_port: null,
     ...overrides,
   };
 }
 
-function seedSession(sandbox: ApiSandboxResponse): void {
+function seedSession(sandboxState: SandboxRuntimeState): void {
   useBuildSessionStore.getState().createSession(SESSION_ID, {
     status: "running",
-    sandbox,
+    sandbox: sandboxState,
   });
   useBuildSessionStore.getState().setCurrentSession(SESSION_ID);
 }
 
-describe("useSandboxSleepWatcher", () => {
+describe("useSandboxStatusReconciler", () => {
   let loadSession: jest.Mock;
 
   beforeEach(() => {
@@ -58,51 +56,37 @@ describe("useSandboxSleepWatcher", () => {
     } as never);
   });
 
-  it("flips the sandbox to sleeping when the poll reports sleeping", async () => {
-    seedSession(runningSandbox());
-    mockedApi.fetchSandboxStatus.mockResolvedValue({
-      status: "sleeping",
-    });
+  it.each(["sleeping", "terminated", "failed"] as const)(
+    "updates the runtime state when the API reports %s",
+    async (status) => {
+      seedSession(sandbox());
+      mockedApi.fetchSandboxStatus.mockResolvedValue({ status });
 
-    renderHook(() => useSandboxSleepWatcher(), { wrapper });
+      renderHook(() => useSandboxStatusReconciler(), { wrapper });
 
-    await waitFor(() => {
-      const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
-      expect(session?.sandbox?.status).toBe("sleeping");
-    });
-  });
+      await waitFor(() => {
+        const session = useBuildSessionStore
+          .getState()
+          .sessions.get(SESSION_ID);
+        expect(session?.sandbox?.status).toBe(status);
+      });
+    }
+  );
 
-  it("flips the sandbox to terminated when the poll reports terminated", async () => {
-    seedSession(runningSandbox());
-    mockedApi.fetchSandboxStatus.mockResolvedValue({
-      status: "terminated",
-    });
+  it("does not poll an inactive sandbox", async () => {
+    seedSession(sandbox({ status: "sleeping" }));
 
-    renderHook(() => useSandboxSleepWatcher(), { wrapper });
-
-    await waitFor(() => {
-      const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
-      expect(session?.sandbox?.status).toBe("terminated");
-    });
-  });
-
-  it("never polls when the sandbox is not active or provisioning", async () => {
-    seedSession(runningSandbox({ status: "sleeping" }));
-
-    renderHook(() => useSandboxSleepWatcher(), { wrapper });
-
+    renderHook(() => useSandboxStatusReconciler(), { wrapper });
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(mockedApi.fetchSandboxStatus).not.toHaveBeenCalled();
   });
 
   it("keeps polling while the sandbox is provisioning", async () => {
-    seedSession(runningSandbox({ status: "provisioning" }));
-    mockedApi.fetchSandboxStatus.mockResolvedValue({
-      status: "provisioning",
-    });
+    seedSession(sandbox({ status: "provisioning" }));
+    mockedApi.fetchSandboxStatus.mockResolvedValue({ status: "provisioning" });
 
-    renderHook(() => useSandboxSleepWatcher(), { wrapper });
+    renderHook(() => useSandboxStatusReconciler(), { wrapper });
 
     await waitFor(() => {
       expect(mockedApi.fetchSandboxStatus).toHaveBeenCalledTimes(1);
@@ -110,13 +94,11 @@ describe("useSandboxSleepWatcher", () => {
     expect(loadSession).not.toHaveBeenCalled();
   });
 
-  it("reconciles the session workspace when provisioning finishes", async () => {
-    seedSession(runningSandbox({ status: "provisioning" }));
-    mockedApi.fetchSandboxStatus.mockResolvedValue({
-      status: "running",
-    });
+  it("reconciles the workspace when provisioning finishes", async () => {
+    seedSession(sandbox({ status: "provisioning" }));
+    mockedApi.fetchSandboxStatus.mockResolvedValue({ status: "running" });
 
-    renderHook(() => useSandboxSleepWatcher(), { wrapper });
+    renderHook(() => useSandboxStatusReconciler(), { wrapper });
 
     await waitFor(() => {
       expect(loadSession).toHaveBeenCalledWith(SESSION_ID, { force: true });
@@ -124,7 +106,7 @@ describe("useSandboxSleepWatcher", () => {
   });
 
   it("does not let a late poll overwrite workspace restoration", async () => {
-    seedSession(runningSandbox({ status: "provisioning" }));
+    seedSession(sandbox({ status: "provisioning" }));
     let finishPoll: (value: { status: "running" }) => void = () => {};
     mockedApi.fetchSandboxStatus.mockReturnValue(
       new Promise((resolve) => {
@@ -132,14 +114,14 @@ describe("useSandboxSleepWatcher", () => {
       })
     );
 
-    renderHook(() => useSandboxSleepWatcher(), { wrapper });
+    renderHook(() => useSandboxStatusReconciler(), { wrapper });
 
     await waitFor(() => {
       expect(mockedApi.fetchSandboxStatus).toHaveBeenCalledTimes(1);
     });
     act(() => {
       useBuildSessionStore.getState().updateSessionData(SESSION_ID, {
-        sandbox: runningSandbox({ status: "restoring" }),
+        sandbox: sandbox({ status: "restoring" }),
       });
       finishPoll({ status: "running" });
     });
@@ -151,39 +133,33 @@ describe("useSandboxSleepWatcher", () => {
     expect(loadSession).not.toHaveBeenCalled();
   });
 
-  it("stops polling once the sandbox is asleep", async () => {
-    seedSession(runningSandbox());
-    mockedApi.fetchSandboxStatus.mockResolvedValue({
-      status: "sleeping",
-    });
+  it("stops polling after the sandbox becomes inactive", async () => {
+    seedSession(sandbox());
+    mockedApi.fetchSandboxStatus.mockResolvedValue({ status: "sleeping" });
 
-    renderHook(() => useSandboxSleepWatcher(), { wrapper });
+    renderHook(() => useSandboxStatusReconciler(), { wrapper });
 
     await waitFor(() => {
       const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
       expect(session?.sandbox?.status).toBe("sleeping");
     });
-
     expect(mockedApi.fetchSandboxStatus).toHaveBeenCalledTimes(1);
 
     await new Promise((resolve) => setTimeout(resolve, 50));
-
     expect(mockedApi.fetchSandboxStatus).toHaveBeenCalledTimes(1);
   });
 
-  it("leaves the sandbox running when the poll reports running", async () => {
-    seedSession(runningSandbox());
-    mockedApi.fetchSandboxStatus.mockResolvedValue({
-      status: "running",
-    });
+  it("leaves an unchanged runtime status alone", async () => {
+    seedSession(sandbox());
+    mockedApi.fetchSandboxStatus.mockResolvedValue({ status: "running" });
 
-    renderHook(() => useSandboxSleepWatcher(), { wrapper });
+    renderHook(() => useSandboxStatusReconciler(), { wrapper });
 
     await waitFor(() => {
       expect(mockedApi.fetchSandboxStatus).toHaveBeenCalled();
     });
-
-    const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
-    expect(session?.sandbox?.status).toBe("running");
+    expect(
+      useBuildSessionStore.getState().sessions.get(SESSION_ID)?.sandbox?.status
+    ).toBe("running");
   });
 });

--- a/web/src/app/craft/hooks/useSandboxStatusReconciler.ts
+++ b/web/src/app/craft/hooks/useSandboxStatusReconciler.ts
@@ -6,45 +6,50 @@ import {
   useBuildSessionStore,
 } from "@/app/craft/hooks/useBuildSessionStore";
 import { fetchSandboxStatus } from "@/app/craft/services/apiServices";
-import { ApiSandboxStatusResponse } from "@/app/craft/types/streamingTypes";
+import type { ApiSandboxStatusResponse } from "@/app/craft/types/streamingTypes";
 
-export const SANDBOX_STATUS_POLL_INTERVAL_MS = 30_000;
-export const SANDBOX_PROVISIONING_POLL_INTERVAL_MS = 2_000;
+const SANDBOX_STATUS_POLL_INTERVAL_MS = 30_000;
+const SANDBOX_PROVISIONING_POLL_INTERVAL_MS = 2_000;
 
-export function useSandboxSleepWatcher(): void {
+export function useSandboxStatusReconciler(): void {
   const sessionId = useSessionId();
   const session = useSession();
   const updateSessionData = useBuildSessionStore(
     (state) => state.updateSessionData
   );
   const loadSession = useBuildSessionStore((state) => state.loadSession);
-  const status = session?.sandbox?.status ?? null;
+  const runtimeStatus = session?.sandbox?.status ?? null;
   const reconcilingSessionIdRef = useRef<string | null>(null);
-  const shouldPoll = status === "running" || status === "provisioning";
+  const shouldPoll =
+    runtimeStatus === "running" || runtimeStatus === "provisioning";
 
   useSWR<ApiSandboxStatusResponse, unknown, [string, string] | null>(
     sessionId && shouldPoll ? ["sandbox-status", sessionId] : null,
     ([, id]) => fetchSandboxStatus(id),
     {
       refreshInterval:
-        status === "provisioning"
+        runtimeStatus === "provisioning"
           ? SANDBOX_PROVISIONING_POLL_INTERVAL_MS
           : SANDBOX_STATUS_POLL_INTERVAL_MS,
       onSuccess: (data) => {
         if (!sessionId || data.status === null) return;
-        // Use onSuccess (not a useEffect over `data`) — SWR can serve a stale
-        // cached "sleeping"/"terminated" result right when a key re-activates
-        // (e.g. after a wake flips status back to running), and an effect
-        // over `data` would re-apply that stale value and wedge the UI.
+
+        // Read current state instead of the render snapshot: a restore may have
+        // started while this request was in flight.
         const sandbox = useBuildSessionStore
           .getState()
           .sessions.get(sessionId)?.sandbox;
         if (!sandbox) return;
 
+        // loadSession owns the client-only restoring state until workspace and
+        // preview readiness have both been reconciled.
+        if (sandbox.status === "restoring" || sandbox.status === data.status) {
+          return;
+        }
+
         if (sandbox.status === "provisioning" && data.status === "running") {
-          // A running sandbox does not prove this session's workspace exists.
-          // Re-run the workspace-aware load so it restores the session when
-          // another request was responsible for provisioning the sandbox.
+          // A running sandbox does not prove that this session's workspace is
+          // loaded, so use the workspace-aware session loader.
           if (reconcilingSessionIdRef.current === sessionId) return;
           reconcilingSessionIdRef.current = sessionId;
           void loadSession(sessionId, { force: true }).finally(() => {
@@ -55,10 +60,6 @@ export function useSandboxSleepWatcher(): void {
           return;
         }
 
-        // loadSession owns the frontend-only restoring state until it has
-        // reconciled the workspace and preview readiness.
-        if (sandbox.status === "restoring") return;
-        if (sandbox.status === data.status) return;
         updateSessionData(sessionId, {
           sandbox: { ...sandbox, status: data.status },
         });

--- a/web/src/app/craft/hooks/useWakeOnIntent.test.ts
+++ b/web/src/app/craft/hooks/useWakeOnIntent.test.ts
@@ -4,20 +4,19 @@
 import { renderHook } from "@testing-library/react";
 import { useWakeOnIntent } from "@/app/craft/hooks/useWakeOnIntent";
 import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
-import { ApiSandboxResponse } from "@/app/craft/types/streamingTypes";
+import type { SandboxRuntimeState } from "@/app/craft/types/streamingTypes";
 
 const SESSION_ID = "11111111-1111-1111-1111-111111111111";
 
 function sandbox(
-  overrides: Partial<ApiSandboxResponse> = {}
-): ApiSandboxResponse {
+  overrides: Partial<SandboxRuntimeState> = {}
+): SandboxRuntimeState {
   return {
     id: "sb1",
     status: "sleeping",
     container_id: null,
     created_at: "2026-07-01T00:00:00.000Z",
     last_heartbeat: "2026-07-01T00:00:00.000Z",
-    nextjs_port: null,
     ...overrides,
   };
 }
@@ -34,7 +33,7 @@ describe("useWakeOnIntent", () => {
     } as never);
   });
 
-  function seedSession(sandboxState: ApiSandboxResponse): void {
+  function seedSession(sandboxState: SandboxRuntimeState): void {
     useBuildSessionStore.getState().createSession(SESSION_ID, {
       status: "running",
       sandbox: sandboxState,

--- a/web/src/app/craft/types/streamingTypes.ts
+++ b/web/src/app/craft/types/streamingTypes.ts
@@ -154,24 +154,23 @@ export interface SessionHistoryItem {
 // API Response Types
 // =============================================================================
 
+export type ApiSandboxStatus =
+  | "provisioning"
+  | "running"
+  | "sleeping"
+  | "terminated"
+  | "failed";
+
 export interface ApiSandboxResponse {
   id: string;
-  status:
-    | "provisioning"
-    | "running"
-    | "idle"
-    | "sleeping"
-    | "terminated"
-    | "failed"
-    | "restoring"; // Frontend-only: set during snapshot restore
+  status: ApiSandboxStatus;
   container_id: string | null;
   created_at: string;
   last_heartbeat: string | null;
-  nextjs_port: number | null;
 }
 
 export interface ApiSandboxStatusResponse {
-  status: Exclude<ApiSandboxResponse["status"], "restoring"> | null;
+  status: ApiSandboxStatus | null;
 }
 
 export interface ApiSessionResponse {
@@ -181,6 +180,7 @@ export interface ApiSessionResponse {
   status: "initializing" | "active" | "idle" | "failed";
   created_at: string;
   last_activity_at: string;
+  nextjs_port: number | null;
   sandbox: ApiSandboxResponse | null;
   artifacts: ApiArtifactResponse[];
   sharing_scope: SharingScope;
@@ -252,6 +252,19 @@ export interface FileSystemEntry {
 export interface DirectoryListing {
   path: string;
   entries: FileSystemEntry[];
+}
+
+// =============================================================================
+// Client Runtime Types
+// =============================================================================
+
+export type SandboxRuntimeStatus = ApiSandboxStatus | "restoring";
+
+export interface SandboxRuntimeState extends Omit<
+  ApiSandboxResponse,
+  "status"
+> {
+  status: SandboxRuntimeStatus;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Description

<img width="1178" height="412" alt="Craft stuck on Initializing sandbox" src="https://github.com/user-attachments/assets/f58fcf3d-baaf-4db1-9265-31ef57ad4671" />

Fix Craft sessions getting stuck on “Initializing sandbox...” when an open tab observes a sandbox while it is provisioning.

The client previously polled only a `running` sandbox. If session loading captured `provisioning`, polling stopped and the tab never observed the transition to `running`; a force reload was then required to restore the session workspace. A late status response could also overwrite the client-owned `restoring` state while that restore was still in progress.

This change:

- reconciles both provisioning and running sandboxes, polling provisioning transitions at a shorter interval
- invokes the existing workspace-aware session loader when provisioning finishes, with duplicate reconciliation guarded
- preserves the client-owned restoring state until workspace and preview readiness are complete
- moves lifecycle reconciliation into the session controller, leaving the asleep notice presentation-only
- separates backend API, client runtime, and display-only sandbox statuses and removes the nonexistent sandbox `idle` state
- treats missing sandbox data as loading instead of optimistically reporting running
- aligns `nextjs_port` with the backend response contract and reads it from the session when constructing preview URLs
- adds Storybook playground and all-state gallery entries for the sandbox status indicator

This is frontend-only and can land independently of #13688. That PR makes interactive turns restore their session runtime atomically; this PR keeps an existing tab synchronized when another request provisions the user's sandbox.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
