### PR TITLE
fix(web): fix react-doctor error-class findings and enforce via oxlint plugin

### DIFF
--- a/web/.oxlintrc.json
+++ b/web/.oxlintrc.json
@@ -1,6 +1,9 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": ["typescript", "unicorn", "oxc", "react", "nextjs"],
+  "jsPlugins": [
+    { "name": "react-doctor", "specifier": "oxlint-plugin-react-doctor" }
+  ],
   "categories": {
     "correctness": "error"
   },
@@ -9,7 +12,15 @@
     "react/exhaustive-deps": "off",
     "typescript/no-unused-vars": "off",
     "unicorn/no-thenable": "off",
-    "no-unused-vars": "off"
+    "no-unused-vars": "off",
+    "react-doctor/rules-of-hooks": "error",
+    "react-doctor/no-unguarded-browser-global-in-render-or-hook-init": "error",
+    "react-doctor/effect-needs-cleanup": "error",
+    "react-doctor/no-effect-with-fresh-deps": "error",
+    "react-doctor/aria-role": "error",
+    "react-doctor/no-ref-current-in-render": "error",
+    "react-doctor/no-impure-state-updater": "error",
+    "react-doctor/no-layout-property-animation": "error"
   },
   "ignorePatterns": [
     ".next",

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -110,6 +110,7 @@
         "jest-environment-jsdom": "^30.2.0",
         "oxfmt": "0.59.0",
         "oxlint": "^1.66.0",
+        "oxlint-plugin-react-doctor": "0.9.11",
         "stats.js": "^0.17.0",
         "storybook": "10.5.0",
         "tailwindcss": "^4.3.0",
@@ -281,11 +282,11 @@
 
     "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
-    "@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
+    "@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
 
-    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
@@ -529,47 +530,47 @@
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 
-    "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.127.0", "", { "os": "android", "cpu": "arm" }, "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ=="],
+    "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.142.0", "", { "os": "android", "cpu": "arm" }, "sha512-ZiRGDutGsv1G6bL/ozy/koC0Sv39T1DqyoC4KD1DOy9ZoACm1O5UWhEK2c02Qdk+4lfLVkvFa/mQ0fm/4h1BtQ=="],
 
-    "@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.127.0", "", { "os": "android", "cpu": "arm64" }, "sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg=="],
+    "@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.142.0", "", { "os": "android", "cpu": "arm64" }, "sha512-WZkvGRLNQTz8lR9zP5nLjUdlroRCopBu3g9zF1p/laE6DzT1UbQo8Rdz5MWhaJUPYg/6gp+jo7HUgsyKaN1FtQ=="],
 
-    "@oxc-parser/binding-darwin-arm64": ["@oxc-parser/binding-darwin-arm64@0.127.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg=="],
+    "@oxc-parser/binding-darwin-arm64": ["@oxc-parser/binding-darwin-arm64@0.142.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-l4khS8LQOOVYsGRVARo1gSaCT/aBSceUVXgtovWc2+drnxVuDr082WA3OCHVdVzIz5JIrP/y9CWsSKxBDNmYGg=="],
 
-    "@oxc-parser/binding-darwin-x64": ["@oxc-parser/binding-darwin-x64@0.127.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw=="],
+    "@oxc-parser/binding-darwin-x64": ["@oxc-parser/binding-darwin-x64@0.142.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-QBsNF3nqlXmcH2B1YOPqQYmCJoy4HuIjUxGbBO/k5JAJUl68ghU2psRY2zPk+RyBaWqKP/qfL4oaFgEMCdwskA=="],
 
-    "@oxc-parser/binding-freebsd-x64": ["@oxc-parser/binding-freebsd-x64@0.127.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA=="],
+    "@oxc-parser/binding-freebsd-x64": ["@oxc-parser/binding-freebsd-x64@0.142.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-b7Q7m4Cqc6XqNhri3R+QhU+GVy646Pn+bkdhrDdWym/Fdi0ZUa+d73H9dm5H91JtbtAQ/z1d8XKMW3oOV8a4tQ=="],
 
-    "@oxc-parser/binding-linux-arm-gnueabihf": ["@oxc-parser/binding-linux-arm-gnueabihf@0.127.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ=="],
+    "@oxc-parser/binding-linux-arm-gnueabihf": ["@oxc-parser/binding-linux-arm-gnueabihf@0.142.0", "", { "os": "linux", "cpu": "arm" }, "sha512-3riVS5IhdH3uCZj1Y9ftDQlR0dvLsIlw/edrRqk8JhgNd5K0XSs+UBtgh50N13CAlW9/TXj6sVGXaKNBocd0Yg=="],
 
-    "@oxc-parser/binding-linux-arm-musleabihf": ["@oxc-parser/binding-linux-arm-musleabihf@0.127.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g=="],
+    "@oxc-parser/binding-linux-arm-musleabihf": ["@oxc-parser/binding-linux-arm-musleabihf@0.142.0", "", { "os": "linux", "cpu": "arm" }, "sha512-NmXUOpgpTSkhl795TiXmWppTwmSJ92RC1qvD6e4XOF+slgmo3e6Ah+kEu+6AN8s7NAOEwqGmir58MgSQSWmBSA=="],
 
-    "@oxc-parser/binding-linux-arm64-gnu": ["@oxc-parser/binding-linux-arm64-gnu@0.127.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ=="],
+    "@oxc-parser/binding-linux-arm64-gnu": ["@oxc-parser/binding-linux-arm64-gnu@0.142.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-gc0EXsKtXgerujmU2Bql3u1L1HsSQ2774R83idq/FoNMPVV/RY/1ErFsvnit7KoiP/sLvzQixeUo4Ut0ic0wmw=="],
 
-    "@oxc-parser/binding-linux-arm64-musl": ["@oxc-parser/binding-linux-arm64-musl@0.127.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA=="],
+    "@oxc-parser/binding-linux-arm64-musl": ["@oxc-parser/binding-linux-arm64-musl@0.142.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-F2XvmWSE0uWpie+jHKKIFgdVOe9ypGhkEZxKx5DuW215K6cbAC274yYaPkcM7EqY4Df3Weyhpcz3lsURyH2LVg=="],
 
-    "@oxc-parser/binding-linux-ppc64-gnu": ["@oxc-parser/binding-linux-ppc64-gnu@0.127.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ=="],
+    "@oxc-parser/binding-linux-ppc64-gnu": ["@oxc-parser/binding-linux-ppc64-gnu@0.142.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-wLMbT21U/QxknQsk+VvNF0b9D2/aGWhcaQQQ+VYlE8FwD5+GoWZIPPXNzyHmkYyhm0KB3itL+TBavjMatqNnYA=="],
 
-    "@oxc-parser/binding-linux-riscv64-gnu": ["@oxc-parser/binding-linux-riscv64-gnu@0.127.0", "", { "os": "linux", "cpu": "none" }, "sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ=="],
+    "@oxc-parser/binding-linux-riscv64-gnu": ["@oxc-parser/binding-linux-riscv64-gnu@0.142.0", "", { "os": "linux", "cpu": "none" }, "sha512-+G8F/4ckwT7FCJV4H2bt09xEzJbjNCfuL4Sp1AYNaFtFMVtgIGMuJlteT82U+K0UIZ/DzAR/LDlMFnEuajG7Kw=="],
 
-    "@oxc-parser/binding-linux-riscv64-musl": ["@oxc-parser/binding-linux-riscv64-musl@0.127.0", "", { "os": "linux", "cpu": "none" }, "sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g=="],
+    "@oxc-parser/binding-linux-riscv64-musl": ["@oxc-parser/binding-linux-riscv64-musl@0.142.0", "", { "os": "linux", "cpu": "none" }, "sha512-hTsHtTLxMAfCo+rpF5K3qZJKW2NpPN/CHd4mYB3y7XlSdspHkd2gehDIofP64AacA9nWQw2tY3O7wR6UY8IVOA=="],
 
-    "@oxc-parser/binding-linux-s390x-gnu": ["@oxc-parser/binding-linux-s390x-gnu@0.127.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q=="],
+    "@oxc-parser/binding-linux-s390x-gnu": ["@oxc-parser/binding-linux-s390x-gnu@0.142.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-6y7qYY3TCUDYjqswImdTGl92y+KA/80twALegQPN27kfY+bG7Ib1+L3jbmrCZQx6wrVnai9IPsEZp07I0hx7JQ=="],
 
-    "@oxc-parser/binding-linux-x64-gnu": ["@oxc-parser/binding-linux-x64-gnu@0.127.0", "", { "os": "linux", "cpu": "x64" }, "sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ=="],
+    "@oxc-parser/binding-linux-x64-gnu": ["@oxc-parser/binding-linux-x64-gnu@0.142.0", "", { "os": "linux", "cpu": "x64" }, "sha512-i69kAWU+2LgoH5bR+zWiiu+UzAw7Oxkwv7COeJTeY19pn4e70nKQcr9Pm6cL2Z0Z54d+gl9qADlK/0yyuCPiBA=="],
 
-    "@oxc-parser/binding-linux-x64-musl": ["@oxc-parser/binding-linux-x64-musl@0.127.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg=="],
+    "@oxc-parser/binding-linux-x64-musl": ["@oxc-parser/binding-linux-x64-musl@0.142.0", "", { "os": "linux", "cpu": "x64" }, "sha512-4SQs678MmjYVrmhAgCWD4o0vpaFszXw9xLX5p2Z9MMFcltxiLkA88wQjh80YHjPrXtpyZ2CWI5m+1yNKM0m2Pw=="],
 
-    "@oxc-parser/binding-openharmony-arm64": ["@oxc-parser/binding-openharmony-arm64@0.127.0", "", { "os": "none", "cpu": "arm64" }, "sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ=="],
+    "@oxc-parser/binding-openharmony-arm64": ["@oxc-parser/binding-openharmony-arm64@0.142.0", "", { "os": "none", "cpu": "arm64" }, "sha512-YHpx9N7Ln3a++Tc8rv+H7mrK1zyJQOAwCFg8LZ3lTs1T5afGWeZrLPhPT9HLnIwSjCyJqPWVMIrMxbjcmBr2oQ=="],
 
-    "@oxc-parser/binding-wasm32-wasi": ["@oxc-parser/binding-wasm32-wasi@0.127.0", "", { "dependencies": { "@emnapi/core": "1.9.2", "@emnapi/runtime": "1.9.2", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ=="],
+    "@oxc-parser/binding-wasm32-wasi": ["@oxc-parser/binding-wasm32-wasi@0.142.0", "", { "dependencies": { "@emnapi/core": "1.11.2", "@emnapi/runtime": "1.11.2", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-3pLDyY3+oogW73RM5uehNgAiR/Xfb7fvO2Q1Z1gIqZ2+50XDVQmBVlRkHXZTU4gKnQHpwETNsYQVsJ3joVB2iA=="],
 
-    "@oxc-parser/binding-win32-arm64-msvc": ["@oxc-parser/binding-win32-arm64-msvc@0.127.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw=="],
+    "@oxc-parser/binding-win32-arm64-msvc": ["@oxc-parser/binding-win32-arm64-msvc@0.142.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Had/VeVY28Oyb0K+Q4FV8KCzoBycIh93oDK6pCbya9lkzdq+ikMHMgBubsdqqlybjJmQRawCQRrnBRHyQwYvcQ=="],
 
-    "@oxc-parser/binding-win32-ia32-msvc": ["@oxc-parser/binding-win32-ia32-msvc@0.127.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw=="],
+    "@oxc-parser/binding-win32-ia32-msvc": ["@oxc-parser/binding-win32-ia32-msvc@0.142.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-GGi3+YphVHavvgs6gum2UXoNCqzHAmPt/nXkn8ZQZstV2Q1qZD1Mn8fz/nWrDkefHQtrG/+1/XrbMxsBTo6Svw=="],
 
-    "@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.127.0", "", { "os": "win32", "cpu": "x64" }, "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w=="],
+    "@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.142.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Ny/Wv4Us1LGC/ljwNTp+Hx3r/pH15EFfeDF0p+n898gt+TtRd6C9SccHcuUhDiNTb8s5tt7jdeAMDRQZ4Vq6hg=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+    "@oxc-project/types": ["@oxc-project/types@0.142.0", "", {}, "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ=="],
 
     "@oxc-resolver/binding-android-arm-eabi": ["@oxc-resolver/binding-android-arm-eabi@11.24.2", "", { "os": "android", "cpu": "arm" }, "sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA=="],
 
@@ -893,6 +894,8 @@
 
     "@sentry/webpack-plugin": ["@sentry/webpack-plugin@5.3.0", "", { "dependencies": { "@sentry/bundler-plugin-core": "5.3.0" }, "peerDependencies": { "webpack": ">=5.0.0" } }, "sha512-i3OQUrS0FZlXLgq57RIKDp+vHHzuvYKPCKewAPXULWKMsBXFGhP6veGRQ+6To/pmZkkXjEX5ofVNDy9C3jEPKQ=="],
 
+    "@shaderfrog/glsl-parser": ["@shaderfrog/glsl-parser@7.0.1", "", {}, "sha512-8mpfsoPeRhesY3pOrzNZBL8uG6N5GVX1EHLBYbd4gzKs+c7vaEIqpTNK5VrffU33qQN4cwpP2v3u4aPPBU32sw=="],
+
     "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
 
     "@sinonjs/commons": ["@sinonjs/commons@3.0.1", "", { "dependencies": { "type-detect": "4.0.8" } }, "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ=="],
@@ -1051,6 +1054,8 @@
 
     "@types/doctrine": ["@types/doctrine@0.0.9", "", {}, "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA=="],
 
+    "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
+
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
@@ -1116,6 +1121,8 @@
     "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
 
     "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
@@ -1533,7 +1540,9 @@
 
     "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
-    "eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^4.1.1" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
+    "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
 
@@ -1543,7 +1552,7 @@
 
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
 
-    "estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
 
@@ -1849,29 +1858,29 @@
 
     "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
-    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+    "lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
 
-    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.33.0", "", { "os": "android", "cpu": "arm64" }, "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg=="],
 
-    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.33.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg=="],
 
-    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.33.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ=="],
 
-    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.33.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg=="],
 
-    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.33.0", "", { "os": "linux", "cpu": "arm" }, "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ=="],
 
-    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg=="],
 
-    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ=="],
 
-    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg=="],
 
-    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw=="],
 
-    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.33.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA=="],
 
-    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
 
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
@@ -2079,13 +2088,15 @@
 
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
-    "oxc-parser": ["oxc-parser@0.127.0", "", { "dependencies": { "@oxc-project/types": "^0.127.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.127.0", "@oxc-parser/binding-android-arm64": "0.127.0", "@oxc-parser/binding-darwin-arm64": "0.127.0", "@oxc-parser/binding-darwin-x64": "0.127.0", "@oxc-parser/binding-freebsd-x64": "0.127.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.127.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.127.0", "@oxc-parser/binding-linux-arm64-gnu": "0.127.0", "@oxc-parser/binding-linux-arm64-musl": "0.127.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.127.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.127.0", "@oxc-parser/binding-linux-riscv64-musl": "0.127.0", "@oxc-parser/binding-linux-s390x-gnu": "0.127.0", "@oxc-parser/binding-linux-x64-gnu": "0.127.0", "@oxc-parser/binding-linux-x64-musl": "0.127.0", "@oxc-parser/binding-openharmony-arm64": "0.127.0", "@oxc-parser/binding-wasm32-wasi": "0.127.0", "@oxc-parser/binding-win32-arm64-msvc": "0.127.0", "@oxc-parser/binding-win32-ia32-msvc": "0.127.0", "@oxc-parser/binding-win32-x64-msvc": "0.127.0" } }, "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA=="],
+    "oxc-parser": ["oxc-parser@0.142.0", "", { "dependencies": { "@oxc-project/types": "^0.142.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.142.0", "@oxc-parser/binding-android-arm64": "0.142.0", "@oxc-parser/binding-darwin-arm64": "0.142.0", "@oxc-parser/binding-darwin-x64": "0.142.0", "@oxc-parser/binding-freebsd-x64": "0.142.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.142.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.142.0", "@oxc-parser/binding-linux-arm64-gnu": "0.142.0", "@oxc-parser/binding-linux-arm64-musl": "0.142.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.142.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.142.0", "@oxc-parser/binding-linux-riscv64-musl": "0.142.0", "@oxc-parser/binding-linux-s390x-gnu": "0.142.0", "@oxc-parser/binding-linux-x64-gnu": "0.142.0", "@oxc-parser/binding-linux-x64-musl": "0.142.0", "@oxc-parser/binding-openharmony-arm64": "0.142.0", "@oxc-parser/binding-wasm32-wasi": "0.142.0", "@oxc-parser/binding-win32-arm64-msvc": "0.142.0", "@oxc-parser/binding-win32-ia32-msvc": "0.142.0", "@oxc-parser/binding-win32-x64-msvc": "0.142.0" } }, "sha512-kKR+jPiRJYJDexVoziIg/FVGvr1fT1FZSSJOk6tVoMKKSlsf1Cso+cgGCJkOEDWOP174vRntCPFKg+AS7InWvw=="],
 
     "oxc-resolver": ["oxc-resolver@11.24.2", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.24.2", "@oxc-resolver/binding-android-arm64": "11.24.2", "@oxc-resolver/binding-darwin-arm64": "11.24.2", "@oxc-resolver/binding-darwin-x64": "11.24.2", "@oxc-resolver/binding-freebsd-x64": "11.24.2", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.24.2", "@oxc-resolver/binding-linux-arm-musleabihf": "11.24.2", "@oxc-resolver/binding-linux-arm64-gnu": "11.24.2", "@oxc-resolver/binding-linux-arm64-musl": "11.24.2", "@oxc-resolver/binding-linux-ppc64-gnu": "11.24.2", "@oxc-resolver/binding-linux-riscv64-gnu": "11.24.2", "@oxc-resolver/binding-linux-riscv64-musl": "11.24.2", "@oxc-resolver/binding-linux-s390x-gnu": "11.24.2", "@oxc-resolver/binding-linux-x64-gnu": "11.24.2", "@oxc-resolver/binding-linux-x64-musl": "11.24.2", "@oxc-resolver/binding-openharmony-arm64": "11.24.2", "@oxc-resolver/binding-wasm32-wasi": "11.24.2", "@oxc-resolver/binding-win32-arm64-msvc": "11.24.2", "@oxc-resolver/binding-win32-x64-msvc": "11.24.2" } }, "sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw=="],
 
     "oxfmt": ["oxfmt@0.59.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.59.0", "@oxfmt/binding-android-arm64": "0.59.0", "@oxfmt/binding-darwin-arm64": "0.59.0", "@oxfmt/binding-darwin-x64": "0.59.0", "@oxfmt/binding-freebsd-x64": "0.59.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.59.0", "@oxfmt/binding-linux-arm-musleabihf": "0.59.0", "@oxfmt/binding-linux-arm64-gnu": "0.59.0", "@oxfmt/binding-linux-arm64-musl": "0.59.0", "@oxfmt/binding-linux-ppc64-gnu": "0.59.0", "@oxfmt/binding-linux-riscv64-gnu": "0.59.0", "@oxfmt/binding-linux-riscv64-musl": "0.59.0", "@oxfmt/binding-linux-s390x-gnu": "0.59.0", "@oxfmt/binding-linux-x64-gnu": "0.59.0", "@oxfmt/binding-linux-x64-musl": "0.59.0", "@oxfmt/binding-openharmony-arm64": "0.59.0", "@oxfmt/binding-win32-arm64-msvc": "0.59.0", "@oxfmt/binding-win32-ia32-msvc": "0.59.0", "@oxfmt/binding-win32-x64-msvc": "0.59.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-Xqk6cPZS1yMvVa7OAuenaDZUsgMDutvvbZ9/L5gSvAfW64+WN4HVhgipLj5rVERbYQt8fLs9TopyZ1rU1XEG/w=="],
 
     "oxlint": ["oxlint@1.71.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.71.0", "@oxlint/binding-android-arm64": "1.71.0", "@oxlint/binding-darwin-arm64": "1.71.0", "@oxlint/binding-darwin-x64": "1.71.0", "@oxlint/binding-freebsd-x64": "1.71.0", "@oxlint/binding-linux-arm-gnueabihf": "1.71.0", "@oxlint/binding-linux-arm-musleabihf": "1.71.0", "@oxlint/binding-linux-arm64-gnu": "1.71.0", "@oxlint/binding-linux-arm64-musl": "1.71.0", "@oxlint/binding-linux-ppc64-gnu": "1.71.0", "@oxlint/binding-linux-riscv64-gnu": "1.71.0", "@oxlint/binding-linux-riscv64-musl": "1.71.0", "@oxlint/binding-linux-s390x-gnu": "1.71.0", "@oxlint/binding-linux-x64-gnu": "1.71.0", "@oxlint/binding-linux-x64-musl": "1.71.0", "@oxlint/binding-openharmony-arm64": "1.71.0", "@oxlint/binding-win32-arm64-msvc": "1.71.0", "@oxlint/binding-win32-ia32-msvc": "1.71.0", "@oxlint/binding-win32-x64-msvc": "1.71.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-U1m1X+C0vDj7DC1e13IoZULzEcPczE7UOMTs8VlZGHUEIUaSTZKo5qkPsQEfzpgnQ29Pea/w3Xntk62UCecxZw=="],
+
+    "oxlint-plugin-react-doctor": ["oxlint-plugin-react-doctor@0.9.11", "", { "dependencies": { "@shaderfrog/glsl-parser": "^7.0.1", "@typescript-eslint/types": "^8.59.3", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "lightningcss": "^1.33.0", "oxc-parser": "^0.142.0" } }, "sha512-ZhW15wfFjQlUwAO6zG3jVZKse4/PBTCArhbibiidHmTlvOpPHPM1AjdYG13023pfsbbtVdy7Tb7KHfqbKt8rHg=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
@@ -2575,8 +2586,6 @@
 
     "@img/sharp-freebsd-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
 
-    "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
-
     "@img/sharp-webcontainers-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
@@ -2602,10 +2611,6 @@
     "@onyx-ai/opal/tailwind-merge": ["tailwind-merge@2.6.1", "", {}, "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ=="],
 
     "@onyx-ai/shared/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
-
-    "@oxc-resolver/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
-
-    "@oxc-resolver/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
 
     "@radix-ui/react-arrow/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.7", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ=="],
 
@@ -2667,6 +2672,8 @@
 
     "@sentry/cli/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
+    "@tailwindcss/node/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
     "@tailwindcss/node/tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
@@ -2704,10 +2711,6 @@
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "cosmiconfig/yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
-
-    "esquery/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
-
-    "esrecurse/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
@@ -2761,6 +2764,8 @@
 
     "stacktrace-parser/type-fest": ["type-fest@0.7.1", "", {}, "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="],
 
+    "storybook/oxc-parser": ["oxc-parser@0.127.0", "", { "dependencies": { "@oxc-project/types": "^0.127.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.127.0", "@oxc-parser/binding-android-arm64": "0.127.0", "@oxc-parser/binding-darwin-arm64": "0.127.0", "@oxc-parser/binding-darwin-x64": "0.127.0", "@oxc-parser/binding-freebsd-x64": "0.127.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.127.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.127.0", "@oxc-parser/binding-linux-arm64-gnu": "0.127.0", "@oxc-parser/binding-linux-arm64-musl": "0.127.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.127.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.127.0", "@oxc-parser/binding-linux-riscv64-musl": "0.127.0", "@oxc-parser/binding-linux-s390x-gnu": "0.127.0", "@oxc-parser/binding-linux-x64-gnu": "0.127.0", "@oxc-parser/binding-linux-x64-musl": "0.127.0", "@oxc-parser/binding-openharmony-arm64": "0.127.0", "@oxc-parser/binding-wasm32-wasi": "0.127.0", "@oxc-parser/binding-win32-arm64-msvc": "0.127.0", "@oxc-parser/binding-win32-ia32-msvc": "0.127.0", "@oxc-parser/binding-win32-x64-msvc": "0.127.0" } }, "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA=="],
+
     "string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "style-dictionary/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
@@ -2784,6 +2789,8 @@
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "webpack/eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^4.1.1" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -2813,8 +2820,6 @@
 
     "@jsonjoy.com/fs-snapshot/@jsonjoy.com/util/@jsonjoy.com/codegen": ["@jsonjoy.com/codegen@17.67.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q=="],
 
-    "@oxc-resolver/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
-
     "@radix-ui/react-menu/@radix-ui/react-popper/@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.10", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.6" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ=="],
 
     "@radix-ui/react-menubar/@radix-ui/react-menu/@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.5", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-primitive": "2.1.7", "@radix-ui/react-use-callback-ref": "1.1.2", "@radix-ui/react-use-effect-event": "0.0.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-b0XaRlzn2QKuo10XyNgi2DAJDf5XC9d1nD3FJcuvCjbR7+4Ad28zmZsLsqx+hvDEzMnRuZaZxZm9gYObV6RmRA=="],
@@ -2834,6 +2839,30 @@
     "@radix-ui/react-tooltip/@radix-ui/react-popper/@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.10", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.6" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ=="],
 
     "@sentry/cli/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "@unrs/resolver-binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "jest-config/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
@@ -2901,6 +2930,48 @@
 
     "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
+    "storybook/oxc-parser/@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.127.0", "", { "os": "android", "cpu": "arm" }, "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.127.0", "", { "os": "android", "cpu": "arm64" }, "sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-darwin-arm64": ["@oxc-parser/binding-darwin-arm64@0.127.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-darwin-x64": ["@oxc-parser/binding-darwin-x64@0.127.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-freebsd-x64": ["@oxc-parser/binding-freebsd-x64@0.127.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-linux-arm-gnueabihf": ["@oxc-parser/binding-linux-arm-gnueabihf@0.127.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-linux-arm-musleabihf": ["@oxc-parser/binding-linux-arm-musleabihf@0.127.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-linux-arm64-gnu": ["@oxc-parser/binding-linux-arm64-gnu@0.127.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-linux-arm64-musl": ["@oxc-parser/binding-linux-arm64-musl@0.127.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-linux-ppc64-gnu": ["@oxc-parser/binding-linux-ppc64-gnu@0.127.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-linux-riscv64-gnu": ["@oxc-parser/binding-linux-riscv64-gnu@0.127.0", "", { "os": "linux", "cpu": "none" }, "sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-linux-riscv64-musl": ["@oxc-parser/binding-linux-riscv64-musl@0.127.0", "", { "os": "linux", "cpu": "none" }, "sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-linux-s390x-gnu": ["@oxc-parser/binding-linux-s390x-gnu@0.127.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-linux-x64-gnu": ["@oxc-parser/binding-linux-x64-gnu@0.127.0", "", { "os": "linux", "cpu": "x64" }, "sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-linux-x64-musl": ["@oxc-parser/binding-linux-x64-musl@0.127.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-openharmony-arm64": ["@oxc-parser/binding-openharmony-arm64@0.127.0", "", { "os": "none", "cpu": "arm64" }, "sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi": ["@oxc-parser/binding-wasm32-wasi@0.127.0", "", { "dependencies": { "@emnapi/core": "1.9.2", "@emnapi/runtime": "1.9.2", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-win32-arm64-msvc": ["@oxc-parser/binding-win32-arm64-msvc@0.127.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-win32-ia32-msvc": ["@oxc-parser/binding-win32-ia32-msvc@0.127.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.127.0", "", { "os": "win32", "cpu": "x64" }, "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w=="],
+
+    "storybook/oxc-parser/@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+
     "test-exclude/minimatch/brace-expansion": ["brace-expansion@1.1.16", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw=="],
 
     "ts-unused-exports/tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
@@ -2957,6 +3028,8 @@
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
+    "webpack/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
+
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
     "@jest/reporters/glob/minimatch/brace-expansion": ["brace-expansion@2.1.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A=="],
@@ -2973,6 +3046,10 @@
 
     "pkg-dir/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
+    "storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
+
     "test-exclude/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
@@ -2984,5 +3061,7 @@
     "jest-runtime/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
+    "storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
   }
 }

--- a/web/lib/opal/src/components/inputs/input-select/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-select/components.tsx
@@ -355,16 +355,17 @@ function InputSelectItem({
   // registrations.
   const childrenRef = React.useRef<string | RichStr>(children);
   const iconRef = React.useRef(icon);
-  childrenRef.current = children;
-  iconRef.current = icon;
+  React.useLayoutEffect(() => {
+    childrenRef.current = children;
+    iconRef.current = icon;
+  }, [children, icon]);
 
   // Layout effect so the trigger never paints the placeholder on first
   // render when a value is already selected. Radix mounts closed Content
   // into a detached fragment, so this runs even while the menu is closed.
-  // Keyed on the rendered content (plain-text key, since RichStr identity
-  // churns per render) so the trigger mirror re-renders when the selected
-  // option's label or icon changes without a value change.
-  const childrenKey = toPlainString(children);
+  // Keyed on the raw rendered content so RichStr formatting changes still
+  // refresh the trigger without reacting to identity churn.
+  const childrenKey = typeof children === "string" ? children : children.raw;
   React.useLayoutEffect(() => {
     if (!isSelected) return;
     setSelectedItemDisplay({ childrenRef, iconRef });

--- a/web/lib/opal/src/components/modal/components.tsx
+++ b/web/lib/opal/src/components/modal/components.tsx
@@ -147,26 +147,18 @@ function ModalContent({
     hasUserTypedRef.current = true;
   }, []);
 
-  const containerNodeRef = React.useRef<HTMLDivElement | null>(null);
-
-  const contentRef = React.useCallback(
-    (node: HTMLDivElement | null) => {
-      if (containerNodeRef.current) {
-        containerNodeRef.current.removeEventListener(
-          "input",
-          handleInput,
-          true
-        );
-      }
-      if (node) {
-        node.addEventListener("input", handleInput, true);
-        containerNodeRef.current = node;
-      } else {
-        containerNodeRef.current = null;
-      }
-    },
-    [handleInput]
+  const [contentNode, setContentNode] = React.useState<HTMLDivElement | null>(
+    null
   );
+
+  React.useEffect(() => {
+    if (!contentNode) return;
+
+    contentNode.addEventListener("input", handleInput, true);
+    return () => {
+      contentNode.removeEventListener("input", handleInput, true);
+    };
+  }, [contentNode, handleInput]);
 
   const handleInteractOutside = React.useCallback(
     (e: Event) => {
@@ -198,9 +190,9 @@ function ModalContent({
       } else if (ref) {
         ref.current = node;
       }
-      contentRef(node);
+      setContentNode(node);
     },
-    [ref, contentRef]
+    [ref]
   );
 
   // Center on [data-main-container] when present (the content area beside

--- a/web/lib/opal/src/components/table/hooks/useDataTable.ts
+++ b/web/lib/opal/src/components/table/hooks/useDataTable.ts
@@ -455,8 +455,10 @@ export default function useDataTable<TData extends RowData>(
     table.toggleAllPageRowsSelected(selected);
   };
 
-  // In server-side mode, these only operate on the loaded page data because
-  // TanStack cannot select rows it has not loaded.
+  // TODO (@raunakab): In server-side mode, these only operate on the loaded
+  // page data, not all rows across all pages. TanStack can't select rows it
+  // doesn't have. Fixing this requires a server-side callback (e.g.
+  // `onSelectAll`) and a `totalItems`-aware selection model.
   const toggleAllRowsSelected = (selected: boolean) => {
     table.toggleAllRowsSelected(selected);
   };

--- a/web/lib/opal/src/components/table/hooks/useDataTable.ts
+++ b/web/lib/opal/src/components/table/hooks/useDataTable.ts
@@ -270,7 +270,9 @@ export default function useDataTable<TData extends RowData>(
   // Single ref for the whole serverSide config — prevents effects from
   // re-firing when the consumer passes an inline object each render.
   const serverSideRef = useRef(serverSide);
-  serverSideRef.current = serverSide;
+  useEffect(() => {
+    serverSideRef.current = serverSide;
+  }, [serverSide]);
 
   useEffect(() => {
     if (!isServerSide) return;
@@ -423,7 +425,9 @@ export default function useDataTable<TData extends RowData>(
   // ---- selection change callback ------------------------------------------
   const isFirstRenderRef = useRef(true);
   const onSelectionChangeRef = useRef(onSelectionChange);
-  onSelectionChangeRef.current = onSelectionChange;
+  useEffect(() => {
+    onSelectionChangeRef.current = onSelectionChange;
+  }, [onSelectionChange]);
 
   useEffect(() => {
     if (isFirstRenderRef.current) {
@@ -451,10 +455,8 @@ export default function useDataTable<TData extends RowData>(
     table.toggleAllPageRowsSelected(selected);
   };
 
-  // TODO (@raunakab): In server-side mode, these only operate on the loaded
-  // page data, not all rows across all pages. TanStack can't select rows it
-  // doesn't have. Fixing this requires a server-side callback (e.g.
-  // `onSelectAll`) and a `totalItems`-aware selection model.
+  // In server-side mode, these only operate on the loaded page data because
+  // TanStack cannot select rows it has not loaded.
   const toggleAllRowsSelected = (selected: boolean) => {
     table.toggleAllRowsSelected(selected);
   };

--- a/web/lib/opal/src/components/tabs/hooks.ts
+++ b/web/lib/opal/src/components/tabs/hooks.ts
@@ -46,6 +46,9 @@ export function usePillIndicator(
   const [isScrolling, setIsScrolling] = useState(false);
   const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
+  // The scroll-debounce timer is ref-held and cleared in this effect's
+  // cleanup. The rule cannot trace handler-created timers.
+  // oxlint-disable-next-line react-doctor/effect-needs-cleanup
   useEffect(() => {
     if (!enabled) return;
 

--- a/web/lib/opal/src/layouts/root/components.tsx
+++ b/web/lib/opal/src/layouts/root/components.tsx
@@ -46,7 +46,9 @@ export function SidebarStateProvider({
   const [folded, setFoldedInternal] = useState(defaultFolded);
 
   const onFoldedChangeRef = useRef(onFoldedChange);
-  onFoldedChangeRef.current = onFoldedChange;
+  useEffect(() => {
+    onFoldedChangeRef.current = onFoldedChange;
+  }, [onFoldedChange]);
 
   const setFolded: Dispatch<SetStateAction<boolean>> = useCallback((value) => {
     setFoldedInternal((prev) =>

--- a/web/package.json
+++ b/web/package.json
@@ -136,6 +136,7 @@
     "jest-environment-jsdom": "^30.2.0",
     "oxfmt": "0.59.0",
     "oxlint": "^1.66.0",
+    "oxlint-plugin-react-doctor": "0.9.11",
     "stats.js": "^0.17.0",
     "storybook": "10.5.0",
     "tailwindcss": "^4.3.0",

--- a/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/StringPairListInput.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/StringPairListInput.tsx
@@ -47,13 +47,30 @@ const StringPairListInput: React.FC<StringPairListInputProps> = ({
   // state (focus/autofill) onto the row that takes its index. Index keys would;
   // content-derived keys would remount the row on every keystroke. New rows are
   // seeded here; the remove handler splices so each id stays with its row.
-  const rowIdsRef = React.useRef<number[]>([]);
-  const nextRowIdRef = React.useRef(0);
-  while (rowIdsRef.current.length < pairs.length) {
-    rowIdsRef.current.push(nextRowIdRef.current++);
-  }
-  if (rowIdsRef.current.length > pairs.length) {
-    rowIdsRef.current.length = pairs.length;
+  const [rowKeys, setRowKeys] = React.useState<{
+    keys: number[];
+    nextKey: number;
+  }>({
+    keys: pairs.map((_, index) => index),
+    nextKey: pairs.length,
+  });
+  if (rowKeys.keys.length < pairs.length) {
+    const keysToAdd = pairs.length - rowKeys.keys.length;
+    setRowKeys({
+      keys: [
+        ...rowKeys.keys,
+        ...Array.from(
+          { length: keysToAdd },
+          (_, index) => rowKeys.nextKey + index
+        ),
+      ],
+      nextKey: rowKeys.nextKey + keysToAdd,
+    });
+  } else if (rowKeys.keys.length > pairs.length) {
+    setRowKeys({
+      keys: rowKeys.keys.slice(0, pairs.length),
+      nextKey: rowKeys.nextKey,
+    });
   }
 
   return (
@@ -89,7 +106,7 @@ const StringPairListInput: React.FC<StringPairListInputProps> = ({
 
             {pairs.map((_, index) => (
               <Section
-                key={rowIdsRef.current[index]}
+                key={rowKeys.keys[index]}
                 gap={0.25}
                 alignItems="start"
                 width="full"
@@ -118,7 +135,10 @@ const StringPairListInput: React.FC<StringPairListInputProps> = ({
                     type="button"
                     tooltip="Remove"
                     onClick={() => {
-                      rowIdsRef.current.splice(index, 1);
+                      setRowKeys((prev) => ({
+                        keys: prev.keys.filter((_, i) => i !== index),
+                        nextKey: prev.nextKey,
+                      }));
                       arrayHelpers.remove(index);
                     }}
                   />
@@ -136,9 +156,13 @@ const StringPairListInput: React.FC<StringPairListInputProps> = ({
               icon={SvgPlusCircle}
               prominence="secondary"
               type="button"
-              onClick={() =>
-                arrayHelpers.push({ [leftKey]: "", [rightKey]: "" })
-              }
+              onClick={() => {
+                setRowKeys((prev) => ({
+                  keys: [...prev.keys, prev.nextKey],
+                  nextKey: prev.nextKey + 1,
+                }));
+                arrayHelpers.push({ [leftKey]: "", [rightKey]: "" });
+              }}
             >
               Add New
             </Button>

--- a/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/StringPairListInput.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/StringPairListInput.tsx
@@ -46,7 +46,8 @@ const StringPairListInput: React.FC<StringPairListInputProps> = ({
   // Stable per-row keys so removing a middle row doesn't shift native input
   // state (focus/autofill) onto the row that takes its index. Index keys would;
   // content-derived keys would remount the row on every keystroke. New rows are
-  // seeded here; the remove handler splices so each id stays with its row.
+  // seeded here, and the remove handler drops the key at that index so each id
+  // stays with its row.
   const [rowKeys, setRowKeys] = React.useState<{
     keys: number[];
     nextKey: number;
@@ -157,10 +158,6 @@ const StringPairListInput: React.FC<StringPairListInputProps> = ({
               prominence="secondary"
               type="button"
               onClick={() => {
-                setRowKeys((prev) => ({
-                  keys: [...prev.keys, prev.nextKey],
-                  nextKey: prev.nextKey + 1,
-                }));
                 arrayHelpers.push({ [leftKey]: "", [rightKey]: "" });
               }}
             >

--- a/web/src/app/app/message/HumanMessage.tsx
+++ b/web/src/app/app/message/HumanMessage.tsx
@@ -56,8 +56,6 @@ function MessageEditing({
           className={cn(
             "w-full h-full resize-none outline-hidden bg-transparent overflow-y-scroll whitespace-normal break-word"
           )}
-          aria-multiline
-          role="textarea"
           value={editedContent}
           style={{ scrollbarWidth: "thin" }}
           onChange={(e) => {

--- a/web/src/app/app/message/MultiModelResponseView.tsx
+++ b/web/src/app/app/message/MultiModelResponseView.tsx
@@ -102,28 +102,20 @@ export default function MultiModelResponseView({
   const [selectionExiting, setSelectionExiting] = useState(false);
   // Measures the overflow-hidden carousel container for responsive preferred-panel sizing.
   const [trackContainerW, setTrackContainerW] = useState(0);
-  const roRef = useRef<ResizeObserver | null>(null);
   const trackContainerElRef = useRef<HTMLDivElement | null>(null);
+  const [trackContainerEl, setTrackContainerEl] =
+    useState<HTMLDivElement | null>(null);
   const trackContainerRef = useCallback((el: HTMLDivElement | null) => {
     trackContainerElRef.current = el;
-    if (roRef.current) {
-      roRef.current.disconnect();
-      roRef.current = null;
-    }
-    if (!el) return;
-    const ro = new ResizeObserver(([entry]) => {
-      setTrackContainerW(entry?.contentRect.width ?? 0);
-    });
-    ro.observe(el);
-    setTrackContainerW(el.offsetWidth);
-    roRef.current = ro;
+    setTrackContainerEl(el);
   }, []);
 
   // Measures the preferred panel's height to cap non-preferred panels in selection mode.
   const [preferredPanelHeight, setPreferredPanelHeight] = useState<
     number | null
   >(null);
-  const preferredRoRef = useRef<ResizeObserver | null>(null);
+  const [preferredPanelEl, setPreferredPanelEl] =
+    useState<HTMLDivElement | null>(null);
   // Refs to each panel wrapper for height animation on deselect
   const panelElsRef = useRef<Map<number, HTMLDivElement>>(new Map());
 
@@ -148,21 +140,40 @@ export default function MultiModelResponseView({
     });
   }, [preferredPanelHeight, preferredIndex, hiddenPanels, responses]);
 
+  useLayoutEffect(() => {
+    if (!trackContainerEl) return;
+    const ro = new ResizeObserver(([entry]) => {
+      setTrackContainerW(entry?.contentRect.width ?? 0);
+    });
+    ro.observe(trackContainerEl);
+    setTrackContainerW(trackContainerEl.offsetWidth);
+    return () => ro.disconnect();
+  }, [trackContainerEl]);
+
   const preferredPanelRef = useCallback((el: HTMLDivElement | null) => {
-    if (preferredRoRef.current) {
-      preferredRoRef.current.disconnect();
-      preferredRoRef.current = null;
-    }
-    if (!el) {
+    setPreferredPanelEl(el);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!preferredPanelEl) {
       setPreferredPanelHeight(null);
       return;
     }
     const ro = new ResizeObserver(([entry]) => {
       setPreferredPanelHeight(entry?.contentRect.height ?? 0);
     });
-    ro.observe(el);
-    setPreferredPanelHeight(el.offsetHeight);
-    preferredRoRef.current = ro;
+    ro.observe(preferredPanelEl);
+    setPreferredPanelHeight(preferredPanelEl.offsetHeight);
+    return () => ro.disconnect();
+  }, [preferredPanelEl]);
+
+  useEffect(() => {
+    return () => {
+      if (deselectTimeoutRef.current !== null) {
+        clearTimeout(deselectTimeoutRef.current);
+        deselectTimeoutRef.current = null;
+      }
+    };
   }, []);
 
   const isGenerating = useMemo(

--- a/web/src/app/app/message/MultiModelResponseView.tsx
+++ b/web/src/app/app/message/MultiModelResponseView.tsx
@@ -150,10 +150,6 @@ export default function MultiModelResponseView({
     return () => ro.disconnect();
   }, [trackContainerEl]);
 
-  const preferredPanelRef = useCallback((el: HTMLDivElement | null) => {
-    setPreferredPanelEl(el);
-  }, []);
-
   useLayoutEffect(() => {
     if (!preferredPanelEl) {
       setPreferredPanelHeight(null);
@@ -565,7 +561,7 @@ export default function MultiModelResponseView({
                   } else {
                     panelElsRef.current.delete(r.modelIndex);
                   }
-                  if (isPref) preferredPanelRef(el);
+                  if (isPref) setPreferredPanelEl(el);
                 }}
                 style={{
                   width: `${selectionEntered ? finalW : startW}px`,

--- a/web/src/app/app/message/messageComponents/hooks/useAuthErrors.ts
+++ b/web/src/app/app/message/messageComponents/hooks/useAuthErrors.ts
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useMemo } from "react";
 import {
   CustomToolDelta,
   Packet,
@@ -11,43 +11,37 @@ interface AuthError {
 }
 
 export function useAuthErrors(rawPackets: Packet[]): AuthError[] {
-  const stateRef = useRef<{ processedCount: number; errors: AuthError[] }>({
-    processedCount: 0,
-    errors: [],
-  });
+  // Keyed on the packet array so typewriter-frame renders between batches
+  // reuse the same result identity instead of rescanning.
+  return useMemo(() => computeAuthErrors(rawPackets), [rawPackets]);
+}
 
-  // Reset if packets shrunk (e.g. new message)
-  if (rawPackets.length < stateRef.current.processedCount) {
-    stateRef.current = { processedCount: 0, errors: [] };
-  }
+function computeAuthErrors(rawPackets: Packet[]): AuthError[] {
+  const errors: AuthError[] = [];
 
-  // Process only new packets (incremental, like usePacketProcessor)
-  if (rawPackets.length > stateRef.current.processedCount) {
-    let newErrors = stateRef.current.errors;
-    for (let i = stateRef.current.processedCount; i < rawPackets.length; i++) {
-      const packet = rawPackets[i]!;
-      if (packet.obj.type === PacketType.CUSTOM_TOOL_DELTA) {
-        const delta = packet.obj as CustomToolDelta;
-        if (delta.error?.is_auth_error) {
-          const alreadyPresent = newErrors.some(
-            (e) =>
-              (delta.tool_id != null && e.toolId === delta.tool_id) ||
-              (delta.tool_id == null && e.toolName === delta.tool_name)
-          );
-          if (!alreadyPresent) {
-            newErrors = [
-              ...newErrors,
-              { toolName: delta.tool_name, toolId: delta.tool_id ?? null },
-            ];
-          }
-        }
-      }
+  for (const packet of rawPackets) {
+    if (packet.obj.type !== PacketType.CUSTOM_TOOL_DELTA) {
+      continue;
     }
-    stateRef.current = {
-      processedCount: rawPackets.length,
-      errors: newErrors,
-    };
+
+    const delta = packet.obj as CustomToolDelta;
+    if (!delta.error?.is_auth_error) {
+      continue;
+    }
+
+    const alreadyPresent = errors.some(
+      (error) =>
+        (delta.tool_id != null && error.toolId === delta.tool_id) ||
+        (delta.tool_id == null && error.toolName === delta.tool_name)
+    );
+
+    if (!alreadyPresent) {
+      errors.push({
+        toolName: delta.tool_name,
+        toolId: delta.tool_id ?? null,
+      });
+    }
   }
 
-  return stateRef.current.errors;
+  return errors;
 }

--- a/web/src/app/app/message/messageComponents/hooks/useAuthErrors.ts
+++ b/web/src/app/app/message/messageComponents/hooks/useAuthErrors.ts
@@ -11,8 +11,8 @@ interface AuthError {
 }
 
 export function useAuthErrors(rawPackets: Packet[]): AuthError[] {
-  // Keyed on the packet array so typewriter-frame renders between batches
-  // reuse the same result identity instead of rescanning.
+  // Keyed on the packet array so re-renders between packet batches reuse
+  // the same result identity instead of rescanning.
   return useMemo(() => computeAuthErrors(rawPackets), [rawPackets]);
 }
 

--- a/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
@@ -339,8 +339,10 @@ export const MessageTextRenderer: MessageRenderer<
   // never change — otherwise every typewriter tick would invalidate
   // React reconciliation on the markdown subtree.
   const stateRef = useRef(state);
+  // oxlint-disable-next-line react-doctor/no-ref-current-in-render
   stateRef.current = state;
   const processedContentRef = useRef(processedContent);
+  // oxlint-disable-next-line react-doctor/no-ref-current-in-render
   processedContentRef.current = processedContent;
 
   const markdownComponents = useMemo<Components>(

--- a/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
@@ -339,10 +339,10 @@ export const MessageTextRenderer: MessageRenderer<
   // never change — otherwise every typewriter tick would invalidate
   // React reconciliation on the markdown subtree.
   const stateRef = useRef(state);
-  // oxlint-disable-next-line react-doctor/no-ref-current-in-render
+  // oxlint-disable-next-line react-doctor/no-ref-current-in-render -- render-phase mirror keeps markdownComponents identities stable (see block comment above)
   stateRef.current = state;
   const processedContentRef = useRef(processedContent);
-  // oxlint-disable-next-line react-doctor/no-ref-current-in-render
+  // oxlint-disable-next-line react-doctor/no-ref-current-in-render -- render-phase mirror keeps markdownComponents identities stable (see block comment above)
   processedContentRef.current = processedContent;
 
   const markdownComponents = useMemo<Components>(

--- a/web/src/app/app/message/messageComponents/timeline/hooks/usePacedTurnGroups.ts
+++ b/web/src/app/app/message/messageComponents/timeline/hooks/usePacedTurnGroups.ts
@@ -71,6 +71,13 @@ function createInitialPacingState(): PacingState {
   };
 }
 
+function createInitialPacingStateForNode(nodeId: string): PacingState {
+  return {
+    ...createInitialPacingState(),
+    nodeId,
+  };
+}
+
 /**
  * Hook that adds pacing delays between steps during streaming.
  * Creates visual breathing room between agent activities.
@@ -97,8 +104,13 @@ export function usePacedTurnGroups(
   pacedDisplayGroups: GroupedPacket[];
   pacedFinalAnswerComing: boolean;
 } {
+  // Stable nodeId string for comparison
+  const nodeIdStr = String(nodeId);
+
   // Ref-based pacing state (no re-renders)
-  const stateRef = useRef<PacingState>(createInitialPacingState());
+  const stateRef = useRef<PacingState>(
+    createInitialPacingStateForNode(nodeIdStr)
+  );
 
   // Track previous finalAnswerComing to detect tool-after-message transitions
   const prevFinalAnswerComingRef = useRef(finalAnswerComing);
@@ -110,21 +122,13 @@ export function usePacedTurnGroups(
   // Trigger re-render when content should update
   // Used in useMemo dependencies since state.revealedStepKeys is stored in a ref
   const [revealTrigger, setRevealTrigger] = useState(0);
-
-  // Stable nodeId string for comparison
-  const nodeIdStr = String(nodeId);
-
-  // Reset on nodeId change
-  if (stateRef.current.nodeId !== nodeIdStr) {
-    if (stateRef.current.pacingTimer) {
-      clearTimeout(stateRef.current.pacingTimer);
-    }
-    stateRef.current = createInitialPacingState();
-    stateRef.current.nodeId = nodeIdStr;
-    prevPacedRef.current = [];
-  }
-
-  const state = stateRef.current;
+  const [timerTrigger, setTimerTrigger] = useState(0);
+  const resetState = useMemo(
+    () => createInitialPacingStateForNode(nodeIdStr),
+    [nodeIdStr]
+  );
+  const hasNodeChanged = stateRef.current.nodeId !== nodeIdStr;
+  const state = hasNodeChanged ? resetState : stateRef.current;
 
   // Bypass pacing for completed messages (old messages loaded from history)
   // If stopPacketSeen is true on first render, return everything immediately
@@ -145,7 +149,7 @@ export function usePacedTurnGroups(
 
       // Schedule next step if more pending (always delay, regardless of type)
       if (state.pendingSteps.length > 0) {
-        state.pacingTimer = setTimeout(revealNextPendingStep, PACING_DELAY_MS);
+        setTimerTrigger((t) => t + 1);
         setRevealTrigger((t) => t + 1);
         return;
       }
@@ -156,6 +160,48 @@ export function usePacedTurnGroups(
     state.pacingTimer = null;
     setRevealTrigger((t) => t + 1);
   }, []);
+
+  useEffect(() => {
+    if (!hasNodeChanged) {
+      return;
+    }
+
+    if (stateRef.current.pacingTimer) {
+      clearTimeout(stateRef.current.pacingTimer);
+    }
+
+    stateRef.current = resetState;
+    prevPacedRef.current = [];
+    prevFinalAnswerComingRef.current = finalAnswerComing;
+  }, [finalAnswerComing, hasNodeChanged, resetState]);
+
+  useEffect(() => {
+    const state = stateRef.current;
+
+    if (
+      shouldBypassPacing ||
+      state.pendingSteps.length === 0 ||
+      state.pacingTimer
+    ) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      if (stateRef.current.pacingTimer === timer) {
+        stateRef.current.pacingTimer = null;
+      }
+      revealNextPendingStep();
+    }, PACING_DELAY_MS);
+
+    state.pacingTimer = timer;
+
+    return () => {
+      clearTimeout(timer);
+      if (stateRef.current.pacingTimer === timer) {
+        stateRef.current.pacingTimer = null;
+      }
+    };
+  }, [revealNextPendingStep, shouldBypassPacing, timerTrigger]);
 
   // Process incoming turn groups
   useEffect(() => {
@@ -256,7 +302,7 @@ export function usePacedTurnGroups(
 
       // Start timer if not already running
       if (!state.pacingTimer && state.pendingSteps.length === 1) {
-        state.pacingTimer = setTimeout(revealNextPendingStep, PACING_DELAY_MS);
+        setTimerTrigger((t) => t + 1);
       }
     }
 
@@ -270,16 +316,10 @@ export function usePacedTurnGroups(
     finalAnswerComing,
     revealNextPendingStep,
     shouldBypassPacing,
+    // Re-process after the node-change reset so the fresh state's first step
+    // reveals immediately even when the group identities are unchanged.
+    nodeIdStr,
   ]);
-
-  // Cleanup timer on unmount
-  useEffect(() => {
-    return () => {
-      if (stateRef.current.pacingTimer) {
-        clearTimeout(stateRef.current.pacingTimer);
-      }
-    };
-  }, []);
 
   // Build paced turn groups from revealed step keys
   // Memoized to prevent unnecessary re-renders in downstream components
@@ -305,7 +345,7 @@ export function usePacedTurnGroups(
     // Stabilize: reuse previous TurnGroup objects when their content hasn't changed.
     // This preserves referential equality for completed groups, preventing
     // unnecessary re-renders in downstream components (e.g. SearchChipList).
-    const prev = prevPacedRef.current;
+    const prev = hasNodeChanged ? [] : prevPacedRef.current;
     if (prev.length === result.length) {
       let allMatch = true;
       for (let i = 0; i < result.length; i++) {
@@ -332,10 +372,13 @@ export function usePacedTurnGroups(
       }
     }
 
-    prevPacedRef.current = result;
     return result;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [toolTurnGroups, revealTrigger, shouldBypassPacing]);
+  }, [toolTurnGroups, revealTrigger, shouldBypassPacing, hasNodeChanged]);
+
+  useEffect(() => {
+    prevPacedRef.current = pacedTurnGroups;
+  }, [pacedTurnGroups]);
 
   // Only return display groups when tool pacing is complete (or bypassing).
   // Also bypass when stop packet is already seen (e.g. history reload of stopped messages)

--- a/web/src/app/app/message/messageComponents/timeline/hooks/usePacedTurnGroups.ts
+++ b/web/src/app/app/message/messageComponents/timeline/hooks/usePacedTurnGroups.ts
@@ -59,7 +59,7 @@ interface PacingState {
   nodeId: string | null;
 }
 
-function createInitialPacingState(): PacingState {
+function createInitialPacingState(nodeId: string): PacingState {
   return {
     revealedStepKeys: new Set(),
     lastRevealedPacketType: null,
@@ -67,13 +67,6 @@ function createInitialPacingState(): PacingState {
     pacingTimer: null,
     toolPacingComplete: false,
     stopPacketSeen: false,
-    nodeId: null,
-  };
-}
-
-function createInitialPacingStateForNode(nodeId: string): PacingState {
-  return {
-    ...createInitialPacingState(),
     nodeId,
   };
 }
@@ -108,9 +101,7 @@ export function usePacedTurnGroups(
   const nodeIdStr = String(nodeId);
 
   // Ref-based pacing state (no re-renders)
-  const stateRef = useRef<PacingState>(
-    createInitialPacingStateForNode(nodeIdStr)
-  );
+  const stateRef = useRef<PacingState>(createInitialPacingState(nodeIdStr));
 
   // Track previous finalAnswerComing to detect tool-after-message transitions
   const prevFinalAnswerComingRef = useRef(finalAnswerComing);
@@ -124,7 +115,7 @@ export function usePacedTurnGroups(
   const [revealTrigger, setRevealTrigger] = useState(0);
   const [timerTrigger, setTimerTrigger] = useState(0);
   const resetState = useMemo(
-    () => createInitialPacingStateForNode(nodeIdStr),
+    () => createInitialPacingState(nodeIdStr),
     [nodeIdStr]
   );
   const hasNodeChanged = stateRef.current.nodeId !== nodeIdStr;

--- a/web/src/app/app/message/messageComponents/timeline/hooks/usePacketProcessor.ts
+++ b/web/src/app/app/message/messageComponents/timeline/hooks/usePacketProcessor.ts
@@ -1,3 +1,8 @@
+/* oxlint-disable react-doctor/no-ref-current-in-render --
+   Render-phase incremental packet processing is this hook's core design:
+   state advances idempotently from a packet-index cursor, so replayed or
+   discarded renders recompute the same result, and consumers (including
+   child mount effects) need the processed state in the same commit. */
 import { useRef, useState, useMemo, useCallback } from "react";
 import {
   Packet,

--- a/web/src/app/app/message/messageComponents/timeline/hooks/usePacketProcessor.ts
+++ b/web/src/app/app/message/messageComponents/timeline/hooks/usePacketProcessor.ts
@@ -1,8 +1,6 @@
-/* oxlint-disable react-doctor/no-ref-current-in-render --
-   Render-phase incremental packet processing is this hook's core design:
-   state advances idempotently from a packet-index cursor, so replayed or
-   discarded renders recompute the same result, and consumers (including
-   child mount effects) need the processed state in the same commit. */
+/* oxlint-disable react-doctor/no-ref-current-in-render -- render-phase
+   incremental processing is the core design: the packet cursor makes
+   replays idempotent and consumers need the state in the same commit. */
 import { useRef, useState, useMemo, useCallback } from "react";
 import {
   Packet,

--- a/web/src/app/app/message/messageComponents/timeline/renderers/reasoning/ReasoningRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/reasoning/ReasoningRenderer.tsx
@@ -124,35 +124,47 @@ export const ReasoningRenderer: MessageRenderer<
   // Handle reasoning completion with minimum duration
   useEffect(() => {
     if (
-      hasEnd &&
-      reasoningStartTime !== null &&
-      !completionHandledRef.current
+      !hasEnd ||
+      reasoningStartTime === null ||
+      completionHandledRef.current
     ) {
-      completionHandledRef.current = true;
-      const elapsedTime = Date.now() - reasoningStartTime;
-      const minimumThinkingDuration = animate ? THINKING_MIN_DURATION_MS : 0;
-
-      if (elapsedTime >= minimumThinkingDuration) {
-        // Enough time has passed, complete immediately
-        onComplete();
-      } else {
-        // Not enough time has passed, delay completion
-        const remainingTime = minimumThinkingDuration - elapsedTime;
-        timeoutRef.current = setTimeout(() => {
-          onComplete();
-        }, remainingTime);
-      }
+      return;
     }
-  }, [hasEnd, reasoningStartTime, animate, onComplete]);
 
-  // Cleanup timeout on unmount
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
+    const complete = () => {
+      if (!completionHandledRef.current) {
+        completionHandledRef.current = true;
+        onComplete();
       }
     };
-  }, []);
+
+    const elapsedTime = Date.now() - reasoningStartTime;
+    const minimumThinkingDuration = animate ? THINKING_MIN_DURATION_MS : 0;
+
+    if (elapsedTime >= minimumThinkingDuration) {
+      // Enough time has passed, complete immediately
+      complete();
+      return;
+    }
+
+    // Not enough time has passed, delay completion
+    const remainingTime = minimumThinkingDuration - elapsedTime;
+    const timeout = setTimeout(() => {
+      if (timeoutRef.current === timeout) {
+        timeoutRef.current = null;
+      }
+      complete();
+    }, remainingTime);
+
+    timeoutRef.current = timeout;
+
+    return () => {
+      clearTimeout(timeout);
+      if (timeoutRef.current === timeout) {
+        timeoutRef.current = null;
+      }
+    };
+  }, [hasEnd, reasoningStartTime, animate, onComplete]);
 
   // Markdown renderer callback for ExpandableTextDisplay
   // Uses collapsed components (no spacing) in collapsed view, normal spacing in expanded modal

--- a/web/src/app/app/message/messageComponents/timeline/renderers/reasoning/ReasoningRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/reasoning/ReasoningRenderer.tsx
@@ -111,7 +111,6 @@ export const ReasoningRenderer: MessageRenderer<
   const [reasoningStartTime, setReasoningStartTime] = useState<number | null>(
     null
   );
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const completionHandledRef = useRef(false);
 
   // Track when reasoning starts
@@ -142,28 +141,13 @@ export const ReasoningRenderer: MessageRenderer<
     const minimumThinkingDuration = animate ? THINKING_MIN_DURATION_MS : 0;
 
     if (elapsedTime >= minimumThinkingDuration) {
-      // Enough time has passed, complete immediately
       complete();
       return;
     }
 
-    // Not enough time has passed, delay completion
     const remainingTime = minimumThinkingDuration - elapsedTime;
-    const timeout = setTimeout(() => {
-      if (timeoutRef.current === timeout) {
-        timeoutRef.current = null;
-      }
-      complete();
-    }, remainingTime);
-
-    timeoutRef.current = timeout;
-
-    return () => {
-      clearTimeout(timeout);
-      if (timeoutRef.current === timeout) {
-        timeoutRef.current = null;
-      }
-    };
+    const timeout = setTimeout(complete, remainingTime);
+    return () => clearTimeout(timeout);
   }, [hasEnd, reasoningStartTime, animate, onComplete]);
 
   // Markdown renderer callback for ExpandableTextDisplay

--- a/web/src/app/craft/components/BuildMessageList.tsx
+++ b/web/src/app/craft/components/BuildMessageList.tsx
@@ -213,7 +213,9 @@ export default function BuildMessageList({
               initial={
                 opts.isCurrentStream ? { opacity: 0, y: -4, height: 0 } : false
               }
+              // oxlint-disable-next-line react-doctor/no-layout-property-animation -- height 0/auto must reflow the message list, transform cannot
               animate={{ opacity: 1, y: 0, height: "auto" }}
+              // oxlint-disable-next-line react-doctor/no-layout-property-animation -- height/marginTop collapse must reflow the message list, transform cannot
               exit={{ opacity: 0, y: -6, height: 0, marginTop: 0 }}
               transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
             >

--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -206,6 +206,9 @@ export default function BuildChatPanel({
     turnId: string;
     timer: ReturnType<typeof setTimeout>;
   } | null>(null);
+  const nameSessionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
   const isPreProvisioning = useIsPreProvisioning();
   const isPreProvisioningFailed = useIsPreProvisioningFailed();
   const preProvisionedSessionId = usePreProvisionedSessionId();
@@ -536,7 +539,16 @@ export default function BuildChatPanel({
         // Schedule naming after delay (message will be saved by then)
         // Note: Don't call refreshSessionHistory() here - it would overwrite the
         // optimistic update from consumePreProvisionedSession() before the message is saved
-        setTimeout(() => nameBuildSession(newSessionId), 1000);
+        if (nameSessionTimeoutRef.current !== null) {
+          clearTimeout(nameSessionTimeoutRef.current);
+        }
+        // Store-level persistence that must survive unmount. Firing before
+        // the 1s save window would name against an unsaved message.
+        // oxlint-disable-next-line react-doctor/effect-needs-cleanup
+        nameSessionTimeoutRef.current = setTimeout(() => {
+          nameSessionTimeoutRef.current = null;
+          nameBuildSession(newSessionId);
+        }, 1000);
 
         // Stream the response (uses session ID directly, not currentSessionId)
         await streamMessage(newSessionId, message, chosen, attachments);

--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -542,8 +542,8 @@ export default function BuildChatPanel({
         if (nameSessionTimeoutRef.current !== null) {
           clearTimeout(nameSessionTimeoutRef.current);
         }
-        // Store-level persistence that must survive unmount. Firing before
-        // the 1s save window would name against an unsaved message.
+        // Session naming is a store action that must survive unmount. Firing
+        // before the 1s save window would name against an unsaved message.
         // oxlint-disable-next-line react-doctor/effect-needs-cleanup
         nameSessionTimeoutRef.current = setTimeout(() => {
           nameSessionTimeoutRef.current = null;

--- a/web/src/app/craft/components/OpencodeDebugLogs.tsx
+++ b/web/src/app/craft/components/OpencodeDebugLogs.tsx
@@ -115,7 +115,9 @@ function LogStreamPane({ open }: LogStreamPaneProps) {
   // Refs mirror the state inside the SSE reader's hot loop without
   // forcing it to re-bind on every state change.
   const followRef = useRef<boolean>(follow);
-  followRef.current = follow;
+  useEffect(() => {
+    followRef.current = follow;
+  }, [follow]);
 
   const appendLine = useCallback((text: string) => {
     const line: LogLine = {

--- a/web/src/app/craft/contexts/BuildContext.tsx
+++ b/web/src/app/craft/contexts/BuildContext.tsx
@@ -42,12 +42,10 @@ export function BuildProvider({ children }: BuildProviderProps) {
   }, []);
 
   const toggleVideoBackground = useCallback(() => {
-    setVideoBackgroundEnabled((prev) => {
-      const next = !prev;
-      localStorage.setItem(VIDEO_BACKGROUND_STORAGE_KEY, String(next));
-      return next;
-    });
-  }, []);
+    const next = !videoBackgroundEnabled;
+    setVideoBackgroundEnabled(next);
+    localStorage.setItem(VIDEO_BACKGROUND_STORAGE_KEY, String(next));
+  }, [videoBackgroundEnabled]);
 
   const value = useMemo<BuildContextValue>(
     () => ({

--- a/web/src/app/craft/contexts/UploadFilesContext.tsx
+++ b/web/src/app/craft/contexts/UploadFilesContext.tsx
@@ -270,6 +270,7 @@ export function UploadFilesProvider({ children }: UploadFilesProviderProps) {
   const [currentMessageFiles, setCurrentMessageFiles] = useState<BuildFile[]>(
     []
   );
+  const currentMessageFilesRef = useRef<BuildFile[]>([]);
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
 
   // Get triggerFilesRefresh from the store to refresh the file explorer
@@ -305,6 +306,10 @@ export function UploadFilesProvider({ children }: UploadFilesProviderProps) {
     );
   }, [currentMessageFiles]);
 
+  useEffect(() => {
+    currentMessageFilesRef.current = currentMessageFiles;
+  }, [currentMessageFiles]);
+
   // =========================================================================
   // Internal operations (not exposed to consumers)
   // =========================================================================
@@ -318,26 +323,23 @@ export function UploadFilesProvider({ children }: UploadFilesProviderProps) {
     async (sessionId: string): Promise<void> => {
       if (isUploadingPendingRef.current) return;
 
-      // Read current files and find pending ones atomically
-      let pendingFiles: BuildFile[] = [];
-      setCurrentMessageFiles((prev) => {
-        pendingFiles = prev.filter(
-          (f) => f.status === UploadFileStatus.PENDING && f.file
-        );
-        // Mark as uploading in the same state update to avoid race conditions
-        if (pendingFiles.length > 0) {
-          return prev.map((f) =>
-            pendingFiles.some((pf) => pf.id === f.id)
-              ? { ...f, status: UploadFileStatus.UPLOADING }
-              : f
-          );
-        }
-        return prev;
-      });
+      const currentFiles = currentMessageFilesRef.current;
+      const pendingFiles = currentFiles.filter(
+        (f) => f.status === UploadFileStatus.PENDING && f.file
+      );
 
       if (pendingFiles.length === 0) return;
 
       isUploadingPendingRef.current = true;
+      // Functional update so a concurrent add/remove in the same batch is
+      // never clobbered. The ref syncs from state in its own effect.
+      setCurrentMessageFiles((prev) =>
+        prev.map((f) =>
+          pendingFiles.some((pf) => pf.id === f.id)
+            ? { ...f, status: UploadFileStatus.UPLOADING }
+            : f
+        )
+      );
 
       try {
         // Upload in parallel
@@ -699,23 +701,22 @@ export function UploadFilesProvider({ children }: UploadFilesProviderProps) {
       // Track this deletion to prevent refetch race condition
       activeDeletionsRef.current.add(fileId);
 
-      // Use functional update to get current state and avoid stale closures
-      let removedFile: BuildFile | null = null;
-      let removedIndex = -1;
+      const currentFiles = currentMessageFilesRef.current;
+      const removedIndex = currentFiles.findIndex((f) => f.id === fileId);
+      if (removedIndex === -1) {
+        activeDeletionsRef.current.delete(fileId);
+        return;
+      }
 
-      setCurrentMessageFiles((prev) => {
-        const index = prev.findIndex((f) => f.id === fileId);
-        if (index === -1) return prev;
+      const removedFile = currentFiles[removedIndex];
+      if (!removedFile) {
+        activeDeletionsRef.current.delete(fileId);
+        return;
+      }
 
-        // Capture file info for potential rollback and backend deletion
-        const file = prev[index];
-        if (!file) return prev;
-        removedFile = file;
-        removedIndex = index;
-
-        // Return filtered array (optimistic removal)
-        return prev.filter((f) => f.id !== fileId);
-      });
+      const nextFiles = currentFiles.filter((f) => f.id !== fileId);
+      currentMessageFilesRef.current = nextFiles;
+      setCurrentMessageFiles(nextFiles);
 
       // After state update, trigger backend deletion if needed
       // Use setTimeout to ensure state update has completed

--- a/web/src/app/craft/contexts/UploadFilesContext.tsx
+++ b/web/src/app/craft/contexts/UploadFilesContext.tsx
@@ -714,9 +714,9 @@ export function UploadFilesProvider({ children }: UploadFilesProviderProps) {
         return;
       }
 
-      const nextFiles = currentFiles.filter((f) => f.id !== fileId);
-      currentMessageFilesRef.current = nextFiles;
-      setCurrentMessageFiles(nextFiles);
+      // Functional update keeps concurrent same-batch changes. The ref syncs
+      // from state in its own effect.
+      setCurrentMessageFiles((prev) => prev.filter((f) => f.id !== fileId));
 
       // After state update, trigger backend deletion if needed
       // Use setTimeout to ensure state update has completed

--- a/web/src/app/craft/v1/tasks/components/ScheduleTaskForm.tsx
+++ b/web/src/app/craft/v1/tasks/components/ScheduleTaskForm.tsx
@@ -146,27 +146,27 @@ export default function ScheduleTaskForm({
         router.push(connectionPath);
         return;
       }
-      setSkillPicker((prev) => {
-        if (!prev.open) return prev;
-        const replacement = `${pickerEntryPromptPrefix(entry)} `;
-        const newPrompt =
-          prompt.slice(0, prev.slashIndex) +
-          replacement +
-          prompt.slice(prev.slashIndex + 1 + prev.query.length);
-        setPrompt(newPrompt);
+      if (!skillPicker.open) return;
 
-        const cursorPos = prev.slashIndex + replacement.length;
-        const textarea = promptTextareaRef.current;
-        if (textarea) {
-          requestAnimationFrame(() => {
-            textarea.focus();
-            textarea.setSelectionRange(cursorPos, cursorPos);
-          });
-        }
-        return { ...prev, open: false };
-      });
+      const replacement = `${pickerEntryPromptPrefix(entry)} `;
+      const newPrompt =
+        prompt.slice(0, skillPicker.slashIndex) +
+        replacement +
+        prompt.slice(skillPicker.slashIndex + 1 + skillPicker.query.length);
+      setPrompt(newPrompt);
+
+      const cursorPos = skillPicker.slashIndex + replacement.length;
+      const textarea = promptTextareaRef.current;
+      if (textarea) {
+        requestAnimationFrame(() => {
+          textarea.focus();
+          textarea.setSelectionRange(cursorPos, cursorPos);
+        });
+      }
+
+      setSkillPicker((prev) => (prev.open ? { ...prev, open: false } : prev));
     },
-    [prompt, router]
+    [prompt, router, skillPicker]
   );
 
   const compiled = compileLocalPayloadToUtcCron(mode, payload);

--- a/web/src/app/ee/admin/export-logs/page.tsx
+++ b/web/src/app/ee/admin/export-logs/page.tsx
@@ -97,6 +97,11 @@ export default function ExportLogsPage() {
   const [isStarting, setIsStarting] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
   const downloadedExportIdRef = useRef<string | null>(null);
+  // Pending deferred revocation: cancelling the timer must also revoke the URL.
+  const pendingRevokeRef = useRef<{
+    timer: ReturnType<typeof setTimeout>;
+    url: string;
+  } | null>(null);
 
   const { data: status, error: statusError } = useSWR<LogExportStatus>(
     exportId === null ? null : SWR_KEYS.logExportStatus(exportId),
@@ -142,6 +147,16 @@ export default function ExportLogsPage() {
     setExportId(null);
   }, [statusError]);
 
+  useEffect(() => {
+    return () => {
+      if (pendingRevokeRef.current !== null) {
+        clearTimeout(pendingRevokeRef.current.timer);
+        URL.revokeObjectURL(pendingRevokeRef.current.url);
+        pendingRevokeRef.current = null;
+      }
+    };
+  }, []);
+
   const downloadBundle = useCallback(async (id: string): Promise<void> => {
     // Mark before any await: an attempt is in flight or succeeded, and only
     // failure re-arms the auto-download below. Owning this here keeps every
@@ -160,7 +175,18 @@ export default function ExportLogsPage() {
       downloadFile(extractFilename(response), { url });
       // Deferred like downloadFile's content mode: the click's download
       // dereferences the blob URL asynchronously.
-      setTimeout(() => URL.revokeObjectURL(url), 0);
+      if (pendingRevokeRef.current !== null) {
+        clearTimeout(pendingRevokeRef.current.timer);
+        URL.revokeObjectURL(pendingRevokeRef.current.url);
+      }
+      // Released on unmount and on replacement. The rule cannot trace the
+      // handle through the pendingRevokeRef object.
+      // oxlint-disable-next-line react-doctor/effect-needs-cleanup
+      const timer = setTimeout(() => {
+        URL.revokeObjectURL(url);
+        pendingRevokeRef.current = null;
+      }, 0);
+      pendingRevokeRef.current = { url, timer };
     } catch (error) {
       console.error("Error downloading log export:", error);
       toast.error("Failed to download the log export.");

--- a/web/src/app/ee/admin/standard-answer/page.tsx
+++ b/web/src/app/ee/admin/standard-answer/page.tsx
@@ -240,8 +240,6 @@ const StandardAnswersTable = ({
         <textarea
           autoFocus
           className="grow ml-2 h-6 bg-transparent outline-hidden placeholder-subtle overflow-hidden whitespace-normal resize-none"
-          role="textarea"
-          aria-multiline
           placeholder="Find standard answers by keyword/phrase..."
           value={query}
           onChange={(event) => {

--- a/web/src/components/voice/Waveform.tsx
+++ b/web/src/components/voice/Waveform.tsx
@@ -47,7 +47,10 @@ function Waveform({
   const animationRef = useRef<number | null>(null);
   const lastPushTimeRef = useRef(0);
   const audioLevelRef = useRef(audioLevel);
-  audioLevelRef.current = audioLevel;
+
+  useEffect(() => {
+    audioLevelRef.current = audioLevel;
+  });
 
   // ─── Speaking variant bars ─────────────────────────────────────────────────
   const speakingBars = useMemo(() => {

--- a/web/src/components/voice/Waveform.tsx
+++ b/web/src/components/voice/Waveform.tsx
@@ -50,7 +50,7 @@ function Waveform({
 
   useEffect(() => {
     audioLevelRef.current = audioLevel;
-  });
+  }, [audioLevel]);
 
   // ─── Speaking variant bars ─────────────────────────────────────────────────
   const speakingBars = useMemo(() => {

--- a/web/src/ee/providers/QueryControllerProvider.tsx
+++ b/web/src/ee/providers/QueryControllerProvider.tsx
@@ -61,14 +61,15 @@ export function QueryControllerProvider({
 
   const setAppMode = useCallback(
     (mode: AppMode) => {
-      if (!businessTier || !searchUiEnabled) return;
-      setState((prev) => {
-        if (prev.phase !== "idle") return prev;
-        appModeRef.current = mode;
-        return { phase: "idle", appMode: mode };
-      });
+      if (!businessTier || !searchUiEnabled || state.phase !== "idle") return;
+      appModeRef.current = mode;
+      // Re-check inside the updater: a phase transition queued in the same
+      // batch must not be rolled back to idle.
+      setState((prev) =>
+        prev.phase === "idle" ? { phase: "idle", appMode: mode } : prev
+      );
     },
-    [businessTier, searchUiEnabled]
+    [businessTier, searchUiEnabled, state.phase]
   );
 
   // ── Ancillary state ───────────────────────────────────────────────────

--- a/web/src/ee/sections/SearchUI.tsx
+++ b/web/src/ee/sections/SearchUI.tsx
@@ -115,7 +115,10 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
   }, [results]);
 
   // Create a set for fast lookup of LLM-selected docs
-  const llmSelectedSet = new Set(llmSelectedDocIds ?? []);
+  const llmSelectedSet = useMemo(
+    () => new Set(llmSelectedDocIds ?? []),
+    [llmSelectedDocIds]
+  );
 
   // Filter and sort results
   const filteredAndSortedResults = useMemo(() => {

--- a/web/src/hooks/useContainerCenter.ts
+++ b/web/src/hooks/useContainerCenter.ts
@@ -49,6 +49,10 @@ function measure(
 export default function useContainerCenter(): ContainerCenter {
   const pathname = usePathname();
   const { isMediumScreen } = useScreenSize();
+  const [container, setContainer] = useState<HTMLElement | null>(() => {
+    if (typeof document === "undefined") return null;
+    return document.querySelector<HTMLElement>(SELECTOR);
+  });
   const [rect, setRect] = useState<{
     x: number | null;
     y: number | null;
@@ -62,41 +66,49 @@ export default function useContainerCenter(): ContainerCenter {
   });
 
   useEffect(() => {
-    let resizeObserver: ResizeObserver | null = null;
-    let mutationObserver: MutationObserver | null = null;
-
-    const attach = (container: HTMLElement) => {
-      const update = () => setRect(measure(container) ?? NULL_MEASURE);
-      update();
-      resizeObserver = new ResizeObserver(update);
-      resizeObserver.observe(container);
-    };
-
     const existing = document.querySelector<HTMLElement>(SELECTOR);
     if (existing) {
-      attach(existing);
-    } else {
-      // The container can mount after this hook (e.g. a root-level consumer
-      // renders before the auth shell reveals the chrome). Watch for it.
-      setRect(NULL_MEASURE);
-      mutationObserver = new MutationObserver(() => {
-        const el = document.querySelector<HTMLElement>(SELECTOR);
-        if (!el) return;
-        mutationObserver?.disconnect();
-        mutationObserver = null;
-        attach(el);
-      });
-      mutationObserver.observe(document.body, {
-        childList: true,
-        subtree: true,
-      });
+      setContainer(existing);
+      setRect(measure(existing) ?? NULL_MEASURE);
+      return;
     }
 
+    // The container can mount after this hook (e.g. a root-level consumer
+    // renders before the auth shell reveals the chrome). Watch for it.
+    setContainer(null);
+    setRect(NULL_MEASURE);
+
+    const mutationObserver = new MutationObserver(() => {
+      const el = document.querySelector<HTMLElement>(SELECTOR);
+      if (!el) return;
+      setContainer(el);
+      setRect(measure(el) ?? NULL_MEASURE);
+      mutationObserver.disconnect();
+    });
+    mutationObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+
     return () => {
-      resizeObserver?.disconnect();
       mutationObserver?.disconnect();
     };
   }, [pathname]);
+
+  useEffect(() => {
+    if (!container) return;
+
+    const update = () => setRect(measure(container) ?? NULL_MEASURE);
+    update();
+
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(container);
+
+    return () => {
+      resizeObserver.unobserve(container);
+      resizeObserver.disconnect();
+    };
+  }, [container]);
 
   return {
     centerX: isMediumScreen ? null : rect.x,

--- a/web/src/hooks/useContainerCenter.ts
+++ b/web/src/hooks/useContainerCenter.ts
@@ -91,7 +91,7 @@ export default function useContainerCenter(): ContainerCenter {
     });
 
     return () => {
-      mutationObserver?.disconnect();
+      mutationObserver.disconnect();
     };
   }, [pathname]);
 
@@ -105,7 +105,6 @@ export default function useContainerCenter(): ContainerCenter {
     resizeObserver.observe(container);
 
     return () => {
-      resizeObserver.unobserve(container);
       resizeObserver.disconnect();
     };
   }, [container]);

--- a/web/src/hooks/useContentSize.ts
+++ b/web/src/hooks/useContentSize.ts
@@ -121,26 +121,37 @@ export function useContentSize(
 
   // Observe resize if enabled
   useEffect(() => {
-    if (!observeResize || !ref.current) return;
+    const container = ref.current;
+    if (!observeResize || !container) return;
+    let animationFrameId: number | null = null;
+    const observedElements = [
+      container,
+      ...Array.from(container.querySelectorAll("*")),
+    ];
 
     const resizeObserver = new ResizeObserver(() => {
       // Use requestAnimationFrame to ensure measurements happen after the resize is complete
-      requestAnimationFrame(() => {
+      if (animationFrameId !== null) {
+        cancelAnimationFrame(animationFrameId);
+      }
+      animationFrameId = requestAnimationFrame(() => {
+        animationFrameId = null;
         measureSize();
       });
     });
 
-    // Observe the container itself
-    resizeObserver.observe(ref.current);
-
-    // Also observe all descendant elements (like textareas)
-    const descendants = ref.current.querySelectorAll("*");
-    descendants.forEach((el) => {
+    observedElements.forEach((el) => {
       resizeObserver.observe(el);
     });
 
     return () => {
+      observedElements.forEach((el) => {
+        resizeObserver.unobserve(el);
+      });
       resizeObserver.disconnect();
+      if (animationFrameId !== null) {
+        cancelAnimationFrame(animationFrameId);
+      }
     };
   }, [observeResize]);
 

--- a/web/src/hooks/useDraft.ts
+++ b/web/src/hooks/useDraft.ts
@@ -63,7 +63,10 @@ export function useDraft<T>({
   );
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isEmptyRef = useRef(isEmpty);
-  isEmptyRef.current = isEmpty;
+
+  useEffect(() => {
+    isEmptyRef.current = isEmpty;
+  }, [isEmpty]);
 
   useEffect(() => {
     const storage = getStorage();
@@ -122,7 +125,7 @@ export function useDraft<T>({
 
   const loaded = entry !== null && entry.key === key;
   const draft = loaded ? entry.draft : null;
-  const hasDraft = draft !== null && !isEmptyRef.current(draft);
+  const hasDraft = draft !== null && !isEmpty(draft);
 
   return { draft, loaded, hasDraft, save, clear };
 }

--- a/web/src/hooks/useEscapeInterrupt.ts
+++ b/web/src/hooks/useEscapeInterrupt.ts
@@ -42,7 +42,10 @@ export function useEscapeInterrupt({
 }: UseEscapeInterruptArgs): void {
   // Held in a ref so the listener doesn't tear down on onInterrupt identity churn.
   const onInterruptRef = useRef(onInterrupt);
-  onInterruptRef.current = onInterrupt;
+
+  useEffect(() => {
+    onInterruptRef.current = onInterrupt;
+  }, [onInterrupt]);
 
   useEffect(() => {
     if (!enabled) return;

--- a/web/src/hooks/useSlashPicker.ts
+++ b/web/src/hooks/useSlashPicker.ts
@@ -1,4 +1,10 @@
-import { useCallback, useRef, useState, type RefObject } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
 import type { BaseInputBarHandle } from "@/sections/input/BaseInputBar";
 import type { PickerEntry } from "@/lib/skills/picker";
 import {
@@ -34,8 +40,11 @@ export default function useSlashPicker({
   const [session, setSession] = useState<PickerSession>(INITIAL_PICKER_SESSION);
   // Mirror into a ref so the returned handlers keep a stable identity.
   const sessionRef = useRef(session);
-  sessionRef.current = session;
   const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
+
+  useEffect(() => {
+    sessionRef.current = session;
+  }, [session]);
 
   const reset = useCallback(() => setSession(INITIAL_PICKER_SESSION), []);
   const onClose = useCallback(() => setSession(reduceOnDismiss), []);

--- a/web/src/hooks/useTypewriter.ts
+++ b/web/src/hooks/useTypewriter.ts
@@ -33,18 +33,21 @@ export function useTypewriter(
 ): UseTypewriterResult {
   // Ref so the rAF loop reads latest length without restarting.
   const targetRef = useRef(target);
-  targetRef.current = target;
 
   // Mirror `enabled` so the restart effect can short-circuit when the
   // caller has turned animation off (e.g. voice-mode, where display is
   // driven by audio position — the typewriter must stay idle and not
   // animate a jump after audio ends).
   const enabledRef = useRef(enabled);
-  enabledRef.current = enabled;
 
   // Read inside the rAF loop without restarting it.
   const streamFinishedRef = useRef(streamFinished);
-  streamFinishedRef.current = streamFinished;
+
+  useEffect(() => {
+    targetRef.current = target;
+    enabledRef.current = enabled;
+    streamFinishedRef.current = streamFinished;
+  }, [target, enabled, streamFinished]);
 
   // Captured once when post-finish drain begins, so the per-frame step
   // size stays constant instead of decaying with the shrinking backlog.

--- a/web/src/hooks/useUnsavedChangesGuard.ts
+++ b/web/src/hooks/useUnsavedChangesGuard.ts
@@ -19,7 +19,10 @@ export default function useUnsavedChangesGuard({
   const [confirmationOpen, setConfirmationOpen] = useState(false);
   const pendingNavigation = useRef<(() => void) | null>(null);
   const onDiscardRef = useRef(onDiscard);
-  onDiscardRef.current = onDiscard;
+
+  useEffect(() => {
+    onDiscardRef.current = onDiscard;
+  }, [onDiscard]);
 
   const requestLeave = useCallback(
     (navigate: () => void) => {

--- a/web/src/hooks/useVisibilityGatedInterval.ts
+++ b/web/src/hooks/useVisibilityGatedInterval.ts
@@ -13,7 +13,10 @@ export function useVisibilityGatedInterval(
   intervalMs: number | null
 ) {
   const callbackRef = useRef(callback);
-  callbackRef.current = callback;
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
 
   useEffect(() => {
     if (!intervalMs) return;

--- a/web/src/lib/agents/hooks.ts
+++ b/web/src/lib/agents/hooks.ts
@@ -268,8 +268,10 @@ export function useAgentController(
 
   const availableAgentsRef = useRef<MinimalAgent[]>(availableAgents);
   const defaultAgentIdRef = useRef<number | undefined>(defaultAgentId);
-  availableAgentsRef.current = availableAgents;
-  defaultAgentIdRef.current = defaultAgentId;
+  useEffect(() => {
+    availableAgentsRef.current = availableAgents;
+    defaultAgentIdRef.current = defaultAgentId;
+  }, [availableAgents, defaultAgentId]);
   const setSelectedAgentFromId = useCallback(
     (agentId: number | null | undefined) => {
       const latestAvailableAgents = availableAgentsRef.current;

--- a/web/src/lib/auth/hooks.ts
+++ b/web/src/lib/auth/hooks.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
@@ -79,29 +79,35 @@ export function useSessionWatcher(): SessionWatcherResult {
 
   const { user, mutateUser, userError } = useCurrentUser();
   const expiryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const hasSeenAuthenticatedUserRef = useRef(false);
-  const sessionEndReasonRef = useRef<SessionEndReason | null>(null);
+  const [hasSeenAuthenticatedUserState, setHasSeenAuthenticatedUserState] =
+    useState(false);
+  const [sessionEndReasonState, setSessionEndReasonState] =
+    useState<SessionEndReason | null>(null);
 
   // Entering login/logout is a session boundary: forget the prior session so a
   // lingering 403 can't resurface the "logged out" modal on the login page.
-  if (inAuthFlow) {
-    hasSeenAuthenticatedUserRef.current = false;
-  } else if (user) {
-    hasSeenAuthenticatedUserRef.current = true;
+  const hasSeenAuthenticatedUser = inAuthFlow
+    ? false
+    : user
+      ? true
+      : hasSeenAuthenticatedUserState;
+  if (hasSeenAuthenticatedUserState !== hasSeenAuthenticatedUser) {
+    setHasSeenAuthenticatedUserState(hasSeenAuthenticatedUser);
   }
 
   const sessionEnded =
-    !inAuthFlow &&
-    userError?.status === 403 &&
-    hasSeenAuthenticatedUserRef.current;
+    !inAuthFlow && userError?.status === 403 && hasSeenAuthenticatedUser;
 
   // Latch the first 403's reason: a later refetch can reclassify (e.g. EXPIRED
   // becomes UNRECOGNIZED once the server-side grace window lapses) and must
   // not flip the modal copy while it is up.
-  if (!sessionEnded) {
-    sessionEndReasonRef.current = null;
-  } else if (sessionEndReasonRef.current === null) {
-    sessionEndReasonRef.current = parseSessionEndReason(userError);
+  const sessionEndReason = !sessionEnded
+    ? null
+    : sessionEndReasonState === null
+      ? parseSessionEndReason(userError)
+      : sessionEndReasonState;
+  if (sessionEndReasonState !== sessionEndReason) {
+    setSessionEndReasonState(sessionEndReason);
   }
 
   useEffect(() => {
@@ -127,12 +133,12 @@ export function useSessionWatcher(): SessionWatcherResult {
 
   useEffect(() => {
     if (inAuthFlow) return;
-    if (userError?.status === 403 && hasSeenAuthenticatedUserRef.current) {
+    if (userError?.status === 403 && hasSeenAuthenticatedUser) {
       logout();
     }
-  }, [inAuthFlow, userError]);
+  }, [inAuthFlow, userError, hasSeenAuthenticatedUser]);
 
-  return { sessionEnded, sessionEndReason: sessionEndReasonRef.current };
+  return { sessionEnded, sessionEndReason };
 }
 
 export function useIsMultiTenant(): boolean | null {

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -706,7 +706,6 @@ export function useLlmManager(
   }
 
   // Compute the resolved LLM synchronously so it's never one render behind.
-  // This replaces the old llmUpdate() effect for model resolution.
   // A second memo preserves object identity when the resolved fields stay the
   // same, preventing unnecessary re-creation of downstream callbacks.
   const resolvedCurrentLlm = useMemo((): LlmDescriptor => {
@@ -771,7 +770,8 @@ export function useLlmManager(
       resolvedCurrentLlm.name,
       resolvedCurrentLlm.provider,
       resolvedCurrentLlm.modelName,
-      resolvedCurrentLlm.modelConfigurationId,
+      // Normalized so undefined vs null cannot produce a fresh identity.
+      resolvedCurrentLlm.modelConfigurationId ?? null,
     ]
   );
 

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -13,7 +13,14 @@ import {
 } from "@/lib/types";
 import useSWR, { mutate, useSWRConfig } from "swr";
 import { errorHandlingFetcher } from "./fetcher";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { DateRangePickerValue } from "@/components/dateRangeSelectors/AdminDateRangeSelector";
 import { SourceMetadata } from "./search/interfaces";
 import {
@@ -106,7 +113,9 @@ export const useConnectorIndexingStatusWithPagination = (
 
   //ref to maintain the current source pages for the main request
   const sourcePagesRef = useRef(sourcePages);
-  sourcePagesRef.current = sourcePages;
+  useLayoutEffect(() => {
+    sourcePagesRef.current = sourcePages;
+  }, [sourcePages]);
 
   // Main request that includes current pagination state
   const mainRequest: IndexingStatusRequest = useMemo(
@@ -698,30 +707,28 @@ export function useLlmManager(
 
   // Compute the resolved LLM synchronously so it's never one render behind.
   // This replaces the old llmUpdate() effect for model resolution.
-  // Wrapped with a ref for referential stability — returns the same object
-  // when the resolved name/provider/modelName haven't actually changed,
-  // preventing unnecessary re-creation of downstream callbacks (e.g. onSubmit).
-  const prevLlmRef = useRef<LlmDescriptor>({
-    name: "",
-    provider: "",
-    modelName: "",
-  });
-  const currentLlm = useMemo((): LlmDescriptor => {
-    let resolved: LlmDescriptor;
-
+  // A second memo preserves object identity when the resolved fields stay the
+  // same, preventing unnecessary re-creation of downstream callbacks.
+  const resolvedCurrentLlm = useMemo((): LlmDescriptor => {
     if (llmProviders === undefined || llmProviders === null) {
-      resolved = manualLlm;
-    } else if (userHasManuallyOverriddenLLM) {
+      return manualLlm;
+    }
+
+    if (userHasManuallyOverriddenLLM) {
       // Manual override wins over session's `current_alternate_model`.
       // Cleared on cross-session navigation by the effect above.
-      resolved = manualLlm;
-    } else if (currentChatSession?.current_alternate_model) {
-      resolved = getValidLlmDescriptorForProviders(
+      return manualLlm;
+    }
+
+    if (currentChatSession?.current_alternate_model) {
+      return getValidLlmDescriptorForProviders(
         currentChatSession.current_alternate_model,
         llmProviders,
         defaultText
       );
-    } else if (liveAgent && liveAgent.id !== DEFAULT_AGENT_ID) {
+    }
+
+    if (liveAgent && liveAgent.id !== DEFAULT_AGENT_ID) {
       // Custom agent — its configured default takes precedence. When the agent
       // has no explicit default, fall to the global system default. The user's
       // personal preference is irrelevant in an agent-scoped chat.
@@ -729,42 +736,44 @@ export function useLlmManager(
         liveAgent,
         llmProviders
       );
-      resolved =
+      return (
         agentOverride ??
         getDefaultLlmDescriptor(llmProviders, defaultText) ??
-        manualLlm;
-    } else if (user?.preferences?.default_model) {
-      resolved = getValidLlmDescriptorForProviders(
+        manualLlm
+      );
+    }
+
+    if (user?.preferences?.default_model) {
+      return getValidLlmDescriptorForProviders(
         user.preferences.default_model,
         llmProviders,
         defaultText
       );
-    } else {
-      resolved =
-        getDefaultLlmDescriptor(llmProviders, defaultText) ?? manualLlm;
     }
 
-    const prev = prevLlmRef.current;
-    if (
-      prev.name === resolved.name &&
-      prev.provider === resolved.provider &&
-      prev.modelName === resolved.modelName &&
-      (prev.modelConfigurationId ?? null) ===
-        (resolved.modelConfigurationId ?? null)
-    ) {
-      return prev;
-    }
-    prevLlmRef.current = resolved;
-    return resolved;
+    return getDefaultLlmDescriptor(llmProviders, defaultText) ?? manualLlm;
   }, [
     llmProviders,
     defaultText,
-    currentChatSession,
+    currentChatSession?.current_alternate_model,
     userHasManuallyOverriddenLLM,
-    manualLlm,
+    manualLlm.name,
+    manualLlm.provider,
+    manualLlm.modelName,
+    manualLlm.modelConfigurationId,
+    liveAgent?.id,
     liveAgent?.default_model_configuration_id,
     user?.preferences?.default_model,
   ]);
+  const currentLlm = useMemo(
+    () => resolvedCurrentLlm,
+    [
+      resolvedCurrentLlm.name,
+      resolvedCurrentLlm.provider,
+      resolvedCurrentLlm.modelName,
+      resolvedCurrentLlm.modelConfigurationId,
+    ]
+  );
 
   // Keep chatSession state in sync (used by temperature effect)
   useEffect(() => {

--- a/web/src/lib/hooks/useCaptcha.ts
+++ b/web/src/lib/hooks/useCaptcha.ts
@@ -45,36 +45,7 @@ export function useCaptcha() {
     }
 
     const scriptSrc = `https://www.google.com/recaptcha/api.js?render=${RECAPTCHA_SITE_KEY}`;
-
-    // Check if the script is already loaded
-    if (window.grecaptcha) {
-      window.grecaptcha.ready(() => {
-        setIsLoaded(true);
-      });
-      return;
-    }
-
-    // Check if the script is already in the DOM (loading but not yet executed)
-    const existingScript = document.querySelector(`script[src="${scriptSrc}"]`);
-    if (existingScript) {
-      // Script exists but hasn't loaded yet, wait for it
-      existingScript.addEventListener("load", () => {
-        if (window.grecaptcha) {
-          window.grecaptcha.ready(() => {
-            setIsLoaded(true);
-          });
-        }
-      });
-      return;
-    }
-
-    // Load the reCAPTCHA script
-    const script = document.createElement("script");
-    script.src = scriptSrc;
-    script.async = true;
-    script.defer = true;
-
-    script.onload = () => {
+    const handleLoad = () => {
       if (window.grecaptcha) {
         window.grecaptcha.ready(() => {
           setIsLoaded(true);
@@ -82,10 +53,35 @@ export function useCaptcha() {
       }
     };
 
+    // Check if the script is already loaded
+    if (window.grecaptcha) {
+      handleLoad();
+      return;
+    }
+
+    // Check if the script is already in the DOM (loading but not yet executed)
+    const existingScript = document.querySelector<HTMLScriptElement>(
+      `script[src="${scriptSrc}"]`
+    );
+    if (existingScript) {
+      // Script exists but hasn't loaded yet, wait for it
+      existingScript.addEventListener("load", handleLoad);
+      return () => {
+        existingScript.removeEventListener("load", handleLoad);
+      };
+    }
+
+    // Load the reCAPTCHA script
+    const script = document.createElement("script");
+    script.src = scriptSrc;
+    script.async = true;
+    script.defer = true;
+    script.addEventListener("load", handleLoad);
+
     document.head.appendChild(script);
 
     return () => {
-      // Cleanup is tricky with reCAPTCHA, so we leave the script in place
+      script.removeEventListener("load", handleLoad);
     };
   }, [isCaptchaEnabled]);
 

--- a/web/src/providers/FullWidthChatProvider.tsx
+++ b/web/src/providers/FullWidthChatProvider.tsx
@@ -44,16 +44,14 @@ export function FullWidthChatProvider({
   }, []);
 
   const toggleFullWidthChat = useCallback(() => {
-    setFullWidthChat((prev) => {
-      const next = !prev;
-      try {
-        localStorage.setItem(STORAGE_KEY, String(next));
-      } catch {
-        // Persisting is best-effort; the toggle still flips for this session.
-      }
-      return next;
-    });
-  }, []);
+    const next = !fullWidthChat;
+    setFullWidthChat(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, String(next));
+    } catch {
+      // Persisting is best-effort. The toggle still flips for this session.
+    }
+  }, [fullWidthChat]);
 
   return (
     <FullWidthChatContext.Provider

--- a/web/src/providers/ProjectsContext.tsx
+++ b/web/src/providers/ProjectsContext.tsx
@@ -145,6 +145,7 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
   const [currentMessageFiles, setCurrentMessageFiles] = useState<ProjectFile[]>(
     []
   );
+  const currentMessageFilesRef = useRef<ProjectFile[]>([]);
   const pollIntervalRef = useRef<number | null>(null);
   const isPollingRef = useRef<boolean>(false);
   const [lastFailedFiles, setLastFailedFiles] = useState<ProjectFile[]>([]);
@@ -531,6 +532,10 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
   // allRecentFiles as well; subsequent updates only touch recentFiles so the
   // merge effect below can non-destructively apply them to allRecentFiles.
   useEffect(() => {
+    currentMessageFilesRef.current = currentMessageFiles;
+  }, [currentMessageFiles]);
+
+  useEffect(() => {
     if (!recentFilesData) return;
     setRecentFiles(recentFilesData);
     if (!hasInitializedAllRecentFilesRef.current) {
@@ -575,19 +580,31 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
         // Build maps for quick lookup
         const statusById = new Map(statuses.map((f) => [f.id, f]));
 
-        // Update currentMessageFiles inline based on polled statuses
+        // Newly-failed detection uses the last committed snapshot. The toast
+        // side effect must stay outside the state updater.
+        const currentMessageFilesSnapshot = currentMessageFilesRef.current;
+        const newlyFailedLocal: ProjectFile[] = [];
+        for (const f of currentMessageFilesSnapshot) {
+          const latest = statusById.get(f.id);
+          if (
+            latest &&
+            String(latest.status).toLowerCase() === "failed" &&
+            String(f.status).toLowerCase() !== "failed"
+          ) {
+            newlyFailedLocal.push(latest);
+          }
+        }
+
+        // Merge statuses into whatever the files are now. A snapshot here
+        // would clobber adds/removes that landed during the fetch.
         setCurrentMessageFiles((prev) => {
           let changed = false;
           const next: ProjectFile[] = [];
-          const newlyFailedLocal: ProjectFile[] = [];
           for (const f of prev) {
             const latest = statusById.get(f.id);
             if (latest) {
               const latestStatus = String(latest.status).toLowerCase();
               if (latestStatus === "failed") {
-                if (String(f.status).toLowerCase() !== "failed") {
-                  newlyFailedLocal.push(latest);
-                }
                 changed = true;
                 continue;
               }
@@ -603,11 +620,11 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
             }
             next.push(f);
           }
-          if (newlyFailedLocal.length > 0) {
-            setLastFailedFiles(newlyFailedLocal);
-          }
-          return changed || next.length !== prev.length ? next : prev;
+          return changed ? next : prev;
         });
+        if (newlyFailedLocal.length > 0) {
+          setLastFailedFiles(newlyFailedLocal);
+        }
 
         // Update currentProjectDetails.files with latest statuses
         setCurrentProjectDetails((prev) => {

--- a/web/src/providers/ProjectsContext.tsx
+++ b/web/src/providers/ProjectsContext.tsx
@@ -528,13 +528,13 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
     []
   );
 
-  // Sync SWR-fetched recent files into local state. On first arrival, seed
-  // allRecentFiles as well; subsequent updates only touch recentFiles so the
-  // merge effect below can non-destructively apply them to allRecentFiles.
   useEffect(() => {
     currentMessageFilesRef.current = currentMessageFiles;
   }, [currentMessageFiles]);
 
+  // Sync SWR-fetched recent files into local state. On first arrival, seed
+  // allRecentFiles as well. Subsequent updates only touch recentFiles so the
+  // merge effect below can non-destructively apply them to allRecentFiles.
   useEffect(() => {
     if (!recentFilesData) return;
     setRecentFiles(recentFilesData);
@@ -580,8 +580,9 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
         // Build maps for quick lookup
         const statusById = new Map(statuses.map((f) => [f.id, f]));
 
-        // Newly-failed detection uses the last committed snapshot. The toast
-        // side effect must stay outside the state updater.
+        // Newly-failed detection uses the last committed snapshot.
+        // setLastFailedFiles (it drives the failure toast downstream) must
+        // stay outside the state updater.
         const currentMessageFilesSnapshot = currentMessageFilesRef.current;
         const newlyFailedLocal: ProjectFile[] = [];
         for (const f of currentMessageFilesSnapshot) {

--- a/web/src/providers/VoiceModeProvider.tsx
+++ b/web/src/providers/VoiceModeProvider.tsx
@@ -161,6 +161,11 @@ export function VoiceModeProvider({ children }: { children: React.ReactNode }) {
     useState(false);
   const [manualStopCount, setManualStopCount] = useState(0);
   const [isTTSMuted, setIsTTSMuted] = useState(false);
+  const [pendingWsConnection, setPendingWsConnection] = useState<{
+    id: number;
+    url: string;
+    speed: number;
+  } | null>(null);
   const manualTTSMuteHandlerRef = useRef<((muted: boolean) => void) | null>(
     null
   );
@@ -191,6 +196,8 @@ export function VoiceModeProvider({ children }: { children: React.ReactNode }) {
   const lastRawTextRef = useRef("");
   const pendingTextRef = useRef<string[]>([]);
   const isConnectingRef = useRef(false);
+  const connectAttemptRef = useRef(0);
+  const connectingWsRef = useRef<WebSocket | null>(null);
 
   // Timers
   const flushTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -470,85 +477,138 @@ export function VoiceModeProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
-    // Set connecting flag to prevent concurrent connection attempts
     isConnectingRef.current = true;
+    const attemptId = connectAttemptRef.current + 1;
+    connectAttemptRef.current = attemptId;
 
     try {
-      // Initialize MediaSource first
       const initialized = await initMediaSource();
-      if (!initialized) {
-        isConnectingRef.current = false;
+      if (!initialized || connectAttemptRef.current !== attemptId) {
+        if (connectAttemptRef.current === attemptId) {
+          isConnectingRef.current = false;
+        }
         return;
       }
 
-      // Get WebSocket URL with auth token
       const wsUrl = await getWebSocketUrl();
+      // Stale attempt: a newer connect/disconnect owns the flags now.
+      if (connectAttemptRef.current !== attemptId) {
+        return;
+      }
 
-      const ws = new WebSocket(wsUrl);
-
-      ws.onopen = () => {
-        isConnectingRef.current = false;
-        // Send initial config
-        ws.send(
-          JSON.stringify({
-            type: "config",
-            speed: playbackSpeed,
-          })
-        );
-
-        // Send any pending text
-        for (const text of pendingTextRef.current) {
-          ws.send(JSON.stringify({ type: "synthesize", text }));
-        }
-        pendingTextRef.current = [];
-      };
-
-      ws.onmessage = async (event) => {
-        if (event.data instanceof Blob) {
-          const arrayBuffer = await event.data.arrayBuffer();
-          handleAudioData(arrayBuffer);
-        } else if (typeof event.data === "string") {
-          try {
-            const msg = JSON.parse(event.data);
-            if (msg.type === "audio_done") {
-              if (loadingTimeoutRef.current) {
-                clearTimeout(loadingTimeoutRef.current);
-                loadingTimeoutRef.current = null;
-              }
-              setIsTTSLoading(false);
-              finalizeStream();
-            }
-          } catch {
-            // Ignore parse errors
-          }
-        }
-      };
-
-      ws.onerror = () => {
-        isConnectingRef.current = false;
-        setIsTTSLoading(false);
-        setIsAwaitingAutoPlaybackStart(false);
-      };
-
-      ws.onclose = () => {
-        wsRef.current = null;
-        isConnectingRef.current = false;
-        setIsTTSLoading(false);
-        setIsAwaitingAutoPlaybackStart(false);
-        finalizeStream();
-      };
-
-      wsRef.current = ws;
+      setPendingWsConnection({
+        id: attemptId,
+        url: wsUrl,
+        speed: playbackSpeed,
+      });
     } catch {
-      isConnectingRef.current = false;
+      if (connectAttemptRef.current === attemptId) {
+        isConnectingRef.current = false;
+      }
     }
-  }, [
-    playbackSpeed,
-    handleAudioData,
-    getWebSocketUrl,
-    initMediaSource,
-    finalizeStream,
-  ]);
+  }, [getWebSocketUrl, initMediaSource, playbackSpeed]);
+
+  useEffect(() => {
+    if (!pendingWsConnection) {
+      return;
+    }
+    const ws = new WebSocket(pendingWsConnection.url);
+    connectingWsRef.current = ws;
+
+    ws.onopen = () => {
+      // Stale socket (a newer attempt superseded this one): drop it silently.
+      if (connectAttemptRef.current !== pendingWsConnection.id) {
+        ws.close();
+        return;
+      }
+      if (connectingWsRef.current === ws) {
+        connectingWsRef.current = null;
+      }
+      isConnectingRef.current = false;
+      ws.send(
+        JSON.stringify({
+          type: "config",
+          speed: pendingWsConnection.speed,
+        })
+      );
+
+      for (const text of pendingTextRef.current) {
+        ws.send(JSON.stringify({ type: "synthesize", text }));
+      }
+      pendingTextRef.current = [];
+    };
+
+    ws.onmessage = async (event) => {
+      if (connectAttemptRef.current !== pendingWsConnection.id) {
+        return;
+      }
+      if (event.data instanceof Blob) {
+        const arrayBuffer = await event.data.arrayBuffer();
+        handleAudioData(arrayBuffer);
+      } else if (typeof event.data === "string") {
+        try {
+          const msg = JSON.parse(event.data);
+          if (msg.type === "audio_done") {
+            if (loadingTimeoutRef.current) {
+              clearTimeout(loadingTimeoutRef.current);
+              loadingTimeoutRef.current = null;
+            }
+            setIsTTSLoading(false);
+            finalizeStream();
+          }
+        } catch {
+          // Ignore parse errors
+        }
+      }
+    };
+
+    ws.onerror = () => {
+      if (connectAttemptRef.current !== pendingWsConnection.id) {
+        return;
+      }
+      isConnectingRef.current = false;
+      setIsTTSLoading(false);
+      setIsAwaitingAutoPlaybackStart(false);
+    };
+
+    ws.onclose = () => {
+      if (wsRef.current === ws) {
+        wsRef.current = null;
+      }
+      if (connectingWsRef.current === ws) {
+        connectingWsRef.current = null;
+      }
+      // Stale socket closing must not reset the active attempt's stream state.
+      if (connectAttemptRef.current !== pendingWsConnection.id) {
+        return;
+      }
+      isConnectingRef.current = false;
+      setIsTTSLoading(false);
+      setIsAwaitingAutoPlaybackStart(false);
+      finalizeStream();
+    };
+
+    wsRef.current = ws;
+
+    return () => {
+      try {
+        ws.close();
+      } catch {
+        // Ignore
+      }
+      if (wsRef.current === ws) {
+        wsRef.current = null;
+      }
+      if (connectingWsRef.current === ws) {
+        connectingWsRef.current = null;
+      }
+      // Only the still-current attempt may release the connecting flag. A
+      // superseding attempt already owns it.
+      if (connectAttemptRef.current === pendingWsConnection.id) {
+        isConnectingRef.current = false;
+      }
+    };
+  }, [pendingWsConnection, handleAudioData, finalizeStream]);
 
   const stopTTS = useCallback((options?: { manual?: boolean }) => {
     // Clear timers
@@ -613,15 +673,19 @@ export function VoiceModeProvider({ children }: { children: React.ReactNode }) {
     streamEndedRef.current = false;
 
     // Close WebSocket
-    if (wsRef.current) {
+    const ws = wsRef.current ?? connectingWsRef.current;
+    if (ws) {
       try {
-        wsRef.current.send(JSON.stringify({ type: "end" }));
-        wsRef.current.close();
+        ws.send(JSON.stringify({ type: "end" }));
+        ws.close();
       } catch {
         // Ignore
       }
-      wsRef.current = null;
     }
+    wsRef.current = null;
+    connectingWsRef.current = null;
+    connectAttemptRef.current += 1;
+    setPendingWsConnection(null);
 
     setIsTTSPlaying(false);
     setIsTTSLoading(false);
@@ -871,15 +935,17 @@ export function VoiceModeProvider({ children }: { children: React.ReactNode }) {
 
   // Toggle TTS mute state
   const toggleTTSMute = useCallback(() => {
-    setIsTTSMuted((prev) => {
-      const newMuted = !prev;
-      if (audioElementRef.current) {
-        audioElementRef.current.muted = newMuted;
-      }
-      manualTTSMuteHandlerRef.current?.(newMuted);
-      return newMuted;
-    });
+    setIsTTSMuted((prev) => !prev);
   }, []);
+
+  // Audio element and manual handler track the committed mute state, so every
+  // path that changes it (toggle, reset) stays in sync.
+  useEffect(() => {
+    if (audioElementRef.current) {
+      audioElementRef.current.muted = isTTSMuted;
+    }
+    manualTTSMuteHandlerRef.current?.(isTTSMuted);
+  }, [isTTSMuted]);
 
   const registerManualTTSMuteHandler = useCallback(
     (handler: ((muted: boolean) => void) | null) => {
@@ -975,14 +1041,17 @@ export function VoiceModeProvider({ children }: { children: React.ReactNode }) {
       if (audioUrlRef.current) {
         URL.revokeObjectURL(audioUrlRef.current);
       }
-      if (wsRef.current) {
+      const ws = wsRef.current ?? connectingWsRef.current;
+      if (ws) {
         try {
-          wsRef.current.close();
+          ws.close();
         } catch (err) {
           // WebSocket may already be closed or in CLOSING state — non-critical
           console.warn("Failed to close TTS WebSocket during cleanup:", err);
         }
       }
+      wsRef.current = null;
+      connectingWsRef.current = null;
       if (audioElementRef.current) {
         try {
           audioElementRef.current.pause();

--- a/web/src/providers/VoiceModeProvider.tsx
+++ b/web/src/providers/VoiceModeProvider.tsx
@@ -544,6 +544,11 @@ export function VoiceModeProvider({ children }: { children: React.ReactNode }) {
       }
       if (event.data instanceof Blob) {
         const arrayBuffer = await event.data.arrayBuffer();
+        // Re-check after the await: a supersede during decoding must not
+        // append this socket's audio to the replacement stream.
+        if (connectAttemptRef.current !== pendingWsConnection.id) {
+          return;
+        }
         handleAudioData(arrayBuffer);
       } else if (typeof event.data === "string") {
         try {

--- a/web/src/refresh-components/inputs/InputSelect.tsx
+++ b/web/src/refresh-components/inputs/InputSelect.tsx
@@ -22,10 +22,8 @@ import type { PaddingVariants, WithoutStyles } from "@opal/types";
 // ============================================================================
 
 interface SelectedItemDisplay {
-  childrenRef: React.MutableRefObject<React.ReactNode>;
-  iconRef: React.MutableRefObject<
-    React.FunctionComponent<IconProps> | undefined
-  >;
+  children: React.ReactNode;
+  icon?: React.FunctionComponent<IconProps>;
 }
 
 interface InputSelectContextValue {
@@ -204,7 +202,6 @@ function InputSelectTrigger({
 }: InputSelectTriggerProps) {
   const { variant, selectedItemDisplay } = useInputSelectContext();
 
-  // Don't memoize - we need to read the latest ref values on every render
   let displayContent: React.ReactNode;
 
   if (!selectedItemDisplay) {
@@ -222,12 +219,12 @@ function InputSelectTrigger({
       </Text>
     );
   } else {
-    const Icon = selectedItemDisplay.iconRef.current;
+    const Icon = selectedItemDisplay.icon;
     displayContent = (
       <div className="flex flex-row items-center gap-2 flex-1 w-full">
         {Icon && <Icon className={cn("h-4 w-4", iconClasses[variant])} />}
         <Truncated className={cn(textClasses[variant])}>
-          {selectedItemDisplay.childrenRef.current}
+          {selectedItemDisplay.children}
         </Truncated>
       </div>
     );
@@ -353,21 +350,15 @@ function InputSelectItem({
   const { currentValue, setSelectedItemDisplay } = useInputSelectContext();
   const isSelected = value === currentValue;
 
-  // Use refs to hold latest children/icon - these are passed to the context
-  // so the trigger always reads current values without needing re-registration
-  const childrenRef = React.useRef(children);
-  const iconRef = React.useRef(icon);
-  childrenRef.current = children;
-  iconRef.current = icon;
-
-  // Only the selected item registers its display data
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (!isSelected) return;
-    setSelectedItemDisplay({ childrenRef, iconRef });
+    setSelectedItemDisplay({ children, icon });
+  }, [children, icon, isSelected, setSelectedItemDisplay]);
 
-    // Clean up functions only need to return for items which are selected.
+  React.useLayoutEffect(() => {
+    if (!isSelected) return;
     return () => setSelectedItemDisplay(null);
-  }, [isSelected]);
+  }, [isSelected, setSelectedItemDisplay]);
 
   return (
     <SelectPrimitive.Item

--- a/web/src/refresh-components/popovers/ActionsPopover/index.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/index.tsx
@@ -79,6 +79,9 @@ const TOOL_DESCRIPTIONS: Record<string, string> = {
 
 const DEFAULT_TOOL_DESCRIPTION = "This action is not configured yet.";
 
+// Stable fallback so absent preferences never churn dependent callbacks.
+const NO_DISABLED_TOOLS: number[] = [];
+
 function getToolTooltip(
   tool: ToolSnapshot,
   isConfigured: boolean,
@@ -281,10 +284,8 @@ export default function ActionsPopover({
   const hasNoConnectors = ccPairs.length === 0;
 
   const agentPreference = agentPreferences?.[selectedAgent.id];
-  const disabledToolIds = useMemo(
-    () => agentPreference?.disabled_tool_ids || [],
-    [agentPreference?.disabled_tool_ids]
-  );
+  const disabledToolIds =
+    agentPreference?.disabled_tool_ids || NO_DISABLED_TOOLS;
   const toggleToolForCurrentAgent = useCallback(
     (toolId: number) => {
       const disabled = disabledToolIds.includes(toolId);

--- a/web/src/refresh-components/popovers/ActionsPopover/index.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/index.tsx
@@ -281,30 +281,45 @@ export default function ActionsPopover({
   const hasNoConnectors = ccPairs.length === 0;
 
   const agentPreference = agentPreferences?.[selectedAgent.id];
-  const disabledToolIds = agentPreference?.disabled_tool_ids || [];
-  const toggleToolForCurrentAgent = (toolId: number) => {
-    const disabled = disabledToolIds.includes(toolId);
-    setSpecificAgentPreferences(selectedAgent.id, {
-      disabled_tool_ids: disabled
-        ? disabledToolIds.filter((id) => id !== toolId)
-        : [...disabledToolIds, toolId],
-    });
+  const disabledToolIds = useMemo(
+    () => agentPreference?.disabled_tool_ids || [],
+    [agentPreference?.disabled_tool_ids]
+  );
+  const toggleToolForCurrentAgent = useCallback(
+    (toolId: number) => {
+      const disabled = disabledToolIds.includes(toolId);
+      setSpecificAgentPreferences(selectedAgent.id, {
+        disabled_tool_ids: disabled
+          ? disabledToolIds.filter((id) => id !== toolId)
+          : [...disabledToolIds, toolId],
+      });
 
-    // If we're disabling a tool that is currently forced, remove it from forced tools
-    if (!disabled && forcedToolIds.includes(toolId)) {
-      setForcedToolIds(forcedToolIds.filter((id) => id !== toolId));
-    }
-  };
+      // If we're disabling a tool that is currently forced, remove it from forced tools
+      if (!disabled && forcedToolIds.includes(toolId)) {
+        setForcedToolIds(forcedToolIds.filter((id) => id !== toolId));
+      }
+    },
+    [
+      disabledToolIds,
+      selectedAgent.id,
+      setSpecificAgentPreferences,
+      forcedToolIds,
+      setForcedToolIds,
+    ]
+  );
 
-  const toggleForcedTool = (toolId: number) => {
-    if (forcedToolIds.includes(toolId)) {
-      // If clicking on already forced tool, unforce it
-      setForcedToolIds([]);
-    } else {
-      // If clicking on a new tool, replace any existing forced tools with just this one
-      setForcedToolIds([toolId]);
-    }
-  };
+  const toggleForcedTool = useCallback(
+    (toolId: number) => {
+      if (forcedToolIds.includes(toolId)) {
+        // If clicking on already forced tool, unforce it
+        setForcedToolIds([]);
+      } else {
+        // If clicking on a new tool, replace any existing forced tools with just this one
+        setForcedToolIds([toolId]);
+      }
+    },
+    [forcedToolIds, setForcedToolIds]
+  );
 
   // Get internal search tool reference for auto-pin logic
   const internalSearchTool = useMemo(

--- a/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
@@ -132,15 +132,11 @@ const validationSchema = Yup.object().shape({
   ),
 });
 
-// Helper function to determine transport from URL
 const getTransportFromUrl = (url: string): MCPTransportType => {
   const lowerUrl = url.toLowerCase();
   if (lowerUrl.endsWith("sse")) {
     return MCPTransportType.SSE;
-  } else if (lowerUrl.endsWith("mcp")) {
-    return MCPTransportType.STREAMABLE_HTTP;
   }
-  // Default to STREAMABLE_HTTP
   return MCPTransportType.STREAMABLE_HTTP;
 };
 

--- a/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
@@ -20,7 +20,7 @@ import {
   Text,
 } from "@opal/components";
 import { markdown } from "@opal/utils";
-import { Formik, Form } from "formik";
+import { Formik, Form, useFormikContext } from "formik";
 import * as Yup from "yup";
 import { useModal } from "@opal/components";
 import {
@@ -132,6 +132,30 @@ const validationSchema = Yup.object().shape({
   ),
 });
 
+// Helper function to determine transport from URL
+const getTransportFromUrl = (url: string): MCPTransportType => {
+  const lowerUrl = url.toLowerCase();
+  if (lowerUrl.endsWith("sse")) {
+    return MCPTransportType.SSE;
+  } else if (lowerUrl.endsWith("mcp")) {
+    return MCPTransportType.STREAMABLE_HTTP;
+  }
+  // Default to STREAMABLE_HTTP
+  return MCPTransportType.STREAMABLE_HTTP;
+};
+
+// Formik render props are plain callbacks, not components, so this effect
+// lives in its own child to keep hook order stable.
+function TransportAutoPopulate({ serverUrl }: { serverUrl?: string }) {
+  const { setFieldValue } = useFormikContext<MCPAuthFormValues>();
+  useEffect(() => {
+    if (serverUrl) {
+      setFieldValue("transport", getTransportFromUrl(serverUrl));
+    }
+  }, [serverUrl, setFieldValue]);
+  return null;
+}
+
 export default function MCPAuthenticationModal({
   mcpServer,
   skipOverlay = false,
@@ -177,18 +201,6 @@ export default function MCPAuthenticationModal({
       );
     }
   }, [fullServer]);
-
-  // Helper function to determine transport from URL
-  const getTransportFromUrl = (url: string): MCPTransportType => {
-    const lowerUrl = url.toLowerCase();
-    if (lowerUrl.endsWith("sse")) {
-      return MCPTransportType.SSE;
-    } else if (lowerUrl.endsWith("mcp")) {
-      return MCPTransportType.STREAMABLE_HTTP;
-    }
-    // Default to STREAMABLE_HTTP
-    return MCPTransportType.STREAMABLE_HTTP;
-  };
 
   const initialValues = useMemo<MCPAuthFormValues>(() => {
     if (!fullServer) {
@@ -521,16 +533,9 @@ export default function MCPAuthenticationModal({
             isValid,
             dirty,
           }) => {
-            // Auto-populate transport based on URL
-            useEffect(() => {
-              if (mcpServer?.server_url) {
-                const transport = getTransportFromUrl(mcpServer.server_url);
-                setFieldValue("transport", transport);
-              }
-            }, [mcpServer?.server_url, setFieldValue]);
-
             return (
               <Form className="flex flex-col h-full">
+                <TransportAutoPopulate serverUrl={mcpServer?.server_url} />
                 <Modal.Body>
                   <div className="flex flex-col gap-4 p-2">
                     {/* Authentication Type */}

--- a/web/src/sections/chat/ChatScrollContainer.tsx
+++ b/web/src/sections/chat/ChatScrollContainer.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react";
@@ -74,7 +75,6 @@ const ChatScrollContainer = React.memo(
         children,
         anchorSelector,
         autoScroll = true,
-        isStreaming = false,
         onScrollButtonVisibilityChange,
         sessionId,
         hideScrollbar = false,
@@ -104,12 +104,15 @@ const ChatScrollContainer = React.memo(
       const onScrollButtonVisibilityChangeRef = useRef(
         onScrollButtonVisibilityChange
       );
-      onScrollButtonVisibilityChangeRef.current =
-        onScrollButtonVisibilityChange;
       const autoScrollRef = useRef(autoScroll);
-      autoScrollRef.current = autoScroll;
-      const isStreamingRef = useRef(isStreaming);
-      isStreamingRef.current = isStreaming;
+
+      // Layout effect: queued rAF/observer callbacks fire after commit, so a
+      // passive sync could let them scroll with a stale autoScroll flag.
+      useLayoutEffect(() => {
+        onScrollButtonVisibilityChangeRef.current =
+          onScrollButtonVisibilityChange;
+        autoScrollRef.current = autoScroll;
+      }, [onScrollButtonVisibilityChange, autoScroll]);
 
       // Get current scroll state
       const getScrollState = useCallback((): ScrollState => {

--- a/web/src/sections/chat/ChatUI.tsx
+++ b/web/src/sections/chat/ChatUI.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { Message } from "@/app/app/interfaces";
 import { OnyxDocument, MinimalOnyxDocument } from "@/lib/search/interfaces";
 import HumanMessage from "@/app/app/message/HumanMessage";
@@ -106,10 +106,13 @@ const ChatUI = React.memo(
     const deepResearchEnabledRef = useRef(deepResearchEnabled);
     const currentMessageFilesRef = useRef(currentMessageFiles);
     const selectedModelsRef = useRef(selectedModels);
-    onSubmitRef.current = onSubmit;
-    deepResearchEnabledRef.current = deepResearchEnabled;
-    currentMessageFilesRef.current = currentMessageFiles;
-    selectedModelsRef.current = selectedModels;
+
+    useEffect(() => {
+      onSubmitRef.current = onSubmit;
+      deepResearchEnabledRef.current = deepResearchEnabled;
+      currentMessageFilesRef.current = currentMessageFiles;
+      selectedModelsRef.current = selectedModels;
+    }, [onSubmit, deepResearchEnabled, currentMessageFiles, selectedModels]);
 
     const createRegenerator = useCallback(
       (regenerationRequest: {

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -218,7 +218,15 @@ const AppInputBar = React.memo(
     // Snapshot of message, read non-reactively in the restore effect so seeding
     // doesn't re-run on every keystroke.
     const messageRef = useRef(message);
-    messageRef.current = message;
+    const isRecordingRef = useRef(isRecording);
+
+    useEffect(() => {
+      messageRef.current = message;
+    }, [message]);
+
+    useEffect(() => {
+      isRecordingRef.current = isRecording;
+    }, [isRecording]);
 
     useEffect(() => {
       draftSeededRef.current = false;
@@ -253,12 +261,12 @@ const AppInputBar = React.memo(
     }, [message, chatDraftLoaded, saveChatDraft]);
 
     const handleRecordingChange = useCallback((nextIsRecording: boolean) => {
-      setIsRecording((prevIsRecording) => {
-        if (!prevIsRecording && nextIsRecording) {
-          setRecordingCycleCount((count) => count + 1);
-        }
-        return nextIsRecording;
-      });
+      const wasRecording = isRecordingRef.current;
+      isRecordingRef.current = nextIsRecording;
+      if (!wasRecording && nextIsRecording) {
+        setRecordingCycleCount((count) => count + 1);
+      }
+      setIsRecording(nextIsRecording);
     }, []);
 
     // Wrapper for onSubmit that stops TTS first to prevent overlapping voices

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -225,10 +225,6 @@ const AppInputBar = React.memo(
     }, [message]);
 
     useEffect(() => {
-      isRecordingRef.current = isRecording;
-    }, [isRecording]);
-
-    useEffect(() => {
       draftSeededRef.current = false;
       // Clear the previous session's leftover text instead of leaking it into
       // this one.

--- a/web/src/sections/input/EntryInfoPopover.tsx
+++ b/web/src/sections/input/EntryInfoPopover.tsx
@@ -91,6 +91,9 @@ function EntryInfoPopover({
     return () => observer.disconnect();
   }, [tileElement, onDismiss]);
 
+  // Browser-only: measures the viewport and portals into document.body.
+  if (typeof window === "undefined") return null;
+
   const POPOVER_MAX_H = 240;
   const POPOVER_MAX_W = 320;
   const GAP = 4;

--- a/web/src/sections/input/InputChipStrip.tsx
+++ b/web/src/sections/input/InputChipStrip.tsx
@@ -178,8 +178,11 @@ export function InputChipStrip({
       {hasContent && (
         <motion.div
           key="chip-strip"
+          // oxlint-disable-next-line react-doctor/no-layout-property-animation -- height 0/auto must reflow the input bar, transform cannot
           initial={{ height: 0, opacity: 0 }}
+          // oxlint-disable-next-line react-doctor/no-layout-property-animation -- height 0/auto must reflow the input bar, transform cannot
           animate={{ height: "auto", opacity: 1 }}
+          // oxlint-disable-next-line react-doctor/no-layout-property-animation -- height 0/auto must reflow the input bar, transform cannot
           exit={{ height: 0, opacity: 0 }}
           transition={stripTransition}
           style={{ overflow: "hidden" }}

--- a/web/src/sections/input/PasteTilePopover.tsx
+++ b/web/src/sections/input/PasteTilePopover.tsx
@@ -63,6 +63,9 @@ function PasteTilePopover({
     };
   }, [updateRect]);
 
+  // Browser-only: measures the viewport and portals into document.body.
+  if (typeof window === "undefined") return null;
+
   const POPOVER_MAX_H = 340;
   const POPOVER_MAX_W = 400;
   const GAP = 4;

--- a/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
+++ b/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
@@ -214,6 +214,9 @@ export default function SourceHierarchyBrowser({
 
   // Store path before entering view selected mode so we can restore it
   const [savedPath, setSavedPath] = useState<HierarchyNodeSummary[]>([]);
+  const pathRef = useRef(path);
+  const savedPathRef = useRef(savedPath);
+  const viewSelectedOnlyRef = useRef(viewSelectedOnly);
 
   // Store selected document details (for showing all selected documents in view selected mode)
   // Note: useState (not useMemo) because this is modified independently when users select/deselect documents
@@ -525,6 +528,18 @@ export default function SourceHierarchyBrowser({
     onSelectionCountChange?.(source, currentSourceSelectedCount);
   }, [source, currentSourceSelectedCount, onSelectionCountChange]);
 
+  useEffect(() => {
+    pathRef.current = path;
+  }, [path]);
+
+  useEffect(() => {
+    savedPathRef.current = savedPath;
+  }, [savedPath]);
+
+  useEffect(() => {
+    viewSelectedOnlyRef.current = viewSelectedOnly;
+  }, [viewSelectedOnly]);
+
   // Header checkbox state: count how many visible items are selected
   const visibleSelectedCount = useMemo(() => {
     return filteredItems.filter((item) => {
@@ -649,18 +664,22 @@ export default function SourceHierarchyBrowser({
   };
 
   // Handler for toggling view selected mode
-  const handleToggleViewSelected = () => {
-    setViewSelectedOnly((prev) => {
-      if (!prev) {
-        // Entering view selected mode - save current path
-        setSavedPath(path);
-      } else {
-        // Exiting view selected mode - restore saved path
-        setPath(savedPath);
-      }
-      return !prev;
-    });
-  };
+  const handleToggleViewSelected = useCallback(() => {
+    if (!viewSelectedOnlyRef.current) {
+      // Entering view selected mode - save current path
+      const currentPath = pathRef.current;
+      savedPathRef.current = currentPath;
+      setSavedPath(currentPath);
+      viewSelectedOnlyRef.current = true;
+      setViewSelectedOnly(true);
+      return;
+    }
+
+    // Exiting view selected mode - restore saved path
+    setPath(savedPathRef.current);
+    viewSelectedOnlyRef.current = false;
+    setViewSelectedOnly(false);
+  }, []);
 
   // Handler for clicking a row (folder or document)
   const handleItemClick = (item: HierarchyItem) => {

--- a/web/src/sections/modals/PreviewModal/variants/docxVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/docxVariant.tsx
@@ -38,7 +38,10 @@ function DocxPreview({ fileUrl, onLoad }: DocxPreviewProps) {
   const bodyRef = useRef<HTMLDivElement>(null);
   const styleRef = useRef<HTMLDivElement>(null);
   const onLoadRef = useRef(onLoad);
-  onLoadRef.current = onLoad;
+
+  useEffect(() => {
+    onLoadRef.current = onLoad;
+  });
 
   useEffect(() => {
     async function loadDocument() {

--- a/web/src/sections/modals/PreviewModal/variants/docxVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/docxVariant.tsx
@@ -41,7 +41,7 @@ function DocxPreview({ fileUrl, onLoad }: DocxPreviewProps) {
 
   useEffect(() => {
     onLoadRef.current = onLoad;
-  });
+  }, [onLoad]);
 
   useEffect(() => {
     async function loadDocument() {

--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useMemo, useState, useEffect, useRef } from "react";
+import {
+  useCallback,
+  useMemo,
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from "react";
 import useNotifications from "@/hooks/useNotifications";
 import { useRouter } from "next/navigation";
 import { useSettings } from "@/lib/settings/hooks";
@@ -133,7 +140,12 @@ function RecentsSection({
   // Sentinel ref for IntersectionObserver-based infinite scroll
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   const onLoadMoreRef = useRef(onLoadMore);
-  onLoadMoreRef.current = onLoadMore;
+
+  // Layout effect: an already-scheduled observer callback must not see the
+  // previous page's loadMore after commit.
+  useLayoutEffect(() => {
+    onLoadMoreRef.current = onLoadMore;
+  }, [onLoadMore]);
 
   useEffect(() => {
     if (!hasMore || isLoadingMore) return;

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useRouter } from "next/navigation";
 import { Route } from "next";
 import { track, AnalyticsEvent } from "@/lib/analytics/utils";
@@ -129,7 +136,9 @@ export default function NotificationsPopover({
   const loadMoreRef = useRef(loadMore);
   const lastLoadScrollTopRef = useRef<number | null>(null);
 
-  useEffect(() => {
+  // Layout effect: an already-scheduled observer callback must not see the
+  // previous page's loadMore after commit.
+  useLayoutEffect(() => {
     loadMoreRef.current = loadMore;
   }, [loadMore]);
 

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -128,7 +128,10 @@ export default function NotificationsPopover({
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   const loadMoreRef = useRef(loadMore);
   const lastLoadScrollTopRef = useRef<number | null>(null);
-  loadMoreRef.current = loadMore;
+
+  useEffect(() => {
+    loadMoreRef.current = loadMore;
+  }, [loadMore]);
 
   // Track IDs dismissed during this session (before popover closes)
   const [sessionDismissedIds, setSessionDismissedIds] = useState<Set<number>>(

--- a/web/src/views/admin/GroupsPage/TokenLimitSection.tsx
+++ b/web/src/views/admin/GroupsPage/TokenLimitSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useState } from "react";
 import { SvgPlusCircle, SvgMinusCircle } from "@opal/icons";
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";
@@ -44,17 +44,33 @@ function TokenLimitSection({
   disabled,
   disabledTooltip,
 }: TokenLimitSectionProps) {
-  const nextKeyRef = useRef(limits.length);
-  const keysRef = useRef<number[]>(limits.map((_, i) => i));
+  const [rowKeys, setRowKeys] = useState<{
+    keys: number[];
+    nextKey: number;
+  }>({
+    keys: limits.map((_, i) => i),
+    nextKey: limits.length,
+  });
 
   // Sync keys if the parent provides a different number of limits externally
   // (e.g. loaded from server after initial mount).
-  if (keysRef.current.length < limits.length) {
-    while (keysRef.current.length < limits.length) {
-      keysRef.current.push(nextKeyRef.current++);
-    }
-  } else if (keysRef.current.length > limits.length) {
-    keysRef.current = keysRef.current.slice(0, limits.length);
+  if (rowKeys.keys.length < limits.length) {
+    const keysToAdd = limits.length - rowKeys.keys.length;
+    setRowKeys({
+      keys: [
+        ...rowKeys.keys,
+        ...Array.from(
+          { length: keysToAdd },
+          (_, index) => rowKeys.nextKey + index
+        ),
+      ],
+      nextKey: rowKeys.nextKey + keysToAdd,
+    });
+  } else if (rowKeys.keys.length > limits.length) {
+    setRowKeys({
+      keys: rowKeys.keys.slice(0, limits.length),
+      nextKey: rowKeys.nextKey,
+    });
   }
 
   function addLimit() {
@@ -65,8 +81,10 @@ function TokenLimitSection({
         l.costBudgetDollars === null
     );
     if (emptyIndex !== -1) return;
-    const key = nextKeyRef.current++;
-    keysRef.current = [...keysRef.current, key];
+    setRowKeys((prev) => ({
+      keys: [...prev.keys, prev.nextKey],
+      nextKey: prev.nextKey + 1,
+    }));
     onLimitsChange([
       ...limits,
       {
@@ -80,7 +98,10 @@ function TokenLimitSection({
   }
 
   function removeLimit(index: number) {
-    keysRef.current = keysRef.current.filter((_, i) => i !== index);
+    setRowKeys((prev) => ({
+      keys: prev.keys.filter((_, i) => i !== index),
+      nextKey: prev.nextKey,
+    }));
     onLimitsChange(limits.filter((_, i) => i !== index));
   }
 
@@ -143,10 +164,7 @@ function TokenLimitSection({
 
               {/* Limit rows */}
               {limits.map((limit, i) => (
-                <div
-                  key={keysRef.current[i]}
-                  className="flex items-center gap-1"
-                >
+                <div key={rowKeys.keys[i]} className="flex items-center gap-1">
                   <div className="flex-1">
                     <InputNumber
                       value={limit.tokenBudget}

--- a/web/src/views/admin/ImageGenerationPage/ImageGenerationContent.tsx
+++ b/web/src/views/admin/ImageGenerationPage/ImageGenerationContent.tsx
@@ -172,14 +172,6 @@ export default function ImageGenerationContent() {
     refetchProviders();
   };
 
-  if (llmError || configError) {
-    return (
-      <div className="text-error">
-        Failed to load configuration. Please refresh the page.
-      </div>
-    );
-  }
-
   // Compute replacement options when disconnecting an active provider
   const isDisconnectingDefault =
     disconnectProvider &&
@@ -209,6 +201,14 @@ export default function ImageGenerationContent() {
       if (firstModel) setReplacementProviderId(firstModel.image_provider_id);
     }
   }, [disconnectProvider]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (llmError || configError) {
+    return (
+      <div className="text-error">
+        Failed to load configuration. Please refresh the page.
+      </div>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
## Description

**Why:** react-doctor's error-class rules catch real bugs our oxlint config misses (3 rules-of-hooks violations live on main today).

**Fix:** Resolve all 93 error-level findings, then enforce 8 rules at error severity via `oxlint-plugin-react-doctor` (pinned 0.9.11) in `.oxlintrc.json`. The existing pre-commit oxlint hook and prek CI pick it up with no hook changes; full-project lint stays ~2s.

Fix classes:
- rules-of-hooks: effect in a Formik render prop, hooks after a conditional return
- SSR guards for unguarded `window`/`document` reads in render
- Effect cleanup for timers/observers; VoiceModeProvider WebSocket connect hardened with attempt-ID ownership
- Impure state updaters purified; two snapshot updaters converted to functional updates (real lost-update races)
- Render-phase ref mutations moved to effect syncs (`useLayoutEffect` where rAF/observer callbacks could read stale values)
- Invalid `role="textarea"` removed (2)

`usePacketProcessor` and `MessageTextRenderer` keep their deliberate render-phase designs with justified suppressions; rule-compliant rewrites regressed streaming and were reverted after review. 10 suppressions total, each with a reason. No visual changes. `react/exhaustive-deps` stays off.

## How Has This Been Tested?

- `bunx oxlint` full-project with all 8 react-doctor rules at error severity
- `bun run types:check`
- `bunx jest --findRelatedTests` over every changed file (755 tests / 80 suites, including the usePacketProcessor and usePacedTurnGroups streaming suites)
- `oxfmt` check over all changed files
- Live pre-commit check: a staged react-doctor violation fails the oxlint hook
- Reviews: codex sixteen-sweep, code-simplifier and comment-analyzer passes, Greptile (its one P1 fixed)
- Manual on a dev stack: chat streaming with tool-step pacing, historical chat loads, cross-chat navigation, TTS read-aloud playback, project file uploads with concurrent add/remove
- Triaged three issues found during manual testing (voice error toast, navigate-back scroll position, nested-button hydration warning): all reproduce on main, pre-existing, not from this PR

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
