### PR TITLE
fix(llm): stream natively on registry miss for OpenAI responses surface

### DIFF
--- a/backend/onyx/llm/litellm_singleton/monkey_patches.py
+++ b/backend/onyx/llm/litellm_singleton/monkey_patches.py
@@ -79,6 +79,15 @@ Status checked against LiteLLM v1.93.0 (2026-07-20):
      OpenAI-compatible gateways such as Bifrost and Portkey), so honor it
      unconditionally and pass the remainder through as the literal model id
    STATUS: STILL NEEDED - v1.93.0 consults the registry before honoring the prefix.
+
+8. OpenAI Responses API Fake Streaming (_patch_openai_responses_should_fake_stream):
+   - Same defect as 4 on the base OpenAIResponsesAPIConfig, which
+     OpenAI-compatible gateways (Bifrost/Portkey responses mode) resolve to:
+     registry-miss models are downgraded to fake streaming, buffering the
+     whole generation before the first chunk
+   - Unlike 4, models the registry explicitly marks
+     supports_native_streaming=False (e.g. o1-pro) keep the fake stream
+   STATUS: STILL NEEDED - v1.93.0 treats a registry miss as "cannot stream".
 """
 
 import time
@@ -459,6 +468,45 @@ def _patch_azure_responses_should_fake_stream() -> None:
     AzureOpenAIResponsesAPIConfig.should_fake_stream = _patched_should_fake_stream
 
 
+def _patch_openai_responses_should_fake_stream() -> None:
+    """
+    Patches OpenAIResponsesAPIConfig.should_fake_stream so a registry miss
+    (e.g. a gateway model alias) streams natively instead of buffering the
+    generation. Models explicitly marked supports_native_streaming=False
+    (e.g. o1-pro) keep the fake stream — a native stream request would be
+    rejected upstream.
+    """
+    from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
+
+    if (
+        getattr(OpenAIResponsesAPIConfig.should_fake_stream, "__name__", "")
+        == "_patched_openai_should_fake_stream"
+    ):
+        return
+
+    def _patched_openai_should_fake_stream(
+        self: Any,  # noqa: ARG001
+        model: Optional[str],
+        stream: Optional[bool],
+        custom_llm_provider: Optional[str] = None,
+    ) -> bool:
+        import litellm
+
+        if stream is not True or model is None:
+            return False
+        try:
+            model_info = litellm.get_model_info(
+                model=model, custom_llm_provider=custom_llm_provider
+            )
+        except Exception:
+            # Registry miss (e.g. gateway alias): assume native streaming.
+            return False
+        return model_info.get("supports_native_streaming") is False
+
+    _patched_openai_should_fake_stream.__name__ = "_patched_openai_should_fake_stream"
+    OpenAIResponsesAPIConfig.should_fake_stream = _patched_openai_should_fake_stream
+
+
 def _patch_responses_api_usage_format() -> None:
     """
     Patches ResponsesAPIResponse.model_construct to properly transform usage data
@@ -695,6 +743,7 @@ def apply_monkey_patches() -> None:
     - Patching chunk_parser for reasoning summary newline insertion between sections
     - Patching LiteLLMResponsesTransformationHandler.transform_response for non-streaming responses
     - Patching AzureOpenAIResponsesAPIConfig.should_fake_stream to enable native streaming
+    - Patching OpenAIResponsesAPIConfig.should_fake_stream to stream natively on registry misses
     - Patching ResponsesAPIResponse.model_construct to fix usage format in all code paths
     - Patching Logging._get_assembled_streaming_response to avoid mutating original response
     - Patching responses_api_bridge_check to always honor an explicit responses/ prefix
@@ -703,6 +752,7 @@ def apply_monkey_patches() -> None:
     _patch_responses_reasoning_summary_newlines()
     _patch_openai_responses_transform_response()
     _patch_azure_responses_should_fake_stream()
+    _patch_openai_responses_should_fake_stream()
     _patch_responses_api_usage_format()
     _patch_logging_assembled_streaming_response()
     _patch_responses_api_bridge_check()

--- a/backend/tests/unit/onyx/llm/test_litellm_monkey_patches.py
+++ b/backend/tests/unit/onyx/llm/test_litellm_monkey_patches.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Any, cast
+from unittest import mock
 
 from litellm.completion_extras.litellm_responses_transformation.transformation import (
     LiteLLMResponsesTransformationHandler,
@@ -299,3 +300,53 @@ def test_bridge_check_delegates_without_prefix() -> None:
     )
     assert model_info.get("mode") != "responses"
     assert model == "gpt-4o"
+
+
+def test_openai_should_fake_stream_streams_natively_on_registry_miss() -> None:
+    # Force the registry miss so the except branch is unambiguously covered.
+    from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
+
+    apply_monkey_patches()
+    config = OpenAIResponsesAPIConfig()
+    with mock.patch(
+        "litellm.get_model_info",
+        side_effect=Exception("This model isn't mapped yet"),
+    ) as get_model_info_mock:
+        result = config.should_fake_stream(
+            model="bedrock_mantle/openai.gpt-5.6-sol",
+            stream=True,
+            custom_llm_provider="openai",
+        )
+    assert get_model_info_mock.called
+    assert result is False
+
+
+def test_openai_should_fake_stream_keeps_faking_for_non_streaming_models() -> None:
+    # o1-pro is registry-marked supports_native_streaming=False.
+    from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
+
+    apply_monkey_patches()
+    config = OpenAIResponsesAPIConfig()
+    assert (
+        config.should_fake_stream(
+            model="o1-pro",
+            stream=True,
+            custom_llm_provider="openai",
+        )
+        is True
+    )
+
+
+def test_openai_should_fake_stream_ignores_non_streaming_requests() -> None:
+    from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
+
+    apply_monkey_patches()
+    config = OpenAIResponsesAPIConfig()
+    assert (
+        config.should_fake_stream(
+            model="o1-pro",
+            stream=None,
+            custom_llm_provider="openai",
+        )
+        is False
+    )


### PR DESCRIPTION
## Description

LiteLLM fake-streams any responses-API call whose model its price registry does not recognize: `OpenAIResponsesAPIConfig.should_fake_stream` consults `litellm.utils.supports_native_streaming()`, which returns `False` on a registry miss. The request is then sent **without** `stream: true`, the entire generation is buffered, and the result is replayed through `MockResponsesAPIStreamingIterator`.

Models routed through OpenAI-compatible gateways in responses mode (Bifrost, Portkey) are never in LiteLLM's registry, so every such chat silently lost streaming: time-to-first-token equal to the full generation, and an API-server worker thread, DB session, and pooled HTTP connection pinned for the whole duration. Under concurrent chat load this exhausts the API server's DB connection pool and surfaces as bursts of 503s ("Database connection pool timeout") across unrelated endpoints.

We already patch this exact defect for Azure (`_patch_azure_responses_should_fake_stream`); the gateway path resolves to the unpatched OpenAI base config. This adds the sibling patch on `OpenAIResponsesAPIConfig` with one refinement: models the registry **explicitly** marks `supports_native_streaming=False` (e.g. `o1-pro`) keep the fake stream, since a native stream request would be rejected upstream — only the registry-miss default flips to native streaming.

Monkey-patch count keeps growing here, which we don't love. Follow-ups to retire it:
- Upstream fix to LiteLLM so a registry miss doesn't imply "cannot stream" (then drop this patch on the next pin bump).
- Longer term: register admin-configured models into LiteLLM's model map at provider-setup time, which would fix streaming detection, cost tracking, and capability lookups for gateway aliases in one place instead of patching call sites.

## How Has This Been Tested?

- 3 new unit tests in `test_litellm_monkey_patches.py`: registry-miss model streams natively, `o1-pro` still fake-streams, non-stream requests unaffected (13/13 pass).
- End-to-end against a mock responses-API gateway through the full `litellm_singleton` patch stack: wire request now carries `stream: true`; first chunk arrives in ~0.02s instead of after the full generation (~3s in the repro), chunks arrive incrementally, assembled text identical.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes native streaming for OpenAI Responses when a model isn’t in the `litellm` registry, restoring real-time chunks for OpenAI-compatible gateways. Registry-miss calls now send `stream: true`; models explicitly marked `supports_native_streaming=False` (e.g., `o1-pro`) still fake-stream.

- **Bug Fixes**
  - Patched `OpenAIResponsesAPIConfig.should_fake_stream` to default to native streaming on registry miss; keep fake stream only when the registry indicates no native streaming.
  - Mirrors the existing Azure patch to cover OpenAI-compatible gateways (Bifrost, Portkey).
  - Prevents buffering entire generations, improving TTFB and reducing DB/connection pressure.
  - Added unit tests for registry-miss streaming, `o1-pro` behavior, and non-stream requests.

<sup>Written for commit c45951401b33b50e4854cc8d8e4582e18ae030c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

