### PR TITLE
fix(web): keep native row role on clickable opal Table rows

### DIFF
--- a/web/lib/opal/src/components/table/components.tsx
+++ b/web/lib/opal/src/components/table/components.tsx
@@ -514,7 +514,6 @@ export function Table<TData>(props: DataTableProps<TData>) {
                     sortableId={rowId}
                     selected={row.getIsSelected()}
                     data-clickable={onRowClick ? true : undefined}
-                    role={onRowClick ? "button" : undefined}
                     tabIndex={onRowClick ? 0 : undefined}
                     aria-label={
                       onRowClick ? getRowLabel?.(row.original) : undefined

--- a/web/src/sections/usage/SpendByUserTable.test.tsx
+++ b/web/src/sections/usage/SpendByUserTable.test.tsx
@@ -22,7 +22,7 @@ test("opens a user from the keyboard", () => {
     />
   );
 
-  const row = screen.getByRole("button", {
+  const row = screen.getByRole("row", {
     name: "View usage details for ada@example.com",
   });
   row.focus();

--- a/web/tests/e2e/pages/AdminUsagePage.ts
+++ b/web/tests/e2e/pages/AdminUsagePage.ts
@@ -20,9 +20,7 @@ export class AdminUsagePage {
     // The table only renders the first page (by spend) without filtering, so
     // narrow to this user via search before asserting their row is visible.
     await this.userSearchInput.fill(email);
-    // Clickable rows render role="button" (see opal Table's onRowClick
-    // handling), not role="row".
-    const row = this.page.getByRole("button", {
+    const row = this.page.getByRole("row", {
       name: `View usage details for ${email}`,
     });
     await expect(row).toBeVisible();


### PR DESCRIPTION
## Description

Fixes a real accessibility + test-locator regression introduced by #13806 (now merged into `main`).

Opal's `Table` component (`web/lib/opal/src/components/table/components.tsx`) was setting `role="button"` on any row that has an `onRowClick` handler, overriding the `<tr>`'s native `row` role. This broke `getByRole("row", ...)` lookups for every consumer — the standard admin e2e locator pattern used by `UsersAdminPage`, `GroupsAdminPage`, `ScheduledTasksPage`, `IndexingStatusPage`, etc. It's also a real accessibility problem: giving a `<tr>` `role="button"` breaks the row/cell structure screen readers rely on to navigate a table.

`691030efc8` (part of #13806) worked around the symptom by changing `AdminUsagePage.expectUser` to assert `getByRole("button", ...)` instead of fixing the component. This PR fixes it properly:

- Removed the `role={onRowClick ? "button" : undefined}` override in `components.tsx` — clickable rows keep their native `row` role. Keyboard interaction (`tabIndex` + Enter/Space handling) is unaffected.
- Reverted `AdminUsagePage.expectUser` back to `getByRole("row", ...)`, matching the rest of the admin e2e suite.
- Reverted the matching assertion in `SpendByUserTable.test.tsx` back to `getByRole("row", ...)`.

## How Has This Been Tested?

- `bun run test -- --testPathPatterns "table|Table" --runInBand` — 110/110 suites, 1075/1075 tests pass.
- `pre-commit run --files web/lib/opal/src/components/table/components.tsx web/tests/e2e/pages/AdminUsagePage.ts web/src/sections/usage/SpendByUserTable.test.tsx` (oxlint, oxfmt, TypeScript check) — passed.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the native table row role for clickable Opal Table rows to fix screen reader navigation and bring back `getByRole('row')` selectors used across admin pages.

- **Bug Fixes**
  - Removed `role="button"` override on clickable `<tr>`; keyboard support (tabIndex + Enter/Space) remains.
  - Reverted tests to target `row` role in `AdminUsagePage` and `SpendByUserTable.test.tsx`.

<sup>Written for commit aefcd2a564834375d905a10253e5eb376a32adc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

