### PR TITLE
fix(web): remove the phantom tab stop on recent chat rows

### DIFF
--- a/web/src/sections/sidebar/ChatButton.tsx
+++ b/web/src/sections/sidebar/ChatButton.tsx
@@ -141,16 +141,18 @@ const ChatButton = memo(
 
     // Drag and drop setup for chat sessions
     const dragId = `${DRAG_TYPES.CHAT}-${chatSession.id}`;
-    const { attributes, listeners, setNodeRef, transform, isDragging } =
-      useDraggable({
-        id: dragId,
-        data: {
-          type: DRAG_TYPES.CHAT,
-          chatSession,
-          projectId: project?.id,
-        },
-        disabled: !draggable || renaming,
-      });
+    // `attributes` is intentionally dropped: it turns the wrapper into a
+    // focusable role="button", which adds a second tab stop per row and lets
+    // Enter/Space start a keyboard drag that looks like the chat is disabled.
+    const { listeners, setNodeRef, transform, isDragging } = useDraggable({
+      id: dragId,
+      data: {
+        type: DRAG_TYPES.CHAT,
+        chatSession,
+        projectId: project?.id,
+      },
+      disabled: !draggable || renaming,
+    });
 
     // Sync local name state when chatSession.name changes (e.g., after auto-naming)
     useEffect(() => {
@@ -528,7 +530,6 @@ const ChatButton = memo(
                 : undefined,
               opacity: isDragging ? 0.5 : 1,
             }}
-            {...(mounted ? attributes : {})}
             {...(mounted ? listeners : {})}
           >
             {popover}


### PR DESCRIPTION
## Problem

Tabbing to a recent chat in the sidebar hits **two** tab stops per row. The first one is not a real control: pressing Enter or Space on it makes the chat look disabled (dimmed, no longer clickable). The second one is the chat link, which behaves as expected.

## Cause

`ChatButton` spreads `@dnd-kit`'s `attributes` onto the `div` that wraps each row. Those attributes are `role="button"` and `tabIndex={0}`, which makes the wrapper a tab stop ahead of the chat link.

The sidebar's `DndContext` registers a `KeyboardSensor`, so Enter or Space on that wrapper starts a keyboard drag. While dragging, the row drops its `href` and renders at `opacity: 0.5` — this is the "disabled" appearance.

## Change

Stop spreading `attributes` onto the wrapper. `listeners` stays, so pointer drag (chat into a project) is unchanged.

This removes keyboard-initiated drag for chats. That path had no visible affordance, produced the confusing state above, and only moves a chat into a project — Recents rows are not reorderable.

## Test

Ran the app and checked the sidebar with Playwright:

- Each recent chat row now has one tab stop, the chat link (`a[href="/app?chatId=..."]`).
- Shift+Tab from the link lands on the previous sidebar row, not on a wrapper.
- No `[aria-roledescription="draggable"]` elements remain in the DOM.
- `tsc --noEmit` shows no new errors, and `bun run format:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the extra tab stop on each recent chat row by dropping `@dnd-kit` drag `attributes` from the wrapper. Previously the wrapper was focusable and Enter/Space started a keyboard drag that dimmed the row and broke the link; now each row has a single tab stop (the link) and the chat stays interactive.

- Stops spreading `attributes` (which added role="button" and tabIndex=0); keeps `listeners`, `setNodeRef`, `transform`, and `isDragging` so pointer drag into a project still works.
- Keyboard-initiated drag for chats is removed; Recents are not reorderable, so behavior is otherwise unchanged.
- Verify: tabbing lands only on the chat link, Shift+Tab moves between rows, and no elements expose `[aria-roledescription="draggable"]`.

<sup>Written for commit b4d8ce9432f3ef284b24c08a1d327fcbaa4fc061. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

