### PR TITLE
feat(web): enable the jsx-a11y oxlint plugin

### DIFF
--- a/web/.oxlintrc.json
+++ b/web/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["typescript", "unicorn", "oxc", "react", "nextjs"],
+  "plugins": ["typescript", "unicorn", "oxc", "react", "nextjs", "jsx-a11y"],
   "jsPlugins": [
     { "name": "react-doctor", "specifier": "oxlint-plugin-react-doctor" }
   ],
@@ -9,6 +9,7 @@
   },
   "rules": {
     "nextjs/no-img-element": "off",
+    "jsx-a11y/prefer-tag-over-role": "off",
     "react/exhaustive-deps": "off",
     "typescript/no-unused-vars": "off",
     "unicorn/no-thenable": "off",

--- a/web/lib/opal/src/components/checkbox/components.tsx
+++ b/web/lib/opal/src/components/checkbox/components.tsx
@@ -111,7 +111,8 @@ function CheckboxInner(
         ref={inputRef}
         id={id}
         type="checkbox"
-        role="presentation"
+        aria-hidden="true"
+        tabIndex={-1}
         className="opal-checkbox-input"
         checked={checked}
         disabled={disabled}

--- a/web/lib/opal/src/components/inputs/input-date-picker/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-date-picker/components.tsx
@@ -114,7 +114,7 @@ function InputDatePicker({
   const normalizedMax = maxDate ? startOfDay(maxDate) : undefined;
 
   const [segments, setSegments] = React.useState<Segments>(() =>
-    toSegments(value),
+    toSegments(value)
   );
   const [open, setOpen] = React.useState(false);
 
@@ -206,11 +206,11 @@ function InputDatePicker({
                     field.maxLen,
                     i < SEGMENT_FIELDS.length - 1
                       ? segmentRefs[SEGMENT_FIELDS[i + 1]!.part]
-                      : null,
+                      : null
                   )}
                   onKeyDown={handleSegmentKeyDown(
                     field.part,
-                    i > 0 ? segmentRefs[SEGMENT_FIELDS[i - 1]!.part] : null,
+                    i > 0 ? segmentRefs[SEGMENT_FIELDS[i - 1]!.part] : null
                   )}
                 />
               </React.Fragment>

--- a/web/lib/opal/src/components/inputs/input-date-picker/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-date-picker/components.tsx
@@ -182,9 +182,8 @@ function InputDatePicker({
           data-variant={variant}
           role="group"
           aria-label="Date"
-          onBlur={handleRootBlur}
         >
-          <div className="opal-input-segmented-content">
+          <div className="opal-input-segmented-content" onBlur={handleRootBlur}>
             {SEGMENT_FIELDS.map((field, i) => (
               <React.Fragment key={field.part}>
                 {i > 0 && separator}

--- a/web/lib/opal/src/components/inputs/input-date-picker/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-date-picker/components.tsx
@@ -114,7 +114,7 @@ function InputDatePicker({
   const normalizedMax = maxDate ? startOfDay(maxDate) : undefined;
 
   const [segments, setSegments] = React.useState<Segments>(() =>
-    toSegments(value)
+    toSegments(value),
   );
   const [open, setOpen] = React.useState(false);
 
@@ -180,10 +180,13 @@ function InputDatePicker({
         <div
           className="opal-input opal-input-segmented"
           data-variant={variant}
-          role="group"
-          aria-label="Date"
+          onBlur={handleRootBlur}
         >
-          <div className="opal-input-segmented-content" onBlur={handleRootBlur}>
+          <div
+            className="opal-input-segmented-content"
+            role="group"
+            aria-label="Date"
+          >
             {SEGMENT_FIELDS.map((field, i) => (
               <React.Fragment key={field.part}>
                 {i > 0 && separator}
@@ -203,11 +206,11 @@ function InputDatePicker({
                     field.maxLen,
                     i < SEGMENT_FIELDS.length - 1
                       ? segmentRefs[SEGMENT_FIELDS[i + 1]!.part]
-                      : null
+                      : null,
                   )}
                   onKeyDown={handleSegmentKeyDown(
                     field.part,
-                    i > 0 ? segmentRefs[SEGMENT_FIELDS[i - 1]!.part] : null
+                    i > 0 ? segmentRefs[SEGMENT_FIELDS[i - 1]!.part] : null,
                   )}
                 />
               </React.Fragment>

--- a/web/lib/opal/src/components/inputs/input-select/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-select/components.tsx
@@ -499,6 +499,7 @@ function InputSelectSearch({
   return (
     <div
       ref={rowRef}
+      role="presentation"
       className="opal-input-select-search"
       // Mousedown must not reach Content, whose preventDefault would kill
       // caret placement and text selection in the input.

--- a/web/lib/opal/src/components/inputs/input-tags/README.md
+++ b/web/lib/opal/src/components/inputs/input-tags/README.md
@@ -26,7 +26,7 @@ Interaction model:
 | `icon` | `IconFunctionComponent` | — | Leading icon (24px container) |
 | `onClear` | `() => void` | — | Renders the clear action button |
 | `minRows` | `number` | `1` | Tag rows the field is tall enough to show before it grows. Rows pack from the top |
-| `autoFocus` | `boolean` | — | Focuses the text input on mount |
+| `focusOnMount` | `boolean` | `false` | Focuses the text input on mount |
 
 ### `TagItem`
 

--- a/web/lib/opal/src/components/inputs/input-tags/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-tags/components.tsx
@@ -4,7 +4,7 @@ import "@opal/components/inputs/shared.css";
 // The inner field reuses InputTypeIn's .opal-input-field styling.
 import "@opal/components/inputs/input-type-in/styles.css";
 import "@opal/components/inputs/input-tags/styles.css";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import type { IconFunctionComponent } from "@opal/types";
 import { Button, Tag, TAG_REMOVE_CLASS } from "@opal/components";
 import { SvgX } from "@opal/icons";
@@ -56,7 +56,7 @@ interface InputTagsProps {
   minRows?: number;
 
   /** Focuses the text input on mount. */
-  autoFocus?: boolean;
+  focusOnMount?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -81,10 +81,16 @@ function InputTags({
   icon: Icon,
   onClear,
   minRows = 1,
-  autoFocus,
+  focusOnMount = false,
 }: InputTagsProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (focusOnMount) inputRef.current?.focus();
+    // Mount only: later prop changes must not steal focus back.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   function handleInputKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
     // During IME composition, Enter confirms the candidate and Backspace
@@ -157,7 +163,6 @@ function InputTags({
           ref={inputRef}
           type="text"
           className="opal-input-field opal-input-tags-field"
-          autoFocus={autoFocus}
           disabled={disabled}
           value={value}
           onChange={(event) => onChange(event.target.value)}

--- a/web/lib/opal/src/components/inputs/input-tags/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-tags/components.tsx
@@ -119,6 +119,7 @@ function InputTags({
   return (
     <div
       ref={rootRef}
+      role="presentation"
       className="opal-input opal-input-tags"
       data-variant={disabled ? "disabled" : variant}
       onKeyDown={handleRootKeyDown}

--- a/web/lib/opal/src/components/inputs/input-time/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-time/components.tsx
@@ -50,7 +50,7 @@ function isValidTime(time: TimeValue): boolean {
     (part) =>
       Number.isInteger(time[part]) &&
       time[part] >= 0 &&
-      time[part] <= SEGMENT_LIMITS[part]
+      time[part] <= SEGMENT_LIMITS[part],
   );
 }
 
@@ -66,7 +66,7 @@ function toSegments(time: TimeValue | null): TimeSegments {
 
 function parseSegments(
   segments: TimeSegments,
-  showSeconds: boolean
+  showSeconds: boolean,
 ): TimeValue | null {
   const { hours, minutes } = segments;
   // Hidden seconds parse as zero so HH:MM commits still produce a value.
@@ -85,7 +85,7 @@ function parseSegments(
 function sameCommitted(
   a: TimeValue,
   b: TimeValue,
-  showSeconds: boolean
+  showSeconds: boolean,
 ): boolean {
   return (
     a.hours === b.hours &&
@@ -144,7 +144,7 @@ function InputTime({
       : "primary";
 
   const [segments, setSegments] = React.useState<TimeSegments>(() =>
-    toSegments(value)
+    toSegments(value),
   );
 
   const hoursRef = React.useRef<HTMLInputElement>(null);
@@ -201,10 +201,13 @@ function InputTime({
       <div
         className="opal-input opal-input-segmented"
         data-variant={variant}
-        role="group"
-        aria-label="Time"
+        onBlur={handleRootBlur}
       >
-        <div className="opal-input-segmented-content" onBlur={handleRootBlur}>
+        <div
+          className="opal-input-segmented-content"
+          role="group"
+          aria-label="Time"
+        >
           {segmentParts.map((part, i) => (
             <React.Fragment key={part}>
               {i > 0 && separator}
@@ -223,11 +226,11 @@ function InputTime({
                   2,
                   i < segmentParts.length - 1
                     ? segmentRefs[segmentParts[i + 1]!]
-                    : null
+                    : null,
                 )}
                 onKeyDown={handleSegmentKeyDown(
                   part,
-                  i > 0 ? segmentRefs[segmentParts[i - 1]!] : null
+                  i > 0 ? segmentRefs[segmentParts[i - 1]!] : null,
                 )}
               />
             </React.Fragment>

--- a/web/lib/opal/src/components/inputs/input-time/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-time/components.tsx
@@ -50,7 +50,7 @@ function isValidTime(time: TimeValue): boolean {
     (part) =>
       Number.isInteger(time[part]) &&
       time[part] >= 0 &&
-      time[part] <= SEGMENT_LIMITS[part],
+      time[part] <= SEGMENT_LIMITS[part]
   );
 }
 
@@ -66,7 +66,7 @@ function toSegments(time: TimeValue | null): TimeSegments {
 
 function parseSegments(
   segments: TimeSegments,
-  showSeconds: boolean,
+  showSeconds: boolean
 ): TimeValue | null {
   const { hours, minutes } = segments;
   // Hidden seconds parse as zero so HH:MM commits still produce a value.
@@ -85,7 +85,7 @@ function parseSegments(
 function sameCommitted(
   a: TimeValue,
   b: TimeValue,
-  showSeconds: boolean,
+  showSeconds: boolean
 ): boolean {
   return (
     a.hours === b.hours &&
@@ -144,7 +144,7 @@ function InputTime({
       : "primary";
 
   const [segments, setSegments] = React.useState<TimeSegments>(() =>
-    toSegments(value),
+    toSegments(value)
   );
 
   const hoursRef = React.useRef<HTMLInputElement>(null);
@@ -226,11 +226,11 @@ function InputTime({
                   2,
                   i < segmentParts.length - 1
                     ? segmentRefs[segmentParts[i + 1]!]
-                    : null,
+                    : null
                 )}
                 onKeyDown={handleSegmentKeyDown(
                   part,
-                  i > 0 ? segmentRefs[segmentParts[i - 1]!] : null,
+                  i > 0 ? segmentRefs[segmentParts[i - 1]!] : null
                 )}
               />
             </React.Fragment>

--- a/web/lib/opal/src/components/inputs/input-time/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-time/components.tsx
@@ -203,9 +203,8 @@ function InputTime({
         data-variant={variant}
         role="group"
         aria-label="Time"
-        onBlur={handleRootBlur}
       >
-        <div className="opal-input-segmented-content">
+        <div className="opal-input-segmented-content" onBlur={handleRootBlur}>
           {segmentParts.map((part, i) => (
             <React.Fragment key={part}>
               {i > 0 && separator}

--- a/web/lib/opal/src/components/inputs/input-type-in/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-type-in/components.tsx
@@ -75,6 +75,7 @@ export default function InputTypeIn({
 
   return (
     <div
+      role="presentation"
       data-variant={variant}
       className="opal-input"
       onClick={(e) => e.currentTarget.querySelector("input")?.focus()}

--- a/web/lib/opal/src/components/pagination/components.tsx
+++ b/web/lib/opal/src/components/pagination/components.tsx
@@ -16,6 +16,7 @@ import {
   type KeyboardEvent,
   type ReactNode,
 } from "react";
+import useFocusOnMount from "@opal/hooks/useFocusOnMount";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -205,6 +206,7 @@ interface GoToPagePopupProps {
 function GoToPagePopup({ totalPages, onSubmit, children }: GoToPagePopupProps) {
   const [open, setOpen] = useState(false);
   const [value, setValue] = useState("");
+  const focusOnMount = useFocusOnMount<HTMLInputElement>();
 
   const parsed = parseInt(value, 10);
   const isValid = !isNaN(parsed) && parsed >= 1 && parsed <= totalPages;
@@ -257,7 +259,7 @@ function GoToPagePopup({ totalPages, onSubmit, children }: GoToPagePopupProps) {
             onChange={handleChange}
             onKeyDown={handleKeyDown}
             placeholder="Go to page"
-            autoFocus
+            ref={focusOnMount}
             className={cn(
               "w-28 bg-transparent px-1.5 py-1 rounded-08",
               containerSizeVariants.lg.height,

--- a/web/lib/opal/src/components/table/TableHead.tsx
+++ b/web/lib/opal/src/components/table/TableHead.tsx
@@ -123,6 +123,7 @@ export default function TableHead({
       </div>
       {resizable && (
         <div
+          role="presentation"
           onMouseDown={onResizeStart}
           onTouchStart={onResizeStart}
           className={cn(

--- a/web/lib/opal/src/hooks/useFocusOnMount.ts
+++ b/web/lib/opal/src/hooks/useFocusOnMount.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useCallback } from "react";
+
+/**
+ * Returns a stable callback ref that moves focus to the element when it mounts.
+ *
+ * Use this for inputs that only render after a user action (inline editors,
+ * popover search fields, modal fields). The `autoFocus` attribute covers the
+ * same case, but it also steals focus on page load, so it is disallowed.
+ */
+export default function useFocusOnMount<T extends HTMLElement>(
+  enabled: boolean = true
+): (element: T | null) => void {
+  return useCallback(
+    (element: T | null) => {
+      if (enabled) element?.focus();
+    },
+    [enabled]
+  );
+}

--- a/web/lib/opal/src/layouts/content/ContentLg.tsx
+++ b/web/lib/opal/src/layouts/content/ContentLg.tsx
@@ -8,6 +8,7 @@ import type { IconFunctionComponent, RichStr } from "@opal/types";
 import { toPlainString } from "@opal/components/text/InlineMarkdown";
 import { cn } from "@opal/utils";
 import { useState } from "react";
+import useFocusOnMount from "@opal/hooks/useFocusOnMount";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -95,6 +96,7 @@ function ContentLg({
 }: ContentLgProps) {
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState(toPlainString(title));
+  const focusOnMount = useFocusOnMount<HTMLInputElement>();
 
   const config = CONTENT_LG_PRESETS[sizePreset];
 
@@ -144,7 +146,7 @@ function ContentLg({
                 value={editValue}
                 onChange={(e) => setEditValue(e.target.value)}
                 size={1}
-                autoFocus
+                ref={focusOnMount}
                 onFocus={(e) => e.currentTarget.select()}
                 onBlur={commit}
                 onKeyDown={(e) => {

--- a/web/lib/opal/src/layouts/content/ContentMd.tsx
+++ b/web/lib/opal/src/layouts/content/ContentMd.tsx
@@ -10,7 +10,7 @@ import SvgXOctagon from "@opal/icons/x-octagon";
 import type { IconFunctionComponent, RichStr } from "@opal/types";
 import { toPlainString } from "@opal/components/text/InlineMarkdown";
 import { cn } from "@opal/utils";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -157,6 +157,11 @@ function ContentMd({
   const [editValue, setEditValue] = useState(toPlainString(title));
   const inputRef = useRef<HTMLInputElement>(null);
 
+  // Move focus to the edit input as soon as editing starts.
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
+
   const config = CONTENT_MD_PRESETS[sizePreset];
 
   function startEditing() {
@@ -221,7 +226,6 @@ function ContentMd({
                 value={editValue}
                 onChange={(e) => setEditValue(e.target.value)}
                 size={1}
-                autoFocus
                 onFocus={(e) => e.currentTarget.select()}
                 onBlur={commit}
                 onKeyDown={(e) => {

--- a/web/lib/opal/src/layouts/content/ContentXl.tsx
+++ b/web/lib/opal/src/layouts/content/ContentXl.tsx
@@ -8,6 +8,7 @@ import type { IconFunctionComponent, RichStr } from "@opal/types";
 import { toPlainString } from "@opal/components/text/InlineMarkdown";
 import { cn } from "@opal/utils";
 import { useState } from "react";
+import useFocusOnMount from "@opal/hooks/useFocusOnMount";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -115,6 +116,7 @@ function ContentXl({
 }: ContentXlProps) {
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState(toPlainString(title));
+  const focusOnMount = useFocusOnMount<HTMLInputElement>();
 
   const config = CONTENT_XL_PRESETS[sizePreset];
 
@@ -194,7 +196,7 @@ function ContentXl({
               value={editValue}
               onChange={(e) => setEditValue(e.target.value)}
               size={1}
-              autoFocus
+              ref={focusOnMount}
               onFocus={(e) => e.currentTarget.select()}
               onBlur={commit}
               onKeyDown={(e) => {

--- a/web/lib/opal/src/layouts/inputs/InputLayouts.stories.tsx
+++ b/web/lib/opal/src/layouts/inputs/InputLayouts.stories.tsx
@@ -28,6 +28,7 @@ const MockInput = (props: React.InputHTMLAttributes<HTMLInputElement>) => (
 const MockSwitch = () => (
   <button
     type="button"
+    aria-label="Toggle"
     className="w-10 h-5 rounded-full bg-background-neutral-03 relative"
   >
     <span className="absolute left-0.5 top-0.5 w-4 h-4 rounded-full bg-background-neutral-00 transition-transform" />

--- a/web/lib/opal/src/layouts/sidebar/components.tsx
+++ b/web/lib/opal/src/layouts/sidebar/components.tsx
@@ -96,6 +96,8 @@ function SidebarRoot({ foldable = false, children }: SidebarRootProps) {
           {inner}
         </div>
         <div
+          // Pointer convenience only — the fold button dismisses via keyboard.
+          role="presentation"
           className="opal-sidebar-root__backdrop"
           data-variant="mobile"
           data-folded={foldedAttr}
@@ -117,6 +119,8 @@ function SidebarRoot({ foldable = false, children }: SidebarRootProps) {
           {inner}
         </div>
         <div
+          // Pointer convenience only — the fold button dismisses via keyboard.
+          role="presentation"
           className="opal-sidebar-root__backdrop"
           data-variant="small"
           data-folded={foldedAttr}

--- a/web/lib/opal/src/layouts/toast/components.tsx
+++ b/web/lib/opal/src/layouts/toast/components.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useState, useSyncExternalStore } from "react";
-import { cn } from "@opal/utils";
+import { clickOnKeyDown, cn } from "@opal/utils";
 import { MessageCard, Text } from "@opal/components";
 import {
   MAX_VISIBLE_TOASTS,
@@ -95,40 +95,53 @@ function ToastContainer({ errorAppendix }: ToastContainerProps) {
           ? t.message.slice(0, MAX_TOAST_MESSAGE_LENGTH) + "…"
           : t.message;
         const expandable = isTruncatable && !isExpanded;
+        const className = cn(
+          "w-full",
+          t.leaving ? "animate-fade-out-scale" : "animate-fade-in-scale",
+          expandable && "cursor-pointer"
+        );
+        const card = (
+          <MessageCard
+            variant={t.level ?? "info"}
+            title={truncatedTitle}
+            description={buildDescription(t, errorAppendix)}
+            padding={1}
+            onClose={t.dismissible ? () => handleClose(t.id) : undefined}
+            bottomChildren={
+              isExpanded ? <ExpandedDetails message={t.message} /> : undefined
+            }
+          />
+        );
+
+        if (!expandable) {
+          return (
+            <div key={t.id} className={className}>
+              {card}
+            </div>
+          );
+        }
+
         return (
+          // The card holds its own close button, so this stays a div with
+          // button semantics rather than a <button> wrapping a <button>.
           <div
             key={t.id}
-            className={cn(
-              "w-full",
-              t.leaving ? "animate-fade-out-scale" : "animate-fade-in-scale",
-              expandable && "cursor-pointer"
-            )}
-            onClick={
-              expandable
-                ? (e) => {
-                    // Don't intercept clicks on the inner close button.
-                    if (
-                      (e.target as HTMLElement).closest(
-                        'button[aria-label="Close"]'
-                      )
-                    ) {
-                      return;
-                    }
-                    handleExpand(t);
-                  }
-                : undefined
-            }
-          >
-            <MessageCard
-              variant={t.level ?? "info"}
-              title={truncatedTitle}
-              description={buildDescription(t, errorAppendix)}
-              padding={1}
-              onClose={t.dismissible ? () => handleClose(t.id) : undefined}
-              bottomChildren={
-                isExpanded ? <ExpandedDetails message={t.message} /> : undefined
+            className={className}
+            role="button"
+            tabIndex={0}
+            aria-label="Show the full message"
+            onKeyDown={clickOnKeyDown(() => handleExpand(t))}
+            onClick={(e) => {
+              // Don't intercept clicks on the inner close button.
+              if (
+                (e.target as HTMLElement).closest('button[aria-label="Close"]')
+              ) {
+                return;
               }
-            />
+              handleExpand(t);
+            }}
+          >
+            {card}
           </div>
         );
       })}

--- a/web/lib/opal/src/utils.ts
+++ b/web/lib/opal/src/utils.ts
@@ -44,3 +44,20 @@ export async function copyText(text: string): Promise<void> {
     throw new Error("Failed to copy to clipboard");
   }
 }
+
+/**
+ * Builds a keyboard handler that mirrors a click on Enter or Space.
+ *
+ * Pair this with `role="button"` and `tabIndex={0}` on containers that cannot
+ * be a real `<button>` — usually because they wrap other interactive elements,
+ * and nested buttons are invalid HTML.
+ */
+export function clickOnKeyDown(
+  onClick: () => void
+): (event: React.KeyboardEvent) => void {
+  return (event: React.KeyboardEvent) => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    onClick();
+  };
+}

--- a/web/lib/opal/src/utils.ts
+++ b/web/lib/opal/src/utils.ts
@@ -53,7 +53,7 @@ export async function copyText(text: string): Promise<void> {
  * and nested buttons are invalid HTML.
  */
 export function clickOnKeyDown(
-  onClick: () => void,
+  onClick: () => void
 ): (event: React.KeyboardEvent) => void {
   return (event: React.KeyboardEvent) => {
     // Keyboard events bubble, so a nested button would fire its own action and

--- a/web/lib/opal/src/utils.ts
+++ b/web/lib/opal/src/utils.ts
@@ -53,10 +53,15 @@ export async function copyText(text: string): Promise<void> {
  * and nested buttons are invalid HTML.
  */
 export function clickOnKeyDown(
-  onClick: () => void
+  onClick: () => void,
 ): (event: React.KeyboardEvent) => void {
   return (event: React.KeyboardEvent) => {
+    // Keyboard events bubble, so a nested button would fire its own action and
+    // this one. Only act when the container itself holds focus.
+    if (event.target !== event.currentTarget) return;
     if (event.key !== "Enter" && event.key !== " ") return;
+    // A held key repeats, but a real <button> fires one click per press.
+    if (event.repeat) return;
     event.preventDefault();
     onClick();
   };

--- a/web/src/app/admin/agents/CollapsibleSection.tsx
+++ b/web/src/app/admin/agents/CollapsibleSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { ReactNode, useState } from "react";
 import { FiSettings } from "react-icons/fi";
+import { clickOnKeyDown } from "@opal/utils";
 
 interface CollapsibleSectionProps {
   children: ReactNode;
@@ -32,6 +33,11 @@ const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
       style={{ transition: "height 0.3s ease-out" }}
     >
       <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={!isCollapsed}
+        aria-label={isCollapsed ? "Expand section" : "Collapse section"}
+        onKeyDown={clickOnKeyDown(toggleCollapse)}
         className={`
           cursor-pointer
           ${isCollapsed ? "h-6" : "pl-6 border-l-2  border-border"}

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -607,12 +607,13 @@ function Main({ ccPairId }: { ccPairId: number }) {
             ) : (
               <>
                 We ran into some issues while processing some documents.{" "}
-                <b
-                  className="text-link cursor-pointer dark:text-blue-300"
+                <button
+                  type="button"
+                  className="text-link cursor-pointer dark:text-blue-300 font-bold"
                   onClick={() => setShowIndexAttemptErrors(true)}
                 >
                   View details.
-                </b>
+                </button>
               </>
             )}
           </AlertDescription>

--- a/web/src/app/admin/documents/explorer/Explorer.tsx
+++ b/web/src/app/admin/documents/explorer/Explorer.tsx
@@ -19,6 +19,7 @@ import { Connector } from "@/lib/connectors/connectors";
 import { HorizontalFilters } from "@/components/filters/SourceSelector";
 import { InputTypeIn } from "@opal/components";
 import SvgSimpleLoader from "@opal/icons/simple-loader";
+import { clickOnKeyDown } from "@opal/utils";
 
 const DocumentDisplay = ({
   document,
@@ -27,6 +28,18 @@ const DocumentDisplay = ({
   document: OnyxDocument;
   refresh: () => void;
 }) => {
+  async function toggleHidden() {
+    const response = await updateHiddenStatus(
+      document.document_id,
+      !document.hidden
+    );
+    if (response.ok) {
+      refresh();
+    } else {
+      toast.error(`Failed to update document - ${getErrorMsg(response)}`);
+    }
+  }
+
   return (
     <div
       key={document.document_id}
@@ -59,19 +72,11 @@ const DocumentDisplay = ({
           />
         </div>
         <div
-          onClick={async () => {
-            const response = await updateHiddenStatus(
-              document.document_id,
-              !document.hidden
-            );
-            if (response.ok) {
-              refresh();
-            } else {
-              toast.error(
-                `Failed to update document - ${getErrorMsg(response)}`
-              );
-            }
-          }}
+          role="button"
+          tabIndex={0}
+          aria-label={document.hidden ? "Unhide document" : "Hide document"}
+          onKeyDown={clickOnKeyDown(() => void toggleHidden())}
+          onClick={() => void toggleHidden()}
           className="px-1 py-0.5 bg-accent-background-hovered hover:bg-accent-background rounded-sm flex cursor-pointer select-none"
         >
           <div className="my-auto">
@@ -179,7 +184,6 @@ export function Explorer({
               event.preventDefault();
             }
           }}
-          role="textarea"
         />
 
         <HorizontalFilters

--- a/web/src/app/admin/documents/feedback/DocumentFeedbackTable.tsx
+++ b/web/src/app/admin/documents/feedback/DocumentFeedbackTable.tsx
@@ -18,6 +18,7 @@ import { HoverPopup } from "@/components/HoverPopup";
 import { Checkbox } from "@opal/components";
 import { ScoreSection } from "../ScoreEditor";
 import { truncateString } from "@/lib/utils";
+import { clickOnKeyDown } from "@opal/utils";
 
 const IsVisibleSection = ({
   document,
@@ -26,18 +27,20 @@ const IsVisibleSection = ({
   document: DocumentBoostStatus;
   onUpdate: (response: Response) => void;
 }) => {
+  async function setHidden(hidden: boolean) {
+    onUpdate(await updateHiddenStatus(document.document_id, hidden));
+  }
+
   return (
     <HoverPopup
       mainContent={
         document.hidden ? (
           <div
-            onClick={async () => {
-              const response = await updateHiddenStatus(
-                document.document_id,
-                false
-              );
-              onUpdate(response);
-            }}
+            role="button"
+            tabIndex={0}
+            aria-label="Unhide document"
+            onKeyDown={clickOnKeyDown(() => void setHidden(false))}
+            onClick={() => void setHidden(false)}
             className="flex text-error cursor-pointer hover:bg-accent-background-hovered py-1 px-2 w-fit rounded-full"
           >
             <div className="select-none">Hidden</div>
@@ -47,13 +50,11 @@ const IsVisibleSection = ({
           </div>
         ) : (
           <div
-            onClick={async () => {
-              const response = await updateHiddenStatus(
-                document.document_id,
-                true
-              );
-              onUpdate(response);
-            }}
+            role="button"
+            tabIndex={0}
+            aria-label="Hide document"
+            onKeyDown={clickOnKeyDown(() => void setHidden(true))}
+            onClick={() => void setHidden(true)}
             className="flex cursor-pointer hover:bg-accent-background-hovered py-1 px-2 w-fit rounded-full"
           >
             <div className="my-auto select-none">Visible</div>

--- a/web/src/app/admin/documents/sets/page.tsx
+++ b/web/src/app/admin/documents/sets/page.tsx
@@ -132,8 +132,13 @@ const EditRow = ({
               ${documentSet.is_up_to_date ? "cursor-pointer" : "cursor-default"}
             `}
           style={{ wordBreak: "normal", overflowWrap: "break-word" }}
-          disabled={!documentSet.is_up_to_date}
-          onClick={() => router.push(`/admin/documents/sets/${documentSet.id}`)}
+          // Not `disabled`: a disabled button fires no pointer events, which
+          // would hide the tooltip that explains why it cannot be used.
+          aria-disabled={!documentSet.is_up_to_date}
+          onClick={() => {
+            if (!documentSet.is_up_to_date) return;
+            router.push(`/admin/documents/sets/${documentSet.id}`);
+          }}
         >
           <FiEdit2 className="mr-2 shrink-0" />
           <span className="font-medium">{documentSet.name}</span>

--- a/web/src/app/admin/documents/sets/page.tsx
+++ b/web/src/app/admin/documents/sets/page.tsx
@@ -123,7 +123,8 @@ const EditRow = ({
             : undefined
         }
       >
-        <div
+        <button
+          type="button"
           className={`
               text-text-darker font-medium my-auto p-1 hover:bg-accent-background flex items-center select-none
               ${documentSet.is_up_to_date ? "cursor-pointer" : "cursor-default"}
@@ -137,7 +138,7 @@ const EditRow = ({
         >
           <FiEdit2 className="mr-2 shrink-0" />
           <span className="font-medium">{documentSet.name}</span>
-        </div>
+        </button>
       </Tooltip>
     </div>
   );

--- a/web/src/app/admin/documents/sets/page.tsx
+++ b/web/src/app/admin/documents/sets/page.tsx
@@ -83,9 +83,7 @@ const FederatedConnectorTitle = ({
             .filter(
               ([_, value]) =>
                 value &&
-                (Array.isArray(value)
-                  ? value.length > 0
-                  : String(value).trim()),
+                (Array.isArray(value) ? value.length > 0 : String(value).trim())
             )
             .map(([key, value]) => (
               <div key={key} className="truncate">
@@ -177,7 +175,7 @@ const DocumentSetTable = ({
   const sortedDocumentSets = [
     ...editableDocumentSets,
     ...documentSets.filter(
-      (ds) => !editableDocumentSets.some((eds) => eds.id === ds.id),
+      (ds) => !editableDocumentSets.some((eds) => eds.id === ds.id)
     ),
   ];
 
@@ -199,7 +197,7 @@ const DocumentSetTable = ({
             .slice((page - 1) * numToDisplay, page * numToDisplay)
             .map((documentSet) => {
               const isEditable = editableDocumentSets.some(
-                (eds) => eds.id === documentSet.id,
+                (eds) => eds.id === documentSet.id
               );
               return (
                 <TableRow key={documentSet.id}>
@@ -236,7 +234,7 @@ const DocumentSetTable = ({
                               </div>
                             </div>
                           );
-                        },
+                        }
                       )}
 
                       {/* Federated Connectors */}
@@ -267,7 +265,7 @@ const DocumentSetTable = ({
                                     />
                                   </div>
                                 );
-                              },
+                              }
                             )}
                           </>
                         )}
@@ -313,16 +311,16 @@ const DocumentSetTable = ({
                       <DeleteButton
                         onClick={async () => {
                           const response = await deleteDocumentSet(
-                            documentSet.id,
+                            documentSet.id
                           );
                           if (response.ok) {
                             toast.success(
-                              `Document set "${documentSet.name}" scheduled for deletion`,
+                              `Document set "${documentSet.name}" scheduled for deletion`
                             );
                           } else {
                             const errorMsg = (await response.json()).detail;
                             toast.error(
-                              `Failed to schedule document set for deletion - ${errorMsg}`,
+                              `Failed to schedule document set for deletion - ${errorMsg}`
                             );
                           }
                           refresh();
@@ -387,7 +385,7 @@ function Main() {
     <div className="mb-8">
       <Text as="p">
         {markdown(
-          "**Document Sets** allow you to group logically connected documents into a single bundle. These can then be used as a filter when performing searches to control the scope of information Onyx searches over.",
+          "**Document Sets** allow you to group logically connected documents into a single bundle. These can then be used as a filter when performing searches to control the scope of information Onyx searches over."
         )}
       </Text>
       <Spacer rem={0.75} />

--- a/web/src/app/admin/documents/sets/page.tsx
+++ b/web/src/app/admin/documents/sets/page.tsx
@@ -83,7 +83,9 @@ const FederatedConnectorTitle = ({
             .filter(
               ([_, value]) =>
                 value &&
-                (Array.isArray(value) ? value.length > 0 : String(value).trim())
+                (Array.isArray(value)
+                  ? value.length > 0
+                  : String(value).trim()),
             )
             .map(([key, value]) => (
               <div key={key} className="truncate">
@@ -130,11 +132,8 @@ const EditRow = ({
               ${documentSet.is_up_to_date ? "cursor-pointer" : "cursor-default"}
             `}
           style={{ wordBreak: "normal", overflowWrap: "break-word" }}
-          onClick={() => {
-            if (documentSet.is_up_to_date) {
-              router.push(`/admin/documents/sets/${documentSet.id}`);
-            }
-          }}
+          disabled={!documentSet.is_up_to_date}
+          onClick={() => router.push(`/admin/documents/sets/${documentSet.id}`)}
         >
           <FiEdit2 className="mr-2 shrink-0" />
           <span className="font-medium">{documentSet.name}</span>
@@ -173,7 +172,7 @@ const DocumentSetTable = ({
   const sortedDocumentSets = [
     ...editableDocumentSets,
     ...documentSets.filter(
-      (ds) => !editableDocumentSets.some((eds) => eds.id === ds.id)
+      (ds) => !editableDocumentSets.some((eds) => eds.id === ds.id),
     ),
   ];
 
@@ -195,7 +194,7 @@ const DocumentSetTable = ({
             .slice((page - 1) * numToDisplay, page * numToDisplay)
             .map((documentSet) => {
               const isEditable = editableDocumentSets.some(
-                (eds) => eds.id === documentSet.id
+                (eds) => eds.id === documentSet.id,
               );
               return (
                 <TableRow key={documentSet.id}>
@@ -232,7 +231,7 @@ const DocumentSetTable = ({
                               </div>
                             </div>
                           );
-                        }
+                        },
                       )}
 
                       {/* Federated Connectors */}
@@ -263,7 +262,7 @@ const DocumentSetTable = ({
                                     />
                                   </div>
                                 );
-                              }
+                              },
                             )}
                           </>
                         )}
@@ -309,16 +308,16 @@ const DocumentSetTable = ({
                       <DeleteButton
                         onClick={async () => {
                           const response = await deleteDocumentSet(
-                            documentSet.id
+                            documentSet.id,
                           );
                           if (response.ok) {
                             toast.success(
-                              `Document set "${documentSet.name}" scheduled for deletion`
+                              `Document set "${documentSet.name}" scheduled for deletion`,
                             );
                           } else {
                             const errorMsg = (await response.json()).detail;
                             toast.error(
-                              `Failed to schedule document set for deletion - ${errorMsg}`
+                              `Failed to schedule document set for deletion - ${errorMsg}`,
                             );
                           }
                           refresh();
@@ -383,7 +382,7 @@ function Main() {
     <div className="mb-8">
       <Text as="p">
         {markdown(
-          "**Document Sets** allow you to group logically connected documents into a single bundle. These can then be used as a filter when performing searches to control the scope of information Onyx searches over."
+          "**Document Sets** allow you to group logically connected documents into a single bundle. These can then be used as a filter when performing searches to control the scope of information Onyx searches over.",
         )}
       </Text>
       <Spacer rem={0.75} />

--- a/web/src/app/admin/indexing/status/FilterComponent.tsx
+++ b/web/src/app/admin/indexing/status/FilterComponent.tsx
@@ -149,7 +149,7 @@ export const FilterComponent = forwardRef<
             <DropdownMenuLabel className="px-2 py-1.5 text-xs text-muted-foreground">
               Access Type
             </DropdownMenuLabel>
-            <div onClick={(e) => e.stopPropagation()}>
+            <div role="presentation" onClick={(e) => e.stopPropagation()}>
               <DropdownMenuCheckboxItem
                 checked={selectedAccessTypes.includes("public")}
                 onCheckedChange={() => handleAccessTypeChange("public")}
@@ -183,7 +183,7 @@ export const FilterComponent = forwardRef<
             <DropdownMenuLabel className="px-2 py-1.5 text-xs text-muted-foreground">
               Last Status
             </DropdownMenuLabel>
-            <div onClick={(e) => e.stopPropagation()}>
+            <div role="presentation" onClick={(e) => e.stopPropagation()}>
               <DropdownMenuCheckboxItem
                 checked={selectedStatuses.includes("success")}
                 onCheckedChange={() => handleStatusChange("success")}
@@ -244,6 +244,7 @@ export const FilterComponent = forwardRef<
               Document Count
             </DropdownMenuLabel>
             <div
+              role="presentation"
               className="flex items-center px-2 py-2 gap-2"
               onClick={(e) => e.stopPropagation()}
             >

--- a/web/src/app/admin/scim/ScimModal.tsx
+++ b/web/src/app/admin/scim/ScimModal.tsx
@@ -2,6 +2,7 @@ import { SvgDownload, SvgKey, SvgRefreshCw } from "@opal/icons";
 import { Interactive, Hoverable } from "@opal/core";
 import { Section } from "@/layouts/general-layouts";
 import { Button, InputTextArea } from "@opal/components";
+import useFocusOnMount from "@opal/hooks/useFocusOnMount";
 import Text from "@/refresh-components/texts/Text";
 import { CopyButton } from "@opal/components";
 import { BasicModalFooter, Modal } from "@opal/components";
@@ -45,6 +46,8 @@ export default function ScimModal({
   onRegenerate,
   onClose,
 }: ScimModalProps) {
+  const focusOnMount = useFocusOnMount<HTMLElement>();
+
   switch (view.kind) {
     case "regenerate":
       return (
@@ -95,7 +98,10 @@ export default function ScimModal({
                       resizable={false}
                       rows={2}
                       rightSection={
-                        <div onClick={(e) => e.stopPropagation()}>
+                        <div
+                          role="presentation"
+                          onClick={(e) => e.stopPropagation()}
+                        >
                           <Hoverable.Item
                             group="token"
                             variant="appear-on-hover"
@@ -126,7 +132,7 @@ export default function ScimModal({
                 }
                 submit={
                   <Button
-                    autoFocus
+                    ref={focusOnMount}
                     onClick={() => copyToClipboard(view.rawToken)}
                   >
                     Copy Token

--- a/web/src/app/app/components/AppPopup.tsx
+++ b/web/src/app/app/components/AppPopup.tsx
@@ -83,13 +83,15 @@ export function AppPopup() {
             <ReactMarkdown
               className="prose prose-neutral dark:prose-invert max-w-full"
               components={{
-                a: ({ node, ...props }) => (
+                a: ({ node, children, ...props }) => (
                   <a
                     {...props}
                     className="text-link hover:text-link-hover"
                     target="_blank"
                     rel="noopener noreferrer"
-                  />
+                  >
+                    {children}
+                  </a>
                 ),
                 p: ({ node, ...props }) => (
                   <Text as="p" mainUiBody text03 {...props} />
@@ -137,13 +139,15 @@ export function AppPopup() {
                     <ReactMarkdown
                       className="prose prose-neutral dark:prose-invert max-w-full"
                       components={{
-                        a: ({ node, ...props }) => (
+                        a: ({ node, children, ...props }) => (
                           <a
                             {...props}
                             className="text-link hover:text-link-hover"
                             target="_blank"
                             rel="noopener noreferrer"
-                          />
+                          >
+                            {children}
+                          </a>
                         ),
                         p: ({ node, ...props }) => (
                           <Text

--- a/web/src/app/app/components/files/images/FullImageModal.tsx
+++ b/web/src/app/app/components/files/images/FullImageModal.tsx
@@ -35,7 +35,7 @@ export function FullImageModal({
         >
           <img
             src={buildImgUrl(fileId)}
-            alt="Uploaded image"
+            alt="Uploaded attachment"
             className="max-w-full max-h-full"
           />
         </Dialog.Content>

--- a/web/src/app/app/components/files/images/InMessageImage.tsx
+++ b/web/src/app/app/components/files/images/InMessageImage.tsx
@@ -83,23 +83,29 @@ export const InMessageImage = memo(function InMessageImage({
             <div className="absolute inset-0 bg-background-tint-02 animate-pulse rounded-lg" />
           )}
 
-          <img
-            width={1200}
-            height={1200}
-            alt="Chat Message Image"
-            onLoad={() => {
-              loadedImages.add(fileId);
-              setImageLoaded(true);
-            }}
-            className={cn(
-              "object-contain object-left overflow-hidden rounded-lg w-full h-full transition-opacity duration-300 cursor-pointer",
-              shapeImageClasses,
-              imageLoaded ? "opacity-100" : "opacity-0"
-            )}
+          <button
+            type="button"
+            className="w-full h-full"
+            aria-label="View the full image"
             onClick={() => setFullImageShowing(true)}
-            src={buildImgUrl(fileId)}
-            loading="lazy"
-          />
+          >
+            <img
+              width={1200}
+              height={1200}
+              alt="Chat attachment"
+              onLoad={() => {
+                loadedImages.add(fileId);
+                setImageLoaded(true);
+              }}
+              className={cn(
+                "object-contain object-left overflow-hidden rounded-lg w-full h-full transition-opacity duration-300 cursor-pointer",
+                shapeImageClasses,
+                imageLoaded ? "opacity-100" : "opacity-0"
+              )}
+              src={buildImgUrl(fileId)}
+              loading="lazy"
+            />
+          </button>
 
           {/* Download button - appears on hover */}
           <div className="absolute bottom-2 right-2 z-10">

--- a/web/src/app/app/components/files/images/InMessageImage.tsx
+++ b/web/src/app/app/components/files/images/InMessageImage.tsx
@@ -5,7 +5,7 @@ import { FullImageModal } from "@/app/app/components/files/images/FullImageModal
 import { buildImgUrl } from "@/app/app/components/files/images/utils";
 import { Button } from "@opal/components";
 import { Hoverable } from "@opal/core";
-import { cn } from "@opal/utils";
+import { cn, clickOnKeyDown } from "@opal/utils";
 
 const DEFAULT_SHAPE: ImageShape = "square";
 
@@ -78,34 +78,36 @@ export const InMessageImage = memo(function InMessageImage({
       />
 
       <Hoverable.Root group="messageImage" width="fit">
-        <div className={cn("relative", shapeContainerClasses)}>
+        {/* The container holds its own download button, so it takes the button
+            semantics rather than a <button> wrapping a <button>. */}
+        <div
+          className={cn("relative", shapeContainerClasses)}
+          role="button"
+          tabIndex={0}
+          aria-label="View the full image"
+          onClick={() => setFullImageShowing(true)}
+          onKeyDown={clickOnKeyDown(() => setFullImageShowing(true))}
+        >
           {!imageLoaded && (
             <div className="absolute inset-0 bg-background-tint-02 animate-pulse rounded-lg" />
           )}
 
-          <button
-            type="button"
-            className="w-full h-full"
-            aria-label="View the full image"
-            onClick={() => setFullImageShowing(true)}
-          >
-            <img
-              width={1200}
-              height={1200}
-              alt="Chat attachment"
-              onLoad={() => {
-                loadedImages.add(fileId);
-                setImageLoaded(true);
-              }}
-              className={cn(
-                "object-contain object-left overflow-hidden rounded-lg w-full h-full transition-opacity duration-300 cursor-pointer",
-                shapeImageClasses,
-                imageLoaded ? "opacity-100" : "opacity-0"
-              )}
-              src={buildImgUrl(fileId)}
-              loading="lazy"
-            />
-          </button>
+          <img
+            width={1200}
+            height={1200}
+            alt="Chat attachment"
+            onLoad={() => {
+              loadedImages.add(fileId);
+              setImageLoaded(true);
+            }}
+            className={cn(
+              "object-contain object-left overflow-hidden rounded-lg w-full h-full transition-opacity duration-300 cursor-pointer",
+              shapeImageClasses,
+              imageLoaded ? "opacity-100" : "opacity-0"
+            )}
+            src={buildImgUrl(fileId)}
+            loading="lazy"
+          />
 
           {/* Download button - appears on hover */}
           <div className="absolute bottom-2 right-2 z-10">

--- a/web/src/app/app/components/files/images/InputBarPreviewImage.tsx
+++ b/web/src/app/app/components/files/images/InputBarPreviewImage.tsx
@@ -28,12 +28,17 @@ export function InputBarPreviewImage({ fileId }: { fileId: string }) {
           h-6
       `}
       >
-        <img
-          alt="preview"
+        <button
+          type="button"
+          aria-label="View the full image"
           onClick={() => setFullImageShowing(true)}
-          className="h-6 w-6 object-cover rounded-lg bg-background cursor-pointer"
-          src={buildImgUrl(fileId)}
-        />
+        >
+          <img
+            alt="preview"
+            className="h-6 w-6 object-cover rounded-lg bg-background cursor-pointer"
+            src={buildImgUrl(fileId)}
+          />
+        </button>
       </div>
     </>
   );

--- a/web/src/app/app/components/files/images/InputBarPreviewImage.tsx
+++ b/web/src/app/app/components/files/images/InputBarPreviewImage.tsx
@@ -14,7 +14,10 @@ export function InputBarPreviewImage({ fileId }: { fileId: string }) {
         open={fullImageShowing}
         onOpenChange={(open) => setFullImageShowing(open)}
       />
-      <div
+      <button
+        type="button"
+        aria-label="View the full image"
+        onClick={() => setFullImageShowing(true)}
         className={`
           bg-transparent
           border-none
@@ -28,18 +31,12 @@ export function InputBarPreviewImage({ fileId }: { fileId: string }) {
           h-6
       `}
       >
-        <button
-          type="button"
-          aria-label="View the full image"
-          onClick={() => setFullImageShowing(true)}
-        >
-          <img
-            alt="preview"
-            className="h-6 w-6 object-cover rounded-lg bg-background cursor-pointer"
-            src={buildImgUrl(fileId)}
-          />
-        </button>
-      </div>
+        <img
+          alt="preview"
+          className="h-6 w-6 object-cover rounded-lg bg-background cursor-pointer"
+          src={buildImgUrl(fileId)}
+        />
+      </button>
     </>
   );
 }

--- a/web/src/app/app/message/CodeBlock.tsx
+++ b/web/src/app/app/message/CodeBlock.tsx
@@ -41,7 +41,8 @@ export const CodeBlock = memo(function CodeBlock({
   }, [codeText]);
 
   const CopyButton = () => (
-    <div
+    <button
+      type="button"
       className="ml-auto cursor-pointer select-none"
       onMouseDown={handleCopy}
     >
@@ -60,7 +61,7 @@ export const CodeBlock = memo(function CodeBlock({
           </Text>
         </div>
       )}
-    </div>
+    </button>
   );
 
   if (typeof children === "string" && !language) {

--- a/web/src/app/app/message/CodeBlock.tsx
+++ b/web/src/app/app/message/CodeBlock.tsx
@@ -44,7 +44,7 @@ export const CodeBlock = memo(function CodeBlock({
     <button
       type="button"
       className="ml-auto cursor-pointer select-none"
-      onMouseDown={handleCopy}
+      onClick={handleCopy}
     >
       {copied ? (
         <div className="flex items-center space-x-2">

--- a/web/src/app/app/message/MemoizedTextComponents.tsx
+++ b/web/src/app/app/message/MemoizedTextComponents.tsx
@@ -205,7 +205,9 @@ export const MemoizedLink = memo(
               semantic_identifier: filename,
             })
           }
-          className="cursor-pointer text-link hover:text-link-hover"
+          // `inline`: a button is inline-block by default, which would break
+          // the surrounding prose differently than the <a> it replaces.
+          className="inline cursor-pointer text-link hover:text-link-hover"
         >
           {rest.children}
         </button>

--- a/web/src/app/app/message/MemoizedTextComponents.tsx
+++ b/web/src/app/app/message/MemoizedTextComponents.tsx
@@ -197,19 +197,18 @@ export const MemoizedLink = memo(
       const fileId = url!.split("/api/chat/file/")[1]?.split(/[?#]/)[0] || "";
       const filename = value?.toString() || "download";
       return (
-        <a
-          href="#"
-          onClick={(e) => {
-            e.preventDefault();
+        <button
+          type="button"
+          onClick={() =>
             updatePresentingDocument({
               document_id: fileId,
               semantic_identifier: filename,
-            });
-          }}
+            })
+          }
           className="cursor-pointer text-link hover:text-link-hover"
         >
           {rest.children}
-        </a>
+        </button>
       );
     }
 

--- a/web/src/app/app/message/MultiModelPanel.tsx
+++ b/web/src/app/app/message/MultiModelPanel.tsx
@@ -10,7 +10,7 @@ import AgentMessage, {
   AgentMessageProps,
 } from "@/app/app/message/messageComponents/AgentMessage";
 import { ErrorBanner } from "@/app/app/message/Resubmit";
-import { cn } from "@opal/utils";
+import { cn, clickOnKeyDown } from "@opal/utils";
 import { markdown } from "@opal/utils";
 
 export interface MultiModelPanelProps {
@@ -88,15 +88,14 @@ export default function MultiModelPanel({
     if (canSelect) onSelect();
   }, [canSelect, onSelect]);
 
-  const header = (
-    <div
-      className={cn(
-        "rounded-12 transition-colors",
-        isPreferred ? "bg-background-tint-02" : "bg-background-tint-00",
-        canSelect && "cursor-pointer hover:bg-background-tint-02"
-      )}
-      onClick={handlePanelClick}
-    >
+  const headerClassName = cn(
+    "rounded-12 transition-colors",
+    isPreferred ? "bg-background-tint-02" : "bg-background-tint-00",
+    canSelect && "cursor-pointer hover:bg-background-tint-02"
+  );
+
+  const headerContent = (
+    <>
       <ContentAction
         sizePreset="main-ui"
         variant="body"
@@ -153,7 +152,24 @@ export default function MultiModelPanel({
           )
         }
       />
+    </>
+  );
+
+  // The header holds its own buttons, so a selectable header stays a div with
+  // button semantics rather than a <button> wrapping a <button>.
+  const header = canSelect ? (
+    <div
+      className={headerClassName}
+      role="button"
+      tabIndex={0}
+      aria-label={`Select the ${displayName} response`}
+      onKeyDown={clickOnKeyDown(handlePanelClick)}
+      onClick={handlePanelClick}
+    >
+      {headerContent}
     </div>
+  ) : (
+    <div className={headerClassName}>{headerContent}</div>
   );
 
   // Hidden/collapsed panel — just the header row

--- a/web/src/app/app/message/messageComponents/timeline/headers/CompletedHeader.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/headers/CompletedHeader.tsx
@@ -167,6 +167,29 @@ export const CompletedHeader = React.memo(function CompletedHeader({
         }`
       : null;
 
+  const summary = (
+    <div className="flex items-center gap-2 px-(--timeline-header-text-padding-x) py-(--timeline-header-text-padding-y)">
+      <Text as="p" mainUiAction text03>
+        {isExpanded ? durationText : (imageText ?? durationText)}
+      </Text>
+      {memoryOperation && !isExpanded && (
+        <MemoryTagWithTooltip
+          memoryText={memoryText}
+          memoryOperation={memoryOperation}
+          memoryId={memoryId}
+          memoryIndex={memoryIndex}
+        />
+      )}
+    </div>
+  );
+
+  const className = "flex items-center justify-between w-full";
+
+  // Without a toggle target the row must not announce itself as a button.
+  if (!collapsible || totalSteps === 0) {
+    return <div className={className}>{summary}</div>;
+  }
+
   return (
     // The row holds its own expand button, so it stays a div with button
     // semantics rather than a <button> wrapping a <button>.
@@ -176,34 +199,20 @@ export const CompletedHeader = React.memo(function CompletedHeader({
       aria-label="Toggle timeline"
       onKeyDown={clickOnKeyDown(onToggle)}
       onClick={onToggle}
-      className="flex items-center justify-between w-full"
+      className={className}
     >
-      <div className="flex items-center gap-2 px-(--timeline-header-text-padding-x) py-(--timeline-header-text-padding-y)">
-        <Text as="p" mainUiAction text03>
-          {isExpanded ? durationText : (imageText ?? durationText)}
-        </Text>
-        {memoryOperation && !isExpanded && (
-          <MemoryTagWithTooltip
-            memoryText={memoryText}
-            memoryOperation={memoryOperation}
-            memoryId={memoryId}
-            memoryIndex={memoryIndex}
-          />
-        )}
-      </div>
+      {summary}
 
-      {collapsible && totalSteps > 0 && (
-        <Button
-          prominence="tertiary"
-          size="md"
-          onClick={noProp(onToggle)}
-          rightIcon={isExpanded ? SvgFold : SvgExpand}
-          aria-label="Expand timeline"
-          aria-expanded={isExpanded}
-        >
-          {`${totalSteps} ${totalSteps === 1 ? "step" : "steps"}`}
-        </Button>
-      )}
+      <Button
+        prominence="tertiary"
+        size="md"
+        onClick={noProp(onToggle)}
+        rightIcon={isExpanded ? SvgFold : SvgExpand}
+        aria-label="Expand timeline"
+        aria-expanded={isExpanded}
+      >
+        {`${totalSteps} ${totalSteps === 1 ? "step" : "steps"}`}
+      </Button>
     </div>
   );
 });

--- a/web/src/app/app/message/messageComponents/timeline/headers/CompletedHeader.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/headers/CompletedHeader.tsx
@@ -10,6 +10,7 @@ import { Section } from "@/layouts/general-layouts";
 import { ContentAction } from "@opal/layouts";
 import { formatDurationSeconds } from "@opal/time";
 import { noProp } from "@/lib/utils";
+import { clickOnKeyDown } from "@opal/utils";
 import MemoriesModal from "@/refresh-components/modals/MemoriesModal";
 import { useCreateModal } from "@opal/components";
 
@@ -167,8 +168,13 @@ export const CompletedHeader = React.memo(function CompletedHeader({
       : null;
 
   return (
+    // The row holds its own expand button, so it stays a div with button
+    // semantics rather than a <button> wrapping a <button>.
     <div
       role="button"
+      tabIndex={0}
+      aria-label="Toggle timeline"
+      onKeyDown={clickOnKeyDown(onToggle)}
       onClick={onToggle}
       className="flex items-center justify-between w-full"
     >

--- a/web/src/app/app/message/messageComponents/timeline/headers/StoppedHeader.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/headers/StoppedHeader.tsx
@@ -3,7 +3,7 @@ import { SvgFold, SvgExpand } from "@opal/icons";
 import { Button } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
 import { noProp } from "@/lib/utils";
-import { cn } from "@opal/utils";
+import { cn, clickOnKeyDown } from "@opal/utils";
 
 export interface StoppedHeaderProps {
   totalSteps: number;
@@ -21,34 +21,50 @@ export const StoppedHeader = React.memo(function StoppedHeader({
 }: StoppedHeaderProps) {
   const isInteractive = collapsible && totalSteps > 0;
 
-  return (
-    <div
-      role={isInteractive ? "button" : undefined}
-      onClick={isInteractive ? onToggle : undefined}
-      className={cn(
-        "flex items-center justify-between w-full rounded-12",
-        isInteractive ? "cursor-pointer" : "cursor-default"
-      )}
-      aria-disabled={isInteractive ? undefined : true}
-    >
-      <div className="px-(--timeline-header-text-padding-x) py-(--timeline-header-text-padding-y)">
-        <Text as="p" mainUiAction text03>
-          Interrupted Thinking
-        </Text>
-      </div>
+  const className = cn(
+    "flex items-center justify-between w-full rounded-12",
+    isInteractive ? "cursor-pointer" : "cursor-default"
+  );
 
-      {isInteractive && (
-        <Button
-          prominence="tertiary"
-          size="md"
-          onClick={noProp(onToggle)}
-          rightIcon={isExpanded ? SvgFold : SvgExpand}
-          aria-label={isExpanded ? "Collapse timeline" : "Expand timeline"}
-          aria-expanded={isExpanded}
-        >
-          {`${totalSteps} ${totalSteps === 1 ? "step" : "steps"}`}
-        </Button>
-      )}
+  const label = (
+    <div className="px-(--timeline-header-text-padding-x) py-(--timeline-header-text-padding-y)">
+      <Text as="p" mainUiAction text03>
+        Interrupted Thinking
+      </Text>
+    </div>
+  );
+
+  if (!isInteractive) {
+    return (
+      <div className={className} aria-disabled>
+        {label}
+      </div>
+    );
+  }
+
+  return (
+    // The row holds its own expand button, so it stays a div with button
+    // semantics rather than a <button> wrapping a <button>.
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label="Toggle timeline"
+      onKeyDown={clickOnKeyDown(onToggle)}
+      onClick={onToggle}
+      className={className}
+    >
+      {label}
+
+      <Button
+        prominence="tertiary"
+        size="md"
+        onClick={noProp(onToggle)}
+        rightIcon={isExpanded ? SvgFold : SvgExpand}
+        aria-label={isExpanded ? "Collapse timeline" : "Expand timeline"}
+        aria-expanded={isExpanded}
+      >
+        {`${totalSteps} ${totalSteps === 1 ? "step" : "steps"}`}
+      </Button>
     </div>
   );
 });

--- a/web/src/app/auth/login/LoginPage.tsx
+++ b/web/src/app/auth/login/LoginPage.tsx
@@ -105,7 +105,8 @@ export default function LoginPage({
       {!hidePageRedirect && passwordAuthEnabled && (
         <p className="text-center mt-4">
           Don&apos;t have an account?{" "}
-          <span
+          <button
+            type="button"
             onClick={() => {
               if (typeof window !== "undefined" && window.top) {
                 window.top.location.href = "/auth/signup";
@@ -116,7 +117,7 @@ export default function LoginPage({
             className="text-link font-medium cursor-pointer"
           >
             Create an account
-          </span>
+          </button>
         </p>
       )}
     </div>

--- a/web/src/app/components/nrf/SettingsPanel.tsx
+++ b/web/src/app/components/nrf/SettingsPanel.tsx
@@ -131,8 +131,9 @@ export const SettingsPanel = ({
 
   return (
     <>
-      {/* Backdrop overlay */}
+      {/* Backdrop overlay — pointer convenience; the panel closes via keyboard. */}
       <div
+        role="presentation"
         className={cn(
           "fixed inset-0 bg-mask-03 backdrop-blur-xs z-40 transition-opacity duration-300",
           settingsOpen

--- a/web/src/app/craft/components/BuildWelcome.tsx
+++ b/web/src/app/craft/components/BuildWelcome.tsx
@@ -66,7 +66,8 @@ export default function BuildWelcome({
           <div className="flex flex-row items-center justify-between gap-4 pb-6">
             {/* The wordmark's baseline sits ~79% down its box, so nudge it
                 down (~0.21 × size) to share craft's baseline. */}
-            <div
+            <button
+              type="button"
               className="flex flex-row items-baseline gap-2 select-none"
               onClick={handleWordmarkClick}
             >
@@ -85,7 +86,7 @@ export default function BuildWelcome({
               >
                 craft
               </Text>
-            </div>
+            </button>
             <ModelPickerButton
               selection={selectedModel}
               onChange={setSelectedModel}

--- a/web/src/app/craft/components/UserLibraryModal.tsx
+++ b/web/src/app/craft/components/UserLibraryModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef, useMemo, useEffect } from "react";
+import useFocusOnMount from "@opal/hooks/useFocusOnMount";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import {
@@ -12,7 +13,7 @@ import {
 } from "@/app/craft/services/apiServices";
 import { LibraryEntry } from "@/app/craft/types/user-library";
 import { Modal } from "@opal/components";
-import { cn } from "@opal/utils";
+import { cn, clickOnKeyDown } from "@opal/utils";
 import {
   SvgFolder,
   SvgFolderOpen,
@@ -100,6 +101,7 @@ export default function UserLibraryModal({
   const [entryToDelete, setEntryToDelete] = useState<LibraryEntry | null>(null);
   const [showNewFolderModal, setShowNewFolderModal] = useState(false);
   const [newFolderName, setNewFolderName] = useState("");
+  const focusOnMount = useFocusOnMount<HTMLInputElement>();
   const [searchQuery, setSearchQuery] = useState("");
   const [isDragging, setIsDragging] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -443,7 +445,7 @@ export default function UserLibraryModal({
                     handleCreateDirectory();
                   }
                 }}
-                autoFocus
+                ref={focusOnMount}
               />
             </div>
           </Modal.Body>
@@ -540,104 +542,115 @@ function LibraryTreeView({
       {sortedEntries.map((entry) => {
         const isExpanded = forceExpanded || expandedPaths.has(entry.path);
 
-        return (
-          <div key={entry.id} className="flex flex-col">
-            <div
-              className={cn(
-                "group flex items-center gap-2 rounded-8 px-2 py-1.5 transition-colors hover:bg-background-tint-01",
-                entry.is_directory && "cursor-pointer"
-              )}
-              onClick={
-                entry.is_directory
-                  ? () => onToggleFolder(entry.path)
-                  : undefined
-              }
-            >
-              {/* Indent for nesting depth */}
-              {depth > 0 && (
-                <span
-                  aria-hidden
-                  className="shrink-0"
-                  style={{ width: `${depth * 1.25}rem` }}
-                />
-              )}
+        const rowClassName = cn(
+          "group flex items-center gap-2 rounded-8 px-2 py-1.5 transition-colors hover:bg-background-tint-01",
+          entry.is_directory && "cursor-pointer"
+        );
 
-              {/* Expand/collapse for directories (icon swap avoids a rotate style) */}
-              {entry.is_directory ? (
-                <Button
-                  prominence="tertiary"
-                  size="2xs"
-                  icon={isExpanded ? SvgChevronDown : SvgChevronRight}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onToggleFolder(entry.path);
-                  }}
-                  tooltip={isExpanded ? "Collapse" : "Expand"}
-                  aria-label={isExpanded ? "Collapse" : "Expand"}
-                />
+        const rowBody = (
+          <>
+            {/* Indent for nesting depth */}
+            {depth > 0 && (
+              <span
+                aria-hidden
+                className="shrink-0"
+                style={{ width: `${depth * 1.25}rem` }}
+              />
+            )}
+
+            {/* Expand/collapse for directories (icon swap avoids a rotate style) */}
+            {entry.is_directory ? (
+              <Button
+                prominence="tertiary"
+                size="2xs"
+                icon={isExpanded ? SvgChevronDown : SvgChevronRight}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleFolder(entry.path);
+                }}
+                tooltip={isExpanded ? "Collapse" : "Expand"}
+                aria-label={isExpanded ? "Collapse" : "Expand"}
+              />
+            ) : (
+              hasDirectories && <span aria-hidden className="w-5 shrink-0" />
+            )}
+
+            {/* Type icon */}
+            {entry.is_directory ? (
+              isExpanded ? (
+                <SvgFolderOpen size={16} className="shrink-0 stroke-text-03" />
               ) : (
-                hasDirectories && <span aria-hidden className="w-5 shrink-0" />
-              )}
+                <SvgFolder size={16} className="shrink-0 stroke-text-03" />
+              )
+            ) : (
+              <SvgFileText size={16} className="shrink-0 stroke-text-03" />
+            )}
 
-              {/* Type icon */}
-              {entry.is_directory ? (
-                isExpanded ? (
-                  <SvgFolderOpen
-                    size={16}
-                    className="shrink-0 stroke-text-03"
-                  />
-                ) : (
-                  <SvgFolder size={16} className="shrink-0 stroke-text-03" />
-                )
-              ) : (
-                <SvgFileText size={16} className="shrink-0 stroke-text-03" />
-              )}
+            {/* Name */}
+            <div className="min-w-0 flex-1">
+              <Text font="main-ui-muted" color="text-04" maxLines={1}>
+                {entry.name}
+              </Text>
+            </div>
 
-              {/* Name */}
-              <div className="min-w-0 flex-1">
-                <Text font="main-ui-muted" color="text-04" maxLines={1}>
-                  {entry.name}
-                </Text>
-              </div>
+            {/* File size */}
+            {!entry.is_directory && entry.file_size !== null && (
+              <Text font="secondary-body" color="text-03" nowrap>
+                {formatFileSize(entry.file_size)}
+              </Text>
+            )}
 
-              {/* File size */}
-              {!entry.is_directory && entry.file_size !== null && (
-                <Text font="secondary-body" color="text-03" nowrap>
-                  {formatFileSize(entry.file_size)}
-                </Text>
-              )}
-
-              {/* Row actions — revealed on hover/focus */}
-              <div className="flex items-center gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 no-hover:opacity-100">
-                {entry.is_directory && (
-                  <Button
-                    prominence="tertiary"
-                    size="sm"
-                    icon={SvgUploadCloud}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      const uploadPath =
-                        entry.path.replace(/^user_library/, "") || "/";
-                      onUploadToFolder(uploadPath);
-                    }}
-                    tooltip="Upload to this folder"
-                    aria-label="Upload to this folder"
-                  />
-                )}
+            {/* Row actions — revealed on hover/focus */}
+            <div className="flex items-center gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 no-hover:opacity-100">
+              {entry.is_directory && (
                 <Button
-                  variant="danger"
                   prominence="tertiary"
                   size="sm"
-                  icon={SvgTrash}
+                  icon={SvgUploadCloud}
                   onClick={(e) => {
                     e.stopPropagation();
-                    onDelete(entry);
+                    const uploadPath =
+                      entry.path.replace(/^user_library/, "") || "/";
+                    onUploadToFolder(uploadPath);
                   }}
-                  tooltip="Delete"
-                  aria-label="Delete"
+                  tooltip="Upload to this folder"
+                  aria-label="Upload to this folder"
                 />
-              </div>
+              )}
+              <Button
+                variant="danger"
+                prominence="tertiary"
+                size="sm"
+                icon={SvgTrash}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete(entry);
+                }}
+                tooltip="Delete"
+                aria-label="Delete"
+              />
             </div>
+          </>
+        );
+
+        return (
+          <div key={entry.id} className="flex flex-col">
+            {entry.is_directory ? (
+              // The row holds its own buttons, so a clickable folder row stays
+              // a div with button semantics rather than a nested <button>.
+              <div
+                className={rowClassName}
+                role="button"
+                tabIndex={0}
+                aria-label={`Toggle ${entry.name}`}
+                onKeyDown={clickOnKeyDown(() => onToggleFolder(entry.path))}
+                onClick={() => onToggleFolder(entry.path)}
+              >
+                {rowBody}
+              </div>
+            ) : (
+              <div className={rowClassName}>{rowBody}</div>
+            )}
 
             {/* Children */}
             {entry.is_directory && isExpanded && entry.children && (

--- a/web/src/app/craft/components/output-panel/ArtifactsTab.tsx
+++ b/web/src/app/craft/components/output-panel/ArtifactsTab.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/app/craft/services/apiServices";
 import { FileSystemEntry } from "@/app/craft/types/streamingTypes";
 import { getFileIcon } from "@/lib/utils";
+import { clickOnKeyDown } from "@opal/utils";
 
 interface ArtifactsTabProps {
   artifacts: Artifact[];
@@ -162,10 +163,16 @@ export default function ArtifactsTab({
         <div className="divide-y divide-border-01">
           {/* Webapp Artifacts */}
           {webappArtifacts.map((artifact) => (
+            // The row holds its own buttons, so it stays a div with button
+            // semantics rather than a <button> wrapping a <button>.
             <div
               key={artifact.id}
               className="flex items-center gap-3 p-3 hover:bg-background-tint-01 transition-colors cursor-pointer"
               style={{ paddingLeft: 12 }}
+              role="button"
+              tabIndex={0}
+              aria-label={`Open ${artifact.name}`}
+              onKeyDown={clickOnKeyDown(handleWebappOpen)}
               onClick={handleWebappOpen}
             >
               <div className="w-4 shrink-0" />
@@ -246,19 +253,27 @@ function OutputEntryRow({
     setExpanded((prev) => !prev);
   }, [entry.is_directory, entry.path, sessionId, loaded]);
 
+  const openEntry = entry.is_directory
+    ? toggleExpand
+    : () => onFileOpen(entry.path, entry.name);
+
   const FileIcon = entry.is_directory ? SvgFolder : getFileIcon(entry.name);
   const paddingLeft = depth * 20;
 
   return (
     <>
+      {/* The row holds its own buttons, so it stays a div with button
+      semantics rather than a <button> wrapping a <button>. */}
       <div
         className="flex items-center gap-3 p-3 hover:bg-background-tint-01 transition-colors cursor-pointer"
         style={{ paddingLeft: 12 + paddingLeft }}
-        onClick={
-          entry.is_directory
-            ? toggleExpand
-            : () => onFileOpen(entry.path, entry.name)
+        role="button"
+        tabIndex={0}
+        aria-label={
+          entry.is_directory ? `Toggle ${entry.name}` : `Open ${entry.name}`
         }
+        onKeyDown={clickOnKeyDown(openEntry)}
+        onClick={openEntry}
       >
         {entry.is_directory ? (
           expanded ? (

--- a/web/src/app/craft/components/output-panel/ImagePreview.tsx
+++ b/web/src/app/craft/components/output-panel/ImagePreview.tsx
@@ -60,7 +60,7 @@ export default function ImagePreview({ src, fileName }: ImagePreviewProps) {
         <img
           src={src}
           alt={displayName}
-          role="img"
+
           aria-label={`Preview of ${displayName}`}
           className={cn(
             "max-w-full max-h-full object-contain transition-opacity",

--- a/web/src/app/craft/v1/apps/admin/ActionPolicyEditorModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ActionPolicyEditorModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import useFocusOnMount from "@opal/hooks/useFocusOnMount";
 import isEqual from "lodash/isEqual";
 import {
   Button,
@@ -97,6 +98,8 @@ export default function ActionPolicyEditorModal({
   allowPristineSave = false,
   closeAfterSave = true,
 }: ActionPolicyEditorModalProps) {
+  const focusFirstField =
+    useFocusOnMount<HTMLInputElement>(autoFocusFirstField);
   const [fieldValues, setFieldValues] = useState<Record<string, string>>({
     ...initialFieldValues,
   });
@@ -196,7 +199,7 @@ export default function ActionPolicyEditorModal({
                     <div key={field.key} className="flex flex-col gap-1">
                       <Text font="main-ui-action">{field.label}</Text>
                       <Input
-                        autoFocus={autoFocusFirstField && field === fields[0]}
+                        ref={field === fields[0] ? focusFirstField : undefined}
                         value={fieldValues[field.key] ?? ""}
                         onChange={(e) =>
                           setFieldValues((prev) => ({

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import useFocusOnMount from "@opal/hooks/useFocusOnMount";
 import { useRouter } from "next/navigation";
 import isEqual from "lodash/isEqual";
 import {
@@ -71,6 +72,8 @@ export default function CreateCustomAppModal({
 }: CreateCustomAppModalProps) {
   const isEdit = existingApp !== null;
   const router = useRouter();
+  // Focus the name field for new apps only; edits keep the natural tab order.
+  const focusNameOnMount = useFocusOnMount<HTMLInputElement>(!isEdit);
 
   const [createdApp, setCreatedApp] = useState<ExternalAppAdminResponse | null>(
     null
@@ -284,7 +287,7 @@ export default function CreateCustomAppModal({
                 <div className="flex flex-col gap-1">
                   <Text font="main-ui-action">Name</Text>
                   <InputTypeIn
-                    autoFocus={!isEdit}
+                    ref={focusNameOnMount}
                     value={name}
                     onChange={(e) => setName(e.target.value)}
                     placeholder="My Custom App"

--- a/web/src/app/ee/admin/standard-answer/page.tsx
+++ b/web/src/app/ee/admin/standard-answer/page.tsx
@@ -18,6 +18,7 @@ import type { Route } from "next";
 import { StandardAnswer, StandardAnswerCategory } from "@/lib/types";
 import { SvgSearch } from "@opal/icons";
 import { useState, JSX } from "react";
+import useFocusOnMount from "@opal/hooks/useFocusOnMount";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { deleteStandardAnswer } from "./lib";
@@ -25,7 +26,7 @@ import { FilterDropdown } from "@/components/search/filtering/FilterDropdown";
 import { FiTag } from "react-icons/fi";
 import { PageSelector } from "@/components/PageSelector";
 import { Text } from "@opal/components";
-import { markdown } from "@opal/utils";
+import { cn, clickOnKeyDown, markdown } from "@opal/utils";
 import { Spacer } from "@opal/components";
 import { TableHeader } from "@/components/ui/table";
 import { SvgEdit, SvgPlusCircle, SvgTrash } from "@opal/icons";
@@ -69,36 +70,35 @@ const CategoryBubble = ({
 }: {
   name: string;
   onDelete?: () => void;
-}) => (
-  <span
-    className={`
-      inline-block
-      px-2
-      py-1
-      mr-1
-      mb-1
-      text-xs
-      font-semibold
-      text-emphasis
-      bg-accent-background-hovered
-      rounded-full
-      items-center
-      w-fit
-      ${onDelete ? "cursor-pointer" : ""}
-    `}
-    onClick={onDelete}
-  >
-    {name}
-    {onDelete && (
+}) => {
+  const className = cn(
+    "inline-block px-2 py-1 mr-1 mb-1 text-xs font-semibold text-emphasis bg-accent-background-hovered rounded-full items-center w-fit",
+    onDelete && "cursor-pointer"
+  );
+
+  if (!onDelete) return <span className={className}>{name}</span>;
+
+  return (
+    // The bubble holds its own remove button, so it stays a span with button
+    // semantics rather than a <button> wrapping a <button>.
+    <span
+      className={className}
+      role="button"
+      tabIndex={0}
+      aria-label={`Remove category ${name}`}
+      onKeyDown={clickOnKeyDown(onDelete)}
+      onClick={onDelete}
+    >
+      {name}
       <button
         className="ml-1 text-subtle hover:text-emphasis"
         aria-label="Remove category"
       >
         &times;
       </button>
-    )}
-  </span>
-);
+    </span>
+  );
+};
 
 const StandardAnswersTableRow = ({
   standardAnswer,
@@ -168,6 +168,7 @@ const StandardAnswersTable = ({
   const [selectedCategories, setSelectedCategories] = useState<
     StandardAnswerCategory[]
   >([]);
+  const focusOnMount = useFocusOnMount<HTMLTextAreaElement>();
   const columns = [
     { name: "", key: "edit" },
     { name: "Categories", key: "category" },
@@ -238,7 +239,7 @@ const StandardAnswersTable = ({
       <div className="flex items-center w-full border-2 border-border rounded-lg px-4 py-2 focus-within:border-accent">
         <SvgSearch className="w-4 h-4" />
         <textarea
-          autoFocus
+          ref={focusOnMount}
           className="grow ml-2 h-6 bg-transparent outline-hidden placeholder-subtle overflow-hidden whitespace-normal resize-none"
           placeholder="Find standard answers by keyword/phrase..."
           value={query}

--- a/web/src/app/global-error.tsx
+++ b/web/src/app/global-error.tsx
@@ -17,7 +17,7 @@ export default function GlobalError({
   }, [error]);
 
   return (
-    <html>
+    <html lang="en">
       <body>
         {/* NextError require  a `statusCode` prop. However, since the App Router
         does not expose status codes for errors, we simply pass 0 to render a

--- a/web/src/components/ConnectorMultiSelect.tsx
+++ b/web/src/components/ConnectorMultiSelect.tsx
@@ -164,9 +164,10 @@ export const ConnectorMultiSelect = ({
             ) : (
               <div>
                 {filteredUnselectedConnectors.map((connector) => (
-                  <div
+                  <button
+                    type="button"
                     key={connector.cc_pair_id}
-                    className="flex items-center justify-between py-2 px-3 cursor-pointer hover:bg-background-neutral-01 text-xs"
+                    className="w-full flex items-center justify-between py-2 px-3 cursor-pointer hover:bg-background-neutral-01 text-xs"
                     onClick={() => selectConnector(connector.cc_pair_id)}
                   >
                     <div className="flex items-center truncate mr-2">
@@ -178,7 +179,7 @@ export const ConnectorMultiSelect = ({
                         showMetadata={false}
                       />
                     </div>
-                  </div>
+                  </button>
                 ))}
               </div>
             )}

--- a/web/src/components/Dropdown.tsx
+++ b/web/src/components/Dropdown.tsx
@@ -4,6 +4,7 @@ import { forwardRef, useEffect, useRef, useState, JSX } from "react";
 import { FiCheck, FiChevronDown, FiInfo } from "react-icons/fi";
 import { Popover } from "@opal/components";
 import { Tooltip } from "@opal/components";
+import { clickOnKeyDown } from "@opal/utils";
 export interface Option<T> {
   name: string;
   value: T;
@@ -46,10 +47,14 @@ export const CustomDropdown = ({
 
   return (
     <div className="relative inline-block text-left w-full" ref={dropdownRef}>
-      <div onClick={() => setIsOpen(!isOpen)}>{children}</div>
+      {/* Pointer convenience only — the trigger inside stays keyboard-reachable. */}
+      <div role="presentation" onClick={() => setIsOpen(!isOpen)}>
+        {children}
+      </div>
 
       {isOpen && (
         <div
+          role="presentation"
           onClick={() => setIsOpen(!isOpen)}
           className={`absolute ${
             direction === "up" ? "bottom-full pb-2" : "pt-2"
@@ -97,6 +102,10 @@ export function DefaultDropdownElement({
         text-text-dark
         ${disabled ? "" : "hover:bg-accent-background-hovered"}
       `}
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled || undefined}
+      onKeyDown={disabled || !onSelect ? undefined : clickOnKeyDown(onSelect)}
       onClick={disabled ? undefined : onSelect}
     >
       <div>

--- a/web/src/components/EditableStringFieldDisplay.tsx
+++ b/web/src/components/EditableStringFieldDisplay.tsx
@@ -134,7 +134,7 @@ export function EditableStringFieldDisplay({
           <button
             type="button"
             onClick={() => setIsEditing(true)}
-            aria-label="Edit"
+            aria-label="Rename"
             className="group flex cursor-pointer"
             style={{ fontSize: `${scale}rem` }}
           >

--- a/web/src/components/EditableStringFieldDisplay.tsx
+++ b/web/src/components/EditableStringFieldDisplay.tsx
@@ -69,6 +69,13 @@ export function EditableStringFieldDisplay({
     }
   };
 
+  const displayClassName = cn(
+    textClassName,
+    "text-3xl font-bold text-text-800",
+    "user-text",
+    isEditable && "cursor-pointer"
+  );
+
   return (
     <div ref={containerRef} className={"flex items-center"}>
       <Input
@@ -85,19 +92,24 @@ export function EditableStringFieldDisplay({
         )}
         style={{ fontSize: `${scale}rem` }}
       />
-      {!isEditing && (
-        <span
-          onClick={() => isEditable && setIsEditing(true)}
-          className={cn(
-            textClassName,
-            "text-3xl font-bold text-text-800",
-            "cursor-pointer user-text"
-          )}
-          style={{ fontSize: `${scale}rem` }}
-        >
-          {value}
-        </span>
-      )}
+      {!isEditing &&
+        (isEditable ? (
+          <button
+            type="button"
+            onClick={() => setIsEditing(true)}
+            className={displayClassName}
+            style={{ fontSize: `${scale}rem` }}
+          >
+            {value}
+          </button>
+        ) : (
+          <span
+            className={displayClassName}
+            style={{ fontSize: `${scale}rem` }}
+          >
+            {value}
+          </span>
+        ))}
       {isEditing && isEditable ? (
         <>
           <div className={cn("flex", "flex-row")}>
@@ -118,15 +130,17 @@ export function EditableStringFieldDisplay({
           </div>
         </>
       ) : (
-        <h1
-          onClick={() => isEditable && setIsEditing(true)}
-          className={`group flex ${isEditable ? "cursor-pointer" : ""} ${""}`}
-          style={{ fontSize: `${scale}rem` }}
-        >
-          {isEditable && (
-            <SvgEdit className={`visible ml-2`} size={12 * scale} />
-          )}
-        </h1>
+        isEditable && (
+          <button
+            type="button"
+            onClick={() => setIsEditing(true)}
+            aria-label="Edit"
+            className="group flex cursor-pointer"
+            style={{ fontSize: `${scale}rem` }}
+          >
+            <SvgEdit className="visible ml-2" size={12 * scale} />
+          </button>
+        )
       )}
     </div>
   );

--- a/web/src/components/EditableValue.tsx
+++ b/web/src/components/EditableValue.tsx
@@ -40,7 +40,9 @@ export function EditableValue({
           }}
           className="border bg-background-200 border-background-300 rounded-sm py-1 px-1 w-12 h-4 my-auto"
         />
-        <div
+        <button
+          type="button"
+          aria-label="Save"
           onClick={async () => {
             const success = await onSubmit(editedValue);
             if (success) {
@@ -50,14 +52,16 @@ export function EditableValue({
           className="cursor-pointer my-auto ml-2"
         >
           <SvgCheck size={16} className="text-green-700" />
-        </div>
+        </button>
       </div>
     );
   }
 
   return (
     <div className="h-full flex flex-col">
-      <div
+      <button
+        type="button"
+        aria-label="Edit"
         className="flex my-auto cursor-pointer hover:bg-accent-background-hovered rounded-sm"
         onClick={() => setIsOpen(true)}
       >
@@ -67,7 +71,7 @@ export function EditableValue({
         <div className="cursor-pointer ml-2 my-auto h-4">
           <FiEdit2 size={16} />
         </div>
-      </div>
+      </button>
     </div>
   );
 }

--- a/web/src/components/FederatedConnectorSelector.tsx
+++ b/web/src/components/FederatedConnectorSelector.tsx
@@ -171,9 +171,11 @@ export const FederatedConnectorSelector = ({
             ) : (
               <div>
                 {filteredUnselectedConnectors.map((connector) => (
-                  <div
+                  <button
+                    type="button"
                     key={connector.id}
-                    className="flex items-center justify-between py-2 px-3 cursor-pointer hover:bg-background-neutral-01 text-xs"
+                    aria-label={connector.name}
+                    className="w-full flex items-center justify-between py-2 px-3 cursor-pointer hover:bg-background-neutral-01 text-xs"
                     onClick={() => selectConnector(connector.id)}
                   >
                     <div className="flex items-center truncate mr-2">
@@ -187,7 +189,7 @@ export const FederatedConnectorSelector = ({
                       </div>
                       <span className="font-medium">{connector.name}</span>
                     </div>
-                  </div>
+                  </button>
                 ))}
               </div>
             )}

--- a/web/src/components/Field.tsx
+++ b/web/src/components/Field.tsx
@@ -763,7 +763,10 @@ export const BooleanFormField = memo(function BooleanFormField({
                   />
                 </div>
                 {!noLabel && (
+                  // Pointer convenience only — the checkbox itself is
+                  // keyboard reachable.
                   <div
+                    role="presentation"
                     className={disabled ? "" : "cursor-pointer"}
                     onClick={toggle}
                   >

--- a/web/src/components/PageSelector.tsx
+++ b/web/src/components/PageSelector.tsx
@@ -51,7 +51,9 @@ const PageLink = ({
   active,
   unclickable,
 }: PageLinkProps) => (
-  <div
+  <button
+    type="button"
+    disabled={unclickable}
     className={`
     select-none
     inline-block
@@ -77,7 +79,7 @@ const PageLink = ({
     }}
   >
     {linkText}
-  </div>
+  </button>
 );
 
 export interface PageSelectorProps {

--- a/web/src/components/admin/connectors/AccessTypeForm.tsx
+++ b/web/src/components/admin/connectors/AccessTypeForm.tsx
@@ -110,7 +110,7 @@ export function AccessTypeForm({
   return (
     <>
       <div>
-        <label className="text-text-950 font-medium">Document Access</label>
+        <p className="text-text-950 font-medium">Document Access</p>
         <p className="text-sm text-text-500">
           Control who has access to the documents indexed by this connector.
         </p>

--- a/web/src/components/dateRangeSelectors/SearchDateRangeSelector.tsx
+++ b/web/src/components/dateRangeSelectors/SearchDateRangeSelector.tsx
@@ -55,7 +55,9 @@ export function SearchDateRangeSelector({
             )}
           </p>
           {value?.selectValue ? (
-            <div
+            <button
+              type="button"
+              aria-label="Clear"
               className="my-auto ml-auto p-0.5 rounded-full w-fit"
               onClick={(e) => {
                 onValueChange(null);
@@ -63,7 +65,7 @@ export function SearchDateRangeSelector({
               }}
             >
               <FiXCircle />
-            </div>
+            </button>
           ) : (
             <FiChevronDown className="my-auto ml-auto" />
           )}

--- a/web/src/components/filters/SourceSelector.tsx
+++ b/web/src/components/filters/SourceSelector.tsx
@@ -36,7 +36,8 @@ export function SelectedBubble({
   onClick: () => void;
 }) {
   return (
-    <div
+    <button
+      type="button"
       className={
         "flex cursor-pointer items-center border border-border " +
         "py-1 my-1.5 rounded-lg px-2 w-fit hover:bg-accent-background-hovered"
@@ -45,7 +46,7 @@ export function SelectedBubble({
     >
       {children}
       <FiX className="ml-2" size={14} />
-    </div>
+    </button>
   );
 }
 

--- a/web/src/components/search/DocumentDisplay.tsx
+++ b/web/src/components/search/DocumentDisplay.tsx
@@ -193,7 +193,8 @@ export function CompactQuestionCard({
   openQuestion,
 }: CompactQuestionCardProps) {
   return (
-    <div
+    <button
+      type="button"
       onClick={() => openQuestion(question)}
       className="max-w-[350px] gap-y-1 cursor-pointer pb-0 pt-0 mt-0 flex gap-y-0 flex-col content-start items-start gap-0"
     >
@@ -213,6 +214,6 @@ export function CompactQuestionCard({
           </span>
         )}
       </div>
-    </div>
+    </button>
   );
 }

--- a/web/src/components/search/filtering/FilterDropdown.tsx
+++ b/web/src/components/search/filtering/FilterDropdown.tsx
@@ -54,7 +54,8 @@ export function FilterDropdown({
             {options.map((option, ind) => {
               const isSelected = selected.includes(option.key);
               return (
-                <div
+                <button
+                  type="button"
                   key={`${option.key}-1`}
                   className={`
                       ${optionClassName}
@@ -90,7 +91,7 @@ export function FilterDropdown({
                       <FiCheck />
                     </div>
                   )}
-                </div>
+                </button>
               );
             })}
           </div>
@@ -118,7 +119,9 @@ export function FilterDropdown({
             <p className="line-clamp-1">{selected.join(", ")}</p>
           )}
           {resetValues && selected.length !== 0 ? (
-            <div
+            <button
+              type="button"
+              aria-label="Clear"
               className="my-auto ml-auto p-0.5 rounded-full w-fit"
               onClick={(e) => {
                 resetValues();
@@ -126,7 +129,7 @@ export function FilterDropdown({
               }}
             >
               <FiXCircle />
-            </div>
+            </button>
           ) : (
             <FiChevronDown className="my-auto ml-auto" />
           )}

--- a/web/src/components/tooltip/CustomTooltip.tsx
+++ b/web/src/components/tooltip/CustomTooltip.tsx
@@ -121,7 +121,9 @@ export const CustomTooltip = ({
 
   return (
     <>
+      {/* Pointer convenience only — the tooltip is hover-driven. */}
       <span
+        role="presentation"
         ref={triggerRef}
         className={cn("relative inline-block", className)}
         onMouseEnter={showTooltip}

--- a/web/src/components/ui/RadioGroupItemField.tsx
+++ b/web/src/components/ui/RadioGroupItemField.tsx
@@ -25,12 +25,9 @@ export const RadioGroupItemField: React.FC<RadioGroupItemFieldProps> = ({
   return (
     <div className="flex items-start space-x-2">
       <RadioGroupItem value={value} id={id} className="mt-1" />
-      <div className="flex flex-col">
-        <label
-          htmlFor={id}
-          className="flex flex-col cursor-pointer"
-          onClick={handleClick}
-        >
+      {/* Pointer convenience only — the radio itself is keyboard reachable. */}
+      <div className="flex flex-col" role="presentation" onClick={handleClick}>
+        <label htmlFor={id} className="flex flex-col cursor-pointer">
           <span className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
             {label}
           </span>

--- a/web/src/components/ui/alert.tsx
+++ b/web/src/components/ui/alert.tsx
@@ -40,12 +40,14 @@ Alert.displayName = "Alert";
 const AlertTitle = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLHeadingElement>
->(({ className, ...props }, ref) => (
+>(({ className, children, ...props }, ref) => (
   <h5
     ref={ref}
     className={cn("mb-1 font-medium leading-none tracking-tight", className)}
     {...props}
-  />
+  >
+    {children}
+  </h5>
 ));
 AlertTitle.displayName = "AlertTitle";
 

--- a/web/src/layouts/table-layouts.tsx
+++ b/web/src/layouts/table-layouts.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@opal/utils";
+import { cn, clickOnKeyDown } from "@opal/utils";
 import type { WithoutStyles } from "@opal/types";
 import React from "react";
 
@@ -39,11 +39,9 @@ function TableRow({ selected, children, onClick, ...rest }: TableRowProps) {
       role="button"
       tabIndex={0}
       onClick={onClick}
-      onKeyDown={(event) => {
-        if (event.key !== "Enter" && event.key !== " ") return;
-        event.preventDefault();
-        event.currentTarget.click();
-      }}
+      onKeyDown={(event) =>
+        clickOnKeyDown(() => event.currentTarget.click())(event)
+      }
       {...rest}
     >
       {children}

--- a/web/src/layouts/table-layouts.tsx
+++ b/web/src/layouts/table-layouts.tsx
@@ -19,11 +19,31 @@ interface TableRowProps extends WithoutStyles<
   selected?: boolean;
 }
 function TableRow({ selected, children, onClick, ...rest }: TableRowProps) {
+  const className = cn("table-row-layout", onClick && "cursor-pointer");
+  const dataSelected = selected ? "true" : undefined;
+
+  if (!onClick) {
+    return (
+      <div className={className} data-selected={dataSelected} {...rest}>
+        {children}
+      </div>
+    );
+  }
+
+  // Rows hold their own buttons, so a clickable row stays a div with button
+  // semantics rather than a <button> wrapping a <button>.
   return (
     <div
-      className={cn("table-row-layout", onClick && "cursor-pointer")}
-      data-selected={selected ? "true" : undefined}
+      className={className}
+      data-selected={dataSelected}
+      role="button"
+      tabIndex={0}
       onClick={onClick}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        event.currentTarget.click();
+      }}
       {...rest}
     >
       {children}

--- a/web/src/lib/credentials/components/ModifyCredential.tsx
+++ b/web/src/lib/credentials/components/ModifyCredential.tsx
@@ -66,7 +66,9 @@ function CredentialSelectionTable({
       <table className="w-full text-sm border-collapse">
         <thead className="sticky top-0 w-full">
           <tr className="bg-neutral-100 dark:bg-neutral-900">
-            <th className="p-2 text-left font-medium text-neutral-600 dark:text-neutral-400"></th>
+            <th className="p-2 text-left font-medium text-neutral-600 dark:text-neutral-400">
+              <span className="sr-only">Select</span>
+            </th>
             <th className="p-2 text-left font-medium text-neutral-600 dark:text-neutral-400">
               ID
             </th>
@@ -79,7 +81,9 @@ function CredentialSelectionTable({
             <th className="p-2 text-left font-medium text-neutral-600 dark:text-neutral-400">
               Last Updated
             </th>
-            <th />
+            <th>
+              <span className="sr-only">Actions</span>
+            </th>
           </tr>
         </thead>
 

--- a/web/src/refresh-components/Divider.tsx
+++ b/web/src/refresh-components/Divider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { cn } from "@opal/utils";
+import { cn, clickOnKeyDown } from "@opal/utils";
 import { SvgChevronRight, SvgChevronDown, SvgInfoSmall } from "@opal/icons";
 import Text from "@/refresh-components/texts/Text";
 import type { IconProps } from "@opal/types";
@@ -108,36 +108,17 @@ export default function Divider({
   }
 
   // Title divider with optional features
-  return (
-    <div
-      ref={ref}
-      role={foldable ? "button" : "separator"}
-      aria-expanded={foldable ? expanded : undefined}
-      tabIndex={foldable ? 0 : undefined}
-      data-selected={isHighlighted ? "true" : undefined}
-      onClick={foldable ? handleClick : undefined}
-      onKeyDown={
-        foldable
-          ? (e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                handleClick();
-              }
-            }
-          : undefined
-      }
-      className={cn(
-        "w-full mt-1 py-0.5 rounded-08",
-        foldable && "group/divider cursor-pointer",
-        foldable && !expanded && "hover:bg-background-tint-02",
-        foldable && !expanded && isHighlighted && "bg-background-tint-02",
-        foldable &&
-          expanded &&
-          "bg-background-tint-01 hover:bg-background-tint-02",
-        className
-      )}
-      {...props}
-    >
+  const titleClassName = cn(
+    "w-full mt-1 py-0.5 rounded-08",
+    foldable && "group/divider cursor-pointer",
+    foldable && !expanded && "hover:bg-background-tint-02",
+    foldable && !expanded && isHighlighted && "bg-background-tint-02",
+    foldable && expanded && "bg-background-tint-01 hover:bg-background-tint-02",
+    className
+  );
+
+  const titleBody = (
+    <>
       {/* Title line */}
       <div
         className={cn(
@@ -260,6 +241,36 @@ export default function Divider({
           </Truncated>
         </div>
       )}
+    </>
+  );
+
+  if (!foldable) {
+    return (
+      <div
+        ref={ref}
+        role="separator"
+        data-selected={isHighlighted ? "true" : undefined}
+        className={titleClassName}
+        {...props}
+      >
+        {titleBody}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={ref}
+      role="button"
+      aria-expanded={expanded}
+      tabIndex={0}
+      data-selected={isHighlighted ? "true" : undefined}
+      onClick={handleClick}
+      onKeyDown={clickOnKeyDown(handleClick)}
+      className={titleClassName}
+      {...props}
+    >
+      {titleBody}
     </div>
   );
 }

--- a/web/src/refresh-components/buttons/ButtonRenaming.tsx
+++ b/web/src/refresh-components/buttons/ButtonRenaming.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
+import useFocusOnMount from "@opal/hooks/useFocusOnMount";
 import { handleEnterPress, useEscapePress } from "@/lib/typingUtils";
 import { UNNAMED_CHAT } from "@/lib/constants";
 import { cn } from "@opal/utils";
@@ -21,6 +22,8 @@ export default function ButtonRenaming({
   const [renamingValue, setRenamingValue] = useState(
     initialName || UNNAMED_CHAT
   );
+
+  const focusOnMount = useFocusOnMount<HTMLInputElement>();
 
   useEscapePress(onClose, true);
 
@@ -52,7 +55,7 @@ export default function ButtonRenaming({
       )}
       onChange={(event) => setRenamingValue(event.target.value)}
       onKeyDown={handleEnterPress(() => submitRename())}
-      autoFocus
+      ref={focusOnMount}
     />
   );
 }

--- a/web/src/refresh-components/buttons/LineItem.tsx
+++ b/web/src/refresh-components/buttons/LineItem.tsx
@@ -226,24 +226,26 @@ export default function LineItem({
     props.onKeyUp?.(e);
   };
 
-  const content = (
-    <div
-      ref={ref}
-      role={interactive ? "button" : undefined}
-      tabIndex={interactive ? 0 : undefined}
-      aria-disabled={disabled || undefined}
-      className={cn(
-        "flex flex-row w-full items-start p-2 rounded-08 group/LineItem gap-2",
-        children && description ? "items-start" : "items-center",
-        interactive && (disabled ? "cursor-not-allowed" : "cursor-pointer"),
-        buttonClassNames[variant][emphasisKey]
-      )}
-      data-selected={selected}
-      {...props}
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      onKeyUp={handleKeyUp}
-    >
+  const rowClassName = cn(
+    "flex flex-row w-full items-start p-2 rounded-08 group/LineItem gap-2",
+    children && description ? "items-start" : "items-center",
+    interactive && (disabled ? "cursor-not-allowed" : "cursor-pointer"),
+    buttonClassNames[variant][emphasisKey]
+  );
+
+  const rowProps = {
+    ref,
+    "aria-disabled": disabled || undefined,
+    className: rowClassName,
+    "data-selected": selected,
+    ...props,
+    onClick: handleClick,
+    onKeyDown: handleKeyDown,
+    onKeyUp: handleKeyUp,
+  };
+
+  const body = (
+    <>
       {Icon && (
         <div
           className={cn(
@@ -302,6 +304,18 @@ export default function LineItem({
           </Section>
         ) : null}
       </Section>
+    </>
+  );
+
+  // A non-interactive row sits inside another interactive primitive, which
+  // already carries the semantics and the keyboard handling.
+  const content = interactive ? (
+    <div role="button" tabIndex={0} {...rowProps}>
+      {body}
+    </div>
+  ) : (
+    <div role="presentation" {...rowProps}>
+      {body}
     </div>
   );
 

--- a/web/src/refresh-components/buttons/SelectButton.tsx
+++ b/web/src/refresh-components/buttons/SelectButton.tsx
@@ -181,8 +181,9 @@ export default function SelectButton({
         onClick={disabled ? undefined : onClick}
         disabled={disabled}
         onMouseEnter={() => setHovered(true)}
-        onMouseOver={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
+        onFocus={() => setHovered(true)}
+        onBlur={() => setHovered(false)}
       >
         {/* Left icon */}
         {hasLeftIcon && LeftIcon && (

--- a/web/src/refresh-components/buttons/Tag.tsx
+++ b/web/src/refresh-components/buttons/Tag.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { cn } from "@opal/utils";
+import { cn, clickOnKeyDown } from "@opal/utils";
 import Text from "@/refresh-components/texts/Text";
 import { SvgX } from "@opal/icons";
 import type { IconProps } from "@opal/types";
@@ -40,32 +40,18 @@ export default function Tag({
 }: TagProps) {
   const styles = variantStyles[variant];
 
-  return (
-    <div
-      ref={ref}
-      className={cn(
-        styles.container,
-        "rounded-08",
-        "bg-background-tint-02 hover:bg-background-tint-03",
-        "focus-visible:shadow-[0_0_0_2px_var(--background-tint-04)]",
-        "outline-hidden transition-colors",
-        onClick || variant === "display" ? "cursor-pointer" : undefined,
-        className
-      )}
-      onClick={onClick}
-      role={onClick ? "button" : undefined}
-      tabIndex={onClick ? 0 : undefined}
-      onKeyDown={
-        onClick
-          ? (e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                onClick();
-              }
-            }
-          : undefined
-      }
-    >
+  const tagClassName = cn(
+    styles.container,
+    "rounded-08",
+    "bg-background-tint-02 hover:bg-background-tint-03",
+    "focus-visible:shadow-[0_0_0_2px_var(--background-tint-04)]",
+    "outline-hidden transition-colors",
+    onClick || variant === "display" ? "cursor-pointer" : undefined,
+    className
+  );
+
+  const body = (
+    <>
       {Icon && <Icon className={styles.icon} />}
       <Text {...styles.text}>{label}</Text>
       {onRemove && (
@@ -81,6 +67,29 @@ export default function Tag({
           <SvgX className="size-3" />
         </button>
       )}
+    </>
+  );
+
+  if (!onClick) {
+    return (
+      <div ref={ref} className={tagClassName}>
+        {body}
+      </div>
+    );
+  }
+
+  return (
+    // The tag can hold its own remove button, so it stays a div with button
+    // semantics rather than a <button> wrapping a <button>.
+    <div
+      ref={ref}
+      className={tagClassName}
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={clickOnKeyDown(onClick)}
+    >
+      {body}
     </div>
   );
 }

--- a/web/src/refresh-components/commandmenu/CommandMenu.tsx
+++ b/web/src/refresh-components/commandmenu/CommandMenu.tsx
@@ -8,6 +8,7 @@ import React, {
   useRef,
   useMemo,
 } from "react";
+import useFocusOnMount from "@opal/hooks/useFocusOnMount";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import useContainerCenter from "@/hooks/useContainerCenter";
@@ -439,6 +440,8 @@ function CommandMenuHeader({
   onClose,
   onEmptyBackspace,
 }: CommandMenuHeaderProps) {
+  const focusOnMount = useFocusOnMount<HTMLInputElement>();
+
   // Prevent default for arrow/enter keys so they don't move cursor or submit forms
   // The actual handling happens in Root's centralized handler via event bubbling
   const handleInputKeyDown = useCallback(
@@ -493,7 +496,7 @@ function CommandMenuHeader({
           value={value}
           onChange={(e) => onValueChange?.(e.target.value)}
           onKeyDown={handleInputKeyDown}
-          autoFocus
+          ref={focusOnMount}
         />
       </div>
     </div>
@@ -531,6 +534,7 @@ function CommandMenuList({ children, emptyMessage }: CommandMenuListProps) {
   return (
     <ScrollIndicatorDiv
       role="listbox"
+      tabIndex={-1}
       aria-label="Command menu options"
       className="p-1 gap-1 max-h-[60vh] bg-background-tint-01"
       backgroundColor="var(--background-tint-01)"

--- a/web/src/refresh-components/form/LabeledCheckboxField.tsx
+++ b/web/src/refresh-components/form/LabeledCheckboxField.tsx
@@ -28,7 +28,7 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
 }) => {
   const [field, , helpers] = useField<boolean>({ name, type: "checkbox" });
 
-  const handleClick = (e: React.MouseEvent<HTMLLabelElement>) => {
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     e.preventDefault();
     const next = !field.value;
     helpers.setValue(next);
@@ -50,12 +50,12 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
         disabled={disabled}
         {...props}
       />
-      <div className="flex flex-col">
+      {/* Pointer convenience only — the checkbox is keyboard reachable. */}
+      <div className="flex flex-col" role="presentation" onClick={handleClick}>
         <label
           id={labelId}
           htmlFor={name}
           className="flex flex-col cursor-pointer"
-          onClick={handleClick}
         >
           <span
             className={cn(

--- a/web/src/refresh-components/form/LabeledCheckboxField.tsx
+++ b/web/src/refresh-components/form/LabeledCheckboxField.tsx
@@ -30,6 +30,7 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     e.preventDefault();
+    if (disabled) return;
     const next = !field.value;
     helpers.setValue(next);
     onChange?.(next);

--- a/web/src/refresh-components/inputs/InputChipField.tsx
+++ b/web/src/refresh-components/inputs/InputChipField.tsx
@@ -127,7 +127,10 @@ function InputChipField({
   );
 
   return (
+    // Pointer convenience only — this forwards a click to the input, which is
+    // already keyboard reachable.
     <div
+      role="presentation"
       className={cn(
         "flex p-1.5 rounded-08 cursor-text w-full",
         layout === "stacked"

--- a/web/src/refresh-components/inputs/InputComboBox/InputComboBox.tsx
+++ b/web/src/refresh-components/inputs/InputComboBox/InputComboBox.tsx
@@ -388,7 +388,10 @@ const InputComboBox = ({
           rightChildren={
             <>
               {rightChildren && (
+                // Propagation guard only — the children keep their own
+                // semantics.
                 <div
+                  role="presentation"
                   className="flex items-center"
                   onPointerDown={(e) => {
                     e.stopPropagation();

--- a/web/src/refresh-components/inputs/InputComboBox/components/OptionItem.tsx
+++ b/web/src/refresh-components/inputs/InputComboBox/components/OptionItem.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cn } from "@opal/utils";
+import { cn, clickOnKeyDown } from "@opal/utils";
 import { ComboBoxOption } from "../types";
 import { sanitizeOptionId } from "../utils/aria";
 
@@ -66,12 +66,14 @@ export const OptionItem = React.memo(
         id={`${fieldId}-option-${sanitizeOptionId(option.value)}`}
         data-index={index}
         role="option"
+        tabIndex={-1}
         aria-selected={isSelected}
         aria-disabled={option.disabled}
         onClick={(e) => {
           e.stopPropagation();
           onSelect(option);
         }}
+        onKeyDown={clickOnKeyDown(() => onSelect(option))}
         onMouseDown={(e) => {
           e.preventDefault();
         }}

--- a/web/src/refresh-components/inputs/InputComboBox/components/OptionsList.tsx
+++ b/web/src/refresh-components/inputs/InputComboBox/components/OptionsList.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Text from "@/refresh-components/texts/Text";
 import { OptionItem } from "./OptionItem";
 import { ComboBoxOption } from "../types";
-import { cn } from "@opal/utils";
+import { cn, clickOnKeyDown } from "@opal/utils";
 import { SvgPlus } from "@opal/icons";
 import { sanitizeOptionId } from "../utils/aria";
 
@@ -72,12 +72,16 @@ export const OptionsList: React.FC<OptionsListProps> = ({
           id={`${fieldId}-option-${sanitizeOptionId(inputValue)}`}
           data-index={0}
           role="option"
+          tabIndex={-1}
           aria-selected={false}
           aria-label={`${createPrefix ?? "Create"} "${inputValue}"`}
           onClick={(e) => {
             e.stopPropagation();
             onSelect({ value: inputValue, label: inputValue });
           }}
+          onKeyDown={clickOnKeyDown(() =>
+            onSelect({ value: inputValue, label: inputValue })
+          )}
           onMouseDown={(e) => {
             e.preventDefault();
           }}

--- a/web/src/refresh-components/inputs/InputNumber.tsx
+++ b/web/src/refresh-components/inputs/InputNumber.tsx
@@ -147,7 +147,10 @@ export default function InputNumber({
   };
 
   return (
+    // Pointer convenience only — this forwards a click to the input, which is
+    // already keyboard reachable.
     <div
+      role="presentation"
       className={cn(
         "flex flex-row items-center justify-between w-full h-fit pr-1.5 pl-1.5 rounded-08",
         wrapperClasses[variant],

--- a/web/src/refresh-components/popovers/ActionsPopover/SwitchList.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/SwitchList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
+import useFocusOnMount from "@opal/hooks/useFocusOnMount";
 import {
   Button,
   InputTypeIn,
@@ -45,6 +46,7 @@ export default function SwitchList({
   footer,
 }: SwitchListProps) {
   const [searchTerm, setSearchTerm] = useState("");
+  const focusOnMount = useFocusOnMount<HTMLInputElement>();
   const filteredItems = useMemo(() => {
     if (!searchTerm) return items;
     const searchLower = searchTerm.toLowerCase();
@@ -76,7 +78,7 @@ export default function SwitchList({
             placeholder={searchPlaceholder}
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            autoFocus
+            ref={focusOnMount}
           />
         </div>,
 

--- a/web/src/refresh-components/popovers/ActionsPopover/index.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/index.tsx
@@ -9,6 +9,7 @@ import {
   WEB_SEARCH_TOOL_ID,
 } from "@/app/app/components/tools/constants";
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import useFocusOnMount from "@opal/hooks/useFocusOnMount";
 import { Popover, PopoverMenu } from "@opal/components";
 import SwitchList, {
   SwitchListItem,
@@ -176,6 +177,7 @@ export default function ActionsPopover({
     null
   );
   const [searchTerm, setSearchTerm] = useState("");
+  const focusOnMount = useFocusOnMount<HTMLInputElement>();
   // const [showFadeMask, setShowFadeMask] = useState(false);
   // const [showTopShadow, setShowTopShadow] = useState(false);
   const { selectedSources, setSelectedSources } = filterManager;
@@ -869,7 +871,7 @@ export default function ActionsPopover({
           searchIcon
           value={searchTerm}
           onChange={(event) => setSearchTerm(event.target.value)}
-          autoFocus
+          ref={focusOnMount}
           variant="internal"
         />,
 

--- a/web/src/refresh-components/tiles/FileTile.tsx
+++ b/web/src/refresh-components/tiles/FileTile.tsx
@@ -1,7 +1,7 @@
 import type { FunctionComponent } from "react";
 
 import { noProp } from "@/lib/utils";
-import { cn } from "@opal/utils";
+import { cn, clickOnKeyDown } from "@opal/utils";
 import { SvgMaximize2, SvgTextLines, SvgX } from "@opal/icons";
 import type { IconProps } from "@opal/types";
 import { Hoverable } from "@opal/core";
@@ -77,97 +77,112 @@ export default function FileTile({
 }: FileTileProps) {
   const Icon = icon ?? SvgTextLines;
   const isMuted = state === "processing" || state === "disabled";
+  const canOpen = !!onOpen && state !== "disabled";
+
+  const tileClassName = cn(
+    "relative min-w-30 max-w-60 h-full",
+    "border rounded-12 p-1",
+    "flex flex-row items-center",
+    "transition-colors duration-150",
+    // Outer container bg + border per state
+    isMuted
+      ? "bg-background-neutral-02 border-border-01"
+      : "bg-background-tint-00 border-border-01",
+    // Hover overrides (disabled gets none)
+    state !== "disabled" && "hover:border-border-02",
+    state === "default" && "hover:bg-background-tint-02",
+    // Clickable cursor when onOpen is provided and not disabled
+    onOpen && state !== "disabled" && "cursor-pointer"
+  );
+
+  const tileBody = (
+    <>
+      {onRemove && <RemoveButton onRemove={onRemove} />}
+
+      <div
+        className={cn(
+          "shrink-0 h-9 w-9 rounded-08",
+          "flex items-center justify-center",
+          isMuted ? "bg-background-neutral-03" : "bg-background-tint-01"
+        )}
+      >
+        <Icon
+          size={16}
+          className={cn(isMuted ? "stroke-text-01" : "stroke-text-02")}
+        />
+      </div>
+
+      {(title || description || onOpen) && (
+        <div className="min-w-0 flex pl-1 w-full justify-between h-full">
+          {isMuted ? (
+            <div className="flex flex-col min-w-0">
+              {title && (
+                <Truncated
+                  secondaryAction
+                  text02
+                  className={cn(
+                    "truncate",
+                    state === "processing" && "hover:text-text-03"
+                  )}
+                >
+                  {title}
+                </Truncated>
+              )}
+              {description && (
+                <Text
+                  secondaryBody
+                  text02
+                  className={cn(
+                    "line-clamp-2",
+                    state === "processing" && "hover:text-text-03"
+                  )}
+                >
+                  {description}
+                </Text>
+              )}
+            </div>
+          ) : (
+            <div className="flex flex-col min-w-0">
+              {title && (
+                <Truncated secondaryAction text04 className="truncate">
+                  {title}
+                </Truncated>
+              )}
+              {description && (
+                <Text secondaryBody text03 className="line-clamp-2">
+                  {description}
+                </Text>
+              )}
+            </div>
+          )}
+          {onOpen && (
+            <div className="h-full">
+              <IconButton small icon={SvgMaximize2} onClick={noProp(onOpen)} />
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
 
   return (
     <Hoverable.Root group="fileTile" width="fit">
-      <div
-        onClick={onOpen && state !== "disabled" ? () => onOpen() : undefined}
-        className={cn(
-          "relative min-w-30 max-w-60 h-full",
-          "border rounded-12 p-1",
-          "flex flex-row items-center",
-          "transition-colors duration-150",
-          // Outer container bg + border per state
-          isMuted
-            ? "bg-background-neutral-02 border-border-01"
-            : "bg-background-tint-00 border-border-01",
-          // Hover overrides (disabled gets none)
-          state !== "disabled" && "hover:border-border-02",
-          state === "default" && "hover:bg-background-tint-02",
-          // Clickable cursor when onOpen is provided and not disabled
-          onOpen && state !== "disabled" && "cursor-pointer"
-        )}
-      >
-        {onRemove && <RemoveButton onRemove={onRemove} />}
-
+      {canOpen ? (
+        // The tile holds its own remove and open buttons, so it stays a div
+        // with button semantics rather than a <button> wrapping a <button>.
         <div
-          className={cn(
-            "shrink-0 h-9 w-9 rounded-08",
-            "flex items-center justify-center",
-            isMuted ? "bg-background-neutral-03" : "bg-background-tint-01"
-          )}
+          role="button"
+          tabIndex={0}
+          aria-label={`Open ${title ?? "file"}`}
+          onKeyDown={clickOnKeyDown(onOpen)}
+          onClick={() => onOpen()}
+          className={tileClassName}
         >
-          <Icon
-            size={16}
-            className={cn(isMuted ? "stroke-text-01" : "stroke-text-02")}
-          />
+          {tileBody}
         </div>
-
-        {(title || description || onOpen) && (
-          <div className="min-w-0 flex pl-1 w-full justify-between h-full">
-            {isMuted ? (
-              <div className="flex flex-col min-w-0">
-                {title && (
-                  <Truncated
-                    secondaryAction
-                    text02
-                    className={cn(
-                      "truncate",
-                      state === "processing" && "hover:text-text-03"
-                    )}
-                  >
-                    {title}
-                  </Truncated>
-                )}
-                {description && (
-                  <Text
-                    secondaryBody
-                    text02
-                    className={cn(
-                      "line-clamp-2",
-                      state === "processing" && "hover:text-text-03"
-                    )}
-                  >
-                    {description}
-                  </Text>
-                )}
-              </div>
-            ) : (
-              <div className="flex flex-col min-w-0">
-                {title && (
-                  <Truncated secondaryAction text04 className="truncate">
-                    {title}
-                  </Truncated>
-                )}
-                {description && (
-                  <Text secondaryBody text03 className="line-clamp-2">
-                    {description}
-                  </Text>
-                )}
-              </div>
-            )}
-            {onOpen && (
-              <div className="h-full">
-                <IconButton
-                  small
-                  icon={SvgMaximize2}
-                  onClick={noProp(onOpen)}
-                />
-              </div>
-            )}
-          </div>
-        )}
-      </div>
+      ) : (
+        <div className={tileClassName}>{tileBody}</div>
+      )}
     </Hoverable.Root>
   );
 }

--- a/web/src/sections/actions/modals/AddMCPServerModal.tsx
+++ b/web/src/sections/actions/modals/AddMCPServerModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import useFocusOnMount from "@opal/hooks/useFocusOnMount";
 import { Formik, Form } from "formik";
 import * as Yup from "yup";
 import { Modal } from "@opal/components";
@@ -51,6 +52,7 @@ export default function AddMCPServerModal({
 }: AddMCPServerModalProps) {
   const { isOpen, toggle } = useModal();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const focusOnMount = useFocusOnMount<HTMLInputElement>();
 
   // Use activeServer from props
   const server = activeServer;
@@ -159,7 +161,7 @@ export default function AddMCPServerModal({
                   <InputTypeInField
                     name="name"
                     placeholder="Name your MCP server"
-                    autoFocus
+                    ref={focusOnMount}
                   />
                 </InputVertical>
 

--- a/web/src/sections/cards/DocumentSetCard.tsx
+++ b/web/src/sections/cards/DocumentSetCard.tsx
@@ -46,7 +46,7 @@ export default function DocumentSetCard({
               description={documentSet.description}
               rightChildren={
                 isSelected === undefined ? undefined : (
-                  <div onClick={(e) => e.stopPropagation()}>
+                  <div role="presentation" onClick={(e) => e.stopPropagation()}>
                     <Checkbox
                       checked={isSelected}
                       disabled={disabled}

--- a/web/src/sections/cards/FileCard.tsx
+++ b/web/src/sections/cards/FileCard.tsx
@@ -57,6 +57,34 @@ function Removable({ onRemove, children }: RemovableProps) {
   );
 }
 
+interface FileThumbnailProps {
+  className: string;
+  label: string;
+  onClick?: () => void;
+  children: React.ReactNode;
+}
+
+/** Renders the thumbnail as a button only when it can be opened. */
+function FileThumbnail({
+  className,
+  label,
+  onClick,
+  children,
+}: FileThumbnailProps) {
+  if (!onClick) return <div className={className}>{children}</div>;
+
+  return (
+    <button
+      type="button"
+      className={className}
+      aria-label={label}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}
+
 interface ImageFileCardProps {
   file: ProjectFile;
   imageUrl: string | null;
@@ -86,18 +114,17 @@ function ImageFileCard({
         removeFile && doneUploading ? () => removeFile(file.id) : undefined
       }
     >
-      <div
+      <FileThumbnail
         className={cn(
           sizeClass,
           "rounded-08 border border-border-01",
           isProcessing && "bg-background-neutral-02",
           onFileClick && !isProcessing && "cursor-pointer hover:opacity-90"
         )}
-        onClick={() => {
-          if (onFileClick && !isProcessing) {
-            onFileClick(file);
-          }
-        }}
+        label={file.name}
+        onClick={
+          onFileClick && !isProcessing ? () => onFileClick(file) : undefined
+        }
       >
         {!doneUploading || !imageUrl ? (
           <div className="h-full w-full flex items-center justify-center">
@@ -115,7 +142,7 @@ function ImageFileCard({
             onError={() => setImgError(true)}
           />
         )}
-      </div>
+      </FileThumbnail>
     </Removable>
   );
 }

--- a/web/src/sections/cards/SkillCard.tsx
+++ b/web/src/sections/cards/SkillCard.tsx
@@ -175,7 +175,10 @@ export default function SkillCard({
             </div>
             <div className="p-0.5 pr-1.5 flex items-center gap-1">
               {item.can_toggle && (
-                <div onClick={(event) => event.stopPropagation()}>
+                <div
+                  role="presentation"
+                  onClick={(event) => event.stopPropagation()}
+                >
                   <Switch
                     checked={item.enabled}
                     onCheckedChange={handleEnabledChange}

--- a/web/src/sections/document-sidebar/ChatDocumentDisplay.tsx
+++ b/web/src/sections/document-sidebar/ChatDocumentDisplay.tsx
@@ -79,10 +79,11 @@ export default function ChatDocumentDisplay({
     document.updated_at || Object.keys(document.metadata).length > 0;
 
   return (
-    <div
+    <button
+      type="button"
       onClick={() => openDocument(document, setPresentingDocument)}
       className={cn(
-        "flex w-full flex-col p-3 gap-2 rounded-12 hover:bg-background-tint-00 cursor-pointer",
+        "flex w-full flex-col p-3 gap-2 rounded-12 hover:bg-background-tint-00 cursor-pointer text-left",
         isSelected && "bg-action-selection-02"
       )}
     >
@@ -104,6 +105,6 @@ export default function ChatDocumentDisplay({
       <Text as="p" className="line-clamp-2 text-left" secondaryBody text03>
         {buildDocumentSummaryDisplay(document.match_highlights, document.blurb)}
       </Text>
-    </div>
+    </button>
   );
 }

--- a/web/src/sections/input/InputChipStrip.tsx
+++ b/web/src/sections/input/InputChipStrip.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, type ReactNode } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { cn } from "@opal/utils";
+import { cn, clickOnKeyDown } from "@opal/utils";
 import { Button, Text, Tooltip } from "@opal/components";
 import {
   SvgAlertCircle,
@@ -38,18 +38,14 @@ function InputChip({
 }: InputChipProps) {
   const chipRef = useRef<HTMLDivElement>(null);
 
-  return (
-    <div
-      ref={chipRef}
-      className={cn(
-        "flex items-center gap-1 px-1 py-px rounded-08 border",
-        colorClassName,
-        onClick && "cursor-pointer"
-      )}
-      onClick={() => {
-        if (chipRef.current) onClick?.(chipRef.current);
-      }}
-    >
+  const chipClassName = cn(
+    "flex items-center gap-1 px-1 py-px rounded-08 border",
+    colorClassName,
+    onClick && "cursor-pointer"
+  );
+
+  const chipBody = (
+    <>
       {icon}
       <span className="max-w-[120px] truncate">
         <Text font="secondary-body" color="inherit" nowrap>
@@ -67,6 +63,34 @@ function InputChip({
         }}
         aria-label={`Remove ${label}`}
       />
+    </>
+  );
+
+  if (!onClick) {
+    return (
+      <div ref={chipRef} className={chipClassName}>
+        {chipBody}
+      </div>
+    );
+  }
+
+  return (
+    // The chip holds its own remove button, so it stays a div with button
+    // semantics rather than a <button> wrapping a <button>.
+    <div
+      ref={chipRef}
+      className={chipClassName}
+      role="button"
+      tabIndex={0}
+      aria-label={label}
+      onKeyDown={clickOnKeyDown(() => {
+        if (chipRef.current) onClick(chipRef.current);
+      })}
+      onClick={() => {
+        if (chipRef.current) onClick(chipRef.current);
+      }}
+    >
+      {chipBody}
     </div>
   );
 }

--- a/web/src/sections/input/QueuedMessageBar.tsx
+++ b/web/src/sections/input/QueuedMessageBar.tsx
@@ -1,6 +1,6 @@
 import { Text, Button } from "@opal/components";
 import { SvgTrash } from "@opal/icons";
-import { cn } from "@opal/utils";
+import { cn, clickOnKeyDown } from "@opal/utils";
 import { QueuedMessage } from "@/app/app/interfaces";
 
 interface QueuedMessageBarProps {
@@ -41,6 +41,12 @@ function QueuedMessageBar({
                 className={cn(
                   "bg-background-neutral-02 rounded-12 border px-3 py-1.5 flex items-center gap-2 cursor-pointer",
                   isHighlighted ? "border-border-03" : "border-border-01"
+                )}
+                role="button"
+                tabIndex={0}
+                aria-label="Toggle queued message"
+                onKeyDown={clickOnKeyDown(() =>
+                  onHighlight(isHighlighted ? null : index)
                 )}
                 onClick={() => onHighlight(isHighlighted ? null : index)}
               >

--- a/web/src/sections/onboarding/components/NonAdminStep.tsx
+++ b/web/src/sections/onboarding/components/NonAdminStep.tsx
@@ -8,7 +8,7 @@ import { useUser } from "@/providers/UserProvider";
 import IconButton from "@/refresh-components/buttons/IconButton";
 import { Button } from "@opal/components";
 import InputAvatar from "@/refresh-components/inputs/InputAvatar";
-import { cn } from "@opal/utils";
+import { cn, clickOnKeyDown } from "@opal/utils";
 import { SvgCheckCircle, SvgEdit, SvgUser, SvgX } from "@opal/icons";
 import { ContentAction, InputHorizontal, toast } from "@opal/layouts";
 import { Hoverable } from "@opal/core";
@@ -32,6 +32,11 @@ export default function NonAdminStep() {
   const containerClasses = cn(
     "flex items-center justify-between w-full p-3 bg-background-tint-00 rounded-16 border border-border-01 mb-4"
   );
+
+  const handleEdit = () => {
+    setIsEditing(true);
+    setName(savedName);
+  };
 
   const handleSave = () => {
     updateUserPersonalization({ name })
@@ -88,36 +93,42 @@ export default function NonAdminStep() {
       {isEditing ? (
         <div
           className={containerClasses}
-          onClick={() => inputRef.current?.focus()}
           role="group"
           aria-label="non-admin-name-prompt"
         >
-          <InputHorizontal
-            responsive
-            icon={SvgUser}
-            title="What should Onyx call you?"
-            description="We will display this name in the app."
+          {/* Pointer convenience only — the input is already keyboard reachable. */}
+          <div
+            role="presentation"
+            className="contents"
+            onClick={() => inputRef.current?.focus()}
           >
-            <div className="flex w-full items-center gap-2">
-              <InputTypeIn
-                ref={inputRef}
-                placeholder="Your name"
-                value={name || ""}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  setName(e.target.value)
-                }
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && name && name.trim().length > 0) {
-                    e.preventDefault();
-                    handleSave();
+            <InputHorizontal
+              responsive
+              icon={SvgUser}
+              title="What should Onyx call you?"
+              description="We will display this name in the app."
+            >
+              <div className="flex w-full items-center gap-2">
+                <InputTypeIn
+                  ref={inputRef}
+                  placeholder="Your name"
+                  value={name || ""}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setName(e.target.value)
                   }
-                }}
-              />
-              <Button disabled={name === ""} onClick={handleSave}>
-                Save
-              </Button>
-            </div>
-          </InputHorizontal>
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && name && name.trim().length > 0) {
+                      e.preventDefault();
+                      handleSave();
+                    }
+                  }}
+                />
+                <Button disabled={name === ""} onClick={handleSave}>
+                  Save
+                </Button>
+              </div>
+            </InputHorizontal>
+          </div>
         </div>
       ) : (
         <Hoverable.Root group="nonAdminName" width="full">
@@ -126,10 +137,8 @@ export default function NonAdminStep() {
             aria-label="Edit display name"
             role="button"
             tabIndex={0}
-            onClick={() => {
-              setIsEditing(true);
-              setName(savedName);
-            }}
+            onClick={handleEdit}
+            onKeyDown={clickOnKeyDown(handleEdit)}
           >
             <div className="flex items-center gap-1">
               <InputAvatar

--- a/web/src/sections/onboarding/steps/NameStep.tsx
+++ b/web/src/sections/onboarding/steps/NameStep.tsx
@@ -9,7 +9,7 @@ import {
   OnboardingStep,
 } from "@/interfaces/onboarding";
 import InputAvatar from "@/refresh-components/inputs/InputAvatar";
-import { cn } from "@opal/utils";
+import { cn, clickOnKeyDown } from "@opal/utils";
 import IconButton from "@/refresh-components/buttons/IconButton";
 import { SvgCheckCircle, SvgEdit, SvgUser } from "@opal/icons";
 import { InputHorizontal } from "@opal/layouts";
@@ -39,36 +39,46 @@ const NameStep = React.memo(
     };
 
     const inputRef = useRef<HTMLInputElement>(null);
+
+    const handleEdit = () => {
+      setButtonActive(true);
+      goToStep(OnboardingStep.Name);
+    };
+
     return isActive ? (
       <div
         className={containerClasses}
-        onClick={() => inputRef.current?.focus()}
         role="group"
         aria-label="onboarding-name-step"
       >
-        <InputHorizontal
-          responsive
-          icon={SvgUser}
-          title="What should Onyx call you?"
-          description="We will display this name in the app."
+        {/* Pointer convenience only — the input is already keyboard reachable. */}
+        <div
+          role="presentation"
+          className="contents"
+          onClick={() => inputRef.current?.focus()}
         >
-          <InputTypeIn
-            ref={inputRef}
-            placeholder="Your name"
-            value={userName || ""}
-            onChange={(e) => updateName(e.target.value)}
-            onKeyDown={handleKeyDown}
-          />
-        </InputHorizontal>
+          <InputHorizontal
+            responsive
+            icon={SvgUser}
+            title="What should Onyx call you?"
+            description="We will display this name in the app."
+          >
+            <InputTypeIn
+              ref={inputRef}
+              placeholder="Your name"
+              value={userName || ""}
+              onChange={(e) => updateName(e.target.value)}
+              onKeyDown={handleKeyDown}
+            />
+          </InputHorizontal>
+        </div>
       </div>
     ) : (
       <Hoverable.Root group="nameStep" width="full">
         <div
           className={containerClasses}
-          onClick={() => {
-            setButtonActive(true);
-            goToStep(OnboardingStep.Name);
-          }}
+          onClick={handleEdit}
+          onKeyDown={clickOnKeyDown(handleEdit)}
           aria-label="Edit display name"
           role="button"
           tabIndex={0}

--- a/web/src/sections/sidebar/ChatButton.tsx
+++ b/web/src/sections/sidebar/ChatButton.tsx
@@ -22,6 +22,7 @@ import ShareChatSessionModal from "@/sections/modals/ShareChatSessionModal";
 import { Button, LineItemButton, SidebarTab } from "@opal/components";
 import IconButton from "@/refresh-components/buttons/IconButton";
 import { InputTypeIn } from "@opal/components";
+import useFocusOnMount from "@opal/hooks/useFocusOnMount";
 import { DRAG_TYPES, LOCAL_STORAGE_KEYS } from "@/lib/sidebar/constants";
 import {
   shouldShowMoveModal,
@@ -53,6 +54,7 @@ export function PopoverSearchInput({
   onSearch,
 }: PopoverSearchInputProps) {
   const [searchTerm, setSearchTerm] = useState("");
+  const focusOnMount = useFocusOnMount<HTMLInputElement>();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
@@ -87,7 +89,7 @@ export function PopoverSearchInput({
         placeholder="Search Projects"
         onClick={noProp()}
         variant="internal"
-        autoFocus
+        ref={focusOnMount}
       />
     </div>
   );

--- a/web/src/sections/sidebar/CreateConnectorSidebar.tsx
+++ b/web/src/sections/sidebar/CreateConnectorSidebar.tsx
@@ -130,17 +130,15 @@ export default function CreateConnectorSidebar() {
                   }}
                 />
               )}
-              <div
+              <button
+                type="button"
+                disabled={!allowed}
                 className={cn(
                   "flex items-center",
                   allowed ? "cursor-pointer" : "cursor-not-allowed"
                 )}
                 style={{ height: STEP_ROW_PX }}
-                onClick={() => {
-                  if (allowed) {
-                    setFormStep(stepValue);
-                  }
-                }}
+                onClick={() => setFormStep(stepValue)}
               >
                 <Content
                   sizePreset="main-ui"
@@ -149,7 +147,7 @@ export default function CreateConnectorSidebar() {
                   title={step}
                   color={selected === "future" ? "muted" : "default"}
                 />
-              </div>
+              </button>
             </Fragment>
           );
         })}

--- a/web/src/views/admin/GroupsPage/SharedGroupResources/ResourcePopover.tsx
+++ b/web/src/views/admin/GroupsPage/SharedGroupResources/ResourcePopover.tsx
@@ -89,7 +89,7 @@ function ResourcePopover({
                           )}
                           role="button"
                           tabIndex={0}
-                          aria-label={item.key}
+                          aria-label={item.label}
                           onKeyDown={clickOnKeyDown(item.onSelect)}
                           onClick={() => {
                             item.onSelect();

--- a/web/src/views/admin/GroupsPage/SharedGroupResources/ResourcePopover.tsx
+++ b/web/src/views/admin/GroupsPage/SharedGroupResources/ResourcePopover.tsx
@@ -8,7 +8,7 @@ import { Popover } from "@opal/components";
 import { Divider } from "@opal/components";
 import { InputTypeIn } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
-import { cn } from "@opal/utils";
+import { cn, clickOnKeyDown } from "@opal/utils";
 import type { ResourcePopoverProps } from "@/views/admin/GroupsPage/SharedGroupResources/interfaces";
 
 function ResourcePopover({
@@ -77,6 +77,8 @@ function ResourcePopover({
                       justifyContent="start"
                     >
                       {section.items.map((item) => (
+                        // The rendered item can hold its own buttons, so this
+                        // stays a div with button semantics.
                         <div
                           key={item.key}
                           className={cn(
@@ -85,6 +87,10 @@ function ResourcePopover({
                               ? "bg-background-tint-02"
                               : "hover:bg-background-tint-02 transition-colors"
                           )}
+                          role="button"
+                          tabIndex={0}
+                          aria-label={item.key}
+                          onKeyDown={clickOnKeyDown(item.onSelect)}
                           onClick={() => {
                             item.onSelect();
                           }}

--- a/web/src/views/admin/GroupsPage/SharedGroupResources/index.tsx
+++ b/web/src/views/admin/GroupsPage/SharedGroupResources/index.tsx
@@ -47,7 +47,7 @@ function SourceIconStack({ sources }: SourceIconStackProps) {
   if (sources.length === 0) return null;
 
   const unique = Array.from(
-    new Map(sources.map((s) => [s.source, s])).values()
+    new Map(sources.map((s) => [s.source, s])).values(),
   ).slice(0, 3);
 
   return (
@@ -98,28 +98,28 @@ function SharedGroupResources({
 
   const selectedCcPairSet = useMemo(
     () => new Set(selectedCcPairIds),
-    [selectedCcPairIds]
+    [selectedCcPairIds],
   );
   const selectedDocSetSet = useMemo(
     () => new Set(selectedDocSetIds),
-    [selectedDocSetIds]
+    [selectedDocSetIds],
   );
   const selectedAgentSet = useMemo(
     () => new Set(selectedAgentIds),
-    [selectedAgentIds]
+    [selectedAgentIds],
   );
 
   const selectedPairs = useMemo(
     () => connectors.filter((p) => selectedCcPairSet.has(p.cc_pair_id)),
-    [connectors, selectedCcPairSet]
+    [connectors, selectedCcPairSet],
   );
   const selectedDocSets = useMemo(
     () => documentSets.filter((ds) => selectedDocSetSet.has(ds.id)),
-    [documentSets, selectedDocSetSet]
+    [documentSets, selectedDocSetSet],
   );
   const selectedAgentObjects = useMemo(
     () => agents.filter((a) => selectedAgentSet.has(a.id)),
-    [agents, selectedAgentSet]
+    [agents, selectedAgentSet],
   );
 
   // --- Popover sections ---
@@ -133,16 +133,17 @@ function SharedGroupResources({
         const isSelected = selectedCcPairSet.has(p.cc_pair_id);
         return {
           key: `c-${p.cc_pair_id}`,
+          label: p.name ?? `Connector #${p.cc_pair_id}`,
           disabled: isSelected,
           onSelect: () =>
             isSelected
               ? onCcPairIdsChange(
-                  selectedCcPairIds.filter((id) => id !== p.cc_pair_id)
+                  selectedCcPairIds.filter((id) => id !== p.cc_pair_id),
                 )
               : onCcPairIdsChange([...selectedCcPairIds, p.cc_pair_id]),
           render: (dimmed: boolean) => (
             <LineItem
-              interactive={!dimmed}
+              interactive={false}
               muted={dimmed}
               icon={getSourceMetadata(p.connector.source).icon}
               strokeIcon={false}
@@ -162,16 +163,17 @@ function SharedGroupResources({
         const isSelected = selectedDocSetSet.has(ds.id);
         return {
           key: `d-${ds.id}`,
+          label: ds.name,
           disabled: isSelected,
           onSelect: () =>
             isSelected
               ? onDocSetIdsChange(
-                  selectedDocSetIds.filter((id) => id !== ds.id)
+                  selectedDocSetIds.filter((id) => id !== ds.id),
                 )
               : onDocSetIdsChange([...selectedDocSetIds, ds.id]),
           render: (dimmed: boolean) => (
             <LineItem
-              interactive={!dimmed}
+              interactive={false}
               muted={dimmed}
               icon={SvgFiles}
               rightChildren={
@@ -213,6 +215,7 @@ function SharedGroupResources({
         const isSelected = selectedAgentSet.has(a.id);
         return {
           key: `a-${a.id}`,
+          label: a.name,
           disabled: isSelected,
           onSelect: () =>
             isSelected
@@ -220,7 +223,7 @@ function SharedGroupResources({
               : onAgentIdsChange([...selectedAgentIds, a.id]),
           render: (dimmed: boolean) => (
             <LineItem
-              interactive={!dimmed}
+              interactive={false}
               muted={dimmed}
               icon={(_props) => <AgentAvatar agent={a} size={16} />}
               description="agent"

--- a/web/src/views/admin/GroupsPage/SharedGroupResources/index.tsx
+++ b/web/src/views/admin/GroupsPage/SharedGroupResources/index.tsx
@@ -47,7 +47,7 @@ function SourceIconStack({ sources }: SourceIconStackProps) {
   if (sources.length === 0) return null;
 
   const unique = Array.from(
-    new Map(sources.map((s) => [s.source, s])).values(),
+    new Map(sources.map((s) => [s.source, s])).values()
   ).slice(0, 3);
 
   return (
@@ -98,28 +98,28 @@ function SharedGroupResources({
 
   const selectedCcPairSet = useMemo(
     () => new Set(selectedCcPairIds),
-    [selectedCcPairIds],
+    [selectedCcPairIds]
   );
   const selectedDocSetSet = useMemo(
     () => new Set(selectedDocSetIds),
-    [selectedDocSetIds],
+    [selectedDocSetIds]
   );
   const selectedAgentSet = useMemo(
     () => new Set(selectedAgentIds),
-    [selectedAgentIds],
+    [selectedAgentIds]
   );
 
   const selectedPairs = useMemo(
     () => connectors.filter((p) => selectedCcPairSet.has(p.cc_pair_id)),
-    [connectors, selectedCcPairSet],
+    [connectors, selectedCcPairSet]
   );
   const selectedDocSets = useMemo(
     () => documentSets.filter((ds) => selectedDocSetSet.has(ds.id)),
-    [documentSets, selectedDocSetSet],
+    [documentSets, selectedDocSetSet]
   );
   const selectedAgentObjects = useMemo(
     () => agents.filter((a) => selectedAgentSet.has(a.id)),
-    [agents, selectedAgentSet],
+    [agents, selectedAgentSet]
   );
 
   // --- Popover sections ---
@@ -138,7 +138,7 @@ function SharedGroupResources({
           onSelect: () =>
             isSelected
               ? onCcPairIdsChange(
-                  selectedCcPairIds.filter((id) => id !== p.cc_pair_id),
+                  selectedCcPairIds.filter((id) => id !== p.cc_pair_id)
                 )
               : onCcPairIdsChange([...selectedCcPairIds, p.cc_pair_id]),
           render: (dimmed: boolean) => (
@@ -168,7 +168,7 @@ function SharedGroupResources({
           onSelect: () =>
             isSelected
               ? onDocSetIdsChange(
-                  selectedDocSetIds.filter((id) => id !== ds.id),
+                  selectedDocSetIds.filter((id) => id !== ds.id)
                 )
               : onDocSetIdsChange([...selectedDocSetIds, ds.id]),
           render: (dimmed: boolean) => (

--- a/web/src/views/admin/GroupsPage/SharedGroupResources/interfaces.ts
+++ b/web/src/views/admin/GroupsPage/SharedGroupResources/interfaces.ts
@@ -1,5 +1,7 @@
 export interface PopoverItem {
   key: string;
+  /** Human-readable name, used as the row's accessible label. */
+  label: string;
   render: (disabled: boolean) => React.ReactNode;
   onSelect: () => void;
   /** When true, the item is already selected — shown dimmed with bg-tint-02. */

--- a/web/src/views/admin/UsersPage/GroupsCell.tsx
+++ b/web/src/views/admin/UsersPage/GroupsCell.tsx
@@ -8,6 +8,7 @@ import {
   useEffect,
 } from "react";
 import { Hoverable } from "@opal/core";
+import { clickOnKeyDown } from "@opal/utils";
 import { SvgEdit } from "@opal/icons";
 import { Button, Tag } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
@@ -137,10 +138,18 @@ export default function GroupsCell({
   return (
     <>
       <Hoverable.Root group="tags">
+        {/* The cell holds its own edit button, so it stays a div with button
+        semantics rather than a <button> wrapping a <button>. */}
         <div
           className={`relative flex justify-between items-center w-full min-w-0 ${
             user.id ? "cursor-pointer" : ""
           }`}
+          role="button"
+          tabIndex={user.id ? 0 : -1}
+          aria-label="Edit groups"
+          onKeyDown={clickOnKeyDown(() => {
+            if (user.id) setShowModal(true);
+          })}
           onClick={user.id ? () => setShowModal(true) : undefined}
         >
           {groups.length === 0 ? (

--- a/web/src/views/admin/UsersPage/GroupsCell.tsx
+++ b/web/src/views/admin/UsersPage/GroupsCell.tsx
@@ -144,13 +144,17 @@ export default function GroupsCell({
           className={`relative flex justify-between items-center w-full min-w-0 ${
             user.id ? "cursor-pointer" : ""
           }`}
-          role="button"
-          tabIndex={user.id ? 0 : -1}
-          aria-label="Edit groups"
-          onKeyDown={clickOnKeyDown(() => {
-            if (user.id) setShowModal(true);
-          })}
-          onClick={user.id ? () => setShowModal(true) : undefined}
+          // A cell without a user has nothing to edit, so it carries no button
+          // semantics at all.
+          {...(user.id
+            ? {
+                role: "button" as const,
+                tabIndex: 0,
+                "aria-label": "Edit groups",
+                onClick: () => setShowModal(true),
+                onKeyDown: clickOnKeyDown(() => setShowModal(true)),
+              }
+            : {})}
         >
           {groups.length === 0 ? (
             <div

--- a/web/src/views/admin/UsersPage/InviteUsersModal.tsx
+++ b/web/src/views/admin/UsersPage/InviteUsersModal.tsx
@@ -224,7 +224,7 @@ export default function InviteUsersModal({
             onChange={handleInputChange}
             placeholder="Add emails to invite, space or comma separated"
             minRows={EMAIL_FIELD_ROWS}
-            autoFocus
+            focusOnMount
           />
           {message && (
             <Content

--- a/web/src/views/admin/UsersPage/UsersSummary.tsx
+++ b/web/src/views/admin/UsersPage/UsersSummary.tsx
@@ -2,6 +2,7 @@ import { SvgArrowUpRight, SvgFilterPlus, SvgUserSync } from "@opal/icons";
 import { ContentAction } from "@opal/layouts";
 import { Button, Card } from "@opal/components";
 import { Hoverable } from "@opal/core";
+import { clickOnKeyDown } from "@opal/utils";
 import { Section } from "@/layouts/general-layouts";
 import IconButton from "@/refresh-components/buttons/IconButton";
 import Text from "@/refresh-components/texts/Text";
@@ -23,37 +24,55 @@ type StatCellProps = {
 function StatCell({ value, label, onFilter }: StatCellProps) {
   const display = value === null ? "\u2014" : value.toLocaleString();
 
+  const cellClassName = `relative flex flex-col items-start gap-0.5 w-full p-2 rounded-08 transition-colors ${
+    onFilter ? "cursor-pointer hover:bg-background-tint-02" : ""
+  }`;
+
+  const cellBody = (
+    <>
+      <Text as="span" mainUiAction text04>
+        {display}
+      </Text>
+      <Text as="span" secondaryBody text03>
+        {label}
+      </Text>
+      {onFilter && (
+        <div className="absolute right-1 top-1">
+          <Hoverable.Item group="stat" variant="appear-on-hover">
+            <IconButton
+              tertiary
+              icon={SvgFilterPlus}
+              tooltip="Add Filter"
+              toolTipPosition="left"
+              onClick={(e) => {
+                e.stopPropagation();
+                onFilter();
+              }}
+            />
+          </Hoverable.Item>
+        </div>
+      )}
+    </>
+  );
+
   return (
     <Hoverable.Root group="stat" width="full">
-      <div
-        className={`relative flex flex-col items-start gap-0.5 w-full p-2 rounded-08 transition-colors ${
-          onFilter ? "cursor-pointer hover:bg-background-tint-02" : ""
-        }`}
-        onClick={onFilter}
-      >
-        <Text as="span" mainUiAction text04>
-          {display}
-        </Text>
-        <Text as="span" secondaryBody text03>
-          {label}
-        </Text>
-        {onFilter && (
-          <div className="absolute right-1 top-1">
-            <Hoverable.Item group="stat" variant="appear-on-hover">
-              <IconButton
-                tertiary
-                icon={SvgFilterPlus}
-                tooltip="Add Filter"
-                toolTipPosition="left"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onFilter();
-                }}
-              />
-            </Hoverable.Item>
-          </div>
-        )}
-      </div>
+      {onFilter ? (
+        // The cell holds its own filter button, so it stays a div with button
+        // semantics rather than a <button> wrapping a <button>.
+        <div
+          className={cellClassName}
+          role="button"
+          tabIndex={0}
+          aria-label={`Filter by ${label}`}
+          onKeyDown={clickOnKeyDown(onFilter)}
+          onClick={onFilter}
+        >
+          {cellBody}
+        </div>
+      ) : (
+        <div className={cellClassName}>{cellBody}</div>
+      )}
     </Hoverable.Root>
   );
 }

--- a/web/tests/e2e/chat/chat_file_uploads.spec.ts
+++ b/web/tests/e2e/chat/chat_file_uploads.spec.ts
@@ -215,7 +215,7 @@ test.describe("Chat File Uploads", () => {
       );
 
       const aiMessage = page.getByTestId("onyx-ai-message").first();
-      const generatedImage = aiMessage.locator('img[alt="Chat Message Image"]');
+      const generatedImage = aiMessage.locator('img[alt="Chat attachment"]');
       await expect(generatedImage).toBeVisible({ timeout: 10000 });
       await expect(generatedImage).toHaveAttribute(
         "src",

--- a/web/tests/e2e/chat/file_preview_modal.spec.ts
+++ b/web/tests/e2e/chat/file_preview_modal.spec.ts
@@ -134,7 +134,7 @@ test.describe("File preview modal from chat file links", () => {
 
     // Find the link in the AI message and click it
     const aiMessage = page.getByTestId("onyx-ai-message").last();
-    const fileLink = aiMessage.locator("a").filter({ hasText: "notes.txt" });
+    const fileLink = aiMessage.getByRole("button", { name: "notes.txt" });
     await expect(fileLink).toBeVisible({ timeout: 5000 });
     await fileLink.click();
 
@@ -171,7 +171,7 @@ test.describe("File preview modal from chat file links", () => {
 
     // Find the link in the AI message and click it
     const aiMessage = page.getByTestId("onyx-ai-message").last();
-    const fileLink = aiMessage.locator("a").filter({ hasText: "app.py" });
+    const fileLink = aiMessage.getByRole("button", { name: "app.py" });
     await expect(fileLink).toBeVisible({ timeout: 5000 });
     await fileLink.click();
 
@@ -224,7 +224,7 @@ test.describe("File preview modal from chat file links", () => {
     await sendMessageWithMockResponse(page, "Give me the csv", mockContent);
 
     const aiMessage = page.getByTestId("onyx-ai-message").last();
-    const fileLink = aiMessage.locator("a").filter({ hasText: "data.csv" });
+    const fileLink = aiMessage.getByRole("button", { name: "data.csv" });
     await expect(fileLink).toBeVisible({ timeout: 5000 });
     await fileLink.click();
 
@@ -265,7 +265,7 @@ test.describe("File preview modal from chat file links", () => {
     );
 
     const aiMessage = page.getByTestId("onyx-ai-message").last();
-    const fileLink = aiMessage.locator("a").filter({ hasText: "report.docx" });
+    const fileLink = aiMessage.getByRole("button", { name: "report.docx" });
     await expect(fileLink).toBeVisible({ timeout: 5000 });
     await fileLink.click();
 
@@ -310,9 +310,9 @@ test.describe("File preview modal from chat file links", () => {
     );
 
     const aiMessage = page.getByTestId("onyx-ai-message").last();
-    const fileLink = aiMessage
-      .locator("a")
-      .filter({ hasText: "old_report.doc" });
+    const fileLink = aiMessage.getByRole("button", {
+      name: "old_report.doc",
+    });
     await expect(fileLink).toBeVisible({ timeout: 5000 });
     await fileLink.click();
 


### PR DESCRIPTION
## What

Enables the `jsx-a11y` oxlint plugin in `web/.oxlintrc.json` and fixes all 211 violations. Keyboard users can now reach every clickable surface.

## How

Three patterns cover the sites:

| Situation | Fix |
| --- | --- |
| Standalone clickable `div`/`span` | Real `<button type="button">` |
| Clickable container that holds its own buttons or checkboxes | `role="button"` + `tabIndex` + `aria-label` + key handler |
| Backdrop, focus proxy, propagation guard, pointer-convenience wrapper | `role="presentation"` |

Containers keep their `div` because a `<button>` inside a `<button>` is invalid HTML.

Two shared helpers support this:

- `clickOnKeyDown` in `web/lib/opal/src/utils.ts` builds the Enter/Space handler that mirrors a click.
- `useFocusOnMount` in `web/lib/opal/src/hooks/` replaces the 15 `autoFocus` uses.

## Notes

- The rules need a role that is visible statically. `role={cond ? "button" : undefined}` does not satisfy them. Components that are interactive only in some states (`Divider`, `Tag`, `LineItem`, `FileTile`, `UsersSummary`, `UserLibraryModal`, `MultiModelPanel`, `StoppedHeader`, `InputChipStrip`) now hoist their `className` and body, then return two static branches. This is most of the diff size.
- `prefer-tag-over-role` stays off (40 violations), because the nested-button containers must keep the role. The other 17 rules are on.
- No behavior changes. Every site that responded to a click still does, and now also responds to the keyboard.

## Test plan

- `bun run lint` passes.
- `bunx tsc --noEmit` passes.
- `pre-commit run --files ...` passes (oxfmt, oxlint, TypeScript).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the `jsx-a11y` `oxlint` plugin and resolves 211 violations so keyboard users can operate every clickable surface. Clickable non‑interactive elements are now real buttons or containers with button semantics; `autoFocus` usages are replaced, image alt text is descriptive, and chat image layout is preserved.

- Config: adds `jsx-a11y` to `web/.oxlintrc.json`; keeps `jsx-a11y/prefer-tag-over-role` off.
- Keyboard parity: `clickOnKeyDown` in `@opal/utils` mirrors a click, runs only when the container holds focus, ignores key repeats, and prevents default; used with `role="button"` + `tabIndex={0}` on containers that cannot be `<button>`.
- Focus: `useFocusOnMount` in `@opal/hooks/useFocusOnMount` replaces `autoFocus` for inputs shown after user actions; `InputTags` renames `autoFocus` to `focusOnMount`.
- Semantics: segmented date/time inputs move `role="group"` + labels to the segment container; internal proxy controls use `aria-hidden`/`tabIndex={-1}`; backdrops/propagation guards use `role="presentation"`; `<html lang="en">` set.
- Content/labels: copy controls and most thumbnails are `<button>`s; file links in chat render as inline buttons (not `<a>`); popover/resource rows announce human‑readable labels and avoid extra tab stops; inactive headers/rows/cells drop button semantics; rows blocked by state use `aria-disabled` with guarded handlers so tooltips remain hoverable.
- Images: avoid baseline whitespace from an inline‑block `<button>` by applying button semantics to the existing container in `InMessageImage`; `InputBarPreviewImage` uses its wrapper as the `<button>`; alt text updated (“Chat attachment”, “Uploaded attachment”).
- Tests: update Playwright locators to match new semantics (chat file links are buttons; updated image alt text; rename control labeled “Rename”).
- No behavior changes: every site that responded to a click still does, and now also responds to the keyboard.

<sup>Written for commit 5dc0d4f6840bd16bbbf95de43acbd96c57e1c998. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

