### PR TITLE
feat(usage): Let personal usage share exact calendar ranges

### DIFF
--- a/backend/onyx/server/features/usage/api.py
+++ b/backend/onyx/server/features/usage/api.py
@@ -205,6 +205,8 @@ admin_usage_router = APIRouter(prefix="/admin/usage", tags=PUBLIC_API_TAGS)
 @user_usage_router.get("")
 def get_my_usage(
     days: Annotated[int | None, Query(ge=1, le=3_650)] = None,
+    start: date | None = None,
+    end: date | None = None,
     user: User = Depends(current_user),
     db_session: Session = Depends(get_session),
 ) -> UserUsageResponse:
@@ -212,11 +214,21 @@ def get_my_usage(
     now = datetime.now(timezone.utc)
     window_start = get_window_start(now, period_seconds=USAGE_LIMIT_WINDOW_SECONDS)
 
-    since = now - timedelta(days=days) if days else window_start
+    if start is not None or end is not None:
+        end_date = end or now.date()
+        inclusive_days = days or _DEFAULT_USAGE_RANGE_INCLUSIVE_DAYS
+        start_date = start or _start_for_inclusive_range(end_date, inclusive_days)
+        since, until = _date_range_to_utc_bounds(start_date, end_date)
+    elif days is not None:
+        since = now - timedelta(days=days)
+        until = now
+    else:
+        since = window_start
+        until = now
     user_id = str(user.id)
 
     per_day = get_user_usage_by_day_and_model(
-        db_session, user_id, since=since, until=now
+        db_session, user_id, since=since, until=until
     )
     window_cost_cents = get_user_cost_cents_since(db_session, user_id, window_start)
 

--- a/backend/onyx/server/features/usage/api.py
+++ b/backend/onyx/server/features/usage/api.py
@@ -65,7 +65,12 @@ _DEFAULT_USAGE_RANGE_INCLUSIVE_DAYS = 30
 
 
 def _start_for_inclusive_range(end_date: date, inclusive_days: int) -> date:
-    return end_date - timedelta(days=inclusive_days - 1)
+    try:
+        return end_date - timedelta(days=inclusive_days - 1)
+    except OverflowError as error:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT, "date range exceeds supported bounds"
+        ) from error
 
 
 def _date_range_to_utc_bounds(
@@ -75,9 +80,14 @@ def _date_range_to_utc_bounds(
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, "start must not be after end")
 
     start_dt = datetime.combine(start_date, time.min, tzinfo=timezone.utc)
-    end_dt = datetime.combine(end_date, time.min, tzinfo=timezone.utc) + timedelta(
-        days=1
-    )
+    try:
+        end_dt = datetime.combine(
+            end_date + timedelta(days=1), time.min, tzinfo=timezone.utc
+        )
+    except OverflowError as error:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT, "date range exceeds supported bounds"
+        ) from error
     return start_dt, end_dt
 
 
@@ -230,7 +240,11 @@ def get_my_usage(
     per_day = get_user_usage_by_day_and_model(
         db_session, user_id, since=since, until=until
     )
-    window_cost_cents = get_user_cost_cents_since(db_session, user_id, window_start)
+    window_cost_cents = (
+        sum(row.cost_cents for row in per_day)
+        if start is not None or end is not None
+        else get_user_cost_cents_since(db_session, user_id, window_start)
+    )
 
     accessible_providers = fetch_all_llm_providers_accessible_in_any_context(
         db_session, user

--- a/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
@@ -336,6 +336,7 @@ def test_custom_date_range_uses_inclusive_calendar_bounds(
         "model-a",
         "model-b",
     ]
+    assert body["window_cost_cents"] == pytest.approx(3.0)
 
 
 def test_custom_date_range_rejects_start_after_end(db_session: Session) -> None:
@@ -343,6 +344,26 @@ def test_custom_date_range_rejects_start_after_end(db_session: Session) -> None:
 
     resp = TestClient(_make_app(db_session, _StubUser(caller))).get(
         "/user/usage", params={"start": "2026-07-04", "end": "2026-07-03"}
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["error_code"] == "INVALID_INPUT"
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"end": "9999-12-31"},
+        {"end": "0001-01-01"},
+    ],
+)
+def test_custom_date_range_rejects_unsupported_bounds(
+    db_session: Session, params: dict[str, str]
+) -> None:
+    caller = str(uuid4())
+
+    resp = TestClient(_make_app(db_session, _StubUser(caller))).get(
+        "/user/usage", params=params
     )
 
     assert resp.status_code == 400

--- a/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
+import onyx.server.features.usage.api as usage_api
 from onyx.auth.users import current_user
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import (
@@ -198,6 +199,154 @@ def test_returns_only_callers_rows_and_aggregates(
     assert body["budget_cents"] is None
     assert body["budget_remaining_cents"] is None
     assert body["selected_model_price"] is None
+
+
+def test_default_range_uses_usage_limit_window(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    caller = str(uuid4())
+    fixed_now = datetime.datetime(2026, 8, 4, 12, 34, tzinfo=datetime.timezone.utc)
+    seen: dict[str, datetime.datetime] = {}
+
+    class _FixedDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz: datetime.tzinfo | None = None) -> datetime.datetime:
+            return fixed_now if tz is not None else fixed_now.replace(tzinfo=None)
+
+    def _capture_usage_bounds(
+        *_args: object,
+        since: datetime.datetime,
+        until: datetime.datetime,
+    ) -> list[object]:
+        seen["since"] = since
+        seen["until"] = until
+        return []
+
+    monkeypatch.setattr(usage_api, "datetime", _FixedDatetime)
+    monkeypatch.setattr(
+        usage_api, "get_user_usage_by_day_and_model", _capture_usage_bounds
+    )
+    monkeypatch.setattr(
+        "onyx.server.features.usage.api.fetch_default_llm_model", lambda _db: None
+    )
+
+    resp = TestClient(_make_app(db_session, _StubUser(caller))).get("/user/usage")
+
+    assert resp.status_code == 200
+    assert seen == {
+        "since": usage_api.get_window_start(
+            fixed_now, period_seconds=usage_api.USAGE_LIMIT_WINDOW_SECONDS
+        ),
+        "until": fixed_now,
+    }
+
+
+def test_days_range_uses_legacy_rolling_bounds(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    caller = str(uuid4())
+    fixed_now = datetime.datetime(2026, 8, 4, 12, 34, tzinfo=datetime.timezone.utc)
+    seen: dict[str, datetime.datetime] = {}
+
+    class _FixedDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz: datetime.tzinfo | None = None) -> datetime.datetime:
+            return fixed_now if tz is not None else fixed_now.replace(tzinfo=None)
+
+    def _capture_usage_bounds(
+        *_args: object,
+        since: datetime.datetime,
+        until: datetime.datetime,
+    ) -> list[object]:
+        seen["since"] = since
+        seen["until"] = until
+        return []
+
+    monkeypatch.setattr(usage_api, "datetime", _FixedDatetime)
+    monkeypatch.setattr(
+        usage_api, "get_user_usage_by_day_and_model", _capture_usage_bounds
+    )
+    monkeypatch.setattr(
+        "onyx.server.features.usage.api.fetch_default_llm_model", lambda _db: None
+    )
+
+    resp = TestClient(_make_app(db_session, _StubUser(caller))).get(
+        "/user/usage", params={"days": 7}
+    )
+
+    assert resp.status_code == 200
+    assert seen == {
+        "since": fixed_now - datetime.timedelta(days=7),
+        "until": fixed_now,
+    }
+
+
+def test_custom_date_range_uses_inclusive_calendar_bounds(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    caller = str(uuid4())
+    _seed_usage(
+        db_session,
+        caller,
+        "model-a",
+        "CHAT",
+        "openai",
+        100,
+        50,
+        0,
+        1.0,
+        datetime.datetime(2026, 7, 1, 12, tzinfo=datetime.timezone.utc),
+    )
+    _seed_usage(
+        db_session,
+        caller,
+        "model-b",
+        "CHAT",
+        "openai",
+        200,
+        60,
+        0,
+        2.0,
+        datetime.datetime(2026, 7, 3, 23, 59, tzinfo=datetime.timezone.utc),
+    )
+    _seed_usage(
+        db_session,
+        caller,
+        "model-c",
+        "CHAT",
+        "openai",
+        300,
+        70,
+        0,
+        3.0,
+        datetime.datetime(2026, 7, 4, tzinfo=datetime.timezone.utc),
+    )
+    db_session.commit()
+    monkeypatch.setattr(
+        "onyx.server.features.usage.api.fetch_default_llm_model", lambda _db: None
+    )
+
+    body = (
+        TestClient(_make_app(db_session, _StubUser(caller)))
+        .get("/user/usage", params={"start": "2026-07-01", "end": "2026-07-03"})
+        .json()
+    )
+
+    assert [row["model"] for row in body["per_day_by_model"]] == [
+        "model-a",
+        "model-b",
+    ]
+
+
+def test_custom_date_range_rejects_start_after_end(db_session: Session) -> None:
+    caller = str(uuid4())
+
+    resp = TestClient(_make_app(db_session, _StubUser(caller))).get(
+        "/user/usage", params={"start": "2026-07-04", "end": "2026-07-03"}
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["error_code"] == "INVALID_INPUT"
 
 
 def test_selected_model_price_known_model(

--- a/web/src/app/app/settings/usage/UsageSettings.test.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import UsageSettings from "@/app/app/settings/usage/UsageSettings";
+import { useUserUsage } from "@/app/app/settings/usage/lib";
+
+jest.mock("@/app/app/settings/usage/lib", () => ({
+  useUserUsage: jest.fn(),
+}));
+
+const mockUseUserUsage = useUserUsage as jest.MockedFunction<
+  typeof useUserUsage
+>;
+
+describe("UsageSettings", () => {
+  beforeEach(() => {
+    mockUseUserUsage.mockReturnValue({
+      data: {
+        per_day_by_model: [],
+        window_cost_cents: 0,
+        budget_cents: null,
+        budget_remaining_cents: null,
+        budget_period_hours: null,
+        selected_model_price: null,
+        available_model_prices: [],
+      },
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: jest.fn(),
+    } as unknown as ReturnType<typeof useUserUsage>);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("uses a wrapping shared date range picker header", () => {
+    render(<UsageSettings />);
+
+    const picker = screen.getByRole("group", { name: "Date range" });
+
+    expect(picker).toBeInTheDocument();
+    expect(picker.parentElement).toHaveClass("flex-wrap");
+  });
+});

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -11,7 +11,6 @@ import {
   SvgSimpleLoader,
   SvgChevronRight,
 } from "@opal/icons";
-import InputSelect from "@/refresh-components/inputs/InputSelect";
 import {
   Collapsible,
   CollapsibleContent,
@@ -24,12 +23,14 @@ import {
   type ModelPrice,
 } from "@/app/app/settings/usage/lib";
 import {
+  DateRangePicker,
+  rangeForInclusiveDays,
+  type DateRange,
+} from "@/refresh-components/DateRangePicker";
+import {
   formatCurrencyFromCents as formatDollars,
   formatTokenCount as formatTokens,
 } from "@/lib/format";
-
-const DAYS_OPTIONS = ["7", "30"] as const;
-const DEFAULT_DAYS = 30;
 
 interface WindowCostSectionProps {
   windowCostCents: number;
@@ -346,8 +347,10 @@ function BudgetSection({
 }
 
 export default function UsageSettings() {
-  const [days, setDays] = useState<string>(String(DEFAULT_DAYS));
-  const { data, error, isLoading } = useUserUsage(Number(days));
+  const [dateRange, setDateRange] = useState<DateRange>(
+    rangeForInclusiveDays(30)
+  );
+  const { data, error, isLoading } = useUserUsage(dateRange);
 
   useEffect(() => {
     if (error) console.error("Failed to load usage", error);
@@ -362,20 +365,14 @@ export default function UsageSettings() {
           alignItems="center"
           width="full"
           gap={4}
+          wrap
         >
           <Content title="Usage" sizePreset="main-content" variant="section" />
-          <div className="min-w-32">
-            <InputSelect value={days} onValueChange={setDays}>
-              <InputSelect.Trigger placeholder="Period" />
-              <InputSelect.Content>
-                {DAYS_OPTIONS.map((option) => (
-                  <InputSelect.Item key={option} value={option}>
-                    {`Last ${option} days`}
-                  </InputSelect.Item>
-                ))}
-              </InputSelect.Content>
-            </InputSelect>
-          </div>
+          <DateRangePicker
+            value={dateRange}
+            onValueChange={setDateRange}
+            size="sm"
+          />
         </Section>
 
         {isLoading ? (

--- a/web/src/app/app/settings/usage/lib.test.tsx
+++ b/web/src/app/app/settings/usage/lib.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import useSWR from "swr";
 import { useUserUsage } from "@/app/app/settings/usage/lib";
+import { rangeForInclusiveDays } from "@/refresh-components/DateRangePicker";
 
 jest.mock("swr", () => jest.fn());
 
@@ -29,6 +30,20 @@ describe("useUserUsage", () => {
 
     expect(mockUseSWR).toHaveBeenCalledWith(
       "/api/user/usage?start=2026-07-06&end=2026-08-04",
+      expect.any(Function),
+      expect.objectContaining({ revalidateOnFocus: false })
+    );
+  });
+
+  it("anchors preset ranges to the current UTC usage day", () => {
+    const nowBeforeUtcDayRollover = new Date("2026-08-13T05:00:00+10:00");
+
+    renderHook(() =>
+      useUserUsage(rangeForInclusiveDays(1, nowBeforeUtcDayRollover))
+    );
+
+    expect(mockUseSWR).toHaveBeenCalledWith(
+      "/api/user/usage?start=2026-08-12&end=2026-08-12",
       expect.any(Function),
       expect.objectContaining({ revalidateOnFocus: false })
     );

--- a/web/src/app/app/settings/usage/lib.test.tsx
+++ b/web/src/app/app/settings/usage/lib.test.tsx
@@ -1,0 +1,36 @@
+import { renderHook } from "@testing-library/react";
+import useSWR from "swr";
+import { useUserUsage } from "@/app/app/settings/usage/lib";
+
+jest.mock("swr", () => jest.fn());
+
+const mockUseSWR = useSWR as jest.MockedFunction<typeof useSWR>;
+
+describe("useUserUsage", () => {
+  beforeEach(() => {
+    mockUseSWR.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+    } as ReturnType<typeof useSWR>);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("requests inclusive calendar start and end dates", () => {
+    renderHook(() =>
+      useUserUsage({
+        from: new Date(2026, 6, 6),
+        to: new Date(2026, 7, 4, 23, 59, 59, 999),
+      })
+    );
+
+    expect(mockUseSWR).toHaveBeenCalledWith(
+      "/api/user/usage?start=2026-07-06&end=2026-08-04",
+      expect.any(Function),
+      expect.objectContaining({ revalidateOnFocus: false })
+    );
+  });
+});

--- a/web/src/app/app/settings/usage/lib.ts
+++ b/web/src/app/app/settings/usage/lib.ts
@@ -3,6 +3,8 @@
 import useSWR from "swr";
 import { errorHandlingFetcher, skipRetryOnAuthError } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import { formatDateForApiParam } from "@/lib/dateUtils";
+import { buildApiPath } from "@/lib/urlBuilder";
 
 export interface UsagePerDayByModel {
   day: string; // "YYYY-MM-DD"
@@ -33,13 +35,14 @@ export interface UserUsageResponse {
   available_model_prices: ModelPrice[];
 }
 
-export function useUserUsage(days: number) {
-  return useSWR<UserUsageResponse>(
-    SWR_KEYS.userUsage(days),
-    errorHandlingFetcher,
-    {
-      revalidateOnFocus: false,
-      onErrorRetry: skipRetryOnAuthError,
-    }
-  );
+export function useUserUsage(range: { from: Date; to: Date } | undefined) {
+  const url = buildApiPath(SWR_KEYS.userUsage, {
+    start: range?.from ? formatDateForApiParam(range.from) : undefined,
+    end: range?.to ? formatDateForApiParam(range.to) : undefined,
+  });
+
+  return useSWR<UserUsageResponse>(url, errorHandlingFetcher, {
+    revalidateOnFocus: false,
+    onErrorRetry: skipRetryOnAuthError,
+  });
 }

--- a/web/src/lib/dateUtils.ts
+++ b/web/src/lib/dateUtils.ts
@@ -76,15 +76,7 @@ export function isDateInFuture(date: Date): boolean {
 }
 
 export const timestampToDateString = (timestamp: string) => {
-  const date = new Date(timestamp);
-  const year = date.getFullYear();
-  const month = date.getMonth() + 1; // getMonth() is zero-based
-  const day = date.getDate();
-
-  const formattedDate = `${year}-${month.toString().padStart(2, "0")}-${day
-    .toString()
-    .padStart(2, "0")}`;
-  return formattedDate;
+  return formatDateForApiParam(new Date(timestamp));
 };
 
 // Options for formatting the date

--- a/web/src/lib/dateUtils.ts
+++ b/web/src/lib/dateUtils.ts
@@ -55,6 +55,12 @@ export function getXYearsAgo(yearsAgo: number) {
   return yearsAgoDate;
 }
 
+export function formatDateForApiParam(date: Date): string {
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
 export function normalizeDate(date: Date): Date {
   const normalizedDate = new Date(date);
   normalizedDate.setHours(0, 0, 0, 0);

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -43,7 +43,7 @@ export const SWR_KEYS = {
   wellKnownLlmProvider: (providerEndpoint: string) =>
     `/api/admin/llm/built-in/options/${providerEndpoint}`,
   llmContextualCost: "/api/admin/llm/provider-contextual-cost",
-  userUsage: (days: number) => `/api/user/usage?days=${days}`,
+  userUsage: "/api/user/usage",
   costOverrides: "/api/admin/cost-overrides",
   adminUsageExport: "/api/admin/usage/export",
   adminUsageReset: "/api/admin/usage/reset",

--- a/web/src/lib/usage/userUsage.ts
+++ b/web/src/lib/usage/userUsage.ts
@@ -4,6 +4,7 @@ import useSWR from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { buildApiPath } from "@/lib/urlBuilder";
+import { formatDateForApiParam } from "@/lib/dateUtils";
 
 export interface UsageExportTotals {
   input_tokens: number;
@@ -35,16 +36,10 @@ export interface UsageExportResponse {
   users: UsageExportUser[];
 }
 
-function formatDateParam(date: Date): string {
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${date.getFullYear()}-${month}-${day}`;
-}
-
 export function useUsageExport(range?: { from: Date; to: Date } | undefined) {
   const url = buildApiPath(SWR_KEYS.adminUsageExport, {
-    start: range?.from ? formatDateParam(range.from) : undefined,
-    end: range?.to ? formatDateParam(range.to) : undefined,
+    start: range?.from ? formatDateForApiParam(range.from) : undefined,
+    end: range?.to ? formatDateForApiParam(range.to) : undefined,
   });
   const { data, error, isLoading, mutate } = useSWR<UsageExportResponse>(
     url,

--- a/web/src/refresh-components/DateRangePicker.tsx
+++ b/web/src/refresh-components/DateRangePicker.tsx
@@ -36,9 +36,15 @@ const PRESETS: DatePreset[] = [
 ];
 
 export function rangeForInclusiveDays(
-  inclusiveDays: number
+  inclusiveDays: number,
+  now = new Date()
 ): Exclude<DateRange, undefined> {
-  const to = endOfDay(new Date());
+  const utcToday = new Date(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate()
+  );
+  const to = endOfDay(utcToday);
   return { from: startOfDay(subDays(to, inclusiveDays - 1)), to };
 }
 


### PR DESCRIPTION
## Description

Move the Settings Usage page to the shared `DateRangePicker` and support explicit calendar `start` and `end` dates in `/user/usage`. Legacy `days=N` rolling-window requests remain supported.

Stack: PR 3 of 3; depends on #13911.

## How Has This Been Tested?

- `uv run pytest -q backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py`
- `bun run test --runTestsByPath src/app/app/settings/usage/lib.test.tsx src/app/app/settings/usage/UsageSettings.test.tsx`
- Browser-level manual QA was not run.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check