### PR TITLE
refactor(mcp): centralize credential checks in credentials.py

### DIFF
--- a/backend/onyx/auth/oauth_token_manager.py
+++ b/backend/onyx/auth/oauth_token_manager.py
@@ -1,6 +1,6 @@
 import time
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 from uuid import UUID
 
 import requests
@@ -40,6 +40,32 @@ logger = setup_logger()
 OAUTH_RESPONSE_TYPE_CODE = "code"
 OAUTH_GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code"
 OAUTH_PKCE_CHALLENGE_METHOD_S256 = "S256"
+
+# Providers that issue a refresh token only when the authorization request
+# explicitly asks for offline access, keyed by authorization-endpoint host.
+# Without these params the grant dies at access-token expiry with no way to
+# refresh. Explicitly configured params always win over these defaults.
+_OFFLINE_ACCESS_AUTH_PARAMS_BY_HOST: dict[str, dict[str, str]] = {
+    # `prompt=consent` because Google issues a refresh token only on flows
+    # that show the consent screen; a silent re-auth would leave a reconnected
+    # config without one. Matches Onyx's own Google login flow.
+    "accounts.google.com": {"access_type": "offline", "prompt": "consent"},
+}
+
+
+def ensure_offline_access_auth_params(authorization_url: str) -> str:
+    """Merge missing offline-access params into a built authorize URL.
+    Params already in the URL win."""
+    parsed = urlparse(authorization_url)
+    defaults = _OFFLINE_ACCESS_AUTH_PARAMS_BY_HOST.get((parsed.hostname or "").lower())
+    if not defaults:
+        return authorization_url
+    query = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    missing = {key: value for key, value in defaults.items() if key not in query}
+    if not missing:
+        return authorization_url
+    query.update(missing)
+    return urlunparse(parsed._replace(query=urlencode(query)))
 
 
 class OAuthFlowParams(BaseModel):
@@ -83,7 +109,9 @@ def build_oauth_authorization_url(
         query.update(params.additional_params)
 
     separator = "&" if "?" in params.authorization_url else "?"
-    return f"{params.authorization_url}{separator}{urlencode(query)}"
+    return ensure_offline_access_auth_params(
+        f"{params.authorization_url}{separator}{urlencode(query)}"
+    )
 
 
 def exchange_oauth_code_for_token(

--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -1,9 +1,6 @@
 import datetime
-from collections.abc import Mapping
-from typing import cast
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
 from sqlalchemy import Select, and_, delete, select
 from sqlalchemy.orm import Session, aliased, selectinload
 from sqlalchemy.orm.attributes import flag_modified
@@ -29,16 +26,8 @@ from onyx.db.models import (
     User__UserGroup,
     UserRole,
 )
-from onyx.server.features.mcp.models import (
-    DENYLISTED_MCP_HEADERS,
-    MCPAuthTemplate,
-    MCPConnectionData,
-    MCPOAuthKeys,
-    mcp_oauth_reauth_required,
-    merge_mcp_headers,
-)
+from onyx.server.features.mcp.models import MCPConnectionData
 from onyx.utils.logger import setup_logger
-from onyx.utils.sensitive import SensitiveValue
 
 logger = setup_logger()
 
@@ -381,21 +370,6 @@ def remove_user_from_mcp_server(
 
 
 # MCPConnectionConfig operations
-def extract_connection_data(
-    config: MCPConnectionConfig | None, apply_mask: bool = False
-) -> MCPConnectionData:
-    """Extract MCPConnectionData from a connection config, with proper typing.
-
-    This helper encapsulates the cast from the JSON column's dict[str, Any]
-    to the typed MCPConnectionData structure.
-    """
-    if config is None or config.config is None:
-        return MCPConnectionData(headers={})
-    if isinstance(config.config, SensitiveValue):
-        return cast(MCPConnectionData, config.config.get_value(apply_mask=apply_mask))
-    return cast(MCPConnectionData, config.config)
-
-
 def get_connection_config_by_id(
     config_id: int, db_session: Session, *, for_update: bool = False
 ) -> MCPConnectionConfig:
@@ -422,196 +396,6 @@ def get_user_connection_config(
             )
         )
     )
-
-
-class MCPCredentialsError(Exception):
-    """Credentials for an MCP server cannot be resolved for this user."""
-
-
-def get_mcp_auth_template(mcp_server: MCPServer) -> MCPAuthTemplate | None:
-    """Read the canonical admin template, including legacy per-user API keys."""
-    config = mcp_server.admin_connection_config
-    if config is None:
-        return None
-    data = extract_connection_data(config, apply_mask=False)
-    headers = data.get("header_template")
-    if headers is None and (
-        mcp_server.auth_type == MCPAuthenticationType.API_TOKEN
-        and mcp_server.auth_performer == MCPAuthenticationPerformer.PER_USER
-    ):
-        headers = data.get("headers")
-    if headers is None:
-        return None
-    return MCPAuthTemplate(headers=headers)
-
-
-class ResolvedMCPCredentials(BaseModel):
-    """Effective connection state for one MCP server and user."""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
-
-    connection_config: MCPConnectionConfig | None
-    user_oauth_token: str | None
-    auth_type: MCPAuthenticationType | None = None
-    auth_template: MCPAuthTemplate | None = None
-    user_email: str = ""
-
-    def _config_data(self) -> MCPConnectionData:
-        return extract_connection_data(self.connection_config, apply_mask=False)
-
-    def _template_substitutions(self) -> dict[str, str]:
-        data = self._config_data()
-        substitutions = dict(data.get("header_substitutions", {}))
-        if api_token := data.get("api_token"):
-            substitutions["api_key"] = api_token
-        return substitutions
-
-    def _configured_headers(self) -> dict[str, str]:
-        data = self._config_data()
-        template_headers: dict[str, str] = {}
-        if self.auth_template is not None and self._has_required_substitutions():
-            template_headers = self.auth_template.render(
-                self._template_substitutions(), user_email=self.user_email
-            )
-        return merge_mcp_headers(data.get("headers", {}), template_headers)
-
-    def _generated_auth_headers(self) -> dict[str, str]:
-        if self.user_oauth_token:
-            return {"Authorization": f"Bearer {self.user_oauth_token}"}
-        if self.auth_type != MCPAuthenticationType.OAUTH:
-            return {}
-        tokens = self._config_data().get(MCPOAuthKeys.TOKENS.value)
-        if not tokens:
-            return {}
-        token_type = tokens.get("token_type")
-        access_token = tokens.get("access_token")
-        if not token_type or not access_token:
-            return {}
-        return {"Authorization": f"{token_type} {access_token}"}
-
-    def _has_required_substitutions(self) -> bool:
-        if self.auth_template is None or not self.auth_template.required_fields:
-            return True
-        substitutions = self._template_substitutions()
-        return all(
-            substitutions.get(field) for field in self.auth_template.required_fields
-        )
-
-    def build_headers(self) -> dict[str, str]:
-        """Build configured headers with generated authentication taking precedence."""
-        stored = merge_mcp_headers(
-            self._configured_headers(), self._generated_auth_headers()
-        )
-        headers = {
-            k: v for k, v in stored.items() if k.lower() not in DENYLISTED_MCP_HEADERS
-        }
-        if len(headers) != len(stored):
-            # Names only — header values are credentials.
-            logger.warning(
-                "Stored MCP credential headers contained denylisted headers "
-                "that were stripped: %s",
-                sorted(k for k in stored if k.lower() in DENYLISTED_MCP_HEADERS),
-            )
-        return headers
-
-    def needs_reauth(self) -> bool:
-        """The stored OAuth grant is dead (expired, no refresh token); only a
-        user reconnect can restore it. Its bearer header still takes precedence
-        in ``build_headers``, so no caller-supplied header can work around it."""
-        return self.auth_type == MCPAuthenticationType.OAUTH and (
-            mcp_oauth_reauth_required(self._config_data())
-        )
-
-    def is_authenticated(self) -> bool:
-        if self.auth_type in (None, MCPAuthenticationType.NONE):
-            return self._has_required_substitutions()
-        if self.auth_type == MCPAuthenticationType.PT_OAUTH:
-            return bool(self.user_oauth_token) and self._has_required_substitutions()
-        if self.auth_type == MCPAuthenticationType.OAUTH:
-            # A dead grant must read as unauthenticated so the UI prompts a
-            # reconnect and Craft configs exclude the server.
-            return (
-                bool(self._generated_auth_headers())
-                and not self.needs_reauth()
-                and self._has_required_substitutions()
-            )
-        return bool(self._configured_headers()) and self._has_required_substitutions()
-
-
-def resolve_mcp_credentials(
-    mcp_server: MCPServer,
-    user: User,
-    db_session: Session,
-    *,
-    user_configs: Mapping[int, MCPConnectionConfig] | None = None,
-) -> ResolvedMCPCredentials:
-    """Combine the admin template, user substitutions, and generated auth.
-
-    `user_configs` may preload every requested server's user row; a missing key
-    means no stored user values.
-    """
-    auth_template = get_mcp_auth_template(mcp_server)
-    user_connection_config = (
-        user_configs.get(mcp_server.id)
-        if user_configs is not None
-        else get_user_connection_config(mcp_server.id, user.email, db_session)
-    )
-
-    if mcp_server.auth_type == MCPAuthenticationType.PT_OAUTH:
-        if user.is_anonymous:
-            raise MCPCredentialsError(
-                f"Anonymous user cannot use PT_OAUTH MCP server {mcp_server.id}"
-            )
-        return ResolvedMCPCredentials(
-            connection_config=user_connection_config,
-            user_oauth_token=(
-                user.oauth_accounts[0].access_token if user.oauth_accounts else None
-            ),
-            auth_type=mcp_server.auth_type,
-            auth_template=auth_template,
-            user_email=user.email,
-        )
-
-    if mcp_server.auth_type in (
-        MCPAuthenticationType.API_TOKEN,
-        MCPAuthenticationType.OAUTH,
-    ):
-        if mcp_server.auth_performer == MCPAuthenticationPerformer.PER_USER:
-            connection_config = user_connection_config
-        else:
-            connection_config = mcp_server.admin_connection_config
-        return ResolvedMCPCredentials(
-            connection_config=connection_config,
-            user_oauth_token=None,
-            auth_type=mcp_server.auth_type,
-            auth_template=auth_template,
-            user_email=user.email,
-        )
-
-    return ResolvedMCPCredentials(
-        connection_config=user_connection_config,
-        user_oauth_token=None,
-        auth_type=mcp_server.auth_type,
-        auth_template=auth_template,
-        user_email=user.email,
-    )
-
-
-def can_resolve_mcp_credentials(
-    mcp_server: MCPServer,
-    user: User,
-    db_session: Session,
-    *,
-    user_configs: Mapping[int, MCPConnectionConfig] | None = None,
-) -> bool:
-    """Whether every generated credential and template value is available."""
-    try:
-        credentials = resolve_mcp_credentials(
-            mcp_server, user, db_session, user_configs=user_configs
-        )
-    except MCPCredentialsError:
-        return False
-    return credentials.is_authenticated()
 
 
 def get_user_connection_configs(

--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -34,6 +34,7 @@ from onyx.server.features.mcp.models import (
     MCPAuthTemplate,
     MCPConnectionData,
     MCPOAuthKeys,
+    mcp_oauth_reauth_required,
     merge_mcp_headers,
 )
 from onyx.utils.logger import setup_logger
@@ -517,8 +518,11 @@ class ResolvedMCPCredentials(BaseModel):
         if self.auth_type == MCPAuthenticationType.PT_OAUTH:
             return bool(self.user_oauth_token) and self._has_required_substitutions()
         if self.auth_type == MCPAuthenticationType.OAUTH:
+            # A dead grant must read as unauthenticated so the UI prompts a
+            # reconnect and Craft configs exclude the server.
             return (
                 bool(self._generated_auth_headers())
+                and not mcp_oauth_reauth_required(self._config_data())
                 and self._has_required_substitutions()
             )
         return bool(self._configured_headers()) and self._has_required_substitutions()

--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -397,12 +397,14 @@ def extract_connection_data(
 
 
 def get_connection_config_by_id(
-    config_id: int, db_session: Session
+    config_id: int, db_session: Session, *, for_update: bool = False
 ) -> MCPConnectionConfig:
-    """Get connection config by ID"""
-    config = db_session.scalar(
-        select(MCPConnectionConfig).where(MCPConnectionConfig.id == config_id)
-    )
+    """Get connection config by ID. ``for_update`` row-locks the config so a
+    read-compare-write over its JSON blob is atomic against concurrent writers."""
+    stmt = select(MCPConnectionConfig).where(MCPConnectionConfig.id == config_id)
+    if for_update:
+        stmt = stmt.with_for_update()
+    config = db_session.scalar(stmt)
     if not config:
         raise ValueError("Connection config by specified id does not exist")
     return config
@@ -512,6 +514,14 @@ class ResolvedMCPCredentials(BaseModel):
             )
         return headers
 
+    def needs_reauth(self) -> bool:
+        """The stored OAuth grant is dead (expired, no refresh token); only a
+        user reconnect can restore it. Its bearer header still takes precedence
+        in ``build_headers``, so no caller-supplied header can work around it."""
+        return self.auth_type == MCPAuthenticationType.OAUTH and (
+            mcp_oauth_reauth_required(self._config_data())
+        )
+
     def is_authenticated(self) -> bool:
         if self.auth_type in (None, MCPAuthenticationType.NONE):
             return self._has_required_substitutions()
@@ -522,7 +532,7 @@ class ResolvedMCPCredentials(BaseModel):
             # reconnect and Craft configs exclude the server.
             return (
                 bool(self._generated_auth_headers())
-                and not mcp_oauth_reauth_required(self._config_data())
+                and not self.needs_reauth()
                 and self._has_required_substitutions()
             )
         return bool(self._configured_headers()) and self._has_required_substitutions()

--- a/backend/onyx/sandbox_proxy/resolvers/mcp_server.py
+++ b/backend/onyx/sandbox_proxy/resolvers/mcp_server.py
@@ -23,11 +23,8 @@ from onyx.db.enums import (
     MCPAuthenticationType,
 )
 from onyx.db.mcp import (
-    MCPCredentialsError,
-    extract_connection_data,
     get_craft_enabled_mcp_servers,
     get_mcp_server_by_id,
-    resolve_mcp_credentials,
     user_can_access_mcp_server,
 )
 from onyx.db.models import MCPServer
@@ -47,7 +44,12 @@ from onyx.sandbox_proxy.resolvers.mcp_matching import (
     normalized_request_path,
     parse_target,
 )
-from onyx.server.features.mcp.models import mcp_token_expired
+from onyx.server.features.mcp.credentials import (
+    MCPCredentialsError,
+    extract_connection_data,
+    mcp_token_expired,
+    resolve_mcp_credentials,
+)
 from onyx.server.features.mcp.oauth import refresh_mcp_oauth_token_if_expired
 from onyx.utils.credential_audit import emit_credential_access
 from onyx.utils.logger import setup_logger
@@ -171,7 +173,7 @@ class MCPServerResolver(CredentialResolver):
                     str(e), sandbox_detail=_connect_detail(server.name, admin_managed)
                 ) from e
             headers = creds.build_headers()
-            credentials_ready = creds.is_authenticated()
+            credentials_ready = creds.can_authenticate()
             expired_oauth_config_id: int | None = None
             if (
                 server.auth_type == MCPAuthenticationType.OAUTH

--- a/backend/onyx/sandbox_proxy/resolvers/mcp_server.py
+++ b/backend/onyx/sandbox_proxy/resolvers/mcp_server.py
@@ -47,10 +47,8 @@ from onyx.sandbox_proxy.resolvers.mcp_matching import (
     normalized_request_path,
     parse_target,
 )
-from onyx.server.features.mcp.oauth import (
-    mcp_token_expired,
-    refresh_mcp_oauth_token_if_expired,
-)
+from onyx.server.features.mcp.models import mcp_token_expired
+from onyx.server.features.mcp.oauth import refresh_mcp_oauth_token_if_expired
 from onyx.utils.credential_audit import emit_credential_access
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR

--- a/backend/onyx/server/features/build/sandbox/util/mcp_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/mcp_config.py
@@ -11,13 +11,13 @@ from collections.abc import Sequence
 from sqlalchemy.orm import Session
 
 from onyx.db.mcp import (
-    can_resolve_mcp_credentials,
     get_craft_enabled_mcp_servers,
     get_mcp_tools_for_servers,
     get_user_connection_configs,
 )
 from onyx.db.models import MCPServer, User
 from onyx.server.features.build.sandbox.models import CraftMCPServerConfig
+from onyx.server.features.mcp.credentials import user_can_authenticate
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -50,9 +50,7 @@ def resolve_craft_mcp_servers(
     )
     servers: list[MCPServer] = []
     for server in accessible:
-        if can_resolve_mcp_credentials(
-            server, user, db_session, user_configs=user_configs
-        ):
+        if user_can_authenticate(server, user, db_session, user_configs=user_configs):
             servers.append(server)
         else:
             # Craft reads no MCP status back from opencode; this is the only

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -48,24 +48,20 @@ from onyx.db.gated_app import (
 )
 from onyx.db.mcp import (
     affected_user_ids_for_mcp_server,
-    can_resolve_mcp_credentials,
     create_connection_config,
     create_mcp_server__no_commit,
     delete_all_user_connection_configs_for_server_no_commit,
     delete_connection_config,
     delete_mcp_server,
     delete_user_connection_configs_for_server,
-    extract_connection_data,
     get_all_mcp_servers,
     get_all_mcp_tools_for_server,
     get_craft_enabled_mcp_servers,
-    get_mcp_auth_template,
     get_mcp_server_by_id,
     get_mcp_servers_accessible_to_user,
     get_mcp_servers_for_persona,
     get_user_connection_config,
     get_user_connection_configs,
-    resolve_mcp_credentials,
     update_connection_config,
     update_connection_config__no_commit,
     update_mcp_server__no_commit,
@@ -92,6 +88,14 @@ from onyx.server.features.mcp.client_metadata import (
 from onyx.server.features.mcp.client_metadata import (
     router as client_metadata_router,
 )
+from onyx.server.features.mcp.credentials import (
+    extract_connection_data,
+    get_mcp_auth_template,
+    mcp_token_expired,
+    requires_user_authentication,
+    resolve_mcp_credentials,
+    user_can_authenticate,
+)
 from onyx.server.features.mcp.models import (
     MCPApiKeyResponse,
     MCPAuthTemplate,
@@ -111,7 +115,6 @@ from onyx.server.features.mcp.models import (
     MCPUserOAuthConnectRequest,
     MCPUserOAuthConnectResponse,
     contains_mcp_placeholder,
-    mcp_token_expired,
     merge_mcp_headers,
 )
 from onyx.server.features.mcp.oauth import (
@@ -771,10 +774,10 @@ async def _connect_oauth(
         and not request.oauth_client_id_changed
         and not request.oauth_client_secret_changed
     )
-    is_authenticated = bool(
+    credentials_usable = bool(
         oauth_credentials_unchanged
         and not mcp_token_expired(existing_user_data)
-        and can_resolve_mcp_credentials(
+        and user_can_authenticate(
             mcp_server,
             user,
             db,
@@ -898,7 +901,7 @@ async def _connect_oauth(
             admin_config_id=mcp_server.admin_connection_config_id,
             connection_headers=connection_config_dict.get("headers", {}),
             transport=mcp_server.transport,
-            is_authenticated=is_authenticated,
+            credentials_usable=credentials_usable,
             force_reauthentication=request.force_reauthentication,
         )
     except OnyxError:
@@ -1192,7 +1195,7 @@ def save_user_credentials(
         message=validation_message,
         server_id=request.server_id,
         server_name=mcp_server.name,
-        authenticated=resolved.is_authenticated(),
+        authenticated=resolved.can_authenticate(),
         validation_tested=validation_tested,
     )
 
@@ -1297,7 +1300,7 @@ def _db_mcp_server_to_api_mcp_server(
         else get_user_connection_config(db_server.id, email, db)
     )
     if request_user is not None:
-        user_authenticated = can_resolve_mcp_credentials(
+        user_authenticated = user_can_authenticate(
             db_server,
             request_user,
             db,
@@ -1466,7 +1469,7 @@ def get_craft_mcp_servers_for_user(
             db_server,
             db,
             request_user=user,
-            craft_connected=can_resolve_mcp_credentials(
+            craft_connected=user_can_authenticate(
                 db_server, user, db, user_configs=user_configs
             ),
             user_configs=user_configs,
@@ -1631,7 +1634,7 @@ def _list_mcp_tools_by_id(
         )
 
     credentials = resolve_mcp_credentials(mcp_server, user, db)
-    if not credentials.is_authenticated():
+    if not credentials.can_authenticate():
         raise OnyxError(
             OnyxErrorCode.UNAUTHENTICATED,
             "This MCP server is not configured for the current user.",
@@ -2391,9 +2394,8 @@ def upsert_mcp_server(
             oauth_token_endpoint=mcp_server.oauth_token_endpoint,
             oauth_scopes_override=mcp_server.oauth_scopes_override,
             oauth_additional_auth_params=mcp_server.oauth_additional_auth_params,
-            is_authenticated=(
-                mcp_server.auth_type == MCPAuthenticationType.NONE.value
-                or request.auth_performer == MCPAuthenticationPerformer.ADMIN
+            is_authenticated=not requires_user_authentication(
+                mcp_server.auth_type, request.auth_performer
             ),
         )
 

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -111,6 +111,7 @@ from onyx.server.features.mcp.models import (
     MCPUserOAuthConnectRequest,
     MCPUserOAuthConnectResponse,
     contains_mcp_placeholder,
+    mcp_token_expired,
     merge_mcp_headers,
 )
 from onyx.server.features.mcp.oauth import (
@@ -125,7 +126,6 @@ from onyx.server.features.mcp.oauth import (
     key_state,
     key_tokens,
     make_oauth_provider,
-    mcp_token_expired,
 )
 from onyx.server.features.mcp.ssrf import validate_mcp_outbound_url
 from onyx.server.features.tool.models import ToolSnapshot

--- a/backend/onyx/server/features/mcp/credentials.py
+++ b/backend/onyx/server/features/mcp/credentials.py
@@ -6,10 +6,10 @@ Each function here answers exactly one, with the consumer noted:
 - ``ResolvedMCPCredentials.can_authenticate`` — are the effective credentials
   usable for a call right now (lazy refresh still allowed)? Consumed by the
   tool runtime, the sandbox proxy, and the API status fields.
+- ``ResolvedMCPCredentials.needs_reauth`` — is the stored OAuth grant dead
+  (expired with no refresh token), so the user must reconnect?
 - ``mcp_token_expired`` — is the stored OAuth access token past its expiry
   (regardless of whether a refresh token could revive it)? Drives refresh.
-- ``mcp_oauth_reauth_required`` — is the stored OAuth grant dead (expired with
-  no refresh token), so the user must reconnect?
 - ``requires_user_authentication`` — does the server's shape require a per-user
   credential at all, or is it usable from admin/none config alone?
 - ``user_can_authenticate`` — resolves the user's credentials and reports
@@ -65,16 +65,6 @@ def mcp_token_expired(config_data: MCPConnectionData) -> bool:
     """True iff the stored access token is past its persisted expiry."""
     expires_at = config_data.get(MCPOAuthKeys.TOKEN_EXPIRES_AT.value)
     return expires_at is not None and float(expires_at) <= time.time()
-
-
-def mcp_oauth_reauth_required(config_data: MCPConnectionData) -> bool:
-    """True when the stored OAuth grant can never authenticate again on its
-    own: the access token is expired and there is no refresh token to redeem.
-    Such a config must not count as authenticated — the user has to reconnect."""
-    if not mcp_token_expired(config_data):
-        return False
-    tokens = config_data.get(MCPOAuthKeys.TOKENS.value) or {}
-    return not tokens.get("refresh_token")
 
 
 def requires_user_authentication(
@@ -178,12 +168,17 @@ class ResolvedMCPCredentials(BaseModel):
         return headers
 
     def needs_reauth(self) -> bool:
-        """The stored OAuth grant is dead (expired, no refresh token); only a
-        user reconnect can restore it. Its bearer header still takes precedence
-        in ``build_headers``, so no caller-supplied header can work around it."""
-        return self.auth_type == MCPAuthenticationType.OAUTH and (
-            mcp_oauth_reauth_required(self._config_data())
-        )
+        """The stored OAuth grant is dead: the access token is expired and
+        there is no refresh token to redeem, so only a user reconnect can
+        restore it. Its bearer header still takes precedence in
+        ``build_headers``, so no caller-supplied header can work around it."""
+        if self.auth_type != MCPAuthenticationType.OAUTH:
+            return False
+        config_data = self._config_data()
+        if not mcp_token_expired(config_data):
+            return False
+        tokens = config_data.get(MCPOAuthKeys.TOKENS.value) or {}
+        return not tokens.get("refresh_token")
 
     def can_authenticate(self) -> bool:
         """Whether these credentials can authenticate a call now (lazy refresh

--- a/backend/onyx/server/features/mcp/credentials.py
+++ b/backend/onyx/server/features/mcp/credentials.py
@@ -1,0 +1,280 @@
+"""Central home for MCP credential/authentication questions.
+
+Several distinct business questions used to share the name ``is_authenticated``.
+Each function here answers exactly one, with the consumer noted:
+
+- ``ResolvedMCPCredentials.can_authenticate`` — are the effective credentials
+  usable for a call right now (lazy refresh still allowed)? Consumed by the
+  tool runtime, the sandbox proxy, and the API status fields.
+- ``mcp_token_expired`` — is the stored OAuth access token past its expiry
+  (regardless of whether a refresh token could revive it)? Drives refresh.
+- ``mcp_oauth_reauth_required`` — is the stored OAuth grant dead (expired with
+  no refresh token), so the user must reconnect?
+- ``requires_user_authentication`` — does the server's shape require a per-user
+  credential at all, or is it usable from admin/none config alone?
+- ``user_can_authenticate`` — resolves the user's credentials and reports
+  whether they authenticate; the DB-backed entry point for status listings.
+
+This module holds pure logic plus the resolve orchestration; the DB fetch lives
+in ``onyx.db.mcp``. It must not import ``onyx.server.features.mcp.oauth``.
+"""
+
+import time
+from collections.abc import Mapping
+from typing import cast
+
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import MCPAuthenticationPerformer, MCPAuthenticationType
+from onyx.db.mcp import get_user_connection_config
+from onyx.db.models import MCPConnectionConfig, MCPServer, User
+from onyx.server.features.mcp.models import (
+    DENYLISTED_MCP_HEADERS,
+    MCPAuthTemplate,
+    MCPConnectionData,
+    MCPOAuthKeys,
+    merge_mcp_headers,
+)
+from onyx.utils.logger import setup_logger
+from onyx.utils.sensitive import SensitiveValue
+
+logger = setup_logger()
+
+
+class MCPCredentialsError(Exception):
+    """Credentials for an MCP server cannot be resolved for this user."""
+
+
+def extract_connection_data(
+    config: MCPConnectionConfig | None, apply_mask: bool = False
+) -> MCPConnectionData:
+    """Extract MCPConnectionData from a connection config, with proper typing.
+
+    This helper encapsulates the cast from the JSON column's dict[str, Any]
+    to the typed MCPConnectionData structure.
+    """
+    if config is None or config.config is None:
+        return MCPConnectionData(headers={})
+    if isinstance(config.config, SensitiveValue):
+        return cast(MCPConnectionData, config.config.get_value(apply_mask=apply_mask))
+    return cast(MCPConnectionData, config.config)
+
+
+def mcp_token_expired(config_data: MCPConnectionData) -> bool:
+    """True iff the stored access token is past its persisted expiry."""
+    expires_at = config_data.get(MCPOAuthKeys.TOKEN_EXPIRES_AT.value)
+    return expires_at is not None and float(expires_at) <= time.time()
+
+
+def mcp_oauth_reauth_required(config_data: MCPConnectionData) -> bool:
+    """True when the stored OAuth grant can never authenticate again on its
+    own: the access token is expired and there is no refresh token to redeem.
+    Such a config must not count as authenticated — the user has to reconnect."""
+    if not mcp_token_expired(config_data):
+        return False
+    tokens = config_data.get(MCPOAuthKeys.TOKENS.value) or {}
+    return not tokens.get("refresh_token")
+
+
+def requires_user_authentication(
+    auth_type: MCPAuthenticationType | None,
+    auth_performer: MCPAuthenticationPerformer | None,
+) -> bool:
+    """Whether the server's shape needs a per-user credential. False when the
+    server requires no auth, or an admin supplies shared credentials for
+    everyone. Consumed at server create/update to report initial auth state."""
+    if auth_type == MCPAuthenticationType.NONE:
+        return False
+    if auth_performer == MCPAuthenticationPerformer.ADMIN:
+        return False
+    return True
+
+
+def get_mcp_auth_template(mcp_server: MCPServer) -> MCPAuthTemplate | None:
+    """Read the canonical admin template, including legacy per-user API keys."""
+    config = mcp_server.admin_connection_config
+    if config is None:
+        return None
+    data = extract_connection_data(config, apply_mask=False)
+    headers = data.get("header_template")
+    if headers is None and (
+        mcp_server.auth_type == MCPAuthenticationType.API_TOKEN
+        and mcp_server.auth_performer == MCPAuthenticationPerformer.PER_USER
+    ):
+        headers = data.get("headers")
+    if headers is None:
+        return None
+    return MCPAuthTemplate(headers=headers)
+
+
+class ResolvedMCPCredentials(BaseModel):
+    """Effective connection state for one MCP server and user."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+    connection_config: MCPConnectionConfig | None
+    user_oauth_token: str | None
+    auth_type: MCPAuthenticationType | None = None
+    auth_template: MCPAuthTemplate | None = None
+    user_email: str = ""
+
+    def _config_data(self) -> MCPConnectionData:
+        return extract_connection_data(self.connection_config, apply_mask=False)
+
+    def _template_substitutions(self) -> dict[str, str]:
+        data = self._config_data()
+        substitutions = dict(data.get("header_substitutions", {}))
+        if api_token := data.get("api_token"):
+            substitutions["api_key"] = api_token
+        return substitutions
+
+    def _configured_headers(self) -> dict[str, str]:
+        data = self._config_data()
+        template_headers: dict[str, str] = {}
+        if self.auth_template is not None and self._has_required_substitutions():
+            template_headers = self.auth_template.render(
+                self._template_substitutions(), user_email=self.user_email
+            )
+        return merge_mcp_headers(data.get("headers", {}), template_headers)
+
+    def _generated_auth_headers(self) -> dict[str, str]:
+        if self.user_oauth_token:
+            return {"Authorization": f"Bearer {self.user_oauth_token}"}
+        if self.auth_type != MCPAuthenticationType.OAUTH:
+            return {}
+        tokens = self._config_data().get(MCPOAuthKeys.TOKENS.value)
+        if not tokens:
+            return {}
+        token_type = tokens.get("token_type")
+        access_token = tokens.get("access_token")
+        if not token_type or not access_token:
+            return {}
+        return {"Authorization": f"{token_type} {access_token}"}
+
+    def _has_required_substitutions(self) -> bool:
+        if self.auth_template is None or not self.auth_template.required_fields:
+            return True
+        substitutions = self._template_substitutions()
+        return all(
+            substitutions.get(field) for field in self.auth_template.required_fields
+        )
+
+    def build_headers(self) -> dict[str, str]:
+        """Build configured headers with generated authentication taking precedence."""
+        stored = merge_mcp_headers(
+            self._configured_headers(), self._generated_auth_headers()
+        )
+        headers = {
+            k: v for k, v in stored.items() if k.lower() not in DENYLISTED_MCP_HEADERS
+        }
+        if len(headers) != len(stored):
+            # Names only — header values are credentials.
+            logger.warning(
+                "Stored MCP credential headers contained denylisted headers "
+                "that were stripped: %s",
+                sorted(k for k in stored if k.lower() in DENYLISTED_MCP_HEADERS),
+            )
+        return headers
+
+    def needs_reauth(self) -> bool:
+        """The stored OAuth grant is dead (expired, no refresh token); only a
+        user reconnect can restore it. Its bearer header still takes precedence
+        in ``build_headers``, so no caller-supplied header can work around it."""
+        return self.auth_type == MCPAuthenticationType.OAUTH and (
+            mcp_oauth_reauth_required(self._config_data())
+        )
+
+    def can_authenticate(self) -> bool:
+        """Whether these credentials can authenticate a call now (lazy refresh
+        of an expired-but-refreshable OAuth token still allowed downstream)."""
+        if self.auth_type in (None, MCPAuthenticationType.NONE):
+            return self._has_required_substitutions()
+        if self.auth_type == MCPAuthenticationType.PT_OAUTH:
+            return bool(self.user_oauth_token) and self._has_required_substitutions()
+        if self.auth_type == MCPAuthenticationType.OAUTH:
+            # A dead grant must read as unauthenticated so the UI prompts a
+            # reconnect and Craft configs exclude the server.
+            return (
+                bool(self._generated_auth_headers())
+                and not self.needs_reauth()
+                and self._has_required_substitutions()
+            )
+        return bool(self._configured_headers()) and self._has_required_substitutions()
+
+
+def resolve_mcp_credentials(
+    mcp_server: MCPServer,
+    user: User,
+    db_session: Session,
+    *,
+    user_configs: Mapping[int, MCPConnectionConfig] | None = None,
+) -> ResolvedMCPCredentials:
+    """Combine the admin template, user substitutions, and generated auth.
+
+    `user_configs` may preload every requested server's user row; a missing key
+    means no stored user values.
+    """
+    auth_template = get_mcp_auth_template(mcp_server)
+    user_connection_config = (
+        user_configs.get(mcp_server.id)
+        if user_configs is not None
+        else get_user_connection_config(mcp_server.id, user.email, db_session)
+    )
+
+    if mcp_server.auth_type == MCPAuthenticationType.PT_OAUTH:
+        if user.is_anonymous:
+            raise MCPCredentialsError(
+                f"Anonymous user cannot use PT_OAUTH MCP server {mcp_server.id}"
+            )
+        return ResolvedMCPCredentials(
+            connection_config=user_connection_config,
+            user_oauth_token=(
+                user.oauth_accounts[0].access_token if user.oauth_accounts else None
+            ),
+            auth_type=mcp_server.auth_type,
+            auth_template=auth_template,
+            user_email=user.email,
+        )
+
+    if mcp_server.auth_type in (
+        MCPAuthenticationType.API_TOKEN,
+        MCPAuthenticationType.OAUTH,
+    ):
+        if mcp_server.auth_performer == MCPAuthenticationPerformer.PER_USER:
+            connection_config = user_connection_config
+        else:
+            connection_config = mcp_server.admin_connection_config
+        return ResolvedMCPCredentials(
+            connection_config=connection_config,
+            user_oauth_token=None,
+            auth_type=mcp_server.auth_type,
+            auth_template=auth_template,
+            user_email=user.email,
+        )
+
+    return ResolvedMCPCredentials(
+        connection_config=user_connection_config,
+        user_oauth_token=None,
+        auth_type=mcp_server.auth_type,
+        auth_template=auth_template,
+        user_email=user.email,
+    )
+
+
+def user_can_authenticate(
+    mcp_server: MCPServer,
+    user: User,
+    db_session: Session,
+    *,
+    user_configs: Mapping[int, MCPConnectionConfig] | None = None,
+) -> bool:
+    """Resolve the user's credentials and report whether they authenticate:
+    every generated credential and template value is available."""
+    try:
+        credentials = resolve_mcp_credentials(
+            mcp_server, user, db_session, user_configs=user_configs
+        )
+    except MCPCredentialsError:
+        return False
+    return credentials.can_authenticate()

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -1,6 +1,5 @@
 import datetime
 import re
-import time
 from enum import Enum
 from typing import Any, List, Literal, NotRequired, Optional, TypedDict
 from uuid import UUID
@@ -120,22 +119,6 @@ class MCPConnectionData(TypedDict):
 
     # the actual models are defined in mcp.shared.auth
     # from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
-
-
-def mcp_token_expired(config_data: MCPConnectionData) -> bool:
-    """True iff the stored access token is past its persisted expiry."""
-    expires_at = config_data.get(MCPOAuthKeys.TOKEN_EXPIRES_AT.value)
-    return expires_at is not None and float(expires_at) <= time.time()
-
-
-def mcp_oauth_reauth_required(config_data: MCPConnectionData) -> bool:
-    """True when the stored OAuth grant can never authenticate again on its
-    own: the access token is expired and there is no refresh token to redeem.
-    Such a config must not count as authenticated — the user has to reconnect."""
-    if not mcp_token_expired(config_data):
-        return False
-    tokens = config_data.get(MCPOAuthKeys.TOKENS.value) or {}
-    return not tokens.get("refresh_token")
 
 
 class MCPAuthTemplate(BaseModel):

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+import time
 from enum import Enum
 from typing import Any, List, Literal, NotRequired, Optional, TypedDict
 from uuid import UUID
@@ -119,6 +120,22 @@ class MCPConnectionData(TypedDict):
 
     # the actual models are defined in mcp.shared.auth
     # from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
+
+
+def mcp_token_expired(config_data: MCPConnectionData) -> bool:
+    """True iff the stored access token is past its persisted expiry."""
+    expires_at = config_data.get(MCPOAuthKeys.TOKEN_EXPIRES_AT.value)
+    return expires_at is not None and float(expires_at) <= time.time()
+
+
+def mcp_oauth_reauth_required(config_data: MCPConnectionData) -> bool:
+    """True when the stored OAuth grant can never authenticate again on its
+    own: the access token is expired and there is no refresh token to redeem.
+    Such a config must not count as authenticated — the user has to reconnect."""
+    if not mcp_token_expired(config_data):
+        return False
+    tokens = config_data.get(MCPOAuthKeys.TOKENS.value) or {}
+    return not tokens.get("refresh_token")
 
 
 class MCPAuthTemplate(BaseModel):

--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -37,7 +37,6 @@ from onyx.cache.locks import cache_shared_lock
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import MCPOAuthProviderMode, MCPTransport
 from onyx.db.mcp import (
-    extract_connection_data,
     get_connection_config_by_id,
     update_connection_config,
 )
@@ -50,10 +49,13 @@ from onyx.server.features.mcp.client_metadata import (
     mcp_oauth_redirect_uri,
     validated_mcp_oauth_client_metadata_url,
 )
+from onyx.server.features.mcp.credentials import (
+    extract_connection_data,
+    mcp_token_expired,
+)
 from onyx.server.features.mcp.models import (
     DENYLISTED_MCP_HEADERS,
     MCPOAuthKeys,
-    mcp_token_expired,
     merge_mcp_headers,
 )
 from onyx.server.features.mcp.ssrf import (
@@ -230,7 +232,7 @@ async def connect_auto_discovery_oauth(
     admin_config_id: int | None,
     connection_headers: dict[str, str],
     transport: MCPTransport,
-    is_authenticated: bool,
+    credentials_usable: bool,
     force_reauthentication: bool = False,
 ) -> str | None:
     redirect_future = asyncio.get_running_loop().create_future()
@@ -249,7 +251,7 @@ async def connect_auto_discovery_oauth(
         load_stored_tokens=not force_reauthentication,
     )
 
-    use_authenticated_connection = is_authenticated and not force_reauthentication
+    use_authenticated_connection = credentials_usable and not force_reauthentication
     oauth_connection_headers = (
         {
             key: value

--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -575,8 +575,12 @@ class OnyxTokenStorage(TokenStorage):
     def bind_oauth_context(self, context: OAuthContext) -> None:
         self._oauth_context = context
 
-    def _ensure_connection_config(self, db_session: Session) -> MCPConnectionConfig:
-        config = get_connection_config_by_id(self.connection_config_id, db_session)
+    def _ensure_connection_config(
+        self, db_session: Session, *, for_update: bool = False
+    ) -> MCPConnectionConfig:
+        config = get_connection_config_by_id(
+            self.connection_config_id, db_session, for_update=for_update
+        )
         if config is None:
             raise OnyxError(OnyxErrorCode.NOT_FOUND, "Connection config not found")
         return config
@@ -688,7 +692,9 @@ class OnyxTokenStorage(TokenStorage):
         replaced the grant, and the replacement must survive. Returns whether
         the grant was discarded."""
         with get_session_with_current_tenant() as db_session:
-            config = self._ensure_connection_config(db_session)
+            # Row lock: a concurrent set_tokens commit between an unlocked read
+            # and the update below would be clobbered by this stale read.
+            config = self._ensure_connection_config(db_session, for_update=True)
             config_data = extract_connection_data(config)
             stored_tokens = config_data.get(MCPOAuthKeys.TOKENS.value) or {}
             if (

--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -677,12 +677,25 @@ class OnyxTokenStorage(TokenStorage):
             r.rpush(key_tokens(str(self.alt_config_id)), tokens.model_dump_json())
             r.expire(key_tokens(str(self.alt_config_id)), OAUTH_WAIT_SECONDS)
 
-    async def discard_persisted_tokens(self) -> None:
+    async def discard_persisted_tokens(
+        self, redeemed_refresh_token: str | None
+    ) -> bool:
         """Drop the persisted grant (tokens, expiry, Authorization header) so
-        the connection reads as unauthenticated until the user reconnects."""
+        the connection reads as unauthenticated until the user reconnects.
+
+        No-ops when the stored refresh token no longer matches
+        ``redeemed_refresh_token``: a concurrent refresh or reconnect already
+        replaced the grant, and the replacement must survive. Returns whether
+        the grant was discarded."""
         with get_session_with_current_tenant() as db_session:
             config = self._ensure_connection_config(db_session)
             config_data = extract_connection_data(config)
+            stored_tokens = config_data.get(MCPOAuthKeys.TOKENS.value) or {}
+            if (
+                redeemed_refresh_token is None
+                or stored_tokens.get("refresh_token") != redeemed_refresh_token
+            ):
+                return False
             config_data.pop(MCPOAuthKeys.TOKENS.value, None)
             config_data.pop(MCPOAuthKeys.TOKEN_EXPIRES_AT.value, None)
             config_data["headers"] = {
@@ -691,6 +704,7 @@ class OnyxTokenStorage(TokenStorage):
                 if key.lower() != "authorization"
             }
             update_connection_config(config.id, db_session, config_data)
+            return True
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
         with get_session_with_current_tenant() as db_session:
@@ -768,6 +782,9 @@ class OnyxOAuthClientProvider(OAuthClientProvider):
         self.refresh_log_context = refresh_log_context
         self.refresh_attempt_id: str | None = None
         self.token_expiry_before_refresh: float | None = None
+        # The refresh token the in-flight refresh attempt redeemed; guards the
+        # invalid_grant discard against wiping a concurrently stored grant.
+        self.redeemed_refresh_token: str | None = None
 
     def _refresh_log_fields(self, **fields: Any) -> dict[str, Any]:
         log_fields: dict[str, Any] = {
@@ -781,6 +798,10 @@ class OnyxOAuthClientProvider(OAuthClientProvider):
     async def _refresh_token(self) -> httpx.Request:
         self.refresh_attempt_id = uuid4().hex
         self.token_expiry_before_refresh = self.context.token_expiry_time
+        current_tokens = self.context.current_tokens
+        self.redeemed_refresh_token = (
+            current_tokens.refresh_token if current_tokens else None
+        )
 
         request = await super()._refresh_token()
         logger.info(
@@ -835,8 +856,12 @@ class OnyxOAuthClientProvider(OAuthClientProvider):
             # reads as unauthenticated instead of retrying forever.
             storage = self.context.storage
             if oauth_error == "invalid_grant" and isinstance(storage, OnyxTokenStorage):
-                await storage.discard_persisted_tokens()
-                logger.warning("mcp_oauth.tokens_discarded", extra=response_fields)
+                if await storage.discard_persisted_tokens(self.redeemed_refresh_token):
+                    logger.warning("mcp_oauth.tokens_discarded", extra=response_fields)
+                else:
+                    logger.info(
+                        "mcp_oauth.tokens_discard_skipped_stale", extra=response_fields
+                    )
             return False
 
         try:

--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -31,6 +31,7 @@ from mcp.shared.auth import (
 from pydantic import AnyUrl, BaseModel, ValidationError
 from sqlalchemy.orm import Session
 
+from onyx.auth.oauth_token_manager import ensure_offline_access_auth_params
 from onyx.cache.interface import CacheLockAcquisitionError
 from onyx.cache.locks import cache_shared_lock
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -51,8 +52,8 @@ from onyx.server.features.mcp.client_metadata import (
 )
 from onyx.server.features.mcp.models import (
     DENYLISTED_MCP_HEADERS,
-    MCPConnectionData,
     MCPOAuthKeys,
+    mcp_token_expired,
     merge_mcp_headers,
 )
 from onyx.server.features.mcp.ssrf import (
@@ -519,12 +520,6 @@ def refresh_mcp_oauth_token_if_expired(
         return _persisted_auth_header(connection_config_id)
 
 
-def mcp_token_expired(config_data: MCPConnectionData) -> bool:
-    """True iff the stored access token is past its persisted expiry."""
-    expires_at = config_data.get(MCPOAuthKeys.TOKEN_EXPIRES_AT.value)
-    return expires_at is not None and float(expires_at) <= time.time()
-
-
 def _persisted_auth_header(connection_config_id: int) -> str | None:
     """The stored ``Authorization`` header when the persisted token is still
     fresh, else None — used as the fallback when a concurrent refresh wins."""
@@ -682,6 +677,21 @@ class OnyxTokenStorage(TokenStorage):
             r.rpush(key_tokens(str(self.alt_config_id)), tokens.model_dump_json())
             r.expire(key_tokens(str(self.alt_config_id)), OAUTH_WAIT_SECONDS)
 
+    async def discard_persisted_tokens(self) -> None:
+        """Drop the persisted grant (tokens, expiry, Authorization header) so
+        the connection reads as unauthenticated until the user reconnects."""
+        with get_session_with_current_tenant() as db_session:
+            config = self._ensure_connection_config(db_session)
+            config_data = extract_connection_data(config)
+            config_data.pop(MCPOAuthKeys.TOKENS.value, None)
+            config_data.pop(MCPOAuthKeys.TOKEN_EXPIRES_AT.value, None)
+            config_data["headers"] = {
+                key: value
+                for key, value in config_data.get("headers", {}).items()
+                if key.lower() != "authorization"
+            }
+            update_connection_config(config.id, db_session, config_data)
+
     async def get_client_info(self) -> OAuthClientInformationFull | None:
         with get_session_with_current_tenant() as db_session:
             config = self._ensure_connection_config(db_session)
@@ -820,6 +830,13 @@ class OnyxOAuthClientProvider(OAuthClientProvider):
         if response.status_code != 200:
             logger.warning("mcp_oauth.refresh.failed", extra=response_fields)
             self.context.clear_tokens()
+            # invalid_grant means the refresh token itself is expired or
+            # revoked (RFC 6749) — discard the dead grant so the connection
+            # reads as unauthenticated instead of retrying forever.
+            storage = self.context.storage
+            if oauth_error == "invalid_grant" and isinstance(storage, OnyxTokenStorage):
+                await storage.discard_persisted_tokens()
+                logger.warning("mcp_oauth.tokens_discarded", extra=response_fields)
             return False
 
         try:
@@ -857,6 +874,9 @@ def make_oauth_provider(
     async def redirect_handler(auth_url: str) -> None:
         if return_path == UNUSED_RETURN_PATH:
             raise ValueError("Please Reconnect to the server")
+        # The SDK exposes no hook for provider-specific authorize params; add
+        # them here, where every auto-discovery consent URL passes through.
+        auth_url = ensure_offline_access_auth_params(auth_url)
         r = get_redis_client()
         # The SDK generated & embedded 'state' in the auth_url; extract & store it.
         parsed = urlparse(auth_url)

--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -13,10 +13,8 @@ from onyx.configs.model_configs import GEN_AI_TEMPERATURE
 from onyx.context.search.models import BaseFilters, PersonaSearchInfo
 from onyx.db.engine.sql_engine import get_session_with_current_tenant_if_none
 from onyx.db.mcp import (
-    MCPCredentialsError,
     get_all_mcp_tools_for_server,
     get_mcp_server_by_id,
-    resolve_mcp_credentials,
 )
 from onyx.db.models import Persona, User
 from onyx.db.models import Tool as ToolDBModel
@@ -27,6 +25,10 @@ from onyx.document_index.factory import get_default_document_index
 from onyx.image_gen.interfaces import ImageGenerationProviderCredentials
 from onyx.llm.interfaces import LLM, LLMConfig
 from onyx.onyxbot.slack.models import SlackContext
+from onyx.server.features.mcp.credentials import (
+    MCPCredentialsError,
+    resolve_mcp_credentials,
+)
 from onyx.tools.built_in_tools import get_built_in_tool_by_id
 from onyx.tools.interface import Tool
 from onyx.tools.models import DynamicSchemaInfo, SearchToolUsage

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -6,9 +6,9 @@ from mcp.client.auth import OAuthClientProvider
 
 from onyx.chat.emitter import Emitter
 from onyx.db.enums import MCPAuthenticationType, MCPTransport
-from onyx.db.mcp import ResolvedMCPCredentials
 from onyx.db.models import MCPConnectionConfig, MCPServer
 from onyx.server.features.mcp.client import call_mcp_tool
+from onyx.server.features.mcp.credentials import ResolvedMCPCredentials
 from onyx.server.features.mcp.models import (
     DENYLISTED_MCP_HEADERS,
     merge_mcp_headers,
@@ -179,7 +179,7 @@ class MCPTool(Tool[None]):
             # Extra request headers can stand in for missing credentials, but
             # not for a dead OAuth grant — its stale bearer wins the header
             # merge, so the call can only fail upstream.
-            if not credentials.is_authenticated() and (
+            if not credentials.can_authenticate() and (
                 credentials.needs_reauth() or not self._additional_headers
             ):
                 auth_error_msg = (

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -176,7 +176,12 @@ class MCPTool(Tool[None]):
                 credentials.build_headers(),
             )
 
-            if not credentials.is_authenticated() and not self._additional_headers:
+            # Extra request headers can stand in for missing credentials, but
+            # not for a dead OAuth grant — its stale bearer wins the header
+            # merge, so the call can only fail upstream.
+            if not credentials.is_authenticated() and (
+                credentials.needs_reauth() or not self._additional_headers
+            ):
                 auth_error_msg = (
                     f"The {self._name} tool from {self.mcp_server.name} requires "
                     "connection values. Tell the user to connect to the server "

--- a/backend/tests/external_dependency_unit/mcp/test_mcp_oauth_dead_grant.py
+++ b/backend/tests/external_dependency_unit/mcp/test_mcp_oauth_dead_grant.py
@@ -1,5 +1,5 @@
 """OAuth MCP grants that can never refresh must read as unauthenticated (ext-dep):
-`is_authenticated` semantics, Craft config exclusion, and the persisted token
+`user_can_authenticate` semantics, Craft config exclusion, and the persisted token
 discard on an `invalid_grant` refresh response, against a real DB."""
 
 from __future__ import annotations
@@ -18,9 +18,7 @@ from onyx.db.enums import (
     MCPTransport,
 )
 from onyx.db.mcp import (
-    can_resolve_mcp_credentials,
     create_mcp_server__no_commit,
-    extract_connection_data,
     get_user_connection_config,
     update_mcp_server__no_commit,
     upsert_user_connection_config,
@@ -28,6 +26,10 @@ from onyx.db.mcp import (
 from onyx.db.models import MCPServer, User
 from onyx.server.features.build.sandbox.util.mcp_config import (
     resolve_craft_mcp_servers,
+)
+from onyx.server.features.mcp.credentials import (
+    extract_connection_data,
+    user_can_authenticate,
 )
 from onyx.server.features.mcp.models import MCPConnectionData
 from onyx.server.features.mcp.oauth import (
@@ -94,7 +96,7 @@ def test_expired_token_with_refresh_token_is_authenticated(
         expires_at=time.time() - 60,
         refresh_token="refresh-token",
     )
-    assert can_resolve_mcp_credentials(server, user, db_session)
+    assert user_can_authenticate(server, user, db_session)
 
 
 def test_dead_grant_is_not_authenticated_and_excluded_from_craft(
@@ -112,13 +114,13 @@ def test_dead_grant_is_not_authenticated_and_excluded_from_craft(
     _store_grant(
         db_session, server, user, expires_at=time.time() + 3600, refresh_token=None
     )
-    assert can_resolve_mcp_credentials(server, user, db_session)
+    assert user_can_authenticate(server, user, db_session)
     assert server.id in craft_server_ids()
 
     _store_grant(
         db_session, server, user, expires_at=time.time() - 60, refresh_token=None
     )
-    assert not can_resolve_mcp_credentials(server, user, db_session)
+    assert not user_can_authenticate(server, user, db_session)
     assert server.id not in craft_server_ids()
 
 
@@ -167,4 +169,4 @@ def test_invalid_grant_refresh_discards_persisted_tokens(
     assert "tokens" not in config_value
     assert "token_expires_at" not in config_value
     assert "Authorization" not in config_value.get("headers", {})
-    assert not can_resolve_mcp_credentials(server, user, db_session)
+    assert not user_can_authenticate(server, user, db_session)

--- a/backend/tests/external_dependency_unit/mcp/test_mcp_oauth_dead_grant.py
+++ b/backend/tests/external_dependency_unit/mcp/test_mcp_oauth_dead_grant.py
@@ -1,0 +1,156 @@
+"""OAuth MCP grants that can never refresh must read as unauthenticated (ext-dep):
+`is_authenticated` semantics, Craft config exclusion, and the persisted token
+discard on an `invalid_grant` refresh response, against a real DB."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+from uuid import uuid4
+
+import httpx
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import (
+    MCPAuthenticationPerformer,
+    MCPAuthenticationType,
+    MCPTransport,
+)
+from onyx.db.mcp import (
+    can_resolve_mcp_credentials,
+    create_mcp_server__no_commit,
+    extract_connection_data,
+    get_user_connection_config,
+    update_mcp_server__no_commit,
+    upsert_user_connection_config,
+)
+from onyx.db.models import MCPServer, User
+from onyx.server.features.build.sandbox.util.mcp_config import (
+    resolve_craft_mcp_servers,
+)
+from onyx.server.features.mcp.models import MCPConnectionData
+from onyx.server.features.mcp.oauth import (
+    UNUSED_RETURN_PATH,
+    make_oauth_provider,
+)
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+def _make_oauth_server(db_session: Session, *, owner_email: str) -> MCPServer:
+    server = create_mcp_server__no_commit(
+        owner_email=owner_email,
+        name=f"oauth-{uuid4().hex[:8]}",
+        description=None,
+        server_url=f"https://mcp-{uuid4().hex[:8]}.example.com/mcp",
+        auth_type=MCPAuthenticationType.OAUTH,
+        transport=MCPTransport.STREAMABLE_HTTP,
+        auth_performer=MCPAuthenticationPerformer.PER_USER,
+        db_session=db_session,
+        is_public=True,
+    )
+    update_mcp_server__no_commit(
+        server_id=server.id, db_session=db_session, available_in_craft=True
+    )
+    db_session.commit()
+    return server
+
+
+def _store_grant(
+    db_session: Session,
+    server: MCPServer,
+    user: User,
+    *,
+    expires_at: float,
+    refresh_token: str | None,
+) -> int:
+    tokens: dict[str, Any] = {
+        "access_token": "access-token",
+        "token_type": "Bearer",
+        "refresh_token": refresh_token,
+    }
+    config_data: MCPConnectionData = {
+        "headers": {"Authorization": "Bearer access-token"},
+        "tokens": tokens,
+        "token_expires_at": expires_at,
+    }
+    config = upsert_user_connection_config(
+        server.id, user.email, config_data, db_session
+    )
+    db_session.commit()
+    return config.id
+
+
+def test_expired_token_with_refresh_token_is_authenticated(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = create_test_user(db_session, "oauth_refreshable")
+    server = _make_oauth_server(db_session, owner_email=user.email)
+    _store_grant(
+        db_session,
+        server,
+        user,
+        expires_at=time.time() - 60,
+        refresh_token="refresh-token",
+    )
+    assert can_resolve_mcp_credentials(server, user, db_session)
+
+
+def test_dead_grant_is_not_authenticated_and_excluded_from_craft(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = create_test_user(db_session, "oauth_dead")
+    server = _make_oauth_server(db_session, owner_email=user.email)
+
+    def craft_server_ids() -> list[int]:
+        return [r.server_id for r in resolve_craft_mcp_servers(db_session, user)]
+
+    # Positive control: a live grant authenticates and reaches Craft configs,
+    # so the exclusion below can't pass vacuously.
+    _store_grant(
+        db_session, server, user, expires_at=time.time() + 3600, refresh_token=None
+    )
+    assert can_resolve_mcp_credentials(server, user, db_session)
+    assert server.id in craft_server_ids()
+
+    _store_grant(
+        db_session, server, user, expires_at=time.time() - 60, refresh_token=None
+    )
+    assert not can_resolve_mcp_credentials(server, user, db_session)
+    assert server.id not in craft_server_ids()
+
+
+def test_invalid_grant_refresh_discards_persisted_tokens(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = create_test_user(db_session, "oauth_revoked")
+    server = _make_oauth_server(db_session, owner_email=user.email)
+    config_id = _store_grant(
+        db_session,
+        server,
+        user,
+        expires_at=time.time() - 60,
+        refresh_token="revoked-refresh-token",
+    )
+
+    provider = make_oauth_provider(
+        server, str(user.id), UNUSED_RETURN_PATH, config_id, None
+    )
+    response = httpx.Response(
+        status_code=400,
+        json={"error": "invalid_grant"},
+        request=httpx.Request("POST", "https://oauth2.example.com/token"),
+    )
+    assert asyncio.run(provider._handle_refresh_response(response)) is False
+
+    db_session.expire_all()
+    config = get_user_connection_config(server.id, user.email, db_session)
+    assert config is not None
+    config_value = extract_connection_data(config, apply_mask=False)
+    assert "tokens" not in config_value
+    assert "token_expires_at" not in config_value
+    assert "Authorization" not in config_value.get("headers", {})
+    assert not can_resolve_mcp_credentials(server, user, db_session)

--- a/backend/tests/external_dependency_unit/mcp/test_mcp_oauth_dead_grant.py
+++ b/backend/tests/external_dependency_unit/mcp/test_mcp_oauth_dead_grant.py
@@ -122,6 +122,14 @@ def test_dead_grant_is_not_authenticated_and_excluded_from_craft(
     assert server.id not in craft_server_ids()
 
 
+def _invalid_grant_response() -> httpx.Response:
+    return httpx.Response(
+        status_code=400,
+        json={"error": "invalid_grant"},
+        request=httpx.Request("POST", "https://oauth2.example.com/token"),
+    )
+
+
 def test_invalid_grant_refresh_discards_persisted_tokens(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
@@ -139,13 +147,19 @@ def test_invalid_grant_refresh_discards_persisted_tokens(
     provider = make_oauth_provider(
         server, str(user.id), UNUSED_RETURN_PATH, config_id, None
     )
-    response = httpx.Response(
-        status_code=400,
-        json={"error": "invalid_grant"},
-        request=httpx.Request("POST", "https://oauth2.example.com/token"),
-    )
-    assert asyncio.run(provider._handle_refresh_response(response)) is False
 
+    # A stale attempt (its refresh token was already rotated away by a
+    # concurrent refresh or reconnect) must not wipe the stored grant.
+    provider.redeemed_refresh_token = "rotated-away-refresh-token"
+    assert not asyncio.run(provider._handle_refresh_response(_invalid_grant_response()))
+    db_session.expire_all()
+    config = get_user_connection_config(server.id, user.email, db_session)
+    assert config is not None
+    assert "tokens" in extract_connection_data(config, apply_mask=False)
+
+    # The attempt that redeemed the stored refresh token discards the grant.
+    provider.redeemed_refresh_token = "revoked-refresh-token"
+    assert not asyncio.run(provider._handle_refresh_response(_invalid_grant_response()))
     db_session.expire_all()
     config = get_user_connection_config(server.id, user.email, db_session)
     assert config is not None

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_mcp_server_resolver.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_mcp_server_resolver.py
@@ -33,7 +33,6 @@ from onyx.db.enums import (
 from onyx.db.mcp import (
     create_connection_config,
     create_mcp_server__no_commit,
-    extract_connection_data,
     get_connection_config_by_id,
     update_mcp_server__no_commit,
 )
@@ -49,6 +48,7 @@ from onyx.sandbox_proxy.credential_injection import (
 )
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.resolvers.mcp_server import MCPServerResolver
+from onyx.server.features.mcp.credentials import extract_connection_data
 from onyx.server.features.mcp.models import MCPConnectionData, MCPOAuthKeys
 from shared_configs.contextvars import POSTGRES_DEFAULT_SCHEMA
 from tests.external_dependency_unit.conftest import create_test_user

--- a/backend/tests/external_dependency_unit/server/features/mcp/test_per_user_api_token_credentials.py
+++ b/backend/tests/external_dependency_unit/server/features/mcp/test_per_user_api_token_credentials.py
@@ -17,13 +17,14 @@ from onyx.db.enums import (
     MCPAuthenticationType,
     MCPTransport,
 )
-from onyx.db.mcp import extract_connection_data, get_user_connection_config
+from onyx.db.mcp import get_user_connection_config
 from onyx.db.models import User
 from onyx.server.features.mcp.api import (
     HEADER_SUBSTITUTIONS,
     _upsert_mcp_server,
     save_user_credentials,
 )
+from onyx.server.features.mcp.credentials import extract_connection_data
 from onyx.server.features.mcp.models import (
     MCPAuthTemplate,
     MCPToolCreateRequest,

--- a/backend/tests/external_dependency_unit/server/features/mcp/test_shared_api_token_template_visibility.py
+++ b/backend/tests/external_dependency_unit/server/features/mcp/test_shared_api_token_template_visibility.py
@@ -17,7 +17,6 @@ from onyx.db.enums import (
 )
 from onyx.db.mcp import (
     create_connection_config,
-    get_mcp_auth_template,
     get_mcp_server_by_id,
     get_user_connection_config,
 )
@@ -25,6 +24,7 @@ from onyx.server.features.mcp.api import (
     _db_mcp_server_to_api_mcp_server,
     _upsert_mcp_server,
 )
+from onyx.server.features.mcp.credentials import get_mcp_auth_template
 from onyx.server.features.mcp.models import (
     MCPAuthTemplate,
     MCPConnectionData,

--- a/backend/tests/unit/onyx/auth/test_offline_access_auth_params.py
+++ b/backend/tests/unit/onyx/auth/test_offline_access_auth_params.py
@@ -1,0 +1,104 @@
+"""Providers like Google issue refresh tokens only when the authorize request
+asks for offline access; these params must be injected into every flow."""
+
+from urllib.parse import parse_qs, urlparse
+
+from onyx.auth.oauth_token_manager import (
+    OAuthFlowParams,
+    build_oauth_authorization_url,
+    ensure_offline_access_auth_params,
+)
+
+_GOOGLE_AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
+
+
+def _query(url: str) -> dict[str, list[str]]:
+    return parse_qs(urlparse(url).query)
+
+
+def test_google_prebuilt_url_gains_offline_access_params() -> None:
+    url = ensure_offline_access_auth_params(
+        f"{_GOOGLE_AUTH_ENDPOINT}?client_id=x&state=s&code_challenge=c"
+    )
+    query = _query(url)
+    assert query["access_type"] == ["offline"]
+    assert query["prompt"] == ["consent"]
+    # Existing params survive the rewrite.
+    assert query["client_id"] == ["x"]
+    assert query["state"] == ["s"]
+    assert query["code_challenge"] == ["c"]
+
+
+def test_prebuilt_url_existing_params_win() -> None:
+    url = ensure_offline_access_auth_params(
+        f"{_GOOGLE_AUTH_ENDPOINT}?client_id=x&prompt=none"
+    )
+    query = _query(url)
+    assert query["prompt"] == ["none"]
+    assert query["access_type"] == ["offline"]
+
+
+def test_non_google_prebuilt_url_unchanged() -> None:
+    url = "https://example.com/authorize?client_id=x"
+    assert ensure_offline_access_auth_params(url) == url
+
+
+def test_build_authorization_url_adds_google_offline_access() -> None:
+    url = build_oauth_authorization_url(
+        OAuthFlowParams(
+            authorization_url=_GOOGLE_AUTH_ENDPOINT,
+            token_url="https://oauth2.googleapis.com/token",
+            client_id="x",
+        ),
+        redirect_uri="https://app.example.com/callback",
+        state="s",
+    )
+    query = _query(url)
+    assert query["access_type"] == ["offline"]
+    assert query["prompt"] == ["consent"]
+
+
+def test_build_authorization_url_additional_params_override_defaults() -> None:
+    url = build_oauth_authorization_url(
+        OAuthFlowParams(
+            authorization_url=_GOOGLE_AUTH_ENDPOINT,
+            token_url="https://oauth2.googleapis.com/token",
+            client_id="x",
+            additional_params={"prompt": "select_account"},
+        ),
+        redirect_uri="https://app.example.com/callback",
+        state="s",
+    )
+    query = _query(url)
+    assert query["prompt"] == ["select_account"]
+    assert query["access_type"] == ["offline"]
+
+
+def test_build_authorization_url_endpoint_embedded_params_win() -> None:
+    url = build_oauth_authorization_url(
+        OAuthFlowParams(
+            authorization_url=f"{_GOOGLE_AUTH_ENDPOINT}?prompt=select_account",
+            token_url="https://oauth2.googleapis.com/token",
+            client_id="x",
+        ),
+        redirect_uri="https://app.example.com/callback",
+        state="s",
+    )
+    query = _query(url)
+    assert query["prompt"] == ["select_account"]
+    assert query["access_type"] == ["offline"]
+
+
+def test_build_authorization_url_non_google_untouched() -> None:
+    url = build_oauth_authorization_url(
+        OAuthFlowParams(
+            authorization_url="https://example.com/authorize",
+            token_url="https://example.com/token",
+            client_id="x",
+        ),
+        redirect_uri="https://app.example.com/callback",
+        state="s",
+    )
+    query = _query(url)
+    assert "access_type" not in query
+    assert "prompt" not in query

--- a/backend/tests/unit/onyx/server/features/mcp/test_build_headers.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_build_headers.py
@@ -5,8 +5,8 @@ import json
 import pytest
 
 from onyx.db.enums import MCPAuthenticationType
-from onyx.db.mcp import ResolvedMCPCredentials
 from onyx.db.models import MCPConnectionConfig
+from onyx.server.features.mcp.credentials import ResolvedMCPCredentials
 from onyx.server.features.mcp.models import MCPAuthTemplate
 from onyx.utils.sensitive import SensitiveValue
 
@@ -75,7 +75,7 @@ def test_pt_oauth_merges_template_headers_and_overrides_authorization() -> None:
         "X-User": "alice@example.com",
         "Authorization": "Bearer login-token",
     }
-    assert creds.is_authenticated()
+    assert creds.can_authenticate()
 
 
 def test_oauth_merges_template_headers_with_token_auth() -> None:
@@ -98,7 +98,7 @@ def test_oauth_merges_template_headers_with_token_auth() -> None:
         "X-Gateway-Key": "gateway-secret",
         "Authorization": "Bearer oauth-token",
     }
-    assert creds.is_authenticated()
+    assert creds.can_authenticate()
 
 
 def test_no_auth_template_requires_user_substitutions() -> None:
@@ -121,8 +121,8 @@ def test_no_auth_template_requires_user_substitutions() -> None:
         }
     )
 
-    assert not disconnected.is_authenticated()
-    assert connected.is_authenticated()
+    assert not disconnected.can_authenticate()
+    assert connected.can_authenticate()
     assert connected.build_headers() == {"X-Gateway-Key": "gateway-secret"}
 
 
@@ -135,7 +135,7 @@ def test_api_token_template_without_placeholders_needs_no_user_config() -> None:
         user_email="alice@example.com",
     )
 
-    assert creds.is_authenticated()
+    assert creds.can_authenticate()
     assert creds.build_headers() == {"X-Gateway-Key": "shared-key"}
 
 

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
@@ -142,7 +142,7 @@ def _setup_coordinator(
 def _connect(
     server: SimpleNamespace,
     *,
-    is_authenticated: bool = False,
+    credentials_usable: bool = False,
     connection_headers: dict[str, str] | None = None,
     force_reauthentication: bool = False,
 ) -> str | None:
@@ -155,7 +155,7 @@ def _connect(
             admin_config_id=100,
             connection_headers=connection_headers or {},
             transport=server.transport,
-            is_authenticated=is_authenticated,
+            credentials_usable=credentials_usable,
             force_reauthentication=force_reauthentication,
         )
     )
@@ -199,7 +199,7 @@ def test_forced_reauthentication_skips_authenticated_fast_path(
     assert (
         _connect(
             server,
-            is_authenticated=True,
+            credentials_usable=True,
             connection_headers={
                 "Authorization": "Bearer current-token",
                 "X-Gateway-Tenant": "tenant-1",
@@ -385,9 +385,7 @@ def _setup_api_connection(
         api, "extract_connection_data", lambda *_args, **_kwargs: stored_data
     )
     monkeypatch.setattr(api, "update_connection_config", update_connection_config)
-    monkeypatch.setattr(
-        api, "can_resolve_mcp_credentials", lambda *_args, **_kwargs: True
-    )
+    monkeypatch.setattr(api, "user_can_authenticate", lambda *_args, **_kwargs: True)
     return server, user, update_connection_config
 
 

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
@@ -99,7 +99,7 @@ def _install_mocks(
     monkeypatch.setattr(
         mcp_oauth,
         "get_connection_config_by_id",
-        lambda config_id, _db_session: SimpleNamespace(id=config_id),
+        lambda config_id, _db_session, **_kwargs: SimpleNamespace(id=config_id),
     )
     # extract_connection_data returns the same dict the SDK storage mutates.
     monkeypatch.setattr(

--- a/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
+++ b/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
@@ -275,7 +275,7 @@ def _patch_config_read(
     monkeypatch.setattr(
         mcp_oauth.OnyxTokenStorage,
         "_ensure_connection_config",
-        lambda _self, _db: SimpleNamespace(id=1),
+        lambda _self, _db, **_kwargs: SimpleNamespace(id=1),
     )
     monkeypatch.setattr(
         mcp_oauth, "extract_connection_data", lambda _config: config_data


### PR DESCRIPTION
## Description

Stacked on #13924. Several distinct credential/auth questions were answered under colliding names — `is_authenticated` alone meant four different things (usable-for-calls, skip-consent eligibility, "server needs no per-user auth", and wire fields) — spread across `db/mcp.py`, `models.py`, `oauth.py`, and inline compositions in `api.py`, the sandbox proxy, and the chat tool.

This centralizes all of it in a new `server/features/mcp/credentials.py` whose module docstring is the contract — one named question per function, with consumers noted:

- `ResolvedMCPCredentials.can_authenticate()` (was `is_authenticated()`) — usable for a call now, lazy refresh allowed
- `ResolvedMCPCredentials.needs_reauth()` — dead grant, only a user reconnect helps
- `mcp_token_expired` — access token past expiry, regardless of refreshability
- `mcp_oauth_reauth_required` — expired with no refresh token
- `requires_user_authentication` — server shape needs per-user credentials at all (was an anonymous inline boolean)
- `user_can_authenticate` (was `can_resolve_mcp_credentials`) — DB-backed entry point for status listings

Layering rule: queries stay in `db/mcp.py` (now pure CRUD, −210 lines), logic moves out. This also removes the inversion where `db/mcp.py` imported business types from `server/features/mcp/models.py`. The connect route's composition is renamed `credentials_usable` and now reads as an explicit rule. No back-compat re-exports — every caller updated. Behavior-neutral: no predicate's semantics changed. Wire field names are untouched here (see the next PR in the stack).

## How Has This Been Tested?

- Behavior-neutral refactor gated by the existing suites: 808 backend unit tests pass (mcp, sandbox_proxy, tools); `pre-commit` (ty, ruff) clean on all touched files.
- Existing external-dependency-unit MCP tests updated for the new names run in CI.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check