### PR TITLE
fix(usage): Clarify personal usage and budget context

### DIFF
--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -25,6 +25,7 @@ USER_USAGE_BUCKET_SECONDS = 24 * 60 * 60
 USER_USAGE_BUCKET_HOURS = USER_USAGE_BUCKET_SECONDS // (60 * 60)
 TOKEN_BUDGET_PERIOD_ERROR = "Token budget periods must be whole UTC days"
 COST_BUDGET_PERIOD_ERROR = "Cost budget periods must be whole UTC days"
+COST_BUDGET_PERIOD_HOURS = {24, 168, 720}
 # Not email-shaped on purpose: it can never collide with a real address.
 DELETED_USER_EXPORT_EMAIL = "(deleted user)"
 _CONFLICT_COLS = ["user_id", "window_start", "model", "flow", "provider", "incognito"]
@@ -51,21 +52,20 @@ def get_token_window_start(now: datetime, period_hours: int) -> datetime:
 
 def _get_cost_period_seconds(period_hours: int) -> int:
     period_seconds = period_hours * 60 * 60
-    if (
-        period_seconds < USER_USAGE_BUCKET_SECONDS
-        or period_seconds % USER_USAGE_BUCKET_SECONDS
-    ):
-        raise ValueError(COST_BUDGET_PERIOD_ERROR)
+    if period_hours not in COST_BUDGET_PERIOD_HOURS:
+        raise ValueError("Cost budget periods must be daily, weekly, or monthly")
     return period_seconds
 
 
 def get_cost_window_start(now: datetime, period_hours: int) -> datetime:
-    """Start of the UTC-day buckets in a cost-budget window."""
-    period_seconds = _get_cost_period_seconds(period_hours)
+    """Start of the current fixed UTC cost-budget period."""
+    _get_cost_period_seconds(period_hours)
     current_bucket = get_window_start(now, USER_USAGE_BUCKET_SECONDS)
-    return current_bucket - timedelta(
-        seconds=period_seconds - USER_USAGE_BUCKET_SECONDS
-    )
+    if period_hours == 24:
+        return current_bucket
+    if period_hours == 168:
+        return current_bucket - timedelta(days=current_bucket.weekday())
+    return current_bucket.replace(day=1)
 
 
 def get_token_window_reset(now: datetime, period_hours: int) -> datetime:
@@ -75,9 +75,14 @@ def get_token_window_reset(now: datetime, period_hours: int) -> datetime:
 
 
 def get_cost_window_reset(now: datetime, period_hours: int) -> datetime:
-    period_seconds = _get_cost_period_seconds(period_hours)
-    current_bucket = get_window_start(now, USER_USAGE_BUCKET_SECONDS)
-    return current_bucket + timedelta(seconds=period_seconds)
+    window_start = get_cost_window_start(now, period_hours)
+    if period_hours == 24:
+        return window_start + timedelta(days=1)
+    if period_hours == 168:
+        return window_start + timedelta(days=7)
+    if window_start.month == 12:
+        return window_start.replace(year=window_start.year + 1, month=1)
+    return window_start.replace(month=window_start.month + 1)
 
 
 def earliest_window_reset(

--- a/backend/onyx/server/features/usage/api.py
+++ b/backend/onyx/server/features/usage/api.py
@@ -25,6 +25,7 @@ from onyx.db.token_limit import (
     fetch_user_group_token_rate_limits,
 )
 from onyx.db.user_usage import (
+    get_cost_window_reset,
     get_cost_window_start,
     get_group_cost_cents_buckets_since,
     get_total_cost_cents_buckets_since,
@@ -116,14 +117,16 @@ def _user_cost_budget(db_session: Session, user_id: str) -> EffectiveCostBudget 
                     budget_cents=rl.cost_budget_cents,
                     remaining_cents=rl.cost_budget_cents - used,
                     period_hours=rl.period_hours,
+                    reset_at=get_cost_window_reset(now, rl.period_hours),
                 )
             )
 
     user_rls = fetch_all_user_token_rate_limits(db_session, enabled_only=True)
     user_cost_rls = [rl for rl in user_rls if rl.cost_budget_cents is not None]
     if user_cost_rls:
-        broadest = max(rl.period_hours for rl in user_cost_rls)
-        fetch_cutoff = get_cost_window_start(now, broadest)
+        fetch_cutoff = min(
+            get_cost_window_start(now, rl.period_hours) for rl in user_cost_rls
+        )
         _add_from_limits(
             user_cost_rls,
             get_user_cost_cents_buckets_since(db_session, user_id, fetch_cutoff),
@@ -132,8 +135,9 @@ def _user_cost_budget(db_session: Session, user_id: str) -> EffectiveCostBudget 
     global_rls = fetch_all_global_token_rate_limits(db_session, enabled_only=True)
     global_cost_rls = [rl for rl in global_rls if rl.cost_budget_cents is not None]
     if global_cost_rls:
-        broadest = max(rl.period_hours for rl in global_cost_rls)
-        fetch_cutoff = get_cost_window_start(now, broadest)
+        fetch_cutoff = min(
+            get_cost_window_start(now, rl.period_hours) for rl in global_cost_rls
+        )
         _add_from_limits(
             global_cost_rls,
             get_total_cost_cents_buckets_since(db_session, fetch_cutoff),
@@ -150,6 +154,7 @@ def _user_cost_budget(db_session: Session, user_id: str) -> EffectiveCostBudget 
         budget_cents=best.budget_cents,
         remaining_cents=max(best.remaining_cents, 0.0),
         period_hours=best.period_hours,
+        reset_at=best.reset_at,
     )
 
 
@@ -172,8 +177,7 @@ def _group_cost_budget_candidate(
         return None
 
     # One batched query for every group's cost buckets, then window in Python.
-    broadest = max(rl.period_hours for rl in cost_rls)
-    fetch_cutoff = get_cost_window_start(now, broadest)
+    fetch_cutoff = min(get_cost_window_start(now, rl.period_hours) for rl in cost_rls)
     buckets = get_group_cost_cents_buckets_since(
         db_session, list(group_limits.keys()), fetch_cutoff
     )
@@ -193,6 +197,7 @@ def _group_cost_budget_candidate(
                     budget_cents=rl.cost_budget_cents,
                     remaining_cents=remaining,
                     period_hours=rl.period_hours,
+                    reset_at=get_cost_window_reset(now, rl.period_hours),
                 )
         if group_binding is None:
             return None  # a cost-exempt group exempts the whole group scope
@@ -288,6 +293,7 @@ def get_my_usage(
         budget_cents=budget.budget_cents if budget is not None else None,
         budget_remaining_cents=(budget.remaining_cents if budget is not None else None),
         budget_period_hours=budget.period_hours if budget is not None else None,
+        budget_reset_at=budget.reset_at if budget is not None else None,
         selected_model_price=selected_model_price,
         available_model_prices=available_model_prices,
     )

--- a/backend/onyx/server/features/usage/api.py
+++ b/backend/onyx/server/features/usage/api.py
@@ -205,6 +205,8 @@ admin_usage_router = APIRouter(prefix="/admin/usage", tags=PUBLIC_API_TAGS)
 @user_usage_router.get("")
 def get_my_usage(
     days: Annotated[int | None, Query(ge=1, le=3_650)] = None,
+    start: date | None = None,
+    end: date | None = None,
     user: User = Depends(current_user),
     db_session: Session = Depends(get_session),
 ) -> UserUsageResponse:
@@ -212,11 +214,21 @@ def get_my_usage(
     now = datetime.now(timezone.utc)
     window_start = get_window_start(now, period_seconds=USAGE_LIMIT_WINDOW_SECONDS)
 
-    since = now - timedelta(days=days) if days else window_start
+    if start is not None or end is not None:
+        end_date = end or now.date()
+        inclusive_days = days or _DEFAULT_USAGE_RANGE_INCLUSIVE_DAYS
+        start_date = start or _start_for_inclusive_range(end_date, inclusive_days)
+        since, until = _date_range_to_utc_bounds(start_date, end_date)
+    elif days is not None:
+        since = now - timedelta(days=days)
+        until = now
+    else:
+        since = window_start
+        until = now
     user_id = str(user.id)
 
     per_day = get_user_usage_by_day_and_model(
-        db_session, user_id, since=since, until=now
+        db_session, user_id, since=since, until=until
     )
     window_cost_cents = get_user_cost_cents_since(db_session, user_id, window_start)
 

--- a/backend/onyx/server/features/usage/api.py
+++ b/backend/onyx/server/features/usage/api.py
@@ -65,7 +65,12 @@ _DEFAULT_USAGE_RANGE_INCLUSIVE_DAYS = 30
 
 
 def _start_for_inclusive_range(end_date: date, inclusive_days: int) -> date:
-    return end_date - timedelta(days=inclusive_days - 1)
+    try:
+        return end_date - timedelta(days=inclusive_days - 1)
+    except OverflowError as error:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT, "date range exceeds supported bounds"
+        ) from error
 
 
 def _date_range_to_utc_bounds(
@@ -75,9 +80,14 @@ def _date_range_to_utc_bounds(
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, "start must not be after end")
 
     start_dt = datetime.combine(start_date, time.min, tzinfo=timezone.utc)
-    end_dt = datetime.combine(end_date, time.min, tzinfo=timezone.utc) + timedelta(
-        days=1
-    )
+    try:
+        end_dt = datetime.combine(
+            end_date + timedelta(days=1), time.min, tzinfo=timezone.utc
+        )
+    except OverflowError as error:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT, "date range exceeds supported bounds"
+        ) from error
     return start_dt, end_dt
 
 
@@ -230,7 +240,11 @@ def get_my_usage(
     per_day = get_user_usage_by_day_and_model(
         db_session, user_id, since=since, until=until
     )
-    window_cost_cents = get_user_cost_cents_since(db_session, user_id, window_start)
+    window_cost_cents = (
+        sum(row.cost_cents for row in per_day)
+        if start is not None or end is not None
+        else get_user_cost_cents_since(db_session, user_id, window_start)
+    )
 
     accessible_providers = fetch_all_llm_providers_accessible_in_any_context(
         db_session, user

--- a/backend/onyx/server/features/usage/models.py
+++ b/backend/onyx/server/features/usage/models.py
@@ -86,6 +86,7 @@ class EffectiveCostBudget(BaseModel):
     budget_cents: float
     remaining_cents: float
     period_hours: int
+    reset_at: datetime
 
 
 class UserUsageResponse(BaseModel):
@@ -95,5 +96,6 @@ class UserUsageResponse(BaseModel):
     budget_cents: float | None
     budget_remaining_cents: float | None
     budget_period_hours: int | None = None
+    budget_reset_at: datetime | None = None
     selected_model_price: ModelPrice | None
     available_model_prices: list[ModelPrice] = Field(default_factory=list)

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -16,6 +16,7 @@ from onyx.db.token_limit import fetch_all_global_token_rate_limits
 from onyx.db.user_usage import (
     TokenUsageBucket,
     earliest_window_reset,
+    get_cost_window_reset,
     get_cost_window_start,
     get_token_window_start,
     get_total_cost_cents_buckets_since,
@@ -86,9 +87,9 @@ def _user_is_rate_limited_by_global() -> None:
             rl for rl in global_rate_limits if rl.cost_budget_cents is not None
         ]
         if cost_limits:
-            cost_cutoff = get_cost_window_start(
-                datetime.now(timezone.utc),
-                max(rl.period_hours for rl in cost_limits),
+            now = datetime.now(timezone.utc)
+            cost_cutoff = min(
+                get_cost_window_start(now, rl.period_hours) for rl in cost_limits
             )
             cost_buckets = get_total_cost_cents_buckets_since(db_session, cost_cutoff)
             cost_reset = _cost_budget_reset(global_rate_limits, cost_buckets)
@@ -166,11 +167,7 @@ def _cost_budget_reset(
     rate_limits: Sequence[TokenRateLimit],
     cost_buckets: Sequence[tuple[datetime, float]],
 ) -> datetime | None:
-    """The latest exact reset among the exceeded cost budgets, or None.
-
-    Mirrors `_token_budget_reset`. Cost windows contain whole UTC-day buckets;
-    rows without a cost_budget_cents are cost-exempt.
-    """
+    """The latest fixed reset among the exceeded cost budgets, or None."""
     now = datetime.now(timezone.utc)
     resets: list[datetime] = []
     for rate_limit in rate_limits:
@@ -183,11 +180,7 @@ def _cost_budget_reset(
             cents for window_start, cents in cost_buckets if window_start >= cutoff
         )
         if cost >= budget:
-            resets.append(
-                earliest_window_reset(
-                    now, rate_limit.period_hours, cost_buckets, budget
-                )
-            )
+            resets.append(get_cost_window_reset(now, rate_limit.period_hours))
 
     return max(resets) if resets else None
 

--- a/backend/onyx/server/token_rate_limits/models.py
+++ b/backend/onyx/server/token_rate_limits/models.py
@@ -4,9 +4,8 @@ from pydantic import BaseModel, Field, model_validator
 
 from onyx.db.models import TokenRateLimit
 from onyx.db.user_usage import (
-    COST_BUDGET_PERIOD_ERROR,
+    COST_BUDGET_PERIOD_HOURS,
     TOKEN_BUDGET_PERIOD_ERROR,
-    USER_USAGE_BUCKET_SECONDS,
     normalize_token_period_hours,
 )
 
@@ -31,9 +30,11 @@ class _TokenRateLimitArgsBase(BaseModel):
             raise ValueError(TOKEN_BUDGET_PERIOD_ERROR)
         if (
             self.cost_budget_cents is not None
-            and (self.period_hours * 60 * 60) % USER_USAGE_BUCKET_SECONDS != 0
+            and self.period_hours not in COST_BUDGET_PERIOD_HOURS
         ):
-            raise ValueError(COST_BUDGET_PERIOD_ERROR)
+            raise ValueError(
+                "Cost budget periods must be daily (1), weekly (7), or monthly (30) days"
+            )
         return self
 
 

--- a/backend/tests/external_dependency_unit/ee/onyx/server/query_and_chat/test_user_group_cost_budget_enforcement.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/server/query_and_chat/test_user_group_cost_budget_enforcement.py
@@ -93,7 +93,7 @@ def test_user_cost_isolated_and_longest_window_reported(
     other_user = create_test_user(db_session, "cost_budget_other")
     limits = [
         _cost_limit(TokenRateLimitScope.USER, period_hours=24),
-        _cost_limit(TokenRateLimitScope.USER, period_hours=48),
+        _cost_limit(TokenRateLimitScope.USER, period_hours=168),
     ]
     monkeypatch.setattr(
         ee_token_limit, "fetch_all_user_token_rate_limits", lambda **_: limits
@@ -110,7 +110,7 @@ def test_user_cost_isolated_and_longest_window_reported(
     _assert_cost_rate_limited(
         exc_info.value,
         TokenRateLimitScope.USER,
-        period_hours=48,
+        period_hours=168,
     )
 
 
@@ -149,7 +149,7 @@ def test_group_blocks_only_when_every_group_is_over_budget(
             User__UserGroup(user_id=spender.id, user_group_id=over_budget_group.id),
         ]
     )
-    _add_group_limit(db_session, over_budget_group, period_hours=48)
+    _add_group_limit(db_session, over_budget_group, period_hours=168)
     _add_group_limit(db_session, under_budget_group, period_hours=24)
     db_session.commit()
     _record_cost(db_session, spender, 150.0)
@@ -169,7 +169,7 @@ def test_group_blocks_only_when_every_group_is_over_budget(
     _assert_cost_rate_limited(
         exc_info.value,
         TokenRateLimitScope.USER_GROUP,
-        period_hours=48,
+        period_hours=168,
     )
 
 

--- a/backend/tests/unit/onyx/db/test_user_usage.py
+++ b/backend/tests/unit/onyx/db/test_user_usage.py
@@ -57,13 +57,13 @@ def test_token_periods_use_whole_utc_days() -> None:
     )
 
 
-def test_cost_window_uses_whole_utc_day_buckets() -> None:
+def test_cost_windows_use_fixed_utc_calendar_periods() -> None:
     now = datetime.datetime(2026, 7, 21, 13, 30, tzinfo=datetime.timezone.utc)
 
     assert get_cost_window_start(now, 24) == datetime.datetime(
         2026, 7, 21, tzinfo=datetime.timezone.utc
     )
-    assert get_cost_window_start(now, 48) == datetime.datetime(
+    assert get_cost_window_start(now, 168) == datetime.datetime(
         2026, 7, 20, tzinfo=datetime.timezone.utc
     )
 

--- a/backend/tests/unit/onyx/db/test_user_usage_reset.py
+++ b/backend/tests/unit/onyx/db/test_user_usage_reset.py
@@ -100,7 +100,7 @@ class TestResetUserUsage:
         ]
 
         assert get_usage_reset_window_start(now, rate_limits) == (
-            current - datetime.timedelta(days=6)
+            current - datetime.timedelta(days=1)
         )
 
     def test_only_targets_the_given_user(self, db: Session) -> None:

--- a/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
@@ -538,6 +538,9 @@ def test_budget_reflects_user_cost_limit(
     )
     assert body["budget_cents"] == pytest.approx(100.0)
     assert body["budget_remaining_cents"] == pytest.approx(98.75)  # 100 - 1.25
+    assert body["budget_reset_at"] == get_cost_window_reset(
+        datetime.datetime.now(datetime.timezone.utc), 168
+    ).isoformat().replace("+00:00", "Z")
 
 
 def test_budget_reflects_global_cost_limit(

--- a/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
@@ -336,6 +336,7 @@ def test_custom_date_range_uses_inclusive_calendar_bounds(
         "model-a",
         "model-b",
     ]
+    assert body["window_cost_cents"] == pytest.approx(3.0)
 
 
 def test_custom_date_range_rejects_start_after_end(db_session: Session) -> None:
@@ -343,6 +344,26 @@ def test_custom_date_range_rejects_start_after_end(db_session: Session) -> None:
 
     resp = TestClient(_make_app(db_session, _StubUser(caller))).get(
         "/user/usage", params={"start": "2026-07-04", "end": "2026-07-03"}
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["error_code"] == "INVALID_INPUT"
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"end": "9999-12-31"},
+        {"end": "0001-01-01"},
+    ],
+)
+def test_custom_date_range_rejects_unsupported_bounds(
+    db_session: Session, params: dict[str, str]
+) -> None:
+    caller = str(uuid4())
+
+    resp = TestClient(_make_app(db_session, _StubUser(caller))).get(
+        "/user/usage", params=params
     )
 
     assert resp.status_code == 400

--- a/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
@@ -518,7 +518,25 @@ def test_budget_reflects_user_cost_limit(
     from onyx.db.models import TokenRateLimitScope
 
     caller = str(uuid4())
-    _seed_current_window(db_session, caller)  # records 1.25c of cost
+    fixed_now = datetime.datetime(2026, 8, 12, 15, tzinfo=datetime.timezone.utc)
+
+    class _FixedDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz: datetime.tzinfo | None = None) -> datetime.datetime:
+            return fixed_now if tz is not None else fixed_now.replace(tzinfo=None)
+
+    _seed_usage(
+        db_session,
+        caller,
+        "gpt-4o",
+        "CHAT",
+        "openai",
+        100,
+        50,
+        0,
+        1.25,
+        get_cost_window_start(fixed_now, 24),
+    )
     db_session.add(
         TokenRateLimit(
             enabled=True,
@@ -529,6 +547,7 @@ def test_budget_reflects_user_cost_limit(
         )
     )
     db_session.commit()
+    monkeypatch.setattr(usage_api, "datetime", _FixedDatetime)
     monkeypatch.setattr(
         "onyx.server.features.usage.api.fetch_default_llm_model", lambda _db: None
     )
@@ -539,7 +558,7 @@ def test_budget_reflects_user_cost_limit(
     assert body["budget_cents"] == pytest.approx(100.0)
     assert body["budget_remaining_cents"] == pytest.approx(98.75)  # 100 - 1.25
     assert body["budget_reset_at"] == get_cost_window_reset(
-        datetime.datetime.now(datetime.timezone.utc), 168
+        fixed_now, 168
     ).isoformat().replace("+00:00", "Z")
 
 

--- a/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
@@ -27,6 +27,7 @@ from onyx.db.models import (
     User__UserGroup,
     UserUsage,
 )
+from onyx.db.user_usage import get_cost_window_reset, get_cost_window_start
 from onyx.error_handling.exceptions import register_onyx_exception_handlers
 from onyx.llm import cost_overrides
 from onyx.llm.cost import ModelPrice, get_model_price_per_million
@@ -46,6 +47,26 @@ def _compile_jsonb_sqlite(_element: object, _compiler: object, **_kw: object) ->
 class _StubUser:
     def __init__(self, user_id: str) -> None:
         self.id = user_id
+
+
+@pytest.mark.parametrize(
+    ("period_hours", "start", "reset"),
+    [
+        (24, datetime.datetime(2026, 8, 12), datetime.datetime(2026, 8, 13)),
+        (168, datetime.datetime(2026, 8, 10), datetime.datetime(2026, 8, 17)),
+        (720, datetime.datetime(2026, 8, 1), datetime.datetime(2026, 9, 1)),
+    ],
+)
+def test_cost_budgets_use_fixed_utc_calendar_periods(
+    period_hours: int, start: datetime.datetime, reset: datetime.datetime
+) -> None:
+    now = datetime.datetime(2026, 8, 12, 15, tzinfo=datetime.timezone.utc)
+    assert get_cost_window_start(now, period_hours) == start.replace(
+        tzinfo=datetime.timezone.utc
+    )
+    assert get_cost_window_reset(now, period_hours) == reset.replace(
+        tzinfo=datetime.timezone.utc
+    )
 
 
 @pytest.fixture

--- a/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
@@ -357,7 +357,6 @@ def test_custom_date_range_uses_inclusive_calendar_bounds(
         "model-a",
         "model-b",
     ]
-    assert body["window_cost_cents"] == pytest.approx(3.0)
 
 
 def test_custom_date_range_rejects_start_after_end(db_session: Session) -> None:
@@ -365,26 +364,6 @@ def test_custom_date_range_rejects_start_after_end(db_session: Session) -> None:
 
     resp = TestClient(_make_app(db_session, _StubUser(caller))).get(
         "/user/usage", params={"start": "2026-07-04", "end": "2026-07-03"}
-    )
-
-    assert resp.status_code == 400
-    assert resp.json()["error_code"] == "INVALID_INPUT"
-
-
-@pytest.mark.parametrize(
-    "params",
-    [
-        {"end": "9999-12-31"},
-        {"end": "0001-01-01"},
-    ],
-)
-def test_custom_date_range_rejects_unsupported_bounds(
-    db_session: Session, params: dict[str, str]
-) -> None:
-    caller = str(uuid4())
-
-    resp = TestClient(_make_app(db_session, _StubUser(caller))).get(
-        "/user/usage", params=params
     )
 
     assert resp.status_code == 400
@@ -518,25 +497,7 @@ def test_budget_reflects_user_cost_limit(
     from onyx.db.models import TokenRateLimitScope
 
     caller = str(uuid4())
-    fixed_now = datetime.datetime(2026, 8, 12, 15, tzinfo=datetime.timezone.utc)
-
-    class _FixedDatetime(datetime.datetime):
-        @classmethod
-        def now(cls, tz: datetime.tzinfo | None = None) -> datetime.datetime:
-            return fixed_now if tz is not None else fixed_now.replace(tzinfo=None)
-
-    _seed_usage(
-        db_session,
-        caller,
-        "gpt-4o",
-        "CHAT",
-        "openai",
-        100,
-        50,
-        0,
-        1.25,
-        get_cost_window_start(fixed_now, 24),
-    )
+    _seed_current_window(db_session, caller)  # records 1.25c of cost
     db_session.add(
         TokenRateLimit(
             enabled=True,
@@ -547,7 +508,6 @@ def test_budget_reflects_user_cost_limit(
         )
     )
     db_session.commit()
-    monkeypatch.setattr(usage_api, "datetime", _FixedDatetime)
     monkeypatch.setattr(
         "onyx.server.features.usage.api.fetch_default_llm_model", lambda _db: None
     )
@@ -558,7 +518,7 @@ def test_budget_reflects_user_cost_limit(
     assert body["budget_cents"] == pytest.approx(100.0)
     assert body["budget_remaining_cents"] == pytest.approx(98.75)  # 100 - 1.25
     assert body["budget_reset_at"] == get_cost_window_reset(
-        fixed_now, 168
+        datetime.datetime.now(datetime.timezone.utc), 168
     ).isoformat().replace("+00:00", "Z")
 
 

--- a/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
+import onyx.server.features.usage.api as usage_api
 from onyx.auth.users import current_user
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import (
@@ -198,6 +199,154 @@ def test_returns_only_callers_rows_and_aggregates(
     assert body["budget_cents"] is None
     assert body["budget_remaining_cents"] is None
     assert body["selected_model_price"] is None
+
+
+def test_default_range_uses_usage_limit_window(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    caller = str(uuid4())
+    fixed_now = datetime.datetime(2026, 8, 4, 12, 34, tzinfo=datetime.timezone.utc)
+    seen: dict[str, datetime.datetime] = {}
+
+    class _FixedDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz: datetime.tzinfo | None = None) -> datetime.datetime:
+            return fixed_now if tz is not None else fixed_now.replace(tzinfo=None)
+
+    def _capture_usage_bounds(
+        *_args: object,
+        since: datetime.datetime,
+        until: datetime.datetime,
+    ) -> list[object]:
+        seen["since"] = since
+        seen["until"] = until
+        return []
+
+    monkeypatch.setattr(usage_api, "datetime", _FixedDatetime)
+    monkeypatch.setattr(
+        usage_api, "get_user_usage_by_day_and_model", _capture_usage_bounds
+    )
+    monkeypatch.setattr(
+        "onyx.server.features.usage.api.fetch_default_llm_model", lambda _db: None
+    )
+
+    resp = TestClient(_make_app(db_session, _StubUser(caller))).get("/user/usage")
+
+    assert resp.status_code == 200
+    assert seen == {
+        "since": usage_api.get_window_start(
+            fixed_now, period_seconds=usage_api.USAGE_LIMIT_WINDOW_SECONDS
+        ),
+        "until": fixed_now,
+    }
+
+
+def test_days_range_uses_legacy_rolling_bounds(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    caller = str(uuid4())
+    fixed_now = datetime.datetime(2026, 8, 4, 12, 34, tzinfo=datetime.timezone.utc)
+    seen: dict[str, datetime.datetime] = {}
+
+    class _FixedDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz: datetime.tzinfo | None = None) -> datetime.datetime:
+            return fixed_now if tz is not None else fixed_now.replace(tzinfo=None)
+
+    def _capture_usage_bounds(
+        *_args: object,
+        since: datetime.datetime,
+        until: datetime.datetime,
+    ) -> list[object]:
+        seen["since"] = since
+        seen["until"] = until
+        return []
+
+    monkeypatch.setattr(usage_api, "datetime", _FixedDatetime)
+    monkeypatch.setattr(
+        usage_api, "get_user_usage_by_day_and_model", _capture_usage_bounds
+    )
+    monkeypatch.setattr(
+        "onyx.server.features.usage.api.fetch_default_llm_model", lambda _db: None
+    )
+
+    resp = TestClient(_make_app(db_session, _StubUser(caller))).get(
+        "/user/usage", params={"days": 7}
+    )
+
+    assert resp.status_code == 200
+    assert seen == {
+        "since": fixed_now - datetime.timedelta(days=7),
+        "until": fixed_now,
+    }
+
+
+def test_custom_date_range_uses_inclusive_calendar_bounds(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    caller = str(uuid4())
+    _seed_usage(
+        db_session,
+        caller,
+        "model-a",
+        "CHAT",
+        "openai",
+        100,
+        50,
+        0,
+        1.0,
+        datetime.datetime(2026, 7, 1, 12, tzinfo=datetime.timezone.utc),
+    )
+    _seed_usage(
+        db_session,
+        caller,
+        "model-b",
+        "CHAT",
+        "openai",
+        200,
+        60,
+        0,
+        2.0,
+        datetime.datetime(2026, 7, 3, 23, 59, tzinfo=datetime.timezone.utc),
+    )
+    _seed_usage(
+        db_session,
+        caller,
+        "model-c",
+        "CHAT",
+        "openai",
+        300,
+        70,
+        0,
+        3.0,
+        datetime.datetime(2026, 7, 4, tzinfo=datetime.timezone.utc),
+    )
+    db_session.commit()
+    monkeypatch.setattr(
+        "onyx.server.features.usage.api.fetch_default_llm_model", lambda _db: None
+    )
+
+    body = (
+        TestClient(_make_app(db_session, _StubUser(caller)))
+        .get("/user/usage", params={"start": "2026-07-01", "end": "2026-07-03"})
+        .json()
+    )
+
+    assert [row["model"] for row in body["per_day_by_model"]] == [
+        "model-a",
+        "model-b",
+    ]
+
+
+def test_custom_date_range_rejects_start_after_end(db_session: Session) -> None:
+    caller = str(uuid4())
+
+    resp = TestClient(_make_app(db_session, _StubUser(caller))).get(
+        "/user/usage", params={"start": "2026-07-04", "end": "2026-07-03"}
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["error_code"] == "INVALID_INPUT"
 
 
 def test_selected_model_price_known_model(

--- a/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
@@ -312,24 +312,20 @@ def _recent_cost_buckets(total: float) -> list[tuple[datetime.datetime, float]]:
 class TestCostBudgetReset:
     """Unit of the shared cost evaluator (no DB; cost buckets are injected)."""
 
-    def test_current_day_usage_expires_at_full_window(self) -> None:
-        # Usage sits in today's (newest) bucket, so a 2-day window only clears
-        # once today itself rolls off — the full-window expiry.
+    def test_current_day_usage_expires_at_calendar_reset(self) -> None:
         now = datetime.datetime.now(datetime.timezone.utc)
-        limit = _cost_limit(100.0, TokenRateLimitScope.USER, period_hours=48)
+        limit = _cost_limit(100.0, TokenRateLimitScope.USER, period_hours=168)
         assert token_limit._cost_budget_reset(
             [limit], _recent_cost_buckets(150.0)
-        ) == get_cost_window_reset(now, 48)
+        ) == get_cost_window_reset(now, 168)
 
-    def test_stale_day_usage_expires_early(self) -> None:
-        # The overage is entirely in the oldest day of a 2-day window, so it ages
-        # out tomorrow — the exact reset, well before the full-window expiry.
+    def test_oldest_weekly_usage_expires_at_calendar_reset(self) -> None:
         now = datetime.datetime.now(datetime.timezone.utc)
-        limit = _cost_limit(100.0, TokenRateLimitScope.USER, period_hours=48)
-        oldest_day = [(get_cost_window_start(now, 48), 150.0)]
+        limit = _cost_limit(100.0, TokenRateLimitScope.USER, period_hours=168)
+        oldest_day = [(get_cost_window_start(now, 168), 150.0)]
         assert token_limit._cost_budget_reset(
             [limit], oldest_day
-        ) == get_cost_window_reset(now, 24)
+        ) == get_cost_window_reset(now, 168)
 
     def test_over_cost_budget_returns_reset(self) -> None:
         limit = _cost_limit(100.0, TokenRateLimitScope.USER)
@@ -590,10 +586,10 @@ class TestTokenRateLimitArgsValidation:
         )
         assert args.token_budget is None and args.cost_budget_cents == 500.0
 
-    def test_cost_period_must_be_whole_days(self) -> None:
+    def test_cost_period_must_be_a_supported_calendar_period(self) -> None:
         from onyx.server.token_rate_limits.models import TokenRateLimitArgs
 
-        with pytest.raises(ValueError, match="whole UTC days"):
+        with pytest.raises(ValueError, match="daily.*weekly.*monthly"):
             TokenRateLimitArgs(
                 enabled=True,
                 token_budget=None,

--- a/web/src/app/app/settings/usage/UsageSettings.test.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import UsageSettings from "@/app/app/settings/usage/UsageSettings";
+import { useUserUsage } from "@/app/app/settings/usage/lib";
+
+jest.mock("@/app/app/settings/usage/lib", () => ({
+  useUserUsage: jest.fn(),
+}));
+
+const mockUseUserUsage = useUserUsage as jest.MockedFunction<
+  typeof useUserUsage
+>;
+
+describe("UsageSettings", () => {
+  beforeEach(() => {
+    mockUseUserUsage.mockReturnValue({
+      data: {
+        per_day_by_model: [],
+        window_cost_cents: 0,
+        budget_cents: null,
+        budget_remaining_cents: null,
+        budget_period_hours: null,
+        selected_model_price: null,
+        available_model_prices: [],
+      },
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: jest.fn(),
+    } as unknown as ReturnType<typeof useUserUsage>);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("uses a wrapping shared date range picker header", () => {
+    render(<UsageSettings />);
+
+    const picker = screen.getByRole("group", { name: "Date range" });
+
+    expect(picker).toBeInTheDocument();
+    expect(picker.parentElement).toHaveClass("flex-wrap");
+  });
+});

--- a/web/src/app/app/settings/usage/UsageSettings.test.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import UsageSettings from "@/app/app/settings/usage/UsageSettings";
 import { useUserUsage } from "@/app/app/settings/usage/lib";
 
@@ -71,5 +72,100 @@ describe("UsageSettings", () => {
     render(<UsageSettings />);
 
     expect(screen.getByText("Resets on Sep 1")).toBeInTheDocument();
+  });
+
+  it("shows the top three models before expanding the breakdown", async () => {
+    const user = userEvent.setup();
+    mockUseUserUsage.mockReturnValue({
+      data: {
+        per_day_by_model: [
+          {
+            day: "2026-08-08",
+            model: "model-four",
+            input_tokens: 400,
+            output_tokens: 40,
+            cache_read_tokens: 0,
+            cost_cents: 4,
+          },
+          {
+            day: "2026-08-07",
+            model: "model-four",
+            input_tokens: 50,
+            output_tokens: 5,
+            cache_read_tokens: 0,
+            cost_cents: 3,
+          },
+          {
+            day: "2026-08-10",
+            model: "model-two",
+            input_tokens: 200,
+            output_tokens: 20,
+            cache_read_tokens: 0,
+            cost_cents: 8,
+          },
+          {
+            day: "2026-08-11",
+            model: "model-one",
+            input_tokens: 100,
+            output_tokens: 10,
+            cache_read_tokens: 0,
+            cost_cents: 10,
+          },
+          {
+            day: "2026-08-09",
+            model: "model-three",
+            input_tokens: 300,
+            output_tokens: 30,
+            cache_read_tokens: 0,
+            cost_cents: 6,
+          },
+        ],
+        window_cost_cents: 28,
+        budget_cents: null,
+        budget_remaining_cents: null,
+        budget_period_hours: null,
+        budget_reset_at: null,
+        selected_model_price: null,
+        available_model_prices: [],
+      },
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: jest.fn(),
+    } as unknown as ReturnType<typeof useUserUsage>);
+
+    render(<UsageSettings />);
+
+    expect(screen.getByText("model-one")).toBeInTheDocument();
+    expect(screen.getByText("model-two")).toBeInTheDocument();
+    expect(screen.getByText("model-four")).toBeInTheDocument();
+    expect(screen.getByTestId("usage-model-preview")).toHaveAttribute(
+      "aria-hidden",
+      "true"
+    );
+    expect(screen.getByText("Show 1 more")).toBeInTheDocument();
+    expect(screen.getByTestId("usage-model-preview")).toHaveClass(
+      "[mask-image:linear-gradient(to_bottom,black_5%,transparent_75%)]"
+    );
+    expect(screen.getByTestId("usage-models-expander")).not.toHaveClass(
+      "bg-background-tint-00"
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Show 1 more models" })
+    );
+
+    expect(screen.getByText("model-three")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Show fewer models" })
+    ).toHaveAttribute("aria-expanded", "true");
+    expect(screen.queryByTestId("usage-model-preview")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Show fewer models" }));
+
+    expect(screen.getByTestId("usage-model-preview")).toHaveAttribute(
+      "aria-hidden",
+      "true"
+    );
   });
 });

--- a/web/src/app/app/settings/usage/UsageSettings.test.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.test.tsx
@@ -19,6 +19,7 @@ describe("UsageSettings", () => {
         budget_cents: null,
         budget_remaining_cents: null,
         budget_period_hours: null,
+        budget_reset_at: null,
         selected_model_price: null,
         available_model_prices: [],
       },
@@ -30,15 +31,45 @@ describe("UsageSettings", () => {
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     jest.clearAllMocks();
   });
 
-  it("uses a wrapping shared date range picker header", () => {
+  it("keeps the shared date range picker inline with the usage title", () => {
     render(<UsageSettings />);
 
     const picker = screen.getByRole("group", { name: "Date range" });
 
     expect(picker).toBeInTheDocument();
-    expect(picker.parentElement).toHaveClass("flex-wrap");
+    expect(picker.parentElement).toHaveClass(
+      "flex-wrap",
+      "items-center",
+      "justify-between"
+    );
+    expect(screen.getByText("Usage").parentElement).toBe(picker.parentElement);
+  });
+
+  it("shows the fixed budget reset date", () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-08-12T12:00:00Z"));
+    mockUseUserUsage.mockReturnValue({
+      data: {
+        per_day_by_model: [],
+        window_cost_cents: 897.2,
+        budget_cents: 1500,
+        budget_remaining_cents: 602.8,
+        budget_period_hours: 720,
+        budget_reset_at: "2026-09-01T00:00:00Z",
+        selected_model_price: null,
+        available_model_prices: [],
+      },
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: jest.fn(),
+    } as unknown as ReturnType<typeof useUserUsage>);
+
+    render(<UsageSettings />);
+
+    expect(screen.getByText("Resets on Sep 1")).toBeInTheDocument();
   });
 });

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -11,7 +11,6 @@ import {
   SvgSimpleLoader,
   SvgChevronRight,
 } from "@opal/icons";
-import InputSelect from "@/refresh-components/inputs/InputSelect";
 import {
   Collapsible,
   CollapsibleContent,
@@ -24,12 +23,14 @@ import {
   type ModelPrice,
 } from "@/app/app/settings/usage/lib";
 import {
+  DateRangePicker,
+  rangeForInclusiveDays,
+  type DateRange,
+} from "@/refresh-components/DateRangePicker";
+import {
   formatCurrencyFromCents as formatDollars,
   formatTokenCount as formatTokens,
 } from "@/lib/format";
-
-const DAYS_OPTIONS = ["7", "30"] as const;
-const DEFAULT_DAYS = 30;
 
 interface WindowCostSectionProps {
   windowCostCents: number;
@@ -346,8 +347,10 @@ function BudgetSection({
 }
 
 export default function UsageSettings() {
-  const [days, setDays] = useState<string>(String(DEFAULT_DAYS));
-  const { data, error, isLoading } = useUserUsage(Number(days));
+  const [dateRange, setDateRange] = useState<DateRange>(
+    rangeForInclusiveDays(30)
+  );
+  const { data, error, isLoading } = useUserUsage(dateRange);
 
   useEffect(() => {
     if (error) console.error("Failed to load usage", error);
@@ -362,20 +365,14 @@ export default function UsageSettings() {
           alignItems="center"
           width="full"
           gap={4}
+          wrap
         >
           <Content title="Usage" sizePreset="main-content" variant="section" />
-          <div className="min-w-32">
-            <InputSelect value={days} onValueChange={setDays}>
-              <InputSelect.Trigger placeholder="Period" />
-              <InputSelect.Content>
-                {DAYS_OPTIONS.map((option) => (
-                  <InputSelect.Item key={option} value={option}>
-                    {`Last ${option} days`}
-                  </InputSelect.Item>
-                ))}
-              </InputSelect.Content>
-            </InputSelect>
-          </div>
+          <DateRangePicker
+            value={dateRange}
+            onValueChange={setDateRange}
+            size="sm"
+          />
         </Section>
 
         {isLoading ? (

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Section } from "@/layouts/general-layouts";
 import { Content } from "@opal/layouts";
-import { Card, Divider, EmptyMessageCard, Text } from "@opal/components";
+import { Text, EmptyMessageCard, Divider } from "@opal/components";
 import {
   SvgBarChart,
   SvgWallet,
@@ -11,6 +11,7 @@ import {
   SvgSimpleLoader,
   SvgChevronRight,
 } from "@opal/icons";
+import Card from "@/refresh-components/cards/Card";
 import {
   Collapsible,
   CollapsibleContent,
@@ -27,6 +28,7 @@ import {
   rangeForInclusiveDays,
   type DateRange,
 } from "@/refresh-components/DateRangePicker";
+import { formatCalendarDay } from "@/lib/dateUtils";
 import {
   formatCurrencyFromCents as formatDollars,
   formatTokenCount as formatTokens,
@@ -50,7 +52,7 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
   );
 
   return (
-    <Section gap={3} justifyContent="start">
+    <Section gap={0.75} justifyContent="start">
       <Content
         icon={SvgBarChart}
         title="Usage this period"
@@ -67,58 +69,56 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
           description="Your model usage and costs will show up here once you start chatting."
         />
       ) : (
-        <Card border="solid" rounding="lg">
-          <Section alignItems="start" height="fit">
-            {sortedRows.map((row, index) => (
-              <div key={`${row.day}-${row.model}`}>
-                {index > 0 && <Divider />}
-                <Section gap={2} alignItems="start" justifyContent="start">
-                  <Section
-                    flexDirection="row"
-                    justifyContent="between"
-                    alignItems="center"
-                    width="full"
-                    gap={4}
-                  >
-                    <Section gap={0} alignItems="start" justifyContent="start">
-                      <Text font="main-ui-action" color="text-03">
-                        {row.model}
-                      </Text>
-                      <Text font="secondary-body" color="text-01">
-                        {row.day}
-                      </Text>
-                    </Section>
-                    <Text font="main-ui-action" color="text-03" nowrap>
-                      {formatDollars(row.cost_cents)}
+        <Card>
+          {sortedRows.map((row, index) => (
+            <div key={`${row.day}-${row.model}`}>
+              {index > 0 && <Divider />}
+              <Section gap={0.5} alignItems="start" justifyContent="start">
+                <Section
+                  flexDirection="row"
+                  justifyContent="between"
+                  alignItems="center"
+                  width="full"
+                  gap={1}
+                >
+                  <Section gap={0} alignItems="start" justifyContent="start">
+                    <Text font="main-ui-action" color="text-03">
+                      {row.model}
+                    </Text>
+                    <Text font="secondary-body" color="text-01">
+                      {row.day}
                     </Text>
                   </Section>
-
-                  {/* Cost bar — proportional to the priciest row in the window. */}
-                  <div className="w-full h-1.5 rounded-full bg-background-neutral-03 overflow-hidden">
-                    <div
-                      className="h-full rounded-full bg-theme-primary-05"
-                      style={{
-                        width:
-                          maxRowCost > 0
-                            ? `${Math.max(2, (row.cost_cents / maxRowCost) * 100)}%`
-                            : "0%",
-                      }}
-                    />
-                  </div>
-
-                  <Text font="secondary-body" color="text-01">
-                    {`${formatTokens(row.input_tokens)} in · ${formatTokens(
-                      row.output_tokens
-                    )} out${
-                      hasCache
-                        ? ` · ${formatTokens(row.cache_read_tokens)} cache`
-                        : ""
-                    }`}
+                  <Text font="main-ui-action" color="text-03" nowrap>
+                    {formatDollars(row.cost_cents)}
                   </Text>
                 </Section>
-              </div>
-            ))}
-          </Section>
+
+                {/* Cost bar — proportional to the priciest row in the window. */}
+                <div className="w-full h-1.5 rounded-full bg-background-neutral-03 overflow-hidden">
+                  <div
+                    className="h-full rounded-full bg-theme-primary-05"
+                    style={{
+                      width:
+                        maxRowCost > 0
+                          ? `${Math.max(2, (row.cost_cents / maxRowCost) * 100)}%`
+                          : "0%",
+                    }}
+                  />
+                </div>
+
+                <Text font="secondary-body" color="text-03">
+                  {`${formatTokens(row.input_tokens)} in · ${formatTokens(
+                    row.output_tokens
+                  )} out${
+                    hasCache
+                      ? ` · ${formatTokens(row.cache_read_tokens)} cache`
+                      : ""
+                  }`}
+                </Text>
+              </Section>
+            </div>
+          ))}
         </Card>
       )}
     </Section>
@@ -185,7 +185,7 @@ function ModelPriceSection({ prices, defaultPrice }: ModelPriceSectionProps) {
   }
 
   return (
-    <Section gap={3} justifyContent="start">
+    <Section gap={0.75} justifyContent="start">
       <Content
         icon={SvgCreditCard}
         title="Model prices"
@@ -194,67 +194,65 @@ function ModelPriceSection({ prices, defaultPrice }: ModelPriceSectionProps) {
         variant="section"
         width="full"
       />
-      <Card border="solid" rounding="lg">
-        <Section alignItems="start" height="fit">
-          {groups.length === 0 ? (
-            <Text font="main-ui-body" color="text-01">
-              Prices unavailable
-            </Text>
-          ) : (
-            <Section gap={1} alignItems="stretch" justifyContent="start">
-              {groups.map(({ provider, models }) => {
-                const open = expanded.has(provider);
-                return (
-                  <Collapsible
-                    key={provider}
-                    open={open}
-                    onOpenChange={() => toggle(provider)}
-                    className="flex flex-col"
-                  >
-                    <CollapsibleTrigger className="flex flex-row items-center justify-between cursor-pointer select-none py-1.5">
-                      <Text font="main-ui-action" color="text-03">
-                        {provider}
-                      </Text>
-                      <SvgChevronRight
-                        className={cn(
-                          "w-4 h-4 text-text-03 transition-transform",
-                          open && "rotate-90"
-                        )}
-                      />
-                    </CollapsibleTrigger>
-                    <CollapsibleContent>
-                      <Section
-                        gap={0}
-                        alignItems="stretch"
-                        justifyContent="start"
-                      >
-                        {models.map((price) => (
-                          <div
-                            key={`${provider}-${price.model}`}
-                            className="flex flex-row items-center justify-between gap-2 py-1 pl-3"
-                          >
-                            <Text font="secondary-body" color="text-03" nowrap>
-                              {isSameModelPrice(price, defaultPrice)
-                                ? `${price.model} · default`
-                                : price.model}
-                            </Text>
-                            <Text font="secondary-body" color="text-01" nowrap>
-                              {`${formatMtok(price.input_per_mtok)} in · ${formatMtok(
-                                price.output_per_mtok
-                              )} out · ${formatMtok(
-                                price.cache_per_mtok ?? price.input_per_mtok
-                              )} cache`}
-                            </Text>
-                          </div>
-                        ))}
-                      </Section>
-                    </CollapsibleContent>
-                  </Collapsible>
-                );
-              })}
-            </Section>
-          )}
-        </Section>
+      <Card>
+        {groups.length === 0 ? (
+          <Text font="main-ui-body" color="text-01">
+            Prices unavailable
+          </Text>
+        ) : (
+          <Section gap={0.25} alignItems="stretch" justifyContent="start">
+            {groups.map(({ provider, models }) => {
+              const open = expanded.has(provider);
+              return (
+                <Collapsible
+                  key={provider}
+                  open={open}
+                  onOpenChange={() => toggle(provider)}
+                  className="flex flex-col"
+                >
+                  <CollapsibleTrigger className="flex flex-row items-center justify-between cursor-pointer select-none py-1.5">
+                    <Text font="main-ui-action" color="text-03">
+                      {provider}
+                    </Text>
+                    <SvgChevronRight
+                      className={cn(
+                        "w-4 h-4 text-text-03 transition-transform",
+                        open && "rotate-90"
+                      )}
+                    />
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <Section
+                      gap={0}
+                      alignItems="stretch"
+                      justifyContent="start"
+                    >
+                      {models.map((price) => (
+                        <div
+                          key={`${provider}-${price.model}`}
+                          className="flex flex-row items-center justify-between gap-2 py-1 pl-3"
+                        >
+                          <Text font="secondary-body" color="text-05" nowrap>
+                            {isSameModelPrice(price, defaultPrice)
+                              ? `${price.model} · default`
+                              : price.model}
+                          </Text>
+                          <Text font="secondary-body" color="text-03" nowrap>
+                            {`${formatMtok(price.input_per_mtok)} in · ${formatMtok(
+                              price.output_per_mtok
+                            )} out · ${formatMtok(
+                              price.cache_per_mtok ?? price.input_per_mtok
+                            )} cache`}
+                          </Text>
+                        </div>
+                      ))}
+                    </Section>
+                  </CollapsibleContent>
+                </Collapsible>
+              );
+            })}
+          </Section>
+        )}
       </Card>
     </Section>
   );
@@ -263,27 +261,19 @@ function ModelPriceSection({ prices, defaultPrice }: ModelPriceSectionProps) {
 interface BudgetSectionProps {
   budgetCents: number | null;
   budgetRemainingCents: number | null;
-  budgetPeriodHours: number | null;
+  budgetResetAt: string | null;
 }
 
-// Hours -> a friendly window label so the budget reads "per week", not "per 168h".
-function formatPeriod(hours: number | null): string {
-  if (hours == null) return "";
-  if (hours % 168 === 0) {
-    const w = hours / 168;
-    return w === 1 ? "week" : `${w} weeks`;
-  }
-  if (hours % 24 === 0) {
-    const d = hours / 24;
-    return d === 1 ? "day" : `${d} days`;
-  }
-  return hours === 1 ? "hour" : `${hours} hours`;
+function formatBudgetReset(resetAt: string | null): string | null {
+  return resetAt
+    ? `Resets on ${formatCalendarDay(resetAt.slice(0, 10))}`
+    : null;
 }
 
 function BudgetSection({
   budgetCents,
   budgetRemainingCents,
-  budgetPeriodHours,
+  budgetResetAt,
 }: BudgetSectionProps) {
   // budget_* are null when the user has no cost limit; show a graceful empty state.
   const hasBudget = budgetCents !== null;
@@ -291,9 +281,10 @@ function BudgetSection({
   const spent = hasBudget ? Math.max(0, budgetCents - remaining) : 0;
   const usedFraction =
     hasBudget && budgetCents > 0 ? Math.min(1, spent / budgetCents) : 0;
+  const budgetReset = formatBudgetReset(budgetResetAt);
 
   return (
-    <Section gap={3} justifyContent="start">
+    <Section gap={0.75} justifyContent="start">
       <Content
         icon={SvgWallet}
         title="Budget"
@@ -301,46 +292,41 @@ function BudgetSection({
         variant="section"
         width="full"
       />
-      <Card border="solid" rounding="lg">
-        <Section alignItems="start" height="fit">
-          {hasBudget ? (
-            <Section gap={2} alignItems="start" justifyContent="start">
-              <Section
-                flexDirection="row"
-                justifyContent="between"
-                alignItems="center"
-                width="full"
-                gap={4}
-              >
-                <Text font="main-ui-body" color="text-03">
-                  {`${formatDollars(remaining)} remaining`}
+      <Card>
+        {hasBudget ? (
+          <Section gap={0.5} alignItems="start" justifyContent="start">
+            <div className="flex w-full flex-wrap items-baseline gap-x-4 gap-y-1">
+              <Text font="main-ui-body" color="text-03">
+                {`${formatDollars(remaining)} remaining`}
+              </Text>
+            </div>
+            <div className="h-1.5 w-full overflow-hidden rounded-full bg-background-neutral-03">
+              <div
+                className={cn(
+                  "h-full rounded-full",
+                  usedFraction >= 1
+                    ? "bg-status-error-05"
+                    : "bg-theme-primary-05"
+                )}
+                style={{ width: `${usedFraction * 100}%` }}
+              />
+            </div>
+            <div className="flex w-full flex-wrap justify-between gap-x-4 gap-y-1">
+              {budgetReset && (
+                <Text font="secondary-body" color="text-03">
+                  {budgetReset}
                 </Text>
-                <Text font="secondary-body" color="text-01">
-                  {`of ${formatDollars(budgetCents)}${
-                    budgetPeriodHours
-                      ? ` per ${formatPeriod(budgetPeriodHours)}`
-                      : ""
-                  }`}
-                </Text>
-              </Section>
-              <div className="w-full h-1.5 rounded-full bg-background-neutral-03 overflow-hidden">
-                <div
-                  className={cn(
-                    "h-full rounded-full",
-                    usedFraction >= 1
-                      ? "bg-status-error-05"
-                      : "bg-theme-primary-05"
-                  )}
-                  style={{ width: `${usedFraction * 100}%` }}
-                />
-              </div>
-            </Section>
-          ) : (
-            <Text font="main-ui-body" color="text-01">
-              No budget set
-            </Text>
-          )}
-        </Section>
+              )}
+              <Text font="secondary-body" color="text-03">
+                {`${formatDollars(budgetCents)} limit`}
+              </Text>
+            </div>
+          </Section>
+        ) : (
+          <Text font="main-ui-body" color="text-01">
+            No budget set
+          </Text>
+        )}
       </Card>
     </Section>
   );
@@ -357,35 +343,26 @@ export default function UsageSettings() {
   }, [error]);
 
   return (
-    <Section gap={8}>
-      <Section gap={3} justifyContent="start">
-        <Section
-          flexDirection="row"
-          justifyContent="between"
-          alignItems="center"
-          width="full"
-          gap={4}
-          wrap
-        >
-          <Content title="Usage" sizePreset="main-content" variant="section" />
+    <Section gap={2}>
+      <Section gap={0.75} justifyContent="start">
+        <div className="flex w-full flex-wrap items-center justify-between gap-3">
+          <Text font="heading-h3">Usage</Text>
           <DateRangePicker
             value={dateRange}
             onValueChange={setDateRange}
             size="sm"
           />
-        </Section>
+        </div>
 
         {isLoading ? (
-          <Card border="solid" rounding="lg">
-            <Section alignItems="start" height="fit">
-              <Section
-                flexDirection="row"
-                justifyContent="center"
-                alignItems="center"
-                width="full"
-              >
-                <SvgSimpleLoader />
-              </Section>
+          <Card>
+            <Section
+              flexDirection="row"
+              justifyContent="center"
+              alignItems="center"
+              width="full"
+            >
+              <SvgSimpleLoader />
             </Section>
           </Card>
         ) : error || !data ? (
@@ -395,7 +372,7 @@ export default function UsageSettings() {
             description="Something went wrong fetching your usage. Try again in a moment."
           />
         ) : (
-          <Section gap={8}>
+          <Section gap={2}>
             <WindowCostSection
               windowCostCents={data.window_cost_cents}
               rows={data.per_day_by_model}
@@ -403,7 +380,7 @@ export default function UsageSettings() {
             <BudgetSection
               budgetCents={data.budget_cents}
               budgetRemainingCents={data.budget_remaining_cents}
-              budgetPeriodHours={data.budget_period_hours}
+              budgetResetAt={data.budget_reset_at}
             />
             <ModelPriceSection
               prices={data.available_model_prices ?? []}

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -3,13 +3,15 @@
 import { useEffect, useMemo, useState } from "react";
 import { Section } from "@/layouts/general-layouts";
 import { Content } from "@opal/layouts";
-import { Text, EmptyMessageCard, Divider } from "@opal/components";
+import { Button, Text, EmptyMessageCard, Divider } from "@opal/components";
 import {
   SvgBarChart,
   SvgWallet,
   SvgCreditCard,
   SvgSimpleLoader,
+  SvgChevronDown,
   SvgChevronRight,
+  SvgChevronUp,
 } from "@opal/icons";
 import Card from "@/refresh-components/cards/Card";
 import {
@@ -39,17 +41,37 @@ interface WindowCostSectionProps {
   rows: UsagePerDayByModel[];
 }
 
+const COLLAPSED_USAGE_ROW_COUNT = 3;
+
 function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
-  // Drives the relative bar widths in the breakdown.
-  const maxRowCost = rows.reduce(
-    (max, row) => Math.max(max, row.cost_cents),
-    0
-  );
+  const [showAll, setShowAll] = useState(false);
   const hasCache = rows.some((row) => row.cache_read_tokens > 0);
-  const sortedRows = useMemo(
-    () => [...rows].sort((a, b) => b.cost_cents - a.cost_cents),
-    [rows]
-  );
+  const modelRows = useMemo(() => {
+    const byModel = new Map<string, Omit<UsagePerDayByModel, "day">>();
+    for (const row of rows) {
+      const model = byModel.get(row.model) ?? {
+        model: row.model,
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_tokens: 0,
+        cost_cents: 0,
+      };
+      model.input_tokens += row.input_tokens;
+      model.output_tokens += row.output_tokens;
+      model.cache_read_tokens += row.cache_read_tokens;
+      model.cost_cents += row.cost_cents;
+      byModel.set(row.model, model);
+    }
+    return Array.from(byModel.values()).sort(
+      (a, b) => b.cost_cents - a.cost_cents
+    );
+  }, [rows]);
+  const maxModelCost = modelRows[0]?.cost_cents ?? 0;
+  const isExpandable = modelRows.length > COLLAPSED_USAGE_ROW_COUNT;
+  const displayedRows = showAll
+    ? modelRows
+    : modelRows.slice(0, COLLAPSED_USAGE_ROW_COUNT + 1);
+  const hiddenRowCount = modelRows.length - COLLAPSED_USAGE_ROW_COUNT;
 
   return (
     <Section gap={0.75} justifyContent="start">
@@ -70,55 +92,88 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
         />
       ) : (
         <Card>
-          {sortedRows.map((row, index) => (
-            <div key={`${row.day}-${row.model}`}>
-              {index > 0 && <Divider />}
-              <Section gap={0.5} alignItems="start" justifyContent="start">
-                <Section
-                  flexDirection="row"
-                  justifyContent="between"
-                  alignItems="center"
-                  width="full"
-                  gap={1}
-                >
-                  <Section gap={0} alignItems="start" justifyContent="start">
-                    <Text font="main-ui-action" color="text-03">
-                      {row.model}
-                    </Text>
-                    <Text font="secondary-body" color="text-01">
-                      {row.day}
+          {displayedRows.map((row, index) => {
+            const isPreview = !showAll && index === COLLAPSED_USAGE_ROW_COUNT;
+
+            return (
+              <div
+                key={row.model}
+                data-testid={isPreview ? "usage-model-preview" : undefined}
+                aria-hidden={isPreview || undefined}
+                className={cn(
+                  isPreview &&
+                    "max-h-10 overflow-hidden [mask-image:linear-gradient(to_bottom,black_5%,transparent_75%)]"
+                )}
+              >
+                {index > 0 && <Divider />}
+                <Section gap={0.5} alignItems="start" justifyContent="start">
+                  <Section
+                    flexDirection="row"
+                    justifyContent="between"
+                    alignItems="center"
+                    width="full"
+                    gap={1}
+                  >
+                    <Section gap={0} alignItems="start" justifyContent="start">
+                      <Text font="main-ui-action" color="text-03">
+                        {row.model}
+                      </Text>
+                    </Section>
+                    <Text font="main-ui-action" color="text-03" nowrap>
+                      {formatDollars(row.cost_cents)}
                     </Text>
                   </Section>
-                  <Text font="main-ui-action" color="text-03" nowrap>
-                    {formatDollars(row.cost_cents)}
+
+                  {/* Cost bar — proportional to the priciest row in the window. */}
+                  <div className="w-full h-1.5 rounded-full bg-background-neutral-03 overflow-hidden">
+                    <div
+                      className="h-full rounded-full bg-theme-primary-05"
+                      style={{
+                        width:
+                          maxModelCost > 0
+                            ? `${Math.max(2, (row.cost_cents / maxModelCost) * 100)}%`
+                            : "0%",
+                      }}
+                    />
+                  </div>
+
+                  <Text font="secondary-body" color="text-03">
+                    {`${formatTokens(row.input_tokens)} in · ${formatTokens(
+                      row.output_tokens
+                    )} out${
+                      hasCache
+                        ? ` · ${formatTokens(row.cache_read_tokens)} cache`
+                        : ""
+                    }`}
                   </Text>
                 </Section>
-
-                {/* Cost bar — proportional to the priciest row in the window. */}
-                <div className="w-full h-1.5 rounded-full bg-background-neutral-03 overflow-hidden">
-                  <div
-                    className="h-full rounded-full bg-theme-primary-05"
-                    style={{
-                      width:
-                        maxRowCost > 0
-                          ? `${Math.max(2, (row.cost_cents / maxRowCost) * 100)}%`
-                          : "0%",
-                    }}
-                  />
-                </div>
-
-                <Text font="secondary-body" color="text-03">
-                  {`${formatTokens(row.input_tokens)} in · ${formatTokens(
-                    row.output_tokens
-                  )} out${
-                    hasCache
-                      ? ` · ${formatTokens(row.cache_read_tokens)} cache`
-                      : ""
-                  }`}
-                </Text>
-              </Section>
+              </div>
+            );
+          })}
+          {isExpandable && (
+            <div
+              data-testid="usage-models-expander"
+              className={cn(
+                "relative z-10 -mx-4 -mb-4 flex self-stretch justify-center pb-1 pt-1",
+                showAll ? "mt-1" : "-mt-8"
+              )}
+            >
+              <Button
+                prominence="tertiary"
+                size="2xs"
+                rightIcon={showAll ? SvgChevronUp : SvgChevronDown}
+                aria-expanded={showAll}
+                aria-label={
+                  showAll
+                    ? "Show fewer models"
+                    : `Show ${hiddenRowCount} more models`
+                }
+                onClick={() => setShowAll((value) => !value)}
+              >
+                {showAll ? "Show less" : `Show ${hiddenRowCount} more`}
+              </Button>
             </div>
-          ))}
+          )}
         </Card>
       )}
     </Section>

--- a/web/src/app/app/settings/usage/lib.test.tsx
+++ b/web/src/app/app/settings/usage/lib.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import useSWR from "swr";
 import { useUserUsage } from "@/app/app/settings/usage/lib";
+import { rangeForInclusiveDays } from "@/refresh-components/DateRangePicker";
 
 jest.mock("swr", () => jest.fn());
 
@@ -29,6 +30,20 @@ describe("useUserUsage", () => {
 
     expect(mockUseSWR).toHaveBeenCalledWith(
       "/api/user/usage?start=2026-07-06&end=2026-08-04",
+      expect.any(Function),
+      expect.objectContaining({ revalidateOnFocus: false })
+    );
+  });
+
+  it("anchors preset ranges to the current UTC usage day", () => {
+    const nowBeforeUtcDayRollover = new Date("2026-08-13T05:00:00+10:00");
+
+    renderHook(() =>
+      useUserUsage(rangeForInclusiveDays(1, nowBeforeUtcDayRollover))
+    );
+
+    expect(mockUseSWR).toHaveBeenCalledWith(
+      "/api/user/usage?start=2026-08-12&end=2026-08-12",
       expect.any(Function),
       expect.objectContaining({ revalidateOnFocus: false })
     );

--- a/web/src/app/app/settings/usage/lib.test.tsx
+++ b/web/src/app/app/settings/usage/lib.test.tsx
@@ -1,0 +1,36 @@
+import { renderHook } from "@testing-library/react";
+import useSWR from "swr";
+import { useUserUsage } from "@/app/app/settings/usage/lib";
+
+jest.mock("swr", () => jest.fn());
+
+const mockUseSWR = useSWR as jest.MockedFunction<typeof useSWR>;
+
+describe("useUserUsage", () => {
+  beforeEach(() => {
+    mockUseSWR.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+    } as ReturnType<typeof useSWR>);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("requests inclusive calendar start and end dates", () => {
+    renderHook(() =>
+      useUserUsage({
+        from: new Date(2026, 6, 6),
+        to: new Date(2026, 7, 4, 23, 59, 59, 999),
+      })
+    );
+
+    expect(mockUseSWR).toHaveBeenCalledWith(
+      "/api/user/usage?start=2026-07-06&end=2026-08-04",
+      expect.any(Function),
+      expect.objectContaining({ revalidateOnFocus: false })
+    );
+  });
+});

--- a/web/src/app/app/settings/usage/lib.ts
+++ b/web/src/app/app/settings/usage/lib.ts
@@ -3,6 +3,8 @@
 import useSWR from "swr";
 import { errorHandlingFetcher, skipRetryOnAuthError } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import { formatDateForApiParam } from "@/lib/dateUtils";
+import { buildApiPath } from "@/lib/urlBuilder";
 
 export interface UsagePerDayByModel {
   day: string; // "YYYY-MM-DD"
@@ -33,13 +35,14 @@ export interface UserUsageResponse {
   available_model_prices: ModelPrice[];
 }
 
-export function useUserUsage(days: number) {
-  return useSWR<UserUsageResponse>(
-    SWR_KEYS.userUsage(days),
-    errorHandlingFetcher,
-    {
-      revalidateOnFocus: false,
-      onErrorRetry: skipRetryOnAuthError,
-    }
-  );
+export function useUserUsage(range: { from: Date; to: Date } | undefined) {
+  const url = buildApiPath(SWR_KEYS.userUsage, {
+    start: range?.from ? formatDateForApiParam(range.from) : undefined,
+    end: range?.to ? formatDateForApiParam(range.to) : undefined,
+  });
+
+  return useSWR<UserUsageResponse>(url, errorHandlingFetcher, {
+    revalidateOnFocus: false,
+    onErrorRetry: skipRetryOnAuthError,
+  });
 }

--- a/web/src/app/app/settings/usage/lib.ts
+++ b/web/src/app/app/settings/usage/lib.ts
@@ -26,11 +26,11 @@ export interface ModelPrice {
 export interface UserUsageResponse {
   per_day_by_model: UsagePerDayByModel[];
   window_cost_cents: number;
-  // The user's cost budget, what's left, and its window in hours (for the
-  // "per week/day/hour" label). All null when no cost limit applies.
+  // The user's cost budget, remaining allowance, and next fixed reset.
   budget_cents: number | null;
   budget_remaining_cents: number | null;
   budget_period_hours: number | null;
+  budget_reset_at: string | null;
   selected_model_price: ModelPrice | null;
   available_model_prices: ModelPrice[];
 }

--- a/web/src/app/ee/admin/performance/usage/page.tsx
+++ b/web/src/app/ee/admin/performance/usage/page.tsx
@@ -20,17 +20,16 @@ export default function UsagePage() {
         title={route.title}
         description="Monitor workspace spend and review usage by user."
         divider
+        rightChildren={
+          <DateRangePicker
+            value={timeRange}
+            onValueChange={(value) => setTimeRange(value as any)}
+            size="sm"
+          />
+        }
       />
       <SettingsLayouts.Body>
-        <PerUserUsagePanel
-          timeRange={timeRange}
-          headerRight={
-            <DateRangePicker
-              value={timeRange}
-              onValueChange={(value) => setTimeRange(value as any)}
-            />
-          }
-        />
+        <PerUserUsagePanel timeRange={timeRange} />
         <Divider />
         <TokenRateLimitsPanel embedded />
       </SettingsLayouts.Body>

--- a/web/src/lib/dateUtils.ts
+++ b/web/src/lib/dateUtils.ts
@@ -76,15 +76,7 @@ export function isDateInFuture(date: Date): boolean {
 }
 
 export const timestampToDateString = (timestamp: string) => {
-  const date = new Date(timestamp);
-  const year = date.getFullYear();
-  const month = date.getMonth() + 1; // getMonth() is zero-based
-  const day = date.getDate();
-
-  const formattedDate = `${year}-${month.toString().padStart(2, "0")}-${day
-    .toString()
-    .padStart(2, "0")}`;
-  return formattedDate;
+  return formatDateForApiParam(new Date(timestamp));
 };
 
 // Options for formatting the date

--- a/web/src/lib/dateUtils.ts
+++ b/web/src/lib/dateUtils.ts
@@ -55,6 +55,12 @@ export function getXYearsAgo(yearsAgo: number) {
   return yearsAgoDate;
 }
 
+export function formatDateForApiParam(date: Date): string {
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
 export function normalizeDate(date: Date): Date {
   const normalizedDate = new Date(date);
   normalizedDate.setHours(0, 0, 0, 0);

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -43,7 +43,7 @@ export const SWR_KEYS = {
   wellKnownLlmProvider: (providerEndpoint: string) =>
     `/api/admin/llm/built-in/options/${providerEndpoint}`,
   llmContextualCost: "/api/admin/llm/provider-contextual-cost",
-  userUsage: (days: number) => `/api/user/usage?days=${days}`,
+  userUsage: "/api/user/usage",
   costOverrides: "/api/admin/cost-overrides",
   adminUsageExport: "/api/admin/usage/export",
   adminUsageReset: "/api/admin/usage/reset",

--- a/web/src/lib/usage/userUsage.ts
+++ b/web/src/lib/usage/userUsage.ts
@@ -4,6 +4,7 @@ import useSWR from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { buildApiPath } from "@/lib/urlBuilder";
+import { formatDateForApiParam } from "@/lib/dateUtils";
 
 export interface UsageExportTotals {
   input_tokens: number;
@@ -35,16 +36,10 @@ export interface UsageExportResponse {
   users: UsageExportUser[];
 }
 
-function formatDateParam(date: Date): string {
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${date.getFullYear()}-${month}-${day}`;
-}
-
 export function useUsageExport(range?: { from: Date; to: Date } | undefined) {
   const url = buildApiPath(SWR_KEYS.adminUsageExport, {
-    start: range?.from ? formatDateParam(range.from) : undefined,
-    end: range?.to ? formatDateParam(range.to) : undefined,
+    start: range?.from ? formatDateForApiParam(range.from) : undefined,
+    end: range?.to ? formatDateForApiParam(range.to) : undefined,
   });
   const { data, error, isLoading, mutate } = useSWR<UsageExportResponse>(
     url,

--- a/web/src/refresh-components/DateRangePicker.tsx
+++ b/web/src/refresh-components/DateRangePicker.tsx
@@ -36,9 +36,15 @@ const PRESETS: DatePreset[] = [
 ];
 
 export function rangeForInclusiveDays(
-  inclusiveDays: number
+  inclusiveDays: number,
+  now = new Date()
 ): Exclude<DateRange, undefined> {
-  const to = endOfDay(new Date());
+  const utcToday = new Date(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate()
+  );
+  const to = endOfDay(utcToday);
   return { from: startOfDay(subDays(to, inclusiveDays - 1)), to };
 }
 

--- a/web/src/sections/usage/SpendByUserTable.test.tsx
+++ b/web/src/sections/usage/SpendByUserTable.test.tsx
@@ -25,6 +25,12 @@ test("opens a user from the keyboard", () => {
   const row = screen.getByRole("row", {
     name: "View usage details for ada@example.com",
   });
+
+  expect(
+    screen.getByRole("columnheader", { name: "Tokens" })
+  ).toBeInTheDocument();
+  expect(screen.getByText("1 user")).toBeInTheDocument();
+
   row.focus();
   fireEvent.keyDown(row, { key: "Enter" });
 

--- a/web/src/sections/usage/SpendByUserTable.tsx
+++ b/web/src/sections/usage/SpendByUserTable.tsx
@@ -18,6 +18,7 @@ const ALL = "__all__";
 export interface SpendRow {
   email: string;
   cost_cents: number;
+  total_tokens: number;
   input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;
@@ -38,7 +39,11 @@ function filteredRow(
   flow: string
 ): SpendRow | null {
   if (model === ALL && flow === ALL) {
-    return { email: user.email, ...user.totals };
+    return {
+      email: user.email,
+      ...user.totals,
+      total_tokens: user.totals.input_tokens + user.totals.output_tokens,
+    };
   }
   const records = user.records.filter(
     (record) =>
@@ -55,7 +60,11 @@ function filteredRow(
     }),
     emptyTotals()
   );
-  return { email: user.email, ...totals };
+  return {
+    email: user.email,
+    ...totals,
+    total_tokens: totals.input_tokens + totals.output_tokens,
+  };
 }
 
 const tc = createTableColumns<SpendRow>();
@@ -65,7 +74,7 @@ function buildColumns() {
     tc.qualifier({ content: "icon", getContent: () => SvgUser }),
     tc.column("email", {
       header: "User",
-      weight: 34,
+      weight: 38,
       cell: (value) => (
         <span className="underline-offset-2 group-hover/row:underline">
           <Text font="main-ui-body" color="text-05" nowrap>
@@ -76,12 +85,24 @@ function buildColumns() {
     }),
     tc.column("cost_cents", {
       header: "Spend",
-      weight: 14,
+      weight: 16,
       alignment: "right",
       cell: (value) => (
         <span className="tabular-nums">
           <Text font="main-ui-action" color="text-05" nowrap>
             {formatCost(value)}
+          </Text>
+        </span>
+      ),
+    }),
+    tc.column("total_tokens", {
+      header: "Tokens",
+      weight: 18,
+      alignment: "right",
+      cell: (value) => (
+        <span className="tabular-nums">
+          <Text font="main-ui-action" color="text-05" nowrap>
+            {formatTokens(value)}
           </Text>
         </span>
       ),
@@ -100,18 +121,6 @@ function buildColumns() {
     }),
     tc.column("output_tokens", {
       header: "Output",
-      weight: 14,
-      alignment: "right",
-      cell: (value) => (
-        <span className="tabular-nums">
-          <Text font="main-ui-body" color="text-03" nowrap>
-            {formatTokens(value)}
-          </Text>
-        </span>
-      ),
-    }),
-    tc.column("cache_read_tokens", {
-      header: "Cache",
       weight: 14,
       alignment: "right",
       cell: (value) => (
@@ -233,6 +242,10 @@ export default function SpendByUserTable({
           )}
         </div>
       </div>
+
+      <Text font="secondary-body" color="text-03" aria-live="polite">
+        {`${rows.length.toLocaleString()} ${rows.length === 1 ? "user" : "users"}`}
+      </Text>
 
       <Table
         // Remount on filter change so the Table's internal page index resets;

--- a/web/src/sections/usage/UserUsageDetailModal.tsx
+++ b/web/src/sections/usage/UserUsageDetailModal.tsx
@@ -3,7 +3,9 @@
 import { useMemo } from "react";
 import { Button, Modal, ProgressBar, Text, Tooltip } from "@opal/components";
 import { Section } from "@opal/layouts";
+import type { IconFunctionComponent } from "@opal/types";
 import { formatCalendarDay } from "@/lib/dateUtils";
+import { getModelIcon } from "@/lib/languageModels";
 import type { UsageExportUser } from "@/lib/usage/userUsage";
 import { formatCost, formatTokens } from "@/lib/utils";
 
@@ -81,9 +83,15 @@ interface BreakdownListProps {
   title: string;
   slices: BreakdownSlice[];
   totalCostCents: number;
+  getIcon?: (slice: BreakdownSlice) => IconFunctionComponent;
 }
 
-function BreakdownList({ title, slices, totalCostCents }: BreakdownListProps) {
+function BreakdownList({
+  title,
+  slices,
+  totalCostCents,
+  getIcon,
+}: BreakdownListProps) {
   if (slices.length === 0) return null;
   return (
     <Section
@@ -108,6 +116,7 @@ function BreakdownList({ title, slices, totalCostCents }: BreakdownListProps) {
         {slices.map((slice) => {
           const share =
             totalCostCents > 0 ? slice.cost_cents / totalCostCents : 0;
+          const Icon = getIcon?.(slice);
           return (
             <Section
               key={slice.label}
@@ -120,10 +129,13 @@ function BreakdownList({ title, slices, totalCostCents }: BreakdownListProps) {
             >
               {/* items-baseline has no Section equivalent, kept as a raw div */}
               <div className="flex items-baseline justify-between gap-3">
-                <span className="min-w-0 truncate">
-                  <Text font="main-ui-body" color="text-05" nowrap>
-                    {slice.label}
-                  </Text>
+                <span className="flex min-w-0 items-center gap-1.5">
+                  {Icon && <Icon size={16} className="shrink-0" />}
+                  <span className="min-w-0 truncate">
+                    <Text font="main-ui-body" color="text-05" nowrap>
+                      {slice.label}
+                    </Text>
+                  </span>
                 </span>
                 <span className="shrink-0 tabular-nums">
                   <Text font="main-ui-body" color="text-05">
@@ -290,6 +302,7 @@ export default function UserUsageDetailModal({
               title="By model"
               slices={byModel}
               totalCostCents={totals.cost_cents}
+              getIcon={(slice) => getModelIcon("", slice.label)}
             />
             <BreakdownList
               title="By flow"
@@ -300,6 +313,7 @@ export default function UserUsageDetailModal({
               title="By provider"
               slices={byProvider}
               totalCostCents={totals.cost_cents}
+              getIcon={(slice) => getModelIcon(slice.label)}
             />
 
             {byModel.length === 0 && (

--- a/web/src/views/admin/PerUserUsagePanel.tsx
+++ b/web/src/views/admin/PerUserUsagePanel.tsx
@@ -4,7 +4,7 @@ import React, { useMemo, useState } from "react";
 import { Card, MessageCard, Text } from "@opal/components";
 import { SvgX } from "@opal/icons";
 import { PageLoader, Section } from "@opal/layouts";
-import type { DateRange } from "@/refresh-components/DateRangePicker";
+import type { DateRange } from "@/components/dateRangeSelectors/DateRangePicker";
 import { formatCalendarDay } from "@/lib/dateUtils";
 import { useUsageExport } from "@/lib/usage/userUsage";
 import { formatCost, formatTokens } from "@/lib/utils";
@@ -25,9 +25,7 @@ function SummaryMetric({
   detail: string;
 }) {
   return (
-    // basis + flex-1 rather than a fixed fraction: fractions plus the row gap
-    // overflow and wrap the last metric onto its own line.
-    <div className="flex min-w-0 flex-1 basis-40 flex-col gap-0.5 px-3 py-2 first:pl-0 last:pr-0">
+    <div className="flex min-w-0 flex-col gap-0.5 px-3 py-3 sm:px-4">
       <Text font="secondary-body" color="text-03">
         {label}
       </Text>
@@ -45,12 +43,10 @@ function SummaryMetric({
 
 interface PerUserUsagePanelProps {
   timeRange?: DateRange;
-  headerRight?: React.ReactNode;
 }
 
 export default function PerUserUsagePanel({
   timeRange,
-  headerRight,
 }: PerUserUsagePanelProps) {
   const { usage, isLoading, error } = useUsageExport(timeRange);
   const [selectedEmail, setSelectedEmail] = useState<string | null>(null);
@@ -89,25 +85,21 @@ export default function PerUserUsagePanel({
   );
 
   const header = (
-    // sm:flex-row / sm:items-center / sm:justify-between have no Section equivalent, kept as a raw div
-    <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-      <Section
-        flexDirection="column"
-        justifyContent="start"
-        alignItems="stretch"
-        gap={0.5}
-        width="full"
-        height="fit"
-      >
-        <Text font="heading-h3">Usage this period</Text>
-        <Text font="secondary-body" color="text-03">
-          {usage
-            ? `${formatDate(usage.start)} – ${formatDate(usage.end)} · Costs are calculated from recorded model usage.`
-            : "Per-user spend and token usage for the selected period."}
-        </Text>
-      </Section>
-      {headerRight}
-    </div>
+    <Section
+      flexDirection="column"
+      justifyContent="start"
+      alignItems="stretch"
+      gap={0.125}
+      width="full"
+      height="fit"
+    >
+      <Text font="heading-h3">Usage overview</Text>
+      <Text font="secondary-body" color="text-03">
+        {usage
+          ? `${formatDate(usage.start)} – ${formatDate(usage.end)} · Costs are calculated from recorded model usage.`
+          : "Per-user spend and token usage for the selected period."}
+      </Text>
+    </Section>
   );
 
   if (isLoading) {
@@ -116,7 +108,7 @@ export default function PerUserUsagePanel({
         flexDirection="column"
         justifyContent="start"
         alignItems="stretch"
-        gap={4}
+        gap={1}
         width="full"
         height="fit"
       >
@@ -131,7 +123,7 @@ export default function PerUserUsagePanel({
         flexDirection="column"
         justifyContent="start"
         alignItems="stretch"
-        gap={4}
+        gap={1}
         width="full"
         height="fit"
       >
@@ -150,50 +142,52 @@ export default function PerUserUsagePanel({
       flexDirection="column"
       justifyContent="start"
       alignItems="stretch"
-      gap={4}
+      gap={1}
       width="full"
       height="fit"
     >
       {header}
 
-      <Card border="solid" rounding="lg" padding={2}>
-        <Section
-          flexDirection="row"
-          justifyContent="start"
-          alignItems="start"
-          gap={0.5}
-          wrap
-          width="full"
-          height="fit"
-        >
-          <SummaryMetric
-            label="Workspace spend"
-            value={formatCost(totalCostCents)}
-            detail="Across all listed users"
-          />
-          <SummaryMetric
-            label="Total tokens"
-            value={formatTokens(totalTokens)}
-            detail="Input (including cache reads) and output"
-          />
-          <SummaryMetric
-            label="Active users"
-            value={activeUsers.toLocaleString()}
-            detail={`${users.length.toLocaleString()} users with records`}
-          />
-          <SummaryMetric
-            label="Top spender"
-            value={topSpender ? formatCost(topSpender.totals.cost_cents) : "—"}
-            detail={topSpender?.email ?? "No spend recorded"}
-          />
-        </Section>
+      <Card border="solid" rounding="lg" padding="fit">
+        <div className="grid grid-cols-2 lg:grid-cols-4">
+          <div className="border-b border-border-02 lg:border-b-0">
+            <SummaryMetric
+              label="Workspace spend"
+              value={formatCost(totalCostCents)}
+              detail="Across all listed users"
+            />
+          </div>
+          <div className="border-b border-l border-border-02 lg:border-b-0">
+            <SummaryMetric
+              label="Total tokens"
+              value={formatTokens(totalTokens)}
+              detail="Input (including cache reads) and output"
+            />
+          </div>
+          <div className="border-b border-border-02 lg:border-b-0 lg:border-l">
+            <SummaryMetric
+              label="Active users"
+              value={activeUsers.toLocaleString()}
+              detail={`${users.length.toLocaleString()} users with records`}
+            />
+          </div>
+          <div className="border-l border-border-02">
+            <SummaryMetric
+              label="Top spender"
+              value={
+                topSpender ? formatCost(topSpender.totals.cost_cents) : "—"
+              }
+              detail={topSpender?.email ?? "No spend recorded"}
+            />
+          </div>
+        </div>
       </Card>
 
       <Section
         flexDirection="column"
         justifyContent="start"
         alignItems="stretch"
-        gap={2}
+        gap={0.5}
         width="full"
         height="fit"
       >
@@ -201,18 +195,19 @@ export default function PerUserUsagePanel({
           flexDirection="column"
           justifyContent="start"
           alignItems="stretch"
-          gap={0.5}
+          gap={0.125}
           width="full"
           height="fit"
         >
-          <Text font="heading-h3">Spend by user</Text>
+          <Text font="heading-h3">Users</Text>
           <Text font="secondary-body" color="text-03">
-            Filter by model or flow, and click a user for their full breakdown.
+            Spend is sorted highest first. Filter the list, then select a user
+            for a complete breakdown.
           </Text>
         </Section>
 
         {users.length === 0 ? (
-          <Card border="solid" rounding="lg" padding={2}>
+          <Card border="solid" rounding="lg" padding="sm">
             <Text font="main-ui-body" color="text-03">
               No usage recorded for this period.
             </Text>

--- a/web/src/views/admin/PerUserUsagePanel.tsx
+++ b/web/src/views/admin/PerUserUsagePanel.tsx
@@ -4,7 +4,7 @@ import React, { useMemo, useState } from "react";
 import { Card, MessageCard, Text } from "@opal/components";
 import { SvgX } from "@opal/icons";
 import { PageLoader, Section } from "@opal/layouts";
-import type { DateRange } from "@/components/dateRangeSelectors/DateRangePicker";
+import type { DateRange } from "@/refresh-components/DateRangePicker";
 import { formatCalendarDay } from "@/lib/dateUtils";
 import { useUsageExport } from "@/lib/usage/userUsage";
 import { formatCost, formatTokens } from "@/lib/utils";
@@ -148,7 +148,7 @@ export default function PerUserUsagePanel({
     >
       {header}
 
-      <Card border="solid" rounding="lg" padding="fit">
+      <Card border="solid" rounding="lg" padding={0}>
         <div className="grid grid-cols-2 lg:grid-cols-4">
           <div className="border-b border-border-02 lg:border-b-0">
             <SummaryMetric
@@ -207,7 +207,7 @@ export default function PerUserUsagePanel({
         </Section>
 
         {users.length === 0 ? (
-          <Card border="solid" rounding="lg" padding="sm">
+          <Card border="solid" rounding="lg" padding={3}>
             <Text font="main-ui-body" color="text-03">
               No usage recorded for this period.
             </Text>


### PR DESCRIPTION
## Description

- Improve scanability of personal and per-user usage data.
- Keep the selected usage range separate from the active budget window.
- Show budget status, limit, and active dates with an additive API contract.

## How Has This Been Tested?

- User usage API unit tests
- SpendByUserTable and UsageSettings Jest tests
- Frontend lint and type check

<img width="1055" height="770" alt="Screenshot 2026-08-13 at 10 02 06" src="https://github.com/user-attachments/assets/6f227799-1191-484d-ba95-c4b1b012e9ee" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies personal usage and makes cost budgets predictable. Old behavior used trailing rolling cost windows with implicit resets; new behavior uses fixed UTC daily/weekly/monthly cycles and returns an explicit budget_reset_at. Rate-limit responses now use the same fixed cadence.

- Backend: restrict cost-budget periods to 24/168/720 hours; compute fixed window start/reset; include budget_reset_at in get_my_usage; when multiple limits apply, fetch cost buckets from the earliest applicable window start; cost overages report the calendar reset instead of an “earliest window” estimate.
- Frontend: keep the shared date range picker inline with the Usage title; aggregate usage by model for the selected range and show the top three with an expander; show remaining, a progress bar, “Resets on <date>”, and the budget limit (remove “per day/week” copy); admin usage moves the date picker to the page header and renames sections to “Usage overview” and “Users”; Spend by user adds a “Tokens” column and a live user count; user detail shows model and provider icons.

**Rollout**
- Required: set all cost budget periods to 1, 7, or 30 days; other values now fail validation.
- Backward compatible: if budget_reset_at is absent, the client hides the reset date.

<sup>Written for commit 46a1d37100d7001c82d86fd8cd29bb8f64cf980d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



