### PR TITLE
feat(mobile): deep-research toggle in the chat composer

### DIFF
--- a/mobile/src/components/chat/ChatSurface.tsx
+++ b/mobile/src/components/chat/ChatSurface.tsx
@@ -22,6 +22,10 @@ import { useChatController } from "@/hooks/useChatController";
 import { useChatSessionController } from "@/hooks/useChatSessionController";
 import { useLiveAgent } from "@/hooks/useLiveAgent";
 import { useComposerDraft } from "@/hooks/useComposerDraft";
+import {
+  ComposerToolsProvider,
+  useComposerToolsState,
+} from "@/state/ComposerToolsProvider";
 
 const TRANSITION_MS = 150;
 
@@ -81,6 +85,16 @@ function ChatSurfaceContent({ focus }: { focus: ChatFocus }) {
   // persistent composer.
   const draft = useComposerDraft(`${sessionId ?? "new"}:${projectId ?? ""}`);
 
+  // null while the agent isn't knowable: until the new session reaches the sessions list,
+  // `liveAgent` falls back to the default agent, which would look like an agent switch and re-gate
+  // the toolbar mid-conversation.
+  const conversationAgent = sessionId == null || session ? liveAgent : null;
+  const composerTools = useComposerToolsState({
+    chatSessionId: sessionId,
+    agent: conversationAgent,
+    isProjectWorkflow: isProject,
+  });
+
   const { data: details, isLoading } = useProjectDetails(projectId);
   const { agents } = useAgents();
   const chats = details?.project?.chat_sessions ?? [];
@@ -101,6 +115,7 @@ function ChatSurfaceContent({ focus }: { focus: ChatFocus }) {
       message ?? draft.text,
       draft.descriptors,
       message == null ? draft.consume : draft.consumeAttachments,
+      composerTools.resolveToolOptions(),
     );
   };
 
@@ -143,51 +158,53 @@ function ChatSurfaceContent({ focus }: { focus: ChatFocus }) {
   ) : undefined;
 
   return (
-    <ChatScreen title={title} input={composer} below={below}>
-      {isProject ? (
-        <Animated.View
-          key="project-context"
-          entering={FadeIn.duration(TRANSITION_MS)}
-          exiting={FadeOut.duration(TRANSITION_MS)}
-          className="max-h-[50%]"
-        >
-          <ScrollView keyboardShouldPersistTaps="handled">
-            <View className="gap-24 px-24 pb-8 pt-8">
-              <ProjectContextPanel
-                projectId={projectId}
-                details={details}
-                isLoading={isLoading}
-              />
-            </View>
-          </ScrollView>
-        </Animated.View>
-      ) : messages.length === 0 && !isHydrating ? (
-        <Animated.View
-          key="empty"
-          entering={FadeIn.duration(TRANSITION_MS)}
-          exiting={FadeOut.duration(TRANSITION_MS)}
-          className="flex-1"
-        >
-          <ChatEmptyState
-            agent={liveAgent}
-            isDefaultAgent={isDefaultAgent}
-            onStarterSelect={sendWithAttachments}
-          />
-        </Animated.View>
-      ) : (
-        <Animated.View
-          key="messages"
-          entering={FadeIn.duration(TRANSITION_MS)}
-          exiting={FadeOut.duration(TRANSITION_MS)}
-          className="flex-1"
-        >
-          <MessageList
-            key={sessionId ?? "new"}
-            messages={messages}
-            agent={liveAgent}
-          />
-        </Animated.View>
-      )}
-    </ChatScreen>
+    <ComposerToolsProvider value={composerTools}>
+      <ChatScreen title={title} input={composer} below={below}>
+        {isProject ? (
+          <Animated.View
+            key="project-context"
+            entering={FadeIn.duration(TRANSITION_MS)}
+            exiting={FadeOut.duration(TRANSITION_MS)}
+            className="max-h-[50%]"
+          >
+            <ScrollView keyboardShouldPersistTaps="handled">
+              <View className="gap-24 px-24 pb-8 pt-8">
+                <ProjectContextPanel
+                  projectId={projectId}
+                  details={details}
+                  isLoading={isLoading}
+                />
+              </View>
+            </ScrollView>
+          </Animated.View>
+        ) : messages.length === 0 && !isHydrating ? (
+          <Animated.View
+            key="empty"
+            entering={FadeIn.duration(TRANSITION_MS)}
+            exiting={FadeOut.duration(TRANSITION_MS)}
+            className="flex-1"
+          >
+            <ChatEmptyState
+              agent={liveAgent}
+              isDefaultAgent={isDefaultAgent}
+              onStarterSelect={sendWithAttachments}
+            />
+          </Animated.View>
+        ) : (
+          <Animated.View
+            key="messages"
+            entering={FadeIn.duration(TRANSITION_MS)}
+            exiting={FadeOut.duration(TRANSITION_MS)}
+            className="flex-1"
+          >
+            <MessageList
+              key={sessionId ?? "new"}
+              messages={messages}
+              agent={liveAgent}
+            />
+          </Animated.View>
+        )}
+      </ChatScreen>
+    </ComposerToolsProvider>
   );
 }

--- a/mobile/src/components/chat/InputBar.tsx
+++ b/mobile/src/components/chat/InputBar.tsx
@@ -6,6 +6,7 @@ import { textPresets } from "@onyx-ai/shared/native";
 import { useRecentFiles } from "@/hooks/useRecentFiles";
 import { FileCard } from "@/components/chat/FileCard";
 import { FilePickerSheet } from "@/components/chat/FilePickerSheet";
+import { ToolbarControls } from "@/components/chat/ToolbarControls";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { FieldTextInput as ComposerInput } from "@/components/ui/text-input";
@@ -124,6 +125,7 @@ export function InputBar({
               accessibilityLabel="Attach files"
               onPress={() => setPickerOpen(true)}
             />
+            <ToolbarControls />
           </View>
 
           <View className="flex-row items-center gap-4">

--- a/mobile/src/components/chat/ToolbarControls.tsx
+++ b/mobile/src/components/chat/ToolbarControls.tsx
@@ -1,0 +1,31 @@
+// The input bar's left-cluster controls, mirroring web's `chatControls` block
+// (web/src/sections/input/AppInputBar.tsx).
+import { View } from "react-native";
+
+import { SelectButton } from "@/components/ui/select-button";
+import { useComposerTools } from "@/state/ComposerToolsProvider";
+import SvgHourglass from "@/icons/hourglass";
+
+export function ToolbarControls() {
+  const { showDeepResearch, deepResearchEnabled, toggleDeepResearch } =
+    useComposerTools();
+
+  if (!showDeepResearch) return null;
+
+  // Wrapper: `SelectButton`'s `self-start` would top-align the 28px pill against the 36px
+  // paperclip; hugging it here keeps the row centered.
+  return (
+    <View className="flex-row items-center">
+      <SelectButton
+        icon={SvgHourglass}
+        state={deepResearchEnabled ? "selected" : "empty"}
+        // folded = label hidden
+        foldable={!deepResearchEnabled}
+        onPress={toggleDeepResearch}
+        accessibilityLabel="Deep Research"
+      >
+        Deep Research
+      </SelectButton>
+    </View>
+  );
+}

--- a/mobile/src/components/chat/__tests__/ToolbarControls.test.tsx
+++ b/mobile/src/components/chat/__tests__/ToolbarControls.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import { ToolbarControls } from "@/components/chat/ToolbarControls";
+import {
+  ComposerToolsProvider,
+  type ComposerTools,
+} from "@/state/ComposerToolsProvider";
+
+// The provider module pulls in the settings API (→ MMKV, no native binary under jest); this suite
+// only uses the context.
+jest.mock("@/api/settings", () => ({ useWorkspaceSettings: jest.fn() }));
+
+function renderControls(overrides: Partial<ComposerTools> = {}) {
+  const value: ComposerTools = {
+    showDeepResearch: true,
+    deepResearchEnabled: false,
+    toggleDeepResearch: jest.fn(),
+    resolveToolOptions: () => ({
+      deepResearch: false,
+      allowedToolIds: null,
+      forcedToolId: null,
+      internalSearchFilters: null,
+    }),
+    ...overrides,
+  };
+  render(
+    <ComposerToolsProvider value={value}>
+      <ToolbarControls />
+    </ComposerToolsProvider>,
+  );
+  return value;
+}
+
+describe("ToolbarControls", () => {
+  it("renders nothing when deep research is gated off", () => {
+    renderControls({ showDeepResearch: false });
+    expect(screen.queryByLabelText("Deep Research")).toBeNull();
+  });
+
+  it("renders the pill icon-only and unselected while off", () => {
+    renderControls();
+    const pill = screen.getByLabelText("Deep Research");
+    expect(pill.props.accessibilityState.selected).toBe(false);
+    expect(screen.queryByText("Deep Research")).toBeNull();
+  });
+
+  it("shows the label and the selected state once enabled", () => {
+    renderControls({ deepResearchEnabled: true });
+    expect(screen.getByText("Deep Research")).toBeTruthy();
+    expect(
+      screen.getByLabelText("Deep Research").props.accessibilityState.selected,
+    ).toBe(true);
+  });
+
+  it("toggles on press", () => {
+    const value = renderControls();
+    fireEvent.press(screen.getByLabelText("Deep Research"));
+    expect(value.toggleDeepResearch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/hooks/__tests__/useDeepResearchToggle.test.ts
+++ b/mobile/src/hooks/__tests__/useDeepResearchToggle.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "@jest/globals";
+import { act, renderHook } from "@testing-library/react-native";
+
+import { useDeepResearchToggle } from "@/hooks/useDeepResearchToggle";
+
+function renderToggle(
+  chatSessionId: string | null,
+  agentId: number | undefined,
+) {
+  return renderHook(
+    (props: { chatSessionId: string | null; agentId: number | undefined }) =>
+      useDeepResearchToggle(props),
+    { initialProps: { chatSessionId, agentId } },
+  );
+}
+
+describe("useDeepResearchToggle", () => {
+  it("starts off and toggles", () => {
+    const { result } = renderToggle(null, 0);
+    expect(result.current.deepResearchEnabled).toBe(false);
+
+    act(() => result.current.toggleDeepResearch());
+    expect(result.current.deepResearchEnabled).toBe(true);
+
+    act(() => result.current.toggleDeepResearch());
+    expect(result.current.deepResearchEnabled).toBe(false);
+  });
+
+  it("preserves the flag when the landing gets its new session", () => {
+    const { result, rerender } = renderToggle(null, 0);
+    act(() => result.current.toggleDeepResearch());
+
+    rerender({ chatSessionId: "session-1", agentId: 0 });
+    expect(result.current.deepResearchEnabled).toBe(true);
+  });
+
+  it("resets when switching between existing sessions", () => {
+    const { result, rerender } = renderToggle("session-1", 0);
+    act(() => result.current.toggleDeepResearch());
+
+    rerender({ chatSessionId: "session-2", agentId: 0 });
+    expect(result.current.deepResearchEnabled).toBe(false);
+  });
+
+  it("resets when leaving a session for a new chat", () => {
+    const { result, rerender } = renderToggle("session-1", 0);
+    act(() => result.current.toggleDeepResearch());
+
+    rerender({ chatSessionId: null, agentId: 0 });
+    expect(result.current.deepResearchEnabled).toBe(false);
+  });
+
+  it("resets when the agent changes", () => {
+    const { result, rerender } = renderToggle(null, 0);
+    act(() => result.current.toggleDeepResearch());
+
+    rerender({ chatSessionId: null, agentId: 7 });
+    expect(result.current.deepResearchEnabled).toBe(false);
+  });
+
+  it("ignores an agent id that is not resolved yet", () => {
+    const { result, rerender } = renderToggle(null, undefined);
+    act(() => result.current.toggleDeepResearch());
+
+    // agents finish loading — the first known id is not a switch
+    rerender({ chatSessionId: null, agentId: 7 });
+    expect(result.current.deepResearchEnabled).toBe(true);
+  });
+
+  it("still resets when a switch passes through an unresolved agent", () => {
+    const { result, rerender } = renderToggle(null, 7);
+    act(() => result.current.toggleDeepResearch());
+
+    rerender({ chatSessionId: null, agentId: undefined });
+    rerender({ chatSessionId: null, agentId: 9 });
+    expect(result.current.deepResearchEnabled).toBe(false);
+  });
+
+  it("keeps the flag across the send that creates a session with an unresolved persona", () => {
+    const { result, rerender } = renderToggle(null, 7);
+    act(() => result.current.toggleDeepResearch());
+
+    // the session exists but isn't in the sessions list yet, so its persona is unknown…
+    rerender({ chatSessionId: "session-1", agentId: undefined });
+    expect(result.current.deepResearchEnabled).toBe(true);
+
+    // …and resolves to the same agent once the list refreshes
+    rerender({ chatSessionId: "session-1", agentId: 7 });
+    expect(result.current.deepResearchEnabled).toBe(true);
+  });
+});

--- a/mobile/src/hooks/useDeepResearchToggle.ts
+++ b/mobile/src/hooks/useDeepResearchToggle.ts
@@ -1,0 +1,50 @@
+// Ported from web/src/hooks/useDeepResearchToggle.ts.
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface UseDeepResearchToggleArgs {
+  chatSessionId: string | null;
+  // undefined = unresolved (agents loading, or a new session missing from the sessions list).
+  agentId: number | undefined;
+}
+
+export interface DeepResearchToggle {
+  deepResearchEnabled: boolean;
+  toggleDeepResearch: () => void;
+}
+
+export function useDeepResearchToggle({
+  chatSessionId,
+  agentId,
+}: UseDeepResearchToggleArgs): DeepResearchToggle {
+  const [deepResearchEnabled, setDeepResearchEnabled] = useState(false);
+  const previousChatSessionId = useRef<string | null>(chatSessionId);
+  const previousAgentId = useRef<number | undefined>(agentId);
+
+  // Preserve across null→new-session: that transition *is* the send, so resetting on every
+  // `chatSessionId` change would clear the flag mid-send.
+  useEffect(() => {
+    const previousId = previousChatSessionId.current;
+    previousChatSessionId.current = chatSessionId;
+    if (previousId !== null && previousId !== chatSessionId) {
+      setDeepResearchEnabled(false);
+    }
+  }, [chatSessionId]);
+
+  // Only known→known counts as a switch. Web resets on every `agentId` change; on mobile that
+  // would include the unresolved step after a send, clearing the flag that send just used.
+  useEffect(() => {
+    if (agentId === undefined) return;
+    const previousId = previousAgentId.current;
+    previousAgentId.current = agentId;
+    if (previousId !== undefined && previousId !== agentId) {
+      setDeepResearchEnabled(false);
+    }
+  }, [agentId]);
+
+  const toggleDeepResearch = useCallback(
+    () => setDeepResearchEnabled((enabled) => !enabled),
+    [],
+  );
+
+  return { deepResearchEnabled, toggleDeepResearch };
+}

--- a/mobile/src/state/ComposerToolsProvider.tsx
+++ b/mobile/src/state/ComposerToolsProvider.tsx
@@ -1,0 +1,95 @@
+// The state lives in a hook rather than inside the provider because ChatSurface both hosts the
+// provider and calls `resolveToolOptions()` at send time — a component can't read a context it
+// provides.
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+
+import { useWorkspaceSettings } from "@/api/settings";
+import type { ChatToolOptions } from "@/api/chat/stream";
+import type { MinimalAgent } from "@/chat/agents";
+import { hasSearchToolsAvailable } from "@/chat/tools";
+import { useDeepResearchToggle } from "@/hooks/useDeepResearchToggle";
+
+export interface ComposerTools {
+  showDeepResearch: boolean;
+  deepResearchEnabled: boolean;
+  toggleDeepResearch: () => void;
+  // Read at send time, never during render.
+  resolveToolOptions: () => ChatToolOptions;
+}
+
+interface ComposerToolsInputs {
+  chatSessionId: string | null;
+  // null while the conversation's agent isn't knowable yet.
+  agent: MinimalAgent | null;
+  // Deep research is unsupported in projects (web hides it too — ENG-3818). Only the project
+  // landing composer is detectable: a chat opened from a project has no project id on the wire.
+  isProjectWorkflow: boolean;
+}
+
+export function useComposerToolsState({
+  chatSessionId,
+  agent,
+  isProjectWorkflow,
+}: ComposerToolsInputs): ComposerTools {
+  const { settings } = useWorkspaceSettings();
+  const { deepResearchEnabled, toggleDeepResearch } = useDeepResearchToggle({
+    chatSessionId,
+    agentId: agent?.id,
+  });
+
+  // Agent unknown → hold the pill as the user left it. Re-gating on the placeholder agent would
+  // either withdraw a control the user just used or offer deep research to an agent that can't
+  // search.
+  const canSearch = agent
+    ? hasSearchToolsAvailable(agent.tools)
+    : deepResearchEnabled;
+  const showDeepResearch =
+    !isProjectWorkflow && settings.deep_research_enabled && canSearch;
+
+  return useMemo(
+    () => ({
+      showDeepResearch,
+      deepResearchEnabled,
+      toggleDeepResearch,
+      // Gated on `showDeepResearch` so a hidden control can never send `true` — e.g. the admin
+      // disabled deep research while a toggle was left on.
+      resolveToolOptions: () => ({
+        deepResearch: showDeepResearch && deepResearchEnabled,
+        allowedToolIds: null,
+        forcedToolId: null,
+        internalSearchFilters: null,
+      }),
+    }),
+    [showDeepResearch, deepResearchEnabled, toggleDeepResearch],
+  );
+}
+
+const ComposerToolsContext = createContext<ComposerTools | undefined>(
+  undefined,
+);
+
+interface ComposerToolsProviderProps {
+  value: ComposerTools;
+  children: ReactNode;
+}
+
+export function ComposerToolsProvider({
+  value,
+  children,
+}: ComposerToolsProviderProps) {
+  return (
+    <ComposerToolsContext.Provider value={value}>
+      {children}
+    </ComposerToolsContext.Provider>
+  );
+}
+
+export function useComposerTools(): ComposerTools {
+  const tools = useContext(ComposerToolsContext);
+  if (!tools) {
+    throw new Error(
+      "useComposerTools must be used within a ComposerToolsProvider",
+    );
+  }
+  return tools;
+}

--- a/mobile/src/state/__tests__/ComposerToolsProvider.test.tsx
+++ b/mobile/src/state/__tests__/ComposerToolsProvider.test.tsx
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { act, renderHook } from "@testing-library/react-native";
+
+import type { MinimalAgent } from "@/chat/agents";
+import { SEARCH_TOOL_ID, type ToolSnapshot } from "@/chat/tools";
+import { useComposerToolsState } from "@/state/ComposerToolsProvider";
+
+// `mock`-prefixed so babel-jest allows the hoisted factory to close over it.
+let mockDeepResearchAdminEnabled = true;
+
+jest.mock("@/api/settings", () => ({
+  useWorkspaceSettings: () => ({
+    settings: {
+      disable_default_assistant: false,
+      user_file_max_upload_size_mb: null,
+      deep_research_enabled: mockDeepResearchAdminEnabled,
+    },
+  }),
+}));
+
+const searchTool: ToolSnapshot = {
+  id: 1,
+  name: "SearchTool",
+  display_name: "Search",
+  description: "",
+  in_code_tool_id: SEARCH_TOOL_ID,
+  mcp_server_id: null,
+  chat_selectable: true,
+};
+
+function agent(tools: ToolSnapshot[]): MinimalAgent {
+  return {
+    id: 0,
+    name: "Agent",
+    description: "",
+    starter_messages: null,
+    uploaded_image_id: null,
+    icon_name: null,
+    is_public: true,
+    is_listed: true,
+    is_featured: false,
+    builtin_persona: true,
+    display_priority: null,
+    labels: [],
+    tools,
+    knowledge_sources: [],
+  };
+}
+
+function renderTools(
+  overrides: { agent?: MinimalAgent | null; isProjectWorkflow?: boolean } = {},
+) {
+  return renderHook(() =>
+    useComposerToolsState({
+      chatSessionId: null,
+      agent:
+        overrides.agent === undefined ? agent([searchTool]) : overrides.agent,
+      isProjectWorkflow: overrides.isProjectWorkflow ?? false,
+    }),
+  );
+}
+
+describe("useComposerToolsState", () => {
+  beforeEach(() => {
+    mockDeepResearchAdminEnabled = true;
+  });
+
+  it("shows deep research when the admin allows it and the agent can search", () => {
+    expect(renderTools().result.current.showDeepResearch).toBe(true);
+  });
+
+  it("hides deep research when the admin setting is off", () => {
+    mockDeepResearchAdminEnabled = false;
+    expect(renderTools().result.current.showDeepResearch).toBe(false);
+  });
+
+  it("hides deep research when the agent has no search tool", () => {
+    expect(
+      renderTools({ agent: agent([]) }).result.current.showDeepResearch,
+    ).toBe(false);
+  });
+
+  it("hides deep research while the agent is unknown and the pill is off", () => {
+    expect(renderTools({ agent: null }).result.current.showDeepResearch).toBe(
+      false,
+    );
+  });
+
+  it("holds the pill through the agent-unknown window after a send", () => {
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useComposerToolsState>[0]) =>
+        useComposerToolsState(props),
+      {
+        initialProps: {
+          chatSessionId: null,
+          agent: agent([searchTool]),
+          isProjectWorkflow: false,
+        },
+      },
+    );
+    act(() => result.current.toggleDeepResearch());
+
+    // Re-gating here would withdraw the control the user just used and drop it from the request.
+    rerender({
+      chatSessionId: "session-1",
+      agent: null,
+      isProjectWorkflow: false,
+    });
+    expect(result.current.showDeepResearch).toBe(true);
+    expect(result.current.resolveToolOptions().deepResearch).toBe(true);
+  });
+
+  it("hides deep research in a project workflow", () => {
+    expect(
+      renderTools({ isProjectWorkflow: true }).result.current.showDeepResearch,
+    ).toBe(false);
+  });
+
+  it("sends the toggled flag and leaves the later fields unset", () => {
+    const { result } = renderTools();
+    expect(result.current.resolveToolOptions()).toEqual({
+      deepResearch: false,
+      allowedToolIds: null,
+      forcedToolId: null,
+      internalSearchFilters: null,
+    });
+
+    act(() => result.current.toggleDeepResearch());
+    expect(result.current.resolveToolOptions().deepResearch).toBe(true);
+  });
+
+  it("never sends deep research while the control is hidden", () => {
+    const { result } = renderTools({ isProjectWorkflow: true });
+    act(() => result.current.toggleDeepResearch());
+    expect(result.current.resolveToolOptions().deepResearch).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

PR 2 of `docs/mobile-chat/input-bar-controls` — the walking skeleton for the input-bar controls, building on the foundation merged in #13091.

- Adds a Deep Research pill to the mobile composer's left cluster, shown only when the workspace enables deep research and the conversation's agent has a search tool (matching web, including hiding it in the projects workflow).
- Sends the toggle's value with the message — `deep_research` was previously hardcoded `false` on mobile; the remaining tool/source fields stay `null` until the ActionsPopover lands in PR 3/4.
- Guards the toggle and the pill's gate against mobile's transient agent resolution, so a send can't silently clear the control the user just used or re-gate it mid-conversation (mobile has no sticky selected agent the way web does).

## How Has This Been Tested?

18 new jest tests (reset matrix, gating, and the resolved send options); full mobile suite green at 616 tests. Device check of the pill in a real chat is still owed.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check