### PR TITLE
feat(web): allow production builds to skip type checking

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -88,6 +88,11 @@ ENV SENTRY_RELEASE=${SENTRY_RELEASE}
 # Add NODE_OPTIONS argument
 ARG NODE_OPTIONS
 
+# Type checking is already enforced by CI's `typescript-check` pre-commit hook, so it's
+# redundant (and slow) inside `next build`. Set to "1" to have next.config.js skip it here.
+ARG SKIP_TYPE_CHECK
+ENV SKIP_TYPE_CHECK=${SKIP_TYPE_CHECK}
+
 # SENTRY_AUTH_TOKEN is injected via BuildKit secret mount so it is never written
 # to any image layer, build cache, or registry manifest.
 # Use NODE_OPTIONS in the build command

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -88,8 +88,6 @@ ENV SENTRY_RELEASE=${SENTRY_RELEASE}
 # Add NODE_OPTIONS argument
 ARG NODE_OPTIONS
 
-# Type checking is already enforced by CI's `typescript-check` pre-commit hook, so it's
-# redundant (and slow) inside `next build`. Set to "1" to have next.config.js skip it here.
 ARG SKIP_TYPE_CHECK
 ENV SKIP_TYPE_CHECK=${SKIP_TYPE_CHECK}
 

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -7,6 +7,13 @@ const nextConfig = {
   productionBrowserSourceMaps: false,
   poweredByHeader: false,
   output: "standalone",
+  // Type checking is already enforced by the `typescript-check` pre-commit hook
+  // (`bun run types:check`, using the faster typescript@7 compiler), so re-checking
+  // during `next build` is redundant there and just slows down production builds.
+  // Set SKIP_TYPE_CHECK=1 to skip it (e.g. in the production Docker build).
+  typescript: {
+    ignoreBuildErrors: process.env.SKIP_TYPE_CHECK === "1",
+  },
   transpilePackages: ["@onyx-ai/opal", "@onyx-ai/shared"],
   typedRoutes: true,
   // NOTE: `reactCompiler` is set per-phase in module.exports below — enabled for

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -7,10 +7,6 @@ const nextConfig = {
   productionBrowserSourceMaps: false,
   poweredByHeader: false,
   output: "standalone",
-  // Type checking is already enforced by the `typescript-check` pre-commit hook
-  // (`bun run types:check`, using the faster typescript@7 compiler), so re-checking
-  // during `next build` is redundant there and just slows down production builds.
-  // Set SKIP_TYPE_CHECK=1 to skip it (e.g. in the production Docker build).
   typescript: {
     ignoreBuildErrors: process.env.SKIP_TYPE_CHECK === "1",
   },

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
     "dev:clean": "bun run clean && next dev",
     "clean": "rm -rf .next node_modules/.cache *.tsbuildinfo",
     "build": "next build",
+    "build:fast": "SKIP_TYPE_CHECK=1 next build",
     "start": "next start",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",


### PR DESCRIPTION
## Summary
- Add `SKIP_TYPE_CHECK` env flag to `web/next.config.js`, which sets `typescript.ignoreBuildErrors` — mirrors the existing `ENABLE_REACT_COMPILER` pattern already used there.
- Wire `SKIP_TYPE_CHECK` through as a `web/Dockerfile` build `ARG`/`ENV` so production Docker builds can opt in via `--build-arg SKIP_TYPE_CHECK=1`.

Type checking is already enforced independently by the `typescript-check` pre-commit hook (`bun run types:check`, via the faster `typescript@7` compiler), so `next build`'s own TS pass is redundant there and just adds time to production builds. This flag lets that redundant check be skipped when desired, without removing the default (still-on) safety net for anyone building without the flag.

## Test plan
- [x] Verified `next.config.js`'s exported config function resolves `typescript.ignoreBuildErrors: false` by default and `true` with `SKIP_TYPE_CHECK=1` set.
- [x] `pre-commit run --files web/next.config.js web/Dockerfile` passes (oxfmt, oxlint).
- [ ] Optional: run a full `next build` locally with and without the flag against code containing a type error, to confirm the build fails/succeeds as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `SKIP_TYPE_CHECK` flag to skip Next.js TypeScript checks during `next build`, speeding up prod builds while CI still enforces types via `typescript-check` (`typescript@7`). Also adds a `build:fast` script for local builds.

- **Migration**
  - Optional: set `SKIP_TYPE_CHECK=1` (env) or pass `--build-arg SKIP_TYPE_CHECK=1` in the `web` Docker build. Default behavior remains unchanged.
  - Local: run `bun run build:fast` to skip type checks.

<sup>Written for commit dbf4a97a6d586a17f4ccae4e84322d28ce52414b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

