### PR TITLE
feat(gateway): serve the OpenAI Responses API natively for true OpenAI models

### DIFF
--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -98,6 +98,10 @@ from onyx.server.gateway.models import (
     ResponsesOutputTextPart,
     ResponsesRequest,
 )
+from onyx.server.gateway.openai_passthrough import (
+    handle_openai_responses_passthrough,
+    is_openai_passthrough_eligible,
+)
 from onyx.server.gateway.stream_bridge import (
     _RATE_LIMIT_ERROR,
     _put_stream_item,
@@ -1432,6 +1436,14 @@ def gateway_responses(
     check_token_rate_limits(user)
     with closing(db_session):
         provider, model_config = resolve_gateway_model(db_session, user, request.model)
+    if is_openai_passthrough_eligible(provider, model_config):
+        return handle_openai_responses_passthrough(
+            request=request,
+            provider=provider,
+            model_config=model_config,
+            flow=flow,
+            user=user,
+        )
     result = handle_responses_request(
         request=request,
         provider=provider,

--- a/backend/onyx/server/gateway/configs.py
+++ b/backend/onyx/server/gateway/configs.py
@@ -9,3 +9,11 @@ ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED = (
 )
 ANTHROPIC_PASSTHROUGH_CONNECT_TIMEOUT_SECONDS = 10
 ANTHROPIC_PASSTHROUGH_READ_TIMEOUT_SECONDS = 600
+
+# Kill switch, default ON: set to "false" to send true-OpenAI models back
+# through the translation path (losing hosted tools / encrypted reasoning).
+OPENAI_GATEWAY_PASSTHROUGH_ENABLED = (
+    os.environ.get("OPENAI_GATEWAY_PASSTHROUGH_ENABLED", "").lower() != "false"
+)
+OPENAI_PASSTHROUGH_CONNECT_TIMEOUT_SECONDS = 10
+OPENAI_PASSTHROUGH_READ_TIMEOUT_SECONDS = 600

--- a/backend/onyx/server/gateway/openai_passthrough.py
+++ b/backend/onyx/server/gateway/openai_passthrough.py
@@ -1,0 +1,495 @@
+"""Proxies ``/v1/responses`` to OpenAI over httpx rather than LiteLLM's
+Responses bridge, which rebuilds the body from a decomposed parameter list and
+drops the unknown fields this passthrough exists to forward.
+"""
+
+import hashlib
+import json
+import queue
+import threading
+from contextlib import ExitStack
+from typing import Any
+
+import httpx
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.llm.constants import LlmProviderNames
+from onyx.llm.factory import llm_from_provider
+from onyx.llm.interfaces import LLM
+from onyx.llm.model_capabilities import is_true_openai_model
+from onyx.llm.model_response import Usage
+from onyx.llm.multi_llm import LitellmLLM
+from onyx.server.gateway.configs import (
+    OPENAI_GATEWAY_PASSTHROUGH_ENABLED,
+    OPENAI_PASSTHROUGH_CONNECT_TIMEOUT_SECONDS,
+    OPENAI_PASSTHROUGH_READ_TIMEOUT_SECONDS,
+)
+from onyx.server.gateway.models import ResponsesRequest
+from onyx.server.gateway.stream_bridge import (
+    _put_stream_item,
+    _sse_response,
+    _stream_worker_guard,
+    _StreamAccumulator,
+)
+from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
+from onyx.tracing.flows import LLMFlow
+from onyx.tracing.framework.create import trace
+from onyx.tracing.framework.traces import Trace
+from onyx.tracing.llm_utils import llm_generation_span, record_llm_span_output
+from onyx.utils.headers import build_llm_extra_headers
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# 401/403 describe OUR credential, not the caller's request, so they are
+# sanitized rather than added here.
+_FORWARDABLE_STATUSES = {400, 404, 413, 429}
+
+_SANITIZED_ERROR = "The upstream LLM request failed."
+_TIMEOUT_ERROR = "The selected model did not respond in time."
+
+_NO_STORAGE_MESSAGE = (
+    "The Onyx gateway does not store responses; send the full "
+    "conversation in `input` instead of `{field}`."
+)
+
+# OpenAI Responses API `tools[].type` wire values, not identifiers we own.
+_TOOL_TYPE_MCP = "mcp"
+_TOOL_TYPE_FILE_SEARCH = "file_search"
+_TOOL_TYPE_CODE_INTERPRETER = "code_interpreter"
+
+
+def is_openai_passthrough_eligible(
+    provider: LLMProviderView, model_config: ModelConfigurationView
+) -> bool:
+    # Azure needs api-key auth, an api-version param, and deployment-scoped
+    # URLs, none of which this module's Bearer /v1/responses shape produces.
+    if provider.provider == LlmProviderNames.AZURE:
+        return False
+    return OPENAI_GATEWAY_PASSTHROUGH_ENABLED and is_true_openai_model(
+        provider.provider, model_config.name
+    )
+
+
+def _base_url(provider: LLMProviderView) -> str:
+    base = (provider.api_base or "https://api.openai.com").rstrip("/")
+    # Operator-supplied api_base conventionally already ends in /v1; strip it
+    # so _responses_url does not double up.
+    return base.removesuffix("/v1")
+
+
+def _responses_url(provider: LLMProviderView) -> str:
+    return _base_url(provider) + "/v1/responses"
+
+
+def _timeout() -> httpx.Timeout:
+    return httpx.Timeout(
+        OPENAI_PASSTHROUGH_READ_TIMEOUT_SECONDS,
+        connect=OPENAI_PASSTHROUGH_CONNECT_TIMEOUT_SECONDS,
+    )
+
+
+def _build_upstream_request(
+    request: ResponsesRequest,
+    model_name: str,
+    user_id: str,
+    stream: bool,
+) -> dict[str, Any]:
+    # exclude_unset + extra="allow" is what forwards unknown client fields
+    # verbatim; dropping either silently degrades the passthrough.
+    body = request.model_dump(exclude_unset=True)
+    if request.previous_response_id is not None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_IMPLEMENTED,
+            _NO_STORAGE_MESSAGE.format(field="previous_response_id"),
+        )
+    if body.get("conversation") is not None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_IMPLEMENTED,
+            _NO_STORAGE_MESSAGE.format(field="conversation"),
+        )
+    if body.get("background"):
+        raise OnyxError(
+            OnyxErrorCode.NOT_IMPLEMENTED,
+            "The Onyx gateway does not support `background` responses.",
+        )
+    for tool in body.get("tools") or []:
+        if not isinstance(tool, dict):
+            continue
+        tool_type = tool.get("type")
+        if tool_type == _TOOL_TYPE_MCP:
+            # Would make OpenAI connect to a client-specified URL under our
+            # account.
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "mcp tools are not supported by the Onyx gateway.",
+            )
+        if tool_type == _TOOL_TYPE_FILE_SEARCH:
+            # Requires org-scoped vector_store_ids no gateway caller can
+            # own; we do not proxy /v1/vector_stores.
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "file_search tools are not supported by the Onyx gateway.",
+            )
+        if tool_type == _TOOL_TYPE_CODE_INTERPRETER:
+            container = tool.get("container")
+            # A string container references an existing sandbox under our
+            # shared org key, and an auto container's file_ids reference
+            # org-scoped uploads; only a bare "auto" form is allowed.
+            if isinstance(container, str) or (
+                isinstance(container, dict) and container.get("file_ids")
+            ):
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    "code_interpreter tools referencing an existing container "
+                    "or uploaded files are not supported by the Onyx gateway.",
+                )
+    if isinstance(body.get("input"), list):
+        for item in body["input"]:
+            if not isinstance(item, dict):
+                continue
+            content = item.get("content")
+            if not isinstance(content, list):
+                continue
+            for part in content:
+                if (
+                    isinstance(part, dict)
+                    and part.get("type") in ("input_file", "input_image")
+                    and part.get("file_id")
+                ):
+                    # References an uploaded file under our shared org key;
+                    # we do not proxy /v1/files.
+                    raise OnyxError(
+                        OnyxErrorCode.INVALID_INPUT,
+                        "file_id references are not supported by the Onyx "
+                        "gateway; send file content inline.",
+                    )
+    if body.get("prompt") is not None:
+        # A stored prompt template reference, scoped to our shared org key.
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "prompt template references are not supported by the Onyx gateway.",
+        )
+    body["model"] = model_name
+    body["stream"] = stream
+    # OpenAI defaults this to true, which would persist state under our
+    # shared key where any other gateway caller could read it back.
+    body["store"] = False
+    # Always overwrite: opaque provider-side abuse/cache attribution, never a
+    # client-supplied identifier.
+    hashed_user = hashlib.sha256(user_id.encode()).hexdigest()
+    body["user"] = hashed_user
+    body["safety_identifier"] = hashed_user
+    body["prompt_cache_key"] = hashed_user
+    return body
+
+
+def _build_upstream_headers(provider: LLMProviderView) -> dict[str, str]:
+    # Never forward inbound headers: OpenAI-Organization/OpenAI-Project would
+    # select a billing scope in the caller's OpenAI account, not ours.
+    if not provider.api_key:
+        raise OnyxError(
+            OnyxErrorCode.BAD_GATEWAY,
+            "The selected provider has no credential configured.",
+        )
+    # Server-configured proxy/routing headers; the entries below must keep
+    # winning on collision.
+    headers = build_llm_extra_headers()
+    headers.update(
+        {
+            "Authorization": f"Bearer {provider.api_key}",
+            "Content-Type": "application/json",
+        }
+    )
+    return headers
+
+
+def _usage_from_openai_wire(usage: dict[str, Any]) -> Usage:
+    # input_tokens is already cache-inclusive, so cached tokens must not be
+    # subtracted back out.
+    input_tokens = usage.get("input_tokens") or 0
+    output_tokens = usage.get("output_tokens") or 0
+    total_tokens = usage.get("total_tokens") or (input_tokens + output_tokens)
+    cache_read = (usage.get("input_tokens_details") or {}).get("cached_tokens") or 0
+    return Usage(
+        prompt_tokens=input_tokens,
+        completion_tokens=output_tokens,
+        total_tokens=total_tokens,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=cache_read,
+    )
+
+
+def _reasoning_tokens(usage: dict[str, Any]) -> int | None:
+    return (usage.get("output_tokens_details") or {}).get("reasoning_tokens")
+
+
+def _error_type_and_message(body: bytes) -> tuple[str, str]:
+    try:
+        parsed = json.loads(body)
+    except (json.JSONDecodeError, TypeError, UnicodeDecodeError):
+        return "api_error", "Upstream returned a non-JSON error."
+    error = parsed.get("error") if isinstance(parsed, dict) else None
+    if isinstance(error, dict):
+        return (
+            str(error.get("type") or "api_error"),
+            str(error.get("message") or "Upstream error."),
+        )
+    return "api_error", "Upstream error."
+
+
+def _non_streaming_error_response(response: httpx.Response) -> JSONResponse:
+    if response.status_code in _FORWARDABLE_STATUSES:
+        try:
+            content = response.json()
+        except ValueError:
+            content = {"error": {"message": response.text[:2000]}}
+        return JSONResponse(status_code=response.status_code, content=content)
+    logger.warning(
+        "OpenAI passthrough upstream error (sanitized): status=%s",
+        response.status_code,
+    )
+    raise OnyxError(OnyxErrorCode.BAD_GATEWAY, _SANITIZED_ERROR)
+
+
+def _gateway_trace(flow: LLMFlow, model: str) -> Trace:
+    return trace("llm_gateway", metadata={"flow": flow.value, "model": model})
+
+
+def handle_openai_responses_passthrough(
+    request: ResponsesRequest,
+    provider: LLMProviderView,
+    model_config: ModelConfigurationView,
+    flow: LLMFlow,
+    user: User,
+) -> JSONResponse | StreamingResponse:
+    body = _build_upstream_request(
+        request, model_config.name, str(user.id), request.stream
+    )
+    headers = _build_upstream_headers(provider)
+    url = _responses_url(provider)
+    # llm is built only for tracing config (model/provider metadata); the
+    # actual call goes straight over httpx, never through llm.invoke/stream.
+    llm = llm_from_provider(model_name=model_config.name, llm_provider=provider)
+
+    if request.stream:
+        return _sse_response(
+            _openai_passthrough_stream_worker,
+            {
+                "url": url,
+                "headers": headers,
+                "body": body,
+                "llm": llm,
+                "flow": flow,
+                "input_messages": request.input,
+                "tools": request.tools,
+                "model": request.model,
+            },
+        )
+
+    with (
+        _gateway_trace(flow, llm.config.model_name),
+        llm_generation_span(
+            llm, flow=flow, input_messages=request.input, tools=request.tools
+        ) as span,
+    ):
+        try:
+            with httpx.Client(timeout=_timeout()) as client:
+                response = client.post(url, json=body, headers=headers)
+        except httpx.TimeoutException as e:
+            if span is not None:
+                span.set_error({"message": f"{type(e).__name__}: {e}", "data": None})
+            logger.warning(
+                "OpenAI passthrough request timed out for model %s", request.model
+            )
+            raise OnyxError(OnyxErrorCode.BAD_GATEWAY, _TIMEOUT_ERROR) from e
+        except httpx.HTTPError as e:
+            if span is not None:
+                span.set_error({"message": f"{type(e).__name__}: {e}", "data": None})
+            # Exception repr carries the request URL, which for custom
+            # api_base values can embed query credentials; log the type only.
+            logger.warning(
+                "OpenAI passthrough transport error for model %s: %s",
+                request.model,
+                type(e).__name__,
+            )
+            raise OnyxError(OnyxErrorCode.BAD_GATEWAY, _SANITIZED_ERROR) from e
+
+        if response.status_code != 200:
+            if span is not None:
+                span.set_error(
+                    {
+                        "message": f"upstream status {response.status_code}",
+                        "data": None,
+                    }
+                )
+            return _non_streaming_error_response(response)
+
+        response_body = response.json()
+        usage = response_body.get("usage")
+        output_items = response_body.get("output") or []
+        text = "\n\n".join(
+            part.get("text", "")
+            for item in output_items
+            if isinstance(item, dict) and item.get("type") == "message"
+            for part in item.get("content") or []
+            if isinstance(part, dict) and part.get("type") == "output_text"
+        )
+        converted_usage = _usage_from_openai_wire(usage) if usage else None
+        if converted_usage is not None and isinstance(llm, LitellmLLM):
+            # Managed-key cost accounting normally happens inside
+            # LLM.invoke/stream, which this path bypasses.
+            llm._track_llm_cost(converted_usage)
+        if span is not None:
+            record_llm_span_output(
+                span,
+                output=text or None,
+                usage=converted_usage,
+                reasoning=None,
+                tool_calls=None,
+            )
+            reasoning_tokens = _reasoning_tokens(usage) if usage else None
+            if reasoning_tokens:
+                # No Usage slot for reasoning-token pricing yet; surface it
+                # in traces instead.
+                span.span_data.model_config = {
+                    **(span.span_data.model_config or {}),
+                    "reasoning_tokens": reasoning_tokens,
+                }
+
+    return JSONResponse(content=response_body)
+
+
+def _openai_passthrough_stream_worker(
+    url: str,
+    headers: dict[str, str],
+    body: dict[str, Any],
+    llm: LLM,
+    flow: LLMFlow,
+    input_messages: Any,
+    tools: list[dict[str, Any]] | None,
+    model: str,
+    out: "queue.Queue[Any]",
+    cancelled: threading.Event,
+) -> None:
+    def emit_error(*, message: str, error_type: str) -> None:
+        payload = {
+            "type": "response.failed",
+            "response": {"error": {"message": message, "type": error_type}},
+        }
+        _put_stream_item(out, f"data: {json.dumps(payload)}\n\n", cancelled)
+
+    # Runs on its own thread after the endpoint returned, so the trace must be
+    # opened here or the generation span sees no active trace.
+    with (
+        _gateway_trace(flow, llm.config.model_name),
+        llm_generation_span(
+            llm, flow=flow, input_messages=input_messages, tools=tools
+        ) as span,
+    ):
+        state = _StreamAccumulator()
+        with _stream_worker_guard(
+            span,
+            model,
+            state,
+            label="openai passthrough stream",
+            emit_error=emit_error,
+            out=out,
+            cancelled=cancelled,
+        ):
+            # ExitStack becomes state.upstream so the guard's finally can
+            # close both the response and the client via one .close() call.
+            stack = ExitStack()
+            state.upstream = stack
+            client = stack.enter_context(httpx.Client(timeout=_timeout()))
+            response = stack.enter_context(
+                client.stream("POST", url, json=body, headers=headers)
+            )
+            # A disconnected client only sets `cancelled`; without this
+            # watchdog a blocking iter_lines() holds the thread and the
+            # upstream request until the next SSE line or the read timeout.
+            threading.Thread(
+                target=lambda: (cancelled.wait(), stack.close()),
+                name="openai-passthrough-cancel-watchdog",
+                daemon=True,
+            ).start()
+
+            if response.status_code != 200:
+                response.read()
+                if response.status_code in _FORWARDABLE_STATUSES:
+                    error_type, message = _error_type_and_message(response.content)
+                else:
+                    logger.warning(
+                        "OpenAI passthrough upstream stream error (sanitized): "
+                        "status=%s",
+                        response.status_code,
+                    )
+                    error_type, message = "api_error", _SANITIZED_ERROR
+                if span is not None:
+                    span.set_error(
+                        {
+                            "message": f"upstream status {response.status_code}",
+                            "data": None,
+                        }
+                    )
+                emit_error(message=message, error_type=error_type)
+                return
+
+            frame_lines: list[str] = []
+            for line in response.iter_lines():
+                if cancelled.is_set():
+                    break
+                if line == "":
+                    if frame_lines:
+                        frame_text = "\n".join(frame_lines)
+                        frame_lines = []
+                        if not _put_stream_item(out, frame_text + "\n\n", cancelled):
+                            break
+                    continue
+                frame_lines.append(line)
+                if not line.startswith("data: "):
+                    continue
+                raw_data = line[len("data: ") :]
+                try:
+                    event = json.loads(raw_data)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "OpenAI passthrough: unparsable SSE data line, "
+                        "forwarding verbatim"
+                    )
+                    continue
+                event_type = event.get("type")
+                if event_type == "response.output_text.delta":
+                    delta_text = event.get("delta")
+                    if isinstance(delta_text, str):
+                        state.content.append(delta_text)
+                elif event_type in (
+                    "response.completed",
+                    "response.failed",
+                    "response.incomplete",
+                ):
+                    # incomplete/failed also bill real tokens, so usage
+                    # cannot be read from completed alone.
+                    response_obj = event.get("response") or {}
+                    usage = response_obj.get("usage")
+                    if isinstance(usage, dict):
+                        state.usage = _usage_from_openai_wire(usage)
+                        reasoning_tokens = _reasoning_tokens(usage)
+                        if reasoning_tokens and span is not None:
+                            span.span_data.model_config = {
+                                **(span.span_data.model_config or {}),
+                                "reasoning_tokens": reasoning_tokens,
+                            }
+                    if event_type in ("response.failed", "response.incomplete"):
+                        error = response_obj.get("error")
+                        if error and span is not None:
+                            span.set_error({"message": str(error), "data": None})
+            if frame_lines and not cancelled.is_set():
+                _put_stream_item(out, "\n".join(frame_lines) + "\n\n", cancelled)
+            # Managed-key cost accounting normally happens inside
+            # LLM.invoke/stream, which this path bypasses.
+            if state.usage is not None and isinstance(llm, LitellmLLM):
+                llm._track_llm_cost(state.usage)

--- a/backend/tests/unit/onyx/server/gateway/test_openai_passthrough.py
+++ b/backend/tests/unit/onyx/server/gateway/test_openai_passthrough.py
@@ -1,0 +1,1177 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from contextlib import contextmanager, nullcontext
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.llm.interfaces import LLMConfig
+from onyx.llm.multi_llm import LitellmLLM
+from onyx.server.gateway import api as gateway_api
+from onyx.server.gateway import openai_passthrough, stream_bridge
+from onyx.server.gateway.models import ResponsesRequest
+from onyx.server.gateway.openai_passthrough import (
+    _SANITIZED_ERROR,
+    _base_url,
+    _build_upstream_headers,
+    _build_upstream_request,
+    _error_type_and_message,
+    _non_streaming_error_response,
+    _openai_passthrough_stream_worker,
+    _reasoning_tokens,
+    _responses_url,
+    _usage_from_openai_wire,
+    handle_openai_responses_passthrough,
+    is_openai_passthrough_eligible,
+)
+from onyx.tracing.flows import LLMFlow
+from tests.unit.onyx.server.gateway.test_llm_gateway_api import (
+    _ConfigOnlyLLM,
+    _model,
+    _provider,
+)
+
+
+def _openai_llm() -> _ConfigOnlyLLM:
+    return _ConfigOnlyLLM(
+        LLMConfig(
+            model_provider="openai",
+            model_name="gpt-5-mini",
+            temperature=0,
+            max_input_tokens=1_000,
+        )
+    )
+
+
+def _real_openai_litellm_llm() -> LitellmLLM:
+    """A real LitellmLLM instance so isinstance(llm, LitellmLLM) holds; only
+    used with _track_llm_cost patched onto the instance so no DB/network
+    call actually happens."""
+    return LitellmLLM(
+        api_key="test-key",
+        model_provider="openai",
+        model_name="gpt-5-mini",
+        max_input_tokens=1_000,
+    )
+
+
+def _fake_httpx_module(client_factory: Any) -> MagicMock:
+    """A stand-in for the ``httpx`` module reference held by
+    openai_passthrough, preserving the real exception/Timeout classes so the
+    module's own exception handling still works."""
+    return MagicMock(
+        Client=client_factory,
+        Timeout=httpx.Timeout,
+        HTTPError=httpx.HTTPError,
+        TimeoutException=httpx.TimeoutException,
+        ConnectError=httpx.ConnectError,
+    )
+
+
+def test_is_openai_passthrough_eligible_true_for_openai_model() -> None:
+    provider = _provider(1, "openai", [_model("gpt-5-mini")])
+    with patch.object(openai_passthrough, "OPENAI_GATEWAY_PASSTHROUGH_ENABLED", True):
+        assert (
+            is_openai_passthrough_eligible(provider, provider.model_configurations[0])
+            is True
+        )
+
+
+def test_is_openai_passthrough_eligible_false_for_anthropic_provider() -> None:
+    provider = _provider(1, "anthropic", [_model("claude-sonnet-4-6")])
+    with patch.object(openai_passthrough, "OPENAI_GATEWAY_PASSTHROUGH_ENABLED", True):
+        assert (
+            is_openai_passthrough_eligible(provider, provider.model_configurations[0])
+            is False
+        )
+
+
+def test_is_openai_passthrough_eligible_false_when_kill_switch_off() -> None:
+    provider = _provider(1, "openai", [_model("gpt-5-mini")])
+    with patch.object(openai_passthrough, "OPENAI_GATEWAY_PASSTHROUGH_ENABLED", False):
+        assert (
+            is_openai_passthrough_eligible(provider, provider.model_configurations[0])
+            is False
+        )
+
+
+def test_is_openai_passthrough_eligible_false_for_openai_compatible_model() -> None:
+    """provider.provider == 'openai' also covers self-hosted/OpenAI-compatible
+    servers (vLLM, litellm-proxy) speaking the OpenAI wire shape but not
+    registered in litellm's model map under the openai provider. Proves
+    is_true_openai_model, not a bare string compare, gates eligibility."""
+    provider = _provider(1, "openai", [_model("my-custom-vllm-model")])
+    with patch.object(openai_passthrough, "OPENAI_GATEWAY_PASSTHROUGH_ENABLED", True):
+        assert (
+            is_openai_passthrough_eligible(provider, provider.model_configurations[0])
+            is False
+        )
+
+
+def test_is_openai_passthrough_eligible_true_for_litellm_proxy_real_openai_model() -> (
+    None
+):
+    provider = _provider(1, "litellm_proxy", [_model("gpt-4o")])
+    with patch.object(openai_passthrough, "OPENAI_GATEWAY_PASSTHROUGH_ENABLED", True):
+        assert (
+            is_openai_passthrough_eligible(provider, provider.model_configurations[0])
+            is True
+        )
+
+
+def test_is_openai_passthrough_eligible_false_for_azure() -> None:
+    """Azure is explicitly excluded from v1 passthrough: its Responses API has
+    a different auth/URL shape (api-key header, api-version query param,
+    deployment-scoped URL) that this module's Bearer-auth /v1/responses
+    construction does not fit."""
+    provider = _provider(1, "azure", [_model("gpt-4o")])
+    with patch.object(openai_passthrough, "OPENAI_GATEWAY_PASSTHROUGH_ENABLED", True):
+        assert (
+            is_openai_passthrough_eligible(provider, provider.model_configurations[0])
+            is False
+        )
+
+
+def test_base_url_defaults_to_openai_when_api_base_unset() -> None:
+    provider = _provider(1, "openai", [_model("gpt-5-mini")])
+    provider.api_base = None
+
+    assert _base_url(provider) == "https://api.openai.com"
+    assert _responses_url(provider) == "https://api.openai.com/v1/responses"
+
+
+def test_base_url_strips_trailing_v1_without_slash() -> None:
+    provider = _provider(1, "openai", [_model("gpt-5-mini")])
+    provider.api_base = "https://api.openai.com/v1"
+
+    assert _base_url(provider) == "https://api.openai.com"
+    assert _responses_url(provider) == "https://api.openai.com/v1/responses"
+
+
+def test_base_url_strips_trailing_v1_with_slash() -> None:
+    provider = _provider(1, "openai", [_model("gpt-5-mini")])
+    provider.api_base = "https://api.openai.com/v1/"
+
+    assert _base_url(provider) == "https://api.openai.com"
+    assert _responses_url(provider) == "https://api.openai.com/v1/responses"
+
+
+def test_base_url_leaves_proxy_base_without_v1_unchanged() -> None:
+    provider = _provider(1, "litellm_proxy", [_model("gpt-4o")])
+    provider.api_base = "http://localhost:4000"
+
+    assert _base_url(provider) == "http://localhost:4000"
+    assert _responses_url(provider) == "http://localhost:4000/v1/responses"
+
+
+def test_base_url_does_not_over_strip_path_not_ending_in_v1() -> None:
+    """A base whose path legitimately ends in something other than /v1 (e.g.
+    a deployment-scoped or versioned path) must be left alone; only an exact
+    trailing "/v1" segment is stripped."""
+    provider = _provider(1, "litellm_proxy", [_model("gpt-4o")])
+    provider.api_base = "https://gateway.example.com/openai/v1beta"
+
+    assert _base_url(provider) == "https://gateway.example.com/openai/v1beta"
+    assert (
+        _responses_url(provider)
+        == "https://gateway.example.com/openai/v1beta/v1/responses"
+    )
+
+
+def _responses_request(**overrides: Any) -> ResponsesRequest:
+    defaults: dict[str, Any] = {
+        "model": "1/gpt-5-mini",
+        "input": [{"role": "user", "content": "hi"}],
+    }
+    defaults.update(overrides)
+    return ResponsesRequest.model_validate(defaults)
+
+
+def test_build_upstream_request_swaps_model_name() -> None:
+    request = _responses_request()
+
+    body = _build_upstream_request(request, "gpt-5-mini", "user-1", True)
+
+    assert body["model"] == "gpt-5-mini"
+
+
+def test_build_upstream_request_forces_store_false_even_when_client_sends_true() -> (
+    None
+):
+    request = _responses_request(store=True)
+
+    body = _build_upstream_request(request, "gpt-5-mini", "user-1", True)
+
+    assert body["store"] is False
+
+
+def test_build_upstream_request_forces_store_false_when_client_omits_it() -> None:
+    request = _responses_request()
+
+    body = _build_upstream_request(request, "gpt-5-mini", "user-1", True)
+
+    assert body["store"] is False
+
+
+@pytest.mark.parametrize("stream_flag", [True, False])
+def test_build_upstream_request_sets_stream_explicitly(stream_flag: bool) -> None:
+    request = _responses_request(stream=stream_flag)
+
+    body = _build_upstream_request(request, "gpt-5-mini", "user-1", stream_flag)
+
+    assert body["stream"] is stream_flag
+
+
+def test_build_upstream_request_overwrites_user_safety_identifier_and_prompt_cache_key() -> (
+    None
+):
+    request = _responses_request(
+        user="client-supplied-user",
+        safety_identifier="client-supplied-safety",
+        prompt_cache_key="client-supplied-cache-key",
+    )
+
+    body = _build_upstream_request(request, "gpt-5-mini", "user-1", True)
+
+    expected_hash = hashlib.sha256(b"user-1").hexdigest()
+    assert body["user"] == expected_hash
+    assert body["safety_identifier"] == expected_hash
+    assert body["prompt_cache_key"] == expected_hash
+    assert body["user"] != "client-supplied-user"
+    assert body["safety_identifier"] != "client-supplied-safety"
+    assert body["prompt_cache_key"] != "client-supplied-cache-key"
+
+
+def test_build_upstream_request_rejects_previous_response_id() -> None:
+    request = _responses_request(previous_response_id="resp_abc123")
+
+    with pytest.raises(OnyxError) as exc_info:
+        _build_upstream_request(request, "gpt-5-mini", "user-1", True)
+
+    assert exc_info.value.error_code is OnyxErrorCode.NOT_IMPLEMENTED
+    assert "previous_response_id" in str(exc_info.value.detail)
+
+
+def test_build_upstream_request_rejects_conversation() -> None:
+    request = _responses_request(conversation="conv_abc123")
+
+    with pytest.raises(OnyxError) as exc_info:
+        _build_upstream_request(request, "gpt-5-mini", "user-1", True)
+
+    assert exc_info.value.error_code is OnyxErrorCode.NOT_IMPLEMENTED
+    assert "conversation" in str(exc_info.value.detail)
+
+
+def test_build_upstream_request_rejects_background() -> None:
+    request = _responses_request(background=True)
+
+    with pytest.raises(OnyxError) as exc_info:
+        _build_upstream_request(request, "gpt-5-mini", "user-1", True)
+
+    assert exc_info.value.error_code is OnyxErrorCode.NOT_IMPLEMENTED
+    assert "background" in str(exc_info.value.detail)
+
+
+def test_build_upstream_request_rejects_mcp_tool() -> None:
+    request = _responses_request(
+        tools=[{"type": "mcp", "server_url": "https://evil.example"}]
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        _build_upstream_request(request, "gpt-5-mini", "user-1", True)
+
+    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
+    assert "mcp" in str(exc_info.value.detail)
+
+
+def test_build_upstream_request_rejects_file_search_tool() -> None:
+    request = _responses_request(
+        tools=[{"type": "file_search", "vector_store_ids": ["vs_1"]}]
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        _build_upstream_request(request, "gpt-5-mini", "user-1", True)
+
+    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
+
+
+def test_build_upstream_request_rejects_code_interpreter_with_string_container() -> (
+    None
+):
+    request = _responses_request(
+        tools=[{"type": "code_interpreter", "container": "cntr_abc"}]
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        _build_upstream_request(request, "gpt-5-mini", "user-1", True)
+
+    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
+
+
+def test_build_upstream_request_rejects_code_interpreter_container_file_ids() -> None:
+    request = _responses_request(
+        tools=[
+            {
+                "type": "code_interpreter",
+                "container": {"type": "auto", "file_ids": ["file-123"]},
+            }
+        ]
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        _build_upstream_request(request, "gpt-5-mini", "user-1", True)
+
+    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
+
+
+def test_build_upstream_request_allows_code_interpreter_with_auto_container() -> None:
+    request = _responses_request(
+        tools=[{"type": "code_interpreter", "container": {"type": "auto"}}]
+    )
+
+    body = _build_upstream_request(request, "gpt-5-mini", "user-1", True)
+
+    assert body["tools"] == [
+        {"type": "code_interpreter", "container": {"type": "auto"}}
+    ]
+
+
+def test_build_upstream_request_rejects_input_file_with_file_id() -> None:
+    request = _responses_request(
+        input=[
+            {
+                "role": "user",
+                "content": [{"type": "input_file", "file_id": "file-123"}],
+            }
+        ]
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        _build_upstream_request(request, "gpt-5-mini", "user-1", True)
+
+    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
+
+
+def test_build_upstream_request_rejects_input_image_with_file_id() -> None:
+    request = _responses_request(
+        input=[
+            {
+                "role": "user",
+                "content": [{"type": "input_image", "file_id": "file-456"}],
+            }
+        ]
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        _build_upstream_request(request, "gpt-5-mini", "user-1", True)
+
+    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
+
+
+def test_build_upstream_request_allows_input_file_with_inline_base64_data() -> None:
+    request = _responses_request(
+        input=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_file",
+                        "filename": "doc.pdf",
+                        "file_data": "base64-encoded-content",
+                    }
+                ],
+            }
+        ]
+    )
+
+    body = _build_upstream_request(request, "gpt-5-mini", "user-1", True)
+
+    assert body["input"][0]["content"][0]["file_data"] == "base64-encoded-content"
+
+
+def test_build_upstream_request_allows_input_image_with_url() -> None:
+    request = _responses_request(
+        input=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_image", "image_url": "https://example.com/x.png"}
+                ],
+            }
+        ]
+    )
+
+    body = _build_upstream_request(request, "gpt-5-mini", "user-1", True)
+
+    assert body["input"][0]["content"][0]["image_url"] == "https://example.com/x.png"
+
+
+def test_build_upstream_request_rejects_top_level_prompt() -> None:
+    request = _responses_request(prompt={"id": "pmpt_123"})
+
+    with pytest.raises(OnyxError) as exc_info:
+        _build_upstream_request(request, "gpt-5-mini", "user-1", True)
+
+    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
+
+
+def test_build_upstream_request_forwards_hosted_tool_and_include_verbatim() -> None:
+    request = _responses_request(
+        tools=[{"type": "web_search"}],
+        include=["reasoning.encrypted_content"],
+    )
+
+    body = _build_upstream_request(request, "gpt-5-mini", "user-1", True)
+
+    assert body["tools"] == [{"type": "web_search"}]
+    assert body["include"] == ["reasoning.encrypted_content"]
+
+
+def test_build_upstream_request_forwards_unknown_future_fields() -> None:
+    request = _responses_request(
+        future_field={"anything": True},
+        truncation="auto",
+    )
+
+    body = _build_upstream_request(request, "gpt-5-mini", "user-1", True)
+
+    assert body["future_field"] == {"anything": True}
+    assert body["truncation"] == "auto"
+
+
+def test_build_upstream_headers_only_authorization_and_content_type() -> None:
+    provider = _provider(1, "openai", [_model("gpt-5-mini")])
+
+    headers = _build_upstream_headers(provider)
+
+    assert headers == {
+        "Authorization": f"Bearer {provider.api_key}",
+        "Content-Type": "application/json",
+    }
+
+
+def test_build_upstream_headers_merges_server_configured_extra_headers() -> None:
+    provider = _provider(1, "openai", [_model("gpt-5-mini")])
+    with patch.object(
+        openai_passthrough,
+        "build_llm_extra_headers",
+        return_value={"x-proxy-auth": "secret", "Authorization": "must-lose"},
+    ):
+        headers = _build_upstream_headers(provider)
+
+    assert headers["x-proxy-auth"] == "secret"
+    assert headers["Authorization"] == f"Bearer {provider.api_key}"
+
+
+def test_build_upstream_headers_rejects_provider_without_api_key() -> None:
+    provider = _provider(1, "openai", [_model("gpt-5-mini")])
+    provider.api_key = None
+
+    with pytest.raises(OnyxError) as exc_info:
+        _build_upstream_headers(provider)
+
+    assert exc_info.value.error_code is OnyxErrorCode.BAD_GATEWAY
+
+
+def test_usage_from_openai_wire_is_direct_mapping_no_addition() -> None:
+    """The highest-risk copy-paste regression: OpenAI's input_tokens is
+    already cache-inclusive, unlike Anthropic's, so prompt_tokens must equal
+    input_tokens with nothing added back."""
+    wire_usage = {
+        "input_tokens": 100,
+        "input_tokens_details": {"cached_tokens": 30},
+        "output_tokens": 42,
+        "total_tokens": 142,
+    }
+
+    usage = _usage_from_openai_wire(wire_usage)
+
+    assert usage.prompt_tokens == 100
+    assert usage.completion_tokens == 42
+    assert usage.total_tokens == 142
+    assert usage.cache_read_input_tokens == 30
+    assert usage.cache_creation_input_tokens == 0
+
+
+def test_usage_from_openai_wire_falls_back_to_input_plus_output_when_total_missing() -> (
+    None
+):
+    wire_usage = {"input_tokens": 100, "output_tokens": 42}
+
+    usage = _usage_from_openai_wire(wire_usage)
+
+    assert usage.total_tokens == 142
+
+
+def test_usage_from_openai_wire_missing_keys_default_zero() -> None:
+    usage = _usage_from_openai_wire({})
+
+    assert usage.prompt_tokens == 0
+    assert usage.completion_tokens == 0
+    assert usage.total_tokens == 0
+    assert usage.cache_read_input_tokens == 0
+    assert usage.cache_creation_input_tokens == 0
+
+
+def test_usage_from_openai_wire_tolerates_none_values() -> None:
+    usage = _usage_from_openai_wire(
+        {
+            "input_tokens": None,
+            "output_tokens": None,
+            "total_tokens": None,
+            "input_tokens_details": None,
+        }
+    )
+
+    assert usage.prompt_tokens == 0
+    assert usage.completion_tokens == 0
+    assert usage.total_tokens == 0
+    assert usage.cache_read_input_tokens == 0
+
+
+def test_reasoning_tokens_extracted_when_present() -> None:
+    usage = {"output_tokens_details": {"reasoning_tokens": 17}}
+
+    assert _reasoning_tokens(usage) == 17
+
+
+def test_reasoning_tokens_none_when_absent() -> None:
+    assert _reasoning_tokens({}) is None
+
+
+@pytest.mark.parametrize("status_code", [400, 404, 413, 429])
+def test_non_streaming_error_response_forwards_body_verbatim(status_code: int) -> None:
+    body = {"error": {"type": "invalid_request_error", "message": "bad"}}
+    response = httpx.Response(status_code=status_code, json=body)
+
+    result = _non_streaming_error_response(response)
+
+    assert isinstance(result, JSONResponse)
+    assert result.status_code == status_code
+    assert json.loads(bytes(result.body)) == body
+
+
+@pytest.mark.parametrize("status_code", [401, 403, 500, 503])
+def test_non_streaming_error_response_sanitizes_other_statuses(
+    status_code: int,
+) -> None:
+    response = httpx.Response(
+        status_code=status_code,
+        json={"error": {"type": "authentication_error", "message": "bad key xyz"}},
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        _non_streaming_error_response(response)
+
+    assert exc_info.value.error_code is OnyxErrorCode.BAD_GATEWAY
+    assert "bad key xyz" not in str(exc_info.value.detail)
+
+
+def test_non_streaming_error_response_wraps_non_json_400_body() -> None:
+    response = httpx.Response(status_code=400, content=b"not json")
+
+    result = _non_streaming_error_response(response)
+
+    payload = json.loads(bytes(result.body))
+    assert result.status_code == 400
+    assert "not json" in payload["error"]["message"]
+
+
+def test_error_type_and_message_non_json_bytes() -> None:
+    error_type, message = _error_type_and_message(b"not json at all")
+
+    assert error_type == "api_error"
+    assert message == "Upstream returned a non-JSON error."
+
+
+def test_error_type_and_message_error_field_is_a_string() -> None:
+    body = json.dumps({"error": "just a string"}).encode()
+
+    error_type, message = _error_type_and_message(body)
+
+    assert error_type == "api_error"
+    assert message == "Upstream error."
+
+
+def test_error_type_and_message_well_formed_type_and_message() -> None:
+    body = json.dumps(
+        {"error": {"type": "rate_limit_exceeded", "message": "quota exceeded"}}
+    ).encode()
+
+    error_type, message = _error_type_and_message(body)
+
+    assert error_type == "rate_limit_exceeded"
+    assert message == "quota exceeded"
+
+
+class _FakePostClient:
+    def __init__(
+        self, response: httpx.Response | None = None, exc: Exception | None = None
+    ) -> None:
+        self._response = response
+        self._exc = exc
+
+    def __enter__(self) -> "_FakePostClient":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        pass
+
+    def post(self, *args: object, **kwargs: object) -> httpx.Response:
+        del args, kwargs
+        if self._exc is not None:
+            raise self._exc
+        assert self._response is not None
+        return self._response
+
+
+def _non_streaming_run(
+    upstream_response: httpx.Response | None = None,
+    *,
+    exc: Exception | None = None,
+    llm_generation_span_patch: Any = None,
+    llm: Any = None,
+) -> JSONResponse:
+    provider = _provider(1, "openai", [_model("gpt-5-mini")])
+    model_config = provider.model_configurations[0]
+    span_patch = llm_generation_span_patch or (lambda *a, **k: nullcontext())  # noqa: ARG005
+
+    with (
+        patch.object(
+            openai_passthrough,
+            "httpx",
+            _fake_httpx_module(
+                MagicMock(return_value=_FakePostClient(upstream_response, exc))
+            ),
+        ),
+        patch.object(
+            openai_passthrough, "llm_from_provider", return_value=llm or _openai_llm()
+        ),
+        patch.object(openai_passthrough, "llm_generation_span", span_patch),
+    ):
+        result = handle_openai_responses_passthrough(
+            request=_responses_request(stream=False),
+            provider=provider,
+            model_config=model_config,
+            flow=LLMFlow.CRAFT_LLM_GENERATION,
+            user=MagicMock(id="user-1"),
+        )
+        assert isinstance(result, JSONResponse)
+        return result
+
+
+def test_handle_openai_passthrough_non_streaming_forwards_400_body_verbatim() -> None:
+    error_body = {"error": {"type": "invalid_request_error", "message": "bad"}}
+    fake_response = httpx.Response(400, json=error_body)
+
+    result = _non_streaming_run(fake_response)
+
+    assert result.status_code == 400
+    assert json.loads(bytes(result.body)) == error_body
+
+
+def test_handle_openai_passthrough_non_streaming_sanitizes_401() -> None:
+    fake_response = httpx.Response(401, json={"error": {"message": "invalid key xyz"}})
+
+    with pytest.raises(OnyxError) as exc_info:
+        _non_streaming_run(fake_response)
+
+    assert exc_info.value.error_code is OnyxErrorCode.BAD_GATEWAY
+    assert "invalid key xyz" not in str(exc_info.value.detail)
+
+
+def test_handle_openai_passthrough_non_streaming_sanitizes_500() -> None:
+    fake_response = httpx.Response(500, json={"error": {"message": "boom"}})
+
+    with pytest.raises(OnyxError) as exc_info:
+        _non_streaming_run(fake_response)
+
+    assert exc_info.value.error_code is OnyxErrorCode.BAD_GATEWAY
+
+
+def test_handle_openai_passthrough_non_streaming_timeout_raises_timeout_message() -> (
+    None
+):
+    with pytest.raises(OnyxError) as exc_info:
+        _non_streaming_run(exc=httpx.TimeoutException("timed out"))
+
+    assert "did not respond in time" in exc_info.value.detail
+
+
+_UPSTREAM_RESPONSE_BODY: dict[str, Any] = {
+    "id": "resp_upstream_abc123",
+    "object": "response",
+    "model": "gpt-5-mini",
+    "output": [
+        {
+            "type": "message",
+            "id": "msg_1",
+            "status": "completed",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "hi there", "annotations": []}],
+        }
+    ],
+    "usage": {
+        "input_tokens": 100,
+        "input_tokens_details": {"cached_tokens": 30},
+        "output_tokens": 42,
+        "total_tokens": 142,
+    },
+}
+
+
+def test_handle_openai_passthrough_non_streaming_forwards_200_body_verbatim() -> None:
+    fake_response = httpx.Response(200, json=_UPSTREAM_RESPONSE_BODY)
+
+    result = _non_streaming_run(fake_response)
+
+    assert result.status_code == 200
+    payload = json.loads(bytes(result.body))
+    assert payload == _UPSTREAM_RESPONSE_BODY
+    assert payload["id"] == "resp_upstream_abc123"
+
+
+def test_handle_openai_passthrough_non_streaming_records_usage() -> None:
+    fake_response = httpx.Response(200, json=_UPSTREAM_RESPONSE_BODY)
+    mock_span = MagicMock()
+
+    @contextmanager
+    def _span_ctx(*args: object, **kwargs: object):
+        del args, kwargs
+        yield mock_span
+
+    with patch.object(openai_passthrough, "record_llm_span_output") as record_output:
+        _non_streaming_run(fake_response, llm_generation_span_patch=_span_ctx)
+
+    record_output.assert_called_once()
+    usage = record_output.call_args.kwargs["usage"]
+    assert usage.prompt_tokens == 100
+    assert usage.completion_tokens == 42
+
+
+def test_handle_openai_passthrough_non_streaming_tracks_cost_once() -> None:
+    fake_response = httpx.Response(200, json=_UPSTREAM_RESPONSE_BODY)
+    llm = _real_openai_litellm_llm()
+
+    with patch.object(llm, "_track_llm_cost") as track_cost:
+        _non_streaming_run(fake_response, llm=llm)
+
+    track_cost.assert_called_once()
+    usage = track_cost.call_args.args[0]
+    assert usage.prompt_tokens == 100
+    assert usage.completion_tokens == 42
+
+
+_SSE_EVENTS: list[dict[str, Any]] = [
+    {"type": "response.created", "response": {"id": "resp_1"}},
+    {
+        "type": "response.output_text.delta",
+        "item_id": "msg_1",
+        "delta": "hi there",
+    },
+    {
+        "type": "response.completed",
+        "response": {
+            "id": "resp_1",
+            "usage": {
+                "input_tokens": 100,
+                "input_tokens_details": {"cached_tokens": 30},
+                "output_tokens": 42,
+                "total_tokens": 142,
+                "output_tokens_details": {"reasoning_tokens": 5},
+            },
+        },
+    },
+]
+
+
+def _sse_lines(events: list[dict[str, Any]]) -> list[str]:
+    lines: list[str] = []
+    for event in events:
+        lines.append(f"data: {json.dumps(event)}")
+        lines.append("")
+    return lines
+
+
+def _expected_sse_text(events: list[dict[str, Any]]) -> str:
+    return "".join(f"data: {json.dumps(event)}\n\n" for event in events)
+
+
+class _FakeStreamResponse:
+    def __init__(
+        self, status_code: int, lines: list[str], content: bytes = b""
+    ) -> None:
+        self.status_code = status_code
+        self._lines = lines
+        self.content = content
+        self.closed = False
+
+    def iter_lines(self) -> list[str]:
+        return self._lines
+
+    def read(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeStreamContext:
+    def __init__(self, response: _FakeStreamResponse) -> None:
+        self._response = response
+
+    def __enter__(self) -> _FakeStreamResponse:
+        return self._response
+
+    def __exit__(self, *exc_info: object) -> None:
+        self._response.close()
+
+
+class _FakeHttpxClient:
+    def __init__(self, response: _FakeStreamResponse) -> None:
+        self._response = response
+        self.closed = False
+
+    def __enter__(self) -> "_FakeHttpxClient":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self.closed = True
+
+    def stream(self, *args: object, **kwargs: object) -> _FakeStreamContext:
+        del args, kwargs
+        return _FakeStreamContext(self._response)
+
+
+_STREAM_WORKER_KWARGS = {
+    "url": "https://api.openai.com/v1/responses",
+    "headers": {"Authorization": "Bearer k"},
+    "body": {"model": "gpt-5-mini"},
+    "flow": LLMFlow.CRAFT_LLM_GENERATION,
+    "input_messages": [{"role": "user", "content": "hi"}],
+    "tools": None,
+    "model": "gpt-5-mini",
+}
+
+
+def _run_passthrough_stream(
+    response: _FakeStreamResponse,
+    *,
+    llm_generation_span_patch: Any = None,
+    llm: Any = None,
+) -> tuple[list[str], _FakeHttpxClient]:
+    fake_client = _FakeHttpxClient(response)
+    span_patch = llm_generation_span_patch or (lambda *a, **k: nullcontext())  # noqa: ARG005
+    with (
+        patch.object(
+            openai_passthrough,
+            "httpx",
+            _fake_httpx_module(MagicMock(return_value=fake_client)),
+        ),
+        patch.object(openai_passthrough, "llm_generation_span", span_patch),
+    ):
+        frames = list(
+            stream_bridge._run_bridged_stream(
+                _openai_passthrough_stream_worker,
+                {**_STREAM_WORKER_KWARGS, "llm": llm or _openai_llm()},
+            )
+        )
+    return frames, fake_client
+
+
+def test_passthrough_stream_forwards_frames_byte_identical() -> None:
+    lines = _sse_lines(_SSE_EVENTS)
+    response = _FakeStreamResponse(200, lines)
+
+    frames, _ = _run_passthrough_stream(response)
+
+    assert "".join(frames) == _expected_sse_text(_SSE_EVENTS)
+
+
+def test_passthrough_stream_forwards_malformed_data_line_verbatim() -> None:
+    lines = ["data: not json at all", ""]
+    response = _FakeStreamResponse(200, lines)
+
+    frames, _ = _run_passthrough_stream(response)
+
+    assert "".join(frames) == "data: not json at all\n\n"
+
+
+def test_passthrough_stream_records_usage_once_from_terminal_event() -> None:
+    lines = _sse_lines(_SSE_EVENTS)
+    response = _FakeStreamResponse(200, lines)
+    mock_span = MagicMock()
+
+    @contextmanager
+    def _span_ctx(*args: object, **kwargs: object):
+        del args, kwargs
+        yield mock_span
+
+    with patch.object(stream_bridge, "record_llm_span_output") as record_output:
+        _run_passthrough_stream(response, llm_generation_span_patch=_span_ctx)
+
+    record_output.assert_called_once()
+    usage = record_output.call_args.kwargs["usage"]
+    assert usage.prompt_tokens == 100
+    assert usage.completion_tokens == 42
+
+
+def test_passthrough_stream_accumulates_output_text_deltas_into_span_output() -> None:
+    delta_events = [
+        {
+            "type": "response.output_text.delta",
+            "item_id": "msg_1",
+            "delta": "hi ",
+        },
+        {
+            "type": "response.output_text.delta",
+            "item_id": "msg_1",
+            "delta": "there",
+        },
+        {"type": "response.completed", "response": {"id": "resp_1"}},
+    ]
+    lines = _sse_lines(delta_events)
+    response = _FakeStreamResponse(200, lines)
+    mock_span = MagicMock()
+
+    @contextmanager
+    def _span_ctx(*args: object, **kwargs: object):
+        del args, kwargs
+        yield mock_span
+
+    with patch.object(stream_bridge, "record_llm_span_output") as record_output:
+        _run_passthrough_stream(response, llm_generation_span_patch=_span_ctx)
+
+    record_output.assert_called_once()
+    assert record_output.call_args.kwargs["output"] == "hi there"
+
+
+def test_passthrough_stream_tracks_cost_once_via_terminal_event() -> None:
+    lines = _sse_lines(_SSE_EVENTS)
+    response = _FakeStreamResponse(200, lines)
+    llm = _real_openai_litellm_llm()
+
+    with patch.object(llm, "_track_llm_cost") as track_cost:
+        _run_passthrough_stream(response, llm=llm)
+
+    track_cost.assert_called_once()
+    usage = track_cost.call_args.args[0]
+    assert usage.prompt_tokens == 100
+    assert usage.completion_tokens == 42
+
+
+def test_passthrough_stream_response_incomplete_still_records_usage_for_cost() -> None:
+    """response.incomplete (e.g. max_output_tokens truncation) still bills
+    real tokens; usage must not be dropped just because the terminal event
+    isn't response.completed, or the caller is undercharged."""
+    incomplete_event = {
+        "type": "response.incomplete",
+        "response": {
+            "error": {"message": "max_output_tokens reached"},
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 42,
+                "total_tokens": 142,
+            },
+        },
+    }
+    lines = _sse_lines([incomplete_event])
+    response = _FakeStreamResponse(200, lines)
+    llm = _real_openai_litellm_llm()
+
+    with patch.object(llm, "_track_llm_cost") as track_cost:
+        _run_passthrough_stream(response, llm=llm)
+
+    track_cost.assert_called_once()
+    usage = track_cost.call_args.args[0]
+    assert usage.prompt_tokens == 100
+    assert usage.completion_tokens == 42
+
+
+@pytest.mark.parametrize("status_code", [401, 500])
+def test_passthrough_stream_sanitizes_non_forwardable_statuses(
+    status_code: int,
+) -> None:
+    error_body = json.dumps(
+        {"error": {"type": "authentication_error", "message": "leaked key xyz"}}
+    ).encode()
+    response = _FakeStreamResponse(status_code, [], content=error_body)
+
+    frames, _ = _run_passthrough_stream(response)
+
+    assert len(frames) == 1
+    data = json.loads(frames[0][len("data: ") : -2])
+    assert data["response"]["error"]["type"] == "api_error"
+    assert data["response"]["error"]["message"] == _SANITIZED_ERROR
+    assert "leaked key xyz" not in "".join(frames)
+
+
+def test_passthrough_stream_forwards_429_type_and_message_verbatim() -> None:
+    error_body = json.dumps(
+        {"error": {"type": "rate_limit_exceeded", "message": "quota exceeded"}}
+    ).encode()
+    response = _FakeStreamResponse(429, [], content=error_body)
+
+    frames, _ = _run_passthrough_stream(response)
+
+    assert len(frames) == 1
+    data = json.loads(frames[0][len("data: ") : -2])
+    assert data["response"]["error"]["type"] == "rate_limit_exceeded"
+    assert data["response"]["error"]["message"] == "quota exceeded"
+
+
+def test_passthrough_stream_response_failed_records_span_error_and_forwards_verbatim() -> (
+    None
+):
+    failed_event = {
+        "type": "response.failed",
+        "response": {"error": {"message": "the model produced invalid output"}},
+    }
+    lines = _sse_lines([failed_event])
+    response = _FakeStreamResponse(200, lines)
+    mock_span = MagicMock()
+
+    @contextmanager
+    def _span_ctx(*args: object, **kwargs: object):
+        del args, kwargs
+        yield mock_span
+
+    frames, _ = _run_passthrough_stream(response, llm_generation_span_patch=_span_ctx)
+
+    assert "".join(frames) == _expected_sse_text([failed_event])
+    mock_span.set_error.assert_called_once()
+
+
+def test_passthrough_stream_response_incomplete_records_span_error() -> None:
+    incomplete_event = {
+        "type": "response.incomplete",
+        "response": {"error": {"message": "max_output_tokens reached"}},
+    }
+    lines = _sse_lines([incomplete_event])
+    response = _FakeStreamResponse(200, lines)
+    mock_span = MagicMock()
+
+    @contextmanager
+    def _span_ctx(*args: object, **kwargs: object):
+        del args, kwargs
+        yield mock_span
+
+    _run_passthrough_stream(response, llm_generation_span_patch=_span_ctx)
+
+    mock_span.set_error.assert_called_once()
+
+
+def test_passthrough_stream_upstream_error_emits_single_error_frame() -> None:
+    error_body = json.dumps(
+        {"error": {"type": "invalid_request_error", "message": "bad request"}}
+    ).encode()
+    response = _FakeStreamResponse(400, [], content=error_body)
+
+    frames, _ = _run_passthrough_stream(response)
+
+    assert len(frames) == 1
+    data = json.loads(frames[0][len("data: ") : -2])
+    assert data["type"] == "response.failed"
+    assert data["response"]["error"]["message"] == "bad request"
+
+
+def test_passthrough_stream_closes_exitstack_resources() -> None:
+    lines = _sse_lines(_SSE_EVENTS)
+    response = _FakeStreamResponse(200, lines)
+
+    _frames, fake_client = _run_passthrough_stream(response)
+
+    assert fake_client.closed is True
+    assert response.closed is True
+
+
+def _responses_endpoint_request() -> ResponsesRequest:
+    return ResponsesRequest(
+        model="1/gpt-5-mini", input=[{"role": "user", "content": "hi"}]
+    )
+
+
+def test_gateway_responses_routes_to_passthrough_when_eligible() -> None:
+    provider = _provider(1, "openai", [_model("gpt-5-mini")])
+    model_config = provider.model_configurations[0]
+    request = _responses_endpoint_request()
+    passthrough_response = JSONResponse(content={"id": "resp_1"})
+
+    with (
+        patch.object(
+            gateway_api,
+            "_authorize_gateway_request",
+            return_value=LLMFlow.CRAFT_LLM_GENERATION,
+        ),
+        patch.object(gateway_api, "check_token_rate_limits"),
+        patch.object(
+            gateway_api,
+            "resolve_gateway_model",
+            return_value=(provider, model_config),
+        ),
+        patch.object(gateway_api, "is_openai_passthrough_eligible", return_value=True),
+        patch.object(
+            gateway_api,
+            "handle_openai_responses_passthrough",
+            return_value=passthrough_response,
+        ) as handle_passthrough,
+        patch.object(gateway_api, "handle_responses_request") as handle_translation,
+    ):
+        result = gateway_api.gateway_responses(
+            request=request,
+            http_request=MagicMock(spec=Request),
+            user=MagicMock(),
+            db_session=MagicMock(),
+        )
+
+    assert result is passthrough_response
+    handle_passthrough.assert_called_once()
+    assert handle_passthrough.call_args.kwargs["provider"] is provider
+    assert handle_passthrough.call_args.kwargs["model_config"] is model_config
+    handle_translation.assert_not_called()
+
+
+def test_gateway_responses_uses_translation_path_when_not_eligible() -> None:
+    provider = _provider(1, "anthropic", [_model("claude-sonnet-4-6")])
+    model_config = provider.model_configurations[0]
+    request = _responses_endpoint_request()
+
+    with (
+        patch.object(
+            gateway_api,
+            "_authorize_gateway_request",
+            return_value=LLMFlow.CRAFT_LLM_GENERATION,
+        ),
+        patch.object(gateway_api, "check_token_rate_limits"),
+        patch.object(
+            gateway_api,
+            "resolve_gateway_model",
+            return_value=(provider, model_config),
+        ),
+        patch.object(gateway_api, "is_openai_passthrough_eligible", return_value=False),
+        patch.object(
+            gateway_api, "handle_openai_responses_passthrough"
+        ) as handle_passthrough,
+        patch.object(gateway_api, "handle_responses_request") as handle_translation,
+    ):
+        handle_translation.return_value.to_wire.return_value = {"id": "resp_1"}
+        gateway_api.gateway_responses(
+            request=request,
+            http_request=MagicMock(spec=Request),
+            user=MagicMock(),
+            db_session=MagicMock(),
+        )
+
+    handle_passthrough.assert_not_called()
+    handle_translation.assert_called_once()

--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
@@ -382,6 +382,10 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # thinking-block signatures, fine-grained streaming); default on. Set to false
 # to send Anthropic-backed providers back through the OpenAI-translation path.
 # ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED=false
+# Kill switch for the gateway's native OpenAI Responses passthrough (hosted
+# tools, encrypted reasoning, fine-grained streaming); default on. Set to
+# false to send true-OpenAI models back through the translation path.
+# OPENAI_GATEWAY_PASSTHROUGH_ENABLED=false
 # ONYX_QUERY_HISTORY_TYPE=
 # Hide the Query History page from the admin sidebar (visibility-only; the history
 # APIs + recording keep working, unlike ONYX_QUERY_HISTORY_TYPE=disabled).

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -382,6 +382,10 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # thinking-block signatures, fine-grained streaming); default on. Set to false
 # to send Anthropic-backed providers back through the OpenAI-translation path.
 # ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED=false
+# Kill switch for the gateway's native OpenAI Responses passthrough (hosted
+# tools, encrypted reasoning, fine-grained streaming); default on. Set to
+# false to send true-OpenAI models back through the translation path.
+# OPENAI_GATEWAY_PASSTHROUGH_ENABLED=false
 # ONYX_QUERY_HISTORY_TYPE=
 # Hide the Query History page from the admin sidebar (visibility-only; the history
 # APIs + recording keep working, unlike ONYX_QUERY_HISTORY_TYPE=disabled).


### PR DESCRIPTION
## Description

Adds a native OpenAI Responses API passthrough to the gateway, mirroring the Anthropic passthrough one branch down: when the resolved provider is a true OpenAI model (`is_true_openai_model`), `/v1/responses` proxies the request nearly verbatim to OpenAI over httpx instead of round-tripping through the LiteLLM translation path. The translation round-trip drops everything the Responses API exists for: hosted tools (`web_search`, `file_search`, `code_interpreter`), reasoning items and `include: ["reasoning.encrypted_content"]` (how Codex CLI stays stateless across turns), and fine-grained streaming events.

Policy highlights, deny-by-default for fields with server-side effects under the shared org credential:
- `store` is forced `false` unconditionally (OpenAI defaults it `true`; stored responses under the shared key would be readable across gateway users)
- `previous_response_id`, `conversation`, `background`: refused (server-side state we do not proxy)
- `mcp` tools, `file_search` tools, `code_interpreter` with an existing container id, `file_id` references, stored `prompt` templates: refused (org-scoped resources no gateway caller can own); `code_interpreter` with `{"type": "auto"}` and inline file content stay allowed
- `user` / `safety_identifier` / `prompt_cache_key` overwritten with a hash of the Onyx user id
- Usage is mapped directly into the ledger (Responses `input_tokens` is cache-inclusive; no Anthropic-style cache add-back), including on `response.incomplete` terminal events so truncated streams still meter

Azure and `/v1/chat/completions` are deliberately out of scope (chat completions already is LiteLLM's native shape; Azure's auth/URL shape needs its own construction). `OPENAI_GATEWAY_PASSTHROUGH_ENABLED=false` is the operational kill switch back to translation, same shape as the Anthropic one.

## How Has This Been Tested?

- 73 unit tests in `test_openai_passthrough.py`: eligibility matrix (incl. Azure and OpenAI-compatible exclusions), the full request-field policy, direct usage mapping, base-URL `/v1` normalization, streaming worker (verbatim frames, terminal-event usage capture incl. `response.incomplete`, error sanitization for 401/500 vs verbatim forwarding for 400/404/413/429), cost tracking asserted against a real `LitellmLLM`, and endpoint routing for both the passthrough and translation branches
- Full gateway unit suite green (271 tests), pre-commit clean
- Six-lens review pass (correctness, security, tests, contracts, concurrency, readability) with confirmed findings fixed

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


---

**Stack:**
1. [gateway-named-tool-choice #13692](https://github.com/onyx-dot-app/onyx/pull/13692)
2. [gateway-anthropic-passthrough #13697](https://github.com/onyx-dot-app/onyx/pull/13697)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native `/v1/responses` passthrough for true OpenAI models to preserve encrypted reasoning and fine-grained streaming. Enabled by default; disable with `OPENAI_GATEWAY_PASSTHROUGH_ENABLED=false`.

- **New Features**
  - Direct passthrough over `httpx`; forwards SSE frames verbatim. Normalizes base URLs (strips trailing `/v1`), merges `LITELLM_EXTRA_HEADERS` with gateway headers (ours win). Excludes Azure; `/v1/chat/completions` unchanged.
  - Guardrails: force `store:false`; reject `previous_response_id`/`conversation`/`background`; block `mcp`, `file_search`, and `code_interpreter` with a string container or `container.file_ids`; allow `{"type":"code_interpreter","container":{"type":"auto"}}` only without `file_ids`; block input `file_id` refs and stored `prompt`; hash `user`/`safety_identifier`/`prompt_cache_key`.
  - Errors and metering: forward 400/404/413/429 bodies; sanitize others and transport/timeouts; mark spans on upstream failures; map OpenAI usage directly to the ledger and track costs (including on `response.incomplete`); attach `reasoning_tokens` to traces; avoid leaking sensitive data in logs.

- **Refactors**
  - Hoisted Responses tool-type discriminators to module constants.

<sup>Written for commit 8361ae2cefe305c63132acd558cf662f60878213. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

