### PR TITLE
fix(admin): reflow security page dropdowns between title and description on narrow viewports

### DIFF
--- a/web/src/views/admin/SecurityHardeningPage.tsx
+++ b/web/src/views/admin/SecurityHardeningPage.tsx
@@ -390,8 +390,9 @@ export default function SecurityHardeningPage() {
                 title="Full User Directory Visibility"
                 description="Exact name and email lookups work regardless of this setting."
                 withLabel
+                responsive
               >
-                <div className="w-60">
+                <div className="w-full sm:w-60">
                   <InputSelect
                     value={
                       draft.user_directory_admin_only
@@ -430,8 +431,9 @@ export default function SecurityHardeningPage() {
                   title="Mask Stored Credentials"
                   description="Display format for saved API keys and credentials for admins."
                   withLabel
+                  responsive
                 >
-                  <div className="w-60">
+                  <div className="w-full sm:w-60">
                     <InputSelect
                       value={
                         draft.mask_credential_prefix ? "masked" : "visible"
@@ -500,8 +502,9 @@ export default function SecurityHardeningPage() {
                   title="SSRF Protection"
                   description="Validate outbound requests against private or internal IPs for Server-Side Request Forgery (SSRF) protection."
                   withLabel
+                  responsive
                 >
-                  <div className="w-60">
+                  <div className="w-full sm:w-60">
                     <InputSelect
                       value={draft.ssrf_protection_level}
                       onValueChange={(value) =>


### PR DESCRIPTION
## Description

The three dropdown rows on the Security & Hardening admin page ("Full User Directory Visibility", "Mask Stored Credentials", "SSRF Protection") kept their select pinned to the right at all viewport widths, squeezing the title/description column on narrow screens.

This enables `InputHorizontal`'s `responsive` mode on those rows — the same pattern the Full Name / Work Role rows use on the user Settings page — so below the `sm` breakpoint (724px) the select stacks full-width between the card's title and description. The select wrappers change from `w-60` to `w-full sm:w-60`; since the Tailwind `sm` screen is custom-set to 724px (the exact `ContentMd` reflow breakpoint), the width snaps back to the fixed 15rem in sync with the grid reflow, leaving the desktop layout pixel-identical.

Toggle rows are intentionally untouched — `InputHorizontal` docs advise against the responsive mode for compact controls like switches.

## How Has This Been Tested?

- `pre-commit run --files web/src/views/admin/SecurityHardeningPage.tsx` (oxfmt, oxlint, TypeScript) passes.
- Ran the app and inspected `/admin/security` in the browser at 1280px (unchanged: selects right-aligned, fixed width, vertically centered) and 500px (each dropdown renders full-width between its title and description).
- Verified via the accessibility tree that each row's DOM order is title → combobox → description.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**before**
<img width="1902" height="2085" alt="20260810_16h19m53s_grim" src="https://github.com/user-attachments/assets/60e4915f-7833-4854-bf1a-89dc04010108" />
**after**
<img width="1902" height="2085" alt="20260810_16h20m18s_grim" src="https://github.com/user-attachments/assets/14baf403-9783-4000-b45c-3bcacf1fc207" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Security & Hardening page layout on narrow screens by stacking the three dropdowns between each card’s title and description. Desktop layout remains unchanged.

- **Bug Fixes**
  - Enabled responsive layout for the select rows: Full User Directory Visibility, Mask Stored Credentials, and SSRF Protection.
  - Updated select container width to w-full sm:w-60 so selects stack below 724px and snap back to fixed width with the grid.
  - Left toggle rows as-is; confirmed DOM order is title → combobox → description for accessibility.

<sup>Written for commit 113784e181b25ab9de89d734caf08d8296549c1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


