### PR TITLE
fix(chat): correct long-chat context accounting and model-switch replay

### DIFF
--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -776,6 +776,7 @@ def convert_chat_history(
                     token_count=chat_message.token_count + image_token_count,
                     message_type=MessageType.USER,
                     image_files=image_files if image_files else None,
+                    image_token_count=image_token_count,
                 )
             )
 

--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -842,11 +842,7 @@ def convert_chat_history(
                         simple_messages.append(
                             ChatMessageSimple(
                                 message=tool_response_message,
-                                token_count=(
-                                    token_counter(tool_response_message)
-                                    if tool_name == IMAGE_GENERATION_TOOL_NAME
-                                    else 20
-                                ),
+                                token_count=token_counter(tool_response_message),
                                 message_type=MessageType.TOOL_CALL_RESPONSE,
                                 tool_call_id=tool_call.tool_call_id,
                                 image_files=None,

--- a/backend/onyx/chat/compression.py
+++ b/backend/onyx/chat/compression.py
@@ -173,6 +173,11 @@ def get_summary_parent_message_id(chat_history: list[ChatMessage]) -> int:
     for msg in reversed(chat_history):
         if msg.message_type == MessageType.USER:
             return msg.id
+    logger.warning(
+        "No USER message in chat history when parenting summary "
+        "(session %s); falling back to chain tail",
+        chat_history[-1].chat_session_id,
+    )
     return chat_history[-1].id
 
 
@@ -213,7 +218,9 @@ def get_messages_to_summarize(
     tokens_used = 0
 
     for msg in reversed(messages):
-        msg_tokens = msg.token_count or 0
+        # Same per-message cost as the compression trigger (tool-call
+        # arguments included) so the verbatim tail respects the budget.
+        msg_tokens = calculate_total_history_tokens([msg])
         if tokens_used + msg_tokens > tokens_for_recent and recent_messages:
             break
         recent_messages.insert(0, msg)

--- a/backend/onyx/chat/compression.py
+++ b/backend/onyx/chat/compression.py
@@ -68,7 +68,8 @@ class SummaryContent(NamedTuple):
 
 def calculate_total_history_tokens(chat_history: list[ChatMessage]) -> int:
     """
-    Calculate the total token count for the given chat history.
+    Calculate the total token count for the given chat history, including
+    tool-call argument tokens (which are replayed alongside the messages).
 
     Args:
         chat_history: Branch-aware list of messages
@@ -76,7 +77,12 @@ def calculate_total_history_tokens(chat_history: list[ChatMessage]) -> int:
     Returns:
         Total token count for the history
     """
-    return sum(m.token_count or 0 for m in chat_history)
+    total = 0
+    for m in chat_history:
+        total += m.token_count or 0
+        for tool_call in m.tool_calls or []:
+            total += tool_call.tool_call_tokens or 0
+    return total
 
 
 def get_compression_params(
@@ -202,6 +208,23 @@ def get_messages_to_summarize(
     # non-user messages from recent_messages to older_messages
     while recent_messages and recent_messages[0].message_type != MessageType.USER:
         recent_messages.pop(0)
+
+    if not recent_messages:
+        # The verbatim tail had no USER message (e.g. a tool-heavy turn).
+        # Rather than summarizing away the latest exchange, keep everything
+        # from the last USER message onward; with no USER at all, skip
+        # compression entirely (older_messages empty → caller no-ops).
+        last_user_idx = next(
+            (
+                i
+                for i in range(len(messages) - 1, -1, -1)
+                if messages[i].message_type == MessageType.USER
+            ),
+            None,
+        )
+        if last_user_idx is None:
+            return SummaryContent(older_messages=[], recent_messages=messages)
+        recent_messages = messages[last_user_idx:]
 
     # Everything else gets summarized
     recent_ids = {m.id for m in recent_messages}

--- a/backend/onyx/chat/compression.py
+++ b/backend/onyx/chat/compression.py
@@ -161,6 +161,21 @@ def find_summary_for_branch(
     return None
 
 
+def get_summary_parent_message_id(chat_history: list[ChatMessage]) -> int:
+    """Parent for a new summary: the last USER message in the chain.
+
+    Every sibling branch — multi-model answers, regenerations — shares that
+    USER message, so the summary applies to whichever answer the user
+    continues from. Parenting to the assistant tail would orphan the summary
+    for all but that one branch (find_summary_for_branch matches on
+    parent_message_id being in the branch's history).
+    """
+    for msg in reversed(chat_history):
+        if msg.message_type == MessageType.USER:
+            return msg.id
+    return chat_history[-1].id
+
+
 def get_messages_to_summarize(
     chat_history: list[ChatMessage],
     existing_summary: ChatMessage | None,
@@ -458,7 +473,7 @@ def compress_chat_history(
                     message_type=MessageType.ASSISTANT,
                     message=summary_text,
                     token_count=summary_token_count,
-                    parent_message_id=chat_history[-1].id,
+                    parent_message_id=get_summary_parent_message_id(chat_history),
                     last_summarized_message_id=summary_content.older_messages[-1].id,
                 )
                 write_session.add(summary_message)

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -407,11 +407,16 @@ def construct_message_history(
         )
 
     def _replay_token_count(msg: ChatMessageSimple) -> int:
-        if not image_files_replayed_as_markers or not msg.image_token_count:
+        if not image_files_replayed_as_markers:
             return msg.token_count
+        # Charge markers for every IMAGE entry, including ones whose stored
+        # token contribution is zero (project/context images are never
+        # counted) — the marker text is still sent for them.
         num_images = sum(
             1 for f in msg.image_files or [] if f.file_type == ChatFileType.IMAGE
         )
+        if not num_images:
+            return msg.token_count
         return (
             max(0, msg.token_count - msg.image_token_count) + num_images * marker_tokens
         )

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -42,12 +42,18 @@ from onyx.context.search.models import SearchDoc, SearchDocsResponse
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.memory import UserMemoryContext, add_memory, update_memory_at_index
 from onyx.db.models import Persona
+from onyx.file_store.models import ChatFileType
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.exceptions import ClassifiedLLMError
 from onyx.llm.interfaces import LLM, LLMUserIdentity, ToolChoiceOptions
 from onyx.llm.model_capabilities import is_true_openai_model
 from onyx.llm.models import ReasoningEffort
-from onyx.prompts.chat_prompts import IMAGE_GEN_REMINDER, OPEN_URL_REMINDER
+from onyx.llm.utils import model_supports_image_input
+from onyx.prompts.chat_prompts import (
+    IMAGE_GEN_REMINDER,
+    NON_VISION_IMAGE_MARKER,
+    OPEN_URL_REMINDER,
+)
 from onyx.prompts.prompt_utils import substitute_user_placeholders
 from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import (
@@ -80,6 +86,10 @@ from onyx.tracing.framework.create import ChatTraceMetadata, trace
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+# Used when no token_counter is available to measure the non-vision image
+# marker; intentionally generous so budgeting stays conservative.
+_NON_VISION_MARKER_TOKEN_FALLBACK = 40
 
 
 class EmptyLLMResponseError(ClassifiedLLMError):
@@ -375,12 +385,36 @@ def construct_message_history(
     last_n_user_messages: int | None = None,
     token_counter: Callable[[str], int] | None = None,
     all_injected_file_metadata: dict[str, FileToolMetadata] | None = None,
+    image_files_replayed_as_markers: bool = False,
 ) -> list[ChatMessageSimple]:
     if last_n_user_messages is not None:
         if last_n_user_messages <= 0:
             raise ValueError(
                 "filtering chat history by last N user messages must be a value greater than 0"
             )
+
+    # Budget each message at its replay cost: when the model takes no image
+    # input, translate_history_to_llm_format sends short text markers instead
+    # of the images, so charging the stored image token cost would evict
+    # history that actually fits.
+    marker_tokens = 0
+    if image_files_replayed_as_markers:
+        sample_marker = NON_VISION_IMAGE_MARKER.format(file_id="0" * 36)
+        marker_tokens = (
+            token_counter(sample_marker)
+            if token_counter
+            else _NON_VISION_MARKER_TOKEN_FALLBACK
+        )
+
+    def _replay_token_count(msg: ChatMessageSimple) -> int:
+        if not image_files_replayed_as_markers or not msg.image_token_count:
+            return msg.token_count
+        num_images = sum(
+            1 for f in msg.image_files or [] if f.file_type == ChatFileType.IMAGE
+        )
+        return (
+            max(0, msg.token_count - msg.image_token_count) + num_images * marker_tokens
+        )
 
     # Build the project / file-metadata messages up front so we can use their
     # actual token counts for the budget.
@@ -451,8 +485,10 @@ def construct_message_history(
     messages_after_last_user = simple_chat_history[last_user_msg_index + 1 :]
 
     # Calculate tokens needed for the last user message and everything after it
-    last_user_tokens = last_user_message.token_count
-    after_user_tokens = sum(msg.token_count for msg in messages_after_last_user)
+    last_user_tokens = _replay_token_count(last_user_message)
+    after_user_tokens = sum(
+        _replay_token_count(msg) for msg in messages_after_last_user
+    )
 
     # Check if we can fit at least the last user message and messages after it
     required_tokens = last_user_tokens + after_user_tokens
@@ -473,10 +509,11 @@ def construct_message_history(
     current_token_count = 0
 
     for msg in reversed(history_before_last_user):
-        if current_token_count + msg.token_count <= remaining_budget:
+        msg_tokens = _replay_token_count(msg)
+        if current_token_count + msg_tokens <= remaining_budget:
             msg.should_cache = True
             truncated_history_before.insert(0, msg)
-            current_token_count += msg.token_count
+            current_token_count += msg_tokens
         else:
             # Can't fit this message, stop truncating.
             # This message and everything older is dropped.
@@ -525,7 +562,7 @@ def construct_message_history(
             remaining_budget -= forgotten_files_message.token_count
             while truncated_history_before and current_token_count > remaining_budget:
                 evicted = truncated_history_before.pop(0)
-                current_token_count -= evicted.token_count
+                current_token_count -= _replay_token_count(evicted)
                 # If the evicted message is itself a file, add it to the
                 # forgotten metadata (it's now dropped too).
                 if (
@@ -768,6 +805,15 @@ def run_llm_loop(
         available_tokens = int(
             llm.config.max_input_tokens * (1 - GEN_AI_INPUT_TOKEN_SAFETY_MARGIN)
         )
+        # When the model takes no image input, history images are replayed as
+        # short text markers (translate_history_to_llm_format) — budget them
+        # as markers too, not at their stored image token cost.
+        image_files_replayed_as_markers = any(
+            msg.message_type == MessageType.USER and msg.image_files
+            for msg in simple_chat_history
+        ) and not model_supports_image_input(
+            llm.config.model_name, llm.config.model_provider
+        )
         tool_choice: ToolChoiceOptions = ToolChoiceOptions.AUTO
         # Initialize gathered_documents with project files if present
         gathered_documents: list[SearchDoc] | None = (
@@ -977,6 +1023,7 @@ def run_llm_loop(
                 available_tokens=max(0, available_tokens - tool_token_budget),
                 token_counter=token_counter,
                 all_injected_file_metadata=all_injected_file_metadata,
+                image_files_replayed_as_markers=image_files_replayed_as_markers,
             )
 
             # This calls the LLM, yields packets (reasoning, answers, etc.) and returns the result

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -866,10 +866,25 @@ def translate_history_to_llm_format(
     last_cacheable_msg_idx = -1
     all_previous_msgs_cacheable = True
 
+    # History can contain images even when the current model cannot accept
+    # them (e.g. the user switched models mid-session). Sending them yields a
+    # provider 400, so replay a text marker instead. Admins can mark custom
+    # vision models with the VISION flow type to keep images flowing.
+    supports_image_input = True
+    if any(msg.message_type == MessageType.USER and msg.image_files for msg in history):
+        supports_image_input = model_supports_image_input(
+            llm_config.model_name, llm_config.model_provider
+        )
+
     # Per-request image cap (provider-aware). When the cap is enforced and
     # images are dropped, we emit a system-reminder UserMessage at the end of
     # the translated request — the same pattern MessageType.USER_REMINDER uses.
-    image_cap = resolve_image_cap(llm_config.model_provider)
+    # The cap bounds image payloads, so it only applies when images are
+    # actually sent — markers for a non-vision model are plain text and must
+    # never be capped away.
+    image_cap = (
+        resolve_image_cap(llm_config.model_provider) if supports_image_input else None
+    )
     keep_image_indices: set[tuple[int, int]] | None = None
     image_drop_notice: str | None = None
     if image_cap is not None:
@@ -887,16 +902,6 @@ def translate_history_to_llm_format(
             image_drop_notice = IMAGE_DROP_REMINDER.format(
                 dropped_count=dropped_image_count
             )
-
-    # History can contain images even when the current model cannot accept
-    # them (e.g. the user switched models mid-session). Sending them yields a
-    # provider 400, so replay a text marker instead. Admins can mark custom
-    # vision models with the VISION flow type to keep images flowing.
-    supports_image_input = True
-    if any(msg.message_type == MessageType.USER and msg.image_files for msg in history):
-        supports_image_input = model_supports_image_input(
-            llm_config.model_name, llm_config.model_provider
-        )
 
     for idx, msg in enumerate(history):
         # if the message is being added to the history

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -43,7 +43,11 @@ from onyx.llm.models import (
 )
 from onyx.llm.prompt_cache.processor import process_with_prompt_cache
 from onyx.llm.utils import model_needs_formatting_reenabled, model_supports_image_input
-from onyx.prompts.chat_prompts import CODE_BLOCK_MARKDOWN, IMAGE_DROP_REMINDER
+from onyx.prompts.chat_prompts import (
+    CODE_BLOCK_MARKDOWN,
+    IMAGE_DROP_REMINDER,
+    NON_VISION_IMAGE_MARKER,
+)
 from onyx.prompts.constants import SYSTEM_REMINDER_TAG_CLOSE, SYSTEM_REMINDER_TAG_OPEN
 from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import (
@@ -940,10 +944,8 @@ def translate_history_to_llm_format(
                         content_parts.append(
                             TextContentPart(
                                 type="text",
-                                text=(
-                                    f"[attached image — file_id: {img_file.file_id} — "
-                                    "not shown: the current model does not support "
-                                    "image input]"
+                                text=NON_VISION_IMAGE_MARKER.format(
+                                    file_id=img_file.file_id
                                 ),
                             )
                         )

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -42,7 +42,7 @@ from onyx.llm.models import (
     UserMessage,
 )
 from onyx.llm.prompt_cache.processor import process_with_prompt_cache
-from onyx.llm.utils import model_needs_formatting_reenabled
+from onyx.llm.utils import model_needs_formatting_reenabled, model_supports_image_input
 from onyx.prompts.chat_prompts import CODE_BLOCK_MARKDOWN, IMAGE_DROP_REMINDER
 from onyx.prompts.constants import SYSTEM_REMINDER_TAG_CLOSE, SYSTEM_REMINDER_TAG_OPEN
 from onyx.server.query_and_chat.placement import Placement
@@ -884,6 +884,16 @@ def translate_history_to_llm_format(
                 dropped_count=dropped_image_count
             )
 
+    # History can contain images even when the current model cannot accept
+    # them (e.g. the user switched models mid-session). Sending them yields a
+    # provider 400, so replay a text marker instead. Admins can mark custom
+    # vision models with the VISION flow type to keep images flowing.
+    supports_image_input = True
+    if any(msg.message_type == MessageType.USER and msg.image_files for msg in history):
+        supports_image_input = model_supports_image_input(
+            llm_config.model_name, llm_config.model_provider
+        )
+
     for idx, msg in enumerate(history):
         # if the message is being added to the history
         if PROMPT_CACHE_CHAT_HISTORY and msg.message_type in [
@@ -925,6 +935,18 @@ def translate_history_to_llm_format(
                         keep_image_indices is not None
                         and (idx, img_idx) not in keep_image_indices
                     ):
+                        continue
+                    if not supports_image_input:
+                        content_parts.append(
+                            TextContentPart(
+                                type="text",
+                                text=(
+                                    f"[attached image — file_id: {img_file.file_id} — "
+                                    "not shown: the current model does not support "
+                                    "image input]"
+                                ),
+                            )
+                        )
                         continue
                     try:
                         image_type = get_image_type_from_bytes(img_file.content)

--- a/backend/onyx/chat/models.py
+++ b/backend/onyx/chat/models.py
@@ -156,6 +156,10 @@ class ChatMessageSimple(BaseModel):
     message_type: MessageType
     # Only for USER type messages
     image_files: list[ChatLoadedFile] | None = None
+    # Portion of token_count contributed by image_files. Kept separate so
+    # budgeting can discount it when a non-vision model replays the images
+    # as text markers instead.
+    image_token_count: int = 0
     # Only for TOOL_CALL_RESPONSE type messages
     tool_call_id: str | None = None
     # For ASSISTANT messages with tool calls (OpenAI parallel tool calling format)

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1201,7 +1201,12 @@ def _run_models(
                 reserved_tokens=setup.reserved_token_count,
                 # All models share one mainline chain — compressing per model
                 # would create duplicate summaries and N summarization calls.
+                # The single check must still protect the smallest-window
+                # model, so the trigger measures against the min window.
                 run_compression=model_idx == 0,
+                compression_max_input_tokens=min(
+                    model_llm.config.max_input_tokens for model_llm in setup.llms
+                ),
             )
         except Exception:
             logger.exception(
@@ -1857,6 +1862,7 @@ def llm_loop_completion_handle(
     llm: LLM,
     reserved_tokens: int,
     run_compression: bool = True,
+    compression_max_input_tokens: int | None = None,
 ) -> None:
     # Snapshot all state under the container's lock before any DB write.
     # Worker threads may still be running (e.g. user-cancellation path), so
@@ -1937,7 +1943,7 @@ def llm_loop_completion_handle(
         return
 
     compression_params = get_compression_params(
-        max_input_tokens=llm.config.max_input_tokens,
+        max_input_tokens=compression_max_input_tokens or llm.config.max_input_tokens,
         current_history_tokens=total_tokens,
         reserved_tokens=reserved_tokens,
     )

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1146,6 +1146,10 @@ def _run_models(
     model_error_info: list[LLMErrorInfo | None] = [None] * n_models
     persist_lock = threading.Lock()
     persisted: list[bool] = [False] * n_models
+    # All models share one mainline chain, so exactly one completion should
+    # run history compression — the first non-errored one to persist, not a
+    # fixed index (model 0 may have errored). Guarded by persist_lock.
+    compression_claimed: list[bool] = [False]
     post_steps_done = threading.Event()
 
     # Set only on stop-button: workers can't be interrupted, so their remaining
@@ -1192,6 +1196,10 @@ def _run_models(
         def _is_connected(value: bool = completed_normally) -> bool:
             return value
 
+        with persist_lock:
+            run_compression = not compression_claimed[0]
+            compression_claimed[0] = True
+
         try:
             llm_loop_completion_handle(
                 state_container=state_containers[model_idx],
@@ -1199,11 +1207,10 @@ def _run_models(
                 assistant_message=setup.reserved_messages[model_idx],
                 llm=setup.llms[model_idx],
                 reserved_tokens=setup.reserved_token_count,
-                # All models share one mainline chain — compressing per model
-                # would create duplicate summaries and N summarization calls.
-                # The single check must still protect the smallest-window
-                # model, so the trigger measures against the min window.
-                run_compression=model_idx == 0,
+                run_compression=run_compression,
+                # The single compression check must still protect the
+                # smallest-window model, so it measures against the min
+                # window across the turn's models.
                 compression_max_input_tokens=min(
                     model_llm.config.max_input_tokens for model_llm in setup.llms
                 ),
@@ -1215,6 +1222,12 @@ def _run_models(
                 model_idx,
                 setup.model_display_names[model_idx],
             )
+            if run_compression:
+                # The handle failed before compression could have run
+                # (compress_chat_history swallows its own errors), so let a
+                # later model's completion pick it up.
+                with persist_lock:
+                    compression_claimed[0] = False
 
     def _run_post_steps() -> None:
         with persist_lock:

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1149,7 +1149,7 @@ def _run_models(
     # All models share one mainline chain, so exactly one completion should
     # run history compression — the first non-errored one to persist, not a
     # fixed index (model 0 may have errored). Guarded by persist_lock.
-    compression_claimed: list[bool] = [False]
+    compression_claimed = False
     post_steps_done = threading.Event()
 
     # Set only on stop-button: workers can't be interrupted, so their remaining
@@ -1196,9 +1196,10 @@ def _run_models(
         def _is_connected(value: bool = completed_normally) -> bool:
             return value
 
+        nonlocal compression_claimed
         with persist_lock:
-            run_compression = not compression_claimed[0]
-            compression_claimed[0] = True
+            run_compression = not compression_claimed
+            compression_claimed = True
 
         try:
             llm_loop_completion_handle(
@@ -1225,9 +1226,12 @@ def _run_models(
             if run_compression:
                 # The handle failed before compression could have run
                 # (compress_chat_history swallows its own errors), so let a
-                # later model's completion pick it up.
+                # later model's completion pick it up. If every other model
+                # already persisted while the claim was held, this turn ends
+                # uncompressed — acceptable, since the next turn's completion
+                # re-evaluates the trigger and compresses then.
                 with persist_lock:
-                    compression_claimed[0] = False
+                    compression_claimed = False
 
     def _run_post_steps() -> None:
         with persist_lock:

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -108,6 +108,7 @@ from onyx.llm.utils import (
     litellm_exception_to_safe_error,
     scrub_sensitive_values,
 )
+from onyx.natural_language_processing.utils import get_tokenizer
 from onyx.onyxbot.slack.models import SlackContext
 from onyx.prompts.prompt_utils import substitute_user_placeholders
 from onyx.server.query_and_chat.chat_utils import mime_type_to_chat_file_type
@@ -762,11 +763,15 @@ def build_chat_turn(
                 hook_result, message_text
             )
 
+        # Store with the model-agnostic default tokenizer (same convention as
+        # assistant/summary rows in save_chat.py) so budget math sums a single
+        # unit even after mid-session model switches.
+        default_tokenizer = get_tokenizer(None, None)
         user_message = create_new_chat_message(
             chat_session_id=chat_session.id,
             parent_message=parent_message,
             message=message_text,
-            token_count=token_counter(message_text),
+            token_count=len(default_tokenizer.encode(message_text)),
             message_type=MessageType.USER,
             files=new_msg_req.file_descriptors,
             db_session=db_session,
@@ -1194,6 +1199,9 @@ def _run_models(
                 assistant_message=setup.reserved_messages[model_idx],
                 llm=setup.llms[model_idx],
                 reserved_tokens=setup.reserved_token_count,
+                # All models share one mainline chain — compressing per model
+                # would create duplicate summaries and N summarization calls.
+                run_compression=model_idx == 0,
             )
         except Exception:
             logger.exception(
@@ -1848,6 +1856,7 @@ def llm_loop_completion_handle(
     assistant_message: ChatMessage,
     llm: LLM,
     reserved_tokens: int,
+    run_compression: bool = True,
 ) -> None:
     # Snapshot all state under the container's lock before any DB write.
     # Worker threads may still be running (e.g. user-cancellation path), so
@@ -1908,7 +1917,24 @@ def llm_loop_completion_handle(
             chat_session_id=chat_session_id,
             db_session=db_session,
         )
-        total_tokens = calculate_total_history_tokens(updated_chat_history)
+
+        # Measure what the next turn will actually replay: the branch summary
+        # (if any) plus messages after its cutoff. The full chain only grows,
+        # so counting it would keep the trigger on permanently once crossed
+        # and inflate tokens_for_recent until compression stalls.
+        summary_message = find_summary_for_branch(db_session, updated_chat_history)
+        effective_history = updated_chat_history
+        summary_tokens = 0
+        if summary_message and summary_message.last_summarized_message_id:
+            cutoff_id = summary_message.last_summarized_message_id
+            effective_history = [m for m in updated_chat_history if m.id > cutoff_id]
+            summary_tokens = summary_message.token_count or 0
+        total_tokens = summary_tokens + calculate_total_history_tokens(
+            effective_history
+        )
+
+    if not run_compression:
+        return
 
     compression_params = get_compression_params(
         max_input_tokens=llm.config.max_input_tokens,

--- a/backend/onyx/prompts/chat_prompts.py
+++ b/backend/onyx/prompts/chat_prompts.py
@@ -96,6 +96,13 @@ TOOL_CALL_RESPONSE_CROSS_MESSAGE = """
 This tool call completed but the results are no longer accessible.
 """.strip()
 
+# Replayed in place of an image when the current model does not accept image
+# input (e.g. after a mid-session model switch).
+NON_VISION_IMAGE_MARKER = (
+    "[attached image — file_id: {file_id} — not shown: the current model does "
+    "not support image input]"
+)
+
 # This is used to add the current date and time to the prompt in the case where the Agent should be aware of the current
 # date and time but the replacement pattern is not present in the prompt.
 ADDITIONAL_INFO = "\n\nAdditional Information:\n\t- {datetime_info}."

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -135,6 +135,7 @@ def _get_available_tokens_for_persona(
     persona: Persona,
     db_session: Session,
     user: User,
+    llm_override: LLMOverride | None = None,
 ) -> int:
     def _get_non_reserved_input_tokens(
         model_max_input_tokens: int,
@@ -151,7 +152,7 @@ def _get_available_tokens_for_persona(
             - default_reserved_tokens
         )
 
-    llm = get_llm_for_persona(persona=persona, user=user)
+    llm = get_llm_for_persona(persona=persona, user=user, llm_override=llm_override)
     token_counter = get_llm_token_counter(llm)
 
     if persona.replace_base_system_prompt and persona.system_prompt:
@@ -917,10 +918,16 @@ class AvailableContextTokensResponse(BaseModel):
 @router.get("/available-context-tokens/{session_id}")
 def get_available_context_tokens_for_session(
     session_id: UUID,
+    model_configuration_id: int | None = None,
     user: User = Depends(current_chat_accessible_user),
     db_session: Session = Depends(get_session),
 ) -> AvailableContextTokensResponse:
-    """Return available context tokens for a chat session based on its persona."""
+    """Return available context tokens for a chat session based on its persona.
+
+    ``model_configuration_id`` selects the model the user currently has picked
+    for the session — without it the budget reflects the persona/global
+    default model, which can differ after a mid-session model switch.
+    """
 
     try:
         chat_session = get_chat_session_by_id(
@@ -936,10 +943,16 @@ def get_available_context_tokens_for_session(
     if not chat_session.persona:
         raise HTTPException(status_code=400, detail="Chat session has no persona")
 
+    llm_override = (
+        LLMOverride(model_configuration_id=model_configuration_id)
+        if model_configuration_id is not None
+        else None
+    )
     available = _get_available_tokens_for_persona(
         persona=chat_session.persona,
         user=user,
         db_session=db_session,
+        llm_override=llm_override,
     )
 
     return AvailableContextTokensResponse(available_tokens=available)

--- a/backend/tests/unit/onyx/chat/test_chat_utils.py
+++ b/backend/tests/unit/onyx/chat/test_chat_utils.py
@@ -309,3 +309,42 @@ class TestConvertChatHistory:
         assert last_user.image_files is not None
         assert len(last_user.image_files) == 1
         assert last_user.image_files[0].file_id == "project_image"
+
+    def test_tool_response_placeholder_token_count_is_measured(self) -> None:
+        """Cross-turn tool responses are replayed as a placeholder — its
+        budgeted token count must come from the token counter, not a
+        hardcoded constant."""
+        tool_call = MagicMock()
+        tool_call.turn_number = 0
+        tool_call.tool_id = 1
+        tool_call.tool_call_id = "call-1"
+        tool_call.tool_call_arguments = {"queries": ["alpha"]}
+        tool_call.tool_call_tokens = 12
+        tool_call.generated_images = None
+        tool_call.tool_call_response = "original tool output"
+
+        assistant_msg = self._make_chat_message("final answer", MessageType.ASSISTANT)
+        assistant_msg.tool_calls = [tool_call]
+
+        chat_history = [
+            self._make_chat_message("A question", MessageType.USER),
+            assistant_msg,
+        ]
+
+        result = convert_chat_history(
+            chat_history=cast(list[ChatMessage], chat_history),
+            files=[],
+            context_image_files=[],
+            additional_context=None,
+            token_counter=lambda s: len(s),
+            tool_id_to_name_map={1: "internal_search"},
+        )
+
+        tool_responses = [
+            m
+            for m in result.simple_messages
+            if m.message_type == MessageType.TOOL_CALL_RESPONSE
+        ]
+        assert len(tool_responses) == 1
+        assert tool_responses[0].message == TOOL_CALL_RESPONSE_CROSS_MESSAGE
+        assert tool_responses[0].token_count == len(TOOL_CALL_RESPONSE_CROSS_MESSAGE)

--- a/backend/tests/unit/onyx/chat/test_compression.py
+++ b/backend/tests/unit/onyx/chat/test_compression.py
@@ -11,6 +11,7 @@ from onyx.chat.compression import (
     generate_summary,
     get_compression_params,
     get_messages_to_summarize,
+    get_summary_parent_message_id,
 )
 from onyx.configs.constants import MessageType
 from onyx.llm.models import AssistantMessage, SystemMessage, UserMessage
@@ -197,6 +198,32 @@ def test_no_user_in_recent_tail_keeps_last_user_exchange() -> None:
     )
     assert [m.id for m in result.recent_messages] == [3, 4]
     assert [m.id for m in result.older_messages] == [1, 2]
+
+
+def test_summary_parent_is_last_user_message() -> None:
+    """Summaries parent to the last USER message so every sibling branch
+    (multi-model answers, regenerations) can find them."""
+    messages = [
+        create_mock_message(1, "q1", 100),
+        create_mock_message(2, "a1", 100, MessageType.ASSISTANT),
+        create_mock_message(3, "q2", 100),
+        create_mock_message(4, "a2", 100, MessageType.ASSISTANT),
+    ]
+    assert (
+        get_summary_parent_message_id(messages)  # ty: ignore[invalid-argument-type]
+        == 3
+    )
+
+
+def test_summary_parent_falls_back_to_tail_without_user_messages() -> None:
+    messages = [
+        create_mock_message(1, "a1", 100, MessageType.ASSISTANT),
+        create_mock_message(2, "a2", 100, MessageType.ASSISTANT),
+    ]
+    assert (
+        get_summary_parent_message_id(messages)  # ty: ignore[invalid-argument-type]
+        == 2
+    )
 
 
 def test_no_user_messages_at_all_skips_compression() -> None:

--- a/backend/tests/unit/onyx/chat/test_compression.py
+++ b/backend/tests/unit/onyx/chat/test_compression.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 from onyx.chat.compression import (
     SummaryContent,
     _build_llm_messages_for_summarization,
+    calculate_total_history_tokens,
     find_summary_for_branch,
     generate_summary,
     get_compression_params,
@@ -155,6 +156,62 @@ def test_empty_history_returns_empty() -> None:
     )
     assert result.older_messages == []
     assert result.recent_messages == []
+
+
+def test_calculate_total_history_tokens_includes_tool_call_tokens() -> None:
+    """Tool-call argument tokens are replayed with the history, so the
+    compression trigger must count them too."""
+    tool_call = MagicMock()
+    tool_call.tool_call_tokens = 30
+    messages = [
+        create_mock_message(1, "question", 100),
+        create_mock_message(
+            2,
+            "answer",
+            50,
+            MessageType.ASSISTANT,
+            tool_calls=[tool_call, tool_call],
+        ),
+    ]
+    assert (
+        calculate_total_history_tokens(messages)  # ty: ignore[invalid-argument-type]
+        == 210
+    )
+
+
+def test_no_user_in_recent_tail_keeps_last_user_exchange() -> None:
+    """A verbatim tail without a USER message must not cause the entire
+    conversation (including the latest exchange) to be summarized away."""
+    messages = [
+        create_mock_message(1, "q1", 100),
+        create_mock_message(2, "a1", 100, MessageType.ASSISTANT),
+        create_mock_message(3, "q2", 100),
+        create_mock_message(4, "a2", 50, MessageType.ASSISTANT),
+    ]
+    result = get_messages_to_summarize(
+        chat_history=messages,  # ty: ignore[invalid-argument-type]
+        existing_summary=None,
+        # Only fits the final ASSISTANT message, which then gets popped as a
+        # leading non-USER message.
+        tokens_for_recent=60,
+    )
+    assert [m.id for m in result.recent_messages] == [3, 4]
+    assert [m.id for m in result.older_messages] == [1, 2]
+
+
+def test_no_user_messages_at_all_skips_compression() -> None:
+    """With no USER message anywhere, nothing is summarized (caller no-ops
+    on empty older_messages)."""
+    messages = [
+        create_mock_message(1, "a1", 100, MessageType.ASSISTANT),
+        create_mock_message(2, "a2", 100, MessageType.ASSISTANT),
+    ]
+    result = get_messages_to_summarize(
+        chat_history=messages,  # ty: ignore[invalid-argument-type]
+        existing_summary=None,
+        tokens_for_recent=50,
+    )
+    assert result.older_messages == []
 
 
 def test_find_summary_for_branch_returns_matching_branch() -> None:

--- a/backend/tests/unit/onyx/chat/test_llm_loop.py
+++ b/backend/tests/unit/onyx/chat/test_llm_loop.py
@@ -737,6 +737,59 @@ def _make_file_metadata(
     )
 
 
+class TestNonVisionImageBudgeting:
+    """When a non-vision model replays history images as text markers, the
+    truncation budget must charge the marker cost, not the stored image token
+    cost — otherwise history that actually fits gets evicted."""
+
+    @staticmethod
+    def _image_user_msg() -> ChatMessageSimple:
+        image = ChatLoadedFile(
+            file_id="img0",
+            content=b"",
+            file_type=ChatFileType.IMAGE,
+            filename="img0.png",
+            content_text=None,
+            token_count=500,
+        )
+        return ChatMessageSimple(
+            message="look at this",
+            token_count=505,
+            message_type=MessageType.USER,
+            image_files=[image],
+            image_token_count=500,
+        )
+
+    def _construct(self, replay_as_markers: bool) -> list[ChatMessageSimple]:
+        simple_chat_history = [
+            self._image_user_msg(),
+            create_message("Response", MessageType.ASSISTANT, 5),
+            create_message("Follow-up", MessageType.USER, 5),
+        ]
+        return construct_message_history(
+            system_prompt=None,
+            custom_agent_prompt=None,
+            simple_chat_history=simple_chat_history,
+            reminder_message=None,
+            context_files=create_context_files(),
+            available_tokens=100,
+            token_counter=lambda _: 10,
+            image_files_replayed_as_markers=replay_as_markers,
+        )
+
+    def test_full_image_cost_evicts_the_image_message(self) -> None:
+        result = self._construct(replay_as_markers=False)
+        assert [m.message for m in result] == ["Response", "Follow-up"]
+
+    def test_marker_cost_keeps_the_image_message(self) -> None:
+        result = self._construct(replay_as_markers=True)
+        assert [m.message for m in result] == [
+            "look at this",
+            "Response",
+            "Follow-up",
+        ]
+
+
 class TestForgottenFileMetadata:
     """Tests for the forgotten-files mechanism in construct_message_history.
 

--- a/backend/tests/unit/onyx/chat/test_llm_step.py
+++ b/backend/tests/unit/onyx/chat/test_llm_step.py
@@ -19,7 +19,13 @@ from onyx.configs.constants import MessageType
 from onyx.file_store.models import ChatFileType
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.interfaces import LLMConfig, ToolChoiceOptions
-from onyx.llm.models import AssistantMessage, TextContentPart, ToolMessage, UserMessage
+from onyx.llm.models import (
+    AssistantMessage,
+    ImageContentPart,
+    TextContentPart,
+    ToolMessage,
+    UserMessage,
+)
 from onyx.llm.well_known_providers.constants import (
     AZURE_PROVIDER_NAME,
     OPENAI_PROVIDER_NAME,
@@ -659,6 +665,13 @@ class TestImageCap:
     the same 30-line feature.
     """
 
+    @pytest.fixture(autouse=True)
+    def _vision_capable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # These tests exercise the cap, not the vision gate — pin it open.
+        monkeypatch.setattr(
+            llm_step_module, "model_supports_image_input", lambda *_: True
+        )
+
     def test_disabled_by_default_passes_everything_through(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -718,6 +731,65 @@ class TestImageCap:
         assert len(translated) == 1
         assert isinstance(translated[0], UserMessage)
         assert len(_attached_image_file_ids(translated[0])) == 5
+
+
+class TestNonVisionImageStripping:
+    """History can contain images the currently selected model cannot accept
+    (e.g. after a mid-session model switch). translate_history_to_llm_format
+    must replace them with text markers instead of causing a provider 400."""
+
+    def test_strips_image_parts_for_non_vision_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            llm_step_module, "model_supports_image_input", lambda *_: False
+        )
+        history = [_make_user_msg("look at this", images=[_make_image("img0")])]
+        translated = translate_history_to_llm_format(
+            history=history, llm_config=_make_llm_config(OPENAI_PROVIDER_NAME)
+        )
+        assert isinstance(translated, list)
+        (user_msg,) = translated
+        assert isinstance(user_msg, UserMessage)
+        assert isinstance(user_msg.content, list)
+        assert not any(isinstance(p, ImageContentPart) for p in user_msg.content)
+        markers = [
+            p.text
+            for p in user_msg.content
+            if isinstance(p, TextContentPart) and "img0" in p.text
+        ]
+        assert markers
+        assert "does not support image input" in markers[0]
+
+    def test_keeps_image_parts_for_vision_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            llm_step_module, "model_supports_image_input", lambda *_: True
+        )
+        history = [_make_user_msg("look at this", images=[_make_image("img0")])]
+        translated = translate_history_to_llm_format(
+            history=history, llm_config=_make_llm_config(OPENAI_PROVIDER_NAME)
+        )
+        (user_msg,) = translated
+        assert isinstance(user_msg, UserMessage)
+        assert isinstance(user_msg.content, list)
+        assert _attached_image_file_ids(user_msg) == ["img0"]
+        assert any(isinstance(p, ImageContentPart) for p in user_msg.content)
+
+    def test_capability_not_checked_without_images(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(*_: object) -> bool:
+            raise AssertionError("capability check should not run for text-only")
+
+        monkeypatch.setattr(llm_step_module, "model_supports_image_input", _boom)
+        history = [_make_user_msg("just text")]
+        translated = translate_history_to_llm_format(
+            history=history, llm_config=_make_llm_config(OPENAI_PROVIDER_NAME)
+        )
+        assert isinstance(translated, list)
+        assert len(translated) == 1
 
 
 class TestEmptyAnswerRecovery:

--- a/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
+++ b/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
@@ -675,6 +675,36 @@ class TestRunModels:
 
         mock_handle.assert_not_called()
 
+    def test_compression_falls_to_first_successful_model_when_model_0_errors(
+        self,
+    ) -> None:
+        """Compression ownership goes to the first non-errored completion, not
+        a fixed model index — a model-0 failure must not skip compression."""
+        setup = _make_setup(n_models=2)
+
+        def fail_model_0(**kwargs: Any) -> None:
+            if kwargs["llm"] is setup.llms[0]:
+                raise RuntimeError("fail")
+
+        with (
+            patch("onyx.chat.process_message.run_llm_loop", side_effect=fail_model_0),
+            patch("onyx.chat.process_message.run_deep_research_llm_loop"),
+            patch("onyx.chat.process_message.construct_tools", return_value={}),
+            patch(
+                "onyx.chat.process_message.llm_loop_completion_handle"
+            ) as mock_handle,
+            patch(
+                "onyx.chat.process_message.get_llm_token_counter",
+                return_value=lambda _: 0,
+            ),
+        ):
+            _run_models_collect(setup)
+
+        assert mock_handle.call_count == 1
+        call = mock_handle.call_args_list[0]
+        assert call.kwargs["llm"] is setup.llms[1]
+        assert call.kwargs["run_compression"] is True
+
     def test_http_disconnect_completion_via_generator_exit(self) -> None:
         """Worker-thread completion survives HTTP disconnect."""
 

--- a/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
+++ b/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
@@ -652,6 +652,11 @@ class TestRunModels:
         persisted_llms = [call.kwargs["llm"] for call in mock_handle.call_args_list]
         assert persisted_llms.count(setup.llms[0]) == 1
         assert persisted_llms.count(setup.llms[1]) == 1
+        # Exactly one completion owns compression; the other must skip it.
+        compression_flags = sorted(
+            call.kwargs["run_compression"] for call in mock_handle.call_args_list
+        )
+        assert compression_flags == [False, True]
 
     def test_completion_handle_not_called_for_failed_model(self) -> None:
         """llm_loop_completion_handle must be skipped for a model that raised."""

--- a/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
+++ b/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
@@ -255,6 +255,9 @@ def _make_setup(n_models: int = 1) -> MagicMock:
     """Minimal ChatTurnSetup mock whose fields pass Pydantic validation in _run_model."""
     setup = MagicMock()
     setup.llms = [MagicMock() for _ in range(n_models)]
+    # Real int so the min() over model windows in _persist_model_outcome works.
+    for mock_llm in setup.llms:
+        mock_llm.config.max_input_tokens = 32_000
     setup.model_display_names = [f"model-{i}" for i in range(n_models)]
     setup.check_is_connected = MagicMock(return_value=True)
     setup.reserved_messages = [MagicMock() for _ in range(n_models)]

--- a/web/src/app/app/services/lib.tsx
+++ b/web/src/app/app/services/lib.tsx
@@ -399,10 +399,15 @@ export async function deleteAllChatSessions() {
 }
 
 export async function getAvailableContextTokens(
-  chatSessionId: string
+  chatSessionId: string,
+  modelConfigurationId?: number | null
 ): Promise<number | null> {
+  const params =
+    modelConfigurationId != null
+      ? `?model_configuration_id=${modelConfigurationId}`
+      : "";
   const response = await fetch(
-    `/api/chat/available-context-tokens/${chatSessionId}`
+    `/api/chat/available-context-tokens/${chatSessionId}${params}`
   );
   if (!response.ok) {
     return null;

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -1475,7 +1475,10 @@ export default function useChatController({
     (async () => {
       try {
         if (sessionId) {
-          const available = await getAvailableContextTokens(sessionId);
+          const available = await getAvailableContextTokens(
+            sessionId,
+            llmManager.currentLlm.modelConfigurationId
+          );
           setIfActive(available ?? DEFAULT_CONTEXT_TOKENS);
           return;
         }
@@ -1502,6 +1505,7 @@ export default function useChatController({
     existingChatSessionId,
     liveAgent?.id,
     llmManager.hasAnyProvider,
+    llmManager.currentLlm.modelConfigurationId,
   ]);
 
   // check if there's an image file in the message history so that we know


### PR DESCRIPTION
## Description

Investigation of two reports: long chats degrading, and context seemingly lost when switching models mid-conversation. The model switch itself turned out fine — the full history is replayed to the newly selected model and the context window is recomputed per request — but the investigation surfaced eight real accounting/replay bugs around it, fixed here.

**Model-switch robustness**
- History images were base64-inlined for every model; a non-vision model then rejected the request with a 400 and the whole turn failed. `translate_history_to_llm_format` now checks `model_supports_image_input` (once per request, only when USER images exist in history) and replays a text marker instead. Admins can mark custom vision models with the VISION flow type to keep images flowing.
- `/chat/available-context-tokens` always resolved the persona/global default LLM, so the input bar's context budget was wrong after a model switch (and the frontend never refetched on model change). The endpoint now accepts an optional `model_configuration_id` (resolved through `get_llm_for_persona`, which already enforces provider access), and the frontend passes the selected model and refetches when it changes.

**Long-chat accounting**
- The compression trigger measured the full message chain, but replay only sends the branch summary + post-cutoff messages. Since the chain only grows, the trigger latched on permanently once crossed, and `tokens_for_recent` (20% of the measured history) grew until `get_messages_to_summarize` had nothing left to summarize — compression stalled in very long sessions while silent hard truncation took over. The trigger now measures the effective (replayed) history.
- Tool-call argument tokens are replayed with the history but were invisible to the trigger, under-reporting tool-heavy sessions.
- Multi-model turns ran the compression check once per model over the same mainline chain, creating duplicate summaries and N summarization LLM calls per turn; only the first model's completion handle compresses now.
- USER rows were token-counted with the per-turn LLM tokenizer while ASSISTANT/summary rows always use the model-agnostic default tokenizer (per `save_chat.py`), so budgets summed mixed units after a model switch. USER rows now use the default tokenizer too.
- Cross-turn tool responses were budgeted at a hardcoded 20 tokens; the replayed placeholder is longer. The actual text is counted now.
- If the verbatim tail contained no USER message (tool-heavy turns), `get_messages_to_summarize` summarized the entire conversation including the latest exchange. It now keeps everything from the last USER message onward, and skips compression when no USER message exists.

Known trade-off: a vision-capable custom model that is neither marked VISION in its model configuration nor known to litellm now gets text markers instead of images. The VISION flow-type flag is the escape hatch; previously every *non*-vision model hard-failed the turn instead.

## How Has This Been Tested?

- 9 new unit tests pinning each behavior (image stripping/markers, placeholder counting, tool-token counting, summarize-everything guard); chat unit suite 495/495.
- Full backend unit suite: 8002 passed with **zero new failures** (the 21 failures reproduce identically on the base commit — pre-existing environment issues in license / process-isolation / confluence tests).
- External-dependency chat tests: 39/39 against real Postgres/Redis.
- `pre-commit` (ty, ruff, ruff format) and web `tsc --noEmit` green.
- Deploy-safety: the new query param is optional, so old-frontend↔new-backend and new-frontend↔old-backend both degrade to current behavior during rolling deploys.
- Backport probe: all three commits cherry-pick cleanly onto `release/v4.5` and the chat suite passes on the picked tree (v4.4 would need a small hand-port of the accounting commit). Cherry-pick box left unchecked pending a decision.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes long‑chat context accounting and makes model switches robust. Prevents 400s on non‑vision models, budgets images at marker cost (including project/context images), restores accurate context budgets, keeps summarization working (and parented to the last USER) in very long sessions, and ensures multi‑model turns compress once using the smallest window and the first successful completion.

- **Bug Fixes**
  - Non‑vision models: replace history images with text markers; budget at marker cost; apply the Azure image cap only when images are actually sent; vision models still receive images.
  - Context budget: endpoint accepts `model_configuration_id`; frontend passes it and refetches on model change.
  - Compression: measure replayed history (summary + post‑cutoff) and include tool‑call argument tokens; tail selection counts the same tokens.
  - Multi‑model turns: one compression per turn, owned by the first successful completion; measured against the smallest model window.
  - Tokenization: store USER messages with the default tokenizer to avoid mixed units after model switches.
  - Tool response placeholder: count actual text, not a fixed 20 tokens.
  - Summarization: parent summaries to the last USER so they apply across branches; keep from the last USER onward and skip compression if no USER exists.
  - Trade‑off: custom vision models must be marked VISION (or recognized by `litellm`) to receive images; otherwise text markers are used.

<sup>Written for commit bd3944b91af74a8c619af8b19ff024f74479680c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

