### PR TITLE
fix(perm-sync): stop duplicate gdrive group-sync crawls from stacking to OOM

### DIFF
--- a/backend/ee/onyx/external_permissions/google_drive/group_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/group_sync.py
@@ -289,6 +289,7 @@ def _get_drive_members(
                 # is an admin
                 useDomainAdminAccess=is_admin,
             ):
+                _check_sync_deadline(deadline)
                 # NOTE: don't need to check for PermissionType.ANYONE since
                 # you can't share a drive with the internet
                 if permission["type"] == PermissionType.GROUP:
@@ -379,6 +380,7 @@ def _get_all_google_groups(
 def _google_group_to_onyx_group(
     admin_service: AdminService,
     group_email: str,
+    deadline: float,
 ) -> ExternalUserGroup:
     """
     This maps google group emails to their member emails.
@@ -390,6 +392,7 @@ def _google_group_to_onyx_group(
         groupKey=group_email,
         fields="members(email),nextPageToken",
     ):
+        _check_sync_deadline(deadline)
         group_member_emails.add(member["email"])
 
     return ExternalUserGroup(
@@ -527,7 +530,9 @@ def gdrive_group_sync(
     group_email_to_member_emails_map: dict[str, list[str]] = {}
     for group_email in all_group_emails:
         _check_sync_deadline(sync_deadline)
-        onyx_group = _google_group_to_onyx_group(admin_service, group_email)
+        onyx_group = _google_group_to_onyx_group(
+            admin_service, group_email, sync_deadline
+        )
         group_email_to_member_emails_map[group_email] = onyx_group.user_emails
         yield onyx_group
 

--- a/backend/ee/onyx/external_permissions/google_drive/group_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/group_sync.py
@@ -42,8 +42,23 @@ class FolderInfo(BaseModel):
     permissions: list[GoogleDrivePermission]
 
 
+def _check_sync_deadline(deadline: float) -> None:
+    """The sync's non-yielding enumeration phases can each run for hours on
+    large domains, where consumer-side timeouts (checked between yields) and
+    celery soft_time_limit (inert on thread pools) never fire — every long
+    loop in this module must check the shared deadline itself."""
+    if time.monotonic() > deadline:
+        raise TimeoutError(
+            f"Drive group sync exceeded {JOB_TIMEOUT}s before completing "
+            "enumeration; failing the sync so the worker releases its lock "
+            "and fence instead of running indefinitely."
+        )
+
+
 def _get_all_folders(
-    google_drive_connector: GoogleDriveConnector, skip_folders_without_permissions: bool
+    google_drive_connector: GoogleDriveConnector,
+    skip_folders_without_permissions: bool,
+    deadline: float | None = None,
 ) -> Generator[FolderInfo, None, None]:
     """Have to get all folders since the group syncing system assumes all groups
     are returned every time.
@@ -59,10 +74,9 @@ def _get_all_folders(
     # enumerated user).
     SKIP_LOG_INTERVAL = 1000
 
-    # The crawl re-enumerates the whole domain once per user and can yield
-    # ~nothing for hours on large domains, so consumer-side timeouts (which
-    # only run between yields) never fire — the deadline must live in here.
-    crawl_deadline = time.monotonic() + JOB_TIMEOUT
+    crawl_deadline = (
+        deadline if deadline is not None else time.monotonic() + JOB_TIMEOUT
+    )
 
     seen_folder_ids: set[str] = set()
     skipped_already_seen = 0
@@ -84,12 +98,7 @@ def _get_all_folders(
         for folder in get_modified_folders(
             service=drive_service,
         ):
-            if time.monotonic() > crawl_deadline:
-                raise TimeoutError(
-                    f"Drive folder crawl exceeded {JOB_TIMEOUT}s before completing "
-                    "domain enumeration; failing the sync so the worker releases "
-                    "its lock and fence instead of running indefinitely."
-                )
+            _check_sync_deadline(crawl_deadline)
             folder_id = folder["id"]
             if folder_id in seen_folder_ids:
                 skipped_already_seen += 1
@@ -221,6 +230,7 @@ def _drive_folder_to_onyx_group(
 def _get_drive_members(
     google_drive_connector: GoogleDriveConnector,
     admin_service: AdminService,
+    deadline: float,
 ) -> dict[str, tuple[set[str], set[str]]]:
     """
     This builds a map of drive ids to their members (group and user emails).
@@ -264,6 +274,7 @@ def _get_drive_members(
     )
 
     for drive_id in drive_ids:
+        _check_sync_deadline(deadline)
         group_emails: set[str] = set()
         user_emails: set[str] = set()
 
@@ -326,6 +337,7 @@ def _drive_member_map_to_onyx_groups(
 def _get_all_domain_users(
     admin_service: AdminService,
     google_domain: str,
+    deadline: float,
 ) -> list[str]:
     """Every user Google lists in the Workspace domain. This is the real
     membership behind an "everyone at <domain>" Drive share, so a user is only in
@@ -338,6 +350,7 @@ def _get_all_domain_users(
         domain=google_domain,
         fields="users(primaryEmail),nextPageToken",
     ):
+        _check_sync_deadline(deadline)
         if email := user.get("primaryEmail"):
             user_emails.add(email)
     return list(user_emails)
@@ -346,6 +359,7 @@ def _get_all_domain_users(
 def _get_all_google_groups(
     admin_service: AdminService,
     google_domain: str,
+    deadline: float,
 ) -> set[str]:
     """
     This gets all the group emails.
@@ -357,6 +371,7 @@ def _get_all_google_groups(
         domain=google_domain,
         fields="groups(email),nextPageToken",
     ):
+        _check_sync_deadline(deadline)
         group_emails.add(group["email"])
     return group_emails
 
@@ -494,17 +509,24 @@ def gdrive_group_sync(
         google_drive_connector.creds, google_drive_connector.primary_admin_email
     )
 
+    # One budget for the whole sync: every long enumeration phase below checks
+    # this deadline, since none of them yield often (or at all) on big domains.
+    sync_deadline = time.monotonic() + JOB_TIMEOUT
+
     # Get all drive members
-    drive_id_to_members_map = _get_drive_members(google_drive_connector, admin_service)
+    drive_id_to_members_map = _get_drive_members(
+        google_drive_connector, admin_service, sync_deadline
+    )
 
     # Get all group emails
     all_group_emails = _get_all_google_groups(
-        admin_service, google_drive_connector.google_domain
+        admin_service, google_drive_connector.google_domain, sync_deadline
     )
 
     # Each google group is an Onyx group, yield those
     group_email_to_member_emails_map: dict[str, list[str]] = {}
     for group_email in all_group_emails:
+        _check_sync_deadline(sync_deadline)
         onyx_group = _google_group_to_onyx_group(admin_service, group_email)
         group_email_to_member_emails_map[group_email] = onyx_group.user_emails
         yield onyx_group
@@ -519,6 +541,7 @@ def gdrive_group_sync(
     folder_info = _get_all_folders(
         google_drive_connector=google_drive_connector,
         skip_folders_without_permissions=True,
+        deadline=sync_deadline,
     )
     for folder in folder_info:
         yield _drive_folder_to_onyx_group(folder, group_email_to_member_emails_map)
@@ -527,7 +550,7 @@ def gdrive_group_sync(
     # connector's own domain is enumerable here; a share to a partner domain is
     # populated by that domain's own connector sync.
     domain_users = _get_all_domain_users(
-        admin_service, google_drive_connector.google_domain
+        admin_service, google_drive_connector.google_domain, sync_deadline
     )
     if domain_users:
         yield ExternalUserGroup(

--- a/backend/ee/onyx/external_permissions/google_drive/group_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/group_sync.py
@@ -1,3 +1,4 @@
+import time
 from collections.abc import Generator
 
 from googleapiclient.errors import HttpError
@@ -14,6 +15,7 @@ from ee.onyx.external_permissions.google_drive.models import (
 )
 from ee.onyx.external_permissions.utils import credential_json
 from onyx.access.utils import build_domain_group_id
+from onyx.configs.app_configs import JOB_TIMEOUT
 from onyx.connectors.google_drive.connector import GoogleDriveConnector
 from onyx.connectors.google_utils.google_utils import execute_paginated_retrieval
 from onyx.connectors.google_utils.resources import (
@@ -57,6 +59,11 @@ def _get_all_folders(
     # enumerated user).
     SKIP_LOG_INTERVAL = 1000
 
+    # The crawl re-enumerates the whole domain once per user and can yield
+    # ~nothing for hours on large domains, so consumer-side timeouts (which
+    # only run between yields) never fire — the deadline must live in here.
+    crawl_deadline = time.monotonic() + JOB_TIMEOUT
+
     seen_folder_ids: set[str] = set()
     skipped_already_seen = 0
     skipped_no_permissions = 0
@@ -77,6 +84,12 @@ def _get_all_folders(
         for folder in get_modified_folders(
             service=drive_service,
         ):
+            if time.monotonic() > crawl_deadline:
+                raise TimeoutError(
+                    f"Drive folder crawl exceeded {JOB_TIMEOUT}s before completing "
+                    "domain enumeration; failing the sync so the worker releases "
+                    "its lock and fence instead of running indefinitely."
+                )
             folder_id = folder["id"]
             if folder_id in seen_folder_ids:
                 skipped_already_seen += 1
@@ -132,6 +145,10 @@ def _get_all_folders(
             yield from _get_all_folders_for_user(
                 google_drive_connector, skip_folders_without_permissions, user_email
             )
+        except TimeoutError:
+            # The crawl deadline is fatal for the whole sync, not a per-user
+            # failure — let it end the task.
+            raise
         except Exception as e:
             # 401 indicates a customer-side credential issue (token revoked /
             # expired), not a bug — surface as a warning instead of an error.

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -168,12 +168,14 @@ CELERY_PRUNING_LOCK_TIMEOUT = 3600  # 1 hour (in seconds)
 
 CELERY_PERMISSIONS_SYNC_LOCK_TIMEOUT = 3600  # 1 hour (in seconds)
 
-# Must exceed the longest legitimate sync (the gdrive folder crawl enforces a
-# JOB_TIMEOUT deadline, 6h by default): while the lock is held, beat's
-# re-dispatches of the same cc_pair exit immediately instead of stacking
-# duplicate multi-hour crawls on one heavy worker (the OOM mechanism). A worker
-# that dies mid-sync leaves the lock stuck for at most this TTL.
-CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT = 7 * 3600  # JOB_TIMEOUT + 1h margin
+# While this lock is held, duplicate dispatches for the same cc_pair exit
+# immediately. Deployments whose group syncs legitimately run for hours should
+# raise this toward the JOB_TIMEOUT crawl deadline (6h) so re-dispatches can't
+# stack concurrent crawls on one heavy worker; a worker that dies mid-sync
+# leaves the lock stuck for at most this TTL.
+CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT = int(
+    os.environ.get("CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT") or 300
+)
 
 CELERY_USER_FILE_PROCESSING_LOCK_TIMEOUT = 30 * 60  # 30 minutes (in seconds)
 

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -173,8 +173,21 @@ CELERY_PERMISSIONS_SYNC_LOCK_TIMEOUT = 3600  # 1 hour (in seconds)
 # raise this toward the JOB_TIMEOUT crawl deadline (6h) so re-dispatches can't
 # stack concurrent crawls on one heavy worker; a worker that dies mid-sync
 # leaves the lock stuck for at most this TTL.
-CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT = int(
-    os.environ.get("CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT") or 300
+# Non-positive values would break the guard (0 = a lock with no TTL that a
+# crashed worker leaves stuck forever; negatives fail acquisition), so clamp
+# bad overrides back to the default.
+_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT_DEFAULT = 300
+try:
+    _external_group_sync_lock_timeout = int(
+        os.environ.get("CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT")
+        or _EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT_DEFAULT
+    )
+except ValueError:
+    _external_group_sync_lock_timeout = _EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT_DEFAULT
+CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT: int = (
+    _external_group_sync_lock_timeout
+    if _external_group_sync_lock_timeout > 0
+    else _EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT_DEFAULT
 )
 
 CELERY_USER_FILE_PROCESSING_LOCK_TIMEOUT = 30 * 60  # 30 minutes (in seconds)

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import platform
 import re
@@ -175,20 +176,30 @@ CELERY_PERMISSIONS_SYNC_LOCK_TIMEOUT = 3600  # 1 hour (in seconds)
 # leaves the lock stuck for at most this TTL.
 # Non-positive values would break the guard (0 = a lock with no TTL that a
 # crashed worker leaves stuck forever; negatives fail acquisition), so clamp
-# bad overrides back to the default.
+# bad overrides back to the default — loudly, since an operator who set a
+# long TTL needs to know their duplicate-crawl protection is NOT in effect.
 _EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT_DEFAULT = 300
+_external_group_sync_lock_timeout_raw = os.environ.get(
+    "CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT"
+)
 try:
-    _external_group_sync_lock_timeout = int(
-        os.environ.get("CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT")
-        or _EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT_DEFAULT
+    _external_group_sync_lock_timeout = (
+        int(_external_group_sync_lock_timeout_raw)
+        if _external_group_sync_lock_timeout_raw
+        else _EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT_DEFAULT
     )
 except ValueError:
-    _external_group_sync_lock_timeout = _EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT_DEFAULT
-CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT: int = (
-    _external_group_sync_lock_timeout
-    if _external_group_sync_lock_timeout > 0
-    else _EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT_DEFAULT
-)
+    _external_group_sync_lock_timeout = -1
+if _external_group_sync_lock_timeout > 0:
+    CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT: int = _external_group_sync_lock_timeout
+else:
+    logging.getLogger(__name__).warning(
+        "Ignoring invalid CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT=%r "
+        "(must be a positive integer of seconds); using the %ds default.",
+        _external_group_sync_lock_timeout_raw,
+        _EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT_DEFAULT,
+    )
+    CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT = _EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT_DEFAULT
 
 CELERY_USER_FILE_PROCESSING_LOCK_TIMEOUT = 30 * 60  # 30 minutes (in seconds)
 

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -168,7 +168,12 @@ CELERY_PRUNING_LOCK_TIMEOUT = 3600  # 1 hour (in seconds)
 
 CELERY_PERMISSIONS_SYNC_LOCK_TIMEOUT = 3600  # 1 hour (in seconds)
 
-CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT = 300  # 5 min
+# Must exceed the longest legitimate sync (the gdrive folder crawl enforces a
+# JOB_TIMEOUT deadline, 6h by default): while the lock is held, beat's
+# re-dispatches of the same cc_pair exit immediately instead of stacking
+# duplicate multi-hour crawls on one heavy worker (the OOM mechanism). A worker
+# that dies mid-sync leaves the lock stuck for at most this TTL.
+CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT = 7 * 3600  # JOB_TIMEOUT + 1h margin
 
 CELERY_USER_FILE_PROCESSING_LOCK_TIMEOUT = 30 * 60  # 30 minutes (in seconds)
 

--- a/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_gdrive_domain_permission_scoping.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_gdrive_domain_permission_scoping.py
@@ -3,6 +3,7 @@
 permission paths. The user-side token comes from the synced domain group's real
 Workspace membership, not from the user's email string."""
 
+import time
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock, call, patch
@@ -336,6 +337,8 @@ def test_group_sync_domain_group_uses_real_roster() -> None:
     with patch.object(
         group_sync, "execute_paginated_retrieval", return_value=iter(roster)
     ):
-        members = group_sync._get_all_domain_users(admin_service, COMPANY_DOMAIN)
+        members = group_sync._get_all_domain_users(
+            admin_service, COMPANY_DOMAIN, deadline=time.monotonic() + 60
+        )
 
     assert set(members) == {"alice@companya.com", "bob@companya.com"}

--- a/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_get_all_folders_streaming.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_get_all_folders_streaming.py
@@ -1,10 +1,14 @@
 import inspect
+import time
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from ee.onyx.external_permissions.google_drive.group_sync import _get_all_folders
+from ee.onyx.external_permissions.google_drive.group_sync import (
+    _get_all_folders,
+    _get_all_google_groups,
+)
 
 
 def _folder(folder_id: str) -> dict[str, Any]:
@@ -147,15 +151,38 @@ def test_get_all_folders_enforces_crawl_deadline(
     mock_get_modified_folders.side_effect = endless_folders
     connector = _make_connector(["a@example.com", "b@example.com"])
 
-    with patch("ee.onyx.external_permissions.google_drive.group_sync.JOB_TIMEOUT", 0):
-        with pytest.raises(TimeoutError, match="folder crawl exceeded"):
-            list(
-                _get_all_folders(
-                    google_drive_connector=connector,
-                    skip_folders_without_permissions=True,
-                )
+    expired_deadline = time.monotonic() - 1
+    with pytest.raises(TimeoutError, match="group sync exceeded"):
+        list(
+            _get_all_folders(
+                google_drive_connector=connector,
+                skip_folders_without_permissions=True,
+                deadline=expired_deadline,
             )
+        )
 
     # Only the first user was touched: the deadline ends the whole sync
     # instead of counting as a per-user failure and moving on.
     assert mock_get_drive_service.call_count == 1
+
+
+def test_group_enumeration_enforces_sync_deadline() -> None:
+    """The groups phase materializes the full group list before anything
+    yields, so it must check the shared sync deadline itself."""
+
+    def endless_groups(*_args: Any, **_kwargs: Any) -> Any:
+        i = 0
+        while True:
+            i += 1
+            yield {"email": f"group-{i}@example.com"}
+
+    with patch(
+        "ee.onyx.external_permissions.google_drive.group_sync.execute_paginated_retrieval",
+        side_effect=endless_groups,
+    ):
+        with pytest.raises(TimeoutError, match="group sync exceeded"):
+            _get_all_google_groups(
+                admin_service=MagicMock(),
+                google_domain="example.com",
+                deadline=time.monotonic() - 1,
+            )

--- a/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_get_all_folders_streaming.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_get_all_folders_streaming.py
@@ -123,3 +123,39 @@ def test_get_all_folders_aborts_after_too_many_user_failures(
                 skip_folders_without_permissions=True,
             )
         )
+
+
+@patch("ee.onyx.external_permissions.google_drive.group_sync.get_modified_folders")
+@patch("ee.onyx.external_permissions.google_drive.group_sync.get_drive_service")
+def test_get_all_folders_enforces_crawl_deadline(
+    mock_get_drive_service: MagicMock,
+    mock_get_modified_folders: MagicMock,
+) -> None:
+    """On large domains the crawl skips almost every folder and yields nothing
+    for hours, so consumer-side timeouts (checked between yields) never fire —
+    the crawl must enforce its own deadline and fail the sync outright rather
+    than being swallowed by the per-user failure accounting."""
+
+    def endless_folders(service: Any) -> Any:
+        del service
+        i = 0
+        while True:
+            i += 1
+            yield _folder(f"f{i}")
+
+    mock_get_drive_service.return_value = MagicMock()
+    mock_get_modified_folders.side_effect = endless_folders
+    connector = _make_connector(["a@example.com", "b@example.com"])
+
+    with patch("ee.onyx.external_permissions.google_drive.group_sync.JOB_TIMEOUT", 0):
+        with pytest.raises(TimeoutError, match="folder crawl exceeded"):
+            list(
+                _get_all_folders(
+                    google_drive_connector=connector,
+                    skip_folders_without_permissions=True,
+                )
+            )
+
+    # Only the first user was touched: the deadline ends the whole sync
+    # instead of counting as a per-user failure and moving on.
+    assert mock_get_drive_service.call_count == 1

--- a/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_get_drive_members_admin_403.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_get_drive_members_admin_403.py
@@ -1,3 +1,4 @@
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -36,7 +37,7 @@ def test_get_drive_members_admin_403_raises_permission_error(
     )
 
     with pytest.raises(PermissionError) as exc_info:
-        _get_drive_members(connector, admin_service)
+        _get_drive_members(connector, admin_service, deadline=time.monotonic() + 60)
 
     assert "primary admin" in str(exc_info.value).lower()
     assert connector.primary_admin_email in str(exc_info.value)
@@ -57,4 +58,4 @@ def test_get_drive_members_admin_non_403_reraised(
     )
 
     with pytest.raises(HttpError):
-        _get_drive_members(connector, admin_service)
+        _get_drive_members(connector, admin_service, deadline=time.monotonic() + 60)

--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
@@ -220,6 +220,10 @@ MINIO_ROOT_PASSWORD=minioadmin
 # CELERY_WORKER_DOCPROCESSING_CONCURRENCY=
 # CELERY_WORKER_LIGHT_CONCURRENCY=
 # CELERY_WORKER_LIGHT_PREFETCH_MULTIPLIER=
+## Per-connector external group sync lock TTL in seconds (default 300). Raise
+## toward the 6h crawl deadline if group syncs run long, so periodic
+## re-dispatches can't start concurrent duplicate syncs.
+# CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT=
 
 ## AWS Configuration
 # AWS_ACCESS_KEY_ID=

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -220,6 +220,10 @@ MINIO_ROOT_PASSWORD=minioadmin
 # CELERY_WORKER_DOCPROCESSING_CONCURRENCY=
 # CELERY_WORKER_LIGHT_CONCURRENCY=
 # CELERY_WORKER_LIGHT_PREFETCH_MULTIPLIER=
+## Per-connector external group sync lock TTL in seconds (default 300). Raise
+## toward the 6h crawl deadline if group syncs run long, so periodic
+## re-dispatches can't start concurrent duplicate syncs.
+# CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT=
 
 ## AWS Configuration
 # AWS_ACCESS_KEY_ID=

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.11
+version: 0.8.12
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1594,6 +1594,10 @@ configMap:
   CELERY_WORKER_LIGHT_CONCURRENCY: ""
   CELERY_WORKER_LIGHT_PREFETCH_MULTIPLIER: ""
   CELERY_WORKER_USER_FILE_PROCESSING_CONCURRENCY: ""
+  # Per-connector external group sync lock TTL in seconds (default 300); raise
+  # toward the 6h crawl deadline if group syncs run long, so periodic
+  # re-dispatches can't start concurrent duplicate syncs.
+  CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT: ""
   # OnyxBot SlackBot Configs
   ONYX_BOT_DISABLE_DOCS_ONLY_ANSWER: ""
   ONYX_BOT_DISPLAY_ERROR_MSGS: ""


### PR DESCRIPTION
## Summary
Fixes the daily heavy-worker OOMKills from Google Drive external group sync (ENG-4311). **Reworked from the earlier ~1,000-line runtime/heartbeat approach to a minimal 2-change fix (~25 code lines)** based on the measured attribution: a *single* eternal crawl only accumulates ~150–300 MiB/h (~2.5 Gi peak of the 5 Gi limit — never enough to alert); the OOMs come from **duplicate crawls stacking** (2–3 concurrent, measured 0.9 GiB/h combined; one cc_pair was dispatched 30× in 29h with zero completions).

## Changes
1. **`CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT`: 300s → 7h.** The per-cc_pair run lock expired 5 minutes into multi-hour crawls, so beat's re-dispatches (fence active TTL is 1h) acquired it and started duplicates. The lock-fail path already exits *before* the `try/finally` — zero work, no fence damage — so a longer TTL alone ends the stacking. (The sibling `CELERY_PERMISSIONS_SYNC_LOCK_TIMEOUT` is already 3600s; 300s was an outlier.)
2. **All long enumeration phases enforce one shared `JOB_TIMEOUT` sync deadline** (per review: shared-drive members, google groups, domain users, and the folder crawl all materialize/skip for long stretches without yielding, so consumer-side timeouts and celery `soft_time_limit` never fire). The crawl yields ~nothing on large domains, so the consumer-side timeout (checked between yields) and celery `soft_time_limit` (inert under the threads pool) never fired — crawls ran until pod death. `TimeoutError` deliberately bypasses the per-user failure accounting and fails the sync properly: FAILED sync record in the UI, fence cleared, lock released, memory freed.

Worst case with both: **one** crawl per cc_pair, capped at 6h, ~2.5 Gi peak → no more near-limit alerts from this path.

## Lock TTL (resolved per review discussion)
The code **default stays 300s** — `CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT` is now env-overridable, and the managed fleet opts into **7h** via [onyx-infra#745](https://github.com/onyx-dot-app/onyx-infra/pull/745) (inert until this PR ships in the fleet image). Deployments with long-running group syncs can raise it toward the 6h crawl deadline; everyone else keeps today's behavior. Documented in `env.template` + helm `values.yaml`. Without the override, stacking is still bounded now (each crawl dies at 6h → ≤6 concurrent) instead of unbounded.

## Not in scope (tracked in ENG-4311)
Large domains still can't *complete* enumeration — the crawl is O(users × folders); with this PR they fail cleanly at 6h instead of zombie-crawling forever. The real completion fix is delta-based enumeration (existing TODO in `_get_all_folders`).

## Tests
- New unit test: endless synthetic crawl hits the deadline, raises `TimeoutError`, and is NOT swallowed by per-user failure accounting (only user 1 touched).
- Regression: all 22 existing gdrive group-sync unit tests + 6 external-dependency-unit group-sync tests pass.

Note: branch was reset and force-pushed for the rework; the previous implementation is preserved at `ecbf1c8c5b` if pieces are ever wanted.

Linear: https://linear.app/onyx-app/issue/ENG-4311

