### PR TITLE
fix(logging): cap third-party DEBUG log noise and single-path LiteLLM emission

### DIFF
--- a/backend/ee/onyx/external_permissions/google_drive/group_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/group_sync.py
@@ -52,8 +52,14 @@ def _get_all_folders(
     TODO: tweak things so we can fetch deltas.
     """
     MAX_FAILED_PERCENTAGE = 0.5
+    # Skips are counted and logged in aggregate: per-folder lines here produce
+    # millions of records on large domains (every folder is revisited for every
+    # enumerated user).
+    SKIP_LOG_INTERVAL = 1000
 
     seen_folder_ids: set[str] = set()
+    skipped_already_seen = 0
+    skipped_no_permissions = 0
 
     def _get_all_folders_for_user(
         google_drive_connector: GoogleDriveConnector,
@@ -61,6 +67,8 @@ def _get_all_folders(
         user_email: str,
     ) -> Generator[FolderInfo, None, None]:
         """Helper to get folders for a specific user + update shared seen_folder_ids"""
+        nonlocal skipped_already_seen, skipped_no_permissions
+
         drive_service = get_drive_service(
             google_drive_connector.creds,
             user_email,
@@ -71,7 +79,11 @@ def _get_all_folders(
         ):
             folder_id = folder["id"]
             if folder_id in seen_folder_ids:
-                logger.debug("Folder %s has already been seen. Skipping.", folder_id)
+                skipped_already_seen += 1
+                if skipped_already_seen % SKIP_LOG_INTERVAL == 0:
+                    logger.debug(
+                        "Skipped %d already-seen folders so far.", skipped_already_seen
+                    )
                 continue
 
             seen_folder_ids.add(folder_id)
@@ -100,7 +112,12 @@ def _get_all_folders(
             ]
 
             if not permissions and skip_folders_without_permissions:
-                logger.debug("Folder %s has no permissions. Skipping.", folder_id)
+                skipped_no_permissions += 1
+                if skipped_no_permissions % SKIP_LOG_INTERVAL == 0:
+                    logger.debug(
+                        "Skipped %d folders without permissions so far.",
+                        skipped_no_permissions,
+                    )
                 continue
 
             yield FolderInfo(
@@ -130,6 +147,14 @@ def _get_all_folders(
 
             if failed_count > MAX_FAILED_PERCENTAGE * len(user_emails):
                 raise RuntimeError("Too many failed folder fetches during group sync")
+
+    if skipped_no_permissions or skipped_already_seen:
+        logger.info(
+            "Folder scan complete: skipped %d folders without permissions "
+            "and %d already-seen folders.",
+            skipped_no_permissions,
+            skipped_already_seen,
+        )
 
 
 def _drive_folder_to_onyx_group(

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -57,6 +57,7 @@ from onyx.utils.logger import (
     ColoredFormatter,
     LoggerContextVars,
     PlainFormatter,
+    cap_third_party_log_levels,
     get_json_formatter,
     get_log_level_from_str,
     setup_logger,
@@ -576,6 +577,11 @@ def on_setup_logging(
         root_logger.addHandler(root_file_handler)
 
     root_logger.setLevel(effective_loglevel)
+
+    # Third-party loggers inherit the root logger's level, so a DEBUG root
+    # would otherwise turn their firehoses on; re-cap them against the level
+    # this worker actually runs at.
+    cap_third_party_log_levels(effective_loglevel)
 
     # Emit the diagnostic after the root logger is configured so it goes through
     # the fresh handler at the level we just chose. (Before this point Python's

--- a/backend/onyx/llm/litellm_singleton/config.py
+++ b/backend/onyx/llm/litellm_singleton/config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import litellm
 
-from onyx.utils.logger import setup_logger
+from onyx.utils.logger import remove_litellm_native_log_handlers, setup_logger
 
 logger = setup_logger()
 
@@ -16,6 +16,9 @@ def configure_litellm_settings() -> None:
     litellm.modify_params = True
     litellm.add_function_to_prompt = False
     litellm.suppress_debug_info = True
+    # LiteLLM records must flow only through the app logging pipeline, not also
+    # through the stream handler LiteLLM attaches at import.
+    remove_litellm_native_log_handlers()
 
 
 # TODO: We might not need to register ollama_chat in addition to ollama but let's just do it for good measure for now.

--- a/backend/onyx/utils/logger.py
+++ b/backend/onyx/utils/logger.py
@@ -80,6 +80,11 @@ LITELLM_NATIVE_LOGGER_NAMES: tuple[str, ...] = (
 
 _third_party_log_levels_capped = False
 
+# Levels this cap itself applied, per logger name. Lets a later re-cap at a
+# more permissive app level replace our own earlier, stricter cap while still
+# preserving levels that other modules raised explicitly.
+_cap_applied_levels: dict[str, int] = {}
+
 
 def get_log_level_from_str(log_level_str: str = LOG_LEVEL) -> int:
     log_level_dict = {
@@ -105,7 +110,9 @@ def cap_third_party_log_levels(
     Levels are set explicitly by logger name, so the cap holds no matter which
     handler tree the process uses (uvicorn, celery root logger, plain stdout)
     and even when the root logger runs at DEBUG. Never lowers a level that
-    another module already raised (e.g. httpx -> WARNING).
+    another module raised explicitly (e.g. httpx -> WARNING); levels this cap
+    applied itself are replaceable, so re-running at a more permissive app
+    level relaxes the cap instead of ratcheting.
     """
     global _third_party_log_levels_capped
     _third_party_log_levels_capped = True
@@ -118,12 +125,14 @@ def cap_third_party_log_levels(
     )
     for logger_name in THIRD_PARTY_CAPPED_LOGGER_NAMES:
         third_party_logger = logging.getLogger(logger_name)
-        if allow_debug:
-            third_party_logger.setLevel(max(level, third_party_logger.level))
-        else:
-            third_party_logger.setLevel(
-                max(logging.INFO, level, third_party_logger.level)
-            )
+        existing_level = third_party_logger.level
+        # A level equal to what this cap last set is ours to replace; anything
+        # else was raised externally and is preserved.
+        if _cap_applied_levels.get(logger_name) == existing_level:
+            existing_level = logging.NOTSET
+        cap_target = level if allow_debug else max(logging.INFO, level)
+        third_party_logger.setLevel(max(cap_target, existing_level))
+        _cap_applied_levels[logger_name] = cap_target
 
 
 def remove_litellm_native_log_handlers() -> None:

--- a/backend/onyx/utils/logger.py
+++ b/backend/onyx/utils/logger.py
@@ -12,6 +12,7 @@ from shared_configs.configs import (
     JSON_LOGGING,
     LOG_FILE_NAME,
     LOG_LEVEL,
+    LOG_THIRD_PARTY_DEBUG,
     LOG_TO_FILE,
     MULTI_TENANT,
     POSTGRES_DEFAULT_SCHEMA,
@@ -41,6 +42,45 @@ class LoggerContextVars:
         doc_permission_sync_ctx.set(dict())
 
 
+# Third-party loggers that are extremely chatty at DEBUG (LiteLLM logs several
+# records per streamed token; httpcore logs every network event; pdfminer logs
+# per PDF object). Capped at INFO unless LOG_THIRD_PARTY_DEBUG opts back in.
+THIRD_PARTY_CAPPED_LOGGER_NAMES: tuple[str, ...] = (
+    "LiteLLM",
+    "LiteLLM Proxy",
+    "LiteLLM Router",
+    "litellm",
+    "httpx",
+    "httpcore",
+    "openai",
+    "anthropic",
+    "urllib3",
+    "botocore",
+    "boto3",
+    "s3transfer",
+    "google",
+    "googleapiclient",
+    "opensearch",
+    "kombu",
+    "amqp",
+    "msal",
+    "asyncio",
+    "charset_normalizer",
+    "filelock",
+    "pdfminer",
+    "unstructured",
+)
+
+# Loggers LiteLLM attaches its own stream handler to at import time.
+LITELLM_NATIVE_LOGGER_NAMES: tuple[str, ...] = (
+    "LiteLLM",
+    "LiteLLM Proxy",
+    "LiteLLM Router",
+)
+
+_third_party_log_levels_capped = False
+
+
 def get_log_level_from_str(log_level_str: str = LOG_LEVEL) -> int:
     log_level_dict = {
         "CRITICAL": logging.CRITICAL,
@@ -53,6 +93,52 @@ def get_log_level_from_str(log_level_str: str = LOG_LEVEL) -> int:
     }
 
     return log_level_dict.get(log_level_str.upper(), logging.INFO)
+
+
+def cap_third_party_log_levels(
+    app_log_level: int | None = None,
+    allow_third_party_debug: bool | None = None,
+) -> None:
+    """Cap chatty third-party loggers at INFO, or at the app log level if that
+    is stricter. LOG_THIRD_PARTY_DEBUG=true opts back into their DEBUG output.
+
+    Levels are set explicitly by logger name, so the cap holds no matter which
+    handler tree the process uses (uvicorn, celery root logger, plain stdout)
+    and even when the root logger runs at DEBUG. Never lowers a level that
+    another module already raised (e.g. httpx -> WARNING).
+    """
+    global _third_party_log_levels_capped
+    _third_party_log_levels_capped = True
+
+    level = app_log_level if app_log_level is not None else get_log_level_from_str()
+    allow_debug = (
+        LOG_THIRD_PARTY_DEBUG
+        if allow_third_party_debug is None
+        else allow_third_party_debug
+    )
+    for logger_name in THIRD_PARTY_CAPPED_LOGGER_NAMES:
+        third_party_logger = logging.getLogger(logger_name)
+        if allow_debug:
+            third_party_logger.setLevel(level)
+        else:
+            third_party_logger.setLevel(
+                max(logging.INFO, level, third_party_logger.level)
+            )
+
+
+def remove_litellm_native_log_handlers() -> None:
+    """LiteLLM attaches its own colored StreamHandler to its loggers at import
+    time while leaving propagation on, so every record is emitted twice: once
+    by LiteLLM's handler and once by the app/root handlers. Drop LiteLLM's
+    handlers so the app logging pipeline is the single emission path.
+
+    Must be called after ``litellm`` has been imported (its handlers are
+    attached as an import side effect).
+    """
+    for logger_name in LITELLM_NATIVE_LOGGER_NAMES:
+        litellm_logger = logging.getLogger(logger_name)
+        litellm_logger.handlers.clear()
+        litellm_logger.propagate = True
 
 
 class OnyxRequestIDFilter(logging.Filter):
@@ -315,6 +401,9 @@ def setup_logger(
     extra: MutableMapping[str, Any] | None = None,
     propagate: bool = True,
 ) -> OnyxLoggingAdapter:
+    if not _third_party_log_levels_capped:
+        cap_third_party_log_levels()
+
     logger = logging.getLogger(name)
 
     # If the logger already has handlers, assume it was already configured and return it.

--- a/backend/onyx/utils/logger.py
+++ b/backend/onyx/utils/logger.py
@@ -119,7 +119,7 @@ def cap_third_party_log_levels(
     for logger_name in THIRD_PARTY_CAPPED_LOGGER_NAMES:
         third_party_logger = logging.getLogger(logger_name)
         if allow_debug:
-            third_party_logger.setLevel(level)
+            third_party_logger.setLevel(max(level, third_party_logger.level))
         else:
             third_party_logger.setLevel(
                 max(logging.INFO, level, third_party_logger.level)

--- a/backend/shared_configs/configs.py
+++ b/backend/shared_configs/configs.py
@@ -77,6 +77,10 @@ DEV_LOGGING_ENABLED = os.environ.get("DEV_LOGGING_ENABLED", "").lower() == "true
 LOG_TO_FILE = os.environ.get("LOG_TO_FILE", "true").lower() != "false"
 # notset, debug, info, notice, warning, error, or critical
 LOG_LEVEL = os.environ.get("LOG_LEVEL") or "info"
+# Chatty third-party libraries (LiteLLM, httpcore, botocore, ...) are capped at
+# INFO even when LOG_LEVEL=debug — LiteLLM alone emits several DEBUG records per
+# streamed token. Set LOG_THIRD_PARTY_DEBUG=true to let them log at LOG_LEVEL.
+LOG_THIRD_PARTY_DEBUG = os.environ.get("LOG_THIRD_PARTY_DEBUG", "").lower() == "true"
 
 # Log output format: "plain" (human-readable text, default) or "json" (structured
 # single-line JSON, suitable for container log aggregators). When "json", context

--- a/backend/tests/unit/onyx/utils/test_third_party_log_cap.py
+++ b/backend/tests/unit/onyx/utils/test_third_party_log_cap.py
@@ -3,6 +3,7 @@ from collections.abc import Generator
 
 import pytest
 
+import onyx.utils.logger as logger_module
 from onyx.utils.logger import (
     THIRD_PARTY_CAPPED_LOGGER_NAMES,
     cap_third_party_log_levels,
@@ -12,13 +13,17 @@ from onyx.utils.logger import (
 
 @pytest.fixture(autouse=True)
 def _restore_third_party_logger_levels() -> Generator[None, None, None]:
-    """Snapshot and restore the global logging state these tests mutate."""
+    """Snapshot and restore the global logging state these tests mutate,
+    including the module-level already-capped flag that setup_logger consults —
+    leaking it True would make later tests skip capping based on test order."""
     saved = {
         name: logging.getLogger(name).level for name in THIRD_PARTY_CAPPED_LOGGER_NAMES
     }
+    saved_capped_flag = logger_module._third_party_log_levels_capped
     yield
     for name, level in saved.items():
         logging.getLogger(name).setLevel(level)
+    logger_module._third_party_log_levels_capped = saved_capped_flag
 
 
 def test_third_party_loggers_capped_at_info_when_app_is_debug() -> None:
@@ -34,12 +39,27 @@ def test_third_party_loggers_capped_at_info_when_app_is_debug() -> None:
 
 
 def test_escape_hatch_lets_third_party_loggers_run_at_debug() -> None:
+    for name in THIRD_PARTY_CAPPED_LOGGER_NAMES:
+        logging.getLogger(name).setLevel(logging.NOTSET)
+
     cap_third_party_log_levels(
         app_log_level=logging.DEBUG, allow_third_party_debug=True
     )
 
     for name in THIRD_PARTY_CAPPED_LOGGER_NAMES:
         assert logging.getLogger(name).getEffectiveLevel() == logging.DEBUG, name
+
+
+def test_escape_hatch_never_lowers_an_already_raised_level() -> None:
+    # An explicitly suppressed logger (e.g. httpx pinned to WARNING) must stay
+    # suppressed even when LOG_THIRD_PARTY_DEBUG opts back into DEBUG output.
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
+    cap_third_party_log_levels(
+        app_log_level=logging.DEBUG, allow_third_party_debug=True
+    )
+
+    assert logging.getLogger("httpx").getEffectiveLevel() == logging.WARNING
 
 
 def test_cap_follows_app_level_when_app_is_stricter_than_info() -> None:

--- a/backend/tests/unit/onyx/utils/test_third_party_log_cap.py
+++ b/backend/tests/unit/onyx/utils/test_third_party_log_cap.py
@@ -1,0 +1,83 @@
+import logging
+from collections.abc import Generator
+
+import pytest
+
+from onyx.utils.logger import (
+    THIRD_PARTY_CAPPED_LOGGER_NAMES,
+    cap_third_party_log_levels,
+    remove_litellm_native_log_handlers,
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_third_party_logger_levels() -> Generator[None, None, None]:
+    """Snapshot and restore the global logging state these tests mutate."""
+    saved = {
+        name: logging.getLogger(name).level for name in THIRD_PARTY_CAPPED_LOGGER_NAMES
+    }
+    yield
+    for name, level in saved.items():
+        logging.getLogger(name).setLevel(level)
+
+
+def test_third_party_loggers_capped_at_info_when_app_is_debug() -> None:
+    for name in THIRD_PARTY_CAPPED_LOGGER_NAMES:
+        logging.getLogger(name).setLevel(logging.NOTSET)
+
+    cap_third_party_log_levels(
+        app_log_level=logging.DEBUG, allow_third_party_debug=False
+    )
+
+    for name in THIRD_PARTY_CAPPED_LOGGER_NAMES:
+        assert logging.getLogger(name).getEffectiveLevel() == logging.INFO, name
+
+
+def test_escape_hatch_lets_third_party_loggers_run_at_debug() -> None:
+    cap_third_party_log_levels(
+        app_log_level=logging.DEBUG, allow_third_party_debug=True
+    )
+
+    for name in THIRD_PARTY_CAPPED_LOGGER_NAMES:
+        assert logging.getLogger(name).getEffectiveLevel() == logging.DEBUG, name
+
+
+def test_cap_follows_app_level_when_app_is_stricter_than_info() -> None:
+    for name in THIRD_PARTY_CAPPED_LOGGER_NAMES:
+        logging.getLogger(name).setLevel(logging.NOTSET)
+
+    cap_third_party_log_levels(
+        app_log_level=logging.WARNING, allow_third_party_debug=False
+    )
+
+    for name in THIRD_PARTY_CAPPED_LOGGER_NAMES:
+        assert logging.getLogger(name).getEffectiveLevel() == logging.WARNING, name
+
+
+def test_cap_never_lowers_an_already_raised_level() -> None:
+    # e.g. litellm itself sets httpx to WARNING at import time
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
+    cap_third_party_log_levels(
+        app_log_level=logging.DEBUG, allow_third_party_debug=False
+    )
+
+    assert logging.getLogger("httpx").getEffectiveLevel() == logging.WARNING
+
+
+def test_remove_litellm_native_log_handlers_leaves_single_emission_path() -> None:
+    litellm_logger = logging.getLogger("LiteLLM")
+    saved_handlers = litellm_logger.handlers[:]
+    saved_propagate = litellm_logger.propagate
+    try:
+        # Simulate litellm's import-time handler attachment.
+        litellm_logger.addHandler(logging.StreamHandler())
+        litellm_logger.propagate = True
+
+        remove_litellm_native_log_handlers()
+
+        assert litellm_logger.handlers == []
+        assert litellm_logger.propagate is True
+    finally:
+        litellm_logger.handlers = saved_handlers
+        litellm_logger.propagate = saved_propagate

--- a/backend/tests/unit/onyx/utils/test_third_party_log_cap.py
+++ b/backend/tests/unit/onyx/utils/test_third_party_log_cap.py
@@ -5,6 +5,7 @@ import pytest
 
 import onyx.utils.logger as logger_module
 from onyx.utils.logger import (
+    LITELLM_NATIVE_LOGGER_NAMES,
     THIRD_PARTY_CAPPED_LOGGER_NAMES,
     cap_third_party_log_levels,
     remove_litellm_native_log_handlers,
@@ -20,10 +21,13 @@ def _restore_third_party_logger_levels() -> Generator[None, None, None]:
         name: logging.getLogger(name).level for name in THIRD_PARTY_CAPPED_LOGGER_NAMES
     }
     saved_capped_flag = logger_module._third_party_log_levels_capped
+    saved_cap_applied = dict(logger_module._cap_applied_levels)
     yield
     for name, level in saved.items():
         logging.getLogger(name).setLevel(level)
     logger_module._third_party_log_levels_capped = saved_capped_flag
+    logger_module._cap_applied_levels.clear()
+    logger_module._cap_applied_levels.update(saved_cap_applied)
 
 
 def test_third_party_loggers_capped_at_info_when_app_is_debug() -> None:
@@ -85,8 +89,36 @@ def test_cap_never_lowers_an_already_raised_level() -> None:
     assert logging.getLogger("httpx").getEffectiveLevel() == logging.WARNING
 
 
-def test_remove_litellm_native_log_handlers_leaves_single_emission_path() -> None:
-    litellm_logger = logging.getLogger("LiteLLM")
+def test_recap_at_more_permissive_level_relaxes_own_earlier_cap() -> None:
+    # A worker reconfiguring logging at DEBUG after an earlier WARNING-level
+    # setup must land at the DEBUG-app cap (INFO), not stay ratcheted at the
+    # WARNING this cap itself applied earlier.
+    for name in THIRD_PARTY_CAPPED_LOGGER_NAMES:
+        logging.getLogger(name).setLevel(logging.NOTSET)
+
+    cap_third_party_log_levels(
+        app_log_level=logging.WARNING, allow_third_party_debug=False
+    )
+    cap_third_party_log_levels(
+        app_log_level=logging.DEBUG, allow_third_party_debug=False
+    )
+
+    for name in THIRD_PARTY_CAPPED_LOGGER_NAMES:
+        assert logging.getLogger(name).getEffectiveLevel() == logging.INFO, name
+
+    # An externally raised level survives the same re-cap sequence.
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    cap_third_party_log_levels(
+        app_log_level=logging.DEBUG, allow_third_party_debug=False
+    )
+    assert logging.getLogger("httpx").getEffectiveLevel() == logging.WARNING
+
+
+@pytest.mark.parametrize("logger_name", LITELLM_NATIVE_LOGGER_NAMES)
+def test_remove_litellm_native_log_handlers_leaves_single_emission_path(
+    logger_name: str,
+) -> None:
+    litellm_logger = logging.getLogger(logger_name)
     saved_handlers = litellm_logger.handlers[:]
     saved_propagate = litellm_logger.propagate
     try:


### PR DESCRIPTION
## Description

Running a cluster at `LOG_LEVEL=DEBUG` was not viable: a single doc-processing celery worker emitted ~43 GiB/day, dominated by third-party DEBUG records.

Root cause, verified against litellm 1.93.0:

1. Celery's `on_setup_logging` sets the **root logger** to `LOG_LEVEL`. Third-party loggers (`LiteLLM`, `LiteLLM Router`, `LiteLLM Proxy`, `httpcore`, `botocore`, `pdfminer`, ...) are created at `NOTSET` and inherit root's DEBUG — LiteLLM alone emits several DEBUG records per streamed token, httpcore one per network event.
2. litellm's `_logging.py` attaches its **own StreamHandler at import time** (level from `LITELLM_LOG`, default DEBUG) while leaving `propagate=True`, so every record was emitted **twice**: once via litellm's colored handler and once via the app/root handlers. (`litellm.suppress_debug_info` only suppresses a printed info banner, not logging.)

Changes:

- `THIRD_PARTY_CAPPED_LOGGER_NAMES` + `cap_third_party_log_levels()` in `onyx/utils/logger.py`: caps a defined list of chatty third-party loggers at INFO (or the app log level if that is stricter). Applied on the first `setup_logger()` call (covers API server, model server, slackbot, scripts) and re-applied from celery's `on_setup_logging` with the worker's effective level. The cap sets explicit levels by logger name so it holds regardless of handler tree, and never lowers a level another module already raised (e.g. litellm sets `httpx` → WARNING itself).
- New env var `LOG_THIRD_PARTY_DEBUG=true` (`shared_configs/configs.py`) opts back into third-party DEBUG output, pinning those loggers to the app level.
- `remove_litellm_native_log_handlers()` called from `configure_litellm_settings()` strips LiteLLM's import-time handlers and keeps propagation on. **The chosen single emission path is the app/root logging pipeline** — LiteLLM's own handler is removed, so each LiteLLM record is emitted exactly once with the app's formatting (and tenant/task context where applicable).
- Google Drive group sync folder scan: the per-folder `"has no permissions. Skipping."` and `"has already been seen. Skipping."` DEBUG lines fired once per folder **per enumerated user** — millions of lines on large domains. Replaced with counters that log a DEBUG summary every 1000 skips and a single INFO total when the scan completes.

## How Has This Been Tested?

- New unit tests (`backend/tests/unit/onyx/utils/test_third_party_log_cap.py`): capped loggers have effective level INFO when the app level is DEBUG, DEBUG when the escape hatch is enabled, follow a stricter app level, are never lowered from an already-raised level, and the litellm handler strip leaves `handlers=[]` / `propagate=True`.
- Manual verification with `LOG_LEVEL=DEBUG` in both an API-server-like (no root handlers) and a celery-like (root handler at DEBUG) configuration: a litellm DEBUG record is filtered in both; a litellm INFO record emits exactly once via the root pipeline with no duplicate colored line; an onyx DEBUG record prints exactly once.
- `pre-commit run` on all changed files passes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce DEBUG log noise and remove duplicate `litellm` lines by capping chatty third‑party loggers and routing `litellm` logs through a single app/root path. Also aggregate Google Drive folder-scan skip logs to avoid millions of lines.

- **Bug Fixes**
  - Cap noisy third-party loggers (`litellm`, `httpx`, `httpcore`, `botocore`, `pdfminer`, etc.) at INFO or the stricter app level; applied in `setup_logger()` and Celery `on_setup_logging`. The cap tracks its own applied levels so re-caps can relax when the app level becomes more permissive, never lowers a level another module already raised, and respects the escape hatch.
  - Strip `litellm` import-time stream handlers so records emit once via the app/root pipeline (keeps app formatting and context).
  - Google Drive group sync: replace per-folder DEBUG spam with counters (DEBUG every 1000, one INFO total).

- **Migration**
  - Set `LOG_THIRD_PARTY_DEBUG=true` to opt back into third‑party DEBUG at the app level; existing explicit raises (e.g., `httpx` → WARNING) are preserved.

<sup>Written for commit 3cf004c8fb1bd954693667b60eac4baebefee6f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




Linear: https://linear.app/onyx-app/issue/ENG-4312
