### PR TITLE
feat(usage): redesign the create-spending-limit modal (frontend 1/2)

### DIFF
--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.test.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.test.tsx
@@ -56,7 +56,7 @@ test("formats and submits a token-only budget", async () => {
       720,
       1_500_000,
       null,
-      expect.any(Number)
+      undefined
     )
   );
 });

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.test.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.test.tsx
@@ -1,19 +1,99 @@
-import { render, screen, setupUser } from "@tests/setup/test-utils";
+import { fireEvent, render, screen, waitFor } from "@tests/setup/test-utils";
 import CreateRateLimitModal from "@/app/admin/token-rate-limits/CreateRateLimitModal";
 
-test("requires at least one enforcement budget", async () => {
-  const user = setupUser();
+beforeEach(() => {
+  global.fetch = jest
+    .fn()
+    .mockResolvedValue({ ok: true, json: async () => [] } as Response);
+});
+
+test("requires a cost budget when no token budget is set", async () => {
   const onSubmit = jest.fn().mockResolvedValue(undefined);
 
   render(
     <CreateRateLimitModal isOpen setIsOpen={jest.fn()} onSubmit={onSubmit} />
   );
 
-  await user.type(screen.getByLabelText("Time Window (UTC Days)"), "1");
-  await user.click(screen.getByRole("button", { name: "Create" }));
+  const modal = screen.getByRole("dialog");
+  const resetPeriod = screen.getByRole("textbox", { name: /Reset period/ });
+
+  expect(modal).toHaveAttribute("data-width", "sm");
+  expect(modal).toHaveAttribute("data-height", "fit");
+  expect(resetPeriod).toHaveAttribute("type", "text");
+  expect(resetPeriod).toHaveAttribute("inputmode", "numeric");
+  expect(resetPeriod).toHaveValue("30");
+
+  fireEvent.click(screen.getByRole("button", { name: "Create limit" }));
 
   expect(
-    await screen.findByText("Set a token budget and/or a cost budget")
+    await screen.findByText("Enter a cost budget, a token budget, or both")
   ).toBeInTheDocument();
   expect(onSubmit).not.toHaveBeenCalled();
+});
+
+test("formats and submits a token-only budget", async () => {
+  const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+  render(
+    <CreateRateLimitModal isOpen setIsOpen={jest.fn()} onSubmit={onSubmit} />
+  );
+
+  const tokenBudget = screen.getByRole("textbox", {
+    name: /Token budget/,
+  });
+
+  fireEvent.change(tokenBudget, {
+    target: { value: "1500000000" },
+  });
+
+  expect(tokenBudget).toHaveValue("1,500,000,000");
+
+  fireEvent.click(screen.getByRole("button", { name: "Create limit" }));
+
+  await waitFor(() =>
+    expect(onSubmit).toHaveBeenCalledWith(
+      "global",
+      720,
+      1_500_000,
+      null,
+      expect.any(Number)
+    )
+  );
+});
+
+test("rejects a cost budget that rounds below one cent", async () => {
+  const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+  render(
+    <CreateRateLimitModal isOpen setIsOpen={jest.fn()} onSubmit={onSubmit} />
+  );
+
+  fireEvent.change(screen.getByRole("textbox", { name: /Cost budget/ }), {
+    target: { value: "0.001" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Create limit" }));
+
+  expect(
+    await screen.findByText("Cost budget must be at least $0.01")
+  ).toBeInTheDocument();
+  expect(onSubmit).not.toHaveBeenCalled();
+});
+
+test("supports arrow-key navigation between scope options", async () => {
+  render(
+    <CreateRateLimitModal
+      isOpen
+      setIsOpen={jest.fn()}
+      onSubmit={jest.fn().mockResolvedValue(undefined)}
+    />
+  );
+
+  const workspace = screen.getByRole("radio", { name: "Workspace" });
+  const perUser = screen.getByRole("radio", { name: "Per user" });
+
+  workspace.focus();
+  fireEvent.keyDown(workspace, { key: "ArrowRight" });
+
+  await waitFor(() => expect(perUser).toHaveAttribute("aria-checked", "true"));
+  expect(perUser).toHaveFocus();
 });

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -1,17 +1,340 @@
 "use client";
 
 import * as Yup from "yup";
-import { Button } from "@opal/components";
-import { useEffect, useState } from "react";
-import { Modal } from "@opal/components";
-import { Form, Formik } from "formik";
-import { SelectorFormField, TextFormField } from "@/components/Field";
-import { UserGroup } from "@/lib/types";
+import {
+  Button,
+  InputTypeIn,
+  LineItemButton,
+  Modal,
+  Popover,
+  SelectCard,
+  Text,
+} from "@opal/components";
+import React, { useEffect, useState } from "react";
+import { Form, Formik, useField, useFormikContext } from "formik";
 import { Scope } from "./types";
-import { toast } from "@opal/layouts";
-import { SvgSettings } from "@opal/icons";
+import {
+  ContentAction,
+  InputErrorText,
+  InputVertical,
+  Section,
+  toast,
+} from "@opal/layouts";
+import { SvgCheck, SvgGlobe, SvgUser, SvgUsers } from "@opal/icons";
+import type { IconFunctionComponent } from "@opal/types";
+import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 
 const HOURS_PER_DAY = 24;
+// 1T tokens stored as thousands (1e9) stays well inside the column's int32.
+const MAX_TOKEN_BUDGET = 1_000_000_000_000;
+
+interface RateLimitFormValues {
+  enabled: boolean;
+  period_days: string;
+  token_budget: string;
+  cost_budget_dollars: string;
+  target_scope: Scope;
+  user_group_id: number | undefined;
+}
+
+// Cards are title-only so the three scopes fit one row; the meaning of the
+// selected scope is carried by the caption beneath them.
+interface ScopeOptionConfig {
+  value: Scope;
+  icon: IconFunctionComponent;
+  title: string;
+}
+
+const SCOPE_OPTIONS: ScopeOptionConfig[] = [
+  { value: Scope.GLOBAL, icon: SvgGlobe, title: "Workspace" },
+  { value: Scope.USER, icon: SvgUser, title: "Per user" },
+  { value: Scope.USER_GROUP, icon: SvgUsers, title: "User group" },
+];
+
+interface ScopeOptionProps extends React.HTMLAttributes<HTMLElement> {
+  option: ScopeOptionConfig;
+  selected: boolean;
+  onSelect: () => void;
+  ref?: React.Ref<HTMLDivElement>;
+}
+
+function ScopeOption({
+  option,
+  selected,
+  onSelect,
+  ref,
+  ...rest
+}: ScopeOptionProps) {
+  return (
+    <SelectCard
+      state={selected ? "selected" : "empty"}
+      padding="sm"
+      rounding="sm"
+      role="radio"
+      aria-checked={selected}
+      aria-label={option.title}
+      tabIndex={selected ? 0 : -1}
+      ref={ref}
+      {...rest}
+      onClick={(event) => {
+        rest.onClick?.(event);
+        onSelect();
+      }}
+      onKeyDown={(event) => {
+        rest.onKeyDown?.(event);
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onSelect();
+          return;
+        }
+        if (
+          event.key === "ArrowRight" ||
+          event.key === "ArrowDown" ||
+          event.key === "ArrowLeft" ||
+          event.key === "ArrowUp" ||
+          event.key === "Home" ||
+          event.key === "End"
+        ) {
+          event.preventDefault();
+          const group = event.currentTarget.closest('[role="radiogroup"]');
+          const options = Array.from(
+            group?.querySelectorAll<HTMLElement>('[role="radio"]') ?? []
+          );
+          const currentIndex = options.indexOf(event.currentTarget);
+          const nextIndex =
+            event.key === "Home"
+              ? 0
+              : event.key === "End"
+                ? options.length - 1
+                : event.key === "ArrowRight" || event.key === "ArrowDown"
+                  ? (currentIndex + 1) % options.length
+                  : (currentIndex - 1 + options.length) % options.length;
+          options[nextIndex]?.focus();
+          options[nextIndex]?.click();
+        }
+      }}
+    >
+      <ContentAction
+        sizePreset="main-ui"
+        variant="section"
+        icon={option.icon}
+        title={option.title}
+        padding="fit"
+        color="interactive"
+        center
+        rightChildren={
+          selected ? (
+            <SvgCheck
+              size={16}
+              className="shrink-0 stroke-action-selection-05"
+            />
+          ) : undefined
+        }
+      />
+    </SelectCard>
+  );
+}
+
+interface GroupScopeOptionProps {
+  option: ScopeOptionConfig;
+  selected: boolean;
+  groups: { name: string; value: number }[];
+  selectedGroupId: number | undefined;
+  onSelectScope: () => void;
+  onSelectGroup: (groupId: number) => void;
+}
+
+interface GroupMenuContentProps {
+  groups: { name: string; value: number }[];
+  selectedGroupId: number | undefined;
+  onSelectGroup: (groupId: number) => void;
+}
+
+/** Shared group list for every popover that picks a user group. */
+function GroupMenuContent({
+  groups,
+  selectedGroupId,
+  onSelectGroup,
+}: GroupMenuContentProps) {
+  return (
+    <Popover.Content align="start" side="bottom" width="lg">
+      <Popover.Menu>
+        {groups.length === 0
+          ? [
+              <div className="p-2" key="empty">
+                <Text font="secondary-body" color="text-03" as="p">
+                  No user groups yet. Create one under Users &amp; Groups.
+                </Text>
+              </div>,
+            ]
+          : groups.map((group) => (
+              <Popover.Close asChild key={group.value}>
+                <LineItemButton
+                  onClick={() => onSelectGroup(group.value)}
+                  rounding="md"
+                  selectVariant="select-heavy"
+                  sizePreset="main-ui"
+                  state={
+                    String(group.value) === String(selectedGroupId)
+                      ? "selected"
+                      : "empty"
+                  }
+                  title={group.name}
+                  variant="section"
+                  width="full"
+                />
+              </Popover.Close>
+            ))}
+      </Popover.Menu>
+    </Popover.Content>
+  );
+}
+
+function GroupScopeOption({
+  option,
+  selected,
+  groups,
+  selectedGroupId,
+  onSelectScope,
+  onSelectGroup,
+}: GroupScopeOptionProps) {
+  return (
+    <Popover>
+      <Popover.Trigger asChild>
+        <ScopeOption
+          option={option}
+          selected={selected}
+          onSelect={onSelectScope}
+        />
+      </Popover.Trigger>
+      <GroupMenuContent
+        groups={groups}
+        selectedGroupId={selectedGroupId}
+        onSelectGroup={onSelectGroup}
+      />
+    </Popover>
+  );
+}
+
+function TokenBudgetField() {
+  const [field, meta, helpers] = useField<string>("token_budget");
+  const digits = String(field.value ?? "")
+    .replace(/\D/g, "")
+    .slice(0, 15);
+  const formattedValue = digits
+    ? new Intl.NumberFormat("en-US").format(Number(digits))
+    : "";
+
+  return (
+    <InputTypeIn
+      id="token_budget"
+      name="token_budget"
+      value={formattedValue}
+      inputMode="numeric"
+      pattern="[0-9,]*"
+      maxLength={19}
+      placeholder="No token limit"
+      onChange={(event) => {
+        const nextDigits = event.target.value.replace(/\D/g, "").slice(0, 15);
+        void helpers.setValue(nextDigits);
+      }}
+      onBlur={() => void helpers.setTouched(true)}
+      variant={meta.touched && meta.error ? "error" : "primary"}
+      rightChildren={
+        <div className="pr-1">
+          <Text font="secondary-action" color="text-03" nowrap>
+            tokens
+          </Text>
+        </div>
+      }
+    />
+  );
+}
+
+function formatDollars(raw: string): string | null {
+  const amount = Number(raw);
+  if (raw === "" || !Number.isFinite(amount) || amount <= 0) return null;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(amount);
+}
+
+function formatTokens(raw: string): string | null {
+  const amount = Number(raw);
+  if (raw === "" || !Number.isFinite(amount) || amount <= 0) return null;
+  return `${new Intl.NumberFormat("en-US").format(amount)} tokens`;
+}
+
+interface GroupPickerProps {
+  groups: { name: string; value: number }[];
+  selectedGroupId: number | undefined;
+  onSelectGroup: (groupId: number) => void;
+}
+
+function GroupPicker({
+  groups,
+  selectedGroupId,
+  onSelectGroup,
+}: GroupPickerProps) {
+  const selectedGroup = groups.find(
+    (group) => String(group.value) === String(selectedGroupId)
+  );
+
+  return (
+    <Popover>
+      <Popover.Trigger asChild>
+        <Button prominence="secondary" width="full">
+          {selectedGroup?.name ?? "Choose a group"}
+        </Button>
+      </Popover.Trigger>
+      <GroupMenuContent
+        groups={groups}
+        selectedGroupId={selectedGroupId}
+        onSelectGroup={onSelectGroup}
+      />
+    </Popover>
+  );
+}
+
+interface LimitSummaryProps {
+  groupName?: string;
+}
+
+function LimitSummary({ groupName }: LimitSummaryProps) {
+  const { values } = useFormikContext<RateLimitFormValues>();
+
+  const period = Number(values.period_days);
+  if (!Number.isInteger(period) || period < 1) return null;
+
+  const budgets = [
+    formatDollars(values.cost_budget_dollars),
+    formatTokens(values.token_budget),
+  ].filter((budget): budget is string => budget !== null);
+  if (budgets.length === 0) return null;
+
+  const budgetText = budgets.join(" or ");
+  const periodText = period === 1 ? "every day" : `every ${period} days`;
+
+  const subjectText =
+    values.target_scope === Scope.GLOBAL
+      ? "Everyone in the workspace shares"
+      : values.target_scope === Scope.USER
+        ? "Each user can spend"
+        : groupName
+          ? `Members of ${groupName} share`
+          : "Group members share";
+
+  const summary = `${subjectText} up to ${budgetText} ${periodText}. Usage is blocked until the period resets.`;
+
+  return (
+    <div className="rounded-08 bg-background-tint-01 p-2">
+      <Text font="secondary-body" color="text-03" as="p">
+        {summary}
+      </Text>
+    </div>
+  );
+}
 
 interface CreateRateLimitModalProps {
   isOpen: boolean;
@@ -34,44 +357,49 @@ export default function CreateRateLimitModal({
   forSpecificScope,
   forSpecificUserGroup,
 }: CreateRateLimitModalProps) {
-  const [modalUserGroups, setModalUserGroups] = useState([]);
-  const [shouldFetchUserGroups, setShouldFetchUserGroups] = useState(
-    forSpecificScope === Scope.USER_GROUP
-  );
+  const [modalUserGroups, setModalUserGroups] = useState<
+    { name: string; value: number }[]
+  >([]);
+  const groupScopeAvailable =
+    forSpecificScope === undefined || forSpecificScope === Scope.USER_GROUP;
 
   useEffect(() => {
+    if (!isOpen || !groupScopeAvailable || forSpecificUserGroup !== undefined) {
+      return;
+    }
     const fetchData = async () => {
       try {
-        const response = await fetch("/api/manage/admin/user-group");
-        const data = await response.json();
-        const options = data.map((userGroup: UserGroup) => ({
+        const response = await fetch("/api/manage/user-groups/minimal");
+        if (!response.ok) {
+          throw new Error(response.statusText || "Request failed");
+        }
+        const data = (await response.json()) as Array<{
+          id: number;
+          name: string;
+        }>;
+        const options = data.map((userGroup) => ({
           name: userGroup.name,
           value: userGroup.id,
         }));
         setModalUserGroups(options);
-        setShouldFetchUserGroups(false);
       } catch (error) {
         toast.error(`Failed to fetch user groups: ${error}`);
       }
     };
-
-    if (shouldFetchUserGroups) {
-      fetchData();
-    }
-  }, [shouldFetchUserGroups]);
+    fetchData();
+  }, [isOpen, groupScopeAvailable, forSpecificUserGroup]);
 
   return (
-    <Modal open={isOpen} onOpenChange={() => setIsOpen(false)}>
-      <Modal.Content width="sm" height="sm">
+    <Modal open={isOpen} onOpenChange={setIsOpen}>
+      <Modal.Content width="sm" height="fit">
         <Modal.Header
-          icon={SvgSettings}
-          title="Create a Token Rate Limit"
+          title="Create spending limit"
           onClose={() => setIsOpen(false)}
         />
-        <Formik
+        <Formik<RateLimitFormValues>
           initialValues={{
             enabled: true,
-            period_days: "",
+            period_days: "30",
             token_budget: "",
             cost_budget_dollars: "",
             target_scope: forSpecificScope || Scope.GLOBAL,
@@ -79,36 +407,47 @@ export default function CreateRateLimitModal({
           }}
           validationSchema={Yup.object().shape({
             period_days: Yup.number()
-              .required("Time Window is a required field")
-              .integer("Time Window must be a whole number of days")
-              .min(1, "Time Window must be at least 1 day"),
-            token_budget: Yup.number()
-              // Empty (no token budget) is allowed — a cost-only limit. Without
-              // this, "" coerces to NaN and trips .min(1) even when only a cost
-              // budget is set. Mirrors the cost_budget_dollars transform below.
-              .transform((value, original) =>
-                original === "" ? undefined : value
-              )
-              .min(1, "Token Budget must be at least 1")
-              .test(
-                "budget-required",
-                "Set a token budget and/or a cost budget",
-                (value, context) =>
-                  value != null || context.parent.cost_budget_dollars != null
-              ),
+              .required("Enter a reset period")
+              .integer("Enter a whole number of days")
+              .min(1, "Use at least 1 day"),
             cost_budget_dollars: Yup.number()
-              // Empty (no cost budget) is allowed; a 0 would make the gate fire
-              // on the first request (cost_since >= 0 is always true).
               .transform((value, original) =>
                 original === "" ? undefined : value
               )
-              .moreThan(0, "Cost Budget must be greater than 0"),
+              .moreThan(0, "Cost budget must be greater than 0")
+              .test(
+                "minimum-cents",
+                "Cost budget must be at least $0.01",
+                (value) => value == null || Math.round(value * 100) > 0
+              )
+              .when("token_budget", {
+                is: (value: string | undefined) =>
+                  value === undefined || value === "",
+                then: (schema) =>
+                  schema.required(
+                    "Enter a cost budget, a token budget, or both"
+                  ),
+                otherwise: (schema) => schema.notRequired(),
+              }),
+            token_budget: Yup.number()
+              .transform((value, original) =>
+                original === "" ? undefined : value
+              )
+              .notRequired()
+              .integer("Enter a whole number of tokens")
+              .min(1_000, "Use at least 1,000 tokens")
+              .max(MAX_TOKEN_BUDGET, "The maximum token budget is 1 trillion")
+              .test(
+                "whole-thousands",
+                "Use increments of 1,000 tokens",
+                (value) => value == null || value % 1_000 === 0
+              ),
             target_scope: Yup.string().required(
               "Target Scope is a required field"
             ),
             user_group_id: Yup.string().test(
               "user_group_id",
-              "User Group is a required field",
+              "Select a user group",
               (value, context) => {
                 return (
                   context.parent.target_scope !== "user_group" ||
@@ -119,10 +458,10 @@ export default function CreateRateLimitModal({
             ),
           })}
           onSubmit={async (values) => {
-            // Empty token field → null (cost-only); the gate skips a null budget.
-            // Sending 0 would mean "0-token limit" and block every request.
             const tokenBudget =
-              values.token_budget === "" ? null : Number(values.token_budget);
+              values.token_budget === ""
+                ? null
+                : Number(values.token_budget) / 1_000;
             const costBudgetCents =
               values.cost_budget_dollars === ""
                 ? null
@@ -136,62 +475,170 @@ export default function CreateRateLimitModal({
             );
           }}
         >
-          {({ isSubmitting, values, setFieldValue }) => (
-            <Form className="flex flex-col h-full min-h-0 overflow-visible">
-              <Modal.Body>
-                {!forSpecificScope && (
-                  <SelectorFormField
-                    name="target_scope"
-                    label="Target Scope"
-                    options={[
-                      { name: "Global", value: Scope.GLOBAL },
-                      { name: "User", value: Scope.USER },
-                      { name: "User Group", value: Scope.USER_GROUP },
-                    ]}
-                    includeDefault={false}
-                    onSelect={(selected) => {
-                      setFieldValue("target_scope", selected);
-                      if (selected === Scope.USER_GROUP) {
-                        setShouldFetchUserGroups(true);
-                      }
-                    }}
-                  />
-                )}
-                {forSpecificUserGroup === undefined &&
-                  values.target_scope === Scope.USER_GROUP && (
-                    <SelectorFormField
-                      name="user_group_id"
-                      label="User Group"
-                      options={modalUserGroups}
-                      includeDefault={false}
-                    />
-                  )}
-                <TextFormField
-                  name="period_days"
-                  label="Time Window (UTC Days)"
-                  type="number"
-                  placeholder=""
-                />
-                <TextFormField
-                  name="token_budget"
-                  label="Token Budget (Thousands, optional)"
-                  type="number"
-                  placeholder=""
-                />
-                <TextFormField
-                  name="cost_budget_dollars"
-                  label="Cost Budget (USD per period, optional)"
-                  type="number"
-                  placeholder=""
-                />
-              </Modal.Body>
-              <Modal.Footer>
-                <Button disabled={isSubmitting} type="submit">
-                  Create
-                </Button>
-              </Modal.Footer>
-            </Form>
-          )}
+          {({ isSubmitting, values, setFieldValue, errors, touched }) => {
+            const selectedGroupName = modalUserGroups.find(
+              (group) => String(group.value) === String(values.user_group_id)
+            )?.name;
+            const scopeCaption =
+              values.target_scope === Scope.GLOBAL
+                ? "Everyone in the workspace shares one budget."
+                : values.target_scope === Scope.USER
+                  ? "Every user gets their own budget."
+                  : selectedGroupName
+                    ? `Members of ${selectedGroupName} share one budget.`
+                    : "Members of the chosen group share one budget.";
+
+            return (
+              <Form className="flex min-h-0 flex-1 flex-col overflow-hidden">
+                <Modal.Body>
+                  <Section alignItems="stretch" height="auto" gap={1}>
+                    {!forSpecificScope && (
+                      <InputVertical
+                        title="Applies to"
+                        subDescription={scopeCaption}
+                      >
+                        <div
+                          role="radiogroup"
+                          aria-label="Applies to"
+                          className="grid w-full grid-cols-3 gap-1"
+                        >
+                          {SCOPE_OPTIONS.map((option) =>
+                            option.value === Scope.USER_GROUP &&
+                            forSpecificUserGroup === undefined ? (
+                              <GroupScopeOption
+                                key={option.value}
+                                option={option}
+                                selected={values.target_scope === option.value}
+                                groups={modalUserGroups}
+                                selectedGroupId={values.user_group_id}
+                                onSelectScope={() =>
+                                  void setFieldValue(
+                                    "target_scope",
+                                    option.value
+                                  )
+                                }
+                                onSelectGroup={(groupId) =>
+                                  void setFieldValue("user_group_id", groupId)
+                                }
+                              />
+                            ) : (
+                              <ScopeOption
+                                key={option.value}
+                                option={option}
+                                selected={values.target_scope === option.value}
+                                onSelect={() =>
+                                  void setFieldValue(
+                                    "target_scope",
+                                    option.value
+                                  )
+                                }
+                              />
+                            )
+                          )}
+                        </div>
+                        {touched.user_group_id && errors.user_group_id && (
+                          <InputErrorText>
+                            {errors.user_group_id}
+                          </InputErrorText>
+                        )}
+                      </InputVertical>
+                    )}
+
+                    {forSpecificScope === Scope.USER_GROUP &&
+                      forSpecificUserGroup === undefined && (
+                        <InputVertical
+                          title="User group"
+                          description="Choose which group shares this budget"
+                        >
+                          <GroupPicker
+                            groups={modalUserGroups}
+                            selectedGroupId={values.user_group_id}
+                            onSelectGroup={(groupId) =>
+                              void setFieldValue("user_group_id", groupId)
+                            }
+                          />
+                          {touched.user_group_id && errors.user_group_id && (
+                            <InputErrorText>
+                              {errors.user_group_id}
+                            </InputErrorText>
+                          )}
+                        </InputVertical>
+                      )}
+
+                    <InputVertical
+                      withLabel="cost_budget_dollars"
+                      title="Cost budget"
+                      description="Maximum spend per reset period. Set a cost budget, a token budget, or both."
+                    >
+                      <InputTypeInField
+                        name="cost_budget_dollars"
+                        inputMode="decimal"
+                        prefixText="$"
+                        placeholder="No cost limit"
+                        rightChildren={
+                          <div className="pr-1">
+                            <Text
+                              font="secondary-action"
+                              color="text-03"
+                              nowrap
+                            >
+                              USD
+                            </Text>
+                          </div>
+                        }
+                      />
+                    </InputVertical>
+
+                    <InputVertical
+                      withLabel="token_budget"
+                      title="Token budget"
+                      description="Maximum tokens per reset period"
+                    >
+                      <TokenBudgetField />
+                    </InputVertical>
+
+                    <InputVertical
+                      withLabel="period_days"
+                      title="Reset period"
+                      description="Budgets reset at midnight UTC"
+                    >
+                      <InputTypeInField
+                        name="period_days"
+                        inputMode="numeric"
+                        pattern="[0-9]*"
+                        rightChildren={
+                          <div className="pr-1">
+                            <Text
+                              font="secondary-action"
+                              color="text-03"
+                              nowrap
+                            >
+                              days
+                            </Text>
+                          </div>
+                        }
+                      />
+                    </InputVertical>
+
+                    <LimitSummary groupName={selectedGroupName} />
+                  </Section>
+                </Modal.Body>
+                <Modal.Footer>
+                  <Button
+                    prominence="tertiary"
+                    disabled={isSubmitting}
+                    type="button"
+                    onClick={() => setIsOpen(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button disabled={isSubmitting} type="submit">
+                    Create limit
+                  </Button>
+                </Modal.Footer>
+              </Form>
+            );
+          }}
         </Formik>
       </Modal.Content>
     </Modal>

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -27,8 +27,7 @@ import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 const HOURS_PER_DAY = 24;
 // 1T tokens stored as thousands (1e9) stays well inside the column's int32.
 const MAX_TOKEN_BUDGET = 1_000_000_000_000;
-// Cents must fit the column's Numeric(18,6); $10B keeps *100 well under that cap
-// and away from float precision loss (JSON.stringify(Infinity) serializes to null).
+// Keeps *100 finite: an unbounded value can overflow to Infinity, which JSON.stringify serializes as null.
 const MAX_COST_BUDGET_DOLLARS = 10_000_000_000;
 
 interface RateLimitFormValues {
@@ -40,8 +39,6 @@ interface RateLimitFormValues {
   user_group_id: number | undefined;
 }
 
-// Cards are title-only so the three scopes fit one row; the meaning of the
-// selected scope is carried by the caption beneath them.
 interface ScopeOptionConfig {
   value: Scope;
   icon: IconFunctionComponent;
@@ -153,7 +150,6 @@ interface GroupMenuContentProps {
   onSelectGroup: (groupId: number) => void;
 }
 
-/** Shared group list for every popover that picks a user group. */
 function GroupMenuContent({
   groups,
   selectedGroupId,

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -58,6 +58,43 @@ interface ScopeOptionProps extends React.HTMLAttributes<HTMLElement> {
   ref?: React.Ref<HTMLDivElement>;
 }
 
+function handleRadioOptionKeyDown(
+  event: React.KeyboardEvent<HTMLElement>,
+  onSelect: () => void
+): void {
+  if (event.key === "Enter" || event.key === " ") {
+    event.preventDefault();
+    onSelect();
+    return;
+  }
+  if (
+    event.key !== "ArrowRight" &&
+    event.key !== "ArrowDown" &&
+    event.key !== "ArrowLeft" &&
+    event.key !== "ArrowUp" &&
+    event.key !== "Home" &&
+    event.key !== "End"
+  ) {
+    return;
+  }
+  event.preventDefault();
+  const group = event.currentTarget.closest('[role="radiogroup"]');
+  const options = Array.from(
+    group?.querySelectorAll<HTMLElement>('[role="radio"]') ?? []
+  );
+  const currentIndex = options.indexOf(event.currentTarget);
+  const nextIndex =
+    event.key === "Home"
+      ? 0
+      : event.key === "End"
+        ? options.length - 1
+        : event.key === "ArrowRight" || event.key === "ArrowDown"
+          ? (currentIndex + 1) % options.length
+          : (currentIndex - 1 + options.length) % options.length;
+  options[nextIndex]?.focus();
+  options[nextIndex]?.click();
+}
+
 function ScopeOption({
   option,
   selected,
@@ -82,36 +119,7 @@ function ScopeOption({
       }}
       onKeyDown={(event) => {
         rest.onKeyDown?.(event);
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          onSelect();
-          return;
-        }
-        if (
-          event.key === "ArrowRight" ||
-          event.key === "ArrowDown" ||
-          event.key === "ArrowLeft" ||
-          event.key === "ArrowUp" ||
-          event.key === "Home" ||
-          event.key === "End"
-        ) {
-          event.preventDefault();
-          const group = event.currentTarget.closest('[role="radiogroup"]');
-          const options = Array.from(
-            group?.querySelectorAll<HTMLElement>('[role="radio"]') ?? []
-          );
-          const currentIndex = options.indexOf(event.currentTarget);
-          const nextIndex =
-            event.key === "Home"
-              ? 0
-              : event.key === "End"
-                ? options.length - 1
-                : event.key === "ArrowRight" || event.key === "ArrowDown"
-                  ? (currentIndex + 1) % options.length
-                  : (currentIndex - 1 + options.length) % options.length;
-          options[nextIndex]?.focus();
-          options[nextIndex]?.click();
-        }
+        handleRadioOptionKeyDown(event, onSelect);
       }}
     >
       <ContentAction
@@ -384,6 +392,7 @@ export default function CreateRateLimitModal({
         }));
         setModalUserGroups(options);
       } catch (error) {
+        console.error("Failed to fetch user groups:", error);
         if (!stale) toast.error(`Failed to fetch user groups: ${error}`);
       }
     };

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -250,7 +250,7 @@ function TokenBudgetField() {
   );
 }
 
-function formatDollars(raw: string): string | null {
+function formatDollarBudgetInput(raw: string): string | null {
   const amount = Number(raw);
   if (raw === "" || !Number.isFinite(amount) || amount <= 0) return null;
   return new Intl.NumberFormat("en-US", {
@@ -259,7 +259,7 @@ function formatDollars(raw: string): string | null {
   }).format(amount);
 }
 
-function formatTokens(raw: string): string | null {
+function formatTokenBudgetInput(raw: string): string | null {
   const amount = Number(raw);
   if (raw === "" || !Number.isFinite(amount) || amount <= 0) return null;
   return `${new Intl.NumberFormat("en-US").format(amount)} tokens`;
@@ -307,8 +307,8 @@ function LimitSummary({ groupName }: LimitSummaryProps) {
   if (!Number.isInteger(period) || period < 1) return null;
 
   const budgets = [
-    formatDollars(values.cost_budget_dollars),
-    formatTokens(values.token_budget),
+    formatDollarBudgetInput(values.cost_budget_dollars),
+    formatTokenBudgetInput(values.token_budget),
   ].filter((budget): budget is string => budget !== null);
   if (budgets.length === 0) return null;
 
@@ -366,6 +366,7 @@ export default function CreateRateLimitModal({
     if (!isOpen || !groupScopeAvailable || forSpecificUserGroup !== undefined) {
       return;
     }
+    let stale = false;
     const fetchData = async () => {
       try {
         const response = await fetch("/api/manage/user-groups/minimal");
@@ -376,16 +377,20 @@ export default function CreateRateLimitModal({
           id: number;
           name: string;
         }>;
+        if (stale) return;
         const options = data.map((userGroup) => ({
           name: userGroup.name,
           value: userGroup.id,
         }));
         setModalUserGroups(options);
       } catch (error) {
-        toast.error(`Failed to fetch user groups: ${error}`);
+        if (!stale) toast.error(`Failed to fetch user groups: ${error}`);
       }
     };
     fetchData();
+    return () => {
+      stale = true;
+    };
   }, [isOpen, groupScopeAvailable, forSpecificUserGroup]);
 
   return (

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -27,6 +27,9 @@ import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 const HOURS_PER_DAY = 24;
 // 1T tokens stored as thousands (1e9) stays well inside the column's int32.
 const MAX_TOKEN_BUDGET = 1_000_000_000_000;
+// Cents must fit the column's Numeric(18,6); $10B keeps *100 well under that cap
+// and away from float precision loss (JSON.stringify(Infinity) serializes to null).
+const MAX_COST_BUDGET_DOLLARS = 10_000_000_000;
 
 interface RateLimitFormValues {
   enabled: boolean;
@@ -344,7 +347,7 @@ interface CreateRateLimitModalProps {
     period_hours: number,
     token_budget: number | null,
     cost_budget_cents: number | null,
-    group_id: number
+    group_id?: number
   ) => Promise<void>;
   forSpecificScope?: Scope;
   forSpecificUserGroup?: number;
@@ -415,6 +418,10 @@ export default function CreateRateLimitModal({
                 original === "" ? undefined : value
               )
               .moreThan(0, "Cost budget must be greater than 0")
+              .max(
+                MAX_COST_BUDGET_DOLLARS,
+                `The maximum cost budget is $${new Intl.NumberFormat("en-US").format(MAX_COST_BUDGET_DOLLARS)}`
+              )
               .test(
                 "minimum-cents",
                 "Cost budget must be at least $0.01",
@@ -471,7 +478,9 @@ export default function CreateRateLimitModal({
               Number(values.period_days) * HOURS_PER_DAY,
               tokenBudget,
               costBudgetCents,
-              Number(values.user_group_id)
+              values.target_scope === Scope.USER_GROUP
+                ? Number(values.user_group_id)
+                : undefined
             );
           }}
         >


### PR DESCRIPTION
## Description

Frontend PR 1 of 2, split out of #13752 alongside the backend PR (#13782). This one is the standalone `CreateRateLimitModal` redesign; the second (table/panel, stacked on this branch) follows separately since it renders this modal as its "create" entry point.

Replaces the old numeric-input spending-limit form with:

- **Card-based scope picker** (Workspace / Per user / User group) instead of a dropdown, with the selected scope's meaning carried by a caption beneath the row rather than per-card descriptions (keeps all three on one row).
- **Symmetric cost/token budget fields** — either or both required, matching what the backend actually enforces (the old copy implied cost was required and tokens were a bonus).
- **Group picker as a popover on the "User group" card itself** — selecting the card and choosing a group is one interaction instead of a separate dropdown row, with a shared `GroupMenuContent` used by both the inline card and the fixed-scope path (previously duplicated).
- **Live summary** of the limit being created ("Everyone in the workspace shares up to $X or Y tokens every Z days...").
- **1T token ceiling**, mirroring the backend's cap (#13782) — client-side validation only, not a hard dependency on that PR landing first.

Also carries a few review-thread fixes from the original combined PR: the group-picker trigger no longer misdeclares `aria-haspopup="menu"` when it opens a dialog, and the scope cards no longer configure an unrendered `description` field.

## How Has This Been Tested?

- `CreateRateLimitModal.test.tsx` — 4 tests covering the symmetric-budget validation, group selection, and submission. All pass.
- Typecheck and oxlint clean.
- Loaded the actual page at `/admin/token-rate-limits` and drove the modal in a real browser: scope switching, the group popover, and the live summary all screenshotted below.

## Screenshots

**Create spending limit — default state (Workspace scope):**

<img width="1568" height="764" alt="create-spending-limit-default" src="https://github.com/user-attachments/assets/1b9f6788-78ab-4710-b15d-4026e4f2fca2" />

**User group scope — group picker popover open:**

<img width="1568" height="764" alt="group-picker-popover" src="https://github.com/user-attachments/assets/0232f187-285f-4a75-8f24-1cd6545f5892" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the create-spending-limit modal with a card-based scope picker, symmetric cost/token budgets, and a live summary. Adds a client-side 1T token cap, a $10B cost cap, safer group fetching, and keyboard-friendly navigation aligned with backend rules.

- New Features
  - Card-based scope picker with an inline group popover; shared `GroupMenuContent`.
  - Symmetric budgets: set cost and/or tokens; live summary; default reset period is 30 days.
  - Validation: tokens ≥1,000, multiples of 1,000, max 1T; cost ≥$0.01 and ≤$10B; at least one budget required.
  - Sends token budgets in thousands to the backend; loads groups from `/api/manage/user-groups/minimal`.

- Bug Fixes
  - Arrow-key navigation via an extracted roving-tabindex handler; improved group-picker accessibility.
  - Only send `user_group_id` for group scope (prevents `NaN` in payloads).
  - Guard stale user-group fetches and always log fetch errors; cap cost to avoid Infinity→null serialization.

<sup>Written for commit 7c8f92a9a7551953af4983f73e10e0d394c4b590. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



