### PR TITLE
fix(mcp): always relay the OAuth authorization URL on connect

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -624,6 +624,11 @@ def make_pkce_pair() -> tuple[str, str]:
 
 MCP_OAUTH_CALLBACK_PATH = "/mcp/oauth/callback"
 
+# BLPOP slice for the authorization-URL wait. Cancellation cannot abort an
+# in-flight BLPOP, so each call stays short to keep a cancelled wait from
+# parking an executor thread and a Redis connection for the rest of the window.
+AUTH_URL_POLL_SECONDS: int = 1
+
 
 def _mcp_oauth_redirect_uri() -> str:
     return f"{WEB_DOMAIN}{MCP_OAUTH_CALLBACK_PATH}"
@@ -915,16 +920,15 @@ async def _connect_oauth(
     # 1) The OAuth redirect URL becomes available in Redis (we should return it)
     # 2) The initialize task completes (tokens already valid) — return to the provided return_path
     r = get_redis_client()
-    loop = asyncio.get_running_loop()
 
     async def wait_auth_url() -> str | None:
-        raw = await loop.run_in_executor(
-            None,
-            lambda: r.blpop([key_auth_url(str(user.id))], timeout=OAUTH_WAIT_SECONDS),
-        )
-        if raw is None:
-            return None
-        return raw[1].decode()
+        key = key_auth_url(str(user.id))
+        deadline = time.monotonic() + OAUTH_WAIT_SECONDS
+        while time.monotonic() < deadline:
+            raw = await asyncio.to_thread(r.blpop, [key], AUTH_URL_POLL_SECONDS)
+            if raw is not None:
+                return raw[1].decode()
+        return None
 
     # The stored config can't tell us whether the handshake will demand a fresh
     # authorization, and the SDK offers that URL exactly once — always listen.

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -926,15 +926,17 @@ async def _connect_oauth(
             return None
         return raw[1].decode()
 
-    auth_task = None if is_connected else asyncio.create_task(wait_auth_url())
+    # The stored config can't tell us whether the handshake will demand a fresh
+    # authorization, and the SDK offers that URL exactly once — always listen.
+    auth_task = asyncio.create_task(wait_auth_url())
 
     done, pending = await asyncio.wait(
-        [init_task] + ([auth_task] if auth_task else []),
+        [init_task, auth_task],
         return_when=asyncio.FIRST_COMPLETED,
     )
 
     # If we got an auth URL first, return it
-    if auth_task is not None and auth_task in done:
+    if auth_task in done:
         oauth_url = await auth_task
         # If no URL was retrieved within the timeout, treat as error
         if not oauth_url:

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -887,6 +887,17 @@ async def _connect_oauth(
     probe_url = mcp_server.server_url
     logger.info("Probing OAuth server at: %s", probe_url)
 
+    # An OAuth server's credential is the stored token; a leftover Authorization
+    # header can still satisfy the probe, reporting connected for a config every
+    # tool call rejects. Drop it so the probe 401s and authorization can run.
+    probe_headers = connection_config_dict.get("headers", {})
+    if not connection_config_dict.get(MCPOAuthKeys.TOKENS.value):
+        probe_headers = {
+            name: value
+            for name, value in probe_headers.items()
+            if name.lower() != "authorization"
+        }
+
     oauth_auth = make_oauth_provider(
         mcp_server,
         str(user.id),
@@ -904,7 +915,7 @@ async def _connect_oauth(
         try:
             x = await initialize_mcp_client(
                 probe_url,
-                connection_headers=connection_config_dict.get("headers", {}),
+                connection_headers=probe_headers,
                 transport=transport,
                 auth=oauth_auth,
             )

--- a/backend/tests/unit/onyx/server/features/mcp/test_connect_oauth_auth_url_relay.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_connect_oauth_auth_url_relay.py
@@ -1,0 +1,122 @@
+"""Regression coverage for `_connect_oauth`'s authorization-URL relay: the
+connect flow must forward the URL the MCP SDK emits even when the caller's
+stored connection config already carries `client_info` plus rendered headers,
+because a stored config never proves the handshake will skip authorization.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from contextlib import ExitStack
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from onyx.db.enums import MCPAuthenticationType, MCPOAuthProviderMode, MCPTransport
+from onyx.server.features.mcp.api import _connect_oauth
+from onyx.server.features.mcp.models import (
+    MCPUserOAuthConnectRequest,
+    MCPUserOAuthConnectResponse,
+)
+
+API_MODULE = "onyx.server.features.mcp.api"
+
+AUTH_URL = "https://idp.example.com/authorize?client_id=stored-client-id"
+RETURN_PATH = "/chat?mcp=1"
+
+USER_CONFIG = MagicMock(id=99)
+
+# A user who previously completed the handshake: `client_info` seeded from the
+# admin config plus the bearer header rendered by the last callback.
+CONNECTED_USER_DATA: dict[str, Any] = {
+    "client_info": {
+        "client_id": "stored-client-id",
+        "redirect_uris": ["https://onyx.example.com/mcp/oauth/callback"],
+    },
+    "headers": {"Authorization": "Bearer stale-access-token"},
+}
+
+
+def _extract_connection_data(config: Any, **_kwargs: Any) -> dict[str, Any]:
+    return dict(CONNECTED_USER_DATA) if config is USER_CONFIG else {}
+
+
+def _mcp_server() -> MagicMock:
+    server = MagicMock()
+    server.id = 7
+    server.name = "example-mcp"
+    server.server_url = "https://mcp.example.com/mcp"
+    server.auth_type = MCPAuthenticationType.OAUTH
+    server.transport = MCPTransport.STREAMABLE_HTTP
+    server.oauth_provider_mode = MCPOAuthProviderMode.AUTO_DISCOVERY
+    server.admin_connection_config_id = 42
+    return server
+
+
+def _blocking_blpop(*_args: Any, **_kwargs: Any) -> None:
+    """Stand in for a Redis list that never receives an auth URL."""
+    time.sleep(0.3)
+    return None
+
+
+async def _connect(initialize: Any, blpop: Any) -> MCPUserOAuthConnectResponse:
+    redis = MagicMock()
+    redis.blpop = blpop
+    user = MagicMock(id="user-uuid", email="user@example.com")
+    request = MCPUserOAuthConnectRequest(
+        server_id=7,
+        return_path=RETURN_PATH,
+        include_resource_param=False,
+        oauth_client_id="stored-client-id",
+    )
+
+    with ExitStack() as stack:
+        for name, replacement in (
+            ("get_mcp_server_by_id", MagicMock(return_value=_mcp_server())),
+            ("get_mcp_auth_template", MagicMock(return_value=None)),
+            ("get_user_connection_config", MagicMock(return_value=USER_CONFIG)),
+            ("extract_connection_data", _extract_connection_data),
+            ("update_connection_config", MagicMock()),
+            ("make_oauth_provider", MagicMock()),
+            ("get_redis_client", MagicMock(return_value=redis)),
+            ("initialize_mcp_client", initialize),
+        ):
+            stack.enter_context(patch(f"{API_MODULE}.{name}", replacement))
+
+        return await _connect_oauth(request, MagicMock(), is_admin=False, user=user)
+
+
+@pytest.mark.asyncio
+async def test_connect_relays_auth_url_for_previously_connected_user() -> None:
+    async def hanging_initialize(*_args: Any, **_kwargs: Any) -> Any:
+        # The SDK blocks on a callback that only arrives once the user has
+        # visited the authorization URL we are expected to return.
+        await asyncio.sleep(1)
+        raise RuntimeError("Timed out waiting for OAuth callback")
+
+    response = await _connect(
+        hanging_initialize, MagicMock(return_value=(b"key", AUTH_URL.encode()))
+    )
+
+    assert response.oauth_url == AUTH_URL
+
+
+@pytest.mark.asyncio
+async def test_connect_returns_return_path_when_stored_tokens_still_work() -> None:
+    response = await _connect(AsyncMock(return_value=MagicMock()), _blocking_blpop)
+
+    assert response.oauth_url == RETURN_PATH
+
+
+@pytest.mark.asyncio
+async def test_connect_surfaces_init_failure_when_no_auth_url_arrives() -> None:
+    async def failing_initialize(*_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError("connection refused")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _connect(failing_initialize, _blocking_blpop)
+
+    assert exc_info.value.status_code == 400

--- a/backend/tests/unit/onyx/server/features/mcp/test_connect_oauth_auth_url_relay.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_connect_oauth_auth_url_relay.py
@@ -174,6 +174,33 @@ async def test_connect_probes_without_the_stored_bearer_when_tokens_are_missing(
 
 
 @pytest.mark.asyncio
+async def test_connect_stops_polling_for_the_auth_url_once_initialization_wins() -> (
+    None
+):
+    slice_starts: list[float] = []
+
+    def blpop_empty_slice(_keys: Any, _timeout: int = 0) -> None:
+        slice_starts.append(time.monotonic())
+        time.sleep(0.1)
+        return None
+
+    async def slow_initialize(*_args: Any, **_kwargs: Any) -> Any:
+        await asyncio.sleep(0.35)
+        return MagicMock()
+
+    response = await _connect(slow_initialize, blpop_empty_slice, TOKENED_USER_DATA)
+
+    assert response.oauth_url == RETURN_PATH
+    slices_at_return = len(slice_starts)
+    assert slices_at_return >= 2
+
+    await asyncio.sleep(0.4)
+    # Cancellation lands between slices, so only the slice already in flight runs
+    # on — the wait does not linger for the rest of the window.
+    assert len(slice_starts) <= slices_at_return + 1
+
+
+@pytest.mark.asyncio
 async def test_connect_surfaces_init_failure_when_no_auth_url_arrives() -> None:
     async def failing_initialize(*_args: Any, **_kwargs: Any) -> Any:
         raise RuntimeError("connection refused")

--- a/backend/tests/unit/onyx/server/features/mcp/test_connect_oauth_auth_url_relay.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_connect_oauth_auth_url_relay.py
@@ -2,6 +2,8 @@
 connect flow must forward the URL the MCP SDK emits even when the caller's
 stored connection config already carries `client_info` plus rendered headers,
 because a stored config never proves the handshake will skip authorization.
+The relay also has to wait in short BLPOP slices so the losing task's
+cancellation is not stranded behind a blocking call.
 """
 
 from __future__ import annotations
@@ -16,7 +18,7 @@ import pytest
 from fastapi import HTTPException
 
 from onyx.db.enums import MCPAuthenticationType, MCPOAuthProviderMode, MCPTransport
-from onyx.server.features.mcp.api import _connect_oauth
+from onyx.server.features.mcp.api import AUTH_URL_POLL_SECONDS, _connect_oauth
 from onyx.server.features.mcp.models import (
     MCPUserOAuthConnectRequest,
     MCPUserOAuthConnectResponse,
@@ -120,3 +122,27 @@ async def test_connect_surfaces_init_failure_when_no_auth_url_arrives() -> None:
         await _connect(failing_initialize, _blocking_blpop)
 
     assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_connect_waits_for_auth_url_in_short_blocking_slices() -> None:
+    timeouts: list[int] = []
+
+    def blpop_after_a_few_slices(
+        _keys: Any, timeout: int = 0
+    ) -> tuple[bytes, bytes] | None:
+        timeouts.append(timeout)
+        if len(timeouts) < 3:
+            return None
+        return (b"key", AUTH_URL.encode())
+
+    async def hanging_initialize(*_args: Any, **_kwargs: Any) -> Any:
+        await asyncio.sleep(5)
+        raise RuntimeError("Timed out waiting for OAuth callback")
+
+    response = await _connect(hanging_initialize, blpop_after_a_few_slices)
+
+    assert response.oauth_url == AUTH_URL
+    # Several bounded waits rather than one block spanning the whole window.
+    assert len(timeouts) == 3
+    assert max(timeouts) <= AUTH_URL_POLL_SECONDS

--- a/backend/tests/unit/onyx/server/features/mcp/test_connect_oauth_auth_url_relay.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_connect_oauth_auth_url_relay.py
@@ -2,8 +2,10 @@
 connect flow must forward the URL the MCP SDK emits even when the caller's
 stored connection config already carries `client_info` plus rendered headers,
 because a stored config never proves the handshake will skip authorization.
-The relay also has to wait in short BLPOP slices so the losing task's
-cancellation is not stranded behind a blocking call.
+Without stored tokens the probe also has to leave the stored Authorization
+header behind, so a still-accepted bearer cannot masquerade as a connection.
+The relay waits in short BLPOP slices so the losing task's cancellation is not
+stranded behind a blocking call.
 """
 
 from __future__ import annotations
@@ -12,7 +14,7 @@ import asyncio
 import time
 from contextlib import ExitStack
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -32,18 +34,34 @@ RETURN_PATH = "/chat?mcp=1"
 USER_CONFIG = MagicMock(id=99)
 
 # A user who previously completed the handshake: `client_info` seeded from the
-# admin config plus the bearer header rendered by the last callback.
+# admin config, the bearer header left by the last callback, and a header the
+# admin's template renders. Tokens are absent — this is the state a connect call
+# leaves behind, and the state tool calls treat as unauthenticated.
 CONNECTED_USER_DATA: dict[str, Any] = {
     "client_info": {
         "client_id": "stored-client-id",
         "redirect_uris": ["https://onyx.example.com/mcp/oauth/callback"],
     },
-    "headers": {"Authorization": "Bearer stale-access-token"},
+    "headers": {
+        "Authorization": "Bearer stale-access-token",
+        "X-Workspace": "acme",
+    },
 }
 
 
-def _extract_connection_data(config: Any, **_kwargs: Any) -> dict[str, Any]:
-    return dict(CONNECTED_USER_DATA) if config is USER_CONFIG else {}
+# The same user after a successful handshake: the token is the credential tool
+# calls actually use.
+TOKENED_USER_DATA: dict[str, Any] = {
+    **CONNECTED_USER_DATA,
+    "tokens": {"access_token": "live-access-token", "token_type": "Bearer"},
+}
+
+
+def _extract_connection_data(user_data: dict[str, Any]) -> Any:
+    def extract(config: Any, **_kwargs: Any) -> dict[str, Any]:
+        return dict(user_data) if config is USER_CONFIG else {}
+
+    return extract
 
 
 def _mcp_server() -> MagicMock:
@@ -64,7 +82,11 @@ def _blocking_blpop(*_args: Any, **_kwargs: Any) -> None:
     return None
 
 
-async def _connect(initialize: Any, blpop: Any) -> MCPUserOAuthConnectResponse:
+async def _connect(
+    initialize: Any,
+    blpop: Any,
+    user_data: dict[str, Any] = CONNECTED_USER_DATA,
+) -> MCPUserOAuthConnectResponse:
     redis = MagicMock()
     redis.blpop = blpop
     user = MagicMock(id="user-uuid", email="user@example.com")
@@ -80,7 +102,7 @@ async def _connect(initialize: Any, blpop: Any) -> MCPUserOAuthConnectResponse:
             ("get_mcp_server_by_id", MagicMock(return_value=_mcp_server())),
             ("get_mcp_auth_template", MagicMock(return_value=None)),
             ("get_user_connection_config", MagicMock(return_value=USER_CONFIG)),
-            ("extract_connection_data", _extract_connection_data),
+            ("extract_connection_data", _extract_connection_data(user_data)),
             ("update_connection_config", MagicMock()),
             ("make_oauth_provider", MagicMock()),
             ("get_redis_client", MagicMock(return_value=redis)),
@@ -108,9 +130,47 @@ async def test_connect_relays_auth_url_for_previously_connected_user() -> None:
 
 @pytest.mark.asyncio
 async def test_connect_returns_return_path_when_stored_tokens_still_work() -> None:
-    response = await _connect(AsyncMock(return_value=MagicMock()), _blocking_blpop)
+    probes: list[dict[str, str]] = []
+
+    async def succeeding_initialize(*_args: Any, **kwargs: Any) -> Any:
+        probes.append(dict(kwargs["connection_headers"]))
+        return MagicMock()
+
+    response = await _connect(
+        succeeding_initialize, _blocking_blpop, user_data=TOKENED_USER_DATA
+    )
 
     assert response.oauth_url == RETURN_PATH
+    # Stored tokens make the stored headers meaningful, so the probe keeps them.
+    assert probes == [TOKENED_USER_DATA["headers"]]
+
+
+@pytest.mark.asyncio
+async def test_connect_probes_without_the_stored_bearer_when_tokens_are_missing() -> (
+    None
+):
+    probes: list[dict[str, str]] = []
+
+    async def initialize_accepting_any_bearer(*_args: Any, **kwargs: Any) -> Any:
+        headers = dict(kwargs["connection_headers"])
+        probes.append(headers)
+        if "Authorization" in headers:
+            # A provider whose access tokens do not expire answers the stored
+            # bearer, so the handshake reports a connection and never redirects.
+            return MagicMock()
+        await asyncio.sleep(5)
+        raise RuntimeError("Timed out waiting for OAuth callback")
+
+    def blpop_after_a_short_slice(_keys: Any, _timeout: int = 0) -> tuple[bytes, bytes]:
+        time.sleep(0.05)
+        return (b"key", AUTH_URL.encode())
+
+    response = await _connect(
+        initialize_accepting_any_bearer, blpop_after_a_short_slice
+    )
+
+    assert response.oauth_url == AUTH_URL
+    assert probes == [{"X-Workspace": "acme"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

`POST /mcp/oauth/connect` (and its admin twin) deterministically fails with
`400 Failed to initialize OAuth client: Timed out waiting for OAuth callback`
for any user who has connected that server before. First-time connects are
unaffected, so the server looks healthy until someone needs to re-authenticate.

**Mechanism.** `_connect_oauth` decides whether to listen for the authorization
URL from the stored per-user config:

```python
is_connected = (
    MCPOAuthKeys.CLIENT_INFO.value in connection_config_dict
    and connection_config_dict.get("headers")
)
...
auth_task = None if is_connected else asyncio.create_task(wait_auth_url())
```

Before #13715 the per-user config was replaced wholesale on every connect, so
`headers` was always empty by the time this ran and `is_connected` was always
falsy — the relay always ran. #13715 (correctly) started preserving the user's
existing `headers` across a connect, which makes `is_connected` true for anyone
who completed the handshake previously.

The two halves of the function then disagree about what is happening:

- the same handler rewrites the per-user config without carrying `tokens`
  forward, so `OnyxTokenStorage.get_tokens()` returns `None` and the SDK runs a
  full authorization;
- its `redirect_handler` pushes the authorization URL onto
  `mcp:oauth:{user_id}:auth_url`, but with `auth_task = None` nothing pops it;
- `callback_handler` blocks for `OAUTH_WAIT_SECONDS` and raises
  `RuntimeError("Timed out waiting for OAuth callback")`, which the endpoint
  surfaces as the 400 above.

The user waits out the timeout and gets an error instead of being sent to the
IdP, with no path back to a working connection.

**Fix.** Arm the relay unconditionally. The endpoint already races the two tasks
with `FIRST_COMPLETED`:

- stored tokens still valid → the initialize task wins, the auth task is
  cancelled along with the other pending tasks, and the response returns
  `return_path` exactly as today;
- an authorization is required → the URL arrives first and is returned to the
  browser.

Whether the handshake will demand a fresh authorization is not knowable from the
stored config, and the SDK offers that URL exactly once, so listening is the only
safe default. This restores the pre-#13715 behavior while keeping #13715's header
preservation.

### Deliberately not addressed here

- **Auth-URL Redis key is per user, not per user+server**
  (`mcp:oauth:{user_id}:auth_url`), so concurrent connects by one user to
  different servers can cross wires. Pre-existing and independent of this
  regression.
- **`blpop` runs in a thread-pool executor and isn't interrupted by task
  cancellation**, so a fast already-connected connect leaves that worker blocked
  until `OAUTH_WAIT_SECONDS` elapses. That was also true before #13715 (the relay
  ran on every connect then), but happy to swap it for a bounded polling loop if
  you'd rather not reinstate it.
- **`transport = mcp_server.transport if is_connected else MCPTransport.STREAMABLE_HTTP`**
  flipped by the same mechanism: pre-#13715 the initial probe was always
  streamable HTTP, matching the comment above it; it now uses the server's
  configured transport for previously-connected users. Left alone here since it
  may be intended — flagging it in case it isn't.

## How Has This Been Tested?

New unit tests in
`backend/tests/unit/onyx/server/features/mcp/test_connect_oauth_auth_url_relay.py`
drive `_connect_oauth` with a stored per-user config carrying `client_info` plus
rendered headers — the shape that triggers the bug:

- returns the authorization URL when the handshake needs one (this test fails on
  `main` with the exact 400 above);
- still returns `return_path` when the initialize task completes first;
- still surfaces a 400 when initialization fails and no URL arrives.

`ruff check`, `ruff format --check` and `ty check` pass on both touched files, and
the full `backend/tests/unit/onyx/server/features/mcp/` suite passes (111 tests).

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

cc @evan-onyx — deterministic re-auth regression from #13715, so flagging for a quick look 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhSBCP2U13rY3D4FhuwmFz

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always relay the OAuth authorization URL on connect and wait for it in short, cancellable slices. Also probe without the stored Authorization header when tokens are missing, so re-auth runs instead of falsely reporting “already connected.”

- **Bug Fixes**
  - Always start the Redis auth-URL listener in `_connect_oauth` and race it with initialization; return `return_path` if init wins, or the OAuth URL if re-auth is needed.
  - Poll Redis in 1s `BLPOP` slices (`AUTH_URL_POLL_SECONDS`) via `asyncio.to_thread` so cancellation takes effect and no executor thread/Redis connection is parked; arrival latency is unchanged.
  - When no tokens are stored, strip the `Authorization` header from the probe so a still-accepted bearer can’t mask missing tokens; other headers still pass through.
  - Fixes deterministic 400 "Timed out waiting for OAuth callback" on POST `/mcp/oauth/connect` (and its admin route) for returning users and prevents false “already connected” states; added unit tests for the relay, probe-without-bearer, init-win cancellation, and error path.

<sup>Written for commit c7fe435c29c4de2aad35fdc3462b539b16315fcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

