### PR TITLE
chore(llm): unify Azure and OpenAI responses fake-stream patches

### DIFF
--- a/backend/onyx/llm/litellm_singleton/monkey_patches.py
+++ b/backend/onyx/llm/litellm_singleton/monkey_patches.py
@@ -36,15 +36,16 @@ Status checked against LiteLLM v1.93.0 (2026-07-20):
    STATUS: STILL NEEDED - Upstream now uses " ".join() instead of discarding earlier
            parts, but we override to use "\\n\\n".join() for readable section breaks.
 
-4. Azure Responses API Fake Streaming (_patch_azure_responses_should_fake_stream):
-   - LiteLLM uses "fake streaming" (MockResponsesAPIStreamingIterator) for models
-     not in its database, which buffers the entire response before yielding
-   - This causes poor time-to-first-token for Azure custom model deployments
-   - Azure's Responses API supports native streaming, so we force real streaming
-   STATUS: STILL NEEDED - AzureOpenAIResponsesAPIConfig does NOT override should_fake_stream,
-           so it inherits from OpenAIResponsesAPIConfig which returns True for models not
-           in litellm.utils.supports_native_streaming(). Custom Azure deployments will
-           still use fake streaming without this patch.
+4. Responses API Fake Streaming (_patch_openai_responses_should_fake_stream):
+   - LiteLLM fake-streams (MockResponsesAPIStreamingIterator) any responses-API
+     call whose model its registry doesn't recognize, buffering the whole
+     generation before the first chunk. Azure custom deployments and
+     OpenAI-compatible gateway aliases (Bifrost/Portkey responses mode) are
+     never in the registry
+   - Patched on the base OpenAIResponsesAPIConfig; AzureOpenAIResponsesAPIConfig
+     inherits it (no upstream override). Models the registry explicitly marks
+     supports_native_streaming=False (e.g. o1-pro) keep the fake stream
+   STATUS: STILL NEEDED - v1.93.0 treats a registry miss as "cannot stream".
 
 # Note: 5 and 6 suppress a warning and may fix usage info but are not strictly required
 5. Responses API Usage Format Mismatch (_patch_responses_api_usage_format):
@@ -80,14 +81,6 @@ Status checked against LiteLLM v1.93.0 (2026-07-20):
      unconditionally and pass the remainder through as the literal model id
    STATUS: STILL NEEDED - v1.93.0 consults the registry before honoring the prefix.
 
-8. OpenAI Responses API Fake Streaming (_patch_openai_responses_should_fake_stream):
-   - Same defect as 4 on the base OpenAIResponsesAPIConfig, which
-     OpenAI-compatible gateways (Bifrost/Portkey responses mode) resolve to:
-     registry-miss models are downgraded to fake streaming, buffering the
-     whole generation before the first chunk
-   - Unlike 4, models the registry explicitly marks
-     supports_native_streaming=False (e.g. o1-pro) keep the fake stream
-   STATUS: STILL NEEDED - v1.93.0 treats a registry miss as "cannot stream".
 """
 
 import time
@@ -434,47 +427,14 @@ def _patch_openai_responses_transform_response() -> None:
     )
 
 
-def _patch_azure_responses_should_fake_stream() -> None:
-    """
-    Patches AzureOpenAIResponsesAPIConfig.should_fake_stream to always return False.
-
-    By default, LiteLLM uses "fake streaming" (MockResponsesAPIStreamingIterator) for models
-    not in its database. This causes Azure custom model deployments to buffer the entire
-    response before yielding, resulting in poor time-to-first-token.
-
-    Azure's Responses API supports native streaming, so we override this to always use
-    real streaming (SyncResponsesAPIStreamingIterator).
-    """
-    from litellm.llms.azure.responses.transformation import (
-        AzureOpenAIResponsesAPIConfig,
-    )
-
-    if (
-        getattr(AzureOpenAIResponsesAPIConfig.should_fake_stream, "__name__", "")
-        == "_patched_should_fake_stream"
-    ):
-        return
-
-    def _patched_should_fake_stream(
-        self: Any,  # noqa: ARG001
-        model: Optional[str],  # noqa: ARG001
-        stream: Optional[bool],  # noqa: ARG001
-        custom_llm_provider: Optional[str] = None,  # noqa: ARG001
-    ) -> bool:
-        # Azure Responses API supports native streaming - never fake it
-        return False
-
-    _patched_should_fake_stream.__name__ = "_patched_should_fake_stream"
-    AzureOpenAIResponsesAPIConfig.should_fake_stream = _patched_should_fake_stream
-
-
 def _patch_openai_responses_should_fake_stream() -> None:
     """
     Patches OpenAIResponsesAPIConfig.should_fake_stream so a registry miss
-    (e.g. a gateway model alias) streams natively instead of buffering the
-    generation. Models explicitly marked supports_native_streaming=False
-    (e.g. o1-pro) keep the fake stream — a native stream request would be
-    rejected upstream.
+    (e.g. a gateway model alias or Azure custom deployment) streams natively
+    instead of buffering the generation. Models explicitly marked
+    supports_native_streaming=False (e.g. o1-pro) keep the fake stream — a
+    native stream request would be rejected upstream.
+    AzureOpenAIResponsesAPIConfig inherits this patch.
     """
     from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
 
@@ -742,8 +702,8 @@ def apply_monkey_patches() -> None:
     - Patching OllamaChatCompletionResponseIterator.chunk_parser for streaming content
     - Patching chunk_parser for reasoning summary newline insertion between sections
     - Patching LiteLLMResponsesTransformationHandler.transform_response for non-streaming responses
-    - Patching AzureOpenAIResponsesAPIConfig.should_fake_stream to enable native streaming
-    - Patching OpenAIResponsesAPIConfig.should_fake_stream to stream natively on registry misses
+    - Patching OpenAIResponsesAPIConfig.should_fake_stream (Azure inherits) to stream
+      natively on registry misses
     - Patching ResponsesAPIResponse.model_construct to fix usage format in all code paths
     - Patching Logging._get_assembled_streaming_response to avoid mutating original response
     - Patching responses_api_bridge_check to always honor an explicit responses/ prefix
@@ -751,7 +711,6 @@ def apply_monkey_patches() -> None:
     _patch_ollama_chunk_parser()
     _patch_responses_reasoning_summary_newlines()
     _patch_openai_responses_transform_response()
-    _patch_azure_responses_should_fake_stream()
     _patch_openai_responses_should_fake_stream()
     _patch_responses_api_usage_format()
     _patch_logging_assembled_streaming_response()

--- a/backend/tests/unit/onyx/llm/test_litellm_monkey_patches.py
+++ b/backend/tests/unit/onyx/llm/test_litellm_monkey_patches.py
@@ -350,3 +350,29 @@ def test_openai_should_fake_stream_ignores_non_streaming_requests() -> None:
         )
         is False
     )
+
+
+def test_azure_should_fake_stream_inherits_registry_aware_patch() -> None:
+    # An upstream override on the Azure subclass would silently bypass the patch.
+    from litellm.llms.azure.responses.transformation import (
+        AzureOpenAIResponsesAPIConfig,
+    )
+
+    apply_monkey_patches()
+    assert (
+        AzureOpenAIResponsesAPIConfig.should_fake_stream.__name__
+        == "_patched_openai_should_fake_stream"
+    )
+    config = AzureOpenAIResponsesAPIConfig()
+    with mock.patch(
+        "litellm.get_model_info",
+        side_effect=Exception("This model isn't mapped yet"),
+    ):
+        assert (
+            config.should_fake_stream(
+                model="my-custom-deployment",
+                stream=True,
+                custom_llm_provider="azure",
+            )
+            is False
+        )


### PR DESCRIPTION
## Description

Follow-up to #13788, addressing the review question there about whether the Azure and OpenAI `should_fake_stream` patches can be joined.

They can: `AzureOpenAIResponsesAPIConfig` subclasses `OpenAIResponsesAPIConfig` with no upstream `should_fake_stream` override, so deleting the Azure always-return-False patch lets Azure inherit the registry-aware base patch added in #13788. Net: two monkey patches become one.

**Behavior-neutral for Azure today**, verified against the LiteLLM 1.93.0 registry: only 4 entries in the entire model map carry an explicit `supports_native_streaming=False` (gpt-5-pro, gpt-5-pro-2025-10-06, o1-pro, o1-pro-2025-03-19) — all under provider `openai`, none under `azure` — and `get_model_info` does no cross-provider fallback. So every possible Azure lookup either misses the registry or resolves without the flag → native streaming, identical to the removed override. If LiteLLM later flags an azure entry as non-streaming, Azure starts (correctly) fake-streaming it instead of sending a native stream request the API rejects.

Intentionally **not** cherry-picked to release/v4.5 — the release branch keeps both patches, which is harmless; this consolidation stays a main-only cleanup with its own revert target.

## How Has This Been Tested?

- New unit test asserts the Azure subclass resolves to the patched base implementation (tripwire for a future upstream override silently bypassing the patch) and streams natively on a forced registry miss.
- Full monkey-patch test file: 14/14 pass; pre-commit green.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unified Responses API fake-streaming logic by removing the Azure-specific patch and letting Azure inherit the registry-aware `should_fake_stream` from `OpenAIResponsesAPIConfig`. Behavior is unchanged for Azure today; future registry flags will enable fake-streaming only when required.

- **Refactors**
  - Removed Azure `should_fake_stream` patch; keep a single patch on `OpenAIResponsesAPIConfig` (Azure inherits it).
  - Added a unit test to verify Azure uses the patched base and streams natively on registry misses.

<sup>Written for commit 4a7d59ddc9b10404546a87ef72df6bc8a777bc83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

