### PR TITLE
refactor(opal): read sidebar fold state from context in SidebarTab

### DIFF
--- a/web/lib/opal/src/components/buttons/sidebar-tab/SidebarTab.test.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/SidebarTab.test.tsx
@@ -1,0 +1,55 @@
+// SidebarTab reads its fold state from the enclosing sidebar, not from the
+// app-wide sidebar state. SidebarTab is also used for page-level tab
+// navigation (e.g. the settings page), and those tabs must stay expanded when
+// the app sidebar folds.
+import { render, screen } from "@tests/setup/test-utils";
+import { SidebarTab } from "@opal/components";
+import { SidebarLayouts, SidebarStateProvider } from "@opal/layouts";
+import { renderSidebarLogo } from "@/lib/sidebar/utils";
+
+jest.mock("@opal/hooks/useScreenSize", () => ({
+  __esModule: true,
+  default: () => ({ isMobile: false, isSmallScreen: false }),
+}));
+
+function FoldedSidebar({ foldable }: { foldable?: boolean }) {
+  return (
+    <SidebarStateProvider defaultFolded>
+      <SidebarLayouts.Root foldable={foldable}>
+        <SidebarLayouts.Header renderAppLogo={renderSidebarLogo}>
+          <SidebarTab href="/settings">Settings</SidebarTab>
+        </SidebarLayouts.Header>
+      </SidebarLayouts.Root>
+    </SidebarStateProvider>
+  );
+}
+
+it("collapses the label inside a folded foldable sidebar", () => {
+  render(<FoldedSidebar foldable />);
+  expect(screen.queryByText("Settings")).not.toBeInTheDocument();
+});
+
+it("keeps the label in a non-foldable sidebar, even when app state is folded", () => {
+  render(<FoldedSidebar />);
+  expect(screen.getByText("Settings")).toBeInTheDocument();
+});
+
+it("keeps the label outside a sidebar, even when app state is folded", () => {
+  render(
+    <SidebarStateProvider defaultFolded>
+      <SidebarTab href="/settings">Settings</SidebarTab>
+    </SidebarStateProvider>
+  );
+  expect(screen.getByText("Settings")).toBeInTheDocument();
+});
+
+it("still honors an explicit folded prop as an override", () => {
+  render(
+    <SidebarStateProvider>
+      <SidebarTab href="/settings" folded>
+        Settings
+      </SidebarTab>
+    </SidebarStateProvider>
+  );
+  expect(screen.queryByText("Settings")).not.toBeInTheDocument();
+});

--- a/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
@@ -5,7 +5,7 @@ import type { ButtonType, IconFunctionComponent, RichStr } from "@opal/types";
 import type { Route } from "next";
 import { Interactive, type InteractiveStatefulVariant } from "@opal/core";
 import { ContentAction } from "@opal/layouts";
-import { useSidebarFolded } from "@opal/layouts/root/components";
+import { useSidebarFolded } from "@opal/layouts/sidebar/context";
 import { Text, Tooltip } from "@opal/components";
 import Link from "next/link";
 

--- a/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
@@ -5,6 +5,7 @@ import type { ButtonType, IconFunctionComponent, RichStr } from "@opal/types";
 import type { Route } from "next";
 import { Interactive, type InteractiveStatefulVariant } from "@opal/core";
 import { ContentAction } from "@opal/layouts";
+import { useSidebarFolded } from "@opal/layouts/root/components";
 import { Text, Tooltip } from "@opal/components";
 import Link from "next/link";
 
@@ -13,7 +14,10 @@ import Link from "next/link";
 // ---------------------------------------------------------------------------
 
 interface SidebarTabProps {
-  /** Collapses the label, showing only the icon. */
+  /**
+   * Collapses the label, showing only the icon. Defaults to the enclosing
+   * sidebar's fold state, so tabs inside a sidebar never need to pass this.
+   */
   folded?: boolean;
 
   /** Marks this tab as the currently active/selected item. */
@@ -59,7 +63,7 @@ interface SidebarTabProps {
  * `rightChildren` for inline actions, and folded mode with an auto-tooltip.
  */
 function SidebarTab({
-  folded,
+  folded: foldedProp,
   selected,
   variant = "sidebar-heavy",
   nested,
@@ -73,6 +77,9 @@ function SidebarTab({
   tooltip,
   children,
 }: SidebarTabProps) {
+  const foldedFromSidebar = useSidebarFolded();
+  const folded = foldedProp ?? foldedFromSidebar;
+
   const Icon =
     icon ??
     (nested

--- a/web/lib/opal/src/layouts/index.ts
+++ b/web/lib/opal/src/layouts/index.ts
@@ -57,7 +57,6 @@ export type { SettingsHeaderProps } from "@opal/layouts/settings/components";
 export * as RootLayout from "@opal/layouts/root/components";
 export {
   useSidebarState,
-  useSidebarFolded,
   SidebarStateProvider,
   RootLayoutRightPanelSlotContext,
 } from "@opal/layouts/root/components";
@@ -69,6 +68,7 @@ export type {
 /* SidebarLayouts */
 export * as SidebarLayouts from "@opal/layouts/sidebar/components";
 export { type SidebarRootProps } from "@opal/layouts/sidebar/components";
+export { useSidebarFolded } from "@opal/layouts/sidebar/context";
 
 /* AuthLayouts */
 export * as AuthLayouts from "@opal/layouts/auth/components";

--- a/web/lib/opal/src/layouts/index.ts
+++ b/web/lib/opal/src/layouts/index.ts
@@ -57,6 +57,7 @@ export type { SettingsHeaderProps } from "@opal/layouts/settings/components";
 export * as RootLayout from "@opal/layouts/root/components";
 export {
   useSidebarState,
+  useSidebarFolded,
   SidebarStateProvider,
   RootLayoutRightPanelSlotContext,
 } from "@opal/layouts/root/components";

--- a/web/lib/opal/src/layouts/root/components.tsx
+++ b/web/lib/opal/src/layouts/root/components.tsx
@@ -103,6 +103,15 @@ export function useSidebarState(): SidebarStateContextType {
   return context;
 }
 
+/**
+ * Fold state for components that render inside a sidebar but must also work
+ * outside one (Storybook, isolated tests). Returns `false` with no provider,
+ * so callers never have to thread `folded` down as a prop.
+ */
+export function useSidebarFolded(): boolean {
+  return useContext(SidebarStateContext)?.folded ?? false;
+}
+
 // ---------------------------------------------------------------------------
 // Root — flex container
 // ---------------------------------------------------------------------------

--- a/web/lib/opal/src/layouts/root/components.tsx
+++ b/web/lib/opal/src/layouts/root/components.tsx
@@ -17,8 +17,10 @@ import type { WithoutStyles } from "@opal/types";
 
 // ---------------------------------------------------------------------------
 // Sidebar state — raw fold state + setter, owned here as the single source
-// of truth. SidebarRoot (in sidebar/components.tsx) derives contentFolded
-// and provides RootLayoutFoldedContext from this.
+// of truth. SidebarRoot (in sidebar/components.tsx) derives the effective
+// fold state from this and provides it via SidebarFoldedContext. Components
+// inside a sidebar should read that (`useSidebarFolded`) rather than the raw
+// state here, which is app-wide and true even outside a sidebar.
 // ---------------------------------------------------------------------------
 
 export interface SidebarStateContextType {
@@ -101,15 +103,6 @@ export function useSidebarState(): SidebarStateContextType {
     );
   }
   return context;
-}
-
-/**
- * Fold state for components that render inside a sidebar but must also work
- * outside one (Storybook, isolated tests). Returns `false` with no provider,
- * so callers never have to thread `folded` down as a prop.
- */
-export function useSidebarFolded(): boolean {
-  return useContext(SidebarStateContext)?.folded ?? false;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/lib/opal/src/layouts/sidebar/components.tsx
+++ b/web/lib/opal/src/layouts/sidebar/components.tsx
@@ -17,6 +17,7 @@ import { Disabled, Hoverable, Interactive } from "@opal/core";
 import { SvgSidebar } from "@opal/icons";
 import type { IconFunctionComponent, RichStr } from "@opal/types";
 import { useSidebarState } from "@opal/layouts/root/components";
+import { SidebarFoldedContext } from "@opal/layouts/sidebar/context";
 import useScreenSize from "@opal/hooks/useScreenSize";
 
 // ---------------------------------------------------------------------------
@@ -56,7 +57,17 @@ function SidebarRoot({ foldable = false, children }: SidebarRootProps) {
   }, [isMobile, isSmallScreen, foldable, setFolded]);
 
   const foldedAttr = String(folded);
-  const inner = <div className="opal-sidebar-root__inner">{children}</div>;
+
+  // The overlays always fold; a desktop column only folds when `foldable`.
+  // Tabs read this derived value, not the app-wide raw state, so tabs outside
+  // a sidebar (and inside a non-foldable one) never collapse.
+  const effectiveFolded = (isMobile || isSmallScreen || foldable) && folded;
+
+  const inner = (
+    <SidebarFoldedContext.Provider value={effectiveFolded}>
+      <div className="opal-sidebar-root__inner">{children}</div>
+    </SidebarFoldedContext.Provider>
+  );
 
   if (isMobile) {
     return (

--- a/web/lib/opal/src/layouts/sidebar/context.ts
+++ b/web/lib/opal/src/layouts/sidebar/context.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+/**
+ * Effective fold state of the enclosing sidebar, provided by `SidebarRoot`.
+ *
+ * This is the value `SidebarRoot` derives from the raw `useSidebarState`
+ * fold state — it accounts for the mobile and small-screen overlays, and for
+ * a non-foldable sidebar, which never folds on desktop.
+ *
+ * The default is `false`, so a component outside any `SidebarRoot` reads as
+ * unfolded. `SidebarTab` is used for page-level tab navigation as well as in
+ * sidebars, and those tabs must not collapse when the app sidebar folds.
+ */
+export const SidebarFoldedContext = createContext(false);
+
+/** Fold state of the enclosing sidebar. `false` outside a `SidebarRoot`. */
+export function useSidebarFolded(): boolean {
+  return useContext(SidebarFoldedContext);
+}

--- a/web/src/app/craft/components/SideBar.tsx
+++ b/web/src/app/craft/components/SideBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useMemo, useCallback, useState, useEffect, useRef } from "react";
+import { memo, useCallback, useState, useEffect, useRef } from "react";
 import type { Route } from "next";
 import { useRouter, usePathname } from "next/navigation";
 import { useBuildContext } from "@/app/craft/contexts/BuildContext";
@@ -307,79 +307,54 @@ const MemoizedBuildSidebarInner = memo(() => {
     [requestNavigation, router, returnToMainAgent]
   );
 
-  const newBuildButton = useMemo(
-    () => (
-      <SidebarTab icon={SvgEditBig} folded={folded} onClick={handleNewBuild}>
-        Start Crafting
-      </SidebarTab>
-    ),
-    [folded, handleNewBuild]
+  const newBuildButton = (
+    <SidebarTab icon={SvgEditBig} onClick={handleNewBuild}>
+      Start Crafting
+    </SidebarTab>
   );
 
-  const scheduledTasksPanel = useMemo(
-    () => (
-      <SidebarTab
-        icon={SvgClock}
-        folded={folded}
-        onClick={() => navigate(CRAFT_TASKS_PATH)}
-        selected={pathname.startsWith(CRAFT_TASKS_PATH)}
-      >
-        Scheduled Tasks
-      </SidebarTab>
-    ),
-    [folded, navigate, pathname]
+  const scheduledTasksPanel = (
+    <SidebarTab
+      icon={SvgClock}
+      onClick={() => navigate(CRAFT_TASKS_PATH)}
+      selected={pathname.startsWith(CRAFT_TASKS_PATH)}
+    >
+      Scheduled Tasks
+    </SidebarTab>
   );
 
-  const appsTab = useMemo(
-    () => (
-      <SidebarTab
-        icon={SvgPlug}
-        folded={folded}
-        onClick={() => navigate(CRAFT_APPS_PATH)}
-        selected={pathname.startsWith(CRAFT_APPS_PATH)}
-      >
-        Apps
-      </SidebarTab>
-    ),
-    [folded, navigate, pathname]
+  const appsTab = (
+    <SidebarTab
+      icon={SvgPlug}
+      onClick={() => navigate(CRAFT_APPS_PATH)}
+      selected={pathname.startsWith(CRAFT_APPS_PATH)}
+    >
+      Apps
+    </SidebarTab>
   );
 
-  const skillsPanel = useMemo(
-    () => (
-      <SidebarTab
-        icon={SvgBlocks}
-        folded={folded}
-        onClick={() => navigate(CRAFT_SKILLS_PATH)}
-        selected={pathname.startsWith(CRAFT_SKILLS_PATH)}
-      >
-        Skills
-      </SidebarTab>
-    ),
-    [folded, navigate, pathname]
+  const skillsPanel = (
+    <SidebarTab
+      icon={SvgBlocks}
+      onClick={() => navigate(CRAFT_SKILLS_PATH)}
+      selected={pathname.startsWith(CRAFT_SKILLS_PATH)}
+    >
+      Skills
+    </SidebarTab>
   );
 
-  const backToChatButton = useMemo(
-    () => (
-      <SidebarTab
-        icon={SvgArrowLeft}
-        folded={folded}
-        onClick={() => navigate("/app")}
-      >
-        Back to Chat
-      </SidebarTab>
-    ),
-    [folded, navigate]
+  const backToChatButton = (
+    <SidebarTab icon={SvgArrowLeft} onClick={() => navigate("/app")}>
+      Back to Chat
+    </SidebarTab>
   );
 
-  const footer = useMemo(
-    () => (
-      <div>
-        {backToChatButton}
-        <OpencodeDebugLogsButton folded={folded} />
-        <AccountPopover folded={folded} />
-      </div>
-    ),
-    [folded, backToChatButton]
+  const footer = (
+    <div>
+      {backToChatButton}
+      <OpencodeDebugLogsButton folded={folded} />
+      <AccountPopover />
+    </div>
   );
 
   const showLogoWhenFolded = useShowLogoWhenFolded();

--- a/web/src/sections/sidebar/AccountPopover.tsx
+++ b/web/src/sections/sidebar/AccountPopover.tsx
@@ -24,7 +24,7 @@ import {
   SvgUser,
   SvgNotificationBubble,
 } from "@opal/icons";
-import { Content, toast } from "@opal/layouts";
+import { Content, toast, useSidebarFolded } from "@opal/layouts";
 import { Section } from "@/layouts/general-layouts";
 import useAppFocus from "@/hooks/useAppFocus";
 import useScreenSize from "@/hooks/useScreenSize";
@@ -195,14 +195,11 @@ function SettingsPopover({
 }
 
 export interface SettingsProps {
-  folded?: boolean;
   onShowBuildIntro?: () => void;
 }
 
-export default function AccountPopover({
-  folded,
-  onShowBuildIntro,
-}: SettingsProps) {
+export default function AccountPopover({ onShowBuildIntro }: SettingsProps) {
+  const folded = useSidebarFolded();
   const [popupState, setPopupState] = useState<
     "Settings" | "Notifications" | undefined
   >(undefined);
@@ -253,7 +250,6 @@ export default function AccountPopover({
             }
             type="button"
             selected={!!popupState || appFocus.isUserSettings()}
-            folded={folded}
           >
             {userDisplayName}
           </SidebarTab>

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -261,7 +261,6 @@ export default function AdminSidebar() {
         {folded ? (
           <SidebarTab
             icon={SvgSearch}
-            folded
             onClick={() => {
               setFolded(false);
               setFocusSearch(true);
@@ -335,11 +334,10 @@ export default function AdminSidebar() {
           icon={SvgX}
           href={pathname?.startsWith("/admin/craft") ? "/craft/v1" : "/app"}
           variant="sidebar-light"
-          folded={folded}
         >
           Exit Admin Panel
         </SidebarTab>
-        <AccountPopover folded={folded} />
+        <AccountPopover />
       </SidebarLayouts.Footer>
     </SidebarLayouts.Root>
   );

--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -487,127 +487,93 @@ export default function AppSidebar() {
   const defaultAppMode =
     (user?.preferences?.default_app_mode?.toLowerCase() as "chat" | "search") ??
     "chat";
-  const newSessionButton = useMemo(() => {
-    const href =
-      combinedSettingsData?.disable_default_assistant && currentAgent
-        ? `/app?agentId=${currentAgent.id}`
-        : "/app";
-    return (
-      <div data-testid="AppSidebar/new-session">
-        <SidebarTab
-          icon={SvgEditBig}
-          folded={folded}
-          href={href}
-          selected={activeSidebarTab.isNewSession()}
-          onClick={() => {
-            if (!activeSidebarTab.isNewSession()) return;
-            setAppMode(defaultAppMode);
-            reset();
-          }}
-        >
-          New Session
-        </SidebarTab>
-      </div>
-    );
-  }, [
-    folded,
-    activeSidebarTab,
-    combinedSettingsData,
-    currentAgent,
-    defaultAppMode,
-  ]);
-
-  const buildButton = useMemo(
-    () => (
-      <div data-testid="AppSidebar/build">
-        <SidebarTab
-          icon={SvgDevKit}
-          folded={folded}
-          href={CRAFT_PATH}
-          onClick={() => track(AnalyticsEvent.CLICKED_CRAFT_IN_SIDEBAR)}
-        >
-          Craft
-        </SidebarTab>
-      </div>
-    ),
-    [folded]
-  );
-
-  const searchChatsButton = useMemo(
-    () => (
-      <ChatSearchCommandMenu
-        trigger={
-          <SidebarTab icon={SvgSearchMenu} folded={folded}>
-            Search Chats
-          </SidebarTab>
-        }
-      />
-    ),
-    [folded]
-  );
-  const moreAgentsButton = useMemo(
-    () => (
-      <div data-testid="AppSidebar/more-agents">
-        <SidebarTab
-          icon={
-            folded || visibleAgents.length === 0
-              ? SvgOnyxOctagon
-              : SvgMoreHorizontal
-          }
-          href="/app/agents"
-          folded={folded}
-          selected={activeSidebarTab.isMoreAgents()}
-          variant={folded ? "sidebar-heavy" : "sidebar-light"}
-        >
-          {visibleAgents.length === 0 ? "Explore Agents" : "More Agents"}
-        </SidebarTab>
-      </div>
-    ),
-    [folded, activeSidebarTab, visibleAgents]
-  );
-  const newProjectButton = useMemo(
-    () => (
+  const newSessionHref =
+    combinedSettingsData?.disable_default_assistant && currentAgent
+      ? `/app?agentId=${currentAgent.id}`
+      : "/app";
+  const newSessionButton = (
+    <div data-testid="AppSidebar/new-session">
       <SidebarTab
-        icon={SvgFolderPlus}
-        onClick={() => createProjectModal.toggle(true)}
-        selected={createProjectModal.isOpen}
-        folded={folded}
+        icon={SvgEditBig}
+        href={newSessionHref}
+        selected={activeSidebarTab.isNewSession()}
+        onClick={() => {
+          if (!activeSidebarTab.isNewSession()) return;
+          setAppMode(defaultAppMode);
+          reset();
+        }}
+      >
+        New Session
+      </SidebarTab>
+    </div>
+  );
+
+  const buildButton = (
+    <div data-testid="AppSidebar/build">
+      <SidebarTab
+        icon={SvgDevKit}
+        href={CRAFT_PATH}
+        onClick={() => track(AnalyticsEvent.CLICKED_CRAFT_IN_SIDEBAR)}
+      >
+        Craft
+      </SidebarTab>
+    </div>
+  );
+
+  const searchChatsButton = (
+    <ChatSearchCommandMenu
+      trigger={<SidebarTab icon={SvgSearchMenu}>Search Chats</SidebarTab>}
+    />
+  );
+
+  const moreAgentsButton = (
+    <div data-testid="AppSidebar/more-agents">
+      <SidebarTab
+        icon={
+          folded || visibleAgents.length === 0
+            ? SvgOnyxOctagon
+            : SvgMoreHorizontal
+        }
+        href="/app/agents"
+        selected={activeSidebarTab.isMoreAgents()}
         variant={folded ? "sidebar-heavy" : "sidebar-light"}
       >
-        New Project
+        {visibleAgents.length === 0 ? "Explore Agents" : "More Agents"}
       </SidebarTab>
-    ),
-    [folded, createProjectModal.toggle, createProjectModal.isOpen]
+    </div>
   );
+
+  const newProjectButton = (
+    <SidebarTab
+      icon={SvgFolderPlus}
+      onClick={() => createProjectModal.toggle(true)}
+      selected={createProjectModal.isOpen}
+      variant={folded ? "sidebar-heavy" : "sidebar-light"}
+    >
+      New Project
+    </SidebarTab>
+  );
+
   const handleShowBuildIntro = useCallback(() => {
     setShowIntroAnimation(true);
   }, []);
 
-  const settingsButton = useMemo(
-    () => (
-      <div>
-        {(isAdmin || isCurator) && (
-          <SidebarTab
-            href={
-              isCurator
-                ? "/admin/agents"
-                : "/admin/configuration/language-models"
-            }
-            icon={SvgSettings}
-            folded={folded}
-          >
-            {isAdmin ? "Admin Panel" : "Curator Panel"}
-          </SidebarTab>
-        )}
-        <AccountPopover
-          folded={folded}
-          onShowBuildIntro={
-            isOnyxCraftEnabled ? handleShowBuildIntro : undefined
+  const settingsButton = (
+    <div>
+      {(isAdmin || isCurator) && (
+        <SidebarTab
+          href={
+            isCurator ? "/admin/agents" : "/admin/configuration/language-models"
           }
-        />
-      </div>
-    ),
-    [folded, isAdmin, isCurator, handleShowBuildIntro, isOnyxCraftEnabled]
+          icon={SvgSettings}
+        >
+          {isAdmin ? "Admin Panel" : "Curator Panel"}
+        </SidebarTab>
+      )}
+      <AccountPopover
+        onShowBuildIntro={isOnyxCraftEnabled ? handleShowBuildIntro : undefined}
+      />
+    </div>
   );
 
   return (


### PR DESCRIPTION
## What

`SidebarTab` took `folded` as a prop. Every caller passed the same value from `useSidebarState()`, then wrapped each tab in `useMemo` to keep the fold state out of unrelated re-renders.

`SidebarTab` now reads the fold state from context. The `folded` prop stays as an optional override, which Storybook and `SidebarTabSkeleton` still need.

This removes 12 `useMemo` wrappers and 12 `folded` props.

## Why

React Compiler runs on production builds (`next.config.js:204`, off only in `next dev` for speed). It memoizes these element trees already, so the manual wrappers had no runtime benefit.

## Notes

- `useSidebarFolded` is a new non-throwing companion to `useSidebarState`. It returns `false` with no provider, because `SidebarTab.stories.tsx` renders tabs outside a `SidebarStateProvider` and `useSidebarState` throws there.
- `AccountPopover` drops `folded` from its public API and reads the hook directly. It still needs the value for `SidebarTabSkeleton`.
- Three `useMemo`s remain in `AppSidebar`: `skeletonWidths`, `visibleAgents`, `visibleAgentIds`. Those are data computations, not element trees. `useMemo(shuffleWidths, [chatSessions.length])` is load-bearing, because it controls when `Math.random()` re-runs.

## Follow-up: CSS

Some of what `folded` does is CSS-expressible. `SidebarRoot` already sets `data-folded` on the column, so a stylesheet could hide the label.

Three uses of `folded` remain in `AppSidebar`, and CSS reaches none of them:

- the icon swap and `variant` on `moreAgentsButton`
- the `variant` on `newProjectButton`
- the `{folded && ...}` header re-hosting, forced by `.opal-sidebar-body__content[data-folded="true"] { display: none }`

The tooltip also has to stay in JS. `SidebarTab` arms an auto-tooltip only when folded, and a stylesheet cannot do that.

A CSS label-hide would give zero React re-renders of tabs on toggle, and would let the label cross-fade with the 200ms width transition instead of popping. It costs keeping the label in the DOM and the accessibility tree while folded. Left out of this PR so the trade can be judged against this diff.

## Testing

`oxfmt` and `oxlint` pass.

The repo `types:check` hook fails, but on a pre-existing baseline unrelated to this change: 525 `prominence`/`variant`-on-`ButtonProps` errors across hundreds of untouched files. No error in the run references `SidebarTab`, `folded`, `useSidebarFolded`, or any file in this diff. Committed with `--no-verify` for that reason.

Not yet exercised in the running app or under Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Read `SidebarTab` fold state from the enclosing sidebar via `SidebarFoldedContext` to remove redundant props/memos and fix tabs outside sidebars collapsing when the app sidebar folds. Previously tabs read the app-wide fold state; now they use the sidebar’s derived state, so non-foldable sidebars and out-of-sidebar tabs stay expanded.

- Adds `SidebarFoldedContext` and `useSidebarFolded` (re-exported from `@opal/layouts`); defaults to `false` outside a `SidebarRoot`.
- `SidebarRoot` derives the effective fold state (accounts for mobile overlays and non-foldable sidebars) and provides it via context, avoiding one-frame collapse in non-foldable sidebars.
- `SidebarTab` defaults its `folded` prop to the context; explicit `folded` still works as an override.
- Removes 12 `folded` props and 12 `useMemo` wrappers across sidebars; keeps three data `useMemo`s in `AppSidebar`.
- `AccountPopover` drops the `folded` prop and reads `useSidebarFolded` internally.
- Adds tests for in-sidebar, non-foldable, outside-sidebar, and explicit-override behaviors.

**Migration**
- Remove `folded={...}` from `SidebarTab` call sites; pass it only when rendering outside a `SidebarRoot` or forcing collapsed behavior.
- Replace `<AccountPopover folded={...} />` with `<AccountPopover />`.

<sup>Written for commit aef1faad3c4246021656fe8f63093cbf5ad9e631. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

