### PR TITLE
fix(enterprise-settings): validate logo uploads against their bytes

### DIFF
--- a/backend/ee/onyx/server/enterprise_settings/store.py
+++ b/backend/ee/onyx/server/enterprise_settings/store.py
@@ -1,9 +1,11 @@
 import os
+import re
 from io import BytesIO
 from typing import IO, Any, cast
 
 import puremagic
-from fastapi import HTTPException, UploadFile
+from fastapi import UploadFile
+from PIL import Image
 
 from ee.onyx.server.enterprise_settings.models import (
     AnalyticsScriptUpload,
@@ -15,6 +17,8 @@ from onyx.configs.constants import (
     ONYX_DEFAULT_APPLICATION_NAME,
     FileOrigin,
 )
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
 from onyx.key_value_store.factory import get_kv_store
 from onyx.key_value_store.interface import KvKeyNotFoundError
@@ -87,24 +91,43 @@ def store_analytics_script(analytics_script_upload: AnalyticsScriptUpload) -> No
 
 
 def is_valid_file_type(filename: str) -> bool:
-    valid_extensions = (".png", ".jpg", ".jpeg")
-    return filename.endswith(valid_extensions)
+    valid_extensions = (".png", ".jpg", ".jpeg", ".svg")
+    return filename.lower().endswith(valid_extensions)
 
 
 # Readers sniff the stored bytes rather than trust the name or the upload
 # header, so the upload has to agree with them or a file accepted here is
-# rejected later. The PDF usage report is the strict reader: it can only draw
-# raster images, and silently falls back to the bundled mark otherwise.
-_RENDERABLE_LOGO_TYPES = ("image/png", "image/jpeg")
+# stored under a type no reader recognises. SVG is accepted because the web UI
+# draws it; the PDF report cannot, and sets the application name as a wordmark
+# instead of drawing someone else's mark.
+_RASTER_LOGO_TYPES = ("image/png", "image/jpeg")
+_SVG_LOGO_TYPE = "image/svg+xml"
 
 # A logo is a wordmark, not an asset library. This bounds what gets buffered
 # into memory every time the usage report embeds it.
 _MAX_LOGO_BYTES = 5 * 1024 * 1024
 
 _LOGO_TYPE_ERROR = (
-    "Invalid file type- only .png, .jpg, and .jpeg files are allowed. "
-    "Vector formats such as SVG cannot be drawn into the PDF usage report."
+    "Invalid file type- only .png, .jpg, .jpeg, and .svg files are allowed. "
+    "An SVG renders everywhere except the PDF usage report, which falls back "
+    "to your application name."
 )
+
+# puremagic misses SVG whenever an exporter emits an XML declaration, a
+# doctype, or a leading comment, so the root element is checked directly.
+_XML_PROLOGUE = re.compile(
+    r"^(?:\s|<\?[^>]*\?>|<!--.*?-->|<!DOCTYPE[^>]*>)+", re.IGNORECASE | re.DOTALL
+)
+
+
+def _is_svg(content: bytes) -> bool:
+    head = content[:4096].decode("utf-8", errors="ignore").lstrip("\ufeff").lstrip()
+    while True:
+        without_prologue = _XML_PROLOGUE.sub("", head, count=1).lstrip()
+        if without_prologue == head:
+            break
+        head = without_prologue
+    return head.lower().startswith("<svg")
 
 
 def sniff_logo_type(content: bytes) -> str | None:
@@ -112,13 +135,21 @@ def sniff_logo_type(content: bytes) -> str | None:
     try:
         matches = puremagic.magic_string(content)
     except Exception:
-        return None
+        matches = []
 
     for match in matches:
         mime_type = cast(str, match.mime_type)
-        if mime_type in _RENDERABLE_LOGO_TYPES:
+        if mime_type in _RASTER_LOGO_TYPES:
+            try:
+                with Image.open(BytesIO(content)) as image:
+                    image.verify()
+            except Exception:
+                return None
             return mime_type
-    return None
+
+    # SVG has no decode check to run: the web UI draws it and the PDF sets the
+    # application name as a wordmark instead.
+    return _SVG_LOGO_TYPE if _is_svg(content) else None
 
 
 def upload_logo(file: UploadFile | str, is_logotype: bool = False) -> bool:
@@ -145,16 +176,13 @@ def upload_logo(file: UploadFile | str, is_logotype: bool = False) -> bool:
     else:
         logger.notice("Uploading logo from uploaded file")
         if not file.filename or not is_valid_file_type(file.filename):
-            raise HTTPException(
-                status_code=400,
-                detail=_LOGO_TYPE_ERROR,
-            )
+            raise OnyxError(OnyxErrorCode.INVALID_INPUT, _LOGO_TYPE_ERROR)
 
         file_content = file.file.read(_MAX_LOGO_BYTES + 1)
         if len(file_content) > _MAX_LOGO_BYTES:
-            raise HTTPException(
-                status_code=413,
-                detail=f"Logo must be under {_MAX_LOGO_BYTES // (1024 * 1024)} MB.",
+            raise OnyxError(
+                OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                f"Logo must be under {_MAX_LOGO_BYTES // (1024 * 1024)} MB.",
             )
 
         display_name = file.filename
@@ -163,7 +191,7 @@ def upload_logo(file: UploadFile | str, is_logotype: bool = False) -> bool:
         # mislabelled upload would be accepted here and dropped at render time.
         file_type_or_none = sniff_logo_type(file_content)
         if file_type_or_none is None:
-            raise HTTPException(status_code=400, detail=_LOGO_TYPE_ERROR)
+            raise OnyxError(OnyxErrorCode.INVALID_INPUT, _LOGO_TYPE_ERROR)
         file_type = file_type_or_none
 
     content = BytesIO(file_content)

--- a/backend/ee/onyx/server/enterprise_settings/store.py
+++ b/backend/ee/onyx/server/enterprise_settings/store.py
@@ -1,5 +1,4 @@
 import os
-import re
 from io import BytesIO
 from typing import IO, Any, cast
 
@@ -91,51 +90,32 @@ def store_analytics_script(analytics_script_upload: AnalyticsScriptUpload) -> No
 
 
 def is_valid_file_type(filename: str) -> bool:
-    valid_extensions = (".png", ".jpg", ".jpeg", ".svg")
+    valid_extensions = (".png", ".jpg", ".jpeg")
     return filename.lower().endswith(valid_extensions)
 
 
 # Readers sniff the stored bytes rather than trust the name or the upload
 # header, so the upload has to agree with them or a file accepted here is
-# stored under a type no reader recognises. SVG is accepted because the web UI
-# draws it; the PDF report cannot, and sets the application name as a wordmark
-# instead of drawing someone else's mark.
+# stored under a type no reader recognises. Logos are also embedded in email,
+# where every reader uses Pillow, so accept only raster image types.
 _RASTER_LOGO_TYPES = ("image/png", "image/jpeg")
-_SVG_LOGO_TYPE = "image/svg+xml"
 
 # A logo is a wordmark, not an asset library. This bounds what gets buffered
 # into memory every time the usage report embeds it.
 _MAX_LOGO_BYTES = 5 * 1024 * 1024
 
-_LOGO_TYPE_ERROR = (
-    "Invalid file type- only .png, .jpg, .jpeg, and .svg files are allowed. "
-    "An SVG renders everywhere except the PDF usage report, which falls back "
-    "to your application name."
-)
-
-# puremagic misses SVG whenever an exporter emits an XML declaration, a
-# doctype, or a leading comment, so the root element is checked directly.
-_XML_PROLOGUE = re.compile(
-    r"^(?:\s|<\?[^>]*\?>|<!--.*?-->|<!DOCTYPE[^>]*>)+", re.IGNORECASE | re.DOTALL
-)
-
-
-def _is_svg(content: bytes) -> bool:
-    head = content[:4096].decode("utf-8", errors="ignore").lstrip("\ufeff").lstrip()
-    while True:
-        without_prologue = _XML_PROLOGUE.sub("", head, count=1).lstrip()
-        if without_prologue == head:
-            break
-        head = without_prologue
-    return head.lower().startswith("<svg")
+_LOGO_TYPE_ERROR = "Invalid file type- only .png, .jpg, and .jpeg files are allowed."
 
 
 def sniff_logo_type(content: bytes) -> str | None:
     """The stored bytes' real type, or None when nothing can render it."""
     try:
         matches = puremagic.magic_string(content)
+    except puremagic.PureError:
+        return None
     except Exception:
-        matches = []
+        logger.exception("Failed to sniff logo MIME type")
+        return None
 
     for match in matches:
         mime_type = cast(str, match.mime_type)
@@ -147,9 +127,7 @@ def sniff_logo_type(content: bytes) -> str | None:
                 return None
             return mime_type
 
-    # SVG has no decode check to run: the web UI draws it and the PDF sets the
-    # application name as a wordmark instead.
-    return _SVG_LOGO_TYPE if _is_svg(content) else None
+    return None
 
 
 def upload_logo(file: UploadFile | str, is_logotype: bool = False) -> bool:
@@ -164,7 +142,10 @@ def upload_logo(file: UploadFile | str, is_logotype: bool = False) -> bool:
             return False
 
         with open(file, "rb") as file_handle:
-            file_content = file_handle.read()
+            file_content = file_handle.read(_MAX_LOGO_BYTES + 1)
+        if len(file_content) > _MAX_LOGO_BYTES:
+            logger.error("Logo must be under %d MB.", _MAX_LOGO_BYTES // (1024 * 1024))
+            return False
         display_name = file
 
         file_type_or_none = sniff_logo_type(file_content)

--- a/backend/ee/onyx/server/enterprise_settings/store.py
+++ b/backend/ee/onyx/server/enterprise_settings/store.py
@@ -94,14 +94,8 @@ def is_valid_file_type(filename: str) -> bool:
     return filename.lower().endswith(valid_extensions)
 
 
-# Readers sniff the stored bytes rather than trust the name or the upload
-# header, so the upload has to agree with them or a file accepted here is
-# stored under a type no reader recognises. Logos are also embedded in email,
-# where every reader uses Pillow, so accept only raster image types.
 _RASTER_LOGO_TYPES = ("image/png", "image/jpeg")
 
-# A logo is a wordmark, not an asset library. This bounds what gets buffered
-# into memory every time the usage report embeds it.
 _MAX_LOGO_BYTES = 5 * 1024 * 1024
 
 _LOGO_TYPE_ERROR = "Invalid file type- only .png, .jpg, and .jpeg files are allowed."
@@ -168,8 +162,6 @@ def upload_logo(file: UploadFile | str, is_logotype: bool = False) -> bool:
 
         display_name = file.filename
 
-        # An extension is a claim; the bytes are the fact. Readers sniff, so a
-        # mislabelled upload would be accepted here and dropped at render time.
         file_type_or_none = sniff_logo_type(file_content)
         if file_type_or_none is None:
             raise OnyxError(OnyxErrorCode.INVALID_INPUT, _LOGO_TYPE_ERROR)

--- a/backend/ee/onyx/server/enterprise_settings/store.py
+++ b/backend/ee/onyx/server/enterprise_settings/store.py
@@ -2,6 +2,7 @@ import os
 from io import BytesIO
 from typing import IO, Any, cast
 
+import puremagic
 from fastapi import HTTPException, UploadFile
 
 from ee.onyx.server.enterprise_settings.models import (
@@ -90,12 +91,34 @@ def is_valid_file_type(filename: str) -> bool:
     return filename.endswith(valid_extensions)
 
 
-def guess_file_type(filename: str) -> str:
-    if filename.lower().endswith(".png"):
-        return "image/png"
-    elif filename.lower().endswith(".jpg") or filename.lower().endswith(".jpeg"):
-        return "image/jpeg"
-    return "application/octet-stream"
+# Readers sniff the stored bytes rather than trust the name or the upload
+# header, so the upload has to agree with them or a file accepted here is
+# rejected later. The PDF usage report is the strict reader: it can only draw
+# raster images, and silently falls back to the bundled mark otherwise.
+_RENDERABLE_LOGO_TYPES = ("image/png", "image/jpeg")
+
+# A logo is a wordmark, not an asset library. This bounds what gets buffered
+# into memory every time the usage report embeds it.
+_MAX_LOGO_BYTES = 5 * 1024 * 1024
+
+_LOGO_TYPE_ERROR = (
+    "Invalid file type- only .png, .jpg, and .jpeg files are allowed. "
+    "Vector formats such as SVG cannot be drawn into the PDF usage report."
+)
+
+
+def sniff_logo_type(content: bytes) -> str | None:
+    """The stored bytes' real type, or None when nothing can render it."""
+    try:
+        matches = puremagic.magic_string(content)
+    except Exception:
+        return None
+
+    for match in matches:
+        mime_type = cast(str, match.mime_type)
+        if mime_type in _RENDERABLE_LOGO_TYPES:
+            return mime_type
+    return None
 
 
 def upload_logo(file: UploadFile | str, is_logotype: bool = False) -> bool:
@@ -111,20 +134,39 @@ def upload_logo(file: UploadFile | str, is_logotype: bool = False) -> bool:
 
         with open(file, "rb") as file_handle:
             file_content = file_handle.read()
-        content = BytesIO(file_content)
         display_name = file
-        file_type = guess_file_type(file)
+
+        file_type_or_none = sniff_logo_type(file_content)
+        if file_type_or_none is None:
+            logger.error(_LOGO_TYPE_ERROR)
+            return False
+        file_type = file_type_or_none
 
     else:
         logger.notice("Uploading logo from uploaded file")
         if not file.filename or not is_valid_file_type(file.filename):
             raise HTTPException(
                 status_code=400,
-                detail="Invalid file type- only .png, .jpg, and .jpeg files are allowed",
+                detail=_LOGO_TYPE_ERROR,
             )
-        content = file.file
+
+        file_content = file.file.read(_MAX_LOGO_BYTES + 1)
+        if len(file_content) > _MAX_LOGO_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail=f"Logo must be under {_MAX_LOGO_BYTES // (1024 * 1024)} MB.",
+            )
+
         display_name = file.filename
-        file_type = file.content_type or "image/jpeg"
+
+        # An extension is a claim; the bytes are the fact. Readers sniff, so a
+        # mislabelled upload would be accepted here and dropped at render time.
+        file_type_or_none = sniff_logo_type(file_content)
+        if file_type_or_none is None:
+            raise HTTPException(status_code=400, detail=_LOGO_TYPE_ERROR)
+        file_type = file_type_or_none
+
+    content = BytesIO(file_content)
 
     file_store = get_default_file_store()
     file_store.save_file(

--- a/backend/tests/unit/ee/onyx/server/enterprise_settings/test_logo_upload.py
+++ b/backend/tests/unit/ee/onyx/server/enterprise_settings/test_logo_upload.py
@@ -1,5 +1,3 @@
-"""Logo uploads must match the readers that render the stored bytes."""
-
 from io import BytesIO
 from unittest.mock import MagicMock, mock_open, patch
 
@@ -58,7 +56,6 @@ def test_sniffs_the_real_type() -> None:
 
 
 def test_an_svg_named_png_is_rejected() -> None:
-    """All logo readers, including email rendering, require raster images."""
     with pytest.raises(OnyxError) as caught:
         _upload(_SVG, "logo.png")
 
@@ -73,7 +70,6 @@ def test_bytes_that_are_not_an_image_are_rejected() -> None:
 
 
 def test_a_truncated_png_is_rejected() -> None:
-    """Magic bytes alone aren't renderability; PIL must decode the file."""
     with pytest.raises(OnyxError) as caught:
         _upload(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100, "logo.png")
 
@@ -81,7 +77,6 @@ def test_a_truncated_png_is_rejected() -> None:
 
 
 def test_a_seeded_logo_path_is_validated_too() -> None:
-    """`seeding.py` uploads by path, so that branch sniffs bytes as well."""
     store = MagicMock()
     with patch(
         "ee.onyx.server.enterprise_settings.store.get_default_file_store",

--- a/backend/tests/unit/ee/onyx/server/enterprise_settings/test_logo_upload.py
+++ b/backend/tests/unit/ee/onyx/server/enterprise_settings/test_logo_upload.py
@@ -9,14 +9,17 @@ from io import BytesIO
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
-from fastapi import HTTPException, UploadFile
+from fastapi import UploadFile
 from PIL import Image
+from starlette.datastructures import Headers
 
 from ee.onyx.server.enterprise_settings.store import (
     _MAX_LOGO_BYTES,
     sniff_logo_type,
     upload_logo,
 )
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 
 _SVG = b'<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>'
 
@@ -33,8 +36,14 @@ def _jpeg() -> bytes:
     return buffer.getvalue()
 
 
-def _upload(content: bytes, filename: str) -> MagicMock:
-    upload = UploadFile(file=BytesIO(content), filename=filename)
+def _upload(
+    content: bytes, filename: str, content_type: str | None = None
+) -> MagicMock:
+    upload = UploadFile(
+        file=BytesIO(content),
+        filename=filename,
+        headers=Headers({"content-type": content_type}) if content_type else None,
+    )
     store = MagicMock()
     with patch(
         "ee.onyx.server.enterprise_settings.store.get_default_file_store",
@@ -47,23 +56,32 @@ def _upload(content: bytes, filename: str) -> MagicMock:
 def test_sniffs_the_real_type() -> None:
     assert sniff_logo_type(_png()) == "image/png"
     assert sniff_logo_type(_jpeg()) == "image/jpeg"
-    assert sniff_logo_type(_SVG) is None
+    assert sniff_logo_type(_SVG) == "image/svg+xml"
     assert sniff_logo_type(b"not-an-image") is None
     assert sniff_logo_type(b"") is None
+    assert sniff_logo_type(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100) is None
 
 
-def test_an_svg_disguised_as_png_is_rejected() -> None:
-    """The bug: this passed the extension check and failed at render time."""
-    with pytest.raises(HTTPException) as caught:
-        _upload(_SVG, "logo.png")
+def test_an_svg_named_png_is_stored_as_an_svg() -> None:
+    """The name is a claim, the bytes are the fact. SVG is allowed: the web UI
+    draws it, and the PDF report sets a wordmark rather than another company's
+    mark."""
+    store = _upload(_SVG, "logo.png")
 
-    assert caught.value.status_code == 400
-    assert "SVG" in caught.value.detail
+    assert store.save_file.call_args.kwargs["file_type"] == "image/svg+xml"
 
 
 def test_bytes_that_are_not_an_image_are_rejected() -> None:
-    with pytest.raises(HTTPException) as caught:
+    with pytest.raises(OnyxError) as caught:
         _upload(b"still not an image", "logo.jpg")
+
+    assert caught.value.status_code == 400
+
+
+def test_a_truncated_png_is_rejected() -> None:
+    """Magic bytes alone aren't renderability; PIL must decode the file."""
+    with pytest.raises(OnyxError) as caught:
+        _upload(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100, "logo.png")
 
     assert caught.value.status_code == 400
 
@@ -76,23 +94,24 @@ def test_a_seeded_logo_path_is_validated_too() -> None:
         return_value=store,
     ):
         with patch("os.path.isfile", return_value=True):
-            with patch("builtins.open", mock_open(read_data=_SVG)):
+            with patch("builtins.open", mock_open(read_data=b"not an image")):
                 assert upload_logo(file="seeded.png") is False
             with patch("builtins.open", mock_open(read_data=_png())):
                 assert upload_logo(file="seeded.png") is True
 
 
 def test_the_stored_type_comes_from_the_bytes_not_the_header() -> None:
-    store = _upload(_png(), "logo.png")
+    store = _upload(_png(), "logo.png", content_type="image/jpeg")
 
     assert store.save_file.call_args.kwargs["file_type"] == "image/png"
 
 
 def test_an_oversized_logo_is_rejected() -> None:
-    with pytest.raises(HTTPException) as caught:
+    with pytest.raises(OnyxError) as caught:
         _upload(b"\x89PNG" + b"\x00" * (_MAX_LOGO_BYTES + 1), "logo.png")
 
     assert caught.value.status_code == 413
+    assert caught.value.error_code == OnyxErrorCode.PAYLOAD_TOO_LARGE
 
 
 def test_a_real_png_is_accepted() -> None:

--- a/backend/tests/unit/ee/onyx/server/enterprise_settings/test_logo_upload.py
+++ b/backend/tests/unit/ee/onyx/server/enterprise_settings/test_logo_upload.py
@@ -1,9 +1,4 @@
-"""Logo uploads must agree with the readers that sniff the stored bytes.
-
-An extension check accepted an SVG named `.png` and stored the browser's
-Content-Type, so the PDF usage report later sniffed the real type, rejected it,
-and silently shipped the bundled mark instead.
-"""
+"""Logo uploads must match the readers that render the stored bytes."""
 
 from io import BytesIO
 from unittest.mock import MagicMock, mock_open, patch
@@ -56,19 +51,18 @@ def _upload(
 def test_sniffs_the_real_type() -> None:
     assert sniff_logo_type(_png()) == "image/png"
     assert sniff_logo_type(_jpeg()) == "image/jpeg"
-    assert sniff_logo_type(_SVG) == "image/svg+xml"
+    assert sniff_logo_type(_SVG) is None
     assert sniff_logo_type(b"not-an-image") is None
     assert sniff_logo_type(b"") is None
     assert sniff_logo_type(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100) is None
 
 
-def test_an_svg_named_png_is_stored_as_an_svg() -> None:
-    """The name is a claim, the bytes are the fact. SVG is allowed: the web UI
-    draws it, and the PDF report sets a wordmark rather than another company's
-    mark."""
-    store = _upload(_SVG, "logo.png")
+def test_an_svg_named_png_is_rejected() -> None:
+    """All logo readers, including email rendering, require raster images."""
+    with pytest.raises(OnyxError) as caught:
+        _upload(_SVG, "logo.png")
 
-    assert store.save_file.call_args.kwargs["file_type"] == "image/svg+xml"
+    assert caught.value.status_code == 400
 
 
 def test_bytes_that_are_not_an_image_are_rejected() -> None:
@@ -98,6 +92,22 @@ def test_a_seeded_logo_path_is_validated_too() -> None:
                 assert upload_logo(file="seeded.png") is False
             with patch("builtins.open", mock_open(read_data=_png())):
                 assert upload_logo(file="seeded.png") is True
+
+
+def test_an_oversized_seeded_logo_is_rejected() -> None:
+    store = MagicMock()
+    with patch(
+        "ee.onyx.server.enterprise_settings.store.get_default_file_store",
+        return_value=store,
+    ):
+        with patch("os.path.isfile", return_value=True):
+            with patch(
+                "builtins.open",
+                mock_open(read_data=b"x" * (_MAX_LOGO_BYTES + 1)),
+            ):
+                assert upload_logo(file="seeded.png") is False
+
+    assert not store.save_file.called
 
 
 def test_the_stored_type_comes_from_the_bytes_not_the_header() -> None:

--- a/backend/tests/unit/ee/onyx/server/enterprise_settings/test_logo_upload.py
+++ b/backend/tests/unit/ee/onyx/server/enterprise_settings/test_logo_upload.py
@@ -1,0 +1,101 @@
+"""Logo uploads must agree with the readers that sniff the stored bytes.
+
+An extension check accepted an SVG named `.png` and stored the browser's
+Content-Type, so the PDF usage report later sniffed the real type, rejected it,
+and silently shipped the bundled mark instead.
+"""
+
+from io import BytesIO
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+from fastapi import HTTPException, UploadFile
+from PIL import Image
+
+from ee.onyx.server.enterprise_settings.store import (
+    _MAX_LOGO_BYTES,
+    sniff_logo_type,
+    upload_logo,
+)
+
+_SVG = b'<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>'
+
+
+def _png(width: int = 8, height: int = 8) -> bytes:
+    buffer = BytesIO()
+    Image.new("RGBA", (width, height), (0, 0, 0, 255)).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _jpeg() -> bytes:
+    buffer = BytesIO()
+    Image.new("RGB", (8, 8), (0, 0, 0)).save(buffer, format="JPEG")
+    return buffer.getvalue()
+
+
+def _upload(content: bytes, filename: str) -> MagicMock:
+    upload = UploadFile(file=BytesIO(content), filename=filename)
+    store = MagicMock()
+    with patch(
+        "ee.onyx.server.enterprise_settings.store.get_default_file_store",
+        return_value=store,
+    ):
+        upload_logo(file=upload)
+    return store
+
+
+def test_sniffs_the_real_type() -> None:
+    assert sniff_logo_type(_png()) == "image/png"
+    assert sniff_logo_type(_jpeg()) == "image/jpeg"
+    assert sniff_logo_type(_SVG) is None
+    assert sniff_logo_type(b"not-an-image") is None
+    assert sniff_logo_type(b"") is None
+
+
+def test_an_svg_disguised_as_png_is_rejected() -> None:
+    """The bug: this passed the extension check and failed at render time."""
+    with pytest.raises(HTTPException) as caught:
+        _upload(_SVG, "logo.png")
+
+    assert caught.value.status_code == 400
+    assert "SVG" in caught.value.detail
+
+
+def test_bytes_that_are_not_an_image_are_rejected() -> None:
+    with pytest.raises(HTTPException) as caught:
+        _upload(b"still not an image", "logo.jpg")
+
+    assert caught.value.status_code == 400
+
+
+def test_a_seeded_logo_path_is_validated_too() -> None:
+    """`seeding.py` uploads by path, so that branch sniffs bytes as well."""
+    store = MagicMock()
+    with patch(
+        "ee.onyx.server.enterprise_settings.store.get_default_file_store",
+        return_value=store,
+    ):
+        with patch("os.path.isfile", return_value=True):
+            with patch("builtins.open", mock_open(read_data=_SVG)):
+                assert upload_logo(file="seeded.png") is False
+            with patch("builtins.open", mock_open(read_data=_png())):
+                assert upload_logo(file="seeded.png") is True
+
+
+def test_the_stored_type_comes_from_the_bytes_not_the_header() -> None:
+    store = _upload(_png(), "logo.png")
+
+    assert store.save_file.call_args.kwargs["file_type"] == "image/png"
+
+
+def test_an_oversized_logo_is_rejected() -> None:
+    with pytest.raises(HTTPException) as caught:
+        _upload(b"\x89PNG" + b"\x00" * (_MAX_LOGO_BYTES + 1), "logo.png")
+
+    assert caught.value.status_code == 413
+
+
+def test_a_real_png_is_accepted() -> None:
+    store = _upload(_png(), "logo.png")
+
+    assert store.save_file.called


### PR DESCRIPTION
## Description

Validate enterprise logo uploads against their actual bytes before storage.

- Accept verified PNG and JPEG logos, regardless of filename casing.
- Store the detected MIME type instead of the upload header or filename.
- Reject SVGs, corrupt raster files, non-images, and uploads over 5 MB.
- Apply the same byte validation and size limit to seeded logo paths.

## How Has This Been Tested?

- `uv run pytest -xv backend/tests/unit/ee/onyx/server/enterprise_settings/test_logo_upload.py`
- `pre-commit run --files backend/ee/onyx/server/enterprise_settings/store.py backend/tests/unit/ee/onyx/server/enterprise_settings/test_logo_upload.py`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
