### PR TITLE
fix(web): keep the groups cell observing its container

### DIFF
--- a/web/src/views/admin/UsersPage/GroupsCell.test.tsx
+++ b/web/src/views/admin/UsersPage/GroupsCell.test.tsx
@@ -1,0 +1,56 @@
+// The cell measures how many group tags fit, and re-measures when the
+// container width changes. The ResizeObserver that reports those changes is
+// attached once per `groups` value, so the observed node must survive the
+// render that follows the first measurement.
+import { render, screen, waitFor } from "@tests/setup/test-utils";
+import { UserRole, UserStatus } from "@/lib/types";
+import GroupsCell from "./GroupsCell";
+import type { UserRow } from "./interfaces";
+
+/** Every node handed to a ResizeObserver, in observe order. */
+const observedNodes: Element[] = [];
+
+beforeEach(() => {
+  observedNodes.length = 0;
+  global.ResizeObserver = class {
+    observe(node: Element) {
+      observedNodes.push(node);
+    }
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+const user: UserRow = {
+  id: "1",
+  email: "user@example.com",
+  role: UserRole.BASIC,
+  status: UserStatus.ACTIVE,
+  is_active: true,
+  is_scim_synced: false,
+  craft_enabled: null,
+  personal_name: null,
+  created_at: null,
+  updated_at: null,
+  groups: [],
+};
+
+it("keeps observing the container after the overflow tooltip appears", async () => {
+  const groups = [
+    { id: 1, name: "Alpha" },
+    { id: 2, name: "Beta" },
+  ];
+
+  render(<GroupsCell groups={groups} user={user} onMutate={() => {}} />);
+
+  // jsdom reports zero widths, so one tag "fits" and the rest overflow. The
+  // "+N" counter marks the end of the measurement phase.
+  await waitFor(() => {
+    expect(screen.getByText("+1")).toBeInTheDocument();
+  });
+
+  const observed = observedNodes[observedNodes.length - 1];
+  expect(observed).toBeDefined();
+  // A detached node reports no resizes, so the cell would stop re-measuring.
+  expect(observed!.isConnected).toBe(true);
+});

--- a/web/src/views/admin/UsersPage/GroupsCell.tsx
+++ b/web/src/views/admin/UsersPage/GroupsCell.tsx
@@ -153,10 +153,13 @@ export default function GroupsCell({
               </Text>
             </div>
           ) : (
+            /* Suppressed, not dropped: dropping the tooltip remounts the row,
+            which re-attaches the ref the overflow measurement reads. */
             <Tooltip
               side="bottom"
               align="start"
-              tooltip={hasOverflow ? allGroupsTooltip : undefined}
+              tooltip={allGroupsTooltip}
+              suppressed={!hasOverflow}
               delayDuration={200}
             >
               <div


### PR DESCRIPTION
## Description

The groups cell in the users table measures how many group tags fit, then re-measures when the container width changes. A `ResizeObserver` reports those changes. Its effect is keyed on `groups`, so it attaches the node once.

The overflow tooltip was dropped while nothing overflowed:

```tsx
tooltip={hasOverflow ? allGroupsTooltip : undefined}
```

A dropped tooltip returns the child bare, and the change of tree shape remounts it. The remount does not re-run the observer effect, so the observer holds a node that is no longer in the document. The cell then stops re-measuring on resize.

This PR passes `suppressed={!hasOverflow}` instead. The trigger stays mounted, so the observed node stays connected. `suppressed` comes from #13953.

## Scope

Two other call sites use the same conditional pattern: `input-select` and `SourceTag`. Both re-measure from a `window` resize listener, not from a node-bound observer, so the remount costs them nothing. They keep the conditional.

## How Has This Been Tested?

`web/src/views/admin/UsersPage/GroupsCell.test.tsx` records every node handed to a `ResizeObserver` and asserts the last one is still connected after the overflow counter appears. It fails on the conditional version and passes with `suppressed`.