### PR TITLE
feat(mobile): actions menu — force a tool + enable/disable per agent

### DIFF
--- a/mobile/src/api/chat/agentPreferences.ts
+++ b/mobile/src/api/chat/agentPreferences.ts
@@ -1,0 +1,29 @@
+// Per-user, per-agent tool preferences — the same record web reads, so disabling a tool here
+// disables it there too (intentional).
+import { apiFetch } from "@/api/client";
+
+export interface AgentPreference {
+  disabled_tool_ids: number[];
+}
+
+// Backend types this `dict[int, ...]`, but JSON keys are strings: index with `String(agentId)`.
+export type AgentPreferences = Record<string, AgentPreference>;
+
+export function getAgentPreferences(
+  signal?: AbortSignal,
+): Promise<AgentPreferences | null> {
+  return apiFetch<AgentPreferences | null>("/user/assistant/preferences", {
+    signal,
+  });
+}
+
+// Replaces the row wholesale, and the field is required — always send the full array.
+export function patchAgentPreferences(
+  agentId: number,
+  disabledToolIds: number[],
+): Promise<void> {
+  return apiFetch<void>(`/user/assistant/${agentId}/preferences`, {
+    method: "PATCH",
+    body: { disabled_tool_ids: disabledToolIds },
+  });
+}

--- a/mobile/src/api/query-keys.ts
+++ b/mobile/src/api/query-keys.ts
@@ -15,4 +15,6 @@ export const QUERY_KEYS = {
     ["project", serverUrl, projectId] as const,
   userRecentFiles: (serverUrl: string | null) =>
     ["recent-files", serverUrl] as const,
+  agentPreferences: (serverUrl: string | null) =>
+    ["agent-preferences", serverUrl] as const,
 };

--- a/mobile/src/components/chat/ActionLineItem.tsx
+++ b/mobile/src/components/chat/ActionLineItem.tsx
@@ -1,0 +1,60 @@
+// One tool row in the actions menu. RN port of
+// web/src/refresh-components/popovers/ActionsPopover/ActionLineItem.tsx, minus MCP, OAuth, the
+// admin cog, source counts and the search drill-in.
+import { Button } from "@/components/ui/button";
+import { LineItemButton } from "@/components/ui/line-item-button";
+import { getIconForToolId, type ToolSnapshot } from "@/chat/tools";
+import SvgSlash from "@/icons/slash";
+
+interface ActionLineItemProps {
+  tool: ToolSnapshot;
+  isForced: boolean;
+  // Switched off in this user's agent preferences. The row stays tappable: tapping it re-enables
+  // and forces the tool in one gesture, as web does.
+  isDisabled: boolean;
+  onForceToggle: () => void;
+  onToggleEnabled: () => void;
+  onClose: () => void;
+}
+
+export function ActionLineItem({
+  tool,
+  isForced,
+  isDisabled,
+  onForceToggle,
+  onToggleEnabled,
+  onClose,
+}: ActionLineItemProps) {
+  function handlePress() {
+    if (isDisabled) onToggleEnabled();
+    onForceToggle();
+    onClose();
+  }
+
+  return (
+    <LineItemButton
+      icon={getIconForToolId(tool.in_code_tool_id)}
+      title={tool.display_name || tool.name}
+      titleMaxLines={1}
+      sizePreset="main-ui"
+      variant="section"
+      // Not LineItemButton's `selected`: its tint is background-tint-00, the very token the sheet
+      // surface uses, so a forced row would look identical to an unforced one.
+      className={isForced ? "bg-background-tint-02" : undefined}
+      // Web strikes the label through; mobile's Text/Content have no strikethrough, so an off tool
+      // reads as muted instead.
+      color={isDisabled ? "muted" : "default"}
+      onPress={handlePress}
+      rightChildren={
+        // Web reveals this on row hover; touch has no hover, so it stays visible.
+        <Button
+          icon={SvgSlash}
+          prominence="tertiary"
+          size="sm"
+          accessibilityLabel={isDisabled ? "Enable" : "Disable"}
+          onPress={onToggleEnabled}
+        />
+      }
+    />
+  );
+}

--- a/mobile/src/components/chat/ActionsMenu.tsx
+++ b/mobile/src/components/chat/ActionsMenu.tsx
@@ -2,7 +2,7 @@
 // web/src/refresh-components/popovers/ActionsPopover/index.tsx. Named for the menu, not its
 // container: the container is deliberately swappable (see components/ui/sheet.tsx).
 import { useState } from "react";
-import { ScrollView } from "react-native";
+import { Keyboard, ScrollView } from "react-native";
 
 import { ActionLineItem } from "@/components/chat/ActionLineItem";
 import { Button } from "@/components/ui/button";
@@ -31,7 +31,12 @@ export function ActionsMenu() {
         prominence="tertiary"
         icon={SvgSliders}
         accessibilityLabel="Manage Actions"
-        onPress={() => setOpen(true)}
+        onPress={() => {
+          // The sheet slides up from the same edge the keyboard occupies; leaving it raised
+          // covers the bottom of the list.
+          Keyboard.dismiss();
+          setOpen(true);
+        }}
       />
 
       <Sheet visible={open} onClose={() => setOpen(false)} title="Actions">

--- a/mobile/src/components/chat/ActionsMenu.tsx
+++ b/mobile/src/components/chat/ActionsMenu.tsx
@@ -10,7 +10,7 @@ import { Sheet } from "@/components/ui/sheet";
 import { useComposerTools } from "@/state/ComposerToolsProvider";
 import SvgSliders from "@/icons/sliders";
 
-// An agent rarely has more than a handful of tools; this only bites on the outliers.
+// Caps the list height; an agent rarely has enough tools to reach it.
 const MAX_LIST_HEIGHT = 420;
 
 export function ActionsMenu() {

--- a/mobile/src/components/chat/ActionsMenu.tsx
+++ b/mobile/src/components/chat/ActionsMenu.tsx
@@ -1,0 +1,58 @@
+// The composer's actions menu — force a tool, enable/disable a tool. RN port of
+// web/src/refresh-components/popovers/ActionsPopover/index.tsx. Named for the menu, not its
+// container: the container is deliberately swappable (see components/ui/sheet.tsx).
+import { useState } from "react";
+import { ScrollView } from "react-native";
+
+import { ActionLineItem } from "@/components/chat/ActionLineItem";
+import { Button } from "@/components/ui/button";
+import { Sheet } from "@/components/ui/sheet";
+import { useComposerTools } from "@/state/ComposerToolsProvider";
+import SvgSliders from "@/icons/sliders";
+
+// An agent rarely has more than a handful of tools; this only bites on the outliers.
+const MAX_LIST_HEIGHT = 420;
+
+export function ActionsMenu() {
+  const {
+    actionTools,
+    forcedToolId,
+    toggleForcedTool,
+    disabledToolIds,
+    toggleToolEnabled,
+  } = useComposerTools();
+  const [open, setOpen] = useState(false);
+
+  if (actionTools.length === 0) return null;
+
+  return (
+    <>
+      <Button
+        prominence="tertiary"
+        icon={SvgSliders}
+        accessibilityLabel="Manage Actions"
+        onPress={() => setOpen(true)}
+      />
+
+      <Sheet visible={open} onClose={() => setOpen(false)} title="Actions">
+        <ScrollView
+          style={{ maxHeight: MAX_LIST_HEIGHT }}
+          keyboardShouldPersistTaps="handled"
+          contentContainerClassName="pb-8"
+        >
+          {actionTools.map((tool) => (
+            <ActionLineItem
+              key={tool.id}
+              tool={tool}
+              isForced={forcedToolId === tool.id}
+              isDisabled={disabledToolIds.includes(tool.id)}
+              onForceToggle={() => toggleForcedTool(tool.id)}
+              onToggleEnabled={() => toggleToolEnabled(tool.id)}
+              onClose={() => setOpen(false)}
+            />
+          ))}
+        </ScrollView>
+      </Sheet>
+    </>
+  );
+}

--- a/mobile/src/components/chat/ChatSurface.tsx
+++ b/mobile/src/components/chat/ChatSurface.tsx
@@ -102,13 +102,14 @@ function ChatSurfaceContent({ focus }: { focus: ChatFocus }) {
   // persistent composer.
   const draft = useComposerDraft(`${sessionId ?? "new"}:${projectId ?? ""}`);
 
-  // null while the agent isn't knowable: until the new session reaches the sessions list (or is
-  // hydrated), `liveAgent` falls back to the default agent, which would look like an agent switch
-  // and re-gate the toolbar mid-conversation.
+  // null while the agent isn't knowable: until the session's persona is known (from the list or
+  // from hydration), `liveAgent` falls back to the default agent, which would look like an agent
+  // switch and re-gate the toolbar mid-conversation. `persona_id` is nullable, so a session row
+  // alone is not proof of knowledge.
+  const conversationPersonaKnown =
+    session?.persona_id != null || conversationPersonaId != null;
   const conversationAgent =
-    sessionId == null || session || conversationPersonaId != null
-      ? liveAgent
-      : null;
+    sessionId == null || conversationPersonaKnown ? liveAgent : null;
   // Project chats are always created with the default persona (see `personaId` above), so the tool
   // controls must describe that persona — not whichever agent the sidebar happens to have selected.
   // Otherwise the menu lists another agent's tools and a forced id from it kills the turn

--- a/mobile/src/components/chat/ChatSurface.tsx
+++ b/mobile/src/components/chat/ChatSurface.tsx
@@ -141,6 +141,9 @@ function ChatSurfaceContent({ focus }: { focus: ChatFocus }) {
     if (draft.hasBlockingFiles) return;
     const clearDraft =
       message == null ? draft.consume : draft.consumeAttachments;
+    // Captured before the create await: picking a different agent while it is in flight must not
+    // change what this session is recorded as running on.
+    const sentWithAgent = composerAgent;
     submit(
       message ?? draft.text,
       draft.descriptors,
@@ -148,7 +151,7 @@ function ChatSurfaceContent({ focus }: { focus: ChatFocus }) {
         // `onAccepted` runs only once the session exists — a failed create throws before it — and
         // everything from here to the route change is synchronous. That makes it the one moment
         // we can say "this send created the session", which a null → non-null id alone cannot.
-        if (sessionId == null) composerTools.notePendingSend();
+        if (sessionId == null) composerTools.notePendingSend(sentWithAgent);
         clearDraft();
       },
       composerTools.resolveToolOptions(),

--- a/mobile/src/components/chat/ChatSurface.tsx
+++ b/mobile/src/components/chat/ChatSurface.tsx
@@ -139,13 +139,18 @@ function ChatSurfaceContent({ focus }: { focus: ChatFocus }) {
   // (consumeAttachments), a send clears both.
   const sendWithAttachments = (message?: string) => {
     if (draft.hasBlockingFiles) return;
-    // Lets the tool state distinguish "this send is creating the session" from simply opening an
-    // existing chat — the two look identical from a null → non-null session id alone.
-    if (sessionId == null) composerTools.notePendingSend();
+    const clearDraft =
+      message == null ? draft.consume : draft.consumeAttachments;
     submit(
       message ?? draft.text,
       draft.descriptors,
-      message == null ? draft.consume : draft.consumeAttachments,
+      () => {
+        // `onAccepted` runs only once the session exists — a failed create throws before it — and
+        // everything from here to the route change is synchronous. That makes it the one moment
+        // we can say "this send created the session", which a null → non-null id alone cannot.
+        if (sessionId == null) composerTools.notePendingSend();
+        clearDraft();
+      },
       composerTools.resolveToolOptions(),
     );
   };

--- a/mobile/src/components/chat/ChatSurface.tsx
+++ b/mobile/src/components/chat/ChatSurface.tsx
@@ -139,6 +139,9 @@ function ChatSurfaceContent({ focus }: { focus: ChatFocus }) {
   // (consumeAttachments), a send clears both.
   const sendWithAttachments = (message?: string) => {
     if (draft.hasBlockingFiles) return;
+    // Lets the tool state distinguish "this send is creating the session" from simply opening an
+    // existing chat — the two look identical from a null → non-null session id alone.
+    if (sessionId == null) composerTools.notePendingSend();
     submit(
       message ?? draft.text,
       draft.descriptors,

--- a/mobile/src/components/chat/ChatSurface.tsx
+++ b/mobile/src/components/chat/ChatSurface.tsx
@@ -50,6 +50,7 @@ function ChatSurfaceContent({ focus }: { focus: ChatFocus }) {
   const isProject = focus.kind === "project";
 
   const { sessions } = useChatSessions();
+  const { agents } = useAgents();
   const { agentId: agentIdParam } = useGlobalSearchParams<{
     agentId?: string;
   }>();
@@ -66,18 +67,34 @@ function ChatSurfaceContent({ focus }: { focus: ChatFocus }) {
     Number.isInteger(parsedAgentId) && parsedAgentId >= 0
       ? parsedAgentId
       : null;
-  const liveAgent = useLiveAgent(selectedAgentId, session?.persona_id ?? null);
+  // Which persona a *new* session would be created with. Deliberately resolved without any session
+  // data: it is only read when `sessionId` is null, i.e. when there is no session to describe. That
+  // is what keeps this off the cycle personaId → controller → hydrated persona → liveAgent.
+  const creationAgent = useLiveAgent(selectedAgentId, null);
   // Project chats create with the default agent; new/chat honors the picked one.
   const personaId = isProject
     ? DEFAULT_AGENT_ID
-    : (liveAgent?.id ?? selectedAgentId ?? DEFAULT_AGENT_ID);
-  const isDefaultAgent = personaId === DEFAULT_AGENT_ID;
+    : (creationAgent?.id ?? selectedAgentId ?? DEFAULT_AGENT_ID);
 
-  const { messages, chatState, submit, stop, isHydrating } = useChatController(
-    sessionId,
-    personaId,
-    projectId,
+  const {
+    messages,
+    chatState,
+    submit,
+    stop,
+    isHydrating,
+    conversationPersonaId,
+  } = useChatController(sessionId, personaId, projectId);
+
+  // The agent this conversation actually runs on. The sessions list omits project chats, so the
+  // hydrated persona is the fallback authority — without it a project chat can never name its agent.
+  const liveAgent = useLiveAgent(
+    selectedAgentId,
+    session?.persona_id ?? conversationPersonaId,
   );
+  // Pairs with `liveAgent` in ChatEmptyState, so it describes the agent on screen rather than the
+  // one a new session would be created with.
+  const isDefaultAgent =
+    (liveAgent?.id ?? selectedAgentId ?? DEFAULT_AGENT_ID) === DEFAULT_AGENT_ID;
   // re-attaches to an in-flight run when opened cold
   useChatSessionController(sessionId);
 
@@ -85,18 +102,28 @@ function ChatSurfaceContent({ focus }: { focus: ChatFocus }) {
   // persistent composer.
   const draft = useComposerDraft(`${sessionId ?? "new"}:${projectId ?? ""}`);
 
-  // null while the agent isn't knowable: until the new session reaches the sessions list,
-  // `liveAgent` falls back to the default agent, which would look like an agent switch and re-gate
-  // the toolbar mid-conversation.
-  const conversationAgent = sessionId == null || session ? liveAgent : null;
+  // null while the agent isn't knowable: until the new session reaches the sessions list (or is
+  // hydrated), `liveAgent` falls back to the default agent, which would look like an agent switch
+  // and re-gate the toolbar mid-conversation.
+  const conversationAgent =
+    sessionId == null || session || conversationPersonaId != null
+      ? liveAgent
+      : null;
+  // Project chats are always created with the default persona (see `personaId` above), so the tool
+  // controls must describe that persona — not whichever agent the sidebar happens to have selected.
+  // Otherwise the menu lists another agent's tools and a forced id from it kills the turn
+  // server-side ("Forced tool N not found in tools").
+  const composerAgent = isProject
+    ? (agents.find((candidate) => candidate.id === personaId) ?? null)
+    : conversationAgent;
   const composerTools = useComposerToolsState({
     chatSessionId: sessionId,
-    agent: conversationAgent,
+    agent: composerAgent,
     isProjectWorkflow: isProject,
+    projectId,
   });
 
   const { data: details, isLoading } = useProjectDetails(projectId);
-  const { agents } = useAgents();
   const chats = details?.project?.chat_sessions ?? [];
 
   const title = isProject

--- a/mobile/src/components/chat/CitedSources.tsx
+++ b/mobile/src/components/chat/CitedSources.tsx
@@ -1,17 +1,15 @@
 // The cited-sources surface: a "Sources · N" button under a completed answer, and the bottom-sheet
-// list it opens (mirrors web's mobile DocumentsSidebar Modal). Sections: Cited / More / User Files.
-import { Modal, Pressable, ScrollView, View } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+// list it opens (mirrors web's mobile DocumentsSidebar). Sections: Cited / More / User Files.
+import { Pressable, ScrollView, View } from "react-native";
 
 import { SelectedSources } from "@/chat/citations";
 import { SearchDoc } from "@/chat/contracts/documents";
 import { openSource } from "@/chat/openSource";
 import { SourceIcon } from "@/components/chat/SourceIcon";
 import { SourceRow } from "@/components/chat/SourceRow";
-import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import { Sheet } from "@/components/ui/sheet";
 import { Text } from "@/components/ui/text";
-import SvgX from "@/icons/x";
 
 interface CitedSourcesBarProps {
   iconDocs: SearchDoc[];
@@ -61,7 +59,6 @@ export function CitedSourcesSheet({
   onClose,
   sources,
 }: CitedSourcesSheetProps) {
-  const insets = useSafeAreaInsets();
   const { cited, more, files } = sources;
 
   const sections = [
@@ -71,62 +68,28 @@ export function CitedSourcesSheet({
   ].filter((section) => section.docs.length > 0);
 
   return (
-    <Modal
-      visible={visible}
-      transparent
-      animationType="slide"
-      onRequestClose={onClose}
-      statusBarTranslucent
-    >
-      {/* Semantic color tokens can't express translucency (bare CSS vars, no alpha channel), so the
-          dimming scrim uses a raw rgba — the one place a non-token color is warranted. */}
-      <Pressable
-        className="flex-1 justify-end"
-        style={{ backgroundColor: "rgba(0, 0, 0, 0.4)" }}
-        onPress={onClose}
+    <Sheet visible={visible} onClose={onClose} title="Sources">
+      <ScrollView
+        className="max-h-[420px]"
+        keyboardShouldPersistTaps="handled"
+        contentContainerClassName="gap-12 pb-8"
       >
-        {/* Stop taps inside the sheet from dismissing it. */}
-        <Pressable
-          onPress={() => {}}
-          className="rounded-t-20 border-t border-border-01 bg-background-tint-00 px-16 pt-16"
-          style={{ paddingBottom: insets.bottom + 16 }}
-        >
-          <View className="mb-8 flex-row items-center justify-between">
-            <Text font="main-content-emphasis" color="text-04">
-              Sources
+        {sections.map((section, index) => (
+          <View key={section.title} className="gap-8">
+            {index > 0 ? <Separator /> : null}
+            <Text font="secondary-body" color="text-02">
+              {section.title}
             </Text>
-            <Button
-              icon={SvgX}
-              prominence="tertiary"
-              size="sm"
-              accessibilityLabel="Close"
-              onPress={onClose}
-            />
-          </View>
-
-          <ScrollView
-            className="max-h-[420px]"
-            keyboardShouldPersistTaps="handled"
-            contentContainerClassName="gap-12 pb-8"
-          >
-            {sections.map((section, index) => (
-              <View key={section.title} className="gap-8">
-                {index > 0 ? <Separator /> : null}
-                <Text font="secondary-body" color="text-02">
-                  {section.title}
-                </Text>
-                {section.docs.map((doc) => (
-                  <SourceRow
-                    key={doc.document_id}
-                    doc={doc}
-                    onPress={() => openSource(doc)}
-                  />
-                ))}
-              </View>
+            {section.docs.map((doc) => (
+              <SourceRow
+                key={doc.document_id}
+                doc={doc}
+                onPress={() => openSource(doc)}
+              />
             ))}
-          </ScrollView>
-        </Pressable>
-      </Pressable>
-    </Modal>
+          </View>
+        ))}
+      </ScrollView>
+    </Sheet>
   );
 }

--- a/mobile/src/components/chat/FilePickerSheet.tsx
+++ b/mobile/src/components/chat/FilePickerSheet.tsx
@@ -1,10 +1,9 @@
 import { useRef } from "react";
-import { Modal, Platform, Pressable, ScrollView, View } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Platform, ScrollView, View } from "react-native";
 
-import { Button } from "@/components/ui/button";
 import { LineItemButton } from "@/components/ui/line-item-button";
 import { Separator } from "@/components/ui/separator";
+import { Sheet } from "@/components/ui/sheet";
 import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/text";
 import {
@@ -16,7 +15,6 @@ import { extensionOf, isImageName } from "@/lib/files";
 import SvgFileText from "@/icons/file-text";
 import SvgImage from "@/icons/image";
 import SvgUploadSquare from "@/icons/upload-square";
-import SvgX from "@/icons/x";
 
 interface FilePickerSheetProps {
   visible: boolean;
@@ -39,8 +37,6 @@ export function FilePickerSheet({
   onPickRecent,
   isLoadingRecent,
 }: FilePickerSheetProps) {
-  const insets = useSafeAreaInsets();
-
   // iOS drops a picker presented while this Modal is still dismissing, so defer the action to
   // onDismiss (after the sheet is gone); Android has no such conflict and runs immediately.
   const pendingRef = useRef<(() => void) | null>(null);
@@ -51,114 +47,83 @@ export function FilePickerSheet({
   };
 
   return (
-    <Modal
+    <Sheet
       visible={visible}
-      transparent
-      animationType="slide"
-      onRequestClose={onClose}
+      onClose={onClose}
+      title="Add files"
       onDismiss={() => {
         const action = pendingRef.current;
         pendingRef.current = null;
         action?.();
       }}
-      statusBarTranslucent
     >
-      {/* Semantic color tokens can't express translucency (bare CSS vars, no alpha channel), so the
-          dimming scrim uses a raw rgba — the one place a non-token color is warranted. */}
-      <Pressable
-        className="flex-1 justify-end"
-        style={{ backgroundColor: "rgba(0, 0, 0, 0.4)" }}
-        onPress={onClose}
-      >
-        {/* Stop taps inside the sheet from dismissing it. */}
-        <Pressable
-          onPress={() => {}}
-          className="rounded-t-20 border-t border-border-01 bg-background-tint-00 px-16 pt-16"
-          style={{ paddingBottom: insets.bottom + 16 }}
-        >
-          <View className="mb-8 flex-row items-center justify-between">
-            <Text font="main-content-emphasis" color="text-04">
-              Add files
-            </Text>
-            <Button
-              icon={SvgX}
-              prominence="tertiary"
-              size="sm"
-              accessibilityLabel="Close"
-              onPress={onClose}
-            />
-          </View>
+      <LineItemButton
+        icon={SvgUploadSquare}
+        title="Upload from device"
+        description="Documents, text, PDFs"
+        sizePreset="main-ui"
+        variant="section"
+        onPress={() => choose(onUploadDocuments)}
+      />
+      <LineItemButton
+        icon={SvgImage}
+        title="Choose photos"
+        description="From your photo library"
+        sizePreset="main-ui"
+        variant="section"
+        onPress={() => choose(onUploadPhotos)}
+      />
 
-          <LineItemButton
-            icon={SvgUploadSquare}
-            title="Upload from device"
-            description="Documents, text, PDFs"
-            sizePreset="main-ui"
-            variant="section"
-            onPress={() => choose(onUploadDocuments)}
-          />
-          <LineItemButton
-            icon={SvgImage}
-            title="Choose photos"
-            description="From your photo library"
-            sizePreset="main-ui"
-            variant="section"
-            onPress={() => choose(onUploadPhotos)}
-          />
+      <View className="py-8">
+        <Separator />
+      </View>
 
-          <View className="py-8">
-            <Separator />
-          </View>
+      <Text font="secondary-body" color="text-02" className="px-8 pb-4">
+        Recent files
+      </Text>
 
-          <Text font="secondary-body" color="text-02" className="px-8 pb-4">
-            Recent files
+      {isLoadingRecent && recentFiles.length === 0 ? (
+        <View className="items-center py-16">
+          <Spinner size={20} />
+        </View>
+      ) : recentFiles.length === 0 ? (
+        <View className="px-8 py-12">
+          <Text font="secondary-body" color="text-02">
+            No recent files to add.
           </Text>
-
-          {isLoadingRecent && recentFiles.length === 0 ? (
-            <View className="items-center py-16">
-              <Spinner size={20} />
-            </View>
-          ) : recentFiles.length === 0 ? (
-            <View className="px-8 py-12">
-              <Text font="secondary-body" color="text-02">
-                No recent files to add.
-              </Text>
-            </View>
-          ) : (
-            <ScrollView
-              className="max-h-[280px]"
-              keyboardShouldPersistTaps="handled"
-            >
-              {recentFiles.map((file) => {
-                const processing = isProcessingStatus(file.status);
-                const uploading =
-                  String(file.status).toUpperCase() ===
-                  UserFileStatus.UPLOADING;
-                return (
-                  <LineItemButton
-                    key={file.id}
-                    leading={processing ? <Spinner size={16} /> : undefined}
-                    icon={isImageName(file.name) ? SvgImage : SvgFileText}
-                    title={file.name}
-                    description={
-                      uploading
-                        ? "Uploading…"
-                        : processing
-                          ? "Indexing…"
-                          : extensionOf(file.name) || "File"
-                    }
-                    titleMaxLines={1}
-                    sizePreset="main-ui"
-                    variant="section"
-                    disabled={uploading}
-                    onPress={() => choose(() => onPickRecent(file.id))}
-                  />
-                );
-              })}
-            </ScrollView>
-          )}
-        </Pressable>
-      </Pressable>
-    </Modal>
+        </View>
+      ) : (
+        <ScrollView
+          className="max-h-[280px]"
+          keyboardShouldPersistTaps="handled"
+        >
+          {recentFiles.map((file) => {
+            const processing = isProcessingStatus(file.status);
+            const uploading =
+              String(file.status).toUpperCase() === UserFileStatus.UPLOADING;
+            return (
+              <LineItemButton
+                key={file.id}
+                leading={processing ? <Spinner size={16} /> : undefined}
+                icon={isImageName(file.name) ? SvgImage : SvgFileText}
+                title={file.name}
+                description={
+                  uploading
+                    ? "Uploading…"
+                    : processing
+                      ? "Indexing…"
+                      : extensionOf(file.name) || "File"
+                }
+                titleMaxLines={1}
+                sizePreset="main-ui"
+                variant="section"
+                disabled={uploading}
+                onPress={() => choose(() => onPickRecent(file.id))}
+              />
+            );
+          })}
+        </ScrollView>
+      )}
+    </Sheet>
   );
 }

--- a/mobile/src/components/chat/InputBar.tsx
+++ b/mobile/src/components/chat/InputBar.tsx
@@ -118,7 +118,9 @@ export function InputBar({
         ) : null}
 
         <View className="min-h-40 flex-row items-center justify-between p-4">
-          <View className="flex-row items-center gap-8">
+          {/* `min-w-0 shrink` so a long forced-tool pill compresses instead of pushing the send
+              cluster past the card's right edge — RN defaults flexShrink to 0. */}
+          <View className="min-w-0 shrink flex-row items-center gap-8">
             <Button
               prominence="tertiary"
               icon={SvgPaperclip}

--- a/mobile/src/components/chat/ToolbarControls.tsx
+++ b/mobile/src/components/chat/ToolbarControls.tsx
@@ -32,7 +32,7 @@ export function ToolbarControls() {
   // `SelectButton`'s `self-start` would top-align the 28px pill against the 36px paperclip;
   // hugging it here keeps the row centered.
   return (
-    <View className="flex-row items-center gap-8">
+    <View className="min-w-0 shrink flex-row items-center gap-8">
       <ActionsMenu />
 
       {showDeepResearch ? (

--- a/mobile/src/components/chat/ToolbarControls.tsx
+++ b/mobile/src/components/chat/ToolbarControls.tsx
@@ -39,7 +39,6 @@ export function ToolbarControls() {
         <SelectButton
           icon={SvgHourglass}
           state={deepResearchEnabled ? "selected" : "empty"}
-          // folded = label hidden
           foldable={!deepResearchEnabled}
           onPress={toggleDeepResearch}
           accessibilityLabel="Deep Research"

--- a/mobile/src/components/chat/ToolbarControls.tsx
+++ b/mobile/src/components/chat/ToolbarControls.tsx
@@ -2,30 +2,67 @@
 // (web/src/sections/input/AppInputBar.tsx).
 import { View } from "react-native";
 
+import { ActionsMenu } from "@/components/chat/ActionsMenu";
 import { SelectButton } from "@/components/ui/select-button";
+import { getIconForToolId } from "@/chat/tools";
 import { useComposerTools } from "@/state/ComposerToolsProvider";
 import SvgHourglass from "@/icons/hourglass";
 
+// Leaves room for the actions trigger, the deep-research pill and the send cluster on the
+// narrowest supported phone.
+const FORCED_PILL_MAX_WIDTH = 132;
+
 export function ToolbarControls() {
-  const { showDeepResearch, deepResearchEnabled, toggleDeepResearch } =
-    useComposerTools();
+  const {
+    showDeepResearch,
+    deepResearchEnabled,
+    toggleDeepResearch,
+    actionTools,
+    forcedToolId,
+    toggleForcedTool,
+    disabledToolIds,
+  } = useComposerTools();
 
-  if (!showDeepResearch) return null;
+  // A forced tool that is switched off is never sent, so its pill would advertise a control the
+  // request ignores.
+  const forcedTool = actionTools.find(
+    (tool) => tool.id === forcedToolId && !disabledToolIds.includes(tool.id),
+  );
 
-  // Wrapper: `SelectButton`'s `self-start` would top-align the 28px pill against the 36px
-  // paperclip; hugging it here keeps the row centered.
+  // `SelectButton`'s `self-start` would top-align the 28px pill against the 36px paperclip;
+  // hugging it here keeps the row centered.
   return (
-    <View className="flex-row items-center">
-      <SelectButton
-        icon={SvgHourglass}
-        state={deepResearchEnabled ? "selected" : "empty"}
-        // folded = label hidden
-        foldable={!deepResearchEnabled}
-        onPress={toggleDeepResearch}
-        accessibilityLabel="Deep Research"
-      >
-        Deep Research
-      </SelectButton>
+    <View className="flex-row items-center gap-8">
+      <ActionsMenu />
+
+      {showDeepResearch ? (
+        <SelectButton
+          icon={SvgHourglass}
+          state={deepResearchEnabled ? "selected" : "empty"}
+          // folded = label hidden
+          foldable={!deepResearchEnabled}
+          onPress={toggleDeepResearch}
+          accessibilityLabel="Deep Research"
+        >
+          Deep Research
+        </SelectButton>
+      ) : null}
+
+      {/* Kept outside the menu, as web does, so the force can be released in one tap. Capped
+          because Yoga defaults flexShrink to 0: a long tool name would otherwise push the send
+          button off the composer card. */}
+      {forcedTool ? (
+        <View className="shrink" style={{ maxWidth: FORCED_PILL_MAX_WIDTH }}>
+          <SelectButton
+            icon={getIconForToolId(forcedTool.in_code_tool_id)}
+            state="selected"
+            onPress={() => toggleForcedTool(forcedTool.id)}
+            accessibilityLabel={`${forcedTool.display_name || forcedTool.name} (forced)`}
+          >
+            {forcedTool.display_name || forcedTool.name}
+          </SelectButton>
+        </View>
+      ) : null}
     </View>
   );
 }

--- a/mobile/src/components/chat/__tests__/ActionLineItem.test.tsx
+++ b/mobile/src/components/chat/__tests__/ActionLineItem.test.tsx
@@ -1,0 +1,89 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import { ActionLineItem } from "@/components/chat/ActionLineItem";
+import { SEARCH_TOOL_ID, type ToolSnapshot } from "@/chat/tools";
+
+const tool: ToolSnapshot = {
+  id: 1,
+  name: "internal_search",
+  display_name: "Search",
+  description: "",
+  in_code_tool_id: SEARCH_TOOL_ID,
+  mcp_server_id: null,
+  chat_selectable: true,
+};
+
+function renderRow(
+  overrides: Partial<React.ComponentProps<typeof ActionLineItem>> = {},
+) {
+  const props = {
+    tool,
+    isForced: false,
+    isDisabled: false,
+    onForceToggle: jest.fn(),
+    onToggleEnabled: jest.fn(),
+    onClose: jest.fn(),
+    ...overrides,
+  };
+  const view = render(<ActionLineItem {...props} />);
+  return { ...props, toJSON: view.toJSON };
+}
+
+describe("ActionLineItem", () => {
+  it("labels the row with the tool's display name", () => {
+    renderRow();
+    expect(screen.getByText("Search")).toBeTruthy();
+  });
+
+  it("falls back to the raw name when there is no display name", () => {
+    renderRow({ tool: { ...tool, display_name: "" } });
+    expect(screen.getByText("internal_search")).toBeTruthy();
+  });
+
+  it("forces the tool and closes the menu on row press", () => {
+    const props = renderRow();
+    fireEvent.press(screen.getByText("Search"));
+
+    expect(props.onForceToggle).toHaveBeenCalledTimes(1);
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+    expect(props.onToggleEnabled).not.toHaveBeenCalled();
+  });
+
+  it("re-enables and forces in one gesture when the tool is switched off", () => {
+    const props = renderRow({ isDisabled: true });
+    fireEvent.press(screen.getByText("Search"));
+
+    expect(props.onToggleEnabled).toHaveBeenCalledTimes(1);
+    expect(props.onForceToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a forced row differently from an unforced one", () => {
+    // LineItemButton's own `selected` tint is background-tint-00, the very token the sheet surface
+    // uses, so a row styled that way would be pixel-identical to an unforced one.
+    const unforced = renderRow({ isForced: false }).toJSON();
+    const forced = renderRow({ isForced: true }).toJSON();
+
+    expect(JSON.stringify(forced)).not.toEqual(JSON.stringify(unforced));
+  });
+
+  it("offers Disable while the tool is on", () => {
+    renderRow();
+    expect(screen.getByLabelText("Disable")).toBeTruthy();
+    expect(screen.queryByLabelText("Enable")).toBeNull();
+  });
+
+  it("offers Enable while the tool is off", () => {
+    renderRow({ isDisabled: true });
+    expect(screen.getByLabelText("Enable")).toBeTruthy();
+  });
+
+  it("only toggles enablement when the trailing control is pressed", () => {
+    const props = renderRow();
+    fireEvent.press(screen.getByLabelText("Disable"));
+
+    expect(props.onToggleEnabled).toHaveBeenCalledTimes(1);
+    expect(props.onForceToggle).not.toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/components/chat/__tests__/ActionsMenu.test.tsx
+++ b/mobile/src/components/chat/__tests__/ActionsMenu.test.tsx
@@ -79,8 +79,11 @@ describe("ActionsMenu", () => {
     renderMenu();
     fireEvent.press(screen.getByLabelText("Manage Actions"));
 
-    expect(screen.getByText("Search")).toBeTruthy();
-    expect(screen.getByText("Generate Image")).toBeTruthy();
+    // An ordered exact match, so a duplicated or reordered row fails here.
+    const labels = screen
+      .getAllByText(/^(Search|Generate Image)$/)
+      .map((node) => node.props.children);
+    expect(labels).toEqual(["Search", "Generate Image"]);
   });
 
   it("forces the tapped tool and closes", () => {

--- a/mobile/src/components/chat/__tests__/ActionsMenu.test.tsx
+++ b/mobile/src/components/chat/__tests__/ActionsMenu.test.tsx
@@ -48,6 +48,7 @@ function renderMenu(overrides: Partial<ComposerTools> = {}) {
     toggleForcedTool: jest.fn(),
     disabledToolIds: [],
     toggleToolEnabled: jest.fn(),
+    notePendingSend: jest.fn(),
     resolveToolOptions: () => ({
       deepResearch: false,
       allowedToolIds: null,

--- a/mobile/src/components/chat/__tests__/ActionsMenu.test.tsx
+++ b/mobile/src/components/chat/__tests__/ActionsMenu.test.tsx
@@ -1,0 +1,103 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import { ActionsMenu } from "@/components/chat/ActionsMenu";
+import { SEARCH_TOOL_ID, type ToolSnapshot } from "@/chat/tools";
+import {
+  ComposerToolsProvider,
+  type ComposerTools,
+} from "@/state/ComposerToolsProvider";
+
+// The provider reaches MMKV via the settings/preferences APIs, which jest can't load; this suite
+// only needs the context.
+jest.mock("@/api/settings", () => ({ useWorkspaceSettings: jest.fn() }));
+jest.mock("@/hooks/useAgentPreferences", () => ({
+  useAgentPreferences: jest.fn(),
+}));
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+const searchTool: ToolSnapshot = {
+  id: 1,
+  name: "internal_search",
+  display_name: "Search",
+  description: "",
+  in_code_tool_id: SEARCH_TOOL_ID,
+  mcp_server_id: null,
+  chat_selectable: true,
+};
+
+const imageTool: ToolSnapshot = {
+  id: 2,
+  name: "generate_image",
+  display_name: "Generate Image",
+  description: "",
+  in_code_tool_id: null,
+  mcp_server_id: null,
+  chat_selectable: true,
+};
+
+function renderMenu(overrides: Partial<ComposerTools> = {}) {
+  const value: ComposerTools = {
+    showDeepResearch: false,
+    deepResearchEnabled: false,
+    toggleDeepResearch: jest.fn(),
+    actionTools: [searchTool, imageTool],
+    forcedToolId: null,
+    toggleForcedTool: jest.fn(),
+    disabledToolIds: [],
+    toggleToolEnabled: jest.fn(),
+    resolveToolOptions: () => ({
+      deepResearch: false,
+      allowedToolIds: null,
+      forcedToolId: null,
+      internalSearchFilters: null,
+    }),
+    ...overrides,
+  };
+  render(
+    <ComposerToolsProvider value={value}>
+      <ActionsMenu />
+    </ComposerToolsProvider>,
+  );
+  return value;
+}
+
+describe("ActionsMenu", () => {
+  it("renders nothing when the agent exposes no selectable tools", () => {
+    renderMenu({ actionTools: [] });
+    expect(screen.queryByLabelText("Manage Actions")).toBeNull();
+  });
+
+  it("keeps the tool list closed until the trigger is pressed", () => {
+    renderMenu();
+    expect(screen.queryByText("Search")).toBeNull();
+  });
+
+  it("lists every tool once opened, in agent order", () => {
+    renderMenu();
+    fireEvent.press(screen.getByLabelText("Manage Actions"));
+
+    expect(screen.getByText("Search")).toBeTruthy();
+    expect(screen.getByText("Generate Image")).toBeTruthy();
+  });
+
+  it("forces the tapped tool and closes", () => {
+    const value = renderMenu();
+    fireEvent.press(screen.getByLabelText("Manage Actions"));
+    fireEvent.press(screen.getByText("Generate Image"));
+
+    expect(value.toggleForcedTool).toHaveBeenCalledWith(2);
+    expect(screen.queryByText("Generate Image")).toBeNull();
+  });
+
+  it("routes the trailing control to the enable/disable toggle", () => {
+    const value = renderMenu({ disabledToolIds: [2] });
+    fireEvent.press(screen.getByLabelText("Manage Actions"));
+
+    // Search is on → "Disable"; Generate Image is off → "Enable".
+    fireEvent.press(screen.getByLabelText("Enable"));
+    expect(value.toggleToolEnabled).toHaveBeenCalledWith(2);
+  });
+});

--- a/mobile/src/components/chat/__tests__/ToolbarControls.test.tsx
+++ b/mobile/src/components/chat/__tests__/ToolbarControls.test.tsx
@@ -39,6 +39,7 @@ function renderControls(overrides: Partial<ComposerTools> = {}) {
     toggleForcedTool: jest.fn(),
     disabledToolIds: [],
     toggleToolEnabled: jest.fn(),
+    notePendingSend: jest.fn(),
     resolveToolOptions: () => ({
       deepResearch: false,
       allowedToolIds: null,

--- a/mobile/src/components/chat/__tests__/ToolbarControls.test.tsx
+++ b/mobile/src/components/chat/__tests__/ToolbarControls.test.tsx
@@ -2,20 +2,43 @@ import { describe, expect, it, jest } from "@jest/globals";
 import { fireEvent, render, screen } from "@testing-library/react-native";
 
 import { ToolbarControls } from "@/components/chat/ToolbarControls";
+import { SEARCH_TOOL_ID, type ToolSnapshot } from "@/chat/tools";
 import {
   ComposerToolsProvider,
   type ComposerTools,
 } from "@/state/ComposerToolsProvider";
 
-// The provider module pulls in the settings API (→ MMKV, no native binary under jest); this suite
-// only uses the context.
+// The provider reaches MMKV via the settings/preferences APIs, which jest can't load; this suite
+// only needs the context.
 jest.mock("@/api/settings", () => ({ useWorkspaceSettings: jest.fn() }));
+jest.mock("@/hooks/useAgentPreferences", () => ({
+  useAgentPreferences: jest.fn(),
+}));
+// ActionsMenu mounts the sheet shell even while closed.
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+const searchTool: ToolSnapshot = {
+  id: 1,
+  name: "internal_search",
+  display_name: "Search",
+  description: "",
+  in_code_tool_id: SEARCH_TOOL_ID,
+  mcp_server_id: null,
+  chat_selectable: true,
+};
 
 function renderControls(overrides: Partial<ComposerTools> = {}) {
   const value: ComposerTools = {
     showDeepResearch: true,
     deepResearchEnabled: false,
     toggleDeepResearch: jest.fn(),
+    actionTools: [],
+    forcedToolId: null,
+    toggleForcedTool: jest.fn(),
+    disabledToolIds: [],
+    toggleToolEnabled: jest.fn(),
     resolveToolOptions: () => ({
       deepResearch: false,
       allowedToolIds: null,
@@ -57,5 +80,46 @@ describe("ToolbarControls", () => {
     const value = renderControls();
     fireEvent.press(screen.getByLabelText("Deep Research"));
     expect(value.toggleDeepResearch).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the actions trigger when the agent has no selectable tools", () => {
+    renderControls({ actionTools: [] });
+    expect(screen.queryByLabelText("Manage Actions")).toBeNull();
+  });
+
+  it("shows the actions trigger once the agent has selectable tools", () => {
+    renderControls({ actionTools: [searchTool] });
+    expect(screen.getByLabelText("Manage Actions")).toBeTruthy();
+  });
+
+  it("shows no forced pill when nothing is forced", () => {
+    renderControls({ actionTools: [searchTool] });
+    expect(screen.queryByLabelText("Search (forced)")).toBeNull();
+  });
+
+  it("shows a labelled forced pill and releases the force on press", () => {
+    const value = renderControls({
+      actionTools: [searchTool],
+      forcedToolId: 1,
+    });
+    const pill = screen.getByLabelText("Search (forced)");
+    expect(pill.props.accessibilityState.selected).toBe(true);
+
+    fireEvent.press(pill);
+    expect(value.toggleForcedTool).toHaveBeenCalledWith(1);
+  });
+
+  it("ignores a forced id the current agent doesn't expose", () => {
+    renderControls({ actionTools: [searchTool], forcedToolId: 99 });
+    expect(screen.queryByLabelText("Search (forced)")).toBeNull();
+  });
+
+  it("hides the pill for a forced tool that is switched off, matching what gets sent", () => {
+    renderControls({
+      actionTools: [searchTool],
+      forcedToolId: 1,
+      disabledToolIds: [1],
+    });
+    expect(screen.queryByLabelText("Search (forced)")).toBeNull();
   });
 });

--- a/mobile/src/components/chat/timeline/ReasoningTextSheet.tsx
+++ b/mobile/src/components/chat/timeline/ReasoningTextSheet.tsx
@@ -1,22 +1,15 @@
-// Web's ExpandableTextDisplay modal, on the same RN Modal + ScrollView bottom sheet as 9a's
-// CitedSourcesSheet. Download is dropped (no mobile analog for a .txt download); Copy is labelled
-// rather than icon-only because mobile has no tooltip to explain a bare glyph.
+// Web's ExpandableTextDisplay modal, on the shared bottom-sheet shell. Download is dropped (no
+// mobile analog for a .txt download); Copy is labelled rather than icon-only because mobile has no
+// tooltip to explain a bare glyph.
 import * as Clipboard from "expo-clipboard";
-import {
-  Modal,
-  Pressable,
-  ScrollView,
-  useWindowDimensions,
-  View,
-} from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { ScrollView, useWindowDimensions, View } from "react-native";
 
 import { countLines, formatContentSize } from "@/chat/timeline/textStats";
 import { StreamingMarkdown } from "@/components/chat/StreamingMarkdown";
 import { Button } from "@/components/ui/button";
+import { Sheet } from "@/components/ui/sheet";
 import { Text } from "@/components/ui/text";
 import { toast } from "@/hooks/useToast";
-import SvgX from "@/icons/x";
 
 // Reasoning is long-form prose, so the body takes most of the screen — unlike 9a's Sources sheet,
 // which wraps a short list. Capping the body (not the sheet) keeps a short reasoning sheet
@@ -35,7 +28,6 @@ export function ReasoningTextSheet({
   onClose,
   content,
 }: ReasoningTextSheetProps) {
-  const insets = useSafeAreaInsets();
   const { height: screenHeight } = useWindowDimensions();
   const lineCount = countLines(content);
 
@@ -45,68 +37,35 @@ export function ReasoningTextSheet({
   }
 
   return (
-    <Modal
+    <Sheet
       visible={visible}
-      transparent
-      animationType="slide"
-      onRequestClose={onClose}
-      statusBarTranslucent
+      onClose={onClose}
+      title="Full text"
+      subtitle={formatContentSize(content)}
     >
-      {/* Semantic tokens are bare CSS vars with no alpha, so the dimming scrim needs a raw rgba. */}
-      <Pressable
-        className="flex-1 justify-end"
-        style={{ backgroundColor: "rgba(0, 0, 0, 0.4)" }}
-        onPress={onClose}
+      <ScrollView
+        style={{
+          maxHeight: Math.round(screenHeight * BODY_MAX_SCREEN_FRACTION),
+        }}
+        keyboardShouldPersistTaps="handled"
+        contentContainerClassName="pb-8"
       >
-        {/* Stop taps inside the sheet from dismissing it. */}
-        <Pressable
-          onPress={() => {}}
-          className="rounded-t-20 border-t border-border-01 bg-background-tint-00 px-16 pt-16"
-          style={{ paddingBottom: insets.bottom + 16 }}
-        >
-          <View className="mb-8 flex-row items-start justify-between">
-            <View className="flex-1">
-              <Text font="main-content-emphasis" color="text-04">
-                Full text
-              </Text>
-              <Text font="secondary-body" color="text-03">
-                {formatContentSize(content)}
-              </Text>
-            </View>
-            <Button
-              icon={SvgX}
-              prominence="tertiary"
-              size="sm"
-              accessibilityLabel="Close"
-              onPress={onClose}
-            />
-          </View>
+        <StreamingMarkdown
+          content={content}
+          isStreaming={false}
+          variant="muted"
+        />
+      </ScrollView>
 
-          <ScrollView
-            style={{
-              maxHeight: Math.round(screenHeight * BODY_MAX_SCREEN_FRACTION),
-            }}
-            keyboardShouldPersistTaps="handled"
-            contentContainerClassName="pb-8"
-          >
-            <StreamingMarkdown
-              content={content}
-              isStreaming={false}
-              variant="muted"
-            />
-          </ScrollView>
-
-          <View className="mt-8 flex-row items-center justify-between">
-            <Text font="main-ui-muted" color="text-03">
-              {lineCount} {lineCount === 1 ? "line" : "lines"}
-            </Text>
-            <Button prominence="tertiary" size="sm" onPress={handleCopy}>
-              Copy
-            </Button>
-          </View>
-        </Pressable>
-      </Pressable>
-    </Modal>
+      <View className="mt-8 flex-row items-center justify-between">
+        <Text font="main-ui-muted" color="text-03">
+          {lineCount} {lineCount === 1 ? "line" : "lines"}
+        </Text>
+        <Button prominence="tertiary" size="sm" onPress={handleCopy}>
+          Copy
+        </Button>
+      </View>
+    </Sheet>
   );
 }
 

--- a/mobile/src/components/ui/__tests__/sheet.test.tsx
+++ b/mobile/src/components/ui/__tests__/sheet.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import { Sheet } from "@/components/ui/sheet";
+import { Text } from "@/components/ui/text";
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+function renderSheet(
+  overrides: Partial<React.ComponentProps<typeof Sheet>> = {},
+) {
+  const props = {
+    visible: true,
+    onClose: jest.fn(),
+    title: "Actions",
+    children: <Text>Body</Text>,
+    ...overrides,
+  };
+  const view = render(<Sheet {...props} />);
+  return { ...props, toJSON: view.toJSON };
+}
+
+// Every `accessible` prop in the rendered tree, outermost first.
+function accessibleFlags(node: unknown): boolean[] {
+  if (node == null || typeof node !== "object") return [];
+  const element = node as {
+    props?: Record<string, unknown>;
+    children?: unknown[];
+  };
+  const own =
+    typeof element.props?.accessible === "boolean"
+      ? [element.props.accessible]
+      : [];
+  const nested = (element.children ?? []).flatMap(accessibleFlags);
+  return [...own, ...nested];
+}
+
+describe("Sheet", () => {
+  it("renders its title and body", () => {
+    renderSheet();
+    expect(screen.getByText("Actions")).toBeTruthy();
+    expect(screen.getByText("Body")).toBeTruthy();
+  });
+
+  it("omits the subtitle unless one is given", () => {
+    renderSheet();
+    expect(screen.queryByText("2.4 KB")).toBeNull();
+
+    renderSheet({ subtitle: "2.4 KB" });
+    expect(screen.getByText("2.4 KB")).toBeTruthy();
+  });
+
+  it("closes from the header button", () => {
+    const props = renderSheet();
+    fireEvent.press(screen.getByLabelText("Close"));
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps its wrappers out of the accessibility tree", () => {
+    // Pressable defaults `accessible` to true, and a view that is an accessibility element hides
+    // its descendants from VoiceOver — the sheet would be read as one blob with Close unreachable.
+    const flags = accessibleFlags(renderSheet().toJSON());
+
+    // The two outermost are the scrim and the card.
+    expect(flags.slice(0, 2)).toEqual([false, false]);
+    // …and a real control inside them stays reachable.
+    expect(screen.getByLabelText("Close")).toBeTruthy();
+  });
+
+  it("paints the gray card differently from the default one", () => {
+    const standard = renderSheet().toJSON();
+    const gray = renderSheet({ background: "gray" }).toJSON();
+
+    expect(JSON.stringify(gray)).not.toEqual(JSON.stringify(standard));
+  });
+});

--- a/mobile/src/components/ui/sheet.tsx
+++ b/mobile/src/components/ui/sheet.tsx
@@ -33,7 +33,6 @@ interface SheetProps {
   visible: boolean;
   onClose: () => void;
   title: string;
-  // Rendered under the title, inside the header row.
   subtitle?: string;
   background?: SheetBackground;
   // Fires after the dismiss animation finishes; iOS drops a picker presented before then.

--- a/mobile/src/components/ui/sheet.tsx
+++ b/mobile/src/components/ui/sheet.tsx
@@ -1,0 +1,119 @@
+/*
+ * Bottom-sheet shell: scrim, card, safe-area padding and the title/close header. The only Modal in
+ * the app — every sheet composes this.
+ *
+ * The body is whatever the caller passes, and the caller caps its own height: the sheets sharing
+ * this shell scroll different regions (the file picker scrolls only its recents list, and the
+ * reasoning sheet keeps a footer outside the scroller), so an outer ScrollView would nest scrollers.
+ *
+ * Also the actions menu's container seam. Web anchors that menu to its trigger, but the mobile
+ * composer is keyboard-sticky, so an anchored panel would chase a moving anchor. Swapping to one
+ * later means changing this component, not its callers.
+ */
+import type { ReactNode } from "react";
+import { Modal, Pressable, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
+import SvgX from "@/icons/x";
+
+// Mirrors Opal's `.opal-modal-card[data-background]`. Literal class strings so NativeWind's
+// compiler sees them. Both tokens flip with the active theme, so `gray` reads as recessed in light
+// mode (#fafafa on #ffffff) and raised in dark (#19191e on #000000).
+type SheetBackground = "default" | "gray";
+
+const SHEET_BACKGROUNDS: Record<SheetBackground, string> = {
+  default: "bg-background-tint-00",
+  gray: "bg-background-tint-01",
+};
+
+interface SheetProps {
+  visible: boolean;
+  onClose: () => void;
+  title: string;
+  // Rendered under the title, inside the header row.
+  subtitle?: string;
+  background?: SheetBackground;
+  // Fires after the dismiss animation finishes; iOS drops a picker presented before then.
+  onDismiss?: () => void;
+  children: ReactNode;
+}
+
+function Sheet({
+  visible,
+  onClose,
+  title,
+  subtitle,
+  background = "default",
+  onDismiss,
+  children,
+}: SheetProps) {
+  const insets = useSafeAreaInsets();
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+      onDismiss={onDismiss}
+      statusBarTranslucent
+    >
+      {/* Same scrim token as web's modal overlay; its backdrop-blur-03 has no RN analog.
+          `accessible={false}` on both wrappers: Pressable defaults it to true, and a view that is
+          an accessibility element hides its descendants from VoiceOver — the whole sheet would be
+          read as one blob and Close/row buttons would be unreachable. Touch is unaffected. */}
+      <Pressable
+        accessible={false}
+        className="flex-1 justify-end bg-mask-03"
+        onPress={onClose}
+      >
+        {/* Stop taps inside the sheet from dismissing it. */}
+        <Pressable
+          accessible={false}
+          onPress={() => {}}
+          className={cn(
+            // The border, not a shadow, is what separates the card: in dark mode both it and the
+            // page behind the scrim are near-black.
+            "rounded-t-20 border-t border-border-01 px-16 pt-16",
+            SHEET_BACKGROUNDS[background],
+          )}
+          style={{ paddingBottom: insets.bottom + 16 }}
+        >
+          {/* A subtitle makes the left column taller than the close button, so top-align only
+              then; a lone title reads better centred against it. */}
+          <View
+            className={cn(
+              "mb-8 flex-row justify-between",
+              subtitle ? "items-start" : "items-center",
+            )}
+          >
+            <View className="flex-1">
+              <Text font="main-content-emphasis" color="text-04">
+                {title}
+              </Text>
+              {subtitle ? (
+                <Text font="secondary-body" color="text-03">
+                  {subtitle}
+                </Text>
+              ) : null}
+            </View>
+            <Button
+              icon={SvgX}
+              prominence="tertiary"
+              size="sm"
+              accessibilityLabel="Close"
+              onPress={onClose}
+            />
+          </View>
+
+          {children}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+export { Sheet, type SheetProps, type SheetBackground };

--- a/mobile/src/hooks/__tests__/useAgentPreferences.test.tsx
+++ b/mobile/src/hooks/__tests__/useAgentPreferences.test.tsx
@@ -1,0 +1,237 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { Mock } from "jest-mock";
+import * as React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { apiFetch, type ApiFetchInit } from "@/api/client";
+import { QUERY_KEYS } from "@/api/query-keys";
+import type { AgentPreferences } from "@/api/chat/agentPreferences";
+import { useAgentPreferences } from "@/hooks/useAgentPreferences";
+
+jest.mock("@/api/client");
+jest.mock("@/state/session", () => ({
+  useSession: (selector: (s: { serverUrl: string | null }) => unknown) =>
+    selector({ serverUrl: "https://example.test" }),
+}));
+jest.mock("@/hooks/useToast", () => ({ toast: { error: jest.fn() } }));
+
+const apiFetchMock = apiFetch as unknown as Mock<
+  (path: string, init?: ApiFetchInit) => Promise<unknown>
+>;
+
+const SERVER_URL = "https://example.test";
+
+// The PATCH invalidates and refetches, so a static mock would answer that refetch with stale data
+// and mask the very races these tests exist to catch.
+function fakeServer(
+  initial: AgentPreferences,
+  { patchInFlight = false }: { patchInFlight?: boolean } = {},
+) {
+  let stored: AgentPreferences = initial;
+  apiFetchMock.mockImplementation(async (path, init) => {
+    if (init?.method === "PATCH") {
+      const agentId = path.split("/")[3];
+      const { disabled_tool_ids } = init.body as {
+        disabled_tool_ids: number[];
+      };
+      // Committing a tick late lets a second toggle start before the first lands — the only way
+      // to observe the concurrent path the UI actually takes.
+      if (patchInFlight) await new Promise((resolve) => setTimeout(resolve, 0));
+      stored = { ...stored, [agentId]: { disabled_tool_ids } };
+      return undefined;
+    }
+    return stored;
+  });
+  return {
+    disabledFor: (agentId: number) =>
+      stored[String(agentId)]?.disabled_tool_ids,
+  };
+}
+
+function patchCalls() {
+  return apiFetchMock.mock.calls.filter(([, init]) => init?.method === "PATCH");
+}
+
+function renderPreferences() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  const settle = () => waitFor(() => expect(client.isFetching()).toBe(0));
+  return {
+    client,
+    settle,
+    ...renderHook(() => useAgentPreferences(), { wrapper }),
+  };
+}
+
+describe("useAgentPreferences", () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+  });
+
+  it("reads disabled ids by agent, indexing the string keys the wire sends", async () => {
+    fakeServer({ "5": { disabled_tool_ids: [2, 4] } });
+
+    const { result } = renderPreferences();
+    await waitFor(() =>
+      expect(result.current.disabledToolIdsFor(5)).toEqual([2, 4]),
+    );
+    expect(result.current.disabledToolIdsFor(9)).toEqual([]);
+  });
+
+  it("treats a null body as no preferences", async () => {
+    apiFetchMock.mockResolvedValue(null);
+
+    const { result } = renderPreferences();
+    await waitFor(() => expect(apiFetchMock).toHaveBeenCalled());
+    expect(result.current.disabledToolIdsFor(5)).toEqual([]);
+  });
+
+  it("adds the tool optimistically and PATCHes the full array", async () => {
+    const server = fakeServer({ "5": { disabled_tool_ids: [2] } });
+
+    const { result, client, settle } = renderPreferences();
+    await waitFor(() =>
+      expect(result.current.disabledToolIdsFor(5)).toEqual([2]),
+    );
+
+    await act(async () => {
+      await result.current.toggleDisabledTool(5, 7);
+    });
+    await settle();
+
+    expect(patchCalls()).toEqual([
+      [
+        "/user/assistant/5/preferences",
+        { method: "PATCH", body: { disabled_tool_ids: [2, 7] } },
+      ],
+    ]);
+    expect(server.disabledFor(5)).toEqual([2, 7]);
+    expect(
+      client.getQueryData<AgentPreferences>(
+        QUERY_KEYS.agentPreferences(SERVER_URL),
+      ),
+    ).toEqual({ "5": { disabled_tool_ids: [2, 7] } });
+  });
+
+  it("removes an already-disabled tool instead of re-adding it", async () => {
+    const server = fakeServer({ "5": { disabled_tool_ids: [2, 7] } });
+
+    const { result, settle } = renderPreferences();
+    await waitFor(() =>
+      expect(result.current.disabledToolIdsFor(5)).toEqual([2, 7]),
+    );
+
+    await act(async () => {
+      await result.current.toggleDisabledTool(5, 7);
+    });
+    await settle();
+
+    expect(server.disabledFor(5)).toEqual([2]);
+  });
+
+  it("leaves other agents' preferences untouched", async () => {
+    const server = fakeServer({
+      "5": { disabled_tool_ids: [2] },
+      "6": { disabled_tool_ids: [9] },
+    });
+
+    const { result, settle } = renderPreferences();
+    await waitFor(() =>
+      expect(result.current.disabledToolIdsFor(6)).toEqual([9]),
+    );
+
+    await act(async () => {
+      await result.current.toggleDisabledTool(5, 7);
+    });
+    await settle();
+
+    expect(server.disabledFor(6)).toEqual([9]);
+  });
+
+  it("rolls the cache back when the PATCH fails", async () => {
+    fakeServer({ "5": { disabled_tool_ids: [2] } });
+
+    const { result, client, settle } = renderPreferences();
+    await waitFor(() =>
+      expect(result.current.disabledToolIdsFor(5)).toEqual([2]),
+    );
+
+    apiFetchMock.mockRejectedValue(new Error("nope"));
+    await act(async () => {
+      await result.current.toggleDisabledTool(5, 7);
+    });
+    await settle();
+
+    expect(
+      client.getQueryData<AgentPreferences>(
+        QUERY_KEYS.agentPreferences(SERVER_URL),
+      ),
+    ).toEqual({ "5": { disabled_tool_ids: [2] } });
+  });
+
+  it("loads the record before PATCHing so a pre-load tap can't wipe other clients' choices", async () => {
+    const server = fakeServer({ "5": { disabled_tool_ids: [2, 4] } });
+
+    // No waitFor: the tap lands while the initial GET is still in flight, so the cache is empty.
+    const { result, settle } = renderPreferences();
+    await act(async () => {
+      await result.current.toggleDisabledTool(5, 7);
+    });
+    await settle();
+
+    // A blind [] baseline would have PATCHed [7] and re-enabled tools 2 and 4 for every client.
+    expect(server.disabledFor(5)).toEqual([2, 4, 7]);
+  });
+
+  it("does not PATCH at all when the record cannot be loaded", async () => {
+    apiFetchMock.mockRejectedValue(new Error("offline"));
+
+    const { result } = renderPreferences();
+    await act(async () => {
+      await result.current.toggleDisabledTool(5, 7);
+    });
+
+    expect(patchCalls()).toEqual([]);
+  });
+
+  it("composes two in-flight toggles rather than dropping one", async () => {
+    // Fired unawaited, as the UI does, with the first PATCH still in flight.
+    const server = fakeServer(
+      { "5": { disabled_tool_ids: [] } },
+      { patchInFlight: true },
+    );
+
+    const { result, settle } = renderPreferences();
+    await waitFor(() => expect(apiFetchMock).toHaveBeenCalled());
+
+    await act(async () => {
+      await Promise.all([
+        result.current.toggleDisabledTool(5, 1),
+        result.current.toggleDisabledTool(5, 2),
+      ]);
+    });
+    await settle();
+
+    expect(server.disabledFor(5)).toEqual([1, 2]);
+  });
+
+  it("composes consecutive toggles instead of racing on a stale array", async () => {
+    const server = fakeServer({ "5": { disabled_tool_ids: [] } });
+
+    const { result, settle } = renderPreferences();
+    await waitFor(() => expect(apiFetchMock).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.toggleDisabledTool(5, 1);
+      await result.current.toggleDisabledTool(5, 2);
+    });
+    await settle();
+
+    expect(server.disabledFor(5)).toEqual([1, 2]);
+  });
+});

--- a/mobile/src/hooks/__tests__/useAgentPreferences.test.tsx
+++ b/mobile/src/hooks/__tests__/useAgentPreferences.test.tsx
@@ -26,8 +26,12 @@ const SERVER_URL = "https://example.test";
 // and mask the very races these tests exist to catch.
 function fakeServer(
   initial: AgentPreferences,
-  { patchInFlight = false }: { patchInFlight?: boolean } = {},
+  {
+    patchInFlight = false,
+    patchDelaysMs = [],
+  }: { patchInFlight?: boolean; patchDelaysMs?: number[] } = {},
 ) {
+  let patchCount = 0;
   let stored: AgentPreferences = initial;
   apiFetchMock.mockImplementation(async (path, init) => {
     if (init?.method === "PATCH") {
@@ -36,8 +40,14 @@ function fakeServer(
         disabled_tool_ids: number[];
       };
       // Committing a tick late lets a second toggle start before the first lands — the only way
-      // to observe the concurrent path the UI actually takes.
-      if (patchInFlight) await new Promise((resolve) => setTimeout(resolve, 0));
+      // to observe the concurrent path the UI actually takes. `patchDelaysMs` additionally lets a
+      // test make an earlier request finish last.
+      const delay = patchDelaysMs[patchCount++];
+      if (delay !== undefined) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      } else if (patchInFlight) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
       stored = { ...stored, [agentId]: { disabled_tool_ids } };
       return undefined;
     }
@@ -204,6 +214,28 @@ describe("useAgentPreferences", () => {
     const server = fakeServer(
       { "5": { disabled_tool_ids: [] } },
       { patchInFlight: true },
+    );
+
+    const { result, settle } = renderPreferences();
+    await waitFor(() => expect(apiFetchMock).toHaveBeenCalled());
+
+    await act(async () => {
+      await Promise.all([
+        result.current.toggleDisabledTool(5, 1),
+        result.current.toggleDisabledTool(5, 2),
+      ]);
+    });
+    await settle();
+
+    expect(server.disabledFor(5)).toEqual([1, 2]);
+  });
+
+  it("keeps both toggles when the first PATCH lands after the second", async () => {
+    // Whole-record writes are last-write-wins on the server, so an out-of-order completion would
+    // silently undo the second toggle unless the writes are serialized.
+    const server = fakeServer(
+      { "5": { disabled_tool_ids: [] } },
+      { patchDelaysMs: [40, 0] },
     );
 
     const { result, settle } = renderPreferences();

--- a/mobile/src/hooks/__tests__/useAgentPreferences.test.tsx
+++ b/mobile/src/hooks/__tests__/useAgentPreferences.test.tsx
@@ -10,10 +10,15 @@ import type { AgentPreferences } from "@/api/chat/agentPreferences";
 import { useAgentPreferences } from "@/hooks/useAgentPreferences";
 
 jest.mock("@/api/client");
-jest.mock("@/state/session", () => ({
-  useSession: (selector: (s: { serverUrl: string | null }) => unknown) =>
-    selector({ serverUrl: "https://example.test" }),
-}));
+// The hook reads the live session identity when a queued write finally runs, so the mock needs a
+// `getState` a test can move underneath it.
+let mockServerUrl: string | null = "https://example.test";
+jest.mock("@/state/session", () => {
+  const useSession = (selector: (s: { serverUrl: string | null }) => unknown) =>
+    selector({ serverUrl: mockServerUrl });
+  useSession.getState = () => ({ serverUrl: mockServerUrl });
+  return { useSession };
+});
 jest.mock("@/hooks/useToast", () => ({ toast: { error: jest.fn() } }));
 
 const apiFetchMock = apiFetch as unknown as Mock<
@@ -81,6 +86,7 @@ function renderPreferences() {
 describe("useAgentPreferences", () => {
   beforeEach(() => {
     apiFetchMock.mockReset();
+    mockServerUrl = SERVER_URL;
   });
 
   it("reads disabled ids by agent, indexing the string keys the wire sends", async () => {
@@ -250,6 +256,32 @@ describe("useAgentPreferences", () => {
     await settle();
 
     expect(server.disabledFor(5)).toEqual([1, 2]);
+  });
+
+  it("drops a write when the session it was made under is gone", async () => {
+    // apiFetch resolves the base URL and bearer token when the write finally runs, so a write
+    // still pending across a logout would otherwise land on whoever signs in next.
+    const server = fakeServer(
+      { "5": { disabled_tool_ids: [] } },
+      { patchInFlight: true },
+    );
+
+    const { result, settle } = renderPreferences();
+    await waitFor(() => expect(apiFetchMock).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.toggleDisabledTool(5, 1);
+    });
+    await settle();
+    expect(server.disabledFor(5)).toEqual([1]);
+
+    await act(async () => {
+      const pending = result.current.toggleDisabledTool(5, 2);
+      mockServerUrl = "https://other.test";
+      await pending;
+    });
+
+    expect(server.disabledFor(5)).toEqual([1]);
   });
 
   it("composes consecutive toggles instead of racing on a stale array", async () => {

--- a/mobile/src/hooks/__tests__/useChatController.test.tsx
+++ b/mobile/src/hooks/__tests__/useChatController.test.tsx
@@ -622,4 +622,27 @@ describe("useChatController", () => {
     expect(result.current.messages[0]!.message).toBe("hi there");
     expect(getSessionMock).toHaveBeenCalledWith("s2");
   });
+
+  it("reports the hydrated session's persona", async () => {
+    // The sessions list omits project chats, so this is the only way the composer can learn which
+    // agent a project chat runs on.
+    getSessionMock.mockResolvedValue({
+      chat_session_id: "s3",
+      description: "",
+      persona_id: 7,
+      messages: [],
+      packets: [],
+      time_created: "",
+    });
+
+    const { result } = renderHook(() => useChatController("s3"), { wrapper });
+
+    await waitFor(() => expect(result.current.conversationPersonaId).toBe(7));
+  });
+
+  it("has no conversation persona for a brand-new chat", () => {
+    const { result } = renderHook(() => useChatController(null), { wrapper });
+    expect(result.current.conversationPersonaId).toBeNull();
+    expect(getSessionMock).not.toHaveBeenCalled();
+  });
 });

--- a/mobile/src/hooks/__tests__/useForcedTools.test.ts
+++ b/mobile/src/hooks/__tests__/useForcedTools.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "@jest/globals";
+import { act, renderHook } from "@testing-library/react-native";
+
+import { useForcedTools } from "@/hooks/useForcedTools";
+
+interface ForcedProps {
+  chatSessionId: string | null;
+  agentId: number | undefined;
+  projectId: number | null;
+}
+
+function renderForced(
+  chatSessionId: string | null,
+  agentId: number | undefined,
+  projectId: number | null = null,
+) {
+  return renderHook((props: ForcedProps) => useForcedTools(props), {
+    initialProps: { chatSessionId, agentId, projectId },
+  });
+}
+
+describe("useForcedTools", () => {
+  it("starts unforced and forces on toggle", () => {
+    const { result } = renderForced(null, 0);
+    expect(result.current.forcedToolId).toBeNull();
+
+    act(() => result.current.toggleForcedTool(3));
+    expect(result.current.forcedToolId).toBe(3);
+  });
+
+  it("releases the force when the same tool is tapped again", () => {
+    const { result } = renderForced(null, 0);
+    act(() => result.current.toggleForcedTool(3));
+    act(() => result.current.toggleForcedTool(3));
+    expect(result.current.forcedToolId).toBeNull();
+  });
+
+  it("replaces rather than accumulates when another tool is tapped", () => {
+    const { result } = renderForced(null, 0);
+    act(() => result.current.toggleForcedTool(3));
+    act(() => result.current.toggleForcedTool(7));
+    expect(result.current.forcedToolId).toBe(7);
+  });
+
+  it("clears on demand", () => {
+    const { result } = renderForced(null, 0);
+    act(() => result.current.toggleForcedTool(3));
+    act(() => result.current.clearForcedTool());
+    expect(result.current.forcedToolId).toBeNull();
+  });
+
+  it("preserves the force when the landing gets its new session", () => {
+    const { result, rerender } = renderForced(null, 0);
+    act(() => result.current.toggleForcedTool(3));
+
+    rerender({ chatSessionId: "session-1", agentId: 0, projectId: null });
+    expect(result.current.forcedToolId).toBe(3);
+  });
+
+  it("resets when switching between existing sessions", () => {
+    const { result, rerender } = renderForced("session-1", 0);
+    act(() => result.current.toggleForcedTool(3));
+
+    rerender({ chatSessionId: "session-2", agentId: 0, projectId: null });
+    expect(result.current.forcedToolId).toBeNull();
+  });
+
+  it("resets when the agent changes", () => {
+    const { result, rerender } = renderForced(null, 0);
+    act(() => result.current.toggleForcedTool(3));
+
+    rerender({ chatSessionId: null, agentId: 7, projectId: null });
+    expect(result.current.forcedToolId).toBeNull();
+  });
+
+  it("keeps the force across the send that creates a session with an unresolved persona", () => {
+    const { result, rerender } = renderForced(null, 7);
+    act(() => result.current.toggleForcedTool(3));
+
+    rerender({
+      chatSessionId: "session-1",
+      agentId: undefined,
+      projectId: null,
+    });
+    expect(result.current.forcedToolId).toBe(3);
+
+    rerender({ chatSessionId: "session-1", agentId: 7, projectId: null });
+    expect(result.current.forcedToolId).toBe(3);
+  });
+
+  it("still resets when a switch passes through an unresolved agent", () => {
+    const { result, rerender } = renderForced(null, 7);
+    act(() => result.current.toggleForcedTool(3));
+
+    rerender({ chatSessionId: null, agentId: undefined, projectId: null });
+    rerender({ chatSessionId: null, agentId: 9, projectId: null });
+    expect(result.current.forcedToolId).toBeNull();
+  });
+
+  it("releases the force when the composer crosses into a project", () => {
+    const { result, rerender } = renderForced(null, 0, null);
+    act(() => result.current.toggleForcedTool(5));
+
+    rerender({ chatSessionId: null, agentId: 0, projectId: 5 });
+    expect(result.current.forcedToolId).toBeNull();
+  });
+
+  it("releases the force when moving between two projects", () => {
+    const { result, rerender } = renderForced(null, 0, 5);
+    act(() => result.current.toggleForcedTool(5));
+
+    rerender({ chatSessionId: null, agentId: 0, projectId: 6 });
+    expect(result.current.forcedToolId).toBeNull();
+  });
+
+  it("keeps the force while the project scope is unchanged", () => {
+    const { result, rerender } = renderForced(null, 0, 5);
+    act(() => result.current.toggleForcedTool(5));
+
+    rerender({ chatSessionId: null, agentId: 0, projectId: 5 });
+    expect(result.current.forcedToolId).toBe(5);
+  });
+});

--- a/mobile/src/hooks/useAgentPreferences.ts
+++ b/mobile/src/hooks/useAgentPreferences.ts
@@ -1,0 +1,85 @@
+import { useCallback } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { QUERY_KEYS } from "@/api/query-keys";
+import {
+  getAgentPreferences,
+  patchAgentPreferences,
+  type AgentPreferences,
+} from "@/api/chat/agentPreferences";
+import { toast } from "@/hooks/useToast";
+import { useSession } from "@/state/session";
+
+const EMPTY_PREFERENCES: AgentPreferences = {};
+
+export interface UseAgentPreferences {
+  preferences: AgentPreferences;
+  disabledToolIdsFor: (agentId: number) => number[];
+  // Optimistic; rolls back and toasts if the PATCH fails.
+  toggleDisabledTool: (agentId: number, toolId: number) => Promise<void>;
+}
+
+export function useAgentPreferences(): UseAgentPreferences {
+  const serverUrl = useSession((state) => state.serverUrl);
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: QUERY_KEYS.agentPreferences(serverUrl),
+    // No serverUrl → `getBaseUrl()` throws, so stay idle until connected.
+    enabled: serverUrl !== null,
+    queryFn: ({ signal }) => getAgentPreferences(signal),
+  });
+
+  const preferences = query.data ?? EMPTY_PREFERENCES;
+
+  const disabledToolIdsFor = useCallback(
+    (agentId: number) => preferences[String(agentId)]?.disabled_tool_ids ?? [],
+    [preferences],
+  );
+
+  const toggleDisabledTool = useCallback(
+    async (agentId: number, toolId: number) => {
+      const key = QUERY_KEYS.agentPreferences(serverUrl);
+
+      // A tap can land before the initial GET resolves, and the PATCH replaces the whole array —
+      // computing it from an empty cache would re-enable everything disabled on another client.
+      if (queryClient.getQueryData(key) === undefined) {
+        try {
+          await queryClient.fetchQuery({
+            queryKey: key,
+            queryFn: ({ signal }) => getAgentPreferences(signal),
+          });
+        } catch {
+          toast.error("Couldn't update this action.");
+          return;
+        }
+      }
+
+      await queryClient.cancelQueries({ queryKey: key });
+
+      // Live cache, not a render-time snapshot, so concurrent toggles compose instead of racing.
+      const previous = queryClient.getQueryData<AgentPreferences | null>(key);
+      const current = previous?.[String(agentId)]?.disabled_tool_ids ?? [];
+      const next = current.includes(toolId)
+        ? current.filter((id) => id !== toolId)
+        : [...current, toolId];
+
+      queryClient.setQueryData<AgentPreferences>(key, {
+        ...(previous ?? EMPTY_PREFERENCES),
+        [String(agentId)]: { disabled_tool_ids: next },
+      });
+
+      try {
+        await patchAgentPreferences(agentId, next);
+      } catch {
+        queryClient.setQueryData(key, previous);
+        toast.error("Couldn't update this action.");
+      } finally {
+        void queryClient.invalidateQueries({ queryKey: key });
+      }
+    },
+    [queryClient, serverUrl],
+  );
+
+  return { preferences, disabledToolIdsFor, toggleDisabledTool };
+}

--- a/mobile/src/hooks/useAgentPreferences.ts
+++ b/mobile/src/hooks/useAgentPreferences.ts
@@ -84,7 +84,13 @@ export function useAgentPreferences(): UseAgentPreferences {
       });
 
       try {
-        await enqueueWrite(() => patchAgentPreferences(agentId, next));
+        await enqueueWrite(async () => {
+          // The queue defers this, and apiFetch resolves the base URL and bearer token only when
+          // it finally runs — so a write queued before a logout or instance switch would land on
+          // whoever is signed in by then. Drop it instead.
+          if (useSession.getState().serverUrl !== serverUrl) return;
+          await patchAgentPreferences(agentId, next);
+        });
       } catch (error) {
         console.error("Failed to save agent preferences", error);
         queryClient.setQueryData(key, previous);

--- a/mobile/src/hooks/useAgentPreferences.ts
+++ b/mobile/src/hooks/useAgentPreferences.ts
@@ -12,10 +12,9 @@ import { useSession } from "@/state/session";
 
 const EMPTY_PREFERENCES: AgentPreferences = {};
 
-// The PATCH replaces the whole record, so two in-flight writes are last-write-wins on the server
-// regardless of how carefully we compose them here — an earlier request completing second would
-// undo the later toggle. Chaining keeps one write in flight at a time. Module-scoped because the
-// record is per-user, not per-hook-instance.
+// The PATCH replaces the whole record, so two in-flight writes are last-write-wins: an earlier
+// request completing second would undo the later toggle. Chaining keeps one write in flight at a
+// time. Module-scoped because the record is per-user, not per-hook-instance.
 let writeQueue: Promise<unknown> = Promise.resolve();
 
 function enqueueWrite<T>(write: () => Promise<T>): Promise<T> {

--- a/mobile/src/hooks/useAgentPreferences.ts
+++ b/mobile/src/hooks/useAgentPreferences.ts
@@ -12,6 +12,19 @@ import { useSession } from "@/state/session";
 
 const EMPTY_PREFERENCES: AgentPreferences = {};
 
+// The PATCH replaces the whole record, so two in-flight writes are last-write-wins on the server
+// regardless of how carefully we compose them here — an earlier request completing second would
+// undo the later toggle. Chaining keeps one write in flight at a time. Module-scoped because the
+// record is per-user, not per-hook-instance.
+let writeQueue: Promise<unknown> = Promise.resolve();
+
+function enqueueWrite<T>(write: () => Promise<T>): Promise<T> {
+  const next = writeQueue.then(write, write);
+  // Keep the chain alive after a rejection so one failure can't wedge every later toggle.
+  writeQueue = next.catch(() => undefined);
+  return next;
+}
+
 export interface UseAgentPreferences {
   preferences: AgentPreferences;
   disabledToolIdsFor: (agentId: number) => number[];
@@ -49,7 +62,8 @@ export function useAgentPreferences(): UseAgentPreferences {
             queryKey: key,
             queryFn: ({ signal }) => getAgentPreferences(signal),
           });
-        } catch {
+        } catch (error) {
+          console.error("Failed to load agent preferences", error);
           toast.error("Couldn't update this action.");
           return;
         }
@@ -70,8 +84,9 @@ export function useAgentPreferences(): UseAgentPreferences {
       });
 
       try {
-        await patchAgentPreferences(agentId, next);
-      } catch {
+        await enqueueWrite(() => patchAgentPreferences(agentId, next));
+      } catch (error) {
+        console.error("Failed to save agent preferences", error);
         queryClient.setQueryData(key, previous);
         toast.error("Couldn't update this action.");
       } finally {

--- a/mobile/src/hooks/useChatController.ts
+++ b/mobile/src/hooks/useChatController.ts
@@ -203,6 +203,10 @@ export interface ChatController {
   ) => void;
   stop: () => void;
   isHydrating: boolean;
+  // The persona the backend says owns this session. The sessions list can't answer this for a
+  // project chat (it is fetched with only_non_project_chats=true), so the hydrated session is the
+  // only authority. null for a new chat, or before hydration lands.
+  conversationPersonaId: number | null;
 }
 
 // `personaId` binds the agent only when this send creates a new session (ignored for an existing
@@ -371,5 +375,7 @@ export function useChatController(
     submit,
     stop,
     isHydrating: needsHydration && hydration.isLoading,
+    // Query keeps serving this once hydration is disabled, so it survives revisiting the chat.
+    conversationPersonaId: hydration.data?.persona_id ?? null,
   };
 }

--- a/mobile/src/hooks/useForcedTools.ts
+++ b/mobile/src/hooks/useForcedTools.ts
@@ -1,0 +1,67 @@
+// Ephemeral "force this tool for the next turn" state. Web stores a number[] but only ever fills
+// it with one id and sends forcedToolIds[0] (web/src/lib/hooks/useForcedTools.ts), so a single
+// nullable id is the same thing without the dead cardinality.
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface UseForcedToolsArgs {
+  chatSessionId: string | null;
+  // undefined = unresolved (agents loading, or a new session missing from the sessions list).
+  agentId: number | undefined;
+  // null = not in a project. A project composer is a different conversation scope, so crossing
+  // the boundary resets, matching web (web/src/views/AppPage.tsx:166-169).
+  projectId: number | null;
+}
+
+export interface ForcedTools {
+  forcedToolId: number | null;
+  toggleForcedTool: (toolId: number) => void;
+  clearForcedTool: () => void;
+}
+
+export function useForcedTools({
+  chatSessionId,
+  agentId,
+  projectId,
+}: UseForcedToolsArgs): ForcedTools {
+  const [forcedToolId, setForcedToolId] = useState<number | null>(null);
+  const previousChatSessionId = useRef<string | null>(chatSessionId);
+  const previousAgentId = useRef<number | undefined>(agentId);
+  const previousProjectId = useRef<number | null>(projectId);
+
+  // Preserve across null→new-session: that transition *is* the send.
+  useEffect(() => {
+    const previousId = previousChatSessionId.current;
+    previousChatSessionId.current = chatSessionId;
+    if (previousId !== null && previousId !== chatSessionId) {
+      setForcedToolId(null);
+    }
+  }, [chatSessionId]);
+
+  // Only known→known counts as a switch; the unresolved step after a send must not clear the
+  // force that send just used.
+  useEffect(() => {
+    if (agentId === undefined) return;
+    const previousId = previousAgentId.current;
+    previousAgentId.current = agentId;
+    if (previousId !== undefined && previousId !== agentId) {
+      setForcedToolId(null);
+    }
+  }, [agentId]);
+
+  // Needs no such guard: the send that creates a chat has already read its options by the time
+  // the route flips, so every project transition is a real scope change.
+  useEffect(() => {
+    const previousId = previousProjectId.current;
+    previousProjectId.current = projectId;
+    if (previousId !== projectId) setForcedToolId(null);
+  }, [projectId]);
+
+  // Single-force: a second tool replaces the first, never accumulates.
+  const toggleForcedTool = useCallback((toolId: number) => {
+    setForcedToolId((current) => (current === toolId ? null : toolId));
+  }, []);
+
+  const clearForcedTool = useCallback(() => setForcedToolId(null), []);
+
+  return { forcedToolId, toggleForcedTool, clearForcedTool };
+}

--- a/mobile/src/hooks/useForcedTools.ts
+++ b/mobile/src/hooks/useForcedTools.ts
@@ -56,7 +56,6 @@ export function useForcedTools({
     if (previousId !== projectId) setForcedToolId(null);
   }, [projectId]);
 
-  // Single-force: a second tool replaces the first, never accumulates.
   const toggleForcedTool = useCallback((toolId: number) => {
     setForcedToolId((current) => (current === toolId ? null : toolId));
   }, []);

--- a/mobile/src/query/client.ts
+++ b/mobile/src/query/client.ts
@@ -37,6 +37,7 @@ const NON_PERSISTED_KEY_PREFIXES: readonly (readonly unknown[])[] = [
   [QUERY_KEYS.userProjects(null)[0]], // "projects"
   [QUERY_KEYS.userProject(null, null)[0]], // "project"
   [QUERY_KEYS.userRecentFiles(null)[0]], // "recent-files" (file names are PII)
+  [QUERY_KEYS.agentPreferences(null)[0]], // "agent-preferences" (per-user workspace config)
 ];
 
 function isNonPersistedKey(queryKey: readonly unknown[]): boolean {

--- a/mobile/src/state/ComposerToolsProvider.tsx
+++ b/mobile/src/state/ComposerToolsProvider.tsx
@@ -71,16 +71,30 @@ export function useComposerToolsState({
   const { disabledToolIdsFor, toggleDisabledTool } = useAgentPreferences();
 
   /*
-   * `agent` goes null after a send until the session lands in the sessions list, and stays null
-   * for a project chat's whole life (that list is fetched with only_non_project_chats=true). Only
-   * our knowledge lapses, not the agent, so hold the last one — otherwise the menu vanishes and
-   * the send re-allows tools the user switched off. Adjusted during render, not in an effect, so
-   * the hold is right on the first render that loses the agent; compared by id so a caller that
-   * rebuilds the object each render can't loop.
+   * `agent` goes null for a beat after a send, before the new session reaches the sessions list.
+   * Only our knowledge lapses, not the agent, so hold the last one — otherwise the menu vanishes
+   * and the send re-allows tools the user switched off.
+   *
+   * The hold is stamped with the conversation it belongs to and is only honoured back in that
+   * same conversation, so it can never describe a chat it was not captured in. The one promotion
+   * is null → new session: that transition is the send itself. Adjusted during render, not in an
+   * effect, so the hold is right on the first render that loses the agent; compared by id so a
+   * caller that rebuilds the object each render can't loop.
    */
-  const [heldAgent, setHeldAgent] = useState<MinimalAgent | null>(agent);
-  if (agent && heldAgent?.id !== agent.id) setHeldAgent(agent);
-  const effectiveAgent = agent ?? heldAgent;
+  const [held, setHeld] = useState<{
+    agent: MinimalAgent | null;
+    sessionId: string | null;
+  }>({ agent, sessionId: chatSessionId });
+  if (
+    agent &&
+    (held.agent?.id !== agent.id || held.sessionId !== chatSessionId)
+  ) {
+    setHeld({ agent, sessionId: chatSessionId });
+  } else if (!agent && held.sessionId === null && chatSessionId !== null) {
+    setHeld({ agent: held.agent, sessionId: chatSessionId });
+  }
+  const effectiveAgent =
+    agent ?? (held.sessionId === chatSessionId ? held.agent : null);
   const effectiveAgentId = effectiveAgent?.id;
 
   // No agent has ever resolved → leave the pill as the user set it rather than withdrawing a

--- a/mobile/src/state/ComposerToolsProvider.tsx
+++ b/mobile/src/state/ComposerToolsProvider.tsx
@@ -35,9 +35,9 @@ export interface ComposerTools {
   toggleForcedTool: (toolId: number) => void;
   disabledToolIds: number[];
   toggleToolEnabled: (toolId: number) => void;
-  // Call right before a send that will create the session. Without it the provider cannot tell
-  // that transition apart from simply opening an existing chat.
-  notePendingSend: () => void;
+  // Report the agent a send used, once that send is known to have created the session. Carries
+  // the agent rather than a flag because the selection can change while the create is in flight.
+  notePendingSend: (agentForSend: MinimalAgent | null) => void;
   // Read at send time, never during render.
   resolveToolOptions: () => ChatToolOptions;
 }
@@ -80,12 +80,15 @@ export function useComposerToolsState({
    *
    * The hold is stamped with the conversation it belongs to and is only honoured back in that
    * same conversation, so it can never describe a chat it was not captured in. It carries over to
-   * a new session only when the host told us a send was creating one — opening an existing chat
-   * from the landing looks identical otherwise. Adjusted during render, not in an effect, so the
-   * hold is right on the first render that loses the agent; compared by id so a caller that
-   * rebuilds the object each render can't loop.
+   * a new session only when the host reports the send that created it, and then takes that send's
+   * agent — picking a different agent while the create was in flight must not rewrite what the
+   * finished session runs on. Adjusted during render, not in an effect, so the hold is right on
+   * the first render that loses the agent; compared by id so a caller that rebuilds the object
+   * each render can't loop.
    */
-  const [pendingSend, setPendingSend] = useState(false);
+  const [pendingSend, setPendingSend] = useState<{
+    agent: MinimalAgent | null;
+  } | null>(null);
   const [held, setHeld] = useState<{
     agent: MinimalAgent | null;
     sessionId: string | null;
@@ -95,15 +98,14 @@ export function useComposerToolsState({
     (held.agent?.id !== agent.id || held.sessionId !== chatSessionId)
   ) {
     setHeld({ agent, sessionId: chatSessionId });
-    if (pendingSend) setPendingSend(false);
   } else if (
     !agent &&
     pendingSend &&
     held.sessionId === null &&
     chatSessionId !== null
   ) {
-    setHeld({ agent: held.agent, sessionId: chatSessionId });
-    setPendingSend(false);
+    setHeld({ agent: pendingSend.agent, sessionId: chatSessionId });
+    setPendingSend(null);
   }
   const effectiveAgent =
     agent ?? (held.sessionId === chatSessionId ? held.agent : null);
@@ -148,7 +150,11 @@ export function useComposerToolsState({
     ],
   );
 
-  const notePendingSend = useCallback(() => setPendingSend(true), []);
+  const notePendingSend = useCallback(
+    (agentForSend: MinimalAgent | null) =>
+      setPendingSend({ agent: agentForSend }),
+    [],
+  );
 
   return useMemo(
     () => ({

--- a/mobile/src/state/ComposerToolsProvider.tsx
+++ b/mobile/src/state/ComposerToolsProvider.tsx
@@ -1,66 +1,172 @@
-// The state lives in a hook rather than inside the provider because ChatSurface both hosts the
-// provider and calls `resolveToolOptions()` at send time — a component can't read a context it
-// provides.
-import { createContext, useContext, useMemo, type ReactNode } from "react";
+// State lives in a hook, not the provider: ChatSurface both hosts the provider and calls
+// `resolveToolOptions()` at send time, and a component can't read a context it provides.
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 
 import { useWorkspaceSettings } from "@/api/settings";
 import type { ChatToolOptions } from "@/api/chat/stream";
 import type { MinimalAgent } from "@/chat/agents";
-import { hasSearchToolsAvailable } from "@/chat/tools";
+import {
+  computeAllowedToolIds,
+  displayableTools,
+  hasSearchToolsAvailable,
+  type ToolSnapshot,
+} from "@/chat/tools";
+import { useAgentPreferences } from "@/hooks/useAgentPreferences";
 import { useDeepResearchToggle } from "@/hooks/useDeepResearchToggle";
+import { useForcedTools } from "@/hooks/useForcedTools";
+
+const NO_TOOLS: ToolSnapshot[] = [];
+const NO_IDS: number[] = [];
 
 export interface ComposerTools {
   showDeepResearch: boolean;
   deepResearchEnabled: boolean;
   toggleDeepResearch: () => void;
+  // Filtered for display — not the agent's full tool list.
+  actionTools: ToolSnapshot[];
+  forcedToolId: number | null;
+  toggleForcedTool: (toolId: number) => void;
+  disabledToolIds: number[];
+  toggleToolEnabled: (toolId: number) => void;
   // Read at send time, never during render.
   resolveToolOptions: () => ChatToolOptions;
 }
 
 interface ComposerToolsInputs {
   chatSessionId: string | null;
-  // null while the conversation's agent isn't knowable yet.
+  // null when ChatSurface can't prove which agent owns the conversation.
   agent: MinimalAgent | null;
   // Deep research is unsupported in projects (web hides it too — ENG-3818). Only the project
   // landing composer is detectable: a chat opened from a project has no project id on the wire.
   isProjectWorkflow: boolean;
+  // Crossing this boundary releases a forced tool.
+  projectId: number | null;
 }
 
 export function useComposerToolsState({
   chatSessionId,
   agent,
   isProjectWorkflow,
+  projectId,
 }: ComposerToolsInputs): ComposerTools {
   const { settings } = useWorkspaceSettings();
+  const agentId = agent?.id;
+
   const { deepResearchEnabled, toggleDeepResearch } = useDeepResearchToggle({
     chatSessionId,
-    agentId: agent?.id,
+    agentId,
   });
+  const { forcedToolId, toggleForcedTool, clearForcedTool } = useForcedTools({
+    chatSessionId,
+    agentId,
+    projectId,
+  });
+  const { disabledToolIdsFor, toggleDisabledTool } = useAgentPreferences();
 
-  // Agent unknown → hold the pill as the user left it. Re-gating on the placeholder agent would
-  // either withdraw a control the user just used or offer deep research to an agent that can't
-  // search.
-  const canSearch = agent
-    ? hasSearchToolsAvailable(agent.tools)
+  /*
+   * `agent` goes null after a send until the session lands in the sessions list, and stays null
+   * for a project chat's whole life (that list is fetched with only_non_project_chats=true). Only
+   * our knowledge lapses, not the agent, so hold the last one — otherwise the menu vanishes and
+   * the send re-allows tools the user switched off. Adjusted during render, not in an effect, so
+   * the hold is right on the first render that loses the agent; compared by id so a caller that
+   * rebuilds the object each render can't loop.
+   */
+  const [heldAgent, setHeldAgent] = useState<MinimalAgent | null>(agent);
+  if (agent && heldAgent?.id !== agent.id) setHeldAgent(agent);
+  const effectiveAgent = agent ?? heldAgent;
+  const effectiveAgentId = effectiveAgent?.id;
+
+  // No agent has ever resolved → leave the pill as the user set it rather than withdrawing a
+  // control they just used.
+  const canSearch = effectiveAgent
+    ? hasSearchToolsAvailable(effectiveAgent.tools)
     : deepResearchEnabled;
   const showDeepResearch =
     !isProjectWorkflow && settings.deep_research_enabled && canSearch;
+
+  const actionTools = useMemo(
+    () => (effectiveAgent ? displayableTools(effectiveAgent.tools) : NO_TOOLS),
+    [effectiveAgent],
+  );
+
+  const disabledToolIds = useMemo(
+    () =>
+      effectiveAgentId == null ? NO_IDS : disabledToolIdsFor(effectiveAgentId),
+    [effectiveAgentId, disabledToolIdsFor],
+  );
+
+  const toggleToolEnabled = useCallback(
+    (toolId: number) => {
+      const agentId = effectiveAgentId;
+      if (agentId == null) return;
+      // The backend kills the turn when a forced tool isn't among the constructed ones
+      // ("Forced tool … not found in tools"), so disabling it must release the force.
+      if (!disabledToolIds.includes(toolId) && forcedToolId === toolId) {
+        clearForcedTool();
+      }
+      void toggleDisabledTool(agentId, toolId);
+    },
+    [
+      effectiveAgentId,
+      clearForcedTool,
+      disabledToolIds,
+      forcedToolId,
+      toggleDisabledTool,
+    ],
+  );
 
   return useMemo(
     () => ({
       showDeepResearch,
       deepResearchEnabled,
       toggleDeepResearch,
+      actionTools,
+      forcedToolId,
+      toggleForcedTool,
+      disabledToolIds,
+      toggleToolEnabled,
       // Gated on `showDeepResearch` so a hidden control can never send `true` — e.g. the admin
       // disabled deep research while a toggle was left on.
-      resolveToolOptions: () => ({
-        deepResearch: showDeepResearch && deepResearchEnabled,
-        allowedToolIds: null,
-        forcedToolId: null,
-        internalSearchFilters: null,
-      }),
+      resolveToolOptions: () => {
+        // The FULL tool list, not the displayed rows: omitting the ones the menu hides (File
+        // Reader, MCP) strips them server-side as soon as any tool is off.
+        const allowedToolIds = effectiveAgent
+          ? computeAllowedToolIds(effectiveAgent.tools, disabledToolIds)
+          : null;
+        // A forced id the request filters out, or that belongs to another agent, fails the turn
+        // mid-stream.
+        const forcedIsSendable =
+          forcedToolId != null &&
+          !disabledToolIds.includes(forcedToolId) &&
+          (effectiveAgent?.tools.some((tool) => tool.id === forcedToolId) ??
+            false);
+
+        return {
+          deepResearch: showDeepResearch && deepResearchEnabled,
+          allowedToolIds,
+          forcedToolId: forcedIsSendable ? forcedToolId : null,
+          internalSearchFilters: null,
+        };
+      },
     }),
-    [showDeepResearch, deepResearchEnabled, toggleDeepResearch],
+    [
+      effectiveAgent,
+      showDeepResearch,
+      deepResearchEnabled,
+      toggleDeepResearch,
+      actionTools,
+      forcedToolId,
+      toggleForcedTool,
+      disabledToolIds,
+      toggleToolEnabled,
+    ],
   );
 }
 

--- a/mobile/src/state/ComposerToolsProvider.tsx
+++ b/mobile/src/state/ComposerToolsProvider.tsx
@@ -35,6 +35,9 @@ export interface ComposerTools {
   toggleForcedTool: (toolId: number) => void;
   disabledToolIds: number[];
   toggleToolEnabled: (toolId: number) => void;
+  // Call right before a send that will create the session. Without it the provider cannot tell
+  // that transition apart from simply opening an existing chat.
+  notePendingSend: () => void;
   // Read at send time, never during render.
   resolveToolOptions: () => ChatToolOptions;
 }
@@ -76,11 +79,13 @@ export function useComposerToolsState({
    * and the send re-allows tools the user switched off.
    *
    * The hold is stamped with the conversation it belongs to and is only honoured back in that
-   * same conversation, so it can never describe a chat it was not captured in. The one promotion
-   * is null → new session: that transition is the send itself. Adjusted during render, not in an
-   * effect, so the hold is right on the first render that loses the agent; compared by id so a
-   * caller that rebuilds the object each render can't loop.
+   * same conversation, so it can never describe a chat it was not captured in. It carries over to
+   * a new session only when the host told us a send was creating one — opening an existing chat
+   * from the landing looks identical otherwise. Adjusted during render, not in an effect, so the
+   * hold is right on the first render that loses the agent; compared by id so a caller that
+   * rebuilds the object each render can't loop.
    */
+  const [pendingSend, setPendingSend] = useState(false);
   const [held, setHeld] = useState<{
     agent: MinimalAgent | null;
     sessionId: string | null;
@@ -90,8 +95,15 @@ export function useComposerToolsState({
     (held.agent?.id !== agent.id || held.sessionId !== chatSessionId)
   ) {
     setHeld({ agent, sessionId: chatSessionId });
-  } else if (!agent && held.sessionId === null && chatSessionId !== null) {
+    if (pendingSend) setPendingSend(false);
+  } else if (
+    !agent &&
+    pendingSend &&
+    held.sessionId === null &&
+    chatSessionId !== null
+  ) {
     setHeld({ agent: held.agent, sessionId: chatSessionId });
+    setPendingSend(false);
   }
   const effectiveAgent =
     agent ?? (held.sessionId === chatSessionId ? held.agent : null);
@@ -136,6 +148,8 @@ export function useComposerToolsState({
     ],
   );
 
+  const notePendingSend = useCallback(() => setPendingSend(true), []);
+
   return useMemo(
     () => ({
       showDeepResearch,
@@ -146,6 +160,7 @@ export function useComposerToolsState({
       toggleForcedTool,
       disabledToolIds,
       toggleToolEnabled,
+      notePendingSend,
       // Gated on `showDeepResearch` so a hidden control can never send `true` — e.g. the admin
       // disabled deep research while a toggle was left on.
       resolveToolOptions: () => {
@@ -180,6 +195,7 @@ export function useComposerToolsState({
       toggleForcedTool,
       disabledToolIds,
       toggleToolEnabled,
+      notePendingSend,
     ],
   );
 }

--- a/mobile/src/state/__tests__/ComposerToolsProvider.test.tsx
+++ b/mobile/src/state/__tests__/ComposerToolsProvider.test.tsx
@@ -86,10 +86,11 @@ function agent(tools: ToolSnapshot[]): MinimalAgent {
   };
 }
 
+// One client per test, created outside the wrapper: building it inside would hand every render a
+// fresh cache and drop what a rerender is meant to observe. gcTime 0 keeps no timers behind.
+let client: QueryClient;
+
 function wrapper({ children }: { children: React.ReactNode }) {
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
 }
 
@@ -114,6 +115,9 @@ describe("useComposerToolsState", () => {
     mockDeepResearchAdminEnabled = true;
     apiFetchMock.mockReset();
     apiFetchMock.mockResolvedValue({});
+    client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
   });
 
   it("shows deep research when the admin allows it and the agent can search", () => {
@@ -295,6 +299,42 @@ describe("useComposerToolsState", () => {
     });
     expect(result.current.disabledToolIds).toEqual([2]);
     expect(result.current.resolveToolOptions().allowedToolIds).toEqual([1]);
+  });
+
+  it("refuses to describe a different conversation with the previous one's agent", async () => {
+    apiFetchMock.mockResolvedValue({ "0": { disabled_tool_ids: [2] } });
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useComposerToolsState>[0]) =>
+        useComposerToolsState(props),
+      {
+        wrapper,
+        initialProps: {
+          chatSessionId: "session-1",
+          agent: agent([searchTool, imageTool]),
+          isProjectWorkflow: false,
+          projectId: null,
+        },
+      },
+    );
+    await waitFor(() => expect(result.current.actionTools).toHaveLength(2));
+    act(() => result.current.toggleForcedTool(2));
+
+    // A different chat whose agent hasn't resolved yet: the held agent describes session-1, so
+    // using it here would send another agent's tool ids against this conversation's persona.
+    rerender({
+      chatSessionId: "session-2",
+      agent: null,
+      isProjectWorkflow: false,
+      projectId: null,
+    });
+
+    expect(result.current.actionTools).toEqual([]);
+    expect(result.current.resolveToolOptions()).toEqual({
+      deepResearch: false,
+      allowedToolIds: null,
+      forcedToolId: null,
+      internalSearchFilters: null,
+    });
   });
 
   it("still sends the force and the allowlist while the agent is momentarily unknown", async () => {

--- a/mobile/src/state/__tests__/ComposerToolsProvider.test.tsx
+++ b/mobile/src/state/__tests__/ComposerToolsProvider.test.tsx
@@ -1,13 +1,27 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
-import { act, renderHook } from "@testing-library/react-native";
+import type { Mock } from "jest-mock";
+import * as React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
+import { apiFetch, type ApiFetchInit } from "@/api/client";
 import type { MinimalAgent } from "@/chat/agents";
-import { SEARCH_TOOL_ID, type ToolSnapshot } from "@/chat/tools";
+import {
+  FILE_READER_TOOL_ID,
+  SEARCH_TOOL_ID,
+  type ToolSnapshot,
+} from "@/chat/tools";
 import { useComposerToolsState } from "@/state/ComposerToolsProvider";
 
 // `mock`-prefixed so babel-jest allows the hoisted factory to close over it.
 let mockDeepResearchAdminEnabled = true;
 
+jest.mock("@/api/client");
+jest.mock("@/state/session", () => ({
+  useSession: (selector: (s: { serverUrl: string | null }) => unknown) =>
+    selector({ serverUrl: "https://example.test" }),
+}));
+jest.mock("@/hooks/useToast", () => ({ toast: { error: jest.fn() } }));
 jest.mock("@/api/settings", () => ({
   useWorkspaceSettings: () => ({
     settings: {
@@ -18,12 +32,37 @@ jest.mock("@/api/settings", () => ({
   }),
 }));
 
+const apiFetchMock = apiFetch as unknown as Mock<
+  (path: string, init?: ApiFetchInit) => Promise<unknown>
+>;
+
 const searchTool: ToolSnapshot = {
   id: 1,
   name: "SearchTool",
   display_name: "Search",
   description: "",
   in_code_tool_id: SEARCH_TOOL_ID,
+  mcp_server_id: null,
+  chat_selectable: true,
+};
+
+const imageTool: ToolSnapshot = {
+  id: 2,
+  name: "ImageTool",
+  display_name: "Image",
+  description: "",
+  in_code_tool_id: null,
+  mcp_server_id: null,
+  chat_selectable: true,
+};
+
+// Hidden from the menu but still part of the agent, so it must survive into allowed_tool_ids.
+const fileReaderTool: ToolSnapshot = {
+  id: 3,
+  name: "FileReaderTool",
+  display_name: "File Reader",
+  description: "",
+  in_code_tool_id: FILE_READER_TOOL_ID,
   mcp_server_id: null,
   chat_selectable: true,
 };
@@ -47,22 +86,34 @@ function agent(tools: ToolSnapshot[]): MinimalAgent {
   };
 }
 
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
 function renderTools(
   overrides: { agent?: MinimalAgent | null; isProjectWorkflow?: boolean } = {},
 ) {
-  return renderHook(() =>
-    useComposerToolsState({
-      chatSessionId: null,
-      agent:
-        overrides.agent === undefined ? agent([searchTool]) : overrides.agent,
-      isProjectWorkflow: overrides.isProjectWorkflow ?? false,
-    }),
+  return renderHook(
+    () =>
+      useComposerToolsState({
+        chatSessionId: null,
+        agent:
+          overrides.agent === undefined ? agent([searchTool]) : overrides.agent,
+        isProjectWorkflow: overrides.isProjectWorkflow ?? false,
+        projectId: null,
+      }),
+    { wrapper },
   );
 }
 
 describe("useComposerToolsState", () => {
   beforeEach(() => {
     mockDeepResearchAdminEnabled = true;
+    apiFetchMock.mockReset();
+    apiFetchMock.mockResolvedValue({});
   });
 
   it("shows deep research when the admin allows it and the agent can search", () => {
@@ -91,10 +142,12 @@ describe("useComposerToolsState", () => {
       (props: Parameters<typeof useComposerToolsState>[0]) =>
         useComposerToolsState(props),
       {
+        wrapper,
         initialProps: {
           chatSessionId: null,
           agent: agent([searchTool]),
           isProjectWorkflow: false,
+          projectId: null,
         },
       },
     );
@@ -105,6 +158,7 @@ describe("useComposerToolsState", () => {
       chatSessionId: "session-1",
       agent: null,
       isProjectWorkflow: false,
+      projectId: null,
     });
     expect(result.current.showDeepResearch).toBe(true);
     expect(result.current.resolveToolOptions().deepResearch).toBe(true);
@@ -116,7 +170,7 @@ describe("useComposerToolsState", () => {
     ).toBe(false);
   });
 
-  it("sends the toggled flag and leaves the later fields unset", () => {
+  it("sends the toggled flag and leaves the unset fields null", () => {
     const { result } = renderTools();
     expect(result.current.resolveToolOptions()).toEqual({
       deepResearch: false,
@@ -133,5 +187,152 @@ describe("useComposerToolsState", () => {
     const { result } = renderTools({ isProjectWorkflow: true });
     act(() => result.current.toggleDeepResearch());
     expect(result.current.resolveToolOptions().deepResearch).toBe(false);
+  });
+
+  it("exposes only the menu-displayable tools as rows", () => {
+    const { result } = renderTools({
+      agent: agent([searchTool, fileReaderTool]),
+    });
+    expect(result.current.actionTools.map((tool) => tool.id)).toEqual([1]);
+  });
+
+  it("has no rows while the agent is unresolved", () => {
+    expect(renderTools({ agent: null }).result.current.actionTools).toEqual([]);
+  });
+
+  it("sends the forced tool id once a row is forced", () => {
+    const { result } = renderTools({ agent: agent([searchTool, imageTool]) });
+    act(() => result.current.toggleForcedTool(2));
+    expect(result.current.resolveToolOptions().forcedToolId).toBe(2);
+  });
+
+  it("refuses to send a forced id the agent doesn't expose", () => {
+    const { result } = renderTools({ agent: agent([searchTool]) });
+    act(() => result.current.toggleForcedTool(99));
+    expect(result.current.resolveToolOptions().forcedToolId).toBeNull();
+  });
+
+  it("computes allowed ids from every agent tool, not just the visible rows", async () => {
+    apiFetchMock.mockResolvedValue({ "0": { disabled_tool_ids: [2] } });
+    const { result } = renderTools({
+      agent: agent([searchTool, imageTool, fileReaderTool]),
+    });
+
+    await waitFor(() => expect(result.current.disabledToolIds).toEqual([2]));
+    // 3 is the hidden File Reader — dropping it here would strip it server-side.
+    expect(result.current.resolveToolOptions().allowedToolIds).toEqual([1, 3]);
+  });
+
+  it("releases the force when the forced tool is disabled", async () => {
+    const { result } = renderTools({ agent: agent([searchTool, imageTool]) });
+    act(() => result.current.toggleForcedTool(2));
+    expect(result.current.forcedToolId).toBe(2);
+
+    await act(async () => {
+      result.current.toggleToolEnabled(2);
+    });
+    expect(result.current.forcedToolId).toBeNull();
+  });
+
+  it("keeps the force when a different tool is disabled", async () => {
+    const { result } = renderTools({ agent: agent([searchTool, imageTool]) });
+    act(() => result.current.toggleForcedTool(2));
+
+    await act(async () => {
+      result.current.toggleToolEnabled(1);
+    });
+    expect(result.current.forcedToolId).toBe(2);
+  });
+
+  it("keeps the menu rows while the agent is momentarily unknown", async () => {
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useComposerToolsState>[0]) =>
+        useComposerToolsState(props),
+      {
+        wrapper,
+        initialProps: {
+          chatSessionId: null,
+          agent: agent([searchTool, imageTool]),
+          isProjectWorkflow: false,
+          projectId: null,
+        },
+      },
+    );
+    expect(result.current.actionTools).toHaveLength(2);
+
+    rerender({
+      chatSessionId: "session-1",
+      agent: null,
+      isProjectWorkflow: false,
+      projectId: null,
+    });
+    // The menu and the forced pill both key off this; zeroing it hides them mid-conversation.
+    expect(result.current.actionTools).toHaveLength(2);
+  });
+
+  it("keeps the disabled set while the agent is momentarily unknown", async () => {
+    apiFetchMock.mockResolvedValue({ "0": { disabled_tool_ids: [2] } });
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useComposerToolsState>[0]) =>
+        useComposerToolsState(props),
+      {
+        wrapper,
+        initialProps: {
+          chatSessionId: null,
+          agent: agent([searchTool, imageTool]),
+          isProjectWorkflow: false,
+          projectId: null,
+        },
+      },
+    );
+    await waitFor(() => expect(result.current.disabledToolIds).toEqual([2]));
+
+    rerender({
+      chatSessionId: "session-1",
+      agent: null,
+      isProjectWorkflow: false,
+      projectId: null,
+    });
+    expect(result.current.disabledToolIds).toEqual([2]);
+    expect(result.current.resolveToolOptions().allowedToolIds).toEqual([1]);
+  });
+
+  it("still sends the force and the allowlist while the agent is momentarily unknown", async () => {
+    apiFetchMock.mockResolvedValue({ "0": { disabled_tool_ids: [2] } });
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useComposerToolsState>[0]) =>
+        useComposerToolsState(props),
+      {
+        wrapper,
+        initialProps: {
+          chatSessionId: null,
+          agent: agent([searchTool, imageTool, fileReaderTool]),
+          isProjectWorkflow: false,
+          projectId: null,
+        },
+      },
+    );
+    await waitFor(() => expect(result.current.disabledToolIds).toEqual([2]));
+    act(() => result.current.toggleForcedTool(1));
+
+    // The send created the session, but it hasn't reached the sessions list yet.
+    rerender({
+      chatSessionId: "session-1",
+      agent: null,
+      isProjectWorkflow: false,
+      projectId: null,
+    });
+
+    expect(result.current.resolveToolOptions().forcedToolId).toBe(1);
+    expect(result.current.resolveToolOptions().allowedToolIds).toEqual([1, 3]);
+  });
+
+  it("never sends a forced id that is also disabled", async () => {
+    apiFetchMock.mockResolvedValue({ "0": { disabled_tool_ids: [2] } });
+    const { result } = renderTools({ agent: agent([searchTool, imageTool]) });
+    await waitFor(() => expect(result.current.disabledToolIds).toEqual([2]));
+
+    act(() => result.current.toggleForcedTool(2));
+    expect(result.current.resolveToolOptions().forcedToolId).toBeNull();
   });
 });

--- a/mobile/src/state/__tests__/ComposerToolsProvider.test.tsx
+++ b/mobile/src/state/__tests__/ComposerToolsProvider.test.tsx
@@ -158,6 +158,7 @@ describe("useComposerToolsState", () => {
     act(() => result.current.toggleDeepResearch());
 
     // Re-gating here would withdraw the control the user just used and drop it from the request.
+    act(() => result.current.notePendingSend());
     rerender({
       chatSessionId: "session-1",
       agent: null,
@@ -264,6 +265,7 @@ describe("useComposerToolsState", () => {
     );
     expect(result.current.actionTools).toHaveLength(2);
 
+    act(() => result.current.notePendingSend());
     rerender({
       chatSessionId: "session-1",
       agent: null,
@@ -291,6 +293,7 @@ describe("useComposerToolsState", () => {
     );
     await waitFor(() => expect(result.current.disabledToolIds).toEqual([2]));
 
+    act(() => result.current.notePendingSend());
     rerender({
       chatSessionId: "session-1",
       agent: null,
@@ -299,6 +302,35 @@ describe("useComposerToolsState", () => {
     });
     expect(result.current.disabledToolIds).toEqual([2]);
     expect(result.current.resolveToolOptions().allowedToolIds).toEqual([1]);
+  });
+
+  it("does not carry the composer's agent into an existing chat opened from the landing", async () => {
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useComposerToolsState>[0]) =>
+        useComposerToolsState(props),
+      {
+        wrapper,
+        initialProps: {
+          chatSessionId: null,
+          agent: agent([searchTool, imageTool]),
+          isProjectWorkflow: false,
+          projectId: null,
+        },
+      },
+    );
+    expect(result.current.actionTools).toHaveLength(2);
+
+    // No notePendingSend: the user tapped an existing chat rather than sending. The landing's
+    // agent says nothing about that conversation.
+    rerender({
+      chatSessionId: "session-9",
+      agent: null,
+      isProjectWorkflow: false,
+      projectId: null,
+    });
+
+    expect(result.current.actionTools).toEqual([]);
+    expect(result.current.resolveToolOptions().forcedToolId).toBeNull();
   });
 
   it("refuses to describe a different conversation with the previous one's agent", async () => {
@@ -356,6 +388,7 @@ describe("useComposerToolsState", () => {
     act(() => result.current.toggleForcedTool(1));
 
     // The send created the session, but it hasn't reached the sessions list yet.
+    act(() => result.current.notePendingSend());
     rerender({
       chatSessionId: "session-1",
       agent: null,

--- a/mobile/src/state/__tests__/ComposerToolsProvider.test.tsx
+++ b/mobile/src/state/__tests__/ComposerToolsProvider.test.tsx
@@ -142,6 +142,7 @@ describe("useComposerToolsState", () => {
   });
 
   it("holds the pill through the agent-unknown window after a send", () => {
+    const sendAgent = agent([searchTool]);
     const { result, rerender } = renderHook(
       (props: Parameters<typeof useComposerToolsState>[0]) =>
         useComposerToolsState(props),
@@ -149,7 +150,7 @@ describe("useComposerToolsState", () => {
         wrapper,
         initialProps: {
           chatSessionId: null,
-          agent: agent([searchTool]),
+          agent: sendAgent,
           isProjectWorkflow: false,
           projectId: null,
         },
@@ -158,7 +159,7 @@ describe("useComposerToolsState", () => {
     act(() => result.current.toggleDeepResearch());
 
     // Re-gating here would withdraw the control the user just used and drop it from the request.
-    act(() => result.current.notePendingSend());
+    act(() => result.current.notePendingSend(sendAgent));
     rerender({
       chatSessionId: "session-1",
       agent: null,
@@ -250,6 +251,7 @@ describe("useComposerToolsState", () => {
   });
 
   it("keeps the menu rows while the agent is momentarily unknown", async () => {
+    const sendAgent = agent([searchTool, imageTool]);
     const { result, rerender } = renderHook(
       (props: Parameters<typeof useComposerToolsState>[0]) =>
         useComposerToolsState(props),
@@ -257,7 +259,7 @@ describe("useComposerToolsState", () => {
         wrapper,
         initialProps: {
           chatSessionId: null,
-          agent: agent([searchTool, imageTool]),
+          agent: sendAgent,
           isProjectWorkflow: false,
           projectId: null,
         },
@@ -265,7 +267,7 @@ describe("useComposerToolsState", () => {
     );
     expect(result.current.actionTools).toHaveLength(2);
 
-    act(() => result.current.notePendingSend());
+    act(() => result.current.notePendingSend(sendAgent));
     rerender({
       chatSessionId: "session-1",
       agent: null,
@@ -278,6 +280,7 @@ describe("useComposerToolsState", () => {
 
   it("keeps the disabled set while the agent is momentarily unknown", async () => {
     apiFetchMock.mockResolvedValue({ "0": { disabled_tool_ids: [2] } });
+    const sendAgent = agent([searchTool, imageTool]);
     const { result, rerender } = renderHook(
       (props: Parameters<typeof useComposerToolsState>[0]) =>
         useComposerToolsState(props),
@@ -285,7 +288,7 @@ describe("useComposerToolsState", () => {
         wrapper,
         initialProps: {
           chatSessionId: null,
-          agent: agent([searchTool, imageTool]),
+          agent: sendAgent,
           isProjectWorkflow: false,
           projectId: null,
         },
@@ -293,7 +296,7 @@ describe("useComposerToolsState", () => {
     );
     await waitFor(() => expect(result.current.disabledToolIds).toEqual([2]));
 
-    act(() => result.current.notePendingSend());
+    act(() => result.current.notePendingSend(sendAgent));
     rerender({
       chatSessionId: "session-1",
       agent: null,
@@ -304,7 +307,9 @@ describe("useComposerToolsState", () => {
     expect(result.current.resolveToolOptions().allowedToolIds).toEqual([1]);
   });
 
-  it("does not carry the composer's agent into an existing chat opened from the landing", async () => {
+  it("records the agent the send used, not one picked while the create was in flight", async () => {
+    const sentWith = agent([searchTool, imageTool]);
+    const switchedTo: MinimalAgent = { ...agent([searchTool]), id: 12 };
     const { result, rerender } = renderHook(
       (props: Parameters<typeof useComposerToolsState>[0]) =>
         useComposerToolsState(props),
@@ -312,7 +317,42 @@ describe("useComposerToolsState", () => {
         wrapper,
         initialProps: {
           chatSessionId: null,
-          agent: agent([searchTool, imageTool]),
+          agent: sentWith,
+          isProjectWorkflow: false,
+          projectId: null,
+        },
+      },
+    );
+
+    // The send goes out, then the user taps a different agent before the session comes back.
+    act(() => result.current.notePendingSend(sentWith));
+    rerender({
+      chatSessionId: null,
+      agent: switchedTo,
+      isProjectWorkflow: false,
+      projectId: null,
+    });
+
+    // The session lands. It runs on the agent that created it, not the newer selection.
+    rerender({
+      chatSessionId: "session-1",
+      agent: null,
+      isProjectWorkflow: false,
+      projectId: null,
+    });
+    expect(result.current.actionTools.map((tool) => tool.id)).toEqual([1, 2]);
+  });
+
+  it("does not carry the composer's agent into an existing chat opened from the landing", async () => {
+    const sendAgent = agent([searchTool, imageTool]);
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useComposerToolsState>[0]) =>
+        useComposerToolsState(props),
+      {
+        wrapper,
+        initialProps: {
+          chatSessionId: null,
+          agent: sendAgent,
           isProjectWorkflow: false,
           projectId: null,
         },
@@ -371,6 +411,7 @@ describe("useComposerToolsState", () => {
 
   it("still sends the force and the allowlist while the agent is momentarily unknown", async () => {
     apiFetchMock.mockResolvedValue({ "0": { disabled_tool_ids: [2] } });
+    const sendAgent = agent([searchTool, imageTool, fileReaderTool]);
     const { result, rerender } = renderHook(
       (props: Parameters<typeof useComposerToolsState>[0]) =>
         useComposerToolsState(props),
@@ -378,7 +419,7 @@ describe("useComposerToolsState", () => {
         wrapper,
         initialProps: {
           chatSessionId: null,
-          agent: agent([searchTool, imageTool, fileReaderTool]),
+          agent: sendAgent,
           isProjectWorkflow: false,
           projectId: null,
         },
@@ -388,7 +429,7 @@ describe("useComposerToolsState", () => {
     act(() => result.current.toggleForcedTool(1));
 
     // The send created the session, but it hasn't reached the sessions list yet.
-    act(() => result.current.notePendingSend());
+    act(() => result.current.notePendingSend(sendAgent));
     rerender({
       chatSessionId: "session-1",
       agent: null,


### PR DESCRIPTION
## Description

- Adds the composer's actions menu: tapping a tool row forces it for the next turn, and a trailing control switches a tool off for that agent (persisted server-side, shared with web). The send request now carries `forced_tool_id` and `allowed_tool_ids`.
- Ships as a bottom sheet rather than web's anchored popover — the mobile composer is keyboard-sticky, so an anchored panel would chase a moving anchor.
- Extracts that sheet shell into `components/ui/sheet.tsx`; the file picker, cited sources and reasoning full-text sheets each dropped their own copy, leaving one `<Modal>` in the app. Their wrappers are now hidden from VoiceOver, which previously read each sheet as a single blob with Close unreachable.
- Fixes project chats never resolving their agent: the sessions list is fetched with `only_non_project_chats=true`, so the menu was absent there and every turn fell back to allowing all tools. The persona now comes from the hydrated session.

## How Has This Been Tested?

Unit tests added (84 suites / 675 tests green, plus typecheck and lint); the load-bearing guards were mutation-checked. Not yet exercised on a device.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a mobile Actions menu to force a tool for the next turn and enable/disable tools per agent, plus a deep-research toggle in the composer. Sends now include `forced_tool_id`, `allowed_tool_ids`, and the deep-research flag; a shared bottom-sheet `Sheet` powers all sheets, and state stays correct across sends, chat switches, projects, and logouts.

- **New Features**
  - Actions menu (bottom sheet): sliders trigger appears only when the agent has selectable tools; tap a row to force; trailing control toggles enable/disable; opening the menu dismisses the keyboard; a capped-width forced pill sits in the toolbar and releases on tap.
  - Preferences persisted server-side; allowed ids are computed from the agent’s full tool list (hidden tools preserved); forced ids are only sent if enabled and present.
  - Deep-research pill in the toolbar; gated by the admin setting and the agent having a search tool.
  - New shared `Sheet`; File Picker, Cited Sources, and Reasoning now compose it; wrappers are hidden from VoiceOver for proper focus.

- **Bug Fixes**
  - Project chats resolve their agent from the hydrated session; a null `persona_id` is “unknown”; the project composer describes the default agent so tool ids match the run.
  - Preference writes are fetched-before-patch, serialized, and dropped after a logout or instance switch to prevent cross-account or out-of-order updates.
  - Tool state carries into a new session only after the send is accepted (`onAccepted`) and is pinned to the agent captured before the await; switching agents mid-create no longer mis-describes the finished chat; opening an existing chat from the landing won’t reuse the composer’s agent.
  - A forced id is omitted if disabled or not among the agent’s tools; the composer’s left cluster shrinks so long forced pills don’t push Send off-screen.

<sup>Written for commit a8ff69abdbfea3468c5cdfa534f7404926a59507. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

