### PR TITLE
fix(craft): document webapp preview base path and real lint/typecheck commands to the agent

### DIFF
--- a/backend/onyx/server/features/build/AGENTS.template.md
+++ b/backend/onyx/server/features/build/AGENTS.template.md
@@ -19,9 +19,8 @@ in the user's connected apps. Use all available resources to best accomplish the
   don't have the data, search again or say so. Do not guess or fabricate.
 - The Next.js dev server is already running on port {{NEXTJS_PORT}}. Never start
   another (`bun run dev`). Preview the app at
-  `http://localhost:{{NEXTJS_PORT}}{{WEBAPP_BASE_PATH}}` — it serves only under
-  that base path; `/` redirects there, and all other outside paths 404 even
-  when the app is healthy.
+  `http://localhost:{{NEXTJS_PORT}}{{WEBAPP_BASE_PATH}}` — requests outside that
+  base path 404 or redirect even when the app is healthy.
 - Be autonomous when building. Act within the turn rather than stopping to ask.
 
 {{DISABLED_TOOLS_SECTION}}

--- a/backend/onyx/server/features/build/AGENTS.template.md
+++ b/backend/onyx/server/features/build/AGENTS.template.md
@@ -18,7 +18,10 @@ in the user's connected apps. Use all available resources to best accomplish the
 - **Never** state a fact that isn't grounded in a retrieved source or an attachment. If you
   don't have the data, search again or say so. Do not guess or fabricate.
 - The Next.js dev server is already running on port {{NEXTJS_PORT}}. Never start
-  another (`bun run dev`).
+  another (`bun run dev`). It serves the app **only** under the base path
+  `{{WEBAPP_BASE_PATH}}` — preview it at
+  `http://localhost:{{NEXTJS_PORT}}{{WEBAPP_BASE_PATH}}`. Any other path
+  (including `/`) returns 404 even when the app is healthy.
 - Be autonomous when building. Act within the turn rather than stopping to ask.
 
 {{DISABLED_TOOLS_SECTION}}

--- a/backend/onyx/server/features/build/AGENTS.template.md
+++ b/backend/onyx/server/features/build/AGENTS.template.md
@@ -18,10 +18,10 @@ in the user's connected apps. Use all available resources to best accomplish the
 - **Never** state a fact that isn't grounded in a retrieved source or an attachment. If you
   don't have the data, search again or say so. Do not guess or fabricate.
 - The Next.js dev server is already running on port {{NEXTJS_PORT}}. Never start
-  another (`bun run dev`). It serves the app **only** under the base path
-  `{{WEBAPP_BASE_PATH}}` — preview it at
-  `http://localhost:{{NEXTJS_PORT}}{{WEBAPP_BASE_PATH}}`. Any other path
-  (including `/`) returns 404 even when the app is healthy.
+  another (`bun run dev`). Preview the app at
+  `http://localhost:{{NEXTJS_PORT}}{{WEBAPP_BASE_PATH}}` — it serves only under
+  that base path; `/` redirects there, and all other outside paths 404 even
+  when the app is healthy.
 - Be autonomous when building. Act within the turn rather than stopping to ask.
 
 {{DISABLED_TOOLS_SECTION}}

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -1056,6 +1056,7 @@ class DockerSandboxManager(SandboxManager):
         agent_model: str | None,
         nextjs_port: int | None,
         connectable_apps_section: str,
+        session_id: UUID | None = None,
         user_name: str | None = None,
     ) -> str:
         """Raw (unescaped) AGENTS.md content."""
@@ -1065,6 +1066,7 @@ class DockerSandboxManager(SandboxManager):
             provider=agent_provider,
             model_name=agent_model,
             nextjs_port=nextjs_port,
+            session_id=session_id,
             disabled_tools=OPENCODE_DISABLED_TOOLS,
             user_name=user_name,
             organization_instructions=load_settings().craft_instructions,
@@ -1087,6 +1089,7 @@ class DockerSandboxManager(SandboxManager):
             agent_model=llm_config.model_name,
             nextjs_port=nextjs_port,
             connectable_apps_section=connectable_apps_section,
+            session_id=session_id,
             user_name=user_name,
         )
         session_opencode_config = json.dumps(
@@ -1509,6 +1512,7 @@ fi
             agent_model=agent_model,
             nextjs_port=nextjs_port,
             connectable_apps_section=connectable_apps_section,
+            session_id=session_id,
             user_name=user_name,
         )
         session_opencode_config = (

--- a/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/AGENTS.md
+++ b/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/AGENTS.md
@@ -5,7 +5,7 @@ This file provides guidance to AI agents when working on the web application wit
 ## Important Notes
 
 - **The development server is already running** at a dynamically allocated port. Do NOT run `bun run dev` yourself.
-- **The app serves under a session-scoped base path** (`/api/build/sessions/<session-id>/webapp`), not at `/`. Paths outside the base path 404 even when the app is healthy (`/` itself redirects to it). The exact preview URL is in the session root `AGENTS.md` (one level up from `outputs/`).
+- **The app serves under a session-scoped base path, not `/`** — use the preview URL from the session root `AGENTS.md`; other paths 404 even when the app is healthy.
 - **We do NOT use a `src` directory** - all code lives directly in the root folders (`app/`, `components/`, `lib/`, etc.)
 - If the app needs pre-computation (data processing, API calls, etc.), create a bash or python script called `prepare.sh`/`prepare.py` at the root of this directory
 - **CRITICAL: Create small, modular components** - Do NOT write everything in `page.tsx`. Break your UI into small, reusable components in the `components/` directory. Each component should have a single responsibility and be in its own file.
@@ -42,12 +42,10 @@ python prepare.py
 
 ```bash
 bun run dev        # Start development server (DO NOT RUN - already running)
-bun run lint       # Lint with oxlint
-bun run typecheck  # Type-check with tsc --noEmit
+bun run lint       # oxlint (ESLint is NOT installed — never run eslint)
+bun run typecheck  # tsc --noEmit
 bun add <pkg>      # Add a new dependency (updates package.json AND bun.lock)
 ```
-
-ESLint is **not** installed — never run `eslint`/`bunx eslint`; use `bun run lint`.
 
 ## Adding dependencies — read this before installing anything
 

--- a/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/AGENTS.md
+++ b/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/AGENTS.md
@@ -5,7 +5,7 @@ This file provides guidance to AI agents when working on the web application wit
 ## Important Notes
 
 - **The development server is already running** at a dynamically allocated port. Do NOT run `bun run dev` yourself.
-- **The app serves under a session-scoped base path, not `/`** — use the preview URL from the session root `AGENTS.md`; other paths 404 even when the app is healthy.
+- **The app serves under a session-scoped base path, not `/`** — use the preview URL from the session root `AGENTS.md`; other paths 404 or redirect even when the app is healthy.
 - **We do NOT use a `src` directory** - all code lives directly in the root folders (`app/`, `components/`, `lib/`, etc.)
 - If the app needs pre-computation (data processing, API calls, etc.), create a bash or python script called `prepare.sh`/`prepare.py` at the root of this directory
 - **CRITICAL: Create small, modular components** - Do NOT write everything in `page.tsx`. Break your UI into small, reusable components in the `components/` directory. Each component should have a single responsibility and be in its own file.

--- a/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/AGENTS.md
+++ b/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/AGENTS.md
@@ -5,7 +5,7 @@ This file provides guidance to AI agents when working on the web application wit
 ## Important Notes
 
 - **The development server is already running** at a dynamically allocated port. Do NOT run `bun run dev` yourself.
-- **The app serves under a session-scoped base path** (`/api/build/sessions/<session-id>/webapp`), not at `/`. Fetching `http://localhost:<port>/` returns 404 even when the app is perfectly healthy. The exact preview URL is in the session root `AGENTS.md` (one level up from `outputs/`).
+- **The app serves under a session-scoped base path** (`/api/build/sessions/<session-id>/webapp`), not at `/`. Paths outside the base path 404 even when the app is healthy (`/` itself redirects to it). The exact preview URL is in the session root `AGENTS.md` (one level up from `outputs/`).
 - **We do NOT use a `src` directory** - all code lives directly in the root folders (`app/`, `components/`, `lib/`, etc.)
 - If the app needs pre-computation (data processing, API calls, etc.), create a bash or python script called `prepare.sh`/`prepare.py` at the root of this directory
 - **CRITICAL: Create small, modular components** - Do NOT write everything in `page.tsx`. Break your UI into small, reusable components in the `components/` directory. Each component should have a single responsibility and be in its own file.
@@ -47,8 +47,7 @@ bun run typecheck  # Type-check with tsc --noEmit
 bun add <pkg>      # Add a new dependency (updates package.json AND bun.lock)
 ```
 
-These are the ONLY lint/type-check commands. ESLint is **not** installed —
-`eslint` / `npx eslint` / `bunx eslint` all fail here; use `bun run lint`.
+ESLint is **not** installed — never run `eslint`/`bunx eslint`; use `bun run lint`.
 
 ## Adding dependencies — read this before installing anything
 

--- a/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/AGENTS.md
+++ b/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/AGENTS.md
@@ -5,6 +5,7 @@ This file provides guidance to AI agents when working on the web application wit
 ## Important Notes
 
 - **The development server is already running** at a dynamically allocated port. Do NOT run `bun run dev` yourself.
+- **The app serves under a session-scoped base path** (`/api/build/sessions/<session-id>/webapp`), not at `/`. Fetching `http://localhost:<port>/` returns 404 even when the app is perfectly healthy. The exact preview URL is in the session root `AGENTS.md` (one level up from `outputs/`).
 - **We do NOT use a `src` directory** - all code lives directly in the root folders (`app/`, `components/`, `lib/`, etc.)
 - If the app needs pre-computation (data processing, API calls, etc.), create a bash or python script called `prepare.sh`/`prepare.py` at the root of this directory
 - **CRITICAL: Create small, modular components** - Do NOT write everything in `page.tsx`. Break your UI into small, reusable components in the `components/` directory. Each component should have a single responsibility and be in its own file.
@@ -40,10 +41,14 @@ python prepare.py
 ## Commands
 
 ```bash
-bun run dev      # Start development server (DO NOT RUN - already running)
-bun run lint     # Run ESLint
-bun add <pkg>    # Add a new dependency (updates package.json AND bun.lock)
+bun run dev        # Start development server (DO NOT RUN - already running)
+bun run lint       # Lint with oxlint
+bun run typecheck  # Type-check with tsc --noEmit
+bun add <pkg>      # Add a new dependency (updates package.json AND bun.lock)
 ```
+
+These are the ONLY lint/type-check commands. ESLint is **not** installed —
+`eslint` / `npx eslint` / `bunx eslint` all fail here; use `bun run lint`.
 
 ## Adding dependencies — read this before installing anything
 

--- a/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/next.config.ts
+++ b/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/next.config.ts
@@ -21,6 +21,15 @@ const nextConfig: NextConfig = {};
 if (webappBasePath) {
   nextConfig.basePath = webappBasePath;
   nextConfig.assetPrefix = webappBasePath;
+  // Point naive probes of "/" (which otherwise 404) at the real app.
+  nextConfig.redirects = async () => [
+    {
+      source: "/",
+      destination: webappBasePath,
+      basePath: false,
+      permanent: false,
+    },
+  ];
 }
 
 if (allowedDevOrigins.length > 0) {

--- a/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/package.json
+++ b/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev -p ${ONYX_WEBAPP_PORT:-$(cat ../../.nextjs-port 2>/dev/null || echo 3000)}",
     "build": "next build",
     "start": "next start",
-    "lint": "oxlint"
+    "lint": "oxlint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -440,6 +440,7 @@ class KubernetesSandboxManager(SandboxManager):
         provider: str | None = None,
         model_name: str | None = None,
         nextjs_port: int | None = None,
+        session_id: UUID | None = None,
         disabled_tools: list[str] | None = None,
         user_name: str | None = None,
     ) -> str:
@@ -450,6 +451,7 @@ class KubernetesSandboxManager(SandboxManager):
             provider=provider,
             model_name=model_name,
             nextjs_port=nextjs_port,
+            session_id=session_id,
             disabled_tools=disabled_tools,
             user_name=user_name,
             organization_instructions=load_settings().craft_instructions,
@@ -1403,6 +1405,7 @@ class KubernetesSandboxManager(SandboxManager):
             provider=llm_config.provider,
             model_name=llm_config.model_name,
             nextjs_port=nextjs_port,
+            session_id=session_id,
             disabled_tools=OPENCODE_DISABLED_TOOLS,
             user_name=user_name,
         )
@@ -1881,6 +1884,7 @@ echo "Session cleanup complete"
             provider=agent_provider,
             model_name=agent_model,
             nextjs_port=nextjs_port,
+            session_id=session_id,
             disabled_tools=OPENCODE_DISABLED_TOOLS,
             user_name=user_name,
         )

--- a/backend/onyx/server/features/build/sandbox/nextjs_dev.py
+++ b/backend/onyx/server/features/build/sandbox/nextjs_dev.py
@@ -6,6 +6,7 @@ environment (base path, allowed dev origins) stays identical across backends.
 
 from pathlib import Path
 from urllib.parse import urlparse
+from uuid import UUID
 
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.server.features.build.sandbox.base import BUN_CACHE_DIR
@@ -13,6 +14,15 @@ from onyx.server.features.build.sandbox.base import BUN_CACHE_DIR
 _TEMPLATE_NEXT_CONFIG = (
     Path(__file__).parent / "image" / "templates" / "outputs" / "web" / "next.config.ts"
 )
+
+
+def webapp_base_path(session_id: UUID | str) -> str:
+    """Base path a session's Next.js dev server serves under.
+
+    Mirrored by the start script below, the template next.config.ts cwd
+    fallback, and the preview proxy's upstream path.
+    """
+    return f"/api/build/sessions/{session_id}/webapp"
 
 
 def allowed_dev_origins() -> str:

--- a/backend/onyx/server/features/build/sandbox/util/agent_instructions.py
+++ b/backend/onyx/server/features/build/sandbox/util/agent_instructions.py
@@ -2,12 +2,14 @@
 
 from collections.abc import Iterable
 from pathlib import Path
+from uuid import UUID
 
 from onyx.db.models import ExternalApp
 from onyx.server.features.build.configs import (
     SANDBOX_APPROVAL_WAIT_MARGIN_SECONDS,
     SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS,
 )
+from onyx.server.features.build.sandbox.nextjs_dev import webapp_base_path
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -107,6 +109,7 @@ def generate_agent_instructions(
     provider: str | None = None,
     model_name: str | None = None,
     nextjs_port: int | None = None,
+    session_id: UUID | None = None,
     disabled_tools: list[str] | None = None,
     user_name: str | None = None,
     organization_instructions: str | None = None,
@@ -119,6 +122,7 @@ def generate_agent_instructions(
         provider: LLM provider type (e.g., "openai", "anthropic")
         model_name: Model name (e.g., "claude-sonnet-4-5", "gpt-4o")
         nextjs_port: Port for Next.js development server
+        session_id: Session ID, used to render the webapp preview base path
         disabled_tools: List of disabled tools
         user_name: User's name for personalization
         organization_instructions: Admin-set workspace-wide Craft instructions
@@ -152,6 +156,12 @@ def generate_agent_instructions(
     content = content.replace("{{LLM_MODEL_NAME}}", model_name or "Unknown")
     content = content.replace(
         "{{NEXTJS_PORT}}", str(nextjs_port) if nextjs_port else "Unknown"
+    )
+    content = content.replace(
+        "{{WEBAPP_BASE_PATH}}",
+        webapp_base_path(session_id)
+        if session_id
+        else webapp_base_path("<session-id>"),
     )
     content = content.replace(
         "{{APPROVAL_WAIT_TIMEOUT_SECONDS}}",

--- a/backend/onyx/server/features/build/webapp_proxy.py
+++ b/backend/onyx/server/features/build/webapp_proxy.py
@@ -41,6 +41,7 @@ from onyx.server.features.build.db.build_session import (
     get_webapp_target_async,
 )
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
+from onyx.server.features.build.sandbox.nextjs_dev import webapp_base_path
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -168,9 +169,8 @@ async def _aiter_and_close(response: httpx.Response) -> AsyncGenerator[bytes, No
 
 
 def _webapp_next_path(session_id: UUID, path: str = "") -> str:
-    session_str = str(session_id)
     rel_path = path.lstrip("/")
-    base_path = f"api/build/sessions/{session_str}/webapp"
+    base_path = webapp_base_path(session_id).lstrip("/")
     return f"{base_path}/{rel_path}" if rel_path else base_path
 
 

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_agent_instructions.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_agent_instructions.py
@@ -1,5 +1,6 @@
 import re
 from pathlib import Path
+from uuid import UUID
 
 import pytest
 
@@ -45,6 +46,7 @@ def test_generate_agent_instructions_populates_real_template_without_skills_sect
         provider="openai",
         model_name="gpt-5-mini",
         nextjs_port=3210,
+        session_id=UUID("0d9ed7f2-8757-4d09-9812-bd7e4a45e232"),
         disabled_tools=["web-search", "shell"],
         user_name="TEST_USER",
     )
@@ -55,6 +57,21 @@ def test_generate_agent_instructions_populates_real_template_without_skills_sect
     assert "web-search, shell" in content
     assert "## Skills" not in content
     assert "{{AVAILABLE_SKILLS_SECTION}}" not in content
+    assert _unresolved_placeholders(content) == set()
+
+
+def test_generate_agent_instructions_renders_webapp_preview_url() -> None:
+    """The agent must be told the exact preview URL — a base-path'd dev server
+    404s on every path outside the base path, so port alone is not enough."""
+    session_id = UUID("0d9ed7f2-8757-4d09-9812-bd7e4a45e232")
+    content = agent_instructions.generate_agent_instructions(
+        template_path=_template_path(),
+        connectable_apps_section="",
+        nextjs_port=3210,
+        session_id=session_id,
+    )
+
+    assert f"http://localhost:3210/api/build/sessions/{session_id}/webapp" in content
     assert _unresolved_placeholders(content) == set()
 
 

--- a/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
@@ -78,6 +78,16 @@ def test_template_dev_script_wires_port_to_managed_env_and_port_file() -> None:
     ) / ".nextjs-port"
 
 
+def test_template_scripts_match_documented_tool_contract() -> None:
+    """The template AGENTS.md documents `bun run lint` (oxlint) and
+    `bun run typecheck`; both scripts must exist, or agents fall back to
+    guessed commands (eslint, bare tsc) that fail in the sandbox."""
+    scripts = json.loads(_TEMPLATE_PACKAGE_JSON.read_text())["scripts"]
+
+    assert scripts["lint"] == "oxlint"
+    assert scripts["typecheck"] == "tsc --noEmit"
+
+
 def test_start_script_passes_port_flag_when_dev_script_ignores_env() -> None:
     """A `dev` script without the ONYX_WEBAPP_PORT marker (legacy scaffold, or
     rewritten by the agent) ignores the env var and would bind 3000; the

--- a/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_nextjs_dev.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 from uuid import UUID
@@ -29,6 +30,7 @@ _TEMPLATE_PACKAGE_JSON = (
     / "web"
     / "package.json"
 )
+_TEMPLATE_AGENTS_MD = _TEMPLATE_PACKAGE_JSON.parent / "AGENTS.md"
 
 
 def test_start_script_exports_allowed_dev_origins() -> None:
@@ -78,14 +80,19 @@ def test_template_dev_script_wires_port_to_managed_env_and_port_file() -> None:
     ) / ".nextjs-port"
 
 
-def test_template_scripts_match_documented_tool_contract() -> None:
-    """The template AGENTS.md documents `bun run lint` (oxlint) and
-    `bun run typecheck`; both scripts must exist, or agents fall back to
-    guessed commands (eslint, bare tsc) that fail in the sandbox."""
-    scripts = json.loads(_TEMPLATE_PACKAGE_JSON.read_text())["scripts"]
+def test_template_agents_md_documents_only_real_scripts() -> None:
+    """The template AGENTS.md and package.json are the two halves of the
+    sandbox tool contract. A documented `bun run <script>` that doesn't exist
+    sends agents into guess-and-fail loops (the doc once said "Run ESLint"
+    while the template shipped oxlint and no typecheck script)."""
+    scripts = set(json.loads(_TEMPLATE_PACKAGE_JSON.read_text())["scripts"])
+    documented = set(
+        re.findall(r"bun run ([A-Za-z0-9:_-]+)", _TEMPLATE_AGENTS_MD.read_text())
+    )
 
-    assert scripts["lint"] == "oxlint"
-    assert scripts["typecheck"] == "tsc --noEmit"
+    assert documented <= scripts
+    # The verify workflow's commands must stay documented, not just valid.
+    assert {"dev", "lint", "typecheck"} <= documented
 
 
 def test_start_script_passes_port_flag_when_dev_script_ignores_env() -> None:


### PR DESCRIPTION
## Description

Craft agents burn large parts of thrash-heavy turns fighting fake failures because the sandbox's tool contract doesn't match the environment (observed: ~75% of preview curls fail, ~23% of lint/type runs die; worst turn ran tsc/eslint ~20 times):

1. **Invisible preview base path.** The session dev server serves the webapp only under `/api/build/sessions/<id>/webapp` (so URLs work through the preview proxy), but agent-visible docs only stated the port. The natural probe `curl localhost:<port>/` returns 404 on a perfectly healthy app, and agents conclude the app is broken.
2. **Wrong lint/typecheck contract.** `outputs/web/AGENTS.md` said `bun run lint # Run ESLint`, but the template ships oxlint, ESLint is not installed (`bunx eslint .` exits 2), and there was no typecheck script (`bun run typecheck` → "Script not found").

Fixes, in three layers:

- **Docs tell the truth**: the session-root `AGENTS.md` now renders the exact per-session preview URL via a new `{{WEBAPP_BASE_PATH}}` placeholder (`session_id` plumbed through both sandbox managers), and warns that any other path — including `/` — 404s even when the app is healthy. `outputs/web/AGENTS.md` gets the base-path note, corrected commands (`lint` = oxlint, new `typecheck`), and an explicit "ESLint is not installed".
- **Environment self-describes**: template `next.config.ts` adds a `/` → basePath 307 redirect, so a naive root probe returns the correct URL in its `Location` header even if the docs were never read; `package.json` adds `"typecheck": "tsc --noEmit"` so the natural guess succeeds.
- **Contract pinned**: new unit tests assert the rendered AGENTS.md contains the full preview URL and that the `lint`/`typecheck` scripts match what the docs promise. The base path string is now single-sourced in `webapp_base_path()` (used by AGENTS.md rendering and the preview proxy).

Template changes reach sessions via the sandbox image rebuild; existing sessions keep their current config (start script only rewrites legacy-marker configs).

## How Has This Been Tested?

- Reproduced both failure modes against the real template locally (basePath set: `/` → 404, basePath URL → 200; `bunx eslint .` → exit 2; `bun run typecheck` → script not found).
- Re-ran the same probes on the edited template: `/` → 307 with `Location` = preview URL, `curl -L /` → 200, basePath URL → 200, HMR/proxy asset paths unaffected; `bun run lint` and `bun run typecheck` both exit 0 (typecheck verified with and without `.next` present).
- Full craft unit suite: 698 passed, including new tests for the rendered preview URL and the script contract.
- pre-commit (ty, ruff, oxlint) clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the session-scoped webapp preview base path and corrected lint/typecheck commands so agents use the right URL and supported tools. Added a root redirect, single-sourced the base path, and tests to pin the tool contract; docs now explicitly note that `/` redirects to the base path.

- **Bug Fixes**
  - Session `AGENTS.md` renders the exact preview URL via `{{WEBAPP_BASE_PATH}}`; both sandbox managers pass `session_id`.
  - `outputs/web/AGENTS.md` and the session `AGENTS.md` share the same base-path guidance; they now state that `/` redirects to the base path, and other paths may 404. They also document the real commands: `bun run lint` (oxlint, ESLint not installed) and `bun run typecheck` (`tsc --noEmit`).
  - `next.config.ts` adds a 307 redirect from `/` to the base path; `package.json` adds the `typecheck` script.
  - Base path is single-sourced in `webapp_base_path()` and used by docs and the preview proxy.
  - Tests assert the rendered preview URL is present and that template docs only list real `bun run` scripts, including `dev`, `lint`, and `typecheck`.

<sup>Written for commit a33545b070726e35825f1e9baf3e5ab6868335f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

