### PR TITLE
feat(chat): incognito page mode with ephemeral files and projects

### DIFF
--- a/backend/alembic/versions/3260759d6965_add_incognito_to_user_file.py
+++ b/backend/alembic/versions/3260759d6965_add_incognito_to_user_file.py
@@ -1,0 +1,48 @@
+"""add incognito columns to user_file
+
+Revision ID: 3260759d6965
+Revises: c7f1a9d4e206
+Create Date: 2026-08-10 13:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "3260759d6965"
+down_revision = "c7f1a9d4e206"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_file",
+        sa.Column(
+            "incognito",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    # No foreign key: the chat_session row is deleted at teardown and these
+    # rows must outlive it long enough for the orphan sweep to find them.
+    op.add_column(
+        "user_file",
+        sa.Column("incognito_session_id", sa.UUID(as_uuid=True), nullable=True),
+    )
+    # Partial index for the stale-incognito sweep, tiny since incognito rows
+    # are short-lived.
+    op.create_index(
+        "ix_user_file_incognito_sweep",
+        "user_file",
+        ["incognito_session_id", "status", "last_accessed_at"],
+        postgresql_where=sa.text("incognito"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_file_incognito_sweep", table_name="user_file")
+    op.drop_column("user_file", "incognito_session_id")
+    op.drop_column("user_file", "incognito")

--- a/backend/ee/onyx/db/query_history.py
+++ b/backend/ee/onyx/db/query_history.py
@@ -153,8 +153,9 @@ def fetch_chat_sessions_eagerly_by_time(
     asc_time_order: UnaryExpression = asc(ChatSession.time_created)
     message_order: UnaryExpression = asc(ChatMessage.id)
 
+    # Unfiltered on record mode: this backs the usage report, which carries
+    # token counts and no message content, and every mode meters usage.
     filters: list[ColumnElement | BinaryExpression] = [
-        content_persisting_sessions_filter(),
         ChatSession.time_created.between(start, end),
     ]
 

--- a/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
@@ -18,7 +18,10 @@ from onyx.background.celery.celery_utils import httpx_init_vespa_pool
 from onyx.background.celery.tasks.shared.RetryDocumentIndex import RetryDocumentIndex
 from onyx.cache.factory import get_cache_backend
 from onyx.chat.chat_processing_checker import is_chat_session_processing
-from onyx.chat.incognito import delete_incognito_generated_files
+from onyx.chat.incognito import (
+    delete_incognito_generated_files,
+    sweep_stale_incognito_user_files,
+)
 from onyx.chat.incognito_context import incognito_session_ended
 from onyx.configs.app_configs import (
     DISABLE_VECTOR_DB,
@@ -577,6 +580,10 @@ def _supply_user_file_to_secondary(user_file_id: str, tenant_id: str) -> bool:
         user_file = db_session.get(UserFile, _as_uuid(user_file_id))
         file_id = user_file.file_id if user_file is not None else None
         file_name = user_file.name if user_file is not None else None
+        incognito = user_file is not None and user_file.incognito
+    # Incognito files never enter any index, so the flag clears with no write.
+    if incognito:
+        return True
     if secondary is None or file_id is None:
         return False
 
@@ -674,6 +681,7 @@ def process_user_file_impl(
 
             file_id = uf.file_id
             file_name = uf.name
+            skip_search_index = uf.incognito
         # DB connection returned to pool here; file I/O and indexing run without it.
 
         try:
@@ -681,7 +689,9 @@ def process_user_file_impl(
                 user_file_id, file_id, file_name, tenant_id
             )
             try:
-                if DISABLE_VECTOR_DB:
+                # Incognito uploads get text extraction for chat use but never
+                # enter the search index.
+                if DISABLE_VECTOR_DB or skip_search_index:
                     _process_user_file_without_vector_db(
                         user_file_id=user_file_id,
                         documents=documents,
@@ -800,6 +810,15 @@ def check_for_user_file_delete(self: Task, *, tenant_id: str) -> None:
             return None
 
         with get_session_with_current_tenant() as db_session:
+            # Orphaned incognito uploads (teardown never arrived) join the
+            # DELETING pool here so the standard machinery below cleans them.
+            stale_incognito = sweep_stale_incognito_user_files(db_session)
+            if stale_incognito:
+                db_session.commit()
+                task_logger.info(
+                    f"check_for_user_file_delete - Queued {stale_incognito} "
+                    f"stale incognito files for tenant={tenant_id}"
+                )
             user_file_ids = (
                 db_session.execute(
                     select(UserFile.id).where(
@@ -943,17 +962,26 @@ def delete_user_file_impl(
                 )
 
         file_store = get_default_file_store()
+        blob_deleted = True
         try:
-            file_store.delete_file(file_id)
+            file_store.delete_file(file_id, error_on_missing=False)
             file_store.delete_file(
-                user_file_id_to_plaintext_file_name(_as_uuid(user_file_id))
+                user_file_id_to_plaintext_file_name(_as_uuid(user_file_id)),
+                error_on_missing=False,
             )
         except Exception as e:
+            blob_deleted = False
             task_logger.exception(
                 f"delete_user_file_impl - Error deleting file id={user_file_id} - {e.__class__.__name__}"
             )
 
-        # Phase 3: short write session — remove the DB record
+        # Phase 3: short write session, removing the DB record. The row is the
+        # only handle a retry has on the blob, so a refused delete keeps it.
+        if not blob_deleted:
+            task_logger.warning(
+                f"delete_user_file_impl - Keeping row id={user_file_id} for retry"
+            )
+            return
         with get_session_with_current_tenant() as db_session:
             user_file = db_session.get(UserFile, _as_uuid(user_file_id))
             if user_file is not None:

--- a/backend/onyx/background/task_utils.py
+++ b/backend/onyx/background/task_utils.py
@@ -163,6 +163,7 @@ def drain_delete_loop(tenant_id: str) -> None:
     from onyx.background.celery.tasks.user_file_processing.tasks import (
         delete_user_file_impl,
     )
+    from onyx.chat.incognito import sweep_stale_incognito_user_files
     from onyx.db.engine.sql_engine import get_session_with_current_tenant
 
     failed: set[UUID] = set()
@@ -180,6 +181,16 @@ def drain_delete_loop(tenant_id: str) -> None:
         except Exception:
             logger.exception("Failed to delete user file %s", file_id)
             failed.add(file_id)
+
+    # Last, and never fatal: this loop is the whole delete path on lite
+    # deployments, so a sweep that cannot reach Redis must not hold up ordinary
+    # deletion. What it queues is picked up on the next pass.
+    try:
+        with get_session_with_current_tenant() as session:
+            if sweep_stale_incognito_user_files(session):
+                session.commit()
+    except Exception:
+        logger.exception("Stale incognito sweep failed")
 
 
 def drain_project_sync_loop(tenant_id: str) -> None:

--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -33,7 +33,11 @@ from onyx.db.chat import (
     get_chat_messages_by_session,
     get_or_create_root_message,
 )
-from onyx.db.enums import IncognitoRecordMode, UserFileStatus
+from onyx.db.enums import (
+    IncognitoRecordMode,
+    UserFileStatus,
+    record_mode_persists_content,
+)
 from onyx.db.file_record import FileRecordNotFoundError
 from onyx.db.kg_config import (
     get_kg_config_settings,
@@ -205,21 +209,33 @@ def create_chat_session_from_request(
                 OnyxErrorCode.DEPLOYMENT_UNSUPPORTED,
                 "Incognito chat is not supported on this deployment.",
             )
-        if not incognito_allowed_for_user(user, db_session):
+        if not incognito_allowed_for_user(user, db_session, cached=False):
             raise OnyxError(
                 OnyxErrorCode.UNAUTHORIZED,
                 "Incognito chat is not enabled for this user.",
             )
         incognito_mode = resolve_incognito_record_mode()
 
-    return create_chat_session(
+    # A caller-supplied title is conversation-derived, so a content-free
+    # session stores none of it.
+    description = (
+        chat_session_request.description or ""
+        if record_mode_persists_content(incognito_mode)
+        else ""
+    )
+
+    chat_session = create_chat_session(
         db_session=db_session,
-        description=chat_session_request.description or "",
+        description=description,
         user_id=user.id,
         persona_id=chat_session_request.persona_id,
         project_id=chat_session_request.project_id,
         incognito_record_mode=incognito_mode,
+        session_id=(
+            chat_session_request.incognito_session_id if incognito_mode else None
+        ),
     )
+    return chat_session
 
 
 def create_chat_history_chain(

--- a/backend/onyx/chat/incognito.py
+++ b/backend/onyx/chat/incognito.py
@@ -18,10 +18,19 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from onyx.chat.incognito_context import incognito_context_available
+from onyx.chat.incognito_context import (
+    incognito_context_available,
+    incognito_session_ended,
+)
 from onyx.db.enums import IncognitoRecordMode, record_mode_persists_content
 from onyx.db.file_record import get_incognito_file_ids
-from onyx.db.incognito import user_in_incognito_enabled_group
+from onyx.db.incognito import (
+    is_content_persisting_session,
+    mark_incognito_user_files_deleting,
+    mark_unadopted_incognito_files_deleting,
+    stale_incognito_session_ids,
+    user_in_incognito_enabled_group,
+)
 from onyx.db.models import User
 from onyx.file_store.file_store import get_default_file_store
 from onyx.file_store.models import FileDescriptor
@@ -38,19 +47,26 @@ def current_turn_persists_content() -> bool:
     return record_mode_persists_content(mode)
 
 
-def incognito_allowed_for_user(user: User, db_session: Session) -> bool:
+def incognito_allowed_for_user(
+    user: User, db_session: Session, *, cached: bool = True
+) -> bool:
     """Whether this user may start an incognito chat.
 
     Availability composes the deployment capability (the ephemeral store must
     exist) with the admin's security setting, which defaults to off. Anonymous
     users never qualify: they share an identity, have no memberships, and
     cannot authenticate against the teardown endpoint.
+
+    ``cached`` must be False wherever this decides an action rather than an
+    affordance. Cache invalidation is process-local, so a second api_server can
+    authorize against a revoked setting for the cache TTL.
     """
     if user.is_anonymous:
         return False
     if not incognito_context_available():
         return False
-    availability = get_security_settings().incognito_availability
+    settings = get_security_settings() if cached else load_effective_uncached()
+    availability = settings.incognito_availability
     if availability is IncognitoAvailability.EVERYONE:
         return True
     if availability is IncognitoAvailability.GROUPS:
@@ -68,6 +84,27 @@ def resolve_incognito_record_mode() -> IncognitoRecordMode:
     full_history would persist content the admin has already disallowed.
     """
     return load_effective_uncached().incognito_record_mode
+
+
+def sweep_stale_incognito_user_files(db_session: Session) -> int:
+    """Queue uploads of dead incognito sessions for deletion. Caller commits.
+
+    Covers both shapes: uploads no session ever adopted, and uploads whose
+    session is gone. A session whose live context is still present is skipped
+    however old its files are, so a chat left open past the orphan window keeps
+    its attachments. Shared by the Celery beat task and the lite deployment
+    poller, which have no scheduler in common.
+    """
+    marked = mark_unadopted_incognito_files_deleting(db_session)
+    for session_id in stale_incognito_session_ids(db_session):
+        # Full-history sessions never create a Redis context, so liveness would
+        # read them as ended and delete a live chat's attachments.
+        if is_content_persisting_session(db_session, session_id):
+            continue
+        if not incognito_session_ended(session_id):
+            continue
+        marked += len(mark_incognito_user_files_deleting(db_session, session_id))
+    return marked
 
 
 def content_free_file_descriptors(

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -13,7 +13,7 @@ from onyx.configs.chat_configs import HARD_DELETE_CHATS
 from onyx.configs.constants import MessageType
 from onyx.context.search.models import InferenceSection, SavedSearchDoc
 from onyx.context.search.models import SearchDoc as ServerSearchDoc
-from onyx.db.enums import IncognitoRecordMode
+from onyx.db.enums import IncognitoRecordMode, record_mode_persists_content
 from onyx.db.models import (
     ChatMessage,
     ChatMessage__SearchDoc,
@@ -251,8 +251,12 @@ def create_chat_session(
     slack_thread_id: str | None = None,
     project_id: int | None = None,
     incognito_record_mode: IncognitoRecordMode | None = None,
+    session_id: UUID | None = None,
 ) -> ChatSession:
     chat_session = ChatSession(
+        # Caller-supplied only for incognito, where uploads name the session
+        # before it exists so the server can verify them.
+        **({"id": session_id} if session_id is not None else {}),
         user_id=user_id,
         persona_id=persona_id,
         description=description,
@@ -328,7 +332,12 @@ def update_chat_session(
     if chat_session.deleted:
         raise ValueError("Trying to rename a deleted chat session")
 
-    if description is not None:
+    # A title is conversation-derived, so a content-free session never stores
+    # one. Enforced here rather than at each caller: auto-naming, manual
+    # rename, and the patch endpoint all write through this.
+    if description is not None and record_mode_persists_content(
+        chat_session.incognito_record_mode
+    ):
         chat_session.description = description
     if sharing_status is not None:
         chat_session.shared_status = sharing_status

--- a/backend/onyx/db/incognito.py
+++ b/backend/onyx/db/incognito.py
@@ -1,11 +1,25 @@
-"""Membership query for groups-only incognito availability."""
+"""Membership query and file cleanup for incognito chats.
 
+A file's privacy is decided when it is uploaded. The client mints the session
+id when incognito is switched on and sends it with every upload, so a file
+names its session before that session exists and the server never has to take
+the client's word for whether the upload is private.
+"""
+
+from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
-from sqlalchemy import exists, select
+from sqlalchemy import exists, select, update
 from sqlalchemy.orm import Session
 
-from onyx.db.models import User__UserGroup, UserGroup
+from onyx.db.enums import UserFileStatus, record_mode_persists_content
+from onyx.db.models import ChatSession, User__UserGroup, UserFile, UserGroup
+
+# Only reached once a session's live context is gone, so this bounds how long a
+# teardown that never arrived (hard tab close, lost beacon) leaves files behind.
+INCOGNITO_FILE_ORPHAN_AGE = timedelta(hours=48)
+# Bounds one sweep so a backlog cannot flood the delete queue in a single pass.
+INCOGNITO_STALE_SWEEP_LIMIT = 500
 
 
 def user_in_incognito_enabled_group(db_session: Session, user_id: UUID) -> bool:
@@ -18,3 +32,113 @@ def user_in_incognito_enabled_group(db_session: Session, user_id: UUID) -> bool:
         )
     )
     return bool(db_session.execute(stmt).scalar())
+
+
+def is_content_persisting_session(db_session: Session, chat_session_id: UUID) -> bool:
+    """Whether the session records content, which means it never creates a
+    Redis context and so cannot be judged by context liveness."""
+    row = db_session.execute(
+        select(ChatSession.incognito_record_mode).where(
+            ChatSession.id == chat_session_id
+        )
+    ).one_or_none()
+    if row is None:
+        # The id was minted client-side and no session ever followed, so there
+        # is no live chat to protect and the files are abandoned.
+        return False
+    return record_mode_persists_content(row[0])
+
+
+def is_incognito_teardown_target(
+    db_session: Session, chat_session_id: UUID, user_id: UUID
+) -> bool:
+    """Whether this caller may tear down the session named by this id.
+
+    A missing row is a teardown target, not an error: the id is minted
+    client-side, so uploads can name a session that no message ever created.
+    Ownership then rests on the per-user scope of the file marking.
+    """
+    row = db_session.execute(
+        select(ChatSession.user_id, ChatSession.incognito_record_mode).where(
+            ChatSession.id == chat_session_id
+        )
+    ).one_or_none()
+    if row is None:
+        return True
+    owner_id, record_mode = row
+    return owner_id in (user_id, None) and record_mode is not None
+
+
+def mark_incognito_user_files_deleting(
+    db_session: Session, chat_session_id: UUID, user_id: UUID | None = None
+) -> list[UUID]:
+    """Queue a session's uploads for deletion. Caller commits.
+
+    Keyed on the session rather than a caller-supplied id list, so an upload
+    that finishes after the user closes the chat is still found. Scoped to the
+    owner where one is known, since the session id originates on a client.
+    """
+    conditions = [
+        UserFile.incognito_session_id == chat_session_id,
+        UserFile.status != UserFileStatus.DELETING,
+    ]
+    if user_id is not None:
+        conditions.append(UserFile.user_id == user_id)
+    file_ids = list(db_session.scalars(select(UserFile.id).where(*conditions)).all())
+    if not file_ids:
+        return []
+    db_session.execute(
+        update(UserFile)
+        .where(UserFile.id.in_(file_ids))
+        .values(status=UserFileStatus.DELETING)
+    )
+    return file_ids
+
+
+def stale_incognito_session_ids(db_session: Session) -> list[UUID]:
+    """Sessions whose uploads are past the orphan window."""
+    cutoff = datetime.now(timezone.utc) - INCOGNITO_FILE_ORPHAN_AGE
+    rows = db_session.scalars(
+        select(UserFile.incognito_session_id)
+        .where(
+            # Matches the partial index predicate so Postgres can use it.
+            UserFile.incognito.is_(True),
+            UserFile.incognito_session_id.is_not(None),
+            UserFile.status != UserFileStatus.DELETING,
+            UserFile.last_accessed_at < cutoff,
+        )
+        .group_by(UserFile.incognito_session_id)
+        .limit(INCOGNITO_STALE_SWEEP_LIMIT)
+    ).all()
+    # The is_not(None) filter above already excludes NULLs. This narrows the
+    # column's Optional type for the caller.
+    return [session_id for session_id in rows if session_id is not None]
+
+
+def mark_unadopted_incognito_files_deleting(db_session: Session) -> int:
+    """Queue incognito uploads no session ever adopted. Caller commits.
+
+    Left by someone who attached a file in incognito and never sent a message,
+    so no session exists to tear them down.
+    """
+    cutoff = datetime.now(timezone.utc) - INCOGNITO_FILE_ORPHAN_AGE
+    file_ids = list(
+        db_session.scalars(
+            select(UserFile.id)
+            .where(
+                UserFile.incognito.is_(True),
+                UserFile.incognito_session_id.is_(None),
+                UserFile.status != UserFileStatus.DELETING,
+                UserFile.last_accessed_at < cutoff,
+            )
+            .limit(INCOGNITO_STALE_SWEEP_LIMIT)
+        ).all()
+    )
+    if not file_ids:
+        return 0
+    db_session.execute(
+        update(UserFile)
+        .where(UserFile.id.in_(file_ids))
+        .values(status=UserFileStatus.DELETING)
+    )
+    return len(file_ids)

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5395,7 +5395,6 @@ class UserDocument(str, Enum):
 
 class UserFile(Base):
     __tablename__ = "user_file"
-
     id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True)
     user_id: Mapped[UUID | None] = mapped_column(ForeignKey("user.id"), nullable=False)
     assistants: Mapped[list["Persona"]] = relationship(
@@ -5417,6 +5416,17 @@ class UserFile(Base):
         Enum(UserFileStatus, native_enum=False, name="userfilestatus"),
         nullable=False,
         default=UserFileStatus.PROCESSING,
+    )
+    # Privacy is decided when the file is uploaded, from the toggle state, so
+    # an attachment made before the session exists is already private.
+    incognito: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
+    # Which session cleans it up. NULL until the session is created on the
+    # first message and adopts it. No foreign key: the session row is deleted
+    # first and these must outlive it to be swept.
+    incognito_session_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True, default=None
     )
     needs_project_sync: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False
@@ -5449,6 +5459,15 @@ class UserFile(Base):
     )
 
     __table_args__ = (
+        # Declared here as well as in the migration so autogenerate does not
+        # read it as a stray index and propose dropping it.
+        Index(
+            "ix_user_file_incognito_sweep",
+            "incognito_session_id",
+            "status",
+            "last_accessed_at",
+            postgresql_where=text("incognito"),
+        ),
         Index(
             "ix_user_file_secondary_reconcile_pending",
             "id",

--- a/backend/onyx/db/projects.py
+++ b/backend/onyx/db/projects.py
@@ -60,6 +60,7 @@ def create_user_files(
     db_session: Session,
     link_url: str | None = None,
     temp_id_map: dict[str, str] | None = None,
+    incognito_session_id: UUID | None = None,
 ) -> CategorizedFilesResult:
     # Categorize the files
     categorized_files = categorize_uploaded_files(files, db_session)
@@ -92,12 +93,15 @@ def create_user_files(
             content_type=file.content_type,
             file_type=file.content_type,
             status=UserFileStatus.SKIPPED if should_skip else UserFileStatus.PROCESSING,
+            incognito=incognito_session_id is not None,
+            incognito_session_id=incognito_session_id,
             last_accessed_at=datetime.datetime.now(datetime.timezone.utc),
         )
         # Persist the UserFile first to satisfy FK constraints for association table
         db_session.add(new_file)
         db_session.flush()
-        if project_id:
+        # Incognito uploads may use a project as context but never join it.
+        if project_id and incognito_session_id is None:
             project_to_user_file = Project__UserFile(
                 project_id=project_id,
                 user_file_id=new_file.id,
@@ -120,6 +124,7 @@ def upload_files_to_user_files_with_indexing(
     temp_id_map: dict[str, str] | None,
     db_session: Session,
     background_tasks: BackgroundTasks | None = None,
+    incognito_session_id: UUID | None = None,
 ) -> CategorizedFilesResult:
     if project_id is not None and user is not None:
         if not check_project_ownership(project_id, user.id, db_session):
@@ -131,6 +136,7 @@ def upload_files_to_user_files_with_indexing(
         user,
         db_session,
         temp_id_map=temp_id_map,
+        incognito_session_id=incognito_session_id,
     )
     user_files = categorized_files_result.user_files
     rejected_files = categorized_files_result.rejected_files

--- a/backend/onyx/db/user_file.py
+++ b/backend/onyx/db/user_file.py
@@ -195,6 +195,7 @@ def get_user_file_ids_for_user_batch(
     stmt = select(UserFile.id).where(
         UserFile.user_id == user_id,
         UserFile.status == UserFileStatus.COMPLETED,
+        UserFile.incognito.is_(False),
     )
     if after_id is not None:
         stmt = stmt.where(UserFile.id > UUID(after_id))

--- a/backend/onyx/server/features/projects/api.py
+++ b/backend/onyx/server/features/projects/api.py
@@ -15,6 +15,8 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
+from onyx.chat.incognito import incognito_allowed_for_user
+from onyx.chat.incognito_context import incognito_session_ended
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.constants import (
     PUBLIC_API_TAGS,
@@ -25,12 +27,15 @@ from onyx.configs.constants import (
 )
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission, UserFileStatus
+from onyx.db.incognito import mark_incognito_user_files_deleting
 from onyx.db.models import ChatSession, Project__UserFile, User, UserFile, UserProject
 from onyx.db.persona import get_personas_by_ids
 from onyx.db.projects import (
     get_project_token_count,
     upload_files_to_user_files_with_indexing,
 )
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.projects.models import (
     CategorizedFilesSnapshot,
     ChatSessionRequest,
@@ -132,9 +137,26 @@ def upload_user_files(
     files: list[UploadFile] = File(...),
     project_id: int | None = Form(None),
     temp_id_map: str | None = Form(None),  # JSON string mapping hashed key -> temp_id
+    incognito_session_id: UUID | None = Form(None),
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> CategorizedFilesSnapshot:
+    # The file names its session before that session exists, so it is private
+    # from the moment it lands and the id is what teardown finds it by.
+    if incognito_session_id is not None:
+        if not incognito_allowed_for_user(user, db_session, cached=False):
+            raise OnyxError(
+                OnyxErrorCode.UNAUTHORIZED,
+                "Incognito chat is not enabled for this user.",
+            )
+        # Teardown marks the rows that exist when it runs, so an upload landing
+        # after it would otherwise sit until the orphan sweep. The tombstone is
+        # durable, which makes this the point where that race is settled.
+        if incognito_session_ended(incognito_session_id):
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "This incognito chat has ended.",
+            )
     try:
         parsed_temp_id_map: dict[str, str] | None = None
         if temp_id_map:
@@ -156,7 +178,19 @@ def upload_user_files(
             temp_id_map=parsed_temp_id_map,
             db_session=db_session,
             background_tasks=bg_tasks if DISABLE_VECTOR_DB else None,
+            incognito_session_id=incognito_session_id,
         )
+
+        # Re-check after the rows exist. The tombstone is monotonic, so a
+        # teardown that landed during the upload is caught here even though the
+        # pre-check passed, which is what the marking query alone would miss.
+        if incognito_session_id is not None and incognito_session_ended(
+            incognito_session_id
+        ):
+            mark_incognito_user_files_deleting(
+                db_session, incognito_session_id, user.id
+            )
+            db_session.commit()
 
         return CategorizedFilesSnapshot.from_result(categorized_files_result)
 

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -1341,6 +1341,8 @@ def get_recent_files(
         .filter(UserFile.user_id == user_id)
         .filter(UserFile.status != UserFileStatus.FAILED)
         .filter(UserFile.status != UserFileStatus.DELETING)
+        # Incognito uploads live only inside their session, never in recents.
+        .filter(UserFile.incognito.is_(False))
         .order_by(UserFile.last_accessed_at.desc())
         .all()
     )

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -47,7 +47,15 @@ from onyx.configs.chat_configs import (
     CHAT_RESUME_POLL_INTERVAL_S,
     HARD_DELETE_CHATS,
 )
-from onyx.configs.constants import PUBLIC_API_TAGS, MessageType, MilestoneRecordType
+from onyx.configs.constants import (
+    CELERY_USER_FILE_DELETE_TASK_EXPIRES,
+    PUBLIC_API_TAGS,
+    MessageType,
+    MilestoneRecordType,
+    OnyxCeleryPriority,
+    OnyxCeleryQueues,
+    OnyxCeleryTask,
+)
 from onyx.configs.model_configs import LITELLM_PASS_THROUGH_HEADERS
 from onyx.db.chat import (
     add_chats_to_session_from_slack_thread,
@@ -68,6 +76,10 @@ from onyx.db.chat_search import search_chat_sessions
 from onyx.db.engine.sql_engine import get_session, get_session_with_current_tenant
 from onyx.db.enums import Permission, record_mode_persists_content
 from onyx.db.feedback import create_chat_message_feedback, remove_chat_message_feedback
+from onyx.db.incognito import (
+    is_incognito_teardown_target,
+    mark_incognito_user_files_deleting,
+)
 from onyx.db.llm import fetch_default_chat_naming_model
 from onyx.db.models import ChatMessage, ChatSessionSharedStatus, Persona, User
 from onyx.db.persona import get_persona_by_id
@@ -541,13 +553,15 @@ def rename_chat_session(
 
     if name:
         with get_session_with_current_tenant() as db_session:
-            update_chat_session(
+            chat_session = update_chat_session(
                 db_session=db_session,
                 user_id=user_id,
                 chat_session_id=chat_session_id,
                 description=name,
             )
-        return RenameChatSessionResponse(new_name=name)
+        # Echo what was stored: a content-free session drops the title, and
+        # reporting the requested one would show a rename that did not happen.
+        return RenameChatSessionResponse(new_name=chat_session.description or "")
 
     # Close the read session before the LLM's multi-second generation window.
     with get_session_with_current_tenant() as db_session:
@@ -615,9 +629,19 @@ def patch_chat_session(
     return None
 
 
-def _teardown_incognito_after_delete(chat_session_id: UUID) -> None:
+def _teardown_incognito_after_delete(
+    chat_session_id: UUID, user_id: UUID, db_session: Session
+) -> None:
     """The rows are already gone, so a failed teardown is logged rather than
-    failing a delete the caller cannot retry. The context TTL is the backstop."""
+    failing a delete the caller cannot retry. The context TTL is the backstop.
+
+    Uploads are queued here too, so deleting a chat cleans up the same things
+    the dedicated teardown endpoint does."""
+    try:
+        mark_incognito_user_files_deleting(db_session, chat_session_id, user_id)
+        db_session.commit()
+    except Exception:
+        logger.exception("Incognito file cleanup failed for %s", chat_session_id)
     try:
         teardown_incognito_session(chat_session_id)
     except Exception:
@@ -645,7 +669,7 @@ def delete_all_chat_sessions(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     for incognito_id in incognito_session_ids:
-        _teardown_incognito_after_delete(incognito_id)
+        _teardown_incognito_after_delete(incognito_id, user.id, db_session)
 
 
 @router.delete("/delete-chat-session/{session_id}", tags=PUBLIC_API_TAGS)
@@ -678,7 +702,7 @@ def delete_chat_session_by_id(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     if is_incognito:
-        _teardown_incognito_after_delete(session_id)
+        _teardown_incognito_after_delete(session_id, user.id, db_session)
 
 
 class IncognitoAvailabilityResponse(BaseModel):
@@ -706,18 +730,39 @@ def end_incognito_session(
     """Drop an incognito session's live context the moment the chat closes.
 
     The context TTL is only the backstop for when this never arrives, such as
-    a hard tab close.
+    a hard tab close. Uploads are found by session id, so one still in flight
+    when the user leaves, or one attached before any message created the
+    session, is queued for deletion just the same.
     """
-    chat_session = get_chat_session_by_id(
-        chat_session_id=session_id, user_id=user.id, db_session=db_session
-    )
-    if chat_session.incognito_record_mode is not None:
-        teardown_incognito_session(session_id)
-        if not delete_incognito_generated_files(session_id, db_session):
-            raise OnyxError(
-                OnyxErrorCode.SERVICE_UNAVAILABLE,
-                "Some generated files could not be deleted yet and will be retried.",
+    if not is_incognito_teardown_target(db_session, session_id, user.id):
+        return
+    # Durable file marking runs before the Redis teardown: the beacon is
+    # one-shot, so a failure after this point still leaves the files queued
+    # for deletion rather than stored but hidden.
+    deletable_ids = mark_incognito_user_files_deleting(db_session, session_id, user.id)
+    db_session.commit()
+    teardown_incognito_session(session_id)
+
+    if deletable_ids:
+        from onyx.background.celery.versioned_apps.client import app as client_app
+
+        tenant_id = get_current_tenant_id()
+        for user_file_id in deletable_ids:
+            client_app.send_task(
+                OnyxCeleryTask.DELETE_SINGLE_USER_FILE,
+                kwargs={"user_file_id": str(user_file_id), "tenant_id": tenant_id},
+                queue=OnyxCeleryQueues.USER_FILE_DELETE,
+                priority=OnyxCeleryPriority.HIGH,
+                expires=CELERY_USER_FILE_DELETE_TASK_EXPIRES,
             )
+
+    # Last, so a store that refuses a blob cannot strand the queued uploads:
+    # this raises to tell the client the sweep will retry.
+    if not delete_incognito_generated_files(session_id, db_session):
+        raise OnyxError(
+            OnyxErrorCode.SERVICE_UNAVAILABLE,
+            "Some generated files could not be deleted yet and will be retried.",
+        )
 
 
 # NOTE: This endpoint is extremely central to the application, any changes to it should be reviewed and approved by an experienced

--- a/backend/onyx/server/query_and_chat/models.py
+++ b/backend/onyx/server/query_and_chat/models.py
@@ -82,6 +82,9 @@ class ChatSessionCreationRequest(BaseModel):
     # Start the session incognito. Refused with an error when incognito is
     # unavailable, never silently downgraded to an ordinary chat.
     incognito: bool = False
+    # The id the client already used when uploading, so this session owns those
+    # files. Ignored unless incognito.
+    incognito_session_id: UUID | None = None
 
 
 class ChatFeedbackRequest(BaseModel):

--- a/backend/tests/external_dependency_unit/chat/test_incognito_availability.py
+++ b/backend/tests/external_dependency_unit/chat/test_incognito_availability.py
@@ -51,15 +51,16 @@ def _make_group(db_session: Session, user: User, incognito_enabled: bool) -> Non
 def _workspace(
     mode: IncognitoAvailability, store_available: bool = True
 ) -> Iterator[None]:
+    """Both settings readers return the same mode, so a test that does not care
+    which one is used passes either way."""
+    settings = MagicMock(incognito_availability=mode)
     with (
         patch(
             "onyx.chat.incognito.incognito_context_available",
             return_value=store_available,
         ),
-        patch(
-            "onyx.chat.incognito.get_security_settings",
-            return_value=MagicMock(incognito_availability=mode),
-        ),
+        patch("onyx.chat.incognito.get_security_settings", return_value=settings),
+        patch("onyx.chat.incognito.load_effective_uncached", return_value=settings),
     ):
         yield
 
@@ -102,3 +103,25 @@ def test_anonymous_user_is_refused(db_session: Session) -> None:
     anonymous = MagicMock(is_anonymous=True)
     with _workspace(IncognitoAvailability.EVERYONE):
         assert not incognito_allowed_for_user(anonymous, db_session)
+
+
+def test_enforcement_reads_past_the_settings_cache(
+    db_session: Session, owner: User
+) -> None:
+    """Cache invalidation is process-local, so a second api_server would keep
+    authorizing against a revoked setting for the cache TTL."""
+    with (
+        patch("onyx.chat.incognito.incognito_context_available", return_value=True),
+        patch(
+            "onyx.chat.incognito.get_security_settings",
+            return_value=MagicMock(
+                incognito_availability=IncognitoAvailability.EVERYONE
+            ),
+        ),
+        patch(
+            "onyx.chat.incognito.load_effective_uncached",
+            return_value=MagicMock(incognito_availability=IncognitoAvailability.OFF),
+        ),
+    ):
+        assert incognito_allowed_for_user(owner, db_session)
+        assert not incognito_allowed_for_user(owner, db_session, cached=False)

--- a/backend/tests/external_dependency_unit/db/test_incognito_history_exclusion.py
+++ b/backend/tests/external_dependency_unit/db/test_incognito_history_exclusion.py
@@ -23,6 +23,7 @@ from onyx.db.chat import (
     create_new_chat_message,
     get_chat_sessions_by_user,
     get_or_create_root_message,
+    update_chat_session,
 )
 from onyx.db.chat_search import search_chat_sessions
 from onyx.db.enums import IncognitoRecordMode
@@ -153,9 +154,12 @@ def test_admin_query_history_page_hides_content_free_sessions(
     assert usage_only.id not in page_ids
 
 
-def test_query_history_export_hides_content_free_sessions(
+def test_usage_report_still_meters_content_free_sessions(
     db_session: Session, owner: User
 ) -> None:
+    """The usage report carries token counts and no message content, so every
+    mode belongs in it. Dropping content-free sessions here would make
+    incognito a way around token rate limits."""
     ordinary = _make_session(db_session, owner.id, "ordinary chat", None)
     usage_only = _make_session(
         db_session, owner.id, "usage only chat", IncognitoRecordMode.USAGE_ONLY
@@ -163,7 +167,7 @@ def test_query_history_export_hides_content_free_sessions(
 
     window = timedelta(minutes=5)
     now = datetime.now(timezone.utc)
-    export_ids = {
+    metered_ids = {
         session.id
         for session in fetch_chat_sessions_eagerly_by_time(
             start=now - window,
@@ -172,8 +176,8 @@ def test_query_history_export_hides_content_free_sessions(
             limit=None,
         )
     }
-    assert ordinary.id in export_ids
-    assert usage_only.id not in export_ids
+    assert ordinary.id in metered_ids
+    assert usage_only.id in metered_ids
 
 
 def test_query_history_detail_hides_content_free_sessions(
@@ -196,6 +200,28 @@ def test_query_history_detail_hides_content_free_sessions(
 
     with pytest.raises(ValueError):
         fetch_persisting_chat_session_by_id(usage_only.id, db_session)
+
+
+def test_rename_cannot_store_a_title_on_a_content_free_session(
+    db_session: Session, owner: User
+) -> None:
+    """A title is caller-supplied conversation content, so no caller may put
+    one on a content-free session. Guarded in the db layer because auto-naming,
+    manual rename, and the patch endpoint all write through it."""
+    usage_only = _make_session(db_session, owner.id, "", IncognitoRecordMode.USAGE_ONLY)
+    full_history = _make_session(
+        db_session, owner.id, "", IncognitoRecordMode.FULL_HISTORY
+    )
+
+    for chat_session, expected in ((usage_only, ""), (full_history, "a real title")):
+        update_chat_session(
+            db_session=db_session,
+            user_id=owner.id,
+            chat_session_id=chat_session.id,
+            description="a real title",
+        )
+        db_session.refresh(chat_session)
+        assert chat_session.description == expected
 
 
 def test_every_mode_is_excluded_from_history(db_session: Session, owner: User) -> None:

--- a/backend/tests/external_dependency_unit/tools/test_python_tool.py
+++ b/backend/tests/external_dependency_unit/tools/test_python_tool.py
@@ -1170,6 +1170,9 @@ def test_code_interpreter_receives_chat_files(
         ],
         project_id=None,
         temp_id_map=json.dumps({"0|data.csv": "data.csv"}),
+        # Explicit: calling the endpoint directly leaves this as the Form
+        # default object, which is truthy and trips the incognito guard.
+        incognito_session_id=None,
         user=user,
         db_session=db_session,
     )

--- a/backend/tests/unit/onyx/background/celery/tasks/test_user_file_processing_no_vectordb.py
+++ b/backend/tests/unit/onyx/background/celery/tasks/test_user_file_processing_no_vectordb.py
@@ -44,6 +44,7 @@ def _make_user_file(
     status: UserFileStatus = UserFileStatus.PROCESSING,
     file_id: str = "test-file-id",
     name: str = "test.txt",
+    incognito: bool = False,
 ) -> MagicMock:
     """Return a MagicMock mimicking a UserFile ORM instance."""
     uf = MagicMock()
@@ -51,6 +52,9 @@ def _make_user_file(
     uf.file_id = file_id
     uf.name = name
     uf.status = status
+    # Explicit: an attribute left to MagicMock reads as truthy and would send
+    # every file down the incognito branch.
+    uf.incognito = incognito
     uf.token_count = None
     uf.chunk_count = None
     uf.last_project_sync_at = None
@@ -275,6 +279,36 @@ class TestProcessImplBranching:
 
         mock_with_indexing.assert_called_once()
         mock_without_vdb.assert_not_called()
+
+    @patch(f"{TASKS_MODULE}._process_user_file_without_vector_db")
+    @patch(f"{TASKS_MODULE}._process_user_file_with_indexing")
+    @patch(f"{TASKS_MODULE}.DISABLE_VECTOR_DB", False)
+    @patch(f"{TASKS_MODULE}.get_session_with_current_tenant")
+    def test_incognito_upload_skips_the_search_index(
+        self,
+        mock_get_session: MagicMock,
+        mock_with_indexing: MagicMock,
+        mock_without_vdb: MagicMock,
+    ) -> None:
+        """An incognito upload is extracted for chat but never indexed, even
+        with the vector DB enabled."""
+        uf = _make_user_file(incognito=True)
+        session = MagicMock()
+        session.get.return_value = uf
+        mock_get_session.return_value.__enter__.return_value = session
+
+        connector_mock = MagicMock()
+        connector_mock.load_from_state.return_value = [_make_documents(["hello"])]
+
+        with patch(f"{TASKS_MODULE}.LocalFileConnector", return_value=connector_mock):
+            process_user_file_impl(
+                user_file_id=str(uf.id),
+                tenant_id="test-tenant",
+                redis_locking=False,
+            )
+
+        mock_without_vdb.assert_called_once()
+        mock_with_indexing.assert_not_called()
 
     @patch(f"{TASKS_MODULE}.run_indexing_pipeline")
     @patch(f"{TASKS_MODULE}.store_user_file_plaintext")

--- a/web/src/app/app/components/WelcomeMessage.tsx
+++ b/web/src/app/app/components/WelcomeMessage.tsx
@@ -12,6 +12,8 @@ import { useState, useEffect } from "react";
 import { useSettings } from "@/lib/settings/hooks";
 import FrostedDiv from "@/refresh-components/FrostedDiv";
 import { Section } from "@/layouts/general-layouts";
+import { SvgEyeClosed } from "@opal/icons";
+import { useIncognito } from "@/providers/IncognitoProvider";
 
 export interface WelcomeMessageProps {
   agent?: MinimalAgent;
@@ -35,9 +37,26 @@ export default function WelcomeMessage({
     }
   }, [settings.enterprise?.custom_greeting_message]);
 
+  const { incognitoEnabled } = useIncognito();
+
   let content: React.ReactNode = null;
 
-  if (isDefaultAgent) {
+  if (incognitoEnabled) {
+    content = (
+      <Section
+        data-testid="incognito-intro"
+        flexDirection="column"
+        alignItems="start"
+        gap={0.5}
+        width="fit"
+      >
+        <SvgEyeClosed size={32} className="text-text-04" />
+        <Text as="p" headingH2>
+          You&apos;re incognito
+        </Text>
+      </Section>
+    );
+  } else if (isDefaultAgent) {
     content = (
       <Section
         data-testid="onyx-logo"

--- a/web/src/app/app/interfaces.ts
+++ b/web/src/app/app/interfaces.ts
@@ -213,6 +213,8 @@ export interface BackendChatSession {
   packets: Packet[][];
   // Set while a run is in flight and resumable via the resume-stream endpoint
   current_run?: { run_id: number } | null;
+  // True for sessions pinned to an incognito record mode.
+  incognito?: boolean;
 }
 
 export function toChatSession(backend: BackendChatSession): ChatSession {

--- a/web/src/app/app/message/messageComponents/MessageToolbar.tsx
+++ b/web/src/app/app/message/messageComponents/MessageToolbar.tsx
@@ -14,6 +14,7 @@ import { convertMarkdownTablesToTsv } from "@/app/app/message/copyingUtils";
 import { getTextContent } from "@/app/app/services/packetUtils";
 import { removeThinkingTokens } from "@/app/app/services/thinkingTokens";
 import MessageSwitcher from "@/app/app/message/MessageSwitcher";
+import { useIncognitoOptional } from "@/providers/IncognitoProvider";
 import SourceTag from "@/refresh-components/buttons/source-tag/SourceTag";
 import { citationsToSourceInfoArray } from "@/refresh-components/buttons/source-tag/sourceTagUtils";
 import { CopyButton, OpenButton, SelectButton } from "@opal/components";
@@ -142,6 +143,15 @@ export default function MessageToolbar({
   citations,
   documentMap,
 }: MessageToolbarProps) {
+  // Incognito responses take no feedback: votes would persist reviewable
+  // signal tied to a chat hidden from the owner's surfaces. The session's
+  // pinned flag keeps suppression on while exit clears the live toggle.
+  const sessionIncognito = useChatSessionStore(
+    (state) =>
+      state.sessions.get(state.currentSessionId || "")?.incognito ?? false
+  );
+  const incognitoEnabled =
+    (useIncognitoOptional()?.incognitoEnabled ?? false) || sessionIncognito;
   // Document sidebar state - managed internally to reduce prop drilling
   const documentSidebarVisible = useDocumentSidebarVisible();
   const selectedMessageForDocDisplay = useSelectedNodeForDocDisplay();
@@ -267,28 +277,32 @@ export default function MessageToolbar({
               getHtmlContent={() => finalAnswerRef.current?.innerHTML || ""}
               data-testid="AgentMessage/copy-button"
             />
-            <SelectButton
-              icon={SvgThumbsUp}
-              onClick={() => handleFeedbackClick("like")}
-              variant="select-light"
-              state={isFeedbackTransient("like") ? "selected" : "empty"}
-              tooltip={
-                currentFeedback === "like" ? "Remove Like" : "Good Response"
-              }
-              data-testid="AgentMessage/like-button"
-            />
-            <SelectButton
-              icon={SvgThumbsDown}
-              onClick={() => handleFeedbackClick("dislike")}
-              variant="select-light"
-              state={isFeedbackTransient("dislike") ? "selected" : "empty"}
-              tooltip={
-                currentFeedback === "dislike"
-                  ? "Remove Dislike"
-                  : "Bad Response"
-              }
-              data-testid="AgentMessage/dislike-button"
-            />
+            {!incognitoEnabled && (
+              <>
+                <SelectButton
+                  icon={SvgThumbsUp}
+                  onClick={() => handleFeedbackClick("like")}
+                  variant="select-light"
+                  state={isFeedbackTransient("like") ? "selected" : "empty"}
+                  tooltip={
+                    currentFeedback === "like" ? "Remove Like" : "Good Response"
+                  }
+                  data-testid="AgentMessage/like-button"
+                />
+                <SelectButton
+                  icon={SvgThumbsDown}
+                  onClick={() => handleFeedbackClick("dislike")}
+                  variant="select-light"
+                  state={isFeedbackTransient("dislike") ? "selected" : "empty"}
+                  tooltip={
+                    currentFeedback === "dislike"
+                      ? "Remove Dislike"
+                      : "Bad Response"
+                  }
+                  data-testid="AgentMessage/dislike-button"
+                />
+              </>
+            )}
             {ttsEnabled && (
               <TTSButton
                 text={

--- a/web/src/app/app/services/lib.tsx
+++ b/web/src/app/app/services/lib.tsx
@@ -83,7 +83,9 @@ export async function updateReasoningEffortForChatSession(
 export async function createChatSession(
   personaId: number,
   description: string | null,
-  projectId: number | null
+  projectId: number | null,
+  incognito: boolean = false,
+  incognitoSessionId: string | null = null
 ): Promise<string> {
   const createChatSessionResponse = await fetch(
     "/api/chat/create-chat-session",
@@ -96,6 +98,8 @@ export async function createChatSession(
         persona_id: personaId,
         description,
         project_id: projectId,
+        incognito,
+        incognito_session_id: incognitoSessionId,
       }),
     }
   );
@@ -106,7 +110,23 @@ export async function createChatSession(
     throw Error("Failed to create chat session");
   }
   const chatSessionResponseJson = await createChatSessionResponse.json();
+  // A server that omits the echo (e.g. an old pod mid-deploy) did not pin the
+  // mode, so proceeding would silently persist a believed-incognito chat.
+  if (incognito && chatSessionResponseJson.incognito !== true) {
+    throw Error("Server did not honor the incognito request");
+  }
   return chatSessionResponseJson.chat_session_id;
+}
+
+export async function endIncognitoSession(sessionId: string): Promise<boolean> {
+  // The server finds the session's uploads itself, so nothing to send.
+  const response = await fetch(`/api/chat/end-incognito-session/${sessionId}`, {
+    method: "POST",
+  });
+  if (!response.ok) {
+    console.error(`Failed to end incognito session - ${response.status}`);
+  }
+  return response.ok;
 }
 
 export type PacketType =

--- a/web/src/app/app/stores/useChatSessionStore.ts
+++ b/web/src/app/app/stores/useChatSessionStore.ts
@@ -41,6 +41,8 @@ interface ChatSessionData {
   isLoaded: boolean;
   description?: string;
   personaId?: number;
+  // Pinned at creation server-side, so it outlives the live UI toggle.
+  incognito?: boolean;
 
   // Streaming duration tracking
   streamingStartTime?: number;
@@ -613,6 +615,7 @@ export const useChatSessionStore = create<ChatSessionStore>()((set, get) => ({
       isLoaded: true,
       description: backendSession?.description,
       personaId: backendSession?.persona_id,
+      incognito: backendSession?.incognito ?? false,
     };
 
     const existingSession = get().sessions.get(sessionId);

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -74,6 +74,7 @@ import { SelectedModel } from "@/sections/model-selector/MultiModelSelector";
 import { useAgentPreferences } from "@/lib/agents/hooks";
 import { useForcedTools } from "@/lib/hooks/useForcedTools";
 import { ProjectFile, useProjectsContext } from "@/providers/ProjectsContext";
+import { useIncognito } from "@/providers/IncognitoProvider";
 import { useAppParams } from "@/hooks/appNavigation";
 import { projectFilesToFileDescriptors } from "@/lib/projects/utils";
 
@@ -151,6 +152,7 @@ export default function useChatController({
   const { forcedToolIds } = useForcedTools();
   const { fetchProjects, setCurrentMessageFiles, beginUpload } =
     useProjectsContext();
+  const { incognitoEnabledRef, incognitoSessionId } = useIncognito();
 
   // Use selectors to access only the specific fields we need
   const currentSessionId = useChatSessionStore(
@@ -235,11 +237,16 @@ export default function useChatController({
     }
   };
 
-  const updateStatesWithNewSessionId = (newSessionId: string) => {
+  const updateStatesWithNewSessionId = (
+    newSessionId: string,
+    incognito = false
+  ) => {
     // Create new session in store if it doesn't exist
     const existingSession = sessions.get(newSessionId);
     if (!existingSession) {
-      createSession(newSessionId);
+      // Pinned here so vote suppression holds even before any backend
+      // session fetch stores the flag.
+      createSession(newSessionId, { incognito });
     }
 
     // Set as current session
@@ -381,6 +388,8 @@ export default function useChatController({
       additionalContext,
       selectedModels,
     }: OnSubmitProps) => {
+      // Read at submit time so no caller can capture a stale value.
+      const incognito = incognitoEnabledRef.current ?? false;
       const isMultiModel =
         !regenerationRequest && (selectedModels?.length ?? 0) >= 2;
       const projectId = params(SEARCH_PARAM_NAMES.PROJECT_ID);
@@ -498,19 +507,26 @@ export default function useChatController({
         (m) => m.type === "user"
       );
       if (isNewSession) {
+        // There is no incognito agent chat, so incognito pins the default
+        // assistant regardless of any selected agent.
         currChatSessionId = await createChatSession(
-          liveAgent?.id || 0,
+          incognito ? 0 : liveAgent?.id || 0,
           searchParamBasedChatSessionName,
-          projectId ? parseInt(projectId) : null
+          projectId ? parseInt(projectId) : null,
+          incognito,
+          incognito ? incognitoSessionId : null
         );
 
-        // Optimistically add the new chat session to the sidebar cache
-        // This ensures "New Chat" appears immediately, even before any messages are saved
-        addPendingChatSession({
-          chatSessionId: currChatSessionId,
-          personaId: liveAgent?.id || 0,
-          projectId: projectId ? parseInt(projectId) : null,
-        });
+        // Optimistically add the new chat session to the sidebar cache so
+        // "New Chat" appears immediately. Incognito sessions are excluded: they
+        // must never show in the sidebar, and the server filters them out too.
+        if (!incognito) {
+          addPendingChatSession({
+            chatSessionId: currChatSessionId,
+            personaId: liveAgent?.id || 0,
+            projectId: projectId ? parseInt(projectId) : null,
+          });
+        }
       } else {
         // Use the existing session ID from props or from the store
         currChatSessionId =
@@ -536,7 +552,7 @@ export default function useChatController({
       );
 
       // mark the session as the current session
-      updateStatesWithNewSessionId(currChatSessionId);
+      updateStatesWithNewSessionId(currChatSessionId, incognito);
 
       // Navigate immediately for new sessions (before streaming starts)
       if (isNewSession) {

--- a/web/src/hooks/useChatSessionController.ts
+++ b/web/src/hooks/useChatSessionController.ts
@@ -29,6 +29,7 @@ import {
   useCurrentMessageHistory,
 } from "@/app/app/stores/useChatSessionStore";
 import { useForcedTools } from "@/lib/hooks/useForcedTools";
+import { useIncognito } from "@/providers/IncognitoProvider";
 import type { ProjectFile } from "@/lib/projects/types";
 import {
   getSessionProjectTokenCount,
@@ -125,6 +126,7 @@ export default function useChatSessionController({
   const currentChatHistory = useCurrentMessageHistory();
   const chatSessions = useChatSessionStore((state) => state.sessions);
   const { setForcedToolIds } = useForcedTools();
+  const { setIncognitoEnabled, setIncognitoSessionId } = useIncognito();
 
   // Fetch chat messages for the chat session
   useEffect(() => {
@@ -235,6 +237,12 @@ export default function useChatSessionController({
 
       const session = await response.json();
       const chatSession = session as BackendChatSession;
+      // Restore the incognito UI state on reload of a live incognito session.
+      // The id must come back too, or a later upload would be sent with none
+      // and land as an ordinary indexed file.
+      const isIncognito = chatSession.incognito ?? false;
+      setIncognitoEnabled(isIncognito);
+      setIncognitoSessionId(isIncognito ? chatSession.chat_session_id : null);
       setSelectedAgentFromId(chatSession.persona_id);
 
       // Ensure the current session is set to the actual session ID from the response

--- a/web/src/layouts/chromes/AppChrome.tsx
+++ b/web/src/layouts/chromes/AppChrome.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/lib/sidebar/utils";
 import { handleMoveOperation } from "@/lib/sidebar/svc";
 import { LOCAL_STORAGE_KEYS } from "@/lib/sidebar/constants";
-import { deleteChatSession } from "@/app/app/services/lib";
+import { deleteChatSession, endIncognitoSession } from "@/app/app/services/lib";
 import {
   exportChatSession,
   ChatExportFormat,
@@ -50,6 +50,7 @@ import {
   SvgChevronLeft,
   SvgDownload,
   SvgFileText,
+  SvgEyeOff,
   SvgFitWidth,
   SvgFolderIn,
   SvgFullWidth,
@@ -59,6 +60,7 @@ import {
   SvgShare,
   SvgSidebar,
   SvgTrash,
+  SvgX,
 } from "@opal/icons";
 import { useIsSearchModeAvailable, useSettings } from "@/lib/settings/hooks";
 import type { AppMode } from "@/providers/QueryControllerProvider";
@@ -68,6 +70,7 @@ import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/lib/settings/types";
 import { useAppDocumentTitle, useCustomFooterContent } from "@/lib/app/hooks";
 import { useFullWidthChat } from "@/providers/FullWidthChatProvider";
+import { useIncognito } from "@/providers/IncognitoProvider";
 
 // ---------------------------------------------------------------------------
 // Header
@@ -82,6 +85,13 @@ function Header() {
   const { isMobile } = useScreenSize();
   const { setFolded } = useSidebarState();
   const { fullWidthChat, toggleFullWidthChat } = useFullWidthChat();
+  const {
+    incognitoAvailable,
+    incognitoEnabled,
+    incognitoLocked,
+    toggleIncognito,
+    setIncognitoEnabled,
+  } = useIncognito();
   const [showShareModal, setShowShareModal] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [showMoveCustomAgentModal, setShowMoveCustomAgentModal] =
@@ -100,9 +110,14 @@ function Header() {
     fetchProjects,
     refreshCurrentProjectDetails,
     currentProjectId,
+    setCurrentMessageFiles,
   } = useProjectsContext();
-  const { currentChatSession, refreshChatSessions, removeSession } =
-    useChatSessions();
+  const {
+    currentChatSession,
+    currentChatSessionId,
+    refreshChatSessions,
+    removeSession,
+  } = useChatSessions();
   const router = useRouter();
 
   const customHeaderContent = settings.enterprise?.custom_header_content;
@@ -202,6 +217,39 @@ function Header() {
       setPopoverOpen(false);
     }
   }, []);
+
+  // Incognito stays on until teardown returns, so the composer cannot submit
+  // into a session being torn down. The server deletes that session's uploads
+  // itself, including any that landed late.
+  const handleExitIncognito = useCallback(async () => {
+    const sessionId = currentChatSessionId;
+    if (sessionId) {
+      let tornDown = false;
+      try {
+        tornDown = await endIncognitoSession(sessionId);
+      } catch (error) {
+        console.error("Failed to end incognito session:", error);
+      }
+      // Stay put on failure. Dropping the id is what would strand the context
+      // and uploads, and the user can retry from here.
+      if (!tornDown) {
+        showErrorNotification("Could not end the incognito chat. Try again.");
+        return;
+      }
+      removeSession(sessionId);
+    }
+    setIncognitoEnabled(false);
+    setCurrentMessageFiles([]);
+    if (sessionId) {
+      router.replace("/app");
+    }
+  }, [
+    currentChatSessionId,
+    setIncognitoEnabled,
+    setCurrentMessageFiles,
+    removeSession,
+    router,
+  ]);
 
   const handleExport = useCallback(
     async (format: ChatExportFormat) => {
@@ -375,8 +423,20 @@ function Header() {
                     onClick={() => setFolded(false)}
                   />
                 )}
+                {incognitoEnabled &&
+                  (appFocus.isChat() || appFocus.isNewSession()) && (
+                    <OpenButton
+                      disabled
+                      icon={SvgEyeOff}
+                      aria-label="Incognito chat"
+                      data-testid="incognito-chat-pill"
+                    >
+                      Incognito Chat
+                    </OpenButton>
+                  )}
                 {businessTier &&
                   isSearchModeAvailable &&
+                  !incognitoEnabled &&
                   appFocus.isNewSession() &&
                   state.phase === "idle" && (
                     <Popover
@@ -457,21 +517,25 @@ function Header() {
           - more-options buttons
         */}
               <div className="flex flex-1 justify-end items-center">
-                {appFocus.isChat() && currentChatSession && (
+                {(appFocus.isChat() || appFocus.isNewSession()) && (
                   <FrostedDiv className="flex shrink flex-row items-center">
-                    <Button
-                      icon={SvgShare}
-                      prominence="tertiary"
-                      interaction={showShareModal ? "hover" : "rest"}
-                      responsiveHideText
-                      onClick={() => setShowShareModal(true)}
-                      aria-label="share-chat-button"
-                    >
-                      Share
-                    </Button>
-                    {/* Below md the reading-width cap never applies (chat is
-                        always full width), so the toggle has nothing to do. */}
-                    <span className="hidden md:flex">
+                    {incognitoAvailable && !incognitoEnabled && (
+                      <Button
+                        icon={SvgEyeOff}
+                        prominence="tertiary"
+                        onClick={toggleIncognito}
+                        disabled={incognitoLocked}
+                        aria-label="Start incognito chat"
+                        tooltip={
+                          incognitoLocked
+                            ? "Incognito can only be set before the chat starts"
+                            : "Incognito Chat"
+                        }
+                      />
+                    )}
+                    {/* On mobile widths the reading-width cap never applies
+                        (chat is always full width), so the toggle is hidden. */}
+                    {!isMobile && (
                       <Button
                         icon={fullWidthChat ? SvgFitWidth : SvgFullWidth}
                         prominence="tertiary"
@@ -480,30 +544,55 @@ function Header() {
                         aria-label="Toggle full width chat"
                         aria-pressed={fullWidthChat}
                       />
-                    </span>
-                    <SimplePopover
-                      trigger={
-                        <Button
-                          icon={SvgMoreHorizontal}
-                          prominence="tertiary"
-                          interaction={popoverOpen ? "hover" : "rest"}
-                        />
-                      }
-                      onOpenChange={(state) => {
-                        setPopoverOpen(state);
-                        if (!state) {
-                          setShowMoveOptions(false);
-                          setShowExportOptions(false);
-                          setSearchTerm("");
-                        }
-                      }}
-                      side="bottom"
-                      align="end"
-                    >
-                      <PopoverMenu>{popoverItems}</PopoverMenu>
-                    </SimplePopover>
+                    )}
+                    {incognitoEnabled && (
+                      <Button
+                        icon={SvgX}
+                        prominence="tertiary"
+                        onClick={() => void handleExitIncognito()}
+                        aria-label="Exit incognito chat"
+                        tooltip="Exit Incognito Chat"
+                      />
+                    )}
                   </FrostedDiv>
                 )}
+                {appFocus.isChat() &&
+                  currentChatSession &&
+                  !incognitoEnabled && (
+                    <FrostedDiv className="flex shrink flex-row items-center">
+                      <Button
+                        icon={SvgShare}
+                        prominence="tertiary"
+                        interaction={showShareModal ? "hover" : "rest"}
+                        responsiveHideText
+                        onClick={() => setShowShareModal(true)}
+                        aria-label="share-chat-button"
+                      >
+                        Share
+                      </Button>
+                      <SimplePopover
+                        trigger={
+                          <Button
+                            icon={SvgMoreHorizontal}
+                            prominence="tertiary"
+                            interaction={popoverOpen ? "hover" : "rest"}
+                          />
+                        }
+                        onOpenChange={(state) => {
+                          setPopoverOpen(state);
+                          if (!state) {
+                            setShowMoveOptions(false);
+                            setShowExportOptions(false);
+                            setSearchTerm("");
+                          }
+                        }}
+                        side="bottom"
+                        align="end"
+                      >
+                        <PopoverMenu>{popoverItems}</PopoverMenu>
+                      </SimplePopover>
+                    </FrostedDiv>
+                  )}
               </div>
             </div>
           </RootLayout.Header>

--- a/web/src/lib/projects/svc.ts
+++ b/web/src/lib/projects/svc.ts
@@ -34,12 +34,17 @@ export async function createProject(name: string): Promise<Project> {
 export async function uploadFiles(
   files: File[],
   projectId?: number | null,
-  tempIdMap?: Map<string, string>
+  tempIdMap?: Map<string, string>,
+  incognitoSessionId?: string | null
 ): Promise<CategorizedFiles> {
   const formData = new FormData();
   files.forEach((file) => formData.append("files", file));
   if (projectId !== undefined && projectId !== null) {
     formData.append("project_id", String(projectId));
+  }
+  // Names the session before it exists, so the server owns the privacy call.
+  if (incognitoSessionId) {
+    formData.append("incognito_session_id", incognitoSessionId);
   }
   if (tempIdMap !== undefined && tempIdMap !== null) {
     formData.append(

--- a/web/src/providers/AppProvider.tsx
+++ b/web/src/providers/AppProvider.tsx
@@ -35,6 +35,7 @@ import { AppBackgroundProvider } from "@/providers/AppBackgroundProvider";
 import { QueryControllerProvider } from "@/providers/QueryControllerProvider";
 import { NEXT_PUBLIC_INCLUDE_ERROR_POPUP_SUPPORT_LINK } from "@/lib/constants";
 import { FullWidthChatProvider } from "@/providers/FullWidthChatProvider";
+import { IncognitoProvider } from "@/providers/IncognitoProvider";
 import { UnsavedChangesNavigationProvider } from "@/providers/UnsavedChangesNavigationProvider";
 
 interface SidebarPersistenceProviderProps {
@@ -82,17 +83,19 @@ export default function AppProvider({ children }: AppProviderProps) {
               <SidebarPersistenceProvider>
                 <QueryControllerProvider>
                   <FullWidthChatProvider>
-                    <UnsavedChangesNavigationProvider>
-                      <ToastProvider
-                        errorAppendix={
-                          NEXT_PUBLIC_INCLUDE_ERROR_POPUP_SUPPORT_LINK
-                            ? "Need help? Join our community at https://discord.gg/4NA5SbzrWb for support!"
-                            : undefined
-                        }
-                      >
-                        {children}
-                      </ToastProvider>
-                    </UnsavedChangesNavigationProvider>
+                    <IncognitoProvider>
+                      <UnsavedChangesNavigationProvider>
+                        <ToastProvider
+                          errorAppendix={
+                            NEXT_PUBLIC_INCLUDE_ERROR_POPUP_SUPPORT_LINK
+                              ? "Need help? Join our community at https://discord.gg/4NA5SbzrWb for support!"
+                              : undefined
+                          }
+                        >
+                          {children}
+                        </ToastProvider>
+                      </UnsavedChangesNavigationProvider>
+                    </IncognitoProvider>
                   </FullWidthChatProvider>
                 </QueryControllerProvider>
               </SidebarPersistenceProvider>

--- a/web/src/providers/IncognitoProvider.tsx
+++ b/web/src/providers/IncognitoProvider.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { usePathname } from "next/navigation";
+import useSWR from "swr";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
+
+interface IncognitoAvailabilityResponse {
+  available: boolean;
+}
+
+// Shared incognito state so the toggle, submit path, and warning stay in
+// sync. Locks once the chat has a message, since the mode pins at creation.
+// Availability only gates the toggle. The server enforces it on creation.
+interface IncognitoContextValue {
+  incognitoAvailable: boolean;
+  incognitoEnabled: boolean;
+  // Always-current mirror of incognitoEnabled. Send paths must read this at
+  // submit time: a stale closure over the boolean submits a persisted chat
+  // while the UI shows incognito.
+  incognitoEnabledRef: React.RefObject<boolean>;
+  incognitoLocked: boolean;
+  // Minted when incognito is switched on and sent with every upload, so a file
+  // names its session before the first message creates it.
+  incognitoSessionId: string | null;
+  toggleIncognito: () => void;
+  setIncognitoSessionId: (sessionId: string | null) => void;
+  setIncognitoEnabled: (enabled: boolean) => void;
+  setIncognitoLocked: (locked: boolean) => void;
+}
+
+const IncognitoContext = createContext<IncognitoContextValue | null>(null);
+
+interface IncognitoProviderProps {
+  children: React.ReactNode;
+}
+
+export function IncognitoProvider({ children }: IncognitoProviderProps) {
+  const [incognitoEnabled, setIncognitoEnabled] = useState(false);
+  const [incognitoLocked, setIncognitoLocked] = useState(false);
+
+  const { data: availability, mutate: revalidateAvailability } =
+    useSWR<IncognitoAvailabilityResponse>(
+      SWR_KEYS.incognitoAvailability,
+      errorHandlingFetcher,
+      {
+        // Hiding the toggle is the safe fallback, but a persistent failure
+        // otherwise looks identical to the admin turning incognito off.
+        onError: (error) =>
+          console.error("Failed to load incognito availability:", error),
+      }
+    );
+  const incognitoAvailable = availability?.available ?? false;
+
+  // The provider mounts once for the whole app, so route changes never
+  // remount the hook. Revalidating per navigation picks up admin changes to
+  // the availability setting or group flags without a hard refresh.
+  const pathname = usePathname();
+  useEffect(() => {
+    void revalidateAvailability();
+  }, [pathname, revalidateAvailability]);
+
+  const [incognitoSessionId, setIncognitoSessionId] = useState<string | null>(
+    null
+  );
+  const toggleIncognito = useCallback(() => {
+    if (incognitoLocked) return;
+    const next = !incognitoEnabled;
+    setIncognitoSessionId(next ? crypto.randomUUID() : null);
+    setIncognitoEnabled(next);
+  }, [incognitoLocked, incognitoEnabled]);
+
+  const incognitoEnabledRef = useRef(false);
+  useEffect(() => {
+    incognitoEnabledRef.current = incognitoEnabled;
+  }, [incognitoEnabled]);
+
+  // Memoized so consumers keying callbacks on the context object do not
+  // rebuild them on every provider render.
+  const value = useMemo(
+    () => ({
+      incognitoAvailable,
+      incognitoEnabled,
+      incognitoEnabledRef,
+      incognitoLocked,
+      incognitoSessionId,
+      toggleIncognito,
+      setIncognitoEnabled,
+      setIncognitoSessionId,
+      setIncognitoLocked,
+    }),
+    [
+      incognitoAvailable,
+      incognitoEnabled,
+      incognitoLocked,
+      incognitoSessionId,
+      toggleIncognito,
+    ]
+  );
+
+  return (
+    <IncognitoContext.Provider value={value}>
+      {children}
+    </IncognitoContext.Provider>
+  );
+}
+
+export function useIncognito(): IncognitoContextValue {
+  const ctx = useContext(IncognitoContext);
+  if (!ctx) {
+    throw new Error("useIncognito must be used within an IncognitoProvider");
+  }
+  return ctx;
+}
+
+// For components that also render outside the provider (e.g. shared chats),
+// where incognito can never be active.
+export function useIncognitoOptional(): IncognitoContextValue | null {
+  return useContext(IncognitoContext);
+}

--- a/web/src/providers/ProjectsContext.tsx
+++ b/web/src/providers/ProjectsContext.tsx
@@ -46,6 +46,7 @@ import { ChatFileType } from "@/app/app/interfaces";
 import { toast } from "@opal/layouts";
 import { useProjects } from "@/lib/projects/hooks";
 import { useSettings } from "@/lib/settings/hooks";
+import { useIncognitoOptional } from "@/providers/IncognitoProvider";
 
 export type { Project, ProjectFile } from "@/lib/projects/types";
 
@@ -134,6 +135,14 @@ interface ProjectsProviderProps {
 export function ProjectsProvider({ children }: ProjectsProviderProps) {
   // Use SWR hook for projects list - no more SSR initial data
   const { projects, refreshProjects } = useProjects();
+  // Uploads made in an incognito chat are tied to its session so the server
+  // deletes them at teardown. Optional: falls back to disabled when no
+  // IncognitoProvider is mounted above.
+  const incognitoCtx = useIncognitoOptional();
+  const incognitoUploadsEnabled = incognitoCtx?.incognitoEnabled ?? false;
+  const incognitoSessionId = incognitoUploadsEnabled
+    ? (incognitoCtx?.incognitoSessionId ?? null)
+    : null;
   const [recentFiles, setRecentFiles] = useState<ProjectFile[]>([]);
   const [currentProjectDetails, setCurrentProjectDetails] =
     useState<ProjectDetails | null>(null);
@@ -379,12 +388,14 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
         createOptimisticFile(f, projectId)
       );
       const tempIdMap = getTempIdMap(validFiles, optimisticFiles);
-      setAllRecentFiles((prev) => [...optimisticFiles, ...prev]);
-      if (projectId) {
+      if (!incognitoUploadsEnabled) {
+        setAllRecentFiles((prev) => [...optimisticFiles, ...prev]);
+      }
+      if (projectId && !incognitoUploadsEnabled) {
         setAllCurrentProjectFiles((prev) => [...optimisticFiles, ...prev]);
         projectToUploadFilesMapRef.current.set(projectId, optimisticFiles);
       }
-      svcUploadFiles(validFiles, projectId, tempIdMap)
+      svcUploadFiles(validFiles, projectId, tempIdMap, incognitoSessionId)
         .then((uploaded) => {
           const uploadedFiles = uploaded.user_files || [];
           const tempIdToUploadedFileMap = new Map(
@@ -485,6 +496,8 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
       refreshRecentFiles,
       removeOptimisticFilesByTempIds,
       userFileMaxUploadSizeMb,
+      incognitoUploadsEnabled,
+      incognitoUploadsEnabled,
     ]
   );
 
@@ -493,7 +506,12 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
       files: File[],
       projectId?: number | null
     ): Promise<CategorizedFiles> => {
-      const uploaded: CategorizedFiles = await svcUploadFiles(files, projectId);
+      const uploaded: CategorizedFiles = await svcUploadFiles(
+        files,
+        projectId,
+        undefined,
+        incognitoSessionId
+      );
       const uploadedFiles = uploaded.user_files || [];
       // Track these uploaded file IDs for targeted polling
       if (uploadedFiles.length > 0) {
@@ -511,7 +529,13 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
       await refreshRecentFiles();
       return uploaded;
     },
-    [currentProjectId, refreshCurrentProjectDetails, refreshRecentFiles]
+    [
+      currentProjectId,
+      refreshCurrentProjectDetails,
+      refreshRecentFiles,
+      incognitoUploadsEnabled,
+      incognitoUploadsEnabled,
+    ]
   );
 
   const getFilesInProject = useCallback(
@@ -575,7 +599,21 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
       isPollingRef.current = true;
       try {
         const statuses = await svcGetUserFileStatuses(ids);
-        if (!statuses || statuses.length === 0) return;
+        if (!statuses) return;
+        if (statuses.length === 0) {
+          // The server reports none of the REQUESTED files: they were deleted
+          // (e.g. incognito teardown). Drop only those, not ids registered
+          // while this request was in flight.
+          const requested = new Set(ids);
+          setTrackedUploadIds((prev) => {
+            const remaining = new Set<string>();
+            prev.forEach((id) => {
+              if (!requested.has(id)) remaining.add(id);
+            });
+            return remaining;
+          });
+          return;
+        }
 
         // Build maps for quick lookup
         const statusById = new Map(statuses.map((f) => [f.id, f]));
@@ -682,6 +720,13 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
           } else if (s === "failed") {
             remaining.delete(f.id);
             newlyFailed.push(f);
+          }
+        }
+        // Requested ids the server no longer reports are deleted files: stop
+        // tracking them. Ids registered after this request went out stay.
+        for (const id of ids) {
+          if (!statusById.has(id)) {
+            remaining.delete(id);
           }
         }
         if (newlyFailed.length > 0) {

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -48,10 +48,11 @@ import {
   SvgX,
   SvgSimpleLoader,
 } from "@opal/icons";
-import { Button, SelectButton } from "@opal/components";
+import { Button, SelectButton, Text } from "@opal/components";
 import { Popover } from "@opal/components";
 import { useQueryController } from "@/providers/QueryControllerProvider";
 import { Section } from "@/layouts/general-layouts";
+import { useIncognito } from "@/providers/IncognitoProvider";
 import { Spacer } from "@opal/components";
 import MicrophoneButton from "@/sections/input/MicrophoneButton";
 import Waveform from "@/components/voice/Waveform";
@@ -121,6 +122,7 @@ const AppInputBar = React.memo(
     currentTabUrl,
     onToggleTabReading,
   }: AppInputBarProps) => {
+    const { incognitoEnabled } = useIncognito();
     const [isRecording, setIsRecording] = useState(false);
     const [recordingCycleCount, setRecordingCycleCount] = useState(0);
     const [isMuted, setIsMuted] = useState(false);
@@ -1073,6 +1075,26 @@ const AppInputBar = React.memo(
             )}
           </div>
         </Disabled>
+        {/* Stays for the whole session: the warning is most relevant
+            once the user is actually chatting. */}
+        {incognitoEnabled && (
+          <Section
+            flexDirection="column"
+            alignItems="center"
+            height="fit"
+            gap={0.125}
+            className="mt-3 text-center"
+          >
+            <Text font="secondary-body" color="text-02">
+              This chat won&apos;t appear in your history or be used for memory.
+            </Text>
+            <Text font="secondary-body" color="text-02">
+              Your admin may still see this chat based on your
+              organization&apos;s policy. Third party tools can still record
+              your activity.
+            </Text>
+          </Section>
+        )}
       </>
     );
   }

--- a/web/src/sections/model-selector/MultiModelSelector.tsx
+++ b/web/src/sections/model-selector/MultiModelSelector.tsx
@@ -178,6 +178,7 @@ export default function MultiModelSelector({
               icon={SvgPlusCircle}
               size="sm"
               tooltip="Add Model"
+              aria-label="Add Model"
               onClick={(e: React.MouseEvent) => {
                 if (noModelsToSelect) return;
                 anchorRef.current = e.currentTarget as HTMLElement;

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { redirect, useRouter, useSearchParams } from "next/navigation";
-import { personaIncludesRetrieval } from "@/app/app/services/lib";
+import {
+  endIncognitoSession,
+  personaIncludesRetrieval,
+} from "@/app/app/services/lib";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { SEARCH_PARAM_NAMES } from "@/app/app/services/searchParams";
 import { Section } from "@/layouts/general-layouts";
@@ -35,6 +38,7 @@ import MultiModelSelector from "@/sections/model-selector/MultiModelSelector";
 import { useAgentController } from "@/lib/agents/hooks";
 import useChatSessionController from "@/hooks/useChatSessionController";
 import useDeepResearchToggle from "@/hooks/useDeepResearchToggle";
+import { useIncognito } from "@/providers/IncognitoProvider";
 import { useIsDefaultAgent } from "@/lib/agents/hooks";
 import AgentDescription from "@/app/app/components/AgentDescription";
 import {
@@ -224,6 +228,16 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     chatSessionId: currentChatSessionId,
     agentId: selectedAgent?.id,
   });
+
+  // Incognito lives in context so the top-bar toggle and this page stay in
+  // sync. This page owns the derived lock, the teardown on leaving a session,
+  // and the unload beacon.
+  const {
+    incognitoEnabled,
+    incognitoEnabledRef,
+    setIncognitoEnabled,
+    setIncognitoLocked,
+  } = useIncognito();
   const deepResearchEnabledForCurrentWorkflow =
     currentProjectId === null && deepResearchEnabled;
 
@@ -364,6 +378,48 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
   const messageHistory = useCurrentMessageHistory();
   const messageTree = useCurrentMessageTree();
 
+  // The mode pins on creation, so lock the toggle whenever a session exists,
+  // even an empty one: submitting would reuse it with its pinned mode.
+  useEffect(() => {
+    setIncognitoLocked(
+      messageHistory.length > 0 || currentChatSessionId !== null
+    );
+  }, [messageHistory.length, currentChatSessionId, setIncognitoLocked]);
+
+  // Leaving an incognito session tears it down, whether the user goes to a
+  // fresh chat or straight into another one. Only the id changing tells us
+  // this happened, since incognito sessions never enter the sessions list.
+  const prevSessionIdForIncognito = useRef(currentChatSessionId);
+  useEffect(() => {
+    const previous = prevSessionIdForIncognito.current;
+    prevSessionIdForIncognito.current = currentChatSessionId;
+    if (!previous || previous === currentChatSessionId) return;
+    if (!incognitoEnabledRef.current) return;
+    // Incognito must clear either way: the user is now in a different chat and
+    // the badge would lie. A failure has no client retry path from here, so the
+    // orphan sweep is what eventually deletes the context and its uploads.
+    void endIncognitoSession(previous).then((tornDown) => {
+      if (!tornDown) {
+        console.error(
+          `Incognito teardown failed for ${previous}; leaving it to the server sweep`
+        );
+      }
+    });
+    setIncognitoEnabled(false);
+  }, [currentChatSessionId, setIncognitoEnabled]);
+
+  // Best-effort teardown when the tab closes over a live incognito session.
+  // sendBeacon survives unload where fetch would be cancelled.
+  useEffect(() => {
+    if (!incognitoEnabled || !currentChatSessionId) return;
+    const sessionId = currentChatSessionId;
+    const handlePageHide = () => {
+      navigator.sendBeacon(`/api/chat/end-incognito-session/${sessionId}`);
+    };
+    window.addEventListener("pagehide", handlePageHide);
+    return () => window.removeEventListener("pagehide", handlePageHide);
+  }, [incognitoEnabled, currentChatSessionId]);
+
   // Block input when the last turn is multi-model and the user hasn't
   // selected a preferred response yet. Without a selection, it's ambiguous
   // which model's response should be used as context for the next message.
@@ -408,10 +464,11 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
 
   const { fullWidthChat } = useFullWidthChat();
 
-  // Full-width only takes effect inside an actual conversation, not the
-  // new-session view (where only the input bar is shown).
+  // Full-width applies in a conversation and on the new-session view, where
+  // it widens the greeting row and the composer.
   const fullWidthActive =
-    fullWidthChat && appFocus.isChat() && !!currentChatSessionId;
+    fullWidthChat &&
+    ((appFocus.isChat() && !!currentChatSessionId) || appFocus.isNewSession());
 
   // Auto-fold sidebar when a multi-model message is submitted.
   // Stays collapsed until the user exits multi-model mode (removes models).
@@ -604,6 +661,12 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     if (!isNewSession && isSearch) resetInputBar();
   }, [isNewSession, defaultAppMode, isSearch, resetInputBar, setAppMode]);
 
+  // Declared after the default-mode reset so incognito wins the same commit:
+  // search mode has its own persistence and no incognito safeguards.
+  useEffect(() => {
+    if (incognitoEnabled) setAppMode("chat");
+  }, [incognitoEnabled, setAppMode]);
+
   const handleSearchDocumentClick = useCallback(
     (doc: MinimalOnyxDocument) => setPresentingDocument(doc),
     []
@@ -631,6 +694,13 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
         return;
       }
 
+      // Incognito always routes to chat: the search path runs its own
+      // persistence and none of the incognito safeguards.
+      if (incognitoEnabledRef.current) {
+        onChat(message);
+        return;
+      }
+
       // For new sessions, let the query controller handle routing.
       // resetInputBar is called inside onChat for chat-routed queries.
       // For search-routed queries, the input bar is intentionally kept
@@ -641,6 +711,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
       currentChatSessionId,
       submitQuery,
       onChat,
+      incognitoEnabledRef,
       resetInputBar,
       onSubmit,
       currentMessageFiles,
@@ -905,7 +976,10 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                       flexDirection="row"
                       justifyContent="between"
                       alignItems="end"
-                      className="max-w-(--app-page-main-content-width)"
+                      className={cn(
+                        !fullWidthActive &&
+                          "max-w-(--app-page-main-content-width)"
+                      )}
                     >
                       <WelcomeMessage
                         agent={liveAgent}

--- a/web/src/views/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/EditGroupPage.tsx
@@ -259,10 +259,6 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
       // Update members and cc_pairs
       await updateGroup(groupId, selectedUserIds, selectedCcPairIds);
 
-      if (group && incognitoEnabled !== group.incognito_enabled) {
-        await setGroupIncognito(groupId, incognitoEnabled);
-      }
-
       // Update agent sharing (add/remove this group from changed agents)
       await updateAgentGroupSharing(
         groupId,
@@ -280,6 +276,12 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
       // Save token rate limits (create/update/delete) — Enterprise-only
       if (isEnterpriseTier) {
         await saveTokenLimits(groupId, tokenLimits, tokenRateLimits ?? []);
+      }
+
+      // Last: granting incognito access must not outlive a save that then
+      // fails, which would report an error while members already had it.
+      if (group && incognitoEnabled !== group.incognito_enabled) {
+        await setGroupIncognito(groupId, incognitoEnabled);
       }
 
       // Update refs so subsequent saves diff correctly

--- a/web/src/views/admin/SecurityHardeningPage.tsx
+++ b/web/src/views/admin/SecurityHardeningPage.tsx
@@ -409,8 +409,9 @@ export default function SecurityHardeningPage() {
                 title="Incognito Chats"
                 description="Incognito chats never appear in their owner's history. Group access is configured per group under Groups."
                 withLabel
+                responsive
               >
-                <div className="w-60">
+                <div className="w-full sm:w-60">
                   <InputSelect
                     value={draft.incognito_availability}
                     onValueChange={async (value) => {
@@ -452,8 +453,9 @@ export default function SecurityHardeningPage() {
                 title="Incognito Chat Records"
                 description="What the workspace keeps from incognito chats. New sessions pin the mode active when they start."
                 withLabel
+                responsive
               >
-                <div className="w-60">
+                <div className="w-full sm:w-60">
                   <InputSelect
                     value={draft.incognito_record_mode}
                     onValueChange={(value) =>

--- a/web/tests/e2e/chat/input_bar_behaviors.spec.ts
+++ b/web/tests/e2e/chat/input_bar_behaviors.spec.ts
@@ -286,9 +286,9 @@ test.describe("Focus Management", () => {
     await chatPage.inputBar.focus();
     await chatPage.inputBar.expectFocused();
 
-    const button = chatPage.page
-      .locator("[data-main-container] button")
-      .first();
+    // The model selector's add button: takes focus and opens a popover,
+    // which the Escape below dismisses. Named rather than positional.
+    const button = chatPage.page.getByRole("button", { name: "Add Model" });
     await button.waitFor({ state: "visible", timeout: 5000 });
     await button.click();
     await expect(chatPage.inputBar.textbox).not.toBeFocused();

--- a/web/tests/e2e/chat/input_focus_retention.spec.ts
+++ b/web/tests/e2e/chat/input_focus_retention.spec.ts
@@ -37,11 +37,16 @@ test.describe(`Chat Input Focus Retention`, () => {
     await expect(textarea).toBeFocused();
 
     // Click on an interactive element inside the container
-    const button = page.locator("[data-main-container] button").first();
+    // The model selector's add button: an interactive element that takes
+    // focus and opens a popover. Named rather than positional so header
+    // layout changes cannot silently repoint this test.
+    const button = page.getByRole("button", { name: "Add Model" });
     await button.waitFor({ state: "visible", timeout: 5000 });
     await button.click();
 
     // Focus should have moved away from the textarea
     await expect(textarea).not.toBeFocused();
+
+    await page.keyboard.press("Escape");
   });
 });


### PR DESCRIPTION
## Description

Part 4 of 5 for incognito chat (ENG-4313). Stacked on #13894 (the admin availability and record-mode settings), which is itself on the merged chat core #13866.

Design doc: [Incognito Chat Mode](https://dev-wiki.onyx.app/app/wiki/Engineering%20Projects/Onyx%20Projects/Incognito%20Chat%20Mode/Design.md)

This is the chat surface plus the upload lifecycle an incognito session needs.

- **The toggle.** Available on a new chat, and locked once the session has a message, because the record mode pins at creation and cannot change under a conversation already under way. The toggle only appears when the server says the user may start one; the create endpoint enforces the same rule regardless of what the client sends.
- **A visible warning while incognito is active**, so the state is never ambiguous.
- **Uploads that die with the session.** An upload made during an incognito session is conversation-derived. The `user_file` row carries an incognito marker, teardown marks those rows deleting and queues their blobs for removal, and a `user_file_ids` payload on the teardown endpoint tells the server which ones. That list is a request, not an authority: the DB layer only touches rows the caller owns that already carry the marker, so no client-supplied id can reach a regular file.
- **Nothing incognito reaches the search index.** Incognito uploads still get text extraction so the chat can read them, but they take the no-index path even with the vector DB enabled, and they are excluded from the batch that feeds user-file indexing.
- **Projects usable for context, never written into.** An incognito chat can select a project and read its files, but the session never joins the project and no upload is added to it.
- **An orphan sweep.** A teardown that never arrives (hard tab close, lost beacon) leaves uploads behind, so a periodic task queues incognito files older than 48 hours, well past the one-hour context TTL.

## How Has This Been Tested?

- Unit: an incognito upload takes the no-index branch while an ordinary upload is indexed, with the vector DB enabled in both cases. This caught a real defect, see below.
- Existing chat and celery unit suites pass against the change.
- `ruff check`, `ruff format --check`, and project-wide `ty check` clean. `alembic heads` reports a single head. `bun run types:check` clean.

One thing worth calling out for reviewers: the test fixture for `UserFile` is a `MagicMock`, so the new `uf.incognito` read as truthy and sent *every* upload down the no-index branch. The existing indexing test caught it. The fixture now sets the attribute explicitly and a new test pins both branches.

Screenshots of the toggle and the warning are still to come; the local stack was down when this went up.

<img width="1982" height="1440" alt="2026-08-12 15 12 15" src="https://github.com/user-attachments/assets/b5f66eac-2aab-40d3-8ded-aeda58f094b4" />

<img width="748" height="390" alt="Screenshot 2026-08-12 at 3 12 42 PM" src="https://github.com/user-attachments/assets/82098720-21fa-44df-aa37-9a9d342cb789" />


## Fixes rolled forward from #13894

#13894 was approved and queued to merge before these landed, so they ride here rather than holding up that merge. They are admin-layer, which is why this diff reaches outside page mode.

- **Usage metering.** `fetch_chat_sessions_eagerly_by_time` backs the usage report CSV, not the query-history export. The content filter there dropped `usage_only` sessions out of token metering, which would have made incognito a way around token rate limits. Removed. The query-history page and its export keep the filter.
- **Authorization read a stale cache.** `incognito_allowed_for_user` now takes `cached`, and the enforcement sites pass `cached=False`. Settings invalidation is process-local with a 10 second TTL and no pub/sub, so a second api_server kept authorizing against a setting an admin had already revoked. The polled availability endpoint keeps the cache so it does not add a DB read per poll.
- **Titles persisted on content-free sessions.** Guarded in `update_chat_session`, which auto-naming, manual rename, and the patch endpoint all write through, so no caller can put a title on a content-free session. The create path drops the caller's description, and rename echoes what was stored rather than what was requested.
- **Group save ordering.** Granting incognito access happens last, so it no longer survives a later save failing.
- **Responsive layout** on the two new Security rows, matching the sibling SSRF row.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

