### PR TITLE
fix(web): type-check app navigation routes and query keys

### DIFF
--- a/web/src/app/app/services/searchParams.ts
+++ b/web/src/app/app/services/searchParams.ts
@@ -25,7 +25,10 @@ export const SEARCH_PARAM_NAMES = {
   // when sending a message for the first time, we don't want to reload the page
   // and cause a re-render
   SKIP_RELOAD: "skip-reload",
-};
+} as const;
+
+export type SearchParamName =
+  (typeof SEARCH_PARAM_NAMES)[keyof typeof SEARCH_PARAM_NAMES];
 
 export function shouldSubmitOnLoad(
   searchParams: ReadonlyURLSearchParams | null

--- a/web/src/hooks/appNavigation.ts
+++ b/web/src/hooks/appNavigation.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { SEARCH_PARAM_NAMES } from "@/app/app/services/searchParams";
+import { routeWithQuery } from "@/lib/routes";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback } from "react";
 
@@ -14,18 +15,16 @@ export function useAppRouter() {
   const router = useRouter();
   return useCallback(
     ({ chatSessionId, agentId, projectId }: UseAppRouterProps = {}) => {
-      const finalParams = [];
+      // At most one parameter is set, in this order of priority.
+      const query = chatSessionId
+        ? { [SEARCH_PARAM_NAMES.CHAT_ID]: chatSessionId }
+        : agentId
+          ? { [SEARCH_PARAM_NAMES.PERSONA_ID]: agentId }
+          : projectId
+            ? { [SEARCH_PARAM_NAMES.PROJECT_ID]: projectId }
+            : {};
 
-      if (chatSessionId)
-        finalParams.push(`${SEARCH_PARAM_NAMES.CHAT_ID}=${chatSessionId}`);
-      else if (agentId)
-        finalParams.push(`${SEARCH_PARAM_NAMES.PERSONA_ID}=${agentId}`);
-      else if (projectId)
-        finalParams.push(`${SEARCH_PARAM_NAMES.PROJECT_ID}=${projectId}`);
-
-      const finalString = finalParams.join("&");
-
-      router.push(`/app?${finalString}`);
+      router.push(routeWithQuery("/app", query));
     },
     [router]
   );

--- a/web/src/hooks/appNavigation.ts
+++ b/web/src/hooks/appNavigation.ts
@@ -2,7 +2,6 @@
 
 import { SEARCH_PARAM_NAMES } from "@/app/app/services/searchParams";
 import { useRouter, useSearchParams } from "next/navigation";
-import type { Route } from "next";
 import { useCallback } from "react";
 
 interface UseAppRouterProps {
@@ -25,9 +24,8 @@ export function useAppRouter() {
         finalParams.push(`${SEARCH_PARAM_NAMES.PROJECT_ID}=${projectId}`);
 
       const finalString = finalParams.join("&");
-      const finalUrl = `/app?${finalString}`;
 
-      router.push(finalUrl as Route);
+      router.push(`/app?${finalString}`);
     },
     [router]
   );

--- a/web/src/lib/routes.ts
+++ b/web/src/lib/routes.ts
@@ -1,0 +1,20 @@
+import type { SearchParamName } from "@/app/app/services/searchParams";
+import type { Route } from "next";
+
+type QueryValue = string | number | boolean | undefined;
+
+/**
+ * Build a route with a query string. The pathname is checked against the routes
+ * that `typedRoutes` generates, and the query keys against `SEARCH_PARAM_NAMES`.
+ * Undefined values are dropped. Values are URL-encoded.
+ */
+export function routeWithQuery<P extends string>(
+  pathname: Route<P>,
+  query: Partial<Record<SearchParamName, QueryValue>>
+): `${P}?${string}` {
+  const searchParams = new URLSearchParams();
+  for (const [name, value] of Object.entries(query)) {
+    if (value !== undefined) searchParams.set(name, String(value));
+  }
+  return `${pathname as P}?${searchParams.toString()}`;
+}


### PR DESCRIPTION
## Problem

`useAppRouter` in `web/src/hooks/appNavigation.ts` cast its destination with `as Route`, so the route was never type-checked. A typo like `/aap?...` compiled fine and failed only at runtime. The query string was also built by hand, so parameter names were unchecked and values were not URL-encoded.

The cast was needed because the URL went through a `const` first. TypeScript widens `` const finalUrl = `/app?${finalString}` `` to plain `string`, which is not assignable to `Route`.

## Changes

**1. Remove the cast.** Pass the template literal directly to `router.push`. It keeps its literal type `` `/app?${string}` ``, which matches the `` `${StaticRoutes}${SearchOrHash}` `` arm of the route union that `typedRoutes: true` generates.

**2. Check the query keys too.** Add `routeWithQuery` in `web/src/lib/routes.ts`. It checks the pathname against the generated route union and the query keys against `SEARCH_PARAM_NAMES`, drops `undefined` values, and encodes the values. `SEARCH_PARAM_NAMES` is now `as const` so the key union can be derived.

The app router `push` accepts a string only — the `| UrlObject` overload exists on `next/link`, not on `useRouter` — so the object form is resolved before the call rather than passed through.

## Verification

- `npx tsc --noEmit` in `web/` is clean.
- A probe file confirmed the checking is real:
  - `routeWithQuery("/aap", …)` → `Argument of type '"/aap"' is not assignable to parameter of type 'Route<"/aap">'`
  - `routeWithQuery("/app", { chatid: "1" })` → `'chatid' does not exist in type ... Did you mean to write 'chatId'?`
  - `/app` and a dynamic route such as `/app/agents/edit/123` both pass.

All current callers pass a UUID or a number, so the encoding change leaves the emitted URLs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)