### PR TITLE
fix(pruning): stop the heavy-worker memory ramp from inline connector enumeration

### DIFF
--- a/backend/onyx/background/celery/celery_utils.py
+++ b/backend/onyx/background/celery/celery_utils.py
@@ -1,3 +1,4 @@
+import gc
 import time
 from collections.abc import Generator, Iterator, Sequence
 from datetime import datetime, timezone
@@ -39,10 +40,14 @@ from onyx.server.metrics.pruning_metrics import (
     observe_pruning_enumeration_duration,
 )
 from onyx.utils.logger import setup_logger
+from onyx.utils.native_memory import release_freed_native_memory
 
 logger = setup_logger()
 
 CT = TypeVar("CT", bound=ConnectorCheckpoint)
+
+# how often the enumeration loop releases freed memory back to the OS
+_MEMORY_RELEASE_INTERVAL = 30  # seconds
 
 
 class SlimConnectorExtractionResult(BaseModel):
@@ -209,6 +214,7 @@ def extract_ids_from_runnable_connector(
 
     # process raw batches to extract both IDs and hierarchy nodes
     enumeration_start = time.monotonic()
+    last_memory_release = time.monotonic()
     try:
         for doc_list in raw_batch_generator:
             if callback and callback.should_stop():
@@ -226,6 +232,13 @@ def extract_ids_from_runnable_connector(
 
             if callback:
                 callback.progress("extract_ids_from_runnable_connector", len(batch_ids))
+
+            # long enumerations ratchet the worker's RSS via glibc retention
+            # of freed crawl allocations — periodically return them to the OS
+            if time.monotonic() - last_memory_release >= _MEMORY_RELEASE_INTERVAL:
+                gc.collect()
+                release_freed_native_memory()
+                last_memory_release = time.monotonic()
     except Exception as e:
         # Best-effort rate limit detection via string matching.
         # Connectors surface rate limits inconsistently — some raise HTTP 429,

--- a/backend/onyx/background/celery/celery_utils.py
+++ b/backend/onyx/background/celery/celery_utils.py
@@ -35,10 +35,6 @@ from onyx.file_store.staging import (
 )
 from onyx.httpx.httpx_pool import HttpxPool
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
-from onyx.server.metrics.pruning_metrics import (
-    inc_pruning_rate_limit_error,
-    observe_pruning_enumeration_duration,
-)
 from onyx.utils.logger import setup_logger
 from onyx.utils.native_memory import release_freed_native_memory
 
@@ -212,8 +208,10 @@ def extract_ids_from_runnable_connector(
         else lambda x: x
     )
 
-    # process raw batches to extract both IDs and hierarchy nodes
-    enumeration_start = time.monotonic()
+    # process raw batches to extract both IDs and hierarchy nodes.
+    # NOTE: Prometheus metrics (enumeration duration, rate limit errors) are
+    # emitted by the pruning parent task — this function runs in a spawned
+    # child whose metric registry is never scraped.
     last_memory_release = time.monotonic()
     try:
         for doc_list in raw_batch_generator:
@@ -239,24 +237,10 @@ def extract_ids_from_runnable_connector(
                 gc.collect()
                 release_freed_native_memory()
                 last_memory_release = time.monotonic()
-    except Exception as e:
-        # Best-effort rate limit detection via string matching.
-        # Connectors surface rate limits inconsistently — some raise HTTP 429,
-        # some use SDK-specific exceptions (e.g. google.api_core.exceptions.ResourceExhausted)
-        # that may or may not include "rate limit" or "429" in the message.
-        # TODO(Bo): replace with a standard ConnectorRateLimitError exception that all
-        # connectors raise when rate limited, making this check precise.
-        error_str = str(e)
-        if "rate limit" in error_str.lower() or "429" in error_str:
-            inc_pruning_rate_limit_error(connector_type)
-        raise
     finally:
         delete_files_best_effort(
             staged_csv_ids,
             context=f"pruning-id-enumeration cleanup ({connector_type})",
-        )
-        observe_pruning_enumeration_duration(
-            time.monotonic() - enumeration_start, connector_type
         )
 
     return SlimConnectorExtractionResult(

--- a/backend/onyx/background/celery/celery_utils.py
+++ b/backend/onyx/background/celery/celery_utils.py
@@ -209,9 +209,8 @@ def extract_ids_from_runnable_connector(
     )
 
     # process raw batches to extract both IDs and hierarchy nodes.
-    # NOTE: Prometheus metrics (enumeration duration, rate limit errors) are
-    # emitted by the pruning parent task — this function runs in a spawned
-    # child whose metric registry is never scraped.
+    # metrics are emitted by the pruning parent task — this runs in a spawned
+    # child whose Prometheus registry is never scraped.
     last_memory_release = time.monotonic()
     try:
         for doc_list in raw_batch_generator:
@@ -231,8 +230,8 @@ def extract_ids_from_runnable_connector(
             if callback:
                 callback.progress("extract_ids_from_runnable_connector", len(batch_ids))
 
-            # long enumerations ratchet the worker's RSS via glibc retention
-            # of freed crawl allocations — periodically return them to the OS
+            # long enumerations ratchet RSS via allocator retention of freed
+            # crawl allocations — periodically return them to the OS
             if time.monotonic() - last_memory_release >= _MEMORY_RELEASE_INTERVAL:
                 gc.collect()
                 release_freed_native_memory()

--- a/backend/onyx/background/celery/tasks/pruning/enumeration_spawn.py
+++ b/backend/onyx/background/celery/tasks/pruning/enumeration_spawn.py
@@ -1,0 +1,226 @@
+"""Run pruning's connector enumeration in a spawned child process.
+
+Multi-hour enumerations ratchet the long-lived heavy worker's RSS until the
+pod OOMs; running them in an ephemeral child (mirroring docfetching's
+`SimpleJobClient` pattern) lets the OS reclaim everything at child exit.
+The celery task acts as the watchdog (owns the redis lock/fence, kills the
+child on stop or timeout); the child returns its result through a JSON file,
+schema-validated on read (an mp queue can deadlock on multi-MB payloads).
+Prometheus metrics are emitted by the parent — the child's registry is never
+scraped.
+"""
+
+import os
+import tempfile
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+from onyx.background.celery.celery_utils import (
+    SlimConnectorExtractionResult,
+    extract_ids_from_runnable_connector,
+)
+from onyx.background.indexing.job_client import SimpleJob, SimpleJobClient
+from onyx.configs.app_configs import JOB_TIMEOUT
+from onyx.connectors.factory import instantiate_connector
+from onyx.connectors.models import InputType
+from onyx.db.connector_credential_pair import get_connector_credential_pair
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
+from onyx.redis.redis_connector import RedisConnector
+from onyx.utils.logger import pruning_ctx, setup_logger
+from onyx.utils.os_reaper import reap_exited_children
+from shared_configs.configs import SENTRY_CELERY_TRACES_SAMPLE_RATE, SENTRY_DSN
+
+logger = setup_logger()
+
+# how long the watchdog waits on the child between liveness checks
+_WATCHDOG_POLL_SECONDS = 5
+
+# how often the watchdog reacquires the pruning redis lock
+_LOCK_REACQUIRE_INTERVAL_SECONDS = 60
+
+# grace period for the child to exit after SIGTERM before SIGKILL
+_TERMINATE_GRACE_SECONDS = 10
+
+
+class PruneEnumerationError(RuntimeError):
+    """Raised when the spawned enumeration child fails, is stopped, or times out."""
+
+
+class SpawnedPruneCallback(IndexingHeartbeatInterface):
+    """Child-side heartbeat: liveness, stop fence, and orphan reaping.
+
+    The parent watchdog owns the redis lock and enforces the timeout by
+    killing this process. A raise out of the enumeration (stop fence, crawl
+    error) means no result file is written — a partial enumeration can never
+    be mistaken for a complete one.
+    """
+
+    def __init__(self, redis_connector: RedisConnector):
+        super().__init__()
+        self.redis_connector = redis_connector
+
+    def should_stop(self) -> bool:
+        return bool(self.redis_connector.stop.fenced)
+
+    def progress(self, tag: str, amount: int) -> None:  # noqa: ARG002
+        self.redis_connector.prune.set_active()
+        reap_exited_children()
+
+
+def pruning_enumeration_task(
+    result_path: str,
+    cc_pair_id: int,
+    connector_id: int,
+    credential_id: int,
+    tenant_id: str,
+) -> None:
+    """Entrypoint of the spawned enumeration child process.
+
+    Instantiates the connector from the DB, enumerates all document IDs and
+    hierarchy nodes, and writes the pickled `SlimConnectorExtractionResult`
+    to `result_path` (atomically, via rename). Exits 0 on success.
+    """
+    # Spawned via SimpleJobClient, so init Sentry ourselves (mirrors
+    # _docfetching_task).
+    if SENTRY_DSN:
+        from onyx.configs.sentry import init_sentry
+
+        init_sentry(traces_sample_rate=SENTRY_CELERY_TRACES_SAMPLE_RATE)
+
+    pruning_ctx_dict = pruning_ctx.get()
+    pruning_ctx_dict["cc_pair_id"] = cc_pair_id
+    pruning_ctx.set(pruning_ctx_dict)
+
+    logger.info(
+        "Pruning enumeration child starting: tenant=%s cc_pair=%s",
+        tenant_id,
+        cc_pair_id,
+    )
+
+    redis_connector = RedisConnector(tenant_id, cc_pair_id)
+
+    with get_session_with_current_tenant() as db_session:
+        cc_pair = get_connector_credential_pair(
+            db_session=db_session,
+            connector_id=connector_id,
+            credential_id=credential_id,
+        )
+        if not cc_pair:
+            raise RuntimeError(f"cc_pair not found for {connector_id} {credential_id}")
+
+        connector_type = cc_pair.connector.source.value
+        runnable_connector = instantiate_connector(
+            db_session,
+            cc_pair.connector.source,
+            InputType.SLIM_RETRIEVAL,
+            cc_pair.connector.connector_specific_config,
+            cc_pair.credential,
+        )
+    # session closed here — no DB connection held during the crawl
+
+    callback = SpawnedPruneCallback(redis_connector)
+
+    extraction_result = extract_ids_from_runnable_connector(
+        runnable_connector, callback, connector_type=connector_type
+    )
+
+    tmp_path = f"{result_path}.tmp"
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        f.write(extraction_result.model_dump_json())
+    os.replace(tmp_path, result_path)
+
+    logger.info(
+        "Pruning enumeration child finished: cc_pair=%s num_docs=%s num_hierarchy_nodes=%s",
+        cc_pair_id,
+        len(extraction_result.raw_id_to_parent),
+        len(extraction_result.hierarchy_nodes),
+    )
+
+    # reap Playwright orphans, then exit hard — os._exit skips
+    # _initializer's finally (mirrors _docfetching_task)
+    reap_exited_children()
+    os._exit(0)
+
+
+def run_enumeration_in_subprocess(
+    cc_pair_id: int,
+    connector_id: int,
+    credential_id: int,
+    tenant_id: str,
+    redis_connector: RedisConnector,
+    reacquire_lock: Callable[[], object],
+) -> SlimConnectorExtractionResult:
+    """Spawn the enumeration child and babysit it until it produces a result.
+
+    `reacquire_lock` is invoked periodically so the parent task's redis lock
+    does not expire during multi-hour enumerations.
+    Raises PruneEnumerationError on child failure, stop signal, or timeout.
+    """
+    result_path = Path(tempfile.gettempdir()) / (
+        f"onyx_prune_enum_{os.getpid()}_{cc_pair_id}_{time.monotonic_ns()}.json"
+    )
+
+    client = SimpleJobClient(n_workers=1)
+    job: SimpleJob | None = client.submit(
+        pruning_enumeration_task,
+        str(result_path),
+        cc_pair_id,
+        connector_id,
+        credential_id,
+        tenant_id,
+    )
+    if job is None or job.process is None:
+        raise PruneEnumerationError(
+            f"Failed to spawn pruning enumeration child: cc_pair={cc_pair_id}"
+        )
+
+    logger.info(
+        "Pruning enumeration child spawned: cc_pair=%s pid=%s",
+        cc_pair_id,
+        job.process.pid,
+    )
+
+    start = time.monotonic()
+    last_lock_reacquire = start
+    try:
+        while True:
+            job.process.join(timeout=_WATCHDOG_POLL_SECONDS)
+            if not job.process.is_alive():
+                break
+
+            now = time.monotonic()
+
+            if now - last_lock_reacquire >= _LOCK_REACQUIRE_INTERVAL_SECONDS:
+                reacquire_lock()
+                last_lock_reacquire = now
+
+            if redis_connector.stop.fenced:
+                raise PruneEnumerationError(
+                    f"Pruning enumeration stopped by signal: cc_pair={cc_pair_id}"
+                )
+
+            # NOTE: celery's time limits don't work with thread pools, so the
+            # watchdog is the timeout enforcement for the enumeration
+            if now - start > JOB_TIMEOUT:
+                raise PruneEnumerationError(
+                    f"Pruning enumeration timed out: cc_pair={cc_pair_id} "
+                    f"timeout={JOB_TIMEOUT}s"
+                )
+
+        if job.process.exitcode == 0 and result_path.exists():
+            return SlimConnectorExtractionResult.model_validate_json(
+                result_path.read_text(encoding="utf-8")
+            )
+
+        raise PruneEnumerationError(
+            f"Pruning enumeration child failed: cc_pair={cc_pair_id} "
+            f"exit_code={job.process.exitcode} exception={job.exception()}"
+        )
+    finally:
+        # never leave a live child behind — this also covers exits caused by
+        # the watchdog itself failing (e.g. a lock reacquisition error)
+        job.terminate_and_wait(_TERMINATE_GRACE_SECONDS)
+        result_path.unlink(missing_ok=True)
+        Path(f"{result_path}.tmp").unlink(missing_ok=True)

--- a/backend/onyx/background/celery/tasks/pruning/enumeration_spawn.py
+++ b/backend/onyx/background/celery/tasks/pruning/enumeration_spawn.py
@@ -1,16 +1,12 @@
 """Run pruning's connector enumeration in a spawned child process.
 
-Multi-hour enumerations ratchet the long-lived heavy worker's RSS until the
-pod OOMs; running them in an ephemeral child (mirroring docfetching's
-`SimpleJobClient` pattern) lets the OS reclaim everything at child exit.
-The celery task acts as the watchdog (owns the redis lock/fence, kills the
-child on stop or timeout); the child returns its result through a JSON file,
-schema-validated on read (an mp queue can deadlock on multi-MB payloads).
-`run_in_isolated_process` is not usable here: it blocks the calling thread for
-the child's whole lifetime, but multi-hour enumerations need the parent free
-to renew the redis lock and react to the stop fence.
-Prometheus metrics are emitted by the parent — the child's registry is never
-scraped.
+Multi-hour enumerations ratchet the long-lived heavy worker's RSS — allocator
+retention is only fully released on process exit — so the crawl runs in an
+ephemeral child (docfetching's `SimpleJobClient` pattern). The celery task
+stays behind as the watchdog: it renews the redis lock, kills the child on
+stop or timeout, and reads the result from a schema-validated JSON file
+(mp queues deadlock on multi-MB payloads; `run_in_isolated_process` would
+block this thread for the child's whole lifetime).
 """
 
 import os
@@ -37,13 +33,8 @@ from shared_configs.configs import SENTRY_CELERY_TRACES_SAMPLE_RATE, SENTRY_DSN
 
 logger = setup_logger()
 
-# how long the watchdog waits on the child between liveness checks
 _WATCHDOG_POLL_SECONDS = 5
-
-# how often the watchdog reacquires the pruning redis lock
 _LOCK_REACQUIRE_INTERVAL_SECONDS = 60
-
-# grace period for the child to exit after SIGTERM before SIGKILL
 _TERMINATE_GRACE_SECONDS = 10
 
 
@@ -54,10 +45,8 @@ class PruneEnumerationError(RuntimeError):
 class SpawnedPruneCallback(IndexingHeartbeatInterface):
     """Child-side heartbeat: liveness, stop fence, and orphan reaping.
 
-    The parent watchdog owns the redis lock and enforces the timeout by
-    killing this process. A raise out of the enumeration (stop fence, crawl
-    error) means no result file is written — a partial enumeration can never
-    be mistaken for a complete one.
+    A raise out of the enumeration means no result file is written, so a
+    partial enumeration can never be mistaken for a complete one.
     """
 
     def __init__(self, redis_connector: RedisConnector):
@@ -79,14 +68,9 @@ def pruning_enumeration_task(
     credential_id: int,
     tenant_id: str,
 ) -> None:
-    """Entrypoint of the spawned enumeration child process.
-
-    Instantiates the connector from the DB, enumerates all document IDs and
-    hierarchy nodes, and writes the pickled `SlimConnectorExtractionResult`
-    to `result_path` (atomically, via rename). Exits 0 on success.
-    """
-    # Spawned via SimpleJobClient, so init Sentry ourselves (mirrors
-    # _docfetching_task).
+    """Child entrypoint: enumerate all doc IDs / hierarchy nodes and write the
+    `SlimConnectorExtractionResult` JSON to `result_path` (atomic rename)."""
+    # spawned via SimpleJobClient, so init Sentry ourselves (mirrors _docfetching_task)
     if SENTRY_DSN:
         from onyx.configs.sentry import init_sentry
 
@@ -121,7 +105,7 @@ def pruning_enumeration_task(
             cc_pair.connector.connector_specific_config,
             cc_pair.credential,
         )
-    # session closed here — no DB connection held during the crawl
+    # session closed — no DB connection held during the crawl
 
     callback = SpawnedPruneCallback(redis_connector)
 
@@ -141,8 +125,7 @@ def pruning_enumeration_task(
         len(extraction_result.hierarchy_nodes),
     )
 
-    # reap Playwright orphans, then exit hard — os._exit skips
-    # _initializer's finally (mirrors _docfetching_task)
+    # os._exit skips _initializer's finally, so drain orphans here (mirrors _docfetching_task)
     reap_exited_children()
     os._exit(0)
 
@@ -157,8 +140,6 @@ def run_enumeration_in_subprocess(
 ) -> SlimConnectorExtractionResult:
     """Spawn the enumeration child and babysit it until it produces a result.
 
-    `reacquire_lock` is invoked periodically so the parent task's redis lock
-    does not expire during multi-hour enumerations.
     Raises PruneEnumerationError on child failure, stop signal, or timeout.
     """
     result_path = Path(tempfile.gettempdir()) / (
@@ -204,8 +185,8 @@ def run_enumeration_in_subprocess(
                     f"Pruning enumeration stopped by signal: cc_pair={cc_pair_id}"
                 )
 
-            # NOTE: celery's time limits don't work with thread pools, so the
-            # watchdog is the timeout enforcement for the enumeration
+            # celery time limits don't work with thread pools, so the watchdog
+            # is the timeout enforcement
             if now - start > JOB_TIMEOUT:
                 raise PruneEnumerationError(
                     f"Pruning enumeration timed out: cc_pair={cc_pair_id} "
@@ -222,8 +203,7 @@ def run_enumeration_in_subprocess(
             f"exit_code={job.process.exitcode} exception={job.exception()}"
         )
     finally:
-        # never leave a live child behind — this also covers exits caused by
-        # the watchdog itself failing (e.g. a lock reacquisition error)
+        # never leave a live child behind, even if the watchdog itself raised
         job.terminate_and_wait(_TERMINATE_GRACE_SECONDS)
         result_path.unlink(missing_ok=True)
         Path(f"{result_path}.tmp").unlink(missing_ok=True)

--- a/backend/onyx/background/celery/tasks/pruning/enumeration_spawn.py
+++ b/backend/onyx/background/celery/tasks/pruning/enumeration_spawn.py
@@ -6,6 +6,9 @@ pod OOMs; running them in an ephemeral child (mirroring docfetching's
 The celery task acts as the watchdog (owns the redis lock/fence, kills the
 child on stop or timeout); the child returns its result through a JSON file,
 schema-validated on read (an mp queue can deadlock on multi-MB payloads).
+`run_in_isolated_process` is not usable here: it blocks the calling thread for
+the child's whole lifetime, but multi-hour enumerations need the parent free
+to renew the redis lock and react to the stop fence.
 Prometheus metrics are emitted by the parent — the child's registry is never
 scraped.
 """

--- a/backend/onyx/background/celery/tasks/pruning/enumeration_spawn.py
+++ b/backend/onyx/background/celery/tasks/pruning/enumeration_spawn.py
@@ -28,7 +28,7 @@ from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 from onyx.redis.redis_connector import RedisConnector
 from onyx.utils.logger import pruning_ctx, setup_logger
-from onyx.utils.os_reaper import reap_exited_children
+from onyx.utils.os_reaper import reap_children_before_exit, reap_exited_children
 from shared_configs.configs import SENTRY_CELERY_TRACES_SAMPLE_RATE, SENTRY_DSN
 
 logger = setup_logger()
@@ -126,7 +126,7 @@ def pruning_enumeration_task(
     )
 
     # os._exit skips _initializer's finally, so drain orphans here (mirrors _docfetching_task)
-    reap_exited_children()
+    reap_children_before_exit()
     os._exit(0)
 
 

--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -18,9 +18,11 @@ from onyx.background.celery.celery_redis import (
     celery_get_queued_task_ids,
     celery_get_unacked_task_ids,
 )
-from onyx.background.celery.celery_utils import extract_ids_from_runnable_connector
 from onyx.background.celery.tasks.beat_schedule import CLOUD_BEAT_MULTIPLIER_DEFAULT
-from onyx.background.celery.tasks.docprocessing.utils import IndexingCallbackBase
+from onyx.background.celery.tasks.pruning.enumeration_spawn import (
+    PruneEnumerationError,
+    run_enumeration_in_subprocess,
+)
 from onyx.configs.app_configs import ALLOW_SIMULTANEOUS_PRUNING, JOB_TIMEOUT
 from onyx.configs.constants import (
     CELERY_GENERIC_BEAT_LOCK_TIMEOUT,
@@ -35,9 +37,6 @@ from onyx.configs.constants import (
     OnyxRedisLocks,
     OnyxRedisSignals,
 )
-from onyx.connectors.factory import instantiate_connector
-from onyx.connectors.interfaces import BaseConnector
-from onyx.connectors.models import InputType
 from onyx.db.connector import mark_ccpair_as_pruned
 from onyx.db.connector_credential_pair import (
     get_connector_credential_pair,
@@ -83,7 +82,11 @@ from onyx.redis.redis_hierarchy import (
 from onyx.redis.redis_pool import get_redis_client, get_redis_replica_client
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
 from onyx.redis.tenant_redis_client import TenantRedisClient
-from onyx.server.metrics.pruning_metrics import observe_pruning_diff_duration
+from onyx.server.metrics.pruning_metrics import (
+    inc_pruning_rate_limit_error,
+    observe_pruning_diff_duration,
+    observe_pruning_enumeration_duration,
+)
 from onyx.server.runtime.onyx_runtime import OnyxRuntime
 from onyx.server.utils import make_short_id
 from onyx.utils.logger import (
@@ -131,12 +134,6 @@ def _get_fence_validation_block_expiration() -> int:
         beat_multiplier = CLOUD_BEAT_MULTIPLIER_DEFAULT
 
     return int(base_expiration * beat_multiplier)
-
-
-class PruneCallback(IndexingCallbackBase):
-    def progress(self, tag: str, amount: int) -> None:
-        self.redis_connector.prune.set_active()
-        super().progress(tag, amount)
 
 
 def _resolve_and_update_document_parents(
@@ -562,13 +559,12 @@ def connector_pruning_generator_task(
         return None
 
     try:
-        # Session 1: pre-enumeration — load cc_pair and instantiate the connector.
+        # Session 1: pre-enumeration — load cc_pair metadata and update the fence.
         # The session is closed before enumeration so the DB connection is not held
-        # open during the 10–30+ minute connector crawl.
+        # open during the multi-hour connector crawl.
         connector_source: DocumentSource | None = None
         connector_type: str = ""
         is_connector_public: bool = False
-        runnable_connector: BaseConnector | None = None
 
         with get_session_with_current_tenant() as db_session:
             cc_pair = get_connector_credential_pair(
@@ -602,28 +598,35 @@ def connector_pruning_generator_task(
             task_logger.info(
                 f"Pruning generator running connector: cc_pair={cc_pair_id} connector_source={connector_source}"
             )
-
-            runnable_connector = instantiate_connector(
-                db_session,
-                connector_source,
-                InputType.SLIM_RETRIEVAL,
-                cc_pair.connector.connector_specific_config,
-                cc_pair.credential,
-            )
         # Session 1 closed here — connection released before enumeration.
 
-        callback = PruneCallback(
-            0,
-            redis_connector,
-            lock,
-            r,
-            timeout_seconds=JOB_TIMEOUT,
-        )
-
-        # Extract docs and hierarchy nodes from the source (no DB session held).
-        extraction_result = extract_ids_from_runnable_connector(
-            runnable_connector, callback, connector_type=connector_type
-        )
+        # Enumerate source doc IDs in a spawned child process so the crawl's
+        # memory churn is reclaimed by the OS instead of ratcheting up this
+        # long-lived worker's RSS (see enumeration_spawn.py). This task
+        # babysits the child: it keeps the redis lock alive and kills the
+        # child on stop signals or timeout.
+        enumeration_start = time.monotonic()
+        try:
+            extraction_result = run_enumeration_in_subprocess(
+                cc_pair_id=cc_pair_id,
+                connector_id=connector_id,
+                credential_id=credential_id,
+                tenant_id=tenant_id,
+                redis_connector=redis_connector,
+                reacquire_lock=lock.reacquire,
+            )
+        except PruneEnumerationError as e:
+            # Best-effort rate limit detection via string matching on the
+            # child's exception text (the child's own Prometheus registry
+            # dies with it, so the metric must be emitted here).
+            error_str = str(e)
+            if "rate limit" in error_str.lower() or "429" in error_str:
+                inc_pruning_rate_limit_error(connector_type)
+            raise
+        finally:
+            observe_pruning_enumeration_duration(
+                time.monotonic() - enumeration_start, connector_type
+            )
         all_connector_doc_ids = extraction_result.raw_id_to_parent
 
         # Session 2: post-enumeration — hierarchy upserts, diff computation, task dispatch.

--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -600,11 +600,8 @@ def connector_pruning_generator_task(
             )
         # Session 1 closed here — connection released before enumeration.
 
-        # Enumerate source doc IDs in a spawned child process so the crawl's
-        # memory churn is reclaimed by the OS instead of ratcheting up this
-        # long-lived worker's RSS (see enumeration_spawn.py). This task
-        # babysits the child: it keeps the redis lock alive and kills the
-        # child on stop signals or timeout.
+        # Enumerate in a spawned child so crawl memory is reclaimed at child
+        # exit instead of ratcheting this worker's RSS (see enumeration_spawn.py).
         enumeration_start = time.monotonic()
         try:
             extraction_result = run_enumeration_in_subprocess(
@@ -616,8 +613,8 @@ def connector_pruning_generator_task(
                 reacquire_lock=lock.reacquire,
             )
         except PruneEnumerationError as e:
-            # the child's own Prometheus registry dies with it, so rate limit
-            # errors are detected from its exception text and emitted here
+            # the child's Prometheus registry dies with it — detect from its
+            # surfaced exception text and emit here
             inc_pruning_rate_limit_error_if_detected(str(e), connector_type)
             raise
         finally:

--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -83,7 +83,7 @@ from onyx.redis.redis_pool import get_redis_client, get_redis_replica_client
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
 from onyx.redis.tenant_redis_client import TenantRedisClient
 from onyx.server.metrics.pruning_metrics import (
-    inc_pruning_rate_limit_error,
+    inc_pruning_rate_limit_error_if_detected,
     observe_pruning_diff_duration,
     observe_pruning_enumeration_duration,
 )
@@ -616,12 +616,9 @@ def connector_pruning_generator_task(
                 reacquire_lock=lock.reacquire,
             )
         except PruneEnumerationError as e:
-            # Best-effort rate limit detection via string matching on the
-            # child's exception text (the child's own Prometheus registry
-            # dies with it, so the metric must be emitted here).
-            error_str = str(e)
-            if "rate limit" in error_str.lower() or "429" in error_str:
-                inc_pruning_rate_limit_error(connector_type)
+            # the child's own Prometheus registry dies with it, so rate limit
+            # errors are detected from its exception text and emitted here
+            inc_pruning_rate_limit_error_if_detected(str(e), connector_type)
             raise
         finally:
             observe_pruning_enumeration_duration(

--- a/backend/onyx/server/metrics/pruning_metrics.py
+++ b/backend/onyx/server/metrics/pruning_metrics.py
@@ -74,13 +74,10 @@ def inc_pruning_rate_limit_error(connector_type: str) -> None:
 def inc_pruning_rate_limit_error_if_detected(
     error_str: str, connector_type: str
 ) -> bool:
-    """Best-effort rate limit detection via string matching.
-
-    Connectors surface rate limits inconsistently — some raise HTTP 429,
-    some use SDK-specific exceptions (e.g. google.api_core.exceptions.ResourceExhausted)
-    that may or may not include "rate limit" or "429" in the message.
-    TODO(Bo): replace with a standard ConnectorRateLimitError exception that all
-    connectors raise when rate limited, making this check precise.
+    """Best-effort rate limit detection — connectors surface rate limits
+    inconsistently (HTTP 429, SDK-specific exception types).
+    TODO(Bo): replace with a standard ConnectorRateLimitError raised by all
+    connectors, making this check precise.
     """
     if "rate limit" in error_str.lower() or "429" in error_str:
         inc_pruning_rate_limit_error(connector_type)

--- a/backend/onyx/server/metrics/pruning_metrics.py
+++ b/backend/onyx/server/metrics/pruning_metrics.py
@@ -69,3 +69,20 @@ def inc_pruning_rate_limit_error(connector_type: str) -> None:
         PRUNING_RATE_LIMIT_ERRORS.labels(connector_type=connector_type).inc()
     except Exception:
         logger.debug("Failed to record pruning rate limit error", exc_info=True)
+
+
+def inc_pruning_rate_limit_error_if_detected(
+    error_str: str, connector_type: str
+) -> bool:
+    """Best-effort rate limit detection via string matching.
+
+    Connectors surface rate limits inconsistently — some raise HTTP 429,
+    some use SDK-specific exceptions (e.g. google.api_core.exceptions.ResourceExhausted)
+    that may or may not include "rate limit" or "429" in the message.
+    TODO(Bo): replace with a standard ConnectorRateLimitError exception that all
+    connectors raise when rate limited, making this check precise.
+    """
+    if "rate limit" in error_str.lower() or "429" in error_str:
+        inc_pruning_rate_limit_error(connector_type)
+        return True
+    return False

--- a/backend/onyx/server/metrics/pruning_metrics.py
+++ b/backend/onyx/server/metrics/pruning_metrics.py
@@ -79,7 +79,8 @@ def inc_pruning_rate_limit_error_if_detected(
     TODO(Bo): replace with a standard ConnectorRateLimitError raised by all
     connectors, making this check precise.
     """
-    if "rate limit" in error_str.lower() or "429" in error_str:
+    lowered = error_str.lower()
+    if "rate limit" in lowered or "ratelimit" in lowered or "429" in error_str:
         inc_pruning_rate_limit_error(connector_type)
         return True
     return False

--- a/backend/onyx/utils/native_memory.py
+++ b/backend/onyx/utils/native_memory.py
@@ -1,0 +1,35 @@
+"""Release freed native memory back to the OS (Linux/glibc).
+
+glibc retains freed allocations in its arenas, so a long-lived worker
+churning through a multi-hour connector crawl ratchets its RSS until the
+pod OOMs even though the live Python heap stays flat. Periodic
+malloc_trim(0) returns that memory to the kernel.
+"""
+
+import ctypes
+import sys
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_libc: ctypes.CDLL | None = None
+_unavailable = False
+
+
+def release_freed_native_memory() -> bool:
+    """Return glibc-retained freed memory to the OS. No-op off Linux."""
+    global _libc, _unavailable
+
+    if sys.platform != "linux" or _unavailable:
+        return False
+
+    try:
+        if _libc is None:
+            _libc = ctypes.CDLL(None)
+        _libc.malloc_trim(0)
+        return True
+    except Exception:
+        _unavailable = True
+        logger.warning("malloc_trim unavailable; not retrying", exc_info=True)
+        return False

--- a/backend/onyx/utils/native_memory.py
+++ b/backend/onyx/utils/native_memory.py
@@ -1,11 +1,9 @@
 """Release freed native memory back to the OS (Linux).
 
-Long-lived workers churning through multi-hour connector crawls accumulate
-freed-but-retained allocator memory, ratcheting RSS until the pod OOMs even
-though the live Python heap stays flat. The backend image LD_PRELOADs
-jemalloc (see backend/Dockerfile), so the release goes through jemalloc's
-mallctl (epoch bump + purge of all arenas); glibc malloc_trim(0) is the
-fallback when jemalloc is absent (e.g. bare-metal dev installs).
+The backend image LD_PRELOADs jemalloc (see backend/Dockerfile), where the
+release is a mallctl epoch bump + purge of all arenas; glibc `malloc_trim(0)`
+is the fallback for non-jemalloc installs. Without this, long crawls ratchet
+worker RSS with freed-but-retained allocator memory until the pod OOMs.
 """
 
 import ctypes
@@ -27,7 +25,7 @@ def _load() -> None:
     global _jemalloc, _glibc, _unavailable
     try:
         _jemalloc = ctypes.CDLL("libjemalloc.so.2")
-        _jemalloc.mallctl  # raises AttributeError if the symbol is missing
+        _jemalloc.mallctl
         return
     except (OSError, AttributeError):
         _jemalloc = None
@@ -52,8 +50,7 @@ def release_freed_native_memory() -> bool:
 
     try:
         if _jemalloc is not None:
-            # advance the epoch so the purge sees current state, then purge
-            # dirty+muzzy pages from every arena
+            # advance the epoch so the purge sees current state
             epoch = ctypes.c_uint64(1)
             epoch_sz = ctypes.c_size_t(ctypes.sizeof(epoch))
             _jemalloc.mallctl(

--- a/backend/onyx/utils/native_memory.py
+++ b/backend/onyx/utils/native_memory.py
@@ -1,9 +1,11 @@
-"""Release freed native memory back to the OS (Linux/glibc).
+"""Release freed native memory back to the OS (Linux).
 
-glibc retains freed allocations in its arenas, so a long-lived worker
-churning through a multi-hour connector crawl ratchets its RSS until the
-pod OOMs even though the live Python heap stays flat. Periodic
-malloc_trim(0) returns that memory to the kernel.
+Long-lived workers churning through multi-hour connector crawls accumulate
+freed-but-retained allocator memory, ratcheting RSS until the pod OOMs even
+though the live Python heap stays flat. The backend image LD_PRELOADs
+jemalloc (see backend/Dockerfile), so the release goes through jemalloc's
+mallctl (epoch bump + purge of all arenas); glibc malloc_trim(0) is the
+fallback when jemalloc is absent (e.g. bare-metal dev installs).
 """
 
 import ctypes
@@ -13,23 +15,63 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
-_libc: ctypes.CDLL | None = None
+# jemalloc's MALLCTL_ARENAS_ALL sentinel (jemalloc/jemalloc.h)
+_MALLCTL_ARENAS_ALL = 4096
+
+_jemalloc: ctypes.CDLL | None = None
+_glibc: ctypes.CDLL | None = None
 _unavailable = False
 
 
+def _load() -> None:
+    global _jemalloc, _glibc, _unavailable
+    try:
+        _jemalloc = ctypes.CDLL("libjemalloc.so.2")
+        _jemalloc.mallctl  # raises AttributeError if the symbol is missing
+        return
+    except (OSError, AttributeError):
+        _jemalloc = None
+    try:
+        _glibc = ctypes.CDLL(None)
+        _glibc.malloc_trim
+    except (OSError, AttributeError):
+        _glibc = None
+        _unavailable = True
+        logger.warning("no jemalloc or glibc malloc_trim available; not retrying")
+
+
 def release_freed_native_memory() -> bool:
-    """Return glibc-retained freed memory to the OS. No-op off Linux."""
-    global _libc, _unavailable
+    """Return allocator-retained freed memory to the OS. No-op off Linux."""
+    global _unavailable
 
     if sys.platform != "linux" or _unavailable:
         return False
 
+    if _jemalloc is None and _glibc is None:
+        _load()
+
     try:
-        if _libc is None:
-            _libc = ctypes.CDLL(None)
-        _libc.malloc_trim(0)
-        return True
+        if _jemalloc is not None:
+            # advance the epoch so the purge sees current state, then purge
+            # dirty+muzzy pages from every arena
+            epoch = ctypes.c_uint64(1)
+            epoch_sz = ctypes.c_size_t(ctypes.sizeof(epoch))
+            _jemalloc.mallctl(
+                b"epoch",
+                ctypes.byref(epoch),
+                ctypes.byref(epoch_sz),
+                ctypes.byref(epoch),
+                epoch_sz,
+            )
+            _jemalloc.mallctl(
+                f"arena.{_MALLCTL_ARENAS_ALL}.purge".encode(), None, None, None, 0
+            )
+            return True
+        if _glibc is not None:
+            _glibc.malloc_trim(0)
+            return True
     except Exception:
-        _unavailable = True
-        logger.warning("malloc_trim unavailable; not retrying", exc_info=True)
-        return False
+        logger.warning("native memory release failed; not retrying", exc_info=True)
+
+    _unavailable = True
+    return False

--- a/backend/tests/external_dependency_unit/celery/test_pruning_enumeration_spawn.py
+++ b/backend/tests/external_dependency_unit/celery/test_pruning_enumeration_spawn.py
@@ -1,0 +1,141 @@
+"""External dependency unit tests for the spawned pruning enumeration.
+
+Verifies the child-process enumeration harness end to end:
+1. A real connector (WEB, single URL) is instantiated inside the spawned
+   child from DB state, enumerated, and the result round-trips back to the
+   parent through the JSON handoff file.
+2. A child that fails (unreachable URL) surfaces a PruneEnumerationError in
+   the parent with the child's exception text attached.
+
+Requires Postgres + Redis (child sets prune-active liveness) + internet.
+"""
+
+from collections.abc import Generator
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.background.celery.tasks.pruning.enumeration_spawn import (
+    PruneEnumerationError,
+    run_enumeration_in_subprocess,
+)
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import InputType
+from onyx.db.enums import AccessType, ConnectorCredentialPairStatus
+from onyx.db.models import Connector, ConnectorCredentialPair, Credential
+from onyx.redis.redis_connector import RedisConnector
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
+
+TEST_URL = "https://example.com/"
+
+
+def _create_web_cc_pair(
+    db_session: Session,
+    base_url: str,
+) -> ConnectorCredentialPair:
+    connector = Connector(
+        name=f"Test enumeration-spawn Connector {base_url}",
+        source=DocumentSource.WEB,
+        input_type=InputType.LOAD_STATE,
+        connector_specific_config={
+            "base_url": base_url,
+            "web_connector_type": "single",
+        },
+    )
+    db_session.add(connector)
+    db_session.flush()
+
+    credential = Credential(
+        source=DocumentSource.WEB,
+        credential_json={},
+        admin_public=True,
+    )
+    db_session.add(credential)
+    db_session.flush()
+
+    cc_pair = ConnectorCredentialPair(
+        connector_id=connector.id,
+        credential_id=credential.id,
+        name=f"Test enumeration-spawn CC Pair {base_url}",
+        status=ConnectorCredentialPairStatus.ACTIVE,
+        access_type=AccessType.PUBLIC,
+    )
+    db_session.add(cc_pair)
+    db_session.commit()
+    db_session.refresh(cc_pair)
+    return cc_pair
+
+
+@pytest.fixture
+def web_cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    cc_pair = _create_web_cc_pair(db_session, TEST_URL)
+    yield cc_pair
+    _cleanup(db_session, cc_pair)
+
+
+@pytest.fixture
+def broken_web_cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    # .invalid is a reserved TLD that can never resolve
+    cc_pair = _create_web_cc_pair(db_session, "https://onyx-test.invalid/")
+    yield cc_pair
+    _cleanup(db_session, cc_pair)
+
+
+def _cleanup(db_session: Session, cc_pair: ConnectorCredentialPair) -> None:
+    connector_id = cc_pair.connector_id
+    credential_id = cc_pair.credential_id
+    db_session.query(ConnectorCredentialPair).filter(
+        ConnectorCredentialPair.id == cc_pair.id
+    ).delete()
+    db_session.query(Connector).filter(Connector.id == connector_id).delete()
+    db_session.query(Credential).filter(Credential.id == credential_id).delete()
+    db_session.commit()
+
+
+def test_spawned_enumeration_success(
+    web_cc_pair: ConnectorCredentialPair,
+) -> None:
+    """The child enumerates a single-URL web connector and the result
+    round-trips through the JSON handoff file."""
+    reacquire_calls: list[int] = []
+
+    result = run_enumeration_in_subprocess(
+        cc_pair_id=web_cc_pair.id,
+        connector_id=web_cc_pair.connector_id,
+        credential_id=web_cc_pair.credential_id,
+        tenant_id=POSTGRES_DEFAULT_SCHEMA,
+        redis_connector=RedisConnector(POSTGRES_DEFAULT_SCHEMA, web_cc_pair.id),
+        reacquire_lock=lambda: reacquire_calls.append(1),
+    )
+
+    # single-page crawl of example.com yields exactly that URL
+    assert set(result.raw_id_to_parent.keys()) == {TEST_URL}
+    assert result.raw_id_to_parent[TEST_URL] is None
+    assert result.hierarchy_nodes == []
+
+
+def test_spawned_enumeration_child_failure(
+    broken_web_cc_pair: ConnectorCredentialPair,
+) -> None:
+    """A child that cannot reach its source fails the enumeration with the
+    child's exception text surfaced to the parent."""
+    with pytest.raises(PruneEnumerationError) as exc_info:
+        run_enumeration_in_subprocess(
+            cc_pair_id=broken_web_cc_pair.id,
+            connector_id=broken_web_cc_pair.connector_id,
+            credential_id=broken_web_cc_pair.credential_id,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA,
+            redis_connector=RedisConnector(
+                POSTGRES_DEFAULT_SCHEMA, broken_web_cc_pair.id
+            ),
+            reacquire_lock=lambda: None,
+        )
+
+    # the child exits nonzero and its traceback is attached
+    assert "exit_code" in str(exc_info.value)

--- a/backend/tests/external_dependency_unit/celery/test_pruning_enumeration_spawn.py
+++ b/backend/tests/external_dependency_unit/celery/test_pruning_enumeration_spawn.py
@@ -1,14 +1,7 @@
-"""External dependency unit tests for the spawned pruning enumeration.
-
-Verifies the child-process enumeration harness end to end:
-1. A real connector (WEB, single URL) is instantiated inside the spawned
-   child from DB state, enumerated, and the result round-trips back to the
-   parent through the JSON handoff file.
-2. A child that fails (unreachable URL) surfaces a PruneEnumerationError in
-   the parent with the child's exception text attached.
-
-Requires Postgres + Redis (child sets prune-active liveness) + internet.
-"""
+"""End-to-end tests for the spawned pruning enumeration: a real WEB connector
+is instantiated inside the child from DB state and the result round-trips via
+the JSON handoff file; a failing child surfaces its exception in
+PruneEnumerationError. Requires Postgres + Redis + internet."""
 
 from collections.abc import Generator
 

--- a/backend/tests/unit/background/celery/test_celery_utils.py
+++ b/backend/tests/unit/background/celery/test_celery_utils.py
@@ -1,87 +1,42 @@
-"""Unit tests for extract_ids_from_runnable_connector metrics instrumentation."""
+"""Unit tests for pruning enumeration metrics.
 
-from collections.abc import Iterator
-from unittest.mock import MagicMock
+Enumeration runs in a spawned child process whose Prometheus registry is never
+scraped, so metrics are emitted by the pruning parent task: duration via
+observe_pruning_enumeration_duration, rate limits via
+inc_pruning_rate_limit_error_if_detected on the child's exception text.
+"""
 
-import pytest
-
-from onyx.background.celery.celery_utils import extract_ids_from_runnable_connector
-from onyx.connectors.interfaces import SlimConnector
-from onyx.connectors.models import SlimDocument
 from onyx.server.metrics.pruning_metrics import (
     PRUNING_ENUMERATION_DURATION,
     PRUNING_RATE_LIMIT_ERRORS,
+    inc_pruning_rate_limit_error_if_detected,
+    observe_pruning_enumeration_duration,
 )
 
 
-def _make_slim_connector(doc_ids: list[str]) -> SlimConnector:
-    """Mock SlimConnector that yields the given doc IDs in one batch."""
-    connector = MagicMock(spec=SlimConnector)
-    docs = [
-        MagicMock(
-            spec=SlimDocument,
-            id=doc_id,
-            parent_hierarchy_raw_node_id=None,
-            doc_created_at=None,
-        )
-        for doc_id in doc_ids
-    ]
-    connector.retrieve_all_slim_docs.return_value = iter([docs])
-    return connector
-
-
-def _raising_connector(message: str) -> SlimConnector:
-    """Mock SlimConnector whose generator raises with the given message."""
-    connector = MagicMock(spec=SlimConnector)
-
-    def raising_iter() -> Iterator:
-        raise Exception(message)
-        yield
-
-    connector.retrieve_all_slim_docs.return_value = raising_iter()
-    return connector
-
-
 class TestEnumerationDuration:
-    def test_recorded_on_success(self) -> None:
-        connector = _make_slim_connector(["doc1"])
+    def test_recorded_under_connector_type_label(self) -> None:
         before = PRUNING_ENUMERATION_DURATION.labels(
             connector_type="google_drive"
         )._sum.get()
 
-        extract_ids_from_runnable_connector(connector, connector_type="google_drive")
+        observe_pruning_enumeration_duration(12.5, "google_drive")
 
         after = PRUNING_ENUMERATION_DURATION.labels(
             connector_type="google_drive"
         )._sum.get()
-        assert after >= before  # duration observed (non-negative)
-
-    def test_recorded_on_exception(self) -> None:
-        connector = _raising_connector("unexpected error")
-        before = PRUNING_ENUMERATION_DURATION.labels(
-            connector_type="confluence"
-        )._sum.get()
-
-        with pytest.raises(Exception):
-            extract_ids_from_runnable_connector(connector, connector_type="confluence")
-
-        after = PRUNING_ENUMERATION_DURATION.labels(
-            connector_type="confluence"
-        )._sum.get()
-        assert after >= before  # duration observed even on exception
+        assert after == before + 12.5
 
 
 class TestRateLimitDetection:
     def test_increments_on_rate_limit_message(self) -> None:
-        connector = _raising_connector("rate limit exceeded")
         before = PRUNING_RATE_LIMIT_ERRORS.labels(
             connector_type="google_drive"
         )._value.get()
 
-        with pytest.raises(Exception, match="rate limit exceeded"):
-            extract_ids_from_runnable_connector(
-                connector, connector_type="google_drive"
-            )
+        assert inc_pruning_rate_limit_error_if_detected(
+            "rate limit exceeded", "google_drive"
+        )
 
         after = PRUNING_RATE_LIMIT_ERRORS.labels(
             connector_type="google_drive"
@@ -89,41 +44,38 @@ class TestRateLimitDetection:
         assert after == before + 1
 
     def test_increments_on_429_in_message(self) -> None:
-        connector = _raising_connector("HTTP 429 Too Many Requests")
         before = PRUNING_RATE_LIMIT_ERRORS.labels(
             connector_type="confluence"
         )._value.get()
 
-        with pytest.raises(Exception, match="429"):
-            extract_ids_from_runnable_connector(connector, connector_type="confluence")
+        assert inc_pruning_rate_limit_error_if_detected(
+            "HTTP 429 Too Many Requests", "confluence"
+        )
 
         after = PRUNING_RATE_LIMIT_ERRORS.labels(
             connector_type="confluence"
         )._value.get()
         assert after == before + 1
 
-    def test_does_not_increment_on_non_rate_limit_exception(self) -> None:
-        connector = _raising_connector("connection timeout")
+    def test_does_not_increment_on_non_rate_limit_error(self) -> None:
         before = PRUNING_RATE_LIMIT_ERRORS.labels(connector_type="slack")._value.get()
 
-        with pytest.raises(Exception, match="connection timeout"):
-            extract_ids_from_runnable_connector(connector, connector_type="slack")
+        assert not inc_pruning_rate_limit_error_if_detected(
+            "connection timeout", "slack"
+        )
 
         after = PRUNING_RATE_LIMIT_ERRORS.labels(connector_type="slack")._value.get()
         assert after == before
 
     def test_rate_limit_detection_is_case_insensitive(self) -> None:
-        connector = _raising_connector("RATE LIMIT exceeded")
         before = PRUNING_RATE_LIMIT_ERRORS.labels(connector_type="jira")._value.get()
 
-        with pytest.raises(Exception):
-            extract_ids_from_runnable_connector(connector, connector_type="jira")
+        assert inc_pruning_rate_limit_error_if_detected("RATE LIMIT exceeded", "jira")
 
         after = PRUNING_RATE_LIMIT_ERRORS.labels(connector_type="jira")._value.get()
         assert after == before + 1
 
     def test_connector_type_label_matches_input(self) -> None:
-        connector = _raising_connector("rate limit exceeded")
         before_gd = PRUNING_RATE_LIMIT_ERRORS.labels(
             connector_type="google_drive"
         )._value.get()
@@ -131,10 +83,7 @@ class TestRateLimitDetection:
             connector_type="jira"
         )._value.get()
 
-        with pytest.raises(Exception):
-            extract_ids_from_runnable_connector(
-                connector, connector_type="google_drive"
-            )
+        inc_pruning_rate_limit_error_if_detected("rate limit exceeded", "google_drive")
 
         assert (
             PRUNING_RATE_LIMIT_ERRORS.labels(connector_type="google_drive")._value.get()
@@ -144,13 +93,3 @@ class TestRateLimitDetection:
             PRUNING_RATE_LIMIT_ERRORS.labels(connector_type="jira")._value.get()
             == before_jira
         )
-
-    def test_defaults_to_unknown_connector_type(self) -> None:
-        connector = _raising_connector("rate limit exceeded")
-        before = PRUNING_RATE_LIMIT_ERRORS.labels(connector_type="unknown")._value.get()
-
-        with pytest.raises(Exception):
-            extract_ids_from_runnable_connector(connector)
-
-        after = PRUNING_RATE_LIMIT_ERRORS.labels(connector_type="unknown")._value.get()
-        assert after == before + 1

--- a/backend/tests/unit/background/celery/test_celery_utils.py
+++ b/backend/tests/unit/background/celery/test_celery_utils.py
@@ -67,6 +67,16 @@ class TestRateLimitDetection:
         after = PRUNING_RATE_LIMIT_ERRORS.labels(connector_type="slack")._value.get()
         assert after == before
 
+    def test_increments_on_rate_limit_error_class_name(self) -> None:
+        before = PRUNING_RATE_LIMIT_ERRORS.labels(connector_type="notion")._value.get()
+
+        assert inc_pruning_rate_limit_error_if_detected(
+            "openai.RateLimitError: too many requests", "notion"
+        )
+
+        after = PRUNING_RATE_LIMIT_ERRORS.labels(connector_type="notion")._value.get()
+        assert after == before + 1
+
     def test_rate_limit_detection_is_case_insensitive(self) -> None:
         before = PRUNING_RATE_LIMIT_ERRORS.labels(connector_type="jira")._value.get()
 


### PR DESCRIPTION
## Description

Fixes the celery-worker-heavy memory ramp during Web connector pruning — the recurring `OnyxContainerMemoryNearLimit` pages on the cloud fleet that remain after the gdrive group-sync stacking fix (#13703).

Linear: [ENG-4309](https://linear.app/onyx-app/issue/ENG-4309/web-connector-pruning-accumulates-memory-across-long-playwright-crawls)

Two defects, both re-verified in the deployed image (`v4.5.0-cloud.4-dev`):

1. **Native-allocator retention (the OOM):** prune enumeration runs the whole crawl inline in the long-lived heavy worker. RSS ratchets while the live Python heap stays flat — freed crawl allocations are retained by the allocator and only fully returned on process exit. A 13k-page crawl ⇒ ~4Gi against the 5Gi limit. New finding while re-verifying: the backend image LD_PRELOADs **jemalloc** (Dockerfile, since #9196), so the `malloc_trim(0)` approach from the original PR (#13451) would have been a **no-op in production** — glibc's `mallinfo2`/`malloc_stats` report ~0 in-image.
2. **Zombie pid leak:** fixed separately in #13832 (merged). The spawned enumeration child here builds on it: orphaned Chromium helpers re-parent to the child and are drained per batch and on every exit path instead of accumulating on PID 1.

The fix (reland of #13451 + #13453, corrected for jemalloc; builds on the reaper from #13832):

- **Enumeration runs in a spawned child process** (`pruning/enumeration_spawn.py`), mirroring the docfetching `SimpleJobClient` pattern. This is the load-bearing, allocator-agnostic fix: everything is reclaimed at child exit, no matter what the allocator retains in-flight. The celery task becomes the watchdog — renews the redis lock on wall-clock cadence (the old callback only renewed on batch progress, so a stalled crawl could let the lock lapse), kills the child on stop fence or `JOB_TIMEOUT`, and always `terminate_and_wait`s it on any exit path. Results cross back via a schema-validated JSON file (mp queues can deadlock on multi-MB payloads). `run_in_isolated_process` is not usable here: it blocks the calling thread for the child's whole lifetime.
- **In-flight release that speaks the actual allocator's language** (`onyx/utils/native_memory.py`): every 30s at batch boundaries, `gc.collect()` + jemalloc `mallctl` epoch + `arena.<ALL>.purge` (verified working in-image), falling back to glibc `malloc_trim(0)` on non-jemalloc installs. Bounds within-crawl growth so a single multi-hour enumeration doesn't OOM the child before it can exit.
- **Prometheus metrics move to the parent task** (the child's registry is never scraped); rate-limit detection string-matches the child's surfaced exception text via `inc_pruning_rate_limit_error_if_detected`.

Known limitation (tracked in ENG-4309 follow-up): crawls that legitimately exceed the 6h `JOB_TIMEOUT` now fail cleanly with bounded memory instead of OOM-looping, but still never complete — needs a prune-specific timeout or a checkpointed slim crawl.

## How Has This Been Tested?

- In-image (deployed `v4.5.0-cloud.4-dev`) A/B memory profile of a real recursive slim crawl (docs.onyx.app, 289 pages/mode), sampling RSS, tracemalloc, and jemalloc stats per batch. Baseline: RSS ratchets ~0.2MiB/page (166 → 253MiB peak) while the live Python heap stays flat — the production slope, ~3–4Gi over a 13k-page crawl. With the fix's 30s `gc.collect()` + jemalloc purge: flat at ~199MiB (+0.2MiB total from page 112 to 289). A single *late* purge on the baseline recovers only ~12MiB — fragmented active pages can't be returned after the fact, which is why the release must run periodically (and why a one-shot end-of-crawl cleanup wouldn't work).
- The release loop makes Python gc collect recycled Playwright drivers, whose teardown leaves zombie children — the child's per-batch `reap_exited_children()` drains them (44 accumulated in a probe without reaping; the fix path reaps every batch).
- EDU `test_pruning_enumeration_spawn.py`: real spawned child enumerates a WEB connector from DB state and round-trips the result; a failing child surfaces its exception text in `PruneEnumerationError`.
- Full unit suite: 8102 passed; 21 failures identical to origin/main baseline (pre-existing local-env issues, verified by running the same files on a pristine main export).
- `release_freed_native_memory()` smoke-tested in-image: resolves jemalloc, purge rc=0.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
