### PR TITLE
chore(helm): publish charts via release assets and OCI

### DIFF
--- a/.github/workflows/helm-chart-releases.yml
+++ b/.github/workflows/helm-chart-releases.yml
@@ -1,40 +1,61 @@
 name: Release Onyx Helm Charts
 
-# Only runs when packaged chart files change. `helm package` is not
-# byte-reproducible (gzip records a timestamp), so every run rewrites every
-# chart tarball on gh-pages. Tarballs are already compressed, so git cannot
-# delta them and stores each republish in full. Running on every push to main
-# grew gh-pages to 2 GB, which every clone of this repo pays for.
+# Publishes the chart three ways from one packaged tarball:
+#   1. a GitHub release (`helm/onyx-<version>`) that carries the .tgz asset,
+#   2. an index.yaml entry on gh-pages pointing at that asset, which keeps
+#      `helm repo add onyx https://onyx-dot-app.github.io/onyx` working,
+#   3. an OCI artifact at ghcr.io/onyx-dot-app/charts/onyx for `helm install
+#      oci://...` users.
+#
+# Tarballs are deliberately NOT committed to gh-pages. `helm package` is not
+# byte-reproducible (gzip records a timestamp), so the previous publisher
+# rewrote every tarball on every run. Tarballs are already compressed, so git
+# cannot delta them and stored each republish in full, which every clone of this
+# repo pays for. Release assets have no such cost and every step below skips
+# versions that are already published, so a re-run is a no-op.
 on:
   push:
     branches:
       - main
     paths:
       - "deployment/helm/charts/**"
+  workflow_dispatch:
 
-permissions: write-all
+permissions: read-all
 
 concurrency:
   group: helm-chart-releases
   cancel-in-progress: false
 
+env:
+  # `onyx-cnpg-crds` is intentionally not published. The parent chart consumes
+  # it as `file://../onyx-cnpg-crds` and `helm package` vendors it into the onyx
+  # tarball, so a standalone release would have no consumer.
+  CHART_DIR: deployment/helm/charts/onyx
+  # cr requires this exact directory name (`cr upload --package-path`).
+  PACKAGE_DIR: .cr-release-packages
+  OCI_REPOSITORY: oci://ghcr.io/onyx-dot-app/charts
+
 jobs:
   release:
     permissions:
-      contents: write
+      contents: write # create the release/tag and push index.yaml to gh-pages
+      packages: write # push the chart to ghcr.io
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v6
         with:
+          # chart-releaser needs full history to resolve the release commit.
           fetch-depth: 0
+          # cr authenticates with CR_TOKEN, not the git credential helper.
           persist-credentials: false
 
       - name: Install Helm CLI
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # ratchet:azure/setup-helm@v5.0.1
         with:
-          version: v3.12.1
+          version: v3.19.0
 
       - name: Add required Helm repositories
         run: |
@@ -47,22 +68,69 @@ jobs:
           helm repo add code-interpreter https://onyx-dot-app.github.io/python-sandbox/
           helm repo update
 
-      - name: Build chart dependencies
+      # Packaged here rather than by chart-releaser so the release, the
+      # index.yaml entry and the OCI artifact all ship the same bytes.
+      - name: Package chart
+        id: package
         run: |
           set -euo pipefail
-          for chart_dir in deployment/helm/charts/*; do
-            if [ -f "$chart_dir/Chart.yaml" ]; then
-              echo "Building dependencies for $chart_dir"
-              helm dependency build "$chart_dir"
-            fi
-          done
+          helm dependency build "${CHART_DIR}"
+          mkdir -p "${PACKAGE_DIR}"
+          helm package "${CHART_DIR}" --destination "${PACKAGE_DIR}"
 
-      - name: Publish Helm charts to gh-pages
-        # NOTE: HEAD of https://github.com/stefanprodan/helm-gh-pages/pull/43
-        uses: stefanprodan/helm-gh-pages@ad32ad3b8720abfeaac83532fd1e9bdfca5bbe27 # zizmor: ignore[impostor-commit]
+          # Derive the version from the artifact helm just wrote rather than by
+          # parsing Chart.yaml, so the release, the index entry and the OCI tag
+          # can never disagree with the file being uploaded.
+          package="$(find "${PACKAGE_DIR}" -name 'onyx-*.tgz' -print -quit)"
+          [ -n "$package" ] || { echo "helm package produced no tarball" >&2; exit 1; }
+          version="$(basename "$package" .tgz)"
+          version="${version#onyx-}"
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "package=${package}" >> "$GITHUB_OUTPUT"
+          echo "Packaged onyx ${version} -> ${package}"
+
+      - name: Publish GitHub release and gh-pages index
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # ratchet:helm/chart-releaser-action@v1.7.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          charts_dir: deployment/helm/charts
-          branch: gh-pages
-          commit_username: ${{ github.actor }}
-          commit_email: ${{ github.actor }}@users.noreply.github.com
+          config: cr.yaml
+          # We already packaged into PACKAGE_DIR above.
+          skip_packaging: true
+          # Tarballs go to release assets; gh-pages only gets index.yaml.
+          packages_with_index: false
+          # A published version is never rewritten, so re-runs are no-ops.
+          skip_existing: true
+          # "Latest" belongs to the application release train (`v*.*.*`).
+          mark_as_latest: false
+          pages_branch: gh-pages
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Secondary distribution channel. The Pages repo above stays the default
+      # documented install path: `helm repo add` cannot consume an `oci://` URL,
+      # so OCI is opt-in for users who ask for it.
+      - name: Log in to GHCR
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          printf '%s' "${GHCR_TOKEN}" \
+            | helm registry login ghcr.io --username "${GHCR_USER}" --password-stdin
+
+      - name: Push chart to GHCR
+        env:
+          CHART_VERSION: ${{ steps.package.outputs.version }}
+          CHART_PACKAGE: ${{ steps.package.outputs.package }}
+        run: |
+          set -euo pipefail
+          # `helm push` overwrites an existing tag, so guard it explicitly to
+          # keep re-runs from republishing a version under new digests.
+          if helm show chart "${OCI_REPOSITORY}/onyx" --version "${CHART_VERSION}" >/dev/null 2>&1; then
+            echo "onyx ${CHART_VERSION} already present in ${OCI_REPOSITORY}, skipping"
+            exit 0
+          fi
+          helm push "${CHART_PACKAGE}" "${OCI_REPOSITORY}"
+
+      - name: Log out of GHCR
+        if: always()
+        run: helm registry logout ghcr.io || true

--- a/cr.yaml
+++ b/cr.yaml
@@ -6,6 +6,12 @@
 #
 # Chart releases get a `helm/` tag prefix so they cannot collide with the
 # application releases (`v*.*.*`) or with the other prefixed release trains
-# (`cli/v*.*.*`, `opal/v*.*.*`). No workflow in this repo triggers on a `helm/`
-# tag, so publishing a chart does not re-run the application pipelines.
+# (`cli/v*.*.*`, `opal/v*.*.*`).
+#
+# The prefix also keeps chart publishes out of the image build pipeline.
+# `deployment.yml` triggers on `tags: ["*"]`, but a GitHub Actions `*` filter
+# does not match `/`, so slash-prefixed tags never reach it — which is why the
+# existing `cli/` and `opal/` tags do not build images either. Keep the prefix:
+# an unprefixed chart tag WOULD match that filter and publish web, backend and
+# model-server images under the chart version.
 release-name-template: "helm/{{ .Name }}-{{ .Version }}"

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,0 +1,11 @@
+# See https://github.com/helm/chart-releaser#configuration
+#
+# Only settings that chart-releaser-action does not expose as a workflow input
+# belong here. Everything else is set in .github/workflows/helm-chart-releases.yml
+# so there is one source of truth per setting.
+#
+# Chart releases get a `helm/` tag prefix so they cannot collide with the
+# application releases (`v*.*.*`) or with the other prefixed release trains
+# (`cli/v*.*.*`, `opal/v*.*.*`). No workflow in this repo triggers on a `helm/`
+# tag, so publishing a chart does not re-run the application pipelines.
+release-name-template: "helm/{{ .Name }}-{{ .Version }}"

--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -23,11 +23,19 @@ helm install onyx oci://ghcr.io/onyx-dot-app/charts/onyx \
 ```
 
 `helm repo add` does not accept `oci://` URLs, so an OCI install needs an
-explicit `--version`; there is no `helm repo update` or `helm search repo` for
-it. List the published versions with:
+explicit `--version`. There is no `helm repo update` or `helm search repo` for
+OCI and no helm command that lists the available versions. Read them from the
+`helm/onyx-<version>` [releases](https://github.com/onyx-dot-app/onyx/releases)
+or from the Helm repository index:
 
 ```bash
-helm show chart oci://ghcr.io/onyx-dot-app/charts/onyx --version <version>
+helm search repo onyx/onyx --versions   # needs `helm repo add` from above
+```
+
+To inspect one version before installing it:
+
+```bash
+helm show chart oci://ghcr.io/onyx-dot-app/charts/onyx --version 0.8.16
 ```
 
 Both channels ship identical bytes from the same build. Use the Helm repository

--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -1,3 +1,38 @@
+# Installing the chart
+
+## Helm repository (default)
+
+```bash
+helm repo add onyx https://onyx-dot-app.github.io/onyx
+helm repo update
+helm install onyx onyx/onyx -n onyx --create-namespace
+```
+
+Chart tarballs are attached to GitHub releases named `helm/onyx-<version>`, and
+`index.yaml` on the `gh-pages` branch points at them. This is an implementation
+detail: the repository URL above does not change and `helm repo add`,
+`helm search repo` and `helm upgrade` all work as before.
+
+## OCI registry (alternative)
+
+The same chart is published to GHCR:
+
+```bash
+helm install onyx oci://ghcr.io/onyx-dot-app/charts/onyx \
+  --version 0.8.16 -n onyx --create-namespace
+```
+
+`helm repo add` does not accept `oci://` URLs, so an OCI install needs an
+explicit `--version`; there is no `helm repo update` or `helm search repo` for
+it. List the published versions with:
+
+```bash
+helm show chart oci://ghcr.io/onyx-dot-app/charts/onyx --version <version>
+```
+
+Both channels ship identical bytes from the same build. Use the Helm repository
+unless you specifically need OCI.
+
 # Recent chart changes (0.5.0)
 
 If you are upgrading from an earlier 0.4.x release, **read [MIGRATION.md](./MIGRATION.md) first.** The 0.5.0 release dropped the bundled Vespa subchart; chart 0.5.6 ships a guard that fails `helm upgrade` if the legacy `da-vespa` StatefulSet is still in the namespace so you don't lose the indexed data silently.

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,25 +5,32 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.15
+version: 0.8.16
 appVersion: latest
 annotations:
   category: Productivity
   licenses: MIT
+  # Links the GHCR package back to this repository. `helm push` copies chart
+  # annotations onto the OCI manifest, and GHCR reads this key to attach the
+  # package to the repo.
+  org.opencontainers.image.source: https://github.com/onyx-dot-app/onyx
   images: |
     - name: webserver
       image: docker.io/onyxdotapp/onyx-web-server:latest
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Cap all child resource names at the 63-character Kubernetes
-        limit. Most templates built names as `<fullname>-<suffix>` without truncation,
-        so long release names made the install fail (for example the Service
-        `<fullname>-celery-worker-heavy-metrics`). Every name now goes through the
-        `onyx.resourceName` helper, which truncates over-limit names and appends a
-        short hash so sibling resources with a shared suffix prefix cannot collide.
-        Rendered names do not change for names already under the limit.
+    - kind: added
+      description: The chart is now also published as an OCI artifact at
+        `oci://ghcr.io/onyx-dot-app/charts/onyx`. Install it with
+        `helm install onyx oci://ghcr.io/onyx-dot-app/charts/onyx --version <version>`.
+        The existing repository at https://onyx-dot-app.github.io/onyx keeps working
+        and stays the default install path; no action is needed to keep using it.
+    - kind: changed
+      description: Chart tarballs are now attached to GitHub releases
+        (`helm/onyx-<version>`) instead of being committed to the gh-pages branch.
+        `helm repo add` and `helm install` are unaffected — only the download URL
+        behind index.yaml changed.
 dependencies:
   # Helm uses the first condition path that exists: `postgresqlOperator.enabled`
   # is unset by default, so this falls through to `postgresql.enabled`. Set it


### PR DESCRIPTION
Closes #13940

## Description

The Helm publisher committed every chart tarball to `gh-pages` on every run. `helm package` is not byte-reproducible (gzip records a timestamp), and tarballs do not delta-compress, so git stored each republish in full. The branch tip is now **102 MiB**: 60 MiB of 131 tarballs, plus **42 MiB of a stale copy of the source tree** (2299 files — `backend/`, `web/`, `web/screenshots/*.png`) that the publisher left behind and never removed. Every clone of this repo pays for it.

### 1. Tarballs move to GitHub release assets

`stefanprodan/helm-gh-pages` → `helm/chart-releaser-action`. Tarballs become release assets under a `helm/onyx-<version>` tag and only `index.yaml` is committed to `gh-pages`, so the branch stops growing.

**No user action required.** `helm repo add onyx https://onyx-dot-app.github.io/onyx` is unchanged — only the `urls:` field of *new* index entries changes. `cr` merges into the existing index, so all 132 historical entries keep their current URLs.

Three details worth reviewing:
- `mark_as_latest: false` — the input defaults to **true**, which would make every chart release the repo's "Latest" and hide `v4.5.6`.
- The `helm/` tag prefix (set in `cr.yaml`) is **load-bearing, not cosmetic**. `deployment.yml` triggers on `tags: ["*"]`, but a GitHub Actions `*` filter does not match `/`, so slash-prefixed tags never reach it — which is why the existing `cli/` and `opal/` tags build no images either. Verified against the last 100 push-triggered runs of `deployment.yml` (2026-07-17 → 08-13): only unslashed tags appear, while `cli/v1.3.1`–`cli/v1.3.4` were all created in that window and triggered zero runs. An *un*prefixed chart tag would match and publish web/backend/model-server images under the chart version. `cr.yaml` documents this.
- `skip_existing: true` plus an explicit guard on the OCI push make a re-run a no-op. That is the regression the old workflow could not pass.

The chart is packaged once in the workflow and that single tarball feeds the release, the index entry and the OCI push, so the three can never disagree. `onyx-cnpg-crds` is no longer published standalone — it is a `file://` dependency and `helm package` vendors it into the `onyx` tarball (confirmed: `onyx/charts/onyx-cnpg-crds/` is present in the built artifact).

### 2. OCI publication (closes #13940)

The same tarball is pushed to `oci://ghcr.io/onyx-dot-app/charts`, as requested in #13940 for GitOps and supply-chain use. The chart carries an `org.opencontainers.image.source` annotation so the GHCR package links back to this repo.

This is **additive, not a replacement**: `helm repo add` does not accept `oci://` and `index.yaml` urls must be http(s), so there is no way to make the existing repo URL transparently resolve to OCI. Moving users there would cost them `helm search repo` and force an explicit `--version`. The Pages repo stays the documented default; OCI is opt-in. Both channels ship identical bytes from the same build.

### 3. Existing `gh-pages` history

Not touched here. This PR stops the growth; reclaiming the 102 MiB already on the branch is a one-time out-of-band step, done manually after this merges. It is not in scope and no migration tooling is checked in — a single run does not justify carrying a script in the repo.

It has to happen in that order: until the new workflow publishes at least once, `gh-pages` holds the only copy of the tarballs.

## Follow-up required after merge

- [ ] The GHCR package `onyx-dot-app/charts/onyx` is **private on creation**. An org admin must flip it to public once, or OCI installs fail for everyone — including the #13940 use case. Everything after that is automatic.
- [ ] Once a chart has published successfully, clean up `gh-pages` out-of-band: move the 131 historical tarballs to an archive release, repoint their `index.yaml` entries, verify every URL still resolves, then prune the branch to `index.yaml` and reset its history.

## How Has This Been Tested?

Locally with helm v3.19.0 (the version the workflow pins):
- `helm dependency build` + `helm package` → `onyx-0.8.16.tgz`; the workflow's version-extraction logic resolves `0.8.16` from it.
- Confirmed all 8 subcharts vendor into the tarball, including `onyx-cnpg-crds`.
- `helm lint` passes (0 failed). `scripts/check-cnpg-crds.sh` reports in sync.
- `pre-commit` passes: zizmor, actionlint, shellcheck, check-yaml.
- Verified slashed-tag release assets download unauthenticated (HTTP 200), and that slashed tags do not trigger `deployment.yml`.

Chart bumped 0.8.15 → 0.8.16 so the merge exercises the new path end to end. On merge, verify: a `helm/onyx-0.8.16` release exists with the `.tgz` attached, "Latest" is still `v4.5.6`, `gh-pages` gained *only* an `index.yaml` change, no image build ran, and both `helm pull onyx/onyx --version 0.8.16` and `--version 0.4.0` (an old gh-pages-hosted one) succeed.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
