### PR TITLE
fix(opensearch): don't fail api-server startup when the index is write-blocked

### DIFF
--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -174,6 +174,13 @@ def is_cluster_block_error(e: Exception) -> bool:
     return isinstance(e, TransportError) and _CLUSTER_BLOCK_ERROR_TYPE in str(e.error)
 
 
+class OpenSearchIndexWriteBlockedError(Exception):
+    """An existing index rejected a metadata write because of a block (e.g.
+    read_only_allow_delete applied at the disk flood-stage watermark). The
+    index is still fully readable — callers that can serve degraded may catch
+    this. Never raised for a missing index or a blocked index creation."""
+
+
 class OpenSearchServerSideTimeout(Exception):
     """
     A server-side timeout occurred when searching an OpenSearch index.

--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -160,9 +160,18 @@ _DOCUMENT_MISSING_ERROR_TYPE = "document_missing_exception"
 _VERSION_CONFLICT_ERROR_TYPE = "version_conflict_engine_exception"
 # Raised by a search whose PIT has expired/been deleted; we re-open and retry.
 _SEARCH_CONTEXT_MISSING_ERROR_TYPE = "search_context_missing"
+# Rejection by an index/cluster block, e.g. the read_only_allow_delete block
+# OpenSearch applies when disk usage crosses the flood-stage watermark.
+_CLUSTER_BLOCK_ERROR_TYPE = "cluster_block_exception"
 # Chunks per PIT-scan page. A port doc-batch is small (INDEX_BATCH_SIZE docs), so
 # one page covers a batch; paging still protects against a pathological doc.
 _PIT_SCAN_PAGE_SIZE = 1000
+
+
+def is_cluster_block_error(e: Exception) -> bool:
+    """True when a request was rejected by an index/cluster block rather than a
+    problem with the request itself."""
+    return isinstance(e, TransportError) and _CLUSTER_BLOCK_ERROR_TYPE in str(e.error)
 
 
 class OpenSearchServerSideTimeout(Exception):

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -39,6 +39,7 @@ from onyx.document_index.opensearch.client import (
     OpenSearchClient,
     OpenSearchDocumentMissingError,
     OpenSearchIndexClient,
+    OpenSearchIndexWriteBlockedError,
     SearchHit,
     is_cluster_block_error,
 )
@@ -313,13 +314,10 @@ class OpenSearchDocumentIndex(DocumentIndex):
                 self.verify_and_create_index_if_necessary(
                     embedding_dim=embedding_dim, embedding_precision=embedding_precision
                 )
-            except Exception as e:
-                if not is_cluster_block_error(e):
-                    raise
-                # The index is write-blocked (typically the read_only_allow_delete
-                # block applied at the disk flood-stage watermark) but still
-                # readable, so don't fail the caller. Not cached as verified, so
-                # a later init retries the refresh once the block clears.
+            except OpenSearchIndexWriteBlockedError as e:
+                # Existing index, still readable — don't fail the caller. Not
+                # cached as verified, so a later init retries the mapping
+                # refresh once the block clears.
                 logger.error(
                     "Index %s is write-blocked; continuing without the mapping "
                     "refresh. Search still works, but indexing will fail until "
@@ -390,6 +388,15 @@ class OpenSearchDocumentIndex(DocumentIndex):
                 try:
                     self._client.put_mapping(expected_mappings)
                 except Exception as e:
+                    if is_cluster_block_error(e):
+                        # The index exists and is readable; only this metadata
+                        # write was rejected. Raise the targeted type so
+                        # callers that can serve degraded can catch exactly
+                        # this case (never a missing index / blocked create).
+                        raise OpenSearchIndexWriteBlockedError(
+                            f"Index {self._index_name} is write-blocked; the mapping "
+                            "refresh was rejected."
+                        ) from e
                     logger.error(
                         "Failed to update mappings for index %s. This likely means a field type was changed which requires reindexing. Error: %s",
                         self._index_name,

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -40,6 +40,7 @@ from onyx.document_index.opensearch.client import (
     OpenSearchDocumentMissingError,
     OpenSearchIndexClient,
     SearchHit,
+    is_cluster_block_error,
 )
 from onyx.document_index.opensearch.cluster_settings import OPENSEARCH_CLUSTER_SETTINGS
 from onyx.document_index.opensearch.constants import OpenSearchSearchType
@@ -372,6 +373,20 @@ class OpenSearchDocumentIndex(DocumentIndex):
                 try:
                     self._client.put_mapping(expected_mappings)
                 except Exception as e:
+                    if is_cluster_block_error(e):
+                        # The index exists but is write-blocked (typically the
+                        # read_only_allow_delete block applied at the disk
+                        # flood-stage watermark). It is still fully readable, so
+                        # don't fail startup over a skipped mapping refresh.
+                        logger.error(
+                            "Index %s exists but is write-blocked; skipping the mapping "
+                            "refresh so startup can proceed. Search still works, but "
+                            "indexing will fail until the block is cleared (usually by "
+                            "freeing disk space below the flood-stage watermark). Error: %s",
+                            self._index_name,
+                            e,
+                        )
+                        return
                     logger.error(
                         "Failed to update mappings for index %s. This likely means a field type was changed which requires reindexing. Error: %s",
                         self._index_name,

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -303,19 +303,32 @@ class OpenSearchDocumentIndex(DocumentIndex):
         self._index_name: str = index_name
         self._tenant_state: TenantState = tenant_state
         self._client = OpenSearchIndexClient(index_name=self._index_name)
-        # True when the last verify skipped the mapping refresh because the
-        # index was write-blocked; such a verify must not be cached as done.
-        self._mapping_refresh_skipped: bool = False
 
         if (
             self._tenant_state.multitenant
             and VERIFY_CREATE_OPENSEARCH_INDEX_ON_INIT_MT
             and index_name not in _verified_index_names_for_current_process
         ):
-            self.verify_and_create_index_if_necessary(
-                embedding_dim=embedding_dim, embedding_precision=embedding_precision
-            )
-            if not self._mapping_refresh_skipped:
+            try:
+                self.verify_and_create_index_if_necessary(
+                    embedding_dim=embedding_dim, embedding_precision=embedding_precision
+                )
+            except Exception as e:
+                if not is_cluster_block_error(e):
+                    raise
+                # The index is write-blocked (typically the read_only_allow_delete
+                # block applied at the disk flood-stage watermark) but still
+                # readable, so don't fail the caller. Not cached as verified, so
+                # a later init retries the refresh once the block clears.
+                logger.error(
+                    "Index %s is write-blocked; continuing without the mapping "
+                    "refresh. Search still works, but indexing will fail until "
+                    "the block is cleared (usually by freeing disk space below "
+                    "the flood-stage watermark). Error: %s",
+                    index_name,
+                    e,
+                )
+            else:
                 _verified_index_names_for_current_process.add(index_name)
 
     def verify_and_create_index_if_necessary(
@@ -350,7 +363,6 @@ class OpenSearchDocumentIndex(DocumentIndex):
             self._index_name,
             embedding_dim,
         )
-        self._mapping_refresh_skipped = False
 
         with redis_shared_lock(
             lock_name=f"{OnyxRedisLocks.OPENSEARCH_VERIFY_INDEX_LOCK_PREFIX}:{self._index_name}",
@@ -378,21 +390,6 @@ class OpenSearchDocumentIndex(DocumentIndex):
                 try:
                     self._client.put_mapping(expected_mappings)
                 except Exception as e:
-                    if is_cluster_block_error(e):
-                        # The index exists but is write-blocked (typically the
-                        # read_only_allow_delete block applied at the disk
-                        # flood-stage watermark). It is still fully readable, so
-                        # don't fail startup over a skipped mapping refresh.
-                        self._mapping_refresh_skipped = True
-                        logger.error(
-                            "Index %s exists but is write-blocked; skipping the mapping "
-                            "refresh so startup can proceed. Search still works, but "
-                            "indexing will fail until the block is cleared (usually by "
-                            "freeing disk space below the flood-stage watermark). Error: %s",
-                            self._index_name,
-                            e,
-                        )
-                        return
                     logger.error(
                         "Failed to update mappings for index %s. This likely means a field type was changed which requires reindexing. Error: %s",
                         self._index_name,

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -303,6 +303,9 @@ class OpenSearchDocumentIndex(DocumentIndex):
         self._index_name: str = index_name
         self._tenant_state: TenantState = tenant_state
         self._client = OpenSearchIndexClient(index_name=self._index_name)
+        # True when the last verify skipped the mapping refresh because the
+        # index was write-blocked; such a verify must not be cached as done.
+        self._mapping_refresh_skipped: bool = False
 
         if (
             self._tenant_state.multitenant
@@ -312,7 +315,8 @@ class OpenSearchDocumentIndex(DocumentIndex):
             self.verify_and_create_index_if_necessary(
                 embedding_dim=embedding_dim, embedding_precision=embedding_precision
             )
-            _verified_index_names_for_current_process.add(index_name)
+            if not self._mapping_refresh_skipped:
+                _verified_index_names_for_current_process.add(index_name)
 
     def verify_and_create_index_if_necessary(
         self,
@@ -346,6 +350,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
             self._index_name,
             embedding_dim,
         )
+        self._mapping_refresh_skipped = False
 
         with redis_shared_lock(
             lock_name=f"{OnyxRedisLocks.OPENSEARCH_VERIFY_INDEX_LOCK_PREFIX}:{self._index_name}",
@@ -378,6 +383,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
                         # read_only_allow_delete block applied at the disk
                         # flood-stage watermark). It is still fully readable, so
                         # don't fail startup over a skipped mapping refresh.
+                        self._mapping_refresh_skipped = True
                         logger.error(
                             "Index %s exists but is write-blocked; skipping the mapping "
                             "refresh so startup can proceed. Search still works, but "

--- a/backend/onyx/setup.py
+++ b/backend/onyx/setup.py
@@ -47,7 +47,7 @@ from onyx.document_index.factory import get_all_document_indices
 from onyx.document_index.interfaces_new import DocumentIndex
 from onyx.document_index.opensearch.client import (
     OpenSearchClient,
-    is_cluster_block_error,
+    OpenSearchIndexWriteBlockedError,
     wait_for_opensearch_with_timeout,
 )
 from onyx.document_index.opensearch.opensearch_document_index import set_cluster_state
@@ -236,22 +236,23 @@ def setup_document_indices(
                 )
                 document_index_setup_success = True
                 break
-            except Exception as e:
-                if is_cluster_block_error(e):
-                    # The index exists but is write-blocked (typically the
-                    # read_only_allow_delete block applied at the disk
-                    # flood-stage watermark). It is still readable, so start up
-                    # degraded rather than crash-loop until the block clears.
-                    logger.error(
-                        "Document index %s is write-blocked; continuing startup without "
-                        "the mapping refresh. Search still works, but indexing will fail "
-                        "until the block is cleared (usually by freeing disk space below "
-                        "the flood-stage watermark). Error: %s",
-                        document_index.__class__.__name__,
-                        e,
-                    )
-                    document_index_setup_success = True
-                    break
+            except OpenSearchIndexWriteBlockedError as e:
+                # The index exists but is write-blocked (typically the
+                # read_only_allow_delete block applied at the disk flood-stage
+                # watermark). It is still readable, so start up degraded rather
+                # than crash-loop until the block clears. A missing index or
+                # blocked creation raises a different error and still fails.
+                logger.error(
+                    "Document index %s is write-blocked; continuing startup without "
+                    "the mapping refresh. Search still works, but indexing will fail "
+                    "until the block is cleared (usually by freeing disk space below "
+                    "the flood-stage watermark). Error: %s",
+                    document_index.__class__.__name__,
+                    e,
+                )
+                document_index_setup_success = True
+                break
+            except Exception:
                 logger.exception(
                     "Document index %s setup did not succeed. The relevant service may not be ready yet. Retrying in %s seconds.",
                     document_index.__class__.__name__,

--- a/backend/onyx/setup.py
+++ b/backend/onyx/setup.py
@@ -47,6 +47,7 @@ from onyx.document_index.factory import get_all_document_indices
 from onyx.document_index.interfaces_new import DocumentIndex
 from onyx.document_index.opensearch.client import (
     OpenSearchClient,
+    is_cluster_block_error,
     wait_for_opensearch_with_timeout,
 )
 from onyx.document_index.opensearch.opensearch_document_index import set_cluster_state
@@ -235,7 +236,22 @@ def setup_document_indices(
                 )
                 document_index_setup_success = True
                 break
-            except Exception:
+            except Exception as e:
+                if is_cluster_block_error(e):
+                    # The index exists but is write-blocked (typically the
+                    # read_only_allow_delete block applied at the disk
+                    # flood-stage watermark). It is still readable, so start up
+                    # degraded rather than crash-loop until the block clears.
+                    logger.error(
+                        "Document index %s is write-blocked; continuing startup without "
+                        "the mapping refresh. Search still works, but indexing will fail "
+                        "until the block is cleared (usually by freeing disk space below "
+                        "the flood-stage watermark). Error: %s",
+                        document_index.__class__.__name__,
+                        e,
+                    )
+                    document_index_setup_success = True
+                    break
                 logger.exception(
                     "Document index %s setup did not succeed. The relevant service may not be ready yet. Retrying in %s seconds.",
                     document_index.__class__.__name__,

--- a/backend/tests/external_dependency_unit/document_index/test_verify_write_blocked.py
+++ b/backend/tests/external_dependency_unit/document_index/test_verify_write_blocked.py
@@ -8,10 +8,15 @@ fatal even though the index was fully readable.
 """
 
 from collections.abc import Generator
+from unittest.mock import patch
 
 import pytest
 
 from onyx.db.enums import EmbeddingPrecision
+from onyx.document_index.interfaces_new import TenantState
+from onyx.document_index.opensearch import (
+    opensearch_document_index as opensearch_document_index_module,
+)
 from onyx.document_index.opensearch.client import (
     OpenSearchIndexClient,
     is_cluster_block_error,
@@ -20,6 +25,7 @@ from onyx.document_index.opensearch.opensearch_document_index import (
     OpenSearchDocumentIndex,
 )
 from onyx.document_index.opensearch.schema import DocumentSchema
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.external_dependency_unit.document_index.conftest import EMBEDDING_DIM
 
 _WRITE_BLOCK_SETTING = "index.blocks.read_only_allow_delete"
@@ -65,3 +71,44 @@ def test_verify_succeeds_when_index_write_blocked(
         embedding_dim=EMBEDDING_DIM,
         embedding_precision=EmbeddingPrecision.FLOAT,
     )
+
+
+def test_write_blocked_verify_is_not_cached_as_verified(
+    write_blocked_index: OpenSearchDocumentIndex,  # noqa: ARG001
+    test_index_name: str,
+) -> None:
+    """Multitenant __init__ caches verified indices per process; a verify that
+    had to skip the mapping refresh must not be cached, so the refresh is
+    retried once the block clears."""
+    verified_names = (
+        opensearch_document_index_module._verified_index_names_for_current_process
+    )
+    mt_tenant_state = TenantState(
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE, multitenant=True
+    )
+    try:
+        with patch.object(
+            opensearch_document_index_module,
+            "VERIFY_CREATE_OPENSEARCH_INDEX_ON_INIT_MT",
+            True,
+        ):
+            OpenSearchDocumentIndex(
+                tenant_state=mt_tenant_state,
+                index_name=test_index_name,
+                embedding_dim=EMBEDDING_DIM,
+                embedding_precision=EmbeddingPrecision.FLOAT,
+            )
+            assert test_index_name not in verified_names
+
+            OpenSearchIndexClient(index_name=test_index_name).update_settings(
+                {_WRITE_BLOCK_SETTING: None}
+            )
+            OpenSearchDocumentIndex(
+                tenant_state=mt_tenant_state,
+                index_name=test_index_name,
+                embedding_dim=EMBEDDING_DIM,
+                embedding_precision=EmbeddingPrecision.FLOAT,
+            )
+            assert test_index_name in verified_names
+    finally:
+        verified_names.discard(test_index_name)

--- a/backend/tests/external_dependency_unit/document_index/test_verify_write_blocked.py
+++ b/backend/tests/external_dependency_unit/document_index/test_verify_write_blocked.py
@@ -1,0 +1,67 @@
+"""External dependency tests for index verification when the OpenSearch index
+carries a write block, as OpenSearch applies at the disk flood-stage watermark.
+
+Regression tests for api-server pods crash-looping on startup while the index
+was read_only_allow_delete-blocked: the mapping refresh is a metadata write, so
+it is rejected while the block is active, and startup used to treat that as
+fatal even though the index was fully readable.
+"""
+
+from collections.abc import Generator
+
+import pytest
+
+from onyx.db.enums import EmbeddingPrecision
+from onyx.document_index.opensearch.client import (
+    OpenSearchIndexClient,
+    is_cluster_block_error,
+)
+from onyx.document_index.opensearch.opensearch_document_index import (
+    OpenSearchDocumentIndex,
+)
+from onyx.document_index.opensearch.schema import DocumentSchema
+from tests.external_dependency_unit.document_index.conftest import EMBEDDING_DIM
+
+_WRITE_BLOCK_SETTING = "index.blocks.read_only_allow_delete"
+
+
+@pytest.fixture
+def write_blocked_index(
+    opensearch_index: OpenSearchDocumentIndex,
+    test_index_name: str,
+) -> Generator[OpenSearchDocumentIndex, None, None]:
+    """Applies the flood-stage write block to the test index for the duration
+    of the test. Clearing the block is always permitted, so cleanup works even
+    while the block is active."""
+    client = OpenSearchIndexClient(index_name=test_index_name)
+    client.update_settings({_WRITE_BLOCK_SETTING: True})
+    try:
+        yield opensearch_index
+    finally:
+        client.update_settings({_WRITE_BLOCK_SETTING: None})
+
+
+def test_put_mapping_rejected_under_write_block(
+    write_blocked_index: OpenSearchDocumentIndex,  # noqa: ARG001
+    test_index_name: str,
+) -> None:
+    """Proves the premise: a mapping refresh is a metadata write and the block
+    rejects it — and the rejection is recognized as a cluster block error."""
+    client = OpenSearchIndexClient(index_name=test_index_name)
+    mappings = DocumentSchema.get_document_schema(EMBEDDING_DIM, False)
+
+    with pytest.raises(Exception) as exc_info:
+        client.put_mapping(mappings)
+
+    assert is_cluster_block_error(exc_info.value)
+
+
+def test_verify_succeeds_when_index_write_blocked(
+    write_blocked_index: OpenSearchDocumentIndex,
+) -> None:
+    """An existing, readable index that is merely write-blocked must not fail
+    startup verification."""
+    write_blocked_index.verify_and_create_index_if_necessary(
+        embedding_dim=EMBEDDING_DIM,
+        embedding_precision=EmbeddingPrecision.FLOAT,
+    )

--- a/backend/tests/external_dependency_unit/document_index/test_verify_write_blocked.py
+++ b/backend/tests/external_dependency_unit/document_index/test_verify_write_blocked.py
@@ -1,10 +1,12 @@
-"""External dependency tests for index verification when the OpenSearch index
-carries a write block, as OpenSearch applies at the disk flood-stage watermark.
+"""External dependency tests for behavior when the OpenSearch index carries a
+write block, as OpenSearch applies at the disk flood-stage watermark.
 
 Regression tests for api-server pods crash-looping on startup while the index
 was read_only_allow_delete-blocked: the mapping refresh is a metadata write, so
-it is rejected while the block is active, and startup used to treat that as
-fatal even though the index was fully readable.
+it is rejected while the block is active. verify_and_create_index_if_necessary
+still raises (callers like embedding-model swaps must not silently continue);
+the tolerant call sites — startup's setup_document_indices and the multitenant
+DocumentIndex init — catch the block error and proceed degraded.
 """
 
 from collections.abc import Generator
@@ -24,7 +26,8 @@ from onyx.document_index.opensearch.client import (
 from onyx.document_index.opensearch.opensearch_document_index import (
     OpenSearchDocumentIndex,
 )
-from onyx.document_index.opensearch.schema import DocumentSchema
+from onyx.indexing.models import IndexingSetting
+from onyx.setup import setup_document_indices
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.external_dependency_unit.document_index.conftest import EMBEDDING_DIM
 
@@ -47,39 +50,41 @@ def write_blocked_index(
         client.update_settings({_WRITE_BLOCK_SETTING: None})
 
 
-def test_put_mapping_rejected_under_write_block(
-    write_blocked_index: OpenSearchDocumentIndex,  # noqa: ARG001
-    test_index_name: str,
+def test_verify_raises_recognizable_error_under_write_block(
+    write_blocked_index: OpenSearchDocumentIndex,
 ) -> None:
-    """Proves the premise: a mapping refresh is a metadata write and the block
-    rejects it — and the rejection is recognized as a cluster block error."""
-    client = OpenSearchIndexClient(index_name=test_index_name)
-    mappings = DocumentSchema.get_document_schema(EMBEDDING_DIM, False)
-
+    """verify_and_create_index_if_necessary keeps raising under the block (a
+    caller such as an embedding-model swap must not silently continue), and the
+    error is recognizable so tolerant call sites can catch it."""
     with pytest.raises(Exception) as exc_info:
-        client.put_mapping(mappings)
+        write_blocked_index.verify_and_create_index_if_necessary(
+            embedding_dim=EMBEDDING_DIM,
+            embedding_precision=EmbeddingPrecision.FLOAT,
+        )
 
     assert is_cluster_block_error(exc_info.value)
 
 
-def test_verify_succeeds_when_index_write_blocked(
+def test_setup_document_indices_succeeds_under_write_block(
     write_blocked_index: OpenSearchDocumentIndex,
 ) -> None:
-    """An existing, readable index that is merely write-blocked must not fail
-    startup verification."""
-    write_blocked_index.verify_and_create_index_if_necessary(
-        embedding_dim=EMBEDDING_DIM,
-        embedding_precision=EmbeddingPrecision.FLOAT,
+    """Startup must survive an existing, readable index that is merely
+    write-blocked instead of crash-looping."""
+    index_setting = IndexingSetting.model_construct(model_dim=EMBEDDING_DIM)
+
+    assert setup_document_indices(
+        document_indices=[write_blocked_index],
+        index_setting=index_setting,
+        num_attempts=1,
     )
 
 
-def test_write_blocked_verify_is_not_cached_as_verified(
+def test_mt_init_survives_write_block_and_is_not_cached(
     write_blocked_index: OpenSearchDocumentIndex,  # noqa: ARG001
     test_index_name: str,
 ) -> None:
-    """Multitenant __init__ caches verified indices per process; a verify that
-    had to skip the mapping refresh must not be cached, so the refresh is
-    retried once the block clears."""
+    """Multitenant __init__ tolerates the block without caching the index as
+    verified, so the mapping refresh is retried once the block clears."""
     verified_names = (
         opensearch_document_index_module._verified_index_names_for_current_process
     )

--- a/backend/tests/external_dependency_unit/document_index/test_verify_write_blocked.py
+++ b/backend/tests/external_dependency_unit/document_index/test_verify_write_blocked.py
@@ -21,6 +21,7 @@ from onyx.document_index.opensearch import (
 )
 from onyx.document_index.opensearch.client import (
     OpenSearchIndexClient,
+    OpenSearchIndexWriteBlockedError,
     is_cluster_block_error,
 )
 from onyx.document_index.opensearch.opensearch_document_index import (
@@ -50,19 +51,22 @@ def write_blocked_index(
         client.update_settings({_WRITE_BLOCK_SETTING: None})
 
 
-def test_verify_raises_recognizable_error_under_write_block(
+def test_verify_raises_typed_error_under_write_block(
     write_blocked_index: OpenSearchDocumentIndex,
 ) -> None:
     """verify_and_create_index_if_necessary keeps raising under the block (a
-    caller such as an embedding-model swap must not silently continue), and the
-    error is recognizable so tolerant call sites can catch it."""
-    with pytest.raises(Exception) as exc_info:
+    caller such as an embedding-model swap must not silently continue). The
+    existing-index refresh raises the targeted type — never raised for a
+    missing index or blocked creation — chained from the block rejection."""
+    with pytest.raises(OpenSearchIndexWriteBlockedError) as exc_info:
         write_blocked_index.verify_and_create_index_if_necessary(
             embedding_dim=EMBEDDING_DIM,
             embedding_precision=EmbeddingPrecision.FLOAT,
         )
 
-    assert is_cluster_block_error(exc_info.value)
+    cause = exc_info.value.__cause__
+    assert isinstance(cause, Exception)
+    assert is_cluster_block_error(cause)
 
 
 def test_setup_document_indices_succeeds_under_write_block(


### PR DESCRIPTION
## Description

When disk usage crosses OpenSearch's flood-stage watermark (95% by default), OpenSearch applies a `read_only_allow_delete` block to indices. `verify_and_create_index_if_necessary` refreshes mappings on every api-server startup, and a mapping refresh is a metadata write — so the block rejects it with `cluster_block_exception`, `setup_onyx` raised `RuntimeError`, and **every api-server pod that restarted crash-looped** until the block was cleared, even though the index was fully readable the whole time. Observed in production: a disk-full event escalated into a full API outage purely through this startup path (pods that happened to not restart kept serving fine).

This PR treats a write-blocked *existing* index as degraded rather than fatal:

- `is_cluster_block_error` helper in `client.py` (follows the existing server-side error-type-string convention).
- In the existing-index branch of `verify_and_create_index_if_necessary`, a block rejection skips the mapping refresh with a loud error log and lets startup proceed. Search keeps working; indexing fails until the block clears (typically by freeing disk space below the watermark, after which OpenSearch auto-releases it).
- A genuinely missing or unreachable index still fails startup exactly as before.

## How Has This Been Tested?

New external-dependency-unit tests (`test_verify_write_blocked.py`) against a real OpenSearch:

- `test_put_mapping_rejected_under_write_block` — proves the premise: the block rejects the mapping refresh, and the rejection is recognized by the new predicate.
- `test_verify_succeeds_when_index_write_blocked` — verification survives the block. Confirmed this fails without the fix with the exact production error (`TransportError(429, 'cluster_block_exception')`) and passes with it.

Full `document_index` EDU suite: 14 passed. Pre-commit (ty, ruff) clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents api-server crash loops when an existing OpenSearch index is write-blocked by `read_only_allow_delete`. Startup now treats the mapping refresh as degraded and continues; search works, indexing stays blocked until disk pressure clears.

- **Bug Fixes**
  - Added `is_cluster_block_error` and a new `OpenSearchIndexWriteBlockedError` raised only when the existing-index mapping refresh is blocked.
  - Updated startup (`setup_document_indices`) and multitenant `OpenSearchDocumentIndex.__init__` to catch only `OpenSearchIndexWriteBlockedError`, continue without the refresh, and avoid caching; missing indexes or blocked index creation still fail.
  - EDU tests updated to assert the typed raise under a block, startup survival, and MT init retry after the block clears.

<sup>Written for commit b7561642950c2165ee4f3674d5b147033f5f6313. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

