### PR TITLE
fix(auth): gate the search surface on read:search instead of basic

### DIFF
--- a/backend/ee/onyx/server/query_and_chat/search_backend.py
+++ b/backend/ee/onyx/server/query_and_chat/search_backend.py
@@ -52,7 +52,7 @@ router = APIRouter(prefix="/search")
 @router.post("/search-flow-classification")
 def search_flow_classification(
     request: SearchFlowClassificationRequest,
-    _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    _: User = Depends(require_permission(Permission.READ_SEARCH)),
     db_session: Session = Depends(get_session),
 ) -> SearchFlowClassificationResponse:
     query = request.user_query
@@ -92,7 +92,7 @@ def search_flow_classification(
 )
 def handle_send_search_message(
     request: SendSearchQueryRequest,
-    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    user: User = Depends(require_permission(Permission.READ_SEARCH)),
     db_session: Session = Depends(get_session),
 ) -> StreamingResponse | SearchFullResponse:
     """
@@ -142,7 +142,7 @@ def handle_send_search_message(
 def get_search_history(
     limit: int = 100,
     filter_days: int | None = None,
-    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    user: User = Depends(require_permission(Permission.READ_SEARCH)),
     db_session: Session = Depends(get_session),
 ) -> SearchHistoryResponse:
     """

--- a/backend/onyx/server/features/web_search/api.py
+++ b/backend/onyx/server/features/web_search/api.py
@@ -231,7 +231,7 @@ def _open_urls(
 @router.post("/search", response_model=WebSearchWithContentResponse)
 def execute_web_search(
     request: WebSearchToolRequest,
-    _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    _: User = Depends(require_permission(Permission.READ_SEARCH)),
     db_session: Session = Depends(get_session),
 ) -> WebSearchWithContentResponse:
     """
@@ -274,7 +274,7 @@ def execute_web_search(
 @router.post("/search-lite", response_model=WebSearchToolResponse)
 def execute_web_search_lite(
     request: WebSearchToolRequest,
-    _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    _: User = Depends(require_permission(Permission.READ_SEARCH)),
     db_session: Session = Depends(get_session),
 ) -> WebSearchToolResponse:
     """
@@ -290,7 +290,7 @@ def execute_web_search_lite(
 @router.post("/open-urls", response_model=OpenUrlsToolResponse)
 def execute_open_urls(
     request: OpenUrlsToolRequest,
-    _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    _: User = Depends(require_permission(Permission.READ_SEARCH)),
     db_session: Session = Depends(get_session),
 ) -> OpenUrlsToolResponse:
     """

--- a/backend/onyx/server/query_and_chat/query_backend.py
+++ b/backend/onyx/server/query_and_chat/query_backend.py
@@ -87,7 +87,7 @@ def get_tags(
     sources: list[DocumentSource] | None = None,
     allow_prefix: bool = True,  # This is currently the only option
     limit: int = 50,
-    _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    _: User = Depends(require_permission(Permission.READ_SEARCH)),
     db_session: Session = Depends(get_session),
 ) -> TagResponse:
     if not allow_prefix:

--- a/backend/tests/unit/onyx/server/test_search_surface_scopes.py
+++ b/backend/tests/unit/onyx/server/test_search_surface_scopes.py
@@ -1,0 +1,55 @@
+"""
+Pins the search surface's route gates to READ_SEARCH so a read:search-scoped
+PAT can reach every endpoint the scope's description promises ("Use search and
+query endpoints"). Scoped PATs can never satisfy BASIC_ACCESS (implication
+only flows basic -> read:search), so a route in this surface regressing to
+BASIC_ACCESS silently locks out scoped tokens while unscoped ones still work.
+"""
+
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from ee.onyx.server.query_and_chat.search_backend import (
+    get_search_history,
+    handle_send_search_message,
+    search_flow_classification,
+)
+from onyx.db.enums import Permission
+from onyx.server.features.web_search.api import (
+    execute_open_urls,
+    execute_web_search,
+    execute_web_search_lite,
+)
+from onyx.server.query_and_chat.query_backend import get_tags
+
+_SEARCH_SURFACE_HANDLERS: list[Callable[..., Any]] = [
+    handle_send_search_message,
+    get_search_history,
+    search_flow_classification,
+    get_tags,
+    execute_web_search,
+    execute_web_search_lite,
+    execute_open_urls,
+]
+
+
+def _permission_gates(handler: Callable[..., Any]) -> list[Permission | None]:
+    gates: list[Permission | None] = []
+    for param in inspect.signature(handler).parameters.values():
+        dependency = getattr(param.default, "dependency", None)
+        if dependency is not None and getattr(
+            dependency, "_is_require_permission", False
+        ):
+            gates.append(getattr(dependency, "_required_permission", None))
+    return gates
+
+
+@pytest.mark.parametrize("handler", _SEARCH_SURFACE_HANDLERS, ids=lambda h: h.__name__)
+def test_search_surface_route_admits_read_search_scope(
+    handler: Callable[..., Any],
+) -> None:
+    gates = _permission_gates(handler)
+    assert gates == [Permission.READ_SEARCH]


### PR DESCRIPTION
## Description

A customer integration using a `read:search`-scoped PAT gets 403 (`INSUFFICIENT_PERMISSIONS`) at `POST /api/search/send-search-message`, while an unscoped PAT from the same user is admitted — so an integrated agent is forced to carry its owner's full authority to use search.

**Root cause:** scoped PATs are capped by `require_permission`: the token's scopes must *imply* the route's required permission, and implication only flows `basic → read:search`, never the reverse. So any route gated on `BASIC_ACCESS` is categorically unreachable by every scoped PAT, while unscoped PATs (no cap) sail through. The scope's own metadata promises "Use search and query endpoints", and the sibling `POST /api/search` already gates on `READ_SEARCH` correctly.

Moves seven search-surface routes from `BASIC_ACCESS` to `READ_SEARCH`:

| Route | Note |
|---|---|
| `POST /search/send-search-message` | the reported endpoint |
| `GET /search/search-history` | same EE router/surface |
| `POST /search/search-flow-classification` | same EE router/surface |
| `GET /query/valid-tags` | search filter tags |
| `POST /web-search/search-lite` | called by the Onyx MCP server with the client's forwarded token — a `read:search` MCP client gets working indexed search but 403s from the web tools today |
| `POST /web-search/open-urls` | same MCP path |
| `POST /web-search/search` | router coherence; public API surface, no in-repo caller |

Browser sessions, API keys, and unscoped PATs are unaffected: `basic` implies `read:search` in effective-permission expansion, and uncapped tokens carry the user's own permissions. Anonymous access is unchanged (none of these routes had `allow_anonymous`).

Deliberately **not** included: chat-peripheral routes and unmarked persona routes have the same structural issue but need a scoping design decision ("which ops belong to `write:chat`") — tracked separately.

## How Has This Been Tested?

- New unit test pins each route's gate via signature introspection (the existing `_required_permission` pattern), so a route regressing to `BASIC_ACCESS` fails CI.
- Live A/B against a real deployment (patched server vs unpatched server, same DB, same tokens):

| Token | Endpoint | Unpatched | Patched |
|---|---|---|---|
| `read:search` PAT | `POST /search/send-search-message` | **403** | admitted (reaches search pipeline, identical response to unscoped) |
| `read:search` PAT | `GET /search/search-history` | 403 | **200** |
| `read:search` PAT | `GET /query/valid-tags` | 403 | **200** |
| `read:chat` PAT | `POST /search/send-search-message` | 403 | **403** (scope capping still enforced) |
| unscoped PAT | `POST /search/send-search-message` | admitted | admitted (unchanged) |

- `uv run pytest backend/tests/unit/onyx/server/test_search_surface_scopes.py` → 7 passed; pre-commit (ty, ruff) green.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches all search-surface endpoints to require READ_SEARCH instead of BASIC_ACCESS so `read:search`-scoped PATs can use search and query APIs without 403s. Browser sessions, API keys, and unscoped PATs are unaffected.

- **Bug Fixes**
  - Updated gates to READ_SEARCH on: POST /search/send-search-message, GET /search/search-history, POST /search/search-flow-classification, GET /query/valid-tags, POST /web-search/search, POST /web-search/search-lite, POST /web-search/open-urls.
  - Added a unit test to pin these routes to READ_SEARCH and prevent regressions.

<sup>Written for commit b8ab4859da1e7b021d0541c17eb7da1ba1d0b3d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

