### PR TITLE
feat: use client metadata during MCP OAuth discovery

### DIFF
--- a/backend/ee/onyx/configs/license_enforcement_config.py
+++ b/backend/ee/onyx/configs/license_enforcement_config.py
@@ -28,6 +28,7 @@ from onyx.server.settings.models import Tier
 #   /settings, /enterprise-settings - View app status and branding
 #   /billing - Unified billing API
 #   /proxy - Self-hosted proxy endpoints (have own license-based auth)
+#   /mcp/oauth/client-metadata - Public OAuth client identity
 #   /tenants/billing-* - Legacy billing endpoints (backwards compatibility)
 #   /manage/users, /users - User management (needed for seat limit resolution)
 #   /notifications - Needed for UI to load properly
@@ -44,6 +45,7 @@ LICENSE_ENFORCEMENT_ALLOWED_PREFIXES: frozenset[str] = frozenset(
         "/admin/billing",
         # Proxy endpoints for self-hosted billing (no tenant context)
         "/proxy",
+        "/mcp/oauth/client-metadata",
         # Legacy tenant billing endpoints (kept for backwards compatibility)
         "/tenants/billing-information",
         "/tenants/create-customer-portal-session",

--- a/backend/onyx/server/auth_check.py
+++ b/backend/onyx/server/auth_check.py
@@ -68,6 +68,7 @@ PUBLIC_ENDPOINT_SPECS = [
     # oauth
     ("/auth/oauth/authorize", {"GET"}),
     ("/auth/oauth/callback", {"GET"}),
+    ("/mcp/oauth/client-metadata", {"GET"}),
     # dedicated mobile google oauth (callback routes to the api_server, not the web app)
     ("/auth/mobile/oauth/authorize", {"GET"}),
     ("/auth/mobile/oauth/callback", {"GET"}),

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -86,6 +86,12 @@ from onyx.server.features.mcp.client import (
     discover_mcp_tools,
     log_exception_group,
 )
+from onyx.server.features.mcp.client_metadata import (
+    mcp_oauth_redirect_uri,
+)
+from onyx.server.features.mcp.client_metadata import (
+    router as client_metadata_router,
+)
 from onyx.server.features.mcp.models import (
     MCPApiKeyResponse,
     MCPAuthTemplate,
@@ -560,6 +566,7 @@ def _upsert_user_template_config(
 
 
 router = APIRouter(prefix="/mcp")
+router.include_router(client_metadata_router)
 admin_router = APIRouter(prefix="/admin/mcp")
 
 HEADER_SUBSTITUTIONS: Literal["header_substitutions"] = "header_substitutions"
@@ -619,13 +626,6 @@ def make_pkce_pair() -> tuple[str, str]:
     verifier = b64url(token_urlsafe(64).encode())
     challenge = b64url(hashlib.sha256(verifier.encode("ascii")).digest())
     return verifier, challenge
-
-
-MCP_OAUTH_CALLBACK_PATH = "/mcp/oauth/callback"
-
-
-def _mcp_oauth_redirect_uri() -> str:
-    return f"{WEB_DOMAIN}{MCP_OAUTH_CALLBACK_PATH}"
 
 
 def _mcp_known_provider_flow_params(
@@ -871,7 +871,7 @@ async def _connect_oauth(
 
         oauth_url = build_oauth_authorization_url(
             _mcp_known_provider_flow_params(mcp_server, client_info),
-            _mcp_oauth_redirect_uri(),
+            mcp_oauth_redirect_uri(),
             state,
             code_challenge=code_challenge,
             resource=(
@@ -991,7 +991,7 @@ async def process_oauth_callback(
             token_payload = exchange_oauth_code_for_token(
                 _mcp_known_provider_flow_params(mcp_server, client_info),
                 code,
-                _mcp_oauth_redirect_uri(),
+                mcp_oauth_redirect_uri(),
                 code_verifier=state_data.code_verifier,
             )
         except (SSRFException, ValueError) as e:

--- a/backend/onyx/server/features/mcp/client_metadata.py
+++ b/backend/onyx/server/features/mcp/client_metadata.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Response
+from mcp.client.auth.utils import is_valid_client_metadata_url
 from pydantic import AnyUrl
 
 from onyx.configs.app_configs import WEB_DOMAIN
@@ -24,6 +25,11 @@ def mcp_oauth_redirect_uri() -> str:
 
 def mcp_oauth_client_metadata_url() -> str:
     return f"{WEB_DOMAIN.rstrip('/')}{MCP_OAUTH_CLIENT_METADATA_PUBLIC_PATH}"
+
+
+def validated_mcp_oauth_client_metadata_url() -> str | None:
+    metadata_url = mcp_oauth_client_metadata_url()
+    return metadata_url if is_valid_client_metadata_url(metadata_url) else None
 
 
 def build_mcp_oauth_client_metadata() -> MCPOAuthClientMetadataDocument:

--- a/backend/onyx/server/features/mcp/client_metadata.py
+++ b/backend/onyx/server/features/mcp/client_metadata.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, Response
+from pydantic import AnyUrl
+
+from onyx.configs.app_configs import WEB_DOMAIN
+from onyx.configs.constants import ONYX_DEFAULT_APPLICATION_NAME, PUBLIC_API_TAGS
+from onyx.server.features.mcp.models import MCPOAuthClientMetadataDocument
+
+MCP_OAUTH_CALLBACK_PATH = "/mcp/oauth/callback"
+MCP_OAUTH_CLIENT_METADATA_ROUTE = "/oauth/client-metadata"
+MCP_OAUTH_CLIENT_METADATA_PUBLIC_PATH = "/api/mcp/oauth/client-metadata"
+MCP_OAUTH_CLIENT_METADATA_CACHE_CONTROL = "public, max-age=3600"
+
+AUTHORIZATION_CODE_GRANT = "authorization_code"
+REFRESH_TOKEN_GRANT = "refresh_token"
+CODE_RESPONSE_TYPE = "code"
+PUBLIC_CLIENT_AUTH_METHOD = "none"
+
+router = APIRouter()
+
+
+def mcp_oauth_redirect_uri() -> str:
+    return f"{WEB_DOMAIN.rstrip('/')}{MCP_OAUTH_CALLBACK_PATH}"
+
+
+def mcp_oauth_client_metadata_url() -> str:
+    return f"{WEB_DOMAIN.rstrip('/')}{MCP_OAUTH_CLIENT_METADATA_PUBLIC_PATH}"
+
+
+def build_mcp_oauth_client_metadata() -> MCPOAuthClientMetadataDocument:
+    return MCPOAuthClientMetadataDocument(
+        client_id=AnyUrl(mcp_oauth_client_metadata_url()),
+        client_name=ONYX_DEFAULT_APPLICATION_NAME,
+        redirect_uris=[AnyUrl(mcp_oauth_redirect_uri())],
+        grant_types=[AUTHORIZATION_CODE_GRANT, REFRESH_TOKEN_GRANT],
+        response_types=[CODE_RESPONSE_TYPE],
+        token_endpoint_auth_method=PUBLIC_CLIENT_AUTH_METHOD,
+    )
+
+
+@router.get(MCP_OAUTH_CLIENT_METADATA_ROUTE, tags=PUBLIC_API_TAGS)
+def get_mcp_oauth_client_metadata(
+    response: Response,
+) -> MCPOAuthClientMetadataDocument:
+    response.headers["Cache-Control"] = MCP_OAUTH_CLIENT_METADATA_CACHE_CONTROL
+    return build_mcp_oauth_client_metadata()

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -348,9 +348,8 @@ class MCPToolCreateRequest(BaseModel):
                     "admin_credentials is required when auth_performer is 'per_user'"
                 )
 
-        # OAuth client ID/secret are optional. If provided, they will seed the
-        # OAuth client info; otherwise, the MCP client will attempt dynamic
-        # client registration.
+        # OAuth client ID/secret are optional. Without them, auto-discovery
+        # attempts CIMD before falling back to dynamic client registration.
         if self.auth_type != MCPAuthenticationType.OAUTH:
             self.oauth_provider_mode = MCPOAuthProviderMode.AUTO_DISCOVERY
             self.oauth_authorization_endpoint = None
@@ -491,10 +490,10 @@ class MCPUserOAuthConnectRequest(BaseModel):
         description="Ignore stored OAuth tokens and start a fresh authorization flow",
     )
     oauth_client_id: str | None = Field(
-        None, description="OAuth client ID (optional for DCR)"
+        None, description="OAuth client ID (optional for CIMD or DCR)"
     )
     oauth_client_secret: str | None = Field(
-        None, description="OAuth client secret (optional for DCR)"
+        None, description="OAuth client secret (optional for CIMD or DCR)"
     )
     oauth_client_id_changed: bool = Field(
         default=False,

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -1,11 +1,11 @@
 import datetime
 import re
 from enum import Enum
-from typing import Any, List, NotRequired, Optional, TypedDict
+from typing import Any, List, Literal, NotRequired, Optional, TypedDict
 from uuid import UUID
 
 from mcp.types import Tool as MCPLibTool
-from pydantic import BaseModel, Field, model_validator
+from pydantic import AnyUrl, BaseModel, Field, model_validator
 
 from onyx.db.enums import (
     EndpointPolicy,
@@ -539,6 +539,15 @@ class MCPOAuthCallbackResponse(BaseModel):
     server_id: int
     server_name: str
     redirect_url: str
+
+
+class MCPOAuthClientMetadataDocument(BaseModel):
+    client_id: AnyUrl
+    client_name: str
+    redirect_uris: list[AnyUrl]
+    grant_types: list[Literal["authorization_code", "refresh_token"]]
+    response_types: list[Literal["code"]]
+    token_endpoint_auth_method: Literal["none"]
 
 
 class MCPDynamicClientRegistrationRequest(BaseModel):

--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -33,7 +33,6 @@ from sqlalchemy.orm import Session
 
 from onyx.cache.interface import CacheLockAcquisitionError
 from onyx.cache.locks import cache_shared_lock
-from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import MCPOAuthProviderMode, MCPTransport
 from onyx.db.mcp import (
@@ -46,6 +45,10 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.mcp.client import initialize_mcp_client
+from onyx.server.features.mcp.client_metadata import (
+    mcp_oauth_redirect_uri,
+    validated_mcp_oauth_client_metadata_url,
+)
 from onyx.server.features.mcp.models import (
     DENYLISTED_MCP_HEADERS,
     MCPConnectionData,
@@ -911,12 +914,17 @@ def make_oauth_provider(
         refresh_log_context,
         load_stored_tokens=load_stored_tokens,
     )
+    client_metadata_url = (
+        validated_mcp_oauth_client_metadata_url()
+        if mcp_server.oauth_provider_mode is MCPOAuthProviderMode.AUTO_DISCOVERY
+        else None
+    )
     provider = OnyxOAuthClientProvider(
         refresh_log_context=refresh_log_context,
         server_url=mcp_server.server_url,
         client_metadata=OAuthClientMetadata(
             client_name=f"Onyx - {mcp_server.name}",
-            redirect_uris=[AnyUrl(f"{WEB_DOMAIN}/mcp/oauth/callback")],
+            redirect_uris=[AnyUrl(mcp_oauth_redirect_uri())],
             grant_types=["authorization_code", "refresh_token"],
             response_types=["code"],
             scope=REQUESTED_SCOPE,  # TODO(evan): do we need to pass this in? maybe make configurable
@@ -925,6 +933,7 @@ def make_oauth_provider(
         storage=storage,
         redirect_handler=redirect_handler,
         callback_handler=callback_handler,
+        client_metadata_url=client_metadata_url,
     )
 
     # A fresh provider per tool call starts with an empty context, so the SDK

--- a/backend/tests/unit/ee/onyx/server/middleware/test_license_enforcement.py
+++ b/backend/tests/unit/ee/onyx/server/middleware/test_license_enforcement.py
@@ -51,6 +51,7 @@ class TestPathAllowlist:
         """Subpaths of allowed prefixes should also be allowed."""
         assert _is_path_allowed("/auth/callback/google") is True
         assert _is_path_allowed("/admin/billing/checkout") is True
+        assert _is_path_allowed("/mcp/oauth/client-metadata") is True
 
     def test_custom_api_prefix_allowlist(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(api_prefix, "APP_API_PREFIX", "v2")

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_client_metadata_document.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_client_metadata_document.py
@@ -1,0 +1,40 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from onyx.server.auth_check import PUBLIC_ENDPOINT_SPECS, is_route_in_spec_list
+from onyx.server.features.mcp import client_metadata
+
+TEST_WEB_DOMAIN = "https://onyx.example.com"
+METADATA_ROUTE = "/mcp/oauth/client-metadata"
+
+
+def _build_test_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(client_metadata.router, prefix="/mcp")
+    return app
+
+
+def test_mcp_oauth_client_metadata_document_is_public_and_cacheable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(client_metadata, "WEB_DOMAIN", f"{TEST_WEB_DOMAIN}/")
+    app = _build_test_app()
+
+    response = TestClient(app).get(METADATA_ROUTE)
+
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "public, max-age=3600"
+    assert response.json() == {
+        "client_id": f"{TEST_WEB_DOMAIN}/api/mcp/oauth/client-metadata",
+        "client_name": "Onyx",
+        "redirect_uris": [f"{TEST_WEB_DOMAIN}/mcp/oauth/callback"],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+    }
+
+    metadata_route = next(
+        route for route in app.routes if getattr(route, "path", "") == METADATA_ROUTE
+    )
+    assert is_route_in_spec_list(metadata_route, PUBLIC_ENDPOINT_SPECS)

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_client_metadata_document.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_client_metadata_document.py
@@ -38,3 +38,23 @@ def test_mcp_oauth_client_metadata_document_is_public_and_cacheable(
         route for route in app.routes if getattr(route, "path", "") == METADATA_ROUTE
     )
     assert is_route_in_spec_list(metadata_route, PUBLIC_ENDPOINT_SPECS)
+
+
+@pytest.mark.parametrize(
+    ("web_domain", "expected_url"),
+    [
+        (
+            "https://onyx.example.com",
+            "https://onyx.example.com/api/mcp/oauth/client-metadata",
+        ),
+        ("http://localhost:3000", None),
+    ],
+)
+def test_mcp_oauth_client_metadata_url_requires_https(
+    monkeypatch: pytest.MonkeyPatch,
+    web_domain: str,
+    expected_url: str | None,
+) -> None:
+    monkeypatch.setattr(client_metadata, "WEB_DOMAIN", web_domain)
+
+    assert client_metadata.validated_mcp_oauth_client_metadata_url() == expected_url

--- a/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
+++ b/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
@@ -8,6 +8,7 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 import pytest
 from mcp.client.auth import OAuthClientProvider
+from mcp.client.auth.utils import should_use_client_metadata_url
 from mcp.shared.auth import OAuthClientInformationFull, OAuthMetadata, OAuthToken
 from pydantic import AnyHttpUrl, AnyUrl
 
@@ -250,6 +251,17 @@ def _build_provider(provider_mode: MCPOAuthProviderMode) -> OAuthClientProvider:
     )
 
 
+def _oauth_metadata_with_cimd(supported: bool) -> OAuthMetadata:
+    return OAuthMetadata(
+        issuer=cast(AnyHttpUrl, "https://accounts.example.com"),
+        authorization_endpoint=cast(
+            AnyHttpUrl, "https://accounts.example.com/authorize"
+        ),
+        token_endpoint=cast(AnyHttpUrl, "https://accounts.example.com/token"),
+        client_id_metadata_document_supported=supported,
+    )
+
+
 def _patch_config_read(
     monkeypatch: pytest.MonkeyPatch, config_data: dict[str, object]
 ) -> None:
@@ -283,15 +295,53 @@ def test_make_oauth_provider_sets_known_provider_metadata_and_binds_storage() ->
     assert storage._oauth_context is provider.context
 
 
-def test_make_oauth_provider_auto_discovery_leaves_metadata_unset() -> None:
+def test_make_oauth_provider_auto_discovery_leaves_metadata_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        mcp_oauth, "validated_mcp_oauth_client_metadata_url", lambda: None
+    )
     provider = _build_provider(MCPOAuthProviderMode.AUTO_DISCOVERY)
     assert provider.context.oauth_metadata is None
     assert provider.context.token_expiry_time is None
+    assert provider.context.client_metadata_url is None
 
 
-def test_make_oauth_provider_auto_discovery_requests_public_pkce_client() -> None:
+def test_make_oauth_provider_auto_discovery_requests_public_pkce_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metadata_url = "https://onyx.example.com/api/mcp/oauth/client-metadata"
+    monkeypatch.setattr(
+        mcp_oauth,
+        "validated_mcp_oauth_client_metadata_url",
+        lambda: metadata_url,
+    )
     provider = _build_provider(MCPOAuthProviderMode.AUTO_DISCOVERY)
+
     assert provider.context.client_metadata.token_endpoint_auth_method == "none"
+    assert provider.context.client_metadata_url == metadata_url
+    assert should_use_client_metadata_url(
+        _oauth_metadata_with_cimd(True),
+        provider.context.client_metadata_url,
+    )
+    assert not should_use_client_metadata_url(
+        _oauth_metadata_with_cimd(False),
+        provider.context.client_metadata_url,
+    )
+
+
+def test_make_oauth_provider_known_provider_ignores_client_metadata_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        mcp_oauth,
+        "validated_mcp_oauth_client_metadata_url",
+        lambda: "https://onyx.example.com/api/mcp/oauth/client-metadata",
+    )
+
+    provider = _build_provider(MCPOAuthProviderMode.KNOWN_PROVIDER)
+
+    assert provider.context.client_metadata_url is None
 
 
 def test_get_tokens_hydrates_expiry_and_invalidates_expired_token(

--- a/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
@@ -684,14 +684,15 @@ export default function MCPAuthenticationModal({
                       {/* Info Text */}
                       <div className="flex flex-col gap-2">
                         <Text as="p" font="secondary-body" color="text-03">
-                          Client ID and secret are optional if the server
-                          connection supports Dynamic Client Registration (DCR).
+                          Client ID and secret are optional. During automatic
+                          discovery, Onyx uses a Client ID Metadata Document
+                          (CIMD) when supported and falls back to Dynamic Client
+                          Registration (DCR).
                         </Text>
                         <Text as="p" font="secondary-body" color="text-03">
-                          If your server does not support DCR, you need register
-                          your Onyx instance with the server provider to obtain
-                          these credentials first. Make sure to grant Onyx
-                          necessary scopes/permissions for your actions.
+                          If your server supports neither method, register your
+                          Onyx instance with the server provider first. Grant
+                          Onyx the necessary scopes for your actions.
                         </Text>
                         {/* Redirect URI */}
                         <div className="flex items-center gap-1 w-full">


### PR DESCRIPTION
## Description

Use the deployment metadata URL for HTTPS MCP OAuth auto-discovery. The SDK selects CIMD when advertised and otherwise keeps the existing DCR flow.

Update the admin guidance to explain CIMD and DCR. This PR depends on [the metadata endpoint PR](https://github.com/onyx-dot-app/onyx/pull/13876).

## How Has This Been Tested?

- 73 MCP OAuth unit tests covering CIMD selection, DCR fallback, known providers, refresh, and stored credentials
- Backend type checks, linting, and formatting
- Frontend linting, formatting, and type checking

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use Client ID Metadata Document (CIMD) during MCP OAuth auto-discovery, falling back to Dynamic Client Registration (DCR) when not supported. Adds HTTPS validation for the client metadata URL and updates redirect handling and UI copy.

- **New Features**
  - Prefer CIMD during auto-discovery; request a public PKCE client (token_endpoint_auth_method: "none"); fallback to DCR.
  - Provide a validated `client_metadata_url` only in `AUTO_DISCOVERY`; ignore in known providers.
  - Enforce HTTPS for the metadata URL via `mcp.client.auth.utils` (`validated_mcp_oauth_client_metadata_url()`); build the redirect URI with `mcp_oauth_redirect_uri()`.
  - Update field descriptions to mention CIMD/DCR and refresh UI copy in `MCPAuthenticationModal`.
  - Add tests for HTTPS validation, provider context (`client_metadata_url`), and `should_use_client_metadata_url` behavior.

<sup>Written for commit 80be7128e7aad29fcb8f9d8d26985a9898e6f724. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

