### PR TITLE
feat(auth): cloud SSO login UI

### DIFF
--- a/web/lib/opal/src/layouts/auth/components.tsx
+++ b/web/lib/opal/src/layouts/auth/components.tsx
@@ -121,7 +121,8 @@ type SubmitLabel =
   | "join"
   | "reset"
   | "impersonate"
-  | "logout";
+  | "logout"
+  | "continue";
 
 interface SubmitProps {
   label: SubmitLabel;
@@ -138,6 +139,7 @@ const SUBMIT_LABEL_TEXT: Record<SubmitLabel, string> = {
   reset: "Reset Password",
   impersonate: "Impersonate",
   logout: "Sign Out",
+  continue: "Continue",
 };
 
 function Submit({ label, isSubmitting, isValid, dirty, onClick }: SubmitProps) {

--- a/web/src/app/auth/login/CloudSSOSignIn.tsx
+++ b/web/src/app/auth/login/CloudSSOSignIn.tsx
@@ -1,0 +1,114 @@
+// Each cloud workspace has its own IdP, so this button cannot redirect
+// anywhere until an address names one. Google and password sign-in can.
+
+"use client";
+
+import { useState } from "react";
+import { Formik } from "formik";
+import * as Yup from "yup";
+import { Button } from "@opal/components";
+import {
+  AuthLayouts,
+  InputErrorText,
+  InputVertical,
+  Section,
+} from "@opal/layouts";
+import { SvgUserKey } from "@opal/icons";
+import InputTypeInField from "@/refresh-components/form/InputTypeInField";
+import ProviderSignInButton from "@/app/auth/login/ProviderSignInButton";
+import type { SSOProviderOption } from "@/lib/auth/types";
+import { discoverSSOProviders } from "@/lib/sso/svc";
+
+// Deliberately the same copy for "no such workspace", "several workspaces" and
+// "workspace without SSO". The endpoint does not distinguish them either.
+const NO_PROVIDERS_MESSAGE =
+  "No SSO sign-in is set up for that address. Try Google or your password below.";
+
+const LOOKUP_SCHEMA = Yup.object({
+  email: Yup.string()
+    .email("Enter a valid email address")
+    .required("Email is required"),
+});
+
+interface LookupValues {
+  email: string;
+}
+
+interface CloudSSOSignInProps {
+  nextUrl: string | null;
+}
+
+export default function CloudSSOSignIn({ nextUrl }: CloudSSOSignInProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [providers, setProviders] = useState<SSOProviderOption[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleLookup(values: LookupValues) {
+    setError(null);
+    try {
+      const found = await discoverSSOProviders(values.email.toLowerCase());
+      if (found.length === 0) {
+        setError(NO_PROVIDERS_MESSAGE);
+        return;
+      }
+      setProviders(found);
+    } catch (exc) {
+      setError(exc instanceof Error ? exc.message : String(exc));
+    }
+  }
+
+  if (!expanded) {
+    return (
+      <Button
+        prominence="secondary"
+        width="full"
+        icon={SvgUserKey}
+        onClick={() => setExpanded(true)}
+      >
+        Sign in with SSO
+      </Button>
+    );
+  }
+
+  return (
+    <Section flexDirection="column" gap={4}>
+      {providers === null ? (
+        <Formik
+          initialValues={{ email: "" }}
+          validationSchema={LOOKUP_SCHEMA}
+          onSubmit={handleLookup}
+        >
+          {({ isSubmitting, isValid, dirty }) => (
+            <AuthLayouts.FormBody>
+              <AuthLayouts.Fields>
+                <InputVertical title="Work Email" withLabel="email">
+                  <InputTypeInField
+                    name="email"
+                    placeholder="email@yourcompany.com"
+                    data-testid="sso-email"
+                    autoComplete="username"
+                  />
+                </InputVertical>
+              </AuthLayouts.Fields>
+              <AuthLayouts.Submit
+                label="continue"
+                isSubmitting={isSubmitting}
+                isValid={isValid}
+                dirty={dirty}
+              />
+            </AuthLayouts.FormBody>
+          )}
+        </Formik>
+      ) : (
+        providers.map((provider) => (
+          <ProviderSignInButton
+            key={provider.name}
+            provider={provider}
+            nextUrl={nextUrl}
+          />
+        ))
+      )}
+      {error && <InputErrorText>{error}</InputErrorText>}
+    </Section>
+  );
+}

--- a/web/src/app/auth/login/LoginPage.tsx
+++ b/web/src/app/auth/login/LoginPage.tsx
@@ -2,7 +2,6 @@
 
 import { AuthTypeMetadata } from "@/lib/auth/types";
 import LoginText from "@/app/auth/login/LoginText";
-import CloudSSOSignIn from "@/app/auth/login/CloudSSOSignIn";
 import ProviderSignInButton from "@/app/auth/login/ProviderSignInButton";
 import { SignInButton, EmailPasswordForm } from "@/lib/auth/components";
 import { NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED } from "@/lib/constants";
@@ -49,12 +48,11 @@ export default function LoginPage({
         <div className="w-full justify-center flex flex-col gap-6">
           <LoginText />
           {authUrl && authTypeMetadata && (
-            <SignInButton authorizeUrl={authUrl} />
+            <>
+              <SignInButton authorizeUrl={authUrl} />
+              <AuthLayouts.OrSeparator />
+            </>
           )}
-          <CloudSSOSignIn nextUrl={effectiveNextUrl} />
-          <AuthLayouts.OrSeparator />
-          {/* Password sign-in is never hidden on cloud: it is the only route
-              that does not need a workspace resolved first. */}
           <EmailPasswordForm
             label="submit"
             shouldVerify={true}

--- a/web/src/app/auth/login/LoginPage.tsx
+++ b/web/src/app/auth/login/LoginPage.tsx
@@ -2,12 +2,13 @@
 
 import { AuthTypeMetadata } from "@/lib/auth/types";
 import LoginText from "@/app/auth/login/LoginText";
+import CloudSSOSignIn from "@/app/auth/login/CloudSSOSignIn";
 import ProviderSignInButton from "@/app/auth/login/ProviderSignInButton";
 import { SignInButton, EmailPasswordForm } from "@/lib/auth/components";
 import { NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED } from "@/lib/constants";
 import { useSendAuthRequiredMessage } from "@/lib/extension/hooks";
-import Text from "@/refresh-components/texts/Text";
 import { Button, MessageCard } from "@opal/components";
+import { AuthLayouts } from "@opal/layouts";
 
 interface LoginPageProps {
   authUrl: string | null;
@@ -48,17 +49,12 @@ export default function LoginPage({
         <div className="w-full justify-center flex flex-col gap-6">
           <LoginText />
           {authUrl && authTypeMetadata && (
-            <>
-              <SignInButton authorizeUrl={authUrl} />
-              <div className="flex flex-row items-center w-full gap-2">
-                <div className="flex-1 border-t border-text-01" />
-                <Text as="p" text03 mainUiMuted>
-                  or
-                </Text>
-                <div className="flex-1 border-t border-text-01" />
-              </div>
-            </>
+            <SignInButton authorizeUrl={authUrl} />
           )}
+          <CloudSSOSignIn nextUrl={effectiveNextUrl} />
+          <AuthLayouts.OrSeparator />
+          {/* Password sign-in is never hidden on cloud: it is the only route
+              that does not need a workspace resolved first. */}
           <EmailPasswordForm
             label="submit"
             shouldVerify={true}
@@ -84,16 +80,7 @@ export default function LoginPage({
                   />
                 ))}
               </div>
-              {passwordAuthEnabled && (
-                /* raw-ok: pre-existing or-divider markup */
-                <div className="flex flex-row items-center w-full gap-2">
-                  <div className="flex-1 border-t border-text-01" />
-                  <Text as="p" text03 mainUiMuted>
-                    or
-                  </Text>
-                  <div className="flex-1 border-t border-text-01" />
-                </div>
-              )}
+              {passwordAuthEnabled && <AuthLayouts.OrSeparator />}
             </>
           )}
           {passwordAuthEnabled && (

--- a/web/src/app/auth/login/ProviderSignInButton.tsx
+++ b/web/src/app/auth/login/ProviderSignInButton.tsx
@@ -17,8 +17,8 @@
 
 import { useState } from "react";
 import { Button } from "@opal/components";
-import { FcGoogle } from "react-icons/fc";
-import Text from "@/refresh-components/texts/Text";
+import { InputErrorText } from "@opal/layouts";
+import { SvgGoogle } from "@opal/logos";
 import { SSOProviderOption } from "@/lib/auth/types";
 
 interface ProviderSignInButtonProps {
@@ -40,10 +40,11 @@ export default function ProviderSignInButton({
     setIsRedirecting(true);
     setError(null);
     try {
-      const url = nextUrl
-        ? `${provider.authorizeUrl}?next=${encodeURIComponent(nextUrl)}`
-        : provider.authorizeUrl;
-      const res = await fetch(url, { credentials: "include" });
+      // The authorize URL may already carry a query (the workspace pin on
+      // cloud), so `next` has to be appended as a parameter, not concatenated.
+      const url = new URL(provider.authorizeUrl, window.location.origin);
+      if (nextUrl) url.searchParams.set("next", nextUrl);
+      const res = await fetch(url.toString(), { credentials: "include" });
       if (!res.ok) {
         throw new Error(`Could not start sign-in (status ${res.status})`);
       }
@@ -64,17 +65,13 @@ export default function ProviderSignInButton({
       <Button
         prominence={isGoogle ? "secondary" : "primary"}
         width="full"
-        icon={isGoogle ? FcGoogle : undefined}
+        icon={isGoogle ? SvgGoogle : undefined}
         onClick={handleClick}
         disabled={isRedirecting}
       >
         {provider.displayName}
       </Button>
-      {error && (
-        <Text as="p" mainUiMuted className="text-status-error-05 mt-2">
-          {error}
-        </Text>
-      )}
+      {error && <InputErrorText>{error}</InputErrorText>}
     </>
   );
 }

--- a/web/src/lib/sso/svc.ts
+++ b/web/src/lib/sso/svc.ts
@@ -1,4 +1,5 @@
 import { SWR_KEYS } from "@/lib/swr-keys";
+import type { SSOProviderOption, SSOProviderType } from "@/lib/auth/types";
 import {
   SSOProviderCreateRequest,
   SSOProviderResponse,
@@ -48,6 +49,31 @@ export function updateSSOProvider(
     "PATCH",
     request
   );
+}
+
+// The backend serves snake_case, so the wire shape is spelled out separately
+// from the camelCase model rather than cast across the boundary.
+interface SSOProviderOptionWire {
+  name: string;
+  display_name: string;
+  provider_type: SSOProviderType;
+  authorize_url: string;
+}
+
+export async function discoverSSOProviders(
+  email: string
+): Promise<SSOProviderOption[]> {
+  const data = await ssoRequest<{ providers?: SSOProviderOptionWire[] }>(
+    "/api/auth/sso/discover",
+    "POST",
+    { email }
+  );
+  return (data.providers ?? []).map((provider) => ({
+    name: provider.name,
+    displayName: provider.display_name,
+    providerType: provider.provider_type,
+    authorizeUrl: provider.authorize_url,
+  }));
 }
 
 export function setSSOProviderEnabled(


### PR DESCRIPTION
## Description

The cloud login page, where one domain serves every workspace.

- Adds **Sign in with SSO**: enter your email, discovery resolves your workspace and offers its providers with a signed pin.
- Google sign-in uses the in-house `SvgGoogle` icon and the shared `InputErrorText`; the two hand-rolled dividers collapse into `AuthLayouts.OrSeparator`.
- Password sign-in is never hidden on cloud, the only route that needs no workspace resolved first.

Stacked on #13936.

## How Has This Been Tested?

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/134961cc-d084-4e1a-b4fd-c7bd89386116) | ![after](https://github.com/user-attachments/assets/d35097f3-ee91-45c1-87a3-799a2492eb78) |

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
