### PR TITLE
chore(craft): bump sandbox onyx-cli pin to 1.3.3

### DIFF
--- a/backend/onyx/server/features/build/sandbox/image/initial-requirements.txt
+++ b/backend/onyx/server/features/build/sandbox/image/initial-requirements.txt
@@ -61,7 +61,7 @@ numpy==2.4.6
     #   contourpy
     #   matplotlib
     #   pandas
-onyx-cli==1.2.3
+onyx-cli==1.3.3
     # via -r initial-requirements.in
 openpyxl==3.1.5
     # via -r initial-requirements.in


### PR DESCRIPTION
## Description

Stacked on #13709. Bumps the sandbox image's `onyx-cli` pin from 1.2.3 (latest published: 1.3.2) to 1.3.3 so Craft sandboxes get concurrent multi-query search.

**Merge order matters — do not merge until 1.3.3 exists on PyPI:**
1. Merge #13709.
2. Push tag `cli/v1.3.3` — `release-cli.yml` builds and publishes to PyPI.
3. Merge this PR (sandbox image builds `pip install onyx-cli==1.3.3` and would fail before step 2 completes).

## How Has This Been Tested?

Pin-only change; the CLI behavior itself was tested in #13709 (unit suite + end-to-end in a kind dev-cluster sandbox via binary swap).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins sandbox image `onyx-cli` to 1.3.3 (from 1.2.3) so Craft sandboxes use the latest CLI.

- **Migration**
  - Merge after `onyx-cli` 1.3.3 is available on PyPI.

<sup>Written for commit d0e05cd4a2753542ad291ede77b37958ffa5b51b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

