### PR TITLE
fix(auth): drop the unsigned onyx_tid tenant cookie

### DIFF
--- a/backend/ee/onyx/server/middleware/tenant_tracking.py
+++ b/backend/ee/onyx/server/middleware/tenant_tracking.py
@@ -12,7 +12,7 @@ from ee.onyx.configs.multi_tenant_gating_config import (
 )
 from ee.onyx.server.tenants.product_gating import is_tenant_gated
 from onyx.auth.utils import extract_tenant_from_auth_header
-from onyx.configs.constants import ANONYMOUS_USER_COOKIE_NAME, TENANT_ID_COOKIE_NAME
+from onyx.configs.constants import ANONYMOUS_USER_COOKIE_NAME
 from onyx.db.engine.sql_engine import is_valid_schema_name
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.redis.redis_pool import (
@@ -111,13 +111,12 @@ def _is_path_allowed(path: str) -> bool:
 async def _get_tenant_id_from_request(
     request: Request, logger: logging.LoggerAdapter
 ) -> str:
-    """
-    Attempt to extract tenant_id from:
-    1) The API key or PAT (Personal Access Token) header
-    2) The Redis-based session token (Cookie: fastapiusersauth, or the
-       Authorization: Bearer header used by mobile clients)
-    3) The anonymous user cookie
-    Fallback: POSTGRES_DEFAULT_SCHEMA
+    """Workspace this request is authenticated for: the API key or PAT header,
+    the Redis session token, or the anonymous-user cookie.
+
+    Every source is signed or server-issued, so a caller cannot name a workspace
+    it has not authenticated to. An unauthenticated request resolves to the
+    default schema, which owns no workspace data.
     """
     # Check for API key or PAT in Authorization header
     tenant_id = extract_tenant_from_auth_header(request)
@@ -185,13 +184,4 @@ async def _get_tenant_id_from_request(
         # Don't `return` while an exception is propagating — it would swallow it
         # and fall back to the wrong tenant. Fall back only on the normal path.
         if sys.exc_info()[0] is None:
-            if tenant_id:
-                return tenant_id  # noqa: B012
-
-            # As a final step, check for explicit tenant_id cookie
-            tenant_id_cookie = request.cookies.get(TENANT_ID_COOKIE_NAME)
-            if tenant_id_cookie and is_valid_schema_name(tenant_id_cookie):
-                return tenant_id_cookie  # noqa: B012
-
-            # If we've reached this point, return the default schema
-            return POSTGRES_DEFAULT_SCHEMA  # noqa: B012
+            return tenant_id or POSTGRES_DEFAULT_SCHEMA  # noqa: B012

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -39,7 +39,6 @@ PUBLIC_API_TAGS: list[str | Enum] = ["public"]
 FASTAPI_USERS_AUTH_COOKIE_NAME = (
     os.environ.get("AUTH_COOKIE_NAME") or "fastapiusersauth"
 )
-TENANT_ID_COOKIE_NAME = "onyx_tid"  # tenant id - for workaround cases
 ANONYMOUS_USER_COOKIE_NAME = "onyx_anonymous_user"
 
 # ID used in UserInfo API responses for anonymous users (not a UUID, just a string identifier)

--- a/backend/tests/unit/ee/onyx/server/middleware/test_tenant_tracking.py
+++ b/backend/tests/unit/ee/onyx/server/middleware/test_tenant_tracking.py
@@ -97,3 +97,21 @@ async def test_no_auth_returns_default_schema(
     req = _request()
     tenant_id = await tenant_tracking._get_tenant_id_from_request(req, MagicMock())
     assert tenant_id == POSTGRES_DEFAULT_SCHEMA
+
+
+@pytest.mark.asyncio
+@patch(f"{MODULE}.retrieve_auth_token_data_from_bearer")
+@patch(f"{MODULE}.retrieve_auth_token_data_from_redis")
+async def test_client_supplied_cookie_cannot_select_a_workspace(
+    mock_cookie: AsyncMock,
+    mock_bearer: AsyncMock,
+) -> None:
+    """Every accepted source is signed or server-issued. A bare cookie naming a
+    schema is attacker input, and honoring it would hand an unauthenticated
+    caller that workspace on any route that reads tenant-scoped data."""
+    mock_cookie.return_value = None
+    mock_bearer.return_value = None
+
+    req = _request({"cookie": "onyx_tid=tenant_victim"})
+    tenant_id = await tenant_tracking._get_tenant_id_from_request(req, MagicMock())
+    assert tenant_id == POSTGRES_DEFAULT_SCHEMA

--- a/web/src/app/auth/reset-password/page.tsx
+++ b/web/src/app/auth/reset-password/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { resetPassword } from "../forgot-password/utils";
 import AuthFlowContainer from "@/components/auth/AuthFlowContainer";
 import Title from "@/components/ui/title";
@@ -14,28 +14,12 @@ import { TextFormField } from "@/components/Field";
 import { toast } from "@opal/layouts";
 import { Spinner } from "@/components/Spinner";
 import { redirect, useSearchParams } from "next/navigation";
-import {
-  NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED,
-  TENANT_ID_COOKIE_NAME,
-} from "@/lib/constants";
-import Cookies from "js-cookie";
+import { NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED } from "@/lib/constants";
 
 const ResetPasswordPage: React.FC = () => {
   const [isWorking, setIsWorking] = useState(false);
   const searchParams = useSearchParams();
   const token = searchParams?.get("token");
-  const tenantId = searchParams?.get(TENANT_ID_COOKIE_NAME);
-  // Keep search param same name as cookie for simplicity
-
-  useEffect(() => {
-    if (tenantId) {
-      Cookies.set(TENANT_ID_COOKIE_NAME, tenantId, {
-        path: "/",
-        expires: 1 / 24,
-      }); // Expires in 1 hour
-    }
-  }, [tenantId]);
-
   if (!NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED) {
     redirect("/auth/login");
   }

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -15,8 +15,6 @@ export const NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED =
   process.env.NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED?.toLowerCase() ===
   "true";
 
-export const TENANT_ID_COOKIE_NAME = "onyx_tid";
-
 // Name of the FastAPI-Users auth cookie. Configurable via env (shared with the
 // backend's AUTH_COOKIE_NAME) so deployments sharing a hostname — e.g. parallel
 // local worktrees on different ports of localhost — keep separate auth cookies.


### PR DESCRIPTION
## Description

**Bug:** the client could send an unsigned `onyx_tid` cookie naming a Postgres schema, and the tenant-tracking middleware honored it. A spoofed value selected another workspace's schema.

**Fix:** remove the cookie and all its client-side plumbing. Workspace resolution now comes only from signed or server-issued sources (API key/PAT header, Redis session token, anonymous-user JWT); unauthenticated requests fall back to the default schema, which owns no tenant data.

Regression test asserts a bare `onyx_tid` cookie is ignored.

First PR of the cloud multi-tenant SSO stack.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
