### PR TITLE
feat(usage): build the detailed usage analytics workspace

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/usage_reporting/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/usage_reporting/tasks.py
@@ -26,6 +26,7 @@ def generate_usage_report_task(
     user_id: str | None = None,
     period_from: str | None = None,
     period_to: str | None = None,
+    report_id: str | None = None,
 ) -> None:
     """User-initiated usage report generation task"""
     # Parse period if provided
@@ -42,4 +43,5 @@ def generate_usage_report_task(
             db_session=db_session,
             user_id=UUID(user_id) if user_id else None,
             period=period,
+            report_id=report_id,
         )

--- a/backend/ee/onyx/server/reporting/usage_export_api.py
+++ b/backend/ee/onyx/server/reporting/usage_export_api.py
@@ -1,5 +1,6 @@
 from collections.abc import Generator
 from datetime import datetime
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Response
 from fastapi.responses import StreamingResponse
@@ -26,6 +27,7 @@ router = APIRouter()
 class GenerateUsageReportParams(BaseModel):
     period_from: str | None = None
     period_to: str | None = None
+    report_id: UUID | None = None
 
 
 @router.post("/admin/usage-report", status_code=204)
@@ -49,6 +51,7 @@ def generate_report(
             "user_id": str(user.id) if user else None,
             "period_from": params.period_from,
             "period_to": params.period_to,
+            "report_id": str(params.report_id) if params.report_id else None,
         },
     )
 

--- a/backend/ee/onyx/server/reporting/usage_export_generation.py
+++ b/backend/ee/onyx/server/reporting/usage_export_generation.py
@@ -131,8 +131,9 @@ def create_new_usage_report(
     db_session: Session,
     user_id: UUID_ID | None,  # None = auto-generated
     period: tuple[datetime, datetime] | None,
+    report_id: str | None = None,
 ) -> UsageReportMetadata:
-    report_id = str(uuid.uuid4())
+    report_id = report_id or str(uuid.uuid4())
     file_store = get_default_file_store()
 
     messages_file_id = generate_chat_messages_report(

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -119,10 +119,10 @@ class UserUsageByDay(BaseModel):
 
 
 class UsageExportRow(BaseModel):
-    """Tenant-wide usage row by email, model, and UTC day."""
-
     email: str
     model: str
+    flow: str
+    provider: str
     day: str  # YYYY-MM-DD
     input_tokens: int
     output_tokens: int
@@ -216,7 +216,6 @@ def get_usage_export(
     end: datetime,
     model: str | None = None,
 ) -> list[UsageExportRow]:
-    """Tenant-wide usage by email, model, and UTC day."""
     utc_day = func.date(func.timezone("UTC", UserUsage.window_start))
     # Deleted users/API keys leave user_id NULL but keep their spend. An inner
     # join would hide that spend here while the tenant-wide totals still count
@@ -226,6 +225,8 @@ def get_usage_export(
         select(
             email_label,
             UserUsage.model,
+            UserUsage.flow,
+            UserUsage.provider,
             utc_day.label("day"),
             func.sum(UserUsage.input_tokens),
             func.sum(UserUsage.output_tokens),
@@ -239,7 +240,9 @@ def get_usage_export(
             UserUsage.window_start >= start,
             UserUsage.window_start < end,
         )
-        .group_by(email_label, UserUsage.model, utc_day)
+        .group_by(
+            email_label, UserUsage.model, UserUsage.flow, UserUsage.provider, utc_day
+        )
         .order_by(email_label, utc_day, UserUsage.model)
     )
     if model is not None:
@@ -251,13 +254,15 @@ def get_usage_export(
         UsageExportRow(
             email=str(email),
             model=mdl,
+            flow=flow,
+            provider=provider,
             day=str(day),
             input_tokens=int(in_tok or 0),
             output_tokens=int(out_tok or 0),
             cache_read_tokens=int(cache_tok or 0),
             cost_cents=float(cost or 0.0),
         )
-        for email, mdl, day, in_tok, out_tok, cache_tok, cost in rows
+        for email, mdl, flow, provider, day, in_tok, out_tok, cache_tok, cost in rows
     ]
 
 

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -243,7 +243,13 @@ def get_usage_export(
         .group_by(
             email_label, UserUsage.model, UserUsage.flow, UserUsage.provider, utc_day
         )
-        .order_by(email_label, utc_day, UserUsage.model)
+        .order_by(
+            email_label,
+            utc_day,
+            UserUsage.model,
+            UserUsage.flow,
+            UserUsage.provider,
+        )
     )
     if model is not None:
         query = query.where(UserUsage.model == model)

--- a/backend/onyx/server/features/usage/models.py
+++ b/backend/onyx/server/features/usage/models.py
@@ -41,6 +41,8 @@ class CostOverride(BaseModel):
 
 class UsageExportRecord(BaseModel):
     model: str
+    flow: str
+    provider: str
     day: str  # YYYY-MM-DD
     input_tokens: int
     output_tokens: int

--- a/backend/tests/integration/tests/reporting/test_usage_export_api.py
+++ b/backend/tests/integration/tests/reporting/test_usage_export_api.py
@@ -3,7 +3,7 @@ import os
 import time
 from datetime import datetime, timedelta, timezone
 from io import BytesIO, StringIO
-from uuid import UUID
+from uuid import UUID, uuid4
 from zipfile import ZipFile
 
 import pytest
@@ -42,11 +42,12 @@ class TestUsageExportAPI:
         assert initial_response.status_code == 200
         initial_reports = initial_response.json()
         initial_count = len(initial_reports)
+        report_id = uuid4()
 
         # Test generating a report without date filters (all time)
         response = client.post(
             f"{API_SERVER_URL}/admin/usage-report",
-            json={},
+            json={"report_id": str(report_id)},
             headers=admin_user.headers,
         )
         assert response.status_code == 204
@@ -77,6 +78,7 @@ class TestUsageExportAPI:
         new_report = current_reports[0]
         assert "report_name" in new_report
         assert new_report["report_name"].endswith(".zip")
+        assert str(report_id) in new_report["report_name"]
 
     def test_generate_usage_report_with_date_range(
         self,

--- a/backend/tests/integration/tests/reporting/test_usage_export_api.py
+++ b/backend/tests/integration/tests/reporting/test_usage_export_api.py
@@ -74,8 +74,13 @@ class TestUsageExportAPI:
         # Verify a new report was created
         assert len(current_reports) > initial_count
 
-        # Find the new report (should be the first one since they're ordered by time)
-        new_report = current_reports[0]
+        new_reports = [
+            report
+            for report in current_reports
+            if str(report_id) in report["report_name"]
+        ]
+        assert len(new_reports) == 1
+        new_report = new_reports[0]
         assert "report_name" in new_report
         assert new_report["report_name"].endswith(".zip")
         assert str(report_id) in new_report["report_name"]

--- a/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
@@ -203,6 +203,41 @@ class TestGetUsageExportHelper:
         assert rows[0].model == "model-b"
         assert rows[0].email == "alice@example.com"
 
+    def test_orders_rows_by_flow_and_provider(self, db_session: Session) -> None:
+        user_id = _add_user(db_session, "alice@example.com")
+        _seed_usage(
+            db_session,
+            user_id,
+            "model-a",
+            "CHAT",
+            "openai",
+            100,
+            50,
+            0,
+            1.0,
+            _W1,
+        )
+        _seed_usage(
+            db_session,
+            user_id,
+            "model-a",
+            "BATCH",
+            "anthropic",
+            200,
+            60,
+            0,
+            2.0,
+            _W1,
+        )
+        db_session.commit()
+
+        rows = get_usage_export(db_session, start=_W1, end=_W2)
+
+        assert [(row.flow, row.provider) for row in rows] == [
+            ("BATCH", "anthropic"),
+            ("CHAT", "openai"),
+        ]
+
     def test_date_range_bounds_half_open(self, db_session: Session) -> None:
         _seed_two_users(db_session)
         # [W1, W2) excludes everything in W2.

--- a/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
@@ -148,6 +148,8 @@ class TestGetUsageExportHelper:
             UsageExportRow(
                 email="alice@example.com",
                 model="model-a",
+                flow="CHAT",
+                provider="openai",
                 day="2026-06-01",
                 input_tokens=100,
                 output_tokens=50,
@@ -157,6 +159,8 @@ class TestGetUsageExportHelper:
             UsageExportRow(
                 email="alice@example.com",
                 model="model-b",
+                flow="CHAT",
+                provider="openai",
                 day="2026-06-01",
                 input_tokens=200,
                 output_tokens=60,
@@ -166,6 +170,8 @@ class TestGetUsageExportHelper:
             UsageExportRow(
                 email="alice@example.com",
                 model="model-a",
+                flow="CHAT",
+                provider="openai",
                 day="2026-06-08",
                 input_tokens=300,
                 output_tokens=70,
@@ -175,6 +181,8 @@ class TestGetUsageExportHelper:
             UsageExportRow(
                 email="bob@example.com",
                 model="model-a",
+                flow="CHAT",
+                provider="anthropic",
                 day="2026-06-08",
                 input_tokens=400,
                 output_tokens=80,

--- a/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
@@ -209,8 +209,8 @@ class TestGetUsageExportHelper:
             db_session,
             user_id,
             "model-a",
-            "CHAT",
-            "openai",
+            "BATCH",
+            "anthropic",
             100,
             50,
             0,
@@ -222,7 +222,7 @@ class TestGetUsageExportHelper:
             user_id,
             "model-a",
             "BATCH",
-            "anthropic",
+            "openai",
             200,
             60,
             0,
@@ -235,7 +235,7 @@ class TestGetUsageExportHelper:
 
         assert [(row.flow, row.provider) for row in rows] == [
             ("BATCH", "anthropic"),
-            ("CHAT", "openai"),
+            ("BATCH", "openai"),
         ]
 
     def test_date_range_bounds_half_open(self, db_session: Session) -> None:

--- a/web/lib/opal/src/components/calendar/components.tsx
+++ b/web/lib/opal/src/components/calendar/components.tsx
@@ -63,7 +63,11 @@ function Calendar(props: CalendarProps) {
       style={undefined}
       styles={undefined}
       formatters={undefined}
-      modifiersClassNames={undefined}
+      modifiersClassNames={{
+        range_preview_start: "opal-calendar-cell--range-preview-start",
+        range_preview_middle: "opal-calendar-cell--range-preview-middle",
+        range_preview_end: "opal-calendar-cell--range-preview-end",
+      }}
       modifiersStyles={undefined}
       // Outside days render as empty fixed-width cells, never as numerals.
       showOutsideDays={false}

--- a/web/lib/opal/src/components/calendar/styles.css
+++ b/web/lib/opal/src/components/calendar/styles.css
@@ -91,7 +91,10 @@
    neighbor-facing side. Week edges stay flush and rounded. */
 .opal-calendar-cell--range-start::before,
 .opal-calendar-cell--range-middle::before,
-.opal-calendar-cell--range-end::before {
+.opal-calendar-cell--range-end::before,
+.opal-calendar-cell--range-preview-start::before,
+.opal-calendar-cell--range-preview-middle::before,
+.opal-calendar-cell--range-preview-end::before {
   content: "";
   position: absolute;
   top: 0;
@@ -103,7 +106,10 @@
 
 .opal-calendar-cell--range-start::before,
 .opal-calendar-cell--range-middle:first-child::before,
-.opal-calendar-cell--range-end:first-child::before {
+.opal-calendar-cell--range-end:first-child::before,
+.opal-calendar-cell--range-preview-start::before,
+.opal-calendar-cell--range-preview-middle:first-child::before,
+.opal-calendar-cell--range-preview-end:first-child::before {
   left: 0;
   border-top-left-radius: var(--radius-08);
   border-bottom-left-radius: var(--radius-08);
@@ -111,7 +117,10 @@
 
 .opal-calendar-cell--range-end::before,
 .opal-calendar-cell--range-middle:last-child::before,
-.opal-calendar-cell--range-start:last-child::before {
+.opal-calendar-cell--range-start:last-child::before,
+.opal-calendar-cell--range-preview-end::before,
+.opal-calendar-cell--range-preview-middle:last-child::before,
+.opal-calendar-cell--range-preview-start:last-child::before {
   right: 0;
   border-top-right-radius: var(--radius-08);
   border-bottom-right-radius: var(--radius-08);

--- a/web/lib/opal/src/components/table/README.md
+++ b/web/lib/opal/src/components/table/README.md
@@ -48,23 +48,24 @@ function UsersTable({ users }: { users: User[] }) {
 
 ## Props
 
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `data` | `TData[]` | required | Row data array |
-| `columns` | `OnyxColumnDef<TData>[]` | required | Column definitions from `createTableColumns()` |
-| `getRowId` | `(row: TData) => string` | required | Unique row identifier |
-| `pageSize` | `number` | `10` | Rows per page (`Infinity` disables pagination) |
-| `size` | `"md" \| "lg"` | `"lg"` | Density variant |
-| `footer` | `DataTableFooterConfig` | — | Footer configuration (mode is derived from `selectionBehavior`) |
-| `initialSorting` | `SortingState` | — | Initial sort state |
-| `initialColumnVisibility` | `VisibilityState` | — | Initial column visibility |
-| `draggable` | `DataTableDraggableConfig` | — | Enable drag-and-drop reordering |
-| `onSelectionChange` | `(ids: string[]) => void` | — | Selection callback |
-| `onRowClick` | `(row: TData) => void` | — | Row click handler |
-| `searchTerm` | `string` | — | Global text filter |
-| `height` | `number \| string` | — | Max scrollable height |
-| `serverSide` | `ServerSideConfig` | — | Server-side pagination/sorting/filtering |
-| `emptyState` | `ReactNode` | — | Empty state content |
+| Prop                      | Type                       | Default  | Description                                                     |
+| ------------------------- | -------------------------- | -------- | --------------------------------------------------------------- |
+| `data`                    | `TData[]`                  | required | Row data array                                                  |
+| `columns`                 | `OnyxColumnDef<TData>[]`   | required | Column definitions from `createTableColumns()`                  |
+| `getRowId`                | `(row: TData) => string`   | required | Unique row identifier                                           |
+| `pageSize`                | `number`                   | `10`     | Rows per page (`Infinity` disables pagination)                  |
+| `size`                    | `"md" \| "lg"`             | `"lg"`   | Density variant                                                 |
+| `footer`                  | `DataTableFooterConfig`    | —        | Footer configuration (mode is derived from `selectionBehavior`) |
+| `initialSorting`          | `SortingState`             | —        | Initial sort state                                              |
+| `initialColumnVisibility` | `VisibilityState`          | —        | Initial column visibility                                       |
+| `draggable`               | `DataTableDraggableConfig` | —        | Enable drag-and-drop reordering                                 |
+| `onSelectionChange`       | `(ids: string[]) => void`  | —        | Selection callback                                              |
+| `onRowClick`              | `(row: TData) => void`     | —        | Row click handler                                               |
+| `getRowLabel`             | `(row: TData) => string`   | —        | Accessible action label for clickable rows                      |
+| `searchTerm`              | `string`                   | —        | Global text filter                                              |
+| `height`                  | `number \| string`         | —        | Max scrollable height                                           |
+| `serverSide`              | `ServerSideConfig`         | —        | Server-side pagination/sorting/filtering                        |
+| `emptyState`              | `ReactNode`                | —        | Empty state content                                             |
 
 ## Column Builder
 
@@ -78,5 +79,6 @@ function UsersTable({ users }: { users: User[] }) {
 ## Footer
 
 The footer mode is derived automatically from `selectionBehavior`:
+
 - **Selection footer** (when `selectionBehavior` is `"single-select"` or `"multi-select"`) — shows selection count, optional view/clear buttons, count pagination
 - **Summary footer** (when `selectionBehavior` is `"no-select"` or omitted) — shows "Showing X\~Y of Z", list pagination, optional extra element

--- a/web/lib/opal/src/components/table/TableCell.tsx
+++ b/web/lib/opal/src/components/table/TableCell.tsx
@@ -8,10 +8,18 @@ interface TableCellProps extends WithoutStyles<
   children: React.ReactNode;
   /** Explicit pixel width for the cell. */
   width?: number;
+  alignment?: "left" | "center" | "right";
 }
+
+const alignmentJustifyClass = {
+  left: "justify-start",
+  center: "justify-center",
+  right: "justify-end",
+} as const;
 
 export default function TableCell({
   width,
+  alignment = "left",
   children,
   ...props
 }: TableCellProps) {
@@ -24,7 +32,11 @@ export default function TableCell({
       {...props}
     >
       <div
-        className={cn("tbl-cell-inner", "flex items-center overflow-hidden")}
+        className={cn(
+          "tbl-cell-inner",
+          "flex items-center overflow-hidden",
+          alignmentJustifyClass[alignment]
+        )}
         data-size={resolvedSize}
       >
         {children}

--- a/web/lib/opal/src/components/table/TableHead.tsx
+++ b/web/lib/opal/src/components/table/TableHead.tsx
@@ -87,7 +87,13 @@ export default function TableHead({
       data-size={resolvedSize}
       data-bottom-border={bottomBorder || undefined}
     >
-      <div className="flex items-center gap-1">
+      <div
+        className={cn(
+          "flex items-center gap-1",
+          alignment === "right" && "flex-row-reverse",
+          alignment === "center" && "justify-center"
+        )}
+      >
         <div className="table-head-label">
           <Text
             font={isSmall ? "secondary-action" : "main-ui-action"}

--- a/web/lib/opal/src/components/table/TableHead.tsx
+++ b/web/lib/opal/src/components/table/TableHead.tsx
@@ -90,7 +90,7 @@ export default function TableHead({
       <div
         className={cn(
           "flex items-center gap-1",
-          alignment === "right" && "flex-row-reverse",
+          alignment === "right" && "justify-end",
           alignment === "center" && "justify-center"
         )}
       >

--- a/web/lib/opal/src/components/table/columns.ts
+++ b/web/lib/opal/src/components/table/columns.ts
@@ -7,6 +7,7 @@ import {
   type CellContext,
 } from "@tanstack/react-table";
 import type {
+  ColumnAlignment,
   ColumnWidth,
   QualifierContentType,
   OnyxQualifierColumn,
@@ -58,6 +59,7 @@ interface DataColumnConfig<TData, TValue> {
   weight?: number;
   /** Explicit column ID. Derived from the accessor key; required for function accessors. */
   id?: string;
+  alignment?: ColumnAlignment;
 }
 
 // ---------------------------------------------------------------------------
@@ -75,6 +77,7 @@ interface DisplayColumnConfig<TData> {
   width: ColumnWidth;
   /** Enable hiding. @default true */
   enableHiding?: boolean;
+  alignment?: ColumnAlignment;
 }
 
 // ---------------------------------------------------------------------------
@@ -188,6 +191,7 @@ export function createTableColumns<TData>(): TableColumnsBuilder<TData> {
         icon,
         weight = 20,
         id: explicitId,
+        alignment,
       } = config;
 
       const id = explicitId ?? (accessor as string);
@@ -210,13 +214,21 @@ export function createTableColumns<TData>(): TableColumnsBuilder<TData> {
         def,
         width: { weight, minWidth: Math.max(header.length * 8 + 40, 80) },
         icon,
+        alignment,
       };
     },
 
     displayColumn(
       config: DisplayColumnConfig<TData>
     ): OnyxDisplayColumn<TData> {
-      const { id, header, cell, width, enableHiding = true } = config;
+      const {
+        id,
+        header,
+        cell,
+        width,
+        enableHiding = true,
+        alignment,
+      } = config;
 
       const def: ColumnDef<TData, any> = helper.display({
         id,
@@ -232,6 +244,7 @@ export function createTableColumns<TData>(): TableColumnsBuilder<TData> {
         id,
         def,
         width,
+        alignment,
       };
     },
 

--- a/web/lib/opal/src/components/table/components.tsx
+++ b/web/lib/opal/src/components/table/components.tsx
@@ -154,6 +154,7 @@ export function Table<TData>(props: DataTableProps<TData>) {
     selectionBehavior = "no-select",
     onSelectionChange,
     onRowClick,
+    getRowLabel,
     searchTerm,
     height,
     serverSide,
@@ -447,6 +448,7 @@ export function Table<TData>(props: DataTableProps<TData>) {
                       <TableHead
                         key={header.id}
                         width={columnWidths[header.id]}
+                        alignment={colDef?.alignment}
                         sorted={
                           canSort ? toOnyxSortDirection(sortDir) : undefined
                         }
@@ -511,6 +513,21 @@ export function Table<TData>(props: DataTableProps<TData>) {
                     key={row.id}
                     sortableId={rowId}
                     selected={row.getIsSelected()}
+                    data-clickable={onRowClick ? true : undefined}
+                    tabIndex={onRowClick ? 0 : undefined}
+                    aria-label={
+                      onRowClick ? getRowLabel?.(row.original) : undefined
+                    }
+                    onKeyDown={(event) => {
+                      if (
+                        onRowClick &&
+                        event.currentTarget === event.target &&
+                        (event.key === "Enter" || event.key === " ")
+                      ) {
+                        event.preventDefault();
+                        onRowClick(row.original);
+                      }
+                    }}
                     onClick={() => {
                       if (
                         hasDraggable &&
@@ -589,6 +606,9 @@ export function Table<TData>(props: DataTableProps<TData>) {
                         <TableCell
                           key={cell.id}
                           data-column-id={cell.column.id}
+                          alignment={
+                            columnKindMap.get(cell.column.id)?.alignment
+                          }
                         >
                           {flexRender(
                             cell.column.columnDef.cell,

--- a/web/lib/opal/src/components/table/styles.css
+++ b/web/lib/opal/src/components/table/styles.css
@@ -128,6 +128,13 @@ table[data-variant="cards"] .tbl-row:has(:focus-visible) > td {
   @apply bg-action-selection-01;
 }
 
+.tbl-row[data-clickable] {
+  @apply cursor-pointer;
+}
+.tbl-row[data-clickable]:hover > td {
+  @apply bg-background-tint-02;
+}
+
 /* ---- QualifierContainer ---- */
 
 .tbl-qualifier[data-type="head"] {

--- a/web/lib/opal/src/components/table/types.ts
+++ b/web/lib/opal/src/components/table/types.ts
@@ -38,12 +38,15 @@ export type OnyxColumnKind = "qualifier" | "data" | "display" | "actions";
 // Column definitions (discriminated union on `kind`)
 // ---------------------------------------------------------------------------
 
+export type ColumnAlignment = "left" | "center" | "right";
+
 interface OnyxColumnBase<TData> {
   kind: OnyxColumnKind;
   /** Stable column identifier (mirrors the TanStack column ID). */
   id: string;
   def: ColumnDef<TData, any>;
   width: ColumnWidth | ((size: TableSize) => ColumnWidth);
+  alignment?: ColumnAlignment;
 }
 
 /** Qualifier column — leading avatar/icon/checkbox column. */
@@ -162,6 +165,7 @@ export interface DataTableProps<TData> {
   onSelectionChange?: (selectedIds: string[]) => void;
   /** Called when a row is clicked (replaces the default selection toggle). */
   onRowClick?: (row: TData) => void;
+  getRowLabel?: (row: TData) => string;
   /** Search term for global text filtering. When provided, rows are filtered
    *  to those containing the term in any accessor column value (case-insensitive). */
   searchTerm?: string;

--- a/web/lib/opal/src/components/table/types.ts
+++ b/web/lib/opal/src/components/table/types.ts
@@ -46,12 +46,12 @@ interface OnyxColumnBase<TData> {
   id: string;
   def: ColumnDef<TData, any>;
   width: ColumnWidth | ((size: TableSize) => ColumnWidth);
-  alignment?: ColumnAlignment;
 }
 
 /** Qualifier column — leading avatar/icon/checkbox column. */
 export interface OnyxQualifierColumn<TData> extends OnyxColumnBase<TData> {
   kind: "qualifier";
+  alignment?: never;
   /** Content type for body-row `<TableQualifier>`. */
   content: QualifierContentType;
   /** Return the icon component to render for a row (for "icon" content). */
@@ -69,6 +69,7 @@ export interface OnyxQualifierColumn<TData> extends OnyxColumnBase<TData> {
 /** Data column — accessor-based column with sorting/resizing. */
 export interface OnyxDataColumn<TData> extends OnyxColumnBase<TData> {
   kind: "data";
+  alignment?: ColumnAlignment;
   /** Override the sort icon for this column. */
   icon?: (sorted: SortDirection) => IconFunctionComponent;
 }
@@ -76,11 +77,13 @@ export interface OnyxDataColumn<TData> extends OnyxColumnBase<TData> {
 /** Display column — non-accessor column with custom rendering. */
 export interface OnyxDisplayColumn<TData> extends OnyxColumnBase<TData> {
   kind: "display";
+  alignment?: ColumnAlignment;
 }
 
 /** Actions column — fixed column with visibility/sorting popovers. */
 export interface OnyxActionsColumn<TData> extends OnyxColumnBase<TData> {
   kind: "actions";
+  alignment?: never;
   /** Show column visibility popover. @default true */
   showColumnVisibility?: boolean;
   /** Show sorting popover. @default true */

--- a/web/src/app/ee/admin/performance/analytics/page.tsx
+++ b/web/src/app/ee/admin/performance/analytics/page.tsx
@@ -16,7 +16,11 @@ const route = ADMIN_ROUTES.WORKSPACE_ANALYTICS;
 
 export default function WorkspaceAnalyticsPage() {
   const [timeRange, setTimeRange] = useTimeRange();
-  const { agents } = useAdminAgents();
+  const {
+    agents,
+    error: agentsError,
+    isLoading: agentsLoading,
+  } = useAdminAgents();
 
   return (
     <SettingsLayouts.Root width="lg">
@@ -41,6 +45,8 @@ export default function WorkspaceAnalyticsPage() {
         <OnyxBotChart timeRange={timeRange} />
         <PersonaMessagesChart
           availablePersonas={agents}
+          agentsError={agentsError}
+          agentsLoading={agentsLoading}
           timeRange={timeRange}
         />
         <Divider />

--- a/web/src/app/ee/admin/performance/analytics/page.tsx
+++ b/web/src/app/ee/admin/performance/analytics/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { AdminDateRangeSelector } from "@/components/dateRangeSelectors/AdminDateRangeSelector";
+import { OnyxBotChart } from "@/app/ee/admin/performance/usage/OnyxBotChart";
+import { FeedbackChart } from "@/app/ee/admin/performance/usage/FeedbackChart";
+import { QueryPerformanceChart } from "@/app/ee/admin/performance/usage/QueryPerformanceChart";
+import { PersonaMessagesChart } from "@/app/ee/admin/performance/usage/PersonaMessagesChart";
+import { useTimeRange } from "@/app/ee/admin/performance/lib";
+import UsageReports from "@/app/ee/admin/performance/usage/UsageReports";
+import { useAdminAgents } from "@/lib/agents/hooks";
+import { ADMIN_ROUTES } from "@/lib/admin-routes";
+import { Divider } from "@opal/components";
+import { SettingsLayouts } from "@opal/layouts";
+
+const route = ADMIN_ROUTES.WORKSPACE_ANALYTICS;
+
+export default function WorkspaceAnalyticsPage() {
+  const [timeRange, setTimeRange] = useTimeRange();
+  const { agents } = useAdminAgents();
+
+  return (
+    <SettingsLayouts.Root width="lg">
+      <SettingsLayouts.Header
+        icon={route.icon}
+        title={route.title}
+        description="Understand how your workspace uses Onyx across queries, feedback, and agents."
+        rightChildren={
+          <div className="self-center">
+            <AdminDateRangeSelector
+              size="sm"
+              value={timeRange}
+              onValueChange={(value) => setTimeRange(value as any)}
+            />
+          </div>
+        }
+        divider
+      />
+      <SettingsLayouts.Body>
+        <QueryPerformanceChart timeRange={timeRange} />
+        <FeedbackChart timeRange={timeRange} />
+        <OnyxBotChart timeRange={timeRange} />
+        <PersonaMessagesChart
+          availablePersonas={agents}
+          timeRange={timeRange}
+        />
+        <Divider />
+        <UsageReports />
+      </SettingsLayouts.Body>
+    </SettingsLayouts.Root>
+  );
+}

--- a/web/src/app/ee/admin/performance/lib.ts
+++ b/web/src/app/ee/admin/performance/lib.ts
@@ -59,11 +59,11 @@ export const useOnyxBotAnalytics = (timeRange: DateRangePickerValue) => {
   };
 };
 
-export function getDatesList(startDate: Date): string[] {
+export function getDatesList(startDate: Date, endDate = new Date()): string[] {
   const datesList: string[] = [];
-  const endDate = new Date(); // current date
+  const lastDate = new Date(endDate);
 
-  for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
+  for (let d = new Date(startDate); d <= lastDate; d.setDate(d.getDate() + 1)) {
     const dateStr = d.toISOString().split("T")[0]; // convert date object to 'YYYY-MM-DD' format
     if (dateStr !== undefined) {
       datesList.push(dateStr);

--- a/web/src/app/ee/admin/performance/usage/FeedbackChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/FeedbackChart.tsx
@@ -37,7 +37,7 @@ export function FeedbackChart({
     );
   } else {
     const initialDate = timeRange.from || new Date(queryAnalyticsData[0].date);
-    const dateRange = getDatesList(initialDate);
+    const dateRange = getDatesList(initialDate, timeRange.to);
 
     const dateToQueryAnalytics = new Map(
       queryAnalyticsData.map((queryAnalyticsEntry) => [

--- a/web/src/app/ee/admin/performance/usage/OnyxBotChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/OnyxBotChart.tsx
@@ -37,7 +37,7 @@ export function OnyxBotChart({
   } else {
     const initialDate =
       timeRange.from || new Date(onyxBotAnalyticsData[0].date);
-    const dateRange = getDatesList(initialDate);
+    const dateRange = getDatesList(initialDate, timeRange.to);
 
     const dateToOnyxBotAnalytics = new Map(
       onyxBotAnalyticsData.map((onyxBotAnalyticsEntry) => [

--- a/web/src/app/ee/admin/performance/usage/PersonaMessagesChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/PersonaMessagesChart.tsx
@@ -54,6 +54,22 @@ export function PersonaMessagesChart({
   const hasError =
     agentsError || personaMessagesError || personaUniqueUsersError;
 
+  // The fallback card is generic; keep the underlying failure diagnosable.
+  useEffect(() => {
+    if (agentsError) {
+      console.error("Failed to fetch admin agents:", agentsError);
+    }
+    if (personaMessagesError) {
+      console.error("Failed to fetch agent messages:", personaMessagesError);
+    }
+    if (personaUniqueUsersError) {
+      console.error(
+        "Failed to fetch agent unique users:",
+        personaUniqueUsersError
+      );
+    }
+  }, [agentsError, personaMessagesError, personaUniqueUsersError]);
+
   const filteredPersonaList = useMemo(() => {
     if (!availablePersonas) return [];
     return availablePersonas.filter((persona) =>

--- a/web/src/app/ee/admin/performance/usage/PersonaMessagesChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/PersonaMessagesChart.tsx
@@ -22,9 +22,13 @@ import { Agent } from "@/lib/agents/types";
 
 export function PersonaMessagesChart({
   availablePersonas,
+  agentsError,
+  agentsLoading,
   timeRange,
 }: {
   availablePersonas: Agent[];
+  agentsError?: unknown;
+  agentsLoading?: boolean;
   timeRange: DateRangePickerValue;
 }) {
   const [selectedPersonaId, setSelectedPersonaId] = useState<
@@ -45,8 +49,10 @@ export function PersonaMessagesChart({
     error: personaUniqueUsersError,
   } = usePersonaUniqueUsers(selectedPersonaId, timeRange);
 
-  const isLoading = isPersonaMessagesLoading || isPersonaUniqueUsersLoading;
-  const hasError = personaMessagesError || personaUniqueUsersError;
+  const isLoading =
+    agentsLoading || isPersonaMessagesLoading || isPersonaUniqueUsersLoading;
+  const hasError =
+    agentsError || personaMessagesError || personaUniqueUsersError;
 
   const filteredPersonaList = useMemo(() => {
     if (!availablePersonas) return [];
@@ -110,7 +116,7 @@ export function PersonaMessagesChart({
           ...personaMessagesData.map((entry) => new Date(entry.date).getTime())
         )
       );
-    const dateRange = getDatesList(initialDate);
+    const dateRange = getDatesList(initialDate, timeRange.to);
 
     // Create maps for messages and unique users data
     const messagesMap = new Map(

--- a/web/src/app/ee/admin/performance/usage/PersonaMessagesChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/PersonaMessagesChart.tsx
@@ -139,6 +139,7 @@ export function PersonaMessagesChart({
     personaMessagesData,
     personaUniqueUsersData,
     timeRange.from,
+    timeRange.to,
     selectedPersonaId,
   ]);
 

--- a/web/src/app/ee/admin/performance/usage/QueryPerformanceChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/QueryPerformanceChart.tsx
@@ -45,7 +45,7 @@ export function QueryPerformanceChart({
     );
   } else {
     const initialDate = timeRange.from || new Date(queryAnalyticsData[0].date);
-    const dateRange = getDatesList(initialDate);
+    const dateRange = getDatesList(initialDate, timeRange.to);
 
     const dateToQueryAnalytics = new Map(
       queryAnalyticsData.map((queryAnalyticsEntry) => [

--- a/web/src/app/ee/admin/performance/usage/UsageReports.tsx
+++ b/web/src/app/ee/admin/performance/usage/UsageReports.tsx
@@ -273,6 +273,10 @@ export default function UsageReports() {
   });
 
   useEffect(() => {
+    if (listError) console.error("Failed to load usage reports:", listError);
+  }, [listError]);
+
+  useEffect(() => {
     if (!reports || !pendingReportId) return;
     const completed = reports.find((report) =>
       report.report_name.includes(pendingReportId)
@@ -339,6 +343,7 @@ export default function UsageReports() {
       }, REPORT_TIMEOUT_MS);
       await mutate();
     } catch (error) {
+      console.error("Failed to start usage report generation:", error);
       const message = error instanceof Error ? error.message : "unknown error";
       toast.error(`Failed to start report generation: ${message}`);
     } finally {
@@ -364,7 +369,7 @@ export default function UsageReports() {
           </Text>
         </div>
         <GenerateReportMenu
-          disabled={requesting || pending || listLoading || Boolean(listError)}
+          disabled={requesting || pending || listLoading}
           pending={pending}
           onGenerate={(period) => void requestReport(period)}
         />

--- a/web/src/app/ee/admin/performance/usage/UsageReports.tsx
+++ b/web/src/app/ee/admin/performance/usage/UsageReports.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
-import { format, startOfDay, subDays } from "date-fns";
+import { endOfDay, format, startOfDay, subDays } from "date-fns";
 import useSWR from "swr";
 import {
   Button,
@@ -316,7 +316,9 @@ export default function UsageReports() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           period_from: period.range ? period.range.from.toISOString() : null,
-          period_to: period.range ? period.range.to.toISOString() : null,
+          period_to: period.range
+            ? endOfDay(period.range.to).toISOString()
+            : null,
           report_id: reportId,
         }),
       });

--- a/web/src/app/ee/admin/performance/usage/UsageReports.tsx
+++ b/web/src/app/ee/admin/performance/usage/UsageReports.tsx
@@ -1,454 +1,415 @@
 "use client";
 
-import { format } from "date-fns";
-import { errorHandlingFetcher } from "@/lib/fetcher";
-
-import { FiDownload } from "react-icons/fi";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { Text } from "@opal/components";
-import Title from "@/components/ui/title";
-import { Spacer } from "@opal/components";
-import Button from "@/refresh-components/buttons/Button";
-import { Button as OpalButton } from "@opal/components";
+import React, { useEffect, useRef, useState } from "react";
+import { format, startOfDay, subDays } from "date-fns";
 import useSWR from "swr";
-import { SWR_KEYS } from "@/lib/swr-keys";
-import React, { useState } from "react";
-import { UsageReport } from "./types";
-import SvgSimpleLoader from "@opal/icons/simple-loader";
-import Link from "next/link";
+import {
+  Button,
+  Calendar,
+  LineItemButton,
+  MessageCard,
+  Pagination,
+  Popover,
+  Text,
+} from "@opal/components";
+import { ContentAction, PageLoader, toast } from "@opal/layouts";
+import {
+  SvgCalendar,
+  SvgDownload,
+  SvgDownloadCloud,
+  SvgSimpleLoader,
+  SvgSpreadsheetFile,
+  SvgX,
+} from "@opal/icons";
 import { humanReadableFormat, humanReadableFormatWithTime } from "@opal/time";
-import { ErrorCallout } from "@/components/ErrorCallout";
-import { PageSelector } from "@/components/PageSelector";
-import { Divider } from "@opal/components";
-import { DateRangePickerValue } from "../../../../../components/dateRangeSelectors/AdminDateRangeSelector";
-import { Popover } from "@opal/components";
-import Calendar from "@/refresh-components/Calendar";
-import { cn } from "@opal/utils";
-import { Spinner } from "@/components/Spinner";
-import { SvgCalendar, SvgDownloadCloud } from "@opal/icons";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
+import { UsageReport } from "./types";
 
-function GenerateReportInput({
-  onReportGenerated,
-  isWaitingForReport,
-}: {
-  onReportGenerated: () => void;
-  isWaitingForReport: boolean;
-}) {
-  const [dateRange, setDateRange] = useState<DateRangePickerValue | undefined>(
-    undefined
-  );
-  const [isLoading, setIsLoading] = useState(false);
+interface ReportPeriod {
+  label: string;
+  range?: { from: Date; to: Date };
+}
 
-  const [errorOccurred, setErrorOccurred] = useState<Error | null>(null);
+const PRESET_DAYS: { label: string; days: number }[] = [
+  { label: "Today", days: 1 },
+  { label: "Last 7 days", days: 7 },
+  { label: "Last 30 days", days: 30 },
+  { label: "Last 3 months", days: 90 },
+];
 
-  const requestReport = async () => {
-    setIsLoading(true);
-    setErrorOccurred(null);
-    try {
-      let period_from: string | null = null;
-      let period_to: string | null = null;
+function presetPeriod(label: string, days: number): ReportPeriod {
+  const to = startOfDay(new Date());
+  return { label, range: { from: subDays(to, days - 1), to } };
+}
 
-      if (dateRange?.selectValue != "allTime" && dateRange?.from) {
-        period_from = dateRange?.from?.toISOString();
-        period_to = dateRange?.to?.toISOString() ?? new Date().toISOString();
-      }
+const PAGE_SIZE = 8;
+const POLL_INTERVAL_MS = 3_000;
+const SLOW_REPORT_AFTER_MS = 20_000;
+const REPORT_TIMEOUT_MS = 5 * 60_000;
 
-      const res = await fetch("/api/admin/usage-report", {
-        method: "POST",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          period_from: period_from,
-          period_to: period_to,
-        }),
-      });
+function periodLabel(report: UsageReport): string {
+  return report.period_from
+    ? `${humanReadableFormat(report.period_from)} – ${humanReadableFormat(
+        report.period_to!
+      )}`
+    : "All time";
+}
 
-      if (!res.ok) {
-        throw Error(`Received an error: ${res.statusText}`);
-      }
+interface PendingReportRowProps {
+  rangeLabel: string;
+  slow: boolean;
+}
 
-      // Trigger refresh of the reports list
-      onReportGenerated();
-    } catch (e) {
-      setErrorOccurred(e as Error);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const today = new Date();
-
-  const lastWeek = new Date();
-  lastWeek.setDate(today.getDate() - 7);
-
-  const lastMonth = new Date();
-  lastMonth.setMonth(today.getMonth() - 1);
-
-  const lastYear = new Date();
-  lastYear.setFullYear(today.getFullYear() - 1);
-
+function PendingReportRow({ rangeLabel, slow }: PendingReportRowProps) {
   return (
-    <div className="mb-8">
-      <Title className="mb-2">Generate Usage Reports</Title>
-      <Text as="p">Generate usage statistics for users in the workspace.</Text>
-      <Spacer rem={2} />
-      <div className="grid gap-2 mb-3">
-        <Popover>
-          <Popover.Trigger asChild>
-            {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-            <Button
-              secondary
-              className={cn(
-                "w-[300px] justify-start text-left font-normal",
-                !dateRange && "text-muted-foreground"
-              )}
-              leftIcon={SvgCalendar}
-            >
-              {dateRange?.from ? (
-                dateRange.to ? (
-                  <>
-                    {format(dateRange.from, "LLL dd, y")} -{" "}
-                    {format(dateRange.to, "LLL dd, y")}
-                  </>
-                ) : (
-                  format(dateRange.from, "LLL dd, y")
-                )
-              ) : (
-                <span>Pick a date range</span>
-              )}
-            </Button>
-          </Popover.Trigger>
-          <Popover.Content align="start">
-            <Calendar
-              initialFocus
-              mode="range"
-              defaultMonth={dateRange?.from}
-              selected={dateRange}
-              onSelect={(range) =>
-                range?.from &&
-                setDateRange({
-                  from: range.from,
-                  to: range.to ?? range.from,
-                  selectValue: "custom",
-                })
-              }
-              numberOfMonths={2}
-              disabled={(date) => date > new Date()}
-            />
-            <div className="border-t p-3">
-              <OpalButton
-                prominence="tertiary"
-                width="full"
-                onClick={() => {
-                  setDateRange({
-                    from: lastWeek,
-                    to: new Date(),
-                    selectValue: "lastWeek",
-                  });
-                }}
-              >
-                Last 7 days
-              </OpalButton>
-              <OpalButton
-                prominence="tertiary"
-                width="full"
-                onClick={() => {
-                  setDateRange({
-                    from: lastMonth,
-                    to: new Date(),
-                    selectValue: "lastMonth",
-                  });
-                }}
-              >
-                Last 30 days
-              </OpalButton>
-              <OpalButton
-                prominence="tertiary"
-                width="full"
-                onClick={() => {
-                  setDateRange({
-                    from: lastYear,
-                    to: new Date(),
-                    selectValue: "lastYear",
-                  });
-                }}
-              >
-                Last year
-              </OpalButton>
-              <OpalButton
-                prominence="tertiary"
-                width="full"
-                onClick={() => {
-                  setDateRange({
-                    from: new Date(1970, 0, 1),
-                    to: new Date(),
-                    selectValue: "allTime",
-                  });
-                }}
-              >
-                All time
-              </OpalButton>
-            </div>
-          </Popover.Content>
-        </Popover>
-      </div>
-      <OpalButton
-        disabled={isLoading || isWaitingForReport}
-        color={"blue"}
-        icon={SvgDownloadCloud}
-        onClick={() => requestReport()}
-      >
-        {isWaitingForReport ? "Generating..." : "Generate Report"}
-      </OpalButton>
-      <p className="mt-1 text-xs">
-        {isWaitingForReport
-          ? "A report is currently being generated. Please wait..."
-          : 'Report generation runs in the background. Check the "Previous Reports" section below to download when ready.'}
-      </p>
-      {errorOccurred && (
-        <ErrorCallout
-          errorTitle="Something went wrong."
-          errorMsg={errorOccurred?.toString()}
-        />
-      )}
+    <div
+      className="rounded-12 border border-border-01 bg-background-tint-01 motion-safe:animate-pulse"
+      data-testid="pending-report-row"
+    >
+      <ContentAction
+        sizePreset="main-ui"
+        variant="section"
+        icon={SvgSpreadsheetFile}
+        title="Preparing report…"
+        description={
+          slow
+            ? "Still working. You can leave this page; the report will appear here."
+            : `${rangeLabel} · usually ready in under a minute`
+        }
+        padding="md"
+        center
+        rightChildren={
+          <SvgSimpleLoader
+            size={16}
+            className="shrink-0 animate-spin stroke-text-03 motion-reduce:animate-none"
+          />
+        }
+      />
     </div>
   );
 }
 
-const USAGE_REPORT_URL = SWR_KEYS.usageReport;
+interface ReportRowProps {
+  report: UsageReport;
+  justArrived: boolean;
+}
 
-function UsageReportsTable({
-  refreshTrigger,
-  isWaitingForReport,
-  onNewReportDetected,
-}: {
-  refreshTrigger: number;
-  isWaitingForReport: boolean;
-  onNewReportDetected: () => void;
-}) {
-  const [page, setPage] = useState(1);
-  const NUM_IN_PAGE = 10;
-  const [previousReportCount, setPreviousReportCount] = useState<number | null>(
-    null
-  );
-
-  const {
-    data: usageReportsMetadata,
-    error: usageReportsError,
-    isLoading: usageReportsIsLoading,
-    mutate,
-  } = useSWR<UsageReport[]>(USAGE_REPORT_URL, errorHandlingFetcher, {
-    refreshInterval: isWaitingForReport ? 3000 : 0, // Poll every 3 seconds when waiting
-  });
-
-  // Refresh when refreshTrigger changes
-  React.useEffect(() => {
-    if (refreshTrigger > 0) {
-      mutate();
-    }
-  }, [refreshTrigger, mutate]);
-
-  // Detect when a new report appears
-  React.useEffect(() => {
-    if (usageReportsMetadata && previousReportCount !== null) {
-      if (usageReportsMetadata.length > previousReportCount) {
-        onNewReportDetected();
+function ReportRow({ report, justArrived }: ReportRowProps) {
+  return (
+    <div
+      className={
+        justArrived
+          ? "rounded-12 border border-border-01 bg-background-neutral-00 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-top-2 motion-safe:duration-500"
+          : "rounded-12 border border-border-01 bg-background-neutral-00"
       }
-    }
-    if (usageReportsMetadata) {
-      setPreviousReportCount(usageReportsMetadata.length);
-    }
-  }, [usageReportsMetadata, previousReportCount, onNewReportDetected]);
+    >
+      <ContentAction
+        sizePreset="main-ui"
+        variant="section"
+        icon={SvgSpreadsheetFile}
+        title={periodLabel(report)}
+        description={`Generated by ${report.requestor ?? "system"} · ${humanReadableFormatWithTime(report.time_created)}`}
+        padding="md"
+        center
+        rightChildren={
+          <Button
+            prominence="tertiary"
+            icon={SvgDownload}
+            tooltip="Download CSV"
+            aria-label={`Download report for ${periodLabel(report)}`}
+            href={`/api/admin/usage-report/${report.report_name}`}
+          />
+        }
+      />
+    </div>
+  );
+}
 
-  const paginatedReports = usageReportsMetadata
-    ? usageReportsMetadata
-        .slice(0)
-        .reverse()
-        .slice(NUM_IN_PAGE * (page - 1), NUM_IN_PAGE * page)
-    : [];
+interface GenerateReportMenuProps {
+  disabled: boolean;
+  pending: boolean;
+  onGenerate: (period: ReportPeriod) => void;
+}
 
-  const totalPages = usageReportsMetadata
-    ? Math.ceil(usageReportsMetadata.length / NUM_IN_PAGE)
-    : 0;
+function GenerateReportMenu({
+  disabled,
+  pending,
+  onGenerate,
+}: GenerateReportMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [view, setView] = useState<"presets" | "calendar">("presets");
+  const [pendingStart, setPendingStart] = useState<Date | undefined>(undefined);
+  const [draftRange, setDraftRange] = useState<
+    { from: Date; to?: Date } | undefined
+  >(undefined);
+
+  function reset() {
+    setView("presets");
+    setPendingStart(undefined);
+    setDraftRange(undefined);
+  }
 
   return (
-    <div>
-      <Title className="mb-2 mt-6 mx-auto"> Previous Reports </Title>
-      {usageReportsIsLoading && !isWaitingForReport ? (
-        <div className="flex justify-center w-full">
-          <SvgSimpleLoader className="h-6 w-6" />
-        </div>
-      ) : usageReportsError ? (
-        <ErrorCallout
-          errorTitle="Something went wrong."
-          errorMsg={(usageReportsError as Error).toString()}
-        />
-      ) : (
-        <>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Report</TableHead>
-                <TableHead>Period</TableHead>
-                <TableHead>Generated By</TableHead>
-                <TableHead>Time Generated</TableHead>
-                <TableHead>Download</TableHead>
-              </TableRow>
-            </TableHeader>
-
-            <TableBody>
-              {paginatedReports.map((r) => (
-                <TableRow key={r.report_name}>
-                  <TableCell>
-                    {r.report_name.split("_")[1]?.substring(0, 8) ||
-                      r.report_name.substring(0, 8)}
-                  </TableCell>
-                  <TableCell>
-                    {r.period_from
-                      ? `${humanReadableFormat(
-                          r.period_from
-                        )} - ${humanReadableFormat(r.period_to!)}`
-                      : "All time"}
-                  </TableCell>
-                  <TableCell>{r.requestor ?? "Auto generated"}</TableCell>
-                  <TableCell>
-                    {humanReadableFormatWithTime(r.time_created)}
-                  </TableCell>
-                  <TableCell>
-                    <Link
-                      href={`/api/admin/usage-report/${r.report_name}`}
-                      className="flex justify-center"
-                    >
-                      <FiDownload color="primary" />
-                    </Link>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-          <div className="mt-3 flex">
-            <div className="mx-auto">
-              <PageSelector
-                totalPages={totalPages}
-                currentPage={page}
-                onPageChange={(newPage) => {
-                  setPage(newPage);
-                  window.scrollTo({
-                    top: 0,
-                    left: 0,
-                    behavior: "smooth",
-                  });
-                }}
-              />
-            </div>
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) reset();
+      }}
+    >
+      <Popover.Trigger asChild>
+        <Button icon={SvgDownloadCloud} disabled={disabled}>
+          {pending ? "Generating…" : "Generate report"}
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content
+        align="end"
+        side="bottom"
+        width={view === "presets" ? "lg" : "fit"}
+      >
+        {view === "presets" ? (
+          <Popover.Menu>
+            {[
+              ...PRESET_DAYS.map((preset) => (
+                <Popover.Close asChild key={preset.label}>
+                  <LineItemButton
+                    title={preset.label}
+                    onClick={() =>
+                      onGenerate(presetPeriod(preset.label, preset.days))
+                    }
+                    rounding="md"
+                    selectVariant="select-heavy"
+                    sizePreset="main-ui"
+                    state="empty"
+                    variant="section"
+                    width="full"
+                  />
+                </Popover.Close>
+              )),
+              <Popover.Close asChild key="all-time">
+                <LineItemButton
+                  title="All time"
+                  onClick={() => onGenerate({ label: "All time" })}
+                  rounding="md"
+                  selectVariant="select-heavy"
+                  sizePreset="main-ui"
+                  state="empty"
+                  variant="section"
+                  width="full"
+                />
+              </Popover.Close>,
+              null,
+              <LineItemButton
+                key="custom"
+                icon={SvgCalendar}
+                title="Custom period…"
+                onClick={() => setView("calendar")}
+                rounding="md"
+                selectVariant="select-heavy"
+                sizePreset="main-ui"
+                state="empty"
+                variant="section"
+                width="full"
+              />,
+            ]}
+          </Popover.Menu>
+        ) : (
+          <div className="flex flex-col gap-1 p-2">
+            <Text font="secondary-body" color="text-03">
+              {pendingStart
+                ? "Pick the end of the period"
+                : "Pick the start of the period"}
+            </Text>
+            <Calendar
+              mode="range"
+              selected={draftRange}
+              onDayClick={(day) => {
+                if (!pendingStart) {
+                  setDraftRange({ from: day });
+                  setPendingStart(day);
+                  return;
+                }
+                const from = day < pendingStart ? day : pendingStart;
+                const to = day < pendingStart ? pendingStart : day;
+                onGenerate({
+                  label: `${format(from, "MMM d, y")} – ${format(to, "MMM d, y")}`,
+                  range: { from, to },
+                });
+                setOpen(false);
+                reset();
+              }}
+              numberOfMonths={1}
+              disabled={(date) => date > new Date()}
+            />
           </div>
-        </>
-      )}
-    </div>
+        )}
+      </Popover.Content>
+    </Popover>
   );
 }
 
 export default function UsageReports() {
-  const [refreshTrigger, setRefreshTrigger] = useState(0);
-  const [isWaitingForReport, setIsWaitingForReport] = useState(false);
-  const [timeoutMessage, setTimeoutMessage] = useState<string | null>(null);
-  const timeoutRef = React.useRef<NodeJS.Timeout | null>(null);
+  const [page, setPage] = useState(1);
+  const [requesting, setRequesting] = useState(false);
+  const [pendingSince, setPendingSince] = useState<number | null>(null);
+  const [pendingLabel, setPendingLabel] = useState<string>("");
+  const [pendingSlow, setPendingSlow] = useState(false);
+  const [arrivedReportName, setArrivedReportName] = useState<string | null>(
+    null
+  );
+  const [pendingReportId, setPendingReportId] = useState<string | null>(null);
+  const slowTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reportTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleReportGenerated = () => {
-    setRefreshTrigger((prev) => prev + 1);
-    setIsWaitingForReport(true);
-    setTimeoutMessage(null);
+  const pending = pendingSince !== null;
+  const {
+    data: reports,
+    error: listError,
+    isLoading: listLoading,
+    mutate,
+  } = useSWR<UsageReport[]>(SWR_KEYS.usageReport, errorHandlingFetcher, {
+    refreshInterval: pending ? POLL_INTERVAL_MS : 0,
+  });
 
-    // Clear any existing timeout
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-    }
-
-    // Set a 15 second timeout
-    timeoutRef.current = setTimeout(() => {
-      setIsWaitingForReport(false);
-      setTimeoutMessage(
-        "Report generation is taking longer than expected. The report will continue generating in the background. Please check back in a few minutes."
-      );
-      timeoutRef.current = null;
-    }, 15000);
-  };
-
-  const handleNewReportDetected = () => {
-    setIsWaitingForReport(false);
-    setTimeoutMessage(null);
-    // Clear the timeout if report completed before timeout
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-      timeoutRef.current = null;
-    }
-  };
-
-  // Cleanup on unmount
-  React.useEffect(() => {
-    return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
+  useEffect(() => {
+    if (!reports || !pendingReportId) return;
+    const completed = reports.find((report) =>
+      report.report_name.includes(pendingReportId)
+    );
+    if (completed && pending) {
+      setPendingSince(null);
+      setPendingReportId(null);
+      setPendingSlow(false);
+      setArrivedReportName(completed.report_name);
+      setPage(1);
+      toast.success("Usage report ready.");
+      if (slowTimerRef.current) {
+        clearTimeout(slowTimerRef.current);
+        slowTimerRef.current = null;
       }
+      if (reportTimeoutRef.current) {
+        clearTimeout(reportTimeoutRef.current);
+        reportTimeoutRef.current = null;
+      }
+    }
+  }, [reports, pending, pendingReportId]);
+
+  useEffect(() => {
+    return () => {
+      if (slowTimerRef.current) clearTimeout(slowTimerRef.current);
+      if (reportTimeoutRef.current) clearTimeout(reportTimeoutRef.current);
     };
   }, []);
 
+  async function requestReport(period: ReportPeriod): Promise<void> {
+    setRequesting(true);
+    try {
+      const reportId = crypto.randomUUID();
+      const res = await fetch("/api/admin/usage-report", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          period_from: period.range ? period.range.from.toISOString() : null,
+          period_to: period.range ? period.range.to.toISOString() : null,
+          report_id: reportId,
+        }),
+      });
+      if (!res.ok) {
+        throw Error(`Received an error: ${res.statusText}`);
+      }
+      setPendingSince(Date.now());
+      setPendingReportId(reportId);
+      setPendingLabel(period.label);
+      setPendingSlow(false);
+      setArrivedReportName(null);
+      slowTimerRef.current = setTimeout(
+        () => setPendingSlow(true),
+        SLOW_REPORT_AFTER_MS
+      );
+      reportTimeoutRef.current = setTimeout(() => {
+        setPendingSince(null);
+        setPendingReportId(null);
+        setPendingSlow(false);
+        toast.error(
+          "Report generation is taking too long. Try again or check back later."
+        );
+        reportTimeoutRef.current = null;
+      }, REPORT_TIMEOUT_MS);
+      await mutate();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "unknown error";
+      toast.error(`Failed to start report generation: ${message}`);
+    } finally {
+      setRequesting(false);
+    }
+  }
+
+  const orderedReports = reports ? [...reports].reverse() : [];
+  const totalPages = Math.max(1, Math.ceil(orderedReports.length / PAGE_SIZE));
+  const pageReports = orderedReports.slice(
+    PAGE_SIZE * (page - 1),
+    PAGE_SIZE * page
+  );
+
   return (
-    <>
-      {isWaitingForReport && <Spinner />}
-      <>
-        <GenerateReportInput
-          onReportGenerated={handleReportGenerated}
-          isWaitingForReport={isWaitingForReport}
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-0.5">
+          <Text font="heading-h3">Usage reports</Text>
+          <Text font="secondary-body" color="text-03">
+            Export per-user usage as a CSV. Reports build in the background and
+            stay available here.
+          </Text>
+        </div>
+        <GenerateReportMenu
+          disabled={requesting || pending || listLoading || Boolean(listError)}
+          pending={pending}
+          onGenerate={(period) => void requestReport(period)}
         />
-        {timeoutMessage && (
-          <div className="mb-4 p-4 bg-status-warning-00 border border-status-warning-02 rounded-regular">
-            <div className="flex items-start gap-2">
-              <div className="text-status-warning-05 mt-0.5">
-                <svg
-                  className="w-5 h-5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-                  />
-                </svg>
-              </div>
-              <div className="flex-1">
-                <div className="text-status-warning-05">
-                  <Text as="p" font="main-ui-action">
-                    Report Generation In Progress
-                  </Text>
-                </div>
-                <Spacer rem={0.25} />
-                <div className="text-status-warning-05">
-                  <Text as="p">{timeoutMessage}</Text>
-                </div>
-              </div>
+      </div>
+
+      {listLoading ? (
+        <PageLoader />
+      ) : listError ? (
+        <MessageCard
+          variant="error"
+          icon={SvgX}
+          title="Failed to load usage reports."
+        />
+      ) : (
+        <div className="flex flex-col gap-2">
+          {pending && page === 1 && (
+            <PendingReportRow rangeLabel={pendingLabel} slow={pendingSlow} />
+          )}
+          {orderedReports.length === 0 && !pending ? (
+            <div className="rounded-12 border border-dashed border-border-02 p-4">
+              <Text font="secondary-body" color="text-03" as="p">
+                No reports yet. Pick a period and generate your first one.
+              </Text>
             </div>
-          </div>
-        )}
-        <Divider />
-        <UsageReportsTable
-          refreshTrigger={refreshTrigger}
-          isWaitingForReport={isWaitingForReport}
-          onNewReportDetected={handleNewReportDetected}
-        />
-      </>
-    </>
+          ) : (
+            pageReports.map((report) => (
+              <ReportRow
+                key={report.report_name}
+                report={report}
+                justArrived={report.report_name === arrivedReportName}
+              />
+            ))
+          )}
+          {totalPages > 1 && (
+            <div className="flex justify-end pt-1">
+              <Pagination
+                variant="simple"
+                currentPage={page}
+                totalPages={totalPages}
+                onChange={setPage}
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
   );
 }

--- a/web/src/app/ee/admin/performance/usage/UsageReports.tsx
+++ b/web/src/app/ee/admin/performance/usage/UsageReports.tsx
@@ -351,9 +351,15 @@ export default function UsageReports() {
         reportTimeoutRef.current = null;
       }, REPORT_TIMEOUT_MS);
     } catch (error) {
+      // Always log, but only toast if the admin is still on this page: a
+      // request aborted by navigating away must not surface as a failure
+      // notice on whatever page they landed on.
       console.error("Failed to start usage report generation:", error);
-      const message = error instanceof Error ? error.message : "unknown error";
-      toast.error(`Failed to start report generation: ${message}`);
+      if (mountedRef.current) {
+        const message =
+          error instanceof Error ? error.message : "unknown error";
+        toast.error(`Failed to start report generation: ${message}`);
+      }
       return;
     } finally {
       if (mountedRef.current) setRequesting(false);

--- a/web/src/app/ee/admin/performance/usage/UsageReports.tsx
+++ b/web/src/app/ee/admin/performance/usage/UsageReports.tsx
@@ -116,7 +116,7 @@ function ReportRow({ report, justArrived }: ReportRowProps) {
           <Button
             prominence="tertiary"
             icon={SvgDownload}
-            tooltip="Download CSV"
+            tooltip="Download ZIP"
             aria-label={`Download report for ${periodLabel(report)}`}
             href={`/api/admin/usage-report/${report.report_name}`}
           />
@@ -261,6 +261,7 @@ export default function UsageReports() {
   const [pendingReportId, setPendingReportId] = useState<string | null>(null);
   const slowTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reportTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef(true);
 
   const pending = pendingSince !== null;
   const {
@@ -300,7 +301,9 @@ export default function UsageReports() {
   }, [reports, pending, pendingReportId]);
 
   useEffect(() => {
+    mountedRef.current = true;
     return () => {
+      mountedRef.current = false;
       if (slowTimerRef.current) clearTimeout(slowTimerRef.current);
       if (reportTimeoutRef.current) clearTimeout(reportTimeoutRef.current);
     };
@@ -325,6 +328,10 @@ export default function UsageReports() {
       if (!res.ok) {
         throw Error(`Received an error: ${res.statusText}`);
       }
+      // The request outlives the component if the admin navigates away
+      // mid-flight; the cleanup effect has already run, so scheduling timers
+      // here would fire a stray "taking too long" toast on another page.
+      if (!mountedRef.current) return;
       setPendingSince(Date.now());
       setPendingReportId(reportId);
       setPendingLabel(period.label);
@@ -343,14 +350,21 @@ export default function UsageReports() {
         );
         reportTimeoutRef.current = null;
       }, REPORT_TIMEOUT_MS);
-      await mutate();
     } catch (error) {
       console.error("Failed to start usage report generation:", error);
       const message = error instanceof Error ? error.message : "unknown error";
       toast.error(`Failed to start report generation: ${message}`);
+      return;
     } finally {
-      setRequesting(false);
+      if (mountedRef.current) setRequesting(false);
     }
+
+    // Best-effort list refresh: generation already succeeded, so a failed
+    // revalidation must not surface as "failed to start report generation".
+    // Polling picks the new report up regardless.
+    void mutate().catch((error: unknown) => {
+      console.error("Failed to refresh the usage report list:", error);
+    });
   }
 
   const orderedReports = reports ? [...reports].reverse() : [];
@@ -366,12 +380,12 @@ export default function UsageReports() {
         <div className="flex flex-col gap-0.5">
           <Text font="heading-h3">Usage reports</Text>
           <Text font="secondary-body" color="text-03">
-            Export per-user usage as a CSV. Reports build in the background and
-            stay available here.
+            Export per-user usage as a ZIP of CSV files. Reports build in the
+            background and stay available here.
           </Text>
         </div>
         <GenerateReportMenu
-          disabled={requesting || pending || listLoading}
+          disabled={requesting || pending}
           pending={pending}
           onGenerate={(period) => void requestReport(period)}
         />

--- a/web/src/app/ee/admin/performance/usage/page.tsx
+++ b/web/src/app/ee/admin/performance/usage/page.tsx
@@ -16,7 +16,7 @@ export default function UsagePage() {
       <SettingsLayouts.Header
         icon={route.icon}
         title={route.title}
-        description="Monitor workspace spend, review usage by user, and manage spending limits."
+        description="Monitor workspace spend and review usage by user."
         divider
       />
       <SettingsLayouts.Body>

--- a/web/src/app/ee/admin/performance/usage/page.tsx
+++ b/web/src/app/ee/admin/performance/usage/page.tsx
@@ -1,43 +1,34 @@
 "use client";
 
 import { AdminDateRangeSelector } from "@/components/dateRangeSelectors/AdminDateRangeSelector";
-import { OnyxBotChart } from "@/app/ee/admin/performance/usage/OnyxBotChart";
-import { FeedbackChart } from "@/app/ee/admin/performance/usage/FeedbackChart";
-import { QueryPerformanceChart } from "@/app/ee/admin/performance/usage/QueryPerformanceChart";
-import { PersonaMessagesChart } from "@/app/ee/admin/performance/usage/PersonaMessagesChart";
 import { useTimeRange } from "@/app/ee/admin/performance/lib";
-import UsageReports from "@/app/ee/admin/performance/usage/UsageReports";
 import PerUserUsagePanel from "@/views/admin/PerUserUsagePanel";
-import { Divider } from "@opal/components";
-import { useAdminAgents } from "@/lib/agents/hooks";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { SettingsLayouts } from "@opal/layouts";
 
 const route = ADMIN_ROUTES.USAGE;
 
-export default function AnalyticsPage() {
+export default function UsagePage() {
   const [timeRange, setTimeRange] = useTimeRange();
-  const { agents } = useAdminAgents();
 
   return (
-    <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
+    <SettingsLayouts.Root width="lg">
+      <SettingsLayouts.Header
+        icon={route.icon}
+        title={route.title}
+        description="Monitor workspace spend, review usage by user, and manage spending limits."
+        divider
+      />
       <SettingsLayouts.Body>
-        <AdminDateRangeSelector
-          value={timeRange}
-          onValueChange={(value) => setTimeRange(value as any)}
-        />
-        <QueryPerformanceChart timeRange={timeRange} />
-        <FeedbackChart timeRange={timeRange} />
-        <OnyxBotChart timeRange={timeRange} />
-        <PersonaMessagesChart
-          availablePersonas={agents}
+        <PerUserUsagePanel
           timeRange={timeRange}
+          headerRight={
+            <AdminDateRangeSelector
+              value={timeRange}
+              onValueChange={(value) => setTimeRange(value as any)}
+            />
+          }
         />
-        <Divider />
-        <PerUserUsagePanel />
-        <Divider />
-        <UsageReports />
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>
   );

--- a/web/src/components/dateRangeSelectors/AdminDateRangeSelector.test.tsx
+++ b/web/src/components/dateRangeSelectors/AdminDateRangeSelector.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AdminDateRangeSelector } from "./AdminDateRangeSelector";
+
+describe("AdminDateRangeSelector", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2026, 7, 4, 12));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("selects and commits a custom range with two date clicks", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const onValueChange = jest.fn();
+
+    render(
+      <AdminDateRangeSelector
+        value={{
+          from: new Date(2026, 6, 5),
+          to: new Date(2026, 7, 4),
+        }}
+        onValueChange={onValueChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /custom range/i }));
+    await user.click(screen.getByRole("button", { name: /august 1st, 2026/i }));
+
+    const endDate = screen.getByRole("button", { name: /august 3rd, 2026/i });
+    await user.hover(endDate);
+
+    expect(endDate.parentElement).toHaveClass(
+      "opal-calendar-cell--range-preview-end"
+    );
+    expect(
+      screen.getByRole("button", { name: /august 2nd, 2026/i }).parentElement
+    ).toHaveClass("opal-calendar-cell--range-preview-middle");
+
+    await user.click(endDate);
+
+    expect(onValueChange).toHaveBeenCalledWith({
+      from: new Date(2026, 7, 1),
+      to: new Date(2026, 7, 3, 23, 59, 59, 999),
+    });
+    expect(
+      screen.getByRole("button", { name: /custom range/i })
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("emits a full current-day range for 1D", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const onValueChange = jest.fn();
+
+    render(
+      <AdminDateRangeSelector
+        value={{
+          from: new Date(2026, 6, 5),
+          to: new Date(2026, 7, 4),
+        }}
+        onValueChange={onValueChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "1D" }));
+
+    expect(onValueChange).toHaveBeenCalledWith({
+      from: new Date(2026, 7, 4),
+      to: new Date(2026, 7, 4, 23, 59, 59, 999),
+    });
+  });
+
+  it("shows the committed custom range when reopened", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(
+      <AdminDateRangeSelector
+        value={{
+          from: new Date(2026, 6, 10),
+          to: new Date(2026, 6, 15),
+        }}
+        onValueChange={jest.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /custom range/i }));
+
+    expect(
+      screen.getByRole("button", { name: /july 10th, 2026/i }).parentElement
+    ).toHaveClass("opal-calendar-cell--range-start");
+    expect(
+      screen.getByRole("button", { name: /july 15th, 2026/i }).parentElement
+    ).toHaveClass("opal-calendar-cell--range-end");
+  });
+});

--- a/web/src/components/dateRangeSelectors/AdminDateRangeSelector.tsx
+++ b/web/src/components/dateRangeSelectors/AdminDateRangeSelector.tsx
@@ -1,12 +1,8 @@
 import React, { memo, useState } from "react";
-import Calendar from "@/refresh-components/Calendar";
-import { Popover } from "@opal/components";
-import Button from "@/refresh-components/buttons/Button";
-import { Button as OpalButton } from "@opal/components";
-import { cn } from "@opal/utils";
-import { format } from "date-fns";
-import { getXDaysAgo } from "./dateUtils";
+import { endOfDay, format, isSameDay, startOfDay, subDays } from "date-fns";
+import { Calendar, Popover, SelectButton } from "@opal/components";
 import { SvgCalendar } from "@opal/icons";
+
 export const THIRTY_DAYS = "30d";
 
 export type DateRangePickerValue = DateRange & {
@@ -20,87 +16,174 @@ export type DateRange =
     }
   | undefined;
 
+type DraftDateRange =
+  | {
+      from: Date;
+      to?: Date;
+    }
+  | undefined;
+
+interface DatePreset {
+  label: string;
+  daysAgo: number;
+}
+
+const PRESETS: DatePreset[] = [
+  { label: "1D", daysAgo: 0 },
+  { label: "7D", daysAgo: 6 },
+  { label: "1M", daysAgo: 30 },
+  { label: "3M", daysAgo: 90 },
+];
+
+function rangeForPreset(preset: DatePreset): Exclude<DateRange, undefined> {
+  const to = endOfDay(new Date());
+  return { from: startOfDay(subDays(to, preset.daysAgo)), to };
+}
+
+function rangesMatch(left: DateRange, right: DateRange): boolean {
+  return Boolean(
+    left?.from &&
+    left.to &&
+    right?.from &&
+    right.to &&
+    isSameDay(left.from, right.from) &&
+    isSameDay(left.to, right.to)
+  );
+}
+
+type SelectorSize = "md" | "sm";
+
 export const AdminDateRangeSelector = memo(function AdminDateRangeSelector({
   value,
   onValueChange,
+  size = "md",
 }: {
   value: DateRange;
   onValueChange: (value: DateRange) => void;
+  size?: SelectorSize;
 }) {
+  const buttonSize = size === "sm" ? "sm" : "md";
   const [isOpen, setIsOpen] = useState(false);
+  const [draftRange, setDraftRange] = useState<DraftDateRange>(value);
+  const [pendingStart, setPendingStart] = useState<Date>();
+  const [hoveredEnd, setHoveredEnd] = useState<Date>();
 
-  const presets = [
-    {
-      label: "Last 30 days",
-      value: {
-        from: getXDaysAgo(30),
-        to: getXDaysAgo(0),
-      },
-    },
-    {
-      label: "Today",
-      value: {
-        from: getXDaysAgo(1),
-        to: getXDaysAgo(0),
-      },
-    },
-  ];
+  const activePreset = PRESETS.find((preset) =>
+    rangesMatch(value, rangeForPreset(preset))
+  );
+  const customActive = !activePreset;
+  const customLabel =
+    customActive && value
+      ? `${format(value.from, "MMM d")} – ${format(value.to, "MMM d")}`
+      : "Custom";
+
+  function selectPreset(preset: DatePreset) {
+    const range = rangeForPreset(preset);
+    setDraftRange(range);
+    setPendingStart(undefined);
+    setHoveredEnd(undefined);
+    setIsOpen(false);
+    onValueChange(range);
+  }
 
   return (
-    <div className="grid gap-2">
-      <Popover open={isOpen} onOpenChange={setIsOpen}>
-        <Popover.Trigger asChild>
-          {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-          <Button
-            data-testid="admin-date-range-selector-button"
-            secondary
-            className={cn("justify-start", !value && "text-muted-foreground")}
-            leftIcon={SvgCalendar}
+    <div
+      className="inline-flex max-w-full items-center overflow-x-auto rounded-12 border border-border-02 bg-background-tint-03 p-0.5"
+      role="group"
+      aria-label="Date range"
+      data-testid="admin-date-range-selector"
+    >
+      {PRESETS.map((preset) => {
+        const active = !isOpen && activePreset?.label === preset.label;
+
+        return (
+          <SelectButton
+            key={preset.label}
+            size={buttonSize}
+            state={active ? "selected" : "empty"}
+            aria-pressed={active}
+            onClick={() => selectPreset(preset)}
           >
-            {value?.from
-              ? value.to
-                ? `${format(value.from, "LLL dd, y")} - ${format(
-                    value.to,
-                    "LLL dd, y"
-                  )}`
-                : format(value.from, "LLL dd, y")
-              : "Pick a date range"}
-          </Button>
+            {preset.label}
+          </SelectButton>
+        );
+      })}
+
+      <Popover
+        open={isOpen}
+        onOpenChange={(open) => {
+          setIsOpen(open);
+          setPendingStart(undefined);
+          setHoveredEnd(undefined);
+          setDraftRange(open && customActive ? value : undefined);
+        }}
+      >
+        <Popover.Trigger asChild>
+          <SelectButton
+            size={buttonSize}
+            state={customActive || isOpen ? "selected" : "empty"}
+            rightIcon={customLabel === "Custom" ? SvgCalendar : undefined}
+            aria-label={
+              value
+                ? `Custom range: ${format(value.from, "MMM d, y")} to ${format(value.to, "MMM d, y")}`
+                : "Choose a custom range"
+            }
+            aria-pressed={customActive}
+            aria-haspopup="dialog"
+            aria-expanded={isOpen}
+            data-testid="admin-date-range-selector-button"
+          >
+            {customLabel}
+          </SelectButton>
         </Popover.Trigger>
-        <Popover.Content align="start">
-          <Calendar
-            initialFocus
-            mode="range"
-            defaultMonth={value?.from}
-            selected={value}
-            onSelect={(range) => {
-              if (range?.from) {
-                if (range.to) {
-                  // Normal range selection when initialized with a range
-                  onValueChange({ from: range.from, to: range.to });
-                } else {
-                  // Single date selection when initilized without a range
-                  const to = new Date(range.from);
-                  const from = new Date(to.setDate(to.getDate() - 1));
-                  onValueChange({ from, to });
-                }
+
+        <Popover.Content align="end">
+          <div className="flex w-full justify-center">
+            <Calendar
+              mode="range"
+              defaultMonth={customActive ? value?.from : undefined}
+              selected={draftRange}
+              modifiers={
+                pendingStart && hoveredEnd
+                  ? {
+                      range_preview_start:
+                        pendingStart < hoveredEnd ? pendingStart : hoveredEnd,
+                      range_preview_middle: {
+                        after:
+                          pendingStart < hoveredEnd ? pendingStart : hoveredEnd,
+                        before:
+                          pendingStart < hoveredEnd ? hoveredEnd : pendingStart,
+                      },
+                      range_preview_end:
+                        pendingStart < hoveredEnd ? hoveredEnd : pendingStart,
+                    }
+                  : undefined
               }
-            }}
-            numberOfMonths={2}
-          />
-          <div className="border-t p-3">
-            {presets.map((preset) => (
-              <OpalButton
-                key={preset.label}
-                prominence="internal"
-                width="full"
-                onClick={() => {
-                  onValueChange(preset.value);
-                }}
-              >
-                {preset.label}
-              </OpalButton>
-            ))}
+              onDayMouseEnter={(day) => {
+                if (pendingStart) setHoveredEnd(day);
+              }}
+              onDayClick={(day) => {
+                if (!pendingStart) {
+                  setDraftRange({ from: day });
+                  setPendingStart(day);
+                  setHoveredEnd(undefined);
+                  return;
+                }
+
+                const from = startOfDay(
+                  day < pendingStart ? day : pendingStart
+                );
+                const to = endOfDay(day < pendingStart ? pendingStart : day);
+
+                setPendingStart(undefined);
+                setHoveredEnd(undefined);
+                setDraftRange({ from, to });
+                onValueChange({ from, to });
+                setIsOpen(false);
+              }}
+              numberOfMonths={1}
+              disabled={(date) => date > new Date()}
+            />
           </div>
         </Popover.Content>
       </Popover>

--- a/web/src/components/dateRangeSelectors/AdminDateRangeSelector.tsx
+++ b/web/src/components/dateRangeSelectors/AdminDateRangeSelector.tsx
@@ -74,7 +74,7 @@ export const AdminDateRangeSelector = memo(function AdminDateRangeSelector({
   const customActive = !activePreset;
   const customLabel =
     customActive && value
-      ? `${format(value.from, "MMM d")} – ${format(value.to, "MMM d")}`
+      ? `${format(value.from, value.from.getFullYear() === value.to.getFullYear() ? "MMM d" : "MMM d, y")} – ${format(value.to, value.from.getFullYear() === value.to.getFullYear() ? "MMM d" : "MMM d, y")}`
       : "Custom";
 
   function selectPreset(preset: DatePreset) {

--- a/web/src/lib/admin-routes.ts
+++ b/web/src/lib/admin-routes.ts
@@ -215,8 +215,14 @@ export const ADMIN_ROUTES = {
   USAGE: {
     path: "/admin/performance/usage",
     icon: SvgActivity,
-    title: "Usage Statistics",
-    sidebarLabel: "Usage Statistics",
+    title: "Usage",
+    sidebarLabel: "Usage",
+  },
+  WORKSPACE_ANALYTICS: {
+    path: "/admin/performance/analytics",
+    icon: SvgBarChart,
+    title: "Workspace Analytics",
+    sidebarLabel: "Workspace Analytics",
   },
   QUERY_HISTORY: {
     path: "/admin/performance/query-history",

--- a/web/src/lib/usage/userUsage.ts
+++ b/web/src/lib/usage/userUsage.ts
@@ -3,6 +3,7 @@
 import useSWR from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import { buildApiPath } from "@/lib/urlBuilder";
 
 export interface UsageExportTotals {
   input_tokens: number;
@@ -14,6 +15,18 @@ export interface UsageExportTotals {
 export interface UsageExportUser {
   email: string;
   totals: UsageExportTotals;
+  records?: UsageExportRecord[];
+}
+
+export interface UsageExportRecord {
+  model: string;
+  flow?: string;
+  provider?: string;
+  day: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cost_cents: number;
 }
 
 export interface UsageExportResponse {
@@ -22,27 +35,22 @@ export interface UsageExportResponse {
   users: UsageExportUser[];
 }
 
-/** Company-wide per-user usage with a revalidation callback. */
-export function useUsageExport() {
+function formatDateParam(date: Date): string {
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
+export function useUsageExport(range?: { from: Date; to: Date } | undefined) {
+  const url = buildApiPath(SWR_KEYS.adminUsageExport, {
+    start: range?.from ? formatDateParam(range.from) : undefined,
+    end: range?.to ? formatDateParam(range.to) : undefined,
+  });
   const { data, error, isLoading, mutate } = useSWR<UsageExportResponse>(
-    SWR_KEYS.adminUsageExport,
+    url,
     errorHandlingFetcher,
     { revalidateOnFocus: false }
   );
 
   return { usage: data, isLoading, error, refetch: mutate };
-}
-
-/** Clears a user's usage across active enforcement windows. */
-export async function resetUserUsage(userEmail: string): Promise<void> {
-  const response = await fetch(SWR_KEYS.adminUsageReset, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ user_email: userEmail }),
-  });
-
-  if (!response.ok) {
-    const data = await response.json().catch(() => null);
-    throw new Error(data?.detail || data?.error_code || response.statusText);
-  }
 }

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -106,6 +106,7 @@ export const config = {
 const EE_ROUTES = [
   "/admin/groups",
   "/admin/performance/usage",
+  "/admin/performance/analytics",
   "/admin/performance/query-history",
   "/admin/theme",
   "/admin/performance/custom-analytics",

--- a/web/src/refresh-components/AdminDateRangeSelector.stories.tsx
+++ b/web/src/refresh-components/AdminDateRangeSelector.stories.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  AdminDateRangeSelector,
+  type DateRange,
+} from "@/components/dateRangeSelectors/AdminDateRangeSelector";
+
+const meta: Meta<typeof AdminDateRangeSelector> = {
+  title: "components/AdminDateRangeSelector",
+  component: AdminDateRangeSelector,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[640px] min-w-[760px] bg-background-neutral-00 p-8">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof AdminDateRangeSelector>;
+
+function ControlledRange({ initialValue }: { initialValue: DateRange }) {
+  const [value, setValue] = useState<DateRange>(initialValue);
+
+  return <AdminDateRangeSelector value={value} onValueChange={setValue} />;
+}
+
+export const Default: Story = {
+  render: () => (
+    <ControlledRange
+      initialValue={{
+        from: new Date(2026, 6, 5),
+        to: new Date(2026, 7, 4),
+      }}
+    />
+  ),
+};
+
+export const ShortCustomRange: Story = {
+  render: () => (
+    <ControlledRange
+      initialValue={{
+        from: new Date(2026, 7, 2),
+        to: new Date(2026, 7, 4),
+      }}
+    />
+  ),
+};
+
+export const Empty: Story = {
+  render: () => <ControlledRange initialValue={undefined} />,
+};

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -146,7 +146,7 @@ function buildItems(
       add(SECTIONS.USAGE, ADMIN_ROUTES.TRACING);
     }
     addGated(SECTIONS.USAGE, ADMIN_ROUTES.USAGE, Tier.BUSINESS);
-    addGated(SECTIONS.USAGE, ADMIN_ROUTES.TOKEN_RATE_LIMITS, Tier.ENTERPRISE);
+    addGated(SECTIONS.USAGE, ADMIN_ROUTES.WORKSPACE_ANALYTICS, Tier.BUSINESS);
     if (
       settings?.query_history_type !== "disabled" &&
       !settings?.hide_query_history_from_admin_panel

--- a/web/src/sections/usage/SpendByUser.stories.tsx
+++ b/web/src/sections/usage/SpendByUser.stories.tsx
@@ -1,0 +1,153 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import SpendByUserTable from "@/sections/usage/SpendByUserTable";
+import UserUsageDetailModal from "@/sections/usage/UserUsageDetailModal";
+import type { UsageExportRecord, UsageExportUser } from "@/lib/usage/userUsage";
+
+function mulberry32(seed: number) {
+  return () => {
+    seed |= 0;
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const MODELS = [
+  {
+    model: "claude-opus-5",
+    provider: "anthropic",
+    inRate: 0.0015,
+    outRate: 0.0075,
+  },
+  {
+    model: "claude-sonnet-5",
+    provider: "anthropic",
+    inRate: 0.0003,
+    outRate: 0.0015,
+  },
+  { model: "gpt-5.5", provider: "openai", inRate: 0.0002, outRate: 0.001 },
+  {
+    model: "gpt-5-mini",
+    provider: "openai",
+    inRate: 0.00003,
+    outRate: 0.00015,
+  },
+];
+const FLOWS = ["chat", "craft", "search", "image generation", "summarization"];
+
+const PEOPLE: { email: string; activity: number }[] = [
+  { email: "maya.okafor@acme.dev", activity: 9 },
+  { email: "arjun.mehta@acme.dev", activity: 6.5 },
+  { email: "lena.fischer@acme.dev", activity: 4 },
+  { email: "theo.lindqvist@acme.dev", activity: 3.2 },
+  { email: "priya.raman@acme.dev", activity: 2.1 },
+  { email: "marcus.hall@acme.dev", activity: 1.4 },
+  { email: "sofia.almeida@acme.dev", activity: 0.8 },
+  { email: "kenji.tanaka@acme.dev", activity: 0.35 },
+  { email: "nadia.petrova@acme.dev", activity: 0.2 },
+  { email: "omar.haddad@acme.dev", activity: 0.12 },
+  { email: "grace.chen@acme.dev", activity: 0.4 },
+  { email: "felix.moreau@acme.dev", activity: 0.09 },
+];
+
+function buildUsers(): UsageExportUser[] {
+  const random = mulberry32(20260804);
+  return PEOPLE.map(({ email, activity }) => {
+    const records: UsageExportRecord[] = [];
+    for (let daysAgo = 27; daysAgo >= 0; daysAgo--) {
+      const date = new Date(Date.UTC(2026, 7, 4));
+      date.setUTCDate(date.getUTCDate() - daysAgo);
+      const day = date.toISOString().slice(0, 10);
+      for (const m of MODELS) {
+        if (random() > 0.32) continue;
+        const flow = FLOWS[Math.floor(random() * FLOWS.length)]!;
+        const input = Math.round(activity * (2_000 + random() * 30_000));
+        const output = Math.round(activity * (500 + random() * 6_000));
+        const cache = Math.round(input * random() * 0.6);
+        records.push({
+          model: m.model,
+          provider: m.provider,
+          flow,
+          day,
+          input_tokens: input,
+          output_tokens: output,
+          cache_read_tokens: cache,
+          cost_cents: input * m.inRate + output * m.outRate,
+        });
+      }
+    }
+    const totals = records.reduce(
+      (sum, record) => ({
+        input_tokens: sum.input_tokens + record.input_tokens,
+        output_tokens: sum.output_tokens + record.output_tokens,
+        cache_read_tokens: sum.cache_read_tokens + record.cache_read_tokens,
+        cost_cents: sum.cost_cents + record.cost_cents,
+      }),
+      { input_tokens: 0, output_tokens: 0, cache_read_tokens: 0, cost_cents: 0 }
+    );
+    return { email, totals, records };
+  });
+}
+
+const USERS = buildUsers();
+const PERIOD_LABEL = "Jul 5 – Aug 4, 2026";
+
+const meta: Meta<typeof SpendByUserTable> = {
+  title: "sections/usage/SpendByUser",
+  component: SpendByUserTable,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-[980px] bg-background-neutral-00 p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof SpendByUserTable>;
+
+function FullFlowDemo() {
+  const [selected, setSelected] = useState<string | null>(null);
+  const user = USERS.find((candidate) => candidate.email === selected) ?? null;
+
+  return (
+    <>
+      <SpendByUserTable users={USERS} onSelectUser={setSelected} />
+      {user && (
+        <UserUsageDetailModal
+          user={user}
+          periodLabel={PERIOD_LABEL}
+          onOpenChange={(open) => {
+            if (!open) setSelected(null);
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+export const FullFlow: Story = {
+  render: () => <FullFlowDemo />,
+};
+
+export const TableOnly: Story = {
+  render: () => <SpendByUserTable users={USERS} onSelectUser={() => {}} />,
+};
+
+export const DetailModal: Story = {
+  render: () => (
+    <UserUsageDetailModal
+      user={USERS[0]!}
+      periodLabel={PERIOD_LABEL}
+      onOpenChange={() => {}}
+    />
+  ),
+};
+
+export const Empty: Story = {
+  render: () => <SpendByUserTable users={[]} onSelectUser={() => {}} />,
+};

--- a/web/src/sections/usage/SpendByUserTable.test.tsx
+++ b/web/src/sections/usage/SpendByUserTable.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from "@tests/setup/test-utils";
+import SpendByUserTable from "./SpendByUserTable";
+
+test("opens a user from the keyboard", () => {
+  const onSelectUser = jest.fn();
+
+  render(
+    <SpendByUserTable
+      users={[
+        {
+          email: "ada@example.com",
+          totals: {
+            input_tokens: 1_000,
+            output_tokens: 200,
+            cache_read_tokens: 100,
+            cost_cents: 25,
+          },
+          records: [],
+        },
+      ]}
+      onSelectUser={onSelectUser}
+    />
+  );
+
+  const row = screen.getByRole("row", {
+    name: "View usage details for ada@example.com",
+  });
+  row.focus();
+  fireEvent.keyDown(row, { key: "Enter" });
+
+  expect(onSelectUser).toHaveBeenCalledWith("ada@example.com");
+});

--- a/web/src/sections/usage/SpendByUserTable.tsx
+++ b/web/src/sections/usage/SpendByUserTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   InputSelect,
   InputTypeIn,
@@ -173,6 +173,14 @@ export default function SpendByUserTable({
       ].sort(),
     [users]
   );
+
+  useEffect(() => {
+    if (model !== ALL && !models.includes(model)) setModel(ALL);
+  }, [model, models]);
+
+  useEffect(() => {
+    if (flow !== ALL && !flows.includes(flow)) setFlow(ALL);
+  }, [flow, flows]);
 
   const rows = useMemo(
     () =>

--- a/web/src/sections/usage/SpendByUserTable.tsx
+++ b/web/src/sections/usage/SpendByUserTable.tsx
@@ -182,14 +182,17 @@ export default function SpendByUserTable({
     if (flow !== ALL && !flows.includes(flow)) setFlow(ALL);
   }, [flow, flows]);
 
-  const rows = useMemo(
-    () =>
-      users.flatMap((user) => {
-        const row = filteredRow(user, model, flow);
-        return row ? [row] : [];
-      }),
-    [users, model, flow]
-  );
+  // Filter on email here rather than passing `searchTerm` to Table: Table's
+  // global filter matches any accessor column, so "500" would surface users by
+  // their token counts even though the field is labelled as an email search.
+  const rows = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase();
+    return users.flatMap((user) => {
+      if (query && !user.email.toLowerCase().includes(query)) return [];
+      const row = filteredRow(user, model, flow);
+      return row ? [row] : [];
+    });
+  }, [users, model, flow, searchTerm]);
 
   return (
     <div className="flex flex-col gap-2">
@@ -242,7 +245,6 @@ export default function SpendByUserTable({
         getRowId={(row) => row.email}
         pageSize={10}
         initialSorting={[{ id: "cost_cents", desc: true }]}
-        searchTerm={searchTerm}
         onRowClick={(row) => onSelectUser(row.email)}
         getRowLabel={(row) => `View usage details for ${row.email}`}
         footer={{}}

--- a/web/src/sections/usage/SpendByUserTable.tsx
+++ b/web/src/sections/usage/SpendByUserTable.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  InputSelect,
+  InputTypeIn,
+  Table,
+  Text,
+  createTableColumns,
+} from "@opal/components";
+import { SvgUser } from "@opal/icons";
+import type { UsageExportTotals, UsageExportUser } from "@/lib/usage/userUsage";
+
+const ALL = "__all__";
+
+export interface SpendRow {
+  email: string;
+  cost_cents: number;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+}
+
+export function formatCost(cents: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(cents / 100);
+}
+
+export function formatTokens(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+function emptyTotals(): UsageExportTotals {
+  return {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    cost_cents: 0,
+  };
+}
+
+function filteredRow(
+  user: UsageExportUser,
+  model: string,
+  flow: string
+): SpendRow | null {
+  if (model === ALL && flow === ALL) {
+    return { email: user.email, ...user.totals };
+  }
+  const records = (user.records ?? []).filter(
+    (record) =>
+      (model === ALL || record.model === model) &&
+      (flow === ALL || record.flow === flow)
+  );
+  if (records.length === 0) return null;
+  const totals = records.reduce(
+    (sum, record) => ({
+      input_tokens: sum.input_tokens + record.input_tokens,
+      output_tokens: sum.output_tokens + record.output_tokens,
+      cache_read_tokens: sum.cache_read_tokens + record.cache_read_tokens,
+      cost_cents: sum.cost_cents + record.cost_cents,
+    }),
+    emptyTotals()
+  );
+  return { email: user.email, ...totals };
+}
+
+const tc = createTableColumns<SpendRow>();
+
+function buildColumns() {
+  return [
+    tc.qualifier({ content: "icon", getContent: () => SvgUser }),
+    tc.column("email", {
+      header: "User",
+      weight: 34,
+      cell: (value) => (
+        <span className="underline-offset-2 group-hover/row:underline">
+          <Text font="main-ui-body" color="text-05" nowrap>
+            {value}
+          </Text>
+        </span>
+      ),
+    }),
+    tc.column("cost_cents", {
+      header: "Spend",
+      weight: 14,
+      alignment: "right",
+      cell: (value) => (
+        <span className="tabular-nums">
+          <Text font="main-ui-action" color="text-05" nowrap>
+            {formatCost(value)}
+          </Text>
+        </span>
+      ),
+    }),
+    tc.column("input_tokens", {
+      header: "Input",
+      weight: 14,
+      alignment: "right",
+      cell: (value) => (
+        <span className="tabular-nums">
+          <Text font="main-ui-body" color="text-03" nowrap>
+            {formatTokens(value)}
+          </Text>
+        </span>
+      ),
+    }),
+    tc.column("output_tokens", {
+      header: "Output",
+      weight: 14,
+      alignment: "right",
+      cell: (value) => (
+        <span className="tabular-nums">
+          <Text font="main-ui-body" color="text-03" nowrap>
+            {formatTokens(value)}
+          </Text>
+        </span>
+      ),
+    }),
+    tc.column("cache_read_tokens", {
+      header: "Cache",
+      weight: 14,
+      alignment: "right",
+      cell: (value) => (
+        <span className="tabular-nums">
+          <Text font="main-ui-body" color="text-03" nowrap>
+            {formatTokens(value)}
+          </Text>
+        </span>
+      ),
+    }),
+  ];
+}
+
+const COLUMNS = buildColumns();
+
+interface SpendByUserTableProps {
+  users: UsageExportUser[];
+  onSelectUser: (email: string) => void;
+}
+
+export default function SpendByUserTable({
+  users,
+  onSelectUser,
+}: SpendByUserTableProps) {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [model, setModel] = useState(ALL);
+  const [flow, setFlow] = useState(ALL);
+
+  const models = useMemo(
+    () =>
+      [
+        ...new Set(
+          users.flatMap((user) =>
+            (user.records ?? []).map((record) => record.model)
+          )
+        ),
+      ].sort(),
+    [users]
+  );
+  const flows = useMemo(
+    () =>
+      [
+        ...new Set(
+          users.flatMap((user) =>
+            (user.records ?? []).flatMap((record) =>
+              record.flow !== undefined ? [record.flow] : []
+            )
+          )
+        ),
+      ].sort(),
+    [users]
+  );
+
+  const rows = useMemo(
+    () =>
+      users.flatMap((user) => {
+        const row = filteredRow(user, model, flow);
+        return row ? [row] : [];
+      }),
+    [users, model, flow]
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <div className="min-w-0 flex-1 sm:max-w-72">
+          <InputTypeIn
+            value={searchTerm}
+            placeholder="Search users by email…"
+            aria-label="Search users by email"
+            onChange={(event) => setSearchTerm(event.target.value)}
+          />
+        </div>
+        <div className="flex w-full flex-col gap-2 sm:ml-auto sm:w-auto sm:flex-row">
+          {models.length > 0 && (
+            <div className="w-full sm:w-44">
+              <InputSelect value={model} onValueChange={setModel}>
+                <InputSelect.Trigger placeholder="All models" />
+                <InputSelect.Content>
+                  <InputSelect.Item value={ALL}>All models</InputSelect.Item>
+                  {models.map((option) => (
+                    <InputSelect.Item key={option} value={option}>
+                      {option}
+                    </InputSelect.Item>
+                  ))}
+                </InputSelect.Content>
+              </InputSelect>
+            </div>
+          )}
+          {flows.length > 0 && (
+            <div className="w-full sm:w-40">
+              <InputSelect value={flow} onValueChange={setFlow}>
+                <InputSelect.Trigger placeholder="All flows" />
+                <InputSelect.Content>
+                  <InputSelect.Item value={ALL}>All flows</InputSelect.Item>
+                  {flows.map((option) => (
+                    <InputSelect.Item key={option} value={option}>
+                      {option}
+                    </InputSelect.Item>
+                  ))}
+                </InputSelect.Content>
+              </InputSelect>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <Table
+        data={rows}
+        columns={COLUMNS}
+        getRowId={(row) => row.email}
+        pageSize={10}
+        initialSorting={[{ id: "cost_cents", desc: true }]}
+        searchTerm={searchTerm}
+        onRowClick={(row) => onSelectUser(row.email)}
+        getRowLabel={(row) => `View usage details for ${row.email}`}
+        footer={{}}
+        emptyState={
+          <Text font="main-ui-body" color="text-03">
+            No usage matches the current filters.
+          </Text>
+        }
+      />
+    </div>
+  );
+}

--- a/web/src/sections/usage/SpendByUserTable.tsx
+++ b/web/src/sections/usage/SpendByUserTable.tsx
@@ -151,26 +151,26 @@ export default function SpendByUserTable({
 
   const models = useMemo(
     () =>
-      [
-        ...new Set(
+      Array.from(
+        new Set(
           users.flatMap((user) =>
             (user.records ?? []).map((record) => record.model)
           )
-        ),
-      ].sort(),
+        )
+      ).sort(),
     [users]
   );
   const flows = useMemo(
     () =>
-      [
-        ...new Set(
+      Array.from(
+        new Set(
           users.flatMap((user) =>
             (user.records ?? []).flatMap((record) =>
               record.flow !== undefined ? [record.flow] : []
             )
           )
-        ),
-      ].sort(),
+        )
+      ).sort(),
     [users]
   );
 

--- a/web/src/sections/usage/UserUsageDetailModal.tsx
+++ b/web/src/sections/usage/UserUsageDetailModal.tsx
@@ -17,7 +17,7 @@ interface BreakdownSlice {
 
 function sliceBy(
   user: UsageExportUser,
-  key: (record: { model: string; flow?: string }) => string
+  key: (record: { model: string; flow?: string; provider?: string }) => string
 ): BreakdownSlice[] {
   const byLabel = new Map<string, BreakdownSlice>();
   for (const record of user.records ?? []) {
@@ -202,6 +202,11 @@ export default function UserUsageDetailModal({
       user ? sliceBy(user, (record) => record.flow ?? UNLABELED_FLOW) : [],
     [user]
   );
+  const byProvider = useMemo(
+    () =>
+      user ? sliceBy(user, (record) => record.provider ?? UNLABELED_FLOW) : [],
+    [user]
+  );
   const days = useMemo(() => (user ? dailySpend(user) : []), [user]);
 
   if (!user) return null;
@@ -242,6 +247,11 @@ export default function UserUsageDetailModal({
             <BreakdownList
               title="By flow"
               slices={byFlow}
+              totalCostCents={totals.cost_cents}
+            />
+            <BreakdownList
+              title="By provider"
+              slices={byProvider}
               totalCostCents={totals.cost_cents}
             />
 

--- a/web/src/sections/usage/UserUsageDetailModal.tsx
+++ b/web/src/sections/usage/UserUsageDetailModal.tsx
@@ -201,7 +201,7 @@ export default function UserUsageDetailModal({
   );
   const byFlow = useMemo(
     () =>
-      user ? sliceBy(user, (record) => record.flow ?? UNLABELED_FLOW) : [],
+      user ? sliceBy(user, (record) => record.flow || UNLABELED_FLOW) : [],
     [user]
   );
   const byProvider = useMemo(

--- a/web/src/sections/usage/UserUsageDetailModal.tsx
+++ b/web/src/sections/usage/UserUsageDetailModal.tsx
@@ -31,7 +31,9 @@ function sliceBy(
     slice.tokens += record.input_tokens + record.output_tokens;
     byLabel.set(label, slice);
   }
-  return [...byLabel.values()].sort((a, b) => b.cost_cents - a.cost_cents);
+  return Array.from(byLabel.values()).sort(
+    (a, b) => b.cost_cents - a.cost_cents
+  );
 }
 
 interface DailySpend {
@@ -44,7 +46,7 @@ function dailySpend(user: UsageExportUser): DailySpend[] {
   for (const record of user.records ?? []) {
     byDay.set(record.day, (byDay.get(record.day) ?? 0) + record.cost_cents);
   }
-  const days = [...byDay.keys()].sort();
+  const days = Array.from(byDay.keys()).sort();
   if (days.length === 0) return [];
   const filled: DailySpend[] = [];
   const first = days[0]!;

--- a/web/src/sections/usage/UserUsageDetailModal.tsx
+++ b/web/src/sections/usage/UserUsageDetailModal.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useMemo } from "react";
+import { Button, Modal, ProgressBar, Text, Tooltip } from "@opal/components";
+import { Section } from "@opal/layouts";
+import type { UsageExportUser } from "@/lib/usage/userUsage";
+import { formatCost, formatTokens } from "@/sections/usage/SpendByUserTable";
+
+const MAX_DAILY_COLUMNS = 62;
+const UNLABELED_FLOW = "other";
+
+interface BreakdownSlice {
+  label: string;
+  cost_cents: number;
+  tokens: number;
+}
+
+function sliceBy(
+  user: UsageExportUser,
+  key: (record: { model: string; flow?: string }) => string
+): BreakdownSlice[] {
+  const byLabel = new Map<string, BreakdownSlice>();
+  for (const record of user.records ?? []) {
+    const label = key(record);
+    const slice = byLabel.get(label) ?? {
+      label,
+      cost_cents: 0,
+      tokens: 0,
+    };
+    slice.cost_cents += record.cost_cents;
+    slice.tokens += record.input_tokens + record.output_tokens;
+    byLabel.set(label, slice);
+  }
+  return [...byLabel.values()].sort((a, b) => b.cost_cents - a.cost_cents);
+}
+
+interface DailySpend {
+  day: string;
+  cost_cents: number;
+}
+
+function dailySpend(user: UsageExportUser): DailySpend[] {
+  const byDay = new Map<string, number>();
+  for (const record of user.records ?? []) {
+    byDay.set(record.day, (byDay.get(record.day) ?? 0) + record.cost_cents);
+  }
+  const days = [...byDay.keys()].sort();
+  if (days.length === 0) return [];
+  const filled: DailySpend[] = [];
+  const first = days[0]!;
+  const last = days[days.length - 1]!;
+  const cursor = new Date(`${first}T00:00:00Z`);
+  const end = new Date(`${last}T00:00:00Z`);
+  while (cursor <= end && filled.length < MAX_DAILY_COLUMNS + 1) {
+    const day = cursor.toISOString().slice(0, 10);
+    filled.push({ day, cost_cents: byDay.get(day) ?? 0 });
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  return filled;
+}
+
+function formatDayLabel(day: string): string {
+  return new Date(`${day}T00:00:00`).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function StatCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex min-w-0 flex-col gap-0.5 px-3 first:pl-0 last:pr-0">
+      <Text font="secondary-body" color="text-03" nowrap>
+        {label}
+      </Text>
+      <span className="tabular-nums">
+        <Text font="main-content-emphasis" nowrap>
+          {value}
+        </Text>
+      </span>
+    </div>
+  );
+}
+
+interface BreakdownListProps {
+  title: string;
+  slices: BreakdownSlice[];
+  totalCostCents: number;
+}
+
+function BreakdownList({ title, slices, totalCostCents }: BreakdownListProps) {
+  if (slices.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-2">
+      <Text font="main-ui-action" color="text-04">
+        {title}
+      </Text>
+      <div className="flex flex-col gap-2.5">
+        {slices.map((slice) => {
+          const share =
+            totalCostCents > 0 ? slice.cost_cents / totalCostCents : 0;
+          return (
+            <div key={slice.label} className="flex flex-col gap-1">
+              <div className="flex items-baseline justify-between gap-3">
+                <span className="min-w-0 truncate">
+                  <Text font="main-ui-body" color="text-05" nowrap>
+                    {slice.label}
+                  </Text>
+                </span>
+                <span className="shrink-0 tabular-nums">
+                  <Text font="main-ui-body" color="text-05">
+                    {formatCost(slice.cost_cents)}
+                  </Text>
+                  <Text font="secondary-body" color="text-03">
+                    {` · ${(share * 100).toFixed(share >= 0.1 ? 0 : 1)}% · ${formatTokens(slice.tokens)} tokens`}
+                  </Text>
+                </span>
+              </div>
+              <ProgressBar
+                value={slice.cost_cents}
+                max={totalCostCents}
+                aria-label={`${slice.label} share of spend`}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function DailySpendStrip({ days }: { days: DailySpend[] }) {
+  const max = Math.max(...days.map((day) => day.cost_cents));
+  if (days.length < 2 || max <= 0 || days.length > MAX_DAILY_COLUMNS) {
+    return null;
+  }
+  return (
+    <div className="flex flex-col gap-1">
+      <Text font="main-ui-action" color="text-04">
+        Daily spend
+      </Text>
+      <div
+        role="img"
+        aria-label={`Daily spend for the selected period: ${days
+          .map(
+            (day) => `${formatDayLabel(day.day)}, ${formatCost(day.cost_cents)}`
+          )
+          .join("; ")}`}
+        className="flex h-14 items-end gap-[2px]"
+      >
+        {days.map((day) => (
+          <Tooltip
+            key={day.day}
+            tooltip={`${formatDayLabel(day.day)} · ${formatCost(day.cost_cents)}`}
+            side="top"
+            delayDuration={0}
+          >
+            {/* Full-height hit target so quiet days are hoverable too. */}
+            <div className="flex h-full flex-1 items-end">
+              <div
+                className="w-full rounded-t-[2px] bg-theme-blue-05"
+                style={{
+                  height:
+                    day.cost_cents > 0
+                      ? `${Math.max((day.cost_cents / max) * 100, 4)}%`
+                      : "2px",
+                  opacity: day.cost_cents > 0 ? 1 : 0.25,
+                }}
+              />
+            </div>
+          </Tooltip>
+        ))}
+      </div>
+      <div className="flex justify-between">
+        <Text font="secondary-body" color="text-03">
+          {formatDayLabel(days[0]!.day)}
+        </Text>
+        <Text font="secondary-body" color="text-03">
+          {formatDayLabel(days[days.length - 1]!.day)}
+        </Text>
+      </div>
+    </div>
+  );
+}
+
+export interface UserUsageDetailModalProps {
+  user: UsageExportUser | null;
+  periodLabel?: string;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function UserUsageDetailModal({
+  user,
+  periodLabel,
+  onOpenChange,
+}: UserUsageDetailModalProps) {
+  const byModel = useMemo(
+    () => (user ? sliceBy(user, (record) => record.model) : []),
+    [user]
+  );
+  const byFlow = useMemo(
+    () =>
+      user ? sliceBy(user, (record) => record.flow ?? UNLABELED_FLOW) : [],
+    [user]
+  );
+  const days = useMemo(() => (user ? dailySpend(user) : []), [user]);
+
+  if (!user) return null;
+  const totals = user.totals;
+
+  return (
+    <Modal open onOpenChange={onOpenChange}>
+      <Modal.Content width="md" height="fit">
+        <Modal.Header
+          title={user.email}
+          description={periodLabel}
+          onClose={() => onOpenChange(false)}
+        />
+        <Modal.Body>
+          <Section alignItems="stretch" height="auto" gap={1.5}>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+              <StatCell label="Spend" value={formatCost(totals.cost_cents)} />
+              <StatCell
+                label="Input tokens"
+                value={formatTokens(totals.input_tokens)}
+              />
+              <StatCell
+                label="Output tokens"
+                value={formatTokens(totals.output_tokens)}
+              />
+              <StatCell
+                label="Cache reads"
+                value={formatTokens(totals.cache_read_tokens)}
+              />
+            </div>
+
+            <DailySpendStrip days={days} />
+            <BreakdownList
+              title="By model"
+              slices={byModel}
+              totalCostCents={totals.cost_cents}
+            />
+            <BreakdownList
+              title="By flow"
+              slices={byFlow}
+              totalCostCents={totals.cost_cents}
+            />
+
+            {byModel.length === 0 && (
+              <Text font="main-ui-body" color="text-03">
+                No per-model records for this period.
+              </Text>
+            )}
+          </Section>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button prominence="secondary" onClick={() => onOpenChange(false)}>
+            Done
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  );
+}

--- a/web/src/sections/usage/UserUsageDetailModal.tsx
+++ b/web/src/sections/usage/UserUsageDetailModal.tsx
@@ -206,7 +206,7 @@ export default function UserUsageDetailModal({
   );
   const byProvider = useMemo(
     () =>
-      user ? sliceBy(user, (record) => record.provider ?? UNLABELED_FLOW) : [],
+      user ? sliceBy(user, (record) => record.provider || UNLABELED_FLOW) : [],
     [user]
   );
   const days = useMemo(() => (user ? dailySpend(user) : []), [user]);

--- a/web/src/views/admin/PerUserUsagePanel.tsx
+++ b/web/src/views/admin/PerUserUsagePanel.tsx
@@ -1,312 +1,191 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { Button, Card, InputTypeIn, MessageCard, Text } from "@opal/components";
-import { SvgChevronLeft, SvgChevronRight, SvgX } from "@opal/icons";
-import { PageLoader, toast } from "@opal/layouts";
-import {
-  resetUserUsage,
-  useUsageExport,
-  UsageExportUser,
-} from "@/lib/usage/userUsage";
+import React, { useMemo, useState } from "react";
+import { Card, MessageCard, Text } from "@opal/components";
+import { SvgX } from "@opal/icons";
+import { PageLoader } from "@opal/layouts";
+import type { DateRange } from "@/components/dateRangeSelectors/AdminDateRangeSelector";
+import { useUsageExport } from "@/lib/usage/userUsage";
+import SpendByUserTable, {
+  formatCost,
+  formatTokens,
+} from "@/sections/usage/SpendByUserTable";
+import UserUsageDetailModal from "@/sections/usage/UserUsageDetailModal";
 
-const PAGE_SIZE = 10;
-
-type SortKey =
-  | "email"
-  | "input_tokens"
-  | "output_tokens"
-  | "cache_read_tokens"
-  | "cost_cents";
-type SortDir = "asc" | "desc";
-
-function formatTokens(n: number): string {
-  return n.toLocaleString();
+function formatDate(value: string): string {
+  return new Date(`${value}T00:00:00`).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
 }
 
-function formatCost(cents: number): string {
-  return `$${(cents / 100).toFixed(2)}`;
-}
-
-function sortValue(user: UsageExportUser, key: SortKey): number | string {
-  if (key === "email") return user.email.toLowerCase();
-  return user.totals[key];
-}
-
-interface UsageRowProps {
-  user: UsageExportUser;
-  onReset: () => void;
-}
-
-function UsageRow({ user, onReset }: UsageRowProps) {
-  const [resetting, setResetting] = useState(false);
-  const totals = user.totals;
-
-  async function handleReset() {
-    setResetting(true);
-    try {
-      await resetUserUsage(user.email);
-      toast.success(`Reset usage for ${user.email}.`);
-      onReset();
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "unknown error";
-      toast.error(`Failed to reset usage: ${message}`);
-    } finally {
-      setResetting(false);
-    }
-  }
-
-  return (
-    <div
-      className="flex flex-row items-center gap-4 py-2"
-      data-testid={`usage-row-${user.email}`}
-    >
-      <div className="flex-1 truncate">
-        <Text font="main-ui-body">{user.email}</Text>
-      </div>
-      <div className="w-24 text-right">
-        <Text font="main-ui-body" color="text-03">
-          {formatTokens(totals.input_tokens)}
-        </Text>
-      </div>
-      <div className="w-24 text-right">
-        <Text font="main-ui-body" color="text-03">
-          {formatTokens(totals.output_tokens)}
-        </Text>
-      </div>
-      <div className="w-24 text-right">
-        <Text font="main-ui-body" color="text-03">
-          {formatTokens(totals.cache_read_tokens)}
-        </Text>
-      </div>
-      <div className="w-24 text-right">
-        <Text font="main-ui-body">{formatCost(totals.cost_cents)}</Text>
-      </div>
-      <Button
-        variant="default"
-        prominence="tertiary"
-        size="sm"
-        disabled={resetting}
-        onClick={handleReset}
-      >
-        Reset
-      </Button>
-    </div>
-  );
-}
-
-interface SortHeaderProps {
-  label: string;
-  sortKey: SortKey;
-  activeKey: SortKey;
-  dir: SortDir;
-  onSort: (key: SortKey) => void;
-  align: "left" | "right";
-}
-
-function SortHeader({
+function SummaryMetric({
   label,
-  sortKey,
-  activeKey,
-  dir,
-  onSort,
-  align,
-}: SortHeaderProps) {
-  const active = activeKey === sortKey;
-  const indicator = active ? (dir === "desc" ? " ↓" : " ↑") : "";
+  value,
+  detail,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+}) {
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={() => onSort(sortKey)}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onSort(sortKey);
-        }
-      }}
-      className={`cursor-pointer select-none ${
-        align === "right" ? "w-24 text-right" : "flex-1"
-      }`}
-    >
-      <Text font="main-ui-action" color={active ? "text-05" : "text-03"}>
-        {`${label}${indicator}`}
+    <div className="flex min-w-0 flex-col gap-0.5 px-3 py-2 first:pl-0 last:pr-0">
+      <Text font="secondary-body" color="text-03">
+        {label}
       </Text>
+      <span className="tabular-nums">
+        <Text font="heading-h3">{value}</Text>
+      </span>
+      <span className="block min-w-0 truncate" title={detail}>
+        <Text font="secondary-body" color="text-03">
+          {detail}
+        </Text>
+      </span>
     </div>
   );
 }
 
-/** Searchable, sortable admin per-user usage totals. */
-export default function PerUserUsagePanel() {
-  const { usage, isLoading, error, refetch } = useUsageExport();
-  const [page, setPage] = useState(0);
-  const [query, setQuery] = useState("");
-  const [sortKey, setSortKey] = useState<SortKey>("cost_cents");
-  const [sortDir, setSortDir] = useState<SortDir>("desc");
+interface PerUserUsagePanelProps {
+  timeRange?: DateRange;
+  headerRight?: React.ReactNode;
+}
+
+export default function PerUserUsagePanel({
+  timeRange,
+  headerRight,
+}: PerUserUsagePanelProps) {
+  const { usage, isLoading, error } = useUsageExport(timeRange);
+  const [selectedEmail, setSelectedEmail] = useState<string | null>(null);
 
   const users = usage?.users ?? [];
+  const selectedUser =
+    users.find((user) => user.email === selectedEmail) ?? null;
 
-  const visible = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    const filtered = q
-      ? users.filter((u) => u.email.toLowerCase().includes(q))
-      : users;
-    return [...filtered].sort((a, b) => {
-      const av = sortValue(a, sortKey);
-      const bv = sortValue(b, sortKey);
-      const cmp =
-        typeof av === "string" && typeof bv === "string"
-          ? av.localeCompare(bv)
-          : (av as number) - (bv as number);
-      return sortDir === "asc" ? cmp : -cmp;
-    });
-  }, [users, query, sortKey, sortDir]);
+  const totalCostCents = useMemo(
+    () => users.reduce((total, user) => total + user.totals.cost_cents, 0),
+    [users]
+  );
+  const totalTokens = useMemo(
+    () =>
+      users.reduce(
+        (total, user) =>
+          total + user.totals.input_tokens + user.totals.output_tokens,
+        0
+      ),
+    [users]
+  );
+  const activeUsers = users.filter(
+    (user) =>
+      user.totals.input_tokens > 0 ||
+      user.totals.output_tokens > 0 ||
+      user.totals.cache_read_tokens > 0
+  ).length;
+  const topSpender = users.reduce<(typeof users)[number] | null>(
+    (top, user) =>
+      top === null || user.totals.cost_cents > top.totals.cost_cents
+        ? user
+        : top,
+    null
+  );
 
-  const pageCount = Math.max(1, Math.ceil(visible.length / PAGE_SIZE));
+  const header = (
+    <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-0.5">
+        <Text font="heading-h3">Usage this period</Text>
+        <Text font="secondary-body" color="text-03">
+          {usage
+            ? `${formatDate(usage.start)} – ${formatDate(usage.end)} · Costs are calculated from recorded model usage.`
+            : "Per-user spend and token usage for the selected period."}
+        </Text>
+      </div>
+      {headerRight}
+    </div>
+  );
 
-  // Jump back to the first page whenever the filter or sort reshapes the list.
-  useEffect(() => {
-    setPage(0);
-  }, [query, sortKey, sortDir]);
-
-  // Clamp the page when the list shrinks (e.g. a reset drops a user off).
-  useEffect(() => {
-    if (page > pageCount - 1) setPage(pageCount - 1);
-  }, [page, pageCount]);
-
-  function handleSort(key: SortKey) {
-    if (key === sortKey) {
-      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
-    } else {
-      setSortKey(key);
-      // Numeric columns lead high→low (leaderboard); email reads A→Z.
-      setSortDir(key === "email" ? "asc" : "desc");
-    }
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-4">
+        {header}
+        <PageLoader />
+      </div>
+    );
   }
-
-  if (isLoading) return <PageLoader />;
   if (error) {
     return (
-      <MessageCard
-        variant="error"
-        icon={SvgX}
-        title="Failed to load per-user usage."
-      />
+      <div className="flex flex-col gap-4">
+        {header}
+        <MessageCard
+          variant="error"
+          icon={SvgX}
+          title="Failed to load usage for this period."
+        />
+      </div>
     );
   }
 
-  const pageUsers = visible.slice(
-    page * PAGE_SIZE,
-    page * PAGE_SIZE + PAGE_SIZE
-  );
-
   return (
-    <Card border="solid" rounding="lg" padding="sm">
-      <div className="flex flex-col gap-2">
-        <Text font="heading-h3">Per-user usage</Text>
-        <Text font="secondary-body" color="text-03">
-          Tokens (input, output, cache reads) and cost per user over the report
-          window. Click a column to rank by it, or search by email. Reset clears
-          usage from every currently active limit window.
-        </Text>
+    <div className="flex flex-col gap-4">
+      {header}
 
-        <InputTypeIn
-          value={query}
-          placeholder="Search users by email…"
-          onChange={(e) => setQuery(e.target.value)}
-        />
+      <Card border="solid" rounding="lg" padding="sm">
+        <div className="grid grid-cols-2 gap-2 lg:grid-cols-4">
+          <SummaryMetric
+            label="Workspace spend"
+            value={formatCost(totalCostCents)}
+            detail="Across all listed users"
+          />
+          <SummaryMetric
+            label="Total tokens"
+            value={formatTokens(totalTokens)}
+            detail="Input (including cache reads) and output"
+          />
+          <SummaryMetric
+            label="Active users"
+            value={activeUsers.toLocaleString()}
+            detail={`${users.length.toLocaleString()} users with records`}
+          />
+          <SummaryMetric
+            label="Top spender"
+            value={topSpender ? formatCost(topSpender.totals.cost_cents) : "—"}
+            detail={topSpender?.email ?? "No spend recorded"}
+          />
+        </div>
+      </Card>
+
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-0.5">
+          <Text font="heading-h3">Spend by user</Text>
+          <Text font="secondary-body" color="text-03">
+            Filter by model or flow, and click a user for their full breakdown.
+            Enforcement limits are managed below.
+          </Text>
+        </div>
 
         {users.length === 0 ? (
-          <Text font="main-ui-body" color="text-03">
-            No usage recorded yet.
-          </Text>
-        ) : visible.length === 0 ? (
-          <Text font="main-ui-body" color="text-03">
-            {`No users match "${query}".`}
-          </Text>
+          <Card border="solid" rounding="lg" padding="sm">
+            <Text font="main-ui-body" color="text-03">
+              No usage recorded for this period.
+            </Text>
+          </Card>
         ) : (
-          <>
-            <div className="overflow-x-auto">
-              <div className="min-w-[740px] flex flex-col divide-y divide-border-01">
-                <div className="flex flex-row items-center gap-4 py-2">
-                  <SortHeader
-                    label="User"
-                    sortKey="email"
-                    activeKey={sortKey}
-                    dir={sortDir}
-                    onSort={handleSort}
-                    align="left"
-                  />
-                  <SortHeader
-                    label="Input"
-                    sortKey="input_tokens"
-                    activeKey={sortKey}
-                    dir={sortDir}
-                    onSort={handleSort}
-                    align="right"
-                  />
-                  <SortHeader
-                    label="Output"
-                    sortKey="output_tokens"
-                    activeKey={sortKey}
-                    dir={sortDir}
-                    onSort={handleSort}
-                    align="right"
-                  />
-                  <SortHeader
-                    label="Cache"
-                    sortKey="cache_read_tokens"
-                    activeKey={sortKey}
-                    dir={sortDir}
-                    onSort={handleSort}
-                    align="right"
-                  />
-                  <SortHeader
-                    label="Cost"
-                    sortKey="cost_cents"
-                    activeKey={sortKey}
-                    dir={sortDir}
-                    onSort={handleSort}
-                    align="right"
-                  />
-                  <div className="w-[68px]" />
-                </div>
-                {pageUsers.map((user) => (
-                  <UsageRow key={user.email} user={user} onReset={refetch} />
-                ))}
-              </div>
-            </div>
-
-            {pageCount > 1 && (
-              <div className="flex flex-row items-center justify-end gap-3 pt-2">
-                <Button
-                  variant="default"
-                  prominence="tertiary"
-                  size="sm"
-                  icon={SvgChevronLeft}
-                  tooltip="Previous page"
-                  aria-label="Previous page"
-                  disabled={page === 0}
-                  onClick={() => setPage((p) => Math.max(0, p - 1))}
-                />
-                <Text font="main-ui-body" color="text-03">
-                  {`Page ${page + 1} of ${pageCount} · ${visible.length} users`}
-                </Text>
-                <Button
-                  variant="default"
-                  prominence="tertiary"
-                  size="sm"
-                  icon={SvgChevronRight}
-                  tooltip="Next page"
-                  aria-label="Next page"
-                  disabled={page >= pageCount - 1}
-                  onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
-                />
-              </div>
-            )}
-          </>
+          <SpendByUserTable users={users} onSelectUser={setSelectedEmail} />
         )}
       </div>
-    </Card>
+
+      {selectedUser && (
+        <UserUsageDetailModal
+          user={selectedUser}
+          periodLabel={
+            usage
+              ? `${formatDate(usage.start)} – ${formatDate(usage.end)}`
+              : undefined
+          }
+          onOpenChange={(open) => {
+            if (!open) setSelectedEmail(null);
+          }}
+        />
+      )}
+    </div>
   );
 }

--- a/web/tests/e2e/admin/per_user_usage.spec.ts
+++ b/web/tests/e2e/admin/per_user_usage.spec.ts
@@ -4,15 +4,14 @@ import { TEST_ADMIN_CREDENTIALS } from "@tests/e2e/constants";
 import { AdminUsagePage } from "@tests/e2e/pages/AdminUsagePage";
 
 /**
- * Admin per-user usage table + Reset. Real e2e (no mocking): the admin sends a
- * chat to accrue usage, then the Usage Statistics page must list that usage per
- * user, and the Reset action must clear it. Requires a working LLM provider in
- * the e2e environment so the chat records token usage.
+ * Admin per-user usage table. Real e2e (no mocking): the admin sends a chat to
+ * accrue usage, then the Usage page must list that usage per user. Requires a
+ * working LLM provider in the e2e environment so the chat records token usage.
  */
 test.use({ storageState: "admin_auth.json" });
 
-test.describe("admin per-user usage table + reset", () => {
-  test("usage shows per user and Reset clears it", async ({ page }) => {
+test.describe("admin per-user usage table", () => {
+  test("usage shows per user", async ({ page }) => {
     // 1) Accrue usage by sending a chat as the admin.
     const chat = new ChatPage(page);
     await chat.goto();
@@ -22,6 +21,6 @@ test.describe("admin per-user usage table + reset", () => {
 
     const usage = new AdminUsagePage(page);
     await usage.goto();
-    await usage.resetUser(TEST_ADMIN_CREDENTIALS.email);
+    await usage.expectUser(TEST_ADMIN_CREDENTIALS.email);
   });
 });

--- a/web/tests/e2e/pages/AdminUsagePage.ts
+++ b/web/tests/e2e/pages/AdminUsagePage.ts
@@ -1,14 +1,12 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 
-const RESET_ENDPOINT = "/api/admin/usage/reset";
-
 export class AdminUsagePage {
   readonly page: Page;
   readonly usageRows: Locator;
 
   constructor(page: Page) {
     this.page = page;
-    this.usageRows = page.locator('[data-testid^="usage-row-"]');
+    this.usageRows = page.locator('tr[aria-label^="View usage details for "]');
   }
 
   async goto(): Promise<void> {
@@ -16,19 +14,10 @@ export class AdminUsagePage {
     await expect(this.usageRows.first()).toBeVisible({ timeout: 15_000 });
   }
 
-  async resetUser(email: string): Promise<void> {
-    const row = this.page.getByTestId(`usage-row-${email}`);
-    await expect(row).toBeVisible();
-    const responsePromise = this.page.waitForResponse(
-      (response) =>
-        response.url().includes(RESET_ENDPOINT) &&
-        response.request().method() === "POST"
-    );
-
-    await row.getByRole("button", { name: "Reset" }).click();
-    expect((await responsePromise).ok()).toBeTruthy();
-    await expect(this.page.getByText(`Reset usage for ${email}.`)).toBeVisible({
-      timeout: 10_000,
+  async expectUser(email: string): Promise<void> {
+    const row = this.page.getByRole("row", {
+      name: `View usage details for ${email}`,
     });
+    await expect(row).toBeVisible();
   }
 }


### PR DESCRIPTION
## Summary

- Add the shared Opal date-range picker, calendar, and table affordances used by admin usage.
- Add per-user spend and usage views with model and flow/provider detail, filters, and user detail inspection.
- Add analytics navigation and a correlated usage-report download flow that remains safe for overlapping requests.
- Keep the usage page focused on analytics; spending limits follow in the next stacked PR.

## Verification

- bun run test -- --runInBand src/components/dateRangeSelectors/AdminDateRangeSelector.test.tsx src/sections/usage/SpendByUserTable.test.tsx (2 suites, 4 tests passed)
- bun run types:check passed
- bun run lint passed
- Pre-commit checks passed.
- Reporting integration cases were collected but skipped because local integration prerequisites are unavailable.
- Playwright was not run because the local admin setup is not authorized for the configured test account.

## Known minor items

- The export remains intentionally unpaginated; large workspaces may need pagination in a follow-up.
- Live browser verification still needs a configured admin workspace.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check