### PR TITLE
feat(admin): incognito availability and record modes

### DIFF
--- a/backend/alembic/versions/c7f1a9d4e206_add_incognito_admin_settings.py
+++ b/backend/alembic/versions/c7f1a9d4e206_add_incognito_admin_settings.py
@@ -1,0 +1,63 @@
+"""add incognito availability, record mode, and the group flag
+
+Revision ID: c7f1a9d4e206
+Revises: 0ec213a5ffde
+Create Date: 2026-08-12 09:40:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from onyx.db.enums import IncognitoRecordMode
+from onyx.server.security.models import IncognitoAvailability
+
+# revision identifiers, used by Alembic.
+revision = "c7f1a9d4e206"
+down_revision = "0ec213a5ffde"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Both settings are nullable: NULL means the workspace never chose, which
+    # reads as off and usage_only.
+    op.add_column(
+        "security_settings",
+        sa.Column(
+            "incognito_availability",
+            sa.Enum(
+                IncognitoAvailability,
+                native_enum=False,
+                values_callable=lambda x: [e.value for e in x],
+            ),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "security_settings",
+        sa.Column(
+            "incognito_record_mode",
+            sa.Enum(
+                IncognitoRecordMode,
+                native_enum=False,
+                values_callable=lambda x: [e.value for e in x],
+            ),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "user_group",
+        sa.Column(
+            "incognito_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_group", "incognito_enabled")
+    op.drop_column("security_settings", "incognito_record_mode")
+    op.drop_column("security_settings", "incognito_availability")

--- a/backend/ee/onyx/db/query_history.py
+++ b/backend/ee/onyx/db/query_history.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from datetime import datetime
+from uuid import UUID
 
 from sqlalchemy import BinaryExpression, ColumnElement, asc, desc, distinct
 from sqlalchemy.orm import Session, contains_eager, joinedload
@@ -8,6 +9,7 @@ from sqlalchemy.sql.expression import UnaryExpression, literal
 
 from ee.onyx.background.task_name_builders import QUERY_HISTORY_TASK_NAME_PREFIX
 from onyx.configs.constants import QAFeedbackType
+from onyx.db.chat import content_persisting_sessions_filter
 from onyx.db.models import ChatMessage, ChatMessageFeedback, ChatSession, TaskQueueState
 from onyx.db.tasks import get_all_tasks_with_prefix
 
@@ -25,7 +27,7 @@ def _build_filter_conditions(
     feedback_filter: Feedback type to filter by
     Returns: List of filter conditions
     """
-    conditions = []
+    conditions = [content_persisting_sessions_filter()]
 
     if start_time is not None:
         conditions.append(ChatSession.time_created >= start_time)
@@ -118,6 +120,27 @@ def get_page_of_chat_sessions(
     return db_session.scalars(stmt).unique().all()
 
 
+def fetch_persisting_chat_session_by_id(
+    chat_session_id: UUID,
+    db_session: Session,
+) -> ChatSession:
+    """The admin detail read, filtered like the list and the export it belongs to.
+
+    A content-free session is absent rather than refused: whether one exists is
+    itself metadata the workspace chose not to keep. Deleted sessions stay
+    visible, which is what the detail view is for.
+    """
+    chat_session = db_session.scalar(
+        select(ChatSession).where(
+            ChatSession.id == chat_session_id,
+            content_persisting_sessions_filter(),
+        )
+    )
+    if chat_session is None:
+        raise ValueError(f"Chat session with id '{chat_session_id}' does not exist.")
+    return chat_session
+
+
 def fetch_chat_sessions_eagerly_by_time(
     start: datetime,
     end: datetime,
@@ -131,7 +154,8 @@ def fetch_chat_sessions_eagerly_by_time(
     message_order: UnaryExpression = asc(ChatMessage.id)
 
     filters: list[ColumnElement | BinaryExpression] = [
-        ChatSession.time_created.between(start, end)
+        content_persisting_sessions_filter(),
+        ChatSession.time_created.between(start, end),
     ]
 
     if initial_time:

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -537,6 +537,18 @@ def _add_user_group__cc_pair_relationships__no_commit(
     return relationships
 
 
+def set_user_group_incognito(
+    db_session: Session, user_group_id: int, enabled: bool
+) -> UserGroup:
+    """Flip whether members may use incognito under groups-only availability."""
+    group = db_session.scalar(select(UserGroup).where(UserGroup.id == user_group_id))
+    if group is None:
+        raise ValueError(f"UserGroup with id '{user_group_id}' not found")
+    group.incognito_enabled = enabled
+    db_session.commit()
+    return group
+
+
 def insert_user_group(db_session: Session, user_group: UserGroupCreate) -> UserGroup:
     db_user_group = UserGroup(
         name=user_group.name,

--- a/backend/ee/onyx/server/query_history/api.py
+++ b/backend/ee/onyx/server/query_history/api.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from ee.onyx.background.task_name_builders import query_history_task_name
 from ee.onyx.db.query_history import (
+    fetch_persisting_chat_session_by_id,
     get_all_query_history_export_tasks,
     get_page_of_chat_sessions,
     get_total_filtered_chat_sessions_count,
@@ -37,7 +38,7 @@ from onyx.configs.constants import (
     QueryHistoryType,
     SessionType,
 )
-from onyx.db.chat import get_chat_session_by_id, get_chat_sessions_by_user
+from onyx.db.chat import get_chat_sessions_by_user
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission, TaskStatus
 from onyx.db.file_record import get_query_history_export_files
@@ -170,8 +171,14 @@ def admin_get_chat_sessions(
     )
 
     try:
+        # Full History incognito is recorded for the workspace and hidden only
+        # from its own owner, so query history must still return it.
         chat_sessions = get_chat_sessions_by_user(
-            user_id=user_id, deleted=False, db_session=db_session, limit=0
+            user_id=user_id,
+            deleted=False,
+            db_session=db_session,
+            limit=0,
+            exclude_content_free=True,
         )
 
     except ValueError:
@@ -248,11 +255,9 @@ def get_chat_session_admin(
     )
 
     try:
-        chat_session = get_chat_session_by_id(
+        chat_session = fetch_persisting_chat_session_by_id(
             chat_session_id=chat_session_id,
-            user_id=None,  # view chat regardless of user
             db_session=db_session,
-            include_deleted=True,
         )
     except ValueError:
         raise HTTPException(

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -12,6 +12,7 @@ from ee.onyx.db.user_group import (
     prepare_user_group_for_deletion,
     rename_user_group,
     set_group_permission__no_commit,
+    set_user_group_incognito,
     update_user_curator_relationship,
     update_user_group,
 )
@@ -25,6 +26,7 @@ from ee.onyx.server.user_group.models import (
     UpdateGroupAgentsRequest,
     UserGroup,
     UserGroupCreate,
+    UserGroupIncognitoUpdate,
     UserGroupRename,
     UserGroupUpdate,
 )
@@ -188,6 +190,28 @@ def rename_user_group_endpoint(
         if "not found" in msg.lower():
             raise OnyxError(OnyxErrorCode.NOT_FOUND, msg)
         raise OnyxError(OnyxErrorCode.CONFLICT, msg)
+
+
+@router.patch("/admin/user-group/{user_group_id}/incognito")
+def patch_user_group_incognito(
+    user_group_id: int,
+    update: UserGroupIncognitoUpdate,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> UserGroup:
+    """Only meaningful while the security setting is groups-only, but always
+    storable so admins can stage membership before flipping the mode."""
+    try:
+        return UserGroup.from_model(
+            set_user_group_incognito(
+                db_session=db_session,
+                user_group_id=user_group_id,
+                enabled=update.enabled,
+            ),
+            mask_credential_prefix=get_security_settings().mask_credential_prefix,
+        )
+    except ValueError as e:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, str(e))
 
 
 @router.patch("/admin/user-group/{user_group_id}")

--- a/backend/ee/onyx/server/user_group/models.py
+++ b/backend/ee/onyx/server/user_group/models.py
@@ -25,6 +25,8 @@ class UserGroup(BaseModel):
     is_up_to_date: bool
     is_up_for_deletion: bool
     is_default: bool
+    # Members may start incognito chats when availability is groups-only.
+    incognito_enabled: bool
 
     @classmethod
     def from_model(
@@ -87,6 +89,7 @@ class UserGroup(BaseModel):
             is_up_to_date=user_group_model.is_up_to_date,
             is_up_for_deletion=user_group_model.is_up_for_deletion,
             is_default=user_group_model.is_default,
+            incognito_enabled=user_group_model.incognito_enabled,
         )
 
 
@@ -113,6 +116,10 @@ class UserGroupCreate(BaseModel):
 class UserGroupUpdate(BaseModel):
     user_ids: list[UUID]
     cc_pair_ids: list[int]
+
+
+class UserGroupIncognitoUpdate(BaseModel):
+    enabled: bool
 
 
 class AddUsersToUserGroupRequest(BaseModel):

--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -8,7 +8,10 @@ from fastapi.datastructures import Headers
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from onyx.chat.incognito import resolve_incognito_record_mode
+from onyx.chat.incognito import (
+    incognito_allowed_for_user,
+    resolve_incognito_record_mode,
+)
 from onyx.chat.incognito_context import incognito_context_available
 from onyx.chat.models import (
     ChatHistoryResult,
@@ -189,15 +192,23 @@ def create_chat_session_from_request(
         ):
             raise ValueError("User does not have access to persona")
 
-    # Pinned at creation. A deployment without the Redis cache backend cannot
-    # hold incognito context, so the request is refused rather than downgraded
-    # into a chat the user believes is incognito.
+    # Pinned at creation so a later setting change cannot alter a live session.
+    # Availability decides server-side, never the client flag. A refusal
+    # errors: degrading would silently persist a believed-incognito chat.
+    # The capability is checked first so a deployment that cannot hold the
+    # context says so, rather than reporting it as a permission the admin
+    # could grant.
     incognito_mode: IncognitoRecordMode | None = None
     if chat_session_request.incognito:
         if not incognito_context_available():
             raise OnyxError(
                 OnyxErrorCode.DEPLOYMENT_UNSUPPORTED,
                 "Incognito chat is not supported on this deployment.",
+            )
+        if not incognito_allowed_for_user(user, db_session):
+            raise OnyxError(
+                OnyxErrorCode.UNAUTHORIZED,
+                "Incognito chat is not enabled for this user.",
             )
         incognito_mode = resolve_incognito_record_mode()
 

--- a/backend/onyx/chat/incognito.py
+++ b/backend/onyx/chat/incognito.py
@@ -18,10 +18,15 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from onyx.chat.incognito_context import incognito_context_available
 from onyx.db.enums import IncognitoRecordMode, record_mode_persists_content
 from onyx.db.file_record import get_incognito_file_ids
+from onyx.db.incognito import user_in_incognito_enabled_group
+from onyx.db.models import User
 from onyx.file_store.file_store import get_default_file_store
 from onyx.file_store.models import FileDescriptor
+from onyx.server.security.models import IncognitoAvailability
+from onyx.server.security.store import get_security_settings, load_effective_uncached
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_incognito_record_mode
 
@@ -33,13 +38,36 @@ def current_turn_persists_content() -> bool:
     return record_mode_persists_content(mode)
 
 
-def resolve_incognito_record_mode() -> IncognitoRecordMode:
-    """The mode a new incognito session must pin.
+def incognito_allowed_for_user(user: User, db_session: Session) -> bool:
+    """Whether this user may start an incognito chat.
 
-    The seam a workspace's record-mode setting must resolve through. Today it
-    returns the default unconditionally.
+    Availability composes the deployment capability (the ephemeral store must
+    exist) with the admin's security setting, which defaults to off. Anonymous
+    users never qualify: they share an identity, have no memberships, and
+    cannot authenticate against the teardown endpoint.
     """
-    return IncognitoRecordMode.USAGE_ONLY
+    if user.is_anonymous:
+        return False
+    if not incognito_context_available():
+        return False
+    availability = get_security_settings().incognito_availability
+    if availability is IncognitoAvailability.EVERYONE:
+        return True
+    if availability is IncognitoAvailability.GROUPS:
+        return user_in_incognito_enabled_group(db_session, user.id)
+    return False
+
+
+def resolve_incognito_record_mode() -> IncognitoRecordMode:
+    """The mode a new incognito session must pin: the workspace's admin
+    record-mode setting, usage_only by default.
+
+    Reads past the settings cache. Cache invalidation is process-local, so a
+    second api_server can hold the pre-save mode for the cache TTL, and this
+    read decides for the whole life of the session: pinning a stale
+    full_history would persist content the admin has already disallowed.
+    """
+    return load_effective_uncached().incognito_record_mode
 
 
 def content_free_file_descriptors(

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException
 from sqlalchemy import Row, delete, desc, func, nullsfirst, or_, select, update
 from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.orm import Session, joinedload, selectinload
+from sqlalchemy.sql.expression import ColumnElement
 
 from onyx.configs.chat_configs import HARD_DELETE_CHATS
 from onyx.configs.constants import MessageType
@@ -107,6 +108,15 @@ def get_incognito_session_ids_for_user(
     )
 
 
+def content_persisting_sessions_filter() -> ColumnElement[bool]:
+    """Ordinary chats plus incognito modes that persist content. Content-free
+    sessions have no message content to show on any history surface."""
+    persisting = [m for m in IncognitoRecordMode if m.persists_content]
+    return ChatSession.incognito_record_mode.is_(
+        None
+    ) | ChatSession.incognito_record_mode.in_(persisting)
+
+
 # Retrieves chat sessions by user
 # Chat sessions do not include onyxbot flows
 def get_chat_sessions_by_user(
@@ -119,6 +129,7 @@ def get_chat_sessions_by_user(
     only_non_project_chats: bool = False,
     include_failed_chats: bool = False,
     exclude_incognito: bool = False,
+    exclude_content_free: bool = False,
 ) -> list[ChatSession]:
     stmt = (
         select(ChatSession)
@@ -127,8 +138,14 @@ def get_chat_sessions_by_user(
         .order_by(desc(ChatSession.time_updated))
     )
 
+    # The two exclusions are independent because the surfaces differ: the owner
+    # sees none of their incognito sessions, while a workspace surface keeps the
+    # full-history ones and drops only those with no content to show.
     if exclude_incognito:
         stmt = stmt.where(ChatSession.incognito_record_mode.is_(None))
+
+    if exclude_content_free:
+        stmt = stmt.where(content_persisting_sessions_filter())
 
     if deleted is not None:
         stmt = stmt.where(ChatSession.deleted == deleted)

--- a/backend/onyx/db/incognito.py
+++ b/backend/onyx/db/incognito.py
@@ -1,0 +1,20 @@
+"""Membership query for groups-only incognito availability."""
+
+from uuid import UUID
+
+from sqlalchemy import exists, select
+from sqlalchemy.orm import Session
+
+from onyx.db.models import User__UserGroup, UserGroup
+
+
+def user_in_incognito_enabled_group(db_session: Session, user_id: UUID) -> bool:
+    """Whether any of the user's groups has its incognito flag set."""
+    stmt = select(
+        exists().where(
+            User__UserGroup.user_id == user_id,
+            User__UserGroup.user_group_id == UserGroup.id,
+            UserGroup.incognito_enabled.is_(True),
+        )
+    )
+    return bool(db_session.execute(stmt).scalar())

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -124,7 +124,7 @@ from onyx.file_store.models import FileDescriptor
 from onyx.kg.models import KGEntityTypeAttributes, KGStage
 from onyx.llm.models import ReasoningEffort
 from onyx.llm.override_models import LLMOverride, PromptOverride
-from onyx.server.security.models import SSRFProtectionLevel
+from onyx.server.security.models import IncognitoAvailability, SSRFProtectionLevel
 from onyx.tools.tool_implementations.web_search.models import WebContentProviderConfig
 from onyx.utils.encryption import decrypt_bytes_to_string, encrypt_string_to_bytes
 from onyx.utils.headers import HeaderItemDict
@@ -4608,6 +4608,27 @@ class SecuritySettings(Base):
     track_external_idp_expiry: Mapped[bool | None] = mapped_column(
         Boolean, nullable=True, default=None
     )
+    # Stored as the IncognitoAvailability value (e.g. "groups"). None falls
+    # back to the off-by-default env behavior.
+    incognito_availability: Mapped[IncognitoAvailability | None] = mapped_column(
+        Enum(
+            IncognitoAvailability,
+            native_enum=False,
+            values_callable=lambda x: [e.value for e in x],
+        ),
+        nullable=True,
+        default=None,
+    )
+    # What new incognito sessions pin. None falls back to usage_only.
+    incognito_record_mode: Mapped[IncognitoRecordMode | None] = mapped_column(
+        Enum(
+            IncognitoRecordMode,
+            native_enum=False,
+            values_callable=lambda x: [e.value for e in x],
+        ),
+        nullable=True,
+        default=None,
+    )
     # Stored as the SSRFProtectionLevel value (e.g. "validate_all"); None falls
     # back to the level derived from the legacy SSRF env vars.
     ssrf_protection_level: Mapped[SSRFProtectionLevel | None] = mapped_column(
@@ -5015,6 +5036,12 @@ class UserGroup(Base):
     )
     # whether this is a default group (e.g. "Basic", "Admins") that cannot be deleted
     is_default: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    # Members may start incognito chats when the workspace availability mode
+    # is groups-only. Ignored under the other modes.
+    incognito_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False
+    )
 
     # Last time a user updated this user group
     time_last_modified_by_user: Mapped[datetime.datetime] = mapped_column(

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -27,7 +27,10 @@ from onyx.chat.chat_utils import (
     create_chat_session_from_request,
     extract_headers,
 )
-from onyx.chat.incognito import delete_incognito_generated_files
+from onyx.chat.incognito import (
+    delete_incognito_generated_files,
+    incognito_allowed_for_user,
+)
 from onyx.chat.incognito_context import teardown_incognito_session
 from onyx.chat.models import ChatFullResponse, CreateChatSessionID
 from onyx.chat.process_message import (
@@ -676,6 +679,22 @@ def delete_chat_session_by_id(
         raise HTTPException(status_code=400, detail=str(e))
     if is_incognito:
         _teardown_incognito_after_delete(session_id)
+
+
+class IncognitoAvailabilityResponse(BaseModel):
+    available: bool
+
+
+@router.get("/incognito-availability")
+def get_incognito_availability(
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> IncognitoAvailabilityResponse:
+    """Whether the acting user may start an incognito chat, so the client can
+    hide the toggle. The create endpoint enforces the same rule regardless."""
+    return IncognitoAvailabilityResponse(
+        available=incognito_allowed_for_user(user, db_session)
+    )
 
 
 @router.post("/end-incognito-session/{session_id}", tags=PUBLIC_API_TAGS)

--- a/backend/onyx/server/security/models.py
+++ b/backend/onyx/server/security/models.py
@@ -4,6 +4,8 @@ from typing import NamedTuple
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from typing_extensions import Self
 
+from onyx.db.enums import IncognitoRecordMode
+
 
 class SSRFProtectionLevel(str, Enum):
     """How aggressively outbound HTTP requests are validated against private /
@@ -93,6 +95,16 @@ def _tenant_editable() -> dict[str, bool]:
     return {_OPERATOR_LOCKED_MARKER: False}
 
 
+class IncognitoAvailability(str, Enum):
+    """Who may start incognito chats. Secure default is OFF: the feature is
+    invisible until an admin turns it on."""
+
+    OFF = "off"
+    EVERYONE = "everyone"
+    # Only members of user groups whose incognito_enabled flag is set.
+    GROUPS = "groups"
+
+
 class SecuritySettingsOverrides(BaseModel):
     """Wire/storage shape. Absent / None on any field means "use env default"."""
 
@@ -105,6 +117,12 @@ class SecuritySettingsOverrides(BaseModel):
         default=None, json_schema_extra=_tenant_editable()
     )
     track_external_idp_expiry: bool | None = Field(
+        default=None, json_schema_extra=_tenant_editable()
+    )
+    incognito_availability: IncognitoAvailability | None = Field(
+        default=None, json_schema_extra=_tenant_editable()
+    )
+    incognito_record_mode: IncognitoRecordMode | None = Field(
         default=None, json_schema_extra=_tenant_editable()
     )
     ssrf_protection_level: SSRFProtectionLevel | None = Field(
@@ -188,6 +206,8 @@ class SecuritySettings(BaseModel):
 
     user_directory_admin_only: bool
     track_external_idp_expiry: bool
+    incognito_availability: IncognitoAvailability
+    incognito_record_mode: IncognitoRecordMode
     ssrf_protection_level: SSRFProtectionLevel
     mask_credential_prefix: bool
     llm_custom_config_env_injection: bool

--- a/backend/onyx/server/security/store.py
+++ b/backend/onyx/server/security/store.py
@@ -11,6 +11,7 @@ from onyx.cache.factory import get_cache_backend
 from onyx.configs import app_configs as _cfg
 from onyx.configs.constants import KV_PASSWORD_AUTH_ENABLED_KEY, OnyxRedisLocks
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import IncognitoRecordMode
 from onyx.db.security_settings import load_overrides as _db_load_overrides
 from onyx.db.security_settings import upsert_overrides as _db_upsert_overrides
 from onyx.db.sso_provider import fetch_sso_providers
@@ -20,6 +21,7 @@ from onyx.key_value_store.factory import get_kv_store
 from onyx.key_value_store.interface import KvKeyNotFoundError
 from onyx.server.security.models import (
     OPERATOR_LOCKED_FIELDS,
+    IncognitoAvailability,
     SecuritySettings,
     SecuritySettingsOverrides,
     SSRFProtectionLevel,
@@ -89,6 +91,9 @@ def _build_env_defaults() -> SecuritySettings:
     return SecuritySettings(
         user_directory_admin_only=_cfg.USER_DIRECTORY_ADMIN_ONLY,
         track_external_idp_expiry=_cfg.TRACK_EXTERNAL_IDP_EXPIRY,
+        # No env knob on purpose: incognito is off until an admin enables it.
+        incognito_availability=IncognitoAvailability.OFF,
+        incognito_record_mode=IncognitoRecordMode.USAGE_ONLY,
         ssrf_protection_level=_derive_ssrf_level_from_env(),
         mask_credential_prefix=_cfg.MASK_CREDENTIAL_PREFIX,
         llm_custom_config_env_injection=not MULTI_TENANT,

--- a/backend/tests/external_dependency_unit/chat/test_incognito_availability.py
+++ b/backend/tests/external_dependency_unit/chat/test_incognito_availability.py
@@ -1,0 +1,104 @@
+"""Guards who may start an incognito chat.
+
+The availability rule composes the admin security setting (default off) with
+group membership under groups-only mode. Runs against real Postgres because
+the membership query is a real join, and a mocked session would return
+whatever it is told.
+"""
+
+from collections.abc import Generator, Iterator
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.chat.incognito import incognito_allowed_for_user
+from onyx.db.models import User, User__UserGroup, UserGroup
+from onyx.server.security.models import IncognitoAvailability
+from tests.external_dependency_unit.conftest import create_test_user
+
+GROUP_NAME_PREFIX = "incognito-avail-"
+
+
+@pytest.fixture
+def owner(db_session: Session) -> Generator[User, None, None]:
+    user = create_test_user(db_session, "incognito-avail")
+    yield user
+    db_session.rollback()
+    db_session.query(User__UserGroup).filter(
+        User__UserGroup.user_id == user.id
+    ).delete()
+    db_session.query(UserGroup).filter(
+        UserGroup.name.like(f"{GROUP_NAME_PREFIX}%")
+    ).delete(synchronize_session=False)
+    db_session.delete(user)
+    db_session.commit()
+
+
+def _make_group(db_session: Session, user: User, incognito_enabled: bool) -> None:
+    group = UserGroup(
+        name=f"{GROUP_NAME_PREFIX}{incognito_enabled}",
+        incognito_enabled=incognito_enabled,
+    )
+    db_session.add(group)
+    db_session.flush()
+    db_session.add(User__UserGroup(user_group_id=group.id, user_id=user.id))
+    db_session.commit()
+
+
+@contextmanager
+def _workspace(
+    mode: IncognitoAvailability, store_available: bool = True
+) -> Iterator[None]:
+    with (
+        patch(
+            "onyx.chat.incognito.incognito_context_available",
+            return_value=store_available,
+        ),
+        patch(
+            "onyx.chat.incognito.get_security_settings",
+            return_value=MagicMock(incognito_availability=mode),
+        ),
+    ):
+        yield
+
+
+@pytest.mark.parametrize(
+    "mode,group_enabled,allowed",
+    [
+        (IncognitoAvailability.OFF, None, False),
+        (IncognitoAvailability.EVERYONE, None, True),
+        (IncognitoAvailability.GROUPS, True, True),
+        (IncognitoAvailability.GROUPS, False, False),
+        # No group at all, which is the case a membership join can get wrong.
+        (IncognitoAvailability.GROUPS, None, False),
+    ],
+)
+def test_availability_setting_decides(
+    db_session: Session,
+    owner: User,
+    mode: IncognitoAvailability,
+    group_enabled: bool | None,
+    allowed: bool,
+) -> None:
+    if group_enabled is not None:
+        _make_group(db_session, owner, group_enabled)
+
+    with _workspace(mode):
+        assert incognito_allowed_for_user(owner, db_session) is allowed
+
+
+def test_unavailable_store_refuses_what_the_setting_allows(
+    db_session: Session, owner: User
+) -> None:
+    """The setting cannot grant what the deployment cannot hold."""
+    with _workspace(IncognitoAvailability.EVERYONE, store_available=False):
+        assert not incognito_allowed_for_user(owner, db_session)
+
+
+def test_anonymous_user_is_refused(db_session: Session) -> None:
+    """Anonymous users share an identity and cannot call teardown."""
+    anonymous = MagicMock(is_anonymous=True)
+    with _workspace(IncognitoAvailability.EVERYONE):
+        assert not incognito_allowed_for_user(anonymous, db_session)

--- a/backend/tests/external_dependency_unit/db/test_incognito_history_exclusion.py
+++ b/backend/tests/external_dependency_unit/db/test_incognito_history_exclusion.py
@@ -6,11 +6,17 @@ since a mocked session would happily return rows the SQL would have filtered.
 """
 
 from collections.abc import Generator
+from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
 import pytest
 from sqlalchemy.orm import Session
 
+from ee.onyx.db.query_history import (
+    fetch_chat_sessions_eagerly_by_time,
+    fetch_persisting_chat_session_by_id,
+    get_page_of_chat_sessions,
+)
 from onyx.configs.constants import MessageType
 from onyx.db.chat import (
     create_chat_session,
@@ -65,8 +71,12 @@ def _make_session(
     return chat_session
 
 
-def _history_ids(db_session: Session, user_id: UUID) -> set[UUID]:
-    """The owner's own history, which is the call site that opts out."""
+def _sessions_by_user(
+    db_session: Session,
+    user_id: UUID,
+    exclude_incognito: bool = False,
+    exclude_content_free: bool = False,
+) -> set[UUID]:
     return {
         session.id
         for session in get_chat_sessions_by_user(
@@ -74,9 +84,118 @@ def _history_ids(db_session: Session, user_id: UUID) -> set[UUID]:
             deleted=None,
             db_session=db_session,
             include_failed_chats=True,
-            exclude_incognito=True,
+            exclude_incognito=exclude_incognito,
+            exclude_content_free=exclude_content_free,
         )
     }
+
+
+def _history_ids(db_session: Session, user_id: UUID) -> set[UUID]:
+    """The owner's own history, which is the call site that opts out."""
+    return _sessions_by_user(db_session, user_id, exclude_incognito=True)
+
+
+def test_history_excludes_incognito_by_default(
+    db_session: Session, owner: User
+) -> None:
+    ordinary = _make_session(db_session, owner.id, "ordinary chat", None)
+    incognito = _make_session(
+        db_session, owner.id, "incognito chat", IncognitoRecordMode.FULL_HISTORY
+    )
+
+    returned_ids = _history_ids(db_session, owner.id)
+    assert ordinary.id in returned_ids
+    assert incognito.id not in returned_ids
+
+
+def test_workspace_surface_keeps_full_history_and_drops_content_free(
+    db_session: Session, owner: User
+) -> None:
+    """The exclusion the query-history endpoint uses, which is the weaker one:
+    a full-history session is recorded for the workspace and only its owner is
+    kept from seeing it."""
+    full_history = _make_session(
+        db_session, owner.id, "full history chat", IncognitoRecordMode.FULL_HISTORY
+    )
+    usage_only = _make_session(
+        db_session, owner.id, "usage only chat", IncognitoRecordMode.USAGE_ONLY
+    )
+
+    returned_ids = _sessions_by_user(db_session, owner.id, exclude_content_free=True)
+    assert full_history.id in returned_ids
+    assert usage_only.id not in returned_ids
+
+
+def test_admin_query_history_page_hides_content_free_sessions(
+    db_session: Session, owner: User
+) -> None:
+    """Content-free sessions must not appear as blank rows in the table."""
+    ordinary = _make_session(db_session, owner.id, "ordinary chat", None)
+    full_history = _make_session(
+        db_session, owner.id, "full history chat", IncognitoRecordMode.FULL_HISTORY
+    )
+    usage_only = _make_session(
+        db_session, owner.id, "usage only chat", IncognitoRecordMode.USAGE_ONLY
+    )
+
+    page_ids = {
+        session.id
+        for session in get_page_of_chat_sessions(
+            start_time=None,
+            end_time=None,
+            db_session=db_session,
+            page_num=0,
+            page_size=1000,
+        )
+    }
+    assert ordinary.id in page_ids
+    assert full_history.id in page_ids
+    assert usage_only.id not in page_ids
+
+
+def test_query_history_export_hides_content_free_sessions(
+    db_session: Session, owner: User
+) -> None:
+    ordinary = _make_session(db_session, owner.id, "ordinary chat", None)
+    usage_only = _make_session(
+        db_session, owner.id, "usage only chat", IncognitoRecordMode.USAGE_ONLY
+    )
+
+    window = timedelta(minutes=5)
+    now = datetime.now(timezone.utc)
+    export_ids = {
+        session.id
+        for session in fetch_chat_sessions_eagerly_by_time(
+            start=now - window,
+            end=now + window,
+            db_session=db_session,
+            limit=None,
+        )
+    }
+    assert ordinary.id in export_ids
+    assert usage_only.id not in export_ids
+
+
+def test_query_history_detail_hides_content_free_sessions(
+    db_session: Session, owner: User
+) -> None:
+    """Knowing the id must not be a way around the list filter: the detail
+    route is the one surface that takes an id straight from the caller."""
+    ordinary = _make_session(db_session, owner.id, "ordinary chat", None)
+    full_history = _make_session(
+        db_session, owner.id, "full history chat", IncognitoRecordMode.FULL_HISTORY
+    )
+    usage_only = _make_session(
+        db_session, owner.id, "usage only chat", IncognitoRecordMode.USAGE_ONLY
+    )
+
+    for visible in (ordinary, full_history):
+        assert fetch_persisting_chat_session_by_id(visible.id, db_session).id == (
+            visible.id
+        )
+
+    with pytest.raises(ValueError):
+        fetch_persisting_chat_session_by_id(usage_only.id, db_session)
 
 
 def test_every_mode_is_excluded_from_history(db_session: Session, owner: User) -> None:
@@ -93,6 +212,23 @@ def test_every_mode_is_excluded_from_history(db_session: Session, owner: User) -
     returned_ids = _history_ids(db_session, owner.id)
     for mode, chat_session in sessions.items():
         assert chat_session.id not in returned_ids, f"{mode.value} leaked"
+
+
+def test_search_excludes_incognito_without_a_query(
+    db_session: Session, owner: User
+) -> None:
+    ordinary = _make_session(db_session, owner.id, "quarterly revenue notes", None)
+    incognito = _make_session(
+        db_session,
+        owner.id,
+        "quarterly revenue secrets",
+        IncognitoRecordMode.FULL_HISTORY,
+    )
+
+    sessions, _ = search_chat_sessions(user_id=owner.id, db_session=db_session)
+    returned_ids = {session.id for session in sessions}
+    assert ordinary.id in returned_ids
+    assert incognito.id not in returned_ids
 
 
 def test_search_excludes_incognito_matching_the_query(

--- a/backend/tests/external_dependency_unit/server/security/test_security_settings_store.py
+++ b/backend/tests/external_dependency_unit/server/security/test_security_settings_store.py
@@ -13,7 +13,10 @@ from sqlalchemy.orm import Session
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import SecuritySettings as SecuritySettingsRow
 from onyx.server.security import store as security_store
-from onyx.server.security.models import SecuritySettingsOverrides
+from onyx.server.security.models import (
+    IncognitoAvailability,
+    SecuritySettingsOverrides,
+)
 from onyx.server.security.store import (
     _build_env_defaults,
     _install_cache_for_test,
@@ -71,6 +74,27 @@ def test_partial_overrides_only_overrides_specified_fields() -> None:
     assert effective.password_min_length == env.password_min_length
     assert effective.password_max_length == env.password_max_length
     assert effective.password_require_uppercase == env.password_require_uppercase
+
+
+def test_every_override_field_has_a_column_or_kv_backing() -> None:
+    """upsert_overrides only writes fields with a matching row column, so an
+    override without one echoes from PUT but vanishes on the next read."""
+    kv_backed = {"password_auth_enabled"}
+    missing = [
+        name
+        for name in SecuritySettingsOverrides.model_fields
+        if name not in kv_backed and not hasattr(SecuritySettingsRow, name)
+    ]
+    assert not missing
+
+
+def test_incognito_availability_round_trips_through_the_store() -> None:
+    apply_patch(
+        SecuritySettingsOverrides(incognito_availability=IncognitoAvailability.GROUPS),
+        present_keys={"incognito_availability"},
+    )
+    effective = get_security_settings()
+    assert effective.incognito_availability is IncognitoAvailability.GROUPS
 
 
 def test_cache_hits_avoid_db_reads() -> None:

--- a/backend/tests/unit/onyx/chat/test_incognito_record_mode.py
+++ b/backend/tests/unit/onyx/chat/test_incognito_record_mode.py
@@ -1,7 +1,13 @@
-"""Guards the incognito recording policy: no mode other than FULL_HISTORY may
-write conversation content, a corrupt mode value reads as the safe one, and a
-content-free turn's persisted file descriptors keep linkage but not names.
+"""Guards the incognito recording policy: which mode permits which sink.
+
+The mode enum is the only policy object, so these tests pin the full
+mode x sink matrix. A behavior change that is not also a deliberate edit
+here is a policy regression.
 """
+
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from onyx.chat.incognito import (
     content_free_file_descriptors,
@@ -11,37 +17,89 @@ from onyx.db.enums import IncognitoRecordMode
 from onyx.file_store.models import ChatFileType, FileDescriptor
 
 
-def test_only_full_history_persists_content() -> None:
-    persisting = [m for m in IncognitoRecordMode if m.persists_content]
-    assert persisting == [IncognitoRecordMode.FULL_HISTORY]
-
-
-def test_default_never_persists_content() -> None:
-    """A dropped admin setting must not silently start recording chats."""
-    assert resolve_incognito_record_mode() is IncognitoRecordMode.USAGE_ONLY
-    assert resolve_incognito_record_mode().persists_content is False
-
-
-def test_unknown_context_value_fails_closed() -> None:
-    """A corrupt contextvar must never read as content-persisting."""
-    assert IncognitoRecordMode.from_context_value("garbage") is (
-        IncognitoRecordMode.USAGE_ONLY
-    )
-    assert IncognitoRecordMode.from_context_value(None) is None
-
-
-def test_descriptors_strip_the_name_and_keep_linkage() -> None:
-    scrubbed = content_free_file_descriptors(
+class TestModeSinkMatrix:
+    @pytest.mark.parametrize(
+        "mode,persists_content,emits_external_traces,fires_hooks",
         [
-            FileDescriptor(
-                id="file-1",
-                type=ChatFileType.DOC,
-                name="acquisition_target.pdf",
-                user_file_id="uf-1",
-            )
-        ]
+            (IncognitoRecordMode.FULL_HISTORY, True, True, True),
+            (IncognitoRecordMode.USAGE_ONLY, False, False, False),
+        ],
     )
-    assert scrubbed == [
-        FileDescriptor(id="file-1", type=ChatFileType.DOC, user_file_id="uf-1")
-    ]
-    assert "name" not in scrubbed[0]
+    def test_matrix(
+        self,
+        mode: IncognitoRecordMode,
+        persists_content: bool,
+        emits_external_traces: bool,
+        fires_hooks: bool,
+    ) -> None:
+        assert mode.persists_content is persists_content
+        assert mode.emits_external_traces is emits_external_traces
+        assert mode.fires_hooks is fires_hooks
+
+    def test_only_full_history_persists_content(self) -> None:
+        """The guarantee: no other mode may write conversation content."""
+        persisting = [m for m in IncognitoRecordMode if m.persists_content]
+        assert persisting == [IncognitoRecordMode.FULL_HISTORY]
+
+    def test_no_mode_emits_external_traces_without_persisting_content(self) -> None:
+        """External egress never outlives the decision to record."""
+        for mode in IncognitoRecordMode:
+            if mode.emits_external_traces:
+                assert mode.persists_content
+
+
+class TestResolver:
+    @pytest.mark.parametrize("mode", list(IncognitoRecordMode))
+    def test_resolves_to_the_admin_setting(self, mode: IncognitoRecordMode) -> None:
+        with patch(
+            "onyx.chat.incognito.load_effective_uncached",
+            return_value=MagicMock(incognito_record_mode=mode),
+        ):
+            assert resolve_incognito_record_mode() is mode
+
+    def test_reads_past_the_settings_cache(self) -> None:
+        """The pin is durable, so a cached pre-save mode must never reach it."""
+        with (
+            patch(
+                "onyx.chat.incognito.load_effective_uncached",
+                return_value=MagicMock(
+                    incognito_record_mode=IncognitoRecordMode.USAGE_ONLY
+                ),
+            ) as uncached,
+            patch(
+                "onyx.chat.incognito.get_security_settings",
+                return_value=MagicMock(
+                    incognito_record_mode=IncognitoRecordMode.FULL_HISTORY
+                ),
+            ) as cached,
+        ):
+            assert resolve_incognito_record_mode() is IncognitoRecordMode.USAGE_ONLY
+        assert uncached.called
+        assert not cached.called
+
+    def test_unknown_context_value_fails_closed(self) -> None:
+        """A corrupt contextvar must never read as content-persisting."""
+        resolved = IncognitoRecordMode.from_context_value("garbage")
+        assert resolved is IncognitoRecordMode.USAGE_ONLY
+        assert IncognitoRecordMode.from_context_value(None) is None
+
+
+class TestContentFreeFileDescriptors:
+    """The persisted descriptor of a content-free turn keeps linkage, never
+    the filename."""
+
+    def test_strips_name_and_keeps_linkage(self) -> None:
+        scrubbed = content_free_file_descriptors(
+            [
+                FileDescriptor(
+                    id="file-1",
+                    type=ChatFileType.DOC,
+                    name="acquisition_target.pdf",
+                    user_file_id="uf-1",
+                )
+            ]
+        )
+        assert scrubbed == [
+            FileDescriptor(id="file-1", type=ChatFileType.DOC, user_file_id="uf-1")
+        ]
+        assert "name" not in scrubbed[0]

--- a/backend/tests/unit/onyx/server/security/test_models.py
+++ b/backend/tests/unit/onyx/server/security/test_models.py
@@ -5,10 +5,12 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
+from onyx.db.enums import IncognitoRecordMode
 from onyx.server.security.models import (
     OPERATOR_LOCKED_FIELDS,
     PASSWORD_LENGTH_CAP,
     PASSWORD_MAX_LENGTH_FLOOR,
+    IncognitoAvailability,
     SecuritySettings,
     SecuritySettingsOverrides,
     SSRFProtectionLevel,
@@ -20,6 +22,8 @@ from onyx.server.security.models import (
 _VALID_EFFECTIVE_KWARGS: dict[str, Any] = {
     "user_directory_admin_only": False,
     "track_external_idp_expiry": False,
+    "incognito_availability": IncognitoAvailability.OFF,
+    "incognito_record_mode": IncognitoRecordMode.USAGE_ONLY,
     "ssrf_protection_level": SSRFProtectionLevel.VALIDATE_LLM,
     "mask_credential_prefix": True,
     "llm_custom_config_env_injection": True,

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -20,6 +20,7 @@ export const SWR_KEYS = {
   customAnalyticsScript: "/api/enterprise-settings/custom-analytics-script",
   authType: "/api/auth/type",
   adminSecuritySettings: "/api/admin/security",
+  incognitoAvailability: "/api/chat/incognito-availability",
   adminSsoProviders: "/api/admin/sso/provider",
 
   // ── Agents / Personas ─────────────────────────────────────────────────────

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -543,6 +543,43 @@ export interface UserGroup {
   is_up_to_date: boolean;
   is_up_for_deletion: boolean;
   is_default: boolean;
+  // Members may start incognito chats while the workspace availability
+  // setting is groups-only.
+  incognito_enabled: boolean;
+}
+
+// Mirrors `IncognitoAvailability` in backend/onyx/server/security/models.py.
+export type IncognitoAvailability = "off" | "everyone" | "groups";
+
+// Mirrors `IncognitoRecordMode` in backend/onyx/db/enums.py.
+export type IncognitoRecordMode = "full_history" | "usage_only";
+
+// Mirrors `SSRFProtectionLevel` in backend/onyx/server/security/models.py.
+export type SSRFProtectionLevel =
+  | "validate_all"
+  | "validate_llm"
+  | "allow_private_network"
+  | "disabled";
+
+// Read shape of GET /admin/security: effective, env-merged settings. Every
+// field is concrete, the backend never returns null here (see
+// `SecuritySettings` in backend/onyx/server/security/models.py).
+export interface SecuritySettings {
+  user_directory_admin_only: boolean;
+  incognito_availability: IncognitoAvailability;
+  incognito_record_mode: IncognitoRecordMode;
+  track_external_idp_expiry: boolean;
+  ssrf_protection_level: SSRFProtectionLevel;
+  mask_credential_prefix: boolean;
+  llm_custom_config_env_injection: boolean;
+  valid_email_domains: string[];
+  password_min_length: number;
+  password_max_length: number;
+  password_require_uppercase: boolean;
+  password_require_lowercase: boolean;
+  password_require_digit: boolean;
+  password_require_special_char: boolean;
+  password_auth_enabled: boolean;
 }
 
 export enum ValidSources {

--- a/web/src/views/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/EditGroupPage.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import useSWR, { useSWRConfig } from "swr";
 import useGroupMemberCandidates from "./useGroupMemberCandidates";
-import { Table, Button, Divider } from "@opal/components";
+import { Table, Button, Divider, Switch } from "@opal/components";
 import { IllustrationContent, InputHorizontal, toast } from "@opal/layouts";
 import {
   SvgUsers,
@@ -23,7 +23,7 @@ import { InputTypeIn } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
 import { ConfirmationModalLayout } from "@opal/layouts";
 import { errorHandlingFetcher, skipRetryOnAuthError } from "@/lib/fetcher";
-import type { UserGroup } from "@/lib/types";
+import type { SecuritySettings, UserGroup } from "@/lib/types";
 import { useSettings } from "@/lib/settings/hooks";
 import { Tier } from "@/lib/settings/types";
 import { tierAtLeast } from "@/lib/tiers";
@@ -32,6 +32,7 @@ import { baseColumns, memberTableColumns, tc, PAGE_SIZE } from "./shared";
 import {
   renameGroup,
   updateGroup,
+  setGroupIncognito,
   deleteGroup,
   updateAgentGroupSharing,
   updateDocSetGroupSharing,
@@ -91,6 +92,17 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     onErrorRetry: skipRetryOnAuthError,
   });
 
+  // The flag only does anything under designated-groups availability, so the
+  // field stays off the page entirely elsewhere. Curators get a 403 reading
+  // security settings, which also leaves it hidden.
+  const { data: securitySettings } = useSWR<
+    Pick<SecuritySettings, "incognito_availability">
+  >(SWR_KEYS.adminSecuritySettings, errorHandlingFetcher, {
+    onErrorRetry: skipRetryOnAuthError,
+  });
+  const showIncognitoField =
+    securitySettings?.incognito_availability === "groups";
+
   // Form state
   const [groupName, setGroupName] = useState("");
   const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
@@ -109,6 +121,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
       costBudgetDollars: null,
     },
   ]);
+  const [incognitoEnabled, setIncognitoEnabled] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [initialized, setInitialized] = useState(false);
@@ -138,6 +151,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
       const agentIds = group.personas.map((p) => p.id);
       setSelectedAgentIds(agentIds);
       initialAgentIdsRef.current = agentIds;
+      setIncognitoEnabled(group.incognito_enabled);
       setInitialized(true);
     }
   }, [group, initialized]);
@@ -245,6 +259,10 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
       // Update members and cc_pairs
       await updateGroup(groupId, selectedUserIds, selectedCcPairIds);
 
+      if (group && incognitoEnabled !== group.incognito_enabled) {
+        await setGroupIncognito(groupId, incognitoEnabled);
+      }
+
       // Update agent sharing (add/remove this group from changed agents)
       await updateAgentGroupSharing(
         groupId,
@@ -270,6 +288,8 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
 
       mutate(SWR_KEYS.adminUserGroups);
       mutate(SWR_KEYS.userGroupTokenRateLimit(groupId));
+      // Membership and the incognito flag both feed chat availability.
+      mutate(SWR_KEYS.incognitoAvailability);
       toast.success(`Group "${trimmed}" updated`);
       router.push("/admin/groups");
     } catch (e) {
@@ -473,6 +493,21 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                 disabled={!isEnterpriseTier}
                 disabledTooltip={tokenLimitsDisabledTooltip}
               />
+
+              {showIncognitoField && (
+                <Card>
+                  <InputHorizontal
+                    title="Incognito Chats"
+                    description="Members of this group may start incognito chats."
+                    withLabel
+                  >
+                    <Switch
+                      checked={incognitoEnabled}
+                      onCheckedChange={setIncognitoEnabled}
+                    />
+                  </InputHorizontal>
+                </Card>
+              )}
 
               {/* Delete This Group */}
               <Card>

--- a/web/src/views/admin/GroupsPage/svc.ts
+++ b/web/src/views/admin/GroupsPage/svc.ts
@@ -63,6 +63,23 @@ async function updateGroup(
   }
 }
 
+async function setGroupIncognito(
+  groupId: number,
+  enabled: boolean
+): Promise<void> {
+  const res = await fetch(`${USER_GROUP_URL}/${groupId}/incognito`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ enabled }),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => null);
+    throw new Error(
+      detail?.detail ?? `Failed to update incognito access: ${res.statusText}`
+    );
+  }
+}
+
 async function deleteGroup(groupId: number): Promise<void> {
   const res = await fetch(`${USER_GROUP_URL}/${groupId}`, {
     method: "DELETE",
@@ -311,6 +328,7 @@ export {
   renameGroup,
   createGroup,
   updateGroup,
+  setGroupIncognito,
   deleteGroup,
   updateAgentGroupSharing,
   updateDocSetGroupSharing,

--- a/web/src/views/admin/SecurityHardeningPage.tsx
+++ b/web/src/views/admin/SecurityHardeningPage.tsx
@@ -23,35 +23,14 @@ import {
 import { Card, Switch } from "@opal/components";
 import { markdown } from "@opal/utils";
 import type { RichStr } from "@opal/types";
+import type {
+  IncognitoAvailability,
+  IncognitoRecordMode,
+  SecuritySettings,
+  SSRFProtectionLevel,
+} from "@/lib/types";
 
 const route = ADMIN_ROUTES.SECURITY_HARDENING;
-
-// Outbound-request validation policy. Mirrors `SSRFProtectionLevel`
-// in backend/onyx/server/security/models.py.
-type SSRFProtectionLevel =
-  | "validate_all"
-  | "validate_llm"
-  | "allow_private_network"
-  | "disabled";
-
-// Read shape: the effective, env-merged settings returned by GET /admin/security.
-// Every field is concrete — the backend never returns null here (see
-// `SecuritySettings` in backend/onyx/server/security/models.py).
-interface SecuritySettings {
-  user_directory_admin_only: boolean;
-  track_external_idp_expiry: boolean;
-  ssrf_protection_level: SSRFProtectionLevel;
-  mask_credential_prefix: boolean;
-  llm_custom_config_env_injection: boolean;
-  valid_email_domains: string[];
-  password_min_length: number;
-  password_max_length: number;
-  password_require_uppercase: boolean;
-  password_require_lowercase: boolean;
-  password_require_digit: boolean;
-  password_require_special_char: boolean;
-  password_auth_enabled: boolean;
-}
 
 // Write shape: a partial patch. The backend treats only the keys present in the
 // PUT body as explicit overrides; absent keys keep their stored value, while an
@@ -420,6 +399,84 @@ export default function SecurityHardeningPage() {
                         description="Only admins can see the full user list."
                       >
                         Visible to Admins Only
+                      </InputSelect.Item>
+                    </InputSelect.Content>
+                  </InputSelect>
+                </div>
+              </InputHorizontal>
+
+              <InputHorizontal
+                title="Incognito Chats"
+                description="Incognito chats never appear in their owner's history. Group access is configured per group under Groups."
+                withLabel
+              >
+                <div className="w-60">
+                  <InputSelect
+                    value={draft.incognito_availability}
+                    onValueChange={async (value) => {
+                      await saveSettings({
+                        incognito_availability: value as IncognitoAvailability,
+                      });
+                      await mutate(SWR_KEYS.incognitoAvailability);
+                    }}
+                  >
+                    <InputSelect.Trigger />
+                    <InputSelect.Content>
+                      <InputSelect.Item
+                        value="off"
+                        wrapDescription
+                        description="No one can start incognito chats."
+                      >
+                        Off
+                      </InputSelect.Item>
+                      <InputSelect.Item
+                        value="everyone"
+                        wrapDescription
+                        description="Anyone signed in can start incognito chats."
+                      >
+                        Everyone
+                      </InputSelect.Item>
+                      <InputSelect.Item
+                        value="groups"
+                        wrapDescription
+                        description="Only members of groups with incognito access enabled."
+                      >
+                        Designated Groups
+                      </InputSelect.Item>
+                    </InputSelect.Content>
+                  </InputSelect>
+                </div>
+              </InputHorizontal>
+
+              <InputHorizontal
+                title="Incognito Chat Records"
+                description="What the workspace keeps from incognito chats. New sessions pin the mode active when they start."
+                withLabel
+              >
+                <div className="w-60">
+                  <InputSelect
+                    value={draft.incognito_record_mode}
+                    onValueChange={(value) =>
+                      void saveSettings({
+                        incognito_record_mode: value as IncognitoRecordMode,
+                      })
+                    }
+                  >
+                    <InputSelect.Trigger />
+                    <InputSelect.Content>
+                      <InputSelect.Item
+                        value="usage_only"
+                        wrapDescription
+                        description="No message content is stored. Token usage is still tracked, and these chats do not appear in query history."
+                      >
+                        Usage Only
+                      </InputSelect.Item>
+                      <InputSelect.Item
+                        value="full_history"
+                        wrapDescription
+                        description="Recorded like any other chat: query history, usage, and tracing. Hidden only from the owner's own history."
+                      >
+                        Full History
                       </InputSelect.Item>
                     </InputSelect.Content>
                   </InputSelect>


### PR DESCRIPTION
## Description

Part 3 of 5 for incognito chat (ENG-4314). Builds on #13866, which added the chat core that reads these settings.

Design doc: [Incognito Chat Mode](https://dev-wiki.onyx.app/app/wiki/Engineering%20Projects/Onyx%20Projects/Incognito%20Chat%20Mode/Design.md)

What this adds:

- **Who may start an incognito chat.** A new Security page setting with three states: off, everyone, or members of designated groups. Off is the default and there is no env knob, so the feature stays invisible until an admin turns it on. Under groups mode, each group carries an `incognito_enabled` flag edited on its own page, and admins can stage that flag before flipping the workspace into groups mode.
- **What the workspace keeps.** A second setting picks the record mode new sessions pin: usage only, which writes no message content, or full history, which records the chat like any other. The chat core stopped returning a hardcoded default and now reads this.
- **Server-side enforcement.** Creating a session decides from the deployment capability, the setting, and the caller's group membership. The client flag only asks. A deployment that cannot hold the ephemeral context refuses with `DEPLOYMENT_UNSUPPORTED`, and a user the admin has not granted refuses with `UNAUTHORIZED`, so the two never report as each other. Anonymous users never qualify: they share an identity and cannot authenticate against the teardown endpoint.
- **A `GET /chat/incognito-availability` endpoint** so the client can hide the toggle. The create path enforces the same rule regardless.
- **Query history that agrees with the mode.** Full-history sessions reach the admin query history page and its CSV export. Content-free sessions stay out of every surface, since they have no message content to show. The owner still sees none of their own incognito sessions in history, search, or a project's list, whichever mode is active.

The record-mode read deliberately bypasses the security-settings cache. Invalidation is process-local with a 10 second TTL, and the pin is durable for the life of the session, so a second api_server holding the pre-save value would otherwise persist content an admin had already disallowed. Availability keeps the cache: it backs a polled endpoint, and a stale allow still yields a correctly pinned session.

One migration adds all three columns: the two settings, both nullable so NULL reads as off and usage_only, and the group flag with a `false` server default.

The five PRs: #13886 the column, #13866 the chat core, this one, then page mode with the upload lifecycle, and the LLM and usage layer that sends `x-bf-disable-content-logging` to Bifrost.

## How Has This Been Tested?

- Unit: the mode/sink matrix, the resolver against each mode, and a regression test that the resolver reads past the settings cache. That test fails on the unfixed resolver and passes with it.
- External dependency unit, against real Postgres: the availability rule across off/everyone/groups including a member of a disabled group and a user with no groups at all, an unavailable store refusing what the setting allows, and an anonymous user refused; the owner's history excluding every mode while the workspace surface keeps full history and drops content-free; and both settings round-tripping through the store.
- A guard that every override field has a backing column, since `upsert_overrides` silently drops fields without one.
- `ruff check`, `ruff format --check`, and project-wide `ty check` clean. Backend unit suite passes; the 8 `test_process_isolation.py` failures reproduce on main and are unrelated.
- Local Greptile CLI review of this exact content against main: confidence 5/5, zero comments.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
