### PR TITLE
fix(desktop): import tauri::Manager in the Windows Alt-menu module

### DIFF
--- a/desktop/src-tauri/src/alt_menu.rs
+++ b/desktop/src-tauri/src/alt_menu.rs
@@ -123,7 +123,7 @@ pub use linux::setup_alt_menu_toggle;
 // entirely.
 #[cfg(target_os = "windows")]
 mod windows {
-    use tauri::Webview;
+    use tauri::{Manager, Webview};
 
     const ALT_MENU_SCRIPT: &str = include_str!("scripts/alt_menu_windows.js");
 


### PR DESCRIPTION
## Description

Every Windows desktop build has failed to compile since #13219: the Windows-only `alt_menu` module calls `webview.app_handle()` without the `tauri::Manager` trait in scope (`error[E0599]` at `alt_menu.rs:133`, identical on both the x64 and arm64 jobs of the v4.5.0 and v4.5.1 tag runs). macOS/Linux never compile that `cfg(windows)` module, and PR CI does not build Windows, so nothing caught it before the tag builds.

One-line fix: add the missing `Manager` import (the exact fix rustc suggests; `main.rs` already uses the same trait for the identical call).

## How Has This Been Tested?

- Verified on a real Windows runner: an earlier revision of this PR temporarily enabled the Windows PR CI build, and its `cargo clippy --all-targets --all-features -- -D warnings` step — which fully compiles the crate for the MSVC target — passed with this fix applied.
- The v4.5.1 tag run reported exactly one error in the whole crate, and Windows tag builds passed on v4.4.8 (pre-#13219), so this import is the sole breakage.
- Local cross-compilation isn't possible on macOS (aws-lc-sys's build script needs the Windows SDK).

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check