### PR TITLE
test(gateway): integration suite driving real Claude Code and Codex through the passthroughs

### DIFF
--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -59,6 +59,7 @@ jobs:
       pull-requests: read
     outputs:
       integration: ${{ steps.filter.outputs.integration || 'true' }}
+      gateway: ${{ steps.filter.outputs.gateway || 'true' }}
     steps:
       - name: Checkout code
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
@@ -82,6 +83,8 @@ jobs:
               - '.github/actions/setup-test-license/**'
               - '.github/actions/install-deps-and-generate-openapi-client/**'
               - '.github/actions/login-ecr-pullthrough-cache/**'
+            gateway:
+              - 'backend/onyx/server/gateway/**'
 
   discover-test-dirs:
     # NOTE: Github-hosted runners have about 20s faster queue times and are preferred here.
@@ -100,10 +103,15 @@ jobs:
 
       - name: Discover test directories
         id: set-matrix
+        env:
+          GATEWAY_CHANGED: ${{ needs.changes.outputs.gateway }}
         run: |
           # Find all leaf-level directories in both test directories.
           # ``craft`` excluded: needs sandbox infra this lane doesn't set up;
-          tests_dirs=$(find backend/tests/integration/tests -mindepth 1 -maxdepth 1 -type d ! -name "__pycache__" ! -name "mcp" ! -name "no_vectordb" ! -name "migrations" ! -name "craft" -exec basename {} \; | sort)
+          tests_dirs=$(find backend/tests/integration/tests -mindepth 1 -maxdepth 1 -type d ! -name "__pycache__" ! -name "mcp" ! -name "no_vectordb" ! -name "migrations" ! -name "craft" ! -name "gateway_clients" -exec basename {} \; | sort)
+          if [[ "$GATEWAY_CHANGED" == "true" ]]; then
+            tests_dirs="$tests_dirs gateway_clients"
+          fi
           connector_dirs=$(find backend/tests/integration/connector_job_tests -mindepth 1 -maxdepth 1 -type d ! -name "__pycache__" -exec basename {} \; | sort)
 
           # Create JSON array with directory info

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -24,6 +24,7 @@ permissions:
 env:
   # Test Environment Variables
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
   SLACK_BOT_TOKEN_TEST_SPACE: ${{ secrets.SLACK_BOT_TOKEN_TEST_SPACE }}
   CONFLUENCE_TEST_SPACE_URL: ${{ vars.CONFLUENCE_TEST_SPACE_URL }}
@@ -361,6 +362,16 @@ jobs:
           command: |
             echo "Running ${{ matrix.edition }} integration tests for ${{ matrix.test-dir.path }}..."
 
+            # gateway_clients drives real CLI subprocesses, which need a real
+            # TCP api_server; run one inside the test container and make every
+            # missing prerequisite a hard failure instead of a skip.
+            GATEWAY_CLIENTS_STRICT=""
+            RUN_CMD="uv run --no-sync pytest -v --tb=short -rs tests/integration/${{ matrix.test-dir.path }}"
+            if [ "${{ matrix.test-dir.path }}" = "tests/gateway_clients" ]; then
+              GATEWAY_CLIENTS_STRICT="true"
+              RUN_CMD="bash tests/integration/tests/gateway_clients/run_with_server.sh"
+            fi
+
             # Mount CLI binary into the container if it exists (CLI tests only)
             CLI_VOLUME=""
             if [ -f "${{ github.workspace }}/onyx-cli-test" ]; then
@@ -391,6 +402,8 @@ jobs:
               -e S3_AWS_ACCESS_KEY_ID=minioadmin \
               -e S3_AWS_SECRET_ACCESS_KEY=minioadmin \
               -e OPENAI_API_KEY=${OPENAI_API_KEY} \
+              -e ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY} \
+              -e GATEWAY_CLIENT_TESTS_REQUIRED=${GATEWAY_CLIENTS_STRICT} \
               -e EXA_API_KEY=${EXA_API_KEY} \
               -e SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN} \
               -e SLACK_BOT_TOKEN_TEST_SPACE=${SLACK_BOT_TOKEN_TEST_SPACE} \
@@ -419,7 +432,7 @@ jobs:
               -e ENABLE_CRAFT=true \
               -e ONYX_DEV_LICENSE \
               ${{ env.RUNS_ON_ECR_CACHE }}:integration-test-devcontainer-${{ github.run_id }} \
-              uv run --no-sync pytest -v --tb=short -rs tests/integration/${{ matrix.test-dir.path }}
+              $RUN_CMD
 
       # ------------------------------------------------------------
       # Always gather logs BEFORE "down". The test-runner container's

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -85,6 +85,7 @@ jobs:
               - '.github/actions/login-ecr-pullthrough-cache/**'
             gateway:
               - 'backend/onyx/server/gateway/**'
+              - 'backend/tests/integration/tests/gateway_clients/**'
 
   discover-test-dirs:
     # NOTE: Github-hosted runners have about 20s faster queue times and are preferred here.

--- a/backend/onyx/server/gateway/anthropic_passthrough.py
+++ b/backend/onyx/server/gateway/anthropic_passthrough.py
@@ -89,7 +89,7 @@ def is_anthropic_passthrough_eligible(provider: LLMProviderView) -> bool:
 
 def _append_api_path(provider: LLMProviderView, suffix: str) -> str:
     parsed = urlsplit(provider.api_base or "https://api.anthropic.com")
-    path = parsed.path.rstrip("/") + suffix
+    path = parsed.path.rstrip("/").removesuffix("/v1") + suffix
     return urlunsplit(parsed._replace(path=path))
 
 

--- a/backend/onyx/server/gateway/anthropic_passthrough.py
+++ b/backend/onyx/server/gateway/anthropic_passthrough.py
@@ -14,6 +14,7 @@ import queue
 import threading
 from contextlib import ExitStack
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 from fastapi import Request
@@ -86,16 +87,18 @@ def is_anthropic_passthrough_eligible(provider: LLMProviderView) -> bool:
     return ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED and provider.provider == "anthropic"
 
 
-def _base_url(provider: LLMProviderView) -> str:
-    return (provider.api_base or "https://api.anthropic.com").rstrip("/")
+def _append_api_path(provider: LLMProviderView, suffix: str) -> str:
+    parsed = urlsplit(provider.api_base or "https://api.anthropic.com")
+    path = parsed.path.rstrip("/") + suffix
+    return urlunsplit(parsed._replace(path=path))
 
 
 def _messages_url(provider: LLMProviderView) -> str:
-    return _base_url(provider) + "/v1/messages"
+    return _append_api_path(provider, "/v1/messages")
 
 
 def _count_tokens_url(provider: LLMProviderView) -> str:
-    return _base_url(provider) + "/v1/messages/count_tokens"
+    return _append_api_path(provider, "/v1/messages/count_tokens")
 
 
 def _timeout() -> httpx.Timeout:

--- a/backend/onyx/server/gateway/openai_passthrough.py
+++ b/backend/onyx/server/gateway/openai_passthrough.py
@@ -7,6 +7,8 @@ import hashlib
 import json
 import queue
 import threading
+import time
+import uuid
 from contextlib import ExitStack
 from typing import Any
 
@@ -27,7 +29,12 @@ from onyx.server.gateway.configs import (
     OPENAI_PASSTHROUGH_CONNECT_TIMEOUT_SECONDS,
     OPENAI_PASSTHROUGH_READ_TIMEOUT_SECONDS,
 )
-from onyx.server.gateway.models import ResponsesRequest
+from onyx.server.gateway.models import (
+    ResponsesErrorCode,
+    ResponsesFailedEvent,
+    ResponsesObjectPayload,
+    ResponsesRequest,
+)
 from onyx.server.gateway.stream_bridge import (
     _put_stream_item,
     _sse_response,
@@ -328,7 +335,23 @@ def handle_openai_responses_passthrough(
                 )
             return _non_streaming_error_response(response)
 
-        response_body = response.json()
+        try:
+            response_body = response.json()
+            if not isinstance(response_body, dict):
+                raise ValueError("response body is not an object")
+        except ValueError as e:
+            if span is not None:
+                span.set_error(
+                    {
+                        "message": f"malformed upstream response: {type(e).__name__}",
+                        "data": None,
+                    }
+                )
+            logger.warning(
+                "OpenAI passthrough returned a malformed success response for model %s",
+                request.model,
+            )
+            raise OnyxError(OnyxErrorCode.BAD_GATEWAY, _SANITIZED_ERROR) from e
         usage = response_body.get("usage")
         output_items = response_body.get("output") or []
         text = "\n\n".join(
@@ -375,10 +398,26 @@ def _openai_passthrough_stream_worker(
     out: "queue.Queue[Any]",
     cancelled: threading.Event,
 ) -> None:
+    response_id = f"resp_{uuid.uuid4().hex}"
+    created_at = int(time.time())
+
     def emit_error(*, message: str, error_type: str) -> None:
+        code: ResponsesErrorCode = (
+            "rate_limit_exceeded"
+            if error_type in ("rate_limit_error", "rate_limit_exceeded")
+            else "server_error"
+        )
         payload = {
-            "type": "response.failed",
-            "response": {"error": {"message": message, "type": error_type}},
+            **ResponsesFailedEvent.create(
+                ResponsesObjectPayload.failed(
+                    response_id=response_id,
+                    created_at=created_at,
+                    model=model,
+                    message=message,
+                    code=code,
+                )
+            ).to_wire(),
+            "sequence_number": 0,
         }
         _put_stream_item(out, f"data: {json.dumps(payload)}\n\n", cancelled)
 

--- a/backend/onyx/server/gateway/openai_passthrough.py
+++ b/backend/onyx/server/gateway/openai_passthrough.py
@@ -399,7 +399,8 @@ def _openai_passthrough_stream_worker(
     cancelled: threading.Event,
 ) -> None:
     response_id = f"resp_{uuid.uuid4().hex}"
-    created_at = int(time.time())
+    response_created_at = int(time.time())
+    next_sequence_number = 0
 
     def emit_error(*, message: str, error_type: str) -> None:
         code: ResponsesErrorCode = (
@@ -411,13 +412,13 @@ def _openai_passthrough_stream_worker(
             **ResponsesFailedEvent.create(
                 ResponsesObjectPayload.failed(
                     response_id=response_id,
-                    created_at=created_at,
+                    created_at=response_created_at,
                     model=model,
                     message=message,
                     code=code,
                 )
             ).to_wire(),
-            "sequence_number": 0,
+            "sequence_number": next_sequence_number,
         }
         _put_stream_item(out, f"data: {json.dumps(payload)}\n\n", cancelled)
 
@@ -478,6 +479,9 @@ def _openai_passthrough_stream_worker(
                 return
 
             frame_lines: list[str] = []
+            frame_response_id: str | None = None
+            frame_created_at: int | None = None
+            frame_next_sequence: int | None = None
             for line in response.iter_lines():
                 if cancelled.is_set():
                     break
@@ -487,6 +491,15 @@ def _openai_passthrough_stream_worker(
                         frame_lines = []
                         if not _put_stream_item(out, frame_text + "\n\n", cancelled):
                             break
+                        if frame_response_id is not None:
+                            response_id = frame_response_id
+                        if frame_created_at is not None:
+                            response_created_at = frame_created_at
+                        if frame_next_sequence is not None:
+                            next_sequence_number = frame_next_sequence
+                        frame_response_id = None
+                        frame_created_at = None
+                        frame_next_sequence = None
                     continue
                 frame_lines.append(line)
                 if not line.startswith("data: "):
@@ -501,6 +514,17 @@ def _openai_passthrough_stream_worker(
                     )
                     continue
                 event_type = event.get("type")
+                event_response = event.get("response")
+                if isinstance(event_response, dict):
+                    upstream_response_id = event_response.get("id")
+                    if isinstance(upstream_response_id, str):
+                        frame_response_id = upstream_response_id
+                    upstream_created_at = event_response.get("created_at")
+                    if isinstance(upstream_created_at, int):
+                        frame_created_at = upstream_created_at
+                upstream_sequence = event.get("sequence_number")
+                if isinstance(upstream_sequence, int):
+                    frame_next_sequence = upstream_sequence + 1
                 if event_type == "response.output_text.delta":
                     delta_text = event.get("delta")
                     if isinstance(delta_text, str):
@@ -527,7 +551,13 @@ def _openai_passthrough_stream_worker(
                         if error and span is not None:
                             span.set_error({"message": str(error), "data": None})
             if frame_lines and not cancelled.is_set():
-                _put_stream_item(out, "\n".join(frame_lines) + "\n\n", cancelled)
+                if _put_stream_item(out, "\n".join(frame_lines) + "\n\n", cancelled):
+                    if frame_response_id is not None:
+                        response_id = frame_response_id
+                    if frame_created_at is not None:
+                        response_created_at = frame_created_at
+                    if frame_next_sequence is not None:
+                        next_sequence_number = frame_next_sequence
             # Managed-key cost accounting normally happens inside
             # LLM.invoke/stream, which this path bypasses.
             if state.usage is not None and isinstance(llm, LitellmLLM):

--- a/backend/onyx/server/gateway/stream_bridge.py
+++ b/backend/onyx/server/gateway/stream_bridge.py
@@ -109,17 +109,28 @@ def _stream_worker_guard(
         else:
             message, error_type = _UPSTREAM_ERROR
         if span is not None:
-            span.set_error({"message": f"{type(exc).__name__}: {exc}", "data": None})
-        logger.exception(
-            "LLM gateway %s failed (%s) for model %s", label, error_type, model
+            span.set_error(
+                {"message": f"{type(exc).__name__}: {error_type}", "data": None}
+            )
+        logger.warning(
+            "LLM gateway %s failed (%s, %s) for model %s",
+            label,
+            error_type,
+            type(exc).__name__,
+            model,
         )
         emit_error(message=message, error_type=error_type)
     finally:
         try:
             if isinstance(state.upstream, _ClosableStream):
                 state.upstream.close()
-        except Exception:
-            logger.exception("LLM gateway %s cleanup failed for model %s", label, model)
+        except Exception as cleanup_error:
+            logger.warning(
+                "LLM gateway %s cleanup failed (%s) for model %s",
+                label,
+                type(cleanup_error).__name__,
+                model,
+            )
         try:
             if span is not None:
                 record_llm_span_output(
@@ -129,9 +140,12 @@ def _stream_worker_guard(
                     reasoning="".join(state.reasoning) or None,
                     tool_calls=_finalize_tool_calls(state.tool_call_buffer),
                 )
-        except Exception:
-            logger.exception(
-                "LLM gateway %s span cleanup failed for model %s", label, model
+        except Exception as span_error:
+            logger.warning(
+                "LLM gateway %s span cleanup failed (%s) for model %s",
+                label,
+                type(span_error).__name__,
+                model,
             )
         finally:
             _put_stream_item(out, _STREAM_END, cancelled)

--- a/backend/tests/integration/tests/gateway_clients/README.md
+++ b/backend/tests/integration/tests/gateway_clients/README.md
@@ -11,9 +11,9 @@ Every other suite under `tests/integration` talks to an in-process FastAPI
 *subprocess*, which needs a real TCP listener. `conftest.py`'s
 `_real_api_server` fixture therefore:
 
-- Skips the whole module if nothing answers `GET {API_SERVER_URL}/health`
-  (default `http://127.0.0.1:8080`) — you need a real, out-of-process dev
-  `api_server` running, not just Postgres/Redis/etc.
+- Skips the whole module unless `GET {API_SERVER_URL}/health` returns the Onyx
+  health payload (default `http://127.0.0.1:8080`) — you need a real,
+  out-of-process dev `api_server` running, not just Postgres/Redis/etc.
 - Swaps the shared `tests.integration.common_utils.http_client` client for a
   raw `httpx.Client` for the module's duration, so the existing Manager
   helpers (PAT, LLM provider) hit that real server too.
@@ -33,8 +33,8 @@ Requirements:
   serves a different checkout). The server must run THIS branch's code, since
   the suite exercises both passthrough modules. An in-process TestClient is
   not enough: the CLI subprocesses need a real TCP socket.
-- `node`/`npm` on `PATH` — the suite installs pinned `claude`/`codex` CLI
-  versions into a throwaway npm prefix per module run.
+- `node`/`npm` on `PATH` — each suite installs its pinned `claude` or `codex`
+  CLI version into an independent throwaway npm prefix per module run.
 - `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` resolvable via
   `tests/utils/aws_secrets.py` (env var, `.vscode/.env`, or AWS Secrets
   Manager). Tests declare these with `@pytest.mark.secrets(...)` and skip
@@ -68,5 +68,5 @@ tiers per repo convention. Never `gpt-4o-mini`.
 ## Cost / runtime
 
 Each test makes 1-3 cheap-tier LLM calls. Expect well under $0.01 total and
-roughly 1-2 minutes of wall time (dominated by the `npm install` in
-`npm_prefix`, which is cached per module run, and CLI subprocess startup).
+roughly 1-2 minutes of wall time (dominated by the client-specific `npm install`,
+which is cached per module run, and CLI subprocess startup).

--- a/backend/tests/integration/tests/gateway_clients/README.md
+++ b/backend/tests/integration/tests/gateway_clients/README.md
@@ -1,0 +1,72 @@
+# Gateway Client Integration Tests
+
+Exercises the Onyx AI gateway's Anthropic (`onyx/server/gateway/anthropic_passthrough.py`)
+and OpenAI (`onyx/server/gateway/openai_passthrough.py`) passthrough endpoints with
+REAL coding-agent CLIs: `@anthropic-ai/claude-code` and `@openai/codex`.
+
+## Why this directory is different
+
+Every other suite under `tests/integration` talks to an in-process FastAPI
+`TestClient` (no real socket). Here the request is made by an external CLI
+*subprocess*, which needs a real TCP listener. `conftest.py`'s
+`_real_api_server` fixture therefore:
+
+- Skips the whole module if nothing answers `GET {API_SERVER_URL}/health`
+  (default `http://127.0.0.1:8080`) — you need a real, out-of-process dev
+  `api_server` running, not just Postgres/Redis/etc.
+- Swaps the shared `tests.integration.common_utils.http_client` client for a
+  raw `httpx.Client` for the module's duration, so the existing Manager
+  helpers (PAT, LLM provider) hit that real server too.
+- Logs in as the standing dev admin (`admin_user@example.com`, see the repo
+  `CLAUDE.md`) rather than creating a user or calling `reset_all()` — this
+  suite must never wipe a shared, already-running deployment.
+
+## Running locally
+
+```bash
+uv run --env-file .vscode/.env pytest backend/tests/integration/tests/gateway_clients
+```
+
+Requirements:
+- A real `api_server` reachable at `API_SERVER_URL` (default `127.0.0.1:8080`;
+  override with `API_SERVER_HOST` / `API_SERVER_PORT`, e.g. when 8080 already
+  serves a different checkout). The server must run THIS branch's code, since
+  the suite exercises both passthrough modules. An in-process TestClient is
+  not enough: the CLI subprocesses need a real TCP socket.
+- `node`/`npm` on `PATH` — the suite installs pinned `claude`/`codex` CLI
+  versions into a throwaway npm prefix per module run.
+- `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` resolvable via
+  `tests/utils/aws_secrets.py` (env var, `.vscode/.env`, or AWS Secrets
+  Manager). Tests declare these with `@pytest.mark.secrets(...)` and skip
+  cleanly if a key is unavailable.
+- The gateway's provider-side flags on: `ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED`
+  and `OPENAI_GATEWAY_PASSTHROUGH_ENABLED` (both default on).
+
+Models used: `claude-haiku-4-5` (Anthropic) and `gpt-5-mini` (OpenAI) — cheap
+tiers per repo convention. Never `gpt-4o-mini`.
+
+## Coverage
+
+`test_claude_code_gateway.py`:
+1. A basic `claude -p` turn answers correctly through `/gateway/v1/messages`.
+2. A tool-use turn (`--allowedTools "Bash(ls:*)"`, `MAX_THINKING_TOKENS`)
+   proves thinking-block signature replay across turns.
+3. A direct `/v1/messages` call with the `web_search_20250305` server tool —
+   a passthrough-only capability the OpenAI-shaped translation path cannot
+   carry.
+4. `count_tokens` exactness against a real turn's `usage.input_tokens`.
+5. `mcp_servers` is refused with `400 INVALID_INPUT`.
+
+`test_codex_gateway.py`:
+1. A basic `codex exec --json` turn through `/gateway/v1/responses`.
+2. Encrypted reasoning (`include=["reasoning.encrypted_content"]`) round-trips
+   across two turns, proving the statelessness contract (`store` is always
+   forced `false`).
+3. `previous_response_id` is refused with `501 NOT_IMPLEMENTED`; an `mcp`
+   tool entry is refused with `400 INVALID_INPUT`.
+
+## Cost / runtime
+
+Each test makes 1-3 cheap-tier LLM calls. Expect well under $0.01 total and
+roughly 1-2 minutes of wall time (dominated by the `npm install` in
+`npm_prefix`, which is cached per module run, and CLI subprocess startup).

--- a/backend/tests/integration/tests/gateway_clients/README.md
+++ b/backend/tests/integration/tests/gateway_clients/README.md
@@ -21,6 +21,13 @@ Every other suite under `tests/integration` talks to an in-process FastAPI
   `CLAUDE.md`) rather than creating a user or calling `reset_all()` — this
   suite must never wipe a shared, already-running deployment.
 
+Skips vs failures: every missing prerequisite (server, npm, CLI install,
+provider secrets) is a *skip* by default, so local boxes and unrelated lanes
+stay usable. The CI lane for this directory sets
+`GATEWAY_CLIENT_TESTS_REQUIRED=true` (and boots an in-container `api_server`
+via `run_with_server.sh`), which turns all of those into hard failures so the
+lane can never go green by silently skipping.
+
 ## Running locally
 
 ```bash

--- a/backend/tests/integration/tests/gateway_clients/conftest.py
+++ b/backend/tests/integration/tests/gateway_clients/conftest.py
@@ -1,0 +1,267 @@
+"""Fixtures for gateway client integration tests.
+
+These tests drive REAL coding-agent CLIs (Claude Code, Codex) against the
+gateway's Anthropic/OpenAI passthrough endpoints. Unlike the rest of
+tests/integration, the request is made by an external subprocess, not by this
+test process, so the in-process FastAPI TestClient the root conftest wires up
+(no real socket) cannot serve it. This directory instead requires a real,
+out-of-process api_server and swaps the shared `http_client` client for a raw
+`httpx.Client` for its duration, so the existing Manager helpers (which always
+build full URLs) hit the real server too.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from onyx.auth.schemas import UserRole
+from onyx.db.enums import Permission
+from onyx.llm.constants import LlmProviderNames
+from tests.integration.common_utils import http_client
+from tests.integration.common_utils.constants import API_SERVER_URL, GENERAL_HEADERS
+from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
+from tests.integration.common_utils.managers.pat import PATManager
+from tests.integration.common_utils.managers.user import DEFAULT_PASSWORD, UserManager
+from tests.integration.common_utils.test_models import (
+    DATestLLMProvider,
+    DATestPAT,
+    DATestUser,
+)
+
+# Opt this directory into the shared @pytest.mark.secrets / test_secrets
+# infrastructure (see tests/utils/pytest_secrets.py).
+from tests.utils.pytest_secrets import (
+    pytest_collection_modifyitems as pytest_collection_modifyitems,
+)
+from tests.utils.pytest_secrets import pytest_configure as pytest_configure
+from tests.utils.pytest_secrets import test_secrets as test_secrets
+from tests.utils.secret_names import TestSecret
+
+CLI_TIMEOUT_SECONDS = 120
+ANTHROPIC_MODEL_NAME = "claude-haiku-4-5"
+OPENAI_MODEL_NAME = "gpt-5-mini"
+
+# The dev admin account created by the playwright global setup / first-user
+# registration (see the project CLAUDE.md). Reused here rather than
+# UserManager.create()/reset_all() so this suite never wipes a shared,
+# already-running dev deployment.
+_DEV_ADMIN_EMAIL = "admin_user@example.com"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _real_api_server() -> Generator[None, None, None]:
+    """Point the shared http_client at a real, out-of-process api_server.
+
+    Skips the whole module if nothing answers at API_SERVER_URL: a CLI
+    subprocess needs an actual TCP socket to connect to, which the rest of
+    tests/integration does not provide.
+    """
+    try:
+        response = httpx.get(f"{API_SERVER_URL}/health", timeout=5)
+        response.raise_for_status()
+    except httpx.HTTPError as e:
+        pytest.skip(
+            f"No real api_server reachable at {API_SERVER_URL} ({e!r}); gateway "
+            "client tests require an out-of-process dev server. See README.md."
+        )
+
+    previous = http_client._test_client
+    http_client.set_test_client(httpx.Client(timeout=60))
+    try:
+        yield
+    finally:
+        http_client.set_test_client(previous)
+
+
+@pytest.fixture(scope="module")
+def npm_prefix() -> Generator[Path, None, None]:
+    """Install pinned CLI versions into a throwaway npm prefix."""
+    if shutil.which("npm") is None:
+        pytest.skip("npm is not available; cannot install the gateway client CLIs.")
+
+    with tempfile.TemporaryDirectory(prefix="onyx-gateway-cli-") as tmpdir:
+        prefix = Path(tmpdir)
+        result = subprocess.run(
+            [
+                "npm",
+                "install",
+                "--prefix",
+                str(prefix),
+                "@anthropic-ai/claude-code",
+                "@openai/codex",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        if result.returncode != 0:
+            pytest.skip(
+                f"npm install of gateway client CLIs failed: {result.stderr[-2000:]}"
+            )
+        yield prefix
+
+
+@pytest.fixture(scope="module")
+def claude_bin(npm_prefix: Path) -> str:
+    path = npm_prefix / "node_modules" / ".bin" / "claude"
+    if not path.exists():
+        pytest.skip("claude CLI binary not found after npm install")
+    return str(path)
+
+
+@pytest.fixture(scope="module")
+def codex_bin(npm_prefix: Path) -> str:
+    path = npm_prefix / "node_modules" / ".bin" / "codex"
+    if not path.exists():
+        pytest.skip("codex CLI binary not found after npm install")
+    return str(path)
+
+
+@pytest.fixture(scope="module")
+def gateway_admin(_real_api_server: None) -> DATestUser:  # noqa: ARG001
+    """Log in as the standing dev admin rather than creating/reset_all()-ing.
+
+    This suite runs against a real, shared dev deployment; it must not wipe
+    its data the way the root `admin_user` fixture does on role mismatch.
+    """
+    try:
+        # role/is_active are placeholders; login_as_user overwrites role from
+        # the real /me response.
+        return UserManager.login_as_user(
+            DATestUser(
+                id="",
+                email=_DEV_ADMIN_EMAIL,
+                password=DEFAULT_PASSWORD,
+                headers=dict(GENERAL_HEADERS),
+                role=UserRole.BASIC,
+                is_active=True,
+            )
+        )
+    except Exception as e:
+        pytest.fail(
+            f"Could not log in as {_DEV_ADMIN_EMAIL}; the gateway client suite "
+            f"needs the standard dev admin account to already exist: {e}"
+        )
+
+
+@pytest.fixture(scope="module")
+def gateway_pat(gateway_admin: DATestUser) -> Generator[DATestPAT, None, None]:
+    pat = PATManager.create(
+        name=f"gateway-client-test-{uuid4()}",
+        expiration_days=1,
+        user_performing_action=gateway_admin,
+        scopes=[Permission.USE_LLM_GATEWAY],
+    )
+    try:
+        yield pat
+    finally:
+        PATManager.revoke(pat.id, gateway_admin)
+
+
+@pytest.fixture(scope="module")
+def anthropic_provider(
+    gateway_admin: DATestUser,
+    test_secrets: dict[TestSecret, str],
+) -> Generator[DATestLLMProvider, None, None]:
+    api_key = test_secrets.get(TestSecret.ANTHROPIC_API_KEY)
+    if not api_key:
+        pytest.skip("ANTHROPIC_API_KEY secret is not available")
+
+    provider = LLMProviderManager.create(
+        user_performing_action=gateway_admin,
+        name=f"gateway-client-test-anthropic-{uuid4()}",
+        provider=LlmProviderNames.ANTHROPIC,
+        api_key=api_key,
+        default_model_name=ANTHROPIC_MODEL_NAME,
+        # Never touch the shared dev deployment's default model.
+        set_as_default=False,
+    )
+    try:
+        yield provider
+    finally:
+        LLMProviderManager.delete(provider, gateway_admin)
+
+
+@pytest.fixture(scope="module")
+def openai_provider(
+    gateway_admin: DATestUser,
+    test_secrets: dict[TestSecret, str],
+) -> Generator[DATestLLMProvider, None, None]:
+    api_key = test_secrets.get(TestSecret.OPENAI_API_KEY)
+    if not api_key:
+        pytest.skip("OPENAI_API_KEY secret is not available")
+
+    provider = LLMProviderManager.create(
+        user_performing_action=gateway_admin,
+        name=f"gateway-client-test-openai-{uuid4()}",
+        provider=LlmProviderNames.OPENAI,
+        api_key=api_key,
+        default_model_name=OPENAI_MODEL_NAME,
+        set_as_default=False,
+    )
+    try:
+        yield provider
+    finally:
+        LLMProviderManager.delete(provider, gateway_admin)
+
+
+def cli_path() -> str:
+    """A minimal but real PATH for CLI subprocesses.
+
+    `codex`'s bin script is a `#!/usr/bin/env node` shim, so PATH needs to
+    resolve `node`, not just the CLI binaries themselves (already passed as
+    absolute paths).
+    """
+    node = shutil.which("node")
+    node_dir = str(Path(node).parent) if node else ""
+    return os.pathsep.join(
+        p for p in (node_dir, "/usr/bin", "/bin", "/usr/local/bin") if p
+    )
+
+
+def run_cli(
+    cmd: list[str], env: dict[str, str], cwd: str, timeout: int = CLI_TIMEOUT_SECONDS
+) -> subprocess.CompletedProcess[str]:
+    """Run a CLI subprocess with a hard timeout, capturing text output."""
+    return subprocess.run(
+        cmd,
+        env=env,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def parse_trailing_json(stdout: str) -> dict[str, object]:
+    """Parse the JSON object at the end of CLI stdout.
+
+    `claude -p --output-format json` occasionally prints a warning line
+    before the JSON payload; find the first `{` and parse from there.
+    """
+    import json
+
+    start = stdout.find("{")
+    if start == -1:
+        raise ValueError(f"No JSON object found in CLI output: {stdout!r}")
+    return json.loads(stdout[start:])
+
+
+def parse_jsonl(stdout: str) -> list[dict[str, object]]:
+    """Parse newline-delimited JSON event output (`codex exec --json`)."""
+    import json
+
+    events: list[dict[str, object]] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line or not line.startswith("{"):
+            continue
+        events.append(json.loads(line))
+    return events

--- a/backend/tests/integration/tests/gateway_clients/conftest.py
+++ b/backend/tests/integration/tests/gateway_clients/conftest.py
@@ -93,11 +93,16 @@ def _real_api_server() -> Generator[None, None, None]:
         )
 
     previous = http_client._test_client
-    http_client.set_test_client(httpx.Client(timeout=60))
+    real_client = httpx.Client(
+        transport=http_client.RetryingTransport(),
+        timeout=httpx.Timeout(60.0, connect=10.0),
+    )
+    http_client.set_test_client(real_client)
     try:
         yield
     finally:
         http_client.set_test_client(previous)
+        real_client.close()
 
 
 def _install_cli(package: str, executable: str) -> Generator[str, None, None]:

--- a/backend/tests/integration/tests/gateway_clients/conftest.py
+++ b/backend/tests/integration/tests/gateway_clients/conftest.py
@@ -47,6 +47,8 @@ from tests.utils.secret_names import TestSecret
 CLI_TIMEOUT_SECONDS = 120
 ANTHROPIC_MODEL_NAME = "claude-haiku-4-5"
 OPENAI_MODEL_NAME = "gpt-5-mini"
+CLAUDE_CODE_PACKAGE = "@anthropic-ai/claude-code@2.1.221"
+CODEX_PACKAGE = "@openai/codex@0.146.0"
 
 # The dev admin account created by the playwright global setup / first-user
 # registration (see the project CLAUDE.md). Reused here rather than
@@ -59,17 +61,21 @@ _DEV_ADMIN_EMAIL = "admin_user@example.com"
 def _real_api_server() -> Generator[None, None, None]:
     """Point the shared http_client at a real, out-of-process api_server.
 
-    Skips the whole module if nothing answers at API_SERVER_URL: a CLI
-    subprocess needs an actual TCP socket to connect to, which the rest of
-    tests/integration does not provide.
+    Skips the whole module unless API_SERVER_URL returns the Onyx health
+    payload: a CLI subprocess needs an actual TCP socket to connect to, which
+    the rest of tests/integration does not provide.
     """
     try:
         response = httpx.get(f"{API_SERVER_URL}/health", timeout=5)
         response.raise_for_status()
-    except httpx.HTTPError as e:
+        payload = response.json()
+        if not isinstance(payload, dict) or payload.get("success") is not True:
+            raise ValueError(f"unexpected health response: {payload!r}")
+    except (httpx.HTTPError, ValueError) as e:
         pytest.skip(
-            f"No real api_server reachable at {API_SERVER_URL} ({e!r}); gateway "
-            "client tests require an out-of-process dev server. See README.md."
+            f"No real api_server returned the Onyx health payload at "
+            f"{API_SERVER_URL} ({e!r}); gateway client tests require an "
+            "out-of-process dev server. See README.md."
         )
 
     previous = http_client._test_client
@@ -80,11 +86,10 @@ def _real_api_server() -> Generator[None, None, None]:
         http_client.set_test_client(previous)
 
 
-@pytest.fixture(scope="module")
-def npm_prefix() -> Generator[Path, None, None]:
-    """Install pinned CLI versions into a throwaway npm prefix."""
+def _install_cli(package: str, executable: str) -> Generator[str, None, None]:
+    """Install one pinned CLI package into an isolated npm prefix."""
     if shutil.which("npm") is None:
-        pytest.skip("npm is not available; cannot install the gateway client CLIs.")
+        pytest.skip(f"npm is not available; cannot install {package}.")
 
     with tempfile.TemporaryDirectory(prefix="onyx-gateway-cli-") as tmpdir:
         prefix = Path(tmpdir)
@@ -94,34 +99,29 @@ def npm_prefix() -> Generator[Path, None, None]:
                 "install",
                 "--prefix",
                 str(prefix),
-                "@anthropic-ai/claude-code",
-                "@openai/codex",
+                package,
             ],
             capture_output=True,
             text=True,
             timeout=180,
         )
         if result.returncode != 0:
-            pytest.skip(
-                f"npm install of gateway client CLIs failed: {result.stderr[-2000:]}"
-            )
-        yield prefix
+            pytest.skip(f"npm install of {package} failed: {result.stderr[-2000:]}")
+
+        path = prefix / "node_modules" / ".bin" / executable
+        if not path.exists():
+            pytest.skip(f"{executable} CLI binary not found after installing {package}")
+        yield str(path)
 
 
 @pytest.fixture(scope="module")
-def claude_bin(npm_prefix: Path) -> str:
-    path = npm_prefix / "node_modules" / ".bin" / "claude"
-    if not path.exists():
-        pytest.skip("claude CLI binary not found after npm install")
-    return str(path)
+def claude_bin() -> Generator[str, None, None]:
+    yield from _install_cli(CLAUDE_CODE_PACKAGE, "claude")
 
 
 @pytest.fixture(scope="module")
-def codex_bin(npm_prefix: Path) -> str:
-    path = npm_prefix / "node_modules" / ".bin" / "codex"
-    if not path.exists():
-        pytest.skip("codex CLI binary not found after npm install")
-    return str(path)
+def codex_bin() -> Generator[str, None, None]:
+    yield from _install_cli(CODEX_PACKAGE, "codex")
 
 
 @pytest.fixture(scope="module")

--- a/backend/tests/integration/tests/gateway_clients/conftest.py
+++ b/backend/tests/integration/tests/gateway_clients/conftest.py
@@ -56,6 +56,19 @@ CODEX_PACKAGE = "@openai/codex@0.146.0"
 # already-running dev deployment.
 _DEV_ADMIN_EMAIL = "admin_user@example.com"
 
+# Set by the CI integration lane for this directory (see
+# .github/workflows/pr-integration-tests.yml). When truthy, every missing
+# prerequisite fails loudly instead of skipping, so the lane can never go
+# green by silently skipping; locally it stays unset and skips keep dev
+# boxes without npm, a running server, or provider keys usable.
+_STRICT_ENV = "GATEWAY_CLIENT_TESTS_REQUIRED"
+
+
+def _skip_or_fail(reason: str) -> None:
+    if os.environ.get(_STRICT_ENV):
+        pytest.fail(reason)
+    pytest.skip(reason)
+
 
 @pytest.fixture(scope="module", autouse=True)
 def _real_api_server() -> Generator[None, None, None]:
@@ -72,7 +85,7 @@ def _real_api_server() -> Generator[None, None, None]:
         if not isinstance(payload, dict) or payload.get("success") is not True:
             raise ValueError(f"unexpected health response: {payload!r}")
     except (httpx.HTTPError, ValueError) as e:
-        pytest.skip(
+        _skip_or_fail(
             f"No real api_server returned the Onyx health payload at "
             f"{API_SERVER_URL} ({e!r}); gateway client tests require an "
             "out-of-process dev server. See README.md."
@@ -89,7 +102,7 @@ def _real_api_server() -> Generator[None, None, None]:
 def _install_cli(package: str, executable: str) -> Generator[str, None, None]:
     """Install one pinned CLI package into an isolated npm prefix."""
     if shutil.which("npm") is None:
-        pytest.skip(f"npm is not available; cannot install {package}.")
+        _skip_or_fail(f"npm is not available; cannot install {package}.")
 
     with tempfile.TemporaryDirectory(prefix="onyx-gateway-cli-") as tmpdir:
         prefix = Path(tmpdir)
@@ -106,11 +119,13 @@ def _install_cli(package: str, executable: str) -> Generator[str, None, None]:
             timeout=180,
         )
         if result.returncode != 0:
-            pytest.skip(f"npm install of {package} failed: {result.stderr[-2000:]}")
+            _skip_or_fail(f"npm install of {package} failed: {result.stderr[-2000:]}")
 
         path = prefix / "node_modules" / ".bin" / executable
         if not path.exists():
-            pytest.skip(f"{executable} CLI binary not found after installing {package}")
+            _skip_or_fail(
+                f"{executable} CLI binary not found after installing {package}"
+            )
         yield str(path)
 
 
@@ -172,7 +187,7 @@ def anthropic_provider(
 ) -> Generator[DATestLLMProvider, None, None]:
     api_key = test_secrets.get(TestSecret.ANTHROPIC_API_KEY)
     if not api_key:
-        pytest.skip("ANTHROPIC_API_KEY secret is not available")
+        _skip_or_fail("ANTHROPIC_API_KEY secret is not available")
 
     provider = LLMProviderManager.create(
         user_performing_action=gateway_admin,
@@ -196,7 +211,7 @@ def openai_provider(
 ) -> Generator[DATestLLMProvider, None, None]:
     api_key = test_secrets.get(TestSecret.OPENAI_API_KEY)
     if not api_key:
-        pytest.skip("OPENAI_API_KEY secret is not available")
+        _skip_or_fail("OPENAI_API_KEY secret is not available")
 
     provider = LLMProviderManager.create(
         user_performing_action=gateway_admin,

--- a/backend/tests/integration/tests/gateway_clients/conftest.py
+++ b/backend/tests/integration/tests/gateway_clients/conftest.py
@@ -16,6 +16,7 @@ import subprocess
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
+from typing import Never
 from uuid import uuid4
 
 import httpx
@@ -64,7 +65,7 @@ _DEV_ADMIN_EMAIL = "admin_user@example.com"
 _STRICT_ENV = "GATEWAY_CLIENT_TESTS_REQUIRED"
 
 
-def _skip_or_fail(reason: str) -> None:
+def _skip_or_fail(reason: str) -> Never:
     if os.environ.get(_STRICT_ENV):
         pytest.fail(reason)
     pytest.skip(reason)
@@ -106,18 +107,21 @@ def _install_cli(package: str, executable: str) -> Generator[str, None, None]:
 
     with tempfile.TemporaryDirectory(prefix="onyx-gateway-cli-") as tmpdir:
         prefix = Path(tmpdir)
-        result = subprocess.run(
-            [
-                "npm",
-                "install",
-                "--prefix",
-                str(prefix),
-                package,
-            ],
-            capture_output=True,
-            text=True,
-            timeout=180,
-        )
+        try:
+            result = subprocess.run(
+                [
+                    "npm",
+                    "install",
+                    "--prefix",
+                    str(prefix),
+                    package,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=180,
+            )
+        except subprocess.TimeoutExpired:
+            _skip_or_fail(f"npm install of {package} timed out after 180 seconds")
         if result.returncode != 0:
             _skip_or_fail(f"npm install of {package} failed: {result.stderr[-2000:]}")
 
@@ -159,11 +163,24 @@ def gateway_admin(_real_api_server: None) -> DATestUser:  # noqa: ARG001
                 is_active=True,
             )
         )
-    except Exception as e:
+    except Exception as login_error:
+        if not os.environ.get(_STRICT_ENV):
+            pytest.fail(
+                f"Could not log in as {_DEV_ADMIN_EMAIL}; the gateway client "
+                f"suite needs the standard dev admin account to already exist: "
+                f"{login_error}"
+            )
+
+    try:
+        user = UserManager.create(email=_DEV_ADMIN_EMAIL)
+    except Exception as create_error:
         pytest.fail(
-            f"Could not log in as {_DEV_ADMIN_EMAIL}; the gateway client suite "
-            f"needs the standard dev admin account to already exist: {e}"
+            f"Could not create {_DEV_ADMIN_EMAIL} in the fresh CI deployment: "
+            f"{create_error}"
         )
+    if user.role != UserRole.ADMIN:
+        pytest.fail(f"Created {_DEV_ADMIN_EMAIL} with role {user.role}, expected admin")
+    return user
 
 
 @pytest.fixture(scope="module")

--- a/backend/tests/integration/tests/gateway_clients/run_with_server.sh
+++ b/backend/tests/integration/tests/gateway_clients/run_with_server.sh
@@ -5,23 +5,53 @@
 # Expected cwd: backend/ (matches the integration test-runner workdir).
 set -uo pipefail
 
-uv run --no-sync uvicorn onyx.main:app --host 127.0.0.1 --port 8080 \
-  > /tmp/gateway-clients-api-server.log 2>&1 &
-server_pid=$!
+api_server_protocol="${API_SERVER_PROTOCOL:-http}"
+api_server_host="${API_SERVER_HOST:-127.0.0.1}"
+api_server_port="${API_SERVER_PORT:-8080}"
+api_server_url="${api_server_protocol}://${api_server_host}:${api_server_port}"
+log_path="/tmp/gateway-clients-api-server.log"
 
+print_server_log_tail() {
+  echo "---- api_server log tail ----"
+  tail -100 "$log_path" || true
+}
+
+# shellcheck disable=SC2329
+cleanup() {
+  kill "$server_pid" 2> /dev/null || true
+  wait "$server_pid" 2> /dev/null || true
+}
+
+uv run --no-sync uvicorn onyx.main:app \
+  --host "$api_server_host" --port "$api_server_port" \
+  > "$log_path" 2>&1 &
+server_pid=$!
+trap cleanup EXIT
+
+ready="false"
 for _ in $(seq 90); do
-  if curl -sf http://127.0.0.1:8080/health > /dev/null; then
+  if ! kill -0 "$server_pid" 2> /dev/null; then
+    echo "api_server exited before becoming ready at ${api_server_url}/health"
+    print_server_log_tail
+    exit 1
+  fi
+  if curl -fsS "${api_server_url}/health" > /dev/null 2>&1; then
+    ready="true"
     break
   fi
   sleep 2
 done
 
+if [ "$ready" != "true" ]; then
+  echo "api_server did not become ready at ${api_server_url}/health"
+  print_server_log_tail
+  exit 1
+fi
+
 uv run --no-sync pytest -v --tb=short -rs tests/integration/tests/gateway_clients
 status=$?
 
-kill "$server_pid" 2> /dev/null || true
 if [ "$status" -ne 0 ]; then
-  echo "---- api_server log tail ----"
-  tail -100 /tmp/gateway-clients-api-server.log || true
+  print_server_log_tail
 fi
 exit "$status"

--- a/backend/tests/integration/tests/gateway_clients/run_with_server.sh
+++ b/backend/tests/integration/tests/gateway_clients/run_with_server.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# CI entrypoint for the gateway client suite. The CLI subprocesses under test
+# need a real TCP api_server, which the in-process TestClient harness cannot
+# provide, so start one in this container (same code, same env) before pytest.
+# Expected cwd: backend/ (matches the integration test-runner workdir).
+set -uo pipefail
+
+uv run --no-sync uvicorn onyx.main:app --host 127.0.0.1 --port 8080 \
+  > /tmp/gateway-clients-api-server.log 2>&1 &
+server_pid=$!
+
+for _ in $(seq 90); do
+  if curl -sf http://127.0.0.1:8080/health > /dev/null; then
+    break
+  fi
+  sleep 2
+done
+
+uv run --no-sync pytest -v --tb=short -rs tests/integration/tests/gateway_clients
+status=$?
+
+kill "$server_pid" 2> /dev/null || true
+if [ "$status" -ne 0 ]; then
+  echo "---- api_server log tail ----"
+  tail -100 /tmp/gateway-clients-api-server.log || true
+fi
+exit "$status"

--- a/backend/tests/integration/tests/gateway_clients/run_with_server.sh
+++ b/backend/tests/integration/tests/gateway_clients/run_with_server.sh
@@ -22,6 +22,14 @@ cleanup() {
   wait "$server_pid" 2> /dev/null || true
 }
 
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+if curl -fsS "${api_server_url}/health" > /dev/null 2>&1; then
+  echo "A server is already responding at ${api_server_url}; refusing to run against stale code"
+  exit 1
+fi
+
 if ! uv run --no-sync alembic upgrade head; then
   echo "Failed to migrate the gateway client test database"
   exit 1
@@ -41,6 +49,11 @@ for _ in $(seq 90); do
     exit 1
   fi
   if curl -fsS "${api_server_url}/health" > /dev/null 2>&1; then
+    if ! kill -0 "$server_pid" 2> /dev/null; then
+      echo "api_server exited while another server answered at ${api_server_url}/health"
+      print_server_log_tail
+      exit 1
+    fi
     ready="true"
     break
   fi

--- a/backend/tests/integration/tests/gateway_clients/run_with_server.sh
+++ b/backend/tests/integration/tests/gateway_clients/run_with_server.sh
@@ -22,6 +22,11 @@ cleanup() {
   wait "$server_pid" 2> /dev/null || true
 }
 
+if ! uv run --no-sync alembic upgrade head; then
+  echo "Failed to migrate the gateway client test database"
+  exit 1
+fi
+
 uv run --no-sync uvicorn onyx.main:app \
   --host "$api_server_host" --port "$api_server_port" \
   > "$log_path" 2>&1 &

--- a/backend/tests/integration/tests/gateway_clients/test_claude_code_gateway.py
+++ b/backend/tests/integration/tests/gateway_clients/test_claude_code_gateway.py
@@ -1,0 +1,174 @@
+"""Integration tests for the Claude Code CLI against the gateway's
+Anthropic Messages API passthrough (onyx.server.gateway.anthropic_passthrough).
+
+Test Suite:
+1. test_basic_turn_answers_correctly - `claude -p` answers correctly through the gateway
+2. test_tool_use_turn_replays_thinking - tool-use turn proves thinking-block signature replay
+3. test_web_search_server_tool - passthrough-only web_search server tool
+4. test_count_tokens_matches_usage - count_tokens exactness against a real turn's usage
+5. test_mcp_servers_refused - mcp_servers is refused with INVALID_INPUT
+"""
+
+import tempfile
+
+import httpx
+import pytest
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.test_models import DATestLLMProvider, DATestPAT
+from tests.integration.tests.gateway_clients.conftest import (
+    ANTHROPIC_MODEL_NAME,
+    cli_path,
+    parse_trailing_json,
+    run_cli,
+)
+from tests.utils.secret_names import TestSecret
+
+pytestmark = pytest.mark.secrets(TestSecret.ANTHROPIC_API_KEY)
+
+
+def _claude_env(
+    pat: DATestPAT, provider: DATestLLMProvider, tmp_home: str
+) -> dict[str, str]:
+    model = f"{provider.id}/{ANTHROPIC_MODEL_NAME}"
+    return {
+        "PATH": cli_path(),
+        "HOME": tmp_home,
+        "ANTHROPIC_BASE_URL": f"{API_SERVER_URL}/gateway",
+        "ANTHROPIC_AUTH_TOKEN": pat.token or "",
+        "ANTHROPIC_MODEL": model,
+        "ANTHROPIC_SMALL_FAST_MODEL": model,
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+        "CI": "true",
+    }
+
+
+def test_basic_turn_answers_correctly(
+    claude_bin: str, gateway_pat: DATestPAT, anthropic_provider: DATestLLMProvider
+) -> None:
+    with tempfile.TemporaryDirectory() as tmp_home:
+        result = run_cli(
+            [
+                claude_bin,
+                "-p",
+                "What is 2+2? Respond with only the digit, nothing else.",
+                "--output-format",
+                "json",
+            ],
+            env=_claude_env(gateway_pat, anthropic_provider, tmp_home),
+            cwd=tmp_home,
+        )
+
+    assert result.returncode == 0, result.stderr
+    payload = parse_trailing_json(result.stdout)
+    assert payload.get("is_error") is False
+    assert "4" in str(payload.get("result", ""))
+
+
+def test_tool_use_turn_replays_thinking(
+    claude_bin: str, gateway_pat: DATestPAT, anthropic_provider: DATestLLMProvider
+) -> None:
+    """A multi-turn tool-use conversation proves the passthrough replays
+    Anthropic thinking-block signatures correctly across turns."""
+    with tempfile.TemporaryDirectory() as tmp_home:
+        env = _claude_env(gateway_pat, anthropic_provider, tmp_home)
+        env["MAX_THINKING_TOKENS"] = "4096"
+        result = run_cli(
+            [
+                claude_bin,
+                "-p",
+                "Run `ls` in the current directory, then tell me how many "
+                "entries it printed.",
+                "--output-format",
+                "json",
+                "--allowedTools",
+                "Bash(ls:*)",
+            ],
+            env=env,
+            cwd=tmp_home,
+        )
+
+    assert result.returncode == 0, result.stderr
+    payload = parse_trailing_json(result.stdout)
+    assert payload.get("is_error") is False
+    num_turns = payload.get("num_turns", 0)
+    assert isinstance(num_turns, int) and num_turns >= 2
+
+
+def test_web_search_server_tool(
+    gateway_pat: DATestPAT, anthropic_provider: DATestLLMProvider
+) -> None:
+    """web_search is a passthrough-only capability: the OpenAI-shaped
+    translation path cannot carry Anthropic server tools."""
+    response = httpx.post(
+        f"{API_SERVER_URL}/gateway/v1/messages",
+        headers={"Authorization": f"Bearer {gateway_pat.token}"},
+        json={
+            "model": f"{anthropic_provider.id}/{ANTHROPIC_MODEL_NAME}",
+            "max_tokens": 1024,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Search the web for the current Onyx (formerly "
+                    "Danswer) GitHub star count and tell me the number.",
+                }
+            ],
+            "tools": [{"type": "web_search_20250305", "name": "web_search"}],
+        },
+        timeout=60,
+    )
+    assert response.status_code == 200, response.text
+    content_blocks = response.json()["content"]
+    block_types = {block.get("type") for block in content_blocks}
+    assert "server_tool_use" in block_types
+    assert "web_search_tool_result" in block_types
+
+
+def test_count_tokens_matches_usage(
+    gateway_pat: DATestPAT, anthropic_provider: DATestLLMProvider
+) -> None:
+    messages = [{"role": "user", "content": "Say hello in exactly one word."}]
+    model = f"{anthropic_provider.id}/{ANTHROPIC_MODEL_NAME}"
+    headers = {"Authorization": f"Bearer {gateway_pat.token}"}
+
+    count_response = httpx.post(
+        f"{API_SERVER_URL}/gateway/v1/messages/count_tokens",
+        headers=headers,
+        json={"model": model, "messages": messages},
+        timeout=60,
+    )
+    assert count_response.status_code == 200, count_response.text
+    counted_tokens = count_response.json()["input_tokens"]
+
+    turn_response = httpx.post(
+        f"{API_SERVER_URL}/gateway/v1/messages",
+        headers=headers,
+        json={"model": model, "max_tokens": 32, "messages": messages},
+        timeout=60,
+    )
+    assert turn_response.status_code == 200, turn_response.text
+    assert turn_response.json()["usage"]["input_tokens"] == counted_tokens
+
+
+def test_mcp_servers_refused(
+    gateway_pat: DATestPAT, anthropic_provider: DATestLLMProvider
+) -> None:
+    response = httpx.post(
+        f"{API_SERVER_URL}/gateway/v1/messages",
+        headers={"Authorization": f"Bearer {gateway_pat.token}"},
+        json={
+            "model": f"{anthropic_provider.id}/{ANTHROPIC_MODEL_NAME}",
+            "max_tokens": 32,
+            "messages": [{"role": "user", "content": "hi"}],
+            "mcp_servers": [
+                {
+                    "type": "url",
+                    "url": "https://example.com/mcp",
+                    "name": "attacker-controlled",
+                }
+            ],
+        },
+        timeout=60,
+    )
+    assert response.status_code == 400, response.text
+    assert response.json()["error_code"] == "INVALID_INPUT"

--- a/backend/tests/integration/tests/gateway_clients/test_codex_gateway.py
+++ b/backend/tests/integration/tests/gateway_clients/test_codex_gateway.py
@@ -1,0 +1,180 @@
+"""Integration tests for the Codex CLI against the gateway's Responses API
+passthrough (onyx.server.gateway.openai_passthrough).
+
+Test Suite:
+1. test_basic_codex_turn - `codex exec` answers correctly through the gateway
+2. test_encrypted_reasoning_statelessness - encrypted reasoning replay across turns, store forced false
+3. test_previous_response_id_refused - previous_response_id -> NOT_IMPLEMENTED
+4. test_mcp_tool_refused - an mcp tool entry -> INVALID_INPUT
+"""
+
+import tempfile
+from pathlib import Path
+
+import httpx
+import pytest
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.test_models import DATestLLMProvider, DATestPAT
+from tests.integration.tests.gateway_clients.conftest import (
+    OPENAI_MODEL_NAME,
+    cli_path,
+    parse_jsonl,
+    run_cli,
+)
+from tests.utils.secret_names import TestSecret
+
+pytestmark = pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
+
+_PROVIDER_KEY = "onyx_gateway"
+
+
+def _write_codex_config(codex_home: str, provider: DATestLLMProvider) -> None:
+    model = f"{provider.id}/{OPENAI_MODEL_NAME}"
+    config_path = Path(codex_home) / "config.toml"
+    config_path.write_text(
+        f"""
+model_provider = "{_PROVIDER_KEY}"
+model = "{model}"
+
+[model_providers.{_PROVIDER_KEY}]
+name = "Onyx Gateway"
+base_url = "{API_SERVER_URL}/gateway/v1"
+env_key = "ONYX_GATEWAY_API_KEY"
+wire_api = "responses"
+"""
+    )
+
+
+def _codex_env(pat: DATestPAT, codex_home: str) -> dict[str, str]:
+    return {
+        "PATH": cli_path(),
+        "HOME": codex_home,
+        "CODEX_HOME": codex_home,
+        "ONYX_GATEWAY_API_KEY": pat.token or "",
+    }
+
+
+def _last_agent_message(events: list[dict[str, object]]) -> str:
+    """`codex exec --json` emits `{"type": "item.completed", "item": {...}}`
+    events; the final agent reply is the last `item.type == "agent_message"`."""
+    for event in reversed(events):
+        item = event.get("item")
+        if isinstance(item, dict) and item.get("type") == "agent_message":
+            return str(item.get("text", ""))
+    return ""
+
+
+def test_basic_codex_turn(
+    codex_bin: str, gateway_pat: DATestPAT, openai_provider: DATestLLMProvider
+) -> None:
+    with tempfile.TemporaryDirectory() as codex_home:
+        _write_codex_config(codex_home, openai_provider)
+        result = run_cli(
+            [
+                codex_bin,
+                "exec",
+                "--json",
+                "--skip-git-repo-check",
+                "What is 2+2? Reply with only the digit, nothing else.",
+            ],
+            env=_codex_env(gateway_pat, codex_home),
+            cwd=codex_home,
+        )
+
+    assert result.returncode == 0, result.stderr
+    events = parse_jsonl(result.stdout)
+    assert "4" in _last_agent_message(events)
+
+
+def test_encrypted_reasoning_statelessness(
+    gateway_pat: DATestPAT, openai_provider: DATestLLMProvider
+) -> None:
+    """The gateway never stores responses (store is always forced false), so
+    a second turn must carry the prior turn's encrypted reasoning item back
+    in `input` rather than referencing it by id."""
+    model = f"{openai_provider.id}/{OPENAI_MODEL_NAME}"
+    headers = {"Authorization": f"Bearer {gateway_pat.token}"}
+
+    first = httpx.post(
+        f"{API_SERVER_URL}/gateway/v1/responses",
+        headers=headers,
+        json={
+            "model": model,
+            "input": [{"role": "user", "content": "What is 6 times 7?"}],
+            "include": ["reasoning.encrypted_content"],
+            "reasoning": {"effort": "low"},
+        },
+        timeout=60,
+    )
+    assert first.status_code == 200, first.text
+    first_body = first.json()
+    assert first_body.get("store") is False
+
+    reasoning_items = [
+        item
+        for item in first_body.get("output", [])
+        if isinstance(item, dict) and item.get("type") == "reasoning"
+    ]
+    assert reasoning_items, "expected an encrypted reasoning item in the output"
+    assert any(item.get("encrypted_content") for item in reasoning_items)
+
+    second = httpx.post(
+        f"{API_SERVER_URL}/gateway/v1/responses",
+        headers=headers,
+        json={
+            "model": model,
+            "input": [
+                {"role": "user", "content": "What is 6 times 7?"},
+                *reasoning_items,
+                {
+                    "role": "user",
+                    "content": "Now divide that result by 2.",
+                },
+            ],
+            "include": ["reasoning.encrypted_content"],
+            "reasoning": {"effort": "low"},
+        },
+        timeout=60,
+    )
+    assert second.status_code == 200, second.text
+
+
+def test_previous_response_id_refused(
+    gateway_pat: DATestPAT, openai_provider: DATestLLMProvider
+) -> None:
+    response = httpx.post(
+        f"{API_SERVER_URL}/gateway/v1/responses",
+        headers={"Authorization": f"Bearer {gateway_pat.token}"},
+        json={
+            "model": f"{openai_provider.id}/{OPENAI_MODEL_NAME}",
+            "input": [{"role": "user", "content": "hi"}],
+            "previous_response_id": "resp_does_not_exist",
+        },
+        timeout=60,
+    )
+    assert response.status_code == 501, response.text
+    assert response.json()["error_code"] == "NOT_IMPLEMENTED"
+
+
+def test_mcp_tool_refused(
+    gateway_pat: DATestPAT, openai_provider: DATestLLMProvider
+) -> None:
+    response = httpx.post(
+        f"{API_SERVER_URL}/gateway/v1/responses",
+        headers={"Authorization": f"Bearer {gateway_pat.token}"},
+        json={
+            "model": f"{openai_provider.id}/{OPENAI_MODEL_NAME}",
+            "input": [{"role": "user", "content": "hi"}],
+            "tools": [
+                {
+                    "type": "mcp",
+                    "server_label": "attacker-controlled",
+                    "server_url": "https://example.com/mcp",
+                }
+            ],
+        },
+        timeout=60,
+    )
+    assert response.status_code == 400, response.text
+    assert response.json()["error_code"] == "INVALID_INPUT"

--- a/backend/tests/unit/onyx/server/gateway/test_anthropic_passthrough.py
+++ b/backend/tests/unit/onyx/server/gateway/test_anthropic_passthrough.py
@@ -20,6 +20,8 @@ from onyx.server.gateway.anthropic_passthrough import (
     AnthropicPassthroughUnavailable,
     _build_upstream_headers,
     _build_upstream_request,
+    _count_tokens_url,
+    _messages_url,
     _non_streaming_error_response,
     _streaming_error_event,
     _usage_from_anthropic_wire,
@@ -48,6 +50,18 @@ def _anthropic_llm() -> _ConfigOnlyLLM:
             temperature=0,
             max_input_tokens=1_000,
         )
+    )
+
+
+def test_passthrough_urls_append_paths_before_query_credentials() -> None:
+    provider = _provider(1, "anthropic", [_model("claude-sonnet-4-6")])
+    provider.api_base = "https://proxy.example/anthropic?api-key=secret"
+
+    assert _messages_url(provider) == (
+        "https://proxy.example/anthropic/v1/messages?api-key=secret"
+    )
+    assert _count_tokens_url(provider) == (
+        "https://proxy.example/anthropic/v1/messages/count_tokens?api-key=secret"
     )
 
 

--- a/backend/tests/unit/onyx/server/gateway/test_anthropic_passthrough.py
+++ b/backend/tests/unit/onyx/server/gateway/test_anthropic_passthrough.py
@@ -64,6 +64,11 @@ def test_passthrough_urls_append_paths_before_query_credentials() -> None:
         "https://proxy.example/anthropic/v1/messages/count_tokens?api-key=secret"
     )
 
+    provider.api_base = "https://proxy.example/anthropic/v1?api-key=secret"
+    assert _messages_url(provider) == (
+        "https://proxy.example/anthropic/v1/messages?api-key=secret"
+    )
+
 
 def _fake_httpx_module(client_factory: Any) -> MagicMock:
     """A stand-in for the ``httpx`` module reference held by

--- a/backend/tests/unit/onyx/server/gateway/test_openai_passthrough.py
+++ b/backend/tests/unit/onyx/server/gateway/test_openai_passthrough.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Iterator
 from contextlib import contextmanager, nullcontext
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -818,15 +819,22 @@ def _expected_sse_text(events: list[dict[str, Any]]) -> str:
 
 class _FakeStreamResponse:
     def __init__(
-        self, status_code: int, lines: list[str], content: bytes = b""
+        self,
+        status_code: int,
+        lines: list[str],
+        content: bytes = b"",
+        stream_error: Exception | None = None,
     ) -> None:
         self.status_code = status_code
         self._lines = lines
         self.content = content
+        self.stream_error = stream_error
         self.closed = False
 
-    def iter_lines(self) -> list[str]:
-        return self._lines
+    def iter_lines(self) -> Iterator[str]:
+        yield from self._lines
+        if self.stream_error is not None:
+            raise self.stream_error
 
     def read(self) -> None:
         pass
@@ -1099,6 +1107,30 @@ def test_passthrough_stream_upstream_error_emits_single_error_frame() -> None:
     assert data["response"]["model"] == "gpt-5-mini"
     assert data["response"]["output"] == []
     assert data["sequence_number"] == 0
+
+
+def test_passthrough_stream_transport_error_continues_response_identity() -> None:
+    created_event = {
+        "type": "response.created",
+        "sequence_number": 7,
+        "response": {
+            "id": "resp_upstream",
+            "created_at": 123,
+        },
+    }
+    response = _FakeStreamResponse(
+        200,
+        _sse_lines([created_event]),
+        stream_error=httpx.ReadError("stream failed"),
+    )
+
+    frames, _ = _run_passthrough_stream(response)
+
+    assert json.loads(frames[0][len("data: ") : -2]) == created_event
+    failure = json.loads(frames[1][len("data: ") : -2])
+    assert failure["response"]["id"] == "resp_upstream"
+    assert failure["response"]["created_at"] == 123
+    assert failure["sequence_number"] == 8
 
 
 def test_passthrough_stream_closes_exitstack_resources() -> None:

--- a/backend/tests/unit/onyx/server/gateway/test_openai_passthrough.py
+++ b/backend/tests/unit/onyx/server/gateway/test_openai_passthrough.py
@@ -450,7 +450,8 @@ def test_build_upstream_request_forwards_unknown_future_fields() -> None:
 def test_build_upstream_headers_only_authorization_and_content_type() -> None:
     provider = _provider(1, "openai", [_model("gpt-5-mini")])
 
-    headers = _build_upstream_headers(provider)
+    with patch.object(openai_passthrough, "build_llm_extra_headers", return_value={}):
+        headers = _build_upstream_headers(provider)
 
     assert headers == {
         "Authorization": f"Bearer {provider.api_key}",
@@ -739,6 +740,16 @@ def test_handle_openai_passthrough_non_streaming_forwards_200_body_verbatim() ->
     assert payload["id"] == "resp_upstream_abc123"
 
 
+def test_handle_openai_passthrough_non_streaming_sanitizes_malformed_200() -> None:
+    fake_response = httpx.Response(200, content=b"not json")
+
+    with pytest.raises(OnyxError) as exc_info:
+        _non_streaming_run(fake_response)
+
+    assert exc_info.value.error_code is OnyxErrorCode.BAD_GATEWAY
+    assert exc_info.value.detail == _SANITIZED_ERROR
+
+
 def test_handle_openai_passthrough_non_streaming_records_usage() -> None:
     fake_response = httpx.Response(200, json=_UPSTREAM_RESPONSE_BODY)
     mock_span = MagicMock()
@@ -1012,7 +1023,7 @@ def test_passthrough_stream_sanitizes_non_forwardable_statuses(
 
     assert len(frames) == 1
     data = json.loads(frames[0][len("data: ") : -2])
-    assert data["response"]["error"]["type"] == "api_error"
+    assert data["response"]["error"]["code"] == "server_error"
     assert data["response"]["error"]["message"] == _SANITIZED_ERROR
     assert "leaked key xyz" not in "".join(frames)
 
@@ -1027,7 +1038,7 @@ def test_passthrough_stream_forwards_429_type_and_message_verbatim() -> None:
 
     assert len(frames) == 1
     data = json.loads(frames[0][len("data: ") : -2])
-    assert data["response"]["error"]["type"] == "rate_limit_exceeded"
+    assert data["response"]["error"]["code"] == "rate_limit_exceeded"
     assert data["response"]["error"]["message"] == "quota exceeded"
 
 
@@ -1084,6 +1095,10 @@ def test_passthrough_stream_upstream_error_emits_single_error_frame() -> None:
     data = json.loads(frames[0][len("data: ") : -2])
     assert data["type"] == "response.failed"
     assert data["response"]["error"]["message"] == "bad request"
+    assert data["response"]["status"] == "failed"
+    assert data["response"]["model"] == "gpt-5-mini"
+    assert data["response"]["output"] == []
+    assert data["sequence_number"] == 0
 
 
 def test_passthrough_stream_closes_exitstack_resources() -> None:

--- a/backend/tests/utils/secret_names.py
+++ b/backend/tests/utils/secret_names.py
@@ -21,6 +21,7 @@ class TestSecret(StrEnum):
     __test__ = False
 
     OPENAI_API_KEY = "OPENAI_API_KEY"
+    ANTHROPIC_API_KEY = "ANTHROPIC_API_KEY"
     COHERE_API_KEY = "COHERE_API_KEY"
     AZURE_API_KEY = "AZURE_API_KEY"
     AZURE_API_URL = "AZURE_API_URL"


### PR DESCRIPTION
## Description

Adds an integration suite (`backend/tests/integration/tests/gateway_clients/`) that verifies the gateway passthroughs end to end with the real clients they exist for: it npm-installs pinned `@anthropic-ai/claude-code` and `@openai/codex` CLIs into a throwaway prefix, provisions a `use:llm_gateway` PAT and Anthropic/OpenAI providers through the existing test managers, points each CLI at the gateway, and asserts the capabilities the translation path cannot serve.

Coverage per client:
- Claude Code: basic `-p` turn, a tool-use turn with extended thinking (proves thinking-block signature replay through the passthrough), the `web_search` server tool returning `server_tool_use` + `web_search_tool_result` blocks, `count_tokens` exactness against real turn usage, and the `mcp_servers` refusal (400 `INVALID_INPUT`)
- Codex: basic `codex exec` turn over `/v1/responses`, encrypted-reasoning statelessness (`include: ["reasoning.encrypted_content"]` round-trip across turns with `store` forced false), and the `previous_response_id` (501) and `mcp` tool (400) refusals

The suite skips cleanly when npm is unavailable, when no real api_server answers `API_SERVER_URL` (CLI subprocesses need a real TCP socket, so the in-process TestClient cannot serve them), or when a provider key is unresolvable (`@pytest.mark.secrets`; adds `TestSecret.ANTHROPIC_API_KEY`). Providers are created non-default with unique names so the suite never mutates shared deployment state.

Known cosmetic issue documented in the README: Codex logs `Model metadata for '<provider_id>/<model>' not found` on every gateway turn because its local pricing table does not recognize the gateway's model naming; turns succeed regardless.

## How Has This Been Tested?

- Full live run against a dev deployment: `9 passed in 68s`, real Anthropic (`claude-haiku-4-5`) and OpenAI (`gpt-5-mini`) calls through real npm-installed CLIs, total spend under $0.05
- Verified the suite's skip paths: missing server and missing secrets both skip with clear reasons rather than failing
- pre-commit clean on all added files

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


---

**Stack:**
1. [gateway-anthropic-passthrough #13697](https://github.com/onyx-dot-app/onyx/pull/13697)
2. [gateway-openai-passthrough #13724](https://github.com/onyx-dot-app/onyx/pull/13724)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an integration test suite that drives the gateway’s Anthropic and OpenAI passthroughs using the real `@anthropic-ai/claude-code` and `@openai/codex` CLIs, and hardens passthrough safety, error handling, and streaming identity.

- **New Features**
  - Pins CLIs (`@anthropic-ai/claude-code@2.1.221`, `@openai/codex@0.146.0`) into isolated npm prefixes; locally skips if `npm`, `/health`, or provider secrets are missing; CI sets `GATEWAY_CLIENT_TESTS_REQUIRED=true` to fail instead.
  - Requires the documented `/health` payload, swaps to a real `httpx.Client`, logs in as the standing dev admin, avoids resetting shared state, and releases the dedicated client after each module.
  - Claude Code coverage: basic `-p`, tool-use with thinking signature replay, `web_search_20250305` server tool, `count_tokens` exactness, and `mcp_servers` rejected (400).
  - Codex coverage: basic `/v1/responses`, encrypted reasoning round‑trip with `include: ["reasoning.encrypted_content"]` and `store=false`, `previous_response_id` rejected (501), and `mcp` tool rejected (400).
  - CI: runs the `gateway_clients` shard only when `backend/onyx/server/gateway/**` or `backend/tests/integration/tests/gateway_clients/**` change; boots a fresh in‑container `api_server` via `run_with_server.sh`, refuses to run against a pre‑existing server at `API_SERVER_URL`, migrates the DB with `alembic upgrade head` before start, honors `API_SERVER_*` overrides, prints server logs on readiness failure and on test failures, exports `ANTHROPIC_API_KEY`, and sets `GATEWAY_CLIENT_TESTS_REQUIRED`.

- **Bug Fixes**
  - Anthropic passthrough: append endpoint paths before reattaching query parameters so proxy credentials in `api_base` are preserved, and strip a trailing `/v1` from custom bases to avoid double paths.
  - OpenAI passthrough: treat malformed 200 bodies as `BAD_GATEWAY` with a sanitized message, emit schema‑complete `response.failed` events with proper `code` (`rate_limit_exceeded` vs `server_error`), continue response identity and sequence numbers on stream errors, and sanitize/downgrade logs and spans (including cleanup paths) to avoid leaking secrets.

<sup>Written for commit 83a129a3b999ed89c63cd7e5751f12c41e38893a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

