### PR TITLE
feat(log-export): re-attach the export page to an in-flight export via URL param

### DIFF
--- a/web/src/app/ee/admin/export-logs/page.tsx
+++ b/web/src/app/ee/admin/export-logs/page.tsx
@@ -17,6 +17,9 @@ const route = ADMIN_ROUTES.EXPORT_LOGS;
 const DESCRIPTION =
   "Download a zip of server log files to attach to an Onyx support thread.";
 const EXPORT_URL = "/api/admin/log-export";
+const EXPORT_ID_QUERY_PARAM = "export";
+// Export ids are uuid4().hex values; anything else found in the URL is noise.
+const EXPORT_ID_PATTERN = /^[0-9a-f]{32}$/;
 const FALLBACK_FILENAME = "onyx_logs.zip";
 const POLL_INTERVAL_MS = 2_000;
 // Give up on a poll that fails this many times in a row (~30s at the poll
@@ -50,6 +53,18 @@ function extractFilename(response: Response): string {
   const disposition = response.headers.get("Content-Disposition");
   const match = disposition?.match(/filename=([^;]+)/);
   return match?.[1]?.trim() ?? FALLBACK_FILENAME;
+}
+
+// Mirrors the export id into the URL (shallow, no navigation) so a refresh or
+// shared tab can re-attach to the export.
+function writeExportIdToUrl(exportId: string | null): void {
+  const url = new URL(window.location.href);
+  if (exportId === null) {
+    url.searchParams.delete(EXPORT_ID_QUERY_PARAM);
+  } else {
+    url.searchParams.set(EXPORT_ID_QUERY_PARAM, exportId);
+  }
+  window.history.replaceState({}, "", url.toString());
 }
 
 function receiptLabel(receipt: LogExportReceipt): string {
@@ -97,11 +112,31 @@ export default function ExportLogsPage() {
   const [isStarting, setIsStarting] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
   const downloadedExportIdRef = useRef<string | null>(null);
+  // The export eligible for auto-download: one this tab started or watched
+  // collecting. A page that loads onto an already-finished export (restored
+  // URL) only offers the manual button, so page loads never trigger downloads.
+  const armedExportIdRef = useRef<string | null>(null);
   // Pending deferred revocation: cancelling the timer must also revoke the URL.
   const pendingRevokeRef = useRef<{
     timer: ReturnType<typeof setTimeout>;
     url: string;
   } | null>(null);
+
+  // Re-attach to an in-flight export after a refresh or navigation; the id is
+  // mirrored into the URL when an export starts. Malformed ids are scrubbed.
+  useEffect(() => {
+    const fromUrl = new URL(window.location.href).searchParams.get(
+      EXPORT_ID_QUERY_PARAM
+    );
+    if (fromUrl === null) {
+      return;
+    }
+    if (EXPORT_ID_PATTERN.test(fromUrl)) {
+      setExportId(fromUrl);
+    } else {
+      writeExportIdToUrl(null);
+    }
+  }, []);
 
   const { data: status, error: statusError } = useSWR<LogExportStatus>(
     exportId === null ? null : SWR_KEYS.logExportStatus(exportId),
@@ -133,7 +168,11 @@ export default function ExportLogsPage() {
       statusError.status >= 400 &&
       statusError.status < 500;
     if (isTerminal4xx) {
-      toast.error("Lost access to the running export. Start a new one.");
+      // An id restored from the URL can be stale (export already swept, or
+      // never real); it has no status yet, so scrub it without a toast.
+      if (status !== undefined) {
+        toast.error("Lost access to the running export. Start a new one.");
+      }
     } else if (
       consecutivePollFailuresRef.current >= MAX_CONSECUTIVE_POLL_FAILURES
     ) {
@@ -144,8 +183,9 @@ export default function ExportLogsPage() {
       return;
     }
     consecutivePollFailuresRef.current = 0;
+    writeExportIdToUrl(null);
     setExportId(null);
-  }, [statusError]);
+  }, [status, statusError]);
 
   useEffect(() => {
     return () => {
@@ -198,11 +238,19 @@ export default function ExportLogsPage() {
     }
   }, []);
 
-  // Download exactly once per export, as soon as it is ready.
+  // Download exactly once per export, as soon as it is ready. Arming happens
+  // while the export is still collecting (or at start, in handleExport), so
+  // attaching to an already-finished export never auto-fires.
   useEffect(() => {
+    if (exportId === null || status === undefined) {
+      return;
+    }
+    if (status.state === "collecting") {
+      armedExportIdRef.current = exportId;
+      return;
+    }
     if (
-      exportId === null ||
-      status?.state !== "ready" ||
+      armedExportIdRef.current !== exportId ||
       downloadedExportIdRef.current === exportId
     ) {
       return;
@@ -224,7 +272,9 @@ export default function ExportLogsPage() {
         );
       }
       const body: { export_id: string } = await response.json();
+      armedExportIdRef.current = body.export_id;
       setExportId(body.export_id);
+      writeExportIdToUrl(body.export_id);
     } catch (error) {
       console.error("Error starting log export:", error);
       toast.error("Failed to start the log export.");


### PR DESCRIPTION
## Description

- Starting an export stamps ?export=<id> into the URL (history.replaceState, no navigation); on mount the page re-attaches and polling resumes, so a refresh mid-collection no longer orphans the export until the lock TTL expires.
- Stale or malformed ids restored from the URL are scrubbed silently; the "lost access" toast now only fires for exports the tab was actively watching.
- Auto-download only fires for an export this tab started or watched collecting; loading the URL of a finished export offers the manual Download button instead of firing a download on page load.

## How Has This Been Tested?

- No automated tests added, verified via pre-commit plus a live browser click-through of every flow.
- Live verification with a throwaway Playwright script against a local stack (api server + web dev server; no celery workers running, so exports stay collecting until the 90s deadline, giving a guaranteed mid-collection window and exercising the pending-worker rendering):
  - Clicking Export Logs stamps ?export=<32-hex id> into the URL without a navigation.
  - Reloading mid-collection re-attaches: the worker status card comes back, polling resumes, and the auto-download still fires once the export turns ready.
  - Reloading after completion does not auto-fire a download; the receipts card renders (api_server uploaded, workers "did not report before the deadline") and the manual Download button still downloads the bundle.
  - Loading the page with a well-formed but unknown id (32 zeros) scrubs the param from the URL with no error toast.
  - Loading the page with a malformed id scrubs the param immediately.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-attaches the Export Logs page to an in-flight export via the `?export=<id>` URL param so refreshes and shared tabs resume polling instead of orphaning the job. Also hardens edge cases and prevents surprise auto-downloads.

- **New Features**
  - Mirror the export id into the URL (no navigation) and re-attach on mount to resume polling.
  - Silently scrub malformed or unknown ids; only show the “lost access” toast for exports this tab actively watched.
  - Auto-download only for exports this tab started or saw collecting; finished exports opened via URL show a manual Download button.
  - Prevent duplicate downloads by arming/recording eligible export ids.

<sup>Written for commit 9682e0d50f0798f5715688a644f5fee50dc778ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

