### PR TITLE
feat(connector-stability): credential capability report accessors

### DIFF
--- a/backend/onyx/db/credential_capability.py
+++ b/backend/onyx/db/credential_capability.py
@@ -6,9 +6,10 @@ Writers upsert against the scope's partial unique index, so concurrent writers
 resolve to one row instead of racing an insert.
 """
 
-from typing import Any
+from datetime import datetime
+from typing import Any, TypedDict
 
-from sqlalchemy import func, select, text
+from sqlalchemy import ColumnElement, func, select, text
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
@@ -18,20 +19,26 @@ from onyx.db.enums import CapabilityCheckTrigger, CapabilityReportRunStatus
 from onyx.db.models import CredentialCapabilityReportRow
 
 
+class _CapabilityReportValues(TypedDict, total=False):
+    """Columns an upsert may write; each writer passes only what it changes."""
+
+    source: DocumentSource
+    trigger: CapabilityCheckTrigger
+    report: dict[str, Any]
+    connector_config_hash: str | None
+    run_status: CapabilityReportRunStatus
+    run_started_at: ColumnElement[datetime]
+    time_updated: ColumnElement[datetime]
+
+
 def _scope_conflict_kwargs(connector_id: int | None) -> dict[str, Any]:
     """ON CONFLICT inference for the row's scope-specific partial index."""
-    if connector_id is None:
-        return {
-            "index_elements": [CredentialCapabilityReportRow.credential_id],
-            "index_where": text("connector_id IS NULL"),
-        }
-    return {
-        "index_elements": [
-            CredentialCapabilityReportRow.credential_id,
-            CredentialCapabilityReportRow.connector_id,
-        ],
-        "index_where": text("connector_id IS NOT NULL"),
-    }
+    index_elements = [CredentialCapabilityReportRow.credential_id]
+    index_where = "connector_id IS NULL"
+    if connector_id is not None:
+        index_elements.append(CredentialCapabilityReportRow.connector_id)
+        index_where = "connector_id IS NOT NULL"
+    return {"index_elements": index_elements, "index_where": text(index_where)}
 
 
 def _upsert_row(
@@ -39,7 +46,7 @@ def _upsert_row(
     *,
     credential_id: int,
     connector_id: int | None,
-    values: dict[str, Any],
+    values: _CapabilityReportValues,
 ) -> CredentialCapabilityReportRow:
     """Inserts or updates the scope's single row with ``values``.
 
@@ -52,7 +59,10 @@ def _upsert_row(
     # ``onupdate`` is not applied to ON CONFLICT SET clauses, and the ``now()``
     # defaults are transaction-start time, which would stamp every write of one
     # transaction identically.
-    stamped = {**values, "time_updated": func.statement_timestamp()}
+    stamped: _CapabilityReportValues = {
+        **values,
+        "time_updated": func.statement_timestamp(),
+    }
     stmt = (
         insert(CredentialCapabilityReportRow)
         .values(credential_id=credential_id, connector_id=connector_id, **stamped)

--- a/backend/onyx/db/credential_capability.py
+++ b/backend/onyx/db/credential_capability.py
@@ -48,16 +48,17 @@ def _upsert_row(
     completion writes preserve ``run_started_at``. The statement executes
     immediately, but the caller owns the transaction and must commit.
     """
+    # Stamp both the insert and the conflict-update path explicitly: the
+    # model's ``onupdate`` is not applied to ON CONFLICT SET clauses, and the
+    # ``now()`` defaults are transaction-start time, which would stamp every
+    # write of one transaction identically.
+    stamped = {**values, "time_updated": func.statement_timestamp()}
     stmt = (
         insert(CredentialCapabilityReportRow)
-        .values(credential_id=credential_id, connector_id=connector_id, **values)
+        .values(credential_id=credential_id, connector_id=connector_id, **stamped)
         .on_conflict_do_update(
             **_scope_conflict_kwargs(connector_id),
-            # The model's ``onupdate`` is not applied to ON CONFLICT SET
-            # clauses, so bump ``time_updated`` explicitly -- with statement
-            # time, because ``now()`` is transaction-start time and would
-            # stamp every write of one transaction identically.
-            set_={**values, "time_updated": func.statement_timestamp()},
+            set_=stamped,
         )
         .returning(CredentialCapabilityReportRow)
     )
@@ -77,6 +78,13 @@ def upsert_completed_capability_report(
     connector_config_hash: str | None = None,
 ) -> CredentialCapabilityReportRow:
     """Writes a finished report onto the scope's row (latest-only replace)."""
+    # A connector-scoped report always ran against a config, a credential-time
+    # one never did; enforcing the pairing keeps an omitted hash from silently
+    # erasing the staleness signal.
+    assert (connector_id is None) == (connector_config_hash is None), (
+        "Connector-scoped reports must carry a config hash; credential-scoped "
+        "reports must not."
+    )
     return _upsert_row(
         db_session,
         credential_id=credential_id,
@@ -112,7 +120,9 @@ def mark_capability_report_running(
             "source": source,
             "trigger": trigger,
             "run_status": CapabilityReportRunStatus.RUNNING,
-            "run_started_at": func.now(),
+            # Statement time, not ``now()``: the run starts now, not when the
+            # caller's transaction began.
+            "run_started_at": func.statement_timestamp(),
         },
     )
 

--- a/backend/onyx/db/credential_capability.py
+++ b/backend/onyx/db/credential_capability.py
@@ -1,0 +1,145 @@
+"""DB accessors for the latest-only credential capability reports.
+
+One row per (credential, connector-scope): ``connector_id`` NULL is the
+config-less credential-time report, non-NULL is one per attached connector.
+Writers upsert against the scope's partial unique index, so concurrent
+writers resolve to one row instead of racing an insert.
+"""
+
+from typing import Any
+
+from sqlalchemy import func, select, text
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.capability_checks.models import CredentialCapabilityReport
+from onyx.db.enums import CapabilityCheckTrigger, CapabilityReportRunStatus
+from onyx.db.models import CredentialCapabilityReportRow
+
+
+def _scope_conflict_kwargs(connector_id: int | None) -> dict[str, Any]:
+    """ON CONFLICT inference for the row's scope-specific partial index."""
+    if connector_id is None:
+        return {
+            "index_elements": [CredentialCapabilityReportRow.credential_id],
+            "index_where": text("connector_id IS NULL"),
+        }
+    return {
+        "index_elements": [
+            CredentialCapabilityReportRow.credential_id,
+            CredentialCapabilityReportRow.connector_id,
+        ],
+        "index_where": text("connector_id IS NOT NULL"),
+    }
+
+
+def _upsert_row(
+    db_session: Session,
+    *,
+    credential_id: int,
+    connector_id: int | None,
+    values: dict[str, Any],
+) -> CredentialCapabilityReportRow:
+    """Inserts or updates the scope's single row with ``values``.
+
+    Columns absent from ``values`` keep their stored value on the update
+    path, which is how RUNNING marks preserve the previous report and
+    completion writes preserve ``run_started_at``.
+    """
+    stmt = (
+        insert(CredentialCapabilityReportRow)
+        .values(credential_id=credential_id, connector_id=connector_id, **values)
+        .on_conflict_do_update(
+            **_scope_conflict_kwargs(connector_id),
+            # The model's ``onupdate`` is not applied to ON CONFLICT SET
+            # clauses, so bump ``time_updated`` explicitly.
+            set_={**values, "time_updated": func.now()},
+        )
+        .returning(CredentialCapabilityReportRow)
+    )
+    # ``populate_existing``: without it, RETURNING resolves to the stale
+    # identity-map instance when the caller's session already holds this row.
+    row = db_session.scalars(stmt, execution_options={"populate_existing": True}).one()
+    db_session.commit()
+    return row
+
+
+def upsert_completed_capability_report(
+    db_session: Session,
+    *,
+    credential_id: int,
+    connector_id: int | None,
+    source: DocumentSource,
+    trigger: CapabilityCheckTrigger,
+    report: CredentialCapabilityReport,
+    connector_config_hash: str | None = None,
+) -> CredentialCapabilityReportRow:
+    """Writes a finished report onto the scope's row (latest-only replace)."""
+    return _upsert_row(
+        db_session,
+        credential_id=credential_id,
+        connector_id=connector_id,
+        values={
+            "source": source,
+            "trigger": trigger,
+            "report": report.model_dump(mode="json"),
+            "connector_config_hash": connector_config_hash,
+            "run_status": CapabilityReportRunStatus.COMPLETED,
+        },
+    )
+
+
+def mark_capability_report_running(
+    db_session: Session,
+    *,
+    credential_id: int,
+    connector_id: int | None,
+    source: DocumentSource,
+    trigger: CapabilityCheckTrigger,
+) -> CredentialCapabilityReportRow:
+    """Flags the scope's row RUNNING with a fresh start time.
+
+    The previous COMPLETED ``report`` stays readable while the run is in
+    flight.
+    """
+    return _upsert_row(
+        db_session,
+        credential_id=credential_id,
+        connector_id=connector_id,
+        values={
+            "source": source,
+            "trigger": trigger,
+            "run_status": CapabilityReportRunStatus.RUNNING,
+            "run_started_at": func.now(),
+        },
+    )
+
+
+def get_capability_report_row(
+    db_session: Session,
+    credential_id: int,
+    connector_id: int | None,
+) -> CredentialCapabilityReportRow | None:
+    """Returns the scope's row; it is the latest report by construction."""
+    stmt = select(CredentialCapabilityReportRow).where(
+        CredentialCapabilityReportRow.credential_id == credential_id
+    )
+    if connector_id is None:
+        stmt = stmt.where(CredentialCapabilityReportRow.connector_id.is_(None))
+    else:
+        stmt = stmt.where(CredentialCapabilityReportRow.connector_id == connector_id)
+    return db_session.scalars(stmt).one_or_none()
+
+
+def get_capability_report_rows_for_source(
+    db_session: Session,
+    source: DocumentSource,
+) -> list[CredentialCapabilityReportRow]:
+    """Returns every report row for a source, most recently updated first."""
+    stmt = (
+        select(CredentialCapabilityReportRow)
+        .where(CredentialCapabilityReportRow.source == source)
+        .order_by(CredentialCapabilityReportRow.time_updated.desc())
+    )
+    return list(db_session.scalars(stmt).all())

--- a/backend/onyx/db/credential_capability.py
+++ b/backend/onyx/db/credential_capability.py
@@ -45,7 +45,8 @@ def _upsert_row(
 
     Columns absent from ``values`` keep their stored value on the update
     path, which is how RUNNING marks preserve the previous report and
-    completion writes preserve ``run_started_at``.
+    completion writes preserve ``run_started_at``. The statement executes
+    immediately, but the caller owns the transaction and must commit.
     """
     stmt = (
         insert(CredentialCapabilityReportRow)
@@ -60,9 +61,7 @@ def _upsert_row(
     )
     # ``populate_existing``: without it, RETURNING resolves to the stale
     # identity-map instance when the caller's session already holds this row.
-    row = db_session.scalars(stmt, execution_options={"populate_existing": True}).one()
-    db_session.commit()
-    return row
+    return db_session.scalars(stmt, execution_options={"populate_existing": True}).one()
 
 
 def upsert_completed_capability_report(

--- a/backend/onyx/db/credential_capability.py
+++ b/backend/onyx/db/credential_capability.py
@@ -54,8 +54,10 @@ def _upsert_row(
         .on_conflict_do_update(
             **_scope_conflict_kwargs(connector_id),
             # The model's ``onupdate`` is not applied to ON CONFLICT SET
-            # clauses, so bump ``time_updated`` explicitly.
-            set_={**values, "time_updated": func.now()},
+            # clauses, so bump ``time_updated`` explicitly -- with statement
+            # time, because ``now()`` is transaction-start time and would
+            # stamp every write of one transaction identically.
+            set_={**values, "time_updated": func.statement_timestamp()},
         )
         .returning(CredentialCapabilityReportRow)
     )
@@ -139,6 +141,10 @@ def get_capability_report_rows_for_source(
     stmt = (
         select(CredentialCapabilityReportRow)
         .where(CredentialCapabilityReportRow.source == source)
-        .order_by(CredentialCapabilityReportRow.time_updated.desc())
+        # ``id`` breaks timestamp ties deterministically.
+        .order_by(
+            CredentialCapabilityReportRow.time_updated.desc(),
+            CredentialCapabilityReportRow.id.desc(),
+        )
     )
     return list(db_session.scalars(stmt).all())

--- a/backend/onyx/db/credential_capability.py
+++ b/backend/onyx/db/credential_capability.py
@@ -2,8 +2,8 @@
 
 One row per (credential, connector-scope): ``connector_id`` NULL is the
 config-less credential-time report, non-NULL is one per attached connector.
-Writers upsert against the scope's partial unique index, so concurrent
-writers resolve to one row instead of racing an insert.
+Writers upsert against the scope's partial unique index, so concurrent writers
+resolve to one row instead of racing an insert.
 """
 
 from typing import Any
@@ -43,15 +43,15 @@ def _upsert_row(
 ) -> CredentialCapabilityReportRow:
     """Inserts or updates the scope's single row with ``values``.
 
-    Columns absent from ``values`` keep their stored value on the update
-    path, which is how RUNNING marks preserve the previous report and
-    completion writes preserve ``run_started_at``. The statement executes
-    immediately, but the caller owns the transaction and must commit.
+    Columns absent from ``values`` keep their stored value on the update path,
+    which is how RUNNING marks preserve the previous report and completion
+    writes preserve ``run_started_at``. The statement executes immediately, but
+    the caller owns the transaction and must commit.
     """
-    # Stamp both the insert and the conflict-update path explicitly: the
-    # model's ``onupdate`` is not applied to ON CONFLICT SET clauses, and the
-    # ``now()`` defaults are transaction-start time, which would stamp every
-    # write of one transaction identically.
+    # Stamp both the insert and the conflict-update path explicitly: the model's
+    # ``onupdate`` is not applied to ON CONFLICT SET clauses, and the ``now()``
+    # defaults are transaction-start time, which would stamp every write of one
+    # transaction identically.
     stamped = {**values, "time_updated": func.statement_timestamp()}
     stmt = (
         insert(CredentialCapabilityReportRow)
@@ -109,8 +109,7 @@ def mark_capability_report_running(
 ) -> CredentialCapabilityReportRow:
     """Flags the scope's row RUNNING with a fresh start time.
 
-    The previous COMPLETED ``report`` stays readable while the run is in
-    flight.
+    The previous COMPLETED ``report`` stays readable while the run is in flight.
     """
     return _upsert_row(
         db_session,

--- a/backend/tests/external_dependency_unit/db/test_credential_capability.py
+++ b/backend/tests/external_dependency_unit/db/test_credential_capability.py
@@ -1,9 +1,9 @@
 """Accessor tests for the latest-only credential capability report rows.
 
-Runs against real Postgres: the upsert semantics live in the two partial
-unique indexes and ON CONFLICT inference, which mocks cannot exercise.
-Nothing here commits (the accessors leave the transaction to the caller), so
-every test's rows roll back when its session closes.
+Runs against real Postgres: the upsert semantics live in the two partial unique
+indexes and ON CONFLICT inference, which mocks cannot exercise. Nothing here
+commits (the accessors leave the transaction to the caller), so every test's
+rows roll back when its session closes.
 """
 
 from datetime import datetime, timezone
@@ -97,8 +97,8 @@ def test_upsert_inserts_then_replaces(db_session: Session) -> None:
 @pytest.mark.usefixtures("tenant_context")
 def test_credential_and_connector_scopes_coexist(db_session: Session) -> None:
     """
-    Verifies the config-less credential-time row and a connector-scoped row
-    are distinct rows for one credential, each fetched by its scope.
+    Verifies the config-less credential-time row and a connector-scoped row are
+    distinct rows for one credential, each fetched by its scope.
     """
     # Precondition.
     cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
@@ -235,8 +235,8 @@ def test_rows_for_source_lists_most_recently_updated_first(
         trigger=CapabilityCheckTrigger.MANUAL,
         report=_report(first_pair.credential_id, check_id="touched"),
     )
-    # A fresh insert after the touch must sort first: inserts and updates
-    # share the statement-time clock.
+    # A fresh insert after the touch must sort first: inserts and updates share
+    # the statement-time clock.
     third_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
     upsert_completed_capability_report(
         db_session,
@@ -251,8 +251,8 @@ def test_rows_for_source_lists_most_recently_updated_first(
     rows = get_capability_report_rows_for_source(db_session, DocumentSource.SLACK)
 
     # Postcondition.
-    # The DB may hold committed SLACK rows from other suites or prior runs,
-    # so assert relative order, not equality.
+    # The DB may hold committed SLACK rows from other suites or prior runs, so
+    # assert relative order, not equality.
     row_credential_ids = [row.credential_id for row in rows]
     third_index = row_credential_ids.index(third_pair.credential_id)
     first_index = row_credential_ids.index(first_pair.credential_id)

--- a/backend/tests/external_dependency_unit/db/test_credential_capability.py
+++ b/backend/tests/external_dependency_unit/db/test_credential_capability.py
@@ -2,6 +2,8 @@
 
 Runs against real Postgres: the upsert semantics live in the two partial
 unique indexes and ON CONFLICT inference, which mocks cannot exercise.
+Nothing here commits (the accessors leave the transaction to the caller), so
+every test's rows roll back when its session closes.
 """
 
 from datetime import datetime, timezone
@@ -61,7 +63,7 @@ def _report(
 def test_upsert_inserts_then_replaces(db_session: Session) -> None:
     """Verifies latest-only semantics: a second write lands on the same row."""
     # Precondition.
-    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK)
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
     credential_id = cc_pair.credential_id
 
     # Under test.
@@ -99,7 +101,7 @@ def test_credential_and_connector_scopes_coexist(db_session: Session) -> None:
     are distinct rows for one credential, each fetched by its scope.
     """
     # Precondition.
-    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK)
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
     credential_id = cc_pair.credential_id
     connector_id = cc_pair.connector_id
 
@@ -146,7 +148,7 @@ def test_mark_running_preserves_report_and_completion_keeps_start_time(
     readable, and the completing write keeps the run's start time.
     """
     # Precondition.
-    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK)
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
     credential_id = cc_pair.credential_id
     upsert_completed_capability_report(
         db_session,
@@ -191,7 +193,7 @@ def test_mark_running_preserves_report_and_completion_keeps_start_time(
 def test_mark_running_creates_the_row_when_none_exists(db_session: Session) -> None:
     """Verifies a first-ever run starts from a report-less RUNNING row."""
     # Precondition.
-    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK)
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
 
     # Under test.
     row = mark_capability_report_running(
@@ -213,8 +215,8 @@ def test_rows_for_source_lists_most_recently_updated_first(
 ) -> None:
     """Verifies the per-source listing includes both rows, freshest first."""
     # Precondition.
-    first_pair = make_cc_pair(db_session, source=DocumentSource.SLACK)
-    second_pair = make_cc_pair(db_session, source=DocumentSource.SLACK)
+    first_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
+    second_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
     for pair in (first_pair, second_pair):
         upsert_completed_capability_report(
             db_session,
@@ -238,7 +240,8 @@ def test_rows_for_source_lists_most_recently_updated_first(
     rows = get_capability_report_rows_for_source(db_session, DocumentSource.SLACK)
 
     # Postcondition.
-    # Other tests write SLACK rows too, so assert relative order, not equality.
+    # The DB may hold committed SLACK rows from other suites or prior runs,
+    # so assert relative order, not equality.
     row_credential_ids = [row.credential_id for row in rows]
     assert first_pair.credential_id in row_credential_ids
     assert second_pair.credential_id in row_credential_ids
@@ -252,7 +255,7 @@ def test_rows_for_source_lists_most_recently_updated_first(
 def test_rows_cascade_with_their_credential(db_session: Session) -> None:
     """Verifies report rows die with the credential, not as orphans."""
     # Precondition.
-    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK)
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
     credential_id = cc_pair.credential_id
     upsert_completed_capability_report(
         db_session,
@@ -268,7 +271,9 @@ def test_rows_cascade_with_their_credential(db_session: Session) -> None:
     credential = db_session.get(Credential, credential_id)
     assert credential is not None, "The cc-pair helper persists its credential."
     db_session.delete(credential)
-    db_session.commit()
+    # The FK cascade fires at statement execution; no commit needed, so the
+    # deletions roll back with the rest of the test's rows.
+    db_session.flush()
 
     # Postcondition.
     assert get_capability_report_row(db_session, credential_id, None) is None

--- a/backend/tests/external_dependency_unit/db/test_credential_capability.py
+++ b/backend/tests/external_dependency_unit/db/test_credential_capability.py
@@ -16,7 +16,6 @@ from onyx.connectors.capabilities import CredentialCapability
 from onyx.connectors.capability_checks.models import (
     CapabilityCheckResult,
     CapabilityCheckStatus,
-    CapabilityCheckTrigger,
     CapabilityVerdict,
     CredentialCapabilityReport,
 )
@@ -26,7 +25,7 @@ from onyx.db.credential_capability import (
     mark_capability_report_running,
     upsert_completed_capability_report,
 )
-from onyx.db.enums import CapabilityReportRunStatus
+from onyx.db.enums import CapabilityCheckTrigger, CapabilityReportRunStatus
 from onyx.db.models import Credential
 from tests.external_dependency_unit.indexing_helpers import make_cc_pair
 

--- a/backend/tests/external_dependency_unit/db/test_credential_capability.py
+++ b/backend/tests/external_dependency_unit/db/test_credential_capability.py
@@ -1,0 +1,274 @@
+"""Accessor tests for the latest-only credential capability report rows.
+
+Runs against real Postgres: the upsert semantics live in the two partial
+unique indexes and ON CONFLICT inference, which mocks cannot exercise.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.capabilities import CredentialCapability
+from onyx.connectors.capability_checks.models import (
+    CapabilityCheckResult,
+    CapabilityCheckStatus,
+    CapabilityCheckTrigger,
+    CapabilityVerdict,
+    CredentialCapabilityReport,
+)
+from onyx.db.credential_capability import (
+    get_capability_report_row,
+    get_capability_report_rows_for_source,
+    mark_capability_report_running,
+    upsert_completed_capability_report,
+)
+from onyx.db.enums import CapabilityReportRunStatus
+from onyx.db.models import Credential
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+
+def _report(
+    credential_id: int,
+    connector_id: int | None = None,
+    check_id: str = "slack_token_auth",
+) -> CredentialCapabilityReport:
+    return CredentialCapabilityReport(
+        credential_id=credential_id,
+        source=DocumentSource.SLACK,
+        connector_id=connector_id,
+        checked_at=datetime.now(timezone.utc),
+        trigger=CapabilityCheckTrigger.MANUAL,
+        verdicts={
+            CredentialCapability.INDEXING: CapabilityVerdict.PASSED,
+            CredentialCapability.DOC_PERMISSION_SYNC: CapabilityVerdict.NOT_APPLICABLE,
+            CredentialCapability.EXTERNAL_GROUP_SYNC: CapabilityVerdict.NOT_APPLICABLE,
+        },
+        check_results=[
+            CapabilityCheckResult(
+                capability=CredentialCapability.INDEXING,
+                check_id=check_id,
+                display_name="Test check",
+                required=True,
+                status=CapabilityCheckStatus.PASSED,
+            )
+        ],
+    )
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_upsert_inserts_then_replaces(db_session: Session) -> None:
+    """Verifies latest-only semantics: a second write lands on the same row."""
+    # Precondition.
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK)
+    credential_id = cc_pair.credential_id
+
+    # Under test.
+    first = upsert_completed_capability_report(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        report=_report(credential_id, check_id="first"),
+    )
+    second = upsert_completed_capability_report(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.CREDENTIAL_CREATED,
+        report=_report(credential_id, check_id="second"),
+    )
+
+    # Postcondition.
+    assert second.id == first.id
+    row = get_capability_report_row(db_session, credential_id, None)
+    assert row is not None
+    assert row.trigger == CapabilityCheckTrigger.CREDENTIAL_CREATED
+    assert row.run_status == CapabilityReportRunStatus.COMPLETED
+    assert row.report is not None
+    assert row.report["check_results"][0]["check_id"] == "second"
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_credential_and_connector_scopes_coexist(db_session: Session) -> None:
+    """
+    Verifies the config-less credential-time row and a connector-scoped row
+    are distinct rows for one credential, each fetched by its scope.
+    """
+    # Precondition.
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK)
+    credential_id = cc_pair.credential_id
+    connector_id = cc_pair.connector_id
+
+    # Under test.
+    credential_scope = upsert_completed_capability_report(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.CREDENTIAL_CREATED,
+        report=_report(credential_id),
+    )
+    connector_scope = upsert_completed_capability_report(
+        db_session,
+        credential_id=credential_id,
+        connector_id=connector_id,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.CC_PAIR_VALIDATION,
+        report=_report(credential_id, connector_id=connector_id),
+        connector_config_hash="abc123",
+    )
+
+    # Postcondition.
+    assert credential_scope.id != connector_scope.id
+    fetched_credential_scope = get_capability_report_row(
+        db_session, credential_id, None
+    )
+    fetched_connector_scope = get_capability_report_row(
+        db_session, credential_id, connector_id
+    )
+    assert fetched_credential_scope is not None
+    assert fetched_credential_scope.id == credential_scope.id
+    assert fetched_connector_scope is not None
+    assert fetched_connector_scope.id == connector_scope.id
+    assert fetched_connector_scope.connector_config_hash == "abc123"
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_mark_running_preserves_report_and_completion_keeps_start_time(
+    db_session: Session,
+) -> None:
+    """
+    Verifies the run lifecycle on one row: RUNNING keeps the previous report
+    readable, and the completing write keeps the run's start time.
+    """
+    # Precondition.
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK)
+    credential_id = cc_pair.credential_id
+    upsert_completed_capability_report(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        report=_report(credential_id, check_id="previous"),
+    )
+
+    # Under test.
+    running = mark_capability_report_running(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+    )
+
+    # Postcondition.
+    assert running.run_status == CapabilityReportRunStatus.RUNNING
+    assert running.run_started_at is not None
+    assert running.report is not None
+    assert running.report["check_results"][0]["check_id"] == "previous"
+
+    # Under test and postcondition (completion preserves the start time).
+    completed = upsert_completed_capability_report(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        report=_report(credential_id, check_id="fresh"),
+    )
+    assert completed.run_status == CapabilityReportRunStatus.COMPLETED
+    assert completed.run_started_at == running.run_started_at
+    assert completed.report is not None
+    assert completed.report["check_results"][0]["check_id"] == "fresh"
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_mark_running_creates_the_row_when_none_exists(db_session: Session) -> None:
+    """Verifies a first-ever run starts from a report-less RUNNING row."""
+    # Precondition.
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK)
+
+    # Under test.
+    row = mark_capability_report_running(
+        db_session,
+        credential_id=cc_pair.credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.CREDENTIAL_CREATED,
+    )
+
+    # Postcondition.
+    assert row.run_status == CapabilityReportRunStatus.RUNNING
+    assert row.report is None
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_rows_for_source_lists_most_recently_updated_first(
+    db_session: Session,
+) -> None:
+    """Verifies the per-source listing includes both rows, freshest first."""
+    # Precondition.
+    first_pair = make_cc_pair(db_session, source=DocumentSource.SLACK)
+    second_pair = make_cc_pair(db_session, source=DocumentSource.SLACK)
+    for pair in (first_pair, second_pair):
+        upsert_completed_capability_report(
+            db_session,
+            credential_id=pair.credential_id,
+            connector_id=None,
+            source=DocumentSource.SLACK,
+            trigger=CapabilityCheckTrigger.MANUAL,
+            report=_report(pair.credential_id),
+        )
+    # Touch the first row so it becomes the most recently updated.
+    upsert_completed_capability_report(
+        db_session,
+        credential_id=first_pair.credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        report=_report(first_pair.credential_id, check_id="touched"),
+    )
+
+    # Under test.
+    rows = get_capability_report_rows_for_source(db_session, DocumentSource.SLACK)
+
+    # Postcondition.
+    # Other tests write SLACK rows too, so assert relative order, not equality.
+    row_credential_ids = [row.credential_id for row in rows]
+    assert first_pair.credential_id in row_credential_ids
+    assert second_pair.credential_id in row_credential_ids
+    assert row_credential_ids.index(
+        first_pair.credential_id
+    ) < row_credential_ids.index(second_pair.credential_id)
+    assert all(row.source == DocumentSource.SLACK for row in rows)
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_rows_cascade_with_their_credential(db_session: Session) -> None:
+    """Verifies report rows die with the credential, not as orphans."""
+    # Precondition.
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK)
+    credential_id = cc_pair.credential_id
+    upsert_completed_capability_report(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        report=_report(credential_id),
+    )
+
+    # Under test.
+    db_session.delete(cc_pair)
+    credential = db_session.get(Credential, credential_id)
+    assert credential is not None, "The cc-pair helper persists its credential."
+    db_session.delete(credential)
+    db_session.commit()
+
+    # Postcondition.
+    assert get_capability_report_row(db_session, credential_id, None) is None

--- a/backend/tests/external_dependency_unit/db/test_credential_capability.py
+++ b/backend/tests/external_dependency_unit/db/test_credential_capability.py
@@ -226,7 +226,7 @@ def test_rows_for_source_lists_most_recently_updated_first(
             trigger=CapabilityCheckTrigger.MANUAL,
             report=_report(pair.credential_id),
         )
-    # Touch the first row so it becomes the most recently updated.
+    # Touch the first row so it becomes more recently updated than the second.
     upsert_completed_capability_report(
         db_session,
         credential_id=first_pair.credential_id,
@@ -234,6 +234,17 @@ def test_rows_for_source_lists_most_recently_updated_first(
         source=DocumentSource.SLACK,
         trigger=CapabilityCheckTrigger.MANUAL,
         report=_report(first_pair.credential_id, check_id="touched"),
+    )
+    # A fresh insert after the touch must sort first: inserts and updates
+    # share the statement-time clock.
+    third_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
+    upsert_completed_capability_report(
+        db_session,
+        credential_id=third_pair.credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        report=_report(third_pair.credential_id),
     )
 
     # Under test.
@@ -243,11 +254,10 @@ def test_rows_for_source_lists_most_recently_updated_first(
     # The DB may hold committed SLACK rows from other suites or prior runs,
     # so assert relative order, not equality.
     row_credential_ids = [row.credential_id for row in rows]
-    assert first_pair.credential_id in row_credential_ids
-    assert second_pair.credential_id in row_credential_ids
-    assert row_credential_ids.index(
-        first_pair.credential_id
-    ) < row_credential_ids.index(second_pair.credential_id)
+    third_index = row_credential_ids.index(third_pair.credential_id)
+    first_index = row_credential_ids.index(first_pair.credential_id)
+    second_index = row_credential_ids.index(second_pair.credential_id)
+    assert third_index < first_index < second_index
     assert all(row.source == DocumentSource.SLACK for row in rows)
 
 


### PR DESCRIPTION
## Description

Data access for the credential_capability_report table (previous PR #13969 in this split, next is #13971); second of three. Nothing in production calls these yet: the blocking-path recorder follows.

- New onyx/db/credential_capability.py: upsert_completed_capability_report, mark_capability_report_running, get_capability_report_row, get_capability_report_rows_for_source.
- Writers upsert via INSERT .. ON CONFLICT against the scope's partial unique index, so concurrent writers to one scope resolve to a single row. Columns absent from a write keep their stored values: a RUNNING mark preserves the previous report, and a completion write preserves run_started_at.
- Two SQLAlchemy gotchas handled and commented at the line: the model's onupdate is not applied to ON CONFLICT SET clauses (time_updated is bumped explicitly), and RETURNING resolves to a stale identity-map instance without populate_existing.

## How Has This Been Tested?

- External-dependency-unit tests against real Postgres: insert-then-replace, credential- and connector-scope rows coexisting, the RUNNING -> COMPLETED lifecycle, first-run RUNNING row, per-source listing order, and cascade delete with the credential.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
