### PR TITLE
feat(telemetry): daily deployment snapshot for POC tracking

### DIFF
--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -210,6 +210,20 @@ beat_task_templates: list[dict] = [
             "work_gated": True,
         },
     },
+    # hourly tick; the task itself enforces a once-per-day cadence
+    {
+        "name": "emit-deployment-snapshot-telemetry",
+        "task": OnyxCeleryTask.EMIT_DEPLOYMENT_SNAPSHOT_TELEMETRY,
+        "schedule": timedelta(hours=1),
+        "options": {
+            "priority": OnyxCeleryPriority.LOW,
+            "expires": BEAT_EXPIRES_DEFAULT,
+            "queue": OnyxCeleryQueues.MONITORING,
+            # POCs are exactly the tenants most likely to be gated, and this is
+            # how we see how they're going.
+            "skip_gated": False,
+        },
+    },
 ]
 
 # Mirror set_is_ee_based_on_env_variable(): EE features are active when either

--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -44,6 +44,7 @@ from onyx.db.models import (
     UserGroup,
 )
 from onyx.db.search_settings import get_active_search_settings_list
+from onyx.db.telemetry_snapshot import build_deployment_snapshot
 from onyx.redis.redis_pool import (
     get_redis_client,
     get_shared_redis_client,
@@ -1193,3 +1194,58 @@ def emit_version_telemetry(*, tenant_id: str) -> None:
     if not delivered:
         # release the slot so the next hourly tick retries
         redis_std.delete(_VERSION_TELEMETRY_EMITTED_KEY)
+
+
+"""Deployment snapshot telemetry"""
+
+_DEPLOYMENT_SNAPSHOT_EMITTED_KEY = "monitoring_deployment_snapshot_emitted"
+_DEPLOYMENT_SNAPSHOT_TTL_SECONDS = 24 * 60 * 60
+
+
+@shared_task(
+    name=OnyxCeleryTask.EMIT_DEPLOYMENT_SNAPSHOT_TELEMETRY,
+    ignore_result=True,
+    soft_time_limit=_MONITORING_SOFT_TIME_LIMIT,
+    time_limit=_MONITORING_TIME_LIMIT,
+    queue=OnyxCeleryQueues.MONITORING,
+)
+def emit_deployment_snapshot_telemetry(*, tenant_id: str) -> None:
+    """Daily report of onboarding + usage state: users, connectors and their
+    indexing/permission-sync health, query volume, and feedback.
+
+    Runs for both self-hosted deployments and cloud tenants. Scheduled hourly
+    (beat schedule state doesn't survive restarts, so a daily interval could
+    never fire); the 1-day-TTL Redis marker enforces the daily cadence.
+    """
+    if DISABLE_TELEMETRY:
+        return
+
+    CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
+
+    redis_std = get_redis_client(tenant_id=tenant_id)
+    # atomically claim the daily slot so overlapping runs can't double-report
+    if not redis_std.set(
+        _DEPLOYMENT_SNAPSHOT_EMITTED_KEY,
+        "1",
+        nx=True,
+        ex=_DEPLOYMENT_SNAPSHOT_TTL_SECONDS,
+    ):
+        return
+
+    try:
+        with get_session_with_current_tenant() as db_session:
+            snapshot = build_deployment_snapshot(db_session)
+
+        delivered = optional_telemetry(
+            record_type=RecordType.DEPLOYMENT_SNAPSHOT,
+            data=snapshot.model_dump(mode="json"),
+            tenant_id=tenant_id,
+            blocking=True,
+        )
+    except Exception:
+        task_logger.exception("Failed to build deployment snapshot telemetry")
+        delivered = False
+
+    if not delivered:
+        # release the slot so the next hourly tick retries
+        redis_std.delete(_DEPLOYMENT_SNAPSHOT_EMITTED_KEY)

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -636,6 +636,7 @@ class OnyxCeleryTask:
     MONITOR_PROCESS_MEMORY = "monitor_process_memory"
     CELERY_BEAT_HEARTBEAT = "celery_beat_heartbeat"
     EMIT_VERSION_TELEMETRY = "emit_version_telemetry"
+    EMIT_DEPLOYMENT_SNAPSHOT_TELEMETRY = "emit_deployment_snapshot_telemetry"
 
     CONNECTOR_PERMISSION_SYNC_GENERATOR_TASK = (
         "connector_permission_sync_generator_task"

--- a/backend/onyx/db/telemetry_snapshot.py
+++ b/backend/onyx/db/telemetry_snapshot.py
@@ -1,0 +1,448 @@
+"""Point-in-time snapshot of a deployment's onboarding + usage state.
+
+Answers the questions we care about while a POC is running: who has been
+onboarded, which connectors exist and whether their indexing / permission
+syncing is healthy, how much the deployment is being queried, and how those
+answers are rated. Emitted periodically via the anonymous telemetry system, so
+it works identically for self-hosted and cloud tenants.
+"""
+
+from datetime import datetime, timedelta, timezone
+from uuid import UUID
+
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from onyx.auth.schemas import UserRole
+from onyx.configs.constants import DEFAULT_CC_PAIR_ID, MessageType
+from onyx.db.document import get_document_counts_for_all_cc_pairs
+from onyx.db.models import (
+    ChatMessage,
+    ChatMessageFeedback,
+    ChatSession,
+    Connector,
+    ConnectorCredentialPair,
+    DocPermissionSyncAttempt,
+    ExternalGroupPermissionSyncAttempt,
+    IndexAttempt,
+    User,
+)
+from onyx.db.users import (
+    get_accepted_user_where_clause,
+    get_user_counts_by_role_and_status,
+)
+
+# Keep a single telemetry POST bounded on large deployments. A POC sits far
+# below both caps, so in practice nothing is ever dropped.
+MAX_USERS_REPORTED = 1000
+MAX_CONNECTORS_REPORTED = 500
+
+
+class UserSnapshot(BaseModel):
+    user_id: str
+    email: str
+    role: str
+    is_active: bool
+    created_at: datetime | None
+    num_queries: int
+    last_query_at: datetime | None
+
+
+class UsersSection(BaseModel):
+    total: int
+    active: int
+    by_role: dict[str, int]
+    # Users discovered by permission sync rather than onboarded; counted only.
+    external_permission_users: int
+    truncated: bool
+    items: list[UserSnapshot]
+
+
+class AttemptSnapshot(BaseModel):
+    status: str
+    time_started: datetime | None
+    time_finished: datetime | None
+
+
+class IndexAttemptSnapshot(AttemptSnapshot):
+    new_docs_indexed: int
+    total_docs_indexed: int
+
+
+class DocPermissionSyncSnapshot(AttemptSnapshot):
+    total_docs_synced: int
+    docs_with_permission_errors: int
+
+
+class ExternalGroupSyncSnapshot(AttemptSnapshot):
+    total_users_processed: int
+    total_groups_processed: int
+
+
+class ConnectorSnapshot(BaseModel):
+    cc_pair_id: int
+    source: str
+    # Permission mode: public / private / sync
+    access_type: str
+    auto_sync_enabled: bool
+    status: str
+    in_repeated_error_state: bool
+    # Documents currently attributed to this connector in the index
+    docs_in_index: int
+    # Running total the connector itself reports having indexed
+    total_docs_indexed: int
+    last_index_attempt: IndexAttemptSnapshot | None
+    last_doc_permission_sync: DocPermissionSyncSnapshot | None
+    last_external_group_sync: ExternalGroupSyncSnapshot | None
+
+
+class ConnectorsSection(BaseModel):
+    total: int
+    truncated: bool
+    items: list[ConnectorSnapshot]
+
+
+class QueriesSection(BaseModel):
+    total: int
+    last_24h: int
+
+
+class FeedbackSection(BaseModel):
+    positive: int
+    negative: int
+    unrated: int
+
+
+class DeploymentSnapshot(BaseModel):
+    snapshot_at: datetime
+    users: UsersSection
+    connectors: ConnectorsSection
+    queries: QueriesSection
+    feedback: FeedbackSection
+
+
+class _UserQueryStats(BaseModel):
+    num_queries: int
+    last_query_at: datetime | None
+
+
+def _query_stats_by_user(db_session: Session) -> dict[UUID, _UserQueryStats]:
+    """Query counts keyed by user. Sessions with no owner (Slack/anonymous flows)
+    are excluded here but still counted in the deployment-wide total."""
+    return {
+        user_id: _UserQueryStats(num_queries=num_queries, last_query_at=last_query_at)
+        for user_id, num_queries, last_query_at in db_session.execute(
+            select(
+                ChatSession.user_id,
+                func.count(ChatMessage.id),
+                func.max(ChatMessage.time_sent),
+            )
+            .join(ChatSession, ChatSession.id == ChatMessage.chat_session_id)
+            .where(ChatMessage.message_type == MessageType.USER)
+            .group_by(ChatSession.user_id)
+        )
+        if user_id is not None
+    }
+
+
+def _collect_users(db_session: Session) -> UsersSection:
+    query_stats = _query_stats_by_user(db_session)
+
+    counts = get_user_counts_by_role_and_status(db_session)
+    by_role = counts["role_counts"]
+
+    external_permission_users = db_session.execute(
+        select(func.count())
+        .select_from(User)
+        .where(User.role == UserRole.EXT_PERM_USER)
+    ).scalar_one()
+
+    # `id` / `email` / `is_active` come from the fastapi-users base class, so go
+    # through __table__.c to get properly typed SQLAlchemy columns.
+    # One extra row tells us whether the cap truncated the list.
+    rows = db_session.execute(
+        select(
+            User.__table__.c.id,
+            User.__table__.c.email,
+            User.role,
+            User.__table__.c.is_active,
+            User.created_at,
+        )
+        .where(*get_accepted_user_where_clause())
+        .order_by(User.created_at, User.__table__.c.id)
+        .limit(MAX_USERS_REPORTED + 1)
+    ).all()
+    truncated = len(rows) > MAX_USERS_REPORTED
+
+    no_queries = _UserQueryStats(num_queries=0, last_query_at=None)
+    items = [
+        UserSnapshot(
+            user_id=str(user_id),
+            email=email,
+            role=role.value,
+            is_active=is_active,
+            created_at=created_at,
+            num_queries=query_stats.get(user_id, no_queries).num_queries,
+            last_query_at=query_stats.get(user_id, no_queries).last_query_at,
+        )
+        for user_id, email, role, is_active, created_at in rows[:MAX_USERS_REPORTED]
+    ]
+
+    return UsersSection(
+        total=sum(by_role.values()),
+        active=counts["status_counts"]["active"],
+        by_role=by_role,
+        external_permission_users=external_permission_users,
+        truncated=truncated,
+        items=items,
+    )
+
+
+def _latest_index_attempts(
+    db_session: Session, cc_pair_ids: list[int]
+) -> dict[int, IndexAttemptSnapshot]:
+    """Latest full-run attempt per cc_pair in one DISTINCT ON pass. Targeted
+    reindexes and synthetic seed rows aren't connector runs, so they're skipped."""
+    if not cc_pair_ids:
+        return {}
+
+    return {
+        cc_pair_id: IndexAttemptSnapshot(
+            status=status.value,
+            time_started=time_started,
+            time_finished=time_updated if status.is_terminal() else None,
+            new_docs_indexed=new_docs_indexed or 0,
+            total_docs_indexed=total_docs_indexed or 0,
+        )
+        for (
+            cc_pair_id,
+            status,
+            time_started,
+            time_updated,
+            new_docs_indexed,
+            total_docs_indexed,
+        ) in db_session.execute(
+            select(
+                IndexAttempt.connector_credential_pair_id,
+                IndexAttempt.status,
+                IndexAttempt.time_started,
+                IndexAttempt.time_updated,
+                IndexAttempt.new_docs_indexed,
+                IndexAttempt.total_docs_indexed,
+            )
+            .where(
+                IndexAttempt.connector_credential_pair_id.in_(cc_pair_ids),
+                IndexAttempt.targeted_reindex_job_id.is_(None),
+                IndexAttempt.is_synthetic_seed.is_(False),
+            )
+            .distinct(IndexAttempt.connector_credential_pair_id)
+            .order_by(
+                IndexAttempt.connector_credential_pair_id,
+                IndexAttempt.time_created.desc(),
+                IndexAttempt.id.desc(),
+            )
+        )
+    }
+
+
+def _latest_doc_permission_syncs(
+    db_session: Session, cc_pair_ids: list[int]
+) -> dict[int, DocPermissionSyncSnapshot]:
+    if not cc_pair_ids:
+        return {}
+
+    return {
+        cc_pair_id: DocPermissionSyncSnapshot(
+            status=status.value,
+            time_started=time_started,
+            time_finished=time_finished,
+            total_docs_synced=total_docs_synced or 0,
+            docs_with_permission_errors=docs_with_permission_errors or 0,
+        )
+        for (
+            cc_pair_id,
+            status,
+            time_started,
+            time_finished,
+            total_docs_synced,
+            docs_with_permission_errors,
+        ) in db_session.execute(
+            select(
+                DocPermissionSyncAttempt.connector_credential_pair_id,
+                DocPermissionSyncAttempt.status,
+                DocPermissionSyncAttempt.time_started,
+                DocPermissionSyncAttempt.time_finished,
+                DocPermissionSyncAttempt.total_docs_synced,
+                DocPermissionSyncAttempt.docs_with_permission_errors,
+            )
+            .where(
+                DocPermissionSyncAttempt.connector_credential_pair_id.in_(cc_pair_ids)
+            )
+            .distinct(DocPermissionSyncAttempt.connector_credential_pair_id)
+            .order_by(
+                DocPermissionSyncAttempt.connector_credential_pair_id,
+                DocPermissionSyncAttempt.time_created.desc(),
+                DocPermissionSyncAttempt.id.desc(),
+            )
+        )
+    }
+
+
+def _latest_external_group_syncs(
+    db_session: Session, cc_pair_ids: list[int]
+) -> dict[int, ExternalGroupSyncSnapshot]:
+    if not cc_pair_ids:
+        return {}
+
+    return {
+        cc_pair_id: ExternalGroupSyncSnapshot(
+            status=status.value,
+            time_started=time_started,
+            time_finished=time_finished,
+            total_users_processed=total_users_processed or 0,
+            total_groups_processed=total_groups_processed or 0,
+        )
+        for (
+            cc_pair_id,
+            status,
+            time_started,
+            time_finished,
+            total_users_processed,
+            total_groups_processed,
+        ) in db_session.execute(
+            select(
+                ExternalGroupPermissionSyncAttempt.connector_credential_pair_id,
+                ExternalGroupPermissionSyncAttempt.status,
+                ExternalGroupPermissionSyncAttempt.time_started,
+                ExternalGroupPermissionSyncAttempt.time_finished,
+                ExternalGroupPermissionSyncAttempt.total_users_processed,
+                ExternalGroupPermissionSyncAttempt.total_groups_processed,
+            )
+            .where(
+                ExternalGroupPermissionSyncAttempt.connector_credential_pair_id.in_(
+                    cc_pair_ids
+                )
+            )
+            .distinct(ExternalGroupPermissionSyncAttempt.connector_credential_pair_id)
+            .order_by(
+                ExternalGroupPermissionSyncAttempt.connector_credential_pair_id,
+                ExternalGroupPermissionSyncAttempt.time_created.desc(),
+                ExternalGroupPermissionSyncAttempt.id.desc(),
+            )
+        )
+        if cc_pair_id is not None
+    }
+
+
+def _collect_connectors(db_session: Session) -> ConnectorsSection:
+    # DEFAULT_CC_PAIR_ID is the internal user-file/ingestion pair, not a connector
+    # anyone set up, so it's excluded from both the count and the listing.
+    total = db_session.execute(
+        select(func.count())
+        .select_from(ConnectorCredentialPair)
+        .where(ConnectorCredentialPair.id != DEFAULT_CC_PAIR_ID)
+    ).scalar_one()
+
+    rows = db_session.execute(
+        select(
+            ConnectorCredentialPair.id,
+            ConnectorCredentialPair.connector_id,
+            ConnectorCredentialPair.credential_id,
+            ConnectorCredentialPair.status,
+            ConnectorCredentialPair.access_type,
+            ConnectorCredentialPair.auto_sync_options,
+            ConnectorCredentialPair.in_repeated_error_state,
+            ConnectorCredentialPair.total_docs_indexed,
+            Connector.source,
+        )
+        .join(Connector, Connector.id == ConnectorCredentialPair.connector_id)
+        .where(ConnectorCredentialPair.id != DEFAULT_CC_PAIR_ID)
+        .order_by(ConnectorCredentialPair.id)
+        .limit(MAX_CONNECTORS_REPORTED)
+    ).all()
+
+    cc_pair_ids = [row[0] for row in rows]
+    index_attempts = _latest_index_attempts(db_session, cc_pair_ids)
+    permission_syncs = _latest_doc_permission_syncs(db_session, cc_pair_ids)
+    group_syncs = _latest_external_group_syncs(db_session, cc_pair_ids)
+    docs_in_index = {
+        (connector_id, credential_id): count
+        for connector_id, credential_id, count in get_document_counts_for_all_cc_pairs(
+            db_session
+        )
+    }
+
+    items = [
+        ConnectorSnapshot(
+            cc_pair_id=cc_pair_id,
+            source=source.value,
+            access_type=access_type.value,
+            auto_sync_enabled=bool(auto_sync_options),
+            status=status.value,
+            in_repeated_error_state=in_repeated_error_state,
+            docs_in_index=docs_in_index.get((connector_id, credential_id), 0),
+            total_docs_indexed=total_docs_indexed or 0,
+            last_index_attempt=index_attempts.get(cc_pair_id),
+            last_doc_permission_sync=permission_syncs.get(cc_pair_id),
+            last_external_group_sync=group_syncs.get(cc_pair_id),
+        )
+        for (
+            cc_pair_id,
+            connector_id,
+            credential_id,
+            status,
+            access_type,
+            auto_sync_options,
+            in_repeated_error_state,
+            total_docs_indexed,
+            source,
+        ) in rows
+    ]
+
+    return ConnectorsSection(
+        total=total,
+        truncated=total > len(items),
+        items=items,
+    )
+
+
+def _collect_queries(db_session: Session, now: datetime) -> QueriesSection:
+    total, last_24h = db_session.execute(
+        select(
+            func.count(ChatMessage.id),
+            func.count(ChatMessage.id).filter(
+                ChatMessage.time_sent >= now - timedelta(days=1)
+            ),
+        ).where(ChatMessage.message_type == MessageType.USER)
+    ).one()
+
+    return QueriesSection(total=total, last_24h=last_24h)
+
+
+def _collect_feedback(db_session: Session) -> FeedbackSection:
+    counts = {
+        is_positive: count
+        for is_positive, count in db_session.execute(
+            select(ChatMessageFeedback.is_positive, func.count()).group_by(
+                ChatMessageFeedback.is_positive
+            )
+        )
+    }
+
+    return FeedbackSection(
+        positive=counts.get(True, 0),
+        negative=counts.get(False, 0),
+        unrated=counts.get(None, 0),
+    )
+
+
+def build_deployment_snapshot(db_session: Session) -> DeploymentSnapshot:
+    now = datetime.now(timezone.utc)
+    return DeploymentSnapshot(
+        snapshot_at=now,
+        users=_collect_users(db_session),
+        connectors=_collect_connectors(db_session),
+        queries=_collect_queries(db_session, now),
+        feedback=_collect_feedback(db_session),
+    )

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -184,7 +184,7 @@ def get_all_users(
     return db_session.scalars(stmt).unique().all()
 
 
-def _get_accepted_user_where_clause(
+def get_accepted_user_where_clause(
     email_filter_string: str | None = None,
     roles_filter: list[UserRole] = [],
     include_external: bool = False,
@@ -245,7 +245,7 @@ def get_all_accepted_users(
     Uses the same filtering as the paginated endpoint but without
     search, role, or active filters."""
     stmt = select(User)
-    where_clause = _get_accepted_user_where_clause(
+    where_clause = get_accepted_user_where_clause(
         include_external=include_external,
     )
     stmt = stmt.where(*where_clause).order_by(User.email)
@@ -263,7 +263,7 @@ def get_page_of_filtered_users(
 ) -> Sequence[User]:
     users_stmt = select(User)
 
-    where_clause = _get_accepted_user_where_clause(
+    where_clause = get_accepted_user_where_clause(
         email_filter_string=email_filter_string,
         roles_filter=roles_filter,
         include_external=include_external,
@@ -284,7 +284,7 @@ def get_total_filtered_users_count(
     roles_filter: list[UserRole] = [],
     include_external: bool = False,
 ) -> int:
-    where_clause = _get_accepted_user_where_clause(
+    where_clause = get_accepted_user_where_clause(
         email_filter_string=email_filter_string,
         roles_filter=roles_filter,
         include_external=include_external,
@@ -305,7 +305,7 @@ def get_user_counts_by_role_and_status(
     Excludes API key users, anonymous users, and no-auth placeholder users.
     Uses a single query with conditional aggregation.
     """
-    base_where = _get_accepted_user_where_clause()
+    base_where = get_accepted_user_where_clause()
     role_col = User.__table__.c.role
     is_active_col = User.__table__.c.is_active
 

--- a/backend/onyx/utils/telemetry.py
+++ b/backend/onyx/utils/telemetry.py
@@ -48,6 +48,7 @@ class RecordType(str, Enum):
     PERMISSION_SYNC_PROGRESS = "permission_sync_progress"
     PERMISSION_SYNC_COMPLETE = "permission_sync_complete"
     INDEX_ATTEMPT_STATUS = "index_attempt_status"
+    DEPLOYMENT_SNAPSHOT = "deployment_snapshot"
 
 
 def _get_or_generate_customer_id_mt(tenant_id: str) -> str:

--- a/backend/tests/external_dependency_unit/celery/test_deployment_snapshot_telemetry.py
+++ b/backend/tests/external_dependency_unit/celery/test_deployment_snapshot_telemetry.py
@@ -1,0 +1,140 @@
+"""Tests for the daily deployment snapshot telemetry task."""
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+
+from onyx.background.celery.tasks.monitoring.tasks import (
+    _DEPLOYMENT_SNAPSHOT_EMITTED_KEY,
+    emit_deployment_snapshot_telemetry,
+)
+from onyx.redis.redis_pool import get_redis_client
+from onyx.utils.telemetry import RecordType
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+
+_TENANT_ID = POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+
+
+@pytest.fixture(autouse=True)
+def enable_telemetry() -> Generator[None, None, None]:
+    # CI runs with DISABLE_TELEMETRY=true; force the task's gate open so the
+    # snapshot logic under test actually executes
+    with patch(
+        "onyx.background.celery.tasks.monitoring.tasks.DISABLE_TELEMETRY",
+        False,
+    ):
+        yield
+
+
+@pytest.fixture
+def clear_snapshot_marker() -> Generator[None, None, None]:
+    redis_client = get_redis_client(tenant_id=_TENANT_ID)
+    redis_client.delete(_DEPLOYMENT_SNAPSHOT_EMITTED_KEY)
+    try:
+        yield
+    finally:
+        redis_client.delete(_DEPLOYMENT_SNAPSHOT_EMITTED_KEY)
+
+
+@pytest.mark.usefixtures("clear_snapshot_marker")
+def test_emits_snapshot_once_per_day() -> None:
+    with patch(
+        "onyx.background.celery.tasks.monitoring.tasks.optional_telemetry"
+    ) as mock_telemetry:
+        emit_deployment_snapshot_telemetry(tenant_id=_TENANT_ID)
+
+        assert mock_telemetry.call_count == 1
+        kwargs = mock_telemetry.call_args.kwargs
+        assert kwargs["record_type"] == RecordType.DEPLOYMENT_SNAPSHOT
+        assert kwargs["tenant_id"] == _TENANT_ID
+        assert kwargs["blocking"] is True
+        # sections the POC report is built from
+        assert set(kwargs["data"]) == {
+            "snapshot_at",
+            "users",
+            "connectors",
+            "queries",
+            "feedback",
+        }
+
+        emit_deployment_snapshot_telemetry(tenant_id=_TENANT_ID)
+        emit_deployment_snapshot_telemetry(tenant_id=_TENANT_ID)
+        assert mock_telemetry.call_count == 1
+
+
+@pytest.mark.usefixtures("clear_snapshot_marker")
+def test_failed_delivery_releases_marker() -> None:
+    with patch(
+        "onyx.background.celery.tasks.monitoring.tasks.optional_telemetry"
+    ) as mock_telemetry:
+        mock_telemetry.return_value = False
+        emit_deployment_snapshot_telemetry(tenant_id=_TENANT_ID)
+
+        redis_client = get_redis_client(tenant_id=_TENANT_ID)
+        assert not redis_client.exists(_DEPLOYMENT_SNAPSHOT_EMITTED_KEY)
+
+        # next tick retries; a successful send keeps the marker
+        mock_telemetry.return_value = True
+        emit_deployment_snapshot_telemetry(tenant_id=_TENANT_ID)
+        assert mock_telemetry.call_count == 2
+        assert redis_client.exists(_DEPLOYMENT_SNAPSHOT_EMITTED_KEY)
+
+
+@pytest.mark.usefixtures("clear_snapshot_marker")
+def test_snapshot_failure_releases_marker() -> None:
+    """A snapshot that blows up must not silence the rest of the day."""
+    with (
+        patch(
+            "onyx.background.celery.tasks.monitoring.tasks.build_deployment_snapshot",
+            side_effect=RuntimeError("boom"),
+        ),
+        patch(
+            "onyx.background.celery.tasks.monitoring.tasks.optional_telemetry"
+        ) as mock_telemetry,
+    ):
+        emit_deployment_snapshot_telemetry(tenant_id=_TENANT_ID)
+
+    mock_telemetry.assert_not_called()
+    redis_client = get_redis_client(tenant_id=_TENANT_ID)
+    assert not redis_client.exists(_DEPLOYMENT_SNAPSHOT_EMITTED_KEY)
+
+
+@pytest.mark.usefixtures("clear_snapshot_marker")
+def test_marker_has_expiration() -> None:
+    with patch("onyx.background.celery.tasks.monitoring.tasks.optional_telemetry"):
+        emit_deployment_snapshot_telemetry(tenant_id=_TENANT_ID)
+
+    redis_client = get_redis_client(tenant_id=_TENANT_ID)
+    # a marker without a TTL would permanently silence the report
+    ttl = redis_client.ttl(_DEPLOYMENT_SNAPSHOT_EMITTED_KEY)
+    assert 0 < ttl <= 24 * 60 * 60
+
+
+@pytest.mark.usefixtures("clear_snapshot_marker")
+def test_noop_when_telemetry_disabled() -> None:
+    with (
+        patch(
+            "onyx.background.celery.tasks.monitoring.tasks.DISABLE_TELEMETRY",
+            True,
+        ),
+        patch(
+            "onyx.background.celery.tasks.monitoring.tasks.optional_telemetry"
+        ) as mock_telemetry,
+    ):
+        emit_deployment_snapshot_telemetry(tenant_id=_TENANT_ID)
+
+    mock_telemetry.assert_not_called()
+
+
+def test_task_is_scheduled_for_self_hosted_and_cloud() -> None:
+    from onyx.background.celery.tasks.beat_schedule import (
+        beat_task_templates,
+        get_tasks_to_schedule,
+    )
+    from onyx.configs.constants import OnyxCeleryTask
+
+    task_name = OnyxCeleryTask.EMIT_DEPLOYMENT_SNAPSHOT_TELEMETRY
+    assert task_name in {entry["task"] for entry in get_tasks_to_schedule()}
+    # membership in the templates is what fans the task out per cloud tenant
+    assert task_name in {entry["task"] for entry in beat_task_templates}

--- a/backend/tests/external_dependency_unit/db/test_telemetry_snapshot.py
+++ b/backend/tests/external_dependency_unit/db/test_telemetry_snapshot.py
@@ -1,0 +1,261 @@
+"""Tests for the deployment snapshot that backs POC telemetry."""
+
+from collections.abc import Generator
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DEFAULT_CC_PAIR_ID, MessageType
+from onyx.db.enums import (
+    AccessType,
+    ConnectorCredentialPairStatus,
+    IndexingStatus,
+    PermissionSyncStatus,
+)
+from onyx.db.models import (
+    ChatMessage,
+    ChatMessageFeedback,
+    ChatSession,
+    ConnectorCredentialPair,
+    DocPermissionSyncAttempt,
+    ExternalGroupPermissionSyncAttempt,
+    IndexAttempt,
+    User,
+)
+from onyx.db.telemetry_snapshot import (
+    ConnectorSnapshot,
+    DeploymentSnapshot,
+    UserSnapshot,
+    build_deployment_snapshot,
+)
+from tests.external_dependency_unit.conftest import create_test_user
+from tests.external_dependency_unit.indexing_helpers import (
+    cleanup_cc_pair,
+    make_cc_pair,
+    seed_cc_pair_documents,
+)
+
+
+def _find_user(snapshot: DeploymentSnapshot, email: str) -> UserSnapshot:
+    return next(item for item in snapshot.users.items if item.email == email)
+
+
+def _find_connector(snapshot: DeploymentSnapshot, cc_pair_id: int) -> ConnectorSnapshot:
+    return next(
+        item for item in snapshot.connectors.items if item.cc_pair_id == cc_pair_id
+    )
+
+
+@pytest.fixture
+def cc_pair(db_session: Session) -> Generator[ConnectorCredentialPair, None, None]:
+    """A connector that isn't the internal user-file pair, torn down afterwards."""
+    pairs = [make_cc_pair(db_session)]
+    if pairs[0].id == DEFAULT_CC_PAIR_ID:
+        pairs.append(make_cc_pair(db_session))
+    try:
+        yield pairs[-1]
+    finally:
+        db_session.rollback()
+        # cleanup_cc_pair doesn't know about attempt rows, and their FKs block
+        # the cc_pair delete
+        for pair in pairs:
+            for model in (
+                IndexAttempt,
+                DocPermissionSyncAttempt,
+                ExternalGroupPermissionSyncAttempt,
+            ):
+                db_session.query(model).filter(
+                    model.connector_credential_pair_id == pair.id
+                ).delete(synchronize_session="fetch")
+        db_session.commit()
+        for pair in reversed(pairs):
+            cleanup_cc_pair(db_session, pair)
+
+
+@pytest.fixture
+def chatting_user(db_session: Session) -> Generator[User, None, None]:
+    """A user with two queries, one rated up and one rated down."""
+    user = create_test_user(db_session, "snapshot_user")
+    session = ChatSession(id=uuid4(), user_id=user.id, description="snapshot")
+    db_session.add(session)
+    db_session.flush()
+
+    for i in range(2):
+        db_session.add(
+            ChatMessage(
+                chat_session_id=session.id,
+                message=f"query {i}",
+                token_count=1,
+                message_type=MessageType.USER,
+            )
+        )
+    # Feedback hangs off assistant messages, not the queries themselves
+    for is_positive in (True, False):
+        answer = ChatMessage(
+            chat_session_id=session.id,
+            message="answer",
+            token_count=1,
+            message_type=MessageType.ASSISTANT,
+        )
+        db_session.add(answer)
+        db_session.flush()
+        db_session.add(
+            ChatMessageFeedback(chat_message_id=answer.id, is_positive=is_positive)
+        )
+    db_session.commit()
+
+    try:
+        yield user
+    finally:
+        db_session.rollback()
+        db_session.query(ChatMessageFeedback).filter(
+            ChatMessageFeedback.chat_message_id.in_(
+                db_session.query(ChatMessage.id).filter(
+                    ChatMessage.chat_session_id == session.id
+                )
+            )
+        ).delete(synchronize_session="fetch")
+        db_session.query(ChatMessage).filter(
+            ChatMessage.chat_session_id == session.id
+        ).delete(synchronize_session="fetch")
+        db_session.query(ChatSession).filter(ChatSession.id == session.id).delete()
+        db_session.query(User).filter(User.__table__.c.id == user.id).delete()
+        db_session.commit()
+
+
+def test_snapshot_reports_onboarded_users_with_emails(
+    db_session: Session,
+    chatting_user: User,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    snapshot = build_deployment_snapshot(db_session)
+
+    reported = _find_user(snapshot, chatting_user.email)
+    assert reported.user_id == str(chatting_user.id)
+    assert reported.role == chatting_user.role.value
+    assert reported.is_active
+    assert reported.num_queries == 2
+    assert reported.last_query_at is not None
+
+    assert snapshot.users.total >= 1
+    assert snapshot.users.by_role.get(chatting_user.role.value, 0) >= 1
+    assert not snapshot.users.truncated
+
+
+def test_snapshot_counts_queries_and_feedback(
+    db_session: Session,
+    chatting_user: User,  # noqa: ARG001
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    # These counters are deployment-wide and the DB is shared across tests, so
+    # the fixture's rows are a floor rather than the exact expected value.
+    snapshot = build_deployment_snapshot(db_session)
+
+    assert snapshot.queries.total >= 2
+    assert snapshot.queries.last_24h >= 2
+    assert snapshot.feedback.positive >= 1
+    assert snapshot.feedback.negative >= 1
+
+
+def test_snapshot_reports_connector_type_docs_and_sync_status(
+    db_session: Session,
+    cc_pair: ConnectorCredentialPair,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    cc_pair.access_type = AccessType.SYNC
+    cc_pair.auto_sync_options = {"enabled": True}
+    cc_pair.total_docs_indexed = 3
+    db_session.add(
+        IndexAttempt(
+            connector_credential_pair_id=cc_pair.id,
+            from_beginning=True,
+            status=IndexingStatus.SUCCESS,
+            new_docs_indexed=3,
+            total_docs_indexed=3,
+        )
+    )
+    db_session.add(
+        DocPermissionSyncAttempt(
+            connector_credential_pair_id=cc_pair.id,
+            status=PermissionSyncStatus.FAILED,
+            total_docs_synced=1,
+            docs_with_permission_errors=2,
+        )
+    )
+    db_session.add(
+        ExternalGroupPermissionSyncAttempt(
+            connector_credential_pair_id=cc_pair.id,
+            status=PermissionSyncStatus.SUCCESS,
+            total_users_processed=5,
+            total_groups_processed=2,
+        )
+    )
+    seed_cc_pair_documents(db_session, cc_pair, 3, prefix="snapdoc-", unique=True)
+    db_session.commit()
+
+    reported = _find_connector(build_deployment_snapshot(db_session), cc_pair.id)
+
+    assert reported.source == cc_pair.connector.source.value
+    assert reported.access_type == AccessType.SYNC.value
+    assert reported.auto_sync_enabled
+    assert reported.status == ConnectorCredentialPairStatus.ACTIVE.value
+    assert not reported.in_repeated_error_state
+    assert reported.docs_in_index == 3
+    assert reported.total_docs_indexed == 3
+
+    assert reported.last_index_attempt is not None
+    assert reported.last_index_attempt.status == IndexingStatus.SUCCESS.value
+    assert reported.last_index_attempt.new_docs_indexed == 3
+
+    assert reported.last_doc_permission_sync is not None
+    assert reported.last_doc_permission_sync.status == PermissionSyncStatus.FAILED.value
+    assert reported.last_doc_permission_sync.docs_with_permission_errors == 2
+
+    assert reported.last_external_group_sync is not None
+    assert (
+        reported.last_external_group_sync.status == PermissionSyncStatus.SUCCESS.value
+    )
+    assert reported.last_external_group_sync.total_groups_processed == 2
+
+
+def test_snapshot_reports_latest_attempt_per_connector(
+    db_session: Session,
+    cc_pair: ConnectorCredentialPair,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    """A connector that failed after succeeding should read as failed."""
+    for status in (IndexingStatus.SUCCESS, IndexingStatus.FAILED):
+        db_session.add(
+            IndexAttempt(
+                connector_credential_pair_id=cc_pair.id,
+                from_beginning=True,
+                status=status,
+            )
+        )
+        db_session.commit()
+
+    reported = _find_connector(build_deployment_snapshot(db_session), cc_pair.id)
+    assert reported.last_index_attempt is not None
+    assert reported.last_index_attempt.status == IndexingStatus.FAILED.value
+
+
+def test_snapshot_excludes_internal_default_connector(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    snapshot = build_deployment_snapshot(db_session)
+    assert all(
+        item.cc_pair_id != DEFAULT_CC_PAIR_ID for item in snapshot.connectors.items
+    )
+
+
+def test_snapshot_is_json_serializable(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    """The telemetry POST json-encodes the payload, so datetimes must not survive."""
+    import json
+
+    payload = build_deployment_snapshot(db_session).model_dump(mode="json")
+    assert json.loads(json.dumps(payload)) == payload


### PR DESCRIPTION
## Description

Adds a `deployment_snapshot` record to the existing anonymous telemetry system so we can follow how a POC is actually going, for both self-hosted deployments and cloud tenants.

One daily record per deployment/tenant, carrying:

| Signal | Payload |
|---|---|
| Users onboarded | `users.items[]` → `email`, `role`, `is_active`, `created_at`; plus `total` / `active` / `by_role` / `external_permission_users` |
| Connector type + permission mode | `connectors.items[]` → `source`, `access_type` (public/private/sync), `auto_sync_enabled` |
| Doc counts | `docs_in_index` (live count from `document_by_connector_credential_pair`) and `total_docs_indexed` (the connector's own counter) |
| Indexing status | `last_index_attempt` → status, `new_docs_indexed`, `total_docs_indexed`, timings |
| Perm sync / group sync status | `last_doc_permission_sync`, `last_external_group_sync` → status + counts |
| Queries | `queries.total`, `queries.last_24h`, and `num_queries` / `last_query_at` per user |
| Feedback | `feedback.positive` / `negative` / `unrated` |

**Implementation**

- `backend/onyx/db/telemetry_snapshot.py` — builds the payload. Latest-attempt-per-connector lookups use single `DISTINCT ON` passes rather than an N+1 over cc_pairs; doc counts reuse the existing `get_document_counts_for_all_cc_pairs` grouped query.
- `emit_deployment_snapshot_telemetry` in `monitoring/tasks.py` — follows the existing version-heartbeat pattern: hourly beat tick with a 24h-TTL Redis marker enforcing the daily cadence, marker released on failure (delivery *or* snapshot build) so the next tick retries.
- Registered in `beat_task_templates` rather than the self-hosted-only list, so cloud fans it out per tenant. `skip_gated: False`, since POCs are exactly the tenants most likely to be gated.
- `get_accepted_user_where_clause` in `db/users.py` made public instead of duplicating the "real user" definition (excludes API-key dummies, anonymous, no-auth placeholder, ext-perm users).

**Deliberate choices worth reviewing**

- **This record is not anonymous.** Exact emails were the ask, but it means this payload is PII inside a system named "anonymous telemetry", and self-hosted admins have no control finer than `DISABLE_TELEMETRY`. If we want a separate opt-in flag gating just this record type, that's an easy follow-up — flagging it rather than deciding it.
- **No error message text.** Existing `INDEX_ATTEMPT_STATUS` records send status only, never `error_msg`, and connector error strings routinely carry URLs and credential fragments. This follows that precedent: statuses plus error *counts*.
- **Payloads are capped** at 1000 users / 500 connectors with `truncated` flags, so a large self-hosted install can't blow up a single POST. POCs sit far below both.

**Follow-up needed outside this repo:** `telemetry.onyx.app` needs a handler for the new `deployment_snapshot` record type before any of this is queryable.

## How Has This Been Tested?

External dependency unit tests against real Postgres — 12 new tests, all passing:

- `tests/external_dependency_unit/db/test_telemetry_snapshot.py` — asserts emails/roles/per-user query counts, connector source + permission mode + doc counts, indexing/perm-sync/group-sync statuses, latest-attempt-wins (success followed by failure reads as failed), exclusion of the internal `DEFAULT_CC_PAIR_ID` pair, and that the payload survives a JSON round-trip.
- `tests/external_dependency_unit/celery/test_deployment_snapshot_telemetry.py` — daily cadence, marker released on failed delivery, marker released when the snapshot build raises, marker TTL, no-op when telemetry is disabled, and that the task is scheduled for both self-hosted and cloud.

Also dumped a fully-populated payload against a seeded database and eyeballed it end to end. `pre-commit` (ty, ruff, format) clean on all touched files.

Note: 11 failures in `test_reindex_port.py` / `test_port_flow_e2e.py` pre-exist on `main` — confirmed by stashing this branch's changes and reproducing the identical set.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a daily `deployment_snapshot` telemetry record to track POC progress across self-hosted deployments and cloud tenants. Reports users, connector health, query volume, and feedback in one per-tenant daily payload.

- **New Features**
  - New record type `deployment_snapshot` with:
    - Users: `email`, `role`, `is_active`, `created_at`, per-user `num_queries` and `last_query_at`; plus totals and `by_role`
    - Connectors: `source`, `access_type` (public/private/sync), `auto_sync_enabled`, `docs_in_index`, `total_docs_indexed`, latest indexing/perm-sync/group-sync statuses
    - Usage: `queries.total` and `queries.last_24h`
    - Feedback: `positive`, `negative`, `unrated`
  - Emitted by `emit_deployment_snapshot_telemetry`; hourly schedule with a 24h Redis marker enforces once-per-day and retries on failure; runs for self-hosted and per-tenant in cloud (`skip_gated: False`).
  - Payload caps: up to 1000 users and 500 connectors with `truncated` flags; excludes internal `DEFAULT_CC_PAIR_ID`; sends statuses and counts only (no error text).
  - Non-anonymous by design (includes emails). Use `DISABLE_TELEMETRY` to opt out.
  - Adds `RecordType.DEPLOYMENT_SNAPSHOT`; `telemetry.onyx.app` needs a handler for this type.

- **Refactors**
  - Made `get_accepted_user_where_clause` public to reuse the accepted user filter.

<sup>Written for commit adddf6d05b73c5f386da6293bc5387dc38485355. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

