### PR TITLE
feat(mcp): arbitrary connection headers for all servers

### DIFF
--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -29,7 +29,13 @@ from onyx.db.models import (
     User__UserGroup,
     UserRole,
 )
-from onyx.server.features.mcp.models import DENYLISTED_MCP_HEADERS, MCPConnectionData
+from onyx.server.features.mcp.models import (
+    DENYLISTED_MCP_HEADERS,
+    MCPAuthTemplate,
+    MCPConnectionData,
+    MCPOAuthKeys,
+    merge_mcp_headers,
+)
 from onyx.utils.logger import setup_logger
 from onyx.utils.sensitive import SensitiveValue
 
@@ -419,28 +425,81 @@ class MCPCredentialsError(Exception):
     """Credentials for an MCP server cannot be resolved for this user."""
 
 
-class ResolvedMCPCredentials(BaseModel):
-    """Credential source for one (server, user) pair.
+def get_mcp_auth_template(mcp_server: MCPServer) -> MCPAuthTemplate | None:
+    """Read the canonical admin template, including legacy per-user API keys."""
+    config = mcp_server.admin_connection_config
+    if config is None:
+        return None
+    data = extract_connection_data(config, apply_mask=False)
+    headers = data.get("header_template")
+    if headers is None and (
+        mcp_server.auth_type == MCPAuthenticationType.API_TOKEN
+        and mcp_server.auth_performer == MCPAuthenticationPerformer.PER_USER
+    ):
+        headers = data.get("headers")
+    if headers is None:
+        return None
+    return MCPAuthTemplate(headers=headers)
 
-    Exactly one of the fields is populated (both are None for auth type NONE):
-    `connection_config` for API_TOKEN / OAUTH servers, `user_oauth_token` for
-    PT_OAUTH servers.
-    """
+
+class ResolvedMCPCredentials(BaseModel):
+    """Effective connection state for one MCP server and user."""
 
     model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
 
     connection_config: MCPConnectionConfig | None
     user_oauth_token: str | None
+    auth_type: MCPAuthenticationType | None = None
+    auth_performer: MCPAuthenticationPerformer | None = None
+    auth_template: MCPAuthTemplate | None = None
+    user_email: str = ""
+
+    def _config_data(self) -> MCPConnectionData:
+        return extract_connection_data(self.connection_config, apply_mask=False)
+
+    def _template_substitutions(self) -> dict[str, str]:
+        data = self._config_data()
+        substitutions = dict(data.get("header_substitutions", {}))
+        if api_token := data.get("api_token"):
+            substitutions["api_key"] = api_token
+        return substitutions
+
+    def _configured_headers(self) -> dict[str, str]:
+        data = self._config_data()
+        template_headers: dict[str, str] = {}
+        if self.auth_template is not None and self._has_required_substitutions():
+            template_headers = self.auth_template.render(
+                self._template_substitutions(), user_email=self.user_email
+            )
+        return merge_mcp_headers(data.get("headers", {}), template_headers)
+
+    def _generated_auth_headers(self) -> dict[str, str]:
+        if self.user_oauth_token:
+            return {"Authorization": f"Bearer {self.user_oauth_token}"}
+        if self.auth_type != MCPAuthenticationType.OAUTH:
+            return {}
+        tokens = self._config_data().get(MCPOAuthKeys.TOKENS.value)
+        if not tokens:
+            return {}
+        token_type = tokens.get("token_type")
+        access_token = tokens.get("access_token")
+        if not token_type or not access_token:
+            return {}
+        return {"Authorization": f"{token_type} {access_token}"}
+
+    def _has_required_substitutions(self) -> bool:
+        if self.auth_template is None or not self.auth_template.required_fields:
+            return True
+        substitutions = self._template_substitutions()
+        return all(
+            substitutions.get(field) for field in self.auth_template.required_fields
+        )
 
     def build_headers(self) -> dict[str, str]:
-        """Auth headers for a request to the server: the stored
-        connection-config headers, with PT_OAUTH's login token taking
-        precedence. Empty when no credentials are stored.
-
-        Denylisted headers (see DENYLISTED_MCP_HEADERS) are stripped so every
-        consumer gets the security filter automatically — stored credentials
-        must never source e.g. a Host header."""
-        stored = extract_connection_data(self.connection_config).get("headers", {})
+        """Build configured headers with generated authentication taking precedence."""
+        stored = merge_mcp_headers(
+            self._configured_headers(), self._generated_auth_headers()
+        )
         headers = {
             k: v for k, v in stored.items() if k.lower() not in DENYLISTED_MCP_HEADERS
         }
@@ -451,9 +510,19 @@ class ResolvedMCPCredentials(BaseModel):
                 "that were stripped: %s",
                 sorted(k for k in stored if k.lower() in DENYLISTED_MCP_HEADERS),
             )
-        if self.user_oauth_token:
-            headers["Authorization"] = f"Bearer {self.user_oauth_token}"
         return headers
+
+    def is_authenticated(self) -> bool:
+        if self.auth_type in (None, MCPAuthenticationType.NONE):
+            return self._has_required_substitutions()
+        if self.auth_type == MCPAuthenticationType.PT_OAUTH:
+            return bool(self.user_oauth_token) and self._has_required_substitutions()
+        if self.auth_type == MCPAuthenticationType.OAUTH:
+            return (
+                bool(self._generated_auth_headers())
+                and self._has_required_substitutions()
+            )
+        return bool(self._configured_headers()) and self._has_required_substitutions()
 
 
 def resolve_mcp_credentials(
@@ -463,33 +532,32 @@ def resolve_mcp_credentials(
     *,
     user_configs: Mapping[int, MCPConnectionConfig] | None = None,
 ) -> ResolvedMCPCredentials:
-    """Resolve which stored credentials authenticate `user` against `mcp_server`.
+    """Combine the admin template, user substitutions, and generated auth.
 
-    The single source of truth for the performer/auth-type branching, shared by
-    chat's MCPTool construction and Craft's sandbox-proxy credential injection:
-    - PT_OAUTH: the user's login OAuth token; no stored config row.
-    - API_TOKEN / OAUTH: the user's own `mcp_connection_config` row for
-      PER_USER servers, the admin config row otherwise.
-    - NONE: no credentials.
-
-    `user_configs` lets a caller resolving many servers pre-load the per-user
-    rows in one query (see `get_user_connection_configs`) instead of one per
-    server. It must cover every server the caller resolves — a miss reads as no
-    stored credential, not as unknown.
-
-    Raises MCPCredentialsError for PT_OAUTH with the anonymous user, who has no
-    login OAuth token.
+    `user_configs` may preload every requested server's user row; a missing key
+    means no stored user values.
     """
+    auth_template = get_mcp_auth_template(mcp_server)
+    user_connection_config = (
+        user_configs.get(mcp_server.id)
+        if user_configs is not None
+        else get_user_connection_config(mcp_server.id, user.email, db_session)
+    )
+
     if mcp_server.auth_type == MCPAuthenticationType.PT_OAUTH:
         if user.is_anonymous:
             raise MCPCredentialsError(
                 f"Anonymous user cannot use PT_OAUTH MCP server {mcp_server.id}"
             )
         return ResolvedMCPCredentials(
-            connection_config=None,
+            connection_config=user_connection_config,
             user_oauth_token=(
                 user.oauth_accounts[0].access_token if user.oauth_accounts else None
             ),
+            auth_type=mcp_server.auth_type,
+            auth_performer=mcp_server.auth_performer,
+            auth_template=auth_template,
+            user_email=user.email,
         )
 
     if mcp_server.auth_type in (
@@ -497,18 +565,26 @@ def resolve_mcp_credentials(
         MCPAuthenticationType.OAUTH,
     ):
         if mcp_server.auth_performer == MCPAuthenticationPerformer.PER_USER:
-            connection_config = (
-                user_configs.get(mcp_server.id)
-                if user_configs is not None
-                else get_user_connection_config(mcp_server.id, user.email, db_session)
-            )
+            connection_config = user_connection_config
         else:
             connection_config = mcp_server.admin_connection_config
         return ResolvedMCPCredentials(
-            connection_config=connection_config, user_oauth_token=None
+            connection_config=connection_config,
+            user_oauth_token=None,
+            auth_type=mcp_server.auth_type,
+            auth_performer=mcp_server.auth_performer,
+            auth_template=auth_template,
+            user_email=user.email,
         )
 
-    return ResolvedMCPCredentials(connection_config=None, user_oauth_token=None)
+    return ResolvedMCPCredentials(
+        connection_config=user_connection_config,
+        user_oauth_token=None,
+        auth_type=mcp_server.auth_type,
+        auth_performer=mcp_server.auth_performer,
+        auth_template=auth_template,
+        user_email=user.email,
+    )
 
 
 def can_resolve_mcp_credentials(
@@ -518,23 +594,14 @@ def can_resolve_mcp_credentials(
     *,
     user_configs: Mapping[int, MCPConnectionConfig] | None = None,
 ) -> bool:
-    """Whether the sandbox proxy will be able to authenticate `user` against
-    `mcp_server`, mirroring `MCPServerResolver._resolve_for_server`'s block
-    condition so callers can't drift from what injection does.
-
-    Not the same as the user having their own connection config: admin-managed,
-    `PT_OAUTH`, and no-auth servers all authenticate without one. See
-    `resolve_mcp_credentials` for `user_configs`.
-    """
-    if mcp_server.auth_type in (None, MCPAuthenticationType.NONE):
-        return True
+    """Whether every generated credential and template value is available."""
     try:
         credentials = resolve_mcp_credentials(
             mcp_server, user, db_session, user_configs=user_configs
         )
     except MCPCredentialsError:
         return False
-    return bool(credentials.build_headers())
+    return credentials.is_authenticated()
 
 
 def get_user_connection_configs(
@@ -591,14 +658,24 @@ def update_connection_config(
     config_data: MCPConnectionData | None = None,
 ) -> MCPConnectionConfig:
     """Update an existing connection config"""
+    config = update_connection_config__no_commit(config_id, db_session, config_data)
+    db_session.commit()
+    return config
+
+
+def update_connection_config__no_commit(
+    config_id: int,
+    db_session: Session,
+    config_data: MCPConnectionData | None = None,
+) -> MCPConnectionConfig:
+    """Update a connection config without owning the transaction."""
     config = get_connection_config_by_id(config_id, db_session)
 
     if config_data is not None:
         config.config = config_data  # ty: ignore[invalid-assignment]
-        # Force SQLAlchemy to detect the change by marking the field as modified
         flag_modified(config, "config")
 
-    db_session.commit()
+    db_session.flush()
     return config
 
 
@@ -622,20 +699,6 @@ def upsert_user_connection_config(
             user_email=user_email,
             db_session=db_session,
         )
-
-
-# TODO: do this in one db call
-def get_server_auth_template(
-    server_id: int, db_session: Session
-) -> MCPConnectionConfig | None:
-    """Get the authentication template for a server (from the admin connection config)"""
-    server = get_mcp_server_by_id(server_id, db_session)
-    if not server.admin_connection_config_id:
-        return None
-
-    if server.auth_performer == MCPAuthenticationPerformer.ADMIN:
-        return None  # admin server implies no template
-    return server.admin_connection_config
 
 
 def delete_connection_config(config_id: int, db_session: Session) -> None:
@@ -670,7 +733,10 @@ def delete_all_user_connection_configs_for_server_no_commit(
     """Delete all user connection configs for a specific MCP server"""
     db_session.execute(
         delete(MCPConnectionConfig).where(
-            MCPConnectionConfig.mcp_server_id == server_id
+            and_(
+                MCPConnectionConfig.mcp_server_id == server_id,
+                MCPConnectionConfig.user_email != "",
+            )
         )
     )
     db_session.flush()  # Don't commit yet, let caller decide when to commit

--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -450,7 +450,6 @@ class ResolvedMCPCredentials(BaseModel):
     connection_config: MCPConnectionConfig | None
     user_oauth_token: str | None
     auth_type: MCPAuthenticationType | None = None
-    auth_performer: MCPAuthenticationPerformer | None = None
     auth_template: MCPAuthTemplate | None = None
     user_email: str = ""
 
@@ -555,7 +554,6 @@ def resolve_mcp_credentials(
                 user.oauth_accounts[0].access_token if user.oauth_accounts else None
             ),
             auth_type=mcp_server.auth_type,
-            auth_performer=mcp_server.auth_performer,
             auth_template=auth_template,
             user_email=user.email,
         )
@@ -572,7 +570,6 @@ def resolve_mcp_credentials(
             connection_config=connection_config,
             user_oauth_token=None,
             auth_type=mcp_server.auth_type,
-            auth_performer=mcp_server.auth_performer,
             auth_template=auth_template,
             user_email=user.email,
         )
@@ -581,7 +578,6 @@ def resolve_mcp_credentials(
         connection_config=user_connection_config,
         user_oauth_token=None,
         auth_type=mcp_server.auth_type,
-        auth_performer=mcp_server.auth_performer,
         auth_template=auth_template,
         user_email=user.email,
     )

--- a/backend/onyx/sandbox_proxy/resolvers/mcp_server.py
+++ b/backend/onyx/sandbox_proxy/resolvers/mcp_server.py
@@ -173,6 +173,7 @@ class MCPServerResolver(CredentialResolver):
                     str(e), sandbox_detail=_connect_detail(server.name, admin_managed)
                 ) from e
             headers = creds.build_headers()
+            credentials_ready = creds.is_authenticated()
             expired_oauth_config_id: int | None = None
             if (
                 server.auth_type == MCPAuthenticationType.OAUTH
@@ -183,18 +184,18 @@ class MCPServerResolver(CredentialResolver):
 
         # Refresh after the session closes — the primitive opens its own.
         if expired_oauth_config_id is not None:
-            headers = _refresh_oauth_headers(
+            refreshed_headers = _refresh_oauth_headers(
                 tenant_id, server, str(user_id), expired_oauth_config_id
             )
-            if not headers:
+            if not refreshed_headers:
                 raise CredentialUnavailableError(
                     f"OAuth token for MCP server {server.id} is expired and "
                     "could not be refreshed",
                     sandbox_detail=_reconnect_detail(server.name, admin_managed),
                 )
+            headers.update(refreshed_headers)
 
-        requires_auth = server.auth_type not in (None, MCPAuthenticationType.NONE)
-        if requires_auth and not headers:
+        if not credentials_ready:
             raise CredentialUnavailableError(
                 f"no stored credentials for user {short_log_id(user_id)} on "
                 f"server {server.id}",

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -369,14 +369,12 @@ def _resolve_auth_template(
     existing_headers = existing_template.headers if existing_template else {}
     for name, request_value in request_template.headers.items():
         existing_value = existing_headers.get(name)
-        preserve_existing = (
+        if (
             not changed_headers.get(name, False)
             and existing_value is not None
             and (request_value == existing_value or is_masked_credential(request_value))
-        )
-        if preserve_existing:
-            assert existing_value is not None
-            headers[name] = existing_headers[name]
+        ):
+            headers[name] = existing_value
             continue
         reject_masked_credentials({name: request_value})
         headers[name] = request_value
@@ -1712,7 +1710,11 @@ def _list_mcp_tools_by_id(
     auth = None
     if mcp_server.auth_type == MCPAuthenticationType.OAUTH:
         connection_config = credentials.connection_config
-        assert connection_config
+        if connection_config is None:
+            raise OnyxError(
+                OnyxErrorCode.INTERNAL_ERROR,
+                "OAuth MCP credentials are missing their connection config.",
+            )
         auth = make_oauth_provider(
             mcp_server,
             user_id,

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -60,13 +60,15 @@ from onyx.db.mcp import (
     get_all_mcp_servers,
     get_all_mcp_tools_for_server,
     get_craft_enabled_mcp_servers,
+    get_mcp_auth_template,
     get_mcp_server_by_id,
     get_mcp_servers_accessible_to_user,
     get_mcp_servers_for_persona,
-    get_server_auth_template,
     get_user_connection_config,
     get_user_connection_configs,
+    resolve_mcp_credentials,
     update_connection_config,
+    update_connection_config__no_commit,
     update_mcp_server__no_commit,
     upsert_user_connection_config,
     user_can_access_mcp_server,
@@ -104,7 +106,8 @@ from onyx.server.features.mcp.models import (
     MCPUserCredentialsRequest,
     MCPUserOAuthConnectRequest,
     MCPUserOAuthConnectResponse,
-    apply_auto_substitutions,
+    contains_mcp_placeholder,
+    merge_mcp_headers,
 )
 from onyx.server.features.mcp.oauth import (
     OAUTH_WAIT_SECONDS,
@@ -357,20 +360,56 @@ def _resolve_shared_api_token_template(
     return None
 
 
+def _resolve_auth_template(
+    request_template: MCPAuthTemplate,
+    changed_headers: dict[str, bool],
+    existing_template: MCPAuthTemplate | None,
+) -> MCPAuthTemplate:
+    headers: dict[str, str] = {}
+    existing_headers = existing_template.headers if existing_template else {}
+    for name, request_value in request_template.headers.items():
+        existing_value = existing_headers.get(name)
+        preserve_existing = (
+            not changed_headers.get(name, False)
+            and existing_value is not None
+            and (request_value == existing_value or is_masked_credential(request_value))
+        )
+        if preserve_existing:
+            assert existing_value is not None
+            headers[name] = existing_headers[name]
+            continue
+        reject_masked_credentials({name: request_value})
+        headers[name] = request_value
+    return MCPAuthTemplate(headers=headers)
+
+
+def _mask_auth_template(template: MCPAuthTemplate) -> MCPAuthTemplate:
+    headers = {
+        name: value if contains_mcp_placeholder(value) else mask_string(value)
+        for name, value in template.headers.items()
+    }
+    return MCPAuthTemplate.model_construct(
+        headers=headers,
+        required_fields=template.required_fields,
+    )
+
+
 def _build_shared_api_token_config_data(
     *,
     api_token: str,
     auth_template: MCPAuthTemplate | None,
+    header_substitutions: dict[str, str] | None,
     user_email: str,
 ) -> MCPConnectionData:
     """Render and persist a shared API-token header template."""
     template = auth_template or _default_shared_api_token_template()
+    substitutions = {**(header_substitutions or {}), "api_key": api_token}
     return MCPConnectionData(
-        headers=_build_headers_from_template(
-            template, {"api_key": api_token}, user_email
-        ),
+        headers=template.render(substitutions, user_email=user_email),
         header_template=template.headers,
         api_token=api_token,
+        header_substitutions=header_substitutions or {},
+        required_fields=template.required_fields,
     )
 
 
@@ -378,6 +417,7 @@ def _build_oauth_admin_config_data(
     *,
     client_id: str | None,
     client_secret: str | None,
+    auth_template: MCPAuthTemplate | None = None,
 ) -> MCPConnectionData:
     """Construct the admin connection config payload for an OAuth client.
 
@@ -387,6 +427,9 @@ def _build_oauth_admin_config_data(
     Dynamic Client Registration to obtain credentials).
     """
     config_data = MCPConnectionData(headers={})
+    if auth_template is not None:
+        config_data["header_template"] = auth_template.headers
+        config_data["required_fields"] = auth_template.required_fields
     if not client_id:
         return config_data
     token_endpoint_auth_method = "client_secret_post" if client_secret else "none"
@@ -403,25 +446,12 @@ def _build_oauth_admin_config_data(
     return config_data
 
 
-def _oauth_user_config_has_tokens(
-    user_config: MCPConnectionConfig | None,
-) -> bool:
-    """Whether a per-user OAuth config holds tokens from a completed handshake.
-
-    The row is created when the connect flow starts, before token exchange, so
-    existence alone doesn't prove the user finished authenticating.
-    """
-    if user_config is None:
-        return False
-    config_data = extract_connection_data(user_config, apply_mask=False)
-    return bool(config_data.get(MCPOAuthKeys.TOKENS.value))
-
-
 def _build_oauth_admin_config_data_for_update(
     *,
     client_id: str | None,
     client_secret: str | None,
     existing_client: OAuthClientInformationFull,
+    auth_template: MCPAuthTemplate | None = None,
 ) -> MCPConnectionData:
     """Construct the admin connection config payload for an OAuth client
     that already has a stored `client_info`, preserving provider-managed
@@ -439,7 +469,9 @@ def _build_oauth_admin_config_data_for_update(
         # the template-path behavior of returning an empty config so the
         # OAuth provider can attempt DCR.
         return _build_oauth_admin_config_data(
-            client_id=client_id, client_secret=client_secret
+            client_id=client_id,
+            client_secret=client_secret,
+            auth_template=auth_template,
         )
 
     if existing_client.client_id != client_id:
@@ -448,7 +480,9 @@ def _build_oauth_admin_config_data_for_update(
             "stored DCR registration metadata and starting fresh."
         )
         return _build_oauth_admin_config_data(
-            client_id=client_id, client_secret=client_secret
+            client_id=client_id,
+            client_secret=client_secret,
+            auth_template=auth_template,
         )
 
     merged = existing_client.model_copy(deep=True)
@@ -466,8 +500,66 @@ def _build_oauth_admin_config_data_for_update(
         )
 
     config_data = MCPConnectionData(headers={})
+    if auth_template is not None:
+        config_data["header_template"] = auth_template.headers
+        config_data["required_fields"] = auth_template.required_fields
     config_data[MCPOAuthKeys.CLIENT_INFO.value] = merged.model_dump(mode="json")
     return config_data
+
+
+def _build_template_config_data(
+    auth_template: MCPAuthTemplate | None,
+) -> MCPConnectionData:
+    config_data = MCPConnectionData(headers={})
+    if auth_template is not None:
+        config_data["header_template"] = auth_template.headers
+        config_data["required_fields"] = auth_template.required_fields
+    return config_data
+
+
+def _persist_admin_connection_config(
+    mcp_server: DbMCPServer,
+    config_data: MCPConnectionData,
+    db_session: Session,
+) -> int:
+    if mcp_server.admin_connection_config_id is not None:
+        update_connection_config__no_commit(
+            mcp_server.admin_connection_config_id, db_session, config_data
+        )
+        return mcp_server.admin_connection_config_id
+    return create_connection_config(
+        config_data=config_data,
+        mcp_server_id=mcp_server.id,
+        db_session=db_session,
+    ).id
+
+
+def _upsert_user_template_config(
+    *,
+    mcp_server: DbMCPServer,
+    template: MCPAuthTemplate,
+    substitutions: dict[str, str],
+    user_email: str,
+    db_session: Session,
+) -> None:
+    existing = get_user_connection_config(mcp_server.id, user_email, db_session)
+    existing_data = extract_connection_data(existing, apply_mask=False)
+    config_data = MCPConnectionData(
+        headers=template.render(substitutions, user_email=user_email),
+        header_substitutions=substitutions,
+    )
+    for oauth_key in MCPOAuthKeys:
+        field_key: Literal["client_info", "tokens", "metadata", "token_expires_at"] = (
+            oauth_key.value
+        )
+        if field_value := existing_data.get(field_key):
+            config_data[field_key] = field_value
+    upsert_user_connection_config(
+        server_id=mcp_server.id,
+        user_email=user_email,
+        config_data=config_data,
+        db_session=db_session,
+    )
 
 
 router = APIRouter(prefix="/mcp")
@@ -494,20 +586,7 @@ def _hot_reload_craft_sessions(user_ids: set[UUID], db_session: Session) -> None
 def _build_headers_from_template(
     template_data: MCPAuthTemplate, credentials: dict[str, str], user_email: str
 ) -> dict[str, str]:
-    """Build headers dict from template and credentials"""
-    headers = {}
-    template_headers = template_data.headers
-
-    for name, value_template in template_headers.items():
-        value = value_template
-        for key, cred_value in credentials.items():
-            value = value.replace(f"{{{key}}}", cred_value)
-        value = apply_auto_substitutions(value, user_email=user_email)
-
-        if name:
-            headers[name] = value
-
-    return headers
+    return template_data.render(credentials, user_email=user_email)
 
 
 def test_mcp_server_credentials(
@@ -658,11 +737,13 @@ async def _connect_oauth(
             client_id=request.oauth_client_id,
             client_secret=request.oauth_client_secret,
             existing_client=existing_client,
+            auth_template=get_mcp_auth_template(mcp_server),
         )
         if existing_client is not None
         else _build_oauth_admin_config_data(
             client_id=request.oauth_client_id,
             client_secret=request.oauth_client_secret,
+            auth_template=get_mcp_auth_template(mcp_server),
         )
     )
 
@@ -687,16 +768,44 @@ async def _connect_oauth(
         update_connection_config(mcp_server.admin_connection_config_id, db, config_data)
 
     connection_config = get_user_connection_config(mcp_server.id, user.email, db)
+    auth_template = get_mcp_auth_template(mcp_server)
+    if auth_template is not None and auth_template.required_fields:
+        existing_data = extract_connection_data(connection_config, apply_mask=False)
+        substitutions = existing_data.get(HEADER_SUBSTITUTIONS, {})
+        missing_fields = [
+            field
+            for field in auth_template.required_fields
+            if not substitutions.get(field)
+        ]
+        if missing_fields:
+            raise OnyxError(
+                OnyxErrorCode.MISSING_REQUIRED_FIELD,
+                "Submit MCP header values before starting OAuth: "
+                f"{', '.join(sorted(missing_fields))}",
+            )
+
+    user_config_data = config_data
+    if connection_config is not None:
+        existing_user_data = extract_connection_data(
+            connection_config, apply_mask=False
+        )
+        user_config_data = MCPConnectionData(
+            headers=existing_user_data.get("headers", {}),
+        )
+        user_config_data.update(config_data)
+        user_config_data["headers"] = existing_user_data.get("headers", {})
+        if substitutions := existing_user_data.get(HEADER_SUBSTITUTIONS):
+            user_config_data[HEADER_SUBSTITUTIONS] = substitutions
 
     if connection_config is None:
         connection_config = create_connection_config(
-            config_data=config_data,
+            config_data=user_config_data,
             mcp_server_id=mcp_server.id,
             user_email=user.email,
             db_session=db,
         )
     else:
-        update_connection_config(connection_config.id, db, config_data)
+        update_connection_config(connection_config.id, db, user_config_data)
 
     db.commit()
 
@@ -988,9 +1097,10 @@ async def process_oauth_callback(
         )
         if expires_at is not None:
             user_config_data[MCPOAuthKeys.TOKEN_EXPIRES_AT.value] = float(expires_at)
-        user_config_data["headers"] = {
-            "Authorization": f"{oauth_token.token_type} {oauth_token.access_token}"
-        }
+        user_config_data["headers"] = merge_mcp_headers(
+            user_config_data.get("headers", {}),
+            {"Authorization": (f"{oauth_token.token_type} {oauth_token.access_token}")},
+        )
         update_connection_config(user_config.id, db_session, user_config_data)
         redis_client.delete(key_state(user_id))
 
@@ -1065,139 +1175,98 @@ def save_user_credentials(
     db_session: Session = Depends(get_session),
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
 ) -> MCPApiKeyResponse:
-    """Save user credentials for template-based MCP server authentication"""
-
-    logger.info("Saving user credentials for server: %s", request.server_id)
-
     try:
-        server_id = request.server_id
-        mcp_server = get_mcp_server_by_id(server_id, db_session)
-    except Exception:
-        raise HTTPException(status_code=404, detail="MCP server not found")
+        mcp_server = get_mcp_server_by_id(request.server_id, db_session)
+    except ValueError:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "MCP server not found")
 
-    if mcp_server.auth_type == "none":
-        raise HTTPException(
-            status_code=400,
-            detail="Server does not require authentication",
-        )
-
+    server_id = mcp_server.id
     email = user.email
-
-    # Get the authentication template for this server
-    auth_template = get_server_auth_template(server_id, db_session)
-    if not auth_template:
-        # Fallback to simple API key storage for servers without templates
-        if "api_key" not in request.credentials:
-            raise HTTPException(
-                status_code=400,
-                detail="No authentication template found and no api_key provided",
+    template = get_mcp_auth_template(mcp_server)
+    if template is None:
+        if (
+            mcp_server.auth_type != MCPAuthenticationType.API_TOKEN
+            or "api_key" not in request.credentials
+        ):
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "This MCP server has no user-configurable header template.",
             )
         config_data = MCPConnectionData(
             headers={"Authorization": f"Bearer {request.credentials['api_key']}"},
+            header_substitutions=request.credentials,
         )
     else:
-        # Render via the shared helper so user + auto (`{user_email}`)
-        # substitutions go through one pipeline.
         try:
-            # TODO: fix and/or type correctly w/base model
-            auth_template_dict = extract_connection_data(
-                auth_template, apply_mask=False
-            )
-            template = MCPAuthTemplate(headers=auth_template_dict.get("headers", {}))
             config_data = MCPConnectionData(
-                headers=_build_headers_from_template(
-                    template, request.credentials, email
-                ),
+                headers=template.render(request.credentials, user_email=email),
                 header_substitutions=request.credentials,
             )
-            for oauth_field_key in MCPOAuthKeys:
-                field_key: Literal[
-                    "client_info", "tokens", "metadata", "token_expires_at"
-                ] = oauth_field_key.value
-                if field_val := auth_template_dict.get(field_key):
-                    config_data[field_key] = field_val
-
-        except Exception as e:
-            logger.error("Failed to process authentication template: %s", e)
-            raise HTTPException(
-                status_code=400,
-                detail=f"Failed to process authentication template: {str(e)}",
+        except ValueError as error:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                str(error),
             )
 
-    # Test the credentials before saving
+    if mcp_server.auth_type == MCPAuthenticationType.OAUTH:
+        existing_config = get_user_connection_config(server_id, email, db_session)
+        source_config = existing_config or mcp_server.admin_connection_config
+        source_data = extract_connection_data(source_config, apply_mask=False)
+        for oauth_key in MCPOAuthKeys:
+            field_key: Literal[
+                "client_info", "tokens", "metadata", "token_expires_at"
+            ] = oauth_key.value
+            if field_value := source_data.get(field_key):
+                config_data[field_key] = field_value
+
     validation_tested = False
     validation_message = "Credentials saved successfully"
-
-    try:
-        auth = None
-        if mcp_server.auth_type == MCPAuthenticationType.OAUTH:
-            # should only be saving user creds if an admin config exists
-            assert mcp_server.admin_connection_config_id is not None
-            auth = make_oauth_provider(
-                mcp_server,
-                email,
-                UNUSED_RETURN_PATH,
-                mcp_server.admin_connection_config_id,
-                None,
+    if mcp_server.auth_type != MCPAuthenticationType.OAUTH:
+        validation_headers = config_data["headers"]
+        if mcp_server.auth_type == MCPAuthenticationType.PT_OAUTH:
+            if not user.oauth_accounts:
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    "Pass-through OAuth requires an OAuth login.",
+                )
+            validation_headers = merge_mcp_headers(
+                validation_headers,
+                {"Authorization": f"Bearer {user.oauth_accounts[0].access_token}"},
             )
-
-        server_url = mcp_server.server_url
         is_valid, test_message = test_mcp_server_credentials(
-            server_url,
-            config_data["headers"],
+            mcp_server.server_url,
+            validation_headers,
             transport=MCPTransport(request.transport.replace("-", "_").upper()),
-            auth=auth,
+            auth=None,
         )
         validation_tested = True
-
         if not is_valid:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Credentials validation failed: {test_message}",
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                f"Credentials validation failed: {test_message}",
             )
-        else:
-            validation_message = (
-                f"Credentials saved and validated successfully. {test_message}"
-            )
-
-    except HTTPException:
-        raise  # Re-raise HTTP exceptions
-    except Exception as e:
-        logger.warning(
-            "Could not validate credentials for server %s: %s", mcp_server.name, e
-        )
-        validation_message = "Credentials saved but could not be validated"
-
-    try:
-        # Save the processed credentials
-        upsert_user_connection_config(
-            server_id=server_id,
-            user_email=email,
-            config_data=config_data,
-            db_session=db_session,
+        validation_message = (
+            f"Credentials saved and validated successfully. {test_message}"
         )
 
-        logger.info(
-            "User credentials saved for server %s and user %s", mcp_server.name, email
-        )
-        db_session.commit()
+    upsert_user_connection_config(
+        server_id=server_id,
+        user_email=email,
+        config_data=config_data,
+        db_session=db_session,
+    )
+    db_session.commit()
+    _hot_reload_craft_sessions({user.id}, db_session)
 
-        # Connecting credentials unblocks tool discovery for this user's craft
-        # session (opencode's startup tools/list is credential-gated); reload it.
-        _hot_reload_craft_sessions({user.id}, db_session)
-
-        return MCPApiKeyResponse(
-            success=True,
-            message=validation_message,
-            server_id=request.server_id,
-            server_name=mcp_server.name,
-            authenticated=True,
-            validation_tested=validation_tested,
-        )
-
-    except Exception as e:
-        logger.error("Failed to save user credentials: %s", e)
-        raise HTTPException(status_code=500, detail="Failed to save user credentials")
+    resolved = resolve_mcp_credentials(mcp_server, user, db_session)
+    return MCPApiKeyResponse(
+        success=True,
+        message=validation_message,
+        server_id=request.server_id,
+        server_name=mcp_server.name,
+        authenticated=resolved.is_authenticated(),
+        validation_tested=validation_tested,
+    )
 
 
 @router.delete("/user-credentials/{server_id}")
@@ -1294,151 +1363,73 @@ def _db_mcp_server_to_api_mcp_server(
     # to the server's owner or an admin. Basic users attaching MCP actions to an
     # assistant don't need either (the connect/OAuth flow is brokered server-side).
     can_view_server_details = is_owner_or_admin
-    if db_server.auth_type == MCPAuthenticationType.NONE:
-        user_authenticated = True  # No auth required
-    elif auth_performer == MCPAuthenticationPerformer.ADMIN:
-        user_authenticated = db_server.admin_connection_config is not None
-        if (
-            can_view_admin_credentials
-            and db_server.admin_connection_config is not None
-            and include_auth_config
-        ):
-            admin_config_dict = extract_connection_data(
-                db_server.admin_connection_config, apply_mask=False
-            )
-            if db_server.auth_type == MCPAuthenticationType.API_TOKEN:
-                raw_api_key = _extract_shared_api_token(admin_config_dict)
-                admin_credentials = {
-                    "api_key": mask_string(raw_api_key),
-                }
-            elif db_server.auth_type == MCPAuthenticationType.OAUTH:
-                user_authenticated = False
-                client_info = None
-                client_info_raw = admin_config_dict.get(MCPOAuthKeys.CLIENT_INFO.value)
-                if client_info_raw:
-                    client_info = OAuthClientInformationFull.model_validate(
-                        client_info_raw
-                    )
-                if client_info:
-                    if not client_info.client_id:
-                        raise ValueError("Stored client info had empty client ID")
-                    admin_credentials = {
-                        "client_id": mask_string(client_info.client_id),
-                    }
-                    if client_info.client_secret:
-                        admin_credentials["client_secret"] = mask_string(
-                            client_info.client_secret
-                        )
-                else:
-                    admin_credentials = {}
-                    logger.warning(
-                        "No admin client info found for server %s", db_server.name
-                    )
-    else:  # currently: per user auth using api key OR oauth
-        user_config = (
-            user_configs.get(db_server.id)
-            if user_configs is not None
-            else get_user_connection_config(db_server.id, email, db)
+    user_config = (
+        user_configs.get(db_server.id)
+        if user_configs is not None
+        else get_user_connection_config(db_server.id, email, db)
+    )
+    if request_user is not None:
+        user_authenticated = can_resolve_mcp_credentials(
+            db_server,
+            request_user,
+            db,
+            user_configs=({db_server.id: user_config} if user_config else {}),
         )
-        # API-token rows exist only once credentials are submitted; OAuth rows
-        # are created before token exchange, so require tokens there.
-        if db_server.auth_type == MCPAuthenticationType.OAUTH:
-            user_authenticated = _oauth_user_config_has_tokens(user_config)
-        else:
-            user_authenticated = user_config is not None
 
-        if user_authenticated and user_config:
-            # Avoid hitting the MCP server when assembling response data.
-            if (
-                include_auth_config
-                and db_server.auth_type != MCPAuthenticationType.OAUTH
-            ):
-                user_config_dict = extract_connection_data(user_config, apply_mask=True)
-                user_credentials = user_config_dict.get(HEADER_SUBSTITUTIONS, {})
+    if include_auth_config and user_config is not None:
+        user_config_dict = extract_connection_data(user_config, apply_mask=True)
+        user_credentials = user_config_dict.get(HEADER_SUBSTITUTIONS, {})
 
+    if can_view_admin_credentials and db_server.admin_connection_config is not None:
+        admin_config_dict = extract_connection_data(
+            db_server.admin_connection_config, apply_mask=False
+        )
         if (
-            db_server.auth_type == MCPAuthenticationType.OAUTH
-            and db_server.admin_connection_config
+            db_server.auth_type == MCPAuthenticationType.API_TOKEN
+            and auth_performer == MCPAuthenticationPerformer.ADMIN
         ):
-            client_info = None
-            oauth_admin_config_dict = extract_connection_data(
-                db_server.admin_connection_config, apply_mask=False
+            admin_credentials = {
+                key: mask_string(value)
+                for key, value in admin_config_dict.get(
+                    HEADER_SUBSTITUTIONS, {}
+                ).items()
+            }
+            admin_credentials.update(
+                {"api_key": mask_string(_extract_shared_api_token(admin_config_dict))}
             )
-            client_info_raw = oauth_admin_config_dict.get(
-                MCPOAuthKeys.CLIENT_INFO.value
+        elif db_server.auth_type == MCPAuthenticationType.OAUTH:
+            client_info_raw = admin_config_dict.get(MCPOAuthKeys.CLIENT_INFO.value)
+            client_info = (
+                OAuthClientInformationFull.model_validate(client_info_raw)
+                if client_info_raw
+                else None
             )
-            if client_info_raw:
-                client_info = OAuthClientInformationFull.model_validate(client_info_raw)
-            if client_info:
+            admin_credentials = {}
+            if client_info is not None:
                 if not client_info.client_id:
                     raise ValueError("Stored client info had empty client ID")
-                if can_view_admin_credentials:
-                    admin_credentials = {
-                        "client_id": mask_string(client_info.client_id),
-                    }
-                    if client_info.client_secret:
-                        admin_credentials["client_secret"] = mask_string(
-                            client_info.client_secret
-                        )
-            elif can_view_admin_credentials:
-                admin_credentials = {}
-                logger.warning("No client info found for server %s", db_server.name)
-
-    # Surface the placeholder header template without exposing rendered
-    # credentials. OAuth servers do not get an auth_template because OAuth
-    # uses the handshake URL rather than a header template.
-    #
-    # Per-user templates are surfaced to any accessible user because they
-    # drive the per-user credential prompt. Shared/admin templates are only
-    # surfaced to the owner/admin auth-config response: basic users never
-    # supply shared credentials, and the template can legitimately carry
-    # literal header values that must not leak.
-    auth_template = None
-    if db_server.auth_type != MCPAuthenticationType.OAUTH and (
-        auth_performer == MCPAuthenticationPerformer.PER_USER
-        or can_view_admin_credentials
-    ):
-        try:
-            template_config = db_server.admin_connection_config
-            if template_config:
-                template_config_dict = extract_connection_data(
-                    template_config, apply_mask=False
-                )
-                if auth_performer == MCPAuthenticationPerformer.ADMIN:
-                    headers = (
-                        template_config_dict.get("header_template")
-                        or _default_shared_api_token_template().headers
+                admin_credentials["client_id"] = mask_string(client_info.client_id)
+                if client_info.client_secret:
+                    admin_credentials["client_secret"] = mask_string(
+                        client_info.client_secret
                     )
-                else:
-                    headers = template_config_dict.get("headers", {})
-                # Prefer the explicitly persisted list; fall back to deriving
-                # from header placeholders for servers created before
-                # `required_fields` was persisted.
-                required_fields = template_config_dict.get(
-                    "required_fields"
-                ) or MCPAuthTemplate.derive_required_fields(headers)
-                auth_template = MCPAuthTemplate(
-                    headers=headers,
-                    required_fields=required_fields,
-                )
-        except Exception as e:
-            logger.warning(
-                "Failed to parse auth template for server %s: %s", db_server.name, e
+
+    stored_template = get_mcp_auth_template(db_server)
+    auth_template = None
+    if stored_template is not None:
+        shared_api_token = (
+            db_server.auth_type == MCPAuthenticationType.API_TOKEN
+            and auth_performer == MCPAuthenticationPerformer.ADMIN
+        )
+        if can_view_admin_credentials:
+            auth_template = _mask_auth_template(stored_template)
+        elif not shared_api_token:
+            auth_template = MCPAuthTemplate(
+                headers={},
+                required_fields=stored_template.required_fields,
             )
 
-    is_authenticated: bool = (
-        db_server.auth_type == MCPAuthenticationType.NONE.value
-        # Pass-through OAuth: user is authenticated via their login OAuth token
-        or db_server.auth_type == MCPAuthenticationType.PT_OAUTH
-        or (
-            auth_performer == MCPAuthenticationPerformer.ADMIN
-            and db_server.auth_type != MCPAuthenticationType.OAUTH
-            and db_server.admin_connection_config_id is not None
-        )
-        or (
-            auth_performer == MCPAuthenticationPerformer.PER_USER and user_authenticated
-        )
-    )
+    is_authenticated = bool(user_authenticated)
 
     # Calculate tool count from the relationship
     tool_count = len(db_server.current_actions) if db_server.current_actions else 0
@@ -1555,43 +1546,6 @@ def get_craft_mcp_servers_for_user(
         for db_server in db_mcp_servers
     ]
     return MCPServersResponse(mcp_servers=mcp_servers)
-
-
-def _get_connection_config(
-    mcp_server: DbMCPServer,
-    is_admin: bool,  # noqa: ARG001
-    user: User,
-    db_session: Session,
-) -> MCPConnectionConfig | None:
-    """
-    Get the connection config for an MCP server.
-    is_admin is true when we want the config used for the admin panel
-
-    """
-    if mcp_server.auth_type == MCPAuthenticationType.NONE:
-        return None
-
-    # Pass-through OAuth uses the user's login OAuth token, not a stored config
-    if mcp_server.auth_type == MCPAuthenticationType.PT_OAUTH:
-        return None
-
-    if (
-        mcp_server.auth_type == MCPAuthenticationType.API_TOKEN
-        and mcp_server.auth_performer == MCPAuthenticationPerformer.ADMIN
-    ):
-        connection_config = mcp_server.admin_connection_config
-    else:
-        connection_config = get_user_connection_config(
-            server_id=mcp_server.id, user_email=user.email, db_session=db_session
-        )
-
-    if not connection_config:
-        raise HTTPException(
-            status_code=401,
-            detail="Authentication required for this MCP server",
-        )
-
-    return connection_config
 
 
 @admin_router.get("/server/{server_id}/tools")
@@ -1748,30 +1702,17 @@ def _list_mcp_tools_by_id(
             "You do not have access to this MCP server.",
         )
 
-    # Get connection config based on auth type
-    # TODO: for now, only the admin that set up a per-user api key server can
-    # see their configuration. This is probably not ideal. Other admins
-    # can of course put their own credentials in and list the tools.
-    connection_config = _get_connection_config(mcp_server, is_admin, user, db)
-
-    # Allow access for NONE and PT_OAUTH (which use user's login token at runtime)
-    if not connection_config and mcp_server.auth_type not in (
-        MCPAuthenticationType.NONE,
-        MCPAuthenticationType.PT_OAUTH,
-    ):
-        raise HTTPException(
-            status_code=401,
-            detail="This MCP server is not configured yet",
+    credentials = resolve_mcp_credentials(mcp_server, user, db)
+    if not credentials.is_authenticated():
+        raise OnyxError(
+            OnyxErrorCode.UNAUTHENTICATED,
+            "This MCP server is not configured for the current user.",
         )
-
     user_id = str(user.id)
-    # Discover tools from the MCP server
     auth = None
-    headers: dict[str, str] = {}
-
     if mcp_server.auth_type == MCPAuthenticationType.OAUTH:
-        # TODO: just pass this in, but should work when auth is set already
-        assert connection_config  # for type-checking
+        connection_config = credentials.connection_config
+        assert connection_config
         auth = make_oauth_provider(
             mcp_server,
             user_id,
@@ -1779,22 +1720,6 @@ def _list_mcp_tools_by_id(
             connection_config.id,
             None,
         )
-    elif mcp_server.auth_type == MCPAuthenticationType.PT_OAUTH:
-        # Pass-through OAuth: use the user's login OAuth token
-        if user.oauth_accounts:
-            user_oauth_token = user.oauth_accounts[0].access_token
-            headers["Authorization"] = f"Bearer {user_oauth_token}"
-        else:
-            raise HTTPException(
-                status_code=401,
-                detail="Pass-through OAuth requires a user logged in with OAuth",
-            )
-
-    if connection_config:
-        connection_config_dict = extract_connection_data(
-            connection_config, apply_mask=False
-        )
-        headers.update(connection_config_dict.get("headers", {}))
 
     t1 = time.time()
     logger.info("Discovering tools for MCP server: %s: %s", mcp_server.name, t1)
@@ -1808,7 +1733,7 @@ def _list_mcp_tools_by_id(
 
     discovered_tools = discover_mcp_tools(
         server_url,
-        headers,
+        credentials.build_headers(),
         transport=mcp_server.transport,
         auth=auth,
     )
@@ -1917,8 +1842,10 @@ def _upsert_mcp_server(
 
     mcp_server = None
     admin_config = None
+    client_info: OAuthClientInformationFull | None = None
 
     changing_connection_config = True
+    users_to_reload: set[UUID] = set()
 
     # Handle existing server update
     if request.existing_server_id:
@@ -1930,7 +1857,6 @@ def _upsert_mcp_server(
                 detail=f"MCP server with ID {request.existing_server_id} not found",
             )
         _ensure_mcp_server_owner_or_admin(mcp_server, user)
-        client_info: OAuthClientInformationFull | None = None
         existing_admin_config_dict: MCPConnectionData = MCPConnectionData(headers={})
         if mcp_server.admin_connection_config:
             existing_admin_config_dict = extract_connection_data(
@@ -1958,24 +1884,41 @@ def _upsert_mcp_server(
                 existing_client=client_info,
             )
 
-        # Same pattern for per-user API_TOKEN: resolve admin credentials
-        # against the admin's stored per-user row
+        # Resolve the editing admin's own template values per field.
         existing_admin_per_user_creds: dict[str, str] = {}
         existing_template_headers: dict[str, str] = {}
         existing_shared_template_headers: dict[str, str] = {}
+        existing_template: MCPAuthTemplate | None = None
         if mcp_server.admin_connection_config:
+            existing_template = get_mcp_auth_template(mcp_server)
             existing_template_headers = (
-                existing_admin_config_dict.get("headers", {}) or {}
+                existing_template.headers if existing_template else {}
             )
             existing_shared_template_headers = (
                 existing_admin_config_dict.get("header_template")
                 or _default_shared_api_token_template().headers
             )
+            if request.auth_template is not None:
+                request.auth_template = _resolve_auth_template(
+                    request.auth_template,
+                    request.auth_template_headers_changed,
+                    existing_template,
+                )
+            elif existing_template is not None:
+                request.auth_template = existing_template
 
         if (
             request.auth_type == MCPAuthenticationType.API_TOKEN
             and request.auth_performer == MCPAuthenticationPerformer.ADMIN
         ):
+            if request.admin_credentials is not None:
+                request.admin_credentials = _resolve_admin_credentials(
+                    request_credentials=request.admin_credentials,
+                    request_credentials_changed=request.admin_credentials_changed,
+                    existing_user_credentials=existing_admin_config_dict.get(
+                        HEADER_SUBSTITUTIONS, {}
+                    ),
+                )
             request.auth_template = _resolve_shared_api_token_template(
                 request_template=request.auth_template,
                 existing_config=(
@@ -2001,8 +1944,10 @@ def _upsert_mcp_server(
                     "A shared API token is required for admin-managed API-token servers.",
                 )
         if (
-            request.auth_type == MCPAuthenticationType.API_TOKEN
-            and request.auth_performer == MCPAuthenticationPerformer.PER_USER
+            not (
+                request.auth_type == MCPAuthenticationType.API_TOKEN
+                and request.auth_performer == MCPAuthenticationPerformer.ADMIN
+            )
             and user.email
         ):
             existing_admin_per_user_config = get_user_connection_config(
@@ -2027,9 +1972,11 @@ def _upsert_mcp_server(
             and request.auth_performer == MCPAuthenticationPerformer.PER_USER
             and existing_admin_per_user_creds != (request.admin_credentials or {})
         )
-        api_token_template_changed = (
-            request.auth_type == MCPAuthenticationType.API_TOKEN
-            and request.auth_performer == MCPAuthenticationPerformer.PER_USER
+        header_template_changed = (
+            not (
+                request.auth_type == MCPAuthenticationType.API_TOKEN
+                and request.auth_performer == MCPAuthenticationPerformer.ADMIN
+            )
             and request.auth_template is not None
             and request.auth_template.headers != existing_template_headers
         )
@@ -2039,12 +1986,23 @@ def _upsert_mcp_server(
             and request.auth_template is not None
             and request.auth_template.headers != existing_shared_template_headers
         )
+        shared_api_token_credentials_changed = (
+            request.auth_type == MCPAuthenticationType.API_TOKEN
+            and request.auth_performer == MCPAuthenticationPerformer.ADMIN
+            and request.admin_credentials is not None
+            and request.admin_credentials
+            != existing_admin_config_dict.get(HEADER_SUBSTITUTIONS, {})
+        )
         api_token_scheme_changed = (
             request.auth_type == MCPAuthenticationType.API_TOKEN
             and (
                 request.auth_type != mcp_server.auth_type
                 or request.auth_performer != mcp_server.auth_performer
             )
+        )
+        auth_scheme_changed = (
+            request.auth_type != mcp_server.auth_type
+            or request.auth_performer != mcp_server.auth_performer
         )
         # Known-provider OAuth settings (endpoints/mode/scopes/extra params)
         # determine where and with what scope user tokens are minted. A change
@@ -2078,8 +2036,9 @@ def _upsert_mcp_server(
                 request.auth_type == MCPAuthenticationType.API_TOKEN
                 and (
                     api_token_creds_changed
-                    or api_token_template_changed
+                    or header_template_changed
                     or shared_api_token_template_changed
+                    or shared_api_token_credentials_changed
                     or (
                         request.auth_performer == MCPAuthenticationPerformer.ADMIN
                         and request.api_token_changed
@@ -2087,16 +2046,23 @@ def _upsert_mcp_server(
                     or api_token_scheme_changed
                 )
             )
+            or header_template_changed
+            or auth_scheme_changed
             or (request.transport != mcp_server.transport)
         )
 
-        # OAuth: wipe every user's tokens — re-handshake required.
-        # API_TOKEN: drop only the shared template; the admin's per-user
-        # row is upserted in place below.
+        if header_template_changed or auth_scheme_changed:
+            users_to_reload = affected_user_ids_for_mcp_server(mcp_server, db_session)
+            delete_all_user_connection_configs_for_server_no_commit(
+                mcp_server.id, db_session
+            )
+
         if (
             changing_connection_config
             and mcp_server.admin_connection_config_id
             and request.auth_type == MCPAuthenticationType.OAUTH
+            and not header_template_changed
+            and not auth_scheme_changed
         ):
             delete_all_user_connection_configs_for_server_no_commit(
                 mcp_server.id, db_session
@@ -2131,6 +2097,12 @@ def _upsert_mcp_server(
 
     else:
         # Handle new server creation
+        if request.auth_template is not None:
+            request.auth_template = _resolve_auth_template(
+                request.auth_template,
+                request.auth_template_headers_changed,
+                None,
+            )
         # Prevent duplicate server creation with same URL
         normalized_url = (request.server_url or "").strip()
         if not normalized_url:
@@ -2176,22 +2148,39 @@ def _upsert_mcp_server(
             db_session=db_session,
         )
 
-    # PT_OAUTH doesn't need stored connection config (uses user's login token)
     if (
-        not changing_connection_config
-        or request.auth_type == MCPAuthenticationType.NONE
-        or request.auth_type == MCPAuthenticationType.PT_OAUTH
+        request.auth_template is not None
+        and request.admin_credentials is not None
+        and not (
+            request.auth_type == MCPAuthenticationType.API_TOKEN
+            and request.auth_performer == MCPAuthenticationPerformer.ADMIN
+        )
     ):
+        _upsert_user_template_config(
+            mcp_server=mcp_server,
+            template=request.auth_template,
+            substitutions=request.admin_credentials,
+            user_email=user.email,
+            db_session=db_session,
+        )
+        users_to_reload.add(user.id)
+
+    if not changing_connection_config:
+        db_session.commit()
+        _hot_reload_craft_sessions(users_to_reload, db_session)
         return mcp_server
 
-    # Create connection configs
-    admin_connection_config_id = None
-    if request.auth_performer == MCPAuthenticationPerformer.ADMIN and request.api_token:
-        # Admin-managed server: create admin config with API token
+    admin_connection_config_id: int | None = None
+    if (
+        request.auth_type == MCPAuthenticationType.API_TOKEN
+        and request.auth_performer == MCPAuthenticationPerformer.ADMIN
+        and request.api_token
+    ):
         admin_config = create_connection_config(
             config_data=_build_shared_api_token_config_data(
                 api_token=request.api_token,
                 auth_template=request.auth_template,
+                header_substitutions=request.admin_credentials,
                 user_email=user.email,
             ),
             mcp_server_id=mcp_server.id,
@@ -2199,82 +2188,42 @@ def _upsert_mcp_server(
         )
         admin_connection_config_id = admin_config.id
 
-    elif request.auth_performer == MCPAuthenticationPerformer.PER_USER:
-        if request.auth_type == MCPAuthenticationType.API_TOKEN:
-            # handled by model validation, this is just for type-checking
-            assert request.auth_template and request.admin_credentials
-
-            # Per-user server: create template and save creator's per-user config
-            template_data = request.auth_template
-
-            # Trust the explicit list when present, otherwise derive it from
-            # the header placeholders so the user-side modal always knows
-            # which fields to prompt for. Older servers created before this
-            # field was persisted are healed lazily on read.
-            persisted_required_fields = (
-                template_data.required_fields
-                or MCPAuthTemplate.derive_required_fields(template_data.headers)
+    elif request.auth_type == MCPAuthenticationType.API_TOKEN:
+        if request.auth_template is None:
+            raise OnyxError(
+                OnyxErrorCode.MISSING_REQUIRED_FIELD,
+                "Per-user API-token servers require a header template.",
             )
+        admin_connection_config_id = create_connection_config(
+            config_data=_build_template_config_data(request.auth_template),
+            mcp_server_id=mcp_server.id,
+            db_session=db_session,
+        ).id
 
-            # Template config: placeholder headers + required fields only.
-            # Admin's credentials live on the admin's own per-user row.
-            template_config = create_connection_config(
-                config_data=MCPConnectionData(
-                    headers=template_data.headers,
-                    required_fields=persisted_required_fields,
-                ),
-                mcp_server_id=mcp_server.id,
-                user_email="",
-                db_session=db_session,
-            )
-
-            # Seed (or refresh) the admin's own per-user row.
-            upsert_user_connection_config(
-                server_id=mcp_server.id,
-                user_email=user.email,
-                config_data=MCPConnectionData(
-                    headers=_build_headers_from_template(
-                        template_data, request.admin_credentials, user.email
-                    ),
-                    header_substitutions=request.admin_credentials,
-                ),
-                db_session=db_session,
-            )
-            admin_connection_config_id = template_config.id
-        elif request.auth_type == MCPAuthenticationType.OAUTH:
-            # Create initial admin config. If client credentials were provided,
-            # seed client_info so the OAuth provider can skip dynamic
-            # registration; otherwise, the provider will attempt it.
-            # NOTE: must go through the shared helper so
-            # `token_endpoint_auth_method` matches what `_connect_oauth`'s
-            # update path expects to preserve later.
-            cfg: MCPConnectionData = _build_oauth_admin_config_data(
+    elif request.auth_type == MCPAuthenticationType.OAUTH:
+        config_data = (
+            _build_oauth_admin_config_data_for_update(
                 client_id=request.oauth_client_id,
                 client_secret=request.oauth_client_secret,
+                existing_client=client_info,
+                auth_template=request.auth_template,
             )
-
-            admin_config = create_connection_config(
-                config_data=cfg,
-                mcp_server_id=mcp_server.id,
-                user_email="",
-                db_session=db_session,
+            if client_info is not None
+            else _build_oauth_admin_config_data(
+                client_id=request.oauth_client_id,
+                client_secret=request.oauth_client_secret,
+                auth_template=request.auth_template,
             )
-            admin_connection_config_id = admin_config.id
-
-            # create user connection config
-            create_connection_config(
-                config_data=cfg,
-                mcp_server_id=mcp_server.id,
-                user_email=user.email,
-                db_session=db_session,
-            )
-    elif request.auth_performer == MCPAuthenticationPerformer.ADMIN:
-        raise HTTPException(
-            status_code=400,
-            detail="Admin authentication is not yet supported for MCP servers: user per-user",
+        )
+        admin_connection_config_id = _persist_admin_connection_config(
+            mcp_server, config_data, db_session
         )
 
-    # Update server with config IDs
+    else:
+        config_data = _build_template_config_data(request.auth_template)
+        admin_connection_config_id = _persist_admin_connection_config(
+            mcp_server, config_data, db_session
+        )
     if admin_connection_config_id is not None:
         mcp_server = update_mcp_server__no_commit(
             server_id=mcp_server.id,
@@ -2283,6 +2232,7 @@ def _upsert_mcp_server(
         )
 
     db_session.commit()
+    _hot_reload_craft_sessions(users_to_reload, db_session)
     return mcp_server
 
 

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -52,12 +52,30 @@ def apply_auto_substitutions(value: str, *, user_email: str) -> str:
     return value
 
 
+def contains_mcp_placeholder(value: str) -> bool:
+    return _PLACEHOLDER_RE.search(value) is not None
+
+
 # Headers that must never be sourced from stored MCP credentials or request
 # templates. Host is particularly critical — it can be used for Host Header
 # Injection attacks to route requests to unintended internal servers.
 DENYLISTED_MCP_HEADERS = {
     "host",
 }
+
+
+def merge_mcp_headers(*sources: dict[str, str]) -> dict[str, str]:
+    """Merge HTTP headers case-insensitively; later sources win."""
+    merged: dict[str, str] = {}
+    names_by_lower: dict[str, str] = {}
+    for source in sources:
+        for name, value in source.items():
+            lowered = name.lower()
+            if previous_name := names_by_lower.get(lowered):
+                merged.pop(previous_name, None)
+            merged[name] = value
+            names_by_lower[lowered] = name
+    return merged
 
 
 # This should be updated along with MCPConnectionData
@@ -77,8 +95,8 @@ class MCPConnectionData(TypedDict):
     in Postgres"""
 
     headers: dict[str, str]
-    # The placeholder form of shared API-token headers. The rendered headers
-    # above remain the source used for outbound requests.
+    # Admin-authored source template. User configs store its rendered result in
+    # `headers`; admin-managed configs may render it at request time.
     header_template: NotRequired[dict[str, str]]
     # Stored in the encrypted connection config so an admin can edit the
     # header template without re-entering the masked API token.
@@ -104,7 +122,7 @@ class MCPConnectionData(TypedDict):
 
 
 class MCPAuthTemplate(BaseModel):
-    """Template for per-user authentication configuration"""
+    """Header template shared by every MCP authentication type."""
 
     headers: dict[str, str] = Field(
         default_factory=dict,
@@ -119,6 +137,24 @@ class MCPAuthTemplate(BaseModel):
         description="List of required field names that users must provide",
     )
 
+    @model_validator(mode="after")
+    def validate_headers(self) -> "MCPAuthTemplate":
+        seen: set[str] = set()
+        for name in self.headers:
+            lowered = name.lower()
+            if _HTTP_FIELD_NAME_RE.fullmatch(name) is None:
+                raise ValueError(f"Invalid MCP header name: {name!r}")
+            if lowered in DENYLISTED_MCP_HEADERS:
+                raise ValueError(f"MCP header {name!r} is not allowed")
+            if lowered in seen:
+                raise ValueError(f"Duplicate MCP header name: {name!r}")
+            seen.add(lowered)
+
+        derived_fields = self.derive_required_fields(self.headers)
+        if self.headers or not self.required_fields:
+            self.required_fields = derived_fields
+        return self
+
     @staticmethod
     def derive_required_fields(headers: dict[str, str]) -> list[str]:
         """Extract the set of `{placeholder}` field names referenced by
@@ -131,7 +167,26 @@ class MCPAuthTemplate(BaseModel):
                 if match in AUTO_SUBSTITUTED_PLACEHOLDER_KEYS:
                     continue
                 seen.add(match)
-        return list(seen)
+        return sorted(seen)
+
+    def render(
+        self, substitutions: dict[str, str], *, user_email: str
+    ) -> dict[str, str]:
+        missing = [
+            field for field in self.required_fields if not substitutions.get(field)
+        ]
+        if missing:
+            raise ValueError(
+                f"Missing MCP header substitutions: {', '.join(sorted(missing))}"
+            )
+
+        headers: dict[str, str] = {}
+        for name, template in self.headers.items():
+            value = template
+            for key, replacement in substitutions.items():
+                value = value.replace(f"{{{key}}}", replacement)
+            headers[name] = apply_auto_substitutions(value, user_email=user_email)
+        return headers
 
 
 class MCPToolCreateRequest(BaseModel):
@@ -196,9 +251,13 @@ class MCPToolCreateRequest(BaseModel):
     auth_template: Optional[MCPAuthTemplate] = Field(
         None,
         description=(
-            "Authentication header template for API-token authentication. "
-            "Shared templates support the {api_key} placeholder."
+            "Headers sent to the MCP server. Values may contain placeholders "
+            "supplied per user."
         ),
+    )
+    auth_template_headers_changed: dict[str, bool] = Field(
+        default_factory=dict,
+        description="Per-header flags marking edited template values.",
     )
     admin_credentials: Optional[dict[str, str]] = Field(
         None,
@@ -257,18 +316,6 @@ class MCPToolCreateRequest(BaseModel):
             # server is created. Do not materialize that default here, since
             # doing so makes an omitted template look like an explicit edit.
             if self.auth_template is not None:
-                placeholders: set[str] = {
-                    match
-                    for value in self.auth_template.headers.values()
-                    for match in _PLACEHOLDER_RE.findall(value)
-                }
-                unsupported_placeholders: set[str] = placeholders - {"api_key"}
-                if unsupported_placeholders:
-                    raise ValueError(
-                        "Shared API-token header templates only support the "
-                        f"{{api_key}} placeholder; unsupported placeholders: "
-                        f"{', '.join(sorted(unsupported_placeholders))}"
-                    )
                 if not any(
                     "{api_key}" in value
                     for value in self.auth_template.headers.values()
@@ -276,16 +323,6 @@ class MCPToolCreateRequest(BaseModel):
                     raise ValueError(
                         "Shared API-token header templates must include the {api_key} placeholder"
                     )
-                if any(
-                    _HTTP_FIELD_NAME_RE.fullmatch(name) is None
-                    or name.strip().lower() in DENYLISTED_MCP_HEADERS
-                    for name in self.auth_template.headers
-                ):
-                    raise ValueError(
-                        "Shared API-token header templates contain an invalid header name"
-                    )
-                self.auth_template.required_fields = ["api_key"]
-
         # Validate that API token is not provided for per-user auth
         if (
             self.auth_type == MCPAuthenticationType.API_TOKEN
@@ -306,7 +343,7 @@ class MCPToolCreateRequest(BaseModel):
                 raise ValueError(
                     "auth_template is required when auth_performer is 'per_user'"
                 )
-            if not self.admin_credentials:
+            if self.auth_template.required_fields and self.admin_credentials is None:
                 raise ValueError(
                     "admin_credentials is required when auth_performer is 'per_user'"
                 )

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -343,7 +343,7 @@ class MCPToolCreateRequest(BaseModel):
                 raise ValueError(
                     "auth_template is required when auth_performer is 'per_user'"
                 )
-            if self.auth_template.required_fields and self.admin_credentials is None:
+            if self.auth_template.required_fields and not self.admin_credentials:
                 raise ValueError(
                     "admin_credentials is required when auth_performer is 'per_user'"
                 )

--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -41,7 +41,11 @@ from onyx.db.models import MCPServer as DbMCPServer
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_pool import get_redis_client
-from onyx.server.features.mcp.models import MCPConnectionData, MCPOAuthKeys
+from onyx.server.features.mcp.models import (
+    MCPConnectionData,
+    MCPOAuthKeys,
+    merge_mcp_headers,
+)
 from onyx.server.features.mcp.ssrf import mcp_ssrf_httpx_client_factory
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import run_async_sync_no_cancel
@@ -410,9 +414,10 @@ class OnyxTokenStorage(TokenStorage):
                 config_data[MCPOAuthKeys.METADATA.value] = (
                     self._oauth_context.oauth_metadata.model_dump(mode="json")
                 )
-            config_data["headers"] = {
-                "Authorization": f"{tokens.token_type} {tokens.access_token}"
-            }
+            config_data["headers"] = merge_mcp_headers(
+                config_data.get("headers", {}),
+                {"Authorization": f"{tokens.token_type} {tokens.access_token}"},
+            )
             update_connection_config(config.id, db_session, config_data)
 
         if self.refresh_attempt_id and self.refresh_log_context:

--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -483,6 +483,7 @@ def _construct_tools_impl(
                     user_id=str(user.id),
                     user_oauth_token=mcp_credentials.user_oauth_token,
                     additional_headers=additional_mcp_headers,
+                    resolved_credentials=mcp_credentials,
                 )
                 mcp_tool_cache[db_tool_model.mcp_server_id][saved_tool.id] = mcp_tool
 

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -9,7 +9,10 @@ from onyx.db.enums import MCPAuthenticationType, MCPTransport
 from onyx.db.mcp import ResolvedMCPCredentials
 from onyx.db.models import MCPConnectionConfig, MCPServer
 from onyx.server.features.mcp.client import call_mcp_tool
-from onyx.server.features.mcp.models import DENYLISTED_MCP_HEADERS
+from onyx.server.features.mcp.models import (
+    DENYLISTED_MCP_HEADERS,
+    merge_mcp_headers,
+)
 from onyx.server.features.mcp.oauth import (
     UNUSED_RETURN_PATH,
     make_oauth_provider,
@@ -79,6 +82,7 @@ class MCPTool(Tool[None]):
         user_id: str = "",
         user_oauth_token: str | None = None,
         additional_headers: dict[str, str] | None = None,
+        resolved_credentials: ResolvedMCPCredentials | None = None,
     ) -> None:
         super().__init__(emitter=emitter)
 
@@ -89,6 +93,7 @@ class MCPTool(Tool[None]):
         self._user_id = user_id
         self._user_oauth_token = user_oauth_token
         self._additional_headers = additional_headers or {}
+        self._resolved_credentials = resolved_credentials
 
         self._mcp_tool_name = tool_name
         self._name = tool_name  # NOTE: this may change in _disambiguate_mcp_tool_names
@@ -147,64 +152,28 @@ class MCPTool(Tool[None]):
         _server = self.mcp_server.name
         outcome = MCPToolCallStatus.ERROR
         try:
-            # Build headers with proper precedence:
-            # 1. Start with additional headers from API request (filled in first, excluding denylisted)
-            # 2. Override with connection config headers (from DB) - these take precedence
-            # 3. Override Authorization header with OAuth token if present
-            headers: dict[str, str] = {}
-
-            # Priority 1: Additional headers from API request (filled in first)
-            # Filter out denylisted headers to prevent security issues (e.g., Host Header Injection)
-            if self._additional_headers:
-                filtered_headers = {
-                    k: v
-                    for k, v in self._additional_headers.items()
-                    if k.lower() not in DENYLISTED_MCP_HEADERS
-                }
-                if filtered_headers:
-                    headers.update(filtered_headers)
-                # Log if any denylisted headers were provided (for security monitoring)
-                denylisted_provided = [
-                    k
-                    for k in self._additional_headers.keys()
-                    if k.lower() in DENYLISTED_MCP_HEADERS
-                ]
-                if denylisted_provided:
-                    logger.warning(
-                        "MCP tool '%s' received denylisted headers that were filtered: %s",
-                        self._name,
-                        denylisted_provided,
-                    )
-
-            # Priority 2 + 3: stored connection-config headers, then the
-            # PT_OAuth login token — both override request headers.
-            headers.update(
-                ResolvedMCPCredentials(
-                    connection_config=self.connection_config,
-                    user_oauth_token=self._user_oauth_token,
-                ).build_headers()
+            request_headers = {
+                name: value
+                for name, value in self._additional_headers.items()
+                if name.lower() not in DENYLISTED_MCP_HEADERS
+            }
+            credentials = self._resolved_credentials or ResolvedMCPCredentials(
+                connection_config=self.connection_config,
+                user_oauth_token=self._user_oauth_token,
+                auth_type=self.mcp_server.auth_type,
+                auth_performer=self.mcp_server.auth_performer,
+                user_email=self.user_email,
+            )
+            headers = merge_mcp_headers(
+                request_headers,
+                credentials.build_headers(),
             )
 
-            # Check if this is an authentication issue before making the call
-            is_passthrough_oauth = (
-                self.mcp_server.auth_type == MCPAuthenticationType.PT_OAUTH
-            )
-            requires_auth = (
-                self.mcp_server.auth_type != MCPAuthenticationType.NONE
-                and self.mcp_server.auth_type is not None
-            )
-            has_auth_config = (
-                (self.connection_config is not None and bool(headers))
-                or bool(self._additional_headers)
-            ) or (is_passthrough_oauth and self._user_oauth_token is not None)
-
-            if requires_auth and not has_auth_config:
-                # Authentication required but not configured
+            if not credentials.is_authenticated() and not self._additional_headers:
                 auth_error_msg = (
-                    f"The {self._name} tool from {self.mcp_server.name} requires authentication "
-                    f"but no credentials have been provided. Tell the user to use the MCP dropdown in the "
-                    f"chat bar to authenticate with the {self.mcp_server.name} server before "
-                    f"using this tool."
+                    f"The {self._name} tool from {self.mcp_server.name} requires "
+                    "connection values. Tell the user to connect to the server "
+                    "from the MCP dropdown before using this tool."
                 )
                 logger.warning(
                     "Authentication required for MCP tool '%s' but no credentials found",

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -157,6 +157,14 @@ class MCPTool(Tool[None]):
                 for name, value in self._additional_headers.items()
                 if name.lower() not in DENYLISTED_MCP_HEADERS
             }
+            if denylisted := sorted(
+                set(self._additional_headers) - set(request_headers)
+            ):
+                logger.warning(
+                    "MCP tool '%s' received denylisted headers that were filtered: %s",
+                    self._name,
+                    denylisted,
+                )
             credentials = self._resolved_credentials or ResolvedMCPCredentials(
                 connection_config=self.connection_config,
                 user_oauth_token=self._user_oauth_token,

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -161,7 +161,6 @@ class MCPTool(Tool[None]):
                 connection_config=self.connection_config,
                 user_oauth_token=self._user_oauth_token,
                 auth_type=self.mcp_server.auth_type,
-                auth_performer=self.mcp_server.auth_performer,
                 user_email=self.user_email,
             )
             headers = merge_mcp_headers(

--- a/backend/tests/external_dependency_unit/server/features/mcp/test_shared_api_token_template_visibility.py
+++ b/backend/tests/external_dependency_unit/server/features/mcp/test_shared_api_token_template_visibility.py
@@ -2,11 +2,11 @@
 the owner/admin auth-config response. Basic users who can merely attach the
 server never supply shared credentials and must not receive the template,
 which can carry literal header values alongside the `{api_key}` placeholder.
-Per-user templates stay visible to basic users because they drive the
-per-user credential prompt."""
+Basic users receive only the required placeholder names for per-user templates."""
 
 from uuid import uuid4
 
+import pytest
 from sqlalchemy.orm import Session
 
 from onyx.auth.schemas import UserRole
@@ -15,15 +15,22 @@ from onyx.db.enums import (
     MCPAuthenticationType,
     MCPTransport,
 )
-from onyx.db.mcp import get_mcp_server_by_id
+from onyx.db.mcp import (
+    create_connection_config,
+    get_mcp_auth_template,
+    get_mcp_server_by_id,
+    get_user_connection_config,
+)
 from onyx.server.features.mcp.api import (
     _db_mcp_server_to_api_mcp_server,
     _upsert_mcp_server,
 )
 from onyx.server.features.mcp.models import (
     MCPAuthTemplate,
+    MCPConnectionData,
     MCPToolCreateRequest,
 )
+from onyx.utils.encryption import is_masked_credential
 from tests.external_dependency_unit.conftest import create_test_user
 
 _LITERAL_HEADER_VALUE = "literal-secret-value"
@@ -75,15 +82,13 @@ def test_admin_receives_shared_template_with_auth_config(
     )
 
     assert view.auth_template is not None
-    assert view.auth_template.headers == {
-        "Authorization": "Bearer {api_key}",
-        "X-Literal": _LITERAL_HEADER_VALUE,
-    }
+    assert view.auth_template.headers["Authorization"] == "Bearer {api_key}"
+    assert is_masked_credential(view.auth_template.headers["X-Literal"])
 
 
-def test_basic_user_still_receives_per_user_template(db_session: Session) -> None:
-    """Guard against over-restricting: per-user templates must remain visible
-    to basic users so the credential prompt can render."""
+def test_basic_user_receives_only_per_user_placeholder_names(
+    db_session: Session,
+) -> None:
     admin = create_test_user(db_session, "admin_per_user_vis", role=UserRole.ADMIN)
     request = MCPToolCreateRequest(
         name=f"per-user-token-{uuid4().hex[:8]}",
@@ -105,4 +110,88 @@ def test_basic_user_still_receives_per_user_template(db_session: Session) -> Non
     view = _db_mcp_server_to_api_mcp_server(server, db_session, request_user=basic_user)
 
     assert view.auth_template is not None
-    assert view.auth_template.headers == {"Authorization": "Bearer {api_key}"}
+    assert view.auth_template.headers == {}
+    assert view.auth_template.required_fields == ["api_key"]
+
+
+@pytest.mark.parametrize(
+    "auth_type",
+    [
+        MCPAuthenticationType.OAUTH,
+        MCPAuthenticationType.PT_OAUTH,
+        MCPAuthenticationType.NONE,
+    ],
+)
+def test_header_template_persists_for_every_auth_type(
+    db_session: Session,
+    auth_type: MCPAuthenticationType,
+) -> None:
+    admin = create_test_user(
+        db_session, f"admin_cross_auth_{auth_type.value}", role=UserRole.ADMIN
+    )
+    server = _upsert_mcp_server(
+        MCPToolCreateRequest(
+            name=f"cross-auth-{auth_type.value}-{uuid4().hex[:8]}",
+            server_url="http://upstream.example.com/mcp",
+            auth_type=auth_type,
+            auth_performer=MCPAuthenticationPerformer.PER_USER,
+            transport=MCPTransport.STREAMABLE_HTTP,
+            auth_template=MCPAuthTemplate(headers={"X-Gateway-Key": "{gateway_key}"}),
+            admin_credentials={"gateway_key": "admin-gateway-key"},
+        ),
+        db_session,
+        admin,
+    )
+
+    stored_template = get_mcp_auth_template(server)
+    assert stored_template is not None
+    assert stored_template.headers == {"X-Gateway-Key": "{gateway_key}"}
+    assert stored_template.required_fields == ["gateway_key"]
+
+
+def test_template_change_requires_users_to_reconnect(db_session: Session) -> None:
+    admin = create_test_user(db_session, "admin_template_reauth", role=UserRole.ADMIN)
+    other_user = create_test_user(db_session, "user_template_reauth")
+    server = _upsert_mcp_server(
+        MCPToolCreateRequest(
+            name=f"template-reauth-{uuid4().hex[:8]}",
+            server_url="http://upstream.example.com/mcp",
+            auth_type=MCPAuthenticationType.OAUTH,
+            auth_performer=MCPAuthenticationPerformer.PER_USER,
+            transport=MCPTransport.STREAMABLE_HTTP,
+            auth_template=MCPAuthTemplate(headers={"X-Gateway-Key": "{gateway_key}"}),
+            admin_credentials={"gateway_key": "admin-key"},
+        ),
+        db_session,
+        admin,
+    )
+    create_connection_config(
+        config_data=MCPConnectionData(
+            headers={"X-Gateway-Key": "user-key"},
+            header_substitutions={"gateway_key": "user-key"},
+        ),
+        db_session=db_session,
+        mcp_server_id=server.id,
+        user_email=other_user.email,
+    )
+    db_session.commit()
+
+    _upsert_mcp_server(
+        MCPToolCreateRequest(
+            name=server.name,
+            server_url=server.server_url,
+            auth_type=MCPAuthenticationType.OAUTH,
+            auth_performer=MCPAuthenticationPerformer.PER_USER,
+            transport=server.transport,
+            auth_template=MCPAuthTemplate(
+                headers={"X-New-Gateway-Key": "{gateway_key}"}
+            ),
+            admin_credentials={"gateway_key": "admin-key"},
+            existing_server_id=server.id,
+        ),
+        db_session,
+        admin,
+    )
+
+    assert get_user_connection_config(server.id, other_user.email, db_session) is None
+    assert get_user_connection_config(server.id, admin.email, db_session) is not None

--- a/backend/tests/unit/onyx/server/features/mcp/test_build_headers.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_build_headers.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from onyx.db.enums import MCPAuthenticationPerformer, MCPAuthenticationType
+from onyx.db.enums import MCPAuthenticationType
 from onyx.db.mcp import ResolvedMCPCredentials
 from onyx.db.models import MCPConnectionConfig
 from onyx.server.features.mcp.models import MCPAuthTemplate
@@ -61,7 +61,6 @@ def test_pt_oauth_merges_template_headers_and_overrides_authorization() -> None:
         connection_config=config,
         user_oauth_token="login-token",
         auth_type=MCPAuthenticationType.PT_OAUTH,
-        auth_performer=MCPAuthenticationPerformer.PER_USER,
         auth_template=MCPAuthTemplate(
             headers={
                 "X-Gateway-Key": "{gateway_key}",
@@ -91,7 +90,6 @@ def test_oauth_merges_template_headers_with_token_auth() -> None:
         connection_config=config,
         user_oauth_token=None,
         auth_type=MCPAuthenticationType.OAUTH,
-        auth_performer=MCPAuthenticationPerformer.PER_USER,
         auth_template=MCPAuthTemplate(headers={"X-Gateway-Key": "{gateway_key}"}),
         user_email="alice@example.com",
     )
@@ -109,7 +107,6 @@ def test_no_auth_template_requires_user_substitutions() -> None:
         connection_config=None,
         user_oauth_token=None,
         auth_type=MCPAuthenticationType.NONE,
-        auth_performer=MCPAuthenticationPerformer.ADMIN,
         auth_template=template,
         user_email="alice@example.com",
     )
@@ -134,7 +131,6 @@ def test_api_token_template_without_placeholders_needs_no_user_config() -> None:
         connection_config=None,
         user_oauth_token=None,
         auth_type=MCPAuthenticationType.API_TOKEN,
-        auth_performer=MCPAuthenticationPerformer.PER_USER,
         auth_template=MCPAuthTemplate(headers={"X-Gateway-Key": "shared-key"}),
         user_email="alice@example.com",
     )
@@ -150,7 +146,6 @@ def test_fresh_template_rendering_overrides_persisted_auto_substitution() -> Non
         ),
         user_oauth_token=None,
         auth_type=MCPAuthenticationType.API_TOKEN,
-        auth_performer=MCPAuthenticationPerformer.ADMIN,
         auth_template=MCPAuthTemplate(headers={"X-User": "{user_email}"}),
         user_email="alice@example.com",
     )

--- a/backend/tests/unit/onyx/server/features/mcp/test_build_headers.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_build_headers.py
@@ -1,14 +1,13 @@
-"""Pins `ResolvedMCPCredentials.build_headers()`: the credential-header
-precedence and the denylist filter on stored headers. Stored credentials must
-never source a denylisted header (e.g. Host) — every consumer (chat's MCPTool,
-the sandbox-proxy resolver) relies on this helper applying that filter."""
+"""Header composition across templates, stored values, and generated auth."""
 
 import json
 
 import pytest
 
+from onyx.db.enums import MCPAuthenticationPerformer, MCPAuthenticationType
 from onyx.db.mcp import ResolvedMCPCredentials
 from onyx.db.models import MCPConnectionConfig
+from onyx.server.features.mcp.models import MCPAuthTemplate
 from onyx.utils.sensitive import SensitiveValue
 
 
@@ -49,3 +48,111 @@ def test_build_headers_empty_without_credentials() -> None:
     creds = ResolvedMCPCredentials(connection_config=None, user_oauth_token=None)
 
     assert creds.build_headers() == {}
+
+
+def test_pt_oauth_merges_template_headers_and_overrides_authorization() -> None:
+    config = MCPConnectionConfig(
+        config={
+            "headers": {"authorization": "Basic stale"},
+            "header_substitutions": {"gateway_key": "gateway-secret"},
+        }
+    )
+    creds = ResolvedMCPCredentials(
+        connection_config=config,
+        user_oauth_token="login-token",
+        auth_type=MCPAuthenticationType.PT_OAUTH,
+        auth_performer=MCPAuthenticationPerformer.PER_USER,
+        auth_template=MCPAuthTemplate(
+            headers={
+                "X-Gateway-Key": "{gateway_key}",
+                "X-User": "{user_email}",
+            }
+        ),
+        user_email="alice@example.com",
+    )
+
+    assert creds.build_headers() == {
+        "X-Gateway-Key": "gateway-secret",
+        "X-User": "alice@example.com",
+        "Authorization": "Bearer login-token",
+    }
+    assert creds.is_authenticated()
+
+
+def test_oauth_merges_template_headers_with_token_auth() -> None:
+    config = MCPConnectionConfig(
+        config={
+            "headers": {},
+            "header_substitutions": {"gateway_key": "gateway-secret"},
+            "tokens": {"token_type": "Bearer", "access_token": "oauth-token"},
+        }
+    )
+    creds = ResolvedMCPCredentials(
+        connection_config=config,
+        user_oauth_token=None,
+        auth_type=MCPAuthenticationType.OAUTH,
+        auth_performer=MCPAuthenticationPerformer.PER_USER,
+        auth_template=MCPAuthTemplate(headers={"X-Gateway-Key": "{gateway_key}"}),
+        user_email="alice@example.com",
+    )
+
+    assert creds.build_headers() == {
+        "X-Gateway-Key": "gateway-secret",
+        "Authorization": "Bearer oauth-token",
+    }
+    assert creds.is_authenticated()
+
+
+def test_no_auth_template_requires_user_substitutions() -> None:
+    template = MCPAuthTemplate(headers={"X-Gateway-Key": "{gateway_key}"})
+    disconnected = ResolvedMCPCredentials(
+        connection_config=None,
+        user_oauth_token=None,
+        auth_type=MCPAuthenticationType.NONE,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+        auth_template=template,
+        user_email="alice@example.com",
+    )
+    connected = disconnected.model_copy(
+        update={
+            "connection_config": MCPConnectionConfig(
+                config={
+                    "headers": {},
+                    "header_substitutions": {"gateway_key": "gateway-secret"},
+                }
+            )
+        }
+    )
+
+    assert not disconnected.is_authenticated()
+    assert connected.is_authenticated()
+    assert connected.build_headers() == {"X-Gateway-Key": "gateway-secret"}
+
+
+def test_api_token_template_without_placeholders_needs_no_user_config() -> None:
+    creds = ResolvedMCPCredentials(
+        connection_config=None,
+        user_oauth_token=None,
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.PER_USER,
+        auth_template=MCPAuthTemplate(headers={"X-Gateway-Key": "shared-key"}),
+        user_email="alice@example.com",
+    )
+
+    assert creds.is_authenticated()
+    assert creds.build_headers() == {"X-Gateway-Key": "shared-key"}
+
+
+def test_fresh_template_rendering_overrides_persisted_auto_substitution() -> None:
+    creds = ResolvedMCPCredentials(
+        connection_config=MCPConnectionConfig(
+            config={"headers": {"X-User": "admin@example.com"}}
+        ),
+        user_oauth_token=None,
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+        auth_template=MCPAuthTemplate(headers={"X-User": "{user_email}"}),
+        user_email="alice@example.com",
+    )
+
+    assert creds.build_headers() == {"X-User": "alice@example.com"}

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
@@ -381,9 +381,7 @@ def test_no_refresh_without_persisted_expiry(monkeypatch: pytest.MonkeyPatch) ->
 def test_refresh_persists_via_real_onyx_token_storage(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Persists via the real `OnyxTokenStorage.set_tokens`, so `headers` is
-    replaced with just the new `Authorization` value (not merged) — other
-    static headers are dropped, same as a non-SSE refresh."""
+    """OAuth refresh replaces Authorization without dropping custom headers."""
     config_data: dict[str, Any] = {
         "headers": {"Authorization": "Bearer OLD", "X-Custom": "static-value"},
         MCPOAuthKeys.TOKENS.value: {
@@ -408,7 +406,10 @@ def test_refresh_persists_via_real_onyx_token_storage(
     header = refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")
 
     assert header == "Bearer NEW"
-    assert config_data["headers"] == {"Authorization": "Bearer NEW"}
+    assert config_data["headers"] == {
+        "Authorization": "Bearer NEW",
+        "X-Custom": "static-value",
+    }
 
 
 def test_refresh_failure_is_non_fatal_to_caller(

--- a/backend/tests/unit/onyx/server/features/mcp/test_per_user_listing_invariants.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_per_user_listing_invariants.py
@@ -4,14 +4,9 @@ listing endpoints (`GET /api/mcp/servers`,
 
 The shared admin connection config row is cross-user state — it's the
 OAuth `client_info` registry used by every user of a given MCP server.
-Per-user state (access tokens, resolved `Authorization` headers) lives
-only on the per-user row. The `auth_template` field on the API model
-exists exclusively to support per-user API_TOKEN servers, where the
-admin defines a header template with placeholders (e.g.
-`Bearer {API_KEY}`) and the user fills the placeholders in their own
-credential modal. OAuth per-user servers use the OAuth handshake URL
-and never consume an `auth_template`, so the field must remain `None`
-for them regardless of caller role or the contents of the shared row.
+Per-user state (tokens and rendered headers) lives only on the per-user
+row. Basic users receive required placeholder names but never the
+admin-authored header template values.
 """
 
 from typing import Any
@@ -195,11 +190,7 @@ class TestPerUserAuthTemplateInvariants:
             for v in api_server.admin_credentials.values()
         )
 
-    def test_api_token_per_user_server_returns_placeholder_template(self) -> None:
-        """The legitimate `auth_template` use case: per-user API_TOKEN
-        servers must keep returning the placeholder header template so
-        the user-side credential modal knows which fields to prompt for.
-        """
+    def test_api_token_per_user_server_returns_placeholder_names(self) -> None:
         db_server = _make_db_server(
             auth_type=MCPAuthenticationType.API_TOKEN,
             auth_performer=MCPAuthenticationPerformer.PER_USER,
@@ -219,7 +210,29 @@ class TestPerUserAuthTemplateInvariants:
             )
 
         assert api_server.auth_template is not None
-        assert api_server.auth_template.headers == {
-            "Authorization": "Bearer {API_KEY}",
-        }
+        assert api_server.auth_template.headers == {}
         assert api_server.auth_template.required_fields == ["API_KEY"]
+
+    def test_api_token_per_user_admin_detail_does_not_extract_shared_key(
+        self,
+    ) -> None:
+        db_server = _make_db_server(
+            auth_type=MCPAuthenticationType.API_TOKEN,
+            auth_performer=MCPAuthenticationPerformer.PER_USER,
+            admin_config=_api_token_template_admin_config(),
+        )
+        owner = _make_user(email="owner@example.com", role=UserRole.ADMIN)
+
+        with patch(
+            "onyx.server.features.mcp.api.get_user_connection_config",
+            return_value=None,
+        ):
+            api_server = _db_mcp_server_to_api_mcp_server(
+                db_server,
+                MagicMock(),
+                request_user=owner,
+                include_auth_config=True,
+            )
+
+        assert api_server.admin_credentials is None
+        assert api_server.auth_template is not None

--- a/backend/tests/unit/onyx/server/features/mcp/test_shared_api_token_headers.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_shared_api_token_headers.py
@@ -7,6 +7,7 @@ from onyx.db.enums import (
 )
 from onyx.server.features.mcp.api import (
     _build_shared_api_token_config_data,
+    _resolve_auth_template,
     _resolve_shared_api_token,
     _resolve_shared_api_token_template,
 )
@@ -15,6 +16,7 @@ from onyx.server.features.mcp.models import (
     MCPConnectionData,
     MCPToolCreateRequest,
 )
+from onyx.utils.encryption import mask_string
 
 
 def _shared_request(
@@ -41,6 +43,7 @@ def test_shared_api_token_template_renders_and_persists_template() -> None:
     config_data = _build_shared_api_token_config_data(
         api_token="shared-secret",
         auth_template=template,
+        header_substitutions=None,
         user_email="admin@example.com",
     )
 
@@ -57,20 +60,31 @@ def test_shared_api_token_template_defaults_to_bearer() -> None:
     config_data = _build_shared_api_token_config_data(
         api_token="shared-secret",
         auth_template=request.auth_template,
+        header_substitutions=None,
         user_email="admin@example.com",
     )
 
     assert config_data["headers"] == {"Authorization": "Bearer shared-secret"}
 
 
-def test_shared_api_token_template_rejects_non_api_key_placeholders() -> None:
-    with pytest.raises(ValueError, match=r"only support the \{api_key\}"):
-        _shared_request(
-            MCPAuthTemplate(
-                headers={"Authorization": "Apikey {user_email}"},
-                required_fields=[],
-            )
-        )
+def test_shared_api_token_template_supports_additional_placeholders() -> None:
+    template = MCPAuthTemplate(
+        headers={
+            "Authorization": "Apikey {api_key}",
+            "X-Gateway-Key": "{gateway_key}",
+        },
+    )
+    config_data = _build_shared_api_token_config_data(
+        api_token="shared-secret",
+        auth_template=template,
+        header_substitutions={"gateway_key": "gateway-secret"},
+        user_email="admin@example.com",
+    )
+
+    assert config_data["headers"] == {
+        "Authorization": "Apikey shared-secret",
+        "X-Gateway-Key": "gateway-secret",
+    }
 
 
 @pytest.mark.parametrize(
@@ -85,7 +99,7 @@ def test_shared_api_token_template_rejects_non_api_key_placeholders() -> None:
 def test_shared_api_token_template_rejects_invalid_header_name(
     header_name: str,
 ) -> None:
-    with pytest.raises(ValueError, match="invalid header name"):
+    with pytest.raises(ValueError, match="Invalid MCP header name"):
         _shared_request(
             MCPAuthTemplate(
                 headers={header_name: "{api_key}"},
@@ -165,3 +179,20 @@ def test_shared_api_token_template_update_preserves_omitted_template() -> None:
 
     assert template is not None
     assert template.headers == {"X-API-Key": "{api_key}"}
+
+
+def test_unchanged_masked_literal_template_value_is_preserved() -> None:
+    existing = MCPAuthTemplate(headers={"X-Gateway-Key": "literal-secret"})
+    request = MCPAuthTemplate(headers={"X-Gateway-Key": mask_string("literal-secret")})
+
+    resolved = _resolve_auth_template(request, {}, existing)
+
+    assert resolved.headers == {"X-Gateway-Key": "literal-secret"}
+
+
+def test_changed_masked_literal_template_value_is_rejected() -> None:
+    existing = MCPAuthTemplate(headers={"X-Gateway-Key": "literal-secret"})
+    request = MCPAuthTemplate(headers={"X-Gateway-Key": mask_string("literal-secret")})
+
+    with pytest.raises(ValueError, match="masked"):
+        _resolve_auth_template(request, {"X-Gateway-Key": True}, existing)

--- a/backend/tests/unit/onyx/server/features/mcp/test_template_header_substitution.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_template_header_substitution.py
@@ -1,6 +1,6 @@
-"""`_build_headers_from_template` is the single source of truth for
-rendering per-user API_TOKEN headers: it must apply both user-supplied
-substitutions and auto ones (e.g. `{user_email}`) in one pass."""
+"""MCP templates apply user and automatic substitutions in one pass."""
+
+import pytest
 
 from onyx.server.features.mcp.api import _build_headers_from_template
 from onyx.server.features.mcp.models import MCPAuthTemplate
@@ -46,15 +46,24 @@ class TestBuildHeadersFromTemplate:
         )
         assert headers == {"Authorization": "Bearer k"}
 
-    def test_empty_header_name_is_dropped(self) -> None:
-        # Empty header names must be filtered (otherwise HTTP layer breaks).
-        template = MCPAuthTemplate(
-            headers={"": "Bearer {api_key}", "Authorization": "Bearer {api_key}"},
-            required_fields=["api_key"],
-        )
-        headers = _build_headers_from_template(
-            template_data=template,
-            credentials={"api_key": "k"},
-            user_email="alice@example.com",
-        )
-        assert headers == {"Authorization": "Bearer k"}
+    def test_empty_header_name_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Invalid MCP header name"):
+            MCPAuthTemplate(
+                headers={
+                    "": "Bearer {api_key}",
+                    "Authorization": "Bearer {api_key}",
+                },
+            )
+
+    def test_denylisted_header_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="not allowed"):
+            MCPAuthTemplate(headers={"Host": "internal.example.com"})
+
+    def test_case_insensitive_duplicate_header_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Duplicate MCP header name"):
+            MCPAuthTemplate(
+                headers={
+                    "Authorization": "Bearer first",
+                    "authorization": "Bearer second",
+                }
+            )

--- a/web/src/app/craft/v1/apps/connectableApps.ts
+++ b/web/src/app/craft/v1/apps/connectableApps.ts
@@ -82,21 +82,16 @@ export function externalAppToConnectable(
 }
 
 export function mcpServerToConnectable(server: MCPServer): ConnectableApp {
-  // Pass-through OAuth authenticates via the user's Onyx login token at runtime,
-  // so there is nothing for the user to connect or disconnect. That says nothing
-  // about whether it works for them — a password-login user has no login OAuth
-  // token, and `craft_connected` reports that.
-  const passThrough = server.auth_type === MCPAuthenticationType.PT_OAUTH;
-  const perUser =
-    !passThrough &&
+  const credentialKeys = server.auth_template?.required_fields ?? [];
+  const requiresHeaderValues = credentialKeys.length > 0;
+  const perUserAuth =
     server.auth_performer === MCPAuthenticationPerformer.PER_USER &&
-    server.auth_type !== MCPAuthenticationType.NONE;
-  // The backend's craft-emission predicate, not "a config row exists" — the
-  // page must not claim connected for a server Craft drops from the session.
+    server.auth_type !== MCPAuthenticationType.NONE &&
+    server.auth_type !== MCPAuthenticationType.PT_OAUTH;
+  const userConnectable = perUserAuth || requiresHeaderValues;
   const authenticated = server.craft_connected ?? false;
-  const credentialKeys: string[] = server.auth_template?.required_fields?.length
-    ? server.auth_template.required_fields
-    : ["api_key"];
+  const startOAuth = async () =>
+    (await startMCPUserOAuth(server.id, CRAFT_APPS_PATH)).oauth_url;
   return {
     key: `mcp-${server.id}`,
     kind: "mcp",
@@ -106,17 +101,20 @@ export function mcpServerToConnectable(server: MCPServer): ConnectableApp {
     connectId: null,
     authenticated,
     logo: getActionIcon(server.server_url, server.name),
-    connectMode: !perUser
-      ? null
-      : server.auth_type === MCPAuthenticationType.API_TOKEN
-        ? "credentials"
-        : "oauth",
-    credentialKeys,
+    connectMode: requiresHeaderValues
+      ? "credentials"
+      : perUserAuth && server.auth_type === MCPAuthenticationType.OAUTH
+        ? "oauth"
+        : null,
+    credentialKeys: credentialKeys.length ? credentialKeys : ["api_key"],
     credentialValues: server.user_credentials ?? {},
-    startOAuth: async () =>
-      (await startMCPUserOAuth(server.id, CRAFT_APPS_PATH)).oauth_url,
-    saveCredentials: (values) =>
-      saveMCPUserCredentials(server.id, values, server.transport),
-    disconnect: perUser ? () => disconnectMCPServer(server.id) : null,
+    startOAuth,
+    saveCredentials: async (values) => {
+      await saveMCPUserCredentials(server.id, values, server.transport);
+      if (server.auth_type === MCPAuthenticationType.OAUTH) {
+        window.location.href = await startOAuth();
+      }
+    },
+    disconnect: userConnectable ? () => disconnectMCPServer(server.id) : null,
   };
 }

--- a/web/src/components/chat/MCPApiKeyModal.tsx
+++ b/web/src/components/chat/MCPApiKeyModal.tsx
@@ -19,12 +19,12 @@ interface MCPApiKeyModalProps {
   serverName: string;
   serverId: number;
   authTemplate?: MCPAuthTemplate;
-  onSubmit: (serverId: number, apiKey: string) => void;
+  onSubmit: (serverId: number, apiKey: string) => Promise<void> | void;
   onSubmitCredentials?: (
     serverId: number,
     credentials: Record<string, string>
-  ) => void;
-  onSuccess?: () => void;
+  ) => Promise<void> | void;
+  onSuccess?: () => Promise<void> | void;
   isAuthenticated?: boolean;
   existingCredentials?: Record<string, string>;
 }
@@ -85,7 +85,7 @@ export default function MCPApiKeyModal({
         }
         setCredentials({});
         if (onSuccess) {
-          onSuccess();
+          await onSuccess();
         }
         onClose();
       } catch (error) {
@@ -109,7 +109,7 @@ export default function MCPApiKeyModal({
         await onSubmit(serverId, apiKey);
         setApiKey("");
         if (onSuccess) {
-          onSuccess();
+          await onSuccess();
         }
         onClose();
       } catch (error) {

--- a/web/src/refresh-components/popovers/ActionsPopover/index.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/index.tsx
@@ -525,15 +525,15 @@ export default function ActionsPopover({
           }),
         });
 
-        if (response.ok) {
-          const { oauth_url } = await response.json();
-          window.location.href = oauth_url;
-        } else {
-          updateLoadingState(false);
+        if (!response.ok) {
+          throw new Error("Failed to start MCP OAuth");
         }
+        const { oauth_url } = await response.json();
+        window.location.href = oauth_url;
       } catch (error) {
         console.error("Error initiating OAuth:", error);
         updateLoadingState(false);
+        throw error;
       }
     }
   };
@@ -594,23 +594,33 @@ export default function ActionsPopover({
   const handleServerAuthentication = (server: MCPServer) => {
     const authType = server.auth_type;
     const performer = server.auth_performer;
+    const requiresHeaderValues =
+      (server.auth_template?.required_fields.length ?? 0) > 0;
 
+    if (!requiresHeaderValues && authType === MCPAuthenticationType.OAUTH) {
+      void handleMCPAuthenticate(server.id, MCPAuthenticationType.OAUTH).catch(
+        () => undefined
+      );
+      return;
+    }
     if (
-      authType === MCPAuthenticationType.NONE ||
-      performer === MCPAuthenticationPerformer.ADMIN
+      !requiresHeaderValues &&
+      (authType === MCPAuthenticationType.NONE ||
+        performer === MCPAuthenticationPerformer.ADMIN)
     ) {
       return;
     }
-
-    if (authType === MCPAuthenticationType.OAUTH) {
-      handleMCPAuthenticate(server.id, MCPAuthenticationType.OAUTH);
-    } else if (authType === MCPAuthenticationType.API_TOKEN) {
+    if (requiresHeaderValues || authType === MCPAuthenticationType.API_TOKEN) {
       setMcpApiKeyModal({
         isOpen: true,
         serverId: server.id,
         serverName: server.name,
         authTemplate: server.auth_template,
-        onSuccess: () => {
+        onSuccess: async () => {
+          if (authType === MCPAuthenticationType.OAUTH) {
+            await handleMCPAuthenticate(server.id, MCPAuthenticationType.OAUTH);
+            return;
+          }
           // Update the authentication state after successful credential submission
           setMcpServerData((prev) => ({
             ...prev,

--- a/web/src/sections/actions/PerUserAuthConfig.tsx
+++ b/web/src/sections/actions/PerUserAuthConfig.tsx
@@ -9,6 +9,7 @@ import { InputTypeIn } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
 import { Divider } from "@opal/components";
 import type { MCPAuthFormValues } from "@/sections/actions/modals/MCPAuthenticationModal";
+import { MCPAuthenticationType } from "@/lib/tools/interfaces";
 import { SvgUser } from "@opal/icons";
 
 interface PerUserAuthConfigProps {
@@ -33,9 +34,12 @@ export function PerUserAuthConfig({
     }))
   );
 
-  // Initialize auth template if not exists
+  // API-token setup keeps its existing bearer default.
   useEffect(() => {
-    if (!values.auth_template) {
+    if (
+      values.auth_type === MCPAuthenticationType.API_TOKEN &&
+      Object.keys(values.auth_template?.headers || {}).length === 0
+    ) {
       const initialHeaders = { Authorization: "Bearer {api_key}" };
       setFieldValue("auth_template", {
         headers: initialHeaders,
@@ -43,7 +47,7 @@ export function PerUserAuthConfig({
       });
       setHeadersDraft([{ key: "Authorization", value: "Bearer {api_key}" }]);
     }
-  }, [values.auth_template, setFieldValue]);
+  }, [values.auth_template, values.auth_type, setFieldValue]);
 
   // Update headers from KeyValue array
   const handleHeadersChange = (items: KeyValue[]) => {
@@ -100,6 +104,10 @@ export function PerUserAuthConfig({
   const requiredFields: string[] = values.auth_template?.required_fields?.length
     ? values.auth_template.required_fields
     : computeRequiredFieldsFromHeaders(values.auth_template?.headers || {});
+  const credentialFields =
+    mode === "shared"
+      ? requiredFields.filter((field) => field !== "api_key")
+      : requiredFields;
   const userCredentials = values.user_credentials || {};
 
   // Shared templates must render the org's single shared key, so at least one
@@ -161,8 +169,7 @@ export function PerUserAuthConfig({
         />
       </FormField>
 
-      {/* Only show user credentials section if there are required fields */}
-      {mode === "per-user" && requiredFields.length > 0 && (
+      {credentialFields.length > 0 && (
         <>
           <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
@@ -171,18 +178,21 @@ export function PerUserAuthConfig({
               <SvgUser className="w-4 h-4 stroke-text-04 mt-0.5" />
               <div className="flex flex-col gap-1">
                 <Text text04 secondaryAction as="p">
-                  Only for your own account
+                  {mode === "per-user"
+                    ? "Only for your own account"
+                    : "Shared organization values"}
                 </Text>
                 <Text text03 secondaryBody as="p">
-                  The following credentials will not be shared with your
-                  organization.
+                  {mode === "per-user"
+                    ? "The following credentials will not be shared with your organization."
+                    : "These values are used for every user in your organization."}
                 </Text>
               </div>
             </div>
 
             {/* User Credentials Fields */}
             <div className="flex flex-col gap-3">
-              {requiredFields.map((field: string) => {
+              {credentialFields.map((field: string) => {
                 const isSecretField =
                   field.toLowerCase().includes("key") ||
                   field.toLowerCase().includes("token") ||

--- a/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
@@ -214,6 +214,13 @@ export default function MCPAuthenticationModal({
       };
     }
 
+    // Only shared API-token servers return their header substitutions in
+    // `admin_credentials`. For every other auth type that field carries OAuth
+    // client credentials, which must not be replayed as per-user substitutions.
+    const sharedApiToken =
+      fullServer.auth_type === MCPAuthenticationType.API_TOKEN &&
+      fullServer.auth_performer === MCPAuthenticationPerformer.ADMIN;
+
     return {
       transport: fullServer.server_url
         ? getTransportFromUrl(fullServer.server_url)
@@ -249,7 +256,9 @@ export default function MCPAuthenticationModal({
       // User Credentials (substitutions)
       user_credentials:
         (fullServer.user_credentials as Record<string, string>) ||
-        (fullServer.admin_credentials as Record<string, string>) ||
+        (sharedApiToken
+          ? (fullServer.admin_credentials as Record<string, string>)
+          : undefined) ||
         {},
     };
   }, [fullServer, mcpServer?.server_url]);

--- a/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
@@ -200,8 +200,8 @@ export default function MCPAuthenticationModal({
         auth_performer: MCPAuthenticationPerformer.PER_USER,
         api_token: "",
         auth_template: {
-          headers: { Authorization: "Bearer {api_key}" },
-          required_fields: ["api_key"],
+          headers: {},
+          required_fields: [],
         },
         user_credentials: {},
         oauth_client_id: "",
@@ -243,12 +243,14 @@ export default function MCPAuthenticationModal({
         : "",
       // Auth Template
       auth_template: (fullServer.auth_template as MCPAuthTemplate) || {
-        headers: { Authorization: "Bearer {api_key}" },
-        required_fields: ["api_key"],
+        headers: {},
+        required_fields: [],
       },
       // User Credentials (substitutions)
       user_credentials:
-        (fullServer.user_credentials as Record<string, string>) || {},
+        (fullServer.user_credentials as Record<string, string>) ||
+        (fullServer.admin_credentials as Record<string, string>) ||
+        {},
     };
   }, [fullServer, mcpServer?.server_url]);
 
@@ -277,10 +279,7 @@ export default function MCPAuthenticationModal({
   const computeAdminCredentialsChangedFlags = (
     values: MCPAuthFormValues
   ): Record<string, boolean> => {
-    if (
-      values.auth_type !== MCPAuthenticationType.API_TOKEN ||
-      values.auth_performer !== MCPAuthenticationPerformer.PER_USER
-    ) {
+    if (!values.auth_template.required_fields.length) {
       return {};
     }
     const current = values.user_credentials || {};
@@ -292,13 +291,30 @@ export default function MCPAuthenticationModal({
     return flags;
   };
 
+  const computeAuthTemplateChangedFlags = (
+    values: MCPAuthFormValues
+  ): Record<string, boolean> => {
+    const initialHeaders = initialValues.auth_template.headers;
+    return Object.fromEntries(
+      Object.entries(values.auth_template.headers).map(([name, value]) => [
+        name,
+        value !== initialHeaders[name],
+      ])
+    );
+  };
+
   const constructServerData = (values: MCPAuthFormValues) => {
     if (!mcpServer) return null;
     const authType = values.auth_type;
     const oauthChangedFlags = computeOAuthChangedFlags(values);
-    const isPerUserApiToken =
-      values.auth_performer === MCPAuthenticationPerformer.PER_USER &&
-      authType === MCPAuthenticationType.API_TOKEN;
+    const hasUserHeaderValues = values.auth_template.required_fields.some(
+      (field) =>
+        !(
+          values.auth_performer === MCPAuthenticationPerformer.ADMIN &&
+          authType === MCPAuthenticationType.API_TOKEN &&
+          field === "api_key"
+        )
+    );
     const isAdminApiToken =
       values.auth_performer === MCPAuthenticationPerformer.ADMIN &&
       authType === MCPAuthenticationType.API_TOKEN;
@@ -345,14 +361,16 @@ export default function MCPAuthenticationModal({
       api_token_changed: isAdminApiToken
         ? values.api_token !== initialValues.api_token
         : false,
-      auth_template:
-        authType === MCPAuthenticationType.API_TOKEN
-          ? values.auth_template
-          : undefined,
-      admin_credentials: isPerUserApiToken
-        ? values.user_credentials || {}
+      auth_template: values.auth_template,
+      auth_template_headers_changed: computeAuthTemplateChangedFlags(values),
+      admin_credentials: hasUserHeaderValues
+        ? Object.fromEntries(
+            Object.entries(values.user_credentials || {}).filter(
+              ([field]) => !isAdminApiToken || field !== "api_key"
+            )
+          )
         : undefined,
-      admin_credentials_changed: isPerUserApiToken
+      admin_credentials_changed: hasUserHeaderValues
         ? computeAdminCredentialsChangedFlags(values)
         : undefined,
       oauth_client_id:
@@ -933,6 +951,12 @@ export default function MCPAuthenticationModal({
                         </Tabs.Content>
                       </Tabs>
                     </div>
+                  )}
+                  {values.auth_type !== MCPAuthenticationType.API_TOKEN && (
+                    <PerUserAuthConfig
+                      values={values}
+                      setFieldValue={setFieldValue}
+                    />
                   )}
                   {values.auth_type === MCPAuthenticationType.NONE && (
                     <MessageCard


### PR DESCRIPTION
## Description

Allow custom connection headers for all MCP server types in the backend. This unifies the way headers (and per-user substitution) are handled across all server types. In the future there will be no need for the admin to distinguish between "per-user" vs "admin" API key servers; it will be the difference between hard-coding a single API key for all users vs having a placeholder in the headers. This PR makes supporting this on the backend possible, but to keep the intent clean (and the diff smaller) for now we're just doing header handling and resolution.

## How Has This Been Tested?

Added tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds arbitrary custom connection headers to all MCP server types with a unified template-and-merge flow that supports per-user placeholders. OAuth refresh now updates only Authorization and preserves custom headers; the UI shows placeholder names to basic users without exposing admin templates.

- **New Features**
  - Unified header templates (`MCPAuthTemplate`) and case-insensitive merging (`merge_mcp_headers`) across API Token, OAuth, and PT-OAuth, with denylisted headers filtered.
  - Single-pass substitution for user and auto fields; admins can fetch full templates, basic users see only required placeholder names.
  - UI updates: per-user API Token defaults to Bearer; connect status uses `required_fields`; modals submit asynchronously; OAuth start throws on failure; per-user config only pre-fills substitutions for shared API-token servers.

- **Bug Fixes**
  - OAuth refresh persists custom headers and only replaces `Authorization`; merge applied in resolver and token storage.

<sup>Written for commit d7e40044e24d6f627c7a5223d0c1590df35a585e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

