### PR TITLE
feat(notifications): add severity tier and min_severity filtering

### DIFF
--- a/backend/alembic/versions/f8048443da9e_add_notification_severity.py
+++ b/backend/alembic/versions/f8048443da9e_add_notification_severity.py
@@ -1,7 +1,7 @@
 """add notification severity
 
 Revision ID: f8048443da9e
-Revises: 3350a25df58e
+Revises: 8d1297b43210
 Create Date: 2026-08-13 15:22:27.752583
 
 """
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "f8048443da9e"
-down_revision = "3350a25df58e"
+down_revision = "8d1297b43210"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/f8048443da9e_add_notification_severity.py
+++ b/backend/alembic/versions/f8048443da9e_add_notification_severity.py
@@ -37,8 +37,9 @@ def upgrade() -> None:
         """
     )
     # License expiry: t_1d / grace stages and failed renewals render as
-    # errors (mirrors the frontend's stage-severity threshold); earlier
-    # stages render as warnings.
+    # errors; earlier stages render as warnings. Mirrors _severity_for_stage
+    # in ee/onyx/utils/license_notifications.py — duplicated here because
+    # migrations must not import application code.
     op.execute(
         """
         UPDATE notification

--- a/backend/alembic/versions/f8048443da9e_add_notification_severity.py
+++ b/backend/alembic/versions/f8048443da9e_add_notification_severity.py
@@ -1,0 +1,57 @@
+"""add notification severity
+
+Revision ID: f8048443da9e
+Revises: 3350a25df58e
+Create Date: 2026-08-13 15:22:27.752583
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f8048443da9e"
+down_revision = "3350a25df58e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "notification",
+        sa.Column(
+            "severity",
+            sa.String(length=16),
+            nullable=False,
+            server_default="INFO",
+        ),
+    )
+
+    # Backfill the types that render as banners today so their banners
+    # survive the switch to severity-driven eligibility.
+    op.execute(
+        """
+        UPDATE notification
+        SET severity = 'WARNING'
+        WHERE notif_type IN ('TRIAL_ENDS_TWO_DAYS', 'SYSTEM_ANNOUNCEMENT')
+        """
+    )
+    # License expiry: t_1d / grace stages and failed renewals render as
+    # errors (mirrors the frontend's stage-severity threshold); earlier
+    # stages render as warnings.
+    op.execute(
+        """
+        UPDATE notification
+        SET severity = CASE
+            WHEN additional_data->>'stage' IN ('t_1d', 'grace')
+                OR (additional_data->>'renewal_failed')::boolean IS TRUE
+            THEN 'ERROR'
+            ELSE 'WARNING'
+        END
+        WHERE notif_type = 'LICENSE_EXPIRY_WARNING'
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("notification", "severity")

--- a/backend/ee/onyx/utils/license_notifications.py
+++ b/backend/ee/onyx/utils/license_notifications.py
@@ -23,6 +23,7 @@ from onyx.auth.email_utils import build_html_email, send_email
 from onyx.auth.schemas import UserRole
 from onyx.configs.app_configs import EMAIL_CONFIGURED
 from onyx.configs.constants import ONYX_DEFAULT_APPLICATION_NAME, NotificationType
+from onyx.db.enums import NotificationSeverity
 from onyx.db.models import User
 from onyx.db.notification import batch_create_notifications
 from onyx.db.users import get_active_admin_users
@@ -158,6 +159,15 @@ def _build_additional_data(
     return data
 
 
+def _severity_for_stage(
+    stage: ExpiryWarningStage, renewal_error: str | None = None
+) -> NotificationSeverity:
+    """t_1d, grace, and failed renewals are errors; earlier stages warn."""
+    if renewal_error or stage in (ExpiryWarningStage.T_1D, ExpiryWarningStage.GRACE):
+        return NotificationSeverity.ERROR
+    return NotificationSeverity.WARNING
+
+
 def notify_admins_for_stage(
     db_session: Session,
     stage: ExpiryWarningStage,
@@ -198,6 +208,7 @@ def notify_admins_for_stage(
         title=title,
         description=description,
         additional_data=additional_data,
+        severity=_severity_for_stage(stage, renewal_error),
     )
     if not inserted_admin_ids:
         return
@@ -261,4 +272,5 @@ def ensure_license_expiry_notification_for_user(
         title=title,
         description=description,
         additional_data=additional_data,
+        severity=_severity_for_stage(stage),
     )

--- a/backend/ee/onyx/utils/license_notifications.py
+++ b/backend/ee/onyx/utils/license_notifications.py
@@ -162,7 +162,8 @@ def _build_additional_data(
 def _severity_for_stage(
     stage: ExpiryWarningStage, renewal_error: str | None = None
 ) -> NotificationSeverity:
-    """t_1d, grace, and failed renewals are errors; earlier stages warn."""
+    """t_1d, grace, and failed renewals are errors; earlier stages warn.
+    Migration f8048443da9e backfills historical rows with the same mapping."""
     if renewal_error or stage in (ExpiryWarningStage.T_1D, ExpiryWarningStage.GRACE):
         return NotificationSeverity.ERROR
     return NotificationSeverity.WARNING

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -73,6 +73,16 @@ class IndexingStatus(str, PyEnum):
         )
 
 
+class NotificationSeverity(str, PyEnum):
+    """How loud a notification renders: INFO stays in the bell popover,
+    WARNING and ERROR also surface in the banner queue. Declared in
+    ascending loudness."""
+
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
 class PermissionSyncStatus(str, PyEnum):
     """Status enum for permission sync attempts"""
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -94,6 +94,7 @@ from onyx.db.enums import (
     MCPOAuthProviderMode,
     MCPServerStatus,
     MCPTransport,
+    NotificationSeverity,
     OpenSearchDocumentMigrationStatus,
     OpenSearchTenantMigrationStatus,
     PatType,
@@ -601,6 +602,11 @@ class Notification(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     notif_type: Mapped[NotificationType] = mapped_column(
         Enum(NotificationType, native_enum=False)
+    )
+    severity: Mapped[NotificationSeverity] = mapped_column(
+        Enum(NotificationSeverity, native_enum=False),
+        default=NotificationSeverity.INFO,
+        server_default=NotificationSeverity.INFO.name,
     )
     user_id: Mapped[UUID | None] = mapped_column(
         ForeignKey("user.id", ondelete="CASCADE"), nullable=True

--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -14,11 +14,6 @@ from onyx.db.enums import NotificationSeverity
 from onyx.db.models import Notification, User
 
 
-def _severity_at_least(min_severity: NotificationSeverity) -> ColumnElement[bool]:
-    ordered = list(NotificationSeverity)
-    return Notification.severity.in_(ordered[ordered.index(min_severity) :])
-
-
 def _notification_additional_data_key() -> ColumnElement[dict]:
     """Normalize legacy JSON null and SQL NULL values to the empty-object key."""
     return func.coalesce(
@@ -44,7 +39,10 @@ def _notification_filters(
     if notif_type:
         filters.append(Notification.notif_type == notif_type)
     if min_severity is not None:
-        filters.append(_severity_at_least(min_severity))
+        ordered = list(NotificationSeverity)
+        filters.append(
+            Notification.severity.in_(ordered[ordered.index(min_severity) :])
+        )
     return filters
 
 

--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -268,6 +268,10 @@ def batch_create_notifications(
     Callers that need to fire side effects only on fresh inserts (emails, webhooks)
     can iterate the returned set without re-triggering on idempotent retries.
 
+    Severity is set only on fresh inserts: a conflicting row keeps its original
+    severity. Producers that need an escalation to re-alert must vary
+    additional_data (as the license flow does with its stage field).
+
     Relies on unique index on (user_id, notif_type, COALESCE(additional_data, '{}'))
     """
     if not user_ids:

--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -10,7 +10,13 @@ from sqlalchemy.sql.elements import ColumnElement
 
 from onyx.auth.schemas import UserRole
 from onyx.configs.constants import NotificationType
+from onyx.db.enums import NotificationSeverity
 from onyx.db.models import Notification, User
+
+
+def _severity_at_least(min_severity: NotificationSeverity) -> ColumnElement[bool]:
+    ordered = list(NotificationSeverity)
+    return Notification.severity.in_(ordered[ordered.index(min_severity) :])
 
 
 def _notification_additional_data_key() -> ColumnElement[dict]:
@@ -28,6 +34,7 @@ def _notification_filters(
     user: User | None,
     notif_type: NotificationType | None = None,
     include_dismissed: bool = True,
+    min_severity: NotificationSeverity | None = None,
 ) -> list[ColumnElement[bool]]:
     filters = [
         Notification.user_id == user.id if user else Notification.user_id.is_(None)
@@ -36,6 +43,8 @@ def _notification_filters(
         filters.append(Notification.dismissed.is_(False))
     if notif_type:
         filters.append(Notification.notif_type == notif_type)
+    if min_severity is not None:
+        filters.append(_severity_at_least(min_severity))
     return filters
 
 
@@ -48,6 +57,7 @@ def create_notification(
     additional_data: dict | None = None,
     autocommit: bool = True,
     refresh_existing: bool = True,
+    severity: NotificationSeverity = NotificationSeverity.INFO,
 ) -> Notification:
     """Create or return a notification without racing concurrent user inserts."""
 
@@ -79,6 +89,7 @@ def create_notification(
         .values(
             user_id=user_id,
             notif_type=notif_type,
+            severity=severity,
             title=title,
             description=description,
             dismissed=False,
@@ -154,12 +165,14 @@ def get_notifications(
     include_dismissed: bool = True,
     limit: int | None = None,
     offset: int = 0,
+    min_severity: NotificationSeverity | None = None,
 ) -> list[Notification]:
     query = select(Notification).where(
         *_notification_filters(
             user=user,
             notif_type=notif_type,
             include_dismissed=include_dismissed,
+            min_severity=min_severity,
         )
     )
     # Sort: undismissed first, then by date (newest first)
@@ -177,6 +190,7 @@ def count_notifications(
     user: User | None,
     db_session: Session,
     notif_type: NotificationType | None = None,
+    min_severity: NotificationSeverity | None = None,
 ) -> tuple[int, int]:
     query = select(
         func.count(Notification.id),
@@ -185,6 +199,7 @@ def count_notifications(
         *_notification_filters(
             user=user,
             notif_type=notif_type,
+            min_severity=min_severity,
         )
     )
     total_items, undismissed_count = db_session.execute(query).one()
@@ -243,6 +258,7 @@ def batch_create_notifications(
     title: str,
     description: str | None = None,
     additional_data: dict | None = None,
+    severity: NotificationSeverity = NotificationSeverity.INFO,
 ) -> set[UUID]:
     """
     Create notifications for multiple users in a single batch operation.
@@ -266,6 +282,7 @@ def batch_create_notifications(
         {
             "user_id": uid,
             "notif_type": notif_type,
+            "severity": severity,
             "title": title,
             "description": description,
             "dismissed": False,

--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -1,10 +1,14 @@
+from threading import Lock
+from uuid import UUID
+
+from cachetools import TTLCache
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
 from onyx.configs.constants import NotificationType
 from onyx.db.engine.sql_engine import get_session
-from onyx.db.enums import Permission
+from onyx.db.enums import NotificationSeverity, Permission
 from onyx.db.models import User
 from onyx.db.notification import (
     count_notifications,
@@ -36,6 +40,23 @@ router = APIRouter(prefix="/notifications")
 
 DEFAULT_NOTIFICATIONS_PAGE_SIZE = 10
 MAX_NOTIFICATIONS_PAGE_SIZE = 50
+
+# The banner queue polls severity-only requests every minute per open tab, so
+# run its lazy-materialization ensures at most once per user per window.
+# Per-replica and best-effort: a miss only repeats an idempotent ensure.
+ENSURE_THROTTLE_SECONDS = 300
+_polled_ensure_cache: TTLCache[UUID, bool] = TTLCache(
+    maxsize=5000, ttl=ENSURE_THROTTLE_SECONDS
+)
+_polled_ensure_lock = Lock()
+
+
+def _should_run_polled_ensures(user_id: UUID) -> bool:
+    with _polled_ensure_lock:
+        if user_id in _polled_ensure_cache:
+            return False
+        _polled_ensure_cache[user_id] = True
+        return True
 
 
 def _check_for_notifications_to_create(
@@ -91,17 +112,20 @@ def get_notifications_api(
         DEFAULT_NOTIFICATIONS_PAGE_SIZE, ge=1, le=MAX_NOTIFICATIONS_PAGE_SIZE
     ),
     notif_type: NotificationType | None = None,
+    min_severity: NotificationSeverity | None = None,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> PaginatedNotifications:
     """
     Get a page of notifications for the current user, optionally filtered to a
-    single notif_type.
+    single notif_type and/or a minimum severity (min_severity returns rows at
+    that severity or louder — the banner queue asks for WARNING and up).
 
-    Note: the first unfiltered page runs the generic create-checks. A
-    type-filtered request skips them, except a SYSTEM_ANNOUNCEMENT or
-    LICENSE_EXPIRY_WARNING filter still ensures that type's current
-    notification exists for the requesting user.
+    Note: the first unfiltered page runs the generic create-checks. A filtered
+    request skips them, except that SYSTEM_ANNOUNCEMENT and
+    LICENSE_EXPIRY_WARNING are ensured whenever they could appear in the
+    response: always on their type filter, and throttled per user on
+    severity-only requests (the banner queue's polled fetch).
 
     Examples of checks that create new notifications:
     - Checking for new release notes the user hasn't seen
@@ -109,17 +133,30 @@ def get_notifications_api(
     - Explicitly announcing breaking changes
     """
     if page_num == 0:
-        if notif_type is None:
+        if notif_type is None and min_severity is None:
             _check_for_notifications_to_create(user, db_session)
-        if notif_type in (None, NotificationType.SYSTEM_ANNOUNCEMENT):
-            _ensure_system_announcement_notification(user, db_session)
-        if notif_type in (None, NotificationType.LICENSE_EXPIRY_WARNING):
-            _ensure_license_expiry_notification(user, db_session)
+        # A severity-only request is the banner queue's polled fetch: its
+        # ensures are throttled. Other requests keep the always-run behavior.
+        polled = min_severity is not None and notif_type is None
+        if not polled or _should_run_polled_ensures(user.id):
+            for banner_type, ensure in (
+                (
+                    NotificationType.SYSTEM_ANNOUNCEMENT,
+                    _ensure_system_announcement_notification,
+                ),
+                (
+                    NotificationType.LICENSE_EXPIRY_WARNING,
+                    _ensure_license_expiry_notification,
+                ),
+            ):
+                if polled or notif_type in (None, banner_type):
+                    ensure(user, db_session)
 
     total_items, undismissed_count = count_notifications(
         user=user,
         db_session=db_session,
         notif_type=notif_type,
+        min_severity=min_severity,
     )
     offset = page_num * page_size
     notifications = [
@@ -131,6 +168,7 @@ def get_notifications_api(
             include_dismissed=True,
             limit=page_size,
             offset=offset,
+            min_severity=min_severity,
         )
     ]
     return PaginatedNotifications(

--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -51,12 +51,14 @@ _polled_ensure_cache: TTLCache[UUID, bool] = TTLCache(
 _polled_ensure_lock = Lock()
 
 
-def _should_run_polled_ensures(user_id: UUID) -> bool:
+def _polled_ensures_due(user_id: UUID) -> bool:
     with _polled_ensure_lock:
-        if user_id in _polled_ensure_cache:
-            return False
+        return user_id not in _polled_ensure_cache
+
+
+def _mark_polled_ensures_done(user_id: UUID) -> None:
+    with _polled_ensure_lock:
         _polled_ensure_cache[user_id] = True
-        return True
 
 
 def _check_for_notifications_to_create(
@@ -83,16 +85,18 @@ def _check_for_notifications_to_create(
         logger.exception("Failed to check for release notes in notifications endpoint")
 
 
-def _ensure_system_announcement_notification(user: User, db_session: Session) -> None:
+def _ensure_system_announcement_notification(user: User, db_session: Session) -> bool:
     """Materialize the current admin-authored site-wide announcement on read so
     it appears without waiting for a background pass. No-op when none is set."""
     try:
         ensure_system_announcement_notification(user, db_session)
+        return True
     except Exception:
         logger.exception("Failed to ensure system announcement notification on read")
+        return False
 
 
-def _ensure_license_expiry_notification(user: User, db_session: Session) -> None:
+def _ensure_license_expiry_notification(user: User, db_session: Session) -> bool:
     """Self-hosted EE only: create the admin's current-stage license-expiry
     notification on read so the banner appears without waiting for the daily
     task. No-op on non-EE builds (and for non-admins / no active warning)."""
@@ -101,8 +105,10 @@ def _ensure_license_expiry_notification(user: User, db_session: Session) -> None
             "onyx.utils.license_notifications",
             "ensure_license_expiry_notification_for_user",
         )(user, db_session)
+        return True
     except Exception:
         logger.exception("Failed to ensure license expiry notification on read")
+        return False
 
 
 @router.get("")
@@ -136,9 +142,12 @@ def get_notifications_api(
         if notif_type is None and min_severity is None:
             _check_for_notifications_to_create(user, db_session)
         # A severity-only request is the banner queue's polled fetch: its
-        # ensures are throttled. Other requests keep the always-run behavior.
+        # ensures are throttled, and a user is only marked done once both
+        # succeed so a transient failure retries on the next poll. Other
+        # requests keep the always-run behavior.
         polled = min_severity is not None and notif_type is None
-        if not polled or _should_run_polled_ensures(user.id):
+        if not polled or _polled_ensures_due(user.id):
+            succeeded: list[bool] = []
             for banner_type, ensure in (
                 (
                     NotificationType.SYSTEM_ANNOUNCEMENT,
@@ -150,7 +159,9 @@ def get_notifications_api(
                 ),
             ):
                 if polled or notif_type in (None, banner_type):
-                    ensure(user, db_session)
+                    succeeded.append(ensure(user, db_session))
+            if polled and all(succeeded):
+                _mark_polled_ensures_done(user.id)
 
     total_items, undismissed_count = count_notifications(
         user=user,

--- a/backend/onyx/server/features/notifications/models.py
+++ b/backend/onyx/server/features/notifications/models.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pydantic import BaseModel, ConfigDict
 
 from onyx.configs.constants import NotificationType
+from onyx.db.enums import NotificationSeverity
 
 
 class NotificationResponse(BaseModel):
@@ -10,6 +11,7 @@ class NotificationResponse(BaseModel):
 
     id: int
     notif_type: NotificationType
+    severity: NotificationSeverity = NotificationSeverity.INFO
     dismissed: bool
     last_shown: datetime
     first_shown: datetime

--- a/backend/onyx/server/features/notifications/utils.py
+++ b/backend/onyx/server/features/notifications/utils.py
@@ -2,6 +2,7 @@ from sqlalchemy.orm import Session
 
 from onyx.configs.constants import NotificationType
 from onyx.db.admin_banner import get_admin_banner
+from onyx.db.enums import NotificationSeverity
 from onyx.db.models import User
 from onyx.db.notification import create_notification
 
@@ -40,4 +41,6 @@ def ensure_system_announcement_notification(user: User, db_session: Session) -> 
         # The stable empty object is this announcement's deduplication key.
         additional_data={},
         refresh_existing=False,
+        # An admin-authored announcement exists to be a banner.
+        severity=NotificationSeverity.WARNING,
     )

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -750,15 +750,23 @@ def test_get_notifications_api_polled_ensures_run_once_per_window(
         monkeypatch.setattr(notifications_api, hook, record_call(hook))
 
     banner_ensure_calls: list[str] = []
+
+    def record_banner_ensure(name: str) -> Callable[..., bool]:
+        def _record(*_args: object, **_kwargs: object) -> bool:
+            banner_ensure_calls.append(name)
+            return True
+
+        return _record
+
     monkeypatch.setattr(
         notifications_api,
         "_ensure_system_announcement_notification",
-        lambda _user, _db_session: banner_ensure_calls.append("announcement"),
+        record_banner_ensure("announcement"),
     )
     monkeypatch.setattr(
         notifications_api,
         "_ensure_license_expiry_notification",
-        lambda _user, _db_session: banner_ensure_calls.append("license"),
+        record_banner_ensure("license"),
     )
     monkeypatch.setattr(notifications_api, "_polled_ensure_cache", {})
 

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -8,6 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import NotificationType
+from onyx.db.enums import NotificationSeverity
 from onyx.db.models import Notification, User
 from onyx.db.notification import (
     batch_create_notifications,
@@ -648,3 +649,138 @@ def _disable_notification_ensure_checks(monkeypatch: pytest.MonkeyPatch) -> None
         "ensure_release_notes_fresh_and_notify",
         noop_ensure,
     )
+
+
+def test_get_notifications_filters_by_min_severity(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = create_test_user(db_session, "notification_severity")
+    for index, severity in enumerate(NotificationSeverity):
+        create_notification(
+            user_id=user.id,
+            notif_type=NotificationType.APPROVAL_REQUESTED,
+            db_session=db_session,
+            title=f"severity {severity.value}",
+            additional_data={"severity_case": index},
+            severity=severity,
+        )
+
+    def severities(
+        min_severity: NotificationSeverity | None,
+    ) -> set[NotificationSeverity]:
+        return {
+            n.severity
+            for n in get_notifications(
+                user=user, db_session=db_session, min_severity=min_severity
+            )
+        }
+
+    # No filter returns everything; min_severity is exact-or-above.
+    assert severities(None) == set(NotificationSeverity)
+    assert severities(NotificationSeverity.WARNING) == {
+        NotificationSeverity.WARNING,
+        NotificationSeverity.ERROR,
+    }
+    assert severities(NotificationSeverity.ERROR) == {NotificationSeverity.ERROR}
+
+    total_items, undismissed_count = count_notifications(
+        user=user,
+        db_session=db_session,
+        min_severity=NotificationSeverity.WARNING,
+    )
+    assert total_items == 2
+    assert undismissed_count == 2
+
+
+def test_get_notifications_api_filters_by_min_severity(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _disable_notification_ensure_checks(monkeypatch)
+    monkeypatch.setattr(notifications_api, "_polled_ensure_cache", {})
+    user = create_test_user(db_session, "notification_api_severity")
+    for index, severity in enumerate(NotificationSeverity):
+        create_notification(
+            user_id=user.id,
+            notif_type=NotificationType.APPROVAL_REQUESTED,
+            db_session=db_session,
+            title=f"severity {severity.value}",
+            additional_data={"api_severity_case": index},
+            severity=severity,
+        )
+
+    response = notifications_api.get_notifications_api(
+        page_num=0,
+        page_size=50,
+        min_severity=NotificationSeverity.WARNING,
+        user=user,
+        db_session=db_session,
+    )
+
+    assert response.total_items == 2
+    assert {n.severity for n in response.notifications} == {
+        NotificationSeverity.WARNING,
+        NotificationSeverity.ERROR,
+    }
+
+
+def test_get_notifications_api_polled_ensures_run_once_per_window(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A severity-only request (the banner poll) runs the banner-type ensures
+    at most once per user per throttle window; the generic create-checks
+    never run on that path."""
+    generic_calls: list[str] = []
+
+    def record_call(name: str) -> Callable[..., None]:
+        def _record_call(*_args: object, **_kwargs: object) -> None:
+            generic_calls.append(name)
+
+        return _record_call
+
+    for hook in (
+        "ensure_build_mode_intro_notification",
+        "ensure_permissions_migration_notification",
+        "ensure_release_notes_fresh_and_notify",
+    ):
+        monkeypatch.setattr(notifications_api, hook, record_call(hook))
+
+    banner_ensure_calls: list[str] = []
+    monkeypatch.setattr(
+        notifications_api,
+        "_ensure_system_announcement_notification",
+        lambda _user, _db_session: banner_ensure_calls.append("announcement"),
+    )
+    monkeypatch.setattr(
+        notifications_api,
+        "_ensure_license_expiry_notification",
+        lambda _user, _db_session: banner_ensure_calls.append("license"),
+    )
+    monkeypatch.setattr(notifications_api, "_polled_ensure_cache", {})
+
+    user = create_test_user(db_session, "notification_api_polled_throttle")
+
+    notifications_api.get_notifications_api(
+        page_num=0,
+        page_size=50,
+        min_severity=NotificationSeverity.WARNING,
+        user=user,
+        db_session=db_session,
+    )
+    assert banner_ensure_calls == ["announcement", "license"]
+    assert generic_calls == []
+
+    banner_ensure_calls.clear()
+    notifications_api.get_notifications_api(
+        page_num=0,
+        page_size=50,
+        min_severity=NotificationSeverity.WARNING,
+        user=user,
+        db_session=db_session,
+    )
+    assert banner_ensure_calls == []
+    assert generic_calls == []


### PR DESCRIPTION
## Description

Notifications gain a `severity` tier: `INFO | WARNING | ERROR`. INFO renders in the bell popover only. WARNING and ERROR also surface in the banner queue (frontend lands in the next PR of this stack).

- New non-native enum column on `notification` with server default `INFO`. The migration backfills the three types that render as banners today: license expiry (stage-based WARNING/ERROR), trial ending, and system announcement.
- `create_notification` / `batch_create_notifications` accept `severity`. Severity is not part of the dedup key.
- `GET /notifications` accepts `min_severity` (exact-or-above). `NotificationResponse` exposes `severity`.
- Severity-only requests are the banner queue's 60s poll, so their lazy-materialization ensures (license, announcement) run at most once per user per 5-minute window (per-replica TTL cache; ensures stay idempotent). Unfiltered and type-filtered requests keep the always-run behavior.

Why: loud connector-failure alerting (top of this stack) must work in airgapped deployments with zero setup. The in-app banner is the delivery surface, and severity is the eligibility signal — the server knows severity, only the frontend knows what a banner is.

Stack: PR 1 of 3 (severity backend → banner queue frontend → loud connector alerts).

<img width="1913" height="988" alt="Screenshot 2026-08-14 at 12 40 02 PM" src="https://github.com/user-attachments/assets/d8f55ba9-16d9-4995-bd1d-5c057a2f2c96" />


## How Has This Been Tested?

External-dependency-unit tests: `min_severity` filtering at the db and API layers, ensure-throttle behavior, and the license notification regression suite (all passing). Migration + backfill applied and verified against a live dev database.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)