### PR TITLE
fix(ods): skip pre-push hooks on tag pushes

### DIFF
--- a/tools/ods/cmd/cherry-pick.go
+++ b/tools/ods/cmd/cherry-pick.go
@@ -461,7 +461,7 @@ func cherryPickToRelease(commitSHAs, commitMessages []string, branchSuffix, vers
 	if noVerify {
 		pushArgs = []string{"push", "--no-verify", "-u", "origin", hotfixBranch}
 	}
-	if err := git.RunCommandVerboseOnError(pushArgs...); err != nil {
+	if err := pushWithHookHint(noVerify, func() error { return git.RunCommandVerboseOnError(pushArgs...) }); err != nil {
 		return "", fmt.Errorf("failed to push hotfix branch: %w", err)
 	}
 

--- a/tools/ods/cmd/deploy_edge.go
+++ b/tools/ods/cmd/deploy_edge.go
@@ -28,6 +28,7 @@ type DeployEdgeOptions struct {
 	DryRun         bool
 	Yes            bool
 	NoWaitDeploy   bool
+	Verify         bool
 }
 
 // NewDeployEdgeCommand creates the `ods deploy edge` command.
@@ -68,6 +69,7 @@ Example usage:
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Perform local operations only; skip pushing the tag and dispatching workflows")
 	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip the confirmation prompt")
 	cmd.Flags().BoolVar(&opts.NoWaitDeploy, "no-wait-deploy", false, "Do not wait for the deploy workflow to finish after dispatching it")
+	cmd.Flags().BoolVar(&opts.Verify, "verify", false, "Run pre-push hooks when pushing the tag; they are skipped by default")
 
 	return cmd
 }
@@ -119,7 +121,7 @@ func deployEdge(opts *DeployEdgeOptions) {
 	}
 
 	log.Infof("Force-pushing tag '%s' to origin...", edgeTagName)
-	if err := git.RunCommand("push", "-f", "origin", edgeTagName); err != nil {
+	if err := git.PushTag(edgeTagName, true, opts.Verify); err != nil {
 		log.Fatalf("Failed to push edge tag: %v", err)
 	}
 

--- a/tools/ods/cmd/push_hint.go
+++ b/tools/ods/cmd/push_hint.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
+)
+
+// pushWithHookHint runs a branch push. If the hooks are enabled and the push is
+// slow, it tells the user about --no-verify.
+func pushWithHookHint(noVerify bool, push func() error) error {
+	if noVerify {
+		return push()
+	}
+	hint := "Push is slow because the pre-push hooks are running. Re-run with --no-verify to skip them."
+	return git.HintAfter(git.PushHookHintDelay, hint, push)
+}

--- a/tools/ods/cmd/release_opal.go
+++ b/tools/ods/cmd/release_opal.go
@@ -24,6 +24,7 @@ type ReleaseOpalOptions struct {
 	Version string
 	DryRun  bool
 	Yes     bool
+	Verify  bool
 }
 
 // NewReleaseOpalCommand creates the `ods release opal` command.
@@ -58,6 +59,7 @@ Example usage:
 	cmd.Flags().StringVar(&opts.Version, "version", "", "Exact version to release (X.Y.Z, no leading v); overrides --bump")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Compute the version but don't tag or push")
 	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip the confirmation prompt")
+	cmd.Flags().BoolVar(&opts.Verify, "verify", false, "Run pre-push hooks when pushing the tag; they are skipped by default")
 
 	return cmd
 }
@@ -114,7 +116,7 @@ func releaseOpal(opts *ReleaseOpalOptions) {
 	if err := git.RunCommand("tag", tag); err != nil {
 		log.Fatalf("Failed to create tag %s: %v", tag, err)
 	}
-	if err := git.RunCommand("push", "origin", tag); err != nil {
+	if err := git.PushTag(tag, false, opts.Verify); err != nil {
 		// Roll back the local tag so the command stays retryable after a failed push.
 		if delErr := git.RunCommand("tag", "-d", tag); delErr != nil {
 			log.Warnf("Also failed to delete local tag %s; remove it before retrying: %v", tag, delErr)

--- a/tools/ods/cmd/run-ci.go
+++ b/tools/ods/cmd/run-ci.go
@@ -206,7 +206,7 @@ func runCI(cmd *cobra.Command, args []string, opts *RunCIOptions) {
 		pushArgs = append(pushArgs, "--no-verify")
 	}
 	pushArgs = append(pushArgs, "--quiet", "-f", "-u", "origin", ciBranch)
-	if err := git.RunCommand(pushArgs...); err != nil {
+	if err := pushWithHookHint(opts.NoVerify, func() error { return git.RunCommand(pushArgs...) }); err != nil {
 		// Switch back to original branch before exiting
 		if switchErr := git.RunCommand("switch", "--quiet", originalBranch); switchErr != nil {
 			log.Warnf("Failed to switch back to original branch: %v", switchErr)

--- a/tools/ods/internal/git/git.go
+++ b/tools/ods/internal/git/git.go
@@ -64,6 +64,21 @@ func RunCommandVerboseOnError(args ...string) error {
 	return nil
 }
 
+// PushTag pushes a tag to origin, optionally with --force. Pre-push hooks are
+// skipped unless verify is true: a tag points at a commit that already passed
+// CI, and the hooks run over the whole delta since the previous tag, which is
+// slow and unrelated to the push.
+func PushTag(tag string, force, verify bool) error {
+	args := []string{"push"}
+	if !verify {
+		args = append(args, "--no-verify")
+	}
+	if force {
+		args = append(args, "-f")
+	}
+	return RunCommand(append(args, "origin", tag)...)
+}
+
 // GetCommitMessage gets the first line of a commit message
 func GetCommitMessage(commitSHA string) (string, error) {
 	cmd := exec.Command("git", "log", "-1", "--format=%s", commitSHA)

--- a/tools/ods/internal/git/git.go
+++ b/tools/ods/internal/git/git.go
@@ -9,9 +9,22 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
+
+// PushHookHintDelay is how long a push with hooks enabled runs before HintAfter
+// tells the user how to skip them.
+const PushHookHintDelay = 10 * time.Second
+
+// HintAfter runs fn and logs hint if fn is still running after delay. Use it to
+// point at a faster flag when pre-push hooks make a command slow.
+func HintAfter(delay time.Duration, hint string, fn func() error) error {
+	timer := time.AfterFunc(delay, func() { log.Warn(hint) })
+	defer timer.Stop()
+	return fn()
+}
 
 // CheckGitHubCLI checks if the GitHub CLI is installed and exits with a helpful message if not
 func CheckGitHubCLI() {
@@ -76,7 +89,12 @@ func PushTag(tag string, force, verify bool) error {
 	if force {
 		args = append(args, "-f")
 	}
-	return RunCommand(append(args, "origin", tag)...)
+	args = append(args, "origin", tag)
+	if !verify {
+		return RunCommand(args...)
+	}
+	hint := "Push is slow because --verify runs the pre-push hooks over every commit since the previous tag. Re-run without --verify to skip them."
+	return HintAfter(PushHookHintDelay, hint, func() error { return RunCommand(args...) })
 }
 
 // GetCommitMessage gets the first line of a commit message


### PR DESCRIPTION
## Problem

`ods deploy edge` force-pushes the `edge` tag. The pre-push hooks then run over the whole delta between the previous and the new `edge` tag, which takes a long time. The same applies to the `opal/vX.Y.Z` tag push in `ods release opal`.

The verification adds no value here: a tag points at a commit on `main` that already passed CI, and the delta the hooks inspect is unrelated to the push itself.

## Change

- Add `git.PushTag(tag, force, verify)`. It passes `--no-verify` unless `verify` is true.
- `ods deploy edge` and `ods release opal` use it, so tag pushes skip the hooks by default.
- Both commands get a `--verify` flag to run the hooks again.

Branch pushes are unchanged. `ods run-ci` and `ods cherry-pick` push real code, and their hooks check the delta that the push actually contains, so they keep the existing opt-in `--no-verify`.

This supersedes #12491, which used an opt-in flag instead of a default.

## Test

`go build ./...`, `go vet ./...`, and `go test ./cmd/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip Git pre-push hooks on tag pushes and add a slow-push hint. Tag pushes for `ods deploy edge` and `ods release opal` now default to `--no-verify`, speeding up releases; when hooks are enabled and a push runs >10s, we log how to skip them.

- Add `git.PushTag(tag, force, verify)`; uses `--no-verify` by default. When `verify` is true and the push runs long, it hints to drop `--verify`.
- `ods deploy edge`: force-pushes `edge` via `git.PushTag(..., true, opts.Verify)`; adds `--verify` to run hooks.
- `ods release opal`: pushes `opal/vX.Y.Z` via `git.PushTag(..., false, opts.Verify)`; adds `--verify` to run hooks.
- `ods run-ci` and `ods cherry-pick`: keep existing verification behavior; when hooks are enabled and a push runs >10s, print a `--no-verify` hint.
- Required action if you depend on hooks for tag pushes: run with `--verify`.

<sup>Written for commit e5364e3532c4f5ccf3a159db317240529d7b363a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

