### PR TITLE
feat(connector-stability): source-operation enforcement and capability-check wiring

### DIFF
--- a/backend/ee/onyx/connectors/capability_checks.py
+++ b/backend/ee/onyx/connectors/capability_checks.py
@@ -78,7 +78,7 @@ def get_perm_sync_capability_checks(source: DocumentSource) -> list[CapabilityCh
     built on a no-op probe.
 
     Ratchet: named checks require a registered source-operations gateway --
-    participation in the checks system IS the drift guarantee. Unmigrated
+    participation in the checks system is an anti-drift guarantee. Unmigrated
     sources keep the fallback path.
     """
     applicable = get_applicable_perm_sync_capabilities(source)

--- a/backend/ee/onyx/connectors/capability_checks.py
+++ b/backend/ee/onyx/connectors/capability_checks.py
@@ -17,6 +17,7 @@ from onyx.connectors.capability_checks.models import (
     CapabilityCheckContext,
     CredentialCapability,
 )
+from onyx.connectors.source_operations import get_source_operations_class
 
 # Named perm-sync checks per source. Empty at framework stage: per-connector
 # work registers named checks here.
@@ -75,6 +76,10 @@ def get_perm_sync_capability_checks(source: DocumentSource) -> list[CapabilityCh
     no-op get no perm-sync checks at all until named ones are registered; their
     verdict renders as "no checks available yet" rather than a trivial PASSED
     built on a no-op probe.
+
+    Ratchet: named checks require a registered source-operations gateway --
+    participation in the checks system IS the drift guarantee. Unmigrated
+    sources keep the fallback path.
     """
     applicable = get_applicable_perm_sync_capabilities(source)
     registered_by_capability: dict[CredentialCapability, list[CapabilityCheck]] = {
@@ -85,6 +90,13 @@ def get_perm_sync_capability_checks(source: DocumentSource) -> list[CapabilityCh
             _EXTERNAL_GROUP_SYNC_CHECKS_BY_SOURCE.get(source, [])
         ),
     }
+    assert (
+        not any(registered_by_capability.values())
+        or get_source_operations_class(source) is not None
+    ), (
+        f"{source.value} registers named perm-sync checks but no "
+        "source-operations gateway; migrate the connector first."
+    )
     checks: list[CapabilityCheck] = []
     for capability, registered in registered_by_capability.items():
         if registered:

--- a/backend/onyx/connectors/capabilities.py
+++ b/backend/onyx/connectors/capabilities.py
@@ -1,0 +1,17 @@
+"""Shared capability vocabulary for connectors.
+
+A leaf module: both the capability-check framework and the source-operations
+layer tag things with capabilities, and neither may import the other for it.
+"""
+
+from enum import Enum
+
+
+class CredentialCapability(str, Enum):
+    """
+    User-visible capabilities a credential may or may not support for a source.
+    """
+
+    INDEXING = "indexing"
+    DOC_PERMISSION_SYNC = "doc_permission_sync"
+    EXTERNAL_GROUP_SYNC = "external_group_sync"

--- a/backend/onyx/connectors/capability_checks/models.py
+++ b/backend/onyx/connectors/capability_checks/models.py
@@ -7,17 +7,9 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict
 
 from onyx.configs.constants import DocumentSource
+from onyx.connectors.capabilities import CredentialCapability
 from onyx.connectors.interfaces import BaseConnector
-
-
-class CredentialCapability(str, Enum):
-    """
-    User-visible capabilities a credential may or may not support for a source.
-    """
-
-    INDEXING = "indexing"
-    DOC_PERMISSION_SYNC = "doc_permission_sync"
-    EXTERNAL_GROUP_SYNC = "external_group_sync"
+from onyx.connectors.source_operations import SourceOperations
 
 
 class CapabilityCheckStatus(str, Enum):
@@ -63,9 +55,14 @@ class CapabilityCheckContext(BaseModel):
     them. ``instantiation_error`` is set when connector construction failed for
     a supplied config; the runner surfaces it on instance-requiring checks
     instead of skipping them.
+
+    ``source_operations`` is the gateway migrated checks compose; it is None
+    for sources without one. ``connector`` serves the fallback path only:
+    migrated checks need no connector instance.
     """
 
-    # ``BaseConnector`` is not a pydantic type; validate by isinstance.
+    # ``BaseConnector`` and ``SourceOperations`` are not pydantic types;
+    # validate by isinstance.
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     source: DocumentSource
@@ -73,6 +70,7 @@ class CapabilityCheckContext(BaseModel):
     connector: BaseConnector | None = None
     connector_specific_config: dict[str, Any] | None = None
     instantiation_error: Exception | None = None
+    source_operations: SourceOperations | None = None
 
 
 class CapabilityCheck(ABC):

--- a/backend/onyx/connectors/capability_checks/models.py
+++ b/backend/onyx/connectors/capability_checks/models.py
@@ -56,9 +56,9 @@ class CapabilityCheckContext(BaseModel):
     a supplied config; the runner surfaces it on instance-requiring checks
     instead of skipping them.
 
-    ``source_operations`` is the gateway migrated checks compose; it is None
-    for sources without one. ``connector`` serves the fallback path only:
-    migrated checks need no connector instance.
+    ``source_operations`` is the gateway migrated checks compose; it is None for
+    sources without one. ``connector`` serves the fallback path only: migrated
+    checks need no connector instance.
     """
 
     # ``BaseConnector`` and ``SourceOperations`` are not pydantic types;

--- a/backend/onyx/connectors/capability_checks/registry.py
+++ b/backend/onyx/connectors/capability_checks/registry.py
@@ -4,6 +4,7 @@ from onyx.connectors.capability_checks.models import (
     CapabilityCheckContext,
     CredentialCapability,
 )
+from onyx.connectors.source_operations import get_source_operations_class
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 
 # INDEXING checks per source. Checks must be enumerable without an instantiated
@@ -43,8 +44,16 @@ def get_capability_checks(source: DocumentSource) -> list[CapabilityCheck]:
     INDEXING checks are registered here; perm-sync checks come from the EE
     implementation and are empty on OSS builds, where the perm-sync feature does
     not exist.
+
+    Ratchet: named checks require a registered source-operations gateway --
+    participation in the checks system IS the drift guarantee. Unmigrated
+    sources keep the fallback path.
     """
     checks = list(_INDEXING_CHECKS_BY_SOURCE.get(source, []))
+    assert not checks or get_source_operations_class(source) is not None, (
+        f"{source.value} registers named INDEXING checks but no "
+        "source-operations gateway; migrate the connector first."
+    )
     if not checks:
         checks.append(_ConnectorSettingsFallbackCheck(source))
     get_perm_sync_checks = fetch_ee_implementation_or_noop(

--- a/backend/onyx/connectors/capability_checks/registry.py
+++ b/backend/onyx/connectors/capability_checks/registry.py
@@ -46,7 +46,7 @@ def get_capability_checks(source: DocumentSource) -> list[CapabilityCheck]:
     not exist.
 
     Ratchet: named checks require a registered source-operations gateway --
-    participation in the checks system IS the drift guarantee. Unmigrated
+    participation in the checks system is an anti-drift guarantee. Unmigrated
     sources keep the fallback path.
     """
     checks = list(_INDEXING_CHECKS_BY_SOURCE.get(source, []))

--- a/backend/onyx/connectors/source_operations.py
+++ b/backend/onyx/connectors/source_operations.py
@@ -151,9 +151,11 @@ class SourceOperations(ABC):
       helpers.
     - Set ``source`` to the ``DocumentSource`` the gateway serves; one gateway
       per source.
-    - Every public method must be classified with ``@source_operation``. Helpers
-      (including any staticmethod/classmethod/property) stay private; data
-      models live at module level.
+    - Declare ``sdk_modules``; an explicit empty tuple marks an SDK-less
+      connector.
+    - Every public method must be classified with ``@source_operation``.
+      Helpers (including any staticmethod/classmethod/property) stay private;
+      data models live at module level.
 
     The gateway owns client construction from the credential plus optional
     connector config; operations return plain data, never live SDK objects.
@@ -163,12 +165,13 @@ class SourceOperations(ABC):
 
     # The SDK module roots this gateway wraps (e.g. ``("slack_sdk",)``). The
     # import-fence test asserts these are imported only from the gateway's
-    # file within the connector's OSS and EE perm-sync directories.
-    sdk_modules: ClassVar[tuple[str, ...]] = ()
+    # own file within the connector's OSS and EE perm-sync directories. Every
+    # gateway must declare this explicitly; an empty tuple marks a genuinely
+    # SDK-less connector as a conspicuous, reviewable decision rather than an
+    # accidentally unfenced one.
+    sdk_modules: ClassVar[tuple[str, ...]]
 
-    _operation_specs: ClassVar[Mapping[str, SourceOperationSpec]] = MappingProxyType(
-        {}
-    )
+    _operation_specs: ClassVar[Mapping[str, SourceOperationSpec]] = MappingProxyType({})
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -192,6 +195,12 @@ class SourceOperations(ABC):
             raise TypeError(
                 f"{cls.__name__} cannot register {source.value}: already "
                 f"registered by {registered.__name__}. One gateway per source."
+            )
+        if "sdk_modules" not in vars(cls):
+            raise TypeError(
+                f"{cls.__name__} must declare ``sdk_modules`` so the import "
+                "fence knows what to guard; declare an explicit empty tuple "
+                "for a genuinely SDK-less connector."
             )
 
         specs: dict[str, SourceOperationSpec] = {}

--- a/backend/onyx/connectors/source_operations.py
+++ b/backend/onyx/connectors/source_operations.py
@@ -56,12 +56,11 @@ class SourceOperationSpec(BaseModel):
     name: str
     capabilities: frozenset[CredentialCapability]
     # Named forms of the operation where a parameter changes the required
-    # permission (e.g. Slack ``conversations.list`` public vs private).
-    # Coverage is counted per (operation, variant); empty means the operation
-    # itself is the single coverage unit. A variant-bearing operation must be
-    # invoked with a ``variant="<name>"`` keyword -- the method may branch on
-    # it or ignore it, but the call site must classify itself; the base class
-    # enforces this at runtime and the coverage harness attributes calls by it.
+    # permission (e.g. Slack ``conversations.list`` public vs private). Coverage
+    # is counted per (operation, variant); empty means the operation itself is
+    # the single coverage unit. A variant-bearing operation must be invoked with
+    # a ``variant="<name>"`` keyword -- the method may branch on it or ignore
+    # it, but the call site must classify itself.
     variants: tuple[str, ...] = ()
     consumes: OperationConsumes
     # Exempts the operation (all variants) from the check-coverage requirement.
@@ -153,9 +152,9 @@ class SourceOperations(ABC):
       per source.
     - Declare ``sdk_modules``; an explicit empty tuple marks an SDK-less
       connector.
-    - Every public method must be classified with ``@source_operation``.
-      Helpers (including any staticmethod/classmethod/property) stay private;
-      data models live at module level.
+    - Every public method must be classified with ``@source_operation``. Helpers
+      (including any staticmethod/classmethod/property) stay private; data
+      models live at module level.
 
     The gateway owns client construction from the credential plus optional
     connector config; operations return plain data, never live SDK objects.
@@ -164,11 +163,10 @@ class SourceOperations(ABC):
     source: ClassVar[DocumentSource]
 
     # The SDK module roots this gateway wraps (e.g. ``("slack_sdk",)``). The
-    # import-fence test asserts these are imported only from the gateway's
-    # own file within the connector's OSS and EE perm-sync directories. Every
+    # import-fence test asserts these are imported only from the gateway's own
+    # file within the connector's OSS and EE perm-sync directories. Every
     # gateway must declare this explicitly; an empty tuple marks a genuinely
-    # SDK-less connector as a conspicuous, reviewable decision rather than an
-    # accidentally unfenced one.
+    # SDK-less connector.
     sdk_modules: ClassVar[tuple[str, ...]]
 
     _operation_specs: ClassVar[Mapping[str, SourceOperationSpec]] = MappingProxyType({})
@@ -202,9 +200,8 @@ class SourceOperations(ABC):
                 "fence knows what to guard; declare an explicit empty tuple "
                 "for a genuinely SDK-less connector."
             )
-        # Shape matters, not just presence: a plain string is a Collection of
-        # single characters to the fence, which would then match nothing and
-        # silently pass.
+        # Shape matters: a plain string is a Collection of single characters to
+        # the fence, which would then match nothing and silently pass.
         sdk_modules = vars(cls)["sdk_modules"]
         if not isinstance(sdk_modules, tuple) or any(
             not isinstance(module, str) or not module for module in sdk_modules
@@ -264,7 +261,7 @@ class SourceOperations(ABC):
         # Variant-bearing operations must self-classify at every call site;
         # wrapping here makes production calls carry the same ``variant=``
         # attribution the coverage harness counts, so coverage claims stay
-        # honest. (Auto-wrap precedent: ``LLM.__init_subclass__``.)
+        # honest.
         for name, spec in specs.items():
             if spec.variants:
                 setattr(cls, name, _enforce_variant_kwarg(vars(cls)[name], spec))

--- a/backend/onyx/connectors/source_operations.py
+++ b/backend/onyx/connectors/source_operations.py
@@ -202,6 +202,17 @@ class SourceOperations(ABC):
                 "fence knows what to guard; declare an explicit empty tuple "
                 "for a genuinely SDK-less connector."
             )
+        # Shape matters, not just presence: a plain string is a Collection of
+        # single characters to the fence, which would then match nothing and
+        # silently pass.
+        sdk_modules = vars(cls)["sdk_modules"]
+        if not isinstance(sdk_modules, tuple) or any(
+            not isinstance(module, str) or not module for module in sdk_modules
+        ):
+            raise TypeError(
+                f"{cls.__name__}.sdk_modules must be a tuple of non-empty "
+                "module roots; use () for a genuinely SDK-less connector."
+            )
 
         specs: dict[str, SourceOperationSpec] = {}
         unstamped: list[str] = []

--- a/backend/onyx/connectors/source_operations.py
+++ b/backend/onyx/connectors/source_operations.py
@@ -16,6 +16,7 @@ fire requests outside any wrapper, and returning plain data is what makes the
 gateway boundary real.
 """
 
+import functools
 import inspect
 from abc import ABC
 from collections.abc import Callable, Collection, Mapping
@@ -26,7 +27,7 @@ from typing import Any, ClassVar, TypeVar, cast
 from pydantic import BaseModel, ConfigDict
 
 from onyx.configs.constants import DocumentSource
-from onyx.connectors.capability_checks.models import CredentialCapability
+from onyx.connectors.capabilities import CredentialCapability
 
 _SPEC_ATTR = "__source_operation_spec__"
 
@@ -55,9 +56,12 @@ class SourceOperationSpec(BaseModel):
     name: str
     capabilities: frozenset[CredentialCapability]
     # Named forms of the operation where a parameter changes the required
-    # permission (e.g. Slack ``conversations.list`` public vs private). Coverage
-    # is counted per (operation, variant); empty means the operation itself is
-    # the single coverage unit.
+    # permission (e.g. Slack ``conversations.list`` public vs private).
+    # Coverage is counted per (operation, variant); empty means the operation
+    # itself is the single coverage unit. A variant-bearing operation must be
+    # invoked with a ``variant="<name>"`` keyword -- the method may branch on
+    # it or ignore it, but the call site must classify itself; the base class
+    # enforces this at runtime and the coverage harness attributes calls by it.
     variants: tuple[str, ...] = ()
     consumes: OperationConsumes
     # Exempts the operation (all variants) from the check-coverage requirement.
@@ -114,6 +118,24 @@ def source_operation(
     return stamp
 
 
+def _enforce_variant_kwarg(
+    func: Callable[..., Any], spec: SourceOperationSpec
+) -> Callable[..., Any]:
+    """Wraps a variant-bearing operation to require a declared ``variant=``."""
+
+    @functools.wraps(func)
+    def wrapped(self: "SourceOperations", *args: Any, **kwargs: Any) -> Any:
+        variant = kwargs.get("variant")
+        if variant not in spec.variants:
+            raise TypeError(
+                f"{spec.name} declares variants {spec.variants}; call it "
+                f"with variant= one of those, got {variant!r}."
+            )
+        return func(self, *args, **kwargs)
+
+    return wrapped
+
+
 # Internal: use ``monkeypatch.setattr(module, "_SOURCE_OPERATIONS_BY_SOURCE",
 # {})`` to isolate in tests.
 _SOURCE_OPERATIONS_BY_SOURCE: dict[DocumentSource, type["SourceOperations"]] = {}
@@ -139,7 +161,14 @@ class SourceOperations(ABC):
 
     source: ClassVar[DocumentSource]
 
-    _operation_specs: ClassVar[Mapping[str, SourceOperationSpec]] = MappingProxyType({})
+    # The SDK module roots this gateway wraps (e.g. ``("slack_sdk",)``). The
+    # import-fence test asserts these are imported only from the gateway's
+    # file within the connector's OSS and EE perm-sync directories.
+    sdk_modules: ClassVar[tuple[str, ...]] = ()
+
+    _operation_specs: ClassVar[Mapping[str, SourceOperationSpec]] = MappingProxyType(
+        {}
+    )
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -211,6 +240,14 @@ class SourceOperations(ABC):
                 f"{unstamped}. Stamp them with @source_operation or make "
                 "them private."
             )
+
+        # Variant-bearing operations must self-classify at every call site;
+        # wrapping here makes production calls carry the same ``variant=``
+        # attribution the coverage harness counts, so coverage claims stay
+        # honest. (Auto-wrap precedent: ``LLM.__init_subclass__``.)
+        for name, spec in specs.items():
+            if spec.variants:
+                setattr(cls, name, _enforce_variant_kwarg(vars(cls)[name], spec))
 
         cls._operation_specs = MappingProxyType(specs)
         _SOURCE_OPERATIONS_BY_SOURCE[source] = cls

--- a/backend/tests/unit/ee/onyx/connectors/test_ee_capability_checks.py
+++ b/backend/tests/unit/ee/onyx/connectors/test_ee_capability_checks.py
@@ -144,7 +144,7 @@ def test_registered_checks_clobber_only_their_capability(
     Verifies named checks clobber the fallback per capability, not per source.
     """
     # Precondition.
-    # Nothing is registered at framework stage, so register a gateway and a
+    # Nothing is registered at the framework layer, so register a gateway and a
     # named doc-sync check the way a per-connector session would (the ratchet
     # requires the gateway).
     monkeypatch.setattr(source_operations_module, "_SOURCE_OPERATIONS_BY_SOURCE", {})

--- a/backend/tests/unit/ee/onyx/connectors/test_ee_capability_checks.py
+++ b/backend/tests/unit/ee/onyx/connectors/test_ee_capability_checks.py
@@ -96,6 +96,13 @@ def test_named_checks_ignore_the_probe_allowlist(
     with registered named checks still returns them.
     """
     # Precondition.
+    # The ratchet requires a gateway wherever named checks register.
+    monkeypatch.setattr(source_operations_module, "_SOURCE_OPERATIONS_BY_SOURCE", {})
+
+    class _SlackOperations(SourceOperations):
+        source = DocumentSource.SLACK
+        sdk_modules = ()
+
     named_check = _NamedCheck(
         capability=CredentialCapability.DOC_PERMISSION_SYNC,
         check_id="slack_named_check",

--- a/backend/tests/unit/ee/onyx/connectors/test_ee_capability_checks.py
+++ b/backend/tests/unit/ee/onyx/connectors/test_ee_capability_checks.py
@@ -144,6 +144,7 @@ def test_registered_checks_clobber_only_their_capability(
 
     class _GoogleDriveOperations(SourceOperations):
         source = DocumentSource.GOOGLE_DRIVE
+        sdk_modules = ()
 
     named_check = _NamedCheck(
         capability=CredentialCapability.DOC_PERMISSION_SYNC,

--- a/backend/tests/unit/ee/onyx/connectors/test_ee_capability_checks.py
+++ b/backend/tests/unit/ee/onyx/connectors/test_ee_capability_checks.py
@@ -8,12 +8,14 @@ from ee.onyx.connectors.capability_checks import (
     get_perm_sync_capability_checks,
 )
 from onyx.configs.constants import DocumentSource
+from onyx.connectors import source_operations as source_operations_module
 from onyx.connectors.capability_checks.models import (
     CapabilityCheck,
     CapabilityCheckContext,
     CredentialCapability,
 )
 from onyx.connectors.interfaces import BaseConnector
+from onyx.connectors.source_operations import SourceOperations
 
 
 class _NamedCheck(CapabilityCheck):
@@ -135,8 +137,14 @@ def test_registered_checks_clobber_only_their_capability(
     Verifies named checks clobber the fallback per capability, not per source.
     """
     # Precondition.
-    # Nothing is registered at framework stage, so register a named doc-sync
-    # check the way a per-connector session would.
+    # Nothing is registered at framework stage, so register a gateway and a
+    # named doc-sync check the way a per-connector session would (the ratchet
+    # requires the gateway).
+    monkeypatch.setattr(source_operations_module, "_SOURCE_OPERATIONS_BY_SOURCE", {})
+
+    class _GoogleDriveOperations(SourceOperations):
+        source = DocumentSource.GOOGLE_DRIVE
+
     named_check = _NamedCheck(
         capability=CredentialCapability.DOC_PERMISSION_SYNC,
         check_id="google_drive_named_check",

--- a/backend/tests/unit/onyx/connectors/capability_checks/test_capability_check_ratchet.py
+++ b/backend/tests/unit/onyx/connectors/capability_checks/test_capability_check_ratchet.py
@@ -1,0 +1,126 @@
+import pytest
+
+from ee.onyx.connectors import capability_checks as ee_capability_checks
+from ee.onyx.connectors.capability_checks import get_perm_sync_capability_checks
+from onyx.configs.constants import DocumentSource
+from onyx.connectors import source_operations as source_operations_module
+from onyx.connectors.capability_checks import registry
+from onyx.connectors.capability_checks.models import (
+    CapabilityCheck,
+    CapabilityCheckContext,
+    CredentialCapability,
+)
+from onyx.connectors.capability_checks.registry import get_capability_checks
+from onyx.connectors.source_operations import SourceOperations
+
+
+class _NamedCheck(CapabilityCheck):
+    """Minimal concrete named check; ``run`` never executes in these tests."""
+
+    def run(self, context: CapabilityCheckContext) -> None:
+        raise NotImplementedError
+
+
+@pytest.fixture
+def isolated_gateway_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolates the gateway registry so test gateways never leak globally."""
+    monkeypatch.setattr(source_operations_module, "_SOURCE_OPERATIONS_BY_SOURCE", {})
+
+
+def _register_github_gateway() -> None:
+    class _GithubOperations(SourceOperations):
+        source = DocumentSource.GITHUB
+
+
+@pytest.mark.usefixtures("isolated_gateway_registry")
+def test_named_indexing_checks_require_a_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verifies the ratchet: no named INDEXING checks without a gateway."""
+    # Precondition.
+    named_check = _NamedCheck(
+        capability=CredentialCapability.INDEXING,
+        check_id="github_named_check",
+        display_name="Named check",
+    )
+    monkeypatch.setitem(
+        registry._INDEXING_CHECKS_BY_SOURCE, DocumentSource.GITHUB, [named_check]
+    )
+
+    # Under test and postcondition.
+    with pytest.raises(AssertionError, match="source-operations gateway"):
+        get_capability_checks(DocumentSource.GITHUB)
+
+
+@pytest.mark.usefixtures("isolated_gateway_registry")
+def test_named_indexing_checks_pass_with_a_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verifies a migrated source registers named checks freely."""
+    # Precondition.
+    _register_github_gateway()
+    named_check = _NamedCheck(
+        capability=CredentialCapability.INDEXING,
+        check_id="github_named_check",
+        display_name="Named check",
+    )
+    monkeypatch.setitem(
+        registry._INDEXING_CHECKS_BY_SOURCE, DocumentSource.GITHUB, [named_check]
+    )
+
+    # Under test and postcondition.
+    assert named_check in get_capability_checks(DocumentSource.GITHUB)
+
+
+@pytest.mark.usefixtures("isolated_gateway_registry")
+def test_named_perm_sync_checks_require_a_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verifies the ratchet applies to the EE perm-sync registries too."""
+    # Precondition.
+    named_check = _NamedCheck(
+        capability=CredentialCapability.DOC_PERMISSION_SYNC,
+        check_id="github_named_check",
+        display_name="Named check",
+    )
+    monkeypatch.setitem(
+        ee_capability_checks._DOC_PERMISSION_SYNC_CHECKS_BY_SOURCE,
+        DocumentSource.GITHUB,
+        [named_check],
+    )
+
+    # Under test and postcondition.
+    with pytest.raises(AssertionError, match="source-operations gateway"):
+        get_perm_sync_capability_checks(DocumentSource.GITHUB)
+
+
+@pytest.mark.usefixtures("isolated_gateway_registry")
+def test_named_perm_sync_checks_pass_with_a_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verifies a migrated source registers named perm-sync checks freely."""
+    # Precondition.
+    _register_github_gateway()
+    named_check = _NamedCheck(
+        capability=CredentialCapability.DOC_PERMISSION_SYNC,
+        check_id="github_named_check",
+        display_name="Named check",
+    )
+    monkeypatch.setitem(
+        ee_capability_checks._DOC_PERMISSION_SYNC_CHECKS_BY_SOURCE,
+        DocumentSource.GITHUB,
+        [named_check],
+    )
+
+    # Under test and postcondition.
+    assert named_check in get_perm_sync_capability_checks(DocumentSource.GITHUB)
+
+
+@pytest.mark.usefixtures("isolated_gateway_registry")
+def test_fallback_path_needs_no_gateway() -> None:
+    """Verifies unmigrated sources keep their fallback coverage untouched."""
+    # Under test.
+    checks = get_capability_checks(DocumentSource.GITHUB)
+
+    # Postcondition.
+    assert any(check.is_fallback for check in checks)

--- a/backend/tests/unit/onyx/connectors/capability_checks/test_capability_check_ratchet.py
+++ b/backend/tests/unit/onyx/connectors/capability_checks/test_capability_check_ratchet.py
@@ -12,6 +12,9 @@ from onyx.connectors.capability_checks.models import (
 )
 from onyx.connectors.capability_checks.registry import get_capability_checks
 from onyx.connectors.source_operations import SourceOperations
+from tests.unit.onyx.connectors.source_operation_harnesses import (
+    import_all_source_operation_gateways,
+)
 
 
 class _NamedCheck(CapabilityCheck):
@@ -30,6 +33,7 @@ def isolated_gateway_registry(monkeypatch: pytest.MonkeyPatch) -> None:
 def _register_github_gateway() -> None:
     class _GithubOperations(SourceOperations):
         source = DocumentSource.GITHUB
+        sdk_modules = ()
 
 
 @pytest.mark.usefixtures("isolated_gateway_registry")
@@ -124,3 +128,28 @@ def test_fallback_path_needs_no_gateway() -> None:
 
     # Postcondition.
     assert any(check.is_fallback for check in checks)
+
+
+def test_every_source_resolves_checks_without_tripping_the_ratchet() -> None:
+    """
+    Verifies real registrations satisfy the ratchet in CI rather than first
+    firing at report time, and smoke-tests fallback synthesis for the whole
+    enum.
+    """
+    # Precondition.
+    import_all_source_operation_gateways()
+
+    # Under test and postcondition.
+    for source in DocumentSource:
+        assert get_capability_checks(source)
+
+
+@pytest.mark.usefixtures("enable_ee")
+def test_every_source_resolves_checks_with_ee_enabled() -> None:
+    """Verifies the same holds with EE resolution on."""
+    # Precondition.
+    import_all_source_operation_gateways()
+
+    # Under test and postcondition.
+    for source in DocumentSource:
+        assert get_capability_checks(source)

--- a/backend/tests/unit/onyx/connectors/capability_checks/test_registry_fallbacks.py
+++ b/backend/tests/unit/onyx/connectors/capability_checks/test_registry_fallbacks.py
@@ -48,7 +48,7 @@ def test_unregistered_source_gets_connector_settings_fallback() -> None:
 def test_registered_source_gets_no_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     """Verifies that registered named checks clobber the INDEXING fallback."""
     # Precondition.
-    # Nothing is registered at framework stage, so register a gateway and a
+    # Nothing is registered at the framework layer, so register a gateway and a
     # named check the way a per-connector session would (the ratchet requires
     # the gateway).
     monkeypatch.setattr(source_operations_module, "_SOURCE_OPERATIONS_BY_SOURCE", {})

--- a/backend/tests/unit/onyx/connectors/capability_checks/test_registry_fallbacks.py
+++ b/backend/tests/unit/onyx/connectors/capability_checks/test_registry_fallbacks.py
@@ -55,6 +55,7 @@ def test_registered_source_gets_no_fallback(monkeypatch: pytest.MonkeyPatch) -> 
 
     class _GithubOperations(SourceOperations):
         source = DocumentSource.GITHUB
+        sdk_modules = ()
 
     named_check = _NamedCheck(
         capability=CredentialCapability.INDEXING,

--- a/backend/tests/unit/onyx/connectors/capability_checks/test_registry_fallbacks.py
+++ b/backend/tests/unit/onyx/connectors/capability_checks/test_registry_fallbacks.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from onyx.configs.constants import DocumentSource
+from onyx.connectors import source_operations as source_operations_module
 from onyx.connectors.capability_checks import registry
 from onyx.connectors.capability_checks.models import (
     CapabilityCheck,
@@ -14,6 +15,7 @@ from onyx.connectors.capability_checks.registry import (
     get_capability_checks,
 )
 from onyx.connectors.interfaces import BaseConnector
+from onyx.connectors.source_operations import SourceOperations
 
 
 class _NamedCheck(CapabilityCheck):
@@ -46,8 +48,14 @@ def test_unregistered_source_gets_connector_settings_fallback() -> None:
 def test_registered_source_gets_no_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     """Verifies that registered named checks clobber the INDEXING fallback."""
     # Precondition.
-    # Nothing is registered at framework stage, so register a named check the
-    # way a per-connector session would.
+    # Nothing is registered at framework stage, so register a gateway and a
+    # named check the way a per-connector session would (the ratchet requires
+    # the gateway).
+    monkeypatch.setattr(source_operations_module, "_SOURCE_OPERATIONS_BY_SOURCE", {})
+
+    class _GithubOperations(SourceOperations):
+        source = DocumentSource.GITHUB
+
     named_check = _NamedCheck(
         capability=CredentialCapability.INDEXING,
         check_id="github_named_check",

--- a/backend/tests/unit/onyx/connectors/source_operation_harnesses.py
+++ b/backend/tests/unit/onyx/connectors/source_operation_harnesses.py
@@ -31,11 +31,11 @@ from onyx.connectors.source_operations import (
 def import_all_source_operation_gateways() -> None:
     """Imports every connector's gateway module so registration fires.
 
-    Asserts every discovered module defines a registered gateway, so
-    discovery rot (a rename, a glob mismatch) surfaces as a loud collection
-    error instead of vacuously skipped harnesses. Deliberately does NOT
-    assume the directory name matches ``source.value`` (``google_site/`` vs
-    ``google_sites``, ``blob/`` serving several sources already violate it).
+    Asserts every discovered module defines a registered gateway, so discovery
+    rot (a rename, a glob mismatch) surfaces as a loud collection error instead
+    of vacuously skipped harnesses. Deliberately does NOT assume the directory
+    name matches ``source.value`` (``google_site/`` vs ``google_sites``,
+    ``blob/`` serving several sources already violate it).
     """
     connectors_dir = Path(onyx.connectors.__file__).parent
     for path in sorted(connectors_dir.glob("*/source_operations.py")):
@@ -147,9 +147,9 @@ def find_import_fence_violations(
 ) -> list[FenceViolation]:
     """Finds imports of fenced SDK modules outside the gateway's own file.
 
-    The exemption is the exact gateway file: another file that merely shares
-    the ``source_operations.py`` basename (in the EE tree, or nested) is
-    scanned like any other.
+    The exemption is the exact gateway file: another file that merely shares the
+    ``source_operations.py`` basename (in the EE tree, or nested) is scanned
+    like any other.
     """
     roots = set(sdk_modules)
     allowed = allowed_file.resolve()

--- a/backend/tests/unit/onyx/connectors/source_operation_harnesses.py
+++ b/backend/tests/unit/onyx/connectors/source_operation_harnesses.py
@@ -21,14 +21,29 @@ from onyx.connectors.capability_checks.models import (
     CapabilityCheckContext,
 )
 from onyx.connectors.interfaces import BaseConnector
-from onyx.connectors.source_operations import SourceOperations
+from onyx.connectors.source_operations import (
+    SourceOperations,
+    registered_source_operations,
+)
 
 
 def import_all_source_operation_gateways() -> None:
-    """Imports every connector's gateway module so registration fires."""
+    """Imports every connector's gateway module so registration fires.
+
+    Asserts every discovered module registered a gateway for its directory's
+    source, so discovery rot (a rename, a glob mismatch) surfaces as a loud
+    collection error instead of vacuously skipped harnesses.
+    """
     connectors_dir = Path(onyx.connectors.__file__).parent
     for path in sorted(connectors_dir.glob("*/source_operations.py")):
-        importlib.import_module(f"onyx.connectors.{path.parent.name}.source_operations")
+        source_value = path.parent.name
+        importlib.import_module(f"onyx.connectors.{source_value}.source_operations")
+        registered = {source.value for source in registered_source_operations()}
+        assert source_value in registered, (
+            f"{path} was imported but registered no gateway for "
+            f"{source_value!r}; the coverage and fence harnesses would "
+            "silently skip it."
+        )
 
 
 class UncoveredUnit(BaseModel):

--- a/backend/tests/unit/onyx/connectors/source_operation_harnesses.py
+++ b/backend/tests/unit/onyx/connectors/source_operation_harnesses.py
@@ -10,7 +10,7 @@ import importlib
 import sys
 from collections.abc import Collection, Sequence
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
 
 from pydantic import BaseModel, ConfigDict
 
@@ -69,11 +69,13 @@ def compute_uncovered_units(
     A unit is covered when a check of the unit's capability invoked the
     operation (with ``variant=`` naming the unit's variant, for variant-bearing
     operations). ``untested``-annotated operations are exempt. Checks run
-    against mock data and may raise; their calls are recorded regardless.
+    against mock data and may raise; their valid calls still count. The spy is
+    autospecced, so a call whose shape the real operation would reject raises
+    and records nothing -- a broken call cannot certify coverage.
     """
     exercised: set[tuple[str, str | None, CredentialCapability]] = set()
     for check in checks:
-        spy = MagicMock(spec=gateway_class)
+        spy = create_autospec(gateway_class, instance=True)
         context = CapabilityCheckContext(
             source=gateway_class.source,
             credential_json={},

--- a/backend/tests/unit/onyx/connectors/source_operation_harnesses.py
+++ b/backend/tests/unit/onyx/connectors/source_operation_harnesses.py
@@ -7,6 +7,7 @@ they can be unit-tested against synthetic gateways and directories.
 
 import ast
 import importlib
+import sys
 from collections.abc import Collection, Sequence
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -30,19 +31,22 @@ from onyx.connectors.source_operations import (
 def import_all_source_operation_gateways() -> None:
     """Imports every connector's gateway module so registration fires.
 
-    Asserts every discovered module registered a gateway for its directory's
-    source, so discovery rot (a rename, a glob mismatch) surfaces as a loud
-    collection error instead of vacuously skipped harnesses.
+    Asserts every discovered module defines a registered gateway, so
+    discovery rot (a rename, a glob mismatch) surfaces as a loud collection
+    error instead of vacuously skipped harnesses. Deliberately does NOT
+    assume the directory name matches ``source.value`` (``google_site/`` vs
+    ``google_sites``, ``blob/`` serving several sources already violate it).
     """
     connectors_dir = Path(onyx.connectors.__file__).parent
     for path in sorted(connectors_dir.glob("*/source_operations.py")):
-        source_value = path.parent.name
-        importlib.import_module(f"onyx.connectors.{source_value}.source_operations")
-        registered = {source.value for source in registered_source_operations()}
-        assert source_value in registered, (
-            f"{path} was imported but registered no gateway for "
-            f"{source_value!r}; the coverage and fence harnesses would "
-            "silently skip it."
+        module_name = f"onyx.connectors.{path.parent.name}.source_operations"
+        importlib.import_module(module_name)
+        assert any(
+            gateway.__module__ == module_name
+            for gateway in registered_source_operations().values()
+        ), (
+            f"{path} was imported but defines no registered gateway; the "
+            "coverage and fence harnesses would silently skip it."
         )
 
 
@@ -82,6 +86,9 @@ def compute_uncovered_units(
         except Exception:
             pass
         for name, _args, kwargs in spy.mock_calls:
+            # Chained calls (``spy.op().foo()``) yield junk segments like
+            # ``op()``; they never match a registered operation name, so they
+            # sit harmlessly in the exercised set.
             operation = name.split(".")[0]
             if not operation:
                 continue
@@ -114,27 +121,42 @@ class FenceViolation(BaseModel):
     module: str
 
 
-def fence_directories_for_source(source_value: str) -> list[Path]:
-    """Returns the directories the import fence scans for a source."""
-    return [
-        Path(onyx.connectors.__file__).parent / source_value,
-        Path(ee.onyx.external_permissions.__file__).parent / source_value,
-    ]
+def gateway_fence_paths(
+    gateway_class: type[SourceOperations],
+) -> tuple[Path, list[Path]]:
+    """Returns the gateway's own file and the directories the fence scans.
+
+    Both derive from the gateway class itself, not from a directory-naming
+    convention: ``google_site/`` (source value ``google_sites``) and ``blob/``
+    (one directory serving several sources) already break name-based paths.
+    """
+    module_file = sys.modules[gateway_class.__module__].__file__
+    assert module_file is not None, "Gateway modules always have a file."
+    gateway_file = Path(module_file).resolve()
+    oss_dir = gateway_file.parent
+    ee_dir = Path(ee.onyx.external_permissions.__file__).parent / oss_dir.name
+    return gateway_file, [oss_dir, ee_dir]
 
 
 def find_import_fence_violations(
     directories: Collection[Path],
     sdk_modules: Collection[str],
-    allowed_filename: str = "source_operations.py",
+    allowed_file: Path,
 ) -> list[FenceViolation]:
-    """Finds imports of fenced SDK modules outside the gateway file."""
+    """Finds imports of fenced SDK modules outside the gateway's own file.
+
+    The exemption is the exact gateway file: another file that merely shares
+    the ``source_operations.py`` basename (in the EE tree, or nested) is
+    scanned like any other.
+    """
     roots = set(sdk_modules)
+    allowed = allowed_file.resolve()
     violations: list[FenceViolation] = []
     for directory in directories:
         if not directory.is_dir():
             continue
         for path in sorted(directory.rglob("*.py")):
-            if path.name == allowed_filename:
+            if path.resolve() == allowed:
                 continue
             tree = ast.parse(path.read_text(), filename=str(path))
             for node in ast.walk(tree):

--- a/backend/tests/unit/onyx/connectors/source_operation_harnesses.py
+++ b/backend/tests/unit/onyx/connectors/source_operation_harnesses.py
@@ -1,0 +1,144 @@
+"""Reusable logic behind the auto-discovering source-operations harnesses.
+
+The harness tests (coverage and import fence) parametrize over
+``registered_source_operations()``; the functions here do the actual work so
+they can be unit-tested against synthetic gateways and directories.
+"""
+
+import ast
+import importlib
+from collections.abc import Collection, Sequence
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from pydantic import BaseModel, ConfigDict
+
+import ee.onyx.external_permissions
+import onyx.connectors
+from onyx.connectors.capabilities import CredentialCapability
+from onyx.connectors.capability_checks.models import (
+    CapabilityCheck,
+    CapabilityCheckContext,
+)
+from onyx.connectors.interfaces import BaseConnector
+from onyx.connectors.source_operations import SourceOperations
+
+
+def import_all_source_operation_gateways() -> None:
+    """Imports every connector's gateway module so registration fires."""
+    connectors_dir = Path(onyx.connectors.__file__).parent
+    for path in sorted(connectors_dir.glob("*/source_operations.py")):
+        importlib.import_module(f"onyx.connectors.{path.parent.name}.source_operations")
+
+
+class UncoveredUnit(BaseModel):
+    """One (operation, variant, capability) unit no check exercised."""
+
+    model_config = ConfigDict(frozen=True)
+
+    operation: str
+    variant: str | None
+    capability: CredentialCapability
+
+
+def compute_uncovered_units(
+    gateway_class: type[SourceOperations],
+    checks: Sequence[CapabilityCheck],
+) -> list[UncoveredUnit]:
+    """Runs each check against a spy gateway and returns unexercised units.
+
+    A unit is covered when a check of the unit's capability invoked the
+    operation (with ``variant=`` naming the unit's variant, for variant-bearing
+    operations). ``untested``-annotated operations are exempt. Checks run
+    against mock data and may raise; their calls are recorded regardless.
+    """
+    exercised: set[tuple[str, str | None, CredentialCapability]] = set()
+    for check in checks:
+        spy = MagicMock(spec=gateway_class)
+        context = CapabilityCheckContext(
+            source=gateway_class.source,
+            credential_json={},
+            connector=MagicMock(spec=BaseConnector),
+            connector_specific_config={},
+            source_operations=spy,
+        )
+        try:
+            check.run(context)
+        except Exception:
+            pass
+        for name, _args, kwargs in spy.mock_calls:
+            operation = name.split(".")[0]
+            if not operation:
+                continue
+            exercised.add((operation, kwargs.get("variant"), check.capability))
+
+    uncovered: list[UncoveredUnit] = []
+    for operation, spec in gateway_class.operation_specs().items():
+        if spec.untested is not None:
+            continue
+        for variant in spec.variants or (None,):
+            for capability in spec.capabilities:
+                if (operation, variant, capability) not in exercised:
+                    uncovered.append(
+                        UncoveredUnit(
+                            operation=operation,
+                            variant=variant,
+                            capability=capability,
+                        )
+                    )
+    return uncovered
+
+
+class FenceViolation(BaseModel):
+    """One import of a fenced SDK module outside the gateway file."""
+
+    model_config = ConfigDict(frozen=True)
+
+    file: str
+    line: int
+    module: str
+
+
+def fence_directories_for_source(source_value: str) -> list[Path]:
+    """Returns the directories the import fence scans for a source."""
+    return [
+        Path(onyx.connectors.__file__).parent / source_value,
+        Path(ee.onyx.external_permissions.__file__).parent / source_value,
+    ]
+
+
+def find_import_fence_violations(
+    directories: Collection[Path],
+    sdk_modules: Collection[str],
+    allowed_filename: str = "source_operations.py",
+) -> list[FenceViolation]:
+    """Finds imports of fenced SDK modules outside the gateway file."""
+    roots = set(sdk_modules)
+    violations: list[FenceViolation] = []
+    for directory in directories:
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.rglob("*.py")):
+            if path.name == allowed_filename:
+                continue
+            tree = ast.parse(path.read_text(), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    imported = [alias.name for alias in node.names]
+                elif isinstance(node, ast.ImportFrom):
+                    # Relative imports cannot reach an external SDK.
+                    if node.module is None or node.level > 0:
+                        continue
+                    imported = [node.module]
+                else:
+                    continue
+                for module in imported:
+                    if module.split(".")[0] in roots:
+                        violations.append(
+                            FenceViolation(
+                                file=str(path),
+                                line=node.lineno,
+                                module=module,
+                            )
+                        )
+    return violations

--- a/backend/tests/unit/onyx/connectors/test_source_operation_coverage.py
+++ b/backend/tests/unit/onyx/connectors/test_source_operation_coverage.py
@@ -1,10 +1,9 @@
 """Auto-discovering coverage harness for source operations.
 
-For every registered gateway, every (operation, variant) unit must be
-exercised, per capability tag, by a capability check of that capability --
-unless the operation carries an ``untested`` reason. A per-connector session
-that registers a gateway is picked up here automatically; it cannot forget to
-wire the test.
+For every registered gateway, every (operation, variant) unit must be exercised,
+per capability tag, by a capability check of that capability -- unless the
+operation carries an ``untested`` reason. A per-connector session that registers
+a gateway is picked up here automatically; it cannot forget to wire the test.
 """
 
 import pytest

--- a/backend/tests/unit/onyx/connectors/test_source_operation_coverage.py
+++ b/backend/tests/unit/onyx/connectors/test_source_operation_coverage.py
@@ -22,6 +22,7 @@ from tests.unit.onyx.connectors.source_operation_harnesses import (
 import_all_source_operation_gateways()
 
 
+@pytest.mark.usefixtures("enable_ee")
 @pytest.mark.parametrize(
     "gateway_class",
     list(registered_source_operations().values()),
@@ -30,7 +31,11 @@ import_all_source_operation_gateways()
 def test_every_operation_unit_is_exercised_by_a_check(
     gateway_class: type[SourceOperations],
 ) -> None:
-    """Verifies check coverage of every non-exempt (operation, variant) unit."""
+    """Verifies check coverage of every non-exempt (operation, variant) unit.
+
+    Runs with EE enabled: perm-sync checks live only in the EE registries, so
+    perm-sync-tagged units are coverable only when EE resolution is on.
+    """
     # Precondition.
     checks = get_capability_checks(gateway_class.source)
 
@@ -40,6 +45,7 @@ def test_every_operation_unit_is_exercised_by_a_check(
     # Postcondition.
     assert not uncovered, (
         f"{gateway_class.source.value} has operation units no capability "
-        f"check exercises: {uncovered}. Add a check composing them or "
-        'annotate the operation untested="<reason>".'
+        f"check exercises: {uncovered}. Add a check composing them "
+        '(variant-bearing operations must be invoked with variant="<name>") '
+        'or annotate the operation untested="<reason>".'
     )

--- a/backend/tests/unit/onyx/connectors/test_source_operation_coverage.py
+++ b/backend/tests/unit/onyx/connectors/test_source_operation_coverage.py
@@ -1,0 +1,45 @@
+"""Auto-discovering coverage harness for source operations.
+
+For every registered gateway, every (operation, variant) unit must be
+exercised, per capability tag, by a capability check of that capability --
+unless the operation carries an ``untested`` reason. A per-connector session
+that registers a gateway is picked up here automatically; it cannot forget to
+wire the test.
+"""
+
+import pytest
+
+from onyx.connectors.capability_checks.registry import get_capability_checks
+from onyx.connectors.source_operations import (
+    SourceOperations,
+    registered_source_operations,
+)
+from tests.unit.onyx.connectors.source_operation_harnesses import (
+    compute_uncovered_units,
+    import_all_source_operation_gateways,
+)
+
+import_all_source_operation_gateways()
+
+
+@pytest.mark.parametrize(
+    "gateway_class",
+    list(registered_source_operations().values()),
+    ids=lambda gateway_class: gateway_class.source.value,
+)
+def test_every_operation_unit_is_exercised_by_a_check(
+    gateway_class: type[SourceOperations],
+) -> None:
+    """Verifies check coverage of every non-exempt (operation, variant) unit."""
+    # Precondition.
+    checks = get_capability_checks(gateway_class.source)
+
+    # Under test.
+    uncovered = compute_uncovered_units(gateway_class, checks)
+
+    # Postcondition.
+    assert not uncovered, (
+        f"{gateway_class.source.value} has operation units no capability "
+        f"check exercises: {uncovered}. Add a check composing them or "
+        'annotate the operation untested="<reason>".'
+    )

--- a/backend/tests/unit/onyx/connectors/test_source_operation_harnesses.py
+++ b/backend/tests/unit/onyx/connectors/test_source_operation_harnesses.py
@@ -1,0 +1,232 @@
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors import source_operations as source_operations_module
+from onyx.connectors.capabilities import CredentialCapability
+from onyx.connectors.capability_checks.models import (
+    CapabilityCheck,
+    CapabilityCheckContext,
+)
+from onyx.connectors.source_operations import (
+    OperationConsumes,
+    SourceOperations,
+    source_operation,
+)
+from tests.unit.onyx.connectors.source_operation_harnesses import (
+    compute_uncovered_units,
+    find_import_fence_violations,
+)
+
+
+class _ScriptedCheck(CapabilityCheck):
+    """Concrete check that runs an injected script against the gateway."""
+
+    def __init__(
+        self,
+        capability: CredentialCapability,
+        check_id: str,
+        # The script receives the spy gateway; typed ``Any`` since the base
+        # ``SourceOperations`` knows nothing of per-gateway operations.
+        script: Callable[[Any], Any],
+    ) -> None:
+        super().__init__(
+            capability=capability,
+            check_id=check_id,
+            display_name="Scripted check",
+            requires_connector_instance=False,
+        )
+        self._script = script
+
+    def run(self, context: CapabilityCheckContext) -> None:
+        assert context.source_operations is not None, "The harness supplies a spy."
+        self._script(context.source_operations)
+
+
+@pytest.fixture
+def gateway_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> type[SourceOperations]:
+    """Builds an isolated synthetic gateway covering the metadata shapes."""
+    monkeypatch.setattr(source_operations_module, "_SOURCE_OPERATIONS_BY_SOURCE", {})
+
+    class _Gateway(SourceOperations):
+        source = DocumentSource.SLACK
+
+        @source_operation(
+            capabilities={CredentialCapability.INDEXING},
+            consumes=OperationConsumes.CREDENTIAL,
+            variants=("public", "private"),
+        )
+        def list_channels(self, *, variant: str | None = None) -> list[str]:
+            return [variant] if variant else []
+
+        @source_operation(
+            capabilities={
+                CredentialCapability.INDEXING,
+                CredentialCapability.DOC_PERMISSION_SYNC,
+            },
+            consumes=OperationConsumes.CREDENTIAL,
+        )
+        def fetch_history(self) -> list[str]:
+            return []
+
+        @source_operation(
+            capabilities={CredentialCapability.EXTERNAL_GROUP_SYNC},
+            consumes=OperationConsumes.NEITHER,
+            untested="Dormant by design.",
+        )
+        def list_usergroups(self) -> list[str]:
+            return []
+
+    return _Gateway
+
+
+def test_full_coverage_yields_no_uncovered_units(
+    gateway_class: type[SourceOperations],
+) -> None:
+    """Verifies a check suite exercising every unit satisfies the harness."""
+    # Precondition.
+    checks = [
+        _ScriptedCheck(
+            CredentialCapability.INDEXING,
+            "indexing_check",
+            lambda operations: (
+                operations.list_channels(variant="public"),
+                operations.list_channels(variant="private"),
+                operations.fetch_history(),
+            ),
+        ),
+        _ScriptedCheck(
+            CredentialCapability.DOC_PERMISSION_SYNC,
+            "perm_sync_check",
+            lambda operations: operations.fetch_history(),
+        ),
+    ]
+
+    # Under test and postcondition.
+    # ``list_usergroups`` is untested-exempt, so nothing is uncovered.
+    assert compute_uncovered_units(gateway_class, checks) == []
+
+
+def test_missing_variant_is_reported(
+    gateway_class: type[SourceOperations],
+) -> None:
+    """Verifies coverage is counted per variant, not per operation."""
+    # Precondition.
+    checks = [
+        _ScriptedCheck(
+            CredentialCapability.INDEXING,
+            "indexing_check",
+            lambda operations: (
+                operations.list_channels(variant="public"),
+                operations.fetch_history(),
+            ),
+        ),
+        _ScriptedCheck(
+            CredentialCapability.DOC_PERMISSION_SYNC,
+            "perm_sync_check",
+            lambda operations: operations.fetch_history(),
+        ),
+    ]
+
+    # Under test.
+    uncovered = compute_uncovered_units(gateway_class, checks)
+
+    # Postcondition.
+    assert [(unit.operation, unit.variant, unit.capability) for unit in uncovered] == [
+        ("list_channels", "private", CredentialCapability.INDEXING)
+    ]
+
+
+def test_coverage_is_attributed_per_capability_tag(
+    gateway_class: type[SourceOperations],
+) -> None:
+    """
+    Verifies an operation serving two capabilities needs a check of each: an
+    INDEXING-only suite leaves the DOC_PERMISSION_SYNC tag uncovered.
+    """
+    # Precondition.
+    checks = [
+        _ScriptedCheck(
+            CredentialCapability.INDEXING,
+            "indexing_check",
+            lambda operations: (
+                operations.list_channels(variant="public"),
+                operations.list_channels(variant="private"),
+                operations.fetch_history(),
+            ),
+        ),
+    ]
+
+    # Under test.
+    uncovered = compute_uncovered_units(gateway_class, checks)
+
+    # Postcondition.
+    assert [(unit.operation, unit.capability) for unit in uncovered] == [
+        ("fetch_history", CredentialCapability.DOC_PERMISSION_SYNC)
+    ]
+
+
+def test_raising_check_still_counts_its_calls(
+    gateway_class: type[SourceOperations],
+) -> None:
+    """Verifies calls recorded before a check fails on mock data still count."""
+
+    # Precondition.
+    def failing_script(operations: Any) -> None:
+        operations.list_channels(variant="public")
+        operations.list_channels(variant="private")
+        operations.fetch_history()
+        raise RuntimeError("Mock data never satisfies the probe.")
+
+    checks = [
+        _ScriptedCheck(CredentialCapability.INDEXING, "indexing_check", failing_script),
+        _ScriptedCheck(
+            CredentialCapability.DOC_PERMISSION_SYNC,
+            "perm_sync_check",
+            lambda operations: operations.fetch_history(),
+        ),
+    ]
+
+    # Under test and postcondition.
+    assert compute_uncovered_units(gateway_class, checks) == []
+
+
+def test_fence_finder_flags_imports_outside_the_gateway(tmp_path: Path) -> None:
+    """Verifies SDK imports are flagged everywhere except the gateway file."""
+    # Precondition.
+    (tmp_path / "source_operations.py").write_text(
+        "import slack_sdk\nfrom slack_sdk.web import WebClient\n"
+    )
+    (tmp_path / "utils.py").write_text(
+        "import json\nfrom slack_sdk.web import WebClient\n"
+    )
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "helpers.py").write_text("import slack_sdk.errors\n")
+    (tmp_path / "clean.py").write_text("from . import utils\nimport requests\n")
+
+    # Under test.
+    violations = find_import_fence_violations([tmp_path], ("slack_sdk",))
+
+    # Postcondition.
+    assert [
+        (Path(violation.file).name, violation.line, violation.module)
+        for violation in violations
+    ] == [
+        ("helpers.py", 1, "slack_sdk.errors"),
+        ("utils.py", 2, "slack_sdk.web"),
+    ]
+
+
+def test_fence_finder_ignores_missing_directories() -> None:
+    """Verifies sources without an EE perm-sync directory scan cleanly."""
+    # Under test and postcondition.
+    assert (
+        find_import_fence_violations([Path("/nonexistent/for/sure")], ("slack_sdk",))
+        == []
+    )

--- a/backend/tests/unit/onyx/connectors/test_source_operation_harnesses.py
+++ b/backend/tests/unit/onyx/connectors/test_source_operation_harnesses.py
@@ -204,8 +204,8 @@ def test_mis_shaped_calls_do_not_count_as_coverage(
     gateway_class: type[SourceOperations],
 ) -> None:
     """
-    Verifies the spy enforces real operation signatures: a call the real
-    gateway would reject records nothing and cannot certify coverage.
+    Verifies the spy enforces real operation signatures: a call the real gateway
+    would reject records nothing and cannot certify coverage.
     """
 
     # Precondition.

--- a/backend/tests/unit/onyx/connectors/test_source_operation_harnesses.py
+++ b/backend/tests/unit/onyx/connectors/test_source_operation_harnesses.py
@@ -4,13 +4,16 @@ from typing import Any
 
 import pytest
 
+from ee.onyx.connectors import capability_checks as ee_capability_checks
 from onyx.configs.constants import DocumentSource
 from onyx.connectors import source_operations as source_operations_module
 from onyx.connectors.capabilities import CredentialCapability
+from onyx.connectors.capability_checks import registry
 from onyx.connectors.capability_checks.models import (
     CapabilityCheck,
     CapabilityCheckContext,
 )
+from onyx.connectors.capability_checks.registry import get_capability_checks
 from onyx.connectors.source_operations import (
     OperationConsumes,
     SourceOperations,
@@ -55,6 +58,7 @@ def gateway_class(
 
     class _Gateway(SourceOperations):
         source = DocumentSource.SLACK
+        sdk_modules = ()
 
         @source_operation(
             capabilities={CredentialCapability.INDEXING},
@@ -196,12 +200,56 @@ def test_raising_check_still_counts_its_calls(
     assert compute_uncovered_units(gateway_class, checks) == []
 
 
+@pytest.mark.usefixtures("enable_ee")
+def test_coverage_pipeline_sees_ee_perm_sync_checks(
+    gateway_class: type[SourceOperations],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Verifies the real check-fetch path resolves EE checks under ``enable_ee``:
+    perm-sync-tagged units are coverable only by EE-registered checks, so a
+    coverage run without EE resolution would report them uncovered.
+    """
+    # Precondition.
+    monkeypatch.setitem(
+        registry._INDEXING_CHECKS_BY_SOURCE,
+        gateway_class.source,
+        [
+            _ScriptedCheck(
+                CredentialCapability.INDEXING,
+                "indexing_check",
+                lambda operations: (
+                    operations.list_channels(variant="public"),
+                    operations.list_channels(variant="private"),
+                    operations.fetch_history(),
+                ),
+            )
+        ],
+    )
+    monkeypatch.setitem(
+        ee_capability_checks._DOC_PERMISSION_SYNC_CHECKS_BY_SOURCE,
+        gateway_class.source,
+        [
+            _ScriptedCheck(
+                CredentialCapability.DOC_PERMISSION_SYNC,
+                "perm_sync_check",
+                lambda operations: operations.fetch_history(),
+            )
+        ],
+    )
+
+    # Under test.
+    checks = get_capability_checks(gateway_class.source)
+
+    # Postcondition.
+    assert compute_uncovered_units(gateway_class, checks) == []
+
+
 def test_fence_finder_flags_imports_outside_the_gateway(tmp_path: Path) -> None:
     """Verifies SDK imports are flagged everywhere except the gateway file."""
     # Precondition.
-    (tmp_path / "source_operations.py").write_text(
-        "import slack_sdk\nfrom slack_sdk.web import WebClient\n"
-    )
+    gateway_file = tmp_path / "source_operations.py"
+    gateway_file.write_text("import slack_sdk\nfrom slack_sdk.web import WebClient\n")
     (tmp_path / "utils.py").write_text(
         "import json\nfrom slack_sdk.web import WebClient\n"
     )
@@ -211,7 +259,9 @@ def test_fence_finder_flags_imports_outside_the_gateway(tmp_path: Path) -> None:
     (tmp_path / "clean.py").write_text("from . import utils\nimport requests\n")
 
     # Under test.
-    violations = find_import_fence_violations([tmp_path], ("slack_sdk",))
+    violations = find_import_fence_violations(
+        [tmp_path], ("slack_sdk",), allowed_file=gateway_file
+    )
 
     # Postcondition.
     assert [
@@ -223,10 +273,41 @@ def test_fence_finder_flags_imports_outside_the_gateway(tmp_path: Path) -> None:
     ]
 
 
-def test_fence_finder_ignores_missing_directories() -> None:
+def test_fence_exempts_the_exact_gateway_file_not_its_basename(
+    tmp_path: Path,
+) -> None:
+    """
+    Verifies a file merely sharing the gateway basename (in the EE tree or
+    nested) is scanned like any other.
+    """
+    # Precondition.
+    oss_dir = tmp_path / "oss"
+    ee_dir = tmp_path / "ee"
+    oss_dir.mkdir()
+    ee_dir.mkdir()
+    gateway_file = oss_dir / "source_operations.py"
+    gateway_file.write_text("import slack_sdk\n")
+    (ee_dir / "source_operations.py").write_text("import slack_sdk\n")
+
+    # Under test.
+    violations = find_import_fence_violations(
+        [oss_dir, ee_dir], ("slack_sdk",), allowed_file=gateway_file
+    )
+
+    # Postcondition.
+    assert [
+        (Path(violation.file).parent.name, violation.module) for violation in violations
+    ] == [("ee", "slack_sdk")]
+
+
+def test_fence_finder_ignores_missing_directories(tmp_path: Path) -> None:
     """Verifies sources without an EE perm-sync directory scan cleanly."""
     # Under test and postcondition.
     assert (
-        find_import_fence_violations([Path("/nonexistent/for/sure")], ("slack_sdk",))
+        find_import_fence_violations(
+            [Path("/nonexistent/for/sure")],
+            ("slack_sdk",),
+            allowed_file=tmp_path / "source_operations.py",
+        )
         == []
     )

--- a/backend/tests/unit/onyx/connectors/test_source_operation_harnesses.py
+++ b/backend/tests/unit/onyx/connectors/test_source_operation_harnesses.py
@@ -200,6 +200,42 @@ def test_raising_check_still_counts_its_calls(
     assert compute_uncovered_units(gateway_class, checks) == []
 
 
+def test_mis_shaped_calls_do_not_count_as_coverage(
+    gateway_class: type[SourceOperations],
+) -> None:
+    """
+    Verifies the spy enforces real operation signatures: a call the real
+    gateway would reject records nothing and cannot certify coverage.
+    """
+
+    # Precondition.
+    # ``fetch_history`` takes no arguments beyond ``self``; the indexing check
+    # calls it with one, which the autospecced spy rejects unrecorded.
+    def mis_shaped_script(operations: Any) -> None:
+        operations.list_channels(variant="public")
+        operations.list_channels(variant="private")
+        operations.fetch_history("argument_the_operation_does_not_take")
+
+    checks = [
+        _ScriptedCheck(
+            CredentialCapability.INDEXING, "indexing_check", mis_shaped_script
+        ),
+        _ScriptedCheck(
+            CredentialCapability.DOC_PERMISSION_SYNC,
+            "perm_sync_check",
+            lambda operations: operations.fetch_history(),
+        ),
+    ]
+
+    # Under test.
+    uncovered = compute_uncovered_units(gateway_class, checks)
+
+    # Postcondition.
+    assert [(unit.operation, unit.capability) for unit in uncovered] == [
+        ("fetch_history", CredentialCapability.INDEXING)
+    ]
+
+
 @pytest.mark.usefixtures("enable_ee")
 def test_coverage_pipeline_sees_ee_perm_sync_checks(
     gateway_class: type[SourceOperations],

--- a/backend/tests/unit/onyx/connectors/test_source_operation_import_fence.py
+++ b/backend/tests/unit/onyx/connectors/test_source_operation_import_fence.py
@@ -14,8 +14,8 @@ from onyx.connectors.source_operations import (
     registered_source_operations,
 )
 from tests.unit.onyx.connectors.source_operation_harnesses import (
-    fence_directories_for_source,
     find_import_fence_violations,
+    gateway_fence_paths,
     import_all_source_operation_gateways,
 )
 
@@ -36,9 +36,11 @@ def test_sdk_imports_stay_inside_the_gateway(
 ) -> None:
     """Verifies the source SDK is imported only from the gateway file."""
     # Under test.
+    gateway_file, directories = gateway_fence_paths(gateway_class)
     violations = find_import_fence_violations(
-        fence_directories_for_source(gateway_class.source.value),
+        directories,
         gateway_class.sdk_modules,
+        allowed_file=gateway_file,
     )
 
     # Postcondition.

--- a/backend/tests/unit/onyx/connectors/test_source_operation_import_fence.py
+++ b/backend/tests/unit/onyx/connectors/test_source_operation_import_fence.py
@@ -1,0 +1,48 @@
+"""Auto-discovering import fence for source operations.
+
+For every registered gateway declaring ``sdk_modules``, the source SDK may be
+imported only from the gateway's own file within the connector's OSS directory
+and its EE perm-sync directory. Every existing wrapper precedent in the
+codebase has bypasses; the fence is what keeps the gateway boundary from
+decaying the same way.
+"""
+
+import pytest
+
+from onyx.connectors.source_operations import (
+    SourceOperations,
+    registered_source_operations,
+)
+from tests.unit.onyx.connectors.source_operation_harnesses import (
+    fence_directories_for_source,
+    find_import_fence_violations,
+    import_all_source_operation_gateways,
+)
+
+import_all_source_operation_gateways()
+
+
+@pytest.mark.parametrize(
+    "gateway_class",
+    [
+        gateway_class
+        for gateway_class in registered_source_operations().values()
+        if gateway_class.sdk_modules
+    ],
+    ids=lambda gateway_class: gateway_class.source.value,
+)
+def test_sdk_imports_stay_inside_the_gateway(
+    gateway_class: type[SourceOperations],
+) -> None:
+    """Verifies the source SDK is imported only from the gateway file."""
+    # Under test.
+    violations = find_import_fence_violations(
+        fence_directories_for_source(gateway_class.source.value),
+        gateway_class.sdk_modules,
+    )
+
+    # Postcondition.
+    assert not violations, (
+        f"{gateway_class.source.value} imports its SDK outside the gateway: "
+        f"{violations}. Route the calls through source operations."
+    )

--- a/backend/tests/unit/onyx/connectors/test_source_operation_import_fence.py
+++ b/backend/tests/unit/onyx/connectors/test_source_operation_import_fence.py
@@ -2,9 +2,8 @@
 
 For every registered gateway declaring ``sdk_modules``, the source SDK may be
 imported only from the gateway's own file within the connector's OSS directory
-and its EE perm-sync directory. Every existing wrapper precedent in the
-codebase has bypasses; the fence is what keeps the gateway boundary from
-decaying the same way.
+and its EE perm-sync directory. This is what keeps the gateway boundary from
+decaying over time.
 """
 
 import pytest

--- a/backend/tests/unit/onyx/connectors/test_source_operations.py
+++ b/backend/tests/unit/onyx/connectors/test_source_operations.py
@@ -141,6 +141,31 @@ def test_missing_sdk_modules_declaration_fails_at_import() -> None:
 
 
 @pytest.mark.usefixtures("isolated_registry")
+def test_non_tuple_sdk_modules_fails_at_import() -> None:
+    """
+    Verifies a plain-string ``sdk_modules`` is rejected: as a collection of
+    single characters it would silently unfence the gateway.
+    """
+    # Under test and postcondition.
+    with pytest.raises(TypeError, match="tuple of non-empty"):
+
+        class _StringSdkOperations(SourceOperations):
+            source = DocumentSource.GITHUB
+            sdk_modules = "github"  # type: ignore[assignment]
+
+
+@pytest.mark.usefixtures("isolated_registry")
+def test_blank_sdk_module_root_fails_at_import() -> None:
+    """Verifies empty module roots cannot slip into the fence."""
+    # Under test and postcondition.
+    with pytest.raises(TypeError, match="tuple of non-empty"):
+
+        class _BlankSdkOperations(SourceOperations):
+            source = DocumentSource.GITHUB
+            sdk_modules = ("github", "")
+
+
+@pytest.mark.usefixtures("isolated_registry")
 def test_duplicate_source_registration_fails() -> None:
     """Verifies the one-gateway-per-source rule."""
 
@@ -220,6 +245,7 @@ def test_public_non_callable_descriptor_is_rejected() -> None:
 
         class _CachedPropertyOperations(SourceOperations):
             source = DocumentSource.SLACK
+            sdk_modules = ()
 
             @cached_property
             def team_id(self) -> str:
@@ -306,6 +332,7 @@ def test_decorator_snapshots_capabilities_at_factory_time() -> None:
     # Under test.
     class _SnapshotOperations(SourceOperations):
         source = DocumentSource.SLACK
+        sdk_modules = ()
 
         @decorator
         def probe(self) -> None:

--- a/backend/tests/unit/onyx/connectors/test_source_operations.py
+++ b/backend/tests/unit/onyx/connectors/test_source_operations.py
@@ -380,8 +380,8 @@ def test_decorator_rejects_blank_variant_names() -> None:
 @pytest.mark.usefixtures("isolated_registry")
 def test_variant_bearing_operation_requires_a_declared_variant() -> None:
     """
-    Verifies calls to a variant-bearing operation must classify themselves
-    with ``variant=`` so coverage attribution reflects real call sites.
+    Verifies calls to a variant-bearing operation must classify themselves with
+    ``variant=`` so coverage attribution reflects real call sites.
     """
 
     # Precondition.

--- a/backend/tests/unit/onyx/connectors/test_source_operations.py
+++ b/backend/tests/unit/onyx/connectors/test_source_operations.py
@@ -327,3 +327,56 @@ def test_decorator_rejects_blank_variant_names() -> None:
             consumes=OperationConsumes.CREDENTIAL,
             variants=("public", ""),
         )
+
+
+@pytest.mark.usefixtures("isolated_registry")
+def test_variant_bearing_operation_requires_a_declared_variant() -> None:
+    """
+    Verifies calls to a variant-bearing operation must classify themselves
+    with ``variant=`` so coverage attribution reflects real call sites.
+    """
+
+    # Precondition.
+    class _VariantOperations(SourceOperations):
+        source = DocumentSource.SLACK
+
+        @source_operation(
+            capabilities={CredentialCapability.INDEXING},
+            consumes=OperationConsumes.CREDENTIAL,
+            variants=("public", "private"),
+        )
+        def list_channels(self, *, variant: str | None = None) -> str | None:
+            return variant
+
+    gateway = _VariantOperations()
+
+    # Under test and postcondition.
+    assert gateway.list_channels(variant="public") == "public"
+    with pytest.raises(TypeError, match="declares variants"):
+        gateway.list_channels(variant="bogus")
+    with pytest.raises(TypeError, match="declares variants"):
+        gateway.list_channels()
+    # The wrap preserves the stamped spec.
+    assert _VariantOperations.operation_specs()["list_channels"].variants == (
+        "public",
+        "private",
+    )
+
+
+@pytest.mark.usefixtures("isolated_registry")
+def test_variantless_operation_is_not_wrapped() -> None:
+    """Verifies operations without variants keep their bare call shape."""
+
+    # Precondition.
+    class _PlainOperations(SourceOperations):
+        source = DocumentSource.SLACK
+
+        @source_operation(
+            capabilities={CredentialCapability.INDEXING},
+            consumes=OperationConsumes.CREDENTIAL,
+        )
+        def fetch_history(self) -> str:
+            return "history"
+
+    # Under test and postcondition.
+    assert _PlainOperations().fetch_history() == "history"

--- a/backend/tests/unit/onyx/connectors/test_source_operations.py
+++ b/backend/tests/unit/onyx/connectors/test_source_operations.py
@@ -27,6 +27,7 @@ def test_gateway_registers_and_collects_specs() -> None:
     # Precondition and under test (registration fires at class creation).
     class _SlackOperations(SourceOperations):
         source = DocumentSource.SLACK
+        sdk_modules = ()
 
         @source_operation(
             capabilities={CredentialCapability.INDEXING},
@@ -66,6 +67,7 @@ def test_unstamped_public_method_fails_at_import() -> None:
 
         class _LeakyOperations(SourceOperations):
             source = DocumentSource.SLACK
+            sdk_modules = ()
 
             def fetch_page(self) -> None:
                 return None
@@ -119,11 +121,22 @@ def test_gateway_inheritance_is_rejected() -> None:
     # Precondition.
     class _SlackOperations(SourceOperations):
         source = DocumentSource.SLACK
+        sdk_modules = ()
 
     # Under test and postcondition.
     with pytest.raises(TypeError, match="directly and nothing else"):
 
         class _SlackCloudOperations(_SlackOperations):
+            source = DocumentSource.GITHUB
+
+
+@pytest.mark.usefixtures("isolated_registry")
+def test_missing_sdk_modules_declaration_fails_at_import() -> None:
+    """Verifies the import fence cannot be skipped by omission."""
+    # Under test and postcondition.
+    with pytest.raises(TypeError, match="must declare ``sdk_modules``"):
+
+        class _UndeclaredOperations(SourceOperations):
             source = DocumentSource.GITHUB
 
 
@@ -134,12 +147,14 @@ def test_duplicate_source_registration_fails() -> None:
     # Precondition.
     class _FirstOperations(SourceOperations):
         source = DocumentSource.SLACK
+        sdk_modules = ()
 
     # Under test and postcondition.
     with pytest.raises(TypeError, match="already registered by _FirstOperations"):
 
         class _SecondOperations(SourceOperations):
             source = DocumentSource.SLACK
+            sdk_modules = ()
 
 
 @pytest.mark.usefixtures("isolated_registry")
@@ -149,6 +164,7 @@ def test_private_helpers_and_data_attrs_are_allowed() -> None:
     # Under test.
     class _TidyOperations(SourceOperations):
         source = DocumentSource.SLACK
+        sdk_modules = ()
         docs_link = "https://docs.onyx.app/connectors/slack"
 
         def _build_client(self) -> None:
@@ -170,6 +186,7 @@ def test_public_staticmethod_is_rejected() -> None:
 
         class _StaticOperations(SourceOperations):
             source = DocumentSource.SLACK
+            sdk_modules = ()
 
             @staticmethod
             def build_client() -> None:
@@ -184,6 +201,7 @@ def test_public_property_is_rejected() -> None:
 
         class _PropertyOperations(SourceOperations):
             source = DocumentSource.SLACK
+            sdk_modules = ()
 
             @property
             def team_id(self) -> str:
@@ -216,6 +234,7 @@ def test_public_classmethod_is_rejected() -> None:
 
         class _ClassmethodOperations(SourceOperations):
             source = DocumentSource.SLACK
+            sdk_modules = ()
 
             @classmethod
             def build_client(cls) -> None:
@@ -230,6 +249,7 @@ def test_public_nested_class_is_rejected() -> None:
 
         class _NestedModelOperations(SourceOperations):
             source = DocumentSource.SLACK
+            sdk_modules = ()
 
             class Channel:
                 pass
@@ -253,6 +273,7 @@ def test_aliased_operation_assignment_is_rejected() -> None:
 
         class _AliasedOperations(SourceOperations):
             source = DocumentSource.SLACK
+            sdk_modules = ()
             list_a = stamped
 
 
@@ -339,6 +360,7 @@ def test_variant_bearing_operation_requires_a_declared_variant() -> None:
     # Precondition.
     class _VariantOperations(SourceOperations):
         source = DocumentSource.SLACK
+        sdk_modules = ()
 
         @source_operation(
             capabilities={CredentialCapability.INDEXING},
@@ -370,6 +392,7 @@ def test_variantless_operation_is_not_wrapped() -> None:
     # Precondition.
     class _PlainOperations(SourceOperations):
         source = DocumentSource.SLACK
+        sdk_modules = ()
 
         @source_operation(
             capabilities={CredentialCapability.INDEXING},


### PR DESCRIPTION
## Description

Wires the source-operations gateway (previous PR #13707) into the capability-check framework and adds the enforcement harnesses that make it drift-proof. No production call sites yet.

- `CapabilityCheckContext` gains a `source_operations` field so migrated checks compose gateway operations; `CredentialCapability` moves to a leaf module (`onyx/connectors/capabilities.py`) to break the resulting import cycle, with all existing import paths unchanged.
- Ratchet: registering named capability checks (OSS INDEXING or EE perm-sync) for a source now requires a registered gateway; participation in the checks system is the drift guarantee. Fallback paths are unaffected.
- Coverage harness: auto-discovers registered gateways, runs each source's checks against a spy gateway, and fails on any (operation, variant, capability) unit not exercised by a check of that capability, unless the operation is annotated untested="<reason>".
- Import fence harness: per gateway-declared sdk_modules, asserts the source SDK is imported only from the gateway file within the connector's OSS and EE perm-sync directories.
- Variant convention: variant-bearing operations must be called with variant="<name>"; enforced at runtime on real gateways and used by the coverage harness for attribution, so per-variant coverage claims reflect real call sites.

Both harnesses collect empty (skip) until the first gateway registers.

## How Has This Been Tested?

Added automated testing.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires `source_operations` into capability checks and enforces gateway boundaries with an auto-discovered coverage harness and SDK import fence. Adds a ratchet so named checks require a registered gateway; fallbacks remain for unmigrated sources.

- **New Features**
  - `CapabilityCheckContext` now includes `source_operations`; migrated checks compose gateway ops, with connector instances kept for fallback.
  - Ratchet: named INDEXING and EE perm-sync checks assert a registered gateway for that source.
  - Coverage harness: auto-imports gateway modules, asserts each defines a registered gateway, and flags any unexercised (operation, variant, capability) unit unless `untested="<reason>"`; variant-bearing ops must be called with `variant="<name>"` and are runtime-enforced.
  - Import fence: gateways declare `sdk_modules`; the source SDK may be imported only from the gateway file in the connector’s OSS and EE perm-sync dirs; declaration is validated as a tuple of non-empty roots.
  - Moved `CredentialCapability` to leaf module `onyx.connectors.capabilities` to avoid import cycles.

- **Migration**
  - Register a gateway before adding named checks for a source.
  - Declare `sdk_modules` on every `SourceOperations` subclass (use `()` for SDK-less connectors).
  - Update call sites: pass `variant="<name>"` when invoking variant-bearing operations.

<sup>Written for commit c36d1e77e02d6c2d6a5ee656b995b9c6a0db39b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

