### PR TITLE
fix(helm): route /scim to api server in ingress mode

### DIFF
--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -24,16 +24,18 @@ When hardcoding a boolean variable to a constant value, remove the variable enti
 
 Code changes must consider both multi-tenant and single-tenant deployments. In multi-tenant mode, preserve tenant isolation, ensure tenant context is propagated correctly, and avoid assumptions that only hold for a single shared schema or globally shared state. In single-tenant mode, avoid introducing unnecessary tenant-specific requirements or cloud-only control-plane dependencies.
 
-## Nginx Routing — New Backend Routes
+## Routing for New Non-/api Backend Routes
 
-Whenever a new backend route is added that does NOT start with `/api`, it must also be explicitly added to ALL nginx configs:
+Whenever a new backend route is added that does NOT start with `/api`, it must be explicitly routed in ALL nginx configs:
 
-- `deployment/helm/charts/onyx/templates/nginx-conf.yaml` (Helm/k8s)
+- `deployment/helm/charts/onyx/templates/nginx-conf.yaml` (Helm/k8s, bundled nginx)
 - `deployment/data/nginx/app.conf.template` (docker-compose dev)
 - `deployment/data/nginx/app.conf.template.prod` (docker-compose prod)
 - `deployment/data/nginx/app.conf.template.no-letsencrypt` (docker-compose no-letsencrypt)
 
-Routes not starting with `/api` are not caught by the existing `^/(api|openapi\.json)` location block and will fall through to `location /`, which proxies to the Next.js web server and returns an HTML 404. The new location block must be placed before the `/api` block. Examples of routes that need this treatment: `/scim`, `/mcp`.
+Routes not starting with `/api` are not caught by the existing `^/(api|openapi\.json)` location block and will fall through to `location /`, which proxies to the Next.js web server and returns an HTML 404. In the nginx configs, the new location block must be placed before the `/api` block. Examples of routes that need this treatment: `/scim`, `/mcp`.
+
+The route must ALSO be covered in Helm ingress mode (`ingress.enabled=true`), which does not use the bundled nginx. Add a dedicated ingress template for the route (see `deployment/helm/charts/onyx/templates/ingress-scim.yaml`). `ingress-api.yaml` cannot host it, since that resource only routes `/api` and its resource-wide rewrite annotation strips other prefixes. If the web app owns a sub-path of the route (for example an IdP callback page), carve that sub-path back out to the webserver with `pathType: Exact`, following `ingress-mcp-oauth-callback.yaml`.
 
 ## Full vs Lite Deployments
 

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -16,21 +16,12 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
-    - kind: changed
-      description: values-localdev.yaml now disables the sandbox image prepuller.
-        Local kind clusters side-load the sandbox image (kind load + IfNotPresent),
-        so there is no registry pull to front-run, and with the localdev defaults
-        (:edge, pullPolicy Always) the prepuller would eagerly pull the ~3.3 GB
-        image from Docker Hub onto the kind node. Production values are unchanged.
     - kind: fixed
-      description: Fixed "helm upgrade" failing with 'PriorityClass ... value: Forbidden;
-        may not be changed in an update' after the sandbox image prepuller landed in
-        0.8.6. PriorityClass.value is immutable and helm upgrade patches, so the
-        prepuller no longer ships a PriorityClass at all; it was buying very little.
-        Upgrading from 0.8.6 deletes it, and the prepuller runs at the cluster default
-        priority — set sandboxImagePrepull.priorityClassName to an existing class to
-        keep it preemptible. Running pods are unaffected, because pod priority is
-        resolved at admission. The chart now renders no cluster-scoped objects.
+      description: Route /scim to the api server in ingress mode (ingress.enabled=true).
+        The ingress templates only routed /api to the api server, so SCIM requests fell
+        through to the webserver and returned an HTML 404. A new ingress-scim.yaml
+        template forwards the /scim prefix, without a rewrite, to the api service on
+        the webserver host.
 dependencies:
   # Helm uses the first condition path that exists: `postgresqlOperator.enabled`
   # is unset by default, so this falls through to `postgresql.enabled`. Set it

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.12
+version: 0.8.13
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/ingress-scim.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-scim.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ingress.enabled -}}
+# SCIM lives at the domain root (/scim/v2, outside /api) because IdPs address
+# it directly. Separate resource: ingress-api's rewrite-target annotation is
+# resource-wide and would strip the prefix. Bound to the webserver host, not
+# the api host, because IdPs are configured with the browser-facing app domain.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "onyx.fullname" . }}-ingress-scim
+  annotations:
+    {{- if not .Values.ingress.className }}
+    kubernetes.io/ingress.class: nginx
+    {{- end }}
+    cert-manager.io/cluster-issuer: {{ include "onyx.fullname" . }}-letsencrypt
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.webserver.host }}
+      http:
+        paths:
+          - path: /scim
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "onyx.fullname" . }}-api-service
+                port:
+                  number: {{ .Values.api.service.servicePort }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.webserver.host }}
+      secretName: {{ include "onyx.fullname" . }}-ingress-scim-tls
+{{- end }}


### PR DESCRIPTION
## Description

In Helm ingress mode (`ingress.enabled=true`) nothing routes `/scim` to the API server: `ingress-api.yaml` only matches `/api(/|$)(.*)` and the webserver ingress catches `/`, so SCIM requests fall through to Next.js and return an HTML 404. #9686 covered the compose nginx templates and the chart's bundled nginx-conf but not the ingress templates, so SCIM has never worked in ingress mode. Hit by an Enterprise customer configuring Entra ID provisioning on the latest chart.

- New `templates/ingress-scim.yaml` routes `/scim` (Prefix, no rewrite) to the api service on the webserver host. Separate resource because ingress-api's rewrite-target annotation is resource-wide and would strip the prefix.
- Chart bumped to 0.8.13.
- Greptile routing rule extended to cover ingress mode.

Note: `/auth/saml` has the same gap in ingress mode. Left out deliberately: the web app owns `/auth/saml/callback` (it converts the backend 204 into the browser redirect), so SAML needs a callback carve-out like `ingress-mcp-oauth-callback.yaml` plus a live SAML check. Follow-up.

## How Has This Been Tested?

`helm template` with `ingress.enabled=true` renders the Ingress with the correct backend (`<fullname>-api-service:8080`) for both the default annotation and `ingress.className` variants, and renders nothing when ingress is disabled. `helm lint` passes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check