### PR TITLE
refactor(web): drive the banner queue from notification severity

### DIFF
--- a/web/src/lib/banner/hooks.ts
+++ b/web/src/lib/banner/hooks.ts
@@ -78,6 +78,8 @@ function isGlobalBannerType(notifType: NotificationType): boolean {
 
 export interface BannerQueueItem {
   notification: Notification;
+  // Every collapsed same-type notification in this slot, most urgent first.
+  ids: number[];
   // Same-type notifications collapsed into this slot; >1 renders aggregate copy.
   count: number;
 }
@@ -88,7 +90,9 @@ export interface UseBannerQueueResult {
   hasMultiple: boolean;
   goToNext: () => void;
   goToPrevious: () => void;
-  dismissCurrent: () => Promise<void>;
+  // Dismisses the current slot's representative, or the given ids (the card
+  // passes every collapsed id when it rendered aggregate copy).
+  dismissCurrent: (ids?: number[]) => Promise<void>;
 }
 
 export function useBannerQueue(): UseBannerQueueResult {
@@ -145,8 +149,16 @@ export function useBannerQueue(): UseBannerQueueResult {
     const byType = new Map<NotificationType, BannerQueueItem>();
     for (const notification of visible.sort(byUrgency)) {
       const slot = byType.get(notification.notif_type);
-      if (slot) slot.count += 1;
-      else byType.set(notification.notif_type, { notification, count: 1 });
+      if (slot) {
+        slot.ids.push(notification.id);
+        slot.count += 1;
+      } else {
+        byType.set(notification.notif_type, {
+          notification,
+          ids: [notification.id],
+          count: 1,
+        });
+      }
     }
     return Array.from(byType.values());
   }, [notifications, pendingDismissals]);
@@ -169,33 +181,39 @@ export function useBannerQueue(): UseBannerQueueResult {
     );
   }, [queue.length]);
 
-  const dismissCurrent = useCallback(async () => {
-    if (!current) return;
-    const id = current.notification.id;
-    const global = isGlobalBannerType(current.notification.notif_type);
-    setPendingDismissals((prev) => new Set(prev).add(id));
-    // A global product-gating alert can't be dismissed per-user server-side, so
-    // record the dismissal in a cookie and treat the server call as best-effort.
-    if (global) {
-      Cookies.set(`${DISMISSED_NOTIFICATION_COOKIE_PREFIX}${id}`, "true", {
-        expires: COOKIE_DISMISS_EXPIRY_DAYS,
-      });
-    }
-    try {
-      await dismissNotification(id);
-    } catch (error) {
-      if (!global) {
-        console.error("Failed to dismiss banner notification:", error);
-        setPendingDismissals((prev) => {
-          const next = new Set(prev);
-          next.delete(id);
-          return next;
-        });
-        return;
+  const dismissCurrent = useCallback(
+    async (ids?: number[]) => {
+      if (!current) return;
+      const targets = ids ?? [current.notification.id];
+      const global = isGlobalBannerType(current.notification.notif_type);
+      setPendingDismissals((prev) => new Set([...prev, ...targets]));
+      // A global product-gating alert can't be dismissed per-user server-side,
+      // so record the dismissal in a cookie and treat the server call as
+      // best-effort.
+      if (global) {
+        for (const id of targets) {
+          Cookies.set(`${DISMISSED_NOTIFICATION_COOKIE_PREFIX}${id}`, "true", {
+            expires: COOKIE_DISMISS_EXPIRY_DAYS,
+          });
+        }
       }
-    }
-    await refresh();
-  }, [current, refresh]);
+      try {
+        await Promise.all(targets.map(dismissNotification));
+      } catch (error) {
+        if (!global) {
+          console.error("Failed to dismiss banner notification:", error);
+          setPendingDismissals((prev) => {
+            const next = new Set(prev);
+            targets.forEach((id) => next.delete(id));
+            return next;
+          });
+          return;
+        }
+      }
+      await refresh();
+    },
+    [current, refresh]
+  );
 
   return {
     current,

--- a/web/src/lib/banner/hooks.ts
+++ b/web/src/lib/banner/hooks.ts
@@ -163,18 +163,21 @@ export function useBannerQueue(): UseBannerQueueResult {
           });
         }
       }
-      try {
-        await Promise.all(targets.map(dismissNotification));
-      } catch (error) {
-        if (!global) {
-          console.error("Failed to dismiss banner notification:", error);
-          setPendingDismissals((prev) => {
-            const next = new Set(prev);
-            targets.forEach((id) => next.delete(id));
-            return next;
-          });
-          return;
-        }
+      // Settle individually: a partial failure must not unhide targets that
+      // did dismiss, and the refresh reconciles with server state either way.
+      const results = await Promise.allSettled(
+        targets.map(dismissNotification)
+      );
+      const failed = targets.filter(
+        (_, index) => results[index]?.status === "rejected"
+      );
+      if (failed.length > 0 && !global) {
+        console.error("Failed to dismiss banner notifications:", failed);
+        setPendingDismissals((prev) => {
+          const next = new Set(prev);
+          failed.forEach((id) => next.delete(id));
+          return next;
+        });
       }
       await refresh();
     },

--- a/web/src/lib/banner/hooks.ts
+++ b/web/src/lib/banner/hooks.ts
@@ -34,6 +34,9 @@ import {
   type Notification,
   type NotificationsResponse,
 } from "@/lib/notifications/interfaces";
+import { buildBannerQueue, type BannerQueueItem } from "@/lib/banner/queue";
+
+export type { BannerQueueItem } from "@/lib/banner/queue";
 
 // A single max-size page always holds every active banner-worthy notification
 // (only a handful are ever live per user at once).
@@ -53,18 +56,6 @@ const BANNER_NOTIFICATIONS_KEY = SWR_KEYS.notificationsBySeverity(
   BANNER_NOTIFICATIONS_PAGE_SIZE
 );
 
-function severityRank(notification: Notification): number {
-  return Object.values(NotificationSeverity).indexOf(notification.severity);
-}
-
-// Loudest first, ties broken by most recent.
-function byUrgency(a: Notification, b: Notification): number {
-  return (
-    severityRank(b) - severityRank(a) ||
-    new Date(b.last_shown).getTime() - new Date(a.last_shown).getTime()
-  );
-}
-
 // TRIAL_ENDS_TWO_DAYS is a global product-gating notification. It can only be
 // dismissed per-user through a browser cookie: a basic user can't dismiss a
 // global row server-side, and an admin dismiss would hide it tenant-wide. This
@@ -74,14 +65,6 @@ const COOKIE_DISMISS_EXPIRY_DAYS = 1;
 
 function isGlobalBannerType(notifType: NotificationType): boolean {
   return notifType === NotificationType.TRIAL_ENDS_TWO_DAYS;
-}
-
-export interface BannerQueueItem {
-  notification: Notification;
-  // Every collapsed same-type notification in this slot, most urgent first.
-  ids: number[];
-  // Same-type notifications collapsed into this slot; >1 renders aggregate copy.
-  count: number;
 }
 
 export interface UseBannerQueueResult {
@@ -135,32 +118,15 @@ export function useBannerQueue(): UseBannerQueueResult {
     await mutate(SWR_KEYS.settings);
   }, []);
 
-  // One slot per type, holding that type's most urgent notification plus the
-  // count it collapses; slots come out loudest-first via the sorted insertion.
   const queue = useMemo<BannerQueueItem[]>(() => {
     const dismissedCookies = Cookies.get();
-    const visible = notifications.filter(
+    return buildBannerQueue(
+      notifications,
       (n) =>
-        !n.dismissed &&
-        !pendingDismissals.has(n.id) &&
-        !(`${DISMISSED_NOTIFICATION_COOKIE_PREFIX}${n.id}` in dismissedCookies)
+        n.dismissed ||
+        pendingDismissals.has(n.id) ||
+        `${DISMISSED_NOTIFICATION_COOKIE_PREFIX}${n.id}` in dismissedCookies
     );
-
-    const byType = new Map<NotificationType, BannerQueueItem>();
-    for (const notification of visible.sort(byUrgency)) {
-      const slot = byType.get(notification.notif_type);
-      if (slot) {
-        slot.ids.push(notification.id);
-        slot.count += 1;
-      } else {
-        byType.set(notification.notif_type, {
-          notification,
-          ids: [notification.id],
-          count: 1,
-        });
-      }
-    }
-    return Array.from(byType.values());
   }, [notifications, pendingDismissals]);
 
   // Clamp during render, not in an effect. Dismissing a non-first banner

--- a/web/src/lib/banner/hooks.ts
+++ b/web/src/lib/banner/hooks.ts
@@ -1,14 +1,14 @@
 "use client";
 
-// Bottom-left banner queue: consolidates the site-wide admin announcement and
-// the other banner-worthy notification types (license expiry, trial ending)
+// Bottom-left banner queue: consolidates every banner-worthy notification
 // into a single pageable card, most urgent first.
 //
-// Per-user types (admin announcement, license expiry) each get their own
-// type-filtered notifications request so none is paged out behind newer,
-// unrelated items. TRIAL_ENDS_TWO_DAYS is a global (user=None) product-gating
-// alert, so it rides in on the settings payload rather than the per-user feed,
-// which only returns the caller's own rows.
+// Banner-worthiness is severity-driven: one server-filtered fetch returns all
+// of the user's WARNING-and-up notifications, so a new loud notification type
+// needs no frontend changes. TRIAL_ENDS_TWO_DAYS is the one exception — it is
+// a global (user=None) product-gating alert, so it rides in on the settings
+// payload rather than the per-user feed, which only returns the caller's own
+// rows.
 //
 // TODO(nikg): deliver `show_as_popup` to a first-visit popup renderer. The
 // notification feed's `additional_data` is `{}` for SYSTEM_ANNOUNCEMENT
@@ -29,55 +29,40 @@ import {
   invalidateNotificationCaches,
 } from "@/lib/notifications/api";
 import {
+  NotificationSeverity,
   NotificationType,
   type Notification,
   type NotificationsResponse,
 } from "@/lib/notifications/interfaces";
-import type { ExpiryWarningStage } from "@/lib/billing/interfaces";
 
-// A single max-size page always holds every active notification of a given
-// banner-worthy type (only a handful are ever live per user at once).
+// A single max-size page always holds every active banner-worthy notification
+// (only a handful are ever live per user at once).
 const BANNER_NOTIFICATIONS_PAGE_SIZE = 50;
 
-// Focus revalidation on so a freshly published announcement reaches other
-// open sessions without a reload (the dedupe window caps the request rate).
+// Focus revalidation so a freshly published announcement reaches other open
+// sessions without a reload, plus a slow poll so an idle admin tab still
+// learns about a newly failing connector (the dedupe window caps the rate).
 const BANNER_SWR_OPTIONS = {
   revalidateOnFocus: true,
   dedupingInterval: 30000,
+  refreshInterval: 60000,
 } as const;
 
-// Types that render in the bottom-left banner queue, most urgent first.
-const BANNER_TYPE_PRIORITY: Partial<Record<NotificationType, number>> = {
-  [NotificationType.LICENSE_EXPIRY_WARNING]: 2,
-  [NotificationType.TRIAL_ENDS_TWO_DAYS]: 1,
-  [NotificationType.SYSTEM_ANNOUNCEMENT]: 0,
-};
+const BANNER_NOTIFICATIONS_KEY = SWR_KEYS.notificationsBySeverity(
+  NotificationSeverity.WARNING,
+  BANNER_NOTIFICATIONS_PAGE_SIZE
+);
 
-// Higher = more urgent.
-const LICENSE_STAGE_SEVERITY: Record<
-  Exclude<ExpiryWarningStage, "none">,
-  number
-> = {
-  t_30d: 0,
-  t_14d: 1,
-  t_1d: 2,
-  grace: 3,
-};
-
-function severityForLicenseStage(stage: string | undefined): number {
-  return (LICENSE_STAGE_SEVERITY as Record<string, number>)[stage ?? ""] ?? 0;
+function severityRank(notification: Notification): number {
+  return Object.values(NotificationSeverity).indexOf(notification.severity);
 }
 
-/** Severity rank for a LICENSE_EXPIRY_WARNING notification's stage (higher = more urgent). */
-export function licenseExpirySeverity(notification: Notification): number {
-  return severityForLicenseStage(notification.additional_data?.stage);
-}
-
-// t_1d and grace (and anything more urgent) render as an error.
-export const LICENSE_EXPIRY_ERROR_THRESHOLD = LICENSE_STAGE_SEVERITY.t_1d;
-
-function isBannerWorthy(notification: Notification): boolean {
-  return notification.notif_type in BANNER_TYPE_PRIORITY;
+// Loudest first, ties broken by most recent.
+function byUrgency(a: Notification, b: Notification): number {
+  return (
+    severityRank(b) - severityRank(a) ||
+    new Date(b.last_shown).getTime() - new Date(a.last_shown).getTime()
+  );
 }
 
 // TRIAL_ENDS_TWO_DAYS is a global product-gating notification. It can only be
@@ -91,40 +76,14 @@ function isGlobalBannerType(notifType: NotificationType): boolean {
   return notifType === NotificationType.TRIAL_ENDS_TWO_DAYS;
 }
 
-function isCookieDismissed(id: number): boolean {
-  return Boolean(Cookies.get(`${DISMISSED_NOTIFICATION_COOKIE_PREFIX}${id}`));
-}
-
-// Collapses multiple undismissed notifications of the same banner type into the
-// single one that should occupy that type's queue slot: most severe stage for
-// license warnings (ties broken by most recent), most recent for everything else.
-function pickRepresentative(
-  notifType: NotificationType,
-  candidates: Notification[]
-): Notification {
-  if (notifType !== NotificationType.LICENSE_EXPIRY_WARNING) {
-    return candidates.reduce((latest, n) =>
-      new Date(n.last_shown).getTime() > new Date(latest.last_shown).getTime()
-        ? n
-        : latest
-    );
-  }
-  return candidates.reduce((best, n) => {
-    const nextSeverity = licenseExpirySeverity(n);
-    const bestSeverity = licenseExpirySeverity(best);
-    if (nextSeverity > bestSeverity) return n;
-    if (
-      nextSeverity === bestSeverity &&
-      new Date(n.last_shown).getTime() > new Date(best.last_shown).getTime()
-    ) {
-      return n;
-    }
-    return best;
-  });
+export interface BannerQueueItem {
+  notification: Notification;
+  // Same-type notifications collapsed into this slot; >1 renders aggregate copy.
+  count: number;
 }
 
 export interface UseBannerQueueResult {
-  current: Notification | null;
+  current: BannerQueueItem | null;
   queueLength: number;
   hasMultiple: boolean;
   goToNext: () => void;
@@ -138,25 +97,9 @@ export function useBannerQueue(): UseBannerQueueResult {
   // banner fetch (see isAuthPath's doc comment).
   const disabled = isAuthPath(pathname);
 
-  // One type-filtered fetch per banner type guarantees full coverage of each
-  // type independent of how many unrelated notifications exist.
-  const announcement = useSWR<NotificationsResponse>(
-    disabled
-      ? null
-      : SWR_KEYS.notificationsByType(
-          NotificationType.SYSTEM_ANNOUNCEMENT,
-          BANNER_NOTIFICATIONS_PAGE_SIZE
-        ),
-    errorHandlingFetcher,
-    BANNER_SWR_OPTIONS
-  );
-  const license = useSWR<NotificationsResponse>(
-    disabled
-      ? null
-      : SWR_KEYS.notificationsByType(
-          NotificationType.LICENSE_EXPIRY_WARNING,
-          BANNER_NOTIFICATIONS_PAGE_SIZE
-        ),
+  // One severity-filtered fetch covers every banner-worthy notification type.
+  const bannerWorthy = useSWR<NotificationsResponse>(
+    disabled ? null : BANNER_NOTIFICATIONS_KEY,
     errorHandlingFetcher,
     BANNER_SWR_OPTIONS
   );
@@ -172,13 +115,12 @@ export function useBannerQueue(): UseBannerQueueResult {
 
   const notifications = useMemo<Notification[]>(
     () => [
-      ...(announcement.data?.notifications ?? []),
-      ...(license.data?.notifications ?? []),
+      ...(bannerWorthy.data?.notifications ?? []),
       ...settings.notifications.filter(
         (n) => n.notif_type === NotificationType.TRIAL_ENDS_TWO_DAYS
       ),
     ],
-    [announcement.data, license.data, settings.notifications]
+    [bannerWorthy.data, settings.notifications]
   );
 
   // Dismissals must update every notification surface (this queue, the bell
@@ -189,31 +131,24 @@ export function useBannerQueue(): UseBannerQueueResult {
     await mutate(SWR_KEYS.settings);
   }, []);
 
-  const queue = useMemo(() => {
-    const byType = new Map<NotificationType, Notification[]>();
-    for (const notification of notifications) {
-      if (
-        !isBannerWorthy(notification) ||
-        notification.dismissed ||
-        pendingDismissals.has(notification.id) ||
-        isCookieDismissed(notification.id)
-      ) {
-        continue;
-      }
-      const bucket = byType.get(notification.notif_type) ?? [];
-      bucket.push(notification);
-      byType.set(notification.notif_type, bucket);
-    }
+  // One slot per type, holding that type's most urgent notification plus the
+  // count it collapses; slots come out loudest-first via the sorted insertion.
+  const queue = useMemo<BannerQueueItem[]>(() => {
+    const dismissedCookies = Cookies.get();
+    const visible = notifications.filter(
+      (n) =>
+        !n.dismissed &&
+        !pendingDismissals.has(n.id) &&
+        !(`${DISMISSED_NOTIFICATION_COOKIE_PREFIX}${n.id}` in dismissedCookies)
+    );
 
-    return Array.from(byType.entries())
-      .map(([notifType, candidates]) =>
-        pickRepresentative(notifType, candidates)
-      )
-      .sort(
-        (a, b) =>
-          (BANNER_TYPE_PRIORITY[b.notif_type] ?? -1) -
-          (BANNER_TYPE_PRIORITY[a.notif_type] ?? -1)
-      );
+    const byType = new Map<NotificationType, BannerQueueItem>();
+    for (const notification of visible.sort(byUrgency)) {
+      const slot = byType.get(notification.notif_type);
+      if (slot) slot.count += 1;
+      else byType.set(notification.notif_type, { notification, count: 1 });
+    }
+    return Array.from(byType.values());
   }, [notifications, pendingDismissals]);
 
   // Clamp during render, not in an effect. Dismissing a non-first banner
@@ -236,8 +171,8 @@ export function useBannerQueue(): UseBannerQueueResult {
 
   const dismissCurrent = useCallback(async () => {
     if (!current) return;
-    const id = current.id;
-    const global = isGlobalBannerType(current.notif_type);
+    const id = current.notification.id;
+    const global = isGlobalBannerType(current.notification.notif_type);
     setPendingDismissals((prev) => new Set(prev).add(id));
     // A global product-gating alert can't be dismissed per-user server-side, so
     // record the dismissal in a cookie and treat the server call as best-effort.

--- a/web/src/lib/banner/hooks.ts
+++ b/web/src/lib/banner/hooks.ts
@@ -152,7 +152,11 @@ export function useBannerQueue(): UseBannerQueueResult {
       if (!current) return;
       const targets = ids ?? [current.notification.id];
       const global = isGlobalBannerType(current.notification.notif_type);
-      setPendingDismissals((prev) => new Set([...prev, ...targets]));
+      setPendingDismissals((prev) => {
+        const next = new Set(prev);
+        targets.forEach((id) => next.add(id));
+        return next;
+      });
       // A global product-gating alert can't be dismissed per-user server-side,
       // so record the dismissal in a cookie and treat the server call as
       // best-effort.
@@ -168,14 +172,17 @@ export function useBannerQueue(): UseBannerQueueResult {
       const results = await Promise.allSettled(
         targets.map(dismissNotification)
       );
-      const failed = targets.filter(
-        (_, index) => results[index]?.status === "rejected"
-      );
-      if (failed.length > 0 && !global) {
-        console.error("Failed to dismiss banner notifications:", failed);
+      const failures = targets.flatMap((id, index) => {
+        const result = results[index];
+        return result?.status === "rejected"
+          ? [{ id, reason: result.reason }]
+          : [];
+      });
+      if (failures.length > 0 && !global) {
+        console.error("Failed to dismiss banner notifications:", failures);
         setPendingDismissals((prev) => {
           const next = new Set(prev);
-          failed.forEach((id) => next.delete(id));
+          failures.forEach(({ id }) => next.delete(id));
           return next;
         });
       }

--- a/web/src/lib/banner/queue.test.ts
+++ b/web/src/lib/banner/queue.test.ts
@@ -1,0 +1,84 @@
+import { buildBannerQueue } from "@/lib/banner/queue";
+import {
+  NotificationSeverity,
+  NotificationType,
+  type Notification,
+} from "@/lib/notifications/interfaces";
+
+let nextId = 1;
+
+function makeNotification(overrides: Partial<Notification>): Notification {
+  return {
+    id: nextId++,
+    notif_type: NotificationType.LICENSE_EXPIRY_WARNING,
+    severity: NotificationSeverity.WARNING,
+    title: "test",
+    description: null,
+    dismissed: false,
+    first_shown: "2026-08-01T00:00:00Z",
+    last_shown: "2026-08-01T00:00:00Z",
+    additional_data: null,
+    ...overrides,
+  };
+}
+
+const neverHidden = () => false;
+
+describe("buildBannerQueue", () => {
+  it("orders slots by severity, then recency", () => {
+    const older = makeNotification({
+      notif_type: NotificationType.SYSTEM_ANNOUNCEMENT,
+      severity: NotificationSeverity.WARNING,
+      last_shown: "2026-08-01T00:00:00Z",
+    });
+    const newer = makeNotification({
+      notif_type: NotificationType.TRIAL_ENDS_TWO_DAYS,
+      severity: NotificationSeverity.WARNING,
+      last_shown: "2026-08-02T00:00:00Z",
+    });
+    const error = makeNotification({
+      notif_type: NotificationType.CONNECTOR_REPEATED_ERRORS,
+      severity: NotificationSeverity.ERROR,
+      last_shown: "2026-07-01T00:00:00Z",
+    });
+
+    const queue = buildBannerQueue([older, newer, error], neverHidden);
+
+    expect(queue.map((item) => item.notification.id)).toEqual([
+      error.id,
+      newer.id,
+      older.id,
+    ]);
+  });
+
+  it("collapses same-type notifications into one slot led by the most urgent", () => {
+    const warning = makeNotification({
+      severity: NotificationSeverity.WARNING,
+      last_shown: "2026-08-02T00:00:00Z",
+    });
+    const error = makeNotification({
+      severity: NotificationSeverity.ERROR,
+      last_shown: "2026-08-01T00:00:00Z",
+    });
+
+    const queue = buildBannerQueue([warning, error], neverHidden);
+
+    expect(queue).toHaveLength(1);
+    expect(queue[0]!.notification.id).toBe(error.id);
+    expect(queue[0]!.count).toBe(2);
+    expect(queue[0]!.ids).toEqual([error.id, warning.id]);
+  });
+
+  it("excludes hidden notifications entirely", () => {
+    const visible = makeNotification({});
+    const hidden = makeNotification({ dismissed: true });
+
+    const queue = buildBannerQueue(
+      [visible, hidden],
+      (notification) => notification.dismissed
+    );
+
+    expect(queue).toHaveLength(1);
+    expect(queue[0]!.ids).toEqual([visible.id]);
+  });
+});

--- a/web/src/lib/banner/queue.ts
+++ b/web/src/lib/banner/queue.ts
@@ -1,0 +1,53 @@
+// Pure queue-building logic for the banner card, kept free of hooks and
+// browser dependencies so it can be unit tested directly.
+
+import {
+  NotificationSeverity,
+  NotificationType,
+  type Notification,
+} from "@/lib/notifications/interfaces";
+
+export interface BannerQueueItem {
+  notification: Notification;
+  // Every collapsed same-type notification in this slot, most urgent first.
+  ids: number[];
+  // Same-type notifications collapsed into this slot; >1 renders aggregate copy.
+  count: number;
+}
+
+function severityRank(notification: Notification): number {
+  return Object.values(NotificationSeverity).indexOf(notification.severity);
+}
+
+// Loudest first, ties broken by most recent.
+function byUrgency(a: Notification, b: Notification): number {
+  return (
+    severityRank(b) - severityRank(a) ||
+    new Date(b.last_shown).getTime() - new Date(a.last_shown).getTime()
+  );
+}
+
+// One slot per type, holding that type's most urgent notification plus every
+// collapsed id; slots come out loudest-first via the sorted insertion.
+export function buildBannerQueue(
+  notifications: Notification[],
+  isHidden: (notification: Notification) => boolean
+): BannerQueueItem[] {
+  const byType = new Map<NotificationType, BannerQueueItem>();
+  for (const notification of notifications
+    .filter((n) => !isHidden(n))
+    .sort(byUrgency)) {
+    const slot = byType.get(notification.notif_type);
+    if (slot) {
+      slot.ids.push(notification.id);
+      slot.count += 1;
+    } else {
+      byType.set(notification.notif_type, {
+        notification,
+        ids: [notification.id],
+        count: 1,
+      });
+    }
+  }
+  return Array.from(byType.values());
+}

--- a/web/src/lib/notifications/index.ts
+++ b/web/src/lib/notifications/index.ts
@@ -8,12 +8,23 @@ export function isExternalLink(link: string): boolean {
   return link.startsWith("http://") || link.startsWith("https://");
 }
 
+// Internal links must be absolute paths. Rejects other schemes (mailto:,
+// tel:) and protocol-relative //host values, which router.push would
+// otherwise navigate to unvalidated.
+function isInternalPath(link: string): boolean {
+  return link.startsWith("/") && !link.startsWith("//");
+}
+
 export function openNotificationLink(
   link: string,
   router: ReturnType<typeof useRouter>
 ): void {
   if (isExternalLink(link)) {
     window.open(link, "_blank", "noopener,noreferrer");
+    return;
+  }
+  if (!isInternalPath(link)) {
+    console.error("Ignoring notification link with unsupported format:", link);
     return;
   }
   router.push(link as Route);

--- a/web/src/lib/notifications/index.ts
+++ b/web/src/lib/notifications/index.ts
@@ -1,6 +1,23 @@
+import type { Route } from "next";
+import type { useRouter } from "next/navigation";
 import { SvgAlertCircle, SvgAlertTriangle, SvgBullhorn } from "@opal/icons";
 import type { IconProps } from "@opal/types";
 import { NotificationType } from "@/lib/notifications/interfaces";
+
+export function isExternalLink(link: string): boolean {
+  return link.startsWith("http://") || link.startsWith("https://");
+}
+
+export function openNotificationLink(
+  link: string,
+  router: ReturnType<typeof useRouter>
+): void {
+  if (isExternalLink(link)) {
+    window.open(link, "_blank", "noopener,noreferrer");
+    return;
+  }
+  router.push(link as Route);
+}
 
 export function getNotificationIcon(
   notifType: string

--- a/web/src/lib/notifications/interfaces.ts
+++ b/web/src/lib/notifications/interfaces.ts
@@ -19,9 +19,18 @@ export enum NotificationType {
   SYSTEM_ANNOUNCEMENT = "system_announcement",
 }
 
+// INFO renders in the bell popover only; WARNING/ERROR also as a banner.
+// Declared in ascending loudness.
+export enum NotificationSeverity {
+  INFO = "info",
+  WARNING = "warning",
+  ERROR = "error",
+}
+
 export interface Notification {
   id: number;
   notif_type: NotificationType;
+  severity: NotificationSeverity;
   title: string;
   description: string | null;
   dismissed: boolean;

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -98,9 +98,9 @@ export const SWR_KEYS = {
     });
     return `/api/notifications?${params.toString()}`;
   },
-  notificationsByType: (notifType: string, pageSize: number) => {
+  notificationsBySeverity: (minSeverity: string, pageSize: number) => {
     const params = new URLSearchParams({
-      notif_type: notifType,
+      min_severity: minSeverity,
       page_size: pageSize.toString(),
     });
     return `/api/notifications?${params.toString()}`;

--- a/web/src/sections/banners/BannerQueue.tsx
+++ b/web/src/sections/banners/BannerQueue.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 // Bottom-left floating banner: shows one banner-worthy notification at a time
-// (admin site-wide announcement, license expiry warning, trial-ending notice),
-// pageable via prev/next when more than one is active. Always dismissible.
-// Anchored to the main content area's bottom-left corner so it never covers
-// the sidebar. Falls back to the viewport edge when there is no content area.
+// (severity WARNING or louder — connector failures, license expiry, admin
+// announcements, trial notices), pageable via prev/next when more than one is
+// active. Always dismissible. Anchored to the main content area's bottom-left
+// corner so it never covers the sidebar. Falls back to the viewport edge when
+// there is no content area.
 
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { Button, Text } from "@opal/components";
 import { cn, markdown } from "@opal/utils";
 import { timeAgo } from "@opal/time";
@@ -14,24 +15,18 @@ import { SvgChevronLeft, SvgChevronRight, SvgX } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
 import { isAuthPath } from "@/lib/auth/paths";
 import useContainerCenter from "@/hooks/useContainerCenter";
-import { getNotificationIcon } from "@/lib/notifications";
+import { getNotificationIcon, openNotificationLink } from "@/lib/notifications";
 import {
+  NotificationSeverity,
   NotificationType,
-  type Notification,
 } from "@/lib/notifications/interfaces";
-import {
-  LICENSE_EXPIRY_ERROR_THRESHOLD,
-  licenseExpirySeverity,
-  useBannerQueue,
-} from "@/lib/banner/hooks";
+import { useBannerQueue, type BannerQueueItem } from "@/lib/banner/hooks";
 
 // Inset from the content area's left edge, matching the card's bottom inset.
 const CONTENT_INSET_PX = 8;
 
-type BannerVariant = "info" | "warning" | "error";
-
 const VARIANT_STYLES: Record<
-  BannerVariant,
+  NotificationSeverity,
   { headerBg: string; iconClass: string }
 > = {
   info: { headerBg: "bg-status-info-00", iconClass: "stroke-status-info-05" },
@@ -45,47 +40,69 @@ const VARIANT_STYLES: Record<
   },
 };
 
-function bannerVariant(notification: Notification): BannerVariant {
-  switch (notification.notif_type) {
-    case NotificationType.TRIAL_ENDS_TWO_DAYS:
-      return "warning";
-    case NotificationType.LICENSE_EXPIRY_WARNING:
-      return licenseExpirySeverity(notification) >=
-        LICENSE_EXPIRY_ERROR_THRESHOLD
-        ? "error"
-        : "warning";
-    default:
-      return "info";
-  }
+// Per-type presentation extras. Variant comes from the notification's
+// severity; ordering and eligibility live in useBannerQueue. Types without an
+// entry get the defaults, so a new loud notification type needs no changes
+// here to render.
+interface BannerTypeConfig {
+  sourceLabel: string;
+  // Overrides the severity-derived look (admin announcements are loud enough
+  // to be banners but keep their informational styling).
+  variantOverride?: NotificationSeverity;
+  ctaLabel?: string;
 }
 
-function bannerSourceLabel(notifType: NotificationType): string {
-  switch (notifType) {
-    case NotificationType.SYSTEM_ANNOUNCEMENT:
-      return "Admin announcement";
-    case NotificationType.LICENSE_EXPIRY_WARNING:
-      return "License";
-    case NotificationType.TRIAL_ENDS_TWO_DAYS:
-      return "Trial";
-    default:
-      return "Notification";
-  }
+interface BannerContent {
+  title: string;
+  description: string | null;
+  link: string | null;
+  ctaLabel: string;
+}
+
+const DEFAULT_SOURCE_LABEL = "Notification";
+const DEFAULT_CTA_LABEL = "View";
+
+const BANNER_TYPE_CONFIG: Partial<Record<NotificationType, BannerTypeConfig>> =
+  {
+    [NotificationType.SYSTEM_ANNOUNCEMENT]: {
+      sourceLabel: "Admin announcement",
+      variantOverride: NotificationSeverity.INFO,
+    },
+    [NotificationType.LICENSE_EXPIRY_WARNING]: { sourceLabel: "License" },
+    [NotificationType.TRIAL_ENDS_TWO_DAYS]: { sourceLabel: "Trial" },
+  };
+
+function bannerContent(item: BannerQueueItem): BannerContent {
+  const { notification } = item;
+  const config = BANNER_TYPE_CONFIG[notification.notif_type];
+  return {
+    title: notification.title,
+    description: notification.description,
+    link: notification.additional_data?.link ?? null,
+    ctaLabel: config?.ctaLabel ?? DEFAULT_CTA_LABEL,
+  };
 }
 
 export default function BannerQueue() {
   const pathname = usePathname();
+  const router = useRouter();
   const { left: contentLeft } = useContainerCenter();
   const { current, hasMultiple, goToNext, goToPrevious, dismissCurrent } =
     useBannerQueue();
 
   if (isAuthPath(pathname) || !current) return null;
 
-  const styles = VARIANT_STYLES[bannerVariant(current)];
-  const Icon = getNotificationIcon(current.notif_type);
-  const relativeTime = timeAgo(current.last_shown);
+  const notification = current.notification;
+  const config = BANNER_TYPE_CONFIG[notification.notif_type];
+  const styles =
+    VARIANT_STYLES[config?.variantOverride ?? notification.severity];
+  const Icon = getNotificationIcon(notification.notif_type);
+  const { title, description, link, ctaLabel } = bannerContent(current);
+  const relativeTime = timeAgo(notification.last_shown);
+  const sourceLabel = config?.sourceLabel ?? DEFAULT_SOURCE_LABEL;
   const footer = relativeTime
-    ? `${bannerSourceLabel(current.notif_type)} • ${relativeTime}`
-    : bannerSourceLabel(current.notif_type);
+    ? `${sourceLabel} • ${relativeTime}`
+    : sourceLabel;
 
   return (
     <div
@@ -119,7 +136,7 @@ export default function BannerQueue() {
               needs a block box, so Section (a flex container) cannot host it. */}
           <div className="flex-1 min-w-0 truncate px-0.5">
             <Text font="main-ui-action" color="text-04">
-              {current.title}
+              {title}
             </Text>
           </div>
           {hasMultiple && (
@@ -158,14 +175,31 @@ export default function BannerQueue() {
           padding={2}
           className="rounded-08 bg-background-tint-01"
         >
-          {current.description && (
+          {description && (
             <Text font="main-ui-body" color="text-03">
-              {markdown(current.description)}
+              {markdown(description)}
             </Text>
           )}
-          <Text font="secondary-body" color="text-03">
-            {footer}
-          </Text>
+          <Section
+            flexDirection="row"
+            alignItems="center"
+            justifyContent="between"
+            height="fit"
+            gap={1}
+          >
+            <Text font="secondary-body" color="text-03">
+              {footer}
+            </Text>
+            {link && (
+              <Button
+                prominence="secondary"
+                size="sm"
+                onClick={() => openNotificationLink(link, router)}
+              >
+                {ctaLabel}
+              </Button>
+            )}
+          </Section>
         </Section>
       </Section>
     </div>

--- a/web/src/sections/banners/BannerQueue.tsx
+++ b/web/src/sections/banners/BannerQueue.tsx
@@ -100,9 +100,15 @@ export default function BannerQueue() {
   const { title, description, link, ctaLabel } = bannerContent(current);
   const relativeTime = timeAgo(notification.last_shown);
   const sourceLabel = config?.sourceLabel ?? DEFAULT_SOURCE_LABEL;
-  const footer = relativeTime
-    ? `${sourceLabel} • ${relativeTime}`
-    : sourceLabel;
+  // Disclose collapsed same-type siblings so dismissing the visible one
+  // never surfaces the rest as a surprise.
+  const footer = [
+    sourceLabel,
+    relativeTime,
+    current.count > 1 ? `+${current.count - 1} more` : null,
+  ]
+    .filter(Boolean)
+    .join(" • ");
 
   return (
     <div

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -9,11 +9,14 @@ import {
   useState,
 } from "react";
 import { useRouter } from "next/navigation";
-import { Route } from "next";
 import { track, AnalyticsEvent } from "@/lib/analytics/utils";
 import type { Notification as NotificationData } from "@/lib/notifications/interfaces";
 import { NotificationType } from "@/lib/notifications/interfaces";
-import { getNotificationIcon } from "@/lib/notifications";
+import {
+  getNotificationIcon,
+  isExternalLink,
+  openNotificationLink,
+} from "@/lib/notifications";
 import {
   dismissAllNotifications,
   dismissNotification,
@@ -183,19 +186,13 @@ export default function NotificationsPopover({
         });
       }
 
-      if (link.startsWith("http://") || link.startsWith("https://")) {
-        if (!notification.dismissed) {
-          handleDismiss(notification.id);
-        }
-        window.open(link, "_blank", "noopener,noreferrer");
-        return;
-      }
-
       if (!notification.dismissed) {
         handleDismiss(notification.id);
       }
-      onNavigate();
-      router.push(link as Route);
+      if (!isExternalLink(link)) {
+        onNavigate();
+      }
+      openNotificationLink(link, router);
     },
     [handleDismiss, onNavigate, onShowBuildIntro, router]
   );


### PR DESCRIPTION
## Description

The banner queue becomes severity-driven:

- One `min_severity=warning` fetch replaces the per-type banner fetches. Eligibility is "WARNING or louder", so a new loud notification type needs no frontend changes. The four per-type switches (priority, variant, source label, plus a fetch per type) collapse into one presentation registry.
- Banner variant comes from the notification's severity; `SYSTEM_ANNOUNCEMENT` keeps its informational look via a registry override.
- New CTA slot: when `additional_data.link` is present the card shows an action button. Link routing is shared with the bell popover via `openNotificationLink`.
- 60s poll so an idle admin tab learns about new alerts without a focus event.
- The trial banner keeps its settings-payload path and cookie dismissal (global row; documented in the hook header).

Behavior-preserving for the existing banner types — the previous PR's backfill guarantees their rows qualify.

Stack: PR 2 of 3, on top of the severity backend.

<img width="1913" height="988" alt="Screenshot 2026-08-14 at 12 40 02 PM" src="https://github.com/user-attachments/assets/21867f57-5d1a-436b-b160-e6200731d9fa" />


## How Has This Been Tested?

Manually verified in the running app: license/announcement banners render as before; the CTA renders and navigates; dismissal and paging work. TypeScript typecheck green. No automated UI spec yet — a Playwright spec needs a way to seed banner state, tracked as follow-up.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)