### PR TITLE
feat(craft): gate Preview tab on webapp readiness with three-state UX

### DIFF
--- a/web/src/app/craft/components/OutputPanel.tsx
+++ b/web/src/app/craft/components/OutputPanel.tsx
@@ -28,7 +28,10 @@ import { Text, Tooltip } from "@opal/components";
 import { SvgGlobe, SvgHardDrive, SvgFiles, SvgX, SvgLoader } from "@opal/icons";
 import { IconProps } from "@opal/types";
 import CraftingLoader from "@/app/craft/components/CraftingLoader";
-import type { WebappState } from "@/app/craft/components/output-panel/PreviewTab";
+import {
+  NO_WEBAPP_LABEL,
+  type WebappState,
+} from "@/app/craft/components/output-panel/interfaces";
 
 // Output panel sub-components. UrlBar is the always-visible chrome and stays
 // static; the heavy tab bodies (preview iframe, file browser, artifact list,
@@ -235,7 +238,6 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
     {
       refreshInterval: shouldPoll ? 2000 : 0,
       revalidateOnFocus: true,
-      keepPreviousData: true,
       // Stop polling via onSuccess (not a useEffect over `ready`) — a refresh
       // bump resets isWebappReady while `ready` stays true across fetches, so
       // an effect keyed on the value never re-fires and each poll window runs
@@ -282,12 +284,8 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
     cachedForSessionId === session?.id ? cachedWebappUrl : null;
   const displayUrl = webappUrl ?? validCachedUrl;
 
-  // Never point the iframe at a URL whose server hasn't been seen ready.
   const iframeUrl = webappHasBeenReady ? displayUrl : null;
 
-  // Three-state model (plus "unknown" while webapp-info hasn't loaded):
-  // "ready" once latched, "starting" once scaffolded (has_webapp) but not
-  // yet latched ready, "none" once loaded with no webapp ever scaffolded.
   const webappState: WebappState = webappHasBeenReady
     ? "ready"
     : !webappInfo
@@ -296,35 +294,47 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
         ? "starting"
         : "none";
 
-  // Preview is disabled only for "none"/"unknown" - a session exists but has
-  // no webapp yet, or webapp-info hasn't loaded. "starting" stays enabled so
-  // the user can watch the dev server boot. Sessions that don't exist yet
-  // keep the current welcome (CraftingLoader) behavior instead of disabling.
-  const previewEnabled =
-    !session || webappState === "starting" || webappState === "ready";
+  // Only a confirmed "none" disables Preview; "unknown" would flash the Files
+  // tab while webapp-info loads.
+  const previewEnabled = !session || webappState !== "none";
 
   // Redirect away from the Preview tab while it's disabled without
   // mutating the user's stored tab preference.
   const effectiveActiveTab: TabValue | null =
     activeTab === "preview" && !previewEnabled ? "files" : activeTab;
 
-  // One-shot auto-switch to Preview the moment this session's webapp first
-  // becomes ready. Fires once per session and never re-forces the tab if
-  // the user navigates away afterward.
-  const wasWebappReadyRef = useRef(false);
+  // One-shot auto-switch to Preview when this session's webapp is observed
+  // booting and then serving. Armed from the raw response rather than
+  // `webappState`, which is unavoidably "starting" for the one render between
+  // webapp-info arriving and `webappHasBeenReady` latching — reading it here
+  // would arm on every revisit of an already-serving session and force the
+  // tab the user had left.
+  const sawWebappStartingRef = useRef(false);
   useEffect(() => {
     // Wait for session-scoped state to catch up before evaluating - avoids
-    // reading a stale webappHasBeenReady value left over from the prior
-    // session during the render right after switching.
+    // reading stale webapp state left over from the prior session during
+    // the render right after switching.
     if (session?.id !== cachedForSessionId) {
-      wasWebappReadyRef.current = false;
+      sawWebappStartingRef.current = false;
       return;
     }
-    if (!wasWebappReadyRef.current && webappHasBeenReady && session?.id) {
-      setActiveOutputTab(session.id, "preview");
+    if (webappInfo?.has_webapp && !webappInfo.ready) {
+      sawWebappStartingRef.current = true;
+    } else if (webappState === "ready" && sawWebappStartingRef.current) {
+      sawWebappStartingRef.current = false;
+      if (session?.id && !isFilePreviewActive) {
+        setActiveOutputTab(session.id, "preview");
+      }
     }
-    wasWebappReadyRef.current = webappHasBeenReady;
-  }, [webappHasBeenReady, session?.id, cachedForSessionId, setActiveOutputTab]);
+  }, [
+    webappInfo?.has_webapp,
+    webappInfo?.ready,
+    webappState,
+    session?.id,
+    cachedForSessionId,
+    isFilePreviewActive,
+    setActiveOutputTab,
+  ]);
 
   // Tab navigation history
   const tabHistory = useTabHistory();
@@ -409,8 +419,11 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
       // Transient panel tab: bump key to reload standalone + content previews
       setFilePreviewRefreshKey((k) => k + 1);
     } else if (effectiveActiveTab === "preview") {
-      // Web preview tab: remount the iframe
+      // Remount the iframe, and re-probe readiness — while the panel is
+      // showing "none"/"starting" the iframe isn't mounted, so the key bump
+      // alone would make refresh a no-op.
       setPreviewRefreshKey((k) => k + 1);
+      mutate();
     } else if (effectiveActiveTab === "files" && session?.id) {
       // Files tab: revalidate the visible directory listings
       triggerFilesRefresh(session.id);
@@ -420,6 +433,7 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
     effectiveActiveTab,
     session?.id,
     triggerFilesRefresh,
+    mutate,
   ]);
 
   // Fetch artifacts - poll every 5 seconds when on artifacts tab
@@ -458,23 +472,24 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
             {tabs.map((tab) => {
               const Icon = tab.icon;
               const isActive = effectiveActiveTab === tab.value;
-              // Disable artifacts tab when no session; disable preview
-              // while the session has no webapp scaffolded yet.
               const isDisabled =
                 (tab.value === "artifacts" && !session) ||
                 (tab.value === "preview" && !previewEnabled);
               const isStarting =
                 tab.value === "preview" && webappState === "starting";
-              const disabledTooltip = isDisabled
+              const tooltip = isDisabled
                 ? tab.value === "preview"
-                  ? "No web app in this session yet"
+                  ? NO_WEBAPP_LABEL
                   : "Start building something to see artifacts!"
-                : undefined;
+                : isStarting
+                  ? "Starting the dev server..."
+                  : undefined;
 
               const tabButton = (
                 <button
                   onClick={() => !isDisabled && handlePinnedTabClick(tab.value)}
                   aria-disabled={isDisabled}
+                  aria-busy={isStarting}
                   className={cn(
                     "relative inline-flex items-center justify-center gap-2 px-5 py-1.5 rounded-t-lg",
                     "max-w-[15%] min-w-fit",
@@ -537,11 +552,7 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
               );
 
               return (
-                <Tooltip
-                  key={tab.value}
-                  tooltip={disabledTooltip}
-                  side="bottom"
-                >
+                <Tooltip key={tab.value} tooltip={tooltip} side="bottom">
                   {tabButton}
                 </Tooltip>
               );

--- a/web/src/app/craft/components/OutputPanel.tsx
+++ b/web/src/app/craft/components/OutputPanel.tsx
@@ -29,6 +29,8 @@ import { SvgGlobe, SvgHardDrive, SvgFiles, SvgX, SvgLoader } from "@opal/icons";
 import { IconProps } from "@opal/types";
 import CraftingLoader from "@/app/craft/components/CraftingLoader";
 import {
+  getWebappState,
+  isWebappPreviewEnabled,
   NO_WEBAPP_LABEL,
   type WebappState,
 } from "@/app/craft/components/output-panel/interfaces";
@@ -222,18 +224,21 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
 
   // Fetch webapp info from dedicated endpoint
   // Only fetch for real sessions when panel is fully open
-  const shouldFetchWebapp =
-    isFullyOpen &&
+  const canQueryWebapp = Boolean(
     session?.id &&
     !session.id.startsWith("temp-") &&
-    session.status !== "creating";
+    session.status !== "creating"
+  );
+  const shouldFetchWebapp = isFullyOpen && canQueryWebapp;
 
   // Poll every 2s while NextJS is starting up (capped at 30s), then stop
   const shouldPoll =
     !isWebappReady && pollingDeadline !== null && Date.now() < pollingDeadline;
 
   const { data: webappInfo, mutate } = useSWR(
-    shouldFetchWebapp ? SWR_KEYS.buildSessionWebappInfo(session.id) : null,
+    shouldFetchWebapp && session
+      ? SWR_KEYS.buildSessionWebappInfo(session.id)
+      : null,
     () => (session?.id ? fetchWebappInfo(session.id) : null),
     {
       refreshInterval: shouldPoll ? 2000 : 0,
@@ -286,17 +291,14 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
 
   const iframeUrl = webappHasBeenReady ? displayUrl : null;
 
-  const webappState: WebappState = webappHasBeenReady
-    ? "ready"
-    : !webappInfo
-      ? "unknown"
-      : webappInfo.has_webapp
-        ? "starting"
-        : "none";
+  const webappState: WebappState = getWebappState(
+    webappHasBeenReady,
+    webappInfo?.has_webapp
+  );
 
-  // Only a confirmed "none" disables Preview; "unknown" would flash the Files
-  // tab while webapp-info loads.
-  const previewEnabled = !session || webappState !== "none";
+  // Existing sessions stay on Preview while webapp-info loads. Provisioning
+  // sessions cannot be queried yet, so they start on Files instead.
+  const previewEnabled = isWebappPreviewEnabled(webappState, canQueryWebapp);
 
   // Redirect away from the Preview tab while it's disabled without
   // mutating the user's stored tab preference.

--- a/web/src/app/craft/components/OutputPanel.tsx
+++ b/web/src/app/craft/components/OutputPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useState, useEffect, useCallback } from "react";
+import { memo, useState, useEffect, useCallback, useRef } from "react";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import {
@@ -24,10 +24,11 @@ import {
 } from "@/app/craft/services/apiServices";
 import { getFileIcon } from "@/lib/utils";
 import { cn } from "@opal/utils";
-import { Text } from "@opal/components";
-import { SvgGlobe, SvgHardDrive, SvgFiles, SvgX } from "@opal/icons";
+import { Text, Tooltip } from "@opal/components";
+import { SvgGlobe, SvgHardDrive, SvgFiles, SvgX, SvgLoader } from "@opal/icons";
 import { IconProps } from "@opal/types";
 import CraftingLoader from "@/app/craft/components/CraftingLoader";
+import type { WebappState } from "@/app/craft/components/output-panel/PreviewTab";
 
 // Output panel sub-components. UrlBar is the always-visible chrome and stays
 // static; the heavy tab bodies (preview iframe, file browser, artifact list,
@@ -182,12 +183,16 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
   const [cachedForSessionId, setCachedForSessionId] = useState<string | null>(
     null
   );
+  // Latches once the webapp has been observed ready for this session, so a
+  // later crash/restart does not hide the Preview tab again.
+  const [webappHasBeenReady, setWebappHasBeenReady] = useState(false);
 
   // Clear cache when session changes
   useEffect(() => {
     if (session?.id !== cachedForSessionId) {
       setCachedWebappUrl(null);
       setCachedForSessionId(session?.id ?? null);
+      setWebappHasBeenReady(false);
     }
   }, [session?.id, cachedForSessionId]);
 
@@ -244,12 +249,23 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
     }
   );
 
-  // Update cache when SWR returns data for current session
+  // Gate on `ready`, not webapp_url alone - the URL can exist before the
+  // dev server has actually started serving.
   useEffect(() => {
-    if (webappInfo?.webapp_url && session?.id === cachedForSessionId) {
+    if (
+      webappInfo?.ready &&
+      webappInfo.webapp_url &&
+      session?.id === cachedForSessionId
+    ) {
       setCachedWebappUrl(webappInfo.webapp_url);
+      setWebappHasBeenReady(true);
     }
-  }, [webappInfo?.webapp_url, session?.id, cachedForSessionId]);
+  }, [
+    webappInfo?.ready,
+    webappInfo?.webapp_url,
+    session?.id,
+    cachedForSessionId,
+  ]);
 
   // Re-fetch webapp-info when web/ files change or after restore. Live code
   // edits reach the iframe via the proxied HMR websocket — no remount needed.
@@ -265,6 +281,50 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
   const validCachedUrl =
     cachedForSessionId === session?.id ? cachedWebappUrl : null;
   const displayUrl = webappUrl ?? validCachedUrl;
+
+  // Never point the iframe at a URL whose server hasn't been seen ready.
+  const iframeUrl = webappHasBeenReady ? displayUrl : null;
+
+  // Three-state model (plus "unknown" while webapp-info hasn't loaded):
+  // "ready" once latched, "starting" once scaffolded (has_webapp) but not
+  // yet latched ready, "none" once loaded with no webapp ever scaffolded.
+  const webappState: WebappState = webappHasBeenReady
+    ? "ready"
+    : !webappInfo
+      ? "unknown"
+      : webappInfo.has_webapp
+        ? "starting"
+        : "none";
+
+  // Preview is disabled only for "none"/"unknown" - a session exists but has
+  // no webapp yet, or webapp-info hasn't loaded. "starting" stays enabled so
+  // the user can watch the dev server boot. Sessions that don't exist yet
+  // keep the current welcome (CraftingLoader) behavior instead of disabling.
+  const previewEnabled =
+    !session || webappState === "starting" || webappState === "ready";
+
+  // Redirect away from the Preview tab while it's disabled without
+  // mutating the user's stored tab preference.
+  const effectiveActiveTab: TabValue | null =
+    activeTab === "preview" && !previewEnabled ? "files" : activeTab;
+
+  // One-shot auto-switch to Preview the moment this session's webapp first
+  // becomes ready. Fires once per session and never re-forces the tab if
+  // the user navigates away afterward.
+  const wasWebappReadyRef = useRef(false);
+  useEffect(() => {
+    // Wait for session-scoped state to catch up before evaluating - avoids
+    // reading a stale webappHasBeenReady value left over from the prior
+    // session during the render right after switching.
+    if (session?.id !== cachedForSessionId) {
+      wasWebappReadyRef.current = false;
+      return;
+    }
+    if (!wasWebappReadyRef.current && webappHasBeenReady && session?.id) {
+      setActiveOutputTab(session.id, "preview");
+    }
+    wasWebappReadyRef.current = webappHasBeenReady;
+  }, [webappHasBeenReady, session?.id, cachedForSessionId, setActiveOutputTab]);
 
   // Tab navigation history
   const tabHistory = useTabHistory();
@@ -348,14 +408,19 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
     if (isFilePreviewActive) {
       // Transient panel tab: bump key to reload standalone + content previews
       setFilePreviewRefreshKey((k) => k + 1);
-    } else if (activeOutputTab === "preview") {
+    } else if (effectiveActiveTab === "preview") {
       // Web preview tab: remount the iframe
       setPreviewRefreshKey((k) => k + 1);
-    } else if (activeOutputTab === "files" && session?.id) {
+    } else if (effectiveActiveTab === "files" && session?.id) {
       // Files tab: revalidate the visible directory listings
       triggerFilesRefresh(session.id);
     }
-  }, [isFilePreviewActive, activeOutputTab, session?.id, triggerFilesRefresh]);
+  }, [
+    isFilePreviewActive,
+    effectiveActiveTab,
+    session?.id,
+    triggerFilesRefresh,
+  ]);
 
   // Fetch artifacts - poll every 5 seconds when on artifacts tab
   const shouldFetchArtifacts =
@@ -392,19 +457,24 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
             {/* Pinned tabs */}
             {tabs.map((tab) => {
               const Icon = tab.icon;
-              const isActive = activeTab === tab.value;
-              // Disable artifacts tab when no session
-              const isDisabled = tab.value === "artifacts" && !session;
-              return (
+              const isActive = effectiveActiveTab === tab.value;
+              // Disable artifacts tab when no session; disable preview
+              // while the session has no webapp scaffolded yet.
+              const isDisabled =
+                (tab.value === "artifacts" && !session) ||
+                (tab.value === "preview" && !previewEnabled);
+              const isStarting =
+                tab.value === "preview" && webappState === "starting";
+              const disabledTooltip = isDisabled
+                ? tab.value === "preview"
+                  ? "No web app in this session yet"
+                  : "Start building something to see artifacts!"
+                : undefined;
+
+              const tabButton = (
                 <button
-                  key={tab.value}
                   onClick={() => !isDisabled && handlePinnedTabClick(tab.value)}
-                  disabled={isDisabled}
-                  title={
-                    isDisabled
-                      ? "Start building something to see artifacts!"
-                      : undefined
-                  }
+                  aria-disabled={isDisabled}
                   className={cn(
                     "relative inline-flex items-center justify-center gap-2 px-5 py-1.5 rounded-t-lg",
                     "max-w-[15%] min-w-fit",
@@ -427,17 +497,27 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
                       }}
                     />
                   )}
-                  <Icon
-                    size={16}
-                    className={cn(
-                      "stroke-current shrink-0",
-                      isDisabled
-                        ? "stroke-text-02"
-                        : isActive
-                          ? "stroke-text-04"
-                          : "stroke-text-03"
-                    )}
-                  />
+                  {isStarting ? (
+                    <SvgLoader
+                      size={16}
+                      className={cn(
+                        "stroke-current shrink-0 motion-safe:animate-spin",
+                        isActive ? "stroke-text-04" : "stroke-text-03"
+                      )}
+                    />
+                  ) : (
+                    <Icon
+                      size={16}
+                      className={cn(
+                        "stroke-current shrink-0",
+                        isDisabled
+                          ? "stroke-text-02"
+                          : isActive
+                            ? "stroke-text-04"
+                            : "stroke-text-03"
+                      )}
+                    />
+                  )}
                   <Text color={isDisabled ? "text-02" : "text-05"} maxLines={1}>
                     {tab.label}
                   </Text>
@@ -454,6 +534,16 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
                     />
                   )}
                 </button>
+              );
+
+              return (
+                <Tooltip
+                  key={tab.value}
+                  tooltip={disabledTooltip}
+                  side="bottom"
+                >
+                  {tabButton}
+                </Tooltip>
               );
             })}
 
@@ -543,11 +633,11 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
         displayUrl={
           isFilePreviewActive && activeFilePath
             ? `sandbox://${activeFilePath}`
-            : activeOutputTab === "preview"
+            : effectiveActiveTab === "preview"
               ? session
-                ? displayUrl || "Loading..."
+                ? iframeUrl || "Loading..."
                 : "no-active-sandbox://"
-              : activeOutputTab === "files"
+              : effectiveActiveTab === "files"
                 ? session
                   ? "sandbox://"
                   : preProvisionedSessionId
@@ -564,10 +654,10 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
         onForward={handleForward}
         previewUrl={
           !isFilePreviewActive &&
-          activeOutputTab === "preview" &&
-          displayUrl &&
-          displayUrl.startsWith("http")
-            ? displayUrl
+          effectiveActiveTab === "preview" &&
+          iframeUrl &&
+          iframeUrl.startsWith("http")
+            ? iframeUrl
             : null
         }
         onDownloadRaw={
@@ -585,12 +675,12 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
         onDownload={isMarkdownPreview ? handleDocxDownload : undefined}
         isDownloading={isExportingDocx}
         onRefresh={handleRefresh}
-        isRefreshing={activeOutputTab === "files" && filesRefreshing}
+        isRefreshing={effectiveActiveTab === "files" && filesRefreshing}
         sessionId={
           !isFilePreviewActive &&
-          activeOutputTab === "preview" &&
+          effectiveActiveTab === "preview" &&
           session?.id &&
-          displayUrl?.startsWith("http")
+          iframeUrl?.startsWith("http")
             ? session.id
             : undefined
         }
@@ -611,7 +701,7 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
         {/* Pinned tab content - only show when no file preview is active */}
         {!isFilePreviewActive && (
           <>
-            {activeOutputTab === "preview" &&
+            {effectiveActiveTab === "preview" &&
               shouldRenderContent &&
               // Show crafting loader only when no session exists (welcome state)
               // Otherwise, PreviewTab handles the loading/iframe display
@@ -619,14 +709,15 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
                 <CraftingLoader />
               ) : (
                 <PreviewTab
-                  webappUrl={displayUrl}
+                  webappUrl={iframeUrl}
+                  webappState={webappState}
                   // Remounts on manual refresh and after a restore (the new
                   // pod's HMR socket can't update the old page). Live edits
                   // flow through HMR and never remount.
                   refreshKey={previewRefreshKey + webappNeedsRemount}
                 />
               ))}
-            {activeOutputTab === "files" && (
+            {effectiveActiveTab === "files" && (
               <FilesTab
                 key={session?.id ?? preProvisionedSessionId}
                 sessionId={session?.id ?? preProvisionedSessionId}
@@ -636,7 +727,7 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
                 isProvisioning={!session && isPreProvisioning}
               />
             )}
-            {activeOutputTab === "artifacts" && (
+            {effectiveActiveTab === "artifacts" && (
               <ArtifactsTab
                 artifacts={artifacts}
                 sessionId={session?.id ?? null}

--- a/web/src/app/craft/components/output-panel/PreviewTab.tsx
+++ b/web/src/app/craft/components/output-panel/PreviewTab.tsx
@@ -2,9 +2,21 @@
 
 import { useState, useEffect } from "react";
 import { cn } from "@opal/utils";
+import { Text } from "@opal/components";
+import { Section } from "@/layouts/general-layouts";
+import { SvgGlobe, SvgLoader } from "@opal/icons";
+
+/**
+ * "unknown" - webapp-info hasn't loaded yet for this session.
+ * "none" - webapp-info loaded, no webapp has ever been scaffolded.
+ * "starting" - webapp scaffolded (has_webapp) but not yet serving.
+ * "ready" - server has been observed ready at least once (latched).
+ */
+export type WebappState = "unknown" | "none" | "starting" | "ready";
 
 interface PreviewTabProps {
   webappUrl: string | null;
+  webappState: WebappState;
   /** Changing this value forces the iframe to fully remount / reload */
   refreshKey?: number;
 }
@@ -13,10 +25,16 @@ interface PreviewTabProps {
  * PreviewTab - Shows the webapp iframe preview
  *
  * States:
- * - No webapp URL yet: Shows blank dark background while SWR fetches
- * - Has webapp URL: Shows iframe with crossfade from blank background
+ * - "unknown": Shows blank dark background while SWR fetches
+ * - "none": Shows an empty state (no web app in this session yet)
+ * - "starting": Shows a spinner state while the dev server boots
+ * - "ready": Shows iframe with crossfade from blank background
  */
-export default function PreviewTab({ webappUrl, refreshKey }: PreviewTabProps) {
+export default function PreviewTab({
+  webappUrl,
+  webappState,
+  refreshKey,
+}: PreviewTabProps) {
   const [iframeLoaded, setIframeLoaded] = useState(false);
 
   // Reset loaded state when URL or refreshKey changes
@@ -24,7 +42,61 @@ export default function PreviewTab({ webappUrl, refreshKey }: PreviewTabProps) {
     setIframeLoaded(false);
   }, [webappUrl, refreshKey]);
 
-  // Base background shown while loading or when no webapp exists yet
+  if (webappState === "none") {
+    return (
+      <div className="h-full flex flex-col">
+        <div className="flex-1 p-3 relative">
+          <Section
+            height="full"
+            alignItems="center"
+            justifyContent="center"
+            gap={0.5}
+            padding={2}
+            className="rounded-b-08 bg-neutral-950"
+          >
+            <SvgGlobe size={48} className="stroke-text-inverted-02" />
+            <Text font="heading-h3" color="text-inverted-03">
+              No web app in this session yet
+            </Text>
+            <Text font="secondary-body" color="text-inverted-02">
+              A live preview appears here once a web app is running.
+            </Text>
+          </Section>
+        </div>
+      </div>
+    );
+  }
+
+  if (webappState === "starting") {
+    return (
+      <div className="h-full flex flex-col">
+        <div className="flex-1 p-3 relative">
+          <Section
+            height="full"
+            alignItems="center"
+            justifyContent="center"
+            gap={0.5}
+            padding={2}
+            className="rounded-b-08 bg-neutral-950"
+          >
+            <SvgLoader
+              size={48}
+              className="stroke-text-inverted-02 motion-safe:animate-spin"
+            />
+            <Text font="heading-h3" color="text-inverted-03">
+              Starting the dev server...
+            </Text>
+            <Text font="secondary-body" color="text-inverted-02">
+              Installing dependencies and booting. This usually takes under a
+              minute.
+            </Text>
+          </Section>
+        </div>
+      </div>
+    );
+  }
+
+  // Base background shown while loading ("unknown") or transitioning to ready
   return (
     <div className="h-full flex flex-col">
       <div className="flex-1 p-3 relative">

--- a/web/src/app/craft/components/output-panel/PreviewTab.tsx
+++ b/web/src/app/craft/components/output-panel/PreviewTab.tsx
@@ -5,14 +5,10 @@ import { cn } from "@opal/utils";
 import { Text } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
 import { SvgGlobe, SvgLoader } from "@opal/icons";
-
-/**
- * "unknown" - webapp-info hasn't loaded yet for this session.
- * "none" - webapp-info loaded, no webapp has ever been scaffolded.
- * "starting" - webapp scaffolded (has_webapp) but not yet serving.
- * "ready" - server has been observed ready at least once (latched).
- */
-export type WebappState = "unknown" | "none" | "starting" | "ready";
+import {
+  NO_WEBAPP_LABEL,
+  type WebappState,
+} from "@/app/craft/components/output-panel/interfaces";
 
 interface PreviewTabProps {
   webappUrl: string | null;
@@ -23,12 +19,6 @@ interface PreviewTabProps {
 
 /**
  * PreviewTab - Shows the webapp iframe preview
- *
- * States:
- * - "unknown": Shows blank dark background while SWR fetches
- * - "none": Shows an empty state (no web app in this session yet)
- * - "starting": Shows a spinner state while the dev server boots
- * - "ready": Shows iframe with crossfade from blank background
  */
 export default function PreviewTab({
   webappUrl,
@@ -44,55 +34,44 @@ export default function PreviewTab({
 
   if (webappState === "none") {
     return (
-      <div className="h-full flex flex-col">
-        <div className="flex-1 p-3 relative">
-          <Section
-            height="full"
-            alignItems="center"
-            justifyContent="center"
-            gap={0.5}
-            padding={2}
-            className="rounded-b-08 bg-neutral-950"
-          >
-            <SvgGlobe size={48} className="stroke-text-inverted-02" />
-            <Text font="heading-h3" color="text-inverted-03">
-              No web app in this session yet
-            </Text>
-            <Text font="secondary-body" color="text-inverted-02">
-              A live preview appears here once a web app is running.
-            </Text>
-          </Section>
-        </div>
-      </div>
+      <Section
+        height="full"
+        alignItems="center"
+        justifyContent="center"
+        padding={2}
+      >
+        <SvgGlobe size={48} className="stroke-text-02" aria-hidden />
+        <Text font="heading-h3" color="text-03">
+          {NO_WEBAPP_LABEL}
+        </Text>
+        <Text font="secondary-body" color="text-02">
+          A live preview appears here once a web app is running.
+        </Text>
+      </Section>
     );
   }
 
   if (webappState === "starting") {
     return (
-      <div className="h-full flex flex-col">
-        <div className="flex-1 p-3 relative">
-          <Section
-            height="full"
-            alignItems="center"
-            justifyContent="center"
-            gap={0.5}
-            padding={2}
-            className="rounded-b-08 bg-neutral-950"
-          >
-            <SvgLoader
-              size={48}
-              className="stroke-text-inverted-02 motion-safe:animate-spin"
-            />
-            <Text font="heading-h3" color="text-inverted-03">
-              Starting the dev server...
-            </Text>
-            <Text font="secondary-body" color="text-inverted-02">
-              Installing dependencies and booting. This usually takes under a
-              minute.
-            </Text>
-          </Section>
-        </div>
-      </div>
+      <Section
+        height="full"
+        alignItems="center"
+        justifyContent="center"
+        padding={2}
+        role="status"
+      >
+        <SvgLoader
+          size={48}
+          className="stroke-text-02 motion-safe:animate-spin"
+          aria-hidden
+        />
+        <Text font="heading-h3" color="text-03">
+          Starting the dev server...
+        </Text>
+        <Text font="secondary-body" color="text-02">
+          Installing dependencies and booting.
+        </Text>
+      </Section>
     );
   }
 

--- a/web/src/app/craft/components/output-panel/interfaces.test.tsx
+++ b/web/src/app/craft/components/output-panel/interfaces.test.tsx
@@ -1,0 +1,44 @@
+import {
+  getWebappState,
+  isWebappPreviewEnabled,
+  type WebappState,
+} from "@/app/craft/components/output-panel/interfaces";
+
+describe("getWebappState", () => {
+  test.each<{
+    hasBeenReady: boolean;
+    hasWebapp: boolean | null | undefined;
+    expected: WebappState;
+  }>([
+    { hasBeenReady: true, hasWebapp: null, expected: "ready" },
+    { hasBeenReady: false, hasWebapp: undefined, expected: "unknown" },
+    { hasBeenReady: false, hasWebapp: null, expected: "unknown" },
+    { hasBeenReady: false, hasWebapp: false, expected: "none" },
+    { hasBeenReady: false, hasWebapp: true, expected: "starting" },
+  ])(
+    "returns $expected for ready=$hasBeenReady and hasWebapp=$hasWebapp",
+    ({ hasBeenReady, hasWebapp, expected }) => {
+      expect(getWebappState(hasBeenReady, hasWebapp)).toBe(expected);
+    }
+  );
+});
+
+describe("isWebappPreviewEnabled", () => {
+  test.each<{
+    state: WebappState;
+    canQueryWebapp: boolean;
+    expected: boolean;
+  }>([
+    { state: "unknown", canQueryWebapp: false, expected: false },
+    { state: "ready", canQueryWebapp: false, expected: false },
+    { state: "unknown", canQueryWebapp: true, expected: true },
+    { state: "none", canQueryWebapp: true, expected: false },
+    { state: "starting", canQueryWebapp: true, expected: true },
+    { state: "ready", canQueryWebapp: true, expected: true },
+  ])(
+    "returns $expected for $state when queryable=$canQueryWebapp",
+    ({ state, canQueryWebapp, expected }) => {
+      expect(isWebappPreviewEnabled(state, canQueryWebapp)).toBe(expected);
+    }
+  );
+});

--- a/web/src/app/craft/components/output-panel/interfaces.ts
+++ b/web/src/app/craft/components/output-panel/interfaces.ts
@@ -6,4 +6,20 @@
  */
 export type WebappState = "unknown" | "none" | "starting" | "ready";
 
+export function getWebappState(
+  hasBeenReady: boolean,
+  hasWebapp: boolean | null | undefined
+): WebappState {
+  if (hasBeenReady) return "ready";
+  if (hasWebapp == null) return "unknown";
+  return hasWebapp ? "starting" : "none";
+}
+
+export function isWebappPreviewEnabled(
+  state: WebappState,
+  canQueryWebapp: boolean
+): boolean {
+  return canQueryWebapp && state !== "none";
+}
+
 export const NO_WEBAPP_LABEL = "No web app in this session yet";

--- a/web/src/app/craft/components/output-panel/interfaces.ts
+++ b/web/src/app/craft/components/output-panel/interfaces.ts
@@ -1,0 +1,9 @@
+/**
+ * "unknown" - webapp-info hasn't loaded yet for this session.
+ * "none" - webapp-info loaded, no webapp has ever been scaffolded.
+ * "starting" - webapp scaffolded (has_webapp) but not yet serving.
+ * "ready" - server has been observed ready at least once (latched).
+ */
+export type WebappState = "unknown" | "none" | "starting" | "ready";
+
+export const NO_WEBAPP_LABEL = "No web app in this session yet";


### PR DESCRIPTION
## Description

Frontend for lazy webapp provisioning. The Preview tab previously pointed an iframe at the webapp URL as soon as it existed, showing a broken/empty frame before the server was up; with lazy provisioning most sessions never have a server at all.

Drives the tab from the already-polled webapp-info (`has_webapp` + `ready`), which the old code collapsed into one signal:

- "none": Preview tab disabled with an opal `Tooltip` (replacing the native `title` on both disabled-tab cases); active preview selection redirects to Files without mutating the user's stored tab preference. PreviewTab gets a teaching empty state.
- "starting" (`has_webapp` true, not yet ready): tab enabled with a spinning `SvgLoader` (`motion-safe:animate-spin`, matching opal's own Loader) and a "Starting the dev server..." panel, so the 30-90s scaffold/install/boot window reads as progress instead of a disabled tab.
- "ready": latched per session (a later crash does not hide the tab), one-shot auto-switch to Preview on first-ready (race-guarded per session, never re-fires after the user navigates away), and the iframe/open-in-new-tab URL is only populated once the server has been seen ready.

## How Has This Been Tested?

- `bun run types:check` clean at this tip; oxlint and oxfmt clean via pre-commit.
- Manual state-machine review: latch reset on session switch, auto-switch one-shot guard, redirect-vs-store separation.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

**Stack:**
1. [lazy-webapp #13710](https://github.com/onyx-dot-app/onyx/pull/13710)
2. [craft-webapp-bootstrap #13711](https://github.com/onyx-dot-app/onyx/pull/13711)
3. [craft-lazy-webapp #13712](https://github.com/onyx-dot-app/onyx/pull/13712)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the Preview tab on webapp readiness with a three‑state UX to prevent broken iframes. Keeps Preview for existing, queryable sessions while webapp-info loads, disables it during provisioning, and only mounts the iframe after the server is ready.

- **New Features**
  - Three-state gating: `none`, `starting`, `ready` (latched per session). Iframe and "open in new tab" URLs are set only after ready; dropped SWR `keepPreviousData` to prevent cross-session latching.
  - UX/flow: Only a confirmed `none` disables Preview; `unknown` no longer redirects to Files. Provisioning (`temp`/`creating`) sessions land on Files. `starting` shows a spinner in the tab and panel; `none` shows a tooltip and teaching empty state, restyled for dark mode. Adds tooltips and ARIA states on tabs.
  - Behavior: Auto-switch to Preview once on the first observed starting→ready per session (never on revisits/reloads, and never while a file preview is open). Refresh re-probes readiness and remounts the iframe; session switches reset latches and cached URLs.

- **Refactors**
  - Extracted `WebappState`, helpers, and shared label to `output-panel/interfaces.ts` with unit tests for state derivation and gating.

<sup>Written for commit f396b949f55be660c64996c721ee60c9b36849ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

