### PR TITLE
feat(connector-stability): gateway credential construction helper

### DIFF
--- a/backend/onyx/connectors/capability_checks/runner.py
+++ b/backend/onyx/connectors/capability_checks/runner.py
@@ -28,6 +28,7 @@ from onyx.connectors.factory import identify_connector_class, instantiate_connec
 from onyx.connectors.interfaces import BaseConnector
 from onyx.connectors.models import InputType
 from onyx.db.models import Credential
+from onyx.utils.credential_audit import emit_credential_access
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import run_with_timeout
 
@@ -287,6 +288,15 @@ def generate_capability_report(
             e,
         )
 
+    if credential.credential_json:
+        # Distinct decrypt site from ``instantiate_connector``'s paths (which
+        # may not have decrypted at all when instantiation fails). Audit is
+        # best-effort and never raises.
+        emit_credential_access(
+            credential_type="connector",
+            provider=str(source),
+            row_id=credential.id,
+        )
     credential_json = (
         credential.credential_json.get_value(apply_mask=False)
         if credential.credential_json

--- a/backend/onyx/connectors/credentials_provider.py
+++ b/backend/onyx/connectors/credentials_provider.py
@@ -5,11 +5,13 @@ from typing import Any
 from redis.lock import Lock as RedisLock
 from sqlalchemy import select
 
+from onyx.configs.constants import DocumentSource
 from onyx.connectors.interfaces import CredentialsProviderInterface
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.models import Credential
 from onyx.redis.redis_pool import get_redis_client
 from onyx.utils.credential_audit import emit_credential_access
+from shared_configs.contextvars import get_current_tenant_id
 
 
 class OnyxDBCredentialsProvider(
@@ -101,6 +103,24 @@ class OnyxDBCredentialsProvider(
 
     def is_dynamic(self) -> bool:
         return True
+
+
+def build_db_credentials_provider(
+    source: DocumentSource, credential_id: int
+) -> OnyxDBCredentialsProvider:
+    """Builds the DB-backed provider for a persisted credential.
+
+    ``instantiate_connector`` and source-operation gateways route through this
+    one site so the decrypt-audit, refresh write-back, and rotation-lock
+    guarantees stay uniform. ``str(source)`` (the historical
+    ``DocumentSource.X`` form, not ``source.value``) feeds the rotation lock
+    key. EE perm-sync code still builds ``source.value``-keyed providers inline;
+    connector migration reroutes those through the gateway and thus through
+    here.
+    """
+    return OnyxDBCredentialsProvider(
+        get_current_tenant_id(), str(source), credential_id
+    )
 
 
 class OnyxStaticCredentialsProvider(

--- a/backend/onyx/connectors/factory.py
+++ b/backend/onyx/connectors/factory.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from onyx.configs.app_configs import INTEGRATION_TESTS_MODE
 from onyx.configs.constants import DocumentSource
 from onyx.configs.llm_configs import get_image_extraction_and_analysis_enabled
-from onyx.connectors.credentials_provider import OnyxDBCredentialsProvider
+from onyx.connectors.credentials_provider import build_db_credentials_provider
 from onyx.connectors.exceptions import ConnectorValidationError, ValidationError
 from onyx.connectors.interfaces import (
     BaseConnector,
@@ -24,7 +24,6 @@ from onyx.db.enums import AccessType
 from onyx.db.models import Credential
 from onyx.file_store.staging import RawFileCallback
 from onyx.utils.credential_audit import emit_credential_access
-from shared_configs.contextvars import get_current_tenant_id
 
 
 class ConnectorMissingException(Exception):
@@ -116,9 +115,7 @@ def instantiate_connector(
     connector = connector_class(**connector_specific_config)
 
     if isinstance(connector, CredentialsConnector):
-        provider = OnyxDBCredentialsProvider(
-            get_current_tenant_id(), str(source), credential.id
-        )
+        provider = build_db_credentials_provider(source, credential.id)
         connector.set_credentials_provider(provider)
     else:
         if credential.credential_json:

--- a/backend/onyx/connectors/source_operations.py
+++ b/backend/onyx/connectors/source_operations.py
@@ -28,6 +28,7 @@ from pydantic import BaseModel, ConfigDict
 
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.capabilities import CredentialCapability
+from onyx.connectors.interfaces import CredentialsProviderInterface
 
 _SPEC_ATTR = "__source_operation_spec__"
 
@@ -155,9 +156,16 @@ class SourceOperations(ABC):
     - Every public method must be classified with ``@source_operation``. Helpers
       (including any staticmethod/classmethod/property) stay private; data
       models live at module level.
+    - Do not override ``__init__``: every gateway is constructed through the
+      framework constructor below, so the checks runner can construct any
+      registered gateway uniformly. Build clients lazily inside operations or
+      private helpers.
 
     The gateway owns client construction from the credential plus optional
     connector config; operations return plain data, never live SDK objects.
+    Credentials arrive as a provider (built via
+    ``build_db_credentials_provider`` for persisted credentials), which carries
+    the decrypt-audit, refresh write-back, and rotation-lock guarantees.
     """
 
     source: ClassVar[DocumentSource]
@@ -171,6 +179,17 @@ class SourceOperations(ABC):
 
     _operation_specs: ClassVar[Mapping[str, SourceOperationSpec]] = MappingProxyType({})
 
+    def __init__(
+        self,
+        *,
+        credentials_provider: CredentialsProviderInterface,
+        connector_specific_config: dict[str, Any] | None = None,
+    ) -> None:
+        self.credentials_provider = credentials_provider
+        # None on config-less credential-time runs; config-consuming operations
+        # are not called then (their checks skip instead).
+        self.connector_specific_config = connector_specific_config
+
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
 
@@ -181,6 +200,14 @@ class SourceOperations(ABC):
                 "the import-time enforcement, which scans only the class's "
                 "own namespace. Put shared logic in private module-level "
                 "helpers."
+            )
+
+        if "__init__" in vars(cls):
+            raise TypeError(
+                f"{cls.__name__} must not override __init__: gateways are "
+                "constructed uniformly from a credentials provider plus "
+                "optional connector config. Build clients lazily inside "
+                "operations or private helpers."
             )
 
         # Read the subclass's own namespace, like the method scan below: the

--- a/backend/tests/unit/onyx/connectors/capability_checks/test_generate_capability_report.py
+++ b/backend/tests/unit/onyx/connectors/capability_checks/test_generate_capability_report.py
@@ -227,3 +227,47 @@ def test_real_config_unlocks_config_requiring_checks(
     assert report.connector_id == 42
     assert report.trigger == CapabilityCheckTrigger.CC_PAIR_VALIDATION
     assert report.check_results[0].status == CapabilityCheckStatus.PASSED
+
+
+def test_report_decrypt_emits_a_credential_audit_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Verifies the report run's own decrypt is audited: it is a distinct decrypt
+    site from ``instantiate_connector``, which may not have decrypted at all.
+    """
+    # Precondition.
+    check = _CallableCheck(MagicMock(return_value=None), check_id="instance_check")
+    _patch_runner_environment(monkeypatch, [check])
+    emit = MagicMock()
+    monkeypatch.setattr(runner_module, "emit_credential_access", emit)
+    credential = _make_credential()
+    credential.credential_json = MagicMock()
+    credential.credential_json.get_value.return_value = {"token": "x"}
+
+    # Under test.
+    generate_capability_report(MagicMock(), credential)
+
+    # Postcondition.
+    emit.assert_called_once_with(
+        credential_type="connector",
+        provider=str(DocumentSource.GITHUB),
+        row_id=7,
+    )
+
+
+def test_empty_credential_decrypts_nothing_and_emits_no_audit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verifies a credential-less row produces no phantom audit event."""
+    # Precondition.
+    check = _CallableCheck(MagicMock(return_value=None), check_id="instance_check")
+    _patch_runner_environment(monkeypatch, [check])
+    emit = MagicMock()
+    monkeypatch.setattr(runner_module, "emit_credential_access", emit)
+
+    # Under test.
+    generate_capability_report(MagicMock(), _make_credential())
+
+    # Postcondition.
+    emit.assert_not_called()

--- a/backend/tests/unit/onyx/connectors/test_credentials_provider.py
+++ b/backend/tests/unit/onyx/connectors/test_credentials_provider.py
@@ -1,0 +1,44 @@
+"""Pins the shared credentials-provider construction helper.
+
+``build_db_credentials_provider`` is the single construction site for the
+DB-backed provider: ``instantiate_connector`` and source-operation gateways both
+route through it, so its output shape is what keeps decrypt-audit, refresh
+write-back, and rotation-lock behavior uniform across consumers.
+"""
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.credentials_provider import (
+    OnyxDBCredentialsProvider,
+    build_db_credentials_provider,
+)
+from shared_configs.contextvars import get_current_tenant_id
+
+
+def test_helper_builds_the_canonical_db_provider() -> None:
+    """
+    Verifies the helper yields the DB-backed provider -- the one carrying the
+    decrypt-audit and refresh write-back guarantees -- keyed to the credential
+    row and the current tenant.
+    """
+
+    # Under test.
+    provider = build_db_credentials_provider(DocumentSource.SLACK, 42)
+
+    # Postcondition.
+    assert isinstance(provider, OnyxDBCredentialsProvider)
+    assert provider.is_dynamic() is True
+    assert provider.get_provider_key() == "42"
+    assert provider.get_tenant_id() == get_current_tenant_id()
+
+
+def test_helper_keeps_the_historical_rotation_lock_key() -> None:
+    """
+    Pins the lock key to the ``str(source)`` form in-flight connectors hold;
+    silently switching to ``source.value`` would stop excluding them.
+    """
+
+    # Under test.
+    provider = build_db_credentials_provider(DocumentSource.SLACK, 42)
+
+    # Postcondition.
+    assert provider.lock_key == "da_lock:connector:DocumentSource.SLACK:credential_42"

--- a/backend/tests/unit/onyx/connectors/test_source_operations.py
+++ b/backend/tests/unit/onyx/connectors/test_source_operations.py
@@ -1,10 +1,12 @@
 from functools import cached_property
+from typing import Any, cast
 
 import pytest
 
 from onyx.configs.constants import DocumentSource
 from onyx.connectors import source_operations as source_operations_module
 from onyx.connectors.capability_checks.models import CredentialCapability
+from onyx.connectors.credentials_provider import OnyxStaticCredentialsProvider
 from onyx.connectors.source_operations import (
     OperationConsumes,
     SourceOperations,
@@ -18,6 +20,11 @@ from onyx.connectors.source_operations import (
 def isolated_registry(monkeypatch: pytest.MonkeyPatch) -> None:
     """Isolates the gateway registry so test classes never leak globally."""
     monkeypatch.setattr(source_operations_module, "_SOURCE_OPERATIONS_BY_SOURCE", {})
+
+
+def _static_provider() -> OnyxStaticCredentialsProvider:
+    """Builds a throwaway credentials provider for gateway construction."""
+    return OnyxStaticCredentialsProvider(None, "test", {})
 
 
 @pytest.mark.usefixtures("isolated_registry")
@@ -397,7 +404,7 @@ def test_variant_bearing_operation_requires_a_declared_variant() -> None:
         def list_channels(self, *, variant: str | None = None) -> str | None:
             return variant
 
-    gateway = _VariantOperations()
+    gateway = _VariantOperations(credentials_provider=_static_provider())
 
     # Under test and postcondition.
     assert gateway.list_channels(variant="public") == "public"
@@ -429,4 +436,65 @@ def test_variantless_operation_is_not_wrapped() -> None:
             return "history"
 
     # Under test and postcondition.
-    assert _PlainOperations().fetch_history() == "history"
+    gateway = _PlainOperations(credentials_provider=_static_provider())
+    assert gateway.fetch_history() == "history"
+
+
+@pytest.mark.usefixtures("isolated_registry")
+def test_framework_constructor_stores_provider_and_config() -> None:
+    """Verifies gateways construct uniformly from a provider plus config."""
+
+    # Precondition.
+    class _SlackOperations(SourceOperations):
+        source = DocumentSource.SLACK
+        sdk_modules = ()
+
+    provider = _static_provider()
+
+    # Under test.
+    gateway = _SlackOperations(
+        credentials_provider=provider,
+        connector_specific_config={"workspace": "onyx"},
+    )
+    configless = _SlackOperations(credentials_provider=provider)
+
+    # Postcondition.
+    assert gateway.credentials_provider is provider
+    assert gateway.connector_specific_config == {"workspace": "onyx"}
+    assert configless.connector_specific_config is None
+
+
+@pytest.mark.usefixtures("isolated_registry")
+def test_framework_constructor_is_keyword_only() -> None:
+    """
+    Verifies positional construction is rejected, so every construction site
+    names its inputs and cannot silently swap them.
+    """
+
+    # Precondition.
+    class _SlackOperations(SourceOperations):
+        source = DocumentSource.SLACK
+        sdk_modules = ()
+
+    # Under test and postcondition. ``Any``-cast to exercise at runtime the
+    # call shape ty rejects statically.
+    with pytest.raises(TypeError):
+        cast(Any, _SlackOperations)(_static_provider())
+
+
+@pytest.mark.usefixtures("isolated_registry")
+def test_init_override_is_rejected() -> None:
+    """
+    Verifies a gateway cannot define ``__init__``: per-gateway constructor
+    signatures would break the runner's uniform gateway construction.
+    """
+
+    # Under test and postcondition.
+    with pytest.raises(TypeError, match="must not override __init__"):
+
+        class _InitOverridingOperations(SourceOperations):
+            source = DocumentSource.SLACK
+            sdk_modules = ()
+
+            def __init__(self) -> None:
+                super().__init__(credentials_provider=_static_provider())


### PR DESCRIPTION
## Description

Framework-level credential plumbing for source-operation gateways; ships dark (the gateway registry is still empty).

- `build_db_credentials_provider`: shared construction site for `OnyxDBCredentialsProvider`. `instantiate_connector` now routes through it and gateway construction will too, so the decrypt-audit, refresh write-back, and rotation-lock-key behaviors cannot drift between the two paths.
- `SourceOperations` framework constructor: every gateway is constructed uniformly from a credentials provider plus optional connector config; `__init__` overrides are rejected at import time so the checks runner can construct any registered gateway. Clients are built lazily inside operations.
- `generate_capability_report`'s own credential decrypt now emits the standard credential-access audit event; it was the one unaudited decrypt site.
- Known pre-existing issue, deliberately not fixed here: the EE perm-sync sites build providers inline with different lock-key strings, so their rotation locks never contend with indexing's; each connector's mismatch disappears when it migrates to a gateway.

## How Has This Been Tested?
Added automated test cases.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared credentials-provider helper and enforces uniform gateway construction so decrypt audit, refresh write-back, and rotation-lock behavior stay consistent. Ships dark; no gateways registered yet.

- **Refactors**
  - Introduced `build_db_credentials_provider` and routed `instantiate_connector` and `SourceOperations` gateways through it; preserves `str(source)` rotation lock key on `OnyxDBCredentialsProvider`.
  - `SourceOperations` now takes `credentials_provider` and optional `connector_specific_config`; `__init__` overrides are rejected and clients should be built lazily inside operations.
  - Note: EE perm-sync paths still build providers inline; they will align after migrating to gateways.

- **Bug Fixes**
  - `generate_capability_report` now emits a credential-access audit event when decrypting credentials; no event is emitted for empty credentials.

<sup>Written for commit 35809d93349dde405df276d758bfb648d6460dde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

