### PR TITLE
feat(sso): verify login domains by DNS and route cloud SSO users

### DIFF
--- a/backend/ee/onyx/auth/sso_domain_verification.py
+++ b/backend/ee/onyx/auth/sso_domain_verification.py
@@ -109,7 +109,13 @@ def _proof_still_present(tenant_id: str, domain: str) -> bool:
 def revalidate_tenant_domains(tenant_id: str) -> None:
     """Re-resolve each verified domain's TXT proof and drop verification for any
     whose record is gone, so a domain the workspace no longer controls stops
-    routing strangers into it."""
+    routing strangers into it.
+
+    Every domain is attempted even if one fails, then the run raises so a domain
+    left routing past its proof surfaces as a failed task rather than only a log
+    line. The next run retries it.
+    """
+    failed: list[str] = []
     for record in list_login_domains(tenant_id):
         if not record.verified:
             continue
@@ -123,3 +129,9 @@ def revalidate_tenant_domains(tenant_id: str) -> None:
             )
         except Exception:
             logger.exception("Failed to re-validate SSO domain %s", record.domain)
+            failed.append(record.domain)
+
+    if failed:
+        raise RuntimeError(
+            f"Could not re-validate SSO domains, still routing: {', '.join(failed)}"
+        )

--- a/backend/ee/onyx/auth/sso_domain_verification.py
+++ b/backend/ee/onyx/auth/sso_domain_verification.py
@@ -1,0 +1,125 @@
+"""Prove a workspace controls an email domain by publishing a DNS TXT record.
+
+Domain routing auto-provisions strangers on a domain, so a workspace must show
+it owns the domain first. Only whoever controls the domain's DNS can publish the
+record we look for, so finding it is that proof. Verifying flips the catalog row
+that lets the domain route. A scheduled re-check drops routing if the record
+later disappears.
+"""
+
+import hashlib
+import hmac
+
+import dns.resolver
+from dns.exception import DNSException
+
+from ee.onyx.db.tenant_sso_domain import (
+    is_claimed_domain,
+    list_login_domains,
+    mark_domain_unverified,
+    mark_domain_verified,
+)
+from onyx.configs.app_configs import USER_AUTH_SECRET
+from onyx.db.sso_provider import is_valid_email_domain
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Published under the claimed domain at this host, kept off the apex so it never
+# collides with the domain's SPF or other TXT records.
+VERIFICATION_HOST = "_onyx-verification"
+_VALUE_PREFIX = "onyx-verify="
+# Bounds a slow or unreachable resolver so it can't tie up the request.
+_DNS_TIMEOUT_SECONDS = 5.0
+
+
+def _domain_token(tenant_id: str, domain: str) -> str:
+    """A stable per-(workspace, domain) token. Bound to the workspace so one
+    tenant's published record cannot verify another's claim, and unguessable
+    without USER_AUTH_SECRET so an attacker cannot forge a record for a domain
+    they do not control."""
+    message = f"sso-domain:{tenant_id}:{domain}".encode()
+    digest = hmac.new(USER_AUTH_SECRET.encode(), message, hashlib.sha256)
+    return digest.hexdigest()[:32]
+
+
+def verification_record(tenant_id: str, domain: str) -> tuple[str, str]:
+    """(host, value) of the TXT record the admin publishes to prove control."""
+    domain = domain.strip().lower()
+    host = f"{VERIFICATION_HOST}.{domain}"
+    return host, f"{_VALUE_PREFIX}{_domain_token(tenant_id, domain)}"
+
+
+def _txt_proof_matches(host: str, expected: str) -> bool | None:
+    """Whether `expected` is among the host's TXT answers. None on a transient
+    resolver failure, where the record's presence is unknown, so callers can
+    tell a definitive miss (NXDOMAIN, no TXT) from a resolver blip."""
+    resolver = dns.resolver.Resolver()
+    resolver.timeout = _DNS_TIMEOUT_SECONDS
+    resolver.lifetime = _DNS_TIMEOUT_SECONDS
+    try:
+        answers = resolver.resolve(host, "TXT")
+    except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+        return False
+    except DNSException:
+        return None
+    # A TXT record is one or more quoted chunks, joined before matching.
+    return any(
+        hmac.compare_digest(
+            b"".join(record.strings).decode(errors="ignore").strip(), expected
+        )
+        for record in answers
+    )
+
+
+def verify_domain_via_dns(tenant_id: str, domain: str) -> bool:
+    """Resolve the TXT record and verify the domain on a match. Returns whether
+    a matching record was found. A miss is expected while DNS is still
+    propagating."""
+    domain = domain.strip().lower()
+    if not is_valid_email_domain(domain):
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT, "That is not a valid email domain."
+        )
+    if not is_claimed_domain(tenant_id, domain):
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            "Save the provider with this domain before verifying it.",
+        )
+
+    host, expected = verification_record(tenant_id, domain)
+    if _txt_proof_matches(host, expected):
+        mark_domain_verified(tenant_id, domain)
+        return True
+    return False
+
+
+def _proof_still_present(tenant_id: str, domain: str) -> bool:
+    """Re-resolve the TXT proof for an already-verified domain. Returns True when
+    the proof is present, and also on a transient resolver failure, so routing is
+    dropped only on a definitive miss (NXDOMAIN, no TXT, or a changed value),
+    never a resolver blip."""
+    domain = domain.strip().lower()
+    host, expected = verification_record(tenant_id, domain)
+    return _txt_proof_matches(host, expected) is not False
+
+
+def revalidate_tenant_domains(tenant_id: str) -> None:
+    """Re-resolve each verified domain's TXT proof and drop verification for any
+    whose record is gone, so a domain the workspace no longer controls stops
+    routing strangers into it."""
+    for record in list_login_domains(tenant_id):
+        if not record.verified:
+            continue
+        try:
+            if _proof_still_present(tenant_id, record.domain):
+                continue
+            mark_domain_unverified(tenant_id, record.domain)
+            logger.info(
+                "Dropped SSO routing for %s: its TXT proof no longer resolves",
+                record.domain,
+            )
+        except Exception:
+            logger.exception("Failed to re-validate SSO domain %s", record.domain)

--- a/backend/ee/onyx/background/celery/apps/primary.py
+++ b/backend/ee/onyx/background/celery/apps/primary.py
@@ -13,6 +13,7 @@ celery_app.autodiscover_tasks(
             "ee.onyx.background.celery.tasks.license_notifications",
             "ee.onyx.background.celery.tasks.license_reclaim",
             "ee.onyx.background.celery.tasks.log_export",
+            "ee.onyx.background.celery.tasks.sso_domain_revalidation",
         ]
     )
 )

--- a/backend/ee/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/ee/onyx/background/celery/tasks/beat_schedule.py
@@ -49,6 +49,18 @@ ee_beat_task_templates: list[dict] = [
             "queue": OnyxCeleryQueues.CSV_GENERATION,
         },
     },
+    {
+        "name": "revalidate-sso-domains",
+        "task": OnyxCeleryTask.REVALIDATE_SSO_DOMAINS_TASK,
+        "schedule": timedelta(hours=6),
+        "options": {
+            "priority": OnyxCeleryPriority.LOW,
+            "expires": BEAT_EXPIRES_DEFAULT,
+            # Revoking stale routing is a security cleanup, so it must reach
+            # gated workspaces too, not just active ones.
+            "skip_gated": False,
+        },
+    },
 ]
 
 ee_tasks_to_schedule: list[dict] = []

--- a/backend/ee/onyx/background/celery/tasks/sso_domain_revalidation/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/sso_domain_revalidation/tasks.py
@@ -1,0 +1,33 @@
+"""Cloud SSO: keep login-domain routing from outliving its proof.
+
+Runs per tenant on a schedule. Re-projects the workspace's claimed domains (so a
+failed on-save projection self-heals) and drops verification for any verified
+domain whose DNS TXT proof no longer resolves.
+"""
+
+from celery import shared_task
+
+from ee.onyx.auth.sso_domain_verification import revalidate_tenant_domains
+from ee.onyx.db.tenant_sso_domain import reproject_tenant_login_domains
+from onyx.configs.app_configs import JOB_TIMEOUT
+from onyx.configs.constants import OnyxCeleryTask
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+@shared_task(
+    name=OnyxCeleryTask.REVALIDATE_SSO_DOMAINS_TASK,
+    ignore_result=True,
+    soft_time_limit=JOB_TIMEOUT,
+    trail=False,
+)
+def revalidate_sso_domains_task(*, tenant_id: str) -> None:
+    """Fanned out per tenant by cloud_beat_task_generator. The re-projection is
+    isolated so its failure can't skip the DNS re-check, which is the part that
+    drops routing for a domain whose proof is gone."""
+    try:
+        reproject_tenant_login_domains(tenant_id)
+    except Exception:
+        logger.exception("Failed to re-project login domains for %s", tenant_id)
+    revalidate_tenant_domains(tenant_id)

--- a/backend/ee/onyx/db/user_tenant_mapping.py
+++ b/backend/ee/onyx/db/user_tenant_mapping.py
@@ -219,6 +219,59 @@ def user_owns_a_tenant(email: str) -> bool:
         return result is not None
 
 
+def is_active_member(
+    tenant_id: str, email: str, oauth_name: str, account_id: str
+) -> bool:
+    """Whether this login is already an active member of tenant_id, by address
+    or by a subject linked to an active membership here. A retired (inactive)
+    membership does not count, so it cannot be reactivated on an unverified
+    domain."""
+    if not MULTI_TENANT:
+        return False
+
+    normalized_email = email.lower()
+    with get_catalog_session() as db_session:
+        by_email = db_session.scalar(
+            select(UserTenantMapping.tenant_id).where(
+                UserTenantMapping.email == normalized_email,
+                UserTenantMapping.tenant_id == tenant_id,
+                UserTenantMapping.active.is_(True),
+            )
+        )
+    if by_email is not None:
+        return True
+    return get_tenant_id_for_oauth_account(oauth_name, account_id) == tenant_id
+
+
+def ensure_tenant_membership(
+    email: str, tenant_id: str, oauth_name: str, account_id: str
+) -> None:
+    """Record an active workspace membership for someone the IdP just vouched for.
+
+    A first SSO login creates the user inside the workspace schema, but nothing
+    else writes the catalog row that makes them a member. Without it they are
+    unbilled, unresolvable by address, and cannot link an IdP subject.
+
+    `add_users_to_tenant` guarantees a row exists (active, with the seat enforced,
+    when they belong nowhere else). If it leaves the row inactive because they are
+    active in another workspace, or an invitation was already pending, the
+    vouching login is the acceptance: activate it, retire the rival, and move this
+    login's subject onto it.
+    """
+    if not MULTI_TENANT:
+        return
+
+    normalized_email = email.lower()
+    add_users_to_tenant([normalized_email], tenant_id)
+
+    with get_catalog_session() as db_session:
+        mapping = db_session.get(UserTenantMapping, (normalized_email, tenant_id))
+        needs_activation = mapping is not None and not mapping.active
+
+    if needs_activation:
+        accept_user_invite(normalized_email, tenant_id, [(oauth_name, account_id)])
+
+
 def record_oauth_identity(
     email: str, tenant_id: str, oauth_name: str, account_id: str
 ) -> None:

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -963,6 +963,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         associate_by_email: bool = False,
         is_verified_by_default: bool = False,
         allowed_email_domains_override: Sequence[str] | None = None,
+        enforce_verified_domain: bool = False,
     ) -> User:
         referral_source = (
             getattr(request.state, "referral_source", None) if request else None
@@ -1000,6 +1001,20 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 account_email,
                 valid_email_domains=effective_valid_email_domains,
             )
+
+            if override is not None and enforce_verified_domain:
+                # Current active members are exempt from the domain gate.
+                already_member = fetch_ee_implementation_or_noop(
+                    "onyx.db.user_tenant_mapping", "is_active_member", False
+                )(tenant_id, account_email, oauth_name, account_id)
+                if not already_member and not fetch_ee_implementation_or_noop(
+                    "onyx.db.tenant_sso_domain", "is_email_domain_verified", False
+                )(tenant_id, account_email):
+                    raise OnyxError(
+                        OnyxErrorCode.UNAUTHORIZED,
+                        "This workspace has not verified your email domain for "
+                        "single sign-on.",
+                    )
 
             # NOTE(rkuo): If this UserManager is instantiated per connection
             # should we even be doing this here?
@@ -1095,6 +1110,13 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                             )
 
             assert user is not None
+
+            if override is not None:
+                # A pinned login skipped the provisioning that records
+                # membership. Record it here, before the link below needs the row.
+                fetch_ee_implementation_or_noop(
+                    "onyx.db.user_tenant_mapping", "ensure_tenant_membership", None
+                )(user.email, tenant_id, oauth_name, account_id)
 
             # Keyed on the stored email rather than the one the IdP just sent.
             # The membership row moves onto the new address at the rekey below.
@@ -2513,6 +2535,7 @@ async def complete_login_flow(
     associate_by_email: bool,
     is_verified_by_default: bool,
     allowed_email_domains_override: Sequence[str] | None = None,
+    enforce_verified_domain: bool = False,
 ) -> RedirectResponse:
     """Shared post-token OAuth/OIDC login: read the verified identity, create or
     authenticate the user, and return a web or mobile redirect.
@@ -2573,6 +2596,7 @@ async def complete_login_flow(
             associate_by_email=associate_by_email,
             is_verified_by_default=is_verified_by_default,
             allowed_email_domains_override=allowed_email_domains_override,  # ty: ignore[unknown-argument]
+            enforce_verified_domain=enforce_verified_domain,  # ty: ignore[unknown-argument]
         )
     except UserAlreadyExists:
         raise OnyxError(

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -680,6 +680,9 @@ class OnyxCeleryTask:
 
     GENERATE_USAGE_REPORT_TASK = "generate_usage_report_task"
 
+    # cloud SSO: re-resolve verified domains' DNS proof and re-project routing
+    REVALIDATE_SSO_DOMAINS_TASK = "revalidate_sso_domains_task"
+
     EVAL_RUN_TASK = "eval_run_task"
     SCHEDULED_EVAL_TASK = "scheduled_eval_task"
 

--- a/backend/onyx/server/manage/sso/api.py
+++ b/backend/onyx/server/manage/sso/api.py
@@ -284,7 +284,7 @@ def _list_login_domains(tenant_id: str) -> list[Any]:
 
 
 def _build_statuses(
-    tenant_id: str, domains: list[str], verified: set[str]
+    tenant_id: str, domains: list[str], verified: set[str], claimed: set[str]
 ) -> SSOLoginDomainsResponse:
     """Pair each domain with its status. A verified domain routes and needs no
     record. A pending one carries the TXT record to publish."""
@@ -296,10 +296,14 @@ def _build_statuses(
 
     def _status(domain: str) -> SSOLoginDomainStatus:
         if domain in verified:
-            return SSOLoginDomainStatus(domain=domain, verified=True)
+            return SSOLoginDomainStatus(domain=domain, verified=True, claimed=True)
         host, value = verification_record(tenant_id, domain)
         return SSOLoginDomainStatus(
-            domain=domain, verified=False, record_host=host, record_value=value
+            domain=domain,
+            verified=False,
+            claimed=domain in claimed,
+            record_host=host,
+            record_value=value,
         )
 
     return SSOLoginDomainsResponse(domains=[_status(domain) for domain in domains])
@@ -307,8 +311,9 @@ def _build_statuses(
 
 def _login_domains_response(tenant_id: str) -> SSOLoginDomainsResponse:
     records = _list_login_domains(tenant_id)
+    domains = [record.domain for record in records]
     verified = {record.domain for record in records if record.verified}
-    return _build_statuses(tenant_id, [record.domain for record in records], verified)
+    return _build_statuses(tenant_id, domains, verified, set(domains))
 
 
 def _domain_statuses(tenant_id: str, domains: list[str]) -> SSOLoginDomainsResponse:
@@ -316,10 +321,11 @@ def _domain_statuses(tenant_id: str, domains: list[str]) -> SSOLoginDomainsRespo
     be shown before the provider is saved. Domains are normalized so a mixed-case
     entry matches the lowercased catalog."""
     normalized = [domain.strip().lower() for domain in domains]
-    verified = {
-        record.domain for record in _list_login_domains(tenant_id) if record.verified
-    }
-    return _build_statuses(tenant_id, normalized, verified)
+    records = _list_login_domains(tenant_id)
+    verified = {record.domain for record in records if record.verified}
+    return _build_statuses(
+        tenant_id, normalized, verified, {record.domain for record in records}
+    )
 
 
 @admin_router.post("/domain/records")

--- a/backend/onyx/server/manage/sso/api.py
+++ b/backend/onyx/server/manage/sso/api.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from fastapi import APIRouter, Depends
+from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -12,6 +13,7 @@ from onyx.db.enums import Permission, SSOProviderType
 from onyx.db.models import SSOProvider, User
 from onyx.db.sso_provider import (
     create_sso_provider,
+    enabled_provider_domains,
     fetch_sso_providers,
     is_valid_email_domain,
     normalize_email_domains,
@@ -24,6 +26,10 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.manage.get_state import invalidate_sso_provider_options_cache
 from onyx.server.manage.sso.models import (
+    SSODomainRecordsRequest,
+    SSODomainVerifyRequest,
+    SSOLoginDomainsResponse,
+    SSOLoginDomainStatus,
     SSOProviderCreateRequest,
     SSOProviderEnabledRequest,
     SSOProviderResponse,
@@ -34,8 +40,12 @@ from onyx.server.security.store import (
     security_settings_write_lock,
 )
 from onyx.utils.encryption import reject_masked_credentials, restore_masked_credentials
+from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 from shared_configs.configs import MULTI_TENANT
+from shared_configs.contextvars import get_current_tenant_id
+
+logger = setup_logger()
 
 
 def _reject_unsupported_provider_type(provider_type: SSOProviderType) -> None:
@@ -49,9 +59,9 @@ def _reject_unsupported_provider_type(provider_type: SSOProviderType) -> None:
 def _validate_cloud_email_domains(allowed_email_domains: list[str] | None) -> None:
     """On cloud the domain list is both the seat boundary and a routing key, so
     it must be non-empty and every entry a valid hostname. A malformed domain
-    would otherwise persist and fail only later, when verification tries to email
-    it. Judged after normalization, which drops blanks. Single-tenant leaves the
-    list optional and unrouted, so it skips both checks."""
+    would otherwise persist and fail only later, at DNS verification. Judged
+    after normalization, which drops blanks. Single-tenant leaves the list
+    optional and unrouted, so it skips both checks."""
     if not MULTI_TENANT or allowed_email_domains is None:
         return
     normalized = normalize_email_domains(allowed_email_domains)
@@ -67,6 +77,23 @@ def _validate_cloud_email_domains(allowed_email_domains: list[str] | None) -> No
             OnyxErrorCode.INVALID_INPUT,
             f"These are not valid email domains: {', '.join(invalid)}.",
         )
+
+
+def _sync_login_domain_routing(db_session: Session) -> None:
+    """Project every enabled provider's domains into the shared catalog, which
+    is the only place the login page can read before a workspace is known.
+    Recomputed from the rows rather than diffed, so a disable or a domain
+    removal stops routing without its own bookkeeping."""
+    # The provider commit is the source of truth, so this whole projection is
+    # best-effort: any failure reprojecting the catalog must not fail a saved
+    # provider, and the next save re-syncs.
+    try:
+        claimed = enabled_provider_domains(db_session)
+        fetch_ee_implementation_or_noop(
+            "onyx.db.tenant_sso_domain", "claim_email_domains", None
+        )(get_current_tenant_id(), sorted(claimed))
+    except Exception:
+        logger.exception("Failed to project SSO login-domain routing")
 
 
 def _reject_unfetchable_idp_url(config: dict[str, Any]) -> None:
@@ -161,6 +188,7 @@ def create_sso_provider_endpoint(
     except ValueError as e:
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e)) from e
 
+    _sync_login_domain_routing(db_session)
     invalidate_sso_provider_options_cache()
     return SSOProviderResponse.from_model(provider, WEB_DOMAIN)
 
@@ -200,6 +228,7 @@ def update_sso_provider_endpoint(
     except ValueError as e:
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e)) from e
 
+    _sync_login_domain_routing(db_session)
     invalidate_sso_provider_options_cache()
     return SSOProviderResponse.from_model(updated_provider, WEB_DOMAIN)
 
@@ -243,5 +272,92 @@ def set_sso_provider_enabled_endpoint(
                 enabled=False,
             )
 
+    _sync_login_domain_routing(db_session)
     invalidate_sso_provider_options_cache()
     return SSOProviderResponse.from_model(provider, WEB_DOMAIN)
+
+
+def _list_login_domains(tenant_id: str) -> list[Any]:
+    return fetch_ee_implementation_or_noop(
+        "onyx.db.tenant_sso_domain", "list_login_domains", lambda _tenant_id: []
+    )(tenant_id)
+
+
+def _build_statuses(
+    tenant_id: str, domains: list[str], verified: set[str]
+) -> SSOLoginDomainsResponse:
+    """Pair each domain with its status. A verified domain routes and needs no
+    record. A pending one carries the TXT record to publish."""
+    verification_record = fetch_ee_implementation_or_noop(
+        "onyx.auth.sso_domain_verification",
+        "verification_record",
+        lambda _tenant_id, _domain: (None, None),
+    )
+
+    def _status(domain: str) -> SSOLoginDomainStatus:
+        if domain in verified:
+            return SSOLoginDomainStatus(domain=domain, verified=True)
+        host, value = verification_record(tenant_id, domain)
+        return SSOLoginDomainStatus(
+            domain=domain, verified=False, record_host=host, record_value=value
+        )
+
+    return SSOLoginDomainsResponse(domains=[_status(domain) for domain in domains])
+
+
+def _login_domains_response(tenant_id: str) -> SSOLoginDomainsResponse:
+    records = _list_login_domains(tenant_id)
+    verified = {record.domain for record in records if record.verified}
+    return _build_statuses(tenant_id, [record.domain for record in records], verified)
+
+
+def _domain_statuses(tenant_id: str, domains: list[str]) -> SSOLoginDomainsResponse:
+    """Statuses for a specific set of domains, claimed or not, so verification can
+    be shown before the provider is saved. Domains are normalized so a mixed-case
+    entry matches the lowercased catalog."""
+    normalized = [domain.strip().lower() for domain in domains]
+    verified = {
+        record.domain for record in _list_login_domains(tenant_id) if record.verified
+    }
+    return _build_statuses(tenant_id, normalized, verified)
+
+
+@admin_router.post("/domain/records")
+def sso_domain_records_endpoint(
+    payload: SSODomainRecordsRequest,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+) -> SSOLoginDomainsResponse:
+    """The TXT record and status for the domains an admin is configuring, so
+    verification can be shown before the provider is saved."""
+    if not MULTI_TENANT:
+        return SSOLoginDomainsResponse(domains=[])
+    return _domain_statuses(get_current_tenant_id(), payload.domains)
+
+
+@admin_router.post("/domain/verify-dns")
+async def verify_sso_domain_via_dns_endpoint(
+    payload: SSODomainVerifyRequest,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+) -> SSOLoginDomainsResponse:
+    if not MULTI_TENANT:
+        raise OnyxError(OnyxErrorCode.SINGLE_TENANT_ONLY)
+
+    tenant_id = get_current_tenant_id()
+    # DNS resolution blocks, so keep it off the event loop.
+    found = await run_in_threadpool(
+        fetch_ee_implementation_or_noop(
+            "onyx.auth.sso_domain_verification",
+            "verify_domain_via_dns",
+            lambda _tenant_id, _domain: False,
+        ),
+        tenant_id,
+        payload.domain,
+    )
+    if not found:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "We couldn't find the TXT record yet. DNS can take up to an hour to "
+            "update, then check again.",
+        )
+    invalidate_sso_provider_options_cache()
+    return _login_domains_response(tenant_id)

--- a/backend/onyx/server/manage/sso/models.py
+++ b/backend/onyx/server/manage/sso/models.py
@@ -30,6 +30,9 @@ class SSOProviderEnabledRequest(BaseModel):
 class SSOLoginDomainStatus(BaseModel):
     domain: str
     verified: bool
+    # Whether the provider holding this domain is saved. Verification needs a
+    # saved claim, so the record shows first and verifying unlocks on save.
+    claimed: bool = False
     # The TXT record to publish to prove control. Unset once verified.
     record_host: str | None = None
     record_value: str | None = None

--- a/backend/onyx/server/manage/sso/models.py
+++ b/backend/onyx/server/manage/sso/models.py
@@ -27,6 +27,26 @@ class SSOProviderEnabledRequest(BaseModel):
     enabled: bool
 
 
+class SSOLoginDomainStatus(BaseModel):
+    domain: str
+    verified: bool
+    # The TXT record to publish to prove control. Unset once verified.
+    record_host: str | None = None
+    record_value: str | None = None
+
+
+class SSOLoginDomainsResponse(BaseModel):
+    domains: list[SSOLoginDomainStatus]
+
+
+class SSODomainVerifyRequest(BaseModel):
+    domain: str
+
+
+class SSODomainRecordsRequest(BaseModel):
+    domains: list[str]
+
+
 class SSOProviderResponse(BaseModel):
     id: int
     name: str

--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -460,6 +460,12 @@ async def oidc_login_callback_for_provider(
             client = await _get_oauth_client(provider, config)
             redirect_uri = _callback_uri(provider, config)
             allowed_email_domains = list(provider.allowed_email_domains)
+            # A tenant-controlled OIDC IdP can assert any address, so its login
+            # may only vouch for a domain the workspace has verified. Google
+            # cannot assert a domain it does not own, so it is trusted as-is.
+            enforce_verified_domain = (
+                provider.provider_type is not SSOProviderType.GOOGLE_OAUTH
+            )
 
         # The state pins the flow's PKCE mode. States without the claim fall
         # back to the row's setting so logins in flight across a deploy complete.
@@ -494,6 +500,7 @@ async def oidc_login_callback_for_provider(
             associate_by_email=_ALLOW_AUTO_LINK,
             is_verified_by_default=True,
             allowed_email_domains_override=allowed_email_domains,
+            enforce_verified_domain=enforce_verified_domain,
         )
 
     if use_pkce:

--- a/backend/onyx/server/sso_discovery.py
+++ b/backend/onyx/server/sso_discovery.py
@@ -117,13 +117,27 @@ def _login_options(
         ]
 
 
+def _resolve_workspace(email: str) -> str | None:
+    """An existing membership wins: an invited or returning user reaches the
+    workspace they actually belong to, even if their address domain routes
+    elsewhere. Domain routing is the fallback that lets a first-time user with no
+    membership reach a workspace at all."""
+    tenant_id = fetch_ee_implementation_or_noop(
+        "onyx.db.user_tenant_mapping", "lookup_tenant_id_for_login", None
+    )(email)
+    if tenant_id:
+        return tenant_id
+
+    return fetch_ee_implementation_or_noop(
+        "onyx.db.tenant_sso_domain", "lookup_tenant_id_for_email_domain", None
+    )(email)
+
+
 def _discover(email: str) -> list[SSOProviderOption]:
     if not MULTI_TENANT:
         return _login_options(POSTGRES_DEFAULT_SCHEMA, workspace_token=None)
 
-    tenant_id = fetch_ee_implementation_or_noop(
-        "onyx.db.user_tenant_mapping", "lookup_tenant_id_for_login", None
-    )(email)
+    tenant_id = _resolve_workspace(email)
     if not tenant_id or tenant_id == POSTGRES_DEFAULT_SCHEMA:
         return []
 

--- a/backend/tests/external_dependency_unit/auth/test_sso_login_discovery.py
+++ b/backend/tests/external_dependency_unit/auth/test_sso_login_discovery.py
@@ -26,8 +26,10 @@ from ee.onyx.auth.sso_domain_verification import (
 )
 from ee.onyx.db.tenant_sso_domain import (
     claim_email_domains,
+    is_claimed_domain,
     is_email_domain_verified,
     lookup_tenant_id_for_email_domain,
+    mark_domain_unverified,
     mark_domain_verified,
 )
 from ee.onyx.db.user_tenant_mapping import (
@@ -289,6 +291,28 @@ def test_revalidation_keeps_a_domain_on_a_transient_dns_failure(
             resolver_cls.return_value.resolve.side_effect = dns.exception.Timeout
             revalidate_tenant_domains(tenant_id)
         assert lookup_tenant_id_for_email_domain(f"user@{domain}") == tenant_id
+    finally:
+        _clear_domains(catalog_with_domains, tenant_id)
+
+
+@patch("ee.onyx.db.tenant_sso_domain.MULTI_TENANT", True)
+def test_catalog_writes_match_a_claim_regardless_of_domain_casing(
+    catalog_with_domains: Session,
+) -> None:
+    """Catalog keys are normalized, so a caller passing mixed case or surrounding
+    whitespace resolves the claim it owns rather than missing it and leaving the
+    domain verified and routable."""
+    tenant_id = f"tenant_{uuid4().hex[:12]}"
+    domain = f"acme-{uuid4().hex[:8]}.com"
+    try:
+        claim_email_domains(tenant_id, [f"  {domain.upper()}  "])
+        assert is_claimed_domain(tenant_id, f"  {domain.upper()}  ")
+
+        mark_domain_verified(tenant_id, domain.upper())
+        assert lookup_tenant_id_for_email_domain(f"user@{domain}") == tenant_id
+
+        mark_domain_unverified(tenant_id, f" {domain.upper()} ")
+        assert lookup_tenant_id_for_email_domain(f"user@{domain}") is None
     finally:
         _clear_domains(catalog_with_domains, tenant_id)
 

--- a/backend/tests/external_dependency_unit/auth/test_sso_login_discovery.py
+++ b/backend/tests/external_dependency_unit/auth/test_sso_login_discovery.py
@@ -11,18 +11,38 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
+import dns.exception
+import dns.resolver
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy import Table, delete, inspect, select
 from sqlalchemy.orm import Session
 
-from ee.onyx.db.user_tenant_mapping import lookup_tenant_id_for_login
+from ee.onyx.auth.sso_domain_verification import (
+    revalidate_tenant_domains,
+    verification_record,
+    verify_domain_via_dns,
+)
+from ee.onyx.db.tenant_sso_domain import (
+    claim_email_domains,
+    is_email_domain_verified,
+    lookup_tenant_id_for_email_domain,
+    mark_domain_verified,
+)
+from ee.onyx.db.user_tenant_mapping import (
+    is_active_member,
+    lookup_tenant_id_for_login,
+)
 from onyx.auth.sso_tenant_token import (
     decode_sso_tenant_token,
     generate_sso_tenant_token,
 )
-from onyx.db.models import UserTenantMapping
+from onyx.db.models import (
+    TenantSSODomain,
+    UserTenantMapping,
+    UserTenantMappingOAuthAccount,
+)
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError, register_onyx_exception_handlers
 from onyx.server.sso_discovery import router as sso_discovery_router
@@ -117,6 +137,162 @@ def test_lookup_returns_none_for_unknown_address() -> None:
     assert lookup_tenant_id_for_login(_new_email()) is None
 
 
+@pytest.fixture()
+def catalog_with_domains(catalog_session: Session) -> Generator[Session, None, None]:
+    """`claim_email_domains` and verification write `tenant_sso_domain`, which a
+    single-tenant dev database never creates."""
+    bind = catalog_session.get_bind()
+    table = cast(Table, TenantSSODomain.__table__)
+    created_here = not inspect(bind).has_table(table.name, schema="public")
+    if created_here:
+        table.create(bind=bind)
+        catalog_session.commit()
+    try:
+        yield catalog_session
+    finally:
+        if created_here:
+            catalog_session.rollback()
+            table.drop(bind=bind)
+            catalog_session.commit()
+
+
+def _clear_domains(session: Session, tenant_id: str) -> None:
+    session.execute(
+        delete(TenantSSODomain).where(TenantSSODomain.tenant_id == tenant_id)
+    )
+    session.commit()
+
+
+class _TxtRecord:
+    """One TXT answer whose joined strings decode to `value`."""
+
+    def __init__(self, value: str) -> None:
+        self.strings = [value.encode()]
+
+
+@patch("ee.onyx.db.tenant_sso_domain.MULTI_TENANT", True)
+def test_claim_records_a_pending_unverified_domain(
+    catalog_with_domains: Session,
+) -> None:
+    tenant_id = f"tenant_{uuid4().hex[:12]}"
+    domain = f"acme-{uuid4().hex[:8]}.example"
+    try:
+        claim_email_domains(tenant_id, [domain])
+        catalog_with_domains.expire_all()
+        row = catalog_with_domains.get(TenantSSODomain, (tenant_id, domain))
+        assert row is not None
+        assert row.verified_at is None
+    finally:
+        _clear_domains(catalog_with_domains, tenant_id)
+
+
+@patch("ee.onyx.db.tenant_sso_domain.MULTI_TENANT", True)
+def test_unverified_domain_does_not_route(catalog_with_domains: Session) -> None:
+    """A claim proves nothing until verified, so it must not route anyone."""
+    tenant_id = f"tenant_{uuid4().hex[:12]}"
+    domain = f"acme-{uuid4().hex[:8]}.example"
+    try:
+        claim_email_domains(tenant_id, [domain])
+        assert lookup_tenant_id_for_email_domain(f"user@{domain}") is None
+    finally:
+        _clear_domains(catalog_with_domains, tenant_id)
+
+
+@patch("ee.onyx.db.tenant_sso_domain.MULTI_TENANT", True)
+def test_dns_verification_marks_verified_and_routes(
+    catalog_with_domains: Session,
+) -> None:
+    """Publishing the TXT record the workspace names verifies the domain, after
+    which it routes its users."""
+    tenant_id = f"tenant_{uuid4().hex[:12]}"
+    domain = f"acme-{uuid4().hex[:8]}.com"
+    try:
+        claim_email_domains(tenant_id, [domain])
+        _host, value = verification_record(tenant_id, domain)
+        with patch("dns.resolver.Resolver") as resolver_cls:
+            resolver_cls.return_value.resolve.return_value = [_TxtRecord(value)]
+            assert verify_domain_via_dns(tenant_id, domain) is True
+        assert lookup_tenant_id_for_email_domain(f"user@{domain}") == tenant_id
+    finally:
+        _clear_domains(catalog_with_domains, tenant_id)
+
+
+@patch("ee.onyx.db.tenant_sso_domain.MULTI_TENANT", True)
+def test_dns_verification_without_the_record_does_not_route(
+    catalog_with_domains: Session,
+) -> None:
+    """A missing or wrong TXT record leaves the domain unverified and unrouted."""
+    tenant_id = f"tenant_{uuid4().hex[:12]}"
+    domain = f"acme-{uuid4().hex[:8]}.com"
+    try:
+        claim_email_domains(tenant_id, [domain])
+        with patch("dns.resolver.Resolver") as resolver_cls:
+            resolver_cls.return_value.resolve.return_value = [
+                _TxtRecord("onyx-verify=wrong")
+            ]
+            assert verify_domain_via_dns(tenant_id, domain) is False
+        assert lookup_tenant_id_for_email_domain(f"user@{domain}") is None
+    finally:
+        _clear_domains(catalog_with_domains, tenant_id)
+
+
+@patch("ee.onyx.db.tenant_sso_domain.MULTI_TENANT", True)
+def test_revalidation_drops_a_domain_whose_record_disappeared(
+    catalog_with_domains: Session,
+) -> None:
+    """A verified domain whose TXT record is later removed stops routing, so a
+    workspace that has lost control of a domain cannot keep pulling its users."""
+    tenant_id = f"tenant_{uuid4().hex[:12]}"
+    domain = f"acme-{uuid4().hex[:8]}.com"
+    try:
+        claim_email_domains(tenant_id, [domain])
+        mark_domain_verified(tenant_id, domain)
+        assert lookup_tenant_id_for_email_domain(f"user@{domain}") == tenant_id
+        with patch("dns.resolver.Resolver") as resolver_cls:
+            resolver_cls.return_value.resolve.side_effect = dns.resolver.NXDOMAIN
+            revalidate_tenant_domains(tenant_id)
+        assert lookup_tenant_id_for_email_domain(f"user@{domain}") is None
+    finally:
+        _clear_domains(catalog_with_domains, tenant_id)
+
+
+@patch("ee.onyx.db.tenant_sso_domain.MULTI_TENANT", True)
+def test_revalidation_keeps_a_domain_whose_record_is_present(
+    catalog_with_domains: Session,
+) -> None:
+    """A verified domain whose TXT record still resolves keeps routing."""
+    tenant_id = f"tenant_{uuid4().hex[:12]}"
+    domain = f"acme-{uuid4().hex[:8]}.com"
+    try:
+        claim_email_domains(tenant_id, [domain])
+        mark_domain_verified(tenant_id, domain)
+        _host, value = verification_record(tenant_id, domain)
+        with patch("dns.resolver.Resolver") as resolver_cls:
+            resolver_cls.return_value.resolve.return_value = [_TxtRecord(value)]
+            revalidate_tenant_domains(tenant_id)
+        assert lookup_tenant_id_for_email_domain(f"user@{domain}") == tenant_id
+    finally:
+        _clear_domains(catalog_with_domains, tenant_id)
+
+
+@patch("ee.onyx.db.tenant_sso_domain.MULTI_TENANT", True)
+def test_revalidation_keeps_a_domain_on_a_transient_dns_failure(
+    catalog_with_domains: Session,
+) -> None:
+    """A resolver timeout is inconclusive, so it must not drop a good domain."""
+    tenant_id = f"tenant_{uuid4().hex[:12]}"
+    domain = f"acme-{uuid4().hex[:8]}.com"
+    try:
+        claim_email_domains(tenant_id, [domain])
+        mark_domain_verified(tenant_id, domain)
+        with patch("dns.resolver.Resolver") as resolver_cls:
+            resolver_cls.return_value.resolve.side_effect = dns.exception.Timeout
+            revalidate_tenant_domains(tenant_id)
+        assert lookup_tenant_id_for_email_domain(f"user@{domain}") == tenant_id
+    finally:
+        _clear_domains(catalog_with_domains, tenant_id)
+
+
 @patch("onyx.server.sso_discovery.MULTI_TENANT", True)
 @patch("onyx.server.sso_discovery._enforce_discovery_rate_limit", new=AsyncMock())
 def test_unknown_address_returns_an_empty_list(client: TestClient) -> None:
@@ -198,3 +374,90 @@ def test_resolved_workspace_authorize_urls_carry_a_workspace_pin(
     [provider] = response.json()["providers"]
     assert provider["authorize_url"].startswith("/api/auth/oidc/okta/authorize?")
     assert "workspace_token=" in provider["authorize_url"]
+
+
+@patch("ee.onyx.db.tenant_sso_domain.MULTI_TENANT", True)
+def test_is_email_domain_verified_only_after_verification(
+    catalog_with_domains: Session,
+) -> None:
+    """A tenant-controlled IdP may vouch for an address only once the workspace
+    has verified its domain, so a pending claim and another workspace's
+    verification must both read as unverified."""
+    tenant_id = f"tenant_{uuid4().hex[:12]}"
+    other_tenant = f"tenant_{uuid4().hex[:12]}"
+    domain = f"acme-{uuid4().hex[:8]}.example"
+    try:
+        claim_email_domains(tenant_id, [domain])
+        assert is_email_domain_verified(tenant_id, f"user@{domain}") is False
+
+        mark_domain_verified(tenant_id, domain)
+        assert is_email_domain_verified(tenant_id, f"user@{domain}") is True
+
+        # Verification belongs to the workspace that proved control, not to any
+        # workspace that merely lists the domain.
+        assert is_email_domain_verified(other_tenant, f"user@{domain}") is False
+        # An unknown domain and a malformed address are both unverified.
+        assert is_email_domain_verified(tenant_id, "user@unclaimed.example") is False
+        assert is_email_domain_verified(tenant_id, "no-at-sign") is False
+    finally:
+        _clear_domains(catalog_with_domains, tenant_id)
+
+
+@pytest.fixture()
+def catalog_with_oauth(catalog_session: Session) -> Generator[Session, None, None]:
+    """The OAuth-subject link table lives in the multi-tenant catalog, which a
+    single-tenant dev database never creates."""
+    bind = catalog_session.get_bind()
+    table = cast(Table, UserTenantMappingOAuthAccount.__table__)
+    created_here = not inspect(bind).has_table(table.name, schema="public")
+    if created_here:
+        table.create(bind=bind)
+        catalog_session.commit()
+    try:
+        yield catalog_session
+    finally:
+        if created_here:
+            catalog_session.rollback()
+            table.drop(bind=bind)
+            catalog_session.commit()
+
+
+@patch("ee.onyx.db.user_tenant_mapping.MULTI_TENANT", True)
+def test_is_active_member_only_for_a_current_active_membership(
+    catalog_with_oauth: Session,
+) -> None:
+    """The verified-domain gate exempts current members. A retired (inactive)
+    membership must not count, or a former member could be reactivated on an
+    unverified domain."""
+    email = _new_email()
+    tenant_id = f"tenant_{uuid4().hex[:12]}"
+    oauth_name, account_id = "oidc", uuid4().hex
+    try:
+        assert is_active_member(tenant_id, email, oauth_name, account_id) is False
+
+        _add_mapping(catalog_with_oauth, email, tenant_id, active=False)
+        assert is_active_member(tenant_id, email, oauth_name, account_id) is False
+
+        catalog_with_oauth.execute(
+            delete(UserTenantMapping).where(UserTenantMapping.email == email)
+        )
+        _add_mapping(catalog_with_oauth, email, tenant_id, active=True)
+        assert is_active_member(tenant_id, email, oauth_name, account_id) is True
+
+        # A subject linked to the active membership also identifies the member,
+        # even after the provider renames their address.
+        catalog_with_oauth.add(
+            UserTenantMappingOAuthAccount(
+                oauth_name=oauth_name,
+                account_id=account_id,
+                email=email,
+                tenant_id=tenant_id,
+            )
+        )
+        catalog_with_oauth.commit()
+        assert (
+            is_active_member(tenant_id, "renamed@example.com", oauth_name, account_id)
+            is True
+        )
+    finally:
+        _cleanup(catalog_with_oauth, email)


### PR DESCRIPTION
## Description

Backend for cloud SSO email-domain routing. Stacks on #14026 (catalog data layer). No UI in this PR, so nothing is user-visible until the UI PR lands.

**Verification.** An admin proves the workspace controls a domain by publishing a TXT record at `_onyx-verification.<domain>` whose value is an HMAC of `USER_AUTH_SECRET` bound to `(tenant, domain)`. Unguessable without the secret, so a domain cannot be forged.

**Routing.** A first-time SSO user has no account and no membership row, so login resolves their workspace by email domain. Only a verified domain routes, and JIT provisioning gates on the same `verified_at`.

**Re-validation.** A per-tenant beat task re-resolves each proof and drops routing when the record is gone. Transient resolver failures keep the domain, so a DNS blip cannot un-verify anyone. It also re-projects claimed domains, so a failed on-save projection self-heals.

Stack: #14026 -> this PR -> UI.

## How Has This Been Tested?


## Additional Options
- [x] Override Linear Check
- [ ] This PR should be cherry-picked into the current release branch