### PR TITLE
feat(usage): polish spending limits inside the usage workspace

### DIFF
--- a/backend/onyx/db/token_limit.py
+++ b/backend/onyx/db/token_limit.py
@@ -7,7 +7,13 @@ from sqlalchemy.orm import Session
 
 from onyx.configs.constants import TokenRateLimitScope
 from onyx.db.models import TokenRateLimit, TokenRateLimit__UserGroup, User__UserGroup
-from onyx.server.token_rate_limits.models import TokenRateLimitArgs
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.token_rate_limits.models import (
+    MAX_TOKEN_BUDGET_THOUSANDS,
+    TokenRateLimitArgs,
+    TokenRateLimitUpdateArgs,
+)
 
 
 def fetch_all_user_token_rate_limits(
@@ -111,11 +117,21 @@ def insert_global_token_rate_limit(
 def update_token_rate_limit(
     db_session: Session,
     token_rate_limit_id: int,
-    token_rate_limit_settings: TokenRateLimitArgs,
+    token_rate_limit_settings: TokenRateLimitUpdateArgs,
 ) -> TokenRateLimit:
     token_limit = db_session.get(TokenRateLimit, token_rate_limit_id)
     if token_limit is None:
         raise ValueError(f"TokenRateLimit with id '{token_rate_limit_id}' not found")
+
+    if (
+        token_rate_limit_settings.token_budget is not None
+        and token_rate_limit_settings.token_budget > MAX_TOKEN_BUDGET_THOUSANDS
+        and token_rate_limit_settings.token_budget != token_limit.token_budget
+    ):
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Token budgets cannot exceed 1T tokens.",
+        )
 
     token_limit.enabled = token_rate_limit_settings.enabled
     token_limit.token_budget = token_rate_limit_settings.token_budget

--- a/backend/onyx/server/token_rate_limits/api.py
+++ b/backend/onyx/server/token_rate_limits/api.py
@@ -18,6 +18,7 @@ from onyx.server.query_and_chat.token_limit import (
 from onyx.server.token_rate_limits.models import (
     TokenRateLimitArgs,
     TokenRateLimitDisplay,
+    TokenRateLimitUpdateArgs,
 )
 
 router = APIRouter(prefix="/admin/token-rate-limits", tags=PUBLIC_API_TAGS)
@@ -61,7 +62,7 @@ General Token Limit Settings
 @router.put("/rate-limit/{token_rate_limit_id}")
 def update_token_limit_settings(
     token_rate_limit_id: int,
-    token_limit_settings: TokenRateLimitArgs,
+    token_limit_settings: TokenRateLimitUpdateArgs,
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> TokenRateLimitDisplay:

--- a/backend/onyx/server/token_rate_limits/models.py
+++ b/backend/onyx/server/token_rate_limits/models.py
@@ -1,3 +1,5 @@
+from typing import Self
+
 from pydantic import BaseModel, Field, model_validator
 
 from onyx.db.models import TokenRateLimit
@@ -12,15 +14,14 @@ from onyx.db.user_usage import (
 MAX_TOKEN_BUDGET_THOUSANDS = 1_000_000_000
 
 
-class TokenRateLimitArgs(BaseModel):
+class _TokenRateLimitArgsBase(BaseModel):
     enabled: bool
-    # Null side exempt. ge/gt=0 — zero/NaN budgets silently disable or break the gate.
-    token_budget: int | None = Field(default=None, ge=1, le=MAX_TOKEN_BUDGET_THOUSANDS)
+    token_budget: int | None = Field(default=None, ge=1)
     period_hours: int = Field(gt=0)
     cost_budget_cents: float | None = Field(default=None, gt=0, allow_inf_nan=False)
 
     @model_validator(mode="after")
-    def validate_budget_set(self) -> "TokenRateLimitArgs":
+    def validate_budget_set(self) -> Self:
         if self.token_budget is None and self.cost_budget_cents is None:
             raise ValueError("Either token_budget or cost_budget_cents must be set")
         if (
@@ -34,6 +35,14 @@ class TokenRateLimitArgs(BaseModel):
         ):
             raise ValueError(COST_BUDGET_PERIOD_ERROR)
         return self
+
+
+class TokenRateLimitArgs(_TokenRateLimitArgsBase):
+    token_budget: int | None = Field(default=None, ge=1, le=MAX_TOKEN_BUDGET_THOUSANDS)
+
+
+class TokenRateLimitUpdateArgs(_TokenRateLimitArgsBase):
+    pass
 
 
 class TokenRateLimitDisplay(BaseModel):

--- a/backend/onyx/server/token_rate_limits/models.py
+++ b/backend/onyx/server/token_rate_limits/models.py
@@ -8,11 +8,14 @@ from onyx.db.user_usage import (
     normalize_token_period_hours,
 )
 
+# 1T tokens; stored in thousands so the ceiling stays inside the int32 column.
+MAX_TOKEN_BUDGET_THOUSANDS = 1_000_000_000
+
 
 class TokenRateLimitArgs(BaseModel):
     enabled: bool
     # Null side exempt. ge/gt=0 — zero/NaN budgets silently disable or break the gate.
-    token_budget: int | None = Field(default=None, ge=1)
+    token_budget: int | None = Field(default=None, ge=1, le=MAX_TOKEN_BUDGET_THOUSANDS)
     period_hours: int = Field(gt=0)
     cost_budget_cents: float | None = Field(default=None, gt=0, allow_inf_nan=False)
 

--- a/backend/tests/unit/onyx/server/test_token_rate_limit_budget_models.py
+++ b/backend/tests/unit/onyx/server/test_token_rate_limit_budget_models.py
@@ -1,15 +1,20 @@
 import datetime
+from unittest.mock import Mock
 
 import pytest
 from pydantic import ValidationError
 
 from onyx.configs.constants import TokenRateLimitScope
 from onyx.db.models import TokenRateLimit
+from onyx.db.token_limit import update_token_rate_limit
 from onyx.db.user_usage import TokenUsageBucket
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.query_and_chat.token_limit import _token_budget_reset
 from onyx.server.token_rate_limits.models import (
+    MAX_TOKEN_BUDGET_THOUSANDS,
     TokenRateLimitArgs,
     TokenRateLimitDisplay,
+    TokenRateLimitUpdateArgs,
 )
 
 
@@ -61,6 +66,66 @@ def test_token_rate_limit_args_requires_a_budget() -> None:
 def test_token_rate_limit_args_requires_whole_utc_days() -> None:
     with pytest.raises(ValidationError, match="whole UTC days"):
         TokenRateLimitArgs(enabled=True, token_budget=1, period_hours=25)
+
+
+def test_token_rate_limit_args_rejects_budgets_above_one_trillion() -> None:
+    with pytest.raises(ValidationError):
+        TokenRateLimitArgs(
+            enabled=True,
+            token_budget=MAX_TOKEN_BUDGET_THOUSANDS + 1,
+            period_hours=24,
+        )
+
+
+def test_token_rate_limit_update_args_accepts_legacy_budget() -> None:
+    args = TokenRateLimitUpdateArgs(
+        enabled=False,
+        token_budget=MAX_TOKEN_BUDGET_THOUSANDS + 1,
+        period_hours=24,
+    )
+
+    assert args.token_budget == MAX_TOKEN_BUDGET_THOUSANDS + 1
+
+
+def test_legacy_budget_can_be_toggled_without_increasing_it() -> None:
+    legacy_budget = MAX_TOKEN_BUDGET_THOUSANDS + 1
+    limit = _rate_limit(legacy_budget)
+    limit.id = 7
+    session = Mock()
+    session.get.return_value = limit
+
+    updated = update_token_rate_limit(
+        session,
+        7,
+        TokenRateLimitUpdateArgs(
+            enabled=False,
+            token_budget=legacy_budget,
+            period_hours=24,
+        ),
+    )
+
+    assert updated.enabled is False
+    session.commit.assert_called_once()
+
+
+def test_existing_limit_cannot_be_raised_above_one_trillion() -> None:
+    limit = _rate_limit(MAX_TOKEN_BUDGET_THOUSANDS)
+    limit.id = 7
+    session = Mock()
+    session.get.return_value = limit
+
+    with pytest.raises(OnyxError):
+        update_token_rate_limit(
+            session,
+            7,
+            TokenRateLimitUpdateArgs(
+                enabled=True,
+                token_budget=MAX_TOKEN_BUDGET_THOUSANDS + 1,
+                period_hours=24,
+            ),
+        )
+
+    session.commit.assert_not_called()
 
 
 def test_token_rate_limit_uses_current_utc_day() -> None:

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.test.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.test.tsx
@@ -1,19 +1,79 @@
-import { render, screen, setupUser } from "@tests/setup/test-utils";
+import { fireEvent, render, screen, waitFor } from "@tests/setup/test-utils";
 import CreateRateLimitModal from "@/app/admin/token-rate-limits/CreateRateLimitModal";
 
-test("requires at least one enforcement budget", async () => {
-  const user = setupUser();
+beforeEach(() => {
+  global.fetch = jest
+    .fn()
+    .mockResolvedValue({ ok: true, json: async () => [] } as Response);
+});
+
+test("requires a cost budget when no token budget is set", async () => {
   const onSubmit = jest.fn().mockResolvedValue(undefined);
 
   render(
     <CreateRateLimitModal isOpen setIsOpen={jest.fn()} onSubmit={onSubmit} />
   );
 
-  await user.type(screen.getByLabelText("Time Window (UTC Days)"), "1");
-  await user.click(screen.getByRole("button", { name: "Create" }));
+  const modal = screen.getByRole("dialog");
+  const resetPeriod = screen.getByRole("textbox", { name: /Reset period/ });
 
-  expect(
-    await screen.findByText("Set a token budget and/or a cost budget")
-  ).toBeInTheDocument();
+  expect(modal).toHaveAttribute("data-width", "sm");
+  expect(modal).toHaveAttribute("data-height", "fit");
+  expect(resetPeriod).toHaveAttribute("type", "text");
+  expect(resetPeriod).toHaveAttribute("inputmode", "numeric");
+  expect(resetPeriod).toHaveValue("30");
+
+  fireEvent.click(screen.getByRole("button", { name: "Create limit" }));
+
+  expect(await screen.findByText("Enter a cost budget")).toBeInTheDocument();
   expect(onSubmit).not.toHaveBeenCalled();
+});
+
+test("formats and submits a token-only budget", async () => {
+  const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+  render(
+    <CreateRateLimitModal isOpen setIsOpen={jest.fn()} onSubmit={onSubmit} />
+  );
+
+  const tokenBudget = screen.getByRole("textbox", {
+    name: /Token budget/,
+  });
+
+  fireEvent.change(tokenBudget, {
+    target: { value: "1500000000" },
+  });
+
+  expect(tokenBudget).toHaveValue("1,500,000,000");
+
+  fireEvent.click(screen.getByRole("button", { name: "Create limit" }));
+
+  await waitFor(() =>
+    expect(onSubmit).toHaveBeenCalledWith(
+      "global",
+      720,
+      1_500_000,
+      null,
+      expect.any(Number)
+    )
+  );
+});
+
+test("supports arrow-key navigation between scope options", async () => {
+  render(
+    <CreateRateLimitModal
+      isOpen
+      setIsOpen={jest.fn()}
+      onSubmit={jest.fn().mockResolvedValue(undefined)}
+    />
+  );
+
+  const workspace = screen.getByRole("radio", { name: "Workspace" });
+  const perUser = screen.getByRole("radio", { name: "Per user" });
+
+  workspace.focus();
+  fireEvent.keyDown(workspace, { key: "ArrowRight" });
+
+  await waitFor(() => expect(perUser).toHaveAttribute("aria-checked", "true"));
+  expect(perUser).toHaveFocus();
 });

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.test.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.test.tsx
@@ -25,7 +25,9 @@ test("requires a cost budget when no token budget is set", async () => {
 
   fireEvent.click(screen.getByRole("button", { name: "Create limit" }));
 
-  expect(await screen.findByText("Enter a cost budget")).toBeInTheDocument();
+  expect(
+    await screen.findByText("Enter a cost budget, a token budget, or both")
+  ).toBeInTheDocument();
   expect(onSubmit).not.toHaveBeenCalled();
 });
 

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.test.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.test.tsx
@@ -59,6 +59,24 @@ test("formats and submits a token-only budget", async () => {
   );
 });
 
+test("rejects a cost budget that rounds below one cent", async () => {
+  const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+  render(
+    <CreateRateLimitModal isOpen setIsOpen={jest.fn()} onSubmit={onSubmit} />
+  );
+
+  fireEvent.change(screen.getByRole("textbox", { name: /Cost budget/ }), {
+    target: { value: "0.001" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Create limit" }));
+
+  expect(
+    await screen.findByText("Cost budget must be at least $0.01")
+  ).toBeInTheDocument();
+  expect(onSubmit).not.toHaveBeenCalled();
+});
+
 test("supports arrow-key navigation between scope options", async () => {
   render(
     <CreateRateLimitModal

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -437,7 +437,10 @@ export default function CreateRateLimitModal({
               .when("token_budget", {
                 is: (value: string | undefined) =>
                   value === undefined || value === "",
-                then: (schema) => schema.required("Enter a cost budget"),
+                then: (schema) =>
+                  schema.required(
+                    "Enter a cost budget, a token budget, or both"
+                  ),
                 otherwise: (schema) => schema.notRequired(),
               }),
             token_budget: Yup.number()
@@ -579,13 +582,13 @@ export default function CreateRateLimitModal({
                     <InputVertical
                       withLabel="cost_budget_dollars"
                       title="Cost budget"
-                      description="Maximum spend per reset period"
+                      description="Maximum spend per reset period. Set a cost budget, a token budget, or both."
                     >
                       <InputTypeInField
                         name="cost_budget_dollars"
                         inputMode="decimal"
                         prefixText="$"
-                        placeholder="0.00"
+                        placeholder="No cost limit"
                         rightChildren={
                           <div className="pr-1">
                             <Text
@@ -603,8 +606,7 @@ export default function CreateRateLimitModal({
                     <InputVertical
                       withLabel="token_budget"
                       title="Token budget"
-                      suffix="optional"
-                      description="Also stop usage at a token count"
+                      description="Maximum tokens per reset period"
                     >
                       <TokenBudgetField />
                     </InputVertical>

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -1,17 +1,302 @@
 "use client";
 
 import * as Yup from "yup";
-import { Button } from "@opal/components";
-import { useEffect, useState } from "react";
-import { Modal } from "@opal/components";
-import { Form, Formik } from "formik";
-import { SelectorFormField, TextFormField } from "@/components/Field";
-import { UserGroup } from "@/lib/types";
+import {
+  Button,
+  InputTypeIn,
+  LineItemButton,
+  Modal,
+  Popover,
+  SelectCard,
+  Text,
+} from "@opal/components";
+import React, { useEffect, useState } from "react";
+import { Form, Formik, useField, useFormikContext } from "formik";
 import { Scope } from "./types";
-import { toast } from "@opal/layouts";
-import { SvgSettings } from "@opal/icons";
+import {
+  ContentAction,
+  InputErrorText,
+  InputVertical,
+  Section,
+  toast,
+} from "@opal/layouts";
+import { SvgCheck, SvgGlobe, SvgUser, SvgUsers } from "@opal/icons";
+import type { IconFunctionComponent } from "@opal/types";
+import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 
 const HOURS_PER_DAY = 24;
+// 1T tokens stored as thousands (1e9) stays well inside the column's int32.
+const MAX_TOKEN_BUDGET = 1_000_000_000_000;
+
+interface RateLimitFormValues {
+  enabled: boolean;
+  period_days: string;
+  token_budget: string;
+  cost_budget_dollars: string;
+  target_scope: Scope;
+  user_group_id: number | undefined;
+}
+
+interface ScopeOptionConfig {
+  value: Scope;
+  icon: IconFunctionComponent;
+  title: string;
+  description: string;
+}
+
+const SCOPE_OPTIONS: ScopeOptionConfig[] = [
+  {
+    value: Scope.GLOBAL,
+    icon: SvgGlobe,
+    title: "Workspace",
+    description: "Everyone shares one budget",
+  },
+  {
+    value: Scope.USER,
+    icon: SvgUser,
+    title: "Per user",
+    description: "Every user gets their own budget",
+  },
+  {
+    value: Scope.USER_GROUP,
+    icon: SvgUsers,
+    title: "User group",
+    description: "Group members share one budget",
+  },
+];
+
+interface ScopeOptionProps extends React.HTMLAttributes<HTMLElement> {
+  option: ScopeOptionConfig;
+  selected: boolean;
+  onSelect: () => void;
+  ref?: React.Ref<HTMLDivElement>;
+}
+
+function ScopeOption({
+  option,
+  selected,
+  onSelect,
+  ref,
+  ...rest
+}: ScopeOptionProps) {
+  return (
+    <SelectCard
+      state={selected ? "selected" : "empty"}
+      padding="sm"
+      rounding="sm"
+      role="radio"
+      aria-checked={selected}
+      aria-label={option.title}
+      tabIndex={selected ? 0 : -1}
+      ref={ref}
+      {...rest}
+      onClick={(event) => {
+        rest.onClick?.(event);
+        onSelect();
+      }}
+      onKeyDown={(event) => {
+        rest.onKeyDown?.(event);
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onSelect();
+          return;
+        }
+        if (
+          event.key === "ArrowRight" ||
+          event.key === "ArrowDown" ||
+          event.key === "ArrowLeft" ||
+          event.key === "ArrowUp" ||
+          event.key === "Home" ||
+          event.key === "End"
+        ) {
+          event.preventDefault();
+          const group = event.currentTarget.closest('[role="radiogroup"]');
+          const options = Array.from(
+            group?.querySelectorAll<HTMLElement>('[role="radio"]') ?? []
+          );
+          const currentIndex = options.indexOf(event.currentTarget);
+          const nextIndex =
+            event.key === "Home"
+              ? 0
+              : event.key === "End"
+                ? options.length - 1
+                : event.key === "ArrowRight" || event.key === "ArrowDown"
+                  ? (currentIndex + 1) % options.length
+                  : (currentIndex - 1 + options.length) % options.length;
+          options[nextIndex]?.focus();
+          options[nextIndex]?.click();
+        }
+      }}
+    >
+      <ContentAction
+        sizePreset="main-ui"
+        variant="section"
+        icon={option.icon}
+        title={option.title}
+        padding="fit"
+        color="interactive"
+        center
+        rightChildren={
+          selected ? (
+            <SvgCheck
+              size={16}
+              className="shrink-0 stroke-action-selection-05"
+            />
+          ) : undefined
+        }
+      />
+    </SelectCard>
+  );
+}
+
+interface GroupScopeOptionProps {
+  option: ScopeOptionConfig;
+  selected: boolean;
+  groups: { name: string; value: number }[];
+  selectedGroupId: number | undefined;
+  onSelectScope: () => void;
+  onSelectGroup: (groupId: number) => void;
+}
+
+function GroupScopeOption({
+  option,
+  selected,
+  groups,
+  selectedGroupId,
+  onSelectScope,
+  onSelectGroup,
+}: GroupScopeOptionProps) {
+  return (
+    <Popover>
+      <Popover.Trigger asChild>
+        <ScopeOption
+          option={option}
+          selected={selected}
+          onSelect={onSelectScope}
+        />
+      </Popover.Trigger>
+      <Popover.Content align="start" side="bottom" width="lg">
+        <Popover.Menu>
+          {groups.length === 0
+            ? [
+                <div className="p-2" key="empty">
+                  <Text font="secondary-body" color="text-03" as="p">
+                    No user groups yet. Create one under Users &amp; Groups.
+                  </Text>
+                </div>,
+              ]
+            : groups.map((group) => (
+                <Popover.Close asChild key={group.value}>
+                  <LineItemButton
+                    onClick={() => onSelectGroup(group.value)}
+                    rounding="md"
+                    selectVariant="select-heavy"
+                    sizePreset="main-ui"
+                    state={
+                      String(group.value) === String(selectedGroupId)
+                        ? "selected"
+                        : "empty"
+                    }
+                    title={group.name}
+                    variant="section"
+                    width="full"
+                  />
+                </Popover.Close>
+              ))}
+        </Popover.Menu>
+      </Popover.Content>
+    </Popover>
+  );
+}
+
+function TokenBudgetField() {
+  const [field, meta, helpers] = useField<string>("token_budget");
+  const digits = String(field.value ?? "")
+    .replace(/\D/g, "")
+    .slice(0, 15);
+  const formattedValue = digits
+    ? new Intl.NumberFormat("en-US").format(Number(digits))
+    : "";
+
+  return (
+    <InputTypeIn
+      id="token_budget"
+      name="token_budget"
+      value={formattedValue}
+      inputMode="numeric"
+      pattern="[0-9,]*"
+      maxLength={19}
+      placeholder="No token limit"
+      onChange={(event) => {
+        const nextDigits = event.target.value.replace(/\D/g, "").slice(0, 15);
+        void helpers.setValue(nextDigits);
+      }}
+      onBlur={() => void helpers.setTouched(true)}
+      variant={meta.touched && meta.error ? "error" : "primary"}
+      rightChildren={
+        <div className="pr-1">
+          <Text font="secondary-action" color="text-03" nowrap>
+            tokens
+          </Text>
+        </div>
+      }
+    />
+  );
+}
+
+function formatDollars(raw: string): string | null {
+  const amount = Number(raw);
+  if (raw === "" || !Number.isFinite(amount) || amount <= 0) return null;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(amount);
+}
+
+function formatTokens(raw: string): string | null {
+  const amount = Number(raw);
+  if (raw === "" || !Number.isFinite(amount) || amount <= 0) return null;
+  return `${new Intl.NumberFormat("en-US").format(amount)} tokens`;
+}
+
+interface LimitSummaryProps {
+  groupName?: string;
+}
+
+function LimitSummary({ groupName }: LimitSummaryProps) {
+  const { values } = useFormikContext<RateLimitFormValues>();
+
+  const period = Number(values.period_days);
+  if (!Number.isInteger(period) || period < 1) return null;
+
+  const budgets = [
+    formatDollars(values.cost_budget_dollars),
+    formatTokens(values.token_budget),
+  ].filter((budget): budget is string => budget !== null);
+  if (budgets.length === 0) return null;
+
+  const budgetText = budgets.join(" or ");
+  const periodText = period === 1 ? "every day" : `every ${period} days`;
+
+  const subjectText =
+    values.target_scope === Scope.GLOBAL
+      ? "Everyone in the workspace shares"
+      : values.target_scope === Scope.USER
+        ? "Each user can spend"
+        : groupName
+          ? `Members of ${groupName} share`
+          : "Group members share";
+
+  const summary = `${subjectText} up to ${budgetText} ${periodText}. Usage is blocked until the period resets.`;
+
+  return (
+    <div className="rounded-08 bg-background-tint-01 p-2">
+      <Text font="secondary-body" color="text-03" as="p">
+        {summary}
+      </Text>
+    </div>
+  );
+}
 
 interface CreateRateLimitModalProps {
   isOpen: boolean;
@@ -34,44 +319,49 @@ export default function CreateRateLimitModal({
   forSpecificScope,
   forSpecificUserGroup,
 }: CreateRateLimitModalProps) {
-  const [modalUserGroups, setModalUserGroups] = useState([]);
-  const [shouldFetchUserGroups, setShouldFetchUserGroups] = useState(
-    forSpecificScope === Scope.USER_GROUP
-  );
+  const [modalUserGroups, setModalUserGroups] = useState<
+    { name: string; value: number }[]
+  >([]);
+  const groupScopeAvailable =
+    forSpecificScope === undefined || forSpecificScope === Scope.USER_GROUP;
 
   useEffect(() => {
+    if (!isOpen || !groupScopeAvailable || forSpecificUserGroup !== undefined) {
+      return;
+    }
     const fetchData = async () => {
       try {
-        const response = await fetch("/api/manage/admin/user-group");
-        const data = await response.json();
-        const options = data.map((userGroup: UserGroup) => ({
+        const response = await fetch("/api/manage/user-groups/minimal");
+        if (!response.ok) {
+          throw new Error(response.statusText || "Request failed");
+        }
+        const data = (await response.json()) as Array<{
+          id: number;
+          name: string;
+        }>;
+        const options = data.map((userGroup) => ({
           name: userGroup.name,
           value: userGroup.id,
         }));
         setModalUserGroups(options);
-        setShouldFetchUserGroups(false);
       } catch (error) {
         toast.error(`Failed to fetch user groups: ${error}`);
       }
     };
-
-    if (shouldFetchUserGroups) {
-      fetchData();
-    }
-  }, [shouldFetchUserGroups]);
+    fetchData();
+  }, [isOpen, groupScopeAvailable, forSpecificUserGroup]);
 
   return (
-    <Modal open={isOpen} onOpenChange={() => setIsOpen(false)}>
-      <Modal.Content width="sm" height="sm">
+    <Modal open={isOpen} onOpenChange={setIsOpen}>
+      <Modal.Content width="sm" height="fit">
         <Modal.Header
-          icon={SvgSettings}
-          title="Create a Token Rate Limit"
+          title="Create spending limit"
           onClose={() => setIsOpen(false)}
         />
-        <Formik
+        <Formik<RateLimitFormValues>
           initialValues={{
             enabled: true,
-            period_days: "",
+            period_days: "30",
             token_budget: "",
             cost_budget_dollars: "",
             target_scope: forSpecificScope || Scope.GLOBAL,
@@ -79,36 +369,39 @@ export default function CreateRateLimitModal({
           }}
           validationSchema={Yup.object().shape({
             period_days: Yup.number()
-              .required("Time Window is a required field")
-              .integer("Time Window must be a whole number of days")
-              .min(1, "Time Window must be at least 1 day"),
-            token_budget: Yup.number()
-              // Empty (no token budget) is allowed — a cost-only limit. Without
-              // this, "" coerces to NaN and trips .min(1) even when only a cost
-              // budget is set. Mirrors the cost_budget_dollars transform below.
-              .transform((value, original) =>
-                original === "" ? undefined : value
-              )
-              .min(1, "Token Budget must be at least 1")
-              .test(
-                "budget-required",
-                "Set a token budget and/or a cost budget",
-                (value, context) =>
-                  value != null || context.parent.cost_budget_dollars != null
-              ),
+              .required("Enter a reset period")
+              .integer("Enter a whole number of days")
+              .min(1, "Use at least 1 day"),
             cost_budget_dollars: Yup.number()
-              // Empty (no cost budget) is allowed; a 0 would make the gate fire
-              // on the first request (cost_since >= 0 is always true).
               .transform((value, original) =>
                 original === "" ? undefined : value
               )
-              .moreThan(0, "Cost Budget must be greater than 0"),
+              .moreThan(0, "Cost budget must be greater than 0")
+              .when("token_budget", {
+                is: (value: string | undefined) =>
+                  value === undefined || value === "",
+                then: (schema) => schema.required("Enter a cost budget"),
+                otherwise: (schema) => schema.notRequired(),
+              }),
+            token_budget: Yup.number()
+              .transform((value, original) =>
+                original === "" ? undefined : value
+              )
+              .notRequired()
+              .integer("Enter a whole number of tokens")
+              .min(1_000, "Use at least 1,000 tokens")
+              .max(MAX_TOKEN_BUDGET, "The maximum token budget is 1 trillion")
+              .test(
+                "whole-thousands",
+                "Use increments of 1,000 tokens",
+                (value) => value == null || value % 1_000 === 0
+              ),
             target_scope: Yup.string().required(
               "Target Scope is a required field"
             ),
             user_group_id: Yup.string().test(
               "user_group_id",
-              "User Group is a required field",
+              "Select a user group",
               (value, context) => {
                 return (
                   context.parent.target_scope !== "user_group" ||
@@ -119,10 +412,10 @@ export default function CreateRateLimitModal({
             ),
           })}
           onSubmit={async (values) => {
-            // Empty token field → null (cost-only); the gate skips a null budget.
-            // Sending 0 would mean "0-token limit" and block every request.
             const tokenBudget =
-              values.token_budget === "" ? null : Number(values.token_budget);
+              values.token_budget === ""
+                ? null
+                : Number(values.token_budget) / 1_000;
             const costBudgetCents =
               values.cost_budget_dollars === ""
                 ? null
@@ -136,62 +429,150 @@ export default function CreateRateLimitModal({
             );
           }}
         >
-          {({ isSubmitting, values, setFieldValue }) => (
-            <Form className="flex flex-col h-full min-h-0 overflow-visible">
-              <Modal.Body>
-                {!forSpecificScope && (
-                  <SelectorFormField
-                    name="target_scope"
-                    label="Target Scope"
-                    options={[
-                      { name: "Global", value: Scope.GLOBAL },
-                      { name: "User", value: Scope.USER },
-                      { name: "User Group", value: Scope.USER_GROUP },
-                    ]}
-                    includeDefault={false}
-                    onSelect={(selected) => {
-                      setFieldValue("target_scope", selected);
-                      if (selected === Scope.USER_GROUP) {
-                        setShouldFetchUserGroups(true);
-                      }
-                    }}
-                  />
-                )}
-                {forSpecificUserGroup === undefined &&
-                  values.target_scope === Scope.USER_GROUP && (
-                    <SelectorFormField
-                      name="user_group_id"
-                      label="User Group"
-                      options={modalUserGroups}
-                      includeDefault={false}
-                    />
-                  )}
-                <TextFormField
-                  name="period_days"
-                  label="Time Window (UTC Days)"
-                  type="number"
-                  placeholder=""
-                />
-                <TextFormField
-                  name="token_budget"
-                  label="Token Budget (Thousands, optional)"
-                  type="number"
-                  placeholder=""
-                />
-                <TextFormField
-                  name="cost_budget_dollars"
-                  label="Cost Budget (USD per period, optional)"
-                  type="number"
-                  placeholder=""
-                />
-              </Modal.Body>
-              <Modal.Footer>
-                <Button disabled={isSubmitting} type="submit">
-                  Create
-                </Button>
-              </Modal.Footer>
-            </Form>
-          )}
+          {({ isSubmitting, values, setFieldValue, errors, touched }) => {
+            const selectedGroupName = modalUserGroups.find(
+              (group) => String(group.value) === String(values.user_group_id)
+            )?.name;
+            const scopeCaption =
+              values.target_scope === Scope.GLOBAL
+                ? "Everyone in the workspace shares one budget."
+                : values.target_scope === Scope.USER
+                  ? "Every user gets their own budget."
+                  : selectedGroupName
+                    ? `Members of ${selectedGroupName} share one budget.`
+                    : "Members of the chosen group share one budget.";
+
+            return (
+              <Form className="flex min-h-0 flex-1 flex-col overflow-hidden">
+                <Modal.Body>
+                  <Section alignItems="stretch" height="auto" gap={1}>
+                    {!forSpecificScope && (
+                      <InputVertical
+                        title="Applies to"
+                        subDescription={scopeCaption}
+                      >
+                        <div
+                          role="radiogroup"
+                          aria-label="Applies to"
+                          className="grid w-full grid-cols-3 gap-1"
+                        >
+                          {SCOPE_OPTIONS.map((option) =>
+                            option.value === Scope.USER_GROUP &&
+                            forSpecificUserGroup === undefined ? (
+                              <GroupScopeOption
+                                key={option.value}
+                                option={option}
+                                selected={values.target_scope === option.value}
+                                groups={modalUserGroups}
+                                selectedGroupId={values.user_group_id}
+                                onSelectScope={() =>
+                                  void setFieldValue(
+                                    "target_scope",
+                                    option.value
+                                  )
+                                }
+                                onSelectGroup={(groupId) =>
+                                  void setFieldValue("user_group_id", groupId)
+                                }
+                              />
+                            ) : (
+                              <ScopeOption
+                                key={option.value}
+                                option={option}
+                                selected={values.target_scope === option.value}
+                                onSelect={() =>
+                                  void setFieldValue(
+                                    "target_scope",
+                                    option.value
+                                  )
+                                }
+                              />
+                            )
+                          )}
+                        </div>
+                        {touched.user_group_id && errors.user_group_id && (
+                          <InputErrorText>
+                            {errors.user_group_id}
+                          </InputErrorText>
+                        )}
+                      </InputVertical>
+                    )}
+
+                    <InputVertical
+                      withLabel="cost_budget_dollars"
+                      title="Cost budget"
+                      description="Maximum spend per reset period"
+                    >
+                      <InputTypeInField
+                        name="cost_budget_dollars"
+                        inputMode="decimal"
+                        prefixText="$"
+                        placeholder="0.00"
+                        rightChildren={
+                          <div className="pr-1">
+                            <Text
+                              font="secondary-action"
+                              color="text-03"
+                              nowrap
+                            >
+                              USD
+                            </Text>
+                          </div>
+                        }
+                      />
+                    </InputVertical>
+
+                    <InputVertical
+                      withLabel="token_budget"
+                      title="Token budget"
+                      suffix="optional"
+                      description="Also stop usage at a token count"
+                    >
+                      <TokenBudgetField />
+                    </InputVertical>
+
+                    <InputVertical
+                      withLabel="period_days"
+                      title="Reset period"
+                      description="Budgets reset at midnight UTC"
+                    >
+                      <InputTypeInField
+                        name="period_days"
+                        inputMode="numeric"
+                        pattern="[0-9]*"
+                        rightChildren={
+                          <div className="pr-1">
+                            <Text
+                              font="secondary-action"
+                              color="text-03"
+                              nowrap
+                            >
+                              days
+                            </Text>
+                          </div>
+                        }
+                      />
+                    </InputVertical>
+
+                    <LimitSummary groupName={selectedGroupName} />
+                  </Section>
+                </Modal.Body>
+                <Modal.Footer>
+                  <Button
+                    prominence="tertiary"
+                    disabled={isSubmitting}
+                    type="button"
+                    onClick={() => setIsOpen(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button disabled={isSubmitting} type="submit">
+                    Create limit
+                  </Button>
+                </Modal.Footer>
+              </Form>
+            );
+          }}
         </Formik>
       </Modal.Content>
     </Modal>

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -158,6 +158,52 @@ interface GroupScopeOptionProps {
   onSelectGroup: (groupId: number) => void;
 }
 
+interface GroupMenuContentProps {
+  groups: { name: string; value: number }[];
+  selectedGroupId: number | undefined;
+  onSelectGroup: (groupId: number) => void;
+}
+
+/** Shared group list for every popover that picks a user group. */
+function GroupMenuContent({
+  groups,
+  selectedGroupId,
+  onSelectGroup,
+}: GroupMenuContentProps) {
+  return (
+    <Popover.Content align="start" side="bottom" width="lg">
+      <Popover.Menu>
+        {groups.length === 0
+          ? [
+              <div className="p-2" key="empty">
+                <Text font="secondary-body" color="text-03" as="p">
+                  No user groups yet. Create one under Users &amp; Groups.
+                </Text>
+              </div>,
+            ]
+          : groups.map((group) => (
+              <Popover.Close asChild key={group.value}>
+                <LineItemButton
+                  onClick={() => onSelectGroup(group.value)}
+                  rounding="md"
+                  selectVariant="select-heavy"
+                  sizePreset="main-ui"
+                  state={
+                    String(group.value) === String(selectedGroupId)
+                      ? "selected"
+                      : "empty"
+                  }
+                  title={group.name}
+                  variant="section"
+                  width="full"
+                />
+              </Popover.Close>
+            ))}
+      </Popover.Menu>
+    </Popover.Content>
+  );
+}
+
 function GroupScopeOption({
   option,
   selected,
@@ -175,36 +221,11 @@ function GroupScopeOption({
           onSelect={onSelectScope}
         />
       </Popover.Trigger>
-      <Popover.Content align="start" side="bottom" width="lg">
-        <Popover.Menu>
-          {groups.length === 0
-            ? [
-                <div className="p-2" key="empty">
-                  <Text font="secondary-body" color="text-03" as="p">
-                    No user groups yet. Create one under Users &amp; Groups.
-                  </Text>
-                </div>,
-              ]
-            : groups.map((group) => (
-                <Popover.Close asChild key={group.value}>
-                  <LineItemButton
-                    onClick={() => onSelectGroup(group.value)}
-                    rounding="md"
-                    selectVariant="select-heavy"
-                    sizePreset="main-ui"
-                    state={
-                      String(group.value) === String(selectedGroupId)
-                        ? "selected"
-                        : "empty"
-                    }
-                    title={group.name}
-                    variant="section"
-                    width="full"
-                  />
-                </Popover.Close>
-              ))}
-        </Popover.Menu>
-      </Popover.Content>
+      <GroupMenuContent
+        groups={groups}
+        selectedGroupId={selectedGroupId}
+        onSelectGroup={onSelectGroup}
+      />
     </Popover>
   );
 }
@@ -277,40 +298,15 @@ function GroupPicker({
   return (
     <Popover>
       <Popover.Trigger asChild>
-        <Button prominence="secondary" aria-haspopup="menu" width="full">
+        <Button prominence="secondary" width="full">
           {selectedGroup?.name ?? "Choose a group"}
         </Button>
       </Popover.Trigger>
-      <Popover.Content align="start" side="bottom" width="lg">
-        <Popover.Menu>
-          {groups.length === 0
-            ? [
-                <div className="p-2" key="empty">
-                  <Text font="secondary-body" color="text-03" as="p">
-                    No user groups yet. Create one under Users &amp; Groups.
-                  </Text>
-                </div>,
-              ]
-            : groups.map((group) => (
-                <Popover.Close asChild key={group.value}>
-                  <LineItemButton
-                    onClick={() => onSelectGroup(group.value)}
-                    rounding="md"
-                    selectVariant="select-heavy"
-                    sizePreset="main-ui"
-                    state={
-                      String(group.value) === String(selectedGroupId)
-                        ? "selected"
-                        : "empty"
-                    }
-                    title={group.name}
-                    variant="section"
-                    width="full"
-                  />
-                </Popover.Close>
-              ))}
-        </Popover.Menu>
-      </Popover.Content>
+      <GroupMenuContent
+        groups={groups}
+        selectedGroupId={selectedGroupId}
+        onSelectGroup={onSelectGroup}
+      />
     </Popover>
   );
 }

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -37,32 +37,18 @@ interface RateLimitFormValues {
   user_group_id: number | undefined;
 }
 
+// Cards are title-only so the three scopes fit one row; the meaning of the
+// selected scope is carried by the caption beneath them.
 interface ScopeOptionConfig {
   value: Scope;
   icon: IconFunctionComponent;
   title: string;
-  description: string;
 }
 
 const SCOPE_OPTIONS: ScopeOptionConfig[] = [
-  {
-    value: Scope.GLOBAL,
-    icon: SvgGlobe,
-    title: "Workspace",
-    description: "Everyone shares one budget",
-  },
-  {
-    value: Scope.USER,
-    icon: SvgUser,
-    title: "Per user",
-    description: "Every user gets their own budget",
-  },
-  {
-    value: Scope.USER_GROUP,
-    icon: SvgUsers,
-    title: "User group",
-    description: "Group members share one budget",
-  },
+  { value: Scope.GLOBAL, icon: SvgGlobe, title: "Workspace" },
+  { value: Scope.USER, icon: SvgUser, title: "Per user" },
+  { value: Scope.USER_GROUP, icon: SvgUsers, title: "User group" },
 ];
 
 interface ScopeOptionProps extends React.HTMLAttributes<HTMLElement> {

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -259,6 +259,62 @@ function formatTokens(raw: string): string | null {
   return `${new Intl.NumberFormat("en-US").format(amount)} tokens`;
 }
 
+interface GroupPickerProps {
+  groups: { name: string; value: number }[];
+  selectedGroupId: number | undefined;
+  onSelectGroup: (groupId: number) => void;
+}
+
+function GroupPicker({
+  groups,
+  selectedGroupId,
+  onSelectGroup,
+}: GroupPickerProps) {
+  const selectedGroup = groups.find(
+    (group) => String(group.value) === String(selectedGroupId)
+  );
+
+  return (
+    <Popover>
+      <Popover.Trigger asChild>
+        <Button prominence="secondary" aria-haspopup="menu" width="full">
+          {selectedGroup?.name ?? "Choose a group"}
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content align="start" side="bottom" width="lg">
+        <Popover.Menu>
+          {groups.length === 0
+            ? [
+                <div className="p-2" key="empty">
+                  <Text font="secondary-body" color="text-03" as="p">
+                    No user groups yet. Create one under Users &amp; Groups.
+                  </Text>
+                </div>,
+              ]
+            : groups.map((group) => (
+                <Popover.Close asChild key={group.value}>
+                  <LineItemButton
+                    onClick={() => onSelectGroup(group.value)}
+                    rounding="md"
+                    selectVariant="select-heavy"
+                    sizePreset="main-ui"
+                    state={
+                      String(group.value) === String(selectedGroupId)
+                        ? "selected"
+                        : "empty"
+                    }
+                    title={group.name}
+                    variant="section"
+                    width="full"
+                  />
+                </Popover.Close>
+              ))}
+        </Popover.Menu>
+      </Popover.Content>
+    </Popover>
+  );
+}
+
 interface LimitSummaryProps {
   groupName?: string;
 }
@@ -377,6 +433,11 @@ export default function CreateRateLimitModal({
                 original === "" ? undefined : value
               )
               .moreThan(0, "Cost budget must be greater than 0")
+              .test(
+                "minimum-cents",
+                "Cost budget must be at least $0.01",
+                (value) => value == null || Math.round(value * 100) > 0
+              )
               .when("token_budget", {
                 is: (value: string | undefined) =>
                   value === undefined || value === "",
@@ -497,6 +558,27 @@ export default function CreateRateLimitModal({
                         )}
                       </InputVertical>
                     )}
+
+                    {forSpecificScope === Scope.USER_GROUP &&
+                      forSpecificUserGroup === undefined && (
+                        <InputVertical
+                          title="User group"
+                          description="Choose which group shares this budget"
+                        >
+                          <GroupPicker
+                            groups={modalUserGroups}
+                            selectedGroupId={values.user_group_id}
+                            onSelectGroup={(groupId) =>
+                              void setFieldValue("user_group_id", groupId)
+                            }
+                          />
+                          {touched.user_group_id && errors.user_group_id && (
+                            <InputErrorText>
+                              {errors.user_group_id}
+                            </InputErrorText>
+                          )}
+                        </InputVertical>
+                      )}
 
                     <InputVertical
                       withLabel="cost_budget_dollars"

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.test.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, setupUser, waitFor } from "@tests/setup/test-utils";
-import { formatPeriod } from "@/app/admin/token-rate-limits/TokenRateLimitTables";
 import { TokenRateLimitTable } from "@/app/admin/token-rate-limits/TokenRateLimitTables";
 import type { TokenRateLimitDisplay } from "@/app/admin/token-rate-limits/types";
 
@@ -40,11 +39,35 @@ function tokenRateLimit(
 }
 
 test.each([
-  ["token-only", tokenRateLimit(24, 1, null), "1 UTC day"],
-  ["cost-only", tokenRateLimit(24, null, 100), "1 UTC day"],
-  ["dual", tokenRateLimit(48, 1, 100), "2 UTC days"],
-])("%s limits display UTC-day windows", (_name, limit, expected) => {
-  expect(formatPeriod(limit)).toBe(expected);
+  [
+    "token-only",
+    tokenRateLimit(24, 1, null),
+    "Up to 1,000 tokens",
+    "Resets every day at midnight UTC",
+  ],
+  [
+    "cost-only",
+    tokenRateLimit(24, null, 100),
+    "Up to $1.00",
+    "Resets every day at midnight UTC",
+  ],
+  [
+    "dual",
+    tokenRateLimit(48, 1, 100),
+    "Up to $1.00 or 1,000 tokens",
+    "Resets every 2 days at midnight UTC",
+  ],
+])("%s limits render budget and cadence", (_name, limit, budget, cadence) => {
+  render(
+    <TokenRateLimitTable
+      tokenRateLimits={[limit]}
+      fetchUrl="/api/test-limits"
+      isAdmin
+    />
+  );
+
+  expect(screen.getByText(budget)).toBeInTheDocument();
+  expect(screen.getByText(cadence)).toBeInTheDocument();
 });
 
 describe("token rate limit mutation failures", () => {
@@ -63,7 +86,7 @@ describe("token rate limit mutation failures", () => {
       />
     );
 
-    await user.click(screen.getByRole("checkbox"));
+    await user.click(screen.getByRole("switch"));
 
     await waitFor(() =>
       expect(mockToastError).toHaveBeenCalledWith("Update failed")
@@ -82,7 +105,7 @@ describe("token rate limit mutation failures", () => {
       />
     );
 
-    await user.click(screen.getByRole("button"));
+    await user.click(screen.getByRole("button", { name: /^Delete Up to/ }));
 
     await waitFor(() =>
       expect(mockToastError).toHaveBeenCalledWith("Delete failed")

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
@@ -1,37 +1,97 @@
 "use client";
 
-import {
-  Table,
-  TableHead,
-  TableRow,
-  TableBody,
-  TableCell,
-} from "@/components/ui/table";
-import Title from "@/components/ui/title";
-import { DeleteButton } from "@/components/DeleteButton";
 import { deleteTokenRateLimit, updateTokenRateLimit } from "./lib";
-import { PageLoader, toast } from "@opal/layouts";
+import { ContentAction, PageLoader, Section, toast } from "@opal/layouts";
 import { TokenRateLimitDisplay } from "./types";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import useSWR, { mutate } from "swr";
-import { Checkbox } from "@opal/components";
-import { TableHeader } from "@/components/ui/table";
-import { Text } from "@opal/components";
-import { Spacer } from "@opal/components";
+import { Button, Switch, Text } from "@opal/components";
+import { SvgTrash, SvgUsers, SvgWallet } from "@opal/icons";
 
 const HOURS_PER_DAY = 24;
-const UTC_DAY_LABEL = "UTC day";
 const UPDATE_ERROR_MESSAGE = "Failed to update token rate limit";
 const DELETE_ERROR_MESSAGE = "Failed to delete token rate limit";
 
-export function formatPeriod(tokenRateLimit: TokenRateLimitDisplay): string {
-  const days = tokenRateLimit.period_hours / HOURS_PER_DAY;
-  return `${days} ${UTC_DAY_LABEL}${days === 1 ? "" : "s"}`;
+function formatBudget(limit: TokenRateLimitDisplay): string {
+  const parts: string[] = [];
+  if (limit.cost_budget_cents != null) {
+    parts.push(
+      new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+      }).format(limit.cost_budget_cents / 100)
+    );
+  }
+  if (limit.token_budget != null) {
+    parts.push(
+      `${new Intl.NumberFormat("en-US").format(limit.token_budget * 1000)} tokens`
+    );
+  }
+  if (parts.length === 0) return "No budget set";
+  return `Up to ${parts.join(" or ")}`;
+}
+
+function formatCadence(limit: TokenRateLimitDisplay): string {
+  const days = limit.period_hours / HOURS_PER_DAY;
+  const period = days === 1 ? "every day" : `every ${days} days`;
+  return `Resets ${period} at midnight UTC`;
+}
+
+interface LimitRowProps {
+  limit: TokenRateLimitDisplay;
+  isAdmin: boolean;
+  onToggle: (id: number) => void;
+  onDelete: (id: number) => void;
+}
+
+function LimitRow({ limit, isAdmin, onToggle, onDelete }: LimitRowProps) {
+  const limitLabel = `${formatBudget(limit)}, ${formatCadence(limit)}`;
+
+  return (
+    <div className="rounded-12 border border-border-01 bg-background-neutral-00">
+      <ContentAction
+        sizePreset="main-ui"
+        variant="section"
+        icon={limit.group_name !== undefined ? SvgUsers : SvgWallet}
+        title={formatBudget(limit)}
+        description={formatCadence(limit)}
+        tag={
+          limit.group_name !== undefined
+            ? { title: limit.group_name }
+            : undefined
+        }
+        padding="md"
+        center
+        rightChildren={
+          <div className="flex items-center gap-2">
+            <Switch
+              checked={limit.enabled}
+              disabled={!isAdmin}
+              onCheckedChange={() => onToggle(limit.token_id)}
+              aria-label={
+                limit.enabled ? `Disable ${limitLabel}` : `Enable ${limitLabel}`
+              }
+            />
+            {isAdmin && (
+              <Button
+                variant="danger"
+                prominence="tertiary"
+                icon={SvgTrash}
+                size="sm"
+                tooltip="Delete limit"
+                aria-label={`Delete ${limitLabel}`}
+                onClick={() => onDelete(limit.token_id)}
+              />
+            )}
+          </div>
+        }
+      />
+    </div>
+  );
 }
 
 type TokenRateLimitTableArgs = {
   tokenRateLimits: TokenRateLimitDisplay[];
-  title?: string;
   description?: string;
   fetchUrl: string;
   hideHeading?: boolean;
@@ -40,17 +100,11 @@ type TokenRateLimitTableArgs = {
 
 export const TokenRateLimitTable = ({
   tokenRateLimits,
-  title,
   description,
   fetchUrl,
   hideHeading,
   isAdmin,
 }: TokenRateLimitTableArgs) => {
-  const shouldRenderGroupName = () =>
-    tokenRateLimits.length > 0 &&
-    tokenRateLimits[0] !== undefined &&
-    tokenRateLimits[0].group_name !== undefined;
-
   const handleEnabledChange = async (id: number) => {
     const tokenRateLimit = tokenRateLimits.find(
       (tokenRateLimit) => tokenRateLimit.token_id === id
@@ -86,129 +140,42 @@ export const TokenRateLimitTable = ({
     }
   };
 
-  if (tokenRateLimits.length === 0) {
-    return (
-      <div className="w-full">
-        {!hideHeading && title && <Title>{title}</Title>}
-        {!hideHeading && description && (
-          <>
-            <Spacer rem={0.5} />
-            <Text as="p">{description}</Text>
-            <Spacer rem={0.5} />
-          </>
-        )}
-        {!hideHeading && <Spacer rem={2} />}
-        <Text as="p">No token rate limits set!</Text>
-        {!hideHeading && <Spacer rem={2} />}
-      </div>
-    );
-  }
-
   return (
-    <div className="w-full">
-      {!hideHeading && title && <Title>{title}</Title>}
+    <Section alignItems="stretch" height="auto" gap={0.5}>
       {!hideHeading && description && (
-        <>
-          <Spacer rem={0.5} />
-          <Text as="p">{description}</Text>
-          <Spacer rem={0.5} />
-        </>
+        <Text font="secondary-body" color="text-03" as="p">
+          {description}
+        </Text>
       )}
-      <Table
-        className={`overflow-visible ${
-          !hideHeading && "my-8"
-        } [&_td]:text-center [&_th]:text-center`}
-      >
-        <TableHeader>
-          <TableRow>
-            <TableHead>Enabled</TableHead>
-            {shouldRenderGroupName() && <TableHead>Group Name</TableHead>}
-            <TableHead>Time Window</TableHead>
-            <TableHead>Token Budget</TableHead>
-            <TableHead>Cost Budget (USD)</TableHead>
-            {isAdmin && <TableHead>Delete</TableHead>}
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {tokenRateLimits.map((tokenRateLimit) => {
-            return (
-              <TableRow key={tokenRateLimit.token_id}>
-                <TableCell>
-                  <div className="flex justify-center">
-                    <div
-                      onClick={
-                        isAdmin
-                          ? () => handleEnabledChange(tokenRateLimit.token_id)
-                          : undefined
-                      }
-                      className={`px-1 py-0.5 rounded select-none w-24 ${
-                        isAdmin
-                          ? "hover:bg-accent-background cursor-pointer"
-                          : "opacity-50"
-                      }`}
-                    >
-                      <div className="flex items-center justify-center">
-                        <Checkbox
-                          checked={tokenRateLimit.enabled}
-                          onCheckedChange={
-                            isAdmin
-                              ? () =>
-                                  handleEnabledChange(tokenRateLimit.token_id)
-                              : undefined
-                          }
-                        />
-                        <p className="ml-2">
-                          {tokenRateLimit.enabled ? "Enabled" : "Disabled"}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </TableCell>
-                {shouldRenderGroupName() && (
-                  <TableCell className="font-bold text-text-darker">
-                    {tokenRateLimit.group_name}
-                  </TableCell>
-                )}
-                <TableCell>{formatPeriod(tokenRateLimit)}</TableCell>
-                <TableCell>
-                  {tokenRateLimit.token_budget != null
-                    ? (tokenRateLimit.token_budget * 1000).toLocaleString() +
-                      " tokens"
-                    : "—"}
-                </TableCell>
-                <TableCell>
-                  {tokenRateLimit.cost_budget_cents != null
-                    ? "$" + (tokenRateLimit.cost_budget_cents / 100).toFixed(2)
-                    : "—"}
-                </TableCell>
-                {isAdmin && (
-                  <TableCell>
-                    <div className="flex justify-center">
-                      <DeleteButton
-                        onClick={() => handleDelete(tokenRateLimit.token_id)}
-                      />
-                    </div>
-                  </TableCell>
-                )}
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </div>
+      {tokenRateLimits.length === 0 ? (
+        <div className="rounded-12 border border-dashed border-border-02 p-4">
+          <Text font="secondary-body" color="text-03" as="p">
+            No limits yet. Create a spending limit to cap usage.
+          </Text>
+        </div>
+      ) : (
+        tokenRateLimits.map((tokenRateLimit) => (
+          <LimitRow
+            key={tokenRateLimit.token_id}
+            limit={tokenRateLimit}
+            isAdmin={isAdmin}
+            onToggle={handleEnabledChange}
+            onDelete={handleDelete}
+          />
+        ))
+      )}
+    </Section>
   );
 };
 
 export const GenericTokenRateLimitTable = ({
   fetchUrl,
-  title,
   description,
   hideHeading,
   responseMapper,
   isAdmin = true,
 }: {
   fetchUrl: string;
-  title?: string;
   description?: string;
   hideHeading?: boolean;
   responseMapper?: (data: any) => TokenRateLimitDisplay[];
@@ -236,7 +203,6 @@ export const GenericTokenRateLimitTable = ({
     <TokenRateLimitTable
       tokenRateLimits={processedData ?? []}
       fetchUrl={fetchUrl}
-      title={title}
       description={description}
       hideHeading={hideHeading}
       isAdmin={isAdmin}

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitsPanel.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitsPanel.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import SimpleTabs from "@/refresh-components/SimpleTabs";
+import { Button, Text } from "@opal/components";
+import { toast } from "@opal/layouts";
+import { useState } from "react";
+import { mutate } from "swr";
+import { useTierAtLeast } from "@/hooks/useTierAtLeast";
+import { Tier } from "@/lib/settings/types";
+import { SWR_KEYS } from "@/lib/swr-keys";
+import { Section } from "@/layouts/general-layouts";
+import { SvgGlobe, SvgPlusCircle, SvgUser, SvgUsers } from "@opal/icons";
+import {
+  insertGlobalTokenRateLimit,
+  insertGroupTokenRateLimit,
+  insertUserTokenRateLimit,
+} from "./lib";
+import { Scope, TokenRateLimit } from "./types";
+import { GenericTokenRateLimitTable } from "./TokenRateLimitTables";
+import CreateRateLimitModal from "./CreateRateLimitModal";
+
+const GLOBAL_TOKEN_FETCH_URL = SWR_KEYS.globalTokenRateLimits;
+const USER_TOKEN_FETCH_URL = SWR_KEYS.userTokenRateLimits;
+const USER_GROUP_FETCH_URL = SWR_KEYS.userGroupTokenRateLimits;
+
+const GLOBAL_DESCRIPTION =
+  "Global limits apply to all users, user groups, and API keys. When the global limit is reached, no more tokens can be spent.";
+const USER_DESCRIPTION =
+  "User limits apply to each user individually. When a user reaches a limit, they are temporarily blocked from spending tokens.";
+const USER_GROUP_DESCRIPTION =
+  "Group limits apply to all users in a group. If a user belongs to multiple groups, the most permissive limit applies.";
+const CREATE_ERROR_MESSAGE = "Failed to create spending limit";
+
+async function createTokenRateLimit(
+  targetScope: Scope,
+  periodHours: number,
+  tokenBudget: number | null,
+  costBudgetCents: number | null,
+  groupId: number
+): Promise<void> {
+  const tokenRateLimitArgs = {
+    enabled: true,
+    token_budget: tokenBudget,
+    period_hours: periodHours,
+    cost_budget_cents: costBudgetCents,
+  };
+
+  if (targetScope === Scope.GLOBAL) {
+    await insertGlobalTokenRateLimit(tokenRateLimitArgs);
+  } else if (targetScope === Scope.USER) {
+    await insertUserTokenRateLimit(tokenRateLimitArgs);
+  } else if (targetScope === Scope.USER_GROUP) {
+    await insertGroupTokenRateLimit(tokenRateLimitArgs, groupId);
+  } else {
+    throw new Error(`Invalid target scope: ${targetScope}`);
+  }
+}
+
+interface TokenRateLimitsPanelProps {
+  embedded?: boolean;
+}
+
+export default function TokenRateLimitsPanel({
+  embedded = false,
+}: TokenRateLimitsPanelProps) {
+  const [tabIndex, setTabIndex] = useState(0);
+  const [modalIsOpen, setModalIsOpen] = useState(false);
+  const enterpriseTier = useTierAtLeast(Tier.ENTERPRISE);
+
+  function updateTable(targetScope: Scope) {
+    if (targetScope === Scope.GLOBAL) {
+      mutate(GLOBAL_TOKEN_FETCH_URL);
+      setTabIndex(0);
+    } else if (targetScope === Scope.USER) {
+      mutate(USER_TOKEN_FETCH_URL);
+      setTabIndex(1);
+    } else if (targetScope === Scope.USER_GROUP) {
+      mutate(USER_GROUP_FETCH_URL);
+      setTabIndex(2);
+    }
+  }
+
+  async function handleSubmit(
+    targetScope: Scope,
+    periodHours: number,
+    tokenBudget: number | null,
+    costBudgetCents: number | null,
+    groupId: number = -1
+  ): Promise<void> {
+    try {
+      await createTokenRateLimit(
+        targetScope,
+        periodHours,
+        tokenBudget,
+        costBudgetCents,
+        groupId
+      );
+      setModalIsOpen(false);
+      toast.success("Spending limit created!");
+      updateTable(targetScope);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : CREATE_ERROR_MESSAGE
+      );
+    }
+  }
+
+  return (
+    <Section alignItems="stretch" justifyContent="start" height="auto">
+      {embedded ? (
+        <Section gap={0.25} alignItems="start" justifyContent="start">
+          <Text font="heading-h3">Manage spending limits</Text>
+          <Text font="secondary-body" color="text-03">
+            Set guardrails for workspace, user, and group usage. Limits can be
+            enabled or disabled without deleting their configuration.
+          </Text>
+        </Section>
+      ) : (
+        <>
+          <Text as="p">
+            Spending limits help you control how many tokens can be spent in a
+            given time period.
+          </Text>
+          <ul className="list-disc ml-4">
+            <li>
+              <Text as="p">
+                Set a workspace-wide limit for your team&apos;s overall spend.
+              </Text>
+            </li>
+            {enterpriseTier && (
+              <>
+                <li>
+                  <Text as="p">
+                    Set limits for users so no single user can spend too much.
+                  </Text>
+                </li>
+                <li>
+                  <Text as="p">
+                    Set limits for user groups to control spend for teams.
+                  </Text>
+                </li>
+              </>
+            )}
+            <li>
+              <Text as="p">Enable and disable limits as needed.</Text>
+            </li>
+          </ul>
+        </>
+      )}
+
+      <Button
+        icon={SvgPlusCircle}
+        prominence="secondary"
+        onClick={() => setModalIsOpen(true)}
+      >
+        Create spending limit
+      </Button>
+
+      {enterpriseTier ? (
+        <SimpleTabs
+          tabs={{
+            "0": {
+              name: "Global",
+              icon: SvgGlobe,
+              content: (
+                <GenericTokenRateLimitTable
+                  fetchUrl={GLOBAL_TOKEN_FETCH_URL}
+                  description={GLOBAL_DESCRIPTION}
+                />
+              ),
+            },
+            "1": {
+              name: "Users",
+              icon: SvgUser,
+              content: (
+                <GenericTokenRateLimitTable
+                  fetchUrl={USER_TOKEN_FETCH_URL}
+                  description={USER_DESCRIPTION}
+                />
+              ),
+            },
+            "2": {
+              name: "Groups",
+              icon: SvgUsers,
+              content: (
+                <GenericTokenRateLimitTable
+                  fetchUrl={USER_GROUP_FETCH_URL}
+                  description={USER_GROUP_DESCRIPTION}
+                  responseMapper={(data: Record<string, TokenRateLimit[]>) =>
+                    Object.entries(data).flatMap(([groupName, elements]) =>
+                      elements.map((element) => ({
+                        ...element,
+                        group_name: groupName,
+                      }))
+                    )
+                  }
+                />
+              ),
+            },
+          }}
+          value={tabIndex.toString()}
+          onValueChange={(value) => setTabIndex(parseInt(value, 10))}
+        />
+      ) : (
+        <GenericTokenRateLimitTable
+          fetchUrl={GLOBAL_TOKEN_FETCH_URL}
+          description={GLOBAL_DESCRIPTION}
+        />
+      )}
+
+      <CreateRateLimitModal
+        isOpen={modalIsOpen}
+        setIsOpen={() => setModalIsOpen(false)}
+        onSubmit={handleSubmit}
+        forSpecificScope={enterpriseTier ? undefined : Scope.GLOBAL}
+      />
+    </Section>
+  );
+}

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitsPanel.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitsPanel.tsx
@@ -99,6 +99,7 @@ export default function TokenRateLimitsPanel({
       toast.success("Spending limit created!");
       updateTable(targetScope);
     } catch (error) {
+      console.error("Failed to create spending limit:", error);
       toast.error(
         error instanceof Error ? error.message : CREATE_ERROR_MESSAGE
       );

--- a/web/src/app/admin/token-rate-limits/page.tsx
+++ b/web/src/app/admin/token-rate-limits/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { redirect } from "next/navigation";
 import type { Route } from "next";
 import { EE_ENABLED } from "@/lib/constants";

--- a/web/src/app/admin/token-rate-limits/page.tsx
+++ b/web/src/app/admin/token-rate-limits/page.tsx
@@ -1,12 +1,12 @@
 import { redirect } from "next/navigation";
 import type { Route } from "next";
-import { SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED } from "@/lib/constants";
+import { EE_ENABLED } from "@/lib/constants";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { SettingsLayouts } from "@opal/layouts";
 import TokenRateLimitsPanel from "./TokenRateLimitsPanel";
 
 export default function Page() {
-  if (SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED) {
+  if (EE_ENABLED) {
     redirect(ADMIN_ROUTES.USAGE.path as Route);
   }
 

--- a/web/src/app/admin/token-rate-limits/page.tsx
+++ b/web/src/app/admin/token-rate-limits/page.tsx
@@ -1,234 +1,24 @@
-"use client";
-
-import SimpleTabs from "@/refresh-components/SimpleTabs";
-import { SettingsLayouts, toast } from "@opal/layouts";
-import { Button, Text } from "@opal/components";
-import { useState } from "react";
-import {
-  insertGlobalTokenRateLimit,
-  insertGroupTokenRateLimit,
-  insertUserTokenRateLimit,
-} from "./lib";
-import { Scope, TokenRateLimit } from "./types";
-import { GenericTokenRateLimitTable } from "./TokenRateLimitTables";
-import { mutate } from "swr";
-import { SWR_KEYS } from "@/lib/swr-keys";
-import CreateRateLimitModal from "./CreateRateLimitModal";
-import { useTierAtLeast } from "@/hooks/useTierAtLeast";
-import { Tier } from "@/lib/settings/types";
-import { SvgGlobe, SvgPlusCircle, SvgUser, SvgUsers } from "@opal/icons";
-import { Section } from "@/layouts/general-layouts";
+import { redirect } from "next/navigation";
+import type { Route } from "next";
+import { SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED } from "@/lib/constants";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
-
-const route = ADMIN_ROUTES.TOKEN_RATE_LIMITS;
-const GLOBAL_TOKEN_FETCH_URL = SWR_KEYS.globalTokenRateLimits;
-const USER_TOKEN_FETCH_URL = SWR_KEYS.userTokenRateLimits;
-const USER_GROUP_FETCH_URL = SWR_KEYS.userGroupTokenRateLimits;
-
-const GLOBAL_DESCRIPTION =
-  "Global rate limits apply to all users, user groups, and API keys. When the global \
-  rate limit is reached, no more tokens can be spent.";
-const USER_DESCRIPTION =
-  "User rate limits apply to individual users. When a user reaches a limit, they will \
-  be temporarily blocked from spending tokens.";
-const USER_GROUP_DESCRIPTION =
-  "User group rate limits apply to all users in a group. When a group reaches a limit, \
-  all users in the group will be temporarily blocked from spending tokens, regardless \
-  of their individual limits. If a user is in multiple groups, the most lenient limit \
-  will apply.";
-const CREATE_ERROR_MESSAGE = "Failed to create token rate limit";
-
-const handleCreateTokenRateLimit = async (
-  target_scope: Scope,
-  period_hours: number,
-  token_budget: number | null,
-  cost_budget_cents: number | null,
-  group_id: number = -1
-): Promise<void> => {
-  const tokenRateLimitArgs = {
-    enabled: true,
-    token_budget: token_budget,
-    period_hours: period_hours,
-    cost_budget_cents: cost_budget_cents,
-  };
-
-  if (target_scope === Scope.GLOBAL) {
-    await insertGlobalTokenRateLimit(tokenRateLimitArgs);
-    return;
-  }
-
-  if (target_scope === Scope.USER) {
-    await insertUserTokenRateLimit(tokenRateLimitArgs);
-    return;
-  }
-
-  if (target_scope === Scope.USER_GROUP) {
-    await insertGroupTokenRateLimit(tokenRateLimitArgs, group_id);
-    return;
-  }
-
-  throw new Error(`Invalid target_scope: ${target_scope}`);
-};
-
-function Main() {
-  const [tabIndex, setTabIndex] = useState(0);
-  const [modalIsOpen, setModalIsOpen] = useState(false);
-
-  const enterpriseTier = useTierAtLeast(Tier.ENTERPRISE);
-
-  const updateTable = (target_scope: Scope) => {
-    if (target_scope === Scope.GLOBAL) {
-      mutate(GLOBAL_TOKEN_FETCH_URL);
-      setTabIndex(0);
-    } else if (target_scope === Scope.USER) {
-      mutate(USER_TOKEN_FETCH_URL);
-      setTabIndex(1);
-    } else if (target_scope === Scope.USER_GROUP) {
-      mutate(USER_GROUP_FETCH_URL);
-      setTabIndex(2);
-    }
-  };
-
-  const handleSubmit = async (
-    target_scope: Scope,
-    period_hours: number,
-    token_budget: number | null,
-    cost_budget_cents: number | null,
-    group_id: number = -1
-  ): Promise<void> => {
-    try {
-      await handleCreateTokenRateLimit(
-        target_scope,
-        period_hours,
-        token_budget,
-        cost_budget_cents,
-        group_id
-      );
-      setModalIsOpen(false);
-      toast.success("Token rate limit created!");
-      updateTable(target_scope);
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : CREATE_ERROR_MESSAGE
-      );
-    }
-  };
-
-  return (
-    <Section alignItems="stretch" justifyContent="start" height="auto">
-      <Text as="p">
-        Token rate limits enable you control how many tokens can be spent in a
-        given time period. With token rate limits, you can:
-      </Text>
-
-      <ul className="list-disc ml-4">
-        <li>
-          <Text as="p">
-            Set a global rate limit to control your team&apos;s overall token
-            spend.
-          </Text>
-        </li>
-        {enterpriseTier && (
-          <>
-            <li>
-              <Text as="p">
-                Set rate limits for users to ensure that no single user can
-                spend too many tokens.
-              </Text>
-            </li>
-            <li>
-              <Text as="p">
-                Set rate limits for user groups to control token spend for your
-                teams.
-              </Text>
-            </li>
-          </>
-        )}
-        <li>
-          <Text as="p">Enable and disable rate limits on the fly.</Text>
-        </li>
-      </ul>
-
-      <Button
-        icon={SvgPlusCircle}
-        prominence="secondary"
-        onClick={() => setModalIsOpen(true)}
-      >
-        Create a Token Rate Limit
-      </Button>
-
-      {enterpriseTier ? (
-        <SimpleTabs
-          tabs={{
-            "0": {
-              name: "Global",
-              icon: SvgGlobe,
-              content: (
-                <GenericTokenRateLimitTable
-                  fetchUrl={GLOBAL_TOKEN_FETCH_URL}
-                  title={"Global Token Rate Limits"}
-                  description={GLOBAL_DESCRIPTION}
-                />
-              ),
-            },
-            "1": {
-              name: "User",
-              icon: SvgUser,
-              content: (
-                <GenericTokenRateLimitTable
-                  fetchUrl={USER_TOKEN_FETCH_URL}
-                  title={"User Token Rate Limits"}
-                  description={USER_DESCRIPTION}
-                />
-              ),
-            },
-            "2": {
-              name: "User Groups",
-              icon: SvgUsers,
-              content: (
-                <GenericTokenRateLimitTable
-                  fetchUrl={USER_GROUP_FETCH_URL}
-                  title={"User Group Token Rate Limits"}
-                  description={USER_GROUP_DESCRIPTION}
-                  responseMapper={(data: Record<string, TokenRateLimit[]>) =>
-                    Object.entries(data).flatMap(([group_name, elements]) =>
-                      elements.map((element) => ({
-                        ...element,
-                        group_name,
-                      }))
-                    )
-                  }
-                />
-              ),
-            },
-          }}
-          value={tabIndex.toString()}
-          onValueChange={(val) => setTabIndex(parseInt(val))}
-        />
-      ) : (
-        <GenericTokenRateLimitTable
-          fetchUrl={GLOBAL_TOKEN_FETCH_URL}
-          title={"Global Token Rate Limits"}
-          description={GLOBAL_DESCRIPTION}
-        />
-      )}
-
-      <CreateRateLimitModal
-        isOpen={modalIsOpen}
-        setIsOpen={() => setModalIsOpen(false)}
-        onSubmit={handleSubmit}
-        forSpecificScope={enterpriseTier ? undefined : Scope.GLOBAL}
-      />
-    </Section>
-  );
-}
+import { SettingsLayouts } from "@opal/layouts";
+import TokenRateLimitsPanel from "./TokenRateLimitsPanel";
 
 export default function Page() {
+  if (SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED) {
+    redirect(ADMIN_ROUTES.USAGE.path as Route);
+  }
+
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header title={route.title} icon={route.icon} divider />
+      <SettingsLayouts.Header
+        title={ADMIN_ROUTES.TOKEN_RATE_LIMITS.title}
+        icon={ADMIN_ROUTES.TOKEN_RATE_LIMITS.icon}
+        divider
+      />
       <SettingsLayouts.Body>
-        <Main />
+        <TokenRateLimitsPanel />
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>
   );

--- a/web/src/app/ee/admin/performance/usage/PersonaMessagesChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/PersonaMessagesChart.tsx
@@ -54,6 +54,22 @@ export function PersonaMessagesChart({
   const hasError =
     agentsError || personaMessagesError || personaUniqueUsersError;
 
+  // The fallback card is generic; keep the underlying failure diagnosable.
+  useEffect(() => {
+    if (agentsError) {
+      console.error("Failed to fetch admin agents:", agentsError);
+    }
+    if (personaMessagesError) {
+      console.error("Failed to fetch agent messages:", personaMessagesError);
+    }
+    if (personaUniqueUsersError) {
+      console.error(
+        "Failed to fetch agent unique users:",
+        personaUniqueUsersError
+      );
+    }
+  }, [agentsError, personaMessagesError, personaUniqueUsersError]);
+
   const filteredPersonaList = useMemo(() => {
     if (!availablePersonas) return [];
     return availablePersonas.filter((persona) =>

--- a/web/src/app/ee/admin/performance/usage/page.tsx
+++ b/web/src/app/ee/admin/performance/usage/page.tsx
@@ -3,13 +3,18 @@
 import { AdminDateRangeSelector } from "@/components/dateRangeSelectors/AdminDateRangeSelector";
 import { useTimeRange } from "@/app/ee/admin/performance/lib";
 import PerUserUsagePanel from "@/views/admin/PerUserUsagePanel";
+import TokenRateLimitsPanel from "@/app/admin/token-rate-limits/TokenRateLimitsPanel";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
+import { Divider } from "@opal/components";
 import { SettingsLayouts } from "@opal/layouts";
+import { useTierAtLeast } from "@/hooks/useTierAtLeast";
+import { Tier } from "@/lib/settings/types";
 
 const route = ADMIN_ROUTES.USAGE;
 
 export default function UsagePage() {
   const [timeRange, setTimeRange] = useTimeRange();
+  const enterpriseTier = useTierAtLeast(Tier.ENTERPRISE);
 
   return (
     <SettingsLayouts.Root width="lg">
@@ -29,6 +34,12 @@ export default function UsagePage() {
             />
           }
         />
+        {enterpriseTier && (
+          <>
+            <Divider />
+            <TokenRateLimitsPanel embedded />
+          </>
+        )}
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>
   );

--- a/web/src/sections/usage/SpendByUser.stories.tsx
+++ b/web/src/sections/usage/SpendByUser.stories.tsx
@@ -148,6 +148,37 @@ export const DetailModal: Story = {
   ),
 };
 
+/** Two-day range: checks the daily-spend chart no longer renders giant slabs. */
+function shortRangeUser(): UsageExportUser {
+  const base = USERS[1]!;
+  const days = ["2026-08-02", "2026-08-03"];
+  const records = (base.records ?? []).filter((_, index) => index < 12);
+  const shortRecords = records.map((record, index) => ({
+    ...record,
+    day: days[index % days.length]!,
+  }));
+  const totals = shortRecords.reduce(
+    (sum, record) => ({
+      input_tokens: sum.input_tokens + record.input_tokens,
+      output_tokens: sum.output_tokens + record.output_tokens,
+      cache_read_tokens: sum.cache_read_tokens + record.cache_read_tokens,
+      cost_cents: sum.cost_cents + record.cost_cents,
+    }),
+    { input_tokens: 0, output_tokens: 0, cache_read_tokens: 0, cost_cents: 0 }
+  );
+  return { email: base.email, totals, records: shortRecords };
+}
+
+export const DetailModalShortRange: Story = {
+  render: () => (
+    <UserUsageDetailModal
+      user={shortRangeUser()}
+      periodLabel="Aug 2, 2026 – Aug 3, 2026"
+      onOpenChange={() => {}}
+    />
+  ),
+};
+
 export const Empty: Story = {
   render: () => <SpendByUserTable users={[]} onSelectUser={() => {}} />,
 };

--- a/web/src/sections/usage/UserUsageDetailModal.tsx
+++ b/web/src/sections/usage/UserUsageDetailModal.tsx
@@ -188,9 +188,7 @@ function DailySpendStrip({ days }: { days: DailySpend[] }) {
           centered, so on short ranges there are no row edges to align to. */}
       <div className="flex justify-center">
         <Text font="secondary-body" color="text-03">
-          {days.length === 1
-            ? formatDayLabel(days[0]!.day)
-            : `${formatDayLabel(days[0]!.day)} – ${formatDayLabel(days[days.length - 1]!.day)}`}
+          {`${formatDayLabel(days[0]!.day)} – ${formatDayLabel(days[days.length - 1]!.day)}`}
         </Text>
       </div>
     </div>

--- a/web/src/sections/usage/UserUsageDetailModal.tsx
+++ b/web/src/sections/usage/UserUsageDetailModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { Button, Modal, ProgressBar, Text, Tooltip } from "@opal/components";
+import { Modal, ProgressBar, Text, Tooltip } from "@opal/components";
 import { Section } from "@opal/layouts";
 import type { UsageExportUser } from "@/lib/usage/userUsage";
 import { formatCost, formatTokens } from "@/sections/usage/SpendByUserTable";
@@ -83,19 +83,30 @@ function StatCell({ label, value }: { label: string; value: string }) {
   );
 }
 
-interface BreakdownListProps {
+function sharePercent(share: number): string {
+  return `${(share * 100).toFixed(share >= 0.1 ? 0 : 1)}%`;
+}
+
+interface BreakdownSectionProps {
   title: string;
   slices: BreakdownSlice[];
   totalCostCents: number;
 }
 
-function BreakdownList({ title, slices, totalCostCents }: BreakdownListProps) {
+/** Stacked variant: full-width rows under a prominent, ruled section heading. */
+function BreakdownSection({
+  title,
+  slices,
+  totalCostCents,
+}: BreakdownSectionProps) {
   if (slices.length === 0) return null;
   return (
-    <div className="flex flex-col gap-2">
-      <Text font="main-ui-action" color="text-04">
-        {title}
-      </Text>
+    <div className="flex flex-col gap-2 rounded-12 border border-border-01 bg-background-neutral-00 p-3">
+      <div className="border-b border-border-01 pb-2">
+        <Text font="main-content-emphasis" color="text-05">
+          {title}
+        </Text>
+      </div>
       <div className="flex flex-col gap-2.5">
         {slices.map((slice) => {
           const share =
@@ -113,7 +124,7 @@ function BreakdownList({ title, slices, totalCostCents }: BreakdownListProps) {
                     {formatCost(slice.cost_cents)}
                   </Text>
                   <Text font="secondary-body" color="text-03">
-                    {` · ${(share * 100).toFixed(share >= 0.1 ? 0 : 1)}% · ${formatTokens(slice.tokens)} tokens`}
+                    {` · ${sharePercent(share)} · ${formatTokens(slice.tokens)} tokens`}
                   </Text>
                 </span>
               </div>
@@ -147,7 +158,7 @@ function DailySpendStrip({ days }: { days: DailySpend[] }) {
             (day) => `${formatDayLabel(day.day)}, ${formatCost(day.cost_cents)}`
           )
           .join("; ")}`}
-        className="flex h-14 items-end gap-[2px]"
+        className="flex h-14 items-end justify-center gap-[2px]"
       >
         {days.map((day) => (
           <Tooltip
@@ -156,8 +167,9 @@ function DailySpendStrip({ days }: { days: DailySpend[] }) {
             side="top"
             delayDuration={0}
           >
-            {/* Full-height hit target so quiet days are hoverable too. */}
-            <div className="flex h-full flex-1 items-end">
+            {/* Capped width keeps 2-day ranges from rendering as giant slabs;
+                full-height hit target so quiet days are hoverable too. */}
+            <div className="flex h-full max-w-8 flex-1 items-end">
               <div
                 className="w-full rounded-t-[2px] bg-theme-blue-05"
                 style={{
@@ -172,12 +184,13 @@ function DailySpendStrip({ days }: { days: DailySpend[] }) {
           </Tooltip>
         ))}
       </div>
-      <div className="flex justify-between">
+      {/* One centered caption instead of edge labels: bars are width-capped and
+          centered, so on short ranges there are no row edges to align to. */}
+      <div className="flex justify-center">
         <Text font="secondary-body" color="text-03">
-          {formatDayLabel(days[0]!.day)}
-        </Text>
-        <Text font="secondary-body" color="text-03">
-          {formatDayLabel(days[days.length - 1]!.day)}
+          {days.length === 1
+            ? formatDayLabel(days[0]!.day)
+            : `${formatDayLabel(days[0]!.day)} – ${formatDayLabel(days[days.length - 1]!.day)}`}
         </Text>
       </div>
     </div>
@@ -241,21 +254,26 @@ export default function UserUsageDetailModal({
             </div>
 
             <DailySpendStrip days={days} />
-            <BreakdownList
-              title="By model"
-              slices={byModel}
-              totalCostCents={totals.cost_cents}
-            />
-            <BreakdownList
-              title="By flow"
-              slices={byFlow}
-              totalCostCents={totals.cost_cents}
-            />
-            <BreakdownList
-              title="By provider"
-              slices={byProvider}
-              totalCostCents={totals.cost_cents}
-            />
+
+            {/* Tighter gap than the modal's section rhythm: these three read as
+                one group of breakdowns, not three unrelated sections. */}
+            <div className="flex flex-col gap-2">
+              <BreakdownSection
+                title="By model"
+                slices={byModel}
+                totalCostCents={totals.cost_cents}
+              />
+              <BreakdownSection
+                title="By flow"
+                slices={byFlow}
+                totalCostCents={totals.cost_cents}
+              />
+              <BreakdownSection
+                title="By provider"
+                slices={byProvider}
+                totalCostCents={totals.cost_cents}
+              />
+            </div>
 
             {byModel.length === 0 && (
               <Text font="main-ui-body" color="text-03">
@@ -264,11 +282,6 @@ export default function UserUsageDetailModal({
             )}
           </Section>
         </Modal.Body>
-        <Modal.Footer>
-          <Button prominence="secondary" onClick={() => onOpenChange(false)}>
-            Done
-          </Button>
-        </Modal.Footer>
       </Modal.Content>
     </Modal>
   );


### PR DESCRIPTION
## Summary

- Replace the legacy spending-limit form with a spacious, stable modal for scope, reset period, and budget selection.
- Add readable token and USD budget inputs, multi-select budget types, validation, and a 1T token maximum.
- Add the spending-limit panel to the Enterprise usage workspace while keeping the standalone route working.
- Preserve the existing rate-limit API contract.

## Verification

<img width="1184" height="865" alt="Screenshot 2026-08-05 at 11 13 22" src="https://github.com/user-attachments/assets/6e090191-4ddb-4ffb-a30e-243671b0fb98" />

<img width="287" height="332" alt="Screenshot 2026-08-05 at 11 13 32" src="https://github.com/user-attachments/assets/fa558ccd-a095-4c9c-ae7c-0e0b8313cf18" />

<img width="659" height="901" alt="Screenshot 2026-08-05 at 11 13 42" src="https://github.com/user-attachments/assets/f9a011d4-00a8-4da0-8a08-37b47da3450d" />

<img width="1070" height="486" alt="Screenshot 2026-08-05 at 11 13 55" src="https://github.com/user-attachments/assets/2586a96b-0cec-4102-a88d-5af10d38962e" />

<img width="542" height="561" alt="Screenshot 2026-08-05 at 11 14 02" src="https://github.com/user-attachments/assets/357affb5-7518-4e66-902f-5b937e1148f7" />


- bun run test -- --runInBand src/app/admin/token-rate-limits/CreateRateLimitModal.test.tsx src/app/admin/token-rate-limits/TokenRateLimitTables.test.tsx (2 suites, 8 tests passed)
- bun run types:check passed
- bun run lint passed
- Pre-commit checks passed.

## Known minor items

- Live browser interaction against a configured Enterprise workspace remains to be verified.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check