### PR TITLE
fix(chat): send a context-aware max output token cap to the LLM

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -37,7 +37,10 @@ from onyx.chat.prompt_utils import (
 from onyx.configs.app_configs import INTEGRATION_TESTS_MODE
 from onyx.configs.chat_configs import MAX_LLM_CYCLES
 from onyx.configs.constants import DocumentSource, MessageType
-from onyx.configs.model_configs import GEN_AI_INPUT_TOKEN_SAFETY_MARGIN
+from onyx.configs.model_configs import (
+    GEN_AI_INPUT_TOKEN_SAFETY_MARGIN,
+    GEN_AI_NUM_RESERVED_OUTPUT_TOKENS,
+)
 from onyx.context.search.models import SearchDoc, SearchDocsResponse
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.memory import UserMemoryContext, add_memory, update_memory_at_index
@@ -1086,10 +1089,14 @@ def run_llm_loop(
                     )
                     - tool_token_budget
                 )
-                if context_headroom > 0:
-                    cycle_max_output_tokens = min(
-                        model_max_output_tokens, context_headroom
-                    )
+                # Never leave this unset once the model is known: an absent cap
+                # hands the request back to LiteLLM's model-ceiling default,
+                # which is the worst possible value precisely when headroom has
+                # run out.
+                cycle_max_output_tokens = min(
+                    model_max_output_tokens,
+                    max(context_headroom, GEN_AI_NUM_RESERVED_OUTPUT_TOKENS),
+                )
 
             llm_step_result, has_reasoned = run_llm_step(
                 emitter=emitter,

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -46,7 +46,7 @@ from onyx.file_store.models import ChatFileType
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.exceptions import ClassifiedLLMError
 from onyx.llm.interfaces import LLM, LLMUserIdentity, ToolChoiceOptions
-from onyx.llm.model_capabilities import is_true_openai_model
+from onyx.llm.model_capabilities import is_true_openai_model, resolve_max_output_tokens
 from onyx.llm.models import ReasoningEffort
 from onyx.llm.utils import model_supports_image_input
 from onyx.prompts.chat_prompts import (
@@ -810,6 +810,13 @@ def run_llm_loop(
         available_tokens = int(
             llm.config.max_input_tokens * (1 - GEN_AI_INPUT_TOKEN_SAFETY_MARGIN)
         )
+        # Without an explicit cap LiteLLM applies its own default (4096 for
+        # Anthropic), which truncates models that spend output tokens on
+        # reasoning before they emit an answer. Stays None for models we can't
+        # resolve, so we never claim a ceiling the provider may reject.
+        model_max_output_tokens = resolve_max_output_tokens(
+            llm.config.model_name, llm.config.model_provider
+        )
         # When the model takes no image input, history images are replayed as
         # short text markers (translate_history_to_llm_format) — budget them
         # as markers too, not at their stored image token cost.
@@ -1039,6 +1046,21 @@ def run_llm_loop(
             # This measures how long the user waits before the answer starts streaming
             pre_answer_processing_time = time.monotonic() - loop_start_time
 
+            # Providers reject a request whose input plus requested output
+            # exceeds the context window, so cap the ask at what this cycle's
+            # history actually leaves free.
+            cycle_max_output_tokens: int | None = None
+            if model_max_output_tokens is not None:
+                context_headroom = (
+                    llm.config.max_input_tokens
+                    - sum(msg.token_count for msg in truncated_message_history)
+                    - tool_token_budget
+                )
+                if context_headroom > 0:
+                    cycle_max_output_tokens = min(
+                        model_max_output_tokens, context_headroom
+                    )
+
             llm_step_result, has_reasoned = run_llm_step(
                 emitter=emitter,
                 history=truncated_message_history,
@@ -1055,6 +1077,7 @@ def run_llm_loop(
                 user_identity=user_identity,
                 pre_answer_processing_time=pre_answer_processing_time,
                 reasoning_effort=reasoning_effort,
+                max_tokens=cycle_max_output_tokens,
             )
             if has_reasoned:
                 reasoning_cycles += 1

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -375,6 +375,45 @@ def _build_project_message(
     return messages
 
 
+def marker_replay_token_count(
+    image_files_replayed_as_markers: bool,
+    token_counter: Callable[[str], int] | None,
+) -> int:
+    """Token cost of the placeholder text sent in place of one image."""
+    if not image_files_replayed_as_markers:
+        return 0
+    sample_marker = NON_VISION_IMAGE_MARKER.format(file_id="0" * 36)
+    return (
+        token_counter(sample_marker)
+        if token_counter
+        else _NON_VISION_MARKER_TOKEN_FALLBACK
+    )
+
+
+def replay_token_count(
+    msg: ChatMessageSimple,
+    image_files_replayed_as_markers: bool,
+    marker_tokens: int,
+) -> int:
+    """Tokens this message actually costs on the wire.
+
+    Shared by the history budget and the output-token cap so both measure the
+    same thing — the stored image cost is not what gets sent when the model
+    takes no image input.
+    """
+    if not image_files_replayed_as_markers:
+        return msg.token_count
+    # Charge markers for every IMAGE entry, including ones whose stored
+    # token contribution is zero (project/context images are never
+    # counted) — the marker text is still sent for them.
+    num_images = sum(
+        1 for f in msg.image_files or [] if f.file_type == ChatFileType.IMAGE
+    )
+    if not num_images:
+        return msg.token_count
+    return max(0, msg.token_count - msg.image_token_count) + num_images * marker_tokens
+
+
 def construct_message_history(
     system_prompt: ChatMessageSimple | None,
     custom_agent_prompt: ChatMessageSimple | None,
@@ -397,29 +436,12 @@ def construct_message_history(
     # input, translate_history_to_llm_format sends short text markers instead
     # of the images, so charging the stored image token cost would evict
     # history that actually fits.
-    marker_tokens = 0
-    if image_files_replayed_as_markers:
-        sample_marker = NON_VISION_IMAGE_MARKER.format(file_id="0" * 36)
-        marker_tokens = (
-            token_counter(sample_marker)
-            if token_counter
-            else _NON_VISION_MARKER_TOKEN_FALLBACK
-        )
+    marker_tokens = marker_replay_token_count(
+        image_files_replayed_as_markers, token_counter
+    )
 
-    def _replay_token_count(msg: ChatMessageSimple) -> int:
-        if not image_files_replayed_as_markers:
-            return msg.token_count
-        # Charge markers for every IMAGE entry, including ones whose stored
-        # token contribution is zero (project/context images are never
-        # counted) — the marker text is still sent for them.
-        num_images = sum(
-            1 for f in msg.image_files or [] if f.file_type == ChatFileType.IMAGE
-        )
-        if not num_images:
-            return msg.token_count
-        return (
-            max(0, msg.token_count - msg.image_token_count) + num_images * marker_tokens
-        )
+    def _replay_tokens(msg: ChatMessageSimple) -> int:
+        return replay_token_count(msg, image_files_replayed_as_markers, marker_tokens)
 
     # Build the project / file-metadata messages up front so we can use their
     # actual token counts for the budget.
@@ -490,10 +512,8 @@ def construct_message_history(
     messages_after_last_user = simple_chat_history[last_user_msg_index + 1 :]
 
     # Calculate tokens needed for the last user message and everything after it
-    last_user_tokens = _replay_token_count(last_user_message)
-    after_user_tokens = sum(
-        _replay_token_count(msg) for msg in messages_after_last_user
-    )
+    last_user_tokens = _replay_tokens(last_user_message)
+    after_user_tokens = sum(_replay_tokens(msg) for msg in messages_after_last_user)
 
     # Check if we can fit at least the last user message and messages after it
     required_tokens = last_user_tokens + after_user_tokens
@@ -514,7 +534,7 @@ def construct_message_history(
     current_token_count = 0
 
     for msg in reversed(history_before_last_user):
-        msg_tokens = _replay_token_count(msg)
+        msg_tokens = _replay_tokens(msg)
         if current_token_count + msg_tokens <= remaining_budget:
             msg.should_cache = True
             truncated_history_before.insert(0, msg)
@@ -567,7 +587,7 @@ def construct_message_history(
             remaining_budget -= forgotten_files_message.token_count
             while truncated_history_before and current_token_count > remaining_budget:
                 evicted = truncated_history_before.pop(0)
-                current_token_count -= _replay_token_count(evicted)
+                current_token_count -= _replay_tokens(evicted)
                 # If the evicted message is itself a file, add it to the
                 # forgotten metadata (it's now dropped too).
                 if (
@@ -826,6 +846,9 @@ def run_llm_loop(
         ) and not model_supports_image_input(
             llm.config.model_name, llm.config.model_provider
         )
+        history_marker_tokens = marker_replay_token_count(
+            image_files_replayed_as_markers, token_counter
+        )
         tool_choice: ToolChoiceOptions = ToolChoiceOptions.AUTO
         # Initialize gathered_documents with project files if present
         gathered_documents: list[SearchDoc] | None = (
@@ -1048,12 +1071,19 @@ def run_llm_loop(
 
             # Providers reject a request whose input plus requested output
             # exceeds the context window, so cap the ask at what this cycle's
-            # history actually leaves free.
+            # history actually leaves free. Measured against available_tokens,
+            # not max_input_tokens, so the safety margin stays reserved for
+            # input our local estimate may undercount.
             cycle_max_output_tokens: int | None = None
             if model_max_output_tokens is not None:
                 context_headroom = (
-                    llm.config.max_input_tokens
-                    - sum(msg.token_count for msg in truncated_message_history)
+                    available_tokens
+                    - sum(
+                        replay_token_count(
+                            msg, image_files_replayed_as_markers, history_marker_tokens
+                        )
+                        for msg in truncated_message_history
+                    )
                     - tool_token_budget
                 )
                 if context_headroom > 0:

--- a/backend/onyx/llm/model_capabilities.py
+++ b/backend/onyx/llm/model_capabilities.py
@@ -227,6 +227,25 @@ _BEDROCK_INFERENCE_PROFILE_PREFIXES = (
     "global.",
 )
 
+# Vendor namespaces AWS publishes Bedrock models under. Gating on these rather
+# than on the provider name keeps the retry working for GovCloud gateways
+# registered as custom providers, without matching arbitrary local model ids.
+_BEDROCK_MODEL_VENDOR_NAMESPACES = (
+    "ai21.",
+    "amazon.",
+    "anthropic.",
+    "cohere.",
+    "deepseek.",
+    "luma.",
+    "meta.",
+    "mistral.",
+    "openai.",
+    "qwen.",
+    "stability.",
+    "twelvelabs.",
+    "writer.",
+)
+
 
 def resolve_max_output_tokens(model_name: str, model_provider: str) -> int | None:
     """The model's real max output tokens, or None when it cannot be determined.
@@ -243,10 +262,10 @@ def resolve_max_output_tokens(model_name: str, model_provider: str) -> int | Non
             if not model_name.startswith(prefix):
                 continue
             base_model_name = model_name[len(prefix) :]
-            # Only retry when the remainder is still `vendor.model` shaped, so a
-            # self-hosted model that merely happens to start with "us." cannot
-            # inherit an unrelated model's ceiling.
-            if "." not in base_model_name:
+            # Only retry when the remainder still carries a Bedrock vendor
+            # namespace, so a self-hosted model that merely happens to start
+            # with "us." cannot inherit an unrelated model's ceiling.
+            if not base_model_name.startswith(_BEDROCK_MODEL_VENDOR_NAMESPACES):
                 break
             model_obj = find_model_obj(model_map, model_provider, base_model_name)
             break

--- a/backend/onyx/llm/model_capabilities.py
+++ b/backend/onyx/llm/model_capabilities.py
@@ -240,11 +240,16 @@ def resolve_max_output_tokens(model_name: str, model_provider: str) -> int | Non
 
     if model_obj is None:
         for prefix in _BEDROCK_INFERENCE_PROFILE_PREFIXES:
-            if model_name.startswith(prefix):
-                model_obj = find_model_obj(
-                    model_map, model_provider, model_name[len(prefix) :]
-                )
+            if not model_name.startswith(prefix):
+                continue
+            base_model_name = model_name[len(prefix) :]
+            # Only retry when the remainder is still `vendor.model` shaped, so a
+            # self-hosted model that merely happens to start with "us." cannot
+            # inherit an unrelated model's ceiling.
+            if "." not in base_model_name:
                 break
+            model_obj = find_model_obj(model_map, model_provider, base_model_name)
+            break
 
     if model_obj is None:
         return None

--- a/backend/onyx/llm/model_capabilities.py
+++ b/backend/onyx/llm/model_capabilities.py
@@ -212,6 +212,47 @@ def get_llm_max_output_tokens(
     return default_output_tokens
 
 
+# Bedrock serves models through regional inference profiles that prefix the base
+# model id. LiteLLM's map carries only some of them, so retry a failed lookup
+# without the prefix rather than treating the model as unknown.
+_BEDROCK_INFERENCE_PROFILE_PREFIXES = (
+    "us-gov.",
+    "us.",
+    "eu.",
+    "apac.",
+    "au.",
+    "jp.",
+    "ca.",
+    "sa.",
+    "global.",
+)
+
+
+def resolve_max_output_tokens(model_name: str, model_provider: str) -> int | None:
+    """The model's real max output tokens, or None when it cannot be determined.
+
+    Unlike `get_llm_max_output_tokens` this never falls back to a guess. Callers
+    that send the value to a provider must not invent a ceiling the model may
+    not accept — returning None leaves the limit to the provider.
+    """
+    model_map = get_model_map()
+    model_obj = find_model_obj(model_map, model_provider, model_name)
+
+    if model_obj is None:
+        for prefix in _BEDROCK_INFERENCE_PROFILE_PREFIXES:
+            if model_name.startswith(prefix):
+                model_obj = find_model_obj(
+                    model_map, model_provider, model_name[len(prefix) :]
+                )
+                break
+
+    if model_obj is None:
+        return None
+
+    max_output_tokens = model_obj.get("max_output_tokens")
+    return int(max_output_tokens) if max_output_tokens else None
+
+
 def get_max_input_tokens(
     model_name: str,
     model_provider: str,

--- a/backend/tests/unit/onyx/llm/test_token_limit_lookups.py
+++ b/backend/tests/unit/onyx/llm/test_token_limit_lookups.py
@@ -263,6 +263,12 @@ class TestResolveMaxOutputTokens:
         with patch("onyx.llm.model_capabilities.get_model_map", return_value=model_map):
             assert resolve_max_output_tokens("us.foo", "ollama") is None
 
+    def test_prefix_strip_requires_a_known_bedrock_vendor(self) -> None:
+        # A dotted remainder is not enough — it must be a Bedrock vendor.
+        model_map = {"foo.bar": {"max_output_tokens": 128000}}
+        with patch("onyx.llm.model_capabilities.get_model_map", return_value=model_map):
+            assert resolve_max_output_tokens("us.foo.bar", "ollama") is None
+
     def test_prefix_strip_still_returns_none_when_base_unknown(self) -> None:
         with patch("onyx.llm.model_capabilities.get_model_map", return_value={}):
             assert (

--- a/backend/tests/unit/onyx/llm/test_token_limit_lookups.py
+++ b/backend/tests/unit/onyx/llm/test_token_limit_lookups.py
@@ -256,6 +256,13 @@ class TestResolveMaxOutputTokens:
                 == 128000
             )
 
+    def test_prefix_strip_requires_a_vendor_namespace(self) -> None:
+        # A self-hosted model merely starting with "us." must not inherit an
+        # unrelated model's ceiling.
+        model_map = {"foo": {"max_output_tokens": 128000}}
+        with patch("onyx.llm.model_capabilities.get_model_map", return_value=model_map):
+            assert resolve_max_output_tokens("us.foo", "ollama") is None
+
     def test_prefix_strip_still_returns_none_when_base_unknown(self) -> None:
         with patch("onyx.llm.model_capabilities.get_model_map", return_value={}):
             assert (

--- a/backend/tests/unit/onyx/llm/test_token_limit_lookups.py
+++ b/backend/tests/unit/onyx/llm/test_token_limit_lookups.py
@@ -8,6 +8,7 @@ from onyx.llm.model_capabilities import (
     get_llm_max_output_tokens,
     get_max_input_tokens,
     llm_max_input_tokens,
+    resolve_max_output_tokens,
 )
 
 
@@ -225,3 +226,41 @@ class TestGetMaxInputTokens:
             )
         assert isinstance(result, int)
         assert result > 0
+
+
+class TestResolveMaxOutputTokens:
+    """`resolve_max_output_tokens` must never guess a ceiling: it returns the
+    model's real limit or None, so callers don't send a value the provider
+    rejects."""
+
+    def test_resolves_known_model(self) -> None:
+        model_map = {"anthropic/claude-sonnet-5": {"max_output_tokens": 128000}}
+        with patch("onyx.llm.model_capabilities.get_model_map", return_value=model_map):
+            assert resolve_max_output_tokens("claude-sonnet-5", "anthropic") == 128000
+
+    def test_returns_none_for_unknown_model(self) -> None:
+        with patch("onyx.llm.model_capabilities.get_model_map", return_value={}):
+            assert resolve_max_output_tokens("some-local-model", "ollama") is None
+
+    def test_returns_none_when_entry_lacks_output_tokens(self) -> None:
+        model_map = {"ollama/llama3": {"max_input_tokens": 8192}}
+        with patch("onyx.llm.model_capabilities.get_model_map", return_value=model_map):
+            assert resolve_max_output_tokens("llama3", "ollama") is None
+
+    def test_strips_bedrock_inference_profile_prefix(self) -> None:
+        # GovCloud ids are absent from LiteLLM's map; the base id is present.
+        model_map = {"anthropic.claude-sonnet-5": {"max_output_tokens": 128000}}
+        with patch("onyx.llm.model_capabilities.get_model_map", return_value=model_map):
+            assert (
+                resolve_max_output_tokens("us-gov.anthropic.claude-sonnet-5", "bedrock")
+                == 128000
+            )
+
+    def test_prefix_strip_still_returns_none_when_base_unknown(self) -> None:
+        with patch("onyx.llm.model_capabilities.get_model_map", return_value={}):
+            assert (
+                resolve_max_output_tokens(
+                    "us-gov.anthropic.claude-sonnet-4-5", "bedrock"
+                )
+                is None
+            )


### PR DESCRIPTION
## Description

The chat loop never set `max_tokens`, so LiteLLM applied its own default for any model missing from its map — **4096 tokens for Anthropic**. Models that spend output tokens on reasoning exhaust that budget before emitting any text or tool call, and the turn fails with *"The selected model returned no final answer before the stream completed."*

Bedrock regional inference profiles are one such gap. GovCloud ids like `us-gov.anthropic.claude-sonnet-5` are absent from LiteLLM's map (the `us.` / `eu.` / `au.` variants are present), so they resolved to 4096 instead of the model's real 128k ceiling. Newer Claude models run adaptive thinking by default when no `thinking` field is sent, so on a self-hosted GovCloud deployment the reasoning alone consumed the entire 4096 and the response carried no content — the turn had already completed 10 successful tool calls by that point.

Three parts:

1. **`resolve_max_output_tokens`** returns the model's real ceiling or `None`. It never guesses. A failed lookup is retried without the Bedrock inference-profile prefix, so GovCloud ids resolve to their base model entry.
2. **Unresolved models send no `max_tokens` at all** and keep the provider default. This deliberately leaves self-hosted deployments untouched — plenty of local models have a real ceiling of 4096 or 8192, and asking for our 32k fallback would break requests that work today.
3. **The per-cycle cap is clamped to the context the turn actually leaves free.** Onyx fills history to 95% of `max_input_tokens` (`GEN_AI_INPUT_TOKEN_SAFETY_MARGIN` = 0.05), so requesting a model's full ceiling on top could push `input + max_tokens` past the context window and be rejected outright. Without the clamp this would trade a low-ceiling bug for a long-conversation failure.

Deliberately scoped to the output-token decision: nothing here changes input-token budgeting, vision/reasoning capability checks, or the gateway model catalog, all of which also read the LiteLLM model map.

Not addressed here, tracked separately: `dr_loop.py` passes `max_tokens` at two of its four `run_llm_step` call sites and not the other two.

## How Has This Been Tested?

- New unit tests for `resolve_max_output_tokens` covering the known-model, unknown-model, missing-field, prefix-strip, and prefix-strip-still-unknown cases.
- `pytest backend/tests/unit/onyx/llm backend/tests/unit/onyx/chat` — 170 passed across the affected modules.
- Pre-commit (`ty`, `ruff`, `ruff format`, lazy-import check, ripsecrets, env-drift) clean on all touched files.
- Behavioral check against the real LiteLLM map, confirming each intended property:

| model | resolved ceiling | history | sent | behavior |
|---|---|---|---|---|
| `us-gov.anthropic.claude-sonnet-5` | 128000 | 60k | **128000** | resolves via prefix strip (was 4096) |
| `claude-sonnet-5` | 128000 | 950k | **50000** | clamped by context, no overflow |
| `claude-haiku-4-5` | 64000 | 190k | **10000** | clamped by context, no overflow |
| `us-gov.anthropic.claude-sonnet-4-5` | — | 60k | **None** | unresolved, provider default (unchanged) |
| local/self-hosted model | — | 5k | **None** | unresolved, provider default (unchanged) |

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents empty answers from models that spend output tokens on reasoning by sending a context-aware max output token cap and clamping it to actual headroom. Previously we sent no cap, so unknown Anthropic variants (e.g., Bedrock GovCloud) fell back to 4096 and exhausted output during reasoning.

- Adds `resolve_max_output_tokens(model_name, provider)`: returns the model’s real ceiling or None; retries after stripping Bedrock inference-profile prefixes only when the remainder is a known AWS vendor namespace in `vendor.model` form, avoiding accidental inheritance and fixing `us-gov.anthropic.*` truncation.
- Leaves `max_tokens` unset when unresolved to keep the provider default, preserving local/self-hosted models.
- Sets the per-cycle cap to min(model ceiling, max(context headroom, `GEN_AI_NUM_RESERVED_OUTPUT_TOKENS`)); headroom is measured against `available_tokens` (keeps the 5% safety margin), subtracts the tool budget, and counts what is actually sent via shared `replay_token_count`/`marker_replay_token_count` to prevent context-window rejections.
- Scope limited to the output-token cap; input-token budgeting and capability checks are unchanged. Unit tests cover known/unknown models and Bedrock prefix-strip vendor gating. No migration required.

<sup>Written for commit 4e0cd0caf4a561c163cb4d897d7d5a6b0d8c8939. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

