### PR TITLE
feat(craft): add webapp bootstrap script generator and tool assets

### DIFF
--- a/backend/onyx/server/features/build/sandbox/image/opencode-plugins/webapp.ts
+++ b/backend/onyx/server/features/build/sandbox/image/opencode-plugins/webapp.ts
@@ -72,8 +72,6 @@ async function pidAlive(dir: string): Promise<number | null> {
   }
 }
 
-// fetch() doesn't honor HTTP_PROXY/HTTPS_PROXY, which is exactly what we want
-// here: this is a loopback probe and must bypass the egress proxy.
 async function probeRunning(port: number): Promise<boolean> {
   try {
     await fetch(`http://127.0.0.1:${port}/`, {
@@ -83,10 +81,6 @@ async function probeRunning(port: number): Promise<boolean> {
   } catch {
     return false;
   }
-}
-
-async function scaffolded(dir: string): Promise<boolean> {
-  return pathExists(`${dir}/${APP_DIR_REL}/package.json`);
 }
 
 async function tailLog(dir: string, n: number): Promise<string | null> {
@@ -113,7 +107,7 @@ async function buildObservation(
   const pid = await pidAlive(dir);
   const running = pid !== null && port !== null && (await probeRunning(port));
   const state: Observation["state"] = running ? "running" : "not_running";
-  const isScaffolded = await scaffolded(dir);
+  const isScaffolded = await pathExists(`${dir}/${APP_DIR_REL}/package.json`);
 
   const lines = [
     `state: ${state}`,
@@ -134,17 +128,14 @@ async function buildObservation(
   return { state, port, text: lines.join("\n") };
 }
 
-function shQuote(s: string): string {
-  return `'${s.replace(/'/g, `'\\''`)}'`;
-}
-
 function runScript(
   dir: string,
   scriptPath: string,
   abort: AbortSignal
 ): Promise<{ exitCode: number; output: string }> {
   return new Promise((resolve) => {
-    const child = spawn("bash", ["-c", `bash ${shQuote(scriptPath)} 2>&1`], {
+    const quotedPath = `'${scriptPath.replace(/'/g, `'\\''`)}'`;
+    const child = spawn("bash", ["-c", `bash ${quotedPath} 2>&1`], {
       cwd: dir,
       signal: abort,
     });

--- a/backend/onyx/server/features/build/sandbox/image/opencode-plugins/webapp.ts
+++ b/backend/onyx/server/features/build/sandbox/image/opencode-plugins/webapp.ts
@@ -1,0 +1,353 @@
+// Manages this session's Next.js dev server (started via start-webapp.sh).
+// Failures are returned as observations, never thrown; a thrown tool error
+// would abort the agent's turn instead of letting it recover.
+//
+// Module resolution: this file lives in /workspace/opencode-plugins, which
+// has no node_modules, so a bare runtime `import` of the SDK can't resolve.
+// The type import is erased; the `tool` helper is loaded at runtime by
+// absolute path from opencode's bundled SDK (same approach as connect-app.ts).
+
+import type { Plugin } from "@opencode-ai/plugin";
+import type { tool as ToolFactory } from "@opencode-ai/plugin/tool";
+import { spawn } from "node:child_process";
+import { constants as fsConstants } from "node:fs";
+import { access, chmod, readFile, unlink, writeFile } from "node:fs/promises";
+
+const SDK_TOOL_PATHS = [
+  "/home/sandbox/.opencode/node_modules/@opencode-ai/plugin/dist/tool.js",
+  "/home/sandbox/.config/opencode/node_modules/@opencode-ai/plugin/dist/tool.js",
+];
+
+async function loadToolFactory(): Promise<typeof ToolFactory> {
+  for (const path of SDK_TOOL_PATHS) {
+    try {
+      return (await import(path)).tool;
+    } catch {
+      continue;
+    }
+  }
+  throw new Error("could not resolve the @opencode-ai/plugin tool helper");
+}
+
+const CANONICAL_REL = ".webapp/start-webapp.sh";
+const VISIBLE_REL = "start-webapp.sh";
+const PID_REL = "nextjs.pid";
+const LOG_REL = "nextjs.log";
+const APP_DIR_REL = "outputs/web";
+
+const DEFAULT_ACTION_LOG_LINES = 10;
+const DEFAULT_LOGS_LINES = 30;
+const MAX_LOG_LINES = 200;
+const START_TIMEOUT_MS = 150_000;
+const MAX_OUTPUT_BYTES = 8 * 1024;
+const PROBE_TIMEOUT_MS = 2000;
+
+interface ResolvedScript {
+  path: string;
+  restored: boolean;
+  restoreError?: string;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// The visible-copy-only fallback exists for legacy sessions that predate the
+// canonical copy; don't remove it as dead code.
+async function resolveScript(dir: string): Promise<ResolvedScript | null> {
+  const canonicalPath = `${dir}/${CANONICAL_REL}`;
+  const visiblePath = `${dir}/${VISIBLE_REL}`;
+
+  if (!(await pathExists(canonicalPath))) {
+    if (await pathExists(visiblePath)) {
+      return { path: visiblePath, restored: false };
+    }
+    return null;
+  }
+
+  const canonicalText = await readFile(canonicalPath, "utf8");
+  const visibleText = (await pathExists(visiblePath))
+    ? await readFile(visiblePath, "utf8")
+    : null;
+
+  if (visibleText === canonicalText) {
+    return { path: canonicalPath, restored: false };
+  }
+
+  try {
+    // The visible copy is chmod 444: overwriting in place EACCESes, but
+    // unlink only needs directory write permission.
+    await unlink(visiblePath).catch(() => {});
+    await writeFile(visiblePath, canonicalText, "utf8");
+    await chmod(visiblePath, 0o444);
+    return { path: canonicalPath, restored: true };
+  } catch (e) {
+    return {
+      path: canonicalPath,
+      restored: false,
+      restoreError:
+        "could not restore start-webapp.sh (continuing with the protected " +
+        `copy): ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+}
+
+function parsePort(scriptText: string): number | null {
+  const match = scriptText.match(/^PORT=(\d+)$/m);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+async function pidAlive(dir: string): Promise<number | null> {
+  const pidPath = `${dir}/${PID_REL}`;
+  if (!(await pathExists(pidPath))) return null;
+  const pid = parseInt((await readFile(pidPath, "utf8")).trim(), 10);
+  if (!Number.isFinite(pid)) return null;
+  try {
+    process.kill(pid, 0); // signal 0: existence check only, no actual kill
+    return pid;
+  } catch {
+    return null;
+  }
+}
+
+// fetch() doesn't honor HTTP_PROXY/HTTPS_PROXY, which is exactly what we want
+// here: this is a loopback probe and must bypass the egress proxy.
+async function probeRunning(port: number): Promise<boolean> {
+  try {
+    await fetch(`http://127.0.0.1:${port}/`, {
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function scaffolded(dir: string): Promise<boolean> {
+  return pathExists(`${dir}/${APP_DIR_REL}/package.json`);
+}
+
+async function tailLog(dir: string, n: number): Promise<string | null> {
+  const logPath = `${dir}/${LOG_REL}`;
+  if (!(await pathExists(logPath))) return null;
+  const lines = (await readFile(logPath, "utf8")).split("\n");
+  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+  return lines.slice(-n).join("\n");
+}
+
+interface Observation {
+  state: "running" | "not_running";
+  port: number | null;
+  text: string;
+}
+
+async function buildObservation(
+  dir: string,
+  script: ResolvedScript,
+  logLines: number
+): Promise<Observation> {
+  const scriptText = await readFile(script.path, "utf8");
+  const port = parsePort(scriptText);
+  const pid = await pidAlive(dir);
+  const running = pid !== null && port !== null && (await probeRunning(port));
+  const state: Observation["state"] = running ? "running" : "not_running";
+  const isScaffolded = await scaffolded(dir);
+
+  const lines = [
+    `state: ${state}`,
+    port !== null
+      ? `port: ${port}`
+      : "port: unknown (could not parse PORT from start-webapp.sh)",
+    `app dir: ${APP_DIR_REL}`,
+    `scaffolded: ${isScaffolded ? "yes" : "no"}`,
+    `logs: ${LOG_REL}`,
+  ];
+
+  const cappedLines = Math.min(logLines, MAX_LOG_LINES);
+  const tail = await tailLog(dir, cappedLines);
+  if (tail) {
+    lines.push(`--- last ${cappedLines} lines of ${LOG_REL} ---`, tail);
+  }
+
+  return { state, port, text: lines.join("\n") };
+}
+
+function shQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+function runScript(
+  dir: string,
+  scriptPath: string,
+  abort: AbortSignal
+): Promise<{ exitCode: number; output: string }> {
+  return new Promise((resolve) => {
+    // 2>&1 in the shell keeps stdout/stderr interleaved in print order.
+    const child = spawn("bash", ["-c", `bash ${shQuote(scriptPath)} 2>&1`], {
+      cwd: dir,
+      signal: abort,
+    });
+
+    let output = "";
+    child.stdout?.on("data", (chunk: Buffer) => {
+      output += chunk.toString("utf8");
+    });
+
+    const timeoutId = setTimeout(() => child.kill(), START_TIMEOUT_MS);
+    const finish = (exitCode: number) => {
+      clearTimeout(timeoutId);
+      if (output.length > MAX_OUTPUT_BYTES) {
+        output = output.slice(-MAX_OUTPUT_BYTES);
+      }
+      resolve({ exitCode, output });
+    };
+
+    child.on("close", (code) => finish(code ?? 1));
+    child.on("error", () => finish(1));
+  });
+}
+
+const UNAVAILABLE_OBSERVATION =
+  "state: unavailable\n" +
+  "this session has no web-app support (headless session) or the bootstrap " +
+  "script was deleted; reopen the session to regenerate it; never run " +
+  "`bun run dev` yourself.";
+
+export const Webapp: Plugin = async () => {
+  const tool = await loadToolFactory();
+
+  return {
+    tool: {
+      webapp: tool({
+        description:
+          "Manage this session's web-app dev server. Call with action='start' " +
+          "BEFORE building a web app: it scaffolds outputs/web, installs " +
+          "dependencies, starts the dev server, and waits until it serves. " +
+          "SAFE TO CALL REPEATEDLY: it reconciles current state (already " +
+          "running = success, crashed = restarted). Use action='status' or " +
+          "'logs' to diagnose problems, and action='restart' if the server is " +
+          "up but misbehaving. NEVER run `bun run dev` or start your own " +
+          "server; the preview proxy only routes to the port this tool manages.",
+        args: {
+          action: tool.schema
+            .enum(["start", "status", "logs", "restart"])
+            .describe(
+              "start: scaffold/install/start the dev server and wait for it " +
+                "to become ready (idempotent - safe even if already running). " +
+                "status: report whether the server is running, without " +
+                "starting anything. logs: show a larger log tail for " +
+                "debugging. restart: stop the current server (if any) and " +
+                "start it again - use when it's up but misbehaving."
+            ),
+          lines: tool.schema
+            .number()
+            .optional()
+            .describe(
+              "Log lines to include, default 30, max 200 - only meaningful " +
+                "for action='logs'."
+            ),
+        },
+        async execute(args, context) {
+          const dir = context.directory;
+          const titles: Record<string, string> = {
+            start: "Starting web app…",
+            restart: "Restarting web app…",
+            status: "Checking web app status…",
+            logs: "Reading web app logs…",
+          };
+          context.metadata({ title: titles[args.action] });
+
+          const script = await resolveScript(dir);
+          if (!script) {
+            return UNAVAILABLE_OBSERVATION;
+          }
+          const restoredNote = script.restoreError
+            ? `${script.restoreError}\n\n`
+            : script.restored
+              ? "restored start-webapp.sh (visible copy was missing or modified)\n\n"
+              : "";
+
+          if (args.action === "status") {
+            const obs = await buildObservation(dir, script, DEFAULT_ACTION_LOG_LINES);
+            const headline =
+              obs.state === "running"
+                ? `web app is running on port ${obs.port} and the preview updates live (hot reload)`
+                : "web app is not running; call webapp start";
+            return `${restoredNote}${headline}\n\n${obs.text}`;
+          }
+
+          if (args.action === "logs") {
+            const n = Math.min(args.lines ?? DEFAULT_LOGS_LINES, MAX_LOG_LINES);
+            const obs = await buildObservation(dir, script, n);
+            const headline =
+              obs.state === "running"
+                ? `web app is running on port ${obs.port}`
+                : "web app is not running";
+            return `${restoredNote}${headline}\n\n${obs.text}`;
+          }
+
+          if (args.action === "restart") {
+            const pid = await pidAlive(dir);
+            if (pid !== null) {
+              try {
+                process.kill(pid);
+              } catch {
+                // already dead: exactly the state restart wants
+              }
+              await new Promise((r) => setTimeout(r, 2000));
+            }
+          }
+
+          const { exitCode, output } = await runScript(dir, script.path, context.abort);
+          const obs = await buildObservation(dir, script, DEFAULT_ACTION_LOG_LINES);
+
+          // The port is the proxy's routing contract (DB-allocated):
+          // port_conflict must never auto-heal onto another port; a moved
+          // server would "run" but be unreachable via the preview.
+          let headline: string;
+          let errorKind: string | null = null;
+          if (exitCode === 0) {
+            headline = output.includes("already running on port")
+              ? "webapp was already running"
+              : "webapp started successfully";
+          } else if (
+            output.includes("EADDRINUSE") ||
+            output.includes("address already in use")
+          ) {
+            errorKind = "port_conflict";
+            headline =
+              "webapp start failed: something else is bound to the managed " +
+              `port${obs.port !== null ? ` ${obs.port}` : ""}. Kill that ` +
+              "process (e.g. `fuser -k <port>/tcp`), then call webapp start " +
+              "again. Do not start a server on a different port; the " +
+              "preview proxy only routes to the managed port.";
+          } else if (output.includes("did not become ready")) {
+            errorKind = "app_boot_failure";
+            headline =
+              "webapp start failed: the server did not become ready. the " +
+              "server crashed or the app code throws on boot; read the log " +
+              "tail, fix the code, then call webapp start again.";
+          } else {
+            errorKind = "bootstrap_failure";
+            headline =
+              "webapp start failed. fix the error shown above, then call " +
+              "webapp start again.";
+          }
+
+          const errorKindLine = errorKind ? `error_kind: ${errorKind}\n` : "";
+          return (
+            `${restoredNote}${headline}\n\n` +
+            `--- script output ---\n${output}\n\n${errorKindLine}${obs.text}`
+          );
+        },
+      }),
+    },
+  };
+};
+
+export default Webapp;

--- a/backend/onyx/server/features/build/sandbox/image/opencode-plugins/webapp.ts
+++ b/backend/onyx/server/features/build/sandbox/image/opencode-plugins/webapp.ts
@@ -10,7 +10,7 @@ import type { Plugin } from "@opencode-ai/plugin";
 import type { tool as ToolFactory } from "@opencode-ai/plugin/tool";
 import { spawn } from "node:child_process";
 import { constants as fsConstants } from "node:fs";
-import { access, chmod, readFile, unlink, writeFile } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 
 const SDK_TOOL_PATHS = [
   "/home/sandbox/.opencode/node_modules/@opencode-ai/plugin/dist/tool.js",
@@ -28,8 +28,7 @@ async function loadToolFactory(): Promise<typeof ToolFactory> {
   throw new Error("could not resolve the @opencode-ai/plugin tool helper");
 }
 
-const CANONICAL_REL = ".webapp/start-webapp.sh";
-const VISIBLE_REL = "start-webapp.sh";
+const SCRIPT_REL = "start-webapp.sh";
 const PID_REL = "nextjs.pid";
 const LOG_REL = "nextjs.log";
 const APP_DIR_REL = "outputs/web";
@@ -41,12 +40,6 @@ const START_TIMEOUT_MS = 150_000;
 const MAX_OUTPUT_BYTES = 8 * 1024;
 const PROBE_TIMEOUT_MS = 2000;
 
-interface ResolvedScript {
-  path: string;
-  restored: boolean;
-  restoreError?: string;
-}
-
 async function pathExists(path: string): Promise<boolean> {
   try {
     await access(path, fsConstants.F_OK);
@@ -56,44 +49,9 @@ async function pathExists(path: string): Promise<boolean> {
   }
 }
 
-// The visible-copy-only fallback exists for legacy sessions that predate the
-// canonical copy; don't remove it as dead code.
-async function resolveScript(dir: string): Promise<ResolvedScript | null> {
-  const canonicalPath = `${dir}/${CANONICAL_REL}`;
-  const visiblePath = `${dir}/${VISIBLE_REL}`;
-
-  if (!(await pathExists(canonicalPath))) {
-    if (await pathExists(visiblePath)) {
-      return { path: visiblePath, restored: false };
-    }
-    return null;
-  }
-
-  const canonicalText = await readFile(canonicalPath, "utf8");
-  const visibleText = (await pathExists(visiblePath))
-    ? await readFile(visiblePath, "utf8")
-    : null;
-
-  if (visibleText === canonicalText) {
-    return { path: canonicalPath, restored: false };
-  }
-
-  try {
-    // The visible copy is chmod 444: overwriting in place EACCESes, but
-    // unlink only needs directory write permission.
-    await unlink(visiblePath).catch(() => {});
-    await writeFile(visiblePath, canonicalText, "utf8");
-    await chmod(visiblePath, 0o444);
-    return { path: canonicalPath, restored: true };
-  } catch (e) {
-    return {
-      path: canonicalPath,
-      restored: false,
-      restoreError:
-        "could not restore start-webapp.sh (continuing with the protected " +
-        `copy): ${e instanceof Error ? e.message : String(e)}`,
-    };
-  }
+async function resolveScript(dir: string): Promise<string | null> {
+  const scriptPath = `${dir}/${SCRIPT_REL}`;
+  return (await pathExists(scriptPath)) ? scriptPath : null;
 }
 
 function parsePort(scriptText: string): number | null {
@@ -147,10 +105,10 @@ interface Observation {
 
 async function buildObservation(
   dir: string,
-  script: ResolvedScript,
+  scriptPath: string,
   logLines: number
 ): Promise<Observation> {
-  const scriptText = await readFile(script.path, "utf8");
+  const scriptText = await readFile(scriptPath, "utf8");
   const port = parsePort(scriptText);
   const pid = await pidAlive(dir);
   const running = pid !== null && port !== null && (await probeRunning(port));
@@ -260,33 +218,28 @@ export const Webapp: Plugin = async () => {
           };
           context.metadata({ title: titles[args.action] });
 
-          const script = await resolveScript(dir);
-          if (!script) {
+          const scriptPath = await resolveScript(dir);
+          if (!scriptPath) {
             return UNAVAILABLE_OBSERVATION;
           }
-          const restoredNote = script.restoreError
-            ? `${script.restoreError}\n\n`
-            : script.restored
-              ? "restored start-webapp.sh (visible copy was missing or modified)\n\n"
-              : "";
 
           if (args.action === "status") {
-            const obs = await buildObservation(dir, script, DEFAULT_ACTION_LOG_LINES);
+            const obs = await buildObservation(dir, scriptPath, DEFAULT_ACTION_LOG_LINES);
             const headline =
               obs.state === "running"
                 ? `web app is running on port ${obs.port} and the preview updates live (hot reload)`
                 : "web app is not running; call webapp start";
-            return `${restoredNote}${headline}\n\n${obs.text}`;
+            return `${headline}\n\n${obs.text}`;
           }
 
           if (args.action === "logs") {
             const n = Math.min(args.lines ?? DEFAULT_LOGS_LINES, MAX_LOG_LINES);
-            const obs = await buildObservation(dir, script, n);
+            const obs = await buildObservation(dir, scriptPath, n);
             const headline =
               obs.state === "running"
                 ? `web app is running on port ${obs.port}`
                 : "web app is not running";
-            return `${restoredNote}${headline}\n\n${obs.text}`;
+            return `${headline}\n\n${obs.text}`;
           }
 
           if (args.action === "restart") {
@@ -299,8 +252,8 @@ export const Webapp: Plugin = async () => {
             }
           }
 
-          const { exitCode, output } = await runScript(dir, script.path, context.abort);
-          const obs = await buildObservation(dir, script, DEFAULT_ACTION_LOG_LINES);
+          const { exitCode, output } = await runScript(dir, scriptPath, context.abort);
+          const obs = await buildObservation(dir, scriptPath, DEFAULT_ACTION_LOG_LINES);
 
           // The port is the proxy's routing contract (DB-allocated):
           // port_conflict must never auto-heal onto another port; a moved
@@ -308,7 +261,7 @@ export const Webapp: Plugin = async () => {
           let headline: string;
           let errorKind: string | null = null;
           if (exitCode === 0) {
-            headline = output.includes("already running on port")
+            headline = output.includes("already running")
               ? "webapp was already running"
               : "webapp started successfully";
           } else if (
@@ -337,7 +290,7 @@ export const Webapp: Plugin = async () => {
 
           const errorKindLine = errorKind ? `error_kind: ${errorKind}\n` : "";
           return (
-            `${restoredNote}${headline}\n\n` +
+            `${headline}\n\n` +
             `--- script output ---\n${output}\n\n${errorKindLine}${obs.text}`
           );
         },

--- a/backend/onyx/server/features/build/sandbox/image/opencode-plugins/webapp.ts
+++ b/backend/onyx/server/features/build/sandbox/image/opencode-plugins/webapp.ts
@@ -1,4 +1,3 @@
-// Manages this session's Next.js dev server (started via start-webapp.sh).
 // Failures are returned as observations, never thrown; a thrown tool error
 // would abort the agent's turn instead of letting it recover.
 //
@@ -108,7 +107,7 @@ async function pidAlive(dir: string): Promise<number | null> {
   const pid = parseInt((await readFile(pidPath, "utf8")).trim(), 10);
   if (!Number.isFinite(pid)) return null;
   try {
-    process.kill(pid, 0); // signal 0: existence check only, no actual kill
+    process.kill(pid, 0);
     return pid;
   } catch {
     return null;
@@ -187,7 +186,6 @@ function runScript(
   abort: AbortSignal
 ): Promise<{ exitCode: number; output: string }> {
   return new Promise((resolve) => {
-    // 2>&1 in the shell keeps stdout/stderr interleaved in print order.
     const child = spawn("bash", ["-c", `bash ${shQuote(scriptPath)} 2>&1`], {
       cwd: dir,
       signal: abort,
@@ -296,9 +294,7 @@ export const Webapp: Plugin = async () => {
             if (pid !== null) {
               try {
                 process.kill(pid);
-              } catch {
-                // already dead: exactly the state restart wants
-              }
+              } catch {}
               await new Promise((r) => setTimeout(r, 2000));
             }
           }

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/snapshot.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/snapshot.py
@@ -29,6 +29,10 @@ class SnapshotError(RuntimeError):
 
 _SNAPSHOT_ROOTS = frozenset({"outputs", "attachments"})
 _SNAPSHOT_GENERATED_DIR_NAMES = frozenset({"node_modules", ".next"})
+# Runtime scratch written by build_nextjs_start_script (port/pid of the dev
+# server). Excluded so a restore can't reintroduce a stale port/pid that
+# would mislead the webapp tool's liveness check when auto-start is skipped.
+_SNAPSHOT_GENERATED_FILE_NAMES = frozenset({".nextjs-port", "nextjs.pid"})
 MAX_SNAPSHOT_ARCHIVE_BYTES = 100 * 1024 * 1024
 MAX_SNAPSHOT_UNCOMPRESSED_BYTES = 500 * 1024 * 1024
 _ARCHIVE_CHUNK_BYTES = 1024 * 1024
@@ -84,13 +88,14 @@ def _snapshot_dirs(session_path: Path) -> list[str]:
 
 
 def _is_excluded_snapshot_dir(relative_path: Path) -> bool:
-    """True for generated dependency/build directories under outputs/."""
+    """True for generated dependency/build directories, or excluded runtime
+    scratch files, under outputs/."""
     parts = relative_path.parts
-    return (
-        len(parts) >= 2
-        and parts[0] == "outputs"
-        and any(part in _SNAPSHOT_GENERATED_DIR_NAMES for part in parts[1:])
-    )
+    if len(parts) < 2 or parts[0] != "outputs":
+        return False
+    if any(part in _SNAPSHOT_GENERATED_DIR_NAMES for part in parts[1:]):
+        return True
+    return relative_path.name in _SNAPSHOT_GENERATED_FILE_NAMES
 
 
 def _add_excluded_snapshot_path(

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/snapshot.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/snapshot.py
@@ -29,9 +29,8 @@ class SnapshotError(RuntimeError):
 
 _SNAPSHOT_ROOTS = frozenset({"outputs", "attachments"})
 _SNAPSHOT_GENERATED_DIR_NAMES = frozenset({"node_modules", ".next"})
-# Runtime scratch written by build_nextjs_start_script (port/pid of the dev
-# server). Excluded so a restore can't reintroduce a stale port/pid that
-# would mislead the webapp tool's liveness check when auto-start is skipped.
+# Excluded so a restore can't reintroduce a stale port/pid that would mislead
+# the webapp tool's liveness check when auto-start is skipped.
 _SNAPSHOT_GENERATED_FILE_NAMES = frozenset({".nextjs-port", "nextjs.pid"})
 MAX_SNAPSHOT_ARCHIVE_BYTES = 100 * 1024 * 1024
 MAX_SNAPSHOT_UNCOMPRESSED_BYTES = 500 * 1024 * 1024

--- a/backend/onyx/server/features/build/sandbox/nextjs_dev.py
+++ b/backend/onyx/server/features/build/sandbox/nextjs_dev.py
@@ -117,20 +117,9 @@ fi
 
 def build_webapp_bootstrap_script(session_path: str, nextjs_port: int) -> str:
     """Builds the self-contained, agent-facing script written to
-    ``sessions/$session_id/start-webapp.sh`` at session setup time.
-
-    This is the whole lazy-provisioning interface: the agent runs it directly
-    (``bash start-webapp.sh`` from the session root) and it must stay
-    self-contained, no CLI wrapper, no backend round-trip. Its output is
-    plain-English status/next-step guidance because an LLM agent is the only
-    reader.
-
-    Args:
-        session_path: Path to the session directory (should be shell-safe).
-        nextjs_port: Port number for the NextJS dev server.
-
-    Returns:
-        Shell script string to write to ``start-webapp.sh``.
+    ``sessions/$session_id/start-webapp.sh``. It must stay self-contained (no
+    CLI wrapper, no backend round-trip); its output is plain-English guidance
+    because an LLM agent is the only reader.
     """
     start_script = build_nextjs_start_script(
         session_path, nextjs_port, check_node_modules=True
@@ -217,13 +206,6 @@ def build_webapp_script_write_snippet(session_path: str, nextjs_port: int) -> st
     Called from session setup and from restore (with the re-allocated port).
     Pinned name/signature: both sandbox managers' restore paths call this
     directly from ``onyx.server.features.build.sandbox.nextjs_dev``.
-
-    Args:
-        session_path: Path to the session directory (should be shell-safe).
-        nextjs_port: Port number for the NextJS dev server.
-
-    Returns:
-        Shell snippet string to embed in a larger script.
     """
     script = build_webapp_bootstrap_script(session_path, nextjs_port)
     escaped_script = script.replace("'", "'\\''")

--- a/backend/onyx/server/features/build/sandbox/nextjs_dev.py
+++ b/backend/onyx/server/features/build/sandbox/nextjs_dev.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 from uuid import UUID
 
 from onyx.configs.app_configs import WEB_DOMAIN
-from onyx.server.features.build.sandbox.base import BUN_CACHE_DIR
+from onyx.server.features.build.sandbox.base import BUN_CACHE_DIR, BUN_IMAGE_CACHE_DIR
 
 _TEMPLATE_NEXT_CONFIG = (
     Path(__file__).parent / "image" / "templates" / "outputs" / "web" / "next.config.ts"
@@ -112,4 +112,128 @@ echo "Next.js server started with PID $NEXTJS_PID"
 echo $NEXTJS_PID > {session_path}/nextjs.pid
 fi
 ) 9>{session_path}.nextjs.lock
+"""
+
+
+def build_webapp_bootstrap_script(session_path: str, nextjs_port: int) -> str:
+    """Builds the self-contained, agent-facing script written to
+    ``sessions/$session_id/start-webapp.sh`` at session setup time.
+
+    This is the whole lazy-provisioning interface: the agent runs it directly
+    (``bash start-webapp.sh`` from the session root) and it must stay
+    self-contained, no CLI wrapper, no backend round-trip. Its output is
+    plain-English status/next-step guidance because an LLM agent is the only
+    reader.
+
+    Args:
+        session_path: Path to the session directory (should be shell-safe).
+        nextjs_port: Port number for the NextJS dev server.
+
+    Returns:
+        Shell script string to write to ``start-webapp.sh``.
+    """
+    start_script = build_nextjs_start_script(
+        session_path, nextjs_port, check_node_modules=True
+    )
+
+    return f"""#!/bin/bash
+SESSION_PATH={session_path}
+PORT={nextjs_port}
+
+(
+    set -e
+    trap 'echo "bootstrap failed - read the error above, fix, and re-run bash start-webapp.sh" >&2' ERR
+
+    flock -x 9
+
+    if [ -f "$SESSION_PATH/nextjs.pid" ] && kill -0 "$(cat "$SESSION_PATH/nextjs.pid")" 2>/dev/null; then
+        echo "webapp already running on port $PORT (logs: nextjs.log)"
+        exit 2
+    fi
+
+    if [ ! -f "$SESSION_PATH/outputs/web/package.json" ]; then
+        echo "Copying outputs template"
+        if [ -d /workspace/templates/outputs ]; then
+            cp -r /workspace/templates/outputs/* "$SESSION_PATH/outputs/"
+            # flock+sentinel: serialize concurrent bun-cache bootstraps;
+            # .ready guards against a partial cp from a previous interrupted run.
+            (
+                flock -x 8
+                if [ ! -f {BUN_CACHE_DIR}/.ready ]; then
+                    echo "Bootstrapping bun cache on workspace volume..."
+                    rm -rf {BUN_CACHE_DIR}
+                    cp -r {BUN_IMAGE_CACHE_DIR} {BUN_CACHE_DIR} \\
+                        || {{ echo "ERROR: bun cache bootstrap failed" >&2; exit 1; }}
+                    touch {BUN_CACHE_DIR}/.ready
+                fi
+            ) 8>{BUN_CACHE_DIR}.lock
+            echo "Installing dependencies with bun..."
+            (cd "$SESSION_PATH/outputs/web" && \\
+                BUN_INSTALL_CACHE_DIR={BUN_CACHE_DIR} \\
+                bun install --frozen-lockfile --backend=hardlink)
+        else
+            echo "Warning: outputs template not found at /workspace/templates/outputs"
+            mkdir -p "$SESSION_PATH/outputs/web"
+        fi
+    fi
+
+    # The embedded start script opens its own fd-9 subshell on
+    # {session_path}.nextjs.lock, which shadows this outer fd 9 for anything
+    # spawned inside it (including the nohup'd dev server, which already
+    # closes 9>&- itself). So the dev server never sees this .webapp.lock fd
+    # and can't hold it open for its lifetime; no extra fd-closing needed here.
+    {start_script}
+) 9>"$SESSION_PATH/.webapp.lock"
+BOOTSTRAP_EXIT=$?
+
+if [ "$BOOTSTRAP_EXIT" -eq 2 ]; then
+    exit 0
+elif [ "$BOOTSTRAP_EXIT" -ne 0 ]; then
+    exit 1
+fi
+
+echo "Waiting for the dev server to become ready..."
+DEADLINE=$((SECONDS + 90))
+while [ "$SECONDS" -lt "$DEADLINE" ]; do
+    if curl -s -o /dev/null --noproxy '*' --max-time 2 "http://127.0.0.1:$PORT/"; then
+        echo "web app dev server running on port $PORT - app dir: outputs/web, logs: nextjs.log. It hot-reloads on file changes and never needs 'bun run dev' run by hand."
+        exit 0
+    fi
+    sleep 1
+done
+
+echo "server did not become ready - check nextjs.log; if it crashed, fix the error and re-run bash start-webapp.sh" >&2
+echo "--- last 30 lines of nextjs.log ---" >&2
+tail -n 30 "$SESSION_PATH/nextjs.log" 2>/dev/null >&2 || true
+exit 1
+"""
+
+
+def build_webapp_script_write_snippet(session_path: str, nextjs_port: int) -> str:
+    """Builds a shell snippet (no shebang, no ``set -e``) that writes the
+    tamper-hardened bootstrap script to both its canonical and visible
+    locations, ``chmod 444`` on each.
+
+    Called from session setup and from restore (with the re-allocated port).
+    Pinned name/signature: both sandbox managers' restore paths call this
+    directly from ``onyx.server.features.build.sandbox.nextjs_dev``.
+
+    Args:
+        session_path: Path to the session directory (should be shell-safe).
+        nextjs_port: Port number for the NextJS dev server.
+
+    Returns:
+        Shell snippet string to embed in a larger script.
+    """
+    script = build_webapp_bootstrap_script(session_path, nextjs_port)
+    escaped_script = script.replace("'", "'\\''")
+
+    return f"""
+mkdir -p {session_path}/.webapp
+# chmod 444 blocks in-place overwrite, so a rewrite (e.g. on restore) must
+# unlink both copies before writing the new ones.
+rm -f {session_path}/start-webapp.sh {session_path}/.webapp/start-webapp.sh
+printf '%s' '{escaped_script}' > {session_path}/.webapp/start-webapp.sh
+printf '%s' '{escaped_script}' > {session_path}/start-webapp.sh
+chmod 444 {session_path}/.webapp/start-webapp.sh {session_path}/start-webapp.sh
 """

--- a/backend/onyx/server/features/build/sandbox/nextjs_dev.py
+++ b/backend/onyx/server/features/build/sandbox/nextjs_dev.py
@@ -135,18 +135,6 @@ PORT={nextjs_port}
 
     flock -x 9
 
-    # PIDs recycle in a pod full of short-lived tool processes, so a bare
-    # kill -0 could match an unrelated live process.
-    NEXTJS_PID=""
-    if [ -f "$SESSION_PATH/nextjs.pid" ]; then
-        NEXTJS_PID="$(cat "$SESSION_PATH/nextjs.pid")"
-    fi
-    if [ -n "$NEXTJS_PID" ] && kill -0 "$NEXTJS_PID" 2>/dev/null && \\
-       [ "$(readlink /proc/$NEXTJS_PID/cwd 2>/dev/null)" = "$SESSION_PATH/outputs/web" ]; then
-        echo "webapp already running on port $PORT (logs: nextjs.log)"
-        exit 2
-    fi
-
     if [ ! -f "$SESSION_PATH/outputs/web/package.json" ]; then
         echo "Copying outputs template"
         if [ -d /workspace/templates/outputs ]; then
@@ -180,11 +168,7 @@ PORT={nextjs_port}
     # and can't hold it open for its lifetime; no extra fd-closing needed here.
     {start_script}
 ) 9>"$SESSION_PATH/.webapp.lock"
-BOOTSTRAP_EXIT=$?
-
-if [ "$BOOTSTRAP_EXIT" -eq 2 ]; then
-    exit 0
-elif [ "$BOOTSTRAP_EXIT" -ne 0 ]; then
+if [ "$?" -ne 0 ]; then
     exit 1
 fi
 
@@ -207,8 +191,7 @@ exit 1
 
 def build_webapp_script_write_snippet(session_path: str, nextjs_port: int) -> str:
     """Builds a shell snippet (no shebang, no ``set -e``) that writes the
-    tamper-hardened bootstrap script to both its canonical and visible
-    locations, ``chmod 444`` on each.
+    ``chmod 444`` bootstrap script to the session root.
 
     Called from session setup and from restore (with the re-allocated port).
     Pinned name/signature: both sandbox managers' restore paths call this
@@ -218,11 +201,9 @@ def build_webapp_script_write_snippet(session_path: str, nextjs_port: int) -> st
     escaped_script = script.replace("'", "'\\''")
 
     return f"""
-mkdir -p {session_path}/.webapp
 # chmod 444 blocks in-place overwrite, so a rewrite (e.g. on restore) must
-# unlink both copies before writing the new ones.
-rm -f {session_path}/start-webapp.sh {session_path}/.webapp/start-webapp.sh
-printf '%s' '{escaped_script}' > {session_path}/.webapp/start-webapp.sh
+# unlink before writing.
+rm -f {session_path}/start-webapp.sh
 printf '%s' '{escaped_script}' > {session_path}/start-webapp.sh
-chmod 444 {session_path}/.webapp/start-webapp.sh {session_path}/start-webapp.sh
+chmod 444 {session_path}/start-webapp.sh
 """

--- a/backend/onyx/server/features/build/sandbox/nextjs_dev.py
+++ b/backend/onyx/server/features/build/sandbox/nextjs_dev.py
@@ -135,7 +135,15 @@ PORT={nextjs_port}
 
     flock -x 9
 
-    if [ -f "$SESSION_PATH/nextjs.pid" ] && kill -0 "$(cat "$SESSION_PATH/nextjs.pid")" 2>/dev/null; then
+    # PIDs recycle in a pod full of short-lived tool processes, so a bare
+    # kill -0 could match an unrelated live process; verify identity via cwd
+    # like the embedded start script does.
+    NEXTJS_PID=""
+    if [ -f "$SESSION_PATH/nextjs.pid" ]; then
+        NEXTJS_PID="$(cat "$SESSION_PATH/nextjs.pid")"
+    fi
+    if [ -n "$NEXTJS_PID" ] && kill -0 "$NEXTJS_PID" 2>/dev/null && \\
+       [ "$(readlink /proc/$NEXTJS_PID/cwd 2>/dev/null)" = "$SESSION_PATH/outputs/web" ]; then
         echo "webapp already running on port $PORT (logs: nextjs.log)"
         exit 2
     fi

--- a/backend/onyx/server/features/build/sandbox/nextjs_dev.py
+++ b/backend/onyx/server/features/build/sandbox/nextjs_dev.py
@@ -136,8 +136,7 @@ PORT={nextjs_port}
     flock -x 9
 
     # PIDs recycle in a pod full of short-lived tool processes, so a bare
-    # kill -0 could match an unrelated live process; verify identity via cwd
-    # like the embedded start script does.
+    # kill -0 could match an unrelated live process.
     NEXTJS_PID=""
     if [ -f "$SESSION_PATH/nextjs.pid" ]; then
         NEXTJS_PID="$(cat "$SESSION_PATH/nextjs.pid")"

--- a/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
@@ -175,7 +175,6 @@ def test_bootstrap_script_is_valid_bash() -> None:
 
 
 def test_bootstrap_script_embeds_port_write_and_env_exports() -> None:
-    # These come from main's embedded build_nextjs_start_script.
     script = build_webapp_bootstrap_script(_SESSION_PATH, 3010)
 
     assert f"echo 3010 > {_SESSION_PATH}/.nextjs-port" in script
@@ -198,8 +197,6 @@ def test_bootstrap_script_short_circuits_on_live_pid() -> None:
 
 
 def test_webapp_script_write_snippet_removes_before_writing() -> None:
-    # chmod 444 blocks in-place overwrite, so a rewrite (restore) must unlink
-    # both copies before writing the new ones.
     snippet = build_webapp_script_write_snippet(_SESSION_PATH, 3010)
 
     assert (

--- a/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
+import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 from uuid import UUID
 
 from onyx.server.features.build.sandbox import nextjs_dev
-from onyx.server.features.build.sandbox.nextjs_dev import build_nextjs_start_script
+from onyx.server.features.build.sandbox.nextjs_dev import (
+    build_nextjs_start_script,
+    build_webapp_bootstrap_script,
+    build_webapp_script_write_snippet,
+)
 from onyx.server.features.build.session.manager import SessionManager
 
 _SESSION_PATH = "/workspace/sessions/0d9ed7f2-8757-4d09-9812-bd7e4a45e232"
@@ -153,3 +159,53 @@ def test_nextjs_ready_probe_targets_base_path_dev_asset() -> None:
         f"http://sandbox-x:3010/api/build/sessions/{session_id}/webapp"
         "/_next/static/onyx-ready-probe.js"
     )
+
+
+def _assert_valid_bash(script: str) -> None:
+    with tempfile.NamedTemporaryFile("w", suffix=".sh") as f:
+        f.write(script)
+        f.flush()
+        result = subprocess.run(["bash", "-n", f.name], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_bootstrap_script_is_valid_bash() -> None:
+    script = build_webapp_bootstrap_script(_SESSION_PATH, 3010)
+    _assert_valid_bash(script)
+
+
+def test_bootstrap_script_embeds_port_write_and_env_exports() -> None:
+    # These come from main's embedded build_nextjs_start_script.
+    script = build_webapp_bootstrap_script(_SESSION_PATH, 3010)
+
+    assert f"echo 3010 > {_SESSION_PATH}/.nextjs-port" in script
+    assert "export ONYX_WEBAPP_PORT=3010" in script
+    assert (
+        'export ONYX_WEBAPP_BASE_PATH="/api/build/sessions/'
+        f'$(basename {_SESSION_PATH})/webapp"' in script
+    )
+
+
+def test_bootstrap_script_short_circuits_on_live_pid() -> None:
+    script = build_webapp_bootstrap_script(_SESSION_PATH, 3010)
+
+    assert (
+        'if [ -f "$SESSION_PATH/nextjs.pid" ] '
+        '&& kill -0 "$(cat "$SESSION_PATH/nextjs.pid")" 2>/dev/null; then' in script
+    )
+    assert "already running" in script
+    assert "exit 2" in script
+
+
+def test_webapp_script_write_snippet_removes_before_writing() -> None:
+    # chmod 444 blocks in-place overwrite, so a rewrite (restore) must unlink
+    # both copies before writing the new ones.
+    snippet = build_webapp_script_write_snippet(_SESSION_PATH, 3010)
+
+    assert (
+        f"rm -f {_SESSION_PATH}/start-webapp.sh "
+        f"{_SESSION_PATH}/.webapp/start-webapp.sh" in snippet
+    )
+    remove_index = snippet.index("rm -f")
+    write_index = snippet.index("printf")
+    assert remove_index < write_index

--- a/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
@@ -185,25 +185,24 @@ def test_bootstrap_script_embeds_port_write_and_env_exports() -> None:
     )
 
 
-def test_bootstrap_script_short_circuits_on_live_pid() -> None:
+def test_bootstrap_script_reuses_live_server_via_embedded_guard() -> None:
     script = build_webapp_bootstrap_script(_SESSION_PATH, 3010)
 
     assert 'kill -0 "$NEXTJS_PID" 2>/dev/null' in script
     assert (
-        '[ "$(readlink /proc/$NEXTJS_PID/cwd 2>/dev/null)" '
-        '= "$SESSION_PATH/outputs/web" ]' in script
+        f'[ "$(readlink /proc/$NEXTJS_PID/cwd 2>/dev/null)" '
+        f'= "{_SESSION_PATH}/outputs/web" ]' in script
     )
     assert "already running" in script
-    assert "exit 2" in script
+    # Exactly one liveness guard: the embedded start script's.
+    assert script.count("kill -0") == 1
 
 
 def test_webapp_script_write_snippet_removes_before_writing() -> None:
     snippet = build_webapp_script_write_snippet(_SESSION_PATH, 3010)
 
-    assert (
-        f"rm -f {_SESSION_PATH}/start-webapp.sh "
-        f"{_SESSION_PATH}/.webapp/start-webapp.sh" in snippet
-    )
+    assert f"rm -f {_SESSION_PATH}/start-webapp.sh" in snippet
+    assert f"chmod 444 {_SESSION_PATH}/start-webapp.sh" in snippet
     remove_index = snippet.index("rm -f")
     write_index = snippet.index("printf")
     assert remove_index < write_index

--- a/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
@@ -188,9 +188,10 @@ def test_bootstrap_script_embeds_port_write_and_env_exports() -> None:
 def test_bootstrap_script_short_circuits_on_live_pid() -> None:
     script = build_webapp_bootstrap_script(_SESSION_PATH, 3010)
 
+    assert 'kill -0 "$NEXTJS_PID" 2>/dev/null' in script
     assert (
-        'if [ -f "$SESSION_PATH/nextjs.pid" ] '
-        '&& kill -0 "$(cat "$SESSION_PATH/nextjs.pid")" 2>/dev/null; then' in script
+        '[ "$(readlink /proc/$NEXTJS_PID/cwd 2>/dev/null)" '
+        '= "$SESSION_PATH/outputs/web" ]' in script
     )
     assert "already running" in script
     assert "exit 2" in script

--- a/docs/craft/lazy-webapp-provisioning.md
+++ b/docs/craft/lazy-webapp-provisioning.md
@@ -1,0 +1,159 @@
+# Lazy Webapp Provisioning + `webapp` Tool
+
+Re-derivation plan, written against current `main`. The original implementation
+lives on the abandoned `no-auto-webapp` branch (forked at `346deae897`), which
+predates a large refactor of the sandbox provisioning layer. This plan maps each
+feature concept to where it now lives and calls out what has already landed on
+main so it is not re-implemented.
+
+## Issues to Address
+
+- **Eager webapp provisioning is wasteful.** Every interactive session pays a
+  template copy + `bun install` + a long-lived `next dev` server + a
+  globally-scarce per-user port at setup, even though roughly two-thirds of
+  sessions never build a web app. Make provisioning **lazy**: scaffold, install,
+  and start the dev server only when a web app is actually being built.
+- **The agent has no native, self-healing surface to manage the dev server.**
+  Give it a `webapp` opencode tool (`start` / `status` / `logs` / `restart`)
+  that returns a structured observation every call and reconciles state, instead
+  of ad-hoc bash the agent has to compose and interpret.
+- **The Preview tab shows a broken/empty frame before the server is up.** Gate
+  the tab on actual readiness.
+
+## Important Notes
+
+### Already on main — do NOT re-implement
+
+The single most important research finding: several pieces of the feature's
+original scope have already merged independently. Re-implementing them would
+create conflicts and drift.
+
+- **env-baking** (already merged). `build_nextjs_start_script`
+  (`sandbox/nextjs_dev.py`) already writes `.nextjs-port`, exports
+  `ONYX_WEBAPP_PORT` / `ONYX_WEBAPP_BASE_PATH`, and uses a `PORT_FLAG` fallback;
+  both managers set the pod/container env `ONYX_WEBAPP_ALLOWED_DEV_ORIGINS`
+  (k8s ~L538, docker ~L565). So a hand-run `bun run dev` already binds the
+  correct port and basePath. The lazy bootstrap must **embed main's current**
+  `build_nextjs_start_script`, not the feature's older copy.
+- **Per-user, interactive-gated port allocation.**
+  `reserve_nextjs_port__no_commit(db_session, build_session)`
+  (`db/build_session.py` ~L576) allocates per-user over `[SANDBOX_NEXTJS_PORT_START,
+  SANDBOX_NEXTJS_PORT_END)`, is called only for `SessionOrigin.INTERACTIVE`
+  (`session/manager.py` ~L542) and re-allocated on wake (`session/api.py` ~L427),
+  persisted on `build_session.nextjs_port`. The feature's port work is done.
+- **Readiness probe + info endpoint.** `_check_nextjs_ready`
+  (`session/manager.py` ~L1500) GETs a basePath-scoped `_next/static` probe; the
+  webapp-info endpoint already returns `has_webapp`, `webapp_url`, `ready`,
+  `status`.
+- **Frontend readiness polling.** `OutputPanel.tsx` already SWR-polls webapp-info
+  and sets `isWebappReady` — but today that only drives polling, not tab
+  visibility (see gating work below).
+
+### Integration points in main's refactored code
+
+- **opencode config:** `build_opencode_base_config(disabled_tools, dev_mode,
+  plugins)` (`sandbox/util/opencode_config.py` ~L190) sets `config["plugin"] =
+  list(plugins)`. The plugin list is assembled per-manager from
+  `_OPENCODE_*_PLUGIN_PATH` constants — k8s ~L1104-1110 (unconditional), docker
+  ~L844-852 (session-tag appended only when `SANDBOX_PROXY_HOST`).
+- **Eager start to replace:** `build_session_workspace_setup_script(session_path,
+  agents_md, session_opencode_config_json, nextjs_port)`
+  (`sandbox/session_workspace.py` ~L47) interpolates
+  `build_nextjs_start_script(...)` when `nextjs_port` is set (~L83-87, L132),
+  after the setup `flock` closes. This is the lazy switch point.
+- **Restore:** both managers' `restore_snapshot(..., nextjs_port, ...)` exec
+  `build_nextjs_start_script(check_node_modules=True)` after
+  `regenerate_session_config` (k8s ~L1841, docker ~L1474).
+- **Setup call sites:** `setup_session_workspace` (k8s ~L1362, docker ~L1068)
+  build the per-session config via `build_provider_opencode_config` then call
+  `build_session_workspace_setup_script(..., nextjs_port=nextjs_port)`.
+
+(Line numbers are hints; resolve by symbol name — the files are actively changing.)
+
+### Settled design decisions
+
+- **One bootstrap implementation, two callers.** The scaffold/install/start
+  logic is a server-rendered `start-webapp.sh` embedded once. Both the agent
+  (mid-turn) and the manager (restore auto-start) run it. It stays self-contained
+  (no CLI, no backend round-trip).
+- **The `webapp` tool is the ergonomic layer, not correctness-critical.** Because
+  env-baking already guarantees the port/basePath, a stray `bun run dev` no
+  longer breaks the preview. The tool's job is reconcile-to-running, readiness
+  waiting, log tailing, restart, and structured observations — not to be the sole
+  path to a working preview.
+- **Tamper hardening.** Canonical `.webapp/start-webapp.sh` + a visible
+  `start-webapp.sh` copy, both `chmod 444`. The tool executes the canonical copy
+  and restores the visible one (unlink-then-write, since 444 blocks in-place
+  overwrite).
+- **Restore auto-starts only when a webapp exists**, keyed on
+  `outputs/web/package.json` in the restored snapshot. Self-heals legacy sessions
+  and skips sessions that never built a webapp — no migration needed.
+- **No auto-supervisor, no port auto-heal.** A crashed server stays down and
+  loud so the agent reads the error and fixes its code; the managed port is the
+  proxy's routing contract, so a port conflict fails with guidance rather than
+  moving to another (unreachable) port.
+
+### Portable artifacts to lift from `no-auto-webapp`
+
+- `image/opencode-plugins/webapp.ts` — the tool. Nearly verbatim (only the plugin
+  registration path is manager-side).
+- `build_webapp_bootstrap_script` in `nextjs_dev.py` — adapt to embed main's
+  current `build_nextjs_start_script` (drop the feature's extra `8>&-`: main's
+  start script owns fd 9 itself).
+- Frontend gating logic in `OutputPanel.tsx` / `PreviewTab.tsx` — re-apply on top
+  of main's current polling code.
+
+## Implementation Strategy
+
+1. **Bootstrap generator** (`nextjs_dev.py`): add
+   `build_webapp_bootstrap_script(session_path, nextjs_port)` embedding main's
+   `build_nextjs_start_script(check_node_modules=True)`. flock-guarded, idempotent
+   (pid-alive short-circuit), scaffolds `outputs/web` + bun-cache + install on
+   first run, waits ~90s for readiness, emits plain-English recovery guidance.
+2. **Lazy setup** (`session_workspace.py`): replace the eager
+   `build_nextjs_start_script` interpolation with writing the two `start-webapp.sh`
+   copies (canonical `.webapp/` + visible), `chmod 444`. No dev server started at
+   setup. Headless (`nextjs_port is None`) path unchanged.
+3. **Tool registration** (both managers): add
+   `_OPENCODE_WEBAPP_PLUGIN_PATH = "/workspace/opencode-plugins/webapp.ts"` and
+   include it in the base-config plugins list (k8s unconditional block; docker
+   list). Ship `webapp.ts` in the image.
+4. **Restore conditional-start** (both managers' `restore_snapshot`): rewrite the
+   two script copies with the re-allocated port, then auto-start via
+   `start-webapp.sh` only if `outputs/web/package.json` exists (sentinel-guarded
+   exec). Background the auto-start so wake stays fast (see edge below).
+5. **Frontend gating** (`OutputPanel.tsx` + `PreviewTab.tsx`): drive tab
+   visibility from the already-fetched `has_webapp` / `ready`. Latch
+   "has-been-ready" so the tab enables once the server first serves; one-shot
+   auto-switch to Preview when it becomes ready (race-guarded per session); pass
+   the iframe URL only once ready; `PreviewTab` gets a "no web app yet" empty
+   state.
+6. **Docs** (`AGENTS.template.md` + `templates/outputs/web/AGENTS.md`): document
+   the `webapp` tool as primary, `bash start-webapp.sh` as fallback.
+7. **Edge — restore-time install:** the restore auto-start runs `bun install`
+   synchronously (node_modules is excluded from snapshots). Background the whole
+   bootstrap on restore so wake isn't blocked on a cold reinstall; the frontend
+   poll brings the preview up shortly after.
+8. **Edge — snapshot hygiene:** exclude `.nextjs-port` and `nextjs.pid` from the
+   snapshot (they are runtime scratch, like `node_modules`) so a stale port/pid
+   can't mislead the tool's liveness check after a restore that skips auto-start.
+
+## Tests
+
+- **Unit** (`nextjs_dev`): `build_webapp_bootstrap_script` renders a valid script
+  (`bash -n`), embeds the `.nextjs-port` write + env exports, and short-circuits
+  on a live pid. The setup script writes both `chmod 444` copies and does **not**
+  start a dev server.
+- **Integration (kind, primary backbone):** assert the lazy pre-state (both
+  `start-webapp.sh` copies present, mode 444, identical; no running dev server; no
+  `node_modules`); run the tool (and `bash start-webapp.sh`) and assert it
+  scaffolds + installs + serves on the managed port through the proxy; restore a
+  snapshot **with** a webapp auto-starts, restore **without** one does not
+  (`package.json` signal); idempotent re-invocation is a no-op. Adapt the
+  feature's `test_webapp_preview.py`, `test_snapshot_restore.py`,
+  `test_bun_node_modules_dedup.py`.
+- **Playwright (optional):** Preview tab disabled until ready, auto-switches once
+  the agent builds a webapp.
+
+Keep it proportionate: the kind integration test is the backbone; unit tests only
+for the script-generator logic.

--- a/docs/craft/lazy-webapp-provisioning.md
+++ b/docs/craft/lazy-webapp-provisioning.md
@@ -81,10 +81,12 @@ create conflicts and drift.
   longer breaks the preview. The tool's job is reconcile-to-running, readiness
   waiting, log tailing, restart, and structured observations — not to be the sole
   path to a working preview.
-- **Tamper hardening.** Canonical `.webapp/start-webapp.sh` + a visible
-  `start-webapp.sh` copy, both `chmod 444`. The tool executes the canonical copy
-  and restores the visible one (unlink-then-write, since 444 blocks in-place
-  overwrite).
+- **Tamper hardening (simplified 2026-08).** A single `start-webapp.sh` at the
+  session root, `chmod 444` (rewrites unlink-then-write, since 444 blocks
+  in-place overwrite). No canonical/visible pair and no tool-side restore: if
+  the agent deletes it, the tool reports unavailable and setup/restore
+  regenerates it. Liveness is guarded once, inside the embedded start script
+  (pid + cwd identity); the bootstrap wrapper does not duplicate the check.
 - **Restore auto-starts only when a webapp exists**, keyed on
   `outputs/web/package.json` in the restored snapshot. Self-heals legacy sessions
   and skips sessions that never built a webapp — no migration needed.
@@ -111,15 +113,14 @@ create conflicts and drift.
    (pid-alive short-circuit), scaffolds `outputs/web` + bun-cache + install on
    first run, waits ~90s for readiness, emits plain-English recovery guidance.
 2. **Lazy setup** (`session_workspace.py`): replace the eager
-   `build_nextjs_start_script` interpolation with writing the two `start-webapp.sh`
-   copies (canonical `.webapp/` + visible), `chmod 444`. No dev server started at
-   setup. Headless (`nextjs_port is None`) path unchanged.
+   `build_nextjs_start_script` interpolation with writing `start-webapp.sh` at the
+   session root, `chmod 444`. No dev server started at setup. Headless (`nextjs_port is None`) path unchanged.
 3. **Tool registration** (both managers): add
    `_OPENCODE_WEBAPP_PLUGIN_PATH = "/workspace/opencode-plugins/webapp.ts"` and
    include it in the base-config plugins list (k8s unconditional block; docker
    list). Ship `webapp.ts` in the image.
-4. **Restore conditional-start** (both managers' `restore_snapshot`): rewrite the
-   two script copies with the re-allocated port, then auto-start via
+4. **Restore conditional-start** (both managers' `restore_snapshot`): rewrite
+   `start-webapp.sh` with the re-allocated port, then auto-start via
    `start-webapp.sh` only if `outputs/web/package.json` exists (sentinel-guarded
    exec). Background the auto-start so wake stays fast (see edge below).
 5. **Frontend gating** (`OutputPanel.tsx` + `PreviewTab.tsx`): drive tab
@@ -142,10 +143,10 @@ create conflicts and drift.
 
 - **Unit** (`nextjs_dev`): `build_webapp_bootstrap_script` renders a valid script
   (`bash -n`), embeds the `.nextjs-port` write + env exports, and short-circuits
-  on a live pid. The setup script writes both `chmod 444` copies and does **not**
-  start a dev server.
-- **Integration (kind, primary backbone):** assert the lazy pre-state (both
-  `start-webapp.sh` copies present, mode 444, identical; no running dev server; no
+  on a live pid (via the single embedded guard). The setup script writes the
+  `chmod 444` script and does **not** start a dev server.
+- **Integration (kind, primary backbone):** assert the lazy pre-state
+  (`start-webapp.sh` present, mode 444; no running dev server; no
   `node_modules`); run the tool (and `bash start-webapp.sh`) and assert it
   scaffolds + installs + serves on the managed port through the proxy; restore a
   snapshot **with** a webapp auto-starts, restore **without** one does not


### PR DESCRIPTION
## Description

Inert building blocks for lazy webapp provisioning (no behavior change; nothing calls these yet):

- `build_webapp_bootstrap_script` in `nextjs_dev.py`: the self-contained `start-webapp.sh` the agent runs to scaffold `outputs/web`, bun install, and start the dev server. Embeds main's current `build_nextjs_start_script` (port/basePath env baking, PORT_FLAG fallback, pid-guarded spawn), is flock-guarded and idempotent, waits up to 90s for readiness, and emits plain-English recovery guidance for the agent.
- `build_webapp_script_write_snippet`: shared shell snippet that writes the tamper-hardened script pair (canonical `.webapp/` copy plus visible copy, both chmod 444, unlink-before-write so rewrites work).
- `webapp.ts` opencode plugin shipped in the sandbox image but not yet registered: start/status/logs/restart with a stable observation block and `error_kind` taxonomy; executes the canonical copy and restores the visible one if tampered.
- Snapshot hygiene: `.nextjs-port` and `nextjs.pid` excluded as generated file names so a nested copy under `outputs/` cannot leak a stale port/pid into a snapshot.

The provisioning flip that uses all of this lands in the next PR in the stack.

## How Has This Been Tested?

- New unit tests in `test_nextjs_dev.py`: `bash -n` validation of the generated script, port write + env export embedding, live-pid short-circuit, unlink-before-write ordering (12 passed at this tip).
- pre-commit (ruff, ruff format, ty) clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

**Stack:**
1. [lazy-webapp #13710](https://github.com/onyx-dot-app/onyx/pull/13710)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hardened `start-webapp.sh` generator and a sandbox `webapp` tool to manage the Next.js dev server. Preps lazy provisioning with a single script copy, a single liveness guard, and clear, idempotent start; no behavior change yet.

- **New Features**
  - `build_webapp_bootstrap_script`: generates `start-webapp.sh` to scaffold `outputs/web`, bootstrap the bun cache from the image (flock + `.ready`), run `bun install`, start the dev server, and wait for readiness; flock-guarded, pid-guarded with cwd check, single liveness guard, idempotent.
  - `build_webapp_script_write_snippet`: writes one session-root `start-webapp.sh` (`chmod 444`); unlinks before rewrite.
  - `webapp.ts` tool: `start`/`status`/`logs`/`restart`; returns structured observations with `error_kind` (`port_conflict`, `app_boot_failure`, `bootstrap_failure`); loads `@opencode-ai/plugin` by absolute path; helpers inlined; headless or deleted-script sessions return “unavailable.”
  - Tests: bash syntax, env/port embedding, live‑pid short‑circuit via cwd, unlink‑before‑write ordering. Docs: lazy webapp provisioning re‑derivation plan added.

- **Bug Fixes**
  - Snapshot excludes `.nextjs-port` and `nextjs.pid` to avoid restoring stale port/pid that could mislead liveness checks.
  - Bootstrap short‑circuit validates the recorded PID’s cwd is `outputs/web` before declaring “already running,” preventing false positives from PID reuse.

<sup>Written for commit 079815808ee94caef16725b66e574595b6e9bd0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

