### PR TITLE
fix(ci): stop pushing buildx attestations to the ephemeral registry

### DIFF
--- a/.github/actions/build-backend-image/action.yml
+++ b/.github/actions/build-backend-image/action.yml
@@ -61,6 +61,10 @@ runs:
         build-args: |
           BASE_IMAGE_REGISTRY=${{ env.BASE_IMAGE_REGISTRY }}
         tags: ${{ inputs.runs-on-ecr-cache }}:nightly-llm-it-backend-${{ inputs.run-id }}
+        # Attestations attach as ECR referrers to the image digest, which is
+        # stable across runs and caps out at 100 per subject.
+        provenance: false
+        sbom: false
         cache-from: |
           type=registry,ref=${{ inputs.runs-on-ecr-cache }}:backend-cache-${{ inputs.github-sha }}
           type=registry,ref=${{ inputs.runs-on-ecr-cache }}:backend-cache-${{ steps.format-branch.outputs.cache-suffix }}

--- a/.github/actions/build-devcontainer-image/action.yml
+++ b/.github/actions/build-devcontainer-image/action.yml
@@ -63,6 +63,10 @@ runs:
         build-args: |
           BASE_IMAGE_REGISTRY=${{ env.BASE_IMAGE_REGISTRY }}
         tags: ${{ inputs.runs-on-ecr-cache }}:${{ inputs.tag-prefix }}-${{ inputs.run-id }}
+        # Attestations attach as ECR referrers to the image digest, which is
+        # stable across runs and caps out at 100 per subject.
+        provenance: false
+        sbom: false
         cache-from: |
           type=registry,ref=${{ inputs.runs-on-ecr-cache }}:devcontainer-cache-${{ inputs.github-sha }}
           type=registry,ref=${{ inputs.runs-on-ecr-cache }}:devcontainer-cache-${{ steps.format-branch.outputs.cache-suffix }}

--- a/.github/actions/build-model-server-image/action.yml
+++ b/.github/actions/build-model-server-image/action.yml
@@ -82,6 +82,10 @@ runs:
           BASE_IMAGE_REGISTRY=${{ env.BASE_IMAGE_REGISTRY }}
           ${{ env.DHI_PYTHON_BUILD_ARGS }}
         tags: ${{ inputs.runs-on-ecr-cache }}:${{ inputs.tag-prefix }}-${{ inputs.run-id }}
+        # Attestations attach as ECR referrers to the image digest, which is
+        # stable across runs and caps out at 100 per subject.
+        provenance: false
+        sbom: false
         cache-from: |
           type=registry,ref=${{ inputs.runs-on-ecr-cache }}:model-server-cache-${{ inputs.github-sha }}
           type=registry,ref=${{ inputs.runs-on-ecr-cache }}:model-server-cache-${{ steps.format-branch.outputs.cache-suffix }}

--- a/.github/workflows/pr-craft-compose-integration.yml
+++ b/.github/workflows/pr-craft-compose-integration.yml
@@ -200,6 +200,10 @@ jobs:
             ${{ matrix.extra_build_args }}
           tags: ${{ env.RUNS_ON_ECR_CACHE }}:craft-compose-${{ matrix.image }}-${{ github.run_id }}
           push: true
+          # Attestations attach as ECR referrers to the image digest, which is
+          # stable across runs and caps out at 100 per subject.
+          provenance: false
+          sbom: false
           cache-from: type=gha,scope=craft-compose-${{ matrix.image }}
           cache-to: type=gha,scope=craft-compose-${{ matrix.image }},mode=max
 

--- a/.github/workflows/pr-craft-k8s-tests.yml
+++ b/.github/workflows/pr-craft-k8s-tests.yml
@@ -345,6 +345,10 @@ jobs:
             ${{ matrix.extra_build_args }}
           tags: ${{ env.RUNS_ON_ECR_CACHE }}:craft-k8s-${{ matrix.image }}-${{ github.run_id }}
           push: true
+          # Attestations attach as ECR referrers to the image digest, which is
+          # stable across runs and caps out at 100 per subject.
+          provenance: false
+          sbom: false
           cache-from: type=gha,scope=craft-${{ matrix.image }}
           cache-to: type=gha,scope=craft-${{ matrix.image }},mode=max
 

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -219,6 +219,10 @@ jobs:
           build-args: |
             BASE_IMAGE_REGISTRY=${{ env.BASE_IMAGE_REGISTRY }}
           tags: ${{ env.RUNS_ON_ECR_CACHE }}:integration-test-devcontainer-${{ github.run_id }}
+          # Attestations attach as ECR referrers to the image digest, which is
+          # stable across runs and caps out at 100 per subject.
+          provenance: false
+          sbom: false
           cache-from: |
             type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:devcontainer-cache-${{ github.event.pull_request.head.sha || github.sha }}
             type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:devcontainer-cache-${{ steps.format-branch.outputs.cache-suffix }}

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -216,6 +216,10 @@ jobs:
           platforms: linux/arm64
           tags: ${{ env.RUNS_ON_ECR_CACHE }}:playwright-test-web-${{ github.run_id }}
           push: true
+          # Attestations attach as ECR referrers to the image digest, which is
+          # stable across runs and caps out at 100 per subject.
+          provenance: false
+          sbom: false
           build-args: |
             BASE_IMAGE_REGISTRY=${{ env.BASE_IMAGE_REGISTRY }}
             ${{ env.DHI_NODE_BUILD_ARGS }}
@@ -284,6 +288,10 @@ jobs:
           platforms: linux/arm64
           tags: ${{ env.RUNS_ON_ECR_CACHE }}:playwright-test-backend-${{ github.run_id }}
           push: true
+          # Attestations attach as ECR referrers to the image digest, which is
+          # stable across runs and caps out at 100 per subject.
+          provenance: false
+          sbom: false
           build-args: |
             BASE_IMAGE_REGISTRY=${{ env.BASE_IMAGE_REGISTRY }}
           cache-from: |


### PR DESCRIPTION
## Description

CI image pushes to the runs-on ephemeral ECR registry fail with:

```
denied: The subject of your artifact has the maximum number of artifacts (100)
referring to it. Configure an appropriate lifecycle policy for cleanup or
delete an existing artifact before retrying.
```

`docker/build-push-action` pushes a provenance attestation by default. That attestation is a separate manifest whose `subject` is the image manifest digest, which makes it an ECR referrer. ECR allows at most 100 referrers per subject.

The CI images (devcontainer especially) rebuild from cache and produce the same manifest digest on every run. The tag changes per run, but the subject digest does not. After ~100 runs, the next attestation push is denied and the job fails.

This change sets `provenance: false` and `sbom: false` on every build step that pushes to the ephemeral registry. These images are throwaway CI artifacts, so attestations add no value. Builds that publish real images (`deployment.yml`, `release-cli.yml`) keep their attestations.

Steps changed:

- `.github/workflows/pr-integration-tests.yml` (devcontainer)
- `.github/actions/build-devcontainer-image/action.yml`
- `.github/actions/build-model-server-image/action.yml`
- `.github/actions/build-backend-image/action.yml`
- `.github/workflows/pr-craft-k8s-tests.yml`
- `.github/workflows/pr-craft-compose-integration.yml`
- `.github/workflows/pr-playwright-tests.yml` (web and backend)

## How Has This Been Tested?

CI on this PR. The image build jobs must push and the downstream test jobs must pull the same tags.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop pushing Buildx provenance and SBOM attestations to the runs-on ephemeral ECR cache to prevent push failures from ECR’s 100-referrer limit. Previously CI pushes included attestations on a stable image digest and started failing; now `provenance: false` and `sbom: false` are set for ephemeral pushes, while release/deployment images still publish attestations.

**Scope**
- Updated build steps in `.github/actions/build-devcontainer-image`, `.github/actions/build-model-server-image`, `.github/actions/build-backend-image` and workflows `pr-integration-tests.yml`, `pr-playwright-tests.yml`, `pr-craft-k8s-tests.yml`, `pr-craft-compose-integration.yml`.
- No migration required; downstream jobs continue pulling the same tags from the ephemeral cache.
- Attestations remain enabled in `deployment.yml` and `release-cli.yml`.

<sup>Written for commit c0de1ebd82507f2a04bd2760a6dc89d393bf141d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

