### PR TITLE
fix(ods): detect cherry-pick target from release branches, not tags

### DIFF
--- a/tools/ods/cmd/cherry-pick.go
+++ b/tools/ods/cmd/cherry-pick.go
@@ -390,7 +390,7 @@ func cherryPickToRelease(commitSHAs, commitMessages []string, branchSuffix, vers
 
 	// Fetch the release branch
 	log.Infof("Fetching release branch: %s", releaseBranch)
-	if err := git.RunCommand("fetch", "--prune", "--quiet", "origin", releaseBranch); err != nil {
+	if err := git.RunCommand("fetch", "--prune", "--quiet", "origin", releaseBranchRefspec(releaseBranch)); err != nil {
 		return "", fmt.Errorf("failed to fetch release branch %s: %w", releaseBranch, err)
 	}
 
@@ -577,6 +577,14 @@ func extractPRNumbers(commitMsg string) []string {
 // deliberately excluded.
 var releaseBranchPattern = regexp.MustCompile(`^release/v(\d+)\.(\d+)$`)
 
+// releaseBranchRefspec returns a forced fetch refspec that creates or updates
+// the origin/<releaseBranch> tracking ref even in clones whose configured fetch
+// refspec does not cover release branches (e.g. single-branch clones), where a
+// plain "git fetch origin <branch>" only writes FETCH_HEAD.
+func releaseBranchRefspec(releaseBranch string) string {
+	return fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", releaseBranch, releaseBranch)
+}
+
 // releaseVersion is the parsed version of a "release/vX.Y" branch.
 type releaseVersion struct {
 	major int
@@ -673,7 +681,7 @@ func findTargetReleaseVersion(commitSHA string) (string, error) {
 	for _, version := range versions {
 		releaseBranch := fmt.Sprintf("release/%s", version)
 		// Fetch so the ancestry check runs against the branch's current tip.
-		if err := git.RunCommand("fetch", "--quiet", "origin", releaseBranch); err != nil {
+		if err := git.RunCommand("fetch", "--quiet", "origin", releaseBranchRefspec(releaseBranch)); err != nil {
 			return "", fmt.Errorf("failed to fetch %s: %w", releaseBranch, err)
 		}
 		contained, err := git.IsAncestor(commitSHA, fmt.Sprintf("origin/%s", releaseBranch))

--- a/tools/ods/cmd/cherry-pick.go
+++ b/tools/ods/cmd/cherry-pick.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -45,7 +46,8 @@ with fewer than 6 digits is treated as a PR number and resolved to its merge
 commit automatically.
 
 This command will:
-  1. Find the nearest stable version tag
+  1. Detect the newest release branch that does not already contain the commit
+     (unless --release is given)
   2. Fetch the corresponding release branch(es)
   3. Create a hotfix branch with the cherry-picked commit(s)
   4. Push and create a PR using the GitHub CLI
@@ -172,11 +174,11 @@ func runCherryPick(cmd *cobra.Command, args []string, opts *CherryPickOptions) {
 		}
 		log.Debugf("Using specified release versions: %v", releases)
 	} else {
-		// Find the nearest stable tag using the first commit
-		version, err := findNearestStableTag(commitSHAs[0])
+		// Find the newest release branch missing the first commit.
+		version, err := findTargetReleaseVersion(commitSHAs[0])
 		if err != nil {
 			git.RestoreStash(stashResult)
-			log.Fatalf("Failed to find nearest stable tag: %v", err)
+			log.Fatalf("Failed to auto-detect the target release: %v", err)
 		}
 
 		// Prompt user for confirmation
@@ -570,26 +572,121 @@ func extractPRNumbers(commitMsg string) []string {
 	return matches
 }
 
-// findNearestStableTag finds the nearest tag matching v*.*.* pattern and returns major.minor
-func findNearestStableTag(commitSHA string) (string, error) {
-	// Get tags that are ancestors of the commit, sorted by version
-	cmd := exec.Command("git", "describe", "--tags", "--abbrev=0", "--match", "v*.*.*", commitSHA)
+// releaseBranchPattern matches maintained release branch names, e.g.
+// "release/v4.5". Ad-hoc branches such as "release/v3.0-qa-f1df36e" are
+// deliberately excluded.
+var releaseBranchPattern = regexp.MustCompile(`^release/v(\d+)\.(\d+)$`)
+
+// releaseVersion is the parsed version of a "release/vX.Y" branch.
+type releaseVersion struct {
+	major int
+	minor int
+}
+
+// String returns the version with its 'v' prefix, e.g. "v4.5".
+func (v releaseVersion) String() string {
+	return fmt.Sprintf("v%d.%d", v.major, v.minor)
+}
+
+// parseReleaseVersions extracts "release/vX.Y" versions from branch names and
+// returns them sorted newest first. Names that do not match the pattern are
+// ignored.
+func parseReleaseVersions(branchNames []string) []releaseVersion {
+	versions := []releaseVersion{}
+	for _, name := range branchNames {
+		matches := releaseBranchPattern.FindStringSubmatch(name)
+		if matches == nil {
+			continue
+		}
+		major, err := strconv.Atoi(matches[1])
+		if err != nil {
+			continue
+		}
+		minor, err := strconv.Atoi(matches[2])
+		if err != nil {
+			continue
+		}
+		versions = append(versions, releaseVersion{major: major, minor: minor})
+	}
+	sort.Slice(versions, func(i, j int) bool {
+		if versions[i].major != versions[j].major {
+			return versions[i].major > versions[j].major
+		}
+		return versions[i].minor > versions[j].minor
+	})
+	return versions
+}
+
+// listRemoteReleaseBranches returns the names (e.g. "release/v4.5") of all
+// release branches on origin.
+func listRemoteReleaseBranches() ([]string, error) {
+	cmd := exec.Command("git", "ls-remote", "--heads", "origin", "release/*")
 	output, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("git describe failed: %w", err)
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("git ls-remote failed: %w: %s", err, string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("git ls-remote failed: %w", err)
 	}
 
-	tag := strings.TrimSpace(string(output))
-	log.Debugf("Found tag: %s", tag)
+	branches := []string{}
+	for _, line := range strings.Split(string(output), "\n") {
+		// Each line is "<sha>\trefs/heads/<branch>".
+		_, ref, found := strings.Cut(line, "\t")
+		if !found {
+			continue
+		}
+		branches = append(branches, strings.TrimPrefix(strings.TrimSpace(ref), "refs/heads/"))
+	}
+	return branches, nil
+}
 
-	// Extract major.minor with v prefix from tag (e.g., v1.2.3 -> v1.2)
-	re := regexp.MustCompile(`^(v\d+\.\d+)\.\d+`)
-	matches := re.FindStringSubmatch(tag)
-	if len(matches) < 2 {
-		return "", fmt.Errorf("tag %s does not match expected format v*.*.* ", tag)
+// findTargetReleaseVersion returns the version (e.g. "v4.5") of the newest
+// "release/vX.Y" branch on origin that does not already contain commitSHA. A
+// commit merged to main after the latest branch cut targets the newest branch;
+// a commit that predates the cut (and is therefore already part of the newer
+// branches) falls back to the newest branch actually missing it. Tags are
+// deliberately not consulted: release tag names on main (e.g. "vX.Y.0-cloud.N")
+// roll over to a new version asynchronously from the branch cut, so the nearest
+// tag can disagree with the newest branch.
+func findTargetReleaseVersion(commitSHA string) (string, error) {
+	// A shallow clone cannot answer ancestry truthfully: history beyond the
+	// shallow boundary makes contained commits look uncontained, silently
+	// routing them to the wrong branch. Fail loudly instead.
+	shallow, err := git.IsShallowRepository()
+	if err != nil {
+		return "", err
+	}
+	if shallow {
+		return "", fmt.Errorf("this is a shallow clone, so release auto-detection cannot check branch ancestry; pass --release explicitly")
 	}
 
-	return matches[1], nil
+	branchNames, err := listRemoteReleaseBranches()
+	if err != nil {
+		return "", err
+	}
+	versions := parseReleaseVersions(branchNames)
+	if len(versions) == 0 {
+		return "", fmt.Errorf("no release/vX.Y branches found on origin")
+	}
+
+	for _, version := range versions {
+		releaseBranch := fmt.Sprintf("release/%s", version)
+		// Fetch so the ancestry check runs against the branch's current tip.
+		if err := git.RunCommand("fetch", "--quiet", "origin", releaseBranch); err != nil {
+			return "", fmt.Errorf("failed to fetch %s: %w", releaseBranch, err)
+		}
+		contained, err := git.IsAncestor(commitSHA, fmt.Sprintf("origin/%s", releaseBranch))
+		if err != nil {
+			return "", err
+		}
+		if !contained {
+			return version.String(), nil
+		}
+		log.Infof("Commit %s is already contained in %s, checking the next older release branch", commitSHA, releaseBranch)
+	}
+
+	return "", fmt.Errorf("commit %s is already contained in every release branch; pass --release explicitly", commitSHA)
 }
 
 // createCherryPickPR creates a pull request for cherry-picks using the GitHub CLI

--- a/tools/ods/cmd/cherry-pick_test.go
+++ b/tools/ods/cmd/cherry-pick_test.go
@@ -81,6 +81,11 @@ func setupReleaseBranchRepo(t *testing.T) (preCutSHA, cutSHA, postCutSHA string)
 	gitIn(t, work, "config", "user.name", "Test")
 	gitIn(t, work, "config", "commit.gpgsign", "false")
 	gitIn(t, work, "remote", "add", "origin", origin)
+	// Narrow the fetch refspec to main only, like a single-branch clone, so the
+	// tests also pin that detection fetches release branches with an explicit
+	// refspec (a plain "git fetch origin <branch>" would only write FETCH_HEAD
+	// here and never create origin/release/vX.Y).
+	gitIn(t, work, "config", "remote.origin.fetch", "+refs/heads/main:refs/remotes/origin/main")
 
 	preCutSHA = commitIn(t, work, "a.txt")
 	gitIn(t, work, "branch", "release/v4.4", preCutSHA)

--- a/tools/ods/cmd/cherry-pick_test.go
+++ b/tools/ods/cmd/cherry-pick_test.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestParseReleaseVersions_sortsNewestFirstIgnoringNonMatching(t *testing.T) {
+	// Precondition.
+	branchNames := []string{
+		"release/v4.4",
+		"release/v3.0-qa-f1df36e",
+		"release/v4.10",
+		"main",
+		"release/v4.5",
+		"release/v10.0",
+	}
+
+	// Under test.
+	versions := parseReleaseVersions(branchNames)
+
+	// Postcondition.
+	got := make([]string, len(versions))
+	for i, version := range versions {
+		got[i] = version.String()
+	}
+	want := []string{"v10.0", "v4.10", "v4.5", "v4.4"}
+	if !slices.Equal(got, want) {
+		t.Errorf("expected %v, got %v", want, got)
+	}
+}
+
+func TestParseReleaseVersions_emptyWhenNothingMatches(t *testing.T) {
+	// Under test and postcondition.
+	if versions := parseReleaseVersions([]string{"main", "hotfix/abc-v4.4"}); len(versions) != 0 {
+		t.Errorf("expected no versions, got %v", versions)
+	}
+}
+
+// gitIn runs a git command in dir, failing the test on error.
+func gitIn(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// commitIn creates a file and commits it in dir, returning the commit SHA.
+func commitIn(t *testing.T, dir, filename string) string {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, filename), []byte(filename), 0644); err != nil {
+		t.Fatal(err)
+	}
+	gitIn(t, dir, "add", filename)
+	gitIn(t, dir, "commit", "-m", "add "+filename)
+	return gitIn(t, dir, "rev-parse", "HEAD")
+}
+
+// setupReleaseBranchRepo creates a bare origin holding main, release/v4.4, and
+// release/v4.5, with a local work repo as the current directory. It returns
+// three main-line commit SHAs: the v4.4 cut point (ancestor of both release
+// branches), the v4.5 cut point (only on release/v4.5), and a post-cut commit
+// (on neither release branch).
+func setupReleaseBranchRepo(t *testing.T) (preCutSHA, cutSHA, postCutSHA string) {
+	t.Helper()
+
+	origin := t.TempDir()
+	gitIn(t, origin, "init", "--bare", "-b", "main")
+
+	work := t.TempDir()
+	gitIn(t, work, "init", "-b", "main")
+	gitIn(t, work, "config", "user.email", "test@test.com")
+	gitIn(t, work, "config", "user.name", "Test")
+	gitIn(t, work, "config", "commit.gpgsign", "false")
+	gitIn(t, work, "remote", "add", "origin", origin)
+
+	preCutSHA = commitIn(t, work, "a.txt")
+	gitIn(t, work, "branch", "release/v4.4", preCutSHA)
+	cutSHA = commitIn(t, work, "b.txt")
+	gitIn(t, work, "branch", "release/v4.5", cutSHA)
+	postCutSHA = commitIn(t, work, "c.txt")
+
+	gitIn(t, work, "push", "--quiet", "origin", "main", "release/v4.4", "release/v4.5")
+
+	// Tags named after the previous release must not influence detection
+	// (tag-anchored detection was the original misrouting bug). Mirror the
+	// incident topology: a stable v4.4 tag at the v4.4 cut point, plus a v4.4
+	// pre-release tag minted on main after the v4.5 cut, which is the exact
+	// shape that misrouted real cherry-picks to release/v4.4.
+	gitIn(t, work, "tag", "v4.4.2", preCutSHA)
+	gitIn(t, work, "tag", "v4.4.0-cloud.9", postCutSHA)
+
+	// Drop the local release branches and the remote-tracking refs the push
+	// created, so the fixture looks like a clone that has never fetched the
+	// release branches; detection must create origin/* itself via fetch.
+	gitIn(t, work, "branch", "-D", "release/v4.4", "release/v4.5")
+	gitIn(t, work, "update-ref", "-d", "refs/remotes/origin/release/v4.4")
+	gitIn(t, work, "update-ref", "-d", "refs/remotes/origin/release/v4.5")
+
+	// The functions under test run git in the process working directory.
+	t.Chdir(work)
+
+	return preCutSHA, cutSHA, postCutSHA
+}
+
+func TestFindTargetReleaseVersion_postCutCommitTargetsNewestBranch(t *testing.T) {
+	// Precondition.
+	_, _, postCutSHA := setupReleaseBranchRepo(t)
+
+	// Under test.
+	version, err := findTargetReleaseVersion(postCutSHA)
+
+	// Postcondition.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if version != "v4.5" {
+		t.Errorf("expected v4.5, got %s", version)
+	}
+}
+
+func TestFindTargetReleaseVersion_preCutCommitFallsBackToOlderBranch(t *testing.T) {
+	// Precondition.
+	_, cutSHA, _ := setupReleaseBranchRepo(t)
+
+	// Under test.
+	version, err := findTargetReleaseVersion(cutSHA)
+
+	// Postcondition.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if version != "v4.4" {
+		t.Errorf("expected v4.4, got %s", version)
+	}
+}
+
+func TestFindTargetReleaseVersion_commitOnAllBranchesErrors(t *testing.T) {
+	// Precondition.
+	preCutSHA, _, _ := setupReleaseBranchRepo(t)
+
+	// Under test.
+	_, err := findTargetReleaseVersion(preCutSHA)
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "already contained in every release branch") {
+		t.Errorf("expected already-contained error, got %v", err)
+	}
+}
+
+func TestFindTargetReleaseVersion_shallowCloneErrors(t *testing.T) {
+	// Precondition: a shallow clone, where ancestry cannot be answered.
+	origin := t.TempDir()
+	gitIn(t, origin, "init", "--bare", "-b", "main")
+	seed := t.TempDir()
+	gitIn(t, seed, "init", "-b", "main")
+	gitIn(t, seed, "config", "user.email", "test@test.com")
+	gitIn(t, seed, "config", "user.name", "Test")
+	gitIn(t, seed, "config", "commit.gpgsign", "false")
+	gitIn(t, seed, "remote", "add", "origin", origin)
+	sha := commitIn(t, seed, "a.txt")
+	gitIn(t, seed, "branch", "release/v4.5")
+	gitIn(t, seed, "push", "--quiet", "origin", "main", "release/v4.5")
+	shallow := filepath.Join(t.TempDir(), "shallow")
+	// Depth flags are ignored for plain local-path clones, hence file://.
+	gitIn(t, t.TempDir(), "clone", "--quiet", "--depth", "1", "--no-single-branch", "file://"+origin, shallow)
+	t.Chdir(shallow)
+
+	// Under test.
+	_, err := findTargetReleaseVersion(sha)
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "shallow clone") {
+		t.Errorf("expected shallow-clone error, got %v", err)
+	}
+}

--- a/tools/ods/internal/git/git.go
+++ b/tools/ods/internal/git/git.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -116,6 +117,39 @@ func RestoreStash(result *StashResult) {
 		log.Warnf("Failed to restore stashed changes (may have conflicts): %v", err)
 		log.Info("Your changes are still in the stash. Run 'git stash pop' to restore them manually.")
 	}
+}
+
+// IsAncestor reports whether ancestor is an ancestor of (or equal to)
+// descendant. Both arguments may be any commit-ish.
+func IsAncestor(ancestor, descendant string) (bool, error) {
+	cmd := exec.Command("git", "merge-base", "--is-ancestor", ancestor, descendant)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		return true, nil
+	}
+	// Exit code 1 is the documented "not an ancestor" result; anything else
+	// (e.g. an unknown revision) is a real error.
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false, nil
+	}
+	if diagnostic := strings.TrimSpace(stderr.String()); diagnostic != "" {
+		return false, fmt.Errorf("git merge-base --is-ancestor %s %s failed: %w: %s", ancestor, descendant, err, diagnostic)
+	}
+	return false, fmt.Errorf("git merge-base --is-ancestor %s %s failed: %w", ancestor, descendant, err)
+}
+
+// IsShallowRepository reports whether the current repository is a shallow
+// clone.
+func IsShallowRepository() (bool, error) {
+	cmd := exec.Command("git", "rev-parse", "--is-shallow-repository")
+	output, err := cmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("git rev-parse --is-shallow-repository failed: %w", err)
+	}
+	return strings.TrimSpace(string(output)) == "true", nil
 }
 
 // CommitExistsOnBranch checks if a commit exists on a branch

--- a/tools/ods/internal/git/git_test.go
+++ b/tools/ods/internal/git/git_test.go
@@ -182,3 +182,25 @@ func TestIsCommitAppliedOnBranch_NoFalsePositiveFromBody(t *testing.T) {
 		t.Error("should NOT match when subject only appears in body of another commit")
 	}
 }
+
+// --- IsAncestor tests ---
+
+func TestIsAncestor_distinguishesFalseFromError(t *testing.T) {
+	// Precondition.
+	r := newTestRepo(t)
+	first := r.HEAD()
+	second := r.Commit("second commit", "second.txt", "content")
+
+	// Under test and postcondition: ancestor, non-ancestor, and error cases.
+	contained, err := IsAncestor(first, second)
+	if err != nil || !contained {
+		t.Errorf("expected (true, nil) for ancestor, got (%v, %v)", contained, err)
+	}
+	contained, err = IsAncestor(second, first)
+	if err != nil || contained {
+		t.Errorf("expected (false, nil) for non-ancestor, got (%v, %v)", contained, err)
+	}
+	if _, err = IsAncestor("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", first); err == nil {
+		t.Error("expected an error for an unknown revision, got nil")
+	}
+}


### PR DESCRIPTION
## Description

Checking the "cherry-pick to latest release" PR checkbox routed cherry-picks to the wrong branch right after a release cut: fixes merged in the ~24h after the release/v4.5 cut were auto-CPed to release/v4.4 (#13543, #13544, #13547, #13548).

Root cause: with no --release flag, `ods cherry-pick` auto-detected the target via `git describe --tags --match "v*.*.*"` on the merge commit, i.e. the nearest version-looking tag reachable on main. Stable vX.Y.Z tags only exist on release branches, so detection actually keyed off -beta./-cloud. tags, and v4.4.0-cloud.8/9 were minted on main after the v4.5 cut. Any tag naming lag reopens this window every release cycle.

Fix: auto-detection now ignores tags entirely. It lists origin release/vX.Y branches (ls-remote), walks them newest-first, and picks the first branch that does not already contain the commit (merge-base --is-ancestor after fetching the branch). Commits that predate the newest cut (already ancestors of it) fall back to the newest branch actually missing them, preserving correct late-backport behavior.

Also:
- New git.IsAncestor distinguishes "not an ancestor" (exit 1) from real git failures and surfaces git's stderr in errors.
- Shallow clones now fail loudly with "pass --release explicitly" instead of silently misrouting (ancestry is unanswerable past the shallow boundary).

## How Has This Been Tested?

- New Go tests with a real bare-origin + clone fixture reproducing the incident topology (stale v4.4.2 tag at the old cut point, v4.4.0-cloud.9 tag on a post-cut main commit): post-cut commit targets v4.5, pre-cut commit falls back to v4.4, commit contained everywhere errors, shallow clone errors; plus IsAncestor exit-code discrimination and branch-name parsing/sorting (v4.10 > v4.5, ad-hoc branch names excluded).
- Mutation-verified: re-implanting the old describe-based detection fails the suite with the production symptom ("expected v4.5, got v4.4"); deleting the fetch or checking local instead of origin/ refs also fails.
- Replayed against the real repo: merge commit 674372933a (misrouted to v4.4 on 2026-07-29) now resolves to v4.5; pre-cut commit ee3bdf0b correctly falls back to v4.4.
- go build/vet, go test ./cmd ./internal/git -count=1, golangci-lint via pre-commit.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cherry-pick auto-targeting in `ods` to use the newest release branch that’s missing the commit, instead of nearest tags. This prevents post-cut misroutes (e.g., v4.5 fixes going to v4.4).

- **Bug Fixes**
  - Auto-detect via `origin` `release/vX.Y` branches (newest-first); pick the first branch that doesn’t contain the commit, with correct fallback for pre-cut commits.
  - Ignore tags; fetch release branches with an explicit refspec and update tips before ancestry checks (works in single-branch clones).
  - Fail fast on shallow clones with a clear message to pass `--release`.
  - Add `git.IsAncestor` (distinguishes non-ancestor vs errors, surfaces stderr) and `git.IsShallowRepository`.
  - Add end-to-end tests reproducing the incident, branch parsing/sorting (v4.10 > v4.5), single-branch clone behavior, and shallow-clone behavior.

<sup>Written for commit f9c76b7d1552a9bea214e596196c81331a1b8516. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

