### PR TITLE
fix(connector-stability): label perm-sync recordings with their own trigger

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
@@ -60,6 +60,7 @@ from onyx.db.engine.sql_engine import (
 )
 from onyx.db.enums import (
     AccessType,
+    CapabilityCheckTrigger,
     ConnectorCredentialPairStatus,
     SyncStatus,
     SyncType,
@@ -515,6 +516,7 @@ def connector_permission_sync_generator_task(
                     cc_pair.access_type,
                     db_session,
                     enforce_creation=False,
+                    trigger=CapabilityCheckTrigger.PERM_SYNC_ATTEMPT,
                 )
                 if not created:
                     task_logger.warning(

--- a/backend/onyx/connectors/factory.py
+++ b/backend/onyx/connectors/factory.py
@@ -154,6 +154,7 @@ def validate_ccpair_for_user(
     access_type: AccessType,
     db_session: Session,
     enforce_creation: bool = True,
+    trigger: CapabilityCheckTrigger = CapabilityCheckTrigger.CC_PAIR_VALIDATION,
 ) -> bool:
     if INTEGRATION_TESTS_MODE:
         return True
@@ -190,7 +191,7 @@ def validate_ccpair_for_user(
             credential_id=credential_id,
             connector_id=connector_id,
             source=source,
-            trigger=CapabilityCheckTrigger.CC_PAIR_VALIDATION,
+            trigger=trigger,
             error=error,
             perm_sync_validated=perm_sync_validated,
             connector_specific_config=connector_specific_config,

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -816,6 +816,8 @@ class CapabilityCheckTrigger(str, PyEnum):
     CC_PAIR_VALIDATION = "cc_pair_validation"
     # Recorded from the blocking validation at indexing-run start.
     INDEXING_ATTEMPT = "indexing_attempt"
+    # Recorded from the blocking validation at doc-permission-sync run start.
+    PERM_SYNC_ATTEMPT = "perm_sync_attempt"
 
 
 class CapabilityReportRunStatus(str, PyEnum):

--- a/backend/tests/external_dependency_unit/connectors/capability_checks/test_blocking_validation_recorder.py
+++ b/backend/tests/external_dependency_unit/connectors/capability_checks/test_blocking_validation_recorder.py
@@ -100,6 +100,35 @@ def test_success_records_a_fallback_shaped_passed_report(
 
 
 @pytest.mark.usefixtures("tenant_context")
+def test_caller_supplied_trigger_lands_on_the_report_row(
+    db_session: Session,
+    blocking_validation: tuple[ConnectorCredentialPair, MagicMock],
+) -> None:
+    """
+    Verifies non-creation callers (the perm-sync task) can relabel their
+    recordings.
+    """
+    # Precondition.
+    cc_pair, _ = blocking_validation
+
+    # Under test.
+    validate_ccpair_for_user(
+        cc_pair.connector_id,
+        cc_pair.credential_id,
+        AccessType.PUBLIC,
+        db_session,
+        trigger=CapabilityCheckTrigger.PERM_SYNC_ATTEMPT,
+    )
+
+    # Postcondition.
+    row = get_capability_report_row(
+        db_session, cc_pair.credential_id, cc_pair.connector_id
+    )
+    assert row is not None
+    assert row.trigger == CapabilityCheckTrigger.PERM_SYNC_ATTEMPT
+
+
+@pytest.mark.usefixtures("tenant_context")
 def test_validation_failure_records_failed_and_still_raises(
     db_session: Session,
     blocking_validation: tuple[ConnectorCredentialPair, MagicMock],


### PR DESCRIPTION
## Description

Fourth PR of a 3 PR chain of the persistence split (prev. #13971): the doc-permission-sync task runs the blocking validation before every sync, so its recordings were stamped cc_pair_validation, which the enum defines as creation/swap time. Label-only change: no validation decision, gate, or return value changes.

- New trigger value perm_sync_attempt; "attempt" matches the existing permission_sync_attempt naming. The column is a varchar enum, so no migration.
- validate_ccpair_for_user takes a trigger param defaulting to CC_PAIR_VALIDATION. The three creation/swap call sites keep the default; the perm-sync task passes PERM_SYNC_ATTEMPT.

## How Has This Been Tested?

- One new test pins the pass-through; the existing success test pins the default.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Labels doc-permission-sync blocking validation recordings with a dedicated trigger to separate them from creation/swap validations. Previously these recordings used cc_pair_validation; now they use perm_sync_attempt. Validation decisions, gating, and return values are unchanged.

- Added enum value PERM_SYNC_ATTEMPT; the DB column is a varchar enum, so no migration.
- validate_ccpair_for_user accepts an optional trigger (default CC_PAIR_VALIDATION). The permission-sync task passes PERM_SYNC_ATTEMPT; other callers keep the default.
- Added a test that verifies the caller-supplied trigger is recorded.
- Required: Update any analytics or alerts that group by trigger to include PERM_SYNC_ATTEMPT.

<sup>Written for commit 7a8ef4dbac972d4f335966b6d3e8ec874df6d436. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

