### PR TITLE
fix(web): app-level undo/redo for the input bar so Cmd+Z stops eating drafts

### DIFF
--- a/web/src/hooks/__tests__/useContentEditable.undo.test.tsx
+++ b/web/src/hooks/__tests__/useContentEditable.undo.test.tsx
@@ -1,0 +1,280 @@
+import { act, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { useRef } from "react";
+import {
+  useContentEditable,
+  type UseContentEditableReturn,
+} from "@/hooks/useContentEditable";
+
+let api: UseContentEditableReturn;
+
+interface HarnessProps {
+  pasteTilesEnabled?: boolean;
+}
+
+function Harness({ pasteTilesEnabled = false }: HarnessProps) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  api = useContentEditable({ wrapperRef, pasteTilesEnabled });
+  return (
+    <div ref={wrapperRef}>
+      <div
+        ref={api.ref}
+        contentEditable
+        suppressContentEditableWarning
+        data-testid="editable"
+        onInput={api.handleInput}
+        onCompositionStart={api.handleCompositionStart}
+        onCompositionEnd={api.handleCompositionEnd}
+      />
+    </div>
+  );
+}
+
+function input(): HTMLDivElement {
+  return api.ref.current as HTMLDivElement;
+}
+
+function caretToEnd(): void {
+  const sel = window.getSelection()!;
+  const r = document.createRange();
+  r.selectNodeContents(input());
+  r.collapse(false);
+  sel.removeAllRanges();
+  sel.addRange(r);
+}
+
+function fireBeforeInput(inputType: string): boolean {
+  let event: Event;
+  try {
+    event = new InputEvent("beforeinput", {
+      inputType,
+      bubbles: true,
+      cancelable: true,
+    });
+    if ((event as InputEvent).inputType !== inputType) {
+      throw new Error("jsdom InputEvent lacks inputType");
+    }
+  } catch {
+    event = new Event("beforeinput", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "inputType", { value: inputType });
+  }
+  return input().dispatchEvent(event);
+}
+
+/** Simulate one natively-typed keystroke (beforeinput → DOM edit → input). */
+function typeText(text: string): void {
+  act(() => {
+    fireBeforeInput("insertText");
+    input().appendChild(document.createTextNode(text));
+    input().normalize();
+    caretToEnd();
+    input().dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function pressKey(init: KeyboardEventInit): boolean {
+  let allowed = true;
+  act(() => {
+    allowed = input().dispatchEvent(
+      new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init })
+    );
+  });
+  return allowed;
+}
+
+const undo = () => pressKey({ key: "z", metaKey: true });
+const redo = () => pressKey({ key: "z", metaKey: true, shiftKey: true });
+
+describe("useContentEditable undo/redo", () => {
+  let now: number;
+
+  beforeEach(() => {
+    now = 1_000_000;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function advance(ms: number): void {
+    now += ms;
+  }
+
+  it("undoes a paste without touching previously typed text", () => {
+    render(<Harness />);
+    typeText("hello ");
+    advance(2000);
+    act(() => api.pasteText("PASTED-WRONG-THING"));
+    expect(input().textContent).toBe("hello PASTED-WRONG-THING");
+
+    undo();
+    expect(input().textContent).toBe("hello ");
+    expect(api.message).toBe("hello ");
+
+    undo();
+    expect(input().textContent).toBe("");
+    expect(api.message).toBe("");
+  });
+
+  it("redoes undone edits", () => {
+    render(<Harness />);
+    typeText("draft");
+    advance(2000);
+    act(() => api.pasteText(" plus paste"));
+
+    undo();
+    undo();
+    expect(input().textContent).toBe("");
+
+    redo();
+    expect(input().textContent).toBe("draft");
+    redo();
+    expect(input().textContent).toBe("draft plus paste");
+  });
+
+  it("supports ctrl+y as redo", () => {
+    render(<Harness />);
+    typeText("abc");
+    undo();
+    expect(input().textContent).toBe("");
+    pressKey({ key: "y", ctrlKey: true });
+    expect(input().textContent).toBe("abc");
+  });
+
+  it("coalesces a typing burst into one undo unit, split by pauses", () => {
+    render(<Harness />);
+    typeText("a");
+    typeText("b");
+    typeText("c");
+    advance(2000);
+    typeText("d");
+    typeText("e");
+    expect(input().textContent).toBe("abcde");
+
+    undo();
+    expect(input().textContent).toBe("abc");
+    undo();
+    expect(input().textContent).toBe("");
+  });
+
+  it("treats insert and delete bursts as separate undo units", () => {
+    render(<Harness />);
+    typeText("abcd");
+    act(() => {
+      fireBeforeInput("deleteContentBackward");
+      const node = input().firstChild as Text;
+      node.textContent = "abc";
+      caretToEnd();
+      input().dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(input().textContent).toBe("abc");
+
+    undo();
+    expect(input().textContent).toBe("abcd");
+    undo();
+    expect(input().textContent).toBe("");
+  });
+
+  it("always consumes cmd+z, even with empty history", () => {
+    render(<Harness />);
+    const allowed = pressKey({ key: "z", metaKey: true });
+    expect(allowed).toBe(false); // preventDefault — native undo must never run
+    expect(input().textContent).toBe("");
+  });
+
+  it("handles historyUndo/historyRedo beforeinput (menu undo)", () => {
+    render(<Harness />);
+    typeText("typed");
+    advance(2000);
+    act(() => api.pasteText("PASTE"));
+
+    let allowed = true;
+    act(() => {
+      allowed = fireBeforeInput("historyUndo");
+    });
+    expect(allowed).toBe(false);
+    expect(input().textContent).toBe("typed");
+
+    act(() => {
+      fireBeforeInput("historyRedo");
+    });
+    expect(input().textContent).toBe("typedPASTE");
+  });
+
+  it("undoes a paste-tile insertion entirely", () => {
+    render(<Harness pasteTilesEnabled />);
+    typeText("note ");
+    advance(2000);
+    const longText = "line1\nline2\nline3\nline4\nline5";
+    act(() => api.pasteText(longText));
+    expect(input().querySelector("[data-rich-tile]")).not.toBeNull();
+    expect(api.message).toBe("note " + longText);
+
+    undo();
+    expect(input().querySelector("[data-rich-tile]")).toBeNull();
+    expect(api.message).toBe("note ");
+  });
+
+  it("restores a tile removed via its remove button", () => {
+    render(<Harness pasteTilesEnabled />);
+    const longText = "line1\nline2\nline3\nline4\nline5";
+    act(() => api.pasteText(longText));
+    const tile = input().querySelector("[data-rich-tile]");
+    expect(tile).not.toBeNull();
+
+    act(() => {
+      const removeBtn = tile!.querySelector("[data-rich-tile-remove]")!;
+      const event = new MouseEvent("mousedown", {
+        bubbles: true,
+        cancelable: true,
+      });
+      Object.defineProperty(event, "target", { value: removeBtn });
+      // Tile removal is delegated through the host's onMouseDown handler.
+      api.handleTileMouseDown(
+        event as unknown as React.MouseEvent<HTMLDivElement>
+      );
+    });
+    expect(input().querySelector("[data-rich-tile]")).toBeNull();
+
+    undo();
+    expect(input().querySelector("[data-rich-tile]")).not.toBeNull();
+    expect(api.message).toBe(longText);
+  });
+
+  it("clears history on clearMessage (submit)", () => {
+    render(<Harness />);
+    typeText("sent message");
+    act(() => api.clearMessage());
+    expect(input().textContent).toBe("");
+
+    undo();
+    expect(input().textContent).toBe("");
+    expect(api.message).toBe("");
+  });
+
+  it("makes setMessage (draft restore / queue edit) undoable", () => {
+    render(<Harness />);
+    typeText("original");
+    advance(2000);
+    act(() => api.setMessage("replaced"));
+    expect(input().textContent).toBe("replaced");
+
+    undo();
+    expect(input().textContent).toBe("original");
+  });
+
+  it("new edits after undo clear the redo stack", () => {
+    render(<Harness />);
+    typeText("first");
+    advance(2000);
+    typeText("second");
+    undo();
+    expect(input().textContent).toBe("first");
+
+    advance(2000);
+    typeText("third");
+    redo();
+    expect(input().textContent).toBe("firstthird");
+  });
+});

--- a/web/src/hooks/__tests__/useContentEditable.undo.test.tsx
+++ b/web/src/hooks/__tests__/useContentEditable.undo.test.tsx
@@ -5,6 +5,12 @@ import {
   useContentEditable,
   type UseContentEditableReturn,
 } from "@/hooks/useContentEditable";
+import {
+  pushBoundedSnapshot,
+  MAX_UNDO_ENTRIES,
+  MAX_UNDO_TOTAL_CHARS,
+  type EditableSnapshot,
+} from "@/lib/contentEditable";
 
 let api: UseContentEditableReturn;
 
@@ -370,5 +376,37 @@ describe("useContentEditable undo/redo", () => {
     typeText("third");
     redo();
     expect(input().textContent).toBe("firstthird");
+  });
+});
+
+describe("pushBoundedSnapshot", () => {
+  function snap(chars: number): EditableSnapshot {
+    return { html: "x".repeat(chars), selStart: 0, selEnd: 0 };
+  }
+
+  it("keeps retained history within the size cap", () => {
+    const stack: EditableSnapshot[] = [];
+    const size = Math.ceil(MAX_UNDO_TOTAL_CHARS * 0.45);
+    pushBoundedSnapshot(stack, snap(size));
+    pushBoundedSnapshot(stack, snap(size));
+    pushBoundedSnapshot(stack, snap(size));
+    expect(stack.length).toBe(2);
+    const total = stack.reduce((sum, s) => sum + s.html.length, 0);
+    expect(total).toBeLessThanOrEqual(MAX_UNDO_TOTAL_CHARS);
+  });
+
+  it("always retains the newest snapshot, even oversized", () => {
+    const stack: EditableSnapshot[] = [];
+    pushBoundedSnapshot(stack, snap(MAX_UNDO_TOTAL_CHARS + 1));
+    pushBoundedSnapshot(stack, snap(MAX_UNDO_TOTAL_CHARS + 1));
+    expect(stack.length).toBe(1);
+  });
+
+  it("enforces the entry-count cap", () => {
+    const stack: EditableSnapshot[] = [];
+    for (let i = 0; i < MAX_UNDO_ENTRIES + 5; i++) {
+      pushBoundedSnapshot(stack, snap(1));
+    }
+    expect(stack.length).toBe(MAX_UNDO_ENTRIES);
   });
 });

--- a/web/src/hooks/__tests__/useContentEditable.undo.test.tsx
+++ b/web/src/hooks/__tests__/useContentEditable.undo.test.tsx
@@ -85,6 +85,27 @@ function pressKey(init: KeyboardEventInit): boolean {
 const undo = () => pressKey({ key: "z", metaKey: true });
 const redo = () => pressKey({ key: "z", metaKey: true, shiftKey: true });
 
+/** Collapsed-caret offset in text units from the start of the input. */
+function flatCaret(): number | null {
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0 || !sel.isCollapsed) return null;
+  const r = document.createRange();
+  r.selectNodeContents(input());
+  const caret = sel.getRangeAt(0);
+  r.setEnd(caret.startContainer, caret.startOffset);
+  return r.toString().length;
+}
+
+function caretAtTextOffset(offset: number): void {
+  const node = input().firstChild as Text;
+  const sel = window.getSelection()!;
+  const r = document.createRange();
+  r.setStart(node, offset);
+  r.collapse(true);
+  sel.removeAllRanges();
+  sel.addRange(r);
+}
+
 describe("useContentEditable undo/redo", () => {
   let now: number;
 
@@ -262,6 +283,79 @@ describe("useContentEditable undo/redo", () => {
 
     undo();
     expect(input().textContent).toBe("original");
+  });
+
+  it("restores the caret alongside the content", () => {
+    render(<Harness />);
+    typeText("helloworld");
+    caretAtTextOffset(5);
+    advance(2000);
+    act(() => api.pasteText("-X-"));
+    expect(input().textContent).toBe("hello-X-world");
+    expect(flatCaret()).toBe(8);
+
+    undo();
+    expect(input().textContent).toBe("helloworld");
+    expect(flatCaret()).toBe(5);
+
+    redo();
+    expect(input().textContent).toBe("hello-X-world");
+    expect(flatCaret()).toBe(8);
+  });
+
+  it("starts a new undo unit when typing replaces a selection", () => {
+    render(<Harness />);
+    typeText("hello");
+    // Select-all within the coalescing window, then type over it
+    act(() => {
+      const sel = window.getSelection()!;
+      const r = document.createRange();
+      r.selectNodeContents(input());
+      sel.removeAllRanges();
+      sel.addRange(r);
+    });
+    act(() => {
+      fireBeforeInput("insertText");
+      input().textContent = "x";
+      caretToEnd();
+      input().dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(input().textContent).toBe("x");
+
+    undo();
+    expect(input().textContent).toBe("hello");
+    undo();
+    expect(input().textContent).toBe("");
+  });
+
+  it("does not resurrect the transient tile highlight on undo", () => {
+    render(<Harness pasteTilesEnabled />);
+    const longText = "line1\nline2\nline3\nline4\nline5";
+    act(() => api.pasteText(longText));
+    expect(input().querySelector("[data-rich-tile]")).not.toBeNull();
+
+    function pressBackspace(): void {
+      act(() => {
+        const event = new KeyboardEvent("keydown", {
+          key: "Backspace",
+          bubbles: true,
+          cancelable: true,
+        });
+        api.handleTileKeyDown(
+          event as unknown as React.KeyboardEvent<HTMLDivElement>
+        );
+      });
+    }
+
+    pressBackspace(); // first press selects the tile
+    expect(input().querySelector(".rich-input-tile-selected")).not.toBeNull();
+    pressBackspace(); // second press deletes it
+    expect(input().querySelector("[data-rich-tile]")).toBeNull();
+
+    undo();
+    const tile = input().querySelector("[data-rich-tile]");
+    expect(tile).not.toBeNull();
+    expect(tile!.classList.contains("rich-input-tile-selected")).toBe(false);
   });
 
   it("new edits after undo clear the redo stack", () => {

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -8,6 +8,10 @@ import {
   getTextContent,
   deleteTokenBeforeCursor,
   stripLeadingBr,
+  captureSnapshot,
+  restoreSnapshot,
+  snapshotsEqual,
+  type EditableSnapshot,
 } from "@/lib/contentEditable";
 import {
   createRichInputTileNode,
@@ -20,6 +24,27 @@ import {
 } from "@/lib/richInputTile";
 
 type PasteTileData = { text: string; tile: HTMLElement };
+
+// App-level undo history. The browser's native undo stack cannot be used:
+// paste, tiles, and draft restores mutate the DOM programmatically, which the
+// native stack can't see, so native undo restores stale states and destroys
+// typed text. All undo entry points (Cmd+Z, menu/context-menu historyUndo)
+// are intercepted and served from these snapshots instead.
+const UNDO_COALESCE_MS = 1000;
+const MAX_UNDO_ENTRIES = 100;
+// Paste tiles can hold very large text; bound total retained snapshot HTML.
+const MAX_UNDO_TOTAL_CHARS = 2_000_000;
+
+const CARET_KEYS = new Set([
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "ArrowDown",
+  "Home",
+  "End",
+  "PageUp",
+  "PageDown",
+]);
 
 export interface UseContentEditableOptions {
   initialContent?: string;
@@ -77,6 +102,10 @@ export function useContentEditable({
   const wrapperPaddingYRef = useRef(0);
   const selectedTileRef = useRef<HTMLElement | null>(null);
   const plainPasteRef = useRef(false);
+  const undoStackRef = useRef<EditableSnapshot[]>([]);
+  const redoStackRef = useRef<EditableSnapshot[]>([]);
+  const lastEditKindRef = useRef<string | null>(null);
+  const lastEditAtRef = useRef(0);
   const [tilePopover, setTilePopover] = useState<PasteTileData | null>(null);
   const [pasteExpandHintVisible, setPasteExpandHintVisible] = useState(false);
 
@@ -173,6 +202,86 @@ export function useContentEditable({
     return text;
   }, []);
 
+  /** Push the current state as an undo restore point (starts a new undo unit). */
+  const pushUndoSnapshot = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    redoStackRef.current = [];
+    lastEditKindRef.current = null;
+    const stack = undoStackRef.current;
+    const snapshot = captureSnapshot(el);
+    const top = stack[stack.length - 1];
+    if (top && snapshotsEqual(top, snapshot)) return;
+    stack.push(snapshot);
+    if (stack.length > MAX_UNDO_ENTRIES) stack.shift();
+    let total = 0;
+    for (let i = stack.length - 1; i >= 0; i--) {
+      total += stack[i]!.html.length;
+      if (total > MAX_UNDO_TOTAL_CHARS && i > 0) {
+        stack.splice(0, i);
+        break;
+      }
+    }
+  }, []);
+
+  /** Record an edit, coalescing bursts of the same kind into one undo unit. */
+  const noteEdit = useCallback(
+    (kind: string) => {
+      const coalescible =
+        kind === "typing" || kind === "deleting" || kind === "tile-edit";
+      const now = Date.now();
+      if (
+        !coalescible ||
+        lastEditKindRef.current !== kind ||
+        now - lastEditAtRef.current > UNDO_COALESCE_MS
+      ) {
+        pushUndoSnapshot();
+      }
+      lastEditKindRef.current = coalescible ? kind : null;
+      lastEditAtRef.current = now;
+    },
+    [pushUndoSnapshot]
+  );
+
+  const clearUndoHistory = useCallback(() => {
+    undoStackRef.current = [];
+    redoStackRef.current = [];
+    lastEditKindRef.current = null;
+  }, []);
+
+  const performUndo = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    const current = captureSnapshot(el);
+    const stack = undoStackRef.current;
+    let snapshot = stack.pop();
+    // Skip no-op restore points (e.g. an op that bailed without mutating).
+    while (snapshot && snapshotsEqual(snapshot, current))
+      snapshot = stack.pop();
+    if (!snapshot) return;
+    redoStackRef.current.push(current);
+    restoreSnapshot(el, snapshot);
+    lastEditKindRef.current = null;
+    clearTileSelection();
+    setTilePopover(null);
+    syncFromDOM();
+    resize();
+  }, [clearTileSelection, syncFromDOM, resize]);
+
+  const performRedo = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    const snapshot = redoStackRef.current.pop();
+    if (!snapshot) return;
+    undoStackRef.current.push(captureSnapshot(el));
+    restoreSnapshot(el, snapshot);
+    lastEditKindRef.current = null;
+    clearTileSelection();
+    setTilePopover(null);
+    syncFromDOM();
+    resize();
+  }, [clearTileSelection, syncFromDOM, resize]);
+
   const handleInput = useCallback(
     (_event: React.SyntheticEvent<HTMLDivElement>): string => {
       if (isComposingRef.current) return messageRef.current;
@@ -197,15 +306,17 @@ export function useContentEditable({
   );
 
   const handleCompositionStart = useCallback(() => {
+    pushUndoSnapshot();
     isComposingRef.current = true;
     if (ref.current) {
       ref.current.removeAttribute("data-empty");
     }
-  }, []);
+  }, [pushUndoSnapshot]);
 
   const handleCompositionEnd = useCallback(() => {
     isComposingRef.current = false;
     plainPasteRef.current = false;
+    lastEditKindRef.current = null;
     syncFromDOM();
     resize();
   }, [syncFromDOM, resize]);
@@ -215,10 +326,92 @@ export function useContentEditable({
     disabledRef.current = disabled;
   }, [disabled]);
 
+  // Undo/redo entry points and typed-edit tracking. Native listeners (not
+  // React props) so every consumer of this hook is covered.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    function handleBeforeInput(event: Event) {
+      if (disabledRef.current) return;
+      const inputType = (event as InputEvent).inputType;
+      if (inputType === "historyUndo") {
+        event.preventDefault();
+        performUndo();
+        return;
+      }
+      if (inputType === "historyRedo") {
+        event.preventDefault();
+        performRedo();
+        return;
+      }
+      if (isComposingRef.current || inputType === "insertCompositionText") {
+        return;
+      }
+      if (
+        inputType === "insertText" ||
+        inputType === "insertParagraph" ||
+        inputType === "insertLineBreak"
+      ) {
+        noteEdit("typing");
+      } else if (
+        inputType === "deleteContentBackward" ||
+        inputType === "deleteContentForward"
+      ) {
+        noteEdit("deleting");
+      } else {
+        noteEdit(inputType);
+      }
+    }
+
+    function handleUndoKeys(event: KeyboardEvent) {
+      if (disabledRef.current) return;
+      const mod = event.metaKey || event.ctrlKey;
+      if (mod && !event.altKey && event.key.toLowerCase() === "z") {
+        // Always intercept, even with empty stacks: native undo must never
+        // run against this element.
+        event.preventDefault();
+        if (event.shiftKey) {
+          performRedo();
+        } else {
+          performUndo();
+        }
+        return;
+      }
+      if (
+        mod &&
+        !event.altKey &&
+        !event.shiftKey &&
+        event.key.toLowerCase() === "y"
+      ) {
+        event.preventDefault();
+        performRedo();
+        return;
+      }
+      if (CARET_KEYS.has(event.key)) {
+        lastEditKindRef.current = null;
+      }
+    }
+
+    function handleCaretMouseDown() {
+      lastEditKindRef.current = null;
+    }
+
+    el.addEventListener("beforeinput", handleBeforeInput);
+    el.addEventListener("keydown", handleUndoKeys);
+    el.addEventListener("mousedown", handleCaretMouseDown);
+    return () => {
+      el.removeEventListener("beforeinput", handleBeforeInput);
+      el.removeEventListener("keydown", handleUndoKeys);
+      el.removeEventListener("mousedown", handleCaretMouseDown);
+    };
+  }, [performUndo, performRedo, noteEdit]);
+
   const setMessage = useCallback(
     (text: string) => {
       if (!ref.current) return;
 
+      pushUndoSnapshot();
       clearTileSelection();
       setTilePopover(null);
       setPasteExpandHintVisible(false);
@@ -242,12 +435,15 @@ export function useContentEditable({
         }
       });
     },
-    [resize, clearTileSelection]
+    [resize, clearTileSelection, pushUndoSnapshot]
   );
 
   const clearMessage = useCallback(() => {
     if (!ref.current) return;
 
+    // Submit/reset starts a fresh history — a sent message is not undoable
+    // back into the input.
+    clearUndoHistory();
     clearTileSelection();
     setTilePopover(null);
     setPasteExpandHintVisible(false);
@@ -257,21 +453,23 @@ export function useContentEditable({
     setMessageState("");
     resize();
     onContentChangeRef.current?.("");
-  }, [resize, clearTileSelection]);
+  }, [resize, clearTileSelection, clearUndoHistory]);
 
   const insertTextAtCursor = useCallback(
     (text: string) => {
       if (!ref.current) return;
+      pushUndoSnapshot();
       insertTextAtCursorUtil(ref.current, text);
       syncFromDOM();
       resize();
     },
-    [syncFromDOM, resize]
+    [syncFromDOM, resize, pushUndoSnapshot]
   );
 
   const insertTileAtCursor = useCallback(
     (text: string): HTMLElement | null => {
       if (!ref.current) return null;
+      pushUndoSnapshot();
       const tile = createRichInputTileNode({
         type: "paste",
         text,
@@ -285,7 +483,7 @@ export function useContentEditable({
       resize();
       return tile;
     },
-    [syncFromDOM, resize]
+    [syncFromDOM, resize, pushUndoSnapshot]
   );
 
   const expandTile = useCallback(
@@ -293,6 +491,7 @@ export function useContentEditable({
       const el = ref.current;
       if (!el || !el.contains(tile)) return;
 
+      pushUndoSnapshot();
       const sel = window.getSelection();
       const caret =
         sel && sel.rangeCount > 0 ? sel.getRangeAt(0).cloneRange() : null;
@@ -323,13 +522,14 @@ export function useContentEditable({
       syncFromDOM();
       resize();
     },
-    [syncFromDOM, resize]
+    [syncFromDOM, resize, pushUndoSnapshot]
   );
 
   const insertSkillTile = useCallback(
     (slug: string, name: string, beforeToken: string): boolean => {
       const el = ref.current;
       if (!el) return false;
+      pushUndoSnapshot();
       // Replacing a typed `/<query>`: bail if it can't be verifiably removed,
       // since the tile serializes back to `/<slug> ` and would duplicate it. An
       // empty `beforeToken` (e.g. paste) just inserts at the caret.
@@ -347,7 +547,7 @@ export function useContentEditable({
       resize();
       return true;
     },
-    [syncFromDOM, resize]
+    [syncFromDOM, resize, pushUndoSnapshot]
   );
 
   const findMatchingPasteTile = useCallback(
@@ -404,13 +604,14 @@ export function useContentEditable({
       event.preventDefault();
       const tile = removeBtn.closest("[data-rich-tile]");
       if (tile) {
+        pushUndoSnapshot();
         tile.remove();
         setTilePopover(null);
         syncFromDOM();
         resize();
       }
     },
-    [syncFromDOM, resize, clearTileSelection]
+    [syncFromDOM, resize, clearTileSelection, pushUndoSnapshot]
   );
 
   const handleTileClick = useCallback(
@@ -460,6 +661,7 @@ export function useContentEditable({
       const { tile } = tilePopover;
 
       if (!newText.trim()) {
+        pushUndoSnapshot();
         const next = tile.nextSibling;
         const prev = tile.previousSibling;
         tile.remove();
@@ -479,6 +681,7 @@ export function useContentEditable({
         return;
       }
 
+      noteEdit("tile-edit");
       tile.setAttribute("data-text", newText);
       tile.title = newText.length > 200 ? newText.slice(0, 200) + "…" : newText;
 
@@ -491,7 +694,7 @@ export function useContentEditable({
         meta.textContent = getPasteTileMeta(newText);
       }
     },
-    [tilePopover, syncFromDOM, resize]
+    [tilePopover, syncFromDOM, resize, pushUndoSnapshot, noteEdit]
   );
 
   const handleTileKeyDown = useCallback(
@@ -557,6 +760,7 @@ export function useContentEditable({
 
         if (isDelete) {
           event.preventDefault();
+          pushUndoSnapshot();
           selected.remove();
           selectedTileRef.current = null;
           syncFromDOM();
@@ -620,7 +824,7 @@ export function useContentEditable({
       }
       return true;
     },
-    [syncFromDOM, resize, clearTileSelection]
+    [syncFromDOM, resize, clearTileSelection, pushUndoSnapshot]
   );
 
   const handleCopy = useCallback(
@@ -660,12 +864,13 @@ export function useContentEditable({
       event.preventDefault();
       event.clipboardData.setData("text/plain", getTextContent(temp));
 
+      pushUndoSnapshot();
       range.deleteContents();
       selectedTileRef.current = null;
       syncFromDOM();
       resize();
     },
-    [syncFromDOM, resize]
+    [syncFromDOM, resize, pushUndoSnapshot]
   );
 
   const setCursorToEnd = useCallback(() => {

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -11,6 +11,7 @@ import {
   captureSnapshot,
   restoreSnapshot,
   snapshotsEqual,
+  pushBoundedSnapshot,
   type EditableSnapshot,
 } from "@/lib/contentEditable";
 import {
@@ -28,9 +29,6 @@ type PasteTileData = { text: string; tile: HTMLElement };
 // App-level undo history: the native undo stack can't see programmatic
 // mutations (paste, tiles, drafts), so it must never run against the input.
 const UNDO_COALESCE_MS = 1000;
-const MAX_UNDO_ENTRIES = 100;
-// Paste tiles can hold very large text; bound total retained snapshot HTML.
-const MAX_UNDO_TOTAL_CHARS = 2_000_000;
 
 const CARET_KEYS = new Set([
   "ArrowLeft",
@@ -42,22 +40,6 @@ const CARET_KEYS = new Set([
   "PageUp",
   "PageDown",
 ]);
-
-function pushBoundedSnapshot(
-  stack: EditableSnapshot[],
-  snapshot: EditableSnapshot
-): void {
-  stack.push(snapshot);
-  if (stack.length > MAX_UNDO_ENTRIES) stack.shift();
-  let total = 0;
-  for (let i = stack.length - 1; i >= 0; i--) {
-    total += stack[i]!.html.length;
-    if (total > MAX_UNDO_TOTAL_CHARS && i > 0) {
-      stack.splice(0, i);
-      break;
-    }
-  }
-}
 
 export interface UseContentEditableOptions {
   initialContent?: string;

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -25,11 +25,8 @@ import {
 
 type PasteTileData = { text: string; tile: HTMLElement };
 
-// App-level undo history. The browser's native undo stack cannot be used:
-// paste, tiles, and draft restores mutate the DOM programmatically, which the
-// native stack can't see, so native undo restores stale states and destroys
-// typed text. All undo entry points (Cmd+Z, menu/context-menu historyUndo)
-// are intercepted and served from these snapshots instead.
+// App-level undo history: the native undo stack can't see programmatic
+// mutations (paste, tiles, drafts), so it must never run against the input.
 const UNDO_COALESCE_MS = 1000;
 const MAX_UNDO_ENTRIES = 100;
 // Paste tiles can hold very large text; bound total retained snapshot HTML.
@@ -326,8 +323,8 @@ export function useContentEditable({
     disabledRef.current = disabled;
   }, [disabled]);
 
-  // Undo/redo entry points and typed-edit tracking. Native listeners (not
-  // React props) so every consumer of this hook is covered.
+  // Undo/redo entry points and typed-edit tracking, as native listeners so
+  // every consumer of the hook is covered.
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
@@ -368,8 +365,7 @@ export function useContentEditable({
       if (disabledRef.current) return;
       const mod = event.metaKey || event.ctrlKey;
       if (mod && !event.altKey && event.key.toLowerCase() === "z") {
-        // Always intercept, even with empty stacks: native undo must never
-        // run against this element.
+        // Intercept even with empty stacks so native undo never runs.
         event.preventDefault();
         if (event.shiftKey) {
           performRedo();
@@ -441,8 +437,7 @@ export function useContentEditable({
   const clearMessage = useCallback(() => {
     if (!ref.current) return;
 
-    // Submit/reset starts a fresh history — a sent message is not undoable
-    // back into the input.
+    // Submit/reset starts fresh history — a sent message is not undoable.
     clearUndoHistory();
     clearTileSelection();
     setTilePopover(null);

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -43,6 +43,22 @@ const CARET_KEYS = new Set([
   "PageDown",
 ]);
 
+function pushBoundedSnapshot(
+  stack: EditableSnapshot[],
+  snapshot: EditableSnapshot
+): void {
+  stack.push(snapshot);
+  if (stack.length > MAX_UNDO_ENTRIES) stack.shift();
+  let total = 0;
+  for (let i = stack.length - 1; i >= 0; i--) {
+    total += stack[i]!.html.length;
+    if (total > MAX_UNDO_TOTAL_CHARS && i > 0) {
+      stack.splice(0, i);
+      break;
+    }
+  }
+}
+
 export interface UseContentEditableOptions {
   initialContent?: string;
   wrapperRef: React.RefObject<HTMLDivElement | null>;
@@ -209,16 +225,7 @@ export function useContentEditable({
     const snapshot = captureSnapshot(el);
     const top = stack[stack.length - 1];
     if (top && snapshotsEqual(top, snapshot)) return;
-    stack.push(snapshot);
-    if (stack.length > MAX_UNDO_ENTRIES) stack.shift();
-    let total = 0;
-    for (let i = stack.length - 1; i >= 0; i--) {
-      total += stack[i]!.html.length;
-      if (total > MAX_UNDO_TOTAL_CHARS && i > 0) {
-        stack.splice(0, i);
-        break;
-      }
-    }
+    pushBoundedSnapshot(stack, snapshot);
   }, []);
 
   /** Record an edit, coalescing bursts of the same kind into one undo unit. */
@@ -226,9 +233,20 @@ export function useContentEditable({
     (kind: string) => {
       const coalescible =
         kind === "typing" || kind === "deleting" || kind === "tile-edit";
+      // Replacing a selection (e.g. Cmd+A then typing) is never a
+      // continuation of a burst — its restore point must be pushed.
+      const el = ref.current;
+      const sel = window.getSelection();
+      const replacesSelection =
+        !!el &&
+        !!sel &&
+        sel.rangeCount > 0 &&
+        !sel.isCollapsed &&
+        el.contains(sel.getRangeAt(0).commonAncestorContainer);
       const now = Date.now();
       if (
         !coalescible ||
+        replacesSelection ||
         lastEditKindRef.current !== kind ||
         now - lastEditAtRef.current > UNDO_COALESCE_MS
       ) {
@@ -256,7 +274,7 @@ export function useContentEditable({
     while (snapshot && snapshotsEqual(snapshot, current))
       snapshot = stack.pop();
     if (!snapshot) return;
-    redoStackRef.current.push(current);
+    pushBoundedSnapshot(redoStackRef.current, current);
     restoreSnapshot(el, snapshot);
     lastEditKindRef.current = null;
     clearTileSelection();
@@ -270,7 +288,7 @@ export function useContentEditable({
     if (!el) return;
     const snapshot = redoStackRef.current.pop();
     if (!snapshot) return;
-    undoStackRef.current.push(captureSnapshot(el));
+    pushBoundedSnapshot(undoStackRef.current, captureSnapshot(el));
     restoreSnapshot(el, snapshot);
     lastEditKindRef.current = null;
     clearTileSelection();

--- a/web/src/lib/contentEditable.ts
+++ b/web/src/lib/contentEditable.ts
@@ -91,12 +91,9 @@ export function insertNodeAtCursor(element: HTMLElement, node: Node): void {
 // ─── Undo Snapshots ─────────────────────────────────────────────────────────
 
 /**
- * A serialized editor state for the app-level undo/redo history. The native
- * browser undo stack cannot be used: programmatic mutations (paste, tiles,
- * drafts) are invisible to it, so native undo restores stale states and eats
- * typed text. Selection endpoints are stored in "flat units" — one unit per
- * text character, `<br>`, or atomic rich tile — so they survive the
- * innerHTML round-trip.
+ * Serialized editor state for the app-level undo/redo history. Selection
+ * endpoints are in "flat units" — one per text character, `<br>`, or atomic
+ * rich tile — so they survive the innerHTML round-trip.
  */
 export interface EditableSnapshot {
   html: string;
@@ -187,10 +184,8 @@ export function captureSnapshot(element: HTMLElement): EditableSnapshot {
 }
 
 /**
- * `snapshot.html` must only ever come from `captureSnapshot` of the same
- * element (a browser serialization of DOM whose content enters via text
- * nodes / `createRichInputTileNode`) — never from external input, or the
- * innerHTML assignment below becomes an XSS sink.
+ * `snapshot.html` must come from `captureSnapshot` of the same element,
+ * never from external input — the innerHTML write would be an XSS sink.
  */
 export function restoreSnapshot(
   element: HTMLElement,

--- a/web/src/lib/contentEditable.ts
+++ b/web/src/lib/contentEditable.ts
@@ -180,7 +180,19 @@ export function captureSnapshot(element: HTMLElement): EditableSnapshot {
       );
     }
   }
-  return { html: element.innerHTML, selStart, selEnd };
+  // Strip transient tile-highlight classes so a restore can't resurrect them.
+  const clone = element.cloneNode(true) as HTMLElement;
+  clone
+    .querySelectorAll(
+      ".rich-input-tile-selected, .rich-input-tile-in-selection"
+    )
+    .forEach((tile) => {
+      tile.classList.remove(
+        "rich-input-tile-selected",
+        "rich-input-tile-in-selection"
+      );
+    });
+  return { html: clone.innerHTML, selStart, selEnd };
 }
 
 /**

--- a/web/src/lib/contentEditable.ts
+++ b/web/src/lib/contentEditable.ts
@@ -88,6 +88,138 @@ export function insertNodeAtCursor(element: HTMLElement, node: Node): void {
   element.normalize();
 }
 
+// ─── Undo Snapshots ─────────────────────────────────────────────────────────
+
+/**
+ * A serialized editor state for the app-level undo/redo history. The native
+ * browser undo stack cannot be used: programmatic mutations (paste, tiles,
+ * drafts) are invisible to it, so native undo restores stale states and eats
+ * typed text. Selection endpoints are stored in "flat units" — one unit per
+ * text character, `<br>`, or atomic rich tile — so they survive the
+ * innerHTML round-trip.
+ */
+export interface EditableSnapshot {
+  html: string;
+  selStart: number;
+  selEnd: number;
+}
+
+function isAtomicNode(node: Node): boolean {
+  if (node.nodeType !== Node.ELEMENT_NODE) return false;
+  const el = node as HTMLElement;
+  return el.tagName === "BR" || el.hasAttribute("data-rich-tile");
+}
+
+function unitLength(node: Node): number {
+  if (node.nodeType === Node.TEXT_NODE) return node.textContent?.length ?? 0;
+  if (isAtomicNode(node)) return 1;
+  let sum = 0;
+  node.childNodes.forEach((child) => {
+    sum += unitLength(child);
+  });
+  return sum;
+}
+
+function boundaryToFlatOffset(
+  root: HTMLElement,
+  container: Node,
+  offset: number
+): number {
+  const range = document.createRange();
+  range.selectNodeContents(root);
+  range.setEnd(container, offset);
+  return unitLength(range.cloneContents());
+}
+
+function resolveFlatOffset(
+  root: HTMLElement,
+  target: number
+): { node: Node; offset: number } {
+  let remaining = target;
+
+  function walk(parent: Node): { node: Node; offset: number } | null {
+    const children = parent.childNodes;
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i]!;
+      if (child.nodeType === Node.TEXT_NODE) {
+        const len = child.textContent?.length ?? 0;
+        if (remaining <= len) return { node: child, offset: remaining };
+        remaining -= len;
+      } else if (isAtomicNode(child)) {
+        if (remaining === 0) return { node: parent, offset: i };
+        remaining -= 1;
+        if (remaining === 0) return { node: parent, offset: i + 1 };
+      } else {
+        const found = walk(child);
+        if (found) return found;
+      }
+    }
+    return null;
+  }
+
+  return walk(root) ?? { node: root, offset: root.childNodes.length };
+}
+
+export function captureSnapshot(element: HTMLElement): EditableSnapshot {
+  const end = unitLength(element);
+  let selStart = end;
+  let selEnd = end;
+  const sel = window.getSelection();
+  if (sel && sel.rangeCount > 0) {
+    const range = sel.getRangeAt(0);
+    if (
+      element.contains(range.startContainer) &&
+      element.contains(range.endContainer)
+    ) {
+      selStart = boundaryToFlatOffset(
+        element,
+        range.startContainer,
+        range.startOffset
+      );
+      selEnd = boundaryToFlatOffset(
+        element,
+        range.endContainer,
+        range.endOffset
+      );
+    }
+  }
+  return { html: element.innerHTML, selStart, selEnd };
+}
+
+/**
+ * `snapshot.html` must only ever come from `captureSnapshot` of the same
+ * element (a browser serialization of DOM whose content enters via text
+ * nodes / `createRichInputTileNode`) — never from external input, or the
+ * innerHTML assignment below becomes an XSS sink.
+ */
+export function restoreSnapshot(
+  element: HTMLElement,
+  snapshot: EditableSnapshot
+): void {
+  element.innerHTML = snapshot.html;
+  const sel = window.getSelection();
+  if (!sel) return;
+  const start = resolveFlatOffset(element, snapshot.selStart);
+  const end =
+    snapshot.selEnd === snapshot.selStart
+      ? start
+      : resolveFlatOffset(element, snapshot.selEnd);
+  const range = document.createRange();
+  range.setStart(start.node, start.offset);
+  range.setEnd(end.node, end.offset);
+  sel.removeAllRanges();
+  sel.addRange(range);
+}
+
+export function snapshotsEqual(
+  a: EditableSnapshot,
+  b: EditableSnapshot
+): boolean {
+  return (
+    a.html === b.html && a.selStart === b.selStart && a.selEnd === b.selEnd
+  );
+}
+
 // ─── Text Content Extraction ────────────────────────────────────────────────
 
 const BLOCK_TAGS = new Set([

--- a/web/src/lib/contentEditable.ts
+++ b/web/src/lib/contentEditable.ts
@@ -227,6 +227,29 @@ export function snapshotsEqual(
   );
 }
 
+export const MAX_UNDO_ENTRIES = 100;
+// Paste tiles can hold very large text; bound total retained snapshot HTML.
+export const MAX_UNDO_TOTAL_CHARS = 2_000_000;
+
+/** Append to an undo/redo stack, enforcing the entry and total-size caps. */
+export function pushBoundedSnapshot(
+  stack: EditableSnapshot[],
+  snapshot: EditableSnapshot
+): void {
+  stack.push(snapshot);
+  if (stack.length > MAX_UNDO_ENTRIES) stack.shift();
+  let total = 0;
+  for (let i = stack.length - 1; i >= 0; i--) {
+    total += stack[i]!.html.length;
+    if (total > MAX_UNDO_TOTAL_CHARS) {
+      // Drop the entry that crossed the cap and everything older, but always
+      // retain the newest entry even if it alone exceeds the cap.
+      stack.splice(0, Math.min(i + 1, stack.length - 1));
+      break;
+    }
+  }
+}
+
 // ─── Text Content Extraction ────────────────────────────────────────────────
 
 const BLOCK_TAGS = new Set([


### PR DESCRIPTION
## Description

Fixes the customer-reported bug where Cmd+Z in the chat input deletes typed text: after typing a message and pasting something, undo would delete the *typed* text while leaving the *pasted* text (or wipe the input entirely), with no way to recover the draft.

**Root cause:** the input bar is a `contentEditable` div. Typing goes through the browser's editing pipeline and is recorded in the native undo stack, but paste is intercepted (`preventDefault`) and applied via programmatic Range-API insertion — invisible to the native stack (same for tiles, drafts, and clears). Cmd+Z then reverted the last transaction the browser knew about: the pre-paste typing burst. Whether the typed text, everything, or nothing got deleted depended on how `normalize()` had merged text nodes, which is why the bug felt intermittent. Present since the contentEditable input refactor (#10500).

**Fix:** an app-level undo/redo history in `useContentEditable`, shared by `AppInputBar`, `BaseInputBar`, and `CraftInputBar`:

- Snapshots (`innerHTML` + selection stored as flat text offsets) are pushed before every mutation. Typed bursts coalesce into one undo unit (tracked via `beforeinput`), split on ~1s pauses, caret movement, and insert↔delete transitions.
- Cmd+Z / Cmd+Shift+Z / Ctrl+Y and `beforeinput` `historyUndo`/`historyRedo` (menu & context-menu undo) are always intercepted, so the corrupted native undo can never run against the input.
- Every programmatic path now creates a restore point: text paste, paste/skill tile insertion, tile removal (button, keyboard, popover-clear), tile expansion, tile popover edits (coalesced), cut, and `setMessage` (draft restore / queued-message edit).
- `clearMessage` (submit) resets history — a sent message is not undoable back into the input.
- The stack is bounded by entry count (100) and total snapshot size (2 MB) since paste tiles can hold large text.

Snapshot restore is XSS-safe by construction: snapshot HTML only ever originates from `captureSnapshot` of the same element, whose content enters exclusively via text nodes and `createRichInputTileNode` (documented invariant on `restoreSnapshot`).

No UI changes; no new components needed.

## How Has This Been Tested?

- 12 new Jest tests (`useContentEditable.undo.test.tsx`): paste undo preserves typed text, redo, Ctrl+Y, typing-burst coalescing + pause splitting, insert/delete unit separation, Cmd+Z always consumed (native undo blocked even with empty history), menu `historyUndo`/`historyRedo`, paste-tile undo/restore, submit clears history, `setMessage` undoable, redo stack cleared by new edits.
- Full web suite: 106 suites / 1047 tests green (no regressions).
- Live-verified in the real app (dev server + trusted keystrokes + real clipboard paste): type → Cmd+V → Cmd+Z removes only the paste; second Cmd+Z removes the typed burst; Cmd+Shift+Z restores both in order. Multi-line variant (Shift+Enter before paste), which previously deleted the draft and kept the paste, now keeps the draft, and the caret is restored correctly.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implemented app-level undo/redo for the chat input so Cmd+Z no longer deletes typed drafts after paste. Applies to `AppInputBar`, `BaseInputBar`, and `CraftInputBar`.

- **Bug Fixes**
  - Replaced native undo with an app-level history in `useContentEditable` (captures HTML + selection).
  - Coalesces typing bursts; splits on ~1s pauses, caret moves, and insert/delete changes; replacing a selection always starts a new unit.
  - Intercepts Cmd+Z / Cmd+Shift+Z / Ctrl+Y and `beforeinput` `historyUndo`/`historyRedo` so native undo never runs.
  - Adds restore points for paste, skill/paste tile insert/remove/expand, tile popover edits, cut, and `setMessage`; `clearMessage` resets history.
  - Undo/redo stacks are bounded (100 entries, exact 2MB total) via `pushBoundedSnapshot` in `@/lib/contentEditable`; snapshots strip transient tile-highlight classes; restore is safe since content only comes from our capture.

<sup>Written for commit 3e95930e4e5ca1ce66f4773cf006d9f56b2f939e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

