### PR TITLE
fix(usage): Make shared usage ranges exact calendar windows

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -37,6 +37,7 @@ Use get_sandbox_manager() from base.py to get the appropriate implementation.
 import base64
 import binascii
 import copy
+import gzip
 import hashlib
 import io
 import ipaddress
@@ -244,16 +245,17 @@ def _build_targz(files: FileSet) -> tuple[bytes, str]:
             f"Bundle size {total} exceeds {_MAX_BUNDLE_BYTES} byte limit"
         )
     buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz", compresslevel=6) as tar:
-        for name in sorted(files):
-            data = files[name]
-            info = tarfile.TarInfo(name=name)
-            info.size = len(data)
-            info.mtime = 0
-            info.uid = 0
-            info.gid = 0
-            info.mode = 0o644
-            tar.addfile(info, io.BytesIO(data))
+    with gzip.GzipFile(fileobj=buf, mode="wb", compresslevel=6, mtime=0) as gzip_file:
+        with tarfile.open(fileobj=gzip_file, mode="w") as tar:
+            for name in sorted(files):
+                data = files[name]
+                info = tarfile.TarInfo(name=name)
+                info.size = len(data)
+                info.mtime = 0
+                info.uid = 0
+                info.gid = 0
+                info.mode = 0o644
+                tar.addfile(info, io.BytesIO(data))
     raw = buf.getvalue()
     return raw, hashlib.sha256(raw).hexdigest()
 

--- a/backend/onyx/server/features/usage/api.py
+++ b/backend/onyx/server/features/usage/api.py
@@ -60,8 +60,25 @@ from onyx.server.features.usage.models import (
 from onyx.utils.datetime import get_window_start
 from shared_configs.configs import USAGE_LIMIT_WINDOW_SECONDS
 
-# Default trailing range for the export when no start is given.
-_DEFAULT_EXPORT_DAYS = 30
+# Default trailing range when no start is given.
+_DEFAULT_USAGE_RANGE_INCLUSIVE_DAYS = 30
+
+
+def _start_for_inclusive_range(end_date: date, inclusive_days: int) -> date:
+    return end_date - timedelta(days=inclusive_days - 1)
+
+
+def _date_range_to_utc_bounds(
+    start_date: date, end_date: date
+) -> tuple[datetime, datetime]:
+    if start_date > end_date:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "start must not be after end")
+
+    start_dt = datetime.combine(start_date, time.min, tzinfo=timezone.utc)
+    end_dt = datetime.combine(end_date, time.min, tzinfo=timezone.utc) + timedelta(
+        days=1
+    )
+    return start_dt, end_dt
 
 
 def _used_from_buckets(
@@ -260,15 +277,10 @@ def export_usage(
 ) -> UsageExportResponse:
     """Company-wide daily usage export by email."""
     end_date = end or datetime.now(timezone.utc).date()
-    start_date = start or (end_date - timedelta(days=_DEFAULT_EXPORT_DAYS))
-    if start_date > end_date:
-        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "start must not be after end")
-
-    # Half-open over the full end day so windows starting on `end` are included.
-    start_dt = datetime.combine(start_date, time.min, tzinfo=timezone.utc)
-    end_dt = datetime.combine(end_date, time.min, tzinfo=timezone.utc) + timedelta(
-        days=1
+    start_date = start or _start_for_inclusive_range(
+        end_date, _DEFAULT_USAGE_RANGE_INCLUSIVE_DAYS
     )
+    start_dt, end_dt = _date_range_to_utc_bounds(start_date, end_date)
 
     # TODO(evan-onyx): this might need to be done in a background task
     rows = get_usage_export(db_session, start=start_dt, end=end_dt, model=model)

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_tarball.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_tarball.py
@@ -43,6 +43,7 @@ def test_deterministic() -> None:
     raw1, sha1 = _build_targz(files)
     raw2, sha2 = _build_targz(files)
 
+    assert raw1[4:8] == b"\0\0\0\0"
     assert raw1 == raw2
     assert sha1 == sha2
 

--- a/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
@@ -297,14 +297,27 @@ class TestExportEndpoint:
         assert all(r["model"] == "model-b" for r in body["users"][0]["records"])
 
     def test_date_range_end_excludes_later_window(self, db_session: Session) -> None:
-        _seed_two_users(db_session)
+        alice, _ = _seed_two_users(db_session)
+        _seed_usage(
+            db_session,
+            alice,
+            "model-a",
+            "CHAT",
+            "openai",
+            500,
+            90,
+            0,
+            5.0,
+            datetime.datetime(2026, 6, 7, tzinfo=datetime.timezone.utc),
+        )
+        db_session.commit()
         client = TestClient(_make_app(db_session, _ADMIN))
         # end=2026-06-07 -> half-open through 06-08 00:00, so W2 (06-08) excluded.
         body = client.get(
             "/admin/usage/export", params={"start": "2026-06-01", "end": "2026-06-07"}
         ).json()
         all_days = {r["day"] for u in body["users"] for r in u["records"]}
-        assert all_days == {"2026-06-01"}
+        assert all_days == {"2026-06-01", "2026-06-07"}
         assert "bob@example.com" not in {u["email"] for u in body["users"]}
 
     def test_non_admin_rejected(self, db_session: Session) -> None:

--- a/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
@@ -247,6 +247,18 @@ class TestGetUsageExportHelper:
 
 
 class TestExportEndpoint:
+    def test_default_range_covers_thirty_calendar_days(
+        self, db_session: Session
+    ) -> None:
+        client = TestClient(_make_app(db_session, _ADMIN))
+
+        body = client.get("/admin/usage/export").json()
+
+        start = datetime.date.fromisoformat(body["start"])
+        end = datetime.date.fromisoformat(body["end"])
+        # Inclusive endpoints differ by 29 days when the range has 30 dates.
+        assert (end - start).days == 29
+
     def test_nested_per_user_with_totals(self, db_session: Session) -> None:
         _seed_two_users(db_session)
         client = TestClient(_make_app(db_session, _ADMIN))

--- a/web/src/app/ee/admin/performance/lib.test.tsx
+++ b/web/src/app/ee/admin/performance/lib.test.tsx
@@ -1,0 +1,25 @@
+import { renderHook } from "@testing-library/react";
+import { useTimeRange } from "@/lib/usage/hooks";
+
+describe("useTimeRange", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2026, 7, 4, 12));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("defaults to exactly 30 calendar days", () => {
+    const { result } = renderHook(() => useTimeRange());
+    const [range] = result.current;
+
+    expect(range.from.getFullYear()).toBe(2026);
+    expect(range.from.getMonth()).toBe(6);
+    expect(range.from.getDate()).toBe(6);
+    expect(range.to.getFullYear()).toBe(2026);
+    expect(range.to.getMonth()).toBe(7);
+    expect(range.to.getDate()).toBe(4);
+  });
+});

--- a/web/src/lib/usage/hooks.ts
+++ b/web/src/lib/usage/hooks.ts
@@ -7,7 +7,6 @@ import { buildApiPath } from "@/lib/urlBuilder";
 import {
   convertDateToEndOfDay,
   convertDateToStartOfDay,
-  getXDaysAgo,
 } from "@/lib/dateUtils";
 import {
   OnyxBotAnalytics,
@@ -17,14 +16,14 @@ import {
   UserAnalytics,
 } from "@/lib/usage/interfaces";
 import {
-  DateRangePickerValue,
   THIRTY_DAYS,
+  type DateRangePickerValue,
+  rangeForInclusiveDays,
 } from "@/refresh-components/DateRangePicker";
 
 export function useTimeRange() {
   return useState<DateRangePickerValue>({
-    to: new Date(),
-    from: getXDaysAgo(30),
+    ...rangeForInclusiveDays(30),
     selectValue: THIRTY_DAYS,
   });
 }

--- a/web/src/refresh-components/DateRangePicker.test.tsx
+++ b/web/src/refresh-components/DateRangePicker.test.tsx
@@ -19,7 +19,7 @@ describe("DateRangePicker", () => {
     render(
       <DateRangePicker
         value={{
-          from: new Date(2026, 6, 5),
+          from: new Date(2026, 7, 1),
           to: new Date(2026, 7, 4),
         }}
         onValueChange={onValueChange}
@@ -68,6 +68,72 @@ describe("DateRangePicker", () => {
 
     expect(onValueChange).toHaveBeenCalledWith({
       from: new Date(2026, 7, 4),
+      to: new Date(2026, 7, 4, 23, 59, 59, 999),
+    });
+  });
+
+  it("emits exactly 30 calendar days for 1M", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const onValueChange = jest.fn();
+
+    render(
+      <DateRangePicker
+        value={{
+          from: new Date(2026, 6, 6),
+          to: new Date(2026, 7, 4),
+        }}
+        onValueChange={onValueChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "1M" }));
+
+    expect(onValueChange).toHaveBeenCalledWith({
+      from: new Date(2026, 6, 6),
+      to: new Date(2026, 7, 4, 23, 59, 59, 999),
+    });
+  });
+
+  it("emits exactly 7 calendar days for 7D", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const onValueChange = jest.fn();
+
+    render(
+      <DateRangePicker
+        value={{
+          from: new Date(2026, 6, 6),
+          to: new Date(2026, 7, 4),
+        }}
+        onValueChange={onValueChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "7D" }));
+
+    expect(onValueChange).toHaveBeenCalledWith({
+      from: new Date(2026, 6, 29),
+      to: new Date(2026, 7, 4, 23, 59, 59, 999),
+    });
+  });
+
+  it("emits exactly 90 calendar days for 3M", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const onValueChange = jest.fn();
+
+    render(
+      <DateRangePicker
+        value={{
+          from: new Date(2026, 6, 6),
+          to: new Date(2026, 7, 4),
+        }}
+        onValueChange={onValueChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "3M" }));
+
+    expect(onValueChange).toHaveBeenCalledWith({
+      from: new Date(2026, 4, 7),
       to: new Date(2026, 7, 4, 23, 59, 59, 999),
     });
   });

--- a/web/src/refresh-components/DateRangePicker.tsx
+++ b/web/src/refresh-components/DateRangePicker.tsx
@@ -3,7 +3,7 @@ import { endOfDay, format, isSameDay, startOfDay, subDays } from "date-fns";
 import { Calendar, Popover, SelectButton } from "@opal/components";
 import { SvgCalendar } from "@opal/icons";
 
-export const THIRTY_DAYS = "30d";
+export const THIRTY_DAYS = "1M";
 
 export type DateRangePickerValue = DateRange & {
   selectValue: string;
@@ -25,19 +25,25 @@ type DraftDateRange =
 
 interface DatePreset {
   label: string;
-  daysAgo: number;
+  inclusiveDays: number;
 }
 
 const PRESETS: DatePreset[] = [
-  { label: "1D", daysAgo: 0 },
-  { label: "7D", daysAgo: 6 },
-  { label: "1M", daysAgo: 30 },
-  { label: "3M", daysAgo: 90 },
+  { label: "1D", inclusiveDays: 1 },
+  { label: "7D", inclusiveDays: 7 },
+  { label: "1M", inclusiveDays: 30 },
+  { label: "3M", inclusiveDays: 90 },
 ];
 
-function rangeForPreset(preset: DatePreset): Exclude<DateRange, undefined> {
+export function rangeForInclusiveDays(
+  inclusiveDays: number
+): Exclude<DateRange, undefined> {
   const to = endOfDay(new Date());
-  return { from: startOfDay(subDays(to, preset.daysAgo)), to };
+  return { from: startOfDay(subDays(to, inclusiveDays - 1)), to };
+}
+
+function rangeForPreset(preset: DatePreset): Exclude<DateRange, undefined> {
+  return rangeForInclusiveDays(preset.inclusiveDays);
 }
 
 function rangesMatch(left: DateRange, right: DateRange): boolean {


### PR DESCRIPTION
## Description

Make shared usage presets and the admin export fallback use exact inclusive calendar windows: 1D, 7D, 1M, and 3M now contain 1, 7, 30, and 90 calendar dates.

Stack: PR 2 of 3; depends on #13910.

## How Has This Been Tested?

- `uv run pytest -q backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py`
- `bun run test --runTestsByPath src/components/dateRangeSelectors/DateRangePicker.test.tsx src/app/ee/admin/performance/lib.test.tsx`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check