### PR TITLE
feat(web): add usage analytics building blocks

### DIFF
--- a/web/src/components/dateRangeSelectors/AdminDateRangeSelector.test.tsx
+++ b/web/src/components/dateRangeSelectors/AdminDateRangeSelector.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { AdminDateRangeSelector } from "./AdminDateRangeSelector";
+import { AdminDateRangeSelector } from "@/components/dateRangeSelectors/AdminDateRangeSelector";
 
 describe("AdminDateRangeSelector", () => {
   beforeEach(() => {

--- a/web/src/components/dateRangeSelectors/AdminDateRangeSelector.test.tsx
+++ b/web/src/components/dateRangeSelectors/AdminDateRangeSelector.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AdminDateRangeSelector } from "./AdminDateRangeSelector";
+
+describe("AdminDateRangeSelector", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2026, 7, 4, 12));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("selects and commits a custom range with two date clicks", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const onValueChange = jest.fn();
+
+    render(
+      <AdminDateRangeSelector
+        value={{
+          from: new Date(2026, 6, 5),
+          to: new Date(2026, 7, 4),
+        }}
+        onValueChange={onValueChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /custom range/i }));
+    await user.click(screen.getByRole("button", { name: /august 1st, 2026/i }));
+
+    const endDate = screen.getByRole("button", { name: /august 3rd, 2026/i });
+    await user.hover(endDate);
+
+    expect(endDate.parentElement).toHaveClass(
+      "opal-calendar-cell--range-preview-end"
+    );
+    expect(
+      screen.getByRole("button", { name: /august 2nd, 2026/i }).parentElement
+    ).toHaveClass("opal-calendar-cell--range-preview-middle");
+
+    await user.click(endDate);
+
+    expect(onValueChange).toHaveBeenCalledWith({
+      from: new Date(2026, 7, 1),
+      to: new Date(2026, 7, 3, 23, 59, 59, 999),
+    });
+    expect(
+      screen.getByRole("button", { name: /custom range/i })
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("emits a full current-day range for 1D", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const onValueChange = jest.fn();
+
+    render(
+      <AdminDateRangeSelector
+        value={{
+          from: new Date(2026, 6, 5),
+          to: new Date(2026, 7, 4),
+        }}
+        onValueChange={onValueChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "1D" }));
+
+    expect(onValueChange).toHaveBeenCalledWith({
+      from: new Date(2026, 7, 4),
+      to: new Date(2026, 7, 4, 23, 59, 59, 999),
+    });
+  });
+
+  it("shows the committed custom range when reopened", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(
+      <AdminDateRangeSelector
+        value={{
+          from: new Date(2026, 6, 10),
+          to: new Date(2026, 6, 15),
+        }}
+        onValueChange={jest.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /custom range/i }));
+
+    expect(
+      screen.getByRole("button", { name: /july 10th, 2026/i }).parentElement
+    ).toHaveClass("opal-calendar-cell--range-start");
+    expect(
+      screen.getByRole("button", { name: /july 15th, 2026/i }).parentElement
+    ).toHaveClass("opal-calendar-cell--range-end");
+  });
+});

--- a/web/src/components/dateRangeSelectors/AdminDateRangeSelector.tsx
+++ b/web/src/components/dateRangeSelectors/AdminDateRangeSelector.tsx
@@ -1,12 +1,8 @@
 import React, { memo, useState } from "react";
-import Calendar from "@/refresh-components/Calendar";
-import { Popover } from "@opal/components";
-import Button from "@/refresh-components/buttons/Button";
-import { Button as OpalButton } from "@opal/components";
-import { cn } from "@opal/utils";
-import { format } from "date-fns";
-import { getXDaysAgo } from "./dateUtils";
+import { endOfDay, format, isSameDay, startOfDay, subDays } from "date-fns";
+import { Calendar, Popover, SelectButton } from "@opal/components";
 import { SvgCalendar } from "@opal/icons";
+
 export const THIRTY_DAYS = "30d";
 
 export type DateRangePickerValue = DateRange & {
@@ -20,87 +16,174 @@ export type DateRange =
     }
   | undefined;
 
+type DraftDateRange =
+  | {
+      from: Date;
+      to?: Date;
+    }
+  | undefined;
+
+interface DatePreset {
+  label: string;
+  daysAgo: number;
+}
+
+const PRESETS: DatePreset[] = [
+  { label: "1D", daysAgo: 0 },
+  { label: "7D", daysAgo: 6 },
+  { label: "1M", daysAgo: 30 },
+  { label: "3M", daysAgo: 90 },
+];
+
+function rangeForPreset(preset: DatePreset): Exclude<DateRange, undefined> {
+  const to = endOfDay(new Date());
+  return { from: startOfDay(subDays(to, preset.daysAgo)), to };
+}
+
+function rangesMatch(left: DateRange, right: DateRange): boolean {
+  return Boolean(
+    left?.from &&
+    left.to &&
+    right?.from &&
+    right.to &&
+    isSameDay(left.from, right.from) &&
+    isSameDay(left.to, right.to)
+  );
+}
+
+type SelectorSize = "md" | "sm";
+
 export const AdminDateRangeSelector = memo(function AdminDateRangeSelector({
   value,
   onValueChange,
+  size = "md",
 }: {
   value: DateRange;
   onValueChange: (value: DateRange) => void;
+  size?: SelectorSize;
 }) {
+  const buttonSize = size === "sm" ? "sm" : "md";
   const [isOpen, setIsOpen] = useState(false);
+  const [draftRange, setDraftRange] = useState<DraftDateRange>(value);
+  const [pendingStart, setPendingStart] = useState<Date>();
+  const [hoveredEnd, setHoveredEnd] = useState<Date>();
 
-  const presets = [
-    {
-      label: "Last 30 days",
-      value: {
-        from: getXDaysAgo(30),
-        to: getXDaysAgo(0),
-      },
-    },
-    {
-      label: "Today",
-      value: {
-        from: getXDaysAgo(1),
-        to: getXDaysAgo(0),
-      },
-    },
-  ];
+  const activePreset = PRESETS.find((preset) =>
+    rangesMatch(value, rangeForPreset(preset))
+  );
+  const customActive = !activePreset;
+  const customLabel =
+    customActive && value
+      ? `${format(value.from, value.from.getFullYear() === value.to.getFullYear() ? "MMM d" : "MMM d, y")} – ${format(value.to, value.from.getFullYear() === value.to.getFullYear() ? "MMM d" : "MMM d, y")}`
+      : "Custom";
+
+  function selectPreset(preset: DatePreset) {
+    const range = rangeForPreset(preset);
+    setDraftRange(range);
+    setPendingStart(undefined);
+    setHoveredEnd(undefined);
+    setIsOpen(false);
+    onValueChange(range);
+  }
 
   return (
-    <div className="grid gap-2">
-      <Popover open={isOpen} onOpenChange={setIsOpen}>
-        <Popover.Trigger asChild>
-          {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-          <Button
-            data-testid="admin-date-range-selector-button"
-            secondary
-            className={cn("justify-start", !value && "text-muted-foreground")}
-            leftIcon={SvgCalendar}
+    <div
+      className="inline-flex max-w-full items-center overflow-x-auto rounded-12 border border-border-02 bg-background-tint-03 p-0.5"
+      role="group"
+      aria-label="Date range"
+      data-testid="admin-date-range-selector"
+    >
+      {PRESETS.map((preset) => {
+        const active = !isOpen && activePreset?.label === preset.label;
+
+        return (
+          <SelectButton
+            key={preset.label}
+            size={buttonSize}
+            state={active ? "selected" : "empty"}
+            aria-pressed={active}
+            onClick={() => selectPreset(preset)}
           >
-            {value?.from
-              ? value.to
-                ? `${format(value.from, "LLL dd, y")} - ${format(
-                    value.to,
-                    "LLL dd, y"
-                  )}`
-                : format(value.from, "LLL dd, y")
-              : "Pick a date range"}
-          </Button>
+            {preset.label}
+          </SelectButton>
+        );
+      })}
+
+      <Popover
+        open={isOpen}
+        onOpenChange={(open) => {
+          setIsOpen(open);
+          setPendingStart(undefined);
+          setHoveredEnd(undefined);
+          setDraftRange(open && customActive ? value : undefined);
+        }}
+      >
+        <Popover.Trigger asChild>
+          <SelectButton
+            size={buttonSize}
+            state={customActive || isOpen ? "selected" : "empty"}
+            rightIcon={customLabel === "Custom" ? SvgCalendar : undefined}
+            aria-label={
+              value
+                ? `Custom range: ${format(value.from, "MMM d, y")} to ${format(value.to, "MMM d, y")}`
+                : "Choose a custom range"
+            }
+            aria-pressed={customActive}
+            aria-haspopup="dialog"
+            aria-expanded={isOpen}
+            data-testid="admin-date-range-selector-button"
+          >
+            {customLabel}
+          </SelectButton>
         </Popover.Trigger>
-        <Popover.Content align="start">
-          <Calendar
-            initialFocus
-            mode="range"
-            defaultMonth={value?.from}
-            selected={value}
-            onSelect={(range) => {
-              if (range?.from) {
-                if (range.to) {
-                  // Normal range selection when initialized with a range
-                  onValueChange({ from: range.from, to: range.to });
-                } else {
-                  // Single date selection when initilized without a range
-                  const to = new Date(range.from);
-                  const from = new Date(to.setDate(to.getDate() - 1));
-                  onValueChange({ from, to });
-                }
+
+        <Popover.Content align="end">
+          <div className="flex w-full justify-center">
+            <Calendar
+              mode="range"
+              defaultMonth={customActive ? value?.from : undefined}
+              selected={draftRange}
+              modifiers={
+                pendingStart && hoveredEnd
+                  ? {
+                      range_preview_start:
+                        pendingStart < hoveredEnd ? pendingStart : hoveredEnd,
+                      range_preview_middle: {
+                        after:
+                          pendingStart < hoveredEnd ? pendingStart : hoveredEnd,
+                        before:
+                          pendingStart < hoveredEnd ? hoveredEnd : pendingStart,
+                      },
+                      range_preview_end:
+                        pendingStart < hoveredEnd ? hoveredEnd : pendingStart,
+                    }
+                  : undefined
               }
-            }}
-            numberOfMonths={2}
-          />
-          <div className="border-t p-3">
-            {presets.map((preset) => (
-              <OpalButton
-                key={preset.label}
-                prominence="internal"
-                width="full"
-                onClick={() => {
-                  onValueChange(preset.value);
-                }}
-              >
-                {preset.label}
-              </OpalButton>
-            ))}
+              onDayMouseEnter={(day) => {
+                if (pendingStart) setHoveredEnd(day);
+              }}
+              onDayClick={(day) => {
+                if (!pendingStart) {
+                  setDraftRange({ from: day });
+                  setPendingStart(day);
+                  setHoveredEnd(undefined);
+                  return;
+                }
+
+                const from = startOfDay(
+                  day < pendingStart ? day : pendingStart
+                );
+                const to = endOfDay(day < pendingStart ? pendingStart : day);
+
+                setPendingStart(undefined);
+                setHoveredEnd(undefined);
+                setDraftRange({ from, to });
+                onValueChange({ from, to });
+                setIsOpen(false);
+              }}
+              numberOfMonths={1}
+              disabled={(date) => date > new Date()}
+            />
           </div>
         </Popover.Content>
       </Popover>

--- a/web/src/lib/dateUtils.ts
+++ b/web/src/lib/dateUtils.ts
@@ -160,6 +160,17 @@ export const formatDateShort = (dateStr: string | null | undefined): string => {
   });
 };
 
+// Parses at local midnight so the day never shifts the way `formatDateShort` can for callers west of UTC.
+export const formatCalendarDay = (
+  dateStr: string,
+  { withYear = false }: { withYear?: boolean } = {}
+): string =>
+  new Date(`${dateStr}T00:00:00`).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    ...(withYear && { year: "numeric" }),
+  });
+
 /**
  * Format an ISO timestamp as "YYYY/MM/DD HH:MM:SS" (24-hour, local time).
  * Intended for log displays where full precision is needed.

--- a/web/src/lib/usage/userUsage.ts
+++ b/web/src/lib/usage/userUsage.ts
@@ -15,7 +15,7 @@ export interface UsageExportTotals {
 export interface UsageExportUser {
   email: string;
   totals: UsageExportTotals;
-  records?: UsageExportRecord[];
+  records: UsageExportRecord[];
 }
 
 export interface UsageExportRecord {

--- a/web/src/lib/usage/userUsage.ts
+++ b/web/src/lib/usage/userUsage.ts
@@ -3,6 +3,7 @@
 import useSWR from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import { buildApiPath } from "@/lib/urlBuilder";
 
 export interface UsageExportTotals {
   input_tokens: number;
@@ -14,6 +15,18 @@ export interface UsageExportTotals {
 export interface UsageExportUser {
   email: string;
   totals: UsageExportTotals;
+  records?: UsageExportRecord[];
+}
+
+export interface UsageExportRecord {
+  model: string;
+  flow?: string;
+  provider?: string;
+  day: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cost_cents: number;
 }
 
 export interface UsageExportResponse {
@@ -22,10 +35,19 @@ export interface UsageExportResponse {
   users: UsageExportUser[];
 }
 
-/** Company-wide per-user usage with a revalidation callback. */
-export function useUsageExport() {
+function formatDateParam(date: Date): string {
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
+export function useUsageExport(range?: { from: Date; to: Date } | undefined) {
+  const url = buildApiPath(SWR_KEYS.adminUsageExport, {
+    start: range?.from ? formatDateParam(range.from) : undefined,
+    end: range?.to ? formatDateParam(range.to) : undefined,
+  });
   const { data, error, isLoading, mutate } = useSWR<UsageExportResponse>(
-    SWR_KEYS.adminUsageExport,
+    url,
     errorHandlingFetcher,
     { revalidateOnFocus: false }
   );

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -287,3 +287,14 @@ export function mergeRefs<T>(
     });
   };
 }
+
+export function formatCost(cents: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(cents / 100);
+}
+
+export function formatTokens(value: number): string {
+  return value.toLocaleString("en-US");
+}

--- a/web/src/refresh-components/AdminDateRangeSelector.stories.tsx
+++ b/web/src/refresh-components/AdminDateRangeSelector.stories.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  AdminDateRangeSelector,
+  type DateRange,
+} from "@/components/dateRangeSelectors/AdminDateRangeSelector";
+
+const meta: Meta<typeof AdminDateRangeSelector> = {
+  title: "components/AdminDateRangeSelector",
+  component: AdminDateRangeSelector,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[640px] min-w-[760px] bg-background-neutral-00 p-8">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof AdminDateRangeSelector>;
+
+function ControlledRange({ initialValue }: { initialValue: DateRange }) {
+  const [value, setValue] = useState<DateRange>(initialValue);
+
+  return <AdminDateRangeSelector value={value} onValueChange={setValue} />;
+}
+
+export const Default: Story = {
+  render: () => (
+    <ControlledRange
+      initialValue={{
+        from: new Date(2026, 6, 5),
+        to: new Date(2026, 7, 4),
+      }}
+    />
+  ),
+};
+
+export const ShortCustomRange: Story = {
+  render: () => (
+    <ControlledRange
+      initialValue={{
+        from: new Date(2026, 7, 2),
+        to: new Date(2026, 7, 4),
+      }}
+    />
+  ),
+};
+
+export const Empty: Story = {
+  render: () => <ControlledRange initialValue={undefined} />,
+};

--- a/web/src/sections/usage/SpendByUserTable.test.tsx
+++ b/web/src/sections/usage/SpendByUserTable.test.tsx
@@ -22,7 +22,7 @@ test("opens a user from the keyboard", () => {
     />
   );
 
-  const row = screen.getByRole("row", {
+  const row = screen.getByRole("button", {
     name: "View usage details for ada@example.com",
   });
   row.focus();

--- a/web/src/sections/usage/SpendByUserTable.test.tsx
+++ b/web/src/sections/usage/SpendByUserTable.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@tests/setup/test-utils";
-import SpendByUserTable from "./SpendByUserTable";
+import SpendByUserTable from "@/sections/usage/SpendByUserTable";
 
 test("opens a user from the keyboard", () => {
   const onSelectUser = jest.fn();

--- a/web/src/sections/usage/SpendByUserTable.test.tsx
+++ b/web/src/sections/usage/SpendByUserTable.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from "@tests/setup/test-utils";
+import SpendByUserTable from "./SpendByUserTable";
+
+test("opens a user from the keyboard", () => {
+  const onSelectUser = jest.fn();
+
+  render(
+    <SpendByUserTable
+      users={[
+        {
+          email: "ada@example.com",
+          totals: {
+            input_tokens: 1_000,
+            output_tokens: 200,
+            cache_read_tokens: 100,
+            cost_cents: 25,
+          },
+          records: [],
+        },
+      ]}
+      onSelectUser={onSelectUser}
+    />
+  );
+
+  const row = screen.getByRole("row", {
+    name: "View usage details for ada@example.com",
+  });
+  row.focus();
+  fireEvent.keyDown(row, { key: "Enter" });
+
+  expect(onSelectUser).toHaveBeenCalledWith("ada@example.com");
+});

--- a/web/src/sections/usage/SpendByUserTable.tsx
+++ b/web/src/sections/usage/SpendByUserTable.tsx
@@ -40,7 +40,7 @@ function filteredRow(
   if (model === ALL && flow === ALL) {
     return { email: user.email, ...user.totals };
   }
-  const records = (user.records ?? []).filter(
+  const records = user.records.filter(
     (record) =>
       (model === ALL || record.model === model) &&
       (flow === ALL || record.flow === flow)
@@ -144,9 +144,7 @@ export default function SpendByUserTable({
     () =>
       Array.from(
         new Set(
-          users.flatMap((user) =>
-            (user.records ?? []).map((record) => record.model)
-          )
+          users.flatMap((user) => user.records.map((record) => record.model))
         )
       ).sort(),
     [users]
@@ -156,7 +154,7 @@ export default function SpendByUserTable({
       Array.from(
         new Set(
           users.flatMap((user) =>
-            (user.records ?? []).flatMap((record) =>
+            user.records.flatMap((record) =>
               record.flow !== undefined ? [record.flow] : []
             )
           )
@@ -237,6 +235,9 @@ export default function SpendByUserTable({
       </div>
 
       <Table
+        // Remount on filter change so the Table's internal page index resets;
+        // otherwise a narrower `rows` can leave it stranded past the last page.
+        key={`${model}-${flow}-${searchTerm}`}
         data={rows}
         columns={COLUMNS}
         getRowId={(row) => row.email}

--- a/web/src/sections/usage/SpendByUserTable.tsx
+++ b/web/src/sections/usage/SpendByUserTable.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  InputSelect,
+  InputTypeIn,
+  Table,
+  Text,
+  createTableColumns,
+} from "@opal/components";
+import { Section } from "@opal/layouts";
+import { SvgUser } from "@opal/icons";
+import type { UsageExportTotals, UsageExportUser } from "@/lib/usage/userUsage";
+import { formatCost, formatTokens } from "@/lib/utils";
+
+const ALL = "__all__";
+
+export interface SpendRow {
+  email: string;
+  cost_cents: number;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+}
+
+function emptyTotals(): UsageExportTotals {
+  return {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    cost_cents: 0,
+  };
+}
+
+function filteredRow(
+  user: UsageExportUser,
+  model: string,
+  flow: string
+): SpendRow | null {
+  if (model === ALL && flow === ALL) {
+    return { email: user.email, ...user.totals };
+  }
+  const records = (user.records ?? []).filter(
+    (record) =>
+      (model === ALL || record.model === model) &&
+      (flow === ALL || record.flow === flow)
+  );
+  if (records.length === 0) return null;
+  const totals = records.reduce(
+    (sum, record) => ({
+      input_tokens: sum.input_tokens + record.input_tokens,
+      output_tokens: sum.output_tokens + record.output_tokens,
+      cache_read_tokens: sum.cache_read_tokens + record.cache_read_tokens,
+      cost_cents: sum.cost_cents + record.cost_cents,
+    }),
+    emptyTotals()
+  );
+  return { email: user.email, ...totals };
+}
+
+const tc = createTableColumns<SpendRow>();
+
+function buildColumns() {
+  return [
+    tc.qualifier({ content: "icon", getContent: () => SvgUser }),
+    tc.column("email", {
+      header: "User",
+      weight: 34,
+      cell: (value) => (
+        <span className="underline-offset-2 group-hover/row:underline">
+          <Text font="main-ui-body" color="text-05" nowrap>
+            {value}
+          </Text>
+        </span>
+      ),
+    }),
+    tc.column("cost_cents", {
+      header: "Spend",
+      weight: 14,
+      alignment: "right",
+      cell: (value) => (
+        <span className="tabular-nums">
+          <Text font="main-ui-action" color="text-05" nowrap>
+            {formatCost(value)}
+          </Text>
+        </span>
+      ),
+    }),
+    tc.column("input_tokens", {
+      header: "Input",
+      weight: 14,
+      alignment: "right",
+      cell: (value) => (
+        <span className="tabular-nums">
+          <Text font="main-ui-body" color="text-03" nowrap>
+            {formatTokens(value)}
+          </Text>
+        </span>
+      ),
+    }),
+    tc.column("output_tokens", {
+      header: "Output",
+      weight: 14,
+      alignment: "right",
+      cell: (value) => (
+        <span className="tabular-nums">
+          <Text font="main-ui-body" color="text-03" nowrap>
+            {formatTokens(value)}
+          </Text>
+        </span>
+      ),
+    }),
+    tc.column("cache_read_tokens", {
+      header: "Cache",
+      weight: 14,
+      alignment: "right",
+      cell: (value) => (
+        <span className="tabular-nums">
+          <Text font="main-ui-body" color="text-03" nowrap>
+            {formatTokens(value)}
+          </Text>
+        </span>
+      ),
+    }),
+  ];
+}
+
+const COLUMNS = buildColumns();
+
+interface SpendByUserTableProps {
+  users: UsageExportUser[];
+  onSelectUser: (email: string) => void;
+}
+
+export default function SpendByUserTable({
+  users,
+  onSelectUser,
+}: SpendByUserTableProps) {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [model, setModel] = useState(ALL);
+  const [flow, setFlow] = useState(ALL);
+
+  const models = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          users.flatMap((user) =>
+            (user.records ?? []).map((record) => record.model)
+          )
+        )
+      ).sort(),
+    [users]
+  );
+  const flows = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          users.flatMap((user) =>
+            (user.records ?? []).flatMap((record) =>
+              record.flow !== undefined ? [record.flow] : []
+            )
+          )
+        )
+      ).sort(),
+    [users]
+  );
+
+  useEffect(() => {
+    if (model !== ALL && !models.includes(model)) setModel(ALL);
+  }, [model, models]);
+
+  useEffect(() => {
+    if (flow !== ALL && !flows.includes(flow)) setFlow(ALL);
+  }, [flow, flows]);
+
+  // Filtered manually: Table's built-in global filter matches any column, so numeric queries would match token counts too.
+  const rows = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase();
+    return users.flatMap((user) => {
+      if (query && !user.email.toLowerCase().includes(query)) return [];
+      const row = filteredRow(user, model, flow);
+      return row ? [row] : [];
+    });
+  }, [users, model, flow, searchTerm]);
+
+  return (
+    <Section
+      flexDirection="column"
+      justifyContent="start"
+      alignItems="stretch"
+      gap={0.5}
+      width="full"
+      height="fit"
+    >
+      {/* sm:flex-row / sm:items-center have no Section equivalent, kept as a raw div */}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <div className="min-w-0 flex-1 sm:max-w-72">
+          <InputTypeIn
+            value={searchTerm}
+            placeholder="Search users by email…"
+            aria-label="Search users by email"
+            onChange={(event) => setSearchTerm(event.target.value)}
+          />
+        </div>
+        <div className="flex w-full flex-col gap-2 sm:ml-auto sm:w-auto sm:flex-row">
+          {models.length > 0 && (
+            <div className="w-full sm:w-44">
+              <InputSelect value={model} onValueChange={setModel}>
+                <InputSelect.Trigger placeholder="All models" />
+                <InputSelect.Content>
+                  <InputSelect.Item value={ALL}>All models</InputSelect.Item>
+                  {models.map((option) => (
+                    <InputSelect.Item key={option} value={option}>
+                      {option}
+                    </InputSelect.Item>
+                  ))}
+                </InputSelect.Content>
+              </InputSelect>
+            </div>
+          )}
+          {flows.length > 0 && (
+            <div className="w-full sm:w-40">
+              <InputSelect value={flow} onValueChange={setFlow}>
+                <InputSelect.Trigger placeholder="All flows" />
+                <InputSelect.Content>
+                  <InputSelect.Item value={ALL}>All flows</InputSelect.Item>
+                  {flows.map((option) => (
+                    <InputSelect.Item key={option} value={option}>
+                      {option}
+                    </InputSelect.Item>
+                  ))}
+                </InputSelect.Content>
+              </InputSelect>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <Table
+        data={rows}
+        columns={COLUMNS}
+        getRowId={(row) => row.email}
+        pageSize={10}
+        initialSorting={[{ id: "cost_cents", desc: true }]}
+        onRowClick={(row) => onSelectUser(row.email)}
+        getRowLabel={(row) => `View usage details for ${row.email}`}
+        footer={{}}
+        emptyState={
+          <Text font="main-ui-body" color="text-03">
+            No usage matches the current filters.
+          </Text>
+        }
+      />
+    </Section>
+  );
+}

--- a/web/src/sections/usage/UserUsageDetailModal.tsx
+++ b/web/src/sections/usage/UserUsageDetailModal.tsx
@@ -21,7 +21,7 @@ function sliceBy(
   key: (record: { model: string; flow?: string; provider?: string }) => string
 ): BreakdownSlice[] {
   const byLabel = new Map<string, BreakdownSlice>();
-  for (const record of user.records ?? []) {
+  for (const record of user.records) {
     const label = key(record);
     const slice = byLabel.get(label) ?? {
       label,
@@ -44,7 +44,7 @@ interface DailySpend {
 
 function dailySpend(user: UsageExportUser): DailySpend[] {
   const byDay = new Map<string, number>();
-  for (const record of user.records ?? []) {
+  for (const record of user.records) {
     byDay.set(record.day, (byDay.get(record.day) ?? 0) + record.cost_cents);
   }
   const days = Array.from(byDay.keys()).sort();

--- a/web/src/sections/usage/UserUsageDetailModal.tsx
+++ b/web/src/sections/usage/UserUsageDetailModal.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { useMemo } from "react";
+import { Button, Modal, ProgressBar, Text, Tooltip } from "@opal/components";
+import { Section } from "@opal/layouts";
+import { formatCalendarDay } from "@/lib/dateUtils";
+import type { UsageExportUser } from "@/lib/usage/userUsage";
+import { formatCost, formatTokens } from "@/lib/utils";
+
+const MAX_DAILY_COLUMNS = 62;
+const UNLABELED_FLOW = "other";
+
+interface BreakdownSlice {
+  label: string;
+  cost_cents: number;
+  tokens: number;
+}
+
+function sliceBy(
+  user: UsageExportUser,
+  key: (record: { model: string; flow?: string; provider?: string }) => string
+): BreakdownSlice[] {
+  const byLabel = new Map<string, BreakdownSlice>();
+  for (const record of user.records ?? []) {
+    const label = key(record);
+    const slice = byLabel.get(label) ?? {
+      label,
+      cost_cents: 0,
+      tokens: 0,
+    };
+    slice.cost_cents += record.cost_cents;
+    slice.tokens += record.input_tokens + record.output_tokens;
+    byLabel.set(label, slice);
+  }
+  return Array.from(byLabel.values()).sort(
+    (a, b) => b.cost_cents - a.cost_cents
+  );
+}
+
+interface DailySpend {
+  day: string;
+  cost_cents: number;
+}
+
+function dailySpend(user: UsageExportUser): DailySpend[] {
+  const byDay = new Map<string, number>();
+  for (const record of user.records ?? []) {
+    byDay.set(record.day, (byDay.get(record.day) ?? 0) + record.cost_cents);
+  }
+  const days = Array.from(byDay.keys()).sort();
+  if (days.length === 0) return [];
+  const filled: DailySpend[] = [];
+  const first = days[0]!;
+  const last = days[days.length - 1]!;
+  const cursor = new Date(`${first}T00:00:00Z`);
+  const end = new Date(`${last}T00:00:00Z`);
+  while (cursor <= end && filled.length < MAX_DAILY_COLUMNS + 1) {
+    const day = cursor.toISOString().slice(0, 10);
+    filled.push({ day, cost_cents: byDay.get(day) ?? 0 });
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  return filled;
+}
+
+function StatCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex min-w-0 flex-col gap-0.5 px-3 first:pl-0 last:pr-0">
+      <Text font="secondary-body" color="text-03" nowrap>
+        {label}
+      </Text>
+      <span className="tabular-nums">
+        <Text font="main-content-emphasis" nowrap>
+          {value}
+        </Text>
+      </span>
+    </div>
+  );
+}
+
+interface BreakdownListProps {
+  title: string;
+  slices: BreakdownSlice[];
+  totalCostCents: number;
+}
+
+function BreakdownList({ title, slices, totalCostCents }: BreakdownListProps) {
+  if (slices.length === 0) return null;
+  return (
+    <Section
+      flexDirection="column"
+      justifyContent="start"
+      alignItems="stretch"
+      gap={0.5}
+      width="full"
+      height="fit"
+    >
+      <Text font="main-ui-action" color="text-04">
+        {title}
+      </Text>
+      <Section
+        flexDirection="column"
+        justifyContent="start"
+        alignItems="stretch"
+        gap={0.625}
+        width="full"
+        height="fit"
+      >
+        {slices.map((slice) => {
+          const share =
+            totalCostCents > 0 ? slice.cost_cents / totalCostCents : 0;
+          return (
+            <Section
+              key={slice.label}
+              flexDirection="column"
+              justifyContent="start"
+              alignItems="stretch"
+              gap={0.25}
+              width="full"
+              height="fit"
+            >
+              {/* items-baseline has no Section equivalent, kept as a raw div */}
+              <div className="flex items-baseline justify-between gap-3">
+                <span className="min-w-0 truncate">
+                  <Text font="main-ui-body" color="text-05" nowrap>
+                    {slice.label}
+                  </Text>
+                </span>
+                <span className="shrink-0 tabular-nums">
+                  <Text font="main-ui-body" color="text-05">
+                    {formatCost(slice.cost_cents)}
+                  </Text>
+                  <Text font="secondary-body" color="text-03">
+                    {` · ${(share * 100).toFixed(share >= 0.1 ? 0 : 1)}% · ${formatTokens(slice.tokens)} tokens`}
+                  </Text>
+                </span>
+              </div>
+              <ProgressBar
+                value={slice.cost_cents}
+                max={totalCostCents}
+                aria-label={`${slice.label} share of spend`}
+              />
+            </Section>
+          );
+        })}
+      </Section>
+    </Section>
+  );
+}
+
+function DailySpendStrip({ days }: { days: DailySpend[] }) {
+  const max = Math.max(...days.map((day) => day.cost_cents));
+  if (days.length < 2 || max <= 0 || days.length > MAX_DAILY_COLUMNS) {
+    return null;
+  }
+  return (
+    <Section
+      flexDirection="column"
+      justifyContent="start"
+      alignItems="stretch"
+      gap={0.25}
+      width="full"
+      height="fit"
+    >
+      <Text font="main-ui-action" color="text-04">
+        Daily spend
+      </Text>
+      <Section
+        role="img"
+        aria-label={`Daily spend for the selected period: ${days
+          .map(
+            (day) =>
+              `${formatCalendarDay(day.day)}, ${formatCost(day.cost_cents)}`
+          )
+          .join("; ")}`}
+        flexDirection="row"
+        justifyContent="start"
+        alignItems="end"
+        gap={0.125}
+        width="full"
+        height={3.5}
+      >
+        {days.map((day) => (
+          <Tooltip
+            key={day.day}
+            tooltip={`${formatCalendarDay(day.day)} · ${formatCost(day.cost_cents)}`}
+            side="top"
+            delayDuration={0}
+          >
+            {/* Full-height hit target so quiet days are hoverable too; flex-1 participates in the parent Section's own layout so it stays a raw div. */}
+            <div className="flex h-full flex-1 items-end">
+              <div
+                className="w-full rounded-t-[2px] bg-theme-blue-05"
+                style={{
+                  height:
+                    day.cost_cents > 0
+                      ? `${Math.max((day.cost_cents / max) * 100, 4)}%`
+                      : "2px",
+                  opacity: day.cost_cents > 0 ? 1 : 0.25,
+                }}
+              />
+            </div>
+          </Tooltip>
+        ))}
+      </Section>
+      <Section
+        flexDirection="row"
+        justifyContent="between"
+        alignItems="stretch"
+        gap={0}
+        width="full"
+        height="fit"
+      >
+        <Text font="secondary-body" color="text-03">
+          {formatCalendarDay(days[0]!.day)}
+        </Text>
+        <Text font="secondary-body" color="text-03">
+          {formatCalendarDay(days[days.length - 1]!.day)}
+        </Text>
+      </Section>
+    </Section>
+  );
+}
+
+export interface UserUsageDetailModalProps {
+  user: UsageExportUser | null;
+  periodLabel?: string;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function UserUsageDetailModal({
+  user,
+  periodLabel,
+  onOpenChange,
+}: UserUsageDetailModalProps) {
+  const byModel = useMemo(
+    () => (user ? sliceBy(user, (record) => record.model) : []),
+    [user]
+  );
+  const byFlow = useMemo(
+    () =>
+      user ? sliceBy(user, (record) => record.flow || UNLABELED_FLOW) : [],
+    [user]
+  );
+  const byProvider = useMemo(
+    () =>
+      user ? sliceBy(user, (record) => record.provider || UNLABELED_FLOW) : [],
+    [user]
+  );
+  const days = useMemo(() => (user ? dailySpend(user) : []), [user]);
+
+  if (!user) return null;
+  const totals = user.totals;
+
+  return (
+    <Modal open onOpenChange={onOpenChange}>
+      <Modal.Content width="md" height="fit">
+        <Modal.Header
+          title={user.email}
+          description={periodLabel}
+          onClose={() => onOpenChange(false)}
+        />
+        <Modal.Body>
+          <Section alignItems="stretch" height="auto" gap={1.5}>
+            <div className="flex flex-wrap gap-2">
+              <div className="basis-1/2 sm:basis-1/4">
+                <StatCell label="Spend" value={formatCost(totals.cost_cents)} />
+              </div>
+              <div className="basis-1/2 sm:basis-1/4">
+                <StatCell
+                  label="Input tokens"
+                  value={formatTokens(totals.input_tokens)}
+                />
+              </div>
+              <div className="basis-1/2 sm:basis-1/4">
+                <StatCell
+                  label="Output tokens"
+                  value={formatTokens(totals.output_tokens)}
+                />
+              </div>
+              <div className="basis-1/2 sm:basis-1/4">
+                <StatCell
+                  label="Cache reads"
+                  value={formatTokens(totals.cache_read_tokens)}
+                />
+              </div>
+            </div>
+
+            <DailySpendStrip days={days} />
+            <BreakdownList
+              title="By model"
+              slices={byModel}
+              totalCostCents={totals.cost_cents}
+            />
+            <BreakdownList
+              title="By flow"
+              slices={byFlow}
+              totalCostCents={totals.cost_cents}
+            />
+            <BreakdownList
+              title="By provider"
+              slices={byProvider}
+              totalCostCents={totals.cost_cents}
+            />
+
+            {byModel.length === 0 && (
+              <Text font="main-ui-body" color="text-03">
+                No per-model records for this period.
+              </Text>
+            )}
+          </Section>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button prominence="secondary" onClick={() => onOpenChange(false)}>
+            Done
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Description

Part 2 of 4 in the usage analytics stack (split out from #13751 per review feedback):

1. #13768 — Opal Table/Calendar alignment support
2. **#13769 (this PR)** — new usage analytics components
3. #13771 — backend report-generation changes
4. #13770 — the Workspace Analytics page + per-user usage integration

Adds the reusable building blocks for the usage analytics page:

- `AdminDateRangeSelector` — presets (1D/7D/1M/3M) plus a custom range picker with hover preview,
  inclusive end-of-day ranges, and disabled future dates.
- `SpendByUserTable` — per-user spend table with email search and model/flow filters, built on the
  Opal `Table`.
- `UserUsageDetailModal` — per-user totals and breakdowns by model/flow/provider with a daily spend
  strip.
- `useUsageExport(range)` now accepts `{ from, to }` and threads `start`/`end` query params through.
- Shared `formatCalendarDay`/`formatCost`/`formatTokens` utilities in `web/src/lib/utils.ts`.

## How Has This Been Tested?

- `bun run test` — `AdminDateRangeSelector.test.tsx` and `SpendByUserTable.test.tsx` passing
- `bun run types:check`, `bun run lint` — clean
- No live UI test yet — this PR only adds the components; end-to-end verification happens in the
  downstream integration PR (#13770) that wires them into the actual Workspace Analytics page

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check