### PR TITLE
fix: preserve HTML table and link boundaries

### DIFF
--- a/backend/onyx/file_processing/html_utils.py
+++ b/backend/onyx/file_processing/html_utils.py
@@ -18,6 +18,9 @@ from onyx.utils.logger import setup_logger
 logger = setup_logger()
 
 MINTLIFY_UNWANTED = ["sticky", "hidden"]
+_ANCHOR_ELEMENT = "a"
+_HREF_ATTRIBUTE = "href"
+_TABLE_ELEMENT = "table"
 
 
 @dataclass
@@ -54,6 +57,20 @@ def format_element_text(element_text: str, link_href: str | None) -> str:
     return f"[{element_text_no_newlines}]({link_href})"
 
 
+def _get_ancestor_link_href(
+    element: bs4.element.PageElement, in_table: bool
+) -> str | None:
+    if in_table:
+        return None
+
+    link = element.find_parent(_ANCHOR_ELEMENT)
+    if not link:
+        return None
+
+    href = link.get(_HREF_ATTRIBUTE)
+    return href[0] if isinstance(href, list) else href
+
+
 def parse_html_with_trafilatura(html_content: str) -> str:
     """Parse HTML content using trafilatura."""
     import trafilatura
@@ -84,15 +101,14 @@ def format_document_soup(
     text = ""
     list_element_start = False
     verbatim_output = 0
-    in_table = False
     last_added_newline = False
-    link_href: str | None = None
 
     for e in document.descendants:
         verbatim_output -= 1
         if isinstance(e, bs4.element.NavigableString):
             if isinstance(e, (bs4.element.Comment, bs4.element.Doctype)):
                 continue
+            in_table = e.find_parent(_TABLE_ELEMENT) is not None
             element_text = e.text
             if in_table:
                 # Tables are represented in natural language with rows separated by newlines
@@ -110,7 +126,9 @@ def format_document_soup(
                 content_to_add = (
                     element_text
                     if verbatim_output > 0
-                    else format_element_text(element_text, link_href)
+                    else format_element_text(
+                        element_text, _get_ancestor_link_href(e, in_table)
+                    )
                 )
 
                 # Don't join separate elements without any spacing
@@ -123,28 +141,16 @@ def format_document_soup(
 
                 list_element_start = False
         elif isinstance(e, bs4.element.Tag):
-            # table is standard HTML element
-            if e.name == "table":
-                in_table = True
+            in_table = e.find_parent(_TABLE_ELEMENT) is not None
             # tr is for rows
-            elif e.name == "tr" and in_table:
+            if e.name == "tr" and in_table:
                 text += "\n"
             # td for data cell, th for header
             elif e.name in ["td", "th"] and in_table:
                 text += table_cell_separator
-            elif e.name == "/table":
-                in_table = False
             elif in_table:
                 # don't handle other cases while in table
                 pass
-            elif e.name == "a":
-                href_value = e.get("href", None)
-                # mostly for typing, having multiple hrefs is not valid HTML
-                link_href = (
-                    href_value[0] if isinstance(href_value, list) else href_value
-                )
-            elif e.name == "/a":
-                link_href = None
             elif e.name in ["p", "div"]:
                 if not list_element_start:
                     text += "\n"

--- a/backend/tests/daily/connectors/confluence/test_confluence_html_parser.py
+++ b/backend/tests/daily/connectors/confluence/test_confluence_html_parser.py
@@ -1,0 +1,83 @@
+import os
+import time
+from unittest.mock import patch
+
+import pytest
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.confluence.connector import ConfluenceConnector
+from onyx.connectors.credentials_provider import OnyxStaticCredentialsProvider
+from onyx.connectors.models import Document
+from onyx.file_processing.enums import HtmlBasedConnectorTransformLinksStrategy
+from tests.daily.connectors.utils import load_all_from_connector
+from tests.utils.secret_names import TestSecret
+
+_PARSER_REGRESSION_SPACE = "ParserReg"
+_LINK_PAGE_TITLE = "HTML Parser Regression - Link Scope"
+_TABLE_PAGE_TITLE = "HTML Parser Regression - Table Scope"
+_LINK_TARGET = "https://example.com/parser-regression-target"
+
+pytestmark = pytest.mark.secrets(TestSecret.CONFLUENCE_ACCESS_TOKEN)
+
+
+def _make_connector(access_token: str) -> ConfluenceConnector:
+    connector = ConfluenceConnector(
+        wiki_base=os.environ["CONFLUENCE_TEST_SPACE_URL"],
+        space=_PARSER_REGRESSION_SPACE,
+        is_cloud=True,
+    )
+    connector.set_credentials_provider(
+        OnyxStaticCredentialsProvider(
+            None,
+            DocumentSource.CONFLUENCE,
+            {
+                "confluence_username": os.environ["CONFLUENCE_USER_NAME"],
+                "confluence_access_token": access_token,
+            },
+        )
+    )
+    return connector
+
+
+@pytest.fixture(scope="module")
+def parser_regression_documents(
+    test_secrets: dict[TestSecret, str],
+) -> dict[str, Document]:
+    connector = _make_connector(
+        test_secrets[TestSecret.CONFLUENCE_ACCESS_TOKEN].strip()
+    )
+    with patch(
+        "onyx.file_processing.html_utils.HTML_BASED_CONNECTOR_TRANSFORM_LINKS_STRATEGY",
+        HtmlBasedConnectorTransformLinksStrategy.MARKDOWN,
+    ):
+        result = load_all_from_connector(connector, 0, time.time())
+
+    return {document.semantic_identifier: document for document in result.documents}
+
+
+def test_confluence_html_link_scope(
+    parser_regression_documents: dict[str, Document],
+) -> None:
+    document = parser_regression_documents[_LINK_PAGE_TITLE]
+
+    assert document.sections[0].text == (
+        f"LINK_BEFORE [LINK_TARGET_ONLY]({_LINK_TARGET}) "
+        "LINK_AFTER_MUST_NOT_BE_CLICKABLE\n"
+        "LINK_NEXT_PARAGRAPH_MUST_NOT_BE_CLICKABLE"
+    )
+
+
+def test_confluence_html_table_scope(
+    parser_regression_documents: dict[str, Document],
+) -> None:
+    document = parser_regression_documents[_TABLE_PAGE_TITLE]
+
+    assert document.sections[0].text == (
+        "TABLE_BEFORE\n"
+        "\tHEADER_ALPHA\tHEADER_BETA\n"
+        "\tCELL_ALPHA\tCELL_BETA_LINE_1 CELL_BETA_LINE_2\n"
+        "TABLE_AFTER_HEADING\n"
+        "TABLE_AFTER_PARAGRAPH_MUST_BE_SEPARATE\n"
+        "- TABLE_AFTER_LIST_ONE\n"
+        "- TABLE_AFTER_LIST_TWO"
+    )

--- a/backend/tests/unit/onyx/connectors/cross_connector_utils/test_html_utils.py
+++ b/backend/tests/unit/onyx/connectors/cross_connector_utils/test_html_utils.py
@@ -1,5 +1,9 @@
 import pathlib
 
+import pytest
+
+import onyx.file_processing.html_utils as html_utils
+from onyx.file_processing.enums import HtmlBasedConnectorTransformLinksStrategy
 from onyx.file_processing.html_utils import parse_html_page_basic
 
 
@@ -11,3 +15,35 @@ def test_parse_table() -> None:
     parsed = parse_html_page_basic(content)
     expected = "\n\thello\tthere\tgeneral\n\tkenobi\ta\tb\n\tc\td\te"
     assert expected in parsed
+
+
+def test_content_after_table_uses_normal_block_formatting() -> None:
+    html = (
+        "<p>before</p>"
+        "<table><tr><td>cell</td></tr></table>"
+        "<h2>after heading</h2>"
+        "<p>after paragraph</p>"
+        "<ul><li>one</li><li>two</li></ul>"
+    )
+
+    assert parse_html_page_basic(html) == (
+        "before\n\tcell\nafter heading\nafter paragraph\n- one\n- two"
+    )
+
+
+def test_markdown_link_ends_at_anchor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        html_utils,
+        "HTML_BASED_CONNECTOR_TRANSFORM_LINKS_STRATEGY",
+        HtmlBasedConnectorTransformLinksStrategy.MARKDOWN,
+    )
+    html = (
+        '<p>See <a href="https://example.com">this link</a> now.</p>'
+        "<p>Next paragraph.</p>"
+    )
+
+    assert parse_html_page_basic(html) == (
+        "See [this link](https://example.com) now.\nNext paragraph."
+    )


### PR DESCRIPTION
## Description

Fix HTML parsing so table formatting ends after each table and Markdown links end after each anchor. The parser now derives scope from Beautiful Soup ancestry and includes unit and live Confluence regression coverage.

## How Has This Been Tested?

- `uv run pytest -q backend/tests/unit/onyx/connectors/cross_connector_utils/test_html_utils.py`
- `uv run pytest -q backend/tests/unit/onyx/connectors/confluence`
- `uv run --env-file ../.vscode/.env pytest -q tests/daily/connectors/confluence/test_confluence_html_parser.py`
- `uv run pre-commit run --files backend/onyx/file_processing/html_utils.py backend/tests/unit/onyx/connectors/cross_connector_utils/test_html_utils.py backend/tests/daily/connectors/confluence/test_confluence_html_parser.py`

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix HTML parsing to stop Markdown links at the anchor and keep table formatting scoped to each table. This prevents link bleed and table formatting from affecting following content; covered by unit and Confluence regression tests.

- **Bug Fixes**
  - Get link href from the nearest `<a>` ancestor and ignore links inside tables.
  - Detect table scope via ancestor `<table>`; add newlines for rows and tabs for cells.
  - Remove global link/table state to prevent cross-element bleed.
  - Respect `HtmlBasedConnectorTransformLinksStrategy.MARKDOWN` when emitting Markdown links.

<sup>Written for commit d4d81bb84712189c7ba72a335756ade67584ae81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

