### PR TITLE
fix(gateway): bound count token requests

### DIFF
--- a/.vscode/env_template.txt
+++ b/.vscode/env_template.txt
@@ -20,6 +20,13 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # More verbose logging
 LOG_LEVEL=debug
 
+# Gateway count-token calls are rate-limited separately from model spend limits.
+# Set either rate value to 0 to disable; set the input cap to 0 to disable the
+# local-tokenization size limit.
+GATEWAY_COUNT_TOKENS_RATE_LIMIT_MAX_REQUESTS=60
+GATEWAY_COUNT_TOKENS_RATE_LIMIT_WINDOW_SECONDS=60
+GATEWAY_COUNT_TOKENS_MAX_LOCAL_INPUT_BYTES=4194304
+
 
 # Useful if you want to toggle auth on/off (google_oauth/OIDC specifically).
 OAUTH_CLIENT_ID=<REPLACE THIS>

--- a/backend/ee/onyx/server/gateway/api.py
+++ b/backend/ee/onyx/server/gateway/api.py
@@ -31,6 +31,7 @@ from ee.onyx.server.gateway.stream_bridge import (
     _StreamAccumulator,
 )
 from onyx.auth.permissions import require_permission
+from onyx.configs.app_configs import GATEWAY_COUNT_TOKENS_MAX_LOCAL_INPUT_BYTES
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.llm import (
@@ -110,6 +111,7 @@ from onyx.server.gateway.models import (
     ResponsesRequest,
 )
 from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
+from onyx.server.middleware.rate_limiting import get_gateway_count_tokens_rate_limiters
 from onyx.server.query_and_chat.token_limit import check_token_rate_limits
 from onyx.tracing.flows import LLMFlow
 from onyx.tracing.framework.create import trace
@@ -1488,7 +1490,35 @@ def gateway_anthropic_messages(
     return JSONResponse(content=result.to_wire())
 
 
-@router.post("/v1/messages/count_tokens")
+def _ensure_anthropic_count_tokens_input_is_bounded(
+    request: AnthropicCountTokensRequest,
+) -> None:
+    if GATEWAY_COUNT_TOKENS_MAX_LOCAL_INPUT_BYTES == 0:
+        return
+
+    countable_input = {
+        "messages": request.messages,
+        "system": request.system,
+        "tools": request.tools,
+    }
+    input_size = len(
+        json.dumps(
+            countable_input,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    )
+    if input_size > GATEWAY_COUNT_TOKENS_MAX_LOCAL_INPUT_BYTES:
+        raise OnyxError(
+            OnyxErrorCode.PAYLOAD_TOO_LARGE,
+            "The count_tokens request is too large for local tokenization.",
+        )
+
+
+@router.post(
+    "/v1/messages/count_tokens",
+    dependencies=get_gateway_count_tokens_rate_limiters(),
+)
 def gateway_anthropic_count_tokens(
     request: AnthropicCountTokensRequest,
     http_request: Request,
@@ -1514,6 +1544,7 @@ def gateway_anthropic_count_tokens(
                 "falling back to the local estimate",
                 request.model,
             )
+    _ensure_anthropic_count_tokens_input_is_bounded(request)
     raw_messages = _anthropic_messages_to_raw_messages(request.messages, request.system)
     tools = _anthropic_tools(request.tools)
     from onyx.llm.litellm_singleton import litellm

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -967,6 +967,27 @@ FEEDBACK_RATE_LIMITING_ENABLED = (
     and CACHE_BACKEND == CacheBackendType.REDIS
 )
 
+# Rate limiting for the Anthropic-compatible count-tokens endpoint. Counting is
+# not billable model usage, but local fallback tokenization can still consume
+# substantial API-server CPU for large requests.
+GATEWAY_COUNT_TOKENS_RATE_LIMIT_MAX_REQUESTS = int(
+    os.environ.get("GATEWAY_COUNT_TOKENS_RATE_LIMIT_MAX_REQUESTS", "60")
+)
+GATEWAY_COUNT_TOKENS_RATE_LIMIT_WINDOW_SECONDS = int(
+    os.environ.get("GATEWAY_COUNT_TOKENS_RATE_LIMIT_WINDOW_SECONDS", "60")
+)
+GATEWAY_COUNT_TOKENS_RATE_LIMITING_ENABLED = (
+    GATEWAY_COUNT_TOKENS_RATE_LIMIT_MAX_REQUESTS > 0
+    and GATEWAY_COUNT_TOKENS_RATE_LIMIT_WINDOW_SECONDS > 0
+    and CACHE_BACKEND == CacheBackendType.REDIS
+)
+
+# Local tokenization is the fallback when a provider cannot count tokens. Keep
+# this below the upstream API body limit so a fallback cannot monopolize CPU.
+GATEWAY_COUNT_TOKENS_MAX_LOCAL_INPUT_BYTES = _non_negative_int_env(
+    "GATEWAY_COUNT_TOKENS_MAX_LOCAL_INPUT_BYTES", 4 * 1024 * 1024
+)
+
 # Used for general redis things
 REDIS_DB_NUMBER = int(os.environ.get("REDIS_DB_NUMBER", 0))
 

--- a/backend/onyx/server/middleware/rate_limiting.py
+++ b/backend/onyx/server/middleware/rate_limiting.py
@@ -2,21 +2,27 @@ from fastapi import Depends, Request, Response, params
 from fastapi_limiter import FastAPILimiter
 from fastapi_limiter.depends import RateLimiter
 
+from onyx.auth.permissions import require_permission
 from onyx.auth.users import current_chat_accessible_user
 from onyx.configs.app_configs import (
     AUTH_RATE_LIMITING_ENABLED,
     FEEDBACK_RATE_LIMIT_MAX_REQUESTS,
     FEEDBACK_RATE_LIMIT_WINDOW_SECONDS,
     FEEDBACK_RATE_LIMITING_ENABLED,
+    GATEWAY_COUNT_TOKENS_RATE_LIMIT_MAX_REQUESTS,
+    GATEWAY_COUNT_TOKENS_RATE_LIMIT_WINDOW_SECONDS,
+    GATEWAY_COUNT_TOKENS_RATE_LIMITING_ENABLED,
     RATE_LIMIT_MAX_REQUESTS,
     RATE_LIMIT_WINDOW_SECONDS,
 )
-from onyx.db.enums import AccountType
+from onyx.db.enums import AccountType, Permission
 from onyx.db.models import User
 from onyx.redis.redis_pool import get_async_redis_connection
 
 RATE_LIMITING_ENABLED = (
-    bool(AUTH_RATE_LIMITING_ENABLED) or FEEDBACK_RATE_LIMITING_ENABLED
+    bool(AUTH_RATE_LIMITING_ENABLED)
+    or FEEDBACK_RATE_LIMITING_ENABLED
+    or GATEWAY_COUNT_TOKENS_RATE_LIMITING_ENABLED
 )
 
 _RATE_LIMIT_USER_ID_STATE_KEY = "rate_limit_user_id"
@@ -106,3 +112,29 @@ def get_feedback_rate_limiters() -> list[params.Depends]:
         await limiter(request, response)
 
     return [Depends(user_scoped_feedback_limiter)]
+
+
+def get_gateway_count_tokens_rate_limiters() -> list[params.Depends]:
+    """Limit count-only gateway calls per authorized user.
+
+    This is intentionally separate from token spend limits: no model output is
+    generated, but local tokenization remains a CPU-expensive operation.
+    """
+    if not GATEWAY_COUNT_TOKENS_RATE_LIMITING_ENABLED:
+        return []
+
+    limiter = RateLimiter(
+        times=GATEWAY_COUNT_TOKENS_RATE_LIMIT_MAX_REQUESTS,
+        seconds=GATEWAY_COUNT_TOKENS_RATE_LIMIT_WINDOW_SECONDS,
+        identifier=user_scoped_rate_limit_key,
+    )
+
+    async def user_scoped_gateway_count_tokens_limiter(
+        request: Request,
+        response: Response,
+        user: User = Depends(require_permission(Permission.USE_LLM_GATEWAY)),
+    ) -> None:
+        request.state.rate_limit_user_id = str(user.id)
+        await limiter(request, response)
+
+    return [Depends(user_scoped_gateway_count_tokens_limiter)]

--- a/backend/tests/unit/ee/onyx/server/gateway/test_anthropic_messages_api.py
+++ b/backend/tests/unit/ee/onyx/server/gateway/test_anthropic_messages_api.py
@@ -879,6 +879,39 @@ def test_gateway_anthropic_count_tokens_includes_tools() -> None:
     )
 
 
+def test_gateway_anthropic_count_tokens_rejects_oversized_local_input() -> None:
+    provider = _provider(1, "openai", [_model("test")])
+    request = AnthropicCountTokensRequest(
+        model="1/test",
+        messages=[{"role": "user", "content": "too large"}],
+    )
+
+    with (
+        patch.object(
+            gateway_api,
+            "gateway_request_flow",
+            MagicMock(return_value=LLMFlow.LLM_GATEWAY),
+        ),
+        patch.object(
+            gateway_api,
+            "resolve_gateway_model",
+            return_value=(provider, provider.model_configurations[0]),
+        ),
+        patch.object(gateway_api, "GATEWAY_COUNT_TOKENS_MAX_LOCAL_INPUT_BYTES", 1),
+        patch("onyx.llm.litellm_singleton.litellm.token_counter") as token_counter,
+        pytest.raises(OnyxError) as exc_info,
+    ):
+        gateway_api.gateway_anthropic_count_tokens(
+            request=request,
+            http_request=MagicMock(spec=Request),
+            user=MagicMock(),
+            db_session=MagicMock(spec=Session),
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.PAYLOAD_TOO_LARGE
+    token_counter.assert_not_called()
+
+
 def test_anthropic_signed_thinking_blocks_survive_input_translation() -> None:
     messages = [
         {"role": "user", "content": "hi"},


### PR DESCRIPTION
## What

Adds dedicated per-user request limiting and a configurable 4 MiB cap for local fallback tokenization on `POST /gateway/v1/messages/count_tokens`.

## Why

`count_tokens` intentionally does not consume generation/spend budgets, but it can still invoke expensive local tokenization when native Anthropic counting is unavailable or the selected provider is not Anthropic. Previously those requests were unbounded.

## Before

An authorized caller could make unlimited count-only requests, and local fallback tokenization accepted any parsed request size.

## After

- Redis-backed limits default to 60 requests per user per 60 seconds.
- Local fallback rejects payloads over 4 MiB with `PAYLOAD_TOO_LARGE`, without invoking the tokenizer.
- Eligible Anthropic providers still use their native count endpoint before the local fallback.
- Generation routes and their spend/token limits are unchanged.

## Tests

- `uv run pytest -q backend/tests/unit/ee/onyx/server/gateway/test_anthropic_messages_api.py backend/tests/unit/ee/onyx/server/gateway/test_anthropic_passthrough.py`
- `uv run ruff check backend/onyx/configs/app_configs.py backend/onyx/server/middleware/rate_limiting.py backend/ee/onyx/server/gateway/api.py backend/tests/unit/ee/onyx/server/gateway/test_anthropic_messages_api.py`
- `uv run ty check backend/onyx/server/middleware/rate_limiting.py backend/ee/onyx/server/gateway/api.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound count-only requests in the gateway with per-user rate limits and a 4 MiB cap on local fallback tokenization for `POST /gateway/v1/messages/count_tokens`. Anthropic providers still use native counting; generation routes and spend limits remain unchanged.

- **Bug Fixes**
  - Added Redis-backed per-user limiter: 60 requests per 60s (configurable via `GATEWAY_COUNT_TOKENS_RATE_LIMIT_*`).
  - Capped local fallback input at `GATEWAY_COUNT_TOKENS_MAX_LOCAL_INPUT_BYTES` (default 4 MiB); oversized payloads return `PAYLOAD_TOO_LARGE` before tokenization.
  - Limiter applies to authorized gateway users; added a unit test for oversized input rejection.

<sup>Written for commit c95267f5af7b85da6a7638dabc8ac6941d93062c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

