### PR TITLE
feat(connectors): loud admin alerts for failing and invalid connectors

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -100,16 +100,11 @@ from onyx.db.index_attempt_metrics import (
 )
 from onyx.db.indexing_coordination import CoordinationStatus, IndexingCoordination
 from onyx.db.models import IndexAttempt, SearchSettings
-from onyx.db.notification import (
-    batch_create_notifications,
-    delete_notifications_by_additional_data,
-)
 from onyx.db.search_settings import (
     get_current_search_settings,
     get_secondary_search_settings,
 )
 from onyx.db.swap_index import check_and_perform_index_swap
-from onyx.db.users import get_active_admin_users
 from onyx.document_index.factory import get_all_document_indices
 from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.document_batch_storage import (
@@ -130,6 +125,10 @@ from onyx.indexing.persistent_indexing import (
 from onyx.natural_language_processing.search_nlp_models import (
     EmbeddingModel,
     warm_up_bi_encoder,
+)
+from onyx.notifications.connector_alerts import (
+    clear_connector_alerts,
+    notify_admins_of_connector_alert,
 )
 from onyx.redis.redis_connector import RedisConnector
 from onyx.redis.redis_docprocessing import RedisDocprocessing
@@ -649,12 +648,12 @@ def check_indexing_completion(
             if cc_pair.in_repeated_error_state:
                 cc_pair.in_repeated_error_state = False
 
-                # Clear every admin's error notification for this connector so a
-                # fresh one is created if it fails again later.
-                delete_notifications_by_additional_data(
-                    notif_type=NotificationType.CONNECTOR_REPEATED_ERRORS,
+                # Clear every admin's alert so the next incident creates a
+                # fresh one.
+                clear_connector_alerts(
                     db_session=db_session,
-                    additional_data={"cc_pair_id": cc_pair.id},
+                    cc_pair_id=cc_pair.id,
+                    notif_type=NotificationType.CONNECTOR_REPEATED_ERRORS,
                 )
 
                 db_session.commit()
@@ -1022,21 +1021,16 @@ def check_for_indexing(self: Task, *, tenant_id: str) -> int | None:
                         or f"CC pair {cc_pair.id}"
                     )
                     source = cc_pair.connector.source.value
-                    connector_url = f"/admin/connector/{cc_pair.id}"
-                    admin_ids = [
-                        admin.id for admin in get_active_admin_users(db_session)
-                    ]
-                    batch_create_notifications(
-                        user_ids=admin_ids,
-                        notif_type=NotificationType.CONNECTOR_REPEATED_ERRORS,
+                    notify_admins_of_connector_alert(
                         db_session=db_session,
+                        cc_pair_id=cc_pair.id,
+                        notif_type=NotificationType.CONNECTOR_REPEATED_ERRORS,
                         title=f"Connector '{connector_name}' has entered repeated error state",
                         description=(
-                            f"The {source} connector has failed repeatedly and "
-                            f"has been flagged. View indexing history in the "
-                            f"Advanced section: {connector_url}"
+                            f"The {source} connector has failed repeatedly "
+                            f"and has been flagged. Check its indexing "
+                            f"history and credentials."
                         ),
-                        additional_data={"cc_pair_id": cc_pair.id},
                     )
 
                     task_logger.error(

--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -69,7 +69,7 @@ from onyx.configs.constants import (
 from onyx.connectors.models import ConnectorFailure, Document, IndexAttemptMetadata
 from onyx.db.connector import mark_ccpair_with_indexing_trigger
 from onyx.db.connector_alerts import (
-    clear_connector_alerts,
+    clear_connector_alerts__no_commit,
     notify_admins_of_connector_alert,
 )
 from onyx.db.connector_credential_pair import (
@@ -650,7 +650,7 @@ def check_indexing_completion(
 
                 # Clear every admin's alert so the next incident creates a
                 # fresh one.
-                clear_connector_alerts(
+                clear_connector_alerts__no_commit(
                     db_session=db_session,
                     cc_pair_id=cc_pair.id,
                     notif_type=NotificationType.CONNECTOR_REPEATED_ERRORS,

--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -68,6 +68,10 @@ from onyx.configs.constants import (
 )
 from onyx.connectors.models import ConnectorFailure, Document, IndexAttemptMetadata
 from onyx.db.connector import mark_ccpair_with_indexing_trigger
+from onyx.db.connector_alerts import (
+    clear_connector_alerts,
+    notify_admins_of_connector_alert,
+)
 from onyx.db.connector_credential_pair import (
     fetch_indexable_standard_connector_credential_pair_ids,
     get_connector_credential_pair_from_id,
@@ -125,10 +129,6 @@ from onyx.indexing.persistent_indexing import (
 from onyx.natural_language_processing.search_nlp_models import (
     EmbeddingModel,
     warm_up_bi_encoder,
-)
-from onyx.notifications.connector_alerts import (
-    clear_connector_alerts,
-    notify_admins_of_connector_alert,
 )
 from onyx.redis.redis_connector import RedisConnector
 from onyx.redis.redis_docprocessing import RedisDocprocessing

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -47,6 +47,7 @@ from onyx.connectors.models import (
     TextSection,
 )
 from onyx.db.connector import mark_ccpair_with_indexing_trigger
+from onyx.db.connector_alerts import notify_admins_of_connector_alert
 from onyx.db.connector_credential_pair import (
     get_connector_credential_pair_from_id,
     get_last_successful_attempt_poll_range_end,
@@ -89,7 +90,6 @@ from onyx.file_store.staging import (
     reap_prior_attempt_staged_files,
 )
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
-from onyx.notifications.connector_alerts import notify_admins_of_connector_alert
 from onyx.redis.redis_docprocessing import RedisDocprocessing
 from onyx.redis.redis_hierarchy import (
     HierarchyNodeCacheEntry,

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -26,7 +26,12 @@ from onyx.configs.app_configs import (
     PERSISTENT_INDEXING,
     POLL_CONNECTOR_OFFSET,
 )
-from onyx.configs.constants import OnyxCeleryPriority, OnyxCeleryQueues, OnyxCeleryTask
+from onyx.configs.constants import (
+    NotificationType,
+    OnyxCeleryPriority,
+    OnyxCeleryQueues,
+    OnyxCeleryTask,
+)
 from onyx.connectors.connector_runner import ConnectorRunner
 from onyx.connectors.exceptions import (
     ConnectorValidationError,
@@ -84,6 +89,7 @@ from onyx.file_store.staging import (
     reap_prior_attempt_staged_files,
 )
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
+from onyx.notifications.connector_alerts import notify_admins_of_connector_alert
 from onyx.redis.redis_docprocessing import RedisDocprocessing
 from onyx.redis.redis_hierarchy import (
     HierarchyNodeCacheEntry,
@@ -912,6 +918,19 @@ def connector_document_extraction(
                             connector_id=db_connector.id,
                             credential_id=db_credential.id,
                             status=ConnectorCredentialPairStatus.INVALID,
+                        )
+                        invalid_name = db_connector.name or f"cc_pair_{cc_pair_id}"
+                        notify_admins_of_connector_alert(
+                            db_session=db_session_temp,
+                            cc_pair_id=cc_pair_id,
+                            notif_type=NotificationType.CONNECTOR_INVALID,
+                            title=f"Connector '{invalid_name}' has been marked invalid",
+                            description=(
+                                f"The {db_connector.source.value} connector failed "
+                                "validation repeatedly, usually due to expired "
+                                "credentials or revoked access. Update its "
+                                "credentials to resume indexing."
+                            ),
                         )
             raise e
         elif isinstance(e, ConnectorStopSignal):

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -324,6 +324,7 @@ class NotificationType(str, Enum):
     FEATURE_ANNOUNCEMENT = "feature_announcement"
     SYSTEM_ANNOUNCEMENT = "system_announcement"  # admin-authored site-wide banner
     CONNECTOR_REPEATED_ERRORS = "connector_repeated_errors"
+    CONNECTOR_INVALID = "connector_invalid"
     LICENSE_EXPIRY_WARNING = "license_expiry_warning"
     SCHEDULED_TASK_FAILED = "scheduled_task_failed"
     SCHEDULED_TASK_AWAITING_APPROVAL = "scheduled_task_awaiting_approval"

--- a/backend/onyx/db/connector_alerts.py
+++ b/backend/onyx/db/connector_alerts.py
@@ -31,8 +31,8 @@ def notify_admins_of_connector_alert(
 ) -> None:
     """Best-effort ERROR alert to all active admins; never raises.
 
-    Rolls the session back on failure, so call it with no uncommitted work
-    pending on the session."""
+    Commits the inserts on success; rolls the session back on failure. Call
+    it with no uncommitted work pending on the session."""
     try:
         batch_create_notifications(
             user_ids=[admin.id for admin in get_active_admin_users(db_session)],
@@ -52,7 +52,7 @@ def notify_admins_of_connector_alert(
         )
 
 
-def clear_connector_alerts(
+def clear_connector_alerts__no_commit(
     db_session: Session,
     cc_pair_id: int,
     notif_type: NotificationType,

--- a/backend/onyx/db/connector_alerts.py
+++ b/backend/onyx/db/connector_alerts.py
@@ -29,7 +29,10 @@ def notify_admins_of_connector_alert(
     title: str,
     description: str,
 ) -> None:
-    """Best-effort ERROR alert to all active admins; never raises."""
+    """Best-effort ERROR alert to all active admins; never raises.
+
+    Rolls the session back on failure, so call it with no uncommitted work
+    pending on the session."""
     try:
         batch_create_notifications(
             user_ids=[admin.id for admin in get_active_admin_users(db_session)],

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -11,7 +11,7 @@ from sqlalchemy.sql.elements import ColumnElement
 
 from onyx.configs.constants import DEFAULT_CC_PAIR_ID, DocumentSource, NotificationType
 from onyx.db.connector import fetch_connector_by_id
-from onyx.db.connector_alerts import clear_connector_alerts
+from onyx.db.connector_alerts import clear_connector_alerts__no_commit
 from onyx.db.credentials import fetch_credential_by_id, fetch_credential_by_id_for_user
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import (
@@ -518,7 +518,7 @@ def _update_connector_credential_pair(
             cc_pair.status == ConnectorCredentialPairStatus.INVALID
             and status != ConnectorCredentialPairStatus.INVALID
         ):
-            clear_connector_alerts(
+            clear_connector_alerts__no_commit(
                 db_session=db_session,
                 cc_pair_id=cc_pair.id,
                 notif_type=NotificationType.CONNECTOR_INVALID,

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -9,7 +9,7 @@ from sqlalchemy import Select, and_, delete, desc, exists, func, or_, select, up
 from sqlalchemy.orm import Session, aliased, joinedload, selectinload
 from sqlalchemy.sql.elements import ColumnElement
 
-from onyx.configs.constants import DEFAULT_CC_PAIR_ID, DocumentSource
+from onyx.configs.constants import DEFAULT_CC_PAIR_ID, DocumentSource, NotificationType
 from onyx.db.connector import fetch_connector_by_id
 from onyx.db.credentials import fetch_credential_by_id, fetch_credential_by_id_for_user
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -32,6 +32,7 @@ from onyx.db.models import (
     UserGroup__ConnectorCredentialPair,
     UserRole,
 )
+from onyx.notifications.connector_alerts import clear_connector_alerts
 from onyx.server.models import StatusResponse
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
@@ -512,6 +513,16 @@ def _update_connector_credential_pair(
     if net_docs is not None:
         cc_pair.total_docs_indexed += net_docs
     if status is not None:
+        # Leaving INVALID means the connector was fixed: retire its alerts.
+        if (
+            cc_pair.status == ConnectorCredentialPairStatus.INVALID
+            and status != ConnectorCredentialPairStatus.INVALID
+        ):
+            clear_connector_alerts(
+                db_session=db_session,
+                cc_pair_id=cc_pair.id,
+                notif_type=NotificationType.CONNECTOR_INVALID,
+            )
         cc_pair.status = status
 
     db_session.commit()

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -11,6 +11,7 @@ from sqlalchemy.sql.elements import ColumnElement
 
 from onyx.configs.constants import DEFAULT_CC_PAIR_ID, DocumentSource, NotificationType
 from onyx.db.connector import fetch_connector_by_id
+from onyx.db.connector_alerts import clear_connector_alerts
 from onyx.db.credentials import fetch_credential_by_id, fetch_credential_by_id_for_user
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import (
@@ -32,7 +33,6 @@ from onyx.db.models import (
     UserGroup__ConnectorCredentialPair,
     UserRole,
 )
-from onyx.notifications.connector_alerts import clear_connector_alerts
 from onyx.server.models import StatusResponse
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop

--- a/backend/onyx/db/credentials.py
+++ b/backend/onyx/db/credentials.py
@@ -6,6 +6,7 @@ from sqlalchemy.sql.expression import and_, or_
 
 from onyx.auth.schemas import UserRole
 from onyx.configs.constants import DocumentSource, NotificationType
+from onyx.db.connector_alerts import clear_connector_alerts
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.models import (
     ConnectorCredentialPair,
@@ -15,7 +16,6 @@ from onyx.db.models import (
     User,
     User__UserGroup,
 )
-from onyx.notifications.connector_alerts import clear_connector_alerts
 from onyx.server.documents.models import CredentialBase
 from onyx.utils.logger import setup_logger
 

--- a/backend/onyx/db/credentials.py
+++ b/backend/onyx/db/credentials.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql.expression import and_, or_
 
 from onyx.auth.schemas import UserRole
-from onyx.configs.constants import DocumentSource
+from onyx.configs.constants import DocumentSource, NotificationType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.models import (
     ConnectorCredentialPair,
@@ -15,6 +15,7 @@ from onyx.db.models import (
     User,
     User__UserGroup,
 )
+from onyx.notifications.connector_alerts import clear_connector_alerts
 from onyx.server.documents.models import CredentialBase
 from onyx.utils.logger import setup_logger
 
@@ -232,6 +233,11 @@ def swap_credentials_connector(
     # Update ccpair status if it's in INVALID state
     if existing_pair.status == ConnectorCredentialPairStatus.INVALID:
         existing_pair.status = ConnectorCredentialPairStatus.ACTIVE
+        clear_connector_alerts(
+            db_session=db_session,
+            cc_pair_id=existing_pair.id,
+            notif_type=NotificationType.CONNECTOR_INVALID,
+        )
 
     # Commit the changes
     db_session.commit()

--- a/backend/onyx/db/credentials.py
+++ b/backend/onyx/db/credentials.py
@@ -6,7 +6,7 @@ from sqlalchemy.sql.expression import and_, or_
 
 from onyx.auth.schemas import UserRole
 from onyx.configs.constants import DocumentSource, NotificationType
-from onyx.db.connector_alerts import clear_connector_alerts
+from onyx.db.connector_alerts import clear_connector_alerts__no_commit
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.models import (
     ConnectorCredentialPair,
@@ -233,7 +233,7 @@ def swap_credentials_connector(
     # Update ccpair status if it's in INVALID state
     if existing_pair.status == ConnectorCredentialPairStatus.INVALID:
         existing_pair.status = ConnectorCredentialPairStatus.ACTIVE
-        clear_connector_alerts(
+        clear_connector_alerts__no_commit(
             db_session=db_session,
             cc_pair_id=existing_pair.id,
             notif_type=NotificationType.CONNECTOR_INVALID,

--- a/backend/onyx/notifications/connector_alerts.py
+++ b/backend/onyx/notifications/connector_alerts.py
@@ -1,0 +1,60 @@
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import NotificationType
+from onyx.db.enums import NotificationSeverity
+from onyx.db.notification import (
+    batch_create_notifications,
+    delete_notifications_by_additional_data,
+)
+from onyx.db.users import get_active_admin_users
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def connector_alert_additional_data(cc_pair_id: int) -> dict[str, Any]:
+    """Dedup key for connector alerts; cleanup deletes by exact match on it."""
+    return {
+        "cc_pair_id": cc_pair_id,
+        "link": f"/admin/connector/{cc_pair_id}",
+    }
+
+
+def notify_admins_of_connector_alert(
+    db_session: Session,
+    cc_pair_id: int,
+    notif_type: NotificationType,
+    title: str,
+    description: str,
+) -> None:
+    """Best-effort ERROR alert to all active admins; never raises."""
+    try:
+        batch_create_notifications(
+            user_ids=[admin.id for admin in get_active_admin_users(db_session)],
+            notif_type=notif_type,
+            db_session=db_session,
+            title=title,
+            description=description,
+            additional_data=connector_alert_additional_data(cc_pair_id),
+            severity=NotificationSeverity.ERROR,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to send %s alert for cc_pair %s", notif_type.value, cc_pair_id
+        )
+
+
+def clear_connector_alerts(
+    db_session: Session,
+    cc_pair_id: int,
+    notif_type: NotificationType,
+) -> None:
+    """Delete every admin's alert for this connector so the next incident
+    creates a fresh one. Caller commits."""
+    delete_notifications_by_additional_data(
+        notif_type=notif_type,
+        db_session=db_session,
+        additional_data=connector_alert_additional_data(cc_pair_id),
+    )

--- a/backend/onyx/notifications/connector_alerts.py
+++ b/backend/onyx/notifications/connector_alerts.py
@@ -41,6 +41,9 @@ def notify_admins_of_connector_alert(
             severity=NotificationSeverity.ERROR,
         )
     except Exception:
+        # Leave the caller's session usable: a failed insert would otherwise
+        # poison the transaction and break the connector update that follows.
+        db_session.rollback()
         logger.exception(
             "Failed to send %s alert for cc_pair %s", notif_type.value, cc_pair_id
         )

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -9,6 +9,10 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.schemas import UserRole
 from onyx.configs.constants import NotificationType
+from onyx.db.connector_alerts import (
+    clear_connector_alerts,
+    notify_admins_of_connector_alert,
+)
 from onyx.db.enums import NotificationSeverity
 from onyx.db.models import Notification, User
 from onyx.db.notification import (
@@ -18,10 +22,6 @@ from onyx.db.notification import (
     delete_notifications_by_additional_data,
     dismiss_user_notifications,
     get_notifications,
-)
-from onyx.notifications.connector_alerts import (
-    clear_connector_alerts,
-    notify_admins_of_connector_alert,
 )
 from onyx.server.features.notifications import api as notifications_api
 from tests.external_dependency_unit.conftest import create_test_user

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 from onyx.auth.schemas import UserRole
 from onyx.configs.constants import NotificationType
 from onyx.db.connector_alerts import (
-    clear_connector_alerts,
+    clear_connector_alerts__no_commit,
     notify_admins_of_connector_alert,
 )
 from onyx.db.enums import NotificationSeverity
@@ -846,7 +846,7 @@ def test_connector_alert_lifecycle_producer_and_recovery_agree(
     }
 
     # Recovery: cleanup deletes by the same helper-built key.
-    clear_connector_alerts(
+    clear_connector_alerts__no_commit(
         db_session=db_session,
         cc_pair_id=cc_pair_id,
         notif_type=notif_type,

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -7,6 +7,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from onyx.auth.schemas import UserRole
 from onyx.configs.constants import NotificationType
 from onyx.db.enums import NotificationSeverity
 from onyx.db.models import Notification, User
@@ -17,6 +18,10 @@ from onyx.db.notification import (
     delete_notifications_by_additional_data,
     dismiss_user_notifications,
     get_notifications,
+)
+from onyx.notifications.connector_alerts import (
+    clear_connector_alerts,
+    notify_admins_of_connector_alert,
 )
 from onyx.server.features.notifications import api as notifications_api
 from tests.external_dependency_unit.conftest import create_test_user
@@ -792,3 +797,63 @@ def test_get_notifications_api_polled_ensures_run_once_per_window(
     )
     assert banner_ensure_calls == []
     assert generic_calls == []
+
+
+def test_connector_alert_lifecycle_producer_and_recovery_agree(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    """The producer and the recovery cleanup must target the same dedup key:
+    fan-out on entering the error state, exact-match delete on recovery,
+    fresh row on the next incident."""
+    admin_one = create_test_user(
+        db_session, "alert_lifecycle_admin1", role=UserRole.ADMIN
+    )
+    admin_two = create_test_user(
+        db_session, "alert_lifecycle_admin2", role=UserRole.ADMIN
+    )
+    admin_ids = [admin_one.id, admin_two.id]
+    cc_pair_id = 424242
+    notif_type = NotificationType.CONNECTOR_REPEATED_ERRORS
+
+    def produce() -> None:
+        notify_admins_of_connector_alert(
+            db_session=db_session,
+            cc_pair_id=cc_pair_id,
+            notif_type=notif_type,
+            title="Connector 'Lifecycle Test' failed",
+            description="test",
+        )
+
+    def rows() -> list[Notification]:
+        return list(
+            db_session.scalars(
+                select(Notification).where(
+                    Notification.notif_type == notif_type,
+                    Notification.user_id.in_(admin_ids),
+                )
+            ).all()
+        )
+
+    # Incident: one ERROR row per admin; a repeat produce is a no-op.
+    produce()
+    produce()
+    incident_rows = rows()
+    assert len(incident_rows) == 2
+    assert {r.severity for r in incident_rows} == {NotificationSeverity.ERROR}
+    assert {(r.additional_data or {}).get("link") for r in incident_rows} == {
+        f"/admin/connector/{cc_pair_id}"
+    }
+
+    # Recovery: cleanup deletes by the same helper-built key.
+    clear_connector_alerts(
+        db_session=db_session,
+        cc_pair_id=cc_pair_id,
+        notif_type=notif_type,
+    )
+    db_session.commit()
+    assert rows() == []
+
+    # Next incident re-creates fresh undismissed rows.
+    produce()
+    assert len(rows()) == 2

--- a/web/src/lib/notifications/index.ts
+++ b/web/src/lib/notifications/index.ts
@@ -38,6 +38,7 @@ export function getNotificationIcon(
     case NotificationType.REINDEX:
     case NotificationType.ASSISTANT_FILES_READY:
     case NotificationType.CONNECTOR_REPEATED_ERRORS:
+    case NotificationType.CONNECTOR_INVALID:
     case NotificationType.SCHEDULED_TASK_PRE_APPROVED_ACTION:
     case NotificationType.APPROVAL_REQUESTED:
       return SvgAlertCircle;

--- a/web/src/lib/notifications/interfaces.ts
+++ b/web/src/lib/notifications/interfaces.ts
@@ -4,6 +4,7 @@ export enum NotificationType {
   REINDEX = "reindex",
   ASSISTANT_FILES_READY = "assistant_files_ready",
   CONNECTOR_REPEATED_ERRORS = "connector_repeated_errors",
+  CONNECTOR_INVALID = "connector_invalid",
   SCHEDULED_TASK_PRE_APPROVED_ACTION = "scheduled_task_pre_approved_action",
   APPROVAL_REQUESTED = "approval_requested",
 

--- a/web/src/sections/banners/BannerQueue.tsx
+++ b/web/src/sections/banners/BannerQueue.tsx
@@ -120,6 +120,9 @@ export default function BannerQueue() {
 
   const notification = current.notification;
   const config = BANNER_TYPE_CONFIG[notification.notif_type];
+  // An aggregate card represents every collapsed notification, so dismissing
+  // it must dismiss them all — not surface them one at a time.
+  const showsAggregate = current.count > 1 && Boolean(config?.aggregate);
   const styles =
     VARIANT_STYLES[config?.variantOverride ?? notification.severity];
   const Icon = getNotificationIcon(notification.notif_type);
@@ -131,7 +134,8 @@ export default function BannerQueue() {
   const footer = [
     sourceLabel,
     relativeTime,
-    current.count > 1 ? `+${current.count - 1} more` : null,
+    // Aggregate copy already states the count in the title.
+    current.count > 1 && !showsAggregate ? `+${current.count - 1} more` : null,
   ]
     .filter(Boolean)
     .join(" • ");
@@ -193,7 +197,9 @@ export default function BannerQueue() {
             icon={SvgX}
             prominence="internal"
             size="sm"
-            onClick={() => void dismissCurrent()}
+            onClick={() =>
+              void dismissCurrent(showsAggregate ? current.ids : undefined)
+            }
             aria-label="Dismiss"
           />
         </Section>

--- a/web/src/sections/banners/BannerQueue.tsx
+++ b/web/src/sections/banners/BannerQueue.tsx
@@ -50,6 +50,8 @@ interface BannerTypeConfig {
   // to be banners but keep their informational styling).
   variantOverride?: NotificationSeverity;
   ctaLabel?: string;
+  // Replaces the copy when several undismissed notifications share the type.
+  aggregate?: (count: number) => BannerContent;
 }
 
 interface BannerContent {
@@ -62,6 +64,15 @@ interface BannerContent {
 const DEFAULT_SOURCE_LABEL = "Notification";
 const DEFAULT_CTA_LABEL = "View";
 
+function connectorAggregate(noun: string, cause: string) {
+  return (count: number): BannerContent => ({
+    title: `${count} connectors are ${noun}`,
+    description: `Multiple connectors have ${cause}. Open the connectors page to review them.`,
+    link: "/admin/indexing/status",
+    ctaLabel: DEFAULT_CTA_LABEL,
+  });
+}
+
 const BANNER_TYPE_CONFIG: Partial<Record<NotificationType, BannerTypeConfig>> =
   {
     [NotificationType.SYSTEM_ANNOUNCEMENT]: {
@@ -70,11 +81,26 @@ const BANNER_TYPE_CONFIG: Partial<Record<NotificationType, BannerTypeConfig>> =
     },
     [NotificationType.LICENSE_EXPIRY_WARNING]: { sourceLabel: "License" },
     [NotificationType.TRIAL_ENDS_TWO_DAYS]: { sourceLabel: "Trial" },
+    [NotificationType.CONNECTOR_REPEATED_ERRORS]: {
+      sourceLabel: "Connectors",
+      ctaLabel: "View connector",
+      aggregate: connectorAggregate("failing", "repeated indexing failures"),
+    },
+    [NotificationType.CONNECTOR_INVALID]: {
+      sourceLabel: "Connectors",
+      ctaLabel: "View connector",
+      aggregate: connectorAggregate("invalid", "invalid credentials"),
+    },
   };
 
+// The notification's own copy when it stands alone, the type's aggregate
+// copy when it represents several.
 function bannerContent(item: BannerQueueItem): BannerContent {
-  const { notification } = item;
+  const { notification, count } = item;
   const config = BANNER_TYPE_CONFIG[notification.notif_type];
+  if (count > 1 && config?.aggregate) {
+    return config.aggregate(count);
+  }
   return {
     title: notification.title,
     description: notification.description,


### PR DESCRIPTION
## Description

Connector failures become loud for admins:

- Repeated-error notifications are now `ERROR` severity with a `/admin/connector/{id}` deep link, so they render as a banner with a "View connector" action instead of sitting silently in the bell popover.
- Connectors marked `INVALID` after repeated validation failures now alert too — previously fully silent.
- `onyx/notifications/connector_alerts.py` owns the alert family: admin fan-out, severity, best-effort semantics, and the dedup key that recovery cleanup deletes by, so producer and cleanup cannot drift.
- Alerts clear where their state clears: repeated-errors on the next successful index (existing path), INVALID at the two INVALID-exit status transitions (credential update, status change) — not on the indexing hot path.
- Multiple failing connectors collapse into aggregate banner copy ("N connectors are failing") linking to `/admin/indexing/status`.

Deploy note: the repeated-errors dedup key gains a `link` field. Rows created before this deploy will not match recovery cleanup and stay in the bell until dismissed — one-time cosmetic effect.

Stack: PR 3 of 3 — the payoff PR.

<img width="1913" height="988" alt="Screenshot 2026-08-14 at 12 40 02 PM" src="https://github.com/user-attachments/assets/0f488fe0-e7aa-407d-bee8-402d5a540652" />


## How Has This Been Tested?

External-dependency-unit lifecycle test: fan-out on incident, idempotent re-produce, exact-key recovery delete, fresh row on the next incident. Banner render, CTA navigation, aggregate copy, and dismissal verified in the running app.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)