### PR TITLE
feat(gateway): tag PAT gateway traffic with its own LLM flow

### DIFF
--- a/backend/onyx/server/features/build/craft_gateway.py
+++ b/backend/onyx/server/features/build/craft_gateway.py
@@ -4,6 +4,7 @@ from onyx.auth.permissions import resolve_effective_permissions
 from onyx.db.enums import Permission
 from onyx.db.models import User
 from onyx.server.features.build.utils import is_craft_enabled_for_user
+from onyx.tracing.flows import LLMFlow
 
 
 def is_craft_gateway_request(request: Request, user: User) -> bool:
@@ -19,13 +20,19 @@ def is_craft_gateway_request(request: Request, user: User) -> bool:
     return token_grants_gateway and is_craft_enabled_for_user(user)
 
 
-def is_gateway_request(request: Request, user: User) -> bool:
+def gateway_request_flow(request: Request, user: User) -> LLMFlow | None:
     """A CRAFT_SANDBOX token must stay on the Craft policy, craft-enabled
-    requirement included; only a directly granted USE_LLM_GATEWAY skips it."""
+    requirement included; only a directly granted USE_LLM_GATEWAY skips it.
+    Future caller-declared sources should become additional LLMFlow return
+    values here, not booleans."""
     token_scopes: list[Permission] | None = getattr(request.state, "token_scopes", None)
     if token_scopes is None:
-        return False
+        return None
     raw_scopes = {s.value for s in token_scopes}
     if Permission.CRAFT_SANDBOX.value in raw_scopes:
-        return is_craft_gateway_request(request, user)
-    return Permission.USE_LLM_GATEWAY.value in resolve_effective_permissions(raw_scopes)
+        if is_craft_gateway_request(request, user):
+            return LLMFlow.CRAFT_LLM_GENERATION
+        return None
+    if Permission.USE_LLM_GATEWAY.value in resolve_effective_permissions(raw_scopes):
+        return LLMFlow.LLM_GATEWAY
+    return None

--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -136,10 +136,6 @@ def _gateway_trace(flow: LLMFlow, model: str) -> Trace:
 
 
 def _gateway_flow(http_request: Request) -> LLMFlow:
-    """Callers never supply the flow; it is derived from the credential that
-    authorized the request. Craft sandbox tokens are Craft traffic; a directly
-    granted use:llm_gateway PAT is external gateway traffic (Claude Code,
-    codex, ...), which tracing and usage metering must attribute separately."""
     token_scopes: list[Permission] | None = getattr(
         http_request.state, "token_scopes", None
     )

--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -47,7 +47,7 @@ from onyx.llm.models import (
 from onyx.llm.multi_llm import LLMRateLimitError, LLMTimeoutError
 from onyx.llm.prompt_cache.processor import process_with_prompt_cache
 from onyx.llm.tracing_wrap import _finalize_tool_calls, _merge_tool_call_delta
-from onyx.server.features.build.craft_gateway import is_gateway_request
+from onyx.server.features.build.craft_gateway import gateway_request_flow
 from onyx.server.gateway.configs import GATEWAY_PATH_PREFIX
 from onyx.server.gateway.model_catalog import build_gateway_model_catalog
 from onyx.server.gateway.models import (
@@ -135,22 +135,14 @@ def _gateway_trace(flow: LLMFlow, model: str) -> Trace:
     return trace("llm_gateway", metadata={"flow": flow.value, "model": model})
 
 
-def _gateway_flow(http_request: Request) -> LLMFlow:
-    token_scopes: list[Permission] | None = getattr(
-        http_request.state, "token_scopes", None
-    )
-    if token_scopes and Permission.CRAFT_SANDBOX in token_scopes:
-        return LLMFlow.CRAFT_LLM_GENERATION
-    return LLMFlow.LLM_GATEWAY
-
-
 def _authorize_gateway_request(http_request: Request, user: User) -> LLMFlow:
-    if not is_gateway_request(http_request, user):
+    flow = gateway_request_flow(http_request, user)
+    if flow is None:
         raise OnyxError(
             OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
             "This credential is not authorized to use the Onyx LLM gateway.",
         )
-    return _gateway_flow(http_request)
+    return flow
 
 
 def resolve_gateway_model(

--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -126,13 +126,6 @@ logger = setup_logger()
 
 router = APIRouter(prefix=GATEWAY_PATH_PREFIX)
 
-# Callers never supply the flow; the endpoint picks it and this mapping
-# enforces the matching credential.
-_FLOW_ACCESS_CHECKS: dict[LLMFlow, Callable[[Request, User], bool]] = {
-    LLMFlow.CRAFT_LLM_GENERATION: is_gateway_request,
-}
-
-
 _MESSAGES_ADAPTER: TypeAdapter[list[ChatCompletionMessage]] = TypeAdapter(
     list[ChatCompletionMessage]
 )
@@ -142,14 +135,26 @@ def _gateway_trace(flow: LLMFlow, model: str) -> Trace:
     return trace("llm_gateway", metadata={"flow": flow.value, "model": model})
 
 
+def _gateway_flow(http_request: Request) -> LLMFlow:
+    """Callers never supply the flow; it is derived from the credential that
+    authorized the request. Craft sandbox tokens are Craft traffic; a directly
+    granted use:llm_gateway PAT is external gateway traffic (Claude Code,
+    codex, ...), which tracing and usage metering must attribute separately."""
+    token_scopes: list[Permission] | None = getattr(
+        http_request.state, "token_scopes", None
+    )
+    if token_scopes and Permission.CRAFT_SANDBOX in token_scopes:
+        return LLMFlow.CRAFT_LLM_GENERATION
+    return LLMFlow.LLM_GATEWAY
+
+
 def _authorize_gateway_request(http_request: Request, user: User) -> LLMFlow:
-    flow = LLMFlow.CRAFT_LLM_GENERATION
-    if not _FLOW_ACCESS_CHECKS[flow](http_request, user):
+    if not is_gateway_request(http_request, user):
         raise OnyxError(
             OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
             "This credential is not authorized to use the Onyx LLM gateway.",
         )
-    return flow
+    return _gateway_flow(http_request)
 
 
 def resolve_gateway_model(

--- a/backend/onyx/tracing/flows.py
+++ b/backend/onyx/tracing/flows.py
@@ -32,6 +32,10 @@ class LLMFlow(StrEnum):
     BUILD_SESSION_NAMING = "build_session_naming"
     CRAFT_LLM_GENERATION = "craft_llm_generation"
 
+    # LLM gateway traffic from external clients (Claude Code, codex, ...)
+    # authorized by a use:llm_gateway PAT rather than a Craft sandbox token.
+    LLM_GATEWAY = "llm_gateway"
+
     # Federated search helpers
     SLACK_DATE_EXTRACTION = "slack_date_extraction"
     SLACK_QUERY_EXPANSION = "slack_query_expansion"

--- a/backend/onyx/tracing/flows.py
+++ b/backend/onyx/tracing/flows.py
@@ -32,8 +32,7 @@ class LLMFlow(StrEnum):
     BUILD_SESSION_NAMING = "build_session_naming"
     CRAFT_LLM_GENERATION = "craft_llm_generation"
 
-    # LLM gateway traffic from external clients (Claude Code, codex, ...)
-    # authorized by a use:llm_gateway PAT rather than a Craft sandbox token.
+    # LLM gateway (external clients via use:llm_gateway PATs)
     LLM_GATEWAY = "llm_gateway"
 
     # Federated search helpers

--- a/backend/tests/unit/onyx/server/features/craft/test_craft_gateway.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_craft_gateway.py
@@ -9,9 +9,10 @@ from onyx.db.enums import Permission
 from onyx.db.models import User
 from onyx.server.features.build import craft_gateway
 from onyx.server.features.build.craft_gateway import (
+    gateway_request_flow,
     is_craft_gateway_request,
-    is_gateway_request,
 )
+from onyx.tracing.flows import LLMFlow
 
 
 def _request(token_scopes: list[Permission] | None) -> Request:
@@ -50,25 +51,31 @@ def test_gateway_rejects_craft_sandbox_scope_when_craft_disabled() -> None:
 
 def test_general_gateway_rejects_no_token_scopes() -> None:
     user = cast(User, MagicMock(spec=User))
-    assert not is_gateway_request(_request(None), user)
+    assert gateway_request_flow(_request(None), user) is None
 
 
 def test_general_gateway_rejects_scope_without_gateway_grant() -> None:
     user = cast(User, MagicMock(spec=User))
-    assert not is_gateway_request(_request([Permission.READ_SEARCH]), user)
+    assert gateway_request_flow(_request([Permission.READ_SEARCH]), user) is None
 
 
 def test_general_gateway_accepts_plain_gateway_scope_without_craft() -> None:
     user = cast(User, MagicMock(spec=User))
     with patch.object(craft_gateway, "is_craft_enabled_for_user", return_value=False):
-        assert is_gateway_request(
-            _request([Permission.READ_SEARCH, Permission.USE_LLM_GATEWAY]), user
+        assert (
+            gateway_request_flow(
+                _request([Permission.READ_SEARCH, Permission.USE_LLM_GATEWAY]), user
+            )
+            is LLMFlow.LLM_GATEWAY
         )
 
 
 def test_general_gateway_defers_craft_sandbox_scope_to_craft_policy() -> None:
     user = cast(User, MagicMock(spec=User))
     with patch.object(craft_gateway, "is_craft_enabled_for_user", return_value=True):
-        assert is_gateway_request(_request([Permission.CRAFT_SANDBOX]), user)
+        assert (
+            gateway_request_flow(_request([Permission.CRAFT_SANDBOX]), user)
+            is LLMFlow.CRAFT_LLM_GENERATION
+        )
     with patch.object(craft_gateway, "is_craft_enabled_for_user", return_value=False):
-        assert not is_gateway_request(_request([Permission.CRAFT_SANDBOX]), user)
+        assert gateway_request_flow(_request([Permission.CRAFT_SANDBOX]), user) is None

--- a/backend/tests/unit/onyx/server/gateway/test_anthropic_messages_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_anthropic_messages_api.py
@@ -682,7 +682,7 @@ def test_anthropic_stream_upstream_failure_emits_single_error_frame(
 def test_anthropic_messages_endpoint_rejects_non_gateway_credentials() -> None:
     request = _anthropic_request()
     with (
-        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=False)),
+        patch.object(gateway_api, "gateway_request_flow", MagicMock(return_value=None)),
         pytest.raises(OnyxError) as exc_info,
     ):
         gateway_api.gateway_anthropic_messages(
@@ -700,7 +700,11 @@ def test_anthropic_messages_endpoint_enforces_token_rate_limits() -> None:
     rate_limited = OnyxError(OnyxErrorCode.RATE_LIMITED, "over budget")
 
     with (
-        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=True)),
+        patch.object(
+            gateway_api,
+            "gateway_request_flow",
+            MagicMock(return_value=LLMFlow.LLM_GATEWAY),
+        ),
         patch.object(
             gateway_api, "check_token_rate_limits", side_effect=rate_limited
         ) as rate_check,
@@ -726,7 +730,7 @@ def test_anthropic_count_tokens_endpoint_rejects_non_gateway_credentials() -> No
         model="1/test", messages=[{"role": "user", "content": "hi"}]
     )
     with (
-        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=False)),
+        patch.object(gateway_api, "gateway_request_flow", MagicMock(return_value=None)),
         pytest.raises(OnyxError) as exc_info,
     ):
         gateway_api.gateway_anthropic_count_tokens(
@@ -754,7 +758,11 @@ def test_gateway_anthropic_count_tokens_includes_tools() -> None:
         ],
     )
     with (
-        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=True)),
+        patch.object(
+            gateway_api,
+            "gateway_request_flow",
+            MagicMock(return_value=LLMFlow.LLM_GATEWAY),
+        ),
         patch.object(
             gateway_api,
             "resolve_gateway_model",

--- a/backend/tests/unit/onyx/server/gateway/test_anthropic_messages_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_anthropic_messages_api.py
@@ -682,10 +682,7 @@ def test_anthropic_stream_upstream_failure_emits_single_error_frame(
 def test_anthropic_messages_endpoint_rejects_non_gateway_credentials() -> None:
     request = _anthropic_request()
     with (
-        patch.dict(
-            gateway_api._FLOW_ACCESS_CHECKS,
-            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=False)},
-        ),
+        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=False)),
         pytest.raises(OnyxError) as exc_info,
     ):
         gateway_api.gateway_anthropic_messages(
@@ -703,10 +700,7 @@ def test_anthropic_messages_endpoint_enforces_token_rate_limits() -> None:
     rate_limited = OnyxError(OnyxErrorCode.RATE_LIMITED, "over budget")
 
     with (
-        patch.dict(
-            gateway_api._FLOW_ACCESS_CHECKS,
-            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=True)},
-        ),
+        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=True)),
         patch.object(
             gateway_api, "check_token_rate_limits", side_effect=rate_limited
         ) as rate_check,
@@ -732,10 +726,7 @@ def test_anthropic_count_tokens_endpoint_rejects_non_gateway_credentials() -> No
         model="1/test", messages=[{"role": "user", "content": "hi"}]
     )
     with (
-        patch.dict(
-            gateway_api._FLOW_ACCESS_CHECKS,
-            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=False)},
-        ),
+        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=False)),
         pytest.raises(OnyxError) as exc_info,
     ):
         gateway_api.gateway_anthropic_count_tokens(
@@ -763,10 +754,7 @@ def test_gateway_anthropic_count_tokens_includes_tools() -> None:
         ],
     )
     with (
-        patch.dict(
-            gateway_api._FLOW_ACCESS_CHECKS,
-            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=True)},
-        ),
+        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=True)),
         patch.object(
             gateway_api,
             "resolve_gateway_model",

--- a/backend/tests/unit/onyx/server/gateway/test_anthropic_messages_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_anthropic_messages_api.py
@@ -725,6 +725,39 @@ def test_anthropic_messages_endpoint_enforces_token_rate_limits() -> None:
     handle.assert_not_called()
 
 
+def test_anthropic_messages_endpoint_threads_authorized_flow_to_handler() -> None:
+    provider = _provider(1, "anthropic", [_model("test")])
+    model_config = provider.model_configurations[0]
+    request = _anthropic_request()
+    with (
+        patch.object(
+            gateway_api,
+            "gateway_request_flow",
+            MagicMock(return_value=LLMFlow.LLM_GATEWAY),
+        ),
+        patch.object(gateway_api, "check_token_rate_limits"),
+        patch.object(
+            gateway_api,
+            "resolve_gateway_model",
+            return_value=(provider, model_config),
+        ),
+        patch.object(gateway_api, "handle_anthropic_messages") as handle,
+    ):
+        handle.return_value.to_wire.return_value = {}
+        gateway_api.gateway_anthropic_messages(
+            request=request,
+            http_request=MagicMock(spec=Request),
+            user=MagicMock(),
+            db_session=MagicMock(spec=Session),
+        )
+    handle.assert_called_once_with(
+        request=request,
+        provider=provider,
+        model_config=model_config,
+        flow=LLMFlow.LLM_GATEWAY,
+    )
+
+
 def test_anthropic_count_tokens_endpoint_rejects_non_gateway_credentials() -> None:
     request = AnthropicCountTokensRequest(
         model="1/test", messages=[{"role": "user", "content": "hi"}]

--- a/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
@@ -47,7 +47,7 @@ from onyx.llm.models import FunctionCall as ToolFunctionCall
 from onyx.llm.multi_llm import LLMRateLimitError, LLMTimeoutError
 from onyx.server.auth_check import check_router_auth
 from onyx.server.features.build import craft_gateway
-from onyx.server.features.build.craft_gateway import is_gateway_request
+from onyx.server.features.build.craft_gateway import gateway_request_flow
 from onyx.server.gateway import api as gateway_api
 from onyx.server.gateway.api import _MESSAGES_ADAPTER
 from onyx.server.gateway.configs import GATEWAY_PATH_PREFIX
@@ -878,9 +878,9 @@ def test_endpoint_applies_craft_policy() -> None:
     user = cast(User, MagicMock(spec=User))
     http_request = cast(Request, MagicMock(spec=Request))
 
-    check_access = MagicMock(return_value=True)
+    check_access = MagicMock(return_value=LLMFlow.LLM_GATEWAY)
     with (
-        patch.object(gateway_api, "is_gateway_request", check_access),
+        patch.object(gateway_api, "gateway_request_flow", check_access),
         patch.object(
             gateway_api,
             "resolve_gateway_model",
@@ -918,7 +918,11 @@ def test_endpoint_enforces_token_rate_limits_before_calling_provider() -> None:
 
     rate_limited = OnyxError(OnyxErrorCode.RATE_LIMITED, "over budget")
     with (
-        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=True)),
+        patch.object(
+            gateway_api,
+            "gateway_request_flow",
+            MagicMock(return_value=LLMFlow.LLM_GATEWAY),
+        ),
         patch.object(
             gateway_api, "check_token_rate_limits", side_effect=rate_limited
         ) as rate_check,
@@ -940,12 +944,16 @@ def test_endpoint_enforces_token_rate_limits_before_calling_provider() -> None:
 
 
 def test_gateway_flow_follows_credential_type() -> None:
-    http_request = cast(Request, MagicMock(spec=Request))
-    http_request.state.token_scopes = [Permission.CRAFT_SANDBOX]
-    assert gateway_api._gateway_flow(http_request) is LLMFlow.CRAFT_LLM_GENERATION
-
-    http_request.state.token_scopes = [Permission.USE_LLM_GATEWAY]
-    assert gateway_api._gateway_flow(http_request) is LLMFlow.LLM_GATEWAY
+    user = cast(User, MagicMock(spec=User))
+    with patch.object(craft_gateway, "is_craft_enabled_for_user", return_value=True):
+        assert (
+            gateway_request_flow(_pat_request([Permission.CRAFT_SANDBOX]), user)
+            is LLMFlow.CRAFT_LLM_GENERATION
+        )
+        assert (
+            gateway_request_flow(_pat_request([Permission.USE_LLM_GATEWAY]), user)
+            is LLMFlow.LLM_GATEWAY
+        )
 
 
 def test_endpoint_rejects_non_gateway_credentials() -> None:
@@ -954,7 +962,7 @@ def test_endpoint_rejects_non_gateway_credentials() -> None:
         messages=[{"role": "user", "content": "hi"}],
     )
     with (
-        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=False)),
+        patch.object(gateway_api, "gateway_request_flow", MagicMock(return_value=None)),
         pytest.raises(OnyxError) as exc_info,
     ):
         gateway_api.gateway_chat_completions(
@@ -987,7 +995,7 @@ class TestGatewayAuthComposition:
         with patch.object(
             craft_gateway, "is_craft_enabled_for_user", return_value=False
         ):
-            assert is_gateway_request(request, user)
+            assert gateway_request_flow(request, user) is LLMFlow.LLM_GATEWAY
 
     @pytest.mark.asyncio
     async def test_craft_sandbox_pat_still_works_unchanged(self) -> None:
@@ -999,11 +1007,11 @@ class TestGatewayAuthComposition:
         with patch.object(
             craft_gateway, "is_craft_enabled_for_user", return_value=True
         ):
-            assert is_gateway_request(request, user)
+            assert gateway_request_flow(request, user) is LLMFlow.CRAFT_LLM_GENERATION
         with patch.object(
             craft_gateway, "is_craft_enabled_for_user", return_value=False
         ):
-            assert not is_gateway_request(request, user)
+            assert gateway_request_flow(request, user) is None
 
     @pytest.mark.asyncio
     async def test_unrestricted_pat_is_rejected(self) -> None:
@@ -1011,7 +1019,7 @@ class TestGatewayAuthComposition:
         user = self._basic_user()
         request = _pat_request(None)
 
-        assert not is_gateway_request(request, user)
+        assert gateway_request_flow(request, user) is None
 
     @pytest.mark.asyncio
     async def test_session_and_api_key_auth_are_rejected(self) -> None:
@@ -1019,7 +1027,7 @@ class TestGatewayAuthComposition:
         user = self._basic_user()
         request = Request({"type": "http", "headers": []})
 
-        assert not is_gateway_request(request, user)
+        assert gateway_request_flow(request, user) is None
 
     @pytest.mark.asyncio
     async def test_gateway_scope_alone_passes_both_gates(self) -> None:
@@ -1031,7 +1039,7 @@ class TestGatewayAuthComposition:
         with patch.object(
             craft_gateway, "is_craft_enabled_for_user", return_value=False
         ):
-            assert is_gateway_request(request, user)
+            assert gateway_request_flow(request, user) is LLMFlow.LLM_GATEWAY
 
     @pytest.mark.asyncio
     async def test_read_search_scope_alone_fails_base_permission_gate(self) -> None:
@@ -1045,7 +1053,7 @@ class TestGatewayAuthComposition:
         with patch.object(
             craft_gateway, "is_craft_enabled_for_user", return_value=False
         ):
-            assert not is_gateway_request(request, user)
+            assert gateway_request_flow(request, user) is None
 
 
 def _catalog_provider() -> LLMProviderView:
@@ -1059,7 +1067,11 @@ def _catalog_provider() -> LLMProviderView:
 def test_list_models_returns_openai_shape_excluding_hidden_models() -> None:
     provider = _catalog_provider()
     with (
-        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=True)),
+        patch.object(
+            gateway_api,
+            "gateway_request_flow",
+            MagicMock(return_value=LLMFlow.LLM_GATEWAY),
+        ),
         patch.object(
             gateway_api,
             "fetch_all_accessible_llm_providers",
@@ -1083,7 +1095,11 @@ def test_list_models_returns_openai_shape_excluding_hidden_models() -> None:
 def test_list_models_ids_round_trip_through_resolve_gateway_model() -> None:
     provider = _catalog_provider()
     with (
-        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=True)),
+        patch.object(
+            gateway_api,
+            "gateway_request_flow",
+            MagicMock(return_value=LLMFlow.LLM_GATEWAY),
+        ),
         patch.object(
             gateway_api, "fetch_all_accessible_llm_providers", return_value=[provider]
         ),
@@ -1110,7 +1126,7 @@ def test_list_models_ids_round_trip_through_resolve_gateway_model() -> None:
 
 def test_list_models_rejects_non_gateway_credentials() -> None:
     with (
-        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=False)),
+        patch.object(gateway_api, "gateway_request_flow", MagicMock(return_value=None)),
         pytest.raises(OnyxError) as exc_info,
     ):
         gateway_api.gateway_list_models(
@@ -1718,7 +1734,7 @@ def test_responses_gateway_route_carries_same_permission_dependency() -> None:
 def test_responses_endpoint_rejects_non_gateway_credentials() -> None:
     request = ResponsesRequest(model="1/test", input="hi")
     with (
-        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=False)),
+        patch.object(gateway_api, "gateway_request_flow", MagicMock(return_value=None)),
         pytest.raises(OnyxError) as exc_info,
     ):
         gateway_api.gateway_responses(
@@ -1759,7 +1775,11 @@ def test_responses_endpoint_enforces_token_rate_limits_before_calling_provider()
 
     rate_limited = OnyxError(OnyxErrorCode.RATE_LIMITED, "over budget")
     with (
-        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=True)),
+        patch.object(
+            gateway_api,
+            "gateway_request_flow",
+            MagicMock(return_value=LLMFlow.LLM_GATEWAY),
+        ),
         patch.object(
             gateway_api, "check_token_rate_limits", side_effect=rate_limited
         ) as rate_check,
@@ -1789,7 +1809,11 @@ def test_responses_endpoint_resolves_model_same_way_as_chat_route() -> None:
     http_request = cast(Request, MagicMock(spec=Request))
 
     with (
-        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=True)),
+        patch.object(
+            gateway_api,
+            "gateway_request_flow",
+            MagicMock(return_value=LLMFlow.LLM_GATEWAY),
+        ),
         patch.object(
             gateway_api,
             "resolve_gateway_model",

--- a/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
@@ -867,7 +867,7 @@ def test_gateway_route_has_single_permission_dependency() -> None:
     assert len(auth_dependencies) == 1
 
 
-def test_endpoint_applies_craft_policy() -> None:
+def test_endpoint_threads_authorized_flow_to_handler() -> None:
     request = ChatCompletionRequest(
         model="1/test",
         messages=[{"role": "user", "content": "hi"}],

--- a/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
@@ -880,10 +880,7 @@ def test_endpoint_applies_craft_policy() -> None:
 
     check_access = MagicMock(return_value=True)
     with (
-        patch.dict(
-            gateway_api._FLOW_ACCESS_CHECKS,
-            {LLMFlow.CRAFT_LLM_GENERATION: check_access},
-        ),
+        patch.object(gateway_api, "is_gateway_request", check_access),
         patch.object(
             gateway_api,
             "resolve_gateway_model",
@@ -906,7 +903,7 @@ def test_endpoint_applies_craft_policy() -> None:
         request=request,
         provider=provider,
         model_config=model_config,
-        flow=LLMFlow.CRAFT_LLM_GENERATION,
+        flow=LLMFlow.LLM_GATEWAY,
     )
 
 
@@ -921,10 +918,7 @@ def test_endpoint_enforces_token_rate_limits_before_calling_provider() -> None:
 
     rate_limited = OnyxError(OnyxErrorCode.RATE_LIMITED, "over budget")
     with (
-        patch.dict(
-            gateway_api._FLOW_ACCESS_CHECKS,
-            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=True)},
-        ),
+        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=True)),
         patch.object(
             gateway_api, "check_token_rate_limits", side_effect=rate_limited
         ) as rate_check,
@@ -945,11 +939,13 @@ def test_endpoint_enforces_token_rate_limits_before_calling_provider() -> None:
     handle.assert_not_called()
 
 
-def test_craft_flow_is_gated_by_general_gateway_credential_check() -> None:
-    assert (
-        gateway_api._FLOW_ACCESS_CHECKS[LLMFlow.CRAFT_LLM_GENERATION]
-        is is_gateway_request
-    )
+def test_gateway_flow_follows_credential_type() -> None:
+    http_request = cast(Request, MagicMock(spec=Request))
+    http_request.state.token_scopes = [Permission.CRAFT_SANDBOX]
+    assert gateway_api._gateway_flow(http_request) is LLMFlow.CRAFT_LLM_GENERATION
+
+    http_request.state.token_scopes = [Permission.USE_LLM_GATEWAY]
+    assert gateway_api._gateway_flow(http_request) is LLMFlow.LLM_GATEWAY
 
 
 def test_endpoint_rejects_non_gateway_credentials() -> None:
@@ -958,10 +954,7 @@ def test_endpoint_rejects_non_gateway_credentials() -> None:
         messages=[{"role": "user", "content": "hi"}],
     )
     with (
-        patch.dict(
-            gateway_api._FLOW_ACCESS_CHECKS,
-            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=False)},
-        ),
+        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=False)),
         pytest.raises(OnyxError) as exc_info,
     ):
         gateway_api.gateway_chat_completions(
@@ -1066,10 +1059,7 @@ def _catalog_provider() -> LLMProviderView:
 def test_list_models_returns_openai_shape_excluding_hidden_models() -> None:
     provider = _catalog_provider()
     with (
-        patch.dict(
-            gateway_api._FLOW_ACCESS_CHECKS,
-            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=True)},
-        ),
+        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=True)),
         patch.object(
             gateway_api,
             "fetch_all_accessible_llm_providers",
@@ -1093,10 +1083,7 @@ def test_list_models_returns_openai_shape_excluding_hidden_models() -> None:
 def test_list_models_ids_round_trip_through_resolve_gateway_model() -> None:
     provider = _catalog_provider()
     with (
-        patch.dict(
-            gateway_api._FLOW_ACCESS_CHECKS,
-            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=True)},
-        ),
+        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=True)),
         patch.object(
             gateway_api, "fetch_all_accessible_llm_providers", return_value=[provider]
         ),
@@ -1123,10 +1110,7 @@ def test_list_models_ids_round_trip_through_resolve_gateway_model() -> None:
 
 def test_list_models_rejects_non_gateway_credentials() -> None:
     with (
-        patch.dict(
-            gateway_api._FLOW_ACCESS_CHECKS,
-            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=False)},
-        ),
+        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=False)),
         pytest.raises(OnyxError) as exc_info,
     ):
         gateway_api.gateway_list_models(
@@ -1734,10 +1718,7 @@ def test_responses_gateway_route_carries_same_permission_dependency() -> None:
 def test_responses_endpoint_rejects_non_gateway_credentials() -> None:
     request = ResponsesRequest(model="1/test", input="hi")
     with (
-        patch.dict(
-            gateway_api._FLOW_ACCESS_CHECKS,
-            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=False)},
-        ),
+        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=False)),
         pytest.raises(OnyxError) as exc_info,
     ):
         gateway_api.gateway_responses(
@@ -1778,10 +1759,7 @@ def test_responses_endpoint_enforces_token_rate_limits_before_calling_provider()
 
     rate_limited = OnyxError(OnyxErrorCode.RATE_LIMITED, "over budget")
     with (
-        patch.dict(
-            gateway_api._FLOW_ACCESS_CHECKS,
-            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=True)},
-        ),
+        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=True)),
         patch.object(
             gateway_api, "check_token_rate_limits", side_effect=rate_limited
         ) as rate_check,
@@ -1811,10 +1789,7 @@ def test_responses_endpoint_resolves_model_same_way_as_chat_route() -> None:
     http_request = cast(Request, MagicMock(spec=Request))
 
     with (
-        patch.dict(
-            gateway_api._FLOW_ACCESS_CHECKS,
-            {LLMFlow.CRAFT_LLM_GENERATION: MagicMock(return_value=True)},
-        ),
+        patch.object(gateway_api, "is_gateway_request", MagicMock(return_value=True)),
         patch.object(
             gateway_api,
             "resolve_gateway_model",
@@ -1836,7 +1811,7 @@ def test_responses_endpoint_resolves_model_same_way_as_chat_route() -> None:
         request=request,
         provider=provider,
         model_config=model_config,
-        flow=LLMFlow.CRAFT_LLM_GENERATION,
+        flow=LLMFlow.LLM_GATEWAY,
     )
 
 


### PR DESCRIPTION
## Description

Every gateway request was hardcoded to `LLMFlow.CRAFT_LLM_GENERATION`, so Braintrust traces (and, once wired up, usage metering) attributed external Claude Code / codex sessions to Craft.

The flow is now derived from the credential that authorized the request, and authorization and classification happen in one step: `gateway_request_flow(request, user) -> LLMFlow | None` (in `craft_gateway.py`) replaces the boolean `is_gateway_request`, returning `None` when the credential is not authorized. A Craft sandbox scoped token stays on the Craft policy and is tagged `craft_llm_generation`; a directly granted `use:llm_gateway` PAT is tagged with the new `LLMFlow.LLM_GATEWAY` (`llm_gateway`). Since the flow comes from server-resolved token scopes, clients cannot spoof their attribution in either direction. Future caller-declared sources (e.g. distinguishing codex from Claude Code) should become additional `LLMFlow` return values rather than a flag.

## How Has This Been Tested?

- Unit tests cover every classification branch: `CRAFT_SANDBOX` with craft enabled -> `CRAFT_LLM_GENERATION`, `CRAFT_SANDBOX` with craft disabled -> rejected, direct `USE_LLM_GATEWAY` -> `LLM_GATEWAY`, no token scopes -> rejected, non-gateway scopes -> rejected.
- Endpoint tests assert the chat, responses, and anthropic handlers each receive the derived flow, and that a `None` classification raises `INSUFFICIENT_PERMISSIONS` before any model resolution.
- `uv run pytest backend/tests/unit/onyx/server/gateway backend/tests/unit/onyx/server/features/craft` (830 passed); pre-commit (ty, ruff, ruff format) green.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

**Stack:**
1. [gateway-anthropic-messages #13687](https://github.com/onyx-dot-app/onyx/pull/13687)
2. [gateway-anthropic-thinking #13691](https://github.com/onyx-dot-app/onyx/pull/13691)
