### PR TITLE
feat(image-gen): support custom base URL for OpenAI-compatible providers

### DIFF
--- a/backend/onyx/image_gen/providers/openai_img_gen.py
+++ b/backend/onyx/image_gen/providers/openai_img_gen.py
@@ -31,17 +31,15 @@ class OpenAIImageGenerationProvider(ImageGenerationProvider):
         cls,
         credentials: ImageGenerationProviderCredentials,
     ) -> bool:
-        return bool(credentials.api_key)
+        return bool(credentials.api_key or credentials.api_base)
 
     @classmethod
     def _build_from_credentials(
         cls,
         credentials: ImageGenerationProviderCredentials,
     ) -> OpenAIImageGenerationProvider:
-        assert credentials.api_key
-
         return cls(
-            api_key=credentials.api_key,
+            api_key=credentials.api_key or "",
             api_base=credentials.api_base,
         )
 
@@ -58,6 +56,8 @@ class OpenAIImageGenerationProvider(ImageGenerationProvider):
         return model.rsplit("/", 1)[-1]
 
     def _model_supports_image_edits(self, model: str) -> bool:
+        if self._api_base:
+            return True
         normalized_model = self._normalize_model_name(model)
         return (
             normalized_model.startswith(self._GPT_IMAGE_MODEL_PREFIX)
@@ -106,7 +106,7 @@ class OpenAIImageGenerationProvider(ImageGenerationProvider):
                     image=[image.data for image in reference_images],
                     prompt=prompt,
                     model=litellm_model,
-                    api_key=self._api_key,
+                    api_key=self._api_key or "not-needed",
                     api_base=self._api_base,
                     size=size,
                     n=n,
@@ -126,7 +126,7 @@ class OpenAIImageGenerationProvider(ImageGenerationProvider):
             return image_generation(
                 prompt=prompt,
                 model=litellm_model,
-                api_key=self._api_key,
+                api_key=self._api_key or "not-needed",
                 api_base=self._api_base,
                 size=size,
                 n=n,

--- a/backend/tests/unit/onyx/image_gen/test_provider_building.py
+++ b/backend/tests/unit/onyx/image_gen/test_provider_building.py
@@ -50,15 +50,28 @@ def test_build_openai_provider_from_api_key_and_base() -> None:
     assert image_gen_provider.max_reference_images == 16
 
 
-def test_build_openai_provider_fails_no_api_key() -> None:
+def test_build_openai_provider_from_api_base_only() -> None:
     credentials = _get_default_image_gen_creds()
 
     credentials.api_base = "test"
 
     provider = OPENAI_PROVIDER
 
+    image_gen_provider = get_image_generation_provider(provider, credentials)
+
+    assert isinstance(image_gen_provider, OpenAIImageGenerationProvider)
+    assert image_gen_provider._api_key == ""
+    assert image_gen_provider._api_base == "test"
+
+
+def test_build_openai_provider_fails_no_credentials() -> None:
+    credentials = _get_default_image_gen_creds()
+
+    provider = OPENAI_PROVIDER
+
     with pytest.raises(ImageProviderCredentialsError):
         get_image_generation_provider(provider, credentials)
+
 
 
 def test_build_azure_provider_from_api_key_and_base_and_version() -> None:
@@ -303,6 +316,52 @@ def test_openai_provider_rejects_reference_images_for_unsupported_model() -> Non
             n=1,
             reference_images=[ReferenceImage(data=b"image-1", mime_type="image/png")],
         )
+
+
+def test_openai_provider_unauthenticated_fallback_api_key() -> None:
+    provider = OpenAIImageGenerationProvider(
+        api_key="",
+        api_base="http://localhost:7860/v1",
+    )
+    expected_response = object()
+
+    with patch("litellm.image_generation", return_value=expected_response) as mock_gen:
+        response = provider.generate_image(
+            prompt="draw a sunset",
+            model="custom-flux-model",
+            size="1024x1024",
+            n=1,
+        )
+
+    assert response is expected_response
+    mock_gen.assert_called_once()
+    assert mock_gen.call_args.kwargs["api_key"] == "not-needed"
+    assert mock_gen.call_args.kwargs["api_base"] == "http://localhost:7860/v1"
+
+
+def test_openai_provider_custom_api_base_allows_edits() -> None:
+    provider = OpenAIImageGenerationProvider(
+        api_key="",
+        api_base="http://localhost:7860/v1",
+    )
+    reference_images = [
+        ReferenceImage(data=b"image-1-bytes", mime_type="image/png"),
+    ]
+    expected_response = object()
+
+    with patch("litellm.image_edit", return_value=expected_response) as mock_edit:
+        response = provider.generate_image(
+            prompt="edit this custom image",
+            model="custom-flux-model",
+            size="1024x1024",
+            n=1,
+            reference_images=reference_images,
+        )
+
+    assert response is expected_response
+    mock_edit.assert_called_once()
+    assert mock_edit.call_args.kwargs["api_key"] == "not-needed"
+    assert mock_edit.call_args.kwargs["api_base"] == "http://localhost:7860/v1"
 
 
 def test_azure_provider_uses_image_generation_without_reference_images() -> None:

--- a/web/src/views/admin/ImageGenerationPage/constants.ts
+++ b/web/src/views/admin/ImageGenerationPage/constants.ts
@@ -39,6 +39,14 @@ export const IMAGE_PROVIDER_GROUPS: ProviderGroup[] = [
         description:
           "A capable image generation model from OpenAI with strong prompt adherence.",
       },
+      {
+        image_provider_id: "openai_compatible",
+        model_name: "gpt-image-1",
+        provider_name: "openai",
+        title: "OpenAI-Compatible (Custom)",
+        description:
+          "Connect any self-hosted or 3rd-party OpenAI-compatible image model (ComfyUI, Stable Diffusion, FLUX, etc.).",
+      },
     ],
   },
   {

--- a/web/src/views/admin/ImageGenerationPage/forms/ImageGenFormWrapper.tsx
+++ b/web/src/views/admin/ImageGenerationPage/forms/ImageGenFormWrapper.tsx
@@ -67,7 +67,8 @@ export function ImageGenFormWrapper<T extends FormValues>({
           if (getInitialValuesFromCredentials) {
             const credValues = getInitialValuesFromCredentials(
               creds,
-              imageProvider
+              imageProvider,
+              existingConfig
             );
             setMergedInitialValues((prev) => ({ ...prev, ...credValues }));
           }

--- a/web/src/views/admin/ImageGenerationPage/forms/OpenAICompatibleImageGenForm.tsx
+++ b/web/src/views/admin/ImageGenerationPage/forms/OpenAICompatibleImageGenForm.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import React from "react";
+import { InputTypeIn, PasswordInputTypeIn } from "@opal/components";
+import * as Yup from "yup";
+import { FormikField } from "@/refresh-components/form/FormikField";
+import { FormField } from "@/refresh-components/form/FormField";
+import InputComboBox from "@/refresh-components/inputs/InputComboBox";
+import { ImageGenFormWrapper } from "@/views/admin/ImageGenerationPage/forms/ImageGenFormWrapper";
+import {
+  ImageGenFormBaseProps,
+  ImageGenFormChildProps,
+  ImageGenSubmitPayload,
+} from "@/views/admin/ImageGenerationPage/forms/types";
+import {
+  ImageGenerationCredentials,
+  ImageGenerationConfigView,
+} from "@/views/admin/ImageGenerationPage/svc";
+import { ImageProvider } from "@/views/admin/ImageGenerationPage/constants";
+
+interface OpenAICompatibleFormValues {
+  api_base: string;
+  model_name: string;
+  api_key: string;
+}
+
+const initialValues: OpenAICompatibleFormValues = {
+  api_base: "",
+  model_name: "gpt-image-1",
+  api_key: "",
+};
+
+const validationSchema = Yup.object().shape({
+  api_base: Yup.string()
+    .required("Base URL is required")
+    .test(
+      "is-valid-url",
+      "Must be a valid URL starting with http:// or https:// (e.g. http://localhost:7860/v1 or https://api.myprovider.com/v1)",
+      (value) => {
+        if (!value) return false;
+        try {
+          const parsed = new URL(value);
+          return parsed.protocol === "http:" || parsed.protocol === "https:";
+        } catch {
+          return false;
+        }
+      }
+    ),
+  model_name: Yup.string().required("Model Name is required"),
+  api_key: Yup.string().optional(),
+});
+
+function OpenAICompatibleFormFields(
+  props: ImageGenFormChildProps<OpenAICompatibleFormValues>
+) {
+  const {
+    apiStatus,
+    showApiMessage,
+    errorMessage,
+    disabled,
+    isLoadingCredentials,
+    apiKeyOptions,
+    resetApiState,
+    imageProvider,
+  } = props;
+
+  return (
+    <>
+      {/* Base URL Field */}
+      <FormikField<string>
+        name="api_base"
+        render={(field, helper, meta, state) => (
+          <FormField
+            name="api_base"
+            state={apiStatus === "error" ? "error" : state}
+            className="w-full"
+          >
+            <FormField.Label>Base URL</FormField.Label>
+            <FormField.Control>
+              <InputTypeIn
+                {...field}
+                onChange={(e) => {
+                  field.onChange(e);
+                  resetApiState();
+                }}
+                placeholder="https://api.myprovider.com/v1"
+                variant={disabled ? "disabled" : undefined}
+              />
+            </FormField.Control>
+            <FormField.Message
+              messages={{
+                idle: "The target API base URL endpoint (e.g. http://localhost:7860/v1 or https://api.myprovider.com/v1)",
+                error: meta.error,
+              }}
+            />
+          </FormField>
+        )}
+      />
+
+      {/* Model Name Field */}
+      <FormikField<string>
+        name="model_name"
+        render={(field, helper, meta, state) => (
+          <FormField name="model_name" state={state} className="w-full">
+            <FormField.Label>Model Name / ID</FormField.Label>
+            <FormField.Control>
+              <InputTypeIn
+                {...field}
+                onChange={(e) => {
+                  field.onChange(e);
+                  resetApiState();
+                }}
+                placeholder="e.g. dall-e-3, flux-schnell, stablediffusion-xl"
+                variant={disabled ? "disabled" : undefined}
+              />
+            </FormField.Control>
+            <FormField.Message
+              messages={{
+                idle: "Specify the model identifier requested by your endpoint.",
+                error: meta.error,
+              }}
+            />
+          </FormField>
+        )}
+      />
+
+      {/* API Key Field (Optional) */}
+      <FormikField<string>
+        name="api_key"
+        render={(field, helper, meta, state) => (
+          <FormField
+            name="api_key"
+            state={apiStatus === "error" ? "error" : state}
+            className="w-full"
+          >
+            <FormField.Label>API Key (Optional)</FormField.Label>
+            <FormField.Control>
+              {apiKeyOptions.length > 0 ? (
+                <InputComboBox
+                  value={field.value}
+                  onChange={(e) => {
+                    helper.setValue(e.target.value);
+                    resetApiState();
+                  }}
+                  onValueChange={(value) => {
+                    helper.setValue(value);
+                    resetApiState();
+                  }}
+                  onBlur={field.onBlur}
+                  options={apiKeyOptions}
+                  placeholder={
+                    isLoadingCredentials
+                      ? "Loading..."
+                      : "Enter new API key or select existing provider"
+                  }
+                  disabled={disabled}
+                  isError={apiStatus === "error"}
+                />
+              ) : (
+                <PasswordInputTypeIn
+                  {...field}
+                  onChange={(e) => {
+                    field.onChange(e);
+                    resetApiState();
+                  }}
+                  placeholder={
+                    isLoadingCredentials
+                      ? "Loading..."
+                      : "Optional (leave empty for local endpoints)"
+                  }
+                  disabled={disabled}
+                  error={apiStatus === "error"}
+                />
+              )}
+            </FormField.Control>
+            {showApiMessage ? (
+              <FormField.APIMessage
+                state={apiStatus}
+                messages={{
+                  loading: `Testing endpoint with ${imageProvider.title}...`,
+                  success: "Provider configuration connected successfully.",
+                  error: errorMessage || "Endpoint validation failed",
+                }}
+              />
+            ) : (
+              <FormField.Message
+                messages={{
+                  idle: "API key is optional for unauthenticated local deployments.",
+                  error: meta.error,
+                }}
+              />
+            )}
+          </FormField>
+        )}
+      />
+    </>
+  );
+}
+
+function getInitialValuesFromCredentials(
+  credentials: ImageGenerationCredentials,
+  imageProvider: ImageProvider,
+  existingConfig?: ImageGenerationConfigView
+): Partial<OpenAICompatibleFormValues> {
+  return {
+    api_base: credentials.api_base || "",
+    model_name: existingConfig?.model_name || imageProvider.model_name || "gpt-image-1",
+    api_key: credentials.api_key || "",
+  };
+}
+
+function transformValues(
+  values: OpenAICompatibleFormValues,
+  imageProvider: ImageProvider
+): ImageGenSubmitPayload {
+  return {
+    modelName: values.model_name || imageProvider.model_name,
+    imageProviderId: imageProvider.image_provider_id,
+    provider: "openai",
+    apiBase: values.api_base,
+    apiKey: values.api_key || undefined,
+  };
+}
+
+export function OpenAICompatibleImageGenForm(props: ImageGenFormBaseProps) {
+  const { imageProvider, existingConfig } = props;
+
+  return (
+    <ImageGenFormWrapper<OpenAICompatibleFormValues>
+      {...props}
+      title={
+        existingConfig
+          ? `Edit ${imageProvider.title}`
+          : `Connect ${imageProvider.title}`
+      }
+      description={imageProvider.description}
+      initialValues={initialValues}
+      validationSchema={validationSchema}
+      getInitialValuesFromCredentials={getInitialValuesFromCredentials}
+      transformValues={(values) => transformValues(values, imageProvider)}
+    >
+      {(childProps) => <OpenAICompatibleFormFields {...childProps} />}
+    </ImageGenFormWrapper>
+  );
+}

--- a/web/src/views/admin/ImageGenerationPage/forms/getImageGenForm.tsx
+++ b/web/src/views/admin/ImageGenerationPage/forms/getImageGenForm.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ImageGenFormBaseProps } from "@/views/admin/ImageGenerationPage/forms/types";
 import { OpenAIImageGenForm } from "@/views/admin/ImageGenerationPage/forms/OpenAIImageGenForm";
+import { OpenAICompatibleImageGenForm } from "@/views/admin/ImageGenerationPage/forms/OpenAICompatibleImageGenForm";
 import { AzureImageGenForm } from "@/views/admin/ImageGenerationPage/forms/AzureImageGenForm";
 import { VertexImageGenForm } from "@/views/admin/ImageGenerationPage/forms/VertexImageGenForm";
 
@@ -13,6 +14,9 @@ export function getImageGenForm(props: ImageGenFormBaseProps): React.ReactNode {
 
   switch (providerName) {
     case "openai":
+      if (props.imageProvider.image_provider_id === "openai_compatible") {
+        return <OpenAICompatibleImageGenForm {...props} />;
+      }
       return <OpenAIImageGenForm {...props} />;
     case "azure":
       return <AzureImageGenForm {...props} />;

--- a/web/src/views/admin/ImageGenerationPage/forms/index.ts
+++ b/web/src/views/admin/ImageGenerationPage/forms/index.ts
@@ -1,5 +1,6 @@
 export * from "@/views/admin/ImageGenerationPage/forms/types";
 export { ImageGenFormWrapper } from "@/views/admin/ImageGenerationPage/forms/ImageGenFormWrapper";
 export { OpenAIImageGenForm } from "@/views/admin/ImageGenerationPage/forms/OpenAIImageGenForm";
+export { OpenAICompatibleImageGenForm } from "@/views/admin/ImageGenerationPage/forms/OpenAICompatibleImageGenForm";
 export { AzureImageGenForm } from "@/views/admin/ImageGenerationPage/forms/AzureImageGenForm";
 export { getImageGenForm } from "@/views/admin/ImageGenerationPage/forms/getImageGenForm";

--- a/web/src/views/admin/ImageGenerationPage/forms/types.ts
+++ b/web/src/views/admin/ImageGenerationPage/forms/types.ts
@@ -33,7 +33,8 @@ export interface ImageGenFormWrapperProps<
   transformValues?: (values: T) => ImageGenSubmitPayload;
   getInitialValuesFromCredentials?: (
     credentials: ImageGenerationCredentials,
-    imageProvider: ImageProvider
+    imageProvider: ImageProvider,
+    existingConfig?: ImageGenerationConfigView
   ) => Partial<T>;
 }
 


### PR DESCRIPTION
## Description
Fixes #11141.

Adds Custom Base URL support for OpenAI-compatible image generation models. This enables Onyx to connect with self-hosted open-source models (e.g. ComfyUI, AUTOMATIC1111, local AI endpoints) and third-party OpenAI-compatible services.

- **Backend**: Supported custom `api_base`, arbitrary model IDs, and optional `api_key` for local endpoints.
- **Frontend**: Added "OpenAI-Compatible (Custom)" provider form under Admin -> Image Generation.

## How Has This Been Tested?
- Unit tests: `pytest backend/tests/unit/onyx/image_gen/test_provider_building.py` (21/21 passed).
- Static type checks (`ty check`, `tsc`) & linter (`oxlint`).
- Verified manually in the Admin Panel (`/admin/configuration/image-generation`).

## Additional Options
- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add custom base URL support for OpenAI-compatible image generation, enabling Onyx to connect to self-hosted and third-party endpoints. Adds a new "OpenAI-Compatible (Custom)" provider in Admin and addresses Linear #11141.

- **New Features**
  - Backend: support `api_base` with optional `api_key` and arbitrary model IDs; allow edits when using a custom base; fallback "not-needed" key for unauthenticated endpoints.
  - Frontend: new provider form with Base URL, Model Name/ID, and optional API Key; URL validation; pre-fills from existing config.
  - Tests: unit tests for base-only config and edit support; expanded provider-building coverage.

<sup>Written for commit dfdb67c9b8ae700b43fe6685188855f835e4db93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

