### PR TITLE
feat(auth): SSRF guard for admin-configured IdP URLs

### DIFF
--- a/backend/onyx/auth/oauth_refresher.py
+++ b/backend/onyx/auth/oauth_refresher.py
@@ -7,9 +7,11 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, cast
 
 import httpx
+from fastapi.concurrency import run_in_threadpool
 from fastapi_users.manager import BaseUserManager
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from onyx.auth.sso_url_guard import UnsafeSSOUrl, validate_idp_url
 from onyx.configs.app_configs import (
     OAUTH_CLIENT_ID,
     OAUTH_CLIENT_SECRET,
@@ -114,8 +116,20 @@ def _cached_token_endpoint(config_url: str) -> tuple[bool, Optional[str]]:
 
 async def _get_oidc_token_endpoint(config_url: str) -> Optional[str]:
     """Resolve token_endpoint from an OIDC discovery document. The per-URL
-    lock + double check coalesce concurrent fetches into one request."""
+    lock + double check coalesce concurrent fetches into one request.
+
+    Refresh runs long after the admin configured the row, and it POSTs the
+    client secret and the user's refresh token to whatever the document names,
+    so both the document URL and that endpoint are held to the same bound the
+    login path applies.
+    """
     if not config_url:
+        return None
+    try:
+        # Off the event loop: the guard resolves the host, which is blocking DNS.
+        await run_in_threadpool(validate_idp_url, config_url, field="openid_config_url")
+    except UnsafeSSOUrl as e:
+        logger.warning("Refusing OIDC discovery for refresh: %s", e)
         return None
     hit, cached = _cached_token_endpoint(config_url)
     if hit:
@@ -134,10 +148,14 @@ async def _get_oidc_token_endpoint(config_url: str) -> Optional[str]:
                 config: Dict[str, Any] = response.json()
             raw_endpoint = config.get("token_endpoint")
             if isinstance(raw_endpoint, str) and raw_endpoint:
+                await run_in_threadpool(
+                    validate_idp_url, raw_endpoint, field="token_endpoint"
+                )
                 token_endpoint = raw_endpoint
         except (httpx.HTTPError, ValueError) as e:
-            # ValueError covers json.JSONDecodeError when the IdP returns a
-            # non-JSON body (e.g. an HTML error page from a misconfigured URL).
+            # ValueError covers json.JSONDecodeError on a non-JSON body, and
+            # UnsafeSSOUrl when the document names a non-public endpoint. Both
+            # leave token_endpoint unset, so refresh declines to post the secret.
             logger.warning("Failed to fetch OIDC discovery document: %s", e)
         _OIDC_TOKEN_ENDPOINT_CACHE[config_url] = (token_endpoint, time.monotonic())
         return token_endpoint

--- a/backend/onyx/auth/oauth_refresher.py
+++ b/backend/onyx/auth/oauth_refresher.py
@@ -114,6 +114,19 @@ def _cached_token_endpoint(config_url: str) -> tuple[bool, Optional[str]]:
     return True, endpoint
 
 
+async def _revalidate_cached_endpoint(endpoint: Optional[str]) -> Optional[str]:
+    """Re-check a cached endpoint against the live SSRF setting, so tightening
+    the setting is not bypassed for the endpoint's remaining cache TTL."""
+    if endpoint is None:
+        return None
+    try:
+        await run_in_threadpool(validate_idp_url, endpoint, field="token_endpoint")
+    except UnsafeSSOUrl as e:
+        logger.warning("Cached token endpoint now fails SSRF policy: %s", e)
+        return None
+    return endpoint
+
+
 async def _get_oidc_token_endpoint(config_url: str) -> Optional[str]:
     """Resolve token_endpoint from an OIDC discovery document. The per-URL
     lock + double check coalesce concurrent fetches into one request.
@@ -133,13 +146,13 @@ async def _get_oidc_token_endpoint(config_url: str) -> Optional[str]:
         return None
     hit, cached = _cached_token_endpoint(config_url)
     if hit:
-        return cached
+        return await _revalidate_cached_endpoint(cached)
     async with await _get_discovery_lock(config_url):
         # Re-check inside the lock — another coroutine may have populated
         # the cache while we were waiting to acquire it.
         hit, cached = _cached_token_endpoint(config_url)
         if hit:
-            return cached
+            return await _revalidate_cached_endpoint(cached)
         token_endpoint: Optional[str] = None
         try:
             async with httpx.AsyncClient() as client:

--- a/backend/onyx/auth/sso_url_guard.py
+++ b/backend/onyx/auth/sso_url_guard.py
@@ -1,0 +1,103 @@
+"""Constrains the IdP URLs the server fetches on an admin's behalf.
+
+An OIDC provider's discovery URL is fetched server-side, and the document it
+returns names the token and userinfo endpoints fetched after it. On a self-hosted
+box that is the operator's own network. On cloud it is Onyx reaching into its own,
+so those URLs are held to the public internet.
+"""
+
+import ipaddress
+import socket
+from urllib.parse import urlsplit
+
+from shared_configs.configs import MULTI_TENANT
+
+_REQUIRED_SCHEME = "https"
+
+
+class UnsafeSSOUrl(ValueError):
+    """The URL names somewhere the server must not fetch on request."""
+
+
+_IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+
+# is_global already rejects loopback, private, link-local, NAT64 (via the ::/8
+# reserved block), and IPv4-mapped (it judges the embedded address). IPv6
+# site-local is the one private range it still reports as global.
+_SITE_LOCAL_V6 = ipaddress.IPv6Network("fec0::/10")
+
+
+def _parse_address(value: str) -> _IPAddress | None:
+    try:
+        return ipaddress.ip_address(value)
+    except ValueError:
+        return None
+
+
+def _is_public_unicast(ip: _IPAddress) -> bool:
+    if isinstance(ip, ipaddress.IPv6Address) and ip in _SITE_LOCAL_V6:
+        return False
+    return ip.is_global and not ip.is_multicast and not ip.is_reserved
+
+
+def _reject_private_host(host: str) -> None:
+    literal = _parse_address(host)
+    if literal is not None:
+        if not _is_public_unicast(literal):
+            raise UnsafeSSOUrl(f"{host} is not a public address")
+        return
+
+    # Resolution here and at fetch time are separate lookups, so this raises the
+    # cost of pointing at a private address rather than making it impossible.
+    # Closing the rebinding gap needs a transport pinned to the vetted address.
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror as e:
+        raise UnsafeSSOUrl(f"{host} could not be resolved") from e
+
+    for address in {info[4][0] for info in infos if isinstance(info[4][0], str)}:
+        resolved = _parse_address(address)
+        if resolved is not None and not _is_public_unicast(resolved):
+            raise UnsafeSSOUrl(
+                f"{host} resolves to {address}, which is not a public address"
+            )
+
+
+def validate_idp_url(url: str, *, field: str) -> None:
+    """Reject a URL a multi-tenant deployment must not fetch off the public
+    internet. Resolves the host, so it does blocking DNS and any redirect-
+    following fetcher must apply it per hop rather than once.
+    """
+    if not MULTI_TENANT:
+        return
+
+    parts = urlsplit(url)
+    if parts.scheme.lower() != _REQUIRED_SCHEME:
+        raise UnsafeSSOUrl(f"{field} must be an https URL")
+    if parts.username or parts.password:
+        raise UnsafeSSOUrl(f"{field} must not carry credentials")
+
+    host = parts.hostname
+    if not host:
+        raise UnsafeSSOUrl(f"{field} must name a host")
+    _reject_private_host(host)
+
+
+def validate_discovered_endpoints(
+    discovery_document: dict[str, object] | None,
+) -> None:
+    """The discovery document is attacker-chosen once its URL is, so the
+    endpoints Onyx goes on to call get the same treatment as the URL itself.
+    A document with no endpoints names nothing to fetch."""
+    if not MULTI_TENANT or not discovery_document:
+        return
+
+    for field in (
+        "authorization_endpoint",
+        "token_endpoint",
+        "userinfo_endpoint",
+        "jwks_uri",
+    ):
+        endpoint = discovery_document.get(field)
+        if isinstance(endpoint, str) and endpoint:
+            validate_idp_url(endpoint, field=field)

--- a/backend/onyx/auth/sso_url_guard.py
+++ b/backend/onyx/auth/sso_url_guard.py
@@ -21,9 +21,9 @@ class UnsafeSSOUrl(ValueError):
 
 _IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
 
-# is_global already rejects loopback, private, link-local, NAT64 (via the ::/8
-# reserved block), and IPv4-mapped (it judges the embedded address). IPv6
-# site-local is the one private range it still reports as global.
+# is_global rejects loopback, private, link-local, and IPv4-mapped (it judges the
+# embedded address). NAT64 and other reserved blocks fall to is_reserved, multicast
+# to is_multicast. IPv6 site-local still reads as global, so it is rejected below.
 _SITE_LOCAL_V6 = ipaddress.IPv6Network("fec0::/10")
 
 

--- a/backend/onyx/auth/sso_url_guard.py
+++ b/backend/onyx/auth/sso_url_guard.py
@@ -1,104 +1,53 @@
-"""Constrains the IdP URLs the server fetches on an admin's behalf.
+"""Stop a tenant admin from aiming the OIDC discovery URL, or the endpoints it
+names, at an address the server should not fetch."""
 
-An OIDC provider's discovery URL is fetched server-side, and the document it
-returns names the token and userinfo endpoints fetched after it. On a self-hosted
-box that is the operator's own network. On cloud it is Onyx reaching into its own,
-so those URLs are held to the public internet.
-"""
+from urllib.parse import urlsplit
 
-import ipaddress
-import socket
-from typing import Any
-from urllib.parse import SplitResult, urlsplit
+from onyx.server.security.models import outbound_ssrf_params
+from onyx.server.security.store import get_security_settings
+from onyx.utils.url import SSRFException, validate_outbound_http_url
 
-from shared_configs.configs import MULTI_TENANT
-
-_REQUIRED_SCHEME = "https"
+_DISCOVERY_ENDPOINT_FIELDS = (
+    "authorization_endpoint",
+    "token_endpoint",
+    "userinfo_endpoint",
+    "jwks_uri",
+)
 
 
 class UnsafeSSOUrl(ValueError):
     """The URL names somewhere the server must not fetch on request."""
 
 
-_IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
-
-# is_global rejects loopback, private, link-local, and IPv4-mapped (it judges the
-# embedded address). NAT64 and other reserved blocks fall to is_reserved, multicast
-# to is_multicast. IPv6 site-local still reads as global, so it is rejected below.
-_SITE_LOCAL_V6 = ipaddress.IPv6Network("fec0::/10")
-
-
-def _parse_address(value: str) -> _IPAddress | None:
-    try:
-        return ipaddress.ip_address(value)
-    except ValueError:
-        return None
-
-
-def _is_public_unicast(ip: _IPAddress) -> bool:
-    if isinstance(ip, ipaddress.IPv6Address) and ip in _SITE_LOCAL_V6:
-        return False
-    return ip.is_global and not ip.is_multicast and not ip.is_reserved
-
-
-def _reject_private_host(host: str) -> None:
-    literal: _IPAddress | None = _parse_address(host)
-    if literal is not None:
-        if not _is_public_unicast(literal):
-            raise UnsafeSSOUrl(f"{host} is not a public address")
-        return
-
-    # Resolution here and at fetch time are separate lookups, so this raises the
-    # cost of pointing at a private address rather than making it impossible.
-    # Closing the rebinding gap needs a transport pinned to the vetted address.
-    try:
-        infos: list[tuple[Any, ...]] = socket.getaddrinfo(host, None)
-    except socket.gaierror as e:
-        raise UnsafeSSOUrl(f"{host} could not be resolved") from e
-
-    for address in {info[4][0] for info in infos if isinstance(info[4][0], str)}:
-        resolved: _IPAddress | None = _parse_address(address)
-        if resolved is not None and not _is_public_unicast(resolved):
-            raise UnsafeSSOUrl(
-                f"{host} resolves to {address}, which is not a public address"
-            )
-
-
 def validate_idp_url(url: str, *, field: str) -> None:
-    """Reject a URL a multi-tenant deployment must not fetch off the public
-    internet. Resolves the host, so it does blocking DNS and any redirect-
-    following fetcher must apply it per hop rather than once.
-    """
-    if not MULTI_TENANT:
-        return
-
-    parts: SplitResult = urlsplit(url)
-    if parts.scheme.lower() != _REQUIRED_SCHEME:
-        raise UnsafeSSOUrl(f"{field} must be an https URL")
+    """Require https, no embedded credentials, and an address the SSRF Protection
+    setting permits. Checks one DNS resolution, so a redirect-following fetcher
+    must re-check each hop."""
+    parts = urlsplit(url)
     if parts.username or parts.password:
         raise UnsafeSSOUrl(f"{field} must not carry credentials")
 
-    host: str | None = parts.hostname
-    if not host:
-        raise UnsafeSSOUrl(f"{field} must name a host")
-    _reject_private_host(host)
+    params = outbound_ssrf_params(get_security_settings().ssrf_protection_level)
+    try:
+        validate_outbound_http_url(
+            url,
+            allow_private_network=params.allow_private_network,
+            https_only=True,
+            block_loopback_and_link_local=params.block_loopback_and_link_local,
+            block_link_local_only=params.block_link_local_only,
+        )
+    except (SSRFException, ValueError) as e:
+        raise UnsafeSSOUrl(f"{field}: {e}") from e
 
 
 def validate_discovered_endpoints(
     discovery_document: dict[str, object] | None,
 ) -> None:
-    """The discovery document is attacker-chosen once its URL is, so the
-    endpoints Onyx goes on to call get the same treatment as the URL itself.
-    A document with no endpoints names nothing to fetch."""
-    if not MULTI_TENANT or not discovery_document:
+    """The document is attacker-controlled once its URL is, so guard every
+    endpoint it names as strictly as the URL."""
+    if not discovery_document:
         return
-
-    for field in (
-        "authorization_endpoint",
-        "token_endpoint",
-        "userinfo_endpoint",
-        "jwks_uri",
-    ):
+    for field in _DISCOVERY_ENDPOINT_FIELDS:
         endpoint = discovery_document.get(field)
         if isinstance(endpoint, str) and endpoint:
             validate_idp_url(endpoint, field=field)

--- a/backend/onyx/auth/sso_url_guard.py
+++ b/backend/onyx/auth/sso_url_guard.py
@@ -8,7 +8,8 @@ so those URLs are held to the public internet.
 
 import ipaddress
 import socket
-from urllib.parse import urlsplit
+from typing import Any
+from urllib.parse import SplitResult, urlsplit
 
 from shared_configs.configs import MULTI_TENANT
 
@@ -41,7 +42,7 @@ def _is_public_unicast(ip: _IPAddress) -> bool:
 
 
 def _reject_private_host(host: str) -> None:
-    literal = _parse_address(host)
+    literal: _IPAddress | None = _parse_address(host)
     if literal is not None:
         if not _is_public_unicast(literal):
             raise UnsafeSSOUrl(f"{host} is not a public address")
@@ -51,12 +52,12 @@ def _reject_private_host(host: str) -> None:
     # cost of pointing at a private address rather than making it impossible.
     # Closing the rebinding gap needs a transport pinned to the vetted address.
     try:
-        infos = socket.getaddrinfo(host, None)
+        infos: list[tuple[Any, ...]] = socket.getaddrinfo(host, None)
     except socket.gaierror as e:
         raise UnsafeSSOUrl(f"{host} could not be resolved") from e
 
     for address in {info[4][0] for info in infos if isinstance(info[4][0], str)}:
-        resolved = _parse_address(address)
+        resolved: _IPAddress | None = _parse_address(address)
         if resolved is not None and not _is_public_unicast(resolved):
             raise UnsafeSSOUrl(
                 f"{host} resolves to {address}, which is not a public address"
@@ -71,13 +72,13 @@ def validate_idp_url(url: str, *, field: str) -> None:
     if not MULTI_TENANT:
         return
 
-    parts = urlsplit(url)
+    parts: SplitResult = urlsplit(url)
     if parts.scheme.lower() != _REQUIRED_SCHEME:
         raise UnsafeSSOUrl(f"{field} must be an https URL")
     if parts.username or parts.password:
         raise UnsafeSSOUrl(f"{field} must not carry credentials")
 
-    host = parts.hostname
+    host: str | None = parts.hostname
     if not host:
         raise UnsafeSSOUrl(f"{field} must name a host")
     _reject_private_host(host)

--- a/backend/tests/unit/onyx/auth/test_oauth_refresher.py
+++ b/backend/tests/unit/onyx/auth/test_oauth_refresher.py
@@ -21,6 +21,14 @@ from onyx.utils.sensitive import make_mock_sensitive_value
 _ENV_DISCOVERY_URL = "https://idp.example.com/.well-known/openid-configuration"
 
 
+@pytest.fixture(autouse=True)
+def _stub_idp_url_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    """These tests mock httpx but not DNS, so the SSRF guard's real
+    getaddrinfo on the discovery host would stall a no-network CI runner.
+    Guard behavior is covered in test_sso_url_guard.py."""
+    monkeypatch.setattr(oauth_refresher, "validate_idp_url", lambda *_a, **_k: None)
+
+
 @pytest.fixture
 def legacy_env_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     """No provider row resolves and the legacy env credentials are set."""

--- a/backend/tests/unit/onyx/auth/test_sso_url_guard.py
+++ b/backend/tests/unit/onyx/auth/test_sso_url_guard.py
@@ -1,45 +1,32 @@
 """Which IdP URLs the server will fetch on an admin's behalf.
 
-Where the admin is the operator, an IdP on their own network is a normal setup
-and nothing here applies. Where the admin is one tenant among many, the same
-URL is a request Onyx makes into its own network, so it is held to the public
-internet. Both directions are guarded: over-blocking would break real IdPs.
+Admin-configured IdP URLs run through the shared outbound-SSRF guard, so this
+covers the guard's own job: reject credentials in the URL, delegate the address
+check to that guard, and honor the SSRF Protection setting. A private IdP is
+reachable only when the operator relaxes that setting.
 """
 
-from unittest.mock import patch
+from contextlib import AbstractContextManager
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from onyx.auth.oauth_refresher import _get_oidc_token_endpoint
 from onyx.auth.sso_url_guard import UnsafeSSOUrl, validate_idp_url
+from onyx.server.security.models import SSRFProtectionLevel
 
 _CONFIG_PATH = "/.well-known/openid-configuration"
 
 
-@pytest.mark.parametrize(
-    "host",
-    [
-        "169.254.169.254",
-        "127.0.0.1",
-        "10.0.0.1",
-        "[::1]",
-        "[fc00::1]",
-        # Python reports each of these as global, so `is_global` alone is not
-        # the question being asked.
-        "[fec0::1]",
-        "[ff02::1]",
-        # NAT64 and IPv4-mapped, both carrying 127.0.0.1.
-        "[64:ff9b::7f00:1]",
-        "[::ffff:127.0.0.1]",
-        # 6to4 is deprecated (RFC 7526) and the stdlib treats the whole prefix
-        # as private, so every 6to4 address is refused, loopback or not.
-        "[2002:7f00:1::1]",
-        "[2002:0808:0808::1]",
-    ],
-)
-@patch("onyx.auth.sso_url_guard.MULTI_TENANT", True)
-def test_rejects_addresses_off_the_public_internet(host: str) -> None:
-    with pytest.raises(UnsafeSSOUrl):
+def _at_level(level: SSRFProtectionLevel) -> AbstractContextManager[MagicMock]:
+    settings = MagicMock()
+    settings.ssrf_protection_level = level
+    return patch("onyx.auth.sso_url_guard.get_security_settings", return_value=settings)
+
+
+@pytest.mark.parametrize("host", ["169.254.169.254", "127.0.0.1", "10.0.0.1"])
+def test_strict_level_rejects_private_targets(host: str) -> None:
+    with _at_level(SSRFProtectionLevel.VALIDATE_ALL), pytest.raises(UnsafeSSOUrl):
         validate_idp_url(f"https://{host}{_CONFIG_PATH}", field="openid_config_url")
 
 
@@ -48,44 +35,31 @@ def test_rejects_addresses_off_the_public_internet(host: str) -> None:
     [
         f"http://idp.example.com{_CONFIG_PATH}",
         f"https://user:pw@idp.example.com{_CONFIG_PATH}",
-        f"https:{_CONFIG_PATH}",
     ],
 )
-@patch("onyx.auth.sso_url_guard.MULTI_TENANT", True)
-def test_rejects_malformed_or_unencrypted_urls(url: str) -> None:
-    with pytest.raises(UnsafeSSOUrl):
+def test_rejects_unencrypted_or_credentialed_urls(url: str) -> None:
+    with _at_level(SSRFProtectionLevel.VALIDATE_ALL), pytest.raises(UnsafeSSOUrl):
         validate_idp_url(url, field="openid_config_url")
 
 
-@pytest.mark.parametrize(
-    "host",
-    [
-        "8.8.8.8",
-        "[2001:4860:4860::8888]",
-        "[2606:4700::1111]",
-        # A public IPv4 wrapped as IPv4-mapped stays reachable (is_global judges
-        # the embedded address).
-        "[::ffff:8.8.8.8]",
-    ],
-)
-@patch("onyx.auth.sso_url_guard.MULTI_TENANT", True)
-def test_allows_public_addresses(host: str) -> None:
-    validate_idp_url(f"https://{host}{_CONFIG_PATH}", field="openid_config_url")
+def test_strict_level_allows_a_public_address() -> None:
+    with _at_level(SSRFProtectionLevel.VALIDATE_ALL):
+        validate_idp_url(f"https://8.8.8.8{_CONFIG_PATH}", field="openid_config_url")
 
 
-@patch("onyx.auth.sso_url_guard.MULTI_TENANT", False)
-def test_allows_private_hosts_when_self_hosted() -> None:
-    """An IdP on the operator's own network is a normal self-hosted setup."""
-    validate_idp_url(
-        f"http://keycloak.internal{_CONFIG_PATH}", field="openid_config_url"
-    )
+def test_disabled_level_allows_a_private_idp() -> None:
+    """Relaxing the SSRF Protection setting is how a self-hosted operator points
+    at an IdP on their own network."""
+    with _at_level(SSRFProtectionLevel.DISABLED):
+        validate_idp_url(f"https://10.0.0.1{_CONFIG_PATH}", field="openid_config_url")
 
 
 @pytest.mark.asyncio
-@patch("onyx.auth.sso_url_guard.MULTI_TENANT", True)
 async def test_refresh_declines_a_private_discovery_url() -> None:
-    """Refresh posts the client secret and the user's refresh token to whatever
-    the document names, so it cannot fetch one login would not."""
-    assert (
-        await _get_oidc_token_endpoint(f"https://169.254.169.254{_CONFIG_PATH}") is None
-    )
+    """Refresh posts the client secret and the refresh token to whatever the
+    document names, so it cannot fetch one login would not."""
+    with _at_level(SSRFProtectionLevel.VALIDATE_ALL):
+        assert (
+            await _get_oidc_token_endpoint(f"https://169.254.169.254{_CONFIG_PATH}")
+            is None
+        )

--- a/backend/tests/unit/onyx/auth/test_sso_url_guard.py
+++ b/backend/tests/unit/onyx/auth/test_sso_url_guard.py
@@ -1,0 +1,91 @@
+"""Which IdP URLs the server will fetch on an admin's behalf.
+
+Where the admin is the operator, an IdP on their own network is a normal setup
+and nothing here applies. Where the admin is one tenant among many, the same
+URL is a request Onyx makes into its own network, so it is held to the public
+internet. Both directions are guarded: over-blocking would break real IdPs.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from onyx.auth.oauth_refresher import _get_oidc_token_endpoint
+from onyx.auth.sso_url_guard import UnsafeSSOUrl, validate_idp_url
+
+_CONFIG_PATH = "/.well-known/openid-configuration"
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "169.254.169.254",
+        "127.0.0.1",
+        "10.0.0.1",
+        "[::1]",
+        "[fc00::1]",
+        # Python reports each of these as global, so `is_global` alone is not
+        # the question being asked.
+        "[fec0::1]",
+        "[ff02::1]",
+        # NAT64 and IPv4-mapped, both carrying 127.0.0.1.
+        "[64:ff9b::7f00:1]",
+        "[::ffff:127.0.0.1]",
+        # 6to4 is deprecated (RFC 7526) and the stdlib treats the whole prefix
+        # as private, so every 6to4 address is refused, loopback or not.
+        "[2002:7f00:1::1]",
+        "[2002:0808:0808::1]",
+    ],
+)
+@patch("onyx.auth.sso_url_guard.MULTI_TENANT", True)
+def test_rejects_addresses_off_the_public_internet(host: str) -> None:
+    with pytest.raises(UnsafeSSOUrl):
+        validate_idp_url(f"https://{host}{_CONFIG_PATH}", field="openid_config_url")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        f"http://idp.example.com{_CONFIG_PATH}",
+        f"https://user:pw@idp.example.com{_CONFIG_PATH}",
+        f"https:{_CONFIG_PATH}",
+    ],
+)
+@patch("onyx.auth.sso_url_guard.MULTI_TENANT", True)
+def test_rejects_malformed_or_unencrypted_urls(url: str) -> None:
+    with pytest.raises(UnsafeSSOUrl):
+        validate_idp_url(url, field="openid_config_url")
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "8.8.8.8",
+        "[2001:4860:4860::8888]",
+        "[2606:4700::1111]",
+        # A public IPv4 wrapped as IPv4-mapped stays reachable (is_global judges
+        # the embedded address).
+        "[::ffff:8.8.8.8]",
+    ],
+)
+@patch("onyx.auth.sso_url_guard.MULTI_TENANT", True)
+def test_allows_public_addresses(host: str) -> None:
+    validate_idp_url(f"https://{host}{_CONFIG_PATH}", field="openid_config_url")
+
+
+@patch("onyx.auth.sso_url_guard.MULTI_TENANT", False)
+def test_allows_private_hosts_when_self_hosted() -> None:
+    """An IdP on the operator's own network is a normal self-hosted setup."""
+    validate_idp_url(
+        f"http://keycloak.internal{_CONFIG_PATH}", field="openid_config_url"
+    )
+
+
+@pytest.mark.asyncio
+@patch("onyx.auth.sso_url_guard.MULTI_TENANT", True)
+async def test_refresh_declines_a_private_discovery_url() -> None:
+    """Refresh posts the client secret and the user's refresh token to whatever
+    the document names, so it cannot fetch one login would not."""
+    assert (
+        await _get_oidc_token_endpoint(f"https://169.254.169.254{_CONFIG_PATH}") is None
+    )

--- a/backend/tests/unit/onyx/auth/test_sso_url_guard.py
+++ b/backend/tests/unit/onyx/auth/test_sso_url_guard.py
@@ -6,11 +6,13 @@ check to that guard, and honor the SSRF Protection setting. A private IdP is
 reachable only when the operator relaxes that setting.
 """
 
+import time
 from contextlib import AbstractContextManager
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from onyx.auth import oauth_refresher
 from onyx.auth.oauth_refresher import _get_oidc_token_endpoint
 from onyx.auth.sso_url_guard import UnsafeSSOUrl, validate_idp_url
 from onyx.server.security.models import SSRFProtectionLevel
@@ -63,3 +65,19 @@ async def test_refresh_declines_a_private_discovery_url() -> None:
             await _get_oidc_token_endpoint(f"https://169.254.169.254{_CONFIG_PATH}")
             is None
         )
+
+
+@pytest.mark.asyncio
+async def test_refresh_rechecks_a_cached_endpoint_when_policy_tightens() -> None:
+    """A token endpoint cached under a looser setting is re-validated on the next
+    refresh, so tightening the SSRF Protection setting is not bypassed."""
+    config_url = f"https://8.8.8.8{_CONFIG_PATH}"
+    oauth_refresher._OIDC_TOKEN_ENDPOINT_CACHE[config_url] = (
+        "https://10.0.0.1/token",
+        time.monotonic(),
+    )
+    try:
+        with _at_level(SSRFProtectionLevel.VALIDATE_ALL):
+            assert await _get_oidc_token_endpoint(config_url) is None
+    finally:
+        oauth_refresher._OIDC_TOKEN_ENDPOINT_CACHE.pop(config_url, None)


### PR DESCRIPTION
## Description

On cloud, an OIDC provider's discovery URL and the token/userinfo endpoints it names are fetched server-side, so a workspace admin's configured URL could reach Onyx's internal network (SSRF).

**Fix:** route these admin-configured IdP URLs through the shared outbound-SSRF guard (`validate_outbound_http_url`) that OAuth and MCP endpoints already use, driven by the deployment's SSRF Protection setting. Requires https, rejects embedded credentials, and blocks a private/internal target unless the setting allows it. An operator with an IdP on a private network relaxes that setting.

The discovery document's endpoints are validated the same way, since the document is attacker-controlled once its URL is.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
