### PR TITLE
chore(gha): build the desktop app for Windows on presubmit

### DIFF
--- a/.github/workflows/pr-desktop-build.yml
+++ b/.github/workflows/pr-desktop-build.yml
@@ -25,7 +25,10 @@ jobs:
   build-desktop:
     name: Build Desktop (${{ matrix.platform }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    # Windows runners are the slow leg: a cold cache compiles the whole Tauri
+    # dep tree twice (Clippy, then the release build), incl. native aws-lc-sys.
+    # Matches the desktop build timeout in deployment.yml.
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -38,11 +41,10 @@ jobs:
             os: macos-latest
             target: universal-apple-darwin
             args: "--target universal-apple-darwin"
-          # TODO: Fix and enable the Windows build.
-          #- platform: windows
-          #  os: windows-latest
-          #  target: x86_64-pc-windows-msvc
-          #  args: ""
+          - platform: windows
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            args: ""
 
     steps:
       - name: Checkout code
@@ -105,6 +107,20 @@ jobs:
       - name: Run Clippy
         working-directory: ./desktop/src-tauri
         run: cargo clippy --all-targets --all-features -- -D warnings
+
+      # `tauri build` bundles an MSI on Windows, and WiX's ProductVersion only
+      # accepts numeric `major.minor.patch[.build]` -- the checked-in
+      # `0.0.0-dev` fails with "optional pre-release identifier in app version
+      # must be numeric-only ... for msi target". The release workflow injects a
+      # real numeric version at this point; presubmit has none to inject, so
+      # pin a throwaway one to keep MSI bundling exercised on PRs.
+      - name: Pin an MSI-compatible version (Windows)
+        if: matrix.platform == 'windows'
+        shell: bash
+        working-directory: ./desktop/src-tauri
+        run: |
+          jq '.version = "0.0.0"' tauri.conf.json > tauri.conf.json.tmp
+          mv tauri.conf.json.tmp tauri.conf.json
 
       - name: Build desktop app
         working-directory: ./desktop


### PR DESCRIPTION
## Description

Enables the Windows leg of `pr-desktop-build.yml`, which has been commented out with a `TODO` since the workflow landed in #7996.

**The failure was in bundling, not compilation.** `tauri.conf.json` sets `"targets": "all"`, so Windows bundles both an MSI and an NSIS installer. The MSI bundler runs the checked-in version `0.0.0-dev` through `convert_version()` and bails:

> `optional pre-release identifier in app version must be numeric-only and cannot be greater than 65535 for msi target`

`deployment.yml` already works around exactly this — it injects a numeric version before bundling ("Windows MSI requires numeric-only build metadata"), which is why the release pipeline ships `Onyx_x64.msi` / `Onyx_x64.exe` while presubmit never could. This PR does the same thing with a throwaway `0.0.0`, so MSI bundling stays covered on PRs rather than being skipped via `--bundles nsis`. Packaging regressions now surface at presubmit instead of at release time.

Changes:

- Uncomment the `windows-latest` / `x86_64-pc-windows-msvc` matrix entry.
- Add a Windows-only step pinning an MSI-compatible version before the build.
- Bump `timeout-minutes` 60 → 90 to match `deployment.yml`. On a cold cache the Windows leg compiles the Tauri dep tree twice (Clippy, then the release build), including native `aws-lc-sys`.

No changes to `desktop/` source were needed.

## How Has This Been Tested?

CI on this PR is the real test of the bundling step. Before pushing, the Rust side was validated locally by cross-compiling to the actual Windows target (`cargo-xwin` + `clang-cl`/`lld-link`):

- `cargo clippy --target x86_64-pc-windows-msvc --all-targets --all-features -- -D warnings` → passes. This was the main open risk: the `#[cfg(target_os = "windows")]` blocks in `alt_menu.rs`, `commands.rs`, `window.rs` and `main.rs` have never been linted, since `deployment.yml` doesn't run Clippy.
- `cargo xwin build --target x86_64-pc-windows-msvc` → links a real `onyx.exe` (`MZ` PE), so `tauri-build`'s Windows resource/icon embedding and the `windows-rs`/`webview2-com` link path are fine.
- `cargo fmt --check` passes.
- `pre-commit run --files .github/workflows/pr-desktop-build.yml` → zizmor, actionlint and the YAML check all pass.
- Confirmed `jq` (1.8.1) and Git Bash ship on the Windows runner image, so the new step's dependencies hold.

MSI/NSIS bundling itself can't be exercised off a Windows host, so that is what this PR's own CI run verifies.

Two related things left out of scope:

- `desktop/README.md`'s `bun run build:windows` local cross-compile hits this same version error, and MSI can't be cross-bundled from Linux/macOS regardless — it would need `--bundles nsis` plus a numeric version.
- Only the x64 leg is enabled here (what the `TODO` had commented out). `deployment.yml` also builds Windows ARM64; adding it would double Windows CI cost on every desktop PR.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Windows desktop builds on presubmit and fix MSI bundling by pinning a numeric version, so packaging issues surface before release. Also bumps the Windows job timeout to match deployment.

- **Bug Fixes**
  - Re-enable Windows in `pr-desktop-build.yml` with `windows-latest` / `x86_64-pc-windows-msvc`.
  - On Windows, set `desktop/src-tauri/tauri.conf.json` version to `0.0.0` before `tauri build` to satisfy MSI’s numeric-only version requirement.
  - Increase job timeout from 60 to 90 minutes.

<sup>Written for commit 899d7db415f1c9efa50c92d1a5d4239a2835eaeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

