### PR TITLE
feat(auth): per-tenant SSO provider config

### DIFF
--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -4,6 +4,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+from email_validator import EmailNotValidError, validate_email
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -181,16 +182,15 @@ def validate_sso_provider_name(name: str) -> None:
         )
 
 
-# A domain is a routing key and, on cloud, an email recipient (the verification
-# code is sent to a role mailbox at the domain), so it must be a syntactically
-# valid hostname before it can be stored.
-_VALID_EMAIL_DOMAIN = re.compile(
-    r"^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$"
-)
-
-
 def is_valid_email_domain(domain: str) -> bool:
-    return bool(_VALID_EMAIL_DOMAIN.match(domain))
+    """A domain is a routing key and, on cloud, an email recipient (the
+    verification code goes to a role mailbox there), so it must be a
+    syntactically valid mail domain before it is stored."""
+    try:
+        validate_email(f"x@{domain}", check_deliverability=False)
+    except EmailNotValidError:
+        return False
+    return True
 
 
 def normalize_email_domains(domains: list[str]) -> list[str]:

--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -181,6 +181,18 @@ def validate_sso_provider_name(name: str) -> None:
         )
 
 
+# A domain is a routing key and, on cloud, an email recipient (the verification
+# code is sent to a role mailbox at the domain), so it must be a syntactically
+# valid hostname before it can be stored.
+_VALID_EMAIL_DOMAIN = re.compile(
+    r"^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$"
+)
+
+
+def is_valid_email_domain(domain: str) -> bool:
+    return bool(_VALID_EMAIL_DOMAIN.match(domain))
+
+
 def normalize_email_domains(domains: list[str]) -> list[str]:
     return sorted({domain.strip().lower() for domain in domains if domain.strip()})
 

--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -81,6 +81,25 @@ _CONFIG_MODEL_BY_TYPE: dict[SSOProviderType, type[_ProviderConfig]] = {
 }
 
 
+# SAML picks its provider by scanning rows for the assertion's issuer, which
+# cannot name a workspace without a catalog issuer index.
+_CLOUD_SUPPORTED_PROVIDER_TYPES = frozenset(
+    {SSOProviderType.GOOGLE_OAUTH, SSOProviderType.OIDC}
+)
+
+
+def sso_provider_type_supported(provider_type: SSOProviderType) -> bool:
+    return not MULTI_TENANT or provider_type in _CLOUD_SUPPORTED_PROVIDER_TYPES
+
+
+def supported_sso_provider_types() -> list[SSOProviderType]:
+    return [
+        provider_type
+        for provider_type in SSOProviderType
+        if sso_provider_type_supported(provider_type)
+    ]
+
+
 def secret_config_keys(provider_type: SSOProviderType) -> frozenset[str]:
     """Config fields marked secret on the provider type's config model."""
     model = _CONFIG_MODEL_BY_TYPE[provider_type]
@@ -141,6 +160,20 @@ def sso_login_callback_uri(
     return f"{web_domain}/api/auth/oidc/{provider.name}/callback"
 
 
+# Keep in sync with the router prefixes in oidc_multi.py and saml_multi.py.
+_AUTHORIZE_ROUTER_BY_TYPE: dict[SSOProviderType, str] = {
+    SSOProviderType.GOOGLE_OAUTH: "oidc",
+    SSOProviderType.OIDC: "oidc",
+    SSOProviderType.SAML: "saml",
+}
+
+
+def sso_authorize_path(provider: SSOProvider) -> str:
+    """Login-page href that starts this provider's flow."""
+    router = _AUTHORIZE_ROUTER_BY_TYPE[provider.provider_type]
+    return f"/api/auth/{router}/{provider.name}/authorize"
+
+
 def validate_sso_provider_name(name: str) -> None:
     if not _PROVIDER_NAME_PATTERN.fullmatch(name):
         raise ValueError(
@@ -148,7 +181,7 @@ def validate_sso_provider_name(name: str) -> None:
         )
 
 
-def _normalize_domains(domains: list[str]) -> list[str]:
+def normalize_email_domains(domains: list[str]) -> list[str]:
     return sorted({domain.strip().lower() for domain in domains if domain.strip()})
 
 
@@ -196,7 +229,7 @@ def create_sso_provider(
         display_name=display_name,
         provider_type=provider_type,
         config=validate_sso_config(provider_type, config),
-        allowed_email_domains=_normalize_domains(allowed_email_domains),
+        allowed_email_domains=normalize_email_domains(allowed_email_domains),
     )
     db_session.add(provider)
     db_session.commit()
@@ -225,7 +258,7 @@ def update_sso_provider(
             provider.provider_type, config
         )
     if allowed_email_domains is not None:
-        provider.allowed_email_domains = _normalize_domains(allowed_email_domains)
+        provider.allowed_email_domains = normalize_email_domains(allowed_email_domains)
 
     db_session.commit()
     return provider

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -17,8 +17,7 @@ from onyx.configs.constants import (
 )
 from onyx.db.auth import get_user_count
 from onyx.db.engine.sql_engine import get_session_with_shared_schema
-from onyx.db.enums import SSOProviderType
-from onyx.db.sso_provider import fetch_sso_providers
+from onyx.db.sso_provider import fetch_sso_providers, sso_authorize_path
 from onyx.server.manage.models import (
     AllVersions,
     AuthConfigResponse,
@@ -31,15 +30,6 @@ from onyx.server.security.store import get_security_settings
 from shared_configs.configs import MULTI_TENANT
 
 router = APIRouter()
-
-# GOOGLE_OAUTH and OIDC share the /auth/oidc router. SAML has its own. Keep in
-# sync with the router prefixes in oidc_multi.py and saml_multi.py.
-_SSO_AUTHORIZE_ROUTER = {
-    SSOProviderType.GOOGLE_OAUTH: "oidc",
-    SSOProviderType.OIDC: "oidc",
-    SSOProviderType.SAML: "saml",
-}
-
 
 # TTL matches the endpoint's HTTP max-age (60s). The two windows stack.
 # Admin mutations invalidate this pod directly. Other pods ride the TTL.
@@ -63,8 +53,8 @@ def invalidate_sso_provider_options_cache() -> None:
 
 
 def _fetch_sso_provider_options() -> list[SSOProviderOption]:
-    # Single-tenant only. /auth/type runs before any tenant context, so a
-    # multi-tenant lookup has no tenant to key on.
+    # One cached response for every visitor, so it can only speak for a
+    # deployment with one set of providers. Cloud uses /auth/sso/discover.
     if MULTI_TENANT:
         return []
     # The lock spans the DB read so a mutation's invalidate cannot land between
@@ -79,10 +69,7 @@ def _fetch_sso_provider_options() -> list[SSOProviderOption]:
                     name=provider.name,
                     display_name=provider.display_name,
                     provider_type=provider.provider_type,
-                    authorize_url=(
-                        f"/api/auth/{_SSO_AUTHORIZE_ROUTER[provider.provider_type]}"
-                        f"/{provider.name}/authorize"
-                    ),
+                    authorize_url=sso_authorize_path(provider),
                 )
                 for provider in fetch_sso_providers(db_session, enabled_only=True)
             ]

--- a/backend/onyx/server/manage/sso/api.py
+++ b/backend/onyx/server/manage/sso/api.py
@@ -5,14 +5,18 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
+from onyx.auth.sso_url_guard import UnsafeSSOUrl, validate_idp_url
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session
-from onyx.db.enums import Permission
+from onyx.db.enums import Permission, SSOProviderType
 from onyx.db.models import SSOProvider, User
 from onyx.db.sso_provider import (
     create_sso_provider,
     fetch_sso_providers,
+    normalize_email_domains,
     set_sso_provider_enabled,
+    sso_provider_type_supported,
+    supported_sso_provider_types,
     update_sso_provider,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
@@ -33,17 +37,43 @@ from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 from shared_configs.configs import MULTI_TENANT
 
 
-def _reject_if_multi_tenant() -> None:
-    if MULTI_TENANT:
+def _reject_unsupported_provider_type(provider_type: SSOProviderType) -> None:
+    if not sso_provider_type_supported(provider_type):
         raise OnyxError(
             OnyxErrorCode.SINGLE_TENANT_ONLY,
-            "SSO provider configuration is not available on this deployment.",
+            f"{provider_type.value} providers are not available on this deployment.",
         )
 
 
-admin_router = APIRouter(
-    prefix="/admin/sso", dependencies=[Depends(_reject_if_multi_tenant)]
-)
+def _reject_unbounded_email_domains(allowed_email_domains: list[str] | None) -> None:
+    """A list that stores empty disables the domain check entirely, so on cloud
+    the provider would admit every address its IdP is willing to assert, each one
+    a billed seat. Judged after normalization, since blank entries are dropped on
+    write and `[" "]` would otherwise pass here and store as `[]`."""
+    if not MULTI_TENANT or allowed_email_domains is None:
+        return
+    if normalize_email_domains(allowed_email_domains):
+        return
+    raise OnyxError(
+        OnyxErrorCode.INVALID_INPUT,
+        "List the email domains this provider may sign in. Leaving it empty "
+        "would let any address its identity provider asserts join the workspace.",
+    )
+
+
+def _reject_unfetchable_idp_url(config: dict[str, Any]) -> None:
+    """Fails the write rather than the first login, so an admin who typo'd a
+    host hears about it here."""
+    discovery_url = config.get("openid_config_url")
+    if not isinstance(discovery_url, str) or not discovery_url:
+        return
+    try:
+        validate_idp_url(discovery_url, field="openid_config_url")
+    except UnsafeSSOUrl as e:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e)) from e
+
+
+admin_router = APIRouter(prefix="/admin/sso")
 
 
 def _require_business_tier_for_additional_enabled_provider(
@@ -71,6 +101,15 @@ def _fetch_sso_provider_or_raise(db_session: Session, provider_id: int) -> SSOPr
     return provider
 
 
+@admin_router.get("/provider-type")
+def list_supported_sso_provider_types(
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+) -> list[SSOProviderType]:
+    """Provider types this deployment can serve, so the admin UI never offers a
+    type the create endpoint would reject."""
+    return supported_sso_provider_types()
+
+
 @admin_router.get("/provider")
 def list_sso_providers(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
@@ -88,6 +127,9 @@ def create_sso_provider_endpoint(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> SSOProviderResponse:
+    _reject_unsupported_provider_type(request.provider_type)
+    _reject_unfetchable_idp_url(request.config)
+    _reject_unbounded_email_domains(request.allowed_email_domains)
     # New providers are created enabled, so an existing enabled provider
     # makes this a multi-SSO create.
     _require_business_tier_for_additional_enabled_provider(db_session)
@@ -123,6 +165,7 @@ def update_sso_provider_endpoint(
     db_session: Session = Depends(get_session),
 ) -> SSOProviderResponse:
     provider = _fetch_sso_provider_or_raise(db_session, provider_id)
+    _reject_unbounded_email_domains(request.allowed_email_domains)
 
     try:
         merged_config: dict[str, Any] | None = None
@@ -138,6 +181,7 @@ def update_sso_provider_endpoint(
                 **restore_masked_credentials(request.config, stored_config),
             }
             reject_masked_credentials(merged_config)
+            _reject_unfetchable_idp_url(merged_config)
         updated_provider = update_sso_provider(
             db_session=db_session,
             provider_id=provider_id,
@@ -159,8 +203,12 @@ def set_sso_provider_enabled_endpoint(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> SSOProviderResponse:
-    _fetch_sso_provider_or_raise(db_session, provider_id)
+    provider_to_toggle = _fetch_sso_provider_or_raise(db_session, provider_id)
     if request.enabled:
+        _reject_unsupported_provider_type(provider_to_toggle.provider_type)
+        # Catches a row stored before the bound existed, which the write paths
+        # never revisit.
+        _reject_unbounded_email_domains(provider_to_toggle.allowed_email_domains)
         _require_business_tier_for_additional_enabled_provider(
             db_session, exclude_provider_id=provider_id
         )

--- a/backend/onyx/server/manage/sso/api.py
+++ b/backend/onyx/server/manage/sso/api.py
@@ -13,6 +13,7 @@ from onyx.db.models import SSOProvider, User
 from onyx.db.sso_provider import (
     create_sso_provider,
     fetch_sso_providers,
+    is_valid_email_domain,
     normalize_email_domains,
     set_sso_provider_enabled,
     sso_provider_type_supported,
@@ -45,20 +46,27 @@ def _reject_unsupported_provider_type(provider_type: SSOProviderType) -> None:
         )
 
 
-def _reject_unbounded_email_domains(allowed_email_domains: list[str] | None) -> None:
-    """A list that stores empty disables the domain check entirely, so on cloud
-    the provider would admit every address its IdP is willing to assert, each one
-    a billed seat. Judged after normalization, since blank entries are dropped on
-    write and `[" "]` would otherwise pass here and store as `[]`."""
+def _validate_cloud_email_domains(allowed_email_domains: list[str] | None) -> None:
+    """On cloud the domain list is both the seat boundary and a routing key, so
+    it must be non-empty and every entry a valid hostname. A malformed domain
+    would otherwise persist and fail only later, when verification tries to email
+    it. Judged after normalization, which drops blanks. Single-tenant leaves the
+    list optional and unrouted, so it skips both checks."""
     if not MULTI_TENANT or allowed_email_domains is None:
         return
-    if normalize_email_domains(allowed_email_domains):
-        return
-    raise OnyxError(
-        OnyxErrorCode.INVALID_INPUT,
-        "List the email domains this provider may sign in. Leaving it empty "
-        "would let any address its identity provider asserts join the workspace.",
-    )
+    normalized = normalize_email_domains(allowed_email_domains)
+    if not normalized:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "List the email domains this provider may sign in. Leaving it empty "
+            "would let any address its identity provider asserts join the workspace.",
+        )
+    invalid = [domain for domain in normalized if not is_valid_email_domain(domain)]
+    if invalid:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"These are not valid email domains: {', '.join(invalid)}.",
+        )
 
 
 def _reject_unfetchable_idp_url(config: dict[str, Any]) -> None:
@@ -129,7 +137,7 @@ def create_sso_provider_endpoint(
 ) -> SSOProviderResponse:
     _reject_unsupported_provider_type(request.provider_type)
     _reject_unfetchable_idp_url(request.config)
-    _reject_unbounded_email_domains(request.allowed_email_domains)
+    _validate_cloud_email_domains(request.allowed_email_domains)
     # New providers are created enabled, so an existing enabled provider
     # makes this a multi-SSO create.
     _require_business_tier_for_additional_enabled_provider(db_session)
@@ -165,7 +173,7 @@ def update_sso_provider_endpoint(
     db_session: Session = Depends(get_session),
 ) -> SSOProviderResponse:
     provider = _fetch_sso_provider_or_raise(db_session, provider_id)
-    _reject_unbounded_email_domains(request.allowed_email_domains)
+    _validate_cloud_email_domains(request.allowed_email_domains)
 
     try:
         merged_config: dict[str, Any] | None = None
@@ -208,7 +216,7 @@ def set_sso_provider_enabled_endpoint(
         _reject_unsupported_provider_type(provider_to_toggle.provider_type)
         # Catches a row stored before the bound existed, which the write paths
         # never revisit.
-        _reject_unbounded_email_domains(provider_to_toggle.allowed_email_domains)
+        _validate_cloud_email_domains(provider_to_toggle.allowed_email_domains)
         _require_business_tier_for_additional_enabled_provider(
             db_session, exclude_provider_id=provider_id
         )

--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -21,6 +21,10 @@ from httpx_oauth.oauth2 import BaseOAuth2, GetAccessTokenError
 from sqlalchemy.orm import Session
 
 from onyx.auth.oidc_client import VerifiedEmailOpenID
+from onyx.auth.sso_url_guard import (
+    validate_discovered_endpoints,
+    validate_idp_url,
+)
 from onyx.auth.sso_web_error import delete_pkce_cookie, redirect_sso_errors_to_web
 from onyx.auth.users import (
     CSRF_TOKEN_COOKIE_NAME,
@@ -119,6 +123,10 @@ def _drop_unadvertised_offline_access(client: BaseOAuth2[Any]) -> None:
 
 def _build_client(provider: SSOProvider, config: dict[str, Any]) -> BaseOAuth2[Any]:
     if provider.provider_type is SSOProviderType.OIDC:
+        # Re-checked here, not just on write, so a row stored before the guard
+        # existed cannot be fetched either. Cached with the client, so this
+        # costs one resolution per TTL rather than one per login.
+        validate_idp_url(config["openid_config_url"], field="openid_config_url")
         # Scope overrides let providers request extra API scopes (e.g. MS Graph
         # User.Read for claims capture): the row's scopes win, then the env
         # override while it exists. offline_access secures refresh tokens.
@@ -134,6 +142,9 @@ def _build_client(provider: SSOProvider, config: dict[str, Any]) -> BaseOAuth2[A
             base_scopes=scopes,
             require_verified_email=config.get("require_verified_email", False),
         )
+        # The document is attacker-chosen once its URL is, and the endpoints it
+        # names are fetched next, so they get the same treatment as the URL.
+        validate_discovered_endpoints(getattr(client, "openid_configuration", None))
         # Explicitly configured offline_access is always respected as-is.
         if offline_access_auto_added:
             _drop_unadvertised_offline_access(client)

--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.oidc_client import VerifiedEmailOpenID
 from onyx.auth.sso_url_guard import (
+    UnsafeSSOUrl,
     validate_discovered_endpoints,
     validate_idp_url,
 )
@@ -186,7 +187,16 @@ async def _get_oauth_client(
     if cached_client is not None:
         return cached_client
 
-    client = await run_in_threadpool(_build_client, provider, config)
+    try:
+        client = await run_in_threadpool(_build_client, provider, config)
+    except UnsafeSSOUrl as e:
+        # A row stored before the write guard, or a discovery doc that started
+        # naming a rejected endpoint, reaches this browser-facing path. Surface a
+        # clean error rather than letting the ValueError escape as a raw 400.
+        raise OnyxError(
+            OnyxErrorCode.BAD_GATEWAY,
+            "This provider's sign-in URL is not reachable.",
+        ) from e
     _CLIENT_CACHE[cache_key] = client
     return client
 

--- a/backend/onyx/server/saml_multi.py
+++ b/backend/onyx/server/saml_multi.py
@@ -20,6 +20,7 @@ from onyx.db.sso_provider import (
     SAMLProviderConfig,
     fetch_sso_provider_by_name,
     fetch_sso_providers,
+    sso_provider_type_supported,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -34,7 +35,21 @@ from onyx.server.saml import (
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
-router = APIRouter(prefix="/auth/saml")
+
+
+def _reject_if_unsupported() -> None:
+    """SAML resolves a login by scanning provider rows for the assertion's
+    issuer, and an IdP-initiated assertion carries no state Onyx signed. Neither
+    can name a workspace on a deployment that has more than one, so the whole
+    router is closed there rather than failing deeper in."""
+    if not sso_provider_type_supported(SSOProviderType.SAML):
+        raise OnyxError(
+            OnyxErrorCode.SINGLE_TENANT_ONLY,
+            "SAML sign-in is not available on this deployment.",
+        )
+
+
+router = APIRouter(prefix="/auth/saml", dependencies=[Depends(_reject_if_unsupported)])
 
 
 # The OneLogin settings schema (its own key names, camelCase). We build and hand

--- a/backend/tests/external_dependency_unit/auth/test_oidc_multi_live_idp.py
+++ b/backend/tests/external_dependency_unit/auth/test_oidc_multi_live_idp.py
@@ -81,6 +81,17 @@ def require_mock_oidc() -> None:
         pytest.skip("requires navikt/mock-oauth2-server (MOCK_OIDC_URL)")
 
 
+@pytest.fixture(autouse=True)
+def _stub_idp_url_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The mock IdP is http on loopback, which the authorize-path guard rejects
+    # (https and public only). Stub it here. The guard is covered in
+    # test_sso_url_guard.py.
+    monkeypatch.setattr(oidc_multi, "validate_idp_url", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        oidc_multi, "validate_discovered_endpoints", lambda *_a, **_k: None
+    )
+
+
 def _config_url(issuer: str) -> str:
     return f"{_MOCK_URL}/{issuer}/.well-known/openid-configuration"
 

--- a/backend/tests/external_dependency_unit/auth/test_sso_admin_api.py
+++ b/backend/tests/external_dependency_unit/auth/test_sso_admin_api.py
@@ -28,6 +28,14 @@ from onyx.server.manage.sso.api import admin_router
 from onyx.utils.encryption import is_masked_credential
 
 
+@pytest.fixture(autouse=True)
+def _stub_idp_url_guard() -> Generator[None, None, None]:
+    # Provider CRUD here uses placeholder IdP URLs and must not hit the network.
+    # The URL guard itself is covered in test_sso_url_guard.
+    with patch("onyx.server.manage.sso.api.validate_idp_url", return_value=None):
+        yield
+
+
 @pytest.fixture()
 def client(
     db_session: Session,

--- a/backend/tests/external_dependency_unit/auth/test_sso_admin_api.py
+++ b/backend/tests/external_dependency_unit/auth/test_sso_admin_api.py
@@ -1,6 +1,6 @@
 """Guard the SSO admin API contract: secrets never persist masked, config
-merges stay partial, conflicting or missing providers are reported, and the
-routes are single-tenant only.
+merges stay partial, conflicting or missing providers are reported, and only
+provider types the deployment can actually route are configurable.
 
 The API must never persist masked secrets as real config values.
 """
@@ -100,6 +100,21 @@ def _build_oidc_request(name: str, client_secret: str) -> dict[str, Any]:
             "client_id": "client-id",
             "client_secret": client_secret,
             "openid_config_url": "https://idp.example.com/.well-known/openid-configuration",
+        },
+        "allowed_email_domains": ["companya.com"],
+    }
+
+
+def _build_saml_request(name: str) -> dict[str, Any]:
+    return {
+        "name": name,
+        "display_name": "Company SAML",
+        "provider_type": SSOProviderType.SAML.value,
+        "config": {
+            "idp_entity_id": "https://idp.example.com/entity",
+            "idp_sso_url": "https://idp.example.com/sso",
+            "idp_x509_cert": "cert",
+            "sp_entity_id": "onyx",
         },
         "allowed_email_domains": ["companya.com"],
     }
@@ -546,17 +561,61 @@ def test_second_enabled_provider_requires_business_tier(
         )
 
 
+@patch("onyx.db.sso_provider.MULTI_TENANT", True)
+def test_multi_tenant_rejects_saml_and_admits_oauth(
+    client: TestClient, provider_names: list[str]
+) -> None:
+    """Cloud cannot route a SAML assertion to a workspace, so SAML alone is
+    refused. OAuth-shaped providers configure normally."""
+    saml_response = client.post(
+        "/admin/sso/provider",
+        json=_build_saml_request(_new_provider_name("saml-test")),
+    )
+    assert saml_response.status_code == OnyxErrorCode.SINGLE_TENANT_ONLY.status_code
+    assert saml_response.json()["error_code"] == OnyxErrorCode.SINGLE_TENANT_ONLY.code
+
+    oidc_name = _new_provider_name()
+    provider_names.append(oidc_name)
+    oidc_response = client.post(
+        "/admin/sso/provider",
+        json=_build_oidc_request(oidc_name, "secret"),
+    )
+    assert oidc_response.status_code == 200
+
+    types_response = client.get("/admin/sso/provider-type")
+    assert types_response.status_code == 200
+    assert types_response.json() == [
+        SSOProviderType.GOOGLE_OAUTH.value,
+        SSOProviderType.OIDC.value,
+    ]
+
+
+@pytest.mark.parametrize("domains", [[], [" "], ["", "  "]])
 @patch("onyx.server.manage.sso.api.MULTI_TENANT", True)
-def test_multi_tenant_deployments_are_rejected(client: TestClient) -> None:
-    """The gate sits on the router, so no handler below it is reachable."""
-    for response in (
-        client.get("/admin/sso/provider"),
-        client.post(
-            "/admin/sso/provider",
-            json=_build_oidc_request(_new_provider_name(), "secret"),
-        ),
-        client.patch("/admin/sso/provider/1", json={"display_name": "Blocked"}),
-        client.post("/admin/sso/provider/1/enabled", json={"enabled": True}),
-    ):
-        assert response.status_code == OnyxErrorCode.SINGLE_TENANT_ONLY.status_code
-        assert response.json()["error_code"] == OnyxErrorCode.SINGLE_TENANT_ONLY.code
+def test_multi_tenant_requires_bounded_email_domains(
+    client: TestClient, domains: list[str]
+) -> None:
+    """A list that stores empty turns the domain check off entirely. Blank
+    entries are dropped on write, so they have to be judged normalized."""
+    request = _build_oidc_request(_new_provider_name(), "secret")
+    request["allowed_email_domains"] = domains
+
+    response = client.post("/admin/sso/provider", json=request)
+    assert response.status_code == OnyxErrorCode.INVALID_INPUT.status_code
+
+
+def test_single_tenant_allows_unbounded_email_domains(
+    client: TestClient, provider_names: list[str]
+) -> None:
+    name = _new_provider_name()
+    provider_names.append(name)
+    request = _build_oidc_request(name, "secret")
+    request["allowed_email_domains"] = []
+
+    assert client.post("/admin/sso/provider", json=request).status_code == 200
+
+
+def test_single_tenant_offers_every_provider_type(client: TestClient) -> None:
+    types_response = client.get("/admin/sso/provider-type")
+    assert types_response.status_code == 200
+    assert SSOProviderType.SAML.value in types_response.json()

--- a/backend/tests/external_dependency_unit/auth/test_sso_admin_api.py
+++ b/backend/tests/external_dependency_unit/auth/test_sso_admin_api.py
@@ -604,6 +604,22 @@ def test_multi_tenant_requires_bounded_email_domains(
     assert response.status_code == OnyxErrorCode.INVALID_INPUT.status_code
 
 
+@pytest.mark.parametrize(
+    "domain", ["company a.com", "notadomain", "-bad.com", "bad_.com"]
+)
+@patch("onyx.server.manage.sso.api.MULTI_TENANT", True)
+def test_multi_tenant_rejects_malformed_email_domains(
+    client: TestClient, domain: str
+) -> None:
+    """A syntactically invalid domain would persist and route nowhere, then fail
+    only later when verification tries to email it, so it is rejected at save."""
+    request = _build_oidc_request(_new_provider_name(), "secret")
+    request["allowed_email_domains"] = [domain]
+
+    response = client.post("/admin/sso/provider", json=request)
+    assert response.status_code == OnyxErrorCode.INVALID_INPUT.status_code
+
+
 def test_single_tenant_allows_unbounded_email_domains(
     client: TestClient, provider_names: list[str]
 ) -> None:

--- a/backend/tests/unit/onyx/server/test_oidc_multi.py
+++ b/backend/tests/unit/onyx/server/test_oidc_multi.py
@@ -28,6 +28,18 @@ _OIDC_CONFIG = {
     "openid_config_url": "https://idp.example.com/.well-known/openid-configuration",
 }
 _GOOGLE_CONFIG = {"client_id": "gid", "client_secret": "gsecret"}
+
+
+@pytest.fixture(autouse=True)
+def _stub_idp_url_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    # These tests build clients from fake IdP URLs and stay off the network. The
+    # URL guard's own DNS/SSRF checks live in test_sso_url_guard.
+    monkeypatch.setattr(oidc_multi, "validate_idp_url", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        oidc_multi, "validate_discovered_endpoints", lambda *_a, **_k: None
+    )
+
+
 _DB = cast(Session, object())
 _TEST_SECRET = "unit-test-secret"
 

--- a/web/src/lib/sso/hooks.ts
+++ b/web/src/lib/sso/hooks.ts
@@ -1,0 +1,30 @@
+import useSWR from "swr";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
+import type { SSOProviderType } from "@/lib/sso/interfaces";
+import { CREATABLE_SSO_PROVIDER_TYPES } from "@/lib/sso/utils";
+
+interface SupportedSSOProviderTypes {
+  providerTypes: SSOProviderType[];
+  isLoading: boolean;
+  error?: unknown;
+}
+
+// Provider types this deployment can serve, in form display order. Keep the
+// picker disabled while loading: an empty list is not yet "none supported".
+export function useSupportedSSOProviderTypes(): SupportedSSOProviderTypes {
+  const { data, error, isLoading } = useSWR<SSOProviderType[]>(
+    SWR_KEYS.adminSsoProviderTypes,
+    errorHandlingFetcher
+  );
+
+  return {
+    // SWR's isLoading is false once the first request settles, error included,
+    // so the picker never waits on data that failed to arrive.
+    providerTypes: CREATABLE_SSO_PROVIDER_TYPES.filter((type) =>
+      (data ?? []).includes(type)
+    ),
+    isLoading,
+    error,
+  };
+}

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -22,6 +22,7 @@ export const SWR_KEYS = {
   adminSecuritySettings: "/api/admin/security",
   incognitoAvailability: "/api/chat/incognito-availability",
   adminSsoProviders: "/api/admin/sso/provider",
+  adminSsoProviderTypes: "/api/admin/sso/provider-type",
 
   // ── Agents / Personas ─────────────────────────────────────────────────────
   personas: "/api/persona",

--- a/web/src/sections/modals/sso/SSOProviderModal.tsx
+++ b/web/src/sections/modals/sso/SSOProviderModal.tsx
@@ -14,6 +14,7 @@ import type {
   SSOProviderUpdateRequest,
 } from "@/lib/sso/interfaces";
 import { useSupportedSSOProviderTypes } from "@/lib/sso/hooks";
+import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 import { createSSOProvider, updateSSOProvider } from "@/lib/sso/svc";
 import {
   CONFIG_FIELDS_BY_TYPE,
@@ -100,7 +101,14 @@ const SSO_VALIDATION_SCHEMA = Yup.object({
     "provider_type",
     ([type], schema) => CONFIG_SCHEMA_BY_TYPE[type as string] ?? schema
   ),
-  allowed_email_domains: Yup.array().of(Yup.string()).optional(),
+  // Cloud rejects an empty list (every address the IdP asserts would become a
+  // billed seat), so require at least one domain there. Single-tenant leaves it
+  // optional, where empty means every address may sign in.
+  allowed_email_domains: NEXT_PUBLIC_CLOUD_ENABLED
+    ? Yup.array()
+        .of(Yup.string())
+        .min(1, "List at least one email domain that may sign in")
+    : Yup.array().of(Yup.string()).optional(),
 });
 
 // The backend masks every config string on read and restores any value sent
@@ -385,8 +393,16 @@ export function SSOProviderModal({ provider, onSaved }: SSOProviderModalProps) {
                   ))}
 
                   <InputVertical
-                    title="Allowed Email Domains (Optional)"
-                    description="Only emails in these domains may sign in through this provider. Empty allows any."
+                    title={
+                      NEXT_PUBLIC_CLOUD_ENABLED
+                        ? "Allowed Email Domains"
+                        : "Allowed Email Domains (Optional)"
+                    }
+                    description={
+                      NEXT_PUBLIC_CLOUD_ENABLED
+                        ? "Only emails in these domains may sign in through this provider."
+                        : "Only emails in these domains may sign in through this provider. Empty allows any."
+                    }
                     withLabel
                   >
                     <TagListField

--- a/web/src/sections/modals/sso/SSOProviderModal.tsx
+++ b/web/src/sections/modals/sso/SSOProviderModal.tsx
@@ -13,6 +13,7 @@ import type {
   SSOProviderType,
   SSOProviderUpdateRequest,
 } from "@/lib/sso/interfaces";
+import { useSupportedSSOProviderTypes } from "@/lib/sso/hooks";
 import { createSSOProvider, updateSSOProvider } from "@/lib/sso/svc";
 import {
   CONFIG_FIELDS_BY_TYPE,
@@ -218,6 +219,8 @@ function ConfigInput({
 export function SSOProviderModal({ provider, onSaved }: SSOProviderModalProps) {
   const onClose = useModalClose();
   const isEditing = provider !== null;
+  const { providerTypes, isLoading: providerTypesLoading } =
+    useSupportedSSOProviderTypes();
 
   const initialValues: SSOProviderFormValues = {
     provider_type: provider?.provider_type ?? "GOOGLE_OAUTH",
@@ -302,7 +305,7 @@ export function SSOProviderModal({ provider, onSaved }: SSOProviderModalProps) {
                   description={
                     isEditing
                       ? "Update how this provider signs users in."
-                      : "Add a Google, OIDC, or SAML provider for sign-in."
+                      : "Add an SSO provider for sign-in."
                   }
                   onClose={onClose}
                 />
@@ -318,14 +321,14 @@ export function SSOProviderModal({ provider, onSaved }: SSOProviderModalProps) {
                       onValueChange={(value) => {
                         void setFieldValue("provider_type", value);
                       }}
-                      disabled={isEditing}
+                      disabled={isEditing || providerTypesLoading}
                       error={Boolean(
                         touched.provider_type && errors.provider_type
                       )}
                     >
                       <InputSelect.Trigger placeholder="Select a provider type" />
                       <InputSelect.Content>
-                        {CREATABLE_SSO_PROVIDER_TYPES.map((type) => {
+                        {providerTypes.map((type) => {
                           const detail = SSO_PROVIDER_DETAILS[type];
                           return (
                             <InputSelect.Item

--- a/web/src/sections/modals/sso/SSOProviderModal.tsx
+++ b/web/src/sections/modals/sso/SSOProviderModal.tsx
@@ -5,7 +5,7 @@ import { Form, Formik, useField } from "formik";
 import * as Yup from "yup";
 import { Button, InputTags, type TagItem, Text } from "@opal/components";
 import { SvgCopy, SvgSimpleLoader } from "@opal/icons";
-import { InputVertical, toast } from "@opal/layouts";
+import { InputErrorText, InputVertical, toast } from "@opal/layouts";
 import { cn } from "@opal/utils";
 import type {
   SSOProviderCreateRequest,
@@ -171,27 +171,35 @@ interface TagListFieldProps {
 // Formik-bound Opal InputTags for string[] values. Always writes an array, so
 // clearing every tag stores [] rather than leaving the previous value.
 function TagListField({ name, placeholder, transform }: TagListFieldProps) {
-  const [field, , helpers] = useField<string[]>(name);
+  const [field, meta, helpers] = useField<string[]>(name);
   const [input, setInput] = useState("");
   const values = field.value ?? [];
   const tags: TagItem[] = values.map((value) => ({ id: value, label: value }));
   return (
-    <InputTags
-      tags={tags}
-      onRemoveTag={(id) => {
-        void helpers.setValue(values.filter((value) => value !== id));
-      }}
-      onAdd={(value) => {
-        const entry = transform ? transform(value.trim()) : value.trim();
-        if (entry && !values.includes(entry)) {
-          void helpers.setValue([...values, entry]);
-        }
-        setInput("");
-      }}
-      value={input}
-      onChange={setInput}
-      placeholder={placeholder}
-    />
+    <>
+      <InputTags
+        tags={tags}
+        onRemoveTag={(id) => {
+          void helpers.setValue(values.filter((value) => value !== id));
+        }}
+        onAdd={(value) => {
+          const entry = transform ? transform(value.trim()) : value.trim();
+          if (entry && !values.includes(entry)) {
+            void helpers.setValue([...values, entry]);
+          }
+          setInput("");
+        }}
+        value={input}
+        onChange={setInput}
+        placeholder={placeholder}
+      />
+      {/* A required list (cloud domains) disables submit when empty, so show the
+          reason directly. Array-level errors are strings; per-element errors are
+          not surfaced here. */}
+      {typeof meta.error === "string" && (
+        <InputErrorText>{meta.error}</InputErrorText>
+      )}
+    </>
   );
 }
 

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -164,7 +164,11 @@ function buildItems(
   if (!isCurator) {
     addGated(SECTIONS.ORGANIZATION, ADMIN_ROUTES.THEME, Tier.BUSINESS);
     add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.SECURITY_HARDENING);
-    add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.SSO_PROVIDERS);
+    // Cloud login cannot use these providers yet, so keep the entry hidden
+    // on cloud until that ships.
+    if (!enableCloud) {
+      add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.SSO_PROVIDERS);
+    }
     if (hasSubscription) {
       add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.BILLING);
     }

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -164,10 +164,7 @@ function buildItems(
   if (!isCurator) {
     addGated(SECTIONS.ORGANIZATION, ADMIN_ROUTES.THEME, Tier.BUSINESS);
     add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.SECURITY_HARDENING);
-    // SSO provider config is not supported on multi-tenant cloud.
-    if (!enableCloud) {
-      add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.SSO_PROVIDERS);
-    }
+    add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.SSO_PROVIDERS);
     if (hasSubscription) {
       add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.BILLING);
     }


### PR DESCRIPTION
## Description

Per-tenant SSO provider config so cloud workspaces can add Google and OIDC providers.

- Create, update, and enable endpoints for provider rows, driven by the admin modal. Provider types come from the server, so the UI never offers a type the backend rejects.
- SAML stays closed on cloud, enforced per endpoint.
- `allowed_email_domains` is required on cloud. An empty list would admit every address the IdP asserts, each a billed seat.
- The SSO Providers admin nav is shown on cloud.

Stacked on #13935.

## How Has This Been Tested?

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/d1dd0010-82e9-4e1a-a300-660b27fe16e1) | ![after](https://github.com/user-attachments/assets/349558d5-7bbe-46a9-981e-f743c8d75e8d) |

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
