### PR TITLE
fix(web): make code block inner radius concentric with its wrapper

### DIFF
--- a/web/src/app/app/message/CodeBlock.tsx
+++ b/web/src/app/app/message/CodeBlock.tsx
@@ -87,10 +87,20 @@ export const CodeBlock = memo(function CodeBlock({
     );
   }
 
+  // Concentric with the wrapper: inner radius = outer radius - the gap between
+  // the two boxes. Both come from vars the wrapper sets, so they stay in sync.
+  const innerRounding =
+    "rounded-[calc(var(--code-block-radius,0px)-var(--code-block-gap,0px))]!";
+
   const CodeContent = () => {
     if (!language) {
       return (
-        <pre className="p-2! m-0 overflow-x-auto w-0 min-w-full hljs">
+        <pre
+          className={cn(
+            "p-2! m-0 overflow-x-auto w-0 min-w-full hljs",
+            innerRounding
+          )}
+        >
           <code className={`text-sm hljs ${className}`}>
             {Array.isArray(children)
               ? children.map((child, index) => (
@@ -103,7 +113,12 @@ export const CodeBlock = memo(function CodeBlock({
     }
 
     return (
-      <pre className="p-2! m-0 overflow-x-auto w-0 min-w-full hljs">
+      <pre
+        className={cn(
+          "p-2! m-0 overflow-x-auto w-0 min-w-full hljs",
+          innerRounding
+        )}
+      >
         <code className="text-xs">
           {Array.isArray(children)
             ? children.map((child, index) => (
@@ -121,7 +136,10 @@ export const CodeBlock = memo(function CodeBlock({
         <div
           className={cn(
             "bg-background-tint-00 rounded-12 max-w-full min-w-0",
-            !noPadding && "px-1 pb-1"
+            "[--code-block-radius:var(--radius-12)]",
+            noPadding
+              ? "[--code-block-gap:0px]"
+              : "px-1 pb-1 [--code-block-gap:0.25rem]"
           )}
         >
           {language && (


### PR DESCRIPTION
## What

The code snippet wrapper in `CodeBlock.tsx` uses `rounded-12` (12px) with a 4px gap (`px-1 pb-1`), but the inner `<pre>` rendered at 6px — the `@tailwindcss/typography` default for `.prose pre`.

Nested rounded boxes only read as continuous when the inner radius equals the outer radius minus the gap between them. At 6px the inner curve is tighter than the outer one, so the gap pinched at the corners.

## How

The wrapper sets `--code-block-radius` and `--code-block-gap`; the `<pre>` derives its radius with `calc(radius - gap)`. Results:

- padded (default): 8px
- `noPadding`: 12px
- headerless (`showHeader={false}`, no wrapper): 0, as the vars are unset

Deriving instead of hardcoding keeps the two values in sync if the wrapper rounding ever changes. The `!` is needed because `.prose pre` otherwise wins on specificity.

## Notes

The wrapper has no top padding (`px-1 pb-1`), so the `<pre>`'s top corners sit flush with the wrapper's. The language header covers them whenever `language` is set; the one path that exposes them is `showHeader && !language`. Splitting into `rounded-t-12 rounded-b-08` would be strictly correct — left out as it is not visible in practice.

## Testing

Visual change only. `pre-commit` passes on the touched file (ripsecrets, oxfmt, oxlint). The repo-wide `tsc` reports 536 errors both with and without this change — all pre-existing `Button` prop errors in unrelated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**before**
<img width="1902" height="2085" alt="20260814_14h33m56s_grim" src="https://github.com/user-attachments/assets/ddd91e11-b35a-4c66-b0d5-8e59130024ea" />

**after**
<img width="1902" height="2085" alt="20260814_14h34m01s_grim" src="https://github.com/user-attachments/assets/1c686f17-292c-4960-955f-31cef990a42d" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pinched corners in code blocks by deriving the inner <pre> radius from the wrapper radius minus the gap. Previously the inner <pre> used the 6px `@tailwindcss/typography` default, which misaligned with a 12px wrapper and 4px gap; now the radii stay concentric in both padded and noPadding states.

- Set `--code-block-radius` and `--code-block-gap` on the wrapper; compute inner rounding as `rounded-[calc(var(--code-block-radius,0px)-var(--code-block-gap,0px))]!`.
- Results: padded = 8px; `noPadding` = 12px; no wrapper (`showHeader={false}`) = 0 (vars unset).
- Use `!` to override `.prose pre` rounding from `@tailwindcss/typography`.
- Visual-only change; check padded vs `noPadding` and headerless variants to confirm continuous corners.

<sup>Written for commit f2bc6db050b5c52119f38a457e09f8a11e2b845d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

