### PR TITLE
fix(ci): rename tauri-action input to releaseAssetNamePattern

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -477,7 +477,7 @@ jobs:
           # Use the release created by the create-release job to avoid race conditions
           # when multiple matrix jobs try to create/update the same release simultaneously
           releaseId: ${{ needs.create-release.outputs.release-id }}
-          assetNamePattern: "[name]_[arch][ext]"
+          releaseAssetNamePattern: "[name]_[arch][ext]"
           args: ${{ matrix.args }}
 
   build-web-amd64:


### PR DESCRIPTION
## Description

Desktop download links via the stable `releases/latest/download/Onyx_universal.dmg` URLs are 404ing. #13304 bumped `tauri-apps/tauri-action` 0.6.2 → 1.0.0, which renamed the `assetNamePattern` input to `releaseAssetNamePattern`. GitHub Actions silently ignores unknown inputs (warning only), so desktop release assets fell back to Tauri's default versioned naming (`Onyx_4.5.1_universal.dmg` instead of `Onyx_universal.dmg`), breaking every stable `latest/download/Onyx_*` URL. The last release with correct asset names was v4.4.8, built from `release/v4.4` before the bump.

This renames the input; the pattern value `[name]_[arch][ext]` is unchanged in 1.0.0 and reproduces the previous naming exactly.

Backport note: `release/v4.5` carries the 1.0.0 pin with the stale input and needs this picked; `release/v4.4` still pins 0.6.2 (old input name is correct there) and is unaffected.

## How Has This Been Tested?

- The v4.5.1 tag build log shows the failure mode explicitly: `##[warning]Unexpected input(s) 'assetNamePattern', valid inputs are [... 'releaseAssetNamePattern' ...]` ([job](https://github.com/onyx-dot-app/onyx/actions/runs/30955129963/job/92146804364)), and the v4.5.1/v4.5.2 releases got versioned asset names while v4.4.8 (tauri-action 0.6.2) got the correct ones.
- Verified against tauri-action 1.0.0's `action.yml`/README at the pinned commit: `releaseAssetNamePattern` is the valid input and the `[name]`/`[arch]`/`[ext]` tokens are unchanged.
- Will be fully exercised by the next tag build.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes desktop release asset naming in CI by switching to the correct `releaseAssetNamePattern` input for `tauri-apps/tauri-action@1.0.0`. Restores stable “latest” download URLs like releases/latest/download/Onyx_universal.dmg.

- **Bug Fixes**
  - Rename input `assetNamePattern` → `releaseAssetNamePattern` for `tauri-apps/tauri-action@1.0.0`.
  - Keep `[name]_[arch][ext]` pattern to produce non-versioned names (e.g., `Onyx_universal.dmg`), fixing 404s from versioned assets.

<sup>Written for commit 82bde8feae989e073fcab86f43c431b987004dbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

