### PR TITLE
feat(usage): cap spending-limit token budgets at one trillion (backend)

### DIFF
--- a/backend/onyx/db/token_limit.py
+++ b/backend/onyx/db/token_limit.py
@@ -7,7 +7,13 @@ from sqlalchemy.orm import Session
 
 from onyx.configs.constants import TokenRateLimitScope
 from onyx.db.models import TokenRateLimit, TokenRateLimit__UserGroup, User__UserGroup
-from onyx.server.token_rate_limits.models import TokenRateLimitArgs
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.token_rate_limits.models import (
+    MAX_TOKEN_BUDGET_THOUSANDS,
+    TokenRateLimitArgs,
+    TokenRateLimitUpdateArgs,
+)
 
 
 def fetch_all_user_token_rate_limits(
@@ -111,11 +117,21 @@ def insert_global_token_rate_limit(
 def update_token_rate_limit(
     db_session: Session,
     token_rate_limit_id: int,
-    token_rate_limit_settings: TokenRateLimitArgs,
+    token_rate_limit_settings: TokenRateLimitUpdateArgs,
 ) -> TokenRateLimit:
     token_limit = db_session.get(TokenRateLimit, token_rate_limit_id)
     if token_limit is None:
         raise ValueError(f"TokenRateLimit with id '{token_rate_limit_id}' not found")
+
+    if (
+        token_rate_limit_settings.token_budget is not None
+        and token_rate_limit_settings.token_budget > MAX_TOKEN_BUDGET_THOUSANDS
+        and token_rate_limit_settings.token_budget != token_limit.token_budget
+    ):
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Token budgets cannot exceed 1T tokens.",
+        )
 
     token_limit.enabled = token_rate_limit_settings.enabled
     token_limit.token_budget = token_rate_limit_settings.token_budget

--- a/backend/onyx/server/token_rate_limits/api.py
+++ b/backend/onyx/server/token_rate_limits/api.py
@@ -18,6 +18,7 @@ from onyx.server.query_and_chat.token_limit import (
 from onyx.server.token_rate_limits.models import (
     TokenRateLimitArgs,
     TokenRateLimitDisplay,
+    TokenRateLimitUpdateArgs,
 )
 
 router = APIRouter(prefix="/admin/token-rate-limits", tags=PUBLIC_API_TAGS)
@@ -61,7 +62,7 @@ General Token Limit Settings
 @router.put("/rate-limit/{token_rate_limit_id}")
 def update_token_limit_settings(
     token_rate_limit_id: int,
-    token_limit_settings: TokenRateLimitArgs,
+    token_limit_settings: TokenRateLimitUpdateArgs,
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> TokenRateLimitDisplay:

--- a/backend/onyx/server/token_rate_limits/models.py
+++ b/backend/onyx/server/token_rate_limits/models.py
@@ -1,3 +1,5 @@
+from typing import Self
+
 from pydantic import BaseModel, Field, model_validator
 
 from onyx.db.models import TokenRateLimit
@@ -8,16 +10,18 @@ from onyx.db.user_usage import (
     normalize_token_period_hours,
 )
 
+# 1T tokens; stored in thousands so the ceiling stays inside the int32 column.
+MAX_TOKEN_BUDGET_THOUSANDS = 1_000_000_000
 
-class TokenRateLimitArgs(BaseModel):
+
+class _TokenRateLimitArgsBase(BaseModel):
     enabled: bool
-    # Null side exempt. ge/gt=0 — zero/NaN budgets silently disable or break the gate.
     token_budget: int | None = Field(default=None, ge=1)
     period_hours: int = Field(gt=0)
     cost_budget_cents: float | None = Field(default=None, gt=0, allow_inf_nan=False)
 
     @model_validator(mode="after")
-    def validate_budget_set(self) -> "TokenRateLimitArgs":
+    def validate_budget_set(self) -> Self:
         if self.token_budget is None and self.cost_budget_cents is None:
             raise ValueError("Either token_budget or cost_budget_cents must be set")
         if (
@@ -31,6 +35,14 @@ class TokenRateLimitArgs(BaseModel):
         ):
             raise ValueError(COST_BUDGET_PERIOD_ERROR)
         return self
+
+
+class TokenRateLimitArgs(_TokenRateLimitArgsBase):
+    token_budget: int | None = Field(default=None, ge=1, le=MAX_TOKEN_BUDGET_THOUSANDS)
+
+
+class TokenRateLimitUpdateArgs(_TokenRateLimitArgsBase):
+    pass
 
 
 class TokenRateLimitDisplay(BaseModel):

--- a/backend/tests/unit/onyx/server/test_token_rate_limit_budget_models.py
+++ b/backend/tests/unit/onyx/server/test_token_rate_limit_budget_models.py
@@ -1,15 +1,20 @@
 import datetime
+from unittest.mock import Mock
 
 import pytest
 from pydantic import ValidationError
 
 from onyx.configs.constants import TokenRateLimitScope
 from onyx.db.models import TokenRateLimit
+from onyx.db.token_limit import update_token_rate_limit
 from onyx.db.user_usage import TokenUsageBucket
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.query_and_chat.token_limit import _token_budget_reset
 from onyx.server.token_rate_limits.models import (
+    MAX_TOKEN_BUDGET_THOUSANDS,
     TokenRateLimitArgs,
     TokenRateLimitDisplay,
+    TokenRateLimitUpdateArgs,
 )
 
 
@@ -61,6 +66,66 @@ def test_token_rate_limit_args_requires_a_budget() -> None:
 def test_token_rate_limit_args_requires_whole_utc_days() -> None:
     with pytest.raises(ValidationError, match="whole UTC days"):
         TokenRateLimitArgs(enabled=True, token_budget=1, period_hours=25)
+
+
+def test_token_rate_limit_args_rejects_budgets_above_one_trillion() -> None:
+    with pytest.raises(ValidationError):
+        TokenRateLimitArgs(
+            enabled=True,
+            token_budget=MAX_TOKEN_BUDGET_THOUSANDS + 1,
+            period_hours=24,
+        )
+
+
+def test_token_rate_limit_update_args_accepts_legacy_budget() -> None:
+    args = TokenRateLimitUpdateArgs(
+        enabled=False,
+        token_budget=MAX_TOKEN_BUDGET_THOUSANDS + 1,
+        period_hours=24,
+    )
+
+    assert args.token_budget == MAX_TOKEN_BUDGET_THOUSANDS + 1
+
+
+def test_legacy_budget_can_be_toggled_without_increasing_it() -> None:
+    legacy_budget = MAX_TOKEN_BUDGET_THOUSANDS + 1
+    limit = _rate_limit(legacy_budget)
+    limit.id = 7
+    session = Mock()
+    session.get.return_value = limit
+
+    updated = update_token_rate_limit(
+        session,
+        7,
+        TokenRateLimitUpdateArgs(
+            enabled=False,
+            token_budget=legacy_budget,
+            period_hours=24,
+        ),
+    )
+
+    assert updated.enabled is False
+    session.commit.assert_called_once()
+
+
+def test_existing_limit_cannot_be_raised_above_one_trillion() -> None:
+    limit = _rate_limit(MAX_TOKEN_BUDGET_THOUSANDS)
+    limit.id = 7
+    session = Mock()
+    session.get.return_value = limit
+
+    with pytest.raises(OnyxError):
+        update_token_rate_limit(
+            session,
+            7,
+            TokenRateLimitUpdateArgs(
+                enabled=True,
+                token_budget=MAX_TOKEN_BUDGET_THOUSANDS + 1,
+                period_hours=24,
+            ),
+        )
+
+    session.commit.assert_not_called()
 
 
 def test_token_rate_limit_uses_current_utc_day() -> None:


### PR DESCRIPTION
## Description

Splits the backend piece out of #13752 (which has grown into a full usage-workspace redesign spanning backend + two independent frontend surfaces) into its own PR so it can be reviewed on its own terms.

Caps spending-limit token budgets at one trillion tokens:

- `TokenRateLimitArgs` (create path) now has `token_budget: int | None = Field(..., le=MAX_TOKEN_BUDGET_THOUSANDS)`, so new limits above 1T are rejected by pydantic validation.
- Update path uses a new `TokenRateLimitUpdateArgs` (no pydantic ceiling) plus an explicit check in `update_token_rate_limit`: an update is rejected if the new `token_budget` exceeds the ceiling **and** differs from the currently stored value. This grandfathers any legacy limit that was created before the ceiling existed — it stays readable/toggleable but can't be increased further.
- `api.py` wires `TokenRateLimitUpdateArgs` into the update endpoint.

This PR only touches `backend/onyx/db/token_limit.py`, `backend/onyx/server/token_rate_limits/{api,models}.py`, and their test file — no frontend changes. The two frontend PRs that consume this ceiling ([modal] and [table/panel], to follow) mirror the same 1T cap client-side for early feedback, but the server is the actual enforcement point.

## How Has This Been Tested?

- `backend/tests/unit/onyx/server/test_token_rate_limit_budget_models.py` — new tests cover the create-path ceiling rejection, the legacy grandfather case (unchanged value under enabled/disabled toggle), and rejection of any increase past the ceiling on update. 45 tests passed across the token-limit backend suites (`test_token_rate_limit_budget_models.py`, `server/token_rate_limits/`, `server/query_and_chat/test_token_limit.py`, `ee/onyx/db/test_user_group_cost_token_limit.py`).
- `ruff check` clean on all changed files.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps spending-limit token budgets at one trillion tokens across backend create and update paths. New limits over 1T are rejected; legacy over-cap limits are allowed but cannot be increased.

- **New Features**
  - Enforced 1T cap on create via `TokenRateLimitArgs` validation (`MAX_TOKEN_BUDGET_THOUSANDS`).
  - Added `TokenRateLimitUpdateArgs` for updates; rejects increases over the cap while allowing unchanged legacy values. Enforced in `update_token_rate_limit` and wired into the update endpoint.

<sup>Written for commit 952e167a8d0c39bb988561592a5db8cba70a5db8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

