### PR TITLE
fix(web): keep deep research out of project chats

### DIFF
--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -527,6 +527,14 @@ export default function useChatController({
             projectId: projectId ? parseInt(projectId) : null,
           });
         }
+
+        // The project's chat list is how the app answers "is this chat inside a
+        // project" once `projectId` leaves the URL. Without this the new chat is
+        // missing from that list until the next revalidation, and the cache is
+        // configured not to revalidate on stale or focus.
+        if (projectId) {
+          void fetchProjects();
+        }
       } else {
         // Use the existing session ID from props or from the store
         currChatSessionId =

--- a/web/src/lib/projects/hooks.ts
+++ b/web/src/lib/projects/hooks.ts
@@ -1,9 +1,11 @@
 "use client";
 
+import { useMemo } from "react";
 import useSWR from "swr";
 import { Project } from "@/lib/projects/types";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import useAppFocus from "@/hooks/useAppFocus";
 
 export function useProjects() {
   const { data, error, mutate } = useSWR<Project[]>(
@@ -22,4 +24,35 @@ export function useProjects() {
     error,
     refreshProjects: mutate,
   };
+}
+
+/**
+ * The project the user is currently inside: either the open project page, or
+ * the project that owns the open chat.
+ *
+ * A chat's project is found by searching for the project that lists it. The URL
+ * cannot answer this on its own — `projectId` is dropped once a chat opens (see
+ * `PARAMS_TO_SKIP` in `app/app/services/lib.tsx`), so a chat URL carries no
+ * project context.
+ */
+export function useActiveProject(): Project | null {
+  const appFocus = useAppFocus();
+  const { projects } = useProjects();
+
+  return useMemo(() => {
+    const id = appFocus.getId();
+    if (!id) return null;
+
+    if (appFocus.isProject()) {
+      return projects.find((project) => String(project.id) === id) ?? null;
+    }
+    if (appFocus.isChat()) {
+      return (
+        projects.find((project) =>
+          project.chat_sessions.some((session) => session.id === id)
+        ) ?? null
+      );
+    }
+    return null;
+  }, [appFocus, projects]);
 }

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -28,7 +28,7 @@ import { Disabled } from "@opal/core";
 import { useUser } from "@/providers/UserProvider";
 import { useSettings } from "@/lib/settings/hooks";
 import { useProjectsContext } from "@/providers/ProjectsContext";
-import { useActiveProject } from "@/lib/projects/hooks";
+import { useActiveProject, useProjects } from "@/lib/projects/hooks";
 import { FileCard } from "@/sections/cards/FileCard";
 import { ProjectFile, UserFileStatus } from "@/lib/projects/types";
 import FilePickerPopover from "@/refresh-components/popovers/FilePickerPopover";
@@ -323,6 +323,7 @@ const AppInputBar = React.memo(
     const { forcedToolIds, setForcedToolIds } = useForcedTools();
     const { currentMessageFiles, setCurrentMessageFiles } =
       useProjectsContext();
+    const { isLoading: isLoadingProjects } = useProjects();
     const activeProject = useActiveProject();
 
     const currentIndexingFiles = useMemo(() => {
@@ -556,7 +557,9 @@ const AppInputBar = React.memo(
       // chat carries no project context in its URL — reading the search param
       // hid the toggle on the project page and left it showing in the one place
       // it actually breaks.
-      const isProjectWorkflow = activeProject !== null;
+      // Loading counts as "unknown", and unknown withholds: an unloaded
+      // projects list makes a project chat look like a normal one.
+      const isProjectWorkflow = isLoadingProjects || activeProject !== null;
 
       // TODO(@yuhong): Re-enable Deep Research in Projects workflow once it is fully supported.
       // https://linear.app/onyx-app/issue/ENG-3818/re-enable-deep-research-in-projects
@@ -569,6 +572,7 @@ const AppInputBar = React.memo(
       selectedAgent?.tools,
       combinedSettingsData?.deep_research_enabled,
       activeProject,
+      isLoadingProjects,
     ]);
 
     function handleKeyDownForPromptShortcuts(

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -28,6 +28,7 @@ import { Disabled } from "@opal/core";
 import { useUser } from "@/providers/UserProvider";
 import { useSettings } from "@/lib/settings/hooks";
 import { useProjectsContext } from "@/providers/ProjectsContext";
+import { useActiveProject } from "@/lib/projects/hooks";
 import { FileCard } from "@/sections/cards/FileCard";
 import { ProjectFile, UserFileStatus } from "@/lib/projects/types";
 import FilePickerPopover from "@/refresh-components/popovers/FilePickerPopover";
@@ -320,8 +321,9 @@ const AppInputBar = React.memo(
     }, [isNewSession, initialMessage]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const { forcedToolIds, setForcedToolIds } = useForcedTools();
-    const { currentMessageFiles, setCurrentMessageFiles, currentProjectId } =
+    const { currentMessageFiles, setCurrentMessageFiles } =
       useProjectsContext();
+    const activeProject = useActiveProject();
 
     const currentIndexingFiles = useMemo(() => {
       return currentMessageFiles.filter(
@@ -548,7 +550,13 @@ const AppInputBar = React.memo(
     const showDeepResearch = useMemo(() => {
       const deepResearchGloballyEnabled =
         combinedSettingsData?.deep_research_enabled ?? true;
-      const isProjectWorkflow = currentProjectId !== null;
+
+      // Resolved from the chat, not the URL. `projectId` is dropped once a chat
+      // opens (`PARAMS_TO_SKIP` in `app/app/services/lib.tsx`), so a project
+      // chat carries no project context in its URL — reading the search param
+      // hid the toggle on the project page and left it showing in the one place
+      // it actually breaks.
+      const isProjectWorkflow = activeProject !== null;
 
       // TODO(@yuhong): Re-enable Deep Research in Projects workflow once it is fully supported.
       // https://linear.app/onyx-app/issue/ENG-3818/re-enable-deep-research-in-projects
@@ -560,7 +568,7 @@ const AppInputBar = React.memo(
     }, [
       selectedAgent?.tools,
       combinedSettingsData?.deep_research_enabled,
-      currentProjectId,
+      activeProject,
     ]);
 
     function handleKeyDownForPromptShortcuts(

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -58,7 +58,7 @@ import ChatScrollContainer, {
 } from "@/sections/chat/ChatScrollContainer";
 import ProjectContextPanel from "@/sections/projects/ProjectContextPanel";
 import { useProjectsContext } from "@/providers/ProjectsContext";
-import { useActiveProject } from "@/lib/projects/hooks";
+import { useActiveProject, useProjects } from "@/lib/projects/hooks";
 import { getProjectTokenCount } from "@/lib/projects/svc";
 import ProjectChatSessionList from "@/sections/projects/ProjectChatSessionList";
 import { cn } from "@opal/utils";
@@ -243,9 +243,12 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
   // opens (`PARAMS_TO_SKIP` in `app/app/services/lib.tsx`), so `currentProjectId`
   // is null inside a project chat. This value is what reaches the backend, so
   // reading the search param let a project chat send deep research and error.
+  const { isLoading: isLoadingProjects } = useProjects();
   const activeProject = useActiveProject();
+  // Withhold until the projects snapshot has loaded: an unloaded list makes a
+  // project chat look like a normal one, and this value reaches the backend.
   const deepResearchEnabledForCurrentWorkflow =
-    activeProject === null && deepResearchEnabled;
+    !isLoadingProjects && activeProject === null && deepResearchEnabled;
 
   const [presentingDocument, setPresentingDocument] =
     useState<MinimalOnyxDocument | null>(null);

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -58,6 +58,7 @@ import ChatScrollContainer, {
 } from "@/sections/chat/ChatScrollContainer";
 import ProjectContextPanel from "@/sections/projects/ProjectContextPanel";
 import { useProjectsContext } from "@/providers/ProjectsContext";
+import { useActiveProject } from "@/lib/projects/hooks";
 import { getProjectTokenCount } from "@/lib/projects/svc";
 import ProjectChatSessionList from "@/sections/projects/ProjectChatSessionList";
 import { cn } from "@opal/utils";
@@ -238,8 +239,13 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     setIncognitoEnabled,
     setIncognitoLocked,
   } = useIncognito();
+  // Resolved from the chat, not the URL: `projectId` is dropped once a chat
+  // opens (`PARAMS_TO_SKIP` in `app/app/services/lib.tsx`), so `currentProjectId`
+  // is null inside a project chat. This value is what reaches the backend, so
+  // reading the search param let a project chat send deep research and error.
+  const activeProject = useActiveProject();
   const deepResearchEnabledForCurrentWorkflow =
-    currentProjectId === null && deepResearchEnabled;
+    activeProject === null && deepResearchEnabled;
 
   const [presentingDocument, setPresentingDocument] =
     useState<MinimalOnyxDocument | null>(null);


### PR DESCRIPTION
## Description

Selecting Deep Research inside a project chat sends a request the backend rejects. A guard for this already existed — it just watched the wrong thing.

`AppInputBar` gated on `currentProjectId`, which `ProjectsContext` reads from the `?projectId=` search param. But `PROJECT_ID` is listed in `PARAMS_TO_SKIP` (`app/app/services/lib.tsx`), with the comment *"do not persist project context in the URL after navigation"*. So:

| where | URL | `currentProjectId` | Deep Research |
|---|---|---|---|
| project page | `?projectId=7` | `7` | correctly withheld |
| **chat inside that project** | `?chatId=abc` | **`null`** | **offered, then rejected** |

The guard held on the page you cannot chat from, and lapsed on the one you can.

**The toggle was not the real problem.** `AppPage.tsx` derives `deepResearchEnabledForCurrentWorkflow` the same way, and *that* is the value attached to the request. Fixing only the toggle would still have let a session with Deep Research already enabled send it on its next project chat and hit the same error. Both sites now resolve the project from the chat rather than the URL.

`useActiveProject` finds the project whose `chat_sessions` contains the open chat, which is the only way to answer the question once the URL has dropped the parameter. It is lifted **verbatim** from `feat/projects-viz` (#13943), where it was written for this same reason, so the two copies reconcile without conflict whichever lands first. Only that hook is brought over, not the rest of that branch.

One remaining `currentProjectId !== null` in `AppPage` is left alone deliberately: it is guarded by `!currentChatSessionId`, so it only runs on the project page, where the search param genuinely is present.

## Screenshots + Videos

The "Deep Research" toggle is *not* present in the `AppInputBar` here.

<img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/ece8e17f-c2e0-4af5-aabd-61827ff39690" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks Deep Research in project chats by resolving the active project from chat/app focus and withholding while projects load. Previously we read the project from the URL; chat URLs drop it, so the toggle could appear and enabled sessions could send Deep Research, which the backend rejected.

- Adds `useActiveProject` to derive the active project from app focus (project page or chat membership); replaces the URL-based guard. Lifted verbatim from `feat/projects-viz`, so either merge order is safe.
- `AppInputBar` hides the Deep Research toggle when a project is active or the projects list is still loading.
- `AppPage` now enables Deep Research only when the projects list has loaded and no active project is found; keeps the `currentProjectId !== null` check for the project page only.
- Refreshes projects after creating a project chat so the new chat appears in its project's list immediately, closing a window where a new project chat looked project-less until revalidation.
- Aligns with Linear `ENG-3818`: keep Deep Research disabled in the project workflow until supported.

<sup>Written for commit da985cc86b7c6910d2783ed0600c46bd06ddc898. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

