### PR TITLE
feat(craft): bake webapp dev-server env into the sandbox so hand-started servers work

### DIFF
--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -560,9 +560,8 @@ def build_container_create_kwargs(
         "ONYX_API_PREFIX": "",
         OPENCODE_SERVER_PASSWORD: opencode_password,
         "OPENCODE_CONFIG_CONTENT": opencode_config_json,
-        # Deployment-global (same for every session), so a dev server the agent
-        # starts by hand inherits the dev-origin allowlist the managed start
-        # path also sets.
+        # In the container env so a dev server the agent starts by hand
+        # inherits the allowlist the managed start path also sets.
         "ONYX_WEBAPP_ALLOWED_DEV_ORIGINS": allowed_dev_origins(),
     }
 

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -128,7 +128,10 @@ from onyx.server.features.build.sandbox.models import (
     SandboxInfo,
     SnapshotResult,
 )
-from onyx.server.features.build.sandbox.nextjs_dev import build_nextjs_start_script
+from onyx.server.features.build.sandbox.nextjs_dev import (
+    allowed_dev_origins,
+    build_nextjs_start_script,
+)
 from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
 from onyx.server.features.build.sandbox.session_workspace import (
     MANAGED_SKILLS_PATH,
@@ -557,6 +560,10 @@ def build_container_create_kwargs(
         "ONYX_API_PREFIX": "",
         OPENCODE_SERVER_PASSWORD: opencode_password,
         "OPENCODE_CONFIG_CONTENT": opencode_config_json,
+        # Deployment-global (same for every session), so a dev server the agent
+        # starts by hand inherits the dev-origin allowlist the managed start
+        # path also sets.
+        "ONYX_WEBAPP_ALLOWED_DEV_ORIGINS": allowed_dev_origins(),
     }
 
     security_opts = ["no-new-privileges:true"]

--- a/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/next.config.ts
+++ b/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/next.config.ts
@@ -1,8 +1,7 @@
 import type { NextConfig } from "next";
 
-// basePath is per-session. Prefer the managed env var, but fall back to the
-// session id in the cwd (.../sessions/<id>/outputs/web) so a dev server the
-// agent starts by hand still serves under the path the preview proxy expects.
+// The cwd fallback lets a dev server the agent starts by hand still serve
+// under the path the preview proxy expects.
 function resolveWebappBasePath(): string | undefined {
   if (process.env.ONYX_WEBAPP_BASE_PATH) {
     return process.env.ONYX_WEBAPP_BASE_PATH;

--- a/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/next.config.ts
+++ b/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/next.config.ts
@@ -1,6 +1,17 @@
 import type { NextConfig } from "next";
 
-const webappBasePath = process.env.ONYX_WEBAPP_BASE_PATH || undefined;
+// basePath is per-session. Prefer the managed env var, but fall back to the
+// session id in the cwd (.../sessions/<id>/outputs/web) so a dev server the
+// agent starts by hand still serves under the path the preview proxy expects.
+function resolveWebappBasePath(): string | undefined {
+  if (process.env.ONYX_WEBAPP_BASE_PATH) {
+    return process.env.ONYX_WEBAPP_BASE_PATH;
+  }
+  const match = process.cwd().match(/\/sessions\/([^/]+)\/outputs\/web\/?$/);
+  return match ? `/api/build/sessions/${match[1]}/webapp` : undefined;
+}
+
+const webappBasePath = resolveWebappBasePath();
 const allowedDevOrigins = (process.env.ONYX_WEBAPP_ALLOWED_DEV_ORIGINS || "")
   .split(",")
   .map((origin) => origin.trim())

--- a/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/package.json
+++ b/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p ${ONYX_WEBAPP_PORT:-$(cat ../../.nextjs-port 2>/dev/null || echo 3000)}",
     "build": "next build",
     "start": "next start",
     "lint": "oxlint"

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -533,9 +533,8 @@ class KubernetesSandboxManager(SandboxManager):
                     )
                 ),
             ),
-            # Deployment-global (same for every session), so a dev server the
-            # agent starts by hand inherits the dev-origin allowlist the managed
-            # start path also sets.
+            # In the pod env so a dev server the agent starts by hand inherits
+            # the allowlist the managed start path also sets.
             client.V1EnvVar(
                 name="ONYX_WEBAPP_ALLOWED_DEV_ORIGINS",
                 value=allowed_dev_origins(),

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -115,7 +115,10 @@ from onyx.server.features.build.sandbox.models import (
     SandboxProvisionContentionError,
     SnapshotResult,
 )
-from onyx.server.features.build.sandbox.nextjs_dev import build_nextjs_start_script
+from onyx.server.features.build.sandbox.nextjs_dev import (
+    allowed_dev_origins,
+    build_nextjs_start_script,
+)
 from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
 from onyx.server.features.build.sandbox.session_workspace import (
     SESSIONS_ROOT,
@@ -529,6 +532,13 @@ class KubernetesSandboxManager(SandboxManager):
                         key=self._OPENCODE_CONFIG_SECRET_KEY,
                     )
                 ),
+            ),
+            # Deployment-global (same for every session), so a dev server the
+            # agent starts by hand inherits the dev-origin allowlist the managed
+            # start path also sets.
+            client.V1EnvVar(
+                name="ONYX_WEBAPP_ALLOWED_DEV_ORIGINS",
+                value=allowed_dev_origins(),
             ),
         ]
 

--- a/backend/onyx/server/features/build/sandbox/nextjs_dev.py
+++ b/backend/onyx/server/features/build/sandbox/nextjs_dev.py
@@ -4,10 +4,15 @@ Shared by the Docker and Kubernetes sandbox managers so the dev-server
 environment (base path, allowed dev origins) stays identical across backends.
 """
 
+from pathlib import Path
 from urllib.parse import urlparse
 
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.server.features.build.sandbox.base import BUN_CACHE_DIR
+
+_TEMPLATE_NEXT_CONFIG = (
+    Path(__file__).parent / "image" / "templates" / "outputs" / "web" / "next.config.ts"
+)
 
 
 def allowed_dev_origins() -> str:
@@ -35,6 +40,11 @@ def build_nextjs_start_script(
     Returns:
         Shell script string to start the NextJS server.
     """
+    # Legacy sessions (scaffolded with a WEBAPP_ASSET_PREFIX placeholder config)
+    # get rewritten to the current template. Read it rather than duplicate it, so
+    # the two can't drift.
+    template_next_config = _TEMPLATE_NEXT_CONFIG.read_text().strip()
+
     install_check = ""
     if check_node_modules:
         install_check = f"""
@@ -47,6 +57,10 @@ fi
 
     return f"""
 set -e
+# Naive-path fallback: the session's dedicated port, read by the template's
+# `dev` script (`next dev -p $(cat ../../.nextjs-port ...)`) so a `bun run dev`
+# the agent runs by hand still binds the port the preview proxy routes to.
+echo {nextjs_port} > {session_path}/.nextjs-port
 # Replay safety: a live server already attached to this session keeps its
 # port; spawning a second one would fail to bind and leave a zombie. The
 # check-and-spawn is serialized under its own flock so two replays (e.g. a
@@ -66,36 +80,21 @@ if [ -n "$NEXTJS_PID" ] && kill -0 "$NEXTJS_PID" 2>/dev/null && \
 else
 cd {session_path}/outputs/web
 {install_check}
+export ONYX_WEBAPP_PORT={nextjs_port}
 export ONYX_WEBAPP_BASE_PATH="/api/build/sessions/$(basename {session_path})/webapp"
 export ONYX_WEBAPP_ALLOWED_DEV_ORIGINS="{allowed_dev_origins()}"
 if grep -q "WEBAPP_ASSET_PREFIX" next.config.ts 2>/dev/null; then
     cat > next.config.ts <<'EOF'
-import type {{ NextConfig }} from "next";
-
-const webappBasePath = process.env.ONYX_WEBAPP_BASE_PATH || undefined;
-const allowedDevOrigins = (process.env.ONYX_WEBAPP_ALLOWED_DEV_ORIGINS || "")
-  .split(",")
-  .map((origin) => origin.trim())
-  .filter(Boolean);
-
-const nextConfig: NextConfig = {{}};
-
-if (webappBasePath) {{
-  nextConfig.basePath = webappBasePath;
-  nextConfig.assetPrefix = webappBasePath;
-}}
-
-if (allowedDevOrigins.length > 0) {{
-  nextConfig.allowedDevOrigins = allowedDevOrigins;
-}}
-
-export default nextConfig;
+{template_next_config}
 EOF
 fi
 echo "Starting Next.js dev server on port {nextjs_port}..."
+# Port comes from ONYX_WEBAPP_PORT (exported above), resolved by the template's
+# `dev` script — a single source of truth shared with the agent's naive path,
+# and no duplicate -p flag.
 # 9>&-: the server must not inherit the lock fd, or it would hold the
 # check-and-spawn lock for its entire lifetime.
-nohup bun run dev -- -H 0.0.0.0 -p {nextjs_port} > {session_path}/nextjs.log 2>&1 9>&- &
+nohup bun run dev -- -H 0.0.0.0 > {session_path}/nextjs.log 2>&1 9>&- &
 NEXTJS_PID=$!
 echo "Next.js server started with PID $NEXTJS_PID"
 echo $NEXTJS_PID > {session_path}/nextjs.pid

--- a/backend/onyx/server/features/build/sandbox/nextjs_dev.py
+++ b/backend/onyx/server/features/build/sandbox/nextjs_dev.py
@@ -40,9 +40,7 @@ def build_nextjs_start_script(
     Returns:
         Shell script string to start the NextJS server.
     """
-    # Legacy sessions (scaffolded with a WEBAPP_ASSET_PREFIX placeholder config)
-    # get rewritten to the current template. Read it rather than duplicate it, so
-    # the two can't drift.
+    # Read the template rather than duplicate it, so the two can't drift.
     template_next_config = _TEMPLATE_NEXT_CONFIG.read_text().strip()
 
     install_check = ""
@@ -57,9 +55,8 @@ fi
 
     return f"""
 set -e
-# Naive-path fallback: the session's dedicated port, read by the template's
-# `dev` script (`next dev -p $(cat ../../.nextjs-port ...)`) so a `bun run dev`
-# the agent runs by hand still binds the port the preview proxy routes to.
+# Read by the template's `dev` script so a `bun run dev` the agent runs by
+# hand still binds the port the preview proxy routes to.
 echo {nextjs_port} > {session_path}/.nextjs-port
 # Replay safety: a live server already attached to this session keeps its
 # port; spawning a second one would fail to bind and leave a zombie. The
@@ -89,9 +86,8 @@ if grep -q "WEBAPP_ASSET_PREFIX" next.config.ts 2>/dev/null; then
 EOF
 fi
 echo "Starting Next.js dev server on port {nextjs_port}..."
-# Port comes from ONYX_WEBAPP_PORT (exported above), resolved by the template's
-# `dev` script — a single source of truth shared with the agent's naive path,
-# and no duplicate -p flag.
+# No -p here: the template's `dev` script resolves ONYX_WEBAPP_PORT itself,
+# and a second -p would collide with its own.
 # 9>&-: the server must not inherit the lock fd, or it would hold the
 # check-and-spawn lock for its entire lifetime.
 nohup bun run dev -- -H 0.0.0.0 > {session_path}/nextjs.log 2>&1 9>&- &

--- a/backend/onyx/server/features/build/sandbox/nextjs_dev.py
+++ b/backend/onyx/server/features/build/sandbox/nextjs_dev.py
@@ -85,12 +85,18 @@ if grep -q "WEBAPP_ASSET_PREFIX" next.config.ts 2>/dev/null; then
 {template_next_config}
 EOF
 fi
+# The template's `dev` script resolves ONYX_WEBAPP_PORT itself; a second -p
+# would collide with its own. But a `dev` script without the marker (legacy
+# scaffold, or rewritten by the agent) ignores the env var and would bind
+# 3000, so pass the port explicitly for those.
+PORT_FLAG=""
+if ! grep -q "ONYX_WEBAPP_PORT" package.json 2>/dev/null; then
+    PORT_FLAG="-p {nextjs_port}"
+fi
 echo "Starting Next.js dev server on port {nextjs_port}..."
-# No -p here: the template's `dev` script resolves ONYX_WEBAPP_PORT itself,
-# and a second -p would collide with its own.
 # 9>&-: the server must not inherit the lock fd, or it would hold the
 # check-and-spawn lock for its entire lifetime.
-nohup bun run dev -- -H 0.0.0.0 > {session_path}/nextjs.log 2>&1 9>&- &
+nohup bun run dev -- -H 0.0.0.0 $PORT_FLAG > {session_path}/nextjs.log 2>&1 9>&- &
 NEXTJS_PID=$!
 echo "Next.js server started with PID $NEXTJS_PID"
 echo $NEXTJS_PID > {session_path}/nextjs.pid

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_manager_config.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_manager_config.py
@@ -505,6 +505,7 @@ def test_container_kwargs_env_is_a_minimal_allowlist(
         "ONYX_API_PREFIX",
         "OPENCODE_SERVER_PASSWORD",
         "OPENCODE_CONFIG_CONTENT",
+        "ONYX_WEBAPP_ALLOWED_DEV_ORIGINS",
     }
 
 
@@ -772,6 +773,7 @@ def test_proxy_kwargs_env_is_a_locked_allowlist(
         "ONYX_API_PREFIX",
         "OPENCODE_SERVER_PASSWORD",
         "OPENCODE_CONFIG_CONTENT",
+        "ONYX_WEBAPP_ALLOWED_DEV_ORIGINS",
         # firewall-init.sh contract
         "SANDBOX_PROXY_HOST",
         "SANDBOX_PROXY_PORT",

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_serve_plumbing.py
@@ -432,6 +432,7 @@ def test_provision_generates_fresh_password_and_injects_into_container_env(
         "ONYX_API_PREFIX",
         OPENCODE_SERVER_PASSWORD,
         "OPENCODE_CONFIG_CONTENT",
+        "ONYX_WEBAPP_ALLOWED_DEV_ORIGINS",
     }
     assert run_calls[0]["ports"] == {
         dev_mode_serve.OPENCODE_SERVE_CONTAINER_PORT: (

--- a/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 from uuid import UUID
@@ -19,6 +20,14 @@ _TEMPLATE_NEXT_CONFIG = (
     / "outputs"
     / "web"
     / "next.config.ts"
+)
+_TEMPLATE_PACKAGE_JSON = (
+    Path(nextjs_dev.__file__).parent
+    / "image"
+    / "templates"
+    / "outputs"
+    / "web"
+    / "package.json"
 )
 
 
@@ -39,8 +48,7 @@ def test_start_script_port_is_env_driven_not_a_dup_flag() -> None:
     script = build_nextjs_start_script(_SESSION_PATH, 3010)
 
     assert "export ONYX_WEBAPP_PORT=3010" in script
-    assert "-p 3010" not in script
-    assert "bun run dev -- -H 0.0.0.0 >" in script
+    assert "bun run dev -- -H 0.0.0.0 $PORT_FLAG >" in script
 
 
 def test_start_script_writes_naive_path_port_file() -> None:
@@ -49,6 +57,35 @@ def test_start_script_writes_naive_path_port_file() -> None:
     script = build_nextjs_start_script(_SESSION_PATH, 3010)
 
     assert f"echo 3010 > {_SESSION_PATH}/.nextjs-port" in script
+
+
+def test_template_dev_script_wires_port_to_managed_env_and_port_file() -> None:
+    """The template `dev` script is the port contract's consumer side: the
+    managed launch flows the port via ONYX_WEBAPP_PORT, and a hand-started
+    `bun run dev` falls back to the `.nextjs-port` file the start script writes
+    (`../../` from the web dir is the session root)."""
+    dev_script = json.loads(_TEMPLATE_PACKAGE_JSON.read_text())["scripts"]["dev"]
+
+    assert dev_script.startswith("next dev -p ")
+    assert (
+        "${ONYX_WEBAPP_PORT:-$(cat ../../.nextjs-port 2>/dev/null || echo 3000)}"
+        in dev_script
+    )
+
+    web_dir = Path(_SESSION_PATH) / "outputs" / "web"
+    assert (web_dir / "../../.nextjs-port").resolve() == Path(
+        _SESSION_PATH
+    ) / ".nextjs-port"
+
+
+def test_start_script_passes_port_flag_when_dev_script_ignores_env() -> None:
+    """A `dev` script without the ONYX_WEBAPP_PORT marker (legacy scaffold, or
+    rewritten by the agent) ignores the env var and would bind 3000; the
+    managed launch must pass -p explicitly for those."""
+    script = build_nextjs_start_script(_SESSION_PATH, 3010)
+
+    assert 'if ! grep -q "ONYX_WEBAPP_PORT" package.json 2>/dev/null; then' in script
+    assert 'PORT_FLAG="-p 3010"' in script
 
 
 def test_start_script_allowed_dev_origins_is_hostname_only() -> None:

--- a/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
@@ -31,7 +31,25 @@ def test_start_script_exports_allowed_dev_origins() -> None:
         'export ONYX_WEBAPP_BASE_PATH="/api/build/sessions/'
         f'$(basename {_SESSION_PATH})/webapp"' in script
     )
-    assert "-p 3010" in script
+
+
+def test_start_script_port_is_env_driven_not_a_dup_flag() -> None:
+    """The managed launch passes the port via ONYX_WEBAPP_PORT (resolved by the
+    template's `dev` script), not a `-p` flag — so it never collides with the
+    dev script's own `-p` and stays the single source of truth."""
+    script = build_nextjs_start_script(_SESSION_PATH, 3010)
+
+    assert "export ONYX_WEBAPP_PORT=3010" in script
+    assert "-p 3010" not in script
+    assert "bun run dev -- -H 0.0.0.0 >" in script
+
+
+def test_start_script_writes_naive_path_port_file() -> None:
+    """A hand-started `bun run dev` reads this file, so the preview proxy still
+    finds the server on the port it routes to."""
+    script = build_nextjs_start_script(_SESSION_PATH, 3010)
+
+    assert f"echo 3010 > {_SESSION_PATH}/.nextjs-port" in script
 
 
 def test_start_script_allowed_dev_origins_is_hostname_only() -> None:

--- a/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
@@ -34,9 +34,8 @@ def test_start_script_exports_allowed_dev_origins() -> None:
 
 
 def test_start_script_port_is_env_driven_not_a_dup_flag() -> None:
-    """The managed launch passes the port via ONYX_WEBAPP_PORT (resolved by the
-    template's `dev` script), not a `-p` flag — so it never collides with the
-    dev script's own `-p` and stays the single source of truth."""
+    """A `-p` flag would collide with the template `dev` script's own `-p`;
+    the port must flow via ONYX_WEBAPP_PORT."""
     script = build_nextjs_start_script(_SESSION_PATH, 3010)
 
     assert "export ONYX_WEBAPP_PORT=3010" in script

--- a/backend/tests/unit/onyx/server/features/craft/test_rewrite_asset_paths.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_rewrite_asset_paths.py
@@ -54,8 +54,6 @@ class TestNextjsProxyMountContract:
         ) in source
         assert "export WEBAPP_ASSET_PREFIX" not in source
         assert 'grep -q "WEBAPP_ASSET_PREFIX" next.config.ts' in source
-        # The legacy rewrite now injects the scaffold template verbatim, so the
-        # basePath/assetPrefix contract is pinned on the template itself.
         template = SANDBOX_WEB_NEXT_CONFIG.read_text()
         assert "nextConfig.basePath = webappBasePath" in template
         assert "nextConfig.assetPrefix = webappBasePath" in template

--- a/backend/tests/unit/onyx/server/features/craft/test_rewrite_asset_paths.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_rewrite_asset_paths.py
@@ -45,6 +45,19 @@ class TestNextjsProxyMountContract:
         assert "assetPrefix" in config_source
         assert re.search(r"\bbasePath\s*[:=]", config_source)
 
+    def test_template_cwd_fallback_pins_session_base_path(self) -> None:
+        """When ONYX_WEBAPP_BASE_PATH is unset (hand-started server), the
+        template derives the per-session base path from the session id in the
+        cwd. Pinned so the naive path can't silently serve without the base path
+        the preview proxy expects."""
+        config_source = NEXT_TEMPLATE_CONFIG.read_text()
+
+        assert (
+            "process.cwd().match(/\\/sessions\\/([^/]+)\\/outputs\\/web\\/?$/)"
+            in config_source
+        )
+        assert "`/api/build/sessions/${match[1]}/webapp`" in config_source
+
     def test_sandbox_start_script_exports_next_base_path(self) -> None:
         source = NEXTJS_DEV_SCRIPT.read_text()
 

--- a/backend/tests/unit/onyx/server/features/craft/test_rewrite_asset_paths.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_rewrite_asset_paths.py
@@ -23,6 +23,10 @@ NEXT_TEMPLATE_CONFIG = (
     / "sandbox/image/templates/outputs/web/next.config.ts"
 )
 NEXTJS_DEV_SCRIPT = Path(api.__file__).resolve().parents[0] / "sandbox/nextjs_dev.py"
+SANDBOX_WEB_NEXT_CONFIG = (
+    Path(api.__file__).resolve().parents[0]
+    / "sandbox/image/templates/outputs/web/next.config.ts"
+)
 WEB_NEXT_CONFIG = find_ancestor_containing("web/next.config.js") / "web/next.config.js"
 
 
@@ -50,8 +54,11 @@ class TestNextjsProxyMountContract:
         ) in source
         assert "export WEBAPP_ASSET_PREFIX" not in source
         assert 'grep -q "WEBAPP_ASSET_PREFIX" next.config.ts' in source
-        assert "nextConfig.basePath = webappBasePath" in source
-        assert "nextConfig.assetPrefix = webappBasePath" in source
+        # The legacy rewrite now injects the scaffold template verbatim, so the
+        # basePath/assetPrefix contract is pinned on the template itself.
+        template = SANDBOX_WEB_NEXT_CONFIG.read_text()
+        assert "nextConfig.basePath = webappBasePath" in template
+        assert "nextConfig.assetPrefix = webappBasePath" in template
 
     def test_web_dev_rewrites_hmr_websocket_to_backend(self) -> None:
         """Local Next dev cannot proxy websocket upgrades via /api/[...path]."""


### PR DESCRIPTION
## Description

When the agent starts the webapp dev server by hand (`bun run dev`) instead of via the managed start script, the server came up without the environment the preview proxy depends on: wrong port, no basePath, and no allowed dev origins. This PR bakes that environment into the sandbox itself so both launch paths behave identically:

- **Port**: the template's `dev` script now resolves its own port from `ONYX_WEBAPP_PORT`, falling back to a `.nextjs-port` file the managed start script writes into the session dir. The managed launch exports the env var and no longer passes a duplicate `-p` flag.
- **basePath / assetPrefix**: the template `next.config.ts` falls back to deriving the session id from the cwd (`.../sessions/<id>/outputs/web`) when `ONYX_WEBAPP_BASE_PATH` is unset, so a hand-started server still serves under the path the proxy routes to.
- **Allowed dev origins**: `ONYX_WEBAPP_ALLOWED_DEV_ORIGINS` is deployment-global, so it is now set in the container env (Docker) / pod env (Kubernetes) rather than only in the managed start script.
- The legacy `next.config.ts` rewrite in the start script now injects the scaffold template verbatim (read from disk) instead of a duplicated inline copy, so the two cannot drift.
- **Legacy sessions**: a session whose `package.json` predates the env-driven `dev` script (or where the agent rewrote it) would ignore `ONYX_WEBAPP_PORT` and bind 3000, so the managed launch detects the missing marker and passes `-p` explicitly for those. No user-owned files are mutated; legacy sessions keep today's behavior and new sessions get the env-driven scheme.

## How Has This Been Tested?

Unit tests: `test_nextjs_dev.py` (port flows via `ONYX_WEBAPP_PORT`, no duplicate `-p` flag, `.nextjs-port` file written, explicit `-p` fallback for legacy dev scripts), `test_rewrite_asset_paths.py` (basePath/assetPrefix contract pinned on the template), and `test_docker_manager_config.py` / `test_docker_serve_plumbing.py` (container env allowlists include the new var). All pass locally.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check