### PR TITLE
feat(users): invite modal email field matches the tag-input mocks

### DIFF
--- a/web/lib/opal/src/components/inputs/input-tags/README.md
+++ b/web/lib/opal/src/components/inputs/input-tags/README.md
@@ -25,6 +25,8 @@ Interaction model:
 | `disabled` | `boolean` | `false` | Dims the field, disables input, hides remove and clear buttons |
 | `icon` | `IconFunctionComponent` | — | Leading icon (24px container) |
 | `onClear` | `() => void` | — | Renders the clear action button |
+| `minRows` | `number` | `1` | Tag rows the field is tall enough to show before it grows. Rows pack from the top |
+| `autoFocus` | `boolean` | — | Focuses the text input on mount |
 
 ### `TagItem`
 

--- a/web/lib/opal/src/components/inputs/input-tags/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-tags/components.tsx
@@ -51,7 +51,17 @@ interface InputTagsProps {
 
   /** Renders the clear action button (Figma `Clear`). */
   onClear?: () => void;
+
+  /** Tag rows the field is tall enough to show before it grows. */
+  minRows?: number;
+
+  /** Focuses the text input on mount. */
+  autoFocus?: boolean;
 }
+
+/** Tag row height and wrap gap, mirroring `.opal-input-tags-tags` in styles.css. */
+const TAG_ROW_HEIGHT_PX = 24;
+const TAG_ROW_GAP_PX = 4;
 
 // ---------------------------------------------------------------------------
 // InputTags
@@ -74,6 +84,8 @@ function InputTags({
   disabled = false,
   icon: Icon,
   onClear,
+  minRows = 1,
+  autoFocus,
 }: InputTagsProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -121,7 +133,20 @@ function InputTags({
           <Icon className="opal-input-tags-icon" />
         </div>
       )}
-      <div className="opal-input-tags-tags">
+      <div
+        className="opal-input-tags-tags"
+        style={
+          minRows > 1
+            ? {
+                minHeight:
+                  minRows * TAG_ROW_HEIGHT_PX + (minRows - 1) * TAG_ROW_GAP_PX,
+                // The taller field packs rows from the top; `content-center`
+                // would float a single row into the middle of the box.
+                alignContent: "flex-start",
+              }
+            : undefined
+        }
+      >
         {tags.map((tag) => (
           <Tag
             key={tag.id}
@@ -140,6 +165,7 @@ function InputTags({
           ref={inputRef}
           type="text"
           className="opal-input-field opal-input-tags-field"
+          autoFocus={autoFocus}
           disabled={disabled}
           value={value}
           onChange={(event) => onChange(event.target.value)}

--- a/web/lib/opal/src/components/inputs/input-tags/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-tags/components.tsx
@@ -59,10 +59,6 @@ interface InputTagsProps {
   autoFocus?: boolean;
 }
 
-/** Tag row height and wrap gap, mirroring `.opal-input-tags-tags` in styles.css. */
-const TAG_ROW_HEIGHT_PX = 24;
-const TAG_ROW_GAP_PX = 4;
-
 // ---------------------------------------------------------------------------
 // InputTags
 // ---------------------------------------------------------------------------
@@ -135,15 +131,10 @@ function InputTags({
       )}
       <div
         className="opal-input-tags-tags"
+        data-multi-row={minRows > 1 || undefined}
         style={
           minRows > 1
-            ? {
-                minHeight:
-                  minRows * TAG_ROW_HEIGHT_PX + (minRows - 1) * TAG_ROW_GAP_PX,
-                // The taller field packs rows from the top; `content-center`
-                // would float a single row into the middle of the box.
-                alignContent: "flex-start",
-              }
+            ? ({ "--opal-input-tags-rows": minRows } as React.CSSProperties)
             : undefined
         }
       >

--- a/web/lib/opal/src/components/inputs/input-tags/styles.css
+++ b/web/lib/opal/src/components/inputs/input-tags/styles.css
@@ -32,9 +32,21 @@
 }
 
 .opal-input-tags-tags {
+  --opal-input-tags-row-height: 24px;
+  --opal-input-tags-row-gap: 4px;
+  --opal-input-tags-rows: 1;
   @apply flex min-w-0 flex-1 flex-wrap content-center items-center;
-  gap: 4px;
-  min-height: 24px;
+  gap: var(--opal-input-tags-row-gap);
+  min-height: calc(
+    var(--opal-input-tags-rows) * var(--opal-input-tags-row-height) +
+      (var(--opal-input-tags-rows) - 1) * var(--opal-input-tags-row-gap)
+  );
+}
+
+/* A multi-row field packs rows from the top. content-center would float a
+   single row into the middle of the box. */
+.opal-input-tags-tags[data-multi-row] {
+  align-content: flex-start;
 }
 
 .opal-input-tags-field {

--- a/web/lib/opal/src/layouts/content/README.md
+++ b/web/lib/opal/src/layouts/content/README.md
@@ -64,6 +64,7 @@ Invalid combinations (e.g. `sizePreset="headline" + variant="body"`) are exclude
 | `onTitleChange` | `(newTitle: string) => void` | — | Called when user commits an edit |
 | `moreIcon1` | `IconFunctionComponent` | — | Secondary icon in icon row (ContentXl only) |
 | `moreIcon2` | `IconFunctionComponent` | — | Tertiary icon in icon row (ContentXl only) |
+| `color` | `ColorTypes` | `"default"` | Icon and title color pair. `"muted-success"` / `"muted-warning"` color only the icon and leave the text at `text-03` |
 
 ## Internal Layouts
 

--- a/web/lib/opal/src/layouts/content/styles.css
+++ b/web/lib/opal/src/layouts/content/styles.css
@@ -59,6 +59,20 @@
   color: var(--content-foreground);
 }
 
+/* Status glyph against muted body text: the field-message pairing, where the
+   icon carries the state and the text stays secondary. */
+[data-content-color="muted-success"] {
+  --content-foreground: var(--text-03);
+  --content-foreground-icon: var(--status-success-05);
+  color: var(--content-foreground);
+}
+
+[data-content-color="muted-warning"] {
+  --content-foreground: var(--text-03);
+  --content-foreground-icon: var(--status-warning-05);
+  color: var(--content-foreground);
+}
+
 [data-content-color="interactive"] {
   color: inherit;
   --content-foreground-icon: var(--interactive-foreground-icon);

--- a/web/lib/opal/src/types.ts
+++ b/web/lib/opal/src/types.ts
@@ -146,6 +146,8 @@ export type BackgroundVariants = "none" | "light" | "heavy";
  * - `"default"` — standard text/border color (`text-04` / `border-01`)
  * - `"muted"` — de-emphasized color (`text-03`)
  * - `"danger"` — destructive / error state
+ * - `"muted-success"` / `"muted-warning"`: status glyph against muted body text,
+ *   for messages where the icon carries the state and the text stays secondary
  * - `"interactive"` — follows the interactive coloring system (`currentColor` / `--interactive-foreground`)
  */
 export type ColorTypes =
@@ -154,6 +156,8 @@ export type ColorTypes =
   | "success"
   | "danger"
   | "warning"
+  | "muted-success"
+  | "muted-warning"
   | "interactive";
 
 // ---------------------------------------------------------------------------

--- a/web/src/views/admin/UsersPage/InviteUsersModal.tsx
+++ b/web/src/views/admin/UsersPage/InviteUsersModal.tsx
@@ -1,13 +1,22 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { Button } from "@opal/components";
-import { SvgUsers, SvgAlertTriangle, SvgLoader } from "@opal/icons";
-import { BasicModalFooter, Modal } from "@opal/components";
-import InputChipField from "@/refresh-components/inputs/InputChipField";
-import type { ChipItem } from "@/refresh-components/inputs/InputChipField";
-import Text from "@/refresh-components/texts/Text";
-import { toast } from "@opal/layouts";
+import {
+  BasicModalFooter,
+  Button,
+  InputTags,
+  Modal,
+  Text,
+} from "@opal/components";
+import type { TagItem } from "@opal/components";
+import {
+  SvgAlertTriangle,
+  SvgCheckCircle,
+  SvgLoader,
+  SvgUsers,
+} from "@opal/icons";
+import type { IconFunctionComponent } from "@opal/types";
+import { Section, toast } from "@opal/layouts";
 import { mutate } from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { inviteUsers } from "./svc";
@@ -18,6 +27,20 @@ import { inviteUsers } from "./svc";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+/** Whitespace and commas both end an address, so typing either commits a tag. */
+const SEPARATOR_REGEX = /[\s,]+/;
+
+/** Tag rows the field is tall enough to show before it grows. */
+const EMAIL_FIELD_ROWS = 3;
+
+function isValidEmail(value: string): boolean {
+  return EMAIL_REGEX.test(value);
+}
+
+function normalizeEmail(value: string): string {
+  return value.trim().toLowerCase();
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -25,6 +48,12 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 interface InviteUsersModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+}
+
+interface FieldMessage {
+  icon: IconFunctionComponent;
+  iconClassName: string;
+  text: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -35,50 +64,87 @@ export default function InviteUsersModal({
   open,
   onOpenChange,
 }: InviteUsersModalProps) {
-  const [chips, setChips] = useState<ChipItem[]>([]);
+  const [tags, setTags] = useState<TagItem[]>([]);
   const [inputValue, setInputValue] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  /** Parse a comma-separated string into de-duped ChipItems */
-  function parseEmails(value: string, existing: ChipItem[]): ChipItem[] {
-    const entries = value
-      .split(",")
-      .map((e) => e.trim().toLowerCase())
-      .filter(Boolean);
-
-    const newChips: ChipItem[] = [];
-    for (const email of entries) {
-      const alreadyAdded =
-        existing.some((c) => c.label === email) ||
-        newChips.some((c) => c.label === email);
-      if (!alreadyAdded) {
-        newChips.push({
-          id: email,
-          label: email,
-          error: !EMAIL_REGEX.test(email),
-        });
+  /** Tags for entries not already present, de-duped case-insensitively. */
+  function buildTags(entries: string[], existing: TagItem[]): TagItem[] {
+    const added: TagItem[] = [];
+    for (const entry of entries) {
+      const email = normalizeEmail(entry);
+      const seen =
+        existing.some((tag) => tag.id === email) ||
+        added.some((tag) => tag.id === email);
+      if (email && !seen) {
+        added.push({ id: email, label: email, error: !isValidEmail(email) });
       }
     }
-    return newChips;
+    return added;
   }
 
-  function addEmail(value: string) {
-    const newChips = parseEmails(value, chips);
-    if (newChips.length > 0) {
-      setChips((prev) => [...prev, ...newChips]);
+  function addTags(entries: string[]) {
+    const added = buildTags(entries, tags);
+    if (added.length > 0) setTags((prev) => [...prev, ...added]);
+  }
+
+  function removeTag(id: string) {
+    setTags((prev) => prev.filter((tag) => tag.id !== id));
+  }
+
+  /** Commits every separator-terminated address, keeping the trailing text. */
+  function handleInputChange(next: string) {
+    if (!SEPARATOR_REGEX.test(next)) {
+      setInputValue(next);
+      return;
     }
+    const parts = next.split(SEPARATOR_REGEX);
+    const trailing = parts.pop() ?? "";
+    addTags(parts);
+    setInputValue(trailing);
+  }
+
+  function handleAdd(value: string) {
+    addTags([value]);
     setInputValue("");
   }
 
-  function removeChip(id: string) {
-    setChips((prev) => prev.filter((c) => c.id !== id));
+  const pendingEmail = normalizeEmail(inputValue);
+  const pendingIsValid =
+    isValidEmail(pendingEmail) && !tags.some((tag) => tag.id === pendingEmail);
+  const validCount =
+    tags.filter((tag) => !tag.error).length + (pendingIsValid ? 1 : 0);
+
+  function buildMessage(): FieldMessage | null {
+    if (tags.length === 0 && pendingEmail === "") return null;
+    if (tags.some((tag) => tag.error)) {
+      return {
+        icon: SvgAlertTriangle,
+        iconClassName: "text-status-warning-05",
+        text: "Some email addresses are invalid and will be skipped.",
+      };
+    }
+    if (validCount === 0) {
+      return {
+        icon: SvgAlertTriangle,
+        iconClassName: "text-status-warning-05",
+        text: "Enter a valid email address to invite.",
+      };
+    }
+    return {
+      icon: SvgCheckCircle,
+      iconClassName: "text-status-success-05",
+      text: `${validCount} email${validCount > 1 ? "s" : ""} to invite`,
+    };
   }
+
+  const message = buildMessage();
 
   const handleClose = useCallback(() => {
     onOpenChange(false);
     // Reset state after close animation
     setTimeout(() => {
-      setChips([]);
+      setTags([]);
       setInputValue("");
       setIsSubmitting(false);
     }, 200);
@@ -97,18 +163,19 @@ export default function InviteUsersModal({
   );
 
   async function handleInvite() {
-    // Flush any pending text in the input into chips synchronously
-    const pending = inputValue.trim();
-    const allChips = pending
-      ? [...chips, ...parseEmails(pending, chips)]
-      : chips;
+    // Flush any pending text in the input into tags synchronously
+    const allTags = pendingEmail
+      ? [...tags, ...buildTags([pendingEmail], tags)]
+      : tags;
 
-    if (pending) {
-      setChips(allChips);
+    if (pendingEmail) {
+      setTags(allTags);
       setInputValue("");
     }
 
-    const validEmails = allChips.filter((c) => !c.error).map((c) => c.label);
+    const validEmails = allTags
+      .filter((tag) => !tag.error)
+      .map((tag) => tag.label);
 
     if (validEmails.length === 0) {
       toast.error("Please add at least one valid email address");
@@ -150,26 +217,45 @@ export default function InviteUsersModal({
         />
 
         <Modal.Body>
-          <InputChipField
-            chips={chips}
-            onRemoveChip={removeChip}
-            onAdd={addEmail}
-            value={inputValue}
-            onChange={setInputValue}
-            placeholder="Add an email and press enter"
-            layout="stacked"
-          />
-          {chips.some((c) => c.error) && (
-            <div className="flex items-center gap-1 pt-1">
-              <SvgAlertTriangle
-                size={14}
-                className="text-status-warning-05 shrink-0"
-              />
-              <Text secondaryBody text03>
-                Some email addresses are invalid and will be skipped.
-              </Text>
-            </div>
-          )}
+          <Section
+            flexDirection="column"
+            alignItems="stretch"
+            height="fit"
+            gap={1}
+          >
+            <InputTags
+              tags={tags}
+              onRemoveTag={removeTag}
+              onAdd={handleAdd}
+              value={inputValue}
+              onChange={handleInputChange}
+              placeholder="Add emails to invite, space or comma separated"
+              minRows={EMAIL_FIELD_ROWS}
+              autoFocus
+            />
+            {message && (
+              <Section
+                flexDirection="row"
+                alignItems="start"
+                justifyContent="start"
+                height="fit"
+                gap={0.5}
+              >
+                <Section
+                  width={1}
+                  height={1}
+                  padding={0.5}
+                  gap={0}
+                  className="shrink-0"
+                >
+                  <message.icon size={12} className={message.iconClassName} />
+                </Section>
+                <Text font="secondary-body" color="text-03">
+                  {message.text}
+                </Text>
+              </Section>
+            )}
+          </Section>
         </Modal.Body>
 
         <Modal.Footer>
@@ -185,7 +271,7 @@ export default function InviteUsersModal({
             }
             submit={
               <Button
-                disabled={isSubmitting || chips.every((c) => c.error)}
+                disabled={isSubmitting || validCount === 0}
                 icon={
                   isSubmitting
                     ? () => <SvgLoader size={16} className="animate-spin" />

--- a/web/src/views/admin/UsersPage/InviteUsersModal.tsx
+++ b/web/src/views/admin/UsersPage/InviteUsersModal.tsx
@@ -6,17 +6,16 @@ import {
   Button,
   InputTags,
   Modal,
-  Text,
+  type TagItem,
 } from "@opal/components";
-import type { TagItem } from "@opal/components";
 import {
   SvgAlertTriangle,
   SvgCheckCircle,
-  SvgLoader,
+  SvgSimpleLoader,
   SvgUsers,
 } from "@opal/icons";
-import type { IconFunctionComponent } from "@opal/types";
-import { Section, toast } from "@opal/layouts";
+import type { ColorTypes, IconFunctionComponent } from "@opal/types";
+import { Content, toast } from "@opal/layouts";
 import { mutate } from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { inviteUsers } from "./svc";
@@ -27,10 +26,10 @@ import { inviteUsers } from "./svc";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-/** Whitespace and commas both end an address, so typing either commits a tag. */
+/** Whitespace and commas both end an address, so either one commits a tag. */
 const SEPARATOR_REGEX = /[\s,]+/;
 
-/** Tag rows the field is tall enough to show before it grows. */
+/** The field in the mock is three tag rows tall. */
 const EMAIL_FIELD_ROWS = 3;
 
 function isValidEmail(value: string): boolean {
@@ -39,6 +38,48 @@ function isValidEmail(value: string): boolean {
 
 function normalizeEmail(value: string): string {
   return value.trim().toLowerCase();
+}
+
+/** Tags for entries not already present, de-duped case-insensitively. */
+function buildTags(entries: string[], existing: TagItem[]): TagItem[] {
+  const added: TagItem[] = [];
+  for (const entry of entries) {
+    const email = normalizeEmail(entry);
+    const seen =
+      existing.some((tag) => tag.id === email) ||
+      added.some((tag) => tag.id === email);
+    if (email && !seen) {
+      added.push({ id: email, label: email, error: !isValidEmail(email) });
+    }
+  }
+  return added;
+}
+
+function buildMessage(
+  tags: TagItem[],
+  pendingEmail: string,
+  validCount: number
+): FieldMessage | null {
+  if (tags.length === 0 && pendingEmail === "") return null;
+  if (tags.some((tag) => tag.error)) {
+    return {
+      icon: SvgAlertTriangle,
+      color: "muted-warning",
+      text: "Some email addresses are invalid and will be skipped.",
+    };
+  }
+  if (validCount === 0) {
+    return {
+      icon: SvgAlertTriangle,
+      color: "muted-warning",
+      text: "Enter a valid email address to invite.",
+    };
+  }
+  return {
+    icon: SvgCheckCircle,
+    color: "muted-success",
+    text: `${validCount} email${validCount > 1 ? "s" : ""} to invite`,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -52,7 +93,7 @@ interface InviteUsersModalProps {
 
 interface FieldMessage {
   icon: IconFunctionComponent;
-  iconClassName: string;
+  color: ColorTypes;
   text: string;
 }
 
@@ -68,24 +109,11 @@ export default function InviteUsersModal({
   const [inputValue, setInputValue] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  /** Tags for entries not already present, de-duped case-insensitively. */
-  function buildTags(entries: string[], existing: TagItem[]): TagItem[] {
-    const added: TagItem[] = [];
-    for (const entry of entries) {
-      const email = normalizeEmail(entry);
-      const seen =
-        existing.some((tag) => tag.id === email) ||
-        added.some((tag) => tag.id === email);
-      if (email && !seen) {
-        added.push({ id: email, label: email, error: !isValidEmail(email) });
-      }
-    }
-    return added;
-  }
-
   function addTags(entries: string[]) {
-    const added = buildTags(entries, tags);
-    if (added.length > 0) setTags((prev) => [...prev, ...added]);
+    setTags((prev) => {
+      const added = buildTags(entries, prev);
+      return added.length > 0 ? [...prev, ...added] : prev;
+    });
   }
 
   function removeTag(id: string) {
@@ -114,31 +142,7 @@ export default function InviteUsersModal({
     isValidEmail(pendingEmail) && !tags.some((tag) => tag.id === pendingEmail);
   const validCount =
     tags.filter((tag) => !tag.error).length + (pendingIsValid ? 1 : 0);
-
-  function buildMessage(): FieldMessage | null {
-    if (tags.length === 0 && pendingEmail === "") return null;
-    if (tags.some((tag) => tag.error)) {
-      return {
-        icon: SvgAlertTriangle,
-        iconClassName: "text-status-warning-05",
-        text: "Some email addresses are invalid and will be skipped.",
-      };
-    }
-    if (validCount === 0) {
-      return {
-        icon: SvgAlertTriangle,
-        iconClassName: "text-status-warning-05",
-        text: "Enter a valid email address to invite.",
-      };
-    }
-    return {
-      icon: SvgCheckCircle,
-      iconClassName: "text-status-success-05",
-      text: `${validCount} email${validCount > 1 ? "s" : ""} to invite`,
-    };
-  }
-
-  const message = buildMessage();
+  const message = buildMessage(tags, pendingEmail, validCount);
 
   const handleClose = useCallback(() => {
     onOpenChange(false);
@@ -150,7 +154,7 @@ export default function InviteUsersModal({
     }, 200);
   }, [onOpenChange]);
 
-  /** Intercept backdrop/ESC closes so state is always reset */
+  /** Route backdrop/ESC closes through handleClose, and block them mid-submit. */
   const handleOpenChange = useCallback(
     (next: boolean) => {
       if (!next) {
@@ -163,15 +167,10 @@ export default function InviteUsersModal({
   );
 
   async function handleInvite() {
-    // Flush any pending text in the input into tags synchronously
-    const allTags = pendingEmail
-      ? [...tags, ...buildTags([pendingEmail], tags)]
-      : tags;
-
-    if (pendingEmail) {
-      setTags(allTags);
-      setInputValue("");
-    }
+    // setTags is not visible until the next render, so submit the locally built list.
+    const allTags = [...tags, ...buildTags([inputValue], tags)];
+    setTags(allTags);
+    setInputValue("");
 
     const validEmails = allTags
       .filter((tag) => !tag.error)
@@ -216,46 +215,27 @@ export default function InviteUsersModal({
           onClose={isSubmitting ? undefined : handleClose}
         />
 
-        <Modal.Body>
-          <Section
-            flexDirection="column"
-            alignItems="stretch"
-            height="fit"
-            gap={1}
-          >
-            <InputTags
-              tags={tags}
-              onRemoveTag={removeTag}
-              onAdd={handleAdd}
-              value={inputValue}
-              onChange={handleInputChange}
-              placeholder="Add emails to invite, space or comma separated"
-              minRows={EMAIL_FIELD_ROWS}
-              autoFocus
+        <Modal.Body alignItems="stretch" gap={1}>
+          <InputTags
+            tags={tags}
+            onRemoveTag={removeTag}
+            onAdd={handleAdd}
+            value={inputValue}
+            onChange={handleInputChange}
+            placeholder="Add emails to invite, space or comma separated"
+            minRows={EMAIL_FIELD_ROWS}
+            autoFocus
+          />
+          {message && (
+            <Content
+              sizePreset="secondary"
+              variant="body"
+              icon={message.icon}
+              title={message.text}
+              color={message.color}
+              role="status"
             />
-            {message && (
-              <Section
-                flexDirection="row"
-                alignItems="start"
-                justifyContent="start"
-                height="fit"
-                gap={0.5}
-              >
-                <Section
-                  width={1}
-                  height={1}
-                  padding={0.5}
-                  gap={0}
-                  className="shrink-0"
-                >
-                  <message.icon size={12} className={message.iconClassName} />
-                </Section>
-                <Text font="secondary-body" color="text-03">
-                  {message.text}
-                </Text>
-              </Section>
-            )}
-          </Section>
+          )}
         </Modal.Body>
 
         <Modal.Footer>
@@ -272,11 +252,7 @@ export default function InviteUsersModal({
             submit={
               <Button
                 disabled={isSubmitting || validCount === 0}
-                icon={
-                  isSubmitting
-                    ? () => <SvgLoader size={16} className="animate-spin" />
-                    : undefined
-                }
+                icon={isSubmitting ? SvgSimpleLoader : undefined}
                 onClick={handleInvite}
               >
                 Invite

--- a/web/tests/e2e/admin/users/UsersAdminPage.ts
+++ b/web/tests/e2e/admin/users/UsersAdminPage.ts
@@ -244,7 +244,11 @@ export class UsersAdminPage {
   }
 
   async submitInvite() {
-    await this.dialog.getByRole("button", { name: "Invite" }).click();
+    // Exact, or the substring default also matches a tag's "Remove <email>"
+    // button whenever the address itself contains "invite".
+    await this.dialog
+      .getByRole("button", { name: "Invite", exact: true })
+      .click();
   }
 
   // ---------------------------------------------------------------------------

--- a/web/tests/e2e/admin/users/UsersAdminPage.ts
+++ b/web/tests/e2e/admin/users/UsersAdminPage.ts
@@ -229,7 +229,9 @@ export class UsersAdminPage {
 
   /** The email input inside the invite modal. */
   get inviteEmailInput(): Locator {
-    return this.dialog.getByPlaceholder("Add an email and press enter");
+    return this.dialog.getByPlaceholder(
+      "Add emails to invite, space or comma separated"
+    );
   }
 
   async openInviteModal() {

--- a/web/tests/e2e/admin/users/UsersAdminPage.ts
+++ b/web/tests/e2e/admin/users/UsersAdminPage.ts
@@ -229,9 +229,7 @@ export class UsersAdminPage {
 
   /** The email input inside the invite modal. */
   get inviteEmailInput(): Locator {
-    return this.dialog.getByPlaceholder(
-      "Add emails to invite, space or comma separated"
-    );
+    return this.dialog.getByRole("textbox");
   }
 
   async openInviteModal() {
@@ -242,7 +240,6 @@ export class UsersAdminPage {
   async addInviteEmail(email: string) {
     await this.inviteEmailInput.pressSequentially(email, { delay: 20 });
     await this.inviteEmailInput.press("Enter");
-    // Wait for the chip to appear in the dialog
     await expect(this.dialog.getByText(email)).toBeVisible();
   }
 


### PR DESCRIPTION
## Description

The invite modal's email field now behaves the way the mocks specify. Five states, taken from the dev-mode annotations on the Figma frames: [Empty](https://www.figma.com/design/sNcHyrXBLtTFDK0ijjMnSk/Admin-Panel?node-id=3021-243485&m=dev), [Single](https://www.figma.com/design/sNcHyrXBLtTFDK0ijjMnSk/Admin-Panel?node-id=7341-114108&m=dev), [Invalid](https://www.figma.com/design/sNcHyrXBLtTFDK0ijjMnSk/Admin-Panel?node-id=7341-113984&m=dev), [Multiple](https://www.figma.com/design/sNcHyrXBLtTFDK0ijjMnSk/Admin-Panel?node-id=7341-115157&m=dev), [Multiple Error](https://www.figma.com/design/sNcHyrXBLtTFDK0ijjMnSk/Admin-Panel?node-id=7341-113817&m=dev).

- Space and comma commit an address into a tag, alongside Enter. Tags are remove-only.
- A summary line under the field counts the valid addresses, or warns.
- Invalid addresses warn and get skipped at submit instead of blocking the invite.
- Invite enables whenever at least one address is valid, including text not yet committed to a tag. Before this, a fully typed valid email left the button disabled until you pressed Enter.

The field moves off the legacy `InputChipField` onto Opal `InputTags`, which gains `minRows` and `autoFocus`. The message line is Opal `Content` with two new color modes, `muted-success` and `muted-warning`, for the mock's pairing of a status glyph with secondary text.

The mocks also show a User Role row. `PUT /api/manage/admin/users` accepts emails only, so that needs backend work and is not in this frontend-only PR.

## How Has This Been Tested?

All five states exercised by hand in Chrome against a live backend. Message-line metrics measured in the DOM against the spec: 12px icon in a 16px box, `#EC5B13` warning and `#00A43F` success, text-03 at 12/16.

| Before | After |
|---|---|
| <img width="480" alt="before-empty" src="https://github.com/user-attachments/assets/8bdb8aa5-79a4-47a5-8cf5-c0ff0f1e5713" /> | <img width="480" alt="after-empty" src="https://github.com/user-attachments/assets/bf498c2e-c01c-4f33-beb8-b30f1eabe13f" /> |
| <img width="480" alt="before-valid-email-typed" src="https://github.com/user-attachments/assets/48259240-39fc-4b92-b378-c94b515e15a4" /> | <img width="480" alt="after-valid-email-typed" src="https://github.com/user-attachments/assets/f5438be5-e17d-4f9d-8bcb-7b4edaf3b198" /> |

Second row is the behavior change: a fully typed valid email, Invite disabled before and enabled after.

Not run: the invite Playwright specs. Their locator is fixed in this PR (it matched the old placeholder copy and now matches by role), but they create and delete real users, so I left the run to CI.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
