### PR TITLE
fix: normalize API prefixes before middleware gates

### DIFF
--- a/backend/ee/onyx/server/middleware/license_enforcement.py
+++ b/backend/ee/onyx/server/middleware/license_enforcement.py
@@ -72,6 +72,7 @@ from ee.onyx.server.license.models import LicenseMetadata
 from ee.onyx.utils.license import maybe_schedule_license_reclaim
 from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.server.middleware.api_prefix import strip_api_prefix
 from onyx.server.settings.models import ApplicationStatus
 from shared_configs.contextvars import get_current_tenant_id
 
@@ -116,9 +117,7 @@ def add_license_enforcement_middleware(
         if not LICENSE_ENFORCEMENT_ENABLED:
             return await call_next(request)
 
-        path = request.url.path
-        if path.startswith("/api/"):
-            path = path[4:]
+        path = strip_api_prefix(request.url.path)
 
         if _is_path_allowed(path):
             return await call_next(request)

--- a/backend/ee/onyx/server/middleware/tenant_tracking.py
+++ b/backend/ee/onyx/server/middleware/tenant_tracking.py
@@ -19,6 +19,7 @@ from onyx.redis.redis_pool import (
     retrieve_auth_token_data_from_bearer,
     retrieve_auth_token_data_from_redis,
 )
+from onyx.server.middleware.api_prefix import strip_api_prefix
 from shared_configs.configs import MULTI_TENANT, POSTGRES_DEFAULT_SCHEMA
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
@@ -101,8 +102,7 @@ def add_api_server_tenant_id_middleware(
 
 
 def _is_path_allowed(path: str) -> bool:
-    if path.startswith("/api/"):
-        path = path[4:]
+    path = strip_api_prefix(path)
     return any(
         path.startswith(prefix) for prefix in MULTI_TENANT_GATING_ALLOWED_PREFIXES
     )

--- a/backend/ee/onyx/server/middleware/tier_gate.py
+++ b/backend/ee/onyx/server/middleware/tier_gate.py
@@ -31,6 +31,7 @@ from ee.onyx.configs.license_enforcement_config import (
 )
 from ee.onyx.utils.tier import get_tier
 from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.server.middleware.api_prefix import strip_api_prefix
 from onyx.server.settings.models import Tier
 from onyx.server.settings.tier_order import tier_at_least
 from shared_configs.contextvars import get_current_tenant_id
@@ -67,9 +68,7 @@ def add_tier_gate_middleware(app: FastAPI, logger: logging.LoggerAdapter) -> Non
         if not _SORTED_GATES:
             return await call_next(request)
 
-        path = request.url.path
-        if path.startswith("/api/"):
-            path = path[4:]
+        path = strip_api_prefix(request.url.path)
 
         if _is_allowed_path(path):
             return await call_next(request)

--- a/backend/onyx/server/middleware/api_prefix.py
+++ b/backend/onyx/server/middleware/api_prefix.py
@@ -1,0 +1,20 @@
+"""Helpers for normalizing ingress paths to application route paths."""
+
+from onyx.configs.app_configs import APP_API_PREFIX
+
+
+def strip_api_prefix(path: str) -> str:
+    """Remove the configured API prefix from an incoming request path.
+
+    When no API prefix is configured, retain the legacy ``/api`` fallback for
+    deployments whose reverse proxy forwards that prefix to the API server.
+    """
+    configured_prefix = f"/{APP_API_PREFIX.strip('/')}" if APP_API_PREFIX else "/api"
+    if path == configured_prefix:
+        return "/"
+
+    prefix_with_separator = f"{configured_prefix}/"
+    if path.startswith(prefix_with_separator):
+        return path[len(configured_prefix) :]
+
+    return path

--- a/backend/tests/unit/ee/onyx/server/middleware/test_license_enforcement.py
+++ b/backend/tests/unit/ee/onyx/server/middleware/test_license_enforcement.py
@@ -13,6 +13,7 @@ from ee.onyx.configs.license_enforcement_config import (
     LICENSE_ENFORCEMENT_ALLOWED_PREFIXES,
 )
 from ee.onyx.server.middleware.license_enforcement import _is_path_allowed
+from onyx.server.middleware import api_prefix
 from onyx.server.settings.models import ApplicationStatus
 
 # Type alias for the middleware harness tuple
@@ -50,6 +51,14 @@ class TestPathAllowlist:
         """Subpaths of allowed prefixes should also be allowed."""
         assert _is_path_allowed("/auth/callback/google") is True
         assert _is_path_allowed("/admin/billing/checkout") is True
+
+    def test_custom_api_prefix_allowlist(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(api_prefix, "APP_API_PREFIX", "v2")
+        assert _is_path_allowed(api_prefix.strip_api_prefix("/v2/auth/login")) is True
+        assert (
+            _is_path_allowed(api_prefix.strip_api_prefix("/v2/admin/billing/checkout"))
+            is True
+        )
 
     @pytest.mark.parametrize("path", BLOCKED_PATHS)
     def test_blocked_paths_are_blocked(self, path: str) -> None:

--- a/backend/tests/unit/ee/onyx/server/middleware/test_tenant_tracking.py
+++ b/backend/tests/unit/ee/onyx/server/middleware/test_tenant_tracking.py
@@ -14,6 +14,7 @@ from fastapi import HTTPException
 from starlette.requests import Request
 
 from ee.onyx.server.middleware import tenant_tracking
+from onyx.server.middleware import api_prefix
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 
 MODULE = "ee.onyx.server.middleware.tenant_tracking"
@@ -22,6 +23,12 @@ MODULE = "ee.onyx.server.middleware.tenant_tracking"
 def _request(headers: dict[str, str] | None = None) -> Request:
     raw = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
     return Request({"type": "http", "method": "GET", "path": "/me", "headers": raw})
+
+
+def test_custom_api_prefix_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(api_prefix, "APP_API_PREFIX", "v2")
+    assert tenant_tracking._is_path_allowed("/v2/auth/login") is True
+    assert tenant_tracking._is_path_allowed("/v2/chat") is False
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/ee/onyx/server/middleware/test_tier_gate.py
+++ b/backend/tests/unit/ee/onyx/server/middleware/test_tier_gate.py
@@ -61,6 +61,29 @@ async def test_community_blocked_from_business_path(
 
 
 @pytest.mark.asyncio
+@patch("onyx.server.middleware.api_prefix.APP_API_PREFIX", "v2")
+@patch("ee.onyx.server.middleware.tier_gate.get_tier")
+async def test_custom_api_prefix_still_applies_tier_gate(
+    mock_get_tier: MagicMock, middleware_harness: MiddlewareHarness
+) -> None:
+    mock_get_tier.return_value = Tier.COMMUNITY
+    middleware, call_next = middleware_harness
+    response = await middleware(_make_request("/v2/admin/hooks"), call_next)
+    assert response.status_code == 402
+
+
+@pytest.mark.asyncio
+@patch("ee.onyx.server.middleware.tier_gate.get_tier")
+async def test_bare_path_still_applies_tier_gate(
+    mock_get_tier: MagicMock, middleware_harness: MiddlewareHarness
+) -> None:
+    mock_get_tier.return_value = Tier.COMMUNITY
+    middleware, call_next = middleware_harness
+    response = await middleware(_make_request("/admin/query-history"), call_next)
+    assert response.status_code == 402
+
+
+@pytest.mark.asyncio
 @patch("ee.onyx.server.middleware.tier_gate.get_tier")
 async def test_business_passes_business_path(
     mock_get_tier: MagicMock, middleware_harness: MiddlewareHarness

--- a/backend/tests/unit/onyx/server/middleware/test_api_prefix.py
+++ b/backend/tests/unit/onyx/server/middleware/test_api_prefix.py
@@ -1,0 +1,26 @@
+import pytest
+
+from onyx.server.middleware import api_prefix
+
+
+@pytest.mark.parametrize(
+    ("configured_prefix", "path", "expected"),
+    [
+        ("v2", "/v2/gateway/v1/models", "/gateway/v1/models"),
+        ("/v2/", "/v2/gateway", "/gateway"),
+        ("v2", "/v2", "/"),
+        ("", "/gateway", "/gateway"),
+        ("", "/api/gateway", "/gateway"),
+        ("", "/apigateway", "/apigateway"),
+        ("v2", "/v2gateway", "/v2gateway"),
+        ("v2", "/api/gateway", "/api/gateway"),
+    ],
+)
+def test_strip_api_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+    configured_prefix: str,
+    path: str,
+    expected: str,
+) -> None:
+    monkeypatch.setattr(api_prefix, "APP_API_PREFIX", configured_prefix)
+    assert api_prefix.strip_api_prefix(path) == expected


### PR DESCRIPTION
## Description

Centralize request-path normalization for middleware gates. The shared helper honors configured `API_PREFIX` values, retains the legacy `/api` fallback for reverse proxies that forward that prefix, and is used by tier gating, self-hosted license enforcement, and multi-tenant gating. This is the base PR for the stacked gateway migration in #13746.

## How Has This Been Tested?

- `uv run pytest -q backend/tests/unit/onyx/server/middleware/test_api_prefix.py backend/tests/unit/ee/onyx/server/middleware/test_tier_gate.py backend/tests/unit/ee/onyx/server/middleware/test_license_enforcement.py backend/tests/unit/ee/onyx/server/middleware/test_tenant_tracking.py` — 59 passed
- Ruff check and format passed
- Targeted pre-commit hooks passed

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
