### PR TITLE
chore(craft): upgrade OpenCode to 1.18.13

### DIFF
--- a/backend/onyx/server/features/build/sandbox/image/Dockerfile
+++ b/backend/onyx/server/features/build/sandbox/image/Dockerfile
@@ -48,7 +48,7 @@ FROM ${BASE_IMAGE_REGISTRY}/library/python:3.13-slim@sha256:f82c96458eedc847b233
 # the image.
 ARG ENABLE_SKILLS=true
 ARG ENABLE_BROWSER=true
-ARG OPENCODE_VERSION=1.15.7
+ARG OPENCODE_VERSION=1.18.13
 ARG AGENT_BROWSER_VERSION=0.31.1
 
 # firewall-init.sh needs: iptables (egress lockdown), ca-certificates (trust

--- a/docs/craft/sandbox/image-and-spinup.md
+++ b/docs/craft/sandbox/image-and-spinup.md
@@ -57,7 +57,7 @@ installs opencode via its own install script with the `--version` flag
 so the build is at least reproducible:
 
 ```dockerfile
-ARG OPENCODE_VERSION=1.15.7
+ARG OPENCODE_VERSION=1.18.13
 RUN curl -fsSL https://opencode.ai/install \
     | bash -s -- --version "${OPENCODE_VERSION}" --no-modify-path
 ```


### PR DESCRIPTION
## Description

Upgrade the OpenCode version installed in the Craft sandbox image from 1.15.7 to 1.18.13. Rebuilding the image is required for Craft sandboxes to run the newer OpenCode runtime.

## How Has This Been Tested?

- Built the linux/amd64 sandbox image and loaded it into the local kind cluster.
- Verified `opencode --version` and the authenticated OpenCode health endpoint report 1.18.13.
- Ran a real Craft agent session through the frontend API, including bash tool execution and artifact creation/readback.
- Verified SSE streaming, duplicate request idempotency, active-turn conflict handling, unauthenticated access, missing input, and path-traversal rejection.
- Snapshotted and restored the sandbox, then verified workspace files, session history, and a post-restore turn survived.
- Ran an actual parent agent that created a subagent, received `CHILD_OK_11813`, followed up directly with the child session, and verified a nonexistent child session returns a 404 error event.
- Ran pre-commit hooks for the changed Dockerfile and `git diff --check`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the `OpenCode` runtime in the Craft sandbox image from 1.15.7 to 1.18.13 and update docs to match. Requires rebuilding the image.

- **Migration**
  - Rebuild and publish the sandbox image, then roll it out to your environment.

<sup>Written for commit 53c1060e9e8bca8581dc2f5be0f8c4952fa00d7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

