### PR TITLE
feat(craft): Sheets/Slides for Drive, and Gmail draft creation on cloud

### DIFF
--- a/backend/alembic/versions/3350a25df58e_add_sheets_and_slides_hosts_to_google_.py
+++ b/backend/alembic/versions/3350a25df58e_add_sheets_and_slides_hosts_to_google_.py
@@ -1,9 +1,7 @@
 """add sheets and slides hosts to google drive external apps
 
-Existing ``google_drive`` external-app rows carry the upstream URL patterns
-snapshotted at creation, so the Sheets and Slides hosts added to
-``onyx/external_apps/providers/google_drive.py`` must be appended to rows that
-predate them. New rows get the full list from the provider descriptor.
+``upstream_url_patterns`` is snapshotted onto app rows at creation, so rows
+that predate the Sheets/Slides hosts need them appended.
 
 Revision ID: 3350a25df58e
 Revises: c7f1a9d4e206

--- a/backend/alembic/versions/3350a25df58e_add_sheets_and_slides_hosts_to_google_.py
+++ b/backend/alembic/versions/3350a25df58e_add_sheets_and_slides_hosts_to_google_.py
@@ -1,0 +1,57 @@
+"""add sheets and slides hosts to google drive external apps
+
+Existing ``google_drive`` external-app rows carry the upstream URL patterns
+snapshotted at creation, so the Sheets and Slides hosts added to
+``onyx/external_apps/providers/google_drive.py`` must be appended to rows that
+predate them. New rows get the full list from the provider descriptor.
+
+Revision ID: 3350a25df58e
+Revises: c7f1a9d4e206
+Create Date: 2026-08-12 16:13:59.650319
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "3350a25df58e"
+down_revision = "c7f1a9d4e206"
+branch_labels = None
+depends_on = None
+
+_APP_TYPE = "GOOGLE_DRIVE"
+_NEW_PATTERNS = [
+    "https://sheets\\.googleapis\\.com/.*",
+    "https://slides\\.googleapis\\.com/.*",
+]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    # The column is varchar[]; CAST keeps array_append/array_remove typed.
+    for pattern in _NEW_PATTERNS:
+        bind.execute(
+            sa.text(
+                "UPDATE external_app "
+                "SET upstream_url_patterns = array_append("
+                "    upstream_url_patterns, CAST(:pattern AS varchar)) "
+                "WHERE app_type = :app_type "
+                "AND NOT (:pattern = ANY(upstream_url_patterns))"
+            ),
+            {"pattern": pattern, "app_type": _APP_TYPE},
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    for pattern in _NEW_PATTERNS:
+        bind.execute(
+            sa.text(
+                "UPDATE external_app "
+                "SET upstream_url_patterns = array_remove("
+                "    upstream_url_patterns, CAST(:pattern AS varchar)) "
+                "WHERE app_type = :app_type"
+            ),
+            {"pattern": pattern, "app_type": _APP_TYPE},
+        )

--- a/backend/alembic/versions/3350a25df58e_add_sheets_and_slides_hosts_to_google_.py
+++ b/backend/alembic/versions/3350a25df58e_add_sheets_and_slides_hosts_to_google_.py
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "3350a25df58e"
-down_revision = "c7f1a9d4e206"
+down_revision = "17135ac06582"
 branch_labels = None
 depends_on = None
 

--- a/backend/onyx/external_apps/providers/gmail.py
+++ b/backend/onyx/external_apps/providers/gmail.py
@@ -135,11 +135,11 @@ _ENDPOINTS: list[EndpointSpec] = [
         id=GmailAction.DRAFTS_CREATE,
         normalised_name="Create a draft",
         # Drafts aren't sent, so creating one is a safe place for the agent to
-        # prepare an email for the user to review and send from Gmail.
+        # prepare an email for the user to review and send from Gmail. Covered
+        # on cloud by the granular `gmail.drafts.create` scope.
         description="Save a new draft email (not sent).",
         matches=(RestRoute(method="POST", path=_DRAFTS),),
         default_policy=EndpointPolicy.ALWAYS,
-        requires_self_hosted_scope=True,
     ),
     EndpointSpec(
         id=GmailAction.DRAFTS_UPDATE,
@@ -170,9 +170,16 @@ _ENDPOINTS: list[EndpointSpec] = [
 # full draft lifecycle — but not permanent message delete, which keeps the
 # integration safer by default.
 _SELF_HOSTED_SCOPE = "https://www.googleapis.com/auth/gmail.modify"
-# Every Gmail scope that can read mail or touch drafts is restricted, so on
-# cloud the app is send-only.
-_CLOUD_SCOPE = "https://www.googleapis.com/auth/gmail.send"
+# Every classic Gmail scope that can read mail or touch drafts is restricted,
+# so on cloud the app is send-only plus draft creation via the granular
+# `gmail.drafts.create` scope. That scope is live in Google's OAuth scope
+# registry (the authorize endpoint accepts it; the Cloud Console scope picker
+# lists it) but not yet in the public scope docs or the Gmail discovery
+# document, which lag the granular-consent rollout.
+_CLOUD_SCOPE = (
+    "https://www.googleapis.com/auth/gmail.send "
+    "https://www.googleapis.com/auth/gmail.drafts.create"
+)
 
 
 class GmailProvider(GoogleOAuthProvider, OnyxManagedExtApp):

--- a/backend/onyx/external_apps/providers/gmail.py
+++ b/backend/onyx/external_apps/providers/gmail.py
@@ -135,8 +135,7 @@ _ENDPOINTS: list[EndpointSpec] = [
         id=GmailAction.DRAFTS_CREATE,
         normalised_name="Create a draft",
         # Drafts aren't sent, so creating one is a safe place for the agent to
-        # prepare an email for the user to review and send from Gmail. Covered
-        # on cloud by the granular `gmail.drafts.create` scope.
+        # prepare an email for the user to review and send from Gmail.
         description="Save a new draft email (not sent).",
         matches=(RestRoute(method="POST", path=_DRAFTS),),
         default_policy=EndpointPolicy.ALWAYS,
@@ -170,12 +169,9 @@ _ENDPOINTS: list[EndpointSpec] = [
 # full draft lifecycle — but not permanent message delete, which keeps the
 # integration safer by default.
 _SELF_HOSTED_SCOPE = "https://www.googleapis.com/auth/gmail.modify"
-# Every classic Gmail scope that can read mail or touch drafts is restricted,
-# so on cloud the app is send-only plus draft creation via the granular
-# `gmail.drafts.create` scope. That scope is live in Google's OAuth scope
-# registry (the authorize endpoint accepts it; the Cloud Console scope picker
-# lists it) but not yet in the public scope docs or the Gmail discovery
-# document, which lag the granular-consent rollout.
+# Every classic Gmail scope that can read mail or touch drafts is restricted.
+# The granular `gmail.drafts.create` scope is not, so cloud is send plus draft
+# creation. That scope is live in Google's OAuth registry; public docs lag.
 _CLOUD_SCOPE = (
     "https://www.googleapis.com/auth/gmail.send "
     "https://www.googleapis.com/auth/gmail.drafts.create"

--- a/backend/onyx/external_apps/providers/google_drive.py
+++ b/backend/onyx/external_apps/providers/google_drive.py
@@ -16,7 +16,8 @@ from shared_configs.configs import MULTI_TENANT
 # Google Drive API v3. Reads (GET) live under `/drive/v3/...`; content uploads
 # use the separate `/upload/drive/v3/...` host path, so both prefixes appear in
 # the upstream patterns and the catalog. The Google Docs, Sheets, and Slides
-# APIs live on their own hosts, all authorized by the same `auth/drive` scope.
+# APIs live on their own hosts, covered by the single `auth/drive` scope
+# self-hosted and by per-API sensitive scopes on cloud (see `_CLOUD_SCOPE`).
 # Reads default to ALWAYS; every mutation defaults to ASK so the egress
 # approval gate prompts the user before it runs.
 class GoogleDriveAction(ExternalAppAction):

--- a/backend/onyx/external_apps/providers/google_drive.py
+++ b/backend/onyx/external_apps/providers/google_drive.py
@@ -15,10 +15,12 @@ from shared_configs.configs import MULTI_TENANT
 
 # Google Drive API v3. Reads (GET) live under `/drive/v3/...`; content uploads
 # use the separate `/upload/drive/v3/...` host path, so both prefixes appear in
-# the upstream patterns and the catalog. The Google Docs API is a separate host
-# (`docs.googleapis.com/v1/documents/...`) authorized by the same `auth/drive`
-# scope. Reads default to ALWAYS; every mutation defaults to ASK so the egress
-# approval gate prompts the user before it runs.
+# the upstream patterns and the catalog. The Google Docs, Sheets, and Slides
+# APIs are separate hosts (`docs.googleapis.com/v1/documents/...`,
+# `sheets.googleapis.com/v4/spreadsheets/...`,
+# `slides.googleapis.com/v1/presentations/...`) all authorized by the same
+# `auth/drive` scope. Reads default to ALWAYS; every mutation defaults to ASK
+# so the egress approval gate prompts the user before it runs.
 class GoogleDriveAction(ExternalAppAction):
     """Strongly-typed catalog ids for the Google Drive provider."""
 
@@ -31,6 +33,12 @@ class GoogleDriveAction(ExternalAppAction):
     DOCS_READ = "gdrive.docs.read"
     DOCS_CREATE = "gdrive.docs.create"
     DOCS_UPDATE = "gdrive.docs.update"
+    SHEETS_READ = "gdrive.sheets.read"
+    SHEETS_CREATE = "gdrive.sheets.create"
+    SHEETS_UPDATE = "gdrive.sheets.update"
+    SLIDES_READ = "gdrive.slides.read"
+    SLIDES_CREATE = "gdrive.slides.create"
+    SLIDES_UPDATE = "gdrive.slides.update"
 
 
 _FILES = "/drive/v3/files"
@@ -39,6 +47,14 @@ _UPLOAD_FILES = "/upload/drive/v3/files"
 _UPLOAD_ITEM = f"{_UPLOAD_FILES}/{{fileId}}"
 _DOCS = "/v1/documents"
 _DOC_ITEM = f"{_DOCS}/{{documentId}}"
+# Google's `:verb` suffixes (`ID:batchUpdate`, `RANGE:append`) share the path
+# segment with the resource id, so a `{name}` placeholder in the last position
+# matches both the plain id and its verb forms.
+_SHEETS = "/v4/spreadsheets"
+_SHEET_ITEM = f"{_SHEETS}/{{spreadsheetId}}"
+_SHEET_VALUES = f"{_SHEET_ITEM}/values/{{range}}"
+_SLIDES = "/v1/presentations"
+_SLIDE_ITEM = f"{_SLIDES}/{{presentationId}}"
 _ENDPOINTS: list[EndpointSpec] = [
     EndpointSpec(
         id=GoogleDriveAction.FILES_READ,
@@ -124,18 +140,83 @@ _ENDPOINTS: list[EndpointSpec] = [
         description="Apply edits to a Google Doc's contents via the Docs API.",
         matches=(RestRoute(method="POST", path=_DOC_ITEM),),
     ),
+    EndpointSpec(
+        id=GoogleDriveAction.SHEETS_READ,
+        normalised_name="Read a spreadsheet",
+        description=(
+            "Read a Google Sheet's structure and cell values via the Sheets API."
+        ),
+        matches=(
+            RestRoute(method="GET", path=_SHEET_ITEM),
+            RestRoute(method="GET", path=_SHEET_VALUES),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=GoogleDriveAction.SHEETS_CREATE,
+        normalised_name="Create a spreadsheet",
+        description="Create a new Google Sheet via the Sheets API.",
+        matches=(RestRoute(method="POST", path=_SHEETS),),
+    ),
+    EndpointSpec(
+        id=GoogleDriveAction.SHEETS_UPDATE,
+        normalised_name="Edit a spreadsheet",
+        description=(
+            "Write, append, or clear cell values and apply structural edits "
+            "to a Google Sheet via the Sheets API."
+        ),
+        matches=(
+            # `{spreadsheetId}` also matches `ID:batchUpdate`.
+            RestRoute(method="POST", path=_SHEET_ITEM),
+            RestRoute(method="PUT", path=_SHEET_VALUES),
+            # `{range}` also matches `RANGE:append` / `RANGE:clear`.
+            RestRoute(method="POST", path=_SHEET_VALUES),
+        ),
+    ),
+    EndpointSpec(
+        id=GoogleDriveAction.SLIDES_READ,
+        normalised_name="Read a presentation",
+        description=(
+            "Read a Google Slides presentation's structure and text via the Slides API."
+        ),
+        matches=(
+            RestRoute(method="GET", path=_SLIDE_ITEM),
+            RestRoute(method="GET", path=f"{_SLIDE_ITEM}/pages/{{pageObjectId}}"),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=GoogleDriveAction.SLIDES_CREATE,
+        normalised_name="Create a presentation",
+        description="Create a new Google Slides presentation via the Slides API.",
+        matches=(RestRoute(method="POST", path=_SLIDES),),
+    ),
+    EndpointSpec(
+        id=GoogleDriveAction.SLIDES_UPDATE,
+        normalised_name="Edit a presentation",
+        description=(
+            "Apply edits (add slides, insert or replace text, restyle) to a "
+            "Google Slides presentation via the Slides API."
+        ),
+        # `{presentationId}` also matches `ID:batchUpdate`.
+        matches=(RestRoute(method="POST", path=_SLIDE_ITEM),),
+    ),
 ]
 
 
 # Full drive scope: read, search, create, edit, and delete any of the user's
-# files. Mutations are gated by per-action ASK approval.
+# files. It also authorizes the Docs, Sheets, and Slides APIs. Mutations are
+# gated by per-action ASK approval.
 _SELF_HOSTED_SCOPE = "https://www.googleapis.com/auth/drive"
 # Every Drive-wide scope is restricted, so cloud pairs per-file access (files
-# Onyx created or the user opened with it) with the Docs API, which reaches any
-# Google Doc by id.
+# Onyx created or the user opened with it) with the Docs, Sheets, and Slides
+# APIs, whose sensitive (not restricted) scopes each reach any file of their
+# type by id.
 _CLOUD_SCOPE = (
     "https://www.googleapis.com/auth/drive.file "
-    "https://www.googleapis.com/auth/documents"
+    "https://www.googleapis.com/auth/documents "
+    "https://www.googleapis.com/auth/spreadsheets "
+    "https://www.googleapis.com/auth/presentations"
 )
 
 
@@ -148,10 +229,14 @@ class GoogleDriveProvider(GoogleOAuthProvider, OnyxManagedExtApp):
             "https://www\\.googleapis\\.com/drive/.*",
             # Content uploads use the separate /upload host path.
             "https://www\\.googleapis\\.com/upload/drive/.*",
-            # The Docs API lives on its own host.
+            # The Docs, Sheets, and Slides APIs each live on their own host.
             "https://docs\\.googleapis\\.com/.*",
+            "https://sheets\\.googleapis\\.com/.*",
+            "https://slides\\.googleapis\\.com/.*",
         ],
-        google_api_name="Google Drive API and Google Docs API",
+        google_api_name=(
+            "Google Drive, Google Docs, Google Sheets, and Google Slides APIs"
+        ),
         endpoint_catalog=_ENDPOINTS,
     )
 

--- a/backend/onyx/external_apps/providers/google_drive.py
+++ b/backend/onyx/external_apps/providers/google_drive.py
@@ -16,11 +16,9 @@ from shared_configs.configs import MULTI_TENANT
 # Google Drive API v3. Reads (GET) live under `/drive/v3/...`; content uploads
 # use the separate `/upload/drive/v3/...` host path, so both prefixes appear in
 # the upstream patterns and the catalog. The Google Docs, Sheets, and Slides
-# APIs are separate hosts (`docs.googleapis.com/v1/documents/...`,
-# `sheets.googleapis.com/v4/spreadsheets/...`,
-# `slides.googleapis.com/v1/presentations/...`) all authorized by the same
-# `auth/drive` scope. Reads default to ALWAYS; every mutation defaults to ASK
-# so the egress approval gate prompts the user before it runs.
+# APIs live on their own hosts, all authorized by the same `auth/drive` scope.
+# Reads default to ALWAYS; every mutation defaults to ASK so the egress
+# approval gate prompts the user before it runs.
 class GoogleDriveAction(ExternalAppAction):
     """Strongly-typed catalog ids for the Google Drive provider."""
 
@@ -47,9 +45,8 @@ _UPLOAD_FILES = "/upload/drive/v3/files"
 _UPLOAD_ITEM = f"{_UPLOAD_FILES}/{{fileId}}"
 _DOCS = "/v1/documents"
 _DOC_ITEM = f"{_DOCS}/{{documentId}}"
-# Google's `:verb` suffixes (`ID:batchUpdate`, `RANGE:append`) share the path
-# segment with the resource id, so a `{name}` placeholder in the last position
-# matches both the plain id and its verb forms.
+# Google's `:verb` suffixes (`ID:batchUpdate`, `RANGE:append`) share a path
+# segment with the resource id, so a trailing `{name}` placeholder matches both.
 _SHEETS = "/v4/spreadsheets"
 _SHEET_ITEM = f"{_SHEETS}/{{spreadsheetId}}"
 _SHEET_VALUES = f"{_SHEET_ITEM}/values/{{range}}"
@@ -166,10 +163,8 @@ _ENDPOINTS: list[EndpointSpec] = [
             "to a Google Sheet via the Sheets API."
         ),
         matches=(
-            # `{spreadsheetId}` also matches `ID:batchUpdate`.
             RestRoute(method="POST", path=_SHEET_ITEM),
             RestRoute(method="PUT", path=_SHEET_VALUES),
-            # `{range}` also matches `RANGE:append` / `RANGE:clear`.
             RestRoute(method="POST", path=_SHEET_VALUES),
         ),
     ),
@@ -198,7 +193,6 @@ _ENDPOINTS: list[EndpointSpec] = [
             "Apply edits (add slides, insert or replace text, restyle) to a "
             "Google Slides presentation via the Slides API."
         ),
-        # `{presentationId}` also matches `ID:batchUpdate`.
         matches=(RestRoute(method="POST", path=_SLIDE_ITEM),),
     ),
 ]

--- a/backend/onyx/skills/builtin/google-drive/SKILL.md.template
+++ b/backend/onyx/skills/builtin/google-drive/SKILL.md.template
@@ -5,291 +5,32 @@ description: Search, read, create, and edit the connected user's Google Drive �
 
 # Google Drive
 
-Call the Google Drive API as the connected user via the bundled helpers. Reads run
-freely; writes (create / upload / edit / delete) may pause for the user to approve.
-`gdrive_api.py` covers Drive files and Google Docs; `gsheets_api.py` and
-`gslides_api.py` (documented below) cover Google Sheets and Slides.
+Call the Google Drive, Docs, Sheets, and Slides APIs as the connected user via
+the bundled helpers. Reads run freely; writes (create / upload / edit / delete)
+may pause for the user to approve.
 
 {{ACTION_AVAILABILITY_SECTION}}
 
-## Usage
-
-    python .opencode/skills/google-drive/gdrive_api.py <command> [args]
-
-Read commands auto-paginate and prune empty fields. Pass `--raw` to skip pruning;
-`python gdrive_api.py <command> -h` shows a command's flags. Add `--shared-drives`
-to a search/list to include shared drives (My Drive only by default).
-
-### Search files
-
-```
-python gdrive_api.py search "quarterly report" [--name NAME] [--mime MIME] \
-    [--in FOLDER_ID] [--include-trashed] [--limit N]
-```
-
-`search` with no positional text just lists recent files. Common `--mime` values:
-`application/vnd.google-apps.document` (Docs),
-`application/vnd.google-apps.spreadsheet` (Sheets),
-`application/vnd.google-apps.folder` (folders), `application/pdf`.
-
-### List a folder's children
-
-```
-python gdrive_api.py list <folder_id> [--limit N]
-```
-
-### One file's metadata
-
-```
-python gdrive_api.py get <file_id> [--fields "id,name,mimeType,..."]
-```
-
-### Read a file's contents (text)
-
-```
-python gdrive_api.py read <file_id> [--mime EXPORT_MIME] [--max-bytes N]
-```
-
-Google-native docs are **exported** to text automatically: Docs → markdown,
-Sheets → CSV (first sheet only), Slides → plain text. Other files are downloaded
-as-is and returned as UTF-8. Output is capped at `--max-bytes` (5 MB default).
-
-### Create a folder (write)
-
-```
-python gdrive_api.py create-folder "Reports" [--in PARENT_FOLDER_ID]
-```
-
-### Upload a file (write)
-
-```
-python gdrive_api.py upload <local_path> [--name NAME] [--in FOLDER_ID] \
-    [--as CONTENT_TYPE] [--convert-to GOOGLE_MIME]
-```
-
-Uploads a file you've produced in the workspace. To create a real **Google Doc**
-from generated markdown/HTML, pass `--convert-to
-application/vnd.google-apps.document` (Sheets:
-`application/vnd.google-apps.spreadsheet`); Drive converts the upload. Without
-`--convert-to` the file is stored as-is.
-
-### Replace a file's contents (write)
-
-```
-python gdrive_api.py replace <file_id> <local_path> [--as CONTENT_TYPE]
-```
-
-### Update metadata: rename / move (write)
-
-```
-python gdrive_api.py update <file_id> [--name NEW_NAME] \
-    [--add-parent FOLDER_ID] [--remove-parent FOLDER_ID]
-```
-
-### Trash or delete (write / destructive)
-
-```
-python gdrive_api.py trash <file_id>     # reversible
-python gdrive_api.py delete <file_id>    # permanent
-```
-
-Prefer `trash` over `delete` unless a permanent removal is explicitly requested.
-
-### Raw request (escape hatch)
-
-```
-python gdrive_api.py call GET "files?q=...&fields=..."
-python gdrive_api.py call PATCH "files/<id>" '{"starred": true}'
-```
-
-Appended to `https://www.googleapis.com/drive/v3/`; pass a JSON object body as the
-last argument for write methods.
-
-## Editing Google Docs (Docs API)
-
-To **surgically edit an existing Google Doc** (insert/delete text, restyle
-paragraphs, add bullets) use the Docs API commands below. These call
-`https://docs.googleapis.com/v1/` — a different host than Drive. `read` still gives
-you the Doc's text, but Docs edits need character **indices**, so fetch the
-structure first with `get-doc`. Note: `<document_id>` is the Drive file id of the
-Doc.
-
-### Get a Doc's structure (indices)
-
-```
-python gdrive_api.py get-doc <document_id> [--fields "documentId,body,title"]
-```
-
-Returns the document's `body.content` with each element's `startIndex` /
-`endIndex`. Use these indices to target edits precisely.
-
-### Insert text at an index (write)
-
-```
-python gdrive_api.py insert-text <document_id> --index N --text "..."
-```
-
-Issues a `batchUpdate` with a single `insertText` request at character index `N`
-(get the index from `get-doc`).
-
-### Append text to the end of a Doc (write)
-
-```
-python gdrive_api.py append-text <document_id> --text "..."
-```
-
-Fetches the Doc, computes the end of the body, and inserts the text there — no
-manual index needed.
-
-### Apply raw batchUpdate requests (write)
-
-```
-python gdrive_api.py batch-update <document_id> '[<request>, ...]'
-python gdrive_api.py batch-update <document_id> --file requests.json
-```
-
-The general escape hatch: pass a JSON **array** of Docs API request objects, sent
-as `{"requests": [...]}` to `documents/<id>:batchUpdate`. Supports the full Docs
-request set, e.g. `insertText`, `deleteContentRange`, `updateParagraphStyle`,
-`createParagraphBullets`, `updateTextStyle`. Example — bold a range then bullet a
-paragraph:
-
-```
-python gdrive_api.py batch-update <document_id> '[
-  {"updateTextStyle": {"range": {"startIndex": 1, "endIndex": 10},
-    "textStyle": {"bold": true}, "fields": "bold"}},
-  {"createParagraphBullets": {"range": {"startIndex": 1, "endIndex": 10},
-    "bulletPreset": "BULLET_DISC_CIRCLE_SQUARE"}}
-]'
-```
-
-### Create a new Google Doc (write)
-
-```
-python gdrive_api.py create-doc --title "My Doc"
-```
-
-Creates a new empty Doc via the Docs API and returns its `documentId` (then use
-`insert-text` / `batch-update` to fill it). To create a Doc from existing
-markdown/HTML content instead, use `upload --convert-to
-application/vnd.google-apps.document`.
-
-## Google Sheets (Sheets API)
-
-Use `gsheets_api.py` to read and **surgically edit spreadsheets** via
-`https://sheets.googleapis.com/v4/`. `read` (above) still exports a Sheet as CSV;
-the commands here read structure, target A1 ranges, and write cells.
-`<spreadsheet_id>` is the Drive file id of the Sheet.
-
-```
-python .opencode/skills/google-drive/gsheets_api.py <command> [args]
-```
-
-### Read structure and values
-
-```
-python gsheets_api.py get <spreadsheet_id> [--fields ...]
-python gsheets_api.py values <spreadsheet_id> "Sheet1!A1:C10" [--formulas]
-```
-
-`get` lists the sheets (tabs) with their `sheetId` and grid size. `values` takes
-A1 notation; a bare sheet title reads the whole tab.
-
-### Create a spreadsheet (write)
-
-```
-python gsheets_api.py create --title "Budget" [--sheet "Q1" --sheet "Q2"]
-```
-
-To build a Sheet from a produced CSV instead, use `gdrive_api.py upload
---convert-to application/vnd.google-apps.spreadsheet`.
-
-### Write cell values (write)
-
-```
-python gsheets_api.py update-values <spreadsheet_id> "Sheet1!A1" '[["a","b"],[1,2]]'
-python gsheets_api.py append-values <spreadsheet_id> "Sheet1" '[["new","row"]]'
-python gsheets_api.py clear-values <spreadsheet_id> "Sheet1!A2:B10"
-```
-
-Values are a JSON array of row arrays (`--file values.json` instead of inline).
-Input is parsed like UI entry (numbers, dates, `=SUM(A1:A5)` formulas); pass
-`--raw-input` to store strings verbatim. `append-values` adds rows after the
-last row of the table that contains the given range.
-
-### Structural edits: raw batchUpdate (write)
-
-```
-python gsheets_api.py batch-update <spreadsheet_id> '[<request>, ...]'
-python gsheets_api.py batch-update <spreadsheet_id> --file requests.json
-```
-
-The escape hatch for everything else — a JSON **array** of Sheets API request
-objects (e.g. `addSheet`, `deleteSheet`, `repeatCell`, `mergeCells`,
-`updateBorders`, `autoResizeDimensions`). Requests that target a tab need its
-numeric `sheetId` from `get` (not the tab title).
-
-## Google Slides (Slides API)
-
-Use `gslides_api.py` to read and **edit presentations** via
-`https://slides.googleapis.com/v1/`. `read` (above) still exports a deck as plain
-text; the commands here expose slide/element `objectId`s, which edits target.
-`<presentation_id>` is the Drive file id of the deck.
-
-```
-python .opencode/skills/google-drive/gslides_api.py <command> [args]
-```
-
-### Read a deck
-
-```
-python gslides_api.py get <presentation_id> [--fields ...]
-python gslides_api.py text <presentation_id>
-python gslides_api.py page <presentation_id> <page_object_id>
-```
-
-`get` returns a compact structure view (slides, element `objectId`s, shape text);
-`text` returns just the plain text per slide; `page` returns one slide in full.
-
-### Create and grow a deck (write)
-
-```
-python gslides_api.py create --title "Roadmap"
-python gslides_api.py add-slide <presentation_id> [--layout TITLE_AND_BODY]
-```
-
-`add-slide` appends a slide with a predefined layout (`BLANK`, `TITLE`,
-`TITLE_AND_BODY`, `SECTION_HEADER`, ...) and returns the new slide's `objectId`.
-
-### Edit text (write)
-
-```
-python gslides_api.py insert-text <presentation_id> <shape_object_id> --text "..."
-python gslides_api.py replace-text <presentation_id> --find "{{name}}" --replace "Ada"
-```
-
-`insert-text` needs a shape `objectId` from `get`. `replace-text` swaps every
-occurrence across the deck — the reliable way to fill placeholder text.
-
-### Raw batchUpdate (write)
-
-```
-python gslides_api.py batch-update <presentation_id> '[<request>, ...]'
-python gslides_api.py batch-update <presentation_id> --file requests.json
-```
-
-The escape hatch for everything else — a JSON **array** of Slides API request
-objects (e.g. `createShape`, `createTable`, `updateTextStyle`, `deleteObject`,
-`updatePageElementTransform`).
+> **Path convention**: run helpers from the session workspace as
+> `python .opencode/skills/google-drive/<helper>.py <command> [args]`.
+> `python <helper>.py <command> -h` shows a command's flags.
+
+## Quick Reference
+
+| Task | Guide |
+|------|-------|
+| Find, read, upload, organize, or delete any Drive file | Read [drive.md](drive.md) — `gdrive_api.py` |
+| Surgically edit or create a Google Doc | Read [docs.md](docs.md) — `gdrive_api.py` Docs commands |
+| Read or write spreadsheet cells; create a Sheet | Read [sheets.md](sheets.md) — `gsheets_api.py` |
+| Read or edit a Slides deck | Read [slides.md](slides.md) — `gslides_api.py` |
+
+To just read a Google-native file as text, `gdrive_api.py read <file_id>` is
+enough (Docs → markdown, Sheets → CSV, Slides → plain text) — see
+[drive.md](drive.md). Open the per-API guides when you need structure, ids,
+indices, or edits.
 
 ## Output
 
-JSON on stdout. Search/list/drives return `{"ok": true, "items": [...], "count":
-N, "truncated": bool}`. `get` / create / upload / update / replace return `{"ok":
-true, "file": {...}}`. `read` returns `{"ok": true, "id", "name", "mimeType",
-"exportedAs", "truncated", "content"}`. `get-doc` / `create-doc` return `{"ok":
-true, "document": {...}}`; `insert-text` / `append-text` / `batch-update` return
-`{"ok": true, "data": {...}}` (`append-text` also echoes the computed `index`).
-The Sheets and Slides helpers follow the same shape: `{"ok": true, "spreadsheet"
-| "presentation" | "page" | "slides" | "data": ...}`. Errors print to stderr and
-exit non-zero.
+Every helper prints JSON on stdout: `{"ok": true, ...}` with the payload under
+a command-specific key (each guide lists its shapes). Errors print to stderr
+and exit non-zero. Pass `--raw` to skip empty-field pruning.

--- a/backend/onyx/skills/builtin/google-drive/SKILL.md.template
+++ b/backend/onyx/skills/builtin/google-drive/SKILL.md.template
@@ -1,12 +1,14 @@
 ---
 name: google-drive
-description: Search, read, create, and edit the connected user's Google Drive via a light Drive API wrapper.
+description: Search, read, create, and edit the connected user's Google Drive — including Google Docs, Sheets, and Slides — via light API wrappers.
 ---
 
 # Google Drive
 
-Call the Google Drive API as the connected user via the bundled helper. Reads run
+Call the Google Drive API as the connected user via the bundled helpers. Reads run
 freely; writes (create / upload / edit / delete) may pause for the user to approve.
+`gdrive_api.py` covers Drive files and Google Docs; `gsheets_api.py` and
+`gslides_api.py` (documented below) cover Google Sheets and Slides.
 
 {{ACTION_AVAILABILITY_SECTION}}
 
@@ -172,6 +174,114 @@ Creates a new empty Doc via the Docs API and returns its `documentId` (then use
 markdown/HTML content instead, use `upload --convert-to
 application/vnd.google-apps.document`.
 
+## Google Sheets (Sheets API)
+
+Use `gsheets_api.py` to read and **surgically edit spreadsheets** via
+`https://sheets.googleapis.com/v4/`. `read` (above) still exports a Sheet as CSV;
+the commands here read structure, target A1 ranges, and write cells.
+`<spreadsheet_id>` is the Drive file id of the Sheet.
+
+```
+python .opencode/skills/google-drive/gsheets_api.py <command> [args]
+```
+
+### Read structure and values
+
+```
+python gsheets_api.py get <spreadsheet_id> [--fields ...]
+python gsheets_api.py values <spreadsheet_id> "Sheet1!A1:C10" [--formulas]
+```
+
+`get` lists the sheets (tabs) with their `sheetId` and grid size. `values` takes
+A1 notation; a bare sheet title reads the whole tab.
+
+### Create a spreadsheet (write)
+
+```
+python gsheets_api.py create --title "Budget" [--sheet "Q1" --sheet "Q2"]
+```
+
+To build a Sheet from a produced CSV instead, use `gdrive_api.py upload
+--convert-to application/vnd.google-apps.spreadsheet`.
+
+### Write cell values (write)
+
+```
+python gsheets_api.py update-values <spreadsheet_id> "Sheet1!A1" '[["a","b"],[1,2]]'
+python gsheets_api.py append-values <spreadsheet_id> "Sheet1" '[["new","row"]]'
+python gsheets_api.py clear-values <spreadsheet_id> "Sheet1!A2:B10"
+```
+
+Values are a JSON array of row arrays (`--file values.json` instead of inline).
+Input is parsed like UI entry (numbers, dates, `=SUM(A1:A5)` formulas); pass
+`--raw-input` to store strings verbatim. `append-values` adds rows after the
+last row of the table that contains the given range.
+
+### Structural edits: raw batchUpdate (write)
+
+```
+python gsheets_api.py batch-update <spreadsheet_id> '[<request>, ...]'
+python gsheets_api.py batch-update <spreadsheet_id> --file requests.json
+```
+
+The escape hatch for everything else — a JSON **array** of Sheets API request
+objects (e.g. `addSheet`, `deleteSheet`, `repeatCell`, `mergeCells`,
+`updateBorders`, `autoResizeDimensions`). Requests that target a tab need its
+numeric `sheetId` from `get` (not the tab title).
+
+## Google Slides (Slides API)
+
+Use `gslides_api.py` to read and **edit presentations** via
+`https://slides.googleapis.com/v1/`. `read` (above) still exports a deck as plain
+text; the commands here expose slide/element `objectId`s, which edits target.
+`<presentation_id>` is the Drive file id of the deck.
+
+```
+python .opencode/skills/google-drive/gslides_api.py <command> [args]
+```
+
+### Read a deck
+
+```
+python gslides_api.py get <presentation_id> [--fields ...]
+python gslides_api.py text <presentation_id>
+python gslides_api.py page <presentation_id> <page_object_id>
+```
+
+`get` returns a compact structure view (slides, element `objectId`s, shape text);
+`text` returns just the plain text per slide; `page` returns one slide in full.
+
+### Create and grow a deck (write)
+
+```
+python gslides_api.py create --title "Roadmap"
+python gslides_api.py add-slide <presentation_id> [--layout TITLE_AND_BODY]
+```
+
+`add-slide` appends a slide with a predefined layout (`BLANK`, `TITLE`,
+`TITLE_AND_BODY`, `SECTION_HEADER`, ...) and returns the new slide's `objectId`.
+
+### Edit text (write)
+
+```
+python gslides_api.py insert-text <presentation_id> <shape_object_id> --text "..."
+python gslides_api.py replace-text <presentation_id> --find "{{name}}" --replace "Ada"
+```
+
+`insert-text` needs a shape `objectId` from `get`. `replace-text` swaps every
+occurrence across the deck — the reliable way to fill placeholder text.
+
+### Raw batchUpdate (write)
+
+```
+python gslides_api.py batch-update <presentation_id> '[<request>, ...]'
+python gslides_api.py batch-update <presentation_id> --file requests.json
+```
+
+The escape hatch for everything else — a JSON **array** of Slides API request
+objects (e.g. `createShape`, `createTable`, `updateTextStyle`, `deleteObject`,
+`updatePageElementTransform`).
+
 ## Output
 
 JSON on stdout. Search/list/drives return `{"ok": true, "items": [...], "count":
@@ -180,4 +290,6 @@ true, "file": {...}}`. `read` returns `{"ok": true, "id", "name", "mimeType",
 "exportedAs", "truncated", "content"}`. `get-doc` / `create-doc` return `{"ok":
 true, "document": {...}}`; `insert-text` / `append-text` / `batch-update` return
 `{"ok": true, "data": {...}}` (`append-text` also echoes the computed `index`).
-Errors print to stderr and exit non-zero.
+The Sheets and Slides helpers follow the same shape: `{"ok": true, "spreadsheet"
+| "presentation" | "page" | "slides" | "data": ...}`. Errors print to stderr and
+exit non-zero.

--- a/backend/onyx/skills/builtin/google-drive/docs.md
+++ b/backend/onyx/skills/builtin/google-drive/docs.md
@@ -1,0 +1,75 @@
+# Google Docs (`gdrive_api.py` Docs commands)
+
+Surgically edit or create a Google Doc (insert/delete text, restyle paragraphs,
+add bullets) via `https://docs.googleapis.com/v1/` — a different host than
+Drive. `gdrive_api.py read` gives you a Doc's text, but Docs edits need
+character **indices**, so fetch the structure first with `get-doc`. Note:
+`<document_id>` is the Drive file id of the Doc.
+
+    python .opencode/skills/google-drive/gdrive_api.py <command> [args]
+
+## Get a Doc's structure (indices)
+
+```
+python gdrive_api.py get-doc <document_id> [--fields "documentId,body,title"]
+```
+
+Returns the document's `body.content` with each element's `startIndex` /
+`endIndex`. Use these indices to target edits precisely.
+
+## Insert text at an index (write)
+
+```
+python gdrive_api.py insert-text <document_id> --index N --text "..."
+```
+
+Issues a `batchUpdate` with a single `insertText` request at character index `N`
+(get the index from `get-doc`).
+
+## Append text to the end of a Doc (write)
+
+```
+python gdrive_api.py append-text <document_id> --text "..."
+```
+
+Fetches the Doc, computes the end of the body, and inserts the text there — no
+manual index needed.
+
+## Apply raw batchUpdate requests (write)
+
+```
+python gdrive_api.py batch-update <document_id> '[<request>, ...]'
+python gdrive_api.py batch-update <document_id> --file requests.json
+```
+
+The general escape hatch: pass a JSON **array** of Docs API request objects, sent
+as `{"requests": [...]}` to `documents/<id>:batchUpdate`. Supports the full Docs
+request set, e.g. `insertText`, `deleteContentRange`, `updateParagraphStyle`,
+`createParagraphBullets`, `updateTextStyle`. Example — bold a range then bullet a
+paragraph:
+
+```
+python gdrive_api.py batch-update <document_id> '[
+  {"updateTextStyle": {"range": {"startIndex": 1, "endIndex": 10},
+    "textStyle": {"bold": true}, "fields": "bold"}},
+  {"createParagraphBullets": {"range": {"startIndex": 1, "endIndex": 10},
+    "bulletPreset": "BULLET_DISC_CIRCLE_SQUARE"}}
+]'
+```
+
+## Create a new Google Doc (write)
+
+```
+python gdrive_api.py create-doc --title "My Doc"
+```
+
+Creates a new empty Doc via the Docs API and returns its `documentId` (then use
+`insert-text` / `batch-update` to fill it). To create a Doc from existing
+markdown/HTML content instead, use `upload --convert-to
+application/vnd.google-apps.document` (see [drive.md](drive.md)).
+
+## Output
+
+`get-doc` / `create-doc` return `{"ok": true, "document": {...}}`.
+`insert-text` / `append-text` / `batch-update` return `{"ok": true, "data":
+{...}}` (`append-text` also echoes the computed `index`).

--- a/backend/onyx/skills/builtin/google-drive/drive.md
+++ b/backend/onyx/skills/builtin/google-drive/drive.md
@@ -1,0 +1,101 @@
+# Drive files (`gdrive_api.py`)
+
+Search, read, upload, organize, and delete files and folders via
+`https://www.googleapis.com/drive/v3/`.
+
+    python .opencode/skills/google-drive/gdrive_api.py <command> [args]
+
+Read commands auto-paginate and prune empty fields. Add `--shared-drives` to a
+search/list to include shared drives (My Drive only by default).
+
+## Search files
+
+```
+python gdrive_api.py search "quarterly report" [--name NAME] [--mime MIME] \
+    [--in FOLDER_ID] [--include-trashed] [--limit N]
+```
+
+`search` with no positional text just lists recent files. Common `--mime` values:
+`application/vnd.google-apps.document` (Docs),
+`application/vnd.google-apps.spreadsheet` (Sheets),
+`application/vnd.google-apps.folder` (folders), `application/pdf`.
+
+## List a folder's children
+
+```
+python gdrive_api.py list <folder_id> [--limit N]
+```
+
+## One file's metadata
+
+```
+python gdrive_api.py get <file_id> [--fields "id,name,mimeType,..."]
+```
+
+## Read a file's contents (text)
+
+```
+python gdrive_api.py read <file_id> [--mime EXPORT_MIME] [--max-bytes N]
+```
+
+Google-native docs are **exported** to text automatically: Docs → markdown,
+Sheets → CSV (first sheet only), Slides → plain text. Other files are downloaded
+as-is and returned as UTF-8. Output is capped at `--max-bytes` (5 MB default).
+
+## Create a folder (write)
+
+```
+python gdrive_api.py create-folder "Reports" [--in PARENT_FOLDER_ID]
+```
+
+## Upload a file (write)
+
+```
+python gdrive_api.py upload <local_path> [--name NAME] [--in FOLDER_ID] \
+    [--as CONTENT_TYPE] [--convert-to GOOGLE_MIME]
+```
+
+Uploads a file you've produced in the workspace. To create a real **Google Doc**
+from generated markdown/HTML, pass `--convert-to
+application/vnd.google-apps.document` (Sheets:
+`application/vnd.google-apps.spreadsheet`); Drive converts the upload. Without
+`--convert-to` the file is stored as-is.
+
+## Replace a file's contents (write)
+
+```
+python gdrive_api.py replace <file_id> <local_path> [--as CONTENT_TYPE]
+```
+
+## Update metadata: rename / move (write)
+
+```
+python gdrive_api.py update <file_id> [--name NEW_NAME] \
+    [--add-parent FOLDER_ID] [--remove-parent FOLDER_ID]
+```
+
+## Trash or delete (write / destructive)
+
+```
+python gdrive_api.py trash <file_id>     # reversible
+python gdrive_api.py delete <file_id>    # permanent
+```
+
+Prefer `trash` over `delete` unless a permanent removal is explicitly requested.
+
+## Raw request (escape hatch)
+
+```
+python gdrive_api.py call GET "files?q=...&fields=..."
+python gdrive_api.py call PATCH "files/<id>" '{"starred": true}'
+```
+
+Appended to `https://www.googleapis.com/drive/v3/`; pass a JSON object body as the
+last argument for write methods.
+
+## Output
+
+Search/list/drives return `{"ok": true, "items": [...], "count": N,
+"truncated": bool}`. `get` / create / upload / update / replace return `{"ok":
+true, "file": {...}}`. `read` returns `{"ok": true, "id", "name", "mimeType",
+"exportedAs", "truncated", "content"}`.

--- a/backend/onyx/skills/builtin/google-drive/gsheets_api.py
+++ b/backend/onyx/skills/builtin/google-drive/gsheets_api.py
@@ -65,6 +65,8 @@ def _req_json(
 
 def _load_json_arg(inline: str | None, file_path: str | None, what: str) -> Any:
     """A JSON payload given inline or via --file (exactly one required)."""
+    if inline and file_path:
+        raise ValueError(f"pass {what} inline or via --file, not both")
     raw = inline
     if file_path:
         with open(file_path, encoding="utf-8") as fh:
@@ -216,7 +218,7 @@ def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
     # batch-update
     requests = _load_json_arg(a.requests_json, a.requests_file, "requests")
     if not isinstance(requests, list):
-        return {"ok": False, "error": "requests_not_array"}
+        raise ValueError("requests must be a JSON array of request objects")
     data = _req_json(
         f"spreadsheets/{_seg(a.spreadsheet_id)}:batchUpdate",
         method="POST",

--- a/backend/onyx/skills/builtin/google-drive/gsheets_api.py
+++ b/backend/onyx/skills/builtin/google-drive/gsheets_api.py
@@ -65,7 +65,7 @@ def _req_json(
 
 def _load_json_arg(inline: str | None, file_path: str | None, what: str) -> Any:
     """A JSON payload given inline or via --file (exactly one required)."""
-    if inline and file_path:
+    if inline is not None and file_path is not None:
         raise ValueError(f"pass {what} inline or via --file, not both")
     raw = inline
     if file_path:

--- a/backend/onyx/skills/builtin/google-drive/gsheets_api.py
+++ b/backend/onyx/skills/builtin/google-drive/gsheets_api.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Google Sheets wrapper for the Onyx Craft sandbox.
+
+Common operations exposed as subcommands. Output is JSON on stdout. No auth is
+handled here: the sandbox egress proxy injects the connected user's bearer token.
+Writes (create / update / append / clear / batch-update) may pause for user
+approval at the proxy.
+"""
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+_BASE = "https://sheets.googleapis.com/v4/"
+_HTTP_TIMEOUT_SECONDS = 180
+# Compact structure view: enough to find sheets and their sizes without the
+# full per-cell grid data.
+_DEFAULT_GET_FIELDS = (
+    "spreadsheetId,spreadsheetUrl,properties(title,locale,timeZone),"
+    "sheets(properties(sheetId,title,index,gridProperties(rowCount,columnCount)))"
+)
+
+
+def _prune(value: Any) -> Any:
+    """Recursively drop None / "" / [] / {} so LLM-facing output stays small.
+    Booleans and 0 are kept — they carry signal."""
+    if isinstance(value, dict):
+        out = {k: _prune(v) for k, v in value.items()}
+        return {k: v for k, v in out.items() if v not in (None, "", [], {})}
+    if isinstance(value, list):
+        return [_prune(v) for v in value]
+    return value
+
+
+def _seg(value: str) -> str:
+    """URL-encode a single path segment (ids and A1 ranges may contain special
+    chars; `:` in a range stays encoded, which the API accepts)."""
+    return urllib.parse.quote(value, safe="")
+
+
+def _req_json(
+    path: str,
+    params: dict[str, Any] | None = None,
+    method: str = "GET",
+    body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Call a Sheets endpoint; return parsed JSON ({} on empty/204)."""
+    url = _BASE + path
+    if params:
+        clean = {k: v for k, v in params.items() if v is not None}
+        url += "?" + urllib.parse.urlencode(clean)
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    headers = {"Content-Type": "application/json; charset=utf-8"} if data else {}
+    req = urllib.request.Request(  # noqa: S310 — fixed https base url
+        url, data=data, method=method, headers=headers
+    )
+    with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SECONDS) as resp:  # noqa: S310
+        raw = resp.read().decode("utf-8")
+    return json.loads(raw) if raw.strip() else {}
+
+
+def _load_json_arg(inline: str | None, file_path: str | None, what: str) -> Any:
+    """A JSON payload given inline or via --file (exactly one required)."""
+    raw = inline
+    if file_path:
+        with open(file_path, encoding="utf-8") as fh:
+            raw = fh.read()
+    if not raw:
+        raise ValueError(f"no {what} given (pass inline JSON or --file)")
+    return json.loads(raw)
+
+
+def _values_body(a: argparse.Namespace) -> dict[str, Any]:
+    values = _load_json_arg(a.values_json, a.values_file, "values")
+    if not isinstance(values, list) or not all(isinstance(r, list) for r in values):
+        raise ValueError("values must be a JSON array of row arrays, e.g. [[1,2]]")
+    return {"values": values}
+
+
+def _input_option(a: argparse.Namespace) -> str:
+    # USER_ENTERED parses input like typing in the UI (numbers, dates, =SUM()).
+    return "RAW" if a.raw_input else "USER_ENTERED"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="gsheets_api.py", description="Google Sheets.")
+    p.add_argument("--raw", action="store_true", help="don't prune empty fields")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("get", help="a spreadsheet's structure (sheets + sizes)")
+    sp.add_argument("spreadsheet_id")
+    sp.add_argument(
+        "--fields",
+        default=_DEFAULT_GET_FIELDS,
+        help="Sheets fields selector (default: compact structure view)",
+    )
+
+    sp = sub.add_parser("values", help="read cell values from an A1 range")
+    sp.add_argument("spreadsheet_id")
+    sp.add_argument("range", help="A1 notation, e.g. 'Sheet1!A1:C10' or 'Sheet1'")
+    sp.add_argument(
+        "--formulas",
+        action="store_true",
+        help="return cell formulas instead of computed values",
+    )
+
+    sp = sub.add_parser("create", help="create a new spreadsheet (write)")
+    sp.add_argument("--title", required=True, help="title of the new spreadsheet")
+    sp.add_argument(
+        "--sheet",
+        dest="sheets",
+        action="append",
+        help="add a sheet (tab) with this title; repeatable",
+    )
+
+    def values_write(name: str, help_text: str) -> argparse.ArgumentParser:
+        wp = sub.add_parser(name, help=help_text)
+        wp.add_argument("spreadsheet_id")
+        wp.add_argument("range", help="A1 notation target range")
+        wp.add_argument(
+            "values_json", nargs="?", help="JSON array of row arrays, e.g. [[1,2]]"
+        )
+        wp.add_argument(
+            "--file",
+            dest="values_file",
+            help="path to a file holding the JSON values array (instead of inline)",
+        )
+        wp.add_argument(
+            "--raw-input",
+            dest="raw_input",
+            action="store_true",
+            help="store input verbatim instead of parsing like UI entry",
+        )
+        return wp
+
+    values_write("update-values", "overwrite cell values in a range (write)")
+    values_write("append-values", "append rows after a table's last row (write)")
+
+    sp = sub.add_parser("clear-values", help="clear cell values in a range (write)")
+    sp.add_argument("spreadsheet_id")
+    sp.add_argument("range", help="A1 notation range to clear")
+
+    sp = sub.add_parser(
+        "batch-update",
+        help="apply raw Sheets batchUpdate requests (write)",
+    )
+    sp.add_argument("spreadsheet_id")
+    sp.add_argument(
+        "requests_json",
+        nargs="?",
+        help="JSON array of Sheets request objects (e.g. addSheet, "
+        "updateCells, repeatCell, mergeCells, deleteRange)",
+    )
+    sp.add_argument(
+        "--file",
+        dest="requests_file",
+        help="path to a file holding the JSON requests array (instead of inline)",
+    )
+    return p
+
+
+def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
+    if a.cmd == "get":
+        data = _req_json(f"spreadsheets/{_seg(a.spreadsheet_id)}", {"fields": a.fields})
+        return {"ok": True, "spreadsheet": data}
+
+    if a.cmd == "values":
+        params = {"valueRenderOption": "FORMULA"} if a.formulas else None
+        data = _req_json(
+            f"spreadsheets/{_seg(a.spreadsheet_id)}/values/{_seg(a.range)}", params
+        )
+        return {"ok": True, "data": data}
+
+    if a.cmd == "create":
+        body: dict[str, Any] = {"properties": {"title": a.title}}
+        if a.sheets:
+            body["sheets"] = [{"properties": {"title": t}} for t in a.sheets]
+        data = _req_json(
+            "spreadsheets",
+            {"fields": _DEFAULT_GET_FIELDS},
+            method="POST",
+            body=body,
+        )
+        return {"ok": True, "spreadsheet": data}
+
+    if a.cmd == "update-values":
+        data = _req_json(
+            f"spreadsheets/{_seg(a.spreadsheet_id)}/values/{_seg(a.range)}",
+            {"valueInputOption": _input_option(a)},
+            method="PUT",
+            body=_values_body(a),
+        )
+        return {"ok": True, "data": data}
+
+    if a.cmd == "append-values":
+        data = _req_json(
+            f"spreadsheets/{_seg(a.spreadsheet_id)}/values/{_seg(a.range)}:append",
+            {"valueInputOption": _input_option(a)},
+            method="POST",
+            body=_values_body(a),
+        )
+        return {"ok": True, "data": data}
+
+    if a.cmd == "clear-values":
+        data = _req_json(
+            f"spreadsheets/{_seg(a.spreadsheet_id)}/values/{_seg(a.range)}:clear",
+            method="POST",
+            body={},
+        )
+        return {"ok": True, "data": data}
+
+    # batch-update
+    requests = _load_json_arg(a.requests_json, a.requests_file, "requests")
+    if not isinstance(requests, list):
+        return {"ok": False, "error": "requests_not_array"}
+    data = _req_json(
+        f"spreadsheets/{_seg(a.spreadsheet_id)}:batchUpdate",
+        method="POST",
+        body={"requests": requests},
+    )
+    return {"ok": True, "data": data}
+
+
+def _emit(result: dict[str, Any], raw: bool) -> int:
+    print(json.dumps(result if raw else _prune(result)))
+    return 0 if result.get("ok") else 1
+
+
+def main(argv: list[str]) -> int:
+    a = _build_parser().parse_args(argv[1:])
+    try:
+        result = _dispatch(a)
+    except FileNotFoundError as e:
+        print(f"file not found: {e.filename}", file=sys.stderr)
+        return 2
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+    except json.JSONDecodeError as e:
+        print(f"invalid JSON: {e}", file=sys.stderr)
+        return 1
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        print(f"HTTP {e.code} calling Google Sheets: {detail}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as e:
+        print(f"network error calling Google Sheets: {e.reason}", file=sys.stderr)
+        return 1
+    return _emit(result, a.raw)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/backend/onyx/skills/builtin/google-drive/gsheets_api.py
+++ b/backend/onyx/skills/builtin/google-drive/gsheets_api.py
@@ -38,7 +38,7 @@ def _prune(value: Any) -> Any:
 
 def _seg(value: str) -> str:
     """URL-encode a single path segment (ids and A1 ranges may contain special
-    chars; `:` in a range stays encoded, which the API accepts)."""
+    chars)."""
     return urllib.parse.quote(value, safe="")
 
 

--- a/backend/onyx/skills/builtin/google-drive/gslides_api.py
+++ b/backend/onyx/skills/builtin/google-drive/gslides_api.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Google Slides wrapper for the Onyx Craft sandbox.
+
+Common operations exposed as subcommands. Output is JSON on stdout. No auth is
+handled here: the sandbox egress proxy injects the connected user's bearer token.
+Writes (create / add-slide / text edits / batch-update) may pause for user
+approval at the proxy.
+"""
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+_BASE = "https://slides.googleapis.com/v1/"
+_HTTP_TIMEOUT_SECONDS = 180
+# Compact structure view: object ids, element kinds, and text content — enough
+# to target edits without the full styling/transform payload.
+_DEFAULT_GET_FIELDS = (
+    "presentationId,title,revisionId,"
+    "slides(objectId,pageElements(objectId,title,"
+    "shape(shapeType,placeholder(type,index),"
+    "text(textElements(textRun(content)))),"
+    "table(rows,columns),image(contentUrl)))"
+)
+# For plain-text extraction: shape text plus table cell text, nothing else.
+_TEXT_FIELDS = (
+    "title,slides(objectId,pageElements(objectId,"
+    "shape(text(textElements(textRun(content)))),"
+    "table(tableRows(tableCells(text(textElements(textRun(content))))))))"
+)
+
+
+def _prune(value: Any) -> Any:
+    """Recursively drop None / "" / [] / {} so LLM-facing output stays small.
+    Booleans and 0 are kept — they carry signal."""
+    if isinstance(value, dict):
+        out = {k: _prune(v) for k, v in value.items()}
+        return {k: v for k, v in out.items() if v not in (None, "", [], {})}
+    if isinstance(value, list):
+        return [_prune(v) for v in value]
+    return value
+
+
+def _seg(value: str) -> str:
+    """URL-encode a single path segment (ids may contain special chars)."""
+    return urllib.parse.quote(value, safe="")
+
+
+def _req_json(
+    path: str,
+    params: dict[str, Any] | None = None,
+    method: str = "GET",
+    body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Call a Slides endpoint; return parsed JSON ({} on empty/204)."""
+    url = _BASE + path
+    if params:
+        clean = {k: v for k, v in params.items() if v is not None}
+        url += "?" + urllib.parse.urlencode(clean)
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    headers = {"Content-Type": "application/json; charset=utf-8"} if data else {}
+    req = urllib.request.Request(  # noqa: S310 — fixed https base url
+        url, data=data, method=method, headers=headers
+    )
+    with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SECONDS) as resp:  # noqa: S310
+        raw = resp.read().decode("utf-8")
+    return json.loads(raw) if raw.strip() else {}
+
+
+def _batch_update(presentation_id: str, requests: list[Any]) -> dict[str, Any]:
+    """POST a Slides `batchUpdate` with the given list of request objects."""
+    return _req_json(
+        f"presentations/{_seg(presentation_id)}:batchUpdate",
+        method="POST",
+        body={"requests": requests},
+    )
+
+
+def _text_runs(text: dict[str, Any]) -> str:
+    return "".join(
+        element.get("textRun", {}).get("content", "")
+        for element in text.get("textElements", [])
+    )
+
+
+def _element_text(element: dict[str, Any]) -> str:
+    """Plain text of one page element: shape text plus any table cell text."""
+    parts: list[str] = []
+    shape_text = element.get("shape", {}).get("text")
+    if shape_text:
+        parts.append(_text_runs(shape_text))
+    for row in element.get("table", {}).get("tableRows", []):
+        for cell in row.get("tableCells", []):
+            if cell.get("text"):
+                parts.append(_text_runs(cell["text"]))
+    return "".join(parts)
+
+
+def _load_json_arg(inline: str | None, file_path: str | None, what: str) -> Any:
+    """A JSON payload given inline or via --file (exactly one required)."""
+    raw = inline
+    if file_path:
+        with open(file_path, encoding="utf-8") as fh:
+            raw = fh.read()
+    if not raw:
+        raise ValueError(f"no {what} given (pass inline JSON or --file)")
+    return json.loads(raw)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="gslides_api.py", description="Google Slides.")
+    p.add_argument("--raw", action="store_true", help="don't prune empty fields")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser(
+        "get", help="a presentation's structure (slides, element ids, text)"
+    )
+    sp.add_argument("presentation_id")
+    sp.add_argument(
+        "--fields",
+        default=_DEFAULT_GET_FIELDS,
+        help="Slides fields selector (default: compact structure view; "
+        "pass '' for the whole presentation)",
+    )
+
+    sp = sub.add_parser("text", help="plain text of every slide")
+    sp.add_argument("presentation_id")
+
+    sp = sub.add_parser("page", help="one page's full structure")
+    sp.add_argument("presentation_id")
+    sp.add_argument("page_object_id")
+    sp.add_argument("--fields", help="Slides fields selector (default: whole page)")
+
+    sp = sub.add_parser("create", help="create a new presentation (write)")
+    sp.add_argument("--title", required=True, help="title of the new presentation")
+
+    sp = sub.add_parser("add-slide", help="append a slide (write)")
+    sp.add_argument("presentation_id")
+    sp.add_argument(
+        "--layout",
+        default="BLANK",
+        help="predefined layout, e.g. BLANK, TITLE, TITLE_AND_BODY, "
+        "SECTION_HEADER (default: BLANK)",
+    )
+
+    sp = sub.add_parser("insert-text", help="insert text into a shape (write)")
+    sp.add_argument("presentation_id")
+    sp.add_argument("object_id", help="target shape objectId (see `get`)")
+    sp.add_argument("--text", required=True, help="text to insert")
+    sp.add_argument("--index", type=int, default=0, help="character index to insert at")
+
+    sp = sub.add_parser(
+        "replace-text", help="replace all occurrences of a string (write)"
+    )
+    sp.add_argument("presentation_id")
+    sp.add_argument("--find", required=True, help="text to find")
+    sp.add_argument("--replace", required=True, help="replacement text")
+    sp.add_argument(
+        "--match-case",
+        dest="match_case",
+        action="store_true",
+        help="case-sensitive matching (case-insensitive by default)",
+    )
+
+    sp = sub.add_parser(
+        "batch-update",
+        help="apply raw Slides batchUpdate requests (write)",
+    )
+    sp.add_argument("presentation_id")
+    sp.add_argument(
+        "requests_json",
+        nargs="?",
+        help="JSON array of Slides request objects (e.g. createSlide, "
+        "createShape, insertText, updateTextStyle, deleteObject)",
+    )
+    sp.add_argument(
+        "--file",
+        dest="requests_file",
+        help="path to a file holding the JSON requests array (instead of inline)",
+    )
+    return p
+
+
+def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
+    if a.cmd == "get":
+        params = {"fields": a.fields} if a.fields else None
+        data = _req_json(f"presentations/{_seg(a.presentation_id)}", params)
+        return {"ok": True, "presentation": data}
+
+    if a.cmd == "text":
+        data = _req_json(
+            f"presentations/{_seg(a.presentation_id)}",
+            {"fields": _TEXT_FIELDS},
+        )
+        slides = [
+            {
+                "index": i,
+                "objectId": slide.get("objectId"),
+                "text": "".join(
+                    _element_text(el) for el in slide.get("pageElements", [])
+                ),
+            }
+            for i, slide in enumerate(data.get("slides", []))
+        ]
+        return {"ok": True, "title": data.get("title"), "slides": slides}
+
+    if a.cmd == "page":
+        params = {"fields": a.fields} if a.fields else None
+        data = _req_json(
+            f"presentations/{_seg(a.presentation_id)}/pages/{_seg(a.page_object_id)}",
+            params,
+        )
+        return {"ok": True, "page": data}
+
+    if a.cmd == "create":
+        data = _req_json("presentations", method="POST", body={"title": a.title})
+        return {"ok": True, "presentation": data}
+
+    if a.cmd == "add-slide":
+        requests = [
+            {"createSlide": {"slideLayoutReference": {"predefinedLayout": a.layout}}}
+        ]
+        data = _batch_update(a.presentation_id, requests)
+        return {"ok": True, "data": data}
+
+    if a.cmd == "insert-text":
+        requests = [
+            {
+                "insertText": {
+                    "objectId": a.object_id,
+                    "insertionIndex": a.index,
+                    "text": a.text,
+                }
+            }
+        ]
+        data = _batch_update(a.presentation_id, requests)
+        return {"ok": True, "data": data}
+
+    if a.cmd == "replace-text":
+        requests = [
+            {
+                "replaceAllText": {
+                    "containsText": {
+                        "text": a.find,
+                        "matchCase": a.match_case,
+                    },
+                    "replaceText": a.replace,
+                }
+            }
+        ]
+        data = _batch_update(a.presentation_id, requests)
+        return {"ok": True, "data": data}
+
+    # batch-update
+    requests = _load_json_arg(a.requests_json, a.requests_file, "requests")
+    if not isinstance(requests, list):
+        return {"ok": False, "error": "requests_not_array"}
+    data = _batch_update(a.presentation_id, requests)
+    return {"ok": True, "data": data}
+
+
+def _emit(result: dict[str, Any], raw: bool) -> int:
+    print(json.dumps(result if raw else _prune(result)))
+    return 0 if result.get("ok") else 1
+
+
+def main(argv: list[str]) -> int:
+    a = _build_parser().parse_args(argv[1:])
+    try:
+        result = _dispatch(a)
+    except FileNotFoundError as e:
+        print(f"file not found: {e.filename}", file=sys.stderr)
+        return 2
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+    except json.JSONDecodeError as e:
+        print(f"invalid JSON: {e}", file=sys.stderr)
+        return 1
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        print(f"HTTP {e.code} calling Google Slides: {detail}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as e:
+        print(f"network error calling Google Slides: {e.reason}", file=sys.stderr)
+        return 1
+    return _emit(result, a.raw)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/backend/onyx/skills/builtin/google-drive/gslides_api.py
+++ b/backend/onyx/skills/builtin/google-drive/gslides_api.py
@@ -103,7 +103,7 @@ def _element_text(element: dict[str, Any]) -> str:
 
 def _load_json_arg(inline: str | None, file_path: str | None, what: str) -> Any:
     """A JSON payload given inline or via --file (exactly one required)."""
-    if inline and file_path:
+    if inline is not None and file_path is not None:
         raise ValueError(f"pass {what} inline or via --file, not both")
     raw = inline
     if file_path:

--- a/backend/onyx/skills/builtin/google-drive/gslides_api.py
+++ b/backend/onyx/skills/builtin/google-drive/gslides_api.py
@@ -26,12 +26,10 @@ _DEFAULT_GET_FIELDS = (
     "text(textElements(textRun(content)))),"
     "table(rows,columns),image(contentUrl)))"
 )
-# For plain-text extraction: shape text plus table cell text, nothing else.
-_TEXT_FIELDS = (
-    "title,slides(objectId,pageElements(objectId,"
-    "shape(text(textElements(textRun(content)))),"
-    "table(tableRows(tableCells(text(textElements(textRun(content))))))))"
-)
+# For plain-text extraction: full pageElements, because grouped elements nest
+# arbitrarily deep and the fields syntax can't express that recursion. Only
+# the extracted text is emitted, so the larger payload never reaches the LLM.
+_TEXT_FIELDS = "title,slides(objectId,pageElements)"
 
 
 def _prune(value: Any) -> Any:
@@ -88,7 +86,8 @@ def _text_runs(text: dict[str, Any]) -> str:
 
 
 def _element_text(element: dict[str, Any]) -> str:
-    """Plain text of one page element: shape text plus any table cell text."""
+    """Plain text of one page element: shape text, table cell text, and
+    grouped children (recursive)."""
     parts: list[str] = []
     shape_text = element.get("shape", {}).get("text")
     if shape_text:
@@ -97,11 +96,15 @@ def _element_text(element: dict[str, Any]) -> str:
         for cell in row.get("tableCells", []):
             if cell.get("text"):
                 parts.append(_text_runs(cell["text"]))
+    for child in element.get("elementGroup", {}).get("children", []):
+        parts.append(_element_text(child))
     return "".join(parts)
 
 
 def _load_json_arg(inline: str | None, file_path: str | None, what: str) -> Any:
     """A JSON payload given inline or via --file (exactly one required)."""
+    if inline and file_path:
+        raise ValueError(f"pass {what} inline or via --file, not both")
     raw = inline
     if file_path:
         with open(file_path, encoding="utf-8") as fh:
@@ -225,7 +228,9 @@ def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
             {"createSlide": {"slideLayoutReference": {"predefinedLayout": a.layout}}}
         ]
         data = _batch_update(a.presentation_id, requests)
-        return {"ok": True, "data": data}
+        replies = data.get("replies") or [{}]
+        object_id = replies[0].get("createSlide", {}).get("objectId")
+        return {"ok": True, "objectId": object_id, "data": data}
 
     if a.cmd == "insert-text":
         requests = [
@@ -258,7 +263,7 @@ def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
     # batch-update
     requests = _load_json_arg(a.requests_json, a.requests_file, "requests")
     if not isinstance(requests, list):
-        return {"ok": False, "error": "requests_not_array"}
+        raise ValueError("requests must be a JSON array of request objects")
     data = _batch_update(a.presentation_id, requests)
     return {"ok": True, "data": data}
 

--- a/backend/onyx/skills/builtin/google-drive/sheets.md
+++ b/backend/onyx/skills/builtin/google-drive/sheets.md
@@ -1,0 +1,58 @@
+# Google Sheets (`gsheets_api.py`)
+
+Read and **surgically edit spreadsheets** via
+`https://sheets.googleapis.com/v4/`. `gdrive_api.py read` (see
+[drive.md](drive.md)) still exports a Sheet as CSV; the commands here read
+structure, target A1 ranges, and write cells. `<spreadsheet_id>` is the Drive
+file id of the Sheet.
+
+    python .opencode/skills/google-drive/gsheets_api.py <command> [args]
+
+## Read structure and values
+
+```
+python gsheets_api.py get <spreadsheet_id> [--fields ...]
+python gsheets_api.py values <spreadsheet_id> "Sheet1!A1:C10" [--formulas]
+```
+
+`get` lists the sheets (tabs) with their `sheetId` and grid size. `values` takes
+A1 notation; a bare sheet title reads the whole tab.
+
+## Create a spreadsheet (write)
+
+```
+python gsheets_api.py create --title "Budget" [--sheet "Q1" --sheet "Q2"]
+```
+
+To build a Sheet from a produced CSV instead, use `gdrive_api.py upload
+--convert-to application/vnd.google-apps.spreadsheet`.
+
+## Write cell values (write)
+
+```
+python gsheets_api.py update-values <spreadsheet_id> "Sheet1!A1" '[["a","b"],[1,2]]'
+python gsheets_api.py append-values <spreadsheet_id> "Sheet1" '[["new","row"]]'
+python gsheets_api.py clear-values <spreadsheet_id> "Sheet1!A2:B10"
+```
+
+Values are a JSON array of row arrays (`--file values.json` instead of inline).
+Input is parsed like UI entry (numbers, dates, `=SUM(A1:A5)` formulas); pass
+`--raw-input` to store strings verbatim. `append-values` adds rows after the
+last row of the table that contains the given range.
+
+## Structural edits: raw batchUpdate (write)
+
+```
+python gsheets_api.py batch-update <spreadsheet_id> '[<request>, ...]'
+python gsheets_api.py batch-update <spreadsheet_id> --file requests.json
+```
+
+The escape hatch for everything else — a JSON **array** of Sheets API request
+objects (e.g. `addSheet`, `deleteSheet`, `repeatCell`, `mergeCells`,
+`updateBorders`, `autoResizeDimensions`). Requests that target a tab need its
+numeric `sheetId` from `get` (not the tab title).
+
+## Output
+
+`get` / `create` return `{"ok": true, "spreadsheet": {...}}`. `values` and the
+write commands return `{"ok": true, "data": {...}}`.

--- a/backend/onyx/skills/builtin/google-drive/slides.md
+++ b/backend/onyx/skills/builtin/google-drive/slides.md
@@ -1,0 +1,58 @@
+# Google Slides (`gslides_api.py`)
+
+Read and **edit presentations** via `https://slides.googleapis.com/v1/`.
+`gdrive_api.py read` (see [drive.md](drive.md)) still exports a deck as plain
+text; the commands here expose slide/element `objectId`s, which edits target.
+`<presentation_id>` is the Drive file id of the deck.
+
+    python .opencode/skills/google-drive/gslides_api.py <command> [args]
+
+## Read a deck
+
+```
+python gslides_api.py get <presentation_id> [--fields ...]
+python gslides_api.py text <presentation_id>
+python gslides_api.py page <presentation_id> <page_object_id>
+```
+
+`get` returns a compact structure view (slides, element `objectId`s, shape text);
+`text` returns just the plain text per slide; `page` returns one slide in full.
+
+## Create and grow a deck (write)
+
+```
+python gslides_api.py create --title "Roadmap"
+python gslides_api.py add-slide <presentation_id> [--layout TITLE_AND_BODY]
+```
+
+`add-slide` appends a slide with a predefined layout (`BLANK`, `TITLE`,
+`TITLE_AND_BODY`, `SECTION_HEADER`, ...) and returns the new slide's `objectId`.
+
+## Edit text (write)
+
+```
+python gslides_api.py insert-text <presentation_id> <shape_object_id> --text "..."
+python gslides_api.py replace-text <presentation_id> --find "{{name}}" --replace "Ada"
+```
+
+`insert-text` needs a shape `objectId` from `get`. `replace-text` swaps every
+occurrence across the deck — the reliable way to fill placeholder text.
+
+## Raw batchUpdate (write)
+
+```
+python gslides_api.py batch-update <presentation_id> '[<request>, ...]'
+python gslides_api.py batch-update <presentation_id> --file requests.json
+```
+
+The escape hatch for everything else — a JSON **array** of Slides API request
+objects (e.g. `createShape`, `createTable`, `updateTextStyle`, `deleteObject`,
+`updatePageElementTransform`).
+
+## Output
+
+`create` returns `{"ok": true, "presentation": {...}}`; `get` and `page` return
+the same under `"presentation"` / `"page"`. `text` returns `{"ok": true,
+"title", "slides": [{"index", "objectId", "text"}]}`. `add-slide` returns
+`{"ok": true, "objectId": ..., "data": {...}}`; other writes return `{"ok":
+true, "data": {...}}`.

--- a/backend/tests/unit/external_apps/test_google_cloud_scopes.py
+++ b/backend/tests/unit/external_apps/test_google_cloud_scopes.py
@@ -66,9 +66,12 @@ def test_self_hosted_keeps_the_full_catalog(app_type: ExternalAppType) -> None:
 
 
 @pytest.mark.usefixtures("cloud")
-def test_gmail_is_send_only_on_cloud() -> None:
+def test_gmail_cloud_catalog_is_send_and_draft_create() -> None:
+    """`gmail.send` covers sending; the granular `gmail.drafts.create` scope
+    covers draft creation. Everything else needs a restricted scope."""
     assert [e.id for e in get_endpoint_catalog(ExternalAppType.GMAIL)] == [
-        GmailAction.MESSAGES_SEND
+        GmailAction.MESSAGES_SEND,
+        GmailAction.DRAFTS_CREATE,
     ]
 
 

--- a/backend/tests/unit/external_apps/test_google_cloud_scopes.py
+++ b/backend/tests/unit/external_apps/test_google_cloud_scopes.py
@@ -74,8 +74,8 @@ def test_gmail_is_send_only_on_cloud() -> None:
 
 @pytest.mark.usefixtures("cloud")
 def test_drive_drops_only_shared_drive_listing_on_cloud() -> None:
-    """`drive.file` + the Docs API cover the rest of the catalog; only
-    drives.list needs a Drive-wide scope."""
+    """`drive.file` + the Docs/Sheets/Slides APIs cover the rest of the
+    catalog; only drives.list needs a Drive-wide scope."""
     withheld = {
         e.id for e in PROVIDERS[ExternalAppType.GOOGLE_DRIVE].spec.endpoint_catalog
     } - {e.id for e in get_endpoint_catalog(ExternalAppType.GOOGLE_DRIVE)}

--- a/backend/tests/unit/external_apps/test_google_drive_provider.py
+++ b/backend/tests/unit/external_apps/test_google_drive_provider.py
@@ -18,6 +18,8 @@ _READ_ACTIONS = {
     GoogleDriveAction.FILES_EXPORT,
     GoogleDriveAction.DRIVES_READ,
     GoogleDriveAction.DOCS_READ,
+    GoogleDriveAction.SHEETS_READ,
+    GoogleDriveAction.SLIDES_READ,
 }
 
 
@@ -35,15 +37,18 @@ def test_registered_as_managed_drive_provider() -> None:
 
 def test_scope_and_patterns_cover_read_and_upload() -> None:
     spec = _provider().spec
-    # The single `auth/drive` scope also authorizes the Google Docs API. Cloud
-    # requests a narrower scope instead — see test_google_cloud_scopes.py.
+    # The single `auth/drive` scope also authorizes the Docs, Sheets, and Slides
+    # APIs. Cloud requests narrower scopes instead — see
+    # test_google_cloud_scopes.py.
     assert spec.oauth.scope == "https://www.googleapis.com/auth/drive"
     # The /upload host path is required for content uploads to be token-injected;
-    # the Docs API lives on its own `docs.googleapis.com` host.
+    # the Docs, Sheets, and Slides APIs each live on their own host.
     assert spec.descriptor.upstream_url_patterns == [
         "https://www\\.googleapis\\.com/drive/.*",
         "https://www\\.googleapis\\.com/upload/drive/.*",
         "https://docs\\.googleapis\\.com/.*",
+        "https://sheets\\.googleapis\\.com/.*",
+        "https://slides\\.googleapis\\.com/.*",
     ]
     assert spec.descriptor.auth_template == {"Authorization": "Bearer {access_token}"}
 
@@ -90,6 +95,17 @@ def test_catalog_recognises_helper_request_paths() -> None:
         ("GET", "/v1/documents/ABC123"),  # read a Google Doc (Docs API)
         ("POST", "/v1/documents"),  # create a Google Doc
         ("POST", "/v1/documents/ABC123:batchUpdate"),  # edit a Google Doc
+        ("GET", "/v4/spreadsheets/ABC123"),  # sheet structure (Sheets API)
+        ("GET", "/v4/spreadsheets/ABC123/values/Sheet1%21A1%3AC10"),  # read values
+        ("POST", "/v4/spreadsheets"),  # create a spreadsheet
+        ("PUT", "/v4/spreadsheets/ABC123/values/Sheet1%21A1"),  # update values
+        ("POST", "/v4/spreadsheets/ABC123/values/Sheet1:append"),  # append values
+        ("POST", "/v4/spreadsheets/ABC123/values/Sheet1%21A2:clear"),  # clear values
+        ("POST", "/v4/spreadsheets/ABC123:batchUpdate"),  # structural edit
+        ("GET", "/v1/presentations/ABC123"),  # deck structure (Slides API)
+        ("GET", "/v1/presentations/ABC123/pages/p1"),  # one page
+        ("POST", "/v1/presentations"),  # create a presentation
+        ("POST", "/v1/presentations/ABC123:batchUpdate"),  # edit a presentation
     ]
     for method, path in helper_calls:
         matched = [r for r in routes if r[0] == method and path_matches(r[1], path)]


### PR DESCRIPTION
## Description

Two additions to the Google external apps:

### Google Drive: Sheets and Slides (cloud + self-hosted)

**Provider** (`google_drive.py`)
- Six new catalog actions: `gdrive.sheets.read/create/update`, `gdrive.slides.read/create/update`. Reads default to `ALWAYS`; writes default to `ASK`.
- New upstream hosts: `sheets.googleapis.com` and `slides.googleapis.com`. Route templates rely on the existing `{id}` placeholder behavior to also match Google's `ID:batchUpdate` / `RANGE:append` verb suffixes (same as the Docs routes).
- Scopes: self-hosted keeps the single `auth/drive` scope, which already authorizes the Sheets and Slides APIs. Cloud adds `auth/spreadsheets` and `auth/presentations` — both **sensitive**, not restricted, so the OAuth verification posture is unchanged.

**Skill** (`builtin/google-drive/`)
- New self-contained helpers pushed with the skill: `gsheets_api.py` (structure, A1-range values read/write/append/clear, create, raw `batchUpdate`) and `gslides_api.py` (structure/text extraction, create, add-slide, insert/replace text, raw `batchUpdate`).
- `SKILL.md.template` documents both, mirroring the existing Docs API section.

**Migration** (`3350a25df58e`)
- Existing `google_drive` rows snapshot `upstream_url_patterns` at creation, so the migration appends the two new hosts to those rows. Idempotent, with a clean downgrade.

### Gmail: draft creation on cloud

- Cloud scope becomes `gmail.send gmail.drafts.create`; the `gmail.drafts.create` action loses its self-hosted-only flag, so the cloud catalog is now send + create-draft. Self-hosted is unchanged (`gmail.modify` already covers the full draft lifecycle).
- `gmail.drafts.create` is one of Google's new granular Gmail scopes. It is live in the OAuth scope registry — the authorize endpoint accepts it (verified: a fake scope errors with `invalid_scope`, this one proceeds like `gmail.send`) and the Cloud Console scope picker lists it — but the public scope docs and the Gmail discovery document still lag the granular-consent rollout.

### Rollout notes

- The cloud OAuth client needs `auth/spreadsheets`, `auth/presentations`, and `auth/gmail.drafts.create` added on the Google Cloud Console consent screen.
- Before enabling broadly, run a one-time OAuth Playground check that a token carrying only `gmail.drafts.create` is accepted by `POST /gmail/v1/users/me/drafts` (docs lag means method-level enforcement should be confirmed empirically once).
- Connections that predate this change must be reconnected before the new Sheets/Slides/draft calls succeed (old tokens lack the new scopes; the flow already uses `prompt=consent`).
- With granular consent (Jan 2026), users can untick individual scopes at the consent screen; an unticked scope surfaces as a Google 403 on that action only.

## How Has This Been Tested?

- `uv run pytest backend/tests/unit/external_apps backend/tests/unit/onyx/skills` — all green, including the updated route-recognition test asserting each helper request path maps to exactly one catalog action, the cloud-scope tests asserting no cloud scope is restricted, and the new cloud Gmail catalog assertion (send + draft-create).
- Migration run up → down → up against a local Postgres; append verified idempotent on a synthetic `google_drive` row.
- Both helper CLIs smoke-tested (argument parsing, JSON validation paths).
- `gmail.drafts.create` validity probed against Google's live authorize endpoint with valid/fake scope controls.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check