### PR TITLE
refactor(opal): suppress the folded tab tooltip instead of controlling it

### DIFF
--- a/web/lib/opal/src/components/buttons/sidebar-tab/README.md
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/README.md
@@ -29,7 +29,7 @@ The label stays in the DOM while folded. It is hidden with `visibility: hidden`,
 
 Pass `folded` only to override the sidebar — outside a sidebar, in Storybook, or in a skeleton. It sets `data-folded` on the tab itself, which wins over the sidebar.
 
-The folded-name tooltip is the one part that stays in JS: CSS cannot arm a tooltip. It lives in a small wrapper that subscribes to the fold state on the tab's behalf, so a fold re-renders the wrapper and nothing below it.
+The folded-name tooltip is the one part that stays in JS: CSS cannot arm a tooltip. It lives in a small wrapper that subscribes to the fold state on the tab's behalf, so a fold re-renders the wrapper and nothing below it. The wrapper keeps the tooltip mounted and passes `suppressed` while the tab is unfolded, so hover stays Radix's to track and an unfolded tab holds no hover state of its own.
 
 ## Props
 

--- a/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
@@ -72,7 +72,7 @@ interface FoldedTooltipProps {
   /** Explicit fold state. Falls back to the enclosing sidebar's. */
   folded?: boolean;
 
-  children: React.ReactElement<React.DOMAttributes<HTMLElement>>;
+  children: React.ReactElement;
 }
 
 /**
@@ -83,44 +83,20 @@ interface FoldedTooltipProps {
  * not. On a fold toggle React re-renders this wrapper alone — `children` is
  * the same element it received before, so the tab below it never re-renders.
  *
- * The tooltip stays mounted and is gated by `open` instead of being added and
- * removed. Changing the tree shape on a fold would remount the tab and cut the
- * label's fade short.
+ * The tooltip stays mounted and is suppressed while unfolded instead of being
+ * added and removed. Dropping it would change the tree shape on a fold, which
+ * remounts the tab and cuts the label's fade short.
  */
 function FoldedTooltip({ label, folded, children }: FoldedTooltipProps) {
   const foldedFromSidebar = useSidebarFolded();
-  const [hovered, setHovered] = React.useState(false);
 
   const effectiveFolded = folded ?? foldedFromSidebar;
 
-  /* Radix compares every open change against the `open` prop and drops the
-  ones that already match it. While the tab is unfolded `open` is false, so the
-  close that follows a hover never reaches `setHovered` and `hovered` stays
-  true. Folding the sidebar would then show the tooltip for a tab the pointer
-  left long ago. Clear the state from the trigger instead. While folded, `open`
-  tracks `hovered`, so Radix reports the close itself — leave it alone there and
-  keep its grace area for a pointer moving onto the tooltip.
-
-  TODO(@jamison): this patches a mismatch instead of removing it. Controlling
-  `open` with a value that is not the hover state is what makes Radix drop the
-  close. A `suppressed` prop on `Tooltip` — one that keeps the trigger mounted
-  but renders no content — would let this component drop `hovered`, `open`, and
-  the `cloneElement` below, and let Radix track the pointer on its own. */
-  const clearStaleHover = React.useCallback(() => {
-    if (!effectiveFolded) setHovered(false);
-  }, [effectiveFolded]);
-
+  /* `suppressed`, not a controlled `open`: hover stays Radix's to track, so an
+  unfolded tab keeps no hover state of its own that a later fold could act on. */
   return (
-    <Tooltip
-      tooltip={label}
-      side="right"
-      open={effectiveFolded && hovered}
-      onOpenChange={setHovered}
-    >
-      {React.cloneElement(children, {
-        onPointerLeave: clearStaleHover,
-        onBlur: clearStaleHover,
-      })}
+    <Tooltip tooltip={label} side="right" suppressed={!effectiveFolded}>
+      {children}
     </Tooltip>
   );
 }

--- a/web/lib/opal/src/components/tooltip/README.md
+++ b/web/lib/opal/src/components/tooltip/README.md
@@ -5,8 +5,8 @@
 A minimal tooltip wrapper that shows content on hover. When `tooltip` is `undefined`, children
 are returned as-is with no wrapping. Uses Radix Tooltip primitives internally.
 
-Supports both uncontrolled (default hover behavior) and controlled (`open` + `onOpenChange`)
-modes.
+Hover is Radix's to track. There is no controlled `open` — use `suppressed` to turn a tooltip
+off while keeping the trigger mounted.
 
 ## Props
 
@@ -15,8 +15,6 @@ modes.
 | `tooltip` | `ReactNode \| RichStr` | — | Tooltip content. `string`/`RichStr` rendered via `Text`; `ReactNode` rendered as-is. `undefined` = no tooltip. |
 | `side` | `"top" \| "bottom" \| "left" \| "right"` | `"right"` | Which side the tooltip appears on |
 | `align` | `"start" \| "center" \| "end"` | `"center"` | Alignment along the tooltip's side axis |
-| `open` | `boolean` | — | Controlled open state. When omitted, uses default hover behavior. |
-| `onOpenChange` | `(open: boolean) => void` | — | Callback when open state changes. Use with `open` for controlled mode. |
 | `suppressed` | `boolean` | `false` | Shows nothing on hover, but keeps the trigger mounted |
 | `delayDuration` | `number` | — | Delay in ms before the tooltip appears on hover |
 | `sideOffset` | `number` | `4` | Distance in pixels between the trigger and the tooltip |
@@ -26,15 +24,8 @@ modes.
 ```tsx
 import { Tooltip } from "@opal/components";
 
-// Uncontrolled (default hover behavior)
 <Tooltip tooltip="Delete this item">
   <Button icon={SvgTrash} />
-</Tooltip>
-
-// Controlled
-const [isOpen, setIsOpen] = useState(false);
-<Tooltip tooltip="Details" open={isOpen} onOpenChange={setIsOpen}>
-  <Button icon={SvgInfo} />
 </Tooltip>
 
 // Conditional — no tooltip when undefined
@@ -55,6 +46,10 @@ const [isOpen, setIsOpen] = useState(false);
 - `string` and `RichStr` content is rendered via `Text font="secondary-body" color="inherit"`.
 - `ReactNode` content is rendered as-is for custom tooltip layouts.
 - The `opal-tooltip` CSS class provides z-indexing, animations, and a `max-width: 20rem` cap.
-- Prefer `suppressed` over dropping `tooltip` when the tooltip comes and goes during the life of
-  the trigger. Dropping `tooltip` returns children bare, and the change of tree shape remounts
-  them — which restarts any animation or transition they hold.
+- There is no controlled `open`. Radix drops any open change that already matches the value it
+  was given, so a caller that gates `open` on something other than the hover state stops hearing
+  about closes and holds a hover that ended.
+- Dropping `tooltip` returns children bare. The tree shape changes, so the children remount. Use
+  `suppressed` when the children hold state that is tied to the node: a ref that a measurement or
+  an observer reads, a running animation, or focus. A remount costs nothing otherwise, so a plain
+  conditional stays right for the usual "no tooltip in this state" case.

--- a/web/lib/opal/src/components/tooltip/README.md
+++ b/web/lib/opal/src/components/tooltip/README.md
@@ -17,6 +17,7 @@ modes.
 | `align` | `"start" \| "center" \| "end"` | `"center"` | Alignment along the tooltip's side axis |
 | `open` | `boolean` | — | Controlled open state. When omitted, uses default hover behavior. |
 | `onOpenChange` | `(open: boolean) => void` | — | Callback when open state changes. Use with `open` for controlled mode. |
+| `suppressed` | `boolean` | `false` | Shows nothing on hover, but keeps the trigger mounted |
 | `delayDuration` | `number` | — | Delay in ms before the tooltip appears on hover |
 | `sideOffset` | `number` | `4` | Distance in pixels between the trigger and the tooltip |
 
@@ -40,6 +41,11 @@ const [isOpen, setIsOpen] = useState(false);
 <Tooltip tooltip={isDisabled ? "Not available" : undefined}>
   <Button>Action</Button>
 </Tooltip>
+
+// Suppressed — same tree, nothing on hover
+<Tooltip tooltip="Rename" suppressed={!isCollapsed}>
+  <Button icon={SvgEdit} />
+</Tooltip>
 ```
 
 ## Notes
@@ -49,3 +55,6 @@ const [isOpen, setIsOpen] = useState(false);
 - `string` and `RichStr` content is rendered via `Text font="secondary-body" color="inherit"`.
 - `ReactNode` content is rendered as-is for custom tooltip layouts.
 - The `opal-tooltip` CSS class provides z-indexing, animations, and a `max-width: 20rem` cap.
+- Prefer `suppressed` over dropping `tooltip` when the tooltip comes and goes during the life of
+  the trigger. Dropping `tooltip` returns children bare, and the change of tree shape remounts
+  them — which restarts any animation or transition they hold.

--- a/web/lib/opal/src/components/tooltip/Tooltip.test.tsx
+++ b/web/lib/opal/src/components/tooltip/Tooltip.test.tsx
@@ -1,0 +1,66 @@
+// `suppressed` keeps the trigger mounted and shows nothing on hover. The
+// trigger must also forget the hover, so that lifting the suppression later
+// does not reveal a tooltip for a pointer that has moved on.
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { useState } from "react";
+import { render, screen, userEvent, waitFor } from "@tests/setup/test-utils";
+import { Tooltip } from "@opal/components";
+
+/** Opens on the first hover, so tests do not wait out the default delay. */
+function Harness({ suppressed }: { suppressed: boolean }) {
+  return (
+    <TooltipPrimitive.Provider delayDuration={0}>
+      <Tooltip tooltip="Rename" suppressed={suppressed}>
+        <button>Trigger</button>
+      </Tooltip>
+    </TooltipPrimitive.Provider>
+  );
+}
+
+it("shows the tooltip on hover", async () => {
+  const user = userEvent.setup();
+  render(<Harness suppressed={false} />);
+
+  await user.hover(screen.getByRole("button", { name: "Trigger" }));
+
+  await waitFor(() => {
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+  });
+});
+
+it("shows nothing on hover while suppressed", async () => {
+  const user = userEvent.setup();
+  render(<Harness suppressed />);
+
+  await user.hover(screen.getByRole("button", { name: "Trigger" }));
+
+  await waitFor(() => {
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+});
+
+it("does not reveal a hover the pointer already left when suppression lifts", async () => {
+  const user = userEvent.setup();
+
+  function ToggleHarness() {
+    const [suppressed, setSuppressed] = useState(true);
+    return (
+      <>
+        <Harness suppressed={suppressed} />
+        <button onClick={() => setSuppressed(false)}>Unsuppress</button>
+      </>
+    );
+  }
+
+  render(<ToggleHarness />);
+
+  const trigger = screen.getByRole("button", { name: "Trigger" });
+  await user.hover(trigger);
+  await user.unhover(trigger);
+
+  await user.click(screen.getByRole("button", { name: "Unsuppress" }));
+
+  await waitFor(() => {
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+});

--- a/web/lib/opal/src/components/tooltip/components.tsx
+++ b/web/lib/opal/src/components/tooltip/components.tsx
@@ -30,23 +30,12 @@ interface TooltipProps {
   align?: TooltipAlign;
 
   /**
-   * Controlled open state. When provided, the tooltip's visibility is
-   * externally managed. When omitted, the tooltip uses Radix's default
-   * hover-based open handling.
-   */
-  open?: boolean;
-
-  /**
-   * Callback fired when the tooltip's open state changes. Use with `open`
-   * for controlled behavior.
-   */
-  onOpenChange?: (open: boolean) => void;
-
-  /**
    * Shows nothing on hover, but keeps the trigger in place.
    *
-   * Use this to turn a tooltip off for a while. Dropping `tooltip` instead
-   * returns `children` bare, and the change of tree shape remounts them.
+   * Use this when the children hold state that is tied to the node: a ref
+   * that a measurement reads, a running animation, or focus. Dropping
+   * `tooltip` instead returns `children` bare, and the change of tree shape
+   * remounts them.
    */
   suppressed?: boolean;
 
@@ -76,21 +65,23 @@ interface TooltipProps {
  * Renders nothing extra when `tooltip` is `undefined` — just passes children
  * through. When `tooltip` is provided, wraps children with a Radix tooltip.
  *
- * Supports both uncontrolled (default hover behavior) and controlled
- * (`open` + `onOpenChange`) modes.
+ * Hover is Radix's to track. There is deliberately no controlled `open`: Radix
+ * drops any open change that already matches the value it was given, so a
+ * caller that gates `open` on something other than the hover state stops
+ * hearing about closes and holds a hover that ended. Use `suppressed` to turn
+ * a tooltip off instead.
  *
  * @example
  * ```tsx
  * import { Tooltip } from "@opal/components";
  *
- * // Uncontrolled (default)
  * <Tooltip tooltip="Delete this item">
  *   <Button icon={SvgTrash} />
  * </Tooltip>
  *
- * // Controlled
- * <Tooltip tooltip="Details" open={isOpen} onOpenChange={setIsOpen}>
- *   <Button icon={SvgInfo} />
+ * // Off for now, but the trigger stays put
+ * <Tooltip tooltip="Rename" suppressed={!isCollapsed}>
+ *   <Button icon={SvgEdit} />
  * </Tooltip>
  * ```
  */
@@ -98,8 +89,6 @@ function Tooltip({
   tooltip,
   side = "right",
   align = "center",
-  open,
-  onOpenChange,
   suppressed,
   delayDuration,
   sideOffset = 4,
@@ -118,8 +107,6 @@ function Tooltip({
 
   return (
     <TooltipPrimitive.Root
-      open={open}
-      onOpenChange={onOpenChange}
       delayDuration={delayDuration}
       /* Radix closes on a pointer that leaves the trigger from the content
       itself, which tracks the pointer across the gap between the two. A

--- a/web/lib/opal/src/components/tooltip/components.tsx
+++ b/web/lib/opal/src/components/tooltip/components.tsx
@@ -43,6 +43,14 @@ interface TooltipProps {
   onOpenChange?: (open: boolean) => void;
 
   /**
+   * Shows nothing on hover, but keeps the trigger in place.
+   *
+   * Use this to turn a tooltip off for a while. Dropping `tooltip` instead
+   * returns `children` bare, and the change of tree shape remounts them.
+   */
+  suppressed?: boolean;
+
+  /**
    * Delay in milliseconds before the tooltip appears on hover.
    * Passed to `TooltipPrimitive.Root`.
    */
@@ -92,6 +100,7 @@ function Tooltip({
   align = "center",
   open,
   onOpenChange,
+  suppressed,
   delayDuration,
   sideOffset = 4,
   children,
@@ -112,18 +121,26 @@ function Tooltip({
       open={open}
       onOpenChange={onOpenChange}
       delayDuration={delayDuration}
+      /* Radix closes on a pointer that leaves the trigger from the content
+      itself, which tracks the pointer across the gap between the two. A
+      suppressed tooltip renders no content, so the trigger has to do the
+      closing. Without this the tooltip stays open in Radix's eyes, and it
+      appears the moment the suppression lifts. */
+      disableHoverableContent={suppressed}
     >
       <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
-      <TooltipPrimitive.Portal>
-        <TooltipPrimitive.Content
-          className="opal-tooltip"
-          side={side}
-          align={align}
-          sideOffset={sideOffset}
-        >
-          {content}
-        </TooltipPrimitive.Content>
-      </TooltipPrimitive.Portal>
+      {!suppressed && (
+        <TooltipPrimitive.Portal>
+          <TooltipPrimitive.Content
+            className="opal-tooltip"
+            side={side}
+            align={align}
+            sideOffset={sideOffset}
+          >
+            {content}
+          </TooltipPrimitive.Content>
+        </TooltipPrimitive.Portal>
+      )}
     </TooltipPrimitive.Root>
   );
 }


### PR DESCRIPTION
Follow-up to #13950 — resolves the TODO it left behind.

## What

#13950 keeps a `hovered` state in `FoldedTooltip` and passes `open={folded && hovered}` to Radix. Controlling `open` with a value that is not the hover state is what makes Radix drop the close in the first place, so that fix has to patch the state back from the trigger with `cloneElement`.

This adds `suppressed` to the opal `Tooltip`: it keeps `Root` and `Trigger` mounted but renders no `Portal`/`Content`. `FoldedTooltip` then needs no state, no `open`, no `onOpenChange`, and no `cloneElement` — hover stays Radix's to track, and an unfolded tab holds no hover state a later fold could act on.

```tsx
function FoldedTooltip({ label, folded, children }: FoldedTooltipProps) {
  const foldedFromSidebar = useSidebarFolded();
  const effectiveFolded = folded ?? foldedFromSidebar;
  return (
    <Tooltip tooltip={label} side="right" suppressed={!effectiveFolded}>
      {children}
    </Tooltip>
  );
}
```

The trigger still stays mounted across a fold, so the label's fade is not cut short — the reason the original refactor avoided dropping `tooltip` outright.

## One non-obvious part

Radix closes on a pointer that leaves the trigger from the *content*, which tracks the pointer across the gap between the two; `onTriggerLeave` only closes directly when `disableHoverableContent` is set. A suppressed tooltip has no content, so without that flag Radix never sees the leave and the tooltip appears the moment suppression lifts — the same bug in a new place. `Tooltip` therefore passes `disableHoverableContent={suppressed}`. Unsuppressed tooltips keep their grace area.

## Tests

- New `Tooltip.test.tsx`: shows on hover, shows nothing while suppressed, and does not reveal a stale hover when suppression lifts.
- The `SidebarTab` regression test from #13950 is unchanged and still passes.

Both files fail if `disableHoverableContent` is removed, so that line is covered rather than assumed. 9 tests pass across the two suites; `tsc`, oxlint, and oxfmt are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses the folded tab tooltip instead of controlling it, fixing stale hovers and preserving tab animations. Removes controlled `open`/`onOpenChange` from `Tooltip` so hover is always Radix-managed.

- `Tooltip`: adds `suppressed`; keeps trigger mounted and renders no `Portal/Content` when true; sets `disableHoverableContent` while suppressed so Radix clears hover and doesn’t reopen on unsuppress; default behavior unchanged.
- `FoldedTooltip`: drops state, `open`, `onOpenChange`, and `cloneElement`; uses `suppressed={!effectiveFolded}` so an unfolded tab holds no hover state.
- Tests: new `Tooltip.test.tsx` covers hover, suppression, and no stale hover; existing `SidebarTab` regression stays green.
- Docs: remove controlled props and examples; document `suppressed` and when to prefer it over dropping `tooltip`.
- Migration: No in-repo callers used `open`/`onOpenChange`. If you previously controlled `Tooltip`, stop passing them; rely on default hover and use `suppressed` to disable without remounting the trigger.

<sup>Written for commit 71ace3d65894fa83ae29ca32048d4e7efd6f2853. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

