### PR TITLE
refactor(opal): move SidebarTab folded styling to CSS

### DIFF
--- a/web/lib/opal/src/components/buttons/sidebar-tab/README.md
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/README.md
@@ -7,7 +7,7 @@ A sidebar navigation tab built on `Interactive.Stateful` > `Interactive.Containe
 ## Architecture
 
 ```
-div.relative
+div.opal-sidebar-tab      <- folded styling hook (see styles.css)
   └─ Interactive.Stateful        <- variant (sidebar-heavy | sidebar-light), state, disabled
        └─ Interactive.Container  <- rounding, height, width
             ├─ Link?             (absolute overlay for client-side navigation)
@@ -18,7 +18,17 @@ div.relative
 - **`sidebar-heavy`** (default) — muted when unselected (text-03/text-02), bold when selected (text-04/text-03)
 - **`sidebar-light`** — uniformly muted across all states (text-02/text-02)
 - **Disabled** — both variants use text-02 foreground, transparent background, no hover/active states
-- **Navigation** uses an absolutely positioned `<Link>` overlay rather than `href` on the Interactive element, so `rightChildren` can sit above it with `pointer-events-auto`.
+- **Navigation** uses an absolutely positioned `<Link>` overlay rather than `href` on the Interactive element, so `rightChildren` can sit above it with `pointer-events-auto`. A string label is also set as the link's `aria-label`, so the tab keeps a name when the label is hidden.
+
+## Folded state
+
+A tab inside a sidebar needs no `folded` prop. `SidebarRoot` publishes its fold state as `data-folded` on `.opal-sidebar-root__inner`, and `styles.css` hides the label and `rightChildren` from there. Folding a sidebar therefore re-renders no tabs, and the label fades with the 200ms column width transition.
+
+The label stays in the DOM while folded. It is hidden with `visibility: hidden`, which keeps it out of the accessibility tree and out of the tab order, so a screen reader never announces it.
+
+Pass `folded` only to override the sidebar — outside a sidebar, in Storybook, or in a skeleton. It sets `data-folded` on the tab itself, which wins over the sidebar.
+
+The folded-name tooltip is the one part that stays in JS: CSS cannot arm a tooltip. It lives in a small wrapper that subscribes to the fold state on the tab's behalf, so a fold re-renders the wrapper and nothing below it.
 
 ## Props
 
@@ -29,7 +39,7 @@ div.relative
 | `icon` | `IconFunctionComponent` | — | Left icon |
 | `children` | `ReactNode` | — | Label text or custom content |
 | `disabled` | `boolean` | `false` | Disables the tab |
-| `folded` | `boolean` | `false` | Collapses label, shows tooltip on hover |
+| `folded` | `boolean` | sidebar state | Collapses label, shows tooltip on hover. Overrides the enclosing sidebar |
 | `nested` | `boolean` | `false` | Renders spacer instead of icon for indented items |
 | `href` | `string` | — | Client-side navigation URL |
 | `onClick` | `MouseEventHandler` | — | Click handler |

--- a/web/lib/opal/src/components/buttons/sidebar-tab/SidebarTab.test.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/SidebarTab.test.tsx
@@ -1,7 +1,10 @@
-// SidebarTab reads its fold state from the enclosing sidebar, not from the
-// app-wide sidebar state. SidebarTab is also used for page-level tab
-// navigation (e.g. the settings page), and those tabs must stay expanded when
-// the app sidebar folds.
+// SidebarTab collapses in CSS, not in React. `SidebarRoot` publishes its fold
+// state as `data-folded`, and the tab's stylesheet hides the label from there.
+// These tests assert that contract, because jsdom applies no stylesheet.
+//
+// SidebarTab is also used for page-level tab navigation (e.g. the settings
+// page). Those tabs have no sidebar above them and must stay expanded when the
+// app sidebar folds.
 import { render, screen } from "@tests/setup/test-utils";
 import { SidebarTab } from "@opal/components";
 import { SidebarLayouts, SidebarStateProvider } from "@opal/layouts";
@@ -24,14 +27,21 @@ function FoldedSidebar({ foldable }: { foldable?: boolean }) {
   );
 }
 
+/** The `data-folded` value that decides the tab's look, or null if unset. */
+function foldStateOf(label: string): string | null {
+  const tab = screen.getByText(label).closest(".opal-sidebar-tab");
+  expect(tab).not.toBeNull();
+  return tab!.closest("[data-folded]")?.getAttribute("data-folded") ?? null;
+}
+
 it("collapses the label inside a folded foldable sidebar", () => {
   render(<FoldedSidebar foldable />);
-  expect(screen.queryByText("Settings")).not.toBeInTheDocument();
+  expect(foldStateOf("Settings")).toBe("true");
 });
 
 it("keeps the label in a non-foldable sidebar, even when app state is folded", () => {
   render(<FoldedSidebar />);
-  expect(screen.getByText("Settings")).toBeInTheDocument();
+  expect(foldStateOf("Settings")).toBe("false");
 });
 
 it("keeps the label outside a sidebar, even when app state is folded", () => {
@@ -40,7 +50,7 @@ it("keeps the label outside a sidebar, even when app state is folded", () => {
       <SidebarTab href="/settings">Settings</SidebarTab>
     </SidebarStateProvider>
   );
-  expect(screen.getByText("Settings")).toBeInTheDocument();
+  expect(foldStateOf("Settings")).toBeNull();
 });
 
 it("still honors an explicit folded prop as an override", () => {
@@ -51,5 +61,12 @@ it("still honors an explicit folded prop as an override", () => {
       </SidebarTab>
     </SidebarStateProvider>
   );
-  expect(screen.queryByText("Settings")).not.toBeInTheDocument();
+  const tab = screen.getByText("Settings").closest(".opal-sidebar-tab");
+  expect(tab).toHaveAttribute("data-folded", "true");
+});
+
+it("names the tab for assistive technology in both states", () => {
+  render(<FoldedSidebar foldable />);
+  // The label is hidden by CSS while folded, so the name comes from the link.
+  expect(screen.getByLabelText("Settings")).toBeInTheDocument();
 });

--- a/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import "@opal/components/buttons/sidebar-tab/styles.css";
 import React from "react";
 import type { ButtonType, IconFunctionComponent, RichStr } from "@opal/types";
 import type { Route } from "next";
 import { Interactive, type InteractiveStatefulVariant } from "@opal/core";
 import { ContentAction } from "@opal/layouts";
 import { useSidebarFolded } from "@opal/layouts/sidebar/context";
-import { Text, Tooltip } from "@opal/components";
+import { Tooltip } from "@opal/components";
 import Link from "next/link";
 
 // ---------------------------------------------------------------------------
@@ -15,8 +16,12 @@ import Link from "next/link";
 
 interface SidebarTabProps {
   /**
-   * Collapses the label, showing only the icon. Defaults to the enclosing
-   * sidebar's fold state, so tabs inside a sidebar never need to pass this.
+   * Collapses the label, showing only the icon.
+   *
+   * Leave this unset inside a sidebar: the enclosing `SidebarRoot` publishes
+   * its fold state as a `data-folded` attribute, and CSS collapses the label.
+   * Set it only to override that — outside a sidebar, in Storybook, or in a
+   * skeleton.
    */
   folded?: boolean;
 
@@ -52,6 +57,50 @@ interface SidebarTabProps {
 }
 
 // ---------------------------------------------------------------------------
+// FoldedTooltip
+// ---------------------------------------------------------------------------
+
+interface FoldedTooltipProps {
+  /** Label to show while the tab is folded. */
+  label: string | RichStr;
+
+  /** Explicit fold state. Falls back to the enclosing sidebar's. */
+  folded?: boolean;
+
+  children: React.ReactElement;
+}
+
+/**
+ * Shows `label` on hover, but only while the tab is folded.
+ *
+ * This is the one part of the folded look that CSS cannot express, so it is
+ * split out: this component subscribes to the fold state, and the tab does
+ * not. On a fold toggle React re-renders this wrapper alone — `children` is
+ * the same element it received before, so the tab below it never re-renders.
+ *
+ * The tooltip stays mounted and is gated by `open` instead of being added and
+ * removed. Changing the tree shape on a fold would remount the tab and cut the
+ * label's fade short.
+ */
+function FoldedTooltip({ label, folded, children }: FoldedTooltipProps) {
+  const foldedFromSidebar = useSidebarFolded();
+  const [hovered, setHovered] = React.useState(false);
+
+  const effectiveFolded = folded ?? foldedFromSidebar;
+
+  return (
+    <Tooltip
+      tooltip={label}
+      side="right"
+      open={effectiveFolded && hovered}
+      onOpenChange={setHovered}
+    >
+      {children}
+    </Tooltip>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // SidebarTab
 // ---------------------------------------------------------------------------
 
@@ -61,9 +110,12 @@ interface SidebarTabProps {
  * Uses `sidebar-heavy` (default) or `sidebar-light` (via `variant`) variants
  * for color styling. Supports an overlay `Link` for client-side navigation,
  * `rightChildren` for inline actions, and folded mode with an auto-tooltip.
+ *
+ * The label and `rightChildren` always render. The folded state hides them in
+ * CSS — see `styles.css` — so folding a sidebar re-renders no tabs.
  */
 function SidebarTab({
-  folded: foldedProp,
+  folded,
   selected,
   variant = "sidebar-heavy",
   nested,
@@ -77,9 +129,6 @@ function SidebarTab({
   tooltip,
   children,
 }: SidebarTabProps) {
-  const foldedFromSidebar = useSidebarFolded();
-  const folded = foldedProp ?? foldedFromSidebar;
-
   const Icon =
     icon ??
     (nested
@@ -94,8 +143,16 @@ function SidebarTab({
     <div className="w-0 group-hover/SidebarTab:w-6" />
   );
 
+  // A folded tab hides its label, and neither the overlay Link nor the button
+  // holds text of its own, so name them explicitly. Without this a folded tab
+  // is an unnamed control.
+  const label = typeof children === "string" ? children : undefined;
+
   const content = (
-    <div className="relative">
+    <div
+      className="opal-sidebar-tab"
+      data-folded={folded === undefined ? undefined : String(folded)}
+    >
       <Interactive.Stateful
         variant={variant}
         state={selected ? "selected" : "empty"}
@@ -104,26 +161,33 @@ function SidebarTab({
         type="button"
         group="group/SidebarTab"
       >
-        <Interactive.Container rounding="sm" size="lg" width="full" type={type}>
+        <Interactive.Container
+          rounding="sm"
+          size="lg"
+          width="full"
+          type={type}
+          // Only when `type` makes this a real button — `aria-label` on a
+          // plain div names nothing.
+          aria-label={type ? label : undefined}
+        >
           {href && !disabled && (
             <Link
               href={href as Route}
               scroll={false}
               className="absolute z-99 inset-0 rounded-08"
               tabIndex={-1}
+              aria-label={label}
             />
           )}
 
-          {!folded && rightChildren && (
-            <div className="absolute z-100 right-1.5 top-0 bottom-0 flex flex-col justify-center items-center pointer-events-auto">
-              {rightChildren}
-            </div>
+          {rightChildren && (
+            <div className="opal-sidebar-tab__actions">{rightChildren}</div>
           )}
 
           {typeof children === "string" ? (
             <ContentAction
               icon={Icon ?? undefined}
-              title={folded ? "" : children}
+              title={children}
               sizePreset="main-ui"
               variant="body"
               color="interactive"
@@ -148,25 +212,22 @@ function SidebarTab({
     </div>
   );
 
-  if (typeof children !== "string") {
-    if (tooltip) {
-      return (
-        <Tooltip tooltip={tooltip} side="right">
-          {content}
-        </Tooltip>
-      );
-    }
-    return content;
-  }
-  const resolvedTooltip = tooltip ?? (folded ? children : undefined);
-  if (resolvedTooltip) {
+  if (tooltip) {
     return (
-      <Tooltip tooltip={resolvedTooltip} side="right">
+      <Tooltip tooltip={tooltip} side="right">
         {content}
       </Tooltip>
     );
   }
-  return content;
+
+  // Only a string label can stand in as its own tooltip.
+  if (label === undefined) return content;
+
+  return (
+    <FoldedTooltip label={label} folded={folded}>
+      {content}
+    </FoldedTooltip>
+  );
 }
 
 export { SidebarTab, type SidebarTabProps };

--- a/web/lib/opal/src/components/buttons/sidebar-tab/styles.css
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/styles.css
@@ -1,0 +1,66 @@
+@reference "#reference.css";
+
+/* ===========================================================================
+   SidebarTab
+
+   The folded look is CSS, not React state. `SidebarRoot` publishes its
+   effective fold state as `data-folded` on `.opal-sidebar-root__inner`, and
+   the rules below read it from any depth. Tabs therefore render once and stay
+   rendered while the sidebar folds, and the label fades in step with the
+   200ms column width transition instead of popping.
+
+   An explicit `folded` prop sets `data-folded` on the tab itself and wins over
+   the enclosing sidebar. Tabs outside a sidebar have no `data-folded`
+   ancestor, so they stay expanded.
+
+   This assumes sidebar roots are never nested in the DOM: a descendant
+   selector matches every `[data-folded="true"]` ancestor, not the nearest one.
+   `SidebarRoot` renders one column per sidebar, side by side, so the app never
+   builds that shape.
+   =========================================================================== */
+
+.opal-sidebar-tab {
+  @apply relative;
+
+  --sidebar-tab-label-opacity: 1;
+  --sidebar-tab-label-visibility: visible;
+  /* Applied to visibility, so it flips only after the label has faded out. */
+  --sidebar-tab-label-visibility-delay: 0s;
+  /* Clipped while folding, so the label never flashes an ellipsis as the
+     column narrows. */
+  --sidebar-tab-label-overflow: ellipsis;
+  --sidebar-tab-actions-display: flex;
+}
+
+.opal-sidebar-tab[data-folded="true"],
+:where(.opal-sidebar-root__inner[data-folded="true"])
+  .opal-sidebar-tab:not([data-folded="false"]) {
+  --sidebar-tab-label-opacity: 0;
+  --sidebar-tab-label-visibility: hidden;
+  --sidebar-tab-label-visibility-delay: 200ms;
+  --sidebar-tab-label-overflow: clip;
+  --sidebar-tab-actions-display: none;
+}
+
+/* The label is `ContentSm`'s title node — the one child of the content row
+   that is not the icon container.
+
+   `visibility` (not `opacity` alone) keeps the folded label out of the
+   accessibility tree and out of the tab order, so a screen reader never
+   announces a label the sidebar is hiding. */
+.opal-sidebar-tab .opal-content-sm > :not(.opal-content-sm-icon-container) {
+  opacity: var(--sidebar-tab-label-opacity);
+  visibility: var(--sidebar-tab-label-visibility);
+  text-overflow: var(--sidebar-tab-label-overflow);
+  transition:
+    opacity 200ms ease-in-out,
+    visibility 0s linear var(--sidebar-tab-label-visibility-delay);
+}
+
+/* `rightChildren` — absolutely positioned above the `Link` overlay. Hidden
+   outright when folded: there is no room for them beside the icon. */
+.opal-sidebar-tab__actions {
+  @apply absolute z-100 right-1.5 top-0 bottom-0 flex-col justify-center items-center pointer-events-auto;
+
+  display: var(--sidebar-tab-actions-display);
+}

--- a/web/lib/opal/src/layouts/sidebar/components.tsx
+++ b/web/lib/opal/src/layouts/sidebar/components.tsx
@@ -63,9 +63,17 @@ function SidebarRoot({ foldable = false, children }: SidebarRootProps) {
   // a sidebar (and inside a non-foldable one) never collapse.
   const effectiveFolded = (isMobile || isSmallScreen || foldable) && folded;
 
+  // The same value in two forms: context for the parts that need JS (the
+  // folded-only tooltip), and `data-folded` for the parts CSS can do on its
+  // own. The attribute lets descendants restyle without re-rendering.
   const inner = (
     <SidebarFoldedContext.Provider value={effectiveFolded}>
-      <div className="opal-sidebar-root__inner">{children}</div>
+      <div
+        className="opal-sidebar-root__inner"
+        data-folded={String(effectiveFolded)}
+      >
+        {children}
+      </div>
     </SidebarFoldedContext.Provider>
   );
 
@@ -247,7 +255,6 @@ interface SidebarBodyProps {
 }
 
 function SidebarBody({ scrollKey, children }: SidebarBodyProps) {
-  const { folded } = useSidebarState();
   const scrollRef = useRef<HTMLDivElement>(null);
   const pathname = usePathname();
 
@@ -283,9 +290,10 @@ function SidebarBody({ scrollKey, children }: SidebarBodyProps) {
       containerClassName="opal-sidebar-body"
       className="opal-sidebar-body__scroll"
     >
-      <div className="opal-sidebar-body__content" data-folded={String(folded)}>
-        {children}
-      </div>
+      {/* Hidden while folded — see styles.css. The fold state comes from the
+          `data-folded` attribute on the root, so folding re-renders nothing
+          here. */}
+      <div className="opal-sidebar-body__content">{children}</div>
       <div className="opal-sidebar-body__spacer" />
     </ShadowDiv>
   );

--- a/web/lib/opal/src/layouts/sidebar/styles.css
+++ b/web/lib/opal/src/layouts/sidebar/styles.css
@@ -154,7 +154,7 @@
 .opal-sidebar-body__content {
   @apply flex-1 flex flex-col px-2 gap-2;
 }
-.opal-sidebar-body__content[data-folded="true"] {
+.opal-sidebar-root__inner[data-folded="true"] .opal-sidebar-body__content {
   @apply hidden;
 }
 


### PR DESCRIPTION
Follow-up to #13920.

## Problem

`SidebarTab` read the fold state from context, so folding a sidebar re-rendered every tab in it.

## Change

`SidebarRoot` now publishes its effective fold state in two forms: context, for the parts that need JS, and `data-folded` on `.opal-sidebar-root__inner`, for the parts CSS can do on its own. A new `sidebar-tab/styles.css` reads the attribute from any depth and flips custom properties that drive the label and the actions row. Tabs render once and stay rendered while the sidebar folds. `SidebarBody` drops its own fold subscription for the same reason.

The folded-only hover tooltip is the one part CSS cannot express. It moves into a small `FoldedTooltip` wrapper that subscribes to the fold state alone. On a toggle React re-renders that wrapper only — its child is the same element it received before, so the tab below never re-renders. The tooltip is gated by `open` rather than mounted and unmounted, so the tree shape stays stable and the label's fade is not cut short.

## Accessibility

The PR flagged a trade here. It is avoided, not documented.

The folded label uses `visibility: hidden`, not `opacity: 0` alone. That keeps it out of the accessibility tree **and** out of the tab order, so a screen reader never announces a label the sidebar is hiding. `visibility` transitions as a step function with a 200ms delay, so it flips only after the fade completes.

This also closes a gap that predates the change: with the label hidden, neither the overlay `Link` nor the button container held any text, so a folded tab was an unnamed control. Both now take `aria-label` from the string label. The container gets it only when `type` makes it a real button — `aria-label` on a plain `div` names nothing.

## Assumption

The CSS assumes sidebar roots are never nested in the DOM: a descendant selector matches every `[data-folded="true"]` ancestor, not the nearest one. `SidebarRoot` renders one column per sidebar, side by side, so the app never builds that shape. This is stated in the stylesheet.

## Out of scope

`AppSidebar`'s `folded`-driven icon swap, its two `variant={folded ? ...}` props, and the `{folded && ...}` header re-hosting stay in JS. They change element types, not styles.

## Testing

- `bun run jest lib/opal/src/components/buttons/sidebar-tab src/sections/sidebar` — 9/9 pass. jsdom applies no stylesheets, so the tests assert the `data-folded` contract plus the accessible name.
- `pre-commit run --files <touched>` — oxfmt, oxlint, TypeScript all pass.
- Manual, in the browser: the folded desktop rail is icon-only at 52px with labels hidden; the folded a11y tree shows only named controls and no hidden label text; the tooltip fires when folded and not when expanded; settings-page tabs stay expanded while the app sidebar folds (the regression case from #13920); the admin non-foldable sidebar reads `data-folded="false"`; the mobile overlay hides labels when closed; the chat-row hover menu still works through the new actions class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves `SidebarTab` folded styling from React to CSS to avoid re-renders on fold. Previously each tab subscribed to fold state and re-rendered; now `SidebarRoot` sets `data-folded` and CSS hides the label/actions, so folding is smoother and tabs stay mounted.

- `SidebarRoot` now exposes fold state via context and `data-folded` on `.opal-sidebar-root__inner`; new `sidebar-tab/styles.css` reads it to fade the label and hide `rightChildren`. `SidebarBody` reads fold state via the root attribute and drops its own subscription.
- Folded-only hover tooltip moves to a small `FoldedTooltip` wrapper that subscribes to fold state; the tab content does not re-render on fold. The tooltip stays mounted and toggles via `open`.
- Accessibility: the folded label uses `visibility: hidden` (with a delay) to stay out of the a11y tree and tab order; the overlay `Link` and button container receive `aria-label` from a string label so folded tabs keep a name.
- Assumption: sidebar roots are not nested; the CSS reads `[data-folded="true"]` from any ancestor.

**Migration**
- Do not pass `folded` to `SidebarTab` inside a sidebar; pass it only to override outside a sidebar or in Storybook.
- If a tab label is not a string and you want a folded tooltip, pass `tooltip`. No other changes required.

<sup>Written for commit 66af8bcfb56b7b62559ceb677ec1ccc02b07ee0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

