### PR TITLE
fix(workers): reap Chromium orphans in spawned connector children

### DIFF
--- a/backend/onyx/background/celery/tasks/docfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/docfetching/tasks.py
@@ -53,6 +53,7 @@ from onyx.db.indexing_coordination import IndexingCoordination
 from onyx.redis.redis_connector import RedisConnector
 from onyx.server.metrics.connector_health_metrics import on_index_attempt_status_change
 from onyx.utils.logger import setup_logger
+from onyx.utils.os_reaper import reap_exited_children
 from onyx.utils.variable_functionality import global_version
 from shared_configs.configs import SENTRY_CELERY_TRACES_SAMPLE_RATE, SENTRY_DSN
 
@@ -272,6 +273,8 @@ def _docfetching_task(
         cc_pair_id,
         search_settings_id,
     )
+    # os._exit bypasses the drain in _initializer's finally, so reap here.
+    reap_exited_children()
     os._exit(0)  # ensure process exits cleanly
 
 

--- a/backend/onyx/background/celery/tasks/docfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/docfetching/tasks.py
@@ -53,7 +53,7 @@ from onyx.db.indexing_coordination import IndexingCoordination
 from onyx.redis.redis_connector import RedisConnector
 from onyx.server.metrics.connector_health_metrics import on_index_attempt_status_change
 from onyx.utils.logger import setup_logger
-from onyx.utils.os_reaper import reap_exited_children
+from onyx.utils.os_reaper import reap_children_before_exit
 from onyx.utils.variable_functionality import global_version
 from shared_configs.configs import SENTRY_CELERY_TRACES_SAMPLE_RATE, SENTRY_DSN
 
@@ -274,7 +274,7 @@ def _docfetching_task(
         search_settings_id,
     )
     # os._exit bypasses the drain in _initializer's finally, so reap here.
-    reap_exited_children()
+    reap_children_before_exit()
     os._exit(0)  # ensure process exits cleanly
 
 

--- a/backend/onyx/background/indexing/job_client.py
+++ b/backend/onyx/background/indexing/job_client.py
@@ -16,7 +16,11 @@ from typing import Any, Literal, Optional
 from onyx.configs.constants import POSTGRES_CELERY_WORKER_INDEXING_CHILD_APP_NAME
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.utils.logger import setup_logger
-from onyx.utils.os_reaper import become_child_subreaper, reap_children_before_exit
+from onyx.utils.os_reaper import (
+    become_child_subreaper,
+    install_sigterm_drain,
+    reap_children_before_exit,
+)
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA, TENANT_ID_PREFIX
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
@@ -57,8 +61,10 @@ def _initializer(
 
     logger.info("Initializing spawned worker child process.")
 
-    # adopt orphans (e.g. Chromium helpers) instead of leaking zombies to PID 1
+    # adopt orphans (e.g. Chromium helpers) instead of leaking zombies to PID 1,
+    # and drain them even when a watchdog cancels this child with SIGTERM
     become_child_subreaper()
+    install_sigterm_drain()
 
     # 1. Get tenant_id from args or fallback to default
     tenant_id = POSTGRES_DEFAULT_SCHEMA

--- a/backend/onyx/background/indexing/job_client.py
+++ b/backend/onyx/background/indexing/job_client.py
@@ -16,7 +16,7 @@ from typing import Any, Literal, Optional
 from onyx.configs.constants import POSTGRES_CELERY_WORKER_INDEXING_CHILD_APP_NAME
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.utils.logger import setup_logger
-from onyx.utils.os_reaper import become_child_subreaper, reap_exited_children
+from onyx.utils.os_reaper import become_child_subreaper, reap_children_before_exit
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA, TENANT_ID_PREFIX
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
@@ -100,7 +100,7 @@ def _initializer(
         CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
 
         # os._exit entrypoints skip this finally and drain themselves
-        reaped = reap_exited_children()
+        reaped = reap_children_before_exit()
         if reaped:
             logger.info("Spawned worker child reaped %s orphaned processes.", reaped)
 

--- a/backend/onyx/background/indexing/job_client.py
+++ b/backend/onyx/background/indexing/job_client.py
@@ -16,6 +16,7 @@ from typing import Any, Literal, Optional
 from onyx.configs.constants import POSTGRES_CELERY_WORKER_INDEXING_CHILD_APP_NAME
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.utils.logger import setup_logger
+from onyx.utils.os_reaper import become_child_subreaper, reap_exited_children
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA, TENANT_ID_PREFIX
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
@@ -55,6 +56,10 @@ def _initializer(
         kwargs = {}
 
     logger.info("Initializing spawned worker child process.")
+
+    # adopt orphans (e.g. Chromium helpers) instead of leaking zombies to PID 1
+    become_child_subreaper()
+
     # 1. Get tenant_id from args or fallback to default
     tenant_id = POSTGRES_DEFAULT_SCHEMA
     for arg in reversed(args):
@@ -93,6 +98,11 @@ def _initializer(
         sys.exit(255)  # use 255 to indicate a generic exception
     finally:
         CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+        # os._exit entrypoints skip this finally and drain themselves
+        reaped = reap_exited_children()
+        if reaped:
+            logger.info("Spawned worker child reaped %s orphaned processes.", reaped)
 
 
 def _run_in_process(

--- a/backend/onyx/utils/os_reaper.py
+++ b/backend/onyx/utils/os_reaper.py
@@ -4,9 +4,13 @@ Chromium helpers orphaned by Playwright teardown re-parent to PID 1 (the
 celery worker, which never wait()s) and accumulate as zombies. Spawned
 connector children mark themselves as the subreaper and drain them instead.
 
-Only call reap_exited_children from a process whose subprocess usage is
-sequential and fully owned — a blanket waitpid(-1) steals exit statuses
-from concurrent waiters.
+Linux-only by nature, not as a shortcut: the pathology exists only where
+PID 1 is a non-reaping worker (our containers). On macOS orphans re-parent
+to launchd, which reaps them.
+
+Only call the drains from a process whose subprocess usage is sequential and
+fully owned — a blanket waitpid(-1) steals exit statuses from concurrent
+waiters.
 """
 
 import os
@@ -136,4 +140,10 @@ def install_sigterm_drain() -> None:
         reap_children_before_exit()
         os._exit(128 + signal.SIGTERM)
 
-    signal.signal(signal.SIGTERM, _drain_and_exit)
+    try:
+        signal.signal(signal.SIGTERM, _drain_and_exit)
+    except (ValueError, OSError):
+        # not the main thread / exotic embedding — child startup must not fail
+        logger.warning(
+            "install_sigterm_drain: could not install handler", exc_info=True
+        )

--- a/backend/onyx/utils/os_reaper.py
+++ b/backend/onyx/utils/os_reaper.py
@@ -1,0 +1,63 @@
+"""Reap orphaned child processes in spawned connector workers (Linux).
+
+Chromium helpers orphaned by Playwright teardown re-parent to PID 1 (the
+celery worker, which never wait()s) and accumulate as zombies. Spawned
+connector children mark themselves as the subreaper and drain them instead.
+
+Only call reap_exited_children from a process whose subprocess usage is
+sequential and fully owned — a blanket waitpid(-1) steals exit statuses
+from concurrent waiters.
+"""
+
+import os
+import sys
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_PR_SET_CHILD_SUBREAPER = 36
+
+
+def become_child_subreaper() -> bool:
+    """Re-parent orphaned descendants to this process instead of PID 1."""
+    if sys.platform != "linux":
+        return False
+
+    try:
+        import ctypes
+
+        libc = ctypes.CDLL(None, use_errno=True)
+        if libc.prctl(_PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0:
+            logger.warning(
+                "become_child_subreaper: prctl failed errno=%s", ctypes.get_errno()
+            )
+            return False
+    except Exception:
+        logger.warning("become_child_subreaper: prctl unavailable", exc_info=True)
+        return False
+
+    return True
+
+
+def reap_exited_children() -> int:
+    """Reap already-exited (zombie) children without blocking; returns count."""
+    if sys.platform != "linux":
+        return 0
+
+    reaped = 0
+    while True:
+        try:
+            pid, _ = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            break  # no children at all
+        except OSError:
+            logger.warning("reap_exited_children: waitpid failed", exc_info=True)
+            break
+
+        if pid == 0:
+            break  # children exist but none have exited
+
+        reaped += 1
+
+    return reaped

--- a/backend/onyx/utils/os_reaper.py
+++ b/backend/onyx/utils/os_reaper.py
@@ -10,7 +10,9 @@ from concurrent waiters.
 """
 
 import os
+import signal
 import sys
+import time
 
 from onyx.utils.logger import setup_logger
 
@@ -59,5 +61,59 @@ def reap_exited_children() -> int:
             break  # children exist but none have exited
 
         reaped += 1
+
+    return reaped
+
+
+def _live_child_pids() -> list[int]:
+    """Direct children (adopted orphans included) that are still running."""
+    me = os.getpid()
+    pids = []
+    for entry in os.listdir("/proc"):
+        if not entry.isdigit():
+            continue
+        try:
+            with open(f"/proc/{entry}/stat") as f:
+                data = f.read()
+            # comm may contain spaces; state and ppid follow the closing paren
+            state, ppid = data[data.rindex(")") + 2 :].split()[:2]
+            if int(ppid) == me and state != "Z":
+                pids.append(int(entry))
+        except (OSError, IndexError, ValueError):
+            continue
+    return pids
+
+
+def reap_children_before_exit(grace_seconds: float = 2.0) -> int:
+    """Exit-path drain: reap exited children, give still-running ones a short
+    grace to finish, then SIGKILL the rest and wait for them. A child left
+    alive at exit would re-parent to PID 1 and zombify there when it dies."""
+    if sys.platform != "linux":
+        return 0
+
+    reaped = reap_exited_children()
+    deadline = time.monotonic() + grace_seconds
+    while _live_child_pids() and time.monotonic() < deadline:
+        time.sleep(0.05)
+        reaped += reap_exited_children()
+
+    stragglers = _live_child_pids()
+    for pid in stragglers:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except OSError:
+            pass
+    if stragglers:
+        logger.warning(
+            "reap_children_before_exit: SIGKILLed %s straggler children",
+            len(stragglers),
+        )
+
+    while True:
+        try:
+            os.waitpid(-1, 0)  # blocking: SIGKILLed children exit promptly
+            reaped += 1
+        except (ChildProcessError, OSError):
+            break
 
     return reaped

--- a/backend/onyx/utils/os_reaper.py
+++ b/backend/onyx/utils/os_reaper.py
@@ -86,8 +86,8 @@ def _live_child_pids() -> list[int]:
 
 def reap_children_before_exit(grace_seconds: float = 2.0) -> int:
     """Exit-path drain: reap exited children, give still-running ones a short
-    grace to finish, then SIGKILL the rest and wait for them. A child left
-    alive at exit would re-parent to PID 1 and zombify there when it dies."""
+    grace to finish, then SIGKILL the rest and reap them. A child left alive
+    at exit would re-parent to PID 1 and zombify there when it dies."""
     if sys.platform != "linux":
         return 0
 
@@ -97,23 +97,43 @@ def reap_children_before_exit(grace_seconds: float = 2.0) -> int:
         time.sleep(0.05)
         reaped += reap_exited_children()
 
-    stragglers = _live_child_pids()
-    for pid in stragglers:
-        try:
-            os.kill(pid, signal.SIGKILL)
-        except OSError:
-            pass
-    if stragglers:
+    # iterate: killing a child re-parents ITS children to us (we are the
+    # subreaper), so new live children can appear mid-kill; bounded hard stop
+    kill_deadline = time.monotonic() + 5.0
+    killed = 0
+    while time.monotonic() < kill_deadline:
+        live = _live_child_pids()
+        if not live:
+            break
+        for pid in live:
+            try:
+                os.kill(pid, signal.SIGKILL)
+                killed += 1
+            except OSError:
+                pass
+        time.sleep(0.05)
+        reaped += reap_exited_children()
+
+    if killed:
         logger.warning(
-            "reap_children_before_exit: SIGKILLed %s straggler children",
-            len(stragglers),
+            "reap_children_before_exit: SIGKILLed %s straggler children", killed
         )
 
-    while True:
-        try:
-            os.waitpid(-1, 0)  # blocking: SIGKILLed children exit promptly
-            reaped += 1
-        except (ChildProcessError, OSError):
-            break
-
+    reaped += reap_exited_children()
     return reaped
+
+
+def install_sigterm_drain() -> None:
+    """Make SIGTERM drain orphans before the process dies (Linux, main thread).
+
+    Watchdogs cancel spawned children with SIGTERM; the default disposition
+    kills the process instantly, stranding adopted zombies and live Chromium
+    descendants on PID 1. Exits 143 after draining."""
+    if sys.platform != "linux":
+        return
+
+    def _drain_and_exit(signum: int, frame: object) -> None:  # noqa: ARG001
+        reap_children_before_exit()
+        os._exit(128 + signal.SIGTERM)
+
+    signal.signal(signal.SIGTERM, _drain_and_exit)

--- a/backend/tests/unit/onyx/utils/test_os_reaper.py
+++ b/backend/tests/unit/onyx/utils/test_os_reaper.py
@@ -4,6 +4,7 @@ The scenario runs in an isolated subprocess so the subreaper flag and the
 waitpid(-1) drain never touch the pytest process: a child orphans a grandchild,
 which must re-parent to the harness (not PID 1) and be drained."""
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -111,6 +112,60 @@ def test_exit_drain_kills_and_reaps_running_orphan() -> None:
     )
     assert result.returncode == 0, result.stderr
     assert "ok" in result.stdout
+
+
+_SIGTERM_HARNESS = """
+import os
+import signal
+import sys
+import time
+
+from onyx.utils.os_reaper import (
+    _live_child_pids,
+    become_child_subreaper,
+    install_sigterm_drain,
+)
+
+assert become_child_subreaper()
+install_sigterm_drain()
+
+# orphan a long-running grandchild, print its pid for the outer test
+child_pid = os.fork()
+if child_pid == 0:
+    grandchild_pid = os.fork()
+    if grandchild_pid == 0:
+        time.sleep(60)
+        os._exit(0)
+    print(grandchild_pid, flush=True)
+    os._exit(0)
+
+os.waitpid(child_pid, 0)
+deadline = time.monotonic() + 10
+while not _live_child_pids() and time.monotonic() < deadline:
+    time.sleep(0.05)
+assert _live_child_pids(), "orphan never re-parented"
+
+os.kill(os.getpid(), signal.SIGTERM)  # watchdog cancellation
+time.sleep(30)  # never reached: the handler drains and exits 143
+"""
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="prctl/waitpid semantics are Linux-only"
+)
+def test_sigterm_cancellation_drains_running_orphan() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _SIGTERM_HARNESS],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={"PYTHONPATH": str(_BACKEND_DIR)},
+    )
+    assert result.returncode == 143, result.stderr
+    orphan_pid = int(result.stdout.split()[0])
+    # the drain must have killed the orphan — not left it running for PID 1
+    with pytest.raises(OSError):
+        os.kill(orphan_pid, 0)
 
 
 def test_reap_exited_children_noop_without_children() -> None:

--- a/backend/tests/unit/onyx/utils/test_os_reaper.py
+++ b/backend/tests/unit/onyx/utils/test_os_reaper.py
@@ -62,6 +62,57 @@ def test_subreaper_adopts_and_drains_orphaned_grandchild() -> None:
     assert "ok" in result.stdout
 
 
+_EXIT_HARNESS = """
+import os
+import sys
+import time
+
+from onyx.utils.os_reaper import (
+    _live_child_pids,
+    become_child_subreaper,
+    reap_children_before_exit,
+)
+
+assert become_child_subreaper(), "prctl(PR_SET_CHILD_SUBREAPER) failed"
+
+# orphan a grandchild that stays RUNNING well past the drain
+child_pid = os.fork()
+if child_pid == 0:
+    grandchild_pid = os.fork()
+    if grandchild_pid == 0:
+        time.sleep(60)
+        os._exit(0)
+    os._exit(0)
+
+os.waitpid(child_pid, 0)
+
+deadline = time.monotonic() + 10
+while not _live_child_pids() and time.monotonic() < deadline:
+    time.sleep(0.05)  # wait for the orphan to re-parent to us
+assert _live_child_pids(), "orphan never re-parented to the subreaper"
+
+reaped = reap_children_before_exit(grace_seconds=0.2)
+assert reaped >= 1, f"expected the running orphan to be killed and reaped, got {reaped}"
+assert not _live_child_pids(), "no running children should remain"
+print("ok")
+"""
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="prctl/waitpid semantics are Linux-only"
+)
+def test_exit_drain_kills_and_reaps_running_orphan() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _EXIT_HARNESS],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={"PYTHONPATH": str(_BACKEND_DIR)},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
 def test_reap_exited_children_noop_without_children() -> None:
     """The drain must be safe to call from a process with no children at all."""
     harness = (

--- a/backend/tests/unit/onyx/utils/test_os_reaper.py
+++ b/backend/tests/unit/onyx/utils/test_os_reaper.py
@@ -1,8 +1,10 @@
 """Validate subreaper adoption + zombie draining (Linux-only).
 
-The scenario runs in an isolated subprocess so the subreaper flag and the
-waitpid(-1) drain never touch the pytest process: a child orphans a grandchild,
-which must re-parent to the harness (not PID 1) and be drained."""
+Each scenario runs in an isolated subprocess so the subreaper flag and the
+waitpid(-1) drains never touch the pytest process. Harnesses end with a
+kill-everything finally so a failed assertion can't leave a sleeping
+grandchild holding the captured stdout/stderr pipes (which would turn the
+real failure into a subprocess timeout)."""
 
 import os
 import subprocess
@@ -13,57 +15,63 @@ import pytest
 
 _BACKEND_DIR = Path(__file__).parents[4]
 
-_HARNESS = """
+_CLEANUP = """
+def _kill_live_children():
+    import os
+    import signal
+
+    from onyx.utils.os_reaper import _live_child_pids, reap_exited_children
+
+    for pid in _live_child_pids():
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except OSError:
+            pass
+    reap_exited_children()
+"""
+
+_HARNESS = (
+    _CLEANUP
+    + """
 import os
 import sys
 import time
 
 from onyx.utils.os_reaper import become_child_subreaper, reap_exited_children
 
-assert become_child_subreaper(), "prctl(PR_SET_CHILD_SUBREAPER) failed"
+try:
+    assert become_child_subreaper(), "prctl(PR_SET_CHILD_SUBREAPER) failed"
 
-child_pid = os.fork()
-if child_pid == 0:
-    # child: orphan a grandchild while it is still running, then exit
-    grandchild_pid = os.fork()
-    if grandchild_pid == 0:
-        time.sleep(0.2)  # outlive the parent so re-parenting happens while alive
+    child_pid = os.fork()
+    if child_pid == 0:
+        # child: orphan a grandchild while it is still running, then exit
+        grandchild_pid = os.fork()
+        if grandchild_pid == 0:
+            time.sleep(0.2)  # outlive the parent so re-parenting happens while alive
+            os._exit(0)
         os._exit(0)
-    os._exit(0)
 
-os.waitpid(child_pid, 0)  # reap the direct child; only the orphan remains
+    os.waitpid(child_pid, 0)  # reap the direct child; only the orphan remains
 
-# the orphaned grandchild re-parents to us (the subreaper) and zombifies on
-# exit; without the subreaper flag it would re-parent to PID 1 and this loop
-# could never observe it
-deadline = time.monotonic() + 10
-reaped = 0
-while reaped == 0 and time.monotonic() < deadline:
-    reaped = reap_exited_children()
-    time.sleep(0.05)
+    # the orphaned grandchild re-parents to us (the subreaper) and zombifies
+    # on exit; without the flag it would re-parent to PID 1 instead
+    deadline = time.monotonic() + 10
+    reaped = 0
+    while reaped == 0 and time.monotonic() < deadline:
+        reaped = reap_exited_children()
+        time.sleep(0.05)
 
-assert reaped == 1, f"expected to reap exactly the orphaned grandchild, got {reaped}"
-assert reap_exited_children() == 0, "no children should remain"
-print("ok")
+    assert reaped == 1, f"expected to reap exactly the orphaned grandchild, got {reaped}"
+    assert reap_exited_children() == 0, "no children should remain"
+    print("ok")
+finally:
+    _kill_live_children()
 """
-
-
-@pytest.mark.skipif(
-    sys.platform != "linux", reason="prctl/waitpid semantics are Linux-only"
 )
-def test_subreaper_adopts_and_drains_orphaned_grandchild() -> None:
-    result = subprocess.run(
-        [sys.executable, "-c", _HARNESS],
-        capture_output=True,
-        text=True,
-        timeout=30,
-        env={"PYTHONPATH": str(_BACKEND_DIR)},
-    )
-    assert result.returncode == 0, result.stderr
-    assert "ok" in result.stdout
 
-
-_EXIT_HARNESS = """
+_EXIT_HARNESS = (
+    _CLEANUP
+    + """
 import os
 import sys
 import time
@@ -74,47 +82,37 @@ from onyx.utils.os_reaper import (
     reap_children_before_exit,
 )
 
-assert become_child_subreaper(), "prctl(PR_SET_CHILD_SUBREAPER) failed"
+try:
+    assert become_child_subreaper(), "prctl(PR_SET_CHILD_SUBREAPER) failed"
 
-# orphan a grandchild that stays RUNNING well past the drain
-child_pid = os.fork()
-if child_pid == 0:
-    grandchild_pid = os.fork()
-    if grandchild_pid == 0:
-        time.sleep(60)
+    # orphan a grandchild that stays RUNNING well past the drain
+    child_pid = os.fork()
+    if child_pid == 0:
+        grandchild_pid = os.fork()
+        if grandchild_pid == 0:
+            time.sleep(60)
+            os._exit(0)
         os._exit(0)
-    os._exit(0)
 
-os.waitpid(child_pid, 0)
+    os.waitpid(child_pid, 0)
 
-deadline = time.monotonic() + 10
-while not _live_child_pids() and time.monotonic() < deadline:
-    time.sleep(0.05)  # wait for the orphan to re-parent to us
-assert _live_child_pids(), "orphan never re-parented to the subreaper"
+    deadline = time.monotonic() + 10
+    while not _live_child_pids() and time.monotonic() < deadline:
+        time.sleep(0.05)  # wait for the orphan to re-parent to us
+    assert _live_child_pids(), "orphan never re-parented to the subreaper"
 
-reaped = reap_children_before_exit(grace_seconds=0.2)
-assert reaped >= 1, f"expected the running orphan to be killed and reaped, got {reaped}"
-assert not _live_child_pids(), "no running children should remain"
-print("ok")
+    reaped = reap_children_before_exit(grace_seconds=0.2)
+    assert reaped >= 1, f"expected the running orphan to be killed and reaped, got {reaped}"
+    assert not _live_child_pids(), "no running children should remain"
+    print("ok")
+finally:
+    _kill_live_children()
 """
-
-
-@pytest.mark.skipif(
-    sys.platform != "linux", reason="prctl/waitpid semantics are Linux-only"
 )
-def test_exit_drain_kills_and_reaps_running_orphan() -> None:
-    result = subprocess.run(
-        [sys.executable, "-c", _EXIT_HARNESS],
-        capture_output=True,
-        text=True,
-        timeout=30,
-        env={"PYTHONPATH": str(_BACKEND_DIR)},
-    )
-    assert result.returncode == 0, result.stderr
-    assert "ok" in result.stdout
 
-
-_SIGTERM_HARNESS = """
+_SIGTERM_HARNESS = (
+    _CLEANUP
+    + """
 import os
 import signal
 import sys
@@ -126,41 +124,67 @@ from onyx.utils.os_reaper import (
     install_sigterm_drain,
 )
 
-assert become_child_subreaper()
-install_sigterm_drain()
+try:
+    assert become_child_subreaper()
+    install_sigterm_drain()
 
-# orphan a long-running grandchild, print its pid for the outer test
-child_pid = os.fork()
-if child_pid == 0:
-    grandchild_pid = os.fork()
-    if grandchild_pid == 0:
-        time.sleep(60)
+    # orphan a long-running grandchild, print its pid for the outer test
+    child_pid = os.fork()
+    if child_pid == 0:
+        grandchild_pid = os.fork()
+        if grandchild_pid == 0:
+            time.sleep(60)
+            os._exit(0)
+        print(grandchild_pid, flush=True)
         os._exit(0)
-    print(grandchild_pid, flush=True)
-    os._exit(0)
 
-os.waitpid(child_pid, 0)
-deadline = time.monotonic() + 10
-while not _live_child_pids() and time.monotonic() < deadline:
-    time.sleep(0.05)
-assert _live_child_pids(), "orphan never re-parented"
+    os.waitpid(child_pid, 0)
+    deadline = time.monotonic() + 10
+    while not _live_child_pids() and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert _live_child_pids(), "orphan never re-parented"
 
-os.kill(os.getpid(), signal.SIGTERM)  # watchdog cancellation
-time.sleep(30)  # never reached: the handler drains and exits 143
+    os.kill(os.getpid(), signal.SIGTERM)  # watchdog cancellation
+    time.sleep(30)  # never reached: the handler drains and exits 143
+finally:
+    _kill_live_children()
 """
+)
+
+
+def _run_harness(code: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={"PYTHONPATH": str(_BACKEND_DIR)},
+    )
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="prctl/waitpid semantics are Linux-only"
+)
+def test_subreaper_adopts_and_drains_orphaned_grandchild() -> None:
+    result = _run_harness(_HARNESS)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="prctl/waitpid semantics are Linux-only"
+)
+def test_exit_drain_kills_and_reaps_running_orphan() -> None:
+    result = _run_harness(_EXIT_HARNESS)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
 
 
 @pytest.mark.skipif(
     sys.platform != "linux", reason="prctl/waitpid semantics are Linux-only"
 )
 def test_sigterm_cancellation_drains_running_orphan() -> None:
-    result = subprocess.run(
-        [sys.executable, "-c", _SIGTERM_HARNESS],
-        capture_output=True,
-        text=True,
-        timeout=30,
-        env={"PYTHONPATH": str(_BACKEND_DIR)},
-    )
+    result = _run_harness(_SIGTERM_HARNESS)
     assert result.returncode == 143, result.stderr
     orphan_pid = int(result.stdout.split()[0])
     # the drain must have killed the orphan — not left it running for PID 1
@@ -175,12 +199,6 @@ def test_reap_exited_children_noop_without_children() -> None:
         "assert reap_exited_children() == 0\n"
         "print('ok')\n"
     )
-    result = subprocess.run(
-        [sys.executable, "-c", harness],
-        capture_output=True,
-        text=True,
-        timeout=30,
-        env={"PYTHONPATH": str(_BACKEND_DIR)},
-    )
+    result = _run_harness(harness)
     assert result.returncode == 0, result.stderr
     assert "ok" in result.stdout

--- a/backend/tests/unit/onyx/utils/test_os_reaper.py
+++ b/backend/tests/unit/onyx/utils/test_os_reaper.py
@@ -1,0 +1,80 @@
+"""Validate subreaper adoption + zombie draining (Linux-only).
+
+The scenario runs in an isolated subprocess so the subreaper flag and the
+waitpid(-1) drain never touch the pytest process: a child orphans a grandchild,
+which must re-parent to the harness (not PID 1) and be drained."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND_DIR = Path(__file__).parents[4]
+
+_HARNESS = """
+import os
+import sys
+import time
+
+from onyx.utils.os_reaper import become_child_subreaper, reap_exited_children
+
+assert become_child_subreaper(), "prctl(PR_SET_CHILD_SUBREAPER) failed"
+
+child_pid = os.fork()
+if child_pid == 0:
+    # child: orphan a grandchild while it is still running, then exit
+    grandchild_pid = os.fork()
+    if grandchild_pid == 0:
+        time.sleep(0.2)  # outlive the parent so re-parenting happens while alive
+        os._exit(0)
+    os._exit(0)
+
+os.waitpid(child_pid, 0)  # reap the direct child; only the orphan remains
+
+# the orphaned grandchild re-parents to us (the subreaper) and zombifies on
+# exit; without the subreaper flag it would re-parent to PID 1 and this loop
+# could never observe it
+deadline = time.monotonic() + 10
+reaped = 0
+while reaped == 0 and time.monotonic() < deadline:
+    reaped = reap_exited_children()
+    time.sleep(0.05)
+
+assert reaped == 1, f"expected to reap exactly the orphaned grandchild, got {reaped}"
+assert reap_exited_children() == 0, "no children should remain"
+print("ok")
+"""
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="prctl/waitpid semantics are Linux-only"
+)
+def test_subreaper_adopts_and_drains_orphaned_grandchild() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _HARNESS],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={"PYTHONPATH": str(_BACKEND_DIR)},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_reap_exited_children_noop_without_children() -> None:
+    """The drain must be safe to call from a process with no children at all."""
+    harness = (
+        "from onyx.utils.os_reaper import reap_exited_children\n"
+        "assert reap_exited_children() == 0\n"
+        "print('ok')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", harness],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={"PYTHONPATH": str(_BACKEND_DIR)},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Description

Fixes the zombie-pid leak in workers that run Playwright: every Chromium browser teardown orphans ~2 helper processes, which re-parent to the container's PID 1 (the celery worker, which never `wait()`s) and stay zombies forever. Measured on the deployed image (`v4.5.0-cloud.4-dev`): exactly 2 zombies per browser cycle; live fleet pods today show 3,693 and **8,082 zombies** (of 8,093 pids) on heavy workers mid-crawl, and ~100 per docfetching pod.

The fix: spawned connector children (`SimpleJobClient._initializer`) mark themselves as a Linux child subreaper, so orphaned descendants re-parent to the child instead of PID 1, and drain them on every exit path:

- normal exit (`_initializer`'s `finally`, plus the `os._exit(0)` path in docfetching which skips it): reap exited children, give still-running strays a short grace, then SIGKILL and reap the rest — iterating, since killing a child re-parents *its* children to us;
- watchdog cancellation: a SIGTERM handler runs the same drain before exiting 143, so `terminate_and_wait` no longer strands adopted zombies or live Chromium descendants on PID 1.

`waitpid(-1)` is only safe from processes with fully-owned sequential subprocess usage; that contract is documented in `os_reaper.py` and the drain is deliberately not added to any worker main.

Split out of the ENG-4309 work so it can land independently; the enumeration-spawn PR (#13831) stacks on this branch and covers the memory-ramp half.

Linear: [ENG-4309](https://linear.app/onyx-app/issue/ENG-4309/web-connector-pruning-accumulates-memory-across-long-playwright-crawls)

## How Has This Been Tested?

- In-image A/B through `SimpleJobClient` with this process as container PID 1 (mimicking celery): 3 Playwright browser cycles in the child leak **6 zombies** to PID 1 on deployed code, **0** with this branch.
- New unit tests `test_os_reaper.py` (subprocess-isolated harnesses, Linux-only; all verified in-image, run in CI): subreaper adopts and drains an orphaned grandchild; the exit drain kills and reaps a still-*running* orphan; SIGTERM cancellation drains a running orphan and exits 143; no-children safety case.
- Full unit suite: no new failures vs an origin/main baseline.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
