### PR TITLE
chore(hotfix): cherry-pick 8 commits to release v4.5

### DIFF
--- a/backend/onyx/chat/citation_processor.py
+++ b/backend/onyx/chat/citation_processor.py
@@ -317,8 +317,10 @@ class DynamicCitationProcessor:
                 if len(parts) > 1 and len(parts[1]) > 0:
                     piece_that_comes_after = parts[1][0]
                     if piece_that_comes_after == "\n" and in_code_block(self.llm_out):
-                        self.curr_segment = self.curr_segment.replace(
-                            "```", "```plaintext"
+                        # Label only this first bare fence; other fences in the
+                        # buffered segment must stay untouched.
+                        self.curr_segment = (
+                            parts[0] + "```plaintext" + "```".join(parts[1:])
                         )
 
         # Look for citations in current segment

--- a/backend/onyx/connectors/bookstack/connector.py
+++ b/backend/onyx/connectors/bookstack/connector.py
@@ -63,15 +63,20 @@ class BookstackConnector(LoadConnector, PollConnector):
             "sort": "+id",
         }
 
+        # BookStack interprets a date-only "updated_at" filter (YYYY-MM-DD) as
+        # "<= YYYY-MM-DD 00:00:00", which silently excludes documents updated
+        # later on the boundary day. Since every poll uses end=now, this drops
+        # anything edited "today" until the next calendar day. Full ISO-8601
+        # datetime granularity makes the gte/lte bounds inclusive as intended.
         if start:
             params["filter[updated_at:gte]"] = datetime.fromtimestamp(
                 start, tz=timezone.utc
-            ).strftime("%Y-%m-%d")
+            ).strftime("%Y-%m-%dT%H:%M:%S")
 
         if end:
             params["filter[updated_at:lte]"] = datetime.fromtimestamp(
                 end, tz=timezone.utc
-            ).strftime("%Y-%m-%d")
+            ).strftime("%Y-%m-%dT%H:%M:%S")
 
         batch = bookstack_client.get(endpoint, params=params).get("data", [])
         doc_batch: list[Document | HierarchyNode] = [

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -217,6 +217,15 @@ def _is_shared_drive_root(folder: GoogleDriveFileType) -> bool:
     return bool(drive_id and folder_id == drive_id)
 
 
+def _resume_start(
+    completed_until: SecondsSinceUnixEpoch,
+    start: SecondsSinceUnixEpoch | None,
+) -> SecondsSinceUnixEpoch:
+    """Resume from the checkpointed frontier, but never before the configured
+    range start (a corrupted frontier must not widen the requested time range)."""
+    return max(completed_until, start) if start is not None else completed_until
+
+
 def _public_access() -> ExternalAccess:
     return ExternalAccess(
         external_user_emails=set(),
@@ -946,7 +955,11 @@ class GoogleDriveConnector(
                         field_type=field_type,
                         include_shared_with_me=self.include_files_shared_with_me,
                         max_num_pages=MY_DRIVE_PAGES_PER_CHECKPOINT,
-                        start=curr_stage.completed_until if resuming else start,
+                        start=(
+                            _resume_start(curr_stage.completed_until, start)
+                            if resuming
+                            else start
+                        ),
                         end=end,
                         cache_folders=not bool(curr_stage.completed_until),
                         page_token=curr_stage.next_page_token,
@@ -995,7 +1008,7 @@ class GoogleDriveConnector(
             if resuming:
                 drive_id = curr_stage.current_folder_or_drive_id
                 if drive_id:
-                    resume_start = curr_stage.completed_until
+                    resume_start = _resume_start(curr_stage.completed_until, start)
                     for file_or_token in _yield_from_drive(drive_id, resume_start):
                         if isinstance(file_or_token, str):
                             checkpoint.completion_map[
@@ -1061,7 +1074,7 @@ class GoogleDriveConnector(
                         user_email,
                     )
                 else:
-                    resume_start = curr_stage.completed_until
+                    resume_start = _resume_start(curr_stage.completed_until, start)
                     yield from _yield_from_folder_crawl(folder_id, resume_start)
                 last_processed_folder = folder_id
 
@@ -1420,9 +1433,10 @@ class GoogleDriveConnector(
             ].current_folder_or_drive_id
             if drive_id is None:
                 raise ValueError("drive id not set in checkpoint")
-            resume_start = checkpoint.completion_map[
-                self.primary_admin_email
-            ].completed_until
+            resume_start = _resume_start(
+                checkpoint.completion_map[self.primary_admin_email].completed_until,
+                start,
+            )
             for file_or_token in _yield_from_drive(drive_id, resume_start):
                 if isinstance(file_or_token, str):
                     checkpoint.completion_map[
@@ -1500,9 +1514,10 @@ class GoogleDriveConnector(
                 self.primary_admin_email
             ].current_folder_or_drive_id
         ):
-            resume_start = checkpoint.completion_map[
-                self.primary_admin_email
-            ].completed_until
+            resume_start = _resume_start(
+                checkpoint.completion_map[self.primary_admin_email].completed_until,
+                start,
+            )
             yield from _yield_from_folder_crawl(
                 folder_id,  # ty: ignore[possibly-unresolved-reference]
                 resume_start,
@@ -1557,6 +1572,16 @@ class GoogleDriveConnector(
                         file.completion_stage,
                         file.user_email,
                     )
+
+            # Never move the frontier backward within the same stage and
+            # drive/folder: a regression changes the listing query, invalidates
+            # the saved page token, and restarts retrieval from the regressed
+            # timestamp — which can loop forever.
+            if (
+                file.completion_stage == completion.stage
+                and file.parent_id == completion.current_folder_or_drive_id
+            ):
+                completed_until = max(completed_until, completion.completed_until)
 
             completion.update(
                 stage=file.completion_stage,
@@ -1614,7 +1639,7 @@ class GoogleDriveConnector(
             all_files_start = start
             # if resuming from a checkpoint
             if completion.stage == DriveRetrievalStage.OAUTH_FILES:
-                all_files_start = completion.completed_until
+                all_files_start = _resume_start(completion.completed_until, start)
 
             for file_or_token in self._oauth_retrieval_all_files(
                 field_type=field_type,

--- a/backend/onyx/connectors/google_drive/file_retrieval.py
+++ b/backend/onyx/connectors/google_drive/file_retrieval.py
@@ -368,6 +368,13 @@ def _resolve_file_or_shortcut(
     logger.debug(
         "Resolved Drive shortcut %s to target %s", file.get("id"), target.get("id")
     )
+    # Use the shortcut's own modifiedTime: listings are filtered and ordered by
+    # it, so this preserves the invariant that a retrieved item's modifiedTime
+    # lies within the requested time range — the target's can sit far outside
+    # it, which would corrupt the checkpoint frontier and re-poll windows.
+    listing_modified_time = file.get(GoogleFields.MODIFIED_TIME.value)
+    if listing_modified_time is not None:
+        target[GoogleFields.MODIFIED_TIME.value] = listing_modified_time
     return target
 
 

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1963,10 +1963,10 @@ class SharepointConnector(
         params: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         """Make an authenticated GET request to the Graph API with retry."""
-        access_token = self._get_graph_access_token()
-        headers = {"Authorization": f"Bearer {access_token}"}
-
         for attempt in range(GRAPH_API_MAX_RETRIES + 1):
+            # Tokens can expire during long traversals — re-acquire per attempt.
+            access_token = self._get_graph_access_token()
+            headers = {"Authorization": f"Bearer {access_token}"}
             try:
                 response = requests.get(
                     url,
@@ -1976,37 +1976,31 @@ class SharepointConnector(
                 )
                 if response.status_code in GRAPH_API_RETRYABLE_STATUSES:
                     if attempt < GRAPH_API_MAX_RETRIES:
-                        parsed_retry_after = parse_retry_after_seconds(
-                            response.headers.get("Retry-After")
+                        wait = _backoff_seconds(
+                            attempt, response.headers.get("Retry-After")
                         )
-                        retry_after = (
-                            parsed_retry_after
-                            if parsed_retry_after is not None
-                            else float(2**attempt)
-                        )
-                        wait = min(retry_after, 60)
                         logger.warning(
-                            "Graph API %s on attempt %s, retrying in %ss: %s",
+                            "Graph API %s on attempt %s, retrying in %.1fs: %s",
                             response.status_code,
                             attempt + 1,
                             wait,
                             url,
                         )
                         time.sleep(wait)
-                        # Re-acquire token in case it expired during a long traversal
-                        access_token = self._get_graph_access_token()
-                        headers = {"Authorization": f"Bearer {access_token}"}
                         continue
                 _log_and_raise_for_status(response)
+                # ValueError covers the empty/non-JSON 2xx bodies Graph
+                # intermittently returns under load.
                 return response.json()
-            except (requests.ConnectionError, requests.Timeout):
+            except TRANSIENT_TRANSPORT_EXCEPTIONS + (ValueError,) as e:
                 if attempt < GRAPH_API_MAX_RETRIES:
-                    wait = min(2**attempt, 60)
+                    wait = _backoff_seconds(attempt, retry_after=None)
                     logger.warning(
-                        "Graph API connection error on attempt %s, retrying in %ss: %s",
+                        "Graph API transient error on attempt %s, retrying in %.1fs: %s (%r)",
                         attempt + 1,
                         wait,
                         url,
+                        e,
                     )
                     time.sleep(wait)
                     continue

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -678,7 +678,7 @@ def _load_readonly_workbook(file: IO[Any], file_name: str) -> openpyxl.Workbook 
     / known-openpyxl-bug cases the xlsx indexers treat as skip-and-continue rather
     than a hard failure."""
     try:
-        return openpyxl.load_workbook(file, read_only=True)
+        return openpyxl.load_workbook(file, read_only=True, data_only=True)
     except BadZipFile as e:
         error_str = f"Failed to extract text from {file_name or 'xlsx file'}: {e}"
         if file_name.startswith("~"):

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -886,7 +886,9 @@ class LitellmLLM(LLM):
                         api_version=api_version,
                         custom_llm_provider=self._custom_llm_provider or None,
                         messages=messages,
-                        tools=tools,
+                        # None (omitted) rather than [] — some OpenAI-compatible
+                        # servers reject requests with an empty tools array.
+                        tools=tools or None,
                         stream=stream,
                         timeout=timeout_override or self._timeout,
                         max_tokens=max_tokens,

--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -103,15 +103,30 @@ def _pkce_enabled(config: dict[str, Any]) -> bool:
     return bool(config.get("pkce_enabled")) or OIDC_PKCE_ENABLED
 
 
+def _drop_unadvertised_offline_access(client: BaseOAuth2[Any]) -> None:
+    """Some IdPs (e.g. Amazon Cognito) fail the entire authorize request on
+    scopes they don't support, so the auto-added offline_access scope only
+    survives when the discovery doc advertises it. A discovery doc without
+    scopes_supported keeps the scope, since support can't be ruled out."""
+    discovery = getattr(client, "openid_configuration", None) or {}
+    supported = discovery.get("scopes_supported")
+    if supported is None or "offline_access" in supported:
+        return
+    client.base_scopes = [
+        scope for scope in (client.base_scopes or []) if scope != "offline_access"
+    ]
+
+
 def _build_client(provider: SSOProvider, config: dict[str, Any]) -> BaseOAuth2[Any]:
     if provider.provider_type is SSOProviderType.OIDC:
         # Scope overrides let providers request extra API scopes (e.g. MS Graph
         # User.Read for claims capture): the row's scopes win, then the env
         # override while it exists. offline_access secures refresh tokens.
         scopes = list(config.get("scopes") or OIDC_SCOPE_OVERRIDE or BASE_SCOPES)
-        if "offline_access" not in scopes:
+        offline_access_auto_added = "offline_access" not in scopes
+        if offline_access_auto_added:
             scopes.append("offline_access")
-        return VerifiedEmailOpenID(
+        client = VerifiedEmailOpenID(
             config["client_id"],
             config["client_secret"],
             config["openid_config_url"],
@@ -119,6 +134,10 @@ def _build_client(provider: SSOProvider, config: dict[str, Any]) -> BaseOAuth2[A
             base_scopes=scopes,
             require_verified_email=config.get("require_verified_email", False),
         )
+        # Explicitly configured offline_access is always respected as-is.
+        if offline_access_auto_added:
+            _drop_unadvertised_offline_access(client)
+        return client
     if provider.provider_type is SSOProviderType.GOOGLE_OAUTH:
         return GoogleOAuth2(
             config["client_id"],

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -70,7 +70,7 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
 from onyx.llm.constants import LlmProviderNames
-from onyx.llm.factory import get_default_llm, get_llm_for_persona, get_llm_token_counter
+from onyx.llm.factory import get_llm_for_persona, get_llm_token_counter
 from onyx.llm.models import (
     USER_SELECTABLE_REASONING_EFFORTS,
     ReasoningEffort,
@@ -482,18 +482,29 @@ def rename_chat_session(
     # send-message. Manual renames return above and stay free.
     check_token_rate_limits(user)
 
-    llm = get_default_llm(
-        additional_headers=extract_headers(
-            request.headers, LITELLM_PASS_THROUGH_HEADERS
-        )
-    )
-
     # Read-phase short session: usage check + history fetch. Closed before the
     # LLM call so the underlying pool connection is fully released for the
     # 2-10s generation window. (db_session.close() alone is insufficient in
     # multi-tenant mode where the session is bound to an explicit Connection
     # held by get_session_with_tenant's outer with-block.)
     with get_session_with_current_tenant() as db_session:
+        chat_session = get_chat_session_by_id(
+            chat_session_id=chat_session_id,
+            user_id=user_id,
+            db_session=db_session,
+            eager_load_persona=True,
+        )
+        # Name with the model the session actually uses (session override →
+        # persona default → global default) — the global default may be a
+        # provider this user's session deliberately avoids.
+        llm = get_llm_for_persona(
+            persona=chat_session.persona,
+            user=user,
+            llm_override=chat_session.llm_override,
+            additional_headers=extract_headers(
+                request.headers, LITELLM_PASS_THROUGH_HEADERS
+            ),
+        )
         check_llm_cost_limit_for_provider(
             db_session=db_session,
             tenant_id=get_current_tenant_id(),

--- a/backend/tests/unit/onyx/chat/test_citation_processor.py
+++ b/backend/tests/unit/onyx/chat/test_citation_processor.py
@@ -806,6 +806,25 @@ def test_code_block_plaintext_added(
     assert "```plaintext" in output
 
 
+def test_bare_fence_labeling_does_not_corrupt_other_fences(
+    mock_search_docs: CitationMapping,  # noqa: ARG001
+) -> None:
+    """Labeling a bare fence must leave the segment's other fences untouched
+    (the first token buffers three fences at labeling time)."""
+    processor = DynamicCitationProcessor()
+
+    tokens: list[str | None] = [
+        "A:\n```\nx\n```\nB:\n```bash",
+        "\necho hi\n```\nDone.\n",
+    ]
+    output, _ = process_tokens(processor, tokens)
+
+    assert output.count("```plaintext") == 1
+    assert "x\n```\nB:" in output
+    assert "```plaintextbash" not in output
+    assert "```bash" in output
+
+
 def test_citation_outside_code_block_processed(
     mock_search_docs: CitationMapping,
 ) -> None:

--- a/backend/tests/unit/onyx/connectors/google_drive/test_drive_checkpoint_frontier.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_drive_checkpoint_frontier.py
@@ -1,0 +1,153 @@
+"""Checkpoint frontier (completed_until) semantics for Google Drive retrieval.
+
+The retrieval listing is ordered by modifiedTime and resumes from
+completed_until, so the frontier must never move backward within a stage +
+drive/folder. A regression changes the listing query, invalidates the saved
+page token, and restarts retrieval from the regressed timestamp — looping
+forever if the same file causes the same regression on every pass (as happened
+when shortcut resolution replaced a file's modifiedTime with its target's).
+"""
+
+from collections.abc import Iterator
+from datetime import datetime
+from typing import Any
+
+from onyx.connectors.google_drive.connector import (
+    GoogleDriveConnector,
+    _resume_start,
+)
+from onyx.connectors.google_drive.file_retrieval import DriveFileFieldType
+from onyx.connectors.google_drive.models import (
+    DriveRetrievalStage,
+    GoogleDriveCheckpoint,
+    RetrievedDriveFile,
+    StageCompletion,
+)
+from onyx.utils.threadpool_concurrency import ThreadSafeDict
+
+_USER = "user@example.com"
+
+
+def _ts(iso: str) -> float:
+    return datetime.fromisoformat(iso).timestamp()
+
+
+def _file(
+    file_id: str,
+    modified_time: str,
+    parent_id: str | None = None,
+    stage: DriveRetrievalStage = DriveRetrievalStage.MY_DRIVE_FILES,
+) -> RetrievedDriveFile:
+    drive_file: dict[str, Any] = {
+        "id": file_id,
+        "name": file_id,
+        "modifiedTime": modified_time,
+        "webViewLink": f"https://drive.google.com/file/d/{file_id}",
+    }
+    return RetrievedDriveFile(
+        completion_stage=stage,
+        drive_file=drive_file,
+        user_email=_USER,
+        parent_id=parent_id,
+    )
+
+
+def _checkpoint(
+    stage: DriveRetrievalStage = DriveRetrievalStage.MY_DRIVE_FILES,
+    current_folder_or_drive_id: str | None = None,
+) -> GoogleDriveCheckpoint:
+    return GoogleDriveCheckpoint(
+        has_more=True,
+        retrieved_folder_and_drive_ids=set(),
+        completion_stage=stage,
+        completion_map=ThreadSafeDict(
+            {
+                _USER: StageCompletion(
+                    stage=stage,
+                    completed_until=0,
+                    current_folder_or_drive_id=current_folder_or_drive_id,
+                )
+            }
+        ),
+    )
+
+
+def _funnel(
+    checkpoint: GoogleDriveCheckpoint, files: list[RetrievedDriveFile]
+) -> Iterator[RetrievedDriveFile]:
+    connector = GoogleDriveConnector(include_my_drives=True)
+
+    def retrieval_method(
+        field_type: DriveFileFieldType,  # noqa: ARG001
+        checkpoint: GoogleDriveCheckpoint,  # noqa: ARG001
+        start: float | None = None,  # noqa: ARG001
+        end: float | None = None,  # noqa: ARG001
+    ) -> Iterator[RetrievedDriveFile]:
+        yield from files
+
+    return connector._checkpointed_retrieval(
+        retrieval_method=retrieval_method,
+        field_type=DriveFileFieldType.STANDARD,
+        checkpoint=checkpoint,
+        start=None,
+        end=None,
+    )
+
+
+def test_out_of_order_mtime_never_regresses_frontier() -> None:
+    checkpoint = _checkpoint()
+    completion = checkpoint.completion_map[_USER]
+    gen = _funnel(
+        checkpoint,
+        [
+            _file("f1", "2024-06-01T00:00:00Z"),
+            _file("f2", "2024-01-15T00:00:00Z"),  # unexpected out-of-order timestamp
+            _file("f3", "2024-06-03T00:00:00Z"),
+        ],
+    )
+
+    next(gen)
+    assert completion.completed_until == _ts("2024-06-01T00:00:00Z")
+    next(gen)
+    assert completion.completed_until == _ts("2024-06-01T00:00:00Z")
+    next(gen)
+    assert completion.completed_until == _ts("2024-06-03T00:00:00Z")
+
+
+def test_frontier_resets_when_drive_changes() -> None:
+    checkpoint = _checkpoint(
+        stage=DriveRetrievalStage.SHARED_DRIVE_FILES,
+        current_folder_or_drive_id="drive_1",
+    )
+    completion = checkpoint.completion_map[_USER]
+    gen = _funnel(
+        checkpoint,
+        [
+            _file(
+                "f1",
+                "2024-06-01T00:00:00Z",
+                parent_id="drive_1",
+                stage=DriveRetrievalStage.SHARED_DRIVE_FILES,
+            ),
+            # next drive starts over at an earlier timestamp; this is a
+            # legitimate reset, not a regression
+            _file(
+                "f2",
+                "2024-02-01T00:00:00Z",
+                parent_id="drive_2",
+                stage=DriveRetrievalStage.SHARED_DRIVE_FILES,
+            ),
+        ],
+    )
+
+    next(gen)
+    assert completion.completed_until == _ts("2024-06-01T00:00:00Z")
+    next(gen)
+    assert completion.completed_until == _ts("2024-02-01T00:00:00Z")
+    assert completion.current_folder_or_drive_id == "drive_2"
+
+
+def test_resume_start_clamps_to_range_start() -> None:
+    assert _resume_start(100.0, 200.0) == 200.0
+    assert _resume_start(300.0, 200.0) == 300.0
+    assert _resume_start(300.0, None) == 300.0

--- a/backend/tests/unit/onyx/connectors/google_drive/test_drive_shortcut_following.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_drive_shortcut_following.py
@@ -148,6 +148,40 @@ def test_shortcut_to_file_yields_target_with_true_parent() -> None:
     assert len(service.files_resource.get_calls) == 1
 
 
+def test_shortcut_resolution_uses_shortcut_modified_time() -> None:
+    target = _target_file("target_file", "true_parent")
+    target["modifiedTime"] = "2024-01-15T00:00:00Z"
+    service = _FakeDriveService(
+        {
+            "shortcut_file": _shortcut("shortcut_file", "target_file", _PDF_MIME_TYPE),
+            "target_file": target,
+        }
+    )
+
+    def _fake_paginated_retrieval(**_kwargs: object) -> Iterator[dict[str, Any]]:
+        shortcut = _shortcut("shortcut_file", "target_file", _PDF_MIME_TYPE)
+        shortcut["modifiedTime"] = "2026-06-02T00:00:00Z"
+        yield shortcut
+
+    with patch(
+        f"{_FILE_RETRIEVAL_MODULE}.execute_paginated_retrieval",
+        side_effect=_fake_paginated_retrieval,
+    ):
+        files = list(
+            _get_files_in_parent(
+                service=cast(Resource, service),
+                parent_id="shortcut_parent",
+                field_type=DriveFileFieldType.STANDARD,
+            )
+        )
+
+    assert len(files) == 1
+    # the retrieved item keeps the shortcut's modifiedTime — the value the
+    # listing was filtered/ordered by — so it stays within the requested range
+    assert files[0]["modifiedTime"] == "2026-06-02T00:00:00Z"
+    assert files[0]["id"] == "target_file"
+
+
 def test_shortcut_to_resource_key_file_uses_header() -> None:
     target = _target_file("target_file", "true_parent")
     service = _FakeDriveService(

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_graph_api_get_json_retry.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_graph_api_get_json_retry.py
@@ -1,0 +1,101 @@
+"""Unit tests for SharepointConnector._graph_api_get_json retry behavior.
+
+Covers the empty/non-JSON 2xx body case: Microsoft Graph intermittently returns
+a body-less response under load (gateway-shed throttling, backend list-view
+timeouts on large libraries, mid-response connection drops). The bare
+response.json() used to raise an unretried JSONDecodeError that aborted indexing
+of large (>2K file) libraries; it must now be retried like any transient error.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+import requests
+from requests import Response
+
+from onyx.connectors.sharepoint import connector as sp_connector
+from onyx.connectors.sharepoint.connector import (
+    GRAPH_API_MAX_RETRIES,
+    SharepointConnector,
+)
+
+SITE_URL = "https://tenant.sharepoint.com/sites/Big"
+PAGE_URL = "https://graph.microsoft.com/v1.0/drives/abc/root/children"
+
+
+def _response(
+    status: int = 200, body: Any = None, raw: bytes | None = None
+) -> Response:
+    """Build a fake requests.Response. body=None + raw=None => empty body."""
+    resp = Response()
+    resp.status_code = status
+    if raw is not None:
+        resp._content = raw
+    elif body is not None:
+        resp._content = json.dumps(body).encode()
+    else:
+        resp._content = b""  # empty 2xx body -> JSONDecodeError on .json()
+    resp.headers["Content-Type"] = "application/json"
+    return resp
+
+
+def _connector(monkeypatch: pytest.MonkeyPatch) -> SharepointConnector:
+    connector = SharepointConnector(sites=[SITE_URL])
+    connector.graph_api_base = "https://graph.microsoft.com/v1.0"
+    # Avoid real MSAL token acquisition.
+    monkeypatch.setattr(connector, "_get_graph_access_token", lambda: "fake-token")
+    # Never actually sleep between retries.
+    monkeypatch.setattr(sp_connector.time, "sleep", lambda *_a, **_k: None)
+    return connector
+
+
+def test_retries_empty_body_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty 2xx body is retried; the next good page is returned."""
+    connector = _connector(monkeypatch)
+    payload = {"value": [{"id": "1", "name": "f.docx"}]}
+    responses = iter([_response(200, body=None), _response(200, body=payload)])
+    monkeypatch.setattr(sp_connector.requests, "get", lambda *_a, **_k: next(responses))
+
+    result = connector._graph_api_get_json(PAGE_URL, {"$top": "200"})
+
+    assert result == payload
+
+
+def test_raises_after_exhausting_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A persistently empty body re-raises JSONDecodeError after all retries."""
+    connector = _connector(monkeypatch)
+    calls = {"n": 0}
+
+    def _always_empty(*_a: Any, **_k: Any) -> Response:
+        calls["n"] += 1
+        return _response(200, body=None)
+
+    monkeypatch.setattr(sp_connector.requests, "get", _always_empty)
+
+    with pytest.raises(requests.exceptions.JSONDecodeError):
+        connector._graph_api_get_json(PAGE_URL)
+
+    assert calls["n"] == GRAPH_API_MAX_RETRIES + 1
+
+
+def test_retries_chunked_encoding_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A mid-stream drop (ChunkedEncodingError) is retried, not fatal."""
+    connector = _connector(monkeypatch)
+    payload = {"value": []}
+    state = {"n": 0}
+
+    def _flaky(*_a: Any, **_k: Any) -> Response:
+        state["n"] += 1
+        if state["n"] == 1:
+            raise requests.exceptions.ChunkedEncodingError("connection dropped")
+        return _response(200, body=payload)
+
+    monkeypatch.setattr(sp_connector.requests, "get", _flaky)
+
+    result = connector._graph_api_get_json(PAGE_URL)
+
+    assert result == payload
+    assert state["n"] == 2

--- a/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
+++ b/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
@@ -28,6 +28,22 @@ def _make_xlsx(sheets: dict[str, list[list[str]]]) -> io.BytesIO:
 
 
 class TestXlsxToText:
+    def test_formula_strings_are_not_indexed(self) -> None:
+        # Workbooks are read with data_only=True: cached calculated values are
+        # extracted instead of formula source. A cell whose formula was never
+        # evaluated by a spreadsheet app has no cached value and is omitted —
+        # the accepted tradeoff for not indexing raw "=SUM(...)" strings.
+        wb = openpyxl.Workbook()
+        ws = cast(Worksheet, wb.active)
+        ws.append(["Total", "=SUM(B2:B10)"])
+        buf = io.BytesIO()
+        wb.save(buf)
+        buf.seek(0)
+
+        result = xlsx_to_text(buf)
+        assert "=SUM" not in result
+        assert "Total" in result
+
     def test_single_sheet_basic(self) -> None:
         xlsx = _make_xlsx(
             {

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -478,6 +478,18 @@ def test_omits_temperature_for_no_sampling_params_models(model_name: str) -> Non
         assert "temperature" not in kwargs
 
 
+def test_empty_tools_list_is_omitted(default_multi_llm: LitellmLLM) -> None:
+    # Some OpenAI-compatible servers reject requests carrying `tools: []`;
+    # an empty list must be dropped from the request entirely.
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(default_multi_llm.stream(messages, tools=[]))
+
+        assert mock_completion.call_args.kwargs["tools"] is None
+
+
 def test_claude_only_in_deployment_name_omits_temperature_and_reasons() -> None:
     # Custom providers (e.g. Azure AI Foundry) may carry the model identity only
     # in the deployment alias — the string actually sent to LiteLLM — while

--- a/backend/tests/unit/onyx/server/test_oidc_multi.py
+++ b/backend/tests/unit/onyx/server/test_oidc_multi.py
@@ -138,6 +138,78 @@ def test_build_client_oidc_uses_provider_name(monkeypatch: pytest.MonkeyPatch) -
     assert client.name == "okta"
 
 
+def _openid_stub_with_discovery(scopes_supported: list[str] | None) -> Any:
+    class _FakeOpenID:
+        def __init__(
+            self,
+            _client_id: str,
+            _client_secret: str,
+            _config_url: str,
+            *,
+            name: str,
+            base_scopes: list[str] | None = None,
+            **_kwargs: Any,
+        ) -> None:
+            self.name = name
+            self.base_scopes = list(base_scopes or [])
+            self.openid_configuration: dict[str, Any] = (
+                {}
+                if scopes_supported is None
+                else {"scopes_supported": scopes_supported}
+            )
+
+    return _FakeOpenID
+
+
+def test_offline_access_dropped_when_idp_does_not_advertise_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Amazon Cognito advertises scopes_supported without offline_access and
+    # rejects the whole authorize request when it is included.
+    monkeypatch.setattr(
+        oidc_multi,
+        "VerifiedEmailOpenID",
+        _openid_stub_with_discovery(["openid", "email", "profile"]),
+    )
+    client = oidc_multi._build_client(_provider(), dict(_OIDC_CONFIG))
+    assert "offline_access" not in (client.base_scopes or [])
+
+
+def test_offline_access_kept_when_idp_advertises_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        oidc_multi,
+        "VerifiedEmailOpenID",
+        _openid_stub_with_discovery(["openid", "email", "offline_access"]),
+    )
+    client = oidc_multi._build_client(_provider(), dict(_OIDC_CONFIG))
+    assert "offline_access" in (client.base_scopes or [])
+
+
+def test_offline_access_kept_when_discovery_has_no_scopes_supported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        oidc_multi, "VerifiedEmailOpenID", _openid_stub_with_discovery(None)
+    )
+    client = oidc_multi._build_client(_provider(), dict(_OIDC_CONFIG))
+    assert "offline_access" in (client.base_scopes or [])
+
+
+def test_explicitly_configured_offline_access_is_never_dropped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        oidc_multi,
+        "VerifiedEmailOpenID",
+        _openid_stub_with_discovery(["openid", "email"]),
+    )
+    config = {**_OIDC_CONFIG, "scopes": ["openid", "email", "offline_access"]}
+    client = oidc_multi._build_client(_provider(), config)
+    assert "offline_access" in (client.base_scopes or [])
+
+
 @pytest.mark.asyncio
 async def test_client_cache_hits_and_rebuilds_on_config_change(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Description

Cherry-picks the following fixes to `release/v4.5`:

- `31083ba50728e6689545e4873575d226a45e69a8` — keep Google Drive checkpoint frontier monotonic across shortcut resolution ([#13501](https://github.com/onyx-dot-app/onyx/pull/13501))
- `05799458a30181ac9445e658983f7317e7550f88` — only auto-request offline_access when the IdP advertises it ([#13534](https://github.com/onyx-dot-app/onyx/pull/13534))
- `23601ad8ec4d926c32ccc8bcd4ffe574c69e0c4c` — auto-name chat sessions with the session's model, not the global default ([#13535](https://github.com/onyx-dot-app/onyx/pull/13535))
- `6052daacaf022b3770d40f6f92df266bff8ce2a7` — index BookStack documents updated on the current day ([#13537](https://github.com/onyx-dot-app/onyx/pull/13537))
- `f3fe767829532851597864c9f0677215de4ba224` — omit empty tools list from litellm completion requests ([#13532](https://github.com/onyx-dot-app/onyx/pull/13532))
- `b86dfb4c40267c2b51d23b800ee7795a24b3257e` — extract cached calculated values from xlsx, not formula strings ([#13536](https://github.com/onyx-dot-app/onyx/pull/13536))
- `674372933ad39bf8f674b1b72d3456300525930b` — retry empty/non-JSON SharePoint Graph responses instead of aborting indexing ([#13540](https://github.com/onyx-dot-app/onyx/pull/13540))
- `96a38339675d2ad99607165bef41bcbc503f3b28` — stop the citation processor from corrupting code fences ([#13538](https://github.com/onyx-dot-app/onyx/pull/13538))

## How Has This Been Tested?

All 8 commits cherry-picked cleanly with no conflicts. Ran the unit tests included in these PRs against the release branch (360 passed).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cherry-picks eight hotfixes into v4.5 to stabilize indexing, chat, and auth. Prevents Drive re-index loops, restores same‑day BookStack updates, hardens SharePoint retries, and cleans up XLSX/LLM/chat behavior.

- **Bug Fixes**
  - Google Drive: keep the checkpoint frontier monotonic and clamp resume start to the requested range; use the shortcut’s own modifiedTime when resolving targets to avoid frontier regressions.
  - SharePoint: retry empty/non-JSON Graph responses and transient errors with backoff; reacquire tokens per attempt instead of aborting indexing.
  - BookStack: filter by full ISO datetime for updated_at so documents edited “today” are indexed.
  - XLSX: read with `openpyxl` `data_only=True` to extract cached values instead of formula strings.
  - LLM: omit empty tools lists in `litellm` requests (send tools: null) to avoid provider rejections.
  - Auth (OIDC): only auto-add offline_access when the IdP advertises it; explicit offline_access in config is respected.
  - Chat: auto-name sessions with the session’s actual model (persona/override aware), not the global default.
  - Citations: avoid corrupting code fences when labeling a bare ``` fence as plaintext.

<sup>Written for commit cf0295ed3c6eea5c77d685425a76b371742826fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

