### PR TITLE
fix(gateway): hide the LLM gateway PAT scope below Enterprise tier

### DIFF
--- a/backend/ee/onyx/configs/license_enforcement_config.py
+++ b/backend/ee/onyx/configs/license_enforcement_config.py
@@ -69,6 +69,7 @@ PATH_PREFIX_MIN_TIER: dict[str, Tier] = {
     "/admin/usage-report": Tier.BUSINESS,
     "/analytics/admin": Tier.BUSINESS,  # query/user/onyxbot/persona analytics
     "/admin/api-key": Tier.BUSINESS,  # service-account keys (no user-bound variant)
+    "/gateway": Tier.BUSINESS,  # external LLM gateway API
     "/admin/enterprise-settings": Tier.BUSINESS,  # admin writes; public /enterprise-settings stays open
     "/manage/admin/user-group": Tier.BUSINESS,  # groups + RBAC (Curator roles, group-scoped access)
     # ----- ENTERPRISE -----

--- a/backend/ee/onyx/configs/license_enforcement_config.py
+++ b/backend/ee/onyx/configs/license_enforcement_config.py
@@ -69,7 +69,6 @@ PATH_PREFIX_MIN_TIER: dict[str, Tier] = {
     "/admin/usage-report": Tier.BUSINESS,
     "/analytics/admin": Tier.BUSINESS,  # query/user/onyxbot/persona analytics
     "/admin/api-key": Tier.BUSINESS,  # service-account keys (no user-bound variant)
-    "/gateway": Tier.BUSINESS,  # external LLM gateway API
     "/admin/enterprise-settings": Tier.BUSINESS,  # admin writes; public /enterprise-settings stays open
     "/manage/admin/user-group": Tier.BUSINESS,  # groups + RBAC (Curator roles, group-scoped access)
     # ----- ENTERPRISE -----

--- a/backend/onyx/server/pat/models.py
+++ b/backend/onyx/server/pat/models.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validat
 from onyx.auth.permissions import resolve_effective_permissions
 from onyx.db.enums import Permission
 from onyx.db.permissions import parse_permission_values
+from onyx.server.settings.models import Tier
 
 # Assignable token scopes, grouped by `group_label`. `implies` is derived from the
 # permission closure and only drives the UI; require_permission re-derives it at
@@ -18,6 +19,9 @@ class PatScopeOption(BaseModel):
     group_label: str
     label: str
     description: str
+    # Minimum license tier at which the FE offers this scope. Not enforced at
+    # minting time; the gated API surface itself rejects lower tiers.
+    min_tier: Tier = Tier.COMMUNITY
 
     @computed_field
     @property
@@ -50,6 +54,7 @@ _ASSIGNABLE_SCOPES: list[PatScopeOption] = [
         group_label="LLM Gateway",
         label="Use",
         description="Call the LLM gateway from external tools.",
+        min_tier=Tier.ENTERPRISE,
     ),
 ]
 

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -1375,8 +1375,9 @@ function AccountsAccessSettings() {
   const currentTier = useSettings().tier;
   const scopeOptions = useMemo(
     () =>
+      // Undefined tier (settings loading/failed) must not hide Community scopes.
       allScopeOptions.filter((option) =>
-        tierAtLeast(currentTier, option.min_tier)
+        tierAtLeast(currentTier ?? Tier.COMMUNITY, option.min_tier)
       ),
     [allScopeOptions, currentTier]
   );

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -69,7 +69,8 @@ import { cn } from "@opal/utils";
 import { Interactive } from "@opal/core";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/lib/settings/types";
-import { useIsSearchModeAvailable } from "@/lib/settings/hooks";
+import { useIsSearchModeAvailable, useSettings } from "@/lib/settings/hooks";
+import { tierAtLeast } from "@/lib/tiers";
 import { Tooltip } from "@opal/components";
 import { useCloudSubscription } from "@/hooks/useCloudSubscription";
 import { useSmoothStreaming } from "@/hooks/useSmoothStreaming";
@@ -90,6 +91,7 @@ interface PatScopeOption {
   group_label: string;
   label: string;
   description: string;
+  min_tier: Tier;
   implies: string[];
 }
 
@@ -1363,12 +1365,20 @@ function AccountsAccessSettings() {
     }
   );
 
-  const { data: scopeOptions = [], error: scopeOptionsError } = useSWR<
+  const { data: allScopeOptions = [], error: scopeOptionsError } = useSWR<
     PatScopeOption[]
   >(
     showTokensSection && canCreateTokens ? SWR_KEYS.userPatScopes : null,
     errorHandlingFetcher,
     { fallbackData: [] }
+  );
+  const currentTier = useSettings().tier;
+  const scopeOptions = useMemo(
+    () =>
+      allScopeOptions.filter((option) =>
+        tierAtLeast(currentTier, option.min_tier)
+      ),
+    [allScopeOptions, currentTier]
   );
 
   const scopeLabels = useMemo(


### PR DESCRIPTION
## Description

The LLM gateway API (`/gateway`) is now gated at Enterprise tier, but the PAT creation UI still offered the `use:llm_gateway` scope to every tier, letting Business admins mint keys that 403 on use.

This adds a `min_tier` field to `PatScopeOption` (defaulting to `COMMUNITY`) and marks the LLM Gateway scope as `ENTERPRISE`. The settings page filters the scope picker by the current tier via the existing `tierAtLeast` helper, so sub-Enterprise deployments no longer see the option. This is display-level gating only: the PAT minting API intentionally stays ungated, since the gateway surface itself rejects lower tiers via the tier_gate middleware.

## How Has This Been Tested?

- `backend/tests/external_dependency_unit/tier/test_tier_order.py` (34 passed)
- pre-commit on touched files: ruff, oxlint, oxfmt, TypeScript type check all pass

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check