### PR TITLE
fix(voice): support non-English languages in the Azure voice provider

### DIFF
--- a/backend/onyx/db/voice.py
+++ b/backend/onyx/db/voice.py
@@ -85,7 +85,10 @@ def upsert_voice_provider(
     provider.name = name
     provider.provider_type = provider_type
     provider.api_base = api_base
-    provider.custom_config = custom_config
+    # None means "leave unchanged" (pass {} to clear) so partial writers can't
+    # wipe keys like speech_region.
+    if custom_config is not None:
+        provider.custom_config = custom_config
     provider.stt_model = stt_model
     provider.tts_model = tts_model
     provider.default_voice = default_voice

--- a/backend/onyx/server/manage/voice/api.py
+++ b/backend/onyx/server/manage/voice/api.py
@@ -71,6 +71,7 @@ def _provider_to_view(provider: VoiceProvider) -> VoiceProviderView:
         default_voice=provider.default_voice,
         api_key=mask_string(raw_key) if raw_key else None,
         target_uri=provider.api_base,  # api_base stores the target URI for Azure
+        custom_config=provider.custom_config,
     )
 
 
@@ -138,6 +139,10 @@ async def upsert_voice_provider_endpoint(
     except OnyxError:
         db_session.rollback()
         raise
+    except ValueError as e:
+        # Bad provider config (e.g. invalid stt_languages) — surface the real reason.
+        db_session.rollback()
+        raise OnyxError(OnyxErrorCode.VALIDATION_ERROR, str(e)) from e
     except Exception as e:
         db_session.rollback()
         logger.error("Voice provider credential validation failed on save: %s", e)

--- a/backend/onyx/server/manage/voice/models.py
+++ b/backend/onyx/server/manage/voice/models.py
@@ -22,6 +22,10 @@ class VoiceProviderView(BaseModel):
         default=None,
         description="Target URI for Azure Speech Services.",
     )
+    custom_config: dict[str, Any] | None = Field(
+        default=None,
+        description="Provider-specific config (e.g. Azure speech_region / stt_languages).",
+    )
 
 
 class VoiceProviderUpdateSuccess(BaseModel):
@@ -60,7 +64,11 @@ class VoiceProviderUpsertRequest(BaseModel):
         default=None,
         description="Target URI for Azure Speech Services (maps to api_base).",
     )
-    custom_config: dict[str, Any] | None = None
+    custom_config: dict[str, Any] | None = Field(
+        default=None,
+        description="Provider-specific config (e.g. Azure speech_region / "
+        "stt_languages). None leaves the stored config unchanged; pass {} to clear.",
+    )
     stt_model: str | None = None
     tts_model: str | None = None
     default_voice: str | None = None

--- a/backend/onyx/voice/providers/azure.py
+++ b/backend/onyx/voice/providers/azure.py
@@ -43,12 +43,66 @@ from onyx.voice.interface import (
     VoiceProviderInterface,
 )
 
+logger = setup_logger()
+
 # SSML namespace — W3C standard for Speech Synthesis Markup Language.
 # This is a fixed W3C specification and will not change.
 SSML_NAMESPACE = "http://www.w3.org/2001/10/synthesis"
 
-# Common Azure Neural voices
+# Locale shape (en-US, iu-Latn-CA); doubles as an SSML attribute injection guard.
+AZURE_LOCALE_PATTERN = re.compile(r"^[A-Za-z]{2,3}(-[A-Za-z]{2,8}){1,2}$")
+
+DEFAULT_LOCALE = "en-US"
+
+# Azure caps language-identification candidates at 10 (continuous LID).
+MAX_STT_LANGUAGES = 10
+
+
+def _normalize_stt_language(raw: str) -> str:
+    """Canonicalize casing (en-us -> en-US) so Azure always gets exact locales."""
+    if not AZURE_LOCALE_PATTERN.fullmatch(raw):
+        raise ValueError(
+            f"Invalid Azure STT language {raw!r}. Use locales like 'en-US' or 'fr-FR'."
+        )
+    lang, *rest = raw.split("-")
+    return "-".join(
+        [lang.lower()] + [s.upper() if len(s) == 2 else s.capitalize() for s in rest]
+    )
+
+
+def _parse_stt_languages(value: Any) -> list[str]:
+    if value is None:
+        return [DEFAULT_LOCALE]
+    if not isinstance(value, list):
+        raise ValueError("stt_languages must be a list of locales like ['fr-FR']")
+    languages = list(
+        dict.fromkeys(
+            _normalize_stt_language(str(item).strip())
+            for item in value
+            if str(item).strip()
+        )
+    )
+    if len(languages) > MAX_STT_LANGUAGES:
+        raise ValueError(
+            f"Azure supports at most {MAX_STT_LANGUAGES} STT languages; got {len(languages)}."
+        )
+    return languages or [DEFAULT_LOCALE]
+
+
+def _voice_locale(voice_name: str | None) -> str:
+    """Derive the SSML locale from an Azure voice name (fr-FR-DeniseNeural -> fr-FR)."""
+    locale = "-".join((voice_name or "").split("-")[:-1])
+    return locale if AZURE_LOCALE_PATTERN.fullmatch(locale) else DEFAULT_LOCALE
+
+
+# Curated picker subset — any Azure voice ID can also be typed in. Multilingual
+# voices speak the language of the input text.
 AZURE_VOICES = [
+    {"id": "en-US-AvaMultilingualNeural", "name": "Ava (Multilingual, Female)"},
+    {"id": "en-US-AndrewMultilingualNeural", "name": "Andrew (Multilingual, Male)"},
+    {"id": "fr-FR-DeniseNeural", "name": "Denise (fr-FR, Female)"},
+    {"id": "fr-FR-HenriNeural", "name": "Henri (fr-FR, Male)"},
+    {"id": "fr-CA-SylvieNeural", "name": "Sylvie (fr-CA, Female)"},
     {"id": "en-US-JennyNeural", "name": "Jenny (en-US, Female)"},
     {"id": "en-US-GuyNeural", "name": "Guy (en-US, Male)"},
     {"id": "en-US-AriaNeural", "name": "Aria (en-US, Female)"},
@@ -73,6 +127,7 @@ class AzureStreamingTranscriber(StreamingTranscriberProtocol):
         endpoint: str | None = None,
         input_sample_rate: int = 24000,
         target_sample_rate: int = 16000,
+        languages: list[str] | None = None,
     ):
         self._logger = setup_logger()
         self.api_key = api_key
@@ -80,6 +135,7 @@ class AzureStreamingTranscriber(StreamingTranscriberProtocol):
         self.endpoint = endpoint
         self.input_sample_rate = input_sample_rate
         self.target_sample_rate = target_sample_rate
+        self.languages = languages or [DEFAULT_LOCALE]
         self._transcript_queue: asyncio.Queue[TranscriptResult | None] = asyncio.Queue()
         self._accumulated_transcript = ""
         self._recognizer: Any = None
@@ -98,17 +154,42 @@ class AzureStreamingTranscriber(StreamingTranscriberProtocol):
 
         self._loop = asyncio.get_running_loop()
 
+        multilingual = len(self.languages) > 1
+
         # Use endpoint for self-hosted containers, region for Azure cloud
         if self.endpoint:
             speech_config = speechsdk.SpeechConfig(
                 subscription=self.api_key,
                 endpoint=self.endpoint,
             )
+        elif multilingual:
+            # Continuous LID (language switches mid-session) requires the
+            # universal/v2 endpoint; a region-based config silently falls
+            # back to at-start detection.
+            speech_config = speechsdk.SpeechConfig(
+                subscription=self.api_key,
+                endpoint=f"wss://{self.region}.stt.speech.microsoft.com/speech/universal/v2",
+            )
+            speech_config.set_property(
+                speechsdk.PropertyId.SpeechServiceConnection_LanguageIdMode,
+                "Continuous",
+            )
         else:
             speech_config = speechsdk.SpeechConfig(
                 subscription=self.api_key,
                 region=self.region,
             )
+
+        auto_detect_config = None
+        if multilingual:
+            # Self-hosted containers keep the default at-start detection.
+            auto_detect_config = (
+                speechsdk.languageconfig.AutoDetectSourceLanguageConfig(
+                    languages=self.languages
+                )
+            )
+        else:
+            speech_config.speech_recognition_language = self.languages[0]
 
         audio_format = speechsdk.audio.AudioStreamFormat(
             samples_per_second=16000,
@@ -121,6 +202,7 @@ class AzureStreamingTranscriber(StreamingTranscriberProtocol):
         self._recognizer = speechsdk.SpeechRecognizer(
             speech_config=speech_config,
             audio_config=audio_config,
+            auto_detect_source_language_config=auto_detect_config,
         )
 
         transcriber = self
@@ -256,6 +338,7 @@ class AzureStreamingSynthesizer(StreamingSynthesizerProtocol):
         self.region = region
         self.endpoint = endpoint
         self.voice = voice
+        self._locale = _voice_locale(voice)
         self.speed = max(0.5, min(2.0, speed))
         self._audio_queue: asyncio.Queue[bytes | None] = asyncio.Queue()
         self._synthesizer: Any = None
@@ -324,7 +407,7 @@ class AzureStreamingSynthesizer(StreamingSynthesizerProtocol):
             # Build SSML with prosody for speed control
             rate = f"{int((self.speed - 1) * 100):+d}%"
             escaped_text = escape(text)
-            ssml = f"""<speak version='1.0' xmlns='{SSML_NAMESPACE}' xml:lang='en-US'>
+            ssml = f"""<speak version='1.0' xmlns='{SSML_NAMESPACE}' xml:lang='{self._locale}'>
                 <voice name={quoteattr(self.voice)}>
                     <prosody rate='{rate}'>{escaped_text}</prosody>
                 </voice>
@@ -373,6 +456,7 @@ class AzureVoiceProvider(VoiceProviderInterface):
             or ""
         )
         self.speech_region = self._validate_speech_region(raw_speech_region)
+        self.stt_languages = _parse_stt_languages(custom_config.get("stt_languages"))
         self.stt_model = stt_model
         self.tts_model = tts_model
         self.default_voice = default_voice or "en-US-JennyNeural"
@@ -492,7 +576,12 @@ class AzureVoiceProvider(VoiceProviderInterface):
             content_type = "audio/webm; codecs=opus"
 
         url = self._get_stt_url()
-        params = {"language": "en-US", "format": "detailed"}
+        # The short-audio REST API takes a single language (no auto-detect).
+        if len(self.stt_languages) > 1:
+            logger.warning(
+                "Azure chunked STT cannot auto-detect; using %s", self.stt_languages[0]
+            )
+        params = {"language": self.stt_languages[0], "format": "detailed"}
         headers = {
             "Ocp-Apim-Subscription-Key": self.api_key,
             "Content-Type": content_type,
@@ -551,7 +640,7 @@ class AzureVoiceProvider(VoiceProviderInterface):
 
         # Build SSML with escaped text and quoted attributes to prevent injection
         escaped_text = escape(text)
-        ssml = f"""<speak version='1.0' xmlns='{SSML_NAMESPACE}' xml:lang='en-US'>
+        ssml = f"""<speak version='1.0' xmlns='{SSML_NAMESPACE}' xml:lang='{_voice_locale(voice_name)}'>
             <voice name={quoteattr(voice_name)}>
                 <prosody rate='{rate}'>{escaped_text}</prosody>
             </voice>
@@ -642,6 +731,7 @@ class AzureVoiceProvider(VoiceProviderInterface):
             endpoint=self.api_base if self._is_self_hosted() else None,
             input_sample_rate=24000,
             target_sample_rate=16000,
+            languages=self.stt_languages,
         )
         await transcriber.connect()
         return transcriber

--- a/backend/onyx/voice/providers/azure.py
+++ b/backend/onyx/voice/providers/azure.py
@@ -54,8 +54,10 @@ AZURE_LOCALE_PATTERN = re.compile(r"^[A-Za-z]{2,3}(-[A-Za-z]{2,8}){1,2}$")
 
 DEFAULT_LOCALE = "en-US"
 
-# Azure caps language-identification candidates at 10 (continuous LID).
+# Azure caps language-identification candidates at 10 for continuous LID and
+# 4 for at-start LID (the self-hosted endpoint path).
 MAX_STT_LANGUAGES = 10
+MAX_AT_START_STT_LANGUAGES = 4
 
 
 def _normalize_stt_language(raw: str) -> str:
@@ -85,6 +87,12 @@ def _parse_stt_languages(value: Any) -> list[str]:
     if len(languages) > MAX_STT_LANGUAGES:
         raise ValueError(
             f"Azure supports at most {MAX_STT_LANGUAGES} STT languages; got {len(languages)}."
+        )
+    bases = [lang.split("-", 1)[0] for lang in languages]
+    if len(set(bases)) != len(bases):
+        raise ValueError(
+            "Azure language detection allows one locale per language "
+            "(e.g. not both en-US and en-GB)."
         )
     return languages or [DEFAULT_LOCALE]
 
@@ -457,6 +465,14 @@ class AzureVoiceProvider(VoiceProviderInterface):
         )
         self.speech_region = self._validate_speech_region(raw_speech_region)
         self.stt_languages = _parse_stt_languages(custom_config.get("stt_languages"))
+        if (
+            self._is_self_hosted()
+            and len(self.stt_languages) > MAX_AT_START_STT_LANGUAGES
+        ):
+            raise ValueError(
+                "Self-hosted Azure endpoints use at-start detection, which supports "
+                f"at most {MAX_AT_START_STT_LANGUAGES} STT languages."
+            )
         self.stt_model = stt_model
         self.tts_model = tts_model
         self.default_voice = default_voice or "en-US-JennyNeural"

--- a/backend/tests/unit/onyx/db/test_voice.py
+++ b/backend/tests/unit/onyx/db/test_voice.py
@@ -232,6 +232,53 @@ class TestUpsertVoiceProvider:
         # api_key should remain unchanged (same object reference)
         assert existing_provider.api_key is original_api_key
 
+    def test_preserves_custom_config_when_omitted(
+        self, mock_db_session: MagicMock
+    ) -> None:
+        existing_provider = _make_voice_provider(id=1, provider_type="azure")
+        existing_provider.custom_config = {
+            "speech_region": "swedencentral",
+            "stt_languages": ["en-US", "fr-FR"],
+        }
+        mock_db_session.scalar.return_value = existing_provider
+        mock_db_session.flush.return_value = None
+        mock_db_session.refresh.return_value = None
+
+        upsert_voice_provider(
+            db_session=mock_db_session,
+            provider_id=1,
+            name="Test",
+            provider_type="azure",
+            api_key=None,
+            api_key_changed=False,
+        )
+
+        assert existing_provider.custom_config == {
+            "speech_region": "swedencentral",
+            "stt_languages": ["en-US", "fr-FR"],
+        }
+
+    def test_clears_custom_config_with_empty_dict(
+        self, mock_db_session: MagicMock
+    ) -> None:
+        existing_provider = _make_voice_provider(id=1, provider_type="azure")
+        existing_provider.custom_config = {"speech_region": "swedencentral"}
+        mock_db_session.scalar.return_value = existing_provider
+        mock_db_session.flush.return_value = None
+        mock_db_session.refresh.return_value = None
+
+        upsert_voice_provider(
+            db_session=mock_db_session,
+            provider_id=1,
+            name="Test",
+            provider_type="azure",
+            api_key=None,
+            api_key_changed=False,
+            custom_config={},
+        )
+
+        assert existing_provider.custom_config == {}
+
     def test_activates_stt_when_requested(self, mock_db_session: MagicMock) -> None:
         existing_provider = _make_voice_provider(id=1)
         mock_db_session.scalar.return_value = existing_provider

--- a/backend/tests/unit/onyx/voice/providers/test_azure_provider.py
+++ b/backend/tests/unit/onyx/voice/providers/test_azure_provider.py
@@ -28,3 +28,21 @@ def test_azure_provider_rejects_invalid_speech_region() -> None:
             api_base=None,
             custom_config={"speech_region": "westus/../../etc"},
         )
+
+
+def test_azure_provider_stt_languages_from_custom_config() -> None:
+    provider = AzureVoiceProvider(
+        api_key="key",
+        api_base=None,
+        custom_config={"speech_region": "eastus", "stt_languages": ["en-US", "fr-FR"]},
+    )
+    assert provider.stt_languages == ["en-US", "fr-FR"]
+
+
+def test_azure_provider_stt_languages_default_to_english() -> None:
+    provider = AzureVoiceProvider(
+        api_key="key",
+        api_base=None,
+        custom_config={"speech_region": "eastus"},
+    )
+    assert provider.stt_languages == ["en-US"]

--- a/backend/tests/unit/onyx/voice/providers/test_azure_provider.py
+++ b/backend/tests/unit/onyx/voice/providers/test_azure_provider.py
@@ -1,6 +1,10 @@
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock, patch
+
 import pytest
 
-from onyx.voice.providers.azure import AzureVoiceProvider
+from onyx.voice.providers.azure import AzureStreamingTranscriber, AzureVoiceProvider
 
 
 def test_azure_provider_extracts_region_from_target_uri() -> None:
@@ -46,3 +50,104 @@ def test_azure_provider_stt_languages_default_to_english() -> None:
         custom_config={"speech_region": "eastus"},
     )
     assert provider.stt_languages == ["en-US"]
+
+
+def test_azure_provider_rejects_duplicate_base_language() -> None:
+    with pytest.raises(ValueError, match="one locale per language"):
+        AzureVoiceProvider(
+            api_key="key",
+            api_base=None,
+            custom_config={
+                "speech_region": "eastus",
+                "stt_languages": ["en-US", "en-GB"],
+            },
+        )
+
+
+def test_azure_provider_self_hosted_caps_at_start_languages() -> None:
+    five_languages = ["en-US", "fr-FR", "de-DE", "es-ES", "it-IT"]
+    with pytest.raises(ValueError, match="at most 4"):
+        AzureVoiceProvider(
+            api_key="key",
+            api_base="http://localhost:5000",
+            custom_config={"stt_languages": five_languages},
+        )
+    # The same list is fine in cloud mode (continuous LID allows 10).
+    provider = AzureVoiceProvider(
+        api_key="key",
+        api_base=None,
+        custom_config={"speech_region": "eastus", "stt_languages": five_languages},
+    )
+    assert provider.stt_languages == five_languages
+
+
+# --- Streaming SDK configuration ---
+
+
+def _connect_transcriber(
+    languages: list[str], **transcriber_kwargs: Any
+) -> dict[str, MagicMock]:
+    with (
+        patch("azure.cognitiveservices.speech.SpeechConfig") as speech_config,
+        patch("azure.cognitiveservices.speech.SpeechRecognizer") as recognizer,
+        patch(
+            "azure.cognitiveservices.speech.languageconfig.AutoDetectSourceLanguageConfig"
+        ) as auto_detect,
+        patch("azure.cognitiveservices.speech.audio.AudioStreamFormat"),
+        patch("azure.cognitiveservices.speech.audio.PushAudioInputStream"),
+        patch("azure.cognitiveservices.speech.audio.AudioConfig"),
+    ):
+        transcriber = AzureStreamingTranscriber(
+            api_key="key", languages=languages, **transcriber_kwargs
+        )
+        asyncio.run(transcriber.connect())
+    return {
+        "speech_config": speech_config,
+        "recognizer": recognizer,
+        "auto_detect": auto_detect,
+    }
+
+
+def test_streaming_multilingual_cloud_uses_v2_endpoint_and_continuous_lid() -> None:
+    import azure.cognitiveservices.speech as speechsdk
+
+    mocks = _connect_transcriber(["en-US", "fr-FR"], region="swedencentral")
+
+    mocks["speech_config"].assert_called_once_with(
+        subscription="key",
+        endpoint="wss://swedencentral.stt.speech.microsoft.com/speech/universal/v2",
+    )
+    mocks["speech_config"].return_value.set_property.assert_called_once_with(
+        speechsdk.PropertyId.SpeechServiceConnection_LanguageIdMode,
+        "Continuous",
+    )
+    mocks["auto_detect"].assert_called_once_with(languages=["en-US", "fr-FR"])
+    recognizer_kwargs = mocks["recognizer"].call_args.kwargs
+    assert (
+        recognizer_kwargs["auto_detect_source_language_config"]
+        is mocks["auto_detect"].return_value
+    )
+
+
+def test_streaming_single_language_cloud_pins_recognition_language() -> None:
+    mocks = _connect_transcriber(["fr-FR"], region="swedencentral")
+
+    mocks["speech_config"].assert_called_once_with(
+        subscription="key", region="swedencentral"
+    )
+    assert mocks["speech_config"].return_value.speech_recognition_language == "fr-FR"
+    mocks["auto_detect"].assert_not_called()
+    assert (
+        mocks["recognizer"].call_args.kwargs["auto_detect_source_language_config"]
+        is None
+    )
+
+
+def test_streaming_multilingual_self_hosted_keeps_at_start_detection() -> None:
+    mocks = _connect_transcriber(["en-US", "fr-FR"], endpoint="http://localhost:5000")
+
+    mocks["speech_config"].assert_called_once_with(
+        subscription="key", endpoint="http://localhost:5000"
+    )
+    mocks["speech_config"].return_value.set_property.assert_not_called()
+    mocks["auto_detect"].assert_called_once_with(languages=["en-US", "fr-FR"])

--- a/backend/tests/unit/onyx/voice/providers/test_azure_ssml.py
+++ b/backend/tests/unit/onyx/voice/providers/test_azure_ssml.py
@@ -4,7 +4,11 @@ import wave
 
 import pytest
 
-from onyx.voice.providers.azure import AzureVoiceProvider
+from onyx.voice.providers.azure import (
+    AzureVoiceProvider,
+    _parse_stt_languages,
+    _voice_locale,
+)
 
 # --- _is_azure_cloud_url ---
 
@@ -83,6 +87,67 @@ def test_validate_region_rejects_path_traversal() -> None:
 def test_validate_region_rejects_dots() -> None:
     with pytest.raises(ValueError, match="Invalid Azure speech_region"):
         AzureVoiceProvider._validate_speech_region("west.us")
+
+
+# --- STT languages ---
+
+
+def test_stt_languages_default_when_unset() -> None:
+    assert _parse_stt_languages(None) == ["en-US"]
+    assert _parse_stt_languages([]) == ["en-US"]
+
+
+def test_stt_languages_normalize_case_and_dedupe() -> None:
+    assert _parse_stt_languages(["en-us", "FR-fr", "fr-FR"]) == ["en-US", "fr-FR"]
+
+
+def test_stt_languages_script_locale() -> None:
+    assert _parse_stt_languages(["iu-latn-ca"]) == ["iu-Latn-CA"]
+
+
+def test_stt_languages_rejects_invalid_locale() -> None:
+    with pytest.raises(ValueError, match="Invalid Azure STT language"):
+        _parse_stt_languages(["not a locale"])
+
+
+def test_stt_languages_rejects_bare_language_code() -> None:
+    with pytest.raises(ValueError, match="Invalid Azure STT language"):
+        _parse_stt_languages(["fr"])
+
+
+def test_stt_languages_rejects_too_many() -> None:
+    locales = [f"en-{chr(ord('A') + i)}A" for i in range(11)]
+    with pytest.raises(ValueError, match="at most 10"):
+        _parse_stt_languages(locales)
+
+
+def test_stt_languages_rejects_non_list_config() -> None:
+    with pytest.raises(ValueError, match="must be a list"):
+        _parse_stt_languages("en-US, fr-FR")
+
+
+# --- _voice_locale ---
+
+
+def test_voice_locale_from_french_voice() -> None:
+    assert _voice_locale("fr-FR-DeniseNeural") == "fr-FR"
+
+
+def test_voice_locale_from_script_locale_voice() -> None:
+    assert _voice_locale("iu-Latn-CA-SiqiniqNeural") == "iu-Latn-CA"
+
+
+def test_voice_locale_falls_back_for_none() -> None:
+    assert _voice_locale(None) == "en-US"
+
+
+def test_voice_locale_falls_back_for_unparseable_name() -> None:
+    assert _voice_locale("weird") == "en-US"
+
+
+def test_voice_locale_rejects_ssml_injection() -> None:
+    # A malformed locale must never flow into the xml:lang attribute.
+    assert _voice_locale("en-US' x='y-EvilNeural") == "en-US"
 
 
 # --- _pcm16_to_wav ---

--- a/web/src/lib/voice/types.ts
+++ b/web/src/lib/voice/types.ts
@@ -11,6 +11,8 @@ export interface VoiceProviderView {
   /** Masked API key (e.g. `"sk-a...b1c2"`). Non-null means a key is stored. */
   api_key: string | null;
   target_uri: string | null;
+  /** Provider-specific config (e.g. Azure `speech_region` / `stt_languages`). */
+  custom_config: Record<string, unknown> | null;
 }
 
 /** A selectable voice option returned by a provider's voices endpoint. */
@@ -27,4 +29,6 @@ export interface VoiceFormValues {
   stt_model: string;
   tts_model: string;
   default_voice: string;
+  /** Comma-separated STT locales (Azure only), e.g. "en-US, fr-FR". */
+  stt_languages: string;
 }

--- a/web/src/lib/voice/utils.ts
+++ b/web/src/lib/voice/utils.ts
@@ -45,8 +45,34 @@ export interface VoiceProviderDetail {
 /** Locale shape for STT languages; mirrors AZURE_LOCALE_PATTERN in backend/onyx/voice/providers/azure.py. */
 export const STT_LOCALE_PATTERN = /^[A-Za-z]{2,3}(-[A-Za-z]{2,8}){1,2}$/;
 
-/** Azure's candidate cap for STT language auto-detect. */
+/** Azure's candidate caps for STT language auto-detect: continuous LID (cloud) vs at-start (self-hosted). */
 export const MAX_STT_LANGUAGES = 10;
+export const MAX_AT_START_STT_LANGUAGES = 4;
+
+const AZURE_CLOUD_HOST_SUFFIXES = [
+  ".speech.microsoft.com",
+  ".api.cognitive.microsoft.com",
+  ".cognitiveservices.azure.com",
+];
+
+/** Mirrors _is_azure_cloud_url in backend/onyx/voice/providers/azure.py. */
+function isAzureCloudUrl(uri: string): boolean {
+  try {
+    const hostname = new URL(uri).hostname.toLowerCase();
+    return AZURE_CLOUD_HOST_SUFFIXES.some((suffix) =>
+      hostname.endsWith(suffix)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Language cap for the endpoint the admin entered: self-hosted endpoints use at-start detection. */
+export function maxSttLanguagesForTargetUri(targetUri: string): number {
+  return !targetUri || isAzureCloudUrl(targetUri)
+    ? MAX_STT_LANGUAGES
+    : MAX_AT_START_STT_LANGUAGES;
+}
 
 /** Splits comma-separated locale input into trimmed entries. */
 export function parseSttLanguages(value: string): string[] {

--- a/web/src/lib/voice/utils.ts
+++ b/web/src/lib/voice/utils.ts
@@ -38,6 +38,29 @@ export interface VoiceProviderDetail {
   sttModels?: Array<{ id: string; name: string }>;
   /** Selectable TTS models for this provider. Omit if the provider has no TTS model choice. */
   ttsModels?: Array<{ id: string; name: string }>;
+  /** Set if the provider supports configurable STT languages; renders the Spoken Languages field. */
+  sttLanguages?: { docsUrl: string };
+}
+
+/** Locale shape for STT languages; mirrors AZURE_LOCALE_PATTERN in backend/onyx/voice/providers/azure.py. */
+export const STT_LOCALE_PATTERN = /^[A-Za-z]{2,3}(-[A-Za-z]{2,8}){1,2}$/;
+
+/** Azure's candidate cap for STT language auto-detect. */
+export const MAX_STT_LANGUAGES = 10;
+
+/** Splits comma-separated locale input into trimmed entries. */
+export function parseSttLanguages(value: string): string[] {
+  return value
+    .split(",")
+    .map((lang) => lang.trim())
+    .filter(Boolean);
+}
+
+/** Renders stored stt_languages config as the form's comma-separated input value. */
+export function sttLanguagesToInput(raw: unknown): string {
+  return Array.isArray(raw)
+    ? raw.filter((v): v is string => typeof v === "string").join(", ")
+    : "";
 }
 
 const DEFAULT_VOICE_PROVIDER_DETAIL: VoiceProviderDetail = {
@@ -71,6 +94,10 @@ export const VOICE_PROVIDER_DETAILS: Record<string, VoiceProviderDetail> = {
     voiceDocsUrl: {
       url: "https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-support?tabs=tts",
       label: "Azure",
+    },
+    sttLanguages: {
+      docsUrl:
+        "https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-support?tabs=stt",
     },
   },
   elevenlabs: {

--- a/web/src/views/admin/VoicePage/shared.tsx
+++ b/web/src/views/admin/VoicePage/shared.tsx
@@ -109,12 +109,16 @@ export function VoiceProviderSetupModal({
     stt_languages: detail.sttLanguages
       ? Yup.string().test(
           "locales",
-          `Enter up to ${MAX_STT_LANGUAGES} comma-separated locales like en-US, fr-FR`,
+          `Enter up to ${MAX_STT_LANGUAGES} comma-separated locales like en-US, fr-FR (one per language)`,
           (value) => {
             if (!value) return true;
             const languages = parseSttLanguages(value);
+            const bases = languages.map((lang) =>
+              lang.split("-")[0]!.toLowerCase()
+            );
             return (
               languages.length <= MAX_STT_LANGUAGES &&
+              new Set(bases).size === bases.length &&
               languages.every((lang) => STT_LOCALE_PATTERN.test(lang))
             );
           }

--- a/web/src/views/admin/VoicePage/shared.tsx
+++ b/web/src/views/admin/VoicePage/shared.tsx
@@ -31,6 +31,10 @@ import {
 import {
   getVoiceProviderDetail,
   resolveModelId,
+  parseSttLanguages,
+  sttLanguagesToInput,
+  MAX_STT_LANGUAGES,
+  STT_LOCALE_PATTERN,
   type ProviderMode,
 } from "@/lib/voice/utils";
 
@@ -102,6 +106,20 @@ export function VoiceProviderSetupModal({
     stt_model: Yup.string(),
     tts_model: Yup.string(),
     default_voice: Yup.string(),
+    stt_languages: detail.sttLanguages
+      ? Yup.string().test(
+          "locales",
+          `Enter up to ${MAX_STT_LANGUAGES} comma-separated locales like en-US, fr-FR`,
+          (value) => {
+            if (!value) return true;
+            const languages = parseSttLanguages(value);
+            return (
+              languages.length <= MAX_STT_LANGUAGES &&
+              languages.every((lang) => STT_LOCALE_PATTERN.test(lang))
+            );
+          }
+        )
+      : Yup.string(),
   });
 
   const initialValues: VoiceFormValues = {
@@ -110,6 +128,9 @@ export function VoiceProviderSetupModal({
     stt_model: existingProvider?.stt_model ?? "whisper-1",
     tts_model: initialTtsModel,
     default_voice: initialDefaultVoice,
+    stt_languages: sttLanguagesToInput(
+      existingProvider?.custom_config?.stt_languages
+    ),
   };
 
   async function handleSubmit(
@@ -140,6 +161,19 @@ export function VoiceProviderSetupModal({
         }
       }
 
+      // Preserve config keys the form doesn't own (e.g. speech_region).
+      const customConfig: Record<string, unknown> = {
+        ...existingProvider?.custom_config,
+      };
+      if (mode === "stt" && detail.sttLanguages) {
+        const languages = parseSttLanguages(values.stt_languages);
+        if (languages.length > 0) {
+          customConfig.stt_languages = languages;
+        } else {
+          delete customConfig.stt_languages;
+        }
+      }
+
       const response = await upsertVoiceProvider({
         id: existingProvider?.id,
         name: detail.label,
@@ -147,6 +181,7 @@ export function VoiceProviderSetupModal({
         api_key: apiKeyChanged ? values.api_key : undefined,
         api_key_changed: apiKeyChanged,
         target_uri: values.target_uri || undefined,
+        custom_config: customConfig,
         stt_model: values.stt_model,
         tts_model: values.tts_model,
         default_voice: values.default_voice,
@@ -227,6 +262,21 @@ export function VoiceProviderSetupModal({
                       placeholder="API key"
                     />
                   </InputVertical>
+
+                  {mode === "stt" && detail.sttLanguages && (
+                    <InputVertical
+                      title="Spoken Languages"
+                      subDescription={markdown(
+                        `Comma-separated locales users may speak, e.g. \`en-US, fr-FR\`. With more than one, live transcription auto-detects the spoken language (uploaded audio uses the first). See [supported locales](${detail.sttLanguages.docsUrl}).`
+                      )}
+                      withLabel="stt_languages"
+                    >
+                      <InputTypeInField
+                        name="stt_languages"
+                        placeholder="en-US, fr-FR"
+                      />
+                    </InputVertical>
+                  )}
 
                   {mode === "stt" && (detail.sttModels?.length ?? 0) > 1 && (
                     <InputVertical title="STT Model" withLabel="stt_model">

--- a/web/src/views/admin/VoicePage/shared.tsx
+++ b/web/src/views/admin/VoicePage/shared.tsx
@@ -33,6 +33,7 @@ import {
   resolveModelId,
   parseSttLanguages,
   sttLanguagesToInput,
+  maxSttLanguagesForTargetUri,
   MAX_STT_LANGUAGES,
   STT_LOCALE_PATTERN,
   type ProviderMode,
@@ -109,18 +110,31 @@ export function VoiceProviderSetupModal({
     stt_languages: detail.sttLanguages
       ? Yup.string().test(
           "locales",
-          `Enter up to ${MAX_STT_LANGUAGES} comma-separated locales like en-US, fr-FR (one per language)`,
-          (value) => {
+          "Enter comma-separated locales like en-US, fr-FR (one per language)",
+          (value, context) => {
             if (!value) return true;
             const languages = parseSttLanguages(value);
             const bases = languages.map((lang) =>
               lang.split("-")[0]!.toLowerCase()
             );
-            return (
-              languages.length <= MAX_STT_LANGUAGES &&
-              new Set(bases).size === bases.length &&
-              languages.every((lang) => STT_LOCALE_PATTERN.test(lang))
+            if (
+              new Set(bases).size !== bases.length ||
+              !languages.every((lang) => STT_LOCALE_PATTERN.test(lang))
+            ) {
+              return false;
+            }
+            const cap = maxSttLanguagesForTargetUri(
+              context.parent.target_uri ?? ""
             );
+            if (languages.length > cap) {
+              return context.createError({
+                message:
+                  cap === MAX_STT_LANGUAGES
+                    ? `Azure supports at most ${cap} spoken languages`
+                    : `Self-hosted endpoints support at most ${cap} spoken languages (at-start detection)`,
+              });
+            }
+            return true;
           }
         )
       : Yup.string(),

--- a/web/src/views/admin/VoicePage/shared.tsx
+++ b/web/src/views/admin/VoicePage/shared.tsx
@@ -107,37 +107,38 @@ export function VoiceProviderSetupModal({
     stt_model: Yup.string(),
     tts_model: Yup.string(),
     default_voice: Yup.string(),
-    stt_languages: detail.sttLanguages
-      ? Yup.string().test(
-          "locales",
-          "Enter comma-separated locales like en-US, fr-FR (one per language)",
-          (value, context) => {
-            if (!value) return true;
-            const languages = parseSttLanguages(value);
-            const bases = languages.map((lang) =>
-              lang.split("-")[0]!.toLowerCase()
-            );
-            if (
-              new Set(bases).size !== bases.length ||
-              !languages.every((lang) => STT_LOCALE_PATTERN.test(lang))
-            ) {
-              return false;
+    stt_languages:
+      mode === "stt" && detail.sttLanguages
+        ? Yup.string().test(
+            "locales",
+            "Enter comma-separated locales like en-US, fr-FR (one per language)",
+            (value, context) => {
+              if (!value) return true;
+              const languages = parseSttLanguages(value);
+              const bases = languages.map((lang) =>
+                lang.split("-")[0]!.toLowerCase()
+              );
+              if (
+                new Set(bases).size !== bases.length ||
+                !languages.every((lang) => STT_LOCALE_PATTERN.test(lang))
+              ) {
+                return false;
+              }
+              const cap = maxSttLanguagesForTargetUri(
+                context.parent.target_uri ?? ""
+              );
+              if (languages.length > cap) {
+                return context.createError({
+                  message:
+                    cap === MAX_STT_LANGUAGES
+                      ? `Azure supports at most ${cap} spoken languages`
+                      : `Self-hosted endpoints support at most ${cap} spoken languages (at-start detection)`,
+                });
+              }
+              return true;
             }
-            const cap = maxSttLanguagesForTargetUri(
-              context.parent.target_uri ?? ""
-            );
-            if (languages.length > cap) {
-              return context.createError({
-                message:
-                  cap === MAX_STT_LANGUAGES
-                    ? `Azure supports at most ${cap} spoken languages`
-                    : `Self-hosted endpoints support at most ${cap} spoken languages (at-start detection)`,
-              });
-            }
-            return true;
-          }
-        )
-      : Yup.string(),
+          )
+        : Yup.string(),
   });
 
   const initialValues: VoiceFormValues = {


### PR DESCRIPTION
## Description

The Azure Speech voice provider was hardcoded to English on every path, so speech in any other language produced garbage transcripts and English-locale-only TTS. This treats multilingual support as a bug fix — the other voice providers already handle non-English speech (OpenAI Whisper auto-detects; ElevenLabs uses a multilingual TTS model), so Azure was the outlier:

- **Streaming STT** never set a recognition language (SDK silently defaults to `en-US`).
- **Chunked REST STT** pinned `language=en-US`.
- **TTS** pinned SSML `xml:lang='en-US'` with an English-only voice list.

### What this does

- Adds `stt_languages` to the provider's existing `custom_config` JSONB (**no migration**). One locale pins recognition; multiple locales enable Azure language auto-detect, so mixed-language orgs get per-utterance detection. Continuous language identification requires building the `SpeechConfig` from the `universal/v2` endpoint — a region-based config silently degrades to at-start detection ([Azure LID docs](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-identification)). Self-hosted container endpoints keep at-start detection.
- Chunked REST fallback uses the first configured language (that API has no auto-detect) and logs a warning when it degrades a multi-language config.
- Derives SSML `xml:lang` from the voice name (`fr-FR-DeniseNeural` → `fr-FR`), locale-validated so malformed voice names can't inject into the attribute.
- Adds multilingual (Ava/Andrew — speak the language of the response text) and French voices to the curated picker.
- New **Spoken Languages** field on the Azure STT admin modal, gated by a `VoiceProviderDetail` capability flag so other providers can adopt it as a data change.
- Fixes a latent config-wipe bug along the way: upsert now treats `custom_config=None` as leave-unchanged (`{}` clears), so a save from one modal can no longer wipe API-set keys like `speech_region`; the admin form round-trips `custom_config`. Config validation errors now surface as real messages instead of the generic credentials error.

Existing deployments are unaffected: with no `stt_languages` configured, behavior is exactly today's (`en-US`).

## How Has This Been Tested?

- 128 voice unit tests pass, including new coverage for locale parsing/normalization/dedupe, the 10-candidate cap, SSML locale derivation + injection guard, and the `custom_config` preserve/clear upsert semantics.
- Azure SDK symbols (`AutoDetectSourceLanguageConfig`, `SpeechServiceConnection_LanguageIdMode`) verified against the pinned `azure-cognitiveservices-speech==1.50.0`.
- Full pre-commit suite (ruff, ty, oxlint, TypeScript) green.
- **Not** yet exercised against a live Azure Speech resource (no credentials in the dev environment) — a smoke test with a real key (e.g. `en-US, fr-FR` + a multilingual voice) is the one remaining verification.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multilingual STT/TTS to the Azure voice provider and removes English-only defaults. Admin now lets you set spoken languages with inline caps based on the endpoint and skips STT validation in TTS-only flows.

- **New Features**
  - Adds `custom_config.stt_languages` for Azure STT: one locale pins recognition; multiple enable auto-detect with continuous LID via `universal/v2` (REST fallback uses the first locale and logs a warning when downgrading).
  - Derives and validates SSML `xml:lang` from the voice name. Adds multilingual (`en-US-AvaMultilingualNeural`, `en-US-AndrewMultilingualNeural`) and French voices. Admin (Azure-only): shows a Spoken Languages field, exposes `custom_config`, and validates locale format and caps inline based on `target_uri` (cloud 10, self-hosted 4).

- **Bug Fixes**
  - `upsert_voice_provider` preserves `custom_config` when omitted (`{}` clears). Streaming STT now sets recognition language(s); backend enforces Azure LID rules (one locale per base language; candidate caps; strict locale validation and SSML injection guard) and surfaces real validation errors (verified against `azure-cognitiveservices-speech@1.50.0`).
  - Skips STT language validation in the TTS modal so saves aren’t blocked when a self-hosted endpoint stores more than 4 locales.

<sup>Written for commit be700179fee6c6b14361d10b17f2107b20ee7182. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

