### PR TITLE
feat(llm): add OrcaRouter as a first-class model provider

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -2081,6 +2081,7 @@ COHERE_DEFAULT_API_KEY = os.environ.get("COHERE_DEFAULT_API_KEY")
 VERTEXAI_DEFAULT_CREDENTIALS = os.environ.get("VERTEXAI_DEFAULT_CREDENTIALS")
 VERTEXAI_DEFAULT_LOCATION = os.environ.get("VERTEXAI_DEFAULT_LOCATION", "global")
 OPENROUTER_DEFAULT_API_KEY = os.environ.get("OPENROUTER_DEFAULT_API_KEY")
+ORCAROUTER_DEFAULT_API_KEY = os.environ.get("ORCAROUTER_DEFAULT_API_KEY")
 # Whether tenant provisioning auto-creates LLMProvider rows seeded with the
 # *_DEFAULT_API_KEY env vars above. Defaults to True so self-hosted
 # deployments keep the existing behavior. Cloud sets this to False to

--- a/backend/onyx/llm/api_surfaces.py
+++ b/backend/onyx/llm/api_surfaces.py
@@ -37,6 +37,8 @@ OPENAI_COMPATIBLE_SURFACES = frozenset(
 _STATIC_SURFACES: dict[str, LlmApiSurface] = {
     LlmProviderNames.OPENAI_COMPATIBLE: LlmApiSurface.OPENAI_CHAT_COMPLETIONS,
     LlmProviderNames.NEBIUS_TOKENFACTORY: LlmApiSurface.OPENAI_CHAT_COMPLETIONS,
+    # OrcaRouter is an OpenAI-compatible gateway; single fixed surface.
+    LlmProviderNames.ORCAROUTER: LlmApiSurface.OPENAI_CHAT_COMPLETIONS,
 }
 
 # Admin-selected surfaces: {provider: (config_key, {stored value: surface}, default)}

--- a/backend/onyx/llm/constants.py
+++ b/backend/onyx/llm/constants.py
@@ -29,6 +29,7 @@ class LlmProviderNames(str, Enum):
     OPENAI_COMPATIBLE = "openai_compatible"
     NEBIUS_TOKENFACTORY = "nebius_tokenfactory"
     PORTKEY = "portkey"
+    ORCAROUTER = "orcarouter"
 
     def __str__(self) -> str:
         """Needed so things like:
@@ -52,6 +53,7 @@ WELL_KNOWN_PROVIDER_NAMES = [
     LlmProviderNames.OPENAI_COMPATIBLE,
     LlmProviderNames.NEBIUS_TOKENFACTORY,
     LlmProviderNames.PORTKEY,
+    LlmProviderNames.ORCAROUTER,
 ]
 
 
@@ -73,6 +75,7 @@ PROVIDER_DISPLAY_NAMES: dict[str, str] = {
     LlmProviderNames.OPENAI_COMPATIBLE: "OpenAI-Compatible",
     LlmProviderNames.NEBIUS_TOKENFACTORY: "Nebius TokenFactory",
     LlmProviderNames.PORTKEY: "Portkey",
+    LlmProviderNames.ORCAROUTER: "OrcaRouter",
     "groq": "Groq",
     "anyscale": "Anyscale",
     "deepseek": "DeepSeek",

--- a/backend/onyx/llm/well_known_providers/constants.py
+++ b/backend/onyx/llm/well_known_providers/constants.py
@@ -33,6 +33,9 @@ PORTKEY_DEFAULT_API_MODE = PORTKEY_API_MODE_CHAT_COMPLETIONS
 PORTKEY_DEFAULT_API_BASE_OPENAI = "https://api.portkey.ai/v1"
 PORTKEY_DEFAULT_API_BASE_ANTHROPIC = "https://api.portkey.ai"
 
+ORCAROUTER_PROVIDER_NAME = "orcarouter"
+ORCAROUTER_DEFAULT_API_BASE = "https://api.orcarouter.ai/v1"
+
 # Providers that use optional Bearer auth from custom_config
 PROVIDERS_WITH_SPECIAL_API_KEY_HANDLING: dict[str, str] = {
     LlmProviderNames.LM_STUDIO: LM_STUDIO_API_KEY_CONFIG_KEY,

--- a/backend/onyx/llm/well_known_providers/llm_provider_options.py
+++ b/backend/onyx/llm/well_known_providers/llm_provider_options.py
@@ -26,6 +26,7 @@ from onyx.llm.well_known_providers.constants import (
     OPENAI_COMPATIBLE_PROVIDER_NAME,
     OPENAI_PROVIDER_NAME,
     OPENROUTER_PROVIDER_NAME,
+    ORCAROUTER_PROVIDER_NAME,
     PORTKEY_PROVIDER_NAME,
     VERTEXAI_PROVIDER_NAME,
 )
@@ -61,6 +62,7 @@ def _get_provider_to_models_map() -> dict[str, list[str]]:
         OPENAI_COMPATIBLE_PROVIDER_NAME: [],  # Dynamic - fetched from OpenAI-compatible API
         NEBIUS_TOKENFACTORY_PROVIDER_NAME: [],  # Dynamic - fetched from /v1/models
         PORTKEY_PROVIDER_NAME: [],  # Dynamic - fetched from the Portkey gateway
+        ORCAROUTER_PROVIDER_NAME: [],  # Dynamic - fetched from /v1/models
     }
 
 
@@ -357,6 +359,7 @@ def get_provider_display_name(provider_name: str) -> str:
         OPENAI_COMPATIBLE_PROVIDER_NAME: "OpenAI-Compatible",
         NEBIUS_TOKENFACTORY_PROVIDER_NAME: "Nebius TokenFactory",
         PORTKEY_PROVIDER_NAME: "Portkey",
+        ORCAROUTER_PROVIDER_NAME: "OrcaRouter",
     }
 
     if provider_name in _ONYX_PROVIDER_DISPLAY_NAMES:

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -105,6 +105,8 @@ from onyx.server.manage.llm.models import (
     OpenRouterFinalModelResponse,
     OpenRouterModelDetails,
     OpenRouterModelsRequest,
+    OrcaRouterFinalModelResponse,
+    OrcaRouterModelsRequest,
     PortkeyFinalModelResponse,
     PortkeyModelsRequest,
     SyncModelEntry,
@@ -2296,6 +2298,113 @@ def get_portkey_available_models(
                 for r in sorted_results
             ],
             source_label="Portkey",
+        )
+
+    return sorted_results
+
+
+def _get_orcarouter_models_response(
+    api_base: str, api_key: str | None = None
+) -> dict:
+    """Fetch models from OrcaRouter's /v1/models endpoint.
+
+    OrcaRouter exposes a standard OpenAI-shaped /v1/models listing, so the base
+    may arrive as either `https://api.orcarouter.ai/v1` or `https://api.orcarouter.ai`.
+    """
+    cleaned_api_base = api_base.strip().rstrip("/")
+    if cleaned_api_base.endswith("/v1"):
+        url = f"{cleaned_api_base}/models"
+    else:
+        url = f"{cleaned_api_base}/v1/models"
+
+    return _get_openai_compatible_models_response(
+        url=url,
+        source_name="OrcaRouter",
+        api_key=api_key,
+    )
+
+
+@admin_router.post("/orcarouter/available-models")
+def get_orcarouter_available_models(
+    request: OrcaRouterModelsRequest,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> list[OrcaRouterFinalModelResponse]:
+    """Fetch available models from OrcaRouter's /v1/models endpoint."""
+    api_key = _resolve_api_key(
+        request.api_key, request.provider_id, request.api_base, db_session
+    )
+
+    response_json = _get_orcarouter_models_response(
+        api_base=request.api_base, api_key=api_key
+    )
+
+    models = response_json.get("data", [])
+    if not isinstance(models, list) or len(models) == 0:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "No models found from your OrcaRouter endpoint",
+        )
+
+    results: list[OrcaRouterFinalModelResponse] = []
+    for model in models:
+        try:
+            model_id = model.get("id", "")
+            model_name = model.get("name", model_id)
+
+            if not model_id:
+                continue
+
+            # Skip embedding models
+            if is_embedding_model(model_id):
+                continue
+
+            results.append(
+                OrcaRouterFinalModelResponse(
+                    name=model_id,
+                    display_name=model_name,
+                    max_input_tokens=model.get("context_length"),
+                    supports_image_input=litellm_thinks_model_supports_image_input(
+                        model_id, LlmProviderNames.ORCAROUTER
+                    ),
+                    # Reasoning support from the LiteLLM cost map, with the
+                    # substring heuristic covering models LiteLLM doesn't know
+                    supports_reasoning=model_is_reasoning_model(
+                        model_id, LlmProviderNames.ORCAROUTER
+                    )
+                    or is_reasoning_model(model_id, model_name),
+                )
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to parse OrcaRouter model entry",
+                extra={"error": str(e), "item": str(model)[:1000]},
+            )
+
+    if not results:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "No compatible models found from your OrcaRouter endpoint",
+        )
+
+    sorted_results = sorted(results, key=lambda m: m.name.lower())
+
+    # Sync new models to DB if provider_id is specified
+    if request.provider_id is not None:
+        _sync_fetched_models(
+            db_session=db_session,
+            provider_id=request.provider_id,
+            models=[
+                SyncModelEntry(
+                    name=r.name,
+                    display_name=r.display_name,
+                    max_input_tokens=r.max_input_tokens,
+                    supports_image_input=r.supports_image_input,
+                    supports_reasoning=r.supports_reasoning,
+                )
+                for r in sorted_results
+            ],
+            source_label="OrcaRouter",
         )
 
     return sorted_results

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -684,3 +684,19 @@ class PortkeyFinalModelResponse(BaseModel):
     max_input_tokens: int | None
     supports_image_input: bool
     supports_reasoning: bool
+
+
+# OrcaRouter dynamic models fetch
+class OrcaRouterModelsRequest(BaseModel):
+    api_base: str
+    api_key: str | None = None
+    # Existing provider id; resolves the stored key and syncs fetched models on edit
+    provider_id: int | None = None
+
+
+class OrcaRouterFinalModelResponse(BaseModel):
+    name: str  # Model ID (e.g. "orcarouter/fusion")
+    display_name: str  # Human-readable name from API
+    max_input_tokens: int | None
+    supports_image_input: bool
+    supports_reasoning: bool

--- a/backend/tests/unit/onyx/llm/test_orcarouter_routing.py
+++ b/backend/tests/unit/onyx/llm/test_orcarouter_routing.py
@@ -1,0 +1,53 @@
+"""Unit tests for OrcaRouter's OpenAI-compatible routing in LitellmLLM.
+
+OrcaRouter is a named OpenAI-compatible gateway with a single fixed API surface
+(OpenAI Chat Completions). These tests lock down the routing: custom_llm_provider
+"openai", a `/v1`-suffixed base, and a bare model name.
+"""
+
+from unittest.mock import patch
+
+from onyx.llm.api_surfaces import LlmApiSurface
+from onyx.llm.constants import LlmProviderNames
+from onyx.llm.models import LanguageModelInput, UserMessage
+from onyx.llm.multi_llm import LitellmLLM
+from onyx.llm.well_known_providers.constants import (
+    ORCAROUTER_DEFAULT_API_BASE,
+)
+
+
+def _make_orcarouter_llm(api_base: str) -> LitellmLLM:
+    return LitellmLLM(
+        api_key="sk-orca-test",
+        timeout=30,
+        model_provider=LlmProviderNames.ORCAROUTER,
+        model_name="orcarouter/fusion",
+        max_input_tokens=128_000,
+        api_base=api_base,
+    )
+
+
+def _completion_kwargs(llm: LitellmLLM) -> dict:
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages))
+        return dict(mock_completion.call_args.kwargs)
+
+
+def test_routes_via_openai_with_v1_base() -> None:
+    llm = _make_orcarouter_llm(ORCAROUTER_DEFAULT_API_BASE)
+    assert llm._custom_llm_provider == "openai"
+    assert llm._api_base == ORCAROUTER_DEFAULT_API_BASE
+    assert llm._api_surface is LlmApiSurface.OPENAI_CHAT_COMPLETIONS
+
+    kwargs = _completion_kwargs(llm)
+    assert kwargs["custom_llm_provider"] == "openai"
+    assert kwargs["base_url"] == ORCAROUTER_DEFAULT_API_BASE
+    # OpenAI-compatible proxies send a bare model name.
+    assert kwargs["model"] == "orcarouter/fusion"
+
+
+def test_bare_base_coerced_to_v1() -> None:
+    llm = _make_orcarouter_llm("https://api.orcarouter.ai")
+    assert llm._api_base == ORCAROUTER_DEFAULT_API_BASE

--- a/backend/tests/unit/onyx/server/manage/llm/test_orcarouter_models.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_orcarouter_models.py
@@ -1,0 +1,89 @@
+"""Tests for the OrcaRouter model fetcher.
+
+Verifies the mapping from OrcaRouter's OpenAI-shaped /v1/models response to Onyx
+model configs: embedding models dropped, context length mapped, id-less entries
+skipped, and results sorted by name.
+"""
+
+from typing import cast
+from unittest.mock import patch
+
+from sqlalchemy.orm import Session
+
+from onyx.db.models import User
+from onyx.server.manage.llm.api import get_orcarouter_available_models
+from onyx.server.manage.llm.models import OrcaRouterModelsRequest
+
+# Trimmed OpenAI-shaped /v1/models payload with two chat models, an embedding
+# model (must be dropped), and an id-less entry (must be skipped).
+_SAMPLE = {
+    "object": "list",
+    "data": [
+        {"id": "orcarouter/fusion", "name": "OrcaRouter Fusion", "context_length": 1000000},
+        {"id": "orcarouter/fusion-mini", "name": "OrcaRouter Fusion Mini", "context_length": 200000},
+        {"id": "text-embedding-3-large", "name": "Embedding", "context_length": 8191},
+        {"id": "", "name": "no id"},
+    ],
+}
+
+
+def _fetch(api_base: str = "https://api.orcarouter.ai/v1") -> dict:
+    with (
+        patch("onyx.server.manage.llm.api._resolve_api_key", return_value="sk-orca-key"),
+        patch(
+            "onyx.server.manage.llm.api._get_orcarouter_models_response",
+            return_value=_SAMPLE,
+        ),
+    ):
+        results = get_orcarouter_available_models(
+            request=OrcaRouterModelsRequest(
+                api_base=api_base,
+                api_key="sk-orca-key",
+                provider_id=None,  # skip DB sync
+            ),
+            _=cast(User, None),
+            db_session=cast(Session, None),
+        )
+    return {r.name: r for r in results}
+
+
+def test_embedding_and_idless_entries_dropped() -> None:
+    by_name = _fetch()
+    assert "text-embedding-3-large" not in by_name
+    # Only the two chat models remain (embedding + id-less entry dropped).
+    assert set(by_name) == {"orcarouter/fusion", "orcarouter/fusion-mini"}
+
+
+def test_context_length_mapped() -> None:
+    by_name = _fetch()
+    assert by_name["orcarouter/fusion"].max_input_tokens == 1000000
+    assert by_name["orcarouter/fusion-mini"].max_input_tokens == 200000
+
+
+def test_display_name_from_payload() -> None:
+    assert _fetch()["orcarouter/fusion"].display_name == "OrcaRouter Fusion"
+
+
+def test_results_sorted_by_name() -> None:
+    with (
+        patch("onyx.server.manage.llm.api._resolve_api_key", return_value="sk-orca-key"),
+        patch(
+            "onyx.server.manage.llm.api._get_orcarouter_models_response",
+            return_value=_SAMPLE,
+        ),
+    ):
+        results = get_orcarouter_available_models(
+            request=OrcaRouterModelsRequest(api_base="https://api.orcarouter.ai/v1"),
+            _=cast(User, None),
+            db_session=cast(Session, None),
+        )
+    assert [r.name for r in results] == [
+        "orcarouter/fusion",
+        "orcarouter/fusion-mini",
+    ]
+
+
+def test_bare_base_still_fetches() -> None:
+    # A base without /v1 still resolves /v1/models.
+    by_name = _fetch(api_base="https://api.orcarouter.ai")
+    assert set(by_name) == {"orcarouter/fusion", "orcarouter/fusion-mini"}

--- a/web/lib/opal/src/logos/index.ts
+++ b/web/lib/opal/src/logos/index.ts
@@ -71,6 +71,7 @@ export { default as SvgOnyxTyped } from "@opal/logos/onyx-typed";
 export { default as SvgOpenai } from "@opal/logos/openai";
 export { default as SvgOpenrouter } from "@opal/logos/openrouter";
 export { default as SvgOracle } from "@opal/logos/oracle";
+export { default as SvgOrcarouter } from "@opal/logos/orcarouter";
 export { default as SvgOutline } from "@opal/logos/outline";
 export { default as SvgOutlook } from "@opal/logos/outlook";
 export { default as SvgPerplexity } from "@opal/logos/perplexity";

--- a/web/lib/opal/src/logos/orcarouter.tsx
+++ b/web/lib/opal/src/logos/orcarouter.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import type { IconProps } from "@opal/types";
+
+// OrcaRouter wordmark fluke: a stylized orca tail that doubles as a router
+// node-graph (three tips feeding a single stem). Gradient id is per-instance so
+// repeated renders don't collide.
+const SvgOrcarouter = ({ size, ...props }: IconProps) => {
+  const gradientId = React.useId();
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <title>OrcaRouter</title>
+      <path
+        d="M12 3.5C10.5 4.5 8 6 5.5 6.8C2.5 7.8 0.5 8 0.5 8.8C0.5 9.6 3 9.6 6 9.4C8.5 9.2 10.5 10 12 13C13.5 10 15.5 9.2 18 9.4C21 9.6 23.5 9.6 23.5 8.8C23.5 8 21.5 7.8 18.5 6.8C16 6 13.5 4.5 12 3.5Z"
+        fill={`url(#${gradientId})`}
+      />
+      <defs>
+        <linearGradient
+          id={gradientId}
+          x1="0.5"
+          y1="3.5"
+          x2="23.5"
+          y2="13"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0" stopColor="#0B1220" />
+          <stop offset="1" stopColor="#3B82F6" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+};
+
+export default SvgOrcarouter;

--- a/web/src/lib/languageModels/index.ts
+++ b/web/src/lib/languageModels/index.ts
@@ -18,6 +18,7 @@ import {
   SvgGoogle,
   SvgNebius,
   SvgPortkey,
+  SvgOrcarouter,
 } from "@opal/logos";
 import { ZAIIcon } from "@/components/icons/icons";
 import {
@@ -39,6 +40,7 @@ import BifrostModal from "@/sections/modals/languageModels/BifrostModal";
 import OpenAICompatibleModal from "@/sections/modals/languageModels/OpenAICompatibleModal";
 import NebiusTokenfactoryModal from "@/sections/modals/languageModels/NebiusTokenfactoryModal";
 import PortkeyModal from "@/sections/modals/languageModels/PortkeyModal";
+import OrcaRouterModal from "@/sections/modals/languageModels/OrcaRouterModal";
 
 // ─── Text (LLM) providers ────────────────────────────────────────────────────
 
@@ -134,6 +136,12 @@ const PROVIDERS: Record<string, ProviderEntry> = {
     companyName: "Portkey",
     Modal: PortkeyModal,
   },
+  [LLMProviderName.ORCAROUTER]: {
+    icon: SvgOrcarouter,
+    productName: "OrcaRouter",
+    companyName: "OrcaRouter",
+    Modal: OrcaRouterModal,
+  },
   [LLMProviderName.CUSTOM]: {
     icon: SvgServer,
     productName: "Custom Models",
@@ -193,6 +201,7 @@ export const AGGREGATOR_PROVIDERS = new Set([
   LLMProviderName.OPENAI_COMPATIBLE,
   LLMProviderName.NEBIUS_TOKENFACTORY,
   LLMProviderName.PORTKEY,
+  LLMProviderName.ORCAROUTER,
   LLMProviderName.VERTEX_AI,
 ]);
 
@@ -211,6 +220,7 @@ const MODEL_ICON_MAP: Record<string, IconFunctionComponent> = {
   [LLMProviderName.OPENAI_COMPATIBLE]: SvgPlug,
   [LLMProviderName.NEBIUS_TOKENFACTORY]: SvgNebius,
   [LLMProviderName.PORTKEY]: SvgPortkey,
+  [LLMProviderName.ORCAROUTER]: SvgOrcarouter,
 
   amazon: SvgAws,
   gpt: SvgOpenai,

--- a/web/src/lib/languageModels/svc.ts
+++ b/web/src/lib/languageModels/svc.ts
@@ -32,6 +32,8 @@ import {
   type NebiusTokenfactoryModelResponse,
   type PortkeyFetchParams,
   type PortkeyModelResponse,
+  type OrcaRouterFetchParams,
+  type OrcaRouterModelResponse,
 } from "@/lib/languageModels/types";
 
 /**
@@ -110,6 +112,7 @@ export const AGGREGATOR_PROVIDERS = new Set([
   "bifrost",
   "openai_compatible",
   "vertex_ai",
+  "orcarouter",
 ]);
 
 export const isAnthropic = (provider: string, modelName?: string) =>
@@ -613,6 +616,13 @@ export const fetchModels = async (
         provider_id: formValues.id,
         signal,
       });
+    case LLMProviderName.ORCAROUTER:
+      return fetchOrcaRouterModels({
+        api_base: formValues.api_base,
+        api_key: formValues.api_key,
+        provider_id: formValues.id,
+        signal,
+      });
     default:
       return { models: [], error: `Unknown provider: ${providerName}` };
   }
@@ -723,6 +733,62 @@ export const fetchPortkeyModels = async (
     }
 
     const data: PortkeyModelResponse[] = await response.json();
+    const models: ModelConfiguration[] = data.map((modelData) => ({
+      name: modelData.name,
+      display_name: modelData.display_name,
+      is_visible: true,
+      max_input_tokens: modelData.max_input_tokens,
+      supports_image_input: modelData.supports_image_input,
+      supports_reasoning: modelData.supports_reasoning,
+      effectiveDisplayName: modelData.display_name || modelData.name,
+    }));
+
+    return { models };
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    return { models: [], error: errorMessage };
+  }
+};
+
+/** Fetches models from OrcaRouter's /v1/models endpoint. */
+export const fetchOrcaRouterModels = async (
+  params: OrcaRouterFetchParams
+): Promise<{ models: ModelConfiguration[]; error?: string }> => {
+  const apiBase = params.api_base;
+  if (!apiBase) {
+    return { models: [], error: "API Base is required" };
+  }
+
+  try {
+    const response = await fetch("/api/admin/llm/orcarouter/available-models", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        api_base: apiBase,
+        api_key: params.api_key,
+        provider_id: params.provider_id,
+      }),
+      signal: params.signal,
+    });
+
+    if (!response.ok) {
+      let errorMessage = "Failed to fetch models";
+      try {
+        const errorData = await response.json();
+        errorMessage = errorData.detail || errorData.message || errorMessage;
+      } catch (jsonError) {
+        console.warn(
+          "Failed to parse OrcaRouter model fetch error response",
+          jsonError
+        );
+      }
+      return { models: [], error: errorMessage };
+    }
+
+    const data: OrcaRouterModelResponse[] = await response.json();
     const models: ModelConfiguration[] = data.map((modelData) => ({
       name: modelData.name,
       display_name: modelData.display_name,

--- a/web/src/lib/languageModels/types.ts
+++ b/web/src/lib/languageModels/types.ts
@@ -57,6 +57,7 @@ export enum LLMProviderName {
   OPENAI_COMPATIBLE = "openai_compatible",
   NEBIUS_TOKENFACTORY = "nebius_tokenfactory",
   PORTKEY = "portkey",
+  ORCAROUTER = "orcarouter",
   CUSTOM = "custom",
 }
 
@@ -266,6 +267,21 @@ export interface PortkeyModelResponse {
   supports_reasoning: boolean;
 }
 
+export interface OrcaRouterFetchParams {
+  api_base?: string;
+  api_key?: string;
+  provider_id?: number;
+  signal?: AbortSignal;
+}
+
+export interface OrcaRouterModelResponse {
+  name: string;
+  display_name: string;
+  max_input_tokens: number | null;
+  supports_image_input: boolean;
+  supports_reasoning: boolean;
+}
+
 export interface VertexAIFetchParams {
   model_configurations?: ModelConfiguration[];
 }
@@ -286,4 +302,5 @@ export type FetchModelsParams =
   | BifrostFetchParams
   | OpenAICompatibleFetchParams
   | VertexAIFetchParams
-  | LMStudioFetchParams;
+  | LMStudioFetchParams
+  | OrcaRouterFetchParams;

--- a/web/src/sections/modals/languageModels/OrcaRouterModal.tsx
+++ b/web/src/sections/modals/languageModels/OrcaRouterModal.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { markdown } from "@opal/utils";
+import { useSWRConfig } from "swr";
+import { useFormikContext } from "formik";
+import { InputDivider, toast } from "@opal/layouts";
+import {
+  LLMProviderFormProps,
+  LLMProviderName,
+  LLMProviderView,
+} from "@/lib/languageModels/types";
+import { fetchOrcaRouterModels } from "@/lib/languageModels/svc";
+import {
+  useInitialValues,
+  buildValidationSchema,
+  BaseLLMFormValues,
+  mergeFetchedModelConfigurations,
+} from "@/sections/modals/languageModels/utils";
+import { submitProvider } from "@/sections/modals/languageModels/svc";
+import { LLMProviderConfiguredSource } from "@/lib/analytics/utils";
+import {
+  APIBaseField,
+  APIKeyField,
+  ModelSelectionField,
+  DisplayNameField,
+  ModelAccessField,
+  ModalWrapper,
+} from "@/sections/modals/languageModels/shared";
+import { refreshLlmProviderCaches } from "@/lib/languageModels/cache";
+
+const DEFAULT_API_BASE = "https://api.orcarouter.ai/v1";
+const DEFAULT_DISPLAY_NAME = "OrcaRouter Gateway";
+
+interface OrcaRouterModalValues extends BaseLLMFormValues {
+  api_key: string;
+  api_base: string;
+}
+
+interface OrcaRouterModalInternalsProps {
+  existingLlmProvider: LLMProviderView | undefined;
+  isOnboarding: boolean;
+}
+
+function OrcaRouterModalInternals({
+  existingLlmProvider,
+  isOnboarding,
+}: OrcaRouterModalInternalsProps) {
+  const formikProps = useFormikContext<OrcaRouterModalValues>();
+  const { setFieldValue } = formikProps;
+
+  const isFetchDisabled = !formikProps.values.api_base;
+
+  const handleFetchModels = async () => {
+    const { models, error } = await fetchOrcaRouterModels({
+      api_base: formikProps.values.api_base,
+      api_key: formikProps.values.api_key || undefined,
+      provider_id: existingLlmProvider?.id ?? undefined,
+    });
+    if (error) {
+      throw new Error(error);
+    }
+    formikProps.setFieldValue(
+      "model_configurations",
+      mergeFetchedModelConfigurations(
+        models,
+        formikProps.values.model_configurations
+      )
+    );
+  };
+
+  // When editing a saved provider, the models load from the DB without the
+  // per-model metadata (context/flag/quantization/features) — so refetch once
+  // on open to make the picker match the "add" view. Best-effort: ignore
+  // errors so the modal still works if the provider is unreachable.
+  const autoRefetched = useRef(false);
+  useEffect(() => {
+    if (autoRefetched.current || !existingLlmProvider?.id) return;
+    if (!formikProps.values.api_base) return;
+    autoRefetched.current = true;
+    fetchOrcaRouterModels({
+      api_base: formikProps.values.api_base,
+      api_key: formikProps.values.api_key || undefined,
+      provider_id: existingLlmProvider.id,
+    })
+      .then(({ models }) => {
+        if (models.length > 0) {
+          setFieldValue(
+            "model_configurations",
+            mergeFetchedModelConfigurations(
+              models,
+              formikProps.values.model_configurations
+            )
+          );
+        }
+      })
+      .catch(() => undefined);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <>
+      <APIBaseField
+        subDescription="OrcaRouter endpoint URL (including API version)."
+        placeholder={DEFAULT_API_BASE}
+      />
+
+      <APIKeyField
+        subDescription={markdown(
+          "Paste your API key from [OrcaRouter](https://www.orcarouter.ai/) to load the available models."
+        )}
+      />
+
+      {!isOnboarding && (
+        <>
+          <InputDivider />
+          <DisplayNameField />
+        </>
+      )}
+
+      <InputDivider />
+      <ModelSelectionField
+        shouldShowAutoUpdateToggle={false}
+        onRefetch={isFetchDisabled ? undefined : handleFetchModels}
+      />
+
+      {!isOnboarding && (
+        <>
+          <InputDivider />
+          <ModelAccessField />
+        </>
+      )}
+    </>
+  );
+}
+
+export default function OrcaRouterModal({
+  variant = "llm-configuration",
+  existingLlmProvider,
+  shouldMarkAsDefault,
+  onOpenChange,
+  onSuccess,
+  analyticsSource,
+}: LLMProviderFormProps) {
+  const isOnboarding = variant === "onboarding";
+  const { mutate } = useSWRConfig();
+
+  const onClose = () => onOpenChange?.(false);
+
+  const initialValues: OrcaRouterModalValues = useInitialValues(
+    isOnboarding,
+    LLMProviderName.ORCAROUTER,
+    existingLlmProvider
+  ) as OrcaRouterModalValues;
+
+  // OrcaRouter always uses the same base; default it whenever it's missing
+  // (new provider, or an edit where the base wasn't persisted) so the model
+  // refetch always has a valid endpoint.
+  if (!initialValues.api_base) {
+    initialValues.api_base = DEFAULT_API_BASE;
+  }
+  if (!isOnboarding && !initialValues.name) {
+    initialValues.name = DEFAULT_DISPLAY_NAME;
+  }
+
+  const validationSchema = buildValidationSchema(isOnboarding, {
+    apiBase: true,
+    apiKey: true,
+  });
+
+  return (
+    <ModalWrapper
+      providerName={LLMProviderName.ORCAROUTER}
+      llmProvider={existingLlmProvider}
+      onClose={onClose}
+      description="Connect to OrcaRouter and set up compatible models."
+      initialValues={initialValues}
+      validationSchema={validationSchema}
+      onSubmit={async (values, { setSubmitting, setStatus }) => {
+        await submitProvider({
+          analyticsSource:
+            analyticsSource ??
+            (isOnboarding
+              ? LLMProviderConfiguredSource.CHAT_ONBOARDING
+              : LLMProviderConfiguredSource.ADMIN_PAGE),
+          providerName: LLMProviderName.ORCAROUTER,
+          values,
+          initialValues,
+          existingLlmProvider,
+          shouldMarkAsDefault,
+          setStatus,
+          setSubmitting,
+          onClose,
+          onSuccess: async () => {
+            if (onSuccess) {
+              await onSuccess();
+            } else {
+              await refreshLlmProviderCaches(mutate);
+              toast.success(
+                existingLlmProvider
+                  ? "Provider updated successfully!"
+                  : "Provider enabled successfully!"
+              );
+            }
+          },
+        });
+      }}
+    >
+      <OrcaRouterModalInternals
+        existingLlmProvider={existingLlmProvider}
+        isOnboarding={isOnboarding}
+      />
+    </ModalWrapper>
+  );
+}

--- a/web/src/views/admin/LanguageModelsPage.tsx
+++ b/web/src/views/admin/LanguageModelsPage.tsx
@@ -77,6 +77,7 @@ const PROVIDER_GROUPS: ProviderGroup[] = [
       LLMProviderName.PORTKEY,
       LLMProviderName.NEBIUS_TOKENFACTORY,
       LLMProviderName.BIFROST,
+      LLMProviderName.ORCAROUTER,
     ],
   },
   {


### PR DESCRIPTION
## Description

Adds [OrcaRouter](https://www.orcarouter.ai) as a first-class model provider, mirroring the existing named-gateway pattern used for OpenRouter, Bifrost, Nebius TokenFactory, and Portkey. OrcaRouter is an OpenAI-compatible model routing gateway that exposes models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key.

What this changes:

- **Backend** (`backend/onyx/llm/`, `backend/onyx/server/manage/llm/`):
  - Registers `orcarouter` in `LlmProviderNames`, `WELL_KNOWN_PROVIDER_NAMES`, and the display-name maps.
  - Adds the `ORCAROUTER_DEFAULT_API_BASE` constant (`https://api.orcarouter.ai/v1`) and a static OpenAI Chat Completions API surface, so requests route through LiteLLM's OpenAI-compatible path with automatic `/v1` base coercion.
  - Adds `ORCAROUTER_DEFAULT_API_KEY` env var, matching the existing `OPENROUTER_DEFAULT_API_KEY` seeding pattern.
  - Adds a `POST /api/admin/llm/orcarouter/available-models` endpoint that fetches the model catalog from OrcaRouter's `/v1/models` listing (embedding models dropped, context length mapped, results sorted), mirroring the Portkey fetcher.
- **Frontend** (`web/src/`):
  - Registers the provider in the admin model picker ("Gateways & Routers" group) with a new OrcaRouter logo, plus a dedicated `OrcaRouterModal` for connecting the provider and loading models.
  - Adds `fetchOrcaRouterModels` to the model-fetch service and wires the provider into the model-icon resolver.

## Why a separate provider rather than the OpenAI-compatible escape hatch

This mirrors how OpenRouter / Portkey / Bifrost are wired in this repo, so the model picker, admin config and model-fetch flow stay consistent for users who already run those gateways. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## How Has This Been Tested?

- Backend unit tests added:
  - `backend/tests/unit/onyx/server/manage/llm/test_orcarouter_models.py` — model-catalog mapping (embedding/id-less entries dropped, context length, sorting, `/v1` base handling).
  - `backend/tests/unit/onyx/llm/test_orcarouter_routing.py` — OpenAI-compatible routing (custom provider, `/v1` coercion, bare model name).
- Frontend changes are type-checked and covered by the existing model-picker tests in CI.
- Live API check against `https://api.orcarouter.ai/v1` with a real API key:
  - `GET /v1/models` returns the model catalog (`orcarouter/free`, `orcarouter/fusion`, …) with `context_length` per model.
  - `POST /v1/chat/completions` returns 200 with a completion.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.

---

I'm an engineer on the OrcaRouter team.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OrcaRouter as a first-class LLM provider routed through the OpenAI Chat Completions surface. Previously, teams configured OrcaRouter via the generic OpenAI‑compatible provider; now it appears in the model picker with a dedicated models fetcher and DB sync.

- Registers `orcarouter` across backend provider enums and display maps, fixes its API surface to OpenAI Chat Completions, and coerces bare bases to `/v1` for LiteLLM routing.
- Adds `ORCAROUTER_DEFAULT_API_KEY` for optional provider seeding and sets the default API base to `https://api.orcarouter.ai/v1`.
- Introduces `POST /api/admin/llm/orcarouter/available-models` that reads `/v1/models`, drops embeddings, maps `context_length`, infers image/reasoning support, sorts, and optionally syncs models to the provider.
- Frontend adds `OrcaRouter` to the “Gateways & Routers” group with a new logo, `OrcaRouterModal` for connect-and-fetch, and a `fetchOrcaRouterModels` service wired into model icons and the picker.
- Tests cover OpenAI-compatible routing (`/v1` coercion and bare model) and model-catalog mapping (filtering, context length, sorting).

<sup>Written for commit f52b25ea72255bda34f53597f0901226c612f267. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

