### PR TITLE
feat(log-export): switch the admin export page to the async flow

### DIFF
--- a/backend/ee/onyx/server/log_export/storage.py
+++ b/backend/ee/onyx/server/log_export/storage.py
@@ -142,7 +142,7 @@ def _build_bundle_readme(snapshot: LogExportSnapshot) -> str:
         "Contents: one piece_<hostname>.zip per host that uploaded logs, plus",
         f"{BUNDLE_MANIFEST_FILE_NAME} with per-worker receipt outcomes.",
         "On Kubernetes, each piece samples a single replica per worker type;",
-        "logs from other replicas and from stdout-only pods are not includedas of now.",
+        "logs from other replicas and from stdout-only pods are not included as of now.",
         "",
         "Worker outcomes:",
     ]

--- a/web/src/app/ee/admin/export-logs/page.tsx
+++ b/web/src/app/ee/admin/export-logs/page.tsx
@@ -20,8 +20,8 @@ const EXPORT_URL = "/api/admin/log-export";
 const FALLBACK_FILENAME = "onyx_logs.zip";
 const POLL_INTERVAL_MS = 2_000;
 // Give up on a poll that fails this many times in a row (~30s at the poll
-// interval); the export's server-side collection window is only 90s, so
-// polling through longer outages has no value.
+// interval); the export's server-side collection window is only 90s, so polling
+// through longer outages has no value.
 const MAX_CONSECUTIVE_POLL_FAILURES = 15;
 
 type LogExportReceiptStatus =

--- a/web/src/app/ee/admin/export-logs/page.tsx
+++ b/web/src/app/ee/admin/export-logs/page.tsx
@@ -19,6 +19,10 @@ const DESCRIPTION =
 const EXPORT_URL = "/api/admin/log-export";
 const FALLBACK_FILENAME = "onyx_logs.zip";
 const POLL_INTERVAL_MS = 2_000;
+// Give up on a poll that fails this many times in a row (~30s at the poll
+// interval); the export's server-side collection window is only 90s, so
+// polling through longer outages has no value.
+const MAX_CONSECUTIVE_POLL_FAILURES = 15;
 
 type LogExportReceiptStatus =
   | "uploaded"
@@ -105,23 +109,37 @@ export default function ExportLogsPage() {
 
   const isCollecting = exportId !== null && status?.state !== "ready";
 
+  const consecutivePollFailuresRef = useRef(0);
+
   // A definitive 4xx means the export is gone (already cleaned up) or no longer
-  // accessible; drop it so the page recovers instead of showing "collecting"
-  // forever. Other errors are transient: interval polling keeps running and
-  // self-heals.
+  // accessible; drop it immediately. Other errors are transient (interval
+  // polling keeps running and self-heals), but only up to a cap: a server that
+  // stays down must not leave the page collecting forever.
   useEffect(() => {
     if (statusError === undefined) {
+      consecutivePollFailuresRef.current = 0;
       return;
     }
     console.error("Log export status poll failed:", statusError);
-    if (
+    consecutivePollFailuresRef.current += 1;
+
+    const isTerminal4xx =
       statusError instanceof FetchError &&
       statusError.status >= 400 &&
-      statusError.status < 500
-    ) {
+      statusError.status < 500;
+    if (isTerminal4xx) {
       toast.error("Lost access to the running export. Start a new one.");
-      setExportId(null);
+    } else if (
+      consecutivePollFailuresRef.current >= MAX_CONSECUTIVE_POLL_FAILURES
+    ) {
+      toast.error(
+        "Cannot reach the server to check export progress. Start a new export once it is back."
+      );
+    } else {
+      return;
     }
+    consecutivePollFailuresRef.current = 0;
+    setExportId(null);
   }, [statusError]);
 
   const downloadBundle = useCallback(async (id: string): Promise<void> => {

--- a/web/src/app/ee/admin/export-logs/page.tsx
+++ b/web/src/app/ee/admin/export-logs/page.tsx
@@ -7,7 +7,8 @@ import { Button, MessageCard, Text } from "@opal/components";
 import { SvgDownload } from "@opal/icons";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { downloadFile } from "@/lib/download";
-import { errorHandlingFetcher } from "@/lib/fetcher";
+import { errorHandlingFetcher, FetchError } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
 import { Section } from "@/layouts/general-layouts";
 import Card from "@/refresh-components/cards/Card";
 
@@ -93,8 +94,8 @@ export default function ExportLogsPage() {
   const [isDownloading, setIsDownloading] = useState(false);
   const downloadedExportIdRef = useRef<string | null>(null);
 
-  const { data: status } = useSWR<LogExportStatus>(
-    exportId === null ? null : `${EXPORT_URL}/${exportId}`,
+  const { data: status, error: statusError } = useSWR<LogExportStatus>(
+    exportId === null ? null : SWR_KEYS.logExportStatus(exportId),
     errorHandlingFetcher,
     {
       refreshInterval: (latest) =>
@@ -103,6 +104,21 @@ export default function ExportLogsPage() {
   );
 
   const isCollecting = exportId !== null && status?.state !== "ready";
+
+  // A definitive 4xx means the export is gone (already cleaned up) or no
+  // longer accessible; drop it so the page recovers instead of showing
+  // "collecting" forever. Other errors are transient: interval polling keeps
+  // running and self-heals.
+  useEffect(() => {
+    if (
+      statusError instanceof FetchError &&
+      statusError.status >= 400 &&
+      statusError.status < 500
+    ) {
+      toast.error("Lost access to the running export. Start a new one.");
+      setExportId(null);
+    }
+  }, [statusError]);
 
   const downloadBundle = useCallback(async (id: string): Promise<void> => {
     setIsDownloading(true);
@@ -122,6 +138,9 @@ export default function ExportLogsPage() {
     } catch (error) {
       console.error("Error downloading log export:", error);
       toast.error("Failed to download the log export.");
+      // Un-mark the export so the download can be retried; the bundle stays
+      // available in the file store until retention sweeps it.
+      downloadedExportIdRef.current = null;
     } finally {
       setIsDownloading(false);
     }
@@ -236,6 +255,18 @@ export default function ExportLogsPage() {
                   pending={row.pending}
                 />
               ))
+            )}
+            {status?.state === "ready" && (
+              <Section flexDirection="row" justifyContent="end" height="fit">
+                <Button
+                  prominence="secondary"
+                  icon={SvgDownload}
+                  onClick={() => void downloadBundle(status.export_id)}
+                  disabled={isDownloading}
+                >
+                  Download
+                </Button>
+              </Section>
             )}
           </Card>
         )}

--- a/web/src/app/ee/admin/export-logs/page.tsx
+++ b/web/src/app/ee/admin/export-logs/page.tsx
@@ -1,19 +1,45 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import useSWR from "swr";
 import { ContentAction, SettingsLayouts, toast } from "@opal/layouts";
-import { Button, MessageCard } from "@opal/components";
+import { Button, MessageCard, Text } from "@opal/components";
 import { SvgDownload } from "@opal/icons";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { downloadFile } from "@/lib/download";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { Section } from "@/layouts/general-layouts";
 import Card from "@/refresh-components/cards/Card";
 
 const route = ADMIN_ROUTES.EXPORT_LOGS;
 
 const DESCRIPTION =
   "Download a zip of server log files to attach to an Onyx support thread.";
-const DOWNLOAD_URL = "/api/admin/log-export/download";
+const EXPORT_URL = "/api/admin/log-export";
 const FALLBACK_FILENAME = "onyx_logs.zip";
+const POLL_INTERVAL_MS = 2_000;
+
+type LogExportReceiptStatus =
+  | "uploaded"
+  | "duplicate_host"
+  | "no_logs_found"
+  | "failed";
+
+interface LogExportReceipt {
+  worker_name: string;
+  hostname: string;
+  status: LogExportReceiptStatus;
+  file_count: number;
+  size_bytes: number;
+  error: string | null;
+}
+
+interface LogExportStatus {
+  export_id: string;
+  state: "collecting" | "ready";
+  receipts: LogExportReceipt[];
+  pending_worker_names: string[];
+}
 
 function extractFilename(response: Response): string {
   const disposition = response.headers.get("Content-Disposition");
@@ -21,15 +47,71 @@ function extractFilename(response: Response): string {
   return match?.[1]?.trim() ?? FALLBACK_FILENAME;
 }
 
-export default function ExportLogsPage() {
-  const [isDownloading, setIsDownloading] = useState(false);
+function receiptLabel(receipt: LogExportReceipt): string {
+  switch (receipt.status) {
+    case "uploaded":
+      return `uploaded ${receipt.file_count} file${
+        receipt.file_count === 1 ? "" : "s"
+      }`;
+    case "duplicate_host":
+      return "covered by another worker on the same host";
+    case "no_logs_found":
+      return "no log files found";
+    case "failed":
+      return receipt.error ? `failed: ${receipt.error}` : "failed";
+    default: {
+      const exhaustive: never = receipt.status;
+      return exhaustive;
+    }
+  }
+}
 
-  async function handleDownload(): Promise<void> {
+interface WorkerStatusRowProps {
+  workerName: string;
+  label: string;
+  pending?: boolean;
+}
+
+function WorkerStatusRow({
+  workerName,
+  label,
+  pending = false,
+}: WorkerStatusRowProps) {
+  return (
+    <Section flexDirection="row" justifyContent="between" height="fit">
+      <Text font="main-ui-body">{workerName}</Text>
+      <Text font="main-ui-body" color={pending ? "text-02" : "text-03"}>
+        {label}
+      </Text>
+    </Section>
+  );
+}
+
+export default function ExportLogsPage() {
+  const [exportId, setExportId] = useState<string | null>(null);
+  const [isStarting, setIsStarting] = useState(false);
+  const [isDownloading, setIsDownloading] = useState(false);
+  const downloadedExportIdRef = useRef<string | null>(null);
+
+  const { data: status } = useSWR<LogExportStatus>(
+    exportId === null ? null : `${EXPORT_URL}/${exportId}`,
+    errorHandlingFetcher,
+    {
+      refreshInterval: (latest) =>
+        latest?.state === "ready" ? 0 : POLL_INTERVAL_MS,
+    }
+  );
+
+  const isCollecting = exportId !== null && status?.state !== "ready";
+
+  const downloadBundle = useCallback(async (id: string): Promise<void> => {
     setIsDownloading(true);
     try {
-      const response = await fetch(DOWNLOAD_URL);
+      const response = await fetch(`${EXPORT_URL}/${id}/download`);
       if (!response.ok) {
-        throw new Error(`Log export failed with status ${response.status}`);
+        throw new Error(
+          `Log export download failed with status ${response.status}`
+        );
       }
       const blob = await response.blob();
       const url = URL.createObjectURL(blob);
@@ -38,12 +120,74 @@ export default function ExportLogsPage() {
       // dereferences the blob URL asynchronously.
       setTimeout(() => URL.revokeObjectURL(url), 0);
     } catch (error) {
-      console.error("Error exporting logs:", error);
-      toast.error("Failed to export logs.");
+      console.error("Error downloading log export:", error);
+      toast.error("Failed to download the log export.");
     } finally {
       setIsDownloading(false);
     }
+  }, []);
+
+  // Download exactly once per export, as soon as it is ready.
+  useEffect(() => {
+    if (
+      exportId === null ||
+      status?.state !== "ready" ||
+      downloadedExportIdRef.current === exportId
+    ) {
+      return;
+    }
+    downloadedExportIdRef.current = exportId;
+    void downloadBundle(exportId);
+  }, [exportId, status, downloadBundle]);
+
+  async function handleExport(): Promise<void> {
+    setIsStarting(true);
+    try {
+      const response = await fetch(EXPORT_URL, { method: "POST" });
+      if (response.status === 429) {
+        toast.error("A log export is already in progress. Try again shortly.");
+        return;
+      }
+      if (!response.ok) {
+        throw new Error(
+          `Starting the log export failed with status ${response.status}`
+        );
+      }
+      const body: { export_id: string } = await response.json();
+      setExportId(body.export_id);
+    } catch (error) {
+      console.error("Error starting log export:", error);
+      toast.error("Failed to start the log export.");
+    } finally {
+      setIsStarting(false);
+    }
   }
+
+  // One row per worker, alphabetical so rows do not jump around as receipts
+  // replace pending entries between polls.
+  const workerRows =
+    status === undefined
+      ? []
+      : [
+          ...status.receipts.map((receipt) => ({
+            workerName: receipt.worker_name,
+            label: receiptLabel(receipt),
+            pending: false,
+          })),
+          ...status.pending_worker_names.map((workerName) => ({
+            workerName,
+            label: "collecting...",
+            pending: true,
+          })),
+        ].sort((a, b) => a.workerName.localeCompare(b.workerName));
+
+  const buttonLabel = isStarting
+    ? "Starting..."
+    : isCollecting
+      ? "Collecting..."
+      : isDownloading
+        ? "Downloading..."
+        : "Export Logs";
 
   return (
     <SettingsLayouts.Root>
@@ -64,19 +208,37 @@ export default function ExportLogsPage() {
             sizePreset="main-ui"
             variant="section"
             icon={SvgDownload}
-            title="Export api_server logs"
-            description="Collects the API server's log files, including rotations, into a single zip. Logs from background workers are not yet included."
+            title="Export logs"
+            description="Collects log files from the API server and every background worker into a single zip. The download starts automatically once collection finishes."
             rightChildren={
               <Button
                 icon={SvgDownload}
-                onClick={handleDownload}
-                disabled={isDownloading}
+                onClick={handleExport}
+                disabled={isStarting || isCollecting || isDownloading}
               >
-                {isDownloading ? "Exporting..." : "Export Logs"}
+                {buttonLabel}
               </Button>
             }
           />
         </Card>
+        {exportId !== null && (
+          <Card>
+            {workerRows.length === 0 ? (
+              <Text font="main-ui-body" color="text-02">
+                Starting collection...
+              </Text>
+            ) : (
+              workerRows.map((row) => (
+                <WorkerStatusRow
+                  key={row.workerName}
+                  workerName={row.workerName}
+                  label={row.label}
+                  pending={row.pending}
+                />
+              ))
+            )}
+          </Card>
+        )}
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>
   );

--- a/web/src/app/ee/admin/export-logs/page.tsx
+++ b/web/src/app/ee/admin/export-logs/page.tsx
@@ -143,6 +143,10 @@ export default function ExportLogsPage() {
   }, [statusError]);
 
   const downloadBundle = useCallback(async (id: string): Promise<void> => {
+    // Mark before any await: an attempt is in flight or succeeded, and only
+    // failure re-arms the auto-download below. Owning this here keeps every
+    // call site (auto-fire, manual retry) consistent.
+    downloadedExportIdRef.current = id;
     setIsDownloading(true);
     try {
       const response = await fetch(`${EXPORT_URL}/${id}/download`);
@@ -177,7 +181,6 @@ export default function ExportLogsPage() {
     ) {
       return;
     }
-    downloadedExportIdRef.current = exportId;
     void downloadBundle(exportId);
   }, [exportId, status, downloadBundle]);
 

--- a/web/src/app/ee/admin/export-logs/page.tsx
+++ b/web/src/app/ee/admin/export-logs/page.tsx
@@ -105,11 +105,15 @@ export default function ExportLogsPage() {
 
   const isCollecting = exportId !== null && status?.state !== "ready";
 
-  // A definitive 4xx means the export is gone (already cleaned up) or no
-  // longer accessible; drop it so the page recovers instead of showing
-  // "collecting" forever. Other errors are transient: interval polling keeps
-  // running and self-heals.
+  // A definitive 4xx means the export is gone (already cleaned up) or no longer
+  // accessible; drop it so the page recovers instead of showing "collecting"
+  // forever. Other errors are transient: interval polling keeps running and
+  // self-heals.
   useEffect(() => {
+    if (statusError === undefined) {
+      return;
+    }
+    console.error("Log export status poll failed:", statusError);
     if (
       statusError instanceof FetchError &&
       statusError.status >= 400 &&
@@ -195,7 +199,12 @@ export default function ExportLogsPage() {
           })),
           ...status.pending_worker_names.map((workerName) => ({
             workerName,
-            label: "collecting...",
+            // Once the export is ready, a missing receipt is final: that
+            // worker's logs are not in the bundle.
+            label:
+              status.state === "ready"
+                ? "did not report before the deadline"
+                : "collecting...",
             pending: true,
           })),
         ].sort((a, b) => a.workerName.localeCompare(b.workerName));
@@ -228,7 +237,7 @@ export default function ExportLogsPage() {
             variant="section"
             icon={SvgDownload}
             title="Export logs"
-            description="Collects log files from the API server and every background worker into a single zip. The download starts automatically once collection finishes."
+            description="Collects log files from the API server and background workers into a single zip. The download starts automatically once collection finishes."
             rightChildren={
               <Button
                 icon={SvgDownload}

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -199,6 +199,7 @@ export const SWR_KEYS = {
   // ── Admin ─────────────────────────────────────────────────────────────────
   hooks: "/api/admin/hooks",
   hookSpecs: "/api/admin/hooks/specs",
+  logExportStatus: (exportId: string) => `/api/admin/log-export/${exportId}`,
 
   // ── Slack Bots ────────────────────────────────────────────────────────────
   slackChannels: "/api/manage/admin/slack-app/channel",


### PR DESCRIPTION
## Description

Reworks `web/src/app/ee/admin/export-logs/page.tsx` from the one-shot `GET /api/admin/log-export/download` to the async flow added in #13736: `POST /api/admin/log-export`, poll `GET /api/admin/log-export/{export_id}` every 2s via `useSWR` (stops at ready), then auto-download the bundle exactly once per export.

- While collecting, a card lists one row per worker (alphabetized so rows don't jump between polls) with receipt outcomes: uploaded N files, covered by another worker on the same host, no log files found, failed with the error detail, or collecting...
- The export button walks Starting -> Collecting -> Downloading and a 429 on start surfaces an "export already in progress" toast.
- The `export_id` lives in component state only: a refresh mid-collection loses the poll (the export itself continues server-side and is swept by retention); re-attach via URL param is a possible follow-up.
- Also fixes a one-word typo in the bundle README (`storage.py`).

The sync endpoint stays untouched and is removed in the next PR once this is live.

## How Has This Been Tested?

Tested with pre-commit (oxlint, oxfmt, tsc) and a real browser click-through: login -> Export Logs -> per-worker rows fill in -> onyx_logs_*.zip downloads automatically; verified the bundle contains README.txt, manifest.json, and the host's piece zip.

<img width="1240" height="1041" alt="Screenshot 2026-08-07 at 12 16 13" src="https://github.com/user-attachments/assets/3eb8eb66-03ec-411c-812a-52f0a9891fdf" />
<img width="1240" height="1041" alt="Screenshot 2026-08-07 at 12 16 25" src="https://github.com/user-attachments/assets/cbce6d0a-8b16-40cb-bc2b-45d5dc558c66" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the admin Export Logs page to an async flow that collects logs from the API server and all workers, shows per-worker progress (including timeouts), and auto-downloads the zip when ready. Adds a manual download option and resilient polling so the UI doesn’t get stuck.

- **New Features**
  - Start export with `POST /api/admin/log-export`, poll `GET /api/admin/log-export/{export_id}` every 2s until ready, then auto-download from `/api/admin/log-export/{export_id}/download` exactly once (manual Download button available to retry).
  - Show per-worker rows with statuses: uploaded N files, covered by another worker on the same host, no logs found, failed, collecting, did not report before the deadline. Rows are alphabetized by worker name.
  - Button flow: Starting → Collecting → Downloading. A 429 shows an “export already in progress” toast.
  - Robust polling: on 4xx, drop the export and show “Lost access to the running export.” After ~30s of consecutive failures, show “Cannot reach the server… Start a new export once it is back.”

- **Bug Fixes**
  - Fixed a one-word typo in the bundle README.

<sup>Written for commit c1d9266fbae672c8a9abbd40c3524e41c1b1acb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



