### PR TITLE
fix(web): gate SSO provider config to single-tenant deployments

### DIFF
--- a/backend/onyx/server/manage/sso/api.py
+++ b/backend/onyx/server/manage/sso/api.py
@@ -30,8 +30,20 @@ from onyx.server.security.store import (
 )
 from onyx.utils.encryption import reject_masked_credentials, restore_masked_credentials
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
+from shared_configs.configs import MULTI_TENANT
 
-admin_router = APIRouter(prefix="/admin/sso")
+
+def _reject_if_multi_tenant() -> None:
+    if MULTI_TENANT:
+        raise OnyxError(
+            OnyxErrorCode.SINGLE_TENANT_ONLY,
+            "SSO provider configuration is not available on this deployment.",
+        )
+
+
+admin_router = APIRouter(
+    prefix="/admin/sso", dependencies=[Depends(_reject_if_multi_tenant)]
+)
 
 
 def _require_business_tier_for_additional_enabled_provider(

--- a/backend/tests/external_dependency_unit/auth/test_sso_admin_api.py
+++ b/backend/tests/external_dependency_unit/auth/test_sso_admin_api.py
@@ -1,5 +1,6 @@
-"""Guard SSO admin CRUD: secret masking, masked-placeholder round-trips,
-partial-config merges, and duplicate or missing provider handling.
+"""Guard the SSO admin API contract: secrets never persist masked, config
+merges stay partial, conflicting or missing providers are reported, and the
+routes are single-tenant only.
 
 The API must never persist masked secrets as real config values.
 """
@@ -543,3 +544,19 @@ def test_second_enabled_provider_requires_business_tier(
             gated_reenable.status_code
             == OnyxErrorCode.FEATURE_NOT_AVAILABLE.status_code
         )
+
+
+@patch("onyx.server.manage.sso.api.MULTI_TENANT", True)
+def test_multi_tenant_deployments_are_rejected(client: TestClient) -> None:
+    """The gate sits on the router, so no handler below it is reachable."""
+    for response in (
+        client.get("/admin/sso/provider"),
+        client.post(
+            "/admin/sso/provider",
+            json=_build_oidc_request(_new_provider_name(), "secret"),
+        ),
+        client.patch("/admin/sso/provider/1", json={"display_name": "Blocked"}),
+        client.post("/admin/sso/provider/1/enabled", json={"enabled": True}),
+    ):
+        assert response.status_code == OnyxErrorCode.SINGLE_TENANT_ONLY.status_code
+        assert response.json()["error_code"] == OnyxErrorCode.SINGLE_TENANT_ONLY.code

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -164,7 +164,10 @@ function buildItems(
   if (!isCurator) {
     addGated(SECTIONS.ORGANIZATION, ADMIN_ROUTES.THEME, Tier.BUSINESS);
     add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.SECURITY_HARDENING);
-    add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.SSO_PROVIDERS);
+    // SSO provider config is not supported on multi-tenant cloud.
+    if (!enableCloud) {
+      add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.SSO_PROVIDERS);
+    }
     if (hasSubscription) {
       add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.BILLING);
     }


### PR DESCRIPTION
## Description

**Bug:** The SSO Providers admin tab is visible and writable on Onyx Cloud, but nothing configured there can ever work.

**Why:** `_fetch_sso_provider_options` in `get_state.py` returns `[]` when `MULTI_TENANT`, because `/auth/type` runs before any tenant context exists. A cloud admin can create a provider, enable it, and copy a redirect URI, and no login button ever renders. The sidebar entry had no cloud gate and the `/admin/sso` routes had no `MULTI_TENANT` check.

**Fix:**
- `AdminSidebar.tsx`: wrap the entry in `if (!enableCloud)`, matching `TRACING` and `EXPORT_LOGS`
- `sso/api.py`: `_reject_if_multi_tenant` as a router dependency, mirroring `tracing/api.py`
- One test covering all four routes

Self-hosted behavior is unchanged. Existing provider rows on cloud tenants are left alone; they were already inert.

Note: the sidebar keys on build-time `NEXT_PUBLIC_CLOUD_ENABLED` while the backend keys on runtime `MULTI_TENANT`, same as both sibling gates. The backend dependency is the real enforcement.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
