### PR TITLE
feat(connector-stability): credential capability report table

### DIFF
--- a/backend/alembic/versions/df90f43d9ab2_add_credential_capability_report_table.py
+++ b/backend/alembic/versions/df90f43d9ab2_add_credential_capability_report_table.py
@@ -1,0 +1,88 @@
+"""add credential capability report table
+
+Latest-only capability-check reports, one row per (credential,
+connector-scope): ``connector_id`` NULL is the config-less credential-time
+report, non-NULL is one per attached connector. The two partial unique
+indexes enforce the upsert semantics.
+
+Revision ID: df90f43d9ab2
+Revises: 3350a25df58e
+Create Date: 2026-08-13 10:57:12.982708
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from onyx.configs.constants import DocumentSource
+from onyx.db.enums import CapabilityCheckTrigger, CapabilityReportRunStatus
+
+# revision identifiers, used by Alembic.
+revision = "df90f43d9ab2"
+down_revision = "3350a25df58e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "credential_capability_report",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("credential_id", sa.Integer(), nullable=False),
+        sa.Column("connector_id", sa.Integer(), nullable=True),
+        sa.Column("source", sa.Enum(DocumentSource, native_enum=False), nullable=False),
+        sa.Column("connector_config_hash", sa.String(), nullable=True),
+        sa.Column(
+            "trigger",
+            sa.Enum(CapabilityCheckTrigger, native_enum=False),
+            nullable=False,
+        ),
+        sa.Column("report", postgresql.JSONB(), nullable=True),
+        sa.Column(
+            "run_status",
+            sa.Enum(CapabilityReportRunStatus, native_enum=False),
+            nullable=False,
+        ),
+        sa.Column("run_started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "time_created",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "time_updated",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["credential_id"], ["credential.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["connector_id"], ["connector.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_credential_capability_report_credential_id",
+        "credential_capability_report",
+        ["credential_id"],
+    )
+    op.create_index(
+        "uq_capability_report_connector_scope",
+        "credential_capability_report",
+        ["credential_id", "connector_id"],
+        unique=True,
+        postgresql_where=sa.text("connector_id IS NOT NULL"),
+    )
+    op.create_index(
+        "uq_capability_report_credential_scope",
+        "credential_capability_report",
+        ["credential_id"],
+        unique=True,
+        postgresql_where=sa.text("connector_id IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("credential_capability_report")

--- a/backend/alembic/versions/df90f43d9ab2_add_credential_capability_report_table.py
+++ b/backend/alembic/versions/df90f43d9ab2_add_credential_capability_report_table.py
@@ -6,7 +6,7 @@ per attached connector. The two partial unique indexes enforce the upsert
 semantics.
 
 Revision ID: df90f43d9ab2
-Revises: 3350a25df58e
+Revises: c71a18ea7d07
 Create Date: 2026-08-13 10:57:12.982708
 
 """
@@ -20,7 +20,7 @@ from onyx.db.enums import CapabilityCheckTrigger, CapabilityReportRunStatus
 
 # revision identifiers, used by Alembic.
 revision = "df90f43d9ab2"
-down_revision = "3350a25df58e"
+down_revision = "c71a18ea7d07"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/df90f43d9ab2_add_credential_capability_report_table.py
+++ b/backend/alembic/versions/df90f43d9ab2_add_credential_capability_report_table.py
@@ -1,9 +1,9 @@
 """add credential capability report table
 
-Latest-only capability-check reports, one row per (credential,
-connector-scope): ``connector_id`` NULL is the config-less credential-time
-report, non-NULL is one per attached connector. The two partial unique
-indexes enforce the upsert semantics.
+Latest-only capability-check reports, one row per (credential, connector-scope):
+``connector_id`` NULL is the config-less credential-time report, non-NULL is one
+per attached connector. The two partial unique indexes enforce the upsert
+semantics.
 
 Revision ID: df90f43d9ab2
 Revises: 3350a25df58e

--- a/backend/alembic/versions/df90f43d9ab2_add_credential_capability_report_table.py
+++ b/backend/alembic/versions/df90f43d9ab2_add_credential_capability_report_table.py
@@ -6,7 +6,7 @@ per attached connector. The two partial unique indexes enforce the upsert
 semantics.
 
 Revision ID: df90f43d9ab2
-Revises: c71a18ea7d07
+Revises: c5d9662b3c50
 Create Date: 2026-08-13 10:57:12.982708
 
 """
@@ -20,7 +20,7 @@ from onyx.db.enums import CapabilityCheckTrigger, CapabilityReportRunStatus
 
 # revision identifiers, used by Alembic.
 revision = "df90f43d9ab2"
-down_revision = "c71a18ea7d07"
+down_revision = "c5d9662b3c50"
 branch_labels = None
 depends_on = None
 

--- a/backend/onyx/connectors/capability_checks/models.py
+++ b/backend/onyx/connectors/capability_checks/models.py
@@ -10,10 +10,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.connectors.capabilities import CredentialCapability
 from onyx.connectors.interfaces import BaseConnector
 from onyx.connectors.source_operations import SourceOperations
-
-# Re-exported: the enum lives in ``onyx.db.enums`` so the DB report row can type
-# its trigger column without importing this framework module.
-from onyx.db.enums import CapabilityCheckTrigger as CapabilityCheckTrigger
+from onyx.db.enums import CapabilityCheckTrigger
 
 
 class CapabilityCheckStatus(str, Enum):

--- a/backend/onyx/connectors/capability_checks/models.py
+++ b/backend/onyx/connectors/capability_checks/models.py
@@ -11,6 +11,10 @@ from onyx.connectors.capabilities import CredentialCapability
 from onyx.connectors.interfaces import BaseConnector
 from onyx.connectors.source_operations import SourceOperations
 
+# Re-exported: the enum lives in ``onyx.db.enums`` so the DB report row can
+# type its trigger column without importing this framework module.
+from onyx.db.enums import CapabilityCheckTrigger as CapabilityCheckTrigger
+
 
 class CapabilityCheckStatus(str, Enum):
     PASSED = "passed"
@@ -34,17 +38,6 @@ class CapabilityVerdict(str, Enum):
     SKIPPED = "skipped"
     # The source does not have this capability (e.g. no group sync for Slack).
     NOT_APPLICABLE = "not_applicable"
-
-
-class CapabilityCheckTrigger(str, Enum):
-    """What initiated a capability-check run."""
-
-    MANUAL = "manual"
-    CREDENTIAL_CREATED = "credential_created"
-    # Recorded from the blocking validation at cc-pair creation/swap time.
-    CC_PAIR_VALIDATION = "cc_pair_validation"
-    # Recorded from the blocking validation at indexing-run start.
-    INDEXING_ATTEMPT = "indexing_attempt"
 
 
 class CapabilityCheckContext(BaseModel):

--- a/backend/onyx/connectors/capability_checks/models.py
+++ b/backend/onyx/connectors/capability_checks/models.py
@@ -11,8 +11,8 @@ from onyx.connectors.capabilities import CredentialCapability
 from onyx.connectors.interfaces import BaseConnector
 from onyx.connectors.source_operations import SourceOperations
 
-# Re-exported: the enum lives in ``onyx.db.enums`` so the DB report row can
-# type its trigger column without importing this framework module.
+# Re-exported: the enum lives in ``onyx.db.enums`` so the DB report row can type
+# its trigger column without importing this framework module.
 from onyx.db.enums import CapabilityCheckTrigger as CapabilityCheckTrigger
 
 

--- a/backend/onyx/connectors/capability_checks/runner.py
+++ b/backend/onyx/connectors/capability_checks/runner.py
@@ -11,7 +11,6 @@ from onyx.connectors.capability_checks.models import (
     CapabilityCheckContext,
     CapabilityCheckResult,
     CapabilityCheckStatus,
-    CapabilityCheckTrigger,
     CredentialCapability,
     CredentialCapabilityReport,
     compute_capability_verdicts,
@@ -32,6 +31,7 @@ from onyx.connectors.source_operations import (
     SourceOperations,
     get_source_operations_class,
 )
+from onyx.db.enums import CapabilityCheckTrigger
 from onyx.db.models import Credential
 from onyx.utils.credential_audit import emit_credential_access
 from onyx.utils.logger import setup_logger

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -805,3 +805,26 @@ class IncognitoRecordMode(str, PyEnum):
 def record_mode_persists_content(mode: IncognitoRecordMode | None) -> bool:
     """None is an ordinary chat, which always persists content."""
     return mode is None or mode.persists_content
+
+
+class CapabilityCheckTrigger(str, PyEnum):
+    """What initiated a capability-check run."""
+
+    MANUAL = "manual"
+    CREDENTIAL_CREATED = "credential_created"
+    # Recorded from the blocking validation at cc-pair creation/swap time.
+    CC_PAIR_VALIDATION = "cc_pair_validation"
+    # Recorded from the blocking validation at indexing-run start.
+    INDEXING_ATTEMPT = "indexing_attempt"
+
+
+class CapabilityReportRunStatus(str, PyEnum):
+    """Lifecycle of one persisted capability-report row.
+
+    Kept separate from the report payload so the last COMPLETED report stays
+    readable while a re-run is RUNNING.
+    """
+
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED_TO_RUN = "failed_to_run"

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2067,10 +2067,10 @@ class Credential(Base):
 class CredentialCapabilityReportRow(Base):
     """Latest capability-check report per (credential, connector-scope).
 
-    One config-less credential-time row (``connector_id`` NULL) plus one row
-    per attached connector; latest-only upsert semantics are enforced by the
-    two partial unique indexes. ``report`` holds the last COMPLETED report so
-    it stays readable while a re-run is RUNNING.
+    One config-less credential-time row (``connector_id`` NULL) plus one row per
+    attached connector; latest-only upsert semantics are enforced by the two
+    partial unique indexes. ``report`` holds the last COMPLETED report so it
+    stays readable while a re-run is RUNNING.
     """
 
     __tablename__ = "credential_capability_report"
@@ -2087,8 +2087,8 @@ class CredentialCapabilityReportRow(Base):
     source: Mapped[DocumentSource] = mapped_column(
         Enum(DocumentSource, native_enum=False), nullable=False
     )
-    # sha256 of the canonical config JSON the report ran with; staleness
-    # signal for connector-scoped reports.
+    # sha256 of the canonical config JSON the report ran with; staleness signal
+    # for connector-scoped reports.
     connector_config_hash: Mapped[str | None] = mapped_column(String, nullable=True)
     # What initiated the run this row reflects (last write wins).
     trigger: Mapped[CapabilityCheckTrigger] = mapped_column(

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -72,6 +72,8 @@ from onyx.db.enums import (
     ApprovalDecision,
     ArtifactType,
     BuildSessionStatus,
+    CapabilityCheckTrigger,
+    CapabilityReportRunStatus,
     ChatSessionSharedStatus,
     ConnectorCredentialPairStatus,
     DefaultAppMode,
@@ -2060,6 +2062,70 @@ class Credential(Base):
     )
 
     user: Mapped[User | None] = relationship("User", back_populates="credentials")
+
+
+class CredentialCapabilityReportRow(Base):
+    """Latest capability-check report per (credential, connector-scope).
+
+    One config-less credential-time row (``connector_id`` NULL) plus one row
+    per attached connector; latest-only upsert semantics are enforced by the
+    two partial unique indexes. ``report`` holds the last COMPLETED report so
+    it stays readable while a re-run is RUNNING.
+    """
+
+    __tablename__ = "credential_capability_report"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    credential_id: Mapped[int] = mapped_column(
+        ForeignKey("credential.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    # NULL marks the config-less credential-time report.
+    connector_id: Mapped[int | None] = mapped_column(
+        ForeignKey("connector.id", ondelete="CASCADE"), nullable=True
+    )
+    # Denormalized for support queries by source.
+    source: Mapped[DocumentSource] = mapped_column(
+        Enum(DocumentSource, native_enum=False), nullable=False
+    )
+    # sha256 of the canonical config JSON the report ran with; staleness
+    # signal for connector-scoped reports.
+    connector_config_hash: Mapped[str | None] = mapped_column(String, nullable=True)
+    # What initiated the run this row reflects (last write wins).
+    trigger: Mapped[CapabilityCheckTrigger] = mapped_column(
+        Enum(CapabilityCheckTrigger, native_enum=False), nullable=False
+    )
+    # Serialized ``CredentialCapabilityReport``; None until a run completes.
+    report: Mapped[dict[str, Any] | None] = mapped_column(
+        postgresql.JSONB(), nullable=True
+    )
+    run_status: Mapped[CapabilityReportRunStatus] = mapped_column(
+        Enum(CapabilityReportRunStatus, native_enum=False), nullable=False
+    )
+    run_started_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    time_created: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    time_updated: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        Index(
+            "uq_capability_report_connector_scope",
+            "credential_id",
+            "connector_id",
+            unique=True,
+            postgresql_where=text("connector_id IS NOT NULL"),
+        ),
+        Index(
+            "uq_capability_report_credential_scope",
+            "credential_id",
+            unique=True,
+            postgresql_where=text("connector_id IS NULL"),
+        ),
+    )
 
 
 class FederatedConnector(Base):

--- a/backend/tests/unit/onyx/connectors/capability_checks/test_generate_capability_report.py
+++ b/backend/tests/unit/onyx/connectors/capability_checks/test_generate_capability_report.py
@@ -9,7 +9,6 @@ from onyx.connectors.capability_checks.models import (
     CapabilityCheck,
     CapabilityCheckContext,
     CapabilityCheckStatus,
-    CapabilityCheckTrigger,
     CapabilityVerdict,
     CredentialCapability,
 )
@@ -17,6 +16,7 @@ from onyx.connectors.capability_checks.runner import generate_capability_report
 from onyx.connectors.exceptions import CredentialInvalidError
 from onyx.connectors.interfaces import BaseConnector
 from onyx.connectors.source_operations import SourceOperations
+from onyx.db.enums import CapabilityCheckTrigger
 
 
 class _CallableCheck(CapabilityCheck):


### PR DESCRIPTION
## Description

Schema for persisted capability-check reports: the first of three PRs (next is #13973) splitting the persistence milestone (table, then accessors, then the blocking-path recorder). Nothing reads or writes the table yet.

- New credential_capability_report table + CredentialCapabilityReportRow: latest-only reports, one row per (credential, connector-scope). connector_id NULL is the config-less credential-time report, non-NULL is one row per attached connector; rows cascade with their credential/connector.
- Two partial unique indexes enforce the latest-only upsert semantics: (credential_id, connector_id) WHERE connector_id IS NOT NULL, and (credential_id) WHERE connector_id IS NULL.
- report (JSONB) holds the last COMPLETED report; run_status (RUNNING / COMPLETED / FAILED_TO_RUN) lives beside it so the previous report stays readable while a re-run is in flight. connector_config_hash (sha256 of canonical config JSON) is the staleness signal for connector-scoped reports.
- CapabilityCheckTrigger moves to onyx.db.enums (existing callers repointed) so the row model types its trigger column without importing the checks framework; the new CapabilityReportRunStatus enum lives beside it.

## How Has This Been Tested?

- Hand-written migration, verified upgrade -> downgrade -> upgrade clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

