### PR TITLE
test(auth): lock in JWT_PUBLIC_KEY_URL passthrough behavior

### DIFF
--- a/backend/tests/external_dependency_unit/auth/test_jwt_passthrough.py
+++ b/backend/tests/external_dependency_unit/auth/test_jwt_passthrough.py
@@ -1,0 +1,273 @@
+"""
+External-IdP JWT passthrough tests (JWT_PUBLIC_KEY_URL): a real HTTP endpoint
+serves the verification key (JWKS and PEM), RS256 bearer tokens flow through
+the production _check_for_saml_and_jwt path against real Postgres.
+
+This is deployed customer surface (gateways / Entra minting JWTs for Onyx
+APIs) with no other functional coverage — these tests lock in existing-user
+login, JIT provisioning, wrong-key rejection, expiry, and key rotation.
+"""
+
+import json
+import threading
+from datetime import datetime, timedelta, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from uuid import uuid4
+
+import jwt as pyjwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from fastapi import Request
+from jwt.algorithms import RSAAlgorithm  # ty: ignore[possibly-missing-import]
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+import onyx.auth.jwt as jwt_module
+import onyx.auth.users as users_module
+from onyx.db.engine.async_sql_engine import get_async_session_context_manager
+from onyx.db.models import User
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+class _RSAKey:
+    def __init__(self, kid: str) -> None:
+        self.kid = kid
+        self._private_key = rsa.generate_private_key(
+            public_exponent=65537, key_size=2048
+        )
+
+    @property
+    def private_pem(self) -> bytes:
+        from cryptography.hazmat.primitives.serialization import (
+            NoEncryption,
+            PrivateFormat,
+        )
+
+        return self._private_key.private_bytes(
+            Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()
+        )
+
+    @property
+    def public_pem(self) -> str:
+        return (
+            self._private_key.public_key()
+            .public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
+            .decode()
+        )
+
+    @property
+    def jwk(self) -> dict[str, Any]:
+        jwk = json.loads(RSAAlgorithm.to_jwk(self._private_key.public_key()))
+        jwk["kid"] = self.kid
+        return jwk
+
+    def mint_token(
+        self, email: str, expires_in_seconds: int = 3600, kid: str | None = None
+    ) -> str:
+        now = datetime.now(timezone.utc)
+        return pyjwt.encode(
+            {
+                "email": email,
+                "iat": now,
+                "exp": now + timedelta(seconds=expires_in_seconds),
+            },
+            self.private_pem,
+            algorithm="RS256",
+            headers={"kid": kid or self.kid},
+        )
+
+
+class _KeyServer(ThreadingHTTPServer):
+    """Serves /jwks and /pem from mutable per-test state (rotation tests swap it)."""
+
+    daemon_threads = True
+
+    def __init__(self) -> None:
+        super().__init__(("127.0.0.1", 0), _KeyRequestHandler)
+        self.responses: dict[str, tuple[str, str]] = {}
+
+    def set_key(self, key: _RSAKey) -> None:
+        self.responses = {
+            "/jwks": ("application/json", json.dumps({"keys": [key.jwk]})),
+            "/pem": ("application/x-pem-file", key.public_pem),
+        }
+
+    def url(self, path: str) -> str:
+        host, port = self.server_address[0], self.server_address[1]
+        return f"http://{host}:{port}{path}"
+
+
+class _KeyRequestHandler(BaseHTTPRequestHandler):
+    server: _KeyServer
+
+    def do_GET(self) -> None:
+        response = self.server.responses.get(self.path)
+        if response is None:
+            self.send_error(404)
+            return
+        content_type, body = response
+        payload = body.encode()
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        pass
+
+
+@pytest.fixture(scope="module")
+def key_server() -> Any:
+    server = _KeyServer()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield server
+    server.shutdown()
+    server.server_close()
+
+
+@pytest.fixture(autouse=True)
+def _reset_key_cache() -> Any:
+    jwt_module._fetch_public_key_payload.cache_clear()
+    yield
+    jwt_module._fetch_public_key_payload.cache_clear()
+
+
+def _point_at(monkeypatch: pytest.MonkeyPatch, url: str) -> None:
+    # The URL is bound at import time in both modules; patch both bindings.
+    monkeypatch.setattr(jwt_module, "JWT_PUBLIC_KEY_URL", url)
+    monkeypatch.setattr(users_module, "JWT_PUBLIC_KEY_URL", url)
+
+
+async def _authenticate(token: str) -> User | None:
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [(b"authorization", f"Bearer {token}".encode())],
+        }
+    )
+    async with get_async_session_context_manager() as async_session:
+        return await users_module._check_for_saml_and_jwt(request, None, async_session)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("tenant_context")
+@pytest.mark.parametrize("key_path", ["/jwks", "/pem"])
+async def test_bearer_jwt_authenticates_existing_user(
+    db_session: Session,
+    key_server: _KeyServer,
+    monkeypatch: pytest.MonkeyPatch,
+    key_path: str,
+) -> None:
+    # Precondition.
+    user = create_test_user(db_session, "jwt_passthrough")
+    key = _RSAKey(kid="primary")
+    key_server.set_key(key)
+    _point_at(monkeypatch, key_server.url(key_path))
+
+    # Under test.
+    authenticated = await _authenticate(key.mint_token(user.email))
+
+    # Postcondition.
+    assert authenticated is not None
+    assert authenticated.id == user.id
+
+    # A second request is served from the cached key material.
+    authenticated_again = await _authenticate(key.mint_token(user.email))
+    assert authenticated_again is not None
+    assert authenticated_again.id == user.id
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("tenant_context")
+async def test_bearer_jwt_jit_provisions_unknown_user(
+    db_session: Session,
+    key_server: _KeyServer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Precondition.
+    key = _RSAKey(kid="primary")
+    key_server.set_key(key)
+    _point_at(monkeypatch, key_server.url("/jwks"))
+    email = f"jwt_jit_{uuid4().hex[:8]}@example.com"
+
+    # Under test.
+    authenticated = await _authenticate(key.mint_token(email))
+
+    # Postcondition: the user was created from the token, verified, and usable.
+    assert authenticated is not None
+    assert authenticated.email == email
+    assert authenticated.is_verified
+    assert authenticated.is_active
+
+    provisioned = db_session.scalar(select(User).where(func.lower(User.email) == email))
+    assert provisioned is not None
+    assert provisioned.id == authenticated.id
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("tenant_context")
+async def test_token_signed_by_unknown_key_rejected(
+    db_session: Session,
+    key_server: _KeyServer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Precondition.
+    user = create_test_user(db_session, "jwt_wrong_key")
+    trusted_key = _RSAKey(kid="primary")
+    key_server.set_key(trusted_key)
+    _point_at(monkeypatch, key_server.url("/jwks"))
+
+    # Under test: signed by a key the server never served, claiming its kid.
+    attacker_key = _RSAKey(kid="attacker")
+    forged = attacker_key.mint_token(user.email, kid="primary")
+
+    # Postcondition.
+    assert await _authenticate(forged) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("tenant_context")
+async def test_expired_token_rejected(
+    db_session: Session,
+    key_server: _KeyServer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Precondition.
+    user = create_test_user(db_session, "jwt_expired")
+    key = _RSAKey(kid="primary")
+    key_server.set_key(key)
+    _point_at(monkeypatch, key_server.url("/jwks"))
+
+    # Under test.
+    expired = key.mint_token(user.email, expires_in_seconds=-300)
+
+    # Postcondition.
+    assert await _authenticate(expired) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("tenant_context")
+async def test_rotated_key_refetched_without_restart(
+    db_session: Session,
+    key_server: _KeyServer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Precondition: prime the in-process cache with the old key.
+    user = create_test_user(db_session, "jwt_rotation")
+    old_key = _RSAKey(kid="old")
+    key_server.set_key(old_key)
+    _point_at(monkeypatch, key_server.url("/jwks"))
+    assert await _authenticate(old_key.mint_token(user.email)) is not None
+
+    # Under test: the IdP rotates its signing key.
+    new_key = _RSAKey(kid="new")
+    key_server.set_key(new_key)
+
+    # Postcondition: verification retries with a fresh fetch and succeeds.
+    authenticated = await _authenticate(new_key.mint_token(user.email))
+    assert authenticated is not None
+    assert authenticated.id == user.id


### PR DESCRIPTION
## Description

External-IdP JWT passthrough (`JWT_PUBLIC_KEY_URL`) is deployed customer surface — gateways / Entra mint RS256 JWTs that Onyx accepts as bearer auth — but it had no functional test coverage (the only reference in tests was the env-var inventory list) and it is not documented. Meanwhile the auth chain it hooks into (`_check_for_saml_and_jwt` / `_resolve_optional_user`) keeps evolving, so a refactor could silently break it with no CI signal.

This adds external-dependency unit tests that exercise the production code path with a real local HTTP key endpoint and real RS256 tokens against Postgres:

- Existing-user login via a **JWKS** endpoint and via a **PEM** endpoint (both formats the fetcher supports)
- **JIT provisioning** of an unknown email (user created, verified, active)
- **Rejection** of a token signed by a key the endpoint never served, even when it claims the trusted `kid`
- **Rejection** of an expired token
- **IdP key rotation** handled without a restart (the cache-clearing retry refetches)

No production code changes.

## How Has This Been Tested?

```
uv run --env-file .vscode/.env pytest backend/tests/external_dependency_unit/auth/test_jwt_passthrough.py
6 passed in 2.49s
```

Pre-commit (ty, ruff, ruff format) green.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds functional tests for external IdP JWT passthrough via `JWT_PUBLIC_KEY_URL`, exercising the production `_check_for_saml_and_jwt` path with a local HTTP key server (JWKS and PEM) and RS256 tokens against Postgres. Covers existing-user login, JIT provisioning, rejection of tokens signed by unknown keys and expired tokens, and key rotation without restart, with no production code changes.

<sup>Written for commit 437deed0f328d52dea66652bea314b7f463934b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

