### PR TITLE
feat: efficient sharepoint role fetching

### DIFF
--- a/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
@@ -549,7 +549,11 @@ def _get_cached_group_expansion(
         else:
             nested_groups, _ = _get_azuread_groups(graph_client, group.login_name)
     except ClientRequestException as e:
-        if e.response is None or e.response.status_code != 404:
+        if (
+            group.principal_type != AZURE_AD_GROUP_PRINCIPAL_TYPE
+            or e.response is None
+            or e.response.status_code != 404
+        ):
             raise
         logger.warning("Group %s not found", group.login_name)
         nested_groups = set()

--- a/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
@@ -575,15 +575,15 @@ def _resolve_document_groups(
 
     while group_queue:
         group = group_queue.popleft()
+        if _is_public_login_name(group.login_name):
+            return DocumentGroupsResult(group_ids=set(), found_public_group=True)
+
+        group_ids.add(group.name)
         cache_key = _group_cache_key(client_context, group)
         if cache_key in visited_group_keys:
             continue
         visited_group_keys.add(cache_key)
 
-        if _is_public_login_name(group.login_name):
-            return DocumentGroupsResult(group_ids=set(), found_public_group=True)
-
-        group_ids.add(group.name)
         expansion = _get_cached_group_expansion(
             client_context, graph_client, group, permission_cache
         )

--- a/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
@@ -30,6 +30,11 @@ from onyx.connectors.sharepoint.connector import (
     SHARED_DOCUMENTS_MAP_REVERSE,
     sleep_and_retry,
 )
+from onyx.connectors.sharepoint.connector_utils import (
+    SharepointGroup,
+    SharepointGroupExpansion,
+    SharepointPermissionCache,
+)
 from onyx.db.enums import HierarchyNodeType
 from onyx.utils.logger import setup_logger
 from onyx.utils.retry_after import parse_retry_after_seconds
@@ -44,6 +49,7 @@ AZURE_AD_GROUP_PRINCIPAL_TYPE = 4  # Azure Active Directory security groups
 SHAREPOINT_GROUP_PRINCIPAL_TYPE = 8  # SharePoint site groups (local to the site)
 MICROSOFT_DOMAIN = ".onmicrosoft"
 SHAREPOINT_GROUP_SCOPE_SEPARATOR = "::"
+GROUP_CACHE_KEY_SEPARATOR = ":"
 # PnP RoleType defines Guest=1 and RestrictedGuest=9:
 # https://github.com/pnp/pnpcore/blob/4e4f58fcac797f2957bfcd14fedcecd690dfe7ee/src/sdk/PnP.Core/Model/SharePoint/Core/Public/Enums/RoleType.cs
 LIMITED_ACCESS_ROLE_TYPES = frozenset({1, 9})
@@ -145,16 +151,13 @@ def _normalize_email(email: str) -> str:
     return email
 
 
-class SharepointGroup(BaseModel):
-    model_config = {"frozen": True}
-
-    name: str
-    login_name: str
-    principal_type: int
-
-
 class GroupsResult(BaseModel):
     groups_to_emails: dict[str, set[str]]
+    found_public_group: bool
+
+
+class DocumentGroupsResult(BaseModel):
+    group_ids: set[str]
     found_public_group: bool
 
 
@@ -515,10 +518,84 @@ def _get_groups_and_members_recursively(
     )
 
 
+def _group_cache_key(
+    client_context: ClientContext,
+    group: SharepointGroup,
+) -> str:
+    identity = group.login_name
+    if group.principal_type == SHAREPOINT_GROUP_PRINCIPAL_TYPE:
+        identity = _get_site_scoped_group_name(client_context, identity)
+    elif guid := _extract_guid_from_claims_token(identity):
+        identity = guid
+    return f"{group.principal_type}{GROUP_CACHE_KEY_SEPARATOR}{identity}"
+
+
+def _get_cached_group_expansion(
+    client_context: ClientContext,
+    graph_client: GraphClient,
+    group: SharepointGroup,
+    permission_cache: SharepointPermissionCache,
+) -> SharepointGroupExpansion:
+    cache_key = _group_cache_key(client_context, group)
+    cached_expansion = permission_cache.group_expansions.get(cache_key)
+    if cached_expansion is not None:
+        return cached_expansion
+
+    try:
+        if group.principal_type == SHAREPOINT_GROUP_PRINCIPAL_TYPE:
+            nested_groups, _ = _get_sharepoint_groups(
+                client_context, group.login_name, graph_client
+            )
+        else:
+            nested_groups, _ = _get_azuread_groups(graph_client, group.login_name)
+    except ClientRequestException as e:
+        if e.response is None or e.response.status_code != 404:
+            raise
+        logger.warning("Group %s not found", group.login_name)
+        nested_groups = set()
+
+    expansion = SharepointGroupExpansion(nested_groups=nested_groups)
+    permission_cache.group_expansions[cache_key] = expansion
+    return expansion
+
+
+def _resolve_document_groups(
+    client_context: ClientContext,
+    graph_client: GraphClient,
+    groups: set[SharepointGroup],
+    permission_cache: SharepointPermissionCache,
+) -> DocumentGroupsResult:
+    group_queue: deque[SharepointGroup] = deque(groups)
+    visited_group_keys: set[str] = set()
+    group_ids: set[str] = set()
+
+    while group_queue:
+        group = group_queue.popleft()
+        cache_key = _group_cache_key(client_context, group)
+        if cache_key in visited_group_keys:
+            continue
+        visited_group_keys.add(cache_key)
+
+        if _is_public_login_name(group.login_name):
+            return DocumentGroupsResult(group_ids=set(), found_public_group=True)
+
+        group_ids.add(group.name)
+        expansion = _get_cached_group_expansion(
+            client_context, graph_client, group, permission_cache
+        )
+        group_queue.extend(expansion.nested_groups)
+
+    return DocumentGroupsResult(
+        group_ids=group_ids,
+        found_public_group=False,
+    )
+
+
 def _get_external_access_from_securable_object(
     client_context: ClientContext,
     graph_client: GraphClient,
     securable_object: SecurableObject,
+    permission_cache: SharepointPermissionCache,
     add_prefix: bool = False,
 ) -> ExternalAccess:
     groups: set[SharepointGroup] = set()
@@ -578,17 +655,20 @@ def _get_external_access_from_securable_object(
         "get_external_access_from_sharepoint",
     )
 
-    groups_and_members = _get_groups_and_members_recursively(
-        client_context, graph_client, groups
+    resolved_groups = _resolve_document_groups(
+        client_context,
+        graph_client,
+        groups,
+        permission_cache,
     )
-    if groups_and_members.found_public_group:
+    if resolved_groups.found_public_group:
         return ExternalAccess(
             external_user_emails=set(),
             external_user_group_ids=set(),
             is_public=True,
         )
 
-    for group_name in groups_and_members.groups_to_emails:
+    for group_name in resolved_groups.group_ids:
         if add_prefix:
             group_name = build_ext_group_name_for_onyx(
                 group_name, DocumentSource.SHAREPOINT
@@ -612,7 +692,9 @@ def get_external_access_from_sharepoint(
     site_page: dict[str, Any] | None,
     add_prefix: bool = False,
     treat_sharing_link_as_public: bool = False,
+    permission_cache: SharepointPermissionCache | None = None,
 ) -> ExternalAccess:
+    permission_cache = permission_cache or SharepointPermissionCache()
     if drive_item and drive_name:
         is_public = _is_public_item(drive_item, treat_sharing_link_as_public)
         if is_public:
@@ -655,6 +737,7 @@ def get_external_access_from_sharepoint(
         client_context,
         graph_client,
         item,
+        permission_cache,
         add_prefix,
     )
 
@@ -665,7 +748,9 @@ def get_hierarchy_node_external_access_from_sharepoint(
     node_type: HierarchyNodeType,
     drive_name: str | None,
     folder_url: str | None,
+    permission_cache: SharepointPermissionCache | None = None,
 ) -> ExternalAccess:
+    permission_cache = permission_cache or SharepointPermissionCache()
     if node_type == HierarchyNodeType.SITE:
         securable_object = client_context.web
     elif node_type == HierarchyNodeType.DRIVE and drive_name:
@@ -683,6 +768,7 @@ def get_hierarchy_node_external_access_from_sharepoint(
         client_context,
         graph_client,
         securable_object,
+        permission_cache,
         add_prefix=True,
     )
 

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -69,6 +69,7 @@ from onyx.connectors.models import (
     TextSection,
 )
 from onyx.connectors.sharepoint.connector_utils import (
+    SharepointPermissionCache,
     get_sharepoint_external_access,
     get_sharepoint_hierarchy_node_external_access,
 )
@@ -464,6 +465,9 @@ class SharepointConnectorCheckpoint(ConnectorCheckpoint):
     # Track yielded document IDs to avoid processing the same document twice.
     # The Microsoft Graph delta API can return the same item on multiple pages.
     seen_document_ids: set[str] = Field(default_factory=set)
+    permission_cache: SharepointPermissionCache = Field(
+        default_factory=SharepointPermissionCache
+    )
 
 
 class SharepointAuthMethod(Enum):
@@ -799,12 +803,14 @@ def _convert_driveitem_to_document_with_permissions(
     access_token: str | None = None,
     treat_sharing_link_as_public: bool = False,
     raw_file_callback: RawFileCallback | None = None,
+    permission_cache: SharepointPermissionCache | None = None,
 ) -> Document | ConnectorFailure | None:
     if not driveitem.name or not driveitem.id:
         raise ValueError("DriveItem name/id is required")
 
     if include_permissions and ctx is None:
         raise ValueError("ClientContext is required for permissions")
+    permission_cache = permission_cache or SharepointPermissionCache()
 
     mime_type = driveitem.mime_type
     if not mime_type or mime_type in OnyxMimeTypes.EXCLUDED_IMAGE_TYPES:
@@ -939,6 +945,7 @@ def _convert_driveitem_to_document_with_permissions(
         external_access = get_sharepoint_external_access(
             ctx=ctx,
             graph_client=graph_client,
+            permission_cache=permission_cache,
             drive_item=sdk_item,
             drive_name=drive_name,
             add_prefix=True,
@@ -981,6 +988,7 @@ def _convert_sitepage_to_document(
     site_name: str | None,
     ctx: ClientContext | None,
     graph_client: GraphClient,
+    permission_cache: SharepointPermissionCache,
     include_permissions: bool = False,
     parent_hierarchy_raw_node_id: str | None = None,
     treat_sharing_link_as_public: bool = False,
@@ -1111,6 +1119,7 @@ def _convert_sitepage_to_document(
         external_access = get_sharepoint_external_access(
             ctx=ctx,  # ty: ignore[invalid-argument-type]
             graph_client=graph_client,
+            permission_cache=permission_cache,
             site_page=site_page,
             add_prefix=True,
             treat_sharing_link_as_public=treat_sharing_link_as_public,
@@ -1155,6 +1164,7 @@ def _convert_driveitem_to_slim_document(
     drive_name: str,
     ctx: ClientContext,
     graph_client: GraphClient,
+    permission_cache: SharepointPermissionCache,
     parent_hierarchy_raw_node_id: str | None = None,
     treat_sharing_link_as_public: bool = False,
 ) -> SlimDocument:
@@ -1165,6 +1175,7 @@ def _convert_driveitem_to_slim_document(
     external_access = get_sharepoint_external_access(
         ctx=ctx,
         graph_client=graph_client,
+        permission_cache=permission_cache,
         drive_item=sdk_item,
         drive_name=drive_name,
         treat_sharing_link_as_public=treat_sharing_link_as_public,
@@ -1186,6 +1197,7 @@ def _convert_sitepage_to_slim_document(
     site_page: dict[str, Any],
     ctx: ClientContext | None,
     graph_client: GraphClient,
+    permission_cache: SharepointPermissionCache,
     parent_hierarchy_raw_node_id: str | None = None,
     treat_sharing_link_as_public: bool = False,
 ) -> SlimDocument:
@@ -1197,6 +1209,7 @@ def _convert_sitepage_to_slim_document(
     external_access = get_sharepoint_external_access(
         ctx=ctx,  # ty: ignore[invalid-argument-type]
         graph_client=graph_client,
+        permission_cache=permission_cache,
         site_page=site_page,
         treat_sharing_link_as_public=treat_sharing_link_as_public,
     )
@@ -2323,6 +2336,7 @@ class SharepointConnector(
                                     drive_name,
                                     ctx,
                                     self.graph_client,
+                                    temp_checkpoint.permission_cache,
                                     parent_hierarchy_raw_node_id=parent_hierarchy_url,
                                     treat_sharing_link_as_public=self.treat_sharing_link_as_public,
                                 )
@@ -2372,6 +2386,7 @@ class SharepointConnector(
                                         site_page,
                                         ctx,
                                         self.graph_client,
+                                        temp_checkpoint.permission_cache,
                                         parent_hierarchy_raw_node_id=site_descriptor.url,
                                         treat_sharing_link_as_public=self.treat_sharing_link_as_public,
                                     )
@@ -2570,6 +2585,7 @@ class SharepointConnector(
             external_access = get_sharepoint_hierarchy_node_external_access(
                 ctx,
                 self.graph_client,
+                checkpoint.permission_cache,
                 HierarchyNodeType.SITE,
             )
 
@@ -2604,6 +2620,7 @@ class SharepointConnector(
             external_access = get_sharepoint_hierarchy_node_external_access(
                 ctx,
                 self.graph_client,
+                checkpoint.permission_cache,
                 HierarchyNodeType.DRIVE,
                 drive_name=drive_name,
             )
@@ -2657,6 +2674,7 @@ class SharepointConnector(
                 external_access = get_sharepoint_hierarchy_node_external_access(
                     ctx,
                     self.graph_client,
+                    checkpoint.permission_cache,
                     HierarchyNodeType.FOLDER,
                     folder_url=folder_url,
                 )
@@ -2794,6 +2812,7 @@ class SharepointConnector(
                 drive_name,
                 ctx,
                 self.graph_client,
+                permission_cache=checkpoint.permission_cache,
                 include_permissions=include_permissions,
                 parent_hierarchy_raw_node_id=parent_hierarchy_url,
                 graph_api_base=self.graph_api_base,
@@ -3187,6 +3206,7 @@ class SharepointConnector(
                                 site_descriptor.drive_name,
                                 client_ctx,
                                 self.graph_client,
+                                permission_cache=checkpoint.permission_cache,
                                 include_permissions=include_permissions,
                                 # Site pages have the site as their parent
                                 parent_hierarchy_raw_node_id=site_descriptor.url,
@@ -3449,6 +3469,7 @@ class SharepointConnector(
             site_descriptor.drive_name,
             ctx,
             self.graph_client,
+            permission_cache=dedup.permission_cache,
             include_permissions=include_permissions,
             parent_hierarchy_raw_node_id=site_descriptor.url,
             treat_sharing_link_as_public=self.treat_sharing_link_as_public,

--- a/backend/onyx/connectors/sharepoint/connector_utils.py
+++ b/backend/onyx/connectors/sharepoint/connector_utils.py
@@ -3,7 +3,7 @@ from typing import Any
 from office365.graph_client import GraphClient
 from office365.onedrive.driveitems.driveItem import DriveItem
 from office365.sharepoint.client_context import ClientContext
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_serializer
 
 from onyx.connectors.models import ExternalAccess
 from onyx.db.enums import HierarchyNodeType
@@ -22,6 +22,12 @@ class SharepointGroup(BaseModel):
 
 class SharepointGroupExpansion(BaseModel):
     nested_groups: set[SharepointGroup]
+
+    @field_serializer("nested_groups")
+    def serialize_nested_groups(
+        self, nested_groups: set[SharepointGroup]
+    ) -> list[SharepointGroup]:
+        return list(nested_groups)
 
 
 class SharepointPermissionCache(BaseModel):

--- a/backend/onyx/connectors/sharepoint/connector_utils.py
+++ b/backend/onyx/connectors/sharepoint/connector_utils.py
@@ -3,6 +3,7 @@ from typing import Any
 from office365.graph_client import GraphClient
 from office365.onedrive.driveitems.driveItem import DriveItem
 from office365.sharepoint.client_context import ClientContext
+from pydantic import BaseModel, Field
 
 from onyx.connectors.models import ExternalAccess
 from onyx.db.enums import HierarchyNodeType
@@ -11,9 +12,26 @@ from onyx.utils.variable_functionality import (
 )
 
 
+class SharepointGroup(BaseModel):
+    model_config = {"frozen": True}
+
+    name: str
+    login_name: str
+    principal_type: int
+
+
+class SharepointGroupExpansion(BaseModel):
+    nested_groups: set[SharepointGroup]
+
+
+class SharepointPermissionCache(BaseModel):
+    group_expansions: dict[str, SharepointGroupExpansion] = Field(default_factory=dict)
+
+
 def get_sharepoint_external_access(
     ctx: ClientContext,
     graph_client: GraphClient,
+    permission_cache: SharepointPermissionCache,
     drive_item: DriveItem | None = None,
     drive_name: str | None = None,
     site_page: dict[str, Any] | None = None,
@@ -44,6 +62,7 @@ def get_sharepoint_external_access(
         site_page,
         add_prefix,
         treat_sharing_link_as_public,
+        permission_cache,
     )
 
     return external_access
@@ -52,6 +71,7 @@ def get_sharepoint_external_access(
 def get_sharepoint_hierarchy_node_external_access(
     ctx: ClientContext,
     graph_client: GraphClient,
+    permission_cache: SharepointPermissionCache,
     node_type: HierarchyNodeType,
     drive_name: str | None = None,
     folder_url: str | None = None,
@@ -73,4 +93,5 @@ def get_sharepoint_hierarchy_node_external_access(
         node_type,
         drive_name,
         folder_url,
+        permission_cache,
     )

--- a/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
@@ -60,6 +60,14 @@ def _make_ad_group(name: str, login_name: str | None = None) -> SharepointGroup:
     )
 
 
+def _make_sharepoint_group(name: str) -> SharepointGroup:
+    return SharepointGroup(
+        name=name,
+        login_name=name,
+        principal_type=SHAREPOINT_GROUP_PRINCIPAL_TYPE,
+    )
+
+
 @patch(f"{MODULE}._get_azuread_groups")
 def test_document_group_expansion_is_cached(mock_get_group: MagicMock) -> None:
     group = _make_ad_group("Engineering", "engineering-id")
@@ -72,6 +80,23 @@ def test_document_group_expansion_is_cached(mock_get_group: MagicMock) -> None:
     assert first == second
     assert first.group_ids == {"Engineering"}
     mock_get_group.assert_called_once()
+
+
+@patch(f"{MODULE}._get_sharepoint_groups")
+def test_sharepoint_group_cache_is_scoped_to_site(
+    mock_get_group: MagicMock,
+) -> None:
+    group = _make_sharepoint_group("Site Members")
+    first_context = MagicMock(base_url="https://tenant.sharepoint.com/sites/first")
+    second_context = MagicMock(base_url="https://tenant.sharepoint.com/sites/second")
+    mock_get_group.return_value = (set(), set())
+    cache = SharepointPermissionCache()
+
+    _resolve_document_groups(first_context, MagicMock(), {group}, cache)
+    _resolve_document_groups(second_context, MagicMock(), {group}, cache)
+
+    assert mock_get_group.call_count == 2
+    assert len(cache.group_expansions) == 2
 
 
 @patch(f"{MODULE}._get_azuread_groups")

--- a/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
@@ -23,6 +23,7 @@ from ee.onyx.external_permissions.sharepoint.permission_utils import (
     get_sharepoint_external_groups,
 )
 from onyx.access.models import ExternalAccess
+from onyx.background.indexing.checkpointing_utils import check_checkpoint_size
 from onyx.connectors.sharepoint.connector import SharepointConnectorCheckpoint
 from onyx.connectors.sharepoint.connector_utils import (
     SharepointGroup,
@@ -136,7 +137,8 @@ def test_document_group_cache_survives_checkpoint(
     mock_get_group: MagicMock,
 ) -> None:
     group = _make_ad_group("Engineering", "engineering-id")
-    mock_get_group.return_value = (set(), set())
+    nested_group = _make_ad_group("Platform", "platform-id")
+    mock_get_group.side_effect = [({nested_group}, set()), (set(), set())]
     cache = SharepointPermissionCache()
     _resolve_document_groups(MagicMock(), MagicMock(), {group}, cache)
 
@@ -144,6 +146,7 @@ def test_document_group_cache_survives_checkpoint(
         has_more=True,
         permission_cache=cache,
     )
+    check_checkpoint_size(checkpoint)
     restored = SharepointConnectorCheckpoint.model_validate_json(
         checkpoint.model_dump_json()
     )
@@ -154,7 +157,11 @@ def test_document_group_cache_survives_checkpoint(
         restored.permission_cache,
     )
 
-    mock_get_group.assert_called_once()
+    assert isinstance(
+        next(iter(restored.permission_cache.group_expansions.values())).nested_groups,
+        set,
+    )
+    assert mock_get_group.call_count == 2
 
 
 @patch(f"{MODULE}._get_azuread_groups")

--- a/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
@@ -6,7 +6,9 @@ import pytest
 
 from ee.onyx.external_permissions.sharepoint.permission_utils import (
     AD_GROUP_ENUMERATION_THRESHOLD,
+    AZURE_AD_GROUP_PRINCIPAL_TYPE,
     SHAREPOINT_GROUP_PRINCIPAL_TYPE,
+    DocumentGroupsResult,
     GroupsResult,
     _enumerate_ad_groups_paginated,
     _get_azuread_groups,
@@ -14,11 +16,17 @@ from ee.onyx.external_permissions.sharepoint.permission_utils import (
     _is_public_item,
     _iter_graph_collection,
     _normalize_email,
+    _resolve_document_groups,
     get_external_access_from_sharepoint,
     get_hierarchy_node_external_access_from_sharepoint,
     get_sharepoint_external_groups,
 )
 from onyx.access.models import ExternalAccess
+from onyx.connectors.sharepoint.connector import SharepointConnectorCheckpoint
+from onyx.connectors.sharepoint.connector_utils import (
+    SharepointGroup,
+    SharepointPermissionCache,
+)
 from onyx.db.enums import HierarchyNodeType
 
 MODULE = "ee.onyx.external_permissions.sharepoint.permission_utils"
@@ -42,6 +50,129 @@ def _make_graph_page(
     if next_link:
         page["@odata.nextLink"] = next_link
     return page
+
+
+def _make_ad_group(name: str, login_name: str | None = None) -> SharepointGroup:
+    return SharepointGroup(
+        name=name,
+        login_name=login_name or name,
+        principal_type=AZURE_AD_GROUP_PRINCIPAL_TYPE,
+    )
+
+
+@patch(f"{MODULE}._get_azuread_groups")
+def test_document_group_expansion_is_cached(mock_get_group: MagicMock) -> None:
+    group = _make_ad_group("Engineering", "engineering-id")
+    mock_get_group.return_value = (set(), {"alice@contoso.com"})
+    cache = SharepointPermissionCache()
+
+    first = _resolve_document_groups(MagicMock(), MagicMock(), {group}, cache)
+    second = _resolve_document_groups(MagicMock(), MagicMock(), {group}, cache)
+
+    assert first == second
+    assert first.group_ids == {"Engineering"}
+    mock_get_group.assert_called_once()
+
+
+@patch(f"{MODULE}._get_azuread_groups")
+def test_ad_group_claims_token_and_guid_share_cache(
+    mock_get_group: MagicMock,
+) -> None:
+    group_id = "11111111-1111-1111-1111-111111111111"
+    claims_group = _make_ad_group("Engineering", f"c:0t.c|tenant|{group_id}")
+    guid_group = _make_ad_group("Engineering", group_id)
+    mock_get_group.return_value = (set(), set())
+    cache = SharepointPermissionCache()
+
+    _resolve_document_groups(MagicMock(), MagicMock(), {claims_group}, cache)
+    _resolve_document_groups(MagicMock(), MagicMock(), {guid_group}, cache)
+
+    mock_get_group.assert_called_once()
+
+
+@patch(f"{MODULE}._get_azuread_groups")
+def test_document_group_cache_survives_checkpoint(
+    mock_get_group: MagicMock,
+) -> None:
+    group = _make_ad_group("Engineering", "engineering-id")
+    mock_get_group.return_value = (set(), set())
+    cache = SharepointPermissionCache()
+    _resolve_document_groups(MagicMock(), MagicMock(), {group}, cache)
+
+    checkpoint = SharepointConnectorCheckpoint(
+        has_more=True,
+        permission_cache=cache,
+    )
+    restored = SharepointConnectorCheckpoint.model_validate_json(
+        checkpoint.model_dump_json()
+    )
+    _resolve_document_groups(
+        MagicMock(),
+        MagicMock(),
+        {group},
+        restored.permission_cache,
+    )
+
+    mock_get_group.assert_called_once()
+
+
+@patch(f"{MODULE}._get_azuread_groups")
+def test_nested_public_group_uses_cached_parent_expansion(
+    mock_get_group: MagicMock,
+) -> None:
+    parent = _make_ad_group("Site Members", "site-members-id")
+    public = _make_ad_group(
+        "Everyone",
+        "c:0-.f|rolemanager|spo-grid-all-users/tenant-id",
+    )
+    mock_get_group.return_value = ({public}, set())
+    cache = SharepointPermissionCache()
+
+    first = _resolve_document_groups(MagicMock(), MagicMock(), {parent}, cache)
+    second = _resolve_document_groups(MagicMock(), MagicMock(), {parent}, cache)
+
+    assert first.found_public_group
+    assert second.found_public_group
+    mock_get_group.assert_called_once()
+
+
+@patch(f"{MODULE}._get_azuread_groups")
+def test_direct_public_group_skips_expansion(mock_get_group: MagicMock) -> None:
+    public = _make_ad_group(
+        "Everyone",
+        "c:0-.f|rolemanager|spo-grid-all-users/tenant-id",
+    )
+
+    result = _resolve_document_groups(
+        MagicMock(),
+        MagicMock(),
+        {public},
+        SharepointPermissionCache(),
+    )
+
+    assert result.found_public_group
+    mock_get_group.assert_not_called()
+
+
+@patch(f"{MODULE}._get_azuread_groups")
+def test_document_group_cycles_are_resolved_once(mock_get_group: MagicMock) -> None:
+    first_group = _make_ad_group("First", "first-id")
+    second_group = _make_ad_group("Second", "second-id")
+    mock_get_group.side_effect = [
+        ({second_group}, set()),
+        ({first_group}, set()),
+    ]
+
+    result = _resolve_document_groups(
+        MagicMock(),
+        MagicMock(),
+        {first_group},
+        SharepointPermissionCache(),
+    )
+
+    assert result.group_ids == {"First", "Second"}
+    assert not result.found_public_group
+    assert mock_get_group.call_count == 2
 
 
 # ---------------------------------------------------------------------------
@@ -618,18 +749,18 @@ def test_drive_item_public_when_sharing_link_enabled(
     assert result.external_user_group_ids == set()
 
 
-@patch(f"{MODULE}._get_groups_and_members_recursively")
+@patch(f"{MODULE}._resolve_document_groups")
 @patch(f"{MODULE}.sleep_and_retry")
 @patch(f"{MODULE}._is_public_item", return_value=False)
 def test_drive_item_falls_through_when_sharing_link_disabled(
     _mock_is_public: MagicMock,
     mock_sleep: MagicMock,  # noqa: ARG001
-    mock_recursive: MagicMock,
+    mock_resolve_groups: MagicMock,
 ) -> None:
     """With treat_sharing_link_as_public=False, the function falls through to
     role-assignment-based permission resolution."""
-    mock_recursive.return_value = GroupsResult(
-        groups_to_emails={"SiteMembers_abc": {"alice@contoso.com"}},
+    mock_resolve_groups.return_value = DocumentGroupsResult(
+        group_ids={"SiteMembers_abc"},
         found_public_group=False,
     )
 

--- a/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
@@ -118,15 +118,17 @@ def test_ad_group_claims_token_and_guid_share_cache(
     mock_get_group: MagicMock,
 ) -> None:
     group_id = "11111111-1111-1111-1111-111111111111"
-    claims_group = _make_ad_group("Engineering", f"c:0t.c|tenant|{group_id}")
-    guid_group = _make_ad_group("Engineering", group_id)
+    claims_group = _make_ad_group("Engineering Members", f"c:0t.c|tenant|{group_id}")
+    guid_group = _make_ad_group("Engineering Owners", group_id)
     mock_get_group.return_value = (set(), set())
     cache = SharepointPermissionCache()
 
-    _resolve_document_groups(MagicMock(), MagicMock(), {claims_group}, cache)
-    _resolve_document_groups(MagicMock(), MagicMock(), {guid_group}, cache)
+    result = _resolve_document_groups(
+        MagicMock(), MagicMock(), {claims_group, guid_group}, cache
+    )
 
     mock_get_group.assert_called_once()
+    assert result.group_ids == {"Engineering Members", "Engineering Owners"}
 
 
 @patch(f"{MODULE}._get_azuread_groups")

--- a/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
@@ -3,6 +3,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from office365.runtime.client_request import ClientRequestException
 
 from ee.onyx.external_permissions.sharepoint.permission_utils import (
     AD_GROUP_ENUMERATION_THRESHOLD,
@@ -97,6 +98,19 @@ def test_sharepoint_group_cache_is_scoped_to_site(
 
     assert mock_get_group.call_count == 2
     assert len(cache.group_expansions) == 2
+
+
+@patch(f"{MODULE}._get_sharepoint_groups")
+def test_sharepoint_group_404_is_not_cached(mock_get_group: MagicMock) -> None:
+    response = MagicMock(status_code=404, headers={}, content=b"")
+    mock_get_group.side_effect = ClientRequestException(response=response)
+    group = _make_sharepoint_group("Missing Group")
+    cache = SharepointPermissionCache()
+
+    with pytest.raises(ClientRequestException):
+        _resolve_document_groups(MagicMock(), MagicMock(), {group}, cache)
+
+    assert cache.group_expansions == {}
 
 
 @patch(f"{MODULE}._get_azuread_groups")

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_delta_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_delta_checkpointing.py
@@ -150,6 +150,7 @@ def _mock_convert(monkeypatch: pytest.MonkeyPatch) -> None:
         access_token: str | None = None,  # noqa: ARG001
         treat_sharing_link_as_public: bool = False,  # noqa: ARG001
         raw_file_callback: Any = None,  # noqa: ARG001
+        permission_cache: Any = None,  # noqa: ARG001
     ) -> Document:
         return _make_document(driveitem)
 

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_drive_matching.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_drive_matching.py
@@ -212,6 +212,7 @@ def test_load_from_checkpoint_maps_drive_name(monkeypatch: pytest.MonkeyPatch) -
         access_token: str | None = None,  # noqa: ARG001
         treat_sharing_link_as_public: bool = False,  # noqa: ARG001
         raw_file_callback: Any = None,  # noqa: ARG001
+        permission_cache: Any = None,  # noqa: ARG001
     ) -> Document:
         captured_drive_names.append(drive_name)
         return Document(

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_hierarchy_helpers.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_hierarchy_helpers.py
@@ -171,7 +171,7 @@ def test_hierarchy_helpers_fetch_permissions_when_requested(
     assert site_node.external_access is access
     assert drive_node.external_access is access
     assert folder_node.external_access is access
-    assert [call.args[2] for call in mock_get_access.call_args_list] == [
+    assert [call.args[3] for call in mock_get_access.call_args_list] == [
         HierarchyNodeType.SITE,
         HierarchyNodeType.DRIVE,
         HierarchyNodeType.FOLDER,

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_load_checkpoint_resilience.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_load_checkpoint_resilience.py
@@ -122,6 +122,7 @@ def _mock_convert(monkeypatch: pytest.MonkeyPatch) -> None:
         access_token: str | None = None,  # noqa: ARG001
         treat_sharing_link_as_public: bool = False,  # noqa: ARG001
         raw_file_callback: Any = None,  # noqa: ARG001
+        permission_cache: Any = None,  # noqa: ARG001
     ) -> Document:
         return _make_document(driveitem)
 
@@ -348,6 +349,7 @@ class TestSitePagesPerPageFailure:
             include_permissions: bool = False,  # noqa: ARG001
             parent_hierarchy_raw_node_id: str | None = None,  # noqa: ARG001
             treat_sharing_link_as_public: bool = False,  # noqa: ARG001
+            permission_cache: Any = None,  # noqa: ARG001
         ) -> Document:
             if page["id"] == "bad-1":
                 raise ValueError("malformed canvasLayout")
@@ -407,6 +409,7 @@ class TestSitePagesPerPageFailure:
             include_permissions: bool = False,  # noqa: ARG001
             parent_hierarchy_raw_node_id: str | None = None,  # noqa: ARG001
             treat_sharing_link_as_public: bool = False,  # noqa: ARG001
+            permission_cache: Any = None,  # noqa: ARG001
         ) -> Document:
             raise KeyError("id")
 

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_slim_and_validation.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_slim_and_validation.py
@@ -8,7 +8,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from onyx.connectors.exceptions import ConnectorValidationError
-from onyx.connectors.sharepoint.connector import SharepointConnector
+from onyx.connectors.models import ExternalAccess
+from onyx.connectors.sharepoint.connector import (
+    SharepointConnector,
+    _convert_sitepage_to_document,
+    _convert_sitepage_to_slim_document,
+)
+from onyx.connectors.sharepoint.connector_utils import SharepointPermissionCache
 
 SITE_URL = "https://tenant.sharepoint.com/sites/MySite"
 
@@ -20,6 +26,46 @@ def _make_connector() -> SharepointConnector:
     connector._credential_json = {"sp_client_id": "x", "sp_directory_id": "y"}
     connector._graph_client = MagicMock()
     return connector
+
+
+@patch("onyx.connectors.sharepoint.connector.get_sharepoint_external_access")
+def test_full_and_slim_site_pages_share_permission_resolution(
+    mock_get_access: MagicMock,
+) -> None:
+    access = ExternalAccess(
+        external_user_emails={"alice@contoso.com"},
+        external_user_group_ids={"engineering"},
+        is_public=False,
+    )
+    mock_get_access.return_value = access
+    permission_cache = SharepointPermissionCache()
+    site_page = {
+        "id": "page-1",
+        "webUrl": f"{SITE_URL}/SitePages/Home.aspx",
+        "title": "Home",
+        "name": "Home.aspx",
+    }
+
+    full_document = _convert_sitepage_to_document(
+        site_page,
+        "MySite",
+        MagicMock(),
+        MagicMock(),
+        permission_cache,
+        include_permissions=True,
+    )
+    slim_document = _convert_sitepage_to_slim_document(
+        site_page,
+        MagicMock(),
+        MagicMock(),
+        permission_cache,
+    )
+
+    assert full_document.external_access == slim_document.external_access == access
+    assert all(
+        call.kwargs["permission_cache"] is permission_cache
+        for call in mock_get_access.call_args_list
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Sharepoint perm-synced connectors initial indexing was fetching and expanding groups on every document, leading to a bunch of extra work. Now we cache group expansions (which are still necessary only for determining whether something is public) across checkpoints.

## How Has This Been Tested?

added tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache SharePoint role group expansions during permission resolution to avoid re-fetching per document. The cache now persists across runs and serializes safely on checkpoints while still detecting public access correctly.

- **Performance**
  - Added `SharepointPermissionCache` to checkpoints and plumbed it through drive items, site pages (full and slim), and hierarchy nodes.
  - Introduced `SharepointGroup` and `SharepointGroupExpansion` in `connector_utils`; unified cache keys for site-scoped SharePoint groups and Azure AD groups (claims token vs GUID).
  - Fixed checkpoint serialization so cached expansions (including nested group sets) survive save/restore.
  - Short-circuits on public groups, resolves cycles, and treats missing Azure AD groups (HTTP 404) as non-fatal without caching them.

<sup>Written for commit 5c4491d2e996b4e0732ae8bb670def9bc4f94bcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

