### PR TITLE
chore(web): remove dead usageReport swr key

### DIFF
--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -175,9 +175,6 @@ export const SWR_KEYS = {
   userGroupTokenRateLimit: (groupId: number) =>
     `/api/admin/token-rate-limits/user-group/${groupId}`,
 
-  // ── Usage Reports ─────────────────────────────────────────────────────────
-  usageReport: "/api/admin/usage-report",
-
   // ── Web Search ────────────────────────────────────────────────────────────
   webSearchContentProviders: "/api/admin/web-search/content-providers",
   webSearchSearchProviders: "/api/admin/web-search/search-providers",


### PR DESCRIPTION
## Description

Removes the unused `usageReport` SWR key from `web/src/lib/swr-keys.ts`. No code referenced this key.

## How Has This Been Tested?

N/A — dead code removal, no behavior change.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `usageReport` SWR key from `web/src/lib/swr-keys.ts` to clean up dead code. No behavior change.

<sup>Written for commit f69e1229ccd35923a4a379084e84d2049bf70289. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

