### PR TITLE
fix(llm): parse LM Studio option-object capabilities

### DIFF
--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1638,32 +1638,38 @@ def get_lm_studio_available_models(
 
     results: list[LMStudioFinalModelResponse] = []
     for item in models:
-        # Filter to LLM-type models only (skip embeddings, etc.)
-        if item.get("type") != "llm":
-            continue
+        try:
+            # Filter to LLM-type models only (skip embeddings, etc.)
+            if item.get("type") != "llm":
+                continue
 
-        model_key = item.get("key")
-        if not model_key:
-            continue
+            model_key = item.get("key")
+            if not model_key:
+                continue
 
-        display_name = item.get("display_name") or model_key
-        max_context_length = item.get("max_context_length")
-        capabilities = item.get("capabilities") or {}
+            display_name = item.get("display_name") or model_key
+            max_context_length = item.get("max_context_length")
+            capabilities = item.get("capabilities") or {}
 
-        results.append(
-            LMStudioFinalModelResponse(
-                name=model_key,
-                display_name=display_name,
-                max_input_tokens=max_context_length,
-                supports_image_input=lm_studio_capability_enabled(
-                    capabilities.get("vision")
-                ),
-                supports_reasoning=lm_studio_capability_enabled(
-                    capabilities.get("reasoning")
+            results.append(
+                LMStudioFinalModelResponse(
+                    name=model_key,
+                    display_name=display_name,
+                    max_input_tokens=max_context_length,
+                    supports_image_input=lm_studio_capability_enabled(
+                        capabilities.get("vision")
+                    ),
+                    supports_reasoning=lm_studio_capability_enabled(
+                        capabilities.get("reasoning")
+                    )
+                    or is_reasoning_model(model_key, display_name),
                 )
-                or is_reasoning_model(model_key, display_name),
             )
-        )
+        except Exception as e:
+            logger.warning(
+                "Failed to parse LM Studio model entry",
+                extra={"error": str(e), "item": str(item)[:1000]},
+            )
 
     if not results:
         raise OnyxError(

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -123,6 +123,7 @@ from onyx.server.manage.llm.utils import (
     is_embedding_model,
     is_reasoning_model,
     is_valid_bedrock_model,
+    lm_studio_capability_enabled,
     strip_openrouter_vendor_prefix,
 )
 from onyx.utils.audit import (
@@ -1654,8 +1655,12 @@ def get_lm_studio_available_models(
                 name=model_key,
                 display_name=display_name,
                 max_input_tokens=max_context_length,
-                supports_image_input=capabilities.get("vision", False),
-                supports_reasoning=capabilities.get("reasoning", False)
+                supports_image_input=lm_studio_capability_enabled(
+                    capabilities.get("vision")
+                ),
+                supports_reasoning=lm_studio_capability_enabled(
+                    capabilities.get("reasoning")
+                )
                 or is_reasoning_model(model_key, display_name),
             )
         )

--- a/backend/onyx/server/manage/llm/utils.py
+++ b/backend/onyx/server/manage/llm/utils.py
@@ -8,7 +8,7 @@ Utilities for dynamic LLM providers (Bedrock, Ollama, OpenRouter):
 """
 
 import re
-from typing import Any, TypedDict
+from typing import TypedDict
 
 from onyx.llm.constants import (
     BEDROCK_MODEL_NAME_MAPPINGS,
@@ -241,7 +241,7 @@ def is_reasoning_model(model_id: str, display_name: str) -> bool:
     return any(pattern in combined for pattern in REASONING_MODEL_PATTERNS)
 
 
-def lm_studio_capability_enabled(value: Any) -> bool:
+def lm_studio_capability_enabled(value: object) -> bool:
     """Read one entry of an LM Studio `capabilities` object as a boolean.
 
     LM Studio reports a capability either as a plain boolean or as an options

--- a/backend/onyx/server/manage/llm/utils.py
+++ b/backend/onyx/server/manage/llm/utils.py
@@ -8,7 +8,7 @@ Utilities for dynamic LLM providers (Bedrock, Ollama, OpenRouter):
 """
 
 import re
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from onyx.llm.constants import (
     BEDROCK_MODEL_NAME_MAPPINGS,
@@ -239,6 +239,27 @@ def is_reasoning_model(model_id: str, display_name: str) -> bool:
     """
     combined = f"{model_id} {display_name}".lower()
     return any(pattern in combined for pattern in REASONING_MODEL_PATTERNS)
+
+
+def lm_studio_capability_enabled(value: Any) -> bool:
+    """Read one entry of an LM Studio `capabilities` object as a boolean.
+
+    LM Studio reports a capability either as a plain boolean or as an options
+    object, for example
+    `{"allowed_options": ["off", "low", "high"], "default": "off"}`.
+    An options object means the model supports the capability, unless "off" is
+    the only allowed option.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, dict):
+        allowed_options = value.get("allowed_options")
+        if isinstance(allowed_options, list):
+            return any(str(option).lower() != "off" for option in allowed_options)
+        return True
+    if isinstance(value, str):
+        return value.lower() not in {"", "off", "false", "none"}
+    return bool(value)
 
 
 def extract_base_model_name(model: str) -> str | None:

--- a/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
@@ -601,6 +601,60 @@ class TestGetLMStudioAvailableModels:
             assert deepseek.supports_reasoning is True
             assert llama.supports_reasoning is False
 
+    def test_reads_capabilities_given_as_options_objects(self) -> None:
+        """Test that option-object capabilities are read as booleans.
+
+        Newer LM Studio servers describe a capability with an object such as
+        {"allowed_options": ["off", "on"], "default": "on"} instead of a bool.
+        """
+        from onyx.server.manage.llm.api import get_lm_studio_available_models
+
+        mock_session = MagicMock()
+        response = {
+            "models": [
+                {
+                    "key": "openai/gpt-oss-20b",
+                    "type": "llm",
+                    "display_name": "gpt-oss 20B",
+                    "max_context_length": 131072,
+                    "capabilities": {
+                        "reasoning": {
+                            "allowed_options": ["off", "low", "medium", "high"],
+                            "default": "medium",
+                        },
+                        "vision": {"allowed_options": ["off", "on"], "default": "on"},
+                    },
+                },
+                {
+                    "key": "lmstudio-community/Meta-Llama-3-8B",
+                    "type": "llm",
+                    "display_name": "Meta Llama 3 8B",
+                    "max_context_length": 8192,
+                    "capabilities": {
+                        "reasoning": {"allowed_options": ["off"], "default": "off"},
+                        "vision": False,
+                    },
+                },
+            ]
+        }
+
+        with patch("onyx.server.manage.llm.api.httpx") as mock_httpx:
+            mock_response = MagicMock()
+            mock_response.json.return_value = response
+            mock_response.raise_for_status = MagicMock()
+            mock_httpx.get.return_value = mock_response
+
+            request = LMStudioModelsRequest(api_base="http://localhost:1234")
+            results = get_lm_studio_available_models(request, MagicMock(), mock_session)
+
+            gpt_oss = next(r for r in results if "gpt-oss" in r.name)
+            llama = next(r for r in results if "Llama" in r.name)
+
+            assert gpt_oss.supports_reasoning is True
+            assert gpt_oss.supports_image_input is True
+            assert llama.supports_reasoning is False
+            assert llama.supports_image_input is False
+
     def test_uses_display_name_from_api(self, mock_lm_studio_response: dict) -> None:
         """Test that display_name from the API is used directly."""
         from onyx.server.manage.llm.api import get_lm_studio_available_models


### PR DESCRIPTION
## Description

Newer LM Studio servers report a model capability as an options object, for example `{"allowed_options": ["off", "on"], "default": "on"}`, instead of a boolean. `/lm-studio/available-models` passed that raw value into the `supports_reasoning` bool field, so the request failed:

```
1 validation error for LMStudioFinalModelResponse
supports_reasoning
  Input should be a valid boolean [type=bool_type, input_value={'allowed_options': ['off... 'on'], 'default': 'on'}, ...]
```

Admins could not list models from an LM Studio provider.

## Changes

- Add `lm_studio_capability_enabled()` in `backend/onyx/server/manage/llm/utils.py`. It reads a capability given as a bool, an options object, or a string. An options object counts as supported unless `"off"` is the only allowed option.
- Use the helper for the `vision` and `reasoning` capabilities in `get_lm_studio_available_models`.

## Tests

Added a unit test in `backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py` that feeds option-object capabilities and checks the parsed booleans. Full file: 52 passed.

Closes #13817

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] [Optional] Please cherry-pick this PR to the latest release version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LM Studio model listing with newer servers by normalizing option-object capabilities and isolating bad entries. Previously, the endpoint passed option objects into boolean fields and failed validation for the entire list; now it converts values to booleans and skips only unparsable items.

- Add `lm_studio_capability_enabled(value: object)` to read capabilities from booleans, option objects, or strings; option objects count as supported unless "off" is the only allowed option.
- Use the helper for `supports_image_input` (vision) and `supports_reasoning`; keep the name-based reasoning fallback.
- Wrap per-model parsing in try/except, log a warning, and continue so one bad upstream entry doesn’t block the list.
- Add a unit test covering option-object capabilities. No API or config changes.

Fixes #13817

<sup>Written for commit df7047da8411de4cc031a8c44917a5dd6d66a15f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

