### PR TITLE
fix(mcp): backward compatibility for legacy stored templates

### DIFF
--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -35,6 +35,7 @@ from onyx.server.features.mcp.models import (
     MCPConnectionData,
     MCPOAuthKeys,
     merge_mcp_headers,
+    sanitize_mcp_header_names,
 )
 from onyx.utils.logger import setup_logger
 from onyx.utils.sensitive import SensitiveValue
@@ -438,6 +439,11 @@ def get_mcp_auth_template(mcp_server: MCPServer) -> MCPAuthTemplate | None:
     ):
         headers = data.get("headers")
     if headers is None:
+        return None
+    # Stored templates predate write-time name validation; sanitize so one
+    # legacy header can't fail every resolve for its server.
+    headers = sanitize_mcp_header_names(headers)
+    if not headers:
         return None
     return MCPAuthTemplate(headers=headers)
 

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -367,8 +367,13 @@ def _resolve_auth_template(
 ) -> MCPAuthTemplate:
     headers: dict[str, str] = {}
     existing_headers = existing_template.headers if existing_template else {}
+    # Case-insensitive: a casing-only rename must reuse the stored value, not
+    # reject its masked read-back as a new (masked) entry.
+    existing_by_lower = {
+        name.lower(): value for name, value in existing_headers.items()
+    }
     for name, request_value in request_template.headers.items():
-        existing_value = existing_headers.get(name)
+        existing_value = existing_by_lower.get(name.lower())
         if (
             not changed_headers.get(name, False)
             and existing_value is not None
@@ -403,12 +408,22 @@ def _build_shared_api_token_config_data(
     template = auth_template or _default_shared_api_token_template()
     substitutions = {**(header_substitutions or {}), "api_key": api_token}
     return MCPConnectionData(
-        headers=template.render(substitutions, user_email=user_email),
+        headers=_render_template_or_400(template, substitutions, user_email),
         header_template=template.headers,
         api_token=api_token,
         header_substitutions=header_substitutions or {},
         required_fields=template.required_fields,
     )
+
+
+def _render_template_or_400(
+    template: MCPAuthTemplate, substitutions: dict[str, str], user_email: str
+) -> dict[str, str]:
+    """Missing substitutions are a client error, not a 500."""
+    try:
+        return template.render(substitutions, user_email=user_email)
+    except ValueError as error:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(error))
 
 
 def _build_oauth_admin_config_data(
@@ -543,7 +558,7 @@ def _upsert_user_template_config(
     existing = get_user_connection_config(mcp_server.id, user_email, db_session)
     existing_data = extract_connection_data(existing, apply_mask=False)
     config_data = MCPConnectionData(
-        headers=template.render(substitutions, user_email=user_email),
+        headers=_render_template_or_400(template, substitutions, user_email),
         header_substitutions=substitutions,
     )
     for oauth_key in MCPOAuthKeys:

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -64,6 +64,26 @@ DENYLISTED_MCP_HEADERS = {
 }
 
 
+def sanitize_mcp_header_names(headers: dict[str, str]) -> dict[str, str]:
+    """Drop names `MCPAuthTemplate` validation would reject (invalid or
+    denylisted; last casing wins a duplicate). For stored rows that predate
+    write-time validation — one legacy header must not fail the whole read."""
+    sanitized: dict[str, str] = {}
+    names_by_lower: dict[str, str] = {}
+    for name, value in headers.items():
+        lowered = name.lower()
+        if (
+            _HTTP_FIELD_NAME_RE.fullmatch(name) is None
+            or lowered in DENYLISTED_MCP_HEADERS
+        ):
+            continue
+        if previous_name := names_by_lower.get(lowered):
+            sanitized.pop(previous_name, None)
+        sanitized[name] = value
+        names_by_lower[lowered] = name
+    return sanitized
+
+
 def merge_mcp_headers(*sources: dict[str, str]) -> dict[str, str]:
     """Merge HTTP headers case-insensitively; later sources win."""
     merged: dict[str, str] = {}

--- a/backend/tests/unit/onyx/server/features/mcp/test_backcompat_templates.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_backcompat_templates.py
@@ -1,0 +1,86 @@
+"""Backward compatibility: legacy stored templates and masked round-trips.
+
+Stored templates predate write-time name validation, so reads must tolerate
+rows the current validator would reject; masked read-back values must survive
+edits that only change a header name's casing.
+"""
+
+import json
+
+from onyx.db.enums import MCPAuthenticationPerformer, MCPAuthenticationType
+from onyx.db.mcp import ResolvedMCPCredentials, get_mcp_auth_template
+from onyx.db.models import MCPConnectionConfig, MCPServer
+from onyx.server.features.mcp.api import _resolve_auth_template
+from onyx.server.features.mcp.models import MCPAuthTemplate
+from onyx.utils.sensitive import SensitiveValue
+
+
+def _sensitive(config_data: dict) -> SensitiveValue[dict]:
+    return SensitiveValue(
+        encrypted_bytes=json.dumps(config_data).encode(),
+        decrypt_fn=lambda b: b.decode(),
+        is_json=True,
+    )
+
+
+def _server_with_admin_config(config_data: dict) -> MCPServer:
+    return MCPServer(
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.PER_USER,
+        admin_connection_config=MCPConnectionConfig(config=_sensitive(config_data)),
+    )
+
+
+def test_legacy_template_with_invalid_names_still_loads_and_sends() -> None:
+    """A stored template the current validator would reject (denylisted,
+    invalid, and case-duplicate names) must not fail resolution; the offending
+    names are dropped and the rest of the template keeps working."""
+    server = _server_with_admin_config(
+        {
+            "headers": {
+                "Host": "internal.example.com",
+                "bad name": "value",
+                "X-Gateway-Key": "stale-key",
+                "x-gateway-key": "literal-key",
+            }
+        }
+    )
+    template = get_mcp_auth_template(server)
+    assert template is not None
+    assert template.headers == {"x-gateway-key": "literal-key"}
+    assert template.required_fields == []
+
+    creds = ResolvedMCPCredentials(
+        connection_config=None,
+        user_oauth_token="login-token",
+        auth_type=MCPAuthenticationType.PT_OAUTH,
+        auth_template=template,
+        user_email="user@example.com",
+    )
+    headers = creds.build_headers()
+    assert "Host" not in headers
+    assert headers["x-gateway-key"] == "literal-key"
+    assert headers["Authorization"] == "Bearer login-token"
+
+
+def test_legacy_template_placeholders_still_derive_required_fields() -> None:
+    server = _server_with_admin_config(
+        {"headers": {"Authorization": "Bearer {api_key}", "Host": "legacy"}}
+    )
+    template = get_mcp_auth_template(server)
+    assert template is not None
+    assert template.required_fields == ["api_key"]
+
+
+def test_casing_only_rename_reuses_stored_masked_value() -> None:
+    """Renaming only a header's casing replays the masked value; resolution
+    must keep the stored value instead of rejecting the masked placeholder."""
+    existing = MCPAuthTemplate(headers={"X-Gateway-Key": "stored-secret"})
+    resolved = _resolve_auth_template(
+        MCPAuthTemplate.model_construct(
+            headers={"x-gateway-key": "••••••••••••"}, required_fields=[]
+        ),
+        {"x-gateway-key": False},
+        existing,
+    )
+    assert resolved.headers == {"x-gateway-key": "stored-secret"}


### PR DESCRIPTION
## Description

Backward-compat hardening for #13715, targeted at its branch. Three fixes:

1. **Legacy stored templates can't brick a server.** Stored templates predate the new write-time name validation, and `ResolvedMCPCredentials` revalidates its nested `auth_template`, so a single legacy header with an invalid/denylisted/case-duplicate name would raise inside every `resolve_mcp_credentials` / listing for that server. `get_mcp_auth_template` now sanitizes stored names first (invalid and denylisted dropped, case-duplicates collapsed to the last casing) — the rest of the template keeps working. Found this by test: `model_construct` alone is NOT enough because the nested revalidation fires anyway.
2. **Casing-only rename keeps its masked value.** `_resolve_auth_template` looked up existing values case-sensitively, so renaming `X-Gateway-Key` → `x-gateway-key` missed the stored value and rejected the masked read-back, failing the whole save. Existing lookup is now case-insensitive.
3. **Missing substitutions are a 400, not a 500.** `template.render()` raises `ValueError` on missing required fields; the two unguarded upsert call sites now surface `OnyxErrorCode.INVALID_INPUT` (older clients don't send `admin_credentials`, so this is reachable during rolling upgrades).

## How Has This Been Tested?

- New `backend/tests/unit/onyx/server/features/mcp/test_backcompat_templates.py` (3 tests): legacy row with denylisted + invalid + case-duplicate names loads and sends correctly, placeholder derivation preserved, casing-only masked rename reuses the stored value.
- All existing suites pass on this branch: 136 unit + 75 external-dependency MCP tests. (One pre-existing flake noted: `test_pt_oauth_uses_first_oauth_account` is order-dependent on the unordered `oauth_accounts` relationship — unrelated, passes in isolation.)

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Harden MCP auth template handling to keep legacy headers working, preserve masked values on casing-only renames, and return 400s for missing substitutions. Prevents servers from failing on old data.

- **Bug Fixes**
  - Sanitize stored header names before building the template: drop invalid/denylisted names and collapse case-duplicates (last casing wins) so legacy rows don’t break resolve/listing.
  - Match existing header values case-insensitively during updates so `X-Gateway-Key` → `x-gateway-key` reuses the stored secret instead of rejecting the masked value.
  - Treat missing required substitutions as client errors by wrapping template rendering to return `INVALID_INPUT` (HTTP 400) instead of a 500 during upserts.

<sup>Written for commit 3e55991645e8b42090144d9e84b5c58b7e59398f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

