### PR TITLE
ci: skip type checking in the Playwright web image build

### DIFF
--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -205,6 +205,8 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
+      # SKIP_TYPE_CHECK cuts the build time of this image. Types are still checked
+      # by the `typescript-check` prek hook in the Quality Checks PR workflow.
       - name: Build and push Web Docker image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
@@ -215,6 +217,7 @@ jobs:
           push: true
           build-args: |
             BASE_IMAGE_REGISTRY=${{ env.BASE_IMAGE_REGISTRY }}
+            SKIP_TYPE_CHECK=1
           cache-from: |
             type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:web-cache-${{ github.event.pull_request.head.sha || github.sha }}
             type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:web-cache-${{ steps.format-branch.outputs.cache-suffix }}


### PR DESCRIPTION
## Description

Building the web image is a long pole in Playwright CI, and type checking is a large part of it. This passes `SKIP_TYPE_CHECK=1` (added in #13848) as a build arg to the Playwright web image build.

Types are still checked on every PR: the `typescript-check` prek hook in the Quality Checks PR workflow runs `bun run types:check`. The image build was repeating that work.

Scope note: the five release builds in `deployment.yml` are unchanged. They publish images to Docker Hub, and the prek hook covers all files only on `main` pushes — not on `v*` tags.

## How Has This Been Tested?

CI on this PR — the Playwright job builds and runs against this image. The first build misses the Docker cache, because the new `ENV SKIP_TYPE_CHECK` layer changes the builder stage hash.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip TypeScript checking in the Playwright web Docker image build by passing `SKIP_TYPE_CHECK=1` to speed up CI. Types are still validated in the Quality Checks PR workflow via the `typescript-check` prek hook (`bun run types:check`).

<sup>Written for commit 060ad724757155c6585a7fcb577861737e898a2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

