### PR TITLE
feat(ods): add `ods release cloud` to cut the next cloud tag off main

### DIFF
--- a/tools/ods/cmd/cherry-pick.go
+++ b/tools/ods/cmd/cherry-pick.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -178,7 +177,7 @@ func runCherryPick(cmd *cobra.Command, args []string, opts *CherryPickOptions) {
 		version, err := findTargetReleaseVersion(commitSHAs[0])
 		if err != nil {
 			git.RestoreStash(stashResult)
-			log.Fatalf("Failed to auto-detect the target release: %v", err)
+			log.Fatalf("Failed to auto-detect the target release (pass --release explicitly): %v", err)
 		}
 
 		// Prompt user for confirmation
@@ -192,7 +191,7 @@ func runCherryPick(cmd *cobra.Command, args []string, opts *CherryPickOptions) {
 			log.Infof("Auto-detected release version: %s", version)
 		}
 
-		releases = []string{version}
+		releases = []string{version.String()}
 	}
 
 	// Get commit messages for PR title and body
@@ -570,131 +569,6 @@ func extractPRNumbers(commitMsg string) []string {
 	re := regexp.MustCompile(`#(\d+)`)
 	matches := re.FindAllString(commitMsg, -1)
 	return matches
-}
-
-// releaseBranchPattern matches maintained release branch names, e.g.
-// "release/v4.5". Ad-hoc branches such as "release/v3.0-qa-f1df36e" are
-// deliberately excluded.
-var releaseBranchPattern = regexp.MustCompile(`^release/v(\d+)\.(\d+)$`)
-
-// releaseBranchRefspec returns a forced fetch refspec that creates or updates
-// the origin/<releaseBranch> tracking ref even in clones whose configured fetch
-// refspec does not cover release branches (e.g. single-branch clones), where a
-// plain "git fetch origin <branch>" only writes FETCH_HEAD.
-func releaseBranchRefspec(releaseBranch string) string {
-	return fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", releaseBranch, releaseBranch)
-}
-
-// releaseVersion is the parsed version of a "release/vX.Y" branch.
-type releaseVersion struct {
-	major int
-	minor int
-}
-
-// String returns the version with its 'v' prefix, e.g. "v4.5".
-func (v releaseVersion) String() string {
-	return fmt.Sprintf("v%d.%d", v.major, v.minor)
-}
-
-// parseReleaseVersions extracts "release/vX.Y" versions from branch names and
-// returns them sorted newest first. Names that do not match the pattern are
-// ignored.
-func parseReleaseVersions(branchNames []string) []releaseVersion {
-	versions := []releaseVersion{}
-	for _, name := range branchNames {
-		matches := releaseBranchPattern.FindStringSubmatch(name)
-		if matches == nil {
-			continue
-		}
-		major, err := strconv.Atoi(matches[1])
-		if err != nil {
-			continue
-		}
-		minor, err := strconv.Atoi(matches[2])
-		if err != nil {
-			continue
-		}
-		versions = append(versions, releaseVersion{major: major, minor: minor})
-	}
-	sort.Slice(versions, func(i, j int) bool {
-		if versions[i].major != versions[j].major {
-			return versions[i].major > versions[j].major
-		}
-		return versions[i].minor > versions[j].minor
-	})
-	return versions
-}
-
-// listRemoteReleaseBranches returns the names (e.g. "release/v4.5") of all
-// release branches on origin.
-func listRemoteReleaseBranches() ([]string, error) {
-	cmd := exec.Command("git", "ls-remote", "--heads", "origin", "release/*")
-	output, err := cmd.Output()
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("git ls-remote failed: %w: %s", err, string(exitErr.Stderr))
-		}
-		return nil, fmt.Errorf("git ls-remote failed: %w", err)
-	}
-
-	branches := []string{}
-	for _, line := range strings.Split(string(output), "\n") {
-		// Each line is "<sha>\trefs/heads/<branch>".
-		_, ref, found := strings.Cut(line, "\t")
-		if !found {
-			continue
-		}
-		branches = append(branches, strings.TrimPrefix(strings.TrimSpace(ref), "refs/heads/"))
-	}
-	return branches, nil
-}
-
-// findTargetReleaseVersion returns the version (e.g. "v4.5") of the newest
-// "release/vX.Y" branch on origin that does not already contain commitSHA. A
-// commit merged to main after the latest branch cut targets the newest branch;
-// a commit that predates the cut (and is therefore already part of the newer
-// branches) falls back to the newest branch actually missing it. Tags are
-// deliberately not consulted: release tag names on main (e.g. "vX.Y.0-cloud.N")
-// roll over to a new version asynchronously from the branch cut, so the nearest
-// tag can disagree with the newest branch.
-func findTargetReleaseVersion(commitSHA string) (string, error) {
-	// A shallow clone cannot answer ancestry truthfully: history beyond the
-	// shallow boundary makes contained commits look uncontained, silently
-	// routing them to the wrong branch. Fail loudly instead.
-	shallow, err := git.IsShallowRepository()
-	if err != nil {
-		return "", err
-	}
-	if shallow {
-		return "", fmt.Errorf("this is a shallow clone, so release auto-detection cannot check branch ancestry; pass --release explicitly")
-	}
-
-	branchNames, err := listRemoteReleaseBranches()
-	if err != nil {
-		return "", err
-	}
-	versions := parseReleaseVersions(branchNames)
-	if len(versions) == 0 {
-		return "", fmt.Errorf("no release/vX.Y branches found on origin")
-	}
-
-	for _, version := range versions {
-		releaseBranch := fmt.Sprintf("release/%s", version)
-		// Fetch so the ancestry check runs against the branch's current tip.
-		if err := git.RunCommand("fetch", "--quiet", "origin", releaseBranchRefspec(releaseBranch)); err != nil {
-			return "", fmt.Errorf("failed to fetch %s: %w", releaseBranch, err)
-		}
-		contained, err := git.IsAncestor(commitSHA, fmt.Sprintf("origin/%s", releaseBranch))
-		if err != nil {
-			return "", err
-		}
-		if !contained {
-			return version.String(), nil
-		}
-		log.Infof("Commit %s is already contained in %s, checking the next older release branch", commitSHA, releaseBranch)
-	}
-
-	return "", fmt.Errorf("commit %s is already contained in every release branch; pass --release explicitly", commitSHA)
 }
 
 // createCherryPickPR creates a pull request for cherry-picks using the GitHub CLI

--- a/tools/ods/cmd/release.go
+++ b/tools/ods/cmd/release.go
@@ -6,8 +6,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// bareSemverRe matches a bare X.Y.Z version (no leading v).
-var bareSemverRe = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+// bareSemverRe matches a bare X.Y.Z version (no leading v). Leading zeroes
+// are rejected per SemVer 2.0.0 item 2.
+var bareSemverRe = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$`)
 
 // NewReleaseCommand creates the parent `ods release` command. Subcommands hang
 // off it (e.g. `ods release opal`) and cut releases of Onyx-published packages.

--- a/tools/ods/cmd/release.go
+++ b/tools/ods/cmd/release.go
@@ -1,8 +1,13 @@
 package cmd
 
 import (
+	"regexp"
+
 	"github.com/spf13/cobra"
 )
+
+// bareSemverRe matches a bare X.Y.Z version (no leading v).
+var bareSemverRe = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
 
 // NewReleaseCommand creates the parent `ods release` command. Subcommands hang
 // off it (e.g. `ods release opal`) and cut releases of Onyx-published packages.
@@ -14,6 +19,7 @@ func NewReleaseCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(NewReleaseOpalCommand())
+	cmd.AddCommand(NewReleaseCloudCommand())
 
 	return cmd
 }

--- a/tools/ods/cmd/release.go
+++ b/tools/ods/cmd/release.go
@@ -6,8 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// bareSemverRe matches a bare X.Y.Z version (no leading v). Leading zeroes
-// are rejected per SemVer 2.0.0 item 2.
+// bareSemverRe matches a bare X.Y.Z version (no leading v). Leading zeroes are
+// rejected per SemVer 2.0.0 item 2.
 var bareSemverRe = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$`)
 
 // NewReleaseCommand creates the parent `ods release` command. Subcommands hang

--- a/tools/ods/cmd/release_cloud.go
+++ b/tools/ods/cmd/release_cloud.go
@@ -32,8 +32,8 @@ func NewReleaseCloudCommand() *cobra.Command {
 		Short: "Cut the next cloud release tag (vX.Y.0-cloud.N) off main",
 		Long: `Cut the next cloud release tag (vX.Y.0-cloud.N) and push it to origin.
 
-The base version names the release train the tagged commit belongs to: one
-minor past the newest release/vX.Y branch that does not contain the commit.
+The base version is one minor past the newest release/vX.Y branch that does
+not contain the tagged commit.
 A commit on main after the release/v4.6 cut is therefore tagged
 v4.7.0-cloud.N, never v4.6.0-cloud.N, so cloud tags order correctly against
 stable and beta tags under semver. N is one past the highest existing counter
@@ -73,9 +73,9 @@ func releaseCloud(opts *ReleaseCloudOptions) error {
 	if err := git.RunCommand("fetch", "--quiet", "--force", "origin", "+refs/heads/main:refs/remotes/origin/main"); err != nil {
 		return fmt.Errorf("failed to fetch origin/main: %w", err)
 	}
-	// Best-effort: a failure here only leaves the counter stale, which is
-	// safe. If the computed tag already exists on origin, the push (which is
-	// never forced) is rejected and rolled back.
+	// Best-effort: a failure here only leaves the counter stale, which is safe.
+	// If the computed tag already exists on origin, the push (which is never
+	// forced) is rejected and rolled back.
 	if err := fetchCloudTags(); err != nil {
 		log.Warnf("Could not fetch cloud tags (using local tags): %v", err)
 	}
@@ -107,7 +107,8 @@ func releaseCloud(opts *ReleaseCloudOptions) error {
 		return fmt.Errorf("failed to create tag %s: %w", tag, err)
 	}
 	if err := git.PushTag(tag, false, opts.Verify); err != nil {
-		// Roll back the local tag so the command stays retryable after a failed push.
+		// Roll back the local tag so the command stays retryable after a failed
+		// push.
 		if delErr := git.RunCommand("tag", "-d", tag); delErr != nil {
 			log.Warnf("Also failed to delete local tag %s; remove it before retrying: %v", tag, delErr)
 		}
@@ -117,10 +118,10 @@ func releaseCloud(opts *ReleaseCloudOptions) error {
 	return nil
 }
 
-// computeCloudTag returns the next cloud tag for commitSHA. The base version
-// is "v" + overrideVersion when given, else one minor past the release train
-// detected from origin's release branches; the counter is one past the highest
-// existing "-cloud.N" tag for that base.
+// computeCloudTag returns the next cloud tag for commitSHA. The base version is
+// "v" + overrideVersion when given, else one minor past the newest release
+// branch on origin that does not contain the commit; the counter is one past
+// the highest existing "-cloud.N" tag for that base.
 func computeCloudTag(commitSHA, overrideVersion string) (string, error) {
 	// The ancestry checks below cannot be answered truthfully in a shallow
 	// clone; fail loudly instead.
@@ -144,12 +145,12 @@ func computeCloudTag(commitSHA, overrideVersion string) (string, error) {
 	if overrideVersion != "" {
 		base = "v" + overrideVersion
 	} else {
-		train, err := findTargetReleaseVersion(commitSHA)
+		branchVersion, err := findTargetReleaseVersion(commitSHA)
 		if err != nil {
-			return "", fmt.Errorf("failed to detect the release train (pass --version to override): %w", err)
+			return "", fmt.Errorf("failed to detect the base version from release branches (pass --version to override): %w", err)
 		}
-		base = train.nextMinorBase()
-		log.Infof("Newest release branch not containing %.10s: release/%s -> cloud base %s", commitSHA, train, base)
+		base = branchVersion.nextMinorBase()
+		log.Infof("Newest release branch not containing %.10s: release/%s -> cloud base %s", commitSHA, branchVersion, base)
 	}
 
 	return nextCloudTag(base)

--- a/tools/ods/cmd/release_cloud.go
+++ b/tools/ods/cmd/release_cloud.go
@@ -73,8 +73,9 @@ func releaseCloud(opts *ReleaseCloudOptions) error {
 	if err := git.RunCommand("fetch", "--quiet", "--force", "origin", "+refs/heads/main:refs/remotes/origin/main"); err != nil {
 		return fmt.Errorf("failed to fetch origin/main: %w", err)
 	}
-	// Best-effort like the opal release: an offline run still works off local
-	// tags, and a stale counter only makes the push fail (and roll back).
+	// Best-effort: a failure here only leaves the counter stale, which is
+	// safe. If the computed tag already exists on origin, the push (which is
+	// never forced) is rejected and rolled back.
 	if err := fetchCloudTags(); err != nil {
 		log.Warnf("Could not fetch cloud tags (using local tags): %v", err)
 	}

--- a/tools/ods/cmd/release_cloud.go
+++ b/tools/ods/cmd/release_cloud.go
@@ -1,0 +1,230 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
+)
+
+// ReleaseCloudOptions holds options for the release cloud command.
+type ReleaseCloudOptions struct {
+	Ref     string
+	Version string
+	DryRun  bool
+	Yes     bool
+	Verify  bool
+}
+
+// NewReleaseCloudCommand creates the `ods release cloud` command.
+func NewReleaseCloudCommand() *cobra.Command {
+	opts := &ReleaseCloudOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "cloud",
+		Short: "Cut the next cloud release tag (vX.Y.0-cloud.N) off main",
+		Long: `Cut the next cloud release tag (vX.Y.0-cloud.N) and push it to origin.
+
+The base version names the release train the tagged commit belongs to: one
+minor past the newest release/vX.Y branch that does not contain the commit.
+A commit on main after the release/v4.6 cut is therefore tagged
+v4.7.0-cloud.N, never v4.6.0-cloud.N, so cloud tags order correctly against
+stable and beta tags under semver. N is one past the highest existing counter
+for the same base, starting at 0.
+
+Pushing the tag triggers deployment.yml, which builds the cloud images.
+
+Example usage:
+
+    $ ods release cloud
+    $ ods release cloud --dry-run
+    $ ods release cloud --ref 1a2b3c4d
+    $ ods release cloud --version 5.0.0`,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return releaseCloud(opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Ref, "ref", "origin/main", "Commit-ish to tag; must be on origin/main")
+	cmd.Flags().StringVar(&opts.Version, "version", "", "Base version override (X.Y.Z, no leading v); skips release-branch detection")
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Compute and print the tag but don't tag or push")
+	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip the confirmation prompt")
+	cmd.Flags().BoolVar(&opts.Verify, "verify", false, "Run pre-push hooks when pushing the tag; they are skipped by default")
+
+	return cmd
+}
+
+func releaseCloud(opts *ReleaseCloudOptions) error {
+	if opts.Version != "" && !bareSemverRe.MatchString(opts.Version) {
+		return fmt.Errorf("--version must be X.Y.Z with no leading v, got %q", opts.Version)
+	}
+
+	// Deployment tags must be cut against origin's current state.
+	log.Info("Fetching main and cloud tags from origin...")
+	if err := git.RunCommand("fetch", "--quiet", "--force", "origin", "+refs/heads/main:refs/remotes/origin/main"); err != nil {
+		return fmt.Errorf("failed to fetch origin/main: %w", err)
+	}
+	// Best-effort like the opal release: an offline run still works off local
+	// tags, and a stale counter only makes the push fail (and roll back).
+	if err := fetchCloudTags(); err != nil {
+		log.Warnf("Could not fetch cloud tags (using local tags): %v", err)
+	}
+
+	sha, err := resolveCommit(opts.Ref)
+	if err != nil {
+		return err
+	}
+
+	tag, err := computeCloudTag(sha, opts.Version)
+	if err != nil {
+		return err
+	}
+
+	if opts.DryRun {
+		log.Warnf("[DRY RUN] Would tag %.10s as %s and push", sha, tag)
+		fmt.Println(tag)
+		return nil
+	}
+
+	if !opts.Yes {
+		if !prompt.Confirm(fmt.Sprintf("Tag %.10s as %s and push to trigger the cloud build? (Y/n): ", sha, tag)) {
+			log.Info("Exiting...")
+			return nil
+		}
+	}
+
+	if err := git.RunCommand("tag", tag, sha); err != nil {
+		return fmt.Errorf("failed to create tag %s: %w", tag, err)
+	}
+	if err := git.PushTag(tag, false, opts.Verify); err != nil {
+		// Roll back the local tag so the command stays retryable after a failed push.
+		if delErr := git.RunCommand("tag", "-d", tag); delErr != nil {
+			log.Warnf("Also failed to delete local tag %s; remove it before retrying: %v", tag, delErr)
+		}
+		return fmt.Errorf("failed to push tag %s: %w", tag, err)
+	}
+	log.Infof("Pushed %s; deployment.yml will build the cloud images.", tag)
+	return nil
+}
+
+// computeCloudTag returns the next cloud tag for commitSHA. The base version
+// is "v" + overrideVersion when given, else one minor past the release train
+// detected from origin's release branches; the counter is one past the highest
+// existing "-cloud.N" tag for that base.
+func computeCloudTag(commitSHA, overrideVersion string) (string, error) {
+	// The ancestry checks below cannot be answered truthfully in a shallow
+	// clone; fail loudly instead.
+	shallow, err := git.IsShallowRepository()
+	if err != nil {
+		return "", err
+	}
+	if shallow {
+		return "", fmt.Errorf("this is a shallow clone, so cloud tag computation cannot check branch ancestry")
+	}
+
+	onMain, err := git.IsAncestor(commitSHA, "origin/main")
+	if err != nil {
+		return "", err
+	}
+	if !onMain {
+		return "", fmt.Errorf("commit %s is not on origin/main; cloud releases are cut from main", commitSHA)
+	}
+
+	var base string
+	if overrideVersion != "" {
+		base = "v" + overrideVersion
+	} else {
+		train, err := findTargetReleaseVersion(commitSHA)
+		if err != nil {
+			return "", fmt.Errorf("failed to detect the release train (pass --version to override): %w", err)
+		}
+		base = train.nextMinorBase()
+		log.Infof("Newest release branch not containing %.10s: release/%s -> cloud base %s", commitSHA, train, base)
+	}
+
+	return nextCloudTag(base)
+}
+
+// fetchCloudTags force-updates the local v*-cloud.* tags from origin. A fetch
+// refspec allows only one wildcard per side, so the matching tag names are
+// listed with ls-remote (which globs freely) and fetched by exact refspec.
+func fetchCloudTags() error {
+	out, err := exec.Command("git", "ls-remote", "--tags", "origin", "v*-cloud.*").Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && len(exitErr.Stderr) > 0 {
+			return fmt.Errorf("git ls-remote failed: %w: %s", err, strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return fmt.Errorf("git ls-remote failed: %w", err)
+	}
+
+	refspecs := []string{}
+	for _, line := range strings.Split(string(out), "\n") {
+		// Each line is "<sha>\trefs/tags/<name>".
+		_, ref, found := strings.Cut(line, "\t")
+		if !found {
+			continue
+		}
+		ref = strings.TrimSpace(ref)
+		// Annotated tags list a second, peeled "<ref>^{}" entry; the plain ref
+		// covers it.
+		if strings.HasSuffix(ref, "^{}") {
+			continue
+		}
+		refspecs = append(refspecs, fmt.Sprintf("+%s:%s", ref, ref))
+	}
+	if len(refspecs) == 0 {
+		return nil
+	}
+
+	args := append([]string{"fetch", "--quiet", "origin"}, refspecs...)
+	return git.RunCommand(args...)
+}
+
+// nextCloudTag returns base + "-cloud.N" where N is one past the highest
+// existing counter for base among local tags (fetched from origin beforehand),
+// or 0 when none exist. Counters compare numerically: lexically "-cloud.9" >
+// "-cloud.10", which would compute a colliding tag. Tags of other bases and
+// tags whose suffix is not a plain integer are ignored.
+func nextCloudTag(base string) (string, error) {
+	out, err := exec.Command("git", "tag", "--list", base+"-cloud.*").Output()
+	if err != nil {
+		return "", fmt.Errorf("git tag --list failed: %w", err)
+	}
+	counterRe := regexp.MustCompile(`^` + regexp.QuoteMeta(base) + `-cloud\.(\d+)$`)
+	next := 0
+	for _, line := range strings.Split(string(out), "\n") {
+		matches := counterRe.FindStringSubmatch(strings.TrimSpace(line))
+		if matches == nil {
+			continue
+		}
+		n, err := strconv.Atoi(matches[1])
+		if err != nil {
+			continue
+		}
+		if n >= next {
+			next = n + 1
+		}
+	}
+	return fmt.Sprintf("%s-cloud.%d", base, next), nil
+}
+
+// resolveCommit resolves a commit-ish to a full commit SHA.
+func resolveCommit(ref string) (string, error) {
+	out, err := exec.Command("git", "rev-parse", "--verify", ref+"^{commit}").Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && len(exitErr.Stderr) > 0 {
+			return "", fmt.Errorf("failed to resolve %q: %w: %s", ref, err, strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return "", fmt.Errorf("failed to resolve %q: %w", ref, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/tools/ods/cmd/release_cloud_test.go
+++ b/tools/ods/cmd/release_cloud_test.go
@@ -1,0 +1,342 @@
+package cmd
+
+// Cloud tag state matrix. Base states (commit vs release branches on origin;
+// computeCloudTag):
+//
+//	S1 commit past the newest cut            -> newest minor+1, counter fresh   TestComputeCloudTag_postCutCommitBumpsPastNewestBranch
+//	S2 commit between two cuts               -> older train's minor+1           TestComputeCloudTag_betweenCutsUsesOlderTrain
+//	S3 commit on every release branch        -> error, hint --version           TestComputeCloudTag_commitOnAllBranchesErrors
+//	S4 no release branches on origin         -> error, hint --version           TestComputeCloudTag_noReleaseBranchesErrors
+//	S5 skipped minor between branch cuts     -> still cut-anchored minor+1      TestComputeCloudTag_skippedMinorStaysCutAnchored
+//	S6 double-digit minor / major boundary   -> numeric minor bump              TestComputeCloudTag_doubleDigitMinorAndMajorBoundary
+//	S7 commit not on origin/main             -> error                           TestComputeCloudTag_commitNotOnMainErrors
+//	S8 shallow clone (even with --version)   -> error                           TestComputeCloudTag_shallowCloneErrors
+//	S9 --version override                    -> override base, counter fresh    TestComputeCloudTag_versionOverride
+//
+// Counter states (existing tags vs a base; nextCloudTag, TestNextCloudTag_countersPerBase):
+//
+//	C1 no tags for the base                  -> cloud.0
+//	C2 gaps in counters                      -> max+1, gaps not refilled
+//	C3 counter 9 and 10 present             -> cloud.11 (numeric, not lexical)
+//	C4 cloud tags only under other bases     -> cloud.0
+//	C5 same-base beta and stable tags        -> ignored, cloud.0
+//	C6 malformed cloud suffixes              -> ignored, cloud.0
+//	C7 base that prefixes another base       -> no cross-base bleed, cloud.0
+//
+// Command states (releaseCloud):
+//
+//	E1 dry run                               -> prints tag, creates nothing     TestReleaseCloud_dryRunCreatesNothing
+//	E2 real run                              -> tag on origin at origin/main    TestReleaseCloud_tagsOriginMainHead
+//	E3 push rejected by origin               -> local tag rolled back           TestReleaseCloud_pushFailureRollsBackLocalTag
+//	E4 counter tag only on origin            -> fetched, counter continues      TestReleaseCloud_fetchesRemoteOnlyCounterTags
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// tagExistsIn reports whether the tag exists in the repository at dir.
+func tagExistsIn(dir, tag string) bool {
+	cmd := exec.Command("git", "rev-parse", "-q", "--verify", "refs/tags/"+tag)
+	cmd.Dir = dir
+	return cmd.Run() == nil
+}
+
+// setupTwoBranchRepo creates an origin whose main holds four commits with
+// branchA cut at the first and branchB at the third, chdirs into the work
+// clone, and returns the SHA between the cuts and the SHA past both.
+func setupTwoBranchRepo(t *testing.T, branchA, branchB string) (betweenSHA, postSHA string) {
+	t.Helper()
+
+	_, work := initOriginAndWork(t)
+	cutA := commitIn(t, work, "a.txt")
+	betweenSHA = commitIn(t, work, "b.txt")
+	cutB := commitIn(t, work, "c.txt")
+	postSHA = commitIn(t, work, "d.txt")
+
+	publishMain(t, work)
+	publishReleaseBranch(t, work, branchA, cutA)
+	publishReleaseBranch(t, work, branchB, cutB)
+
+	t.Chdir(work)
+	return betweenSHA, postSHA
+}
+
+func TestComputeCloudTag_postCutCommitBumpsPastNewestBranch(t *testing.T) {
+	// Precondition: the fixture's v4.4.0-cloud.9 tag also pins that counters
+	// under other bases do not bleed into a fresh base.
+	repo := setupReleaseBranchRepo(t)
+
+	// Under test.
+	tag, err := computeCloudTag(repo.postCutSHA, "")
+
+	// Postcondition.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v4.6.0-cloud.0" {
+		t.Errorf("expected v4.6.0-cloud.0, got %s", tag)
+	}
+}
+
+func TestComputeCloudTag_betweenCutsUsesOlderTrain(t *testing.T) {
+	// Precondition.
+	repo := setupReleaseBranchRepo(t)
+
+	// Under test: the v4.5 cut point is on release/v4.5 but not release/v4.4,
+	// so it ships in the 4.5 train.
+	tag, err := computeCloudTag(repo.cutSHA, "")
+
+	// Postcondition.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v4.5.0-cloud.0" {
+		t.Errorf("expected v4.5.0-cloud.0, got %s", tag)
+	}
+}
+
+func TestComputeCloudTag_commitOnAllBranchesErrors(t *testing.T) {
+	// Precondition.
+	repo := setupReleaseBranchRepo(t)
+
+	// Under test.
+	_, err := computeCloudTag(repo.preCutSHA, "")
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "already contained in every release branch") {
+		t.Errorf("expected already-contained error, got %v", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "--version") {
+		t.Errorf("expected a --version hint, got %v", err)
+	}
+}
+
+func TestComputeCloudTag_noReleaseBranchesErrors(t *testing.T) {
+	// Precondition: an origin with main only.
+	_, work := initOriginAndWork(t)
+	sha := commitIn(t, work, "a.txt")
+	publishMain(t, work)
+	t.Chdir(work)
+
+	// Under test.
+	_, err := computeCloudTag(sha, "")
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "no release/vX.Y branches") {
+		t.Errorf("expected no-release-branches error, got %v", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "--version") {
+		t.Errorf("expected a --version hint, got %v", err)
+	}
+}
+
+func TestComputeCloudTag_skippedMinorStaysCutAnchored(t *testing.T) {
+	// Precondition: v4.5 was never branched; 4.5.0 will never ship.
+	betweenSHA, postSHA := setupTwoBranchRepo(t, "release/v4.4", "release/v4.6")
+
+	// Under test and postcondition: the base is anchored to the branch cuts,
+	// not to consecutive numbering. v4.5.0-cloud.N for the between commit is
+	// sound: it sorts below v4.6.0, whose branch contains the commit.
+	tag, err := computeCloudTag(betweenSHA, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v4.5.0-cloud.0" {
+		t.Errorf("expected v4.5.0-cloud.0, got %s", tag)
+	}
+	tag, err = computeCloudTag(postSHA, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v4.7.0-cloud.0" {
+		t.Errorf("expected v4.7.0-cloud.0, got %s", tag)
+	}
+}
+
+func TestComputeCloudTag_doubleDigitMinorAndMajorBoundary(t *testing.T) {
+	// Precondition.
+	betweenSHA, postSHA := setupTwoBranchRepo(t, "release/v4.10", "release/v5.0")
+
+	// Under test and postcondition: v4.10 bumps numerically to v4.11.0, and a
+	// commit past the v5.0 cut lands on the v5.1 train (major bumps are not
+	// guessed; they arrive via the next branch cut or --version).
+	tag, err := computeCloudTag(betweenSHA, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v4.11.0-cloud.0" {
+		t.Errorf("expected v4.11.0-cloud.0, got %s", tag)
+	}
+	tag, err = computeCloudTag(postSHA, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v5.1.0-cloud.0" {
+		t.Errorf("expected v5.1.0-cloud.0, got %s", tag)
+	}
+}
+
+func TestComputeCloudTag_commitNotOnMainErrors(t *testing.T) {
+	// Precondition: a commit on a feature branch only.
+	repo := setupReleaseBranchRepo(t)
+	gitIn(t, repo.work, "checkout", "--quiet", "-b", "feature", repo.preCutSHA)
+	featureSHA := commitIn(t, repo.work, "f.txt")
+	gitIn(t, repo.work, "checkout", "--quiet", "main")
+
+	// Under test.
+	_, err := computeCloudTag(featureSHA, "")
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "not on origin/main") {
+		t.Errorf("expected not-on-main error, got %v", err)
+	}
+}
+
+func TestComputeCloudTag_shallowCloneErrors(t *testing.T) {
+	// Precondition.
+	sha := setupShallowClone(t)
+
+	// Under test: the override skips release-branch detection, so this pins
+	// computeCloudTag's own shallow guard, not findTargetReleaseVersion's.
+	_, err := computeCloudTag(sha, "5.0.0")
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "shallow clone") {
+		t.Errorf("expected shallow-clone error, got %v", err)
+	}
+}
+
+func TestComputeCloudTag_versionOverride(t *testing.T) {
+	// Precondition.
+	repo := setupReleaseBranchRepo(t)
+
+	// Under test.
+	tag, err := computeCloudTag(repo.postCutSHA, "5.0.0")
+
+	// Postcondition.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v5.0.0-cloud.0" {
+		t.Errorf("expected v5.0.0-cloud.0, got %s", tag)
+	}
+}
+
+func TestNextCloudTag_countersPerBase(t *testing.T) {
+	// Precondition: one repo holding every counter state side by side.
+	_, work := initOriginAndWork(t)
+	sha := commitIn(t, work, "a.txt")
+	for _, tag := range []string{
+		"v4.6.0-cloud.0", "v4.6.0-cloud.5", // Gap between counters.
+		"v4.7.0-cloud.9", "v4.7.0-cloud.10", // Numeric vs lexical ordering.
+		"v4.9.0-beta.1", "v4.9.0", // Same-base non-cloud tags.
+		"v4.10.0-cloud.5",                                         // Base that v4.1.0 prefixes.
+		"v4.12.0-cloud", "v4.12.0-cloud.abc", "v4.12.0-cloud.1.2", // Malformed suffixes.
+	} {
+		gitIn(t, work, "tag", tag, sha)
+	}
+	t.Chdir(work)
+
+	// Under test and postcondition.
+	cases := []struct {
+		base string
+		want string
+	}{
+		{"v4.6.0", "v4.6.0-cloud.6"},
+		{"v4.7.0", "v4.7.0-cloud.11"},
+		{"v4.8.0", "v4.8.0-cloud.0"},
+		{"v4.9.0", "v4.9.0-cloud.0"},
+		{"v4.10.0", "v4.10.0-cloud.6"},
+		{"v4.12.0", "v4.12.0-cloud.0"},
+		{"v4.1.0", "v4.1.0-cloud.0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.base, func(t *testing.T) {
+			tag, err := nextCloudTag(tc.base)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tag != tc.want {
+				t.Errorf("expected %s, got %s", tc.want, tag)
+			}
+		})
+	}
+}
+
+func TestReleaseCloud_dryRunCreatesNothing(t *testing.T) {
+	// Precondition.
+	repo := setupReleaseBranchRepo(t)
+
+	// Under test.
+	err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", DryRun: true, Yes: true})
+
+	// Postcondition.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tagExistsIn(repo.work, "v4.6.0-cloud.0") || tagExistsIn(repo.origin, "v4.6.0-cloud.0") {
+		t.Error("dry run must not create the tag")
+	}
+}
+
+func TestReleaseCloud_tagsOriginMainHead(t *testing.T) {
+	// Precondition.
+	repo := setupReleaseBranchRepo(t)
+
+	// Under test.
+	err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", Yes: true})
+
+	// Postcondition.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	taggedSHA := gitIn(t, repo.origin, "rev-parse", "refs/tags/v4.6.0-cloud.0^{commit}")
+	if taggedSHA != repo.postCutSHA {
+		t.Errorf("expected origin tag at %s, got %s", repo.postCutSHA, taggedSHA)
+	}
+}
+
+func TestReleaseCloud_fetchesRemoteOnlyCounterTags(t *testing.T) {
+	// Precondition: a counter tag another developer pushed but this clone
+	// never fetched. Computing from local tags alone would mint a colliding
+	// v4.6.0-cloud.3.
+	repo := setupReleaseBranchRepo(t)
+	gitIn(t, repo.work, "tag", "v4.6.0-cloud.3", repo.postCutSHA)
+	gitIn(t, repo.work, "push", "--quiet", "origin", "v4.6.0-cloud.3")
+	gitIn(t, repo.work, "tag", "-d", "v4.6.0-cloud.3")
+
+	// Under test.
+	err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", Yes: true})
+
+	// Postcondition.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !tagExistsIn(repo.origin, "v4.6.0-cloud.4") {
+		t.Error("expected v4.6.0-cloud.4 on origin")
+	}
+}
+
+func TestReleaseCloud_pushFailureRollsBackLocalTag(t *testing.T) {
+	// Precondition: origin rejects every push.
+	repo := setupReleaseBranchRepo(t)
+	hook := filepath.Join(repo.origin, "hooks", "pre-receive")
+	if err := os.WriteFile(hook, []byte("#!/bin/sh\nexit 1\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Under test.
+	err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", Yes: true})
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "failed to push") {
+		t.Errorf("expected push failure, got %v", err)
+	}
+	if tagExistsIn(repo.work, "v4.6.0-cloud.0") {
+		t.Error("local tag must be rolled back after a failed push")
+	}
+}

--- a/tools/ods/cmd/release_cloud_test.go
+++ b/tools/ods/cmd/release_cloud_test.go
@@ -1,14 +1,21 @@
 package cmd
 
-// Cloud tag state matrix. Base states (commit vs release branches on origin;
-// computeCloudTag):
+// Cloud tag state matrix. A "cut" is the commit where a release/vX.Y branch was
+// created off main; the branch contains every main commit up to its cut and
+// none after. The base version of a cloud tag is one minor past the newest
+// release branch that does not contain the tagged commit. That places the tag
+// above every release whose branch is missing the commit and below every
+// release whose branch contains it.
 //
-//	S1 commit past the newest cut            -> newest minor+1, counter fresh   TestComputeCloudTag_postCutCommitBumpsPastNewestBranch
-//	S2 commit between two cuts               -> older train's minor+1           TestComputeCloudTag_betweenCutsUsesOlderTrain
-//	S3 commit on every release branch        -> error, hint --version           TestComputeCloudTag_commitOnAllBranchesErrors
+// Base states (computeCloudTag; the fixture cuts release/v4.4, then
+// release/v4.5, on a shared main line):
+//
+//	S1 commit after the v4.5 cut             -> v4.6.0-cloud.0                  TestComputeCloudTag_postCutCommitBumpsPastNewestBranch
+//	S2 commit after the v4.4 cut, before v4.5's -> v4.5.0-cloud.0               TestComputeCloudTag_betweenCutsBumpsPastOlderBranch
+//	S3 commit before every cut               -> error, hint --version           TestComputeCloudTag_commitOnAllBranchesErrors
 //	S4 no release branches on origin         -> error, hint --version           TestComputeCloudTag_noReleaseBranchesErrors
-//	S5 skipped minor between branch cuts     -> still cut-anchored minor+1      TestComputeCloudTag_skippedMinorStaysCutAnchored
-//	S6 double-digit minor / major boundary   -> numeric minor bump              TestComputeCloudTag_doubleDigitMinorAndMajorBoundary
+//	S5 v4.5 never branched (v4.4, v4.6 cuts) -> between-cuts commit still v4.5.0 TestComputeCloudTag_skippedMinorStaysCutAnchored
+//	S6 v4.10 and v5.0 cuts                   -> v4.11.0 / v5.1.0 (numeric bump) TestComputeCloudTag_doubleDigitMinorAndMajorBoundary
 //	S7 commit not on origin/main             -> error                           TestComputeCloudTag_commitNotOnMainErrors
 //	S8 shallow clone (even with --version)   -> error                           TestComputeCloudTag_shallowCloneErrors
 //	S9 --version override                    -> override base, counter fresh    TestComputeCloudTag_versionOverride
@@ -83,12 +90,12 @@ func TestComputeCloudTag_postCutCommitBumpsPastNewestBranch(t *testing.T) {
 	}
 }
 
-func TestComputeCloudTag_betweenCutsUsesOlderTrain(t *testing.T) {
+func TestComputeCloudTag_betweenCutsBumpsPastOlderBranch(t *testing.T) {
 	// Precondition.
 	repo := setupReleaseBranchRepo(t)
 
 	// Under test: the v4.5 cut point is on release/v4.5 but not release/v4.4,
-	// so it ships in the 4.5 train.
+	// so its code ships in v4.5.0 and the tag must sort below v4.5.0.
 	tag, err := computeCloudTag(repo.cutSHA, "")
 
 	// Postcondition.
@@ -163,8 +170,8 @@ func TestComputeCloudTag_doubleDigitMinorAndMajorBoundary(t *testing.T) {
 	betweenSHA, postSHA := setupTwoBranchRepo(t, "release/v4.10", "release/v5.0")
 
 	// Under test and postcondition: v4.10 bumps numerically to v4.11.0, and a
-	// commit past the v5.0 cut lands on the v5.1 train (major bumps are not
-	// guessed; they arrive via the next branch cut or --version).
+	// commit past the v5.0 cut gets base v5.1.0 (major bumps are not guessed;
+	// they arrive via the next branch cut or --version).
 	tag, err := computeCloudTag(betweenSHA, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -302,8 +309,8 @@ func TestReleaseCloud_tagsOriginMainHead(t *testing.T) {
 }
 
 func TestReleaseCloud_fetchesRemoteOnlyCounterTags(t *testing.T) {
-	// Precondition: a counter tag another developer pushed but this clone
-	// never fetched. Computing from local tags alone would mint a colliding
+	// Precondition: a counter tag another developer pushed but this clone never
+	// fetched. Computing from local tags alone would mint a colliding
 	// v4.6.0-cloud.3.
 	repo := setupReleaseBranchRepo(t)
 	gitIn(t, repo.work, "tag", "v4.6.0-cloud.3", repo.postCutSHA)

--- a/tools/ods/cmd/release_cloud_test.go
+++ b/tools/ods/cmd/release_cloud_test.go
@@ -29,6 +29,7 @@ package cmd
 //	E2 real run                              -> tag on origin at origin/main    TestReleaseCloud_tagsOriginMainHead
 //	E3 push rejected by origin               -> local tag rolled back           TestReleaseCloud_pushFailureRollsBackLocalTag
 //	E4 counter tag only on origin            -> fetched, counter continues      TestReleaseCloud_fetchesRemoteOnlyCounterTags
+//	E5 --version with leading zeroes         -> rejected before any git work    TestReleaseCloud_rejectsLeadingZeroVersion
 
 import (
 	"os"
@@ -318,6 +319,20 @@ func TestReleaseCloud_fetchesRemoteOnlyCounterTags(t *testing.T) {
 	}
 	if !tagExistsIn(repo.origin, "v4.6.0-cloud.4") {
 		t.Error("expected v4.6.0-cloud.4 on origin")
+	}
+}
+
+func TestReleaseCloud_rejectsLeadingZeroVersion(t *testing.T) {
+	// Precondition: SemVer 2.0.0 item 2 forbids leading zeroes in numeric
+	// identifiers; such an override must never become a tag.
+	setupReleaseBranchRepo(t)
+
+	// Under test and postcondition.
+	for _, version := range []string{"04.6.0", "4.06.0", "4.6.00"} {
+		err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", Version: version, DryRun: true, Yes: true})
+		if err == nil || !strings.Contains(err.Error(), "--version must be X.Y.Z") {
+			t.Errorf("expected validation error for %q, got %v", version, err)
+		}
 	}
 }
 

--- a/tools/ods/cmd/release_detection.go
+++ b/tools/ods/cmd/release_detection.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
+)
+
+// releaseBranchPattern matches maintained release branch names, e.g.
+// "release/v4.5". Ad-hoc branches such as "release/v3.0-qa-f1df36e" are
+// deliberately excluded.
+var releaseBranchPattern = regexp.MustCompile(`^release/v(\d+)\.(\d+)$`)
+
+// releaseBranchRefspec returns a forced fetch refspec that creates or updates
+// the origin/<releaseBranch> tracking ref even in clones whose configured fetch
+// refspec does not cover release branches (e.g. single-branch clones), where a
+// plain "git fetch origin <branch>" only writes FETCH_HEAD.
+func releaseBranchRefspec(releaseBranch string) string {
+	return fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", releaseBranch, releaseBranch)
+}
+
+// releaseVersion is the parsed version of a "release/vX.Y" branch.
+type releaseVersion struct {
+	major int
+	minor int
+}
+
+// String returns the version with its 'v' prefix, e.g. "v4.5".
+func (v releaseVersion) String() string {
+	return fmt.Sprintf("v%d.%d", v.major, v.minor)
+}
+
+// nextMinorBase returns the base version of the next minor release after this
+// branch, e.g. v4.5 -> "v4.6.0".
+func (v releaseVersion) nextMinorBase() string {
+	return fmt.Sprintf("v%d.%d.0", v.major, v.minor+1)
+}
+
+// parseReleaseVersions extracts "release/vX.Y" versions from branch names and
+// returns them sorted newest first. Names that do not match the pattern are
+// ignored.
+func parseReleaseVersions(branchNames []string) []releaseVersion {
+	versions := []releaseVersion{}
+	for _, name := range branchNames {
+		matches := releaseBranchPattern.FindStringSubmatch(name)
+		if matches == nil {
+			continue
+		}
+		major, err := strconv.Atoi(matches[1])
+		if err != nil {
+			continue
+		}
+		minor, err := strconv.Atoi(matches[2])
+		if err != nil {
+			continue
+		}
+		versions = append(versions, releaseVersion{major: major, minor: minor})
+	}
+	sort.Slice(versions, func(i, j int) bool {
+		if versions[i].major != versions[j].major {
+			return versions[i].major > versions[j].major
+		}
+		return versions[i].minor > versions[j].minor
+	})
+	return versions
+}
+
+// listRemoteReleaseBranches returns the names (e.g. "release/v4.5") of all
+// release branches on origin.
+func listRemoteReleaseBranches() ([]string, error) {
+	cmd := exec.Command("git", "ls-remote", "--heads", "origin", "release/*")
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("git ls-remote failed: %w: %s", err, string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("git ls-remote failed: %w", err)
+	}
+
+	branches := []string{}
+	for _, line := range strings.Split(string(output), "\n") {
+		// Each line is "<sha>\trefs/heads/<branch>".
+		_, ref, found := strings.Cut(line, "\t")
+		if !found {
+			continue
+		}
+		branches = append(branches, strings.TrimPrefix(strings.TrimSpace(ref), "refs/heads/"))
+	}
+	return branches, nil
+}
+
+// findTargetReleaseVersion returns the version (e.g. v4.5) of the newest
+// "release/vX.Y" branch on origin that does not already contain commitSHA. A
+// commit merged to main after the latest branch cut targets the newest branch;
+// a commit that predates the cut (and is therefore already part of the newer
+// branches) falls back to the newest branch actually missing it. Tags are
+// deliberately not consulted: release tag names on main (e.g. "vX.Y.0-cloud.N")
+// roll over to a new version asynchronously from the branch cut, so the nearest
+// tag can disagree with the newest branch.
+func findTargetReleaseVersion(commitSHA string) (releaseVersion, error) {
+	// A shallow clone cannot answer ancestry truthfully: history beyond the
+	// shallow boundary makes contained commits look uncontained, silently
+	// routing them to the wrong branch. Fail loudly instead.
+	shallow, err := git.IsShallowRepository()
+	if err != nil {
+		return releaseVersion{}, err
+	}
+	if shallow {
+		return releaseVersion{}, fmt.Errorf("this is a shallow clone, so release auto-detection cannot check branch ancestry")
+	}
+
+	branchNames, err := listRemoteReleaseBranches()
+	if err != nil {
+		return releaseVersion{}, err
+	}
+	versions := parseReleaseVersions(branchNames)
+	if len(versions) == 0 {
+		return releaseVersion{}, fmt.Errorf("no release/vX.Y branches found on origin")
+	}
+
+	for _, version := range versions {
+		releaseBranch := fmt.Sprintf("release/%s", version)
+		// Fetch so the ancestry check runs against the branch's current tip.
+		if err := git.RunCommand("fetch", "--quiet", "origin", releaseBranchRefspec(releaseBranch)); err != nil {
+			return releaseVersion{}, fmt.Errorf("failed to fetch %s: %w", releaseBranch, err)
+		}
+		contained, err := git.IsAncestor(commitSHA, fmt.Sprintf("origin/%s", releaseBranch))
+		if err != nil {
+			return releaseVersion{}, err
+		}
+		if !contained {
+			return version, nil
+		}
+		log.Infof("Commit %s is already contained in %s, checking the next older release branch", commitSHA, releaseBranch)
+	}
+
+	return releaseVersion{}, fmt.Errorf("commit %s is already contained in every release branch", commitSHA)
+}

--- a/tools/ods/cmd/release_detection_test.go
+++ b/tools/ods/cmd/release_detection_test.go
@@ -64,36 +64,75 @@ func commitIn(t *testing.T, dir, filename string) string {
 	return gitIn(t, dir, "rev-parse", "HEAD")
 }
 
-// setupReleaseBranchRepo creates a bare origin holding main, release/v4.4, and
-// release/v4.5, with a local work repo as the current directory. It returns
-// three main-line commit SHAs: the v4.4 cut point (ancestor of both release
-// branches), the v4.5 cut point (only on release/v4.5), and a post-cut commit
-// (on neither release branch).
-func setupReleaseBranchRepo(t *testing.T) (preCutSHA, cutSHA, postCutSHA string) {
+// initOriginAndWork creates a bare origin and a work clone wired to it, and
+// returns both paths. The work clone is configured like a single-branch
+// checkout of main so tests also pin that detection fetches release branches
+// with an explicit refspec (a plain "git fetch origin <branch>" would only
+// write FETCH_HEAD here and never create origin/release/vX.Y).
+func initOriginAndWork(t *testing.T) (origin, work string) {
 	t.Helper()
 
-	origin := t.TempDir()
+	origin = t.TempDir()
 	gitIn(t, origin, "init", "--bare", "-b", "main")
 
-	work := t.TempDir()
+	work = t.TempDir()
 	gitIn(t, work, "init", "-b", "main")
 	gitIn(t, work, "config", "user.email", "test@test.com")
 	gitIn(t, work, "config", "user.name", "Test")
 	gitIn(t, work, "config", "commit.gpgsign", "false")
 	gitIn(t, work, "remote", "add", "origin", origin)
-	// Narrow the fetch refspec to main only, like a single-branch clone, so the
-	// tests also pin that detection fetches release branches with an explicit
-	// refspec (a plain "git fetch origin <branch>" would only write FETCH_HEAD
-	// here and never create origin/release/vX.Y).
 	gitIn(t, work, "config", "remote.origin.fetch", "+refs/heads/main:refs/remotes/origin/main")
 
-	preCutSHA = commitIn(t, work, "a.txt")
-	gitIn(t, work, "branch", "release/v4.4", preCutSHA)
-	cutSHA = commitIn(t, work, "b.txt")
-	gitIn(t, work, "branch", "release/v4.5", cutSHA)
-	postCutSHA = commitIn(t, work, "c.txt")
+	return origin, work
+}
 
-	gitIn(t, work, "push", "--quiet", "origin", "main", "release/v4.4", "release/v4.5")
+// publishMain pushes main to origin and force-updates the origin/main
+// remote-tracking ref, which ancestry guards resolve.
+func publishMain(t *testing.T, work string) {
+	t.Helper()
+	gitIn(t, work, "push", "--quiet", "origin", "main")
+	gitIn(t, work, "fetch", "--quiet", "--force", "origin", "+refs/heads/main:refs/remotes/origin/main")
+}
+
+// publishReleaseBranch pushes a release branch cut at sha to origin, then
+// deletes the local branch and its remote-tracking ref so the fixture looks
+// like a clone that has never fetched the release branches; detection must
+// create origin/* itself via fetch.
+func publishReleaseBranch(t *testing.T, work, branch, sha string) {
+	t.Helper()
+	gitIn(t, work, "branch", branch, sha)
+	gitIn(t, work, "push", "--quiet", "origin", branch)
+	gitIn(t, work, "branch", "-D", branch)
+	gitIn(t, work, "update-ref", "-d", "refs/remotes/origin/"+branch)
+}
+
+// releaseBranchRepo describes the fixture built by setupReleaseBranchRepo.
+type releaseBranchRepo struct {
+	origin string
+	work   string
+	// preCutSHA is the v4.4 cut point, an ancestor of both release branches.
+	preCutSHA string
+	// cutSHA is the v4.5 cut point, only on release/v4.5.
+	cutSHA string
+	// postCutSHA is on neither release branch.
+	postCutSHA string
+}
+
+// setupReleaseBranchRepo creates a bare origin holding main, release/v4.4, and
+// release/v4.5, with a local work repo as the current directory. It returns
+// the repo paths and three main-line commit SHAs bracketing the branch cuts.
+func setupReleaseBranchRepo(t *testing.T) releaseBranchRepo {
+	t.Helper()
+
+	origin, work := initOriginAndWork(t)
+
+	preCutSHA := commitIn(t, work, "a.txt")
+	cutSHA := commitIn(t, work, "b.txt")
+	postCutSHA := commitIn(t, work, "c.txt")
+
+	publishMain(t, work)
+	publishReleaseBranch(t, work, "release/v4.4", preCutSHA)
+	publishReleaseBranch(t, work, "release/v4.5", cutSHA)
 
 	// Tags named after the previous release must not influence detection
 	// (tag-anchored detection was the original misrouting bug). Mirror the
@@ -103,57 +142,75 @@ func setupReleaseBranchRepo(t *testing.T) (preCutSHA, cutSHA, postCutSHA string)
 	gitIn(t, work, "tag", "v4.4.2", preCutSHA)
 	gitIn(t, work, "tag", "v4.4.0-cloud.9", postCutSHA)
 
-	// Drop the local release branches and the remote-tracking refs the push
-	// created, so the fixture looks like a clone that has never fetched the
-	// release branches; detection must create origin/* itself via fetch.
-	gitIn(t, work, "branch", "-D", "release/v4.4", "release/v4.5")
-	gitIn(t, work, "update-ref", "-d", "refs/remotes/origin/release/v4.4")
-	gitIn(t, work, "update-ref", "-d", "refs/remotes/origin/release/v4.5")
-
 	// The functions under test run git in the process working directory.
 	t.Chdir(work)
 
-	return preCutSHA, cutSHA, postCutSHA
+	return releaseBranchRepo{
+		origin:     origin,
+		work:       work,
+		preCutSHA:  preCutSHA,
+		cutSHA:     cutSHA,
+		postCutSHA: postCutSHA,
+	}
+}
+
+// setupShallowClone seeds an origin holding main and release/v4.5 at a single
+// commit, makes a depth-1 clone the current directory, and returns the commit
+// SHA. Ancestry cannot be answered truthfully in the clone.
+func setupShallowClone(t *testing.T) string {
+	t.Helper()
+
+	origin, seed := initOriginAndWork(t)
+	sha := commitIn(t, seed, "a.txt")
+	gitIn(t, seed, "branch", "release/v4.5")
+	gitIn(t, seed, "push", "--quiet", "origin", "main", "release/v4.5")
+
+	shallow := filepath.Join(t.TempDir(), "shallow")
+	// Depth flags are ignored for plain local-path clones, hence file://.
+	gitIn(t, t.TempDir(), "clone", "--quiet", "--depth", "1", "--no-single-branch", "file://"+origin, shallow)
+	t.Chdir(shallow)
+
+	return sha
 }
 
 func TestFindTargetReleaseVersion_postCutCommitTargetsNewestBranch(t *testing.T) {
 	// Precondition.
-	_, _, postCutSHA := setupReleaseBranchRepo(t)
+	repo := setupReleaseBranchRepo(t)
 
 	// Under test.
-	version, err := findTargetReleaseVersion(postCutSHA)
+	version, err := findTargetReleaseVersion(repo.postCutSHA)
 
 	// Postcondition.
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if version != "v4.5" {
+	if version.String() != "v4.5" {
 		t.Errorf("expected v4.5, got %s", version)
 	}
 }
 
 func TestFindTargetReleaseVersion_preCutCommitFallsBackToOlderBranch(t *testing.T) {
 	// Precondition.
-	_, cutSHA, _ := setupReleaseBranchRepo(t)
+	repo := setupReleaseBranchRepo(t)
 
 	// Under test.
-	version, err := findTargetReleaseVersion(cutSHA)
+	version, err := findTargetReleaseVersion(repo.cutSHA)
 
 	// Postcondition.
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if version != "v4.4" {
+	if version.String() != "v4.4" {
 		t.Errorf("expected v4.4, got %s", version)
 	}
 }
 
 func TestFindTargetReleaseVersion_commitOnAllBranchesErrors(t *testing.T) {
 	// Precondition.
-	preCutSHA, _, _ := setupReleaseBranchRepo(t)
+	repo := setupReleaseBranchRepo(t)
 
 	// Under test.
-	_, err := findTargetReleaseVersion(preCutSHA)
+	_, err := findTargetReleaseVersion(repo.preCutSHA)
 
 	// Postcondition.
 	if err == nil || !strings.Contains(err.Error(), "already contained in every release branch") {
@@ -162,22 +219,8 @@ func TestFindTargetReleaseVersion_commitOnAllBranchesErrors(t *testing.T) {
 }
 
 func TestFindTargetReleaseVersion_shallowCloneErrors(t *testing.T) {
-	// Precondition: a shallow clone, where ancestry cannot be answered.
-	origin := t.TempDir()
-	gitIn(t, origin, "init", "--bare", "-b", "main")
-	seed := t.TempDir()
-	gitIn(t, seed, "init", "-b", "main")
-	gitIn(t, seed, "config", "user.email", "test@test.com")
-	gitIn(t, seed, "config", "user.name", "Test")
-	gitIn(t, seed, "config", "commit.gpgsign", "false")
-	gitIn(t, seed, "remote", "add", "origin", origin)
-	sha := commitIn(t, seed, "a.txt")
-	gitIn(t, seed, "branch", "release/v4.5")
-	gitIn(t, seed, "push", "--quiet", "origin", "main", "release/v4.5")
-	shallow := filepath.Join(t.TempDir(), "shallow")
-	// Depth flags are ignored for plain local-path clones, hence file://.
-	gitIn(t, t.TempDir(), "clone", "--quiet", "--depth", "1", "--no-single-branch", "file://"+origin, shallow)
-	t.Chdir(shallow)
+	// Precondition.
+	sha := setupShallowClone(t)
 
 	// Under test.
 	_, err := findTargetReleaseVersion(sha)

--- a/tools/ods/cmd/release_detection_test.go
+++ b/tools/ods/cmd/release_detection_test.go
@@ -119,8 +119,8 @@ type releaseBranchRepo struct {
 }
 
 // setupReleaseBranchRepo creates a bare origin holding main, release/v4.4, and
-// release/v4.5, with a local work repo as the current directory. It returns
-// the repo paths and three main-line commit SHAs bracketing the branch cuts.
+// release/v4.5, with a local work repo as the current directory. It returns the
+// repo paths and three main-line commit SHAs bracketing the branch cuts.
 func setupReleaseBranchRepo(t *testing.T) releaseBranchRepo {
 	t.Helper()
 

--- a/tools/ods/cmd/release_opal.go
+++ b/tools/ods/cmd/release_opal.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os/exec"
-	"regexp"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -14,9 +13,6 @@ import (
 )
 
 const opalTagPrefix = "opal/v"
-
-// opalSemverRe matches a bare X.Y.Z version (no leading v).
-var opalSemverRe = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
 
 // ReleaseOpalOptions holds options for the release opal command.
 type ReleaseOpalOptions struct {
@@ -66,7 +62,7 @@ Example usage:
 
 func releaseOpal(opts *ReleaseOpalOptions) {
 	if opts.Version != "" {
-		if !opalSemverRe.MatchString(opts.Version) {
+		if !bareSemverRe.MatchString(opts.Version) {
 			log.Fatalf("--version must be X.Y.Z with no leading v, got %q", opts.Version)
 		}
 	} else if opts.Bump != "patch" && opts.Bump != "minor" && opts.Bump != "major" {
@@ -134,7 +130,7 @@ func latestOpalVersion() (string, error) {
 	}
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		version := strings.TrimPrefix(strings.TrimSpace(line), opalTagPrefix)
-		if opalSemverRe.MatchString(version) {
+		if bareSemverRe.MatchString(version) {
 			return version, nil
 		}
 	}


### PR DESCRIPTION
## Description

Cloud tags are currently minted by hand as pre-releases of the last stable version (e.g. v4.5.0-cloud.6 on post-4.5.0 main), which inverts semver precedence: the tag sorts below v4.5.0 while the code is newer. This adds `ods release cloud` to compute the correct tag and push it.

- Base version = one minor past the newest release/vX.Y branch not containing the commit, so main after the v4.6 cut tags as v4.7.0-cloud.N. This places the tag above every release missing the commit and below every release containing it. Reuses the cherry-pick release-branch detection; branches are the source of truth, tags are ignored.
- Counter = highest existing -cloud.N for that base plus one, compared numerically (lexically cloud.9 > cloud.10). Remote cloud tags are fetched first via ls-remote + exact refspecs, since a fetch refspec only allows one wildcard and v*-cloud.* is invalid. Concurrent operators computing the same tag are resolved by git: the push is never forced, so the loser is rejected and rolled back.
- Guards: commit must be on origin/main, shallow clones refused, --version rejects leading zeroes per semver. --version overrides the base (e.g. planned major bumps), --dry-run prints the tag, --yes skips the prompt. Push failure rolls back the local tag.
- Refactor: release-branch detection helpers moved from cherry-pick.go to release_detection.go; findTargetReleaseVersion now returns the parsed version and its --release hint moved to the cherry-pick call site. No behavior change to cherry-pick. One behavior change to release opal: --version now rejects leading zeroes (the shared validator was tightened to semver-core per review); all existing opal/v* tags still parse.

No CI changes: deployment.yml already classifies any *cloud* tag and uses the tag string verbatim for image tags and ONYX_VERSION. Verify nothing outside this repo (control plane, cluster manifests) parses the stable-version prefix out of cloud tag names before pushing the first new-style tag; merging this changes nothing until the command is run.

## How Has This Been Tested?

- Tests enumerate a state matrix (release_cloud_test.go header): 9 base-detection states, 7 counter states, 5 command states.
- Dry run against this repo yields v4.7.0-cloud.0 (newest cut: release/v4.6).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ods release cloud` to compute and push the next cloud tag from main so tags sort correctly under SemVer. Previously cloud tags were prereleases of the last stable (sorted below it); now the base is the next minor after the newest release branch that doesn’t contain the commit, and counters increment numerically.

- Base detection anchors to branches, not tags: newest `release/vX.Y` missing the commit → base `vX.(Y+1).0`. `--version X.Y.Z` (no leading v; no leading zeros) overrides the base and shares the validator with `ods release opal`.
- Counter is one past the highest existing `-cloud.N` for that base (numeric comparison). Remote cloud tags are fetched first via `git ls-remote` and exact refspecs to avoid collisions.
- Guards and flags: commit must be on `origin/main`; shallow clones are refused. `--ref` selects the commit, `--dry-run` prints the tag, `--yes` skips the prompt, `--verify` runs pre-push hooks. On push failure, the local tag is deleted to keep retries clean.
- Refactor: release-train helpers moved to `release_detection.go`; `findTargetReleaseVersion` now returns a parsed version. Cherry-pick uses it with unchanged behavior. Bare SemVer validation moved to `release.go` and reused by `ods release opal`.
- CI/rollout: no changes; `deployment.yml` already builds on any cloud tag and uses the tag verbatim. Confirm no external tooling parses the stable-version prefix from cloud tag names.

<sup>Written for commit 7e8e5b3decd47653044443b6473138b2fb578d6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
