### PR TITLE
feat: publish MCP OAuth client metadata

### DIFF
--- a/backend/ee/onyx/configs/license_enforcement_config.py
+++ b/backend/ee/onyx/configs/license_enforcement_config.py
@@ -28,6 +28,7 @@ from onyx.server.settings.models import Tier
 #   /settings, /enterprise-settings - View app status and branding
 #   /billing - Unified billing API
 #   /proxy - Self-hosted proxy endpoints (have own license-based auth)
+#   /mcp/oauth/client-metadata - Public OAuth client identity
 #   /tenants/billing-* - Legacy billing endpoints (backwards compatibility)
 #   /manage/users, /users - User management (needed for seat limit resolution)
 #   /notifications - Needed for UI to load properly
@@ -44,6 +45,7 @@ LICENSE_ENFORCEMENT_ALLOWED_PREFIXES: frozenset[str] = frozenset(
         "/admin/billing",
         # Proxy endpoints for self-hosted billing (no tenant context)
         "/proxy",
+        "/mcp/oauth/client-metadata",
         # Legacy tenant billing endpoints (kept for backwards compatibility)
         "/tenants/billing-information",
         "/tenants/create-customer-portal-session",

--- a/backend/onyx/server/auth_check.py
+++ b/backend/onyx/server/auth_check.py
@@ -68,6 +68,7 @@ PUBLIC_ENDPOINT_SPECS = [
     # oauth
     ("/auth/oauth/authorize", {"GET"}),
     ("/auth/oauth/callback", {"GET"}),
+    ("/mcp/oauth/client-metadata", {"GET"}),
     # dedicated mobile google oauth (callback routes to the api_server, not the web app)
     ("/auth/mobile/oauth/authorize", {"GET"}),
     ("/auth/mobile/oauth/callback", {"GET"}),

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -86,6 +86,12 @@ from onyx.server.features.mcp.client import (
     discover_mcp_tools,
     log_exception_group,
 )
+from onyx.server.features.mcp.client_metadata import (
+    mcp_oauth_redirect_uri,
+)
+from onyx.server.features.mcp.client_metadata import (
+    router as client_metadata_router,
+)
 from onyx.server.features.mcp.models import (
     MCPApiKeyResponse,
     MCPAuthTemplate,
@@ -560,6 +566,7 @@ def _upsert_user_template_config(
 
 
 router = APIRouter(prefix="/mcp")
+router.include_router(client_metadata_router)
 admin_router = APIRouter(prefix="/admin/mcp")
 
 HEADER_SUBSTITUTIONS: Literal["header_substitutions"] = "header_substitutions"
@@ -619,13 +626,6 @@ def make_pkce_pair() -> tuple[str, str]:
     verifier = b64url(token_urlsafe(64).encode())
     challenge = b64url(hashlib.sha256(verifier.encode("ascii")).digest())
     return verifier, challenge
-
-
-MCP_OAUTH_CALLBACK_PATH = "/mcp/oauth/callback"
-
-
-def _mcp_oauth_redirect_uri() -> str:
-    return f"{WEB_DOMAIN}{MCP_OAUTH_CALLBACK_PATH}"
 
 
 def _mcp_known_provider_flow_params(
@@ -871,7 +871,7 @@ async def _connect_oauth(
 
         oauth_url = build_oauth_authorization_url(
             _mcp_known_provider_flow_params(mcp_server, client_info),
-            _mcp_oauth_redirect_uri(),
+            mcp_oauth_redirect_uri(),
             state,
             code_challenge=code_challenge,
             resource=(
@@ -991,7 +991,7 @@ async def process_oauth_callback(
             token_payload = exchange_oauth_code_for_token(
                 _mcp_known_provider_flow_params(mcp_server, client_info),
                 code,
-                _mcp_oauth_redirect_uri(),
+                mcp_oauth_redirect_uri(),
                 code_verifier=state_data.code_verifier,
             )
         except (SSRFException, ValueError) as e:

--- a/backend/onyx/server/features/mcp/client_metadata.py
+++ b/backend/onyx/server/features/mcp/client_metadata.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, Response
+from pydantic import AnyUrl
+
+from onyx.configs.app_configs import WEB_DOMAIN
+from onyx.configs.constants import ONYX_DEFAULT_APPLICATION_NAME, PUBLIC_API_TAGS
+from onyx.server.features.mcp.models import MCPOAuthClientMetadataDocument
+
+MCP_OAUTH_CALLBACK_PATH = "/mcp/oauth/callback"
+MCP_OAUTH_CLIENT_METADATA_ROUTE = "/oauth/client-metadata"
+MCP_OAUTH_CLIENT_METADATA_PUBLIC_PATH = "/api/mcp/oauth/client-metadata"
+MCP_OAUTH_CLIENT_METADATA_CACHE_CONTROL = "public, max-age=3600"
+
+AUTHORIZATION_CODE_GRANT = "authorization_code"
+REFRESH_TOKEN_GRANT = "refresh_token"
+CODE_RESPONSE_TYPE = "code"
+PUBLIC_CLIENT_AUTH_METHOD = "none"
+
+router = APIRouter()
+
+
+def mcp_oauth_redirect_uri() -> str:
+    return f"{WEB_DOMAIN.rstrip('/')}{MCP_OAUTH_CALLBACK_PATH}"
+
+
+def mcp_oauth_client_metadata_url() -> str:
+    return f"{WEB_DOMAIN.rstrip('/')}{MCP_OAUTH_CLIENT_METADATA_PUBLIC_PATH}"
+
+
+def build_mcp_oauth_client_metadata() -> MCPOAuthClientMetadataDocument:
+    return MCPOAuthClientMetadataDocument(
+        client_id=AnyUrl(mcp_oauth_client_metadata_url()),
+        client_name=ONYX_DEFAULT_APPLICATION_NAME,
+        redirect_uris=[AnyUrl(mcp_oauth_redirect_uri())],
+        grant_types=[AUTHORIZATION_CODE_GRANT, REFRESH_TOKEN_GRANT],
+        response_types=[CODE_RESPONSE_TYPE],
+        token_endpoint_auth_method=PUBLIC_CLIENT_AUTH_METHOD,
+    )
+
+
+@router.get(MCP_OAUTH_CLIENT_METADATA_ROUTE, tags=PUBLIC_API_TAGS)
+def get_mcp_oauth_client_metadata(
+    response: Response,
+) -> MCPOAuthClientMetadataDocument:
+    response.headers["Cache-Control"] = MCP_OAUTH_CLIENT_METADATA_CACHE_CONTROL
+    return build_mcp_oauth_client_metadata()

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -1,11 +1,11 @@
 import datetime
 import re
 from enum import Enum
-from typing import Any, List, NotRequired, Optional, TypedDict
+from typing import Any, List, Literal, NotRequired, Optional, TypedDict
 from uuid import UUID
 
 from mcp.types import Tool as MCPLibTool
-from pydantic import BaseModel, Field, model_validator
+from pydantic import AnyUrl, BaseModel, Field, model_validator
 
 from onyx.db.enums import (
     EndpointPolicy,
@@ -539,6 +539,15 @@ class MCPOAuthCallbackResponse(BaseModel):
     server_id: int
     server_name: str
     redirect_url: str
+
+
+class MCPOAuthClientMetadataDocument(BaseModel):
+    client_id: AnyUrl
+    client_name: str
+    redirect_uris: list[AnyUrl]
+    grant_types: list[Literal["authorization_code", "refresh_token"]]
+    response_types: list[Literal["code"]]
+    token_endpoint_auth_method: Literal["none"]
 
 
 class MCPDynamicClientRegistrationRequest(BaseModel):

--- a/backend/tests/unit/ee/onyx/server/middleware/test_license_enforcement.py
+++ b/backend/tests/unit/ee/onyx/server/middleware/test_license_enforcement.py
@@ -51,6 +51,7 @@ class TestPathAllowlist:
         """Subpaths of allowed prefixes should also be allowed."""
         assert _is_path_allowed("/auth/callback/google") is True
         assert _is_path_allowed("/admin/billing/checkout") is True
+        assert _is_path_allowed("/mcp/oauth/client-metadata") is True
 
     def test_custom_api_prefix_allowlist(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(api_prefix, "APP_API_PREFIX", "v2")

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_client_metadata_document.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_client_metadata_document.py
@@ -1,0 +1,40 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from onyx.server.auth_check import PUBLIC_ENDPOINT_SPECS, is_route_in_spec_list
+from onyx.server.features.mcp import client_metadata
+
+TEST_WEB_DOMAIN = "https://onyx.example.com"
+METADATA_ROUTE = "/mcp/oauth/client-metadata"
+
+
+def _build_test_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(client_metadata.router, prefix="/mcp")
+    return app
+
+
+def test_mcp_oauth_client_metadata_document_is_public_and_cacheable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(client_metadata, "WEB_DOMAIN", f"{TEST_WEB_DOMAIN}/")
+    app = _build_test_app()
+
+    response = TestClient(app).get(METADATA_ROUTE)
+
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "public, max-age=3600"
+    assert response.json() == {
+        "client_id": f"{TEST_WEB_DOMAIN}/api/mcp/oauth/client-metadata",
+        "client_name": "Onyx",
+        "redirect_uris": [f"{TEST_WEB_DOMAIN}/mcp/oauth/callback"],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+    }
+
+    metadata_route = next(
+        route for route in app.routes if getattr(route, "path", "") == METADATA_ROUTE
+    )
+    assert is_route_in_spec_list(metadata_route, PUBLIC_ENDPOINT_SPECS)


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose MCP OAuth client metadata via a public, cacheable endpoint to support dynamic registration and simplify OAuth flows. Adds `GET /mcp/oauth/client-metadata` and centralizes the OAuth redirect URI.

- **New Features**
  - Added `GET /mcp/oauth/client-metadata` (public, cacheable for 1 hour).
  - Returns `MCPOAuthClientMetadataDocument` with `client_id` at `/api/mcp/oauth/client-metadata`, `redirect_uris` including `/mcp/oauth/callback`, `grant_types` `authorization_code` and `refresh_token`, `response_types` `code`, and `token_endpoint_auth_method` `none`.
  - Endpoint added to public endpoint specs and license allowlist.
  - Unit tests cover document shape, caching, and public route status.

- **Refactors**
  - Centralized `mcp_oauth_redirect_uri()` and updated OAuth flows to use it.
  - Included the client metadata router under the `/mcp` API.

<sup>Written for commit 968f754633184dd1c0ea59ad5beb02888e452aa5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

