### PR TITLE
fix: fetch perms for sharepoint hierarchynodes

### DIFF
--- a/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
@@ -12,7 +12,10 @@ from office365.onedrive.driveitems.driveItem import DriveItem
 from office365.runtime.client_request import ClientRequestException
 from office365.sharepoint.client_context import ClientContext
 from office365.sharepoint.permissions.roles.definitions.definition import RoleDefinition
-from office365.sharepoint.permissions.securable_object import RoleAssignmentCollection
+from office365.sharepoint.permissions.securable_object import (
+    RoleAssignmentCollection,
+    SecurableObject,
+)
 from office365.sharepoint.principal.users.collection import UserCollection
 from pydantic import BaseModel
 
@@ -27,6 +30,7 @@ from onyx.connectors.sharepoint.connector import (
     SHARED_DOCUMENTS_MAP_REVERSE,
     sleep_and_retry,
 )
+from onyx.db.enums import HierarchyNodeType
 from onyx.utils.logger import setup_logger
 from onyx.utils.retry_after import parse_retry_after_seconds
 
@@ -511,23 +515,16 @@ def _get_groups_and_members_recursively(
     )
 
 
-def get_external_access_from_sharepoint(
+def _get_external_access_from_securable_object(
     client_context: ClientContext,
     graph_client: GraphClient,
-    drive_name: str | None,
-    drive_item: DriveItem | None,
-    site_page: dict[str, Any] | None,
+    securable_object: SecurableObject,
     add_prefix: bool = False,
-    treat_sharing_link_as_public: bool = False,
 ) -> ExternalAccess:
-    """
-    Get external access information from SharePoint.
-    """
     groups: set[SharepointGroup] = set()
     user_emails: set[str] = set()
     group_ids: set[str] = set()
 
-    # Add all members to a processing set first
     def add_user_and_group_to_sets(
         role_assignments: RoleAssignmentCollection,
     ) -> None:
@@ -571,6 +568,51 @@ def get_external_access_from_sharepoint(
                         )
                     )
 
+    sleep_and_retry(
+        securable_object.role_assignments.expand(
+            ["Member", "RoleDefinitionBindings"]
+        ).get_all(
+            page_size=ROLE_ASSIGNMENTS_PAGE_SIZE,
+            page_loaded=add_user_and_group_to_sets,
+        ),
+        "get_external_access_from_sharepoint",
+    )
+
+    groups_and_members = _get_groups_and_members_recursively(
+        client_context, graph_client, groups
+    )
+    if groups_and_members.found_public_group:
+        return ExternalAccess(
+            external_user_emails=set(),
+            external_user_group_ids=set(),
+            is_public=True,
+        )
+
+    for group_name in groups_and_members.groups_to_emails:
+        if add_prefix:
+            group_name = build_ext_group_name_for_onyx(
+                group_name, DocumentSource.SHAREPOINT
+            )
+        group_ids.add(group_name.lower())
+
+    logger.info("User emails: %s", len(user_emails))
+    logger.info("Group IDs: %s", len(group_ids))
+    return ExternalAccess(
+        external_user_emails=user_emails,
+        external_user_group_ids=group_ids,
+        is_public=False,
+    )
+
+
+def get_external_access_from_sharepoint(
+    client_context: ClientContext,
+    graph_client: GraphClient,
+    drive_name: str | None,
+    drive_item: DriveItem | None,
+    site_page: dict[str, Any] | None,
+    add_prefix: bool = False,
+    treat_sharing_link_as_public: bool = False,
+) -> ExternalAccess:
     if drive_item and drive_name:
         is_public = _is_public_item(drive_item, treat_sharing_link_as_public)
         if is_public:
@@ -594,14 +636,6 @@ def get_external_access_from_sharepoint(
         item = client_context.web.lists.get_by_title(drive_name).items.get_by_id(
             item_id
         )
-
-        sleep_and_retry(
-            item.role_assignments.expand(["Member", "RoleDefinitionBindings"]).get_all(
-                page_size=ROLE_ASSIGNMENTS_PAGE_SIZE,
-                page_loaded=add_user_and_group_to_sets,
-            ),
-            "get_external_access_from_sharepoint",
-        )
     elif site_page:
         site_url = site_page.get("webUrl")
         # Keep percent-encoding intact so the path matches the encoding
@@ -614,43 +648,42 @@ def get_external_access_from_sharepoint(
             server_relative_url
         )
         item = file_obj.listItemAllFields
-
-        sleep_and_retry(
-            item.role_assignments.expand(["Member", "RoleDefinitionBindings"]).get_all(
-                page_size=ROLE_ASSIGNMENTS_PAGE_SIZE,
-                page_loaded=add_user_and_group_to_sets,
-            ),
-            "get_external_access_from_sharepoint",
-        )
     else:
         raise RuntimeError("No drive item or site page provided")
 
-    groups_and_members: GroupsResult = _get_groups_and_members_recursively(
-        client_context, graph_client, groups
+    return _get_external_access_from_securable_object(
+        client_context,
+        graph_client,
+        item,
+        add_prefix,
     )
 
-    # If the site is public, w have default groups assigned to it, so we return early
-    if groups_and_members.found_public_group:
-        return ExternalAccess(
-            external_user_emails=set(),
-            external_user_group_ids=set(),
-            is_public=True,
-        )
 
-    for group_name, _ in groups_and_members.groups_to_emails.items():
-        if add_prefix:
-            group_name = build_ext_group_name_for_onyx(
-                group_name, DocumentSource.SHAREPOINT
-            )
-        group_ids.add(group_name.lower())
+def get_hierarchy_node_external_access_from_sharepoint(
+    client_context: ClientContext,
+    graph_client: GraphClient,
+    node_type: HierarchyNodeType,
+    drive_name: str | None,
+    folder_url: str | None,
+) -> ExternalAccess:
+    if node_type == HierarchyNodeType.SITE:
+        securable_object = client_context.web
+    elif node_type == HierarchyNodeType.DRIVE and drive_name:
+        list_name = SHARED_DOCUMENTS_MAP_REVERSE.get(drive_name, drive_name)
+        securable_object = client_context.web.lists.get_by_title(list_name)
+    elif node_type == HierarchyNodeType.FOLDER and folder_url:
+        server_relative_url = urlparse(folder_url).path
+        securable_object = client_context.web.get_folder_by_server_relative_url(
+            server_relative_url
+        ).list_item_all_fields
+    else:
+        raise ValueError(f"Unsupported SharePoint hierarchy node: {node_type}")
 
-    logger.info("User emails: %s", len(user_emails))
-    logger.info("Group IDs: %s", len(group_ids))
-
-    return ExternalAccess(
-        external_user_emails=user_emails,
-        external_user_group_ids=group_ids,
-        is_public=False,
+    return _get_external_access_from_securable_object(
+        client_context,
+        graph_client,
+        securable_object,
+        add_prefix=True,
     )
 
 

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -68,7 +68,10 @@ from onyx.connectors.models import (
     TabularSection,
     TextSection,
 )
-from onyx.connectors.sharepoint.connector_utils import get_sharepoint_external_access
+from onyx.connectors.sharepoint.connector_utils import (
+    get_sharepoint_external_access,
+    get_sharepoint_hierarchy_node_external_access,
+)
 from onyx.db.enums import HierarchyNodeType
 from onyx.file_processing.extract_file_text import extract_text_and_images, get_file_ext
 from onyx.file_processing.file_types import OnyxFileExtensions, OnyxMimeTypes
@@ -2258,7 +2261,11 @@ class SharepointConnector(
 
             # Yield site hierarchy node using helper
             doc_batch.extend(
-                self._yield_site_hierarchy_node(site_descriptor, temp_checkpoint)
+                self._yield_site_hierarchy_node(
+                    site_descriptor,
+                    temp_checkpoint,
+                    include_permissions=include_permissions,
+                )
             )
 
             # Process site documents if flag is True
@@ -2277,7 +2284,11 @@ class SharepointConnector(
                     if drive_web_url:
                         doc_batch.extend(
                             self._yield_drive_hierarchy_node(
-                                site_url, drive_web_url, drive_name, temp_checkpoint
+                                site_url,
+                                drive_web_url,
+                                drive_name,
+                                temp_checkpoint,
+                                include_permissions=include_permissions,
                             )
                         )
 
@@ -2292,6 +2303,7 @@ class SharepointConnector(
                                 drive_name,
                                 folder_path,
                                 temp_checkpoint,
+                                include_permissions=include_permissions,
                             )
                         )
 
@@ -2537,6 +2549,7 @@ class SharepointConnector(
         self,
         site_descriptor: SiteDescriptor,
         checkpoint: SharepointConnectorCheckpoint,
+        include_permissions: bool = False,
     ) -> Generator[HierarchyNode, None, None]:
         """Yield a hierarchy node for a site if not already yielded.
 
@@ -2551,6 +2564,14 @@ class SharepointConnector(
 
         # Extract display name from URL (last path segment)
         display_name = site_url.rstrip("/").split("/")[-1]
+        external_access = None
+        if include_permissions:
+            ctx = self._create_rest_client_context(site_url)
+            external_access = get_sharepoint_hierarchy_node_external_access(
+                ctx,
+                self.graph_client,
+                HierarchyNodeType.SITE,
+            )
 
         yield HierarchyNode(
             raw_node_id=site_url,
@@ -2558,6 +2579,7 @@ class SharepointConnector(
             display_name=display_name,
             link=site_url,
             node_type=HierarchyNodeType.SITE,
+            external_access=external_access,
         )
 
     def _yield_drive_hierarchy_node(
@@ -2566,6 +2588,7 @@ class SharepointConnector(
         drive_web_url: str,
         drive_name: str,
         checkpoint: SharepointConnectorCheckpoint,
+        include_permissions: bool = False,
     ) -> Generator[HierarchyNode, None, None]:
         """Yield a hierarchy node for a drive if not already yielded.
 
@@ -2575,6 +2598,15 @@ class SharepointConnector(
             return
 
         checkpoint.seen_hierarchy_node_raw_ids.add(drive_web_url)
+        external_access = None
+        if include_permissions:
+            ctx = self._create_rest_client_context(site_url)
+            external_access = get_sharepoint_hierarchy_node_external_access(
+                ctx,
+                self.graph_client,
+                HierarchyNodeType.DRIVE,
+                drive_name=drive_name,
+            )
 
         yield HierarchyNode(
             raw_node_id=drive_web_url,
@@ -2582,6 +2614,7 @@ class SharepointConnector(
             display_name=drive_name,
             link=drive_web_url,
             node_type=HierarchyNodeType.DRIVE,
+            external_access=external_access,
         )
 
     def _yield_folder_hierarchy_nodes(
@@ -2591,6 +2624,7 @@ class SharepointConnector(
         drive_name: str,
         folder_path: str,
         checkpoint: SharepointConnectorCheckpoint,
+        include_permissions: bool = False,
     ) -> Generator[HierarchyNode, None, None]:
         """Yield hierarchy nodes for all folders in a path.
 
@@ -2617,6 +2651,15 @@ class SharepointConnector(
                 continue
 
             checkpoint.seen_hierarchy_node_raw_ids.add(folder_url)
+            external_access = None
+            if include_permissions:
+                ctx = self._create_rest_client_context(site_url)
+                external_access = get_sharepoint_hierarchy_node_external_access(
+                    ctx,
+                    self.graph_client,
+                    HierarchyNodeType.FOLDER,
+                    folder_url=folder_url,
+                )
 
             # Determine parent URL
             if i == 0:
@@ -2633,6 +2676,7 @@ class SharepointConnector(
                 display_name=part,  # Just the folder name
                 link=folder_url,
                 node_type=HierarchyNodeType.FOLDER,
+                external_access=external_access,
             )
 
     def _get_parent_hierarchy_url(
@@ -2727,6 +2771,7 @@ class SharepointConnector(
                 drive_name,
                 folder_path,
                 checkpoint,
+                include_permissions=include_permissions,
             )
 
         parent_hierarchy_url: str | None = None
@@ -2837,7 +2882,9 @@ class SharepointConnector(
                 )
                 # Yield site hierarchy node for the first site
                 yield from self._yield_site_hierarchy_node(
-                    checkpoint.current_site_descriptor, checkpoint
+                    checkpoint.current_site_descriptor,
+                    checkpoint,
+                    include_permissions=include_permissions,
                 )
                 return checkpoint
 
@@ -2979,6 +3026,7 @@ class SharepointConnector(
                     drive_web_url,
                     display_drive_name,
                     checkpoint,
+                    include_permissions=include_permissions,
                 )
 
             # For non-folder-scoped drives, use delta API with per-page
@@ -3234,7 +3282,9 @@ class SharepointConnector(
             )
             # Yield site hierarchy node for the new site
             yield from self._yield_site_hierarchy_node(
-                checkpoint.current_site_descriptor, checkpoint
+                checkpoint.current_site_descriptor,
+                checkpoint,
+                include_permissions=include_permissions,
             )
             return checkpoint
 
@@ -3345,10 +3395,15 @@ class SharepointConnector(
         yield from self._yield_site_hierarchy_node(
             SiteDescriptor(url=resolved.site_url, drive_name=None, folder_path=None),
             dedup,
+            include_permissions=include_permissions,
         )
         if resolved.drive_web_url:
             yield from self._yield_drive_hierarchy_node(
-                resolved.site_url, resolved.drive_web_url, resolved.drive_name, dedup
+                resolved.site_url,
+                resolved.drive_web_url,
+                resolved.drive_name,
+                dedup,
+                include_permissions=include_permissions,
             )
         yield from self._process_drive_item(
             resolved.driveitem,
@@ -3380,7 +3435,11 @@ class SharepointConnector(
 
         page = self._fetch_single_site_page(cast(str, site.id), document_id)
 
-        yield from self._yield_site_hierarchy_node(site_descriptor, dedup)
+        yield from self._yield_site_hierarchy_node(
+            site_descriptor,
+            dedup,
+            include_permissions=include_permissions,
+        )
 
         ctx: ClientContext | None = None
         if include_permissions:

--- a/backend/onyx/connectors/sharepoint/connector_utils.py
+++ b/backend/onyx/connectors/sharepoint/connector_utils.py
@@ -5,6 +5,7 @@ from office365.onedrive.driveitems.driveItem import DriveItem
 from office365.sharepoint.client_context import ClientContext
 
 from onyx.connectors.models import ExternalAccess
+from onyx.db.enums import HierarchyNodeType
 from onyx.utils.variable_functionality import (
     fetch_versioned_implementation_with_fallback,
 )
@@ -46,3 +47,30 @@ def get_sharepoint_external_access(
     )
 
     return external_access
+
+
+def get_sharepoint_hierarchy_node_external_access(
+    ctx: ClientContext,
+    graph_client: GraphClient,
+    node_type: HierarchyNodeType,
+    drive_name: str | None = None,
+    folder_url: str | None = None,
+) -> ExternalAccess:
+    def noop_fallback(
+        *args: Any,  # noqa: ARG001
+        **kwargs: Any,  # noqa: ARG001
+    ) -> ExternalAccess:
+        return ExternalAccess.empty()
+
+    get_external_access_func = fetch_versioned_implementation_with_fallback(
+        "onyx.external_permissions.sharepoint.permission_utils",
+        "get_hierarchy_node_external_access_from_sharepoint",
+        fallback=noop_fallback,
+    )
+    return get_external_access_func(
+        ctx,
+        graph_client,
+        node_type,
+        drive_name,
+        folder_url,
+    )

--- a/backend/onyx/db/hierarchy.py
+++ b/backend/onyx/db/hierarchy.py
@@ -326,10 +326,10 @@ def upsert_hierarchy_node(
         existing_node.link = node.link
         existing_node.node_type = node.node_type
         existing_node.parent_id = parent_id
-        # Update permission fields
-        existing_node.is_public = is_public
-        existing_node.external_user_emails = external_user_emails
-        existing_node.external_user_group_ids = external_user_group_ids
+        if is_connector_public or node.external_access is not None:
+            existing_node.is_public = is_public
+            existing_node.external_user_emails = external_user_emails
+            existing_node.external_user_group_ids = external_user_group_ids
         hierarchy_node = existing_node
     else:
         # Create new node

--- a/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
+++ b/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
@@ -21,6 +21,7 @@ from onyx.connectors.sharepoint.connector import (
 )
 from onyx.db.enums import HierarchyNodeType
 from tests.daily.connectors.utils import load_all_from_connector
+from tests.utils.pytest_secrets import RedactedDict
 from tests.utils.secret_names import TestSecret
 
 pytestmark = pytest.mark.secrets(
@@ -211,12 +212,14 @@ def mock_store_image() -> MagicMock:
 @pytest.fixture
 def sharepoint_credentials(
     test_secrets: dict[TestSecret, str],
-) -> dict[str, str]:
-    return {
-        "sp_client_id": os.environ["SHAREPOINT_CLIENT_ID"],
-        "sp_client_secret": test_secrets[TestSecret.SHAREPOINT_CLIENT_SECRET],
-        "sp_directory_id": os.environ["SHAREPOINT_CLIENT_DIRECTORY_ID"],
-    }
+) -> RedactedDict[str, str]:
+    return RedactedDict(
+        {
+            "sp_client_id": os.environ["SHAREPOINT_CLIENT_ID"],
+            "sp_client_secret": test_secrets[TestSecret.SHAREPOINT_CLIENT_SECRET],
+            "sp_directory_id": os.environ["SHAREPOINT_CLIENT_DIRECTORY_ID"],
+        }
+    )
 
 
 def test_sharepoint_connector_all_sites__docs_only(
@@ -598,22 +601,27 @@ def test_sharepoint_connector_hierarchy_nodes(
 @pytest.fixture
 def sharepoint_cert_credentials(
     test_secrets: dict[TestSecret, str],
-) -> dict[str, str]:
-    return {
-        "authentication_method": SharepointAuthMethod.CERTIFICATE.value,
-        "sp_client_id": test_secrets[TestSecret.PERM_SYNC_SHAREPOINT_CLIENT_ID],
-        "sp_private_key": test_secrets[TestSecret.PERM_SYNC_SHAREPOINT_PRIVATE_KEY],
-        "sp_certificate_password": test_secrets[
-            TestSecret.PERM_SYNC_SHAREPOINT_CERTIFICATE_PASSWORD
-        ],
-        "sp_directory_id": test_secrets[TestSecret.PERM_SYNC_SHAREPOINT_DIRECTORY_ID],
-    }
+) -> RedactedDict[str, str]:
+    return RedactedDict(
+        {
+            "authentication_method": SharepointAuthMethod.CERTIFICATE.value,
+            "sp_client_id": test_secrets[TestSecret.PERM_SYNC_SHAREPOINT_CLIENT_ID],
+            "sp_private_key": test_secrets[TestSecret.PERM_SYNC_SHAREPOINT_PRIVATE_KEY],
+            "sp_certificate_password": test_secrets[
+                TestSecret.PERM_SYNC_SHAREPOINT_CERTIFICATE_PASSWORD
+            ],
+            "sp_directory_id": test_secrets[
+                TestSecret.PERM_SYNC_SHAREPOINT_DIRECTORY_ID
+            ],
+        }
+    )
 
 
 def test_sharepoint_connector_hierarchy_node_permissions(
     mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
     mock_store_image: MagicMock,
     sharepoint_cert_credentials: dict[str, str],
+    enable_ee: None,  # noqa: ARG001
 ) -> None:
     site_url = os.environ["SHAREPOINT_SITE"]
     connector = SharepointConnector(
@@ -662,6 +670,7 @@ def test_permission_sync_site_hierarchy_node_permissions(
     mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
     mock_store_image: MagicMock,
     sharepoint_cert_credentials: dict[str, str],
+    enable_ee: None,  # noqa: ARG001
 ) -> None:
     connector = SharepointConnector(
         sites=[PERMISSION_SYNC_SITE_URL],

--- a/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
+++ b/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
@@ -33,6 +33,7 @@ pytestmark = pytest.mark.secrets(
 
 # NOTE: Sharepoint site for tests is "sharepoint-tests"
 SCALE_TEST_SITE_URL = "https://danswerai.sharepoint.com/sites/OnyxTesting2"
+PERMISSION_SYNC_SITE_URL = "https://danswerai.sharepoint.com/sites/Permisisonsync"
 
 
 @dataclass
@@ -95,9 +96,39 @@ EXPECTED_PAGES = [
     ),
 ]
 
-EXPECTED_SITE_ACCESS: ExternalAccess | None = None
-EXPECTED_SHARED_DOCUMENTS_ACCESS: ExternalAccess | None = None
-EXPECTED_TEST_FOLDER_ACCESS: ExternalAccess | None = None
+EXPECTED_HIERARCHY_ACCESS = ExternalAccess(
+    external_user_emails=set(),
+    external_user_group_ids={
+        "sharepoint_https://danswerai.sharepoint.com/sites/sharepoint-tests::sharepoint-tests members",
+        "sharepoint_https://danswerai.sharepoint.com/sites/sharepoint-tests::sharepoint-tests owners",
+        "sharepoint_https://danswerai.sharepoint.com/sites/sharepoint-tests::sharepoint-tests visitors",
+        "sharepoint_sharepoint-tests members_b1e591ce-fda6-4f5f-8ef3-eac8296a5b1d",
+        "sharepoint_sharepoint-tests owners_b1e591ce-fda6-4f5f-8ef3-eac8296a5b1d",
+    },
+    is_public=False,
+)
+EXPECTED_PERMISSION_SYNC_HIERARCHY_ACCESS = ExternalAccess(
+    external_user_emails=set(),
+    external_user_group_ids={
+        "sharepoint_https://danswerai.sharepoint.com/sites/permisisonsync::permisison sync members",
+        "sharepoint_https://danswerai.sharepoint.com/sites/permisisonsync::permisison sync owners",
+        "sharepoint_https://danswerai.sharepoint.com/sites/permisisonsync::permisison sync visitors",
+        "sharepoint_https://danswerai.sharepoint.com/sites/permisisonsync::test group",
+        "sharepoint_inner group test_4054a013-e061-43fc-95ed-103c3a8c94d5",
+        "sharepoint_permisison sync members_5c0de9c9-6d58-452d-8b35-e5a18f583799",
+        "sharepoint_permisison sync owners_5c0de9c9-6d58-452d-8b35-e5a18f583799",
+        "sharepoint_sharepoint group sync 365 group members_757ef1f5-0bfb-44b4-8d03-3b0dc5c862d1",
+        "sharepoint_sharepoint group sync test_3ae47611-eadb-45b0-89c8-ad454fc04b12",
+    },
+    is_public=False,
+)
+EXPECTED_PERMISSION_SYNC_FOLDER_ACCESS = ExternalAccess(
+    external_user_emails={"subash@onyx.app"},
+    external_user_group_ids=(
+        EXPECTED_PERMISSION_SYNC_HIERARCHY_ACCESS.external_user_group_ids
+    ),
+    is_public=False,
+)
 
 
 def verify_document_metadata(doc: Document) -> None:
@@ -584,13 +615,6 @@ def test_sharepoint_connector_hierarchy_node_permissions(
     mock_store_image: MagicMock,
     sharepoint_cert_credentials: dict[str, str],
 ) -> None:
-    site_expected_access = EXPECTED_SITE_ACCESS
-    drive_expected_access = EXPECTED_SHARED_DOCUMENTS_ACCESS
-    folder_expected_access = EXPECTED_TEST_FOLDER_ACCESS
-    assert site_expected_access is not None
-    assert drive_expected_access is not None
-    assert folder_expected_access is not None
-
     site_url = os.environ["SHAREPOINT_SITE"]
     connector = SharepointConnector(
         sites=[site_url],
@@ -629,9 +653,55 @@ def test_sharepoint_connector_hierarchy_node_permissions(
         drive_node.raw_node_id,
     )
 
-    assert site_node.external_access == site_expected_access
-    assert drive_node.external_access == drive_expected_access
-    assert folder_node.external_access == folder_expected_access
+    assert site_node.external_access == EXPECTED_HIERARCHY_ACCESS
+    assert drive_node.external_access == EXPECTED_HIERARCHY_ACCESS
+    assert folder_node.external_access == EXPECTED_HIERARCHY_ACCESS
+
+
+def test_permission_sync_site_hierarchy_node_permissions(
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
+    mock_store_image: MagicMock,
+    sharepoint_cert_credentials: dict[str, str],
+) -> None:
+    connector = SharepointConnector(
+        sites=[PERMISSION_SYNC_SITE_URL],
+        include_site_pages=False,
+        include_site_documents=True,
+    )
+    connector.load_credentials(sharepoint_cert_credentials)
+    with patch(
+        "onyx.connectors.sharepoint.connector.store_image_and_create_section",
+        mock_store_image,
+    ):
+        result = load_all_from_connector(
+            connector,
+            start=0,
+            end=time.time(),
+            include_permissions=True,
+        )
+
+    site_node = find_hierarchy_node(
+        result.hierarchy_nodes,
+        HierarchyNodeType.SITE,
+        "Permisisonsync",
+        None,
+    )
+    drive_node = find_hierarchy_node(
+        result.hierarchy_nodes,
+        HierarchyNodeType.DRIVE,
+        "Test library 1",
+        site_node.raw_node_id,
+    )
+    folder_node = find_hierarchy_node(
+        result.hierarchy_nodes,
+        HierarchyNodeType.FOLDER,
+        "test folder",
+        drive_node.raw_node_id,
+    )
+
+    assert site_node.external_access == EXPECTED_PERMISSION_SYNC_HIERARCHY_ACCESS
+    assert drive_node.external_access == EXPECTED_PERMISSION_SYNC_HIERARCHY_ACCESS
+    assert folder_node.external_access == EXPECTED_PERMISSION_SYNC_FOLDER_ACCESS
 
 
 def test_resolve_tenant_domain_from_site_urls(

--- a/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
+++ b/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from onyx.access.models import ExternalAccess
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.models import (
     ConnectorFailure,
@@ -94,6 +95,10 @@ EXPECTED_PAGES = [
     ),
 ]
 
+EXPECTED_SITE_ACCESS: ExternalAccess | None = None
+EXPECTED_SHARED_DOCUMENTS_ACCESS: ExternalAccess | None = None
+EXPECTED_TEST_FOLDER_ACCESS: ExternalAccess | None = None
+
 
 def verify_document_metadata(doc: Document) -> None:
     """Verify common metadata that should be present on all documents."""
@@ -139,6 +144,26 @@ def find_document(documents: list[Document], semantic_identifier: str) -> Docume
         f"Expected exactly one document with identifier {semantic_identifier}"
     )
     return matching_docs[0]
+
+
+def find_hierarchy_node(
+    nodes: list[HierarchyNode],
+    node_type: HierarchyNodeType,
+    display_name: str,
+    raw_parent_id: str | None,
+) -> HierarchyNode:
+    matching_nodes = [
+        node
+        for node in nodes
+        if node.node_type == node_type
+        and node.display_name == display_name
+        and node.raw_parent_id == raw_parent_id
+    ]
+    assert len(matching_nodes) == 1, (
+        f"Expected one {node_type.value} node named {display_name} "
+        f"under {raw_parent_id}, found {len(matching_nodes)}"
+    )
+    return matching_nodes[0]
 
 
 @pytest.fixture
@@ -552,6 +577,61 @@ def sharepoint_cert_credentials(
         ],
         "sp_directory_id": test_secrets[TestSecret.PERM_SYNC_SHAREPOINT_DIRECTORY_ID],
     }
+
+
+def test_sharepoint_connector_hierarchy_node_permissions(
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
+    mock_store_image: MagicMock,
+    sharepoint_cert_credentials: dict[str, str],
+) -> None:
+    site_expected_access = EXPECTED_SITE_ACCESS
+    drive_expected_access = EXPECTED_SHARED_DOCUMENTS_ACCESS
+    folder_expected_access = EXPECTED_TEST_FOLDER_ACCESS
+    assert site_expected_access is not None
+    assert drive_expected_access is not None
+    assert folder_expected_access is not None
+
+    site_url = os.environ["SHAREPOINT_SITE"]
+    connector = SharepointConnector(
+        sites=[site_url],
+        include_site_pages=False,
+        include_site_documents=True,
+    )
+    connector.load_credentials(sharepoint_cert_credentials)
+
+    with patch(
+        "onyx.connectors.sharepoint.connector.store_image_and_create_section",
+        mock_store_image,
+    ):
+        result = load_all_from_connector(
+            connector,
+            start=0,
+            end=time.time(),
+            include_permissions=True,
+        )
+
+    site_node = find_hierarchy_node(
+        result.hierarchy_nodes,
+        HierarchyNodeType.SITE,
+        site_url.rstrip("/").rsplit("/", 1)[-1],
+        None,
+    )
+    drive_node = find_hierarchy_node(
+        result.hierarchy_nodes,
+        HierarchyNodeType.DRIVE,
+        "Shared Documents",
+        site_node.raw_node_id,
+    )
+    folder_node = find_hierarchy_node(
+        result.hierarchy_nodes,
+        HierarchyNodeType.FOLDER,
+        "test",
+        drive_node.raw_node_id,
+    )
+
+    assert site_node.external_access == site_expected_access
+    assert drive_node.external_access == drive_expected_access
+    assert folder_node.external_access == folder_expected_access
 
 
 def test_resolve_tenant_domain_from_site_urls(

--- a/backend/tests/external_dependency_unit/celery/test_pruning_hierarchy_nodes.py
+++ b/backend/tests/external_dependency_unit/celery/test_pruning_hierarchy_nodes.py
@@ -456,6 +456,44 @@ def test_pruning_hierarchy_node_upsert_updates_fields(db_session: Session) -> No
     assert set(db_node.external_user_emails) == {"new_user@example.com"}
 
 
+def test_pruning_hierarchy_node_upsert_preserves_unspecified_access(
+    db_session: Session,
+) -> None:
+    _cleanup_test_data(db_session)
+    ensure_source_node_exists(db_session, TEST_SOURCE, commit=True)
+    access = ExternalAccess(
+        external_user_emails={"user@example.com"},
+        external_user_group_ids={"external_group"},
+        is_public=False,
+    )
+    node = PydanticHierarchyNode(
+        raw_node_id=CHANNEL_A_ID,
+        display_name=CHANNEL_A_NAME,
+        node_type=HierarchyNodeType.CHANNEL,
+        external_access=access,
+    )
+    upsert_hierarchy_nodes_batch(
+        db_session,
+        [node],
+        TEST_SOURCE,
+        commit=True,
+    )
+
+    node.external_access = None
+    upsert_hierarchy_nodes_batch(
+        db_session,
+        [node],
+        TEST_SOURCE,
+        commit=True,
+    )
+
+    db_node = get_hierarchy_node_by_raw_id(db_session, CHANNEL_A_ID, TEST_SOURCE)
+    assert db_node is not None
+    assert db_node.external_user_emails == ["user@example.com"]
+    assert db_node.external_user_group_ids == ["external_group"]
+    assert db_node.is_public is False
+
+
 # ---------------------------------------------------------------------------
 # Document-to-hierarchy-node linkage tests
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
@@ -15,8 +15,11 @@ from ee.onyx.external_permissions.sharepoint.permission_utils import (
     _iter_graph_collection,
     _normalize_email,
     get_external_access_from_sharepoint,
+    get_hierarchy_node_external_access_from_sharepoint,
     get_sharepoint_external_groups,
 )
+from onyx.access.models import ExternalAccess
+from onyx.db.enums import HierarchyNodeType
 
 MODULE = "ee.onyx.external_permissions.sharepoint.permission_utils"
 GRAPH_API_BASE = "https://graph.microsoft.com/v1.0"
@@ -270,6 +273,51 @@ def test_default_skips_ad_enumeration(
     assert len(results) == 1
     assert results[0].id == "SiteGroup_abc"
     assert results[0].user_emails == ["alice@contoso.com"]
+
+
+@pytest.mark.parametrize(
+    ("node_type", "drive_name", "folder_url"),
+    [
+        (HierarchyNodeType.SITE, None, None),
+        (HierarchyNodeType.DRIVE, "Shared Documents", None),
+        (
+            HierarchyNodeType.FOLDER,
+            None,
+            "https://contoso.sharepoint.com/sites/eng/Shared%20Documents/API",
+        ),
+    ],
+)
+@patch(f"{MODULE}._get_external_access_from_securable_object")
+def test_hierarchy_node_access_uses_securable_object(
+    mock_get_access: MagicMock,
+    node_type: HierarchyNodeType,
+    drive_name: str | None,
+    folder_url: str | None,
+) -> None:
+    expected_access = ExternalAccess.empty()
+    mock_get_access.return_value = expected_access
+    ctx = MagicMock()
+    graph_client = MagicMock()
+
+    result = get_hierarchy_node_external_access_from_sharepoint(
+        ctx,
+        graph_client,
+        node_type,
+        drive_name,
+        folder_url,
+    )
+
+    assert result is expected_access
+    securable_object = mock_get_access.call_args.args[2]
+    if node_type == HierarchyNodeType.SITE:
+        assert securable_object is ctx.web
+    elif node_type == HierarchyNodeType.DRIVE:
+        ctx.web.lists.get_by_title.assert_called_once_with("Documents")
+    else:
+        ctx.web.get_folder_by_server_relative_url.assert_called_once_with(
+            "/sites/eng/Shared%20Documents/API"
+        )
+    assert mock_get_access.call_args.kwargs == {"add_prefix": True}
 
 
 @patch(f"{MODULE}._get_groups_and_members_recursively")

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_hierarchy_helpers.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_hierarchy_helpers.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
-from onyx.connectors.sharepoint.connector import SharepointConnector
+from unittest.mock import MagicMock, patch
+
+from onyx.access.models import ExternalAccess
+from onyx.connectors.sharepoint.connector import (
+    SharepointConnector,
+    SharepointConnectorCheckpoint,
+    SiteDescriptor,
+)
+from onyx.db.enums import HierarchyNodeType
 
 
 def test_extract_folder_path_from_parent_reference_with_folder() -> None:
@@ -108,3 +116,63 @@ def test_build_folder_url_with_spaces() -> None:
     result = connector._build_folder_url(site_url, drive_name, folder_path)
     expected = "https://company.sharepoint.com/sites/eng/Shared Documents/Engineering/API Docs/Version 2"
     assert result == expected
+
+
+@patch(
+    "onyx.connectors.sharepoint.connector.get_sharepoint_hierarchy_node_external_access"
+)
+def test_hierarchy_helpers_fetch_permissions_when_requested(
+    mock_get_access: MagicMock,
+) -> None:
+    access = ExternalAccess(
+        external_user_emails={"user@contoso.com"},
+        external_user_group_ids={"sharepoint_group"},
+        is_public=False,
+    )
+    mock_get_access.return_value = access
+    connector = SharepointConnector()
+    connector._graph_client = MagicMock()
+    checkpoint = SharepointConnectorCheckpoint(has_more=True)
+    site_url = "https://contoso.sharepoint.com/sites/eng"
+    drive_url = f"{site_url}/Shared%20Documents"
+
+    with patch.object(
+        connector,
+        "_create_rest_client_context",
+        return_value=MagicMock(),
+    ):
+        site_node = next(
+            connector._yield_site_hierarchy_node(
+                SiteDescriptor(url=site_url, drive_name=None, folder_path=None),
+                checkpoint,
+                include_permissions=True,
+            )
+        )
+        drive_node = next(
+            connector._yield_drive_hierarchy_node(
+                site_url,
+                drive_url,
+                "Shared Documents",
+                checkpoint,
+                include_permissions=True,
+            )
+        )
+        folder_node = next(
+            connector._yield_folder_hierarchy_nodes(
+                site_url,
+                drive_url,
+                "Shared Documents",
+                "Engineering",
+                checkpoint,
+                include_permissions=True,
+            )
+        )
+
+    assert site_node.external_access is access
+    assert drive_node.external_access is access
+    assert folder_node.external_access is access
+    assert [call.args[2] for call in mock_get_access.call_args_list] == [
+        HierarchyNodeType.SITE,
+        HierarchyNodeType.DRIVE,
+        HierarchyNodeType.FOLDER,
+    ]

--- a/backend/tests/unit/onyx/utils/test_pytest_secret_redaction.py
+++ b/backend/tests/unit/onyx/utils/test_pytest_secret_redaction.py
@@ -1,0 +1,13 @@
+from _pytest._io.saferepr import saferepr
+
+from tests.utils.pytest_secrets import RedactedDict
+
+SAMPLE_SECRET = "sensitive-test-value"
+
+
+def test_redacted_dict_hides_values_from_pytest_repr() -> None:
+    secrets = RedactedDict({"credential": SAMPLE_SECRET})
+
+    assert secrets["credential"] == SAMPLE_SECRET
+    assert SAMPLE_SECRET not in repr(secrets)
+    assert SAMPLE_SECRET not in saferepr(secrets)

--- a/backend/tests/utils/pytest_secrets.py
+++ b/backend/tests/utils/pytest_secrets.py
@@ -21,12 +21,23 @@ Then in tests:
         ...
 """
 
+from typing import TypeVar
+
 import pytest
 
 from tests.utils.aws_secrets import get_secrets
 from tests.utils.secret_names import TestSecret
 
 _NEEDED_SECRETS_KEY = "_onyx_test_secrets_needed"
+_REDACTED_REPR = "<redacted>"
+
+Key = TypeVar("Key")
+Value = TypeVar("Value")
+
+
+class RedactedDict(dict[Key, Value]):
+    def __repr__(self) -> str:
+        return _REDACTED_REPR
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -56,7 +67,7 @@ def pytest_collection_modifyitems(
 
 
 @pytest.fixture(scope="session")
-def test_secrets(request: pytest.FixtureRequest) -> dict[TestSecret, str]:
+def test_secrets(request: pytest.FixtureRequest) -> RedactedDict[TestSecret, str]:
     """Resolve only the secrets declared by collected tests, in one batch."""
     needed: set[TestSecret] = getattr(request.config, _NEEDED_SECRETS_KEY, set())
-    return get_secrets(sorted(needed, key=lambda s: s.value))
+    return RedactedDict(get_secrets(sorted(needed, key=lambda s: s.value)))


### PR DESCRIPTION
## Description

We were previously not fetching permissions for sharepoint hierarchynodes, making them inaccessible in the agent knowledge pane for permission synced sharepoint connectors. This PR adds permission retrieval for those nodes and fixes an old bug that in theory could cause indexing to make these nodes temporarily inaccessible (not observed in practice because it required a node to be re-yielded by a connector after initial indexing completed, and required the user to view the knowledge pane between that happening and a pruning run).

## How Has This Been Tested?

added tests
## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetches SharePoint permissions for site/drive/folder hierarchy nodes via `SecurableObject` and attaches `external_access` when `include_permissions` is true. Also preserves existing access on upsert and redacts test credentials in output.

- **Bug Fixes**
  - Added `_get_external_access_from_securable_object` and `get_hierarchy_node_external_access_from_sharepoint` to read role assignments for sites, drives, and folders (scoped, prefixed group IDs).
  - Connector uses `get_sharepoint_hierarchy_node_external_access` to populate `external_access` on hierarchy nodes.
  - `upsert_hierarchy_node` updates access only when the connector is public or the node provides `external_access`, preventing unintended overwrites.
  - Tests: expanded coverage for hierarchy permissions (including permission-sync site/folder) and upsert preservation; introduced `RedactedDict` to redact secrets in pytest output.

<sup>Written for commit c155ab4611ad08ea71fef0d8d6c4b40712d35dde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



