### PR TITLE
feat(connector-stability): blocking-path capability report recorder

### DIFF
--- a/backend/ee/onyx/connectors/capability_applicability.py
+++ b/backend/ee/onyx/connectors/capability_applicability.py
@@ -1,8 +1,8 @@
 """Which perm-sync capabilities exist per source.
 
 Kept apart from the EE check dispatch (``capability_checks``) so applicability
-resolution never depends on per-connector check modules: a broken or heavy
-check import must not affect callers that only need applicability (the
+resolution never depends on per-connector check modules: a broken or heavy check
+import must not affect callers that only need applicability (the
 blocking-validation recorder). ``sync_params`` is the truth source for what
 syncs exist and is already part of the EE production import graph.
 """

--- a/backend/ee/onyx/connectors/capability_applicability.py
+++ b/backend/ee/onyx/connectors/capability_applicability.py
@@ -1,0 +1,27 @@
+"""Which perm-sync capabilities exist per source.
+
+Kept apart from the EE check dispatch (``capability_checks``) so applicability
+resolution never depends on per-connector check modules: a broken or heavy
+check import must not affect callers that only need applicability (the
+blocking-validation recorder). ``sync_params`` is the truth source for what
+syncs exist and is already part of the EE production import graph.
+"""
+
+from ee.onyx.external_permissions.sync_params import (
+    source_requires_doc_sync,
+    source_requires_external_group_sync,
+)
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.capabilities import CredentialCapability
+
+
+def get_applicable_perm_sync_capabilities(
+    source: DocumentSource,
+) -> set[CredentialCapability]:
+    """Returns which perm-sync capabilities exist for this source."""
+    applicable: set[CredentialCapability] = set()
+    if source_requires_doc_sync(source):
+        applicable.add(CredentialCapability.DOC_PERMISSION_SYNC)
+    if source_requires_external_group_sync(source):
+        applicable.add(CredentialCapability.EXTERNAL_GROUP_SYNC)
+    return applicable

--- a/backend/ee/onyx/connectors/capability_checks.py
+++ b/backend/ee/onyx/connectors/capability_checks.py
@@ -6,10 +6,8 @@ implementations stay in the OSS connector modules, mirroring the
 ``perm_sync_valid.py`` pattern.
 """
 
-# Re-exported: applicability lives in its own module so its resolution never
-# depends on the per-connector check imports below.
 from ee.onyx.connectors.capability_applicability import (
-    get_applicable_perm_sync_capabilities as get_applicable_perm_sync_capabilities,
+    get_applicable_perm_sync_capabilities,
 )
 from ee.onyx.connectors.perm_sync_valid import source_has_perm_sync_probe
 from onyx.configs.constants import DocumentSource

--- a/backend/ee/onyx/connectors/capability_checks.py
+++ b/backend/ee/onyx/connectors/capability_checks.py
@@ -6,11 +6,12 @@ implementations stay in the OSS connector modules, mirroring the
 ``perm_sync_valid.py`` pattern.
 """
 
-from ee.onyx.connectors.perm_sync_valid import source_has_perm_sync_probe
-from ee.onyx.external_permissions.sync_params import (
-    source_requires_doc_sync,
-    source_requires_external_group_sync,
+# Re-exported: applicability lives in its own module so its resolution never
+# depends on the per-connector check imports below.
+from ee.onyx.connectors.capability_applicability import (
+    get_applicable_perm_sync_capabilities as get_applicable_perm_sync_capabilities,
 )
+from ee.onyx.connectors.perm_sync_valid import source_has_perm_sync_probe
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.capability_checks.models import (
     CapabilityCheck,
@@ -60,18 +61,6 @@ class _PermSyncFallbackCheck(CapabilityCheck):
             "The runner guarantees an instance of a connector."
         )
         context.connector.validate_perm_sync()
-
-
-def get_applicable_perm_sync_capabilities(
-    source: DocumentSource,
-) -> set[CredentialCapability]:
-    """Returns which perm-sync capabilities exist for this source."""
-    applicable: set[CredentialCapability] = set()
-    if source_requires_doc_sync(source):
-        applicable.add(CredentialCapability.DOC_PERMISSION_SYNC)
-    if source_requires_external_group_sync(source):
-        applicable.add(CredentialCapability.EXTERNAL_GROUP_SYNC)
-    return applicable
 
 
 def get_perm_sync_capability_checks(source: DocumentSource) -> list[CapabilityCheck]:

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -137,6 +137,16 @@ def _get_connector_runner(
 
     task = attempt.connector_credential_pair.connector.input_type
 
+    # Plain values for the closure: it runs inside exception handlers, where
+    # lazy ORM attribute loads can raise (e.g. ``PendingRollbackError``) and
+    # replace the exception being handled.
+    credential_id = attempt.connector_credential_pair.credential.id
+    connector_id = attempt.connector_credential_pair.connector.id
+    source = attempt.connector_credential_pair.connector.source
+    connector_specific_config = (
+        attempt.connector_credential_pair.connector.connector_specific_config
+    )
+
     def _record_outcome(error: Exception | None, perm_sync_validated: bool) -> None:
         # Best-effort scribe for the validation outcome below; never raises.
         # INTEGRATION_TESTS_MODE skips the validation itself, so there is no
@@ -144,15 +154,13 @@ def _get_connector_runner(
         if INTEGRATION_TESTS_MODE:
             return
         record_blocking_validation_outcome(
-            credential_id=attempt.connector_credential_pair.credential.id,
-            connector_id=attempt.connector_credential_pair.connector.id,
-            source=attempt.connector_credential_pair.connector.source,
+            credential_id=credential_id,
+            connector_id=connector_id,
+            source=source,
             trigger=CapabilityCheckTrigger.INDEXING_ATTEMPT,
             error=error,
             perm_sync_validated=perm_sync_validated,
-            connector_specific_config=(
-                attempt.connector_credential_pair.connector.connector_specific_config
-            ),
+            connector_specific_config=connector_specific_config,
         )
 
     try:

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -131,8 +131,9 @@ def _get_connector_runner(
     NOTE: `start_time` and `end_time` are only used for poll connectors
 
     Returns an iterator of document batches and whether the returned documents
-    are the complete list of existing documents of the connector. If the task
-    of type LOAD_STATE, the list will be considered complete and otherwise incomplete.
+    are the complete list of existing documents of the connector. If the task of
+    type LOAD_STATE, the list will be considered complete and otherwise
+    incomplete.
     """
 
     task = attempt.connector_credential_pair.connector.input_type
@@ -174,7 +175,7 @@ def _get_connector_runner(
                 raw_file_callback=raw_file_callback,
             )
 
-            # validate the connector settings
+            # Validate the connector settings.
             if not INTEGRATION_TESTS_MODE:
                 runnable_connector.validate_connector_settings()
 

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -32,6 +32,9 @@ from onyx.configs.constants import (
     OnyxCeleryQueues,
     OnyxCeleryTask,
 )
+from onyx.connectors.capability_checks.recorder import (
+    record_blocking_validation_outcome,
+)
 from onyx.connectors.connector_runner import ConnectorRunner
 from onyx.connectors.exceptions import (
     ConnectorValidationError,
@@ -57,6 +60,7 @@ from onyx.db.constants import CONNECTOR_VALIDATION_ERROR_MESSAGE_PREFIX
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import (
     AccessType,
+    CapabilityCheckTrigger,
     ConnectorCredentialPairStatus,
     IndexingStatus,
     IndexModelStatus,
@@ -133,6 +137,24 @@ def _get_connector_runner(
 
     task = attempt.connector_credential_pair.connector.input_type
 
+    def _record_outcome(error: Exception | None, perm_sync_validated: bool) -> None:
+        # Best-effort scribe for the validation outcome below; never raises.
+        # INTEGRATION_TESTS_MODE skips the validation itself, so there is no
+        # outcome to record.
+        if INTEGRATION_TESTS_MODE:
+            return
+        record_blocking_validation_outcome(
+            credential_id=attempt.connector_credential_pair.credential.id,
+            connector_id=attempt.connector_credential_pair.connector.id,
+            source=attempt.connector_credential_pair.connector.source,
+            trigger=CapabilityCheckTrigger.INDEXING_ATTEMPT,
+            error=error,
+            perm_sync_validated=perm_sync_validated,
+            connector_specific_config=(
+                attempt.connector_credential_pair.connector.connector_specific_config
+            ),
+        )
+
     try:
         with time_stage(IndexAttemptStage.CONNECTOR_VALIDATION, attempt.id):
             runnable_connector = instantiate_connector(
@@ -159,9 +181,11 @@ def _get_connector_runner(
         logger.exception(
             "Unable to instantiate connector due to an unexpected temporary issue."
         )
+        _record_outcome(e, perm_sync_validated=False)
         raise e
     except Exception as e:
         logger.exception("Unable to instantiate connector. Pausing until fixed.")
+        _record_outcome(e, perm_sync_validated=False)
         # since we failed to even instantiate the connector, we pause the CCPair since
         # it will never succeed
 
@@ -183,6 +207,12 @@ def _get_connector_runner(
                     status=ConnectorCredentialPairStatus.PAUSED,
                 )
         raise e
+
+    _record_outcome(
+        None,
+        perm_sync_validated=attempt.connector_credential_pair.access_type
+        == AccessType.SYNC,
+    )
 
     return ConnectorRunner(
         connector=runnable_connector,

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -179,12 +179,15 @@ def _get_connector_runner(
             if not INTEGRATION_TESTS_MODE:
                 runnable_connector.validate_connector_settings()
 
-        if (
+        perm_sync_validated = (
             not INTEGRATION_TESTS_MODE
             and attempt.connector_credential_pair.access_type == AccessType.SYNC
-        ):
+        )
+        if perm_sync_validated:
             with time_stage(IndexAttemptStage.PERMISSION_VALIDATION, attempt.id):
                 runnable_connector.validate_perm_sync()
+
+        _record_outcome(None, perm_sync_validated=perm_sync_validated)
 
     except UnexpectedValidationError as e:
         logger.exception(
@@ -216,12 +219,6 @@ def _get_connector_runner(
                     status=ConnectorCredentialPairStatus.PAUSED,
                 )
         raise e
-
-    _record_outcome(
-        None,
-        perm_sync_validated=attempt.connector_credential_pair.access_type
-        == AccessType.SYNC,
-    )
 
     return ConnectorRunner(
         connector=runnable_connector,

--- a/backend/onyx/connectors/capability_checks/applicability.py
+++ b/backend/onyx/connectors/capability_checks/applicability.py
@@ -1,8 +1,9 @@
 """Which capabilities exist per source on this build.
 
-Kept apart from the check registry so hot-path modules (the blocking
-validation recorder) can resolve applicability without importing the
-registry, which eagerly imports every migrated connector's check module.
+Kept apart from the check registry, on both the OSS and EE sides, so
+applicability resolution never imports a per-connector check module: the
+blocking-validation recorder resolves applicability on hot paths, and a check
+module's import failure or weight must not reach it.
 """
 
 from onyx.configs.constants import DocumentSource
@@ -18,7 +19,7 @@ def get_applicable_capabilities(source: DocumentSource) -> set[CredentialCapabil
     exist there.
     """
     get_perm_sync_capabilities = fetch_ee_implementation_or_noop(
-        "onyx.connectors.capability_checks",
+        "onyx.connectors.capability_applicability",
         "get_applicable_perm_sync_capabilities",
         noop_return_value=set(),
     )

--- a/backend/onyx/connectors/capability_checks/applicability.py
+++ b/backend/onyx/connectors/capability_checks/applicability.py
@@ -1,0 +1,25 @@
+"""Which capabilities exist per source on this build.
+
+Kept apart from the check registry so hot-path modules (the blocking
+validation recorder) can resolve applicability without importing the
+registry, which eagerly imports every migrated connector's check module.
+"""
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.capabilities import CredentialCapability
+from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
+
+
+def get_applicable_capabilities(source: DocumentSource) -> set[CredentialCapability]:
+    """Returns the capabilities that exist for this source on this build.
+
+    Capabilities outside this set aggregate to a NOT_APPLICABLE verdict. On OSS
+    builds only INDEXING applies, which is correct since perm sync does not
+    exist there.
+    """
+    get_perm_sync_capabilities = fetch_ee_implementation_or_noop(
+        "onyx.connectors.capability_checks",
+        "get_applicable_perm_sync_capabilities",
+        noop_return_value=set(),
+    )
+    return {CredentialCapability.INDEXING} | get_perm_sync_capabilities(source)

--- a/backend/onyx/connectors/capability_checks/recorder.py
+++ b/backend/onyx/connectors/capability_checks/recorder.py
@@ -30,11 +30,9 @@ from onyx.connectors.capability_checks.models import (
 )
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.db.credential_capability import (
-    get_capability_report_row,
-    upsert_completed_capability_report,
+    upsert_completed_capability_report_unless_granular,
 )
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
-from onyx.db.models import CredentialCapabilityReportRow
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -97,14 +95,6 @@ def _synthesize_results(
     return results
 
 
-def _has_granular_report(row: CredentialCapabilityReportRow) -> bool:
-    """True when the stored report came from named checks, not a fallback."""
-    if row.report is None:
-        return False
-    check_results = row.report.get("check_results", [])
-    return any(not result.get("is_fallback") for result in check_results)
-
-
 def _connector_config_hash(config: dict[str, Any] | None) -> str | None:
     """sha256 of the canonical config JSON; the staleness signal."""
     if config is None:
@@ -127,7 +117,8 @@ def record_blocking_validation_outcome(
 
     Uses its own session so the caller's in-flight transaction is untouched,
     and never overwrites a granular (named-checks) report with this coarse
-    fallback-shaped record (the no-clobber rule).
+    fallback-shaped record: the no-clobber guard is part of the upsert
+    statement itself, so a concurrent granular write cannot race it.
     """
     try:
         results = _synthesize_results(source, error, perm_sync_validated)
@@ -143,12 +134,7 @@ def record_blocking_validation_outcome(
             check_results=results,
         )
         with get_session_with_current_tenant() as db_session:
-            existing = get_capability_report_row(
-                db_session, credential_id, connector_id
-            )
-            if existing is not None and _has_granular_report(existing):
-                return
-            upsert_completed_capability_report(
+            upsert_completed_capability_report_unless_granular(
                 db_session,
                 credential_id=credential_id,
                 connector_id=connector_id,

--- a/backend/onyx/connectors/capability_checks/recorder.py
+++ b/backend/onyx/connectors/capability_checks/recorder.py
@@ -78,19 +78,19 @@ def _synthesize_results(
         )
     ]
     if perm_sync_validated:
-        for capability in applicable - {CredentialCapability.INDEXING}:
-            results.append(
-                CapabilityCheckResult(
-                    capability=capability,
-                    check_id=f"{source.value}_perm_sync",
-                    display_name="Permission sync validation",
-                    required=True,
-                    status=status,
-                    message=message,
-                    error_type=error_type,
-                    is_fallback=True,
-                )
+        results.extend(
+            CapabilityCheckResult(
+                capability=capability,
+                check_id=f"{source.value}_perm_sync",
+                display_name="Permission sync validation",
+                required=True,
+                status=status,
+                message=message,
+                error_type=error_type,
+                is_fallback=True,
             )
+            for capability in applicable - {CredentialCapability.INDEXING}
+        )
     return results
 
 

--- a/backend/onyx/connectors/capability_checks/recorder.py
+++ b/backend/onyx/connectors/capability_checks/recorder.py
@@ -23,7 +23,6 @@ from onyx.connectors.capability_checks.applicability import (
 from onyx.connectors.capability_checks.models import (
     CapabilityCheckResult,
     CapabilityCheckStatus,
-    CapabilityCheckTrigger,
     CredentialCapability,
     CredentialCapabilityReport,
     compute_capability_verdicts,
@@ -33,6 +32,7 @@ from onyx.db.credential_capability import (
     upsert_completed_capability_report_unless_granular,
 )
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import CapabilityCheckTrigger
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()

--- a/backend/onyx/connectors/capability_checks/recorder.py
+++ b/backend/onyx/connectors/capability_checks/recorder.py
@@ -2,13 +2,13 @@
 
 The blocking paths (cc-pair validation, indexing-run start) already probe the
 source; this module records what they found as a fallback-shaped capability
-report, so reports accumulate before any check-running infrastructure exists.
-It runs no checks of its own.
+report, so reports accumulate before any check-running infrastructure exists. It
+runs no checks of its own.
 
 Deliberately import-light: the hook sites live in ``factory.py`` and the
-docfetching hot path, so this module must not pull in the check registry
-(which eagerly imports every migrated connector's check module) or the
-runner (which imports ``factory``).
+docfetching hot path, so this module must not pull in the check registry (which
+eagerly imports every migrated connector's check module) or the runner (which
+imports ``factory``).
 """
 
 import hashlib
@@ -57,8 +57,8 @@ def _synthesize_results(
 ) -> list[CapabilityCheckResult]:
     """Builds fallback-shaped results mirroring what the blocking path ran.
 
-    Perm-sync rows appear only when the caller knows ``validate_perm_sync``
-    ran (the success path with sync access). On failure the outcome cannot be
+    Perm-sync rows appear only when the caller knows ``validate_perm_sync`` ran
+    (the success path with sync access). On failure the outcome cannot be
     attributed between the settings and perm-sync probes, so only the INDEXING
     row carries it.
     """
@@ -114,10 +114,10 @@ def record_blocking_validation_outcome(
 ) -> None:
     """Persists one blocking validation's outcome; never raises.
 
-    Uses its own session so the caller's in-flight transaction is untouched,
-    and never overwrites a granular (named-checks) report with this coarse
-    fallback-shaped record: the no-clobber guard is part of the upsert
-    statement itself, so a concurrent granular write cannot race it.
+    Uses its own session so the caller's in-flight transaction is untouched, and
+    never overwrites a granular (named-checks) report with this coarse
+    fallback-shaped record: the no-clobber guard is part of the upsert statement
+    itself, so a concurrent granular write cannot race it.
     """
     try:
         applicable = get_applicable_capabilities(source)
@@ -141,8 +141,8 @@ def record_blocking_validation_outcome(
                 report=report,
                 connector_config_hash=_connector_config_hash(connector_specific_config),
             )
-            # The accessors leave the transaction to the caller, and the
-            # session context manager closes without committing.
+            # The accessors leave the transaction to the caller, and the session
+            # context manager closes without committing.
             db_session.commit()
     except Exception:
         logger.warning(

--- a/backend/onyx/connectors/capability_checks/recorder.py
+++ b/backend/onyx/connectors/capability_checks/recorder.py
@@ -51,6 +51,7 @@ def _outcome_status(error: Exception | None) -> CapabilityCheckStatus:
 
 def _synthesize_results(
     source: DocumentSource,
+    applicable: set[CredentialCapability],
     error: Exception | None,
     perm_sync_validated: bool,
 ) -> list[CapabilityCheckResult]:
@@ -77,9 +78,7 @@ def _synthesize_results(
         )
     ]
     if perm_sync_validated:
-        for capability in get_applicable_capabilities(source) - {
-            CredentialCapability.INDEXING
-        }:
+        for capability in applicable - {CredentialCapability.INDEXING}:
             results.append(
                 CapabilityCheckResult(
                     capability=capability,
@@ -121,16 +120,15 @@ def record_blocking_validation_outcome(
     statement itself, so a concurrent granular write cannot race it.
     """
     try:
-        results = _synthesize_results(source, error, perm_sync_validated)
+        applicable = get_applicable_capabilities(source)
+        results = _synthesize_results(source, applicable, error, perm_sync_validated)
         report = CredentialCapabilityReport(
             credential_id=credential_id,
             source=source,
             connector_id=connector_id,
             checked_at=datetime.now(timezone.utc),
             trigger=trigger,
-            verdicts=compute_capability_verdicts(
-                get_applicable_capabilities(source), results
-            ),
+            verdicts=compute_capability_verdicts(applicable, results),
             check_results=results,
         )
         with get_session_with_current_tenant() as db_session:

--- a/backend/onyx/connectors/capability_checks/recorder.py
+++ b/backend/onyx/connectors/capability_checks/recorder.py
@@ -1,0 +1,165 @@
+"""Best-effort persistence of blocking-validation outcomes.
+
+The blocking paths (cc-pair validation, indexing-run start) already probe the
+source; this module records what they found as a fallback-shaped capability
+report, so reports accumulate before any check-running infrastructure exists.
+It runs no checks of its own.
+
+Deliberately import-light: the hook sites live in ``factory.py`` and the
+docfetching hot path, so this module must not pull in the check registry
+(which eagerly imports every migrated connector's check module) or the
+runner (which imports ``factory``).
+"""
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.capability_checks.applicability import (
+    get_applicable_capabilities,
+)
+from onyx.connectors.capability_checks.models import (
+    CapabilityCheckResult,
+    CapabilityCheckStatus,
+    CapabilityCheckTrigger,
+    CredentialCapability,
+    CredentialCapabilityReport,
+    compute_capability_verdicts,
+)
+from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.db.credential_capability import (
+    get_capability_report_row,
+    upsert_completed_capability_report,
+)
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.models import CredentialCapabilityReportRow
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def _outcome_status(error: Exception | None) -> CapabilityCheckStatus:
+    """Maps a blocking validation's outcome per the check exception contract."""
+    if error is None:
+        return CapabilityCheckStatus.PASSED
+    if isinstance(error, ConnectorValidationError):
+        return CapabilityCheckStatus.FAILED
+    # ``UnexpectedValidationError`` and unrecognized exceptions alike: never
+    # proof of a broken credential.
+    return CapabilityCheckStatus.INDETERMINATE
+
+
+def _synthesize_results(
+    source: DocumentSource,
+    error: Exception | None,
+    perm_sync_validated: bool,
+) -> list[CapabilityCheckResult]:
+    """Builds fallback-shaped results mirroring what the blocking path ran.
+
+    Perm-sync rows appear only when the caller knows ``validate_perm_sync``
+    ran (the success path with sync access). On failure the outcome cannot be
+    attributed between the settings and perm-sync probes, so only the INDEXING
+    row carries it.
+    """
+    status = _outcome_status(error)
+    message = str(error) if error is not None else ""
+    error_type = type(error).__name__ if error is not None else None
+    results = [
+        CapabilityCheckResult(
+            capability=CredentialCapability.INDEXING,
+            check_id=f"{source.value}_connector_settings",
+            display_name="Connector settings validation",
+            required=True,
+            status=status,
+            message=message,
+            error_type=error_type,
+            is_fallback=True,
+        )
+    ]
+    if perm_sync_validated:
+        for capability in get_applicable_capabilities(source) - {
+            CredentialCapability.INDEXING
+        }:
+            results.append(
+                CapabilityCheckResult(
+                    capability=capability,
+                    check_id=f"{source.value}_perm_sync",
+                    display_name="Permission sync validation",
+                    required=True,
+                    status=status,
+                    message=message,
+                    error_type=error_type,
+                    is_fallback=True,
+                )
+            )
+    return results
+
+
+def _has_granular_report(row: CredentialCapabilityReportRow) -> bool:
+    """True when the stored report came from named checks, not a fallback."""
+    if row.report is None:
+        return False
+    check_results = row.report.get("check_results", [])
+    return any(not result.get("is_fallback") for result in check_results)
+
+
+def _connector_config_hash(config: dict[str, Any] | None) -> str | None:
+    """sha256 of the canonical config JSON; the staleness signal."""
+    if config is None:
+        return None
+    canonical = json.dumps(config, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def record_blocking_validation_outcome(
+    *,
+    credential_id: int,
+    connector_id: int,
+    source: DocumentSource,
+    trigger: CapabilityCheckTrigger,
+    error: Exception | None,
+    perm_sync_validated: bool,
+    connector_specific_config: dict[str, Any] | None,
+) -> None:
+    """Persists one blocking validation's outcome; never raises.
+
+    Uses its own session so the caller's in-flight transaction is untouched,
+    and never overwrites a granular (named-checks) report with this coarse
+    fallback-shaped record (the no-clobber rule).
+    """
+    try:
+        results = _synthesize_results(source, error, perm_sync_validated)
+        report = CredentialCapabilityReport(
+            credential_id=credential_id,
+            source=source,
+            connector_id=connector_id,
+            checked_at=datetime.now(timezone.utc),
+            trigger=trigger,
+            verdicts=compute_capability_verdicts(
+                get_applicable_capabilities(source), results
+            ),
+            check_results=results,
+        )
+        with get_session_with_current_tenant() as db_session:
+            existing = get_capability_report_row(
+                db_session, credential_id, connector_id
+            )
+            if existing is not None and _has_granular_report(existing):
+                return
+            upsert_completed_capability_report(
+                db_session,
+                credential_id=credential_id,
+                connector_id=connector_id,
+                source=source,
+                trigger=trigger,
+                report=report,
+                connector_config_hash=_connector_config_hash(connector_specific_config),
+            )
+    except Exception:
+        logger.warning(
+            "Failed to record a blocking validation outcome for credential %s.",
+            credential_id,
+            exc_info=True,
+        )

--- a/backend/onyx/connectors/capability_checks/recorder.py
+++ b/backend/onyx/connectors/capability_checks/recorder.py
@@ -157,6 +157,9 @@ def record_blocking_validation_outcome(
                 report=report,
                 connector_config_hash=_connector_config_hash(connector_specific_config),
             )
+            # The accessors leave the transaction to the caller, and the
+            # session context manager closes without committing.
+            db_session.commit()
     except Exception:
         logger.warning(
             "Failed to record a blocking validation outcome for credential %s.",

--- a/backend/onyx/connectors/capability_checks/registry.py
+++ b/backend/onyx/connectors/capability_checks/registry.py
@@ -1,8 +1,8 @@
 from onyx.configs.constants import DocumentSource
 
-# Re-exported: existing callers resolve applicability through the registry;
-# the function lives in ``applicability`` so hot-path modules can import it
-# without this module's eager per-connector check imports.
+# Re-exported: existing callers resolve applicability through the registry; the
+# function lives in ``applicability`` so hot-path modules can import it without
+# this module's eager per-connector check imports.
 from onyx.connectors.capability_checks.applicability import (
     get_applicable_capabilities as get_applicable_capabilities,
 )

--- a/backend/onyx/connectors/capability_checks/registry.py
+++ b/backend/onyx/connectors/capability_checks/registry.py
@@ -1,4 +1,11 @@
 from onyx.configs.constants import DocumentSource
+
+# Re-exported: existing callers resolve applicability through the registry;
+# the function lives in ``applicability`` so hot-path modules can import it
+# without this module's eager per-connector check imports.
+from onyx.connectors.capability_checks.applicability import (
+    get_applicable_capabilities as get_applicable_capabilities,
+)
 from onyx.connectors.capability_checks.models import (
     CapabilityCheck,
     CapabilityCheckContext,
@@ -66,18 +73,3 @@ def get_capability_checks(source: DocumentSource) -> list[CapabilityCheck]:
     )
     checks.extend(get_perm_sync_checks(source))
     return checks
-
-
-def get_applicable_capabilities(source: DocumentSource) -> set[CredentialCapability]:
-    """Returns the capabilities that exist for this source on this build.
-
-    Capabilities outside this set aggregate to a NOT_APPLICABLE verdict. On OSS
-    builds only INDEXING applies, which is correct since perm sync does not
-    exist there.
-    """
-    get_perm_sync_capabilities = fetch_ee_implementation_or_noop(
-        "onyx.connectors.capability_checks",
-        "get_applicable_perm_sync_capabilities",
-        noop_return_value=set(),
-    )
-    return {CredentialCapability.INDEXING} | get_perm_sync_capabilities(source)

--- a/backend/onyx/connectors/factory.py
+++ b/backend/onyx/connectors/factory.py
@@ -6,6 +6,9 @@ from sqlalchemy.orm import Session
 from onyx.configs.app_configs import INTEGRATION_TESTS_MODE
 from onyx.configs.constants import DocumentSource
 from onyx.configs.llm_configs import get_image_extraction_and_analysis_enabled
+from onyx.connectors.capability_checks.recorder import (
+    record_blocking_validation_outcome,
+)
 from onyx.connectors.credentials_provider import build_db_credentials_provider
 from onyx.connectors.exceptions import ConnectorValidationError, ValidationError
 from onyx.connectors.interfaces import (
@@ -20,7 +23,7 @@ from onyx.connectors.models import InputType
 from onyx.connectors.registry import CONNECTOR_CLASS_MAP
 from onyx.db.connector import fetch_connector_by_id
 from onyx.db.credentials import backend_update_credential_json, fetch_credential_by_id
-from onyx.db.enums import AccessType
+from onyx.db.enums import AccessType, CapabilityCheckTrigger
 from onyx.db.models import Credential
 from onyx.file_store.staging import RawFileCallback
 from onyx.utils.credential_audit import emit_credential_access
@@ -174,6 +177,19 @@ def validate_ccpair_for_user(
     if not credential:
         raise ValueError("Credential not found")
 
+    def _record_outcome(error: Exception | None, perm_sync_validated: bool) -> None:
+        # Best-effort scribe for the outcome below; never raises and never
+        # touches this function's session or semantics.
+        record_blocking_validation_outcome(
+            credential_id=credential.id,
+            connector_id=connector_id,
+            source=connector.source,
+            trigger=CapabilityCheckTrigger.CC_PAIR_VALIDATION,
+            error=error,
+            perm_sync_validated=perm_sync_validated,
+            connector_specific_config=connector.connector_specific_config,
+        )
+
     try:
         runnable_connector = instantiate_connector(
             db_session=db_session,
@@ -185,12 +201,17 @@ def validate_ccpair_for_user(
         runnable_connector.validate_connector_settings()
         if access_type == AccessType.SYNC:
             runnable_connector.validate_perm_sync()
-    except ValidationError:
+    except ValidationError as e:
+        _record_outcome(e, perm_sync_validated=False)
         raise
     except Exception as e:
         if enforce_creation:
-            raise ConnectorValidationError(str(e))
+            validation_error = ConnectorValidationError(str(e))
+            _record_outcome(validation_error, perm_sync_validated=False)
+            raise validation_error
         else:
+            _record_outcome(e, perm_sync_validated=False)
             return False
 
+    _record_outcome(None, perm_sync_validated=access_type == AccessType.SYNC)
     return True

--- a/backend/onyx/connectors/factory.py
+++ b/backend/onyx/connectors/factory.py
@@ -177,17 +177,23 @@ def validate_ccpair_for_user(
     if not credential:
         raise ValueError("Credential not found")
 
+    # Plain values for the closure: it runs inside exception handlers, where
+    # lazy ORM attribute loads can raise (e.g. ``PendingRollbackError``) and
+    # replace the exception being handled.
+    source = connector.source
+    connector_specific_config = connector.connector_specific_config
+
     def _record_outcome(error: Exception | None, perm_sync_validated: bool) -> None:
         # Best-effort scribe for the outcome below; never raises and never
         # touches this function's session or semantics.
         record_blocking_validation_outcome(
-            credential_id=credential.id,
+            credential_id=credential_id,
             connector_id=connector_id,
-            source=connector.source,
+            source=source,
             trigger=CapabilityCheckTrigger.CC_PAIR_VALIDATION,
             error=error,
             perm_sync_validated=perm_sync_validated,
-            connector_specific_config=connector.connector_specific_config,
+            connector_specific_config=connector_specific_config,
         )
 
     try:
@@ -205,13 +211,12 @@ def validate_ccpair_for_user(
         _record_outcome(e, perm_sync_validated=False)
         raise
     except Exception as e:
+        # Record ``e`` itself: wrapping first would misreport an unexpected
+        # error as FAILED and erase the real ``error_type``.
+        _record_outcome(e, perm_sync_validated=False)
         if enforce_creation:
-            validation_error = ConnectorValidationError(str(e))
-            _record_outcome(validation_error, perm_sync_validated=False)
-            raise validation_error
-        else:
-            _record_outcome(e, perm_sync_validated=False)
-            return False
+            raise ConnectorValidationError(str(e))
+        return False
 
     _record_outcome(None, perm_sync_validated=access_type == AccessType.SYNC)
     return True

--- a/backend/onyx/db/credential_capability.py
+++ b/backend/onyx/db/credential_capability.py
@@ -151,9 +151,12 @@ def upsert_completed_capability_report_unless_granular(
 ) -> CredentialCapabilityReportRow | None:
     """Writes a finished report unless the stored one came from named checks.
 
-    The guard is part of the upsert statement, so a granular report committed
-    concurrently can never be replaced by this coarse write (the no-clobber
-    rule). Returns None when the stored report was preserved.
+    The "unless" is not Python logic: it compiles into the statement as ``ON
+    CONFLICT DO UPDATE ... WHERE <stored report is not granular>``. A
+    read-then-decide here would race a concurrent granular write; Postgres
+    evaluates the guard against the stored row atomically, so a granular report
+    can never be replaced by this coarse write (the no-clobber rule). Returns
+    None when the stored report was preserved.
     """
     return _upsert_row(
         db_session,
@@ -162,6 +165,7 @@ def upsert_completed_capability_report_unless_granular(
         values=_completed_values(
             connector_id, source, trigger, report, connector_config_hash
         ),
+        # The "unless": evaluated by Postgres inside the upsert, not here.
         update_where=_STORED_REPORT_IS_NOT_GRANULAR,
     )
 

--- a/backend/onyx/db/credential_capability.py
+++ b/backend/onyx/db/credential_capability.py
@@ -9,7 +9,7 @@ resolve to one row instead of racing an insert.
 from datetime import datetime
 from typing import Any, TypedDict
 
-from sqlalchemy import ColumnElement, func, select, text
+from sqlalchemy import ColumnElement, func, literal_column, or_, select, text
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
@@ -17,6 +17,16 @@ from onyx.configs.constants import DocumentSource
 from onyx.connectors.capability_checks.models import CredentialCapabilityReport
 from onyx.db.enums import CapabilityCheckTrigger, CapabilityReportRunStatus
 from onyx.db.models import CredentialCapabilityReportRow
+
+# A stored report is granular when any check result came from a named check;
+# report serialization always writes ``is_fallback`` explicitly.
+_STORED_REPORT_IS_NOT_GRANULAR: ColumnElement[bool] = or_(
+    CredentialCapabilityReportRow.report.is_(None),
+    ~func.jsonb_path_exists(
+        CredentialCapabilityReportRow.report,
+        literal_column("'$.check_results[*] ? (@.is_fallback == false)'::jsonpath"),
+    ),
+)
 
 
 class _CapabilityReportValues(TypedDict, total=False):
@@ -47,13 +57,16 @@ def _upsert_row(
     credential_id: int,
     connector_id: int | None,
     values: _CapabilityReportValues,
-) -> CredentialCapabilityReportRow:
+    update_where: ColumnElement[bool] | None = None,
+) -> CredentialCapabilityReportRow | None:
     """Inserts or updates the scope's single row with ``values``.
 
     Columns absent from ``values`` keep their stored value on the update path,
     which is how RUNNING marks preserve the previous report and completion
     writes preserve ``run_started_at``. The statement executes immediately, but
-    the caller owns the transaction and must commit.
+    the caller owns the transaction and must commit. ``update_where`` guards
+    only the conflict-update path: when the stored row fails it, nothing is
+    written and None is returned.
     """
     # Stamp both the insert and the conflict-update path explicitly: the model's
     # ``onupdate`` is not applied to ON CONFLICT SET clauses, and the ``now()``
@@ -69,12 +82,38 @@ def _upsert_row(
         .on_conflict_do_update(
             **_scope_conflict_kwargs(connector_id),
             set_=stamped,
+            where=update_where,
         )
         .returning(CredentialCapabilityReportRow)
     )
     # ``populate_existing``: without it, RETURNING resolves to the stale
     # identity-map instance when the caller's session already holds this row.
-    return db_session.scalars(stmt, execution_options={"populate_existing": True}).one()
+    return db_session.scalars(
+        stmt, execution_options={"populate_existing": True}
+    ).one_or_none()
+
+
+def _completed_values(
+    connector_id: int | None,
+    source: DocumentSource,
+    trigger: CapabilityCheckTrigger,
+    report: CredentialCapabilityReport,
+    connector_config_hash: str | None,
+) -> _CapabilityReportValues:
+    # A connector-scoped report always ran against a config, a credential-time
+    # one never did; enforcing the pairing keeps an omitted hash from silently
+    # erasing the staleness signal. ``connector_id`` is taken only for this.
+    assert (connector_id is None) == (connector_config_hash is None), (
+        "Connector-scoped reports must carry a config hash; credential-scoped "
+        "reports must not."
+    )
+    return {
+        "source": source,
+        "trigger": trigger,
+        "report": report.model_dump(mode="json"),
+        "connector_config_hash": connector_config_hash,
+        "run_status": CapabilityReportRunStatus.COMPLETED,
+    }
 
 
 def upsert_completed_capability_report(
@@ -88,24 +127,42 @@ def upsert_completed_capability_report(
     connector_config_hash: str | None = None,
 ) -> CredentialCapabilityReportRow:
     """Writes a finished report onto the scope's row (latest-only replace)."""
-    # A connector-scoped report always ran against a config, a credential-time
-    # one never did; enforcing the pairing keeps an omitted hash from silently
-    # erasing the staleness signal.
-    assert (connector_id is None) == (connector_config_hash is None), (
-        "Connector-scoped reports must carry a config hash; credential-scoped "
-        "reports must not."
+    row = _upsert_row(
+        db_session,
+        credential_id=credential_id,
+        connector_id=connector_id,
+        values=_completed_values(
+            connector_id, source, trigger, report, connector_config_hash
+        ),
     )
+    assert row is not None, "An unguarded upsert always returns the row."
+    return row
+
+
+def upsert_completed_capability_report_unless_granular(
+    db_session: Session,
+    *,
+    credential_id: int,
+    connector_id: int | None,
+    source: DocumentSource,
+    trigger: CapabilityCheckTrigger,
+    report: CredentialCapabilityReport,
+    connector_config_hash: str | None = None,
+) -> CredentialCapabilityReportRow | None:
+    """Writes a finished report unless the stored one came from named checks.
+
+    The guard is part of the upsert statement, so a granular report committed
+    concurrently can never be replaced by this coarse write (the no-clobber
+    rule). Returns None when the stored report was preserved.
+    """
     return _upsert_row(
         db_session,
         credential_id=credential_id,
         connector_id=connector_id,
-        values={
-            "source": source,
-            "trigger": trigger,
-            "report": report.model_dump(mode="json"),
-            "connector_config_hash": connector_config_hash,
-            "run_status": CapabilityReportRunStatus.COMPLETED,
-        },
+        values=_completed_values(
+            connector_id, source, trigger, report, connector_config_hash
+        ),
+        update_where=_STORED_REPORT_IS_NOT_GRANULAR,
     )
 
 
@@ -121,7 +178,7 @@ def mark_capability_report_running(
 
     The previous COMPLETED ``report`` stays readable while the run is in flight.
     """
-    return _upsert_row(
+    row = _upsert_row(
         db_session,
         credential_id=credential_id,
         connector_id=connector_id,
@@ -134,6 +191,8 @@ def mark_capability_report_running(
             "run_started_at": func.statement_timestamp(),
         },
     )
+    assert row is not None, "An unguarded upsert always returns the row."
+    return row
 
 
 def get_capability_report_row(

--- a/backend/onyx/db/credential_capability.py
+++ b/backend/onyx/db/credential_capability.py
@@ -4,6 +4,13 @@ One row per (credential, connector-scope): ``connector_id`` NULL is the
 config-less credential-time report, non-NULL is one per attached connector.
 Writers upsert against the scope's partial unique index, so concurrent writers
 resolve to one row instead of racing an insert.
+
+Two writer classes share these rows, with fixed precedence: granular named-check
+runs write through ``upsert_completed_capability_report`` and replace whatever
+is stored (latest-only truth); the coarse blocking-validation recorder writes
+through the ``unless_granular`` variant and never replaces a granular report.
+``mark_capability_report_running`` belongs to the check-runner lifecycle: it
+flags a run in flight while the last completed report stays readable.
 """
 
 from datetime import datetime

--- a/backend/tests/external_dependency_unit/connectors/capability_checks/test_blocking_validation_recorder.py
+++ b/backend/tests/external_dependency_unit/connectors/capability_checks/test_blocking_validation_recorder.py
@@ -6,6 +6,7 @@ guarantees (fallback shape, no-clobber, never breaking validation), not the
 per-connector validation logic.
 """
 
+from collections.abc import Generator
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
@@ -35,14 +36,22 @@ from onyx.db.credential_capability import (
 )
 from onyx.db.enums import AccessType, CapabilityReportRunStatus
 from onyx.db.models import ConnectorCredentialPair
-from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+from tests.external_dependency_unit.indexing_helpers import (
+    cleanup_cc_pair,
+    make_cc_pair,
+)
 
 
 @pytest.fixture
 def blocking_validation(
     db_session: Session, monkeypatch: pytest.MonkeyPatch
-) -> tuple[ConnectorCredentialPair, MagicMock]:
-    """A Slack cc-pair plus a mocked connector behind the blocking validation."""
+) -> Generator[tuple[ConnectorCredentialPair, MagicMock], None, None]:
+    """A Slack cc-pair plus a mocked connector behind the blocking validation.
+
+    Committed on purpose: the recorder reads and writes through its own
+    session, which cannot see this session's uncommitted rows. Teardown
+    removes the pair; report rows cascade with the credential.
+    """
     cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK)
     connector_mock = MagicMock(spec=BaseConnector)
     monkeypatch.setattr(
@@ -50,7 +59,8 @@ def blocking_validation(
     )
     # The early return would skip validation (and thus recording) entirely.
     monkeypatch.setattr(factory, "INTEGRATION_TESTS_MODE", False)
-    return cc_pair, connector_mock
+    yield cc_pair, connector_mock
+    cleanup_cc_pair(db_session, cc_pair)
 
 
 @pytest.mark.usefixtures("tenant_context")
@@ -207,6 +217,9 @@ def test_no_clobber_of_a_granular_report(
         trigger=CapabilityCheckTrigger.MANUAL,
         report=granular,
     )
+    # Commit the seed: the recorder's own session cannot see it uncommitted,
+    # and its upsert would block on this transaction's index lock.
+    db_session.commit()
 
     # Under test.
     validate_ccpair_for_user(

--- a/backend/tests/external_dependency_unit/connectors/capability_checks/test_blocking_validation_recorder.py
+++ b/backend/tests/external_dependency_unit/connectors/capability_checks/test_blocking_validation_recorder.py
@@ -22,7 +22,6 @@ from onyx.connectors.capability_checks import recorder
 from onyx.connectors.capability_checks.models import (
     CapabilityCheckResult,
     CapabilityCheckStatus,
-    CapabilityCheckTrigger,
     CapabilityVerdict,
     CredentialCapabilityReport,
 )
@@ -36,7 +35,12 @@ from onyx.db.credential_capability import (
     get_capability_report_row,
     upsert_completed_capability_report,
 )
-from onyx.db.enums import AccessType, CapabilityReportRunStatus, IndexingStatus
+from onyx.db.enums import (
+    AccessType,
+    CapabilityCheckTrigger,
+    CapabilityReportRunStatus,
+    IndexingStatus,
+)
 from onyx.db.models import ConnectorCredentialPair, IndexAttempt
 from tests.external_dependency_unit.indexing_helpers import (
     cleanup_cc_pair,

--- a/backend/tests/external_dependency_unit/connectors/capability_checks/test_blocking_validation_recorder.py
+++ b/backend/tests/external_dependency_unit/connectors/capability_checks/test_blocking_validation_recorder.py
@@ -1,6 +1,7 @@
 """Recorder tests: blocking validation outcomes become persisted reports.
 
-Runs ``validate_ccpair_for_user`` against real Postgres with the connector
+Runs the two hook sites (``validate_ccpair_for_user`` and docfetching's
+``_get_connector_runner``) against real Postgres with the connector
 instantiation mocked: the subject is the recording side effect and its
 guarantees (fallback shape, no-clobber, never breaking validation), not the
 per-connector validation logic.
@@ -13,6 +14,7 @@ from unittest.mock import MagicMock
 import pytest
 from sqlalchemy.orm import Session
 
+from onyx.background.indexing import run_docfetching
 from onyx.configs.constants import DocumentSource
 from onyx.connectors import factory
 from onyx.connectors.capabilities import CredentialCapability
@@ -34,8 +36,8 @@ from onyx.db.credential_capability import (
     get_capability_report_row,
     upsert_completed_capability_report,
 )
-from onyx.db.enums import AccessType, CapabilityReportRunStatus
-from onyx.db.models import ConnectorCredentialPair
+from onyx.db.enums import AccessType, CapabilityReportRunStatus, IndexingStatus
+from onyx.db.models import ConnectorCredentialPair, IndexAttempt
 from tests.external_dependency_unit.indexing_helpers import (
     cleanup_cc_pair,
     make_cc_pair,
@@ -153,6 +155,36 @@ def test_unexpected_failure_records_indeterminate(
     assert row.report["verdicts"]["indexing"] == "indeterminate"
 
 
+@pytest.mark.usefixtures("tenant_context")
+def test_wrapped_creation_failure_records_the_original_exception(
+    db_session: Session,
+    blocking_validation: tuple[ConnectorCredentialPair, MagicMock],
+) -> None:
+    """
+    Verifies the creation gate raises its wrapper while the report keeps the
+    original exception: an unexpected error is INDETERMINATE, never FAILED.
+    """
+    # Precondition.
+    cc_pair, connector_mock = blocking_validation
+    connector_mock.validate_connector_settings.side_effect = RuntimeError("boom")
+
+    # Under test.
+    with pytest.raises(ConnectorValidationError, match="boom"):
+        validate_ccpair_for_user(
+            cc_pair.connector_id, cc_pair.credential_id, AccessType.PUBLIC, db_session
+        )
+
+    # Postcondition.
+    row = get_capability_report_row(
+        db_session, cc_pair.credential_id, cc_pair.connector_id
+    )
+    assert row is not None
+    assert row.report is not None
+    assert row.report["verdicts"]["indexing"] == "indeterminate"
+    (check_result,) = row.report["check_results"]
+    assert check_result["error_type"] == "RuntimeError"
+
+
 @pytest.mark.usefixtures("tenant_context", "enable_ee")
 def test_sync_success_mirrors_the_outcome_onto_perm_sync(
     db_session: Session,
@@ -260,3 +292,74 @@ def test_recorder_failure_never_breaks_validation(
         )
         is True
     )
+
+
+@pytest.fixture
+def docfetching_validation(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> Generator[tuple[IndexAttempt, MagicMock], None, None]:
+    """A committed Slack index attempt with docfetching's instantiation mocked.
+
+    Mirrors ``blocking_validation`` for the ``_get_connector_runner`` hook.
+    """
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK)
+    attempt = IndexAttempt(
+        connector_credential_pair_id=cc_pair.id,
+        search_settings_id=None,
+        from_beginning=False,
+        status=IndexingStatus.NOT_STARTED,
+    )
+    db_session.add(attempt)
+    db_session.commit()
+    db_session.refresh(attempt)
+    instantiate_mock = MagicMock()
+    monkeypatch.setattr(run_docfetching, "instantiate_connector", instantiate_mock)
+    monkeypatch.setattr(run_docfetching, "INTEGRATION_TESTS_MODE", False)
+    yield attempt, instantiate_mock
+    # The attempt does not cascade from the pair; its stage-metric rows
+    # cascade from the attempt.
+    db_session.query(IndexAttempt).filter(IndexAttempt.id == attempt.id).delete(
+        synchronize_session="fetch"
+    )
+    db_session.commit()
+    cleanup_cc_pair(db_session, cc_pair)
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_docfetching_failure_records_through_the_indexing_attempt_hook(
+    db_session: Session,
+    docfetching_validation: tuple[IndexAttempt, MagicMock],
+) -> None:
+    """
+    Verifies the second hook site: a validation failure at docfetching start
+    lands as an INDEXING_ATTEMPT-triggered report and still propagates.
+    """
+    # Precondition.
+    attempt, instantiate_mock = docfetching_validation
+    instantiate_mock.side_effect = RuntimeError("source down")
+    cc_pair = attempt.connector_credential_pair
+
+    # Under test.
+    with pytest.raises(RuntimeError, match="source down"):
+        run_docfetching._get_connector_runner(
+            db_session=db_session,
+            attempt=attempt,
+            batch_size=16,
+            start_time=datetime.now(timezone.utc),
+            end_time=datetime.now(timezone.utc),
+            include_permissions=False,
+            # True skips the pause-the-pair branch, which is not under test.
+            leave_connector_active=True,
+        )
+
+    # Postcondition.
+    row = get_capability_report_row(
+        db_session, cc_pair.credential_id, cc_pair.connector_id
+    )
+    assert row is not None
+    assert row.trigger == CapabilityCheckTrigger.INDEXING_ATTEMPT
+    assert row.report is not None
+    assert row.report["verdicts"]["indexing"] == "indeterminate"
+    (check_result,) = row.report["check_results"]
+    assert check_result["is_fallback"] is True
+    assert check_result["error_type"] == "RuntimeError"

--- a/backend/tests/external_dependency_unit/connectors/capability_checks/test_blocking_validation_recorder.py
+++ b/backend/tests/external_dependency_unit/connectors/capability_checks/test_blocking_validation_recorder.py
@@ -1,0 +1,247 @@
+"""Recorder tests: blocking validation outcomes become persisted reports.
+
+Runs ``validate_ccpair_for_user`` against real Postgres with the connector
+instantiation mocked: the subject is the recording side effect and its
+guarantees (fallback shape, no-clobber, never breaking validation), not the
+per-connector validation logic.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors import factory
+from onyx.connectors.capabilities import CredentialCapability
+from onyx.connectors.capability_checks import recorder
+from onyx.connectors.capability_checks.models import (
+    CapabilityCheckResult,
+    CapabilityCheckStatus,
+    CapabilityCheckTrigger,
+    CapabilityVerdict,
+    CredentialCapabilityReport,
+)
+from onyx.connectors.exceptions import (
+    ConnectorValidationError,
+    UnexpectedValidationError,
+)
+from onyx.connectors.factory import validate_ccpair_for_user
+from onyx.connectors.interfaces import BaseConnector
+from onyx.db.credential_capability import (
+    get_capability_report_row,
+    upsert_completed_capability_report,
+)
+from onyx.db.enums import AccessType, CapabilityReportRunStatus
+from onyx.db.models import ConnectorCredentialPair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+
+@pytest.fixture
+def blocking_validation(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> tuple[ConnectorCredentialPair, MagicMock]:
+    """A Slack cc-pair plus a mocked connector behind the blocking validation."""
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK)
+    connector_mock = MagicMock(spec=BaseConnector)
+    monkeypatch.setattr(
+        factory, "instantiate_connector", MagicMock(return_value=connector_mock)
+    )
+    # The early return would skip validation (and thus recording) entirely.
+    monkeypatch.setattr(factory, "INTEGRATION_TESTS_MODE", False)
+    return cc_pair, connector_mock
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_success_records_a_fallback_shaped_passed_report(
+    db_session: Session,
+    blocking_validation: tuple[ConnectorCredentialPair, MagicMock],
+) -> None:
+    # Precondition.
+    cc_pair, _ = blocking_validation
+
+    # Under test.
+    result = validate_ccpair_for_user(
+        cc_pair.connector_id, cc_pair.credential_id, AccessType.PUBLIC, db_session
+    )
+
+    # Postcondition.
+    assert result is True
+    row = get_capability_report_row(
+        db_session, cc_pair.credential_id, cc_pair.connector_id
+    )
+    assert row is not None
+    assert row.trigger == CapabilityCheckTrigger.CC_PAIR_VALIDATION
+    assert row.run_status == CapabilityReportRunStatus.COMPLETED
+    assert row.connector_config_hash is not None
+    assert row.report is not None
+    assert row.report["verdicts"]["indexing"] == "passed"
+    (check_result,) = row.report["check_results"]
+    assert check_result["check_id"] == "slack_connector_settings"
+    assert check_result["is_fallback"] is True
+    assert check_result["status"] == "passed"
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_validation_failure_records_failed_and_still_raises(
+    db_session: Session,
+    blocking_validation: tuple[ConnectorCredentialPair, MagicMock],
+) -> None:
+    # Precondition.
+    cc_pair, connector_mock = blocking_validation
+    connector_mock.validate_connector_settings.side_effect = ConnectorValidationError(
+        "missing scope"
+    )
+
+    # Under test.
+    with pytest.raises(ConnectorValidationError, match="missing scope"):
+        validate_ccpair_for_user(
+            cc_pair.connector_id, cc_pair.credential_id, AccessType.PUBLIC, db_session
+        )
+
+    # Postcondition.
+    row = get_capability_report_row(
+        db_session, cc_pair.credential_id, cc_pair.connector_id
+    )
+    assert row is not None
+    assert row.report is not None
+    assert row.report["verdicts"]["indexing"] == "failed"
+    (check_result,) = row.report["check_results"]
+    assert check_result["status"] == "failed"
+    assert check_result["message"] == "missing scope"
+    assert check_result["error_type"] == "ConnectorValidationError"
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_unexpected_failure_records_indeterminate(
+    db_session: Session,
+    blocking_validation: tuple[ConnectorCredentialPair, MagicMock],
+) -> None:
+    """
+    Verifies the exception contract carries over: a transient failure is never
+    recorded as proof of a broken credential.
+    """
+    # Precondition.
+    cc_pair, connector_mock = blocking_validation
+    connector_mock.validate_connector_settings.side_effect = UnexpectedValidationError(
+        "source hiccup"
+    )
+
+    # Under test.
+    with pytest.raises(UnexpectedValidationError):
+        validate_ccpair_for_user(
+            cc_pair.connector_id, cc_pair.credential_id, AccessType.PUBLIC, db_session
+        )
+
+    # Postcondition.
+    row = get_capability_report_row(
+        db_session, cc_pair.credential_id, cc_pair.connector_id
+    )
+    assert row is not None
+    assert row.report is not None
+    assert row.report["verdicts"]["indexing"] == "indeterminate"
+
+
+@pytest.mark.usefixtures("tenant_context", "enable_ee")
+def test_sync_success_mirrors_the_outcome_onto_perm_sync(
+    db_session: Session,
+    blocking_validation: tuple[ConnectorCredentialPair, MagicMock],
+) -> None:
+    """
+    Verifies a SYNC-access success also claims the applicable perm-sync
+    capability (EE resolution on: applicability comes from the EE hook).
+    """
+    # Precondition.
+    cc_pair, _ = blocking_validation
+
+    # Under test.
+    validate_ccpair_for_user(
+        cc_pair.connector_id, cc_pair.credential_id, AccessType.SYNC, db_session
+    )
+
+    # Postcondition.
+    row = get_capability_report_row(
+        db_session, cc_pair.credential_id, cc_pair.connector_id
+    )
+    assert row is not None
+    assert row.report is not None
+    check_ids = {result["check_id"] for result in row.report["check_results"]}
+    assert check_ids == {"slack_connector_settings", "slack_perm_sync"}
+    assert row.report["verdicts"]["doc_permission_sync"] == "passed"
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_no_clobber_of_a_granular_report(
+    db_session: Session,
+    blocking_validation: tuple[ConnectorCredentialPair, MagicMock],
+) -> None:
+    """
+    Verifies the coarse recorder never overwrites a named-checks report.
+    """
+    # Precondition.
+    cc_pair, _ = blocking_validation
+    granular = CredentialCapabilityReport(
+        credential_id=cc_pair.credential_id,
+        source=DocumentSource.SLACK,
+        connector_id=cc_pair.connector_id,
+        checked_at=datetime.now(timezone.utc),
+        trigger=CapabilityCheckTrigger.MANUAL,
+        verdicts={CredentialCapability.INDEXING: CapabilityVerdict.FAILED},
+        check_results=[
+            CapabilityCheckResult(
+                capability=CredentialCapability.INDEXING,
+                check_id="slack_token_auth",
+                display_name="Bot token is valid",
+                required=True,
+                status=CapabilityCheckStatus.FAILED,
+                is_fallback=False,
+            )
+        ],
+    )
+    upsert_completed_capability_report(
+        db_session,
+        credential_id=cc_pair.credential_id,
+        connector_id=cc_pair.connector_id,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        report=granular,
+    )
+
+    # Under test.
+    validate_ccpair_for_user(
+        cc_pair.connector_id, cc_pair.credential_id, AccessType.PUBLIC, db_session
+    )
+
+    # Postcondition.
+    row = get_capability_report_row(
+        db_session, cc_pair.credential_id, cc_pair.connector_id
+    )
+    assert row is not None
+    assert row.trigger == CapabilityCheckTrigger.MANUAL
+    assert row.report is not None
+    (check_result,) = row.report["check_results"]
+    assert check_result["check_id"] == "slack_token_auth"
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_recorder_failure_never_breaks_validation(
+    db_session: Session,
+    blocking_validation: tuple[ConnectorCredentialPair, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Precondition.
+    cc_pair, _ = blocking_validation
+    monkeypatch.setattr(
+        recorder,
+        "upsert_completed_capability_report",
+        MagicMock(side_effect=RuntimeError("db down")),
+    )
+
+    # Under test and postcondition.
+    assert (
+        validate_ccpair_for_user(
+            cc_pair.connector_id, cc_pair.credential_id, AccessType.PUBLIC, db_session
+        )
+        is True
+    )

--- a/backend/tests/external_dependency_unit/connectors/capability_checks/test_blocking_validation_recorder.py
+++ b/backend/tests/external_dependency_unit/connectors/capability_checks/test_blocking_validation_recorder.py
@@ -50,9 +50,9 @@ def blocking_validation(
 ) -> Generator[tuple[ConnectorCredentialPair, MagicMock], None, None]:
     """A Slack cc-pair plus a mocked connector behind the blocking validation.
 
-    Committed on purpose: the recorder reads and writes through its own
-    session, which cannot see this session's uncommitted rows. Teardown
-    removes the pair; report rows cascade with the credential.
+    Committed on purpose: the recorder reads and writes through its own session,
+    which cannot see this session's uncommitted rows. Teardown removes the pair;
+    report rows cascade with the credential.
     """
     cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK)
     connector_mock = MagicMock(spec=BaseConnector)
@@ -251,8 +251,8 @@ def test_no_clobber_of_a_granular_report(
         # Connector-scoped writes must carry the config hash they ran with.
         connector_config_hash="seeded-hash",
     )
-    # Commit the seed: the recorder's own session cannot see it uncommitted,
-    # and its upsert would block on this transaction's index lock.
+    # Commit the seed: the recorder's own session cannot see it uncommitted, and
+    # its upsert would block on this transaction's index lock.
     db_session.commit()
 
     # Under test.
@@ -316,8 +316,8 @@ def docfetching_validation(
     monkeypatch.setattr(run_docfetching, "instantiate_connector", instantiate_mock)
     monkeypatch.setattr(run_docfetching, "INTEGRATION_TESTS_MODE", False)
     yield attempt, instantiate_mock
-    # The attempt does not cascade from the pair; its stage-metric rows
-    # cascade from the attempt.
+    # The attempt does not cascade from the pair; its stage-metric rows cascade
+    # from the attempt.
     db_session.query(IndexAttempt).filter(IndexAttempt.id == attempt.id).delete(
         synchronize_session="fetch"
     )

--- a/backend/tests/external_dependency_unit/connectors/capability_checks/test_blocking_validation_recorder.py
+++ b/backend/tests/external_dependency_unit/connectors/capability_checks/test_blocking_validation_recorder.py
@@ -216,6 +216,8 @@ def test_no_clobber_of_a_granular_report(
         source=DocumentSource.SLACK,
         trigger=CapabilityCheckTrigger.MANUAL,
         report=granular,
+        # Connector-scoped writes must carry the config hash they ran with.
+        connector_config_hash="seeded-hash",
     )
     # Commit the seed: the recorder's own session cannot see it uncommitted,
     # and its upsert would block on this transaction's index lock.

--- a/backend/tests/external_dependency_unit/connectors/capability_checks/test_blocking_validation_recorder.py
+++ b/backend/tests/external_dependency_unit/connectors/capability_checks/test_blocking_validation_recorder.py
@@ -247,7 +247,7 @@ def test_recorder_failure_never_breaks_validation(
     cc_pair, _ = blocking_validation
     monkeypatch.setattr(
         recorder,
-        "upsert_completed_capability_report",
+        "upsert_completed_capability_report_unless_granular",
         MagicMock(side_effect=RuntimeError("db down")),
     )
 

--- a/backend/tests/external_dependency_unit/db/test_credential_capability.py
+++ b/backend/tests/external_dependency_unit/db/test_credential_capability.py
@@ -24,6 +24,7 @@ from onyx.db.credential_capability import (
     get_capability_report_rows_for_source,
     mark_capability_report_running,
     upsert_completed_capability_report,
+    upsert_completed_capability_report_unless_granular,
 )
 from onyx.db.enums import CapabilityCheckTrigger, CapabilityReportRunStatus
 from onyx.db.models import Credential
@@ -34,6 +35,7 @@ def _report(
     credential_id: int,
     connector_id: int | None = None,
     check_id: str = "slack_token_auth",
+    is_fallback: bool = False,
 ) -> CredentialCapabilityReport:
     return CredentialCapabilityReport(
         credential_id=credential_id,
@@ -53,6 +55,7 @@ def _report(
                 display_name="Test check",
                 required=True,
                 status=CapabilityCheckStatus.PASSED,
+                is_fallback=is_fallback,
             )
         ],
     )
@@ -258,6 +261,82 @@ def test_rows_for_source_lists_most_recently_updated_first(
     second_index = row_credential_ids.index(second_pair.credential_id)
     assert third_index < first_index < second_index
     assert all(row.source == DocumentSource.SLACK for row in rows)
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_unless_granular_preserves_a_granular_report(db_session: Session) -> None:
+    """
+    Verifies the no-clobber guard: the guarded upsert is a no-op against a
+    stored named-checks report and signals it by returning None.
+    """
+    # Precondition.
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
+    credential_id = cc_pair.credential_id
+    upsert_completed_capability_report(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        report=_report(credential_id, check_id="granular"),
+    )
+
+    # Under test.
+    result = upsert_completed_capability_report_unless_granular(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.CC_PAIR_VALIDATION,
+        report=_report(credential_id, check_id="fallback", is_fallback=True),
+    )
+
+    # Postcondition.
+    assert result is None
+    row = get_capability_report_row(db_session, credential_id, None)
+    assert row is not None
+    assert row.trigger == CapabilityCheckTrigger.MANUAL
+    assert row.report is not None
+    assert row.report["check_results"][0]["check_id"] == "granular"
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_unless_granular_inserts_and_replaces_fallback_reports(
+    db_session: Session,
+) -> None:
+    """
+    Verifies the guard only protects granular state: the guarded upsert
+    still inserts into an empty scope and replaces fallback-shaped reports.
+    """
+    # Precondition.
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
+    credential_id = cc_pair.credential_id
+
+    # Under test.
+    inserted = upsert_completed_capability_report_unless_granular(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.CC_PAIR_VALIDATION,
+        report=_report(credential_id, check_id="first", is_fallback=True),
+    )
+    replaced = upsert_completed_capability_report_unless_granular(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.INDEXING_ATTEMPT,
+        report=_report(credential_id, check_id="second", is_fallback=True),
+    )
+
+    # Postcondition.
+    assert inserted is not None
+    assert replaced is not None
+    assert replaced.id == inserted.id
+    assert replaced.trigger == CapabilityCheckTrigger.INDEXING_ATTEMPT
+    assert replaced.report is not None
+    assert replaced.report["check_results"][0]["check_id"] == "second"
 
 
 @pytest.mark.usefixtures("tenant_context")

--- a/backend/tests/external_dependency_unit/db/test_credential_capability.py
+++ b/backend/tests/external_dependency_unit/db/test_credential_capability.py
@@ -305,8 +305,8 @@ def test_unless_granular_inserts_and_replaces_fallback_reports(
     db_session: Session,
 ) -> None:
     """
-    Verifies the guard only protects granular state: the guarded upsert
-    still inserts into an empty scope and replaces fallback-shaped reports.
+    Verifies the guard only protects granular state: the guarded upsert still
+    inserts into an empty scope and replaces fallback-shaped reports.
     """
     # Precondition.
     cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)


### PR DESCRIPTION
## Description

Third PR of the persistence split (prev. #13973): records the outcome of each existing blocking validation run as a capability report row. This cannot block or change behavior for existing customers: no validation decision, gate, or return value changes, the recorder never raises (any failure degrades to a warning log), and it writes through its own session so the caller's transaction is untouched. Added cost on the validation paths is one upsert.

- record_blocking_validation_outcome (new module) persists each outcome as a fallback-shaped report: success -> PASSED, ConnectorValidationError -> FAILED, anything else -> INDETERMINATE.
- Hooked at the two places blocking validation already runs: validate_ccpair_for_user and indexing-run start.
- No-clobber: a coarse fallback record never overwrites a granular named-checks report.
- Failures land on the INDEXING row only; perm-sync rows are written only on a SYNC success, since the monolithic gate cannot attribute a failure between the two probes.
- get_applicable_capabilities moved to a new applicability module so the hook sites do not import the check registry, which would eagerly load every migrated connector (slack_sdk included) into all production processes.

## How Has This Been Tested?

- Tests cover the status mapping, no-clobber, perm-sync mirroring, and that a recorder failure never breaks validation.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

