### PR TITLE
refactor(mcp): rename auth wire fields for clarity

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -1282,7 +1282,7 @@ def _db_mcp_server_to_api_mcp_server(
 
     # Check if user has authentication configured and extract credentials
     auth_performer = db_server.auth_performer
-    user_authenticated: bool | None = None
+    can_authenticate: bool | None = None
     user_credentials = None
     admin_credentials = None
     is_owner_or_admin = request_user is not None and (
@@ -1300,7 +1300,7 @@ def _db_mcp_server_to_api_mcp_server(
         else get_user_connection_config(db_server.id, email, db)
     )
     if request_user is not None:
-        user_authenticated = user_can_authenticate(
+        can_authenticate = user_can_authenticate(
             db_server,
             request_user,
             db,
@@ -1360,8 +1360,6 @@ def _db_mcp_server_to_api_mcp_server(
                 required_fields=stored_template.required_fields,
             )
 
-    is_authenticated = bool(user_authenticated)
-
     # Calculate tool count from the relationship
     tool_count = len(db_server.current_actions) if db_server.current_actions else 0
 
@@ -1379,8 +1377,7 @@ def _db_mcp_server_to_api_mcp_server(
         oauth_token_endpoint=db_server.oauth_token_endpoint,
         oauth_scopes_override=db_server.oauth_scopes_override,
         oauth_additional_auth_params=db_server.oauth_additional_auth_params,
-        is_authenticated=is_authenticated,
-        user_authenticated=user_authenticated,
+        user_can_authenticate=can_authenticate,
         craft_connected=craft_connected,
         status=db_server.status,
         is_public=db_server.is_public,
@@ -2394,7 +2391,7 @@ def upsert_mcp_server(
             oauth_token_endpoint=mcp_server.oauth_token_endpoint,
             oauth_scopes_override=mcp_server.oauth_scopes_override,
             oauth_additional_auth_params=mcp_server.oauth_additional_auth_params,
-            is_authenticated=not requires_user_authentication(
+            no_user_authentication_required=not requires_user_authentication(
                 mcp_server.auth_type, request.auth_performer
             ),
         )
@@ -2512,7 +2509,7 @@ def create_mcp_server_simple(
         oauth_token_endpoint=mcp_server.oauth_token_endpoint,
         oauth_scopes_override=mcp_server.oauth_scopes_override,
         oauth_additional_auth_params=mcp_server.oauth_additional_auth_params,
-        is_authenticated=False,  # Not authenticated yet
+        user_can_authenticate=False,  # No credentials resolved yet
         status=mcp_server.status,
         is_public=mcp_server.is_public,
         groups=[group.id for group in mcp_server.user_groups],

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -460,7 +460,7 @@ class MCPToolResponse(BaseModel):
     server_url: str
     auth_type: str
     auth_performer: Optional[str] = None
-    is_authenticated: bool
+    user_can_authenticate: bool
 
 
 class MCPOAuthConnectRequest(BaseModel):
@@ -615,8 +615,9 @@ class MCPServer(BaseModel):
     oauth_token_endpoint: Optional[str] = None
     oauth_scopes_override: Optional[list[str]] = None
     oauth_additional_auth_params: Optional[dict[str, str]] = None
-    is_authenticated: bool
-    user_authenticated: Optional[bool] = None
+    # Whether this user's credentials resolve for the server right now (or the
+    # server needs no per-user auth). None when there is no user context.
+    user_can_authenticate: Optional[bool] = None
     status: MCPServerStatus
     is_public: bool = True
     groups: list[int] = Field(default_factory=list)
@@ -670,7 +671,9 @@ class MCPServerCreateResponse(BaseModel):
     oauth_token_endpoint: Optional[str] = None
     oauth_scopes_override: Optional[list[str]] = None
     oauth_additional_auth_params: Optional[dict[str, str]] = None
-    is_authenticated: bool
+    # True when the server needs no per-user auth (auth_type NONE or an admin
+    # supplies shared credentials), so it is usable right after creation.
+    no_user_authentication_required: bool
 
 
 class MCPServerUpdateResponse(BaseModel):

--- a/backend/tests/external_dependency_unit/craft/test_mcp_config_resolution.py
+++ b/backend/tests/external_dependency_unit/craft/test_mcp_config_resolution.py
@@ -265,8 +265,8 @@ def test_craft_listing_agrees_with_session_emission(
     a server the session never gets, so pin the two together across the auth
     matrix rather than trusting them to stay in sync by hand.
 
-    `is_authenticated` / `user_authenticated` cannot serve this purpose: they
-    report whether a config row exists, not whether it yields auth headers.
+    `user_can_authenticate` cannot serve this purpose: it reports whether a
+    config row exists, not whether it yields auth headers.
     """
     craft, _ = craft_server
     user = create_test_user(db_session, "mcp_listing")

--- a/backend/tests/external_dependency_unit/craft/test_mcp_config_resolution.py
+++ b/backend/tests/external_dependency_unit/craft/test_mcp_config_resolution.py
@@ -265,8 +265,9 @@ def test_craft_listing_agrees_with_session_emission(
     a server the session never gets, so pin the two together across the auth
     matrix rather than trusting them to stay in sync by hand.
 
-    `user_can_authenticate` cannot serve this purpose: it reports whether a
-    config row exists, not whether it yields auth headers.
+    Asserting each consumer against `user_can_authenticate` directly cannot
+    serve this purpose: both derive from it, so per-consumer assertions would
+    pass even if the two consumers drifted apart.
     """
     craft, _ = craft_server
     user = create_test_user(db_session, "mcp_listing")

--- a/backend/tests/external_dependency_unit/server/features/mcp/test_mcp_oauth_authenticated_status.py
+++ b/backend/tests/external_dependency_unit/server/features/mcp/test_mcp_oauth_authenticated_status.py
@@ -1,4 +1,4 @@
-"""`is_authenticated` for per-user OAuth servers must reflect a completed
+"""`user_can_authenticate` for per-user OAuth servers must reflect a completed
 handshake (stored tokens), not mere connection-config row existence, since the
 row is created before token exchange. API-token servers stay authenticated on
 row existence alone."""
@@ -57,8 +57,7 @@ def test_oauth_tokenless_row_is_not_authenticated(db_session: Session) -> None:
     db_session.commit()
 
     api_server = _db_mcp_server_to_api_mcp_server(server, db_session, request_user=user)
-    assert api_server.user_authenticated is False
-    assert api_server.is_authenticated is False
+    assert api_server.user_can_authenticate is False
 
 
 def test_oauth_row_with_tokens_is_authenticated(db_session: Session) -> None:
@@ -76,8 +75,7 @@ def test_oauth_row_with_tokens_is_authenticated(db_session: Session) -> None:
     db_session.commit()
 
     api_server = _db_mcp_server_to_api_mcp_server(server, db_session, request_user=user)
-    assert api_server.user_authenticated is True
-    assert api_server.is_authenticated is True
+    assert api_server.user_can_authenticate is True
 
 
 def test_api_token_row_is_authenticated_without_tokens_key(
@@ -97,5 +95,4 @@ def test_api_token_row_is_authenticated_without_tokens_key(
     db_session.commit()
 
     api_server = _db_mcp_server_to_api_mcp_server(server, db_session, request_user=user)
-    assert api_server.user_authenticated is True
-    assert api_server.is_authenticated is True
+    assert api_server.user_can_authenticate is True

--- a/backend/tests/integration/tests/mcp/test_craft_mcp_servers.py
+++ b/backend/tests/integration/tests/mcp/test_craft_mcp_servers.py
@@ -158,8 +158,7 @@ def test_craft_mcp_server_listing(
     assert [server["id"] for server in craft_servers] == [server_id]
     entry = craft_servers[0]
     assert entry["available_in_craft"] is True
-    assert entry["user_authenticated"] is False
-    assert entry["is_authenticated"] is False
+    assert entry["user_can_authenticate"] is False
     # Nothing for the proxy to authenticate with, so Craft would not emit it.
     assert entry["craft_connected"] is False
 
@@ -178,8 +177,7 @@ def test_craft_mcp_server_listing(
 
     # ...and the craft listing reflects the chat-side auth state
     entry = _get_craft_servers(basic_user)[0]
-    assert entry["user_authenticated"] is True
-    assert entry["is_authenticated"] is True
+    assert entry["user_can_authenticate"] is True
     assert entry["craft_connected"] is True
 
     # Toggling the flag off removes the server from the craft listing

--- a/web/src/lib/skills/__fixtures__/picker.ts
+++ b/web/src/lib/skills/__fixtures__/picker.ts
@@ -90,7 +90,7 @@ export function mcpServerFixture(
     owner: "admin@example.com",
     auth_type: MCPAuthenticationType.API_TOKEN,
     auth_performer: MCPAuthenticationPerformer.PER_USER,
-    is_authenticated: true,
+    user_can_authenticate: true,
     craft_connected: true,
     status: MCPServerStatus.CONNECTED,
     is_public: true,

--- a/web/src/lib/skills/__tests__/picker.test.ts
+++ b/web/src/lib/skills/__tests__/picker.test.ts
@@ -168,11 +168,11 @@ describe("toPickerSections", () => {
     const servers = [
       mcpServerFixture({ id: 9, name: "Zulip MCP" }),
       // A credential row can exist while the proxy still cannot authenticate
-      // the user, so `is_authenticated` must not drive this.
+      // the user, so `user_can_authenticate` must not drive this.
       mcpServerFixture({
         id: 4,
         name: "Asana MCP",
-        is_authenticated: true,
+        user_can_authenticate: true,
         craft_connected: false,
       }),
     ];

--- a/web/src/lib/tools/interfaces.ts
+++ b/web/src/lib/tools/interfaces.ts
@@ -32,12 +32,13 @@ export interface MCPServer {
   oauth_token_endpoint?: string;
   oauth_scopes_override?: string[];
   oauth_additional_auth_params?: Record<string, string>;
-  is_authenticated: boolean;
-  user_authenticated?: boolean;
+  // Whether this user's credentials resolve for the server right now (or the
+  // server needs no per-user auth). Absent when there is no user context.
+  user_can_authenticate?: boolean;
   // Whether Craft will actually emit this server into the user's sessions, i.e.
-  // whether the sandbox proxy can authenticate them against it. Unlike the two
-  // flags above it asks whether stored credentials yield auth headers, not
-  // whether a config row exists. Only the Craft listing computes it.
+  // whether the sandbox proxy can authenticate them against it. Unlike the flag
+  // above it asks whether stored credentials yield auth headers, not whether a
+  // config row exists. Only the Craft listing computes it.
   craft_connected?: boolean;
   auth_template?: MCPAuthTemplate | null;
   admin_credentials?: Record<string, string>;

--- a/web/src/lib/tools/mcpService.ts
+++ b/web/src/lib/tools/mcpService.ts
@@ -180,7 +180,7 @@ interface UpsertMCPServerResponse {
   oauth_token_endpoint?: string;
   oauth_scopes_override?: string[];
   oauth_additional_auth_params?: Record<string, string>;
-  is_authenticated: boolean;
+  no_user_authentication_required: boolean;
 }
 
 export async function upsertMCPServer(serverData: {

--- a/web/src/refresh-components/popovers/ActionsPopover/MCPLineItem.test.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/MCPLineItem.test.tsx
@@ -15,7 +15,7 @@ const oauthServer: MCPServer = {
   server_url: "https://mcp.example.com",
   auth_type: MCPAuthenticationType.OAUTH,
   auth_performer: MCPAuthenticationPerformer.PER_USER,
-  is_authenticated: false,
+  user_can_authenticate: false,
 };
 
 const tool: ToolSnapshot = {

--- a/web/src/refresh-components/popovers/ActionsPopover/MCPLineItem.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/MCPLineItem.tsx
@@ -28,8 +28,7 @@ export interface MCPServer {
   server_url: string;
   auth_type: MCPAuthenticationType;
   auth_performer: MCPAuthenticationPerformer;
-  is_authenticated: boolean;
-  user_authenticated?: boolean;
+  user_can_authenticate?: boolean;
   auth_template?: any;
   user_credentials?: Record<string, string>;
 }

--- a/web/src/refresh-components/popovers/ActionsPopover/index.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/index.tsx
@@ -481,7 +481,7 @@ export default function ActionsPopover({
             const next = { ...prev } as any;
             servers.forEach((s: any) => {
               next[s.id as number] = {
-                isAuthenticated: !!s.user_authenticated || !!s.is_authenticated,
+                isAuthenticated: !!s.user_can_authenticate,
                 isLoading: false,
               };
             });
@@ -658,7 +658,7 @@ export default function ActionsPopover({
             },
           }));
         },
-        isAuthenticated: server.user_authenticated,
+        isAuthenticated: server.user_can_authenticate,
         existingCredentials: server.user_credentials,
       });
     }
@@ -698,10 +698,7 @@ export default function ActionsPopover({
     : undefined;
   const isActiveServerAuthenticated =
     selectedMcpServerData?.isAuthenticated ??
-    !!(
-      selectedMcpServer?.user_authenticated ||
-      selectedMcpServer?.is_authenticated
-    );
+    !!selectedMcpServer?.user_can_authenticate;
   const showActiveReauthRow =
     !!selectedMcpServer &&
     selectedMcpTools.length > 0 &&
@@ -928,8 +925,7 @@ export default function ActionsPopover({
         // MCP Servers
         ...filteredMCPServers.map((server) => {
           const serverData = mcpServerData[server.id] || {
-            isAuthenticated:
-              !!server.user_authenticated || !!server.is_authenticated,
+            isAuthenticated: !!server.user_can_authenticate,
             isLoading: false,
           };
 

--- a/web/src/sections/actions/modals/AddMCPServerModal.tsx
+++ b/web/src/sections/actions/modals/AddMCPServerModal.tsx
@@ -200,7 +200,7 @@ export default function AddMCPServerModal({
 
                 {/* Authentication Status Section - Only show in edit mode when authenticated */}
                 {isEditMode &&
-                  server?.is_authenticated &&
+                  server?.user_can_authenticate &&
                   server?.status === MCPServerStatus.CONNECTED && (
                     <Section
                       flexDirection="row"

--- a/web/src/views/admin/ChatPreferencesPage.tsx
+++ b/web/src/views/admin/ChatPreferencesPage.tsx
@@ -114,7 +114,7 @@ function MCPServerCard({
 
   const allToolIds = tools.map((t) => t.id);
   const serverEnabled = tools.some((t) => isToolEnabled(t.id));
-  const needsAuth = !server.is_authenticated;
+  const needsAuth = !server.user_can_authenticate;
   const authTooltip = needsAuth
     ? "Authenticate this MCP server before enabling its tools."
     : undefined;

--- a/web/tests/e2e/mcp/mcp_oauth_flow.spec.ts
+++ b/web/tests/e2e/mcp/mcp_oauth_flow.spec.ts
@@ -342,9 +342,9 @@ test.describe("MCP OAuth flows", () => {
 
     // Per-user OAuth servers require the user to authenticate from chat before
     // their tools become usable: the admin-page "connect" only stores the
-    // server's client config, not a per-user token for this user
-    // (backend mcp/api.py: user_authenticated = get_user_connection_config(...)
-    // is not None). So authenticate from chat first, then verify the tool runs.
+    // server's client config, not a per-user token for this user (backend
+    // mcp/api.py resolves the server's `user_can_authenticate` from the user's
+    // stored credentials). So authenticate from chat first, then verify the tool runs.
     const actions = new ActionsPopover(page);
     await oauthFlow.reauthenticateFromChat(
       actions,


### PR DESCRIPTION
## Description

Stacked on #13947. Renames the MCP auth wire fields so each name states the question it answers, matching the centralized backend predicates — atomically across producer and every consumer, no back-compat aliases:

- `is_authenticated` + `user_authenticated` (duplicated per-user connection state; one was populated as `bool` of the other) → collapsed into a single `user_can_authenticate`
- `is_authenticated` on the server-create response (which actually meant "server needs no per-user auth") → `no_user_authentication_required`
- `craft_connected` → unchanged; its name already matches its question

Updated consumers: TS interfaces (`lib/tools/interfaces.ts`), `mcpService`, `ActionsPopover`/`MCPLineItem`, `AddMCPServerModal`, `ChatPreferencesPage`, skill-picker fixtures/tests, backend integration tests, and the playwright OAuth spec (rename-only edits). A repo-wide grep across `web/`, `mobile/`, `desktop/`, `widget/`, `extensions/`, and `cli/` confirms no references to the old names remain.

## How Has This Been Tested?

- Rename-only change gated by existing suites: 29 web unit tests and 119 backend MCP unit tests pass; `pre-commit` clean including oxfmt, oxlint, and the TypeScript type check.
- Renamed integration and playwright specs run in CI.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check