### PR TITLE
fix(ci): seed Enterprise license for Craft Compose tests

### DIFF
--- a/.github/workflows/pr-craft-compose-integration.yml
+++ b/.github/workflows/pr-craft-compose-integration.yml
@@ -91,6 +91,7 @@ jobs:
               - 'backend/tests/integration/tests/craft/*.py'
               - 'backend/tests/integration/tests/craft/docker_e2e/**'
               - '.github/workflows/pr-craft-compose-integration.yml'
+              - '.github/actions/setup-test-license/**'
               - '.github/actions/setup-python-and-install-dependencies/**'
               - '.github/actions/login-ecr-pullthrough-cache/**'
 
@@ -206,6 +207,9 @@ jobs:
     name: craft-compose (${{ matrix.test-file.name }})
     needs: [changes, discover-test-files, build-images]
     if: needs.changes.outputs.craft_compose == 'true'
+    permissions:
+      contents: read
+      id-token: write
     runs-on:
       - runs-on
       - runner=4cpu-linux-x64
@@ -232,6 +236,11 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
+
+      - name: Fetch dev license
+        uses: ./.github/actions/setup-test-license
+        with:
+          aws-oidc-role-arn: ${{ secrets.AWS_OIDC_ROLE_ARN }}
 
       - name: Setup Python + deps
         uses: ./.github/actions/setup-python-and-install-dependencies
@@ -303,6 +312,13 @@ jobs:
           docker ps --format 'table {{.Names}}\t{{.Status}}'
           curl --fail -sS -o /dev/null -w "api_server /health -> %{http_code}\n" \
             http://localhost:8080/health
+
+      - name: Seed dev license
+        run: |
+          docker exec \
+            -e ONYX_DEV_LICENSE="${ONYX_DEV_LICENSE}" \
+            onyx-api_server-1 \
+            python -m scripts.seed_dev_license
 
       - name: Run integration tests
         timeout-minutes: 25

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,6 +44,7 @@
     },
     {
       "name": "Run All Onyx Services (k8s)",
+      "preLaunchTask": "k8s: telepresence quit",
       "configurations": [
         "Web Server",
         "API Server (k8s)",


### PR DESCRIPTION
## Description

Fetch and seed the shared Enterprise dev license before running Craft Docker Compose integration tests.

The LLM gateway is now Enterprise-tier gated. The Craft streaming tests exercise it from sandbox containers, but the Compose lane previously started the API server without a license, causing turns to fail with `402 FEATURE_NOT_AVAILABLE`.

This also grants the job the OIDC permission required by the shared license action and makes changes to that action trigger the workflow.

Additionally, stop any existing Telepresence session before launching the local Kubernetes service group from VS Code, preventing stale routing state from carrying into a new development session.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check