### PR TITLE
feat(desktop): global summon shortcut + View-menu navigation accelerators

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1257,6 +1257,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,6 +1402,24 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c386b0a4a70cb2d39fffd74480f985b6f0bfbcb934b6a6b6b7e630e448f242e"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -2031,6 +2059,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2470,6 +2504,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-shell",
  "tauri-plugin-window-state",
  "tokio",
@@ -3263,6 +3298,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4125,6 +4173,21 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9f4c5136c09cd962da0c86dc4accd4666db2ea591cf16e6597435843bd2b"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5726,6 +5789,29 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ tauri-build = { version = "2.6", features = [] }
 
 [dependencies]
 tauri = { version = "2.11", features = ["macos-private-api", "tray-icon", "image-png"] }
+tauri-plugin-global-shortcut = "2.3.1"
 tauri-plugin-shell = "2.3.5"
 tauri-plugin-window-state = "2.4.1"
 clap = { version = "4", features = ["derive"] }

--- a/desktop/src-tauri/src/config.rs
+++ b/desktop/src-tauri/src/config.rs
@@ -24,6 +24,14 @@ pub struct AppConfig {
 
     #[serde(default)]
     pub hide_window_decorations: bool,
+
+    /// Global shortcut that summons Onyx from any app, in Tauri accelerator
+    /// syntax. Explicit `null` in config.json disables it.
+    #[serde(default = "default_summon_shortcut")]
+    pub summon_shortcut: Option<String>,
+
+    #[serde(default = "default_summon_opens_new_chat")]
+    pub summon_opens_new_chat: bool,
 }
 
 fn default_window_title() -> String {
@@ -34,6 +42,24 @@ const fn default_show_menu_bar() -> bool {
     true
 }
 
+// Space-with-modifiers chords are the only family major apps leave alone.
+// Alt+Space is contested on Windows (system window menu, Copilot, PowerToys
+// Run) and Ctrl+Alt+<letter> collides with AltGr typing on European layouts,
+// so Ctrl+Alt+Space is the safe non-mac default.
+#[allow(clippy::unnecessary_wraps)] // serde default for an `Option` field must return `Option`
+fn default_summon_shortcut() -> Option<String> {
+    let chord = if cfg!(target_os = "macos") {
+        "Super+Shift+Space"
+    } else {
+        "Ctrl+Alt+Space"
+    };
+    Some(chord.to_string())
+}
+
+const fn default_summon_opens_new_chat() -> bool {
+    true
+}
+
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
@@ -41,6 +67,8 @@ impl Default for AppConfig {
             window_title: default_window_title(),
             show_menu_bar: true,
             hide_window_decorations: false,
+            summon_shortcut: default_summon_shortcut(),
+            summon_opens_new_chat: true,
         }
     }
 }
@@ -195,5 +223,38 @@ impl ConfigState {
             .app_base_url
             .write()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = url;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::unwrap_used)]
+    fn parse(json: &str) -> AppConfig {
+        serde_json::from_str(json).unwrap()
+    }
+
+    #[test]
+    fn missing_summon_fields_get_defaults() {
+        let config = parse(r#"{"server_url": "https://cloud.onyx.app"}"#);
+        assert_eq!(config.summon_shortcut, default_summon_shortcut());
+        assert!(config.summon_shortcut.is_some());
+        assert!(config.summon_opens_new_chat);
+    }
+
+    #[test]
+    fn explicit_null_disables_summon_shortcut() {
+        let config = parse(r#"{"server_url": "https://cloud.onyx.app", "summon_shortcut": null}"#);
+        assert_eq!(config.summon_shortcut, None);
+    }
+
+    #[test]
+    fn custom_summon_settings_are_preserved() {
+        let config = parse(
+            r#"{"server_url": "https://cloud.onyx.app", "summon_shortcut": "F19", "summon_opens_new_chat": false}"#,
+        );
+        assert_eq!(config.summon_shortcut.as_deref(), Some("F19"));
+        assert!(!config.summon_opens_new_chat);
     }
 }

--- a/desktop/src-tauri/src/config.rs
+++ b/desktop/src-tauri/src/config.rs
@@ -68,7 +68,7 @@ impl Default for AppConfig {
             show_menu_bar: true,
             hide_window_decorations: false,
             summon_shortcut: default_summon_shortcut(),
-            summon_opens_new_chat: true,
+            summon_opens_new_chat: default_summon_opens_new_chat(),
         }
     }
 }
@@ -187,13 +187,21 @@ impl ConfigState {
     /// concurrent caller can't save its own update in between this update and
     /// this save (which would otherwise leave `config.json` not matching
     /// whichever update actually happened last in memory).
+    ///
+    /// A failed save rolls the in-memory config back to its prior value, so a
+    /// setting can't appear to change for the session and then silently revert
+    /// on the next launch.
     pub fn update_and_persist(&self, f: impl FnOnce(&mut AppConfig)) -> Result<AppConfig, String> {
         let _guard = self
             .persist_lock
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous = self.config();
         let config = self.update_config(f);
-        save_config(&config)?;
+        if let Err(e) = save_config(&config) {
+            self.update_config(|current| *current = previous);
+            return Err(e);
+        }
         Ok(config)
     }
 

--- a/desktop/src-tauri/src/debug_log.rs
+++ b/desktop/src-tauri/src/debug_log.rs
@@ -93,20 +93,7 @@ pub fn log_backend_error(app: &AppHandle, message: &str) {
     if !state.debug_mode {
         return;
     }
-    // Bind the lock result to a named local rather than matching on it
-    // directly in the `if let` scrutinee: `if let Ok(x) = mutex.lock() { }`
-    // extends the whole `Result<MutexGuard, _>` temporary's lifetime to the
-    // end of the enclosing block, which the borrow checker rejects here
-    // since that block also owns `state` (the guard's ultimate borrow
-    // source). A named binding is scoped by normal liveness instead.
-    let lock_result = state.debug_log_file.lock();
-    if let Ok(mut guard) = lock_result {
-        if let Some(ref mut file) = *guard {
-            let line = format!("[{}] [ERROR] {}", format_utc_timestamp(), message);
-            let _ = writeln!(file, "{line}");
-            let _ = file.flush();
-        }
-    }
+    append_debug_log_line(&state, "ERROR", message);
 }
 
 /// Debug-mode-only sibling of `log_backend_error` for tracing expected
@@ -117,12 +104,20 @@ pub fn log_backend_debug(app: &AppHandle, message: &str) {
         return;
     }
     eprintln!("[ONYX DEBUG] {message}");
+    append_debug_log_line(&state, "DEBUG", message);
+}
 
-    // Named binding for the same borrow-checker reason as `log_backend_error`.
+/// Append one line to the debug log file. The lock result is bound to a named
+/// local rather than matched directly in the `if let` scrutinee: `if let
+/// Ok(x) = mutex.lock() { }` extends the whole `Result<MutexGuard, _>`
+/// temporary's lifetime to the end of the enclosing block, which the borrow
+/// checker rejects when that block also owns the guard's ultimate borrow
+/// source. A named binding is scoped by normal liveness instead.
+fn append_debug_log_line(state: &ConfigState, level: &str, message: &str) {
     let lock_result = state.debug_log_file.lock();
     if let Ok(mut guard) = lock_result {
         if let Some(ref mut file) = *guard {
-            let line = format!("[{}] [DEBUG] {}", format_utc_timestamp(), message);
+            let line = format!("[{}] [{level}] {}", format_utc_timestamp(), message);
             let _ = writeln!(file, "{line}");
             let _ = file.flush();
         }

--- a/desktop/src-tauri/src/debug_log.rs
+++ b/desktop/src-tauri/src/debug_log.rs
@@ -109,6 +109,26 @@ pub fn log_backend_error(app: &AppHandle, message: &str) {
     }
 }
 
+/// Debug-mode-only sibling of `log_backend_error` for tracing expected
+/// behavior, e.g. confirming a global shortcut registered and actually fires.
+pub fn log_backend_debug(app: &AppHandle, message: &str) {
+    let state = app.state::<ConfigState>();
+    if !state.debug_mode {
+        return;
+    }
+    eprintln!("[ONYX DEBUG] {message}");
+
+    // Named binding for the same borrow-checker reason as `log_backend_error`.
+    let lock_result = state.debug_log_file.lock();
+    if let Ok(mut guard) = lock_result {
+        if let Some(ref mut file) = *guard {
+            let line = format!("[{}] [DEBUG] {}", format_utc_timestamp(), message);
+            let _ = writeln!(file, "{line}");
+            let _ = file.flush();
+        }
+    }
+}
+
 pub fn inject_console_capture(webview: &Webview) {
     if let Err(e) = webview.eval(CONSOLE_CAPTURE_SCRIPT) {
         log_backend_error(

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -230,6 +230,9 @@ fn main() {
             menu::MENU_NEW_CHAT_ID => window::trigger_new_chat(app),
             menu::MENU_NEW_WINDOW_ID => window::trigger_new_window(app),
             menu::MENU_OPEN_SETTINGS_ID => window::open_settings(app),
+            menu::MENU_RELOAD_ID => menu::handle_reload(app),
+            menu::MENU_GO_BACK_ID => menu::handle_go_back(app),
+            menu::MENU_GO_FORWARD_ID => menu::handle_go_forward(app),
             menu::MENU_SHOW_MENU_BAR_ID => menu::handle_menu_bar_toggle(app),
             #[cfg(target_os = "linux")]
             menu::MENU_HIDE_DECORATIONS_ID => menu::handle_decorations_toggle(app),

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -9,6 +9,7 @@ mod commands;
 mod config;
 mod debug_log;
 mod menu;
+mod shortcuts;
 mod window;
 
 use clap::Parser;
@@ -107,6 +108,9 @@ fn print_debug_startup_banner() {
 /// window's platform tweaks, and Alt-menu/devtools wiring. Every failure here
 /// is logged and non-fatal, so this never needs to return a `Result`.
 fn setup_app(app: &tauri::AppHandle) {
+    // Before the tray, so its menu can reflect whether the shortcut registered.
+    shortcuts::setup_global_shortcuts(app);
+
     if let Err(e) = menu::setup_app_menu(app) {
         debug_log::log_backend_error(app, &format!("Failed to setup menu: {e}"));
     }
@@ -170,6 +174,7 @@ fn main() {
     // `std::process::exit` internally on some platforms.
     #[allow(clippy::expect_used, clippy::exit)]
     tauri::Builder::default()
+        .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .plugin(tauri_plugin_shell::init())
         .plugin(
             tauri::plugin::Builder::<Wry>::new("chat-external-navigation-handler")

--- a/desktop/src-tauri/src/menu.rs
+++ b/desktop/src-tauri/src/menu.rs
@@ -1,5 +1,6 @@
 use crate::config::ConfigState;
 use crate::debug_log::{log_backend_error, MENU_OPEN_DEBUG_LOG_ID, MENU_TOGGLE_DEVTOOLS_ID};
+use crate::shortcuts::SummonShortcut;
 use crate::window::{focus_main_window, open_chat_window};
 use tauri::image::Image;
 #[cfg(not(target_os = "macos"))]
@@ -18,6 +19,7 @@ const TRAY_ICON_BYTES: &[u8] = include_bytes!("../icons/tray-icon.png");
 const ABOUT_ICON_BYTES: &[u8] = include_bytes!("../icons/128x128.png");
 const TRAY_MENU_OPEN_APP_ID: &str = "tray_open_app";
 const TRAY_MENU_OPEN_CHAT_ID: &str = "tray_open_chat";
+const TRAY_MENU_SUMMON_NEW_CHAT_ID: &str = "tray_summon_new_chat";
 const TRAY_MENU_SHOW_IN_BAR_ID: &str = "tray_show_in_menu_bar";
 const TRAY_MENU_QUIT_ID: &str = "tray_quit";
 pub const MENU_SHOW_MENU_BAR_ID: &str = "show_menu_bar";
@@ -288,14 +290,47 @@ pub fn handle_decorations_toggle(app: &AppHandle) {
 }
 
 fn build_tray_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
-    let open_app = MenuItem::with_id(app, TRAY_MENU_OPEN_APP_ID, "Open Onyx", true, None::<&str>)?;
+    let summon_chord = app
+        .try_state::<SummonShortcut>()
+        .map(|shortcut| shortcut.chord.clone());
+    let summon_opens_new_chat = app.state::<ConfigState>().config().summon_opens_new_chat;
+
+    // Surface the summon chord on whichever tray action it actually triggers.
+    // Tray accelerators are display-only hints here; the real binding is the
+    // global shortcut registered in `shortcuts.rs`.
+    let (open_app_chord, open_chat_chord) = if summon_opens_new_chat {
+        (None, summon_chord.clone())
+    } else {
+        (summon_chord.clone(), None)
+    };
+
+    let open_app = MenuItem::with_id(
+        app,
+        TRAY_MENU_OPEN_APP_ID,
+        "Open Onyx",
+        true,
+        open_app_chord.as_deref(),
+    )?;
     let open_chat = MenuItem::with_id(
         app,
         TRAY_MENU_OPEN_CHAT_ID,
         "Open Chat Window",
         true,
-        None::<&str>,
+        open_chat_chord.as_deref(),
     )?;
+    // Only meaningful while a summon shortcut is registered.
+    let summon_new_chat = if summon_chord.is_some() {
+        Some(CheckMenuItem::with_id(
+            app,
+            TRAY_MENU_SUMMON_NEW_CHAT_ID,
+            "New Chat on Summon",
+            true,
+            summon_opens_new_chat,
+            None::<&str>,
+        )?)
+    } else {
+        None
+    };
     let show_in_menu_bar = CheckMenuItem::with_id(
         app,
         TRAY_MENU_SHOW_IN_BAR_ID,
@@ -308,14 +343,42 @@ fn build_tray_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
     show_in_menu_bar.set_enabled(false)?;
     let quit = PredefinedMenuItem::quit(app, Some("Quit Onyx"))?;
 
-    MenuBuilder::new(app)
-        .item(&open_app)
-        .item(&open_chat)
+    let mut builder = MenuBuilder::new(app).item(&open_app).item(&open_chat);
+    if let Some(item) = summon_new_chat.as_ref() {
+        builder = builder.separator().item(item);
+    }
+    builder
         .separator()
         .item(&show_in_menu_bar)
         .separator()
         .item(&quit)
         .build()
+}
+
+/// Toggle whether the global summon shortcut opens a new chat or just focuses
+/// the window, then rebuild the tray menu so the accelerator hint follows the
+/// action it actually triggers.
+fn handle_summon_new_chat_toggle(app: &AppHandle) {
+    let state = app.state::<ConfigState>();
+    if let Err(e) = state.update_and_persist(|c| c.summon_opens_new_chat = !c.summon_opens_new_chat)
+    {
+        log_backend_error(app, &format!("Failed to save config: {e}"));
+    }
+    refresh_tray_menu(app);
+}
+
+fn refresh_tray_menu(app: &AppHandle) {
+    let Some(tray) = app.tray_by_id(TRAY_ID) else {
+        return;
+    };
+    match build_tray_menu(app) {
+        Ok(menu) => {
+            if let Err(e) = tray.set_menu(Some(menu)) {
+                log_backend_error(app, &format!("Failed to refresh tray menu: {e}"));
+            }
+        }
+        Err(e) => log_backend_error(app, &format!("Failed to rebuild tray menu: {e}")),
+    }
 }
 
 // `TRAY_MENU_SHOW_IN_BAR_ID`'s arm is intentionally kept distinct from the
@@ -334,6 +397,7 @@ fn handle_tray_menu_event(app: &AppHandle, id: &str) {
         TRAY_MENU_QUIT_ID => {
             app.exit(0);
         }
+        TRAY_MENU_SUMMON_NEW_CHAT_ID => handle_summon_new_chat_toggle(app),
         TRAY_MENU_SHOW_IN_BAR_ID => {}
         _ => {}
     }

--- a/desktop/src-tauri/src/menu.rs
+++ b/desktop/src-tauri/src/menu.rs
@@ -29,6 +29,9 @@ pub const MENU_NEW_CHAT_ID: &str = "new_chat";
 pub const MENU_NEW_WINDOW_ID: &str = "new_window";
 pub const MENU_OPEN_SETTINGS_ID: &str = "open_settings";
 pub const MENU_OPEN_DOCS_ID: &str = "open_docs";
+pub const MENU_RELOAD_ID: &str = "reload_page";
+pub const MENU_GO_BACK_ID: &str = "go_back";
+pub const MENU_GO_FORWARD_ID: &str = "go_forward";
 
 /// Handles to the checkable menu items, populated once in `setup_app_menu`.
 /// Toggling reaches for these directly instead of re-walking the whole menu
@@ -79,6 +82,80 @@ fn build_file_menu(app: &AppHandle, menu: &Menu<Wry>) -> tauri::Result<()> {
     }
 
     Ok(())
+}
+
+/// Reload/Back/Forward as View-menu accelerators. These are the chords the
+/// removed global-shortcut set (#7914) wrongly registered system-wide; as
+/// menu accelerators they only fire while an Onyx window has focus.
+fn build_view_menu(app: &AppHandle, menu: &Menu<Wry>) -> tauri::Result<()> {
+    let reload_item = MenuItem::with_id(app, MENU_RELOAD_ID, "Reload", true, Some("CmdOrCtrl+R"))?;
+
+    // Browser-convention history chords: Cmd+[ / Cmd+] on macOS, Alt+arrows elsewhere.
+    let (back_accel, forward_accel) = if cfg!(target_os = "macos") {
+        ("CmdOrCtrl+BracketLeft", "CmdOrCtrl+BracketRight")
+    } else {
+        ("Alt+ArrowLeft", "Alt+ArrowRight")
+    };
+    let back_item = MenuItem::with_id(app, MENU_GO_BACK_ID, "Back", true, Some(back_accel))?;
+    let forward_item = MenuItem::with_id(
+        app,
+        MENU_GO_FORWARD_ID,
+        "Forward",
+        true,
+        Some(forward_accel),
+    )?;
+
+    if let Some(view_menu) = menu
+        .items()?
+        .into_iter()
+        .filter_map(|item| item.as_submenu().cloned())
+        .find(|submenu| submenu.text().ok().as_deref() == Some("View"))
+    {
+        view_menu.insert_items(&[&reload_item, &back_item, &forward_item], 0)?;
+        view_menu.insert(&PredefinedMenuItem::separator(app)?, 3)?;
+    } else {
+        let view_menu = SubmenuBuilder::new(app, "View")
+            .items(&[&reload_item, &back_item, &forward_item])
+            .build()?;
+        let items = menu.items()?;
+        let insert_idx = items
+            .iter()
+            .position(|item| {
+                let text = item.as_submenu().and_then(|submenu| submenu.text().ok());
+                matches!(text.as_deref(), Some("Window" | "Help"))
+            })
+            .unwrap_or(items.len());
+        menu.insert(&view_menu, insert_idx)?;
+    }
+
+    Ok(())
+}
+
+/// The window a View-menu action should apply to: whichever one is focused
+/// (menu accelerators only fire while the app is active, but the app can have
+/// several windows).
+fn focused_webview_window(app: &AppHandle) -> Option<tauri::WebviewWindow> {
+    app.webview_windows()
+        .into_values()
+        .find(|window| window.is_focused().unwrap_or(false))
+}
+
+pub fn handle_reload(app: &AppHandle) {
+    if let Some(window) = focused_webview_window(app) {
+        crate::commands::reload_page(window);
+    }
+}
+
+pub fn handle_go_back(app: &AppHandle) {
+    if let Some(window) = focused_webview_window(app) {
+        crate::commands::go_back(window);
+    }
+}
+
+pub fn handle_go_forward(app: &AppHandle) {
+    if let Some(window) = focused_webview_window(app) {
+        crate::commands::go_forward(window);
+    }
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -218,6 +295,7 @@ pub fn setup_app_menu(app: &AppHandle) -> tauri::Result<()> {
     let menu = app.menu().unwrap_or(Menu::default(app)?);
 
     build_file_menu(app, &menu)?;
+    build_view_menu(app, &menu)?;
     #[cfg(not(target_os = "macos"))]
     build_window_menu(app, &menu)?;
     build_help_menu(app, &menu)?;

--- a/desktop/src-tauri/src/menu.rs
+++ b/desktop/src-tauri/src/menu.rs
@@ -135,9 +135,12 @@ fn build_view_menu(app: &AppHandle, menu: &Menu<Wry>) -> tauri::Result<()> {
 /// (menu accelerators only fire while the app is active, but the app can have
 /// several windows).
 fn focused_webview_window(app: &AppHandle) -> Option<tauri::WebviewWindow> {
-    app.webview_windows()
-        .into_values()
-        .find(|window| window.is_focused().unwrap_or(false))
+    app.webview_windows().into_values().find(|window| {
+        window.is_focused().unwrap_or_else(|e| {
+            log_backend_error(app, &format!("Failed to query window focus: {e}"));
+            false
+        })
+    })
 }
 
 pub fn handle_reload(app: &AppHandle) {

--- a/desktop/src-tauri/src/shortcuts.rs
+++ b/desktop/src-tauri/src/shortcuts.rs
@@ -1,5 +1,5 @@
 use crate::config::ConfigState;
-use crate::debug_log::log_backend_error;
+use crate::debug_log::{log_backend_debug, log_backend_error};
 use crate::window::{focus_main_window, open_chat_window};
 use tauri::{AppHandle, Manager};
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
@@ -36,7 +36,12 @@ pub fn setup_global_shortcuts(app: &AppHandle) {
             if event.state() != ShortcutState::Pressed {
                 return;
             }
-            if app.state::<ConfigState>().config().summon_opens_new_chat {
+            let opens_new_chat = app.state::<ConfigState>().config().summon_opens_new_chat;
+            log_backend_debug(
+                app,
+                &format!("Summon shortcut fired (opens_new_chat={opens_new_chat})"),
+            );
+            if opens_new_chat {
                 open_chat_window(app);
             } else {
                 focus_main_window(app);
@@ -45,6 +50,7 @@ pub fn setup_global_shortcuts(app: &AppHandle) {
 
     match result {
         Ok(()) => {
+            log_backend_debug(app, &format!("Registered summon shortcut \"{chord}\""));
             app.manage(SummonShortcut { chord });
         }
         // Registration fails when another app owns the chord (reliably

--- a/desktop/src-tauri/src/shortcuts.rs
+++ b/desktop/src-tauri/src/shortcuts.rs
@@ -1,0 +1,75 @@
+use crate::config::ConfigState;
+use crate::debug_log::log_backend_error;
+use crate::window::{focus_main_window, open_chat_window};
+use tauri::{AppHandle, Manager};
+use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
+
+/// Managed only while the summon shortcut is actually registered, so menus
+/// can surface the chord without risking advertising a binding that failed
+/// to register.
+pub struct SummonShortcut {
+    pub chord: String,
+}
+
+/// Register the configured summon shortcut. This is deliberately the only
+/// global (system-wide) shortcut the app registers: summoning Onyx is the one
+/// action that must work while another app is focused. Every other shortcut
+/// belongs in the menus, which only fire while Onyx has focus -- registering
+/// in-app chords like CmdOrCtrl+N globally steals them from every other
+/// application (the #7914 regression).
+pub fn setup_global_shortcuts(app: &AppHandle) {
+    let Some(chord) = app.state::<ConfigState>().config().summon_shortcut else {
+        return;
+    };
+
+    let shortcut: Shortcut = match chord.parse() {
+        Ok(shortcut) => shortcut,
+        Err(e) => {
+            log_backend_error(app, &format!("Invalid summon shortcut \"{chord}\": {e}"));
+            return;
+        }
+    };
+
+    let result = app
+        .global_shortcut()
+        .on_shortcut(shortcut, |app, _shortcut, event| {
+            if event.state() != ShortcutState::Pressed {
+                return;
+            }
+            if app.state::<ConfigState>().config().summon_opens_new_chat {
+                open_chat_window(app);
+            } else {
+                focus_main_window(app);
+            }
+        });
+
+    match result {
+        Ok(()) => {
+            app.manage(SummonShortcut { chord });
+        }
+        // Registration fails when another app owns the chord (reliably
+        // reported on Windows/X11 only) or on Wayland, where the plugin has
+        // no backend. The app stays fully usable without the shortcut.
+        Err(e) => {
+            log_backend_error(
+                app,
+                &format!("Failed to register summon shortcut \"{chord}\": {e}"),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_chords_parse_as_shortcuts() {
+        for chord in ["Super+Shift+Space", "Ctrl+Alt+Space"] {
+            assert!(
+                chord.parse::<Shortcut>().is_ok(),
+                "default chord {chord} no longer parses"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Description

Re-introduces desktop keyboard shortcuts with the scoping that the removed set (#7914) got wrong: exactly **one** global (system-wide) shortcut, with everything else as menu accelerators that only fire while an Onyx window has focus.

**Global summon shortcut** — `Cmd+Shift+Space` (macOS) / `Ctrl+Alt+Space` (Windows/Linux):
- Summons + focuses Onyx and opens a new chat; a tray checkbox ("New Chat on Summon") switches it to focus-only, persisted as `summon_opens_new_chat` in config.json
- Rebindable via `summon_shortcut` in config.json; explicit `null` disables it
- The tray shows the chord as accelerator text on whichever action it triggers, and only while registration actually succeeded — a failed registration (chord owned by another app, or Wayland where the plugin has no backend) logs and degrades gracefully instead of advertising a dead binding
- Defaults chosen to avoid the known conflict zones: `Alt+Space` (Windows system menu / Copilot / PowerToys Run) and `Ctrl+Alt+<letter>` (AltGr layouts)
- Registration and every fire are logged in `--debug` mode for supportability

**View menu (in-app accelerators)** — Reload `CmdOrCtrl+R`, Back/Forward `Cmd+[` / `Cmd+]` on macOS and `Alt+Left` / `Alt+Right` elsewhere, targeting the focused window.

Deliberately excluded (possible follow-ups): toggle-to-hide on second press, single-instance plugin (Wayland summon story), zoom accelerators.

## How Has This Been Tested?

- `cargo clippy --all-targets` clean under the crate's strict lint set; `cargo fmt --check` clean; 14 unit tests pass (4 new: config serde defaults / null-disable / custom-value round-trip, and both default chords parse as `Shortcut`)
- Live end-to-end on macOS: registration succeeds with no permission prompt and no focus stealing; repeated real keypresses of `Cmd+Shift+Space` each fired the handler and summoned the app into a new chat (verified via the new debug logging)
- Menu setup verified error-free at runtime on macOS; non-macOS accelerator strings (`Alt+ArrowLeft` etc.) verified against muda's accelerator parser (accepted on all three platform backends); Windows/Linux behavior is otherwise compile-verified only

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds one global “summon Onyx” shortcut and restores navigation as in-app accelerators, so we don’t steal shortcuts from other apps.

- **New Features**
  - One system-wide summon shortcut: Cmd+Shift+Space (macOS) / Ctrl+Alt+Space (Windows/Linux). Opens a new chat by default; tray toggle “New Chat on Summon” switches to focus-only and persists as `summon_opens_new_chat`. Rebind via `summon_shortcut` in `config.json`; set `null` to disable.
  - Tray shows the chord only if registration succeeds; failures log and degrade gracefully. Debug mode logs registration and each press.
  - View menu accelerators: Reload `CmdOrCtrl+R`; Back/Forward `Cmd+[` / `Cmd+]` on macOS and `Alt+Left` / `Alt+Right` elsewhere. Actions target the focused window.

- **Bug Fixes**
  - Config updates now roll back in-memory values when disk save fails, preventing “looks changed this session but reverts on next launch.”
  - Focused-window detection logs query errors instead of silently treating them as “no focused window.”

<sup>Written for commit 6b807f1617e8f9c715dbb518691a82fc29be7376. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

