### PR TITLE
feat(usage): extract TokenRateLimitsPanel and rework the limits table (frontend 2/2)

### DIFF
--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.test.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.test.tsx
@@ -56,7 +56,7 @@ test("formats and submits a token-only budget", async () => {
       720,
       1_500_000,
       null,
-      expect.any(Number)
+      undefined
     )
   );
 });

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.test.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.test.tsx
@@ -1,19 +1,99 @@
-import { render, screen, setupUser } from "@tests/setup/test-utils";
+import { fireEvent, render, screen, waitFor } from "@tests/setup/test-utils";
 import CreateRateLimitModal from "@/app/admin/token-rate-limits/CreateRateLimitModal";
 
-test("requires at least one enforcement budget", async () => {
-  const user = setupUser();
+beforeEach(() => {
+  global.fetch = jest
+    .fn()
+    .mockResolvedValue({ ok: true, json: async () => [] } as Response);
+});
+
+test("requires a cost budget when no token budget is set", async () => {
   const onSubmit = jest.fn().mockResolvedValue(undefined);
 
   render(
     <CreateRateLimitModal isOpen setIsOpen={jest.fn()} onSubmit={onSubmit} />
   );
 
-  await user.type(screen.getByLabelText("Time Window (UTC Days)"), "1");
-  await user.click(screen.getByRole("button", { name: "Create" }));
+  const modal = screen.getByRole("dialog");
+  const resetPeriod = screen.getByRole("textbox", { name: /Reset period/ });
+
+  expect(modal).toHaveAttribute("data-width", "sm");
+  expect(modal).toHaveAttribute("data-height", "fit");
+  expect(resetPeriod).toHaveAttribute("type", "text");
+  expect(resetPeriod).toHaveAttribute("inputmode", "numeric");
+  expect(resetPeriod).toHaveValue("30");
+
+  fireEvent.click(screen.getByRole("button", { name: "Create limit" }));
 
   expect(
-    await screen.findByText("Set a token budget and/or a cost budget")
+    await screen.findByText("Enter a cost budget, a token budget, or both")
   ).toBeInTheDocument();
   expect(onSubmit).not.toHaveBeenCalled();
+});
+
+test("formats and submits a token-only budget", async () => {
+  const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+  render(
+    <CreateRateLimitModal isOpen setIsOpen={jest.fn()} onSubmit={onSubmit} />
+  );
+
+  const tokenBudget = screen.getByRole("textbox", {
+    name: /Token budget/,
+  });
+
+  fireEvent.change(tokenBudget, {
+    target: { value: "1500000000" },
+  });
+
+  expect(tokenBudget).toHaveValue("1,500,000,000");
+
+  fireEvent.click(screen.getByRole("button", { name: "Create limit" }));
+
+  await waitFor(() =>
+    expect(onSubmit).toHaveBeenCalledWith(
+      "global",
+      720,
+      1_500_000,
+      null,
+      expect.any(Number)
+    )
+  );
+});
+
+test("rejects a cost budget that rounds below one cent", async () => {
+  const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+  render(
+    <CreateRateLimitModal isOpen setIsOpen={jest.fn()} onSubmit={onSubmit} />
+  );
+
+  fireEvent.change(screen.getByRole("textbox", { name: /Cost budget/ }), {
+    target: { value: "0.001" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Create limit" }));
+
+  expect(
+    await screen.findByText("Cost budget must be at least $0.01")
+  ).toBeInTheDocument();
+  expect(onSubmit).not.toHaveBeenCalled();
+});
+
+test("supports arrow-key navigation between scope options", async () => {
+  render(
+    <CreateRateLimitModal
+      isOpen
+      setIsOpen={jest.fn()}
+      onSubmit={jest.fn().mockResolvedValue(undefined)}
+    />
+  );
+
+  const workspace = screen.getByRole("radio", { name: "Workspace" });
+  const perUser = screen.getByRole("radio", { name: "Per user" });
+
+  workspace.focus();
+  fireEvent.keyDown(workspace, { key: "ArrowRight" });
+
+  await waitFor(() => expect(perUser).toHaveAttribute("aria-checked", "true"));
+  expect(perUser).toHaveFocus();
 });

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -1,17 +1,340 @@
 "use client";
 
 import * as Yup from "yup";
-import { Button } from "@opal/components";
-import { useEffect, useState } from "react";
-import { Modal } from "@opal/components";
-import { Form, Formik } from "formik";
-import { SelectorFormField, TextFormField } from "@/components/Field";
-import { UserGroup } from "@/lib/types";
+import {
+  Button,
+  InputTypeIn,
+  LineItemButton,
+  Modal,
+  Popover,
+  SelectCard,
+  Text,
+} from "@opal/components";
+import React, { useEffect, useState } from "react";
+import { Form, Formik, useField, useFormikContext } from "formik";
 import { Scope } from "./types";
-import { toast } from "@opal/layouts";
-import { SvgSettings } from "@opal/icons";
+import {
+  ContentAction,
+  InputErrorText,
+  InputVertical,
+  Section,
+  toast,
+} from "@opal/layouts";
+import { SvgCheck, SvgGlobe, SvgUser, SvgUsers } from "@opal/icons";
+import type { IconFunctionComponent } from "@opal/types";
+import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 
 const HOURS_PER_DAY = 24;
+// 1T tokens stored as thousands (1e9) stays well inside the column's int32.
+const MAX_TOKEN_BUDGET = 1_000_000_000_000;
+
+interface RateLimitFormValues {
+  enabled: boolean;
+  period_days: string;
+  token_budget: string;
+  cost_budget_dollars: string;
+  target_scope: Scope;
+  user_group_id: number | undefined;
+}
+
+// Cards are title-only so the three scopes fit one row; the meaning of the
+// selected scope is carried by the caption beneath them.
+interface ScopeOptionConfig {
+  value: Scope;
+  icon: IconFunctionComponent;
+  title: string;
+}
+
+const SCOPE_OPTIONS: ScopeOptionConfig[] = [
+  { value: Scope.GLOBAL, icon: SvgGlobe, title: "Workspace" },
+  { value: Scope.USER, icon: SvgUser, title: "Per user" },
+  { value: Scope.USER_GROUP, icon: SvgUsers, title: "User group" },
+];
+
+interface ScopeOptionProps extends React.HTMLAttributes<HTMLElement> {
+  option: ScopeOptionConfig;
+  selected: boolean;
+  onSelect: () => void;
+  ref?: React.Ref<HTMLDivElement>;
+}
+
+function ScopeOption({
+  option,
+  selected,
+  onSelect,
+  ref,
+  ...rest
+}: ScopeOptionProps) {
+  return (
+    <SelectCard
+      state={selected ? "selected" : "empty"}
+      padding="sm"
+      rounding="sm"
+      role="radio"
+      aria-checked={selected}
+      aria-label={option.title}
+      tabIndex={selected ? 0 : -1}
+      ref={ref}
+      {...rest}
+      onClick={(event) => {
+        rest.onClick?.(event);
+        onSelect();
+      }}
+      onKeyDown={(event) => {
+        rest.onKeyDown?.(event);
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onSelect();
+          return;
+        }
+        if (
+          event.key === "ArrowRight" ||
+          event.key === "ArrowDown" ||
+          event.key === "ArrowLeft" ||
+          event.key === "ArrowUp" ||
+          event.key === "Home" ||
+          event.key === "End"
+        ) {
+          event.preventDefault();
+          const group = event.currentTarget.closest('[role="radiogroup"]');
+          const options = Array.from(
+            group?.querySelectorAll<HTMLElement>('[role="radio"]') ?? []
+          );
+          const currentIndex = options.indexOf(event.currentTarget);
+          const nextIndex =
+            event.key === "Home"
+              ? 0
+              : event.key === "End"
+                ? options.length - 1
+                : event.key === "ArrowRight" || event.key === "ArrowDown"
+                  ? (currentIndex + 1) % options.length
+                  : (currentIndex - 1 + options.length) % options.length;
+          options[nextIndex]?.focus();
+          options[nextIndex]?.click();
+        }
+      }}
+    >
+      <ContentAction
+        sizePreset="main-ui"
+        variant="section"
+        icon={option.icon}
+        title={option.title}
+        padding="fit"
+        color="interactive"
+        center
+        rightChildren={
+          selected ? (
+            <SvgCheck
+              size={16}
+              className="shrink-0 stroke-action-selection-05"
+            />
+          ) : undefined
+        }
+      />
+    </SelectCard>
+  );
+}
+
+interface GroupScopeOptionProps {
+  option: ScopeOptionConfig;
+  selected: boolean;
+  groups: { name: string; value: number }[];
+  selectedGroupId: number | undefined;
+  onSelectScope: () => void;
+  onSelectGroup: (groupId: number) => void;
+}
+
+interface GroupMenuContentProps {
+  groups: { name: string; value: number }[];
+  selectedGroupId: number | undefined;
+  onSelectGroup: (groupId: number) => void;
+}
+
+/** Shared group list for every popover that picks a user group. */
+function GroupMenuContent({
+  groups,
+  selectedGroupId,
+  onSelectGroup,
+}: GroupMenuContentProps) {
+  return (
+    <Popover.Content align="start" side="bottom" width="lg">
+      <Popover.Menu>
+        {groups.length === 0
+          ? [
+              <div className="p-2" key="empty">
+                <Text font="secondary-body" color="text-03" as="p">
+                  No user groups yet. Create one under Users &amp; Groups.
+                </Text>
+              </div>,
+            ]
+          : groups.map((group) => (
+              <Popover.Close asChild key={group.value}>
+                <LineItemButton
+                  onClick={() => onSelectGroup(group.value)}
+                  rounding="md"
+                  selectVariant="select-heavy"
+                  sizePreset="main-ui"
+                  state={
+                    String(group.value) === String(selectedGroupId)
+                      ? "selected"
+                      : "empty"
+                  }
+                  title={group.name}
+                  variant="section"
+                  width="full"
+                />
+              </Popover.Close>
+            ))}
+      </Popover.Menu>
+    </Popover.Content>
+  );
+}
+
+function GroupScopeOption({
+  option,
+  selected,
+  groups,
+  selectedGroupId,
+  onSelectScope,
+  onSelectGroup,
+}: GroupScopeOptionProps) {
+  return (
+    <Popover>
+      <Popover.Trigger asChild>
+        <ScopeOption
+          option={option}
+          selected={selected}
+          onSelect={onSelectScope}
+        />
+      </Popover.Trigger>
+      <GroupMenuContent
+        groups={groups}
+        selectedGroupId={selectedGroupId}
+        onSelectGroup={onSelectGroup}
+      />
+    </Popover>
+  );
+}
+
+function TokenBudgetField() {
+  const [field, meta, helpers] = useField<string>("token_budget");
+  const digits = String(field.value ?? "")
+    .replace(/\D/g, "")
+    .slice(0, 15);
+  const formattedValue = digits
+    ? new Intl.NumberFormat("en-US").format(Number(digits))
+    : "";
+
+  return (
+    <InputTypeIn
+      id="token_budget"
+      name="token_budget"
+      value={formattedValue}
+      inputMode="numeric"
+      pattern="[0-9,]*"
+      maxLength={19}
+      placeholder="No token limit"
+      onChange={(event) => {
+        const nextDigits = event.target.value.replace(/\D/g, "").slice(0, 15);
+        void helpers.setValue(nextDigits);
+      }}
+      onBlur={() => void helpers.setTouched(true)}
+      variant={meta.touched && meta.error ? "error" : "primary"}
+      rightChildren={
+        <div className="pr-1">
+          <Text font="secondary-action" color="text-03" nowrap>
+            tokens
+          </Text>
+        </div>
+      }
+    />
+  );
+}
+
+function formatDollars(raw: string): string | null {
+  const amount = Number(raw);
+  if (raw === "" || !Number.isFinite(amount) || amount <= 0) return null;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(amount);
+}
+
+function formatTokens(raw: string): string | null {
+  const amount = Number(raw);
+  if (raw === "" || !Number.isFinite(amount) || amount <= 0) return null;
+  return `${new Intl.NumberFormat("en-US").format(amount)} tokens`;
+}
+
+interface GroupPickerProps {
+  groups: { name: string; value: number }[];
+  selectedGroupId: number | undefined;
+  onSelectGroup: (groupId: number) => void;
+}
+
+function GroupPicker({
+  groups,
+  selectedGroupId,
+  onSelectGroup,
+}: GroupPickerProps) {
+  const selectedGroup = groups.find(
+    (group) => String(group.value) === String(selectedGroupId)
+  );
+
+  return (
+    <Popover>
+      <Popover.Trigger asChild>
+        <Button prominence="secondary" width="full">
+          {selectedGroup?.name ?? "Choose a group"}
+        </Button>
+      </Popover.Trigger>
+      <GroupMenuContent
+        groups={groups}
+        selectedGroupId={selectedGroupId}
+        onSelectGroup={onSelectGroup}
+      />
+    </Popover>
+  );
+}
+
+interface LimitSummaryProps {
+  groupName?: string;
+}
+
+function LimitSummary({ groupName }: LimitSummaryProps) {
+  const { values } = useFormikContext<RateLimitFormValues>();
+
+  const period = Number(values.period_days);
+  if (!Number.isInteger(period) || period < 1) return null;
+
+  const budgets = [
+    formatDollars(values.cost_budget_dollars),
+    formatTokens(values.token_budget),
+  ].filter((budget): budget is string => budget !== null);
+  if (budgets.length === 0) return null;
+
+  const budgetText = budgets.join(" or ");
+  const periodText = period === 1 ? "every day" : `every ${period} days`;
+
+  const subjectText =
+    values.target_scope === Scope.GLOBAL
+      ? "Everyone in the workspace shares"
+      : values.target_scope === Scope.USER
+        ? "Each user can spend"
+        : groupName
+          ? `Members of ${groupName} share`
+          : "Group members share";
+
+  const summary = `${subjectText} up to ${budgetText} ${periodText}. Usage is blocked until the period resets.`;
+
+  return (
+    <div className="rounded-08 bg-background-tint-01 p-2">
+      <Text font="secondary-body" color="text-03" as="p">
+        {summary}
+      </Text>
+    </div>
+  );
+}
 
 interface CreateRateLimitModalProps {
   isOpen: boolean;
@@ -34,44 +357,49 @@ export default function CreateRateLimitModal({
   forSpecificScope,
   forSpecificUserGroup,
 }: CreateRateLimitModalProps) {
-  const [modalUserGroups, setModalUserGroups] = useState([]);
-  const [shouldFetchUserGroups, setShouldFetchUserGroups] = useState(
-    forSpecificScope === Scope.USER_GROUP
-  );
+  const [modalUserGroups, setModalUserGroups] = useState<
+    { name: string; value: number }[]
+  >([]);
+  const groupScopeAvailable =
+    forSpecificScope === undefined || forSpecificScope === Scope.USER_GROUP;
 
   useEffect(() => {
+    if (!isOpen || !groupScopeAvailable || forSpecificUserGroup !== undefined) {
+      return;
+    }
     const fetchData = async () => {
       try {
-        const response = await fetch("/api/manage/admin/user-group");
-        const data = await response.json();
-        const options = data.map((userGroup: UserGroup) => ({
+        const response = await fetch("/api/manage/user-groups/minimal");
+        if (!response.ok) {
+          throw new Error(response.statusText || "Request failed");
+        }
+        const data = (await response.json()) as Array<{
+          id: number;
+          name: string;
+        }>;
+        const options = data.map((userGroup) => ({
           name: userGroup.name,
           value: userGroup.id,
         }));
         setModalUserGroups(options);
-        setShouldFetchUserGroups(false);
       } catch (error) {
         toast.error(`Failed to fetch user groups: ${error}`);
       }
     };
-
-    if (shouldFetchUserGroups) {
-      fetchData();
-    }
-  }, [shouldFetchUserGroups]);
+    fetchData();
+  }, [isOpen, groupScopeAvailable, forSpecificUserGroup]);
 
   return (
-    <Modal open={isOpen} onOpenChange={() => setIsOpen(false)}>
-      <Modal.Content width="sm" height="sm">
+    <Modal open={isOpen} onOpenChange={setIsOpen}>
+      <Modal.Content width="sm" height="fit">
         <Modal.Header
-          icon={SvgSettings}
-          title="Create a Token Rate Limit"
+          title="Create spending limit"
           onClose={() => setIsOpen(false)}
         />
-        <Formik
+        <Formik<RateLimitFormValues>
           initialValues={{
             enabled: true,
-            period_days: "",
+            period_days: "30",
             token_budget: "",
             cost_budget_dollars: "",
             target_scope: forSpecificScope || Scope.GLOBAL,
@@ -79,36 +407,47 @@ export default function CreateRateLimitModal({
           }}
           validationSchema={Yup.object().shape({
             period_days: Yup.number()
-              .required("Time Window is a required field")
-              .integer("Time Window must be a whole number of days")
-              .min(1, "Time Window must be at least 1 day"),
-            token_budget: Yup.number()
-              // Empty (no token budget) is allowed — a cost-only limit. Without
-              // this, "" coerces to NaN and trips .min(1) even when only a cost
-              // budget is set. Mirrors the cost_budget_dollars transform below.
-              .transform((value, original) =>
-                original === "" ? undefined : value
-              )
-              .min(1, "Token Budget must be at least 1")
-              .test(
-                "budget-required",
-                "Set a token budget and/or a cost budget",
-                (value, context) =>
-                  value != null || context.parent.cost_budget_dollars != null
-              ),
+              .required("Enter a reset period")
+              .integer("Enter a whole number of days")
+              .min(1, "Use at least 1 day"),
             cost_budget_dollars: Yup.number()
-              // Empty (no cost budget) is allowed; a 0 would make the gate fire
-              // on the first request (cost_since >= 0 is always true).
               .transform((value, original) =>
                 original === "" ? undefined : value
               )
-              .moreThan(0, "Cost Budget must be greater than 0"),
+              .moreThan(0, "Cost budget must be greater than 0")
+              .test(
+                "minimum-cents",
+                "Cost budget must be at least $0.01",
+                (value) => value == null || Math.round(value * 100) > 0
+              )
+              .when("token_budget", {
+                is: (value: string | undefined) =>
+                  value === undefined || value === "",
+                then: (schema) =>
+                  schema.required(
+                    "Enter a cost budget, a token budget, or both"
+                  ),
+                otherwise: (schema) => schema.notRequired(),
+              }),
+            token_budget: Yup.number()
+              .transform((value, original) =>
+                original === "" ? undefined : value
+              )
+              .notRequired()
+              .integer("Enter a whole number of tokens")
+              .min(1_000, "Use at least 1,000 tokens")
+              .max(MAX_TOKEN_BUDGET, "The maximum token budget is 1 trillion")
+              .test(
+                "whole-thousands",
+                "Use increments of 1,000 tokens",
+                (value) => value == null || value % 1_000 === 0
+              ),
             target_scope: Yup.string().required(
               "Target Scope is a required field"
             ),
             user_group_id: Yup.string().test(
               "user_group_id",
-              "User Group is a required field",
+              "Select a user group",
               (value, context) => {
                 return (
                   context.parent.target_scope !== "user_group" ||
@@ -119,10 +458,10 @@ export default function CreateRateLimitModal({
             ),
           })}
           onSubmit={async (values) => {
-            // Empty token field → null (cost-only); the gate skips a null budget.
-            // Sending 0 would mean "0-token limit" and block every request.
             const tokenBudget =
-              values.token_budget === "" ? null : Number(values.token_budget);
+              values.token_budget === ""
+                ? null
+                : Number(values.token_budget) / 1_000;
             const costBudgetCents =
               values.cost_budget_dollars === ""
                 ? null
@@ -136,62 +475,170 @@ export default function CreateRateLimitModal({
             );
           }}
         >
-          {({ isSubmitting, values, setFieldValue }) => (
-            <Form className="flex flex-col h-full min-h-0 overflow-visible">
-              <Modal.Body>
-                {!forSpecificScope && (
-                  <SelectorFormField
-                    name="target_scope"
-                    label="Target Scope"
-                    options={[
-                      { name: "Global", value: Scope.GLOBAL },
-                      { name: "User", value: Scope.USER },
-                      { name: "User Group", value: Scope.USER_GROUP },
-                    ]}
-                    includeDefault={false}
-                    onSelect={(selected) => {
-                      setFieldValue("target_scope", selected);
-                      if (selected === Scope.USER_GROUP) {
-                        setShouldFetchUserGroups(true);
-                      }
-                    }}
-                  />
-                )}
-                {forSpecificUserGroup === undefined &&
-                  values.target_scope === Scope.USER_GROUP && (
-                    <SelectorFormField
-                      name="user_group_id"
-                      label="User Group"
-                      options={modalUserGroups}
-                      includeDefault={false}
-                    />
-                  )}
-                <TextFormField
-                  name="period_days"
-                  label="Time Window (UTC Days)"
-                  type="number"
-                  placeholder=""
-                />
-                <TextFormField
-                  name="token_budget"
-                  label="Token Budget (Thousands, optional)"
-                  type="number"
-                  placeholder=""
-                />
-                <TextFormField
-                  name="cost_budget_dollars"
-                  label="Cost Budget (USD per period, optional)"
-                  type="number"
-                  placeholder=""
-                />
-              </Modal.Body>
-              <Modal.Footer>
-                <Button disabled={isSubmitting} type="submit">
-                  Create
-                </Button>
-              </Modal.Footer>
-            </Form>
-          )}
+          {({ isSubmitting, values, setFieldValue, errors, touched }) => {
+            const selectedGroupName = modalUserGroups.find(
+              (group) => String(group.value) === String(values.user_group_id)
+            )?.name;
+            const scopeCaption =
+              values.target_scope === Scope.GLOBAL
+                ? "Everyone in the workspace shares one budget."
+                : values.target_scope === Scope.USER
+                  ? "Every user gets their own budget."
+                  : selectedGroupName
+                    ? `Members of ${selectedGroupName} share one budget.`
+                    : "Members of the chosen group share one budget.";
+
+            return (
+              <Form className="flex min-h-0 flex-1 flex-col overflow-hidden">
+                <Modal.Body>
+                  <Section alignItems="stretch" height="auto" gap={1}>
+                    {!forSpecificScope && (
+                      <InputVertical
+                        title="Applies to"
+                        subDescription={scopeCaption}
+                      >
+                        <div
+                          role="radiogroup"
+                          aria-label="Applies to"
+                          className="grid w-full grid-cols-3 gap-1"
+                        >
+                          {SCOPE_OPTIONS.map((option) =>
+                            option.value === Scope.USER_GROUP &&
+                            forSpecificUserGroup === undefined ? (
+                              <GroupScopeOption
+                                key={option.value}
+                                option={option}
+                                selected={values.target_scope === option.value}
+                                groups={modalUserGroups}
+                                selectedGroupId={values.user_group_id}
+                                onSelectScope={() =>
+                                  void setFieldValue(
+                                    "target_scope",
+                                    option.value
+                                  )
+                                }
+                                onSelectGroup={(groupId) =>
+                                  void setFieldValue("user_group_id", groupId)
+                                }
+                              />
+                            ) : (
+                              <ScopeOption
+                                key={option.value}
+                                option={option}
+                                selected={values.target_scope === option.value}
+                                onSelect={() =>
+                                  void setFieldValue(
+                                    "target_scope",
+                                    option.value
+                                  )
+                                }
+                              />
+                            )
+                          )}
+                        </div>
+                        {touched.user_group_id && errors.user_group_id && (
+                          <InputErrorText>
+                            {errors.user_group_id}
+                          </InputErrorText>
+                        )}
+                      </InputVertical>
+                    )}
+
+                    {forSpecificScope === Scope.USER_GROUP &&
+                      forSpecificUserGroup === undefined && (
+                        <InputVertical
+                          title="User group"
+                          description="Choose which group shares this budget"
+                        >
+                          <GroupPicker
+                            groups={modalUserGroups}
+                            selectedGroupId={values.user_group_id}
+                            onSelectGroup={(groupId) =>
+                              void setFieldValue("user_group_id", groupId)
+                            }
+                          />
+                          {touched.user_group_id && errors.user_group_id && (
+                            <InputErrorText>
+                              {errors.user_group_id}
+                            </InputErrorText>
+                          )}
+                        </InputVertical>
+                      )}
+
+                    <InputVertical
+                      withLabel="cost_budget_dollars"
+                      title="Cost budget"
+                      description="Maximum spend per reset period. Set a cost budget, a token budget, or both."
+                    >
+                      <InputTypeInField
+                        name="cost_budget_dollars"
+                        inputMode="decimal"
+                        prefixText="$"
+                        placeholder="No cost limit"
+                        rightChildren={
+                          <div className="pr-1">
+                            <Text
+                              font="secondary-action"
+                              color="text-03"
+                              nowrap
+                            >
+                              USD
+                            </Text>
+                          </div>
+                        }
+                      />
+                    </InputVertical>
+
+                    <InputVertical
+                      withLabel="token_budget"
+                      title="Token budget"
+                      description="Maximum tokens per reset period"
+                    >
+                      <TokenBudgetField />
+                    </InputVertical>
+
+                    <InputVertical
+                      withLabel="period_days"
+                      title="Reset period"
+                      description="Budgets reset at midnight UTC"
+                    >
+                      <InputTypeInField
+                        name="period_days"
+                        inputMode="numeric"
+                        pattern="[0-9]*"
+                        rightChildren={
+                          <div className="pr-1">
+                            <Text
+                              font="secondary-action"
+                              color="text-03"
+                              nowrap
+                            >
+                              days
+                            </Text>
+                          </div>
+                        }
+                      />
+                    </InputVertical>
+
+                    <LimitSummary groupName={selectedGroupName} />
+                  </Section>
+                </Modal.Body>
+                <Modal.Footer>
+                  <Button
+                    prominence="tertiary"
+                    disabled={isSubmitting}
+                    type="button"
+                    onClick={() => setIsOpen(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button disabled={isSubmitting} type="submit">
+                    Create limit
+                  </Button>
+                </Modal.Footer>
+              </Form>
+            );
+          }}
         </Formik>
       </Modal.Content>
     </Modal>

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -27,8 +27,7 @@ import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 const HOURS_PER_DAY = 24;
 // 1T tokens stored as thousands (1e9) stays well inside the column's int32.
 const MAX_TOKEN_BUDGET = 1_000_000_000_000;
-// Cents must fit the column's Numeric(18,6); $10B keeps *100 well under that cap
-// and away from float precision loss (JSON.stringify(Infinity) serializes to null).
+// Keeps *100 finite: an unbounded value can overflow to Infinity, which JSON.stringify serializes as null.
 const MAX_COST_BUDGET_DOLLARS = 10_000_000_000;
 
 interface RateLimitFormValues {
@@ -40,8 +39,6 @@ interface RateLimitFormValues {
   user_group_id: number | undefined;
 }
 
-// Cards are title-only so the three scopes fit one row; the meaning of the
-// selected scope is carried by the caption beneath them.
 interface ScopeOptionConfig {
   value: Scope;
   icon: IconFunctionComponent;
@@ -153,7 +150,6 @@ interface GroupMenuContentProps {
   onSelectGroup: (groupId: number) => void;
 }
 
-/** Shared group list for every popover that picks a user group. */
 function GroupMenuContent({
   groups,
   selectedGroupId,

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -58,6 +58,43 @@ interface ScopeOptionProps extends React.HTMLAttributes<HTMLElement> {
   ref?: React.Ref<HTMLDivElement>;
 }
 
+function handleRadioOptionKeyDown(
+  event: React.KeyboardEvent<HTMLElement>,
+  onSelect: () => void
+): void {
+  if (event.key === "Enter" || event.key === " ") {
+    event.preventDefault();
+    onSelect();
+    return;
+  }
+  if (
+    event.key !== "ArrowRight" &&
+    event.key !== "ArrowDown" &&
+    event.key !== "ArrowLeft" &&
+    event.key !== "ArrowUp" &&
+    event.key !== "Home" &&
+    event.key !== "End"
+  ) {
+    return;
+  }
+  event.preventDefault();
+  const group = event.currentTarget.closest('[role="radiogroup"]');
+  const options = Array.from(
+    group?.querySelectorAll<HTMLElement>('[role="radio"]') ?? []
+  );
+  const currentIndex = options.indexOf(event.currentTarget);
+  const nextIndex =
+    event.key === "Home"
+      ? 0
+      : event.key === "End"
+        ? options.length - 1
+        : event.key === "ArrowRight" || event.key === "ArrowDown"
+          ? (currentIndex + 1) % options.length
+          : (currentIndex - 1 + options.length) % options.length;
+  options[nextIndex]?.focus();
+  options[nextIndex]?.click();
+}
+
 function ScopeOption({
   option,
   selected,
@@ -82,36 +119,7 @@ function ScopeOption({
       }}
       onKeyDown={(event) => {
         rest.onKeyDown?.(event);
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          onSelect();
-          return;
-        }
-        if (
-          event.key === "ArrowRight" ||
-          event.key === "ArrowDown" ||
-          event.key === "ArrowLeft" ||
-          event.key === "ArrowUp" ||
-          event.key === "Home" ||
-          event.key === "End"
-        ) {
-          event.preventDefault();
-          const group = event.currentTarget.closest('[role="radiogroup"]');
-          const options = Array.from(
-            group?.querySelectorAll<HTMLElement>('[role="radio"]') ?? []
-          );
-          const currentIndex = options.indexOf(event.currentTarget);
-          const nextIndex =
-            event.key === "Home"
-              ? 0
-              : event.key === "End"
-                ? options.length - 1
-                : event.key === "ArrowRight" || event.key === "ArrowDown"
-                  ? (currentIndex + 1) % options.length
-                  : (currentIndex - 1 + options.length) % options.length;
-          options[nextIndex]?.focus();
-          options[nextIndex]?.click();
-        }
+        handleRadioOptionKeyDown(event, onSelect);
       }}
     >
       <ContentAction
@@ -384,6 +392,7 @@ export default function CreateRateLimitModal({
         }));
         setModalUserGroups(options);
       } catch (error) {
+        console.error("Failed to fetch user groups:", error);
         if (!stale) toast.error(`Failed to fetch user groups: ${error}`);
       }
     };

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -250,7 +250,7 @@ function TokenBudgetField() {
   );
 }
 
-function formatDollars(raw: string): string | null {
+function formatDollarBudgetInput(raw: string): string | null {
   const amount = Number(raw);
   if (raw === "" || !Number.isFinite(amount) || amount <= 0) return null;
   return new Intl.NumberFormat("en-US", {
@@ -259,7 +259,7 @@ function formatDollars(raw: string): string | null {
   }).format(amount);
 }
 
-function formatTokens(raw: string): string | null {
+function formatTokenBudgetInput(raw: string): string | null {
   const amount = Number(raw);
   if (raw === "" || !Number.isFinite(amount) || amount <= 0) return null;
   return `${new Intl.NumberFormat("en-US").format(amount)} tokens`;
@@ -307,8 +307,8 @@ function LimitSummary({ groupName }: LimitSummaryProps) {
   if (!Number.isInteger(period) || period < 1) return null;
 
   const budgets = [
-    formatDollars(values.cost_budget_dollars),
-    formatTokens(values.token_budget),
+    formatDollarBudgetInput(values.cost_budget_dollars),
+    formatTokenBudgetInput(values.token_budget),
   ].filter((budget): budget is string => budget !== null);
   if (budgets.length === 0) return null;
 
@@ -366,6 +366,7 @@ export default function CreateRateLimitModal({
     if (!isOpen || !groupScopeAvailable || forSpecificUserGroup !== undefined) {
       return;
     }
+    let stale = false;
     const fetchData = async () => {
       try {
         const response = await fetch("/api/manage/user-groups/minimal");
@@ -376,16 +377,20 @@ export default function CreateRateLimitModal({
           id: number;
           name: string;
         }>;
+        if (stale) return;
         const options = data.map((userGroup) => ({
           name: userGroup.name,
           value: userGroup.id,
         }));
         setModalUserGroups(options);
       } catch (error) {
-        toast.error(`Failed to fetch user groups: ${error}`);
+        if (!stale) toast.error(`Failed to fetch user groups: ${error}`);
       }
     };
     fetchData();
+    return () => {
+      stale = true;
+    };
   }, [isOpen, groupScopeAvailable, forSpecificUserGroup]);
 
   return (

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -27,6 +27,9 @@ import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 const HOURS_PER_DAY = 24;
 // 1T tokens stored as thousands (1e9) stays well inside the column's int32.
 const MAX_TOKEN_BUDGET = 1_000_000_000_000;
+// Cents must fit the column's Numeric(18,6); $10B keeps *100 well under that cap
+// and away from float precision loss (JSON.stringify(Infinity) serializes to null).
+const MAX_COST_BUDGET_DOLLARS = 10_000_000_000;
 
 interface RateLimitFormValues {
   enabled: boolean;
@@ -344,7 +347,7 @@ interface CreateRateLimitModalProps {
     period_hours: number,
     token_budget: number | null,
     cost_budget_cents: number | null,
-    group_id: number
+    group_id?: number
   ) => Promise<void>;
   forSpecificScope?: Scope;
   forSpecificUserGroup?: number;
@@ -415,6 +418,10 @@ export default function CreateRateLimitModal({
                 original === "" ? undefined : value
               )
               .moreThan(0, "Cost budget must be greater than 0")
+              .max(
+                MAX_COST_BUDGET_DOLLARS,
+                `The maximum cost budget is $${new Intl.NumberFormat("en-US").format(MAX_COST_BUDGET_DOLLARS)}`
+              )
               .test(
                 "minimum-cents",
                 "Cost budget must be at least $0.01",
@@ -471,7 +478,9 @@ export default function CreateRateLimitModal({
               Number(values.period_days) * HOURS_PER_DAY,
               tokenBudget,
               costBudgetCents,
-              Number(values.user_group_id)
+              values.target_scope === Scope.USER_GROUP
+                ? Number(values.user_group_id)
+                : undefined
             );
           }}
         >

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -10,7 +10,7 @@ import {
   SelectCard,
   Text,
 } from "@opal/components";
-import React, { useEffect, useState } from "react";
+import React, { useRef } from "react";
 import { Form, Formik, useField, useFormikContext } from "formik";
 import { Scope } from "./types";
 import {
@@ -18,11 +18,12 @@ import {
   InputErrorText,
   InputVertical,
   Section,
-  toast,
 } from "@opal/layouts";
 import { SvgCheck, SvgGlobe, SvgUser, SvgUsers } from "@opal/icons";
 import type { IconFunctionComponent } from "@opal/types";
 import InputTypeInField from "@/refresh-components/form/InputTypeInField";
+import useShareableGroups from "@/hooks/useShareableGroups";
+import { formatCurrency, formatTokenCount } from "@/lib/format";
 
 const HOURS_PER_DAY = 24;
 // 1T tokens stored as thousands (1e9) stays well inside the column's int32.
@@ -48,6 +49,12 @@ const SCOPE_OPTIONS: ScopeOptionConfig[] = [
   { value: Scope.USER, icon: SvgUser, title: "Per user" },
   { value: Scope.USER_GROUP, icon: SvgUsers, title: "User group" },
 ];
+
+function scopeSubject(scope: Scope, groupName?: string): string {
+  if (scope === Scope.GLOBAL) return "Everyone in the workspace";
+  if (scope === Scope.USER) return "Each user";
+  return groupName ? `Members of ${groupName}` : "Members of the chosen group";
+}
 
 interface ScopeOptionProps extends React.HTMLAttributes<HTMLElement> {
   option: ScopeOptionConfig;
@@ -171,11 +178,7 @@ function GroupMenuContent({
                   rounding="md"
                   selectVariant="select-heavy"
                   sizePreset="main-ui"
-                  state={
-                    String(group.value) === String(selectedGroupId)
-                      ? "selected"
-                      : "empty"
-                  }
+                  state={group.value === selectedGroupId ? "selected" : "empty"}
                   title={group.name}
                   variant="section"
                   width="full"
@@ -215,6 +218,7 @@ function GroupScopeOption({
 
 function TokenBudgetField() {
   const [field, meta, helpers] = useField<string>("token_budget");
+  const inputRef = useRef<HTMLInputElement>(null);
   const digits = String(field.value ?? "")
     .replace(/\D/g, "")
     .slice(0, 15);
@@ -224,6 +228,7 @@ function TokenBudgetField() {
 
   return (
     <InputTypeIn
+      ref={inputRef}
       id="token_budget"
       name="token_budget"
       value={formattedValue}
@@ -232,8 +237,33 @@ function TokenBudgetField() {
       maxLength={19}
       placeholder="No token limit"
       onChange={(event) => {
-        const nextDigits = event.target.value.replace(/\D/g, "").slice(0, 15);
+        const input = event.target;
+        const cursorPosition = input.selectionStart ?? input.value.length;
+        const digitsBeforeCursor = input.value
+          .slice(0, cursorPosition)
+          .replace(/\D/g, "").length;
+
+        const nextDigits = input.value.replace(/\D/g, "").slice(0, 15);
         void helpers.setValue(nextDigits);
+
+        const nextFormatted = nextDigits
+          ? new Intl.NumberFormat("en-US").format(Number(nextDigits))
+          : "";
+        let seenDigits = 0;
+        let nextCursorPosition = nextFormatted.length;
+        for (let i = 0; i < nextFormatted.length; i++) {
+          if (/\d/.test(nextFormatted.charAt(i))) seenDigits++;
+          if (seenDigits === digitsBeforeCursor) {
+            nextCursorPosition = i + 1;
+            break;
+          }
+        }
+        requestAnimationFrame(() => {
+          inputRef.current?.setSelectionRange(
+            nextCursorPosition,
+            nextCursorPosition
+          );
+        });
       }}
       onBlur={() => void helpers.setTouched(true)}
       variant={meta.touched && meta.error ? "error" : "primary"}
@@ -251,16 +281,13 @@ function TokenBudgetField() {
 function formatDollars(raw: string): string | null {
   const amount = Number(raw);
   if (raw === "" || !Number.isFinite(amount) || amount <= 0) return null;
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-  }).format(amount);
+  return formatCurrency(amount);
 }
 
 function formatTokens(raw: string): string | null {
   const amount = Number(raw);
   if (raw === "" || !Number.isFinite(amount) || amount <= 0) return null;
-  return `${new Intl.NumberFormat("en-US").format(amount)} tokens`;
+  return `${formatTokenCount(amount)} tokens`;
 }
 
 interface GroupPickerProps {
@@ -274,9 +301,7 @@ function GroupPicker({
   selectedGroupId,
   onSelectGroup,
 }: GroupPickerProps) {
-  const selectedGroup = groups.find(
-    (group) => String(group.value) === String(selectedGroupId)
-  );
+  const selectedGroup = groups.find((group) => group.value === selectedGroupId);
 
   return (
     <Popover>
@@ -313,14 +338,11 @@ function LimitSummary({ groupName }: LimitSummaryProps) {
   const budgetText = budgets.join(" or ");
   const periodText = period === 1 ? "every day" : `every ${period} days`;
 
+  const subject = scopeSubject(values.target_scope, groupName);
   const subjectText =
-    values.target_scope === Scope.GLOBAL
-      ? "Everyone in the workspace shares"
-      : values.target_scope === Scope.USER
-        ? "Each user can spend"
-        : groupName
-          ? `Members of ${groupName} share`
-          : "Group members share";
+    values.target_scope === Scope.USER
+      ? `${subject} can spend`
+      : `${subject} share${values.target_scope === Scope.GLOBAL ? "s" : ""}`;
 
   const summary = `${subjectText} up to ${budgetText} ${periodText}. Usage is blocked until the period resets.`;
 
@@ -354,37 +376,11 @@ export default function CreateRateLimitModal({
   forSpecificScope,
   forSpecificUserGroup,
 }: CreateRateLimitModalProps) {
-  const [modalUserGroups, setModalUserGroups] = useState<
-    { name: string; value: number }[]
-  >([]);
-  const groupScopeAvailable =
-    forSpecificScope === undefined || forSpecificScope === Scope.USER_GROUP;
-
-  useEffect(() => {
-    if (!isOpen || !groupScopeAvailable || forSpecificUserGroup !== undefined) {
-      return;
-    }
-    const fetchData = async () => {
-      try {
-        const response = await fetch("/api/manage/user-groups/minimal");
-        if (!response.ok) {
-          throw new Error(response.statusText || "Request failed");
-        }
-        const data = (await response.json()) as Array<{
-          id: number;
-          name: string;
-        }>;
-        const options = data.map((userGroup) => ({
-          name: userGroup.name,
-          value: userGroup.id,
-        }));
-        setModalUserGroups(options);
-      } catch (error) {
-        toast.error(`Failed to fetch user groups: ${error}`);
-      }
-    };
-    fetchData();
-  }, [isOpen, groupScopeAvailable, forSpecificUserGroup]);
+  const { data: shareableGroupsData } = useShareableGroups();
+  const modalUserGroups = (shareableGroupsData ?? []).map((userGroup) => ({
+    name: userGroup.name,
+    value: userGroup.id,
+  }));
 
   return (
     <Modal open={isOpen} onOpenChange={setIsOpen}>
@@ -468,22 +464,26 @@ export default function CreateRateLimitModal({
               Number(values.period_days) * HOURS_PER_DAY,
               tokenBudget,
               costBudgetCents,
-              Number(values.user_group_id)
+              values.user_group_id === undefined
+                ? -1
+                : Number(values.user_group_id)
             );
           }}
         >
           {({ isSubmitting, values, setFieldValue, errors, touched }) => {
             const selectedGroupName = modalUserGroups.find(
-              (group) => String(group.value) === String(values.user_group_id)
+              (group) => group.value === values.user_group_id
             )?.name;
+            const scopeSubjectLabel = scopeSubject(
+              values.target_scope,
+              selectedGroupName
+            );
             const scopeCaption =
-              values.target_scope === Scope.GLOBAL
-                ? "Everyone in the workspace shares one budget."
-                : values.target_scope === Scope.USER
-                  ? "Every user gets their own budget."
-                  : selectedGroupName
-                    ? `Members of ${selectedGroupName} share one budget.`
-                    : "Members of the chosen group share one budget.";
+              values.target_scope === Scope.USER
+                ? `${scopeSubjectLabel} gets their own budget.`
+                : `${scopeSubjectLabel} share${
+                    values.target_scope === Scope.GLOBAL ? "s" : ""
+                  } one budget.`;
 
             return (
               <Form className="flex min-h-0 flex-1 flex-col overflow-hidden">

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -37,8 +37,6 @@ interface RateLimitFormValues {
   user_group_id: number | undefined;
 }
 
-// Cards are title-only so the three scopes fit one row; the meaning of the
-// selected scope is carried by the caption beneath them.
 interface ScopeOptionConfig {
   value: Scope;
   icon: IconFunctionComponent;
@@ -150,7 +148,6 @@ interface GroupMenuContentProps {
   onSelectGroup: (groupId: number) => void;
 }
 
-/** Shared group list for every popover that picks a user group. */
 function GroupMenuContent({
   groups,
   selectedGroupId,

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.test.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, setupUser, waitFor } from "@tests/setup/test-utils";
-import { formatPeriod } from "@/app/admin/token-rate-limits/TokenRateLimitTables";
 import { TokenRateLimitTable } from "@/app/admin/token-rate-limits/TokenRateLimitTables";
 import type { TokenRateLimitDisplay } from "@/app/admin/token-rate-limits/types";
 
@@ -40,11 +39,35 @@ function tokenRateLimit(
 }
 
 test.each([
-  ["token-only", tokenRateLimit(24, 1, null), "1 UTC day"],
-  ["cost-only", tokenRateLimit(24, null, 100), "1 UTC day"],
-  ["dual", tokenRateLimit(48, 1, 100), "2 UTC days"],
-])("%s limits display UTC-day windows", (_name, limit, expected) => {
-  expect(formatPeriod(limit)).toBe(expected);
+  [
+    "token-only",
+    tokenRateLimit(24, 1, null),
+    "Up to 1,000 tokens",
+    "Resets every day at midnight UTC",
+  ],
+  [
+    "cost-only",
+    tokenRateLimit(24, null, 100),
+    "Up to $1.00",
+    "Resets every day at midnight UTC",
+  ],
+  [
+    "dual",
+    tokenRateLimit(48, 1, 100),
+    "Up to $1.00 or 1,000 tokens",
+    "Resets every 2 days at midnight UTC",
+  ],
+])("%s limits render budget and cadence", (_name, limit, budget, cadence) => {
+  render(
+    <TokenRateLimitTable
+      tokenRateLimits={[limit]}
+      fetchUrl="/api/test-limits"
+      isAdmin
+    />
+  );
+
+  expect(screen.getByText(budget)).toBeInTheDocument();
+  expect(screen.getByText(cadence)).toBeInTheDocument();
 });
 
 describe("token rate limit mutation failures", () => {
@@ -63,7 +86,7 @@ describe("token rate limit mutation failures", () => {
       />
     );
 
-    await user.click(screen.getByRole("checkbox"));
+    await user.click(screen.getByRole("switch"));
 
     await waitFor(() =>
       expect(mockToastError).toHaveBeenCalledWith("Update failed")
@@ -82,7 +105,7 @@ describe("token rate limit mutation failures", () => {
       />
     );
 
-    await user.click(screen.getByRole("button"));
+    await user.click(screen.getByRole("button", { name: /^Delete Up to/ }));
 
     await waitFor(() =>
       expect(mockToastError).toHaveBeenCalledWith("Delete failed")

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
@@ -7,6 +7,7 @@ import { errorHandlingFetcher } from "@/lib/fetcher";
 import useSWR, { mutate } from "swr";
 import { Button, Switch, Text } from "@opal/components";
 import { SvgTrash, SvgUsers, SvgWallet } from "@opal/icons";
+import { formatCurrencyFromCents, formatTokenCount } from "@/lib/format";
 
 const HOURS_PER_DAY = 24;
 const UPDATE_ERROR_MESSAGE = "Failed to update token rate limit";
@@ -15,17 +16,10 @@ const DELETE_ERROR_MESSAGE = "Failed to delete token rate limit";
 function formatBudget(limit: TokenRateLimitDisplay): string {
   const parts: string[] = [];
   if (limit.cost_budget_cents != null) {
-    parts.push(
-      new Intl.NumberFormat("en-US", {
-        style: "currency",
-        currency: "USD",
-      }).format(limit.cost_budget_cents / 100)
-    );
+    parts.push(formatCurrencyFromCents(limit.cost_budget_cents));
   }
   if (limit.token_budget != null) {
-    parts.push(
-      `${new Intl.NumberFormat("en-US").format(limit.token_budget * 1000)} tokens`
-    );
+    parts.push(`${formatTokenCount(limit.token_budget * 1000)} tokens`);
   }
   if (parts.length === 0) return "No budget set";
   return `Up to ${parts.join(" or ")}`;

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
@@ -1,37 +1,97 @@
 "use client";
 
-import {
-  Table,
-  TableHead,
-  TableRow,
-  TableBody,
-  TableCell,
-} from "@/components/ui/table";
-import Title from "@/components/ui/title";
-import { DeleteButton } from "@/components/DeleteButton";
 import { deleteTokenRateLimit, updateTokenRateLimit } from "./lib";
-import { PageLoader, toast } from "@opal/layouts";
+import { ContentAction, PageLoader, Section, toast } from "@opal/layouts";
 import { TokenRateLimitDisplay } from "./types";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import useSWR, { mutate } from "swr";
-import { Checkbox } from "@opal/components";
-import { TableHeader } from "@/components/ui/table";
-import { Text } from "@opal/components";
-import { Spacer } from "@opal/components";
+import { Button, Switch, Text } from "@opal/components";
+import { SvgTrash, SvgUsers, SvgWallet } from "@opal/icons";
 
 const HOURS_PER_DAY = 24;
-const UTC_DAY_LABEL = "UTC day";
 const UPDATE_ERROR_MESSAGE = "Failed to update token rate limit";
 const DELETE_ERROR_MESSAGE = "Failed to delete token rate limit";
 
-export function formatPeriod(tokenRateLimit: TokenRateLimitDisplay): string {
-  const days = tokenRateLimit.period_hours / HOURS_PER_DAY;
-  return `${days} ${UTC_DAY_LABEL}${days === 1 ? "" : "s"}`;
+function formatBudget(limit: TokenRateLimitDisplay): string {
+  const parts: string[] = [];
+  if (limit.cost_budget_cents != null) {
+    parts.push(
+      new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+      }).format(limit.cost_budget_cents / 100)
+    );
+  }
+  if (limit.token_budget != null) {
+    parts.push(
+      `${new Intl.NumberFormat("en-US").format(limit.token_budget * 1000)} tokens`
+    );
+  }
+  if (parts.length === 0) return "No budget set";
+  return `Up to ${parts.join(" or ")}`;
+}
+
+function formatCadence(limit: TokenRateLimitDisplay): string {
+  const days = limit.period_hours / HOURS_PER_DAY;
+  const period = days === 1 ? "every day" : `every ${days} days`;
+  return `Resets ${period} at midnight UTC`;
+}
+
+interface LimitRowProps {
+  limit: TokenRateLimitDisplay;
+  isAdmin: boolean;
+  onToggle: (id: number) => void;
+  onDelete: (id: number) => void;
+}
+
+function LimitRow({ limit, isAdmin, onToggle, onDelete }: LimitRowProps) {
+  const limitLabel = `${formatBudget(limit)}, ${formatCadence(limit)}`;
+
+  return (
+    <div className="rounded-12 border border-border-01 bg-background-neutral-00">
+      <ContentAction
+        sizePreset="main-ui"
+        variant="section"
+        icon={limit.group_name !== undefined ? SvgUsers : SvgWallet}
+        title={formatBudget(limit)}
+        description={formatCadence(limit)}
+        tag={
+          limit.group_name !== undefined
+            ? { title: limit.group_name }
+            : undefined
+        }
+        padding="md"
+        center
+        rightChildren={
+          <div className="flex items-center gap-2">
+            <Switch
+              checked={limit.enabled}
+              disabled={!isAdmin}
+              onCheckedChange={() => onToggle(limit.token_id)}
+              aria-label={
+                limit.enabled ? `Disable ${limitLabel}` : `Enable ${limitLabel}`
+              }
+            />
+            {isAdmin && (
+              <Button
+                variant="danger"
+                prominence="tertiary"
+                icon={SvgTrash}
+                size="sm"
+                tooltip="Delete limit"
+                aria-label={`Delete ${limitLabel}`}
+                onClick={() => onDelete(limit.token_id)}
+              />
+            )}
+          </div>
+        }
+      />
+    </div>
+  );
 }
 
 type TokenRateLimitTableArgs = {
   tokenRateLimits: TokenRateLimitDisplay[];
-  title?: string;
   description?: string;
   fetchUrl: string;
   hideHeading?: boolean;
@@ -40,17 +100,11 @@ type TokenRateLimitTableArgs = {
 
 export const TokenRateLimitTable = ({
   tokenRateLimits,
-  title,
   description,
   fetchUrl,
   hideHeading,
   isAdmin,
 }: TokenRateLimitTableArgs) => {
-  const shouldRenderGroupName = () =>
-    tokenRateLimits.length > 0 &&
-    tokenRateLimits[0] !== undefined &&
-    tokenRateLimits[0].group_name !== undefined;
-
   const handleEnabledChange = async (id: number) => {
     const tokenRateLimit = tokenRateLimits.find(
       (tokenRateLimit) => tokenRateLimit.token_id === id
@@ -86,129 +140,42 @@ export const TokenRateLimitTable = ({
     }
   };
 
-  if (tokenRateLimits.length === 0) {
-    return (
-      <div className="w-full">
-        {!hideHeading && title && <Title>{title}</Title>}
-        {!hideHeading && description && (
-          <>
-            <Spacer rem={0.5} />
-            <Text as="p">{description}</Text>
-            <Spacer rem={0.5} />
-          </>
-        )}
-        {!hideHeading && <Spacer rem={2} />}
-        <Text as="p">No token rate limits set!</Text>
-        {!hideHeading && <Spacer rem={2} />}
-      </div>
-    );
-  }
-
   return (
-    <div className="w-full">
-      {!hideHeading && title && <Title>{title}</Title>}
+    <Section alignItems="stretch" height="auto" gap={0.5}>
       {!hideHeading && description && (
-        <>
-          <Spacer rem={0.5} />
-          <Text as="p">{description}</Text>
-          <Spacer rem={0.5} />
-        </>
+        <Text font="secondary-body" color="text-03" as="p">
+          {description}
+        </Text>
       )}
-      <Table
-        className={`overflow-visible ${
-          !hideHeading && "my-8"
-        } [&_td]:text-center [&_th]:text-center`}
-      >
-        <TableHeader>
-          <TableRow>
-            <TableHead>Enabled</TableHead>
-            {shouldRenderGroupName() && <TableHead>Group Name</TableHead>}
-            <TableHead>Time Window</TableHead>
-            <TableHead>Token Budget</TableHead>
-            <TableHead>Cost Budget (USD)</TableHead>
-            {isAdmin && <TableHead>Delete</TableHead>}
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {tokenRateLimits.map((tokenRateLimit) => {
-            return (
-              <TableRow key={tokenRateLimit.token_id}>
-                <TableCell>
-                  <div className="flex justify-center">
-                    <div
-                      onClick={
-                        isAdmin
-                          ? () => handleEnabledChange(tokenRateLimit.token_id)
-                          : undefined
-                      }
-                      className={`px-1 py-0.5 rounded select-none w-24 ${
-                        isAdmin
-                          ? "hover:bg-accent-background cursor-pointer"
-                          : "opacity-50"
-                      }`}
-                    >
-                      <div className="flex items-center justify-center">
-                        <Checkbox
-                          checked={tokenRateLimit.enabled}
-                          onCheckedChange={
-                            isAdmin
-                              ? () =>
-                                  handleEnabledChange(tokenRateLimit.token_id)
-                              : undefined
-                          }
-                        />
-                        <p className="ml-2">
-                          {tokenRateLimit.enabled ? "Enabled" : "Disabled"}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </TableCell>
-                {shouldRenderGroupName() && (
-                  <TableCell className="font-bold text-text-darker">
-                    {tokenRateLimit.group_name}
-                  </TableCell>
-                )}
-                <TableCell>{formatPeriod(tokenRateLimit)}</TableCell>
-                <TableCell>
-                  {tokenRateLimit.token_budget != null
-                    ? (tokenRateLimit.token_budget * 1000).toLocaleString() +
-                      " tokens"
-                    : "—"}
-                </TableCell>
-                <TableCell>
-                  {tokenRateLimit.cost_budget_cents != null
-                    ? "$" + (tokenRateLimit.cost_budget_cents / 100).toFixed(2)
-                    : "—"}
-                </TableCell>
-                {isAdmin && (
-                  <TableCell>
-                    <div className="flex justify-center">
-                      <DeleteButton
-                        onClick={() => handleDelete(tokenRateLimit.token_id)}
-                      />
-                    </div>
-                  </TableCell>
-                )}
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </div>
+      {tokenRateLimits.length === 0 ? (
+        <div className="rounded-12 border border-dashed border-border-02 p-4">
+          <Text font="secondary-body" color="text-03" as="p">
+            No limits yet. Create a spending limit to cap usage.
+          </Text>
+        </div>
+      ) : (
+        tokenRateLimits.map((tokenRateLimit) => (
+          <LimitRow
+            key={tokenRateLimit.token_id}
+            limit={tokenRateLimit}
+            isAdmin={isAdmin}
+            onToggle={handleEnabledChange}
+            onDelete={handleDelete}
+          />
+        ))
+      )}
+    </Section>
   );
 };
 
 export const GenericTokenRateLimitTable = ({
   fetchUrl,
-  title,
   description,
   hideHeading,
   responseMapper,
   isAdmin = true,
 }: {
   fetchUrl: string;
-  title?: string;
   description?: string;
   hideHeading?: boolean;
   responseMapper?: (data: any) => TokenRateLimitDisplay[];
@@ -236,7 +203,6 @@ export const GenericTokenRateLimitTable = ({
     <TokenRateLimitTable
       tokenRateLimits={processedData ?? []}
       fetchUrl={fetchUrl}
-      title={title}
       description={description}
       hideHeading={hideHeading}
       isAdmin={isAdmin}

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitsPanel.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitsPanel.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import SimpleTabs from "@/refresh-components/SimpleTabs";
+import { Button, Text } from "@opal/components";
+import { toast } from "@opal/layouts";
+import { useState } from "react";
+import { mutate } from "swr";
+import { useTierAtLeast } from "@/hooks/useTierAtLeast";
+import { Tier } from "@/lib/settings/types";
+import { SWR_KEYS } from "@/lib/swr-keys";
+import { Section } from "@/layouts/general-layouts";
+import { SvgGlobe, SvgPlusCircle, SvgUser, SvgUsers } from "@opal/icons";
+import {
+  insertGlobalTokenRateLimit,
+  insertGroupTokenRateLimit,
+  insertUserTokenRateLimit,
+} from "./lib";
+import { Scope, TokenRateLimit } from "./types";
+import { GenericTokenRateLimitTable } from "./TokenRateLimitTables";
+import CreateRateLimitModal from "./CreateRateLimitModal";
+
+const GLOBAL_TOKEN_FETCH_URL = SWR_KEYS.globalTokenRateLimits;
+const USER_TOKEN_FETCH_URL = SWR_KEYS.userTokenRateLimits;
+const USER_GROUP_FETCH_URL = SWR_KEYS.userGroupTokenRateLimits;
+
+const GLOBAL_DESCRIPTION =
+  "Global limits apply to all users, user groups, and API keys. When the global limit is reached, no more tokens can be spent.";
+const USER_DESCRIPTION =
+  "User limits apply to each user individually. When a user reaches a limit, they are temporarily blocked from spending tokens.";
+const USER_GROUP_DESCRIPTION =
+  "Group limits apply to all users in a group. If a user belongs to multiple groups, the most permissive limit applies.";
+const CREATE_ERROR_MESSAGE = "Failed to create spending limit";
+
+async function createTokenRateLimit(
+  targetScope: Scope,
+  periodHours: number,
+  tokenBudget: number | null,
+  costBudgetCents: number | null,
+  groupId: number
+): Promise<void> {
+  const tokenRateLimitArgs = {
+    enabled: true,
+    token_budget: tokenBudget,
+    period_hours: periodHours,
+    cost_budget_cents: costBudgetCents,
+  };
+
+  if (targetScope === Scope.GLOBAL) {
+    await insertGlobalTokenRateLimit(tokenRateLimitArgs);
+  } else if (targetScope === Scope.USER) {
+    await insertUserTokenRateLimit(tokenRateLimitArgs);
+  } else if (targetScope === Scope.USER_GROUP) {
+    await insertGroupTokenRateLimit(tokenRateLimitArgs, groupId);
+  } else {
+    throw new Error(`Invalid target scope: ${targetScope}`);
+  }
+}
+
+interface TokenRateLimitsPanelProps {
+  embedded?: boolean;
+}
+
+export default function TokenRateLimitsPanel({
+  embedded = false,
+}: TokenRateLimitsPanelProps) {
+  const [tabIndex, setTabIndex] = useState(0);
+  const [modalIsOpen, setModalIsOpen] = useState(false);
+  const enterpriseTier = useTierAtLeast(Tier.ENTERPRISE);
+
+  function updateTable(targetScope: Scope) {
+    if (targetScope === Scope.GLOBAL) {
+      mutate(GLOBAL_TOKEN_FETCH_URL);
+      setTabIndex(0);
+    } else if (targetScope === Scope.USER) {
+      mutate(USER_TOKEN_FETCH_URL);
+      setTabIndex(1);
+    } else if (targetScope === Scope.USER_GROUP) {
+      mutate(USER_GROUP_FETCH_URL);
+      setTabIndex(2);
+    }
+  }
+
+  async function handleSubmit(
+    targetScope: Scope,
+    periodHours: number,
+    tokenBudget: number | null,
+    costBudgetCents: number | null,
+    groupId: number = -1
+  ): Promise<void> {
+    try {
+      await createTokenRateLimit(
+        targetScope,
+        periodHours,
+        tokenBudget,
+        costBudgetCents,
+        groupId
+      );
+      setModalIsOpen(false);
+      toast.success("Spending limit created!");
+      updateTable(targetScope);
+    } catch (error) {
+      console.error("Failed to create spending limit:", error);
+      toast.error(
+        error instanceof Error ? error.message : CREATE_ERROR_MESSAGE
+      );
+    }
+  }
+
+  return (
+    <Section alignItems="stretch" justifyContent="start" height="auto">
+      {embedded ? (
+        <Section gap={0.25} alignItems="start" justifyContent="start">
+          <Text font="heading-h3">Manage spending limits</Text>
+          <Text font="secondary-body" color="text-03">
+            Set guardrails for workspace, user, and group usage. Limits can be
+            enabled or disabled without deleting their configuration.
+          </Text>
+        </Section>
+      ) : (
+        <>
+          <Text as="p">
+            Spending limits help you control how many tokens can be spent in a
+            given time period.
+          </Text>
+          <ul className="list-disc ml-4">
+            <li>
+              <Text as="p">
+                Set a workspace-wide limit for your team&apos;s overall spend.
+              </Text>
+            </li>
+            {enterpriseTier && (
+              <>
+                <li>
+                  <Text as="p">
+                    Set limits for users so no single user can spend too much.
+                  </Text>
+                </li>
+                <li>
+                  <Text as="p">
+                    Set limits for user groups to control spend for teams.
+                  </Text>
+                </li>
+              </>
+            )}
+            <li>
+              <Text as="p">Enable and disable limits as needed.</Text>
+            </li>
+          </ul>
+        </>
+      )}
+
+      <Button
+        icon={SvgPlusCircle}
+        prominence="secondary"
+        onClick={() => setModalIsOpen(true)}
+      >
+        Create spending limit
+      </Button>
+
+      {enterpriseTier ? (
+        <SimpleTabs
+          tabs={{
+            "0": {
+              name: "Global",
+              icon: SvgGlobe,
+              content: (
+                <GenericTokenRateLimitTable
+                  fetchUrl={GLOBAL_TOKEN_FETCH_URL}
+                  description={GLOBAL_DESCRIPTION}
+                />
+              ),
+            },
+            "1": {
+              name: "Users",
+              icon: SvgUser,
+              content: (
+                <GenericTokenRateLimitTable
+                  fetchUrl={USER_TOKEN_FETCH_URL}
+                  description={USER_DESCRIPTION}
+                />
+              ),
+            },
+            "2": {
+              name: "Groups",
+              icon: SvgUsers,
+              content: (
+                <GenericTokenRateLimitTable
+                  fetchUrl={USER_GROUP_FETCH_URL}
+                  description={USER_GROUP_DESCRIPTION}
+                  responseMapper={(data: Record<string, TokenRateLimit[]>) =>
+                    Object.entries(data).flatMap(([groupName, elements]) =>
+                      elements.map((element) => ({
+                        ...element,
+                        group_name: groupName,
+                      }))
+                    )
+                  }
+                />
+              ),
+            },
+          }}
+          value={tabIndex.toString()}
+          onValueChange={(value) => setTabIndex(parseInt(value, 10))}
+        />
+      ) : (
+        <GenericTokenRateLimitTable
+          fetchUrl={GLOBAL_TOKEN_FETCH_URL}
+          description={GLOBAL_DESCRIPTION}
+        />
+      )}
+
+      <CreateRateLimitModal
+        isOpen={modalIsOpen}
+        setIsOpen={() => setModalIsOpen(false)}
+        onSubmit={handleSubmit}
+        forSpecificScope={enterpriseTier ? undefined : Scope.GLOBAL}
+      />
+    </Section>
+  );
+}

--- a/web/src/app/admin/token-rate-limits/page.tsx
+++ b/web/src/app/admin/token-rate-limits/page.tsx
@@ -1,234 +1,24 @@
-"use client";
-
-import SimpleTabs from "@/refresh-components/SimpleTabs";
-import { SettingsLayouts, toast } from "@opal/layouts";
-import { Button, Text } from "@opal/components";
-import { useState } from "react";
-import {
-  insertGlobalTokenRateLimit,
-  insertGroupTokenRateLimit,
-  insertUserTokenRateLimit,
-} from "./lib";
-import { Scope, TokenRateLimit } from "./types";
-import { GenericTokenRateLimitTable } from "./TokenRateLimitTables";
-import { mutate } from "swr";
-import { SWR_KEYS } from "@/lib/swr-keys";
-import CreateRateLimitModal from "./CreateRateLimitModal";
-import { useTierAtLeast } from "@/hooks/useTierAtLeast";
-import { Tier } from "@/lib/settings/types";
-import { SvgGlobe, SvgPlusCircle, SvgUser, SvgUsers } from "@opal/icons";
-import { Section } from "@/layouts/general-layouts";
+import { redirect } from "next/navigation";
+import type { Route } from "next";
+import { EE_ENABLED } from "@/lib/constants";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
-
-const route = ADMIN_ROUTES.TOKEN_RATE_LIMITS;
-const GLOBAL_TOKEN_FETCH_URL = SWR_KEYS.globalTokenRateLimits;
-const USER_TOKEN_FETCH_URL = SWR_KEYS.userTokenRateLimits;
-const USER_GROUP_FETCH_URL = SWR_KEYS.userGroupTokenRateLimits;
-
-const GLOBAL_DESCRIPTION =
-  "Global rate limits apply to all users, user groups, and API keys. When the global \
-  rate limit is reached, no more tokens can be spent.";
-const USER_DESCRIPTION =
-  "User rate limits apply to individual users. When a user reaches a limit, they will \
-  be temporarily blocked from spending tokens.";
-const USER_GROUP_DESCRIPTION =
-  "User group rate limits apply to all users in a group. When a group reaches a limit, \
-  all users in the group will be temporarily blocked from spending tokens, regardless \
-  of their individual limits. If a user is in multiple groups, the most lenient limit \
-  will apply.";
-const CREATE_ERROR_MESSAGE = "Failed to create token rate limit";
-
-const handleCreateTokenRateLimit = async (
-  target_scope: Scope,
-  period_hours: number,
-  token_budget: number | null,
-  cost_budget_cents: number | null,
-  group_id: number = -1
-): Promise<void> => {
-  const tokenRateLimitArgs = {
-    enabled: true,
-    token_budget: token_budget,
-    period_hours: period_hours,
-    cost_budget_cents: cost_budget_cents,
-  };
-
-  if (target_scope === Scope.GLOBAL) {
-    await insertGlobalTokenRateLimit(tokenRateLimitArgs);
-    return;
-  }
-
-  if (target_scope === Scope.USER) {
-    await insertUserTokenRateLimit(tokenRateLimitArgs);
-    return;
-  }
-
-  if (target_scope === Scope.USER_GROUP) {
-    await insertGroupTokenRateLimit(tokenRateLimitArgs, group_id);
-    return;
-  }
-
-  throw new Error(`Invalid target_scope: ${target_scope}`);
-};
-
-function Main() {
-  const [tabIndex, setTabIndex] = useState(0);
-  const [modalIsOpen, setModalIsOpen] = useState(false);
-
-  const enterpriseTier = useTierAtLeast(Tier.ENTERPRISE);
-
-  const updateTable = (target_scope: Scope) => {
-    if (target_scope === Scope.GLOBAL) {
-      mutate(GLOBAL_TOKEN_FETCH_URL);
-      setTabIndex(0);
-    } else if (target_scope === Scope.USER) {
-      mutate(USER_TOKEN_FETCH_URL);
-      setTabIndex(1);
-    } else if (target_scope === Scope.USER_GROUP) {
-      mutate(USER_GROUP_FETCH_URL);
-      setTabIndex(2);
-    }
-  };
-
-  const handleSubmit = async (
-    target_scope: Scope,
-    period_hours: number,
-    token_budget: number | null,
-    cost_budget_cents: number | null,
-    group_id: number = -1
-  ): Promise<void> => {
-    try {
-      await handleCreateTokenRateLimit(
-        target_scope,
-        period_hours,
-        token_budget,
-        cost_budget_cents,
-        group_id
-      );
-      setModalIsOpen(false);
-      toast.success("Token rate limit created!");
-      updateTable(target_scope);
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : CREATE_ERROR_MESSAGE
-      );
-    }
-  };
-
-  return (
-    <Section alignItems="stretch" justifyContent="start" height="auto">
-      <Text as="p">
-        Token rate limits enable you control how many tokens can be spent in a
-        given time period. With token rate limits, you can:
-      </Text>
-
-      <ul className="list-disc ml-4">
-        <li>
-          <Text as="p">
-            Set a global rate limit to control your team&apos;s overall token
-            spend.
-          </Text>
-        </li>
-        {enterpriseTier && (
-          <>
-            <li>
-              <Text as="p">
-                Set rate limits for users to ensure that no single user can
-                spend too many tokens.
-              </Text>
-            </li>
-            <li>
-              <Text as="p">
-                Set rate limits for user groups to control token spend for your
-                teams.
-              </Text>
-            </li>
-          </>
-        )}
-        <li>
-          <Text as="p">Enable and disable rate limits on the fly.</Text>
-        </li>
-      </ul>
-
-      <Button
-        icon={SvgPlusCircle}
-        prominence="secondary"
-        onClick={() => setModalIsOpen(true)}
-      >
-        Create a Token Rate Limit
-      </Button>
-
-      {enterpriseTier ? (
-        <SimpleTabs
-          tabs={{
-            "0": {
-              name: "Global",
-              icon: SvgGlobe,
-              content: (
-                <GenericTokenRateLimitTable
-                  fetchUrl={GLOBAL_TOKEN_FETCH_URL}
-                  title={"Global Token Rate Limits"}
-                  description={GLOBAL_DESCRIPTION}
-                />
-              ),
-            },
-            "1": {
-              name: "User",
-              icon: SvgUser,
-              content: (
-                <GenericTokenRateLimitTable
-                  fetchUrl={USER_TOKEN_FETCH_URL}
-                  title={"User Token Rate Limits"}
-                  description={USER_DESCRIPTION}
-                />
-              ),
-            },
-            "2": {
-              name: "User Groups",
-              icon: SvgUsers,
-              content: (
-                <GenericTokenRateLimitTable
-                  fetchUrl={USER_GROUP_FETCH_URL}
-                  title={"User Group Token Rate Limits"}
-                  description={USER_GROUP_DESCRIPTION}
-                  responseMapper={(data: Record<string, TokenRateLimit[]>) =>
-                    Object.entries(data).flatMap(([group_name, elements]) =>
-                      elements.map((element) => ({
-                        ...element,
-                        group_name,
-                      }))
-                    )
-                  }
-                />
-              ),
-            },
-          }}
-          value={tabIndex.toString()}
-          onValueChange={(val) => setTabIndex(parseInt(val))}
-        />
-      ) : (
-        <GenericTokenRateLimitTable
-          fetchUrl={GLOBAL_TOKEN_FETCH_URL}
-          title={"Global Token Rate Limits"}
-          description={GLOBAL_DESCRIPTION}
-        />
-      )}
-
-      <CreateRateLimitModal
-        isOpen={modalIsOpen}
-        setIsOpen={() => setModalIsOpen(false)}
-        onSubmit={handleSubmit}
-        forSpecificScope={enterpriseTier ? undefined : Scope.GLOBAL}
-      />
-    </Section>
-  );
-}
+import { SettingsLayouts } from "@opal/layouts";
+import TokenRateLimitsPanel from "./TokenRateLimitsPanel";
 
 export default function Page() {
+  if (EE_ENABLED) {
+    redirect(ADMIN_ROUTES.USAGE.path as Route);
+  }
+
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header title={route.title} icon={route.icon} divider />
+      <SettingsLayouts.Header
+        title={ADMIN_ROUTES.TOKEN_RATE_LIMITS.title}
+        icon={ADMIN_ROUTES.TOKEN_RATE_LIMITS.icon}
+        divider
+      />
       <SettingsLayouts.Body>
-        <Main />
+        <TokenRateLimitsPanel />
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>
   );

--- a/web/src/app/admin/token-rate-limits/page.tsx
+++ b/web/src/app/admin/token-rate-limits/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { redirect } from "next/navigation";
 import type { Route } from "next";
 import { EE_ENABLED } from "@/lib/constants";

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -24,17 +24,13 @@ import {
   type UsagePerDayByModel,
   type ModelPrice,
 } from "@/app/app/settings/usage/lib";
+import {
+  formatCurrencyFromCents as formatDollars,
+  formatTokenCount as formatTokens,
+} from "@/lib/format";
 
 const DAYS_OPTIONS = ["7", "30"] as const;
 const DEFAULT_DAYS = 30;
-
-function formatDollars(cents: number): string {
-  return `$${(cents / 100).toFixed(2)}`;
-}
-
-function formatTokens(tokens: number): string {
-  return tokens.toLocaleString();
-}
 
 interface WindowCostSectionProps {
   windowCostCents: number;

--- a/web/src/app/ee/admin/performance/usage/page.tsx
+++ b/web/src/app/ee/admin/performance/usage/page.tsx
@@ -12,6 +12,7 @@ import { Divider } from "@opal/components";
 import { useAdminAgents } from "@/lib/agents/hooks";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { SettingsLayouts } from "@opal/layouts";
+import TokenRateLimitsPanel from "@/app/admin/token-rate-limits/TokenRateLimitsPanel";
 
 const route = ADMIN_ROUTES.USAGE;
 
@@ -38,6 +39,8 @@ export default function AnalyticsPage() {
         <PerUserUsagePanel />
         <Divider />
         <UsageReports />
+        <Divider />
+        <TokenRateLimitsPanel embedded />
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>
   );

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,0 +1,14 @@
+export function formatCurrency(amountDollars: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(amountDollars);
+}
+
+export function formatCurrencyFromCents(cents: number): string {
+  return formatCurrency(cents / 100);
+}
+
+export function formatTokenCount(tokens: number): string {
+  return new Intl.NumberFormat("en-US").format(tokens);
+}


### PR DESCRIPTION
## Description

Frontend PR 2 of 2, split out of #13752. Stacked on #13783 (the `CreateRateLimitModal` redesign) since this panel renders that modal as its "create" entry point.

- **`TokenRateLimitsPanel.tsx` (new)** — extracts the page body (tab group + "Create a Token Rate Limit" entry point) out of `page.tsx` into a standalone, reusable component. It's usable on its own on the Community-edition page today; embedding it into the Enterprise usage workspace is a small follow-up once that page's ongoing restructuring (#13769/#13770) settles — deliberately not included here to avoid landing on top of in-flight, unrelated work.
- **`TokenRateLimitTables.tsx` reworked** from a plain HTML table into an Opal card-list matching the rest of the usage admin surface: a `Switch` for enabled/disabled, a quiet trash action, and per-limit budget/reset copy ("Up to $110.00 · Resets every 30 days at midnight UTC") instead of raw column values.
- **`page.tsx`** is now a thin wrapper rendering `TokenRateLimitsPanel`.

**Bug found and fixed while verifying in a real browser** (not caught by typecheck or lint): `page.tsx` was a Server Component passing `icon={ADMIN_ROUTES.TOKEN_RATE_LIMITS.icon}` into `SettingsLayouts.Header`, which is a Client Component — this throws `Functions cannot be passed directly to Client Components` at runtime. Every other `admin/*/page.tsx` using this exact pattern is already marked `"use client"`; this one was missed when the panel was extracted. Fixed by adding the directive (see the second commit).

## How Has This Been Tested?

- `TokenRateLimitTables.test.tsx` — updated for the card-list markup. 15 tests pass across this directory (includes the modal's tests from the base branch).
- Typecheck and oxlint clean.
- Loaded `/admin/token-rate-limits` in a real browser against a live backend — caught and fixed the Server/Client Component crash above, then confirmed the Global tab (populated) and Groups tab (empty state) both render correctly. Screenshots below.

## Screenshots

**Global tab — card-list with Switch and trash actions:**

<img width="1568" height="721" alt="global-tab-cardlist" src="https://github.com/user-attachments/assets/fc312e9c-8ddd-45cf-a8d3-172116c25b8a" />

**Groups tab — empty state:**

<img width="1568" height="721" alt="groups-tab-empty" src="https://github.com/user-attachments/assets/577724f2-0612-46d6-a871-b3a509f29b3b" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a reusable TokenRateLimitsPanel and redesigned limits as card-list rows with clear budgets and reset cadence. Embedded the panel in the Enterprise usage page and cleaned up formatting and UX around creating limits.

- **New Features**
  - Added `TokenRateLimitsPanel` with tabs (Global, Users, Groups where available) and a “Create spending limit” flow via `CreateRateLimitModal`; limits render as cards with `Switch` toggles, quiet delete, and concise “Up to $X or Y tokens · Resets every N days at midnight UTC” copy.
  - Embedded `TokenRateLimitsPanel` in the Enterprise usage page; community page now wraps the panel.

- **Bug Fixes**
  - Marked `page.tsx` as a client component to fix “Functions cannot be passed directly to Client Components”.
  - `CreateRateLimitModal`: preserved cursor in the token budget field, switched to `useShareableGroups`, fixed non‑group submission, deduped scope copy; unified currency/token formatting via `@/lib/format`.
  - Improved keyboard navigation in the scope picker (roving‑tabindex handler).

<sup>Written for commit 98e8203bf2d1ae2cdea9470585eb67ca4ca7f97b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



