### PR TITLE
fix(mcp): discover OAuth metadata before consent

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -980,6 +980,15 @@ async def _connect_oauth(
             status_code=400, detail=f"Failed to initialize OAuth client: {str(saved_e)}"
         )
 
+    if not is_connected:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "OAuth auto-discovery did not produce an authorization redirect. "
+            "The MCP server permits unauthenticated initialization; configure "
+            "it with Known Provider OAuth, including its authorization endpoint, "
+            "token endpoint, and scopes.",
+        )
+
     return MCPUserOAuthConnectResponse(
         server_id=int(request.server_id),
         oauth_url=request.return_path,

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -119,6 +119,7 @@ from onyx.server.features.mcp.oauth import (
     key_state,
     key_tokens,
     make_oauth_provider,
+    mcp_token_expired,
 )
 from onyx.server.features.mcp.ssrf import validate_mcp_outbound_url
 from onyx.server.features.tool.models import ToolSnapshot
@@ -764,10 +765,15 @@ async def _connect_oauth(
         update_connection_config(mcp_server.admin_connection_config_id, db, config_data)
 
     connection_config = get_user_connection_config(mcp_server.id, user.email, db)
-    is_authenticated = bool(
+    existing_user_data = extract_connection_data(connection_config, apply_mask=False)
+    oauth_credentials_unchanged = bool(
         connection_config is not None
         and not request.oauth_client_id_changed
         and not request.oauth_client_secret_changed
+    )
+    is_authenticated = bool(
+        oauth_credentials_unchanged
+        and not mcp_token_expired(existing_user_data)
         and can_resolve_mcp_credentials(
             mcp_server,
             user,
@@ -777,8 +783,7 @@ async def _connect_oauth(
     )
     auth_template = get_mcp_auth_template(mcp_server)
     if auth_template is not None and auth_template.required_fields:
-        existing_data = extract_connection_data(connection_config, apply_mask=False)
-        substitutions = existing_data.get(HEADER_SUBSTITUTIONS, {})
+        substitutions = existing_user_data.get(HEADER_SUBSTITUTIONS, {})
         missing_fields = [
             field
             for field in auth_template.required_fields
@@ -793,9 +798,6 @@ async def _connect_oauth(
 
     user_config_data = config_data
     if connection_config is not None:
-        existing_user_data = extract_connection_data(
-            connection_config, apply_mask=False
-        )
         user_config_data = MCPConnectionData(
             headers=existing_user_data.get("headers", {}),
         )
@@ -803,9 +805,13 @@ async def _connect_oauth(
         user_config_data["headers"] = existing_user_data.get("headers", {})
         if substitutions := existing_user_data.get(HEADER_SUBSTITUTIONS):
             user_config_data[HEADER_SUBSTITUTIONS] = substitutions
-        if is_authenticated:
-            for key in (MCPOAuthKeys.TOKENS.value, MCPOAuthKeys.TOKEN_EXPIRES_AT.value):
-                if value := existing_user_data.get(key):
+        if oauth_credentials_unchanged:
+            for key in (
+                MCPOAuthKeys.TOKENS.value,
+                MCPOAuthKeys.TOKEN_EXPIRES_AT.value,
+                MCPOAuthKeys.METADATA.value,
+            ):
+                if (value := existing_user_data.get(key)) is not None:
                     user_config_data[key] = value
 
     if connection_config is None:

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -16,7 +16,6 @@ import requests
 from fastapi import APIRouter, Depends, HTTPException, Request
 from mcp.client.auth import OAuthClientProvider
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
-from mcp.types import InitializeResult
 from mcp.types import Tool as MCPLibTool
 from pydantic import AnyUrl, BaseModel
 from sqlalchemy.orm import Session
@@ -116,6 +115,7 @@ from onyx.server.features.mcp.oauth import (
     UNUSED_RETURN_PATH,
     MCPOauthState,
     _absolute_token_expiry,
+    initiate_auto_discovery_oauth,
     key_auth_url,
     key_code,
     key_state,
@@ -868,20 +868,13 @@ async def _connect_oauth(
         MCPOAuthKeys.CLIENT_INFO.value in connection_config_dict
         and connection_config_dict.get("headers")
     )
-    # Step 1: make unauthenticated request and parse returned www authenticate header
-    # Ensure we have a trailing slash for the MCP endpoint
-
     if mcp_server.transport is None:
         raise HTTPException(
             status_code=400,
             detail="MCP server transport is not configured",
         )
 
-    # always make a http request for the initial probe
-    transport = mcp_server.transport if is_connected else MCPTransport.STREAMABLE_HTTP
     probe_url = mcp_server.server_url
-    logger.info("Probing OAuth server at: %s", probe_url)
-
     oauth_auth = make_oauth_provider(
         mcp_server,
         str(user.id),
@@ -890,103 +883,62 @@ async def _connect_oauth(
         mcp_server.admin_connection_config_id,
     )
 
-    # start the oauth handshake in the background
-    # the background task will block on the callback handler after setting
-    # the auth_url for us to send to the frontend. The callback handler waits for
-    # the auth code to be available in redis; this code gets set by our callback endpoint
-    # which is called by the frontend after the user goes through the login flow.
-    async def tmp_func() -> InitializeResult:
-        try:
-            x = await initialize_mcp_client(
-                probe_url,
-                connection_headers=connection_config_dict.get("headers", {}),
-                transport=transport,
-                auth=oauth_auth,
-            )
-            logger.info("OAuth initialization completed successfully: %s", x)
-            return x
-        except Exception:
-            logger.exception("OAuth initialization failed")
-            raise
-
-    init_task = asyncio.create_task(tmp_func())
-
-    # Wait for whichever happens first:
-    # 1) The OAuth redirect URL becomes available in Redis (we should return it)
-    # 2) The initialize task completes (tokens already valid) — return to the provided return_path
-    r = get_redis_client()
-    loop = asyncio.get_running_loop()
-
-    async def wait_auth_url() -> str | None:
-        raw = await loop.run_in_executor(
-            None,
-            lambda: r.blpop([key_auth_url(str(user.id))], timeout=OAUTH_WAIT_SECONDS),
-        )
-        if raw is None:
-            return None
-        return raw[1].decode()
-
-    auth_task = None if is_connected else asyncio.create_task(wait_auth_url())
-
-    done, pending = await asyncio.wait(
-        [init_task] + ([auth_task] if auth_task else []),
-        return_when=asyncio.FIRST_COMPLETED,
-    )
-
-    # If we got an auth URL first, return it
-    if auth_task is not None and auth_task in done:
-        oauth_url = await auth_task
-        # If no URL was retrieved within the timeout, treat as error
-        if not oauth_url:
-            # If initialization also finished, treat as already authenticated
-            if init_task.done() and not init_task.cancelled():
-                try:
-                    init_result = init_task.result()
-                    logger.info(
-                        "OAuth initialization completed during timeout: %s", init_result
-                    )
-                    return MCPUserOAuthConnectResponse(
-                        server_id=int(request.server_id),
-                        oauth_url=request.return_path,
-                    )
-                except Exception as e:
-                    logger.error("OAuth initialization failed during timeout: %s", e)
-                    raise HTTPException(
-                        status_code=400, detail=f"OAuth initialization failed: {str(e)}"
-                    )
-            raise HTTPException(status_code=400, detail="Auth URL retrieval timed out")
-
-        logger.info(
-            "Connected to auth url: %s for mcp server: %s", oauth_url, mcp_server.name
-        )
-        return MCPUserOAuthConnectResponse(
-            server_id=int(request.server_id), oauth_url=oauth_url
-        )
-
-    # Otherwise, initialization finished first — no redirect needed; go back to return_path
-    for t in pending:
-        t.cancel()
-    try:
-        init_result = init_task.result()
-        logger.info("OAuth initialization completed without redirect: %s", init_result)
-    except Exception as e:
-        if isinstance(e, ExceptionGroup):
-            saved_e = log_exception_group(e)
-        else:
-            saved_e = e
-        logger.error("OAuth initialization failed: %s", saved_e)
-        # If initialize failed and we also didn't get an auth URL, surface an error
-        raise HTTPException(
-            status_code=400, detail=f"Failed to initialize OAuth client: {str(saved_e)}"
-        )
-
     if not is_connected:
+        redis_client = get_redis_client()
+
+        async def wait_auth_url() -> str | None:
+            raw = await asyncio.to_thread(
+                redis_client.blpop,
+                [key_auth_url(str(user.id))],
+                timeout=OAUTH_WAIT_SECONDS,
+            )
+            return raw[1].decode() if raw is not None else None
+
+        oauth_task = asyncio.create_task(
+            initiate_auto_discovery_oauth(oauth_auth, probe_url)
+        )
+        auth_url_task = asyncio.create_task(wait_auth_url())
+        done, _ = await asyncio.wait(
+            [oauth_task, auth_url_task],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if oauth_task in done:
+            try:
+                await oauth_task
+            except Exception:
+                auth_url_task.cancel()
+                raise
+
+        oauth_url = await auth_url_task
+        if oauth_url:
+            logger.info(
+                "Connected to auth url: %s for mcp server: %s",
+                oauth_url,
+                mcp_server.name,
+            )
+            return MCPUserOAuthConnectResponse(
+                server_id=int(request.server_id), oauth_url=oauth_url
+            )
+        oauth_task.cancel()
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
-            "OAuth auto-discovery did not produce an authorization redirect. "
-            "The MCP server permits unauthenticated initialization; configure "
-            "it with Known Provider OAuth, including its authorization endpoint, "
-            "token endpoint, and scopes.",
+            "OAuth auto-discovery did not produce an authorization redirect.",
+        )
+
+    logger.info("Initializing authenticated OAuth server at: %s", probe_url)
+    try:
+        init_result = await initialize_mcp_client(
+            probe_url,
+            connection_headers=connection_config_dict.get("headers", {}),
+            transport=mcp_server.transport,
+            auth=oauth_auth,
+        )
+        logger.info("OAuth initialization completed successfully: %s", init_result)
+    except Exception as e:
+        saved_e = log_exception_group(e) if isinstance(e, ExceptionGroup) else e
+        logger.error("OAuth initialization failed: %s", saved_e)
+        raise HTTPException(
+            status_code=400, detail=f"Failed to initialize OAuth client: {str(saved_e)}"
         )
 
     return MCPUserOAuthConnectResponse(

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -84,7 +84,6 @@ from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.mcp.client import (
     discover_mcp_tools,
-    initialize_mcp_client,
     log_exception_group,
 )
 from onyx.server.features.mcp.models import (
@@ -115,8 +114,7 @@ from onyx.server.features.mcp.oauth import (
     UNUSED_RETURN_PATH,
     MCPOauthState,
     _absolute_token_expiry,
-    initiate_auto_discovery_oauth,
-    key_auth_url,
+    connect_auto_discovery_oauth,
     key_code,
     key_state,
     key_tokens,
@@ -766,6 +764,17 @@ async def _connect_oauth(
         update_connection_config(mcp_server.admin_connection_config_id, db, config_data)
 
     connection_config = get_user_connection_config(mcp_server.id, user.email, db)
+    is_authenticated = bool(
+        connection_config is not None
+        and not request.oauth_client_id_changed
+        and not request.oauth_client_secret_changed
+        and can_resolve_mcp_credentials(
+            mcp_server,
+            user,
+            db,
+            user_configs={mcp_server.id: connection_config},
+        )
+    )
     auth_template = get_mcp_auth_template(mcp_server)
     if auth_template is not None and auth_template.required_fields:
         existing_data = extract_connection_data(connection_config, apply_mask=False)
@@ -794,6 +803,10 @@ async def _connect_oauth(
         user_config_data["headers"] = existing_user_data.get("headers", {})
         if substitutions := existing_user_data.get(HEADER_SUBSTITUTIONS):
             user_config_data[HEADER_SUBSTITUTIONS] = substitutions
+        if is_authenticated:
+            for key in (MCPOAuthKeys.TOKENS.value, MCPOAuthKeys.TOKEN_EXPIRES_AT.value):
+                if value := existing_user_data.get(key):
+                    user_config_data[key] = value
 
     if connection_config is None:
         connection_config = create_connection_config(
@@ -864,76 +877,25 @@ async def _connect_oauth(
             oauth_url=oauth_url,
         )
 
-    is_connected = (
-        MCPOAuthKeys.CLIENT_INFO.value in connection_config_dict
-        and connection_config_dict.get("headers")
-    )
     if mcp_server.transport is None:
         raise HTTPException(
             status_code=400,
             detail="MCP server transport is not configured",
         )
 
-    probe_url = mcp_server.server_url
-    oauth_auth = make_oauth_provider(
-        mcp_server,
-        str(user.id),
-        request.return_path,
-        connection_config.id,
-        mcp_server.admin_connection_config_id,
-    )
-
-    if not is_connected:
-        redis_client = get_redis_client()
-
-        async def wait_auth_url() -> str | None:
-            raw = await asyncio.to_thread(
-                redis_client.blpop,
-                [key_auth_url(str(user.id))],
-                timeout=OAUTH_WAIT_SECONDS,
-            )
-            return raw[1].decode() if raw is not None else None
-
-        oauth_task = asyncio.create_task(
-            initiate_auto_discovery_oauth(oauth_auth, probe_url)
-        )
-        auth_url_task = asyncio.create_task(wait_auth_url())
-        done, _ = await asyncio.wait(
-            [oauth_task, auth_url_task],
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-        if oauth_task in done:
-            try:
-                await oauth_task
-            except Exception:
-                auth_url_task.cancel()
-                raise
-
-        oauth_url = await auth_url_task
-        if oauth_url:
-            logger.info(
-                "Connected to auth url: %s for mcp server: %s",
-                oauth_url,
-                mcp_server.name,
-            )
-            return MCPUserOAuthConnectResponse(
-                server_id=int(request.server_id), oauth_url=oauth_url
-            )
-        oauth_task.cancel()
-        raise OnyxError(
-            OnyxErrorCode.INVALID_INPUT,
-            "OAuth auto-discovery did not produce an authorization redirect.",
-        )
-
-    logger.info("Initializing authenticated OAuth server at: %s", probe_url)
     try:
-        init_result = await initialize_mcp_client(
-            probe_url,
+        oauth_url = await connect_auto_discovery_oauth(
+            mcp_server=mcp_server,
+            user_id=str(user.id),
+            return_path=request.return_path,
+            connection_config_id=connection_config.id,
+            admin_config_id=mcp_server.admin_connection_config_id,
             connection_headers=connection_config_dict.get("headers", {}),
             transport=mcp_server.transport,
-            auth=oauth_auth,
+            is_authenticated=is_authenticated,
         )
-        logger.info("OAuth initialization completed successfully: %s", init_result)
+    except OnyxError:
+        raise
     except Exception as e:
         saved_e = log_exception_group(e) if isinstance(e, ExceptionGroup) else e
         logger.error("OAuth initialization failed: %s", saved_e)
@@ -943,7 +905,7 @@ async def _connect_oauth(
 
     return MCPUserOAuthConnectResponse(
         server_id=int(request.server_id),
-        oauth_url=request.return_path,
+        oauth_url=oauth_url or request.return_path,
     )
 
 

--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -154,13 +154,21 @@ async def _run_until_oauth_redirect(
 async def _initiate_oauth_from_well_known_metadata(
     oauth_auth: OAuthClientProvider,
     server_url: str,
+    connection_headers: dict[str, str],
 ) -> None:
     timeout = httpx.Timeout(_OAUTH_HTTP_TIMEOUT_SECONDS)
     discovery_urls = build_protected_resource_metadata_discovery_urls(None, server_url)
     metadata_url: str | None = None
+    discovery_headers = {
+        key: value
+        for key, value in connection_headers.items()
+        if key.lower() != "authorization"
+    }
     async with mcp_ssrf_httpx_client_factory(timeout=timeout) as client:
         for url in discovery_urls:
-            response = await client.send(create_oauth_metadata_request(url))
+            request = create_oauth_metadata_request(url)
+            request.headers.update(discovery_headers)
+            response = await client.send(request)
             if await handle_protected_resource_response(response) is not None:
                 metadata_url = url
                 break
@@ -218,7 +226,7 @@ async def connect_auto_discovery_oauth(
                 auth=oauth_auth,
             )
         except Exception:
-            if is_authenticated:
+            if is_authenticated or oauth_auth.context.is_token_valid():
                 raise
             logger.info(
                 "Initial MCP OAuth probe failed; trying well-known discovery",
@@ -228,7 +236,7 @@ async def connect_auto_discovery_oauth(
         if is_authenticated or oauth_auth.context.is_token_valid():
             return
         await _initiate_oauth_from_well_known_metadata(
-            oauth_auth, mcp_server.server_url
+            oauth_auth, mcp_server.server_url, connection_headers
         )
 
     try:

--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -47,6 +47,7 @@ from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.mcp.client import initialize_mcp_client
 from onyx.server.features.mcp.models import (
+    DENYLISTED_MCP_HEADERS,
     MCPConnectionData,
     MCPOAuthKeys,
     merge_mcp_headers,
@@ -104,6 +105,9 @@ def key_client_info(user_id: str) -> str:
 REQUESTED_SCOPE: str | None = None
 
 _OAUTH_HTTP_TIMEOUT_SECONDS = 30.0
+# The connect request returns as soon as the SDK publishes its consent URL, but
+# that same task must stay alive to receive the callback code and exchange it.
+# Keep a strong reference until the task completes; asyncio only holds weak ones.
 _INFLIGHT_OAUTH_TASKS: set[asyncio.Task[object]] = set()
 
 
@@ -126,12 +130,23 @@ async def _run_until_oauth_redirect(
     operation: Awaitable[object],
     redirect_future: asyncio.Future[str],
 ) -> str | None:
+    """Run an SDK OAuth operation until it finishes or publishes a redirect.
+
+    A redirect returns immediately while the operation continues in the
+    background to exchange the eventual callback code. Completion without a
+    redirect returns ``None``; operation failures and the outer timeout are
+    propagated to the caller.
+    """
+
     async def run_operation() -> object:
         return await operation
 
     operation_task = asyncio.create_task(run_operation())
     operation_retained = False
     try:
+        # Wait until the SDK either produces a consent URL or completes without
+        # one because the connection is already authenticated. Bound the wait in
+        # case the MCP server does neither.
         async with asyncio.timeout(OAUTH_WAIT_SECONDS):
             done, _ = await asyncio.wait(
                 [operation_task, redirect_future],
@@ -139,10 +154,15 @@ async def _run_until_oauth_redirect(
             )
         if redirect_future in done:
             redirect_url = redirect_future.result()
+            # The browser can navigate now, but the SDK operation continues in
+            # the background and blocks on the Redis-delivered callback code.
             _retain_oauth_task(operation_task)
             operation_retained = True
             return redirect_url
 
+        # asyncio.wait() reports completion but does not consume the result.
+        # The task is already done here, so this cannot block; awaiting it
+        # propagates any operation exception instead of losing it.
         await operation_task
         return None
     finally:
@@ -159,14 +179,20 @@ async def _initiate_oauth_from_well_known_metadata(
     timeout = httpx.Timeout(_OAUTH_HTTP_TIMEOUT_SECONDS)
     discovery_urls = build_protected_resource_metadata_discovery_urls(None, server_url)
     metadata_url: str | None = None
+    # Preserve gateway/tenant routing headers on the server's own well-known
+    # paths, but do not replay an expired bearer token or allow a stored Host
+    # override to route the validated URL to a different virtual host.
+    excluded_headers = DENYLISTED_MCP_HEADERS | {"authorization"}
     discovery_headers = {
         key: value
         for key, value in connection_headers.items()
-        if key.lower() != "authorization"
+        if key.lower() not in excluded_headers
     }
     async with mcp_ssrf_httpx_client_factory(timeout=timeout) as client:
         for url in discovery_urls:
             request = create_oauth_metadata_request(url)
+            # The SDK returns a prebuilt Request, so AsyncClient default headers
+            # would not be merged by send(); apply the routing headers directly.
             request.headers.update(discovery_headers)
             response = await client.send(request)
             if await handle_protected_resource_response(response) is not None:
@@ -180,6 +206,9 @@ async def _initiate_oauth_from_well_known_metadata(
             "the MCP server's well-known URI.",
         )
 
+    # Feed the discovered metadata URL back through the SDK's normal challenge
+    # handling. The local transport supplies the otherwise-missing 401, letting
+    # the SDK own authorization-server discovery, registration, and token exchange.
     async with mcp_oauth_challenge_httpx_client_factory(
         server_url,
         metadata_url,
@@ -215,6 +244,9 @@ async def connect_auto_discovery_oauth(
     )
 
     async def initialize_or_start_oauth() -> None:
+        # HTTPX auth cannot inspect an infinite SSE response body. Use an
+        # auth-capable Streamable HTTP probe for fresh SSE connections solely to
+        # elicit a 401 challenge; authenticated connections use their real transport.
         probe_transport = (
             transport if is_authenticated else MCPTransport.STREAMABLE_HTTP
         )
@@ -226,6 +258,10 @@ async def connect_auto_discovery_oauth(
                 auth=oauth_auth,
             )
         except Exception:
+            # A fresh compatibility probe may fail because the endpoint is SSE
+            # or permits no Streamable HTTP initialization; well-known discovery
+            # can still start OAuth. Once a token already existed or was refreshed,
+            # however, this is a real authenticated initialization failure.
             if is_authenticated or oauth_auth.context.is_token_valid():
                 raise
             logger.info(
@@ -233,6 +269,9 @@ async def connect_auto_discovery_oauth(
                 exc_info=True,
             )
 
+        # Successful public initialization proves reachability, not consent.
+        # Only a usable token makes the connection complete; otherwise force the
+        # RFC 9728 well-known path so the user still receives a consent screen.
         if is_authenticated or oauth_auth.context.is_token_valid():
             return
         await _initiate_oauth_from_well_known_metadata(

--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -17,6 +17,11 @@ from uuid import uuid4
 import httpx
 from mcp.client.auth import OAuthClientProvider, TokenStorage
 from mcp.client.auth.oauth2 import OAuthContext
+from mcp.client.auth.utils import (
+    build_protected_resource_metadata_discovery_urls,
+    create_oauth_metadata_request,
+    handle_protected_resource_response,
+)
 from mcp.shared.auth import (
     OAuthClientInformationFull,
     OAuthClientMetadata,
@@ -98,6 +103,46 @@ def key_client_info(user_id: str) -> str:
 
 
 REQUESTED_SCOPE: str | None = None
+
+
+async def initiate_auto_discovery_oauth(
+    oauth_auth: OAuthClientProvider,
+    server_url: str,
+) -> None:
+    discovery_urls = build_protected_resource_metadata_discovery_urls(None, server_url)
+    metadata_url: str | None = None
+    async with mcp_ssrf_httpx_client_factory() as client:
+        for url in discovery_urls:
+            response = await client.send(create_oauth_metadata_request(url))
+            if await handle_protected_resource_response(response) is not None:
+                metadata_url = url
+                break
+
+    if metadata_url is None:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "OAuth auto-discovery could not find protected resource metadata at "
+            "the MCP server's well-known URI.",
+        )
+
+    initial_request = httpx.Request("GET", server_url)
+    auth_flow = oauth_auth.async_auth_flow(initial_request)
+    request = await anext(auth_flow)
+    # The SDK only enters its OAuth flow in response to a challenge. The MCP
+    # endpoint may allow public initialization even though its tools need OAuth.
+    response = httpx.Response(
+        status_code=401,
+        headers={"WWW-Authenticate": f'Bearer resource_metadata="{metadata_url}"'},
+        request=request,
+    )
+
+    async with mcp_ssrf_httpx_client_factory() as client:
+        while True:
+            request = await auth_flow.asend(response)
+            if request is initial_request:
+                await auth_flow.aclose()
+                return
+            response = await client.send(request)
 
 
 class MCPOauthState(BaseModel):

--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -41,8 +41,7 @@ from onyx.db.mcp import (
     get_connection_config_by_id,
     update_connection_config,
 )
-from onyx.db.models import MCPConnectionConfig
-from onyx.db.models import MCPServer as DbMCPServer
+from onyx.db.models import MCPConnectionConfig, MCPServer
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_pool import get_redis_client
@@ -131,16 +130,25 @@ async def _run_until_oauth_redirect(
         return await operation
 
     operation_task = asyncio.create_task(run_operation())
-    done, _ = await asyncio.wait(
-        [operation_task, redirect_future],
-        return_when=asyncio.FIRST_COMPLETED,
-    )
-    if redirect_future in done:
-        _retain_oauth_task(operation_task)
-        return redirect_future.result()
+    operation_retained = False
+    try:
+        async with asyncio.timeout(OAUTH_WAIT_SECONDS):
+            done, _ = await asyncio.wait(
+                [operation_task, redirect_future],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        if redirect_future in done:
+            redirect_url = redirect_future.result()
+            _retain_oauth_task(operation_task)
+            operation_retained = True
+            return redirect_url
 
-    await operation_task
-    return None
+        await operation_task
+        return None
+    finally:
+        if not operation_retained and not operation_task.done():
+            operation_task.cancel()
+            await asyncio.gather(operation_task, return_exceptions=True)
 
 
 async def _initiate_oauth_from_well_known_metadata(
@@ -148,42 +156,33 @@ async def _initiate_oauth_from_well_known_metadata(
     server_url: str,
 ) -> None:
     timeout = httpx.Timeout(_OAUTH_HTTP_TIMEOUT_SECONDS)
-    try:
-        async with asyncio.timeout(STATE_TTL_SECONDS):
-            discovery_urls = build_protected_resource_metadata_discovery_urls(
-                None, server_url
-            )
-            metadata_url: str | None = None
-            async with mcp_ssrf_httpx_client_factory(timeout=timeout) as client:
-                for url in discovery_urls:
-                    response = await client.send(create_oauth_metadata_request(url))
-                    if await handle_protected_resource_response(response) is not None:
-                        metadata_url = url
-                        break
+    discovery_urls = build_protected_resource_metadata_discovery_urls(None, server_url)
+    metadata_url: str | None = None
+    async with mcp_ssrf_httpx_client_factory(timeout=timeout) as client:
+        for url in discovery_urls:
+            response = await client.send(create_oauth_metadata_request(url))
+            if await handle_protected_resource_response(response) is not None:
+                metadata_url = url
+                break
 
-            if metadata_url is None:
-                raise OnyxError(
-                    OnyxErrorCode.INVALID_INPUT,
-                    "OAuth auto-discovery could not find protected resource metadata "
-                    "at the MCP server's well-known URI.",
-                )
-
-            async with mcp_oauth_challenge_httpx_client_factory(
-                server_url,
-                metadata_url,
-                oauth_auth,
-                timeout,
-            ) as client:
-                await client.get(server_url)
-    except TimeoutError as e:
+    if metadata_url is None:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
-            "OAuth auto-discovery timed out.",
-        ) from e
+            "OAuth auto-discovery could not find protected resource metadata at "
+            "the MCP server's well-known URI.",
+        )
+
+    async with mcp_oauth_challenge_httpx_client_factory(
+        server_url,
+        metadata_url,
+        oauth_auth,
+        timeout,
+    ) as client:
+        await client.get(server_url)
 
 
 async def connect_auto_discovery_oauth(
-    mcp_server: DbMCPServer,
+    mcp_server: MCPServer,
     user_id: str,
     return_path: str,
     connection_config_id: int,
@@ -207,28 +206,52 @@ async def connect_auto_discovery_oauth(
         authorization_url_callback=publish_redirect,
     )
 
-    redirect_url = await _run_until_oauth_redirect(
-        initialize_mcp_client(
-            mcp_server.server_url,
-            connection_headers=connection_headers,
-            transport=transport,
-            auth=oauth_auth,
-        ),
-        redirect_future,
-    )
-    if redirect_url is not None or is_authenticated:
-        return redirect_url
+    async def initialize_or_start_oauth() -> None:
+        probe_transport = (
+            transport if is_authenticated else MCPTransport.STREAMABLE_HTTP
+        )
+        try:
+            await initialize_mcp_client(
+                mcp_server.server_url,
+                connection_headers=connection_headers,
+                transport=probe_transport,
+                auth=oauth_auth,
+            )
+        except Exception:
+            if is_authenticated:
+                raise
+            logger.info(
+                "Initial MCP OAuth probe failed; trying well-known discovery",
+                exc_info=True,
+            )
 
-    redirect_url = await _run_until_oauth_redirect(
-        _initiate_oauth_from_well_known_metadata(oauth_auth, mcp_server.server_url),
-        redirect_future,
-    )
-    if redirect_url is None:
+        if is_authenticated or oauth_auth.context.is_token_valid():
+            return
+        await _initiate_oauth_from_well_known_metadata(
+            oauth_auth, mcp_server.server_url
+        )
+
+    try:
+        redirect_url = await _run_until_oauth_redirect(
+            initialize_or_start_oauth(), redirect_future
+        )
+    except TimeoutError as e:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
-            "OAuth auto-discovery did not produce an authorization redirect.",
-        )
-    return redirect_url
+            "Timed out waiting for OAuth auto-discovery.",
+        ) from e
+
+    if (
+        redirect_url is not None
+        or is_authenticated
+        or oauth_auth.context.is_token_valid()
+    ):
+        return redirect_url
+
+    raise OnyxError(
+        OnyxErrorCode.INVALID_INPUT,
+        "OAuth auto-discovery did not produce an authorization redirect.",
+    )
 
 
 class MCPOauthState(BaseModel):
@@ -253,7 +276,7 @@ class MCPRefreshLogContext(TypedDict):
 
 
 def _refresh_log_context(
-    mcp_server: DbMCPServer, connection_config_id: int
+    mcp_server: MCPServer, connection_config_id: int
 ) -> MCPRefreshLogContext:
     return {
         "mcp_server_id": mcp_server.id,
@@ -333,7 +356,7 @@ def _absolute_token_expiry(tokens: OAuthToken) -> float | None:
 
 
 async def _refresh_mcp_oauth_token_if_expired(
-    mcp_server: DbMCPServer,
+    mcp_server: MCPServer,
     connection_config_id: int,
     user_id: str,
 ) -> str | None:
@@ -398,7 +421,7 @@ async def _refresh_mcp_oauth_token_if_expired(
 
 
 def refresh_mcp_oauth_token_if_expired(
-    mcp_server: DbMCPServer,
+    mcp_server: MCPServer,
     connection_config_id: int,
     user_id: str,
 ) -> str | None:
@@ -451,7 +474,7 @@ def _persisted_auth_header(connection_config_id: int) -> str | None:
     return (config_data.get("headers") or {}).get("Authorization")
 
 
-def _known_provider_oauth_metadata(mcp_server: DbMCPServer) -> OAuthMetadata | None:
+def _known_provider_oauth_metadata(mcp_server: MCPServer) -> OAuthMetadata | None:
     """Expose a KNOWN_PROVIDER server's configured endpoints as SDK OAuth
     metadata so refresh targets the real token endpoint, not the SDK's
     `<server-origin>/token` fallback."""
@@ -756,7 +779,7 @@ class OnyxOAuthClientProvider(OAuthClientProvider):
 
 
 def make_oauth_provider(
-    mcp_server: DbMCPServer,
+    mcp_server: MCPServer,
     user_id: str,
     return_path: str,
     connection_config_id: int,

--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -9,7 +9,7 @@ Routes and route-only flow helpers stay in `api.py`.
 import asyncio
 import json
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from typing import Any, TypedDict
 from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
@@ -35,7 +35,7 @@ from onyx.cache.interface import CacheLockAcquisitionError
 from onyx.cache.locks import cache_shared_lock
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
-from onyx.db.enums import MCPOAuthProviderMode
+from onyx.db.enums import MCPOAuthProviderMode, MCPTransport
 from onyx.db.mcp import (
     extract_connection_data,
     get_connection_config_by_id,
@@ -46,6 +46,7 @@ from onyx.db.models import MCPServer as DbMCPServer
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_pool import get_redis_client
+from onyx.server.features.mcp.client import initialize_mcp_client
 from onyx.server.features.mcp.models import (
     MCPConnectionData,
     MCPOAuthKeys,
@@ -82,10 +83,6 @@ OAUTH_WAIT_SECONDS = 30  # Give the user 30 seconds to complete the OAuth flow
 UNUSED_RETURN_PATH = "unused_path"
 
 
-def key_auth_url(user_id: str) -> str:
-    return f"mcp:oauth:{user_id}:auth_url"
-
-
 def key_state(user_id: str) -> str:
     return f"mcp:oauth:{user_id}:state"
 
@@ -104,8 +101,42 @@ def key_client_info(user_id: str) -> str:
 
 REQUESTED_SCOPE: str | None = None
 
+_INFLIGHT_OAUTH_TASKS: set[asyncio.Task[Any]] = set()
 
-async def initiate_auto_discovery_oauth(
+
+def _retain_oauth_task(task: asyncio.Task[Any]) -> None:
+    _INFLIGHT_OAUTH_TASKS.add(task)
+
+    def release(completed_task: asyncio.Task[Any]) -> None:
+        _INFLIGHT_OAUTH_TASKS.discard(completed_task)
+        exception = None if completed_task.cancelled() else completed_task.exception()
+        if exception is not None:
+            logger.error(
+                "Background MCP OAuth flow failed",
+                exc_info=exception,
+            )
+
+    task.add_done_callback(release)
+
+
+async def _run_until_oauth_redirect(
+    operation: Coroutine[Any, Any, Any],
+    redirect_future: asyncio.Future[str],
+) -> str | None:
+    operation_task = asyncio.create_task(operation)
+    done, _ = await asyncio.wait(
+        [operation_task, redirect_future],
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+    if redirect_future in done:
+        _retain_oauth_task(operation_task)
+        return redirect_future.result()
+
+    await operation_task
+    return None
+
+
+async def _initiate_oauth_from_well_known_metadata(
     oauth_auth: OAuthClientProvider,
     server_url: str,
 ) -> None:
@@ -143,6 +174,55 @@ async def initiate_auto_discovery_oauth(
                 await auth_flow.aclose()
                 return
             response = await client.send(request)
+
+
+async def connect_auto_discovery_oauth(
+    mcp_server: DbMCPServer,
+    user_id: str,
+    return_path: str,
+    connection_config_id: int,
+    admin_config_id: int | None,
+    connection_headers: dict[str, str],
+    transport: MCPTransport,
+    is_authenticated: bool,
+) -> str | None:
+    redirect_future = asyncio.get_running_loop().create_future()
+
+    async def publish_redirect(auth_url: str) -> None:
+        if not redirect_future.done():
+            redirect_future.set_result(auth_url)
+
+    oauth_auth = make_oauth_provider(
+        mcp_server,
+        user_id,
+        return_path,
+        connection_config_id,
+        admin_config_id,
+        authorization_url_callback=publish_redirect,
+    )
+
+    redirect_url = await _run_until_oauth_redirect(
+        initialize_mcp_client(
+            mcp_server.server_url,
+            connection_headers=connection_headers,
+            transport=transport,
+            auth=oauth_auth,
+        ),
+        redirect_future,
+    )
+    if redirect_url is not None or is_authenticated:
+        return redirect_url
+
+    redirect_url = await _run_until_oauth_redirect(
+        _initiate_oauth_from_well_known_metadata(oauth_auth, mcp_server.server_url),
+        redirect_future,
+    )
+    if redirect_url is None:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "OAuth auto-discovery did not produce an authorization redirect.",
+        )
+    return redirect_url
 
 
 class MCPOauthState(BaseModel):
@@ -670,6 +750,7 @@ def make_oauth_provider(
     return_path: str,
     connection_config_id: int,
     admin_config_id: int | None,
+    authorization_url_callback: Callable[[str], Awaitable[None]] | None = None,
 ) -> OAuthClientProvider:
     async def redirect_handler(auth_url: str) -> None:
         if return_path == UNUSED_RETURN_PATH:
@@ -683,18 +764,17 @@ def make_oauth_provider(
             # Defensive: some providers encode state differently; adapt if needed.
             raise RuntimeError("Missing state in authorization_url")
 
-        # Save for the frontend & for callback validation
+        # Save for callback validation before exposing the URL to the browser.
         state_obj = MCPOauthState(
             server_id=mcp_server.id,
             return_path=return_path,
             is_admin=admin_config_id is not None,
             state=state,
         )
-        r.rpush(key_auth_url(user_id), auth_url)
-        r.expire(key_auth_url(user_id), OAUTH_WAIT_SECONDS)
         r.set(key_state(user_id), state_obj.model_dump_json(), ex=STATE_TTL_SECONDS)
-
-        # Return immediately; the HTTP layer will read the stored URL and send it to the browser.
+        if authorization_url_callback is None:
+            raise RuntimeError("OAuth authorization URL callback is not configured")
+        await authorization_url_callback(auth_url)
 
     async def callback_handler() -> tuple[str, str | None]:
         r = get_redis_client()
@@ -725,7 +805,7 @@ def make_oauth_provider(
             raise RuntimeError("Invalid state in OAuth callback")
 
         # Optional: cleanup
-        r.delete(key_auth_url(user_id), key_state(user_id))
+        r.delete(key_state(user_id))
         return code, state_obj.state
 
     refresh_log_context = _refresh_log_context(mcp_server, connection_config_id)

--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -9,7 +9,7 @@ Routes and route-only flow helpers stay in `api.py`.
 import asyncio
 import json
 import time
-from collections.abc import Awaitable, Callable, Coroutine
+from collections.abc import Awaitable, Callable
 from typing import Any, TypedDict
 from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
@@ -52,7 +52,10 @@ from onyx.server.features.mcp.models import (
     MCPOAuthKeys,
     merge_mcp_headers,
 )
-from onyx.server.features.mcp.ssrf import mcp_ssrf_httpx_client_factory
+from onyx.server.features.mcp.ssrf import (
+    mcp_oauth_challenge_httpx_client_factory,
+    mcp_ssrf_httpx_client_factory,
+)
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import run_async_sync_no_cancel
 from shared_configs.contextvars import ONYX_REQUEST_ID_CONTEXTVAR, get_current_tenant_id
@@ -101,13 +104,14 @@ def key_client_info(user_id: str) -> str:
 
 REQUESTED_SCOPE: str | None = None
 
-_INFLIGHT_OAUTH_TASKS: set[asyncio.Task[Any]] = set()
+_OAUTH_HTTP_TIMEOUT_SECONDS = 30.0
+_INFLIGHT_OAUTH_TASKS: set[asyncio.Task[object]] = set()
 
 
-def _retain_oauth_task(task: asyncio.Task[Any]) -> None:
+def _retain_oauth_task(task: asyncio.Task[object]) -> None:
     _INFLIGHT_OAUTH_TASKS.add(task)
 
-    def release(completed_task: asyncio.Task[Any]) -> None:
+    def release(completed_task: asyncio.Task[object]) -> None:
         _INFLIGHT_OAUTH_TASKS.discard(completed_task)
         exception = None if completed_task.cancelled() else completed_task.exception()
         if exception is not None:
@@ -120,10 +124,13 @@ def _retain_oauth_task(task: asyncio.Task[Any]) -> None:
 
 
 async def _run_until_oauth_redirect(
-    operation: Coroutine[Any, Any, Any],
+    operation: Awaitable[object],
     redirect_future: asyncio.Future[str],
 ) -> str | None:
-    operation_task = asyncio.create_task(operation)
+    async def run_operation() -> object:
+        return await operation
+
+    operation_task = asyncio.create_task(run_operation())
     done, _ = await asyncio.wait(
         [operation_task, redirect_future],
         return_when=asyncio.FIRST_COMPLETED,
@@ -140,40 +147,39 @@ async def _initiate_oauth_from_well_known_metadata(
     oauth_auth: OAuthClientProvider,
     server_url: str,
 ) -> None:
-    discovery_urls = build_protected_resource_metadata_discovery_urls(None, server_url)
-    metadata_url: str | None = None
-    async with mcp_ssrf_httpx_client_factory() as client:
-        for url in discovery_urls:
-            response = await client.send(create_oauth_metadata_request(url))
-            if await handle_protected_resource_response(response) is not None:
-                metadata_url = url
-                break
+    timeout = httpx.Timeout(_OAUTH_HTTP_TIMEOUT_SECONDS)
+    try:
+        async with asyncio.timeout(STATE_TTL_SECONDS):
+            discovery_urls = build_protected_resource_metadata_discovery_urls(
+                None, server_url
+            )
+            metadata_url: str | None = None
+            async with mcp_ssrf_httpx_client_factory(timeout=timeout) as client:
+                for url in discovery_urls:
+                    response = await client.send(create_oauth_metadata_request(url))
+                    if await handle_protected_resource_response(response) is not None:
+                        metadata_url = url
+                        break
 
-    if metadata_url is None:
+            if metadata_url is None:
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    "OAuth auto-discovery could not find protected resource metadata "
+                    "at the MCP server's well-known URI.",
+                )
+
+            async with mcp_oauth_challenge_httpx_client_factory(
+                server_url,
+                metadata_url,
+                oauth_auth,
+                timeout,
+            ) as client:
+                await client.get(server_url)
+    except TimeoutError as e:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
-            "OAuth auto-discovery could not find protected resource metadata at "
-            "the MCP server's well-known URI.",
-        )
-
-    initial_request = httpx.Request("GET", server_url)
-    auth_flow = oauth_auth.async_auth_flow(initial_request)
-    request = await anext(auth_flow)
-    # The SDK only enters its OAuth flow in response to a challenge. The MCP
-    # endpoint may allow public initialization even though its tools need OAuth.
-    response = httpx.Response(
-        status_code=401,
-        headers={"WWW-Authenticate": f'Bearer resource_metadata="{metadata_url}"'},
-        request=request,
-    )
-
-    async with mcp_ssrf_httpx_client_factory() as client:
-        while True:
-            request = await auth_flow.asend(response)
-            if request is initial_request:
-                await auth_flow.aclose()
-                return
-            response = await client.send(request)
+            "OAuth auto-discovery timed out.",
+        ) from e
 
 
 async def connect_auto_discovery_oauth(
@@ -231,6 +237,11 @@ class MCPOauthState(BaseModel):
     is_admin: bool
     state: str
     code_verifier: str | None = None
+
+
+class MCPOAuthCodePayload(BaseModel):
+    code: str
+    state: str
 
 
 class MCPRefreshLogContext(TypedDict):
@@ -751,7 +762,7 @@ def make_oauth_provider(
     connection_config_id: int,
     admin_config_id: int | None,
     authorization_url_callback: Callable[[str], Awaitable[None]] | None = None,
-) -> OAuthClientProvider:
+) -> OnyxOAuthClientProvider:
     async def redirect_handler(auth_url: str) -> None:
         if return_path == UNUSED_RETURN_PATH:
             raise ValueError("Please Reconnect to the server")
@@ -797,16 +808,13 @@ def make_oauth_provider(
         if not pop:
             raise RuntimeError("Timed out waiting for OAuth callback")
 
-        code_state_dict = json.loads(pop[1].decode())
-
-        code = code_state_dict["code"]
-
-        if code_state_dict["state"] != state_obj.state:
+        code_payload = MCPOAuthCodePayload.model_validate_json(pop[1])
+        if code_payload.state != state_obj.state:
             raise RuntimeError("Invalid state in OAuth callback")
 
         # Optional: cleanup
         r.delete(key_state(user_id))
-        return code, state_obj.state
+        return code_payload.code, state_obj.state
 
     refresh_log_context = _refresh_log_context(mcp_server, connection_config_id)
     storage = OnyxTokenStorage(

--- a/backend/onyx/server/features/mcp/ssrf.py
+++ b/backend/onyx/server/features/mcp/ssrf.py
@@ -7,8 +7,6 @@ transport so every request the SDK makes — each redirect hop, discovery,
 registration, and token request — is checked.
 """
 
-from typing import Any
-
 import httpx
 
 from onyx.server.security.models import outbound_ssrf_params
@@ -47,6 +45,42 @@ class _SSRFGuardAsyncTransport(httpx.AsyncHTTPTransport):
         return await super().handle_async_request(request)
 
 
+class _OAuthChallengeTransport(httpx.AsyncBaseTransport):
+    """Drive OAuth with a local challenge and authenticated completion response."""
+
+    def __init__(self, server_url: str, metadata_url: str) -> None:
+        self._server_url = httpx.URL(server_url)
+        self._metadata_url = metadata_url
+        self._challenged = False
+        self._delegate = _SSRFGuardAsyncTransport()
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        if request.url == self._server_url:
+            if not self._challenged:
+                self._challenged = True
+                return httpx.Response(
+                    status_code=401,
+                    headers={
+                        "WWW-Authenticate": (
+                            f'Bearer resource_metadata="{self._metadata_url}"'
+                        )
+                    },
+                    request=request,
+                )
+            if "Authorization" not in request.headers:
+                raise RuntimeError(
+                    "OAuth flow retried the MCP request without an access token"
+                )
+            # The SDK retries the original request after storing the token. The
+            # OAuth connection is complete; no MCP request is needed here.
+            return httpx.Response(status_code=204, request=request)
+
+        return await self._delegate.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        await self._delegate.aclose()
+
+
 def mcp_ssrf_httpx_client_factory(
     headers: dict[str, str] | None = None,
     timeout: httpx.Timeout | None = None,
@@ -54,14 +88,25 @@ def mcp_ssrf_httpx_client_factory(
 ) -> httpx.AsyncClient:
     """Drop-in replacement for the MCP SDK's default client factory that swaps
     in an SSRF-guarded transport. Signature matches ``McpHttpClientFactory``."""
-    kwargs: dict[str, Any] = {
-        "follow_redirects": True,
-        "transport": _SSRFGuardAsyncTransport(),
-        "timeout": timeout
+    return httpx.AsyncClient(
+        auth=auth,
+        follow_redirects=True,
+        headers=headers,
+        timeout=timeout
         or httpx.Timeout(_MCP_DEFAULT_TIMEOUT, read=_MCP_DEFAULT_SSE_READ_TIMEOUT),
-    }
-    if headers is not None:
-        kwargs["headers"] = headers
-    if auth is not None:
-        kwargs["auth"] = auth
-    return httpx.AsyncClient(**kwargs)
+        transport=_SSRFGuardAsyncTransport(),
+    )
+
+
+def mcp_oauth_challenge_httpx_client_factory(
+    server_url: str,
+    metadata_url: str,
+    auth: httpx.Auth,
+    timeout: httpx.Timeout,
+) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        auth=auth,
+        follow_redirects=True,
+        timeout=timeout,
+        transport=_OAuthChallengeTransport(server_url, metadata_url),
+    )

--- a/backend/onyx/server/features/mcp/ssrf.py
+++ b/backend/onyx/server/features/mcp/ssrf.py
@@ -67,10 +67,6 @@ class _OAuthChallengeTransport(httpx.AsyncBaseTransport):
                     },
                     request=request,
                 )
-            if "Authorization" not in request.headers:
-                raise RuntimeError(
-                    "OAuth flow retried the MCP request without an access token"
-                )
             # The SDK retries the original request after storing the token. The
             # OAuth connection is complete; no MCP request is needed here.
             return httpx.Response(status_code=204, request=request)

--- a/backend/onyx/server/features/mcp/ssrf.py
+++ b/backend/onyx/server/features/mcp/ssrf.py
@@ -55,7 +55,7 @@ class _OAuthChallengeTransport(httpx.AsyncBaseTransport):
         self._delegate = _SSRFGuardAsyncTransport()
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        if request.url == self._server_url:
+        if request.method == "GET" and request.url == self._server_url:
             if not self._challenged:
                 self._challenged = True
                 return httpx.Response(

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
@@ -209,6 +209,7 @@ def test_public_initialization_uses_well_known_metadata(
             connection_headers={
                 "X-Gateway-Tenant": "tenant-1",
                 "Authorization": "Bearer stale-token",
+                "Host": "internal.example.com",
             },
         )
         == "https://consent"
@@ -223,9 +224,11 @@ def test_public_initialization_uses_well_known_metadata(
     assert initialize_call.kwargs["connection_headers"] == {
         "X-Gateway-Tenant": "tenant-1",
         "Authorization": "Bearer stale-token",
+        "Host": "internal.example.com",
     }
     assert all(headers["X-Gateway-Tenant"] == "tenant-1" for headers in request_headers)
     assert all("Authorization" not in headers for headers in request_headers)
+    assert all(headers["Host"] == "mcp.example.com" for headers in request_headers)
     assert providers[0].challenge == (
         'Bearer resource_metadata="https://mcp.example.com/'
         '.well-known/oauth-protected-resource"'

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
@@ -1,0 +1,84 @@
+import asyncio
+import time
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from onyx.db.enums import (
+    MCPAuthenticationPerformer,
+    MCPAuthenticationType,
+    MCPOAuthProviderMode,
+    MCPTransport,
+)
+from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.mcp import api
+from onyx.server.features.mcp.models import MCPUserOAuthConnectRequest
+
+
+def test_public_initialization_does_not_complete_fresh_oauth_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = SimpleNamespace(
+        id=42,
+        name="Public MCP",
+        server_url="https://mcp.example.com/mcp",
+        auth_type=MCPAuthenticationType.OAUTH,
+        auth_performer=MCPAuthenticationPerformer.PER_USER,
+        transport=MCPTransport.STREAMABLE_HTTP,
+        oauth_provider_mode=MCPOAuthProviderMode.AUTO_DISCOVERY,
+        admin_connection_config=None,
+        admin_connection_config_id=None,
+    )
+    user = SimpleNamespace(id=uuid4(), email="user@example.com")
+    admin_config = SimpleNamespace(id=100)
+    user_config = SimpleNamespace(id=101)
+    redis_client = MagicMock()
+    redis_client.blpop.side_effect = lambda *_args, **_kwargs: time.sleep(0.05)
+
+    monkeypatch.setattr(api, "get_mcp_server_by_id", lambda *_args: server)
+    monkeypatch.setattr(api, "_ensure_mcp_server_owner_or_admin", lambda *_args: None)
+    monkeypatch.setattr(api, "get_mcp_auth_template", lambda *_args: None)
+    monkeypatch.setattr(api, "get_user_connection_config", lambda *_args: None)
+    monkeypatch.setattr(
+        api,
+        "create_connection_config",
+        MagicMock(side_effect=[admin_config, user_config]),
+    )
+    monkeypatch.setattr(
+        api,
+        "extract_connection_data",
+        lambda *_args, **_kwargs: {
+            "client_info": {"client_id": "client-id"},
+            "headers": {},
+        },
+    )
+    monkeypatch.setattr(api, "get_redis_client", lambda: redis_client)
+    monkeypatch.setattr(api, "make_oauth_provider", lambda *_args: MagicMock())
+    initialize = AsyncMock(return_value=MagicMock())
+    monkeypatch.setattr(api, "initialize_mcp_client", initialize)
+
+    request = MCPUserOAuthConnectRequest(
+        server_id=server.id,
+        return_path="/admin/actions/mcp",
+        include_resource_param=True,
+        oauth_client_id="client-id",
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        asyncio.run(
+            api._connect_oauth(
+                request,
+                MagicMock(),
+                is_admin=True,
+                user=cast(User, user),
+            )
+        )
+
+    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
+    assert "permits unauthenticated initialization" in exc_info.value.detail
+    initialize.assert_awaited_once()

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
@@ -1,5 +1,4 @@
 import asyncio
-import queue
 from collections.abc import AsyncGenerator
 from types import SimpleNamespace
 from typing import Any, cast
@@ -20,21 +19,6 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.mcp import api, oauth
 from onyx.server.features.mcp.models import MCPUserOAuthConnectRequest
-
-
-class _Redis:
-    def __init__(self) -> None:
-        self.auth_urls: queue.Queue[str] = queue.Queue()
-
-    def blpop(self, _keys: list[str], timeout: int) -> tuple[bytes, bytes] | None:
-        try:
-            value = self.auth_urls.get(timeout=min(timeout, 0.1))
-        except queue.Empty:
-            return None
-        return b"auth_url", value.encode()
-
-    def rpush(self, _key: str, value: str) -> None:
-        self.auth_urls.put(value)
 
 
 class _DiscoveryClient:
@@ -64,22 +48,25 @@ class _DiscoveryClient:
 
 
 class _OAuthProvider:
-    def __init__(self, redis_client: _Redis) -> None:
-        self.redis_client = redis_client
+    def __init__(self, authorization_url_callback: Any) -> None:
+        self.authorization_url_callback = authorization_url_callback
         self.challenge: str | None = None
+
+    async def publish_redirect(self, auth_url: str) -> None:
+        await self.authorization_url_callback(auth_url)
 
     async def async_auth_flow(
         self, request: httpx.Request
     ) -> AsyncGenerator[httpx.Request, httpx.Response]:
         response = yield request
         self.challenge = response.headers["WWW-Authenticate"]
-        self.redis_client.rpush("auth_url", "https://consent")
+        await self.publish_redirect("https://consent")
         yield request
 
 
 def _setup_fresh_auto_discovery(
     monkeypatch: pytest.MonkeyPatch,
-) -> tuple[SimpleNamespace, SimpleNamespace, _Redis, _OAuthProvider]:
+) -> tuple[SimpleNamespace, SimpleNamespace, list[_OAuthProvider]]:
     server = SimpleNamespace(
         id=42,
         name="Public MCP",
@@ -92,8 +79,12 @@ def _setup_fresh_auto_discovery(
         admin_connection_config_id=None,
     )
     user = SimpleNamespace(id=uuid4(), email="user@example.com")
-    redis_client = _Redis()
-    oauth_provider = _OAuthProvider(redis_client)
+    oauth_providers: list[_OAuthProvider] = []
+
+    def make_oauth_provider(*_args: Any, **kwargs: Any) -> _OAuthProvider:
+        provider = _OAuthProvider(kwargs["authorization_url_callback"])
+        oauth_providers.append(provider)
+        return provider
 
     monkeypatch.setattr(api, "get_mcp_server_by_id", lambda *_args: server)
     monkeypatch.setattr(api, "_ensure_mcp_server_owner_or_admin", lambda *_args: None)
@@ -112,12 +103,11 @@ def _setup_fresh_auto_discovery(
             "headers": {},
         },
     )
-    monkeypatch.setattr(api, "get_redis_client", lambda: redis_client)
-    monkeypatch.setattr(api, "make_oauth_provider", lambda *_args: oauth_provider)
+    monkeypatch.setattr(oauth, "make_oauth_provider", make_oauth_provider)
     monkeypatch.setattr(
-        api, "initialize_mcp_client", AsyncMock(return_value=MagicMock())
+        oauth, "initialize_mcp_client", AsyncMock(return_value=MagicMock())
     )
-    return server, user, redis_client, oauth_provider
+    return server, user, oauth_providers
 
 
 def _request(server_id: int) -> MCPUserOAuthConnectRequest:
@@ -130,10 +120,39 @@ def _request(server_id: int) -> MCPUserOAuthConnectRequest:
     )
 
 
+def test_fresh_auto_discovery_preserves_www_authenticate_flow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server, user, oauth_providers = _setup_fresh_auto_discovery(monkeypatch)
+    discovery_factory = MagicMock(
+        side_effect=AssertionError("well-known fallback should not run")
+    )
+    monkeypatch.setattr(oauth, "mcp_ssrf_httpx_client_factory", discovery_factory)
+
+    async def initialize_with_challenge(*_args: Any, **kwargs: Any) -> MagicMock:
+        await kwargs["auth"].publish_redirect("https://challenge-consent")
+        return MagicMock()
+
+    monkeypatch.setattr(oauth, "initialize_mcp_client", initialize_with_challenge)
+
+    response = asyncio.run(
+        api._connect_oauth(
+            _request(server.id),
+            MagicMock(),
+            is_admin=True,
+            user=cast(User, user),
+        )
+    )
+
+    assert response.oauth_url == "https://challenge-consent"
+    assert oauth_providers[0].challenge is None
+    discovery_factory.assert_not_called()
+
+
 def test_fresh_auto_discovery_uses_well_known_metadata_to_start_oauth(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    server, user, _, oauth_provider = _setup_fresh_auto_discovery(monkeypatch)
+    server, user, oauth_providers = _setup_fresh_auto_discovery(monkeypatch)
     discovery_client = _DiscoveryClient([404, 200])
     monkeypatch.setattr(
         oauth, "mcp_ssrf_httpx_client_factory", lambda: discovery_client
@@ -153,7 +172,7 @@ def test_fresh_auto_discovery_uses_well_known_metadata_to_start_oauth(
         "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
         "https://mcp.example.com/.well-known/oauth-protected-resource",
     ]
-    assert oauth_provider.challenge == (
+    assert oauth_providers[0].challenge == (
         'Bearer resource_metadata="https://mcp.example.com/'
         '.well-known/oauth-protected-resource"'
     )
@@ -162,7 +181,7 @@ def test_fresh_auto_discovery_uses_well_known_metadata_to_start_oauth(
 def test_fresh_auto_discovery_errors_when_well_known_metadata_is_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    server, user, _, _ = _setup_fresh_auto_discovery(monkeypatch)
+    server, user, _ = _setup_fresh_auto_discovery(monkeypatch)
     discovery_client = _DiscoveryClient([404, 404])
     monkeypatch.setattr(
         oauth, "mcp_ssrf_httpx_client_factory", lambda: discovery_client
@@ -180,3 +199,44 @@ def test_fresh_auto_discovery_errors_when_well_known_metadata_is_missing(
 
     assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
     assert "well-known URI" in exc_info.value.detail
+
+
+def test_authenticated_connection_initializes_without_new_oauth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server, user, _ = _setup_fresh_auto_discovery(monkeypatch)
+    user_config = SimpleNamespace(id=101)
+    stored_data = {
+        "client_info": {"client_id": "client-id"},
+        "headers": {"Authorization": "Bearer stored-token"},
+        "tokens": {"access_token": "stored-token", "token_type": "Bearer"},
+        "token_expires_at": 1234.0,
+    }
+    update_connection_config = MagicMock()
+    discovery_factory = MagicMock(
+        side_effect=AssertionError("authenticated connection should not discover")
+    )
+    monkeypatch.setattr(api, "get_user_connection_config", lambda *_args: user_config)
+    monkeypatch.setattr(
+        api, "can_resolve_mcp_credentials", lambda *_args, **_kwargs: True
+    )
+    monkeypatch.setattr(
+        api, "extract_connection_data", lambda *_args, **_kwargs: stored_data
+    )
+    monkeypatch.setattr(api, "update_connection_config", update_connection_config)
+    monkeypatch.setattr(oauth, "mcp_ssrf_httpx_client_factory", discovery_factory)
+
+    response = asyncio.run(
+        api._connect_oauth(
+            _request(server.id),
+            MagicMock(),
+            is_admin=True,
+            user=cast(User, user),
+        )
+    )
+
+    assert response.oauth_url == "/admin/actions/mcp"
+    discovery_factory.assert_not_called()
+    updated_user_data = update_connection_config.call_args.args[2]
+    assert updated_user_data["tokens"] == stored_data["tokens"]
+    assert updated_user_data["token_expires_at"] == 1234.0

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections.abc import AsyncGenerator, Awaitable, Callable
-from types import SimpleNamespace, TracebackType
+from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
@@ -24,25 +24,15 @@ from onyx.server.features.mcp.models import (
 )
 
 
-class _DiscoveryClient:
-    def __init__(self, responses: list[int]) -> None:
-        self.responses = iter(responses)
-        self.request_urls: list[str] = []
+def _install_discovery_responses(
+    monkeypatch: pytest.MonkeyPatch, statuses: list[int]
+) -> list[str]:
+    remaining_statuses = iter(statuses)
+    request_urls: list[str] = []
 
-    async def __aenter__(self) -> "_DiscoveryClient":
-        return self
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: TracebackType | None,
-    ) -> None:
-        return None
-
-    async def send(self, request: httpx.Request) -> httpx.Response:
-        self.request_urls.append(str(request.url))
-        status = next(self.responses)
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        request_urls.append(str(request.url))
+        status = next(remaining_statuses)
         if status == 200:
             return httpx.Response(
                 status,
@@ -53,6 +43,21 @@ class _DiscoveryClient:
                 request=request,
             )
         return httpx.Response(status, request=request)
+
+    def client_factory(
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        auth: httpx.Auth | None = None,
+    ) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            auth=auth,
+            headers=headers,
+            timeout=timeout,
+            transport=httpx.MockTransport(handle_request),
+        )
+
+    monkeypatch.setattr(oauth, "mcp_ssrf_httpx_client_factory", client_factory)
+    return request_urls
 
 
 class _OAuthContext:
@@ -166,20 +171,31 @@ def test_challenge_redirect_skips_well_known_fallback(
     discovery_factory.assert_not_called()
 
 
-def test_public_initialization_uses_path_then_root_metadata(
+@pytest.mark.parametrize(
+    ("transport", "initialization_error"),
+    [
+        (MCPTransport.STREAMABLE_HTTP, None),
+        (MCPTransport.SSE, RuntimeError("SSE endpoint is not streamable")),
+    ],
+    ids=["public-streamable", "sse-probe-failure"],
+)
+def test_public_initialization_uses_well_known_metadata(
     monkeypatch: pytest.MonkeyPatch,
+    transport: MCPTransport,
+    initialization_error: Exception | None,
 ) -> None:
-    server, providers, _ = _setup_coordinator(monkeypatch)
-    discovery_client = _DiscoveryClient([404, 200])
-    monkeypatch.setattr(
-        oauth, "mcp_ssrf_httpx_client_factory", lambda **_kwargs: discovery_client
-    )
+    server, providers, initialize = _setup_coordinator(monkeypatch, transport)
+    initialize.side_effect = initialization_error
+    request_urls = _install_discovery_responses(monkeypatch, [404, 200])
 
     assert _connect(server) == "https://consent"
-    assert discovery_client.request_urls == [
+    assert request_urls == [
         "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
         "https://mcp.example.com/.well-known/oauth-protected-resource",
     ]
+    initialize_call = initialize.await_args
+    assert initialize_call is not None
+    assert initialize_call.kwargs["transport"] is MCPTransport.STREAMABLE_HTTP
     assert providers[0].challenge == (
         'Bearer resource_metadata="https://mcp.example.com/'
         '.well-known/oauth-protected-resource"'
@@ -190,32 +206,13 @@ def test_public_initialization_errors_when_metadata_is_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     server, _, _ = _setup_coordinator(monkeypatch)
-    discovery_client = _DiscoveryClient([404, 404])
-    monkeypatch.setattr(
-        oauth, "mcp_ssrf_httpx_client_factory", lambda **_kwargs: discovery_client
-    )
+    _install_discovery_responses(monkeypatch, [404, 404])
 
     with pytest.raises(OnyxError) as exc_info:
         _connect(server)
 
     assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
     assert "well-known URI" in exc_info.value.detail
-
-
-def test_fresh_sse_connection_uses_auth_capable_probe_before_fallback(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    server, _, initialize = _setup_coordinator(monkeypatch, MCPTransport.SSE)
-    initialize.side_effect = RuntimeError("SSE endpoint is not streamable")
-    discovery_client = _DiscoveryClient([200])
-    monkeypatch.setattr(
-        oauth, "mcp_ssrf_httpx_client_factory", lambda **_kwargs: discovery_client
-    )
-
-    assert _connect(server) == "https://consent"
-    initialize_call = initialize.await_args
-    assert initialize_call is not None
-    assert initialize_call.kwargs["transport"] is MCPTransport.STREAMABLE_HTTP
 
 
 def test_oauth_redirect_wait_is_bounded_and_cancels_probe(
@@ -280,59 +277,39 @@ def _setup_api_connection(
     return server, user, update_connection_config
 
 
-def test_valid_connection_preserves_oauth_state_without_new_consent(
+@pytest.mark.parametrize(
+    ("expires_at", "expected_oauth_url", "expected_discovery_urls"),
+    [
+        (4_000_000_000.0, "/admin/actions/mcp", []),
+        (
+            1.0,
+            "https://consent",
+            ["https://mcp.example.com/.well-known/oauth-protected-resource/mcp"],
+        ),
+    ],
+    ids=["valid", "expired"],
+)
+def test_token_expiry_controls_fast_path_without_dropping_oauth_state(
     monkeypatch: pytest.MonkeyPatch,
+    expires_at: float,
+    expected_oauth_url: str,
+    expected_discovery_urls: list[str],
 ) -> None:
     stored_data = MCPConnectionData(
         client_info={"client_id": "client-id"},
         headers={"Authorization": "Bearer stored-token"},
-        tokens={"access_token": "stored-token", "token_type": "Bearer"},
-        token_expires_at=4_000_000_000.0,
-        metadata={"token_endpoint": "https://accounts.example.com/token"},
-    )
-    server, user, update_connection_config = _setup_api_connection(
-        monkeypatch, stored_data
-    )
-    discovery_factory = MagicMock(
-        side_effect=AssertionError("authenticated connection should not discover")
-    )
-    monkeypatch.setattr(oauth, "mcp_ssrf_httpx_client_factory", discovery_factory)
-
-    response = asyncio.run(
-        api._connect_oauth(
-            _request(server.id), MagicMock(), is_admin=True, user=cast(User, user)
-        )
-    )
-
-    assert response.oauth_url == "/admin/actions/mcp"
-    discovery_factory.assert_not_called()
-    updated_data = update_connection_config.call_args.args[2]
-    assert updated_data["tokens"] == stored_data["tokens"]
-    assert updated_data["token_expires_at"] == stored_data["token_expires_at"]
-    assert updated_data["metadata"] == stored_data["metadata"]
-
-
-def test_expired_connection_preserves_refresh_state_but_requires_oauth(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    stored_data = MCPConnectionData(
-        client_info={"client_id": "client-id"},
-        headers={"Authorization": "Bearer expired-token"},
         tokens={
-            "access_token": "expired-token",
+            "access_token": "stored-token",
             "refresh_token": "refresh-token",
             "token_type": "Bearer",
         },
-        token_expires_at=1.0,
+        token_expires_at=expires_at,
         metadata={"token_endpoint": "https://accounts.example.com/token"},
     )
     server, user, update_connection_config = _setup_api_connection(
         monkeypatch, stored_data
     )
-    discovery_client = _DiscoveryClient([200])
-    monkeypatch.setattr(
-        oauth, "mcp_ssrf_httpx_client_factory", lambda **_kwargs: discovery_client
-    )
+    request_urls = _install_discovery_responses(monkeypatch, [200])
 
     response = asyncio.run(
         api._connect_oauth(
@@ -340,7 +317,8 @@ def test_expired_connection_preserves_refresh_state_but_requires_oauth(
         )
     )
 
-    assert response.oauth_url == "https://consent"
+    assert response.oauth_url == expected_oauth_url
+    assert request_urls == expected_discovery_urls
     updated_data = update_connection_config.call_args.args[2]
     assert updated_data["tokens"] == stored_data["tokens"]
     assert updated_data["token_expires_at"] == stored_data["token_expires_at"]

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
@@ -1,7 +1,7 @@
 import asyncio
-from collections.abc import AsyncGenerator
-from types import SimpleNamespace
-from typing import Any, cast
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from types import SimpleNamespace, TracebackType
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -29,7 +29,12 @@ class _DiscoveryClient:
     async def __aenter__(self) -> "_DiscoveryClient":
         return self
 
-    async def __aexit__(self, *_args: Any) -> None:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         return None
 
     async def send(self, request: httpx.Request) -> httpx.Response:
@@ -47,8 +52,10 @@ class _DiscoveryClient:
         return httpx.Response(status, request=request)
 
 
-class _OAuthProvider:
-    def __init__(self, authorization_url_callback: Any) -> None:
+class _OAuthProvider(httpx.Auth):
+    def __init__(
+        self, authorization_url_callback: Callable[[str], Awaitable[None]]
+    ) -> None:
         self.authorization_url_callback = authorization_url_callback
         self.challenge: str | None = None
 
@@ -61,7 +68,20 @@ class _OAuthProvider:
         response = yield request
         self.challenge = response.headers["WWW-Authenticate"]
         await self.publish_redirect("https://consent")
+        request.headers["Authorization"] = "Bearer test-token"
         yield request
+
+
+class _HangingDiscoveryClient(_DiscoveryClient):
+    def __init__(self) -> None:
+        super().__init__([])
+        self.started = False
+
+    async def send(self, request: httpx.Request) -> httpx.Response:
+        del request
+        self.started = True
+        await asyncio.Event().wait()
+        raise RuntimeError("unreachable")
 
 
 def _setup_fresh_auto_discovery(
@@ -81,8 +101,17 @@ def _setup_fresh_auto_discovery(
     user = SimpleNamespace(id=uuid4(), email="user@example.com")
     oauth_providers: list[_OAuthProvider] = []
 
-    def make_oauth_provider(*_args: Any, **kwargs: Any) -> _OAuthProvider:
-        provider = _OAuthProvider(kwargs["authorization_url_callback"])
+    def make_oauth_provider(
+        _mcp_server: object,
+        _user_id: str,
+        _return_path: str,
+        _connection_config_id: int,
+        _admin_config_id: int | None,
+        authorization_url_callback: Callable[[str], Awaitable[None]] | None = None,
+    ) -> _OAuthProvider:
+        if authorization_url_callback is None:
+            raise TypeError("authorization_url_callback is required")
+        provider = _OAuthProvider(authorization_url_callback)
         oauth_providers.append(provider)
         return provider
 
@@ -129,8 +158,16 @@ def test_fresh_auto_discovery_preserves_www_authenticate_flow(
     )
     monkeypatch.setattr(oauth, "mcp_ssrf_httpx_client_factory", discovery_factory)
 
-    async def initialize_with_challenge(*_args: Any, **kwargs: Any) -> MagicMock:
-        await kwargs["auth"].publish_redirect("https://challenge-consent")
+    async def initialize_with_challenge(
+        _server_url: str,
+        connection_headers: dict[str, str] | None = None,
+        transport: MCPTransport = MCPTransport.STREAMABLE_HTTP,
+        auth: object | None = None,
+    ) -> MagicMock:
+        del connection_headers, transport
+        if not isinstance(auth, _OAuthProvider):
+            raise TypeError("expected test OAuth provider")
+        await auth.publish_redirect("https://challenge-consent")
         return MagicMock()
 
     monkeypatch.setattr(oauth, "initialize_mcp_client", initialize_with_challenge)
@@ -155,7 +192,7 @@ def test_fresh_auto_discovery_uses_well_known_metadata_to_start_oauth(
     server, user, oauth_providers = _setup_fresh_auto_discovery(monkeypatch)
     discovery_client = _DiscoveryClient([404, 200])
     monkeypatch.setattr(
-        oauth, "mcp_ssrf_httpx_client_factory", lambda: discovery_client
+        oauth, "mcp_ssrf_httpx_client_factory", lambda **_kwargs: discovery_client
     )
 
     response = asyncio.run(
@@ -184,7 +221,7 @@ def test_fresh_auto_discovery_errors_when_well_known_metadata_is_missing(
     server, user, _ = _setup_fresh_auto_discovery(monkeypatch)
     discovery_client = _DiscoveryClient([404, 404])
     monkeypatch.setattr(
-        oauth, "mcp_ssrf_httpx_client_factory", lambda: discovery_client
+        oauth, "mcp_ssrf_httpx_client_factory", lambda **_kwargs: discovery_client
     )
 
     with pytest.raises(OnyxError) as exc_info:
@@ -240,3 +277,27 @@ def test_authenticated_connection_initializes_without_new_oauth(
     updated_user_data = update_connection_config.call_args.args[2]
     assert updated_user_data["tokens"] == stored_data["tokens"]
     assert updated_user_data["token_expires_at"] == 1234.0
+
+
+def test_well_known_oauth_flow_has_total_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server, user, _ = _setup_fresh_auto_discovery(monkeypatch)
+    discovery_client = _HangingDiscoveryClient()
+    monkeypatch.setattr(
+        oauth, "mcp_ssrf_httpx_client_factory", lambda **_kwargs: discovery_client
+    )
+    monkeypatch.setattr(oauth, "STATE_TTL_SECONDS", 0.01)
+
+    with pytest.raises(OnyxError) as exc_info:
+        asyncio.run(
+            api._connect_oauth(
+                _request(server.id),
+                MagicMock(),
+                is_admin=True,
+                user=cast(User, user),
+            )
+        )
+
+    assert discovery_client.started
+    assert "timed out" in exc_info.value.detail

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
@@ -14,11 +14,14 @@ from onyx.db.enums import (
     MCPOAuthProviderMode,
     MCPTransport,
 )
-from onyx.db.models import User
+from onyx.db.models import MCPServer, User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.mcp import api, oauth
-from onyx.server.features.mcp.models import MCPUserOAuthConnectRequest
+from onyx.server.features.mcp.models import (
+    MCPConnectionData,
+    MCPUserOAuthConnectRequest,
+)
 
 
 class _DiscoveryClient:
@@ -52,11 +55,17 @@ class _DiscoveryClient:
         return httpx.Response(status, request=request)
 
 
+class _OAuthContext:
+    def is_token_valid(self) -> bool:
+        return False
+
+
 class _OAuthProvider(httpx.Auth):
     def __init__(
         self, authorization_url_callback: Callable[[str], Awaitable[None]]
     ) -> None:
         self.authorization_url_callback = authorization_url_callback
+        self.context = _OAuthContext()
         self.challenge: str | None = None
 
     async def publish_redirect(self, auth_url: str) -> None:
@@ -72,34 +81,26 @@ class _OAuthProvider(httpx.Auth):
         yield request
 
 
-class _HangingDiscoveryClient(_DiscoveryClient):
-    def __init__(self) -> None:
-        super().__init__([])
-        self.started = False
-
-    async def send(self, request: httpx.Request) -> httpx.Response:
-        del request
-        self.started = True
-        await asyncio.Event().wait()
-        raise RuntimeError("unreachable")
-
-
-def _setup_fresh_auto_discovery(
-    monkeypatch: pytest.MonkeyPatch,
-) -> tuple[SimpleNamespace, SimpleNamespace, list[_OAuthProvider]]:
-    server = SimpleNamespace(
+def _server(transport: MCPTransport = MCPTransport.STREAMABLE_HTTP) -> SimpleNamespace:
+    return SimpleNamespace(
         id=42,
         name="Public MCP",
         server_url="https://mcp.example.com/mcp",
         auth_type=MCPAuthenticationType.OAUTH,
         auth_performer=MCPAuthenticationPerformer.PER_USER,
-        transport=MCPTransport.STREAMABLE_HTTP,
+        transport=transport,
         oauth_provider_mode=MCPOAuthProviderMode.AUTO_DISCOVERY,
         admin_connection_config=None,
         admin_connection_config_id=None,
     )
-    user = SimpleNamespace(id=uuid4(), email="user@example.com")
-    oauth_providers: list[_OAuthProvider] = []
+
+
+def _setup_coordinator(
+    monkeypatch: pytest.MonkeyPatch,
+    transport: MCPTransport = MCPTransport.STREAMABLE_HTTP,
+) -> tuple[SimpleNamespace, list[_OAuthProvider], AsyncMock]:
+    server = _server(transport)
+    providers: list[_OAuthProvider] = []
 
     def make_oauth_provider(
         _mcp_server: object,
@@ -112,31 +113,135 @@ def _setup_fresh_auto_discovery(
         if authorization_url_callback is None:
             raise TypeError("authorization_url_callback is required")
         provider = _OAuthProvider(authorization_url_callback)
-        oauth_providers.append(provider)
+        providers.append(provider)
         return provider
 
-    monkeypatch.setattr(api, "get_mcp_server_by_id", lambda *_args: server)
-    monkeypatch.setattr(api, "_ensure_mcp_server_owner_or_admin", lambda *_args: None)
-    monkeypatch.setattr(api, "get_mcp_auth_template", lambda *_args: None)
-    monkeypatch.setattr(api, "get_user_connection_config", lambda *_args: None)
-    monkeypatch.setattr(
-        api,
-        "create_connection_config",
-        MagicMock(side_effect=[SimpleNamespace(id=100), SimpleNamespace(id=101)]),
-    )
-    monkeypatch.setattr(
-        api,
-        "extract_connection_data",
-        lambda *_args, **_kwargs: {
-            "client_info": {"client_id": "client-id"},
-            "headers": {},
-        },
-    )
+    initialize = AsyncMock(return_value=MagicMock())
     monkeypatch.setattr(oauth, "make_oauth_provider", make_oauth_provider)
-    monkeypatch.setattr(
-        oauth, "initialize_mcp_client", AsyncMock(return_value=MagicMock())
+    monkeypatch.setattr(oauth, "initialize_mcp_client", initialize)
+    return server, providers, initialize
+
+
+def _connect(server: SimpleNamespace, *, is_authenticated: bool = False) -> str | None:
+    return asyncio.run(
+        oauth.connect_auto_discovery_oauth(
+            mcp_server=cast(MCPServer, server),
+            user_id=str(uuid4()),
+            return_path="/admin/actions/mcp",
+            connection_config_id=101,
+            admin_config_id=100,
+            connection_headers={},
+            transport=server.transport,
+            is_authenticated=is_authenticated,
+        )
     )
-    return server, user, oauth_providers
+
+
+def test_challenge_redirect_skips_well_known_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server, providers, _ = _setup_coordinator(monkeypatch)
+    discovery_factory = MagicMock(
+        side_effect=AssertionError("well-known fallback should not run")
+    )
+    monkeypatch.setattr(oauth, "mcp_ssrf_httpx_client_factory", discovery_factory)
+
+    async def initialize_with_challenge(
+        _server_url: str,
+        connection_headers: dict[str, str] | None = None,
+        transport: MCPTransport = MCPTransport.STREAMABLE_HTTP,
+        auth: object | None = None,
+    ) -> object:
+        del connection_headers, transport
+        if not isinstance(auth, _OAuthProvider):
+            raise TypeError("expected test OAuth provider")
+        await auth.publish_redirect("https://challenge-consent")
+        await asyncio.Event().wait()
+        raise RuntimeError("unreachable")
+
+    monkeypatch.setattr(oauth, "initialize_mcp_client", initialize_with_challenge)
+
+    assert _connect(server) == "https://challenge-consent"
+    assert providers[0].challenge is None
+    discovery_factory.assert_not_called()
+
+
+def test_public_initialization_uses_path_then_root_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server, providers, _ = _setup_coordinator(monkeypatch)
+    discovery_client = _DiscoveryClient([404, 200])
+    monkeypatch.setattr(
+        oauth, "mcp_ssrf_httpx_client_factory", lambda **_kwargs: discovery_client
+    )
+
+    assert _connect(server) == "https://consent"
+    assert discovery_client.request_urls == [
+        "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+        "https://mcp.example.com/.well-known/oauth-protected-resource",
+    ]
+    assert providers[0].challenge == (
+        'Bearer resource_metadata="https://mcp.example.com/'
+        '.well-known/oauth-protected-resource"'
+    )
+
+
+def test_public_initialization_errors_when_metadata_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server, _, _ = _setup_coordinator(monkeypatch)
+    discovery_client = _DiscoveryClient([404, 404])
+    monkeypatch.setattr(
+        oauth, "mcp_ssrf_httpx_client_factory", lambda **_kwargs: discovery_client
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        _connect(server)
+
+    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
+    assert "well-known URI" in exc_info.value.detail
+
+
+def test_fresh_sse_connection_uses_auth_capable_probe_before_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server, _, initialize = _setup_coordinator(monkeypatch, MCPTransport.SSE)
+    initialize.side_effect = RuntimeError("SSE endpoint is not streamable")
+    discovery_client = _DiscoveryClient([200])
+    monkeypatch.setattr(
+        oauth, "mcp_ssrf_httpx_client_factory", lambda **_kwargs: discovery_client
+    )
+
+    assert _connect(server) == "https://consent"
+    initialize_call = initialize.await_args
+    assert initialize_call is not None
+    assert initialize_call.kwargs["transport"] is MCPTransport.STREAMABLE_HTTP
+
+
+def test_oauth_redirect_wait_is_bounded_and_cancels_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server, _, _ = _setup_coordinator(monkeypatch)
+    probe_started = asyncio.Event()
+    probe_cancelled = False
+
+    async def initialize_forever(*_args: object, **_kwargs: object) -> object:
+        nonlocal probe_cancelled
+        probe_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            probe_cancelled = True
+        raise RuntimeError("unreachable")
+
+    monkeypatch.setattr(oauth, "initialize_mcp_client", initialize_forever)
+    monkeypatch.setattr(oauth, "OAUTH_WAIT_SECONDS", 0.01)
+
+    with pytest.raises(OnyxError, match="Timed out waiting"):
+        _connect(server)
+
+    assert probe_started.is_set()
+    assert probe_cancelled
 
 
 def _request(server_id: int) -> MCPUserOAuthConnectRequest:
@@ -149,155 +254,94 @@ def _request(server_id: int) -> MCPUserOAuthConnectRequest:
     )
 
 
-def test_fresh_auto_discovery_preserves_www_authenticate_flow(
+def _setup_api_connection(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    server, user, oauth_providers = _setup_fresh_auto_discovery(monkeypatch)
-    discovery_factory = MagicMock(
-        side_effect=AssertionError("well-known fallback should not run")
-    )
-    monkeypatch.setattr(oauth, "mcp_ssrf_httpx_client_factory", discovery_factory)
-
-    async def initialize_with_challenge(
-        _server_url: str,
-        connection_headers: dict[str, str] | None = None,
-        transport: MCPTransport = MCPTransport.STREAMABLE_HTTP,
-        auth: object | None = None,
-    ) -> MagicMock:
-        del connection_headers, transport
-        if not isinstance(auth, _OAuthProvider):
-            raise TypeError("expected test OAuth provider")
-        await auth.publish_redirect("https://challenge-consent")
-        return MagicMock()
-
-    monkeypatch.setattr(oauth, "initialize_mcp_client", initialize_with_challenge)
-
-    response = asyncio.run(
-        api._connect_oauth(
-            _request(server.id),
-            MagicMock(),
-            is_admin=True,
-            user=cast(User, user),
-        )
-    )
-
-    assert response.oauth_url == "https://challenge-consent"
-    assert oauth_providers[0].challenge is None
-    discovery_factory.assert_not_called()
-
-
-def test_fresh_auto_discovery_uses_well_known_metadata_to_start_oauth(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    server, user, oauth_providers = _setup_fresh_auto_discovery(monkeypatch)
-    discovery_client = _DiscoveryClient([404, 200])
-    monkeypatch.setattr(
-        oauth, "mcp_ssrf_httpx_client_factory", lambda **_kwargs: discovery_client
-    )
-
-    response = asyncio.run(
-        api._connect_oauth(
-            _request(server.id),
-            MagicMock(),
-            is_admin=True,
-            user=cast(User, user),
-        )
-    )
-
-    assert response.oauth_url == "https://consent"
-    assert discovery_client.request_urls == [
-        "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
-        "https://mcp.example.com/.well-known/oauth-protected-resource",
-    ]
-    assert oauth_providers[0].challenge == (
-        'Bearer resource_metadata="https://mcp.example.com/'
-        '.well-known/oauth-protected-resource"'
-    )
-
-
-def test_fresh_auto_discovery_errors_when_well_known_metadata_is_missing(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    server, user, _ = _setup_fresh_auto_discovery(monkeypatch)
-    discovery_client = _DiscoveryClient([404, 404])
-    monkeypatch.setattr(
-        oauth, "mcp_ssrf_httpx_client_factory", lambda **_kwargs: discovery_client
-    )
-
-    with pytest.raises(OnyxError) as exc_info:
-        asyncio.run(
-            api._connect_oauth(
-                _request(server.id),
-                MagicMock(),
-                is_admin=True,
-                user=cast(User, user),
-            )
-        )
-
-    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
-    assert "well-known URI" in exc_info.value.detail
-
-
-def test_authenticated_connection_initializes_without_new_oauth(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    server, user, _ = _setup_fresh_auto_discovery(monkeypatch)
+    stored_data: MCPConnectionData,
+) -> tuple[SimpleNamespace, SimpleNamespace, MagicMock]:
+    server, _, _ = _setup_coordinator(monkeypatch)
+    user = SimpleNamespace(id=uuid4(), email="user@example.com")
     user_config = SimpleNamespace(id=101)
-    stored_data = {
-        "client_info": {"client_id": "client-id"},
-        "headers": {"Authorization": "Bearer stored-token"},
-        "tokens": {"access_token": "stored-token", "token_type": "Bearer"},
-        "token_expires_at": 1234.0,
-    }
     update_connection_config = MagicMock()
-    discovery_factory = MagicMock(
-        side_effect=AssertionError("authenticated connection should not discover")
-    )
+
+    monkeypatch.setattr(api, "get_mcp_server_by_id", lambda *_args: server)
+    monkeypatch.setattr(api, "_ensure_mcp_server_owner_or_admin", lambda *_args: None)
+    monkeypatch.setattr(api, "get_mcp_auth_template", lambda *_args: None)
     monkeypatch.setattr(api, "get_user_connection_config", lambda *_args: user_config)
     monkeypatch.setattr(
-        api, "can_resolve_mcp_credentials", lambda *_args, **_kwargs: True
+        api, "create_connection_config", MagicMock(return_value=SimpleNamespace(id=100))
     )
     monkeypatch.setattr(
         api, "extract_connection_data", lambda *_args, **_kwargs: stored_data
     )
     monkeypatch.setattr(api, "update_connection_config", update_connection_config)
+    monkeypatch.setattr(
+        api, "can_resolve_mcp_credentials", lambda *_args, **_kwargs: True
+    )
+    return server, user, update_connection_config
+
+
+def test_valid_connection_preserves_oauth_state_without_new_consent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stored_data = MCPConnectionData(
+        client_info={"client_id": "client-id"},
+        headers={"Authorization": "Bearer stored-token"},
+        tokens={"access_token": "stored-token", "token_type": "Bearer"},
+        token_expires_at=4_000_000_000.0,
+        metadata={"token_endpoint": "https://accounts.example.com/token"},
+    )
+    server, user, update_connection_config = _setup_api_connection(
+        monkeypatch, stored_data
+    )
+    discovery_factory = MagicMock(
+        side_effect=AssertionError("authenticated connection should not discover")
+    )
     monkeypatch.setattr(oauth, "mcp_ssrf_httpx_client_factory", discovery_factory)
 
     response = asyncio.run(
         api._connect_oauth(
-            _request(server.id),
-            MagicMock(),
-            is_admin=True,
-            user=cast(User, user),
+            _request(server.id), MagicMock(), is_admin=True, user=cast(User, user)
         )
     )
 
     assert response.oauth_url == "/admin/actions/mcp"
     discovery_factory.assert_not_called()
-    updated_user_data = update_connection_config.call_args.args[2]
-    assert updated_user_data["tokens"] == stored_data["tokens"]
-    assert updated_user_data["token_expires_at"] == 1234.0
+    updated_data = update_connection_config.call_args.args[2]
+    assert updated_data["tokens"] == stored_data["tokens"]
+    assert updated_data["token_expires_at"] == stored_data["token_expires_at"]
+    assert updated_data["metadata"] == stored_data["metadata"]
 
 
-def test_well_known_oauth_flow_has_total_timeout(
+def test_expired_connection_preserves_refresh_state_but_requires_oauth(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    server, user, _ = _setup_fresh_auto_discovery(monkeypatch)
-    discovery_client = _HangingDiscoveryClient()
+    stored_data = MCPConnectionData(
+        client_info={"client_id": "client-id"},
+        headers={"Authorization": "Bearer expired-token"},
+        tokens={
+            "access_token": "expired-token",
+            "refresh_token": "refresh-token",
+            "token_type": "Bearer",
+        },
+        token_expires_at=1.0,
+        metadata={"token_endpoint": "https://accounts.example.com/token"},
+    )
+    server, user, update_connection_config = _setup_api_connection(
+        monkeypatch, stored_data
+    )
+    discovery_client = _DiscoveryClient([200])
     monkeypatch.setattr(
         oauth, "mcp_ssrf_httpx_client_factory", lambda **_kwargs: discovery_client
     )
-    monkeypatch.setattr(oauth, "STATE_TTL_SECONDS", 0.01)
 
-    with pytest.raises(OnyxError) as exc_info:
-        asyncio.run(
-            api._connect_oauth(
-                _request(server.id),
-                MagicMock(),
-                is_admin=True,
-                user=cast(User, user),
-            )
+    response = asyncio.run(
+        api._connect_oauth(
+            _request(server.id), MagicMock(), is_admin=True, user=cast(User, user)
         )
+    )
 
-    assert discovery_client.started
-    assert "timed out" in exc_info.value.detail
+    assert response.oauth_url == "https://consent"
+    updated_data = update_connection_config.call_args.args[2]
+    assert updated_data["tokens"] == stored_data["tokens"]
+    assert updated_data["token_expires_at"] == stored_data["token_expires_at"]
+    assert updated_data["metadata"] == stored_data["metadata"]

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
@@ -22,16 +22,21 @@ from onyx.server.features.mcp.models import (
     MCPConnectionData,
     MCPUserOAuthConnectRequest,
 )
+from onyx.server.features.mcp.ssrf import _OAuthChallengeTransport
 
 
 def _install_discovery_responses(
-    monkeypatch: pytest.MonkeyPatch, statuses: list[int]
+    monkeypatch: pytest.MonkeyPatch,
+    statuses: list[int],
+    request_headers: list[httpx.Headers] | None = None,
 ) -> list[str]:
     remaining_statuses = iter(statuses)
     request_urls: list[str] = []
 
     def handle_request(request: httpx.Request) -> httpx.Response:
         request_urls.append(str(request.url))
+        if request_headers is not None:
+            request_headers.append(request.headers)
         status = next(remaining_statuses)
         if status == 200:
             return httpx.Response(
@@ -61,8 +66,10 @@ def _install_discovery_responses(
 
 
 class _OAuthContext:
+    token_valid = False
+
     def is_token_valid(self) -> bool:
-        return False
+        return self.token_valid
 
 
 class _OAuthProvider(httpx.Auth):
@@ -127,7 +134,12 @@ def _setup_coordinator(
     return server, providers, initialize
 
 
-def _connect(server: SimpleNamespace, *, is_authenticated: bool = False) -> str | None:
+def _connect(
+    server: SimpleNamespace,
+    *,
+    is_authenticated: bool = False,
+    connection_headers: dict[str, str] | None = None,
+) -> str | None:
     return asyncio.run(
         oauth.connect_auto_discovery_oauth(
             mcp_server=cast(MCPServer, server),
@@ -135,7 +147,7 @@ def _connect(server: SimpleNamespace, *, is_authenticated: bool = False) -> str 
             return_path="/admin/actions/mcp",
             connection_config_id=101,
             admin_config_id=100,
-            connection_headers={},
+            connection_headers=connection_headers or {},
             transport=server.transport,
             is_authenticated=is_authenticated,
         )
@@ -186,9 +198,21 @@ def test_public_initialization_uses_well_known_metadata(
 ) -> None:
     server, providers, initialize = _setup_coordinator(monkeypatch, transport)
     initialize.side_effect = initialization_error
-    request_urls = _install_discovery_responses(monkeypatch, [404, 200])
+    request_headers: list[httpx.Headers] = []
+    request_urls = _install_discovery_responses(
+        monkeypatch, [404, 200], request_headers
+    )
 
-    assert _connect(server) == "https://consent"
+    assert (
+        _connect(
+            server,
+            connection_headers={
+                "X-Gateway-Tenant": "tenant-1",
+                "Authorization": "Bearer stale-token",
+            },
+        )
+        == "https://consent"
+    )
     assert request_urls == [
         "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
         "https://mcp.example.com/.well-known/oauth-protected-resource",
@@ -196,6 +220,12 @@ def test_public_initialization_uses_well_known_metadata(
     initialize_call = initialize.await_args
     assert initialize_call is not None
     assert initialize_call.kwargs["transport"] is MCPTransport.STREAMABLE_HTTP
+    assert initialize_call.kwargs["connection_headers"] == {
+        "X-Gateway-Tenant": "tenant-1",
+        "Authorization": "Bearer stale-token",
+    }
+    assert all(headers["X-Gateway-Tenant"] == "tenant-1" for headers in request_headers)
+    assert all("Authorization" not in headers for headers in request_headers)
     assert providers[0].challenge == (
         'Bearer resource_metadata="https://mcp.example.com/'
         '.well-known/oauth-protected-resource"'
@@ -239,6 +269,48 @@ def test_oauth_redirect_wait_is_bounded_and_cancels_probe(
 
     assert probe_started.is_set()
     assert probe_cancelled
+
+
+def test_probe_failure_after_token_refresh_is_not_treated_as_connected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server, providers, _ = _setup_coordinator(monkeypatch)
+
+    async def initialize_after_refresh(*_args: object, **_kwargs: object) -> object:
+        providers[0].context.token_valid = True
+        raise RuntimeError("MCP initialization failed after refresh")
+
+    monkeypatch.setattr(oauth, "initialize_mcp_client", initialize_after_refresh)
+
+    with pytest.raises(RuntimeError, match="initialization failed after refresh"):
+        _connect(server)
+
+
+def test_oauth_challenge_transport_delegates_same_url_posts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def run() -> None:
+        delegated_requests: list[httpx.Request] = []
+
+        def handle_delegated(request: httpx.Request) -> httpx.Response:
+            delegated_requests.append(request)
+            return httpx.Response(201, request=request)
+
+        transport = _OAuthChallengeTransport(
+            "https://mcp.example.com/mcp",
+            "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+        )
+        monkeypatch.setattr(
+            transport, "_delegate", httpx.MockTransport(handle_delegated)
+        )
+        async with httpx.AsyncClient(transport=transport) as client:
+            assert (await client.get("https://mcp.example.com/mcp")).status_code == 401
+            assert (await client.get("https://mcp.example.com/mcp")).status_code == 204
+            assert (await client.post("https://mcp.example.com/mcp")).status_code == 201
+
+        assert [request.method for request in delegated_requests] == ["POST"]
+
+    asyncio.run(run())
 
 
 def _request(server_id: int) -> MCPUserOAuthConnectRequest:

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
@@ -1,10 +1,12 @@
 import asyncio
-import time
+import queue
+from collections.abc import AsyncGenerator
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
+import httpx
 import pytest
 
 from onyx.db.enums import (
@@ -16,13 +18,68 @@ from onyx.db.enums import (
 from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.server.features.mcp import api
+from onyx.server.features.mcp import api, oauth
 from onyx.server.features.mcp.models import MCPUserOAuthConnectRequest
 
 
-def test_public_initialization_does_not_complete_fresh_oauth_connection(
+class _Redis:
+    def __init__(self) -> None:
+        self.auth_urls: queue.Queue[str] = queue.Queue()
+
+    def blpop(self, _keys: list[str], timeout: int) -> tuple[bytes, bytes] | None:
+        try:
+            value = self.auth_urls.get(timeout=min(timeout, 0.1))
+        except queue.Empty:
+            return None
+        return b"auth_url", value.encode()
+
+    def rpush(self, _key: str, value: str) -> None:
+        self.auth_urls.put(value)
+
+
+class _DiscoveryClient:
+    def __init__(self, responses: list[int]) -> None:
+        self.responses = iter(responses)
+        self.request_urls: list[str] = []
+
+    async def __aenter__(self) -> "_DiscoveryClient":
+        return self
+
+    async def __aexit__(self, *_args: Any) -> None:
+        return None
+
+    async def send(self, request: httpx.Request) -> httpx.Response:
+        self.request_urls.append(str(request.url))
+        status = next(self.responses)
+        if status == 200:
+            return httpx.Response(
+                status,
+                json={
+                    "resource": "https://mcp.example.com/mcp",
+                    "authorization_servers": ["https://accounts.example.com"],
+                },
+                request=request,
+            )
+        return httpx.Response(status, request=request)
+
+
+class _OAuthProvider:
+    def __init__(self, redis_client: _Redis) -> None:
+        self.redis_client = redis_client
+        self.challenge: str | None = None
+
+    async def async_auth_flow(
+        self, request: httpx.Request
+    ) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        response = yield request
+        self.challenge = response.headers["WWW-Authenticate"]
+        self.redis_client.rpush("auth_url", "https://consent")
+        yield request
+
+
+def _setup_fresh_auto_discovery(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+) -> tuple[SimpleNamespace, SimpleNamespace, _Redis, _OAuthProvider]:
     server = SimpleNamespace(
         id=42,
         name="Public MCP",
@@ -35,10 +92,8 @@ def test_public_initialization_does_not_complete_fresh_oauth_connection(
         admin_connection_config_id=None,
     )
     user = SimpleNamespace(id=uuid4(), email="user@example.com")
-    admin_config = SimpleNamespace(id=100)
-    user_config = SimpleNamespace(id=101)
-    redis_client = MagicMock()
-    redis_client.blpop.side_effect = lambda *_args, **_kwargs: time.sleep(0.05)
+    redis_client = _Redis()
+    oauth_provider = _OAuthProvider(redis_client)
 
     monkeypatch.setattr(api, "get_mcp_server_by_id", lambda *_args: server)
     monkeypatch.setattr(api, "_ensure_mcp_server_owner_or_admin", lambda *_args: None)
@@ -47,7 +102,7 @@ def test_public_initialization_does_not_complete_fresh_oauth_connection(
     monkeypatch.setattr(
         api,
         "create_connection_config",
-        MagicMock(side_effect=[admin_config, user_config]),
+        MagicMock(side_effect=[SimpleNamespace(id=100), SimpleNamespace(id=101)]),
     )
     monkeypatch.setattr(
         api,
@@ -58,21 +113,65 @@ def test_public_initialization_does_not_complete_fresh_oauth_connection(
         },
     )
     monkeypatch.setattr(api, "get_redis_client", lambda: redis_client)
-    monkeypatch.setattr(api, "make_oauth_provider", lambda *_args: MagicMock())
-    initialize = AsyncMock(return_value=MagicMock())
-    monkeypatch.setattr(api, "initialize_mcp_client", initialize)
+    monkeypatch.setattr(api, "make_oauth_provider", lambda *_args: oauth_provider)
+    monkeypatch.setattr(
+        api, "initialize_mcp_client", AsyncMock(return_value=MagicMock())
+    )
+    return server, user, redis_client, oauth_provider
 
-    request = MCPUserOAuthConnectRequest(
-        server_id=server.id,
+
+def _request(server_id: int) -> MCPUserOAuthConnectRequest:
+    return MCPUserOAuthConnectRequest(
+        server_id=server_id,
         return_path="/admin/actions/mcp",
         include_resource_param=True,
         oauth_client_id="client-id",
+        oauth_client_secret=None,
+    )
+
+
+def test_fresh_auto_discovery_uses_well_known_metadata_to_start_oauth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server, user, _, oauth_provider = _setup_fresh_auto_discovery(monkeypatch)
+    discovery_client = _DiscoveryClient([404, 200])
+    monkeypatch.setattr(
+        oauth, "mcp_ssrf_httpx_client_factory", lambda: discovery_client
+    )
+
+    response = asyncio.run(
+        api._connect_oauth(
+            _request(server.id),
+            MagicMock(),
+            is_admin=True,
+            user=cast(User, user),
+        )
+    )
+
+    assert response.oauth_url == "https://consent"
+    assert discovery_client.request_urls == [
+        "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+        "https://mcp.example.com/.well-known/oauth-protected-resource",
+    ]
+    assert oauth_provider.challenge == (
+        'Bearer resource_metadata="https://mcp.example.com/'
+        '.well-known/oauth-protected-resource"'
+    )
+
+
+def test_fresh_auto_discovery_errors_when_well_known_metadata_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server, user, _, _ = _setup_fresh_auto_discovery(monkeypatch)
+    discovery_client = _DiscoveryClient([404, 404])
+    monkeypatch.setattr(
+        oauth, "mcp_ssrf_httpx_client_factory", lambda: discovery_client
     )
 
     with pytest.raises(OnyxError) as exc_info:
         asyncio.run(
             api._connect_oauth(
-                request,
+                _request(server.id),
                 MagicMock(),
                 is_admin=True,
                 user=cast(User, user),
@@ -80,5 +179,4 @@ def test_public_initialization_does_not_complete_fresh_oauth_connection(
         )
 
     assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
-    assert "permits unauthenticated initialization" in exc_info.value.detail
-    initialize.assert_awaited_once()
+    assert "well-known URI" in exc_info.value.detail

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_ssrf.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_ssrf.py
@@ -142,6 +142,36 @@ def test_transport_blocks_before_network() -> None:
         asyncio.run(transport.handle_async_request(request))
 
 
+def test_oauth_challenge_transport_requires_authenticated_retry() -> None:
+    server_url = "https://mcp.example.com/mcp"
+    metadata_url = "https://mcp.example.com/.well-known/oauth-protected-resource/mcp"
+    transport = mcp_ssrf._OAuthChallengeTransport(server_url, metadata_url)
+
+    async def run_requests() -> tuple[httpx.Response, httpx.Response]:
+        try:
+            first_response = await transport.handle_async_request(
+                httpx.Request("GET", server_url)
+            )
+            with pytest.raises(RuntimeError, match="without an access token"):
+                await transport.handle_async_request(httpx.Request("GET", server_url))
+            retry_response = await transport.handle_async_request(
+                httpx.Request(
+                    "GET", server_url, headers={"Authorization": "Bearer token"}
+                )
+            )
+            return first_response, retry_response
+        finally:
+            await transport.aclose()
+
+    first_response, retry_response = asyncio.run(run_requests())
+
+    assert first_response.status_code == 401
+    assert first_response.headers["WWW-Authenticate"] == (
+        f'Bearer resource_metadata="{metadata_url}"'
+    )
+    assert retry_response.status_code == 204
+
+
 @pytest.mark.parametrize(
     "url", ["http://localhost:9000/mcp", "http://169.254.169.254/x"]
 )

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_ssrf.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_ssrf.py
@@ -142,36 +142,6 @@ def test_transport_blocks_before_network() -> None:
         asyncio.run(transport.handle_async_request(request))
 
 
-def test_oauth_challenge_transport_requires_authenticated_retry() -> None:
-    server_url = "https://mcp.example.com/mcp"
-    metadata_url = "https://mcp.example.com/.well-known/oauth-protected-resource/mcp"
-    transport = mcp_ssrf._OAuthChallengeTransport(server_url, metadata_url)
-
-    async def run_requests() -> tuple[httpx.Response, httpx.Response]:
-        try:
-            first_response = await transport.handle_async_request(
-                httpx.Request("GET", server_url)
-            )
-            with pytest.raises(RuntimeError, match="without an access token"):
-                await transport.handle_async_request(httpx.Request("GET", server_url))
-            retry_response = await transport.handle_async_request(
-                httpx.Request(
-                    "GET", server_url, headers={"Authorization": "Bearer token"}
-                )
-            )
-            return first_response, retry_response
-        finally:
-            await transport.aclose()
-
-    first_response, retry_response = asyncio.run(run_requests())
-
-    assert first_response.status_code == 401
-    assert first_response.headers["WWW-Authenticate"] == (
-        f'Bearer resource_metadata="{metadata_url}"'
-    )
-    assert retry_response.status_code == 204
-
-
 @pytest.mark.parametrize(
     "url", ["http://localhost:9000/mcp", "http://169.254.169.254/x"]
 )


### PR DESCRIPTION
## Description

Fix Auto Discovery OAuth for MCP servers that permit unauthenticated initialization and tool discovery but require OAuth for tool execution, including BigQuery.

The previous flow treated a successful MCP `initialize` response as proof that authentication had completed. The updated flow:

- Runs the normal MCP SDK initialization first, preserving `WWW-Authenticate` challenge behavior and custom protected-resource metadata URLs.
- If initialization completes without a consent redirect or valid token, discovers RFC 9728 protected-resource metadata at the path-specific URI and then the origin-level fallback.
- Drives the SDK OAuth flow through a local HTTPX challenge while retaining SSRF validation for discovery, registration, token, and redirect requests.
- Returns the consent URL through a request-local future while retaining Redis only for cross-request state, authorization-code, and token coordination.
- Uses an auth-capable Streamable HTTP probe for fresh SSE configurations and bounds consent discovery to 30 seconds, cancelling stalled probes.
- Preserves tokens, token expiry, and discovered authorization-server metadata when OAuth client credentials are unchanged. Expired tokens cannot take the authenticated fast path, but their refresh state remains available to the SDK.
- Returns a configuration error when neither well-known protected-resource metadata location is valid.

Known Provider OAuth is unchanged. Existing authenticated connections continue using their configured transport, and challenge-based Auto Discovery servers retain backward-compatible behavior.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
