### PR TITLE
fix(connectors): pin create-connector sidebar and reskin step rail

### DIFF
--- a/web/src/app/admin/connectors/[connector]/ConnectorWrapper.tsx
+++ b/web/src/app/admin/connectors/[connector]/ConnectorWrapper.tsx
@@ -8,7 +8,8 @@ import {
 } from "@/lib/types";
 import AddConnector from "./AddConnectorPage";
 import { FormProvider } from "@/components/context/FormContext";
-import Sidebar from "../../../../sections/sidebar/CreateConnectorSidebar";
+import Sidebar from "@/sections/sidebar/CreateConnectorSidebar";
+import { AdminCustomSidebarPortal } from "@/layouts/chromes/AdminChrome";
 import { HeaderTitle } from "@/components/header/HeaderTitle";
 import Button from "@/refresh-components/buttons/Button";
 import { isValidSource, getSourceMetadata } from "@/lib/sources";
@@ -41,22 +42,22 @@ export default function ConnectorWrapper({
   if (!isValidSource(connector)) {
     return (
       <FormProvider connector={connector}>
-        <div className="flex justify-center w-full h-full">
+        <AdminCustomSidebarPortal>
           <Sidebar />
-          <div className="mt-12 w-full max-w-3xl mx-auto">
-            <div className="mx-auto flex flex-col gap-y-2">
-              <HeaderTitle>
-                <p>&lsquo;{connector}&rsquo; is not a valid Connector Type!</p>
-              </HeaderTitle>
-              {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-              <Button
-                onClick={() => window.open("/admin/indexing/status", "_self")}
-                className="mr-auto"
-              >
-                {" "}
-                Go home{" "}
-              </Button>
-            </div>
+        </AdminCustomSidebarPortal>
+        <div className="mt-12 w-full max-w-3xl mx-auto">
+          <div className="mx-auto flex flex-col gap-y-2">
+            <HeaderTitle>
+              <p>&lsquo;{connector}&rsquo; is not a valid Connector Type!</p>
+            </HeaderTitle>
+            {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
+            <Button
+              onClick={() => window.open("/admin/indexing/status", "_self")}
+              className="mr-auto"
+            >
+              {" "}
+              Go home{" "}
+            </Button>
           </div>
         </div>
       </FormProvider>
@@ -83,11 +84,11 @@ export default function ConnectorWrapper({
   // For regular connectors, use the existing flow
   return (
     <FormProvider connector={connector}>
-      <div className="flex justify-center w-full h-full">
+      <AdminCustomSidebarPortal>
         <Sidebar />
-        <div className="mt-12 w-full max-w-3xl mx-auto">
-          <AddConnector connector={connector} />
-        </div>
+      </AdminCustomSidebarPortal>
+      <div className="mt-12 w-full max-w-3xl mx-auto">
+        <AddConnector connector={connector} />
       </div>
     </FormProvider>
   );

--- a/web/src/app/admin/connectors/[connector]/NavigationRow.tsx
+++ b/web/src/app/admin/connectors/[connector]/NavigationRow.tsx
@@ -1,24 +1,28 @@
+"use client";
+
 import { useFormContext } from "@/components/context/FormContext";
 import { Button } from "@opal/components";
 import { SvgArrowLeft, SvgArrowRight, SvgPlusCircle } from "@opal/icons";
 
-const NavigationRow = ({
-  noAdvanced,
-  noCredentials,
-  activatedCredential,
-  onSubmit,
-  isValid,
-}: {
+interface NavigationRowProps {
   isValid: boolean;
   onSubmit: () => void;
   noAdvanced: boolean;
   noCredentials: boolean;
   activatedCredential: boolean;
-}) => {
+}
+
+export default function NavigationRow({
+  noAdvanced,
+  noCredentials,
+  activatedCredential,
+  onSubmit,
+  isValid,
+}: NavigationRowProps) {
   const { formStep, prevFormStep, nextFormStep } = useFormContext();
 
   return (
-    <div className="mt-4 w-full grid grid-cols-3">
+    <div className="py-4 w-full grid grid-cols-3">
       <div>
         {((formStep > 0 && !noCredentials) ||
           (formStep > 1 && !noAdvanced)) && (
@@ -66,5 +70,4 @@ const NavigationRow = ({
       </div>
     </div>
   );
-};
-export default NavigationRow;
+}

--- a/web/src/layouts/chromes/AdminChrome.tsx
+++ b/web/src/layouts/chromes/AdminChrome.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { createContext, useContext, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 import AdminSidebar from "@/sections/sidebar/AdminSidebar";
 import { usePathname } from "next/navigation";
 import { useSettings } from "@/lib/settings/hooks";
@@ -18,12 +20,31 @@ export interface AdminChromeProps {
   children: React.ReactNode;
 }
 
+// Lets a page render its own sidebar into the chrome as a sibling of the main
+// content column — i.e. *outside* the scrollable region — so it stays pinned
+// while the page scrolls. The page keeps ownership (and React context) of the
+// sidebar; only the DOM is portaled up next to `RootLayout.App`.
+const AdminCustomSidebarSlotContext = createContext<HTMLElement | null>(null);
+
+export function AdminCustomSidebarPortal({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const slot = useContext(AdminCustomSidebarSlotContext);
+  if (!slot) return null;
+  return createPortal(children, slot);
+}
+
 export default function AdminChrome({ children }: AdminChromeProps) {
   const { setFolded } = useSidebarState();
   const { isMobile } = useScreenSize();
   const pathname = usePathname();
   const { vectorDbEnabled, isLoading, application_status } = useSettings();
   useAdminDocumentTitle();
+
+  const [customSidebarSlot, setCustomSidebarSlot] =
+    useState<HTMLDivElement | null>(null);
 
   // Certain admin panels have their own custom sidebar.
   // For those pages, we skip rendering the default `AdminSidebar` and let those individual pages render their own.
@@ -43,39 +64,47 @@ export default function AdminChrome({ children }: AdminChromeProps) {
   }
 
   return (
-    <RootLayout.Root>
-      {application_status === ApplicationStatus.PAYMENT_REMINDER && (
-        <div className="fixed top-2 left-1/2 -translate-x-1/2 bg-status-warning-01 p-4 rounded-lg shadow-lg z-50 max-w-md text-center">
-          <Text font="main-ui-body" color="text-05">
-            {markdown(
-              "**Warning:** Your trial ends in less than 5 days and no payment method has been added."
-            )}
-          </Text>
-          <div className="mt-2">
-            <Button width="full" href="/admin/billing">
-              Update Billing Information
-            </Button>
-          </div>
-        </div>
-      )}
-
-      {!hasCustomSidebar && <AdminSidebar />}
-
-      <RootLayout.App data-main-container>
-        {isMobile && !hasCustomSidebar && (
-          <RootLayout.Header>
-            <div className="h-full flex items-center px-4 py-2">
-              <Button
-                prominence="internal"
-                icon={SvgSidebar}
-                aria-label="Open Sidebar"
-                onClick={() => setFolded(false)}
-              />
+    <AdminCustomSidebarSlotContext.Provider value={customSidebarSlot}>
+      <RootLayout.Root>
+        {application_status === ApplicationStatus.PAYMENT_REMINDER && (
+          <div className="fixed top-2 left-1/2 -translate-x-1/2 bg-status-warning-01 p-4 rounded-lg shadow-lg z-50 max-w-md text-center">
+            <Text font="main-ui-body" color="text-05">
+              {markdown(
+                "**Warning:** Your trial ends in less than 5 days and no payment method has been added."
+              )}
+            </Text>
+            <div className="mt-2">
+              <Button width="full" href="/admin/billing">
+                Update Billing Information
+              </Button>
             </div>
-          </RootLayout.Header>
+          </div>
         )}
-        <RootLayout.MainContent>{content}</RootLayout.MainContent>
-      </RootLayout.App>
-    </RootLayout.Root>
+
+        {hasCustomSidebar ? (
+          // `display: contents` so the portaled sidebar column becomes the
+          // direct flex child of `RootLayout.Root`, exactly like `AdminSidebar`.
+          <div ref={setCustomSidebarSlot} className="contents" />
+        ) : (
+          <AdminSidebar />
+        )}
+
+        <RootLayout.App data-main-container>
+          {isMobile && !hasCustomSidebar && (
+            <RootLayout.Header>
+              <div className="h-full flex items-center px-4 py-2">
+                <Button
+                  prominence="internal"
+                  icon={SvgSidebar}
+                  aria-label="Open Sidebar"
+                  onClick={() => setFolded(false)}
+                />
+              </div>
+            </RootLayout.Header>
+          )}
+          <RootLayout.MainContent>{content}</RootLayout.MainContent>
+        </RootLayout.App>
+      </RootLayout.Root>
+    </AdminCustomSidebarSlotContext.Provider>
   );
 }

--- a/web/src/sections/sidebar/CreateConnectorSidebar.tsx
+++ b/web/src/sections/sidebar/CreateConnectorSidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Fragment } from "react";
 import { useFormContext } from "@/components/context/FormContext";
 import { credentialTemplates } from "@/lib/connectors/credentials";
 import { Text } from "@opal/components";
@@ -11,6 +12,29 @@ import { SvgSettings } from "@opal/icons";
 // Fixed height of each step row (px). A uniform row height lets the connecting
 // rail line up deterministically with every dot regardless of step count.
 const STEP_ROW_PX = 36;
+
+type SelectionType = "done" | "current" | "future";
+
+interface SelectionIconProps {
+  selected: SelectionType;
+}
+
+function SelectionIcon({ selected }: SelectionIconProps) {
+  return (
+    <div
+      className={cn(
+        "shrink-0 z-10 rounded-full h-3.5 w-3.5 flex items-center justify-center",
+        selected === "future"
+          ? "bg-background-tint-04"
+          : "bg-action-selection-05"
+      )}
+    >
+      {selected === "current" && (
+        <div className="h-1.5 w-1.5 rounded-full bg-background-tint-inverted-00" />
+      )}
+    </div>
+  );
+}
 
 export default function Sidebar() {
   const { formStep, setFormStep, connector, allowAdvanced, allowCreate } =
@@ -33,15 +57,6 @@ export default function Sidebar() {
       buttonHref="/admin/add-connector"
     >
       <div className="relative mx-2.5 flex flex-col">
-        {settingSteps.length > 1 && (
-          <div
-            className="absolute left-[6px] w-0.5 bg-background-tint-04"
-            style={{
-              top: STEP_ROW_PX / 2,
-              height: (settingSteps.length - 1) * STEP_ROW_PX,
-            }}
-          />
-        )}
         {settingSteps.map((step, index) => {
           const allowed =
             (step == "Connector" && allowCreate) ||
@@ -49,37 +64,51 @@ export default function Sidebar() {
             index <= formStep;
 
           return (
-            <div
-              key={index}
-              className={cn(
-                "flex items-center gap-4",
-                allowed ? "cursor-pointer" : "cursor-not-allowed"
+            <Fragment key={index}>
+              {index !== 0 && (
+                <div
+                  className={cn(
+                    "absolute left-1.5 w-0.5",
+                    index <= formStep
+                      ? "bg-action-selection-05"
+                      : "bg-background-tint-04"
+                  )}
+                  style={{
+                    top: (index - 1) * STEP_ROW_PX + STEP_ROW_PX / 2,
+                    height: STEP_ROW_PX,
+                  }}
+                />
               )}
-              style={{ height: STEP_ROW_PX }}
-              onClick={() => {
-                if (allowed) {
-                  setFormStep(index - (noCredential ? 1 : 0));
-                }
-              }}
-            >
               <div
                 className={cn(
-                  "shrink-0 z-10 rounded-full h-3.5 w-3.5 flex items-center justify-center",
-                  allowed ? "bg-action-selection-05" : "bg-background-tint-04"
+                  "flex items-center gap-4",
+                  allowed ? "cursor-pointer" : "cursor-not-allowed"
                 )}
+                style={{ height: STEP_ROW_PX }}
+                onClick={() => {
+                  if (allowed) {
+                    setFormStep(index - (noCredential ? 1 : 0));
+                  }
+                }}
               >
-                {formStep === index && (
-                  <div className="h-2 w-2 rounded-full bg-background-neutral-00" />
-                )}
+                <SelectionIcon
+                  selected={
+                    formStep === index
+                      ? "current"
+                      : formStep < index
+                        ? "future"
+                        : "done"
+                  }
+                />
+                <Text
+                  as="p"
+                  font="main-ui-body"
+                  color={index <= formStep ? "text-04" : "text-02"}
+                >
+                  {step}
+                </Text>
               </div>
-              <Text
-                as="p"
-                font="main-ui-body"
-                color={index <= formStep ? "text-04" : "text-02"}
-              >
-                {step}
-              </Text>
-            </div>
+            </Fragment>
           );
         })}
       </div>

--- a/web/src/sections/sidebar/CreateConnectorSidebar.tsx
+++ b/web/src/sections/sidebar/CreateConnectorSidebar.tsx
@@ -3,7 +3,7 @@
 import { Fragment } from "react";
 import { useFormContext } from "@/components/context/FormContext";
 import { credentialTemplates } from "@/lib/connectors/credentials";
-import { Text } from "@opal/components";
+import { Content } from "@opal/layouts";
 import { cn } from "@opal/utils";
 import StepSidebar from "@/sections/sidebar/StepSidebarWrapper";
 import { useUser } from "@/providers/UserProvider";
@@ -56,19 +56,26 @@ export default function Sidebar() {
       buttonIcon={SvgSettings}
       buttonHref="/admin/add-connector"
     >
-      <div className="relative mx-2.5 flex flex-col">
+      <div className="relative mx-2 flex flex-col">
         {settingSteps.map((step, index) => {
           const allowed =
             (step == "Connector" && allowCreate) ||
             (step == "Advanced (optional)" && allowAdvanced) ||
             index <= formStep;
 
+          const selected: SelectionType =
+            formStep === index
+              ? "current"
+              : formStep < index
+                ? "future"
+                : "done";
+
           return (
             <Fragment key={index}>
               {index !== 0 && (
                 <div
                   className={cn(
-                    "absolute left-1.5 w-0.5",
+                    "absolute left-2 w-0.5",
                     index <= formStep
                       ? "bg-action-selection-05"
                       : "bg-background-tint-04"
@@ -81,7 +88,7 @@ export default function Sidebar() {
               )}
               <div
                 className={cn(
-                  "flex items-center gap-4",
+                  "flex items-center",
                   allowed ? "cursor-pointer" : "cursor-not-allowed"
                 )}
                 style={{ height: STEP_ROW_PX }}
@@ -91,22 +98,13 @@ export default function Sidebar() {
                   }
                 }}
               >
-                <SelectionIcon
-                  selected={
-                    formStep === index
-                      ? "current"
-                      : formStep < index
-                        ? "future"
-                        : "done"
-                  }
+                <Content
+                  sizePreset="main-ui"
+                  variant="body"
+                  icon={() => <SelectionIcon selected={selected} />}
+                  title={step}
+                  color={selected === "future" ? "muted" : "default"}
                 />
-                <Text
-                  as="p"
-                  font="main-ui-body"
-                  color={index <= formStep ? "text-04" : "text-02"}
-                >
-                  {step}
-                </Text>
               </div>
             </Fragment>
           );

--- a/web/src/sections/sidebar/CreateConnectorSidebar.tsx
+++ b/web/src/sections/sidebar/CreateConnectorSidebar.tsx
@@ -2,10 +2,15 @@
 
 import { useFormContext } from "@/components/context/FormContext";
 import { credentialTemplates } from "@/lib/connectors/credentials";
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
+import { cn } from "@opal/utils";
 import StepSidebar from "@/sections/sidebar/StepSidebarWrapper";
 import { useUser } from "@/providers/UserProvider";
 import { SvgSettings } from "@opal/icons";
+
+// Fixed height of each step row (px). A uniform row height lets the connecting
+// rail line up deterministically with every dot regardless of step count.
+const STEP_ROW_PX = 36;
 
 export default function Sidebar() {
   const { formStep, setFormStep, connector, allowAdvanced, allowCreate } =
@@ -27,9 +32,15 @@ export default function Sidebar() {
       buttonIcon={SvgSettings}
       buttonHref="/admin/add-connector"
     >
-      <div className="relative">
-        {connector != "file" && (
-          <div className="absolute h-[85%] left-[6px] top-[8px] bottom-0 w-0.5 bg-background-tint-04"></div>
+      <div className="relative mx-2.5 flex flex-col">
+        {settingSteps.length > 1 && (
+          <div
+            className="absolute left-[6px] w-0.5 bg-background-tint-04"
+            style={{
+              top: STEP_ROW_PX / 2,
+              height: (settingSteps.length - 1) * STEP_ROW_PX,
+            }}
+          />
         )}
         {settingSteps.map((step, index) => {
           const allowed =
@@ -40,27 +51,32 @@ export default function Sidebar() {
           return (
             <div
               key={index}
-              className={`flex items-center mb-6 relative ${
-                !allowed ? "cursor-not-allowed" : "cursor-pointer"
-              }`}
+              className={cn(
+                "flex items-center gap-4",
+                allowed ? "cursor-pointer" : "cursor-not-allowed"
+              )}
+              style={{ height: STEP_ROW_PX }}
               onClick={() => {
                 if (allowed) {
                   setFormStep(index - (noCredential ? 1 : 0));
                 }
               }}
             >
-              <div className="shrink-0 mr-4 z-10">
-                <div
-                  className={`rounded-full h-3.5 w-3.5 flex items-center justify-center ${
-                    allowed ? "bg-blue-500" : "bg-background-tint-04"
-                  }`}
-                >
-                  {formStep === index && (
-                    <div className="h-2 w-2 rounded-full bg-white"></div>
-                  )}
-                </div>
+              <div
+                className={cn(
+                  "shrink-0 z-10 rounded-full h-3.5 w-3.5 flex items-center justify-center",
+                  allowed ? "bg-action-selection-05" : "bg-background-tint-04"
+                )}
+              >
+                {formStep === index && (
+                  <div className="h-2 w-2 rounded-full bg-background-neutral-00" />
+                )}
               </div>
-              <Text as="p" text04={index <= formStep} text02={index > formStep}>
+              <Text
+                as="p"
+                font="main-ui-body"
+                color={index <= formStep ? "text-04" : "text-02"}
+              >
                 {step}
               </Text>
             </div>

--- a/web/src/sections/sidebar/CreateConnectorSidebar.tsx
+++ b/web/src/sections/sidebar/CreateConnectorSidebar.tsx
@@ -58,15 +58,21 @@ export default function Sidebar() {
     >
       <div className="relative mx-2 flex flex-col">
         {settingSteps.map((step, index) => {
+          // The form numbers steps absolutely (0 = Credential, 1 = Connector,
+          // 2 = Advanced) and clamps `formStep` to >= 1 when there's no
+          // credential step. Since we omit the Credential row in that case,
+          // shift the row index up to recover the form's step numbering.
+          const stepValue = index + (noCredential ? 1 : 0);
+
           const allowed =
             (step == "Connector" && allowCreate) ||
             (step == "Advanced (optional)" && allowAdvanced) ||
-            index <= formStep;
+            stepValue <= formStep;
 
           const selected: SelectionType =
-            formStep === index
+            formStep === stepValue
               ? "current"
-              : formStep < index
+              : formStep < stepValue
                 ? "future"
                 : "done";
 
@@ -76,7 +82,7 @@ export default function Sidebar() {
                 <div
                   className={cn(
                     "absolute left-2 w-0.5",
-                    index <= formStep
+                    stepValue <= formStep
                       ? "bg-action-selection-05"
                       : "bg-background-tint-04"
                   )}
@@ -94,7 +100,7 @@ export default function Sidebar() {
                 style={{ height: STEP_ROW_PX }}
                 onClick={() => {
                   if (allowed) {
-                    setFormStep(index - (noCredential ? 1 : 0));
+                    setFormStep(stepValue);
                   }
                 }}
               >


### PR DESCRIPTION
## Description

Fixes a few UI issues on the create-connector page (`/admin/connectors/[connector]`):

- **Step rail reskin** — the vertical progress rail no longer uses a fragile `h-[85%]` absolute line; it renders deterministic per-segment lines that align to every dot regardless of step count, with per-segment progress coloring. Migrated to Opal `Text`/`Content` and theme color tokens (dropping raw `bg-blue-500` / `bg-white`).
- **Pinned sidebar** — the step sidebar previously scrolled away with the form because it was rendered *inside* the scrollable main content. It's now hoisted out via an `AdminChrome` portal slot so it sits as a sibling of `RootLayout.App` (like `AdminSidebar`), staying pinned while the page scrolls and putting the scrollbar back at the page's right edge.
- **`NavigationRow` tidy** — props interface extraction, function declaration, padding over margin.
- Step rows now render through Opal `Content` (`ContentSm`) so icon/label layout and typography come from the design system.

## Screenshots + Videos

Sidebar (alignment fix + rails fix):

<img width="244" height="1043" alt="image" src="https://github.com/user-attachments/assets/9a25d161-1ea2-4230-9863-468c5da81c06" />

Main content (scroll fix + bottom padding fix):

<img width="1539" height="1041" alt="image" src="https://github.com/user-attachments/assets/fc4ca8ed-b4cb-4d60-977f-7ece45b4a79f" />

Full flow:

https://github.com/user-attachments/assets/60e31539-6c2b-417a-8da1-5749bc608ce7

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the create-connector sidebar, rebuilds the step rail for consistent alignment, and fixes step tracking for connectors without credentials. The sidebar stays visible while the form scrolls, the rail aligns with every step, and the current step highlights correctly across all connector types.

- **Bug Fixes**
  - Sidebar on `/admin/connectors/[connector]` now renders outside the scrollable content via an `AdminChrome` portal, so it stays pinned and the page scrollbar returns to the right edge.
  - Step rail uses uniform row heights with per-segment progress colors, ensuring dots and lines always line up across any step count.
  - Corrected step numbering for connectors without credentials (e.g., web, wikipedia) by deriving the real step index, so progress and navigation work and Advanced is reachable.

- **Refactors**
  - Added `AdminCustomSidebarPortal` and a slot context in `AdminChrome` to host page-specific sidebars as siblings of the main column.
  - Switched step rows to `Content` from `@opal/layouts` with theme tokens, replacing manual text and raw color classes.
  - Cleaned `NavigationRow`: typed props, function component, padding spacing, and added "use client".

<sup>Written for commit 94bcd81d5d5c9835ed6559e766aa9d6a988debb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

