### PR TITLE
fix(craft): restore stale skills after turn failure

### DIFF
--- a/web/src/app/craft/components/SkillsStaleNotice.test.tsx
+++ b/web/src/app/craft/components/SkillsStaleNotice.test.tsx
@@ -36,9 +36,17 @@ describe("SkillsStaleNotice", () => {
     });
   });
 
-  it("disables reload while a turn is active", () => {
-    render(<SkillsStaleNotice sessionId={SESSION_ID} turnActive />);
+  it("reveals retained stale state after an active turn stops", () => {
+    const { rerender } = render(
+      <SkillsStaleNotice sessionId={SESSION_ID} turnActive />
+    );
 
-    expect(screen.getByRole("button", { name: "Reload" })).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: "Reload" })
+    ).not.toBeInTheDocument();
+
+    rerender(<SkillsStaleNotice sessionId={SESSION_ID} turnActive={false} />);
+
+    expect(screen.getByRole("button", { name: "Reload" })).toBeEnabled();
   });
 });

--- a/web/src/app/craft/components/SkillsStaleNotice.tsx
+++ b/web/src/app/craft/components/SkillsStaleNotice.tsx
@@ -34,20 +34,15 @@ export default function SkillsStaleNotice({
     }
   };
 
+  if (turnActive) return null;
+
   return (
     <MessageCard
       variant="warning"
       title="Your agent’s capabilities have changed"
       description="Reload this session to apply the latest skills and app access."
       rightChildren={
-        <Button
-          icon={SvgRefreshCw}
-          onClick={reload}
-          disabled={turnActive || reloading}
-          tooltip={
-            turnActive ? "Wait for the current turn to finish." : undefined
-          }
-        >
+        <Button icon={SvgRefreshCw} onClick={reload} disabled={reloading}>
           {reloading ? "Reloading…" : "Reload"}
         </Button>
       }

--- a/web/src/app/craft/hooks/loadSessionRestore.test.ts
+++ b/web/src/app/craft/hooks/loadSessionRestore.test.ts
@@ -551,42 +551,6 @@ describe("loadSession restore status", () => {
     ).toBe(false);
   });
 
-  it("keeps a stale observation from a newer overlapping load", async () => {
-    const olderMessages = deferred<unknown[]>();
-    const newerMessages = deferred<unknown[]>();
-    mockedApi.fetchSession
-      .mockResolvedValueOnce({
-        ...runningSession(),
-        skills_stale: false,
-      } as never)
-      .mockResolvedValueOnce({
-        ...runningSession(),
-        skills_stale: true,
-      } as never);
-    mockedApi.fetchMessages
-      .mockReturnValueOnce(olderMessages.promise as never)
-      .mockReturnValueOnce(newerMessages.promise as never);
-
-    const olderLoad = useBuildSessionStore
-      .getState()
-      .loadSession(SESSION_ID, { force: true });
-    await Promise.resolve();
-    const newerLoad = useBuildSessionStore
-      .getState()
-      .loadSession(SESSION_ID, { force: true });
-    await Promise.resolve();
-    expect(mockedApi.fetchMessages).toHaveBeenCalledTimes(2);
-
-    olderMessages.resolve([]);
-    await olderLoad;
-    newerMessages.resolve([]);
-    await newerLoad;
-
-    expect(
-      useBuildSessionStore.getState().sessions.get(SESSION_ID)?.skillsStale
-    ).toBe(true);
-  });
-
   it("clears stale turn metadata when active turn lookup says no turn is running", async () => {
     mockedApi.fetchSession.mockResolvedValue(runningSession() as never);
     mockedApi.fetchActiveTurn.mockResolvedValue(null as never);

--- a/web/src/app/craft/hooks/loadSessionRestore.test.ts
+++ b/web/src/app/craft/hooks/loadSessionRestore.test.ts
@@ -12,10 +12,11 @@ const SESSION_ID = "11111111-1111-1111-1111-111111111111";
 
 // Minimal DetailedSessionResponse shapes — loadSession only reads status,
 // session_loaded_in_sandbox, nextjs_port, and sandbox.status.
-function sleepingSession(): unknown {
+function sleepingSession(): Record<string, unknown> {
   return {
     id: SESSION_ID,
     status: "idle",
+    skills_stale: false,
     nextjs_port: null,
     session_loaded_in_sandbox: false,
     sandbox: { id: "sb1", status: "sleeping" },
@@ -28,6 +29,7 @@ function runningSession(
   return {
     id: SESSION_ID,
     status: "active",
+    skills_stale: false,
     nextjs_port: nextjsPort,
     session_loaded_in_sandbox: true,
     sandbox: { id: "sb1", status: "running" },
@@ -36,6 +38,14 @@ function runningSession(
 
 function webappInfo(has_webapp: boolean | null, ready: boolean): unknown {
   return { has_webapp, webapp_url: null, status: "running", ready };
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve: (value: T) => void = () => {};
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 }
 
 describe("loadSession restore status", () => {
@@ -86,6 +96,23 @@ describe("loadSession restore status", () => {
 
     const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
     expect(session?.sandbox?.status).toBe("failed");
+  });
+
+  it("clears stale skills after a successful session restore", async () => {
+    mockedApi.fetchSession.mockResolvedValue({
+      ...sleepingSession(),
+      skills_stale: true,
+    } as never);
+    mockedApi.restoreSession.mockResolvedValue({
+      ...runningSession(),
+      skills_stale: false,
+    } as never);
+
+    await useBuildSessionStore.getState().loadSession(SESSION_ID);
+
+    expect(
+      useBuildSessionStore.getState().sessions.get(SESSION_ID)?.skillsStale
+    ).toBe(false);
   });
 
   it("waits for the webapp before flipping to running, then shows running", async () => {
@@ -500,16 +527,12 @@ describe("loadSession restore status", () => {
   });
 
   it("rejects a load fetched before a newer stale-skill update", async () => {
-    let resolveMessages: (value: unknown[]) => void = () => {};
+    const messages = deferred<unknown[]>();
     mockedApi.fetchSession.mockResolvedValue({
       ...runningSession(),
       skills_stale: true,
     } as never);
-    mockedApi.fetchMessages.mockReturnValue(
-      new Promise((resolve) => {
-        resolveMessages = resolve;
-      }) as never
-    );
+    mockedApi.fetchMessages.mockReturnValue(messages.promise as never);
 
     const load = useBuildSessionStore
       .getState()
@@ -520,12 +543,48 @@ describe("loadSession restore status", () => {
     useBuildSessionStore
       .getState()
       .updateSessionData(SESSION_ID, { skillsStale: false });
-    resolveMessages([]);
+    messages.resolve([]);
     await load;
 
     expect(
       useBuildSessionStore.getState().sessions.get(SESSION_ID)?.skillsStale
     ).toBe(false);
+  });
+
+  it("keeps a stale observation from a newer overlapping load", async () => {
+    const olderMessages = deferred<unknown[]>();
+    const newerMessages = deferred<unknown[]>();
+    mockedApi.fetchSession
+      .mockResolvedValueOnce({
+        ...runningSession(),
+        skills_stale: false,
+      } as never)
+      .mockResolvedValueOnce({
+        ...runningSession(),
+        skills_stale: true,
+      } as never);
+    mockedApi.fetchMessages
+      .mockReturnValueOnce(olderMessages.promise as never)
+      .mockReturnValueOnce(newerMessages.promise as never);
+
+    const olderLoad = useBuildSessionStore
+      .getState()
+      .loadSession(SESSION_ID, { force: true });
+    await Promise.resolve();
+    const newerLoad = useBuildSessionStore
+      .getState()
+      .loadSession(SESSION_ID, { force: true });
+    await Promise.resolve();
+    expect(mockedApi.fetchMessages).toHaveBeenCalledTimes(2);
+
+    olderMessages.resolve([]);
+    await olderLoad;
+    newerMessages.resolve([]);
+    await newerLoad;
+
+    expect(
+      useBuildSessionStore.getState().sessions.get(SESSION_ID)?.skillsStale
+    ).toBe(true);
   });
 
   it("clears stale turn metadata when active turn lookup says no turn is running", async () => {

--- a/web/src/app/craft/hooks/loadSessionRestore.test.ts
+++ b/web/src/app/craft/hooks/loadSessionRestore.test.ts
@@ -471,7 +471,7 @@ describe("loadSession restore status", () => {
     expect(session?.activeTurnLocalOwner).toBe(false);
   });
 
-  it("preserves stale-skill state while loading a pre-provisioned turn", async () => {
+  it("retains fetched stale-skill state during a pre-provisioned turn", async () => {
     mockedApi.fetchSession.mockResolvedValue({
       ...runningSession(),
       skills_stale: true,
@@ -496,7 +496,7 @@ describe("loadSession restore status", () => {
 
     expect(
       useBuildSessionStore.getState().sessions.get(SESSION_ID)?.skillsStale
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("clears stale turn metadata when active turn lookup says no turn is running", async () => {

--- a/web/src/app/craft/hooks/loadSessionRestore.test.ts
+++ b/web/src/app/craft/hooks/loadSessionRestore.test.ts
@@ -499,6 +499,35 @@ describe("loadSession restore status", () => {
     ).toBe(true);
   });
 
+  it("rejects a load fetched before a newer stale-skill update", async () => {
+    let resolveMessages: (value: unknown[]) => void = () => {};
+    mockedApi.fetchSession.mockResolvedValue({
+      ...runningSession(),
+      skills_stale: true,
+    } as never);
+    mockedApi.fetchMessages.mockReturnValue(
+      new Promise((resolve) => {
+        resolveMessages = resolve;
+      }) as never
+    );
+
+    const load = useBuildSessionStore
+      .getState()
+      .loadSession(SESSION_ID, { force: true });
+    await Promise.resolve();
+    expect(mockedApi.fetchMessages).toHaveBeenCalled();
+
+    useBuildSessionStore
+      .getState()
+      .updateSessionData(SESSION_ID, { skillsStale: false });
+    resolveMessages([]);
+    await load;
+
+    expect(
+      useBuildSessionStore.getState().sessions.get(SESSION_ID)?.skillsStale
+    ).toBe(false);
+  });
+
   it("clears stale turn metadata when active turn lookup says no turn is running", async () => {
     mockedApi.fetchSession.mockResolvedValue(runningSession() as never);
     mockedApi.fetchActiveTurn.mockResolvedValue(null as never);

--- a/web/src/app/craft/hooks/useBuildSessionController.test.tsx
+++ b/web/src/app/craft/hooks/useBuildSessionController.test.tsx
@@ -41,7 +41,7 @@ describe("useBuildSessionController", () => {
     useBuildSessionStore.getState().setCurrentSession(SESSION_ID);
   });
 
-  it("refreshes stale skill state on mount and browser focus", async () => {
+  it("marks skills stale from reads without clearing confirmed stale state", async () => {
     jest.mocked(api.fetchSession).mockResolvedValue({
       skills_stale: true,
     } as never);
@@ -65,10 +65,12 @@ describe("useBuildSessionController", () => {
     act(() => window.dispatchEvent(new Event("focus")));
 
     await waitFor(() => {
-      expect(
-        useBuildSessionStore.getState().sessions.get(SESSION_ID)?.skillsStale
-      ).toBe(false);
+      expect(api.fetchSession).toHaveBeenCalledTimes(2);
     });
+    await act(async () => Promise.resolve());
+    expect(
+      useBuildSessionStore.getState().sessions.get(SESSION_ID)?.skillsStale
+    ).toBe(true);
   });
 
   it("does not restore stale state after an intervening reload", async () => {

--- a/web/src/app/craft/hooks/useBuildSessionController.ts
+++ b/web/src/app/craft/hooks/useBuildSessionController.ts
@@ -109,12 +109,13 @@ export function useBuildSessionController({
         const session = await fetchSession(sessionId, {
           checkWorkspace: false,
         });
+        if (!session.skills_stale) return;
         const currentSession = useBuildSessionStore
           .getState()
           .sessions.get(sessionId);
         if (currentSession?.skillsStaleRevision !== skillsStaleRevision) return;
         updateSessionData(sessionId, {
-          skillsStale: session.skills_stale,
+          skillsStale: true,
         });
       } catch {
         // Keep the usable cached session on transient refresh failures.

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -1506,6 +1506,11 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
 
     // Set as current and mark as loading
     setCurrentSession(sessionId);
+    const skillsStaleRevision =
+      get().sessions.get(sessionId)!.skillsStaleRevision;
+    const canApplySkillsStale = () =>
+      get().sessions.get(sessionId)?.skillsStaleRevision ===
+      skillsStaleRevision;
 
     try {
       // First fetch session to check sandbox status
@@ -1611,7 +1616,10 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
         sandbox,
         agentProvider: sessionData.agent_provider,
         agentModel: sessionData.agent_model,
-        skillsStale: sessionData.skills_stale,
+        ...(!needsRestore &&
+          canApplySkillsStale() && {
+            skillsStale: sessionData.skills_stale,
+          }),
         origin: sessionData.origin,
         activeTurnId: resolvedActiveTurnId,
         activeTurnIndex: resolvedActiveTurnIndex,
@@ -1647,7 +1655,9 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
           sandbox: sessionData.sandbox
             ? { ...sessionData.sandbox, status: "restoring" }
             : sessionData.sandbox,
-          skillsStale: sessionData.skills_stale,
+          ...(canApplySkillsStale() && {
+            skillsStale: sessionData.skills_stale,
+          }),
           webappNeedsRefresh:
             (get().sessions.get(sessionId)?.webappNeedsRefresh || 0) + 1,
         });

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -1616,10 +1616,8 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
         sandbox,
         agentProvider: sessionData.agent_provider,
         agentModel: sessionData.agent_model,
-        ...(!needsRestore &&
-          canApplySkillsStale() && {
-            skillsStale: sessionData.skills_stale,
-          }),
+        ...(sessionData.skills_stale &&
+          canApplySkillsStale() && { skillsStale: true }),
         origin: sessionData.origin,
         activeTurnId: resolvedActiveTurnId,
         activeTurnIndex: resolvedActiveTurnIndex,
@@ -1634,6 +1632,8 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
       });
 
       if (needsRestore) {
+        const skillsStaleRevisionBeforeRestore =
+          get().sessions.get(sessionId)?.skillsStaleRevision;
         try {
           sessionData = await restoreSession(sessionId);
         } catch (restoreErr) {
@@ -1655,7 +1655,8 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
           sandbox: sessionData.sandbox
             ? { ...sessionData.sandbox, status: "restoring" }
             : sessionData.sandbox,
-          ...(canApplySkillsStale() && {
+          ...(get().sessions.get(sessionId)?.skillsStaleRevision ===
+            skillsStaleRevisionBeforeRestore && {
             skillsStale: sessionData.skills_stale,
           }),
           webappNeedsRefresh:

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -1611,9 +1611,7 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
         sandbox,
         agentProvider: sessionData.agent_provider,
         agentModel: sessionData.agent_model,
-        // Persisted loads reconcile stale state. Optimistic welcome loads keep
-        // their live local state until the turn settles.
-        ...(useDbMessages && { skillsStale: sessionData.skills_stale }),
+        skillsStale: sessionData.skills_stale,
         origin: sessionData.origin,
         activeTurnId: resolvedActiveTurnId,
         activeTurnIndex: resolvedActiveTurnIndex,

--- a/web/src/app/craft/hooks/useBuildStreaming.test.tsx
+++ b/web/src/app/craft/hooks/useBuildStreaming.test.tsx
@@ -119,6 +119,45 @@ describe("useBuildStreaming thinking packets", () => {
     });
   });
 
+  it.each([
+    { changesDuringTurn: false, expected: false },
+    { changesDuringTurn: true, expected: true },
+  ])(
+    "reconciles stale skills after turn creation when changesDuringTurn is $changesDuringTurn",
+    async ({ changesDuringTurn, expected }) => {
+      let resolveTurn: (
+        turn: Awaited<ReturnType<typeof createTurn>>
+      ) => void = () => {};
+      jest.mocked(createTurn).mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveTurn = resolve;
+        })
+      );
+      useBuildSessionStore.getState().updateSessionData(sessionId, {
+        skillsStale: true,
+      });
+      const { result } = renderHook(() => useBuildStreaming());
+
+      const stream = result.current.streamMessage(sessionId, "build the app");
+      if (changesDuringTurn) {
+        useBuildSessionStore.getState().updateSessionData(sessionId, {
+          skillsStale: true,
+        });
+      }
+      resolveTurn({
+        session_id: sessionId,
+        turn_id: "turn-thinking",
+        status: "QUEUED",
+        turn_index: 0,
+      });
+      await act(async () => stream);
+
+      expect(
+        useBuildSessionStore.getState().sessions.get(sessionId)?.skillsStale
+      ).toBe(expected);
+    }
+  );
+
   it("does not reset the abort controller when a newer turn took ownership mid-stream", async () => {
     const newerController = new AbortController();
     jest.mocked(processSSEStream).mockImplementationOnce(async () => {

--- a/web/src/app/craft/hooks/useBuildStreaming.ts
+++ b/web/src/app/craft/hooks/useBuildStreaming.ts
@@ -957,6 +957,7 @@ export function useBuildStreaming() {
     ): Promise<void> => {
       const currentState = useBuildSessionStore.getState();
       const existingSession = currentState.sessions.get(sessionId);
+      const skillsStaleRevision = existingSession?.skillsStaleRevision;
 
       if (existingSession?.abortController) {
         existingSession.abortController.abort();
@@ -986,10 +987,16 @@ export function useBuildStreaming() {
           model,
           attachments
         );
+        const currentSession = useBuildSessionStore
+          .getState()
+          .sessions.get(sessionId);
         updateSessionData(sessionId, {
           activeTurnId: turn.turn_id,
           activeTurnIndex: turn.turn_index,
           activeTurnLocalOwner: true,
+          ...(currentSession?.skillsStaleRevision === skillsStaleRevision && {
+            skillsStale: false,
+          }),
         });
 
         await streamTurnEvents(sessionId, turn.turn_id, controller.signal);


### PR DESCRIPTION
## Description

Follow-up to #13842.

Keep the backend stale-skills value during optimistic turn loads.
Hide the stale-skills notice while a turn is active.
Show the retained notice if turn creation fails.
Successful turns clear the value during settlement.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale skills handling with ordered reconciliation across loads, restores, and turn starts. Keeps confirmed stale state during background reads, hides the notice during turns, and clears or restores the flag only when safe.

- **Bug Fixes**
  - Gate updates with a `skillsStaleRevision` to ignore older or overlapping loads, restores, and turn creation results.
  - Hide the stale skills notice during active turns; show it again after the turn stops.
  - Background reads only set `skillsStale: true`; never clear it. Clear at turn start if unchanged, or after restore when the server reports not stale.

<sup>Written for commit 0685ad4e3ddf04768e1ed9d8d962c8e140fb05af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

