### PR TITLE
fix(usage): align performance date controls

### DIFF
--- a/web/lib/opal/src/layouts/settings/components.tsx
+++ b/web/lib/opal/src/layouts/settings/components.tsx
@@ -128,7 +128,7 @@ function SettingsHeader({
       <Spacer rem={3.25} />
 
       <div className="flex flex-col gap-6 px-4">
-        <div className="flex w-full justify-between">
+        <div className="flex w-full items-center justify-between">
           <div aria-label="admin-page-title">
             <Content
               icon={Icon}

--- a/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
+++ b/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
@@ -12,12 +12,9 @@ import SvgSimpleLoader from "@opal/icons/simple-loader";
 import { ChatSessionMinimal } from "@/app/ee/admin/performance/usage/types";
 import { Section } from "@/layouts/general-layouts";
 import { timestampToReadableDate } from "@/lib/dateUtils";
-import { Dispatch, SetStateAction, useCallback, useState } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import { Feedback, TaskStatus } from "@/lib/types";
-import {
-  DateRange,
-  DateRangePicker,
-} from "@/refresh-components/DateRangePicker";
+import { DateRange } from "@/refresh-components/DateRangePicker";
 import { PageSelector } from "@/components/PageSelector";
 import Link from "next/link";
 import type { Route } from "next";
@@ -244,14 +241,26 @@ function PreviousQueryHistoryExportsModal({
   );
 }
 
-export function QueryHistoryTable() {
-  const [dateRange, setDateRange] = useState<DateRange>(undefined);
-  const [filters, setFilters] = useState<{
-    feedback_type?: Feedback | "all";
-    start_time?: string;
-    end_time?: string;
-  }>({});
+export type QueryHistoryFilters = Record<
+  string,
+  string | number | boolean | string[] | Date
+> & {
+  feedback_type?: Feedback | "all";
+  start_time?: string;
+  end_time?: string;
+};
 
+interface QueryHistoryTableProps {
+  dateRange: DateRange;
+  filters: QueryHistoryFilters;
+  setFilters: Dispatch<SetStateAction<QueryHistoryFilters>>;
+}
+
+export function QueryHistoryTable({
+  dateRange,
+  filters,
+  setFilters,
+}: QueryHistoryTableProps) {
   const [showModal, setShowModal] = useState(false);
 
   const {
@@ -267,25 +276,6 @@ export function QueryHistoryTable() {
     endpoint: "/api/admin/chat-session-history",
     filter: filters,
   });
-
-  const onTimeRangeChange = useCallback((value: DateRange) => {
-    setDateRange(value);
-
-    if (value?.from && value?.to) {
-      setFilters((prev) => ({
-        ...prev,
-        start_time: value.from.toISOString(),
-        end_time: value.to.toISOString(),
-      }));
-    } else {
-      setFilters((prev) => {
-        const newFilters = { ...prev };
-        delete newFilters.start_time;
-        delete newFilters.end_time;
-        return newFilters;
-      });
-    }
-  }, []);
 
   if (error) {
     return (
@@ -314,11 +304,6 @@ export function QueryHistoryTable() {
                   return newFilters;
                 });
               }}
-            />
-
-            <DateRangePicker
-              value={dateRange}
-              onValueChange={onTimeRangeChange}
             />
           </div>
           <div className="flex flex-row w-full items-center gap-x-2">

--- a/web/src/app/ee/admin/performance/query-history/page.tsx
+++ b/web/src/app/ee/admin/performance/query-history/page.tsx
@@ -16,14 +16,12 @@ import { useCallback, useState } from "react";
 const route = ADMIN_ROUTES.QUERY_HISTORY;
 
 export default function QueryHistoryPage() {
-  const [dateRange, setDateRange] = useState<DateRange>(() =>
-    rangeForInclusiveDays(30)
-  );
+  const initialRange = rangeForInclusiveDays(30);
+  const [dateRange, setDateRange] = useState<DateRange>(initialRange);
   const [filters, setFilters] = useState<QueryHistoryFilters>(() => {
-    const range = rangeForInclusiveDays(30);
     return {
-      start_time: range.from.toISOString(),
-      end_time: range.to.toISOString(),
+      start_time: initialRange.from.toISOString(),
+      end_time: initialRange.to.toISOString(),
     };
   });
 

--- a/web/src/app/ee/admin/performance/query-history/page.tsx
+++ b/web/src/app/ee/admin/performance/query-history/page.tsx
@@ -1,18 +1,72 @@
 "use client";
 
 import { SettingsLayouts } from "@opal/layouts";
-import { QueryHistoryTable } from "@/app/ee/admin/performance/query-history/QueryHistoryTable";
+import {
+  QueryHistoryFilters,
+  QueryHistoryTable,
+} from "@/app/ee/admin/performance/query-history/QueryHistoryTable";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
+import {
+  DateRange,
+  DateRangePicker,
+  rangeForInclusiveDays,
+} from "@/refresh-components/DateRangePicker";
+import { useCallback, useState } from "react";
 
 const route = ADMIN_ROUTES.QUERY_HISTORY;
 
 export default function QueryHistoryPage() {
+  const [dateRange, setDateRange] = useState<DateRange>(() =>
+    rangeForInclusiveDays(30)
+  );
+  const [filters, setFilters] = useState<QueryHistoryFilters>(() => {
+    const range = rangeForInclusiveDays(30);
+    return {
+      start_time: range.from.toISOString(),
+      end_time: range.to.toISOString(),
+    };
+  });
+
+  const onTimeRangeChange = useCallback((value: DateRange) => {
+    setDateRange(value);
+
+    if (value?.from && value?.to) {
+      setFilters((previous) => ({
+        ...previous,
+        start_time: value.from.toISOString(),
+        end_time: value.to.toISOString(),
+      }));
+      return;
+    }
+
+    setFilters((previous) => {
+      const nextFilters = { ...previous };
+      delete nextFilters.start_time;
+      delete nextFilters.end_time;
+      return nextFilters;
+    });
+  }, []);
+
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
+      <SettingsLayouts.Header
+        icon={route.icon}
+        title={route.title}
+        divider
+        rightChildren={
+          <DateRangePicker
+            value={dateRange}
+            onValueChange={onTimeRangeChange}
+          />
+        }
+      />
 
       <SettingsLayouts.Body>
-        <QueryHistoryTable />
+        <QueryHistoryTable
+          dateRange={dateRange}
+          filters={filters}
+          setFilters={setFilters}
+        />
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>
   );

--- a/web/src/hooks/usePaginatedFetch.ts
+++ b/web/src/hooks/usePaginatedFetch.ts
@@ -65,7 +65,16 @@ function usePaginatedFetch<T extends PaginatedType>({
   );
 
   // Tracks ongoing requests to avoid duplicate requests, uses ref to persist across renders
-  const ongoingRequestsRef = useRef<Set<number>>(new Set());
+  const requestKey = useMemo(
+    () =>
+      JSON.stringify({ endpoint, query, filter, itemsPerPage, pagesPerBatch }),
+    [endpoint, query, filter, itemsPerPage, pagesPerBatch]
+  );
+  const requestKeyRef = useRef(requestKey);
+  useEffect(() => {
+    requestKeyRef.current = requestKey;
+  }, [requestKey]);
+  const ongoingRequestsRef = useRef<Set<string>>(new Set());
 
   const totalPages = useMemo(() => {
     if (totalItems === 0) return 1;
@@ -82,11 +91,12 @@ function usePaginatedFetch<T extends PaginatedType>({
   // Fetches a batch of data and stores it in the cache
   const fetchBatchData = useCallback(
     async (batchNum: number) => {
+      const requestId = `${requestKey}:${batchNum}`;
       // Prevents duplicate requests
-      if (ongoingRequestsRef.current.has(batchNum)) {
+      if (ongoingRequestsRef.current.has(requestId)) {
         return;
       }
-      ongoingRequestsRef.current.add(batchNum);
+      ongoingRequestsRef.current.add(requestId);
 
       try {
         // Build query params
@@ -110,6 +120,10 @@ function usePaginatedFetch<T extends PaginatedType>({
         const url = `${endpoint}?${params.toString()}`;
         const responseData =
           await errorHandlingFetcher<PaginatedApiResponse<T>>(url);
+
+        if (requestKeyRef.current !== requestKey) {
+          return;
+        }
 
         // Validate response data structure
         if (
@@ -140,10 +154,10 @@ function usePaginatedFetch<T extends PaginatedType>({
       } catch (error) {
         setError(error instanceof Error ? error : new Error(String(error)));
       } finally {
-        ongoingRequestsRef.current.delete(batchNum);
+        ongoingRequestsRef.current.delete(requestId);
       }
     },
-    [endpoint, pagesPerBatch, itemsPerPage, query, filter]
+    [endpoint, pagesPerBatch, itemsPerPage, query, filter, requestKey]
   );
 
   // Updates the URL with the current page number

--- a/web/src/views/admin/WorkspaceAnalyticsPage/index.tsx
+++ b/web/src/views/admin/WorkspaceAnalyticsPage/index.tsx
@@ -11,7 +11,7 @@ import { PersonaMessagesChart } from "@/views/admin/WorkspaceAnalyticsPage/Perso
 import UsageReports from "@/views/admin/WorkspaceAnalyticsPage/UsageReports";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { Divider } from "@opal/components";
-import { Section, SettingsLayouts } from "@opal/layouts";
+import { SettingsLayouts } from "@opal/layouts";
 
 const route = ADMIN_ROUTES.WORKSPACE_ANALYTICS;
 
@@ -25,9 +25,7 @@ export default function WorkspaceAnalyticsPage() {
         title={route.title}
         description="Understand how your workspace uses Onyx across queries, feedback, and agents."
         divider
-      />
-      <SettingsLayouts.Body>
-        <Section flexDirection="row" justifyContent="end" height="fit">
+        rightChildren={
           <DateRangePicker
             value={timeRange}
             onValueChange={(range) =>
@@ -38,7 +36,9 @@ export default function WorkspaceAnalyticsPage() {
               )
             }
           />
-        </Section>
+        }
+      />
+      <SettingsLayouts.Body>
         <UsageChart timeRange={timeRange} />
         <FeedbackChart timeRange={timeRange} />
         <SlackChannelChart timeRange={timeRange} />


### PR DESCRIPTION
## Summary
- center shared settings-header actions so date controls keep their intended height
- place Analytics and Query History date controls in the header action slot
- apply the inclusive 1M default to Query History filters and exports

## Verification
- `bun run format:check -- ...changed files...`
- `bunx oxlint ...changed files...`
- `bun run types:check`
- `bun run test -- DateRangePicker.test.tsx lib.test.tsx --runInBand`

Before
<img width="1039" height="149" alt="Screenshot 2026-08-13 at 12 44 46" src="https://github.com/user-attachments/assets/9fa2161e-40a7-49b5-9934-0802e1a45b6f" />

After
<img width="1075" height="137" alt="Screenshot 2026-08-13 at 12 45 01" src="https://github.com/user-attachments/assets/8479210f-1a11-4884-9d7b-8f74db151d01" />


## Known minor items
- On very narrow screens, a full date picker can crowd a long header title. Usage already uses this same header pattern; browser visual validation was unavailable locally.

## Linear
- [x] Override Linear Check