### PR TITLE
feat(usage): add per-user attribution to usage report exports

### DIFF
--- a/backend/ee/onyx/server/reporting/usage_export_generation.py
+++ b/backend/ee/onyx/server/reporting/usage_export_generation.py
@@ -2,6 +2,7 @@ import csv
 import tempfile
 import uuid
 import zipfile
+from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 
 from fastapi_users_db_sqlalchemy import UUID_ID
@@ -20,11 +21,14 @@ from ee.onyx.server.reporting.usage_export_models import (
 )
 from onyx.configs.constants import FileOrigin
 from onyx.db.models import User
-from onyx.db.user_usage import UsageExportRow, get_usage_export
+from onyx.db.user_usage import UsageExportRow, iter_usage_export
 from onyx.db.users import get_all_users
 from onyx.file_store.constants import MAX_IN_MEMORY_SIZE
 from onyx.file_store.file_store import FileStore, get_default_file_store
 from onyx.utils.csv_utils import sanitize_csv_cell_or_none
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
 
 
 def _normalize_period(
@@ -133,7 +137,7 @@ def generate_user_report(
 def generate_usage_breakdown_report(
     file_store: FileStore,
     report_id: str,
-    rows: list[UsageExportRow],
+    rows: Iterable[UsageExportRow],
 ) -> str:
     file_name = f"{report_id}_usage_by_user"
 
@@ -190,58 +194,70 @@ def create_new_usage_report(
     report_id = report_id or str(uuid.uuid4())
     file_store = get_default_file_store()
 
-    messages_file_id = generate_chat_messages_report(
-        db_session, file_store, report_id, period
-    )
-    users_file_id = generate_user_report(db_session, file_store, report_id)
-
-    query_start, query_end = _normalize_period(period)
-    usage_rows = get_usage_export(db_session, query_start, query_end)
-
-    usage_breakdown_file_id = generate_usage_breakdown_report(
-        file_store, report_id, usage_rows
-    )
-
-    # Re-check just before writing the final report: the API-level check
-    # happens before this (async) task runs, so a second request with the
-    # same client-supplied report_id can slip past it while this task is
-    # still generating the first report.
-    if usage_report_id_in_use(db_session, uuid.UUID(report_id)):
-        raise ValueError(f"report_id {report_id} is already in use")
-
-    with tempfile.SpooledTemporaryFile(max_size=MAX_IN_MEMORY_SIZE) as zip_buffer:
-        with zipfile.ZipFile(zip_buffer, "a", zipfile.ZIP_DEFLATED) as zip_file:
-            # write messages
-            chat_messages_tmpfile = file_store.read_file(
-                messages_file_id, mode="b", use_tempfile=True
-            )
-            zip_file.writestr(
-                "chat_messages.csv",
-                chat_messages_tmpfile.read(),
-            )
-
-            # write users
-            users_tmpfile = file_store.read_file(
-                users_file_id, mode="b", use_tempfile=True
-            )
-            zip_file.writestr("users.csv", users_tmpfile.read())
-
-            usage_breakdown_tmpfile = file_store.read_file(
-                usage_breakdown_file_id, mode="b", use_tempfile=True
-            )
-            zip_file.writestr("usage_by_user.csv", usage_breakdown_tmpfile.read())
-
-        zip_buffer.seek(0)
-
-        # store zip blob to file_store
-        report_name = f"{datetime.now(tz=timezone.utc).strftime('%Y-%m-%d')}_{report_id}_usage_report.zip"
-        file_store.save_file(
-            content=zip_buffer,
-            display_name=report_name,
-            file_origin=FileOrigin.GENERATED_REPORT,
-            file_type="application/zip",
-            file_id=report_name,
+    intermediate_file_ids: list[str] = []
+    try:
+        messages_file_id = generate_chat_messages_report(
+            db_session, file_store, report_id, period
         )
+        intermediate_file_ids.append(messages_file_id)
+        users_file_id = generate_user_report(db_session, file_store, report_id)
+        intermediate_file_ids.append(users_file_id)
+
+        query_start, query_end = _normalize_period(period)
+        usage_rows = iter_usage_export(db_session, query_start, query_end)
+        usage_breakdown_file_id = generate_usage_breakdown_report(
+            file_store, report_id, usage_rows
+        )
+        intermediate_file_ids.append(usage_breakdown_file_id)
+
+        # Re-check just before writing the final report: the API-level check
+        # happens before this (async) task runs, so a second request with the
+        # same client-supplied report_id can slip past it while this task is
+        # still generating the first report.
+        if usage_report_id_in_use(db_session, uuid.UUID(report_id)):
+            raise ValueError(f"report_id {report_id} is already in use")
+
+        with tempfile.SpooledTemporaryFile(max_size=MAX_IN_MEMORY_SIZE) as zip_buffer:
+            with zipfile.ZipFile(zip_buffer, "a", zipfile.ZIP_DEFLATED) as zip_file:
+                # write messages
+                chat_messages_tmpfile = file_store.read_file(
+                    messages_file_id, mode="b", use_tempfile=True
+                )
+                zip_file.writestr(
+                    "chat_messages.csv",
+                    chat_messages_tmpfile.read(),
+                )
+
+                # write users
+                users_tmpfile = file_store.read_file(
+                    users_file_id, mode="b", use_tempfile=True
+                )
+                zip_file.writestr("users.csv", users_tmpfile.read())
+
+                usage_breakdown_tmpfile = file_store.read_file(
+                    usage_breakdown_file_id, mode="b", use_tempfile=True
+                )
+                zip_file.writestr("usage_by_user.csv", usage_breakdown_tmpfile.read())
+
+            zip_buffer.seek(0)
+
+            # store zip blob to file_store
+            report_name = f"{datetime.now(tz=timezone.utc).strftime('%Y-%m-%d')}_{report_id}_usage_report.zip"
+            file_store.save_file(
+                content=zip_buffer,
+                display_name=report_name,
+                file_origin=FileOrigin.GENERATED_REPORT,
+                file_type="application/zip",
+                file_id=report_name,
+            )
+    finally:
+        for file_id in intermediate_file_ids:
+            try:
+                file_store.delete_file(file_id, error_on_missing=False)
+            except Exception:
+                logger.exception(
+                    "Failed to delete temporary usage report file %s", file_id
+                )
 
     # add report after zip file is written
     new_report = write_usage_report(db_session, report_name, user_id, period)

--- a/backend/ee/onyx/server/reporting/usage_export_generation.py
+++ b/backend/ee/onyx/server/reporting/usage_export_generation.py
@@ -20,10 +20,24 @@ from ee.onyx.server.reporting.usage_export_models import (
 )
 from onyx.configs.constants import FileOrigin
 from onyx.db.models import User
+from onyx.db.user_usage import UsageExportRow, get_usage_export
 from onyx.db.users import get_all_users
 from onyx.file_store.constants import MAX_IN_MEMORY_SIZE
 from onyx.file_store.file_store import FileStore, get_default_file_store
 from onyx.utils.csv_utils import sanitize_csv_cell_or_none
+
+
+def _normalize_period(
+    period: tuple[datetime, datetime] | None,
+) -> tuple[datetime, datetime]:
+    if period is None:
+        return (
+            datetime.fromtimestamp(0, tz=timezone.utc),
+            datetime.now(tz=timezone.utc),
+        )
+    # time-picker sends a time which is at the beginning of the day
+    # so we need to add one day to the end time to make it inclusive
+    return (period[0], period[1] + timedelta(days=1))
 
 
 def generate_chat_messages_report(
@@ -33,19 +47,7 @@ def generate_chat_messages_report(
     period: tuple[datetime, datetime] | None,
 ) -> str:
     file_name = f"{report_id}_chat_sessions"
-
-    if period is None:
-        period = (
-            datetime.fromtimestamp(0, tz=timezone.utc),
-            datetime.now(tz=timezone.utc),
-        )
-    else:
-        # time-picker sends a time which is at the beginning of the day
-        # so we need to add one day to the end time to make it inclusive
-        period = (
-            period[0],
-            period[1] + timedelta(days=1),
-        )
+    period = _normalize_period(period)
 
     with tempfile.SpooledTemporaryFile(
         max_size=MAX_IN_MEMORY_SIZE, mode="w+"
@@ -128,6 +130,57 @@ def generate_user_report(
     return file_id
 
 
+def generate_usage_breakdown_report(
+    file_store: FileStore,
+    report_id: str,
+    rows: list[UsageExportRow],
+) -> str:
+    file_name = f"{report_id}_usage_by_user"
+
+    with tempfile.SpooledTemporaryFile(
+        max_size=MAX_IN_MEMORY_SIZE, mode="w+"
+    ) as temp_file:
+        csvwriter = csv.writer(temp_file, delimiter=",")
+        csvwriter.writerow(
+            [
+                "user_email",
+                "day",
+                "model",
+                "flow",
+                "provider",
+                "input_tokens",
+                "output_tokens",
+                "cache_read_tokens",
+                "cost_cents",
+            ]
+        )
+        for row in rows:
+            # User-controlled strings: formula-injection guard.
+            csvwriter.writerow(
+                [
+                    sanitize_csv_cell_or_none(row.email),
+                    row.day,
+                    sanitize_csv_cell_or_none(row.model),
+                    sanitize_csv_cell_or_none(row.flow),
+                    sanitize_csv_cell_or_none(row.provider),
+                    row.input_tokens,
+                    row.output_tokens,
+                    row.cache_read_tokens,
+                    row.cost_cents,
+                ]
+            )
+
+        temp_file.seek(0)
+        file_id = file_store.save_file(
+            content=temp_file,
+            display_name=file_name,
+            file_origin=FileOrigin.GENERATED_REPORT,
+            file_type="text/csv",
+        )
+
+    return file_id
+
+
 def create_new_usage_report(
     db_session: Session,
     user_id: UUID_ID | None,  # None = auto-generated
@@ -141,6 +194,13 @@ def create_new_usage_report(
         db_session, file_store, report_id, period
     )
     users_file_id = generate_user_report(db_session, file_store, report_id)
+
+    query_start, query_end = _normalize_period(period)
+    usage_rows = get_usage_export(db_session, query_start, query_end)
+
+    usage_breakdown_file_id = generate_usage_breakdown_report(
+        file_store, report_id, usage_rows
+    )
 
     # Re-check just before writing the final report: the API-level check
     # happens before this (async) task runs, so a second request with the
@@ -165,6 +225,11 @@ def create_new_usage_report(
                 users_file_id, mode="b", use_tempfile=True
             )
             zip_file.writestr("users.csv", users_tmpfile.read())
+
+            usage_breakdown_tmpfile = file_store.read_file(
+                usage_breakdown_file_id, mode="b", use_tempfile=True
+            )
+            zip_file.writestr("usage_by_user.csv", usage_breakdown_tmpfile.read())
 
         zip_buffer.seek(0)
 

--- a/backend/ee/onyx/server/reporting/usage_export_generation.py
+++ b/backend/ee/onyx/server/reporting/usage_export_generation.py
@@ -48,10 +48,9 @@ def generate_chat_messages_report(
     db_session: Session,
     file_store: FileStore,
     report_id: str,
-    period: tuple[datetime, datetime] | None,
+    period: tuple[datetime, datetime],
 ) -> str:
     file_name = f"{report_id}_chat_sessions"
-    period = _normalize_period(period)
 
     with tempfile.SpooledTemporaryFile(
         max_size=MAX_IN_MEMORY_SIZE, mode="w+"
@@ -193,17 +192,18 @@ def create_new_usage_report(
 ) -> UsageReportMetadata:
     report_id = report_id or str(uuid.uuid4())
     file_store = get_default_file_store()
+    normalized_period = _normalize_period(period)
 
     intermediate_file_ids: list[str] = []
     try:
         messages_file_id = generate_chat_messages_report(
-            db_session, file_store, report_id, period
+            db_session, file_store, report_id, normalized_period
         )
         intermediate_file_ids.append(messages_file_id)
         users_file_id = generate_user_report(db_session, file_store, report_id)
         intermediate_file_ids.append(users_file_id)
 
-        query_start, query_end = _normalize_period(period)
+        query_start, query_end = normalized_period
         usage_rows = iter_usage_export(db_session, query_start, query_end)
         usage_breakdown_file_id = generate_usage_breakdown_report(
             file_store, report_id, usage_rows

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -4,7 +4,7 @@ A window rollup: rows accumulate in place per (user, window,
 model, flow, provider), not an append-only per-call ledger."""
 
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from datetime import datetime, timedelta
 from math import ceil
 from typing import Any, cast
@@ -210,12 +210,11 @@ def get_user_usage_by_day_and_model(
     ]
 
 
-def get_usage_export(
-    db_session: Session,
+def _get_usage_export_query(
     start: datetime,
     end: datetime,
     model: str | None = None,
-) -> list[UsageExportRow]:
+) -> Any:
     utc_day = func.date(func.timezone("UTC", UserUsage.window_start))
     # Deleted users/API keys leave user_id NULL but keep their spend. An inner
     # join would hide that spend here while the tenant-wide totals still count
@@ -254,10 +253,22 @@ def get_usage_export(
     if model is not None:
         query = query.where(UserUsage.model == model)
 
-    rows = db_session.execute(query).all()
+    return query
 
-    return [
-        UsageExportRow(
+
+def iter_usage_export(
+    db_session: Session,
+    start: datetime,
+    end: datetime,
+    model: str | None = None,
+) -> Iterator[UsageExportRow]:
+    result = db_session.execute(
+        _get_usage_export_query(start, end, model).execution_options(
+            stream_results=True
+        )
+    ).yield_per(1000)
+    for email, mdl, flow, provider, day, in_tok, out_tok, cache_tok, cost in result:
+        yield UsageExportRow(
             email=str(email),
             model=mdl,
             flow=flow,
@@ -268,8 +279,15 @@ def get_usage_export(
             cache_read_tokens=int(cache_tok or 0),
             cost_cents=float(cost or 0.0),
         )
-        for email, mdl, flow, provider, day, in_tok, out_tok, cache_tok, cost in rows
-    ]
+
+
+def get_usage_export(
+    db_session: Session,
+    start: datetime,
+    end: datetime,
+    model: str | None = None,
+) -> list[UsageExportRow]:
+    return list(iter_usage_export(db_session, start, end, model))
 
 
 def get_usage_reset_window_start(

--- a/backend/tests/integration/tests/reporting/test_usage_export_api.py
+++ b/backend/tests/integration/tests/reporting/test_usage_export_api.py
@@ -289,6 +289,28 @@ class TestUsageExportAPI:
             file_names = zip_file.namelist()
             assert "chat_messages.csv" in file_names
             assert "users.csv" in file_names
+            assert "usage_by_user.csv" in file_names
+            # Verify usage_by_user.csv has the expected columns. The seeded
+            # chat history doesn't record UserUsage rows, so there's no data
+            # to assert on, just the header shape.
+            with zip_file.open("usage_by_user.csv") as csv_file:
+                csv_content = csv_file.read().decode("utf-8")
+                csv_reader = csv.DictReader(StringIO(csv_content))
+                expected_columns = {
+                    "user_email",
+                    "day",
+                    "model",
+                    "flow",
+                    "provider",
+                    "input_tokens",
+                    "output_tokens",
+                    "cache_read_tokens",
+                    "cost_cents",
+                }
+                actual_columns = set(csv_reader.fieldnames or [])
+                assert expected_columns == actual_columns, (
+                    f"Expected columns {expected_columns}, but got {actual_columns}"
+                )
 
             # Verify chat_messages.csv has the expected columns
             with zip_file.open("chat_messages.csv") as csv_file:


### PR DESCRIPTION
## Description

Adds `usage_by_user.csv` to admin-generated usage report ZIPs. The CSV contains one row per user, day, model, flow, and provider, with input, output, and cache token counts plus `cost_cents`.

The new CSV is bundled with the existing `chat_messages.csv` and `users.csv` files. User- and model-controlled fields are sanitized before writing CSV cells to prevent spreadsheet formula injection. The selected report end date is included in the export range.

## How Has This Been Tested?

- Added integration coverage in `backend/tests/integration/tests/reporting/test_usage_export_api.py`.
- Passed `pre-commit run --files backend/ee/onyx/server/reporting/usage_export_generation.py backend/tests/integration/tests/reporting/test_usage_export_api.py`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check