### PR TITLE
Change FOSS repo URL to use access token

### DIFF
--- a/.github/workflows/sync_foss.yml
+++ b/.github/workflows/sync_foss.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Push to FOSS repo
         env:
-          FOSS_REPO_URL: git@github.com:onyx-dot-app/onyx-foss.git
+          FOSS_REPO_URL: https://x-access-token:${{ secrets.GH_PAT }}@github.com/onyx-dot-app/onyx-foss.git
         run: |
           cd /tmp/foss_repo
           git remote add public "$FOSS_REPO_URL"


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the FOSS sync workflow to push via HTTPS using `${{ secrets.GH_PAT }}` instead of SSH. This fixes push failures on hosted runners and removes the need for deploy keys.

<sup>Written for commit 82081fa2f448b7f4657c6f5529da774054ddd059. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

