### PR TITLE
chore(web): enable oxlint import, jest, node and promise plugins

### DIFF
--- a/web/.oxlintrc.json
+++ b/web/.oxlintrc.json
@@ -1,6 +1,16 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["typescript", "unicorn", "oxc", "react", "nextjs"],
+  "plugins": [
+    "typescript",
+    "unicorn",
+    "oxc",
+    "react",
+    "nextjs",
+    "import",
+    "jest",
+    "node",
+    "promise"
+  ],
   "jsPlugins": [
     { "name": "react-doctor", "specifier": "oxlint-plugin-react-doctor" }
   ],
@@ -20,7 +30,11 @@
     "react-doctor/aria-role": "error",
     "react-doctor/no-ref-current-in-render": "error",
     "react-doctor/no-impure-state-updater": "error",
-    "react-doctor/no-layout-property-animation": "error"
+    "react-doctor/no-layout-property-animation": "error",
+    "jest/expect-expect": [
+      "error",
+      { "assertFunctionNames": ["expect", "expect*"] }
+    ]
   },
   "ignorePatterns": [
     ".next",

--- a/web/src/app/app/message/messageComponents/timeline/hooks/usePacedTurnGroups.test.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/hooks/usePacedTurnGroups.test.tsx
@@ -603,12 +603,12 @@ describe("usePacedTurnGroups", () => {
       // Unmount before timer fires
       unmount();
 
-      // Advance timer - should not throw
-      act(() => {
-        jest.advanceTimersByTime(200);
-      });
-
-      // No assertion needed - just verifying no errors on timer fire after unmount
+      // A timer that fires after unmount must not throw
+      expect(() => {
+        act(() => {
+          jest.advanceTimersByTime(200);
+        });
+      }).not.toThrow();
     });
 
     test("clears timer on nodeId change", () => {

--- a/web/src/instrumentation-client.ts
+++ b/web/src/instrumentation-client.ts
@@ -20,5 +20,8 @@ if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
 }
 
 // This export will instrument router navigations, and is only relevant if you enable tracing.
-// `captureRouterTransitionStart` is available from SDK version 9.12.0 onwards
+// `captureRouterTransitionStart` is available from SDK version 9.12.0 onwards.
+// oxlint cannot follow the `export * from './client'` chain in the Sentry type
+// entrypoint, so it reports a false positive here. TypeScript resolves it.
+// oxlint-disable-next-line import/namespace
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;


### PR DESCRIPTION
## What

Enables four more oxlint built-in plugins in `web/.oxlintrc.json`: `import`, `jest`, `node` and `promise`.

`node` and `promise` report nothing on the current tree, so they cost no cleanup and act as ratchets against future regressions. `import` and `jest` each surfaced one item worth acting on.

## Findings and how they were handled

| plugin | reports | action |
|---|---|---|
| `node` | 0 | none needed |
| `promise` | 0 | none needed |
| `jest` | 5 | 1 real fix, 4 were false positives resolved by rule config |
| `import` | 1 | false positive, targeted disable comment |

**Real fix.** `usePacedTurnGroups.test.tsx` had a test with no assertion — it advanced a timer after unmount and relied on the absence of a throw, which meant the test could not fail. It now asserts that explicitly:

```ts
expect(() => {
  act(() => {
    jest.advanceTimersByTime(200);
  });
}).not.toThrow();
```

**`jest/expect-expect` config.** `richInputTileSync.test.ts` does assert, but through the helpers `expectIconMirrors` and `expectColorsFromTag`, which the rule cannot see by default. Adding an `assertFunctionNames` glob for `expect*` clears those four reports. Verified the rule still catches a genuinely assertion-less test.

**`import/namespace` false positive.** oxlint cannot follow the `export * from './client'` chain in `@sentry/nextjs`'s type entrypoint, so it reports `captureRouterTransitionStart` as missing. TypeScript resolves it. Suppressed at the single call site rather than disabling the rule, so it stays active elsewhere.

## Also considered

- `react-perf` — measured 3119 violations. Its four rules only matter when a fresh prop identity reaches a memoized child, and React Compiler is enabled for production builds (`next.config.js:204`), which memoizes those values at the creation site. Not adopted.
- `jsdoc` — 25 reports, all `check-tag-names`, all false positives on valid usage (`@jest-environment`, `@remarks`). Not adopted.
- `jsx-a11y` — 200 reports, the majority being the `<div onClick>` pattern that `web/CLAUDE.md` already forbids. Genuinely worthwhile but a separate piece of work.
- `vue` / `vitest` — not applicable to this codebase.

## Testing

- `bun run lint` — clean, exit 0.
- `bunx jest` on both touched test files — 23 tests pass.
- `pre-commit run --files ...` — `oxfmt` and `oxlint` pass.
- `bun run types:check` reports 532 errors, identical before and after this change. They are pre-existing `ButtonProps` errors unrelated to this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables `oxlint` plugins `import`, `jest`, `node`, and `promise` to expand lint coverage. Fixes an assertion-less Jest test so it can fail correctly and suppresses one false-positive `import/namespace` report.

- .oxlintrc.json: adds plugins and configures `jest/expect-expect` with `assertFunctionNames: ["expect", "expect*"]` so `expect*` helpers count as assertions.
- usePacedTurnGroups.test.tsx: adds `expect(() => jest.advanceTimersByTime(...)).not.toThrow()`; previously the test had no assertion and could not fail.
- instrumentation-client.ts: adds a targeted `// oxlint-disable-next-line import/namespace` for `Sentry.captureRouterTransitionStart`; `@sentry/nextjs` re-exports confuse the rule, but TypeScript resolves it.
- `node` and `promise` currently report 0; they act as ratchets against future regressions.

<sup>Written for commit bd820e6eb8035ffd6ec013e0359eefc2734c39a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

