### PR TITLE
refactor(opal): move the card padding scale onto Spacing

### DIFF
--- a/web/lib/opal/src/components/cards/card/Card.stories.tsx
+++ b/web/lib/opal/src/components/cards/card/Card.stories.tsx
@@ -4,7 +4,7 @@ import { Button, Card } from "@opal/components";
 
 const BACKGROUND_VARIANTS = ["none", "light", "heavy"] as const;
 const BORDER_VARIANTS = ["none", "dashed", "solid"] as const;
-const PADDING_VARIANTS = ["fit", "2xs", "xs", "sm", "md", "lg"] as const;
+const PADDING_VARIANTS = [0, 0.5, 1, 2, 4, 6] as const;
 const ROUNDING_VARIANTS = ["xs", "sm", "md", "lg"] as const;
 
 const meta: Meta<typeof Card> = {

--- a/web/lib/opal/src/components/cards/card/README.md
+++ b/web/lib/opal/src/components/cards/card/README.md
@@ -23,7 +23,7 @@ import { Card } from "@opal/components";
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `padding` | `Spacing` | `"md"` | Padding preset |
+| `padding` | `Spacing` | `4` | Padding, as a spacing step (`N / 4` rem) |
 | `rounding` | `RoundingVariants` | `"md"` | Border-radius preset |
 | `background` | `"none" \| "light" \| "heavy"` | `"light"` | Background fill intensity |
 | `border` | `"none" \| "dashed" \| "solid"` | `"none"` | Border style |
@@ -33,14 +33,8 @@ import { Card } from "@opal/components";
 
 ### Padding scale
 
-| `padding` | Class   |
-|-----------|---------|
-| `"lg"`    | `p-6`   |
-| `"md"`    | `p-4`   |
-| `"sm"`    | `p-2`   |
-| `"xs"`    | `p-1`   |
-| `"2xs"`   | `p-0.5` |
-| `"fit"`   | `p-0`   |
+`padding` is a spacing step, not a preset: `N` is `N / 4` rem, the same scale Tailwind
+uses. So `padding={2}` is the same distance as `p-2`, and the default `4` is `1rem`.
 
 ### Rounding scale
 

--- a/web/lib/opal/src/components/cards/card/README.md
+++ b/web/lib/opal/src/components/cards/card/README.md
@@ -14,7 +14,7 @@ Default behavior — a plain container.
 ```tsx
 import { Card } from "@opal/components";
 
-<Card padding="md" border="solid">
+<Card padding={4} border="solid">
   <p>Hello</p>
 </Card>
 ```
@@ -23,7 +23,7 @@ import { Card } from "@opal/components";
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `padding` | `PaddingVariants` | `"md"` | Padding preset |
+| `padding` | `Spacing` | `"md"` | Padding preset |
 | `rounding` | `RoundingVariants` | `"md"` | Border-radius preset |
 | `background` | `"none" \| "light" \| "heavy"` | `"light"` | Background fill intensity |
 | `border` | `"none" \| "dashed" \| "solid"` | `"none"` | Border style |
@@ -113,7 +113,7 @@ Because Card doesn't own the trigger, it also doesn't generate IDs or ARIA attri
 
 ```ts
 type CardBaseProps = {
-  padding?: PaddingVariants;
+  padding?: Spacing;
   rounding?: RoundingVariants;
   background?: "none" | "light" | "heavy";
   border?: "none" | "dashed" | "solid";

--- a/web/lib/opal/src/components/cards/card/components.tsx
+++ b/web/lib/opal/src/components/cards/card/components.tsx
@@ -26,22 +26,15 @@ import { cn } from "@opal/utils";
  */
 type CardBaseProps = {
   /**
-   * Padding preset.
+   * Padding.
    *
-   * | Value   | Class   |
-   * |---------|---------|
-   * | `"lg"`  | `p-6`   |
-   * | `"md"`  | `p-4`   |
-   * | `"sm"`  | `p-2`   |
-   * | `"xs"`  | `p-1`   |
-   * | `"2xs"` | `p-0.5` |
-   * | `"fit"` | `p-0`   |
+   * A spacing step: `N` is `N / 4` rem, so `4` is `1rem`.
    *
    * In expandable mode, applied **only** to the header region. The
    * `expandedContent` slot has no intrinsic padding — callers own any padding
    * inside the content they pass in.
    *
-   * @default "md"
+   * @default 4
    */
   padding?: Spacing;
 

--- a/web/lib/opal/src/components/cards/card/components.tsx
+++ b/web/lib/opal/src/components/cards/card/components.tsx
@@ -3,17 +3,17 @@ import "@opal/components/cards/card/styles.css";
 import type {
   BackgroundVariants,
   BorderVariants,
-  PaddingVariants,
+  Spacing,
   RoundingVariants,
   ShadowVariants,
   SizeVariants,
   StatusVariants,
 } from "@opal/types";
 import {
-  paddingVariants,
   cardRoundingVariants,
   cardTopRoundingVariants,
   cardBottomRoundingVariants,
+  spacingToRem,
 } from "@opal/shared";
 import { cn } from "@opal/utils";
 
@@ -43,7 +43,7 @@ type CardBaseProps = {
    *
    * @default "md"
    */
-  padding?: PaddingVariants;
+  padding?: Spacing;
 
   /**
    * Border-radius preset.
@@ -182,7 +182,7 @@ type CardProps = CardPlainProps | CardExpandableProps;
  *
  * @example Plain
  * ```tsx
- * <Card padding="md" border="solid">
+ * <Card padding={4} border="solid">
  *   <p>Hello</p>
  * </Card>
  * ```
@@ -202,7 +202,7 @@ type CardProps = CardPlainProps | CardExpandableProps;
  */
 function Card(props: CardProps) {
   const {
-    padding: paddingProp = "md",
+    padding: paddingProp = 4,
     rounding: roundingProp = "md",
     background = "light",
     border = "none",
@@ -212,14 +212,15 @@ function Card(props: CardProps) {
     children,
   } = props;
 
-  const padding = paddingVariants[paddingProp];
+  const paddingStyle = { padding: spacingToRem(paddingProp) };
 
   // Plain mode — unchanged behavior
   if (!props.expandable) {
     return (
       <div
         ref={ref}
-        className={cn("opal-card", padding, cardRoundingVariants[roundingProp])}
+        className={cn("opal-card", cardRoundingVariants[roundingProp])}
+        style={paddingStyle}
         data-background={background}
         data-border={border}
         data-opal-status-border={borderColor}
@@ -244,7 +245,8 @@ function Card(props: CardProps) {
   return (
     <div ref={ref} className="opal-card-expandable" data-shadow={shadow}>
       <div
-        className={cn("opal-card-expandable-header", padding, headerRounding)}
+        className={cn("opal-card-expandable-header", headerRounding)}
+        style={paddingStyle}
         data-background={background}
         data-border={border}
         data-opal-status-border={borderColor}

--- a/web/lib/opal/src/components/cards/empty-message-card/EmptyMessageCard.stories.tsx
+++ b/web/lib/opal/src/components/cards/empty-message-card/EmptyMessageCard.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { EmptyMessageCard } from "@opal/components";
 import { SvgActions, SvgServer, SvgSparkle, SvgUsers } from "@opal/icons";
 
-const PADDING_VARIANTS = ["fit", "2xs", "xs", "sm", "md", "lg"] as const;
+const PADDING_VARIANTS = [0, 0.5, 1, 2, 4, 6] as const;
 
 const meta: Meta<typeof EmptyMessageCard> = {
   title: "opal/components/EmptyMessageCard",

--- a/web/lib/opal/src/components/cards/empty-message-card/README.md
+++ b/web/lib/opal/src/components/cards/empty-message-card/README.md
@@ -13,7 +13,7 @@ A pre-configured Card for empty states. Renders a transparent card with a dashed
 | `sizePreset` | `"secondary" \| "main-ui"`   | `"secondary"` | Controls layout and text sizing    |
 | `icon`       | `IconFunctionComponent`       | `SvgEmpty`    | Icon displayed alongside the title |
 | `title`      | `string \| RichStr`           | —             | Primary message text (required)    |
-| `padding`    | `PaddingVariants`             | `"md"`        | Padding preset for the card        |
+| `padding`    | `Spacing`             | `4`           | Padding, as a spacing step (`N / 4` rem) |
 | `ref`        | `React.Ref<HTMLDivElement>`   | —             | Ref forwarded to the root div      |
 
 ### `sizePreset="main-ui"` only
@@ -45,5 +45,5 @@ import { SvgSparkle, SvgFileText, SvgActions } from "@opal/icons";
 />
 
 // Custom padding
-<EmptyMessageCard padding="xs" icon={SvgFileText} title="No documents available." />
+<EmptyMessageCard padding={1} icon={SvgFileText} title="No documents available." />
 ```

--- a/web/lib/opal/src/components/cards/empty-message-card/components.tsx
+++ b/web/lib/opal/src/components/cards/empty-message-card/components.tsx
@@ -1,11 +1,7 @@
 import { Card } from "@opal/components/cards/card/components";
 import { Content } from "@opal/layouts";
 import { SvgEmpty } from "@opal/icons";
-import type {
-  IconFunctionComponent,
-  PaddingVariants,
-  RichStr,
-} from "@opal/types";
+import type { IconFunctionComponent, Spacing, RichStr } from "@opal/types";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -19,7 +15,7 @@ type EmptyMessageCardBaseProps = {
   title: string | RichStr;
 
   /** Padding preset for the card. @default "md" */
-  padding?: PaddingVariants;
+  padding?: Spacing;
 
   /** Ref forwarded to the root Card div. */
   ref?: React.Ref<HTMLDivElement>;
@@ -45,7 +41,7 @@ function EmptyMessageCard(props: EmptyMessageCardProps) {
     sizePreset = "secondary",
     icon = SvgEmpty,
     title,
-    padding = "md",
+    padding = 4,
     ref,
   } = props;
 

--- a/web/lib/opal/src/components/cards/message-card/README.md
+++ b/web/lib/opal/src/components/cards/message-card/README.md
@@ -14,7 +14,7 @@ and border colors.
 | `icon` | `IconFunctionComponent` | per variant | Override the default variant icon |
 | `title` | `string \| RichStr` | — | Main title text |
 | `description` | `string \| RichStr` | — | Description below the title |
-| `padding` | `Spacing` | `2` | Padding around the outer card, as a spacing step (`N / 4` rem) |
+| `padding` | `1 \| 2` | `2` | Padding around the outer card, as a spacing step (`N / 4` rem). Narrowed to two densities. |
 | `headerPadding` | `Spacing` | `0` | Padding around the header Content area, as a spacing step (`N / 4` rem) |
 | `bottomChildren` | `ReactNode` | — | Content below a divider, under the main content |
 | `rightChildren` | `ReactNode` | — | Content on the right side. Mutually exclusive with `onClose`. |

--- a/web/lib/opal/src/components/cards/message-card/README.md
+++ b/web/lib/opal/src/components/cards/message-card/README.md
@@ -14,8 +14,8 @@ and border colors.
 | `icon` | `IconFunctionComponent` | per variant | Override the default variant icon |
 | `title` | `string \| RichStr` | — | Main title text |
 | `description` | `string \| RichStr` | — | Description below the title |
-| `padding` | `"sm" \| "xs"` | `"sm"` | Padding preset for the outer card |
-| `headerPadding` | `Spacing` | `"fit"` | Padding around the header Content area. `"fit"` → no padding; `"sm"` → `p-2`. |
+| `padding` | `Spacing` | `2` | Padding around the outer card, as a spacing step (`N / 4` rem) |
+| `headerPadding` | `Spacing` | `0` | Padding around the header Content area, as a spacing step (`N / 4` rem) |
 | `bottomChildren` | `ReactNode` | — | Content below a divider, under the main content |
 | `rightChildren` | `ReactNode` | — | Content on the right side. Mutually exclusive with `onClose`. |
 | `onClose` | `() => void` | — | Close button callback. When omitted, no close button is rendered. |

--- a/web/lib/opal/src/components/cards/message-card/README.md
+++ b/web/lib/opal/src/components/cards/message-card/README.md
@@ -15,7 +15,7 @@ and border colors.
 | `title` | `string \| RichStr` | — | Main title text |
 | `description` | `string \| RichStr` | — | Description below the title |
 | `padding` | `"sm" \| "xs"` | `"sm"` | Padding preset for the outer card |
-| `headerPadding` | `PaddingVariants` | `"fit"` | Padding around the header Content area. `"fit"` → no padding; `"sm"` → `p-2`. |
+| `headerPadding` | `Spacing` | `"fit"` | Padding around the header Content area. `"fit"` → no padding; `"sm"` → `p-2`. |
 | `bottomChildren` | `ReactNode` | — | Content below a divider, under the main content |
 | `rightChildren` | `ReactNode` | — | Content on the right side. Mutually exclusive with `onClose`. |
 | `onClose` | `() => void` | — | Close button callback. When omitted, no close button is rendered. |

--- a/web/lib/opal/src/components/cards/message-card/components.tsx
+++ b/web/lib/opal/src/components/cards/message-card/components.tsx
@@ -39,10 +39,10 @@ interface MessageCardBaseProps {
   /** Clamp the title to N lines with ellipsis. Default: `1`. Pass `undefined` to wrap freely. */
   titleMaxLines?: number;
 
-  /** Padding preset. @default "sm" */
+  /** Padding, as a spacing step (`N / 4` rem). @default 2 */
   padding?: Spacing;
 
-  /** Padding around the header Content area. @default "fit" */
+  /** Padding around the header Content area, as a spacing step. @default 0 */
   headerPadding?: Spacing;
 
   /**

--- a/web/lib/opal/src/components/cards/message-card/components.tsx
+++ b/web/lib/opal/src/components/cards/message-card/components.tsx
@@ -3,11 +3,11 @@ import "@opal/components/cards/message-card/styles.css";
 import { cn } from "@opal/utils";
 import type {
   IconFunctionComponent,
-  PaddingVariants,
+  Spacing,
   RichStr,
   StatusVariants,
 } from "@opal/types";
-import { paddingVariants } from "@opal/shared";
+import { spacingToRem } from "@opal/shared";
 import { ContentAction } from "@opal/layouts";
 import { Button, Divider } from "@opal/components";
 import {
@@ -40,10 +40,10 @@ interface MessageCardBaseProps {
   titleMaxLines?: number;
 
   /** Padding preset. @default "sm" */
-  padding?: Extract<PaddingVariants, "sm" | "xs">;
+  padding?: Spacing;
 
   /** Padding around the header Content area. @default "fit" */
-  headerPadding?: PaddingVariants;
+  headerPadding?: Spacing;
 
   /**
    * Content rendered below a divider, under the main content area.
@@ -130,8 +130,8 @@ function MessageCard({
   title,
   description,
   titleMaxLines,
-  padding = "sm",
-  headerPadding = "fit",
+  padding = 2,
+  headerPadding = 0,
   bottomChildren,
   rightChildren,
   onClose,
@@ -154,12 +154,13 @@ function MessageCard({
 
   return (
     <div
-      className={cn("opal-message-card", paddingVariants[padding])}
+      className="opal-message-card"
+      style={{ padding: spacingToRem(padding) }}
       data-variant={variant}
       data-opal-status-border={variant}
       ref={ref}
     >
-      <div className={paddingVariants[headerPadding]}>
+      <div style={{ padding: spacingToRem(headerPadding) }}>
         <ContentAction
           icon={(props) => (
             <Icon {...props} className={cn(props.className, iconClass)} />
@@ -176,7 +177,7 @@ function MessageCard({
 
       {bottomChildren && (
         <>
-          <Divider paddingParallel="sm" paddingPerpendicular="xs" />
+          <Divider paddingParallel={2} paddingPerpendicular={1} />
           {bottomChildren}
         </>
       )}

--- a/web/lib/opal/src/components/cards/message-card/components.tsx
+++ b/web/lib/opal/src/components/cards/message-card/components.tsx
@@ -39,8 +39,13 @@ interface MessageCardBaseProps {
   /** Clamp the title to N lines with ellipsis. Default: `1`. Pass `undefined` to wrap freely. */
   titleMaxLines?: number;
 
-  /** Padding, as a spacing step (`N / 4` rem). @default 2 */
-  padding?: Spacing;
+  /**
+   * Padding, as a spacing step (`N / 4` rem). Narrowed on purpose — a message
+   * card is a fixed-density surface, so only these two densities are offered.
+   *
+   * @default 2
+   */
+  padding?: 1 | 2;
 
   /** Padding around the header Content area, as a spacing step. @default 0 */
   headerPadding?: Spacing;

--- a/web/lib/opal/src/components/cards/select-card/README.md
+++ b/web/lib/opal/src/components/cards/select-card/README.md
@@ -38,7 +38,7 @@ Inherits **all** props from `InteractiveStatefulProps` (except `variant`, which 
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `padding` | `PaddingVariants` | `"md"` | Padding preset |
+| `padding` | `Spacing` | `"md"` | Padding preset |
 | `rounding` | `RoundingVariants` | `"md"` | Border-radius preset |
 | `border` | `BorderVariants` | `"solid"` | Border style (`"none"` \| `"dashed"` \| `"solid"`) |
 | `ref` | `React.Ref<HTMLDivElement>` | — | Ref forwarded to the root div |

--- a/web/lib/opal/src/components/cards/select-card/README.md
+++ b/web/lib/opal/src/components/cards/select-card/README.md
@@ -38,7 +38,7 @@ Inherits **all** props from `InteractiveStatefulProps` (except `variant`, which 
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `padding` | `Spacing` | `"md"` | Padding preset |
+| `padding` | `Spacing` | `4` | Padding, as a spacing step (`N / 4` rem) |
 | `rounding` | `RoundingVariants` | `"md"` | Border-radius preset |
 | `border` | `BorderVariants` | `"solid"` | Border style (`"none"` \| `"dashed"` \| `"solid"`) |
 | `ref` | `React.Ref<HTMLDivElement>` | — | Ref forwarded to the root div |
@@ -46,14 +46,8 @@ Inherits **all** props from `InteractiveStatefulProps` (except `variant`, which 
 
 ### Padding scale
 
-| `padding` | Class   |
-|-----------|---------|
-| `"lg"`    | `p-6`   |
-| `"md"`    | `p-4`   |
-| `"sm"`    | `p-2`   |
-| `"xs"`    | `p-1`   |
-| `"2xs"`   | `p-0.5` |
-| `"fit"`   | `p-0`   |
+`padding` is a spacing step, not a preset: `N` is `N / 4` rem, the same scale Tailwind
+uses. So `padding={2}` is the same distance as `p-2`, and the default `4` is `1rem`.
 
 ### Rounding scale
 

--- a/web/lib/opal/src/components/cards/select-card/SelectCard.stories.tsx
+++ b/web/lib/opal/src/components/cards/select-card/SelectCard.stories.tsx
@@ -13,7 +13,7 @@ import {
 import { Interactive } from "@opal/core";
 
 const STATES = ["empty", "filled", "selected"] as const;
-const PADDING_VARIANTS = ["fit", "2xs", "xs", "sm", "md", "lg"] as const;
+const PADDING_VARIANTS = [0, 0.5, 1, 2, 4, 6] as const;
 const ROUNDING_VARIANTS = ["xs", "sm", "md", "lg"] as const;
 
 const meta = {

--- a/web/lib/opal/src/components/cards/select-card/components.tsx
+++ b/web/lib/opal/src/components/cards/select-card/components.tsx
@@ -10,18 +10,11 @@ import { Interactive, type InteractiveStatefulProps } from "@opal/core";
 
 type SelectCardProps = Omit<InteractiveStatefulProps, "variant"> & {
   /**
-   * Padding preset.
+   * Padding.
    *
-   * | Value   | Class   |
-   * |---------|---------|
-   * | `"lg"`  | `p-6`   |
-   * | `"md"`  | `p-4`   |
-   * | `"sm"`  | `p-2`   |
-   * | `"xs"`  | `p-1`   |
-   * | `"2xs"` | `p-0.5` |
-   * | `"fit"` | `p-0`   |
+   * A spacing step: `N` is `N / 4` rem, so `4` is `1rem`.
    *
-   * @default "md"
+   * @default 4
    */
   padding?: Spacing;
 

--- a/web/lib/opal/src/components/cards/select-card/components.tsx
+++ b/web/lib/opal/src/components/cards/select-card/components.tsx
@@ -1,10 +1,6 @@
 import "@opal/components/cards/select-card/styles.css";
-import type {
-  BorderVariants,
-  PaddingVariants,
-  RoundingVariants,
-} from "@opal/types";
-import { paddingVariants, cardRoundingVariants } from "@opal/shared";
+import type { BorderVariants, Spacing, RoundingVariants } from "@opal/types";
+import { cardRoundingVariants, spacingToRem } from "@opal/shared";
 import { cn } from "@opal/utils";
 import { Interactive, type InteractiveStatefulProps } from "@opal/core";
 
@@ -27,7 +23,7 @@ type SelectCardProps = Omit<InteractiveStatefulProps, "variant"> & {
    *
    * @default "md"
    */
-  padding?: PaddingVariants;
+  padding?: Spacing;
 
   /**
    * Border-radius preset.
@@ -86,21 +82,22 @@ type SelectCardProps = Omit<InteractiveStatefulProps, "variant"> & {
  * ```
  */
 function SelectCard({
-  padding: paddingProp = "md",
+  padding: paddingProp = 4,
   rounding: roundingProp = "md",
   border = "solid",
   ref,
   children,
   ...statefulProps
 }: SelectCardProps) {
-  const padding = paddingVariants[paddingProp];
+  const paddingStyle = { padding: spacingToRem(paddingProp) };
   const rounding = cardRoundingVariants[roundingProp];
 
   return (
     <Interactive.Stateful {...statefulProps} variant="select-card">
       <div
         ref={ref}
-        className={cn("opal-select-card", padding, rounding)}
+        className={cn("opal-select-card", rounding)}
+        style={paddingStyle}
         data-border={border}
       >
         {children}

--- a/web/lib/opal/src/components/divider/Divider.stories.tsx
+++ b/web/lib/opal/src/components/divider/Divider.stories.tsx
@@ -28,11 +28,11 @@ export const Vertical: Story = {
 };
 
 export const NoPadding: Story = {
-  render: () => <Divider paddingParallel="fit" paddingPerpendicular="fit" />,
+  render: () => <Divider paddingParallel={0} paddingPerpendicular={0} />,
 };
 
 export const CustomPadding: Story = {
-  render: () => <Divider paddingParallel="lg" paddingPerpendicular="sm" />,
+  render: () => <Divider paddingParallel={6} paddingPerpendicular={2} />,
 };
 
 export const VerticalNoPadding: Story = {
@@ -43,8 +43,8 @@ export const VerticalNoPadding: Story = {
       <span>Left</span>
       <Divider
         orientation="vertical"
-        paddingParallel="fit"
-        paddingPerpendicular="fit"
+        paddingParallel={0}
+        paddingPerpendicular={0}
       />
       <span>Right</span>
     </div>

--- a/web/lib/opal/src/components/divider/README.md
+++ b/web/lib/opal/src/components/divider/README.md
@@ -15,8 +15,8 @@ A plain line with no title or description.
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `orientation` | `"horizontal" \| "vertical"` | `"horizontal"` | Direction of the line |
-| `paddingParallel` | `PaddingVariants` | `"sm"` | Padding along the line direction (0.5rem) |
-| `paddingPerpendicular` | `PaddingVariants` | `"xs"` | Padding perpendicular to the line (0.25rem) |
+| `paddingParallel` | `Spacing` | `2` | Padding along the line direction (0.5rem) |
+| `paddingPerpendicular` | `Spacing` | `1` | Padding perpendicular to the line (0.25rem) |
 
 ### Titled divider
 
@@ -53,10 +53,10 @@ import { Divider } from "@opal/components";
 <Divider orientation="vertical" />
 
 // No padding
-<Divider paddingParallel="fit" paddingPerpendicular="fit" />
+<Divider paddingParallel={0} paddingPerpendicular={0} />
 
 // Custom padding
-<Divider paddingParallel="lg" paddingPerpendicular="sm" />
+<Divider paddingParallel={6} paddingPerpendicular={2} />
 
 // With title
 <Divider title="Advanced" />

--- a/web/lib/opal/src/components/divider/components.tsx
+++ b/web/lib/opal/src/components/divider/components.tsx
@@ -2,16 +2,12 @@
 
 import "@opal/components/divider/styles.css";
 import { useState, useCallback } from "react";
-import type {
-  OrientationVariants,
-  PaddingVariants,
-  RichStr,
-} from "@opal/types";
+import type { OrientationVariants, Spacing, RichStr } from "@opal/types";
 import { Button, Text } from "@opal/components";
 import { SvgChevronRight } from "@opal/icons";
 import { Interactive } from "@opal/core";
 import { cn } from "@opal/utils";
-import { paddingXVariants, paddingYVariants } from "@opal/shared";
+import { spacingToRem } from "@opal/shared";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -39,9 +35,9 @@ type DividerBareProps = Omit<
   /** Orientation of the line. Default: `"horizontal"`. */
   orientation?: OrientationVariants;
   /** Padding along the line direction. Default: `"sm"` (0.5rem). */
-  paddingParallel?: PaddingVariants;
+  paddingParallel?: Spacing;
   /** Padding perpendicular to the line. Default: `"xs"` (0.25rem). */
-  paddingPerpendicular?: PaddingVariants;
+  paddingPerpendicular?: Spacing;
 };
 
 /** Line with a title to the left. */
@@ -93,19 +89,19 @@ function Divider(props: DividerProps) {
     title,
     description,
     orientation = "horizontal",
-    paddingParallel = "sm",
-    paddingPerpendicular = "xs",
+    paddingParallel = 2,
+    paddingPerpendicular = 1,
   } = props;
 
   if (orientation === "vertical") {
     return (
       <div
         ref={ref}
-        className={cn(
-          "opal-divider-vertical",
-          paddingXVariants[paddingPerpendicular],
-          paddingYVariants[paddingParallel]
-        )}
+        className="opal-divider-vertical"
+        style={{
+          paddingInline: spacingToRem(paddingPerpendicular),
+          paddingBlock: spacingToRem(paddingParallel),
+        }}
       >
         <div className="opal-divider-line-vertical" />
       </div>
@@ -115,11 +111,11 @@ function Divider(props: DividerProps) {
   return (
     <div
       ref={ref}
-      className={cn(
-        "opal-divider",
-        paddingXVariants[paddingParallel],
-        paddingYVariants[paddingPerpendicular]
-      )}
+      className="opal-divider"
+      style={{
+        paddingInline: spacingToRem(paddingParallel),
+        paddingBlock: spacingToRem(paddingPerpendicular),
+      }}
     >
       <div className="opal-divider-row">
         {title && (

--- a/web/lib/opal/src/components/divider/components.tsx
+++ b/web/lib/opal/src/components/divider/components.tsx
@@ -34,9 +34,9 @@ type DividerBareProps = Omit<
 > & {
   /** Orientation of the line. Default: `"horizontal"`. */
   orientation?: OrientationVariants;
-  /** Padding along the line direction. Default: `"sm"` (0.5rem). */
+  /** Padding along the line direction, as a spacing step. Default: `2` (0.5rem). */
   paddingParallel?: Spacing;
-  /** Padding perpendicular to the line. Default: `"xs"` (0.25rem). */
+  /** Padding perpendicular to the line, as a spacing step. Default: `1` (0.25rem). */
   paddingPerpendicular?: Spacing;
 };
 

--- a/web/lib/opal/src/components/end-of-list/components.tsx
+++ b/web/lib/opal/src/components/end-of-list/components.tsx
@@ -11,11 +11,11 @@ interface EndOfListProps {
 function EndOfList({ title }: EndOfListProps) {
   return (
     <div className="opal-end-of-list">
-      <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+      <Divider paddingParallel={0} paddingPerpendicular={0} />
       <Text font="secondary-body" color="text-03" nowrap>
         {title}
       </Text>
-      <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+      <Divider paddingParallel={0} paddingPerpendicular={0} />
     </div>
   );
 }

--- a/web/lib/opal/src/components/inputs/input-select/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-select/components.tsx
@@ -8,7 +8,7 @@ import { cn } from "@opal/utils";
 import type {
   IconFunctionComponent,
   InputVariants,
-  PaddingVariants,
+  Spacing,
   RichStr,
   WithoutStyles,
 } from "@opal/types";
@@ -434,8 +434,8 @@ function InputSelectLabel({
 }
 
 interface InputSelectSeparatorProps {
-  paddingParallel?: PaddingVariants;
-  paddingPerpendicular?: PaddingVariants;
+  paddingParallel?: Spacing;
+  paddingPerpendicular?: Spacing;
 }
 
 function InputSelectSeparator({

--- a/web/lib/opal/src/components/popover/components.tsx
+++ b/web/lib/opal/src/components/popover/components.tsx
@@ -165,7 +165,7 @@ const Popover = Object.assign(PopoverRoot, {
 // ============================================================================
 
 function SeparatorHelper() {
-  return <Divider paddingPerpendicular="fit" />;
+  return <Divider paddingPerpendicular={0} />;
 }
 
 /**

--- a/web/lib/opal/src/components/tooltip/Tooltip.stories.tsx
+++ b/web/lib/opal/src/components/tooltip/Tooltip.stories.tsx
@@ -35,7 +35,7 @@ export const Sides: Story = {
 export const OnCard: Story = {
   render: () => (
     <Tooltip tooltip="Card tooltip appears on hover">
-      <Card border="solid" padding="md">
+      <Card border="solid" padding={4}>
         <p className="text-sm">Hover this card</p>
       </Card>
     </Tooltip>

--- a/web/lib/opal/src/core/disabled/Disabled.stories.tsx
+++ b/web/lib/opal/src/core/disabled/Disabled.stories.tsx
@@ -12,7 +12,7 @@ export default meta;
 type Story = StoryObj<typeof Disabled>;
 
 const SampleContent = () => (
-  <Card border="solid" padding="md">
+  <Card border="solid" padding={4}>
     <div className="flex flex-col gap-2">
       <p className="text-sm font-medium">Card Title</p>
       <p className="text-xs text-text-03">Some content that can be disabled.</p>
@@ -63,7 +63,7 @@ export const TooltipSides: Story = {
           tooltip={`Tooltip on ${side}`}
           tooltipSide={side}
         >
-          <Card border="solid" padding="sm">
+          <Card border="solid" padding={2}>
             <p className="text-sm">tooltipSide: {side}</p>
           </Card>
         </Disabled>
@@ -76,7 +76,7 @@ export const WithAllowClick: Story = {
   render: () => (
     <div className="w-80">
       <Disabled disabled allowClick>
-        <Card border="solid" padding="md">
+        <Card border="solid" padding={4}>
           <p className="text-sm">
             Disabled visuals, but pointer events are still active.
           </p>

--- a/web/lib/opal/src/layouts/auth/components.tsx
+++ b/web/lib/opal/src/layouts/auth/components.tsx
@@ -49,7 +49,7 @@ function Card({
 }: CardProps) {
   return (
     <div className="opal-auth-card-outer">
-      <OpalCard padding="lg" rounding="lg" shadow="lg">
+      <OpalCard padding={6} rounding="lg" shadow="lg">
         <div className="flex flex-col gap-6">
           <div className="flex flex-col gap-3">
             <div className="p-0.5">

--- a/web/lib/opal/src/layouts/inputs/components.tsx
+++ b/web/lib/opal/src/layouts/inputs/components.tsx
@@ -285,7 +285,7 @@ function InputErrorText({
 // ---------------------------------------------------------------------------
 
 function InputDivider() {
-  return <Divider paddingParallel="sm" paddingPerpendicular="sm" />;
+  return <Divider paddingParallel={2} paddingPerpendicular={2} />;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/lib/opal/src/layouts/settings/components.tsx
+++ b/web/lib/opal/src/layouts/settings/components.tsx
@@ -147,7 +147,7 @@ function SettingsHeader({
       {divider ? (
         <>
           <Spacer rem={1.5} />
-          <Divider paddingParallel="md" paddingPerpendicular="fit" />
+          <Divider paddingParallel={4} paddingPerpendicular={0} />
         </>
       ) : (
         <Spacer rem={0.5} />

--- a/web/lib/opal/src/layouts/toast/components.tsx
+++ b/web/lib/opal/src/layouts/toast/components.tsx
@@ -123,7 +123,7 @@ function ToastContainer({ errorAppendix }: ToastContainerProps) {
               variant={t.level ?? "info"}
               title={truncatedTitle}
               description={buildDescription(t, errorAppendix)}
-              padding="xs"
+              padding={1}
               onClose={t.dismissible ? () => handleClose(t.id) : undefined}
               bottomChildren={
                 isExpanded ? <ExpandedDetails message={t.message} /> : undefined

--- a/web/lib/opal/src/shared.ts
+++ b/web/lib/opal/src/shared.ts
@@ -13,7 +13,6 @@ import type {
   OverridableExtremaSizeVariants,
   ContainerSizeVariants,
   ExtremaSizeVariants,
-  PaddingVariants,
   RoundingVariants,
   Spacing,
 } from "@opal/types";
@@ -121,33 +120,6 @@ const heightVariants: Record<ExtremaSizeVariants, string> = {
 //   - SelectCard    (padding, rounding)
 // ---------------------------------------------------------------------------
 
-const paddingVariants: Record<PaddingVariants, string> = {
-  lg: "p-6",
-  md: "p-4",
-  sm: "p-2",
-  xs: "p-1",
-  "2xs": "p-0.5",
-  fit: "p-0",
-};
-
-const paddingXVariants: Record<PaddingVariants, string> = {
-  lg: "px-6",
-  md: "px-4",
-  sm: "px-2",
-  xs: "px-1",
-  "2xs": "px-0.5",
-  fit: "px-0",
-};
-
-const paddingYVariants: Record<PaddingVariants, string> = {
-  lg: "py-6",
-  md: "py-4",
-  sm: "py-2",
-  xs: "py-1",
-  "2xs": "py-0.5",
-  fit: "py-0",
-};
-
 /**
  * Converts a spacing step to a CSS length: `N` is `N / 4` rem.
  *
@@ -190,9 +162,6 @@ export {
   type Spacing,
   containerSizeVariants,
   spacingToRem,
-  paddingVariants,
-  paddingXVariants,
-  paddingYVariants,
   cardRoundingVariants,
   cardTopRoundingVariants,
   cardBottomRoundingVariants,

--- a/web/lib/opal/src/types.ts
+++ b/web/lib/opal/src/types.ts
@@ -46,23 +46,6 @@ export type SizeVariants =
 export type ContainerSizeVariants = Exclude<SizeVariants, "full" | "xl">;
 
 /**
- * Padding size variants.
- *
- * | Variant | Class   |
- * |---------|---------|
- * | `lg`    | `p-6`   |
- * | `md`    | `p-4`   |
- * | `sm`    | `p-2`   |
- * | `xs`    | `p-1`   |
- * | `2xs`   | `p-0.5` |
- * | `fit`   | `p-0`   |
- */
-export type PaddingVariants = Extract<
-  SizeVariants,
-  "fit" | "lg" | "md" | "sm" | "xs" | "2xs"
->;
-
-/**
  * Rounding size variants.
  *
  * | Variant | Class        |

--- a/web/src/app/admin/billing/CheckoutView.tsx
+++ b/web/src/app/admin/billing/CheckoutView.tsx
@@ -218,7 +218,7 @@ export default function CheckoutView({ onAdjustPlan }: CheckoutViewProps) {
             </Section>
           </InputHorizontal>
 
-          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+          <Divider paddingParallel={0} paddingPerpendicular={0} />
 
           {/* Seats */}
           <InputHorizontal

--- a/web/src/app/admin/connector/[ccPairId]/ConfigDisplay.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ConfigDisplay.tsx
@@ -228,7 +228,7 @@ export function AdvancedConfigDisplay({
             />
           </div>
           {index < items.length - 1 && (
-            <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+            <Divider paddingParallel={0} paddingPerpendicular={0} />
           )}
         </div>
       ))}
@@ -257,7 +257,7 @@ export function ConfigDisplay({
             />
           </div>
           {index < entries.length - 1 && (
-            <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+            <Divider paddingParallel={0} paddingPerpendicular={0} />
           )}
         </div>
       ))}

--- a/web/src/app/admin/scim/ScimSyncCard.tsx
+++ b/web/src/app/admin/scim/ScimSyncCard.tsx
@@ -65,7 +65,7 @@ export default function ScimSyncCard({
 
       {hasToken && (
         <>
-          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+          <Divider paddingParallel={0} paddingPerpendicular={0} />
 
           <Section
             flexDirection="row"

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -112,7 +112,7 @@ function ScopeOption({
   return (
     <SelectCard
       state={selected ? "selected" : "empty"}
-      padding="sm"
+      padding={2}
       rounding="sm"
       role="radio"
       aria-checked={selected}

--- a/web/src/app/craft/v1/apps/admin/AssociatedSkillsEditor.tsx
+++ b/web/src/app/craft/v1/apps/admin/AssociatedSkillsEditor.tsx
@@ -250,14 +250,14 @@ export default function AssociatedSkillsEditor({
       </div>
 
       {selectedSkillIds.length === 0 ? (
-        <Card border="solid" rounding="lg" padding="sm">
+        <Card border="solid" rounding="lg" padding={2}>
           <Text font="secondary-body" color="text-03">
             No skills are associated yet. This app can still be saved and used
             without one.
           </Text>
         </Card>
       ) : (
-        <Card border="solid" rounding="sm" padding="fit">
+        <Card border="solid" rounding="sm" padding={0}>
           <div className="flex max-h-48 flex-col divide-y divide-border-01 overflow-y-auto overscroll-contain">
             {selectedSkillIds.map((skillId) => {
               const skill = customSkillById.get(skillId);

--- a/web/src/app/craft/v1/tasks/components/ScheduleTaskForm.tsx
+++ b/web/src/app/craft/v1/tasks/components/ScheduleTaskForm.tsx
@@ -361,7 +361,7 @@ export default function ScheduleTaskForm({
           </InputVertical>
         </GeneralLayouts.Section>
 
-        <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+        <Divider paddingParallel={0} paddingPerpendicular={0} />
 
         <GeneralLayouts.Section>
           <InputVertical title="Schedule">
@@ -375,7 +375,7 @@ export default function ScheduleTaskForm({
           </InputVertical>
         </GeneralLayouts.Section>
 
-        <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+        <Divider paddingParallel={0} paddingPerpendicular={0} />
 
         <GeneralLayouts.Section>
           <InputVertical

--- a/web/src/app/mcp/oauth/callback/page.tsx
+++ b/web/src/app/mcp/oauth/callback/page.tsx
@@ -185,7 +185,7 @@ export default function MCPOAuthCallbackPage() {
   return (
     <div className="min-h-screen flex items-center justify-center p-4">
       <div className="w-full max-w-md">
-        <Card padding="lg" rounding="lg" background="light" border="solid">
+        <Card padding={6} rounding="lg" background="light" border="solid">
           <div className="flex flex-col items-stretch gap-4">
             {state.phase === "processing" && (
               <div className="flex flex-col items-center gap-3 p-5 text-center">

--- a/web/src/ee/sections/SearchUI.tsx
+++ b/web/src/ee/sections/SearchUI.tsx
@@ -312,7 +312,7 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
             </Popover>
           </div>
 
-          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+          <Divider paddingParallel={0} paddingPerpendicular={0} />
         </div>
 
         {!showEmpty && (
@@ -323,7 +323,7 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
               </Text>
             </Section>
 
-            <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+            <Divider paddingParallel={0} paddingPerpendicular={0} />
           </div>
         )}
       </div>

--- a/web/src/ee/views/admin/HooksPage/HookStatusPopover.tsx
+++ b/web/src/ee/views/admin/HooksPage/HookStatusPopover.tsx
@@ -250,7 +250,7 @@ export default function HookStatusPopover({
 
                 {topErrors.length > 0 ? (
                   <>
-                    <Divider paddingPerpendicular="fit" />
+                    <Divider paddingPerpendicular={0} />
 
                     <Section
                       flexDirection="column"
@@ -270,7 +270,7 @@ export default function HookStatusPopover({
                     </Section>
                   </>
                 ) : (
-                  <Divider paddingPerpendicular="fit" />
+                  <Divider paddingPerpendicular={0} />
                 )}
 
                 <LineItem
@@ -307,7 +307,7 @@ export default function HookStatusPopover({
                   />
                 </div>
 
-                <Divider paddingPerpendicular="fit" />
+                <Divider paddingPerpendicular={0} />
 
                 {/* Log rows — at most 3, timestamp first then error message */}
                 <Section
@@ -352,7 +352,7 @@ export default function HookStatusPopover({
                   />
                 </div>
 
-                <Divider paddingPerpendicular="fit" />
+                <Divider paddingPerpendicular={0} />
 
                 {/* View Older Errors */}
                 <LineItem

--- a/web/src/ee/views/admin/HooksPage/index.tsx
+++ b/web/src/ee/views/admin/HooksPage/index.tsx
@@ -176,7 +176,7 @@ function UnconnectedHookCard({ spec, onConnect }: UnconnectedHookCardProps) {
   const Icon = getHookPointIcon(spec.hook_point);
 
   return (
-    <SelectCard state="empty" padding="sm" rounding="lg" onClick={onConnect}>
+    <SelectCard state="empty" padding={2} rounding="lg" onClick={onConnect}>
       <div className="w-full flex flex-row">
         <div className="flex-1 p-2">
           <Content
@@ -342,7 +342,7 @@ function ConnectedHookCard({
 
       <Hoverable.Root group="connected-hook-card">
         {/* TODO(@raunakab): Modify the background colour (by using `SelectCard disabled={...}` [when it lands]) to indicate when the card is "disconnected". */}
-        <SelectCard state="filled" padding="sm" rounding="lg" onClick={onEdit}>
+        <SelectCard state="filled" padding={2} rounding="lg" onClick={onEdit}>
           <div className="w-full flex flex-row">
             <div className="flex-1 p-2">
               <Content

--- a/web/src/lib/credentials/components/CredentialSection.tsx
+++ b/web/src/lib/credentials/components/CredentialSection.tsx
@@ -217,7 +217,7 @@ export default function CredentialSection({
       rounded-lg
       bg-background"
     >
-      <Card padding="lg" border="solid" rounding="lg">
+      <Card padding={6} border="solid" rounding="lg">
         <div className="flex items-center">
           <div className="shrink-0 mr-3">
             <SvgKey size={16} className="text-muted-foreground" />

--- a/web/src/refresh-components/inputs/InputKeyValue.tsx
+++ b/web/src/refresh-components/inputs/InputKeyValue.tsx
@@ -347,7 +347,7 @@ export default function KeyValueInput({
       ) : (
         <EmptyMessageCard
           title="No items added yet."
-          padding="sm"
+          padding={2}
           sizePreset="secondary"
         />
       )}

--- a/web/src/refresh-components/inputs/InputSelect.tsx
+++ b/web/src/refresh-components/inputs/InputSelect.tsx
@@ -15,7 +15,7 @@ import {
 import Truncated from "@/refresh-components/texts/Truncated";
 import { SvgChevronDownSmall } from "@opal/icons";
 import { Divider } from "@opal/components";
-import type { PaddingVariants, WithoutStyles } from "@opal/types";
+import type { Spacing, WithoutStyles } from "@opal/types";
 
 // ============================================================================
 // Context
@@ -439,8 +439,8 @@ function InputSelectLabel({
 }
 
 interface InputSelectSeparatorProps {
-  paddingParallel?: PaddingVariants;
-  paddingPerpendicular?: PaddingVariants;
+  paddingParallel?: Spacing;
+  paddingPerpendicular?: Spacing;
 }
 
 function InputSelectSeparator({

--- a/web/src/refresh-components/modals/MemoriesModal.tsx
+++ b/web/src/refresh-components/modals/MemoriesModal.tsx
@@ -319,7 +319,7 @@ export default function MemoriesModal({
                     }}
                   />
                   {memory.isNew && (
-                    <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+                    <Divider paddingParallel={0} paddingPerpendicular={0} />
                   )}
                 </Fragment>
               ))}

--- a/web/src/sections/actions/PerUserAuthConfig.tsx
+++ b/web/src/sections/actions/PerUserAuthConfig.tsx
@@ -171,7 +171,7 @@ export function PerUserAuthConfig({
 
       {credentialFields.length > 0 && (
         <>
-          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+          <Divider paddingParallel={0} paddingPerpendicular={0} />
 
           <div className="flex flex-col gap-4">
             <div className="flex items-start gap-1">

--- a/web/src/sections/actions/modals/AddMCPServerModal.tsx
+++ b/web/src/sections/actions/modals/AddMCPServerModal.tsx
@@ -175,7 +175,7 @@ export default function AddMCPServerModal({
                   />
                 </InputVertical>
 
-                <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+                <Divider paddingParallel={0} paddingPerpendicular={0} />
 
                 <InputVertical
                   withLabel="server_url"
@@ -188,7 +188,7 @@ export default function AddMCPServerModal({
                   />
                 </InputVertical>
 
-                <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+                <Divider paddingParallel={0} paddingPerpendicular={0} />
 
                 {/* Access control: who can add this server's tools to agents.
                     Self-gates on tier/role; no-op when groups are unavailable. */}

--- a/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
+++ b/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
@@ -281,7 +281,7 @@ function FormContent({
           </Hoverable.Root>
         </InputVertical>
 
-        <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+        <Divider paddingParallel={0} paddingPerpendicular={0} />
 
         {methodSpecs && methodSpecs.length > 0 ? (
           <>
@@ -299,7 +299,7 @@ function FormContent({
                 description="URL found in the schema. Only connect to servers you trust."
               />
             )}
-            <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+            <Divider paddingParallel={0} paddingPerpendicular={0} />
             <Section gap={2}>
               {methodSpecs.map((method) => (
                 <ToolItem

--- a/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
@@ -619,7 +619,7 @@ export default function MCPAuthenticationModal({
                         }}
                       />
                     </FormField>
-                    <Divider paddingPerpendicular="fit" />
+                    <Divider paddingPerpendicular={0} />
                   </div>
 
                   {/* OAuth Section */}

--- a/web/src/sections/actions/modals/OpenAPIAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/OpenAPIAuthenticationModal.tsx
@@ -413,7 +413,7 @@ export default function OpenAPIAuthenticationModal({
                       </FormField>
                     </div>
 
-                    <Divider paddingPerpendicular="fit" />
+                    <Divider paddingPerpendicular={0} />
 
                     {values.authMethod === "oauth" && (
                       <section className="flex flex-col gap-4 rounded-12 bg-background-tint-00 border border-border-01 p-4">

--- a/web/src/sections/admin/ProviderCard.tsx
+++ b/web/src/sections/admin/ProviderCard.tsx
@@ -100,7 +100,7 @@ export default function ProviderCard({
     >
       <SelectCard
         state={STATUS_TO_STATE[status]}
-        padding="sm"
+        padding={2}
         rounding="lg"
         aria-label={ariaLabel}
         onClick={

--- a/web/src/sections/document-sidebar/DocumentsSidebar.tsx
+++ b/web/src/sections/document-sidebar/DocumentsSidebar.tsx
@@ -59,7 +59,7 @@ function Header({ children, onClose }: HeaderProps) {
           tooltip="Close Sidebar"
         />
       </div>
-      <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+      <Divider paddingParallel={0} paddingPerpendicular={0} />
     </div>
   );
 }

--- a/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
+++ b/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
@@ -894,7 +894,7 @@ export default function SourceHierarchyBrowser({
         </TableLayouts.TableCell>
       </TableLayouts.TableRow>
 
-      <OpalDivider paddingParallel="fit" paddingPerpendicular="fit" />
+      <OpalDivider paddingParallel={0} paddingPerpendicular={0} />
 
       {/* Scrollable table body */}
       <div

--- a/web/src/sections/knowledge/agent-knowledge/KnowledgeSearch.tsx
+++ b/web/src/sections/knowledge/agent-knowledge/KnowledgeSearch.tsx
@@ -276,7 +276,7 @@ export function KnowledgeSearchResultsPanel({
           </TableLayouts.TableCell>
         </TableLayouts.TableRow>
 
-        <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+        <Divider paddingParallel={0} paddingPerpendicular={0} />
 
         <div className="overflow-y-auto max-h-80">
           {allResults.map((entry) => {

--- a/web/src/sections/knowledge/agent-knowledge/KnowledgeSidebar.tsx
+++ b/web/src/sections/knowledge/agent-knowledge/KnowledgeSidebar.tsx
@@ -79,7 +79,7 @@ export function KnowledgeSidebar({
             Document Set
           </LineItem>
 
-          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+          <Divider paddingParallel={0} paddingPerpendicular={0} />
 
           {connectedSources.map((connectedSource) => {
             const sourceMetadata = getSourceMetadata(connectedSource.source);

--- a/web/src/sections/knowledge/agent-knowledge/KnowledgeTable.tsx
+++ b/web/src/sections/knowledge/agent-knowledge/KnowledgeTable.tsx
@@ -91,7 +91,7 @@ export function KnowledgeTable<T>({
         ))}
       </TableLayouts.TableRow>
 
-      <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+      <Divider paddingParallel={0} paddingPerpendicular={0} />
 
       {items.length === 0 ? (
         <GeneralLayouts.Section height="auto" padding={4}>

--- a/web/src/sections/modals/AgentViewerModal.tsx
+++ b/web/src/sections/modals/AgentViewerModal.tsx
@@ -57,7 +57,7 @@ function ViewerMCPServerCard({ server, tools }: ViewerMCPServerCardProps) {
       expanded={expanded}
       border="solid"
       rounding="lg"
-      padding="sm"
+      padding={2}
       expandedContent={
         tools.length > 0 ? (
           <div className="flex flex-col gap-2 p-2">
@@ -102,7 +102,7 @@ function ViewerMCPServerCard({ server, tools }: ViewerMCPServerCardProps) {
  */
 function ViewerOpenApiToolCard({ tool }: { tool: ToolSnapshot }) {
   return (
-    <Card border="solid" rounding="lg" padding="md">
+    <Card border="solid" rounding="lg" padding={4}>
       <Content
         icon={SvgActions}
         title={tool.display_name}
@@ -281,7 +281,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
           {agent.description && <Text text03>{agent.description}</Text>}
 
           {/* Knowledge */}
-          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+          <Divider paddingParallel={0} paddingPerpendicular={0} />
           <Section gap={2} alignItems="start">
             <Content
               title="Knowledge"
@@ -334,7 +334,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
           </SimpleCollapsible>
 
           {/* More Info (Collapsible) */}
-          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+          <Divider paddingParallel={0} paddingPerpendicular={0} />
           <SimpleCollapsible>
             <SimpleCollapsible.Header title="More Info" />
             <SimpleCollapsible.Content>
@@ -378,7 +378,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
           {/* Prompt Reminders */}
           {agent.task_prompt && (
             <>
-              <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+              <Divider paddingParallel={0} paddingPerpendicular={0} />
               <Content
                 title="Prompt Reminders"
                 description={agent.task_prompt}
@@ -391,7 +391,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
           {/* Conversation Starters */}
           {agent.starter_messages && agent.starter_messages.length > 0 && (
             <>
-              <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+              <Divider paddingParallel={0} paddingPerpendicular={0} />
               <Content
                 title="Conversation Starters"
                 sizePreset="main-content"

--- a/web/src/sections/modals/ShareAgentModal.tsx
+++ b/web/src/sections/modals/ShareAgentModal.tsx
@@ -568,7 +568,7 @@ export default function ShareAgentModal({
           }
         />
 
-        <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+        <Divider paddingParallel={0} paddingPerpendicular={0} />
 
         {/* Admins always appear and always hold edit access (ENG-4175);
             on vacant agents this row carries the transfer affordance */}

--- a/web/src/sections/modals/ShareChatSessionModal.tsx
+++ b/web/src/sections/modals/ShareChatSessionModal.tsx
@@ -63,7 +63,7 @@ function PrivacyOption({
   return (
     <SelectCard
       state={selected ? "filled" : "empty"}
-      padding="sm"
+      padding={2}
       rounding="sm"
       border="none"
       onClick={onClick}

--- a/web/src/sections/modals/languageModels/BedrockModal.tsx
+++ b/web/src/sections/modals/languageModels/BedrockModal.tsx
@@ -180,7 +180,7 @@ function BedrockModalInternals({
       </InputPadder>
 
       {authMethod === AUTH_METHOD_ACCESS_KEY && (
-        <Card background="light" border="none" padding="sm">
+        <Card background="light" border="none" padding={2}>
           <Section gap={4}>
             <InputVertical
               withLabel={FIELD_AWS_ACCESS_KEY_ID}
@@ -214,7 +214,7 @@ function BedrockModalInternals({
       )}
 
       {authMethod === AUTH_METHOD_LONG_TERM_API_KEY && (
-        <Card background="light" border="none" padding="sm">
+        <Card background="light" border="none" padding={2}>
           <Section gap={2}>
             <InputVertical
               withLabel={FIELD_AWS_BEARER_TOKEN_BEDROCK}

--- a/web/src/sections/modals/languageModels/CustomModal.tsx
+++ b/web/src/sections/modals/languageModels/CustomModal.tsx
@@ -166,7 +166,7 @@ function ModelConfigurationList() {
           ))}
         </div>
       ) : (
-        <EmptyMessageCard title="No models added yet." padding="sm" />
+        <EmptyMessageCard title="No models added yet." padding={2} />
       )}
 
       <Button
@@ -442,7 +442,7 @@ export default function CustomModal({
           />
         </InputPadder>
 
-        <Card padding="sm">
+        <Card padding={2}>
           <ModelConfigurationList />
         </Card>
       </Section>

--- a/web/src/sections/modals/languageModels/OllamaModal.tsx
+++ b/web/src/sections/modals/languageModels/OllamaModal.tsx
@@ -92,7 +92,7 @@ function OllamaModalInternals({
 
   return (
     <>
-      <Card background="light" border="none" padding="sm">
+      <Card background="light" border="none" padding={2}>
         <Tabs value={tab} onValueChange={(value) => setTab(value as Tab)}>
           <Tabs.List>
             <Tabs.Trigger value={Tab.TAB_SELF_HOSTED}>

--- a/web/src/sections/modals/languageModels/VertexAIModal.tsx
+++ b/web/src/sections/modals/languageModels/VertexAIModal.tsx
@@ -139,7 +139,7 @@ function VertexAIModalInternals({
               title="Onyx will use the pod's ambient Google Cloud credentials (via google.auth.default). Ensure the Kubernetes ServiceAccount is bound to a GCP Service Account with access to Vertex AI."
             />
           </InputPadder>
-          <Card background="light" border="none" padding="sm">
+          <Card background="light" border="none" padding={2}>
             <InputVertical
               withLabel={FIELD_VERTEX_PROJECT}
               title="GCP Project ID"

--- a/web/src/sections/modals/languageModels/shared.tsx
+++ b/web/src/sections/modals/languageModels/shared.tsx
@@ -292,7 +292,7 @@ export function ModelAccessField() {
       </InputPadder>
 
       {!isPublic && (
-        <Card background="light" border="none" padding="sm">
+        <Card background="light" border="none" padding={2}>
           <Section gap={2}>
             <InputComboBox
               placeholder="Add groups and agents"
@@ -304,7 +304,7 @@ export function ModelAccessField() {
               searchIcon
             />
 
-            <Card background="heavy" border="none" padding="sm">
+            <Card background="heavy" border="none" padding={2}>
               <ContentAction
                 icon={SvgUserManage}
                 title="Admin"
@@ -328,7 +328,7 @@ export function ModelAccessField() {
                   const memberCount = group?.users.length ?? 0;
                   return (
                     <div key={`group-${id}`} className="min-w-0">
-                      <Card background="heavy" border="none" padding="sm">
+                      <Card background="heavy" border="none" padding={2}>
                         <ContentAction
                           icon={SvgUsers}
                           title={group?.name ?? `Group ${id}`}
@@ -363,7 +363,7 @@ export function ModelAccessField() {
                   const agent = agentMap.get(id);
                   return (
                     <div key={`agent-${id}`} className="min-w-0">
-                      <Card background="heavy" border="none" padding="sm">
+                      <Card background="heavy" border="none" padding={2}>
                         <ContentAction
                           icon={
                             agent
@@ -674,7 +674,7 @@ export function ModelSelectionField({
   const visibleModels = models.filter((m) => m.is_visible);
 
   return (
-    <Card background="light" border="none" padding="sm">
+    <Card background="light" border="none" padding={2}>
       <Section gap={2}>
         <InputHorizontal
           title="Models"
@@ -697,7 +697,7 @@ export function ModelSelectionField({
         {models.length === 0 ? (
           <EmptyMessageCard
             title={emptyMessage ?? "No models available."}
-            padding="sm"
+            padding={2}
           />
         ) : (
           <Section gap={1} alignItems="stretch">

--- a/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.tsx
+++ b/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.tsx
@@ -264,7 +264,7 @@ export function ImportSkillsFromGitHubModalView({
               {result.imported.length > 0 && (
                 <section className="flex flex-col gap-1.5">
                   <Text font="main-ui-action">Imported</Text>
-                  <Card border="solid" rounding="sm" padding="fit">
+                  <Card border="solid" rounding="sm" padding={0}>
                     <div className="divide-y divide-border-01">
                       {result.imported.map((item) => (
                         <div
@@ -297,7 +297,7 @@ export function ImportSkillsFromGitHubModalView({
               {resultNotImported.length > 0 && (
                 <section className="flex flex-col gap-1.5">
                   <Text font="main-ui-action">Not imported</Text>
-                  <Card border="solid" rounding="sm" padding="fit">
+                  <Card border="solid" rounding="sm" padding={0}>
                     <div className="divide-y divide-border-01">
                       {resultNotImported.map((item) => (
                         <div
@@ -376,7 +376,7 @@ export function ImportSkillsFromGitHubModalView({
                       {`${selectedPaths.length} of ${importablePaths.length} importable ${importablePaths.length === 1 ? "skill" : "skills"} selected`}
                     </Text>
                   </div>
-                  <Card border="solid" rounding="sm" padding="fit">
+                  <Card border="solid" rounding="sm" padding={0}>
                     <div className="max-h-80 divide-y divide-border-01 overflow-y-auto overscroll-contain">
                       {preview.skills.map((skill) => {
                         const unavailable = skill.unavailable_reason !== null;

--- a/web/src/sections/modals/skills/ShareSkillModal.tsx
+++ b/web/src/sections/modals/skills/ShareSkillModal.tsx
@@ -404,7 +404,7 @@ export default function ShareSkillModal({
           </Text>
         )}
 
-        <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+        <Divider paddingParallel={0} paddingPerpendicular={0} />
 
         {skill.owner ? (
           <ShareAccessRow

--- a/web/src/sections/model-selector/MultiModelSelector.tsx
+++ b/web/src/sections/model-selector/MultiModelSelector.tsx
@@ -195,8 +195,8 @@ export default function MultiModelSelector({
               {!atMax && (
                 <Divider
                   orientation="vertical"
-                  paddingParallel="sm"
-                  paddingPerpendicular="sm"
+                  paddingParallel={2}
+                  paddingPerpendicular={2}
                 />
               )}
               <div className="flex items-center shrink-0">
@@ -216,8 +216,8 @@ export default function MultiModelSelector({
                       {index > 0 && (
                         <Divider
                           orientation="vertical"
-                          paddingParallel="sm"
-                          paddingPerpendicular="sm"
+                          paddingParallel={2}
+                          paddingPerpendicular={2}
                         />
                       )}
                       <SelectButton

--- a/web/src/sections/projects/ProjectChatSessionList.tsx
+++ b/web/src/sections/projects/ProjectChatSessionList.tsx
@@ -302,7 +302,7 @@ export default function ProjectChatSessionList() {
         {isLoadingProjectDetails && !currentProjectDetails ? (
           <SvgSimpleLoader className="mx-4" />
         ) : projectChats.length === 0 ? (
-          <Card rounding="md" border="dashed" background="none" padding="sm">
+          <Card rounding="md" border="dashed" background="none" padding={2}>
             <div className="p-1">
               <Text as="p" font="secondary-body" color="text-02">
                 No chats yet.

--- a/web/src/sections/projects/ProjectContextPanel.tsx
+++ b/web/src/sections/projects/ProjectContextPanel.tsx
@@ -134,7 +134,7 @@ export default function ProjectContextPanel({
           }}
         />
 
-        <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+        <Divider paddingParallel={0} paddingPerpendicular={0} />
 
         <ContentAction
           sizePreset="main-ui"

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -302,7 +302,7 @@ export default function AdminSidebar() {
 
         {disabledGroups.length > 0 && (
           <>
-            <Divider paddingPerpendicular="fit" />
+            <Divider paddingPerpendicular={0} />
             {/* Empty div here just to add spacing (via the `gap` property on `SidebarLayouts.Body`) */}
             <div />
           </>
@@ -330,7 +330,7 @@ export default function AdminSidebar() {
       </SidebarLayouts.Body>
 
       <SidebarLayouts.Footer>
-        {!folded && <Divider paddingPerpendicular="sm" />}
+        {!folded && <Divider paddingPerpendicular={2} />}
         <SidebarTab
           icon={SvgX}
           href={pathname?.startsWith("/admin/craft") ? "/craft/v1" : "/app"}

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -347,7 +347,7 @@ function MCPServerCard({
             !getFieldMeta<boolean>(`${serverFieldName}.enabled`).value;
           return (
             <Disabled key={tool.id} disabled={toolDisabled}>
-              <Card border="solid" rounding="md" padding="sm">
+              <Card border="solid" rounding="md" padding={2}>
                 <ContentAction
                   icon={tool.icon ?? SvgSliders}
                   title={tool.name}
@@ -380,7 +380,7 @@ function MCPServerCard({
         expanded={!isFolded}
         border="solid"
         rounding="lg"
-        padding="sm"
+        padding={2}
         expandedContent={cardContent}
       >
         <CardLayout.Header
@@ -1406,10 +1406,7 @@ export default function AgentEditorPage({
                         </GeneralLayouts.Section>
                       </GeneralLayouts.Section>
 
-                      <Divider
-                        paddingParallel="fit"
-                        paddingPerpendicular="fit"
-                      />
+                      <Divider paddingParallel={0} paddingPerpendicular={0} />
 
                       <GeneralLayouts.Section>
                         <InputVertical
@@ -1437,10 +1434,7 @@ export default function AgentEditorPage({
                         </InputVertical>
                       </GeneralLayouts.Section>
 
-                      <Divider
-                        paddingParallel="fit"
-                        paddingPerpendicular="fit"
-                      />
+                      <Divider paddingParallel={0} paddingPerpendicular={0} />
 
                       <AgentKnowledgePane
                         enableKnowledge={values.enable_knowledge}
@@ -1485,10 +1479,7 @@ export default function AgentEditorPage({
                         vectorDbEnabled={vectorDbEnabled}
                       />
 
-                      <Divider
-                        paddingParallel="fit"
-                        paddingPerpendicular="fit"
-                      />
+                      <Divider paddingParallel={0} paddingPerpendicular={0} />
 
                       <GeneralLayouts.Section
                         gap={2}
@@ -1580,10 +1571,7 @@ export default function AgentEditorPage({
                         </Card>
                       </GeneralLayouts.Section>
 
-                      <Divider
-                        paddingParallel="fit"
-                        paddingPerpendicular="fit"
-                      />
+                      <Divider paddingParallel={0} paddingPerpendicular={0} />
 
                       <SimpleCollapsible>
                         <SimpleCollapsible.Header
@@ -1681,8 +1669,8 @@ export default function AgentEditorPage({
                               {(mcpServersWithVisibleTools.length > 0 ||
                                 openApiTools.length > 0) && (
                                 <Divider
-                                  paddingPerpendicular="xs"
-                                  paddingParallel="fit"
+                                  paddingPerpendicular={1}
+                                  paddingParallel={0}
                                 />
                               )}
 
@@ -1721,10 +1709,7 @@ export default function AgentEditorPage({
                         </SimpleCollapsible.Content>
                       </SimpleCollapsible>
 
-                      <Divider
-                        paddingParallel="fit"
-                        paddingPerpendicular="fit"
-                      />
+                      <Divider paddingParallel={0} paddingPerpendicular={0} />
 
                       <SimpleCollapsible>
                         <SimpleCollapsible.Header
@@ -1806,8 +1791,8 @@ export default function AgentEditorPage({
                       {existingAgent && (
                         <>
                           <Divider
-                            paddingParallel="fit"
-                            paddingPerpendicular="fit"
+                            paddingParallel={0}
+                            paddingPerpendicular={0}
                           />
 
                           <Card border="solid" rounding="lg">

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -635,7 +635,7 @@ function GeneralSettings() {
           </Card>
         </Section>
 
-        <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+        <Divider paddingParallel={0} paddingPerpendicular={0} />
 
         <Section gap={3}>
           <Content

--- a/web/src/views/SkillEditorPage.tsx
+++ b/web/src/views/SkillEditorPage.tsx
@@ -551,7 +551,7 @@ export default function SkillEditorPage({
               {isCreating && !creationDraft && (
                 <>
                   <Section gap={2} alignItems="stretch" height="auto">
-                    <Card border="solid" rounding="lg" padding="sm">
+                    <Card border="solid" rounding="lg" padding={2}>
                       <Section gap={2} alignItems="stretch" height="auto">
                         <Content
                           title="Have an existing skill?"
@@ -575,7 +575,7 @@ export default function SkillEditorPage({
                     </Card>
                   </Section>
 
-                  <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+                  <Divider paddingParallel={0} paddingPerpendicular={0} />
                 </>
               )}
 
@@ -641,7 +641,7 @@ export default function SkillEditorPage({
                 </InputVertical>
               </Section>
 
-              <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+              <Divider paddingParallel={0} paddingPerpendicular={0} />
 
               <Section alignItems="stretch">
                 <div className="flex w-full items-start justify-between gap-2">
@@ -657,7 +657,7 @@ export default function SkillEditorPage({
                   />
                 </div>
 
-                <Card border="solid" rounding="lg" padding="sm">
+                <Card border="solid" rounding="lg" padding={2}>
                   {instructionsDisplayMode === "raw" ? (
                     <InputTextArea
                       id="instructions_markdown"
@@ -680,7 +680,7 @@ export default function SkillEditorPage({
                 </Card>
               </Section>
 
-              <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+              <Divider paddingParallel={0} paddingPerpendicular={0} />
 
               <Section gap={2} alignItems="stretch" height="auto">
                 <Content
@@ -727,7 +727,7 @@ export default function SkillEditorPage({
 
               {skill && (
                 <>
-                  <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+                  <Divider paddingParallel={0} paddingPerpendicular={0} />
 
                   <Section gap={2} alignItems="stretch" height="auto">
                     <Content
@@ -801,10 +801,7 @@ export default function SkillEditorPage({
 
                   {canManageSkill && (
                     <>
-                      <Divider
-                        paddingParallel="fit"
-                        paddingPerpendicular="fit"
-                      />
+                      <Divider paddingParallel={0} paddingPerpendicular={0} />
 
                       <Card border="solid" rounding="lg">
                         <Section>

--- a/web/src/views/admin/ChatPreferencesPage.tsx
+++ b/web/src/views/admin/ChatPreferencesPage.tsx
@@ -128,7 +128,7 @@ function MCPServerCard({
       expanded={expanded}
       border="solid"
       rounding="lg"
-      padding="sm"
+      padding={2}
       expandedContent={
         hasContent ? (
           <Section gap={2} padding={2}>
@@ -1051,7 +1051,7 @@ export default function ChatPreferencesPage() {
             </Section>
           </Card>
 
-          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+          <Divider paddingParallel={0} paddingPerpendicular={0} />
 
           {/* Team Context */}
           <Section gap={4}>
@@ -1112,7 +1112,7 @@ export default function ChatPreferencesPage() {
             </Button>
           </InputHorizontal>
 
-          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+          <Divider paddingParallel={0} paddingPerpendicular={0} />
 
           <Disabled disabled={s.disable_default_assistant ?? false}>
             <div>
@@ -1148,7 +1148,7 @@ export default function ChatPreferencesPage() {
                             const meta = getSourceMetadata(source);
                             return (
                               <div key={source} className="w-40">
-                                <Card padding="sm" border="solid">
+                                <Card padding={2} border="solid">
                                   <Content
                                     icon={meta.icon}
                                     title={meta.displayName}
@@ -1324,10 +1324,7 @@ export default function ChatPreferencesPage() {
                     {/* Separator between built-in tools and MCP/OpenAPI tools */}
                     {(mcpServersWithTools.length > 0 ||
                       openApiTools.length > 0) && (
-                      <Divider
-                        paddingPerpendicular="sm"
-                        paddingParallel="fit"
-                      />
+                      <Divider paddingPerpendicular={2} paddingParallel={0} />
                     )}
 
                     {/* MCP Servers & OpenAPI Tools */}
@@ -1366,7 +1363,7 @@ export default function ChatPreferencesPage() {
             </div>
           </Disabled>
 
-          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+          <Divider paddingParallel={0} paddingPerpendicular={0} />
 
           {/* Advanced Options */}
           <SimpleCollapsible defaultOpen={false}>
@@ -1600,7 +1597,7 @@ export default function ChatPreferencesPage() {
                     <MessageCard
                       title="Modify with caution."
                       description="System prompt affects all chats, agents, and projects. Significant changes may degrade response quality."
-                      padding="xs"
+                      padding={1}
                     />
                   </Modal.Body>
                   <Modal.Footer>

--- a/web/src/views/admin/CodeInterpreterPage/index.tsx
+++ b/web/src/views/admin/CodeInterpreterPage/index.tsx
@@ -174,7 +174,7 @@ export default function CodeInterpreterPage() {
             group="code-interpreter/Card"
             interaction={showDisconnectModal ? "hover" : "rest"}
           >
-            <SelectCard state="filled" padding="sm" rounding="lg">
+            <SelectCard state="filled" padding={2} rounding="lg">
               <Card.Header>
                 <ContentAction
                   sizePreset="main-ui"
@@ -226,7 +226,7 @@ export default function CodeInterpreterPage() {
         ) : (
           <SelectCard
             state="empty"
-            padding="sm"
+            padding={2}
             rounding="lg"
             onClick={() => handleToggle(true)}
           >
@@ -264,7 +264,7 @@ export default function CodeInterpreterPage() {
             onMouseLeave={() => handleErrorHover(false)}
           >
             <div className="w-[15rem]">
-              <SelectCard state="filled" padding="sm" rounding="lg">
+              <SelectCard state="filled" padding={2} rounding="lg">
                 <Content
                   icon={(props) => (
                     <SvgXOctagon

--- a/web/src/views/admin/CostOverridesPanel.tsx
+++ b/web/src/views/admin/CostOverridesPanel.tsx
@@ -248,7 +248,7 @@ function OverrideRow({ override }: OverrideRowProps) {
 
   return (
     <Hoverable.Root group="OverrideRow">
-      <Card border="solid" rounding="lg" padding="sm">
+      <Card border="solid" rounding="lg" padding={2}>
         <div className="flex flex-row items-center justify-between gap-2 p-2">
           <div className="flex flex-col gap-0.5 min-w-0">
             <Text font="main-ui-action" color="text-04" nowrap>

--- a/web/src/views/admin/GroupsPage/CreateGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/CreateGroupPage.tsx
@@ -113,7 +113,7 @@ function CreateGroupPage() {
           />
         </Section>
 
-        <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+        <Divider paddingParallel={0} paddingPerpendicular={0} />
 
         {/* Members table */}
         {isLoading && <SvgSimpleLoader />}

--- a/web/src/views/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/EditGroupPage.tsx
@@ -375,7 +375,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                 />
               </Section>
 
-              <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+              <Divider paddingParallel={0} paddingPerpendicular={0} />
 
               {/* Members table */}
               <Section

--- a/web/src/views/admin/GroupsPage/GroupsList.tsx
+++ b/web/src/views/admin/GroupsPage/GroupsList.tsx
@@ -41,7 +41,7 @@ function GroupsList({ groups, searchQuery }: GroupsListProps) {
       ))}
 
       {builtInGroups.length > 0 && customGroups.length > 0 && (
-        <Divider paddingPerpendicular="sm" paddingParallel="fit" />
+        <Divider paddingPerpendicular={2} paddingParallel={0} />
       )}
 
       {customGroups.map((group) => (

--- a/web/src/views/admin/GroupsPage/SharedGroupResources/ResourcePopover.tsx
+++ b/web/src/views/admin/GroupsPage/SharedGroupResources/ResourcePopover.tsx
@@ -68,10 +68,7 @@ function ResourcePopover({
                         <Text secondaryBody text03 className="shrink-0">
                           {section.label}
                         </Text>
-                        <Divider
-                          paddingParallel="fit"
-                          paddingPerpendicular="fit"
-                        />
+                        <Divider paddingParallel={0} paddingPerpendicular={0} />
                       </Section>
                     )}
                     <Section

--- a/web/src/views/admin/GroupsPage/SharedGroupResources/index.tsx
+++ b/web/src/views/admin/GroupsPage/SharedGroupResources/index.tsx
@@ -341,7 +341,7 @@ function SharedGroupResources({
               )}
             </Section>
 
-            <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+            <Divider paddingParallel={0} paddingPerpendicular={0} />
 
             {/* Agents */}
             <Section

--- a/web/src/views/admin/IndexSettingsPage/index.tsx
+++ b/web/src/views/admin/IndexSettingsPage/index.tsx
@@ -393,7 +393,7 @@ function ProviderGroup({
           <SelectCard
             state="filled"
             rounding="md"
-            padding="sm"
+            padding={2}
             onClick={() => providerCreationModal.toggle(true)}
           >
             <ContentAction
@@ -521,7 +521,7 @@ function EmbeddingModelCard({
     <SelectCard
       state={cardState}
       rounding="md"
-      padding="xs"
+      padding={1}
       onClick={isClickable ? onSelect : undefined}
     >
       <GeneralLayouts.Section flexDirection="row" alignItems="start">
@@ -959,7 +959,7 @@ export default function IndexSettingsPage() {
                       // Non-port reindex has no PortAttempt progress → the original banner.
                       <MessageCard
                         variant="warning"
-                        headerPadding="sm"
+                        headerPadding={2}
                         title="Re-indexing in progress"
                         description={markdown(
                           `Switching to **${secondarySearchSettings?.model_name}**. Existing documents are being re-embedded — this may take hours or days depending on corpus size. The previous model continues to serve queries until the switchover completes.`
@@ -994,7 +994,7 @@ export default function IndexSettingsPage() {
                         variant={
                           contextualRagModelMissing ? "error" : statusVariant
                         }
-                        headerPadding="sm"
+                        headerPadding={2}
                         title={
                           contextualRagModelMissing
                             ? "Select a Contextual Retrieval LLM"
@@ -1091,7 +1091,7 @@ export default function IndexSettingsPage() {
 
                         {NEXT_PUBLIC_CLOUD_ENABLED ? (
                           <CloudDisabled>
-                            <Card border="solid" rounding="lg" padding="sm">
+                            <Card border="solid" rounding="lg" padding={2}>
                               <GeneralLayouts.Section padding={2}>
                                 <Content
                                   icon={SvgVector}
@@ -1116,7 +1116,7 @@ export default function IndexSettingsPage() {
                                 border="solid"
                                 borderColor={statusVariant}
                                 rounding="lg"
-                                padding={viewAllModelsOpen ? "fit" : "sm"}
+                                padding={viewAllModelsOpen ? 0 : 2}
                                 expandedContent={
                                   <>
                                     <Tabs.Content value={MODEL_TAB_CLOUD}>
@@ -1269,7 +1269,7 @@ export default function IndexSettingsPage() {
                                             <SelectCard
                                               state="filled"
                                               rounding="md"
-                                              padding="sm"
+                                              padding={2}
                                               onClick={() =>
                                                 customModelModal.toggle(true)
                                               }
@@ -1443,10 +1443,7 @@ export default function IndexSettingsPage() {
                         )}
                       </GeneralLayouts.Section>
 
-                      <Divider
-                        paddingParallel="fit"
-                        paddingPerpendicular="fit"
-                      />
+                      <Divider paddingParallel={0} paddingPerpendicular={0} />
 
                       {/* ── Retrieval Optimization ── */}
                       <GeneralLayouts.Section
@@ -1544,10 +1541,7 @@ export default function IndexSettingsPage() {
                         </CloudDisabled>
                       </GeneralLayouts.Section>
 
-                      <Divider
-                        paddingParallel="fit"
-                        paddingPerpendicular="fit"
-                      />
+                      <Divider paddingParallel={0} paddingPerpendicular={0} />
 
                       {/* ── Image Processing ── */}
                       <GeneralLayouts.Section

--- a/web/src/views/admin/IndexSettingsPage/shared.tsx
+++ b/web/src/views/admin/IndexSettingsPage/shared.tsx
@@ -170,7 +170,7 @@ export function ModelSpecFields({
         subDescription={modelNameSubDescription}
       />
 
-      <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+      <Divider paddingParallel={0} paddingPerpendicular={0} />
 
       <TextField
         name="modelDim"

--- a/web/src/views/admin/LanguageModelsPage.tsx
+++ b/web/src/views/admin/LanguageModelsPage.tsx
@@ -176,7 +176,7 @@ function ExistingProviderCard({
       >
         <SelectCard
           state="filled"
-          padding="sm"
+          padding={2}
           rounding="lg"
           onClick={() => setIsOpen(true)}
         >
@@ -241,7 +241,7 @@ function NewProviderCard({
   return (
     <SelectCard
       state="empty"
-      padding="sm"
+      padding={2}
       rounding="lg"
       onClick={() => setIsOpen(true)}
     >
@@ -294,7 +294,7 @@ function NewCustomProviderCard({
 
       <SelectCard
         state="empty"
-        padding="sm"
+        padding={2}
         rounding="lg"
         onClick={() => setIsOpen(true)}
       >
@@ -457,7 +457,7 @@ export default function LanguageModelsPage() {
               </div>
             </GeneralLayouts.Section>
 
-            <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+            <Divider paddingParallel={0} paddingPerpendicular={0} />
           </>
         )}
 
@@ -466,7 +466,7 @@ export default function LanguageModelsPage() {
           <MessageCard
             title="New LLM configuration temporarily unavailable."
             description="Existing LLM providers can still be used and updated."
-            headerPadding="xs"
+            headerPadding={1}
           />
         )}
 
@@ -511,7 +511,7 @@ export default function LanguageModelsPage() {
           </div>
         </Disabled>
 
-        <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+        <Divider paddingParallel={0} paddingPerpendicular={0} />
 
         {/* ── Cost Overrides — negotiated per-model rates for usage costing ── */}
         <CostOverridesPanel />

--- a/web/src/views/admin/PerUserUsagePanel.tsx
+++ b/web/src/views/admin/PerUserUsagePanel.tsx
@@ -154,7 +154,7 @@ export default function PerUserUsagePanel({
     >
       {header}
 
-      <Card border="solid" rounding="lg" padding="sm">
+      <Card border="solid" rounding="lg" padding={2}>
         <div className="flex flex-wrap gap-2">
           <div className="basis-1/2 lg:basis-1/4">
             <SummaryMetric
@@ -212,7 +212,7 @@ export default function PerUserUsagePanel({
         </Section>
 
         {users.length === 0 ? (
-          <Card border="solid" rounding="lg" padding="sm">
+          <Card border="solid" rounding="lg" padding={2}>
             <Text font="main-ui-body" color="text-03">
               No usage recorded for this period.
             </Text>

--- a/web/src/views/admin/ServiceAccountsPage/EditServiceAccountModal.tsx
+++ b/web/src/views/admin/ServiceAccountsPage/EditServiceAccountModal.tsx
@@ -301,7 +301,7 @@ export default function EditServiceAccountModal({
               </ShadowDiv>
             </Section>
 
-            <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+            <Divider paddingParallel={0} paddingPerpendicular={0} />
 
             <ContentAction
               title="Account Role"

--- a/web/src/views/admin/UsersPage/EditUserModal.tsx
+++ b/web/src/views/admin/UsersPage/EditUserModal.tsx
@@ -294,7 +294,7 @@ export default function EditUserModal({
             </Section>
             {user.role && (
               <>
-                <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+                <Divider paddingParallel={0} paddingPerpendicular={0} />
 
                 <ContentAction
                   title="User Role"

--- a/web/src/views/admin/UsersPage/UserRowActions.tsx
+++ b/web/src/views/admin/UsersPage/UserRowActions.tsx
@@ -90,7 +90,7 @@ export default function UserRowActions({
               Deactivate User
             </LineItem>
           </Disabled>
-          <Divider paddingPerpendicular="md" />
+          <Divider paddingPerpendicular={4} />
           <Text as="p" secondaryBody text03 className="px-3 py-1">
             This is a synced SCIM user managed by your identity provider.
           </Text>
@@ -150,7 +150,7 @@ export default function UserRowActions({
             >
               Reset Password
             </LineItem>
-            <Divider paddingPerpendicular="md" />
+            <Divider paddingPerpendicular={4} />
             <LineItem
               danger
               icon={SvgUserX}
@@ -178,14 +178,14 @@ export default function UserRowActions({
             >
               Reset Password
             </LineItem>
-            <Divider paddingPerpendicular="md" />
+            <Divider paddingPerpendicular={4} />
             <LineItem
               icon={SvgUserPlus}
               onClick={() => openModal(Modal.ACTIVATE)}
             >
               Activate User
             </LineItem>
-            <Divider paddingPerpendicular="md" />
+            <Divider paddingPerpendicular={4} />
             <LineItem
               danger
               icon={SvgUserX}


### PR DESCRIPTION
## Description

Follow-up to #13909, which added `Spacing` and moved `Section` and `Tabs.Content` onto it.

This moves the rest of the named padding scale over. `Card`, `SelectCard`, `EmptyMessageCard`, `MessageCard` (and its `headerPadding`), `Divider`, and both `InputSelect`s now take `Spacing` instead of `PaddingVariants`. That leaves `ContentAction` as the last holdout — it uses a *different* named scale where `lg` is 8px rather than 24px, so it converts differently and moves in its own PR.

Because these components applied padding as a Tailwind class, they now compute it the way `Section` does. That orphans and deletes `paddingVariants`, `paddingXVariants`, `paddingYVariants`, and the `PaddingVariants` type — `Divider` was the only component reading the two axis maps.

`Divider` keeps `paddingParallel` / `paddingPerpendicular` rather than gaining a positional form. Its axes follow the line's orientation — for a vertical divider "parallel" is the Y axis, for a horizontal one it's X — so neither maps to a fixed side.

Conversion used the old scale: `lg→6, md→4, sm→2, xs→1, 2xs→0.5, fit→0`. Nothing should move by a pixel.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves remaining Opal padding props from named tokens to numeric `Spacing` computed with `spacingToRem`. Old: Tailwind `p-*` classes and string tokens; new: numbers (`N/4rem`) consistent with `Section`. Removes `paddingVariants` maps and the `PaddingVariants` type; padding is now applied via inline styles.

- **Migration**
  - Replace string tokens with numbers using the legacy map: lg→6, md→4, sm→2, xs→1, 2xs→0.5, fit→0.
  - `MessageCard` `padding` is restricted to `1 | 2`; `headerPadding` is numeric `Spacing` (default `0`).
  - `Divider` keeps `paddingParallel`/`paddingPerpendicular` as numeric `Spacing` (defaults `2`/`1`).
  - Remove imports/usages of `PaddingVariants`, `paddingVariants`, `paddingXVariants`, `paddingYVariants`.

- **Review focus**
  - Visual pass on cards and dividers; spacing should be unchanged. Defaults: `Card` 4; `SelectCard` 4; `EmptyMessageCard` 4; `MessageCard` 2 with `headerPadding` 0; `Divider` 2/1.
  - Inline padding styles replace classes; Tailwind class-based overrides on containers will no longer affect component padding.
  - Docs and JSDoc updated to numeric `Spacing`; confirm generated API shows numbers and defaults.

<sup>Written for commit 8f7c3610b5dd709852f3d72dc382911b2f64952d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

