### PR TITLE
fix(admin): prevent date range picker pills from clipping in narrow headers

### DIFF
--- a/web/src/components/dateRangeSelectors/AdminDateRangeSelector.tsx
+++ b/web/src/components/dateRangeSelectors/AdminDateRangeSelector.tsx
@@ -88,7 +88,7 @@ export const AdminDateRangeSelector = memo(function AdminDateRangeSelector({
 
   return (
     <div
-      className="inline-flex max-w-full items-center overflow-x-auto rounded-12 border border-border-02 bg-background-tint-03 p-0.5"
+      className="inline-flex max-w-full shrink-0 items-center overflow-x-auto rounded-12 border border-border-02 bg-background-tint-03 p-0.5"
       role="group"
       aria-label="Date range"
       data-testid="admin-date-range-selector"


### PR DESCRIPTION
## Description

Fixes the admin date range picker clipping its "Custom" option in narrow headers (e.g. the Usage Statistics page header). The picker's wrapper had no `flex-shrink-0`, and its `overflow-x-auto` reset its automatic flex minimum size to 0 — so a greedy sibling (the panel title, `width="full"`) could squeeze the picker below its content width. Since the individual pill buttons are `overflow-clip` with no ellipsis, the last pill got hard-clipped mid-word instead of the title text wrapping to make room.

Added `shrink-0` to the picker's wrapper (`AdminDateRangeSelector.tsx`) so it keeps its natural content width and the title text wraps instead.

## How Has This Been Tested?

<img width="1133" height="204" alt="Screenshot 2026-08-11 at 10 44 12" src="https://github.com/user-attachments/assets/4685eeae-56ba-4c3e-b6a6-60d366f6589c" />


- Reproduced the clipping bug live at `/ee/admin/performance/usage` by constraining the header row's width and removing `shrink-0` via devtools, confirming the "Custom" pill clipped exactly as reported.
- Re-applied `shrink-0` and confirmed all five pills ("1D", "7D", "1M", "3M", "Custom") render fully, with the title/description wrapping to a second line instead.
- Verified with `tsc --noEmit`, `oxlint`, and `pre-commit run --all-files` (TypeScript type check, oxfmt, oxlint all passed on commit).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the admin date range picker pills from clipping in narrow headers by adding shrink-0 to the picker wrapper. The picker now keeps its natural width and the header title/description wraps instead, fixing the cut-off "Custom" pill on Usage Statistics.

<sup>Written for commit c23e25ccdac11302152379eb5ed65fb9affc68f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

