### PR TITLE
fix(helm): truncate all child resource names to the 63-char k8s limit (chart 0.8.15)

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.14
+version: 0.8.15
 appVersion: latest
 annotations:
   category: Productivity
@@ -16,17 +16,13 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
-    - kind: added
-      description: PostgreSQL TLS can now be configured with postgresTls, which
-        mounts a CA certificate and sets verified POSTGRES_SSL* defaults across
-        Onyx backend workloads. Craft's sandbox proxy now trusts customCACerts for
-        outbound HTTPS while retaining the public CA bundle.
     - kind: fixed
-      description: Route /scim to the api server in ingress mode (ingress.enabled=true).
-        The ingress templates only routed /api to the api server, so SCIM requests fell
-        through to the webserver and returned an HTML 404. A new ingress-scim.yaml
-        template forwards the /scim prefix, without a rewrite, to the api service on
-        the webserver host.
+      description: Truncate all child resource names to the 63-character Kubernetes
+        limit. Most templates built names as `<fullname>-<suffix>` without truncation,
+        so long release names made the install fail (for example the Service
+        `<fullname>-celery-worker-heavy-metrics`). Every name now goes through the
+        `onyx.resourceName` helper. Rendered names do not change for release names
+        short enough to stay under the limit.
 dependencies:
   # Helm uses the first condition path that exists: `postgresqlOperator.enabled`
   # is unset by default, so this falls through to `postgresql.enabled`. Set it

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -17,12 +17,13 @@ annotations:
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
     - kind: fixed
-      description: Truncate all child resource names to the 63-character Kubernetes
+      description: Cap all child resource names at the 63-character Kubernetes
         limit. Most templates built names as `<fullname>-<suffix>` without truncation,
         so long release names made the install fail (for example the Service
         `<fullname>-celery-worker-heavy-metrics`). Every name now goes through the
-        `onyx.resourceName` helper. Rendered names do not change for release names
-        short enough to stay under the limit.
+        `onyx.resourceName` helper, which truncates over-limit names and appends a
+        short hash so sibling resources with a shared suffix prefix cannot collide.
+        Rendered names do not change for names already under the limit.
 dependencies:
   # Helm uses the first condition path that exists: `postgresqlOperator.enabled`
   # is unset by default, so this falls through to `postgresql.enabled`. Set it

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -31,17 +31,26 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
-Build a child resource name as `<fullname>-<suffix>`, truncated to 63 chars to
+Build a child resource name as `<fullname>-<suffix>`, capped at 63 chars to
 satisfy the Kubernetes DNS-1123 label limit that applies to Services, Pods,
-Deployments, HPAs, etc. Always use this instead of
+Deployments, HPAs, etc. Names that fit are used as-is. Longer names are
+truncated and get a short hash of the full name, so two suffixes that share a
+prefix (e.g. celery-worker-docfetching / celery-worker-docprocessing) cannot
+collapse onto the same truncated name. The result is deterministic, so every
+caller that passes the same suffix renders the same name and cross-references
+stay consistent. Always use this instead of
   {{ include "onyx.fullname" . }}-<suffix>
-so that long release names cannot push a rendered name over 63 chars.
 Callers must pass `(list . "<suffix>")`.
 */}}
 {{- define "onyx.resourceName" -}}
 {{- $ctx := index . 0 -}}
 {{- $suffix := index . 1 -}}
-{{- printf "%s-%s" (include "onyx.fullname" $ctx) $suffix | trunc 63 | trimSuffix "-" -}}
+{{- $name := printf "%s-%s" (include "onyx.fullname" $ctx) $suffix -}}
+{{- if gt (len $name) 63 -}}
+{{- printf "%s-%s" ($name | trunc 54 | trimSuffix "-") (sha256sum $name | trunc 8) -}}
+{{- else -}}
+{{- $name -}}
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -33,10 +33,10 @@ Create chart name and version as used by the chart label.
 {{/*
 Build a child resource name as `<fullname>-<suffix>`, truncated to 63 chars to
 satisfy the Kubernetes DNS-1123 label limit that applies to Services, Pods,
-Deployments, HPAs, etc. Use this in place of
+Deployments, HPAs, etc. Always use this instead of
   {{ include "onyx.fullname" . }}-<suffix>
-whenever the suffix could push the rendered name over 63 chars for a long
-release name. Callers must pass `(list . "<suffix>")`.
+so that long release names cannot push a rendered name over 63 chars.
+Callers must pass `(list . "<suffix>")`.
 */}}
 {{- define "onyx.resourceName" -}}
 {{- $ctx := index . 0 -}}
@@ -140,7 +140,7 @@ Helpers for mounting a psql convenience script into pods.
 {{- end }}
 
 {{- define "onyx.pgInto.configMapName" -}}
-{{- printf "%s-pginto" (include "onyx.fullname" .) -}}
+{{- include "onyx.resourceName" (list . "pginto") -}}
 {{- end }}
 
 {{- define "onyx.pgInto.checksumAnnotation" -}}
@@ -241,7 +241,7 @@ invisible (the DaemonSet looks healthy while every sandbox still cold-pulls).
 {{- end }}
 
 {{- define "onyx.sandboxProxyHost" -}}
-{{- (index .Values.configMap "SANDBOX_PROXY_HOST") | default (printf "%s-sandbox-proxy.%s.svc.cluster.local" (include "onyx.fullname" .) .Release.Namespace) -}}
+{{- (index .Values.configMap "SANDBOX_PROXY_HOST") | default (printf "%s.%s.svc.cluster.local" (include "onyx.resourceName" (list . "sandbox-proxy")) .Release.Namespace) -}}
 {{- end }}
 
 {{- define "onyx.sandboxProxyPort" -}}

--- a/deployment/helm/charts/onyx/templates/api-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/api-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "onyx.fullname" . }}-api-server
+  name: {{ include "onyx.resourceName" (list . "api-server") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.api.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/api-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/api-hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "onyx.fullname" . }}-api
+  name: {{ include "onyx.resourceName" (list . "api") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-api-server
+    name: {{ include "onyx.resourceName" (list . "api-server") }}
   minReplicas: {{ .Values.api.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.api.autoscaling.maxReplicas }}
   metrics:

--- a/deployment/helm/charts/onyx/templates/api-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/api-scaledobject.yaml
@@ -2,14 +2,14 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ include "onyx.fullname" . }}-api
+  name: {{ include "onyx.resourceName" (list . "api") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-api-server
+    name: {{ include "onyx.resourceName" (list . "api-server") }}
   minReplicaCount: {{ .Values.api.autoscaling.minReplicas | default 1 }}
   maxReplicaCount: {{ .Values.api.autoscaling.maxReplicas | default 10 }}
   pollingInterval: {{ .Values.api.autoscaling.pollingInterval | default 30 }}

--- a/deployment/helm/charts/onyx/templates/api-service.yaml
+++ b/deployment/helm/charts/onyx/templates/api-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   # INTERNAL_URL env variable depends on this, don't change without changing INTERNAL_URL
-  name: {{ include "onyx.fullname" . }}-api-service
+  name: {{ include "onyx.resourceName" (list . "api-service") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- if .Values.api.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/api-servicemonitor.yaml
+++ b/deployment/helm/charts/onyx/templates/api-servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "onyx.fullname" . }}-api
+  name: {{ include "onyx.resourceName" (list . "api") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.monitoring.serviceMonitors.labels }}

--- a/deployment/helm/charts/onyx/templates/celery-beat.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-beat.yaml
@@ -15,7 +15,7 @@ their own /tmp volume. */}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-beat
+  name: {{ include "onyx.resourceName" (list . "celery-beat") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.celery_beat.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching-hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-docfetching
+  name: {{ include "onyx.resourceName" (list . "celery-worker-docfetching") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-celery-worker-docfetching
+    name: {{ include "onyx.resourceName" (list . "celery-worker-docfetching") }}
   minReplicas: {{ .Values.celery_worker_docfetching.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.celery_worker_docfetching.autoscaling.maxReplicas }}
   metrics:

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching-scaledobject.yaml
@@ -2,14 +2,14 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-docfetching
+  name: {{ include "onyx.resourceName" (list . "celery-worker-docfetching") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-celery-worker-docfetching
+    name: {{ include "onyx.resourceName" (list . "celery-worker-docfetching") }}
   minReplicaCount: {{ .Values.celery_worker_docfetching.autoscaling.minReplicas | default 1 }}
   maxReplicaCount: {{ .Values.celery_worker_docfetching.autoscaling.maxReplicas | default 20 }}
   pollingInterval: {{ .Values.celery_worker_docfetching.autoscaling.pollingInterval | default 30 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-docfetching
+  name: {{ include "onyx.resourceName" (list . "celery-worker-docfetching") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.celery_worker_docfetching.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing-hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-docprocessing
+  name: {{ include "onyx.resourceName" (list . "celery-worker-docprocessing") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-celery-worker-docprocessing
+    name: {{ include "onyx.resourceName" (list . "celery-worker-docprocessing") }}
   minReplicas: {{ .Values.celery_worker_docprocessing.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.celery_worker_docprocessing.autoscaling.maxReplicas }}
   metrics:

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing-scaledobject.yaml
@@ -2,14 +2,14 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-docprocessing
+  name: {{ include "onyx.resourceName" (list . "celery-worker-docprocessing") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-celery-worker-docprocessing
+    name: {{ include "onyx.resourceName" (list . "celery-worker-docprocessing") }}
   minReplicaCount: {{ .Values.celery_worker_docprocessing.autoscaling.minReplicas | default 1 }}
   maxReplicaCount: {{ .Values.celery_worker_docprocessing.autoscaling.maxReplicas | default 10 }}
   pollingInterval: {{ .Values.celery_worker_docprocessing.autoscaling.pollingInterval | default 30 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-docprocessing
+  name: {{ include "onyx.resourceName" (list . "celery-worker-docprocessing") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.celery_worker_docprocessing.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy-hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-heavy
+  name: {{ include "onyx.resourceName" (list . "celery-worker-heavy") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-celery-worker-heavy
+    name: {{ include "onyx.resourceName" (list . "celery-worker-heavy") }}
   minReplicas: {{ .Values.celery_worker_heavy.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.celery_worker_heavy.autoscaling.maxReplicas }}
   metrics:

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy-metrics-service.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy-metrics-service.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-heavy-metrics
+  name: {{ include "onyx.resourceName" (list . "celery-worker-heavy-metrics") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- if .Values.celery_worker_heavy.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy-scaledobject.yaml
@@ -2,14 +2,14 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-heavy
+  name: {{ include "onyx.resourceName" (list . "celery-worker-heavy") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-celery-worker-heavy
+    name: {{ include "onyx.resourceName" (list . "celery-worker-heavy") }}
   minReplicaCount: {{ .Values.celery_worker_heavy.autoscaling.minReplicas | default 1 }}
   maxReplicaCount: {{ .Values.celery_worker_heavy.autoscaling.maxReplicas | default 10 }}
   pollingInterval: {{ .Values.celery_worker_heavy.autoscaling.pollingInterval | default 30 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-heavy
+  name: {{ include "onyx.resourceName" (list . "celery-worker-heavy") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.celery_worker_heavy.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-light-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light-hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-light
+  name: {{ include "onyx.resourceName" (list . "celery-worker-light") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-celery-worker-light
+    name: {{ include "onyx.resourceName" (list . "celery-worker-light") }}
   minReplicas: {{ .Values.celery_worker_light.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.celery_worker_light.autoscaling.maxReplicas }}
   metrics:

--- a/deployment/helm/charts/onyx/templates/celery-worker-light-metrics-service.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light-metrics-service.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-light-metrics
+  name: {{ include "onyx.resourceName" (list . "celery-worker-light-metrics") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- if .Values.celery_worker_light.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-light-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light-scaledobject.yaml
@@ -2,14 +2,14 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-light
+  name: {{ include "onyx.resourceName" (list . "celery-worker-light") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-celery-worker-light
+    name: {{ include "onyx.resourceName" (list . "celery-worker-light") }}
   minReplicaCount: {{ .Values.celery_worker_light.autoscaling.minReplicas | default 1 }}
   maxReplicaCount: {{ .Values.celery_worker_light.autoscaling.maxReplicas | default 10 }}
   pollingInterval: {{ .Values.celery_worker_light.autoscaling.pollingInterval | default 30 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-light
+  name: {{ include "onyx.resourceName" (list . "celery-worker-light") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.celery_worker_light.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring-hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-monitoring
+  name: {{ include "onyx.resourceName" (list . "celery-worker-monitoring") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-celery-worker-monitoring
+    name: {{ include "onyx.resourceName" (list . "celery-worker-monitoring") }}
   minReplicas: {{ .Values.celery_worker_monitoring.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.celery_worker_monitoring.autoscaling.maxReplicas }}
   metrics:

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring-scaledobject.yaml
@@ -2,14 +2,14 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-monitoring
+  name: {{ include "onyx.resourceName" (list . "celery-worker-monitoring") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-celery-worker-monitoring
+    name: {{ include "onyx.resourceName" (list . "celery-worker-monitoring") }}
   minReplicaCount: {{ .Values.celery_worker_monitoring.autoscaling.minReplicas | default 1 }}
   maxReplicaCount: {{ .Values.celery_worker_monitoring.autoscaling.maxReplicas | default 10 }}
   pollingInterval: {{ .Values.celery_worker_monitoring.autoscaling.pollingInterval | default 30 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-monitoring
+  name: {{ include "onyx.resourceName" (list . "celery-worker-monitoring") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.celery_worker_monitoring.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary-hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-primary
+  name: {{ include "onyx.resourceName" (list . "celery-worker-primary") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-celery-worker-primary
+    name: {{ include "onyx.resourceName" (list . "celery-worker-primary") }}
   minReplicas: {{ .Values.celery_worker_primary.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.celery_worker_primary.autoscaling.maxReplicas }}
   metrics:

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary-scaledobject.yaml
@@ -2,14 +2,14 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-primary
+  name: {{ include "onyx.resourceName" (list . "celery-worker-primary") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-celery-worker-primary
+    name: {{ include "onyx.resourceName" (list . "celery-worker-primary") }}
   minReplicaCount: {{ .Values.celery_worker_primary.autoscaling.minReplicas | default 1 }}
   maxReplicaCount: {{ .Values.celery_worker_primary.autoscaling.maxReplicas | default 10 }}
   pollingInterval: {{ .Values.celery_worker_primary.autoscaling.pollingInterval | default 30 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-primary
+  name: {{ include "onyx.resourceName" (list . "celery-worker-primary") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.celery_worker_primary.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-servicemonitors.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-servicemonitors.yaml
@@ -4,7 +4,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-monitoring
+  name: {{ include "onyx.resourceName" (list . "celery-worker-monitoring") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.monitoring.serviceMonitors.labels }}
@@ -29,7 +29,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-docfetching
+  name: {{ include "onyx.resourceName" (list . "celery-worker-docfetching") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.monitoring.serviceMonitors.labels }}
@@ -54,7 +54,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-docprocessing
+  name: {{ include "onyx.resourceName" (list . "celery-worker-docprocessing") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.monitoring.serviceMonitors.labels }}
@@ -79,7 +79,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-heavy
+  name: {{ include "onyx.resourceName" (list . "celery-worker-heavy") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.monitoring.serviceMonitors.labels }}
@@ -104,7 +104,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-light
+  name: {{ include "onyx.resourceName" (list . "celery-worker-light") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.monitoring.serviceMonitors.labels }}
@@ -129,7 +129,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-primary
+  name: {{ include "onyx.resourceName" (list . "celery-worker-primary") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.monitoring.serviceMonitors.labels }}
@@ -154,7 +154,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-scheduled-tasks
+  name: {{ include "onyx.resourceName" (list . "celery-worker-scheduled-tasks") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.monitoring.serviceMonitors.labels }}

--- a/deployment/helm/charts/onyx/templates/configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "onyx.labels" . | nindent 4 }}
 data:
   {{- $craftEnabled := eq (include "onyx.craftEnabled" .) "true" }}
-  INTERNAL_URL: "http://{{ include "onyx.fullname" . }}-api-service:{{ .Values.api.service.servicePort | default 8080 }}"
+  INTERNAL_URL: "http://{{ include "onyx.resourceName" (list . "api-service") }}:{{ .Values.api.service.servicePort | default 8080 }}"
   {{- if .Values.postgresql.enabled }}
   POSTGRES_HOST: {{ .Release.Name }}-pg-rw
   {{- end }}
@@ -24,11 +24,11 @@ data:
   {{- /* configMap overrides win (rendered by the range below) — emitting the
   default too would produce a duplicate YAML key. */}}
   {{- if not (index .Values.configMap "MODEL_SERVER_HOST") }}
-  MODEL_SERVER_HOST: "{{ include "onyx.fullname" . }}-inference-model-service"
+  MODEL_SERVER_HOST: "{{ include "onyx.resourceName" (list . "inference-model-service") }}"
   {{- end }}
   {{- if .Values.vectorDB.enabled }}
   {{- if not (index .Values.configMap "INDEXING_MODEL_SERVER_HOST") }}
-  INDEXING_MODEL_SERVER_HOST: "{{ include "onyx.fullname" . }}-indexing-model-service"
+  INDEXING_MODEL_SERVER_HOST: "{{ include "onyx.resourceName" (list . "indexing-model-service") }}"
   {{- end }}
   DISABLE_VECTOR_DB: "false"
   {{- else }}

--- a/deployment/helm/charts/onyx/templates/discordbot.yaml
+++ b/deployment/helm/charts/onyx/templates/discordbot.yaml
@@ -4,7 +4,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "onyx.fullname" . }}-discordbot
+  name: {{ include "onyx.resourceName" (list . "discordbot") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.discordbot.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/grafana-dashboards.yaml
+++ b/deployment/helm/charts/onyx/templates/grafana-dashboards.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "onyx.fullname" . }}-indexing-pipeline-dashboard
+  name: {{ include "onyx.resourceName" (list . "indexing-pipeline-dashboard") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     grafana_dashboard: "1"
@@ -16,7 +16,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "onyx.fullname" . }}-opensearch-search-latency-dashboard
+  name: {{ include "onyx.resourceName" (list . "opensearch-search-latency-dashboard") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     grafana_dashboard: "1"
@@ -29,7 +29,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "onyx.fullname" . }}-redis-queues-dashboard
+  name: {{ include "onyx.resourceName" (list . "redis-queues-dashboard") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     grafana_dashboard: "1"
@@ -42,7 +42,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "onyx.fullname" . }}-indexing-pruning-dashboard
+  name: {{ include "onyx.resourceName" (list . "indexing-pruning-dashboard") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     grafana_dashboard: "1"

--- a/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "onyx.fullname" . }}-indexing-model
+  name: {{ include "onyx.resourceName" (list . "indexing-model") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.indexCapability.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/indexing-model-service.yaml
+++ b/deployment/helm/charts/onyx/templates/indexing-model-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "onyx.fullname" . }}-indexing-model-service
+  name: {{ include "onyx.resourceName" (list . "indexing-model-service") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:

--- a/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "onyx.fullname" . }}-inference-model
+  name: {{ include "onyx.resourceName" (list . "inference-model") }}
   labels:
     {{- range .Values.inferenceCapability.labels }}
     {{ .key }}: {{ .value }}

--- a/deployment/helm/charts/onyx/templates/inference-model-service.yaml
+++ b/deployment/helm/charts/onyx/templates/inference-model-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "onyx.fullname" . }}-inference-model-service
+  name: {{ include "onyx.resourceName" (list . "inference-model-service") }}
 spec:
   type: {{ .Values.inferenceCapability.service.type }}
   ports:

--- a/deployment/helm/charts/onyx/templates/ingress-api.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-api.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "onyx.fullname" . }}-ingress-api
+  name: {{ include "onyx.resourceName" (list . "ingress-api") }}
   annotations:
     {{- if not .Values.ingress.className }}
     kubernetes.io/ingress.class: nginx
@@ -12,7 +12,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ .Values.nginx.timeouts.read }}"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "{{ .Values.nginx.timeouts.send }}"
     nginx.ingress.kubernetes.io/proxy-body-size: "5G"
-    cert-manager.io/cluster-issuer: {{ include "onyx.fullname" . }}-letsencrypt
+    cert-manager.io/cluster-issuer: {{ include "onyx.resourceName" (list . "letsencrypt") }}
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
@@ -25,11 +25,11 @@ spec:
             pathType: ImplementationSpecific
             backend:
               service:
-                name: {{ include "onyx.fullname" . }}-api-service
+                name: {{ include "onyx.resourceName" (list . "api-service") }}
                 port:
                   number: {{ .Values.api.service.servicePort }}
   tls:
     - hosts:
         - {{ .Values.ingress.api.host }}
-      secretName: {{ include "onyx.fullname" . }}-ingress-api-tls
+      secretName: {{ include "onyx.resourceName" (list . "ingress-api-tls") }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/ingress-mcp-oauth-callback.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-mcp-oauth-callback.yaml
@@ -2,12 +2,12 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "onyx.fullname" . }}-ingress-mcp-oauth-callback
+  name: {{ include "onyx.resourceName" (list . "ingress-mcp-oauth-callback") }}
   annotations:
     {{- if not .Values.ingress.className }}
     kubernetes.io/ingress.class: nginx
     {{- end }}
-    cert-manager.io/cluster-issuer: {{ include "onyx.fullname" . }}-letsencrypt
+    cert-manager.io/cluster-issuer: {{ include "onyx.resourceName" (list . "letsencrypt") }}
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
@@ -20,11 +20,11 @@ spec:
             pathType: Exact
             backend:
               service:
-                name: {{ include "onyx.fullname" . }}-webserver
+                name: {{ include "onyx.resourceName" (list . "webserver") }}
                 port:
                   number: {{ .Values.webserver.service.servicePort }}
   tls:
     - hosts:
         - {{ .Values.ingress.api.host }}
-      secretName: {{ include "onyx.fullname" . }}-ingress-mcp-oauth-callback-tls
+      secretName: {{ include "onyx.resourceName" (list . "ingress-mcp-oauth-callback-tls") }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/ingress-mcp.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-mcp.yaml
@@ -2,14 +2,14 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "onyx.fullname" . }}-ingress-mcp
+  name: {{ include "onyx.resourceName" (list . "ingress-mcp") }}
   annotations:
     {{- if not .Values.ingress.className }}
     kubernetes.io/ingress.class: nginx
     {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/use-regex: "true"
-    cert-manager.io/cluster-issuer: {{ include "onyx.fullname" . }}-letsencrypt
+    cert-manager.io/cluster-issuer: {{ include "onyx.resourceName" (list . "letsencrypt") }}
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
@@ -22,12 +22,12 @@ spec:
             pathType: ImplementationSpecific
             backend:
               service:
-                name: {{ include "onyx.fullname" . }}-mcp-server-service
+                name: {{ include "onyx.resourceName" (list . "mcp-server-service") }}
                 port:
                   number: {{ .Values.mcpServer.service.servicePort }}
   tls:
     - hosts:
         - {{ .Values.ingress.api.host }}
-      secretName: {{ include "onyx.fullname" . }}-ingress-mcp-tls
+      secretName: {{ include "onyx.resourceName" (list . "ingress-mcp-tls") }}
 {{- end }}
 

--- a/deployment/helm/charts/onyx/templates/ingress-scim.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-scim.yaml
@@ -6,12 +6,12 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "onyx.fullname" . }}-ingress-scim
+  name: {{ include "onyx.resourceName" (list . "ingress-scim") }}
   annotations:
     {{- if not .Values.ingress.className }}
     kubernetes.io/ingress.class: nginx
     {{- end }}
-    cert-manager.io/cluster-issuer: {{ include "onyx.fullname" . }}-letsencrypt
+    cert-manager.io/cluster-issuer: {{ include "onyx.resourceName" (list . "letsencrypt") }}
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
@@ -24,11 +24,11 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ include "onyx.fullname" . }}-api-service
+                name: {{ include "onyx.resourceName" (list . "api-service") }}
                 port:
                   number: {{ .Values.api.service.servicePort }}
   tls:
     - hosts:
         - {{ .Values.ingress.webserver.host }}
-      secretName: {{ include "onyx.fullname" . }}-ingress-scim-tls
+      secretName: {{ include "onyx.resourceName" (list . "ingress-scim-tls") }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/ingress-webserver.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-webserver.yaml
@@ -2,12 +2,12 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "onyx.fullname" . }}-ingress-webserver
+  name: {{ include "onyx.resourceName" (list . "ingress-webserver") }}
   annotations:
     {{- if not .Values.ingress.className }}
     kubernetes.io/ingress.class: nginx
     {{- end }}
-    cert-manager.io/cluster-issuer: {{ include "onyx.fullname" . }}-letsencrypt
+    cert-manager.io/cluster-issuer: {{ include "onyx.resourceName" (list . "letsencrypt") }}
     kubernetes.io/tls-acme: "true"
 spec:
   {{- if .Values.ingress.className }}
@@ -21,11 +21,11 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ include "onyx.fullname" . }}-webserver
+                name: {{ include "onyx.resourceName" (list . "webserver") }}
                 port:
                   number: {{ .Values.webserver.service.servicePort }}
   tls:
     - hosts:
         - {{ .Values.ingress.webserver.host }}
-      secretName: {{ include "onyx.fullname" . }}-ingress-webserver-tls
+      secretName: {{ include "onyx.resourceName" (list . "ingress-webserver-tls") }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/lets-encrypt.yaml
+++ b/deployment/helm/charts/onyx/templates/lets-encrypt.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: {{ include "onyx.fullname" . }}-letsencrypt
+  name: {{ include "onyx.resourceName" (list . "letsencrypt") }}
 spec:
   acme:
     # The ACME server URL
@@ -11,7 +11,7 @@ spec:
     email: {{ .Values.letsencrypt.email }}
     # Name of a secret used to store the ACME account private key
     privateKeySecretRef:
-      name: {{ include "onyx.fullname" . }}-letsencrypt
+      name: {{ include "onyx.resourceName" (list . "letsencrypt") }}
     # Enable the HTTP-01 challenge provider
     solvers:
       - http01:

--- a/deployment/helm/charts/onyx/templates/mcp-server-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/mcp-server-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "onyx.fullname" . }}-mcp-server
+  name: {{ include "onyx.resourceName" (list . "mcp-server") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.mcpServer.deploymentLabels }}
@@ -101,7 +101,7 @@ spec:
             # API server connection for authentication and proxying
             # Uses full override variable to set the port instead of using default 8080
             - name: API_SERVER_URL_OVERRIDE_FOR_HTTP_REQUESTS
-              value: "http://{{ include "onyx.fullname" . }}-api-service:{{ .Values.api.service.servicePort }}"
+              value: "http://{{ include "onyx.resourceName" (list . "api-service") }}:{{ .Values.api.service.servicePort }}"
             {{- include "onyx.envSecrets" . | nindent 12 }}
             {{- include "onyx.metricsAuthEnv" . | nindent 12 }}
             {{- with include "onyx.customCACerts.env" . }}

--- a/deployment/helm/charts/onyx/templates/mcp-server-service.yaml
+++ b/deployment/helm/charts/onyx/templates/mcp-server-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "onyx.fullname" . }}-mcp-server-service
+  name: {{ include "onyx.resourceName" (list . "mcp-server-service") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- if .Values.mcpServer.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/mcp-server-servicemonitor.yaml
+++ b/deployment/helm/charts/onyx/templates/mcp-server-servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "onyx.fullname" . }}-mcp-server
+  name: {{ include "onyx.resourceName" (list . "mcp-server") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.monitoring.serviceMonitors.labels }}

--- a/deployment/helm/charts/onyx/templates/network-policy-sandbox-egress.yaml
+++ b/deployment/helm/charts/onyx/templates/network-policy-sandbox-egress.yaml
@@ -9,7 +9,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "onyx.fullname" . }}-sandbox-egress
+  name: {{ include "onyx.resourceName" (list . "sandbox-egress") }}
   namespace: {{ $sandboxNs }}
 spec:
   podSelector:

--- a/deployment/helm/charts/onyx/templates/network-policy-sandbox-push.yaml
+++ b/deployment/helm/charts/onyx/templates/network-policy-sandbox-push.yaml
@@ -3,7 +3,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "onyx.fullname" . }}-sandbox-push
+  name: {{ include "onyx.resourceName" (list . "sandbox-push") }}
   namespace: {{ $sandboxNs }}
 spec:
   podSelector:

--- a/deployment/helm/charts/onyx/templates/nginx-conf.yaml
+++ b/deployment/helm/charts/onyx/templates/nginx-conf.yaml
@@ -15,16 +15,16 @@ metadata:
 data:
   upstreams.conf: |
     upstream api_server {
-        server {{ include "onyx.fullname" . }}-api-service:{{ .Values.api.service.servicePort }} fail_timeout=0;
+        server {{ include "onyx.resourceName" (list . "api-service") }}:{{ .Values.api.service.servicePort }} fail_timeout=0;
     }
 
     upstream web_server {
-        server {{ include "onyx.fullname" . }}-webserver:{{ .Values.webserver.service.servicePort }} fail_timeout=0;
+        server {{ include "onyx.resourceName" (list . "webserver") }}:{{ .Values.webserver.service.servicePort }} fail_timeout=0;
     }
     {{- if .Values.mcpServer.enabled }}
 
     upstream mcp_server {
-        server {{ include "onyx.fullname" . }}-mcp-server-service:{{ .Values.mcpServer.service.servicePort }} fail_timeout=0;
+        server {{ include "onyx.resourceName" (list . "mcp-server-service") }}:{{ .Values.mcpServer.service.servicePort }} fail_timeout=0;
     }
     {{- end }}
 

--- a/deployment/helm/charts/onyx/templates/pre-delete-cleanup.yaml
+++ b/deployment/helm/charts/onyx/templates/pre-delete-cleanup.yaml
@@ -9,7 +9,7 @@ die before finishing finalizer processing, and namespace cleanup hangs.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "onyx.fullname" . }}-pre-delete
+  name: {{ include "onyx.resourceName" (list . "pre-delete") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
   annotations:
@@ -20,7 +20,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "onyx.fullname" . }}-pre-delete
+  name: {{ include "onyx.resourceName" (list . "pre-delete") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
   annotations:
@@ -42,7 +42,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "onyx.fullname" . }}-pre-delete
+  name: {{ include "onyx.resourceName" (list . "pre-delete") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
   annotations:
@@ -52,16 +52,16 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "onyx.fullname" . }}-pre-delete
+  name: {{ include "onyx.resourceName" (list . "pre-delete") }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "onyx.fullname" . }}-pre-delete
+    name: {{ include "onyx.resourceName" (list . "pre-delete") }}
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "onyx.fullname" . }}-pre-delete
+  name: {{ include "onyx.resourceName" (list . "pre-delete") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
   annotations:
@@ -75,7 +75,7 @@ spec:
       labels:
         {{- include "onyx.selectorLabels" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "onyx.fullname" . }}-pre-delete
+      serviceAccountName: {{ include "onyx.resourceName" (list . "pre-delete") }}
       restartPolicy: Never
       containers:
         - name: cleanup

--- a/deployment/helm/charts/onyx/templates/sandbox-image-prepuller.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-image-prepuller.yaml
@@ -21,7 +21,7 @@ PriorityClass; see the docs above before adding one back.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "onyx.fullname" . }}-sandbox-image-prepuller
+  name: {{ include "onyx.resourceName" (list . "sandbox-image-prepuller") }}
   namespace: {{ $sandboxNs }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
@@ -98,7 +98,7 @@ kubelet's. Listing a policyType with no rules is deny-all. */}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "onyx.fullname" . }}-sandbox-image-prepuller
+  name: {{ include "onyx.resourceName" (list . "sandbox-image-prepuller") }}
   namespace: {{ $sandboxNs }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/deployment.yaml
@@ -4,7 +4,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "onyx.fullname" . }}-sandbox-proxy
+  name: {{ include "onyx.resourceName" (list . "sandbox-proxy") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     app.kubernetes.io/component: sandbox-proxy
@@ -36,7 +36,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "onyx.fullname" . }}-sandbox-proxy
+      serviceAccountName: {{ include "onyx.resourceName" (list . "sandbox-proxy") }}
       terminationGracePeriodSeconds: {{ .Values.sandboxProxy.terminationGracePeriodSeconds }}
       securityContext:
         runAsNonRoot: true

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/networkpolicy-egress.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/networkpolicy-egress.yaml
@@ -14,7 +14,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "onyx.fullname" . }}-sandbox-proxy-egress
+  name: {{ include "onyx.resourceName" (list . "sandbox-proxy-egress") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     app.kubernetes.io/component: sandbox-proxy

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/networkpolicy.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/networkpolicy.yaml
@@ -7,7 +7,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "onyx.fullname" . }}-sandbox-proxy
+  name: {{ include "onyx.resourceName" (list . "sandbox-proxy") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     app.kubernetes.io/component: sandbox-proxy

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/pdb.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/pdb.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "onyx.fullname" . }}-sandbox-proxy
+  name: {{ include "onyx.resourceName" (list . "sandbox-proxy") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     app.kubernetes.io/component: sandbox-proxy

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/rbac.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/rbac.yaml
@@ -9,7 +9,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "onyx.fullname" . }}-sandbox-proxy
+  name: {{ include "onyx.resourceName" (list . "sandbox-proxy") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     app.kubernetes.io/component: sandbox-proxy
@@ -23,7 +23,7 @@ automountServiceAccountToken: {{ $sandboxProxyServiceAccountAutomount }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "onyx.fullname" . }}-sandbox-proxy-ca
+  name: {{ include "onyx.resourceName" (list . "sandbox-proxy-ca") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     app.kubernetes.io/component: sandbox-proxy
@@ -41,17 +41,17 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "onyx.fullname" . }}-sandbox-proxy-ca
+  name: {{ include "onyx.resourceName" (list . "sandbox-proxy-ca") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     app.kubernetes.io/component: sandbox-proxy
 subjects:
   - kind: ServiceAccount
-    name: {{ include "onyx.fullname" . }}-sandbox-proxy
+    name: {{ include "onyx.resourceName" (list . "sandbox-proxy") }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ include "onyx.fullname" . }}-sandbox-proxy-ca
+  name: {{ include "onyx.resourceName" (list . "sandbox-proxy-ca") }}
   apiGroup: rbac.authorization.k8s.io
 ---
 # Pod watch (informer) + CA ConfigMap write, both scoped to the
@@ -59,7 +59,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "onyx.fullname" . }}-sandbox-proxy
+  name: {{ include "onyx.resourceName" (list . "sandbox-proxy") }}
   namespace: {{ $sandboxNs }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
@@ -79,17 +79,17 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "onyx.fullname" . }}-sandbox-proxy
+  name: {{ include "onyx.resourceName" (list . "sandbox-proxy") }}
   namespace: {{ $sandboxNs }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     app.kubernetes.io/component: sandbox-proxy
 subjects:
   - kind: ServiceAccount
-    name: {{ include "onyx.fullname" . }}-sandbox-proxy
+    name: {{ include "onyx.resourceName" (list . "sandbox-proxy") }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ include "onyx.fullname" . }}-sandbox-proxy
+  name: {{ include "onyx.resourceName" (list . "sandbox-proxy") }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/service.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "onyx.fullname" . }}-sandbox-proxy
+  name: {{ include "onyx.resourceName" (list . "sandbox-proxy") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     app.kubernetes.io/component: sandbox-proxy

--- a/deployment/helm/charts/onyx/templates/slackbot.yaml
+++ b/deployment/helm/charts/onyx/templates/slackbot.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "onyx.fullname" . }}-slackbot
+  name: {{ include "onyx.resourceName" (list . "slackbot") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.slackbot.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/tests/test-connection.yaml
+++ b/deployment/helm/charts/onyx/templates/tests/test-connection.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "onyx.fullname" . }}-test-connection"
+  name: "{{ include "onyx.resourceName" (list . "test-connection") }}"
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
   annotations:
@@ -17,7 +17,7 @@ spec:
         - -c
       args:
         - |
-          SVC="{{ include "onyx.fullname" . }}-webserver"
+          SVC="{{ include "onyx.resourceName" (list . "webserver") }}"
           PORT="{{ .Values.webserver.service.servicePort }}"
           URL="http://${SVC}:${PORT}/"
           for i in $(seq 1 40); do

--- a/deployment/helm/charts/onyx/templates/webserver-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/webserver-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "onyx.fullname" . }}-web-server
+  name: {{ include "onyx.resourceName" (list . "web-server") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.webserver.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/webserver-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/webserver-hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "onyx.fullname" . }}-webserver
+  name: {{ include "onyx.resourceName" (list . "webserver") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-web-server
+    name: {{ include "onyx.resourceName" (list . "web-server") }}
   minReplicas: {{ .Values.webserver.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.webserver.autoscaling.maxReplicas }}
   metrics:

--- a/deployment/helm/charts/onyx/templates/webserver-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/webserver-scaledobject.yaml
@@ -2,14 +2,14 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ include "onyx.fullname" . }}-web-server
+  name: {{ include "onyx.resourceName" (list . "web-server") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-web-server
+    name: {{ include "onyx.resourceName" (list . "web-server") }}
   minReplicaCount: {{ .Values.webserver.autoscaling.minReplicas }}
   maxReplicaCount: {{ .Values.webserver.autoscaling.maxReplicas }}
   pollingInterval: {{ .Values.webserver.autoscaling.pollingInterval | default 30 }}

--- a/deployment/helm/charts/onyx/templates/webserver-service.yaml
+++ b/deployment/helm/charts/onyx/templates/webserver-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "onyx.fullname" . }}-webserver
+  name: {{ include "onyx.resourceName" (list . "webserver") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- if .Values.webserver.deploymentLabels }}


### PR DESCRIPTION
## Description

A customer's dev environments hit install failures with long Helm release names:

```
Service "<release>-onyx-celery-worker-heavy-metrics" is invalid:
metadata.name: Invalid value: "...": must be no more than 63 characters
```

The chart already has a truncating helper (`onyx.resourceName`, added with the scheduled-tasks/user-file-processing templates), but most templates still build names as `{{ include "onyx.fullname" . }}-<suffix>` with no truncation.

This PR aligns everything on the helper:

- Converts all 123 remaining name constructions across 60 templates to `onyx.resourceName`.
- Converts the two helpers that derive names from `onyx.fullname` so they keep matching the truncated resource names: `onyx.pgInto.configMapName` and `onyx.sandboxProxyHost` (the sandbox proxy's cluster DNS default now uses the truncated Service name).
- Suffixes are unchanged, so every cross-reference truncates to the same string as the resource it points at: HPA/ScaledObject scale targets, ingress backends, nginx upstream hosts, the configmap's `INTERNAL_URL`/model-server hosts, and serviceAccountName references.
- Left alone: `sandbox-rbac.yaml` (already has its own hash-suffix truncation for namespace-qualified names) and bare `onyx.fullname` uses with no suffix.
- Chart bumped to 0.8.15 with an `artifacthub.io/changes` entry.

Known residuals (out of scope, vendored subcharts): with a long release name, ingress-nginx still renders a 66-char admission Service name (workaround: `nginx.fullnameOverride`), and code-interpreter renders a 65-char NetworkPolicy name (harmless — NetworkPolicy names allow 253 chars).

## How Has This Been Tested?

All with `helm template` + `ci/ct-values.yaml`:

- **No churn for existing installs**: with a short release name, rendered output is byte-identical to current main across three configurations (default values; everything enabled with HPA engine; everything enabled with KEDA engine) — the only differences are the `helm.sh/chart` version label and the `checksum/config` annotations derived from it, which any version bump produces.
- **Bug fixed**: with a 39-char release name matching the report and everything enabled, names over 63 chars drop from 18 to 2 (both from the vendored subcharts above; every onyx-chart resource is ≤63).
- **References stay consistent**: script-verified on the long-name render that every HPA/ScaledObject scale target names an existing Deployment, every ingress backend / nginx upstream / configmap host names an existing Service, and every serviceAccountName resolves.
- `helm lint` passes; pre-commit passes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps all child resource names in the `onyx` Helm chart at 63 characters and adds an 8‑char hash for over‑limit names to prevent sibling collisions. Previously names were `<fullname>-<suffix>` without truncation, and plain right‑truncation could collapse siblings; installs with long release names failed or produced duplicate kind/name pairs.

- Switches 123 name constructions across 60 templates to `onyx.resourceName`; suffixes are unchanged and all cross‑references (HPA/ScaledObject targets, ingress backends, NGINX upstreams, configmap service hosts, serviceAccountName refs) remain consistent.
- Updates `onyx.resourceName` to render names under the limit as‑is; for over‑limit names, uses a 54‑char prefix plus an 8‑char sha256 of the full name. The result is deterministic and prevents sibling collisions.
- Updates helpers: `onyx.pgInto.configMapName` and the default `onyx.sandboxProxyHost` (cluster DNS now uses the truncated Service name). Leaves `sandbox-rbac.yaml` (its own truncation) and bare `onyx.fullname` uses without a suffix as‑is.
- Chart bumped to 0.8.15 with `artifacthub.io/changes` updated. Short‑name renders are byte‑identical aside from version labels; `helm lint` passes. Verified with `helm template` at release‑name lengths 39, 48, and 53: no over‑63 names or duplicate kind/name pairs in `onyx`.
- Known residuals in vendored subcharts (e.g., `ingress-nginx`, `code-interpreter`, `minio`, `cloudnative-pg`, `redis`); use `nginx.fullnameOverride` if needed.

<sup>Written for commit e6e7b8d7d9a01bdd703d587fb8dd2206514591a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

