### PR TITLE
fix(craft): align session deletion modal

### DIFF
--- a/web/lib/opal/src/layouts/modal/components.tsx
+++ b/web/lib/opal/src/layouts/modal/components.tsx
@@ -50,14 +50,15 @@ function ConfirmationModalLayout({
 }: ConfirmationModalProps) {
   const modalClose = useModalClose(externalOnClose);
   const closedRef = React.useRef(false);
+  const canClose = modalClose !== undefined;
 
   // The header X sits inside DialogPrimitive.Close AND carries onClick, so
   // one click reaches here twice (directly and via onOpenChange). A closed
   // confirmation unmounts, so close is one-shot by definition.
   const onClose = () => {
-    if (closedRef.current) return;
+    if (!modalClose || closedRef.current) return;
     closedRef.current = true;
-    modalClose?.();
+    modalClose();
   };
 
   return (
@@ -67,7 +68,7 @@ function ConfirmationModalLayout({
           icon={icon}
           title={title}
           description={description}
-          onClose={onClose}
+          onClose={canClose ? onClose : undefined}
         />
         <Modal.Body twoTone={twoTone}>
           {typeof children === "string" ? (
@@ -79,7 +80,7 @@ function ConfirmationModalLayout({
           )}
         </Modal.Body>
         <Modal.Footer>
-          {!hideCancel && (
+          {!hideCancel && canClose && (
             <Button prominence="secondary" onClick={onClose}>
               Cancel
             </Button>

--- a/web/src/app/craft/components/CraftSessionDeleteModal.stories.tsx
+++ b/web/src/app/craft/components/CraftSessionDeleteModal.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CraftSessionDeleteModal } from "@/app/craft/components/SideBar";
+
+const meta: Meta<typeof CraftSessionDeleteModal> = {
+  title: "Apps/Craft/Session/Delete Confirmation",
+  component: CraftSessionDeleteModal,
+  tags: ["autodocs"],
+  args: {
+    sessionTitle: "Quarterly planning dashboard",
+    isDeleting: false,
+    onClose: () => {},
+    onConfirm: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CraftSessionDeleteModal>;
+
+export const Playground: Story = {};

--- a/web/src/app/craft/components/SideBar.tsx
+++ b/web/src/app/craft/components/SideBar.tsx
@@ -75,7 +75,6 @@ export function CraftSessionDeleteModal({
   return (
     <ConfirmationModalLayout
       title={`Delete "${sessionTitle}"?`}
-      description="This permanently removes the Craft session and all of its data. This action cannot be undone."
       icon={SvgTrash}
       onClose={onClose}
       submit={
@@ -89,7 +88,10 @@ export function CraftSessionDeleteModal({
           {isDeleting ? "Deleting..." : "Delete"}
         </Button>
       }
-    />
+    >
+      This permanently removes the Craft session and all of its data. This
+      action cannot be undone.
+    </ConfirmationModalLayout>
   );
 }
 

--- a/web/src/app/craft/components/SideBar.tsx
+++ b/web/src/app/craft/components/SideBar.tsx
@@ -76,7 +76,7 @@ export function CraftSessionDeleteModal({
     <ConfirmationModalLayout
       title={`Delete "${sessionTitle}"?`}
       icon={SvgTrash}
-      onClose={onClose}
+      onClose={isDeleting ? undefined : onClose}
       submit={
         <Button
           disabled={isDeleting}
@@ -146,6 +146,7 @@ function BuildSessionButton({
 
       try {
         await onDelete();
+        setIsDeleting(false);
         toast.success(`Deleted "${historyItem.title}".`);
         closeModal();
         if (isActive && onDeleteActiveSession) {

--- a/web/src/app/craft/components/SideBar.tsx
+++ b/web/src/app/craft/components/SideBar.tsx
@@ -11,17 +11,24 @@ import {
   SessionHistoryItem,
 } from "@/app/craft/hooks/useBuildSessionStore";
 import { CRAFT_SEARCH_PARAM_NAMES } from "@/app/craft/services/searchParams";
-import { SidebarTab, Text } from "@opal/components";
 import {
+  Button,
+  Popover,
+  PopoverMenu,
+  SidebarTab,
+  Text,
+} from "@opal/components";
+import {
+  ConfirmationModalLayout,
   SidebarLayouts,
   SidebarStateProvider,
+  toast,
   useSidebarState,
 } from "@opal/layouts";
 import RefreshText from "@/refresh-components/texts/Text";
 import { renderSidebarLogo } from "@/lib/sidebar/utils";
 import { useShowLogoWhenFolded } from "@/lib/sidebar/hooks";
 import AccountPopover from "@/sections/sidebar/AccountPopover";
-import { Popover, PopoverMenu } from "@opal/components";
 import IconButton from "@/refresh-components/buttons/IconButton";
 import ButtonRenaming from "@/refresh-components/buttons/ButtonRenaming";
 import LineItem from "@/refresh-components/buttons/LineItem";
@@ -35,18 +42,11 @@ import {
   SvgMoreHorizontal,
   SvgEdit,
   SvgTrash,
-  SvgCheckCircle,
   SvgPlug,
   SvgSimpleLoader,
 } from "@opal/icons";
-import { ConfirmationModalLayout } from "@opal/layouts";
-import { Button } from "@opal/components";
 import TypewriterText from "@/app/craft/components/TypewriterText";
 import OpencodeDebugLogsButton from "@/app/craft/components/OpencodeDebugLogs";
-import {
-  DELETE_SUCCESS_DISPLAY_DURATION_MS,
-  DELETE_MESSAGE_ROTATION_INTERVAL_MS,
-} from "@/app/craft/constants";
 import {
   CRAFT_PATH,
   CRAFT_SKILLS_PATH,
@@ -56,57 +56,42 @@ import {
 import { useUnsavedChangesNavigation } from "@/providers/UnsavedChangesNavigationProvider";
 
 // ============================================================================
-// Fun Deleting Messages
-// ============================================================================
-
-const DELETING_MESSAGES = [
-  "Mining away your blocks...",
-  "Returning diamonds to the caves...",
-  "Creeper blew up your save file...",
-  "Throwing items into lava...",
-  "Despawning your entities...",
-  "Breaking bedrock illegally...",
-  "Enderman teleported your data away...",
-  "Falling into the void...",
-  "Your build ran out of hearts...",
-  "Respawning at world spawn...",
-  "Feeding your code to the Ender Dragon...",
-  "Activating TNT chain reaction...",
-  "Zombie horde consumed your bytes...",
-  "Wither withering your session...",
-  "Herobrine deleted your world...",
-];
-
-function DeletingMessage() {
-  const [messageIndex, setMessageIndex] = useState(() =>
-    Math.floor(Math.random() * DELETING_MESSAGES.length)
-  );
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setMessageIndex((prev) => {
-        let next = Math.floor(Math.random() * DELETING_MESSAGES.length);
-        while (next === prev && DELETING_MESSAGES.length > 1) {
-          next = Math.floor(Math.random() * DELETING_MESSAGES.length);
-        }
-        return next;
-      });
-    }, DELETE_MESSAGE_ROTATION_INTERVAL_MS);
-    return () => clearInterval(interval);
-  }, []);
-
-  return (
-    <div className="animate-subtle-pulse">
-      <Text as="p" color="text-03">
-        {DELETING_MESSAGES[messageIndex]}
-      </Text>
-    </div>
-  );
-}
-
-// ============================================================================
 // Build Session Button
 // ============================================================================
+
+interface CraftSessionDeleteModalProps {
+  sessionTitle: string;
+  isDeleting?: boolean;
+  onClose: () => void;
+  onConfirm: (event: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+export function CraftSessionDeleteModal({
+  sessionTitle,
+  isDeleting = false,
+  onClose,
+  onConfirm,
+}: CraftSessionDeleteModalProps) {
+  return (
+    <ConfirmationModalLayout
+      title={`Delete "${sessionTitle}"?`}
+      description="This permanently removes the Craft session and all of its data. This action cannot be undone."
+      icon={SvgTrash}
+      onClose={onClose}
+      submit={
+        <Button
+          disabled={isDeleting}
+          variant="danger"
+          prominence="primary"
+          onClick={onConfirm}
+          icon={isDeleting ? SvgSimpleLoader : undefined}
+        >
+          {isDeleting ? "Deleting..." : "Delete"}
+        </Button>
+      }
+    />
+  );
+}
 
 interface BuildSessionButtonProps {
   historyItem: SessionHistoryItem;
@@ -129,9 +114,6 @@ function BuildSessionButton({
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
-  const [deleteSuccess, setDeleteSuccess] = useState(false);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
-  const deleteTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // Track title changes for typewriter animation (only for auto-naming, not manual rename)
   const prevTitleRef = useRef(historyItem.title);
@@ -151,42 +133,30 @@ function BuildSessionButton({
   }, [historyItem.title, renaming]);
 
   const closeModal = useCallback(() => {
-    if (deleteTimeoutRef.current) {
-      clearTimeout(deleteTimeoutRef.current);
-      deleteTimeoutRef.current = null;
-    }
     setIsDeleteModalOpen(false);
     setPopoverOpen(false);
-    setDeleteSuccess(false);
-    setDeleteError(null);
-    setIsDeleting(false);
   }, []);
 
   const handleConfirmDelete = useCallback(
     async (e: React.MouseEvent<HTMLButtonElement>) => {
       e.stopPropagation();
       setIsDeleting(true);
-      setDeleteError(null);
 
       try {
         await onDelete();
-        setIsDeleting(false);
-        setDeleteSuccess(true);
-        // Show success briefly, then close and redirect if needed
-        deleteTimeoutRef.current = setTimeout(() => {
-          closeModal();
-          if (isActive && onDeleteActiveSession) {
-            onDeleteActiveSession();
-          }
-        }, DELETE_SUCCESS_DISPLAY_DURATION_MS);
+        toast.success(`Deleted "${historyItem.title}".`);
+        closeModal();
+        if (isActive && onDeleteActiveSession) {
+          onDeleteActiveSession();
+        }
       } catch (err) {
         setIsDeleting(false);
-        setDeleteError(
+        toast.error(
           err instanceof Error ? err.message : "Failed to delete session"
         );
       }
     },
-    [onDelete, closeModal, isActive, onDeleteActiveSession]
+    [onDelete, historyItem.title, closeModal, isActive, onDeleteActiveSession]
   );
 
   const rightMenu = (
@@ -271,53 +241,12 @@ function BuildSessionButton({
         </Popover.Anchor>
       </Popover>
       {isDeleteModalOpen && (
-        <ConfirmationModalLayout
-          title={
-            deleteSuccess
-              ? "Deleted"
-              : deleteError
-                ? "Delete Failed"
-                : "Delete Craft"
-          }
-          icon={deleteSuccess ? SvgCheckCircle : SvgTrash}
-          onClose={isDeleting || deleteSuccess ? undefined : closeModal}
-          hideCancel={isDeleting || deleteSuccess}
-          twoTone={!isDeleting && !deleteSuccess && !deleteError}
-          submit={
-            deleteSuccess ? (
-              <Button disabled variant="action" icon={SvgCheckCircle}>
-                Done
-              </Button>
-            ) : deleteError ? (
-              <Button variant="danger" onClick={closeModal}>
-                Close
-              </Button>
-            ) : (
-              <Button
-                disabled={isDeleting}
-                variant="danger"
-                onClick={handleConfirmDelete}
-                icon={isDeleting ? SvgSimpleLoader : undefined}
-              >
-                {isDeleting ? "Deleting..." : "Delete"}
-              </Button>
-            )
-          }
-        >
-          {deleteSuccess ? (
-            <Text as="p" color="text-03">
-              Build deleted successfully.
-            </Text>
-          ) : deleteError ? (
-            <Text as="p" color="status-error-02">
-              {deleteError}
-            </Text>
-          ) : isDeleting ? (
-            <DeletingMessage />
-          ) : (
-            "Are you sure you want to delete this craft? This action cannot be undone."
-          )}
-        </ConfirmationModalLayout>
+        <CraftSessionDeleteModal
+          sessionTitle={historyItem.title}
+          isDeleting={isDeleting}
+          onClose={closeModal}
+          onConfirm={handleConfirmDelete}
+        />
       )}
     </>
   );

--- a/web/src/app/craft/constants.ts
+++ b/web/src/app/craft/constants.ts
@@ -1,9 +1,0 @@
-// ============================================================================
-// Build Session Constants
-// ============================================================================
-
-/** Duration to display success state after session deletion (ms) */
-export const DELETE_SUCCESS_DISPLAY_DURATION_MS = 800;
-
-/** Interval for rotating delete messages during session deletion (ms) */
-export const DELETE_MESSAGE_ROTATION_INTERVAL_MS = 3000;

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import { create } from "zustand";
-import { DELETE_SUCCESS_DISPLAY_DURATION_MS } from "@/app/craft/constants";
 
 import {
   ApiSessionResponse,
@@ -1751,11 +1750,7 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
         };
       });
 
-      // Refresh history after UI has shown success state
-      setTimeout(
-        () => refreshSessionHistory(),
-        DELETE_SUCCESS_DISPLAY_DURATION_MS
-      );
+      await refreshSessionHistory();
     } catch (err) {
       console.error("Failed to delete session:", err);
       throw err;

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -1745,12 +1745,15 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
         newSessions.delete(sessionId);
         return {
           sessions: newSessions,
+          sessionHistory: state.sessionHistory.filter(
+            (historyItem) => historyItem.id !== sessionId
+          ),
           currentSessionId:
             currentSessionId === sessionId ? null : state.currentSessionId,
         };
       });
 
-      await refreshSessionHistory();
+      void refreshSessionHistory();
     } catch (err) {
       console.error("Failed to delete session:", err);
       throw err;


### PR DESCRIPTION
## Description
<img width="607" height="548" alt="image" src="https://github.com/user-attachments/assets/b6779452-a3ee-4fba-b655-3750c8813160" />

- Align the Craft session deletion confirmation with the standard Craft modal pattern.
- Replace bespoke deletion messages and in-modal result states with standard loading and toast feedback.
- Refresh session history immediately after deletion.
- Add a lightweight Storybook playground for quick visual verification.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align the Craft session delete flow with the standard `@opal/layouts` modal and toast pattern. Block closing while deleting and refresh session history immediately.

- **Refactors**
  - Added `CraftSessionDeleteModal` using `ConfirmationModalLayout` with a danger submit and loader; moved the warning copy into the modal body.
  - Hardened `ConfirmationModalLayout` to hide the header close and Cancel when `onClose` is unavailable and avoid double close.
  - Replaced custom deleting/success/error UI with `toast` feedback; simplified `SideBar` state.
  - Immediately prune and refresh session history after deletion in `useBuildSessionStore`; removed the timeout and `constants.ts`.
  - Added a Storybook playground.

<sup>Written for commit b666f85d66498bc3854802f411600cee58cd9469. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



