### PR TITLE
feat(usage): accept a client-supplied report_id for generation

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/usage_reporting/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/usage_reporting/tasks.py
@@ -26,6 +26,7 @@ def generate_usage_report_task(
     user_id: str | None = None,
     period_from: str | None = None,
     period_to: str | None = None,
+    report_id: str | None = None,
 ) -> None:
     """User-initiated usage report generation task"""
     # Parse period if provided
@@ -42,4 +43,5 @@ def generate_usage_report_task(
             db_session=db_session,
             user_id=UUID(user_id) if user_id else None,
             period=period,
+            report_id=report_id,
         )

--- a/backend/ee/onyx/db/usage_export.py
+++ b/backend/ee/onyx/db/usage_export.py
@@ -132,6 +132,20 @@ def get_all_empty_chat_message_entries(
         initial_time = time_created
 
 
+def usage_report_id_in_use(db_session: Session, report_id: uuid.UUID) -> bool:
+    """Checks whether a usage report already exists for the given report_id.
+
+    report_name is formatted as `{date}_{report_id}_usage_report.zip`, so a
+    substring match on report_id is sufficient to detect reuse.
+    """
+    return (
+        db_session.query(UsageReport)
+        .filter(UsageReport.report_name.contains(str(report_id)))
+        .first()
+        is not None
+    )
+
+
 def get_all_usage_reports(db_session: Session) -> list[UsageReportMetadata]:
     # Get the user emails
     usage_reports = db_session.query(UsageReport).all()

--- a/backend/ee/onyx/server/reporting/usage_export_api.py
+++ b/backend/ee/onyx/server/reporting/usage_export_api.py
@@ -19,6 +19,8 @@ from onyx.configs.constants import OnyxCeleryTask
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.constants import STANDARD_CHUNK_SIZE
 from shared_configs.contextvars import get_current_tenant_id
 
@@ -46,9 +48,9 @@ def generate_report(
             raise HTTPException(status_code=400, detail=str(e))
 
     if params.report_id and usage_report_id_in_use(db_session, params.report_id):
-        raise HTTPException(
-            status_code=409,
-            detail=f"report_id {params.report_id} is already in use",
+        raise OnyxError(
+            OnyxErrorCode.DUPLICATE_RESOURCE,
+            f"report_id {params.report_id} is already in use",
         )
 
     tenant_id = get_current_tenant_id()

--- a/backend/ee/onyx/server/reporting/usage_export_api.py
+++ b/backend/ee/onyx/server/reporting/usage_export_api.py
@@ -1,5 +1,6 @@
 from collections.abc import Generator
 from datetime import datetime
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Response
 from fastapi.responses import StreamingResponse
@@ -26,6 +27,7 @@ router = APIRouter()
 class GenerateUsageReportParams(BaseModel):
     period_from: str | None = None
     period_to: str | None = None
+    report_id: UUID | None = None
 
 
 @router.post("/admin/usage-report", status_code=204)
@@ -49,6 +51,7 @@ def generate_report(
             "user_id": str(user.id) if user else None,
             "period_from": params.period_from,
             "period_to": params.period_to,
+            "report_id": str(params.report_id) if params.report_id else None,
         },
     )
 

--- a/backend/ee/onyx/server/reporting/usage_export_api.py
+++ b/backend/ee/onyx/server/reporting/usage_export_api.py
@@ -11,6 +11,7 @@ from ee.onyx.db.usage_export import (
     UsageReportMetadata,
     get_all_usage_reports,
     get_usage_report_data,
+    usage_report_id_in_use,
 )
 from onyx.auth.permissions import require_permission
 from onyx.background.celery.versioned_apps.client import app as client_app
@@ -34,6 +35,7 @@ class GenerateUsageReportParams(BaseModel):
 def generate_report(
     params: GenerateUsageReportParams,
     user: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
 ) -> None:
     # Validate period parameters
     if params.period_from and params.period_to:
@@ -42,6 +44,12 @@ def generate_report(
             datetime.fromisoformat(params.period_to)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+
+    if params.report_id and usage_report_id_in_use(db_session, params.report_id):
+        raise HTTPException(
+            status_code=409,
+            detail=f"report_id {params.report_id} is already in use",
+        )
 
     tenant_id = get_current_tenant_id()
     client_app.send_task(

--- a/backend/ee/onyx/server/reporting/usage_export_generation.py
+++ b/backend/ee/onyx/server/reporting/usage_export_generation.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from ee.onyx.db.usage_export import (
     get_all_empty_chat_message_entries,
+    usage_report_id_in_use,
     write_usage_report,
 )
 from ee.onyx.server.reporting.usage_export_models import (
@@ -140,6 +141,13 @@ def create_new_usage_report(
         db_session, file_store, report_id, period
     )
     users_file_id = generate_user_report(db_session, file_store, report_id)
+
+    # Re-check just before writing the final report: the API-level check
+    # happens before this (async) task runs, so a second request with the
+    # same client-supplied report_id can slip past it while this task is
+    # still generating the first report.
+    if usage_report_id_in_use(db_session, uuid.UUID(report_id)):
+        raise ValueError(f"report_id {report_id} is already in use")
 
     with tempfile.SpooledTemporaryFile(max_size=MAX_IN_MEMORY_SIZE) as zip_buffer:
         with zipfile.ZipFile(zip_buffer, "a", zipfile.ZIP_DEFLATED) as zip_file:

--- a/backend/ee/onyx/server/reporting/usage_export_generation.py
+++ b/backend/ee/onyx/server/reporting/usage_export_generation.py
@@ -131,8 +131,9 @@ def create_new_usage_report(
     db_session: Session,
     user_id: UUID_ID | None,  # None = auto-generated
     period: tuple[datetime, datetime] | None,
+    report_id: str | None = None,
 ) -> UsageReportMetadata:
-    report_id = str(uuid.uuid4())
+    report_id = report_id or str(uuid.uuid4())
     file_store = get_default_file_store()
 
     messages_file_id = generate_chat_messages_report(

--- a/backend/tests/integration/tests/reporting/test_usage_export_api.py
+++ b/backend/tests/integration/tests/reporting/test_usage_export_api.py
@@ -34,14 +34,6 @@ class TestUsageExportAPI:
             persona_id=DEFAULT_PERSONA_ID,
         )
 
-        # Get initial list of reports
-        initial_response = client.get(
-            f"{API_SERVER_URL}/admin/usage-report",
-            headers=admin_user.headers,
-        )
-        assert initial_response.status_code == 200
-        initial_reports = initial_response.json()
-        initial_count = len(initial_reports)
         report_id = uuid4()
 
         # Test generating a report without date filters (all time)
@@ -55,7 +47,7 @@ class TestUsageExportAPI:
         # Wait for the new report to appear (with timeout)
         max_wait_time = 60  # seconds
         start_time = time.time()
-        current_reports = initial_reports
+        new_reports: list[dict] = []
 
         while time.time() - start_time < max_wait_time:
             check_response = client.get(
@@ -65,20 +57,18 @@ class TestUsageExportAPI:
             assert check_response.status_code == 200
             current_reports = check_response.json()
 
-            if len(current_reports) > initial_count:
-                # New report has been generated
+            new_reports = [
+                report
+                for report in current_reports
+                if str(report_id) in report["report_name"]
+            ]
+            if new_reports:
+                # The requested report has been generated
                 break
 
             time.sleep(2)
 
-        # Verify a new report was created
-        assert len(current_reports) > initial_count
-
-        new_reports = [
-            report
-            for report in current_reports
-            if str(report_id) in report["report_name"]
-        ]
+        # Verify the requested report was created
         assert len(new_reports) == 1
         new_report = new_reports[0]
         assert "report_name" in new_report

--- a/backend/tests/integration/tests/reporting/test_usage_export_api.py
+++ b/backend/tests/integration/tests/reporting/test_usage_export_api.py
@@ -3,7 +3,7 @@ import os
 import time
 from datetime import datetime, timedelta, timezone
 from io import BytesIO, StringIO
-from uuid import UUID
+from uuid import UUID, uuid4
 from zipfile import ZipFile
 
 import pytest
@@ -42,11 +42,12 @@ class TestUsageExportAPI:
         assert initial_response.status_code == 200
         initial_reports = initial_response.json()
         initial_count = len(initial_reports)
+        report_id = uuid4()
 
         # Test generating a report without date filters (all time)
         response = client.post(
             f"{API_SERVER_URL}/admin/usage-report",
-            json={},
+            json={"report_id": str(report_id)},
             headers=admin_user.headers,
         )
         assert response.status_code == 204
@@ -73,10 +74,16 @@ class TestUsageExportAPI:
         # Verify a new report was created
         assert len(current_reports) > initial_count
 
-        # Find the new report (should be the first one since they're ordered by time)
-        new_report = current_reports[0]
+        new_reports = [
+            report
+            for report in current_reports
+            if str(report_id) in report["report_name"]
+        ]
+        assert len(new_reports) == 1
+        new_report = new_reports[0]
         assert "report_name" in new_report
         assert new_report["report_name"].endswith(".zip")
+        assert str(report_id) in new_report["report_name"]
 
     def test_generate_usage_report_with_date_range(
         self,

--- a/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
@@ -209,8 +209,8 @@ class TestGetUsageExportHelper:
             db_session,
             user_id,
             "model-a",
-            "BATCH",
-            "anthropic",
+            "CHAT",
+            "openai",
             100,
             50,
             0,
@@ -222,7 +222,7 @@ class TestGetUsageExportHelper:
             user_id,
             "model-a",
             "BATCH",
-            "openai",
+            "anthropic",
             200,
             60,
             0,
@@ -235,7 +235,7 @@ class TestGetUsageExportHelper:
 
         assert [(row.flow, row.provider) for row in rows] == [
             ("BATCH", "anthropic"),
-            ("BATCH", "openai"),
+            ("CHAT", "openai"),
         ]
 
     def test_date_range_bounds_half_open(self, db_session: Session) -> None:

--- a/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
@@ -209,8 +209,8 @@ class TestGetUsageExportHelper:
             db_session,
             user_id,
             "model-a",
-            "CHAT",
-            "openai",
+            "BATCH",
+            "anthropic",
             100,
             50,
             0,
@@ -222,7 +222,7 @@ class TestGetUsageExportHelper:
             user_id,
             "model-a",
             "BATCH",
-            "anthropic",
+            "openai",
             200,
             60,
             0,
@@ -235,7 +235,7 @@ class TestGetUsageExportHelper:
 
         assert [(row.flow, row.provider) for row in rows] == [
             ("BATCH", "anthropic"),
-            ("CHAT", "openai"),
+            ("BATCH", "openai"),
         ]
 
     def test_date_range_bounds_half_open(self, db_session: Session) -> None:


### PR DESCRIPTION
## Description

Part 3 of 4 in the usage analytics stack (split out from #13751 per review feedback):

1. #13768 — Opal Table/Calendar alignment support
2. #13769 — new usage analytics components
3. **#13771 (this PR)** — backend report-generation changes
4. #13770 — the Workspace Analytics page + per-user usage integration

Lets the frontend pass its own `report_id` through the generate-report API (`POST /admin/usage-report`) and the `generate_usage_report_task` Celery task, so it can track a specific pending report (e.g. for polling) instead of only discovering new reports by list-diffing.

(The "expose flow and provider detail in usage exports" and "make usage export ordering reproducible" work originally planned for this bucket already shipped independently as #13750 — confirmed the db/models files are byte-identical to current `main`, so this PR only carries the `report_id` threading.)

## How Has This Been Tested?

- `ruff check` / `ruff format --check` — clean
- `pytest backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py` — 14/14 passing
- Integration test `backend/tests/integration/tests/reporting/test_usage_export_api.py` updated for the new field

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
