### PR TITLE
feat(usage): expose flow and provider detail in usage exports

### DIFF
--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -119,10 +119,10 @@ class UserUsageByDay(BaseModel):
 
 
 class UsageExportRow(BaseModel):
-    """Tenant-wide usage row by email, model, and UTC day."""
-
     email: str
     model: str
+    flow: str
+    provider: str
     day: str  # YYYY-MM-DD
     input_tokens: int
     output_tokens: int
@@ -216,7 +216,6 @@ def get_usage_export(
     end: datetime,
     model: str | None = None,
 ) -> list[UsageExportRow]:
-    """Tenant-wide usage by email, model, and UTC day."""
     utc_day = func.date(func.timezone("UTC", UserUsage.window_start))
     # Deleted users/API keys leave user_id NULL but keep their spend. An inner
     # join would hide that spend here while the tenant-wide totals still count
@@ -226,6 +225,8 @@ def get_usage_export(
         select(
             email_label,
             UserUsage.model,
+            UserUsage.flow,
+            UserUsage.provider,
             utc_day.label("day"),
             func.sum(UserUsage.input_tokens),
             func.sum(UserUsage.output_tokens),
@@ -239,7 +240,9 @@ def get_usage_export(
             UserUsage.window_start >= start,
             UserUsage.window_start < end,
         )
-        .group_by(email_label, UserUsage.model, utc_day)
+        .group_by(
+            email_label, UserUsage.model, UserUsage.flow, UserUsage.provider, utc_day
+        )
         .order_by(email_label, utc_day, UserUsage.model)
     )
     if model is not None:
@@ -251,13 +254,15 @@ def get_usage_export(
         UsageExportRow(
             email=str(email),
             model=mdl,
+            flow=flow,
+            provider=provider,
             day=str(day),
             input_tokens=int(in_tok or 0),
             output_tokens=int(out_tok or 0),
             cache_read_tokens=int(cache_tok or 0),
             cost_cents=float(cost or 0.0),
         )
-        for email, mdl, day, in_tok, out_tok, cache_tok, cost in rows
+        for email, mdl, flow, provider, day, in_tok, out_tok, cache_tok, cost in rows
     ]
 
 

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -243,7 +243,13 @@ def get_usage_export(
         .group_by(
             email_label, UserUsage.model, UserUsage.flow, UserUsage.provider, utc_day
         )
-        .order_by(email_label, utc_day, UserUsage.model)
+        .order_by(
+            email_label,
+            utc_day,
+            UserUsage.model,
+            UserUsage.flow,
+            UserUsage.provider,
+        )
     )
     if model is not None:
         query = query.where(UserUsage.model == model)

--- a/backend/onyx/server/features/usage/models.py
+++ b/backend/onyx/server/features/usage/models.py
@@ -41,6 +41,8 @@ class CostOverride(BaseModel):
 
 class UsageExportRecord(BaseModel):
     model: str
+    flow: str
+    provider: str
     day: str  # YYYY-MM-DD
     input_tokens: int
     output_tokens: int

--- a/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
@@ -203,6 +203,41 @@ class TestGetUsageExportHelper:
         assert rows[0].model == "model-b"
         assert rows[0].email == "alice@example.com"
 
+    def test_orders_rows_by_flow_and_provider(self, db_session: Session) -> None:
+        user_id = _add_user(db_session, "alice@example.com")
+        _seed_usage(
+            db_session,
+            user_id,
+            "model-a",
+            "CHAT",
+            "openai",
+            100,
+            50,
+            0,
+            1.0,
+            _W1,
+        )
+        _seed_usage(
+            db_session,
+            user_id,
+            "model-a",
+            "BATCH",
+            "anthropic",
+            200,
+            60,
+            0,
+            2.0,
+            _W1,
+        )
+        db_session.commit()
+
+        rows = get_usage_export(db_session, start=_W1, end=_W2)
+
+        assert [(row.flow, row.provider) for row in rows] == [
+            ("BATCH", "anthropic"),
+            ("CHAT", "openai"),
+        ]
+
     def test_date_range_bounds_half_open(self, db_session: Session) -> None:
         _seed_two_users(db_session)
         # [W1, W2) excludes everything in W2.

--- a/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
@@ -148,6 +148,8 @@ class TestGetUsageExportHelper:
             UsageExportRow(
                 email="alice@example.com",
                 model="model-a",
+                flow="CHAT",
+                provider="openai",
                 day="2026-06-01",
                 input_tokens=100,
                 output_tokens=50,
@@ -157,6 +159,8 @@ class TestGetUsageExportHelper:
             UsageExportRow(
                 email="alice@example.com",
                 model="model-b",
+                flow="CHAT",
+                provider="openai",
                 day="2026-06-01",
                 input_tokens=200,
                 output_tokens=60,
@@ -166,6 +170,8 @@ class TestGetUsageExportHelper:
             UsageExportRow(
                 email="alice@example.com",
                 model="model-a",
+                flow="CHAT",
+                provider="openai",
                 day="2026-06-08",
                 input_tokens=300,
                 output_tokens=70,
@@ -175,6 +181,8 @@ class TestGetUsageExportHelper:
             UsageExportRow(
                 email="bob@example.com",
                 model="model-a",
+                flow="CHAT",
+                provider="anthropic",
                 day="2026-06-08",
                 input_tokens=400,
                 output_tokens=80,


### PR DESCRIPTION
## Summary

- Extend admin usage export rows with flow and provider dimensions.
- Preserve existing totals while grouping and returning the additional detail.
- Add unit coverage for the expanded export contract.

## Verification

- uv run --project backend pytest -q backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py (14 passed)
- Pre-commit checks passed.
- Greptile and Cubic ordering feedback fixed in c9e0dfa8bd.

## Known minor items

- The export remains intentionally unpaginated; large workspaces may need pagination in a follow-up.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check