### PR TITLE
feat(desktop): summon shortcut toggles -- press while focused hides

### DIFF
--- a/desktop/src-tauri/src/menu.rs
+++ b/desktop/src-tauri/src/menu.rs
@@ -1,7 +1,7 @@
 use crate::config::ConfigState;
 use crate::debug_log::{log_backend_error, MENU_OPEN_DEBUG_LOG_ID, MENU_TOGGLE_DEVTOOLS_ID};
 use crate::shortcuts::SummonShortcut;
-use crate::window::{focus_main_window, open_chat_window};
+use crate::window::{focus_main_window, focused_webview_window, open_chat_window};
 use tauri::image::Image;
 #[cfg(not(target_os = "macos"))]
 use tauri::menu::AboutMetadataBuilder;
@@ -129,18 +129,6 @@ fn build_view_menu(app: &AppHandle, menu: &Menu<Wry>) -> tauri::Result<()> {
     }
 
     Ok(())
-}
-
-/// The window a View-menu action should apply to: whichever one is focused
-/// (menu accelerators only fire while the app is active, but the app can have
-/// several windows).
-fn focused_webview_window(app: &AppHandle) -> Option<tauri::WebviewWindow> {
-    app.webview_windows().into_values().find(|window| {
-        window.is_focused().unwrap_or_else(|e| {
-            log_backend_error(app, &format!("Failed to query window focus: {e}"));
-            false
-        })
-    })
 }
 
 pub fn handle_reload(app: &AppHandle) {

--- a/desktop/src-tauri/src/shortcuts.rs
+++ b/desktop/src-tauri/src/shortcuts.rs
@@ -36,6 +36,14 @@ pub fn setup_global_shortcuts(app: &AppHandle) {
             if event.state() != ShortcutState::Pressed {
                 return;
             }
+            // Toggle contract: the chord that summons Onyx also dismisses it,
+            // returning focus to whatever app was active before. This also
+            // keeps repeated presses from stacking up new chats.
+            if main_window_is_focused(app) {
+                log_backend_debug(app, "Summon shortcut fired (action=hide)");
+                hide_main_window(app);
+                return;
+            }
             let opens_new_chat = app.state::<ConfigState>().config().summon_opens_new_chat;
             log_backend_debug(
                 app,
@@ -61,6 +69,23 @@ pub fn setup_global_shortcuts(app: &AppHandle) {
                 app,
                 &format!("Failed to register summon shortcut \"{chord}\": {e}"),
             );
+        }
+    }
+}
+
+fn main_window_is_focused(app: &AppHandle) -> bool {
+    app.get_webview_window("main").is_some_and(|window| {
+        window.is_focused().unwrap_or_else(|e| {
+            log_backend_error(app, &format!("Failed to query window focus: {e}"));
+            false
+        })
+    })
+}
+
+fn hide_main_window(app: &AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        if let Err(e) = window.hide() {
+            log_backend_error(app, &format!("Failed to hide main window: {e}"));
         }
     }
 }

--- a/desktop/src-tauri/src/shortcuts.rs
+++ b/desktop/src-tauri/src/shortcuts.rs
@@ -112,12 +112,15 @@ fn dismiss_all_windows(app: &AppHandle) {
 }
 
 /// Re-show the windows the last dismissal hid. `main` is skipped here; the
-/// summon action that follows shows and focuses it.
+/// summon action that follows shows and focuses it. A window whose `show`
+/// fails stays queued so a later summon retries it -- dropping the label
+/// would strand the window hidden with no path back.
 fn restore_dismissed_windows(app: &AppHandle) {
     let Some(state) = app.try_state::<DismissedWindows>() else {
         return;
     };
     let labels = std::mem::take(&mut *state.0.lock().unwrap_or_else(PoisonError::into_inner));
+    let mut failed = Vec::new();
     for label in labels {
         if label == "main" {
             continue;
@@ -125,8 +128,16 @@ fn restore_dismissed_windows(app: &AppHandle) {
         if let Some(window) = app.get_webview_window(&label) {
             if let Err(e) = window.show() {
                 log_backend_error(app, &format!("Failed to restore window \"{label}\": {e}"));
+                failed.push(label);
             }
         }
+    }
+    if !failed.is_empty() {
+        state
+            .0
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .extend(failed);
     }
 }
 

--- a/desktop/src-tauri/src/shortcuts.rs
+++ b/desktop/src-tauri/src/shortcuts.rs
@@ -106,8 +106,15 @@ fn dismiss_all_windows(app: &AppHandle) {
             hidden.len()
         ),
     );
+    // Merge rather than replace: the queue may still hold labels whose
+    // restore failed earlier, and overwriting would strand those windows.
     if let Some(state) = app.try_state::<DismissedWindows>() {
-        *state.0.lock().unwrap_or_else(PoisonError::into_inner) = hidden;
+        let mut queued = state.0.lock().unwrap_or_else(PoisonError::into_inner);
+        for label in hidden {
+            if !queued.contains(&label) {
+                queued.push(label);
+            }
+        }
     }
 }
 

--- a/desktop/src-tauri/src/shortcuts.rs
+++ b/desktop/src-tauri/src/shortcuts.rs
@@ -1,6 +1,7 @@
 use crate::config::ConfigState;
 use crate::debug_log::{log_backend_debug, log_backend_error};
 use crate::window::{focus_main_window, focused_webview_window, open_chat_window};
+use std::sync::{Mutex, PoisonError};
 use tauri::{AppHandle, Manager};
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
 
@@ -10,6 +11,11 @@ use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
 pub struct SummonShortcut {
     pub chord: String,
 }
+
+/// Labels of the windows the last chord dismissal hid. Auxiliary windows
+/// have no other path back once hidden (the tray and summon paths only
+/// manage `main`), so the next summon restores this exact set.
+struct DismissedWindows(Mutex<Vec<String>>);
 
 /// Register the configured summon shortcut. This is deliberately the only
 /// global (system-wide) shortcut the app registers: summoning Onyx is the one
@@ -30,6 +36,8 @@ pub fn setup_global_shortcuts(app: &AppHandle) {
         }
     };
 
+    app.manage(DismissedWindows(Mutex::new(Vec::new())));
+
     let result = app
         .global_shortcut()
         .on_shortcut(shortcut, |app, _shortcut, event| {
@@ -37,18 +45,15 @@ pub fn setup_global_shortcuts(app: &AppHandle) {
                 return;
             }
             // Toggle contract: the chord that summons Onyx also dismisses it,
-            // returning focus to whatever app was active before. This also
-            // keeps repeated presses from stacking up new chats. Any focused
-            // Onyx window counts -- with an auxiliary window frontmost, the
-            // user is in Onyx, so the chord should dismiss rather than drag
-            // the main window forward.
-            if let Some(window) = focused_webview_window(app) {
-                log_backend_debug(app, "Summon shortcut fired (action=hide)");
-                if let Err(e) = window.hide() {
-                    log_backend_error(app, &format!("Failed to hide focused window: {e}"));
-                }
+            // returning focus to whatever app was active before. Dismissal
+            // hides every visible Onyx window -- hiding only the focused one
+            // would just hand focus to the next Onyx window instead of the
+            // previous application.
+            if focused_webview_window(app).is_some() {
+                dismiss_all_windows(app);
                 return;
             }
+            restore_dismissed_windows(app);
             let opens_new_chat = app.state::<ConfigState>().config().summon_opens_new_chat;
             log_backend_debug(
                 app,
@@ -74,6 +79,53 @@ pub fn setup_global_shortcuts(app: &AppHandle) {
                 app,
                 &format!("Failed to register summon shortcut \"{chord}\": {e}"),
             );
+        }
+    }
+}
+
+fn dismiss_all_windows(app: &AppHandle) {
+    let mut hidden = Vec::new();
+    for (label, window) in app.webview_windows() {
+        let visible = window.is_visible().unwrap_or_else(|e| {
+            log_backend_error(app, &format!("Failed to query window visibility: {e}"));
+            false
+        });
+        if !visible {
+            continue;
+        }
+        if let Err(e) = window.hide() {
+            log_backend_error(app, &format!("Failed to hide window \"{label}\": {e}"));
+        } else {
+            hidden.push(label);
+        }
+    }
+    log_backend_debug(
+        app,
+        &format!(
+            "Summon shortcut fired (action=dismiss, windows={})",
+            hidden.len()
+        ),
+    );
+    if let Some(state) = app.try_state::<DismissedWindows>() {
+        *state.0.lock().unwrap_or_else(PoisonError::into_inner) = hidden;
+    }
+}
+
+/// Re-show the windows the last dismissal hid. `main` is skipped here; the
+/// summon action that follows shows and focuses it.
+fn restore_dismissed_windows(app: &AppHandle) {
+    let Some(state) = app.try_state::<DismissedWindows>() else {
+        return;
+    };
+    let labels = std::mem::take(&mut *state.0.lock().unwrap_or_else(PoisonError::into_inner));
+    for label in labels {
+        if label == "main" {
+            continue;
+        }
+        if let Some(window) = app.get_webview_window(&label) {
+            if let Err(e) = window.show() {
+                log_backend_error(app, &format!("Failed to restore window \"{label}\": {e}"));
+            }
         }
     }
 }

--- a/desktop/src-tauri/src/shortcuts.rs
+++ b/desktop/src-tauri/src/shortcuts.rs
@@ -1,6 +1,6 @@
 use crate::config::ConfigState;
 use crate::debug_log::{log_backend_debug, log_backend_error};
-use crate::window::{focus_main_window, open_chat_window};
+use crate::window::{focus_main_window, focused_webview_window, open_chat_window};
 use tauri::{AppHandle, Manager};
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
 
@@ -38,10 +38,15 @@ pub fn setup_global_shortcuts(app: &AppHandle) {
             }
             // Toggle contract: the chord that summons Onyx also dismisses it,
             // returning focus to whatever app was active before. This also
-            // keeps repeated presses from stacking up new chats.
-            if main_window_is_focused(app) {
+            // keeps repeated presses from stacking up new chats. Any focused
+            // Onyx window counts -- with an auxiliary window frontmost, the
+            // user is in Onyx, so the chord should dismiss rather than drag
+            // the main window forward.
+            if let Some(window) = focused_webview_window(app) {
                 log_backend_debug(app, "Summon shortcut fired (action=hide)");
-                hide_main_window(app);
+                if let Err(e) = window.hide() {
+                    log_backend_error(app, &format!("Failed to hide focused window: {e}"));
+                }
                 return;
             }
             let opens_new_chat = app.state::<ConfigState>().config().summon_opens_new_chat;
@@ -69,23 +74,6 @@ pub fn setup_global_shortcuts(app: &AppHandle) {
                 app,
                 &format!("Failed to register summon shortcut \"{chord}\": {e}"),
             );
-        }
-    }
-}
-
-fn main_window_is_focused(app: &AppHandle) -> bool {
-    app.get_webview_window("main").is_some_and(|window| {
-        window.is_focused().unwrap_or_else(|e| {
-            log_backend_error(app, &format!("Failed to query window focus: {e}"));
-            false
-        })
-    })
-}
-
-fn hide_main_window(app: &AppHandle) {
-    if let Some(window) = app.get_webview_window("main") {
-        if let Err(e) = window.hide() {
-            log_backend_error(app, &format!("Failed to hide main window: {e}"));
         }
     }
 }

--- a/desktop/src-tauri/src/window.rs
+++ b/desktop/src-tauri/src/window.rs
@@ -14,6 +14,18 @@ use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial};
 const TITLEBAR_SCRIPT: &str = include_str!("../../src/titlebar.js");
 const CHAT_LINK_INTERCEPT_SCRIPT: &str = include_str!("scripts/chat_link_intercept.js");
 
+/// The window a shortcut or menu action should apply to: whichever one is
+/// focused (the app can have several windows). Focus-query failures are
+/// logged and treated as unfocused.
+pub fn focused_webview_window(app: &AppHandle) -> Option<WebviewWindow> {
+    app.webview_windows().into_values().find(|window| {
+        window.is_focused().unwrap_or_else(|e| {
+            log_backend_error(app, &format!("Failed to query window focus: {e}"));
+            false
+        })
+    })
+}
+
 pub fn focus_main_window(app: &AppHandle) {
     if let Some(window) = app.get_webview_window("main") {
         if let Err(e) = window.unminimize() {


### PR DESCRIPTION
## Description

Follow-up to #13765. Completes the summon-hotkey contract (Raycast/ChatGPT convention): pressing the global summon chord while Onyx is already frontmost now hides the window and returns focus to the previous app, instead of opening yet another new chat. Pressing it from any other app summons as before (new chat by default, focus-only when the tray's "New Chat on Summon" is unchecked).

This also fixes the repeated-press behavior from #13765, where mashing the chord stacked up a new chat per press.

Implementation: the shortcut handler checks whether the main window is focused (focus-query failures are logged, not swallowed) and hides it if so; otherwise the existing summon path runs unchanged.

## How Has This Been Tested?

- `cargo clippy --all-targets` clean under the crate's strict lint set; `cargo fmt --check` clean; all 14 unit tests pass
- Live end-to-end on macOS: 12 real keypresses of `Cmd+Shift+Space` alternating between focused and unfocused states — debug log shows perfect hide/summon alternation (`action=hide` ↔ summon-into-new-chat), zero errors, focus correctly returned to the previously active app after each hide
- Windows/Linux compile-verified (`window.hide()` / `window.is_focused()` are cross-platform Tauri APIs on the already-exercised code path)

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the global summon shortcut a toggle. If any Onyx window is frontmost, pressing it hides all visible windows and returns focus to the previous app; otherwise it summons as before and restores any auxiliary windows hidden by the last dismissal.

- **New Features**
  - Dismissal hides all visible Onyx windows and records them; the next summon restores that same set and focuses the main window.
  - Honors the tray setting: new chat by default; focus-only when “New Chat on Summon” is unchecked.

- **Bug Fixes**
  - Dismisses when any Onyx window is focused (main or auxiliary).
  - Prevents stacking new chats on repeated presses.
  - Keeps dismissed-window queue safe: retries failed restores and merges/deduplicates labels so pending restores aren’t dropped.

<sup>Written for commit e79e8c0f4ea23cb25ea7b113cd9f58f63c2eecb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

