### PR TITLE
feat(craft): gate advertised HubSpot actions on the user's granted scopes (ENG-4262)

### DIFF
--- a/backend/onyx/external_apps/providers/actions.py
+++ b/backend/onyx/external_apps/providers/actions.py
@@ -119,3 +119,12 @@ class EndpointSpec(BaseModel):
     # Set when the action needs a scope only a self-hosted deployment requests,
     # which drops it from the cloud catalog (``registry.get_endpoint_catalog``).
     requires_self_hosted_scope: bool = False
+    # The OAuth scopes an account must have granted for this action to work at
+    # all. Only worth declaring for actions whose scope is *optional* in the
+    # authorize request (e.g. HubSpot writes via ``optional_scope``), because
+    # those diverge per user: a read-only account connects successfully but
+    # can't write. Consumers compare it against the user's persisted
+    # ``granted_scopes`` to stop advertising actions the grant won't authorize
+    # (see ``onyx.skills.rendering``). Left empty for scopes every connected
+    # user necessarily has, where the check would be pure overhead.
+    required_scopes: tuple[str, ...] = ()

--- a/backend/onyx/external_apps/providers/hubspot.py
+++ b/backend/onyx/external_apps/providers/hubspot.py
@@ -51,6 +51,32 @@ class HubspotAction(ExternalAppAction):
     DEALS_WRITE = "hubspot.deals.write"
 
 
+# `oauth` is mandatory for the auth-code flow; the reads cover the CRM objects
+# this provider catalogs. Every HubSpot tier can grant these.
+_REQUIRED_SCOPES = [
+    "oauth",
+    "crm.objects.owners.read",
+    "crm.objects.contacts.read",
+    "crm.objects.companies.read",
+    "crm.objects.deals.read",
+]
+
+# Optional, read-only/free tiers can't grant writes, and HubSpot
+# fails the whole authorize page on any ungrantable required scope. As optional
+# scopes it drops what the account lacks, so everyone can still connect — which
+# is why each write action declares its scope as ``required_scopes`` below:
+# whether the user actually has it varies per account.
+_CONTACTS_WRITE_SCOPE = "crm.objects.contacts.write"
+_COMPANIES_WRITE_SCOPE = "crm.objects.companies.write"
+_DEALS_WRITE_SCOPE = "crm.objects.deals.write"
+
+_OPTIONAL_WRITE_SCOPES = [
+    _CONTACTS_WRITE_SCOPE,
+    _COMPANIES_WRITE_SCOPE,
+    _DEALS_WRITE_SCOPE,
+]
+
+
 # HubSpot's CRM is a path-addressed JSON REST API rooted at
 # https://api.hubapi.com; the action is the HTTP method + path template. A
 # `{name}` segment matches one path segment (an object id). CRM search is a
@@ -117,6 +143,7 @@ _ENDPOINTS: list[EndpointSpec] = [
             RestRoute(method="POST", path="/crm/v3/objects/contacts"),
             RestRoute(method="PATCH", path="/crm/v3/objects/contacts/{contact_id}"),
         ),
+        required_scopes=(_CONTACTS_WRITE_SCOPE,),
     ),
     EndpointSpec(
         id=HubspotAction.COMPANIES_WRITE,
@@ -126,6 +153,7 @@ _ENDPOINTS: list[EndpointSpec] = [
             RestRoute(method="POST", path="/crm/v3/objects/companies"),
             RestRoute(method="PATCH", path="/crm/v3/objects/companies/{company_id}"),
         ),
+        required_scopes=(_COMPANIES_WRITE_SCOPE,),
     ),
     EndpointSpec(
         id=HubspotAction.DEALS_WRITE,
@@ -135,27 +163,8 @@ _ENDPOINTS: list[EndpointSpec] = [
             RestRoute(method="POST", path="/crm/v3/objects/deals"),
             RestRoute(method="PATCH", path="/crm/v3/objects/deals/{deal_id}"),
         ),
+        required_scopes=(_DEALS_WRITE_SCOPE,),
     ),
-]
-
-
-# `oauth` is mandatory for the auth-code flow; the reads cover the CRM objects
-# this provider catalogs. Every HubSpot tier can grant these.
-_REQUIRED_SCOPES = [
-    "oauth",
-    "crm.objects.owners.read",
-    "crm.objects.contacts.read",
-    "crm.objects.companies.read",
-    "crm.objects.deals.read",
-]
-
-# Optional, read-only/free tiers can't grant writes, and HubSpot
-# fails the whole authorize page on any ungrantable required scope. As optional
-# scopes it drops what the account lacks, so everyone can still connect.
-_OPTIONAL_WRITE_SCOPES = [
-    "crm.objects.contacts.write",
-    "crm.objects.companies.write",
-    "crm.objects.deals.write",
 ]
 
 

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -12,8 +12,9 @@ from sqlalchemy.orm import Session
 from onyx.db.external_app import (
     get_connectable_apps_for_user,
     get_external_app_by_skill_id,
+    get_external_app_user_credential,
 )
-from onyx.db.models import Skill, User
+from onyx.db.models import ExternalApp, Skill, User
 from onyx.db.skill import (
     SkillValidityUpdate,
     affected_user_ids_for_skill,
@@ -96,6 +97,25 @@ def _add_static_builtin(
         files[f"{skill.name}/{rel.as_posix()}"] = path.read_bytes()
 
 
+def _granted_scopes_for(
+    db_session: Session,
+    external_app: ExternalApp | None,
+    user: User,
+) -> list[str] | None:
+    """The user's persisted OAuth grant for ``external_app``, or ``None`` when
+    it's unknown — no app, no stored credential, or a credential written before
+    the grant was recorded. ``None`` means the renderer gates nothing on scopes,
+    so a missing signal can never hide an action the user actually has."""
+    if external_app is None:
+        return None
+    credential = get_external_app_user_credential(
+        db_session,
+        external_app_id=external_app.id,
+        user_id=user.id,
+    )
+    return credential.granted_scopes if credential else None
+
+
 def _render_template(
     files: FileSet,
     skill: Skill,
@@ -121,6 +141,7 @@ def _render_template(
             app_type,
             external_app,
             definition.source_dir,
+            _granted_scopes_for(db_session, external_app, user),
         )
         files[f"{skill.name}/SKILL.md"] = rendered.encode("utf-8")
         return

--- a/backend/onyx/skills/rendering.py
+++ b/backend/onyx/skills/rendering.py
@@ -10,7 +10,8 @@ from onyx.db.connector_credential_pair import get_connector_credential_pairs_for
 from onyx.db.enums import EndpointPolicy, ExternalAppType, GatedAppKind
 from onyx.db.gated_app import get_action_policies
 from onyx.db.models import ExternalApp, User
-from onyx.external_apps.providers.registry import action_policy_views
+from onyx.external_apps.providers.actions import EndpointSpec
+from onyx.external_apps.providers.registry import effective_policy, get_endpoint_catalog
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -78,22 +79,52 @@ def render_company_search_skill(
     return template.replace("{{AVAILABLE_SOURCES_SECTION}}", sources_section)
 
 
+def _is_scope_denied(
+    endpoint: EndpointSpec,
+    granted_scopes: list[str] | None,
+) -> bool:
+    """Whether the user's OAuth grant can't authorize ``endpoint``.
+
+    Only actions that declare ``required_scopes`` are gated — those are the ones
+    a provider requests as *optional* scopes, so the grant genuinely differs per
+    user (a read-only HubSpot account connects fine but can't write). Anything
+    else is authorized by definition for a connected user.
+
+    ``granted_scopes is None`` means "grant unknown" (a legacy credential row, or
+    a provider that doesn't report scopes). Unknown is never treated as denied:
+    hiding actions on a missing signal would silently break every pre-existing
+    credential, so the DENY-policy behaviour is all that applies there.
+    """
+    if granted_scopes is None or not endpoint.required_scopes:
+        return False
+    return not set(endpoint.required_scopes).issubset(granted_scopes)
+
+
 def build_action_availability_section(
     app_type: ExternalAppType,
     stored: dict[str, EndpointPolicy],
+    granted_scopes: list[str] | None = None,
 ) -> str:
-    """Render the warning listing the app's ``DENY`` (unavailable) actions, or an
-    empty string when nothing is disabled. Available actions are intentionally
+    """Render the warning listing the app's unavailable actions, or an empty
+    string when nothing is unavailable. Available actions are intentionally
     omitted — the skill body already documents what the agent can do; this only
     fences off what it must not attempt.
 
+    An action is unavailable when the admin set its policy to ``DENY``, or when
+    the user's OAuth grant lacks a scope the action requires (see
+    ``_is_scope_denied``) — advertising a write to a read-only account only gets
+    the agent a 401 it then has to reason about. Both land in one list, so an
+    action is never named twice.
+
     ``stored`` is the app's per-action overrides; an empty map falls back to the
-    catalog defaults.
+    catalog defaults. ``granted_scopes`` is the user's persisted grant, or
+    ``None`` when it's unknown (nothing is scope-gated then).
     """
     disabled = [
-        f"- {view.normalised_name}"
-        for view in action_policy_views(app_type, stored)
-        if view.state == EndpointPolicy.DENY
+        f"- {endpoint.normalised_name}"
+        for endpoint in get_endpoint_catalog(app_type)
+        if effective_policy(endpoint, stored) == EndpointPolicy.DENY
+        or _is_scope_denied(endpoint, granted_scopes)
     ]
     if not disabled:
         return ""
@@ -106,10 +137,13 @@ def render_external_app_skill(
     app_type: ExternalAppType,
     external_app: ExternalApp | None,
     skill_dir: Path,
+    granted_scopes: list[str] | None = None,
 ) -> str:
     """Render an external-app SKILL.md with its per-user action availability.
 
     ``skill_dir`` is the skill's on-disk directory (holds ``SKILL.md.template``).
+    ``granted_scopes`` is the rendering user's persisted OAuth grant for the app;
+    ``None`` (the default) means unknown, which gates nothing.
     """
     template = (skill_dir / "SKILL.md.template").read_text()
     stored = (
@@ -117,7 +151,7 @@ def render_external_app_skill(
         if external_app
         else {}
     )
-    section = build_action_availability_section(app_type, stored)
+    section = build_action_availability_section(app_type, stored, granted_scopes)
     if section:
         return template.replace(ACTION_AVAILABILITY_PLACEHOLDER, section)
     # Nothing disabled: drop the placeholder and its trailing blank line so the

--- a/backend/tests/unit/external_apps/test_skill_action_availability.py
+++ b/backend/tests/unit/external_apps/test_skill_action_availability.py
@@ -1,0 +1,258 @@
+"""Scope-gating of the actions a skill advertises (ENG-4262).
+
+``build_action_availability_section`` fences off what the agent must not
+attempt. Beyond the admin's ``DENY`` policies it now also hides actions the
+user's OAuth grant can't authorize — HubSpot requests its write scopes as
+*optional* scopes (ENG-4260), so a read-only account connects fine but 401s on
+every write. A grant we have no record of (``granted_scopes is None``, i.e. a
+credential written before ENG-4261 or a provider that never reports scopes)
+gates nothing, so pre-existing credentials keep their full skill body.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import EndpointPolicy, ExternalAppType
+from onyx.external_apps.providers.hubspot import HubspotAction
+from onyx.external_apps.providers.registry import get_endpoint_catalog
+from onyx.skills.rendering import (
+    ACTION_AVAILABILITY_PLACEHOLDER,
+    build_action_availability_section,
+    render_external_app_skill,
+)
+
+_READ_SCOPES = [
+    "oauth",
+    "crm.objects.owners.read",
+    "crm.objects.contacts.read",
+    "crm.objects.companies.read",
+    "crm.objects.deals.read",
+]
+_WRITE_SCOPES = [
+    "crm.objects.contacts.write",
+    "crm.objects.companies.write",
+    "crm.objects.deals.write",
+]
+_FULL_SCOPES = _READ_SCOPES + _WRITE_SCOPES
+
+_WRITE_ACTIONS = (
+    HubspotAction.CONTACTS_WRITE,
+    HubspotAction.COMPANIES_WRITE,
+    HubspotAction.DEALS_WRITE,
+)
+_READ_ACTIONS = (
+    HubspotAction.OWNERS_READ,
+    HubspotAction.CONTACTS_READ,
+    HubspotAction.COMPANIES_READ,
+    HubspotAction.DEALS_READ,
+    HubspotAction.CRM_SEARCH,
+)
+
+
+def _name(action: HubspotAction) -> str:
+    """The action's admin display name, which is what the section lists."""
+    for endpoint in get_endpoint_catalog(ExternalAppType.HUBSPOT):
+        if endpoint.id == action:
+            return endpoint.normalised_name
+    raise AssertionError(f"{action} missing from the HubSpot catalog")
+
+
+def _listed(section: str) -> list[str]:
+    return [line[2:] for line in section.splitlines() if line.startswith("- ")]
+
+
+# --- The catalog declares which actions are scope-gated at all ---------------
+
+
+@pytest.mark.parametrize(
+    "action, scope",
+    [
+        (HubspotAction.CONTACTS_WRITE, "crm.objects.contacts.write"),
+        (HubspotAction.COMPANIES_WRITE, "crm.objects.companies.write"),
+        (HubspotAction.DEALS_WRITE, "crm.objects.deals.write"),
+    ],
+)
+def test_hubspot_writes_declare_their_optional_scope(
+    action: HubspotAction, scope: str
+) -> None:
+    endpoint = next(
+        e for e in get_endpoint_catalog(ExternalAppType.HUBSPOT) if e.id == action
+    )
+    assert endpoint.required_scopes == (scope,)
+
+
+@pytest.mark.parametrize("action", _READ_ACTIONS)
+def test_hubspot_reads_declare_no_required_scopes(action: HubspotAction) -> None:
+    """Reads are in the mandatory scope set, so every connected user has them;
+    declaring them would only add a check that can never fail."""
+    endpoint = next(
+        e for e in get_endpoint_catalog(ExternalAppType.HUBSPOT) if e.id == action
+    )
+    assert endpoint.required_scopes == ()
+
+
+# --- Scope gating ------------------------------------------------------------
+
+
+def test_read_only_grant_marks_writes_unavailable() -> None:
+    section = build_action_availability_section(
+        ExternalAppType.HUBSPOT, {}, _READ_SCOPES
+    )
+    assert _listed(section) == [_name(action) for action in _WRITE_ACTIONS]
+    assert section.startswith(
+        "These actions are unavailable and should not be attempted:"
+    )
+
+
+def test_read_only_grant_keeps_reads_available() -> None:
+    section = build_action_availability_section(
+        ExternalAppType.HUBSPOT, {}, _READ_SCOPES
+    )
+    listed = _listed(section)
+    for action in _READ_ACTIONS:
+        assert _name(action) not in listed
+
+
+def test_partial_write_grant_hides_only_the_missing_writes() -> None:
+    """HubSpot drops individual ungrantable optional scopes, so a grant can hold
+    some writes and not others."""
+    section = build_action_availability_section(
+        ExternalAppType.HUBSPOT,
+        {},
+        _READ_SCOPES + ["crm.objects.contacts.write"],
+    )
+    assert _listed(section) == [
+        _name(HubspotAction.COMPANIES_WRITE),
+        _name(HubspotAction.DEALS_WRITE),
+    ]
+
+
+def test_full_grant_lists_nothing() -> None:
+    assert (
+        build_action_availability_section(ExternalAppType.HUBSPOT, {}, _FULL_SCOPES)
+        == ""
+    )
+
+
+def test_unknown_grant_gates_nothing() -> None:
+    """Regression guard: ``None`` is "we have no record", not "nothing granted"."""
+    assert build_action_availability_section(ExternalAppType.HUBSPOT, {}, None) == ""
+
+
+def test_granted_scopes_defaults_to_unknown() -> None:
+    """Callers that don't resolve a credential keep the pre-ENG-4262 behaviour."""
+    assert build_action_availability_section(ExternalAppType.HUBSPOT, {}) == ""
+
+
+def test_empty_grant_hides_every_scope_gated_action() -> None:
+    """An empty list is an authoritative "granted nothing" (providers record an
+    unreadable grant as ``None``), so the writes go."""
+    assert _listed(
+        build_action_availability_section(ExternalAppType.HUBSPOT, {}, [])
+    ) == [_name(action) for action in _WRITE_ACTIONS]
+
+
+# --- DENY policies, and the two gates together -------------------------------
+
+
+def test_deny_policy_still_listed_with_unknown_grant() -> None:
+    section = build_action_availability_section(
+        ExternalAppType.HUBSPOT,
+        {HubspotAction.DEALS_READ: EndpointPolicy.DENY},
+        None,
+    )
+    assert _listed(section) == [_name(HubspotAction.DEALS_READ)]
+
+
+def test_deny_policy_still_listed_with_full_grant() -> None:
+    section = build_action_availability_section(
+        ExternalAppType.HUBSPOT,
+        {HubspotAction.CONTACTS_WRITE: EndpointPolicy.DENY},
+        _FULL_SCOPES,
+    )
+    assert _listed(section) == [_name(HubspotAction.CONTACTS_WRITE)]
+
+
+def test_deny_and_scope_denied_action_is_listed_once() -> None:
+    section = build_action_availability_section(
+        ExternalAppType.HUBSPOT,
+        {HubspotAction.DEALS_WRITE: EndpointPolicy.DENY},
+        _READ_SCOPES,
+    )
+    listed = _listed(section)
+    assert listed.count(_name(HubspotAction.DEALS_WRITE)) == 1
+    assert listed == [_name(action) for action in _WRITE_ACTIONS]
+
+
+def test_deny_and_scope_gates_combine() -> None:
+    section = build_action_availability_section(
+        ExternalAppType.HUBSPOT,
+        {HubspotAction.CRM_SEARCH: EndpointPolicy.DENY},
+        _READ_SCOPES,
+    )
+    assert set(_listed(section)) == {
+        _name(HubspotAction.CRM_SEARCH),
+        *(_name(action) for action in _WRITE_ACTIONS),
+    }
+    # Catalog order, not "denies first".
+    assert _listed(section)[0] == _name(HubspotAction.CRM_SEARCH)
+
+
+# --- Rendering the template around the section -------------------------------
+
+
+def _template_dir(tmp_path: Path, body: str) -> Path:
+    (tmp_path / "SKILL.md.template").write_text(body)
+    return tmp_path
+
+
+def test_render_substitutes_the_scope_gated_section(tmp_path: Path) -> None:
+    skill_dir = _template_dir(
+        tmp_path, f"# HubSpot\n\n{ACTION_AVAILABILITY_PLACEHOLDER}\n\n## Usage\n"
+    )
+    rendered = render_external_app_skill(
+        # Unused: ``external_app is None`` short-circuits the policy lookup.
+        db_session=cast(Session, None),
+        app_type=ExternalAppType.HUBSPOT,
+        external_app=None,
+        skill_dir=skill_dir,
+        granted_scopes=_READ_SCOPES,
+    )
+    assert ACTION_AVAILABILITY_PLACEHOLDER not in rendered
+    assert "These actions are unavailable and should not be attempted:" in rendered
+    for action in _WRITE_ACTIONS:
+        assert _name(action) in rendered
+
+
+def test_render_drops_the_placeholder_on_a_full_grant(tmp_path: Path) -> None:
+    skill_dir = _template_dir(
+        tmp_path, f"# HubSpot\n\n{ACTION_AVAILABILITY_PLACEHOLDER}\n\n## Usage\n"
+    )
+    rendered = render_external_app_skill(
+        # Unused: ``external_app is None`` short-circuits the policy lookup.
+        db_session=cast(Session, None),
+        app_type=ExternalAppType.HUBSPOT,
+        external_app=None,
+        skill_dir=skill_dir,
+        granted_scopes=_FULL_SCOPES,
+    )
+    assert rendered == "# HubSpot\n\n## Usage\n"
+
+
+def test_shipped_hubspot_template_carries_the_placeholder() -> None:
+    """The gating is conveyed purely through the placeholder, so the shipped
+    template must still contain it."""
+    template = (
+        Path(__file__).resolve().parents[3]
+        / "onyx"
+        / "skills"
+        / "builtin"
+        / "hubspot"
+        / "SKILL.md.template"
+    ).read_text()
+    assert ACTION_AVAILABILITY_PLACEHOLDER in template


### PR DESCRIPTION
## Description

If `SKILL.md` advertises HubSpot **write** actions to a read-only account, the agent
attempts `deals-writer`/`companies-writer` calls that 401 and then has to reason about
the auth error (the confusion pattern noted in ENG-3748). Since ENG-4260 requests the
write scopes as *optional* scopes, the grant genuinely differs per user, so the
advertised action list is now gated on the grant ENG-4261 persists.

- `EndpointSpec` gains `required_scopes: tuple[str, ...] = ()` — the OAuth scopes an
  account must have granted for an action to work. Only worth declaring where the
  provider requests the scope optionally; left empty elsewhere.
- The three HubSpot write endpoints declare their write scope
  (`crm.objects.{contacts,companies,deals}.write`); the reads are in the mandatory
  scope set, so they declare nothing. The scope literals are now module constants
  shared with `_OPTIONAL_WRITE_SCOPES`, so the two can't drift — the strings sent to
  HubSpot's authorize endpoint are unchanged.
- `build_action_availability_section` / `render_external_app_skill` take an optional
  `granted_scopes`, and list an action as unavailable when the admin policy is `DENY`
  **or** the grant is missing a scope the action requires. One combined list in catalog
  order, so an action that's both is never named twice, and the existing wording is
  unchanged.
- `push.py` resolves the rendering user's `ExternalAppUserCredential.granted_scopes` and
  passes it through. `granted_scopes is None` (legacy row, or a provider that can't
  report scopes) means "grant unknown" and gates nothing, so pre-existing credentials
  render exactly as before; the new params default to `None` for the same reason.
- `SKILL.md.template` and `hubspot_api.py` are untouched — the existing
  `{{ACTION_AVAILABILITY_SECTION}}` placeholder carries the gating, and leaving
  `hubspot_api.py` alone keeps this off #12572's toes.

Note: `build_action_availability_section` now walks `get_endpoint_catalog` +
`effective_policy` instead of `action_policy_views`, because the FE-facing
`ActionPolicyView` doesn't carry `required_scopes` and shouldn't have to. Same registry
helpers, same order, same policy resolution — `action_policy_views` composes those two
internally.

## How Has This Been Tested?

Added `backend/tests/unit/external_apps/test_skill_action_availability.py` (22 tests)
covering: read-only grant → the three writes listed unavailable; partial grant → only
the ungranted writes; full grant → empty section; `granted_scopes=None` and the param
omitted → nothing gated (regression guards for existing credentials); `[]` → all writes
gated; `DENY` still works with unknown and full grants; an action both `DENY`-ed and
scope-denied is listed exactly once; both gates combine in catalog order;
`render_external_app_skill` substitutes the section and still drops the placeholder plus
its blank line on a full grant; the shipped HubSpot template still contains the
placeholder.

- `python -m pytest tests/unit/external_apps/ -q` → **344 passed** (322 on a clean
  `main`, + the 22 new — no regressions).
- `python -m pytest tests/unit/onyx/skills tests/unit/external_apps -q` → **504 passed**.
- `ruff check` and `ruff format --check` clean on all five changed files.

## Additional Options

Fixes ENG-4262 — https://linear.app/onyx-app/issue/ENG-4262/surface-only-granted-hubspot-actions-in-the-skillagents-context

Part of the HubSpot read/write-gap series, relating to ENG-4260 (optional write scopes),
ENG-4261 (persist per-user granted scopes), and ENG-4263 (friendly 401 message, #12572).

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate HubSpot skill actions by the user’s granted OAuth scopes so read-only accounts don’t see write actions, preventing 401s and agent confusion. Satisfies ENG-4262 using the persisted per-user grant.

- **New Features**
  - Added `required_scopes` to `EndpointSpec` to gate actions that rely on optional OAuth scopes.
  - HubSpot write endpoints declare their scopes (`crm.objects.contacts.write`, `crm.objects.companies.write`, `crm.objects.deals.write`) as module constants shared with `_OPTIONAL_WRITE_SCOPES`.
  - `build_action_availability_section` now combines admin `DENY` policies and missing scopes into one “unavailable actions” list in catalog order; `render_external_app_skill` accepts `granted_scopes`.
  - `push.py` resolves and passes the user’s `ExternalAppUserCredential.granted_scopes`; `None` means unknown and does not gate actions, preserving behavior for existing credentials.

<sup>Written for commit 441a96ade165fadefeea9e798adc49364f262711. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

