### PR TITLE
fix(celery): launch beat watchdog as module (#13664) to release v4.5

### DIFF
--- a/backend/onyx/utils/platform_utils.py
+++ b/backend/onyx/utils/platform_utils.py
@@ -1,8 +1,5 @@
-# Named `platform_utils` (not `platform`) because `supervisord_watchdog.py` in this
-# same directory is launched as a script (`python onyx/utils/supervisord_watchdog.py`),
-# which puts this directory on `sys.path[0]`. A module named `platform.py` here would
-# then shadow the stdlib `platform`, breaking `uuid` (which calls `platform.system()`)
-# and any transitive import of it (e.g. `redis`). See issue #10975.
+# Named `platform_utils` (not `platform`) so direct execution of a utility from this
+# directory cannot shadow the stdlib `platform`. See issue #10975.
 import os
 import warnings
 

--- a/backend/supervisord.conf
+++ b/backend/supervisord.conf
@@ -135,7 +135,7 @@ stopasgroup=true
 # supervisord only restarts the process if it's dead
 # make sure this key matches ONYX_CELERY_BEAT_HEARTBEAT_KEY
 [program:supervisord_watchdog_celery_beat]
-command=python onyx/utils/supervisord_watchdog.py
+command=python -m onyx.utils.supervisord_watchdog
     --conf /etc/supervisor/conf.d/supervisord.conf
     --key "onyx:celery:beat:heartbeat"
     --program celery_beat


### PR DESCRIPTION
Cherry-pick of commit b6cbfa92c309bc064da560b9a75b105884e6581d to release/v4.5 branch.

Original PR: #13664

On v4.5.x the `supervisord_watchdog_celery_beat` program crash-loops on startup: launching the watchdog as a script path puts `/app/onyx/utils` at `sys.path[0]`, so `onyx/utils/datetime.py` (added in #13084) shadows the stdlib `datetime` module and the `redis` import fails with `ImportError: cannot import name 'datetime' from 'datetime'`. Celery beat itself is unaffected, but it loses its heartbeat watchdog. Launching via `python -m` keeps the package directory off `sys.path`.

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Celery beat watchdog crash loop in v4.5 by launching it as a module, preventing stdlib shadowing and restoring the heartbeat watchdog.

- **Bug Fixes**
  - Run watchdog via `python -m onyx.utils.supervisord_watchdog` in `supervisord.conf` to avoid `datetime` shadowing that broke `redis` imports.
  - Tightened comment in `platform_utils.py` to document avoiding `platform` shadowing.

<sup>Written for commit ad6e2211ee07bbff19b8073c6ff97547312d6a92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

