### PR TITLE
fix(tests): stop celery logging tests leaking third-party log cap state

### DIFF
--- a/backend/tests/unit/onyx/background/celery/test_app_base_logging.py
+++ b/backend/tests/unit/onyx/background/celery/test_app_base_logging.py
@@ -13,16 +13,18 @@ from collections.abc import Generator
 
 import pytest
 
+import onyx.utils.logger as logger_module
 from onyx.background.celery.apps import app_base
+from onyx.utils.logger import THIRD_PARTY_CAPPED_LOGGER_NAMES
 
 
 @pytest.fixture
 def _snapshot_loggers() -> Generator[None, None, None]:
-    """on_setup_logging mutates the root logger and the Celery task logger.
-
-    Snapshot and restore both so tests don't bleed into each other or the rest
-    of the suite.
-    """
+    """on_setup_logging mutates the root logger, the Celery task logger, and
+    (via cap_third_party_log_levels) the third-party logger levels plus the
+    logger module's cap bookkeeping. Snapshot and restore all of it; leaking
+    _cap_applied_levels makes later tests' externally raised levels look like
+    cap-owned values that the cap is free to lower."""
     root = logging.getLogger()
     task = app_base.task_logger
 
@@ -31,6 +33,11 @@ def _snapshot_loggers() -> Generator[None, None, None]:
     task_handlers_before = list(task.handlers)
     task_level_before = task.level
     task_propagate_before = task.propagate
+    third_party_levels_before = {
+        name: logging.getLogger(name).level for name in THIRD_PARTY_CAPPED_LOGGER_NAMES
+    }
+    capped_flag_before = logger_module._third_party_log_levels_capped
+    cap_applied_before = dict(logger_module._cap_applied_levels)
 
     yield
 
@@ -39,6 +46,11 @@ def _snapshot_loggers() -> Generator[None, None, None]:
     task.handlers = task_handlers_before
     task.setLevel(task_level_before)
     task.propagate = task_propagate_before
+    for name, level in third_party_levels_before.items():
+        logging.getLogger(name).setLevel(level)
+    logger_module._third_party_log_levels_capped = capped_flag_before
+    logger_module._cap_applied_levels.clear()
+    logger_module._cap_applied_levels.update(cap_applied_before)
 
 
 def _clean_argv(monkeypatch: pytest.MonkeyPatch, *extra: str) -> None:


### PR DESCRIPTION
## Description

Fixes an order-dependent unit-test failure: `test_app_base_logging.py` exercises `on_setup_logging`, which calls `cap_third_party_log_levels` and thereby mutates both the third-party logger levels (httpx etc.) and the logger module's `_cap_applied_levels` bookkeeping, but its `_snapshot_loggers` fixture only restored the root and Celery task loggers. Any later test in the same worker that pins httpx to WARNING (e.g. `test_third_party_log_cap.py::test_escape_hatch_never_lowers_an_already_raised_level`) then fails, because the leaked bookkeeping makes the externally raised level look like a cap-owned value the cap is free to lower. With pytest-randomly this surfaces as a flaky `backend-check` on unrelated PRs (seen on #13697).

The fix extends the fixture to snapshot and restore the third-party logger levels, `_cap_applied_levels`, and the `_third_party_log_levels_capped` flag.

## How Has This Been Tested?

- Deterministic repro before the fix: `pytest -p no:randomly backend/tests/unit/onyx/background/celery/test_app_base_logging.py backend/tests/unit/onyx/utils/test_third_party_log_cap.py` fails the two log-cap tests; after the fix, 20/20 pass in the same order
- Full `backend/tests/unit/onyx/utils/` + `backend/tests/unit/onyx/background/celery/` runs show no new failures vs main
- pre-commit clean

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Celery logging tests from leaking third‑party log-cap state, eliminating order-dependent test failures and flakes.

- **Bug Fixes**
  - `_snapshot_loggers` now saves and restores third‑party logger levels from `THIRD_PARTY_CAPPED_LOGGER_NAMES`.
  - Restores `logger_module._cap_applied_levels` and `logger_module._third_party_log_levels_capped` between tests.

<sup>Written for commit 190046e7b2433c3785a2c32e51b57dfd03b2844d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

