### PR TITLE
refactor(opal): give spacing a numeric scale

### DIFF
--- a/web/lib/opal/src/components/modal/components.tsx
+++ b/web/lib/opal/src/components/modal/components.tsx
@@ -359,13 +359,13 @@ function ModalHeader({
   );
 
   return (
-    <Section ref={ref} padding={0.5} alignItems="start" height="fit" {...props}>
+    <Section ref={ref} padding={2} alignItems="start" height="fit" {...props}>
       <Section
         flexDirection="row"
         justifyContent="between"
         alignItems="start"
         gap={0}
-        padding={0.5}
+        padding={2}
       >
         <div className="opal-modal-header-content">
           <div className="opal-modal-header-close">{closeButton}</div>
@@ -416,7 +416,7 @@ function ModalBody({
       className="opal-modal-body"
       {...(twoTone && { "data-two-tone": "" })}
     >
-      <Section height="auto" padding={1} gap={1} alignItems="start" {...props}>
+      <Section height="auto" padding={4} gap={4} alignItems="start" {...props}>
         {children}
       </Section>
     </div>
@@ -433,8 +433,8 @@ function ModalFooter({ ref, ...props }: ModalFooterProps) {
       ref={ref}
       flexDirection="row"
       justifyContent="end"
-      gap={0.5}
-      padding={1}
+      gap={2}
+      padding={4}
       height="fit"
       {...props}
     />
@@ -469,7 +469,7 @@ function BasicModalFooter({ left, cancel, submit }: BasicModalFooterProps) {
     <>
       {left && <Section alignItems="start">{left}</Section>}
       {(cancel || submit) && (
-        <Section flexDirection="row" justifyContent="end" gap={0.5}>
+        <Section flexDirection="row" justifyContent="end" gap={2}>
           {cancel}
           {submit}
         </Section>

--- a/web/lib/opal/src/components/tabs/README.md
+++ b/web/lib/opal/src/components/tabs/README.md
@@ -109,7 +109,7 @@ When tabs overflow the available width, show navigation arrows:
 ### Content padding
 
 ```tsx
-<Tabs.Content value="tab" padding={0.5}>
+<Tabs.Content value="tab" padding={2}>
   Padded content
 </Tabs.Content>
 ```
@@ -150,4 +150,4 @@ Forwards all [Radix Tabs.Root](https://www.radix-ui.com/docs/primitives/componen
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `value` | `string` | **required** | Must match a `Tabs.Trigger` value |
-| `padding` | `number` | `0` | Additional inner padding in rem units |
+| `padding` | `Spacing` | `0` | Additional inner padding, as a spacing step (`N / 4` rem) |

--- a/web/lib/opal/src/components/tabs/Tabs.stories.tsx
+++ b/web/lib/opal/src/components/tabs/Tabs.stories.tsx
@@ -190,7 +190,7 @@ export const ContentPadding: Story = {
         <Tabs.Trigger value="padded">Padded</Tabs.Trigger>
         <Tabs.Trigger value="flush">Flush</Tabs.Trigger>
       </Tabs.List>
-      <Tabs.Content value="padded" padding={1}>
+      <Tabs.Content value="padded" padding={4}>
         <div className="border border-border-02 rounded-08 p-4">
           Inner content with 1rem padding
         </div>

--- a/web/lib/opal/src/components/tabs/components.tsx
+++ b/web/lib/opal/src/components/tabs/components.tsx
@@ -4,7 +4,12 @@ import "@opal/components/tabs/styles.css";
 import React, { useRef, useState, useEffect, useMemo } from "react";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 import { mergeRefs } from "@opal/utils";
-import { IconFunctionComponent, type WithoutStyles } from "@opal/types";
+import {
+  IconFunctionComponent,
+  type Spacing,
+  type WithoutStyles,
+} from "@opal/types";
+import { spacingToRem } from "@opal/shared";
 import { SvgChevronLeft, SvgChevronRight } from "@opal/icons";
 import { Tooltip, Text, Button } from "@opal/components";
 import {
@@ -283,15 +288,15 @@ function TabsTrigger({
 interface TabsContentProps extends WithoutStyles<
   React.ComponentProps<typeof TabsPrimitive.Content>
 > {
-  /** Additional inner padding in rem. @default 0 */
-  padding?: number;
+  /** Additional inner padding, as a {@link Spacing} step (`N / 4` rem). @default 0 */
+  padding?: Spacing;
 }
 
 function TabsContent({ padding, children, ...props }: TabsContentProps) {
   return (
     <TabsPrimitive.Content {...props} className="w-full pt-4">
       {padding ? (
-        <div style={{ padding: `${padding}rem` }}>{children}</div>
+        <div style={{ padding: spacingToRem(padding) }}>{children}</div>
       ) : (
         children
       )}

--- a/web/lib/opal/src/layouts/general/README.md
+++ b/web/lib/opal/src/layouts/general/README.md
@@ -4,7 +4,10 @@
 
 A flexbox container primitive for grouping related content. Configurable direction, alignment,
 spacing, and dimensions. Defaults to a full-width / full-height column with centered children
-and a 1rem gap.
+and a gap of `4` (1rem).
+
+`gap` and `padding` are spacing steps, not raw lengths: `N` is `N / 4` rem, the same scale
+Tailwind uses. So `gap={2}` is the same distance as `gap-2`.
 
 ## Props
 
@@ -15,8 +18,8 @@ and a 1rem gap.
 | `alignItems`     | `"start" \| "center" \| "end" \| "stretch"` | `"center"` | Cross-axis alignment         |
 | `width`          | `"auto" \| "fit" \| "full" \| number`       | `"full"`   | Width. `number` = rem.       |
 | `height`         | `"auto" \| "fit" \| "full" \| number`       | `"full"`   | Height. `number` = rem.      |
-| `gap`            | `number`                                    | `1`        | Gap between children, in rem |
-| `padding`        | `number`                                    | `0`        | Padding, in rem              |
+| `gap`            | `Spacing`                                   | `4`        | Gap between children, as a spacing step (`N / 4` rem) |
+| `padding`        | `Spacing`                                   | `0`        | Padding, as a spacing step (`N / 4` rem)              |
 | `wrap`           | `boolean`                                   | `false`    | Enables `flex-wrap`          |
 | `dbg`            | `boolean`                                   | `false`    | Adds a red debug border      |
 | `className`      | `string`                                    | —          | Additional classes           |
@@ -40,7 +43,7 @@ import { Section } from "@opal/layouts";
 </Section>
 
 // Tighter gap, custom width
-<Section gap={0.5} width="fit">
+<Section gap={2} width="fit">
   <Tag>One</Tag>
   <Tag>Two</Tag>
 </Section>

--- a/web/lib/opal/src/layouts/general/components.tsx
+++ b/web/lib/opal/src/layouts/general/components.tsx
@@ -2,7 +2,8 @@
 
 import React from "react";
 import { cn } from "@opal/utils";
-import type { WithoutStyles } from "@opal/types";
+import type { Spacing, WithoutStyles } from "@opal/types";
+import { spacingToRem } from "@opal/shared";
 
 type FlexDirection = "row" | "column";
 type JustifyContent = "start" | "center" | "end" | "between";
@@ -46,8 +47,10 @@ interface SectionProps extends WithoutStyles<
   width?: Length;
   height?: Length;
 
-  gap?: number;
-  padding?: number;
+  /** Spacing between children, as a {@link Spacing} step (`N / 4` rem). @default 4 */
+  gap?: Spacing;
+  /** Inner padding, as a {@link Spacing} step (`N / 4` rem). @default 0 */
+  padding?: Spacing;
   wrap?: boolean;
 
   ref?: React.Ref<HTMLDivElement>;
@@ -60,7 +63,7 @@ function Section({
   alignItems = "center",
   width = "full",
   height = "full",
-  gap = 1,
+  gap = 4,
   padding = 0,
   wrap,
   ref,
@@ -83,8 +86,8 @@ function Section({
         className
       )}
       style={{
-        gap: `${gap}rem`,
-        padding: `${padding}rem`,
+        gap: spacingToRem(gap),
+        padding: spacingToRem(padding),
         ...(typeof width === "number" && { width: `${width}rem` }),
         ...(typeof height === "number" && { height: `${height}rem` }),
       }}

--- a/web/lib/opal/src/layouts/inputs/components.tsx
+++ b/web/lib/opal/src/layouts/inputs/components.tsx
@@ -120,7 +120,7 @@ function Vertical({
   );
 
   const content = (
-    <Section ref={ref} gap={0.25} alignItems="start">
+    <Section ref={ref} gap={1} alignItems="start">
       {titleRow}
       {children}
       {fieldName && <FormikInputError name={fieldName} />}
@@ -182,7 +182,7 @@ function Horizontal({
     typeof withLabelProp === "string" ? withLabelProp : undefined;
 
   const content = (
-    <Section ref={ref} gap={0.25} alignItems="start">
+    <Section ref={ref} gap={1} alignItems="start">
       <ContentAction
         icon={icon}
         title={title}

--- a/web/lib/opal/src/shared.ts
+++ b/web/lib/opal/src/shared.ts
@@ -15,6 +15,7 @@ import type {
   ExtremaSizeVariants,
   PaddingVariants,
   RoundingVariants,
+  Spacing,
 } from "@opal/types";
 
 /**
@@ -147,6 +148,16 @@ const paddingYVariants: Record<PaddingVariants, string> = {
   fit: "py-0",
 };
 
+/**
+ * Converts a spacing step to a CSS length: `N` is `N / 4` rem.
+ *
+ * Kept as a function rather than a class lookup so the scale stays open —
+ * Tailwind cannot build a class name from a runtime value, but arithmetic can.
+ */
+function spacingToRem(spacing: Spacing): string {
+  return `${spacing / 4}rem`;
+}
+
 const cardRoundingVariants: Record<RoundingVariants, string> = {
   xl: "rounded-20",
   lg: "rounded-16",
@@ -176,7 +187,9 @@ export {
   type ContainerSizeVariants,
   type OverridableExtremaSizeVariants,
   type SizeVariants,
+  type Spacing,
   containerSizeVariants,
+  spacingToRem,
   paddingVariants,
   paddingXVariants,
   paddingYVariants,

--- a/web/lib/opal/src/types.ts
+++ b/web/lib/opal/src/types.ts
@@ -85,6 +85,24 @@ export type RoundingVariants = Extract<
  */
 export type ExtremaSizeVariants = Extract<SizeVariants, "fit" | "full">;
 
+// ---------------------------------------------------------------------------
+// Spacing Scale
+// ---------------------------------------------------------------------------
+
+/**
+ * A spacing step. `N` is `N / 4` rem, so `4` is `1rem` and `2` is `0.5rem`.
+ *
+ * This borrows Tailwind's scale as an interface, not as an implementation — a
+ * step reads the same here as in a class name, so a `padding` of `2` is the same
+ * distance as `p-2`. The value is converted with {@link spacingToRem} rather
+ * than looked up as a class, which keeps the scale open: any step works,
+ * including ones Tailwind does not ship.
+ *
+ * Replaces the named scales. `PaddingVariants` meant one distance on a card and
+ * a different one on a container; a number cannot be ambiguous that way.
+ */
+export type Spacing = number;
+
 /**
  * Shadow depth variants.
  *

--- a/web/src/app/admin/billing/BillingDetailsView.tsx
+++ b/web/src/app/admin/billing/BillingDetailsView.tsx
@@ -299,7 +299,7 @@ function SubscriptionCard({
         alignItems="start"
         height="auto"
       >
-        <Section gap={0.25} alignItems="start" height="auto" width="auto">
+        <Section gap={1} alignItems="start" height="auto" width="auto">
           <PlanIcon className="w-5 h-5" />
           <Text headingH3Muted text04>
             {planName}
@@ -310,7 +310,7 @@ function SubscriptionCard({
         </Section>
         <Section
           flexDirection="column"
-          gap={0.25}
+          gap={1}
           alignItems="end"
           height="auto"
           width="fit"
@@ -339,7 +339,7 @@ function SubscriptionCard({
           ) : (
             <Section
               flexDirection="row"
-              gap={0.5}
+              gap={2}
               alignItems="end"
               height="auto"
               width="auto"
@@ -484,7 +484,7 @@ function SeatsCard({
           flexDirection="row"
           justifyContent="between"
           alignItems="start"
-          padding={1}
+          padding={4}
           height="auto"
         >
           <Content
@@ -506,8 +506,8 @@ function SeatsCard({
           <Section
             flexDirection="column"
             alignItems="stretch"
-            gap={0.25}
-            padding={1}
+            gap={1}
+            padding={4}
             height="auto"
           >
             <InputVertical title="Seats" withLabel>
@@ -547,7 +547,7 @@ function SeatsCard({
           flexDirection="row"
           alignItems="center"
           justifyContent="between"
-          padding={1}
+          padding={4}
           height="auto"
         >
           {isAdding ? (
@@ -595,7 +595,7 @@ function SeatsCard({
         alignItems="center"
         height="auto"
       >
-        <Section gap={0.25} alignItems="start" height="auto" width="auto">
+        <Section gap={1} alignItems="start" height="auto" width="auto">
           <Text mainContentMuted text04>
             {totalSeats} Seats
           </Text>
@@ -606,7 +606,7 @@ function SeatsCard({
         </Section>
         <Section
           flexDirection="row"
-          gap={0.5}
+          gap={2}
           justifyContent="end"
           height="auto"
           width="auto"
@@ -660,12 +660,7 @@ function PaymentSection({ billing }: { billing: BillingInformation }) {
     <div className="billing-payment-section">
       <Section alignItems="start" height="auto" width="full">
         <Text mainContentEmphasis>Payment</Text>
-        <Section
-          flexDirection="row"
-          gap={0.5}
-          alignItems="stretch"
-          height="auto"
-        >
+        <Section flexDirection="row" gap={2} alignItems="stretch" height="auto">
           <Card className="billing-payment-card">
             <Section
               flexDirection="row"
@@ -748,7 +743,7 @@ export default function BillingDetailsView({
     isAirGapped || hasStripeError || isManualLicenseOnly;
 
   return (
-    <Section gap={1} height="auto" width="full">
+    <Section gap={4} height="auto" width="full">
       {/* Renewal fetched on arrival while expired. The page renders regardless:
           billing is the one route a lapsed instance must always reach. */}
       {isGraceSyncing && (

--- a/web/src/app/admin/billing/CheckoutView.tsx
+++ b/web/src/app/admin/billing/CheckoutView.tsx
@@ -42,7 +42,7 @@ function BillingOption({
     >
       <Section
         flexDirection="row"
-        gap={0.5}
+        gap={2}
         height="fit"
         justifyContent="between"
         alignItems="start"
@@ -69,7 +69,7 @@ function BillingOption({
         {badge && (
           <Section
             flexDirection="row"
-            gap={0.25}
+            gap={1}
             alignItems="center"
             justifyContent="end"
             width="fit"
@@ -160,13 +160,13 @@ export default function CheckoutView({ onAdjustPlan }: CheckoutViewProps) {
         flexDirection="row"
         justifyContent="between"
         alignItems="start"
-        padding={1}
+        padding={4}
         height="auto"
       >
         <Section
           flexDirection="column"
           alignItems="start"
-          gap={0.25}
+          gap={1}
           height="auto"
           width="fit"
         >
@@ -185,8 +185,8 @@ export default function CheckoutView({ onAdjustPlan }: CheckoutViewProps) {
         <Section
           flexDirection="column"
           alignItems="stretch"
-          gap={1}
-          padding={1}
+          gap={4}
+          padding={4}
           height="auto"
         >
           {/* Billing Cycle */}
@@ -197,7 +197,7 @@ export default function CheckoutView({ onAdjustPlan }: CheckoutViewProps) {
           >
             <Section
               flexDirection="row"
-              gap={0.25}
+              gap={1}
               width="fit"
               height="auto"
               justifyContent="start"
@@ -244,7 +244,7 @@ export default function CheckoutView({ onAdjustPlan }: CheckoutViewProps) {
         flexDirection="row"
         alignItems="center"
         justifyContent="between"
-        padding={1}
+        padding={4}
         height="auto"
       >
         {error ? (

--- a/web/src/app/admin/billing/LicenseActivationCard.tsx
+++ b/web/src/app/admin/billing/LicenseActivationCard.tsx
@@ -86,7 +86,7 @@ export default function LicenseActivationCard({
   // License status view (when license exists and not editing)
   if (hasLicense && !showInput) {
     return (
-      <Card padding={1} alignItems="stretch">
+      <Card padding={4} alignItems="stretch">
         <Section
           flexDirection="row"
           justifyContent="between"
@@ -96,7 +96,7 @@ export default function LicenseActivationCard({
           <Section
             flexDirection="column"
             alignItems="start"
-            gap={0.5}
+            gap={2}
             height="auto"
             width="auto"
           >
@@ -118,7 +118,7 @@ export default function LicenseActivationCard({
               )}
             </Text>
           </Section>
-          <Section flexDirection="row" gap={0.5} height="auto" width="auto">
+          <Section flexDirection="row" gap={2} height="auto" width="auto">
             <Button prominence="secondary" onClick={() => setShowInput(true)}>
               Update Key
             </Button>
@@ -137,7 +137,7 @@ export default function LicenseActivationCard({
   return (
     <Card padding={0} alignItems="stretch" gap={0}>
       {/* Header */}
-      <Section flexDirection="column" alignItems="stretch" gap={0} padding={1}>
+      <Section flexDirection="column" alignItems="stretch" gap={0} padding={4}>
         <Section
           flexDirection="row"
           justifyContent="between"
@@ -164,8 +164,8 @@ export default function LicenseActivationCard({
         <Section
           flexDirection="column"
           alignItems="stretch"
-          gap={0.5}
-          padding={1}
+          gap={2}
+          padding={4}
         >
           {success && (
             <div className="billing-success-message">
@@ -197,7 +197,7 @@ export default function LicenseActivationCard({
                 flexDirection="row"
                 alignItems="center"
                 justifyContent="start"
-                gap={0.25}
+                gap={1}
                 height="auto"
               >
                 <div className="billing-error-icon">
@@ -221,7 +221,7 @@ export default function LicenseActivationCard({
       </div>
 
       {/* Footer */}
-      <Section flexDirection="row" justifyContent="end" padding={1}>
+      <Section flexDirection="row" justifyContent="end" padding={4}>
         <Button
           disabled={isActivating || !licenseKey.trim() || success}
           onClick={handleActivate}

--- a/web/src/app/admin/billing/PlansView.tsx
+++ b/web/src/app/admin/billing/PlansView.tsx
@@ -106,16 +106,11 @@ function PlanCard({
       <Section
         flexDirection="column"
         alignItems="stretch"
-        padding={1}
+        padding={4}
         height="fit"
       >
         {/* Title */}
-        <Section
-          flexDirection="column"
-          alignItems="start"
-          gap={0.25}
-          width="full"
-        >
+        <Section flexDirection="column" alignItems="start" gap={1} width="full">
           <Icon size={24} />
           <Text headingH3 text04>
             {title}
@@ -127,7 +122,7 @@ function PlanCard({
           flexDirection="row"
           justifyContent="start"
           alignItems="center"
-          gap={0.5}
+          gap={2}
           height="auto"
         >
           {pricing && (
@@ -188,8 +183,8 @@ function PlanCard({
           flexDirection="column"
           alignItems="start"
           justifyContent="start"
-          gap={1}
-          padding={1}
+          gap={4}
+          padding={4}
         >
           <Text mainUiBody text03>
             {featuresPrefix}
@@ -197,7 +192,7 @@ function PlanCard({
           <Section
             flexDirection="column"
             alignItems="start"
-            gap={0.5}
+            gap={2}
             height="auto"
           >
             {features.map((feature) => (
@@ -206,7 +201,7 @@ function PlanCard({
                 flexDirection="row"
                 alignItems="start"
                 justifyContent="start"
-                gap={0.25}
+                gap={1}
                 width="fit"
                 height="auto"
               >

--- a/web/src/app/admin/billing/page.tsx
+++ b/web/src/app/admin/billing/page.tsx
@@ -69,7 +69,7 @@ function FooterLinks({
   )}`;
 
   return (
-    <Section flexDirection="row" justifyContent="center" gap={1} height="auto">
+    <Section flexDirection="row" justifyContent="center" gap={4} height="auto">
       {onActivateLicense && !hideLicenseLink && (
         <>
           <Text secondaryBody text03>

--- a/web/src/app/admin/connector/[ccPairId]/ConfigDisplay.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ConfigDisplay.tsx
@@ -56,7 +56,7 @@ function ConfigItem({ label, value, onEdit }: ConfigItemProps) {
       return (
         <Section
           flexDirection="row"
-          gap={0.25}
+          gap={1}
           justifyContent="end"
           alignItems="center"
           height="fit"
@@ -70,7 +70,7 @@ function ConfigItem({ label, value, onEdit }: ConfigItemProps) {
       );
     } else if (typeof value === "object" && value !== null) {
       return (
-        <Section gap={0.25} alignItems="end" height="fit">
+        <Section gap={1} alignItems="end" height="fit">
           {Object.entries(value).map(([key, val]) => (
             <Text key={key} secondaryBody text03 className="wrap-break-word">
               <Text mainContentEmphasis text03>
@@ -100,7 +100,7 @@ function ConfigItem({ label, value, onEdit }: ConfigItemProps) {
       flexDirection="row"
       justifyContent="between"
       alignItems="center"
-      gap={1}
+      gap={4}
     >
       <Section alignItems="start">
         <Text mainUiBody text04>
@@ -111,7 +111,7 @@ function ConfigItem({ label, value, onEdit }: ConfigItemProps) {
         flexDirection="row"
         justifyContent="end"
         alignItems="center"
-        gap={0.5}
+        gap={2}
       >
         {renderValue()}
 

--- a/web/src/app/admin/connector/[ccPairId]/DocPermissionSyncAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/DocPermissionSyncAttemptsTable.tsx
@@ -187,7 +187,7 @@ export function DocPermissionSyncAttemptsTable({
         />
       )}
 
-      <Section gap={0.75} alignItems="stretch" height="auto">
+      <Section gap={3} alignItems="stretch" height="auto">
         <Table
           data={attempts}
           columns={columns}

--- a/web/src/app/admin/connector/[ccPairId]/ExternalGroupSyncAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ExternalGroupSyncAttemptsTable.tsx
@@ -213,7 +213,7 @@ export function ExternalGroupSyncAttemptsTable({
         />
       )}
 
-      <Section gap={0.75} alignItems="stretch" height="auto">
+      <Section gap={3} alignItems="stretch" height="auto">
         <Table
           data={attempts}
           columns={columns}

--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptsTable.tsx
@@ -121,12 +121,7 @@ export function IndexAttemptsTable({
                     : "-"}
                 </TableCell>
                 <TableCell>
-                  <Section
-                    alignItems="start"
-                    width="fit"
-                    height="fit"
-                    gap={0.25}
-                  >
+                  <Section alignItems="start" width="fit" height="fit" gap={1}>
                     <IndexAttemptStatus
                       status={indexAttempt.status || "not_started"}
                     />
@@ -137,7 +132,7 @@ export function IndexAttemptsTable({
                         alignItems="center"
                         width="fit"
                         height="fit"
-                        gap={0.25}
+                        gap={1}
                         // Stack above the row-wide trace overlay button so
                         // the metrics button stays clickable on rows with
                         // a full exception trace.

--- a/web/src/app/admin/connector/[ccPairId]/stage-metrics/AttemptOverhead.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/stage-metrics/AttemptOverhead.tsx
@@ -27,7 +27,7 @@ export default function AttemptOverhead({
   }, [attemptStages]);
 
   return (
-    <Section alignItems="start" height="fit" width="full" gap={0.25}>
+    <Section alignItems="start" height="fit" width="full" gap={1}>
       <Button
         prominence="tertiary"
         size="sm"
@@ -46,7 +46,7 @@ interface AttemptOverheadListProps {
 
 function AttemptOverheadList({ stages }: AttemptOverheadListProps) {
   return (
-    <Section alignItems="stretch" height="fit" width="full" gap={0.125}>
+    <Section alignItems="stretch" height="fit" width="full" gap={0.5}>
       {stages.map((stage) => (
         <AttemptOverheadRow key={stage.stage} stage={stage} />
       ))}
@@ -66,7 +66,7 @@ function AttemptOverheadRow({ stage }: AttemptOverheadRowProps) {
       alignItems="center"
       width="full"
       height="fit"
-      gap={1}
+      gap={4}
     >
       <Text font="secondary-body" color="text-04">
         {STAGE_LABELS[stage.stage]}

--- a/web/src/app/admin/connector/[ccPairId]/stage-metrics/AvgTimeCell.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/stage-metrics/AvgTimeCell.tsx
@@ -29,7 +29,7 @@ export default function AvgTimeCell({ stage, maxAvgMs }: AvgTimeCellProps) {
       justifyContent="center"
       width="full"
       height="fit"
-      gap={0.25}
+      gap={1}
     >
       <Text font="secondary-body" color="text-05" nowrap>
         {avgLabel}

--- a/web/src/app/admin/connector/[ccPairId]/stage-metrics/PerBatchSection.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/stage-metrics/PerBatchSection.tsx
@@ -26,7 +26,7 @@ export default function PerBatchSection({
     );
   }
   return (
-    <Section alignItems="start" height="fit" width="full" gap={0.75}>
+    <Section alignItems="start" height="fit" width="full" gap={3}>
       <SortToggle sortMode={sortMode} onChange={onSortModeChange} />
       <PerBatchTable perBatchStages={perBatchStages} sortMode={sortMode} />
     </Section>

--- a/web/src/app/admin/connector/[ccPairId]/stage-metrics/SortToggle.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/stage-metrics/SortToggle.tsx
@@ -17,7 +17,7 @@ export default function SortToggle({ sortMode, onChange }: SortToggleProps) {
       alignItems="center"
       width="fit"
       height="fit"
-      gap={0.5}
+      gap={2}
     >
       <Text font="secondary-body" color="text-03">
         Sort:

--- a/web/src/app/admin/connector/[ccPairId]/stage-metrics/StageLabelCell.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/stage-metrics/StageLabelCell.tsx
@@ -20,7 +20,7 @@ export default function StageLabelCell({ stage }: StageLabelCellProps) {
       alignItems="center"
       width="fit"
       height="fit"
-      gap={0.5}
+      gap={2}
     >
       {/* Inline color swatch: a color-only marker doesn't fit any
           layout primitive, and Tailwind handles the styling fully. */}

--- a/web/src/app/admin/connector/[ccPairId]/stage-metrics/StageMetricsPanel.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/stage-metrics/StageMetricsPanel.tsx
@@ -64,7 +64,7 @@ export default function StageMetricsPanel({
   }
 
   return (
-    <Section alignItems="start" height="fit" width="full" gap={0.75}>
+    <Section alignItems="start" height="fit" width="full" gap={3}>
       <BatchTotalHeader batchTotal={batchTotal} />
       <PerBatchSection
         perBatchStages={perBatchStages}

--- a/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
+++ b/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
@@ -562,7 +562,7 @@ export default function AddConnector({
                   <Section
                     flexDirection="row"
                     justifyContent="start"
-                    gap={1}
+                    gap={4}
                     className="mt-6"
                   >
                     {/* Button to pop up a form to manually enter credentials */}

--- a/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/StringPairListInput.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/StringPairListInput.tsx
@@ -79,13 +79,13 @@ const StringPairListInput: React.FC<StringPairListInputProps> = ({
       <FieldArray
         name={name}
         render={(arrayHelpers: ArrayHelpers) => (
-          <Section gap={0.5} alignItems="start" width="full">
+          <Section gap={2} alignItems="start" width="full">
             {pairs.length > 0 && (
               <Section
                 flexDirection="row"
                 justifyContent="start"
                 alignItems="center"
-                gap={0.25}
+                gap={1}
                 width="full"
               >
                 <Section width="full" alignItems="start" gap={0}>
@@ -108,7 +108,7 @@ const StringPairListInput: React.FC<StringPairListInputProps> = ({
             {pairs.map((_, index) => (
               <Section
                 key={rowKeys.keys[index]}
-                gap={0.25}
+                gap={1}
                 alignItems="start"
                 width="full"
               >
@@ -116,7 +116,7 @@ const StringPairListInput: React.FC<StringPairListInputProps> = ({
                   flexDirection="row"
                   justifyContent="start"
                   alignItems="center"
-                  gap={0.25}
+                  gap={1}
                   width="full"
                 >
                   <InputTypeInField

--- a/web/src/app/admin/connectors/[connector]/pages/FieldRendering.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/FieldRendering.tsx
@@ -45,7 +45,7 @@ const TabsField: FC<TabsFieldProps> = ({
       : tabField.description;
 
   return (
-    <GeneralLayouts.Section gap={0.5} alignItems="start">
+    <GeneralLayouts.Section gap={2} alignItems="start">
       {tabField.label && (
         <Content
           title={resolvedLabel ?? ""}
@@ -86,7 +86,7 @@ const TabsField: FC<TabsFieldProps> = ({
           </Tabs.List>
           {tabField.tabs.map((tab) => (
             <Tabs.Content key={tab.value} value={tab.value}>
-              <GeneralLayouts.Section gap={0.75} alignItems="start">
+              <GeneralLayouts.Section gap={3} alignItems="start">
                 {tab.fields.map((subField) => {
                   // Check visibility condition first
                   if (
@@ -224,7 +224,7 @@ export const RenderField: FC<RenderFieldProps> = ({
           flexDirection="row"
           justifyContent="start"
           alignItems="start"
-          gap={0.5}
+          gap={2}
         >
           <CheckboxField
             name={field.name}

--- a/web/src/app/admin/connectors/[connector]/pages/gdrive/Credential.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/gdrive/Credential.tsx
@@ -44,7 +44,7 @@ export const DriveAuthSection = ({
       <Section
         alignItems="start"
         justifyContent="start"
-        gap={0.25}
+        gap={1}
         className="mt-4 rounded-sm border border-border-02 bg-background-tint-02 px-4 py-3"
       >
         <Text as="p" font="main-ui-action">
@@ -59,11 +59,11 @@ export const DriveAuthSection = ({
   }
 
   return (
-    <Section alignItems="start" justifyContent="start" gap={1}>
+    <Section alignItems="start" justifyContent="start" gap={4}>
       <Text as="h3" font="heading-h2">
         Google Drive Authentication
       </Text>
-      <Section alignItems="start" justifyContent="start" gap={1}>
+      <Section alignItems="start" justifyContent="start" gap={4}>
         <Text as="p" font="main-ui-action">
           Option 1: OAuth app
         </Text>
@@ -200,7 +200,7 @@ export const DriveAuthSection = ({
         >
           {({ isSubmitting }) => (
             <Form className="w-full">
-              <Section alignItems="start" justifyContent="start" gap={0.25}>
+              <Section alignItems="start" justifyContent="start" gap={1}>
                 <Text font="main-ui-body" color="text-03">
                   Primary Admin Email
                 </Text>

--- a/web/src/app/admin/connectors/[connector]/pages/gmail/Credential.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/gmail/Credential.tsx
@@ -50,7 +50,7 @@ export const GmailAuthSection = ({
       <Section
         alignItems="start"
         justifyContent="start"
-        gap={0.25}
+        gap={1}
         className="mt-4 rounded-sm border border-border-02 bg-background-tint-02 px-4 py-3"
       >
         <Text as="p" font="main-ui-action">
@@ -65,11 +65,11 @@ export const GmailAuthSection = ({
   }
 
   return (
-    <Section alignItems="start" justifyContent="start" gap={1}>
+    <Section alignItems="start" justifyContent="start" gap={4}>
       <Text as="h3" font="heading-h2">
         Gmail Authentication
       </Text>
-      <Section alignItems="start" justifyContent="start" gap={1}>
+      <Section alignItems="start" justifyContent="start" gap={4}>
         <Text as="p" font="main-ui-action">
           Option 1: OAuth app
         </Text>
@@ -207,7 +207,7 @@ export const GmailAuthSection = ({
         >
           {({ isSubmitting }) => (
             <Form className="w-full">
-              <Section alignItems="start" justifyContent="start" gap={0.25}>
+              <Section alignItems="start" justifyContent="start" gap={1}>
                 <Text font="main-ui-body" color="text-03">
                   Primary Admin Email
                 </Text>

--- a/web/src/app/admin/discord-bot/BotConfigCard.tsx
+++ b/web/src/app/admin/discord-bot/BotConfigCard.tsx
@@ -109,7 +109,7 @@ export function BotConfigCard() {
       )}
       <Card>
         <Section flexDirection="row" justifyContent="between">
-          <Section flexDirection="row" gap={0.5} width="fit">
+          <Section flexDirection="row" gap={2} width="fit">
             <Text mainContentEmphasis text05>
               Bot Token
             </Text>
@@ -137,7 +137,7 @@ export function BotConfigCard() {
         </Section>
 
         {isConfigured ? (
-          <Section flexDirection="column" alignItems="start" gap={0.5}>
+          <Section flexDirection="column" alignItems="start" gap={2}>
             <Text text03 secondaryBody>
               Your Discord bot token is configured.
               {botConfig?.created_at && (
@@ -152,12 +152,12 @@ export function BotConfigCard() {
             </Text>
           </Section>
         ) : (
-          <Section flexDirection="column" alignItems="start" gap={0.75}>
+          <Section flexDirection="column" alignItems="start" gap={3}>
             <Text text03 secondaryBody>
               Enter your Discord bot token to enable the bot. You can get this
               from the Discord Developer Portal.
             </Text>
-            <Section flexDirection="row" alignItems="end" gap={0.5}>
+            <Section flexDirection="row" alignItems="end" gap={2}>
               <PasswordInputTypeIn
                 value={botToken}
                 onChange={(e) => setBotToken(e.target.value)}

--- a/web/src/app/admin/discord-bot/[guild-id]/DiscordChannelsTable.tsx
+++ b/web/src/app/admin/discord-bot/[guild-id]/DiscordChannelsTable.tsx
@@ -92,7 +92,7 @@ export function DiscordChannelsTable({
                 <Section
                   flexDirection="row"
                   justifyContent="start"
-                  gap={0.5}
+                  gap={2}
                   width="fit"
                 >
                   <ChannelIcon width={16} height={16} />

--- a/web/src/app/admin/discord-bot/[guild-id]/page.tsx
+++ b/web/src/app/admin/discord-bot/[guild-id]/page.tsx
@@ -101,7 +101,7 @@ function GuildDetailContent({
                 justifyContent="end"
                 alignItems="center"
                 width="fit"
-                gap={0.5}
+                gap={2}
               >
                 <Button
                   disabled={disabled}

--- a/web/src/app/admin/scim/ScimModal.tsx
+++ b/web/src/app/admin/scim/ScimModal.tsx
@@ -62,7 +62,7 @@ export default function ScimModal({
             </Button>
           }
         >
-          <Section alignItems="start" gap={0.5}>
+          <Section alignItems="start" gap={2}>
             <Text as="p" text03>
               Your current SCIM token will be revoked and a new token will be
               generated. You will need to update the token on your identity

--- a/web/src/app/admin/scim/ScimSyncCard.tsx
+++ b/web/src/app/admin/scim/ScimSyncCard.tsx
@@ -34,7 +34,7 @@ export default function ScimSyncCard({
   onRegenerate,
 }: ScimSyncCardProps) {
   return (
-    <Card gap={0.75}>
+    <Card gap={3}>
       <ContentAction
         title="SCIM Sync"
         description="Connect your identity provider to import and sync users and groups."
@@ -71,7 +71,7 @@ export default function ScimSyncCard({
             flexDirection="row"
             justifyContent="between"
             alignItems="end"
-            gap={1}
+            gap={4}
           >
             <Section alignItems="start" gap={0} width="fit">
               {isConnected ? (

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -502,7 +502,7 @@ export default function CreateRateLimitModal({
             return (
               <Form className="flex min-h-0 flex-1 flex-col overflow-hidden">
                 <Modal.Body>
-                  <Section alignItems="stretch" height="auto" gap={1}>
+                  <Section alignItems="stretch" height="auto" gap={4}>
                     {!forSpecificScope && (
                       <InputVertical
                         title="Applies to"

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
@@ -135,7 +135,7 @@ export const TokenRateLimitTable = ({
   };
 
   return (
-    <Section alignItems="stretch" height="auto" gap={0.5}>
+    <Section alignItems="stretch" height="auto" gap={2}>
       {!hideHeading && description && (
         <Text font="secondary-body" color="text-03" as="p">
           {description}

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitsPanel.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitsPanel.tsx
@@ -109,7 +109,7 @@ export default function TokenRateLimitsPanel({
   return (
     <Section alignItems="stretch" justifyContent="start" height="auto">
       {embedded ? (
-        <Section gap={0.25} alignItems="start" justifyContent="start">
+        <Section gap={1} alignItems="start" justifyContent="start">
           <Text font="heading-h3">Manage spending limits</Text>
           <Text font="secondary-body" color="text-03">
             Set guardrails for workspace, user, and group usage. Limits can be

--- a/web/src/app/app/components/WelcomeMessage.tsx
+++ b/web/src/app/app/components/WelcomeMessage.tsx
@@ -43,7 +43,7 @@ export default function WelcomeMessage({
         data-testid="onyx-logo"
         flexDirection="column"
         alignItems="start"
-        gap={0.5}
+        gap={2}
         width="fit"
       >
         <Logo folded size={32} />
@@ -58,7 +58,7 @@ export default function WelcomeMessage({
         data-testid="agent-name-display"
         flexDirection="column"
         alignItems="start"
-        gap={0.5}
+        gap={2}
         width="fit"
       >
         <AgentAvatar agent={agent} size={36} />

--- a/web/src/app/app/message/messageComponents/timeline/headers/CompletedHeader.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/headers/CompletedHeader.tsx
@@ -58,8 +58,8 @@ function MemoryTagWithTooltip({
             <Section
               flexDirection="column"
               alignItems="start"
-              padding={0.25}
-              gap={0.25}
+              padding={1}
+              gap={1}
               height="auto"
             >
               <div className="p-1">

--- a/web/src/app/app/message/messageComponents/timeline/renderers/filereader/FileReaderToolRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/filereader/FileReaderToolRenderer.tsx
@@ -105,14 +105,14 @@ export const FileReaderToolRenderer: MessageRenderer<
       supportsCollapsible: true,
       timelineLayout: "timeline",
       content: (
-        <Section gap={0.5} alignItems="start" height="fit">
+        <Section gap={2} alignItems="start" height="fit">
           {state.fileName ? (
             <>
               <Section
                 flexDirection="row"
                 alignItems="center"
                 justifyContent="start"
-                gap={0.5}
+                gap={2}
                 height="fit"
               >
                 <Text as="span" mainUiAction text02>
@@ -127,7 +127,7 @@ export const FileReaderToolRenderer: MessageRenderer<
                 </Text>
               </Section>
               {hasPreview && (
-                <Card variant="secondary" padding={0.5} gap={0.25}>
+                <Card variant="secondary" padding={2} gap={1}>
                   <Text as="span" secondaryMono text04>
                     {state.previewStart}
                     {state.previewEnd && "\u2026"}

--- a/web/src/app/app/settings/layout.tsx
+++ b/web/src/app/app/settings/layout.tsx
@@ -54,7 +54,7 @@ export default function Layout({ children }: LayoutProps) {
           flexDirection="column"
           justifyContent="start"
           alignItems="stretch"
-          gap={1.5}
+          gap={6}
           className="sm:flex-row sm:items-start"
         >
           {/* Narrow screens: dropdown navigation above the tab content */}

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -50,7 +50,7 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
   );
 
   return (
-    <Section gap={0.75} justifyContent="start">
+    <Section gap={3} justifyContent="start">
       <Content
         icon={SvgBarChart}
         title="Usage this period"
@@ -71,13 +71,13 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
           {sortedRows.map((row, index) => (
             <div key={`${row.day}-${row.model}`}>
               {index > 0 && <Divider />}
-              <Section gap={0.5} alignItems="start" justifyContent="start">
+              <Section gap={2} alignItems="start" justifyContent="start">
                 <Section
                   flexDirection="row"
                   justifyContent="between"
                   alignItems="center"
                   width="full"
-                  gap={1}
+                  gap={4}
                 >
                   <Section gap={0} alignItems="start" justifyContent="start">
                     <Text font="main-ui-action" color="text-03">
@@ -183,7 +183,7 @@ function ModelPriceSection({ prices, defaultPrice }: ModelPriceSectionProps) {
   }
 
   return (
-    <Section gap={0.75} justifyContent="start">
+    <Section gap={3} justifyContent="start">
       <Content
         icon={SvgCreditCard}
         title="Model prices"
@@ -198,7 +198,7 @@ function ModelPriceSection({ prices, defaultPrice }: ModelPriceSectionProps) {
             Prices unavailable
           </Text>
         ) : (
-          <Section gap={0.25} alignItems="stretch" justifyContent="start">
+          <Section gap={1} alignItems="stretch" justifyContent="start">
             {groups.map(({ provider, models }) => {
               const open = expanded.has(provider);
               return (
@@ -289,7 +289,7 @@ function BudgetSection({
     hasBudget && budgetCents > 0 ? Math.min(1, spent / budgetCents) : 0;
 
   return (
-    <Section gap={0.75} justifyContent="start">
+    <Section gap={3} justifyContent="start">
       <Content
         icon={SvgWallet}
         title="Budget"
@@ -299,13 +299,13 @@ function BudgetSection({
       />
       <Card>
         {hasBudget ? (
-          <Section gap={0.5} alignItems="start" justifyContent="start">
+          <Section gap={2} alignItems="start" justifyContent="start">
             <Section
               flexDirection="row"
               justifyContent="between"
               alignItems="center"
               width="full"
-              gap={1}
+              gap={4}
             >
               <Text font="main-ui-body" color="text-03">
                 {`${formatDollars(remaining)} remaining`}
@@ -349,14 +349,14 @@ export default function UsageSettings() {
   }, [error]);
 
   return (
-    <Section gap={2}>
-      <Section gap={0.75} justifyContent="start">
+    <Section gap={8}>
+      <Section gap={3} justifyContent="start">
         <Section
           flexDirection="row"
           justifyContent="between"
           alignItems="center"
           width="full"
-          gap={1}
+          gap={4}
         >
           <Content title="Usage" sizePreset="main-content" variant="section" />
           <div className="min-w-32">
@@ -391,7 +391,7 @@ export default function UsageSettings() {
             description="Something went wrong fetching your usage. Try again in a moment."
           />
         ) : (
-          <Section gap={2}>
+          <Section gap={8}>
             <WindowCostSection
               windowCostCents={data.window_cost_cents}
               rows={data.per_day_by_model}

--- a/web/src/app/app/shared/[chatId]/SharedChatDisplay.tsx
+++ b/web/src/app/app/shared/[chatId]/SharedChatDisplay.tsx
@@ -49,7 +49,7 @@ export default function SharedChatDisplay({
   if (!chatSession) {
     return (
       <div className="h-full w-full flex flex-col items-center justify-center">
-        <Section flexDirection="column" alignItems="center" gap={1}>
+        <Section flexDirection="column" alignItems="center" gap={4}>
           <IllustrationContent
             illustration={SvgNotFound}
             title="Shared chat not found"
@@ -74,7 +74,7 @@ export default function SharedChatDisplay({
   if (firstMessage === undefined) {
     return (
       <div className="h-full w-full flex flex-col items-center justify-center">
-        <Section flexDirection="column" alignItems="center" gap={1}>
+        <Section flexDirection="column" alignItems="center" gap={4}>
           <IllustrationContent
             illustration={SvgNotFound}
             title="Shared chat not found"

--- a/web/src/app/craft/components/BuildLLMPopover.tsx
+++ b/web/src/app/craft/components/BuildLLMPopover.tsx
@@ -278,7 +278,7 @@ export function BuildLLMPopover({
       <Popover.Trigger asChild>{children}</Popover.Trigger>
       <Popover.Content side="bottom" align="start" width="lg">
         <div className="px-3">
-          <Section gap={0.5}>
+          <Section gap={2}>
             <div className="flex items-center justify-between py-3 gap-3 border-b border-border-01 px-1">
               <Text font="secondary-body" color="text-03">
                 Recommended Models Only

--- a/web/src/app/craft/components/ShareButton.tsx
+++ b/web/src/app/craft/components/ShareButton.tsx
@@ -106,13 +106,13 @@ export default function ShareButton({
         <Popover.Content side="bottom" align="end" width="lg" sideOffset={4}>
           <Section
             alignItems="stretch"
-            gap={0.25}
-            padding={0.25}
+            gap={1}
+            padding={1}
             width="full"
             height="fit"
           >
             {/* Scope options */}
-            <Section alignItems="stretch" gap={0.25} width="full">
+            <Section alignItems="stretch" gap={1} width="full">
               {SCOPE_OPTIONS.map((opt) => (
                 <div
                   key={opt.value}
@@ -147,8 +147,8 @@ export default function ShareButton({
                 <Section
                   flexDirection="row"
                   alignItems="center"
-                  gap={0.25}
-                  padding={0.25}
+                  gap={1}
+                  padding={1}
                   width="full"
                   height="fit"
                 >

--- a/web/src/app/craft/components/UserLibraryModal.tsx
+++ b/web/src/app/craft/components/UserLibraryModal.tsx
@@ -283,7 +283,7 @@ export default function UserLibraryModal({
             description="Files your agent can read in every session."
             onClose={onClose}
           >
-            <Section flexDirection="row" gap={0.5}>
+            <Section flexDirection="row" gap={2}>
               <InputTypeIn
                 placeholder="Search files..."
                 value={searchQuery}

--- a/web/src/app/craft/components/output-panel/ArtifactsTab.tsx
+++ b/web/src/app/craft/components/output-panel/ArtifactsTab.tsx
@@ -143,7 +143,7 @@ export default function ArtifactsTab({
         height="full"
         alignItems="center"
         justifyContent="center"
-        padding={2}
+        padding={8}
       >
         <SvgFiles size={48} className="stroke-text-02" />
         <Text font="heading-h3" color="text-03">

--- a/web/src/app/craft/components/output-panel/FilePreviewContent.tsx
+++ b/web/src/app/craft/components/output-panel/FilePreviewContent.tsx
@@ -177,7 +177,7 @@ function FetchedFilePreview({
           height="full"
           alignItems="center"
           justifyContent="center"
-          padding={2}
+          padding={8}
         >
           <Text font="secondary-body" color="text-03">
             Loading file...
@@ -201,7 +201,7 @@ function FetchedFilePreview({
           height="full"
           alignItems="center"
           justifyContent="center"
-          padding={2}
+          padding={8}
         >
           <SvgFileText size={48} className="stroke-text-02" />
           <Text font="heading-h3" color="text-03">
@@ -229,7 +229,7 @@ function FetchedFilePreview({
           height="full"
           alignItems="center"
           justifyContent="center"
-          padding={2}
+          padding={8}
         >
           <Text font="secondary-body" color="text-03">
             No content
@@ -253,7 +253,7 @@ function FetchedFilePreview({
           height="full"
           alignItems="center"
           justifyContent="center"
-          padding={2}
+          padding={8}
         >
           <SvgFileText size={48} className="stroke-text-02" />
           <Text font="heading-h3" color="text-03">

--- a/web/src/app/craft/components/output-panel/FilesTab.tsx
+++ b/web/src/app/craft/components/output-panel/FilesTab.tsx
@@ -345,7 +345,7 @@ export default function FilesTab({
         height="full"
         alignItems="center"
         justifyContent="center"
-        padding={2}
+        padding={8}
       >
         <SvgHardDrive size={48} className="stroke-text-02" />
         <Text font="heading-h3" color="text-03">
@@ -366,7 +366,7 @@ export default function FilesTab({
         height="full"
         alignItems="center"
         justifyContent="center"
-        padding={2}
+        padding={8}
       >
         <SvgHardDrive size={48} className="stroke-text-02" />
         <Text font="heading-h3" color="text-03">
@@ -385,7 +385,7 @@ export default function FilesTab({
         height="full"
         alignItems="center"
         justifyContent="center"
-        padding={2}
+        padding={8}
       >
         <Text font="secondary-body" color="text-03">
           Loading files...
@@ -442,7 +442,7 @@ export default function FilesTab({
             height="full"
             alignItems="center"
             justifyContent="center"
-            padding={2}
+            padding={8}
           >
             <Text font="secondary-body" color="text-03">
               No files in this directory

--- a/web/src/app/craft/components/output-panel/ImagePreview.tsx
+++ b/web/src/app/craft/components/output-panel/ImagePreview.tsx
@@ -34,7 +34,7 @@ export default function ImagePreview({ src, fileName }: ImagePreviewProps) {
         height="full"
         alignItems="center"
         justifyContent="center"
-        padding={2}
+        padding={8}
       >
         <SvgImage size={48} className="stroke-text-02" />
         <Text font="heading-h3" color="text-03">

--- a/web/src/app/craft/components/output-panel/PdfPreview.tsx
+++ b/web/src/app/craft/components/output-panel/PdfPreview.tsx
@@ -79,7 +79,7 @@ export default function PdfPreview({
         height="full"
         alignItems="center"
         justifyContent="center"
-        padding={2}
+        padding={8}
       >
         <SvgFileText size={48} className="stroke-text-02" />
         <Text font="heading-h3" color="text-03">
@@ -100,7 +100,7 @@ export default function PdfPreview({
         height="full"
         alignItems="center"
         justifyContent="center"
-        padding={2}
+        padding={8}
       >
         <Text font="secondary-body" color="text-03">
           Loading PDF...

--- a/web/src/app/craft/components/output-panel/PptxPreview.tsx
+++ b/web/src/app/craft/components/output-panel/PptxPreview.tsx
@@ -84,7 +84,7 @@ export default function PptxPreview({
         height="full"
         alignItems="center"
         justifyContent="center"
-        padding={2}
+        padding={8}
       >
         <Text font="secondary-body" color="text-03">
           Converting presentation...
@@ -99,7 +99,7 @@ export default function PptxPreview({
         height="full"
         alignItems="center"
         justifyContent="center"
-        padding={2}
+        padding={8}
       >
         <SvgFileText size={48} className="stroke-text-02" />
         <Text font="heading-h3" color="text-03">
@@ -120,7 +120,7 @@ export default function PptxPreview({
         height="full"
         alignItems="center"
         justifyContent="center"
-        padding={2}
+        padding={8}
       >
         <SvgFileText size={48} className="stroke-text-02" />
         <Text font="secondary-body" color="text-03">

--- a/web/src/app/craft/components/output-panel/PreviewTab.tsx
+++ b/web/src/app/craft/components/output-panel/PreviewTab.tsx
@@ -38,7 +38,7 @@ export default function PreviewTab({
         height="full"
         alignItems="center"
         justifyContent="center"
-        padding={2}
+        padding={8}
       >
         <SvgGlobe size={48} className="stroke-text-02" aria-hidden />
         <Text font="heading-h3" color="text-03">
@@ -57,7 +57,7 @@ export default function PreviewTab({
         height="full"
         alignItems="center"
         justifyContent="center"
-        padding={2}
+        padding={8}
         role="status"
       >
         <SvgLoader

--- a/web/src/app/craft/onboarding/components/LivingMapModal.tsx
+++ b/web/src/app/craft/onboarding/components/LivingMapModal.tsx
@@ -88,7 +88,7 @@ export default function LivingMapModal({
         {/* The X routes through Radix → onOpenChange, which owns dismissal;
             a real handler here would double-fire onDismiss. */}
         <Modal.Header title="Meet Craft" onClose={() => {}} />
-        <Modal.Body padding={1.5}>
+        <Modal.Body padding={6}>
           <div className="flex w-full flex-col gap-3">
             {/* Stage copy crossfades above a scene that never unmounts. */}
             <div className="relative h-14">

--- a/web/src/app/craft/v1/apps/page.tsx
+++ b/web/src/app/craft/v1/apps/page.tsx
@@ -444,7 +444,7 @@ function ConnectableCard({
             description={statusLine(app, needsSkillSetup)}
             descriptionMaxLines={1}
             rightChildren={
-              <Section flexDirection="row" width="fit" height="fit" gap={0.5}>
+              <Section flexDirection="row" width="fit" height="fit" gap={2}>
                 {app.authenticated ? (
                   <>
                     {/* Only the problem state gets a glyph — "Connected" in the

--- a/web/src/app/craft/v1/tasks/components/RunHistoryTable.tsx
+++ b/web/src/app/craft/v1/tasks/components/RunHistoryTable.tsx
@@ -274,7 +274,7 @@ export default function RunHistoryTable({ taskId }: RunHistoryTableProps) {
 
   if (error) {
     return (
-      <Section gap={0.5}>
+      <Section gap={2}>
         <Text font="main-ui-body" color="text-03">
           Failed to load run history.
         </Text>
@@ -302,7 +302,7 @@ export default function RunHistoryTable({ taskId }: RunHistoryTableProps) {
   }
 
   return (
-    <Section gap={0.5} alignItems="stretch">
+    <Section gap={2} alignItems="stretch">
       <Table
         data={allRuns}
         columns={columns}

--- a/web/src/app/craft/v1/tasks/components/ScheduleEditor.tsx
+++ b/web/src/app/craft/v1/tasks/components/ScheduleEditor.tsx
@@ -82,7 +82,7 @@ export default function ScheduleEditor({
   const tabEntries = Object.entries(tabContent);
 
   return (
-    <Section gap={0.5}>
+    <Section gap={2}>
       <Tabs
         value={mode}
         onValueChange={(value) => {
@@ -154,7 +154,7 @@ interface IntervalEditorProps {
 
 function IntervalEditor({ payload, onChange }: IntervalEditorProps) {
   return (
-    <Section gap={0.5}>
+    <Section gap={2}>
       <div className="flex items-center gap-2 flex-wrap">
         <Text font="main-ui-body" color="text-05">
           Every
@@ -211,7 +211,7 @@ function DailyWeeklyEditor({ payload, onChange }: DailyWeeklyEditorProps) {
       ? "Runs every day"
       : `Runs on ${selectedDays.join(", ")}`;
   return (
-    <Section gap={0.5}>
+    <Section gap={2}>
       <div className="flex items-center gap-2">
         <Text font="main-ui-body" color="text-05">
           At

--- a/web/src/app/craft/v1/tasks/page.tsx
+++ b/web/src/app/craft/v1/tasks/page.tsx
@@ -209,7 +209,7 @@ export default function ScheduledTasksListPage() {
             <SvgSimpleLoader className="h-6 w-6" />
           </div>
         ) : error ? (
-          <Section gap={0.5}>
+          <Section gap={2}>
             <Text font="main-ui-body" color="text-03">
               Failed to load scheduled tasks.
             </Text>

--- a/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
+++ b/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
@@ -101,7 +101,7 @@ function SelectFeedbackType({
   onValueChange: (value: Feedback | "all") => void;
 }) {
   return (
-    <Section alignItems="start" gap={0.25}>
+    <Section alignItems="start" gap={1}>
       <Text as="p" className="font-medium">
         Feedback Type
       </Text>

--- a/web/src/ee/sections/SearchCard.tsx
+++ b/web/src/ee/sections/SearchCard.tsx
@@ -57,13 +57,13 @@ export default function SearchCard({
   return (
     <Interactive.Stateless onClick={handleClick} prominence="secondary">
       <Interactive.Container size="fit" width="full">
-        <Section alignItems="start" gap={0} padding={0.25}>
+        <Section alignItems="start" gap={0} padding={1}>
           {/* Title Row */}
           <Section
             flexDirection="row"
             justifyContent="start"
-            gap={0.25}
-            padding={0.25}
+            gap={1}
+            padding={1}
           >
             {isWebSource && document.link ? (
               <WebResultIcon url={document.link} size={18} />
@@ -78,9 +78,9 @@ export default function SearchCard({
 
           {/* Body Row */}
           <div className="px-1 pb-1">
-            <Section alignItems="start" gap={0.25}>
+            <Section alignItems="start" gap={1}>
               {/* Metadata */}
-              <Section flexDirection="row" justifyContent="start" gap={0.25}>
+              <Section flexDirection="row" justifyContent="start" gap={1}>
                 {(document.primary_owners ?? []).map((owner, index) => (
                   <Chip key={index}>{owner}</Chip>
                 ))}

--- a/web/src/ee/sections/SearchUI.tsx
+++ b/web/src/ee/sections/SearchUI.tsx
@@ -368,7 +368,7 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
 
         {!showEmpty && (
           <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-4 px-1">
-            <Section gap={0.25} height="fit">
+            <Section gap={1} height="fit">
               {sourcesWithMeta.map(({ source, meta, count }) => (
                 <LineItemButton
                   key={source}

--- a/web/src/ee/views/admin/HooksPage/HookFormModal.tsx
+++ b/web/src/ee/views/admin/HooksPage/HookFormModal.tsx
@@ -382,7 +382,7 @@ export default function HookFormModal({
                       alignItems="center"
                       justifyContent="start"
                       height="fit"
-                      gap={1}
+                      gap={4}
                       className="px-0.5"
                     >
                       <div className="p-0.5 shrink-0">

--- a/web/src/ee/views/admin/HooksPage/HookLogsModal.tsx
+++ b/web/src/ee/views/admin/HooksPage/HookLogsModal.tsx
@@ -47,7 +47,7 @@ function LogRow({ log, group }: { log: HookExecutionRecord; group: string }) {
         flexDirection="row"
         justifyContent="start"
         alignItems="start"
-        gap={0.5}
+        gap={2}
         height="fit"
         className="py-2"
       >
@@ -157,7 +157,7 @@ export default function HookLogsModal({ hook, spec }: HookLogsModalProps) {
           flexDirection="row"
           justifyContent="between"
           alignItems="center"
-          padding={0.5}
+          padding={2}
           className="bg-background-tint-01"
         >
           <Text font="main-ui-body" color="text-03">
@@ -167,8 +167,8 @@ export default function HookLogsModal({ hook, spec }: HookLogsModalProps) {
             flexDirection="row"
             alignItems="center"
             width="fit"
-            gap={0.25}
-            padding={0.25}
+            gap={1}
+            padding={1}
             className="rounded-xl bg-background-tint-00"
           >
             <CopyButton size="sm" tooltip="Copy" getCopyText={getLogsText} />

--- a/web/src/ee/views/admin/HooksPage/HookStatusPopover.tsx
+++ b/web/src/ee/views/admin/HooksPage/HookStatusPopover.tsx
@@ -39,8 +39,8 @@ function ErrorLogRow({
         flexDirection="column"
         justifyContent="start"
         alignItems="start"
-        gap={0.25}
-        padding={0.25}
+        gap={1}
+        padding={1}
         height="fit"
       >
         <Section
@@ -221,8 +221,8 @@ export default function HookStatusPopover({
                   ? 20
                   : 12.5
             }
-            padding={0.125}
-            gap={0.25}
+            padding={0.5}
+            gap={1}
           >
             {isLoading ? (
               <Section justifyContent="center">
@@ -256,8 +256,8 @@ export default function HookStatusPopover({
                       flexDirection="column"
                       justifyContent="start"
                       alignItems="start"
-                      gap={0.25}
-                      padding={0.25}
+                      gap={1}
+                      padding={1}
                       height="fit"
                     >
                       {topErrors.map((log, idx) => (
@@ -314,8 +314,8 @@ export default function HookStatusPopover({
                   flexDirection="column"
                   justifyContent="start"
                   alignItems="start"
-                  gap={0.25}
-                  padding={0.25}
+                  gap={1}
+                  padding={1}
                   height="fit"
                 >
                   {recentErrors.slice(0, 3).map((log, idx) => (

--- a/web/src/layouts/chromes/AdminChrome.tsx
+++ b/web/src/layouts/chromes/AdminChrome.tsx
@@ -54,7 +54,7 @@ export default function AdminChrome({ children }: AdminChromeProps) {
   if (isVectorDbRequiredRoute(pathname)) {
     if (isLoading) {
       content = (
-        <Section padding={2}>
+        <Section padding={8}>
           <SvgSimpleLoader className="h-6 w-6" />
         </Section>
       );

--- a/web/src/layouts/general-layouts.tsx
+++ b/web/src/layouts/general-layouts.tsx
@@ -33,12 +33,7 @@ function AttachmentItemLayout({
   rightChildren,
 }: AttachmentItemLayoutProps) {
   return (
-    <Section
-      flexDirection="row"
-      justifyContent="start"
-      gap={0.25}
-      padding={0.25}
-    >
+    <Section flexDirection="row" justifyContent="start" gap={1} padding={1}>
       <div className={cn("h-9 aspect-square rounded-08 shrink-0")}>
         <Section>
           <div
@@ -53,7 +48,7 @@ function AttachmentItemLayout({
         flexDirection="row"
         justifyContent="between"
         alignItems="center"
-        gap={1.5}
+        gap={6}
         className="min-w-0"
       >
         <div data-testid="attachment-item-title" className="flex-1 min-w-0">

--- a/web/src/refresh-components/buttons/LineItem.tsx
+++ b/web/src/refresh-components/buttons/LineItem.tsx
@@ -259,7 +259,7 @@ export default function LineItem({
       <Section alignItems="start" gap={0}>
         {children ? (
           <>
-            <Section flexDirection="row" gap={0.5}>
+            <Section flexDirection="row" gap={2}>
               <Truncated
                 mainUiMuted
                 className={cn("text-left w-full", textClassNames[variant])}
@@ -284,7 +284,7 @@ export default function LineItem({
               ))}
           </>
         ) : description ? (
-          <Section flexDirection="row" gap={0.5}>
+          <Section flexDirection="row" gap={2}>
             {wrapDescription ? (
               <Text as="p" secondaryBody text03 className="text-left w-full">
                 {description}

--- a/web/src/refresh-components/cards/Card.tsx
+++ b/web/src/refresh-components/cards/Card.tsx
@@ -66,7 +66,7 @@ export interface CardProps extends SectionProps {
 
 export default function Card({
   variant = "primary",
-  padding = 1,
+  padding = 4,
   className,
   ref,
   ...props

--- a/web/src/refresh-components/commandmenu/CommandMenu.tsx
+++ b/web/src/refresh-components/commandmenu/CommandMenu.tsx
@@ -458,12 +458,7 @@ function CommandMenuHeader({
     <div className="shrink-0">
       {/* Top row: Search icon, filters, close button */}
       <div className="px-3 pt-3 flex flex-row justify-between items-center">
-        <Section
-          flexDirection="row"
-          justifyContent="start"
-          gap={0.5}
-          width="fit"
-        >
+        <Section flexDirection="row" justifyContent="start" gap={2} width="fit">
           {/* Standalone search icon */}
           <SvgSearch className="w-6 h-6 stroke-text-04" />
           {filters.map((filter) => (
@@ -745,12 +740,7 @@ function CommandMenuAction({
 function CommandMenuFooter({ leftActions }: CommandMenuFooterProps) {
   return (
     <div className="shrink-0">
-      <Section
-        flexDirection="row"
-        justifyContent="start"
-        gap={1}
-        padding={0.75}
-      >
+      <Section flexDirection="row" justifyContent="start" gap={4} padding={3}>
         {leftActions}
       </Section>
     </div>

--- a/web/src/refresh-components/form/InputTypeInElementField.tsx
+++ b/web/src/refresh-components/form/InputTypeInElementField.tsx
@@ -32,7 +32,7 @@ export default function InputTypeInElementField({
     inputProps.variant === "disabled" || inputProps.variant === "readOnly";
 
   return (
-    <Section flexDirection="row" gap={0.25}>
+    <Section flexDirection="row" gap={1}>
       {/* Input */}
       <InputTypeIn
         {...inputProps}

--- a/web/src/refresh-components/inputs/InputDatePicker.tsx
+++ b/web/src/refresh-components/inputs/InputDatePicker.tsx
@@ -76,8 +76,8 @@ export default function InputDatePicker({
         </Button>
       </Popover.Trigger>
       <Popover.Content>
-        <Section padding={0.25}>
-          <Section flexDirection="row" gap={0.5}>
+        <Section padding={1}>
+          <Section flexDirection="row" gap={2}>
             <InputSelect
               value={`${extractYear(displayedMonth)}`}
               onValueChange={(value) => {

--- a/web/src/refresh-components/modals/MemoriesModal.tsx
+++ b/web/src/refresh-components/modals/MemoriesModal.tsx
@@ -86,8 +86,8 @@ function MemoryItem({
           "bg-action-selection-01 hover:bg-action-selection-01 border-action-selection-05 duration-700"
       )}
     >
-      <Section gap={0.25} alignItems="start">
-        <Section flexDirection="row" alignItems="start" gap={0.5}>
+      <Section gap={1} alignItems="start">
+        <Section flexDirection="row" alignItems="start" gap={2}>
           <InputTextArea
             ref={textareaRef}
             placeholder="Type or paste in a personal note or memory"
@@ -269,7 +269,7 @@ export default function MemoriesModal({
           description="Let Onyx reference these stored notes and memories in chats."
           onClose={close}
         >
-          <Section flexDirection="row" gap={0.5}>
+          <Section flexDirection="row" gap={2}>
             <InputTypeIn
               placeholder="Search..."
               value={searchQuery}
@@ -292,9 +292,9 @@ export default function MemoriesModal({
           </Section>
         </Modal.Header>
 
-        <Modal.Body padding={0.5}>
+        <Modal.Body padding={2}>
           {filteredMemories.length === 0 ? (
-            <Section alignItems="center" padding={2}>
+            <Section alignItems="center" padding={8}>
               <Text secondaryBody text03>
                 {searchQuery.trim()
                   ? "No memories match your search."
@@ -302,7 +302,7 @@ export default function MemoriesModal({
               </Text>
             </Section>
           ) : (
-            <Section gap={0.5}>
+            <Section gap={2}>
               {filteredMemories.map(({ memory, originalIndex }) => (
                 <Fragment key={memory.id}>
                   <MemoryItem

--- a/web/src/refresh-components/popovers/ActionsPopover/ActionLineItem.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/ActionLineItem.tsx
@@ -112,7 +112,7 @@ export default function ActionLineItem({
         strikethrough={disabled}
         icon={Icon}
         rightChildren={
-          <Section gap={0.25} flexDirection="row">
+          <Section gap={1} flexDirection="row">
             {!isUnavailable && tool?.oauth_config_id && toolAuthStatus && (
               <Button
                 icon={SvgKey}

--- a/web/src/refresh-components/popovers/ActionsPopover/MCPLineItem.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/MCPLineItem.tsx
@@ -102,7 +102,7 @@ export default function MCPLineItem({
       strikethrough={allToolsDisabled}
       selected={isActive}
       rightChildren={
-        <Section gap={0.25} flexDirection="row">
+        <Section gap={1} flexDirection="row">
           {isAuthenticated &&
             tools.length > 0 &&
             enabledTools.length > 0 &&

--- a/web/src/sections/actions/modals/AddMCPServerModal.tsx
+++ b/web/src/sections/actions/modals/AddMCPServerModal.tsx
@@ -206,12 +206,12 @@ export default function AddMCPServerModal({
                       flexDirection="row"
                       justifyContent="between"
                       alignItems="start"
-                      gap={1}
+                      gap={4}
                     >
-                      <Section gap={0.25} alignItems="start">
+                      <Section gap={1} alignItems="start">
                         <Section
                           flexDirection="row"
-                          gap={0.5}
+                          gap={2}
                           alignItems="center"
                           width="fit"
                         >
@@ -228,7 +228,7 @@ export default function AddMCPServerModal({
                       </Section>
                       <Section
                         flexDirection="row"
-                        gap={0.5}
+                        gap={2}
                         alignItems="center"
                         width="fit"
                       >

--- a/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
+++ b/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
@@ -300,7 +300,7 @@ function FormContent({
               />
             )}
             <Divider paddingParallel="fit" paddingPerpendicular="fit" />
-            <Section gap={0.5}>
+            <Section gap={2}>
               {methodSpecs.map((method) => (
                 <ToolItem
                   key={`${method.method}-${method.path}-${method.name}`}
@@ -329,12 +329,12 @@ function FormContent({
             flexDirection="row"
             justifyContent="between"
             alignItems="start"
-            gap={1}
+            gap={4}
           >
-            <Section gap={0.25} alignItems="start">
+            <Section gap={1} alignItems="start">
               <Section
                 flexDirection="row"
-                gap={0.5}
+                gap={2}
                 alignItems="center"
                 width="fit"
               >
@@ -353,7 +353,7 @@ function FormContent({
             </Section>
             <Section
               flexDirection="row"
-              gap={0.5}
+              gap={2}
               alignItems="center"
               width="fit"
             >

--- a/web/src/sections/admin/LiteModeIndexingNotice.tsx
+++ b/web/src/sections/admin/LiteModeIndexingNotice.tsx
@@ -12,7 +12,7 @@ const DEPLOYMENT_DOCS_URL = `${DOCS_BASE_URL}/deployment/getting_started/quickst
  */
 export default function LiteModeIndexingNotice() {
   return (
-    <Section padding={2}>
+    <Section padding={8}>
       <IllustrationContent
         illustration={SvgUnPlugged}
         title="Indexing is unavailable in Lite mode"

--- a/web/src/sections/admin/ProviderCard.tsx
+++ b/web/src/sections/admin/ProviderCard.tsx
@@ -156,11 +156,7 @@ export default function ProviderCard({
                 ) : undefined}
                 {(onDisconnect || onEdit) && (
                   <div className="px-1 pb-1">
-                    <Section
-                      flexDirection="row"
-                      justifyContent="end"
-                      gap={0.25}
-                    >
+                    <Section flexDirection="row" justifyContent="end" gap={1}>
                       {onDisconnect && (
                         <Hoverable.Item
                           group="ProviderCard"

--- a/web/src/sections/banners/BannerQueue.tsx
+++ b/web/src/sections/banners/BannerQueue.tsx
@@ -101,8 +101,8 @@ export default function BannerQueue() {
         alignItems="stretch"
         justifyContent="start"
         height="fit"
-        gap={0.25}
-        padding={0.25}
+        gap={1}
+        padding={1}
         className="rounded-12 border border-border-01 bg-background-neutral-00 shadow-box"
       >
         <Section
@@ -110,8 +110,8 @@ export default function BannerQueue() {
           alignItems="center"
           justifyContent="start"
           height="fit"
-          gap={0.25}
-          padding={0.375}
+          gap={1}
+          padding={1.5}
           className={cn("rounded-08", styles.headerBg)}
         >
           <Icon className={cn("h-5 w-5 shrink-0 p-0.5", styles.iconClass)} />
@@ -154,8 +154,8 @@ export default function BannerQueue() {
           alignItems="stretch"
           justifyContent="start"
           height="fit"
-          gap={0.25}
-          padding={0.5}
+          gap={1}
+          padding={2}
           className="rounded-08 bg-background-tint-01"
         >
           {current.description && (

--- a/web/src/sections/knowledge/AgentKnowledgePane.tsx
+++ b/web/src/sections/knowledge/AgentKnowledgePane.tsx
@@ -361,7 +361,7 @@ export default function AgentKnowledgePane({
 
       case "add":
         return (
-          <GeneralLayouts.Section gap={0.5} alignItems="stretch" height="auto">
+          <GeneralLayouts.Section gap={2} alignItems="stretch" height="auto">
             {vectorDbEnabled && (
               <KnowledgeSearchBar
                 query={searchQuery}
@@ -516,7 +516,7 @@ export default function AgentKnowledgePane({
   ]);
 
   return (
-    <GeneralLayouts.Section gap={0.5} alignItems="stretch" height="auto">
+    <GeneralLayouts.Section gap={2} alignItems="stretch" height="auto">
       <Content
         title="Knowledge"
         description="Add specific connectors and documents for this agent to use to inform its responses."
@@ -525,7 +525,7 @@ export default function AgentKnowledgePane({
       />
 
       <Card>
-        <GeneralLayouts.Section gap={0.5} alignItems="stretch" height="auto">
+        <GeneralLayouts.Section gap={2} alignItems="stretch" height="auto">
           <InputHorizontal
             title="Use Knowledge"
             description="Let this agent reference these documents to inform its responses."

--- a/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
+++ b/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
@@ -88,7 +88,7 @@ function HierarchyBreadcrumb({
       flexDirection="row"
       justifyContent="start"
       alignItems="center"
-      gap={0.25}
+      gap={1}
       height="auto"
     >
       {/* Root source link */}
@@ -719,7 +719,7 @@ export default function SourceHierarchyBrowser({
   // Render loading state
   if (isLoadingNodes) {
     return (
-      <GeneralLayouts.Section height="auto" padding={1}>
+      <GeneralLayouts.Section height="auto" padding={4}>
         <Text text03 secondaryBody>
           Loading folders...
         </Text>
@@ -730,7 +730,7 @@ export default function SourceHierarchyBrowser({
   // Render error state
   if (nodesError) {
     return (
-      <GeneralLayouts.Section height="auto" padding={1}>
+      <GeneralLayouts.Section height="auto" padding={4}>
         <Text text03 secondaryBody>
           {nodesError}
         </Text>
@@ -745,7 +745,7 @@ export default function SourceHierarchyBrowser({
         flexDirection="row"
         justifyContent="start"
         alignItems="center"
-        gap={0.5}
+        gap={2}
         height="auto"
       >
         <GeneralLayouts.Section height="auto" width="fit">
@@ -903,7 +903,7 @@ export default function SourceHierarchyBrowser({
         className="overflow-y-auto max-h-80"
       >
         {filteredItems.length === 0 && !isLoadingDocuments ? (
-          <GeneralLayouts.Section height="auto" padding={1}>
+          <GeneralLayouts.Section height="auto" padding={4}>
             <Text text03 secondaryBody>
               {path.length === 0
                 ? "Select a folder to browse documents."
@@ -935,7 +935,7 @@ export default function SourceHierarchyBrowser({
                         flexDirection="row"
                         justifyContent="start"
                         alignItems="center"
-                        gap={0.25}
+                        gap={1}
                         height="auto"
                       >
                         <GeneralLayouts.Section
@@ -996,7 +996,7 @@ export default function SourceHierarchyBrowser({
 
             {/* Loading more indicator */}
             {isLoadingDocuments && documents.length > 0 && (
-              <GeneralLayouts.Section height="auto" padding={0.5}>
+              <GeneralLayouts.Section height="auto" padding={2}>
                 <Text text03 secondaryBody>
                   Loading more...
                 </Text>
@@ -1014,7 +1014,7 @@ export default function SourceHierarchyBrowser({
             flexDirection="row"
             justifyContent="start"
             alignItems="center"
-            gap={0.5}
+            gap={2}
             height="auto"
           >
             <Text text03 secondaryBody>

--- a/web/src/sections/knowledge/agent-knowledge/KnowledgeAddView.tsx
+++ b/web/src/sections/knowledge/agent-knowledge/KnowledgeAddView.tsx
@@ -34,7 +34,7 @@ export const KnowledgeAddView = memo(function KnowledgeAddView({
 }: KnowledgeAddViewProps) {
   return (
     <GeneralLayouts.Section
-      gap={0.5}
+      gap={2}
       alignItems="start"
       height="auto"
       aria-label="knowledge-add-view"
@@ -42,7 +42,7 @@ export const KnowledgeAddView = memo(function KnowledgeAddView({
       <GeneralLayouts.Section
         flexDirection="row"
         justifyContent="start"
-        gap={0.5}
+        gap={2}
         height="auto"
         wrap
       >

--- a/web/src/sections/knowledge/agent-knowledge/KnowledgeSearch.tsx
+++ b/web/src/sections/knowledge/agent-knowledge/KnowledgeSearch.tsx
@@ -54,7 +54,7 @@ export function KnowledgeSearchBar({
     <GeneralLayouts.Section
       flexDirection="row"
       alignItems="center"
-      gap={0.25}
+      gap={1}
       height="auto"
     >
       {isSearchMode ? (
@@ -194,7 +194,7 @@ export function KnowledgeSearchResultsPanel({
       <GeneralLayouts.Section
         alignItems="center"
         justifyContent="center"
-        gap={0.5}
+        gap={2}
         aria-label="search-empty-state"
       >
         <SvgSearch size={32} className="stroke-text-04" />
@@ -224,7 +224,7 @@ export function KnowledgeSearchResultsPanel({
       <GeneralLayouts.Section
         alignItems="center"
         justifyContent="center"
-        gap={0.5}
+        gap={2}
         aria-label="search-error"
       >
         <Text secondaryBody text03>
@@ -249,7 +249,7 @@ export function KnowledgeSearchResultsPanel({
       <GeneralLayouts.Section
         alignItems="center"
         justifyContent="center"
-        gap={0.5}
+        gap={2}
         aria-label="search-no-results"
       >
         <Text secondaryBody text03>
@@ -303,7 +303,7 @@ export function KnowledgeSearchResultsPanel({
                       flexDirection="row"
                       justifyContent="start"
                       alignItems="center"
-                      gap={0.25}
+                      gap={1}
                       height="auto"
                     >
                       <SvgFolder size={16} />
@@ -368,7 +368,7 @@ export function KnowledgeSearchResultsPanel({
                     flexDirection="row"
                     justifyContent="start"
                     alignItems="center"
-                    gap={0.25}
+                    gap={1}
                     height="auto"
                   >
                     <SvgFileText size={16} />

--- a/web/src/sections/knowledge/agent-knowledge/KnowledgeTable.tsx
+++ b/web/src/sections/knowledge/agent-knowledge/KnowledgeTable.tsx
@@ -47,7 +47,7 @@ export function KnowledgeTable<T>({
         flexDirection="row"
         justifyContent="start"
         alignItems="center"
-        gap={0.5}
+        gap={2}
         height="auto"
       >
         {onSearchChange !== undefined && (
@@ -80,7 +80,7 @@ export function KnowledgeTable<T>({
               flexDirection="row"
               justifyContent="start"
               alignItems="center"
-              gap={0.25}
+              gap={1}
               height="auto"
             >
               <Text secondaryBody text03>
@@ -94,7 +94,7 @@ export function KnowledgeTable<T>({
       <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
       {items.length === 0 ? (
-        <GeneralLayouts.Section height="auto" padding={1}>
+        <GeneralLayouts.Section height="auto" padding={4}>
           <Text text03 secondaryBody>
             {emptyMessage}
           </Text>

--- a/web/src/sections/knowledge/agent-knowledge/KnowledgeTableContent.tsx
+++ b/web/src/sections/knowledge/agent-knowledge/KnowledgeTableContent.tsx
@@ -124,7 +124,7 @@ export function SourcesTableContent({
   initialNodeId,
 }: SourcesTableContentProps) {
   return (
-    <GeneralLayouts.Section gap={0.5} alignItems="stretch">
+    <GeneralLayouts.Section gap={2} alignItems="stretch">
       <SourceHierarchyBrowser
         source={source}
         selectedDocumentIds={selectedDocumentIds}
@@ -196,7 +196,7 @@ export function RecentFilesTableContent({
   const fileInputRef = React.useRef<HTMLInputElement>(null);
 
   return (
-    <GeneralLayouts.Section gap={0.5} alignItems="stretch">
+    <GeneralLayouts.Section gap={2} alignItems="stretch">
       <TableLayouts.HiddenInput
         inputRef={fileInputRef}
         type="file"

--- a/web/src/sections/knowledge/agent-knowledge/KnowledgeTwoColumnView.tsx
+++ b/web/src/sections/knowledge/agent-knowledge/KnowledgeTwoColumnView.tsx
@@ -119,7 +119,7 @@ export const KnowledgeTwoColumnView = memo(function KnowledgeTwoColumnView({
   searchNavigateNodeId,
 }: KnowledgeTwoColumnViewProps) {
   return (
-    <GeneralLayouts.Section gap={0.5} alignItems="stretch" height="auto">
+    <GeneralLayouts.Section gap={2} alignItems="stretch" height="auto">
       {vectorDbEnabled && (
         <KnowledgeSearchBar
           query={searchQuery}

--- a/web/src/sections/modals/AgentViewerModal.tsx
+++ b/web/src/sections/modals/AgentViewerModal.tsx
@@ -62,7 +62,7 @@ function ViewerMCPServerCard({ server, tools }: ViewerMCPServerCardProps) {
         tools.length > 0 ? (
           <div className="flex flex-col gap-2 p-2">
             {tools.map((tool) => (
-              <Section key={tool.id} padding={0.25}>
+              <Section key={tool.id} padding={1}>
                 <Content
                   title={tool.display_name}
                   description={tool.description}
@@ -282,7 +282,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
 
           {/* Knowledge */}
           <Divider paddingParallel="fit" paddingPerpendicular="fit" />
-          <Section gap={0.5} alignItems="start">
+          <Section gap={2} alignItems="start">
             <Content
               title="Knowledge"
               sizePreset="main-content"
@@ -290,7 +290,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
             />
             {hasKnowledge ? (
               <Section
-                gap={0.5}
+                gap={2}
                 flexDirection="row"
                 justifyContent="start"
                 wrap
@@ -315,7 +315,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
             <SimpleCollapsible.Header title="Actions & Tools" />
             <SimpleCollapsible.Content>
               {hasActions ? (
-                <Section gap={0.5} alignItems="start">
+                <Section gap={2} alignItems="start">
                   {mcpServersWithTools.map(({ server, tools }) => (
                     <ViewerMCPServerCard
                       key={server.id}
@@ -338,7 +338,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
           <SimpleCollapsible>
             <SimpleCollapsible.Header title="More Info" />
             <SimpleCollapsible.Content>
-              <Section gap={0.5} alignItems="start">
+              <Section gap={2} alignItems="start">
                 {agent.system_prompt && (
                   <Content
                     title="Instructions"

--- a/web/src/sections/modals/PreviewModal/PreviewModal.tsx
+++ b/web/src/sections/modals/PreviewModal/PreviewModal.tsx
@@ -221,7 +221,7 @@ export default function PreviewModal({
               <SvgSimpleLoader className="h-8 w-8" />
             </Section>
           ) : loadError ? (
-            <Section padding={1}>
+            <Section padding={4}>
               <Text text03 mainUiBody>
                 {loadError}
               </Text>

--- a/web/src/sections/modals/PreviewModal/variants/csvVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/csvVariant.tsx
@@ -43,7 +43,7 @@ export const csvVariant: PreviewVariant = {
     if (!ctx.fileContent) return null;
     const { headers, rows } = parseCsv(ctx.fileContent);
     return (
-      <Section justifyContent="start" alignItems="start" padding={1}>
+      <Section justifyContent="start" alignItems="start" padding={4}>
         <Table>
           <TableHeader className="sticky top-0 z-sticky bg-background-tint-01">
             <TableRow noHover>

--- a/web/src/sections/modals/PreviewModal/variants/docxVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/docxVariant.tsx
@@ -107,7 +107,7 @@ function DocxPreview({ fileUrl, onLoad }: DocxPreviewProps) {
 
   if (error) {
     return (
-      <Section justifyContent="center" alignItems="center" padding={1.5}>
+      <Section justifyContent="center" alignItems="center" padding={6}>
         <Text text03 mainUiBody>
           {error}
         </Text>
@@ -160,7 +160,7 @@ export const docxVariant: PreviewVariant = {
     if (isLegacyDoc(ctx.fileName)) {
       lastDocxResult = null;
       return (
-        <Section justifyContent="center" alignItems="center" padding={1.5}>
+        <Section justifyContent="center" alignItems="center" padding={6}>
           <Text text03 mainUiBody>
             Legacy .doc format cannot be previewed. Download the file to view
             it.

--- a/web/src/sections/modals/PreviewModal/variants/xlsxVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/xlsxVariant.tsx
@@ -38,7 +38,7 @@ export const xlsxVariant: PreviewVariant = {
     const preview = parseSpreadsheetPreview(ctx.fileContent);
     if (!preview || preview.sheets.length === 0) {
       return (
-        <Section padding={1}>
+        <Section padding={4}>
           <Text as="p" font="main-ui-body" color="text-03">
             Unable to preview this spreadsheet.
           </Text>

--- a/web/src/sections/modals/ShareChatSessionModal.tsx
+++ b/web/src/sections/modals/ShareChatSessionModal.tsx
@@ -182,7 +182,7 @@ export default function ShareChatSessionModal({
             justifyContent="start"
             alignItems="stretch"
             height="auto"
-            gap={0.25}
+            gap={1}
           >
             <PrivacyOption
               icon={SvgLock}

--- a/web/src/sections/modals/SkillPreviewModal.tsx
+++ b/web/src/sections/modals/SkillPreviewModal.tsx
@@ -97,7 +97,7 @@ export default function SkillPreviewModal({
           )}
 
           {preview && !isLoading && !error && (
-            <Section gap={1} alignItems="stretch">
+            <Section gap={4} alignItems="stretch">
               {displayedUnavailableReason && (
                 <MessageCard
                   variant="warning"
@@ -119,7 +119,7 @@ export default function SkillPreviewModal({
                 ))}
               </div>
 
-              <Section gap={0.25} alignItems="stretch">
+              <Section gap={1} alignItems="stretch">
                 <div className="flex items-center justify-between gap-2">
                   <Text font="main-ui-action" color="text-05">
                     Instructions

--- a/web/src/sections/modals/UserFilesModal.tsx
+++ b/web/src/sections/modals/UserFilesModal.tsx
@@ -178,7 +178,7 @@ export default function UserFilesModal({
         >
           <Modal.Header icon={SvgFiles} title={title} description={description}>
             {/* Search bar section */}
-            <Section flexDirection="row" gap={0.5}>
+            <Section flexDirection="row" gap={2}>
               <InputTypeIn
                 ref={searchInputRef}
                 placeholder="Search files..."
@@ -205,7 +205,7 @@ export default function UserFilesModal({
 
           <Modal.Body
             padding={filtered.length === 0 ? 0.5 : 0}
-            gap={0.5}
+            gap={2}
             alignItems="center"
           >
             {/* File display section */}
@@ -263,7 +263,7 @@ export default function UserFilesModal({
           <Modal.Footer>
             {/* Left side: file count and controls */}
             {onPickRecent && (
-              <Section flexDirection="row" justifyContent="start" gap={0.5}>
+              <Section flexDirection="row" justifyContent="start" gap={2}>
                 <Text as="p" text03>
                   {selectedCount} {selectedCount === 1 ? "file" : "files"}{" "}
                   selected

--- a/web/src/sections/modals/UserFilesModal.tsx
+++ b/web/src/sections/modals/UserFilesModal.tsx
@@ -204,7 +204,7 @@ export default function UserFilesModal({
           </Modal.Header>
 
           <Modal.Body
-            padding={filtered.length === 0 ? 0.5 : 0}
+            padding={filtered.length === 0 ? 2 : 0}
             gap={2}
             alignItems="center"
           >

--- a/web/src/sections/modals/languageModels/BedrockModal.tsx
+++ b/web/src/sections/modals/languageModels/BedrockModal.tsx
@@ -129,7 +129,7 @@ function BedrockModalInternals({
   return (
     <>
       <InputPadder>
-        <Section gap={1}>
+        <Section gap={4}>
           <InputVertical
             withLabel={FIELD_AWS_REGION_NAME}
             title="AWS Region"
@@ -181,7 +181,7 @@ function BedrockModalInternals({
 
       {authMethod === AUTH_METHOD_ACCESS_KEY && (
         <Card background="light" border="none" padding="sm">
-          <Section gap={1}>
+          <Section gap={4}>
             <InputVertical
               withLabel={FIELD_AWS_ACCESS_KEY_ID}
               title="AWS Access Key ID"
@@ -215,7 +215,7 @@ function BedrockModalInternals({
 
       {authMethod === AUTH_METHOD_LONG_TERM_API_KEY && (
         <Card background="light" border="none" padding="sm">
-          <Section gap={0.5}>
+          <Section gap={2}>
             <InputVertical
               withLabel={FIELD_AWS_BEARER_TOKEN_BEDROCK}
               title="Long-term API Key"

--- a/web/src/sections/modals/languageModels/CustomModal.tsx
+++ b/web/src/sections/modals/languageModels/CustomModal.tsx
@@ -408,7 +408,7 @@ export default function CustomModal({
       </InputPadder>
 
       <InputPadder>
-        <Section gap={0.75}>
+        <Section gap={3}>
           <Content
             title="Environment Variables"
             description={markdown(
@@ -431,7 +431,7 @@ export default function CustomModal({
       )}
 
       <InputDivider />
-      <Section gap={0.5}>
+      <Section gap={2}>
         <InputPadder>
           <Content
             title="Models"

--- a/web/src/sections/modals/languageModels/VertexAIModal.tsx
+++ b/web/src/sections/modals/languageModels/VertexAIModal.tsx
@@ -79,7 +79,7 @@ function VertexAIModalInternals({
   return (
     <>
       <InputPadder>
-        <Section gap={1}>
+        <Section gap={4}>
           {showAuthMethodSelector && (
             <InputVertical
               withLabel={FIELD_VERTEX_AUTH_METHOD}

--- a/web/src/sections/modals/languageModels/shared.tsx
+++ b/web/src/sections/modals/languageModels/shared.tsx
@@ -293,7 +293,7 @@ export function ModelAccessField() {
 
       {!isPublic && (
         <Card background="light" border="none" padding="sm">
-          <Section gap={0.5}>
+          <Section gap={2}>
             <InputComboBox
               placeholder="Add groups and agents"
               value=""
@@ -675,7 +675,7 @@ export function ModelSelectionField({
 
   return (
     <Card background="light" border="none" padding="sm">
-      <Section gap={0.5}>
+      <Section gap={2}>
         <InputHorizontal
           title="Models"
           description="Select models to make available for this provider."
@@ -700,7 +700,7 @@ export function ModelSelectionField({
             padding="sm"
           />
         ) : (
-          <Section gap={0.25} alignItems="stretch">
+          <Section gap={1} alignItems="stretch">
             {(() => {
               const baseModels = isAutoMode ? visibleModels : models;
               // Sort alphabetically by id for providers that ship rich model
@@ -760,7 +760,7 @@ export function ModelSelectionField({
         )}
 
         {onAddModel && !isAutoMode && (
-          <Section flexDirection="row" gap={0.5}>
+          <Section flexDirection="row" gap={2}>
             <div className="flex-1">
               <InputTypeIn
                 placeholder="Enter model name"
@@ -930,7 +930,7 @@ function ModalWrapperInner({
             description={description}
             onClose={onClose}
           />
-          <Modal.Body padding={0.5} gap={0}>
+          <Modal.Body padding={2} gap={0}>
             {children}
           </Modal.Body>
           <Modal.Footer>

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -240,16 +240,16 @@ function SettingRow({
         alignItems="stretch"
         height="auto"
         gap={0}
-        padding={0.375}
+        padding={1.5}
         className="rounded-08"
       >
         <Section
           flexDirection="row"
           justifyContent="between"
           height="auto"
-          gap={0.5}
+          gap={2}
         >
-          <Section flexDirection="row" width="fit" height="auto" gap={0.5}>
+          <Section flexDirection="row" width="fit" height="auto" gap={2}>
             <Section width={1.25} height={1.25} className="text-text-04">
               <Icon size={16} />
             </Section>
@@ -622,7 +622,7 @@ export default function ModelSelectorContent({
   }
 
   return (
-    <Section gap={0.5}>
+    <Section gap={2}>
       <InputTypeIn
         searchIcon
         variant="internal"
@@ -665,11 +665,7 @@ export default function ModelSelectorContent({
                 ]
               : groupedOptions.length === 1
                 ? [
-                    <Section
-                      key="single-provider"
-                      gap={0.25}
-                      alignItems="stretch"
-                    >
+                    <Section key="single-provider" gap={1} alignItems="stretch">
                       {groupedOptions[0]!.options.map(renderModelItem)}
                     </Section>,
                   ]
@@ -723,7 +719,7 @@ export default function ModelSelectorContent({
                         </CollapsibleTrigger>
 
                         <CollapsibleContent>
-                          <Section gap={0.25} alignItems="stretch">
+                          <Section gap={1} alignItems="stretch">
                             {group.options.map(renderModelItem)}
                           </Section>
                         </CollapsibleContent>

--- a/web/src/sections/onboarding/components/OnboardingHeader.tsx
+++ b/web/src/sections/onboarding/components/OnboardingHeader.tsx
@@ -39,7 +39,7 @@ const OnboardingHeader = React.memo(
     }
 
     return (
-      <Card padding={0.5} data-label="onboarding-header">
+      <Card padding={2} data-label="onboarding-header">
         <ContentAction
           icon={(props) => (
             <SvgProgressCircle value={iconPercentage} {...props} />

--- a/web/src/sections/onboarding/steps/FinalStep.tsx
+++ b/web/src/sections/onboarding/steps/FinalStep.tsx
@@ -23,7 +23,7 @@ const FinalStepItem = React.memo(
       : {};
 
     return (
-      <Card padding={0.25} variant="secondary">
+      <Card padding={1} variant="secondary">
         <ContentAction
           icon={Icon}
           title={title}
@@ -47,7 +47,7 @@ FinalStepItem.displayName = "FinalStepItem";
 
 export default function FinalStep() {
   return (
-    <Section gap={0.5}>
+    <Section gap={2}>
       {FINAL_SETUP_CONFIG.map((item) => (
         <FinalStepItem key={item.title} {...item} />
       ))}

--- a/web/src/sections/sidebar/AccountPopover.tsx
+++ b/web/src/sections/sidebar/AccountPopover.tsx
@@ -246,7 +246,7 @@ export default function AccountPopover({
             )}
             rightChildren={
               undismissedCount ? (
-                <Section padding={0.5}>
+                <Section padding={2}>
                   <SvgNotificationBubble count={undismissedCount} />
                 </Section>
               ) : undefined

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -72,7 +72,7 @@ function NotificationItem({
         onClick={onClick}
         rightChildren={
           <Section justifyContent="start">
-            <Section height="fit" gap={0.5} flexDirection="row">
+            <Section height="fit" gap={2} flexDirection="row">
               <Text font="secondary-body" color="text-02">
                 {timeAgo(notification.first_shown) ?? ""}
               </Text>
@@ -298,8 +298,8 @@ export default function NotificationsPopover({
 
   return (
     <Section gap={0} justifyContent="start" alignItems="stretch">
-      <Section flexDirection="row" padding={0.325}>
-        <Section flexDirection="row" gap={0.25} justifyContent="start">
+      <Section flexDirection="row" padding={1.5}>
+        <Section flexDirection="row" gap={1} justifyContent="start">
           <Button
             icon={SvgChevronLeft}
             size="sm"
@@ -309,7 +309,7 @@ export default function NotificationsPopover({
           <Text color="text-02">Notifications</Text>
         </Section>
 
-        <Section flexDirection="row" gap={0.25} justifyContent="end">
+        <Section flexDirection="row" gap={1} justifyContent="end">
           {undismissedCount !== 0 && (
             <span className="text-action-selection-05 font-secondary-body">
               {`${undismissedCount} unread`}

--- a/web/src/sections/usage/SpendByUserTable.tsx
+++ b/web/src/sections/usage/SpendByUserTable.tsx
@@ -186,7 +186,7 @@ export default function SpendByUserTable({
       flexDirection="column"
       justifyContent="start"
       alignItems="stretch"
-      gap={0.5}
+      gap={2}
       width="full"
       height="fit"
     >

--- a/web/src/sections/usage/UserUsageDetailModal.tsx
+++ b/web/src/sections/usage/UserUsageDetailModal.tsx
@@ -90,7 +90,7 @@ function BreakdownList({ title, slices, totalCostCents }: BreakdownListProps) {
       flexDirection="column"
       justifyContent="start"
       alignItems="stretch"
-      gap={0.5}
+      gap={2}
       width="full"
       height="fit"
     >
@@ -101,7 +101,7 @@ function BreakdownList({ title, slices, totalCostCents }: BreakdownListProps) {
         flexDirection="column"
         justifyContent="start"
         alignItems="stretch"
-        gap={0.625}
+        gap={2.5}
         width="full"
         height="fit"
       >
@@ -114,7 +114,7 @@ function BreakdownList({ title, slices, totalCostCents }: BreakdownListProps) {
               flexDirection="column"
               justifyContent="start"
               alignItems="stretch"
-              gap={0.25}
+              gap={1}
               width="full"
               height="fit"
             >
@@ -157,7 +157,7 @@ function DailySpendStrip({ days }: { days: DailySpend[] }) {
       flexDirection="column"
       justifyContent="start"
       alignItems="stretch"
-      gap={0.25}
+      gap={1}
       width="full"
       height="fit"
     >
@@ -175,7 +175,7 @@ function DailySpendStrip({ days }: { days: DailySpend[] }) {
         flexDirection="row"
         justifyContent="start"
         alignItems="end"
-        gap={0.125}
+        gap={0.5}
         width="full"
         height={3.5}
       >
@@ -260,7 +260,7 @@ export default function UserUsageDetailModal({
           onClose={() => onOpenChange(false)}
         />
         <Modal.Body>
-          <Section alignItems="stretch" height="auto" gap={1.5}>
+          <Section alignItems="stretch" height="auto" gap={6}>
             <div className="flex flex-wrap gap-2">
               <div className="basis-1/2 sm:basis-1/4">
                 <StatCell label="Spend" value={formatCost(totals.cost_cents)} />

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -333,14 +333,14 @@ function MCPServerCard({
   if (isLoading) {
     cardContent = (
       <div className="flex flex-col gap-2 p-2">
-        <GeneralLayouts.Section padding={1}>
+        <GeneralLayouts.Section padding={4}>
           <SvgSimpleLoader />
         </GeneralLayouts.Section>
       </div>
     );
   } else if (hasTools) {
     cardContent = (
-      <GeneralLayouts.Section gap={0.5} padding={0.5} alignItems="stretch">
+      <GeneralLayouts.Section gap={2} padding={2} alignItems="stretch">
         {filteredTools.map((tool) => {
           const toolDisabled =
             !tool.isAvailable ||
@@ -385,7 +385,7 @@ function MCPServerCard({
       >
         <CardLayout.Header
           bottomChildren={
-            <GeneralLayouts.Section flexDirection="row" gap={0.5}>
+            <GeneralLayouts.Section flexDirection="row" gap={2}>
               <InputTypeIn
                 placeholder="Search tools..."
                 variant="internal"
@@ -416,7 +416,7 @@ function MCPServerCard({
               rightChildren={
                 <GeneralLayouts.Section
                   flexDirection="row"
-                  gap={0.5}
+                  gap={2}
                   alignItems="start"
                 >
                   <EnabledCount
@@ -471,7 +471,7 @@ function AgentStarterMessages() {
   return (
     <FieldArray name="starter_messages">
       {(arrayHelpers) => (
-        <GeneralLayouts.Section gap={0.5}>
+        <GeneralLayouts.Section gap={2}>
           {Array.from({ length: visibleCount }, (_, i) => (
             <InputTypeInElementField
               key={`starter_messages.${i}`}
@@ -1304,7 +1304,7 @@ export default function AgentEditorPage({
                       }
                       onClose={() => deleteAgentModal.toggle(false)}
                     >
-                      <GeneralLayouts.Section alignItems="start" gap={0.5}>
+                      <GeneralLayouts.Section alignItems="start" gap={2}>
                         <Text>
                           Anyone using this agent will no longer be able to
                           access it. Deletion cannot be undone.
@@ -1373,7 +1373,7 @@ export default function AgentEditorPage({
 
                       <GeneralLayouts.Section
                         flexDirection="row"
-                        gap={2.5}
+                        gap={10}
                         alignItems="start"
                       >
                         <GeneralLayouts.Section>
@@ -1491,7 +1491,7 @@ export default function AgentEditorPage({
                       />
 
                       <GeneralLayouts.Section
-                        gap={0.5}
+                        gap={2}
                         alignItems="stretch"
                         height="auto"
                       >
@@ -1539,7 +1539,7 @@ export default function AgentEditorPage({
                               </>
                             )}
                             <GeneralLayouts.Section
-                              gap={0.25}
+                              gap={1}
                               alignItems="stretch"
                             >
                               <InputChipField
@@ -1591,10 +1591,7 @@ export default function AgentEditorPage({
                           description="Tools and capabilities available for this agent to use."
                         />
                         <SimpleCollapsible.Content>
-                          <GeneralLayouts.Section
-                            gap={0.5}
-                            alignItems="stretch"
-                          >
+                          <GeneralLayouts.Section gap={2} alignItems="stretch">
                             <Disabled
                               disabled={!isImageGenerationAvailable}
                               tooltip={imageGenerationDisabledTooltip}
@@ -1692,7 +1689,7 @@ export default function AgentEditorPage({
                               {/* MCP tools */}
                               {mcpServersWithVisibleTools.length > 0 && (
                                 <GeneralLayouts.Section
-                                  gap={0.5}
+                                  gap={2}
                                   alignItems="stretch"
                                 >
                                   {mcpServersWithVisibleTools.map(
@@ -1710,7 +1707,7 @@ export default function AgentEditorPage({
 
                               {/* OpenAPI tools */}
                               {openApiTools.length > 0 && (
-                                <GeneralLayouts.Section gap={0.5}>
+                                <GeneralLayouts.Section gap={2}>
                                   {openApiTools.map((tool) => (
                                     <OpenApiToolCard
                                       key={tool.id}
@@ -1780,7 +1777,7 @@ export default function AgentEditorPage({
                               </GeneralLayouts.Section>
                             </Card>
 
-                            <GeneralLayouts.Section gap={0.25}>
+                            <GeneralLayouts.Section gap={1}>
                               <InputVertical
                                 withLabel="reminders"
                                 title="Reminders"

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -855,7 +855,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                       <Section
                         flexDirection="column"
                         alignItems="center"
-                        gap={1}
+                        gap={4}
                       >
                         <IllustrationContent
                           illustration={

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -284,7 +284,7 @@ function PATModal({
         </Button>
       }
     >
-      <Section gap={1}>
+      <Section gap={4}>
         <InputVertical title="Token Name" withLabel>
           <InputTypeIn
             placeholder="Name your token"
@@ -452,7 +452,7 @@ function GeneralSettings() {
             </Button>
           }
         >
-          <Section gap={0.5} alignItems="start">
+          <Section gap={2} alignItems="start">
             <Text color="text-05">
               All your chat sessions and history will be permanently deleted.
               Deletion cannot be undone.
@@ -464,8 +464,8 @@ function GeneralSettings() {
         </ConfirmationModalLayout>
       )}
 
-      <Section gap={2}>
-        <Section gap={0.75}>
+      <Section gap={8}>
+        <Section gap={3}>
           <Content
             title="Profile"
             sizePreset="main-content"
@@ -530,7 +530,7 @@ function GeneralSettings() {
           </Card>
         </Section>
 
-        <Section gap={0.75}>
+        <Section gap={3}>
           <Content
             title="Appearance"
             sizePreset="main-content"
@@ -637,7 +637,7 @@ function GeneralSettings() {
 
         <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
-        <Section gap={0.75}>
+        <Section gap={3}>
           <Content
             title="Danger Zone"
             sizePreset="main-content"
@@ -867,7 +867,7 @@ function PromptShortcuts() {
   return (
     <>
       {shortcuts.length > 0 && (
-        <Section gap={0.75}>
+        <Section gap={3}>
           {shortcuts.map((shortcut, index) => {
             const isEmpty = !shortcut.prompt.trim() && !shortcut.content.trim();
             const isExisting = !shortcut.isNew;
@@ -1028,8 +1028,8 @@ function ChatPreferencesSettings() {
   );
 
   return (
-    <Section gap={2}>
-      <Section gap={0.75}>
+    <Section gap={8}>
+      <Section gap={3}>
         <Content
           title="Chats"
           sizePreset="main-content"
@@ -1150,7 +1150,7 @@ function ChatPreferencesSettings() {
         </Card>
       </Section>
 
-      <Section gap={0.75}>
+      <Section gap={3}>
         <InputVertical
           title="Personal Preferences"
           description="Provide your custom preferences in natural language."
@@ -1218,7 +1218,7 @@ function ChatPreferencesSettings() {
         </Card>
       </Section>
 
-      <Section gap={0.75}>
+      <Section gap={3}>
         <Content
           title="Prompt Shortcuts"
           sizePreset="main-content"
@@ -1243,7 +1243,7 @@ function ChatPreferencesSettings() {
         </Card>
       </Section>
 
-      <Section gap={0.75}>
+      <Section gap={3}>
         <Content
           title="Voice"
           sizePreset="main-content"
@@ -1559,7 +1559,7 @@ function AccountsAccessSettings() {
             </Button>
           }
         >
-          <Section gap={0.5} alignItems="start">
+          <Section gap={2} alignItems="start">
             <Text color="text-05">
               {`Any application using the token ${tokenToDelete.name} (${tokenToDelete.token_display}) will lose access to Onyx. This action cannot be undone.`}
             </Text>
@@ -1616,8 +1616,8 @@ function AccountsAccessSettings() {
                   setShowPasswordModal(false);
                 }}
               >
-                <Section gap={1}>
-                  <Section gap={0.25} alignItems="start">
+                <Section gap={4}>
+                  <Section gap={1} alignItems="start">
                     <InputVertical
                       withLabel="currentPassword"
                       title="Current Password"
@@ -1633,7 +1633,7 @@ function AccountsAccessSettings() {
                       />
                     </InputVertical>
                   </Section>
-                  <Section gap={0.25} alignItems="start">
+                  <Section gap={1} alignItems="start">
                     <InputVertical withLabel="newPassword" title="New Password">
                       <PasswordInputTypeIn
                         name="newPassword"
@@ -1644,7 +1644,7 @@ function AccountsAccessSettings() {
                       />
                     </InputVertical>
                   </Section>
-                  <Section gap={0.25} alignItems="start">
+                  <Section gap={1} alignItems="start">
                     <InputVertical
                       withLabel="confirmPassword"
                       title="Confirm New Password"
@@ -1667,8 +1667,8 @@ function AccountsAccessSettings() {
         </Formik>
       )}
 
-      <Section gap={2}>
-        <Section gap={0.75}>
+      <Section gap={8}>
+        <Section gap={3}>
           <Content
             title="Accounts"
             sizePreset="main-content"
@@ -1704,7 +1704,7 @@ function AccountsAccessSettings() {
         </Section>
 
         {showTokensSection && (
-          <Section gap={0.75}>
+          <Section gap={3}>
             <Content
               title="Access Tokens"
               sizePreset="main-content"
@@ -1712,12 +1712,12 @@ function AccountsAccessSettings() {
               width="full"
             />
             {canCreateTokens ? (
-              <Card padding={0.25}>
+              <Card padding={1}>
                 <Section gap={0}>
-                  <Section flexDirection="row" padding={0.25} gap={0.5}>
+                  <Section flexDirection="row" padding={1} gap={2}>
                     {pats.length === 0 ? (
                       <Section
-                        padding={0.5}
+                        padding={2}
                         alignItems="start"
                         data-testid="access-token-list-status"
                       >
@@ -1748,7 +1748,7 @@ function AccountsAccessSettings() {
                     </div>
                   </Section>
 
-                  <Section gap={0.25}>
+                  <Section gap={1}>
                     {filteredPats.map((pat) => {
                       const now = new Date();
                       const createdDate = new Date(pat.created_at);
@@ -1907,7 +1907,7 @@ function FederatedConnectorCard({
             </Button>
           }
         >
-          <Section gap={0.5} alignItems="start">
+          <Section gap={2} alignItems="start">
             <Text color="text-05">
               {`Onyx will no longer be able to access or search content from your ${sourceMetadata.displayName} account.`}
             </Text>
@@ -1918,7 +1918,7 @@ function FederatedConnectorCard({
         </ConfirmationModalLayout>
       )}
 
-      <Card padding={0.5}>
+      <Card padding={2}>
         <ContentAction
           icon={sourceMetadata.icon}
           title={sourceMetadata.displayName}
@@ -1994,8 +1994,8 @@ function ConnectorsSettings() {
     Object.keys(groupedConnectors).length > 0 || federatedConnectors.length > 0;
 
   return (
-    <Section gap={2}>
-      <Section gap={0.75} justifyContent="start">
+    <Section gap={8}>
+      <Section gap={3} justifyContent="start">
         <Content
           title="Connectors"
           sizePreset="main-content"

--- a/web/src/views/SkillEditorPage.tsx
+++ b/web/src/views/SkillEditorPage.tsx
@@ -550,9 +550,9 @@ export default function SkillEditorPage({
 
               {isCreating && !creationDraft && (
                 <>
-                  <Section gap={0.5} alignItems="stretch" height="auto">
+                  <Section gap={2} alignItems="stretch" height="auto">
                     <Card border="solid" rounding="lg" padding="sm">
-                      <Section gap={0.5} alignItems="stretch" height="auto">
+                      <Section gap={2} alignItems="stretch" height="auto">
                         <Content
                           title="Have an existing skill?"
                           description="Import a SKILL.md, ZIP, or skill folder to prefill the form and include its files."
@@ -682,7 +682,7 @@ export default function SkillEditorPage({
 
               <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
-              <Section gap={0.5} alignItems="stretch" height="auto">
+              <Section gap={2} alignItems="stretch" height="auto">
                 <Content
                   title="Supporting files"
                   description="Add references, scripts, assets, or other files used by this skill. ZIP files are unpacked automatically."
@@ -729,7 +729,7 @@ export default function SkillEditorPage({
                 <>
                   <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
-                  <Section gap={0.5} alignItems="stretch" height="auto">
+                  <Section gap={2} alignItems="stretch" height="auto">
                     <Content
                       title="Management"
                       description="Control who can use this skill."

--- a/web/src/views/admin/AgentsPage/AgentsTable.tsx
+++ b/web/src/views/admin/AgentsPage/AgentsTable.tsx
@@ -144,14 +144,14 @@ export default function AgentsTable() {
 
   return (
     <div className="flex flex-col">
-      <Section gap={0.5}>
+      <Section gap={2}>
         <InputTypeIn
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
           placeholder="Search agents..."
           searchIcon
         />
-        <Section gap={0.25} flexDirection="row" justifyContent="start">
+        <Section gap={1} flexDirection="row" justifyContent="start">
           {filterBar}
         </Section>
       </Section>

--- a/web/src/views/admin/ChatPreferencesPage.tsx
+++ b/web/src/views/admin/ChatPreferencesPage.tsx
@@ -131,7 +131,7 @@ function MCPServerCard({
       padding="sm"
       expandedContent={
         hasContent ? (
-          <Section gap={0.5} padding={0.5}>
+          <Section gap={2} padding={2}>
             {filteredTools.map((tool) => (
               <Card key={tool.id} border="solid" rounding="md">
                 <InputHorizontal
@@ -159,7 +159,7 @@ function MCPServerCard({
       <CardLayout.Header
         bottomChildren={
           tools.length > 0 ? (
-            <Section flexDirection="row" gap={0.5}>
+            <Section flexDirection="row" gap={2}>
               <InputTypeIn
                 placeholder="Search tools..."
                 variant="internal"
@@ -586,7 +586,7 @@ function RetentionField({ value, disabled, onSave }: RetentionFieldProps) {
               disabled ? "disabled" : customInvalid ? "error" : undefined
             }
             rightChildren={
-              <Section flexDirection="row" gap={0.125} width="fit" height="fit">
+              <Section flexDirection="row" gap={0.5} width="fit" height="fit">
                 <Button
                   icon={SvgRevert}
                   tooltip="Restore Default"
@@ -1054,7 +1054,7 @@ export default function ChatPreferencesPage() {
           <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
           {/* Team Context */}
-          <Section gap={1}>
+          <Section gap={4}>
             <InputVertical
               title="Team Name"
               subDescription="This is added to all chat sessions as additional context to provide a richer/customized experience."
@@ -1116,9 +1116,9 @@ export default function ChatPreferencesPage() {
 
           <Disabled disabled={s.disable_default_assistant ?? false}>
             <div>
-              <Section gap={1.5}>
+              <Section gap={6}>
                 {/* Connectors */}
-                <Section gap={0.75}>
+                <Section gap={3}>
                   <Content
                     title="Connectors"
                     sizePreset="main-content"
@@ -1129,7 +1129,7 @@ export default function ChatPreferencesPage() {
                     flexDirection="row"
                     justifyContent="between"
                     alignItems="center"
-                    gap={0.25}
+                    gap={1}
                   >
                     {uniqueSources.length === 0 ? (
                       <EmptyMessageCard
@@ -1142,7 +1142,7 @@ export default function ChatPreferencesPage() {
                           flexDirection="row"
                           justifyContent="start"
                           alignItems="center"
-                          gap={0.25}
+                          gap={1}
                         >
                           {uniqueSources.slice(0, 3).map((source) => {
                             const meta = getSourceMetadata(source);
@@ -1179,7 +1179,7 @@ export default function ChatPreferencesPage() {
                     description="Tools and capabilities available for chat to use. This does not apply to agents."
                   />
                   <SimpleCollapsible.Content>
-                    <Section gap={0.5} alignItems="stretch">
+                    <Section gap={2} alignItems="stretch">
                       {vectorDbEnabled && searchTool && (
                         <Card border="solid" rounding="lg">
                           <InputHorizontal
@@ -1331,7 +1331,7 @@ export default function ChatPreferencesPage() {
                     )}
 
                     {/* MCP Servers & OpenAPI Tools */}
-                    <Section gap={0.5}>
+                    <Section gap={2}>
                       {mcpServersWithTools.map(({ server, tools }) => (
                         <MCPServerCard
                           key={server.id}
@@ -1372,7 +1372,7 @@ export default function ChatPreferencesPage() {
           <SimpleCollapsible defaultOpen={false}>
             <SimpleCollapsible.Header title="Advanced Options" />
             <SimpleCollapsible.Content>
-              <Section gap={1}>
+              <Section gap={4}>
                 <Card border="solid" rounding="lg">
                   <Section alignItems="stretch">
                     <Disabled
@@ -1568,7 +1568,7 @@ export default function ChatPreferencesPage() {
                     onClose={() => setSystemPromptModalOpen(false)}
                   />
                   <Modal.Body>
-                    <Section gap={0.25} alignItems="start">
+                    <Section gap={1} alignItems="start">
                       <Hoverable.Root group="systemPromptRestore" width="full">
                         <InputTextAreaField
                           name="system_prompt"

--- a/web/src/views/admin/CodeInterpreterPage/index.tsx
+++ b/web/src/views/admin/CodeInterpreterPage/index.tsx
@@ -57,8 +57,8 @@ function CheckingStatus() {
       flexDirection="row"
       justifyContent="end"
       alignItems="center"
-      gap={0.25}
-      padding={0.5}
+      gap={1}
+      padding={2}
     >
       <Text mainUiAction text03>
         Checking...
@@ -91,8 +91,8 @@ function ConnectionStatus({
       flexDirection="row"
       justifyContent="end"
       alignItems="center"
-      gap={0.25}
-      padding={0.5}
+      gap={1}
+      padding={2}
     >
       <Text mainUiAction text03>
         {label}
@@ -194,7 +194,7 @@ export default function CodeInterpreterPage() {
                         <Section
                           flexDirection="row"
                           justifyContent="end"
-                          gap={0.25}
+                          gap={1}
                         >
                           <Disabled disabled={isLoading}>
                             <Hoverable.Item group="code-interpreter/Card">

--- a/web/src/views/admin/CostOverridesPanel.tsx
+++ b/web/src/views/admin/CostOverridesPanel.tsx
@@ -122,7 +122,7 @@ function OverrideForm({ existing, onDone }: OverrideFormProps) {
   return (
     <Card border="solid" rounding="lg">
       <GeneralLayouts.Section
-        gap={0.75}
+        gap={3}
         height="fit"
         alignItems="stretch"
         justifyContent="start"
@@ -302,7 +302,7 @@ export default function CostOverridesPanel() {
 
   return (
     <GeneralLayouts.Section
-      gap={0.75}
+      gap={3}
       height="fit"
       alignItems="stretch"
       justifyContent="start"

--- a/web/src/views/admin/CraftInstructionsPage/index.tsx
+++ b/web/src/views/admin/CraftInstructionsPage/index.tsx
@@ -158,7 +158,7 @@ export default function CraftInstructionsPage() {
       {header}
       <SettingsLayouts.Body>
         <Card border="solid" rounding="lg">
-          <Section alignItems="stretch" gap={0.25}>
+          <Section alignItems="stretch" gap={1}>
             <InputVertical
               title="Workspace instructions"
               topRight={`${value.length.toLocaleString()} / ${MAX_INSTRUCTIONS_LENGTH.toLocaleString()}`}

--- a/web/src/views/admin/CraftPage/index.tsx
+++ b/web/src/views/admin/CraftPage/index.tsx
@@ -199,7 +199,7 @@ export default function CraftPage() {
       {header}
       <SettingsLayouts.Body>
         <Card border="solid" rounding="lg">
-          <Section alignItems="stretch" gap={0.5}>
+          <Section alignItems="stretch" gap={2}>
             <InputHorizontal
               title="Enable Craft by default"
               tag={{ title: "beta", color: "blue" }}
@@ -220,7 +220,7 @@ export default function CraftPage() {
           </Section>
         </Card>
 
-        <Section alignItems="stretch" gap={0.75}>
+        <Section alignItems="stretch" gap={3}>
           <Content
             sizePreset="main-content"
             variant="section"

--- a/web/src/views/admin/GroupsPage/CreateGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/CreateGroupPage.tsx
@@ -70,7 +70,7 @@ function CreateGroupPage() {
   }
 
   const headerActions = (
-    <Section flexDirection="row" gap={0.5} width="auto" height="auto">
+    <Section flexDirection="row" gap={2} width="auto" height="auto">
       <Button
         prominence="secondary"
         onClick={() => router.push("/admin/groups")}
@@ -98,7 +98,7 @@ function CreateGroupPage() {
       <SettingsLayouts.Body>
         {/* Group Name */}
         <Section
-          gap={0.5}
+          gap={2}
           height="auto"
           alignItems="stretch"
           justifyContent="start"
@@ -126,7 +126,7 @@ function CreateGroupPage() {
 
         {!isLoading && !error && (
           <Section
-            gap={0.75}
+            gap={3}
             height="auto"
             alignItems="stretch"
             justifyContent="start"

--- a/web/src/views/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/EditGroupPage.tsx
@@ -316,7 +316,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
   }
 
   const headerActions = (
-    <Section flexDirection="row" gap={0.5} width="auto" height="auto">
+    <Section flexDirection="row" gap={2} width="auto" height="auto">
       <Button
         prominence="secondary"
         onClick={() => router.push("/admin/groups")}
@@ -360,7 +360,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
             <>
               {/* Group Name */}
               <Section
-                gap={0.5}
+                gap={2}
                 height="auto"
                 alignItems="stretch"
                 justifyContent="start"
@@ -379,14 +379,14 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
 
               {/* Members table */}
               <Section
-                gap={0.75}
+                gap={3}
                 height="auto"
                 alignItems="stretch"
                 justifyContent="start"
               >
                 <Section
                   flexDirection="row"
-                  gap={0.5}
+                  gap={2}
                   height="auto"
                   alignItems="center"
                   justifyContent="start"

--- a/web/src/views/admin/GroupsPage/GroupCard.tsx
+++ b/web/src/views/admin/GroupsPage/GroupCard.tsx
@@ -42,7 +42,7 @@ function GroupCard({ group }: GroupCardProps) {
   }
 
   return (
-    <Card padding={0.5} data-card>
+    <Card padding={2} data-card>
       <ContentAction
         icon={isAdmin ? SvgUserManage : SvgUsers}
         title={group.name}

--- a/web/src/views/admin/GroupsPage/GroupsList.tsx
+++ b/web/src/views/admin/GroupsPage/GroupsList.tsx
@@ -35,7 +35,7 @@ function GroupsList({ groups, searchQuery }: GroupsListProps) {
   const customGroups = filtered.filter((g) => !isBuiltInGroup(g));
 
   return (
-    <Section flexDirection="column" gap={0.5}>
+    <Section flexDirection="column" gap={2}>
       {builtInGroups.map((group) => (
         <GroupCard key={group.id} group={group} />
       ))}

--- a/web/src/views/admin/GroupsPage/SharedGroupResources/ResourcePopover.tsx
+++ b/web/src/views/admin/GroupsPage/SharedGroupResources/ResourcePopover.tsx
@@ -58,7 +58,7 @@ function ResourcePopover({
                     {section.label && (
                       <Section
                         flexDirection="row"
-                        gap={0.25}
+                        gap={1}
                         padding={0}
                         height="auto"
                         alignItems="center"
@@ -75,7 +75,7 @@ function ResourcePopover({
                       </Section>
                     )}
                     <Section
-                      gap={0.25}
+                      gap={1}
                       alignItems="stretch"
                       justifyContent="start"
                     >

--- a/web/src/views/admin/GroupsPage/SharedGroupResources/index.tsx
+++ b/web/src/views/admin/GroupsPage/SharedGroupResources/index.tsx
@@ -270,7 +270,7 @@ function SharedGroupResources({
       <SimpleCollapsible.Content>
         <Card>
           <Section
-            gap={1}
+            gap={4}
             height="auto"
             alignItems="stretch"
             justifyContent="start"
@@ -278,13 +278,13 @@ function SharedGroupResources({
           >
             {/* Connectors & Document Sets */}
             <Section
-              gap={0.5}
+              gap={2}
               height="auto"
               alignItems="stretch"
               justifyContent="start"
             >
               <Section
-                gap={0.25}
+                gap={1}
                 height="auto"
                 alignItems="stretch"
                 justifyContent="start"
@@ -303,7 +303,7 @@ function SharedGroupResources({
                 <Section
                   flexDirection="row"
                   wrap
-                  gap={0.25}
+                  gap={1}
                   height="auto"
                   alignItems="start"
                   justifyContent="start"
@@ -345,13 +345,13 @@ function SharedGroupResources({
 
             {/* Agents */}
             <Section
-              gap={0.5}
+              gap={2}
               height="auto"
               alignItems="stretch"
               justifyContent="start"
             >
               <Section
-                gap={0.25}
+                gap={1}
                 height="auto"
                 alignItems="stretch"
                 justifyContent="start"
@@ -370,7 +370,7 @@ function SharedGroupResources({
                 <Section
                   flexDirection="row"
                   wrap
-                  gap={0.25}
+                  gap={1}
                   height="auto"
                   alignItems="start"
                   justifyContent="start"

--- a/web/src/views/admin/GroupsPage/TokenLimitSection.tsx
+++ b/web/src/views/admin/GroupsPage/TokenLimitSection.tsx
@@ -128,7 +128,7 @@ function TokenLimitSection({
         <Disabled disabled={disabled} tooltip={disabledTooltip}>
           <Card>
             <Section
-              gap={0.5}
+              gap={2}
               height="auto"
               alignItems="stretch"
               justifyContent="start"

--- a/web/src/views/admin/ImageGenerationPage/ImageGenerationContent.tsx
+++ b/web/src/views/admin/ImageGenerationPage/ImageGenerationContent.tsx
@@ -290,7 +290,7 @@ export default function ImageGenerationContent() {
                     `**${disconnectProvider.title}** is currently the default image generation model. Session history will be preserved.`
                   )}
                 </Text>
-                <Section alignItems="start" gap={0.25}>
+                <Section alignItems="start" gap={1}>
                   <Text as="p" color="text-04">
                     Set New Default
                   </Text>

--- a/web/src/views/admin/IndexSettingsPage/index.tsx
+++ b/web/src/views/admin/IndexSettingsPage/index.tsx
@@ -342,7 +342,7 @@ function ProviderGroup({
         />
       </providerCreationModal.Provider>
 
-      <GeneralLayouts.Section gap={0.25}>
+      <GeneralLayouts.Section gap={1}>
         <div className="px-1 pt-1 w-full h-(--height-line-h1-headline)">
           <GeneralLayouts.Section flexDirection="row" gap={0}>
             <Spacer orientation="horizontal" rem={0.675} />
@@ -361,11 +361,7 @@ function ProviderGroup({
               />
 
               {isCloud && isConfigured ? (
-                <GeneralLayouts.Section
-                  flexDirection="row"
-                  gap={0.25}
-                  width="fit"
-                >
+                <GeneralLayouts.Section flexDirection="row" gap={1} width="fit">
                   <Button
                     icon={SvgUnplug}
                     prominence="tertiary"
@@ -529,7 +525,7 @@ function EmbeddingModelCard({
       onClick={isClickable ? onSelect : undefined}
     >
       <GeneralLayouts.Section flexDirection="row" alignItems="start">
-        <GeneralLayouts.Section gap={0} padding={0.5} alignItems="start">
+        <GeneralLayouts.Section gap={0} padding={2} alignItems="start">
           <Content
             icon={provider.icon}
             title={model.modelName}
@@ -971,9 +967,9 @@ export default function IndexSettingsPage() {
                         bottomChildren={
                           <GeneralLayouts.Section
                             flexDirection="row"
-                            gap={0.5}
+                            gap={2}
                             justifyContent="end"
-                            padding={0.5}
+                            padding={2}
                           >
                             <Button
                               icon={SvgExternalLink}
@@ -1081,7 +1077,7 @@ export default function IndexSettingsPage() {
                     <div className="flex w-full flex-col gap-8">
                       {/* ── Embedding Model ── */}
                       <GeneralLayouts.Section
-                        gap={0.75}
+                        gap={3}
                         height="fit"
                         alignItems="stretch"
                         justifyContent="start"
@@ -1096,7 +1092,7 @@ export default function IndexSettingsPage() {
                         {NEXT_PUBLIC_CLOUD_ENABLED ? (
                           <CloudDisabled>
                             <Card border="solid" rounding="lg" padding="sm">
-                              <GeneralLayouts.Section padding={0.5}>
+                              <GeneralLayouts.Section padding={2}>
                                 <Content
                                   icon={SvgVector}
                                   title="Embedding model and settings are managed by Onyx Cloud."
@@ -1126,8 +1122,8 @@ export default function IndexSettingsPage() {
                                     <Tabs.Content value={MODEL_TAB_CLOUD}>
                                       {filteredCloudProviders.length > 0 ? (
                                         <GeneralLayouts.Section
-                                          gap={0.5}
-                                          padding={0.5}
+                                          gap={2}
+                                          padding={2}
                                         >
                                           {filteredCloudProviders.map(
                                             (provider) => (
@@ -1204,8 +1200,8 @@ export default function IndexSettingsPage() {
                                       {filteredSelfHostedProviders.length >
                                       0 ? (
                                         <GeneralLayouts.Section
-                                          gap={0.5}
-                                          padding={0.5}
+                                          gap={2}
+                                          padding={2}
                                         >
                                           {filteredSelfHostedProviders.map(
                                             (shProvider) => (
@@ -1250,7 +1246,7 @@ export default function IndexSettingsPage() {
                                             )
                                           )}
 
-                                          <GeneralLayouts.Section gap={0.25}>
+                                          <GeneralLayouts.Section gap={1}>
                                             <div className="px-1 pt-1 w-full h-(--height-line-h1-headline)">
                                               <GeneralLayouts.Section
                                                 flexDirection="row"
@@ -1373,7 +1369,7 @@ export default function IndexSettingsPage() {
                                 ) : (
                                   <div className="flex flex-row items-start w-full">
                                     <GeneralLayouts.Section
-                                      padding={0.5}
+                                      padding={2}
                                       gap={0}
                                       alignItems="start"
                                     >
@@ -1454,7 +1450,7 @@ export default function IndexSettingsPage() {
 
                       {/* ── Retrieval Optimization ── */}
                       <GeneralLayouts.Section
-                        gap={0.75}
+                        gap={3}
                         height="fit"
                         alignItems="stretch"
                         justifyContent="start"
@@ -1555,7 +1551,7 @@ export default function IndexSettingsPage() {
 
                       {/* ── Image Processing ── */}
                       <GeneralLayouts.Section
-                        gap={0.75}
+                        gap={3}
                         height="fit"
                         alignItems="stretch"
                         justifyContent="start"

--- a/web/src/views/admin/IndexSettingsPage/modals.tsx
+++ b/web/src/views/admin/IndexSettingsPage/modals.tsx
@@ -63,7 +63,7 @@ function ModalShell({ provider, isEditing, children }: ModalShellProps) {
           onClose={onClose}
         />
         <Modal.Body twoTone>
-          <GeneralLayouts.Section gap={1}>{children}</GeneralLayouts.Section>
+          <GeneralLayouts.Section gap={4}>{children}</GeneralLayouts.Section>
         </Modal.Body>
         <Modal.Footer>
           <Button prominence="secondary" onClick={onClose}>

--- a/web/src/views/admin/LanguageModelsPage.tsx
+++ b/web/src/views/admin/LanguageModelsPage.tsx
@@ -144,7 +144,7 @@ function ExistingProviderCard({
             </Button>
           }
         >
-          <Section alignItems="start" gap={0.5}>
+          <Section alignItems="start" gap={2}>
             {isDefault && !isLastProvider ? (
               <Text font="main-ui-body" color="text-03">
                 Cannot delete the default provider. Select another provider as
@@ -434,7 +434,7 @@ export default function LanguageModelsPage() {
         {hasProviders && (
           <>
             <GeneralLayouts.Section
-              gap={0.75}
+              gap={3}
               height="fit"
               alignItems="stretch"
               justifyContent="start"
@@ -476,7 +476,7 @@ export default function LanguageModelsPage() {
             {PROVIDER_GROUPS.map((group) => (
               <GeneralLayouts.Section
                 key={group.title}
-                gap={0.75}
+                gap={3}
                 height="fit"
                 alignItems="stretch"
                 justifyContent="start"

--- a/web/src/views/admin/PerUserUsagePanel.tsx
+++ b/web/src/views/admin/PerUserUsagePanel.tsx
@@ -93,7 +93,7 @@ export default function PerUserUsagePanel({
         flexDirection="column"
         justifyContent="start"
         alignItems="stretch"
-        gap={0.125}
+        gap={0.5}
         width="full"
         height="fit"
       >
@@ -114,7 +114,7 @@ export default function PerUserUsagePanel({
         flexDirection="column"
         justifyContent="start"
         alignItems="stretch"
-        gap={1}
+        gap={4}
         width="full"
         height="fit"
       >
@@ -129,7 +129,7 @@ export default function PerUserUsagePanel({
         flexDirection="column"
         justifyContent="start"
         alignItems="stretch"
-        gap={1}
+        gap={4}
         width="full"
         height="fit"
       >
@@ -148,7 +148,7 @@ export default function PerUserUsagePanel({
       flexDirection="column"
       justifyContent="start"
       alignItems="stretch"
-      gap={1}
+      gap={4}
       width="full"
       height="fit"
     >
@@ -193,7 +193,7 @@ export default function PerUserUsagePanel({
         flexDirection="column"
         justifyContent="start"
         alignItems="stretch"
-        gap={0.5}
+        gap={2}
         width="full"
         height="fit"
       >
@@ -201,7 +201,7 @@ export default function PerUserUsagePanel({
           flexDirection="column"
           justifyContent="start"
           alignItems="stretch"
-          gap={0.125}
+          gap={0.5}
           width="full"
           height="fit"
         >

--- a/web/src/views/admin/ServiceAccountsPage/EditServiceAccountModal.tsx
+++ b/web/src/views/admin/ServiceAccountsPage/EditServiceAccountModal.tsx
@@ -197,8 +197,8 @@ export default function EditServiceAccountModal({
         <Modal.Body twoTone>
           <Section padding={0} height="auto" alignItems="stretch">
             <Section
-              gap={0.5}
-              padding={0.25}
+              gap={2}
+              padding={1}
               height={joinedGroups.length === 0 && !popoverOpen ? "auto" : 14.5}
               alignItems="stretch"
               justifyContent="start"

--- a/web/src/views/admin/ServiceAccountsPage/index.tsx
+++ b/web/src/views/admin/ServiceAccountsPage/index.tsx
@@ -444,7 +444,7 @@ export default function ServiceAccountsPage() {
             </Button>
           }
         >
-          <Section alignItems="start" gap={0.5}>
+          <Section alignItems="start" gap={2}>
             <Text as="p" color="text-03">
               {markdown(
                 `Any application using the API key of account *${

--- a/web/src/views/admin/TracingPage/TracingDisconnectModal.tsx
+++ b/web/src/views/admin/TracingPage/TracingDisconnectModal.tsx
@@ -56,7 +56,7 @@ export function TracingDisconnectModal({
         </Button>
       }
     >
-      <Section alignItems="start" gap={0.5}>
+      <Section alignItems="start" gap={2}>
         <Text color="text-03">
           {markdown(
             `LLM call traces will no longer be sent to **${target.label}**. Traces already sent are unaffected.`

--- a/web/src/views/admin/UsersPage/EditUserModal.tsx
+++ b/web/src/views/admin/UsersPage/EditUserModal.tsx
@@ -189,8 +189,8 @@ export default function EditUserModal({
         <Modal.Body twoTone>
           <Section padding={0} height="auto" alignItems="stretch">
             <Section
-              gap={0.5}
-              padding={0.25}
+              gap={2}
+              padding={1}
               height={joinedGroups.length === 0 && !popoverOpen ? "auto" : 14.5}
               alignItems="stretch"
               justifyContent="start"

--- a/web/src/views/admin/UsersPage/InviteOnlyCard.tsx
+++ b/web/src/views/admin/UsersPage/InviteOnlyCard.tsx
@@ -43,7 +43,7 @@ export default function InviteOnlyCard() {
   );
 
   return (
-    <Card gap={0.5} padding={0.75}>
+    <Card gap={2} padding={3}>
       <ContentAction
         title="Restrict Open Sign-Up"
         description="New users must be invited to join this workspace."

--- a/web/src/views/admin/UsersPage/UserRowActions.tsx
+++ b/web/src/views/admin/UsersPage/UserRowActions.tsx
@@ -211,7 +211,7 @@ export default function UserRowActions({
         </Popover.Trigger>
         <Popover.Content align="end" width="sm">
           <Section
-            gap={0.5}
+            gap={2}
             height="auto"
             alignItems="stretch"
             justifyContent="start"

--- a/web/src/views/admin/UsersPage/UsersSummary.tsx
+++ b/web/src/views/admin/UsersPage/UsersSummary.tsx
@@ -65,7 +65,7 @@ function StatCell({ value, label, onFilter }: StatCellProps) {
 
 function ScimCard() {
   return (
-    <Card gap={0.5} padding={0.75}>
+    <Card gap={2} padding={3}>
       <ContentAction
         icon={SvgUserSync}
         title="SCIM Sync"
@@ -113,7 +113,7 @@ export default function UsersSummary({
   const showRequests = requests !== null && requests > 0;
 
   const statsCard = (
-    <Card padding={0.5}>
+    <Card padding={2}>
       <Section flexDirection="row" gap={0}>
         <StatCell
           value={activeUsers}
@@ -148,7 +148,7 @@ export default function UsersSummary({
         flexDirection="row"
         justifyContent="start"
         alignItems="stretch"
-        gap={0.5}
+        gap={2}
       >
         {statsCard}
         {rightCard}

--- a/web/src/views/admin/VoicePage/index.tsx
+++ b/web/src/views/admin/VoicePage/index.tsx
@@ -234,8 +234,8 @@ export default function VoicePage() {
         divider
       />
       <SettingsLayouts.Body>
-        <Section gap={2}>
-          <Section gap={0.75}>
+        <Section gap={8}>
+          <Section gap={3}>
             <Content
               title="Speech to Text"
               description="Select a model to transcribe speech to text in chats."
@@ -250,7 +250,7 @@ export default function VoicePage() {
               />
             )}
 
-            <Section gap={0.5}>
+            <Section gap={2}>
               {STT_MODELS.map((model) => (
                 <ModelCard
                   key={`stt-${model.id}`}
@@ -282,7 +282,7 @@ export default function VoicePage() {
             </Section>
           </Section>
 
-          <Section gap={0.75}>
+          <Section gap={3}>
             <Content
               title="Text to Speech"
               description="Select a model to speak out chat responses."
@@ -297,7 +297,7 @@ export default function VoicePage() {
               />
             )}
 
-            <Section gap={1}>
+            <Section gap={4}>
               {TTS_PROVIDER_GROUPS.map((group) => (
                 <div
                   key={group.providerType}

--- a/web/src/views/admin/VoicePage/shared.tsx
+++ b/web/src/views/admin/VoicePage/shared.tsx
@@ -253,7 +253,7 @@ export function VoiceProviderSetupModal({
                 onClose={onClose}
               />
               <Modal.Body>
-                <Section gap={1} alignItems="stretch">
+                <Section gap={4} alignItems="stretch">
                   {providerType === "azure" && (
                     <InputVertical
                       title="Target URI"
@@ -439,7 +439,7 @@ export function VoiceDisconnectModal({
         </Button>
       }
     >
-      <Section alignItems="start" gap={0.5}>
+      <Section alignItems="start" gap={2}>
         <Text color="text-03">
           {markdown(
             `**${disconnectTarget.providerLabel}** models will no longer be used for speech-to-text or text-to-speech, and it will no longer be your default. Session history will be preserved.`

--- a/web/src/views/admin/WebSearchPage/WebSearchDisconnectModal.tsx
+++ b/web/src/views/admin/WebSearchPage/WebSearchDisconnectModal.tsx
@@ -82,7 +82,7 @@ export function WebSearchDisconnectModal({
         </Button>
       }
     >
-      <Section alignItems="start" gap={0.5}>
+      <Section alignItems="start" gap={2}>
         {isSearch ? (
           <>
             <Text color="text-03">


### PR DESCRIPTION
## Description

Opal had two named padding scales that disagreed with each other. `padding="md"` meant 16px on a card but 4px on a container, and the container scale was not even injective — `md` and `sm` both resolved to 4px, as did `xs` and `2xs` to 2px. A named token could not say which scale it belonged to.

This adds `Spacing`, a number on Tailwind's scale: **N is N / 4 rem**. A step reads the same here as it does in a class name, so a `padding` of `2` is the same distance as `p-2`. `spacingToRem` converts it, which keeps the scale open rather than capping it at whichever classes Tailwind happens to ship.

`Section` and `Tabs.Content` move onto it. Both already took a `number`, but read it as **raw rem** — so every call site is multiplied by four to preserve the exact same distance. `Section`'s default `gap` goes from `1` to `4`, which is the same 1rem restated on the new scale.

Nothing should move by a single pixel.

The named scales stay for now. Cards and `ContentAction` still use them and they convert differently (`lg` is 24px on a card, 8px on a `ContentAction`), so they move in follow-up PRs.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors Opal spacing to a Tailwind-aligned numeric scale so numbers are steps, not raw rem. Previously numeric gap/padding were rem; now N equals N/4 rem. All in-repo usages were updated to preserve visuals, including two missed spots: `Card`’s default padding (now `4`) and `UserFilesModal`’s `Modal.Body` ternary padding.

- Adds `Spacing` (number) in `@opal/types` and `spacingToRem` in `@opal/shared`. `Section` and `Tabs.Content` now accept `padding?: Spacing` and `gap?: Spacing`; `Section`’s default `gap` is `4` (1rem). Updates `@opal/layouts/general` and `@opal/components/tabs` docs and examples. No visual changes expected; verify a few key screens and `Tabs.Content` stories.

**Migration**
- Update any out-of-repo numeric `Section`/`Tabs.Content` spacing by multiplying by 4 (e.g., `padding={1}` → `padding={4}`, `gap={0.5}` → `gap={2}`). Named scales on `Card` and `ContentAction` remain for now and will migrate separately.

<sup>Written for commit d6f2cbf713c4348dd491e5896249c88a121fbd98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

