### PR TITLE
fix(llm): stop dropping reasoning params for Vertex Anthropic and gateway-routed Claude

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -780,6 +780,16 @@ class LitellmLLM(LLM):
                         "summary": "auto",
                     }
 
+            elif is_claude_model and is_openai_compatible_proxy:
+                # Wire format follows the API surface, not the model vendor.
+                # LiteLLM drops thinking/output_config as unsupported on an
+                # openai surface, so a gateway only sees reasoning.effort.
+                if not _prompt_contains_tool_call_history(prompt):
+                    optional_kwargs["reasoning"] = {
+                        "effort": OPENAI_REASONING_EFFORT[reasoning_effort],
+                        "summary": "auto",
+                    }
+
             elif is_claude_model:
                 # Anthropic requires every assistant message with tool_use
                 # blocks to start with a thinking block that carries a

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -413,19 +413,25 @@ def _parse_anthropic_model_version(model_name: str) -> tuple[int, int] | None:
     return (major, minor)
 
 
-def _anthropic_uses_adaptive_thinking(model_name: str) -> bool:
+def _anthropic_meets_version(model_name: str, min_version: tuple[int, int]) -> bool:
     version = _parse_anthropic_model_version(model_name)
-    return version is not None and version >= _ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION
+    return version is not None and version >= min_version
+
+
+def _anthropic_uses_adaptive_thinking(model_name: str) -> bool:
+    return _anthropic_meets_version(
+        model_name, _ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION
+    )
 
 
 def _anthropic_supports_thinking(model_name: str) -> bool:
-    version = _parse_anthropic_model_version(model_name)
-    return version is not None and version >= _ANTHROPIC_THINKING_MIN_VERSION
+    return _anthropic_meets_version(model_name, _ANTHROPIC_THINKING_MIN_VERSION)
 
 
 def _anthropic_omits_sampling_params(model_name: str) -> bool:
-    version = _parse_anthropic_model_version(model_name)
-    return version is not None and version >= _ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION
+    return _anthropic_meets_version(
+        model_name, _ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION
+    )
 
 
 def _env_injection_enabled() -> bool:
@@ -652,9 +658,6 @@ class LitellmLLM(LLM):
         uses_adaptive_thinking = any(
             _anthropic_uses_adaptive_thinking(name) for name in model_identity_names
         )
-        # Claude >= 3.7 reasons regardless of what the litellm registry knows,
-        # so parse the version off the name too. Without this, an aliased
-        # deployment silently drops the user's reasoning setting.
         anthropic_supports_thinking = any(
             _anthropic_supports_thinking(name) for name in model_identity_names
         )
@@ -675,8 +678,8 @@ class LitellmLLM(LLM):
         is_mistral = self._model_provider == LlmProviderNames.MISTRAL
         is_vertex_ai = self._model_provider == LlmProviderNames.VERTEX_AI
         # Some Vertex Anthropic models reject stream_options. Reasoning params
-        # are no longer gated on this: a provider that rejects them answers
-        # with a 400 naming the kwarg, and the retry ladder below strips it.
+        # are sent regardless: a provider that rejects one answers with a 400
+        # naming the kwarg, which the retry ladder below strips.
         is_vertex_model_rejecting_stream_options = (
             is_vertex_ai
             and _is_vertex_model_rejecting_stream_options(self.config.model_name)
@@ -770,25 +773,26 @@ class LitellmLLM(LLM):
             and reasoning_effort != ReasoningEffort.OFF
             and not openai_model_rejects_reasoning_effort(self.config.model_name)
         ):
+            openai_style_reasoning = {
+                "effort": OPENAI_REASONING_EFFORT[reasoning_effort],
+                "summary": "auto",
+            }
+
             if is_openai_model:
                 # OpenAI API does not accept reasoning params for GPT 5 chat models
                 # (neither reasoning nor reasoning_effort are accepted)
                 # even though they are reasoning models (bug in OpenAI)
                 if "-chat" not in model:
-                    optional_kwargs["reasoning"] = {
-                        "effort": OPENAI_REASONING_EFFORT[reasoning_effort],
-                        "summary": "auto",
-                    }
+                    optional_kwargs["reasoning"] = openai_style_reasoning
 
             elif is_claude_model and is_openai_compatible_proxy:
                 # Wire format follows the API surface, not the model vendor.
                 # LiteLLM drops thinking/output_config as unsupported on an
                 # openai surface, so a gateway only sees reasoning.effort.
+                # The gateway still translates to Anthropic, so the tool-call
+                # constraint below applies here too.
                 if not _prompt_contains_tool_call_history(prompt):
-                    optional_kwargs["reasoning"] = {
-                        "effort": OPENAI_REASONING_EFFORT[reasoning_effort],
-                        "summary": "auto",
-                    }
+                    optional_kwargs["reasoning"] = openai_style_reasoning
 
             elif is_claude_model:
                 # Anthropic requires every assistant message with tool_use

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -77,7 +77,7 @@ STANDARD_MAX_TOKENS_KWARG = "max_completion_tokens"
 # LiteLLM's BaseAzureLLM._is_azure_v1_api_version.
 _AZURE_V1_API_VERSIONS = frozenset({"preview", "latest", "v1"})
 
-_VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG = (
+_VERTEX_ANTHROPIC_MODELS_REJECTING_STREAM_OPTIONS = (
     "claude-opus-4-5",
     "claude-opus-4-6",
     "claude-opus-4-7",
@@ -94,6 +94,11 @@ _VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG = (
 # avoids relying on LiteLLM's drop_params (unreliable here, since AnthropicConfig
 # still advertises temperature as supported).
 _ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION = (4, 7)
+
+# Extended thinking landed in Claude 3.7. Parsing the version off the name
+# keeps aliased deployments (gateways, custom model names) reasoning even when
+# the litellm registry doesn't recognize the string.
+_ANTHROPIC_THINKING_MIN_VERSION = (3, 7)
 
 # Best-effort tuning kwargs, never worth failing a chat over. _completion
 # retries provider rejections without them: reasoning keys first, then all.
@@ -361,11 +366,11 @@ def _log_azure_responses_api_version_override(
     )
 
 
-def _is_vertex_model_rejecting_output_config(model_name: str) -> bool:
+def _is_vertex_model_rejecting_stream_options(model_name: str) -> bool:
     normalized_model_name = model_name.lower()
     return any(
         blocked_model in normalized_model_name
-        for blocked_model in _VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG
+        for blocked_model in _VERTEX_ANTHROPIC_MODELS_REJECTING_STREAM_OPTIONS
     )
 
 
@@ -411,6 +416,11 @@ def _parse_anthropic_model_version(model_name: str) -> tuple[int, int] | None:
 def _anthropic_uses_adaptive_thinking(model_name: str) -> bool:
     version = _parse_anthropic_model_version(model_name)
     return version is not None and version >= _ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION
+
+
+def _anthropic_supports_thinking(model_name: str) -> bool:
+    version = _parse_anthropic_model_version(model_name)
+    return version is not None and version >= _ANTHROPIC_THINKING_MIN_VERSION
 
 
 def _anthropic_omits_sampling_params(model_name: str) -> bool:
@@ -639,16 +649,22 @@ class LitellmLLM(LLM):
         ]
         is_claude_model = any("claude" in name.lower() for name in model_identity_names)
         is_qwen_model = "qwen" in self.config.model_name.lower()
-        # Claude >= 4.7 always reasons via the adaptive thinking API, so treat
-        # it as a reasoning model even when the litellm registry doesn't know
-        # the (possibly aliased) name — otherwise reasoning_effort is silently
-        # dropped for such models.
         uses_adaptive_thinking = any(
             _anthropic_uses_adaptive_thinking(name) for name in model_identity_names
         )
-        is_reasoning = uses_adaptive_thinking or any(
-            model_is_reasoning_model(name, self.config.model_provider)
-            for name in model_identity_names
+        # Claude >= 3.7 reasons regardless of what the litellm registry knows,
+        # so parse the version off the name too. Without this, an aliased
+        # deployment silently drops the user's reasoning setting.
+        anthropic_supports_thinking = any(
+            _anthropic_supports_thinking(name) for name in model_identity_names
+        )
+        is_reasoning = (
+            uses_adaptive_thinking
+            or anthropic_supports_thinking
+            or any(
+                model_is_reasoning_model(name, self.config.model_provider)
+                for name in model_identity_names
+            )
         )
         # All OpenAI models will use responses API for consistency
         # Responses API is needed to get reasoning packets from OpenAI models
@@ -658,11 +674,12 @@ class LitellmLLM(LLM):
         is_ollama = self._model_provider == LlmProviderNames.OLLAMA_CHAT
         is_mistral = self._model_provider == LlmProviderNames.MISTRAL
         is_vertex_ai = self._model_provider == LlmProviderNames.VERTEX_AI
-        # Some Vertex Anthropic models reject output_config.
-        # Keep this guard until LiteLLM/Vertex accept the field for these models.
-        is_vertex_model_rejecting_output_config = (
+        # Some Vertex Anthropic models reject stream_options. Reasoning params
+        # are no longer gated on this: a provider that rejects them answers
+        # with a 400 naming the kwarg, and the retry ladder below strips it.
+        is_vertex_model_rejecting_stream_options = (
             is_vertex_ai
-            and _is_vertex_model_rejecting_output_config(self.config.model_name)
+            and _is_vertex_model_rejecting_stream_options(self.config.model_name)
         )
 
         #########################
@@ -742,7 +759,7 @@ class LitellmLLM(LLM):
         if not omits_sampling_params:
             optional_kwargs["temperature"] = 1 if is_reasoning else self._temperature
 
-        if stream and not is_vertex_model_rejecting_output_config:
+        if stream and not is_vertex_model_rejecting_stream_options:
             optional_kwargs["stream_options"] = {"include_usage": True}
 
         # Note, there is a reasoning_effort parameter in LiteLLM but it is completely jank and does not work for any
@@ -751,7 +768,6 @@ class LitellmLLM(LLM):
             is_reasoning
             # The default of this parameter not set is surprisingly not the equivalent of an Auto but is actually Off
             and reasoning_effort != ReasoningEffort.OFF
-            and not is_vertex_model_rejecting_output_config
             and not openai_model_rejects_reasoning_effort(self.config.model_name)
         ):
             if is_openai_model:

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -716,9 +716,8 @@ def test_openai_auto_reasoning_effort_maps_to_medium() -> None:
 
 @pytest.mark.parametrize("model_name", VERTEX_OPUS_MODELS_REJECTING_STREAM_OPTIONS)
 def test_vertex_opus_still_sends_thinking(model_name: str) -> None:
-    """Rejecting stream_options must not cost these models their reasoning.
-    A provider that rejects a reasoning kwarg answers with a 400 naming it,
-    which the retry ladder strips."""
+    """Rejecting stream_options must not cost these models their reasoning:
+    thinking is still sent."""
     llm = LitellmLLM(
         api_key="test_key",
         timeout=30,
@@ -744,9 +743,9 @@ def test_vertex_opus_still_sends_thinking(model_name: str) -> None:
 
 
 def test_claude_via_openai_compatible_proxy_uses_reasoning_param() -> None:
-    """The wire format follows the API surface, not the model vendor. An
-    OpenAI-shaped gateway drops Anthropic's thinking/output_config, so Claude
-    behind one must ask for reasoning the OpenAI way."""
+    """The wire format follows the API surface, not the model vendor: Claude
+    behind an OpenAI-shaped gateway asks for reasoning the OpenAI way, never
+    Anthropic's thinking/output_config."""
     llm = LitellmLLM(
         api_key="test_key",
         timeout=30,

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -743,13 +743,39 @@ def test_vertex_opus_still_sends_thinking(model_name: str) -> None:
         assert "thinking" in kwargs
 
 
+def test_claude_via_openai_compatible_proxy_uses_reasoning_param() -> None:
+    """The wire format follows the API surface, not the model vendor. An
+    OpenAI-shaped gateway drops Anthropic's thinking/output_config, so Claude
+    behind one must ask for reasoning the OpenAI way."""
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.BIFROST,
+        model_name="anthropic/claude-sonnet-4-5",
+        api_base="https://gateway.example/v1",
+        max_input_tokens=200000,
+        custom_config={"bifrost_api_mode": "chat_completions"},
+    )
+
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages, reasoning_effort=ReasoningEffort.HIGH))
+
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["reasoning"] == {"effort": "high", "summary": "auto"}
+        assert "thinking" not in kwargs
+        assert "output_config" not in kwargs
+
+
 def test_aliased_claude_model_still_reasons() -> None:
     """A gateway alias the litellm registry doesn't know still reasons: the
     version parsed off the name decides, not the registry."""
     llm = LitellmLLM(
         api_key="test_key",
         timeout=30,
-        model_provider=LlmProviderNames.BIFROST,
+        model_provider=LlmProviderNames.VERTEX_AI,
         model_name="gateway-claude-sonnet-4-5-prod",
         max_input_tokens=100000,
     )

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -34,7 +34,7 @@ from onyx.llm.multi_llm import (
     temporary_env_and_lock,
 )
 
-VERTEX_OPUS_MODELS_REJECTING_OUTPUT_CONFIG = [
+VERTEX_OPUS_MODELS_REJECTING_STREAM_OPTIONS = [
     "claude-opus-4-5@20251101",
     "claude-opus-4-6",
     "claude-opus-4-7",
@@ -665,7 +665,7 @@ def test_parse_anthropic_model_version(
     assert _parse_anthropic_model_version(model_name) == expected
 
 
-@pytest.mark.parametrize("model_name", VERTEX_OPUS_MODELS_REJECTING_OUTPUT_CONFIG)
+@pytest.mark.parametrize("model_name", VERTEX_OPUS_MODELS_REJECTING_STREAM_OPTIONS)
 def test_vertex_stream_omits_stream_options(model_name: str) -> None:
     llm = LitellmLLM(
         api_key="test_key",
@@ -714,8 +714,11 @@ def test_openai_auto_reasoning_effort_maps_to_medium() -> None:
         assert kwargs["reasoning"]["effort"] == "medium"
 
 
-@pytest.mark.parametrize("model_name", VERTEX_OPUS_MODELS_REJECTING_OUTPUT_CONFIG)
-def test_vertex_opus_omits_reasoning_effort(model_name: str) -> None:
+@pytest.mark.parametrize("model_name", VERTEX_OPUS_MODELS_REJECTING_STREAM_OPTIONS)
+def test_vertex_opus_still_sends_thinking(model_name: str) -> None:
+    """Rejecting stream_options must not cost these models their reasoning.
+    A provider that rejects a reasoning kwarg answers with a 400 naming it,
+    which the retry ladder strips."""
     llm = LitellmLLM(
         api_key="test_key",
         timeout=30,
@@ -734,10 +737,34 @@ def test_vertex_opus_omits_reasoning_effort(model_name: str) -> None:
         mock_completion.return_value = []
 
         messages: LanguageModelInput = [UserMessage(content="Hi")]
-        list(llm.stream(messages))
+        list(llm.stream(messages, reasoning_effort=ReasoningEffort.HIGH))
 
         kwargs = mock_completion.call_args.kwargs
-        assert "reasoning_effort" not in kwargs
+        assert "thinking" in kwargs
+
+
+def test_aliased_claude_model_still_reasons() -> None:
+    """A gateway alias the litellm registry doesn't know still reasons: the
+    version parsed off the name decides, not the registry."""
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.BIFROST,
+        model_name="gateway-claude-sonnet-4-5-prod",
+        max_input_tokens=100000,
+    )
+
+    with (
+        patch("litellm.completion") as mock_completion,
+        patch("onyx.llm.multi_llm.model_is_reasoning_model", return_value=False),
+    ):
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages, reasoning_effort=ReasoningEffort.HIGH))
+
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["thinking"] == {"type": "enabled", "budget_tokens": 4096}
 
 
 def test_openai_chat_omits_reasoning_params() -> None:


### PR DESCRIPTION
## Description

**Bug:** the per-session reasoning-effort control did nothing for Anthropic models on Vertex, and for Claude routed through an OpenAI-compatible gateway (Bifrost, LiteLLM proxy). The setting was discarded before the request left Onyx.

**Causes:**
- A Feb model list (`claude-opus-4-5/4-6/4-7/4-8` on `vertex_ai`) gated the whole reasoning block, not just `output_config`. It was needed when a provider 400 killed the chat; the retry ladder added since backstops exactly that.
- On an OpenAI-shaped surface, LiteLLM drops Anthropic's `thinking`/`output_config` as unsupported, so nothing reached the gateway. The wire format has to follow the API surface, not the model vendor.
- `is_reasoning` came only from LiteLLM's registry, so aliased model names (`anthropic/claude-…`, custom gateway names) silently fell through as non-reasoning.

**Fix:** drop the list from the reasoning gate (kept for `stream_options`, renamed accordingly); send OpenAI-style `reasoning{effort,summary}` for Claude on OpenAI-compatible surfaces; treat Claude >= 3.7 as reasoning-capable from the version parsed off the name.

**Verified live, not just unit-tested.** Vertex `claude-opus-4-5`: 0 -> 712 reasoning chars in a clean A/B. Bifrost (v1.6.8): `opus-5` from hard failure -> reasoning returned; sonnet-4-5 522, haiku-4-5 306. Effort is honored (low 2,226 vs high 6,687 chars).

Requires Bifrost >= v1.6.5 for Opus 5 (onyx-infra#744).

## How Has This Been Tested?

Live calls against both real providers, plus unit tests.

**Vertex (clean A/B, same prompt, only the code differing):**

| model | origin/main | with fix |
|---|---|---|
| claude-opus-4-5 | 0 chars | 712 chars |
| claude-opus-4-6 | 0 chars | 135 chars |

**Bifrost gateway (v1.6.8), through Onyx's streaming path:**

| model | before | after |
|---|---|---|
| claude-opus-5 | hard failure | 116 chars |
| claude-sonnet-4-5 | 0 | 430 |
| claude-haiku-4-5 | 0 | 306 |
| claude-sonnet-5 | 0 | 124 |
| claude-opus-4-8 | 0 | 142 |

Effort is honored, not just transmitted: on a harder prompt, sonnet-4-5 gave 4,253 chars at low vs 12,103 at high; opus-5 gave 2,226 vs 6,687.

**Unit tests:** 3 new tests, each confirmed to fail against unfixed code before being trusted. Full LLM suite 427 passed, `ty check` clean, `ruff format --check` clean.

**Non-gateway paths re-verified after the refactor** (it touches shared helpers): vertex/opus-4-5 -> `thinking{enabled,budget_tokens}`, vertex/opus-4-8 -> `thinking{adaptive}+output_config`, azure/gpt-5.4 -> `reasoning{effort,summary}`, all byte-identical to before.

**Not covered:** reasoning is still suppressed after the first tool call in a turn (`multi_llm.py:794`, `:805`) for every Claude on every surface. Pre-existing, needs signed thinking-block persistence.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
