### PR TITLE
chore(lint): enable flake8-bugbear ruff rules

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
@@ -414,7 +414,7 @@ def connector_permission_sync_generator_task(
 
     LoggerContextVars.reset()
 
-    doc_permission_sync_ctx_dict = doc_permission_sync_ctx.get()
+    doc_permission_sync_ctx_dict = dict(doc_permission_sync_ctx.get())
     doc_permission_sync_ctx_dict["cc_pair_id"] = cc_pair_id
     doc_permission_sync_ctx_dict["request_id"] = self.request.id
     doc_permission_sync_ctx.set(doc_permission_sync_ctx_dict)

--- a/backend/ee/onyx/external_permissions/github/utils.py
+++ b/backend/ee/onyx/external_permissions/github/utils.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from enum import Enum
+from functools import partial
 from typing import List, Optional, Tuple, TypeVar
 
 from github import Github, RateLimitExceededException
@@ -151,7 +152,7 @@ def _fetch_repository_teams_detailed(
 
         members: PaginatedList[NamedUser] | list[NamedUser] = (
             _run_with_retry(
-                lambda: team.get_members(),
+                team.get_members,
                 f"get members for team {team.name}",
                 github_client,
             )
@@ -230,7 +231,7 @@ def _get_collaborators_and_outside_collaborators(
             if org is not None:
                 org_obj = org
                 membership = _run_with_retry(
-                    lambda: org_obj.has_in_members(collaborator),
+                    partial(org_obj.has_in_members, collaborator),
                     f"check membership for {collaborator.login} in org {org_obj.login}",
                     github_client,
                 )

--- a/backend/ee/onyx/server/gateway/api.py
+++ b/backend/ee/onyx/server/gateway/api.py
@@ -1246,7 +1246,7 @@ def _anthropic_stream_worker(
                     tc for tc in finalized_tool_calls or [] if tc.function.name
                 ]
                 for tool_index, (tool_block, tool_call) in enumerate(
-                    zip(tool_blocks, named_tool_calls), start=next_index
+                    zip(tool_blocks, named_tool_calls, strict=True), start=next_index
                 ):
                     emit(
                         AnthropicContentBlockStartEvent.create(

--- a/backend/ee/onyx/server/middleware/tenant_tracking.py
+++ b/backend/ee/onyx/server/middleware/tenant_tracking.py
@@ -186,12 +186,12 @@ async def _get_tenant_id_from_request(
         # and fall back to the wrong tenant. Fall back only on the normal path.
         if sys.exc_info()[0] is None:
             if tenant_id:
-                return tenant_id
+                return tenant_id  # noqa: B012
 
             # As a final step, check for explicit tenant_id cookie
             tenant_id_cookie = request.cookies.get(TENANT_ID_COOKIE_NAME)
             if tenant_id_cookie and is_valid_schema_name(tenant_id_cookie):
-                return tenant_id_cookie
+                return tenant_id_cookie  # noqa: B012
 
             # If we've reached this point, return the default schema
-            return POSTGRES_DEFAULT_SCHEMA
+            return POSTGRES_DEFAULT_SCHEMA  # noqa: B012

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1884,12 +1884,12 @@ class FastAPIUserWithRefreshRouter(FastAPIUsers[models.UP, models.ID]):
 
                 # Check if strategy supports refreshing
                 supports_refresh = hasattr(strategy, "refresh_token") and callable(
-                    getattr(strategy, "refresh_token")
+                    getattr(strategy, "refresh_token")  # noqa: B009
                 )
 
                 if supports_refresh:
                     try:
-                        refresh_method = getattr(strategy, "refresh_token")
+                        refresh_method = getattr(strategy, "refresh_token")  # noqa: B009
                         new_token = await refresh_method(token, user)
                         logger.info(
                             "Successfully refreshed session token for user %s",

--- a/backend/onyx/background/celery/tasks/docfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/docfetching/tasks.py
@@ -564,7 +564,7 @@ def docfetching_proxy_task(
                     )
                 finally:
                     job.release()
-                    break
+                break
 
             # log the memory usage for tracking down memory leaks / connector-specific memory issues
             pid = job.process.pid

--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -843,7 +843,7 @@ def cloud_check_alembic() -> bool | None:
                     tenant_to_revision[tenant_id] = ALEMBIC_NULL_REVISION
 
         # get the total count of each revision
-        for k, v in tenant_to_revision.items():
+        for v in tenant_to_revision.values():
             revision_counts[v] = revision_counts.get(v, 0) + 1
 
         # error if any null revision tenants are found

--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -496,7 +496,7 @@ def connector_pruning_generator_task(
 
     LoggerContextVars.reset()
 
-    pruning_ctx_dict = pruning_ctx.get()
+    pruning_ctx_dict = dict(pruning_ctx.get())
     pruning_ctx_dict["cc_pair_id"] = cc_pair_id
     pruning_ctx_dict["request_id"] = self.request.id
     pruning_ctx.set(pruning_ctx_dict)

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -923,7 +923,7 @@ def build_chat_turn(
             user_message_id=user_message.id,
             responses=[
                 ModelResponseSlot(message_id=m.id, model_name=name)
-                for m, name in zip(reserved_messages, model_display_names)
+                for m, name in zip(reserved_messages, model_display_names, strict=True)
             ],
         )
     else:

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -743,9 +743,9 @@ REDIS_SOCKET_KEEPALIVE_OPTIONS[socket.TCP_KEEPCNT] = 3
 # platform where the attribute actually resolves, since ty analyzes one
 # platform at a time and can't model cross-platform conditional unused-ignores.
 if platform.system() == "Darwin":
-    REDIS_SOCKET_KEEPALIVE_OPTIONS[getattr(socket, "TCP_KEEPALIVE")] = 60
+    REDIS_SOCKET_KEEPALIVE_OPTIONS[getattr(socket, "TCP_KEEPALIVE")] = 60  # noqa: B009
 else:
-    REDIS_SOCKET_KEEPALIVE_OPTIONS[getattr(socket, "TCP_KEEPIDLE")] = 60
+    REDIS_SOCKET_KEEPALIVE_OPTIONS[getattr(socket, "TCP_KEEPIDLE")] = 60  # noqa: B009
 
 
 class OnyxCallTypes(str, Enum):

--- a/backend/onyx/connectors/airtable/airtable_connector.py
+++ b/backend/onyx/connectors/airtable/airtable_connector.py
@@ -48,7 +48,6 @@ DEFAULT_METADATA_FIELD_TYPES = {
     "lookup",
     "count",
     "formula",
-    "date",
 }
 
 
@@ -249,7 +248,9 @@ class AirtableConnector(LoadConnector):
                     backoff=2,
                     max_delay=10,
                 )
-                def get_attachment_with_retry(url: str, record_id: str) -> bytes | None:
+                def get_attachment_with_retry(
+                    url: str, record_id: str, filename: str
+                ) -> bytes | None:
                     try:
                         attachment_response = requests.get(
                             url, timeout=REQUEST_TIMEOUT_SECONDS
@@ -280,7 +281,7 @@ class AirtableConnector(LoadConnector):
                             )
                         raise
 
-                attachment_content = get_attachment_with_retry(url, record_id)
+                attachment_content = get_attachment_with_retry(url, record_id, filename)
                 if attachment_content:
                     try:
                         file_ext = get_file_ext(filename)

--- a/backend/onyx/connectors/connector_runner.py
+++ b/backend/onyx/connectors/connector_runner.py
@@ -177,10 +177,13 @@ class ConnectorRunner(Generic[CT]):
                     document,
                     hierarchy_node,
                     failure,
-                    _next_checkpoint,
+                    loop_checkpoint,
                 ) in CheckpointOutputWrapper[CT]()(
                     checkpoint_connector_generator  # ty: ignore[invalid-argument-type]
                 ):
+                    # Keep the last checkpoint seen; it is yielded after the loop.
+                    next_checkpoint = loop_checkpoint
+
                     if document is not None:
                         self.doc_batch.append(document)
 

--- a/backend/onyx/connectors/connector_runner.py
+++ b/backend/onyx/connectors/connector_runner.py
@@ -33,7 +33,7 @@ def batched_doc_ids(
     batch_size: int,
 ) -> Generator[set[str], None, None]:
     batch: set[str] = set()
-    for document, hierarchy_node, failure, next_checkpoint in CheckpointOutputWrapper[
+    for document, _hierarchy_node, failure, _next_checkpoint in CheckpointOutputWrapper[
         CT
     ]()(checkpoint_connector_generator):
         if document is not None:
@@ -177,7 +177,7 @@ class ConnectorRunner(Generic[CT]):
                     document,
                     hierarchy_node,
                     failure,
-                    next_checkpoint,
+                    _next_checkpoint,
                 ) in CheckpointOutputWrapper[CT]()(
                     checkpoint_connector_generator  # ty: ignore[invalid-argument-type]
                 ):

--- a/backend/onyx/connectors/discord/connector.py
+++ b/backend/onyx/connectors/discord/connector.py
@@ -266,12 +266,16 @@ def _manage_async_retrieval(
 class DiscordConnector(PollConnector, LoadConnector):
     def __init__(
         self,
-        server_ids: list[str] = [],
-        channel_names: list[str] = [],
+        server_ids: list[str] | None = None,
+        channel_names: list[str] | None = None,
         # YYYY-MM-DD
         start_date: str | None = None,
         batch_size: int = INDEX_BATCH_SIZE,
     ):
+        if channel_names is None:
+            channel_names = []
+        if server_ids is None:
+            server_ids = []
         self.batch_size = batch_size
         self.channel_names: list[str] = channel_names if channel_names else []
         self.server_ids: list[int] = (

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -238,7 +238,7 @@ def _process_file(
         )
 
     # Then any extracted images from docx, PDFs, etc.
-    for idx, (img_data, img_name) in enumerate(
+    for idx, (img_data, _img_name) in enumerate(
         extraction_result.embedded_images, start=1
     ):
         # Store each embedded image as a separate file in FileStore

--- a/backend/onyx/connectors/gitbook/connector.py
+++ b/backend/onyx/connectors/gitbook/connector.py
@@ -146,7 +146,7 @@ def _extract_text_from_document(document: dict[str, Any]) -> str:
                 records.items(), key=lambda x: x[1].get("orderIndex", "")
             )
 
-            for record_id, record_data in sorted_records:
+            for _record_id, record_data in sorted_records:
                 values = record_data.get("values", {})
                 row_cells = []
                 for col_id in columns:

--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -274,7 +274,7 @@ def _get_batch_rate_limited(
         # this is needed to capture the rate limit exception here (if one occurs)
         for obj in objs:
             if hasattr(obj, "raw_data"):
-                getattr(obj, "raw_data")
+                _ = obj.raw_data
         yield from objs
     except RateLimitExceededException:
         sleep_after_rate_limit_exception(github_client)
@@ -1489,7 +1489,7 @@ if __name__ == "__main__":
 
     # Run the connector
     while checkpoint.has_more:
-        for doc_batch, hierarchy_node_batch, failure, next_checkpoint in runner.run(
+        for doc_batch, _hierarchy_node_batch, failure, next_checkpoint in runner.run(
             checkpoint
         ):
             if doc_batch:

--- a/backend/onyx/connectors/salesforce/connector.py
+++ b/backend/onyx/connectors/salesforce/connector.py
@@ -217,9 +217,11 @@ class SalesforceConnector(LoadConnector, PollConnector, SlimConnectorWithPermSyn
     def __init__(
         self,
         batch_size: int = INDEX_BATCH_SIZE,
-        requested_objects: list[str] = [],
+        requested_objects: list[str] | None = None,
         custom_query_config: str | None = None,
     ) -> None:
+        if requested_objects is None:
+            requested_objects = []
         self.batch_size = batch_size
         self._sf_client: OnyxSalesforce | None = None
 
@@ -379,7 +381,7 @@ class SalesforceConnector(LoadConnector, PollConnector, SlimConnectorWithPermSyn
 
                 with open(csv_path, "r", newline="", encoding="utf-8") as f:
                     reader = csv.DictReader(f)
-                    for row in reader:
+                    for _row in reader:
                         num_records += 1
 
                 new_ids = sf_db.update_from_csv(
@@ -592,7 +594,7 @@ class SalesforceConnector(LoadConnector, PollConnector, SlimConnectorWithPermSyn
                     num_records = 0
                     with open(csv_path, "r", newline="", encoding="utf-8") as f:
                         reader = csv.DictReader(f)
-                        for row in reader:
+                        for _row in reader:
                             num_records += 1
 
                     logger.debug(

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1273,9 +1273,9 @@ class SharepointConnector(
     def __init__(
         self,
         batch_size: int = INDEX_BATCH_SIZE,
-        sites: list[str] = [],
-        excluded_sites: list[str] = [],
-        excluded_paths: list[str] = [],
+        sites: list[str] | None = None,
+        excluded_sites: list[str] | None = None,
+        excluded_paths: list[str] | None = None,
         include_site_pages: bool = True,
         include_site_documents: bool = True,
         treat_sharing_link_as_public: bool = False,
@@ -1283,6 +1283,12 @@ class SharepointConnector(
         graph_api_host: str = DEFAULT_GRAPH_API_HOST,
         sharepoint_domain_suffix: str = DEFAULT_SHAREPOINT_DOMAIN_SUFFIX,
     ) -> None:
+        if excluded_paths is None:
+            excluded_paths = []
+        if excluded_sites is None:
+            excluded_sites = []
+        if sites is None:
+            sites = []
         self.batch_size = batch_size
         self.sites = list(sites)
         self.excluded_sites = [s for p in excluded_sites if (s := p.strip())]
@@ -1377,7 +1383,7 @@ class SharepointConnector(
         )
         unauthorized_sites: list[str] = [
             site_url
-            for site_url, authorized in zip(sites_to_probe, results)
+            for site_url, authorized in zip(sites_to_probe, results, strict=True)
             if authorized is False
         ]
 
@@ -3687,7 +3693,7 @@ if __name__ == "__main__":
 
     # Run the connector
     while checkpoint.has_more:
-        for doc_batch, hierarchy_node_batch, failure, next_checkpoint in runner.run(
+        for doc_batch, _hierarchy_node_batch, failure, next_checkpoint in runner.run(
             checkpoint
         ):
             if doc_batch:

--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -377,9 +377,7 @@ _DISALLOWED_MSG_SUBTYPES = {
     "group_leave",
     "group_archive",
     "group_unarchive",
-    "channel_leave",
     "channel_name",
-    "channel_join",
 }
 
 

--- a/backend/onyx/connectors/teams/connector.py
+++ b/backend/onyx/connectors/teams/connector.py
@@ -2,6 +2,7 @@ import copy
 import os
 from collections.abc import Iterator
 from datetime import datetime, timezone
+from functools import partial
 from typing import Any
 
 import msal
@@ -72,11 +73,13 @@ class TeamsConnector(
         self,
         # TODO: (chris) move from "Display Names" to IDs, since display names
         # are not necessarily guaranteed to be unique
-        teams: list[str] = [],
+        teams: list[str] | None = None,
         max_workers: int = MAX_WORKERS,
         authority_host: str = DEFAULT_AUTHORITY_HOST,
         graph_api_host: str = DEFAULT_GRAPH_API_HOST,
     ) -> None:
+        if teams is None:
+            teams = []
         self.graph_client: GraphClient | None = None
         self.msal_app: msal.ConfidentialClientApplication | None = None
         self.max_workers = max_workers
@@ -593,9 +596,7 @@ def _collect_all_teams(
 
             if next_url:
                 url = next_url
-                query.before_execute(
-                    lambda req: _update_request_url(request=req, next_url=url)
-                )
+                query.before_execute(partial(_update_request_url, next_url=url))
 
             team_collection = execute_query_with_retry(
                 query, method_name="_collect_all_teams"
@@ -784,9 +785,7 @@ def _collect_all_channels_from_team(
         )
         if next_url:
             url = next_url
-            query = query.before_execute(
-                lambda req: _update_request_url(request=req, next_url=url)
-            )
+            query = query.before_execute(partial(_update_request_url, next_url=url))
 
         channel_collection = execute_query_with_retry(
             query, method_name="_collect_all_channels_from_team"
@@ -870,7 +869,7 @@ if __name__ == "__main__":
     )
     teams_connector.validate_connector_settings()
 
-    for slim_doc in teams_connector.retrieve_all_slim_docs_perm_sync():
+    for _slim_doc in teams_connector.retrieve_all_slim_docs_perm_sync():
         ...
 
     for doc in load_all_from_connector(

--- a/backend/onyx/context/search/federated/slack_search.py
+++ b/backend/onyx/context/search/federated/slack_search.py
@@ -1233,7 +1233,7 @@ def slack_retrieval(
         access_token=access_token,
         team_id=team_id,
     )
-    for slack_message, thread_text in zip(slack_messages, thread_texts):
+    for slack_message, thread_text in zip(slack_messages, thread_texts, strict=True):
         slack_message.text = thread_text
 
     # get the highlighted texts from shortest to longest

--- a/backend/onyx/context/search/pipeline.py
+++ b/backend/onyx/context/search/pipeline.py
@@ -174,7 +174,7 @@ def merge_individual_chunks(
     chunk_to_section: dict[tuple[str, int], InferenceSection] = {}
 
     # Process each document's chunks
-    for doc_id, doc_chunk_list in doc_chunks.items():
+    for _doc_id, doc_chunk_list in doc_chunks.items():
         if not doc_chunk_list:
             continue
 

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -1681,7 +1681,7 @@ def get_base_llm_doc_information(
 
     documents = []
 
-    for doc_nr, doc in enumerate(results):
+    for _doc_nr, doc in enumerate(results):
         bare_doc = doc[0]
         documents.append(
             f"""* [{bare_doc.semantic_id}]({bare_doc.link}) ({bare_doc.doc_updated_at})"""

--- a/backend/onyx/db/projects.py
+++ b/backend/onyx/db/projects.py
@@ -71,7 +71,7 @@ def create_user_files(
     id_to_temp_id: dict[str, str] = {}
     # Pair returned storage paths with the same set of acceptable files we uploaded
     for file_path, file in zip(
-        upload_response.file_paths, categorized_files.acceptable
+        upload_response.file_paths, categorized_files.acceptable, strict=True
     ):
         new_id = uuid.uuid4()
         new_temp_id = (

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -186,7 +186,7 @@ def get_all_users(
 
 def _get_accepted_user_where_clause(
     email_filter_string: str | None = None,
-    roles_filter: list[UserRole] = [],
+    roles_filter: list[UserRole] | None = None,
     include_external: bool = False,
     is_active_filter: bool | None = None,
 ) -> list[ColumnElement[bool]]:
@@ -206,6 +206,8 @@ def _get_accepted_user_where_clause(
 
     # Access table columns directly via __table__.c to get proper SQLAlchemy column types
     # This ensures type checking works correctly for SQL operations like ilike, endswith, and is_
+    if roles_filter is None:
+        roles_filter = []
     email_col: KeyedColumnElement[Any] = User.__table__.c.email
     is_active_col: KeyedColumnElement[Any] = User.__table__.c.is_active
 
@@ -258,9 +260,11 @@ def get_page_of_filtered_users(
     page_num: int,
     email_filter_string: str | None = None,
     is_active_filter: bool | None = None,
-    roles_filter: list[UserRole] = [],
+    roles_filter: list[UserRole] | None = None,
     include_external: bool = False,
 ) -> Sequence[User]:
+    if roles_filter is None:
+        roles_filter = []
     users_stmt = select(User)
 
     where_clause = _get_accepted_user_where_clause(
@@ -281,9 +285,11 @@ def get_total_filtered_users_count(
     db_session: Session,
     email_filter_string: str | None = None,
     is_active_filter: bool | None = None,
-    roles_filter: list[UserRole] = [],
+    roles_filter: list[UserRole] | None = None,
     include_external: bool = False,
 ) -> int:
+    if roles_filter is None:
+        roles_filter = []
     where_clause = _get_accepted_user_where_clause(
         email_filter_string=email_filter_string,
         roles_filter=roles_filter,

--- a/backend/onyx/document_index/document_index_utils.py
+++ b/backend/onyx/document_index/document_index_utils.py
@@ -160,8 +160,13 @@ def get_uuid_from_chunk_info(
 
 
 def get_uuid_from_chunk_info_old(
-    *, document_id: str, chunk_id: int, large_chunk_reference_ids: list[int] = []
+    *,
+    document_id: str,
+    chunk_id: int,
+    large_chunk_reference_ids: list[int] | None = None,
 ) -> UUID:
+    if large_chunk_reference_ids is None:
+        large_chunk_reference_ids = []
     doc_str = document_id
 
     # Web parsing URL duplicate catching
@@ -188,8 +193,11 @@ def get_uuid_from_chunk(chunk: DocMetadataAwareIndexChunk) -> uuid.UUID:
 
 
 def get_uuid_from_chunk_old(
-    chunk: DocMetadataAwareIndexChunk, large_chunk_reference_ids: list[int] = []
+    chunk: DocMetadataAwareIndexChunk,
+    large_chunk_reference_ids: list[int] | None = None,
 ) -> UUID:
+    if large_chunk_reference_ids is None:
+        large_chunk_reference_ids = []
     return get_uuid_from_chunk_info_old(
         document_id=chunk.source_document.id,
         chunk_id=chunk.chunk_id,

--- a/backend/onyx/evals/eval.py
+++ b/backend/onyx/evals/eval.py
@@ -446,8 +446,11 @@ def run_eval(
     configuration: EvalConfigurationOptions,
     data: list[dict[str, Any]] | None = None,
     remote_dataset_name: str | None = None,
-    provider: EvalProvider = get_provider(),
+    provider: EvalProvider | None = None,
 ) -> EvalationAck:
+    if provider is None:
+        provider = get_provider()
+
     if data is not None and remote_dataset_name is not None:
         raise ValueError("Cannot specify both data and remote_dataset_name")
 

--- a/backend/onyx/external_apps/providers/actions.py
+++ b/backend/onyx/external_apps/providers/actions.py
@@ -74,12 +74,16 @@ def path_matches(template: str, path: str) -> bool:
         # Wildcard must swallow >=1 segment and reject empties (`//`), like `{name}`.
         if not tail or not all(tail):
             return False
-        return all(_segment_matches(e, a) for e, a in zip(prefix, actual_segments))
+        return all(
+            _segment_matches(e, a)
+            for e, a in zip(prefix, actual_segments, strict=False)
+        )
 
     if len(expected_segments) != len(actual_segments):
         return False
     return all(
-        _segment_matches(e, a) for e, a in zip(expected_segments, actual_segments)
+        _segment_matches(e, a)
+        for e, a in zip(expected_segments, actual_segments, strict=True)
     )
 
 

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -69,7 +69,7 @@ def get_markitdown_converter() -> "MarkItDown":
         # unindexable.
         from markitdown.converters._pptx_converter import PptxConverter
 
-        setattr(
+        setattr(  # noqa: B010
             PptxConverter,
             "_convert_chart_to_markdown",
             lambda self, chart: "\n\n[chart omitted]\n\n",  # noqa: ARG005

--- a/backend/onyx/file_processing/html_utils.py
+++ b/backend/onyx/file_processing/html_utils.py
@@ -200,7 +200,7 @@ def web_html_cleanup(
         [
             tag.extract()
             for tag in soup.find_all(
-                class_=lambda x: x and undesired_element in x.split()
+                class_=lambda x, cls=undesired_element: x and cls in x.split()
             )
         ]
 

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
@@ -72,7 +72,7 @@ def format_columns_header(headers: list[str]) -> str:
 
 
 def _row_to_pairs(headers: list[str], row: list[str]) -> list[tuple[str, str]]:
-    return [(h, v) for h, v in zip(headers, row) if v.strip()]
+    return [(h, v) for h, v in zip(headers, row, strict=False) if v.strip()]
 
 
 def pack_chunk(chunk: str, new_row: str) -> str:

--- a/backend/onyx/indexing/embedder.py
+++ b/backend/onyx/indexing/embedder.py
@@ -178,7 +178,9 @@ class DefaultIndexingEmbedder(IndexingEmbedder):
             title_embed_dict.update(
                 {
                     title: vector
-                    for title, vector in zip(chunk_titles_list, title_embeddings)
+                    for title, vector in zip(
+                        chunk_titles_list, title_embeddings, strict=True
+                    )
                 }
             )
 

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -847,7 +847,7 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
             max_workers=MAX_IMAGE_WORKERS,
         )
 
-        for p, result in zip(pending, results):
+        for p, result in zip(pending, results, strict=True):
             p.section.text = result or "[Error processing image]"
 
     return indexed_documents

--- a/backend/onyx/indexing/port_reembed.py
+++ b/backend/onyx/indexing/port_reembed.py
@@ -300,7 +300,7 @@ def re_embed_chunks(
     ]
     doc_aware_chunks = [
         _stored_chunk_to_doc_aware(chunk, embed_input)
-        for chunk, embed_input in zip(stored_chunks, embed_inputs)
+        for chunk, embed_input in zip(stored_chunks, embed_inputs, strict=True)
     ]
     embedded = embedder.embed_chunks(doc_aware_chunks)
     # Pair each stored chunk with its OWN vector by identity, not list position.
@@ -312,7 +312,7 @@ def re_embed_chunks(
             content_vector=index_chunk.embeddings.full_embedding,
             title_vector=index_chunk.title_embedding,
         )
-        for stored, index_chunk in zip(stored_chunks, matched)
+        for stored, index_chunk in zip(stored_chunks, matched, strict=True)
     ]
 
 
@@ -341,7 +341,8 @@ def _reconstruct_source_document(
     contextual LLM to regenerate summaries — see the module docstring on the
     accepted imprecision of concatenating overlapping chunks."""
     ordered = sorted(
-        zip(stored_chunks, bare_contents), key=lambda pair: pair[0].chunk_index
+        zip(stored_chunks, bare_contents, strict=True),
+        key=lambda pair: pair[0].chunk_index,
     )
     doc_text = " ".join(bare for _, bare in ordered if bare)
     first = stored_chunks[0]
@@ -384,7 +385,7 @@ def _augmentation_reembed(
     pairs_by_doc: dict[str, list[tuple[DocumentChunkWithoutVectors, str]]] = (
         defaultdict(list)
     )
-    for chunk, bare in zip(stored_chunks, bare_contents):
+    for chunk, bare in zip(stored_chunks, bare_contents, strict=True):
         pairs_by_doc[chunk.document_id].append((chunk, bare))
     source_documents = {
         doc_id: _reconstruct_source_document(
@@ -417,7 +418,7 @@ def _augmentation_reembed(
             large_chunk_id=None,
             large_chunk_reference_ids=[],
         )
-        for chunk, bare in zip(stored_chunks, bare_contents)
+        for chunk, bare in zip(stored_chunks, bare_contents, strict=True)
     ]
 
     if future_rag_on:
@@ -441,7 +442,9 @@ def _augmentation_reembed(
     matched = _match_embeddings_by_identity(stored_chunks, embedded)
 
     results: list[DocumentChunk] = []
-    for stored, doc_aware, index_chunk in zip(stored_chunks, doc_aware_chunks, matched):
+    for stored, doc_aware, index_chunk in zip(
+        stored_chunks, doc_aware_chunks, matched, strict=True
+    ):
         fields = dict(stored)
         # The stored (BM25) content, rebuilt under FUTURE enrichment.
         fields["content"] = generate_enriched_content_for_chunk_text(doc_aware)

--- a/backend/onyx/kg/clustering/clustering.py
+++ b/backend/onyx/kg/clustering/clustering.py
@@ -329,7 +329,7 @@ def kg_clustering(
     # Cluster and transfer grounded entities sequentially
     start_time = time.monotonic()
     i_batch = 0
-    for i_batch, untransferred_grounded_entities in enumerate(
+    for i_batch, untransferred_grounded_entities in enumerate(  # noqa: B007
         _get_batch_untransferred_grounded_entities(
             batch_size=processing_chunk_batch_size
         )
@@ -367,7 +367,7 @@ def kg_clustering(
     # Transfer the relationship types (no need to do in parallel as there's only a few)
     start_time = time.monotonic()
     i_batch = 0
-    for i_batch, relationship_types in enumerate(
+    for i_batch, relationship_types in enumerate(  # noqa: B007
         _get_batch_untransferred_relationship_types(
             batch_size=processing_chunk_batch_size
         )
@@ -390,7 +390,7 @@ def kg_clustering(
     # Transfer the relationships in parallel
     start_time = time.monotonic()
     i_batch = 0
-    for i_batch, relationships in enumerate(
+    for i_batch, relationships in enumerate(  # noqa: B007
         _get_batch_untransferred_relationships(batch_size=processing_chunk_batch_size)
     ):
         run_functions_tuples_in_parallel(
@@ -413,7 +413,7 @@ def kg_clustering(
     # Update vespa for each document
     start_time = time.monotonic()
     i_batch = 0
-    for i_batch, documents in enumerate(
+    for i_batch, documents in enumerate(  # noqa: B007
         _get_batch_kg_processed_documents(batch_size=processing_chunk_batch_size)
     ):
         batch_update_requests = run_functions_tuples_in_parallel(
@@ -422,7 +422,9 @@ def kg_clustering(
                 for document in documents
             ]
         )
-        for update_requests, document in zip(batch_update_requests, documents):
+        for update_requests, document in zip(
+            batch_update_requests, documents, strict=True
+        ):
             try:
                 update_kg_chunks_vespa_info(update_requests, index_name, tenant_id)
             except Exception as e:

--- a/backend/onyx/kg/clustering/normalizations.py
+++ b/backend/onyx/kg/clustering/normalizations.py
@@ -251,11 +251,11 @@ def normalize_entities(
     mapping: list[str | None] = run_functions_tuples_in_parallel(
         [
             (_normalize_one_entity, (entity, attributes, allowed_docs_temp_view_name))
-            for entity, attributes in zip(raw_entities, entity_attributes)
+            for entity, attributes in zip(raw_entities, entity_attributes, strict=True)
         ]
     )
     for entity, attributes, normalized_entity in zip(
-        raw_entities, entity_attributes, mapping
+        raw_entities, entity_attributes, mapping, strict=True
     ):
         if normalized_entity is not None:
             normalized_entities.append(normalized_entity)

--- a/backend/onyx/kg/extractions/extraction_processing.py
+++ b/backend/onyx/kg/extractions/extraction_processing.py
@@ -406,7 +406,9 @@ def kg_extraction(
             batch_deep_extractions: dict[str, KGDocumentDeepExtractionResults] = {
                 document_id: result
                 for document_id, result in zip(
-                    documents_to_process,
+                    # Only the deep-extraction documents have a result. Skipped
+                    # documents are not in `batch_deep_extraction_args`.
+                    [arg[0] for arg in batch_deep_extraction_args],
                     run_functions_tuples_in_parallel(batch_deep_extraction_func_calls),
                     strict=True,
                 )

--- a/backend/onyx/kg/extractions/extraction_processing.py
+++ b/backend/onyx/kg/extractions/extraction_processing.py
@@ -408,6 +408,7 @@ def kg_extraction(
                 for document_id, result in zip(
                     documents_to_process,
                     run_functions_tuples_in_parallel(batch_deep_extraction_func_calls),
+                    strict=True,
                 )
             }
 

--- a/backend/onyx/kg/utils/extraction_utils.py
+++ b/backend/onyx/kg/utils/extraction_utils.py
@@ -398,7 +398,6 @@ def kg_classify_document(
         return None
 
     # prepare prompt
-    implied_extraction.document_entity
     company_participants = implied_extraction.company_participant_emails
     account_participants = implied_extraction.account_participant_emails
     content = (

--- a/backend/onyx/kg/vespa/vespa_interactions.py
+++ b/backend/onyx/kg/vespa/vespa_interactions.py
@@ -53,7 +53,7 @@ def get_document_vespa_contents(
     # Convert Vespa chunks to KGChunks
     # kg_chunks: list[KGChunkFormat] = []
 
-    for i, chunk in enumerate(chunks):
+    for _i, chunk in enumerate(chunks):
         fields = chunk["fields"]
         if isinstance(fields.get("metadata", {}), str):
             fields["metadata"] = json.loads(fields["metadata"])

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -103,7 +103,7 @@ def _unwrap_nested_exception(error: Exception) -> Exception:
             candidate = cause
         elif (
             hasattr(current, "args")
-            and len(getattr(current, "args")) == 1
+            and len(current.args) == 1
             and isinstance(current.args[0], Exception)
         ):
             candidate = current.args[0]

--- a/backend/onyx/natural_language_processing/query_embedding_cache.py
+++ b/backend/onyx/natural_language_processing/query_embedding_cache.py
@@ -227,7 +227,7 @@ def cache_query_embeddings(
 
     successes = 0
     errors = 0
-    for query, embedding in zip(queries, embeddings):
+    for query, embedding in zip(queries, embeddings, strict=True):
         key = _build_key(query, search_settings_id)
         try:
             packed = _safe_pack_or_none(embedding)

--- a/backend/onyx/onyxbot/discord/cache.py
+++ b/backend/onyx/onyxbot/discord/cache.py
@@ -82,7 +82,7 @@ class DiscordCacheManager:
                     max_workers=_REFRESH_MAX_WORKERS,
                 )
 
-                for tenant_id, result in zip(tenant_ids, results):
+                for tenant_id, result in zip(tenant_ids, results, strict=True):
                     if result is None:
                         continue
 

--- a/backend/onyx/prompts/prompt_utils.py
+++ b/backend/onyx/prompts/prompt_utils.py
@@ -301,7 +301,7 @@ def drop_messages_history_overflow(
 
     final_messages: list[BaseMessage] = []
     messages, token_counts = cast(
-        tuple[list[BaseMessage], list[int]], zip(*messages_with_token_cnts)
+        tuple[list[BaseMessage], list[int]], zip(*messages_with_token_cnts, strict=True)
     )
     system_msg = (
         final_messages[0]

--- a/backend/onyx/secondary_llm_flows/memory_update.py
+++ b/backend/onyx/secondary_llm_flows/memory_update.py
@@ -27,7 +27,7 @@ def _format_chat_history(chat_history: list[ChatMinimalTextMessage]) -> str:
     recent_user_messages = user_messages[-MAX_USER_MESSAGES:]
 
     formatted_parts = []
-    for i, msg in enumerate(recent_user_messages, start=1):
+    for _i, msg in enumerate(recent_user_messages, start=1):
         if len(msg.message) > MAX_CHARS_PER_MESSAGE:
             truncated_message = msg.message[:MAX_CHARS_PER_MESSAGE] + "[...truncated]"
         else:

--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -507,7 +507,7 @@ def list_connector_files(
         )
         backfilled_sizes = {
             file_id: size
-            for file_id, size in zip(missing_size_ids, looked_up_sizes)
+            for file_id, size in zip(missing_size_ids, looked_up_sizes, strict=True)
             if isinstance(size, int)
         }
         if backfilled_sizes:
@@ -523,7 +523,7 @@ def list_connector_files(
                 )
 
     files = []
-    for file_id, file_name in zip(file_locations, file_names):
+    for file_id, file_name in zip(file_locations, file_names, strict=False):
         record = records_by_id.get(file_id)
         file_size = None
         upload_date = None
@@ -657,7 +657,9 @@ def update_connector_files(
     remaining_file_names = []
     removed_file_names = set()
 
-    for file_id, file_name in zip(current_file_locations, current_file_names):
+    for file_id, file_name in zip(
+        current_file_locations, current_file_names, strict=False
+    ):
         if file_id not in files_to_remove_set:
             remaining_file_locations.append(file_id)
             remaining_file_names.append(file_name)

--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -839,7 +839,7 @@ def _merge_field_meta(event: SandboxEvent, extra: dict[str, Any]) -> None:
     existing = getattr(event, "field_meta", None)
     merged: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
     merged.update(extra)
-    setattr(event, "field_meta", merged)
+    setattr(event, "field_meta", merged)  # noqa: B010
 
 
 def _emit_tool_events(

--- a/backend/onyx/server/features/default_assistant/models.py
+++ b/backend/onyx/server/features/default_assistant/models.py
@@ -29,6 +29,3 @@ class DefaultAssistantUpdateRequest(BaseModel):
         default=None,
         description="New system prompt (instructions). None resets to default, empty string is allowed.",
     )
-
-
-3

--- a/backend/onyx/server/features/projects/api.py
+++ b/backend/onyx/server/features/projects/api.py
@@ -31,6 +31,8 @@ from onyx.db.projects import (
     get_project_token_count,
     upload_files_to_user_files_with_indexing,
 )
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.projects.models import (
     CategorizedFilesSnapshot,
     ChatSessionRequest,
@@ -45,6 +47,19 @@ logger = setup_logger()
 
 
 router = APIRouter(prefix="/user/projects")
+
+# `user_project.name` and `user_project.description` are both varchar(255). Longer
+# values make Postgres reject the write, which surfaces as a 500.
+_MAX_PROJECT_FIELD_LENGTH = 255
+
+
+def _validate_project_field_length(value: str, field_name: str) -> None:
+    if len(value) > _MAX_PROJECT_FIELD_LENGTH:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"Project {field_name} cannot be longer than "
+            f"{_MAX_PROJECT_FIELD_LENGTH} characters",
+        )
 
 
 class UserFileDeleteResult(BaseModel):
@@ -119,6 +134,7 @@ def create_project(
 ) -> UserProjectSnapshot:
     if name == "":
         raise HTTPException(status_code=400, detail="Project name cannot be empty")
+    _validate_project_field_length(name, "name")
     user_id = user.id
     project = UserProject(name=name, user_id=user_id)
     db_session.add(project)
@@ -405,8 +421,10 @@ def update_project(
         raise HTTPException(status_code=404, detail="Project not found")
 
     if body.name is not None:
+        _validate_project_field_length(body.name, "name")
         project.name = body.name
     if body.description is not None:
+        _validate_project_field_length(body.description, "description")
         project.description = body.description
 
     db_session.commit()

--- a/backend/onyx/server/features/projects/models.py
+++ b/backend/onyx/server/features/projects/models.py
@@ -28,8 +28,10 @@ class UserFileSnapshot(BaseModel):
 
     @classmethod
     def from_model(
-        cls, model: UserFile, temp_id_map: dict[str, str] = {}
+        cls, model: UserFile, temp_id_map: dict[str, str] | None = None
     ) -> "UserFileSnapshot":
+        if temp_id_map is None:
+            temp_id_map = {}
         return cls(
             id=model.id,
             temp_id=temp_id_map.get(str(model.id)),

--- a/backend/onyx/server/manage/voice/websocket_api.py
+++ b/backend/onyx/server/manage/voice/websocket_api.py
@@ -114,7 +114,7 @@ def trim_pcm16_silence(audio: bytes) -> bytes:
 
     speech_frame_indices = [
         idx
-        for idx, frame_rms in zip(frame_offsets, frame_rms_values)
+        for idx, frame_rms in zip(frame_offsets, frame_rms_values, strict=True)
         if frame_rms >= threshold
     ]
     if not speech_frame_indices:

--- a/backend/onyx/server/query_and_chat/models.py
+++ b/backend/onyx/server/query_and_chat/models.py
@@ -237,8 +237,8 @@ class ChatMessageDetail(BaseModel):
         self, *args: list, **kwargs: dict[str, Any]
     ) -> dict[str, Any]:
         initial_dict = super().model_dump(
-            mode="json",
             *args,
+            mode="json",
             **kwargs,  # ty: ignore[invalid-argument-type]
         )
         initial_dict["time_sent"] = self.time_sent.isoformat()

--- a/backend/onyx/skills/builtin/pptx/scripts/office/validators/pptx.py
+++ b/backend/onyx/skills/builtin/pptx/scripts/office/validators/pptx.py
@@ -252,7 +252,7 @@ class PPTXSchemaValidator(BaseSchemaValidator):
                 errors.append(
                     f"  Notes slide '{target}' is referenced by multiple slides: {', '.join(slide_names)}"
                 )
-                for slide_name, rels_file in references:
+                for _slide_name, rels_file in references:
                     errors.append(f"    - {rels_file.relative_to(self.unpacked_dir)}")
 
         if errors:

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -694,7 +694,7 @@ def run_research_agent_calls(
             ),
         )
         for research_agent_call, parent_tool_call_id in zip(
-            research_agent_calls, parent_tool_call_ids
+            research_agent_calls, parent_tool_call_ids, strict=False
         )
     ]
 

--- a/backend/onyx/tools/tool_implementations/images/image_generation_tool.py
+++ b/backend/onyx/tools/tool_implementations/images/image_generation_tool.py
@@ -400,7 +400,7 @@ class ImageGenerationTool(Tool[None]):
                 revised_prompt=img.revised_prompt,
                 shape=shape.value,
             )
-            for img, file_id in zip(image_generation_responses, file_ids)
+            for img, file_id in zip(image_generation_responses, file_ids, strict=True)
         ]
 
         # Emit final packet with generated images

--- a/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
+++ b/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
@@ -305,7 +305,7 @@ def _resolve_urls_to_document_ids(
 def _estimate_result_chars(result: dict[str, Any]) -> int:
     """Estimate character count from document fields in a result dict."""
     total = 0
-    for key, value in result.items():
+    for _key, value in result.items():
         if value is not None:
             total += len(str(value))
     return total

--- a/backend/onyx/tools/tool_implementations/python/python_tool.py
+++ b/backend/onyx/tools/tool_implementations/python/python_tool.py
@@ -163,7 +163,7 @@ def _select_files_for_staging(
         )
 
         over_budget = False
-        for idx, content in zip(batch, contents):
+        for idx, content in zip(batch, contents, strict=True):
             if content is None:
                 logger.warning(
                     "Failed to read file for Python execution: %s",
@@ -327,7 +327,7 @@ class PythonTool(Tool[PythonToolOverrideKwargs]):
                 allow_failures=True,
                 max_workers=CODE_INTERPRETER_STAGING_CONCURRENCY,
             )
-            for plan, ci_file_id in zip(misses, upload_results):
+            for plan, ci_file_id in zip(misses, upload_results, strict=True):
                 if ci_file_id is None:
                     logger.warning(
                         "Failed to upload file for Python execution: %s", plan.file_name

--- a/backend/onyx/tools/tool_implementations/search/search_utils.py
+++ b/backend/onyx/tools/tool_implementations/search/search_utils.py
@@ -84,7 +84,9 @@ def weighted_reciprocal_rank_fusion(
     id_to_source_rank: dict[str, int] = {}
 
     # Compute weighted RRF scores
-    for source_idx, (result_list, weight) in enumerate(zip(ranked_results, weights)):
+    for source_idx, (result_list, weight) in enumerate(
+        zip(ranked_results, weights, strict=True)
+    ):
         for rank, item in enumerate(result_list, start=1):
             item_id = id_extractor(item)
 
@@ -241,7 +243,7 @@ def merge_overlapping_sections(
     merged_sections: dict[tuple[str, int], InferenceSection] = {}
 
     # Process each document's sections
-    for doc_id, doc_section_list in doc_sections.items():
+    for _doc_id, doc_section_list in doc_sections.items():
         if not doc_section_list:
             continue
 

--- a/backend/onyx/tools/tool_implementations/web_search/web_search_tool.py
+++ b/backend/onyx/tools/tool_implementations/web_search/web_search_tool.py
@@ -249,7 +249,9 @@ class WebSearchTool(Tool[WebSearchToolOverrideKwargs]):
         valid_results: list[list[WebSearchResult]] = []
         failed_queries: dict[str, str] = {}
 
-        for query, (results, error) in zip(queries, search_results_with_errors):
+        for query, (results, error) in zip(
+            queries, search_results_with_errors, strict=True
+        ):
             if error is not None:
                 failed_queries[query] = error
             elif results is not None:

--- a/backend/onyx/tools/tool_runner.py
+++ b/backend/onyx/tools/tool_runner.py
@@ -246,7 +246,7 @@ def run_tool_calls(
     # Files from the chat session to pass to tools like PythonTool
     chat_files: list[ChatFile] | None = None,
     # A map of url -> summary for passing web results to open url tool
-    url_snippet_map: dict[str, str] = {},
+    url_snippet_map: dict[str, str] | None = None,
     # When False, don't pass memory context to search tools for query expansion
     # (but still pass it to the memory tool for persistence)
     inject_memories_in_prompt: bool = True,
@@ -289,6 +289,8 @@ def run_tool_calls(
         - `updated_citation_mapping`: The updated citation mapping dictionary.
     """
     # Merge tool calls for SearchTool, WebSearchTool, and OpenURLTool
+    if url_snippet_map is None:
+        url_snippet_map = {}
     merged_tool_calls = _merge_tool_calls(tool_calls)
 
     if not merged_tool_calls:

--- a/backend/onyx/utils/logger.py
+++ b/backend/onyx/utils/logger.py
@@ -26,12 +26,15 @@ from shared_configs.contextvars import (
 
 logging.addLevelName(logging.INFO + 5, "NOTICE")
 
+# The shared default dicts are only ever read, never mutated in place: writers
+# copy, update, then `set()` a new dict.
 pruning_ctx: contextvars.ContextVar[dict[str, Any]] = contextvars.ContextVar(
-    "pruning_ctx", default=dict()
+    "pruning_ctx",
+    default=dict(),  # noqa: B039
 )
 
 doc_permission_sync_ctx: contextvars.ContextVar[dict[str, Any]] = (
-    contextvars.ContextVar("doc_permission_sync_ctx", default=dict())
+    contextvars.ContextVar("doc_permission_sync_ctx", default=dict())  # noqa: B039
 )
 
 

--- a/backend/scripts/build_docx_preview.py
+++ b/backend/scripts/build_docx_preview.py
@@ -121,7 +121,7 @@ def _paragraph_alignment_score(
     """Fraction of position-aligned paragraphs whose text AND style both match."""
     if not a and not b:
         return 1.0
-    matches = sum(1 for pa, pb in zip(a, b) if pa == pb)
+    matches = sum(1 for pa, pb in zip(a, b, strict=False) if pa == pb)
     return matches / max(len(a), len(b))
 
 
@@ -129,7 +129,7 @@ def _text_alignment_score(a: list[tuple[str, str]], b: list[tuple[str, str]]) ->
     """Fraction of position-aligned paragraphs whose text matches (ignoring style)."""
     if not a and not b:
         return 1.0
-    matches = sum(1 for (_, ta), (_, tb) in zip(a, b) if ta == tb)
+    matches = sum(1 for (_, ta), (_, tb) in zip(a, b, strict=False) if ta == tb)
     return matches / max(len(a), len(b))
 
 
@@ -175,7 +175,7 @@ def compare(
     )
     shown = 0
     for index, (ref_p, cand_p) in enumerate(
-        zip(reference.paragraphs, candidate.paragraphs)
+        zip(reference.paragraphs, candidate.paragraphs, strict=False)
     ):
         if ref_p == cand_p:
             continue

--- a/backend/scripts/orphan_doc_cleanup_script.py
+++ b/backend/scripts/orphan_doc_cleanup_script.py
@@ -80,7 +80,9 @@ def main() -> None:
             # Process documents in parallel using ThreadPoolExecutor
             with concurrent.futures.ThreadPoolExecutor(max_workers=100) as executor:
 
-                def process_doc(doc_id: str) -> str | None:
+                def process_doc(
+                    doc_id: str, vespa_index: VespaDocumentIndex = vespa_index
+                ) -> str | None:
                     document = get_document(doc_id, db_session)
                     if not document:
                         return None

--- a/backend/scripts/sources_selection_analysis.py
+++ b/backend/scripts/sources_selection_analysis.py
@@ -176,7 +176,9 @@ class CompareAnalysis:
                                 pos
                                 if content_key == "score"
                                 else {
-                                    "x": k for k, v in new_content.items() if v == data
+                                    "x": k  # noqa: B035
+                                    for k, v in new_content.items()
+                                    if v == data
                                 }.get("x", "not_ranked")
                             ),
                             "document_id": self._previous_content[pos]["document_id"],
@@ -318,8 +320,8 @@ class SelectionAnalysis:
     def __init__(
         self,
         exectype: str,
-        analysisfiles: list = [],
-        queries: list = [],
+        analysisfiles: list | None = None,
+        queries: list | None = None,
         threshold: float = 0.0,
         web_port: int = 3000,
         auth_cookie: str = "",
@@ -339,6 +341,10 @@ class SelectionAnalysis:
             wait (int, optional): The waiting time (in seconds) to respect between queries.
                                     It is helpful to avoid hitting the Generative AI rate limiting.
         """
+        if queries is None:
+            queries = []
+        if analysisfiles is None:
+            analysisfiles = []
         self._exectype = exectype
         self._analysisfiles = analysisfiles
         self._queries = queries

--- a/backend/tests/daily/connectors/airtable/test_airtable_basic.py
+++ b/backend/tests/daily/connectors/airtable/test_airtable_basic.py
@@ -185,7 +185,7 @@ def compare_documents(
             f"Number of sections mismatch for document {doc_id}"
         )
         for i, (actual_section, expected_section) in enumerate(
-            zip(actual.sections, expected.sections)
+            zip(actual.sections, expected.sections, strict=True)
         ):
             assert actual_section.text == expected_section.text, (
                 f"Section {i} text mismatch for document {doc_id}"

--- a/backend/tests/daily/connectors/google_drive/test_service_acct.py
+++ b/backend/tests/daily/connectors/google_drive/test_service_acct.py
@@ -701,7 +701,7 @@ def test_slim_retrieval_does_not_call_permissions_list(
         "onyx.connectors.google_drive.connector.execute_paginated_retrieval",
         wraps=execute_paginated_retrieval,
     ) as mock_paginated:
-        for batch in connector.retrieve_all_slim_docs():
+        for _batch in connector.retrieve_all_slim_docs():
             pass
 
     permissions_calls = [

--- a/backend/tests/daily/connectors/slack/test_slack_connector.py
+++ b/backend/tests/daily/connectors/slack/test_slack_connector.py
@@ -121,7 +121,7 @@ def test_indexing_channels_that_dont_exist(
         ValueError,
         match=r"Channel '.*' not found in workspace.*",
     ):
-        load_all_from_connector(
+        _ = load_all_from_connector(
             connector=slack_connector,
             start=0.0,
             end=time.time(),

--- a/backend/tests/external_dependency_unit/answer/stream_test_assertions.py
+++ b/backend/tests/external_dependency_unit/answer/stream_test_assertions.py
@@ -69,7 +69,7 @@ def _are_search_docs_equal(
     received.sort(key=lambda x: x.document_id)
     expected.sort(key=lambda x: x.document_id)
 
-    for received_document, expected_document in zip(received, expected):
+    for received_document, expected_document in zip(received, expected, strict=True):
         if received_document.document_id != expected_document.document_id:
             return False
         if received_document.link != expected_document.link:
@@ -147,7 +147,9 @@ def is_image_generation_final_equal(
     if len(received.images) != len(expected.images):
         return False
 
-    for received_image, expected_image in zip(received.images, expected.images):
+    for received_image, expected_image in zip(
+        received.images, expected.images, strict=True
+    ):
         if received_image.url != f"/api/chat/file/{received_image.file_id}":
             return False
         if received_image.revised_prompt != expected_image.revised_prompt:

--- a/backend/tests/external_dependency_unit/document_index/conftest.py
+++ b/backend/tests/external_dependency_unit/document_index/conftest.py
@@ -98,7 +98,7 @@ def make_indexing_metadata(
                 old_chunk_cnt=old,
                 new_chunk_cnt=new,
             )
-            for doc_id, old, new in zip(doc_ids, old_counts, new_counts)
+            for doc_id, old, new in zip(doc_ids, old_counts, new_counts, strict=True)
         }
     )
 

--- a/backend/tests/external_dependency_unit/document_index/test_document_index.py
+++ b/backend/tests/external_dependency_unit/document_index/test_document_index.py
@@ -271,7 +271,7 @@ class TestDocumentIndexNew:
             doc_id = f"test_gen_{uuid.uuid4().hex[:8]}"
             metadata = make_indexing_metadata([doc_id], old_counts=[0], new_counts=[3])
 
-            def chunk_gen() -> Iterator[DocMetadataAwareIndexChunk]:
+            def chunk_gen(doc_id: str = doc_id) -> Iterator[DocMetadataAwareIndexChunk]:
                 for i in range(3):
                     yield make_chunk(doc_id, chunk_id=i)
 

--- a/backend/tests/external_dependency_unit/file_store/test_postgres_file_store_non_mocked.py
+++ b/backend/tests/external_dependency_unit/file_store/test_postgres_file_store_non_mocked.py
@@ -11,6 +11,7 @@ from collections.abc import Generator
 from io import BytesIO, StringIO
 from typing import Any, Dict, List
 
+import psycopg2
 import pytest
 from sqlalchemy.orm import Session
 
@@ -314,7 +315,7 @@ class TestPostgresBackedFileStore:
             assert new_oid != old_oid
 
             raw_conn = _get_raw_connection(session)
-            with pytest.raises(Exception):
+            with pytest.raises(psycopg2.Error):
                 _read_large_object(raw_conn, old_oid)
 
     # ── change_file_id ─────────────────────────────────────────────

--- a/backend/tests/external_dependency_unit/indexing/test_persistent_indexing.py
+++ b/backend/tests/external_dependency_unit/indexing/test_persistent_indexing.py
@@ -372,7 +372,7 @@ def test_threshold_default_aborts_attempt(
 
     try:
         mock_app = MagicMock()
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError, match="too many errors"):
             run_docfetching_entrypoint(
                 app=mock_app,
                 index_attempt_id=attempt_id,

--- a/backend/tests/external_dependency_unit/indexing/test_port_reembed.py
+++ b/backend/tests/external_dependency_unit/indexing/test_port_reembed.py
@@ -571,7 +571,7 @@ def test_reembed_pairs_embeddings_by_identity_not_position() -> None:
     ]
     # ...and each chunk carries ITS OWN content's vector despite the reversed output
     # (a positional zip would give c0 the vector of c2, etc.).
-    for result, stored in zip(results, [c0, c1, c2]):
+    for result, stored in zip(results, [c0, c1, c2], strict=True):
         assert result.content_vector == _vec(stored.content)
 
 

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_api_base.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_api_base.py
@@ -610,7 +610,7 @@ def test_upload_with_custom_config_then_change(
             # Check inside the database and check that custom_config is the same as the original
             db_provider = fetch_existing_llm_provider(name=name, db_session=db_session)
             if not db_provider:
-                assert False, "Provider not found in the database"
+                raise AssertionError("Provider not found in the database")
 
             assert db_provider.custom_config == custom_config, (
                 f"Expected custom_config {custom_config}, but got {db_provider.custom_config}"

--- a/backend/tests/external_dependency_unit/mock_llm.py
+++ b/backend/tests/external_dependency_unit/mock_llm.py
@@ -326,7 +326,7 @@ class MockLLM(LLM, MockLLMController):
         if not self.stream_controller:
             return
 
-        for idx, item in enumerate(self.stream_controller):
+        for _idx, item in enumerate(self.stream_controller):
             yield ModelResponseStream(
                 id="chatcmp-123",
                 created="1",

--- a/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
+++ b/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
@@ -59,6 +59,14 @@ from onyx.document_index.opensearch.search import (
 )
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 
+_PUBLIC_DOCUMENT_ACCESS = DocumentAccess.build(
+    user_emails=[],
+    user_groups=[],
+    external_user_emails=[],
+    external_user_group_ids=[],
+    is_public=True,
+)
+
 
 def _patch_global_tenant_state(monkeypatch: pytest.MonkeyPatch, state: bool) -> None:
     """Patches MULTI_TENANT wherever necessary for this test file.
@@ -138,13 +146,7 @@ def _create_test_document_chunk(
     title: str | None = None,
     title_vector: list[float] | None = None,
     hidden: bool = False,
-    document_access: DocumentAccess = DocumentAccess.build(
-        user_emails=[],
-        user_groups=[],
-        external_user_emails=[],
-        external_user_group_ids=[],
-        is_public=True,
-    ),
+    document_access: DocumentAccess = _PUBLIC_DOCUMENT_ACCESS,
     source_type: DocumentSource = DocumentSource.FILE,
     last_updated: datetime | None = None,
     created_at: datetime | None = None,
@@ -1257,7 +1259,7 @@ class TestOpenSearchClient:
 
         # Postcondition.
         # Retrieve each document and verify updates were applied.
-        for doc, doc_chunk_id in zip(docs, doc_chunk_ids):
+        for doc, doc_chunk_id in zip(docs, doc_chunk_ids, strict=True):
             updated_doc = test_client.get_document(document_chunk_id=doc_chunk_id)
             assert updated_doc.hidden is True
             assert updated_doc.global_boost == 7

--- a/backend/tests/external_dependency_unit/permission_sync/test_doc_permission_sync_attempt.py
+++ b/backend/tests/external_dependency_unit/permission_sync/test_doc_permission_sync_attempt.py
@@ -197,7 +197,7 @@ class TestDocPermissionSyncAttempt:
 
         # Create multiple attempts
         attempt_ids = []
-        for i in range(5):
+        for _ in range(5):
             attempt_id = create_doc_permission_sync_attempt(cc_pair.id, db_session)
             attempt_ids.append(attempt_id)
 

--- a/backend/tests/external_dependency_unit/permission_sync/test_external_group_permission_sync_attempt.py
+++ b/backend/tests/external_dependency_unit/permission_sync/test_external_group_permission_sync_attempt.py
@@ -246,7 +246,7 @@ class TestExternalGroupPermissionSyncAttempt:
 
         # Create multiple attempts for the cc_pair
         attempt_ids = []
-        for i in range(5):
+        for _ in range(5):
             attempt_id = create_external_group_sync_attempt(cc_pair.id, db_session)
             attempt_ids.append(attempt_id)
 
@@ -293,7 +293,7 @@ class TestExternalGroupPermissionSyncAttempt:
 
         # Create multiple global attempts
         global_attempt_ids = []
-        for i in range(3):
+        for _ in range(3):
             attempt_id = create_external_group_sync_attempt(None, db_session)  # Global
             global_attempt_ids.append(attempt_id)
 

--- a/backend/tests/integration/tests/indexing/test_repeated_error_state.py
+++ b/backend/tests/integration/tests/indexing/test_repeated_error_state.py
@@ -133,7 +133,9 @@ def test_repeated_error_state_detection_and_recovery(
                 break
 
         if time.monotonic() - start_time > 90:
-            assert False, "CC pair did not enter repeated error state within 90 seconds"
+            raise AssertionError(
+                "CC pair did not enter repeated error state within 90 seconds"
+            )
 
         time.sleep(2)
 

--- a/backend/tests/integration/tests/projects/test_projects.py
+++ b/backend/tests/integration/tests/projects/test_projects.py
@@ -1,7 +1,7 @@
 from typing import List
 
+import httpx
 import pytest
-import requests
 
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import UserFile
@@ -195,7 +195,7 @@ def test_projects_flow(
             assert len(remaining_files) == 2
 
     # Case 7: Edge cases
-    with pytest.raises(requests.HTTPError):
+    with pytest.raises(httpx.HTTPStatusError):
         ProjectManager.create(
             name="",
             user_performing_action=basic_user,
@@ -208,14 +208,14 @@ def test_projects_flow(
     )
     assert not deletion_success
 
-    with pytest.raises(requests.HTTPError):
+    with pytest.raises(httpx.HTTPStatusError):
         ProjectManager.set_instructions(
             project_id=non_existent_id,
             instructions="Test instructions",
             user_performing_action=basic_user,
         )
 
-    with pytest.raises(requests.HTTPError):
+    with pytest.raises(httpx.HTTPStatusError):
         ProjectManager.upload_files(
             project_id=non_existent_id,
             files=[("test.txt", b"content")],
@@ -223,7 +223,7 @@ def test_projects_flow(
         )
 
     long_name = "a" * 1000
-    with pytest.raises(requests.HTTPError):
+    with pytest.raises(httpx.HTTPStatusError):
         ProjectManager.create(
             name=long_name,
             user_performing_action=basic_user,

--- a/backend/tests/integration/tests/projects/test_projects.py
+++ b/backend/tests/integration/tests/projects/test_projects.py
@@ -2,6 +2,7 @@ from typing import List
 
 import httpx
 import pytest
+import sqlalchemy.exc
 
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import UserFile
@@ -223,7 +224,9 @@ def test_projects_flow(
         )
 
     long_name = "a" * 1000
-    with pytest.raises(httpx.HTTPStatusError):
+    # The endpoint does not check the name length, so Postgres rejects the insert
+    # and the test client re-raises the server exception.
+    with pytest.raises(sqlalchemy.exc.DataError):
         ProjectManager.create(
             name=long_name,
             user_performing_action=basic_user,

--- a/backend/tests/integration/tests/projects/test_projects.py
+++ b/backend/tests/integration/tests/projects/test_projects.py
@@ -1,6 +1,7 @@
 from typing import List
 
 import pytest
+import requests
 
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import UserFile
@@ -194,7 +195,7 @@ def test_projects_flow(
             assert len(remaining_files) == 2
 
     # Case 7: Edge cases
-    with pytest.raises(Exception):
+    with pytest.raises(requests.HTTPError):
         ProjectManager.create(
             name="",
             user_performing_action=basic_user,
@@ -207,14 +208,14 @@ def test_projects_flow(
     )
     assert not deletion_success
 
-    with pytest.raises(Exception):
+    with pytest.raises(requests.HTTPError):
         ProjectManager.set_instructions(
             project_id=non_existent_id,
             instructions="Test instructions",
             user_performing_action=basic_user,
         )
 
-    with pytest.raises(Exception):
+    with pytest.raises(requests.HTTPError):
         ProjectManager.upload_files(
             project_id=non_existent_id,
             files=[("test.txt", b"content")],
@@ -222,7 +223,7 @@ def test_projects_flow(
         )
 
     long_name = "a" * 1000
-    with pytest.raises(Exception):
+    with pytest.raises(requests.HTTPError):
         ProjectManager.create(
             name=long_name,
             user_performing_action=basic_user,

--- a/backend/tests/integration/tests/projects/test_projects.py
+++ b/backend/tests/integration/tests/projects/test_projects.py
@@ -2,7 +2,6 @@ from typing import List
 
 import httpx
 import pytest
-import sqlalchemy.exc
 
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import UserFile
@@ -224,9 +223,7 @@ def test_projects_flow(
         )
 
     long_name = "a" * 1000
-    # The endpoint does not check the name length, so Postgres rejects the insert
-    # and the test client re-raises the server exception.
-    with pytest.raises(sqlalchemy.exc.DataError):
+    with pytest.raises(httpx.HTTPStatusError):
         ProjectManager.create(
             name=long_name,
             user_performing_action=basic_user,

--- a/backend/tests/integration/tests/query_history/test_usage_reports.py
+++ b/backend/tests/integration/tests/query_history/test_usage_reports.py
@@ -23,7 +23,7 @@ def test_usage_reports(reset: None) -> None:  # noqa: ARG001
 
         count = 0
         for entry_batch in get_all_empty_chat_message_entries(db_session, period):
-            for entry in entry_batch:
+            for _entry in entry_batch:
                 count += 1
 
         assert count == EXPECTED_MESSAGES
@@ -37,7 +37,7 @@ def test_usage_reports(reset: None) -> None:  # noqa: ARG001
 
         count = 0
         for entry_batch in get_all_empty_chat_message_entries(db_session, period):
-            for entry in entry_batch:
+            for _entry in entry_batch:
                 count += 1
 
         lower = EXPECTED_MESSAGES // 3 - (EXPECTED_MESSAGES // (3 * 3))

--- a/backend/tests/integration/tests/reporting/test_usage_export_api.py
+++ b/backend/tests/integration/tests/reporting/test_usage_export_api.py
@@ -404,7 +404,7 @@ class TestUsageExportAPI:
 
         # Generate multiple reports concurrently
         num_reports = 3
-        for i in range(num_reports):
+        for _i in range(num_reports):
             response = client.post(
                 f"{API_SERVER_URL}/admin/usage-report",
                 json={},

--- a/backend/tests/regression/search_quality/run_search_eval.py
+++ b/backend/tests/regression/search_quality/run_search_eval.py
@@ -346,7 +346,7 @@ class SearchAnswerAnalyzer:
         plt.grid(axis="y", alpha=0.3)
 
         # add value labels on top of each bar
-        for bar, count in zip(bars, counts):
+        for bar, count in zip(bars, counts, strict=True):
             if count > 0:
                 plt.text(
                     bar.get_x() + bar.get_width() / 2,

--- a/backend/tests/unit/background/celery/test_celery_utils.py
+++ b/backend/tests/unit/background/celery/test_celery_utils.py
@@ -62,7 +62,7 @@ class TestEnumerationDuration:
             connector_type="confluence"
         )._sum.get()
 
-        with pytest.raises(Exception):
+        with pytest.raises(Exception, match="unexpected error"):
             extract_ids_from_runnable_connector(connector, connector_type="confluence")
 
         after = PRUNING_ENUMERATION_DURATION.labels(
@@ -116,7 +116,7 @@ class TestRateLimitDetection:
         connector = _raising_connector("RATE LIMIT exceeded")
         before = PRUNING_RATE_LIMIT_ERRORS.labels(connector_type="jira")._value.get()
 
-        with pytest.raises(Exception):
+        with pytest.raises(Exception, match="RATE LIMIT exceeded"):
             extract_ids_from_runnable_connector(connector, connector_type="jira")
 
         after = PRUNING_RATE_LIMIT_ERRORS.labels(connector_type="jira")._value.get()
@@ -131,7 +131,7 @@ class TestRateLimitDetection:
             connector_type="jira"
         )._value.get()
 
-        with pytest.raises(Exception):
+        with pytest.raises(Exception, match="rate limit exceeded"):
             extract_ids_from_runnable_connector(
                 connector, connector_type="google_drive"
             )
@@ -149,7 +149,7 @@ class TestRateLimitDetection:
         connector = _raising_connector("rate limit exceeded")
         before = PRUNING_RATE_LIMIT_ERRORS.labels(connector_type="unknown")._value.get()
 
-        with pytest.raises(Exception):
+        with pytest.raises(Exception, match="rate limit exceeded"):
             extract_ids_from_runnable_connector(connector)
 
         after = PRUNING_RATE_LIMIT_ERRORS.labels(connector_type="unknown")._value.get()

--- a/backend/tests/unit/onyx/auth/test_user_registration.py
+++ b/backend/tests/unit/onyx/auth/test_user_registration.py
@@ -66,8 +66,8 @@ class _AsyncSessionContextManager:
 
 
 def _mock_user_manager_methods(user_manager: UserManager) -> None:
-    setattr(user_manager, "validate_password", AsyncMock())
-    setattr(user_manager, "_assign_default_pinned_assistants", AsyncMock())
+    user_manager.validate_password = AsyncMock()
+    user_manager._assign_default_pinned_assistants = AsyncMock()
 
 
 class TestDisposableEmailValidation:
@@ -593,11 +593,9 @@ class TestOAuthDottedGmail:
 
         user_manager = UserManager(MagicMock())
         _mock_user_manager_methods(user_manager)
-        setattr(user_manager, "on_after_register", AsyncMock())
-        setattr(
-            user_manager,
-            "get_by_oauth_account",
-            AsyncMock(side_effect=exceptions.UserNotExists()),
+        user_manager.on_after_register = AsyncMock()
+        user_manager.get_by_oauth_account = AsyncMock(
+            side_effect=exceptions.UserNotExists()
         )
 
         created_user = MagicMock(id="test-id", email=dotted_email)
@@ -657,11 +655,9 @@ class TestOAuthNoAutoLinkExemptions:
     def _manager_with_existing(existing_user: MagicMock) -> UserManager:
         user_manager = UserManager(MagicMock())
         _mock_user_manager_methods(user_manager)
-        setattr(user_manager, "on_after_register", AsyncMock())
-        setattr(
-            user_manager,
-            "get_by_oauth_account",
-            AsyncMock(side_effect=exceptions.UserNotExists()),
+        user_manager.on_after_register = AsyncMock()
+        user_manager.get_by_oauth_account = AsyncMock(
+            side_effect=exceptions.UserNotExists()
         )
         mock_user_db = MagicMock()
         mock_user_db.get_by_email = AsyncMock(return_value=existing_user)

--- a/backend/tests/unit/onyx/connectors/box/test_box_connector.py
+++ b/backend/tests/unit/onyx/connectors/box/test_box_connector.py
@@ -652,7 +652,7 @@ def test_load_credentials_defers_clients_and_impersonation_lookup() -> None:
     assert connector._content_client is None
     assert connector._user_email == "user@example.com"
 
-    connector.enterprise_client
+    _ = connector.enterprise_client
 
     assert connector._enterprise_client is not None
     assert connector._content_client is None

--- a/backend/tests/unit/onyx/connectors/jira/test_jira_bulk_fetch.py
+++ b/backend/tests/unit/onyx/connectors/jira/test_jira_bulk_fetch.py
@@ -104,7 +104,7 @@ def test_bulk_fetch_non_json_error_propagates() -> None:
 
     try:
         bulk_fetch_issues(client, ["1"])
-        assert False, "Expected ValueError to propagate"
+        raise AssertionError("Expected ValueError to propagate")
     except ValueError:
         pass
 

--- a/backend/tests/unit/onyx/connectors/mediawiki/test_wiki.py
+++ b/backend/tests/unit/onyx/connectors/mediawiki/test_wiki.py
@@ -101,7 +101,7 @@ def test_get_doc_from_page(
     )
     assert len(doc.sections) == 3
     for section, expected_section in zip(
-        doc.sections, test_page._sections_helper + [test_page.header]
+        doc.sections, test_page._sections_helper + [test_page.header], strict=True
     ):
         assert (
             section.text is not None

--- a/backend/tests/unit/onyx/connectors/salesforce/test_salesforce_custom_config.py
+++ b/backend/tests/unit/onyx/connectors/salesforce/test_salesforce_custom_config.py
@@ -85,7 +85,9 @@ def test_validation() -> None:
     for i, invalid_config in enumerate(invalid_configs):
         try:
             _validate_custom_query_config(invalid_config)
-            assert False, f"Should have raised ValueError for invalid_config[{i}]"
+            raise AssertionError(
+                f"Should have raised ValueError for invalid_config[{i}]"
+            )
         except ValueError:
             print(f"✅ Correctly rejected invalid config {i}")
 

--- a/backend/tests/unit/onyx/connectors/test_connector_factory.py
+++ b/backend/tests/unit/onyx/connectors/test_connector_factory.py
@@ -262,7 +262,8 @@ class TestInstantiateConnectorIntegration:
 
         # This should trigger lazy loading but will fail on actual instantiation
         # due to missing real configuration - that's expected
-        with pytest.raises(Exception):  # We expect some kind of error due to mock data
+        # We expect some kind of error due to mock data
+        with pytest.raises(Exception):  # noqa: B017
             instantiate_connector(
                 mock_session,
                 DocumentSource.WEB,  # Simple connector

--- a/backend/tests/unit/onyx/document_index/vespa/test_vespa_batch_flush.py
+++ b/backend/tests/unit/onyx/document_index/vespa/test_vespa_batch_flush.py
@@ -80,7 +80,7 @@ def _make_indexing_metadata(
                 old_chunk_cnt=old,
                 new_chunk_cnt=new,
             )
-            for doc_id, old, new in zip(doc_ids, old_counts, new_counts)
+            for doc_id, old, new in zip(doc_ids, old_counts, new_counts, strict=True)
         }
     )
 

--- a/backend/tests/unit/onyx/llm/test_tracing_wrap.py
+++ b/backend/tests/unit/onyx/llm/test_tracing_wrap.py
@@ -211,7 +211,7 @@ def test_outer_guard_false_for_finished_span_leaked_into_contextvar() -> None:
 
 def test_extract_prompt_reads_positional_arg() -> None:
     llm = _FakeLLM()
-    sig = _validate_prompt_param(getattr(_FakeLLM.invoke, "__wrapped__"))
+    sig = _validate_prompt_param(getattr(_FakeLLM.invoke, "__wrapped__"))  # noqa: B009
     prompt, tools = _extract_prompt_and_tools(sig, llm, ("hi",), {})
     assert prompt == "hi"
     assert tools is None
@@ -219,7 +219,7 @@ def test_extract_prompt_reads_positional_arg() -> None:
 
 def test_extract_prompt_reads_keyword_arg() -> None:
     llm = _FakeLLM()
-    sig = _validate_prompt_param(getattr(_FakeLLM.invoke, "__wrapped__"))
+    sig = _validate_prompt_param(getattr(_FakeLLM.invoke, "__wrapped__"))  # noqa: B009
     prompt, tools = _extract_prompt_and_tools(sig, llm, (), {"prompt": "hi"})
     assert prompt == "hi"
     assert tools is None
@@ -227,7 +227,7 @@ def test_extract_prompt_reads_keyword_arg() -> None:
 
 def test_extract_tools_reads_keyword_arg() -> None:
     llm = _FakeLLM()
-    sig = _validate_prompt_param(getattr(_FakeLLM.invoke, "__wrapped__"))
+    sig = _validate_prompt_param(getattr(_FakeLLM.invoke, "__wrapped__"))  # noqa: B009
     tool_defs = [{"type": "function", "function": {"name": "search"}}]
     prompt, tools = _extract_prompt_and_tools(
         sig, llm, (), {"prompt": "hi", "tools": tool_defs}
@@ -240,7 +240,7 @@ def test_extract_prompt_returns_none_on_signature_mismatch() -> None:
     """Unknown keyword arguments don't match the signature → bind fails →
     extraction returns (None, None) rather than raising."""
     llm = _FakeLLM()
-    sig = _validate_prompt_param(getattr(_FakeLLM.invoke, "__wrapped__"))
+    sig = _validate_prompt_param(getattr(_FakeLLM.invoke, "__wrapped__"))  # noqa: B009
     assert _extract_prompt_and_tools(sig, llm, (), {"not_a_real_param": "hi"}) == (
         None,
         None,

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_serve_client_401_reload.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_serve_client_401_reload.py
@@ -54,7 +54,7 @@ def test_request_does_not_retry_when_password_unchanged() -> None:
     # 401 with unchanged password → no retry, surfaces as HTTPStatusError.
     try:
         client.ensure_session(None, directory="/workspace/sessions/x")
-        assert False, "expected HTTPStatusError"
+        raise AssertionError("expected HTTPStatusError")
     except httpx.HTTPStatusError:
         pass
     assert n == 1, n

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
@@ -487,14 +487,15 @@ def test_form_encoded_refresh_error_is_logged_without_secrets(
         for record in caplog.records
         if record.getMessage() == "mcp_oauth.refresh.started"
     )
-    assert getattr(failed_record, "oauth_error") == "bad_refresh_token"
+    assert getattr(failed_record, "oauth_error") == "bad_refresh_token"  # noqa: B009
     assert (
-        getattr(failed_record, "response_content_type")
+        getattr(failed_record, "response_content_type")  # noqa: B009
         == "application/x-www-form-urlencoded"
     )
-    assert getattr(failed_record, "response_body_format") == "form"
-    assert getattr(failed_record, "refresh_attempt_id") == getattr(
-        started_record, "refresh_attempt_id"
+    assert getattr(failed_record, "response_body_format") == "form"  # noqa: B009
+    assert getattr(failed_record, "refresh_attempt_id") == getattr(  # noqa: B009
+        started_record,
+        "refresh_attempt_id",  # noqa: B009
     )
     assert "OLD_ACCESS_TOKEN" not in caplog.text
     assert "ROTATING_REFRESH_TOKEN" not in caplog.text

--- a/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
+++ b/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
@@ -529,8 +529,9 @@ def test_proactive_refresh_targets_configured_endpoint_and_persists(
         for record in caplog.records
         if record.getMessage() == "mcp_oauth.refresh.persisted"
     )
-    assert getattr(persisted_record, "refresh_attempt_id") == getattr(
-        started_record, "refresh_attempt_id"
+    assert getattr(persisted_record, "refresh_attempt_id") == getattr(  # noqa: B009
+        started_record,
+        "refresh_attempt_id",  # noqa: B009
     )
 
     caplog.clear()

--- a/backend/tests/unit/onyx/utils/test_threadpool_contextvars.py
+++ b/backend/tests/unit/onyx/utils/test_threadpool_contextvars.py
@@ -46,7 +46,7 @@ def test_run_functions_in_parallel_preserves_contextvar() -> None:
     # Run in parallel and verify all results have the correct value
     results = run_functions_in_parallel(function_calls)
 
-    for result_id, value in results.items():
+    for _result_id, value in results.items():
         assert value == "parallel_test"
 
 

--- a/backend/tests/unit/sandbox_proxy/test_response_streaming.py
+++ b/backend/tests/unit/sandbox_proxy/test_response_streaming.py
@@ -188,7 +188,11 @@ def _start_proxy(
         holder: dict[str, Any] = {}
         ready = threading.Event()
 
-        async def _amain(bind_port: int) -> None:
+        async def _amain(
+            bind_port: int,
+            holder: dict[str, Any] = holder,
+            ready: threading.Event = ready,
+        ) -> None:
             options = Options(
                 listen_host="127.0.0.1",
                 listen_port=bind_port,
@@ -207,7 +211,9 @@ def _start_proxy(
         )
         thread.start()
 
-        def _stop() -> None:
+        def _stop(
+            holder: dict[str, Any] = holder, thread: threading.Thread = thread
+        ) -> None:
             loop = holder.get("loop")
             master = holder.get("master")
             if loop is not None and master is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,9 +285,24 @@ ignore = [
     # Tracked in kanban ticket #491 — to be removed once existing violations are
     # cleaned up:
     "S113", # request-without-timeout (~463 existing violations).
+    # flake8-bugbear (B) rule deferred — to be removed once existing violations
+    # are cleaned up:
+    "B904", # raise-without-from-inside-except (~465 existing violations).
 ]
 # G004: f-strings in logging break Sentry's message-pattern grouping.
-select = ["ARG", "E", "F", "G004", "I", "S", "W"]
+select = ["ARG", "B", "E", "F", "G004", "I", "S", "W"]
+
+[tool.ruff.lint.flake8-bugbear]
+# FastAPI dependency-injection markers are the intended way to write these
+# defaults, so B008 must not flag them.
+extend-immutable-calls = [
+    "fastapi.Body",
+    "fastapi.Depends",
+    "fastapi.File",
+    "fastapi.Form",
+    "fastapi.Query",
+    "onyx.auth.permissions.require_permission",
+]
 
 [tool.ruff.lint.isort]
 known-first-party = ["onyx", "ee", "tests", "shared_configs", "model_server"]


### PR DESCRIPTION
## Description

Enables the flake8-bugbear (`B`) ruff rules and fixes the existing violations (2314 → 0).

`pyproject.toml`:
- `B` added to `select`.
- `B904` (`raise-without-from-inside-except`, ~465 existing violations) deferred in `ignore` with a tracking comment, the same way `S113` is.
- `flake8-bugbear.extend-immutable-calls` stops `B008` from flagging FastAPI dependency-injection markers.

Real bugs fixed:
- Duplicate set/dict members that silently dropped entries — `airtable_connector.py`, `slack/connector.py` (B033, B035).
- Late-binding closure captures in loops — `ee/.../github/utils.py`, `teams/connector.py`, `html_utils.py`, plus 3 test/script sites (B023).
- Mutable `ContextVar` defaults shared across contexts in `utils/logger.py`, with copy-on-read at the two writer sites (B039).
- `break` inside a `finally` block that swallowed exceptions in `docfetching/tasks.py` (B012).
- 16 mutable default arguments, converted to `X | None = None` with guards (B006).
- 5 `pytest.raises(Exception)` assertions tightened to real exception types or `match=` (B017).
- 45 `zip()` calls given an explicit `strict` argument. `strict=True` except 8 sites where unequal lengths are intended, each documented inline (B905).

Deliberate exceptions keep a `# noqa` with a reason: the platform-conditional `getattr(socket, "TCP_KEEPALIVE")`, the guarded `return`s in the tenant-tracking `finally`, the `PptxConverter` monkeypatch, one intentionally broad test assertion, and several `getattr`/`setattr` calls that `ty` cannot resolve as plain attributes.

## How Has This Been Tested?

- `ruff check .`, `ruff format --check .`, and `uv run ty check` all pass.
- `pytest backend/tests/unit` → 8137 passed, 19 failed. The same 19 fail on a clean worktree at `main` (license reclaim, license API, process isolation), so they are pre-existing and unrelated.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables `flake8-bugbear` rules in `ruff` and fixes violations to catch logic errors earlier. Also hardens Projects API input validation: previously over‑long project names/descriptions caused a DB 500; now the API rejects values >255 chars with 400 (INVALID_INPUT).

- **Config**
  - Adds `B` to `select` in `pyproject.toml`; defers `B904` with a tracking comment.
  - Sets `flake8-bugbear.extend-immutable-calls` for FastAPI DI and `onyx.auth.permissions.require_permission`.
  - CI now enforces `B` rules. Migration: when using `zip()`, pass `strict=True` or `strict=False` explicitly.

- **Behavior and review focus**
  - Makes `zip()` intent explicit across pipelines, search, indexing, connectors, and tests; most use `strict=True`, with a few `strict=False` where uneven lengths are intended and documented.
  - Fixes late-binding closures by using direct callables or `functools.partial` (e.g., GitHub and Teams connectors).
  - Replaces mutable default args with `None` and guards in connectors/utilities; avoids shared mutable `ContextVar` defaults by copy-on-read/write in pruning and permission-sync tasks.
  - Preserves exception propagation by moving a `break` out of a `finally`; retains deliberate `return`s in a `finally` with `# noqa: B012` and rationale. Adds targeted `# noqa` for dynamic attribute access/monkeypatching (`B009`, `B010`).
  - Removes duplicate set/dict members; tightens broad `pytest.raises(Exception)` to specific types or `match=`.
  - Restores checkpoint propagation in `ConnectorRunner.run` by tracking the last loop checkpoint and yielding it after the loop.
  - `kg_extraction`: zip only deep‑extraction documents with their results.
  - Projects API: validate name/description length in create/update and return 400 with `OnyxErrorCode.INVALID_INPUT`; tests now expect `httpx.HTTPStatusError`. Review: confirm consumers don’t rely on previous 500 behavior.

<sup>Written for commit b91fc88674046698bee5d53c2fabe32554162dcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

