### PR TITLE
fix(opal): clear stale sidebar tab hover state

### DIFF
--- a/web/lib/opal/src/components/buttons/sidebar-tab/SidebarTab.test.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/SidebarTab.test.tsx
@@ -5,9 +5,14 @@
 // SidebarTab is also used for page-level tab navigation (e.g. the settings
 // page). Those tabs have no sidebar above them and must stay expanded when the
 // app sidebar folds.
-import { render, screen } from "@tests/setup/test-utils";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { render, screen, userEvent, waitFor } from "@tests/setup/test-utils";
 import { SidebarTab } from "@opal/components";
-import { SidebarLayouts, SidebarStateProvider } from "@opal/layouts";
+import {
+  SidebarLayouts,
+  SidebarStateProvider,
+  useSidebarState,
+} from "@opal/layouts";
 import { renderSidebarLogo } from "@/lib/sidebar/utils";
 
 jest.mock("@opal/hooks/useScreenSize", () => ({
@@ -63,6 +68,44 @@ it("still honors an explicit folded prop as an override", () => {
   );
   const tab = screen.getByText("Settings").closest(".opal-sidebar-tab");
   expect(tab).toHaveAttribute("data-folded", "true");
+});
+
+it("does not show the folded tooltip for a tab the pointer already left", async () => {
+  const user = userEvent.setup();
+
+  function FoldableSidebar() {
+    const { setFolded } = useSidebarState();
+    return (
+      <SidebarLayouts.Root foldable>
+        <SidebarLayouts.Header renderAppLogo={renderSidebarLogo}>
+          <SidebarTab href="/settings">Settings</SidebarTab>
+        </SidebarLayouts.Header>
+        <button onClick={() => setFolded(true)}>Fold</button>
+      </SidebarLayouts.Root>
+    );
+  }
+
+  render(
+    // Open on the first hover, so the test does not wait out the default delay.
+    <TooltipPrimitive.Provider delayDuration={0}>
+      <SidebarStateProvider>
+        <FoldableSidebar />
+      </SidebarStateProvider>
+    </TooltipPrimitive.Provider>
+  );
+
+  // Hover the tab while the sidebar is open, then leave it. An open sidebar
+  // shows its labels, so the tooltip stays closed the whole time.
+  const tab = screen.getByLabelText("Settings");
+  await user.hover(tab);
+  await user.unhover(tab);
+
+  await user.click(screen.getByRole("button", { name: "Fold" }));
+
+  // The pointer is elsewhere, so folding must not reveal a tooltip.
+  await waitFor(() => {
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
 });
 
 it("names the tab for assistive technology in both states", () => {

--- a/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
@@ -72,7 +72,7 @@ interface FoldedTooltipProps {
   /** Explicit fold state. Falls back to the enclosing sidebar's. */
   folded?: boolean;
 
-  children: React.ReactElement;
+  children: React.ReactElement<React.DOMAttributes<HTMLElement>>;
 }
 
 /**
@@ -93,6 +93,17 @@ function FoldedTooltip({ label, folded, children }: FoldedTooltipProps) {
 
   const effectiveFolded = folded ?? foldedFromSidebar;
 
+  /* Radix compares every open change against the `open` prop and drops the
+  ones that already match it. While the tab is unfolded `open` is false, so the
+  close that follows a hover never reaches `setHovered` and `hovered` stays
+  true. Folding the sidebar would then show the tooltip for a tab the pointer
+  left long ago. Clear the state from the trigger instead. While folded, `open`
+  tracks `hovered`, so Radix reports the close itself — leave it alone there and
+  keep its grace area for a pointer moving onto the tooltip. */
+  const clearStaleHover = React.useCallback(() => {
+    if (!effectiveFolded) setHovered(false);
+  }, [effectiveFolded]);
+
   return (
     <Tooltip
       tooltip={label}
@@ -100,7 +111,10 @@ function FoldedTooltip({ label, folded, children }: FoldedTooltipProps) {
       open={effectiveFolded && hovered}
       onOpenChange={setHovered}
     >
-      {children}
+      {React.cloneElement(children, {
+        onPointerLeave: clearStaleHover,
+        onBlur: clearStaleHover,
+      })}
     </Tooltip>
   );
 }

--- a/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
@@ -99,7 +99,13 @@ function FoldedTooltip({ label, folded, children }: FoldedTooltipProps) {
   true. Folding the sidebar would then show the tooltip for a tab the pointer
   left long ago. Clear the state from the trigger instead. While folded, `open`
   tracks `hovered`, so Radix reports the close itself — leave it alone there and
-  keep its grace area for a pointer moving onto the tooltip. */
+  keep its grace area for a pointer moving onto the tooltip.
+
+  TODO(@jamison): this patches a mismatch instead of removing it. Controlling
+  `open` with a value that is not the hover state is what makes Radix drop the
+  close. A `suppressed` prop on `Tooltip` — one that keeps the trigger mounted
+  but renders no content — would let this component drop `hovered`, `open`, and
+  the `cloneElement` below, and let Radix track the pointer on its own. */
   const clearStaleHover = React.useCallback(() => {
     if (!effectiveFolded) setHovered(false);
   }, [effectiveFolded]);


### PR DESCRIPTION
## Problem

Introduced by 43841e8519. Hover a sidebar tab while the sidebar is open, move the pointer away, then fold the sidebar: the tab's tooltip appears even though nothing is hovered.

`FoldedTooltip` keeps a `hovered` state and passes `open={folded && hovered}` to Radix. Radix compares each open change against the `open` prop and drops the ones that already match it (`useControllableState`). While the tab is unfolded `open` is false, so the close that follows a hover never reaches `setHovered` and `hovered` stays true forever. Folding then flips `open` to true.

## Fix

Clear the hover state from the trigger itself while the tab is unfolded. In the folded state `open` tracks `hovered`, so Radix reports its own closes — that path is untouched and keeps the grace area for a pointer moving onto the tooltip.

## Tests

New case in `SidebarTab.test.tsx`: hover a tab in an open sidebar, unhover, fold, and assert no tooltip. It fails on the current `main` behavior and passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents folded sidebar tabs from showing a tooltip after the pointer already left. Before: hover a tab while the sidebar is open, leave it, then fold ⇒ tooltip appears. Now: the tooltip stays hidden unless the tab is actually hovered while folded.

- Clears stale hover by setting hovered=false on the trigger’s onPointerLeave/onBlur when unfolded; when folded, `open={folded && hovered}` with `@radix-ui/react-tooltip` preserves the grace area.
- Injects these handlers with `React.cloneElement(children, { onPointerLeave, onBlur })`; this overwrites any existing handlers on the child. If a trigger needs its own handlers, compose them at the call site.
- Updates tests to cover the hover–leave–fold case; uses `TooltipPrimitive.Provider` with `delayDuration={0}` and folds via `useSidebarState`.
- Notes a follow-up (TODO) to remove controlled tooltip state and rely on an approach that doesn’t require cloning or manual hover state.

<sup>Written for commit 1b9bfda708292249fe6dbed91097114c4176347e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

