### PR TITLE
feat(craft): lazy webapp provisioning on setup and restore

### DIFF
--- a/backend/onyx/server/features/build/AGENTS.template.md
+++ b/backend/onyx/server/features/build/AGENTS.template.md
@@ -17,10 +17,11 @@ in the user's connected apps. Use all available resources to best accomplish the
   `not_authorized` / `policy_denied`). Surface the outcome and offer an alternative.
 - **Never** state a fact that isn't grounded in a retrieved source or an attachment. If you
   don't have the data, search again or say so. Do not guess or fabricate.
-- The Next.js dev server is already running on port {{NEXTJS_PORT}}. Never start
-  another (`bun run dev`). Preview the app at
-  `http://localhost:{{NEXTJS_PORT}}{{WEBAPP_BASE_PATH}}` — requests outside that
-  base path 404 or redirect even when the app is healthy.
+- No web server is running initially. If your deliverable is a web app, call the `webapp`
+  tool with `action: "start"` FIRST. It scaffolds `outputs/web`, installs deps, starts the
+  dev server, and reports the port; safe to call repeatedly, and `status`/`logs` diagnose
+  problems. (If the tool is unavailable, run `bash start-webapp.sh` from the session root.)
+  Never run `bun run dev` or start your own server.
 - Be autonomous when building. Act within the turn rather than stopping to ask.
 
 {{DISABLED_TOOLS_SECTION}}
@@ -39,10 +40,11 @@ Your working directory is the session root. Everything you produce goes under `o
 ```
 ./
 ├── AGENTS.md          # this file
+├── start-webapp.sh    # fallback: use the `webapp` tool (action: "start") instead
 ├── attachments/       # files attached to THIS session (see Files & attachments)
 ├── user_library/      # the user's persistent library, shared across sessions (symlink)
 ├── outputs/           # ALL deliverables go here
-│   └── web/           # Next.js app, pre-scaffolded and running
+│   └── web/           # Next.js app; appears once the webapp tool is started
 └── .opencode/skills/  # installed skills
 ```
 
@@ -107,10 +109,13 @@ as needed. Pick the format that best answers the request.
 | **Markdown** | Reports, analyses, docs → `outputs/markdown/*.md` |
 | **Response** | Quick answers and lookups (no file needed)       |
 
-The web app under `outputs/web` renders live (Next.js 16.1.1, React 19, Tailwind, Recharts,
-shadcn/ui) — read `outputs/web/AGENTS.md` for its specs and styling before building. For a
-direct Response, put the full answer in your reply; don't paste a file's full contents
-into chat when you can point to it under `outputs/`. Give files human-readable names.
+A web app requires calling the `webapp` tool with `action: "start"` before building. It
+scaffolds `outputs/web`, installs deps, and starts the dev server (fallback: `bash
+start-webapp.sh`). Once running, it renders live (Next.js 16.1.1, React 19, Tailwind,
+Recharts, shadcn/ui); read `outputs/web/AGENTS.md` for its specs and styling before
+building. For a direct Response, put the full answer in your reply; don't paste a file's
+full contents into chat when you can point to it under `outputs/`. Give files
+human-readable names.
 
 ## How to work
 

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -98,10 +98,13 @@ class SandboxManager(_ServeMixin, ABC):
         └── sessions/
             ├── $session_id_1/         # Per-session workspace
             │   ├── outputs/           # Agent output for this session
-            │   │   └── web/           # Next.js app
+            │   │   └── web/           # Next.js app (scaffolded lazily by
+            │   │                      # start-webapp.sh, not at setup)
             │   ├── venv/              # Python virtual environment
             │   ├── .opencode/skills   # Symlink → managed/skills
             │   ├── AGENTS.md          # Agent instructions
+            │   ├── start-webapp.sh    # Bootstrap script, chmod 444 (present
+            │   │                      # when session has a port)
             │   └── attachments/
             └── $session_id_2/
                 └── ...
@@ -190,6 +193,14 @@ class SandboxManager(_ServeMixin, ABC):
         - sessions/$session_id/.opencode/skills (symlink → managed skills dir)
         - sessions/$session_id/AGENTS.md
         - sessions/$session_id/attachments/
+
+        Does NOT scaffold ``outputs/web`` or install/start the dev server.
+        When ``nextjs_port`` is given, writes an executable
+        ``sessions/$session_id/start-webapp.sh`` bootstrap script (see
+        :func:`nextjs_dev.build_webapp_bootstrap_script`) that the agent runs
+        later, purely locally, to lazily scaffold and start the webapp; no
+        server-side trigger is involved. Skipped entirely when
+        ``nextjs_port`` is None (headless callers).
 
         Args:
             sandbox_id: The sandbox ID (must be provisioned)
@@ -286,6 +297,11 @@ class SandboxManager(_ServeMixin, ABC):
 
         For Kubernetes: Downloads and extracts the snapshot, regenerates config files.
         For Local: No-op since workspaces persist on disk (no snapshots).
+
+        When ``nextjs_port`` is given, always (re)writes ``start-webapp.sh``
+        with the new port (ports change across sleep/wake) and auto-starts
+        the dev server in the background, but only if the restored snapshot
+        actually contains a webapp (``outputs/web/package.json``).
 
         Args:
             sandbox_id: The sandbox ID

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -130,7 +130,7 @@ from onyx.server.features.build.sandbox.models import (
 )
 from onyx.server.features.build.sandbox.nextjs_dev import (
     allowed_dev_origins,
-    build_webapp_script_write_snippet,
+    build_webapp_restore_script,
 )
 from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
 from onyx.server.features.build.sandbox.session_workspace import (
@@ -1478,22 +1478,9 @@ fi
         )
 
         if nextjs_port is not None:
-            # Ports change across sleep/wake, so the two script copies are
-            # always rewritten. Auto-start only if the restored snapshot
-            # actually contains a webapp, and background it so wake isn't
-            # blocked on a cold bun install (node_modules is excluded from
-            # snapshots).
-            write_snippet = build_webapp_script_write_snippet(session_path, nextjs_port)
-            restore_webapp_script = f"""
-set -e
-{write_snippet}
-if [ -f {session_path}/outputs/web/package.json ]; then
-    nohup bash {session_path}/start-webapp.sh > {session_path}/webapp-bootstrap.log 2>&1 &
-    echo "ONYX_WEBAPP_AUTOSTART"
-else
-    echo "ONYX_WEBAPP_ABSENT"
-fi
-"""
+            restore_webapp_script = build_webapp_restore_script(
+                session_path, nextjs_port
+            )
             try:
                 _run_in_container_as_sandbox_user(
                     container,

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -1515,7 +1515,6 @@ fi
             agent_provider=agent_provider,
             agent_model=agent_model,
             connectable_apps_section=connectable_apps_section,
-            session_id=session_id,
             user_name=user_name,
         )
         session_opencode_config = (

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -130,7 +130,7 @@ from onyx.server.features.build.sandbox.models import (
 )
 from onyx.server.features.build.sandbox.nextjs_dev import (
     allowed_dev_origins,
-    build_nextjs_start_script,
+    build_webapp_script_write_snippet,
 )
 from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
 from onyx.server.features.build.sandbox.session_workspace import (
@@ -201,6 +201,8 @@ _OPENCODE_SESSION_TAG_PLUGIN_PATH = "/workspace/opencode-plugins/session-proxy-t
 _OPENCODE_CONNECT_APP_PLUGIN_PATH = "/workspace/opencode-plugins/connect-app.ts"
 # Soft turn-budget wrap-up steer (reads the per-turn deadline stamp).
 _OPENCODE_TURN_BUDGET_PLUGIN_PATH = "/workspace/opencode-plugins/turn-budget.ts"
+# Surfaces the `webapp` tool (start/status/logs/restart); always on.
+_OPENCODE_WEBAPP_PLUGIN_PATH = "/workspace/opencode-plugins/webapp.ts"
 _MUTABLE_SANDBOX_IMAGE_TAGS = {"latest", "beta", "edge"}
 
 # In-container opencode-history archive builder: reuses the sandbox_daemon
@@ -841,11 +843,13 @@ class DockerSandboxManager(SandboxManager):
             # opencode-serve reads provider config from env at startup; must be
             # in create_kwargs before the container ever runs.
             opencode_password = secrets.token_urlsafe(32)
-            # connect_app is always loaded; the egress-tagging plugin only when
-            # the proxy is wired up (else it no-ops — no HTTP(S)_PROXY to re-tag).
+            # connect_app, turn_budget, and webapp are always loaded; the
+            # egress-tagging plugin only when the proxy is wired up (else it
+            # no-ops — no HTTP(S)_PROXY to re-tag).
             plugins = [
                 _OPENCODE_CONNECT_APP_PLUGIN_PATH,
                 _OPENCODE_TURN_BUDGET_PLUGIN_PATH,
+                _OPENCODE_WEBAPP_PLUGIN_PATH,
             ]
             if SANDBOX_PROXY_HOST:
                 plugins.append(_OPENCODE_SESSION_TAG_PLUGIN_PATH)
@@ -1054,9 +1058,7 @@ class DockerSandboxManager(SandboxManager):
         *,
         agent_provider: str | None,
         agent_model: str | None,
-        nextjs_port: int | None,
         connectable_apps_section: str,
-        session_id: UUID | None = None,
         user_name: str | None = None,
     ) -> str:
         """Raw (unescaped) AGENTS.md content."""
@@ -1065,8 +1067,6 @@ class DockerSandboxManager(SandboxManager):
             connectable_apps_section=connectable_apps_section,
             provider=agent_provider,
             model_name=agent_model,
-            nextjs_port=nextjs_port,
-            session_id=session_id,
             disabled_tools=OPENCODE_DISABLED_TOOLS,
             user_name=user_name,
             organization_instructions=load_settings().craft_instructions,
@@ -1087,9 +1087,7 @@ class DockerSandboxManager(SandboxManager):
         agents_md = self._build_agents_md(
             agent_provider=llm_config.provider,
             agent_model=llm_config.model_name,
-            nextjs_port=nextjs_port,
             connectable_apps_section=connectable_apps_section,
-            session_id=session_id,
             user_name=user_name,
         )
         session_opencode_config = json.dumps(
@@ -1480,16 +1478,31 @@ fi
         )
 
         if nextjs_port is not None:
-            start_script = build_nextjs_start_script(
-                session_path, nextjs_port, check_node_modules=True
-            )
+            # Ports change across sleep/wake, so the two script copies are
+            # always rewritten. Auto-start only if the restored snapshot
+            # actually contains a webapp, and background it so wake isn't
+            # blocked on a cold bun install (node_modules is excluded from
+            # snapshots).
+            write_snippet = build_webapp_script_write_snippet(session_path, nextjs_port)
+            restore_webapp_script = f"""
+set -e
+{write_snippet}
+if [ -f {session_path}/outputs/web/package.json ]; then
+    nohup bash {session_path}/start-webapp.sh > {session_path}/webapp-bootstrap.log 2>&1 &
+    echo "ONYX_WEBAPP_AUTOSTART"
+else
+    echo "ONYX_WEBAPP_ABSENT"
+fi
+"""
             try:
                 _run_in_container_as_sandbox_user(
                     container,
-                    ["/bin/sh", "-c", start_script],
+                    ["/bin/sh", "-c", restore_webapp_script],
                 )
             except ExecError as e:
-                raise RuntimeError(f"Failed to start Next.js after restore: {e}") from e
+                raise RuntimeError(
+                    f"Failed to restore webapp bootstrap script: {e}"
+                ) from e
 
     def regenerate_session_config(
         self,
@@ -1505,12 +1518,15 @@ fi
         mcp_servers: Sequence[CraftMCPServerConfig] = (),
     ) -> None:
         """Rewrite generated session configuration and managed symlinks."""
+        # nextjs_port stays in the signature to match the abstract contract
+        # (base.py) shared with restore_snapshot's own webapp-script rewrite;
+        # AGENTS.md no longer embeds it.
+        _ = nextjs_port
         container = self._require_container(sandbox_id)
         session_path = f"{SESSIONS_ROOT}/{session_id}"
         agents_md = self._build_agents_md(
             agent_provider=agent_provider,
             agent_model=agent_model,
-            nextjs_port=nextjs_port,
             connectable_apps_section=connectable_apps_section,
             session_id=session_id,
             user_name=user_name,

--- a/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/AGENTS.md
+++ b/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/AGENTS.md
@@ -4,8 +4,8 @@ This file provides guidance to AI agents when working on the web application wit
 
 ## Important Notes
 
-- **The development server is already running** at a dynamically allocated port. Do NOT run `bun run dev` yourself.
-- **The app serves under a session-scoped base path, not `/`** — use the preview URL from the session root `AGENTS.md`; other paths 404 or redirect even when the app is healthy.
+- **The development server is already running** (started by the `webapp` tool, which scaffolded this app) on a dynamically allocated port. Do NOT run `bun run dev` yourself. Use the `webapp` tool's `status`/`logs` actions to check on it (logs also at `../../nextjs.log`).
+- **The app serves under a session-scoped base path, not `/`** — use the preview URL returned by the `webapp` tool; other paths 404 or redirect even when the app is healthy.
 - **We do NOT use a `src` directory** - all code lives directly in the root folders (`app/`, `components/`, `lib/`, etc.)
 - If the app needs pre-computation (data processing, API calls, etc.), create a bash or python script called `prepare.sh`/`prepare.py` at the root of this directory
 - **CRITICAL: Create small, modular components** - Do NOT write everything in `page.tsx`. Break your UI into small, reusable components in the `components/` directory. Each component should have a single responsibility and be in its own file.
@@ -41,7 +41,7 @@ python prepare.py
 ## Commands
 
 ```bash
-bun run dev        # Start development server (DO NOT RUN - already running)
+bun run dev        # Start development server (DO NOT RUN, already running via the webapp tool)
 bun run lint       # oxlint (ESLint is NOT installed — never run eslint)
 bun run typecheck  # tsc --noEmit
 bun add <pkg>      # Add a new dependency (updates package.json AND bun.lock)

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -116,8 +116,10 @@ from onyx.server.features.build.sandbox.models import (
     SnapshotResult,
 )
 from onyx.server.features.build.sandbox.nextjs_dev import (
+    WEBAPP_ABSENT_SENTINEL,
+    WEBAPP_AUTOSTART_SENTINEL,
     allowed_dev_origins,
-    build_webapp_script_write_snippet,
+    build_webapp_restore_script,
 )
 from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
 from onyx.server.features.build.sandbox.session_workspace import (
@@ -1377,11 +1379,12 @@ class KubernetesSandboxManager(SandboxManager):
 
         Executes kubectl exec to:
         1. Create sessions/$session_id/ directory
-        2. Copy outputs template from local templates (downloaded during init)
-        3. Write AGENTS.md
-        4. Write opencode.json with LLM config
-        5. Start Next.js dev server (skipped when ``nextjs_port`` is None,
-           e.g. for headless scheduled-task fires that don't need a preview).
+        2. Write AGENTS.md
+        3. Write opencode.json with LLM config
+        4. Write the tamper-hardened ``start-webapp.sh`` pair (skipped when
+           ``nextjs_port`` is None, e.g. for headless scheduled-task fires
+           that don't need a preview). Does NOT scaffold ``outputs/web`` or
+           start a dev server — webapp provisioning is lazy.
 
         Args:
             sandbox_id: The sandbox ID (must be provisioned)
@@ -1845,25 +1848,10 @@ echo "Session cleanup complete"
             )
 
             if nextjs_port is not None:
-                # Ports change across sleep/wake, so the two script copies
-                # are always rewritten. Auto-start only if the restored
-                # snapshot actually contains a webapp, and background it so
-                # wake isn't blocked on a cold bun install (node_modules is
-                # excluded from snapshots).
-                write_snippet = build_webapp_script_write_snippet(
+                restore_webapp_script = build_webapp_restore_script(
                     safe_session_path, nextjs_port
                 )
-                restore_webapp_script = f"""
-set -e
-{write_snippet}
-if [ -f {safe_session_path}/outputs/web/package.json ]; then
-    nohup bash {safe_session_path}/start-webapp.sh > {safe_session_path}/webapp-bootstrap.log 2>&1 &
-    echo "ONYX_WEBAPP_AUTOSTART"
-else
-    echo "ONYX_WEBAPP_ABSENT"
-fi
-"""
-                k8s_stream(
+                exec_response = k8s_stream(
                     self._stream_core_api.connect_get_namespaced_pod_exec,
                     name=pod_name,
                     namespace=self._namespace,
@@ -1875,6 +1863,18 @@ fi
                     tty=False,
                     _request_timeout=WORKSPACE_SETUP_DEADLINE_SECONDS,
                 )
+                # The exec client returns buffered output without raising on
+                # timeout or nonzero exit, so the sentinel is the only
+                # reliable success signal (same contract as workspace setup).
+                if (
+                    WEBAPP_AUTOSTART_SENTINEL not in exec_response
+                    and WEBAPP_ABSENT_SENTINEL not in exec_response
+                ):
+                    raise RuntimeError(
+                        f"Webapp bootstrap-script restore for session "
+                        f"{session_id} did not complete (output tail: "
+                        f"{exec_response[-500:]!r})"
+                    )
         except ApiException as e:
             raise RuntimeError(f"Failed to restore snapshot: {e}") from e
 

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -117,7 +117,7 @@ from onyx.server.features.build.sandbox.models import (
 )
 from onyx.server.features.build.sandbox.nextjs_dev import (
     allowed_dev_origins,
-    build_nextjs_start_script,
+    build_webapp_script_write_snippet,
 )
 from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
 from onyx.server.features.build.sandbox.session_workspace import (
@@ -176,6 +176,8 @@ _OPENCODE_SESSION_TAG_PLUGIN_PATH = "/workspace/opencode-plugins/session-proxy-t
 _OPENCODE_CONNECT_APP_PLUGIN_PATH = "/workspace/opencode-plugins/connect-app.ts"
 # Soft turn-budget wrap-up steer (reads the per-turn deadline stamp).
 _OPENCODE_TURN_BUDGET_PLUGIN_PATH = "/workspace/opencode-plugins/turn-budget.ts"
+# Surfaces the `webapp` tool (start/status/logs/restart); always on.
+_OPENCODE_WEBAPP_PLUGIN_PATH = "/workspace/opencode-plugins/webapp.ts"
 
 
 _PROXY_RESOLVE_RETRY_ATTEMPTS = 5
@@ -439,8 +441,6 @@ class KubernetesSandboxManager(SandboxManager):
         connectable_apps_section: str,
         provider: str | None = None,
         model_name: str | None = None,
-        nextjs_port: int | None = None,
-        session_id: UUID | None = None,
         disabled_tools: list[str] | None = None,
         user_name: str | None = None,
     ) -> str:
@@ -450,8 +450,6 @@ class KubernetesSandboxManager(SandboxManager):
             connectable_apps_section=connectable_apps_section,
             provider=provider,
             model_name=model_name,
-            nextjs_port=nextjs_port,
-            session_id=session_id,
             disabled_tools=disabled_tools,
             user_name=user_name,
             organization_instructions=load_settings().craft_instructions,
@@ -1110,6 +1108,7 @@ class KubernetesSandboxManager(SandboxManager):
                     plugins=[
                         _OPENCODE_CONNECT_APP_PLUGIN_PATH,
                         _OPENCODE_TURN_BUDGET_PLUGIN_PATH,
+                        _OPENCODE_WEBAPP_PLUGIN_PATH,
                         _OPENCODE_SESSION_TAG_PLUGIN_PATH,
                     ],
                 )
@@ -1404,8 +1403,6 @@ class KubernetesSandboxManager(SandboxManager):
             connectable_apps_section=connectable_apps_section,
             provider=llm_config.provider,
             model_name=llm_config.model_name,
-            nextjs_port=nextjs_port,
-            session_id=session_id,
             disabled_tools=OPENCODE_DISABLED_TOOLS,
             user_name=user_name,
         )
@@ -1795,15 +1792,18 @@ echo "Session cleanup complete"
         1. Read the snapshot from Onyx FileStore in the api-server
         2. Stream it to the sidecar, which extracts it in the session workspace
         3. Regenerate configuration files (AGENTS.md, opencode.json)
-        4. Start the NextJS dev server (skipped when ``nextjs_port`` is None,
-           e.g. for headless scheduled-task fires that don't attach a preview).
+        4. Rewrite ``start-webapp.sh`` with the re-allocated port (skipped
+           when ``nextjs_port`` is None, e.g. headless scheduled-task fires)
+           and auto-start the dev server in the background, but only if the
+           restored snapshot actually contains a webapp
+           (``outputs/web/package.json``).
 
         Args:
             sandbox_id: The sandbox ID
             session_id: The session ID to restore
             snapshot_storage_path: FileStore file id for the snapshot archive
             nextjs_port: Port number for the NextJS dev server, or None to
-                skip starting it.
+                skip rewriting/starting it.
             llm_config: LLM provider configuration for opencode.json
 
         Raises:
@@ -1845,15 +1845,30 @@ echo "Session cleanup complete"
             )
 
             if nextjs_port is not None:
-                start_script = build_nextjs_start_script(
-                    safe_session_path, nextjs_port, check_node_modules=True
+                # Ports change across sleep/wake, so the two script copies
+                # are always rewritten. Auto-start only if the restored
+                # snapshot actually contains a webapp, and background it so
+                # wake isn't blocked on a cold bun install (node_modules is
+                # excluded from snapshots).
+                write_snippet = build_webapp_script_write_snippet(
+                    safe_session_path, nextjs_port
                 )
+                restore_webapp_script = f"""
+set -e
+{write_snippet}
+if [ -f {safe_session_path}/outputs/web/package.json ]; then
+    nohup bash {safe_session_path}/start-webapp.sh > {safe_session_path}/webapp-bootstrap.log 2>&1 &
+    echo "ONYX_WEBAPP_AUTOSTART"
+else
+    echo "ONYX_WEBAPP_ABSENT"
+fi
+"""
                 k8s_stream(
                     self._stream_core_api.connect_get_namespaced_pod_exec,
                     name=pod_name,
                     namespace=self._namespace,
                     container=_SANDBOX_CONTAINER_NAME,
-                    command=["/bin/sh", "-c", start_script],
+                    command=["/bin/sh", "-c", restore_webapp_script],
                     stderr=True,
                     stdin=False,
                     stdout=True,
@@ -1877,14 +1892,16 @@ echo "Session cleanup complete"
         mcp_servers: Sequence[CraftMCPServerConfig] = (),
     ) -> None:
         """Rewrite generated session configuration and managed symlinks."""
+        # nextjs_port stays in the signature to match the abstract contract
+        # (base.py) shared with restore_snapshot's own webapp-script rewrite;
+        # AGENTS.md no longer embeds it.
+        _ = nextjs_port
         pod_name = self._get_pod_name(str(sandbox_id))
         session_path = shlex.quote(f"/workspace/sessions/{session_id}")
         agent_instructions = self._load_agent_instructions(
             connectable_apps_section=connectable_apps_section,
             provider=agent_provider,
             model_name=agent_model,
-            nextjs_port=nextjs_port,
-            session_id=session_id,
             disabled_tools=OPENCODE_DISABLED_TOOLS,
             user_name=user_name,
         )

--- a/backend/onyx/server/features/build/sandbox/nextjs_dev.py
+++ b/backend/onyx/server/features/build/sandbox/nextjs_dev.py
@@ -15,6 +15,9 @@ _TEMPLATE_NEXT_CONFIG = (
     Path(__file__).parent / "image" / "templates" / "outputs" / "web" / "next.config.ts"
 )
 
+# Canonical scaffold marker shared by bootstrap, restore, and API detection.
+WEBAPP_PACKAGE_JSON_PATH = "outputs/web/package.json"
+
 
 def webapp_base_path(session_id: UUID | str) -> str:
     """Base path a session's Next.js dev server serves under.
@@ -135,7 +138,7 @@ PORT={nextjs_port}
 
     flock -x 9
 
-    if [ ! -f "$SESSION_PATH/outputs/web/package.json" ]; then
+    if [ ! -f "$SESSION_PATH/{WEBAPP_PACKAGE_JSON_PATH}" ]; then
         echo "Copying outputs template"
         if [ -d /workspace/templates/outputs ]; then
             cp -r /workspace/templates/outputs/* "$SESSION_PATH/outputs/"
@@ -210,7 +213,7 @@ def build_webapp_restore_script(session_path: str, nextjs_port: int) -> str:
     return f"""
 set -e
 {write_snippet}
-if [ -f {session_path}/outputs/web/package.json ]; then
+if [ -f {session_path}/{WEBAPP_PACKAGE_JSON_PATH} ]; then
     nohup bash {session_path}/start-webapp.sh > {session_path}/webapp-bootstrap.log 2>&1 &
     echo "{WEBAPP_AUTOSTART_SENTINEL}"
 else

--- a/backend/onyx/server/features/build/sandbox/nextjs_dev.py
+++ b/backend/onyx/server/features/build/sandbox/nextjs_dev.py
@@ -189,6 +189,36 @@ exit 1
 """
 
 
+# Restore-script sentinels: the k8s exec client returns buffered output
+# without raising on timeout or nonzero exit, so callers verify one of these
+# appeared instead of trusting a clean return.
+WEBAPP_AUTOSTART_SENTINEL = "ONYX_WEBAPP_AUTOSTART"
+WEBAPP_ABSENT_SENTINEL = "ONYX_WEBAPP_ABSENT"
+
+
+def build_webapp_restore_script(session_path: str, nextjs_port: int) -> str:
+    """Builds the shell script both sandbox managers run after a snapshot
+    restore.
+
+    Ports change across sleep/wake, so the script is always rewritten. Auto-starts the dev server only if the restored snapshot
+    actually contains a webapp (``outputs/web/package.json``), and backgrounds
+    it so wake isn't blocked on a cold bun install (node_modules is excluded
+    from snapshots). Echoes exactly one of the sentinels above on completion;
+    they are diagnostics for Docker and the success signal for Kubernetes.
+    """
+    write_snippet = build_webapp_script_write_snippet(session_path, nextjs_port)
+    return f"""
+set -e
+{write_snippet}
+if [ -f {session_path}/outputs/web/package.json ]; then
+    nohup bash {session_path}/start-webapp.sh > {session_path}/webapp-bootstrap.log 2>&1 &
+    echo "{WEBAPP_AUTOSTART_SENTINEL}"
+else
+    echo "{WEBAPP_ABSENT_SENTINEL}"
+fi
+"""
+
+
 def build_webapp_script_write_snippet(session_path: str, nextjs_port: int) -> str:
     """Builds a shell snippet (no shebang, no ``set -e``) that writes the
     ``chmod 444`` bootstrap script to the session root.

--- a/backend/onyx/server/features/build/sandbox/session_workspace.py
+++ b/backend/onyx/server/features/build/sandbox/session_workspace.py
@@ -2,22 +2,21 @@
 sandbox managers.
 
 The script is replay-safe: the whole setup is serialized per session with an
-in-sandbox ``flock``, an in-progress marker distinguishes a partial directory
-from a complete workspace, and the Next.js dev server is only spawned when no
-live server is already attached to the session. Re-running the script after an
-interruption converges on the same completed workspace.
+in-sandbox ``flock``, and an in-progress marker distinguishes a partial
+directory from a complete workspace. Setup is lazy with respect to the web
+app: it writes the tamper-hardened ``start-webapp.sh`` (when the session has
+a port) but never scaffolds the template, installs dependencies, or starts a
+dev server itself. Re-running the script after an interruption converges on
+the same completed workspace.
 """
 
 import shlex
 
-from onyx.server.features.build.sandbox.base import (
-    BUN_CACHE_DIR,
-    BUN_IMAGE_CACHE_DIR,
+from onyx.server.features.build.sandbox.nextjs_dev import (
+    build_webapp_script_write_snippet,
 )
-from onyx.server.features.build.sandbox.nextjs_dev import build_nextjs_start_script
 
 SESSIONS_ROOT = "/workspace/sessions"
-TEMPLATES_OUTPUTS_PATH = "/workspace/templates/outputs"
 MANAGED_SKILLS_PATH = "/workspace/managed/skills"
 MANAGED_USER_LIBRARY_PATH = "/workspace/managed/user_library"
 
@@ -53,35 +52,12 @@ def build_session_workspace_setup_script(
     """Build the shell script that creates a session workspace.
 
     Headless callers (scheduled tasks) pass ``nextjs_port=None`` — the agent's
-    tools work without a dev server.
+    tools work without a dev server, and no ``start-webapp.sh`` is written.
     """
-    outputs_setup = f"""
-echo "Copying outputs template"
-if [ -d {TEMPLATES_OUTPUTS_PATH} ]; then
-    cp -r {TEMPLATES_OUTPUTS_PATH}/* {session_path}/outputs/
-    # flock+sentinel: serialize concurrent session setups; .ready guards
-    # against a partial cp from a previous interrupted run.
-    (
-        flock -x 9
-        if [ ! -f {BUN_CACHE_DIR}/.ready ]; then
-            echo "Bootstrapping bun cache on workspace volume..."
-            rm -rf {BUN_CACHE_DIR}
-            cp -r {BUN_IMAGE_CACHE_DIR} {BUN_CACHE_DIR} \\
-                || {{ echo "ERROR: bun cache bootstrap failed" >&2; exit 1; }}
-            touch {BUN_CACHE_DIR}/.ready
-        fi
-    ) 9>{BUN_CACHE_DIR}.lock
-    cd {session_path}/outputs/web && \\
-        BUN_INSTALL_CACHE_DIR={BUN_CACHE_DIR} \\
-        bun install --frozen-lockfile --backend=hardlink
-else
-    echo "Warning: outputs template not found at {TEMPLATES_OUTPUTS_PATH}"
-    mkdir -p {session_path}/outputs/web
-fi
-"""
-
-    nextjs_start_script = (
-        build_nextjs_start_script(session_path, nextjs_port, check_node_modules=False)
+    webapp_script_write_snippet = (
+        # Lazy provisioning: write start-webapp.sh, but don't scaffold
+        # outputs/web, install, or start a dev server here.
+        build_webapp_script_write_snippet(session_path, nextjs_port)
         if nextjs_port is not None
         else ""
     )
@@ -91,10 +67,8 @@ set -e
 
 # Serialize workspace *materialization* per session with an flock: a concurrent
 # replay blocks here and then re-runs over the completed workspace, converging
-# instead of racing. The dev-server launch is deliberately NOT inside this
-# subshell — a backgrounded server started here would inherit fd 8 and hold the
-# lock for its entire lifetime, deadlocking every later repair/restore. It runs
-# after the lock releases and has its own pid-guard for idempotency.
+# instead of racing. Nothing spawned here outlives the setup, so nothing can
+# inherit fd 8 and hold the lock open.
 (
 flock -x 8
 set -e
@@ -104,9 +78,6 @@ mkdir -p {session_path}
 touch {session_path}/{SETUP_IN_PROGRESS_MARKER}
 mkdir -p {session_path}/outputs
 mkdir -p {session_path}/attachments
-
-# Setup outputs
-{outputs_setup}
 
 # DO NOT mkdir /workspace/managed/skills or /workspace/managed/user_library
 # here — the push daemon swaps these paths via os.rename(symlink, mount),
@@ -124,11 +95,11 @@ printf '%s' {shlex.quote(agents_md)} > {session_path}/AGENTS.md
 
 printf '%s' {shlex.quote(session_opencode_config_json)} > {session_path}/opencode.json
 
+{webapp_script_write_snippet}
+
 rm -f {session_path}/{SETUP_IN_PROGRESS_MARKER}
 echo "Workspace materialization complete"
 ) 8>{session_path}.setup.lock
 
-# Start Next.js dev server (outside the setup lock; own pid-guard).
-{nextjs_start_script}
 echo "{WORKSPACE_SETUP_COMPLETE_SENTINEL}"
 """

--- a/backend/onyx/server/features/build/sandbox/util/agent_instructions.py
+++ b/backend/onyx/server/features/build/sandbox/util/agent_instructions.py
@@ -2,14 +2,12 @@
 
 from collections.abc import Iterable
 from pathlib import Path
-from uuid import UUID
 
 from onyx.db.models import ExternalApp
 from onyx.server.features.build.configs import (
     SANDBOX_APPROVAL_WAIT_MARGIN_SECONDS,
     SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS,
 )
-from onyx.server.features.build.sandbox.nextjs_dev import webapp_base_path
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -108,8 +106,6 @@ def generate_agent_instructions(
     connectable_apps_section: str,
     provider: str | None = None,
     model_name: str | None = None,
-    nextjs_port: int | None = None,
-    session_id: UUID | None = None,
     disabled_tools: list[str] | None = None,
     user_name: str | None = None,
     organization_instructions: str | None = None,
@@ -121,8 +117,6 @@ def generate_agent_instructions(
         connectable_apps_section: Pre-rendered connectable-apps list (may be empty)
         provider: LLM provider type (e.g., "openai", "anthropic")
         model_name: Model name (e.g., "claude-sonnet-4-5", "gpt-4o")
-        nextjs_port: Port for Next.js development server
-        session_id: Session ID, used to render the webapp preview base path
         disabled_tools: List of disabled tools
         user_name: User's name for personalization
         organization_instructions: Admin-set workspace-wide Craft instructions
@@ -154,15 +148,6 @@ def generate_agent_instructions(
     content = content.replace("{{USER_CONTEXT}}", user_context)
     content = content.replace("{{LLM_PROVIDER_NAME}}", provider_display or "Unknown")
     content = content.replace("{{LLM_MODEL_NAME}}", model_name or "Unknown")
-    content = content.replace(
-        "{{NEXTJS_PORT}}", str(nextjs_port) if nextjs_port else "Unknown"
-    )
-    content = content.replace(
-        "{{WEBAPP_BASE_PATH}}",
-        webapp_base_path(session_id)
-        if session_id
-        else webapp_base_path("<session-id>"),
-    )
     content = content.replace(
         "{{APPROVAL_WAIT_TIMEOUT_SECONDS}}",
         str(SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS),

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -23,6 +23,17 @@ from onyx.server.features.build.sandbox.models import (
 _OPENAI_COMPATIBLE_NPM = "@ai-sdk/openai-compatible"
 
 
+_PROTECTED_FILE_RULES: dict[str, str] = {
+    # OpenCode uses the last matching rule, so specific denies must follow the
+    # catch-all allow.
+    "*": "allow",
+    "opencode.json": "deny",
+    "**/opencode.json": "deny",
+    "start-webapp.sh": "deny",
+    "**/start-webapp.sh": "deny",
+}
+
+
 _PERMISSIONS_TEMPLATE: dict[str, Any] = {
     "bash": {
         "rm": "deny",
@@ -41,17 +52,14 @@ _PERMISSIONS_TEMPLATE: dict[str, Any] = {
         "strings": "deny",
         "base64": "deny",
         "*": "allow",
+        "*start-webapp.sh*": "deny",
+        # The webapp plugin starts the script via child_process, not the bash
+        # tool. These are the two documented direct fallbacks for the agent.
+        "bash start-webapp.sh": "allow",
+        "bash ./start-webapp.sh": "allow",
     },
-    "edit": {
-        "opencode.json": "deny",
-        "**/opencode.json": "deny",
-        "*": "allow",
-    },
-    "write": {
-        "opencode.json": "deny",
-        "**/opencode.json": "deny",
-        "*": "allow",
-    },
+    "edit": _PROTECTED_FILE_RULES,
+    "write": _PROTECTED_FILE_RULES,
     "read": {
         "*": "allow",
         "opencode.json": "deny",
@@ -69,7 +77,7 @@ _PERMISSIONS_TEMPLATE: dict[str, Any] = {
     },
     "list": "allow",
     "lsp": "allow",
-    "patch": "allow",
+    "patch": _PROTECTED_FILE_RULES,
     # Deny opencode's built-in customize-opencode skill (edits opencode.json
     # via the skill tool, bypassing our edit/write denies). "*" must precede
     # the named deny — opencode evaluates skill rules with findLast().

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -64,6 +64,9 @@ from onyx.server.features.build.sandbox.models import (
     FilesystemEntry,
     PromptAttachment,
 )
+from onyx.server.features.build.sandbox.nextjs_dev import (
+    WEBAPP_PACKAGE_JSON_PATH,
+)
 from onyx.server.features.build.sandbox.serve_transport import PromptSlot
 from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
 from onyx.server.features.build.sandbox.util.agent_instructions import (
@@ -143,6 +146,9 @@ HIDDEN_PATTERNS = {
     "nextjs.log",
     "nextjs.pid",
 }
+
+_WEBAPP_DIRECTORY = str(Path(WEBAPP_PACKAGE_JSON_PATH).parent)
+_WEBAPP_PACKAGE_FILENAME = Path(WEBAPP_PACKAGE_JSON_PATH).name
 
 
 def _sanitize_zip_basename(name: str, *, allow_dots: bool) -> str:
@@ -1491,32 +1497,58 @@ class SessionManager:
         sandbox = get_sandbox_by_user_id(self._db_session, user_id)
         if sandbox is None:
             return {
-                "has_webapp": False,
+                "has_webapp": None,
                 "webapp_url": None,
                 "status": "no_sandbox",
                 "ready": False,
                 "sharing_scope": session.sharing_scope,
             }
 
+        has_webapp = (
+            self._has_scaffolded_webapp(sandbox.id, session_id)
+            if sandbox.status == SandboxStatus.RUNNING
+            else None
+        )
         # Return the proxy URL - the proxy handles routing to the correct sandbox
-        # for both local and Kubernetes environments
+        # for both local and Kubernetes environments.
         webapp_url = None
         ready = False
-        if session.nextjs_port:
+        if has_webapp and session.nextjs_port:
             webapp_url = f"{WEB_DOMAIN}/api/build/sessions/{session_id}/webapp"
-
-            # Quick health check: can the API server reach the NextJS dev server?
             ready = self._check_nextjs_ready(
                 sandbox.id, session_id, session.nextjs_port
             )
 
         return {
-            "has_webapp": session.nextjs_port is not None,
+            "has_webapp": has_webapp,
             "webapp_url": webapp_url,
             "status": sandbox.status.value,
             "ready": ready,
             "sharing_scope": session.sharing_scope,
         }
+
+    def _has_scaffolded_webapp(self, sandbox_id: UUID, session_id: UUID) -> bool | None:
+        """Return True if ``outputs/web/package.json`` exists in the session."""
+        try:
+            entries = self._sandbox_manager.list_directory(
+                sandbox_id=sandbox_id,
+                session_id=session_id,
+                path=_WEBAPP_DIRECTORY,
+            )
+        except ValueError:
+            return False
+        except RuntimeError:
+            logger.warning(
+                "Could not check webapp scaffold for session %s",
+                session_id,
+                exc_info=True,
+            )
+            return None
+
+        return any(
+            entry.name == _WEBAPP_PACKAGE_FILENAME and not entry.is_directory
+            for entry in entries
+        )
 
     def _check_nextjs_ready(
         self, sandbox_id: UUID, session_id: UUID, port: int

--- a/backend/onyx/server/features/build/session/models.py
+++ b/backend/onyx/server/features/build/session/models.py
@@ -279,7 +279,8 @@ class MessageListResponse(BaseModel):
 
 
 class WebappInfo(BaseModel):
-    has_webapp: bool  # Whether a webapp exists in outputs/web
+    # None means the sandbox is unavailable, so existence cannot be inspected.
+    has_webapp: bool | None
     webapp_url: str | None  # URL to access the webapp (e.g., http://localhost:3015)
     status: str  # Sandbox status (running, terminated, etc.)
     ready: bool  # Whether the NextJS dev server is actually responding

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_agent_instructions.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_agent_instructions.py
@@ -1,6 +1,5 @@
 import re
 from pathlib import Path
-from uuid import UUID
 
 import pytest
 
@@ -45,33 +44,15 @@ def test_generate_agent_instructions_populates_real_template_without_skills_sect
         connectable_apps_section="",
         provider="openai",
         model_name="gpt-5-mini",
-        nextjs_port=3210,
-        session_id=UUID("0d9ed7f2-8757-4d09-9812-bd7e4a45e232"),
         disabled_tools=["web-search", "shell"],
         user_name="TEST_USER",
     )
 
     assert "TEST_USER" in content
-    assert "3210" in content
     assert "OpenAI / gpt-5-mini" in content
     assert "web-search, shell" in content
     assert "## Skills" not in content
     assert "{{AVAILABLE_SKILLS_SECTION}}" not in content
-    assert _unresolved_placeholders(content) == set()
-
-
-def test_generate_agent_instructions_renders_webapp_preview_url() -> None:
-    """The agent must be told the exact preview URL — a base-path'd dev server
-    404s on every path outside the base path, so port alone is not enough."""
-    session_id = UUID("0d9ed7f2-8757-4d09-9812-bd7e4a45e232")
-    content = agent_instructions.generate_agent_instructions(
-        template_path=_template_path(),
-        connectable_apps_section="",
-        nextjs_port=3210,
-        session_id=session_id,
-    )
-
-    assert f"http://localhost:3210/api/build/sessions/{session_id}/webapp" in content
     assert _unresolved_placeholders(content) == set()
 
 

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_docker_serve_plumbing.py
@@ -246,7 +246,6 @@ def test_build_agents_md_renders_instructions(
     agents_md = mgr._build_agents_md(
         agent_provider=llm_config.provider,
         agent_model=llm_config.model_name,
-        nextjs_port=None,
         connectable_apps_section="",
     )
     assert isinstance(agents_md, str)

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_opencode_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import pytest
 
@@ -194,6 +195,32 @@ def test_base_config_keeps_sandbox_permissions_and_plugins() -> None:
         "*": "allow",
         "customize-opencode": "deny",
     }
+
+
+@pytest.mark.parametrize(
+    "config",
+    [build_opencode_base_config(), build_provider_opencode_config(_gateway())],
+)
+def test_start_webapp_script_is_write_protected(config: dict[str, Any]) -> None:
+    permissions = config["permission"]
+    assert isinstance(permissions, dict)
+
+    for permission_name in ("edit", "write", "patch"):
+        rules = permissions[permission_name]
+        assert isinstance(rules, dict)
+        assert rules["start-webapp.sh"] == "deny"
+        assert rules["**/start-webapp.sh"] == "deny"
+        assert list(rules).index("*") < list(rules).index("start-webapp.sh")
+
+    bash_rules = permissions["bash"]
+    assert isinstance(bash_rules, dict)
+    assert bash_rules["*start-webapp.sh*"] == "deny"
+    assert bash_rules["bash start-webapp.sh"] == "allow"
+    assert bash_rules["bash ./start-webapp.sh"] == "allow"
+    bash_rule_names = list(bash_rules)
+    deny_index = bash_rule_names.index("*start-webapp.sh*")
+    assert deny_index < bash_rule_names.index("bash start-webapp.sh")
+    assert deny_index < bash_rule_names.index("bash ./start-webapp.sh")
 
 
 def test_dev_mode_allows_external_directories() -> None:

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_session_workspace_script.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_session_workspace_script.py
@@ -52,13 +52,16 @@ class TestSetupScriptReplaySafety:
         # The flock must open before any workspace mutation.
         assert script.index("flock -x 8") < script.index("mkdir -p")
 
-    def test_dev_server_starts_outside_the_setup_lock(self) -> None:
-        # A backgrounded dev server inside the flock subshell would inherit
-        # fd 8 and hold the setup lock for its entire lifetime, deadlocking
-        # every later repair/restore. It must start after the lock releases.
+    def test_setup_never_eagerly_installs_or_starts_dev_server(self) -> None:
+        # Setup is lazy: it writes start-webapp.sh but never itself scaffolds
+        # outputs/web, installs deps, or execs a dev server. The eager
+        # `cd .../outputs/web && bun install` invocation this used to run
+        # directly (unquoted session path) must be gone; the only mention of
+        # those commands left is inert text inside the printf'd script.
         script = _setup_script()
-        lock_close = script.index(f"8>{_SESSION_PATH}.setup.lock")
-        assert script.index("bun run dev") > lock_close
+        assert f"cd {_SESSION_PATH}/outputs/web &&" not in script
+        assert "start-webapp.sh" in script
+        assert f"chmod 444 {_SESSION_PATH}/start-webapp.sh" in script
 
     def test_agents_md_is_shell_quoted(self) -> None:
         # Content with quotes must round-trip through printf without breaking

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_session_workspace_script.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_session_workspace_script.py
@@ -7,7 +7,10 @@ from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
     build_sandbox_labels,
 )
 from onyx.server.features.build.sandbox.labels import LABEL_PROVISIONING_ATTEMPT
-from onyx.server.features.build.sandbox.nextjs_dev import build_nextjs_start_script
+from onyx.server.features.build.sandbox.nextjs_dev import (
+    build_nextjs_start_script,
+    build_webapp_script_write_snippet,
+)
 from onyx.server.features.build.sandbox.session_workspace import (
     SETUP_IN_PROGRESS_MARKER,
     build_session_workspace_setup_script,
@@ -40,11 +43,13 @@ class TestWorkspaceExistsCheck:
 
 class TestSetupScriptReplaySafety:
     def test_marker_brackets_the_setup(self) -> None:
+        # The start-webapp.sh write is the last real mutation of the
+        # workspace; it must land between touch and removal of the marker.
         script = _setup_script()
         touch_index = script.index(f"touch {_SESSION_PATH}/{SETUP_IN_PROGRESS_MARKER}")
         remove_index = script.index(f"rm -f {_SESSION_PATH}/{SETUP_IN_PROGRESS_MARKER}")
-        outputs_index = script.index("Copying outputs template")
-        assert touch_index < outputs_index < remove_index
+        script_write_index = script.index(f"> {_SESSION_PATH}/start-webapp.sh")
+        assert touch_index < script_write_index < remove_index
 
     def test_materialization_serialized_with_session_flock(self) -> None:
         script = _setup_script()
@@ -54,12 +59,17 @@ class TestSetupScriptReplaySafety:
 
     def test_setup_never_eagerly_installs_or_starts_dev_server(self) -> None:
         # Setup is lazy: it writes start-webapp.sh but never itself scaffolds
-        # outputs/web, installs deps, or execs a dev server. The eager
-        # `cd .../outputs/web && bun install` invocation this used to run
-        # directly (unquoted session path) must be gone; the only mention of
-        # those commands left is inert text inside the printf'd script.
-        script = _setup_script()
-        assert f"cd {_SESSION_PATH}/outputs/web &&" not in script
+        # outputs/web, installs deps, or execs a dev server. Subtracting the
+        # printf'd start-webapp.sh payload (the one place those commands may
+        # legitimately appear, as inert quoted text) must leave a script with
+        # no scaffold/install/dev-server invocations at all.
+        script = _setup_script(nextjs_port=3010)
+        remainder = script.replace(
+            build_webapp_script_write_snippet(_SESSION_PATH, 3010), ""
+        )
+        assert "bun install" not in remainder
+        assert "bun run dev" not in remainder
+        assert "cp -r" not in remainder
         assert "start-webapp.sh" in script
         assert f"chmod 444 {_SESSION_PATH}/start-webapp.sh" in script
 

--- a/backend/tests/unit/onyx/server/features/craft/session/test_webapp_info.py
+++ b/backend/tests/unit/onyx/server/features/craft/session/test_webapp_info.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
+
+from onyx.db.enums import SandboxStatus
+from onyx.server.features.build.sandbox.models import FilesystemEntry
+from onyx.server.features.build.session.manager import SessionManager
+from tests.common.craft.stubs import StubSandboxManager
+
+
+def _manager(sandbox_manager: StubSandboxManager) -> SessionManager:
+    manager = SessionManager.__new__(SessionManager)
+    manager._db_session = MagicMock()
+    manager._sandbox_manager = sandbox_manager
+    return manager
+
+
+def _get_webapp_info(
+    manager: SessionManager,
+    *,
+    session: SimpleNamespace,
+    sandbox: SimpleNamespace | None,
+    session_id: UUID,
+    user_id: UUID,
+) -> dict[str, object] | None:
+    with (
+        patch(
+            "onyx.server.features.build.session.manager.get_build_session",
+            return_value=session,
+        ),
+        patch(
+            "onyx.server.features.build.session.manager.get_sandbox_by_user_id",
+            return_value=sandbox,
+        ),
+    ):
+        return manager.get_webapp_info(session_id, user_id)
+
+
+def _session() -> SimpleNamespace:
+    return SimpleNamespace(nextjs_port=3010, sharing_scope="private")
+
+
+def test_reserved_port_without_scaffold_is_not_a_webapp() -> None:
+    sandbox_manager = StubSandboxManager()
+    sandbox_manager.list_directory_returns_by_path = {}
+    manager = _manager(sandbox_manager)
+    session_id = uuid4()
+    user_id = uuid4()
+    sandbox = SimpleNamespace(id=uuid4(), status=SandboxStatus.RUNNING)
+
+    with patch.object(manager, "_check_nextjs_ready") as check_ready:
+        info = _get_webapp_info(
+            manager,
+            session=_session(),
+            sandbox=sandbox,
+            session_id=session_id,
+            user_id=user_id,
+        )
+
+    assert info is not None
+    assert info["has_webapp"] is False
+    assert info["webapp_url"] is None
+    assert info["ready"] is False
+    assert sandbox_manager.last_list_directory_payload == {
+        "sandbox_id": sandbox.id,
+        "session_id": session_id,
+        "path": "outputs/web",
+    }
+    check_ready.assert_not_called()
+
+
+def test_scaffold_marker_enables_readiness_probe() -> None:
+    sandbox_manager = StubSandboxManager()
+    sandbox_manager.list_directory_returns_by_path = {
+        "outputs/web": [
+            FilesystemEntry(
+                name="package.json",
+                path="outputs/web/package.json",
+                is_directory=False,
+            )
+        ]
+    }
+    manager = _manager(sandbox_manager)
+    session_id = uuid4()
+    user_id = uuid4()
+    sandbox = SimpleNamespace(id=uuid4(), status=SandboxStatus.RUNNING)
+
+    with patch.object(manager, "_check_nextjs_ready", return_value=True) as check_ready:
+        info = _get_webapp_info(
+            manager,
+            session=_session(),
+            sandbox=sandbox,
+            session_id=session_id,
+            user_id=user_id,
+        )
+
+    assert info is not None
+    assert info["has_webapp"] is True
+    assert info["ready"] is True
+    check_ready.assert_called_once_with(sandbox.id, session_id, 3010)
+
+
+def test_sleeping_sandbox_reports_webapp_existence_as_unknown() -> None:
+    sandbox_manager = StubSandboxManager()
+    manager = _manager(sandbox_manager)
+    session_id = uuid4()
+    user_id = uuid4()
+    sandbox = SimpleNamespace(id=uuid4(), status=SandboxStatus.SLEEPING)
+
+    with patch.object(manager, "_check_nextjs_ready") as check_ready:
+        info = _get_webapp_info(
+            manager,
+            session=_session(),
+            sandbox=sandbox,
+            session_id=session_id,
+            user_id=user_id,
+        )
+
+    assert info is not None
+    assert info["has_webapp"] is None
+    assert info["ready"] is False
+    assert sandbox_manager.list_directory_count == 0
+    check_ready.assert_not_called()
+
+
+def test_session_without_sandbox_reports_webapp_existence_as_unknown() -> None:
+    sandbox_manager = StubSandboxManager()
+    manager = _manager(sandbox_manager)
+
+    info = _get_webapp_info(
+        manager,
+        session=_session(),
+        sandbox=None,
+        session_id=uuid4(),
+        user_id=uuid4(),
+    )
+
+    assert info is not None
+    assert info["has_webapp"] is None
+    assert info["status"] == "no_sandbox"
+    assert info["ready"] is False
+
+
+def test_transient_scaffold_check_failure_reports_unknown() -> None:
+    sandbox_manager = StubSandboxManager()
+    manager = _manager(sandbox_manager)
+    session_id = uuid4()
+    user_id = uuid4()
+    sandbox = SimpleNamespace(id=uuid4(), status=SandboxStatus.RUNNING)
+
+    with (
+        patch.object(
+            sandbox_manager,
+            "list_directory",
+            side_effect=RuntimeError("sidecar unavailable"),
+        ),
+        patch.object(manager, "_check_nextjs_ready") as check_ready,
+    ):
+        info = _get_webapp_info(
+            manager,
+            session=_session(),
+            sandbox=sandbox,
+            session_id=session_id,
+            user_id=user_id,
+        )
+
+    assert info is not None
+    assert info["has_webapp"] is None
+    assert info["webapp_url"] is None
+    assert info["ready"] is False
+    check_ready.assert_not_called()

--- a/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
@@ -12,8 +12,11 @@ from uuid import UUID
 
 from onyx.server.features.build.sandbox import nextjs_dev
 from onyx.server.features.build.sandbox.nextjs_dev import (
+    WEBAPP_ABSENT_SENTINEL,
+    WEBAPP_AUTOSTART_SENTINEL,
     build_nextjs_start_script,
     build_webapp_bootstrap_script,
+    build_webapp_restore_script,
     build_webapp_script_write_snippet,
 )
 from onyx.server.features.build.sandbox.session_workspace import (
@@ -251,3 +254,28 @@ def test_webapp_script_write_snippet_removes_before_writing() -> None:
     remove_index = snippet.index("rm -f")
     write_index = snippet.index("printf")
     assert remove_index < write_index
+
+
+def test_restore_script_rewrites_scripts_before_gated_autostart() -> None:
+    script = build_webapp_restore_script(_SESSION_PATH, 3010)
+
+    # Script rewrite (with the new port) must come before the auto-start gate.
+    assert build_webapp_script_write_snippet(_SESSION_PATH, 3010) in script
+    gate = f"[ -f {_SESSION_PATH}/outputs/web/package.json ]"
+    assert gate in script
+    assert script.index("printf") < script.index(gate)
+
+    # The auto-start must exec the tamper-hardened canonical copy, gated on
+    # the webapp actually existing in the restored snapshot, and backgrounded.
+    autostart = f"nohup bash {_SESSION_PATH}/start-webapp.sh"
+    assert autostart in script
+    assert script.index(gate) < script.index(autostart)
+    assert f"> {_SESSION_PATH}/webapp-bootstrap.log 2>&1 &" in script
+
+    # Exactly one sentinel per branch; k8s restore relies on them for success.
+    assert WEBAPP_AUTOSTART_SENTINEL in script
+    assert WEBAPP_ABSENT_SENTINEL in script
+
+
+def test_restore_script_is_valid_bash() -> None:
+    _assert_valid_bash(build_webapp_restore_script(_SESSION_PATH, 3010))

--- a/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
@@ -16,6 +16,9 @@ from onyx.server.features.build.sandbox.nextjs_dev import (
     build_webapp_bootstrap_script,
     build_webapp_script_write_snippet,
 )
+from onyx.server.features.build.sandbox.session_workspace import (
+    build_session_workspace_setup_script,
+)
 from onyx.server.features.build.session.manager import SessionManager
 
 _SESSION_PATH = "/workspace/sessions/0d9ed7f2-8757-4d09-9812-bd7e4a45e232"
@@ -196,6 +199,48 @@ def test_bootstrap_script_reuses_live_server_via_embedded_guard() -> None:
     assert "already running" in script
     # Exactly one liveness guard: the embedded start script's.
     assert script.count("kill -0") == 1
+
+
+def test_setup_script_writes_start_webapp_script_and_chmod_444() -> None:
+    script = build_session_workspace_setup_script(
+        session_path=_SESSION_PATH,
+        agents_md="# Agent",
+        session_opencode_config_json='{"model": "x"}',
+        nextjs_port=3010,
+    )
+
+    assert f"> {_SESSION_PATH}/start-webapp.sh" in script
+    assert f"chmod 444 {_SESSION_PATH}/start-webapp.sh" in script
+    # No eager scaffold/install at setup time: the old eager invocations (bare
+    # session path, unquoted) are gone. What's left mentioning bun/outputs is
+    # inert text inside the printf'd start-webapp.sh payload, which addresses
+    # the session dir via the $SESSION_PATH shell variable instead.
+    assert f"cd {_SESSION_PATH}/outputs/web &&" not in script
+    assert (
+        f"cp -r /workspace/templates/outputs/* {_SESSION_PATH}/outputs/" not in script
+    )
+
+
+def test_setup_script_headless_writes_no_start_webapp_script() -> None:
+    script = build_session_workspace_setup_script(
+        session_path=_SESSION_PATH,
+        agents_md="# Agent",
+        session_opencode_config_json='{"model": "x"}',
+        nextjs_port=None,
+    )
+
+    assert "start-webapp.sh" not in script
+    assert "chmod 444" not in script
+
+
+def test_setup_script_is_valid_bash() -> None:
+    script = build_session_workspace_setup_script(
+        session_path=_SESSION_PATH,
+        agents_md="# Agent",
+        session_opencode_config_json='{"model": "x"}',
+        nextjs_port=3010,
+    )
+    _assert_valid_bash(script)
 
 
 def test_webapp_script_write_snippet_removes_before_writing() -> None:

--- a/docs/craft/lazy-webapp-provisioning.md
+++ b/docs/craft/lazy-webapp-provisioning.md
@@ -83,10 +83,13 @@ create conflicts and drift.
   path to a working preview.
 - **Tamper hardening (simplified 2026-08).** A single `start-webapp.sh` at the
   session root, `chmod 444` (rewrites unlink-then-write, since 444 blocks
-  in-place overwrite). No canonical/visible pair and no tool-side restore: if
-  the agent deletes it, the tool reports unavailable and setup/restore
-  regenerates it. Liveness is guarded once, inside the embedded start script
-  (pid + cwd identity); the bootstrap wrapper does not duplicate the check.
+  in-place overwrite). OpenCode's edit/write/patch permissions deny mutations
+  to the script, and bash permissions deny commands that mention it except the
+  documented `bash start-webapp.sh` fallback. No canonical/visible pair and no
+  tool-side restore: if the script is otherwise deleted, the tool reports
+  unavailable and setup/restore regenerates it. Liveness is guarded once,
+  inside the embedded start script (pid + cwd identity); the bootstrap wrapper
+  does not duplicate the check.
 - **Restore auto-starts only when a webapp exists**, keyed on
   `outputs/web/package.json` in the restored snapshot. Self-heals legacy sessions
   and skips sessions that never built a webapp — no migration needed.

--- a/web/src/app/craft/hooks/loadSessionRestore.test.ts
+++ b/web/src/app/craft/hooks/loadSessionRestore.test.ts
@@ -32,7 +32,7 @@ function runningSession(nextjsPort: number | null = null): unknown {
   };
 }
 
-function webappInfo(has_webapp: boolean, ready: boolean): unknown {
+function webappInfo(has_webapp: boolean | null, ready: boolean): unknown {
   return { has_webapp, webapp_url: null, status: "running", ready };
 }
 
@@ -623,6 +623,14 @@ describe("waitForWebappReady", () => {
     mockedApi.fetchWebappInfo
       .mockRejectedValueOnce(new Error("sandbox not reachable"))
       .mockResolvedValue(webappInfo(true, true) as never);
+    await waitForWebappReady(SESSION_ID, { intervalMs: 0 });
+    expect(mockedApi.fetchWebappInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps polling while webapp existence is unknown", async () => {
+    mockedApi.fetchWebappInfo
+      .mockResolvedValueOnce(webappInfo(null, false) as never)
+      .mockResolvedValue(webappInfo(false, false) as never);
     await waitForWebappReady(SESSION_ID, { intervalMs: 0 });
     expect(mockedApi.fetchWebappInfo).toHaveBeenCalledTimes(2);
   });

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -978,7 +978,7 @@ export async function waitForWebappReady(
       // keep polling
     }
     // Done on a definitive answer (no webapp or serving); errors keep polling.
-    if (info && (!info.has_webapp || info.ready)) return;
+    if (info && (info.has_webapp === false || info.ready)) return;
     await new Promise((resolve) => setTimeout(resolve, intervalMs));
   }
 }

--- a/web/src/app/craft/types/streamingTypes.ts
+++ b/web/src/app/craft/types/streamingTypes.ts
@@ -195,7 +195,7 @@ export interface ApiArtifactResponse {
 }
 
 export interface ApiWebappInfoResponse {
-  has_webapp: boolean;
+  has_webapp: boolean | null;
   webapp_url: string | null;
   status: string;
   ready: boolean;


### PR DESCRIPTION
## Description

The provisioning flip. Roughly two thirds of interactive sessions never build a web app, yet every session paid a template copy, `bun install`, and a long-lived `next dev` server at setup.

- Session setup no longer scaffolds `outputs/web`, installs deps, or starts a dev server. It writes the tamper-hardened `start-webapp.sh` pair (from the previous PR) and nothing else; headless (`nextjs_port=None`) sessions get no script at all.
- The `webapp` opencode tool is now registered in both sandbox managers, and `AGENTS.template.md` documents it as the primary way to start the dev server, with `bash start-webapp.sh` as the fallback.
- Restore always rewrites the script pair with the re-allocated port (ports change across sleep/wake), then auto-starts the server in the background only when the restored snapshot actually contains `outputs/web/package.json`. This self-heals legacy sessions and skips sessions without a webapp, no migration needed; backgrounding keeps wake fast even when a cold `bun install` is required.
- `nextjs_port` removed from the agent-instructions pipeline (AGENTS.md no longer embeds a port).

No auto-supervisor and no port auto-heal by design: a crashed server stays down and loud so the agent reads the error, and the managed port is the proxy's routing contract so a conflict fails with guidance instead of moving somewhere unreachable.

## How Has This Been Tested?

- Full craft unit suite at this tip: 701 passed (includes new lazy-setup assertions and the rewritten replay-safety test).
- pre-commit (ruff, ruff format, ty) clean.
- kind integration coverage (lazy pre-state, tool run through the proxy, restore with/without webapp) is planned as follow-up per the plan doc.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

**Stack:**
1. [lazy-webapp #13710](https://github.com/onyx-dot-app/onyx/pull/13710)
2. [craft-webapp-bootstrap #13711](https://github.com/onyx-dot-app/onyx/pull/13711)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazily provision the web app via a single tamper‑hardened `start-webapp.sh` exposed through the always‑on `webapp` tool. Adds launcher protections, verifies Kubernetes restore with sentinels, and only advertises a preview after a scaffold exists.

- New Features
  - Added always‑on `webapp` tool (start/status/logs/restart). Use it first; fallback is `bash start-webapp.sh`. Never run `bun run dev`.
  - Setup writes read‑only `start-webapp.sh` and never scaffolds `outputs/web` or starts a server.
  - Restore rewrites the script with the new port and background‑autostarts only when `outputs/web/package.json` exists; Docker/Kubernetes share one restore script and Kubernetes validates `ONYX_WEBAPP_AUTOSTART`/`ONYX_WEBAPP_ABSENT`.
  - Hardened the launcher: OpenCode permissions deny edit/write/patch and shell mutations of `start-webapp.sh` (while allowing `bash start-webapp.sh`/`bash ./start-webapp.sh`).
  - Webapp detection is explicit: `WebappInfo.has_webapp` is tri‑state (true/false/null) based on the `outputs/web/package.json` marker. Readiness is probed only when a scaffold exists, and the frontend keeps polling while `null`.

- Refactors
  - Removed eager preview details from AGENTS and regeneration: no embedded port or preview URL; dropped `nextjs_port` and `session_id` from instruction generation and Docker/Kubernetes regeneration.
  - Simplified workspace setup (no outputs template copy, no install/start at setup); always load `connect-app`, `turn-budget`, and `webapp` plugins.

<sup>Written for commit d0d0d4943482f3017e92d58342ec3858e753f10b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

