### PR TITLE
feat(log-export): skip worker fan-out on deployments without a celery broker

### DIFF
--- a/backend/ee/onyx/server/log_export/api.py
+++ b/backend/ee/onyx/server/log_export/api.py
@@ -26,6 +26,8 @@ from ee.onyx.server.log_export.storage import (
 from onyx import __version__
 from onyx.auth.permissions import require_permission
 from onyx.background.celery.versioned_apps.client import app as client_app
+from onyx.cache.interface import CacheBackendType
+from onyx.configs.app_configs import CACHE_BACKEND
 from onyx.configs.constants import (
     OnyxCeleryPriority,
     OnyxCeleryQueues,
@@ -137,9 +139,9 @@ def start_log_export(
     Starts an export: fans out one collector task per worker type, collects the
     api_server's logs inline, and returns the export ID to poll.
 
-    Fan-out failures (e.g. deployments with no broker or workers, like the
-    onyx-lite overlay) degrade the export to just the api_server's logs instead
-    of failing.
+    The fan-out is skipped on deployments that have no celery broker (the
+    onyx-lite overlay); a failing broker degrades the export to the workers
+    already enqueued instead of failing it.
     """
     if MULTI_TENANT:
         raise OnyxError(
@@ -165,33 +167,44 @@ def start_log_export(
 
         # Fan out before the inline collection below so workers get the full
         # window before ``expires=`` discards their tasks, and their collection
-        # overlaps the api_server's.
+        # overlaps the api_server's. When redis is absent by design (the
+        # onyx-lite overlay), there is no broker behind ``send_task`` and no
+        # workers to collect from, so the fan-out is skipped outright
+        # (``maybe_schedule_license_reclaim`` applies the same rule); a broker
+        # that exists but is down degrades per-send below instead.
         enqueued_worker_names: list[str] = []
-        for worker_name, queue in WORKER_COLLECT_QUEUES.items():
-            try:
-                client_app.send_task(
-                    OnyxCeleryTask.EXPORT_LOGS_COLLECT_TASK,
-                    priority=OnyxCeleryPriority.HIGHEST,
-                    queue=queue,
-                    expires=deadline,
-                    kwargs={
-                        "export_id": export_id,
-                        "worker_name": worker_name,
-                    },
-                )
-            except Exception as e:
-                # All sends share one broker, so the first failure means the
-                # rest would fail too. Only the workers already enqueued are
-                # awaited.
-                logger.warning(
-                    "Log export fan-out failed while enqueueing %s; continuing "
-                    "with %s: %s",
-                    worker_name,
-                    enqueued_worker_names,
-                    e,
-                )
-                break
-            enqueued_worker_names.append(worker_name)
+        if CACHE_BACKEND != CacheBackendType.REDIS:
+            logger.info(
+                "Log export fan-out skipped: this deployment has no celery "
+                "broker (CACHE_BACKEND=%s).",
+                CACHE_BACKEND.value,
+            )
+        else:
+            for worker_name, queue in WORKER_COLLECT_QUEUES.items():
+                try:
+                    client_app.send_task(
+                        OnyxCeleryTask.EXPORT_LOGS_COLLECT_TASK,
+                        priority=OnyxCeleryPriority.HIGHEST,
+                        queue=queue,
+                        expires=deadline,
+                        kwargs={
+                            "export_id": export_id,
+                            "worker_name": worker_name,
+                        },
+                    )
+                except Exception as e:
+                    # All sends share one broker, so the first failure means the
+                    # rest would fail too. Only the workers already enqueued are
+                    # awaited.
+                    logger.warning(
+                        "Log export fan-out failed while enqueueing %s; "
+                        "continuing with %s: %s",
+                        worker_name,
+                        enqueued_worker_names,
+                        e,
+                    )
+                    break
+                enqueued_worker_names.append(worker_name)
 
         manifest = LogExportManifest(
             export_id=export_id,

--- a/backend/tests/external_dependency_unit/ee/onyx/server/log_export/test_start_export.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/server/log_export/test_start_export.py
@@ -23,6 +23,7 @@ from ee.onyx.server.log_export.storage import (
     derive_export_state,
     read_export_snapshot,
 )
+from onyx.cache.interface import CacheBackendType
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 
@@ -62,9 +63,9 @@ def _admin_user() -> MagicMock:
 
 def test_fanout_failure_degrades_to_api_server_only() -> None:
     # Precondition.
-    # No broker is reachable, as in the onyx-lite overlay.
+    # A broker is configured but unreachable.
     with patch(f"{_API_MODULE}.client_app") as celery_client:
-        celery_client.send_task.side_effect = OSError("no broker")
+        celery_client.send_task.side_effect = OSError("broker down")
 
         # Under test.
         response = start_log_export(user=_admin_user())
@@ -72,6 +73,26 @@ def test_fanout_failure_degrades_to_api_server_only() -> None:
     # Postcondition.
     # The manifest awaits only the api_server, whose inline receipt already
     # exists, so the export is ready without any deadline wait.
+    snapshot = read_export_snapshot(response.export_id)
+    assert snapshot is not None
+    assert snapshot.manifest.worker_names == [API_SERVER_WORKER_NAME]
+    now = datetime.now(tz=timezone.utc)
+    assert derive_export_state(snapshot, now=now) is LogExportState.READY
+
+
+def test_lite_deployment_skips_fanout(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Precondition.
+    # Redis is absent by design (the onyx-lite overlay), so there is no celery
+    # broker and there are no workers.
+    monkeypatch.setattr(log_export_api, "CACHE_BACKEND", CacheBackendType.POSTGRES)
+    with patch(f"{_API_MODULE}.client_app") as celery_client:
+        # Under test.
+        response = start_log_export(user=_admin_user())
+
+    # Postcondition.
+    # The broker is never touched, and the manifest awaits only the api_server,
+    # whose inline receipt already exists.
+    celery_client.send_task.assert_not_called()
     snapshot = read_export_snapshot(response.export_id)
     assert snapshot is not None
     assert snapshot.manifest.worker_names == [API_SERVER_WORKER_NAME]


### PR DESCRIPTION
## Description

- On onyx-lite (CACHE_BACKEND != redis) there is no broker and no workers, so starting an export now skips the celery fan-out outright instead of waiting for the first send to time out against a host that is absent by design. Same rule maybe_schedule_license_reclaim already applies.
- The per-send failure handling stays for deployments whose broker exists but is down mid-request.
- An info log records the skip so support can distinguish a lite deployment from a broken fan-out when a bundle only contains api_server logs.

## How Has This Been Tested?

- New external-dependency-unit test: with CACHE_BACKEND patched to postgres, send_task is never called, the manifest awaits only the api_server, and the export is ready immediately.
- Existing fan-out degradation, lock lifecycle, and unit tests unchanged and passing (10 EDU + 13 unit).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip celery fan-out in log exports when the deployment has no broker (`CACHE_BACKEND` != `CacheBackendType.REDIS`), collecting only `api_server` logs inline. Adds an info log to flag `onyx-lite`, and keeps per-send degradation for deployments with a broker that is down.

- **New Features**
  - Skip fan-out when `CACHE_BACKEND` is not `CacheBackendType.REDIS`; manifest awaits only `api_server`.
  - Log `info` on skip to distinguish `onyx-lite`; keep `warning` on failed enqueues when a broker exists but is down.
  - Added tests for the skip path; existing degradation and lock lifecycle tests pass.

<sup>Written for commit de8845cee1f62401c9f9d4968a68bdf22cfd1eed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

