### PR TITLE
fix(confluence): survive DC attachment-pagination 400s in indexing, reindex, and pruning

### DIFF
--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -1044,6 +1044,11 @@ class ConfluenceConnector(
                 ) or space_level_access.get(space_key)
             yield doc_or_failure
 
+            # Refetch attachments too
+            attachment_docs, attachment_failures = self._fetch_page_attachments(page)
+            yield from attachment_docs
+            yield from attachment_failures
+
         for doc_id, page_id in url_to_page_id.items():
             if page_id not in seen_page_ids:
                 yield ConnectorFailure(

--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -121,6 +121,7 @@ _PRUNING_EXPANSION_FIELDS = [
 ]
 
 _SLIM_DOC_BATCH_SIZE = 5000
+_SLIM_ATTACHMENT_MAX_ATTEMPTS = 3
 
 # Confluence document_id is the page URL. Reindex inputs come from
 # IndexAttemptError rows (also URLs). Two URL shapes show up in the wild:
@@ -141,6 +142,11 @@ def _get_page_id(page: dict[str, Any], allow_missing: bool = False) -> str:
     if allow_missing and "id" not in page:
         return "unknown"
     return str(page["id"])
+
+
+def _http_status(e: HTTPError) -> int | None:
+    # NOTE: requests.Response is falsy for error statuses, so compare to None.
+    return e.response.status_code if e.response is not None else None
 
 
 class ConfluenceCheckpoint(ConnectorCheckpoint):
@@ -792,8 +798,7 @@ class ConfluenceConnector(
         except HTTPError as e:
             # A 400/401/403 on the attachment query shouldn't fail the whole job:
             # log, record a failure for the page, and continue.
-            # NOTE: requests.Response is falsy for error statuses, so compare to None.
-            status_code = e.response.status_code if e.response is not None else None
+            status_code = _http_status(e)
             page_id = _get_page_id(page, allow_missing=True)
             page_ref = f"page '{page.get('title', 'unknown')}' (ID: {page_id})"
             match status_code:
@@ -1114,6 +1119,48 @@ class ConfluenceConnector(
             expand_per_page=True,
         )
 
+    def _retrieve_attachments_for_slim_page(
+        self,
+        page_id: str,
+        expand: str,
+        start: SecondsSinceUnixEpoch | None,
+        end: SecondsSinceUnixEpoch | None,
+    ) -> list[dict[str, Any]]:
+        """Fetch a page's attachments for the slim path, retrying Data
+        Center's intermittent pagination 400s (see _fetch_page_attachments).
+
+        Unlike the indexing path, partial results are never kept: pruning
+        deletes anything not enumerated, so a silently truncated enumeration
+        would delete validly indexed attachment docs. Enumerate fully or
+        raise.
+        """
+        attachment_query = self._construct_attachment_query(page_id, start, end)
+        attempts = 0
+        while True:
+            try:
+                return list(
+                    self.confluence_client.cql_paginate_all_expansions(
+                        cql=attachment_query,
+                        expand=expand,
+                        limit=_SLIM_DOC_BATCH_SIZE,
+                    )
+                )
+            except HTTPError as e:
+                attempts += 1
+                if (
+                    _http_status(e) != 400
+                    or is_atlassian_date_error(e)
+                    or attempts >= _SLIM_ATTACHMENT_MAX_ATTEMPTS
+                ):
+                    raise
+                logger.warning(
+                    "Bad request (400) while paginating attachments for page %s "
+                    "(attempt %d/%d); retrying.",
+                    page_id,
+                    attempts,
+                    _SLIM_ATTACHMENT_MAX_ATTEMPTS,
+                )
+
     def _retrieve_all_slim_docs(
         self,
         start: SecondsSinceUnixEpoch | None = None,
@@ -1211,13 +1258,8 @@ class ConfluenceConnector(
             page_hierarchy_node_yielded = False
             attachment_results: Iterable[dict[str, Any]] = ()
             if self.include_attachments:
-                attachment_query = self._construct_attachment_query(
-                    _get_page_id(page), start, end
-                )
-                attachment_results = self.confluence_client.cql_paginate_all_expansions(
-                    cql=attachment_query,
-                    expand=restrictions_expand,
-                    limit=_SLIM_DOC_BATCH_SIZE,
+                attachment_results = self._retrieve_attachments_for_slim_page(
+                    _get_page_id(page), restrictions_expand, start, end
                 )
             for attachment in attachment_results:
                 # admission must mirror the main indexing pass
@@ -1293,7 +1335,7 @@ class ConfluenceConnector(
             )
             first_space = next(spaces_iter, None)
         except HTTPError as e:
-            status_code = e.response.status_code if e.response else None
+            status_code = _http_status(e)
             if status_code == 401:
                 raise CredentialExpiredError(
                     "Invalid or expired Confluence credentials (HTTP 401)."

--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -790,43 +790,58 @@ class ConfluenceConnector(
                         )
                     )
         except HTTPError as e:
-            # If we get a 403 after all retries, the user likely doesn't have permission
-            # to access attachments on this page. Log and skip rather than failing the whole job.
+            # A 400/401/403 on the attachment query shouldn't fail the whole job:
+            # log, record a failure for the page, and continue.
+            # NOTE: requests.Response is falsy for error statuses, so compare to None.
+            status_code = e.response.status_code if e.response is not None else None
             page_id = _get_page_id(page, allow_missing=True)
-            page_title = page.get("title", "unknown")
-            if e.response and e.response.status_code in [401, 403]:
-                failure_message_prefix = (
-                    "Invalid credentials (401)"
-                    if e.response.status_code == 401
-                    else "Permission denied (403)"
-                )
-                failure_message = (
-                    f"{failure_message_prefix} when fetching attachments for page '{page_title}' "
-                    f"(ID: {page_id}). The user may not have permission to query attachments on this page. "
-                    "Skipping attachments for this page."
-                )
-                logger.warning(failure_message)
-
-                # Build the page URL for the failure record
-                try:
-                    page_url = build_confluence_document_id(
-                        self.wiki_base, page["_links"]["webui"], self.is_cloud
+            page_ref = f"page '{page.get('title', 'unknown')}' (ID: {page_id})"
+            match status_code:
+                # Date errors are 400s but must propagate so load_from_checkpoint
+                # can retry the batch with an adjusted time offset.
+                case 400 if not is_atlassian_date_error(e):
+                    # Confluence Data Center intermittently rejects offset
+                    # pagination of attachment queries.
+                    failure_message = (
+                        f"Bad request (400) while paginating attachments for {page_ref}. "
+                        "Keeping the attachments retrieved so far and skipping the rest."
                     )
-                except Exception:
-                    page_url = f"page_id:{page_id}"
-
-                return [], [
-                    ConnectorFailure(
-                        failed_document=DocumentFailure(
-                            document_id=page_id,
-                            document_link=page_url,
-                        ),
-                        failure_message=failure_message,
-                        exception=e,
+                case 401 | 403:
+                    failure_message_prefix = (
+                        "Invalid credentials (401)"
+                        if status_code == 401
+                        else "Permission denied (403)"
                     )
-                ]
-            else:
-                raise
+                    failure_message = (
+                        f"{failure_message_prefix} when fetching attachments for {page_ref}. "
+                        "The user may not have permission to query attachments on this page. "
+                        "Skipping attachments for this page."
+                    )
+                    attachment_docs = []
+                    attachment_failures = []
+                case _:
+                    raise
+            logger.warning(failure_message)
+
+            # Build the page URL for the failure record
+            try:
+                page_url = build_confluence_document_id(
+                    self.wiki_base, page["_links"]["webui"], self.is_cloud
+                )
+            except Exception:
+                page_url = f"page_id:{page_id}"
+            attachment_failures.append(
+                ConnectorFailure(
+                    # Confluence document ids are page URLs; targeted reindex
+                    # extracts the page id from this field.
+                    failed_document=DocumentFailure(
+                        document_id=page_url,
+                        document_link=page_url,
+                    ),
+                    failure_message=failure_message,
+                    exception=e,
+                )
+            )
 
         return attachment_docs, attachment_failures
 

--- a/backend/tests/unit/onyx/connectors/confluence/test_attachment_pagination_400.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_attachment_pagination_400.py
@@ -1,0 +1,124 @@
+"""A 4xx during attachment CQL pagination must not abort the whole index run.
+
+Confluence Data Center intermittently 400s when offset pagination of an
+attachment query advances past the first page. The connector keeps the
+attachments retrieved before the error, records a ConnectorFailure for the
+page, and continues. 401/403 skip the page's attachments entirely; other
+statuses still propagate.
+"""
+
+from collections.abc import Iterator
+from typing import Any
+from unittest import mock
+
+import pytest
+import requests
+from requests.exceptions import HTTPError
+
+from onyx.connectors.confluence.connector import (
+    ConfluenceConnector,
+    _extract_page_id_from_url,
+)
+from onyx.connectors.confluence.onyx_confluence import OnyxConfluence
+from onyx.connectors.models import ConnectorFailure, Document
+
+_PAGE = {
+    "id": "111",
+    "title": "Big Page",
+    "_links": {"webui": "/spaces/X/pages/111/Page"},
+    "space": {"key": "X"},
+    "history": {"createdDate": "2023-01-01T12:00:00.000+0000"},
+}
+_PDF_ATTACHMENT = {
+    "id": "222",
+    "title": "spec.pdf",
+    "metadata": {"mediaType": "application/pdf"},
+    "_links": {
+        "webui": "/spaces/X/pages/111/Page?preview=spec.pdf",
+        "download": "/download/attachments/111/spec.pdf",
+    },
+    "space": {"key": "X"},
+    "history": {"createdDate": "2023-01-02T12:00:00.000+0000"},
+    "version": {"when": "2023-01-02T12:00:00.000+0000"},
+}
+
+
+def _http_error(status_code: int, message: str = "") -> HTTPError:
+    # A real Response: it is falsy for error statuses, which the handler's
+    # `is not None` check must tolerate.
+    response = requests.Response()
+    response.status_code = status_code
+    return HTTPError(message, response=response)
+
+
+def _fetch_with_pagination_error(
+    status_code: int, message: str = ""
+) -> tuple[list[Any], list[ConnectorFailure]]:
+    """Drive _fetch_page_attachments with a client that yields one attachment
+    and then fails pagination with the given status code."""
+    connector = ConfluenceConnector(
+        wiki_base="https://confluence.example.com",
+        is_cloud=False,
+        include_attachments=True,
+    )
+    fake_client = mock.Mock(spec=OnyxConfluence)
+
+    def failing_pagination(**_kwargs: Any) -> Iterator[dict[str, Any]]:
+        yield _PDF_ATTACHMENT
+        raise _http_error(status_code, message)
+
+    fake_client.paginated_cql_retrieval.side_effect = failing_pagination
+
+    with (
+        mock.patch.object(
+            ConfluenceConnector,
+            "confluence_client",
+            new_callable=mock.PropertyMock,
+            return_value=fake_client,
+        ),
+        mock.patch.object(
+            connector, "_maybe_yield_page_hierarchy_node", return_value=None
+        ),
+        mock.patch(
+            "onyx.connectors.confluence.connector.convert_attachment_to_content",
+            return_value=("extracted text", None),
+        ),
+    ):
+        return connector._fetch_page_attachments(_PAGE)
+
+
+def test_400_keeps_partial_attachments_and_records_failure() -> None:
+    docs, failures = _fetch_with_pagination_error(400)
+
+    assert len(docs) == 1
+    assert isinstance(docs[0], Document)
+    assert docs[0].semantic_identifier == "spec.pdf"
+
+    assert len(failures) == 1
+    failure = failures[0]
+    assert "400" in failure.failure_message
+    assert failure.failed_document is not None
+    # document_id must be the page URL so targeted reindex can recover the page id
+    assert _extract_page_id_from_url(failure.failed_document.document_id) == "111"
+    assert isinstance(failure.exception, HTTPError)
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_401_403_skips_page_attachments(status_code: int) -> None:
+    docs, failures = _fetch_with_pagination_error(status_code)
+
+    assert docs == []
+    assert len(failures) == 1
+    assert str(status_code) in failures[0].failure_message
+
+
+def test_other_http_errors_propagate() -> None:
+    with pytest.raises(HTTPError):
+        _fetch_with_pagination_error(500)
+
+
+def test_400_date_error_propagates() -> None:
+    """Atlassian date errors are 400s but must reach load_from_checkpoint's
+    time-offset retry instead of being skipped as a page failure."""
+    with pytest.raises(HTTPError):
+        _fetch_with_pagination_error(400, "The field 'updated' is invalid")

--- a/backend/tests/unit/onyx/connectors/confluence/test_attachment_pagination_400.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_attachment_pagination_400.py
@@ -15,12 +15,13 @@ import pytest
 import requests
 from requests.exceptions import HTTPError
 
+from onyx.configs.constants import DocumentSource
 from onyx.connectors.confluence.connector import (
     ConfluenceConnector,
     _extract_page_id_from_url,
 )
 from onyx.connectors.confluence.onyx_confluence import OnyxConfluence
-from onyx.connectors.models import ConnectorFailure, Document
+from onyx.connectors.models import ConnectorFailure, Document, DocumentFailure
 
 _PAGE = {
     "id": "111",
@@ -122,3 +123,89 @@ def test_400_date_error_propagates() -> None:
     time-offset retry instead of being skipped as a page failure."""
     with pytest.raises(HTTPError):
         _fetch_with_pagination_error(400, "The field 'updated' is invalid")
+
+
+_PAGE_URL = "https://confluence.example.com/spaces/X/pages/111/Page"
+
+
+def _run_reindex(attachment_error_code: int | None) -> list[Any]:
+    """Run targeted reindex for _PAGE with a client whose attachment pagination
+    yields one attachment and then optionally fails."""
+    connector = ConfluenceConnector(
+        wiki_base="https://confluence.example.com",
+        is_cloud=False,
+        include_attachments=True,
+    )
+    fake_client = mock.Mock(spec=OnyxConfluence)
+
+    def paginate(**kwargs: Any) -> Iterator[dict[str, Any]]:
+        if str(kwargs.get("cql", "")).startswith("type=page"):
+            yield _PAGE
+            return
+        yield _PDF_ATTACHMENT
+        if attachment_error_code is not None:
+            raise _http_error(attachment_error_code)
+
+    fake_client.paginated_cql_retrieval.side_effect = paginate
+
+    error = ConnectorFailure(
+        failed_document=DocumentFailure(document_id=_PAGE_URL, document_link=_PAGE_URL),
+        failure_message="Bad request (400) while paginating attachments",
+    )
+    with (
+        mock.patch.object(
+            ConfluenceConnector,
+            "confluence_client",
+            new_callable=mock.PropertyMock,
+            return_value=fake_client,
+        ),
+        mock.patch.object(
+            connector, "_yield_space_hierarchy_nodes", return_value=iter([])
+        ),
+        mock.patch.object(
+            connector, "_yield_ancestor_hierarchy_nodes", return_value=iter([])
+        ),
+        mock.patch.object(
+            connector, "_maybe_yield_page_hierarchy_node", return_value=None
+        ),
+        mock.patch.object(
+            connector,
+            "_convert_page_to_document",
+            return_value=Document(
+                id=_PAGE_URL,
+                sections=[],
+                source=DocumentSource.CONFLUENCE,
+                semantic_identifier="Big Page",
+                metadata={},
+            ),
+        ),
+        mock.patch(
+            "onyx.connectors.confluence.connector.convert_attachment_to_content",
+            return_value=("extracted text", None),
+        ),
+    ):
+        return list(connector.reindex([error]))
+
+
+def test_reindex_refetches_attachments() -> None:
+    outputs = _run_reindex(attachment_error_code=None)
+
+    assert any(
+        isinstance(o, Document) and o.semantic_identifier == "spec.pdf" for o in outputs
+    )
+    assert not any(isinstance(o, ConnectorFailure) for o in outputs)
+
+
+def test_reindex_rerecords_attachment_failure() -> None:
+    """If the 400 recurs during targeted reindex, the failure must be yielded
+    again so the error is not silently cleared."""
+    outputs = _run_reindex(attachment_error_code=400)
+
+    assert any(
+        isinstance(o, Document) and o.semantic_identifier == "spec.pdf" for o in outputs
+    )
+    failures = [o for o in outputs if isinstance(o, ConnectorFailure)]
+    assert len(failures) == 1
+    assert "400" in failures[0].failure_message
+    assert failures[0].failed_document is not None
+    assert _extract_page_id_from_url(failures[0].failed_document.document_id) == "111"

--- a/backend/tests/unit/onyx/connectors/confluence/test_attachment_pagination_400.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_attachment_pagination_400.py
@@ -196,6 +196,58 @@ def test_reindex_refetches_attachments() -> None:
     assert not any(isinstance(o, ConnectorFailure) for o in outputs)
 
 
+def _slim_attachments_with(side_effects: list[Any]) -> tuple[list[Any], mock.Mock]:
+    """Drive _retrieve_attachments_for_slim_page with a client whose
+    cql_paginate_all_expansions produces the given results/exceptions."""
+    connector = ConfluenceConnector(
+        wiki_base="https://confluence.example.com",
+        is_cloud=False,
+        include_attachments=True,
+    )
+    fake_client = mock.Mock(spec=OnyxConfluence)
+    fake_client.cql_paginate_all_expansions.side_effect = side_effects
+
+    with mock.patch.object(
+        ConfluenceConnector,
+        "confluence_client",
+        new_callable=mock.PropertyMock,
+        return_value=fake_client,
+    ):
+        results = connector._retrieve_attachments_for_slim_page(
+            "111", "space", None, None
+        )
+    return results, fake_client
+
+
+def test_slim_attachment_400_retries_then_succeeds() -> None:
+    results, fake_client = _slim_attachments_with(
+        [_http_error(400), _http_error(400), iter([_PDF_ATTACHMENT])]
+    )
+
+    assert results == [_PDF_ATTACHMENT]
+    assert fake_client.cql_paginate_all_expansions.call_count == 3
+
+
+def test_slim_attachment_persistent_400_raises() -> None:
+    """The slim path must never keep partial results (pruning deletes anything
+    not enumerated) -- a persistent 400 aborts instead of truncating."""
+    with pytest.raises(HTTPError):
+        _slim_attachments_with([_http_error(400), _http_error(400), _http_error(400)])
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        _http_error(403),
+        _http_error(500),
+        _http_error(400, "The field 'updated' is invalid"),
+    ],
+)
+def test_slim_attachment_other_errors_raise_immediately(error: HTTPError) -> None:
+    with pytest.raises(HTTPError):
+        _slim_attachments_with([error])
+
+
 def test_reindex_rerecords_attachment_failure() -> None:
     """If the 400 recurs during targeted reindex, the failure must be yielded
     again so the error is not silently cleared."""


### PR DESCRIPTION
## Description

Confluence Data Center intermittently returns `400 Bad Request` from `/rest/api/content/search` when offset pagination of an attachment CQL query (`type=attachment and container='<pageId>' ...`) advances past the first page — observed at `start=200, 400, 1400, 5400, ...` on customer instances, so it's not a single deep-offset ceiling. `_paginate_url` only has recovery for 5xx (`_SERVER_ERROR_CODES`), so the `HTTPError` propagated out of `_fetch_page_attachments` and **aborted the entire index attempt**. On a large space this is unrecoverable; the only workaround was an ever-growing per-page `id not in (...)` CQL exclusion list.

### Fix

`_fetch_page_attachments` already skips 401/403 with a per-page `ConnectorFailure`; a 400 now gets the same treatment via a `match` on the status code, with one difference: the attachments retrieved before the pagination error are **kept** (they were fetched successfully), unlike the all-or-nothing `include_attachments=false` toggle. Atlassian date errors (also 400s) are explicitly excluded so they still reach `load_from_checkpoint`'s time-offset retry.

Two adjacent bugs fixed while here:

- **The 401/403 skip was dead code in production.** `requests.Response.__bool__` returns `self.ok`, which is `False` for any 4xx — so `if e.response and e.response.status_code in [401, 403]` never matched a real response and every such error crashed the run (existing tests passed because they mocked the response with a truthy `MagicMock`). The check is now `e.response is not None`.
- **Failure records were not targeted-reindexable.** `reindex()` recovers the page id from `failed_document.document_id` via URL patterns (`/pages/<id>/`, `pageId=<id>`); the records used the bare numeric page id, which those patterns can't parse. They now use the page URL.

Deliberately scoped out (deeper pre-existing issues): the slim-doc/pruning path (`_retrieve_all_slim_docs`) has the same unhandled 400 exposure, and the 401/403 clear path can mark a page hierarchy node as seen without emitting it.

## How Has This Been Tested?

New unit tests in `backend/tests/unit/onyx/connectors/confluence/test_attachment_pagination_400.py` (5 passing), driving `_fetch_page_attachments` with a client that yields one attachment then raises `HTTPError` built on a **real** `requests.Response` (a truthy mock would miss the falsy-response bug):

- 400 keeps the partial attachment and records a `ConnectorFailure` whose `document_id` round-trips through `_extract_page_id_from_url`
- 401/403 return no docs plus a failure (existing semantics, now actually reachable)
- 500 still propagates to `_paginate_url`'s limit-reduction/one-by-one recovery
- a 400 date error (`field 'updated' is invalid`) propagates instead of being skipped

Full Confluence unit suite passes (70 tests).

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent Confluence indexing and permission-sync runs from aborting on intermittent 400s during attachment pagination. Indexing keeps partial attachments and records a page failure; the slim path retries, and targeted reindex refetches attachments and re-records failures if they recur.

- **Bug Fixes**
  - Indexing: on 400 during attachment CQL pagination, keep partial attachments, record a `ConnectorFailure`, continue. Date-400s still propagate.
  - Slim path (pruning/perm sync): retry attachment pagination 400s up to 3 times; never keep partial; raise if persistent.
  - Fix 401/403 skip path (requests.Response truthiness); now returns no docs plus a failure.
  - Failures use the page URL as `document_id` so targeted reindex can extract the page id.
  - Targeted reindex refetches attachments and re-yields failures if the error recurs.
  - Preserve existing 5xx behavior (handled by pagination backoff/retry).
  - Share HTTP status helper; validation now reports 401/403 as credential/permission errors.

<sup>Written for commit dc6db1ddda6f7dc88aee5eda11fd9d9852b55360. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



