### PR TITLE
feat(connector-stability): implement source operations framework

### DIFF
--- a/backend/onyx/connectors/source_operations.py
+++ b/backend/onyx/connectors/source_operations.py
@@ -1,21 +1,19 @@
 """Source operations: the per-connector gateway for all remote source calls.
 
-Validation that is written as parallel probe code duplicates the connector's
-API calls and drifts as the connector evolves. The source operations layer
-makes that drift structurally hard: each migrated connector has one
-conspicuous gateway class (``backend/onyx/connectors/<source>/
-source_operations.py``) subclassing ``SourceOperations``, and every remote
-interaction with the source is a method on it. Connector indexing code, EE
-perm-sync code, and capability checks all call these methods and nothing else
-makes source API calls.
+Validation that is written as parallel probe code duplicates the connector's API
+calls and drifts as the connector evolves. The source operations layer makes
+that drift structurally hard: each migrated connector has one conspicuous
+gateway class (``backend/onyx/connectors/<source>/ source_operations.py``)
+subclassing ``SourceOperations``, and every remote interaction with the source
+is a method on it. Connector indexing code, EE perm-sync code, and capability
+checks all call these methods and nothing else makes source API calls.
 
 Every public method on a gateway must be classified via the
 ``@source_operation`` decorator; ``__init_subclass__`` raises at import time
-otherwise, so adding an unclassified source call to a gateway is impossible
-rather than just discouraged. Operations return plain data (dicts/models),
-never live SDK objects: lazy-loading libraries (PyGithub attribute access,
-office365 fluent chains) can fire requests outside any wrapper, and returning
-plain data is what makes the gateway boundary real.
+otherwise. Operations return plain data (dicts/models), never live SDK objects:
+lazy-loading libraries (PyGithub attribute access, office365 fluent chains) can
+fire requests outside any wrapper, and returning plain data is what makes the
+gateway boundary real.
 """
 
 from abc import ABC
@@ -38,8 +36,8 @@ class OperationConsumes(str, Enum):
     """What an operation needs in order to run.
 
     Capability checks composing an operation derive their skip semantics from
-    this: config-consuming operations cannot run on config-less
-    credential-time report runs.
+    this: config-consuming operations cannot run on config-less credential-time
+    report runs.
     """
 
     CREDENTIAL = "credential"
@@ -56,18 +54,18 @@ class SourceOperationSpec(BaseModel):
     name: str
     capabilities: frozenset[CredentialCapability]
     # Named forms of the operation where a parameter changes the required
-    # permission (e.g. Slack ``conversations.list`` public vs private).
-    # Coverage is counted per (operation, variant); empty means the operation
-    # itself is the single coverage unit.
+    # permission (e.g. Slack ``conversations.list`` public vs private). Coverage
+    # is counted per (operation, variant); empty means the operation itself is
+    # the single coverage unit.
     variants: tuple[str, ...] = ()
     consumes: OperationConsumes
-    # Exempts the operation (all variants) from the check-coverage
-    # requirement. The reason string is mandatory and reviewable: side effects
-    # (e.g. ``conversations.join``), graceful production degradation, or "not
-    # yet tested" during incremental migration. To exempt a single variant,
-    # split it into its own operation and annotate the split-off half: a
-    # variant that permanently cannot be probed while its sibling can is a
-    # different operation.
+    # Exempts the operation (all variants) from the check-coverage requirement.
+    # The reason string is mandatory and reviewable: e.g. side effects (e.g.
+    # ``conversations.join``), graceful production degradation, or "not yet
+    # tested" during incremental migration. To exempt a single variant, split it
+    # into its own operation and annotate the split-off half: a variant that
+    # permanently cannot be probed while its sibling can is a different
+    # operation.
     untested: str | None = None
 
 
@@ -98,8 +96,8 @@ def source_operation(
             func,
             _SPEC_ATTR,
             SourceOperationSpec(
-                # The cast is safe for anything that ultimately registers:
-                # the class-level scan rejects everything but plain functions.
+                # The cast is safe for anything that ultimately registers: the
+                # class-level scan rejects everything but plain functions.
                 name=cast(FunctionType, func).__name__,
                 capabilities=frozenset(capabilities),
                 variants=tuple(variant_list),
@@ -127,9 +125,9 @@ class SourceOperations(ABC):
       helpers.
     - Set ``source`` to the ``DocumentSource`` the gateway serves; one gateway
       per source.
-    - Every public method must be classified with ``@source_operation``.
-      Helpers (including any staticmethod/classmethod/property) stay private;
-      data models live at module level.
+    - Every public method must be classified with ``@source_operation``. Helpers
+      (including any staticmethod/classmethod/property) stay private; data
+      models live at module level.
 
     The gateway owns client construction from the credential plus optional
     connector config; operations return plain data, never live SDK objects.
@@ -151,7 +149,9 @@ class SourceOperations(ABC):
                 "helpers."
             )
 
-        source = getattr(cls, "source", None)
+        # Read the subclass's own namespace, like the method scan below: the
+        # flat-base rule means there is nowhere else a value could come from.
+        source = vars(cls).get("source")
         if not isinstance(source, DocumentSource):
             raise TypeError(f"{cls.__name__} must set ``source`` to a DocumentSource.")
         registered = _SOURCE_OPERATIONS_BY_SOURCE.get(source)

--- a/backend/onyx/connectors/source_operations.py
+++ b/backend/onyx/connectors/source_operations.py
@@ -1,0 +1,190 @@
+"""Source operations: the per-connector gateway for all remote source calls.
+
+Validation that is written as parallel probe code duplicates the connector's
+API calls and drifts as the connector evolves. The source operations layer
+makes that drift structurally hard: each migrated connector has one
+conspicuous gateway class (``backend/onyx/connectors/<source>/
+source_operations.py``) subclassing ``SourceOperations``, and every remote
+interaction with the source is a method on it. Connector indexing code, EE
+perm-sync code, and capability checks all call these methods and nothing else
+makes source API calls.
+
+Every public method on a gateway must be classified via the
+``@source_operation`` decorator; ``__init_subclass__`` raises at import time
+otherwise, so adding an unclassified source call to a gateway is impossible
+rather than just discouraged. Operations return plain data (dicts/models),
+never live SDK objects: lazy-loading libraries (PyGithub attribute access,
+office365 fluent chains) can fire requests outside any wrapper, and returning
+plain data is what makes the gateway boundary real.
+"""
+
+from abc import ABC
+from collections.abc import Callable, Collection, Mapping
+from enum import Enum
+from types import FunctionType, MappingProxyType
+from typing import Any, ClassVar, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.capability_checks.models import CredentialCapability
+
+_SPEC_ATTR = "__source_operation_spec__"
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+
+class OperationConsumes(str, Enum):
+    """What an operation needs in order to run.
+
+    Capability checks composing an operation derive their skip semantics from
+    this: config-consuming operations cannot run on config-less
+    credential-time report runs.
+    """
+
+    CREDENTIAL = "credential"
+    CONFIG = "config"
+    BOTH = "both"
+    NEITHER = "neither"
+
+
+class SourceOperationSpec(BaseModel):
+    """Metadata stamped on one gateway method by ``@source_operation``."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    capabilities: frozenset[CredentialCapability]
+    # Named forms of the operation where a parameter changes the required
+    # permission (e.g. Slack ``conversations.list`` public vs private).
+    # Coverage is counted per (operation, variant); empty means the operation
+    # itself is the single coverage unit.
+    variants: tuple[str, ...] = ()
+    consumes: OperationConsumes
+    # Exempts the operation (all variants) from the check-coverage
+    # requirement. The reason string is mandatory and reviewable: side effects
+    # (e.g. ``conversations.join``), graceful production degradation, or "not
+    # yet tested" during incremental migration.
+    untested: str | None = None
+
+
+def source_operation(
+    *,
+    capabilities: Collection[CredentialCapability],
+    consumes: OperationConsumes,
+    variants: Collection[str] = (),
+    untested: str | None = None,
+) -> Callable[[_F], _F]:
+    """Classifies one gateway method as a source operation.
+
+    Raises at decoration (import) time for malformed metadata, so a bad
+    classification can never register.
+    """
+    if not capabilities:
+        raise ValueError("A source operation must serve at least one capability.")
+    variant_list = list(variants)
+    if len(set(variant_list)) != len(variant_list):
+        raise ValueError(f"Duplicate variants: {variant_list}.")
+    if any(not variant for variant in variant_list):
+        raise ValueError("Variant names must be non-empty.")
+    if untested is not None and not untested.strip():
+        raise ValueError("An untested exemption requires a non-empty reason string.")
+
+    def stamp(func: _F) -> _F:
+        setattr(
+            func,
+            _SPEC_ATTR,
+            SourceOperationSpec(
+                # Only plain functions are stampable (the base class rejects
+                # staticmethod/classmethod/property), so the cast is safe.
+                name=cast(FunctionType, func).__name__,
+                capabilities=frozenset(capabilities),
+                variants=tuple(variant_list),
+                consumes=consumes,
+                untested=untested,
+            ),
+        )
+        return func
+
+    return stamp
+
+
+# Internal: use ``monkeypatch.setattr(module, "_SOURCE_OPERATIONS_BY_SOURCE",
+# {})`` to isolate in tests.
+_SOURCE_OPERATIONS_BY_SOURCE: dict[DocumentSource, type["SourceOperations"]] = {}
+
+
+class SourceOperations(ABC):
+    """Base class for per-connector source-operation gateways.
+
+    Subclass contract, enforced at import time:
+    - Set ``source`` to the ``DocumentSource`` the gateway serves; one gateway
+      per source.
+    - Every public method must be classified with ``@source_operation``.
+      Helpers (including any staticmethod/classmethod/property) stay private.
+
+    The gateway owns client construction from the credential plus optional
+    connector config; operations return plain data, never live SDK objects.
+    """
+
+    source: ClassVar[DocumentSource]
+
+    _operation_specs: ClassVar[Mapping[str, SourceOperationSpec]]
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+
+        source = getattr(cls, "source", None)
+        if not isinstance(source, DocumentSource):
+            raise TypeError(f"{cls.__name__} must set ``source`` to a DocumentSource.")
+        registered = _SOURCE_OPERATIONS_BY_SOURCE.get(source)
+        if registered is not None:
+            raise TypeError(
+                f"{cls.__name__} cannot register {source.value}: already "
+                f"registered by {registered.__name__}. One gateway per source."
+            )
+
+        specs: dict[str, SourceOperationSpec] = {}
+        unstamped: list[str] = []
+        for name, member in vars(cls).items():
+            if name.startswith("_"):
+                continue
+            if isinstance(member, (staticmethod, classmethod, property)):
+                raise TypeError(
+                    f"{cls.__name__}.{name}: public staticmethod/classmethod/"
+                    "property is not allowed on a gateway; make it private or "
+                    "expose it as a stamped instance method."
+                )
+            if not callable(member):
+                continue
+            spec = getattr(member, _SPEC_ATTR, None)
+            if spec is None:
+                unstamped.append(name)
+            else:
+                specs[name] = spec
+        if unstamped:
+            raise TypeError(
+                f"{cls.__name__} has unclassified public methods: "
+                f"{unstamped}. Stamp them with @source_operation or make "
+                "them private."
+            )
+
+        cls._operation_specs = MappingProxyType(specs)
+        _SOURCE_OPERATIONS_BY_SOURCE[source] = cls
+
+    @classmethod
+    def operation_specs(cls) -> Mapping[str, SourceOperationSpec]:
+        """Returns the specs of the operations defined on this gateway."""
+        return cls._operation_specs
+
+
+def get_source_operations_class(
+    source: DocumentSource,
+) -> type[SourceOperations] | None:
+    """Returns the registered gateway class for a source, if one exists."""
+    return _SOURCE_OPERATIONS_BY_SOURCE.get(source)
+
+
+def registered_source_operations() -> Mapping[DocumentSource, type[SourceOperations]]:
+    """Returns all registered gateways, for auto-discovering harnesses."""
+    return MappingProxyType(_SOURCE_OPERATIONS_BY_SOURCE)

--- a/backend/onyx/connectors/source_operations.py
+++ b/backend/onyx/connectors/source_operations.py
@@ -16,6 +16,7 @@ fire requests outside any wrapper, and returning plain data is what makes the
 gateway boundary real.
 """
 
+import inspect
 from abc import ABC
 from collections.abc import Callable, Collection, Mapping
 from enum import Enum
@@ -81,7 +82,10 @@ def source_operation(
     Raises at decoration (import) time for malformed metadata, so a bad
     classification can never register.
     """
-    if not capabilities:
+    # Snapshot before validating so a caller-held collection mutated after this
+    # factory returns cannot bypass the checks below.
+    capability_set = frozenset(capabilities)
+    if not capability_set:
         raise ValueError("A source operation must serve at least one capability.")
     variant_list = list(variants)
     if len(set(variant_list)) != len(variant_list):
@@ -99,7 +103,7 @@ def source_operation(
                 # The cast is safe for anything that ultimately registers: the
                 # class-level scan rejects everything but plain functions.
                 name=cast(FunctionType, func).__name__,
-                capabilities=frozenset(capabilities),
+                capabilities=capability_set,
                 variants=tuple(variant_list),
                 consumes=consumes,
                 untested=untested,
@@ -176,6 +180,17 @@ class SourceOperations(ABC):
                     f"{cls.__name__}.{name}: public staticmethod/classmethod/"
                     "property is not allowed on a gateway; make it private or "
                     "expose it as a stamped instance method."
+                )
+            # Other descriptors (``cached_property``, custom ``__get__``) are
+            # not callable, so they would otherwise pass as data attributes --
+            # yet they execute on attribute access, the exact lazy-call hazard
+            # the gateway exists to contain. Plain functions also carry
+            # ``__get__`` (method binding), hence the exclusion.
+            if not inspect.isfunction(member) and hasattr(member, "__get__"):
+                raise TypeError(
+                    f"{cls.__name__}.{name}: public descriptor is not allowed "
+                    "on a gateway; make it private or expose it as a stamped "
+                    "instance method."
                 )
             if not callable(member):
                 continue

--- a/backend/onyx/connectors/source_operations.py
+++ b/backend/onyx/connectors/source_operations.py
@@ -64,7 +64,10 @@ class SourceOperationSpec(BaseModel):
     # Exempts the operation (all variants) from the check-coverage
     # requirement. The reason string is mandatory and reviewable: side effects
     # (e.g. ``conversations.join``), graceful production degradation, or "not
-    # yet tested" during incremental migration.
+    # yet tested" during incremental migration. To exempt a single variant,
+    # split it into its own operation and annotate the split-off half: a
+    # variant that permanently cannot be probed while its sibling can is a
+    # different operation.
     untested: str | None = None
 
 
@@ -95,8 +98,8 @@ def source_operation(
             func,
             _SPEC_ATTR,
             SourceOperationSpec(
-                # Only plain functions are stampable (the base class rejects
-                # staticmethod/classmethod/property), so the cast is safe.
+                # The cast is safe for anything that ultimately registers:
+                # the class-level scan rejects everything but plain functions.
                 name=cast(FunctionType, func).__name__,
                 capabilities=frozenset(capabilities),
                 variants=tuple(variant_list),
@@ -118,10 +121,15 @@ class SourceOperations(ABC):
     """Base class for per-connector source-operation gateways.
 
     Subclass contract, enforced at import time:
+    - Subclass ``SourceOperations`` directly and nothing else: no mixins and
+      no gateway inheritance, since inherited members would bypass the
+      own-namespace scan below. Shared logic goes in private module-level
+      helpers.
     - Set ``source`` to the ``DocumentSource`` the gateway serves; one gateway
       per source.
     - Every public method must be classified with ``@source_operation``.
-      Helpers (including any staticmethod/classmethod/property) stay private.
+      Helpers (including any staticmethod/classmethod/property) stay private;
+      data models live at module level.
 
     The gateway owns client construction from the credential plus optional
     connector config; operations return plain data, never live SDK objects.
@@ -129,10 +137,19 @@ class SourceOperations(ABC):
 
     source: ClassVar[DocumentSource]
 
-    _operation_specs: ClassVar[Mapping[str, SourceOperationSpec]]
+    _operation_specs: ClassVar[Mapping[str, SourceOperationSpec]] = MappingProxyType({})
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
+
+        if cls.__bases__ != (SourceOperations,):
+            raise TypeError(
+                f"{cls.__name__} must subclass SourceOperations directly and "
+                "nothing else: mixins and gateway inheritance would bypass "
+                "the import-time enforcement, which scans only the class's "
+                "own namespace. Put shared logic in private module-level "
+                "helpers."
+            )
 
         source = getattr(cls, "source", None)
         if not isinstance(source, DocumentSource):
@@ -149,6 +166,11 @@ class SourceOperations(ABC):
         for name, member in vars(cls).items():
             if name.startswith("_"):
                 continue
+            if isinstance(member, type):
+                raise TypeError(
+                    f"{cls.__name__}.{name}: public nested class is not "
+                    "allowed on a gateway; define data models at module level."
+                )
             if isinstance(member, (staticmethod, classmethod, property)):
                 raise TypeError(
                     f"{cls.__name__}.{name}: public staticmethod/classmethod/"
@@ -160,6 +182,12 @@ class SourceOperations(ABC):
             spec = getattr(member, _SPEC_ATTR, None)
             if spec is None:
                 unstamped.append(name)
+            elif spec.name != name:
+                raise TypeError(
+                    f"{cls.__name__}.{name} is an aliased assignment of the "
+                    f"operation stamped as {spec.name!r}; define it as a "
+                    "plain method under its own name."
+                )
             else:
                 specs[name] = spec
         if unstamped:

--- a/backend/tests/unit/onyx/connectors/test_source_operations.py
+++ b/backend/tests/unit/onyx/connectors/test_source_operations.py
@@ -56,7 +56,9 @@ def test_gateway_registers_and_collects_specs() -> None:
 
 @pytest.mark.usefixtures("isolated_registry")
 def test_unstamped_public_method_fails_at_import() -> None:
-    """Verifies the forcing function: unclassified public methods cannot exist."""
+    """
+    Verifies the forcing function: unclassified public methods cannot exist.
+    """
     # Under test and postcondition.
     with pytest.raises(TypeError, match="unclassified public methods.*fetch_page"):
 

--- a/backend/tests/unit/onyx/connectors/test_source_operations.py
+++ b/backend/tests/unit/onyx/connectors/test_source_operations.py
@@ -88,6 +88,42 @@ def test_non_document_source_fails_at_import() -> None:
 
 
 @pytest.mark.usefixtures("isolated_registry")
+def test_mixin_bases_are_rejected() -> None:
+    """
+    Verifies mixins cannot smuggle unscanned public methods past enforcement.
+    """
+
+    # Precondition.
+    class _PaginationMixin:
+        def fetch_all_pages(self) -> None:
+            return None
+
+    # Under test and postcondition.
+    with pytest.raises(TypeError, match="directly and nothing else"):
+
+        class _MixedOperations(_PaginationMixin, SourceOperations):
+            source = DocumentSource.SLACK
+
+
+@pytest.mark.usefixtures("isolated_registry")
+def test_gateway_inheritance_is_rejected() -> None:
+    """
+    Verifies a gateway cannot be subclassed: inherited operations would be
+    invisible to ``operation_specs`` and silently under-counted by coverage.
+    """
+
+    # Precondition.
+    class _SlackOperations(SourceOperations):
+        source = DocumentSource.SLACK
+
+    # Under test and postcondition.
+    with pytest.raises(TypeError, match="directly and nothing else"):
+
+        class _SlackCloudOperations(_SlackOperations):
+            source = DocumentSource.GITHUB
+
+
+@pytest.mark.usefixtures("isolated_registry")
 def test_duplicate_source_registration_fails() -> None:
     """Verifies the one-gateway-per-source rule."""
 
@@ -150,6 +186,60 @@ def test_public_property_is_rejected() -> None:
                 return ""
 
 
+@pytest.mark.usefixtures("isolated_registry")
+def test_public_classmethod_is_rejected() -> None:
+    """Verifies classmethods cannot bypass classification either."""
+    # Under test and postcondition.
+    with pytest.raises(TypeError, match="make it private"):
+
+        class _ClassmethodOperations(SourceOperations):
+            source = DocumentSource.SLACK
+
+            @classmethod
+            def build_client(cls) -> None:
+                return None
+
+
+@pytest.mark.usefixtures("isolated_registry")
+def test_public_nested_class_is_rejected() -> None:
+    """Verifies nested classes get their own accurate rejection message."""
+    # Under test and postcondition.
+    with pytest.raises(TypeError, match="define data models at module level"):
+
+        class _NestedModelOperations(SourceOperations):
+            source = DocumentSource.SLACK
+
+            class Channel:
+                pass
+
+
+@pytest.mark.usefixtures("isolated_registry")
+def test_aliased_operation_assignment_is_rejected() -> None:
+    """Verifies a stamped operation cannot register under a different name."""
+
+    # Precondition.
+    def _shared_impl(_self: SourceOperations) -> None:
+        return None
+
+    stamped = source_operation(
+        capabilities={CredentialCapability.INDEXING},
+        consumes=OperationConsumes.CREDENTIAL,
+    )(_shared_impl)
+
+    # Under test and postcondition.
+    with pytest.raises(TypeError, match="aliased assignment"):
+
+        class _AliasedOperations(SourceOperations):
+            source = DocumentSource.SLACK
+            list_a = stamped
+
+
+def test_base_operation_specs_is_empty() -> None:
+    """Verifies the accessor is total on the base class itself."""
+    # Under test and postcondition.
+    assert SourceOperations.operation_specs() == {}
+
+
 def test_decorator_rejects_empty_capabilities() -> None:
     """Verifies an operation must serve at least one capability."""
     # Under test and postcondition.
@@ -176,4 +266,15 @@ def test_decorator_rejects_duplicate_variants() -> None:
             capabilities={CredentialCapability.INDEXING},
             consumes=OperationConsumes.CREDENTIAL,
             variants=("public", "public"),
+        )
+
+
+def test_decorator_rejects_blank_variant_names() -> None:
+    """Verifies variant names must be non-empty."""
+    # Under test and postcondition.
+    with pytest.raises(ValueError, match="Variant names must be non-empty"):
+        source_operation(
+            capabilities={CredentialCapability.INDEXING},
+            consumes=OperationConsumes.CREDENTIAL,
+            variants=("public", ""),
         )

--- a/backend/tests/unit/onyx/connectors/test_source_operations.py
+++ b/backend/tests/unit/onyx/connectors/test_source_operations.py
@@ -1,3 +1,5 @@
+from functools import cached_property
+
 import pytest
 
 from onyx.configs.constants import DocumentSource
@@ -189,6 +191,24 @@ def test_public_property_is_rejected() -> None:
 
 
 @pytest.mark.usefixtures("isolated_registry")
+def test_public_non_callable_descriptor_is_rejected() -> None:
+    """
+    Verifies descriptors like ``cached_property`` cannot pass as data
+    attributes: they execute on attribute access, the lazy-call hazard the
+    gateway exists to contain.
+    """
+    # Under test and postcondition.
+    with pytest.raises(TypeError, match="public descriptor"):
+
+        class _CachedPropertyOperations(SourceOperations):
+            source = DocumentSource.SLACK
+
+            @cached_property
+            def team_id(self) -> str:
+                return ""
+
+
+@pytest.mark.usefixtures("isolated_registry")
 def test_public_classmethod_is_rejected() -> None:
     """Verifies classmethods cannot bypass classification either."""
     # Under test and postcondition.
@@ -247,6 +267,33 @@ def test_decorator_rejects_empty_capabilities() -> None:
     # Under test and postcondition.
     with pytest.raises(ValueError, match="at least one capability"):
         source_operation(capabilities=set(), consumes=OperationConsumes.CREDENTIAL)
+
+
+@pytest.mark.usefixtures("isolated_registry")
+def test_decorator_snapshots_capabilities_at_factory_time() -> None:
+    """
+    Verifies the capability set is snapped and validated atomically: mutating
+    the caller's collection after the factory call changes nothing.
+    """
+    # Precondition.
+    capabilities = {CredentialCapability.INDEXING}
+    decorator = source_operation(
+        capabilities=capabilities, consumes=OperationConsumes.CREDENTIAL
+    )
+    capabilities.clear()
+
+    # Under test.
+    class _SnapshotOperations(SourceOperations):
+        source = DocumentSource.SLACK
+
+        @decorator
+        def probe(self) -> None:
+            return None
+
+    # Postcondition.
+    assert _SnapshotOperations.operation_specs()["probe"].capabilities == {
+        CredentialCapability.INDEXING
+    }
 
 
 def test_decorator_rejects_blank_untested_reason() -> None:

--- a/backend/tests/unit/onyx/connectors/test_source_operations.py
+++ b/backend/tests/unit/onyx/connectors/test_source_operations.py
@@ -1,0 +1,179 @@
+import pytest
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors import source_operations as source_operations_module
+from onyx.connectors.capability_checks.models import CredentialCapability
+from onyx.connectors.source_operations import (
+    OperationConsumes,
+    SourceOperations,
+    get_source_operations_class,
+    registered_source_operations,
+    source_operation,
+)
+
+
+@pytest.fixture
+def isolated_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolates the gateway registry so test classes never leak globally."""
+    monkeypatch.setattr(source_operations_module, "_SOURCE_OPERATIONS_BY_SOURCE", {})
+
+
+@pytest.mark.usefixtures("isolated_registry")
+def test_gateway_registers_and_collects_specs() -> None:
+    """Verifies stamped methods register with their metadata intact."""
+
+    # Precondition and under test (registration fires at class creation).
+    class _SlackOperations(SourceOperations):
+        source = DocumentSource.SLACK
+
+        @source_operation(
+            capabilities={CredentialCapability.INDEXING},
+            consumes=OperationConsumes.CREDENTIAL,
+            variants=("public", "private"),
+        )
+        def list_channels(self, _private: bool) -> list[str]:
+            return []
+
+        @source_operation(
+            capabilities={CredentialCapability.EXTERNAL_GROUP_SYNC},
+            consumes=OperationConsumes.NEITHER,
+            untested="Dormant by design.",
+        )
+        def list_usergroups(self) -> list[str]:
+            return []
+
+    # Postcondition.
+    assert get_source_operations_class(DocumentSource.SLACK) is _SlackOperations
+    assert registered_source_operations() == {DocumentSource.SLACK: _SlackOperations}
+    specs = _SlackOperations.operation_specs()
+    assert set(specs) == {"list_channels", "list_usergroups"}
+    assert specs["list_channels"].capabilities == {CredentialCapability.INDEXING}
+    assert specs["list_channels"].variants == ("public", "private")
+    assert specs["list_channels"].consumes == OperationConsumes.CREDENTIAL
+    assert specs["list_channels"].untested is None
+    assert specs["list_usergroups"].untested == "Dormant by design."
+
+
+@pytest.mark.usefixtures("isolated_registry")
+def test_unstamped_public_method_fails_at_import() -> None:
+    """Verifies the forcing function: unclassified public methods cannot exist."""
+    # Under test and postcondition.
+    with pytest.raises(TypeError, match="unclassified public methods.*fetch_page"):
+
+        class _LeakyOperations(SourceOperations):
+            source = DocumentSource.SLACK
+
+            def fetch_page(self) -> None:
+                return None
+
+
+@pytest.mark.usefixtures("isolated_registry")
+def test_missing_source_fails_at_import() -> None:
+    """Verifies a gateway must declare which source it serves."""
+    # Under test and postcondition.
+    with pytest.raises(TypeError, match="must set ``source``"):
+
+        class _SourcelessOperations(SourceOperations):
+            pass
+
+
+@pytest.mark.usefixtures("isolated_registry")
+def test_non_document_source_fails_at_import() -> None:
+    """Verifies ``source`` must be a DocumentSource, not a lookalike string."""
+    # Under test and postcondition.
+    with pytest.raises(TypeError, match="must set ``source``"):
+
+        class _StringSourceOperations(SourceOperations):
+            source = "slack"  # type: ignore[assignment]
+
+
+@pytest.mark.usefixtures("isolated_registry")
+def test_duplicate_source_registration_fails() -> None:
+    """Verifies the one-gateway-per-source rule."""
+
+    # Precondition.
+    class _FirstOperations(SourceOperations):
+        source = DocumentSource.SLACK
+
+    # Under test and postcondition.
+    with pytest.raises(TypeError, match="already registered by _FirstOperations"):
+
+        class _SecondOperations(SourceOperations):
+            source = DocumentSource.SLACK
+
+
+@pytest.mark.usefixtures("isolated_registry")
+def test_private_helpers_and_data_attrs_are_allowed() -> None:
+    """Verifies enforcement only targets public methods."""
+
+    # Under test.
+    class _TidyOperations(SourceOperations):
+        source = DocumentSource.SLACK
+        docs_link = "https://docs.onyx.app/connectors/slack"
+
+        def _build_client(self) -> None:
+            return None
+
+        @staticmethod
+        def _parse_page(page: dict) -> dict:
+            return page
+
+    # Postcondition.
+    assert _TidyOperations.operation_specs() == {}
+
+
+@pytest.mark.usefixtures("isolated_registry")
+def test_public_staticmethod_is_rejected() -> None:
+    """Verifies public non-instance-method callables cannot slip through."""
+    # Under test and postcondition.
+    with pytest.raises(TypeError, match="make it private"):
+
+        class _StaticOperations(SourceOperations):
+            source = DocumentSource.SLACK
+
+            @staticmethod
+            def build_client() -> None:
+                return None
+
+
+@pytest.mark.usefixtures("isolated_registry")
+def test_public_property_is_rejected() -> None:
+    """Verifies properties cannot bypass classification either."""
+    # Under test and postcondition.
+    with pytest.raises(TypeError, match="make it private"):
+
+        class _PropertyOperations(SourceOperations):
+            source = DocumentSource.SLACK
+
+            @property
+            def team_id(self) -> str:
+                return ""
+
+
+def test_decorator_rejects_empty_capabilities() -> None:
+    """Verifies an operation must serve at least one capability."""
+    # Under test and postcondition.
+    with pytest.raises(ValueError, match="at least one capability"):
+        source_operation(capabilities=set(), consumes=OperationConsumes.CREDENTIAL)
+
+
+def test_decorator_rejects_blank_untested_reason() -> None:
+    """Verifies the untested exemption cannot be claimed without a reason."""
+    # Under test and postcondition.
+    with pytest.raises(ValueError, match="non-empty reason"):
+        source_operation(
+            capabilities={CredentialCapability.INDEXING},
+            consumes=OperationConsumes.CREDENTIAL,
+            untested="   ",
+        )
+
+
+def test_decorator_rejects_duplicate_variants() -> None:
+    """Verifies variant names must be unique."""
+    # Under test and postcondition.
+    with pytest.raises(ValueError, match="Duplicate variants"):
+        source_operation(
+            capabilities={CredentialCapability.INDEXING},
+            consumes=OperationConsumes.CREDENTIAL,
+            variants=("public", "public"),
+        )


### PR DESCRIPTION
## Description

Framework layer for per-connector source-operation gateways: one conspicuous class per connector owns every remote source call, so connector indexing code, EE perm sync, and capability checks share call sites instead of drifting apart. Framework only; no gateway is registered yet and there are no production call sites.

- `SourceOperations` base class: a subclass declares its `DocumentSource` and registers at import time, one gateway per source. Gateways must subclass the base directly (no mixins, no gateway inheritance): the enforcement scans only the class's own namespace, so inherited members would bypass it.
- `@source_operation` decorator stamps each public method with metadata: capabilities served, named permission variants, what it consumes (credential/config/both/neither), and an optional untested="<reason>" coverage exemption with a mandatory reason string.
- `__init_subclass__` enforcement (same pattern as `HookPointSpec`): an unclassified public method, a missing or mistyped source, a duplicate gateway, an aliased method assignment, a public nested class, or a public staticmethod/classmethod/property fails at import time rather than in review.
- Registry accessors (get_source_operations_class, registered_source_operations) that the auto-discovering coverage and import-fence harnesses in the follow-up PR parametrize over.

Deliberately deferred: the shared client-construction helper (credential-decryption audit + refresh write-back guarantees) lands with the first concrete gateway (Slack), where its requirements are concrete.

## How Has This Been Tested?

Added automated testing.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a framework that routes all remote source calls through a single per-connector gateway class to prevent drift across indexing, EE perm sync, and capability checks. No gateways are registered yet; no production behavior changes.

- **New Features**
  - `SourceOperations` base: one gateway per `DocumentSource`; operations return plain data, not SDK objects.
  - `@source_operation` decorator: records capabilities, variants, what it consumes (`credential`/`config`/`both`/`neither`), and an optional `untested` reason (non-empty).
  - Import-time enforcement: rejects unclassified public methods, mixins/inheritance, duplicate sources, aliased methods, public nested classes, static/class methods/properties, and descriptors (e.g., `cached_property`).
  - Accessors: per-gateway `operation_specs`, plus registry helpers `get_source_operations_class` and `registered_source_operations`.
  - Unit tests cover registration, enforcement, and decorator validation.

<sup>Written for commit ed7f2a51a6ca45dc15c76f027311d3f8a5b69bd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

