### PR TITLE
refactor(web): derive the active agent instead of latching it in state

### DIFF
--- a/web/src/app/app/services/lib.tsx
+++ b/web/src/app/app/services/lib.tsx
@@ -539,7 +539,7 @@ const PARAMS_TO_SKIP = [
   SEARCH_PARAM_NAMES.TITLE,
   // only use these if explicitly passed in
   SEARCH_PARAM_NAMES.CHAT_ID,
-  SEARCH_PARAM_NAMES.PERSONA_ID,
+  SEARCH_PARAM_NAMES.AGENT_ID,
   SEARCH_PARAM_NAMES.PROJECT_ID,
   // do not persist project context in the URL after navigation
   "projectid",
@@ -561,7 +561,7 @@ export function buildChatUrl(
     );
   }
   if (personaId !== null) {
-    finalSearchParams.push(`${SEARCH_PARAM_NAMES.PERSONA_ID}=${personaId}`);
+    finalSearchParams.push(`${SEARCH_PARAM_NAMES.AGENT_ID}=${personaId}`);
   }
 
   existingSearchParams?.forEach((value, key) => {

--- a/web/src/app/app/services/searchParams.ts
+++ b/web/src/app/app/services/searchParams.ts
@@ -4,7 +4,7 @@ import { ReadonlyURLSearchParams } from "next/navigation";
 export const SEARCH_PARAM_NAMES = {
   CHAT_ID: "chatId",
   SEARCH_ID: "searchId",
-  PERSONA_ID: "agentId",
+  AGENT_ID: "agentId",
   PROJECT_ID: "projectId",
   ALL_MY_DOCUMENTS: "allMyDocuments",
   // overrides

--- a/web/src/app/nrf/NRFPage.tsx
+++ b/web/src/app/nrf/NRFPage.tsx
@@ -94,8 +94,7 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
   }, [lastFailedFiles, clearLastFailedFiles]);
 
   // Assistant controller
-  const { selectedAgent, setSelectedAgentFromId, liveAgent } =
-    useAgentController(undefined, () => {});
+  const { liveAgent } = useAgentController(undefined);
 
   // LLM manager for model selection.
   // - currentChatSession: undefined because NRF always starts new chats
@@ -136,7 +135,7 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
   // Deep research toggle
   const { deepResearchEnabled, toggleDeepResearch } = useDeepResearchToggle({
     chatSessionId: existingChatSessionId,
-    agentId: selectedAgent?.id,
+    agentId: liveAgent?.id,
   });
 
   // State
@@ -281,7 +280,6 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
       selectedDocuments: [],
       searchParams: searchParams!,
       resetInputBar,
-      setSelectedAgentFromId,
     });
 
   // Chat session controller for loading sessions
@@ -290,7 +288,6 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
     searchParams: searchParams!,
     filterManager,
     firstMessage: undefined,
-    setSelectedAgentFromId,
     setSelectedDocuments: () => {}, // No-op: NRF doesn't support document selection
     setCurrentMessageFiles,
     chatSessionIdRef: { current: null },

--- a/web/src/app/nrf/NRFPage.tsx
+++ b/web/src/app/nrf/NRFPage.tsx
@@ -22,7 +22,7 @@ import { useProjectsContext } from "@/providers/ProjectsContext";
 import useDeepResearchToggle from "@/hooks/useDeepResearchToggle";
 import useChatController from "@/hooks/useChatController";
 import useChatSessionController from "@/hooks/useChatSessionController";
-import { useAgentController } from "@/lib/agents/hooks";
+import { useLiveAgent } from "@/lib/agents/hooks";
 import {
   useCurrentChatState,
   useCurrentMessageHistory,
@@ -94,7 +94,7 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
   }, [lastFailedFiles, clearLastFailedFiles]);
 
   // Assistant controller
-  const { liveAgent } = useAgentController(undefined);
+  const liveAgent = useLiveAgent();
 
   // LLM manager for model selection.
   // - currentChatSession: undefined because NRF always starts new chats

--- a/web/src/hooks/appNavigation.ts
+++ b/web/src/hooks/appNavigation.ts
@@ -20,7 +20,7 @@ export function useAppRouter() {
       if (chatSessionId)
         finalParams.push(`${SEARCH_PARAM_NAMES.CHAT_ID}=${chatSessionId}`);
       else if (agentId)
-        finalParams.push(`${SEARCH_PARAM_NAMES.PERSONA_ID}=${agentId}`);
+        finalParams.push(`${SEARCH_PARAM_NAMES.AGENT_ID}=${agentId}`);
       else if (projectId)
         finalParams.push(`${SEARCH_PARAM_NAMES.PROJECT_ID}=${projectId}`);
 

--- a/web/src/hooks/useAppFocus.ts
+++ b/web/src/hooks/useAppFocus.ts
@@ -68,7 +68,7 @@ export default function useAppFocus(): AppFocus {
   const searchParams = useSearchParams();
 
   const chatId = searchParams.get(SEARCH_PARAM_NAMES.CHAT_ID);
-  const agentId = searchParams.get(SEARCH_PARAM_NAMES.PERSONA_ID);
+  const agentId = searchParams.get(SEARCH_PARAM_NAMES.AGENT_ID);
   const projectId = searchParams.get(SEARCH_PARAM_NAMES.PROJECT_ID);
 
   // Memoize on the values that determine which AppFocus is constructed.

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -116,7 +116,6 @@ interface UseChatControllerProps {
   selectedDocuments: OnyxDocument[];
   searchParams: ReadonlyURLSearchParams;
   resetInputBar: () => void;
-  setSelectedAgentFromId: (agentId: number | null) => void;
 }
 
 async function stopChatSession(chatSessionId: string): Promise<void> {
@@ -140,7 +139,6 @@ export default function useChatController({
   existingChatSessionId,
   selectedDocuments,
   resetInputBar,
-  setSelectedAgentFromId,
 }: UseChatControllerProps) {
   const pathname = usePathname();
   const router = useRouter();
@@ -1368,7 +1366,6 @@ export default function useChatController({
       selectedDocuments,
       searchParams,
       resetInputBar,
-      setSelectedAgentFromId,
       updateSelectedNodeForDocDisplay,
       currentMessageTree,
       currentChatState,
@@ -1427,14 +1424,6 @@ export default function useChatController({
       }
     };
   }, [pathname]);
-
-  // update chosen assistant if we navigate between pages
-  useEffect(() => {
-    if (currentMessageHistory.length === 0 && existingChatSessionId === null) {
-      // Select from available assistants so shared assistants appear.
-      setSelectedAgentFromId(null);
-    }
-  }, [existingChatSessionId, availableAgents, currentMessageHistory.length]);
 
   useEffect(() => {
     const handleSlackChatRedirect = async () => {

--- a/web/src/hooks/useChatSessionController.ts
+++ b/web/src/hooks/useChatSessionController.ts
@@ -48,7 +48,6 @@ interface UseChatSessionControllerProps {
   firstMessage?: string;
 
   // UI state setters
-  setSelectedAgentFromId: (agentId: number | null) => void;
   setSelectedDocuments: (documents: OnyxDocument[]) => void;
   setCurrentMessageFiles: (
     files: ProjectFile[] | ((prev: ProjectFile[]) => ProjectFile[])
@@ -81,7 +80,6 @@ export default function useChatSessionController({
   searchParams,
   filterManager,
   firstMessage,
-  setSelectedAgentFromId,
   setSelectedDocuments,
   setCurrentMessageFiles,
   chatSessionIdRef,
@@ -175,8 +173,6 @@ export default function useChatSessionController({
         // Clear the current session in the store to show intro messages
         setCurrentSession(null);
 
-        // Reset the selected agent back to default
-        setSelectedAgentFromId(null);
         updateCurrentChatSessionSharedStatus(ChatSessionSharedStatus.Private);
 
         // If we're supposed to submit on initial load, then do that here
@@ -243,7 +239,6 @@ export default function useChatSessionController({
       const isIncognito = chatSession.incognito ?? false;
       setIncognitoEnabled(isIncognito);
       setIncognitoSessionId(isIncognito ? chatSession.chat_session_id : null);
-      setSelectedAgentFromId(chatSession.persona_id);
 
       // Ensure the current session is set to the actual session ID from the response
       setCurrentSession(chatSession.chat_session_id);

--- a/web/src/hooks/useChatSessionController.ts
+++ b/web/src/hooks/useChatSessionController.ts
@@ -487,7 +487,7 @@ export default function useChatSessionController({
     }
   }, [
     existingChatSessionId,
-    searchParams?.get(SEARCH_PARAM_NAMES.PERSONA_ID),
+    searchParams?.get(SEARCH_PARAM_NAMES.AGENT_ID),
     // Note: We're intentionally not including all dependencies to avoid infinite loops
     // This effect should only run when existingChatSessionId or persona ID changes
   ]);

--- a/web/src/lib/agents/hooks.ts
+++ b/web/src/lib/agents/hooks.ts
@@ -20,7 +20,6 @@ import { pinAgents } from "@/lib/agents/svc";
 import { useUser } from "@/providers/UserProvider";
 import { useSearchParams } from "next/navigation";
 import { SEARCH_PARAM_NAMES } from "@/app/app/services/searchParams";
-import { ChatSession } from "@/app/app/interfaces";
 import { DEFAULT_AGENT_ID } from "@/lib/constants";
 import { useSettings } from "@/lib/settings/hooks";
 import {
@@ -183,130 +182,102 @@ export function usePinnedAgents() {
   };
 }
 
-// ── Current agent (URL param or chat session) ─────────────────────────────────
+// ── Agent resolution ──────────────────────────────────────────────────────────
 
 /**
- * Resolves the active agent from the URL search param, falling back to the
- * agent attached to the current chat session. Returns null when neither is
- * available or the agent list hasn't loaded yet.
+ * The id the user has actually landed on: the open chat's agent, or the one
+ * named by the URL. `undefined` when neither applies, which is the plain
+ * new-session case.
+ *
+ * The two inputs are disjoint in practice. `AGENT_ID` is stripped from the URL
+ * the moment a chat opens (`PARAMS_TO_SKIP` in `app/app/services/lib.tsx`), so
+ * a session and a URL agent never coexist under normal navigation. The session
+ * is preferred anyway, for the case of a hand-written URL carrying both: the
+ * messages already on screen came from the session's agent, and resolving to
+ * the URL's would mislabel them.
  */
-export function useCurrentAgent(): MinimalAgent | null {
-  const { agents } = useAgents();
+function useResolvedAgentId(): number | undefined {
   const searchParams = useSearchParams();
-  const agentIdRaw = searchParams?.get(SEARCH_PARAM_NAMES.PERSONA_ID);
   const { currentChatSession } = useChatSessions();
 
+  const urlAgentIdRaw = searchParams?.get(SEARCH_PARAM_NAMES.AGENT_ID);
+  const sessionAgentId = currentChatSession?.persona_id;
+
   return useMemo(() => {
-    if (agents.length === 0) return null;
-    const agentId = agentIdRaw
-      ? parseInt(agentIdRaw)
-      : currentChatSession?.persona_id;
-    if (!agentId) return null;
-    return agents.find((a) => a.id === agentId) ?? null;
-  }, [agents, agentIdRaw, currentChatSession?.persona_id]);
+    if (sessionAgentId !== undefined && sessionAgentId !== null) {
+      return sessionAgentId;
+    }
+    return urlAgentIdRaw ? parseInt(urlAgentIdRaw) : undefined;
+  }, [sessionAgentId, urlAgentIdRaw]);
 }
 
-// ── Agent controller (chat UI selection) ──────────────────────────────────────
+/**
+ * The agent the user explicitly landed on, or null when they did not pick one.
+ *
+ * Use this to answer "is this agent the one in view" — highlighting a sidebar
+ * entry, showing starter messages. For the agent a message would actually run
+ * on, use {@link useLiveAgent}, which never returns null.
+ */
+export function useSelectedAgent(): MinimalAgent | null {
+  const { agents } = useAgents();
+  const agentId = useResolvedAgentId();
+
+  return useMemo(() => {
+    if (agentId === undefined) return null;
+    return agents.find((a) => a.id === agentId) ?? null;
+  }, [agents, agentId]);
+}
 
 /**
- * The agent a new message will use, resolved by priority: the open session's
- * agent → the URL's `personaId` → the built-in default → first pinned → first
- * available. When `disable_default_assistant` is on, the built-in default
- * (id=0) is skipped in the fallback chain.
+ * The agent a new message will use: the selected one, or the Assistant, or
+ * whatever else is available. Unlike {@link useSelectedAgent} this always
+ * answers, because every message is sent against some agent — a plain chat
+ * runs on the Assistant (id 0), sent explicitly as `personaId: 0`.
+ *
+ * `disable_default_assistant` excludes the Assistant from the fallback, so an
+ * install with no other agent resolves to `undefined` and the caller shows its
+ * no-agent state rather than silently using the agent the admin disabled.
  *
  * This is a derivation, not state. Every input is shared — the URL, the open
- * session, and the SWR-backed agent lists — so two callers always agree, and
- * the answer re-resolves on navigation.
- *
- * It used to hold the choice in `useState`, latched by a one-shot effect the
- * first time agents loaded. That made it path-dependent, so callers had to
- * write the new agent back in on every navigation and session load, and the
- * value could not be read anywhere but the component that owned it.
+ * session, the SWR-backed agent list — so two callers always agree, and the
+ * answer re-resolves on navigation.
  */
-export function useAgentController(
-  selectedChatSession: ChatSession | null | undefined
-) {
-  const searchParams = useSearchParams();
-  const { agents: availableAgents } = useAgents();
-  const { pinnedAgents } = usePinnedAgents();
+export function useLiveAgent(): MinimalAgent | undefined {
+  const selectedAgent = useSelectedAgent();
+  const { agents } = useAgents();
   const settings = useSettings();
-  const disableDefaultAssistant = settings.disable_default_assistant ?? false;
+  const assistantDisabled = settings.disable_default_assistant ?? false;
 
-  const urlAgentIdRaw = searchParams?.get(SEARCH_PARAM_NAMES.PERSONA_ID);
-  const urlAgentId = urlAgentIdRaw ? parseInt(urlAgentIdRaw) : undefined;
-  const existingChatSessionAgentId = selectedChatSession?.persona_id;
-
-  const liveAgent: MinimalAgent | undefined = useMemo(() => {
-    // The session wins over the URL: an open chat is pinned to the agent it
-    // was created with. An id that matches no available agent falls through,
-    // which is how a deleted or inaccessible agent degrades.
-    const chosen =
-      existingChatSessionAgentId !== undefined
-        ? availableAgents.find((a) => a.id === existingChatSessionAgentId)
-        : urlAgentId !== undefined
-          ? availableAgents.find((a) => a.id === urlAgentId)
-          : undefined;
-    if (chosen) return chosen;
-
-    if (disableDefaultAssistant) {
-      const nonDefaultPinned = pinnedAgents.filter((a) => a.id !== 0);
-      const nonDefaultAvailable = availableAgents.filter((a) => a.id !== 0);
-      return (
-        nonDefaultPinned[0] || nonDefaultAvailable[0] || availableAgents[0]
-      );
+  return useMemo(() => {
+    // A selected id that matches no available agent falls through to the
+    // fallback, which is how a deleted or inaccessible agent degrades.
+    if (selectedAgent) return selectedAgent;
+    if (assistantDisabled) {
+      return agents.find((a) => a.id !== DEFAULT_AGENT_ID);
     }
-    const unifiedAgent = availableAgents.find((a) => a.id === 0);
-    if (unifiedAgent) return unifiedAgent;
-    return pinnedAgents[0] || availableAgents[0];
-  }, [
-    existingChatSessionAgentId,
-    urlAgentId,
-    availableAgents,
-    pinnedAgents,
-    disableDefaultAssistant,
-  ]);
-
-  return { liveAgent };
+    return agents.find((a) => a.id === DEFAULT_AGENT_ID) ?? agents[0];
+  }, [selectedAgent, agents, assistantDisabled]);
 }
 
 // ── Default agent detection ───────────────────────────────────────────────────
 
 /**
- * Returns true when the session is using the built-in default agent (id=0).
- * Accounts for the URL param, the existing session's agent, and the
- * `disable_default_assistant` setting which forces a non-default agent.
+ * Whether the chat is running on the Assistant (id 0) rather than a chosen
+ * agent. This is the "no particular agent" case, which the UI treats as plain
+ * chat — no agent description, a generic greeting.
+ *
+ * Loading counts as the Assistant: it is what an unresolved chat will almost
+ * always settle on, and assuming otherwise flashes a named-agent layout for an
+ * agent that is not there yet.
  */
-export function useIsDefaultAgent(
-  liveAgent: MinimalAgent | undefined,
-  existingChatSessionId: string | null,
-  selectedChatSession: ChatSession | undefined,
-  disableDefaultAssistant: boolean
-) {
-  const searchParams = useSearchParams();
-  const urlAssistantId = searchParams?.get(SEARCH_PARAM_NAMES.PERSONA_ID);
+export function useIsDefaultAgent(): boolean {
+  const liveAgent = useLiveAgent();
+  const settings = useSettings();
 
-  return useMemo(() => {
-    if (disableDefaultAssistant) return false;
-    if (
-      urlAssistantId !== null &&
-      urlAssistantId !== DEFAULT_AGENT_ID.toString()
-    )
-      return false;
-    if (
-      existingChatSessionId &&
-      selectedChatSession?.persona_id !== DEFAULT_AGENT_ID
-    )
-      return false;
-    if (liveAgent !== undefined && liveAgent.id !== DEFAULT_AGENT_ID)
-      return false;
-    return true;
-  }, [
-    disableDefaultAssistant,
-    urlAssistantId,
-    existingChatSessionId,
-    selectedChatSession?.persona_id,
-    liveAgent?.id,
-  ]);
+  // With the Assistant disabled it is never the answer, even before the agent
+  // list resolves.
+  if (settings.disable_default_assistant) return false;
+  return liveAgent === undefined || liveAgent.id === DEFAULT_AGENT_ID;
 }
 
 // ── Agent preferences ─────────────────────────────────────────────────────────

--- a/web/src/lib/agents/hooks.ts
+++ b/web/src/lib/agents/hooks.ts
@@ -209,15 +209,22 @@ export function useCurrentAgent(): MinimalAgent | null {
 // ── Agent controller (chat UI selection) ──────────────────────────────────────
 
 /**
- * Manages agent selection state for the chat UI. `liveAgent` is the agent
- * that will actually be used for a new message, resolved by priority:
- * explicit user selection → URL param → first pinned → first available.
- * When `disable_default_assistant` is on, the built-in default (id=0) is
- * skipped in the fallback chain.
+ * The agent a new message will use, resolved by priority: the open session's
+ * agent → the URL's `personaId` → the built-in default → first pinned → first
+ * available. When `disable_default_assistant` is on, the built-in default
+ * (id=0) is skipped in the fallback chain.
+ *
+ * This is a derivation, not state. Every input is shared — the URL, the open
+ * session, and the SWR-backed agent lists — so two callers always agree, and
+ * the answer re-resolves on navigation.
+ *
+ * It used to hold the choice in `useState`, latched by a one-shot effect the
+ * first time agents loaded. That made it path-dependent, so callers had to
+ * write the new agent back in on every navigation and session load, and the
+ * value could not be read anywhere but the component that owned it.
  */
 export function useAgentController(
-  selectedChatSession: ChatSession | null | undefined,
-  onAgentSelect?: () => void
+  selectedChatSession: ChatSession | null | undefined
 ) {
   const searchParams = useSearchParams();
   const { agents: availableAgents } = useAgents();
@@ -225,35 +232,22 @@ export function useAgentController(
   const settings = useSettings();
   const disableDefaultAssistant = settings.disable_default_assistant ?? false;
 
-  const defaultAgentIdRaw = searchParams?.get(SEARCH_PARAM_NAMES.PERSONA_ID);
-  const defaultAgentId = defaultAgentIdRaw
-    ? parseInt(defaultAgentIdRaw)
-    : undefined;
-
+  const urlAgentIdRaw = searchParams?.get(SEARCH_PARAM_NAMES.PERSONA_ID);
+  const urlAgentId = urlAgentIdRaw ? parseInt(urlAgentIdRaw) : undefined;
   const existingChatSessionAgentId = selectedChatSession?.persona_id;
-  const [selectedAgent, setSelectedAssistant] = useState<
-    MinimalAgent | undefined
-  >(undefined);
-
-  // The agents list loads asynchronously, so a useState initializer would
-  // always see an empty array. This effect runs the same logic once agents
-  // are available, and never again (agentsLoadedRef guard) so it doesn't
-  // override explicit user selections made via setSelectedAgentFromId.
-  const agentsLoadedRef = useRef(false);
-  useEffect(() => {
-    if (agentsLoadedRef.current || availableAgents.length === 0) return;
-    agentsLoadedRef.current = true;
-    setSelectedAssistant(
-      existingChatSessionAgentId !== undefined
-        ? availableAgents.find((a) => a.id === existingChatSessionAgentId)
-        : defaultAgentId !== undefined
-          ? availableAgents.find((a) => a.id === defaultAgentId)
-          : undefined
-    );
-  }, [availableAgents, existingChatSessionAgentId, defaultAgentId]);
 
   const liveAgent: MinimalAgent | undefined = useMemo(() => {
-    if (selectedAgent) return selectedAgent;
+    // The session wins over the URL: an open chat is pinned to the agent it
+    // was created with. An id that matches no available agent falls through,
+    // which is how a deleted or inaccessible agent degrades.
+    const chosen =
+      existingChatSessionAgentId !== undefined
+        ? availableAgents.find((a) => a.id === existingChatSessionAgentId)
+        : urlAgentId !== undefined
+          ? availableAgents.find((a) => a.id === urlAgentId)
+          : undefined;
+    if (chosen) return chosen;
+
     if (disableDefaultAssistant) {
       const nonDefaultPinned = pinnedAgents.filter((a) => a.id !== 0);
       const nonDefaultAvailable = availableAgents.filter((a) => a.id !== 0);
@@ -264,36 +258,15 @@ export function useAgentController(
     const unifiedAgent = availableAgents.find((a) => a.id === 0);
     if (unifiedAgent) return unifiedAgent;
     return pinnedAgents[0] || availableAgents[0];
-  }, [selectedAgent, pinnedAgents, availableAgents, disableDefaultAssistant]);
+  }, [
+    existingChatSessionAgentId,
+    urlAgentId,
+    availableAgents,
+    pinnedAgents,
+    disableDefaultAssistant,
+  ]);
 
-  const availableAgentsRef = useRef<MinimalAgent[]>(availableAgents);
-  const defaultAgentIdRef = useRef<number | undefined>(defaultAgentId);
-  useEffect(() => {
-    availableAgentsRef.current = availableAgents;
-    defaultAgentIdRef.current = defaultAgentId;
-  }, [availableAgents, defaultAgentId]);
-  const setSelectedAgentFromId = useCallback(
-    (agentId: number | null | undefined) => {
-      const latestAvailableAgents = availableAgentsRef.current;
-      const latestDefaultAgentId = defaultAgentIdRef.current;
-
-      let newAssistant =
-        agentId !== null
-          ? latestAvailableAgents.find((a) => a.id === agentId)
-          : undefined;
-
-      if (!newAssistant && latestDefaultAgentId !== undefined) {
-        newAssistant = latestAvailableAgents.find(
-          (a) => a.id === latestDefaultAgentId
-        );
-      }
-      setSelectedAssistant(newAssistant);
-      onAgentSelect?.();
-    },
-    [onAgentSelect]
-  );
-
-  return { selectedAgent, setSelectedAgentFromId, liveAgent };
+  return { liveAgent };
 }
 
 // ── Default agent detection ───────────────────────────────────────────────────

--- a/web/src/lib/languageModels/hooks.ts
+++ b/web/src/lib/languageModels/hooks.ts
@@ -6,7 +6,8 @@ import useSWR from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { isAuthPath } from "@/lib/auth/paths";
-import { useCurrentAgent } from "@/lib/agents/hooks";
+import { useSelectedAgent } from "@/lib/agents/hooks";
+import { DEFAULT_AGENT_ID } from "@/lib/constants";
 import {
   LLMProviderDescriptor,
   LLMProviderName,
@@ -149,14 +150,21 @@ export function useLLMProviders(agentId?: number) {
 }
 
 /**
- * Resolves the active agent via `useCurrentAgent` and fetches that agent's
+ * Resolves the active agent via `useSelectedAgent` and fetches that agent's
  * LLM providers via `useLLMProviders`. User-facing model UIs (chat model
  * selectors, popovers) consistently need exactly this pairing, so this hook
  * keeps the resolution in one place instead of repeating it at each call site.
  */
 export function useCurrentAgentLLMProviders() {
-  const currentAgent = useCurrentAgent();
-  return useLLMProviders(currentAgent?.id);
+  const selectedAgent = useSelectedAgent();
+  // The Assistant is every install's baseline, so its models are the unscoped
+  // provider list. Scoping the fetch to id 0 would ask a narrower question than
+  // the model pickers mean.
+  const agentId =
+    selectedAgent && selectedAgent.id !== DEFAULT_AGENT_ID
+      ? selectedAgent.id
+      : undefined;
+  return useLLMProviders(agentId);
 }
 
 /**

--- a/web/src/sections/Suggestions.tsx
+++ b/web/src/sections/Suggestions.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { OnSubmitProps } from "@/hooks/useChatController";
-import { useCurrentAgent } from "@/lib/agents/hooks";
+import { useSelectedAgent } from "@/lib/agents/hooks";
 import { Interactive } from "@opal/core";
 import { Content } from "@opal/layouts";
 
@@ -10,12 +10,12 @@ export interface SuggestionsProps {
 }
 
 export default function Suggestions({ onSubmit }: SuggestionsProps) {
-  const currentAgent = useCurrentAgent();
+  const selectedAgent = useSelectedAgent();
 
   if (
-    !currentAgent ||
-    !currentAgent.starter_messages ||
-    currentAgent.starter_messages.length === 0
+    !selectedAgent ||
+    !selectedAgent.starter_messages ||
+    selectedAgent.starter_messages.length === 0
   )
     return null;
 
@@ -29,7 +29,7 @@ export default function Suggestions({ onSubmit }: SuggestionsProps) {
 
   return (
     <div className="max-w-(--app-page-main-content-width) flex flex-col w-full p-1">
-      {currentAgent.starter_messages.map(({ message }, index) => (
+      {selectedAgent.starter_messages.map(({ message }, index) => (
         <Interactive.Stateless
           key={index}
           variant="default"

--- a/web/src/sections/modals/AgentViewerModal.tsx
+++ b/web/src/sections/modals/AgentViewerModal.tsx
@@ -177,7 +177,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
   const handleStartChat = useCallback(
     (message: string) => {
       const params = new URLSearchParams({
-        [SEARCH_PARAM_NAMES.PERSONA_ID]: String(agent.id),
+        [SEARCH_PARAM_NAMES.AGENT_ID]: String(agent.id),
         [SEARCH_PARAM_NAMES.USER_PROMPT]: message,
         [SEARCH_PARAM_NAMES.SEND_ON_LOAD]: "true",
       });

--- a/web/src/sections/sidebar/AgentButton.tsx
+++ b/web/src/sections/sidebar/AgentButton.tsx
@@ -2,7 +2,7 @@
 
 import React, { memo } from "react";
 import { MinimalAgent } from "@/lib/agents/types";
-import { usePinnedAgents, useCurrentAgent } from "@/lib/agents/hooks";
+import { usePinnedAgents, useSelectedAgent } from "@/lib/agents/hooks";
 import { noProp } from "@/lib/utils";
 import { cn } from "@opal/utils";
 import { SidebarTab } from "@opal/components";
@@ -48,10 +48,10 @@ export interface AgentButtonProps {
 }
 
 const AgentButton = memo(({ agent }: AgentButtonProps) => {
-  const currentAgent = useCurrentAgent();
+  const selectedAgent = useSelectedAgent();
   const { pinnedAgents, togglePinnedAgent } = usePinnedAgents();
   const isActuallyPinned = pinnedAgents.some((a) => a.id === agent.id);
-  const isCurrentAgent = currentAgent?.id === agent.id;
+  const isCurrentAgent = selectedAgent?.id === agent.id;
 
   const handleClick = async () => {
     if (!isActuallyPinned) {

--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -40,7 +40,7 @@ import useChatSessions from "@/hooks/useChatSessions";
 import { useProjects } from "@/lib/projects/hooks";
 import {
   useAgents,
-  useCurrentAgent,
+  useSelectedAgent,
   usePinnedAgents,
 } from "@/lib/agents/hooks";
 import ProjectFolderButton from "@/sections/sidebar/ProjectFolderButton";
@@ -92,17 +92,17 @@ import { useQueryController } from "@/providers/QueryControllerProvider";
 // OR Visible-agents = pinned-agents (if current-agent in pinned-agents)
 function buildVisibleAgents(
   pinnedAgents: MinimalAgent[],
-  currentAgent: MinimalAgent | null
+  selectedAgent: MinimalAgent | null
 ): [MinimalAgent[], boolean] {
   /* NOTE: The unified agent (id = 0) is not visible in the sidebar,
   so we filter it out. */
-  if (!currentAgent)
+  if (!selectedAgent)
     return [pinnedAgents.filter((agent) => agent.id !== 0), false];
   const currentAgentIsPinned = pinnedAgents.some(
-    (pinnedAgent) => pinnedAgent.id === currentAgent.id
+    (pinnedAgent) => pinnedAgent.id === selectedAgent.id
   );
   const visibleAgents = (
-    currentAgentIsPinned ? pinnedAgents : [...pinnedAgents, currentAgent]
+    currentAgentIsPinned ? pinnedAgents : [...pinnedAgents, selectedAgent]
   ).filter((agent) => agent.id !== 0);
 
   return [visibleAgents, currentAgentIsPinned];
@@ -230,7 +230,7 @@ export default function AppSidebar() {
     isLoading: isLoadingProjects,
   } = useProjects();
   const { isLoading: isLoadingAgents } = useAgents();
-  const currentAgent = useCurrentAgent();
+  const selectedAgent = useSelectedAgent();
   const {
     pinnedAgents,
     updatePinnedAgents,
@@ -319,8 +319,8 @@ export default function AppSidebar() {
   }, [buildModeNotification, mutateNotifications]);
 
   const [visibleAgents, currentAgentIsPinned] = useMemo(
-    () => buildVisibleAgents(pinnedAgents, currentAgent),
-    [pinnedAgents, currentAgent]
+    () => buildVisibleAgents(pinnedAgents, selectedAgent),
+    [pinnedAgents, selectedAgent]
   );
   const visibleAgentIds = useMemo(
     () => visibleAgents.map((agent) => agent.id),
@@ -354,11 +354,11 @@ export default function AppSidebar() {
 
       let newPinnedAgents: MinimalAgent[];
 
-      if (currentAgent && !currentAgentIsPinned) {
+      if (selectedAgent && !currentAgentIsPinned) {
         // This is the case in which the user is dragging the UNPINNED agent and moving it to somewhere else in the list.
         // This is an indication that we WANT to pin this agent!
         if (activeIndex === visibleAgentIds.length - 1) {
-          const pinnedWithCurrent = [...pinnedAgents, currentAgent];
+          const pinnedWithCurrent = [...pinnedAgents, selectedAgent];
           newPinnedAgents = arrayMove(
             pinnedWithCurrent,
             activeIndex,
@@ -380,7 +380,7 @@ export default function AppSidebar() {
       visibleAgents,
       pinnedAgents,
       updatePinnedAgents,
-      currentAgent,
+      selectedAgent,
       currentAgentIsPinned,
     ]
   );
@@ -488,8 +488,8 @@ export default function AppSidebar() {
     (user?.preferences?.default_app_mode?.toLowerCase() as "chat" | "search") ??
     "chat";
   const newSessionHref =
-    combinedSettingsData?.disable_default_assistant && currentAgent
-      ? `/app?agentId=${currentAgent.id}`
+    combinedSettingsData?.disable_default_assistant && selectedAgent
+      ? `/app?agentId=${selectedAgent.id}`
       : "/app";
   const newSessionButton = (
     <div data-testid="AppSidebar/new-session">

--- a/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
+++ b/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
@@ -12,7 +12,7 @@ import CreateProjectModal from "@/sections/modals/CreateProjectModal";
 import { timeAgo } from "@opal/time";
 import { highlightMatch } from "@/lib/sidebar/utils";
 import { useSettings } from "@/lib/settings/hooks";
-import { useCurrentAgent } from "@/lib/agents/hooks";
+import { useSelectedAgent } from "@/lib/agents/hooks";
 import Text from "@/refresh-components/texts/Text";
 import useChatSearchOptimistic from "@/lib/sidebar/hooks";
 import {
@@ -74,7 +74,7 @@ export default function ChatSearchCommandMenu({
   // Data hooks
   const { projects } = useProjects();
   const settings = useSettings();
-  const currentAgent = useCurrentAgent();
+  const selectedAgent = useSelectedAgent();
   const createProjectModal = useCreateModal();
 
   // Constants for preview limits
@@ -151,12 +151,12 @@ export default function ChatSearchCommandMenu({
   // Navigation handlers
   const handleNewSession = useCallback(() => {
     const href =
-      settings?.disable_default_assistant && currentAgent
-        ? `/app?agentId=${currentAgent.id}`
+      settings?.disable_default_assistant && selectedAgent
+        ? `/app?agentId=${selectedAgent.id}`
         : "/app";
     router.push(href as Route);
     setOpen(false);
-  }, [router, settings, currentAgent]);
+  }, [router, settings, selectedAgent]);
 
   const handleChatSelect = useCallback(
     (chatId: string) => {

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -35,7 +35,7 @@ import DocumentsSidebar from "@/sections/document-sidebar/DocumentsSidebar";
 import useChatController from "@/hooks/useChatController";
 import useMultiModelChat from "@/hooks/useMultiModelChat";
 import MultiModelSelector from "@/sections/model-selector/MultiModelSelector";
-import { useAgentController } from "@/lib/agents/hooks";
+import { useLiveAgent } from "@/lib/agents/hooks";
 import useChatSessionController from "@/hooks/useChatSessionController";
 import useDeepResearchToggle from "@/hooks/useDeepResearchToggle";
 import { useIncognito } from "@/providers/IncognitoProvider";
@@ -212,7 +212,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     }
   }
 
-  const { liveAgent } = useAgentController(currentChatSession);
+  const liveAgent = useLiveAgent();
 
   // An explicit agent pick supersedes project context — the two cannot both
   // scope a new chat. This used to ride on the agent-selection callback, but
@@ -220,7 +220,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
   useEffect(() => {
     const params = new URLSearchParams(searchParams?.toString() || "");
     if (
-      params.has(SEARCH_PARAM_NAMES.PERSONA_ID) &&
+      params.has(SEARCH_PARAM_NAMES.AGENT_ID) &&
       params.has(SEARCH_PARAM_NAMES.PROJECT_ID)
     ) {
       params.delete(SEARCH_PARAM_NAMES.PROJECT_ID);
@@ -321,12 +321,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
 
   const filterManager = useFilters();
 
-  const isDefaultAgent = useIsDefaultAgent(
-    liveAgent,
-    currentChatSessionId,
-    currentChatSession ?? undefined,
-    disable_default_assistant ?? false
-  );
+  const isDefaultAgent = useIsDefaultAgent();
 
   const scrollContainerRef = useRef<ChatScrollContainerHandle>(null);
   const [showScrollButton, setShowScrollButton] = useState(false);

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -212,22 +212,25 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     }
   }
 
-  const { selectedAgent, setSelectedAgentFromId, liveAgent } =
-    useAgentController(currentChatSession, () => {
-      // Only remove project context if user explicitly selected an agent
-      // (i.e., agentId is present). Avoid clearing project when agentId was removed.
-      const newSearchParams = new URLSearchParams(
-        searchParams?.toString() || ""
-      );
-      if (newSearchParams.has(SEARCH_PARAM_NAMES.PERSONA_ID)) {
-        newSearchParams.delete(SEARCH_PARAM_NAMES.PROJECT_ID);
-        router.replace(`?${newSearchParams.toString()}`, { scroll: false });
-      }
-    });
+  const { liveAgent } = useAgentController(currentChatSession);
+
+  // An explicit agent pick supersedes project context — the two cannot both
+  // scope a new chat. This used to ride on the agent-selection callback, but
+  // it is a URL concern, so it is stated against the URL.
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams?.toString() || "");
+    if (
+      params.has(SEARCH_PARAM_NAMES.PERSONA_ID) &&
+      params.has(SEARCH_PARAM_NAMES.PROJECT_ID)
+    ) {
+      params.delete(SEARCH_PARAM_NAMES.PROJECT_ID);
+      router.replace(`?${params.toString()}`, { scroll: false });
+    }
+  }, [searchParams, router]);
 
   const { deepResearchEnabled, toggleDeepResearch } = useDeepResearchToggle({
     chatSessionId: currentChatSessionId,
-    agentId: selectedAgent?.id,
+    agentId: liveAgent?.id,
   });
 
   // Incognito lives in context so the top-bar toggle and this page stay in
@@ -544,7 +547,6 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     selectedDocuments,
     searchParams,
     resetInputBar,
-    setSelectedAgentFromId,
   });
 
   const {
@@ -556,7 +558,6 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     searchParams,
     filterManager,
     firstMessage,
-    setSelectedAgentFromId,
     setSelectedDocuments,
     setCurrentMessageFiles,
     chatSessionIdRef,
@@ -1114,7 +1115,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                             : projectContextTokenCount
                         }
                         availableContextTokens={availableContextTokens}
-                        selectedAgent={selectedAgent || liveAgent}
+                        selectedAgent={liveAgent}
                         handleFileUpload={handleMessageSpecificFileUpload}
                         setPresentingDocument={setPresentingDocument}
                         // Intentionally enabled during name-only onboarding (showOnboarding=false)


### PR DESCRIPTION
## Description

`useAgentController` held the active agent in `useState`, set by an effect
guarded to fire only the first time the agents list loaded. That made the value
path-dependent: it latched whatever the inputs were at that moment and never
re-derived, so every navigation and session load had to write the new agent back
in, and nothing outside the owning component could read it.

Every input it reads is already shared — the URL, the open chat session, the
SWR-backed agent lists. So the answer is a function of state the whole tree can
already see. Deriving it makes two callers agree by construction, re-resolves on
navigation, and removes the three write sites along with their plumbing through
both chat controllers.

That surfaced a second problem: three places each answered "which agent is
active" with their own rule.

| | precedence | result |
| --- | --- | --- |
| `useCurrentAgent` | URL → session | nullable |
| `useAgentController` | session → URL | total, with fallback chain |
| `useIsDefaultAgent` | re-derived both, from four parameters | boolean |

They agreed only because `agentId` is stripped from the URL once a chat opens
(`PARAMS_TO_SKIP`), so the two inputs are never populated at once. The
disagreement was unreachable rather than absent.

One private resolver now answers it, with two public views over it — both
zero-argument:

- `useSelectedAgent()` — the agent the user landed on, or `null`
- `useLiveAgent()` — the agent a message will run on, always answers
- `useIsDefaultAgent()` — now just `liveAgent.id === 0`

Pinning no longer breaks ties. It orders the sidebar; it should not choose the
agent that answers.

`PERSONA_ID` is renamed to `AGENT_ID`. The value was already `"agentId"`, so
this is the symbol catching up to the wire — no URL or API change.

### Two behavior changes worth reviewing

**A falsy-zero bug, fixed.** `useCurrentAgent` ended in `if (!agentId) return
null`, and the built-in Assistant is id `0` — so it reported "no agent" whenever
you were on the Assistant. The resolver now checks `=== undefined`.

That fix would have silently repointed the model selector, since
`useLLMProviders` switches SWR keys on `agentId !== undefined`. It is pinned
explicitly instead: `useCurrentAgentLLMProviders` treats the Assistant as an
unscoped fetch, so model pickers behave exactly as before. The visible
remainder is that `AgentButton` now highlights the Assistant when it is active
and pinned.

**One edge case changed deliberately.** With `disable_default_assistant` on and
no other agent available, the old chain ended `|| availableAgents[0]` — handing
back the very agent the admin disabled. It now resolves to `undefined`, so
`AppPage` shows `NoAgentModal`. Happy to restore the old fallback if that reads
wrong.

## How Has This Been Tested?

`bun run types:check`, `oxlint`, `oxfmt`, and the full jest suite (1123 tests)
pass.

Not yet covered, and worth a manual pass since jest does not reach it:

- open an existing chat, confirm its agent resolves
- navigate between two chats on different agents
- `/app?agentId=N`, confirm the agent survives the first message
- a plain New Session still runs on the Assistant

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check
