### PR TITLE
test(craft): drive lazy webapp provisioning in the craft integration suites

### DIFF
--- a/backend/tests/integration/tests/craft/docker_e2e/conftest.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/conftest.py
@@ -15,8 +15,18 @@ from onyx.db.external_app import (
     create_external_app,
     get_built_in_external_app,
 )
+from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
+    SANDBOX_EXEC_USER,
+)
 from tests.integration.common_utils.managers.build_session import BuildSessionManager
 from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.craft.webapp_preview import (
+    WEBAPP_BOOTSTRAP_TIMEOUT_S,
+    WEBAPP_INSTALLED,
+    webapp_bootstrap_command,
+    webapp_install_check_command,
+    webapp_logs_command,
+)
 
 
 class DockerSandbox(NamedTuple):
@@ -107,6 +117,53 @@ def _provision_sandbox(
         session_id=UUID(session.id),
         container_name=_container_name(sandbox.id),
     )
+
+
+def start_session_webapp(container: str, session_id: UUID) -> str:
+    """Run the lazy webapp bootstrap in-container, standing in for the agent's
+    `webapp` tool, and return the script's output.
+
+    Blocks until the scaffold and install finish (the script's own readiness
+    wait can still lapse, so callers that need a live dev server must poll for
+    it). Fails the test unless the install landed — docker exec does not raise
+    on a nonzero exit, so the in-container state is the only trustworthy
+    signal.
+    """
+    try:
+        result = _docker_exec(
+            container,
+            ["sh", "-c", webapp_bootstrap_command(session_id)],
+            timeout=WEBAPP_BOOTSTRAP_TIMEOUT_S,
+            user=SANDBOX_EXEC_USER,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail(
+            f"start-webapp.sh did not finish within "
+            f"{WEBAPP_BOOTSTRAP_TIMEOUT_S}s for session {session_id}:\n"
+            f"{session_webapp_logs(container, session_id)}"
+        )
+    output = f"{result.stdout}{result.stderr}"
+    state = _docker_exec(
+        container,
+        ["sh", "-c", webapp_install_check_command(session_id)],
+        user=SANDBOX_EXEC_USER,
+    ).stdout.strip()
+    if state != WEBAPP_INSTALLED:
+        pytest.fail(
+            f"start-webapp.sh did not install outputs/web for session "
+            f"{session_id} (state={state}, exit={result.returncode}):\n{output}"
+        )
+    return output
+
+
+def session_webapp_logs(container: str, session_id: UUID) -> str:
+    """Bootstrap + dev-server logs for a session, for failure diagnostics."""
+    result = _docker_exec(
+        container,
+        ["sh", "-c", webapp_logs_command(session_id)],
+        user=SANDBOX_EXEC_USER,
+    )
+    return f"{result.stdout}{result.stderr}"
 
 
 @pytest.fixture(scope="session")

--- a/backend/tests/integration/tests/craft/docker_e2e/conftest.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/conftest.py
@@ -130,11 +130,9 @@ def start_session_webapp(container: str, session_id: UUID) -> str:
     """Run the lazy webapp bootstrap in-container, standing in for the agent's
     `webapp` tool, and return the script's output.
 
-    Fails the test unless the bootstrap installed and started within the
-    budget the agent's `webapp` tool allows. Runs with the sandbox user's HOME
-    as well as its uid: the container itself runs as root under the egress
-    proxy, so a bare ``--user 1000:1000`` would leave HOME=/root and have the
-    agent's real privilege context diverge from the tested one.
+    Carries the sandbox user's HOME as well as its uid: under the egress proxy
+    the container runs as root, so a bare ``--user 1000:1000`` would leave
+    HOME=/root and diverge from the agent's real privilege context.
     """
     started_at = time.monotonic()
     try:
@@ -169,7 +167,6 @@ def start_session_webapp(container: str, session_id: UUID) -> str:
 
 
 def session_webapp_logs(container: str, session_id: UUID) -> str:
-    """Bootstrap + dev-server logs for a session, for failure diagnostics."""
     result = _docker_exec(
         container,
         ["sh", "-c", webapp_logs_command(session_id)],

--- a/backend/tests/integration/tests/craft/docker_e2e/conftest.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import time
 from typing import NamedTuple, Protocol
 from uuid import UUID
 
@@ -16,13 +17,15 @@ from onyx.db.external_app import (
     get_built_in_external_app,
 )
 from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
+    SANDBOX_EXEC_ENV,
     SANDBOX_EXEC_USER,
 )
 from tests.integration.common_utils.managers.build_session import BuildSessionManager
 from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.tests.craft.webapp_preview import (
     WEBAPP_BOOTSTRAP_TIMEOUT_S,
-    WEBAPP_INSTALLED,
+    truncate_output,
+    verify_webapp_bootstrap,
     webapp_bootstrap_command,
     webapp_install_check_command,
     webapp_logs_command,
@@ -42,6 +45,7 @@ class DockerExec(Protocol):
         *,
         timeout: float = 30.0,
         user: str | None = None,
+        env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]: ...
 
 
@@ -79,10 +83,13 @@ def _docker_exec(
     *,
     timeout: float = 30.0,
     user: str | None = None,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     command = ["docker", "exec"]
     if user is not None:
         command.extend(["--user", user])
+    for key, value in (env or {}).items():
+        command.extend(["-e", f"{key}={value}"])
     command.extend([container, *cmd])
     return subprocess.run(
         command,
@@ -123,18 +130,20 @@ def start_session_webapp(container: str, session_id: UUID) -> str:
     """Run the lazy webapp bootstrap in-container, standing in for the agent's
     `webapp` tool, and return the script's output.
 
-    Blocks until the scaffold and install finish (the script's own readiness
-    wait can still lapse, so callers that need a live dev server must poll for
-    it). Fails the test unless the install landed — docker exec does not raise
-    on a nonzero exit, so the in-container state is the only trustworthy
-    signal.
+    Fails the test unless the bootstrap installed and started within the
+    budget the agent's `webapp` tool allows. Runs with the sandbox user's HOME
+    as well as its uid: the container itself runs as root under the egress
+    proxy, so a bare ``--user 1000:1000`` would leave HOME=/root and have the
+    agent's real privilege context diverge from the tested one.
     """
+    started_at = time.monotonic()
     try:
         result = _docker_exec(
             container,
             ["sh", "-c", webapp_bootstrap_command(session_id)],
             timeout=WEBAPP_BOOTSTRAP_TIMEOUT_S,
             user=SANDBOX_EXEC_USER,
+            env=SANDBOX_EXEC_ENV,
         )
     except subprocess.TimeoutExpired:
         pytest.fail(
@@ -142,17 +151,20 @@ def start_session_webapp(container: str, session_id: UUID) -> str:
             f"{WEBAPP_BOOTSTRAP_TIMEOUT_S}s for session {session_id}:\n"
             f"{session_webapp_logs(container, session_id)}"
         )
+    elapsed_s = time.monotonic() - started_at
     output = f"{result.stdout}{result.stderr}"
-    state = _docker_exec(
+    install_state = _docker_exec(
         container,
         ["sh", "-c", webapp_install_check_command(session_id)],
         user=SANDBOX_EXEC_USER,
+        env=SANDBOX_EXEC_ENV,
     ).stdout.strip()
-    if state != WEBAPP_INSTALLED:
-        pytest.fail(
-            f"start-webapp.sh did not install outputs/web for session "
-            f"{session_id} (state={state}, exit={result.returncode}):\n{output}"
-        )
+    verify_webapp_bootstrap(
+        session_id,
+        output=output,
+        install_state=install_state,
+        elapsed_s=elapsed_s,
+    )
     return output
 
 
@@ -162,8 +174,9 @@ def session_webapp_logs(container: str, session_id: UUID) -> str:
         container,
         ["sh", "-c", webapp_logs_command(session_id)],
         user=SANDBOX_EXEC_USER,
+        env=SANDBOX_EXEC_ENV,
     )
-    return f"{result.stdout}{result.stderr}"
+    return truncate_output(f"{result.stdout}{result.stderr}")
 
 
 @pytest.fixture(scope="session")

--- a/backend/tests/integration/tests/craft/docker_e2e/test_webapp_preview_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_webapp_preview_docker.py
@@ -1,11 +1,11 @@
 """Webapp preview against a real Next dev server on the docker backend.
 
-Docker counterpart of ``k8s/test_webapp_preview.py``: pins that
-``DockerSandboxManager`` launches the shared Next.js start script at session
-setup and that the resulting dev server serves the basePath route through the
-proxy. A docker-only divergence from the shared start script (or a broken
-basePath contract) fails here and nowhere else — the k8s suite only covers
-the kubernetes manager's invocation.
+Docker counterpart of ``k8s/test_webapp_preview.py``: drives the shared
+``start-webapp.sh`` the way the agent's `webapp` tool does, then pins that the
+resulting dev server serves the basePath route through the proxy. A
+docker-only divergence from the shared start script (or a broken basePath
+contract) fails here and nowhere else — the k8s suite only covers the
+kubernetes manager's side.
 """
 
 from __future__ import annotations
@@ -20,6 +20,8 @@ from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.tests.craft.docker_e2e.conftest import (
     ProvisionSandbox,
     remove_container,
+    session_webapp_logs,
+    start_session_webapp,
 )
 from tests.integration.tests.craft.webapp_preview import (
     proxy_get,
@@ -30,8 +32,6 @@ pytestmark = pytest.mark.skipif(
     SANDBOX_BACKEND != SandboxBackend.DOCKER,
     reason="Docker integration tests require SANDBOX_BACKEND=docker.",
 )
-
-_WEBAPP_READY_TIMEOUT_S = 180.0
 
 
 @pytest.fixture
@@ -47,8 +47,18 @@ def test_preview_serves_at_base_path_and_reports_ready(
     sandbox = provision_sandbox(webapp_user, headless=False)
     try:
         session_id = str(sandbox.session_id)
+        # Provisioning writes start-webapp.sh but scaffolds nothing; the agent
+        # would run it via the `webapp` tool, so the test does it instead.
+        bootstrap_output = start_session_webapp(
+            sandbox.container_name, sandbox.session_id
+        )
         wait_for_webapp_ready(
-            webapp_user, session_id, timeout_s=_WEBAPP_READY_TIMEOUT_S
+            webapp_user,
+            session_id,
+            diagnostics=lambda: (
+                f"--- start-webapp.sh ---\n{bootstrap_output}\n"
+                + session_webapp_logs(sandbox.container_name, sandbox.session_id)
+            ),
         )
 
         resp = proxy_get(webapp_user, session_id)

--- a/backend/tests/integration/tests/craft/docker_e2e/test_webapp_preview_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_webapp_preview_docker.py
@@ -47,8 +47,6 @@ def test_preview_serves_at_base_path_and_reports_ready(
     sandbox = provision_sandbox(webapp_user, headless=False)
     try:
         session_id = str(sandbox.session_id)
-        # Provisioning writes start-webapp.sh but scaffolds nothing; the agent
-        # would run it via the `webapp` tool, so the test does it instead.
         bootstrap_output = start_session_webapp(
             sandbox.container_name, sandbox.session_id
         )

--- a/backend/tests/integration/tests/craft/docker_e2e/test_workspace_setup_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_workspace_setup_docker.py
@@ -24,6 +24,7 @@ from tests.integration.tests.craft.docker_e2e.conftest import (
     DockerExec,
     DockerSandbox,
     ProvisionSandbox,
+    remove_container,
 )
 
 pytestmark = pytest.mark.skipif(
@@ -65,8 +66,9 @@ def test_session_setup_creates_user_writable_workspace(
         "/workspace/managed/skills",
         "/workspace/managed/user_library",
         session_path,
+        # outputs/web is not a setup-time invariant: webapp provisioning is
+        # lazy, so the scaffold only lands once start-webapp.sh runs.
         f"{session_path}/outputs",
-        f"{session_path}/outputs/web",
         f"{session_path}/attachments",
         f"{session_path}/.opencode",
     ]
@@ -111,11 +113,11 @@ def test_session_setup_creates_user_writable_workspace(
                 'printf ok > "/workspace/managed/.write-check"\n'
                 f'printf ok > "{session_path}/.write-check"\n'
                 f'printf ok > "{session_path}/attachments/.write-check"\n'
-                f'printf ok > "{session_path}/outputs/web/.write-check"\n'
+                f'printf ok > "{session_path}/outputs/.write-check"\n'
                 'rm -f "/workspace/managed/.write-check"\n'
                 f'rm -f "{session_path}/.write-check"\n'
                 f'rm -f "{session_path}/attachments/.write-check"\n'
-                f'rm -f "{session_path}/outputs/web/.write-check"\n'
+                f'rm -f "{session_path}/outputs/.write-check"\n'
             ),
         ],
         user=SANDBOX_EXEC_USER,
@@ -177,3 +179,47 @@ def test_session_setup_creates_user_writable_workspace(
     )
     post_delete_names = {entry.name for entry in post_delete_listing.entries}
     assert upload_name not in post_delete_names
+
+
+def test_session_setup_writes_tamper_hardened_webapp_script(
+    workspace_user: DATestUser,
+    provision_sandbox: ProvisionSandbox,
+    docker_exec: DockerExec,
+) -> None:
+    """A session with a preview port gets start-webapp.sh and nothing else.
+
+    Webapp provisioning is lazy, so this script is all that setup leaves behind
+    for the agent to run; it is chmod 444 so the agent can't rewrite it.
+    """
+    sandbox = provision_sandbox(workspace_user, headless=False)
+    try:
+        script_path = f"/workspace/sessions/{sandbox.session_id}/start-webapp.sh"
+        stat_result = docker_exec(
+            sandbox.container_name,
+            ["sh", "-c", f'stat -c "%u:%g %a" "{script_path}"'],
+            user=SANDBOX_EXEC_USER,
+        )
+        assert stat_result.returncode == 0, (
+            "Expected start-webapp.sh after provisioning a session with a port. "
+            f"stdout={stat_result.stdout!r} stderr={stat_result.stderr!r}"
+        )
+        assert stat_result.stdout.strip() == f"{SANDBOX_EXEC_USER} 444", (
+            f"start-webapp.sh must be sandbox-user-owned and read-only: "
+            f"{stat_result.stdout!r}"
+        )
+
+        scaffolded = docker_exec(
+            sandbox.container_name,
+            [
+                "sh",
+                "-c",
+                f'test -e "/workspace/sessions/{sandbox.session_id}/outputs/web" '
+                "&& echo PRESENT || echo ABSENT",
+            ],
+            user=SANDBOX_EXEC_USER,
+        ).stdout.strip()
+        assert scaffolded == "ABSENT", (
+            "Setup must not scaffold outputs/web; provisioning is lazy."
+        )
+    finally:
+        remove_container(sandbox.container_name)

--- a/backend/tests/integration/tests/craft/docker_e2e/test_workspace_setup_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_workspace_setup_docker.py
@@ -67,8 +67,6 @@ def test_session_setup_creates_user_writable_workspace(
         "/workspace/managed/skills",
         "/workspace/managed/user_library",
         session_path,
-        # outputs/web is not a setup-time invariant: webapp provisioning is
-        # lazy, so the scaffold only lands once start-webapp.sh runs.
         f"{session_path}/outputs",
         f"{session_path}/attachments",
         f"{session_path}/.opencode",

--- a/backend/tests/integration/tests/craft/docker_e2e/test_workspace_setup_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_workspace_setup_docker.py
@@ -26,6 +26,7 @@ from tests.integration.tests.craft.docker_e2e.conftest import (
     ProvisionSandbox,
     remove_container,
 )
+from tests.integration.tests.craft.webapp_preview import webapp_script_stat_command
 
 pytestmark = pytest.mark.skipif(
     SANDBOX_BACKEND != SandboxBackend.DOCKER,
@@ -181,22 +182,23 @@ def test_session_setup_creates_user_writable_workspace(
     assert upload_name not in post_delete_names
 
 
-def test_session_setup_writes_tamper_hardened_webapp_script(
+def test_session_setup_writes_read_only_webapp_script(
     workspace_user: DATestUser,
     provision_sandbox: ProvisionSandbox,
     docker_exec: DockerExec,
 ) -> None:
     """A session with a preview port gets start-webapp.sh and nothing else.
 
-    Webapp provisioning is lazy, so this script is all that setup leaves behind
-    for the agent to run; it is chmod 444 so the agent can't rewrite it.
+    Webapp provisioning is lazy, so this script is all that setup leaves
+    behind for the agent to run. Mode 444 makes a stray redirect into the
+    script fail loudly; it is not a boundary against the agent, which owns
+    both the file and its directory.
     """
     sandbox = provision_sandbox(workspace_user, headless=False)
     try:
-        script_path = f"/workspace/sessions/{sandbox.session_id}/start-webapp.sh"
         stat_result = docker_exec(
             sandbox.container_name,
-            ["sh", "-c", f'stat -c "%u:%g %a" "{script_path}"'],
+            ["sh", "-c", webapp_script_stat_command(sandbox.session_id)],
             user=SANDBOX_EXEC_USER,
         )
         assert stat_result.returncode == 0, (

--- a/backend/tests/integration/tests/craft/k8s/k8s_fixtures.py
+++ b/backend/tests/integration/tests/craft/k8s/k8s_fixtures.py
@@ -38,6 +38,13 @@ from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from tests.integration.common_utils.managers.build_session import BuildSessionManager
 from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.tests.craft.webapp_preview import (
+    WEBAPP_BOOTSTRAP_TIMEOUT_S,
+    WEBAPP_INSTALLED,
+    webapp_bootstrap_command,
+    webapp_install_check_command,
+    webapp_logs_command,
+)
 
 logger = setup_logger()
 
@@ -468,10 +475,14 @@ def _cleanup_pool_workspace(
         "-mindepth 1 -delete 2>/dev/null; true",
         container="sidecar",
     )
+    # Dev servers are nohup'd, so deleting the tree alone leaves them running
+    # with a vanished cwd; on the module-scoped pool pod they accumulate until
+    # something OOMs and fails an unrelated test.
     pod_exec(
         k8s_client,
         pod_name,
         SANDBOX_NAMESPACE,
+        "pkill -f 'bun run dev'; pkill -f next-server; "
         "find /workspace/sessions -mindepth 1 -delete 2>/dev/null; true",
         container="sandbox",
     )
@@ -611,15 +622,20 @@ def pod_exec(
     namespace: str,
     command: str,
     container: str = "sandbox",
+    timeout_s: float | None = None,
 ) -> str:
     """Run a one-shot ``/bin/sh -c`` command in a pod container; return combined output.
 
     Pass ``container="sidecar"`` to write to ``/workspace/managed/`` (RO in the
-    sandbox container).
+    sandbox container). ``timeout_s`` bounds a long command so a wedged one
+    fails inside pytest instead of burning the whole CI job; note the exec
+    client returns buffered output on a lapse rather than raising, so callers
+    must verify the command's effect rather than trust the return.
     """
     from kubernetes.stream import stream as k8s_stream
 
     argv = ["/bin/sh", "-c", command]
+    optional_kwargs = {} if timeout_s is None else {"_request_timeout": timeout_s}
     resp = k8s_stream(
         client.connect_get_namespaced_pod_exec,
         name=pod_name,
@@ -630,6 +646,7 @@ def pod_exec(
         stdin=False,
         stdout=True,
         tty=False,
+        **optional_kwargs,
     )
     return str(resp) if resp is not None else ""
 
@@ -831,9 +848,14 @@ def pool_session(
     Same shape as ``live_pod`` but reuses the pool pod. Use this unless the test
     mutates pod-level state (lifecycle/terminate/restart); those must use ``live_pod``.
     Sessions are headless (no dev server) by default; parametrize indirectly
-    with ``{"headless": False}`` for webapp/preview tests.
+    with ``{"headless": False}`` for webapp/preview tests, or use
+    ``webapp_pool_session`` to also get the webapp bootstrapped.
     """
     headless = getattr(request, "param", {}).get("headless", True)
+    return _create_pool_session(_pool_pod, headless=headless)
+
+
+def _create_pool_session(_pool_pod: _PoolPod, *, headless: bool) -> PoolSession:
     _cleanup_pool_workspace(_pool_pod.k8s_client, _pool_pod.pod_name)
     session_id, sandbox_id = BuildSessionManager.create_with_sandbox(
         _pool_pod.api_user, headless=headless
@@ -853,6 +875,67 @@ def pool_session(
         session_id=session_id,
         pod_name=_pool_pod.pod_name,
     )
+
+
+def start_session_webapp(
+    k8s_client: "k8s_client_module.CoreV1Api",
+    pod_name: str,
+    session_id: UUID,
+) -> str:
+    """Run the lazy webapp bootstrap in-pod, standing in for the agent's
+    `webapp` tool, and return the script's output.
+
+    Blocks until the scaffold and install finish (the script's own readiness
+    wait can still lapse, so callers that need a live dev server must poll for
+    it). Fails the test unless the install landed — the exec returns buffered
+    output without raising on a nonzero exit or a lapsed timeout, so the
+    in-pod state is the only trustworthy signal.
+    """
+    output = pod_exec(
+        k8s_client,
+        pod_name,
+        SANDBOX_NAMESPACE,
+        webapp_bootstrap_command(session_id),
+        timeout_s=WEBAPP_BOOTSTRAP_TIMEOUT_S,
+    )
+    state = pod_exec(
+        k8s_client,
+        pod_name,
+        SANDBOX_NAMESPACE,
+        webapp_install_check_command(session_id),
+    ).strip()
+    if state != WEBAPP_INSTALLED:
+        pytest.fail(
+            f"start-webapp.sh did not install outputs/web for session "
+            f"{session_id} (state={state}):\n{output}"
+        )
+    return output
+
+
+def session_webapp_logs(
+    k8s_client: "k8s_client_module.CoreV1Api",
+    pod_name: str,
+    session_id: UUID,
+) -> str:
+    """Bootstrap + dev-server logs for a session, for failure diagnostics."""
+    return pod_exec(
+        k8s_client,
+        pod_name,
+        SANDBOX_NAMESPACE,
+        webapp_logs_command(session_id),
+    )
+
+
+@pytest.fixture(scope="function")
+def webapp_pool_session(_pool_pod: _PoolPod) -> PoolSession:
+    """``pool_session`` with a port reserved and the webapp bootstrapped.
+
+    For tests that need a scaffolded, installed ``outputs/web`` — provisioning
+    no longer produces one.
+    """
+    session = _create_pool_session(_pool_pod, headless=False)
+    start_session_webapp(_pool_pod.k8s_client, session.pod_name, session.session_id)
+    return session
 
 
 @pytest.fixture(scope="function")

--- a/backend/tests/integration/tests/craft/k8s/k8s_fixtures.py
+++ b/backend/tests/integration/tests/craft/k8s/k8s_fixtures.py
@@ -482,7 +482,9 @@ def _cleanup_pool_workspace(
         k8s_client,
         pod_name,
         SANDBOX_NAMESPACE,
-        "pkill -f 'bun run dev'; pkill -f next-server; "
+        # Bracketed so the patterns don't match this cleanup shell's own
+        # cmdline, which would kill it before the find runs.
+        "pkill -f 'bun run de[v]'; pkill -f 'next-serve[r]'; "
         "find /workspace/sessions -mindepth 1 -delete 2>/dev/null; true",
         container="sandbox",
     )

--- a/backend/tests/integration/tests/craft/k8s/k8s_fixtures.py
+++ b/backend/tests/integration/tests/craft/k8s/k8s_fixtures.py
@@ -33,6 +33,7 @@ from onyx.server.features.build.db.user_library import delete_user_file, list_us
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
     KubernetesSandboxManager,
 )
+from onyx.server.features.build.sandbox.session_workspace import SESSIONS_ROOT
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
@@ -475,9 +476,8 @@ def _cleanup_pool_workspace(
         "-mindepth 1 -delete 2>/dev/null; true",
         container="sidecar",
     )
-    # Dev servers are nohup'd, so deleting the tree alone leaves them running
-    # with a vanished cwd; on the module-scoped pool pod they accumulate until
-    # something OOMs and fails an unrelated test.
+    # Dev servers are nohup'd: without the kill they survive the delete and
+    # accumulate on the module-scoped pool pod until something OOMs.
     pod_exec(
         k8s_client,
         pod_name,
@@ -629,10 +629,8 @@ def pod_exec(
     """Run a one-shot ``/bin/sh -c`` command in a pod container; return combined output.
 
     Pass ``container="sidecar"`` to write to ``/workspace/managed/`` (RO in the
-    sandbox container). ``timeout_s`` bounds a long command so a wedged one
-    fails inside pytest instead of burning the whole CI job; note the exec
-    client returns buffered output on a lapse rather than raising, so callers
-    must verify the command's effect rather than trust the return.
+    sandbox container). A lapsed ``timeout_s`` returns buffered output rather
+    than raising, so callers must verify the command's effect.
     """
     from kubernetes.stream import stream as k8s_stream
 
@@ -886,11 +884,6 @@ def start_session_webapp(
 ) -> str:
     """Run the lazy webapp bootstrap in-pod, standing in for the agent's
     `webapp` tool, and return the script's output.
-
-    Fails the test unless the bootstrap installed and started within the
-    budget the agent's `webapp` tool allows — the exec returns buffered output
-    without raising on a nonzero exit or a lapsed timeout, so what the script
-    printed and what it left behind are the only trustworthy signals.
     """
     started_at = time.monotonic()
     output = pod_exec(
@@ -921,7 +914,6 @@ def session_webapp_logs(
     pod_name: str,
     session_id: UUID,
 ) -> str:
-    """Bootstrap + dev-server logs for a session, for failure diagnostics."""
     return pod_exec(
         k8s_client,
         pod_name,
@@ -930,15 +922,42 @@ def session_webapp_logs(
     )
 
 
+def stop_session_webapp(
+    k8s_client: "k8s_client_module.CoreV1Api",
+    pod_name: str,
+    session_id: UUID,
+) -> None:
+    """Stop a session's dev server and wait for it to actually exit.
+
+    A live Turbopack keeps writing into the session tree, so a workspace
+    delete races it and leaves the directory behind — which then makes a
+    restore skip its reinstall, since the stale ``package.json`` is still
+    there.
+    """
+    session_path = f"{SESSIONS_ROOT}/{session_id}"
+    pod_exec(
+        k8s_client,
+        pod_name,
+        SANDBOX_NAMESPACE,
+        f"if [ -f {session_path}/nextjs.pid ]; then "
+        f"  pid=$(cat {session_path}/nextjs.pid); "
+        f"  kill $pid 2>/dev/null; "
+        f"  for _ in $(seq 1 20); do kill -0 $pid 2>/dev/null || break; sleep 1; done; "
+        f"  kill -9 $pid 2>/dev/null; "
+        f"fi; true",
+    )
+
+
 @pytest.fixture(scope="function")
 def webapp_pool_session(_pool_pod: _PoolPod) -> PoolSession:
-    """``pool_session`` with a port reserved and the webapp bootstrapped.
+    """``pool_session`` with an installed ``outputs/web`` and no dev server.
 
-    For tests that need a scaffolded, installed ``outputs/web`` — provisioning
-    no longer produces one.
+    Its consumers measure install state; leaving the server up would have it
+    writing into the tree while they snapshot, delete, and restore it.
     """
     session = _create_pool_session(_pool_pod, headless=False)
     start_session_webapp(_pool_pod.k8s_client, session.pod_name, session.session_id)
+    stop_session_webapp(_pool_pod.k8s_client, session.pod_name, session.session_id)
     return session
 
 

--- a/backend/tests/integration/tests/craft/k8s/k8s_fixtures.py
+++ b/backend/tests/integration/tests/craft/k8s/k8s_fixtures.py
@@ -40,7 +40,7 @@ from tests.integration.common_utils.managers.build_session import BuildSessionMa
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.tests.craft.webapp_preview import (
     WEBAPP_BOOTSTRAP_TIMEOUT_S,
-    WEBAPP_INSTALLED,
+    verify_webapp_bootstrap,
     webapp_bootstrap_command,
     webapp_install_check_command,
     webapp_logs_command,
@@ -885,12 +885,12 @@ def start_session_webapp(
     """Run the lazy webapp bootstrap in-pod, standing in for the agent's
     `webapp` tool, and return the script's output.
 
-    Blocks until the scaffold and install finish (the script's own readiness
-    wait can still lapse, so callers that need a live dev server must poll for
-    it). Fails the test unless the install landed — the exec returns buffered
-    output without raising on a nonzero exit or a lapsed timeout, so the
-    in-pod state is the only trustworthy signal.
+    Fails the test unless the bootstrap installed and started within the
+    budget the agent's `webapp` tool allows — the exec returns buffered output
+    without raising on a nonzero exit or a lapsed timeout, so what the script
+    printed and what it left behind are the only trustworthy signals.
     """
+    started_at = time.monotonic()
     output = pod_exec(
         k8s_client,
         pod_name,
@@ -898,17 +898,19 @@ def start_session_webapp(
         webapp_bootstrap_command(session_id),
         timeout_s=WEBAPP_BOOTSTRAP_TIMEOUT_S,
     )
-    state = pod_exec(
+    elapsed_s = time.monotonic() - started_at
+    install_state = pod_exec(
         k8s_client,
         pod_name,
         SANDBOX_NAMESPACE,
         webapp_install_check_command(session_id),
     ).strip()
-    if state != WEBAPP_INSTALLED:
-        pytest.fail(
-            f"start-webapp.sh did not install outputs/web for session "
-            f"{session_id} (state={state}):\n{output}"
-        )
+    verify_webapp_bootstrap(
+        session_id,
+        output=output,
+        install_state=install_state,
+        elapsed_s=elapsed_s,
+    )
     return output
 
 

--- a/backend/tests/integration/tests/craft/k8s/test_bun_node_modules_dedup.py
+++ b/backend/tests/integration/tests/craft/k8s/test_bun_node_modules_dedup.py
@@ -64,11 +64,8 @@ def _setup_session(
     sandbox_id: UUID,
     session_id: UUID,
 ) -> None:
-    """Set up a session workspace and bootstrap its webapp.
-
-    A port is required: without one setup writes no ``start-webapp.sh``, and
-    nothing else installs ``outputs/web/node_modules`` for dedup to observe.
-    """
+    """A port is required: without one setup writes no ``start-webapp.sh``,
+    and nothing else installs the ``node_modules`` dedup measures."""
     manager.setup_session_workspace(
         sandbox_id=sandbox_id,
         session_id=session_id,
@@ -81,9 +78,8 @@ def _setup_session(
 
 
 def _du_bytes(k8s_client: client.CoreV1Api, pod_name: str, path: str) -> int:
-    # .next is dev-server build output, not install state; bootstrapping a
-    # session boots a dev server, so counting it would fail this budget for a
-    # reason that has nothing to do with hardlink dedup.
+    # .next is dev-server build output, not install state; counting it would
+    # fail this budget for a reason unrelated to hardlink dedup.
     raw = pod_exec(
         k8s_client,
         pod_name,
@@ -100,11 +96,8 @@ def _wait_for_file(
     *,
     timeout_s: float = 180.0,
 ) -> None:
-    """Poll for a file the restore path installs in the background.
-
-    Restore returns as soon as its sentinel prints; the reinstall it kicks off
-    is nohup'd, so a single stat would race a multi-second bun install.
-    """
+    """Restore returns as soon as its sentinel prints and the reinstall it
+    kicks off is nohup'd, so a single stat would race a bun install."""
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
         found = pod_exec(
@@ -255,8 +248,7 @@ def test_restored_session_hardlinks_to_cache(
     assert "MISSING" in gone
 
     # Also the only live coverage of the restore script's autostart branch,
-    # which fires exactly because this fixture's session has a real
-    # outputs/web/package.json to snapshot.
+    # which fires only because this fixture's session really installed.
     BuildSessionManager.restore(pool_api_user, session_id)
 
     _wait_for_file(
@@ -306,7 +298,6 @@ def test_agent_added_package_survives_snapshot_restore(
     assert snapshot is not None
     k8s_manager.cleanup_session_workspace(sandbox_id, session_id)
     BuildSessionManager.restore(pool_api_user, session_id)
-    # Rebuilt from bun.lock by the restore script's backgrounded install.
     _wait_for_file(
         k8s_client, pod_name, f"{session_web}/node_modules/lodash/package.json"
     )

--- a/backend/tests/integration/tests/craft/k8s/test_bun_node_modules_dedup.py
+++ b/backend/tests/integration/tests/craft/k8s/test_bun_node_modules_dedup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import time
 from collections.abc import Generator
 from contextlib import suppress
 from typing import NamedTuple
@@ -90,6 +91,32 @@ def _du_bytes(k8s_client: client.CoreV1Api, pod_name: str, path: str) -> int:
         f"du -sb --exclude=.next {path} | awk '{{print $1}}'",
     )
     return int(raw.strip())
+
+
+def _wait_for_file(
+    k8s_client: client.CoreV1Api,
+    pod_name: str,
+    path: str,
+    *,
+    timeout_s: float = 180.0,
+) -> None:
+    """Poll for a file the restore path installs in the background.
+
+    Restore returns as soon as its sentinel prints; the reinstall it kicks off
+    is nohup'd, so a single stat would race a multi-second bun install.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        found = pod_exec(
+            k8s_client,
+            pod_name,
+            SANDBOX_NAMESPACE,
+            f"test -f {path} && echo YES || echo NO",
+        ).strip()
+        if found == "YES":
+            return
+        time.sleep(5.0)
+    pytest.fail(f"{path} never appeared within {timeout_s:.0f}s of restore")
 
 
 def _inode(k8s_client: client.CoreV1Api, pod_name: str, path: str) -> str:
@@ -227,16 +254,16 @@ def test_restored_session_hardlinks_to_cache(
     )
     assert "MISSING" in gone
 
+    # Also the only live coverage of the restore script's autostart branch,
+    # which fires exactly because this fixture's session has a real
+    # outputs/web/package.json to snapshot.
     BuildSessionManager.restore(pool_api_user, session_id)
 
-    have_next = pod_exec(
+    _wait_for_file(
         k8s_client,
         pod_name,
-        SANDBOX_NAMESPACE,
-        f"test -f /workspace/sessions/{session_id}/outputs/web/node_modules/next/package.json "
-        f"&& echo YES || echo NO",
-    ).strip()
-    assert have_next == "YES", "restored session must have node_modules rebuilt"
+        f"/workspace/sessions/{session_id}/outputs/web/node_modules/next/package.json",
+    )
 
     # Link count >= 2 means the file is hardlinked to the bun cache.
     nlink = pod_exec(
@@ -279,14 +306,10 @@ def test_agent_added_package_survives_snapshot_restore(
     assert snapshot is not None
     k8s_manager.cleanup_session_workspace(sandbox_id, session_id)
     BuildSessionManager.restore(pool_api_user, session_id)
-    have_lodash = pod_exec(
-        k8s_client,
-        pod_name,
-        SANDBOX_NAMESPACE,
-        f"test -f {session_web}/node_modules/lodash/package.json "
-        f"&& echo YES || echo NO",
-    ).strip()
-    assert have_lodash == "YES", "lodash should be rebuilt after restore via bun.lock"
+    # Rebuilt from bun.lock by the restore script's backgrounded install.
+    _wait_for_file(
+        k8s_client, pod_name, f"{session_web}/node_modules/lodash/package.json"
+    )
 
 
 def test_agent_install_in_one_session_does_not_break_other(

--- a/backend/tests/integration/tests/craft/k8s/test_bun_node_modules_dedup.py
+++ b/backend/tests/integration/tests/craft/k8s/test_bun_node_modules_dedup.py
@@ -28,6 +28,7 @@ from tests.integration.tests.craft.k8s.k8s_fixtures import (
     PoolSession,
     cleanup_api_user_sandbox_rows,
     pod_exec,
+    start_session_webapp,
     wait_for_pod_deletion,
 )
 
@@ -52,29 +53,41 @@ _MAX_WORKSPACE_BYTES_WITH_TWO_SESSIONS = 1_200 * 1024 * 1024
 # Snapshot without node_modules is a few MB; with it, ~150 MB.
 _MAX_SNAPSHOT_BYTES = 5 * 1024 * 1024
 
+# Outside the API's [3010, 3100) reservation range, so the hand-made second
+# session can't collide with the API-created one on the same pod.
+_SECOND_SESSION_NEXTJS_PORT = 3999
+
 
 def _setup_session(
     manager: KubernetesSandboxManager,
     sandbox_id: UUID,
     session_id: UUID,
 ) -> None:
+    """Set up a session workspace and bootstrap its webapp.
+
+    A port is required: without one setup writes no ``start-webapp.sh``, and
+    nothing else installs ``outputs/web/node_modules`` for dedup to observe.
+    """
     manager.setup_session_workspace(
         sandbox_id=sandbox_id,
         session_id=session_id,
         llm_config=default_llm_config(
             api_key=os.environ.get("OPENAI_API_KEY", "test-key"),
         ),
-        nextjs_port=None,
+        nextjs_port=_SECOND_SESSION_NEXTJS_PORT,
         connectable_apps_section="",
     )
 
 
 def _du_bytes(k8s_client: client.CoreV1Api, pod_name: str, path: str) -> int:
+    # .next is dev-server build output, not install state; bootstrapping a
+    # session boots a dev server, so counting it would fail this budget for a
+    # reason that has nothing to do with hardlink dedup.
     raw = pod_exec(
         k8s_client,
         pod_name,
         SANDBOX_NAMESPACE,
-        f"du -sb {path} | awk '{{print $1}}'",
+        f"du -sb --exclude=.next {path} | awk '{{print $1}}'",
     )
     return int(raw.strip())
 
@@ -96,11 +109,15 @@ def two_session_pod(
 ) -> Generator[TwoSessionPod, None, None]:
     """Sandbox + two bun-installed sessions: ``(sandbox_id, session_a, session_b, pod_name)``."""
     api_user = UserManager.create(name=f"craft-k8s-{uuid4().hex[:8]}")
-    session_a, sandbox_id = BuildSessionManager.create_with_sandbox(api_user)
+    session_a, sandbox_id = BuildSessionManager.create_with_sandbox(
+        api_user, headless=False
+    )
     pod_name = k8s_manager._get_pod_name(sandbox_id)
     session_b = uuid4()
     try:
+        start_session_webapp(k8s_client, pod_name, session_a)
         _setup_session(k8s_manager, sandbox_id, session_b)
+        start_session_webapp(k8s_client, pod_name, session_b)
         yield TwoSessionPod(
             sandbox_id=sandbox_id,
             session_a=session_a,
@@ -117,11 +134,11 @@ def two_session_pod(
 
 def test_bun_cache_lives_on_workspace_volume(
     k8s_client: client.CoreV1Api,
-    pool_session: PoolSession,
+    webapp_pool_session: PoolSession,
 ) -> None:
     # Cross-mount hardlinks fall back to copies, so the cache must share a mount
     # with the session dirs.
-    _, _, pod_name = pool_session
+    _, _, pod_name = webapp_pool_session
     cache_mount = pod_exec(
         k8s_client,
         pod_name,
@@ -178,10 +195,10 @@ def test_two_sessions_stay_under_dedup_budget(
 
 
 def test_snapshot_excludes_node_modules(
-    pool_session: PoolSession,
+    webapp_pool_session: PoolSession,
     pool_api_user: DATestUser,
 ) -> None:
-    _sandbox_id, session_id, _ = pool_session
+    _sandbox_id, session_id, _ = webapp_pool_session
     snapshot = BuildSessionManager.create_snapshot(pool_api_user, session_id)
     assert snapshot is not None, "snapshot should succeed for populated session"
     assert snapshot.size_bytes < _MAX_SNAPSHOT_BYTES, (
@@ -194,10 +211,10 @@ def test_snapshot_excludes_node_modules(
 def test_restored_session_hardlinks_to_cache(
     k8s_manager: KubernetesSandboxManager,
     k8s_client: client.CoreV1Api,
-    pool_session: PoolSession,
+    webapp_pool_session: PoolSession,
     pool_api_user: DATestUser,
 ) -> None:
-    sandbox_id, session_id, pod_name = pool_session
+    sandbox_id, session_id, pod_name = webapp_pool_session
     snapshot = BuildSessionManager.create_snapshot(pool_api_user, session_id)
     assert snapshot is not None
 
@@ -238,10 +255,10 @@ def test_restored_session_hardlinks_to_cache(
 def test_agent_added_package_survives_snapshot_restore(
     k8s_manager: KubernetesSandboxManager,
     k8s_client: client.CoreV1Api,
-    pool_session: PoolSession,
+    webapp_pool_session: PoolSession,
     pool_api_user: DATestUser,
 ) -> None:
-    sandbox_id, session_id, pod_name = pool_session
+    sandbox_id, session_id, pod_name = webapp_pool_session
     session_web = f"/workspace/sessions/{session_id}/outputs/web"
 
     pod_exec(

--- a/backend/tests/integration/tests/craft/k8s/test_kubernetes_sandbox_file_ops.py
+++ b/backend/tests/integration/tests/craft/k8s/test_kubernetes_sandbox_file_ops.py
@@ -154,7 +154,6 @@ class TestCreateSnapshot:
     ) -> None:
         _sandbox_id, session_id, pod_name = pool_session
 
-        # Wipe snapshot-eligible trees so the session is truly empty.
         session_root = f"/workspace/sessions/{session_id}"
         pod_exec(
             k8s_client,

--- a/backend/tests/integration/tests/craft/k8s/test_kubernetes_sandbox_file_ops.py
+++ b/backend/tests/integration/tests/craft/k8s/test_kubernetes_sandbox_file_ops.py
@@ -154,8 +154,7 @@ class TestCreateSnapshot:
     ) -> None:
         _sandbox_id, session_id, pod_name = pool_session
 
-        # Wipe snapshot-eligible trees so the session is truly empty (setup
-        # scaffolds outputs/web/).
+        # Wipe snapshot-eligible trees so the session is truly empty.
         session_root = f"/workspace/sessions/{session_id}"
         pod_exec(
             k8s_client,

--- a/backend/tests/integration/tests/craft/k8s/test_webapp_preview.py
+++ b/backend/tests/integration/tests/craft/k8s/test_webapp_preview.py
@@ -7,10 +7,15 @@ cannot see: the dev-resource origin gate and basePath serving.
 from __future__ import annotations
 
 import pytest
+from kubernetes import client
 
 from onyx.server.features.build.configs import SANDBOX_BACKEND, SandboxBackend
 from tests.integration.common_utils.test_models import DATestUser
-from tests.integration.tests.craft.k8s.k8s_fixtures import PoolSession
+from tests.integration.tests.craft.k8s.k8s_fixtures import (
+    PoolSession,
+    session_webapp_logs,
+    start_session_webapp,
+)
 from tests.integration.tests.craft.webapp_preview import (
     proxy_get,
     wait_for_webapp_ready,
@@ -29,33 +34,54 @@ pytestmark = [
     ),
 ]
 
-_WEBAPP_READY_TIMEOUT_S = 120.0
+
+@pytest.fixture
+def ready_webapp_session(
+    pool_session: PoolSession,
+    pool_api_user: DATestUser,
+    k8s_client: client.CoreV1Api,
+) -> PoolSession:
+    """A pool session whose dev server is up and serving.
+
+    Provisioning writes start-webapp.sh but scaffolds nothing, so the fixture
+    runs it the way the agent's `webapp` tool would.
+    """
+    bootstrap_output = start_session_webapp(
+        k8s_client, pool_session.pod_name, pool_session.session_id
+    )
+    wait_for_webapp_ready(
+        pool_api_user,
+        str(pool_session.session_id),
+        diagnostics=lambda: (
+            f"--- start-webapp.sh ---\n{bootstrap_output}\n"
+            + session_webapp_logs(
+                k8s_client, pool_session.pod_name, pool_session.session_id
+            )
+        ),
+    )
+    return pool_session
 
 
 def test_preview_serves_at_base_path_and_reports_ready(
-    pool_session: PoolSession,
+    ready_webapp_session: PoolSession,
     pool_api_user: DATestUser,
 ) -> None:
     """``ready`` flips true and the route users actually load returns 200."""
-    session_id = str(pool_session.session_id)
-    wait_for_webapp_ready(pool_api_user, session_id, timeout_s=_WEBAPP_READY_TIMEOUT_S)
-
-    resp = proxy_get(pool_api_user, session_id)
+    resp = proxy_get(pool_api_user, str(ready_webapp_session.session_id))
     assert resp.status_code == 200, resp.text[:500]
 
 
 def test_dev_resources_not_blocked_by_origin_gate(
-    pool_session: PoolSession,
+    ready_webapp_session: PoolSession,
     pool_api_user: DATestUser,
 ) -> None:
     """A browser-shaped dev-resource request must not hit Next's cross-origin
     403 (``blockCrossSiteDEV`` rejects /_next/* when the Origin hostname is
     not allowlisted — the exact failure from the 2026-07-06 incident)."""
-    session_id = str(pool_session.session_id)
-    wait_for_webapp_ready(pool_api_user, session_id, timeout_s=_WEBAPP_READY_TIMEOUT_S)
-
     resp = proxy_get(
-        pool_api_user, session_id, "_next/static/onyx-origin-gate-probe.js"
+        pool_api_user,
+        str(ready_webapp_session.session_id),
+        "_next/static/onyx-origin-gate-probe.js",
     )
     # 404 for a nonexistent asset is fine; the gate rejects before routing,
     # so a 403 means Origin/sec-fetch-* leaked through the proxy or the

--- a/backend/tests/integration/tests/craft/k8s/test_webapp_preview.py
+++ b/backend/tests/integration/tests/craft/k8s/test_webapp_preview.py
@@ -9,16 +9,22 @@ from __future__ import annotations
 import pytest
 from kubernetes import client
 
-from onyx.server.features.build.configs import SANDBOX_BACKEND, SandboxBackend
+from onyx.server.features.build.configs import (
+    SANDBOX_BACKEND,
+    SANDBOX_NAMESPACE,
+    SandboxBackend,
+)
 from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.tests.craft.k8s.k8s_fixtures import (
     PoolSession,
+    pod_exec,
     session_webapp_logs,
     start_session_webapp,
 )
 from tests.integration.tests.craft.webapp_preview import (
     proxy_get,
     wait_for_webapp_ready,
+    webapp_script_stat_command,
 )
 
 pytestmark = [
@@ -60,6 +66,25 @@ def ready_webapp_session(
         ),
     )
     return pool_session
+
+
+def test_setup_writes_read_only_webapp_script(
+    pool_session: PoolSession,
+    k8s_client: client.CoreV1Api,
+) -> None:
+    """Setup's only webapp artifact, written through the k8s exec path.
+
+    The docker suite pins the same bytes; both matter because the two managers
+    write the script separately. Mode 444 is what keeps a stray redirect from
+    clobbering the one file opencode's deny rules treat as fixed.
+    """
+    stat_line = pod_exec(
+        k8s_client,
+        pool_session.pod_name,
+        SANDBOX_NAMESPACE,
+        webapp_script_stat_command(pool_session.session_id),
+    ).strip()
+    assert stat_line == "1000:1000 444", stat_line
 
 
 def test_preview_serves_at_base_path_and_reports_ready(

--- a/backend/tests/integration/tests/craft/webapp_preview.py
+++ b/backend/tests/integration/tests/craft/webapp_preview.py
@@ -3,24 +3,78 @@
 The proxy contracts these pin (Origin/Sec-Fetch header stripping, basePath
 serving) must hold identically on every sandbox backend, so the k8s and
 docker suites assert them through this single implementation.
+
+Webapp provisioning is lazy: session setup only writes ``start-webapp.sh``,
+and nothing scaffolds ``outputs/web`` or starts a dev server until the agent's
+`webapp` tool runs it. Tests stand in for the agent by running that script
+themselves — see each backend's ``start_session_webapp``.
 """
 
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
+from uuid import UUID
 
 import httpx
 import pytest
 
+from onyx.server.features.build.sandbox.nextjs_dev import WEBAPP_PACKAGE_JSON_PATH
+from onyx.server.features.build.sandbox.session_workspace import SESSIONS_ROOT
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.test_models import DATestUser
 
 _POLL_INTERVAL_S = 2.0
 
+# Cold path: template copy, bun-cache bootstrap, install, then a Next dev boot.
+# All of it used to happen during provisioning, outside the test's own clock.
+WEBAPP_BOOTSTRAP_TIMEOUT_S = 420.0
+WEBAPP_READY_TIMEOUT_S = 300.0
+
+
+def webapp_bootstrap_command(session_id: UUID | str) -> str:
+    """In-sandbox command that lazily scaffolds and starts the webapp."""
+    return f"bash {SESSIONS_ROOT}/{session_id}/start-webapp.sh"
+
+
+def webapp_logs_command(session_id: UUID | str, *, lines: int = 40) -> str:
+    """In-sandbox command dumping both webapp logs, for failure diagnostics."""
+    session_path = f"{SESSIONS_ROOT}/{session_id}"
+    return (
+        f"for log in {session_path}/webapp-bootstrap.log {session_path}/nextjs.log; do "
+        f'echo "--- $log ---"; tail -n {lines} "$log" 2>&1 || true; '
+        f"done"
+    )
+
+
+WEBAPP_INSTALLED = "INSTALLED"
+
+
+def webapp_install_check_command(session_id: UUID | str) -> str:
+    """In-sandbox command echoing how far webapp provisioning actually got.
+
+    The scaffold alone is not enough to distinguish success: the template copy
+    writes ``package.json`` before the bun install runs, and neither backend's
+    exec raises on a nonzero exit or a lapsed timeout. Checking the install
+    marker is what makes a failed install loud instead of green.
+    """
+    session_path = f"{SESSIONS_ROOT}/{session_id}"
+    web_path = f"{session_path}/outputs/web"
+    return (
+        f"if [ -f {web_path}/node_modules/next/package.json ]; "
+        f"then echo {WEBAPP_INSTALLED}; "
+        f"elif [ -f {session_path}/{WEBAPP_PACKAGE_JSON_PATH} ]; "
+        f"then echo SCAFFOLD_ONLY; else echo MISSING; fi"
+    )
+
 
 def wait_for_webapp_ready(
-    user: DATestUser, session_id: str, *, timeout_s: float
+    user: DATestUser,
+    session_id: str,
+    *,
+    timeout_s: float = WEBAPP_READY_TIMEOUT_S,
+    diagnostics: Callable[[], str] | None = None,
 ) -> None:
     deadline = time.monotonic() + timeout_s
     info: dict[str, object] = {}
@@ -35,7 +89,8 @@ def wait_for_webapp_ready(
         if info.get("has_webapp") and info.get("ready"):
             return
         time.sleep(_POLL_INTERVAL_S)
-    pytest.fail(f"webapp never became ready within timeout: {info}")
+    detail = f"\n{diagnostics()}" if diagnostics is not None else ""
+    pytest.fail(f"webapp never became ready within timeout: {info}{detail}")
 
 
 def proxy_get(user: DATestUser, session_id: str, path: str = "") -> httpx.Response:

--- a/backend/tests/integration/tests/craft/webapp_preview.py
+++ b/backend/tests/integration/tests/craft/webapp_preview.py
@@ -29,16 +29,45 @@ _POLL_INTERVAL_S = 2.0
 
 # Cold path: template copy, bun-cache bootstrap, install, then a Next dev boot.
 # All of it used to happen during provisioning, outside the test's own clock.
+# This is only the hard exec cap, so a wedged bootstrap fails with diagnostics
+# instead of hanging; the budget the bootstrap must actually meet is below.
 WEBAPP_BOOTSTRAP_TIMEOUT_S = 420.0
 WEBAPP_READY_TIMEOUT_S = 300.0
 
+# What the agent's `webapp` tool allows before it kills the bootstrap
+# (START_TIMEOUT_MS in image/opencode-plugins/webapp.ts). Tests run the script
+# directly, so without asserting this a cold path that creeps past it stays
+# green here while being broken for every agent.
+WEBAPP_TOOL_START_BUDGET_S = 150.0
 
-def webapp_bootstrap_command(session_id: UUID | str) -> str:
+# Last line the bootstrap prints on success. It is the only signal either
+# backend gets: neither exec surfaces the script's nonzero exit, so a dev
+# server that failed to boot is otherwise indistinguishable from one that did.
+WEBAPP_STARTED_SENTINEL = "dev server running on port"
+
+# Bootstrap output is unbounded (a full bun install); cap what a failure
+# message carries.
+_MAX_DIAGNOSTIC_CHARS = 4000
+
+
+def truncate_output(output: str) -> str:
+    """Last chunk of command output, for failure messages."""
+    if len(output) <= _MAX_DIAGNOSTIC_CHARS:
+        return output
+    return f"...(truncated)\n{output[-_MAX_DIAGNOSTIC_CHARS:]}"
+
+
+def webapp_bootstrap_command(session_id: UUID) -> str:
     """In-sandbox command that lazily scaffolds and starts the webapp."""
     return f"bash {SESSIONS_ROOT}/{session_id}/start-webapp.sh"
 
 
-def webapp_logs_command(session_id: UUID | str, *, lines: int = 40) -> str:
+def webapp_script_stat_command(session_id: UUID) -> str:
+    """In-sandbox command printing ``<uid>:<gid> <mode>`` for the bootstrap script."""
+    return f'stat -c "%u:%g %a" {SESSIONS_ROOT}/{session_id}/start-webapp.sh'
+
+
+def webapp_logs_command(session_id: UUID, *, lines: int = 40) -> str:
     """In-sandbox command dumping both webapp logs, for failure diagnostics."""
     session_path = f"{SESSIONS_ROOT}/{session_id}"
     return (
@@ -51,7 +80,7 @@ def webapp_logs_command(session_id: UUID | str, *, lines: int = 40) -> str:
 WEBAPP_INSTALLED = "INSTALLED"
 
 
-def webapp_install_check_command(session_id: UUID | str) -> str:
+def webapp_install_check_command(session_id: UUID) -> str:
     """In-sandbox command echoing how far webapp provisioning actually got.
 
     The scaffold alone is not enough to distinguish success: the template copy
@@ -67,6 +96,40 @@ def webapp_install_check_command(session_id: UUID | str) -> str:
         f"elif [ -f {session_path}/{WEBAPP_PACKAGE_JSON_PATH} ]; "
         f"then echo SCAFFOLD_ONLY; else echo MISSING; fi"
     )
+
+
+def verify_webapp_bootstrap(
+    session_id: UUID,
+    *,
+    output: str,
+    install_state: str,
+    elapsed_s: float,
+) -> None:
+    """Fail unless the bootstrap installed, started, and did so in budget.
+
+    Shared by both backends because neither exec raises on the script's own
+    failure paths, so the test has to judge success from what the script
+    printed and what it left behind.
+    """
+    tail = truncate_output(output)
+    if install_state != WEBAPP_INSTALLED:
+        pytest.fail(
+            f"start-webapp.sh did not install outputs/web for session "
+            f"{session_id} (state={install_state}):\n{tail}"
+        )
+    if WEBAPP_STARTED_SENTINEL not in output:
+        pytest.fail(
+            f"start-webapp.sh installed but never started a dev server for "
+            f"session {session_id}:\n{tail}"
+        )
+    if elapsed_s > WEBAPP_TOOL_START_BUDGET_S:
+        pytest.fail(
+            f"start-webapp.sh took {elapsed_s:.0f}s for session {session_id}, "
+            f"over the {WEBAPP_TOOL_START_BUDGET_S:.0f}s the `webapp` tool "
+            f"allows before it kills the bootstrap (START_TIMEOUT_MS in "
+            f"image/opencode-plugins/webapp.ts). The agent's path is broken "
+            f"even though the script eventually finished."
+        )
 
 
 def wait_for_webapp_ready(

--- a/backend/tests/integration/tests/craft/webapp_preview.py
+++ b/backend/tests/integration/tests/craft/webapp_preview.py
@@ -4,10 +4,8 @@ The proxy contracts these pin (Origin/Sec-Fetch header stripping, basePath
 serving) must hold identically on every sandbox backend, so the k8s and
 docker suites assert them through this single implementation.
 
-Webapp provisioning is lazy: session setup only writes ``start-webapp.sh``,
-and nothing scaffolds ``outputs/web`` or starts a dev server until the agent's
-`webapp` tool runs it. Tests stand in for the agent by running that script
-themselves — see each backend's ``start_session_webapp``.
+Provisioning is lazy — setup only writes ``start-webapp.sh`` — so tests stand
+in for the agent and run it themselves via ``start_session_webapp``.
 """
 
 from __future__ import annotations
@@ -27,48 +25,37 @@ from tests.integration.common_utils.test_models import DATestUser
 
 _POLL_INTERVAL_S = 2.0
 
-# Cold path: template copy, bun-cache bootstrap, install, then a Next dev boot.
-# All of it used to happen during provisioning, outside the test's own clock.
-# This is only the hard exec cap, so a wedged bootstrap fails with diagnostics
-# instead of hanging; the budget the bootstrap must actually meet is below.
+# Hard exec cap only, so a wedged bootstrap fails with diagnostics rather than
+# hanging; the budget it must actually meet is WEBAPP_TOOL_START_BUDGET_S.
 WEBAPP_BOOTSTRAP_TIMEOUT_S = 420.0
 WEBAPP_READY_TIMEOUT_S = 300.0
 
 # What the agent's `webapp` tool allows before it kills the bootstrap
-# (START_TIMEOUT_MS in image/opencode-plugins/webapp.ts). Tests run the script
-# directly, so without asserting this a cold path that creeps past it stays
-# green here while being broken for every agent.
+# (START_TIMEOUT_MS in image/opencode-plugins/webapp.ts).
 WEBAPP_TOOL_START_BUDGET_S = 150.0
 
-# Last line the bootstrap prints on success. It is the only signal either
-# backend gets: neither exec surfaces the script's nonzero exit, so a dev
-# server that failed to boot is otherwise indistinguishable from one that did.
+# Neither backend's exec surfaces the script's nonzero exit, so this line is
+# the only signal that the dev server actually came up.
 WEBAPP_STARTED_SENTINEL = "dev server running on port"
 
-# Bootstrap output is unbounded (a full bun install); cap what a failure
-# message carries.
 _MAX_DIAGNOSTIC_CHARS = 4000
 
 
 def truncate_output(output: str) -> str:
-    """Last chunk of command output, for failure messages."""
     if len(output) <= _MAX_DIAGNOSTIC_CHARS:
         return output
     return f"...(truncated)\n{output[-_MAX_DIAGNOSTIC_CHARS:]}"
 
 
 def webapp_bootstrap_command(session_id: UUID) -> str:
-    """In-sandbox command that lazily scaffolds and starts the webapp."""
     return f"bash {SESSIONS_ROOT}/{session_id}/start-webapp.sh"
 
 
 def webapp_script_stat_command(session_id: UUID) -> str:
-    """In-sandbox command printing ``<uid>:<gid> <mode>`` for the bootstrap script."""
     return f'stat -c "%u:%g %a" {SESSIONS_ROOT}/{session_id}/start-webapp.sh'
 
 
 def webapp_logs_command(session_id: UUID, *, lines: int = 40) -> str:
-    """In-sandbox command dumping both webapp logs, for failure diagnostics."""
     session_path = f"{SESSIONS_ROOT}/{session_id}"
     return (
         f"for log in {session_path}/webapp-bootstrap.log {session_path}/nextjs.log; do "
@@ -81,12 +68,11 @@ WEBAPP_INSTALLED = "INSTALLED"
 
 
 def webapp_install_check_command(session_id: UUID) -> str:
-    """In-sandbox command echoing how far webapp provisioning actually got.
+    """Echoes how far provisioning got.
 
-    The scaffold alone is not enough to distinguish success: the template copy
-    writes ``package.json`` before the bun install runs, and neither backend's
-    exec raises on a nonzero exit or a lapsed timeout. Checking the install
-    marker is what makes a failed install loud instead of green.
+    Keys on the install marker, not the scaffold: the template copy writes
+    ``package.json`` before the bun install runs, so a scaffold check would
+    read a failed install as success.
     """
     session_path = f"{SESSIONS_ROOT}/{session_id}"
     web_path = f"{session_path}/outputs/web"
@@ -107,9 +93,8 @@ def verify_webapp_bootstrap(
 ) -> None:
     """Fail unless the bootstrap installed, started, and did so in budget.
 
-    Shared by both backends because neither exec raises on the script's own
-    failure paths, so the test has to judge success from what the script
-    printed and what it left behind.
+    Neither backend's exec raises on the script's own failure paths, so
+    success has to be judged from what it printed and what it left behind.
     """
     tail = truncate_output(output)
     if install_state != WEBAPP_INSTALLED:


### PR DESCRIPTION
## Description

Four craft CI shards have been red on `main` since #13712 landed: `craft-k8s (webapp_preview)`, `craft-k8s (bun_node_modules_dedup)`, `craft-compose (webapp_preview_docker)` and `craft-compose (workspace_setup_docker)`. They only run on PRs that touch craft paths, so unrelated merges have been passing over them.

The cause is stale tests, not a product bug. #13711/#13712/#13713 made webapp provisioning lazy: session setup no longer copies the `outputs/web` template, installs deps, or starts a dev server. It writes a `chmod 444` `start-webapp.sh`, and nothing runs until the agent calls the `webapp` tool. `get_webapp_info` is a pure read, so tests that provision a session and poll `webapp-info` waited forever on `has_webapp: False`, and the dedup tests looked for a `node_modules` and a bun cache that no longer existed.

The tests now stand in for the agent and run `start-webapp.sh` themselves:

- `craft/webapp_preview.py` gains the shared in-sandbox command builders and a `diagnostics` hook on `wait_for_webapp_ready`, so a timeout prints the bootstrap output and the tail of `nextjs.log` instead of just the info dict.
- `k8s/k8s_fixtures.py` gains `start_session_webapp` / `session_webapp_logs` and a `webapp_pool_session` fixture (non-headless pool session, bootstrapped). `pod_exec` takes an optional timeout so a wedged install fails inside pytest rather than at the 40-minute job timeout, and pool-workspace cleanup now reaps orphaned dev servers before deleting their cwd.
- `docker_e2e/conftest.py` gains the docker-exec twins, running as `SANDBOX_EXEC_USER` so the bootstrap leaves no root-owned files.
- `k8s/test_bun_node_modules_dedup.py`: sessions are created with a preview port (without one, setup writes no `start-webapp.sh` and nothing ever installs). The workspace budget excludes `.next`, which is dev-server build output rather than install state.
- `docker_e2e/test_workspace_setup_docker.py`: `outputs/web` is no longer a setup-time invariant, so it comes out of the required-paths and write-check lists. A new test pins what setup does produce: `start-webapp.sh` owned by the sandbox user at mode 444, with `outputs/web` absent.

The install check deliberately asserts `outputs/web/node_modules/next/package.json`, not `package.json`. The template copy writes `package.json` before the install runs, and neither exec path raises on a nonzero exit, so checking the scaffold alone would go green on a failed install and make the dedup budget and snapshot-size assertions pass trivially.

## How Has This Been Tested?

`pre-commit` (ty, ruff, ruff format) passes and all touched files collect under pytest. The tests themselves need a live kind cluster or the craft compose stack, so real verification is this PR's craft CI shards — the four that are currently red are exactly the ones this touches.

Known minor items for the reviewer:

- The dedup shard now boots ~10 dev servers where it previously booted none (the installs themselves are unchanged in count). Its green baseline was ~9-10 min against a 40-minute timeout, so there is headroom, but it will get slower. Making `two_session_pod` module-scoped would remove 4 of them; not done here because one of its tests runs `bun add lodash` into session A and another asserts session B is untouched, so a shared fixture would leak state between them.
- The k8s side has no direct equivalent of the new docker assertion that setup writes `start-webapp.sh` at mode 444. It is covered indirectly: `start_session_webapp` fails loudly if the script is missing or the install never lands.
- `webapp_logs_command` also tails `webapp-bootstrap.log`, which only the restore path writes; on the test-driven path that half of the dump is a `tail: cannot open`. The bootstrap output is passed into the diagnostics separately, so nothing is actually lost.

Separately worth a look: #13712 merged with its own craft merge-queue runs already red (`31208190868`, `31208190914`). Whatever allowed that will allow the next one.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check