### PR TITLE
feat(chat): incognito chat sessions with content-free records

### DIFF
--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -50,6 +50,18 @@ beat_task_templates: list[dict] = [
         },
     },
     {
+        "name": "check-for-incognito-file-cleanup",
+        "task": OnyxCeleryTask.CHECK_FOR_INCOGNITO_FILE_CLEANUP,
+        "schedule": timedelta(minutes=10),
+        "options": {
+            "priority": OnyxCeleryPriority.LOW,
+            "expires": BEAT_EXPIRES_DEFAULT,
+            # Run on gated tenants too, their registries hold blob handles.
+            "skip_gated": False,
+            "work_gated": True,
+        },
+    },
+    {
         "name": "check-for-user-file-project-sync",
         "task": OnyxCeleryTask.CHECK_FOR_USER_FILE_PROJECT_SYNC,
         "schedule": timedelta(seconds=20),

--- a/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
@@ -16,6 +16,10 @@ from onyx.background.celery.celery_redis import (
 )
 from onyx.background.celery.celery_utils import httpx_init_vespa_pool
 from onyx.background.celery.tasks.shared.RetryDocumentIndex import RetryDocumentIndex
+from onyx.cache.factory import get_cache_backend
+from onyx.chat.chat_processing_checker import is_chat_session_processing
+from onyx.chat.incognito import delete_incognito_generated_files
+from onyx.chat.incognito_context import incognito_session_ended
 from onyx.configs.app_configs import (
     DISABLE_VECTOR_DB,
     MANAGED_VESPA,
@@ -29,6 +33,7 @@ from onyx.configs.constants import (
     CELERY_USER_FILE_PROCESSING_TASK_EXPIRES,
     CELERY_USER_FILE_PROJECT_SYNC_LOCK_TIMEOUT,
     CELERY_USER_FILE_PROJECT_SYNC_TASK_EXPIRES,
+    INCOGNITO_FILE_CLEANUP_BATCH,
     USER_FILE_DELETE_MAX_QUEUE_DEPTH,
     USER_FILE_PROCESSING_MAX_QUEUE_DEPTH,
     USER_FILE_PROJECT_SYNC_MAX_QUEUE_DEPTH,
@@ -42,6 +47,7 @@ from onyx.connectors.file.connector import LocalFileConnector
 from onyx.connectors.models import Document, HierarchyNode
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import UserFileStatus
+from onyx.db.file_record import get_session_ids_with_incognito_files
 from onyx.db.models import SearchSettings, UserFile
 from onyx.db.port_attempt import port_backfill_has_pending_work
 from onyx.db.port_orphan_candidate import record_port_orphan_candidates_for_user_file
@@ -1196,3 +1202,47 @@ def process_single_user_file_project_sync(
     project_sync_user_file_impl(
         user_file_id=user_file_id, tenant_id=tenant_id, redis_locking=True
     )
+
+
+@shared_task(  # ty: ignore[invalid-argument-type]
+    name=OnyxCeleryTask.CHECK_FOR_INCOGNITO_FILE_CLEANUP,
+    soft_time_limit=300,
+    bind=True,
+    ignore_result=True,
+)
+def check_for_incognito_file_cleanup(self: Task, *, tenant_id: str) -> None:  # noqa: ARG001
+    """Retry deletion of tool-generated blobs whose teardown pass failed.
+
+    A blob's own record carries the session that produced it, and deleting the
+    blob deletes the record, so anything still stamped is what a store failure
+    left behind."""
+    redis_client = get_redis_client(tenant_id=tenant_id)
+    lock: RedisLock = redis_client.lock(
+        OnyxRedisLocks.INCOGNITO_FILE_CLEANUP_BEAT_LOCK,
+        timeout=CELERY_GENERIC_BEAT_LOCK_TIMEOUT,
+    )
+    if not lock.acquire(blocking=False):
+        return
+    try:
+        with get_session_with_current_tenant() as db_session:
+            cache = get_cache_backend()
+            for raw_id in get_session_ids_with_incognito_files(
+                db_session, limit=INCOGNITO_FILE_CLEANUP_BATCH
+            ):
+                session_id = UUID(raw_id)
+                # A turn in flight owns its files, and an evicted context reads
+                # as ended, so the processing fence decides, not the context.
+                if is_chat_session_processing(session_id, cache):
+                    continue
+                if not incognito_session_ended(session_id):
+                    continue
+                try:
+                    delete_incognito_generated_files(session_id, db_session)
+                except Exception:
+                    # One unreachable blob must not strand every session behind it.
+                    task_logger.exception(
+                        "Incognito file cleanup failed for session %s", session_id
+                    )
+    finally:
+        if lock.owned():
+            lock.release()

--- a/backend/onyx/chat/chat_state.py
+++ b/backend/onyx/chat/chat_state.py
@@ -15,8 +15,9 @@ from onyx.chat.models import (
     SearchParams,
 )
 from onyx.context.search.models import SearchDoc
+from onyx.db.enums import IncognitoRecordMode
 from onyx.db.memory import UserMemoryContext
-from onyx.db.models import ChatMessage, ChatSession, Persona
+from onyx.db.models import ChatMessage, Persona
 from onyx.llm.interfaces import LLM, LLMUserIdentity
 from onyx.llm.models import ReasoningEffort
 from onyx.onyxbot.slack.models import SlackContext
@@ -183,18 +184,24 @@ class ChatTurnSetup:
     """Immutable context produced by ``build_chat_turn`` and consumed by ``_run_models``.
 
     **Detached-safety contract:** instances of this class travel outside the DB
-    session that built them. Every ORM object reachable from this dataclass
-    (``chat_session``, ``persona``, ``user_message``, ``reserved_messages``,
-    ``llms``) is detached after ``build_chat_turn`` returns. Downstream code
-    must only read column attributes that were eager-loaded during setup —
-    do NOT access lazy-loaded relationships (e.g. ``setup.chat_session.messages``,
-    ``setup.persona.tools[i].some_lazy_field``) or SQLAlchemy will raise
-    ``DetachedInstanceError`` at runtime."""
+    session that built them. The ORM objects still reachable from this dataclass
+    (``persona``, ``reserved_messages``) are detached after ``build_chat_turn``
+    returns. Downstream code must only read column attributes that were
+    eager-loaded during setup. Do NOT access lazy-loaded relationships
+    (e.g. ``setup.persona.tools[i].some_lazy_field``) or SQLAlchemy will raise
+    ``DetachedInstanceError`` at runtime. Closures stored here count: bind the
+    ids they need, never the rows.
+
+    Session and user-message identity are carried as plain scalars: the turn
+    needs only their ids and the session's project id."""
 
     new_msg_req: SendMessageRequest
-    chat_session: ChatSession
+    chat_session_id: UUID
+    chat_session_project_id: int | None
+    # The session's pinned recording policy. None is an ordinary chat.
+    incognito_record_mode: IncognitoRecordMode | None
     persona: Persona
-    user_message: ChatMessage
+    user_message_id: int
     user_identity: LLMUserIdentity
     llms: list[LLM]  # length 1 for single-model, N for multi-model
     model_display_names: list[str]  # parallel to llms

--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -8,6 +8,8 @@ from fastapi.datastructures import Headers
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from onyx.chat.incognito import resolve_incognito_record_mode
+from onyx.chat.incognito_context import incognito_context_available
 from onyx.chat.models import (
     ChatHistoryResult,
     ChatLoadedFile,
@@ -28,7 +30,7 @@ from onyx.db.chat import (
     get_chat_messages_by_session,
     get_or_create_root_message,
 )
-from onyx.db.enums import UserFileStatus
+from onyx.db.enums import IncognitoRecordMode, UserFileStatus
 from onyx.db.file_record import FileRecordNotFoundError
 from onyx.db.kg_config import (
     get_kg_config_settings,
@@ -39,6 +41,8 @@ from onyx.db.models import SearchDoc as DbSearchDoc
 from onyx.db.persona import user_can_access_persona
 from onyx.db.projects import check_project_ownership
 from onyx.db.user_file import get_user_file_by_id
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.file_processing.extract_file_text import extract_file_text
 from onyx.file_store.file_store import get_default_file_store
 from onyx.file_store.models import ChatFileType, FileDescriptor
@@ -185,12 +189,25 @@ def create_chat_session_from_request(
         ):
             raise ValueError("User does not have access to persona")
 
+    # Pinned at creation. A deployment without the Redis cache backend cannot
+    # hold incognito context, so the request is refused rather than downgraded
+    # into a chat the user believes is incognito.
+    incognito_mode: IncognitoRecordMode | None = None
+    if chat_session_request.incognito:
+        if not incognito_context_available():
+            raise OnyxError(
+                OnyxErrorCode.DEPLOYMENT_UNSUPPORTED,
+                "Incognito chat is not supported on this deployment.",
+            )
+        incognito_mode = resolve_incognito_record_mode()
+
     return create_chat_session(
         db_session=db_session,
         description=chat_session_request.description or "",
         user_id=user.id,
         persona_id=chat_session_request.persona_id,
         project_id=chat_session_request.project_id,
+        incognito_record_mode=incognito_mode,
     )
 
 

--- a/backend/onyx/chat/incognito.py
+++ b/backend/onyx/chat/incognito.py
@@ -1,0 +1,75 @@
+"""Recording policy for incognito chat turns.
+
+An incognito chat is an ordinary chat carrying a mode. ``IncognitoRecordMode``
+is the only policy object: behavior is exposed as derived properties on it, so
+the legal states are the only representable ones and no caller can assemble an
+illegal combination out of loose booleans.
+
+The contract that enforcement points must honor: an incognito session must pin
+its mode on a metadata-only ``chat_session`` row at creation, and downstream
+code must read the pinned value, never the live admin setting, so a setting
+change cannot alter a session under way. Only FULL_HISTORY may write
+conversation content into ``chat_message`` rows. USAGE_ONLY writes
+content-free rows and must carry the live conversation outside Postgres
+for the length of the session.
+"""
+
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import IncognitoRecordMode, record_mode_persists_content
+from onyx.db.file_record import get_incognito_file_ids
+from onyx.file_store.file_store import get_default_file_store
+from onyx.file_store.models import FileDescriptor
+from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_incognito_record_mode
+
+logger = setup_logger()
+
+
+def current_turn_persists_content() -> bool:
+    mode = IncognitoRecordMode.from_context_value(get_current_incognito_record_mode())
+    return record_mode_persists_content(mode)
+
+
+def resolve_incognito_record_mode() -> IncognitoRecordMode:
+    """The mode a new incognito session must pin.
+
+    The seam a workspace's record-mode setting must resolve through. Today it
+    returns the default unconditionally.
+    """
+    return IncognitoRecordMode.USAGE_ONLY
+
+
+def content_free_file_descriptors(
+    file_descriptors: list[FileDescriptor],
+) -> list[FileDescriptor]:
+    """Descriptors safe to persist for a content-free turn. Linkage ids and
+    type survive for the file-reader tool and teardown. The content-derived
+    filename does not."""
+    return [
+        FileDescriptor(
+            id=fd["id"], type=fd["type"], user_file_id=fd.get("user_file_id")
+        )
+        for fd in file_descriptors
+    ]
+
+
+def delete_incognito_generated_files(
+    chat_session_id: UUID, db_session: Session
+) -> bool:
+    """Delete the blobs the session's tools saved. True when none remain.
+
+    The file record carries the session stamp, so deleting the blob deletes the
+    handle with it. A blob the store refuses keeps both, which is what the
+    cleanup sweep retries from."""
+    file_store = get_default_file_store()
+    outstanding = False
+    for file_id in get_incognito_file_ids(str(chat_session_id), db_session):
+        try:
+            file_store.delete_file(file_id, error_on_missing=False)
+        except Exception:
+            logger.warning("Failed to delete incognito generated file %s", file_id)
+            outstanding = True
+    return not outstanding

--- a/backend/onyx/chat/incognito_context.py
+++ b/backend/onyx/chat/incognito_context.py
@@ -1,0 +1,201 @@
+"""Ephemeral conversation context for incognito chat turns.
+
+USAGE_ONLY must carry the live conversation outside Postgres, so it lives in
+Redis: one value per session, a sliding TTL that starts over on every save,
+and explicit teardown when the chat closes. Keys are tenant-prefixed by the
+Redis client. Redis may evict or expire the value mid-session: an expired
+value loads as empty and the turn continues without earlier context.
+
+Concurrent turns on one session are possible (the chat processing fence is a
+status marker, not admission control), so save is a compare-and-set on a
+version. A lost save means a concurrent writer won or the session ended, and
+the caller must not retry with the history it loaded.
+"""
+
+from uuid import UUID
+
+from pydantic import BaseModel, TypeAdapter, ValidationError
+
+from onyx.cache.interface import CacheBackendType
+from onyx.chat.models import ChatMessageSimple
+from onyx.chat.stream_buffer import stream_buffer_key_pattern
+from onyx.configs import app_configs
+from onyx.redis.redis_pool import get_redis_client
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Sliding: restarted on every save, so context survives while the page stays
+# active and dies within the hour once it goes idle or closes uncleanly.
+INCOGNITO_CONTEXT_TTL_SECONDS = 3600
+# Long enough that an in-flight turn cannot resurrect a torn-down context.
+_TOMBSTONE_TTL_SECONDS = INCOGNITO_CONTEXT_TTL_SECONDS
+# Raw-storage caps. Token budgeting trims context further at prompt build.
+# These only bound what one session may hold in Redis.
+_MAX_CONTEXT_MESSAGES = 200
+_MAX_CONTEXT_BYTES = 1_000_000
+# 15 digits stay exact in a Lua double, and turn counts never approach it.
+_MAX_VERSION_DIGITS = 15
+
+_KEY_PREFIX = "incognito_ctx"
+
+_MESSAGES_ADAPTER: TypeAdapter[list[ChatMessageSimple]] = TypeAdapter(
+    list[ChatMessageSimple]
+)
+
+# Stored value grammar: ``<version>:<messages json>``. Lua and Python agree
+# only on the digits-before-colon prefix, mirrored by _parse_version_prefix.
+# Non-matching values read as version 0. Applies when stored version == ARGV[1].
+_TOMBSTONE = b"tombstone"
+_CAS_SCRIPT = """
+local cur = redis.call('GET', KEYS[1])
+if cur == 'tombstone' then
+  return 0
+end
+local cur_version = 0
+if cur then
+  local v = string.match(cur, '^(%d+):')
+  if v ~= nil and #v <= 15 then
+    cur_version = tonumber(v)
+  end
+end
+if cur_version ~= tonumber(ARGV[1]) then
+  return 0
+end
+redis.call('SET', KEYS[1], ARGV[2], 'EX', tonumber(ARGV[3]))
+return 1
+"""
+
+
+class IncognitoContext(BaseModel):
+    """A session's history plus the version that makes save a compare-and-set."""
+
+    version: int
+    messages: list[ChatMessageSimple]
+
+
+def incognito_context_available() -> bool:
+    """Whether this deployment can hold incognito context at all.
+
+    USAGE_ONLY content must never reach Postgres, so the Postgres cache
+    backend (Lite) means the feature is absent rather than degraded.
+    """
+    return app_configs.CACHE_BACKEND == CacheBackendType.REDIS
+
+
+def _context_key(chat_session_id: UUID) -> str:
+    return f"{_KEY_PREFIX}:{chat_session_id}"
+
+
+def _parse_version_prefix(raw: bytes) -> tuple[int, bytes | None]:
+    """The value's version and JSON body, or (0, None) for a tombstone or a
+    value this store did not write.
+
+    Byte-for-byte the same rule as the CAS script: ASCII digits, at most
+    ``_MAX_VERSION_DIGITS`` of them, immediately followed by a colon.
+    """
+    prefix, sep, body = raw.partition(b":")
+    if sep and prefix.isdigit() and len(prefix) <= _MAX_VERSION_DIGITS:
+        return int(prefix), body
+    return 0, None
+
+
+def load_incognito_context(chat_session_id: UUID) -> IncognitoContext:
+    """The session's context, messages oldest first.
+
+    Empty messages mean nothing was written, the session was torn down, the
+    value expired, or its body failed to parse. The turn proceeds with whatever
+    loads: missing context is degraded recall, never an error.
+    """
+    raw = get_redis_client().get(_context_key(chat_session_id))
+    if raw is None:
+        return IncognitoContext(version=0, messages=[])
+
+    version, body = _parse_version_prefix(raw)
+    if body is None:
+        logger.warning(
+            "Dropping unreadable incognito context for session %s", chat_session_id
+        )
+        return IncognitoContext(version=0, messages=[])
+    try:
+        messages = _MESSAGES_ADAPTER.validate_json(body)
+    except ValidationError:
+        # Corrupt context must end the session cleanly, not fail the turn.
+        # Keeping the prefix version lets the next save overwrite the value.
+        logger.warning(
+            "Dropping unparseable incognito context for session %s", chat_session_id
+        )
+        return IncognitoContext(version=version, messages=[])
+    return IncognitoContext(version=version, messages=messages)
+
+
+def save_incognito_context(chat_session_id: UUID, context: IncognitoContext) -> bool:
+    """Write the full history, bump the version, restart the idle clock.
+
+    Applies only while the stored version still equals ``context.version``
+    and the session has not been torn down. False means the write was
+    discarded.
+
+    Images are stripped: file bytes do not round-trip JSON, and incognito
+    attachments only live within their own turn. Oldest messages fall off
+    past the count and byte caps.
+    """
+    trimmed = [
+        message.model_copy(update={"image_files": None, "image_token_count": 0})
+        for message in context.messages[-_MAX_CONTEXT_MESSAGES:]
+    ]
+    body = _MESSAGES_ADAPTER.dump_json(trimmed)
+    while len(body) > _MAX_CONTEXT_BYTES and len(trimmed) > 1:
+        trimmed = trimmed[1:]
+        body = _MESSAGES_ADAPTER.dump_json(trimmed)
+    payload = f"{context.version + 1}:".encode() + body
+
+    client = get_redis_client()
+    result = client.eval(
+        _CAS_SCRIPT,
+        keys=[_context_key(chat_session_id)],
+        args=[
+            str(context.version).encode(),
+            payload,
+            str(INCOGNITO_CONTEXT_TTL_SECONDS).encode(),
+        ],
+    )
+    return bool(result)
+
+
+def append_incognito_message(chat_session_id: UUID, message: ChatMessageSimple) -> None:
+    """Append one message to the session's live context, tolerating failure.
+
+    A lost compare-and-set (a concurrent writer or an ended session) or a Redis
+    blip must degrade the stored context, never fail the turn.
+    Worst case the next turn is missing this message, which the load contract
+    treats as ordinary missing context rather than an error.
+    """
+    try:
+        context = load_incognito_context(chat_session_id)
+        context.messages.append(message)
+        if not save_incognito_context(chat_session_id, context):
+            logger.warning(
+                "Incognito context save lost the CAS for session %s", chat_session_id
+            )
+    except Exception:
+        logger.exception(
+            "Failed to persist incognito context for session %s", chat_session_id
+        )
+
+
+def incognito_session_ended(chat_session_id: UUID) -> bool:
+    """Whether the live context is gone, by teardown or by expiry."""
+    raw = get_redis_client().get(_context_key(chat_session_id))
+    return raw is None or raw == _TOMBSTONE
+
+
+def teardown_incognito_session(chat_session_id: UUID) -> None:
+    """End the session now: tombstone the context so an in-flight turn cannot
+    recreate it (a missing key reads as version zero), and delete the buffered
+    stream chunks holding the streamed answer NDJSON."""
+    client = get_redis_client()
+    client.set(_context_key(chat_session_id), _TOMBSTONE, ex=_TOMBSTONE_TTL_SECONDS)
+    buffered = list(client.scan_iter(match=stream_buffer_key_pattern(chat_session_id)))
+    if buffered:
+        client.delete(*buffered)

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -67,6 +67,7 @@ from onyx.tools.interface import Tool
 from onyx.tools.models import (
     ChatFile,
     CustomToolCallSummary,
+    CustomToolUserFileSnapshot,
     MemoryToolResponseSnapshot,
     PythonToolRichResponse,
     ToolCallInfo,
@@ -84,6 +85,7 @@ from onyx.tools.tool_runner import run_tool_calls
 from onyx.tools.utils import compute_all_tool_tokens
 from onyx.tracing.framework.create import ChatTraceMetadata, trace
 from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_incognito_record_mode
 
 logger = setup_logger()
 
@@ -1220,35 +1222,60 @@ def run_llm_loop(
                         tool_response.rich_response.generated_files or None
                     )
 
-                # Persist memory if this is a memory tool response
-                memory_snapshot: MemoryToolResponseSnapshot | None = None
-                if isinstance(tool_response.rich_response, MemoryToolResponse):
-                    persisted_memory_id: int | None = None
-                    if user_memory_context and user_memory_context.user_id:
-                        if tool_response.rich_response.index_to_replace is not None:
-                            persisted_memory_id = update_memory_at_index(
-                                user_id=user_memory_context.user_id,
-                                index=tool_response.rich_response.index_to_replace,
-                                new_text=tool_response.rich_response.memory_text,
-                            )
-                        else:
-                            persisted_memory_id = add_memory(
-                                user_id=user_memory_context.user_id,
-                                memory_text=tool_response.rich_response.memory_text,
-                            )
-                    operation: Literal["add", "update"] = (
-                        "update"
-                        if tool_response.rich_response.index_to_replace is not None
-                        else "add"
-                    )
-                    memory_snapshot = MemoryToolResponseSnapshot(
-                        memory_text=tool_response.rich_response.memory_text,
-                        operation=operation,
-                        memory_id=persisted_memory_id,
-                        index=tool_response.rich_response.index_to_replace,
+                # Custom tools save image/CSV blobs and return their ids.
+                generated_file_ids = None
+                if isinstance(
+                    tool_response.rich_response, CustomToolCallSummary
+                ) and isinstance(
+                    tool_response.rich_response.tool_result, CustomToolUserFileSnapshot
+                ):
+                    generated_file_ids = (
+                        tool_response.rich_response.tool_result.file_ids or None
                     )
 
-                if memory_snapshot:
+                # Persist memory if this is a memory tool response
+                memory_snapshot: MemoryToolResponseSnapshot | None = None
+                incognito_memory_refusal: str | None = None
+                if isinstance(tool_response.rich_response, MemoryToolResponse):
+                    # Any incognito mode refuses memory writes with an explicit
+                    # error, so neither the model nor the user sees a saved
+                    # memory that does not exist.
+                    if get_current_incognito_record_mode() is not None:
+                        incognito_memory_refusal = (
+                            "Error: memories cannot be saved from an incognito "
+                            "chat. Tell the user their request was not saved."
+                        )
+                    else:
+                        persisted_memory_id: int | None = None
+                        if user_memory_context and user_memory_context.user_id:
+                            if tool_response.rich_response.index_to_replace is not None:
+                                persisted_memory_id = update_memory_at_index(
+                                    user_id=user_memory_context.user_id,
+                                    index=tool_response.rich_response.index_to_replace,
+                                    new_text=tool_response.rich_response.memory_text,
+                                )
+                            else:
+                                persisted_memory_id = add_memory(
+                                    user_id=user_memory_context.user_id,
+                                    memory_text=tool_response.rich_response.memory_text,
+                                )
+                        operation: Literal["add", "update"] = (
+                            "update"
+                            if tool_response.rich_response.index_to_replace is not None
+                            else "add"
+                        )
+                        memory_snapshot = MemoryToolResponseSnapshot(
+                            memory_text=tool_response.rich_response.memory_text,
+                            operation=operation,
+                            memory_id=persisted_memory_id,
+                            index=tool_response.rich_response.index_to_replace,
+                        )
+
+                if incognito_memory_refusal:
+                    saved_response = incognito_memory_refusal
+                    # The next LLM cycle must see the refusal too.
+                    tool_response.llm_facing_response = incognito_memory_refusal
+                elif memory_snapshot:
                     saved_response = json.dumps(memory_snapshot.model_dump())
                 elif isinstance(tool_response.rich_response, CustomToolCallSummary):
                     saved_response = json.dumps(
@@ -1272,6 +1299,7 @@ def run_llm_loop(
                     search_docs=displayed_docs or search_docs,
                     generated_images=generated_images,
                     generated_files=generated_files,
+                    generated_file_ids=generated_file_ids,
                 )
                 # Add to state container for partial save support
                 state_container.add_tool_call(tool_call_info)

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 from onyx.chat.chat_state import ChatStateContainer
 from onyx.chat.citation_processor import DynamicCitationProcessor
 from onyx.chat.emitter import Emitter
+from onyx.chat.incognito import current_turn_persists_content
 from onyx.chat.models import ChatMessageSimple, LlmStepResult
 from onyx.chat.tool_call_args_streaming import maybe_emit_argument_delta
 from onyx.configs.app_configs import (
@@ -1155,7 +1156,7 @@ def run_llm_step_pkt_generator(
     llm_msg_history = translate_history_to_llm_format(history, llm.config)
     has_reasoned = False
 
-    if LOG_ONYX_MODEL_INTERACTIONS:
+    if LOG_ONYX_MODEL_INTERACTIONS and current_turn_persists_content():
         logger.debug(
             "Message history:\n%s",
             _format_message_history_for_logging(llm_msg_history),
@@ -1521,7 +1522,7 @@ def run_llm_step_pkt_generator(
 
     # Note: Content (AgentResponseDelta) doesn't need an explicit end packet - OverallStop handles it
     # Tool calls are handled by tool execution code and emit their own packets (e.g., SectionEnd)
-    if LOG_ONYX_MODEL_INTERACTIONS:
+    if LOG_ONYX_MODEL_INTERACTIONS and current_turn_persists_content():
         logger.debug("Accumulated reasoning: %s", accumulated_reasoning)
         logger.debug("Accumulated answer: %s", accumulated_answer)
 

--- a/backend/onyx/chat/models.py
+++ b/backend/onyx/chat/models.py
@@ -37,6 +37,9 @@ class CustomToolResponse(BaseModel):
 
 class CreateChatSessionID(BaseModel):
     chat_session_id: UUID
+    # Echoes the pinned mode so the client can verify the server honored an
+    # incognito request. A server that omits it did not.
+    incognito: bool = False
 
 
 AnswerStreamPart = (
@@ -93,6 +96,9 @@ class ChatFullResponse(BaseModel):
     # Metadata
     message_id: int
     chat_session_id: UUID | None = None
+    # Echoes the pinned mode for newly-created sessions, like the streaming
+    # packet does. A server that omits it did not honor an incognito request.
+    incognito: bool = False
     error_msg: str | None = None
 
 

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -39,6 +39,14 @@ from onyx.chat.compression import (
     get_compression_params,
 )
 from onyx.chat.emitter import Emitter
+from onyx.chat.incognito import (
+    content_free_file_descriptors,
+)
+from onyx.chat.incognito_context import (
+    append_incognito_message,
+    incognito_session_ended,
+    load_incognito_context,
+)
 from onyx.chat.llm_loop import EmptyLLMResponseError, run_llm_loop
 from onyx.chat.models import (
     AnswerStream,
@@ -78,9 +86,9 @@ from onyx.db.chat import (
 )
 from onyx.db.document_set import filter_document_set_names_by_user_access
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
-from onyx.db.enums import HookPoint
+from onyx.db.enums import HookPoint, record_mode_persists_content
 from onyx.db.memory import get_memories
-from onyx.db.models import ChatMessage, Persona, User, UserFile
+from onyx.db.models import ChatMessage, ChatSession, Persona, User, UserFile
 from onyx.db.projects import get_user_files_from_project
 from onyx.db.tools import get_tools
 from onyx.deep_research.dr_loop import run_deep_research_llm_loop
@@ -142,7 +150,11 @@ from onyx.tools.tool_constructor import (
 from onyx.utils.logger import setup_logger
 from onyx.utils.telemetry import mt_cloud_telemetry
 from onyx.utils.timing import log_function_time
-from shared_configs.contextvars import get_current_tenant_id
+from shared_configs.contextvars import (
+    CURRENT_CONTENT_FREE_SESSION_ID_CONTEXTVAR,
+    CURRENT_INCOGNITO_RECORD_MODE_CONTEXTVAR,
+    get_current_tenant_id,
+)
 
 logger = setup_logger()
 ERROR_TYPE_CANCELLED = "cancelled"
@@ -626,7 +638,10 @@ def build_chat_turn(
             user=user,
             db_session=db_session,
         )
-        yield CreateChatSessionID(chat_session_id=chat_session.id)
+        yield CreateChatSessionID(
+            chat_session_id=chat_session.id,
+            incognito=chat_session.incognito_record_mode is not None,
+        )
         chat_session = get_chat_session_by_id(
             chat_session_id=chat_session.id,
             user_id=user_id,
@@ -741,11 +756,11 @@ def build_chat_turn(
     if parent_message.message_type == MessageType.USER:
         user_message = parent_message
     else:
-        # New message — run the Query Processing hook before saving to DB.
-        # Skipped on regeneration: the message already exists and was accepted previously.
-        # Skip for empty/whitespace-only messages — no meaningful query to process,
-        # and SendMessageRequest.message has no min_length guard.
-        if message_text.strip():
+        # Runs only for new, non-blank messages: regeneration already processed
+        # this text, and SendMessageRequest.message has no min_length guard. The
+        # hook ships the query and user email out, so egress-suppressing modes skip it.
+        mode = chat_session.incognito_record_mode
+        if message_text.strip() and (mode is None or mode.fires_hooks):
             hook_result = execute_hook(
                 db_session=db_session,
                 hook_point=HookPoint.QUERY_PROCESSING,
@@ -767,13 +782,22 @@ def build_chat_turn(
         # assistant/summary rows in save_chat.py) so budget math sums a single
         # unit even after mid-session model switches.
         default_tokenizer = get_tokenizer(None, None)
+        user_token_count = len(default_tokenizer.encode(message_text))
+        # Incognito keeps the row for tracking (id, tokens, structure) but its
+        # text lives in the ephemeral store, never in Postgres. Token count is
+        # from the real text so usage and budgeting are unaffected.
+        keeps_content = record_mode_persists_content(mode)
         user_message = create_new_chat_message(
             chat_session_id=chat_session.id,
             parent_message=parent_message,
-            message=message_text,
-            token_count=len(default_tokenizer.encode(message_text)),
+            message=message_text if keeps_content else "",
+            token_count=user_token_count,
             message_type=MessageType.USER,
-            files=new_msg_req.file_descriptors,
+            files=(
+                new_msg_req.file_descriptors
+                if keeps_content
+                else content_free_file_descriptors(new_msg_req.file_descriptors)
+            ),
             db_session=db_session,
             commit=True,
         )
@@ -957,6 +981,26 @@ def build_chat_turn(
     )
     simple_chat_history = chat_history_result.simple_messages
 
+    # Incognito rows are content-free, so earlier turns come from the store and
+    # the current message's text is restored onto convert_chat_history()'s
+    # blank-row shape. Regeneration uses the store as-is, it already holds the turn.
+    incognito_mode = chat_session.incognito_record_mode
+    if not record_mode_persists_content(incognito_mode):
+        stored_messages = load_incognito_context(chat_session.id).messages
+        is_new_user_message = parent_message.message_type != MessageType.USER
+        if (
+            is_new_user_message
+            and simple_chat_history
+            and simple_chat_history[-1].message_type == MessageType.USER
+        ):
+            current_user = simple_chat_history[-1].model_copy(
+                update={"message": new_msg_req.message}
+            )
+            simple_chat_history = stored_messages + [current_user]
+            append_incognito_message(chat_session.id, current_user)
+        else:
+            simple_chat_history = stored_messages
+
     # Metadata for every text file injected into the history. After context-window
     # truncation drops older messages, the LLM loop compares surviving file_id tags
     # against this map to discover "forgotten" files and provide their metadata to
@@ -991,8 +1035,12 @@ def build_chat_turn(
     cache = get_cache_backend()
     reset_cancel_status(chat_session.id, cache)
 
+    # Bind the id, not the row: this closure is stored on ChatTurnSetup and
+    # would otherwise keep a detached ChatSession reachable for the whole turn.
+    chat_session_id = chat_session.id
+
     def check_is_connected() -> bool:
-        return check_stop_signal(chat_session.id, cache)
+        return check_stop_signal(chat_session_id, cache)
 
     set_processing_status(
         chat_session_id=chat_session.id,
@@ -1012,9 +1060,11 @@ def build_chat_turn(
 
     return ChatTurnSetup(
         new_msg_req=new_msg_req,
-        chat_session=chat_session,
+        chat_session_id=chat_session.id,
+        chat_session_project_id=chat_session.project_id,
+        incognito_record_mode=chat_session.incognito_record_mode,
         persona=persona,
-        user_message=user_message,
+        user_message_id=user_message.id,
         user_identity=user_identity,
         llms=llms,
         model_display_names=model_display_names,
@@ -1247,7 +1297,7 @@ def _run_models(
         # "processing", whatever happened to the request generator.
         try:
             set_processing_status(
-                chat_session_id=setup.chat_session.id,
+                chat_session_id=setup.chat_session_id,
                 cache=setup.cache,
                 value=False,
             )
@@ -1287,8 +1337,8 @@ def _run_models(
                     auto_detect_filters=auto_detect_search_filters,
                 ),
                 custom_tool_config=CustomToolConfig(
-                    chat_session_id=setup.chat_session.id,
-                    message_id=setup.user_message.id,
+                    chat_session_id=setup.chat_session_id,
+                    message_id=setup.user_message_id,
                     additional_headers=setup.custom_tool_additional_headers,
                     mcp_headers=setup.mcp_headers,
                 ),
@@ -1312,7 +1362,7 @@ def _run_models(
 
             # Per-thread copy: run_llm_loop mutates simple_chat_history in-place.
             if n_models == 1 and setup.new_msg_req.deep_research:
-                if setup.chat_session.project_id:
+                if setup.chat_session_project_id:
                     raise RuntimeError("Deep research is not supported for projects")
                 run_deep_research_llm_loop(
                     emitter=model_emitter,
@@ -1325,7 +1375,7 @@ def _run_models(
                     reasoning_effort=setup.reasoning_effort,
                     skip_clarification=setup.skip_clarification,
                     user_identity=setup.user_identity,
-                    chat_session_id=str(setup.chat_session.id),
+                    chat_session_id=str(setup.chat_session_id),
                     all_injected_file_metadata=setup.all_injected_file_metadata,
                 )
             else:
@@ -1342,7 +1392,7 @@ def _run_models(
                     token_counter=get_llm_token_counter(model_llm),
                     forced_tool_id=setup.forced_tool_id,
                     user_identity=setup.user_identity,
-                    chat_session_id=str(setup.chat_session.id),
+                    chat_session_id=str(setup.chat_session_id),
                     chat_files=setup.chat_files_for_tools,
                     reasoning_effort=setup.reasoning_effort,
                     include_citations=setup.new_msg_req.include_citations,
@@ -1371,18 +1421,33 @@ def _run_models(
                     ChatMessage, setup.reserved_messages[model_idx].id
                 )
                 if msg is not None:
-                    info = model_error_info[model_idx]
-                    detail = (
-                        info.message
-                        if info is not None
-                        else "model encountered an error during generation."
-                    )
-                    error_text = "Error from %s: %s" % (
-                        setup.model_display_names[model_idx],
-                        detail,
-                    )
+                    mode = setup.incognito_record_mode
+                    if not record_mode_persists_content(mode):
+                        # Provider errors can echo prompt fragments, so the
+                        # durable row gets a generic marker. The live stream
+                        # still carries the real error to the user.
+                        error_text = "The model encountered an error."
+                    else:
+                        info = model_error_info[model_idx]
+                        detail = (
+                            info.message
+                            if info is not None
+                            else "model encountered an error during generation."
+                        )
+                        error_text = "Error from %s: %s" % (
+                            setup.model_display_names[model_idx],
+                            detail,
+                        )
                     msg.message = error_text
                     msg.error = error_text
+                    # The reservation's placeholder count must not survive:
+                    # rows carry the real output count, zero when none emitted.
+                    partial_answer = state_containers[model_idx].get_answer_tokens()
+                    msg.token_count = (
+                        len(get_tokenizer(None, None).encode(partial_answer))
+                        if partial_answer
+                        else 0
+                    )
                     save_db_session.commit()
         except Exception:
             logger.exception(
@@ -1416,7 +1481,7 @@ def _run_models(
                     last_fence_refresh = now
                     try:
                         set_processing_status(
-                            chat_session_id=setup.chat_session.id,
+                            chat_session_id=setup.chat_session_id,
                             cache=setup.cache,
                             value=True,
                             run_id=setup.processing_run_id,
@@ -1554,7 +1619,7 @@ def _run_models(
                 # the writer thread keeps draining to completion in the background.
                 logger.info(
                     "chat stream reader detached; writer continues for session %s",
-                    setup.chat_session.id,
+                    setup.chat_session_id,
                 )
 
     return _read_stream()
@@ -1610,6 +1675,7 @@ def _stream_chat_turn(
         )
 
     mock_response_token: Token[str | None] | None = None
+    incognito_mode_flag_set = False
     setup: ChatTurnSetup | None = None
     pre_run_packets: list[AnswerStreamPart] = []
     run_started = False
@@ -1677,10 +1743,29 @@ def _stream_chat_turn(
         assert setup is not None, (
             "build_chat_turn must complete before _run_models is called"
         )
+        # Read at trace start, by the memory gate, and by interaction logging.
+        # Cleared with a plain set: a Token reset raises when this generator's
+        # frames resume under a different context.
+        if setup.incognito_record_mode is not None:
+            CURRENT_INCOGNITO_RECORD_MODE_CONTEXTVAR.set(
+                setup.incognito_record_mode.value
+            )
+            incognito_mode_flag_set = True
+        content_free = not record_mode_persists_content(setup.incognito_record_mode)
+        if content_free:
+            # Set for the whole turn so a blob any tool saves carries the
+            # session on its record, which is what teardown deletes by.
+            CURRENT_CONTENT_FREE_SESSION_ID_CONTEXTVAR.set(str(setup.chat_session_id))
         stream_buffer = StreamBufferWriter(
             cache=setup.cache,
-            chat_session_id=setup.chat_session.id,
+            chat_session_id=setup.chat_session_id,
             run_id=setup.processing_run_id,
+            delete_on_done=content_free,
+            session_ended=(
+                (lambda: incognito_session_ended(setup.chat_session_id))
+                if content_free
+                else None
+            ),
         )
         for pre_run_packet in pre_run_packets:
             stream_buffer.append_line(get_json_line(pre_run_packet.model_dump()))
@@ -1769,12 +1854,15 @@ def _stream_chat_turn(
     finally:
         if mock_response_token is not None:
             reset_llm_mock_response(mock_response_token)
+        if incognito_mode_flag_set:
+            CURRENT_INCOGNITO_RECORD_MODE_CONTEXTVAR.set(None)
+            CURRENT_CONTENT_FREE_SESSION_ID_CONTEXTVAR.set(None)
         try:
             # Once _run_models started, its writer thread owns the fence — the
             # run may still be in flight after this generator is closed.
             if setup is not None and not run_started:
                 set_processing_status(
-                    chat_session_id=setup.chat_session.id,
+                    chat_session_id=setup.chat_session_id,
                     cache=setup.cache,
                     value=False,
                 )
@@ -1923,6 +2011,12 @@ def llm_loop_completion_handle(
                 "ChatMessage %d not found during completion" % assistant_message_id
             )
 
+        incognito_session = db_session.get(ChatSession, chat_session_id)
+        incognito_mode = (
+            incognito_session.incognito_record_mode if incognito_session else None
+        )
+        keeps_content = record_mode_persists_content(incognito_mode)
+
         save_chat_turn(
             message_text=final_answer,
             reasoning_tokens=reasoning_tokens,
@@ -1934,7 +2028,21 @@ def llm_loop_completion_handle(
             is_clarification=is_clarification,
             emitted_citations=emitted_citations,
             pre_answer_processing_time=pre_answer_processing_time,
+            persist_content=keeps_content,
         )
+
+        # Incognito: the answer lives only in the ephemeral store, and
+        # compression is skipped since a summary is a durable content row.
+        if not keeps_content:
+            append_incognito_message(
+                chat_session_id,
+                ChatMessageSimple(
+                    message=final_answer,
+                    token_count=attached_message.token_count,
+                    message_type=MessageType.ASSISTANT,
+                ),
+            )
+            return
 
         updated_chat_history = create_chat_history_chain(
             chat_session_id=chat_session_id,
@@ -2090,6 +2198,7 @@ def gather_stream_full(
     message_id: int | None = None
     top_documents: list[SearchDoc] = []
     chat_session_id: UUID | None = None
+    incognito = False
 
     for packet in packets:
         if isinstance(packet, Packet):
@@ -2109,6 +2218,7 @@ def gather_stream_full(
             message_id = packet.reserved_assistant_message_id
         elif isinstance(packet, CreateChatSessionID):
             chat_session_id = packet.chat_session_id
+            incognito = packet.incognito
 
     if message_id is None:
         raise ValueError("Message ID is required")
@@ -2141,5 +2251,6 @@ def gather_stream_full(
         citation_info=citations,
         message_id=message_id,
         chat_session_id=chat_session_id,
+        incognito=incognito,
         error_msg=error_msg,
     )

--- a/backend/onyx/chat/save_chat.py
+++ b/backend/onyx/chat/save_chat.py
@@ -176,6 +176,7 @@ def save_chat_turn(
     is_clarification: bool = False,
     emitted_citations: set[int] | None = None,
     pre_answer_processing_time: float | None = None,
+    persist_content: bool = True,
 ) -> None:
     """
     Save a chat turn by populating the assistant_message and creating related entities.
@@ -206,10 +207,20 @@ def save_chat_turn(
     sanitized_message_text = (
         sanitize_string(message_text) if message_text else message_text
     )
-    assistant_message.message = sanitized_message_text
-    assistant_message.reasoning_tokens = (
-        sanitize_string(reasoning_tokens) if reasoning_tokens else reasoning_tokens
-    )
+    # A content-free turn keeps the row and its token count, which comes from
+    # the real answer, but none of the conversation-derived parts.
+    if persist_content:
+        assistant_message.message = sanitized_message_text
+        assistant_message.reasoning_tokens = (
+            sanitize_string(reasoning_tokens) if reasoning_tokens else reasoning_tokens
+        )
+    else:
+        assistant_message.message = ""
+        assistant_message.reasoning_tokens = None
+        tool_calls = []
+        citation_to_doc = {}
+        all_search_docs = {}
+        emitted_citations = set()
     assistant_message.is_clarification = is_clarification
 
     # Use pre-answer processing time (captured when MESSAGE_START was emitted)

--- a/backend/onyx/chat/stream_buffer.py
+++ b/backend/onyx/chat/stream_buffer.py
@@ -11,6 +11,7 @@ to the DB-rendered message rather than replaying a broken sequence.
 """
 
 import zlib
+from collections.abc import Callable
 from uuid import UUID
 
 from pydantic import BaseModel, ValidationError
@@ -55,6 +56,11 @@ def _meta_key(chat_session_id: UUID, run_id: int) -> str:
     return f"{_PREFIX}_{chat_session_id}_{run_id}:meta"
 
 
+def stream_buffer_key_pattern(chat_session_id: UUID) -> str:
+    """Glob matching every buffered chunk and meta key of the session's runs."""
+    return f"{_PREFIX}_{chat_session_id}_*"
+
+
 class StreamBufferWriter:
     """Append-only writer for one run. Errors never propagate into the stream
     path — a broken cache downgrades the run to non-resumable (truncated)."""
@@ -64,10 +70,20 @@ class StreamBufferWriter:
         cache: CacheBackend,
         chat_session_id: UUID,
         run_id: int,
+        delete_on_done: bool = False,
+        session_ended: Callable[[], bool] | None = None,
     ) -> None:
         self._cache = cache
         self._chat_session_id = chat_session_id
         self._run_id = run_id
+        # Content-free incognito runs: completion deletes the run's keys, so a
+        # flush racing the session teardown still cleans itself up. Costs
+        # post-completion resume.
+        self._delete_on_done = delete_on_done
+        # Teardown scans the session's keys once. Without this the run keeps
+        # writing answer chunks behind it, which then live out the buffer TTL
+        # if the run never reaches completion.
+        self._session_ended = session_ended
         self._meta = StreamBufferMeta()
         self._pending: list[str] = []
         self._pending_bytes = 0
@@ -87,6 +103,11 @@ class StreamBufferWriter:
 
     def flush(self) -> None:
         if not self._pending or self._meta.truncated or self._meta.done:
+            return
+        if self._session_ended is not None and self._session_ended():
+            self._pending = []
+            self._pending_bytes = 0
+            self.mark_done()
             return
         payload = zlib.compress("".join(self._pending).encode("utf-8"))
         self._pending = []
@@ -129,6 +150,23 @@ class StreamBufferWriter:
                 )
 
     def mark_done(self) -> None:
+        if self._delete_on_done:
+            if self._meta.done:
+                return
+            self._meta.done = True
+            try:
+                self._cache.delete(_meta_key(self._chat_session_id, self._run_id))
+                for chunk_n in range(self._meta.chunk_count):
+                    self._cache.delete(
+                        _chunk_key(self._chat_session_id, self._run_id, chunk_n)
+                    )
+            except Exception:
+                logger.exception(
+                    "stream buffer deletion failed for session %s run %d",
+                    self._chat_session_id,
+                    self._run_id,
+                )
+            return
         self.flush()
         if self._meta.done:
             return

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -133,6 +133,10 @@ KV_KG_CONFIG_KEY = "kg_config"
 
 # NOTE: we use this timeout / 4 in various places to refresh a lock
 # might be worth separating this timeout into separate timeouts for each situation
+# One pass of the incognito cleanup sweep. Leftovers wait for the next pass
+# rather than holding the beat lock past its timeout.
+INCOGNITO_FILE_CLEANUP_BATCH = 200
+
 CELERY_GENERIC_BEAT_LOCK_TIMEOUT = 120
 
 CELERY_VESPA_SYNC_BEAT_LOCK_TIMEOUT = 120
@@ -560,6 +564,7 @@ class OnyxRedisLocks:
     USER_FILE_PROJECT_SYNC_LOCK_PREFIX = "da_lock:user_file_project_sync"
     USER_FILE_PROJECT_SYNC_QUEUED_PREFIX = "da_lock:user_file_project_sync_queued"
     USER_FILE_DELETE_BEAT_LOCK = "da_lock:check_user_file_delete_beat"
+    INCOGNITO_FILE_CLEANUP_BEAT_LOCK = "da_lock:check_incognito_file_cleanup_beat"
     USER_FILE_DELETE_LOCK_PREFIX = "da_lock:user_file_delete"
     # Short-lived key set when a delete task is enqueued; cleared when the worker picks it up.
     # Prevents the beat from re-enqueuing the same file while a delete task is already queued.
@@ -643,6 +648,7 @@ class OnyxCeleryTask:
     PROCESS_SINGLE_USER_FILE_PROJECT_SYNC = "process_single_user_file_project_sync"
     CHECK_FOR_USER_FILE_DELETE = "check_for_user_file_delete"
     DELETE_SINGLE_USER_FILE = "delete_single_user_file"
+    CHECK_FOR_INCOGNITO_FILE_CLEANUP = "check_for_incognito_file_cleanup"
 
     # Targeted reindex
     TARGETED_REINDEX_TASK = "targeted_reindex_task"

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -12,6 +12,7 @@ from onyx.configs.chat_configs import HARD_DELETE_CHATS
 from onyx.configs.constants import MessageType
 from onyx.context.search.models import InferenceSection, SavedSearchDoc
 from onyx.context.search.models import SearchDoc as ServerSearchDoc
+from onyx.db.enums import IncognitoRecordMode
 from onyx.db.models import (
     ChatMessage,
     ChatMessage__SearchDoc,
@@ -93,6 +94,19 @@ def get_chat_sessions_by_slack_thread_id(
     return db_session.scalars(stmt).all()
 
 
+def get_incognito_session_ids_for_user(
+    user_id: UUID, db_session: Session
+) -> list[UUID]:
+    return list(
+        db_session.scalars(
+            select(ChatSession.id).where(
+                ChatSession.user_id == user_id,
+                ChatSession.incognito_record_mode.is_not(None),
+            )
+        )
+    )
+
+
 # Retrieves chat sessions by user
 # Chat sessions do not include onyxbot flows
 def get_chat_sessions_by_user(
@@ -104,6 +118,7 @@ def get_chat_sessions_by_user(
     project_id: int | None = None,
     only_non_project_chats: bool = False,
     include_failed_chats: bool = False,
+    exclude_incognito: bool = False,
 ) -> list[ChatSession]:
     stmt = (
         select(ChatSession)
@@ -111,6 +126,9 @@ def get_chat_sessions_by_user(
         .where(ChatSession.onyxbot_flow.is_(False))
         .order_by(desc(ChatSession.time_updated))
     )
+
+    if exclude_incognito:
+        stmt = stmt.where(ChatSession.incognito_record_mode.is_(None))
 
     if deleted is not None:
         stmt = stmt.where(ChatSession.deleted == deleted)
@@ -215,6 +233,7 @@ def create_chat_session(
     onyxbot_flow: bool = False,
     slack_thread_id: str | None = None,
     project_id: int | None = None,
+    incognito_record_mode: IncognitoRecordMode | None = None,
 ) -> ChatSession:
     chat_session = ChatSession(
         user_id=user_id,
@@ -225,6 +244,7 @@ def create_chat_session(
         onyxbot_flow=onyxbot_flow,
         slack_thread_id=slack_thread_id,
         project_id=project_id,
+        incognito_record_mode=incognito_record_mode,
     )
 
     db_session.add(chat_session)
@@ -250,6 +270,8 @@ def duplicate_chat_session_for_user_from_slack(
         user_id=None,  # Ignore user permissions for this
         db_session=db_session,
     )
+    if chat_session.incognito_record_mode is not None:
+        raise ValueError("Incognito chat sessions cannot be duplicated")
     if not chat_session:
         raise HTTPException(status_code=400, detail="Invalid Chat Session ID provided")
 
@@ -474,6 +496,9 @@ def add_chats_to_session_from_slack_thread(
     slack_chat_session_id: UUID,
     new_chat_session_id: UUID,
 ) -> None:
+    source_session = db_session.get(ChatSession, slack_chat_session_id)
+    if source_session and source_session.incognito_record_mode is not None:
+        raise ValueError("Incognito chat sessions cannot be duplicated")
     new_root_message = get_or_create_root_message(
         chat_session_id=new_chat_session_id,
         db_session=db_session,

--- a/backend/onyx/db/chat_search.py
+++ b/backend/onyx/db/chat_search.py
@@ -32,6 +32,7 @@ def search_chat_sessions(
         stmt = (
             select(ChatSession)
             .where(ChatSession.onyxbot_flow.is_(False))
+            .where(ChatSession.incognito_record_mode.is_(None))
             .order_by(desc(ChatSession.time_created))
             .offset(offset_val)
             .limit(page_size + 1)
@@ -53,7 +54,12 @@ def search_chat_sessions(
     # Otherwise, proceed with full-text search
     query = query.strip()
 
-    base_conditions: list[ColumnElement[bool]] = [ChatSession.onyxbot_flow.is_(False)]
+    # Applied to both arms of the union, so an incognito session cannot surface
+    # through a message body when its description does not match.
+    base_conditions: list[ColumnElement[bool]] = [
+        ChatSession.onyxbot_flow.is_(False),
+        ChatSession.incognito_record_mode.is_(None),
+    ]
     if user_id is not None:
         base_conditions.append(ChatSession.user_id == user_id)
     if not include_deleted:

--- a/backend/onyx/db/file_record.py
+++ b/backend/onyx/db/file_record.py
@@ -6,6 +6,8 @@ from onyx.background.task_utils import QUERY_REPORT_NAME_PREFIX
 from onyx.configs.constants import FileOrigin, FileType
 from onyx.db.enums import IndexingStatus
 from onyx.db.models import FileRecord, IndexAttempt
+from onyx.file_store.constants import INCOGNITO_SESSION_METADATA_KEY
+from shared_configs.contextvars import CURRENT_CONTENT_FREE_SESSION_ID_CONTEXTVAR
 
 
 def get_query_history_export_files(
@@ -190,7 +192,18 @@ def upsert_filerecord(
     file_size: int | None = None,
 ) -> FileRecord:
     """Atomic upsert using INSERT ... ON CONFLICT DO UPDATE to avoid
-    race conditions when concurrent calls target the same file_id."""
+    race conditions when concurrent calls target the same file_id.
+
+    Every backend writes its record here, so this is also where a blob saved
+    during a content-free chat turn gets stamped with its session. The stamp
+    is the only handle cleanup has, and it lands with the record itself.
+    """
+    session_id = CURRENT_CONTENT_FREE_SESSION_ID_CONTEXTVAR.get()
+    if session_id is not None:
+        file_metadata = {
+            **(file_metadata or {}),
+            INCOGNITO_SESSION_METADATA_KEY: session_id,
+        }
     stmt = insert(FileRecord).values(
         file_id=file_id,
         display_name=display_name,
@@ -216,3 +229,30 @@ def upsert_filerecord(
     db_session.execute(stmt)
 
     return db_session.get(FileRecord, file_id)  # ty: ignore[invalid-return-type]
+
+
+def get_incognito_file_ids(session_id: str, db_session: Session) -> list[str]:
+    """Ids of blobs a content-free session produced and has not deleted yet."""
+    return list(
+        db_session.scalars(
+            select(FileRecord.file_id).where(
+                FileRecord.file_metadata[INCOGNITO_SESSION_METADATA_KEY].astext
+                == session_id
+            )
+        )
+    )
+
+
+def get_session_ids_with_incognito_files(
+    db_session: Session, limit: int | None = None
+) -> list[str]:
+    """Sessions still holding blobs. Empty in steady state, since teardown
+    deletes the records, so this only sees what a store failure left."""
+    return list(
+        db_session.scalars(
+            select(FileRecord.file_metadata[INCOGNITO_SESSION_METADATA_KEY].astext)
+            .distinct()
+            .where(FileRecord.file_metadata.has_key(INCOGNITO_SESSION_METADATA_KEY))
+            .limit(limit)
+        )
+    )

--- a/backend/onyx/error_handling/error_codes.py
+++ b/backend/onyx/error_handling/error_codes.py
@@ -43,6 +43,8 @@ class OnyxErrorCode(Enum):
     EE_REQUIRED = ("EE_REQUIRED", 403)
     SINGLE_TENANT_ONLY = ("SINGLE_TENANT_ONLY", 403)
     ENV_VAR_GATED = ("ENV_VAR_GATED", 403)
+    # The deployment cannot support the feature at all, so no grant helps.
+    DEPLOYMENT_UNSUPPORTED = ("DEPLOYMENT_UNSUPPORTED", 403)
 
     # --------------------------------------------------------------------------
     # Validation / Bad Request (400)

--- a/backend/onyx/file_store/constants.py
+++ b/backend/onyx/file_store/constants.py
@@ -1,2 +1,6 @@
 MAX_IN_MEMORY_SIZE = 30 * 1024 * 1024  # 30MB
 STANDARD_CHUNK_SIZE = 10 * 1024 * 1024  # 10MB chunks
+
+# Marks a blob a content-free chat turn produced, so cleanup can find it by the
+# record itself rather than by anything that can expire.
+INCOGNITO_SESSION_METADATA_KEY = "incognito_session_id"

--- a/backend/onyx/server/features/projects/models.py
+++ b/backend/onyx/server/features/projects/models.py
@@ -95,10 +95,12 @@ class UserProjectSnapshot(BaseModel):
             created_at=model.created_at,
             user_id=model.user_id,
             instructions=model.instructions,
+            # A project lists its sessions by title, so an incognito chat would
+            # surface here the same way it would in the sidebar.
             chat_sessions=[
                 ChatSessionDetails.from_model(chat)
                 for chat in model.chat_sessions
-                if not chat.deleted
+                if not chat.deleted and chat.incognito_record_mode is None
             ],
         )
 

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -27,6 +27,8 @@ from onyx.chat.chat_utils import (
     create_chat_session_from_request,
     extract_headers,
 )
+from onyx.chat.incognito import delete_incognito_generated_files
+from onyx.chat.incognito_context import teardown_incognito_session
 from onyx.chat.models import ChatFullResponse, CreateChatSessionID
 from onyx.chat.process_message import (
     gather_stream_full,
@@ -53,6 +55,7 @@ from onyx.db.chat import (
     get_chat_messages_by_session,
     get_chat_session_by_id,
     get_chat_sessions_by_user,
+    get_incognito_session_ids_for_user,
     set_as_latest_chat_message,
     set_preferred_response,
     translate_db_message_to_chat_message_detail,
@@ -60,7 +63,7 @@ from onyx.db.chat import (
 )
 from onyx.db.chat_search import search_chat_sessions
 from onyx.db.engine.sql_engine import get_session, get_session_with_current_tenant
-from onyx.db.enums import Permission
+from onyx.db.enums import Permission, record_mode_persists_content
 from onyx.db.feedback import create_chat_message_feedback, remove_chat_message_feedback
 from onyx.db.llm import fetch_default_chat_naming_model
 from onyx.db.models import ChatMessage, ChatSessionSharedStatus, Persona, User
@@ -79,6 +82,7 @@ from onyx.llm.models import (
 )
 from onyx.llm.override_models import LLMOverride
 from onyx.secondary_llm_flows.chat_session_naming import (
+    DEFAULT_CHAT_SESSION_NAME,
     generate_chat_session_name,
     get_fallback_chat_session_name,
 )
@@ -199,6 +203,8 @@ def get_user_chat_sessions(
             project_id=project_id,
             only_non_project_chats=only_non_project_chats,
             include_failed_chats=include_failed_chats,
+            # The owner's own history is the one surface incognito hides from.
+            exclude_incognito=True,
             limit=page_size + 1,
             before=before_dt,
         )
@@ -433,6 +439,7 @@ def get_chat_session(
         # Packets are now directly serialized as Packet Pydantic models
         packets=replay_packet_lists,
         current_run=current_run,
+        incognito=chat_session.incognito_record_mode is not None,
     )
 
 
@@ -450,6 +457,9 @@ def create_new_chat_session(
             user=user,
             db_session=db_session,
         )
+    except OnyxError:
+        # Carries its own status and detail (e.g. incognito refused).
+        raise
     except ValueError as e:
         # Project or persona access denied
         raise HTTPException(status_code=403, detail=str(e))
@@ -457,7 +467,10 @@ def create_new_chat_session(
         logger.exception(e)
         raise HTTPException(status_code=400, detail="Invalid Persona provided.")
 
-    return CreateChatSessionID(chat_session_id=new_chat_session.id)
+    return CreateChatSessionID(
+        chat_session_id=new_chat_session.id,
+        incognito=new_chat_session.incognito_record_mode is not None,
+    )
 
 
 def _generate_or_fallback_chat_session_name(
@@ -541,6 +554,11 @@ def rename_chat_session(
             db_session=db_session,
             eager_load_persona=True,
         )
+        # Auto-naming derives a title from the conversation and writes it to the
+        # session row. A non-persisting incognito mode keeps no content in
+        # Postgres, so it keeps the fallback name and skips the LLM call.
+        if not record_mode_persists_content(chat_session.incognito_record_mode):
+            return RenameChatSessionResponse(new_name=DEFAULT_CHAT_SESSION_NAME)
         full_history = create_chat_history_chain(
             chat_session_id=chat_session_id,
             db_session=db_session,
@@ -594,15 +612,37 @@ def patch_chat_session(
     return None
 
 
+def _teardown_incognito_after_delete(chat_session_id: UUID) -> None:
+    """The rows are already gone, so a failed teardown is logged rather than
+    failing a delete the caller cannot retry. The context TTL is the backstop."""
+    try:
+        teardown_incognito_session(chat_session_id)
+    except Exception:
+        logger.exception("Incognito teardown failed for session %s", chat_session_id)
+
+
 @router.delete("/delete-all-chat-sessions", tags=PUBLIC_API_TAGS)
 def delete_all_chat_sessions(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> None:
+    incognito_session_ids = get_incognito_session_ids_for_user(user.id, db_session)
+    # Blobs first, and nothing is deleted while any remain: their ids live on
+    # the rows this is about to drop, so the other order strands them.
+    if not all(
+        delete_incognito_generated_files(incognito_id, db_session)
+        for incognito_id in incognito_session_ids
+    ):
+        raise OnyxError(
+            OnyxErrorCode.SERVICE_UNAVAILABLE,
+            "Some generated files could not be deleted yet. Try again shortly.",
+        )
     try:
         delete_all_chat_sessions_for_user(user=user, db_session=db_session)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    for incognito_id in incognito_session_ids:
+        _teardown_incognito_after_delete(incognito_id)
 
 
 @router.delete("/delete-chat-session/{session_id}", tags=PUBLIC_API_TAGS)
@@ -614,6 +654,17 @@ def delete_chat_session_by_id(
 ) -> None:
     user_id = user.id
     try:
+        session = get_chat_session_by_id(
+            chat_session_id=session_id, user_id=user_id, db_session=db_session
+        )
+        is_incognito = session.incognito_record_mode is not None
+        if is_incognito and not delete_incognito_generated_files(
+            session_id, db_session
+        ):
+            raise OnyxError(
+                OnyxErrorCode.SERVICE_UNAVAILABLE,
+                "Some generated files could not be deleted yet. Try again shortly.",
+            )
         # Use the provided hard_delete parameter if specified, otherwise use the default config
         actual_hard_delete = (
             hard_delete if hard_delete is not None else HARD_DELETE_CHATS
@@ -623,6 +674,31 @@ def delete_chat_session_by_id(
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    if is_incognito:
+        _teardown_incognito_after_delete(session_id)
+
+
+@router.post("/end-incognito-session/{session_id}", tags=PUBLIC_API_TAGS)
+def end_incognito_session(
+    session_id: UUID,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> None:
+    """Drop an incognito session's live context the moment the chat closes.
+
+    The context TTL is only the backstop for when this never arrives, such as
+    a hard tab close.
+    """
+    chat_session = get_chat_session_by_id(
+        chat_session_id=session_id, user_id=user.id, db_session=db_session
+    )
+    if chat_session.incognito_record_mode is not None:
+        teardown_incognito_session(session_id)
+        if not delete_incognito_generated_files(session_id, db_session):
+            raise OnyxError(
+                OnyxErrorCode.SERVICE_UNAVAILABLE,
+                "Some generated files could not be deleted yet and will be retried.",
+            )
 
 
 # NOTE: This endpoint is extremely central to the application, any changes to it should be reviewed and approved by an experienced
@@ -674,7 +750,12 @@ def handle_send_chat_message(
     Returns:
         StreamingResponse | ChatFullResponse: Either streams or returns complete response.
     """
-    logger.debug("Received new chat message: %s", chat_message_req.message)
+    # Session id only: the session's incognito mode isn't loaded yet, and a
+    # verbatim prompt in the debug log would be exactly the durable message
+    # log incognito must never leave behind.
+    logger.debug(
+        "Received new chat message for session %s", chat_message_req.chat_session_id
+    )
 
     tenant_id = get_current_tenant_id()
     mt_cloud_telemetry(

--- a/backend/onyx/server/query_and_chat/models.py
+++ b/backend/onyx/server/query_and_chat/models.py
@@ -79,6 +79,9 @@ class ChatSessionCreationRequest(BaseModel):
     persona_id: int = 0
     description: str | None = None
     project_id: int | None = None
+    # Start the session incognito. Refused with an error when incognito is
+    # unavailable, never silently downgraded to an ordinary chat.
+    incognito: bool = False
 
 
 class ChatFeedbackRequest(BaseModel):
@@ -274,6 +277,9 @@ class ChatSessionDetailResponse(BaseModel):
     # Set while a run is in flight and resumable: cursor-0 replay+tail is
     # available at /chat-session/{id}/resume-stream.
     current_run: CurrentRunInfo | None = None
+    # True for sessions pinned to an incognito record mode, so a reload can
+    # restore the incognito UI state.
+    incognito: bool = False
 
 
 class AdminSearchRequest(BaseModel):

--- a/backend/onyx/tools/models.py
+++ b/backend/onyx/tools/models.py
@@ -274,6 +274,8 @@ class ToolCallInfo(BaseModel):
     search_docs: list[SearchDoc] | None = None
     generated_images: list[GeneratedImage] | None = None
     generated_files: list[PythonExecutionFile] | None = None
+    # File-store ids of blobs custom tools saved during the call.
+    generated_file_ids: list[str] | None = None
 
 
 CHAT_SESSION_ID_PLACEHOLDER = "CHAT_SESSION_ID"

--- a/backend/onyx/tools/tool_implementations/memory/memory_tool.py
+++ b/backend/onyx/tools/tool_implementations/memory/memory_tool.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from typing_extensions import override
 
 from onyx.chat.emitter import Emitter
+from onyx.chat.incognito import current_turn_persists_content
 from onyx.llm.interfaces import LLM
 from onyx.secondary_llm_flows.memory_update import process_memory_update
 from onyx.server.query_and_chat.placement import Placement
@@ -134,7 +135,8 @@ class MemoryTool(Tool[MemoryToolOverrideKwargs]):
             user_role=override_kwargs.user_role,
         )
 
-        logger.info("New memory to be added: %s", memory_text)
+        if current_turn_persists_content():
+            logger.info("New memory to be added: %s", memory_text)
 
         operation: Literal["add", "update"] = (
             "update" if index_to_replace is not None else "add"

--- a/backend/onyx/tracing/braintrust_tracing_processor.py
+++ b/backend/onyx/tracing/braintrust_tracing_processor.py
@@ -6,6 +6,7 @@ from braintrust import NOOP_SPAN
 
 from onyx.llm.cost import compute_cost_cents
 from onyx.tracing.flows import IMAGE_FLOWS
+from onyx.tracing.incognito import suppresses_external_traces
 
 from .framework.processor_interface import TracingProcessor
 from .framework.span_data import (
@@ -72,8 +73,16 @@ class BraintrustTracingProcessor(TracingProcessor):
         self._last_output: Dict[str, Any] = {}
         self._trace_metadata: Dict[str, Dict[str, Any]] = {}
         self._span_names: Dict[str, str] = {}
+        # Traces suppressed at start. Membership decides every later callback,
+        # so an incognito flag change mid-trace cannot mismatch start/end state.
+        self._suppressed_traces: set[str] = set()
 
     def on_trace_start(self, trace: Trace) -> None:
+        # Incognito turns must leave no content in external tracing, so the
+        # whole trace is dropped, spans included.
+        if suppresses_external_traces():
+            self._suppressed_traces.add(trace.trace_id)
+            return
         trace_meta = trace.export() or {}
         metadata = trace_meta.get("metadata") or {}
         if metadata:
@@ -102,6 +111,9 @@ class BraintrustTracingProcessor(TracingProcessor):
         self._span_names[trace.trace_id] = trace.name
 
     def on_trace_end(self, trace: Trace) -> None:
+        if trace.trace_id in self._suppressed_traces:
+            self._suppressed_traces.discard(trace.trace_id)
+            return
         span: Any = self._spans.pop(trace.trace_id)
         self._trace_metadata.pop(trace.trace_id, None)
         self._span_names.pop(trace.trace_id, None)
@@ -227,6 +239,8 @@ class BraintrustTracingProcessor(TracingProcessor):
             return {}
 
     def on_span_start(self, span: Span[SpanData]) -> None:
+        if span.trace_id in self._suppressed_traces:
+            return
         parent: Any = (
             self._spans[span.parent_id]
             if span.parent_id is not None
@@ -253,6 +267,8 @@ class BraintrustTracingProcessor(TracingProcessor):
         created_span.set_current()
 
     def on_span_end(self, span: Span[SpanData]) -> None:
+        if span.trace_id in self._suppressed_traces:
+            return
         s: Any = self._spans.pop(span.span_id)
         self._span_names.pop(span.span_id, None)
         event = dict(error=span.error, **self._log_data(span))

--- a/backend/onyx/tracing/incognito.py
+++ b/backend/onyx/tracing/incognito.py
@@ -1,0 +1,9 @@
+from onyx.db.enums import IncognitoRecordMode
+from shared_configs.contextvars import get_current_incognito_record_mode
+
+
+def suppresses_external_traces() -> bool:
+    """External tracing processors must check this at trace start and drop the
+    whole trace, spans included, when True."""
+    mode = IncognitoRecordMode.from_context_value(get_current_incognito_record_mode())
+    return mode is not None and not mode.emits_external_traces

--- a/backend/onyx/tracing/langfuse_tracing_processor.py
+++ b/backend/onyx/tracing/langfuse_tracing_processor.py
@@ -20,6 +20,7 @@ from onyx.tracing.framework.span_data import (
 )
 from onyx.tracing.framework.spans import Span
 from onyx.tracing.framework.traces import Trace
+from onyx.tracing.incognito import suppresses_external_traces
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +65,8 @@ class LangfuseTracingProcessor(TracingProcessor):
         self._langfuse_span_ids: dict[
             str, str
         ] = {}  # framework_span_id -> langfuse_span.id
+        # Membership decides every later callback, immune to mid-trace changes.
+        self._suppressed_traces: set[str] = set()
 
     def _get_client(self) -> Langfuse:
         """Get or create Langfuse client."""
@@ -125,6 +128,10 @@ class LangfuseTracingProcessor(TracingProcessor):
 
     def on_trace_start(self, trace: Trace) -> None:
         """Called when a trace is started."""
+        if suppresses_external_traces():
+            with self._lock:
+                self._suppressed_traces.add(trace.trace_id)
+            return
         try:
             client = self._get_client()
             trace_meta = trace.export() or {}
@@ -162,6 +169,10 @@ class LangfuseTracingProcessor(TracingProcessor):
 
     def on_trace_end(self, trace: Trace) -> None:
         """Called when a trace is finished."""
+        with self._lock:
+            if trace.trace_id in self._suppressed_traces:
+                self._suppressed_traces.discard(trace.trace_id)
+                return
         try:
             with self._lock:
                 langfuse_span = self._trace_spans.pop(trace.trace_id, None)
@@ -191,6 +202,9 @@ class LangfuseTracingProcessor(TracingProcessor):
         agents run in parallel threads, and calling methods on span objects created
         in other threads can cause OpenTelemetry context issues.
         """
+        with self._lock:
+            if span.trace_id in self._suppressed_traces:
+                return
         try:
             data = span.span_data
             # Declare as Any since different code paths return different observation types

--- a/backend/shared_configs/contextvars.py
+++ b/backend/shared_configs/contextvars.py
@@ -36,6 +36,19 @@ CURRENT_USER_ID_CONTEXTVAR: contextvars.ContextVar[str | None] = contextvars.Con
     "current_user_id", default=None
 )
 
+# IncognitoRecordMode value of the streaming turn's session, None outside
+# incognito. A plain string keeps this layer free of onyx imports.
+CURRENT_INCOGNITO_RECORD_MODE_CONTEXTVAR: contextvars.ContextVar[str | None] = (
+    contextvars.ContextVar("current_incognito_record_mode", default=None)
+)
+
+# Session id of a content-free turn, and only of a content-free turn: a blob
+# saved while this is set is conversation-derived and must die with the
+# session, so the file store stamps it on the record at creation.
+CURRENT_CONTENT_FREE_SESSION_ID_CONTEXTVAR: contextvars.ContextVar[str | None] = (
+    contextvars.ContextVar("current_content_free_session_id", default=None)
+)
+
 
 class UsageCredentialIdentity(NamedTuple):
     credential_type: UsageCredentialType
@@ -69,6 +82,11 @@ def get_current_tenant_id() -> str:
 def get_current_user_id() -> str | None:
     """Requesting user's id, or None outside a per-request context."""
     return CURRENT_USER_ID_CONTEXTVAR.get()
+
+
+def get_current_incognito_record_mode() -> str | None:
+    """The incognito record-mode value of the current turn, None outside one."""
+    return CURRENT_INCOGNITO_RECORD_MODE_CONTEXTVAR.get()
 
 
 def get_current_usage_credential() -> UsageCredentialIdentity | None:

--- a/backend/tests/external_dependency_unit/chat/test_incognito_persistence.py
+++ b/backend/tests/external_dependency_unit/chat/test_incognito_persistence.py
@@ -1,0 +1,266 @@
+"""Guards the incognito persistence seams against real Postgres and Redis.
+
+Two behaviors the feature rests on: save_chat_turn keeps the assistant row for
+tracking but writes no text when content is not persisted, and the ephemeral
+store round-trips a turn's messages so the next turn has its context. Run here
+rather than as unit tests because both only mean something against the real
+stores.
+"""
+
+from collections.abc import Generator
+from io import BytesIO
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.chat.incognito import delete_incognito_generated_files
+from onyx.chat.incognito_context import (
+    append_incognito_message,
+    load_incognito_context,
+    teardown_incognito_session,
+)
+from onyx.chat.models import ChatMessageSimple
+from onyx.chat.save_chat import save_chat_turn
+from onyx.configs.constants import DocumentSource, FileOrigin, MessageType
+from onyx.context.search.models import SearchDoc
+from onyx.db.chat import (
+    create_chat_session,
+    get_or_create_root_message,
+    reserve_message_id,
+)
+from onyx.db.file_record import (
+    get_incognito_file_ids,
+    get_session_ids_with_incognito_files,
+)
+from onyx.db.models import ChatMessage, ChatSession, User
+from onyx.file_store.file_store import get_default_file_store
+from onyx.redis.redis_pool import get_redis_client
+from onyx.tools.models import ToolCallInfo
+from shared_configs.contextvars import CURRENT_CONTENT_FREE_SESSION_ID_CONTEXTVAR
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+@pytest.fixture
+def owner(db_session: Session) -> Generator[User, None, None]:
+    user = create_test_user(db_session, "incognito-persist")
+    yield user
+    db_session.rollback()
+    db_session.query(ChatSession).filter(ChatSession.user_id == user.id).delete()
+    db_session.delete(user)
+    db_session.commit()
+
+
+def _new_session(db_session: Session, user_id: UUID) -> ChatSession:
+    return create_chat_session(
+        db_session=db_session,
+        description="incognito",
+        user_id=user_id,
+        persona_id=None,
+    )
+
+
+def _reserve_assistant(db_session: Session, session_id: UUID) -> ChatMessage:
+    root = get_or_create_root_message(chat_session_id=session_id, db_session=db_session)
+    return reserve_message_id(
+        db_session=db_session,
+        chat_session_id=session_id,
+        parent_message=root.id,
+    )
+
+
+def _search_doc(document_id: str) -> SearchDoc:
+    return SearchDoc(
+        document_id=document_id,
+        chunk_ind=0,
+        semantic_identifier="secret doc",
+        blurb="confidential excerpt",
+        source_type=DocumentSource.WEB,
+        boost=0,
+        hidden=False,
+        metadata={},
+        match_highlights=["<hi>confidential</hi>"],
+    )
+
+
+def test_save_chat_turn_keeps_the_row_but_writes_no_text(
+    db_session: Session, owner: User
+) -> None:
+    session = _new_session(db_session, owner.id)
+    assistant = _reserve_assistant(db_session, session.id)
+
+    doc = _search_doc("secret-doc-1")
+    save_chat_turn(
+        message_text="the acquisition target is confidential",
+        reasoning_tokens="secret reasoning",
+        tool_calls=[
+            ToolCallInfo(
+                parent_tool_call_id=None,
+                turn_index=0,
+                tab_index=0,
+                tool_name="run_search",
+                tool_call_id="call-1",
+                tool_id=1,
+                reasoning_tokens=None,
+                tool_call_arguments={"query": "the confidential query"},
+                tool_call_response="retrieved excerpt text",
+                search_docs=[doc],
+            )
+        ],
+        citation_to_doc={1: doc},
+        all_search_docs={doc.document_id: doc},
+        db_session=db_session,
+        assistant_message=assistant,
+        emitted_citations={1},
+        persist_content=False,
+    )
+    db_session.commit()
+
+    stored = db_session.get(ChatMessage, assistant.id)
+    assert stored is not None
+    # Row survives for tracking, with a real token count, but no text.
+    assert stored.message == ""
+    assert stored.reasoning_tokens is None
+    assert stored.token_count > 0
+    # Conversation-derived artifacts stay out too: no tool calls, no search
+    # docs, no citations for a content-free turn.
+    assert not stored.tool_calls
+    assert not stored.search_docs
+    assert not stored.citations
+
+
+def test_save_chat_turn_persists_text_by_default(
+    db_session: Session, owner: User
+) -> None:
+    session = _new_session(db_session, owner.id)
+    assistant = _reserve_assistant(db_session, session.id)
+
+    save_chat_turn(
+        message_text="an ordinary answer",
+        reasoning_tokens=None,
+        tool_calls=[],
+        citation_to_doc={},
+        all_search_docs={},
+        db_session=db_session,
+        assistant_message=assistant,
+    )
+    db_session.commit()
+
+    stored = db_session.get(ChatMessage, assistant.id)
+    assert stored is not None
+    assert stored.message == "an ordinary answer"
+
+
+def test_turn_round_trips_through_the_store() -> None:
+    """A turn appends the user message then the answer. The next turn loads both
+    in order so the model sees its own context."""
+    session_id = uuid4()
+    try:
+        append_incognito_message(
+            session_id,
+            ChatMessageSimple(
+                message="what is our runway",
+                token_count=4,
+                message_type=MessageType.USER,
+            ),
+        )
+        append_incognito_message(
+            session_id,
+            ChatMessageSimple(
+                message="eighteen months",
+                token_count=2,
+                message_type=MessageType.ASSISTANT,
+            ),
+        )
+
+        history = load_incognito_context(session_id).messages
+        assert [(m.message_type, m.message) for m in history] == [
+            (MessageType.USER, "what is our runway"),
+            (MessageType.ASSISTANT, "eighteen months"),
+        ]
+    finally:
+        teardown_incognito_session(session_id)
+
+
+def test_teardown_ends_the_session_immediately() -> None:
+    session_id = uuid4()
+    append_incognito_message(
+        session_id,
+        ChatMessageSimple(
+            message="secret", token_count=1, message_type=MessageType.USER
+        ),
+    )
+    assert load_incognito_context(session_id).messages
+
+    teardown_incognito_session(session_id)
+
+    assert load_incognito_context(session_id).messages == []
+
+
+def test_teardown_clears_buffered_stream_chunks() -> None:
+    """The stream buffer holds the streamed answer NDJSON, so teardown must
+    delete it with the context instead of leaving it to the TTL."""
+    session_id = uuid4()
+    client = get_redis_client()
+    chunk_key = f"chatstream_{session_id}_1:0"
+    client.set(chunk_key, b"buffered answer text", ex=600)
+    assert client.get(chunk_key) is not None
+
+    teardown_incognito_session(session_id)
+
+    assert client.get(chunk_key) is None
+
+
+def _content_free_blob(session_id: UUID) -> str:
+    """Save a blob the way a tool does inside a content-free turn."""
+    token = CURRENT_CONTENT_FREE_SESSION_ID_CONTEXTVAR.set(str(session_id))
+    try:
+        return get_default_file_store().save_file(
+            content=BytesIO(b"generated chart bytes"),
+            display_name="chart.png",
+            file_origin=FileOrigin.CHAT_IMAGE_GEN,
+            file_type="image/png",
+        )
+    finally:
+        CURRENT_CONTENT_FREE_SESSION_ID_CONTEXTVAR.reset(token)
+
+
+def test_a_blob_is_stamped_when_it_is_saved(db_session: Session) -> None:
+    """The stamp lands with the record, so no window exists where a blob is
+    durable but unfindable."""
+    session_id = uuid4()
+    file_id = _content_free_blob(session_id)
+
+    assert get_incognito_file_ids(str(session_id), db_session) == [file_id]
+
+
+def test_teardown_deletes_the_stamped_blobs(db_session: Session) -> None:
+    session_id = uuid4()
+    file_id = _content_free_blob(session_id)
+    file_store = get_default_file_store()
+
+    assert delete_incognito_generated_files(session_id, db_session)
+
+    with pytest.raises(Exception):
+        file_store.read_file(file_id)
+    assert get_incognito_file_ids(str(session_id), db_session) == []
+
+
+def test_a_refused_deletion_keeps_the_stamp(db_session: Session) -> None:
+    """A store outage must leave the blob findable for the sweep."""
+    session_id = uuid4()
+    file_id = _content_free_blob(session_id)
+    file_store = get_default_file_store()
+
+    with patch.object(
+        type(file_store), "delete_file", side_effect=RuntimeError("store blip")
+    ):
+        assert not delete_incognito_generated_files(session_id, db_session)
+
+    assert get_incognito_file_ids(str(session_id), db_session) == [file_id]
+    assert str(session_id) in get_session_ids_with_incognito_files(db_session)
+
+    assert delete_incognito_generated_files(session_id, db_session)
+    with pytest.raises(Exception):
+        file_store.read_file(file_id)

--- a/backend/tests/external_dependency_unit/db/test_incognito_history_exclusion.py
+++ b/backend/tests/external_dependency_unit/db/test_incognito_history_exclusion.py
@@ -1,0 +1,178 @@
+"""Guards that an incognito session stays out of every surface its owner sees.
+
+Covers the three that list a user's own sessions: history, search, and the
+chat list a project carries. Exercises the real WHERE clauses against Postgres,
+since a mocked session would happily return rows the SQL would have filtered.
+"""
+
+from collections.abc import Generator
+from uuid import UUID
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import MessageType
+from onyx.db.chat import (
+    create_chat_session,
+    create_new_chat_message,
+    get_chat_sessions_by_user,
+    get_or_create_root_message,
+)
+from onyx.db.chat_search import search_chat_sessions
+from onyx.db.enums import IncognitoRecordMode
+from onyx.db.models import ChatSession, User, UserProject
+from onyx.server.features.projects.models import UserProjectSnapshot
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+@pytest.fixture
+def owner(db_session: Session) -> Generator[User, None, None]:
+    """A user whose rows are deleted afterwards rather than rolled back.
+
+    ``create_chat_session`` commits, so a rollback cannot reach these rows, and
+    the filter under test hides them from the UI that would otherwise clean them
+    up. Left alone they accumulate as sessions nobody can see or remove.
+    """
+    user = create_test_user(db_session, "incognito-history")
+    yield user
+
+    db_session.rollback()
+    # Sessions before projects: chat_session.project_id references user_project.
+    db_session.query(ChatSession).filter(ChatSession.user_id == user.id).delete()
+    db_session.query(UserProject).filter(UserProject.user_id == user.id).delete()
+    db_session.delete(user)
+    db_session.commit()
+
+
+def _make_session(
+    db_session: Session,
+    user_id: UUID,
+    description: str,
+    mode: IncognitoRecordMode | None,
+    project_id: int | None = None,
+) -> ChatSession:
+    chat_session = create_chat_session(
+        db_session=db_session,
+        description=description,
+        user_id=user_id,
+        persona_id=None,
+        project_id=project_id,
+    )
+    chat_session.incognito_record_mode = mode
+    # Commit rather than flush: the next create_chat_session would otherwise be
+    # what commits this assignment, leaving the last one written only in memory.
+    db_session.commit()
+    return chat_session
+
+
+def _history_ids(db_session: Session, user_id: UUID) -> set[UUID]:
+    """The owner's own history, which is the call site that opts out."""
+    return {
+        session.id
+        for session in get_chat_sessions_by_user(
+            user_id=user_id,
+            deleted=None,
+            db_session=db_session,
+            include_failed_chats=True,
+            exclude_incognito=True,
+        )
+    }
+
+
+def test_every_mode_is_excluded_from_history(db_session: Session, owner: User) -> None:
+    """Every mode must stay out of the owner's history.
+
+    Iterates the enum so a newly added mode is covered without editing this
+    test.
+    """
+    sessions = {
+        mode: _make_session(db_session, owner.id, f"chat {mode.value}", mode)
+        for mode in IncognitoRecordMode
+    }
+
+    returned_ids = _history_ids(db_session, owner.id)
+    for mode, chat_session in sessions.items():
+        assert chat_session.id not in returned_ids, f"{mode.value} leaked"
+
+
+def test_search_excludes_incognito_matching_the_query(
+    db_session: Session, owner: User
+) -> None:
+    """The description arm of the union must not surface an incognito session."""
+    ordinary = _make_session(db_session, owner.id, "penguin migration notes", None)
+    incognito = _make_session(
+        db_session,
+        owner.id,
+        "penguin migration secrets",
+        IncognitoRecordMode.FULL_HISTORY,
+    )
+
+    sessions, _ = search_chat_sessions(
+        user_id=owner.id, db_session=db_session, query="penguin"
+    )
+    returned_ids = {session.id for session in sessions}
+    assert ordinary.id in returned_ids
+    assert incognito.id not in returned_ids
+
+
+def test_project_does_not_list_its_incognito_sessions(
+    db_session: Session, owner: User
+) -> None:
+    """A project lists sessions by title, which is the thing incognito hides."""
+    project = UserProject(name="incognito-project", user_id=owner.id)
+    db_session.add(project)
+    db_session.commit()
+
+    ordinary = _make_session(
+        db_session, owner.id, "ordinary chat", None, project_id=project.id
+    )
+    incognito = _make_session(
+        db_session,
+        owner.id,
+        "incognito chat",
+        IncognitoRecordMode.FULL_HISTORY,
+        project_id=project.id,
+    )
+
+    db_session.expire(project)
+    listed = UserProjectSnapshot.from_model(project).chat_sessions
+    listed_ids = {session.id for session in listed}
+    assert ordinary.id in listed_ids
+    assert incognito.id not in listed_ids
+    assert all(session.name != "incognito chat" for session in listed)
+
+
+def test_search_excludes_incognito_matching_only_in_a_message(
+    db_session: Session, owner: User
+) -> None:
+    """The message-body arm of the union is filtered too.
+
+    Both arms carry base_conditions, so a hit on message text must not surface
+    a session whose description never matched.
+    """
+    incognito = _make_session(
+        db_session, owner.id, "untitled", IncognitoRecordMode.FULL_HISTORY
+    )
+    ordinary = _make_session(db_session, owner.id, "untitled", None)
+
+    for chat_session in (incognito, ordinary):
+        create_new_chat_message(
+            chat_session_id=chat_session.id,
+            parent_message=get_or_create_root_message(
+                chat_session_id=chat_session.id, db_session=db_session
+            ),
+            message="the aardvark budget is confidential",
+            token_count=7,
+            message_type=MessageType.USER,
+            db_session=db_session,
+        )
+    db_session.commit()
+
+    sessions, _ = search_chat_sessions(
+        user_id=owner.id, db_session=db_session, query="aardvark"
+    )
+    returned_ids = {session.id for session in sessions}
+    # The ordinary control proves the query actually matches message bodies,
+    # so the incognito assertion is not passing for want of any hit at all.
+    assert ordinary.id in returned_ids
+    assert incognito.id not in returned_ids

--- a/backend/tests/external_dependency_unit/redis/test_incognito_context.py
+++ b/backend/tests/external_dependency_unit/redis/test_incognito_context.py
@@ -1,0 +1,230 @@
+"""Guards the incognito context store's Redis contract.
+
+Round trip, the compare-and-set that guards against concurrent turns, the
+sliding TTL, teardown, corruption degrading to an ended session, image
+stripping, and the storage caps, all against a real Redis. Each test runs
+under a unique tenant so runs cannot collide, mirroring test_tenant_redis.py.
+"""
+
+import time
+from collections.abc import Generator
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from onyx.cache.interface import CacheBackendType
+from onyx.chat.incognito_context import (
+    INCOGNITO_CONTEXT_TTL_SECONDS,
+    IncognitoContext,
+    _context_key,
+    incognito_context_available,
+    load_incognito_context,
+    save_incognito_context,
+    teardown_incognito_session,
+)
+from onyx.chat.models import ChatLoadedFile, ChatMessageSimple, ToolCallSimple
+from onyx.configs.constants import MessageType
+from onyx.file_store.models import ChatFileType
+from onyx.redis.redis_pool import get_raw_redis_client, get_redis_client
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
+
+@pytest.fixture(autouse=True)
+def isolated_tenant() -> Generator[str, None, None]:
+    tenant = f"tenant_test_{uuid4().hex[:12]}"
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant)
+    yield tenant
+    CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+    raw = get_raw_redis_client()
+    keys = list(raw.scan_iter(match=f"{tenant}:*"))
+    if keys:
+        raw.delete(*keys)
+
+
+def _message(
+    text: str, message_type: MessageType = MessageType.USER
+) -> ChatMessageSimple:
+    return ChatMessageSimple(
+        message=text, token_count=len(text), message_type=message_type
+    )
+
+
+def _save(
+    chat_session_id: UUID, messages: list[ChatMessageSimple], version: int = 0
+) -> bool:
+    return save_incognito_context(
+        chat_session_id, IncognitoContext(version=version, messages=messages)
+    )
+
+
+def test_missing_key_loads_empty_version_zero() -> None:
+    context = load_incognito_context(uuid4())
+    assert context.messages == []
+    assert context.version == 0
+
+
+def test_stale_version_save_is_discarded() -> None:
+    """A concurrent turn that loaded the same version must not roll the
+    winner's write back."""
+    session_id = uuid4()
+    assert _save(session_id, [_message("turn one")], version=0)
+
+    # A racing writer that also loaded version 0 loses.
+    assert not _save(session_id, [_message("stale rollback")], version=0)
+
+    loaded = load_incognito_context(session_id)
+    assert loaded.version == 1
+    assert loaded.messages[0].message == "turn one"
+
+
+def test_sequential_turns_chain_versions() -> None:
+    session_id = uuid4()
+    assert _save(session_id, [_message("one")], version=0)
+
+    first = load_incognito_context(session_id)
+    assert _save(session_id, first.messages + [_message("two")], first.version)
+
+    second = load_incognito_context(session_id)
+    assert second.version == 2
+    assert [m.message for m in second.messages] == ["one", "two"]
+
+
+def test_corrupt_value_degrades_and_is_overwritable() -> None:
+    session_id = uuid4()
+    get_redis_client().set(_context_key(session_id), b"not json at all")
+
+    context = load_incognito_context(session_id)
+    assert context.messages == []
+    assert context.version == 0
+
+    # The load/save pair recovers: expecting version 0 overwrites the garbage.
+    assert _save(session_id, [_message("fresh start")], version=0)
+    assert load_incognito_context(session_id).messages[0].message == "fresh start"
+
+
+def test_ttl_is_set_and_slides_on_save() -> None:
+    session_id = uuid4()
+    client = get_redis_client()
+
+    assert _save(session_id, [_message("first")])
+    ttl_after_first = client.ttl(_context_key(session_id))
+    assert 0 < ttl_after_first <= INCOGNITO_CONTEXT_TTL_SECONDS
+
+    time.sleep(2)
+    first = load_incognito_context(session_id)
+    assert _save(session_id, first.messages + [_message("second")], first.version)
+    ttl_after_second = client.ttl(_context_key(session_id))
+    # A non-sliding TTL would have decayed by the sleep. A fresh save restarts it.
+    assert ttl_after_second > INCOGNITO_CONTEXT_TTL_SECONDS - 2
+
+
+def test_teardown_ends_the_context_and_fences_writers() -> None:
+    session_id = uuid4()
+    assert _save(session_id, [_message("secret plans")])
+    context = load_incognito_context(session_id)
+    assert context.messages
+
+    teardown_incognito_session(session_id)
+
+    # Loads empty, and the tombstone refuses any save from an in-flight turn.
+    assert load_incognito_context(session_id).messages == []
+    assert not _save(session_id, [_message("resurrected")])
+    assert load_incognito_context(session_id).messages == []
+
+
+def test_images_are_stripped_before_storage() -> None:
+    """File bytes do not round-trip JSON, so save must drop them rather than
+    fail the turn or store binary content."""
+    session_id = uuid4()
+    image = ChatLoadedFile(
+        file_id="f1",
+        content=b"\x89PNG\r\n",
+        file_type=ChatFileType.IMAGE,
+        filename="chart.png",
+        content_text=None,
+        token_count=0,
+    )
+    message = ChatMessageSimple(
+        message="see attached",
+        token_count=100,
+        message_type=MessageType.USER,
+        image_files=[image],
+        image_token_count=85,
+    )
+
+    assert _save(session_id, [message])
+    (loaded,) = load_incognito_context(session_id).messages
+
+    assert loaded.image_files is None
+    assert loaded.image_token_count == 0
+    assert loaded.message == "see attached"
+
+
+def test_tool_calls_round_trip() -> None:
+    """Assistant tool calls and tool responses are part of history and must
+    survive storage intact."""
+    session_id = uuid4()
+    call = ChatMessageSimple(
+        message="",
+        token_count=12,
+        message_type=MessageType.ASSISTANT,
+        tool_calls=[
+            ToolCallSimple(
+                tool_call_id="call_1",
+                tool_name="run_search",
+                tool_arguments={"query": "churn", "limit": 5, "nested": {"a": [1]}},
+                token_count=12,
+            )
+        ],
+    )
+    response = ChatMessageSimple(
+        message="3 documents found",
+        token_count=4,
+        message_type=MessageType.TOOL_CALL_RESPONSE,
+        tool_call_id="call_1",
+    )
+
+    assert _save(session_id, [call, response])
+    loaded = load_incognito_context(session_id).messages
+
+    assert loaded == [call, response]
+
+
+def test_message_count_cap_keeps_the_newest() -> None:
+    session_id = uuid4()
+    history = [_message(f"m{i}") for i in range(205)]
+
+    assert _save(session_id, history)
+    loaded = load_incognito_context(session_id).messages
+
+    assert len(loaded) == 200
+    assert loaded[0].message == "m5"
+    assert loaded[-1].message == "m204"
+
+
+def test_byte_cap_drops_oldest_but_keeps_an_oversized_singleton() -> None:
+    session_id = uuid4()
+    big = "x" * 600_000
+    oversized = "y" * 1_200_000
+
+    assert _save(session_id, [_message(big), _message(big + "newer")])
+    loaded = load_incognito_context(session_id).messages
+    assert len(loaded) == 1
+    assert loaded[0].message.endswith("newer")
+
+    # One message alone over the cap is stored anyway: an empty save would
+    # read as session-ended on the next turn.
+    singleton_session = uuid4()
+    assert _save(singleton_session, [_message(oversized)])
+    assert len(load_incognito_context(singleton_session).messages) == 1
+
+
+def test_availability_follows_the_cache_backend() -> None:
+    """USAGE_ONLY content must never reach Postgres, so the Postgres cache
+    backend (Lite) means the feature is absent."""
+    with patch("onyx.chat.incognito_context.app_configs") as mock_configs:
+        mock_configs.CACHE_BACKEND = CacheBackendType.REDIS
+        assert incognito_context_available()
+        mock_configs.CACHE_BACKEND = CacheBackendType.POSTGRES
+        assert not incognito_context_available()

--- a/backend/tests/unit/onyx/chat/test_incognito_record_mode.py
+++ b/backend/tests/unit/onyx/chat/test_incognito_record_mode.py
@@ -1,0 +1,47 @@
+"""Guards the incognito recording policy: no mode other than FULL_HISTORY may
+write conversation content, a corrupt mode value reads as the safe one, and a
+content-free turn's persisted file descriptors keep linkage but not names.
+"""
+
+from onyx.chat.incognito import (
+    content_free_file_descriptors,
+    resolve_incognito_record_mode,
+)
+from onyx.db.enums import IncognitoRecordMode
+from onyx.file_store.models import ChatFileType, FileDescriptor
+
+
+def test_only_full_history_persists_content() -> None:
+    persisting = [m for m in IncognitoRecordMode if m.persists_content]
+    assert persisting == [IncognitoRecordMode.FULL_HISTORY]
+
+
+def test_default_never_persists_content() -> None:
+    """A dropped admin setting must not silently start recording chats."""
+    assert resolve_incognito_record_mode() is IncognitoRecordMode.USAGE_ONLY
+    assert resolve_incognito_record_mode().persists_content is False
+
+
+def test_unknown_context_value_fails_closed() -> None:
+    """A corrupt contextvar must never read as content-persisting."""
+    assert IncognitoRecordMode.from_context_value("garbage") is (
+        IncognitoRecordMode.USAGE_ONLY
+    )
+    assert IncognitoRecordMode.from_context_value(None) is None
+
+
+def test_descriptors_strip_the_name_and_keep_linkage() -> None:
+    scrubbed = content_free_file_descriptors(
+        [
+            FileDescriptor(
+                id="file-1",
+                type=ChatFileType.DOC,
+                name="acquisition_target.pdf",
+                user_file_id="uf-1",
+            )
+        ]
+    )
+    assert scrubbed == [
+        FileDescriptor(id="file-1", type=ChatFileType.DOC, user_file_id="uf-1")
+    ]
+    assert "name" not in scrubbed[0]

--- a/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
+++ b/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
@@ -276,8 +276,9 @@ def _make_setup(n_models: int = 1) -> MagicMock:
     setup.available_files.chat_file_ids = []
     setup.forced_tool_id = None
     setup.simple_chat_history = []
-    setup.chat_session.id = uuid4()
-    setup.user_message.id = None
+    setup.chat_session_id = uuid4()
+    setup.chat_session_project_id = None
+    setup.user_message_id = None
     setup.custom_tool_additional_headers = None
     setup.mcp_headers = None
     return setup

--- a/backend/tests/unit/onyx/tracing/test_braintrust_incognito_suppression.py
+++ b/backend/tests/unit/onyx/tracing/test_braintrust_incognito_suppression.py
@@ -1,0 +1,80 @@
+"""Incognito turns must leave no content in Braintrust: the processor drops
+the whole trace, spans included, keyed on membership recorded at trace start."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.tracing.braintrust_tracing_processor import BraintrustTracingProcessor
+from shared_configs.contextvars import CURRENT_INCOGNITO_RECORD_MODE_CONTEXTVAR
+
+
+@pytest.fixture
+def incognito_context() -> Generator[None, None, None]:
+    token = CURRENT_INCOGNITO_RECORD_MODE_CONTEXTVAR.set("usage_only")
+    yield
+    CURRENT_INCOGNITO_RECORD_MODE_CONTEXTVAR.reset(token)
+
+
+def _fake_trace(trace_id: str) -> MagicMock:
+    trace = MagicMock()
+    trace.trace_id = trace_id
+    trace.name = "run_llm_loop"
+    trace.export.return_value = {}
+    return trace
+
+
+def _fake_span(trace_id: str, span_id: str) -> MagicMock:
+    span = MagicMock()
+    span.trace_id = trace_id
+    span.span_id = span_id
+    span.parent_id = None
+    return span
+
+
+def test_incognito_trace_is_fully_suppressed(
+    incognito_context: None,  # noqa: ARG001 (requested for the flag side-effect)
+) -> None:
+    logger = MagicMock()
+    processor = BraintrustTracingProcessor(logger=logger)
+    trace = _fake_trace("t1")
+    span = _fake_span("t1", "s1")
+
+    processor.on_trace_start(trace)
+    processor.on_span_start(span)
+    processor.on_span_end(span)
+    processor.on_trace_end(trace)
+
+    logger.start_span.assert_not_called()
+    assert processor._spans == {}
+    assert processor._suppressed_traces == set()
+
+
+def test_suppression_holds_even_if_flag_clears_mid_trace() -> None:
+    """Membership at trace start decides, so a reset contextvar cannot leak
+    the tail of an incognito trace."""
+    logger = MagicMock()
+    processor = BraintrustTracingProcessor(logger=logger)
+    trace = _fake_trace("t1")
+    span = _fake_span("t1", "s1")
+
+    token = CURRENT_INCOGNITO_RECORD_MODE_CONTEXTVAR.set("usage_only")
+    processor.on_trace_start(trace)
+    CURRENT_INCOGNITO_RECORD_MODE_CONTEXTVAR.reset(token)
+
+    processor.on_span_start(span)
+    processor.on_span_end(span)
+    processor.on_trace_end(trace)
+
+    logger.start_span.assert_not_called()
+    assert processor._suppressed_traces == set()
+
+
+def test_regular_trace_still_logs() -> None:
+    logger = MagicMock()
+    processor = BraintrustTracingProcessor(logger=logger)
+
+    processor.on_trace_start(_fake_trace("t2"))
+
+    logger.start_span.assert_called_once()

--- a/backend/tests/unit/onyx/tracing/test_langfuse_incognito_suppression.py
+++ b/backend/tests/unit/onyx/tracing/test_langfuse_incognito_suppression.py
@@ -1,0 +1,60 @@
+"""Incognito turns must leave no content in Langfuse: the processor drops the
+whole trace, spans included, keyed on membership recorded at trace start."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.tracing.langfuse_tracing_processor import LangfuseTracingProcessor
+from shared_configs.contextvars import CURRENT_INCOGNITO_RECORD_MODE_CONTEXTVAR
+
+
+@pytest.fixture
+def incognito_context() -> Generator[None, None, None]:
+    token = CURRENT_INCOGNITO_RECORD_MODE_CONTEXTVAR.set("usage_only")
+    yield
+    CURRENT_INCOGNITO_RECORD_MODE_CONTEXTVAR.reset(token)
+
+
+def _fake_trace(trace_id: str) -> MagicMock:
+    trace = MagicMock()
+    trace.trace_id = trace_id
+    trace.name = "run_llm_loop"
+    trace.export.return_value = {}
+    return trace
+
+
+def _fake_span(trace_id: str, span_id: str) -> MagicMock:
+    span = MagicMock()
+    span.trace_id = trace_id
+    span.span_id = span_id
+    span.parent_id = None
+    return span
+
+
+def test_incognito_trace_is_fully_suppressed(
+    incognito_context: None,  # noqa: ARG001 (requested for the flag side-effect)
+) -> None:
+    client = MagicMock()
+    processor = LangfuseTracingProcessor(client=client)
+    trace = _fake_trace("t1")
+    span = _fake_span("t1", "s1")
+
+    processor.on_trace_start(trace)
+    processor.on_span_start(span)
+    processor.on_span_end(span)
+    processor.on_trace_end(trace)
+
+    client.start_observation.assert_not_called()
+    assert processor._suppressed_traces == set()
+
+
+def test_ordinary_trace_still_exports() -> None:
+    client = MagicMock()
+    processor = LangfuseTracingProcessor(client=client)
+    trace = _fake_trace("t2")
+
+    processor.on_trace_start(trace)
+
+    client.start_observation.assert_called_once()


### PR DESCRIPTION
## Description

Part 2 of 5 for incognito chat (ENG-4313). Based on #13886, which adds the `chat_session.incognito_record_mode` column this reads.

Design doc: [Incognito Chat Mode](https://dev-wiki.onyx.app/app/wiki/Engineering%20Projects/Onyx%20Projects/Incognito%20Chat%20Mode/Design.md)

What this adds:

- **An incognito flag on session creation.** `ChatSessionCreationRequest.incognito` pins a record mode on the new session, and both the create response and the session-detail response echo it back. Every later read uses the pinned value, never the live admin setting, so a setting change cannot alter a session already under way. The resolver returns `usage_only` unconditionally here. The admin setting that can change it is a later PR.
- **A conversation store in Redis** (`onyx/chat/incognito_context.py`). One value per session holding the turns, written through a Lua compare-and-set on a version because two turns on one session can overlap, with a one-hour TTL that restarts on every save. Loads degrade to empty rather than failing a turn.
- **Content-free row writes.** `save_chat_turn` grows a `persist_content` flag. When it is off the message row keeps its id, structure, and a real token count, and drops the text, reasoning, tool calls, search docs, citations, and the compression summary. Attachment descriptors keep their opaque ids and lose the filename.
- **Teardown, and a new `POST /chat/end-incognito-session/{id}`.** Teardown replaces the context value with a tombstone that the compare-and-set refuses, so a turn still streaming cannot recreate what the user just closed, and deletes the buffered stream chunks holding the streamed answer NDJSON.
- **Deletion of tool-generated blobs.** Image generation, python, and custom tools write files to the object store during a turn. The assistant row records their ids as opaque descriptors, teardown deletes by them, and a deletion the store refuses leaves its id on that row. A new `check-for-incognito-file-cleanup` beat task retries those sessions once their context is gone. Deleting a session deletes its blobs first and refuses while any remain, because the rows are what carry the ids.
- **Trace and log suppression.** The Braintrust and Langfuse processors drop an incognito trace whole rather than scrubbing it, tracked by trace id from the first callback so a mid-trace change cannot mismatch. Model-interaction, memory, and Slack query debug logs fire only for content-persisting turns.
- **Memory reads without writes.** The memory tool stays available and returns an explicit refusal the next LLM cycle sees, instead of writing.
- **Exclusion from the owner's surfaces.** History, chat search (both arms of its union), and a project's session list filter these sessions out, so a project is usable for context while the chat is not saved to it.

Two things refuse rather than degrade: creating an incognito session fails when the cache backend is not Redis, since the conversation would otherwise have to live in Postgres, and copying a Slack thread into or out of one fails, since that path writes real message rows.

Not here: uploads. No upload path carries the incognito flag and the `user_file` incognito column does not exist yet, both of which land in the page-mode PR, before any incognito UI is user-reachable.

The five PRs: #13886 the column, this one, then the admin record-mode setting, page mode with the upload lifecycle, and the LLM and usage layer that sends `x-bf-disable-content-logging` to Bifrost.

## How Has This Been Tested?

- Unit: the record-mode policy, and Braintrust and Langfuse suppression including a flag cleared mid-trace.
- External dependency unit, against real Redis, Postgres, and a real file store: a content-free turn keeping its row and token count but no text, tool calls, docs, or citations, while a normal turn still writes them; the context round-trip with its compare-and-set, TTL slide, size caps, and tombstone fencing; a generated blob recorded on the row and deleted with the session; a refused deletion keeping its id for retry; and exclusion from history, search, and a project's list.
- Local Greptile CLI review of this exact content against main with the feature contract as context: confidence 5/5, zero comments.
- `ruff check`, `ruff format --check`, and `ty check` clean. 1007 unit tests pass across chat, tools, and tracing.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
