### PR TITLE
ci: only republish Helm charts when chart files change

### DIFF
--- a/.github/workflows/helm-chart-releases.yml
+++ b/.github/workflows/helm-chart-releases.yml
@@ -1,9 +1,16 @@
 name: Release Onyx Helm Charts
 
+# Only runs when packaged chart files change. `helm package` is not
+# byte-reproducible (gzip records a timestamp), so every run rewrites every
+# chart tarball on gh-pages. Tarballs are already compressed, so git cannot
+# delta them and stores each republish in full. Running on every push to main
+# grew gh-pages to 2 GB, which every clone of this repo pays for.
 on:
   push:
     branches:
       - main
+    paths:
+      - "deployment/helm/charts/**"
 
 permissions: write-all
 

--- a/.github/workflows/pr-helm-chart-version.yml
+++ b/.github/workflows/pr-helm-chart-version.yml
@@ -5,9 +5,9 @@ concurrency:
 
 # Requires deployment/helm/charts/onyx/Chart.yaml `version` to be bumped above the
 # version on main whenever the packaged chart changes. helm-chart-releases.yml
-# republishes the chart on every push to main and will NOT overwrite an
-# already-published version, so a chart change that reuses main's version is
-# silently never released. This gate prevents that.
+# republishes the chart on every push to main that touches the charts, and will
+# NOT overwrite an already-published version, so a chart change that reuses
+# main's version is silently never released. This gate prevents that.
 #
 # Uses native path filtering: the workflow only runs when watched chart files
 # change (onyx-cnpg-crds is bundled into the onyx chart via Chart.lock, so it


### PR DESCRIPTION
## Problem

`helm-chart-releases.yml` triggers on **every** push to `main`. Each run repackages all charts and commits them to `gh-pages`.

`helm package` is not byte-reproducible — gzip records a timestamp — so every run produces new blobs even when chart content is identical. Because tarballs are already compressed, git cannot delta them, and each republish is stored in full.

The result:

| | |
|---|---|
| `.tgz` blobs in `gh-pages` history | 5720 → **2.0 GB** |
| `.tgz` files at the `gh-pages` tip | 130 → **60 MB** |
| Commits on `gh-pages` | 9337 (1569 in the last 90 days) |
| Byte-distinct copies of `onyx-cnpg-crds-0.1.0.tgz` | **646**, for one immutable version |

So 97% of the branch is unreachable copies. A default `git clone` fetches all branches, so every contributor downloads that 2.0 GB.

## Change

Restrict the trigger to pushes that touch `deployment/helm/charts/**`. The glob covers both `onyx` and `onyx-cnpg-crds`.

This composes with the existing gate in `pr-helm-chart-version.yml`, which already blocks chart changes that reuse main's version. Together they publish about once per version bump instead of ~17 times a day.

Also refreshes the comment in `pr-helm-chart-version.yml` that described the old trigger. That gate is still required and its reasoning is unchanged.

## Notes

Not addressed here, as separate follow-ups:

- **Reclaiming the existing 2.0 GB** needs a force-push squashing `gh-pages` to a single orphan commit at the current tip. That preserves all 130 published chart URLs and `index.yaml`, but rewrites a shared branch, so it needs maintainer coordination. Clones speed up immediately after; GitHub's stored size needs a Support request to `gc`.
- **The durable fix** is `helm/chart-releaser-action`, which uploads tarballs to GitHub Releases and commits only `index.yaml`, keeping binaries out of git entirely.

## Testing

`index.yaml` at the `gh-pages` tip was verified against the tarball bytes: all 130 entries match, so the tip is self-consistent and safe to preserve. `pre-commit` passes, including `zizmor` and actionlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit Helm chart releases to runs where chart files change, stopping tarball rewrites on every push to main. Old behavior republished charts on every push; new behavior triggers only on `deployment/helm/charts/**` changes, reducing `gh-pages` churn and clone size.

- Adds a `paths` filter in `.github/workflows/helm-chart-releases.yml` to watch `deployment/helm/charts/**`.
- Refreshes comments in `.github/workflows/pr-helm-chart-version.yml`; the version-bump gate still blocks unreleasable chart changes.
- No migration required; continue bumping the chart `version` on changes.

<sup>Written for commit b53f49a2025bcf43059b13ac5e3d74cb62494608. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

