### PR TITLE
refactor(web): modernize MCP OAuth callback UI with Opal components

### DIFF
--- a/web/src/app/mcp/oauth/callback/page.tsx
+++ b/web/src/app/mcp/oauth/callback/page.tsx
@@ -1,27 +1,249 @@
 "use client";
 
-import OAuthCallbackPage from "@/components/oauth/OAuthCallbackPage";
+import { useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import type { Route } from "next";
+import { Button, Card, OnyxLoader, Text } from "@opal/components";
+import { IllustrationContent } from "@opal/layouts";
+import {
+  SvgBrokenKey,
+  SvgConnected,
+  SvgPlugBroken,
+  SvgTimeout,
+  SvgUnPlugged,
+} from "@opal/illustrations";
+import type { IconFunctionComponent } from "@opal/types";
+import { completeMCPUserOAuth } from "@/lib/tools/mcpService";
+
+const AUTO_REDIRECT_DELAY_MS = 2000;
+const DEFAULT_REDIRECT_PATH = "/app";
+
+interface CallbackError {
+  illustration: IconFunctionComponent;
+  title: string;
+  description: string;
+}
+
+type CallbackState =
+  | { phase: "processing" }
+  | { phase: "success"; serverName: string; redirectPath: string }
+  | { phase: "error"; error: CallbackError };
+
+function cancelledError(errorDescription: string | null): CallbackError {
+  return {
+    illustration: SvgUnPlugged,
+    title: "Authorization cancelled",
+    description:
+      errorDescription ||
+      "The authorization was cancelled or denied, so no connection was made. " +
+        "To try again, restart the connection from the MCP server's authentication settings.",
+  };
+}
+
+const INVALID_LINK_ERROR: CallbackError = {
+  illustration: SvgBrokenKey,
+  title: "Invalid authorization link",
+  description:
+    "This link is missing the required authorization parameters. " +
+    "Restart the connection from the MCP server's authentication settings.",
+};
+
+// Maps the backend's error `detail` strings to actionable guidance. Order
+// matters: "No tokens found" must match before the generic "token" and
+// "not found" checks.
+function classifyCallbackError(detail: string): CallbackError {
+  const lowerDetail = detail.toLowerCase();
+
+  if (lowerDetail.includes("state")) {
+    return {
+      illustration: SvgBrokenKey,
+      title: "Authorization session expired",
+      description:
+        "This authorization link is invalid, has expired, or was already used. " +
+        "Restart the connection from the MCP server's authentication settings.",
+    };
+  }
+  if (lowerDetail.includes("no tokens found")) {
+    return {
+      illustration: SvgTimeout,
+      title: "Authorization timed out",
+      description:
+        "The MCP server didn't confirm the authorization in time. Try connecting " +
+        "again — if this keeps happening, verify the server's OAuth configuration.",
+    };
+  }
+  if (
+    lowerDetail.includes("token exchange") ||
+    lowerDetail.includes("access_token")
+  ) {
+    return {
+      illustration: SvgPlugBroken,
+      title: "Token exchange failed",
+      description:
+        "The provider approved the authorization but a valid access token could " +
+        "not be obtained. Check the server's OAuth client credentials and " +
+        "endpoints, then try connecting again.",
+    };
+  }
+  if (
+    lowerDetail.includes("not found") ||
+    lowerDetail.includes("not configured")
+  ) {
+    return {
+      illustration: SvgPlugBroken,
+      title: "MCP server not found",
+      description:
+        "The MCP server this authorization belongs to no longer exists or is no " +
+        "longer configured. Recreate or reconfigure the server, then connect again.",
+    };
+  }
+  return {
+    illustration: SvgPlugBroken,
+    title: "Something went wrong",
+    description: detail,
+  };
+}
+
+// Respect the backend-provided redirect path (from state.return_path) while
+// preventing open redirects (e.g. "//evil.com" or absolute URLs).
+function buildRedirectPath(rawPath: string): string {
+  const sanitizedPath =
+    rawPath.startsWith("http://") || rawPath.startsWith("https://")
+      ? DEFAULT_REDIRECT_PATH
+      : "/" + rawPath.replace(/^\/+/, "");
+  const redirectUrl = new URL(sanitizedPath, window.location.origin);
+  redirectUrl.searchParams.set("message", "oauth_connected");
+  return redirectUrl.pathname + redirectUrl.search;
+}
 
 export default function MCPOAuthCallbackPage() {
-  const mcpConfig = {
-    processingMessage: "Processing...",
-    processingDetails: "Please wait while we complete the MCP server setup.",
-    successMessage: "Success!",
-    successDetailsTemplate:
-      "Your {serviceName} authorization completed successfully. You can now use this server's tools in chat.",
-    errorMessage: "Something Went Wrong",
-    backButtonText: "Back to Chat",
-    redirectingMessage: "Redirecting back in 2 seconds...",
-    autoRedirectDelay: 2000,
-    defaultRedirectPath: "/app",
-    callbackApiUrl: "/api/mcp/oauth/callback",
-    errorMessageMap: {
-      "server not found": "MCP server configuration not found",
-      credentials: "Authentication credentials are invalid",
-      oauth: "OAuth authorization failed",
-      validation: "Could not validate connection to MCP server",
-    },
-  };
+  const router = useRouter();
+  const searchParams = useSearchParams();
 
-  return <OAuthCallbackPage config={mcpConfig} />;
+  const [state, setState] = useState<CallbackState>({ phase: "processing" });
+
+  // State + auth code are single-use; block duplicate POSTs (StrictMode
+  // double-invoke or re-renders) that race the first request and 400.
+  const hasProcessedRef = useRef(false);
+
+  useEffect(() => {
+    if (state.phase !== "success") return;
+    const timer = setTimeout(
+      () => router.push(state.redirectPath as Route),
+      AUTO_REDIRECT_DELAY_MS
+    );
+    return () => clearTimeout(timer);
+  }, [state, router]);
+
+  useEffect(() => {
+    if (hasProcessedRef.current) return;
+    hasProcessedRef.current = true;
+
+    const code = searchParams?.get("code");
+    const stateParam = searchParams?.get("state");
+    const providerError = searchParams?.get("error");
+    const errorDescription = searchParams?.get("error_description");
+
+    // The provider redirected back with an error (e.g. the user cancelled)
+    if (providerError) {
+      setState({ phase: "error", error: cancelledError(errorDescription) });
+      return;
+    }
+
+    if (!code || !stateParam) {
+      setState({ phase: "error", error: INVALID_LINK_ERROR });
+      return;
+    }
+
+    const handleOAuthCallback = async () => {
+      try {
+        const response = await completeMCPUserOAuth(code, stateParam);
+        setState({
+          phase: "success",
+          serverName: response.server_name,
+          redirectPath: buildRedirectPath(
+            response.redirect_url || DEFAULT_REDIRECT_PATH
+          ),
+        });
+      } catch (error) {
+        setState({
+          phase: "error",
+          error: classifyCallbackError(
+            error instanceof Error
+              ? error.message
+              : "Failed to complete authorization"
+          ),
+        });
+      }
+    };
+
+    handleOAuthCallback();
+    // Run once; the single-use callback must not re-fire (see hasProcessedRef).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        <Card padding="lg" rounding="lg" background="light" border="solid">
+          <div className="flex flex-col items-stretch gap-4">
+            {state.phase === "processing" && (
+              <div className="flex flex-col items-center gap-3 p-5 text-center">
+                {/* Match the illustration footprint so success/error don't shift layout */}
+                <div className="flex h-30 w-30 items-center justify-center">
+                  <OnyxLoader />
+                </div>
+                <div className="flex flex-col items-center text-center">
+                  <Text font="main-content-emphasis" color="text-04" as="p">
+                    Completing authorization
+                  </Text>
+                  <Text font="secondary-body" color="text-03" as="p">
+                    Finishing the connection to your MCP server. This may take a
+                    few moments…
+                  </Text>
+                </div>
+              </div>
+            )}
+
+            {state.phase === "success" && (
+              <>
+                <IllustrationContent
+                  illustration={SvgConnected}
+                  title={`Connected to ${state.serverName}`}
+                  description="Authorization completed successfully. You can now use this server's tools in chat."
+                />
+                <Button
+                  width="full"
+                  onClick={() => router.push(state.redirectPath as Route)}
+                >
+                  Continue
+                </Button>
+                <div className="flex justify-center">
+                  <Text font="secondary-body" color="text-03" as="p">
+                    Taking you back automatically…
+                  </Text>
+                </div>
+              </>
+            )}
+
+            {state.phase === "error" && (
+              <>
+                <IllustrationContent
+                  illustration={state.error.illustration}
+                  title={state.error.title}
+                  description={state.error.description}
+                />
+                <Button
+                  width="full"
+                  onClick={() => router.push(DEFAULT_REDIRECT_PATH as Route)}
+                >
+                  Back to Chat
+                </Button>
+              </>
+            )}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
 }

--- a/web/src/lib/tools/mcpService.ts
+++ b/web/src/lib/tools/mcpService.ts
@@ -260,6 +260,33 @@ export async function startMCPUserOAuth(
   return res.json();
 }
 
+export interface MCPOAuthCallbackResponse {
+  success: boolean;
+  server_id: number;
+  server_name: string;
+  message: string;
+  redirect_url: string;
+}
+
+/** Complete the OAuth flow started by `startMCPUserOAuth`: exchange the
+ * provider's authorization code for tokens and store them for the current
+ * user. The code + state are single-use — call at most once per callback. */
+export async function completeMCPUserOAuth(
+  code: string,
+  state: string
+): Promise<MCPOAuthCallbackResponse> {
+  const params = new URLSearchParams({ code, state });
+  const res = await fetch(`/api/mcp/oauth/callback?${params.toString()}`, {
+    method: "POST",
+  });
+  if (!res.ok) {
+    throw new Error(
+      await parseErrorDetail(res, "Failed to complete authorization")
+    );
+  }
+  return res.json();
+}
+
 /** Save per-user credentials (API key / template fields) for an MCP server. */
 export async function saveMCPUserCredentials(
   serverId: number,

--- a/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
@@ -17,9 +17,9 @@ import {
   MessageCard,
   PasswordInputTypeIn,
   Tabs,
+  Text,
 } from "@opal/components";
 import { markdown } from "@opal/utils";
-import Text from "@/refresh-components/texts/Text";
 import { Formik, Form } from "formik";
 import * as Yup from "yup";
 import { useModal } from "@opal/components";
@@ -682,11 +682,11 @@ export default function MCPAuthenticationModal({
 
                       {/* Info Text */}
                       <div className="flex flex-col gap-2">
-                        <Text as="p" text03 secondaryBody>
+                        <Text as="p" font="secondary-body" color="text-03">
                           Client ID and secret are optional if the server
                           connection supports Dynamic Client Registration (DCR).
                         </Text>
-                        <Text as="p" text03 secondaryBody>
+                        <Text as="p" font="secondary-body" color="text-03">
                           If your server does not support DCR, you need register
                           your Onyx instance with the server provider to obtain
                           these credentials first. Make sure to grant Onyx
@@ -696,20 +696,17 @@ export default function MCPAuthenticationModal({
                         <div className="flex items-center gap-1 w-full">
                           <Text
                             as="p"
-                            text03
-                            secondaryBody
-                            className="whitespace-nowrap"
+                            font="secondary-body"
+                            color="text-03"
+                            nowrap
                           >
-                            Use{" "}
-                            <span className="font-secondary-action">
-                              redirect URI
-                            </span>
-                            :
+                            {markdown("Use **redirect URI**:")}
                           </Text>
                           <Text
                             as="p"
-                            text04
-                            className="font-mono text-[12px] leading-[16px] truncate"
+                            font="secondary-mono"
+                            color="text-04"
+                            maxLines={1}
                           >
                             {redirectUri}
                           </Text>
@@ -870,12 +867,12 @@ export default function MCPAuthenticationModal({
                                   </FormField.Control>
                                 </FormField>
 
-                                <Text as="p" text03 secondaryBody>
-                                  Known-provider mode requires endpoint
-                                  configuration. Google reference endpoints:
-                                  authorization{" "}
-                                  {GOOGLE_AUTHORIZATION_ENDPOINT_HINT} and token{" "}
-                                  {GOOGLE_TOKEN_ENDPOINT_HINT}.
+                                <Text
+                                  as="p"
+                                  font="secondary-body"
+                                  color="text-03"
+                                >
+                                  {`Known-provider mode requires endpoint configuration. Google reference endpoints: authorization ${GOOGLE_AUTHORIZATION_ENDPOINT_HINT} and token ${GOOGLE_TOKEN_ENDPOINT_HINT}.`}
                                 </Text>
                               </>
                             )}


### PR DESCRIPTION
## Description

The MCP OAuth callback screens still used the legacy Danswer UI (legacy `OAuthCallbackPage` shared component, `CardSection`, raw Tailwind palette colors, manual `dark:` overrides). This migrates the MCP-specific experience to current Opal components and patterns:

- `web/src/app/mcp/oauth/callback/page.tsx` rewritten as a self-contained page (mirroring the Craft OAuth callback): Opal `Card` + `OnyxLoader` for the loading state, `IllustrationContent` for success/error, Opal `Button`/`Text` throughout. No `dark:` modifiers or raw palette colors.
- Failure modes map to actionable messages + illustrations keyed off the backend's error `detail` strings: cancelled/denied authorization, invalid link, expired/reused state, timeout waiting for tokens, token exchange failure, and server not found/not configured. Success gets a **Continue** button alongside the preserved 2s auto-redirect.
- API call moved out of the page into `completeMCPUserOAuth` in `mcpService.ts`, next to `startMCPUserOAuth` (typed to mirror the backend `MCPOAuthCallbackResponse` model, using the shared `parseErrorDetail`).
- Preserved behaviors: one-shot callback submission (StrictMode-safe ref guard), open-redirect sanitization of the return path, and the `message=oauth_connected` toast param consumed by `AppPage`.
- Dropped legacy dead code: the `return_path` URL-param fallback (the registered redirect URI never carries it), the `server_name`/`redirect_url` defensive fallbacks contradicting the backend model, and the countdown interval (static "Taking you back automatically…" + one timer effect instead of interval + two extra states).
- `MCPAuthenticationModal`: migrated the remaining deprecated boolean-flag `Text` usages to the Opal `Text` string-enum API.

## How Has This Been Tested?

Exercised live via Chrome DevTools against a running dev stack:

- Cancelled, invalid-link, and expired-state screens driven against the real `/api/mcp/oauth/callback` (bogus code/state → backend 400); timeout, token-exchange, server-not-found, and success screens via stubbed responses matching the backend detail strings.
- Verified exactly one callback POST per page load in api-server logs despite React StrictMode double-invoke.
- Verified the success auto-redirect honors the backend-provided admin return path (`/admin/actions/mcp/?server_id=…`) and that the `oauth_connected` toast fires on `/app`.
- Opened the MCP authentication modal to confirm the migrated `Text` usages (DCR info, bold redirect-URI label, mono URI) render correctly.
- `pre-commit` (oxfmt, oxlint, TypeScript type check) passes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modernized the MCP OAuth callback UI with Opal components for a clearer, consistent experience and safer redirects. Moved the callback API call to `mcpService.ts` and removed legacy code.

- **New Features**
  - Clear success and error screens with `IllustrationContent` and actionable messages (cancelled, invalid link, expired state, timeout, token exchange failure, server not found).
  - 2s auto-redirect with a “Continue” button; preserves `message=oauth_connected`.
  - Open-redirect-safe return path that honors the backend-provided URL.
  - One-shot callback submission guard to avoid duplicate POSTs under React StrictMode.

- **Refactors**
  - Rebuilt `/mcp/oauth/callback` page using `@opal/components` (`Card`, `Button`, `Text`, `OnyxLoader`) and `@opal/layouts` (`IllustrationContent`); removed raw Tailwind colors and `dark:` overrides.
  - Added `completeMCPUserOAuth` to `mcpService.ts`, typed to `MCPOAuthCallbackResponse`, using shared `parseErrorDetail`.
  - Removed dead fallbacks and countdown interval; simplified to a single timer.
  - Updated `MCPAuthenticationModal` to the Opal `Text` string-enum API.

<sup>Written for commit cf2a008bbe4918b338ff34b601a1b627f0557bea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

