### PR TITLE
fix(web): keep co-located tests out of the Docker build context

### DIFF
--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -2,6 +2,12 @@ node_modules
 .next
 /tests/
 
+# Co-located unit tests. They import helpers from /tests/, which is excluded above,
+# so keeping them would break the `next build` type check inside the image.
+# Pre-commit still type checks them through tsconfig.types.json.
+src/**/*.test.ts
+src/**/*.test.tsx
+
 # Local build artifacts — opal/shared rebuild these via `prepare` on `bun install`.
 # Excluding them keeps a stale local dist out of hand-built images (CI clones clean,
 # so a stale dist only exists when building the image from a dirty working tree).


### PR DESCRIPTION
## Problem

The production web image fails to build during the `next build` type check ([failed run](https://github.com/onyx-dot-app/onyx/actions/runs/31587331463/job/94084527539)):

```
src/app/admin/billing/page.test.tsx(10,41): error TS2307: Cannot find module '@tests/setup/test-utils' or its corresponding type declarations.
... 40 more
Failed to type check.
```

## Cause

`web/.dockerignore` excludes `/tests/`, but 113 unit tests live co-located under `src/` and are copied into the image by `COPY . .`. Those tests import `@tests/setup/test-utils`, which is not in the build context. `tsconfig.json` includes `**/*.ts` and `**/*.tsx`, so the build type checks them and every import fails. The `TS7006` implicit-any errors come from the same unresolved imports.

The Next.js 16 upgrade surfaced this. The mismatch between the build context and the tsconfig include was already there.

## Fix

Exclude `src/**/*.test.ts(x)` from the build context too. Test files do not belong in a production image.

Coverage is not lost: the `typescript-check` pre-commit hook runs `bun run types:check`, which uses `tsconfig.types.json` and includes both `src/**/*` and `tests/**/*`.

## Testing

No Docker daemon in the devcontainer, so no real image build.

- Ran `tsc --noEmit` with a temporary tsconfig that replicates the image file set (no `tests/`, no `src/**/*.test.*`) and compared it to the unmodified baseline: the same errors in both, zero new errors. The baseline errors are a local artifact — `lib/opal/dist` is not built in this checkout, and CI builds it through the `prepare` script of `bun install`.
- Confirmed that no other file in the remaining build context imports `@tests/`. Only `jest.config.js`, `tsconfig.json`, and `tsconfig.types.json` refer to it, all as path mappings, which do not cause errors when unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `next build` type-check failures by excluding co-located test files from the `web` Docker build context. Previously `src/**/*.test.ts(x)` were copied while `/tests/` (their helpers) was excluded, triggering TS2307; now we ignore those test files so the image type-checks only app code, with tests still type-checked via `tsconfig.types.json` pre-commit.

- Adds `src/**/*.test.ts` and `src/**/*.test.tsx` to `web/.dockerignore`.
- No runtime change or migration. Avoid importing `@tests/*` from non-test code.

<sup>Written for commit e94a92887c0ac3df07fd8121d9df9a07c54fe230. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

