### PR TITLE
refactor(web): inline single-use sidebar JSX variables

### DIFF
--- a/web/src/app/craft/components/SideBar.tsx
+++ b/web/src/app/craft/components/SideBar.tsx
@@ -308,56 +308,6 @@ const MemoizedBuildSidebarInner = memo(() => {
     [requestNavigation, router, returnToMainAgent]
   );
 
-  const newBuildButton = (
-    <SidebarTab icon={SvgEditBig} onClick={handleNewBuild}>
-      Start Crafting
-    </SidebarTab>
-  );
-
-  const scheduledTasksPanel = (
-    <SidebarTab
-      icon={SvgClock}
-      onClick={() => navigate(CRAFT_TASKS_PATH)}
-      selected={pathname.startsWith(CRAFT_TASKS_PATH)}
-    >
-      Scheduled Tasks
-    </SidebarTab>
-  );
-
-  const appsTab = (
-    <SidebarTab
-      icon={SvgPlug}
-      onClick={() => navigate(CRAFT_APPS_PATH)}
-      selected={pathname.startsWith(CRAFT_APPS_PATH)}
-    >
-      Apps
-    </SidebarTab>
-  );
-
-  const skillsPanel = (
-    <SidebarTab
-      icon={SvgBlocks}
-      onClick={() => navigate(CRAFT_SKILLS_PATH)}
-      selected={pathname.startsWith(CRAFT_SKILLS_PATH)}
-    >
-      Skills
-    </SidebarTab>
-  );
-
-  const backToChatButton = (
-    <SidebarTab icon={SvgArrowLeft} onClick={() => navigate("/app")}>
-      Back to Chat
-    </SidebarTab>
-  );
-
-  const footer = (
-    <div>
-      {backToChatButton}
-      <OpencodeDebugLogsButton folded={folded} />
-      <AccountPopover />
-    </div>
-  );
-
   const showLogoWhenFolded = useShowLogoWhenFolded();
 
   return (
@@ -367,10 +317,30 @@ const MemoizedBuildSidebarInner = memo(() => {
         showLogoWhenFolded={showLogoWhenFolded}
       >
         <div className="flex flex-col gap-0.5">
-          {newBuildButton}
-          {scheduledTasksPanel}
-          {skillsPanel}
-          {appsTab}
+          <SidebarTab icon={SvgEditBig} onClick={handleNewBuild}>
+            Start Crafting
+          </SidebarTab>
+          <SidebarTab
+            icon={SvgClock}
+            onClick={() => navigate(CRAFT_TASKS_PATH)}
+            selected={pathname.startsWith(CRAFT_TASKS_PATH)}
+          >
+            Scheduled Tasks
+          </SidebarTab>
+          <SidebarTab
+            icon={SvgBlocks}
+            onClick={() => navigate(CRAFT_SKILLS_PATH)}
+            selected={pathname.startsWith(CRAFT_SKILLS_PATH)}
+          >
+            Skills
+          </SidebarTab>
+          <SidebarTab
+            icon={SvgPlug}
+            onClick={() => navigate(CRAFT_APPS_PATH)}
+            selected={pathname.startsWith(CRAFT_APPS_PATH)}
+          >
+            Apps
+          </SidebarTab>
         </div>
       </SidebarLayouts.Header>
       <SidebarLayouts.Body scrollKey="build-sidebar">
@@ -410,7 +380,15 @@ const MemoizedBuildSidebarInner = memo(() => {
           </>
         )}
       </SidebarLayouts.Body>
-      <SidebarLayouts.Footer>{footer}</SidebarLayouts.Footer>
+      <SidebarLayouts.Footer>
+        <div>
+          <SidebarTab icon={SvgArrowLeft} onClick={() => navigate("/app")}>
+            Back to Chat
+          </SidebarTab>
+          <OpencodeDebugLogsButton folded={folded} />
+          <AccountPopover />
+        </div>
+      </SidebarLayouts.Footer>
     </SidebarLayouts.Root>
   );
 });

--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -491,45 +491,6 @@ export default function AppSidebar() {
     combinedSettingsData?.disable_default_assistant && currentAgent
       ? `/app?agentId=${currentAgent.id}`
       : "/app";
-  const newSessionButton = (
-    <div data-testid="AppSidebar/new-session">
-      <SidebarTab
-        icon={SvgEditBig}
-        href={newSessionHref}
-        selected={activeSidebarTab.isNewSession()}
-        onClick={() => {
-          if (!activeSidebarTab.isNewSession()) return;
-          setAppMode(defaultAppMode);
-          reset();
-        }}
-      >
-        New Session
-      </SidebarTab>
-    </div>
-  );
-
-  const buildButton = (
-    <div data-testid="AppSidebar/build">
-      <SidebarTab
-        icon={SvgDevKit}
-        href={CRAFT_PATH}
-        onClick={() => track(AnalyticsEvent.CLICKED_CRAFT_IN_SIDEBAR)}
-      >
-        Craft
-      </SidebarTab>
-    </div>
-  );
-
-  const searchChatsButton = (
-    <ChatSearchCommandMenu
-      trigger={(open) => (
-        <SidebarTab icon={SvgSearchMenu} onClick={open}>
-          Search Chats
-        </SidebarTab>
-      )}
-    />
-  );
-
   const moreAgentsButton = (
     <div data-testid="AppSidebar/more-agents">
       <SidebarTab
@@ -561,24 +522,6 @@ export default function AppSidebar() {
   const handleShowBuildIntro = useCallback(() => {
     setShowIntroAnimation(true);
   }, []);
-
-  const settingsButton = (
-    <div>
-      {(isAdmin || isCurator) && (
-        <SidebarTab
-          href={
-            isCurator ? "/admin/agents" : "/admin/configuration/language-models"
-          }
-          icon={SvgSettings}
-        >
-          {isAdmin ? "Admin Panel" : "Curator Panel"}
-        </SidebarTab>
-      )}
-      <AccountPopover
-        onShowBuildIntro={isOnyxCraftEnabled ? handleShowBuildIntro : undefined}
-      />
-    </div>
-  );
 
   return (
     <>
@@ -647,9 +590,38 @@ export default function AppSidebar() {
           showLogoWhenFolded={showLogoWhenFolded}
           renderAppLogo={renderSidebarLogo}
         >
-          {newSessionButton}
-          {searchChatsButton}
-          {isOnyxCraftEnabled && buildButton}
+          <div data-testid="AppSidebar/new-session">
+            <SidebarTab
+              icon={SvgEditBig}
+              href={newSessionHref}
+              selected={activeSidebarTab.isNewSession()}
+              onClick={() => {
+                if (!activeSidebarTab.isNewSession()) return;
+                setAppMode(defaultAppMode);
+                reset();
+              }}
+            >
+              New Session
+            </SidebarTab>
+          </div>
+          <ChatSearchCommandMenu
+            trigger={(open) => (
+              <SidebarTab icon={SvgSearchMenu} onClick={open}>
+                Search Chats
+              </SidebarTab>
+            )}
+          />
+          {isOnyxCraftEnabled && (
+            <div data-testid="AppSidebar/build">
+              <SidebarTab
+                icon={SvgDevKit}
+                href={CRAFT_PATH}
+                onClick={() => track(AnalyticsEvent.CLICKED_CRAFT_IN_SIDEBAR)}
+              >
+                Craft
+              </SidebarTab>
+            </div>
+          )}
           {folded && moreAgentsButton}
           {folded && newProjectButton}
         </SidebarLayouts.Header>
@@ -717,7 +689,27 @@ export default function AppSidebar() {
           )}
         </SidebarLayouts.Body>
 
-        <SidebarLayouts.Footer>{settingsButton}</SidebarLayouts.Footer>
+        <SidebarLayouts.Footer>
+          <div>
+            {(isAdmin || isCurator) && (
+              <SidebarTab
+                href={
+                  isCurator
+                    ? "/admin/agents"
+                    : "/admin/configuration/language-models"
+                }
+                icon={SvgSettings}
+              >
+                {isAdmin ? "Admin Panel" : "Curator Panel"}
+              </SidebarTab>
+            )}
+            <AccountPopover
+              onShowBuildIntro={
+                isOnyxCraftEnabled ? handleShowBuildIntro : undefined
+              }
+            />
+          </div>
+        </SidebarLayouts.Footer>
       </SidebarLayouts.Root>
     </>
   );


### PR DESCRIPTION
## Summary

f0918b956f removed the `useMemo` wrappers around several sidebar components. Each one stayed assigned to a local variable, which no longer serves a purpose. This moves the single-use ones into the render return.

**`web/src/app/craft/components/SideBar.tsx`** — all six were single-use: `newBuildButton`, `scheduledTasksPanel`, `skillsPanel`, `appsTab` go into `SidebarLayouts.Header`; `footer` (with `backToChatButton`) goes into `SidebarLayouts.Footer`.

**`web/src/sections/sidebar/AppSidebar.tsx`** — `newSessionButton`, `searchChatsButton`, `buildButton` go into the header; `settingsButton` goes into the footer. `buildButton` keeps its `isOnyxCraftEnabled` guard as a JSX conditional.

Kept as variables:
- `moreAgentsButton` and `newProjectButton` — each renders in two places, so inlining would duplicate the JSX.
- `newSessionHref` — a plain value, not a component.

No behavior change.

## Testing

`oxfmt` and `oxlint` pass. The `TypeScript type check` hook fails, but that is a pre-existing repo-wide failure (`Button` `variant`/`prominence` props across many files); the two errors that touch these files are unchanged on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inline single‑use sidebar JSX variables to reduce indirection after removing memoization. Old: sidebar items assigned to local consts; New: items inlined in render returns; no behavior change.

- SideBar.tsx: inlined Start Crafting, Scheduled Tasks, Skills, and Apps into `SidebarLayouts.Header`; inlined footer with Back to Chat, `OpencodeDebugLogsButton`, and `AccountPopover`.
- AppSidebar.tsx: inlined New Session, Search Chats, and conditional Craft into header; inlined footer with Admin/Curator Panel button and `AccountPopover`. Kept `moreAgentsButton` and `newProjectButton` as variables (rendered twice) and `newSessionHref` as a value. Preserves the `isOnyxCraftEnabled` guard and existing click/selected behaviors.

<sup>Written for commit 09afa8c0f812231b4a50d0ca7d35e901075d696d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

