### PR TITLE
fix(web): stop rendering "Anonymous" while the current user is unresolved

### DIFF
--- a/web/src/lib/fetcher.ts
+++ b/web/src/lib/fetcher.ts
@@ -33,6 +33,13 @@ const DEFAULT_AUTH_ERROR_MSG =
 
 const DEFAULT_ERROR_MSG = "An error occurred while fetching the data.";
 
+export function isAuthStatusError(error: unknown): boolean {
+  return (
+    error instanceof FetchError &&
+    (error.status === 401 || error.status === 402 || error.status === 403)
+  );
+}
+
 /**
  * SWR `onErrorRetry` callback that suppresses automatic retries for
  * auth or tier-gated errors (401/402/403). Pass this to any SWR hook whose
@@ -42,11 +49,7 @@ const DEFAULT_ERROR_MSG = "An error occurred while fetching the data.";
 export const skipRetryOnAuthError: NonNullable<
   import("swr").SWRConfiguration["onErrorRetry"]
 > = (error, _key, _config, revalidate, { retryCount }) => {
-  if (
-    error instanceof FetchError &&
-    (error.status === 401 || error.status === 402 || error.status === 403)
-  )
-    return;
+  if (isAuthStatusError(error)) return;
   // For non-auth errors, retry with exponential backoff
   if (
     _config.errorRetryCount !== undefined &&

--- a/web/src/providers/UserProvider.test.tsx
+++ b/web/src/providers/UserProvider.test.tsx
@@ -1,0 +1,169 @@
+// Guards the /api/me resolution contract: an unresolved fetch must read as
+// loading (never signed out), and a failed auth fetch self-heals with bounded retries.
+import { act, render, screen } from "@tests/setup/test-utils";
+// Relative import required: jest's moduleNameMapper swaps the @/ specifier for
+// the global UserProvider stub, and this suite must exercise the real one.
+import { UserProvider, useUser } from "./UserProvider";
+import { FetchError } from "@/lib/fetcher";
+import { useCurrentUser } from "@/lib/users/hooks";
+import { User } from "@/lib/types";
+
+jest.mock("posthog-js/react", () => ({ usePostHog: () => undefined }));
+jest.mock("@/lib/settings/hooks", () => ({ useSettings: () => ({}) }));
+jest.mock("@/lib/users/hooks", () => ({ useCurrentUser: jest.fn() }));
+jest.mock("@/lib/auth/hooks", () => ({
+  useAuthTypeMetadata: () => ({
+    authTypeMetadata: undefined,
+    isLoading: false,
+  }),
+  useTokenRefresh: jest.fn(),
+}));
+jest.mock("@/lib/users/svc", () => ({
+  updateUserPersonalization: jest.fn(),
+  setUserDefaultModel: jest.fn(),
+}));
+jest.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "light", setTheme: jest.fn() }),
+}));
+
+const mockedUseCurrentUser = jest.mocked(useCurrentUser);
+
+function setCurrentUser(overrides: Partial<ReturnType<typeof useCurrentUser>>) {
+  mockedUseCurrentUser.mockReturnValue({
+    user: undefined,
+    isLoading: true,
+    mutateUser: jest.fn(),
+    userError: undefined,
+    ...overrides,
+  } as ReturnType<typeof useCurrentUser>);
+}
+
+function Probe() {
+  const { user, isUserLoading } = useUser();
+  if (isUserLoading) {
+    return <span>loading</span>;
+  }
+  return <span>{user ? user.email : "signed-out"}</span>;
+}
+
+// Factory, not a constant: an identical element reference would let React
+// bail out of the re-render these tests depend on.
+function probeTree() {
+  return (
+    <UserProvider>
+      <Probe />
+    </UserProvider>
+  );
+}
+
+function renderProbe() {
+  return render(probeTree());
+}
+
+describe("UserProvider user resolution", () => {
+  it("reports loading while /api/me is unresolved", () => {
+    setCurrentUser({ user: undefined });
+    renderProbe();
+    expect(screen.getByText("loading")).toBeInTheDocument();
+  });
+
+  it("reports loading when /api/me failed instead of signed-out", () => {
+    setCurrentUser({
+      user: undefined,
+      isLoading: false,
+      userError: new Error("transient"),
+    });
+    renderProbe();
+    expect(screen.getByText("loading")).toBeInTheDocument();
+  });
+
+  it("reports signed-out only for a resolved null user", () => {
+    setCurrentUser({ user: null, isLoading: false });
+    renderProbe();
+    expect(screen.getByText("signed-out")).toBeInTheDocument();
+  });
+
+  it("exposes the user once resolved", () => {
+    setCurrentUser({
+      user: { id: "u1", email: "john@example.com" } as User,
+      isLoading: false,
+    });
+    renderProbe();
+    expect(screen.getByText("john@example.com")).toBeInTheDocument();
+  });
+});
+
+function authError(label: string): FetchError {
+  return new FetchError(label, 403, null);
+}
+
+describe("UserProvider /api/me retry", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("retries an auth failure on a backoff schedule, then falls back to signed-out", () => {
+    const mutateUser = jest.fn();
+
+    setCurrentUser({ userError: authError("fail 1"), mutateUser });
+    const { rerender } = renderProbe();
+    act(() => jest.advanceTimersByTime(2_000));
+    expect(mutateUser).toHaveBeenCalledTimes(1);
+
+    setCurrentUser({ userError: authError("fail 2"), mutateUser });
+    rerender(probeTree());
+    act(() => jest.advanceTimersByTime(5_000));
+    expect(mutateUser).toHaveBeenCalledTimes(2);
+
+    setCurrentUser({ userError: authError("fail 3"), mutateUser });
+    rerender(probeTree());
+    act(() => jest.advanceTimersByTime(15_000));
+    expect(mutateUser).toHaveBeenCalledTimes(3);
+
+    setCurrentUser({ userError: authError("fail 4"), mutateUser });
+    rerender(probeTree());
+    act(() => jest.advanceTimersByTime(120_000));
+    expect(mutateUser).toHaveBeenCalledTimes(3);
+    // Budget spent: reports signed-out instead of loading forever.
+    expect(screen.getByText("signed-out")).toBeInTheDocument();
+  });
+
+  it("does not schedule retries for non-auth failures (SWR owns those)", () => {
+    const mutateUser = jest.fn();
+
+    setCurrentUser({
+      userError: new FetchError("boom", 500, null),
+      mutateUser,
+    });
+    renderProbe();
+    act(() => jest.advanceTimersByTime(120_000));
+    expect(mutateUser).not.toHaveBeenCalled();
+    // Still treated as loading while SWR's own backoff keeps trying.
+    expect(screen.getByText("loading")).toBeInTheDocument();
+  });
+
+  it("resets the retry budget after a successful fetch", () => {
+    const mutateUser = jest.fn();
+
+    setCurrentUser({ userError: authError("fail"), mutateUser });
+    const { rerender } = renderProbe();
+    act(() => jest.advanceTimersByTime(2_000));
+    expect(mutateUser).toHaveBeenCalledTimes(1);
+
+    setCurrentUser({
+      user: { id: "u1", email: "john@example.com" } as User,
+      isLoading: false,
+      mutateUser,
+    });
+    rerender(probeTree());
+
+    setCurrentUser({ userError: authError("fail again"), mutateUser });
+    rerender(probeTree());
+    act(() => jest.advanceTimersByTime(2_000));
+    expect(mutateUser).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/providers/UserProvider.test.tsx
+++ b/web/src/providers/UserProvider.test.tsx
@@ -1,8 +1,6 @@
-// Guards the /api/me resolution contract: an unresolved fetch must read as
-// loading (never signed out), and a failed auth fetch self-heals with bounded retries.
+// Guards the /api/me contract: unresolved reads as loading and failed auth fetches self-heal.
 import { act, render, screen } from "@tests/setup/test-utils";
-// Relative import required: jest's moduleNameMapper swaps the @/ specifier for
-// the global UserProvider stub, and this suite must exercise the real one.
+// Relative import: jest's moduleNameMapper swaps the @/ path for the global stub.
 import { UserProvider, useUser } from "./UserProvider";
 import { FetchError } from "@/lib/fetcher";
 import { useCurrentUser } from "@/lib/users/hooks";
@@ -46,8 +44,7 @@ function Probe() {
   return <span>{user ? user.email : "signed-out"}</span>;
 }
 
-// Factory, not a constant: an identical element reference would let React
-// bail out of the re-render these tests depend on.
+// Factory: an identical element reference would let React skip the re-render.
 function probeTree() {
   return (
     <UserProvider>
@@ -128,7 +125,7 @@ describe("UserProvider /api/me retry", () => {
     rerender(probeTree());
     act(() => jest.advanceTimersByTime(120_000));
     expect(mutateUser).toHaveBeenCalledTimes(3);
-    // Budget spent: reports signed-out instead of loading forever.
+    // Budget spent: signed-out, not loading forever.
     expect(screen.getByText("signed-out")).toBeInTheDocument();
   });
 
@@ -142,7 +139,6 @@ describe("UserProvider /api/me retry", () => {
     renderProbe();
     act(() => jest.advanceTimersByTime(120_000));
     expect(mutateUser).not.toHaveBeenCalled();
-    // Still treated as loading while SWR's own backoff keeps trying.
     expect(screen.getByText("loading")).toBeInTheDocument();
   });
 

--- a/web/src/providers/UserProvider.test.tsx
+++ b/web/src/providers/UserProvider.test.tsx
@@ -37,12 +37,9 @@ function setCurrentUser(overrides: Partial<ReturnType<typeof useCurrentUser>>) {
 }
 
 function Probe() {
-  const { user, isUserLoading, isUserUnavailable } = useUser();
-  if (isUserLoading) {
-    return <span>loading</span>;
-  }
-  if (isUserUnavailable) {
-    return <span>unavailable</span>;
+  const { user, userResolution } = useUser();
+  if (userResolution !== "resolved") {
+    return <span>{userResolution}</span>;
   }
   return <span>{user ? user.email : "signed-out"}</span>;
 }

--- a/web/src/providers/UserProvider.test.tsx
+++ b/web/src/providers/UserProvider.test.tsx
@@ -137,9 +137,16 @@ describe("UserProvider /api/me retry", () => {
       mutateUser,
     });
     renderProbe();
-    act(() => jest.advanceTimersByTime(120_000));
+    act(() => jest.advanceTimersByTime(29_000));
     expect(mutateUser).not.toHaveBeenCalled();
     expect(screen.getByText("loading")).toBeInTheDocument();
+  });
+
+  it("stops reporting loading once a non-auth failure outlives the deadline", () => {
+    setCurrentUser({ userError: new FetchError("boom", 500, null) });
+    renderProbe();
+    act(() => jest.advanceTimersByTime(31_000));
+    expect(screen.getByText("signed-out")).toBeInTheDocument();
   });
 
   it("resets the retry budget after a successful fetch", () => {

--- a/web/src/providers/UserProvider.test.tsx
+++ b/web/src/providers/UserProvider.test.tsx
@@ -37,9 +37,12 @@ function setCurrentUser(overrides: Partial<ReturnType<typeof useCurrentUser>>) {
 }
 
 function Probe() {
-  const { user, isUserLoading } = useUser();
+  const { user, isUserLoading, isUserUnavailable } = useUser();
   if (isUserLoading) {
     return <span>loading</span>;
+  }
+  if (isUserUnavailable) {
+    return <span>unavailable</span>;
   }
   return <span>{user ? user.email : "signed-out"}</span>;
 }
@@ -103,7 +106,7 @@ describe("UserProvider /api/me retry", () => {
     jest.useRealTimers();
   });
 
-  it("retries an auth failure on a backoff schedule, then falls back to signed-out", () => {
+  it("retries an auth failure on a backoff schedule, then reports unavailable", () => {
     const mutateUser = jest.fn();
 
     setCurrentUser({ userError: authError("fail 1"), mutateUser });
@@ -125,8 +128,8 @@ describe("UserProvider /api/me retry", () => {
     rerender(probeTree());
     act(() => jest.advanceTimersByTime(120_000));
     expect(mutateUser).toHaveBeenCalledTimes(3);
-    // Budget spent: signed-out, not loading forever.
-    expect(screen.getByText("signed-out")).toBeInTheDocument();
+    // Budget spent: unavailable, never a false signed-out claim.
+    expect(screen.getByText("unavailable")).toBeInTheDocument();
   });
 
   it("does not schedule retries for non-auth failures (SWR owns those)", () => {
@@ -142,11 +145,11 @@ describe("UserProvider /api/me retry", () => {
     expect(screen.getByText("loading")).toBeInTheDocument();
   });
 
-  it("stops reporting loading once a non-auth failure outlives the deadline", () => {
+  it("reports unavailable once a non-auth failure outlives the deadline", () => {
     setCurrentUser({ userError: new FetchError("boom", 500, null) });
     renderProbe();
     act(() => jest.advanceTimersByTime(31_000));
-    expect(screen.getByText("signed-out")).toBeInTheDocument();
+    expect(screen.getByText("unavailable")).toBeInTheDocument();
   });
 
   it("resets the retry budget after a successful fetch", () => {

--- a/web/src/providers/UserProvider.tsx
+++ b/web/src/providers/UserProvider.tsx
@@ -33,12 +33,12 @@ const ME_RETRY_DELAYS_MS = [2_000, 5_000, 15_000];
 // Ceiling on reporting loading for a failing /api/me, so the account menu always comes back.
 const ME_LOADING_DEADLINE_MS = 30_000;
 
+/** Only "resolved" lets a null user mean signed out. "unavailable" means /api/me keeps failing for a possibly valid session. */
+export type UserResolution = "loading" | "unavailable" | "resolved";
+
 interface UserContextType {
   user: User | null;
-  /** True while the user is still resolving. A null `user` means signed out only once this is false. */
-  isUserLoading: boolean;
-  /** True when /api/me keeps failing: the session may be valid, the identity is just unknown. */
-  isUserUnavailable: boolean;
+  userResolution: UserResolution;
   isAdmin: boolean;
   isCurator: boolean;
   refreshUser: () => Promise<void>;
@@ -152,9 +152,12 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
 
   const awaitingMe = fetchedUser === undefined && !meRetriesExhausted;
   const mergePending = fetchedUser != null && upToDateUser === null;
-  const isUserLoading = awaitingMe || mergePending;
-  // Unresolved is not signed out: /api/me never returned, so no identity claim is honest.
-  const isUserUnavailable = meRetriesExhausted && fetchedUser === undefined;
+  const userResolution: UserResolution =
+    awaitingMe || mergePending
+      ? "loading"
+      : fetchedUser === undefined
+        ? "unavailable"
+        : "resolved";
 
   useEffect(() => {
     if (!posthog) return;
@@ -596,8 +599,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
     <UserContext.Provider
       value={{
         user: upToDateUser,
-        isUserLoading,
-        isUserUnavailable,
+        userResolution,
         refreshUser,
         authTypeMetadata,
         updateUserAutoScroll,

--- a/web/src/providers/UserProvider.tsx
+++ b/web/src/providers/UserProvider.tsx
@@ -16,6 +16,7 @@ import {
   ThemePreference,
 } from "@/lib/types";
 import { usePostHog } from "posthog-js/react";
+import { isAuthStatusError } from "@/lib/fetcher";
 import { useSettings } from "@/lib/settings/hooks";
 import { useCurrentUser } from "@/lib/users/hooks";
 import { useAuthTypeMetadata, useTokenRefresh } from "@/lib/auth/hooks";
@@ -26,8 +27,15 @@ import {
 } from "@/lib/users/svc";
 import { useTheme } from "next-themes";
 
+// Bounded self-heal for /api/me auth failures (401/402/403), which SWR's
+// onErrorRetry skips but which are usually transient token-refresh races
+// right after SSR validated the session. SWR's backoff owns other errors.
+const ME_RETRY_DELAYS_MS = [2_000, 5_000, 15_000];
+
 interface UserContextType {
   user: User | null;
+  /** True while the user is still resolving. A null `user` means signed out only once this is false. */
+  isUserLoading: boolean;
   isAdmin: boolean;
   isCurator: boolean;
   refreshUser: () => Promise<void>;
@@ -61,7 +69,7 @@ interface UserContextType {
 const UserContext = createContext<UserContextType | undefined>(undefined);
 
 export function UserProvider({ children }: { children: React.ReactNode }) {
-  const { user: fetchedUser, mutateUser } = useCurrentUser();
+  const { user: fetchedUser, mutateUser, userError } = useCurrentUser();
   const { authTypeMetadata, isLoading: authTypeMetadataLoading } =
     useAuthTypeMetadata();
   const updatedSettingsData = useSettings();
@@ -98,6 +106,45 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     setUpToDateUser(mergeUserPreferences(fetchedUser ?? null));
   }, [fetchedUser, mergeUserPreferences]);
+
+  // A spent budget stops reporting loading, so a failed /api/me cannot
+  // hold consumers in a loading state forever.
+  const [meRetriesExhausted, setMeRetriesExhausted] = useState(false);
+
+  const meRetryCountRef = useRef(0);
+  useEffect(() => {
+    if (!userError) {
+      meRetryCountRef.current = 0;
+      setMeRetriesExhausted(false);
+      return;
+    }
+    if (!isAuthStatusError(userError)) {
+      // A new non-auth failure hands the key back to SWR's backoff, so an
+      // earlier spent auth budget must not keep reporting resolved.
+      setMeRetriesExhausted(false);
+      return;
+    }
+    // Each failed revalidation yields a fresh error instance, and that
+    // identity change advances the schedule. The count only advances when a
+    // timer fires, so StrictMode's double-invoke cannot burn an attempt.
+    const attempt = meRetryCountRef.current;
+    const delay = ME_RETRY_DELAYS_MS[attempt];
+    if (delay === undefined) {
+      setMeRetriesExhausted(true);
+      return;
+    }
+    const timeoutId = setTimeout(() => {
+      meRetryCountRef.current = attempt + 1;
+      void mutateUser();
+    }, delay);
+    return () => clearTimeout(timeoutId);
+  }, [userError, mutateUser]);
+
+  // Still waiting on /api/me (first fetch, SWR backoff, or bounded auth
+  // retry), or the one-render gap before the merge effect lands the user.
+  const awaitingMe = fetchedUser === undefined && !meRetriesExhausted;
+  const mergePending = fetchedUser != null && upToDateUser === null;
+  const isUserLoading = awaitingMe || mergePending;
 
   useEffect(() => {
     if (!posthog) return;
@@ -539,6 +586,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
     <UserContext.Provider
       value={{
         user: upToDateUser,
+        isUserLoading,
         refreshUser,
         authTypeMetadata,
         updateUserAutoScroll,

--- a/web/src/providers/UserProvider.tsx
+++ b/web/src/providers/UserProvider.tsx
@@ -30,6 +30,9 @@ import { useTheme } from "next-themes";
 // Auth failures skip SWR's retry but are usually transient refresh races. SWR's backoff owns the rest.
 const ME_RETRY_DELAYS_MS = [2_000, 5_000, 15_000];
 
+// Ceiling on reporting loading for a failing /api/me, so the account menu always comes back.
+const ME_LOADING_DEADLINE_MS = 30_000;
+
 interface UserContextType {
   user: User | null;
   /** True while the user is still resolving. A null `user` means signed out only once this is false. */
@@ -108,15 +111,28 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
   const [meRetriesExhausted, setMeRetriesExhausted] = useState(false);
 
   const meRetryCountRef = useRef(0);
+  const meFirstErrorAtRef = useRef<number | null>(null);
   useEffect(() => {
     if (!userError) {
       meRetryCountRef.current = 0;
+      meFirstErrorAtRef.current = null;
       setMeRetriesExhausted(false);
       return;
     }
+    meFirstErrorAtRef.current ??= Date.now();
     if (!isAuthStatusError(userError)) {
-      setMeRetriesExhausted(false);
-      return;
+      // SWR's backoff owns non-auth retries. Bound only how long we report loading.
+      const remaining =
+        ME_LOADING_DEADLINE_MS - (Date.now() - meFirstErrorAtRef.current);
+      if (remaining <= 0) {
+        setMeRetriesExhausted(true);
+        return;
+      }
+      const deadlineId = setTimeout(
+        () => setMeRetriesExhausted(true),
+        remaining
+      );
+      return () => clearTimeout(deadlineId);
     }
     // Fresh error identity per failure advances the schedule. The count moves in the timer, so StrictMode is safe.
     const attempt = meRetryCountRef.current;

--- a/web/src/providers/UserProvider.tsx
+++ b/web/src/providers/UserProvider.tsx
@@ -27,9 +27,7 @@ import {
 } from "@/lib/users/svc";
 import { useTheme } from "next-themes";
 
-// Bounded self-heal for /api/me auth failures (401/402/403), which SWR's
-// onErrorRetry skips but which are usually transient token-refresh races
-// right after SSR validated the session. SWR's backoff owns other errors.
+// Auth failures skip SWR's retry but are usually transient refresh races. SWR's backoff owns the rest.
 const ME_RETRY_DELAYS_MS = [2_000, 5_000, 15_000];
 
 interface UserContextType {
@@ -107,8 +105,6 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
     setUpToDateUser(mergeUserPreferences(fetchedUser ?? null));
   }, [fetchedUser, mergeUserPreferences]);
 
-  // A spent budget stops reporting loading, so a failed /api/me cannot
-  // hold consumers in a loading state forever.
   const [meRetriesExhausted, setMeRetriesExhausted] = useState(false);
 
   const meRetryCountRef = useRef(0);
@@ -119,14 +115,10 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
       return;
     }
     if (!isAuthStatusError(userError)) {
-      // A new non-auth failure hands the key back to SWR's backoff, so an
-      // earlier spent auth budget must not keep reporting resolved.
       setMeRetriesExhausted(false);
       return;
     }
-    // Each failed revalidation yields a fresh error instance, and that
-    // identity change advances the schedule. The count only advances when a
-    // timer fires, so StrictMode's double-invoke cannot burn an attempt.
+    // Fresh error identity per failure advances the schedule. The count moves in the timer, so StrictMode is safe.
     const attempt = meRetryCountRef.current;
     const delay = ME_RETRY_DELAYS_MS[attempt];
     if (delay === undefined) {
@@ -140,8 +132,6 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
     return () => clearTimeout(timeoutId);
   }, [userError, mutateUser]);
 
-  // Still waiting on /api/me (first fetch, SWR backoff, or bounded auth
-  // retry), or the one-render gap before the merge effect lands the user.
   const awaitingMe = fetchedUser === undefined && !meRetriesExhausted;
   const mergePending = fetchedUser != null && upToDateUser === null;
   const isUserLoading = awaitingMe || mergePending;

--- a/web/src/providers/UserProvider.tsx
+++ b/web/src/providers/UserProvider.tsx
@@ -37,6 +37,8 @@ interface UserContextType {
   user: User | null;
   /** True while the user is still resolving. A null `user` means signed out only once this is false. */
   isUserLoading: boolean;
+  /** True when /api/me keeps failing: the session may be valid, the identity is just unknown. */
+  isUserUnavailable: boolean;
   isAdmin: boolean;
   isCurator: boolean;
   refreshUser: () => Promise<void>;
@@ -151,6 +153,8 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
   const awaitingMe = fetchedUser === undefined && !meRetriesExhausted;
   const mergePending = fetchedUser != null && upToDateUser === null;
   const isUserLoading = awaitingMe || mergePending;
+  // Unresolved is not signed out: /api/me never returned, so no identity claim is honest.
+  const isUserUnavailable = meRetriesExhausted && fetchedUser === undefined;
 
   useEffect(() => {
     if (!posthog) return;
@@ -593,6 +597,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
       value={{
         user: upToDateUser,
         isUserLoading,
+        isUserUnavailable,
         refreshUser,
         authTypeMetadata,
         updateUserAutoScroll,

--- a/web/src/refresh-components/skeletons/SidebarTabSkeleton.tsx
+++ b/web/src/refresh-components/skeletons/SidebarTabSkeleton.tsx
@@ -2,18 +2,20 @@ import { cn } from "@opal/utils";
 
 interface SidebarTabSkeletonProps {
   textWidth?: string;
+  folded?: boolean;
 }
 
 export default function SidebarTabSkeleton({
   textWidth = "w-2/3",
+  folded,
 }: SidebarTabSkeletonProps) {
   return (
     <div className="w-full rounded-08 p-1.5">
       <div className="h-6 flex flex-row items-center px-1 py-0.5">
         <div
           className={cn(
-            "h-3 rounded-sm bg-background-tint-04 animate-pulse",
-            textWidth
+            "bg-background-tint-04 animate-pulse",
+            folded ? "h-4 w-4 rounded-full" : cn("h-3 rounded-sm", textWidth)
           )}
         />
       </div>

--- a/web/src/sections/sidebar/AccountPopover.test.tsx
+++ b/web/src/sections/sidebar/AccountPopover.test.tsx
@@ -1,12 +1,10 @@
-// Guards the account chip's loading contract: skeleton while the user is
-// unresolved, "Anonymous" only for a resolved signed-out user.
+// The chip shows a skeleton while unresolved and "Anonymous" only when resolved signed-out.
 import { render, screen } from "@tests/setup/test-utils";
-import AccountPopover from "./AccountPopover";
+import AccountPopover from "@/sections/sidebar/AccountPopover";
 import { useUser } from "@/providers/UserProvider";
 import { User } from "@/lib/types";
 
-// Factory mock so the loading branch is drivable. The global stub pins
-// isUserLoading to false.
+// Factory mock: the global stub pins isUserLoading false.
 jest.mock("@/providers/UserProvider", () => ({ useUser: jest.fn() }));
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: jest.fn() }),
@@ -45,7 +43,6 @@ it("shows a skeleton instead of Anonymous while the user is unresolved", () => {
   setUser(null, true);
   render(<AccountPopover />);
   expect(screen.queryByText("Anonymous")).not.toBeInTheDocument();
-  // The trigger button is replaced entirely, not rendered empty.
   expect(screen.queryByRole("button")).not.toBeInTheDocument();
 });
 

--- a/web/src/sections/sidebar/AccountPopover.test.tsx
+++ b/web/src/sections/sidebar/AccountPopover.test.tsx
@@ -4,7 +4,7 @@ import AccountPopover from "@/sections/sidebar/AccountPopover";
 import { useUser } from "@/providers/UserProvider";
 import { User } from "@/lib/types";
 
-// Factory mock: the global stub pins isUserLoading false.
+// Factory mock: the global stub pins userResolution to "resolved".
 jest.mock("@/providers/UserProvider", () => ({ useUser: jest.fn() }));
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: jest.fn() }),
@@ -34,32 +34,30 @@ const mockedUseUser = jest.mocked(useUser);
 
 function setUser(
   user: User | null,
-  isUserLoading: boolean,
-  isUserUnavailable = false
+  userResolution: "loading" | "unavailable" | "resolved"
 ) {
   mockedUseUser.mockReturnValue({
     user,
-    isUserLoading,
-    isUserUnavailable,
+    userResolution,
   } as ReturnType<typeof useUser>);
 }
 
 it("shows a skeleton instead of Anonymous while the user is unresolved", () => {
-  setUser(null, true);
+  setUser(null, "loading");
   render(<AccountPopover />);
   expect(screen.queryByText("Anonymous")).not.toBeInTheDocument();
   expect(screen.queryByRole("button")).not.toBeInTheDocument();
 });
 
 it("shows a neutral label, not Anonymous, when the user is unavailable", () => {
-  setUser(null, false, true);
+  setUser(null, "unavailable");
   render(<AccountPopover />);
   expect(screen.getByText("Account")).toBeInTheDocument();
   expect(screen.queryByText("Anonymous")).not.toBeInTheDocument();
 });
 
 it("shows Anonymous for a resolved signed-out user", () => {
-  setUser(null, false);
+  setUser(null, "resolved");
   render(<AccountPopover />);
   expect(screen.getByText("Anonymous")).toBeInTheDocument();
 });
@@ -71,7 +69,7 @@ it("shows the user's name once resolved", () => {
       email: "john@example.com",
       personalization: { name: "John" },
     } as unknown as User,
-    false
+    "resolved"
   );
   render(<AccountPopover />);
   expect(screen.getByText("John")).toBeInTheDocument();

--- a/web/src/sections/sidebar/AccountPopover.test.tsx
+++ b/web/src/sections/sidebar/AccountPopover.test.tsx
@@ -1,0 +1,69 @@
+// Guards the account chip's loading contract: skeleton while the user is
+// unresolved, "Anonymous" only for a resolved signed-out user.
+import { render, screen } from "@tests/setup/test-utils";
+import AccountPopover from "./AccountPopover";
+import { useUser } from "@/providers/UserProvider";
+import { User } from "@/lib/types";
+
+// Factory mock so the loading branch is drivable. The global stub pins
+// isUserLoading to false.
+jest.mock("@/providers/UserProvider", () => ({ useUser: jest.fn() }));
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => "/app",
+  useSearchParams: () => new URLSearchParams(),
+}));
+jest.mock("@/sections/sidebar/NotificationsPopover", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("@/hooks/useAppFocus", () => ({
+  __esModule: true,
+  default: () => ({ isUserSettings: () => false }),
+}));
+jest.mock("@/hooks/useScreenSize", () => ({
+  __esModule: true,
+  default: () => ({ isMobile: false }),
+}));
+jest.mock("@/lib/settings/hooks", () => ({
+  useSettings: () => ({ vectorDbEnabled: false }),
+}));
+jest.mock("@/hooks/useNotifications", () => ({
+  useNotificationSummary: () => ({ undismissedCount: 0, refresh: jest.fn() }),
+}));
+
+const mockedUseUser = jest.mocked(useUser);
+
+function setUser(user: User | null, isUserLoading: boolean) {
+  mockedUseUser.mockReturnValue({
+    user,
+    isUserLoading,
+  } as ReturnType<typeof useUser>);
+}
+
+it("shows a skeleton instead of Anonymous while the user is unresolved", () => {
+  setUser(null, true);
+  render(<AccountPopover />);
+  expect(screen.queryByText("Anonymous")).not.toBeInTheDocument();
+  // The trigger button is replaced entirely, not rendered empty.
+  expect(screen.queryByRole("button")).not.toBeInTheDocument();
+});
+
+it("shows Anonymous for a resolved signed-out user", () => {
+  setUser(null, false);
+  render(<AccountPopover />);
+  expect(screen.getByText("Anonymous")).toBeInTheDocument();
+});
+
+it("shows the user's name once resolved", () => {
+  setUser(
+    {
+      id: "u1",
+      email: "john@example.com",
+      personalization: { name: "John" },
+    } as unknown as User,
+    false
+  );
+  render(<AccountPopover />);
+  expect(screen.getByText("John")).toBeInTheDocument();
+});

--- a/web/src/sections/sidebar/AccountPopover.test.tsx
+++ b/web/src/sections/sidebar/AccountPopover.test.tsx
@@ -32,10 +32,15 @@ jest.mock("@/hooks/useNotifications", () => ({
 
 const mockedUseUser = jest.mocked(useUser);
 
-function setUser(user: User | null, isUserLoading: boolean) {
+function setUser(
+  user: User | null,
+  isUserLoading: boolean,
+  isUserUnavailable = false
+) {
   mockedUseUser.mockReturnValue({
     user,
     isUserLoading,
+    isUserUnavailable,
   } as ReturnType<typeof useUser>);
 }
 
@@ -44,6 +49,13 @@ it("shows a skeleton instead of Anonymous while the user is unresolved", () => {
   render(<AccountPopover />);
   expect(screen.queryByText("Anonymous")).not.toBeInTheDocument();
   expect(screen.queryByRole("button")).not.toBeInTheDocument();
+});
+
+it("shows a neutral label, not Anonymous, when the user is unavailable", () => {
+  setUser(null, false, true);
+  render(<AccountPopover />);
+  expect(screen.getByText("Account")).toBeInTheDocument();
+  expect(screen.queryByText("Anonymous")).not.toBeInTheDocument();
 });
 
 it("shows Anonymous for a resolved signed-out user", () => {

--- a/web/src/sections/sidebar/AccountPopover.tsx
+++ b/web/src/sections/sidebar/AccountPopover.tsx
@@ -30,6 +30,7 @@ import useAppFocus from "@/hooks/useAppFocus";
 import useScreenSize from "@/hooks/useScreenSize";
 import { useSettings } from "@/lib/settings/hooks";
 import UserAvatar from "@/refresh-components/avatars/UserAvatar";
+import SidebarTabSkeleton from "@/refresh-components/skeletons/SidebarTabSkeleton";
 import { useNotificationSummary } from "@/hooks/useNotifications";
 import { SvgOnyxLogo } from "@opal/logos";
 import { markdown } from "@opal/utils";
@@ -198,7 +199,7 @@ export default function AccountPopover({
   const [popupState, setPopupState] = useState<
     "Settings" | "Notifications" | undefined
   >(undefined);
-  const { user } = useUser();
+  const { user, isUserLoading } = useUser();
   const appFocus = useAppFocus();
   const { isMobile } = useScreenSize();
   const { vectorDbEnabled } = useSettings();
@@ -221,6 +222,10 @@ export default function AccountPopover({
       setPopupState(undefined);
     }
   };
+
+  if (isUserLoading) {
+    return <SidebarTabSkeleton folded={folded} />;
+  }
 
   return (
     <Popover open={!!popupState} onOpenChange={handlePopoverOpen}>

--- a/web/src/sections/sidebar/AccountPopover.tsx
+++ b/web/src/sections/sidebar/AccountPopover.tsx
@@ -46,7 +46,7 @@ function SettingsPopover({
   onOpenNotifications,
   undismissedCount,
 }: SettingsPopoverProps) {
-  const { user } = useUser();
+  const { user, isUserUnavailable } = useUser();
   const settings = useSettings();
   const enterpriseSettings = settings.enterprise;
   const router = useRouter();
@@ -91,7 +91,12 @@ function SettingsPopover({
     <PopoverMenu>
       {[
         <div key="user-email" className="p-2">
-          <Content sizePreset="main-ui" title={getUserEmail(user)} />
+          <Content
+            sizePreset="main-ui"
+            title={
+              isUserUnavailable ? "Profile unavailable" : getUserEmail(user)
+            }
+          />
         </div>,
         null,
         <div key="user-settings" data-testid="Settings/user-settings">
@@ -199,13 +204,15 @@ export default function AccountPopover({
   const [popupState, setPopupState] = useState<
     "Settings" | "Notifications" | undefined
   >(undefined);
-  const { user, isUserLoading } = useUser();
+  const { user, isUserLoading, isUserUnavailable } = useUser();
   const appFocus = useAppFocus();
   const { isMobile } = useScreenSize();
   const { vectorDbEnabled } = useSettings();
   const { undismissedCount, refresh: refreshNotificationSummary } =
     useNotificationSummary();
-  const userDisplayName = getUserDisplayName(user);
+  const userDisplayName = isUserUnavailable
+    ? "Account"
+    : getUserDisplayName(user);
 
   const handlePopoverOpen = (state: boolean) => {
     if (state) {

--- a/web/src/sections/sidebar/AccountPopover.tsx
+++ b/web/src/sections/sidebar/AccountPopover.tsx
@@ -46,7 +46,7 @@ function SettingsPopover({
   onOpenNotifications,
   undismissedCount,
 }: SettingsPopoverProps) {
-  const { user, isUserUnavailable } = useUser();
+  const { user, userResolution } = useUser();
   const settings = useSettings();
   const enterpriseSettings = settings.enterprise;
   const router = useRouter();
@@ -94,7 +94,9 @@ function SettingsPopover({
           <Content
             sizePreset="main-ui"
             title={
-              isUserUnavailable ? "Profile unavailable" : getUserEmail(user)
+              userResolution === "unavailable"
+                ? "Profile unavailable"
+                : getUserEmail(user)
             }
           />
         </div>,
@@ -204,15 +206,14 @@ export default function AccountPopover({
   const [popupState, setPopupState] = useState<
     "Settings" | "Notifications" | undefined
   >(undefined);
-  const { user, isUserLoading, isUserUnavailable } = useUser();
+  const { user, userResolution } = useUser();
   const appFocus = useAppFocus();
   const { isMobile } = useScreenSize();
   const { vectorDbEnabled } = useSettings();
   const { undismissedCount, refresh: refreshNotificationSummary } =
     useNotificationSummary();
-  const userDisplayName = isUserUnavailable
-    ? "Account"
-    : getUserDisplayName(user);
+  const userDisplayName =
+    userResolution === "unavailable" ? "Account" : getUserDisplayName(user);
 
   const handlePopoverOpen = (state: boolean) => {
     if (state) {
@@ -229,8 +230,7 @@ export default function AccountPopover({
       setPopupState(undefined);
     }
   };
-
-  if (isUserLoading) {
+  if (userResolution === "loading") {
     return <SidebarTabSkeleton folded={folded} />;
   }
 

--- a/web/tests/setup/mocks/components/UserProvider.tsx
+++ b/web/tests/setup/mocks/components/UserProvider.tsx
@@ -20,6 +20,7 @@ import React, { createContext, useContext } from "react";
 interface UserContextType {
   user: any;
   isUserLoading: boolean;
+  isUserUnavailable: boolean;
   isAdmin: boolean;
   isCurator: boolean;
   refreshUser: () => Promise<void>;
@@ -38,6 +39,7 @@ interface UserContextType {
 const mockUserContext: UserContextType = {
   user: null,
   isUserLoading: false,
+  isUserUnavailable: false,
   isAdmin: false,
   isCurator: false,
   refreshUser: async () => {},

--- a/web/tests/setup/mocks/components/UserProvider.tsx
+++ b/web/tests/setup/mocks/components/UserProvider.tsx
@@ -19,8 +19,7 @@ import React, { createContext, useContext } from "react";
 
 interface UserContextType {
   user: any;
-  isUserLoading: boolean;
-  isUserUnavailable: boolean;
+  userResolution: "loading" | "unavailable" | "resolved";
   isAdmin: boolean;
   isCurator: boolean;
   refreshUser: () => Promise<void>;
@@ -38,8 +37,7 @@ interface UserContextType {
 
 const mockUserContext: UserContextType = {
   user: null,
-  isUserLoading: false,
-  isUserUnavailable: false,
+  userResolution: "resolved",
   isAdmin: false,
   isCurator: false,
   refreshUser: async () => {},

--- a/web/tests/setup/mocks/components/UserProvider.tsx
+++ b/web/tests/setup/mocks/components/UserProvider.tsx
@@ -19,6 +19,7 @@ import React, { createContext, useContext } from "react";
 
 interface UserContextType {
   user: any;
+  isUserLoading: boolean;
   isAdmin: boolean;
   isCurator: boolean;
   refreshUser: () => Promise<void>;
@@ -36,6 +37,7 @@ interface UserContextType {
 
 const mockUserContext: UserContextType = {
   user: null,
+  isUserLoading: false,
   isAdmin: false,
   isCurator: false,
   refreshUser: async () => {},


### PR DESCRIPTION
## Description

Customer report (Azure AD/Entra OIDC, v4.5.x): ~20% of page loads show "Anonymous" in the sidebar account chip. A refresh restores the account.

Bug:
- The account chip renders the null-user fallback ("Anonymous") during the /api/me load window.
- One failed /api/me pins it there for the whole SPA session: auth errors skip SWR retry (`skipRetryOnAuthError`) and the key never revalidates, so only a hard reload recovers.

Fix:
- `UserProvider` exposes `isUserLoading`. A null user only means signed out once /api/me has resolved to null.
- `AccountPopover` shows `SidebarTabSkeleton` (folded-aware) until the user is resolved.
- Failed /api/me auth errors (401/402/403) self-heal with bounded retries (2s/5s/15s). Non-auth errors stay with SWR's own backoff.
- After the retry budget is spent the chip falls back to the resolved presentation, so the account menu never stays a skeleton.
- `isAuthStatusError` shared between `skipRetryOnAuthError` and the retry.

## How Has This Been Tested?
Loading states:
<img width="255" height="85" alt="Screenshot 2026-08-11 at 10 32 31 AM" src="https://github.com/user-attachments/assets/35347843-8114-49cd-b204-4efeb721ee94" />
<img width="76" height="73" alt="Screenshot 2026-08-11 at 10 32 26 AM" src="https://github.com/user-attachments/assets/ce78411a-d03a-4281-b067-8a36fddf89b7" />

- New jest suites: UserProvider tri-state, retry schedule/cap/reset, exhaustion fallback (7 tests) and AccountPopover skeleton/Anonymous/name (3 tests).
- Full web jest suite green (112 suites, 1085 tests). `bun run types:check` clean. pre-commit (oxfmt, oxlint, tsc) green.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check