### PR TITLE
fix(ci): unbreak the Helm chart release workflow

### DIFF
--- a/.github/workflows/helm-chart-releases.yml
+++ b/.github/workflows/helm-chart-releases.yml
@@ -100,7 +100,11 @@ jobs:
           echo "Packaged onyx ${version} -> ${package}"
 
       - name: Publish GitHub release and gh-pages index
-        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # ratchet:helm/chart-releaser-action@v1.7.0
+        # HEAD of main, one commit past v1.7.0. v1.7.0 reads `latest_tag` after
+        # the branch that defines it, so `skip_packaging` makes cr.sh exit 1 on
+        # an unbound variable AFTER the release and the index are published.
+        # Move back to a tag once one ships past that fix.
+        uses: helm/chart-releaser-action@3e001cb8c68933439c7e721650f20a07a1a5c61e # ratchet:helm/chart-releaser-action@main
         with:
           config: cr.yaml
           # We already packaged into PACKAGE_DIR above.

--- a/.github/workflows/helm-chart-releases.yml
+++ b/.github/workflows/helm-chart-releases.yml
@@ -52,6 +52,15 @@ jobs:
           # cr authenticates with CR_TOKEN, not the git credential helper.
           persist-credentials: false
 
+      # `cr index` commits index.yaml in a gh-pages worktree. The worktree
+      # shares this repository config, and chart-releaser-action has no input
+      # for the committer, so the identity must be set here or the commit
+      # fails with "empty ident name".
+      - name: Configure the git committer
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Install Helm CLI
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # ratchet:azure/setup-helm@v5.0.1
         with:


### PR DESCRIPTION
## Problem

The first run of the new chart publisher (#13966) failed. Three separate causes, found in order:

1. **Transient.** `cr upload` got a `POST /repos/onyx-dot-app/onyx/releases: 500` from GitHub. A re-run of the same job succeeded, so no code change is needed — `skip_existing: true` already makes re-runs safe.

2. **No git committer.** `cr index` commits `index.yaml` into a gh-pages worktree, and the workflow set no identity:

   ```
   fatal: empty ident name (for <runner@runnervm...>) not allowed
   ```

   `stefanprodan/helm-gh-pages`, the publisher this replaced, took `commit_username` and `commit_email` inputs. `helm/chart-releaser-action` has no such input, so the committer must be set on the checkout.

3. **Upstream bug reached through `skip_packaging`.** With the committer fixed, the run published the release and pushed the index, then still exited 1:

   ```
   cr.sh: line 111: latest_tag: unbound variable
   ```

   `cr.sh` v1.7.0 defines `latest_tag` only inside its packaging branch but reads it unconditionally at the end. `set -u` then kills the step after all the real work is done, so the GHCR steps never ran.

## Fix

- Add a `Configure the git committer` step setting `github-actions[bot]`. The worktree cr creates shares the repository config, so a local `git config` is enough.
- Pin `chart-releaser-action` to `3e001cb`, the HEAD of `main`. That is [`Write chart_version only if latest_tag is defined (#202)`](https://github.com/helm/chart-releaser-action/commit/3e001cb8c68933439c7e721650f20a07a1a5c61e), merged one day after v1.7.0 was cut. Upstream has tagged nothing since. The whole delta from v1.7.0 is that fix plus ARM64 support. A comment says to move back to a tag once one ships.

## Testing

`workflow_dispatch` off this branch, [run 31821811660](https://github.com/onyx-dot-app/onyx/actions/runs/31821811660) — green, all three channels published for 0.8.16:

- release [`helm/onyx-0.8.16`](https://github.com/onyx-dot-app/onyx/releases/tag/helm/onyx-0.8.16) with `onyx-0.8.16.tgz`
- `index.yaml` on gh-pages, live at https://onyx-dot-app.github.io/onyx/index.yaml, pointing at the release asset (asset downloads, 666 KB, valid chart tarball)
- `ghcr.io/onyx-dot-app/charts/onyx:0.8.16`, digest `sha256:4a16402944c9b2...`

The idempotency guards all held on that run: `cr upload` skipped the existing release, `cr index` reported "did not change" on a repeat, and the GHCR guard is in place for the next re-run.

`zizmor` and `actionlint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)