### PR TITLE
fix(opal): make the SidebarTab click target keyboard focusable

### DIFF
--- a/web/lib/opal/src/components/buttons/sidebar-tab/README.md
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/README.md
@@ -10,15 +10,16 @@ A sidebar navigation tab built on `Interactive.Stateful` > `Interactive.Containe
 div.opal-sidebar-tab      <- folded styling hook (see styles.css)
   └─ Interactive.Stateful        <- variant (sidebar-heavy | sidebar-light), state, disabled
        └─ Interactive.Container  <- rounding, height, width
-            ├─ Link?             (absolute overlay for client-side navigation)
-            ├─ rightChildren?    (absolute, above Link for inline actions)
+            ├─ Link | button?    (absolute overlay — the click target)
+            ├─ rightChildren?    (absolute, above the overlay for inline actions)
             └─ ContentAction     (icon + title + truncation spacer)
 ```
 
 - **`sidebar-heavy`** (default) — muted when unselected (text-03/text-02), bold when selected (text-04/text-03)
 - **`sidebar-light`** — uniformly muted across all states (text-02/text-02)
 - **Disabled** — both variants use text-02 foreground, transparent background, no hover/active states
-- **Navigation** uses an absolutely positioned `<Link>` overlay rather than `href` on the Interactive element, so `rightChildren` can sit above it with `pointer-events-auto`. A string label is also set as the link's `aria-label`, so the tab keeps a name when the label is hidden.
+- **The click target** is an absolutely positioned overlay: a `<Link>` when `href` is set, a `<button>` when only `onClick` is set. Both are keyboard focusable. The overlay stays a sibling of the content, so `rightChildren` can sit above it with `pointer-events-auto` and remain a valid nested control.
+- **The overlay's name** comes from `aria-label` for a string label, and from `aria-labelledby` on the content row otherwise. The tab therefore keeps a name when the label is hidden.
 
 ## Folded state
 

--- a/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
@@ -45,6 +45,11 @@ interface SidebarTabProps {
 
   onClick?: React.MouseEventHandler<HTMLElement>;
   href?: string;
+
+  /**
+   * HTML button type for the click target. Ignored when `href` is set.
+   * @default "button"
+   */
   type?: ButtonType;
   icon?: IconFunctionComponent;
   children?: React.ReactNode;
@@ -108,8 +113,10 @@ function FoldedTooltip({ label, folded, children }: FoldedTooltipProps) {
  * Sidebar navigation tab built on `Interactive.Stateful` > `Interactive.Container`.
  *
  * Uses `sidebar-heavy` (default) or `sidebar-light` (via `variant`) variants
- * for color styling. Supports an overlay `Link` for client-side navigation,
- * `rightChildren` for inline actions, and folded mode with an auto-tooltip.
+ * for color styling. The click target is an overlay control — a `Link` when
+ * `href` is set, a `button` when only `onClick` is set — so both paths are
+ * keyboard focusable. Supports `rightChildren` for inline actions, and folded
+ * mode with an auto-tooltip.
  *
  * The label and `rightChildren` always render. The folded state hides them in
  * CSS — see `styles.css` — so folding a sidebar re-renders no tabs.
@@ -138,15 +145,36 @@ function SidebarTab({
       : null);
 
   // The `rightChildren` node is absolutely positioned to sit on top of the
-  // overlay Link. A zero-width spacer reserves truncation space for the title.
+  // overlay control. A zero-width spacer reserves truncation space for the title.
   const truncationSpacer = rightChildren && (
     <div className="w-0 group-hover/SidebarTab:w-6" />
   );
 
-  // A folded tab hides its label, and neither the overlay Link nor the button
-  // holds text of its own, so name them explicitly. Without this a folded tab
-  // is an unnamed control.
+  /* The click target is an overlay that covers the whole row: a `Link` when
+  `href` is set, a `button` otherwise. It stays a sibling of the content so that
+  `rightChildren` and interactive icons remain valid nested controls. The focus
+  outline is inset because the container clips its overflow. */
+  const overlayClassName =
+    "absolute z-99 inset-0 rounded-08 outline-border-04 outline-offset-[-2px] focus-visible:outline-2";
+  // A folded tab hides its label, and the overlay holds no text of its own, so
+  // name it explicitly. Without this a folded tab is an unnamed control.
   const label = typeof children === "string" ? children : undefined;
+  const overlay = disabled ? null : href ? (
+    <Link
+      href={href as Route}
+      scroll={false}
+      onClick={onClick}
+      aria-label={label}
+      className={overlayClassName}
+    />
+  ) : onClick ? (
+    <button
+      type={type ?? "button"}
+      onClick={onClick}
+      aria-label={label}
+      className={overlayClassName}
+    />
+  ) : null;
 
   const content = (
     <div
@@ -157,28 +185,11 @@ function SidebarTab({
         variant={variant}
         state={selected ? "selected" : "empty"}
         disabled={disabled}
-        onClick={onClick}
         type="button"
         group="group/SidebarTab"
       >
-        <Interactive.Container
-          rounding="sm"
-          size="lg"
-          width="full"
-          type={type}
-          // Only when `type` makes this a real button — `aria-label` on a
-          // plain div names nothing.
-          aria-label={type ? label : undefined}
-        >
-          {href && !disabled && (
-            <Link
-              href={href as Route}
-              scroll={false}
-              className="absolute z-99 inset-0 rounded-08"
-              tabIndex={-1}
-              aria-label={label}
-            />
-          )}
+        <Interactive.Container rounding="sm" size="lg" width="full">
+          {overlay}
 
           {rightChildren && (
             <div className="opal-sidebar-tab__actions">{rightChildren}</div>
@@ -199,7 +210,8 @@ function SidebarTab({
           ) : (
             <div className="flex flex-row items-center gap-2 w-full">
               {Icon && (
-                <div className="flex items-center justify-center p-0.5">
+                /* Sits above the overlay so an interactive icon stays clickable. */
+                <div className="relative z-100 flex items-center justify-center p-0.5">
                   <Icon className="h-4 w-4 text-text-03" />
                 </div>
               )}

--- a/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
@@ -158,22 +158,29 @@ function SidebarTab({
   over the value inherited from `.interactive`. */
   const overlayClassName =
     "absolute z-99 inset-0 rounded-08 cursor-pointer outline-border-04 outline-offset-[-2px] focus-visible:outline-2";
-  // A folded tab hides its label, and the overlay holds no text of its own, so
-  // name it explicitly. Without this a folded tab is an unnamed control.
+  /* The overlay holds no text of its own, and a folded tab hides its label, so
+  name the overlay explicitly. String children name it directly. Other content
+  (truncated or animated titles) names it through the element that renders the
+  title. */
   const label = typeof children === "string" ? children : undefined;
+  const labelId = React.useId();
+  const labelProps =
+    label !== undefined
+      ? { "aria-label": label }
+      : { "aria-labelledby": labelId };
   const overlay = disabled ? null : href ? (
     <Link
       href={href as Route}
       scroll={false}
       onClick={onClick}
-      aria-label={label}
+      {...labelProps}
       className={overlayClassName}
     />
   ) : onClick ? (
     <button
       type={type ?? "button"}
       onClick={onClick}
-      aria-label={label}
+      {...labelProps}
       className={overlayClassName}
     />
   ) : null;
@@ -210,7 +217,10 @@ function SidebarTab({
               titleMaxLines={1}
             />
           ) : (
-            <div className="flex flex-row items-center gap-2 w-full">
+            <div
+              id={labelId}
+              className="flex flex-row items-center gap-2 w-full"
+            >
               {Icon && (
                 /* Sits above the overlay so an interactive icon stays clickable. */
                 <div className="relative z-100 flex items-center justify-center p-0.5">

--- a/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
@@ -153,9 +153,11 @@ function SidebarTab({
   /* The click target is an overlay that covers the whole row: a `Link` when
   `href` is set, a `button` otherwise. It stays a sibling of the content so that
   `rightChildren` and interactive icons remain valid nested controls. The focus
-  outline is inset because the container clips its overflow. */
+  outline is inset because the container clips its overflow. `cursor-pointer` is
+  explicit because the UA stylesheet gives `button` a default cursor, which wins
+  over the value inherited from `.interactive`. */
   const overlayClassName =
-    "absolute z-99 inset-0 rounded-08 outline-border-04 outline-offset-[-2px] focus-visible:outline-2";
+    "absolute z-99 inset-0 rounded-08 cursor-pointer outline-border-04 outline-offset-[-2px] focus-visible:outline-2";
   // A folded tab hides its label, and the overlay holds no text of its own, so
   // name it explicitly. Without this a folded tab is an unnamed control.
   const label = typeof children === "string" ? children : undefined;

--- a/web/src/app/craft/components/SideBar.tsx
+++ b/web/src/app/craft/components/SideBar.tsx
@@ -212,7 +212,8 @@ function BuildSessionButton({
       >
         <Popover.Anchor>
           <SidebarTab
-            onClick={onLoad}
+            /* While renaming, drop the click target so the input stays usable. */
+            onClick={renaming ? undefined : onLoad}
             selected={isActive}
             rightChildren={rightMenu}
           >

--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -522,7 +522,11 @@ export default function AppSidebar() {
 
   const searchChatsButton = (
     <ChatSearchCommandMenu
-      trigger={<SidebarTab icon={SvgSearchMenu}>Search Chats</SidebarTab>}
+      trigger={(open) => (
+        <SidebarTab icon={SvgSearchMenu} onClick={open}>
+          Search Chats
+        </SidebarTab>
+      )}
     />
   );
 

--- a/web/src/sections/sidebar/ChatButton.tsx
+++ b/web/src/sections/sidebar/ChatButton.tsx
@@ -433,8 +433,13 @@ const ChatButton = memo(
       >
         <Popover.Anchor>
           <SidebarTab
-            href={isDragging ? undefined : `/app?chatId=${chatSession.id}`}
-            onClick={handleClick}
+            /* While renaming, drop the click target so the input stays usable. */
+            href={
+              isDragging || renaming
+                ? undefined
+                : `/app?chatId=${chatSession.id}`
+            }
+            onClick={renaming ? undefined : handleClick}
             selected={active}
             rightChildren={rightMenu}
             nested={!!project}

--- a/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
+++ b/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
@@ -47,7 +47,8 @@ function DynamicFooter() {
 }
 
 interface ChatSearchCommandMenuProps {
-  trigger: React.ReactNode;
+  /** Renders the control that opens the menu. */
+  trigger: (open: () => void) => React.ReactNode;
 }
 
 interface FilterableProject {
@@ -182,6 +183,8 @@ export default function ChatSearchCommandMenu({
     [createProjectModal]
   );
 
+  const handleOpen = useCallback(() => setOpen(true), []);
+
   const handleOpenChange = useCallback((newOpen: boolean) => {
     setOpen(newOpen);
     if (!newOpen) {
@@ -204,9 +207,7 @@ export default function ChatSearchCommandMenu({
 
   return (
     <>
-      <div aria-label="Open chat search" onClick={() => setOpen(true)}>
-        {trigger}
-      </div>
+      {trigger(handleOpen)}
 
       <CommandMenu open={open} onOpenChange={handleOpenChange}>
         <CommandMenu.Content>

--- a/web/src/sections/sidebar/ProjectFolderButton.tsx
+++ b/web/src/sections/sidebar/ProjectFolderButton.tsx
@@ -152,7 +152,8 @@ const ProjectFolderButton = memo(({ project }: ProjectFolderButtonProps) => {
               activeSidebar.isProject() &&
               activeSidebar.getId() === String(project.id)
             }
-            onClick={noProp(handleTextClick)}
+            /* While renaming, drop the click target so the input stays usable. */
+            onClick={isEditing ? undefined : noProp(handleTextClick)}
             rightChildren={
               <>
                 <Popover.Trigger asChild onClick={noProp()}>

--- a/web/tests/e2e/chat/chat-search-command-menu.spec.ts
+++ b/web/tests/e2e/chat/chat-search-command-menu.spec.ts
@@ -24,7 +24,7 @@ function getCommandMenuContent(page: Page): Locator {
  * Helper to open the command menu and return a scoped locator
  */
 async function openCommandMenu(page: Page): Promise<Locator> {
-  await page.getByLabel("Open chat search").click();
+  await page.getByRole("button", { name: "Search Chats" }).click();
   const dialog = getCommandMenuContent(page);
   await expect(
     dialog.getByPlaceholder("Search chat sessions, projects...")


### PR DESCRIPTION
## Problem

`SidebarTab` had two click paths, and neither was keyboard reachable:

- With `href`, the overlay `Link` had `tabIndex={-1}`, and `Interactive.Container` rendered a plain `div` (no caller passes `type`, and `Interactive.Stateful` swallows its own hardcoded `type="button"`). Nothing in the row could take focus.
- With only `onClick`, there was no control at all — the handler sat on a `div`. "Search Chats" in `AppSidebar` was an example: `ChatSearchCommandMenu` wrapped the tab in a non-focusable `<div aria-label="Open chat search" onClick>`.

## Change

One overlay control serves both paths: a `Link` when `href` is set, a `button` when only `onClick` is set. It stays a sibling of the content, so `rightChildren` and interactive icons remain valid nested controls instead of buttons inside a button. The focus outline is inset (`outline-offset-[-2px]`) because the container clips its overflow.

`ChatSearchCommandMenu` now takes `trigger` as a render prop `(open) => ReactNode`, so the SidebarTab owns the real button and the wrapper `div` is gone.

Call sites that render a rename input now drop the click target while renaming. This also fixes a pre-existing bug where the `z-99` overlay covered the rename field in `ChatButton`.

## Tests

`web/tests/e2e/chat/chat-search-command-menu.spec.ts` — the helper now targets the real `button` named "Search Chats". 19 passed.

Manually verified in the browser: tab focus and visible focus ring on every tab, Enter opens the command menu, the folder toggle still expands without navigating, project/chat navigation, popovers, rename inputs stay on top, and sidebar drag-and-drop.

## Out of scope

- `AccountPopover` is still keyboard-unreachable — `Popover.Trigger asChild` puts the handler on a wrapper `div`, and its SidebarTab has neither `href` nor `onClick`. A fix needs `SidebarTab` to forward a ref and trigger props to the overlay button.
- `Interactive.Stateful` hardcodes `type="button"`, so a tab with no click target still shows `cursor-pointer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `SidebarTab` click targets keyboard focusable and named, and unifies the overlay into one control. Previously `href` tabs were not focusable and `onClick` tabs had no control; now a single overlay (`Link` with `href`, `button` otherwise) handles clicks, keeps a pointer cursor, and preserves nested interactions.

- `SidebarTab`: adds a focusable overlay with an inset focus ring; keeps `cursor-pointer` on the overlay `button`; names the overlay via `aria-label` for string titles and `aria-labelledby` for non-string titles; icons and `rightChildren` remain interactive; adds optional `type` for the `button` (ignored with `href`).
- `ChatSearchCommandMenu`: `trigger` is now a render prop. Migrate by passing a function, e.g., `trigger={(open) => <SidebarTab onClick={open}>Search Chats</SidebarTab>}`.
- Callers drop `href`/`onClick` while renaming or dragging to keep inputs usable.
- Tests: e2e now click the real button by role/name (“Search Chats”).

<sup>Written for commit 6a2113b41cc5b1add5740b310f7b595dc64ac19b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

