### PR TITLE
feat: add PKCE support to connector OAuth

### DIFF
--- a/backend/onyx/auth/pkce.py
+++ b/backend/onyx/auth/pkce.py
@@ -1,12 +1,8 @@
-"""PKCE (RFC 7636) S256 transform for the mobile SSO bridge.
-
-Used by the mobile SSO code store to verify the app's ``code_verifier``. The web
-OAuth flow computes the same transform independently in
-``users.generate_pkce_pair``; a test pins that the two agree so they can't drift.
-"""
+"""PKCE (RFC 7636) S256 helpers for OAuth flows."""
 
 import base64
 import hashlib
+import secrets
 
 
 def compute_s256_challenge(code_verifier: str) -> str:
@@ -17,3 +13,8 @@ def compute_s256_challenge(code_verifier: str) -> str:
     """
     digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def generate_pkce_pair() -> tuple[str, str]:
+    code_verifier = secrets.token_urlsafe(64)
+    return code_verifier, compute_s256_challenge(code_verifier)

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1,4 +1,3 @@
-import base64
 import hashlib
 import os
 import random
@@ -79,6 +78,7 @@ from onyx.auth.mobile_sso.sso_completion import (
 )
 from onyx.auth.pat import get_hashed_pat_from_request
 from onyx.auth.permissions import has_global_permission
+from onyx.auth.pkce import generate_pkce_pair
 from onyx.auth.schemas import AuthBackend, UserCreate
 from onyx.auth.session_tokens import (
     SESSION_TOKEN_GRACE_PERIOD_SECONDS,
@@ -2450,16 +2450,6 @@ def generate_state_token(
 
 def generate_csrf_token() -> str:
     return secrets.token_urlsafe(32)
-
-
-def _base64url_encode(data: bytes) -> str:
-    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
-
-
-def generate_pkce_pair() -> tuple[str, str]:
-    verifier = secrets.token_urlsafe(64)
-    challenge = _base64url_encode(hashlib.sha256(verifier.encode("ascii")).digest())
-    return verifier, challenge
 
 
 def get_pkce_cookie_name(state: str) -> str:

--- a/backend/onyx/connectors/egnyte/connector.py
+++ b/backend/onyx/connectors/egnyte/connector.py
@@ -161,6 +161,7 @@ class EgnyteConnector(LoadConnector, PollConnector, OAuthConnector):
         base_domain: str,
         state: str,
         additional_kwargs: dict[str, str],
+        code_challenge: str | None = None,  # noqa: ARG003
     ) -> str:
         if not EGNYTE_CLIENT_ID:
             raise ValueError("EGNYTE_CLIENT_ID environment variable must be set")
@@ -183,6 +184,7 @@ class EgnyteConnector(LoadConnector, PollConnector, OAuthConnector):
         base_domain: str,
         code: str,
         additional_kwargs: dict[str, str],
+        code_verifier: str | None = None,  # noqa: ARG003
     ) -> dict[str, Any]:
         if not EGNYTE_CLIENT_ID:
             raise ValueError("EGNYTE_CLIENT_ID environment variable must be set")

--- a/backend/onyx/connectors/interfaces.py
+++ b/backend/onyx/connectors/interfaces.py
@@ -1,7 +1,7 @@
 import abc
 from collections.abc import Generator, Iterator
 from types import TracebackType
-from typing import Any, Generic, TypeAlias, TypeVar
+from typing import Any, ClassVar, Generic, TypeAlias, TypeVar
 
 from pydantic import BaseModel, Field
 
@@ -158,6 +158,8 @@ class SlimConnectorWithPermSync(BaseConnector):
 
 
 class OAuthConnector(BaseConnector):
+    supports_pkce: ClassVar[bool] = False
+
     class AdditionalOauthKwargs(BaseModel):
         # if overridden, all fields should be str type
         pass
@@ -174,6 +176,7 @@ class OAuthConnector(BaseConnector):
         base_domain: str,
         state: str,
         additional_kwargs: dict[str, str],
+        code_challenge: str | None = None,
     ) -> str:
         raise NotImplementedError
 
@@ -184,6 +187,7 @@ class OAuthConnector(BaseConnector):
         base_domain: str,
         code: str,
         additional_kwargs: dict[str, str],
+        code_verifier: str | None = None,
     ) -> dict[str, Any]:
         raise NotImplementedError
 

--- a/backend/onyx/connectors/linear/connector.py
+++ b/backend/onyx/connectors/linear/connector.py
@@ -96,6 +96,7 @@ class LinearConnector(LoadConnector, PollConnector, OAuthConnector):
         base_domain: str,
         state: str,
         additional_kwargs: dict[str, str],  # noqa: ARG003
+        code_challenge: str | None = None,  # noqa: ARG003
     ) -> str:
         if not LINEAR_CLIENT_ID:
             raise ValueError("LINEAR_CLIENT_ID environment variable must be set")
@@ -117,6 +118,7 @@ class LinearConnector(LoadConnector, PollConnector, OAuthConnector):
         base_domain: str,
         code: str,
         additional_kwargs: dict[str, str],  # noqa: ARG003
+        code_verifier: str | None = None,  # noqa: ARG003
     ) -> dict[str, Any]:
         data = {
             "code": code,

--- a/backend/onyx/redis/tenant_redis_client.py
+++ b/backend/onyx/redis/tenant_redis_client.py
@@ -146,6 +146,10 @@ class TenantRedisClient:
         """
         return cast("bytes | None", self._r.get(_prefix_key(self._prefix, name)))
 
+    def getdel(self, name: KeyArg) -> bytes | None:
+        """Atomically gets and deletes a tenant-prefixed key."""
+        return cast("bytes | None", self._r.getdel(_prefix_key(self._prefix, name)))
+
     def mget(self, names: Sequence[KeyArg]) -> list[bytes | None]:
         """Issues an MGET against tenant-prefixed keys.
 

--- a/backend/onyx/server/documents/standard_oauth.py
+++ b/backend/onyx/server/documents/standard_oauth.py
@@ -1,12 +1,12 @@
-import json
 import uuid
 from typing import Annotated, cast
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, Query, Request
 from pydantic import BaseModel, ValidationError
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
+from onyx.auth.pkce import generate_pkce_pair
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.interfaces import OAuthConnector
@@ -14,6 +14,8 @@ from onyx.db.credentials import create_credential
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.documents.models import CredentialBase
 from onyx.utils.logger import setup_logger
@@ -25,9 +27,7 @@ logger = setup_logger()
 router = APIRouter(prefix="/connector/oauth")
 
 _OAUTH_STATE_KEY_FMT = "oauth_state:{state}"
-_OAUTH_STATE_EXPIRATION_SECONDS = 10 * 60  # 10 minutes
-_DESIRED_RETURN_URL_KEY = "desired_return_url"
-_ADDITIONAL_KWARGS_KEY = "additional_kwargs"
+_OAUTH_STATE_EXPIRATION_SECONDS = 10 * 60
 
 # Cache for OAuth connectors, populated at module load time
 _OAUTH_CONNECTORS: dict[DocumentSource, type[OAuthConnector]] = {}
@@ -55,24 +55,25 @@ _discover_oauth_connectors()
 def _get_additional_kwargs(
     request: Request, connector_cls: type[OAuthConnector], args_to_ignore: list[str]
 ) -> dict[str, str]:
-    # get additional kwargs from request
-    # e.g. anything except for desired_return_url
     additional_kwargs_dict = {
         k: v for k, v in request.query_params.items() if k not in args_to_ignore
     }
     try:
-        # validate
         connector_cls.AdditionalOauthKwargs(**additional_kwargs_dict)
-    except ValidationError:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"Invalid additional kwargs. Got {additional_kwargs_dict}, expected "
-                f"{connector_cls.AdditionalOauthKwargs.model_json_schema()}"
-            ),
+    except ValidationError as error:
+        detail = (
+            f"Invalid additional kwargs. Got {additional_kwargs_dict}, expected "
+            f"{connector_cls.AdditionalOauthKwargs.model_json_schema()}"
         )
+        raise OnyxError(OnyxErrorCode.VALIDATION_ERROR, detail) from error
 
     return additional_kwargs_dict
+
+
+class OAuthState(BaseModel):
+    desired_return_url: str
+    additional_kwargs: dict[str, str]
+    code_verifier: str | None = None
 
 
 class AuthorizeResponse(BaseModel):
@@ -92,36 +93,39 @@ def oauth_authorize(
     oauth_connectors = _discover_oauth_connectors()
 
     if source not in oauth_connectors:
-        raise HTTPException(status_code=400, detail=f"Unknown OAuth source: {source}")
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, f"Unknown OAuth source: {source}")
 
     connector_cls = oauth_connectors[source]
     base_url = WEB_DOMAIN
 
-    # get additional kwargs from request
-    # e.g. anything except for desired_return_url
     additional_kwargs = _get_additional_kwargs(
         request, connector_cls, ["desired_return_url"]
     )
 
-    # store state in redis
     if not desired_return_url:
         desired_return_url = f"{base_url}/admin/connectors/{source}?step=0"
+
+    code_verifier = None
+    code_challenge = None
+    if connector_cls.supports_pkce:
+        code_verifier, code_challenge = generate_pkce_pair()
+
     redis_client = get_redis_client(tenant_id=tenant_id)
     state = str(uuid.uuid4())
+    oauth_state = OAuthState(
+        desired_return_url=desired_return_url,
+        additional_kwargs=additional_kwargs,
+        code_verifier=code_verifier,
+    )
     redis_client.set(
         _OAUTH_STATE_KEY_FMT.format(state=state),
-        json.dumps(
-            {
-                _DESIRED_RETURN_URL_KEY: desired_return_url,
-                _ADDITIONAL_KWARGS_KEY: additional_kwargs,
-            }
-        ),
+        oauth_state.model_dump_json(),
         ex=_OAUTH_STATE_EXPIRATION_SECONDS,
     )
 
     return AuthorizeResponse(
         redirect_url=connector_cls.oauth_authorization_url(
-            base_url, state, additional_kwargs
+            base_url, state, additional_kwargs, code_challenge
         )
     )
 
@@ -142,29 +146,30 @@ def oauth_callback(
     oauth_connectors = _discover_oauth_connectors()
 
     if source not in oauth_connectors:
-        raise HTTPException(status_code=400, detail=f"Unknown OAuth source: {source}")
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, f"Unknown OAuth source: {source}")
 
     connector_cls = oauth_connectors[source]
 
-    # get state from redis
     redis_client = get_redis_client()
-    oauth_state_bytes = cast(
-        bytes, redis_client.get(_OAUTH_STATE_KEY_FMT.format(state=state))
-    )
+    oauth_state_bytes = redis_client.getdel(_OAUTH_STATE_KEY_FMT.format(state=state))
     if not oauth_state_bytes:
-        raise HTTPException(status_code=400, detail="Invalid OAuth state")
-    oauth_state = json.loads(oauth_state_bytes.decode("utf-8"))
-
-    desired_return_url = cast(str, oauth_state[_DESIRED_RETURN_URL_KEY])
-    additional_kwargs = cast(dict[str, str], oauth_state[_ADDITIONAL_KWARGS_KEY])
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "Invalid OAuth state")
+    try:
+        oauth_state = OAuthState.model_validate_json(oauth_state_bytes)
+    except ValidationError as error:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "Invalid OAuth state") from error
 
     base_url = WEB_DOMAIN
-    token_info = connector_cls.oauth_code_to_token(base_url, code, additional_kwargs)
+    token_info = connector_cls.oauth_code_to_token(
+        base_url,
+        code,
+        oauth_state.additional_kwargs,
+        oauth_state.code_verifier,
+    )
 
-    # Create a new credential with the token info
     credential_data = CredentialBase(
         credential_json=token_info,
-        admin_public=True,  # Or based on some logic/parameter
+        admin_public=True,
         source=source,
         name=f"{source.title()} OAuth Credential",
     )
@@ -175,10 +180,12 @@ def oauth_callback(
         db_session=db_session,
     )
 
-    # TODO: use a library for url handling
-    sep = "&" if "?" in desired_return_url else "?"
+    # Preserve existing query parameters in the requested return URL.
+    sep = "&" if "?" in oauth_state.desired_return_url else "?"
     return CallbackResponse(
-        redirect_url=f"{desired_return_url}{sep}credentialId={credential.id}"
+        redirect_url=(
+            f"{oauth_state.desired_return_url}{sep}credentialId={credential.id}"
+        )
     )
 
 

--- a/backend/tests/external_dependency_unit/auth/test_mobile_sso_code_store.py
+++ b/backend/tests/external_dependency_unit/auth/test_mobile_sso_code_store.py
@@ -78,9 +78,8 @@ async def test_code_expires_after_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
     assert await consume_sso_code(code, verifier) is None
 
 
-def test_s256_matches_generate_pkce_pair() -> None:
-    # The store's S256 transform must agree with the app-facing PKCE generator,
-    # otherwise a verifier produced by the client would never validate.
+def test_users_pkce_generator_uses_shared_s256_transform() -> None:
+    # Keep the app-facing import bound to the shared PKCE helpers.
     verifier, challenge = generate_pkce_pair()
     assert compute_s256_challenge(verifier) == challenge
 

--- a/backend/tests/unit/onyx/server/documents/test_standard_connector_oauth_pkce.py
+++ b/backend/tests/unit/onyx/server/documents/test_standard_connector_oauth_pkce.py
@@ -1,0 +1,186 @@
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import Request
+from sqlalchemy.orm import Session
+
+from onyx.auth.pkce import compute_s256_challenge, generate_pkce_pair
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.interfaces import OAuthConnector
+from onyx.connectors.linear.connector import LinearConnector
+from onyx.db.models import User
+from onyx.error_handling.exceptions import OnyxError
+from onyx.redis.tenant_redis_client import TenantRedisClient
+from onyx.server.documents import standard_oauth
+from onyx.server.documents.standard_oauth import OAuthState
+
+
+class PKCEOAuthConnector(OAuthConnector):
+    supports_pkce = True
+
+    @classmethod
+    def oauth_id(cls) -> DocumentSource:
+        return DocumentSource.LINEAR
+
+    @classmethod
+    def oauth_authorization_url(
+        cls,
+        base_domain: str,  # noqa: ARG003
+        state: str,  # noqa: ARG003
+        additional_kwargs: dict[str, str],  # noqa: ARG003
+        code_challenge: str | None = None,  # noqa: ARG003
+    ) -> str:
+        return "https://provider.example/authorize"
+
+    @classmethod
+    def oauth_code_to_token(
+        cls,
+        base_domain: str,  # noqa: ARG003
+        code: str,  # noqa: ARG003
+        additional_kwargs: dict[str, str],  # noqa: ARG003
+        code_verifier: str | None = None,  # noqa: ARG003
+    ) -> dict[str, Any]:
+        return {"access_token": "token"}
+
+
+def _request(query_string: bytes = b"") -> Request:
+    return Request({"type": "http", "query_string": query_string})
+
+
+def test_pkce_generator_uses_s256() -> None:
+    code_verifier, code_challenge = generate_pkce_pair()
+
+    assert compute_s256_challenge(code_verifier) == code_challenge
+
+
+def test_authorize_stores_verifier_and_passes_challenge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    redis_client = MagicMock()
+    authorization_url = MagicMock(return_value="https://provider.example/authorize")
+    monkeypatch.setattr(
+        standard_oauth,
+        "_discover_oauth_connectors",
+        lambda: {DocumentSource.LINEAR: PKCEOAuthConnector},
+    )
+    monkeypatch.setattr(standard_oauth, "get_redis_client", lambda **_: redis_client)
+    monkeypatch.setattr(
+        standard_oauth, "generate_pkce_pair", lambda: ("verifier", "challenge")
+    )
+    monkeypatch.setattr(
+        PKCEOAuthConnector, "oauth_authorization_url", authorization_url
+    )
+
+    response = standard_oauth.oauth_authorize(
+        request=_request(),
+        source=DocumentSource.LINEAR,
+        desired_return_url="https://onyx.example/return",
+        _=cast(User, object()),
+    )
+
+    assert response.redirect_url == "https://provider.example/authorize"
+    stored_state = OAuthState.model_validate_json(redis_client.set.call_args.args[1])
+    assert stored_state.code_verifier == "verifier"
+    authorization_url.assert_called_once()
+    assert authorization_url.call_args.args[3] == "challenge"
+
+
+def test_authorize_skips_pkce_for_existing_connector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    redis_client = MagicMock()
+    authorization_url = MagicMock(return_value="https://linear.app/oauth/authorize")
+    generate_pkce_pair_mock = MagicMock()
+    monkeypatch.setattr(
+        standard_oauth,
+        "_discover_oauth_connectors",
+        lambda: {DocumentSource.LINEAR: LinearConnector},
+    )
+    monkeypatch.setattr(standard_oauth, "get_redis_client", lambda **_: redis_client)
+    monkeypatch.setattr(standard_oauth, "generate_pkce_pair", generate_pkce_pair_mock)
+    monkeypatch.setattr(LinearConnector, "oauth_authorization_url", authorization_url)
+
+    standard_oauth.oauth_authorize(
+        request=_request(),
+        source=DocumentSource.LINEAR,
+        desired_return_url="https://onyx.example/return",
+        _=cast(User, object()),
+    )
+
+    generate_pkce_pair_mock.assert_not_called()
+    stored_state = OAuthState.model_validate_json(redis_client.set.call_args.args[1])
+    assert stored_state.code_verifier is None
+    assert authorization_url.call_args.args[3] is None
+
+
+def test_callback_consumes_state_and_passes_verifier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    oauth_state = OAuthState(
+        desired_return_url="https://onyx.example/return",
+        additional_kwargs={"instance": "example"},
+        code_verifier="verifier",
+    )
+    redis_client = MagicMock()
+    redis_client.getdel.return_value = oauth_state.model_dump_json().encode()
+    code_to_token = MagicMock(return_value={"access_token": "token"})
+    monkeypatch.setattr(
+        standard_oauth,
+        "_discover_oauth_connectors",
+        lambda: {DocumentSource.LINEAR: PKCEOAuthConnector},
+    )
+    monkeypatch.setattr(standard_oauth, "get_redis_client", lambda: redis_client)
+    monkeypatch.setattr(PKCEOAuthConnector, "oauth_code_to_token", code_to_token)
+    monkeypatch.setattr(
+        standard_oauth,
+        "create_credential",
+        lambda **_: SimpleNamespace(id=7),
+    )
+
+    response = standard_oauth.oauth_callback(
+        source=DocumentSource.LINEAR,
+        code="authorization-code",
+        state="state-id",
+        db_session=cast(Session, object()),
+        user=cast(User, object()),
+    )
+
+    assert response.redirect_url == "https://onyx.example/return?credentialId=7"
+    redis_client.getdel.assert_called_once_with("oauth_state:state-id")
+    code_to_token.assert_called_once_with(
+        standard_oauth.WEB_DOMAIN,
+        "authorization-code",
+        {"instance": "example"},
+        "verifier",
+    )
+
+
+def test_callback_rejects_consumed_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    redis_client = MagicMock()
+    redis_client.getdel.return_value = None
+    monkeypatch.setattr(
+        standard_oauth,
+        "_discover_oauth_connectors",
+        lambda: {DocumentSource.LINEAR: PKCEOAuthConnector},
+    )
+    monkeypatch.setattr(standard_oauth, "get_redis_client", lambda: redis_client)
+
+    with pytest.raises(OnyxError, match="Invalid OAuth state"):
+        standard_oauth.oauth_callback(
+            source=DocumentSource.LINEAR,
+            code="authorization-code",
+            state="consumed-state",
+            db_session=cast(Session, object()),
+            user=cast(User, object()),
+        )
+
+
+def test_tenant_redis_getdel_prefixes_key() -> None:
+    raw_client = MagicMock()
+    raw_client.getdel.return_value = b"value"
+    redis_client = TenantRedisClient("tenant", raw_client)
+
+    assert redis_client.getdel("oauth_state:state-id") == b"value"
+    raw_client.getdel.assert_called_once_with("tenant:oauth_state:state-id")


### PR DESCRIPTION
## Description

Add opt-in S256 PKCE to the standard connector OAuth flow. Store typed callback state once and preserve existing Linear and Egnyte behavior.

## How Has This Been Tested?

- Focused connector OAuth and mobile SSO PKCE tests
- `ruff check` and `ruff format --check`
- `ty` checks through pre-commit

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in S256 PKCE to connector OAuth and makes OAuth state one-use. Previously the flow did not support PKCE and could reuse state if left in Redis; now connectors can opt in, and state is atomically consumed to prevent replay. Existing `LinearConnector` and `EgnyteConnector` behavior is unchanged.

- Adds `OAuthConnector.supports_pkce` (default `False`) and optional `code_challenge`/`code_verifier` params to `oauth_authorization_url`/`oauth_code_to_token`. Authorize passes a challenge only when a connector opts in; callback passes the verifier accordingly.
- Moves `generate_pkce_pair` to `onyx.auth.pkce` and shares S256 helpers with mobile SSO.
- Stores a typed `OAuthState` in Redis and validates on load; replaces `HTTPException` with `OnyxError` for invalid input.
- Consumes state with Redis `GETDEL` via `TenantRedisClient.getdel` to prevent replay; preserves existing query params in the return URL.

**Migration**
- Connectors that want PKCE must set `supports_pkce = True` and handle `code_challenge`/`code_verifier` in the updated method signatures.
- Update imports of `generate_pkce_pair` to `onyx.auth.pkce`.
- Ensure Redis supports `GETDEL` (Redis 6.2+ and compatible `redis-py`).

<sup>Written for commit d1bcff12e941fe79a73b833d28a424248e9058f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

