### PR TITLE
fix(chat): accept incognito attachments before the first message

### DIFF
--- a/backend/onyx/chat/incognito_context.py
+++ b/backend/onyx/chat/incognito_context.py
@@ -87,6 +87,10 @@ def _context_key(chat_session_id: UUID) -> str:
     return f"{_KEY_PREFIX}:{chat_session_id}"
 
 
+def _stored_context(chat_session_id: UUID) -> bytes | None:
+    return get_redis_client().get(_context_key(chat_session_id))
+
+
 def _parse_version_prefix(raw: bytes) -> tuple[int, bytes | None]:
     """The value's version and JSON body, or (0, None) for a tombstone or a
     value this store did not write.
@@ -107,7 +111,7 @@ def load_incognito_context(chat_session_id: UUID) -> IncognitoContext:
     value expired, or its body failed to parse. The turn proceeds with whatever
     loads: missing context is degraded recall, never an error.
     """
-    raw = get_redis_client().get(_context_key(chat_session_id))
+    raw = _stored_context(chat_session_id)
     if raw is None:
         return IncognitoContext(version=0, messages=[])
 
@@ -184,9 +188,22 @@ def append_incognito_message(chat_session_id: UUID, message: ChatMessageSimple) 
         )
 
 
+def incognito_session_torn_down(chat_session_id: UUID) -> bool:
+    """Whether this session's teardown tombstone is still present.
+
+    A session holds no context until its first message, so absence is not an
+    answer. Callers deciding whether to accept new work must use this.
+    """
+    return _stored_context(chat_session_id) == _TOMBSTONE
+
+
 def incognito_session_ended(chat_session_id: UUID) -> bool:
-    """Whether the live context is gone, by teardown or by expiry."""
-    raw = get_redis_client().get(_context_key(chat_session_id))
+    """Whether the live context is gone, by teardown or by expiry.
+
+    Absence counts, so a session that has not written its first message reads
+    as ended. Only for callers that have already ruled that out.
+    """
+    raw = _stored_context(chat_session_id)
     return raw is None or raw == _TOMBSTONE
 
 

--- a/backend/onyx/server/features/projects/api.py
+++ b/backend/onyx/server/features/projects/api.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
 from onyx.chat.incognito import incognito_allowed_for_user
-from onyx.chat.incognito_context import incognito_session_ended
+from onyx.chat.incognito_context import incognito_session_torn_down
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.constants import (
     PUBLIC_API_TAGS,
@@ -164,9 +164,8 @@ def upload_user_files(
                 "Incognito chat is not enabled for this user.",
             )
         # Teardown marks the rows that exist when it runs, so an upload landing
-        # after it would otherwise sit until the orphan sweep. The tombstone is
-        # durable, which makes this the point where that race is settled.
-        if incognito_session_ended(incognito_session_id):
+        # after it would otherwise sit until the orphan sweep.
+        if incognito_session_torn_down(incognito_session_id):
             raise OnyxError(
                 OnyxErrorCode.INVALID_INPUT,
                 "This incognito chat has ended.",
@@ -198,7 +197,7 @@ def upload_user_files(
         # Re-check after the rows exist. The tombstone is monotonic, so a
         # teardown that landed during the upload is caught here even though the
         # pre-check passed, which is what the marking query alone would miss.
-        if incognito_session_id is not None and incognito_session_ended(
+        if incognito_session_id is not None and incognito_session_torn_down(
             incognito_session_id
         ):
             mark_incognito_user_files_deleting(

--- a/backend/tests/unit/onyx/chat/test_incognito_liveness_predicates.py
+++ b/backend/tests/unit/onyx/chat/test_incognito_liveness_predicates.py
@@ -1,0 +1,46 @@
+"""Guards the split between "never started" and "explicitly ended".
+
+A session holds no context until its first message, so absence and teardown
+look identical in Redis. Anything deciding whether to accept new work must read
+only the tombstone, or attaching a file before sending the first message is
+rejected as an ended chat.
+"""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from onyx.chat.incognito_context import (
+    _TOMBSTONE,
+    incognito_session_ended,
+    incognito_session_torn_down,
+)
+
+MODULE = "onyx.chat.incognito_context"
+LIVE_CONTEXT = b"1:[]"
+
+
+def _with_stored(value: bytes | None) -> MagicMock:
+    client = MagicMock()
+    client.get.return_value = value
+    return client
+
+
+@pytest.mark.parametrize(
+    "stored, torn_down, ended",
+    [
+        # Absence is the one row where the two predicates disagree, and the
+        # reason a guard cannot be built on `ended`.
+        (None, False, True),
+        (_TOMBSTONE, True, True),
+        (LIVE_CONTEXT, False, False),
+    ],
+    ids=["no_context_yet", "tombstoned", "live"],
+)
+def test_liveness_predicates_split_on_absence(
+    stored: bytes | None, torn_down: bool, ended: bool
+) -> None:
+    with patch(f"{MODULE}.get_redis_client", return_value=_with_stored(stored)):
+        assert incognito_session_torn_down(uuid4()) is torn_down
+        assert incognito_session_ended(uuid4()) is ended

--- a/backend/tests/unit/onyx/server/test_incognito_upload_guard.py
+++ b/backend/tests/unit/onyx/server/test_incognito_upload_guard.py
@@ -1,0 +1,90 @@
+"""Guards which incognito sessions the upload endpoint accepts files for.
+
+The guard must read the teardown tombstone alone, since an absent context key
+means the session is new: switching incognito on mints the id client-side, so
+uploads arrive naming a session that holds no context until its first message.
+"""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import BackgroundTasks
+
+from onyx.chat.incognito_context import _TOMBSTONE
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.projects.api import upload_user_files
+
+MODULE = "onyx.server.features.projects.api"
+CONTEXT_MODULE = "onyx.chat.incognito_context"
+# No context key exists until the first message of a session is sent.
+NO_CONTEXT_YET = None
+
+
+def _upload(
+    *,
+    stored_before: bytes | None = NO_CONTEXT_YET,
+    stored_after: bytes | None = NO_CONTEXT_YET,
+    allowed: bool = True,
+    expect_upload: bool = True,
+) -> MagicMock:
+    """Runs the endpoint against a fresh incognito session id and returns the
+    marking helper, so the caller can assert whether cleanup was queued.
+
+    *stored_before* and *stored_after* are what Redis holds for the context key
+    on the pre-check and the post-check. Driving the store rather than the
+    predicate keeps the assertion on which verdict the endpoint asks for.
+    """
+    redis_client = MagicMock()
+    redis_client.get.side_effect = [stored_before, stored_after]
+    with (
+        patch(f"{MODULE}.incognito_allowed_for_user", return_value=allowed),
+        patch(f"{CONTEXT_MODULE}.get_redis_client", return_value=redis_client),
+        patch(f"{MODULE}.upload_files_to_user_files_with_indexing") as upload_impl,
+        patch(f"{MODULE}.mark_incognito_user_files_deleting") as mark,
+        patch(f"{MODULE}.CategorizedFilesSnapshot"),
+    ):
+        try:
+            upload_user_files(
+                bg_tasks=BackgroundTasks(),
+                files=[],
+                project_id=None,
+                temp_id_map=None,
+                incognito_session_id=uuid4(),
+                user=MagicMock(id=uuid4()),
+                db_session=MagicMock(),
+            )
+        finally:
+            # In a finally so a refused upload still asserts nothing was
+            # written. A guard moved below the write would pass otherwise.
+            assert upload_impl.call_count == (1 if expect_upload else 0)
+    return mark
+
+
+def test_a_session_that_has_sent_no_message_yet_accepts_the_upload() -> None:
+    mark = _upload()
+
+    mark.assert_not_called()
+
+
+def test_an_upload_racing_teardown_is_queued_for_deletion() -> None:
+    """The pre-check passed and the tombstone landed mid-upload, so the rows
+    exist and the post-check is what catches them."""
+    mark = _upload(stored_after=_TOMBSTONE)
+
+    mark.assert_called_once()
+
+
+def test_an_upload_into_an_ended_session_never_writes_a_row() -> None:
+    with pytest.raises(OnyxError) as raised:
+        _upload(stored_before=_TOMBSTONE, expect_upload=False)
+
+    assert raised.value.error_code is OnyxErrorCode.INVALID_INPUT
+
+
+def test_a_user_without_incognito_is_refused() -> None:
+    with pytest.raises(OnyxError) as raised:
+        _upload(allowed=False, expect_upload=False)
+
+    assert raised.value.error_code is OnyxErrorCode.UNAUTHORIZED


### PR DESCRIPTION
## Description

Attaching a file to a new incognito chat silently failed until the first message was sent.

An incognito session's context key is only written once the first message is sent. `incognito_session_ended()` is true when that key is missing as well as when it holds the teardown tombstone, and the upload endpoint used it as its guard, so every attachment made before the first message was rejected as an ended chat.

Adds `incognito_session_torn_down()`, true only for the tombstone, and uses it for the upload pre-check and post-check. The cleanup sweeps keep `incognito_session_ended()`, where counting absence is right because they only reach sessions already ruled out as new.

The tombstone carries a one-hour TTL, so an upload arriving more than an hour after teardown passes the guard and its files are queued by the orphan sweep instead.

## How Has This Been Tested?

Reproduced on st-dev before the fix: toggling incognito and attaching a PNG produced no chip, and the api pod logged `INVALID_INPUT: This incognito chat has ended` with a 400 on `POST /user/projects/file/upload` for a session never ended. Confirmed against real Redis that a session with no context reads as not torn down, while a tombstoned one still does.

Unit tests for both predicates across all three stored states, and for the endpoint accepting a pre-first-message upload, refusing a tombstoned one without writing a row, and queueing cleanup when teardown races the upload. Both fail against the old predicate.

`ruff check`, `ruff format --check`, `ty check`, and the `backend/tests/unit/onyx/chat` and `onyx/server` suites.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
