### PR TITLE
fix(celery): make Redis Sentinel work for beat and the result backend

### DIFF
--- a/backend/onyx/background/celery/configs/base.py
+++ b/backend/onyx/background/celery/configs/base.py
@@ -65,10 +65,19 @@ def _redis_ssl_settings() -> dict[str, str]:
     return settings
 
 
-_SENTINEL_NODES = ";".join(
-    f"sentinel://{CELERY_PASSWORD_PART}{host}:{port}"
-    for host, port in REDIS_SENTINEL_HOSTS
-)
+def _sentinel_url(db: int) -> str:
+    """Build the `;`-separated Sentinel URL for one Redis db.
+
+    The db goes on every node. Celery reads the db from the first URL in the
+    list and kombu reads it from the primary URL, so a db on the last node only
+    is dropped and both silently fall back to db 0.
+    """
+    return ";".join(
+        f"sentinel://{CELERY_PASSWORD_PART}{host}:{port}/{db}"
+        for host, port in REDIS_SENTINEL_HOSTS
+    )
+
+
 _SENTINEL_TRANSPORT_OPTIONS: dict = {}
 # Celery TLS settings for the Sentinel data connections. Always defined (empty =
 # no SSL, matching Celery's default) so they're not conditionally-present module
@@ -97,7 +106,7 @@ if USE_SENTINEL:
 # region Broker settings
 # example celery_broker_url: "redis://:password@localhost:6379/15"
 if USE_SENTINEL:
-    broker_url = f"{_SENTINEL_NODES}/{REDIS_DB_NUMBER_CELERY}"
+    broker_url = _sentinel_url(REDIS_DB_NUMBER_CELERY)
 else:
     broker_url = f"{REDIS_SCHEME}://{CELERY_PASSWORD_PART}{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB_NUMBER_CELERY}{SSL_QUERY_PARAMS}"
 
@@ -136,7 +145,7 @@ task_acks_late = True
 # might be irrelevant
 result_backend_transport_options: dict = {}
 if USE_SENTINEL:
-    result_backend = f"{_SENTINEL_NODES}/{REDIS_DB_NUMBER_CELERY_RESULT_BACKEND}"
+    result_backend = _sentinel_url(REDIS_DB_NUMBER_CELERY_RESULT_BACKEND)
     result_backend_transport_options = _SENTINEL_TRANSPORT_OPTIONS
 else:
     result_backend = f"{REDIS_SCHEME}://{CELERY_PASSWORD_PART}{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB_NUMBER_CELERY_RESULT_BACKEND}{SSL_QUERY_PARAMS}"

--- a/backend/onyx/background/celery/configs/beat.py
+++ b/backend/onyx/background/celery/configs/beat.py
@@ -5,10 +5,13 @@ broker_url = shared_config.broker_url
 broker_connection_retry_on_startup = shared_config.broker_connection_retry_on_startup
 broker_pool_limit = shared_config.broker_pool_limit
 broker_transport_options = shared_config.broker_transport_options
+broker_use_ssl = shared_config.broker_use_ssl
 
 redis_socket_keepalive = shared_config.redis_socket_keepalive
 redis_retry_on_timeout = shared_config.redis_retry_on_timeout
 redis_backend_health_check_interval = shared_config.redis_backend_health_check_interval
+redis_backend_use_ssl = shared_config.redis_backend_use_ssl
 
 result_backend = shared_config.result_backend
+result_backend_transport_options = shared_config.result_backend_transport_options
 result_expires = shared_config.result_expires  # 86400 seconds is the default

--- a/backend/onyx/background/celery/configs/client.py
+++ b/backend/onyx/background/celery/configs/client.py
@@ -4,12 +4,15 @@ broker_url = shared_config.broker_url
 broker_connection_retry_on_startup = shared_config.broker_connection_retry_on_startup
 broker_pool_limit = shared_config.broker_pool_limit
 broker_transport_options = shared_config.broker_transport_options
+broker_use_ssl = shared_config.broker_use_ssl
 
 redis_socket_keepalive = shared_config.redis_socket_keepalive
 redis_retry_on_timeout = shared_config.redis_retry_on_timeout
 redis_backend_health_check_interval = shared_config.redis_backend_health_check_interval
+redis_backend_use_ssl = shared_config.redis_backend_use_ssl
 
 result_backend = shared_config.result_backend
+result_backend_transport_options = shared_config.result_backend_transport_options
 result_expires = shared_config.result_expires  # 86400 seconds is the default
 
 task_default_priority = shared_config.task_default_priority

--- a/backend/onyx/background/celery/configs/docfetching.py
+++ b/backend/onyx/background/celery/configs/docfetching.py
@@ -5,12 +5,15 @@ broker_url = shared_config.broker_url
 broker_connection_retry_on_startup = shared_config.broker_connection_retry_on_startup
 broker_pool_limit = shared_config.broker_pool_limit
 broker_transport_options = shared_config.broker_transport_options
+broker_use_ssl = shared_config.broker_use_ssl
 
 redis_socket_keepalive = shared_config.redis_socket_keepalive
 redis_retry_on_timeout = shared_config.redis_retry_on_timeout
 redis_backend_health_check_interval = shared_config.redis_backend_health_check_interval
+redis_backend_use_ssl = shared_config.redis_backend_use_ssl
 
 result_backend = shared_config.result_backend
+result_backend_transport_options = shared_config.result_backend_transport_options
 result_expires = shared_config.result_expires  # 86400 seconds is the default
 
 task_default_priority = shared_config.task_default_priority

--- a/backend/onyx/background/celery/configs/docprocessing.py
+++ b/backend/onyx/background/celery/configs/docprocessing.py
@@ -5,12 +5,15 @@ broker_url = shared_config.broker_url
 broker_connection_retry_on_startup = shared_config.broker_connection_retry_on_startup
 broker_pool_limit = shared_config.broker_pool_limit
 broker_transport_options = shared_config.broker_transport_options
+broker_use_ssl = shared_config.broker_use_ssl
 
 redis_socket_keepalive = shared_config.redis_socket_keepalive
 redis_retry_on_timeout = shared_config.redis_retry_on_timeout
 redis_backend_health_check_interval = shared_config.redis_backend_health_check_interval
+redis_backend_use_ssl = shared_config.redis_backend_use_ssl
 
 result_backend = shared_config.result_backend
+result_backend_transport_options = shared_config.result_backend_transport_options
 result_expires = shared_config.result_expires  # 86400 seconds is the default
 
 task_default_priority = shared_config.task_default_priority

--- a/backend/onyx/background/celery/configs/heavy.py
+++ b/backend/onyx/background/celery/configs/heavy.py
@@ -5,12 +5,15 @@ broker_url = shared_config.broker_url
 broker_connection_retry_on_startup = shared_config.broker_connection_retry_on_startup
 broker_pool_limit = shared_config.broker_pool_limit
 broker_transport_options = shared_config.broker_transport_options
+broker_use_ssl = shared_config.broker_use_ssl
 
 redis_socket_keepalive = shared_config.redis_socket_keepalive
 redis_retry_on_timeout = shared_config.redis_retry_on_timeout
 redis_backend_health_check_interval = shared_config.redis_backend_health_check_interval
+redis_backend_use_ssl = shared_config.redis_backend_use_ssl
 
 result_backend = shared_config.result_backend
+result_backend_transport_options = shared_config.result_backend_transport_options
 result_expires = shared_config.result_expires  # 86400 seconds is the default
 
 task_default_priority = shared_config.task_default_priority

--- a/backend/onyx/background/celery/configs/light.py
+++ b/backend/onyx/background/celery/configs/light.py
@@ -8,12 +8,15 @@ broker_url = shared_config.broker_url
 broker_connection_retry_on_startup = shared_config.broker_connection_retry_on_startup
 broker_pool_limit = shared_config.broker_pool_limit
 broker_transport_options = shared_config.broker_transport_options
+broker_use_ssl = shared_config.broker_use_ssl
 
 redis_socket_keepalive = shared_config.redis_socket_keepalive
 redis_retry_on_timeout = shared_config.redis_retry_on_timeout
 redis_backend_health_check_interval = shared_config.redis_backend_health_check_interval
+redis_backend_use_ssl = shared_config.redis_backend_use_ssl
 
 result_backend = shared_config.result_backend
+result_backend_transport_options = shared_config.result_backend_transport_options
 result_expires = shared_config.result_expires  # 86400 seconds is the default
 
 task_default_priority = shared_config.task_default_priority

--- a/backend/onyx/background/celery/configs/monitoring.py
+++ b/backend/onyx/background/celery/configs/monitoring.py
@@ -5,12 +5,15 @@ broker_url = shared_config.broker_url
 broker_connection_retry_on_startup = shared_config.broker_connection_retry_on_startup
 broker_pool_limit = shared_config.broker_pool_limit
 broker_transport_options = shared_config.broker_transport_options
+broker_use_ssl = shared_config.broker_use_ssl
 
 redis_socket_keepalive = shared_config.redis_socket_keepalive
 redis_retry_on_timeout = shared_config.redis_retry_on_timeout
 redis_backend_health_check_interval = shared_config.redis_backend_health_check_interval
+redis_backend_use_ssl = shared_config.redis_backend_use_ssl
 
 result_backend = shared_config.result_backend
+result_backend_transport_options = shared_config.result_backend_transport_options
 result_expires = shared_config.result_expires  # 86400 seconds is the default
 
 task_default_priority = shared_config.task_default_priority

--- a/backend/onyx/background/celery/configs/primary.py
+++ b/backend/onyx/background/celery/configs/primary.py
@@ -5,12 +5,15 @@ broker_url = shared_config.broker_url
 broker_connection_retry_on_startup = shared_config.broker_connection_retry_on_startup
 broker_pool_limit = shared_config.broker_pool_limit
 broker_transport_options = shared_config.broker_transport_options
+broker_use_ssl = shared_config.broker_use_ssl
 
 redis_socket_keepalive = shared_config.redis_socket_keepalive
 redis_retry_on_timeout = shared_config.redis_retry_on_timeout
 redis_backend_health_check_interval = shared_config.redis_backend_health_check_interval
+redis_backend_use_ssl = shared_config.redis_backend_use_ssl
 
 result_backend = shared_config.result_backend
+result_backend_transport_options = shared_config.result_backend_transport_options
 result_expires = shared_config.result_expires  # 86400 seconds is the default
 
 task_default_priority = shared_config.task_default_priority

--- a/backend/onyx/background/celery/configs/scheduled_tasks.py
+++ b/backend/onyx/background/celery/configs/scheduled_tasks.py
@@ -5,12 +5,15 @@ broker_url = shared_config.broker_url
 broker_connection_retry_on_startup = shared_config.broker_connection_retry_on_startup
 broker_pool_limit = shared_config.broker_pool_limit
 broker_transport_options = shared_config.broker_transport_options
+broker_use_ssl = shared_config.broker_use_ssl
 
 redis_socket_keepalive = shared_config.redis_socket_keepalive
 redis_retry_on_timeout = shared_config.redis_retry_on_timeout
 redis_backend_health_check_interval = shared_config.redis_backend_health_check_interval
+redis_backend_use_ssl = shared_config.redis_backend_use_ssl
 
 result_backend = shared_config.result_backend
+result_backend_transport_options = shared_config.result_backend_transport_options
 result_expires = shared_config.result_expires  # 86400 seconds is the default
 
 task_default_priority = shared_config.task_default_priority

--- a/backend/onyx/background/celery/configs/user_file_processing.py
+++ b/backend/onyx/background/celery/configs/user_file_processing.py
@@ -5,12 +5,15 @@ broker_url = shared_config.broker_url
 broker_connection_retry_on_startup = shared_config.broker_connection_retry_on_startup
 broker_pool_limit = shared_config.broker_pool_limit
 broker_transport_options = shared_config.broker_transport_options
+broker_use_ssl = shared_config.broker_use_ssl
 
 redis_socket_keepalive = shared_config.redis_socket_keepalive
 redis_retry_on_timeout = shared_config.redis_retry_on_timeout
 redis_backend_health_check_interval = shared_config.redis_backend_health_check_interval
+redis_backend_use_ssl = shared_config.redis_backend_use_ssl
 
 result_backend = shared_config.result_backend
+result_backend_transport_options = shared_config.result_backend_transport_options
 result_expires = shared_config.result_expires  # 86400 seconds is the default
 
 task_default_priority = shared_config.task_default_priority

--- a/backend/tests/unit/onyx/redis/test_redis_sentinel.py
+++ b/backend/tests/unit/onyx/redis/test_redis_sentinel.py
@@ -1,5 +1,7 @@
 import importlib
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import cast
 from unittest.mock import patch
 
@@ -83,38 +85,6 @@ def test_sentinel_tls_and_auth_apply_to_both_connection_sets() -> None:
 
 # --- Celery broker / result backend ---------------------------------------
 
-
-def test_celery_uses_sentinel_urls_and_master_name() -> None:
-    env = {
-        "REDIS_SENTINEL_HOSTS": "s1:26379,s2:26379",
-        "REDIS_SENTINEL_MASTER_NAME": "mymaster",
-    }
-    with patch.dict(os.environ, env):
-        import onyx.background.celery.configs.base as celery_base
-        import onyx.configs.app_configs as app_configs
-
-        importlib.reload(app_configs)
-        importlib.reload(celery_base)
-        try:
-            # the db goes on every node, not just the last one
-            assert celery_base.broker_url == (
-                "sentinel://s1:26379/15;sentinel://s2:26379/15"
-            )
-            assert celery_base.result_backend == (
-                "sentinel://s1:26379/14;sentinel://s2:26379/14"
-            )
-            assert celery_base.broker_transport_options["master_name"] == "mymaster"
-            assert (
-                celery_base.result_backend_transport_options["master_name"]
-                == "mymaster"
-            )
-        finally:
-            importlib.reload(app_configs)
-            importlib.reload(celery_base)
-
-
-# --- per-app Celery config modules ----------------------------------------
-
 # Celery reads settings as attributes of the module given to
 # `config_from_object`. A setting that base.py defines but a per-app module
 # does not re-export falls back to the Celery default, silently.
@@ -133,6 +103,54 @@ _APP_CONFIG_MODULES = [
         "user_file_processing",
     )
 ]
+
+
+def _reload_celery_configs() -> None:
+    import onyx.background.celery.configs.base as celery_base
+    import onyx.configs.app_configs as app_configs
+
+    importlib.reload(app_configs)
+    importlib.reload(celery_base)
+    for module_name in _APP_CONFIG_MODULES:
+        importlib.reload(importlib.import_module(module_name))
+
+
+@contextmanager
+def _celery_config_env(env: dict[str, str]) -> Iterator[None]:
+    """Reload the Celery config modules under `env`, then restore them.
+
+    The restore runs outside the env patch on purpose. These modules read
+    os.environ as they execute, so reloading while it is still patched would
+    leave the Sentinel settings in place for every later test.
+    """
+    try:
+        with patch.dict(os.environ, env):
+            _reload_celery_configs()
+            yield
+    finally:
+        _reload_celery_configs()
+
+
+def test_celery_uses_sentinel_urls_and_master_name() -> None:
+    env = {
+        "REDIS_SENTINEL_HOSTS": "s1:26379,s2:26379",
+        "REDIS_SENTINEL_MASTER_NAME": "mymaster",
+    }
+    with _celery_config_env(env):
+        import onyx.background.celery.configs.base as celery_base
+
+        # the db goes on every node, not just the last one
+        assert celery_base.broker_url == (
+            "sentinel://s1:26379/15;sentinel://s2:26379/15"
+        )
+        assert celery_base.result_backend == (
+            "sentinel://s1:26379/14;sentinel://s2:26379/14"
+        )
+        assert celery_base.broker_transport_options["master_name"] == "mymaster"
+        assert celery_base.result_backend_transport_options["master_name"] == "mymaster"
+
+
+# --- per-app Celery config modules ----------------------------------------
 
 # Redis connection settings that every app must share with base.py.
 _SHARED_CONNECTION_SETTINGS = [
@@ -154,6 +172,10 @@ _SHARED_CONNECTION_SETTINGS = [
 def test_app_configs_reexport_all_shared_connection_settings() -> None:
     import onyx.background.celery.configs.base as celery_base
 
+    # normalize first: this assertion holds for any env, but only if base and
+    # the app modules were last loaded under the same one
+    _reload_celery_configs()
+
     for module_name in _APP_CONFIG_MODULES:
         module = importlib.import_module(module_name)
         for setting in _SHARED_CONNECTION_SETTINGS:
@@ -173,36 +195,23 @@ def test_every_app_resolves_sentinel_master_name_on_both_connections() -> None:
         "REDIS_SENTINEL_MASTER_NAME": "mymaster",
         "REDIS_SENTINEL_PASSWORD": "sentinelpw",
     }
-    with patch.dict(os.environ, env):
-        import onyx.background.celery.configs.base as celery_base
-        import onyx.configs.app_configs as app_configs
+    with _celery_config_env(env):
+        for module_name in _APP_CONFIG_MODULES:
+            module = importlib.import_module(module_name)
+            app = Celery(f"test-{module_name}")
+            app.config_from_object(module)
 
-        importlib.reload(app_configs)
-        importlib.reload(celery_base)
-        try:
-            for module_name in _APP_CONFIG_MODULES:
-                module = importlib.reload(importlib.import_module(module_name))
-                app = Celery(f"test-{module_name}")
-                app.config_from_object(module)
-
-                broker_options = cast(dict, app.conf["broker_transport_options"])
-                backend_options = cast(
-                    dict, app.conf["result_backend_transport_options"]
-                )
-                assert broker_options["master_name"] == "mymaster", (
-                    f"{module_name} broker lost the master name"
-                )
-                assert backend_options["master_name"] == "mymaster", (
-                    f"{module_name} result backend lost the master name"
-                )
-                assert backend_options["sentinel_kwargs"] == {
-                    "password": "sentinelpw"
-                }, f"{module_name} result backend lost the sentinel password"
-        finally:
-            importlib.reload(app_configs)
-            importlib.reload(celery_base)
-            for module_name in _APP_CONFIG_MODULES:
-                importlib.reload(importlib.import_module(module_name))
+            broker_options = cast(dict, app.conf["broker_transport_options"])
+            backend_options = cast(dict, app.conf["result_backend_transport_options"])
+            assert broker_options["master_name"] == "mymaster", (
+                f"{module_name} broker lost the master name"
+            )
+            assert backend_options["master_name"] == "mymaster", (
+                f"{module_name} result backend lost the master name"
+            )
+            assert backend_options["sentinel_kwargs"] == {"password": "sentinelpw"}, (
+                f"{module_name} result backend lost the sentinel password"
+            )
 
 
 def test_sentinel_urls_keep_the_configured_redis_db() -> None:
@@ -218,38 +227,27 @@ def test_sentinel_urls_keep_the_configured_redis_db() -> None:
         "REDIS_SENTINEL_MASTER_NAME": "mymaster",
         "REDIS_PASSWORD": "datapw",
     }
-    with patch.dict(os.environ, env):
-        import onyx.background.celery.configs.base as celery_base
+    with _celery_config_env(env):
         import onyx.configs.app_configs as app_configs
 
-        importlib.reload(app_configs)
-        importlib.reload(celery_base)
-        try:
-            beat = importlib.reload(
-                importlib.import_module("onyx.background.celery.configs.beat")
-            )
-            app = Celery("test-sentinel-db")
-            app.config_from_object(beat)
+        beat = importlib.import_module("onyx.background.celery.configs.beat")
+        app = Celery("test-sentinel-db")
+        app.config_from_object(beat)
 
-            # kombu takes the db from the primary URL. It read "/" (-> db 0)
-            # while the db sat on the last node.
-            broker = Connection(
-                app.conf["broker_url"],
-                transport_options=app.conf["broker_transport_options"],
-            )
-            assert broker.virtual_host == str(app_configs.REDIS_DB_NUMBER_CELERY)
+        # kombu takes the db from the primary URL. It read "/" (-> db 0) while
+        # the db sat on the last node.
+        broker = Connection(
+            app.conf["broker_url"],
+            transport_options=app.conf["broker_transport_options"],
+        )
+        assert broker.virtual_host == str(app_configs.REDIS_DB_NUMBER_CELERY)
 
-            backend = SentinelBackend(app=app, url=app.conf["result_backend"])
-            connparams = cast(dict, backend.connparams)  # ty: ignore[unresolved-attribute]
-            assert connparams["db"] == app_configs.REDIS_DB_NUMBER_CELERY_RESULT_BACKEND
-            # master auth still rides the URL, and every node is discovered
-            assert connparams["password"] == "datapw"
-            assert len(connparams["hosts"]) == 3
-        finally:
-            importlib.reload(app_configs)
-            importlib.reload(celery_base)
-            for module_name in _APP_CONFIG_MODULES:
-                importlib.reload(importlib.import_module(module_name))
+        backend = SentinelBackend(app=app, url=app.conf["result_backend"])
+        connparams = cast(dict, backend.connparams)  # ty: ignore[unresolved-attribute]
+        assert connparams["db"] == app_configs.REDIS_DB_NUMBER_CELERY_RESULT_BACKEND
+        # master auth still rides the URL, and every node is discovered
+        assert connparams["password"] == "datapw"
+        assert len(connparams["hosts"]) == 3
 
 
 # --- config validation + Celery TLS ---------------------------------------
@@ -280,22 +278,15 @@ def test_sentinel_with_iam_auth_raises() -> None:
 
 def test_celery_sentinel_kwargs_enable_ssl_under_tls() -> None:
     env = {"REDIS_SENTINEL_HOSTS": "s1:26379", "REDIS_SSL": "true"}
-    with patch.dict(os.environ, env):
+    with _celery_config_env(env):
         import onyx.background.celery.configs.base as celery_base
-        import onyx.configs.app_configs as app_configs
 
-        importlib.reload(app_configs)
-        importlib.reload(celery_base)
-        try:
-            sk = cast(dict, celery_base.broker_transport_options["sentinel_kwargs"])
-            # cert params are inert without the explicit ssl flag
-            assert sk["ssl"] is True
-            # broker_use_ssl is a Celery setting; its presence enables TLS and it
-            # must NOT carry the ssl key
-            assert "ssl" not in celery_base.broker_use_ssl
-        finally:
-            importlib.reload(app_configs)
-            importlib.reload(celery_base)
+        sk = cast(dict, celery_base.broker_transport_options["sentinel_kwargs"])
+        # cert params are inert without the explicit ssl flag
+        assert sk["ssl"] is True
+        # broker_use_ssl is a Celery setting; its presence enables TLS and it
+        # must NOT carry the ssl key
+        assert "ssl" not in celery_base.broker_use_ssl
 
 
 def test_out_of_range_sentinel_port_raises() -> None:

--- a/backend/tests/unit/onyx/redis/test_redis_sentinel.py
+++ b/backend/tests/unit/onyx/redis/test_redis_sentinel.py
@@ -112,6 +112,98 @@ def test_celery_uses_sentinel_urls_and_master_name() -> None:
             importlib.reload(celery_base)
 
 
+# --- per-app Celery config modules ----------------------------------------
+
+# Celery reads settings as attributes of the module given to
+# `config_from_object`. A setting that base.py defines but a per-app module
+# does not re-export falls back to the Celery default, silently.
+_APP_CONFIG_MODULES = [
+    f"onyx.background.celery.configs.{name}"
+    for name in (
+        "beat",
+        "client",
+        "docfetching",
+        "docprocessing",
+        "heavy",
+        "light",
+        "monitoring",
+        "primary",
+        "scheduled_tasks",
+        "user_file_processing",
+    )
+]
+
+# Redis connection settings that every app must share with base.py.
+_SHARED_CONNECTION_SETTINGS = [
+    "broker_url",
+    "broker_connection_retry_on_startup",
+    "broker_pool_limit",
+    "broker_transport_options",
+    "broker_use_ssl",
+    "redis_socket_keepalive",
+    "redis_retry_on_timeout",
+    "redis_backend_health_check_interval",
+    "redis_backend_use_ssl",
+    "result_backend",
+    "result_backend_transport_options",
+    "result_expires",
+]
+
+
+def test_app_configs_reexport_all_shared_connection_settings() -> None:
+    import onyx.background.celery.configs.base as celery_base
+
+    for module_name in _APP_CONFIG_MODULES:
+        module = importlib.import_module(module_name)
+        for setting in _SHARED_CONNECTION_SETTINGS:
+            assert hasattr(module, setting), f"{module_name} does not set {setting}"
+            assert getattr(module, setting) == getattr(celery_base, setting), (
+                f"{module_name} {setting} does not match base"
+            )
+
+
+def test_every_app_resolves_sentinel_master_name_on_both_connections() -> None:
+    """Beat failed with "No master found for None" because the app config
+    modules re-exported result_backend but not its transport options."""
+    from celery import Celery
+
+    env = {
+        "REDIS_SENTINEL_HOSTS": "s1:26379,s2:26379",
+        "REDIS_SENTINEL_MASTER_NAME": "mymaster",
+        "REDIS_SENTINEL_PASSWORD": "sentinelpw",
+    }
+    with patch.dict(os.environ, env):
+        import onyx.background.celery.configs.base as celery_base
+        import onyx.configs.app_configs as app_configs
+
+        importlib.reload(app_configs)
+        importlib.reload(celery_base)
+        try:
+            for module_name in _APP_CONFIG_MODULES:
+                module = importlib.reload(importlib.import_module(module_name))
+                app = Celery(f"test-{module_name}")
+                app.config_from_object(module)
+
+                broker_options = cast(dict, app.conf["broker_transport_options"])
+                backend_options = cast(
+                    dict, app.conf["result_backend_transport_options"]
+                )
+                assert broker_options["master_name"] == "mymaster", (
+                    f"{module_name} broker lost the master name"
+                )
+                assert backend_options["master_name"] == "mymaster", (
+                    f"{module_name} result backend lost the master name"
+                )
+                assert backend_options["sentinel_kwargs"] == {
+                    "password": "sentinelpw"
+                }, f"{module_name} result backend lost the sentinel password"
+        finally:
+            importlib.reload(app_configs)
+            importlib.reload(celery_base)
+            for module_name in _APP_CONFIG_MODULES:
+                importlib.reload(importlib.import_module(module_name))
+
+
 # --- config validation + Celery TLS ---------------------------------------
 
 

--- a/backend/tests/unit/onyx/redis/test_redis_sentinel.py
+++ b/backend/tests/unit/onyx/redis/test_redis_sentinel.py
@@ -96,11 +96,12 @@ def test_celery_uses_sentinel_urls_and_master_name() -> None:
         importlib.reload(app_configs)
         importlib.reload(celery_base)
         try:
+            # the db goes on every node, not just the last one
             assert celery_base.broker_url == (
-                "sentinel://s1:26379;sentinel://s2:26379/15"
+                "sentinel://s1:26379/15;sentinel://s2:26379/15"
             )
-            assert celery_base.result_backend.startswith(
-                "sentinel://s1:26379;sentinel://s2:26379/"
+            assert celery_base.result_backend == (
+                "sentinel://s1:26379/14;sentinel://s2:26379/14"
             )
             assert celery_base.broker_transport_options["master_name"] == "mymaster"
             assert (
@@ -197,6 +198,53 @@ def test_every_app_resolves_sentinel_master_name_on_both_connections() -> None:
                 assert backend_options["sentinel_kwargs"] == {
                     "password": "sentinelpw"
                 }, f"{module_name} result backend lost the sentinel password"
+        finally:
+            importlib.reload(app_configs)
+            importlib.reload(celery_base)
+            for module_name in _APP_CONFIG_MODULES:
+                importlib.reload(importlib.import_module(module_name))
+
+
+def test_sentinel_urls_keep_the_configured_redis_db() -> None:
+    """Celery and kombu both read the db from the first node in the list. A db
+    on the last node only sent the broker, the result backend, and the app
+    itself all into db 0."""
+    from celery import Celery
+    from celery.backends.redis import SentinelBackend
+    from kombu import Connection
+
+    env = {
+        "REDIS_SENTINEL_HOSTS": "s1:26379,s2:26379,s3:26379",
+        "REDIS_SENTINEL_MASTER_NAME": "mymaster",
+        "REDIS_PASSWORD": "datapw",
+    }
+    with patch.dict(os.environ, env):
+        import onyx.background.celery.configs.base as celery_base
+        import onyx.configs.app_configs as app_configs
+
+        importlib.reload(app_configs)
+        importlib.reload(celery_base)
+        try:
+            beat = importlib.reload(
+                importlib.import_module("onyx.background.celery.configs.beat")
+            )
+            app = Celery("test-sentinel-db")
+            app.config_from_object(beat)
+
+            # kombu takes the db from the primary URL. It read "/" (-> db 0)
+            # while the db sat on the last node.
+            broker = Connection(
+                app.conf["broker_url"],
+                transport_options=app.conf["broker_transport_options"],
+            )
+            assert broker.virtual_host == str(app_configs.REDIS_DB_NUMBER_CELERY)
+
+            backend = SentinelBackend(app=app, url=app.conf["result_backend"])
+            connparams = cast(dict, backend.connparams)  # ty: ignore[unresolved-attribute]
+            assert connparams["db"] == app_configs.REDIS_DB_NUMBER_CELERY_RESULT_BACKEND
+            # master auth still rides the URL, and every node is discovered
+            assert connparams["password"] == "datapw"
+            assert len(connparams["hosts"]) == 3
         finally:
             importlib.reload(app_configs)
             importlib.reload(celery_base)


### PR DESCRIPTION
## Description

Redis Sentinel support is broken for Celery. A self-hosted deployment moving onto Sentinel found that all workers started, but `celery-beat` failed on every tick:

```
Couldn't apply scheduled task check-for-indexing-public:
No master found for None : ... AuthenticationError('Authentication required.')
```

Two independent bugs, both in the Celery Sentinel config.

### 1. The Sentinel options never reached the result backend

Celery reads settings as attributes of the module given to `config_from_object`. `configs/base.py` computes the Sentinel settings correctly, but all 10 per-app config modules re-exported `result_backend` while omitting `result_backend_transport_options`. The omitted setting silently fell back to Celery's default of `{}`.

`SentinelBackend` reads both failing values from that dict (`celery/backends/redis.py:462,655,668`):

- `master_name` → `None` ⇒ `No master found for None`
- `sentinel_kwargs` → `{}` ⇒ no sentinel password ⇒ `AuthenticationError`

Beat is the loud victim because `send_task` → `backend.on_task_call` touches the result backend on every tick. Workers ride the broker, whose transport options *were* re-exported.

`broker_use_ssl` and `redis_backend_use_ssl` had the same gap, which silently dropped TLS on the Sentinel data connections.

### 2. The configured Redis db was dropped

The Sentinel URL is a `;`-separated node list and the db went on the end, so only the last node carried it. Both parsers read the db from the front: Celery's `SentinelBackend._params_from_url` takes `db` from `hosts[0]`, and kombu reads `virtual_host` from the primary URL. Both saw no db and fell back to db 0.

Under Sentinel the broker (db 15), the result backend (db 14), and the Onyx application Redis (db 0) all shared one keyspace.

Both bugs date to #12347, which added Sentinel support. Non-Sentinel deployments are unaffected — those URLs are built on a separate branch and are unchanged.

### Upgrade note

Sentinel deployments move from db 0 onto the intended dbs 15 / 14. Queued Celery messages left in db 0 are dropped, so drain or accept the loss of in-flight background tasks. Beat re-schedules its periodic tasks on the next tick.

Sentinel deployments whose sentinels require auth must set `REDIS_SENTINEL_PASSWORD`. It is distinct from `REDIS_PASSWORD`, which authenticates the master.

## How Has This Been Tested?

Added 3 regression tests in `backend/tests/unit/onyx/redis/test_redis_sentinel.py`. Each was confirmed to fail on the unfixed code (`KeyError: 'master_name'` and `assert 0 == 15`) and pass after:

- every app config module re-exports the full shared connection set
- every app resolves `master_name` + `sentinel_kwargs` on **both** broker and result backend
- broker and result backend keep their configured db, asserted through the real kombu and Celery parsers rather than string matching

The existing `test_celery_uses_sentinel_urls_and_master_name` encoded the buggy URL shape and was updated.

Also verified by building the real `SentinelBackend` and kombu `Connection` from each of the 10 Celery apps across four configurations — Sentinel, Sentinel + TLS, plain Redis, plain Redis + TLS — confirming the fix and no regression on the non-Sentinel paths.

`backend/tests/unit/onyx/redis` and `backend/tests/unit/onyx/background`: 99 passed. Pre-commit clean.

Not tested against a live Sentinel cluster.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores working Redis Sentinel support for `celery` beat and the result backend. Previously: beat failed on each tick (“No master found for None”) and broker/backend silently fell back to db 0; now both connections resolve the Sentinel master with auth and keep their configured dbs.

- Builds the Sentinel URL with the db on every `sentinel://` node via `_sentinel_url(db)`; applies to broker and result backend.
- Re-exports `result_backend_transport_options`, `broker_use_ssl`, and `redis_backend_use_ssl` from all app config modules so the result backend receives `master_name` and `sentinel_kwargs`.
- Adds regression tests for URL shape, per-app re-exports, and db parsing through `celery` and `kombu`; introduces `_celery_config_env` to reload configs under patched env without leaking settings; non-Sentinel paths unchanged.

**Rollout/Migration**
- Sentinel deployments move from db 0 to db 15 (broker) and db 14 (result backend). Drain db 0 or accept loss of in-flight tasks.
- If sentinels require auth, set `REDIS_SENTINEL_PASSWORD` (distinct from `REDIS_PASSWORD`).

<sup>Written for commit 4ea85964c563b71813ee81075a2bc6e58a1b69f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

