### PR TITLE
fix(highspot): surface plain-text API errors and xfail the 403 tests

### DIFF
--- a/backend/onyx/connectors/highspot/client.py
+++ b/backend/onyx/connectors/highspot/client.py
@@ -161,7 +161,11 @@ class HighspotClient:
                 if isinstance(error_data, dict):
                     error_msg = error_data.get("message", str(e))
             except (ValueError, KeyError):
-                pass
+                # Highspot sends some errors as plain text (e.g. the licensing
+                # 403). Keep the body so the reason reaches the logs.
+                body = e.response.text.strip()
+                if body:
+                    error_msg = f"{e} - {body}"
 
             if status_code == 401:
                 raise HighspotAuthenticationError(f"Authentication failed: {error_msg}")

--- a/backend/tests/daily/connectors/highspot/test_highspot_connector.py
+++ b/backend/tests/daily/connectors/highspot/test_highspot_connector.py
@@ -12,10 +12,22 @@ from onyx.connectors.highspot.connector import HighspotConnector
 from onyx.connectors.models import Document, HierarchyNode
 from tests.utils.secret_names import TestSecret
 
-pytestmark = pytest.mark.secrets(
-    TestSecret.HIGHSPOT_KEY,
-    TestSecret.HIGHSPOT_SECRET,
-)
+# Since 2026-08-10 the Highspot API answers 403 for valid credentials, so no test
+# here can pass. `-x` makes the failure abort the whole connector suite, so mark
+# them xfail until we know the cause. Remove the mark once the API works again.
+pytestmark = [
+    pytest.mark.secrets(
+        TestSecret.HIGHSPOT_KEY,
+        TestSecret.HIGHSPOT_SECRET,
+    ),
+    pytest.mark.xfail(
+        reason=(
+            "Highspot API returns 403 for valid credentials since 2026-08-10. "
+            "Case raised with Highspot to confirm the cause."
+        ),
+        strict=False,
+    ),
+]
 
 
 def load_test_data(file_name: str = "test_highspot_data.json") -> dict:


### PR DESCRIPTION
## Description

- Mark the Highspot connector tests `xfail`. The Highspot API has returned 403 for valid credentials since 2026-08-10, and because the suite runs with `-x` that one failure aborts every other connector test — so Connector Tests is red on all PRs. Remove the mark once the API works again.
- Keep the response body in `HighspotClientError` when the error is not JSON. Highspot sent the 403 as plain text with no `content-type`, so `response.json()` raised and the handler discarded the only useful part of the message.

Before: `API error 403: 403 Client Error: Forbidden for url: .../v1.0/spots?...`
After: `API error 403: 403 Client Error: Forbidden for url: .../v1.0/spots?... - Sorry, the Highspot REST API requires an eligible Highspot license. Please reach out to your system administrator`

A case is open with Highspot to confirm the cause. Regenerating the API credentials did not help — the new key returns the same 403, while invalid credentials return 401, so authentication itself works.

## How Has This Been Tested?

Ran `backend/tests/daily/connectors/highspot` against the live API: 4 xfailed, exit code 0, and `-x` no longer aborts the run. Confirmed the new error message with a real 403 and a real 401.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces plain-text Highspot API errors and temporarily xfails Highspot connector tests to unblock CI. Keeps the 403 reason in error messages and prevents the Highspot failure from aborting the connector suite.

- **Bug Fixes**
  - Preserve non-JSON response bodies in Highspot errors so 403 messages (e.g., license errors) appear in logs.
  - Mark Highspot connector tests as xfail while the API returns 403 for valid credentials, so -x no longer stops the run. Remove once the API is fixed.

<sup>Written for commit ba456b27e4ba461f1e00235fbd13e69ccf62689d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

