### PR TITLE
test(unit): reset EE state leaked by import side effects

### DIFF
--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -21,10 +21,10 @@ def _reset_leaked_ee_state() -> Generator[None, None, None]:
     ``set_is_ee_based_on_env_variable()`` runs at module level in ``onyx.main``
     and every ``background/celery/versioned_apps`` module, and flips the
     process-global EE flag whenever license enforcement is on (its default). A
-    unit test whose import chain reaches one of those modules therefore
-    silently switches every later test in the worker to EE resolution,
-    breaking OSS-asserting tests order-dependently. Runs before ``enable_ee``
-    (autouse fixtures are instantiated first), so opting in still works.
+    unit test whose import chain reaches one of those modules therefore silently
+    switches every later test in the worker to EE resolution, breaking
+    OSS-asserting tests order-dependently. Runs before ``enable_ee`` (autouse
+    fixtures are instantiated first), so opting in still works.
     """
     if global_version.is_ee_version():
         global_version.unset_ee()

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -1,0 +1,34 @@
+"""Unit-suite conftest.
+
+Unit tests assume OSS resolution unless they opt into EE via the shared
+``enable_ee`` fixture (see ``backend/tests/conftest.py``).
+"""
+
+from collections.abc import Generator
+
+import pytest
+
+from onyx.utils.variable_functionality import (
+    fetch_versioned_implementation,
+    global_version,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_leaked_ee_state() -> Generator[None, None, None]:
+    """Undoes EE state leaked into the process by import side effects.
+
+    ``set_is_ee_based_on_env_variable()`` runs at module level in ``onyx.main``
+    and every ``background/celery/versioned_apps`` module, and flips the
+    process-global EE flag whenever license enforcement is on (its default). A
+    unit test whose import chain reaches one of those modules therefore
+    silently switches every later test in the worker to EE resolution,
+    breaking OSS-asserting tests order-dependently. Runs before ``enable_ee``
+    (autouse fixtures are instantiated first), so opting in still works.
+    """
+    if global_version.is_ee_version():
+        global_version.unset_ee()
+        # Entries resolved while the flag was flipped point at EE
+        # implementations; drop them along with the flag.
+        fetch_versioned_implementation.cache_clear()
+    yield


### PR DESCRIPTION
## Description

`set_is_ee_based_on_env_variable()` runs at module level in `onyx.main` and the celery `versioned_apps` modules, and flips the process-global EE flag whenever `LICENSE_ENFORCEMENT_ENABLED` is on (its default). Any unit test whose import chain reaches one of those modules silently switches every later test in that pytest worker to EE resolution, order-dependently breaking OSS-asserting tests (`test_registry_fallbacks`, the confluence perm-sync checkpointing test, the license suites).

- Adds `backend/tests/unit/conftest.py` with an autouse fixture that unsets the leaked flag and clears the `fetch_versioned_implementation` cache before each test.
- Opting into EE stays explicit via the existing `enable_ee` fixture; autouse fixtures instantiate first, so the opt-in wins.

## How Has This Been Tested?

- Local full unit run: 21 order-dependent/flaky failures down to 8 (all machine-environmental, unrelated).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes order-dependent unit test failures by resetting EE state leaked by import side effects. Adds an autouse fixture that unsets `global_version` EE and clears the `fetch_versioned_implementation` cache so tests default to OSS unless they opt into EE via `enable_ee`.

- **Bug Fixes**
  - Added `backend/tests/unit/conftest.py` with `_reset_leaked_ee_state` autouse fixture.
  - Prevents EE leaks from module-level `set_is_ee_based_on_env_variable()` in `onyx.main` and `background/celery/versioned_apps`.

<sup>Written for commit e3f7a34626250398bf53df2b936c1ba8cef8d45e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

