### PR TITLE
fix(craft): surface cloud Google grant limits in rendered skills

### DIFF
--- a/backend/onyx/external_apps/providers/registry.py
+++ b/backend/onyx/external_apps/providers/registry.py
@@ -126,6 +126,18 @@ def get_endpoint_catalog(app_type: ExternalAppType) -> list[EndpointSpec]:
     return list(catalog)
 
 
+def withheld_on_cloud(app_type: ExternalAppType) -> list[EndpointSpec]:
+    """The catalog actions this app cannot offer on cloud, where Onyx's own
+    OAuth client must avoid Google's restricted scopes — every endpoint marked
+    ``requires_self_hosted_scope``. Empty when the deployment uses its own
+    credentials."""
+    if not uses_cloud_scope(app_type):
+        return []
+    # uses_cloud_scope implies the provider is registered.
+    catalog = PROVIDERS[app_type].spec.endpoint_catalog
+    return [e for e in catalog if e.requires_self_hosted_scope]
+
+
 def effective_policy(
     endpoint: EndpointSpec,
     stored: dict[str, EndpointPolicy],

--- a/backend/onyx/skills/builtin/gmail/SKILL.md.template
+++ b/backend/onyx/skills/builtin/gmail/SKILL.md.template
@@ -1,18 +1,33 @@
 ---
 name: gmail
 description: Read, search, send, and draft email from the connected user's Gmail via a light Gmail API wrapper.
+cloud-description: Send email and create drafts from the connected user's Gmail via a light Gmail API wrapper.
 ---
 
 # Gmail
 
 Call the Gmail API as the connected user via the bundled helper.
 
+{{#IF_CLOUD_SCOPE}}
+This deployment's Gmail grant covers sending (`gmail.send`) and creating
+drafts (`gmail.drafts.create`) — nothing else. The helper's other commands
+fail even though `gmail_api.py -h` lists them. Do not offer the unavailable
+actions to the user.
+
+{{/IF_CLOUD_SCOPE}}
 {{ACTION_AVAILABILITY_SECTION}}
 
 ## Usage
 
     python .opencode/skills/gmail/gmail_api.py <command> [args]
 
+{{#IF_CLOUD_SCOPE}}
+Only `send` and `draft-create` are available. Prefer `draft-create` when an
+email needs the user's review. Use `--raw` to skip empty-field pruning;
+`python gmail_api.py <command> -h` shows a command's flags.
+
+{{/IF_CLOUD_SCOPE}}
+{{^IF_CLOUD_SCOPE}}
 Read commands auto-paginate and prune empty fields. The writes are `send`,
 `modify`, `trash`, `draft-create`, `draft-update`, `draft-delete`, and
 `draft-send`; there is no permanent message delete. `me` is always the
@@ -47,6 +62,7 @@ A whole conversation, each message with its decoded plain-text body.
 python gmail_api.py thread <thread_id>
 ```
 
+{{/IF_CLOUD_SCOPE}}
 ### Send a message (write)
 
 ```
@@ -54,6 +70,17 @@ python gmail_api.py send to@x.com "Subject" "Body text" \
     [--cc a@x.com,b@x.com] [--bcc c@x.com]
 ```
 
+### Create a draft (write, not sent)
+
+Saves an email without sending it — the user can review and send it from
+Gmail.
+
+```
+python gmail_api.py draft-create to@x.com "Subject" "Body text" \
+    [--cc a@x.com,b@x.com] [--bcc c@x.com]
+```
+
+{{^IF_CLOUD_SCOPE}}
 ### List labels
 
 ```
@@ -90,14 +117,11 @@ python gmail_api.py drafts [--limit N]
 python gmail_api.py draft <draft_id>
 ```
 
-### Create / update a draft (write, not sent)
+### Update a draft (write, not sent)
 
-Saves an email without sending it — the user can review and send it from Gmail.
 `draft-update` replaces the whole draft.
 
 ```
-python gmail_api.py draft-create to@x.com "Subject" "Body text" \
-    [--cc a@x.com,b@x.com] [--bcc c@x.com]
 python gmail_api.py draft-update <draft_id> to@x.com "Subject" "Body text" \
     [--cc a@x.com,b@x.com] [--bcc c@x.com]
 ```
@@ -122,12 +146,17 @@ message's payload parts (fetch the message first).
 python gmail_api.py attachment <message_id> <attachment_id> --out path/to/file
 ```
 
+{{/IF_CLOUD_SCOPE}}
 ## Output
 
-JSON on stdout. List commands return `{"ok": true, "items": [...], "count": N,
+JSON on stdout.
+{{^IF_CLOUD_SCOPE}}
+List commands return `{"ok": true, "items": [...], "count": N,
 "truncated": bool}` (`truncated` means more results existed past `--limit`).
+{{/IF_CLOUD_SCOPE}}
 Transport errors print to stderr and exit non-zero; Google's error JSON (with
 `code` and `message`) is included.
+{{^IF_CLOUD_SCOPE}}
 
 ## Notes
 
@@ -135,3 +164,4 @@ Transport errors print to stderr and exit non-zero; Google's error JSON (with
   first `text/plain` part is used.
 - Common system label IDs: `INBOX`, `UNREAD`, `STARRED`, `SENT`, `TRASH`,
   `SPAM`, `IMPORTANT`.
+{{/IF_CLOUD_SCOPE}}

--- a/backend/onyx/skills/builtin/google-drive/SKILL.md.template
+++ b/backend/onyx/skills/builtin/google-drive/SKILL.md.template
@@ -1,6 +1,7 @@
 ---
 name: google-drive
 description: Search, read, create, and edit the connected user's Google Drive — including Google Docs, Sheets, and Slides — via light API wrappers.
+cloud-description: Create, upload, and organize Google Drive files, and read or edit any Google Doc, Sheet, or Slides file by id, via light API wrappers.
 ---
 
 # Google Drive
@@ -9,6 +10,27 @@ Call the Google Drive, Docs, Sheets, and Slides APIs as the connected user via
 the bundled helpers. Reads run freely; writes (create / upload / edit / delete)
 may pause for the user to approve.
 
+{{#IF_CLOUD_SCOPE}}
+This deployment's Google Drive grant is per-file (`drive.file`). The Drive
+commands in [drive.md](drive.md) (`search`, `list`, `get`, `read`, `update`,
+`trash`, ...) only see files that Onyx itself created — through these helpers,
+in any session. Everything else in the user's Drive is invisible there, even
+files the user owns. Drive reports an invisible file as **HTTP 404 "File not
+found"** — never 403 — even though it exists. The Docs, Sheets, and Slides
+APIs are not per-file scoped; they reach any file of their type the user can
+open, by id. So:
+
+- For a Docs, Sheets, or Slides link or id, go straight to the per-API helper:
+  `get-doc` ([docs.md](docs.md)), `gsheets_api.py` ([sheets.md](sheets.md)), or
+  `gslides_api.py` ([slides.md](slides.md)) — they work even where
+  `gdrive_api.py read` answers 404.
+- An empty `search` result does not mean the file is absent — it may just be
+  outside the grant.
+- PDFs, folders, and other non-native files not created through Onyx are
+  unreachable; ask the user to attach the file to the session instead of
+  passing a link.
+
+{{/IF_CLOUD_SCOPE}}
 {{ACTION_AVAILABILITY_SECTION}}
 
 > **Path convention**: run helpers from the session workspace as

--- a/backend/onyx/skills/builtin/google-drive/docs.md
+++ b/backend/onyx/skills/builtin/google-drive/docs.md
@@ -15,7 +15,9 @@ python gdrive_api.py get-doc <document_id> [--fields "documentId,body,title"]
 ```
 
 Returns the document's `body.content` with each element's `startIndex` /
-`endIndex`. Use these indices to target edits precisely.
+`endIndex`. Use these indices to target edits precisely. For a tabbed Doc,
+`body` holds only the first tab — pass `--tabs` to get every tab's content
+under `tabs[]`.
 
 ## Insert text at an index (write)
 

--- a/backend/onyx/skills/builtin/google-drive/drive.md
+++ b/backend/onyx/skills/builtin/google-drive/drive.md
@@ -5,7 +5,8 @@ Search, read, upload, organize, and delete files and folders via
 
     python .opencode/skills/google-drive/gdrive_api.py <command> [args]
 
-Read commands auto-paginate and prune empty fields. Add `--shared-drives` to a
+Read commands auto-paginate and prune empty fields. Id arguments also accept
+a full Drive/Docs URL — the id is extracted for you. Add `--shared-drives` to a
 search/list to include shared drives (My Drive only by default).
 
 ## Search files

--- a/backend/onyx/skills/builtin/google-drive/gdrive_api.py
+++ b/backend/onyx/skills/builtin/google-drive/gdrive_api.py
@@ -10,6 +10,7 @@ import argparse
 import json
 import mimetypes
 import os
+import re
 import sys
 import urllib.error
 import urllib.parse
@@ -72,6 +73,24 @@ def _prune(value: Any) -> Any:
 def _seg(value: str) -> str:
     """URL-encode a single path segment (ids may contain special chars)."""
     return urllib.parse.quote(value, safe="")
+
+
+_URL_ID_RE = re.compile(r"/(?:d|folders)/([A-Za-z0-9_-]+)")
+
+
+def _id_arg(value: str) -> str:
+    """Accept a bare id or a Drive/Docs URL — extracts the `/d/<id>` or
+    `/folders/<id>` path segment, or the `?id=` query parameter of share
+    links; agents paste full links."""
+    if "://" not in value:
+        return value
+    match = _URL_ID_RE.search(value)
+    if match:
+        return match.group(1)
+    query = urllib.parse.parse_qs(urllib.parse.urlparse(value).query)
+    if query.get("id"):
+        return query["id"][0]
+    return value
 
 
 def _url(base: str, path: str, params: dict[str, Any] | None = None) -> str:
@@ -139,9 +158,19 @@ def _doc_end_index(doc: dict[str, Any]) -> int:
     return end
 
 
-def _get_doc(document_id: str, fields: str | None = None) -> dict[str, Any]:
-    params = {"fields": fields} if fields else None
-    return _req_docs(f"documents/{_seg(document_id)}", params=params)
+def _get_doc(
+    document_id: str, fields: str | None = None, include_tabs: bool = False
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+    if fields:
+        # A mask without `tabs` would filter out the requested tab content.
+        if include_tabs and "tabs" not in fields:
+            fields += ",tabs"
+        params["fields"] = fields
+    # Without this a tabbed Doc's response `body` holds only the first tab.
+    if include_tabs:
+        params["includeTabsContent"] = "true"
+    return _req_docs(f"documents/{_seg(document_id)}", params=params or None)
 
 
 def _batch_update(document_id: str, requests: list[Any]) -> dict[str, Any]:
@@ -342,7 +371,9 @@ def _build_parser() -> argparse.ArgumentParser:
     sp.add_argument("text", nargs="?", help="free-text query (fullText contains)")
     sp.add_argument("--name", help="filter: name contains")
     sp.add_argument("--mime", help="filter: exact mimeType")
-    sp.add_argument("--in", dest="parent", help="filter: files in this folder id")
+    sp.add_argument(
+        "--in", dest="parent", type=_id_arg, help="filter: files in this folder id"
+    )
     sp.add_argument(
         "--include-trashed",
         dest="include_trashed",
@@ -352,15 +383,15 @@ def _build_parser() -> argparse.ArgumentParser:
     with_common(sp)
 
     sp = sub.add_parser("list", help="list a folder's children")
-    sp.add_argument("folder_id")
+    sp.add_argument("folder_id", type=_id_arg)
     with_common(sp)
 
     sp = sub.add_parser("get", help="one file's metadata")
-    sp.add_argument("file_id")
+    sp.add_argument("file_id", type=_id_arg)
     sp.add_argument("--fields", default=_FILE_FIELDS, help="Drive fields selector")
 
     sp = sub.add_parser("read", help="read a file's contents as text")
-    sp.add_argument("file_id")
+    sp.add_argument("file_id", type=_id_arg)
     sp.add_argument("--mime", help="override export mimeType for native docs")
     sp.add_argument(
         "--max-bytes", dest="max_bytes", type=int, default=_DEFAULT_MAX_BYTES
@@ -372,14 +403,14 @@ def _build_parser() -> argparse.ArgumentParser:
     # --- writes (may prompt for approval) ---
     sp = sub.add_parser("create-folder", help="create a folder (write)")
     sp.add_argument("name")
-    sp.add_argument("--in", dest="parent", help="parent folder id")
+    sp.add_argument("--in", dest="parent", type=_id_arg, help="parent folder id")
 
     sp = sub.add_parser(
         "upload", help="upload a local file as a new Drive file (write)"
     )
     sp.add_argument("path", help="local file path to upload")
     sp.add_argument("--name", help="Drive file name (default: basename)")
-    sp.add_argument("--in", dest="parent", help="parent folder id")
+    sp.add_argument("--in", dest="parent", type=_id_arg, help="parent folder id")
     sp.add_argument("--as", dest="content_type", help="source content-type override")
     sp.add_argument(
         "--convert-to",
@@ -388,21 +419,28 @@ def _build_parser() -> argparse.ArgumentParser:
     )
 
     sp = sub.add_parser("replace", help="replace a file's contents (write)")
-    sp.add_argument("file_id")
+    sp.add_argument("file_id", type=_id_arg)
     sp.add_argument("path", help="local file path with the new contents")
     sp.add_argument("--as", dest="content_type", help="source content-type override")
 
     sp = sub.add_parser("update", help="update a file's metadata (write)")
-    sp.add_argument("file_id")
+    sp.add_argument("file_id", type=_id_arg)
     sp.add_argument("--name", help="new name")
-    sp.add_argument("--add-parent", dest="add_parent", help="folder id to add")
-    sp.add_argument("--remove-parent", dest="remove_parent", help="folder id to remove")
+    sp.add_argument(
+        "--add-parent", dest="add_parent", type=_id_arg, help="folder id to add"
+    )
+    sp.add_argument(
+        "--remove-parent",
+        dest="remove_parent",
+        type=_id_arg,
+        help="folder id to remove",
+    )
 
     sp = sub.add_parser("trash", help="move a file to the trash (write)")
-    sp.add_argument("file_id")
+    sp.add_argument("file_id", type=_id_arg)
 
     sp = sub.add_parser("delete", help="permanently delete a file (destructive)")
-    sp.add_argument("file_id")
+    sp.add_argument("file_id", type=_id_arg)
 
     sp = sub.add_parser("call", help="raw Drive request")
     sp.add_argument("method", choices=("GET", "POST", "PATCH", "PUT", "DELETE"))
@@ -413,18 +451,24 @@ def _build_parser() -> argparse.ArgumentParser:
     sp = sub.add_parser(
         "get-doc", help="get a Google Doc's structure (body content + indices)"
     )
-    sp.add_argument("document_id")
+    sp.add_argument("document_id", type=_id_arg)
     sp.add_argument(
         "--fields",
         help="Docs fields selector, e.g. 'documentId,body,title' "
         "(default: whole document)",
+    )
+    sp.add_argument(
+        "--tabs",
+        action="store_true",
+        help="include every tab's content under tabs[] "
+        "(a tabbed Doc's body holds only the first tab)",
     )
 
     sp = sub.add_parser(
         "batch-update",
         help="apply raw Docs batchUpdate requests to a Doc (write)",
     )
-    sp.add_argument("document_id")
+    sp.add_argument("document_id", type=_id_arg)
     sp.add_argument(
         "requests_json",
         nargs="?",
@@ -438,7 +482,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
 
     sp = sub.add_parser("insert-text", help="insert text at an index in a Doc (write)")
-    sp.add_argument("document_id")
+    sp.add_argument("document_id", type=_id_arg)
     sp.add_argument(
         "--index", type=int, required=True, help="1-based character index to insert at"
     )
@@ -447,7 +491,7 @@ def _build_parser() -> argparse.ArgumentParser:
     sp = sub.add_parser(
         "append-text", help="append text to the end of a Doc's body (write)"
     )
-    sp.add_argument("document_id")
+    sp.add_argument("document_id", type=_id_arg)
     sp.add_argument("--text", required=True, help="text to append")
 
     sp = sub.add_parser("create-doc", help="create a new empty Google Doc (write)")
@@ -527,7 +571,9 @@ def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
 
     # --- Google Docs API ---
     if a.cmd == "get-doc":
-        doc = _get_doc(a.document_id, fields=getattr(a, "fields", None))
+        doc = _get_doc(
+            a.document_id, fields=getattr(a, "fields", None), include_tabs=a.tabs
+        )
         return {"ok": True, "document": doc}
 
     if a.cmd == "batch-update":
@@ -592,7 +638,18 @@ def main(argv: list[str]) -> int:
         return 1
     except urllib.error.HTTPError as e:
         detail = e.read().decode("utf-8", errors="replace")
-        print(f"HTTP {e.code} calling Google Drive: {detail}", file=sys.stderr)
+        url = getattr(e, "url", None) or e.filename or ""
+        is_docs = url.startswith(_DOCS_BASE)
+        api = "Google Docs" if is_docs else "Google Drive"
+        print(f"HTTP {e.code} calling {api}: {detail}", file=sys.stderr)
+        if e.code == 404 and not is_docs:
+            print(
+                "note: Drive answers 404 both for a missing id and for an "
+                "existing file the current grant cannot see. A Google Doc, "
+                "Sheet, or Slides file may still be reachable through its own "
+                "API (get-doc / gsheets_api.py / gslides_api.py).",
+                file=sys.stderr,
+            )
         return 1
     except urllib.error.URLError as e:
         print(f"network error calling Google Drive: {e.reason}", file=sys.stderr)

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -9,10 +9,12 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from onyx.db.enums import GatedAppKind
 from onyx.db.external_app import (
     get_connectable_apps_for_user,
     get_external_app_by_skill_id,
 )
+from onyx.db.gated_app import get_action_policies
 from onyx.db.models import Skill, User
 from onyx.db.skill import (
     SkillValidityUpdate,
@@ -116,12 +118,13 @@ def _render_template(
     app_type = EXTERNAL_APP_SKILL_ID_TO_APP_TYPE.get(definition.built_in_skill_id)
     if app_type is not None:
         external_app = get_external_app_by_skill_id(db_session, skill.id)
-        rendered = render_external_app_skill(
-            db_session,
-            app_type,
-            external_app,
-            definition.source_dir,
+        stored = (
+            get_action_policies(db_session, GatedAppKind.EXTERNAL_APP, external_app.id)
+            if external_app
+            else {}
         )
+        template = (definition.source_dir / "SKILL.md.template").read_text()
+        rendered = render_external_app_skill(template, app_type, stored)
         files[f"{skill.name}/SKILL.md"] = rendered.encode("utf-8")
         return
 

--- a/backend/onyx/skills/rendering.py
+++ b/backend/onyx/skills/rendering.py
@@ -1,5 +1,6 @@
 """Render dynamic skill templates for the per-user skills fileset."""
 
+import re
 from pathlib import Path
 
 from sqlalchemy.orm import Session
@@ -7,15 +8,33 @@ from sqlalchemy.orm import Session
 from onyx.configs.constants import DocumentSource, DocumentSourceDescription
 from onyx.db.connector import _INTERNAL_ONLY_SOURCES
 from onyx.db.connector_credential_pair import get_connector_credential_pairs_for_user
-from onyx.db.enums import EndpointPolicy, ExternalAppType, GatedAppKind
-from onyx.db.gated_app import get_action_policies
-from onyx.db.models import ExternalApp, User
-from onyx.external_apps.providers.registry import action_policy_views
+from onyx.db.enums import EndpointPolicy, ExternalAppType
+from onyx.db.models import User
+from onyx.external_apps.providers.registry import (
+    action_policy_views,
+    uses_cloud_scope,
+    withheld_on_cloud,
+)
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
 ACTION_AVAILABILITY_PLACEHOLDER = "{{ACTION_AVAILABILITY_SECTION}}"
+
+# ``{{#IF_CLOUD_SCOPE}}`` blocks render only on cloud (``uses_cloud_scope``);
+# ``{{^IF_CLOUD_SCOPE}}`` (mustache-style inverted) only elsewhere. Markers
+# sit on their own lines; blocks cannot nest.
+_CLOUD_SCOPE_BLOCK_RE = re.compile(
+    r"\{\{([#^])IF_CLOUD_SCOPE\}\}\n(.*?)\{\{/IF_CLOUD_SCOPE\}\}\n", re.DOTALL
+)
+
+# On cloud, `cloud-description:` replaces the frontmatter `description:` that
+# skill discovery reads. Pre-render it is ordinary extra frontmatter
+# (SkillMetadata is extra="allow"); the rendered SKILL.md never carries it.
+_CLOUD_DESCRIPTION_RE = re.compile(
+    r"^cloud-description:[ \t]*(\S[^\n]*)\n", re.MULTILINE
+)
+_DESCRIPTION_RE = re.compile(r"^description:[^\n]*\n", re.MULTILINE)
 
 
 def build_available_sources_section(
@@ -82,44 +101,58 @@ def build_action_availability_section(
     app_type: ExternalAppType,
     stored: dict[str, EndpointPolicy],
 ) -> str:
-    """Render the warning listing the app's ``DENY`` (unavailable) actions, or an
-    empty string when nothing is disabled. Available actions are intentionally
-    omitted — the skill body already documents what the agent can do; this only
-    fences off what it must not attempt.
-
-    ``stored`` is the app's per-action overrides; an empty map falls back to the
-    catalog defaults.
-    """
-    disabled = [
-        f"- {view.normalised_name}"
+    """The warning listing the app's unavailable actions — cloud-withheld plus
+    the ``DENY`` entries from ``stored`` (the admin's per-action overrides) —
+    or "" when none apply. Available actions are omitted: the skill body
+    already documents those."""
+    # Cloud-withheld actions never reach the filtered catalog, so the DENY
+    # loop below can't see them.
+    unavailable: list[str] = [
+        endpoint.normalised_name for endpoint in withheld_on_cloud(app_type)
+    ]
+    unavailable.extend(
+        view.normalised_name
         for view in action_policy_views(app_type, stored)
         if view.state == EndpointPolicy.DENY
-    ]
-    if not disabled:
+    )
+    if not unavailable:
         return ""
     header = "These actions are unavailable and should not be attempted:"
-    return "\n".join([header, "", *disabled])
+    return "\n".join([header, "", *(f"- {name}" for name in unavailable)])
 
 
 def render_external_app_skill(
-    db_session: Session,
+    template: str,
     app_type: ExternalAppType,
-    external_app: ExternalApp | None,
-    skill_dir: Path,
+    stored: dict[str, EndpointPolicy],
 ) -> str:
-    """Render an external-app SKILL.md with its per-user action availability.
+    """Pure template rendering for an external-app SKILL.md: apply the cloud
+    description override, resolve the cloud-scope blocks, then fill the
+    action-availability placeholder."""
+    is_cloud = uses_cloud_scope(app_type)
 
-    ``skill_dir`` is the skill's on-disk directory (holds ``SKILL.md.template``).
-    """
-    template = (skill_dir / "SKILL.md.template").read_text()
-    stored = (
-        get_action_policies(db_session, GatedAppKind.EXTERNAL_APP, external_app.id)
-        if external_app
-        else {}
-    )
+    cloud_description = _CLOUD_DESCRIPTION_RE.search(template)
+    if cloud_description:
+        template = _CLOUD_DESCRIPTION_RE.sub("", template, count=1)
+        if is_cloud:
+            replacement = f"description: {cloud_description.group(1)}\n"
+            template = _DESCRIPTION_RE.sub(lambda _: replacement, template, count=1)
+
+    def _resolve_block(match: re.Match[str]) -> str:
+        # Keep a block whose condition matches (markers stripped); drop the rest.
+        keep = (match.group(1) == "#") == is_cloud
+        return match.group(2) if keep else ""
+
+    template = _CLOUD_SCOPE_BLOCK_RE.sub(_resolve_block, template)
     section = build_action_availability_section(app_type, stored)
     if section:
-        return template.replace(ACTION_AVAILABILITY_PLACEHOLDER, section)
-    # Nothing disabled: drop the placeholder and its trailing blank line so the
-    # surrounding sections stay flush.
-    return template.replace(f"{ACTION_AVAILABILITY_PLACEHOLDER}\n\n", "")
+        rendered = template.replace(ACTION_AVAILABILITY_PLACEHOLDER, section)
+    else:
+        # Nothing disabled: drop the placeholder and its trailing blank line so
+        # the surrounding sections stay flush.
+        rendered = template.replace(f"{ACTION_AVAILABILITY_PLACEHOLDER}\n\n", "")
+    if "{{" in rendered:
+        # Fail loudly rather than ship unresolved markup to the agent.
+        offending = next(line for line in rendered.splitlines() if "{{" in line)
+        raise ValueError(f"Unresolved skill-template markup: {offending!r}")
+    return rendered

--- a/backend/tests/unit/external_apps/test_gdrive_api_helper.py
+++ b/backend/tests/unit/external_apps/test_gdrive_api_helper.py
@@ -1,6 +1,7 @@
-"""The bundled ``gdrive_api.py`` sandbox helper: Drive ``q`` construction and the
-native-export-vs-raw-download branch in ``read``. The helper is a standalone
-script under the skills dir (not an importable package), so load it by path."""
+"""The bundled ``gdrive_api.py`` sandbox helper: Drive ``q`` construction, the
+native-export-vs-raw-download branch in ``read``, URL-tolerant id arguments,
+and the Docs tab flags. The helper is a standalone script under the skills dir
+(not an importable package), so load it by path."""
 
 from __future__ import annotations
 
@@ -9,6 +10,8 @@ import importlib.util
 from pathlib import Path
 from types import ModuleType
 from typing import Any
+
+import pytest
 
 _HELPER = (
     Path(__file__).resolve().parents[3]
@@ -397,3 +400,103 @@ def test_create_doc_posts_title(monkeypatch: Any) -> None:
     assert captured["method"] == "POST"
     assert captured["body"] == {"title": "My Doc"}
     assert result["document"]["documentId"] == "NEW"
+
+
+# --- id arguments and get-doc flags ---
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (
+            "https://docs.google.com/document/d/1TestDocId_-abc123/edit?tab=t.0",
+            "1TestDocId_-abc123",
+        ),
+        (
+            "https://drive.google.com/drive/folders/0ATestFolderId9Uk9PVA",
+            "0ATestFolderId9Uk9PVA",
+        ),
+        # Query-param share form and the multi-account path form.
+        ("https://drive.google.com/open?id=1TestDocId_-abc123", "1TestDocId_-abc123"),
+        (
+            "https://drive.google.com/uc?export=download&id=1TestDocId_-abc123",
+            "1TestDocId_-abc123",
+        ),
+        (
+            "https://docs.google.com/document/u/0/d/1TestDocId_-abc123/edit",
+            "1TestDocId_-abc123",
+        ),
+        ("1BareTestId_-xyz789", "1BareTestId_-xyz789"),
+        ("https://example.com/no-id-here", "https://example.com/no-id-here"),
+    ],
+)
+def test_id_arg_accepts_urls_and_bare_ids(value: str, expected: str) -> None:
+    assert gdrive._id_arg(value) == expected
+
+
+def test_get_doc_tabs_flag_requests_tab_content(monkeypatch: Any) -> None:
+    calls: list[tuple[str, dict[str, Any] | None]] = []
+    monkeypatch.setattr(
+        gdrive,
+        "_req_docs",
+        lambda path, params=None, **_kwargs: calls.append((path, params)) or {},
+    )
+
+    args = gdrive._build_parser().parse_args(
+        ["get-doc", "https://docs.google.com/document/d/D1/edit", "--tabs"]
+    )
+    gdrive._dispatch(args)
+
+    assert calls[0][0] == "documents/D1"  # id extracted from the pasted URL
+    assert calls[0][1] == {"includeTabsContent": "true"}
+
+
+_ID_DESTS = {
+    "file_id",
+    "document_id",
+    "folder_id",
+    "parent",
+    "add_parent",
+    "remove_parent",
+}
+
+
+def test_every_id_argument_normalizes_urls() -> None:
+    """Every id-shaped argument must opt into URL extraction — the `update`
+    parent flags shipped without it once, so sweep the whole parser instead of
+    pinning individual flags."""
+    parser = gdrive._build_parser()
+    subparsers = next(
+        a for a in parser._actions if isinstance(a, argparse._SubParsersAction)
+    )
+    missing = [
+        f"{command} --{action.dest}"
+        for command, sub in subparsers.choices.items()
+        for action in sub._actions
+        if action.dest in _ID_DESTS and action.type is not gdrive._id_arg
+    ]
+    assert missing == []
+
+
+@pytest.mark.parametrize(
+    "fields,expected",
+    [
+        # A mask without `tabs` would filter out the content includeTabsContent asks for.
+        ("documentId,title", "documentId,title,tabs"),
+        # A mask that already selects tabs must not grow a duplicate.
+        ("documentId,tabs", "documentId,tabs"),
+    ],
+)
+def test_get_doc_tabs_extends_a_caller_field_mask(
+    monkeypatch: Any, fields: str, expected: str
+) -> None:
+    calls: list[dict[str, Any] | None] = []
+    monkeypatch.setattr(
+        gdrive,
+        "_req_docs",
+        lambda _path, params=None, **_kwargs: calls.append(params) or {},
+    )
+
+    gdrive._get_doc("D1", fields=fields, include_tabs=True)
+
+    assert calls[0] == {"fields": expected, "includeTabsContent": "true"}

--- a/backend/tests/unit/external_apps/test_google_cloud_scopes.py
+++ b/backend/tests/unit/external_apps/test_google_cloud_scopes.py
@@ -1,16 +1,19 @@
 """The cloud/self-hosted scope split for the Google providers: the cloud scope
-stays clear of Google's restricted tier, and the catalog it exposes never
-outruns it."""
+stays clear of Google's restricted tier, the catalog it exposes never outruns
+it, and the SKILL.md rendered under it surfaces the withheld actions and
+per-grant caveats."""
 
 from __future__ import annotations
 
 import pytest
 
-from onyx.db.enums import ExternalAppType
+from onyx.db.enums import EndpointPolicy, ExternalAppType
 from onyx.external_apps.providers import gmail, google_calendar, google_drive, registry
 from onyx.external_apps.providers.gmail import GmailAction
 from onyx.external_apps.providers.google_drive import GoogleDriveAction
 from onyx.external_apps.providers.registry import PROVIDERS, get_endpoint_catalog
+from onyx.skills.built_in import BUILTIN_SKILLS_PATH
+from onyx.skills.rendering import render_external_app_skill
 
 # Requesting any of these subjects the OAuth client to an annual third-party
 # security assessment: https://support.google.com/cloud/answer/13464325
@@ -92,3 +95,95 @@ def test_calendar_catalog_survives_on_cloud() -> None:
         get_endpoint_catalog(ExternalAppType.GOOGLE_CALENDAR)
         == PROVIDERS[ExternalAppType.GOOGLE_CALENDAR].spec.endpoint_catalog
     )
+
+
+# --- Skill-facing cloud-scope caveats ---
+# The rendered SKILL.md must surface what the narrowed cloud grant changes:
+# the {{#IF_CLOUD_SCOPE}} note carries the why/guidance, and the unavailable
+# list carries the withheld actions (nothing else surfaces them — they are
+# filtered out of the catalog).
+
+_SKILL_TEMPLATES = {
+    ExternalAppType.GOOGLE_DRIVE: "google-drive",
+    ExternalAppType.GMAIL: "gmail",
+}
+
+
+def _render_skill(
+    app_type: ExternalAppType,
+    stored: dict[str, EndpointPolicy] | None = None,
+) -> str:
+    template = (
+        BUILTIN_SKILLS_PATH / _SKILL_TEMPLATES[app_type] / "SKILL.md.template"
+    ).read_text()
+    return render_external_app_skill(template, app_type, stored or {})
+
+
+@pytest.mark.usefixtures("cloud")
+def test_drive_skill_warns_about_per_file_grant_on_cloud() -> None:
+    rendered = _render_skill(ExternalAppType.GOOGLE_DRIVE)
+    assert "drive.file" in rendered
+    assert "get-doc" in rendered
+    # DRIVES_READ is withheld on cloud; it must be listed, not silently absent.
+    assert "- List shared drives" in rendered
+    # Discovery must not promise Drive-wide search on cloud.
+    assert "description: Create, upload, and organize" in rendered
+    assert "cloud-description" not in rendered
+
+
+@pytest.mark.usefixtures("cloud")
+def test_gmail_skill_is_send_and_draft_create_on_cloud() -> None:
+    rendered = _render_skill(ExternalAppType.GMAIL)
+    assert "gmail.send" in rendered
+    # Withheld actions are fenced off in the unavailable list...
+    assert "- Read messages" in rendered
+    assert "- Update a draft" in rendered
+    # ...and their usage docs are not rendered at all.
+    assert "### Send a message (write)" in rendered
+    assert "### List / search messages" not in rendered
+    assert "draft-update" not in rendered
+    assert "### Download an attachment" not in rendered
+    # Surviving actions are not fenced, and draft-create is documented.
+    assert "- Send a message" not in rendered
+    assert "- Create a draft" not in rendered
+    assert "### Create a draft (write, not sent)" in rendered
+    # Skill discovery reads the description: it must not advertise reads.
+    assert "description: Send email and create drafts" in rendered
+    assert "Read, search" not in rendered
+    assert "cloud-description" not in rendered
+
+
+def test_gmail_skill_documents_everything_self_hosted() -> None:
+    rendered = _render_skill(ExternalAppType.GMAIL)
+    assert "### List / search messages" in rendered
+    assert "### Update a draft (write, not sent)" in rendered
+    assert "### Download an attachment" in rendered
+    assert "description: Read, search, send, and draft email" in rendered
+    assert "cloud-description" not in rendered
+
+
+@pytest.mark.usefixtures("cloud")
+def test_cloud_note_precedes_the_unavailable_list_with_deny_merged() -> None:
+    """An admin DENY must not displace the cloud note (or vice versa): the note
+    renders first, and the unavailable list carries both the withheld action
+    and the DENY override."""
+    rendered = _render_skill(
+        ExternalAppType.GOOGLE_DRIVE,
+        {GoogleDriveAction.FILES_CREATE: EndpointPolicy.DENY},
+    )
+    assert rendered.index("drive.file") < rendered.index(
+        "These actions are unavailable"
+    )
+    assert "- List shared drives" in rendered
+    assert "- Create or upload a file" in rendered
+
+
+@pytest.mark.parametrize(
+    "app_type", [ExternalAppType.GOOGLE_DRIVE, ExternalAppType.GMAIL]
+)
+def test_self_hosted_skill_has_no_cloud_caveats(app_type: ExternalAppType) -> None:
+    rendered = _render_skill(app_type)
+    assert "drive.file" not in rendered
+    assert "Create, upload, and organize" not in rendered
+    assert "gmail.drafts.create" not in rendered
+    assert "These actions are unavailable" not in rendered


### PR DESCRIPTION
## Description

On managed cloud, the Google external apps connect with narrowed OAuth scopes. Drive's grant is per-file (`drive.file`): the user's real Drive is invisible to Drive endpoints, and Google masks that as **404 "File not found"** — never 403. Investigated in prod session `995a7fb3` ("Google Doc Access Check"): the agent got 404s on a pasted Docs link and nothing told it why. Gmail has the same class of problem — its cloud grant covers only send + draft creation, but the skill documented every read/draft command and advertised them in its discovery description.

This PR makes the rendered skills tell the truth per deployment:

- **Conditional SKILL.md template blocks**: `{{#IF_CLOUD_SCOPE}}` / `{{^IF_CLOUD_SCOPE}}` (mustache-style inverted), resolved by `uses_cloud_scope()` at render time. Drive's hub gains a cloud-only note explaining the per-file grant, the 404 masking, and routing to the per-API helpers (`get-doc`, `gsheets_api.py`, `gslides_api.py`, which are not per-file scoped). Gmail's cloud render documents only `send` and `draft-create` and drops the dead read/draft sections entirely. A `cloud-description:` frontmatter key swaps in an accurate discovery description on cloud. Rendering raises if any unresolved `{{` markup survives, so template typos fail in CI instead of shipping into the model's instructions.
- **Data-derived unavailable list**: new `registry.withheld_on_cloud()` — the actions `get_endpoint_catalog()` drops on cloud — feeds the skill's "unavailable actions" section alongside admin DENYs, so the fence derives from the catalog flag and cannot drift from the actual scope decision. (It auto-corrected when #13928 un-withheld Gmail draft creation.)
- **Actionable failure**: `gdrive_api.py` prints a note on Drive 404s (host-gated so Docs-API 404s aren't misattributed) saying the file may exist outside the grant and naming the per-API helpers as the way in.
- **Input tolerance**: all `gdrive_api.py` id arguments accept full Drive/Docs URLs (agents paste links), and `get-doc --tabs` fetches every tab of a tabbed Doc (`body` otherwise holds only the first tab).

Deliberately **not** included: an automatic Docs-API fallback inside `read`/`get` (an earlier revision had one). With accurate instructions and an actionable error, a fallback that mutates the command's output contract (markdown vs flattened text, ignored `--mime`/`--fields`) and heals only Docs is redundant complexity — the per-API helpers are the recovery path.

No OAuth scope changes.

## How Has This Been Tested?

- `backend/tests/unit/external_apps/test_google_cloud_scopes.py`: renders the real templates in both modes — cloud surfaces the grant caveats, the withheld actions (Gmail's 11, Drive's "List shared drives"), the send+draft-create Gmail view, and the swapped description; self-hosted renders the full docs with no cloud artifacts or marker leaks; admin DENYs merge with the withheld list.
- `backend/tests/unit/external_apps/test_gdrive_api_helper.py`: URL-tolerant id extraction and `get-doc --tabs`.
- Full `tests/unit/external_apps` + `tests/unit/onyx/skills` suites and pre-commit green; all four template/mode renders verified for blank-line hygiene and unresolved-markup.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check