### PR TITLE
refactor(chat): collapse the incognito sweep and unify the delete path

### DIFF
--- a/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
@@ -16,13 +16,11 @@ from onyx.background.celery.celery_redis import (
 )
 from onyx.background.celery.celery_utils import httpx_init_vespa_pool
 from onyx.background.celery.tasks.shared.RetryDocumentIndex import RetryDocumentIndex
-from onyx.cache.factory import get_cache_backend
-from onyx.chat.chat_processing_checker import is_chat_session_processing
+from onyx.background.task_utils import send_user_file_delete_task
 from onyx.chat.incognito import (
-    delete_incognito_generated_files,
+    sweep_incognito_generated_files,
     sweep_stale_incognito_user_files,
 )
-from onyx.chat.incognito_context import incognito_session_ended
 from onyx.configs.app_configs import (
     DISABLE_VECTOR_DB,
     MANAGED_VESPA,
@@ -36,7 +34,6 @@ from onyx.configs.constants import (
     CELERY_USER_FILE_PROCESSING_TASK_EXPIRES,
     CELERY_USER_FILE_PROJECT_SYNC_LOCK_TIMEOUT,
     CELERY_USER_FILE_PROJECT_SYNC_TASK_EXPIRES,
-    INCOGNITO_FILE_CLEANUP_BATCH,
     USER_FILE_DELETE_MAX_QUEUE_DEPTH,
     USER_FILE_PROCESSING_MAX_QUEUE_DEPTH,
     USER_FILE_PROJECT_SYNC_MAX_QUEUE_DEPTH,
@@ -50,7 +47,6 @@ from onyx.connectors.file.connector import LocalFileConnector
 from onyx.connectors.models import Document, HierarchyNode
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import UserFileStatus
-from onyx.db.file_record import get_session_ids_with_incognito_files
 from onyx.db.models import SearchSettings, UserFile
 from onyx.db.port_attempt import port_backfill_has_pending_work
 from onyx.db.port_orphan_candidate import record_port_orphan_candidates_for_user_file
@@ -813,10 +809,12 @@ def check_for_user_file_delete(self: Task, *, tenant_id: str) -> None:
             # Orphaned incognito uploads (teardown never arrived) join the
             # DELETING pool here so the standard machinery below cleans them.
             stale_incognito = sweep_stale_incognito_user_files(db_session)
+            # Always: the sweep also restarts the orphan clock on sessions it
+            # found live, which is lost if only a queued file triggers this.
+            db_session.commit()
             if stale_incognito:
-                db_session.commit()
                 task_logger.info(
-                    f"check_for_user_file_delete - Queued {stale_incognito} "
+                    f"check_for_user_file_delete - Queued {len(stale_incognito)} "
                     f"stale incognito files for tenant={tenant_id}"
                 )
             user_file_ids = (
@@ -843,16 +841,7 @@ def check_for_user_file_delete(self: Task, *, tenant_id: str) -> None:
 
                 # --- Protection 3: task expiry ---
                 try:
-                    self.app.send_task(
-                        OnyxCeleryTask.DELETE_SINGLE_USER_FILE,
-                        kwargs={
-                            "user_file_id": str(user_file_id),
-                            "tenant_id": tenant_id,
-                        },
-                        queue=OnyxCeleryQueues.USER_FILE_DELETE,
-                        priority=OnyxCeleryPriority.HIGH,
-                        expires=CELERY_USER_FILE_DELETE_TASK_EXPIRES,
-                    )
+                    send_user_file_delete_task(self.app, user_file_id, tenant_id)
                 except Exception:
                     redis_client.delete(queued_key)
                     raise
@@ -1253,24 +1242,7 @@ def check_for_incognito_file_cleanup(self: Task, *, tenant_id: str) -> None:  # 
         return
     try:
         with get_session_with_current_tenant() as db_session:
-            cache = get_cache_backend()
-            for raw_id in get_session_ids_with_incognito_files(
-                db_session, limit=INCOGNITO_FILE_CLEANUP_BATCH
-            ):
-                session_id = UUID(raw_id)
-                # A turn in flight owns its files, and an evicted context reads
-                # as ended, so the processing fence decides, not the context.
-                if is_chat_session_processing(session_id, cache):
-                    continue
-                if not incognito_session_ended(session_id):
-                    continue
-                try:
-                    delete_incognito_generated_files(session_id, db_session)
-                except Exception:
-                    # One unreachable blob must not strand every session behind it.
-                    task_logger.exception(
-                        "Incognito file cleanup failed for session %s", session_id
-                    )
+            sweep_incognito_generated_files(db_session)
     finally:
         if lock.owned():
             lock.release()

--- a/backend/onyx/background/task_utils.py
+++ b/backend/onyx/background/task_utils.py
@@ -1,10 +1,12 @@
 """Background task utilities.
 
-Contains query-history report helpers (used by all deployment modes) and
-in-process background task execution helpers for NO_VECTOR_DB mode:
+Contains query-history report helpers (used by all deployment modes), the
+shared enqueue path for user file deletes, and in-process background task
+execution helpers for NO_VECTOR_DB mode:
 
 - Atomic claim-and-mark helpers that prevent duplicate processing
 - Drain loops that process all pending user file work
+- The delete enqueue every request handler routes through
 
 Each claim function runs a short-lived transaction: SELECT ... FOR UPDATE
 SKIP LOCKED, UPDATE the row to remove it from future queries, COMMIT.
@@ -12,12 +14,22 @@ After the commit the row lock is released, but the row is no longer
 eligible for re-claiming.  No long-lived sessions or advisory locks.
 """
 
+from collections.abc import Sequence
 from uuid import UUID
 
 import sqlalchemy as sa
+from celery import Celery
+from fastapi import BackgroundTasks
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from onyx.configs.app_configs import DISABLE_VECTOR_DB
+from onyx.configs.constants import (
+    CELERY_USER_FILE_DELETE_TASK_EXPIRES,
+    OnyxCeleryPriority,
+    OnyxCeleryQueues,
+    OnyxCeleryTask,
+)
 from onyx.db.enums import UserFileStatus
 from onyx.db.models import UserFile
 from onyx.utils.logger import setup_logger
@@ -163,7 +175,10 @@ def drain_delete_loop(tenant_id: str) -> None:
     from onyx.background.celery.tasks.user_file_processing.tasks import (
         delete_user_file_impl,
     )
-    from onyx.chat.incognito import sweep_stale_incognito_user_files
+    from onyx.chat.incognito import (
+        sweep_incognito_generated_files,
+        sweep_stale_incognito_user_files,
+    )
     from onyx.db.engine.sql_engine import get_session_with_current_tenant
 
     failed: set[UUID] = set()
@@ -187,8 +202,11 @@ def drain_delete_loop(tenant_id: str) -> None:
     # deletion. What it queues is picked up on the next pass.
     try:
         with get_session_with_current_tenant() as session:
-            if sweep_stale_incognito_user_files(session):
-                session.commit()
+            sweep_stale_incognito_user_files(session)
+            # Always: the sweep also restarts the orphan clock on sessions it
+            # found live, which is lost if only a queued file triggers this.
+            session.commit()
+            sweep_incognito_generated_files(session)
     except Exception:
         logger.exception("Stale incognito sweep failed")
 
@@ -215,3 +233,48 @@ def drain_project_sync_loop(tenant_id: str) -> None:
         except Exception:
             logger.exception("Failed to sync user file %s", file_id)
             failed.add(file_id)
+
+
+# ------------------------------------------------------------------
+# Delete enqueue: the one path request handlers use
+# ------------------------------------------------------------------
+
+
+def send_user_file_delete_task(app: Celery, user_file_id: UUID, tenant_id: str) -> None:
+    """Send one delete to the worker queue.
+
+    Carries the expiry every send needs, so a backlog cannot grow without bound.
+    """
+    app.send_task(
+        OnyxCeleryTask.DELETE_SINGLE_USER_FILE,
+        kwargs={"user_file_id": str(user_file_id), "tenant_id": tenant_id},
+        queue=OnyxCeleryQueues.USER_FILE_DELETE,
+        priority=OnyxCeleryPriority.HIGH,
+        expires=CELERY_USER_FILE_DELETE_TASK_EXPIRES,
+    )
+
+
+def enqueue_user_file_deletes(
+    user_file_ids: Sequence[UUID],
+    *,
+    tenant_id: str,
+    bg_tasks: BackgroundTasks,
+) -> None:
+    """Hand rows already marked DELETING to whatever drains them here.
+
+    Lite deployments run no Celery, so the queue has no consumer and the work
+    goes to an in-process drain that runs with the request rather than waiting
+    on the recovery poll.
+    """
+    if not user_file_ids:
+        return
+    if DISABLE_VECTOR_DB:
+        bg_tasks.add_task(drain_delete_loop, tenant_id)
+        logger.info("Queued in-process delete for %d user file(s)", len(user_file_ids))
+        return
+
+    from onyx.background.celery.versioned_apps.client import app as client_app
+
+    for user_file_id in user_file_ids:
+        send_user_file_delete_task(client_app, user_file_id, tenant_id)
+    logger.info("Queued delete task for %d user file(s)", len(user_file_ids))

--- a/backend/onyx/chat/incognito.py
+++ b/backend/onyx/chat/incognito.py
@@ -19,17 +19,24 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from onyx.cache.factory import get_cache_backend
+from onyx.chat.chat_processing_checker import is_chat_session_processing
 from onyx.chat.incognito_context import (
     incognito_context_available,
-    incognito_session_ended,
+    incognito_sessions_ended,
 )
+from onyx.configs.constants import INCOGNITO_FILE_CLEANUP_BATCH
 from onyx.db.enums import IncognitoRecordMode, record_mode_persists_content
-from onyx.db.file_record import get_incognito_file_ids
+from onyx.db.file_record import (
+    get_incognito_file_ids,
+    get_session_ids_with_incognito_files,
+)
 from onyx.db.incognito import (
-    is_content_persisting_session,
-    mark_incognito_user_files_deleting,
-    mark_unadopted_incognito_files_deleting,
+    mark_user_files_deleting,
     stale_incognito_session_ids,
+    stale_unadopted_upload_ids,
+    stale_upload_ids_for_sessions,
+    touch_incognito_uploads_for_sessions,
     user_in_incognito_enabled_group,
 )
 from onyx.db.models import User
@@ -102,25 +109,56 @@ def resolve_incognito_record_mode() -> IncognitoRecordMode:
     return load_effective_uncached().incognito_record_mode
 
 
-def sweep_stale_incognito_user_files(db_session: Session) -> int:
+def sweep_stale_incognito_user_files(db_session: Session) -> list[UUID]:
     """Queue uploads of dead incognito sessions for deletion. Caller commits.
 
-    Covers both shapes: uploads no session ever adopted, and uploads whose
-    session is gone. A session whose live context is still present is skipped
-    however old its files are, so a chat left open past the orphan window keeps
-    its attachments. Shared by the Celery beat task and the lite deployment
-    poller, which have no scheduler in common.
+    Two passes, because the two shapes starve differently. Uploads no session
+    ever claimed are deletable on sight. Uploads a session holds depend on that
+    session's liveness, and are bounded by distinct sessions so one busy session
+    cannot fill a pass. A live session keeps its attachments and its orphan
+    clock restarts, so it does not occupy the next pass as well.
     """
-    marked = mark_unadopted_incognito_files_deleting(db_session)
-    for session_id in stale_incognito_session_ids(db_session):
-        # Full-history sessions never create a Redis context, so liveness would
-        # read them as ended and delete a live chat's attachments.
-        if is_content_persisting_session(db_session, session_id):
+    deletable = stale_unadopted_upload_ids(db_session)
+
+    session_ids = stale_incognito_session_ids(db_session)
+    ended = incognito_sessions_ended(session_ids)
+    deletable += stale_upload_ids_for_sessions(db_session, sorted(ended))
+    touch_incognito_uploads_for_sessions(
+        db_session,
+        [session_id for session_id in session_ids if session_id not in ended],
+    )
+
+    mark_user_files_deleting(db_session, deletable)
+    return deletable
+
+
+def sweep_incognito_generated_files(db_session: Session) -> None:
+    """Retry deletion of tool-generated blobs a teardown pass failed to remove.
+
+    A blob's record carries the session that produced it and deleting the blob
+    deletes the record, so anything still stamped is what a store failure left
+    behind. Shared by the Celery beat task and the lite drain, which is that
+    deployment's only background pass.
+    """
+    cache = get_cache_backend()
+    ended = incognito_sessions_ended(
+        [
+            UUID(raw_id)
+            for raw_id in get_session_ids_with_incognito_files(
+                db_session, limit=INCOGNITO_FILE_CLEANUP_BATCH
+            )
+        ]
+    )
+    for session_id in ended:
+        # A turn in flight owns its files, and an evicted context reads as
+        # ended, so the processing fence decides, not the context.
+        if is_chat_session_processing(session_id, cache):
             continue
-        if not incognito_session_ended(session_id):
-            continue
-        marked += len(mark_incognito_user_files_deleting(db_session, session_id))
-    return marked
+        try:
+            delete_incognito_generated_files(session_id, db_session)
+        except Exception:
+            # One unreachable blob must not strand every session behind it.
+            logger.exception("Incognito file cleanup failed for session %s", session_id)
 
 
 def incognito_llm_extra_headers(

--- a/backend/onyx/chat/incognito_context.py
+++ b/backend/onyx/chat/incognito_context.py
@@ -12,6 +12,7 @@ version. A lost save means a concurrent writer won or the session ended, and
 the caller must not retry with the history it loaded.
 """
 
+from collections.abc import Collection
 from uuid import UUID
 
 from pydantic import BaseModel, TypeAdapter, ValidationError
@@ -197,14 +198,31 @@ def incognito_session_torn_down(chat_session_id: UUID) -> bool:
     return _stored_context(chat_session_id) == _TOMBSTONE
 
 
+def incognito_sessions_ended(chat_session_ids: Collection[UUID]) -> set[UUID]:
+    """Which of these sessions have no live context, by teardown or by expiry.
+
+    One round trip for the whole batch. Duplicate ids collapse in the result.
+    """
+    # Materialized once: the ids and the values are zipped positionally, so a
+    # set argument must not be iterated twice.
+    session_ids = list(chat_session_ids)
+    values = get_redis_client().mget(
+        [_context_key(session_id) for session_id in session_ids]
+    )
+    return {
+        session_id
+        for session_id, raw in zip(session_ids, values, strict=True)
+        if raw is None or raw == _TOMBSTONE
+    }
+
+
 def incognito_session_ended(chat_session_id: UUID) -> bool:
     """Whether the live context is gone, by teardown or by expiry.
 
     Absence counts, so a session that has not written its first message reads
     as ended. Only for callers that have already ruled that out.
     """
-    raw = _stored_context(chat_session_id)
-    return raw is None or raw == _TOMBSTONE
+    return bool(incognito_sessions_ended([chat_session_id]))
 
 
 def teardown_incognito_session(chat_session_id: UUID) -> None:

--- a/backend/onyx/db/file_record.py
+++ b/backend/onyx/db/file_record.py
@@ -1,4 +1,4 @@
-from sqlalchemy import String, and_, case, cast, select, update
+from sqlalchemy import String, and_, case, cast, func, select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
@@ -247,12 +247,16 @@ def get_session_ids_with_incognito_files(
     db_session: Session, limit: int | None = None
 ) -> list[str]:
     """Sessions still holding blobs. Empty in steady state, since teardown
-    deletes the records, so this only sees what a store failure left."""
-    return list(
-        db_session.scalars(
-            select(FileRecord.file_metadata[INCOGNITO_SESSION_METADATA_KEY].astext)
-            .distinct()
-            .where(FileRecord.file_metadata.has_key(INCOGNITO_SESSION_METADATA_KEY))
-            .limit(limit)
-        )
+    deletes the records, so this only sees what a store failure left.
+
+    Sampled at random when limited: every row here is a retry, so a set that
+    keeps failing must not occupy the batch and hide the sessions behind it.
+    """
+    stmt = (
+        select(FileRecord.file_metadata[INCOGNITO_SESSION_METADATA_KEY].astext)
+        .distinct()
+        .where(FileRecord.file_metadata.has_key(INCOGNITO_SESSION_METADATA_KEY))
     )
+    if limit is not None:
+        stmt = stmt.order_by(func.random()).limit(limit)
+    return list(db_session.scalars(stmt))

--- a/backend/onyx/db/incognito.py
+++ b/backend/onyx/db/incognito.py
@@ -6,13 +6,15 @@ names its session before that session exists and the server never has to take
 the client's word for whether the upload is private.
 """
 
+from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
+from typing import Any
 from uuid import UUID
 
-from sqlalchemy import exists, select, update
+from sqlalchemy import exists, func, select, update
 from sqlalchemy.orm import Session
 
-from onyx.db.enums import UserFileStatus, record_mode_persists_content
+from onyx.db.enums import IncognitoRecordMode, UserFileStatus
 from onyx.db.models import ChatSession, User__UserGroup, UserFile, UserGroup
 
 # Only reached once a session's live context is gone, so this bounds how long a
@@ -32,21 +34,6 @@ def user_in_incognito_enabled_group(db_session: Session, user_id: UUID) -> bool:
         )
     )
     return bool(db_session.execute(stmt).scalar())
-
-
-def is_content_persisting_session(db_session: Session, chat_session_id: UUID) -> bool:
-    """Whether the session records content, which means it never creates a
-    Redis context and so cannot be judged by context liveness."""
-    row = db_session.execute(
-        select(ChatSession.incognito_record_mode).where(
-            ChatSession.id == chat_session_id
-        )
-    ).one_or_none()
-    if row is None:
-        # The id was minted client-side and no session ever followed, so there
-        # is no live chat to protect and the files are abandoned.
-        return False
-    return record_mode_persists_content(row[0])
 
 
 def is_incognito_teardown_target(
@@ -69,6 +56,17 @@ def is_incognito_teardown_target(
     return owner_id in (user_id, None) and record_mode is not None
 
 
+def mark_user_files_deleting(db_session: Session, file_ids: Sequence[UUID]) -> None:
+    """Move these files to DELETING. Caller commits."""
+    if not file_ids:
+        return
+    db_session.execute(
+        update(UserFile)
+        .where(UserFile.id.in_(file_ids))
+        .values(status=UserFileStatus.DELETING)
+    )
+
+
 def mark_incognito_user_files_deleting(
     db_session: Session, chat_session_id: UUID, user_id: UUID | None = None
 ) -> list[UUID]:
@@ -85,29 +83,60 @@ def mark_incognito_user_files_deleting(
     if user_id is not None:
         conditions.append(UserFile.user_id == user_id)
     file_ids = list(db_session.scalars(select(UserFile.id).where(*conditions)).all())
-    if not file_ids:
-        return []
-    db_session.execute(
-        update(UserFile)
-        .where(UserFile.id.in_(file_ids))
-        .values(status=UserFileStatus.DELETING)
-    )
+    mark_user_files_deleting(db_session, file_ids)
     return file_ids
 
 
-def stale_incognito_session_ids(db_session: Session) -> list[UUID]:
-    """Sessions whose uploads are past the orphan window."""
+def _stale_upload_conditions() -> list[Any]:
+    """Uploads old enough for a sweep to consider, whatever claims them."""
     cutoff = datetime.now(timezone.utc) - INCOGNITO_FILE_ORPHAN_AGE
+    return [
+        # Matches ix_user_file_incognito_sweep's partial predicate.
+        UserFile.incognito.is_(True),
+        UserFile.status != UserFileStatus.DELETING,
+        UserFile.last_accessed_at < cutoff,
+    ]
+
+
+def stale_unadopted_upload_ids(db_session: Session) -> list[UUID]:
+    """Stale uploads no session ever claimed.
+
+    Separate from the session-keyed pass so they can never queue behind a
+    session that is still live: every row here is deletable on sight.
+    """
+    return list(
+        db_session.scalars(
+            select(UserFile.id)
+            .where(*_stale_upload_conditions(), UserFile.incognito_session_id.is_(None))
+            .order_by(UserFile.last_accessed_at)
+            .limit(INCOGNITO_STALE_SWEEP_LIMIT)
+        ).all()
+    )
+
+
+def stale_incognito_session_ids(db_session: Session) -> list[UUID]:
+    """Sessions holding stale uploads whose liveness decides their fate.
+
+    Bounded by distinct sessions rather than files, so one session holding
+    thousands of uploads costs a single slot. Sessions that persist content are
+    excluded in SQL: a session row that is absent means the client-minted id
+    never became a session, which is not the same as a NULL mode on a row that
+    exists, since that is an ordinary chat.
+    """
+    session_persists_content = ChatSession.id.is_not(None) & (
+        ChatSession.incognito_record_mode.is_(None)
+        | (ChatSession.incognito_record_mode == IncognitoRecordMode.FULL_HISTORY)
+    )
     rows = db_session.scalars(
         select(UserFile.incognito_session_id)
+        .outerjoin(ChatSession, ChatSession.id == UserFile.incognito_session_id)
         .where(
-            # Matches the partial index predicate so Postgres can use it.
-            UserFile.incognito.is_(True),
+            *_stale_upload_conditions(),
             UserFile.incognito_session_id.is_not(None),
-            UserFile.status != UserFileStatus.DELETING,
-            UserFile.last_accessed_at < cutoff,
+            ~session_persists_content,
         )
         .group_by(UserFile.incognito_session_id)
+        .order_by(func.min(UserFile.last_accessed_at))
         .limit(INCOGNITO_STALE_SWEEP_LIMIT)
     ).all()
     # The is_not(None) filter above already excludes NULLs. This narrows the
@@ -115,30 +144,38 @@ def stale_incognito_session_ids(db_session: Session) -> list[UUID]:
     return [session_id for session_id in rows if session_id is not None]
 
 
-def mark_unadopted_incognito_files_deleting(db_session: Session) -> int:
-    """Queue incognito uploads no session ever adopted. Caller commits.
+def touch_incognito_uploads_for_sessions(
+    db_session: Session, chat_session_ids: Sequence[UUID]
+) -> None:
+    """Restart the orphan clock on these sessions' uploads. Caller commits.
 
-    Left by someone who attached a file in incognito and never sent a message,
-    so no session exists to tear them down.
+    A session whose context is still live is still using its files, so the
+    sweep records that rather than reconsidering the same rows every pass and
+    starving the sessions behind them.
     """
-    cutoff = datetime.now(timezone.utc) - INCOGNITO_FILE_ORPHAN_AGE
-    file_ids = list(
-        db_session.scalars(
-            select(UserFile.id)
-            .where(
-                UserFile.incognito.is_(True),
-                UserFile.incognito_session_id.is_(None),
-                UserFile.status != UserFileStatus.DELETING,
-                UserFile.last_accessed_at < cutoff,
-            )
-            .limit(INCOGNITO_STALE_SWEEP_LIMIT)
-        ).all()
-    )
-    if not file_ids:
-        return 0
+    if not chat_session_ids:
+        return
     db_session.execute(
         update(UserFile)
-        .where(UserFile.id.in_(file_ids))
-        .values(status=UserFileStatus.DELETING)
+        .where(
+            UserFile.incognito_session_id.in_(chat_session_ids),
+            UserFile.status != UserFileStatus.DELETING,
+        )
+        .values(last_accessed_at=datetime.now(timezone.utc))
     )
-    return len(file_ids)
+
+
+def stale_upload_ids_for_sessions(
+    db_session: Session, chat_session_ids: Sequence[UUID]
+) -> list[UUID]:
+    """The stale uploads these sessions hold."""
+    if not chat_session_ids:
+        return []
+    return list(
+        db_session.scalars(
+            select(UserFile.id).where(
+                *_stale_upload_conditions(),
+                UserFile.incognito_session_id.in_(chat_session_ids),
+            )
+        ).all()
+    )

--- a/backend/onyx/redis/tenant_redis_client.py
+++ b/backend/onyx/redis/tenant_redis_client.py
@@ -12,7 +12,7 @@ typing error, not a silent cross-tenant write.
 # annotations like ``-> set[bytes]``.
 from __future__ import annotations
 
-from collections.abc import Generator, Mapping
+from collections.abc import Generator, Mapping, Sequence
 from typing import Any, cast
 
 import redis
@@ -145,6 +145,23 @@ class TenantRedisClient:
             exist.
         """
         return cast("bytes | None", self._r.get(_prefix_key(self._prefix, name)))
+
+    def mget(self, names: Sequence[KeyArg]) -> list[bytes | None]:
+        """Issues an MGET against tenant-prefixed keys.
+
+        Args:
+            names: The (unprefixed) keys to read, in the order to read them.
+                An empty sequence skips the round trip, since MGET rejects a
+                call with no keys.
+
+        Returns:
+            One entry per key, positionally aligned with *names*. A key that
+            does not exist reads as ``None``.
+        """
+        if not names:
+            return []
+        prefixed = [_prefix_key(self._prefix, n) for n in names]
+        return cast("list[bytes | None]", self._r.mget(prefixed))
 
     def set(
         self,

--- a/backend/onyx/server/features/projects/api.py
+++ b/backend/onyx/server/features/projects/api.py
@@ -71,6 +71,31 @@ class UserFileDeleteResult(BaseModel):
     assistant_names: list[str] = []
 
 
+def _claim_upload_if_session_ended(
+    db_session: Session, incognito_session_id: UUID | None, user_id: UUID
+) -> None:
+    """Queue this session's uploads if a teardown landed during the upload.
+
+    Never raises: it runs on the upload's failure path too, where masking the
+    original error would cost more than the delay to the orphan sweep.
+    """
+    if incognito_session_id is None:
+        return
+    try:
+        # The caller may be unwinding a failed statement, which would refuse
+        # any further query on this session.
+        db_session.rollback()
+        if not incognito_session_torn_down(incognito_session_id):
+            return
+        mark_incognito_user_files_deleting(db_session, incognito_session_id, user_id)
+        db_session.commit()
+    except Exception:
+        logger.exception(
+            "Could not claim uploads for ended incognito session %s",
+            incognito_session_id,
+        )
+
+
 def _trigger_user_file_project_sync(
     user_file_id: UUID,
     tenant_id: str,
@@ -194,17 +219,6 @@ def upload_user_files(
             incognito_session_id=incognito_session_id,
         )
 
-        # Re-check after the rows exist. The tombstone is monotonic, so a
-        # teardown that landed during the upload is caught here even though the
-        # pre-check passed, which is what the marking query alone would miss.
-        if incognito_session_id is not None and incognito_session_torn_down(
-            incognito_session_id
-        ):
-            mark_incognito_user_files_deleting(
-                db_session, incognito_session_id, user.id
-            )
-            db_session.commit()
-
         return CategorizedFilesSnapshot.from_result(categorized_files_result)
 
     except Exception as e:
@@ -213,6 +227,10 @@ def upload_user_files(
             status_code=500,
             detail="Failed to upload files. Please try again or contact support if the issue persists.",
         )
+    finally:
+        # Rows are committed before the indexing hand-off, which can still
+        # fail, so this runs on every exit.
+        _claim_upload_if_session_ended(db_session, incognito_session_id, user.id)
 
 
 @router.get("/{project_id}", tags=PUBLIC_API_TAGS)

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -5,7 +5,15 @@ from collections.abc import Generator
 from datetime import timedelta
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Query,
+    Request,
+    Response,
+)
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
@@ -15,6 +23,7 @@ from onyx.auth.api_key import get_hashed_api_key_from_request
 from onyx.auth.pat import get_hashed_pat_from_request
 from onyx.auth.permissions import require_permission
 from onyx.auth.users import current_chat_accessible_user
+from onyx.background.task_utils import enqueue_user_file_deletes
 from onyx.cache.factory import get_cache_backend
 from onyx.chat.chat_processing_checker import (
     get_processing_run_id,
@@ -48,13 +57,9 @@ from onyx.configs.chat_configs import (
     HARD_DELETE_CHATS,
 )
 from onyx.configs.constants import (
-    CELERY_USER_FILE_DELETE_TASK_EXPIRES,
     PUBLIC_API_TAGS,
     MessageType,
     MilestoneRecordType,
-    OnyxCeleryPriority,
-    OnyxCeleryQueues,
-    OnyxCeleryTask,
 )
 from onyx.configs.model_configs import LITELLM_PASS_THROUGH_HEADERS
 from onyx.db.chat import (
@@ -724,6 +729,7 @@ def get_incognito_availability(
 @router.post("/end-incognito-session/{session_id}", tags=PUBLIC_API_TAGS)
 def end_incognito_session(
     session_id: UUID,
+    bg_tasks: BackgroundTasks,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> None:
@@ -741,28 +747,27 @@ def end_incognito_session(
     # for deletion rather than stored but hidden.
     deletable_ids = mark_incognito_user_files_deleting(db_session, session_id, user.id)
     db_session.commit()
-    teardown_incognito_session(session_id)
 
-    if deletable_ids:
-        from onyx.background.celery.versioned_apps.client import app as client_app
-
-        tenant_id = get_current_tenant_id()
-        for user_file_id in deletable_ids:
-            client_app.send_task(
-                OnyxCeleryTask.DELETE_SINGLE_USER_FILE,
-                kwargs={"user_file_id": str(user_file_id), "tenant_id": tenant_id},
-                queue=OnyxCeleryQueues.USER_FILE_DELETE,
-                priority=OnyxCeleryPriority.HIGH,
-                expires=CELERY_USER_FILE_DELETE_TASK_EXPIRES,
-            )
-
-    # Last, so a store that refuses a blob cannot strand the queued uploads:
-    # this raises to tell the client the sweep will retry.
-    if not delete_incognito_generated_files(session_id, db_session):
-        raise OnyxError(
-            OnyxErrorCode.SERVICE_UNAVAILABLE,
-            "Some generated files could not be deleted yet and will be retried.",
-        )
+    # Nothing past the commit may raise. This is a one-shot beacon, so an error
+    # reaches nobody who can act on it, and raising would discard the response
+    # carrying the in-process drain that a Celery-less deployment relies on.
+    enqueue_user_file_deletes(
+        deletable_ids, tenant_id=get_current_tenant_id(), bg_tasks=bg_tasks
+    )
+    for what, step in (
+        (
+            "delete generated files",
+            lambda: delete_incognito_generated_files(session_id, db_session),
+        ),
+        ("end the context", lambda: teardown_incognito_session(session_id)),
+    ):
+        try:
+            if step() is False:
+                logger.warning(
+                    "Incognito teardown could not %s for %s", what, session_id
+                )
+        except Exception:
+            logger.exception("Incognito teardown could not %s for %s", what, session_id)
 
 
 # NOTE: This endpoint is extremely central to the application, any changes to it should be reviewed and approved by an experienced

--- a/backend/tests/external_dependency_unit/db/test_incognito_stale_sweep.py
+++ b/backend/tests/external_dependency_unit/db/test_incognito_stale_sweep.py
@@ -1,0 +1,135 @@
+"""Guards which uploads the sweep's query returns, and how it reads the mode of
+the session that claims each one.
+
+An absent session row and an ordinary chat both arrive as a NULL mode through
+the outer join while meaning opposite things. Exercises the real SQL against
+Postgres, since the distinction lives entirely in the join.
+"""
+
+from collections.abc import Generator
+from datetime import datetime, timedelta, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import IncognitoRecordMode, UserFileStatus
+from onyx.db.incognito import (
+    INCOGNITO_FILE_ORPHAN_AGE,
+    stale_incognito_session_ids,
+    stale_unadopted_upload_ids,
+)
+from onyx.db.models import ChatSession, User, UserFile
+from tests.external_dependency_unit.conftest import create_test_user
+
+PAST_THE_WINDOW = INCOGNITO_FILE_ORPHAN_AGE + timedelta(hours=1)
+
+
+@pytest.fixture
+def owner(db_session: Session) -> Generator[User, None, None]:
+    """A user whose rows are deleted afterwards rather than rolled back, since
+    the helpers below commit and a rollback cannot reach committed rows."""
+    user = create_test_user(db_session, "incognito-sweep")
+    yield user
+
+    db_session.rollback()
+    db_session.query(UserFile).filter(UserFile.user_id == user.id).delete()
+    db_session.query(ChatSession).filter(ChatSession.user_id == user.id).delete()
+    db_session.delete(user)
+    db_session.commit()
+
+
+def _make_chat_session(
+    db_session: Session, user_id: UUID, mode: IncognitoRecordMode | None
+) -> UUID:
+    chat_session = ChatSession(
+        id=uuid4(), user_id=user_id, description="", incognito_record_mode=mode
+    )
+    db_session.add(chat_session)
+    db_session.commit()
+    return chat_session.id
+
+
+def _make_upload(
+    db_session: Session,
+    user_id: UUID,
+    session_id: UUID | None,
+    age: timedelta = PAST_THE_WINDOW,
+) -> UUID:
+    user_file = UserFile(
+        id=uuid4(),
+        user_id=user_id,
+        file_id=f"file-{uuid4()}",
+        name="attachment.txt",
+        file_type="text/plain",
+        status=UserFileStatus.COMPLETED,
+        incognito=True,
+        incognito_session_id=session_id,
+        last_accessed_at=datetime.now(timezone.utc) - age,
+    )
+    db_session.add(user_file)
+    db_session.commit()
+    return user_file.id
+
+
+def _session_is_swept(db_session: Session, session_id: UUID) -> bool:
+    """Whether the session-keyed pass considers this session at all."""
+    return session_id in stale_incognito_session_ids(db_session)
+
+
+@pytest.mark.parametrize(
+    "mode, returned",
+    [
+        # No session row at all: the client-minted id never became a session,
+        # which the query must not read as the NULL mode of an ordinary chat.
+        ("no_session", True),
+        (None, False),
+        (IncognitoRecordMode.FULL_HISTORY, False),
+        (IncognitoRecordMode.USAGE_ONLY, True),
+    ],
+    ids=["no_session_row", "ordinary_chat", "full_history", "usage_only"],
+)
+def test_the_session_pass_considers_only_sessions_a_sweep_may_act_on(
+    db_session: Session,
+    owner: User,
+    mode: object,
+    returned: bool,
+) -> None:
+    if mode == "no_session":
+        session_id = uuid4()
+    else:
+        session_id = _make_chat_session(db_session, owner.id, mode)  # ty: ignore[invalid-argument-type]
+    _make_upload(db_session, owner.id, session_id)
+
+    assert _session_is_swept(db_session, session_id) is returned
+
+
+def test_an_unadopted_upload_is_returned_by_its_own_pass(
+    db_session: Session, owner: User
+) -> None:
+    """It has no session to ask about, so it must not depend on the session
+    pass having room for it."""
+    file_id = _make_upload(db_session, owner.id, None)
+
+    assert file_id in stale_unadopted_upload_ids(db_session)
+
+
+@pytest.mark.parametrize(
+    "age, status",
+    [
+        (timedelta(minutes=5), UserFileStatus.COMPLETED),
+        (PAST_THE_WINDOW, UserFileStatus.DELETING),
+    ],
+    ids=["inside_the_orphan_window", "already_deleting"],
+)
+def test_the_query_skips_uploads_it_has_no_business_with(
+    db_session: Session, owner: User, age: timedelta, status: UserFileStatus
+) -> None:
+    file_id = _make_upload(db_session, owner.id, None, age=age)
+    if status is UserFileStatus.DELETING:
+        db_session.query(UserFile).filter(UserFile.id == file_id).update(
+            {"status": status}
+        )
+        db_session.commit()
+
+    assert file_id not in stale_unadopted_upload_ids(db_session)

--- a/backend/tests/external_dependency_unit/redis/test_tenant_redis.py
+++ b/backend/tests/external_dependency_unit/redis/test_tenant_redis.py
@@ -136,6 +136,16 @@ class TestRoundTrip:
             None,
         ]
 
+    def test_set_mget(self, tenant_redis: TenantRedisClient) -> None:
+        first, second = _unique_key(), _unique_key()
+        tenant_redis.set(first, "v1")
+        tenant_redis.set(second, "v2")
+        assert tenant_redis.mget([first, second, _unique_key()]) == [
+            b"v1",
+            b"v2",
+            None,
+        ]
+
     def test_incr_then_get_sees_same_counter(
         self, tenant_redis: TenantRedisClient
     ) -> None:

--- a/backend/tests/unit/onyx/background/test_user_file_delete_enqueue.py
+++ b/backend/tests/unit/onyx/background/test_user_file_delete_enqueue.py
@@ -1,0 +1,51 @@
+"""Guards that queued user file deletes reach a consumer on every deployment.
+
+Lite deployments run no Celery, so a send_task there lands on a queue nothing
+drains and the delete waits on the recovery poll instead of running with the
+request.
+"""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from fastapi import BackgroundTasks
+
+from onyx.background.task_utils import drain_delete_loop, enqueue_user_file_deletes
+
+MODULE = "onyx.background.task_utils"
+TENANT = "tenant_test"
+
+
+def _enqueue(file_count: int, lite: bool) -> tuple[MagicMock, BackgroundTasks]:
+    """Returns the celery client the call would have used, and the request's
+    background tasks."""
+    client = MagicMock()
+    bg_tasks = BackgroundTasks()
+    file_ids = [uuid4() for _ in range(file_count)]
+    with (
+        patch(f"{MODULE}.DISABLE_VECTOR_DB", lite),
+        patch.dict(
+            "sys.modules",
+            {"onyx.background.celery.versioned_apps.client": MagicMock(app=client)},
+        ),
+    ):
+        enqueue_user_file_deletes(file_ids, tenant_id=TENANT, bg_tasks=bg_tasks)
+    return client, bg_tasks
+
+
+def test_lite_deployment_drains_in_process_instead_of_queueing() -> None:
+    client, bg_tasks = _enqueue(file_count=2, lite=True)
+
+    client.send_task.assert_not_called()
+    assert [task.func for task in bg_tasks.tasks] == [drain_delete_loop]
+    assert bg_tasks.tasks[0].args == (TENANT,)
+
+
+def test_ordinary_deployment_sends_one_expiring_task_per_file() -> None:
+    """A delete task with no expiry sits on the queue forever when nothing
+    drains it."""
+    client, bg_tasks = _enqueue(file_count=3, lite=False)
+
+    assert client.send_task.call_count == 3
+    assert client.send_task.call_args.kwargs["expires"]
+    assert bg_tasks.tasks == []

--- a/backend/tests/unit/onyx/chat/test_incognito_liveness_predicates.py
+++ b/backend/tests/unit/onyx/chat/test_incognito_liveness_predicates.py
@@ -15,6 +15,7 @@ from onyx.chat.incognito_context import (
     _TOMBSTONE,
     incognito_session_ended,
     incognito_session_torn_down,
+    incognito_sessions_ended,
 )
 
 MODULE = "onyx.chat.incognito_context"
@@ -24,6 +25,7 @@ LIVE_CONTEXT = b"1:[]"
 def _with_stored(value: bytes | None) -> MagicMock:
     client = MagicMock()
     client.get.return_value = value
+    client.mget.return_value = [value]
     return client
 
 
@@ -44,3 +46,16 @@ def test_liveness_predicates_split_on_absence(
     with patch(f"{MODULE}.get_redis_client", return_value=_with_stored(stored)):
         assert incognito_session_torn_down(uuid4()) is torn_down
         assert incognito_session_ended(uuid4()) is ended
+
+
+def test_the_batched_read_answers_for_the_whole_set_at_once() -> None:
+    """One round trip is what keeps a sweep pass flat, whatever its backlog."""
+    client = MagicMock()
+    live, expired, tombstoned = uuid4(), uuid4(), uuid4()
+    client.mget.return_value = [LIVE_CONTEXT, None, _TOMBSTONE]
+
+    with patch(f"{MODULE}.get_redis_client", return_value=client):
+        ended = incognito_sessions_ended([live, expired, tombstoned])
+
+    assert ended == {expired, tombstoned}
+    assert client.mget.call_count == 1

--- a/backend/tests/unit/onyx/chat/test_incognito_sweep_selection.py
+++ b/backend/tests/unit/onyx/chat/test_incognito_sweep_selection.py
@@ -1,0 +1,76 @@
+"""Guards which stale incognito uploads the sweep queues for deletion.
+
+Two shapes with different fates: an upload no session ever claimed goes without
+asking anything, and one a session holds goes only once that session's live
+context is gone. A session that is still live has its orphan clock restarted so
+it cannot occupy every pass.
+"""
+
+from collections.abc import Collection
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+from onyx.chat.incognito import sweep_stale_incognito_user_files
+
+MODULE = "onyx.chat.incognito"
+
+
+def _sweep(
+    unadopted: list[UUID], sessions: list[UUID], ended: set[UUID]
+) -> tuple[list[UUID], list[UUID], list[UUID]]:
+    """Returns what the sweep marked, which sessions it asked about, and which
+    it touched, having checked it marked exactly what it returned."""
+    asked: list[UUID] = []
+
+    def _ended(session_ids: Collection[UUID]) -> set[UUID]:
+        asked.extend(session_ids)
+        return {session_id for session_id in session_ids if session_id in ended}
+
+    with (
+        patch(f"{MODULE}.stale_unadopted_upload_ids", return_value=list(unadopted)),
+        patch(f"{MODULE}.stale_incognito_session_ids", return_value=sessions),
+        patch(f"{MODULE}.incognito_sessions_ended", side_effect=_ended),
+        patch(
+            f"{MODULE}.stale_upload_ids_for_sessions",
+            side_effect=lambda _db, ids: [UUID(int=i) for i, _ in enumerate(ids, 1)],
+        ),
+        patch(f"{MODULE}.touch_incognito_uploads_for_sessions") as touch,
+        patch(f"{MODULE}.mark_user_files_deleting") as mark,
+    ):
+        queued = sweep_stale_incognito_user_files(db_session=None)  # ty: ignore[invalid-argument-type]
+        assert [call.args[1] for call in mark.call_args_list] == [queued]
+        touched = list(touch.call_args.args[1]) if touch.call_args else []
+    return queued, asked, touched
+
+
+def test_an_unadopted_upload_goes_without_a_liveness_check() -> None:
+    file_id = uuid4()
+
+    queued, asked, _ = _sweep(unadopted=[file_id], sessions=[], ended=set())
+
+    assert queued == [file_id]
+    assert asked == []
+
+
+def test_a_live_session_keeps_its_uploads_and_leaves_the_window() -> None:
+    live = uuid4()
+
+    queued, asked, touched = _sweep(unadopted=[], sessions=[live], ended=set())
+
+    assert queued == []
+    assert asked == [live]
+    # Its clock restarts, so it cannot occupy the next pass as well.
+    assert touched == [live]
+
+
+def test_a_dead_session_has_its_uploads_queued_alongside_the_unadopted() -> None:
+    orphan, live, dead = uuid4(), uuid4(), uuid4()
+
+    queued, asked, touched = _sweep(
+        unadopted=[orphan], sessions=[live, dead], ended={dead}
+    )
+
+    assert queued[0] == orphan
+    assert len(queued) == 2
+    assert sorted(asked) == sorted([live, dead])
+    assert touched == [live]

--- a/backend/tests/unit/onyx/server/test_incognito_upload_guard.py
+++ b/backend/tests/unit/onyx/server/test_incognito_upload_guard.py
@@ -1,14 +1,15 @@
 """Guards which incognito sessions the upload endpoint accepts files for.
 
-The guard must read the teardown tombstone alone, since an absent context key
-means the session is new: switching incognito on mints the id client-side, so
-uploads arrive naming a session that holds no context until its first message.
+Switching incognito on mints the session id client-side, so uploads arrive
+naming a session that holds no context until its first message. Only a teardown
+tombstone closes a session to new files, and an upload that overlaps one has to
+claim its own rows however the request ends.
 """
 
+from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
-import pytest
 from fastapi import BackgroundTasks
 
 from onyx.chat.incognito_context import _TOMBSTONE
@@ -22,29 +23,42 @@ CONTEXT_MODULE = "onyx.chat.incognito_context"
 NO_CONTEXT_YET = None
 
 
+@dataclass
+class Attempt:
+    """What one upload request did, including how it ended."""
+
+    wrote_rows: bool
+    claimed_rows: bool
+    error: Exception | None
+
+
 def _upload(
     *,
-    stored_before: bytes | None = NO_CONTEXT_YET,
-    stored_after: bytes | None = NO_CONTEXT_YET,
+    stored: list[bytes | None],
     allowed: bool = True,
-    expect_upload: bool = True,
-) -> MagicMock:
-    """Runs the endpoint against a fresh incognito session id and returns the
-    marking helper, so the caller can assert whether cleanup was queued.
+    upload_fails: bool = False,
+) -> Attempt:
+    """Run the endpoint against a fresh incognito session id.
 
-    *stored_before* and *stored_after* are what Redis holds for the context key
-    on the pre-check and the post-check. Driving the store rather than the
-    predicate keeps the assertion on which verdict the endpoint asks for.
+    *stored* is what Redis holds for the context key on the pre-check and then
+    the post-check, which is the only thing separating an ordinary upload from
+    one racing a teardown.
     """
     redis_client = MagicMock()
-    redis_client.get.side_effect = [stored_before, stored_after]
+    redis_client.get.side_effect = list(stored)
     with (
         patch(f"{MODULE}.incognito_allowed_for_user", return_value=allowed),
         patch(f"{CONTEXT_MODULE}.get_redis_client", return_value=redis_client),
-        patch(f"{MODULE}.upload_files_to_user_files_with_indexing") as upload_impl,
+        patch(
+            f"{MODULE}.upload_files_to_user_files_with_indexing",
+            side_effect=ConnectionError("indexing hand-off failed")
+            if upload_fails
+            else None,
+        ) as upload_impl,
         patch(f"{MODULE}.mark_incognito_user_files_deleting") as mark,
         patch(f"{MODULE}.CategorizedFilesSnapshot"),
     ):
+        error: Exception | None = None
         try:
             upload_user_files(
                 bg_tasks=BackgroundTasks(),
@@ -55,36 +69,51 @@ def _upload(
                 user=MagicMock(id=uuid4()),
                 db_session=MagicMock(),
             )
-        finally:
-            # In a finally so a refused upload still asserts nothing was
-            # written. A guard moved below the write would pass otherwise.
-            assert upload_impl.call_count == (1 if expect_upload else 0)
-    return mark
+        except Exception as raised:
+            error = raised
+        return Attempt(
+            wrote_rows=upload_impl.call_count == 1,
+            claimed_rows=mark.call_count == 1,
+            error=error,
+        )
 
 
 def test_a_session_that_has_sent_no_message_yet_accepts_the_upload() -> None:
-    mark = _upload()
+    """The case that rejected the first attachment of every new incognito
+    chat: no message sent, so no context key exists."""
+    attempt = _upload(stored=[NO_CONTEXT_YET, NO_CONTEXT_YET])
 
-    mark.assert_not_called()
+    assert attempt.error is None
+    assert attempt.wrote_rows
+    assert not attempt.claimed_rows
 
 
 def test_an_upload_racing_teardown_is_queued_for_deletion() -> None:
-    """The pre-check passed and the tombstone landed mid-upload, so the rows
-    exist and the post-check is what catches them."""
-    mark = _upload(stored_after=_TOMBSTONE)
+    attempt = _upload(stored=[NO_CONTEXT_YET, _TOMBSTONE])
 
-    mark.assert_called_once()
+    assert attempt.claimed_rows
+
+
+def test_an_upload_that_fails_after_writing_still_claims_its_rows() -> None:
+    """Rows are committed before the indexing hand-off, which can still fail,
+    so a torn-down session's files must not be left stored and unmarked."""
+    attempt = _upload(stored=[NO_CONTEXT_YET, _TOMBSTONE], upload_fails=True)
+
+    assert attempt.error is not None
+    assert attempt.claimed_rows
 
 
 def test_an_upload_into_an_ended_session_never_writes_a_row() -> None:
-    with pytest.raises(OnyxError) as raised:
-        _upload(stored_before=_TOMBSTONE, expect_upload=False)
+    attempt = _upload(stored=[_TOMBSTONE])
 
-    assert raised.value.error_code is OnyxErrorCode.INVALID_INPUT
+    assert isinstance(attempt.error, OnyxError)
+    assert attempt.error.error_code is OnyxErrorCode.INVALID_INPUT
+    assert not attempt.wrote_rows
 
 
 def test_a_user_without_incognito_is_refused() -> None:
-    with pytest.raises(OnyxError) as raised:
-        _upload(allowed=False, expect_upload=False)
+    attempt = _upload(stored=[], allowed=False)
 
-    assert raised.value.error_code is OnyxErrorCode.UNAUTHORIZED
+    assert isinstance(attempt.error, OnyxError)
+    assert attempt.error.error_code is OnyxErrorCode.UNAUTHORIZED
+    assert not attempt.wrote_rows


### PR DESCRIPTION
## Description

Stacked on #13932.

The incognito orphan sweep did one Redis round trip and one record-mode lookup per session, so a pass at the 500 session cap cost about 1500 statements. It now runs two bounded passes: unadopted uploads in their own query, and session-held uploads bounded by distinct sessions so one busy session cannot fill a batch.

Three copies of the `DELETE_SINGLE_USER_FILE` enqueue had drifted apart, and the chat teardown copy never branched to the in-process drain, so on a deployment running no Celery its files landed on a queue with no consumer. All request paths now share one helper, as does the blob retry sweep.

Known and unchanged: an upload committing between teardown's marking query and its tombstone write waits for the orphan sweep. `main` has the same ordering.

## How Has This Been Tested?

Unit tests for the two sweep passes, the shared enqueue routing to the in-process drain when Celery is absent, and an upload claiming its rows when the indexing hand-off fails after they are committed.

`ruff check`, `ruff format --check`, `ty check`, and the full `backend/tests/unit` suite. Only `test_process_isolation.py` fails, the same way it does on main. The Postgres and Redis suites were not run: no services attached to this worktree.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
