### PR TITLE
fix(auth): claim an unowned account on first SSO login (#13791) to release v4.4

### DIFF
--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -54,6 +54,7 @@ from ee.onyx.server.scim.schema_definitions import (
     USER_RESOURCE_TYPE,
     USER_SCHEMA_DEF,
 )
+from onyx.auth.users import is_user_curator_or_admin
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import AccountType, GrantSource, Permission
 from onyx.db.models import ScimToken, ScimUserMapping, User, UserGroup, UserRole
@@ -221,6 +222,16 @@ def _check_seat_availability(dal: ScimDAL) -> str | None:
     if not result.available:
         return result.error_message or "Seat limit reached"
     return None
+
+
+def _is_privileged_rename(user: User, new_email: str) -> bool:
+    """Whether this would move a curator or admin onto a different address.
+
+    A rename puts the account on an address the caller chose, and a row no IdP
+    owns yet is claimed by the first login for its address. Provisioning only
+    ever grants BASIC, so a token must not move anything above that.
+    """
+    return new_email.lower() != user.email.lower() and is_user_curator_or_admin(user)
 
 
 def _is_ext_perm_user(user: User) -> bool:
@@ -626,6 +637,9 @@ def replace_user(
         return result
     user = result
 
+    if _is_privileged_rename(user, user_resource.userName.strip()):
+        return _scim_error_response(403, "Cannot move a curator or admin address")
+
     # Handle activation (need seat check) / deactivation. Promoting a shadow
     # EXT_PERM_USER also consumes a seat, so self-heal any that the IdP
     # re-syncs after being adopted while still in the shadow role.
@@ -719,6 +733,9 @@ def patch_user(
         )
     except ScimPatchError as e:
         return _scim_error_response(e.status, e.detail)
+
+    if patched.userName and _is_privileged_rename(user, patched.userName.strip()):
+        return _scim_error_response(403, "Cannot move a curator or admin address")
 
     # Apply changes back to the DB model. A seat is consumed when the user
     # becomes active (reactivation) or when a shadow EXT_PERM_USER is promoted

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -960,12 +960,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                         if not user.is_active:
                             return user
 
-                        # An owned row must not take a second provider, and a
-                        # rename stops the address identifying the row. All else
-                        # is claimable, password signups included.
-                        if not associate_by_email and (
-                            user.oauth_accounts or user.prior_emails
-                        ):
+                        # Only a row an IdP already owns is off limits. Any other
+                        # row is claimed by the first login that proves its address.
+                        if not associate_by_email and user.oauth_accounts:
                             raise exceptions.UserAlreadyExists()
 
                     user = await self.user_db.add_oauth_account(

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -952,14 +952,21 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     user = await self.user_db.get_by_email(account_email)
                     if user is None:
                         raise exceptions.UserNotExists()
-                    if not associate_by_email and user.account_type.is_web_login():
-                        # Linking a login to an existing same-email account is
-                        # an account-takeover vector unless explicitly enabled.
-                        # Non-web-login placeholders (permission-sync
-                        # EXT_PERM_USER, bots) carry no credentials or sessions,
-                        # so there is nothing to take over, and the non-web-login
-                        # upgrade below claims them.
-                        raise exceptions.UserAlreadyExists()
+                    # Placeholders (EXT_PERM_USER, bots) carry no credentials or
+                    # sessions, so neither check applies and the upgrade claims them.
+                    if user.account_type.is_web_login():
+                        # Linking commits, so a disabled row comes back unlinked.
+                        # Linking would hand it to this identity on reactivation.
+                        if not user.is_active:
+                            return user
+
+                        # An owned row must not take a second provider, and a
+                        # rename stops the address identifying the row. All else
+                        # is claimable, password signups included.
+                        if not associate_by_email and (
+                            user.oauth_accounts or user.prior_emails
+                        ):
+                            raise exceptions.UserAlreadyExists()
 
                     user = await self.user_db.add_oauth_account(
                         user, oauth_account_dict

--- a/backend/tests/external_dependency_unit/auth/test_oidc_multi_live_idp.py
+++ b/backend/tests/external_dependency_unit/auth/test_oidc_multi_live_idp.py
@@ -1,9 +1,9 @@
 """Live-IdP coverage for the DB-backed multi-provider OIDC login against a real
-OIDC server: two providers on one instance complete the authorization-code flow
-(discovery fetch, code exchange, userinfo, JIT user provisioning, session
-issuance), the per-provider email-domain gate rejects a cross-domain login, an
-unverified email is rejected, and with auto-linking off a second provider does
-not attach to an existing account.
+OIDC server. Two providers run on one instance, so these guard the parts that
+only break in a real authorization-code flow: discovery, code exchange, userinfo
+and session issuance end to end, the per-provider gates that reject a login
+(email domain, unverified address), and which pre-existing same-email rows a
+login may claim when auto-linking is off.
 
 Uses navikt/mock-oauth2-server, a real OIDC server whose per-login claims are
 set through its documented username+claims form post, so there is no HTML
@@ -23,12 +23,14 @@ import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from fastapi_users.password import PasswordHelper
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.orm import Session
 
+from onyx.auth.schemas import UserRole
 from onyx.auth.users import cookie_transport
-from onyx.db.enums import SSOProviderType
-from onyx.db.models import SSOProvider, User, User__UserGroup
+from onyx.db.enums import AccountType, SSOProviderType
+from onyx.db.models import ScimUserMapping, SSOProvider, User, User__UserGroup
 from onyx.db.sso_provider import create_sso_provider
 from onyx.error_handling.exceptions import register_onyx_exception_handlers
 from onyx.server import oidc_multi
@@ -52,10 +54,12 @@ _PROVIDER_D = "mock-d"
 _ISSUER_C = "issuer-c"
 _ISSUER_D = "issuer-d"
 _SHARED_USER = "shared@shared.com"
+# Provisioned by SCIM before ever logging in, on the same shared.com domain.
+_SCIM_USER = "provisioned@shared.com"
 
 _SESSION_COOKIE = cookie_transport.cookie_name
 
-_EMAILS = [_USER_A, _USER_B, _EVE, _SHARED_USER]
+_EMAILS = [_USER_A, _USER_B, _EVE, _SHARED_USER, _SCIM_USER]
 _NAMES = [_PROVIDER_A, _PROVIDER_B, _PROVIDER_C, _PROVIDER_D]
 
 
@@ -132,6 +136,35 @@ def same_domain_providers(db_session: Session) -> Generator[None, None, None]:
     _create_provider(db_session, _PROVIDER_D, _ISSUER_D, "shared.com")
     yield
     _cleanup_db(db_session)
+
+
+def _provision(
+    db_session: Session, scim_managed: bool = False, **overrides: object
+) -> User:
+    """An account created ahead of its owner: complete, active, and holding only a
+    throwaway password, with no oauth_account until someone logs in as it.
+
+    ``scim_managed`` adds the mapping SCIM's POST /Users writes. The guard does not
+    read it, so it is opt-in for the tests that reproduce the SCIM report.
+    """
+    pw_helper = PasswordHelper()
+    user = User(
+        **{
+            "email": _SCIM_USER,
+            "hashed_password": pw_helper.hash(pw_helper.generate()),
+            "role": UserRole.BASIC,
+            "account_type": AccountType.STANDARD,
+            "is_active": True,
+            "is_verified": True,
+            **overrides,
+        }
+    )
+    db_session.add(user)
+    db_session.flush()
+    if scim_managed:
+        db_session.add(ScimUserMapping(external_id="idp-ext-1", user_id=user.id))
+    db_session.commit()
+    return user
 
 
 @pytest.fixture
@@ -259,3 +292,90 @@ async def test_second_provider_does_not_link_existing_account(
     db_session.expire_all()
     user = _user_by_email(db_session, _SHARED_USER)
     assert [oa.oauth_name for oa in user.oauth_accounts] == [_PROVIDER_C]
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("same_domain_providers")
+async def test_provisioned_user_links_on_first_login(
+    app: FastAPI, db_session: Session
+) -> None:
+    """Provisioning creates the account ahead of the person, so their first login
+    finds a same-email row with no oauth_account and must claim that row rather
+    than reject it. Auto-linking stays off throughout."""
+    provisioned_id = _provision(db_session, scim_managed=True).id
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=_WEB_DOMAIN) as client:
+        resp = await _drive_login(client, _PROVIDER_C, _SCIM_USER)
+        assert resp.status_code == 302, resp.text
+        assert _SESSION_COOKIE in resp.cookies
+
+    db_session.expire_all()
+    user = _user_by_email(db_session, _SCIM_USER)
+    # Claiming the row rather than creating a second one is the whole point: the
+    # SCIM mapping is keyed on user_id, so a new row would strand it.
+    assert user.id == provisioned_id
+    assert [oa.oauth_name for oa in user.oauth_accounts] == [_PROVIDER_C]
+    assert db_session.query(ScimUserMapping).filter_by(user_id=user.id).count() == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("same_domain_providers")
+async def test_claimed_row_rejects_second_provider(
+    app: FastAPI, db_session: Session
+) -> None:
+    """A provisioned row is claimable only until an IdP claims it. A second
+    provider asserting the same address is then refused, and the first provider's
+    link is left untouched."""
+    _provision(db_session, scim_managed=True)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=_WEB_DOMAIN) as client:
+        first = await _drive_login(client, _PROVIDER_C, _SCIM_USER)
+        assert first.status_code == 302, first.text
+
+        second = await _drive_login(client, _PROVIDER_D, _SCIM_USER)
+        assert second.status_code == 400, second.text
+        assert _SESSION_COOKIE not in second.cookies
+
+    db_session.expire_all()
+    user = _user_by_email(db_session, _SCIM_USER)
+    assert [oa.oauth_name for oa in user.oauth_accounts] == [_PROVIDER_C]
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("same_domain_providers")
+async def test_renamed_row_is_not_claimable(app: FastAPI, db_session: Session) -> None:
+    """A row moved onto this address by a rename must not be claimable. Whoever
+    performed the rename would otherwise hand the original account, and its
+    history and privileges, to any identity that can assert the new address."""
+    renamed = _provision(db_session, prior_emails=["someone-else@shared.com"])
+    renamed_id = renamed.id
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=_WEB_DOMAIN) as client:
+        resp = await _drive_login(client, _PROVIDER_C, _SCIM_USER)
+        assert resp.status_code == 400, resp.text
+        assert _SESSION_COOKIE not in resp.cookies
+
+    db_session.expire_all()
+    user = _user_by_email(db_session, _SCIM_USER)
+    assert user.id == renamed_id
+    assert user.oauth_accounts == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("same_domain_providers")
+async def test_deactivated_row_is_not_linked(app: FastAPI, db_session: Session) -> None:
+    """Claiming commits, so a deprovisioned row must come back unlinked. Linking
+    it would hand the account to this identity the moment SCIM reactivates it."""
+    _provision(db_session, is_active=False)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=_WEB_DOMAIN) as client:
+        resp = await _drive_login(client, _PROVIDER_C, _SCIM_USER)
+        assert resp.status_code == 400, resp.text
+        assert _SESSION_COOKIE not in resp.cookies
+
+    db_session.expire_all()
+    assert _user_by_email(db_session, _SCIM_USER).oauth_accounts == []

--- a/backend/tests/external_dependency_unit/auth/test_oidc_multi_live_idp.py
+++ b/backend/tests/external_dependency_unit/auth/test_oidc_multi_live_idp.py
@@ -54,7 +54,6 @@ _PROVIDER_D = "mock-d"
 _ISSUER_C = "issuer-c"
 _ISSUER_D = "issuer-d"
 _SHARED_USER = "shared@shared.com"
-# Provisioned by SCIM before ever logging in, on the same shared.com domain.
 _SCIM_USER = "provisioned@shared.com"
 
 _SESSION_COOKIE = cookie_transport.cookie_name
@@ -141,12 +140,8 @@ def same_domain_providers(db_session: Session) -> Generator[None, None, None]:
 def _provision(
     db_session: Session, scim_managed: bool = False, **overrides: object
 ) -> User:
-    """An account created ahead of its owner: complete, active, and holding only a
-    throwaway password, with no oauth_account until someone logs in as it.
-
-    ``scim_managed`` adds the mapping SCIM's POST /Users writes. The guard does not
-    read it, so it is opt-in for the tests that reproduce the SCIM report.
-    """
+    """A row created ahead of its owner: active by default, throwaway password, no
+    oauth_account. The SCIM mapping is opt-in because the guard never reads it."""
     pw_helper = PasswordHelper()
     user = User(
         **{
@@ -312,8 +307,7 @@ async def test_provisioned_user_links_on_first_login(
 
     db_session.expire_all()
     user = _user_by_email(db_session, _SCIM_USER)
-    # Claiming the row rather than creating a second one is the whole point: the
-    # SCIM mapping is keyed on user_id, so a new row would strand it.
+    # The SCIM mapping is keyed on user_id, so a second row would strand it.
     assert user.id == provisioned_id
     assert [oa.oauth_name for oa in user.oauth_accounts] == [_PROVIDER_C]
     assert db_session.query(ScimUserMapping).filter_by(user_id=user.id).count() == 1
@@ -327,7 +321,7 @@ async def test_claimed_row_rejects_second_provider(
     """A provisioned row is claimable only until an IdP claims it. A second
     provider asserting the same address is then refused, and the first provider's
     link is left untouched."""
-    _provision(db_session, scim_managed=True)
+    _provision(db_session)
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url=_WEB_DOMAIN) as client:
@@ -345,30 +339,9 @@ async def test_claimed_row_rejects_second_provider(
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("same_domain_providers")
-async def test_renamed_row_is_not_claimable(app: FastAPI, db_session: Session) -> None:
-    """A row moved onto this address by a rename must not be claimable. Whoever
-    performed the rename would otherwise hand the original account, and its
-    history and privileges, to any identity that can assert the new address."""
-    renamed = _provision(db_session, prior_emails=["someone-else@shared.com"])
-    renamed_id = renamed.id
-
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url=_WEB_DOMAIN) as client:
-        resp = await _drive_login(client, _PROVIDER_C, _SCIM_USER)
-        assert resp.status_code == 400, resp.text
-        assert _SESSION_COOKIE not in resp.cookies
-
-    db_session.expire_all()
-    user = _user_by_email(db_session, _SCIM_USER)
-    assert user.id == renamed_id
-    assert user.oauth_accounts == []
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("same_domain_providers")
 async def test_deactivated_row_is_not_linked(app: FastAPI, db_session: Session) -> None:
     """Claiming commits, so a deprovisioned row must come back unlinked. Linking
-    it would hand the account to this identity the moment SCIM reactivates it."""
+    it would hand the account to this identity on reactivation."""
     _provision(db_session, is_active=False)
 
     transport = ASGITransport(app=app)

--- a/backend/tests/unit/onyx/auth/test_user_registration.py
+++ b/backend/tests/unit/onyx/auth/test_user_registration.py
@@ -622,15 +622,14 @@ class TestOAuthDottedGmail:
             assert call.kwargs.get("is_registration") is not True
 
 
-class TestOAuthNoAutoLinkExemptions:
-    """With auto-link off, a web-login row refuses a same-email login once it is
-    spoken for: a linked IdP (a second provider must not attach), a rename (a moved
-    address stops proving whose row it is), or deactivation. A row with none of
-    those is claimed. Placeholders skip the checks and are promoted instead."""
+class TestOAuthNoAutoLinkClaim:
+    """With auto-link off, a first SSO login claims a web-login row unless an IdP
+    already owns it or it is deactivated. Placeholders skip both checks and are
+    promoted instead."""
 
     @staticmethod
     def _unclaimed(**attrs: object) -> MagicMock:
-        """A row provisioned ahead of its owner: no IdP, original address, active.
+        """A row provisioned ahead of its owner: no IdP, active.
 
         Every attribute the guard reads is set explicitly. A bare MagicMock
         attribute is truthy, which would silently invert the assertions here.
@@ -640,7 +639,6 @@ class TestOAuthNoAutoLinkExemptions:
                 "id": "user-id",
                 "email": "provisioned@corp.com",
                 "oauth_accounts": [],
-                "prior_emails": [],
                 "is_active": True,
                 "account_type": AccountType.STANDARD,
                 # Read by the offboarding tail of oauth_callback, not the guard.
@@ -669,8 +667,8 @@ class TestOAuthNoAutoLinkExemptions:
         return user_manager
 
     @pytest.mark.asyncio
-    # A placeholder is deactivated until its owner shows up, so the deactivated
-    # case is the one that matters: it must promote, not be turned away.
+    # The deactivation check is web-login-only, so a deactivated placeholder must
+    # still reach the upgrade rather than being turned away.
     @pytest.mark.parametrize("is_active", [True, False], ids=["active", "deactivated"])
     @patch("onyx.auth.users.MULTI_TENANT", False)
     @patch("onyx.auth.users.verify_email_in_whitelist")
@@ -777,38 +775,30 @@ class TestOAuthNoAutoLinkExemptions:
         assert result is provisioned
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "overrides",
-        [
-            # A second provider must not attach to a row an IdP already owns.
-            pytest.param({"oauth_accounts": [MagicMock()]}, id="already-linked"),
-            # A rename moved this row onto the address, so the address no longer
-            # proves whose row it is.
-            pytest.param({"prior_emails": ["old@corp.com"]}, id="renamed"),
-        ],
-    )
     @patch("onyx.auth.users.MULTI_TENANT", False)
     @patch("onyx.auth.users.verify_email_in_whitelist")
     @patch("onyx.auth.users.verify_email_domain")
     @patch("onyx.auth.users.fetch_ee_implementation_or_noop")
     @patch("onyx.auth.users.get_async_session_context_manager")
     @patch("onyx.auth.users.remove_user_from_invited_users")
-    async def test_spoken_for_row_is_rejected(
+    async def test_already_linked_row_is_rejected(
         self,
         mock_remove_invited: MagicMock,  # noqa: ARG002
         mock_session_manager: MagicMock,
         mock_fetch_ee: MagicMock,
         mock_verify_domain: MagicMock,  # noqa: ARG002
         mock_verify_whitelist: MagicMock,  # noqa: ARG002
-        overrides: dict[str, object],
         mock_async_session: MagicMock,
     ) -> None:
+        """A second provider must not attach to a row an IdP already owns."""
         mock_session_manager.return_value = _AsyncSessionContextManager(
             mock_async_session
         )
         mock_fetch_ee.return_value = AsyncMock(return_value="test_tenant")
 
-        user_manager = self._manager_with_existing(self._unclaimed(**overrides))
+        user_manager = self._manager_with_existing(
+            self._unclaimed(oauth_accounts=[MagicMock()])
+        )
 
         with pytest.raises(exceptions.UserAlreadyExists):
             await user_manager.oauth_callback(

--- a/backend/tests/unit/onyx/auth/test_user_registration.py
+++ b/backend/tests/unit/onyx/auth/test_user_registration.py
@@ -622,10 +622,32 @@ class TestOAuthDottedGmail:
             assert call.kwargs.get("is_registration") is not True
 
 
-class TestOAuthPlaceholderPromotion:
-    """A permission-sync placeholder (non-web-login account_type) must be
-    claimed and upgraded by SSO login even with auto-link off, while real
-    web-login accounts keep the account-takeover rejection."""
+class TestOAuthNoAutoLinkExemptions:
+    """With auto-link off, a web-login row refuses a same-email login once it is
+    spoken for: a linked IdP (a second provider must not attach), a rename (a moved
+    address stops proving whose row it is), or deactivation. A row with none of
+    those is claimed. Placeholders skip the checks and are promoted instead."""
+
+    @staticmethod
+    def _unclaimed(**attrs: object) -> MagicMock:
+        """A row provisioned ahead of its owner: no IdP, original address, active.
+
+        Every attribute the guard reads is set explicitly. A bare MagicMock
+        attribute is truthy, which would silently invert the assertions here.
+        """
+        return MagicMock(
+            **{  # ty: ignore[invalid-argument-type]
+                "id": "user-id",
+                "email": "provisioned@corp.com",
+                "oauth_accounts": [],
+                "prior_emails": [],
+                "is_active": True,
+                "account_type": AccountType.STANDARD,
+                # Read by the offboarding tail of oauth_callback, not the guard.
+                "oidc_expiry": None,
+                **attrs,
+            }
+        )
 
     @staticmethod
     def _manager_with_existing(existing_user: MagicMock) -> UserManager:
@@ -647,6 +669,9 @@ class TestOAuthPlaceholderPromotion:
         return user_manager
 
     @pytest.mark.asyncio
+    # A placeholder is deactivated until its owner shows up, so the deactivated
+    # case is the one that matters: it must promote, not be turned away.
+    @pytest.mark.parametrize("is_active", [True, False], ids=["active", "deactivated"])
     @patch("onyx.auth.users.MULTI_TENANT", False)
     @patch("onyx.auth.users.verify_email_in_whitelist")
     @patch("onyx.auth.users.verify_email_domain")
@@ -666,6 +691,7 @@ class TestOAuthPlaceholderPromotion:
         mock_fetch_ee: MagicMock,
         mock_verify_domain: MagicMock,  # noqa: ARG002
         mock_verify_whitelist: MagicMock,  # noqa: ARG002
+        is_active: bool,
         mock_async_session: MagicMock,
     ) -> None:
         mock_session_manager.return_value = _AsyncSessionContextManager(
@@ -673,13 +699,15 @@ class TestOAuthPlaceholderPromotion:
         )
         mock_fetch_ee.return_value = AsyncMock(return_value="test_tenant")
 
-        placeholder = MagicMock(id="placeholder-id", email="synced@corp.com")
-        placeholder.account_type = AccountType.EXT_PERM_USER
-        placeholder.oidc_expiry = None
-        placeholder.is_active = True
+        placeholder = self._unclaimed(
+            id="placeholder-id",
+            email="synced@corp.com",
+            account_type=AccountType.EXT_PERM_USER,
+            is_active=is_active,
+        )
         user_manager = self._manager_with_existing(placeholder)
 
-        sync_user = MagicMock(is_active=True)
+        sync_user = MagicMock(is_active=is_active)
         mock_sync_db = MagicMock()
         mock_sync_db.query.return_value.filter.return_value.first.return_value = (
             sync_user
@@ -704,6 +732,9 @@ class TestOAuthPlaceholderPromotion:
         assert sync_user.role == UserRole.BASIC
         assert sync_user.account_type == AccountType.STANDARD
         assert sync_user.is_verified is True
+        # Promotion reactivates, so the web-login deactivation check must not
+        # short-circuit a placeholder before it reaches the upgrade.
+        assert sync_user.is_active is True
         mock_assign_groups.assert_called_once()
         mock_sync_db.commit.assert_called_once()
         assert result is placeholder
@@ -715,7 +746,7 @@ class TestOAuthPlaceholderPromotion:
     @patch("onyx.auth.users.fetch_ee_implementation_or_noop")
     @patch("onyx.auth.users.get_async_session_context_manager")
     @patch("onyx.auth.users.remove_user_from_invited_users")
-    async def test_web_login_account_still_rejected_without_auto_link(
+    async def test_unclaimed_row_is_claimed_by_first_login(
         self,
         mock_remove_invited: MagicMock,  # noqa: ARG002
         mock_session_manager: MagicMock,
@@ -724,25 +755,109 @@ class TestOAuthPlaceholderPromotion:
         mock_verify_whitelist: MagicMock,  # noqa: ARG002
         mock_async_session: MagicMock,
     ) -> None:
+        """The provisioned-ahead-of-its-owner case: SCIM, invite, any out-of-band
+        create. Nothing about the row is spoken for, so the login claims it."""
         mock_session_manager.return_value = _AsyncSessionContextManager(
             mock_async_session
         )
         mock_fetch_ee.return_value = AsyncMock(return_value="test_tenant")
 
-        real_user = MagicMock(id="real-id", email="taken@corp.com")
-        real_user.account_type = AccountType.STANDARD
-        user_manager = self._manager_with_existing(real_user)
+        provisioned = self._unclaimed()
+        user_manager = self._manager_with_existing(provisioned)
+
+        result = await user_manager.oauth_callback(
+            oauth_name="okta",
+            access_token="token",
+            account_id="acct-3",
+            account_email="provisioned@corp.com",
+            associate_by_email=False,
+        )
+
+        cast(AsyncMock, user_manager.user_db.add_oauth_account).assert_awaited_once()
+        assert result is provisioned
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            # A second provider must not attach to a row an IdP already owns.
+            pytest.param({"oauth_accounts": [MagicMock()]}, id="already-linked"),
+            # A rename moved this row onto the address, so the address no longer
+            # proves whose row it is.
+            pytest.param({"prior_emails": ["old@corp.com"]}, id="renamed"),
+        ],
+    )
+    @patch("onyx.auth.users.MULTI_TENANT", False)
+    @patch("onyx.auth.users.verify_email_in_whitelist")
+    @patch("onyx.auth.users.verify_email_domain")
+    @patch("onyx.auth.users.fetch_ee_implementation_or_noop")
+    @patch("onyx.auth.users.get_async_session_context_manager")
+    @patch("onyx.auth.users.remove_user_from_invited_users")
+    async def test_spoken_for_row_is_rejected(
+        self,
+        mock_remove_invited: MagicMock,  # noqa: ARG002
+        mock_session_manager: MagicMock,
+        mock_fetch_ee: MagicMock,
+        mock_verify_domain: MagicMock,  # noqa: ARG002
+        mock_verify_whitelist: MagicMock,  # noqa: ARG002
+        overrides: dict[str, object],
+        mock_async_session: MagicMock,
+    ) -> None:
+        mock_session_manager.return_value = _AsyncSessionContextManager(
+            mock_async_session
+        )
+        mock_fetch_ee.return_value = AsyncMock(return_value="test_tenant")
+
+        user_manager = self._manager_with_existing(self._unclaimed(**overrides))
 
         with pytest.raises(exceptions.UserAlreadyExists):
             await user_manager.oauth_callback(
-                oauth_name="okta",
+                oauth_name="entra",
                 access_token="token",
-                account_id="acct-2",
-                account_email="taken@corp.com",
+                account_id="acct-4",
+                account_email="provisioned@corp.com",
                 associate_by_email=False,
             )
 
         cast(AsyncMock, user_manager.user_db.add_oauth_account).assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("onyx.auth.users.MULTI_TENANT", False)
+    @patch("onyx.auth.users.verify_email_in_whitelist")
+    @patch("onyx.auth.users.verify_email_domain")
+    @patch("onyx.auth.users.fetch_ee_implementation_or_noop")
+    @patch("onyx.auth.users.get_async_session_context_manager")
+    @patch("onyx.auth.users.remove_user_from_invited_users")
+    async def test_deactivated_row_is_not_linked(
+        self,
+        mock_remove_invited: MagicMock,  # noqa: ARG002
+        mock_session_manager: MagicMock,
+        mock_fetch_ee: MagicMock,
+        mock_verify_domain: MagicMock,  # noqa: ARG002
+        mock_verify_whitelist: MagicMock,  # noqa: ARG002
+        mock_async_session: MagicMock,
+    ) -> None:
+        """Linking commits, so a deprovisioned row must come back unclaimed. The
+        caller's is_active gate is what turns this into a rejected login."""
+        mock_session_manager.return_value = _AsyncSessionContextManager(
+            mock_async_session
+        )
+        mock_fetch_ee.return_value = AsyncMock(return_value="test_tenant")
+
+        deactivated = self._unclaimed(is_active=False)
+        user_manager = self._manager_with_existing(deactivated)
+
+        result = await user_manager.oauth_callback(
+            oauth_name="okta",
+            access_token="token",
+            account_id="acct-5",
+            account_email="provisioned@corp.com",
+            associate_by_email=False,
+        )
+
+        cast(AsyncMock, user_manager.user_db.add_oauth_account).assert_not_awaited()
+        assert result is deactivated
+        assert result.is_active is False
 
 
 class TestPasswordAuthKillSwitch:

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+import pytest
 from fastapi import Response
 from sqlalchemy.exc import IntegrityError
 
@@ -585,6 +586,63 @@ class TestReplaceUser:
         mock_dal.update_user.assert_called_once()
         mock_dal.commit.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "role", [UserRole.ADMIN, UserRole.CURATOR, UserRole.GLOBAL_CURATOR]
+    )
+    def test_moving_a_curator_or_admin_address_is_refused(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+        role: UserRole,
+    ) -> None:
+        """A rename puts the account on an address the caller picked, and a row
+        no IdP owns yet is claimed by the first login for its address. Anything
+        above BASIC must not be movable by a token that can only grant BASIC."""
+        user = make_db_user(email="admin@example.com", role=role)
+        mock_dal.get_user.return_value = user
+        resource = make_scim_user(userName="attacker@example.com")
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=resource,
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 403)
+        mock_dal.update_user.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "role", [UserRole.ADMIN, UserRole.CURATOR, UserRole.GLOBAL_CURATOR]
+    )
+    def test_privileged_update_without_a_rename_is_allowed(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+        role: UserRole,
+    ) -> None:
+        """Only the address is off limits. Deprovisioning an admin still has to
+        work, or a departing one keeps their seat and their access."""
+        user = make_db_user(email="admin@example.com", role=role)
+        mock_dal.get_user.return_value = user
+        resource = make_scim_user(userName="Admin@Example.com", active=False)
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=resource,
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        mock_dal.update_user.assert_called_once()
+
     def test_not_found_returns_404(
         self,
         mock_db_session: MagicMock,
@@ -751,6 +809,38 @@ class TestPatchUser:
 
         parse_scim_user(result)
         mock_dal.update_user.assert_called_once()
+
+    def test_moving_a_curator_or_admin_address_is_refused(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """PATCH is what IdPs actually send, so the address guard has to hold
+        here and not only on PUT."""
+        user = make_db_user(email="admin@example.com", role=UserRole.ADMIN)
+        mock_dal.get_user.return_value = user
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REPLACE,
+                    path="userName",
+                    value="attacker@example.com",
+                )
+            ]
+        )
+
+        result = patch_user(
+            user_id=str(user.id),
+            patch_request=patch_req,
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 403)
+        mock_dal.update_user.assert_not_called()
 
     @patch("ee.onyx.server.scim.api.assign_user_to_default_groups__no_commit")
     @patch("ee.onyx.server.scim.api._check_seat_availability", return_value=None)


### PR DESCRIPTION
Cherry-pick of commit a5dc1d6c3b3ec2380a0170d2662135d13dd67281 to release/v4.4 branch.

Original PR: #13791

- [x] [Optional] Override Linear Check
