### PR TITLE
feat(config): TOML config service — loader core + shared_configs migration

### DIFF
--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -2307,7 +2307,9 @@ pydantic-core==2.41.5 \
 pydantic-settings==2.14.2 \
     --hash=sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440 \
     --hash=sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f
-    # via mcp
+    # via
+    #   mcp
+    #   onyx
 pydivert==2.1.0 ; sys_platform == 'win32' \
     --hash=sha256:382db488e3c37c03ec9ec94e061a0b24334d78dbaeebb7d4e4d32ce4355d9da1 \
     --hash=sha256:f0e150f4ff591b78e35f514e319561dadff7f24a82186a171dd4d465483de5b4

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -1458,6 +1458,7 @@ pydantic==2.12.5 \
     #   litellm
     #   onyx
     #   openai
+    #   pydantic-settings
 pydantic-core==2.41.5 \
     --hash=sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90 \
     --hash=sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740 \
@@ -1505,6 +1506,10 @@ pydantic-core==2.41.5 \
     # via
     #   cohere
     #   pydantic
+pydantic-settings==2.14.2 \
+    --hash=sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440 \
+    --hash=sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f
+    # via onyx
 pyee==13.0.0 \
     --hash=sha256:48195a3cddb3b1515ce0695ed76036b5ccc2ef3a9f963ff9f77aec0139845498 \
     --hash=sha256:b391e3c5a434d1f5118a25615001dbc8f669cf410ab67d04c4d4e07c55481c37
@@ -1571,6 +1576,7 @@ python-dotenv==1.2.2 \
     --hash=sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3
     # via
     #   litellm
+    #   pydantic-settings
     #   pytest-dotenv
 python-json-logger==4.1.0 \
     --hash=sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2 \
@@ -2072,6 +2078,7 @@ typing-inspection==0.4.2 \
     # via
     #   fastapi
     #   pydantic
+    #   pydantic-settings
 tzdata==2025.2 ; sys_platform == 'win32' \
     --hash=sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8 \
     --hash=sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9

--- a/backend/requirements/ee.txt
+++ b/backend/requirements/ee.txt
@@ -1002,6 +1002,7 @@ pydantic==2.12.5 \
     #   litellm
     #   onyx
     #   openai
+    #   pydantic-settings
 pydantic-core==2.41.5 \
     --hash=sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90 \
     --hash=sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740 \
@@ -1049,6 +1050,10 @@ pydantic-core==2.41.5 \
     # via
     #   cohere
     #   pydantic
+pydantic-settings==2.14.2 \
+    --hash=sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440 \
+    --hash=sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f
+    # via onyx
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
@@ -1060,7 +1065,9 @@ python-dateutil==2.9.0.post0 \
 python-dotenv==1.2.2 \
     --hash=sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a \
     --hash=sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3
-    # via litellm
+    # via
+    #   litellm
+    #   pydantic-settings
 python-json-logger==4.1.0 \
     --hash=sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2 \
     --hash=sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195
@@ -1354,6 +1361,7 @@ typing-inspection==0.4.2 \
     # via
     #   fastapi
     #   pydantic
+    #   pydantic-settings
 urllib3==2.7.0 \
     --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
     --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897

--- a/backend/requirements/model_server.txt
+++ b/backend/requirements/model_server.txt
@@ -1149,6 +1149,7 @@ pydantic==2.12.5 \
     #   litellm
     #   onyx
     #   openai
+    #   pydantic-settings
 pydantic-core==2.41.5 \
     --hash=sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90 \
     --hash=sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740 \
@@ -1196,6 +1197,10 @@ pydantic-core==2.41.5 \
     # via
     #   cohere
     #   pydantic
+pydantic-settings==2.14.2 \
+    --hash=sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440 \
+    --hash=sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f
+    # via onyx
 pygments==2.20.0 \
     --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
     --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
@@ -1211,7 +1216,9 @@ python-dateutil==2.9.0.post0 \
 python-dotenv==1.2.2 \
     --hash=sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a \
     --hash=sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3
-    # via litellm
+    # via
+    #   litellm
+    #   pydantic-settings
 python-json-logger==4.1.0 \
     --hash=sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2 \
     --hash=sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195
@@ -1655,6 +1662,7 @@ typing-inspection==0.4.2 \
     # via
     #   fastapi
     #   pydantic
+    #   pydantic-settings
 tzdata==2025.2 \
     --hash=sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8 \
     --hash=sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9

--- a/backend/scripts/env_inventory.py
+++ b/backend/scripts/env_inventory.py
@@ -72,6 +72,24 @@ ENV_HELPER_FUNCS = {
     "_non_negative_int_env": "int",
 }
 
+# Config modules migrated to the TOML settings service declare their env
+# surface as pydantic-settings fields instead of os.environ reads. Without
+# these, every migrated variable would silently vanish from the inventory —
+# and the drift gate would read that as "resolved" rather than "invisible".
+# Kept in sync with shared_configs/settings_base.py: the base class name, the
+# field-declaration helper, and its aliases kwarg.
+SETTINGS_BASE_CLASSES = {"OnyxBaseSettings"}
+SETTINGS_FIELD_FUNC = "onyx_field"
+SETTINGS_FIELD_ENV_KWARG = "env"
+
+# Annotations that carry a legacy string-coercion wrapper rather than a plain
+# builtin. Maps the annotation's base name to the effective value type.
+SETTINGS_ANNOTATION_TYPES = {
+    "LegacyEnvBool": "bool",
+    "LegacyEnvBoolUnlessFalse": "bool",
+    "CommaSeparatedStrList": "str",
+}
+
 # Deployment files to cross-reference.
 ENV_TEMPLATES = [
     REPO_ROOT / "deployment" / "docker_compose" / "env.template",
@@ -393,6 +411,103 @@ def _scan_os_imports(tree: ast.AST) -> tuple[set[str], set[str]]:
     return environ_aliases, getenv_aliases
 
 
+def _annotation_type(node: ast.AST | None) -> str:
+    """Effective value type for a settings field annotation.
+
+    Unwraps `X | None` and maps the legacy-coercion aliases onto the builtin
+    they validate to, so a `LegacyEnvBool` field reports `bool` exactly as the
+    equivalent `.lower() == "true"` read used to.
+    """
+    if node is None:
+        return "unknown"
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        # `str | None` -> str; `None | str` is not idiomatic but handle both.
+        for side in (node.left, node.right):
+            if not (isinstance(side, ast.Constant) and side.value is None):
+                return _annotation_type(side)
+        return "unknown"
+    if isinstance(node, ast.Subscript):  # list[str], dict[str, str], ...
+        return _annotation_type(node.value)
+    if isinstance(node, ast.Name):
+        return SETTINGS_ANNOTATION_TYPES.get(node.id, node.id)
+    return "unknown"
+
+
+class SettingsFieldVisitor(ast.NodeVisitor):
+    """Collects the env surface declared by OnyxBaseSettings subclasses.
+
+    Each `onyx_field(...)` declaration maps to one or more env var names: the
+    field name uppercased always works, plus any legacy names in the `env`
+    kwarg (which take priority). This mirrors `env_names_of` in
+    shared_configs/settings_base.py — if that priority rule changes, change it
+    here too.
+    """
+
+    def __init__(self, rel_path: str, is_ee: bool) -> None:
+        self.rel_path = rel_path
+        self.is_ee = is_ee
+        self.in_config_dir = any(m in f"/{rel_path}" for m in CONFIG_DIR_MARKERS)
+        self.reads: list[EnvRead] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        bases = {b.id for b in node.bases if isinstance(b, ast.Name)}
+        if bases & SETTINGS_BASE_CLASSES:
+            for stmt in node.body:
+                if isinstance(stmt, ast.AnnAssign):
+                    self._record_field(stmt)
+        self.generic_visit(node)
+
+    def _record_field(self, stmt: ast.AnnAssign) -> None:
+        if not isinstance(stmt.target, ast.Name):
+            return
+        call = stmt.value
+        if not (
+            isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Name)
+            and call.func.id == SETTINGS_FIELD_FUNC
+        ):
+            return
+
+        kwargs = {kw.arg: kw.value for kw in call.keywords if kw.arg}
+        names: list[str] = []
+        env_arg = kwargs.get(SETTINGS_FIELD_ENV_KWARG)
+        if isinstance(env_arg, (ast.Tuple, ast.List)):
+            # `env=` is the complete surface when present — the field name does
+            # NOT also apply, because populate_by_name is off.
+            for element in env_arg.elts:
+                literal = _str_const(element)
+                if literal:
+                    names.append(literal.upper())
+        if not names:
+            names.append(stmt.target.id.upper())
+
+        default_node = kwargs.get("default") or kwargs.get("default_factory")
+        default = _literal_default(default_node)
+        inferred = _annotation_type(stmt.annotation)
+
+        for name in names:
+            if not re.fullmatch(r"[A-Z][A-Z0-9_]*", name):
+                continue
+            self.reads.append(
+                EnvRead(
+                    name=name,
+                    file=self.rel_path,
+                    line=stmt.lineno,
+                    read_style=f"settings:{SETTINGS_FIELD_FUNC}",
+                    inferred_type=inferred,
+                    default=default,
+                    # A settings field is a declaration, not an assignment, so
+                    # it cannot participate in duplicate-assignment detection.
+                    assigned_to=None,
+                    assign_id=None,
+                    assign_line=None,
+                    module_scope=True,
+                    in_config_dir=self.in_config_dir,
+                    is_ee=self.is_ee,
+                )
+            )
+
+
 def collect_reads() -> list[EnvRead]:
     reads: list[EnvRead] = []
     for root in SCAN_ROOTS:
@@ -409,6 +524,9 @@ def collect_reads() -> list[EnvRead]:
             visitor = EnvVisitor(rel, is_ee, environ_aliases, getenv_aliases)
             visitor.visit(tree)
             reads.extend(visitor.reads)
+            settings_visitor = SettingsFieldVisitor(rel, is_ee)
+            settings_visitor.visit(tree)
+            reads.extend(settings_visitor.reads)
     return reads
 
 

--- a/backend/shared_configs/configs.py
+++ b/backend/shared_configs/configs.py
@@ -1,35 +1,42 @@
-import os
+"""Facade over SharedSettings (shared_configs/settings.py).
+
+Constants keep their historical names so the hundreds of
+``from shared_configs.configs import X`` call sites are unaffected. The
+settings instance is built at module scope on purpose: reloading this module
+re-reads the environment, which the ``monkeypatch.setenv`` plus
+``importlib.reload`` test seam relies on, while the TOML document stays
+memoized per path in settings_base.
+
+Every SharedSettings field must be re-exported here — enforced by
+tests/unit/shared_configs/test_settings_facade.py.
+"""
+
 from typing import Any, List
 from urllib.parse import urlparse
+
+from shared_configs.settings import SharedSettings
+
+_settings = SharedSettings()
 
 # Used for logging
 SLACK_CHANNEL_ID = "channel_id"
 
 # Skip model warmup at startup
 # Default to True (skip warmup) if not set, otherwise respect the value
-SKIP_WARM_UP = os.environ.get("SKIP_WARM_UP", "true").lower() == "true"
+SKIP_WARM_UP = _settings.skip_warm_up
 
 # Check if model server is disabled
-DISABLE_MODEL_SERVER = os.environ.get("DISABLE_MODEL_SERVER", "").lower() == "true"
+DISABLE_MODEL_SERVER = _settings.disable_model_server
 
 # If model server is disabled, use "disabled" as host to trigger proper handling
-if DISABLE_MODEL_SERVER:
-    MODEL_SERVER_HOST = "disabled"
-    MODEL_SERVER_ALLOWED_HOST = "disabled"
-    INDEXING_MODEL_SERVER_HOST = "disabled"
-else:
-    MODEL_SERVER_HOST = os.environ.get("MODEL_SERVER_HOST") or "localhost"
-    MODEL_SERVER_ALLOWED_HOST = os.environ.get("MODEL_SERVER_HOST") or "0.0.0.0"  # noqa: S104 — model server allowed-host default; intentional for containerized deployment
-    INDEXING_MODEL_SERVER_HOST = (
-        os.environ.get("INDEXING_MODEL_SERVER_HOST") or MODEL_SERVER_HOST
-    )
+MODEL_SERVER_HOST = _settings.model_server_host
+MODEL_SERVER_ALLOWED_HOST = _settings.model_server_allowed_host
+INDEXING_MODEL_SERVER_HOST = _settings.indexing_model_server_host
 
-MODEL_SERVER_PORT = int(os.environ.get("MODEL_SERVER_PORT") or "9000")
+MODEL_SERVER_PORT = _settings.model_server_port
 # Model server for indexing should use a separate one to not allow indexing to introduce delay
 # for inference
-INDEXING_MODEL_SERVER_PORT = int(
-    os.environ.get("INDEXING_MODEL_SERVER_PORT") or MODEL_SERVER_PORT
-)
+INDEXING_MODEL_SERVER_PORT = _settings.indexing_model_server_port
 
 # Onyx custom Deep Learning Models
 CONNECTOR_CLASSIFIER_MODEL_REPO = "Danswer/filter-extraction-model"
@@ -46,54 +53,48 @@ ALT_INDEX_SUFFIX = "__danswer_alt_index"
 
 # Used for loading defaults for automatic deployments and dev flows
 # For local, use: mixedbread-ai/mxbai-rerank-xsmall-v1
-DEFAULT_CROSS_ENCODER_MODEL_NAME = (
-    os.environ.get("DEFAULT_CROSS_ENCODER_MODEL_NAME") or None
-)
-DEFAULT_CROSS_ENCODER_API_KEY = os.environ.get("DEFAULT_CROSS_ENCODER_API_KEY") or None
-DEFAULT_CROSS_ENCODER_PROVIDER_TYPE = (
-    os.environ.get("DEFAULT_CROSS_ENCODER_PROVIDER_TYPE") or None
-)
-DISABLE_RERANK_FOR_STREAMING = (
-    os.environ.get("DISABLE_RERANK_FOR_STREAMING", "").lower() == "true"
-)
+DEFAULT_CROSS_ENCODER_MODEL_NAME = _settings.default_cross_encoder_model_name
+DEFAULT_CROSS_ENCODER_API_KEY = _settings.default_cross_encoder_api_key
+DEFAULT_CROSS_ENCODER_PROVIDER_TYPE = _settings.default_cross_encoder_provider_type
+DISABLE_RERANK_FOR_STREAMING = _settings.disable_rerank_for_streaming
 
 # This controls the minimum number of pytorch "threads" to allocate to the embedding
 # model. If torch finds more threads on its own, this value is not used.
-MIN_THREADS_ML_MODELS = int(os.environ.get("MIN_THREADS_ML_MODELS") or 1)
+MIN_THREADS_ML_MODELS = _settings.min_threads_ml_models
 
 # Model server that has indexing only set will throw exception if used for reranking
 # or intent classification
-INDEXING_ONLY = os.environ.get("INDEXING_ONLY", "").lower() == "true"
+INDEXING_ONLY = _settings.indexing_only
 
 # The process needs to have this for the log file to write to
 # otherwise, it will not create additional log files
 # This should just be the filename base without extension or path.
-LOG_FILE_NAME = os.environ.get("LOG_FILE_NAME") or "onyx"
+LOG_FILE_NAME = _settings.log_file_name
 
 # Enable generating persistent log files for local dev environments
-DEV_LOGGING_ENABLED = os.environ.get("DEV_LOGGING_ENABLED", "").lower() == "true"
+DEV_LOGGING_ENABLED = _settings.dev_logging_enabled
 # File logging is on by default. Set LOG_TO_FILE=false to disable it for a given
 # pod/process — it then logs to stdout only (e.g. read-only-root containers where
 # /var/log/onyx isn't writable).
-LOG_TO_FILE = os.environ.get("LOG_TO_FILE", "true").lower() != "false"
+LOG_TO_FILE = _settings.log_to_file
 # notset, debug, info, notice, warning, error, or critical
-LOG_LEVEL = os.environ.get("LOG_LEVEL") or "info"
+LOG_LEVEL = _settings.log_level
 # Chatty third-party libraries (LiteLLM, httpcore, botocore, ...) are capped at
 # INFO even when LOG_LEVEL=debug — LiteLLM alone emits several DEBUG records per
 # streamed token. Set LOG_THIRD_PARTY_DEBUG=true to let them log at LOG_LEVEL.
-LOG_THIRD_PARTY_DEBUG = os.environ.get("LOG_THIRD_PARTY_DEBUG", "").lower() == "true"
+LOG_THIRD_PARTY_DEBUG = _settings.log_third_party_debug
 
 # Log output format: "plain" (human-readable text, default) or "json" (structured
 # single-line JSON, suitable for container log aggregators). When "json", context
 # such as tenant/request/task ids are emitted as discrete fields rather than being
 # prefixed into the message string.
-LOG_FORMAT = (os.environ.get("LOG_FORMAT") or "plain").lower()
+LOG_FORMAT = _settings.log_format
 JSON_LOGGING = LOG_FORMAT == "json"
 
 # Timeout for API-based embedding models
 # NOTE: does not apply for Google VertexAI, since the python client doesn't
 # allow us to specify a custom timeout
-API_BASED_EMBEDDING_TIMEOUT = int(os.environ.get("API_BASED_EMBEDDING_TIMEOUT", "600"))
+API_BASED_EMBEDDING_TIMEOUT = _settings.api_based_embedding_timeout
 
 # Timeouts for requests to the self-hosted model server (embedding / rerank /
 # intent). The connect timeout fails fast on an unreachable server; the read
@@ -102,35 +103,27 @@ API_BASED_EMBEDDING_TIMEOUT = int(os.environ.get("API_BASED_EMBEDDING_TIMEOUT", 
 # requests.post (observed wedging every docprocessing thread for hours during
 # an upgrade). Reads are generous because CPU embedding of large batches can
 # legitimately take minutes.
-MODEL_SERVER_CONNECT_TIMEOUT = int(os.environ.get("MODEL_SERVER_CONNECT_TIMEOUT", "30"))
-MODEL_SERVER_READ_TIMEOUT = int(os.environ.get("MODEL_SERVER_READ_TIMEOUT", "600"))
+MODEL_SERVER_CONNECT_TIMEOUT = _settings.model_server_connect_timeout
+MODEL_SERVER_READ_TIMEOUT = _settings.model_server_read_timeout
 
 # Local batch size for VertexAI embedding models currently calibrated for item size of 512 tokens
 # NOTE: increasing this value may lead to API errors due to token limit exhaustion per call.
-VERTEXAI_EMBEDDING_LOCAL_BATCH_SIZE = int(
-    os.environ.get("VERTEXAI_EMBEDDING_LOCAL_BATCH_SIZE", "50")
-)
+VERTEXAI_EMBEDDING_LOCAL_BATCH_SIZE = _settings.vertexai_embedding_local_batch_size
 
 # Only used for OpenAI
-OPENAI_EMBEDDING_TIMEOUT = int(
-    os.environ.get("OPENAI_EMBEDDING_TIMEOUT", API_BASED_EMBEDDING_TIMEOUT)
-)
+OPENAI_EMBEDDING_TIMEOUT = _settings.openai_embedding_timeout
 
 # Whether or not to strictly enforce token limit for chunking.
-STRICT_CHUNK_TOKEN_LIMIT = (
-    os.environ.get("STRICT_CHUNK_TOKEN_LIMIT", "").lower() == "true"
-)
+STRICT_CHUNK_TOKEN_LIMIT = _settings.strict_chunk_token_limit
 
 # Set up Sentry integration (for error logging)
-SENTRY_DSN = os.environ.get("SENTRY_DSN")
+SENTRY_DSN = _settings.sentry_dsn
 
 # Celery task spans dominate ingestion volume (~94%), so default celery
 # tracing to 0. Web/API traces stay at a small non-zero rate so http.server
 # traces remain available. Both are env-tunable without a code change.
-SENTRY_TRACES_SAMPLE_RATE = float(os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0.01"))
-SENTRY_CELERY_TRACES_SAMPLE_RATE = float(
-    os.environ.get("SENTRY_CELERY_TRACES_SAMPLE_RATE", "0.0")
-)
+SENTRY_TRACES_SAMPLE_RATE = _settings.sentry_traces_sample_rate
+SENTRY_CELERY_TRACES_SAMPLE_RATE = _settings.sentry_celery_traces_sample_rate
 
 
 # Fields which should only be set on new search setting
@@ -163,7 +156,7 @@ def validate_cors_origin(origin: str) -> None:
 # - "http://example.com" (single origin)
 # - "http://example.com,https://example.org" (multiple origins)
 # - "*" (allow all origins, credentials disabled)
-CORS_ALLOWED_ORIGIN_ENV = os.environ.get("CORS_ALLOWED_ORIGIN", "")
+CORS_ALLOWED_ORIGIN_ENV = _settings.cors_allowed_origin
 
 
 def parse_cors_allowed_origins(env_value: str) -> List[str]:
@@ -191,15 +184,13 @@ CORS_ALLOW_CREDENTIALS: bool = cors_allow_credentials(CORS_ALLOWED_ORIGIN)
 
 
 # Multi-tenancy configuration
-MULTI_TENANT = os.environ.get("MULTI_TENANT", "").lower() == "true"
+MULTI_TENANT = _settings.multi_tenant
 
 # Outside this file, should almost always use `POSTGRES_DEFAULT_SCHEMA` unless you
 # have a very good reason
 POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE = "public"
-POSTGRES_DEFAULT_SCHEMA = (
-    os.environ.get("POSTGRES_DEFAULT_SCHEMA") or POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
-)
-DEFAULT_REDIS_PREFIX = os.environ.get("DEFAULT_REDIS_PREFIX") or "default"
+POSTGRES_DEFAULT_SCHEMA = _settings.postgres_default_schema
+DEFAULT_REDIS_PREFIX = _settings.default_redis_prefix
 
 
 async def async_return_default_schema(
@@ -212,7 +203,7 @@ async def async_return_default_schema(
 # Prefix used for all tenant ids
 TENANT_ID_PREFIX = "tenant_"
 
-DISALLOWED_SLACK_BOT_TENANT_IDS = os.environ.get("DISALLOWED_SLACK_BOT_TENANT_IDS")
+DISALLOWED_SLACK_BOT_TENANT_IDS = _settings.disallowed_slack_bot_tenant_ids
 DISALLOWED_SLACK_BOT_TENANT_LIST = (
     [
         tenant.strip()
@@ -223,7 +214,7 @@ DISALLOWED_SLACK_BOT_TENANT_LIST = (
     else None
 )
 
-IGNORED_SYNCING_TENANT_IDS = os.environ.get("IGNORED_SYNCING_TENANT_IDS")
+IGNORED_SYNCING_TENANT_IDS = _settings.ignored_syncing_tenant_ids
 IGNORED_SYNCING_TENANT_LIST = (
     [
         tenant.strip()
@@ -238,41 +229,24 @@ IGNORED_SYNCING_TENANT_LIST = (
 # Usage Limits Configuration (meant for cloud, off by default for self-hosted)
 #####
 # Whether usage limits are enforced (defaults to MULTI_TENANT value)
-_USAGE_LIMITS_ENABLED_RAW = os.environ.get("USAGE_LIMITS_ENABLED")
-if _USAGE_LIMITS_ENABLED_RAW is not None:
-    USAGE_LIMITS_ENABLED = _USAGE_LIMITS_ENABLED_RAW.lower() == "true"
-else:
-    # Default: enabled on cloud (MULTI_TENANT), disabled for self-hosted
-    USAGE_LIMITS_ENABLED = MULTI_TENANT
+USAGE_LIMITS_ENABLED = _settings.usage_limits_enabled
 
 # Usage limit window in seconds (default: 1 week = 604800 seconds)
-USAGE_LIMIT_WINDOW_SECONDS = int(os.environ.get("USAGE_LIMIT_WINDOW_SECONDS", "604800"))
+USAGE_LIMIT_WINDOW_SECONDS = _settings.usage_limit_window_seconds
 
 # Per-week LLM usage cost limits in cents (e.g., 1000 = $10.00)
 # Trial users get lower limits than paid users
-USAGE_LIMIT_LLM_COST_CENTS_TRIAL = int(
-    os.environ.get("USAGE_LIMIT_LLM_COST_CENTS_TRIAL", "3200")  # $32.00 default
-)
-USAGE_LIMIT_LLM_COST_CENTS_PAID = int(
-    os.environ.get("USAGE_LIMIT_LLM_COST_CENTS_PAID", "6400")  # $64.00 default
-)
+USAGE_LIMIT_LLM_COST_CENTS_TRIAL = _settings.usage_limit_llm_cost_cents_trial
+USAGE_LIMIT_LLM_COST_CENTS_PAID = _settings.usage_limit_llm_cost_cents_paid
 
 # Per-week chunks indexed limits
-USAGE_LIMIT_CHUNKS_INDEXED_TRIAL = int(
-    os.environ.get("USAGE_LIMIT_CHUNKS_INDEXED_TRIAL", 400_000)
-)
-USAGE_LIMIT_CHUNKS_INDEXED_PAID = int(
-    os.environ.get("USAGE_LIMIT_CHUNKS_INDEXED_PAID", 4_000_000)
-)
+USAGE_LIMIT_CHUNKS_INDEXED_TRIAL = _settings.usage_limit_chunks_indexed_trial
+USAGE_LIMIT_CHUNKS_INDEXED_PAID = _settings.usage_limit_chunks_indexed_paid
 
 # Per-week API calls using API keys or Personal Access Tokens
-USAGE_LIMIT_API_CALLS_TRIAL = int(os.environ.get("USAGE_LIMIT_API_CALLS_TRIAL", "0"))
-USAGE_LIMIT_API_CALLS_PAID = int(os.environ.get("USAGE_LIMIT_API_CALLS_PAID", "40000"))
+USAGE_LIMIT_API_CALLS_TRIAL = _settings.usage_limit_api_calls_trial
+USAGE_LIMIT_API_CALLS_PAID = _settings.usage_limit_api_calls_paid
 
 # Per-week non-streaming API calls (more expensive, so lower limits)
-USAGE_LIMIT_NON_STREAMING_CALLS_TRIAL = int(
-    os.environ.get("USAGE_LIMIT_NON_STREAMING_CALLS_TRIAL", "0")
-)
-USAGE_LIMIT_NON_STREAMING_CALLS_PAID = int(
-    os.environ.get("USAGE_LIMIT_NON_STREAMING_CALLS_PAID", "160")
-)
+USAGE_LIMIT_NON_STREAMING_CALLS_TRIAL = _settings.usage_limit_non_streaming_calls_trial
+USAGE_LIMIT_NON_STREAMING_CALLS_PAID = _settings.usage_limit_non_streaming_calls_paid

--- a/backend/shared_configs/settings.py
+++ b/backend/shared_configs/settings.py
@@ -1,0 +1,299 @@
+"""Typed schema for the config surface shared by the backend and the model
+server. The facade that preserves the legacy constant names lives in
+``shared_configs/configs.py``.
+
+Must stay importable by ``model_server``: stdlib and pydantic only, never
+``onyx.*``.
+"""
+
+from pydantic import model_validator
+
+from shared_configs.settings_base import (
+    LegacyEnvBool,
+    LegacyEnvBoolUnlessFalse,
+    OnyxBaseSettings,
+    onyx_field,
+)
+
+# Sentinel host that tells model-server clients to skip the call entirely.
+MODEL_SERVER_DISABLED_HOST = "disabled"
+
+
+class SharedSettings(OnyxBaseSettings):
+    # --- model server ---
+    skip_warm_up: LegacyEnvBool = onyx_field(
+        default=True,
+        toml="model_server.skip_warm_up",
+        description="Skip ML model warmup at startup.",
+        # Legacy default was the string "true", so a blank value read as False
+        # rather than falling back to the default.
+        blank_is_falsy=True,
+    )
+    disable_model_server: LegacyEnvBool = onyx_field(
+        default=False,
+        toml="model_server.disable",
+        description="Disable the model server entirely; hosts become 'disabled'.",
+    )
+    model_server_host: str = onyx_field(
+        default="localhost",
+        toml="model_server.host",
+        description="Hostname of the inference model server.",
+    )
+    model_server_allowed_host: str = onyx_field(
+        default="0.0.0.0",  # noqa: S104 — intentional bind default for containers
+        # Legacy reads MODEL_SERVER_HOST for this too, with a different
+        # default. Deliberately NOT also exposing MODEL_SERVER_ALLOWED_HOST:
+        # separating the bind address from the client-facing host is a real
+        # improvement, but it is a new operator knob and belongs in its own
+        # change, not smuggled in by a config refactor.
+        env=("MODEL_SERVER_HOST",),
+        toml="model_server.allowed_host",
+        description="Host or interface the model server binds to.",
+    )
+    indexing_model_server_host: str = onyx_field(
+        default_factory=lambda data: data["model_server_host"],
+        toml="model_server.indexing_host",
+        description="Hostname of the dedicated indexing model server; defaults "
+        "to the inference model server host.",
+    )
+    model_server_port: int = onyx_field(
+        default=9000,
+        toml="model_server.port",
+        description="Port of the inference model server.",
+    )
+    indexing_model_server_port: int = onyx_field(
+        default_factory=lambda data: data["model_server_port"],
+        toml="model_server.indexing_port",
+        description="Port of the dedicated indexing model server; defaults to "
+        "the inference model server port.",
+    )
+    min_threads_ml_models: int = onyx_field(
+        default=1,
+        toml="model_server.min_threads_ml_models",
+        description="Minimum number of torch threads for embedding models.",
+    )
+    indexing_only: LegacyEnvBool = onyx_field(
+        default=False,
+        toml="model_server.indexing_only",
+        description="Model server serves indexing requests only.",
+    )
+    model_server_connect_timeout: int = onyx_field(
+        default=30,
+        toml="model_server.connect_timeout",
+        description="Connect timeout in seconds for model server requests.",
+    )
+    model_server_read_timeout: int = onyx_field(
+        default=600,
+        toml="model_server.read_timeout",
+        description="Read timeout in seconds for model server requests.",
+    )
+
+    # --- reranking ---
+    default_cross_encoder_model_name: str | None = onyx_field(
+        default=None,
+        toml="rerank.default_model_name",
+        description="Default cross-encoder model for automatic deployments.",
+    )
+    default_cross_encoder_api_key: str | None = onyx_field(
+        default=None,
+        toml="rerank.default_api_key",
+        description="API key for the default cross-encoder provider.",
+        secret=True,
+    )
+    default_cross_encoder_provider_type: str | None = onyx_field(
+        default=None,
+        toml="rerank.default_provider_type",
+        description="Provider type for the default cross-encoder.",
+    )
+    disable_rerank_for_streaming: LegacyEnvBool = onyx_field(
+        default=False,
+        toml="rerank.disable_for_streaming",
+        description="Skip reranking in streaming flows.",
+    )
+
+    # --- logging ---
+    log_file_name: str = onyx_field(
+        default="onyx",
+        toml="logging.file_name",
+        description="Base filename, no extension or path, for log files.",
+    )
+    dev_logging_enabled: LegacyEnvBool = onyx_field(
+        default=False,
+        toml="logging.dev_logging_enabled",
+        description="Generate persistent log files for local dev environments.",
+    )
+    log_to_file: LegacyEnvBoolUnlessFalse = onyx_field(
+        default=True,
+        toml="logging.to_file",
+        description="Write log files; disable for read-only-root containers.",
+    )
+    log_level: str = onyx_field(
+        default="info",
+        toml="logging.level",
+        description="Log level: notset, debug, info, notice, warning, error, "
+        "or critical.",
+    )
+    log_third_party_debug: LegacyEnvBool = onyx_field(
+        default=False,
+        toml="logging.third_party_debug",
+        description="Let chatty third-party libraries log at LOG_LEVEL instead "
+        "of being capped at INFO.",
+    )
+    log_format: str = onyx_field(
+        default="plain",
+        toml="logging.format",
+        description='Log output format: "plain" or "json".',
+    )
+
+    # --- embedding ---
+    api_based_embedding_timeout: int = onyx_field(
+        default=600,
+        toml="embedding.api_timeout",
+        description="Timeout in seconds for API-based embedding models.",
+    )
+    openai_embedding_timeout: int = onyx_field(
+        default_factory=lambda data: data["api_based_embedding_timeout"],
+        toml="embedding.openai_timeout",
+        description="Timeout in seconds for OpenAI embedding calls; defaults "
+        "to the API-based embedding timeout.",
+    )
+    vertexai_embedding_local_batch_size: int = onyx_field(
+        default=50,
+        toml="embedding.vertexai_local_batch_size",
+        description="Local batch size for VertexAI embedding models.",
+    )
+    strict_chunk_token_limit: LegacyEnvBool = onyx_field(
+        default=False,
+        toml="embedding.strict_chunk_token_limit",
+        description="Strictly enforce the token limit when chunking.",
+    )
+
+    # --- sentry ---
+    sentry_dsn: str | None = onyx_field(
+        default=None,
+        toml="sentry.dsn",
+        description="Sentry DSN for error reporting.",
+        secret=True,
+        # Legacy was a bare os.environ.get, so blank stayed "" rather than
+        # becoming None. Both are falsy, but keeping "" makes the migration
+        # byte-identical instead of merely equivalent.
+        blank_is_falsy=True,
+    )
+    sentry_traces_sample_rate: float = onyx_field(
+        default=0.01,
+        toml="sentry.traces_sample_rate",
+        description="Sentry trace sample rate for web and API requests.",
+    )
+    sentry_celery_traces_sample_rate: float = onyx_field(
+        default=0.0,
+        toml="sentry.celery_traces_sample_rate",
+        description="Sentry trace sample rate for Celery tasks.",
+    )
+
+    # --- CORS ---
+    # Raw comma-separated origin list. Parsing and validation stay in the
+    # facade's parse_cors_allowed_origins, which treats empty as "allow all".
+    cors_allowed_origin: str = onyx_field(
+        default="",
+        toml="cors.allowed_origins",
+        description="Comma-separated allowed CORS origins; empty allows all.",
+    )
+
+    # --- multi-tenancy ---
+    multi_tenant: LegacyEnvBool = onyx_field(
+        default=False,
+        toml="tenancy.multi_tenant",
+        description="Run in multi-tenant (cloud) mode.",
+    )
+    postgres_default_schema: str = onyx_field(
+        default="public",
+        toml="tenancy.postgres_default_schema",
+        description="Default Postgres schema for single-tenant deployments.",
+    )
+    default_redis_prefix: str = onyx_field(
+        default="default",
+        toml="tenancy.default_redis_prefix",
+        description="Redis key prefix for the default tenant.",
+    )
+    # Both stay raw strings: the facade splits them into the *_TENANT_LIST
+    # exports. blank_is_falsy keeps a blank as "" rather than None, matching
+    # the legacy bare os.environ.get exactly.
+    disallowed_slack_bot_tenant_ids: str | None = onyx_field(
+        default=None,
+        toml="tenancy.disallowed_slack_bot_tenant_ids",
+        description="Comma-separated tenant ids excluded from the Slack bot.",
+        blank_is_falsy=True,
+    )
+    ignored_syncing_tenant_ids: str | None = onyx_field(
+        default=None,
+        toml="tenancy.ignored_syncing_tenant_ids",
+        description="Comma-separated tenant ids excluded from syncing.",
+        blank_is_falsy=True,
+    )
+
+    # --- usage limits (cloud; off by default for self-hosted) ---
+    usage_limits_enabled: LegacyEnvBool = onyx_field(
+        # Enabled on cloud, disabled for self-hosted, unless set explicitly.
+        default_factory=lambda data: data["multi_tenant"],
+        toml="usage_limits.enabled",
+        description="Enforce usage limits; defaults to the multi-tenant flag.",
+        # Legacy branched on `is not None`, so a blank value read as False
+        # rather than falling back to the multi_tenant default.
+        blank_is_falsy=True,
+    )
+    usage_limit_window_seconds: int = onyx_field(
+        default=604_800,
+        toml="usage_limits.window_seconds",
+        description="Usage limit window in seconds; default is one week.",
+    )
+    usage_limit_llm_cost_cents_trial: int = onyx_field(
+        default=3200,
+        toml="usage_limits.llm_cost_cents_trial",
+        description="Per-window LLM cost limit in cents for trial users.",
+    )
+    usage_limit_llm_cost_cents_paid: int = onyx_field(
+        default=6400,
+        toml="usage_limits.llm_cost_cents_paid",
+        description="Per-window LLM cost limit in cents for paid users.",
+    )
+    usage_limit_chunks_indexed_trial: int = onyx_field(
+        default=400_000,
+        toml="usage_limits.chunks_indexed_trial",
+        description="Per-window chunks-indexed limit for trial users.",
+    )
+    usage_limit_chunks_indexed_paid: int = onyx_field(
+        default=4_000_000,
+        toml="usage_limits.chunks_indexed_paid",
+        description="Per-window chunks-indexed limit for paid users.",
+    )
+    usage_limit_api_calls_trial: int = onyx_field(
+        default=0,
+        toml="usage_limits.api_calls_trial",
+        description="Per-window API-key or PAT call limit for trial users.",
+    )
+    usage_limit_api_calls_paid: int = onyx_field(
+        default=40_000,
+        toml="usage_limits.api_calls_paid",
+        description="Per-window API-key or PAT call limit for paid users.",
+    )
+    usage_limit_non_streaming_calls_trial: int = onyx_field(
+        default=0,
+        toml="usage_limits.non_streaming_calls_trial",
+        description="Per-window non-streaming API call limit for trial users.",
+    )
+    usage_limit_non_streaming_calls_paid: int = onyx_field(
+        default=160,
+        toml="usage_limits.non_streaming_calls_paid",
+        description="Per-window non-streaming API call limit for paid users.",
+    )
+
+    @model_validator(mode="after")
+    def _normalize(self) -> "SharedSettings":
+        self.log_format = self.log_format.lower()
+        # Disabling the model server overrides every host to the sentinel so
+        # downstream clients skip it.
+        if self.disable_model_server:
+            self.model_server_host = MODEL_SERVER_DISABLED_HOST
+            self.model_server_allowed_host = MODEL_SERVER_DISABLED_HOST
+            self.indexing_model_server_host = MODEL_SERVER_DISABLED_HOST
+        return self

--- a/backend/shared_configs/settings_base.py
+++ b/backend/shared_configs/settings_base.py
@@ -1,0 +1,439 @@
+"""Base infrastructure for Onyx's TOML-backed configuration service.
+
+Configuration precedence, highest to lowest:
+
+1. Environment variables — the legacy surface and per-service overrides.
+2. The optional ``onyx.toml`` config file.
+3. Hardcoded field defaults.
+
+With no TOML file present, behavior matches the historical env-var-only
+configuration.
+
+The file is located via the ``ONYX_CONFIG_FILE`` env var (the literal value
+``disabled`` opts out; a set-but-missing path fails loudly), falling back to
+``/etc/onyx/onyx.toml``. The parsed document is memoized per resolved path for
+the lifetime of the process: config facade modules build their settings class
+fresh on every (re)import — which keeps the ``monkeypatch.setenv`` plus
+``importlib.reload`` test pattern working — while the file is read and parsed
+at most once per path.
+
+Declare fields with :func:`onyx_field`, never with a bare ``Field``. The base
+class rejects any field that skips it, so a TOML path cannot go missing or
+collide by accident.
+
+This module must stay importable by ``model_server``: stdlib and pydantic
+only, never ``onyx.*``.
+"""
+
+import os
+import tomllib
+from collections.abc import Callable
+from pathlib import Path
+from typing import Annotated, Any, cast
+
+from pydantic import AliasChoices, BeforeValidator, Field
+from pydantic.fields import FieldInfo
+from pydantic_settings import (
+    BaseSettings,
+    NoDecode,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+)
+
+ONYX_CONFIG_FILE_ENV_VAR = "ONYX_CONFIG_FILE"
+# Sentinel for ONYX_CONFIG_FILE: skip file loading entirely. Tests and dev
+# machines use it to guarantee no stray config file is picked up. An explicit
+# nonexistent path raises, so this is the only "no file, period" knob.
+ONYX_CONFIG_FILE_DISABLED = "disabled"
+DEFAULT_CONFIG_FILE_PATH = Path("/etc/onyx/onyx.toml")
+
+# json_schema_extra keys written by onyx_field.
+TOML_PATH_KEY = "toml_path"
+SECRET_KEY = "secret"
+BLANK_IS_FALSY_KEY = "blank_is_falsy"
+
+_MISSING = object()
+
+_toml_document_cache: dict[Path, dict[str, Any]] = {}
+
+
+# --- config file loading ------------------------------------------------------
+
+
+def resolve_config_file() -> Path | None:
+    """Resolve the TOML config file path, or None when no file should load.
+
+    An explicitly configured path that does not exist raises: a typo'd
+    ``ONYX_CONFIG_FILE`` must never silently degrade to "no config".
+    """
+    override = os.environ.get(ONYX_CONFIG_FILE_ENV_VAR)
+    if override:
+        if override == ONYX_CONFIG_FILE_DISABLED:
+            return None
+        path = Path(override)
+        if not path.is_file():
+            raise FileNotFoundError(
+                f"{ONYX_CONFIG_FILE_ENV_VAR}={override!r} does not exist"
+            )
+        return path
+    if DEFAULT_CONFIG_FILE_PATH.is_file():
+        return DEFAULT_CONFIG_FILE_PATH
+    return None
+
+
+def load_toml_document() -> dict[str, Any]:
+    """Load the config file, memoized per resolved path.
+
+    The cache lives in this module, which config facades never reload, so a
+    process parses the file at most once per path while facades stay free to
+    rebuild their settings on every reload (re-reading env each time). A
+    changed ``ONYX_CONFIG_FILE`` is a new cache key and parses fresh. Edits to
+    an already-loaded file are not picked up: restart the process, or call
+    ``clear_toml_document_cache`` in tests.
+    """
+    path = resolve_config_file()
+    if path is None:
+        return {}
+    cached = _toml_document_cache.get(path)
+    if cached is not None:
+        return cached
+    with path.open("rb") as file:
+        try:
+            document = tomllib.load(file)
+        except tomllib.TOMLDecodeError as e:
+            raise ValueError(f"Malformed Onyx config file at {path}: {e}") from e
+    _toml_document_cache[path] = document
+    return document
+
+
+def clear_toml_document_cache() -> None:
+    _toml_document_cache.clear()
+
+
+# --- field declaration --------------------------------------------------------
+
+
+def onyx_field(
+    *,
+    toml: str,
+    description: str,
+    default: Any = ...,
+    default_factory: Callable[..., Any] | None = None,
+    env: tuple[str, ...] = (),
+    secret: bool = False,
+    blank_is_falsy: bool = False,
+) -> Any:
+    """Declare an Onyx settings field.
+
+    Args:
+        toml: Dotted path into the TOML document, e.g. ``model_server.port``.
+            Required — see :class:`OnyxBaseSettings` for why.
+        description: Operator-facing help text. Feeds the config template.
+        default: Static default. Omit when passing ``default_factory``.
+        default_factory: Zero-arg or data-aware factory for defaults that
+            derive from an earlier field, e.g.
+            ``lambda data: data["model_server_port"]``.
+        env: Extra env var names to accept, highest priority first. The field
+            name uppercased is always accepted; list only legacy aliases here.
+        secret: Marks a credential so the template generator redacts it.
+        blank_is_falsy: Keep a blank env var (``FOO=``) as an empty string
+            instead of treating it as unset. Needed only where the legacy code
+            gave a blank value a meaning that differs from the field default —
+            see :class:`_BlankAwareEnvSource`.
+
+    Returns:
+        A configured pydantic ``FieldInfo``. Typed ``Any`` so assigning it to a
+        narrowly-typed field annotation type-checks, matching ``Field`` itself.
+    """
+    extra: dict[str, Any] = {
+        TOML_PATH_KEY: toml,
+        SECRET_KEY: secret,
+        BLANK_IS_FALSY_KEY: blank_is_falsy,
+    }
+    validation_alias = AliasChoices(*env) if env else None
+    if default_factory is not None:
+        return Field(
+            default_factory=default_factory,
+            validation_alias=validation_alias,
+            json_schema_extra=extra,
+            description=description,
+        )
+    return Field(
+        default=default,
+        validation_alias=validation_alias,
+        json_schema_extra=extra,
+        description=description,
+    )
+
+
+def _field_extra(field: FieldInfo) -> dict[str, Any]:
+    extra = field.json_schema_extra
+    return cast(dict[str, Any], extra) if isinstance(extra, dict) else {}
+
+
+def toml_path_of(field: FieldInfo) -> str | None:
+    value = _field_extra(field).get(TOML_PATH_KEY)
+    return value if isinstance(value, str) else None
+
+
+def is_secret(field: FieldInfo) -> bool:
+    return _field_extra(field).get(SECRET_KEY) is True
+
+
+def _blank_is_falsy(field: FieldInfo) -> bool:
+    return _field_extra(field).get(BLANK_IS_FALSY_KEY) is True
+
+
+def primary_key_of(field_name: str, field: FieldInfo) -> str:
+    """The key a settings source must use to populate this field.
+
+    ``populate_by_name`` is off (see :class:`OnyxBaseSettings`), so an aliased
+    field is reachable only through its aliases — non-env sources have to key
+    by the primary alias. An unaliased field keys by its plain Python name.
+    """
+    alias = field.validation_alias
+    if isinstance(alias, AliasChoices):
+        return str(alias.choices[0])
+    if isinstance(alias, str):
+        return alias
+    return field_name
+
+
+def env_names_of(field_name: str, field: FieldInfo) -> list[str]:
+    """Every env var name that can populate this field, highest priority first.
+
+    Exactly the declared surface: the aliases when ``env=`` was given, else the
+    field name uppercased. Nothing implicit — a field never gains an extra env
+    var just because of how it is spelled in Python. Kept in sync with the env
+    source so tooling (the drift inventory, the template generator) can
+    enumerate the real env surface without importing settings.
+    """
+    alias = field.validation_alias
+    if isinstance(alias, AliasChoices):
+        return [str(choice).upper() for choice in alias.choices]
+    if isinstance(alias, str):
+        return [alias.upper()]
+    return [field_name.upper()]
+
+
+# --- settings sources ---------------------------------------------------------
+
+
+def _get_nested(document: dict[str, Any], dotted_path: str) -> Any:
+    node: Any = document
+    for part in dotted_path.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return _MISSING
+        node = node[part]
+    return node
+
+
+class _BlankAwareEnvSource(PydanticBaseSettingsSource):
+    """Env source that drops blank values, per field.
+
+    Almost every legacy read used ``os.environ.get("FOO") or default``, so a
+    blank ``FOO=`` meant "unset" — pydantic-settings spells this
+    ``env_ignore_empty=True``, but only globally. A handful of legacy reads
+    instead gave blank a meaning that differs from the default:
+
+        SKIP_WARM_UP="" -> False, while the default is True
+
+    Under a global ignore-empty those flags would silently flip when a
+    deployment renders an unset value as an empty string (Helm does this), so
+    blank handling is per-field: ignored by default, kept when the field is
+    declared ``blank_is_falsy=True``.
+    """
+
+    def __init__(
+        self, settings_cls: type[BaseSettings], inner: PydanticBaseSettingsSource
+    ) -> None:
+        super().__init__(settings_cls)
+        self._inner = inner
+        # The env source keys by field name for plain fields and by alias for
+        # aliased ones, so match on both, case-insensitively.
+        self._keep_blank: set[str] = set()
+        for name, field in settings_cls.model_fields.items():
+            if not _blank_is_falsy(field):
+                continue
+            self._keep_blank.add(name.lower())
+            self._keep_blank.update(n.lower() for n in env_names_of(name, field))
+
+    def get_field_value(
+        self,
+        field: FieldInfo,  # noqa: ARG002 — signature fixed by the base class
+        field_name: str,
+    ) -> tuple[Any, str, bool]:
+        # Unused: __call__ returns the whole mapping at once.
+        return None, field_name, False
+
+    def __call__(self) -> dict[str, Any]:
+        return {
+            name: value
+            for name, value in self._inner().items()
+            if value != "" or name.lower() in self._keep_blank
+        }
+
+
+class OnyxTomlSource(PydanticBaseSettingsSource):
+    """Settings source reading the shared onyx.toml file.
+
+    Flattens nested TOML tables into a mapping keyed by each field's primary
+    validation key, pulling each value from the dotted TOML path declared via
+    :func:`onyx_field`. Aliased fields are keyed by their primary alias because
+    ``populate_by_name`` is off — the field name alone would not populate them.
+
+    TOML values are already native Python types (tomllib), so no string
+    decoding happens here. Document keys matching no field are ignored: this
+    class cannot tell a typo from a key belonging to one of the *other*
+    settings classes reading the same file, so typo detection belongs in the
+    offline template checker.
+    """
+
+    def __init__(self, settings_cls: type[BaseSettings]) -> None:
+        super().__init__(settings_cls)
+        document = load_toml_document()
+        values: dict[str, Any] = {}
+        for field_name, field in settings_cls.model_fields.items():
+            path = toml_path_of(field)
+            if path is None:
+                continue
+            value = _get_nested(document, path)
+            if value is not _MISSING:
+                values[primary_key_of(field_name, field)] = value
+        self._values = values
+
+    def get_field_value(
+        self,
+        field: FieldInfo,  # noqa: ARG002 — signature fixed by the base class
+        field_name: str,
+    ) -> tuple[Any, str, bool]:
+        # Unused: __call__ returns the whole prebuilt mapping at once.
+        return None, field_name, False
+
+    def __call__(self) -> dict[str, Any]:
+        return self._values
+
+
+# --- base class ---------------------------------------------------------------
+
+
+class OnyxBaseSettings(BaseSettings):
+    """Base class for Onyx settings groups.
+
+    Conventions, enforced by ``__pydantic_init_subclass__`` rather than left to
+    review:
+
+    - Every field is declared with :func:`onyx_field`. A field that carries no
+      TOML path is a hard error, so it cannot silently become env-only or fall
+      back to a bare-name path that no config template documents.
+    - Two fields cannot claim the same TOML path, and no path may be a prefix
+      of another (``a.b`` versus ``a.b.c``): both make the document ambiguous.
+    - Field names are the lowercased legacy env var names, so the env source
+      matches legacy vars with no per-field configuration. Extra legacy names
+      go in ``onyx_field(env=(...))``, highest priority first — and once
+      ``env=`` is given it is the *complete* list, including the field's own
+      name if that should still work.
+
+    ``populate_by_name`` is deliberately off. With it on, every field also
+    answers to its Python name as an env var, so an aliased field silently
+    grows an extra undocumented knob that no template mentions and no reviewer
+    asked for. Keeping it off means the env surface is exactly what
+    :func:`env_names_of` reports, which is what the drift inventory reads.
+    """
+
+    model_config = SettingsConfigDict(
+        populate_by_name=False,
+        extra="ignore",
+        # Blank handling is per-field, in _BlankAwareEnvSource. Leave the
+        # global switch off so it cannot double-apply.
+        env_ignore_empty=False,
+        case_sensitive=False,
+        validate_default=True,
+    )
+
+    @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
+        super().__pydantic_init_subclass__(**kwargs)
+        seen: dict[str, str] = {}
+        for field_name, field in cls.model_fields.items():
+            path = toml_path_of(field)
+            if path is None:
+                raise TypeError(
+                    f"{cls.__name__}.{field_name} must be declared with "
+                    f"onyx_field(toml=...); a bare Field has no TOML path."
+                )
+            if path in seen:
+                raise TypeError(
+                    f"{cls.__name__}: fields {seen[path]!r} and {field_name!r} "
+                    f"both map to TOML path {path!r}."
+                )
+            seen[path] = field_name
+        for path, field_name in seen.items():
+            parts = path.split(".")
+            for depth in range(1, len(parts)):
+                ancestor = ".".join(parts[:depth])
+                if ancestor in seen:
+                    raise TypeError(
+                        f"{cls.__name__}: TOML path {path!r} ({field_name}) nests "
+                        f"under {ancestor!r} ({seen[ancestor]}), which is a value."
+                    )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,  # noqa: ARG003 — keyword-called by pydantic-settings
+        file_secret_settings: PydanticBaseSettingsSource,  # noqa: ARG003 — keyword-called by pydantic-settings
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        # Earlier entries win: env var > TOML > field default. The dotenv and
+        # file-secret sources are deliberately dropped — Onyx loads .env files
+        # outside the process (ods / docker / test harnesses), never here.
+        return (
+            init_settings,
+            _BlankAwareEnvSource(settings_cls, env_settings),
+            OnyxTomlSource(settings_cls),
+        )
+
+
+# --- legacy coercion annotations ----------------------------------------------
+
+
+def _coerce_legacy_env_bool(value: object) -> object:
+    if isinstance(value, str):
+        return value.lower() == "true"
+    return value
+
+
+def _coerce_legacy_env_bool_unless_false(value: object) -> object:
+    if isinstance(value, str):
+        return value.lower() != "false"
+    return value
+
+
+def _split_comma_separated(value: object) -> object:
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    return value
+
+
+# Bool with the dominant legacy idiom's semantics, `env.lower() == "true"`.
+# Notably "1"/"yes" read as False, unlike pydantic's default bool coercion,
+# which would silently FLIP such deployments to True. Native TOML bools pass
+# through untouched.
+LegacyEnvBool = Annotated[bool, BeforeValidator(_coerce_legacy_env_bool)]
+
+# Bool with the inverted legacy idiom's semantics, `env.lower() != "false"`:
+# any string other than "false" reads as True.
+LegacyEnvBoolUnlessFalse = Annotated[
+    bool, BeforeValidator(_coerce_legacy_env_bool_unless_false)
+]
+
+# Comma-separated list with the common strip-and-drop-empties behavior.
+# NoDecode stops the env source from attempting JSON decoding first; TOML
+# arrays pass through natively. Variants (no-strip, frozenset, ...) belong in
+# per-field validators on the owning settings class.
+CommaSeparatedStrList = Annotated[
+    list[str], NoDecode, BeforeValidator(_split_comma_separated)
+]

--- a/backend/tests/unit/shared_configs/test_settings_base.py
+++ b/backend/tests/unit/shared_configs/test_settings_base.py
@@ -1,0 +1,336 @@
+"""Unit tests for the TOML settings loader in shared_configs.settings_base.
+
+Uses a synthetic settings class so the tests do not depend on any real config
+module's schema.
+"""
+
+from enum import Enum
+from pathlib import Path
+
+import pytest
+
+from shared_configs.settings_base import (
+    ONYX_CONFIG_FILE_DISABLED,
+    ONYX_CONFIG_FILE_ENV_VAR,
+    CommaSeparatedStrList,
+    LegacyEnvBool,
+    LegacyEnvBoolUnlessFalse,
+    OnyxBaseSettings,
+    clear_toml_document_cache,
+    env_names_of,
+    onyx_field,
+)
+
+
+class _DemoColor(str, Enum):
+    RED = "red"
+    BLUE = "blue"
+
+
+class _DemoSettings(OnyxBaseSettings):
+    demo_host: str = onyx_field(default="localhost", toml="demo.host", description="d")
+    demo_port: int = onyx_field(default=8080, toml="demo.port", description="d")
+    demo_flag: LegacyEnvBool = onyx_field(
+        default=False, toml="demo.flag", description="d"
+    )
+    demo_lenient_flag: LegacyEnvBoolUnlessFalse = onyx_field(
+        default=True, toml="demo.lenient_flag", description="d"
+    )
+    demo_blank_flag: LegacyEnvBool = onyx_field(
+        default=True, toml="demo.blank_flag", description="d", blank_is_falsy=True
+    )
+    demo_tags: CommaSeparatedStrList = onyx_field(
+        default_factory=list, toml="demo.tags", description="d"
+    )
+    demo_map: dict[str, str] | None = onyx_field(
+        default=None, toml="demo.map", description="d"
+    )
+    demo_color: _DemoColor = onyx_field(
+        default=_DemoColor.RED, toml="demo.color", description="d"
+    )
+    demo_derived: int = onyx_field(
+        default_factory=lambda data: data["demo_port"],
+        toml="demo.derived",
+        description="d",
+    )
+    # Aliased field: reachable ONLY via the declared env names.
+    demo_renamed: str = onyx_field(
+        default="",
+        env=("DEMO_ALIASED", "DEMO_ALIASED_LEGACY"),
+        toml="demo.aliased",
+        description="d",
+    )
+
+
+_DEMO_ENV_VARS = [
+    "DEMO_HOST",
+    "DEMO_PORT",
+    "DEMO_FLAG",
+    "DEMO_LENIENT_FLAG",
+    "DEMO_BLANK_FLAG",
+    "DEMO_TAGS",
+    "DEMO_MAP",
+    "DEMO_COLOR",
+    "DEMO_DERIVED",
+    "DEMO_ALIASED",
+    "DEMO_ALIASED_LEGACY",
+    "DEMO_RENAMED",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_config_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    clear_toml_document_cache()
+    for name in _DEMO_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv(ONYX_CONFIG_FILE_ENV_VAR, ONYX_CONFIG_FILE_DISABLED)
+
+
+def _use_toml(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, content: str) -> Path:
+    path = tmp_path / "onyx.toml"
+    path.write_text(content)
+    monkeypatch.setenv(ONYX_CONFIG_FILE_ENV_VAR, str(path))
+    return path
+
+
+# --- precedence ---------------------------------------------------------------
+
+
+def test_defaults_with_no_file() -> None:
+    settings = _DemoSettings()
+    assert settings.demo_host == "localhost"
+    assert settings.demo_port == 8080
+    assert settings.demo_flag is False
+    assert settings.demo_tags == []
+    assert settings.demo_map is None
+    assert settings.demo_color is _DemoColor.RED
+    assert settings.demo_renamed == ""
+
+
+def test_toml_overrides_defaults(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _use_toml(monkeypatch, tmp_path, '[demo]\nhost = "from-toml"\nport = 1234\n')
+    settings = _DemoSettings()
+    assert settings.demo_host == "from-toml"
+    assert settings.demo_port == 1234
+
+
+def test_env_beats_toml(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _use_toml(monkeypatch, tmp_path, '[demo]\nhost = "from-toml"\n')
+    monkeypatch.setenv("DEMO_HOST", "from-env")
+    assert _DemoSettings().demo_host == "from-env"
+
+
+def test_data_aware_default_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert _DemoSettings().demo_derived == 8080
+    monkeypatch.setenv("DEMO_PORT", "77")
+    assert _DemoSettings().demo_derived == 77
+    monkeypatch.setenv("DEMO_DERIVED", "99")
+    assert _DemoSettings().demo_derived == 99
+
+
+# --- blank handling -----------------------------------------------------------
+
+
+def test_blank_env_falls_through_to_default() -> None:
+    """The dominant legacy idiom: `os.environ.get("X") or default`."""
+    import os
+
+    os.environ["DEMO_HOST"] = ""
+    try:
+        assert _DemoSettings().demo_host == "localhost"
+    finally:
+        del os.environ["DEMO_HOST"]
+
+
+def test_blank_env_falls_through_to_toml(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _use_toml(monkeypatch, tmp_path, '[demo]\nhost = "from-toml"\n')
+    monkeypatch.setenv("DEMO_HOST", "")
+    assert _DemoSettings().demo_host == "from-toml"
+
+
+def test_blank_is_falsy_field_keeps_blank(monkeypatch: pytest.MonkeyPatch) -> None:
+    """blank_is_falsy=True preserves legacy reads where blank meant False.
+
+    Without it a flag defaulting to True would silently flip on when a
+    deployment renders an unset value as an empty string.
+    """
+    assert _DemoSettings().demo_blank_flag is True
+    monkeypatch.setenv("DEMO_BLANK_FLAG", "")
+    assert _DemoSettings().demo_blank_flag is False
+
+
+def test_blank_is_falsy_does_not_leak_to_other_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DEMO_BLANK_FLAG", "")
+    monkeypatch.setenv("DEMO_HOST", "")
+    settings = _DemoSettings()
+    assert settings.demo_blank_flag is False
+    assert settings.demo_host == "localhost"
+
+
+# --- legacy coercions ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("true", True), ("TRUE", True), ("True", True), ("false", False), ("1", False)],
+)
+def test_legacy_bool_matches_lower_eq_true(
+    monkeypatch: pytest.MonkeyPatch, raw: str, expected: bool
+) -> None:
+    """`FOO=1` must stay False — pydantic's native bool coercion says True."""
+    monkeypatch.setenv("DEMO_FLAG", raw)
+    assert _DemoSettings().demo_flag is expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("false", False), ("FALSE", False), ("true", True), ("1", True), ("yes", True)],
+)
+def test_legacy_bool_unless_false(
+    monkeypatch: pytest.MonkeyPatch, raw: str, expected: bool
+) -> None:
+    monkeypatch.setenv("DEMO_LENIENT_FLAG", raw)
+    assert _DemoSettings().demo_lenient_flag is expected
+
+
+def test_native_toml_bool_passes_through(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _use_toml(monkeypatch, tmp_path, "[demo]\nflag = true\nlenient_flag = false\n")
+    settings = _DemoSettings()
+    assert settings.demo_flag is True
+    assert settings.demo_lenient_flag is False
+
+
+def test_comma_list_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DEMO_TAGS", " a , b ,, c ")
+    assert _DemoSettings().demo_tags == ["a", "b", "c"]
+
+
+def test_comma_list_from_toml_array(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _use_toml(monkeypatch, tmp_path, '[demo]\ntags = ["a", "b"]\n')
+    assert _DemoSettings().demo_tags == ["a", "b"]
+
+
+def test_json_and_enum_coercion(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("DEMO_MAP", '{"k": "v"}')
+    monkeypatch.setenv("DEMO_COLOR", "blue")
+    settings = _DemoSettings()
+    assert settings.demo_map == {"k": "v"}
+    assert settings.demo_color is _DemoColor.BLUE
+
+    monkeypatch.delenv("DEMO_MAP")
+    monkeypatch.delenv("DEMO_COLOR")
+    _use_toml(monkeypatch, tmp_path, '[demo.map]\nk = "v"\n')
+    assert _DemoSettings().demo_map == {"k": "v"}
+
+
+# --- aliases ------------------------------------------------------------------
+
+
+def test_alias_priority(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DEMO_ALIASED_LEGACY", "legacy")
+    assert _DemoSettings().demo_renamed == "legacy"
+    monkeypatch.setenv("DEMO_ALIASED", "primary")
+    assert _DemoSettings().demo_renamed == "primary"
+
+
+def test_field_name_is_not_an_env_var_when_aliased(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An aliased field must NOT also answer to its Python name.
+
+    populate_by_name would grant every aliased field a second, undocumented
+    env var that no deployment template mentions and no drift gate expects.
+    """
+    monkeypatch.setenv("DEMO_RENAMED", "field-name")
+    assert _DemoSettings().demo_renamed == ""
+
+
+def test_aliased_field_fills_from_toml(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _use_toml(monkeypatch, tmp_path, '[demo]\naliased = "from-toml"\n')
+    assert _DemoSettings().demo_renamed == "from-toml"
+
+
+def test_env_names_of_reports_the_real_surface() -> None:
+    fields = _DemoSettings.model_fields
+    assert env_names_of("demo_host", fields["demo_host"]) == ["DEMO_HOST"]
+    assert env_names_of("demo_renamed", fields["demo_renamed"]) == [
+        "DEMO_ALIASED",
+        "DEMO_ALIASED_LEGACY",
+    ]
+
+
+# --- config file resolution ---------------------------------------------------
+
+
+def test_missing_default_path_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ONYX_CONFIG_FILE_ENV_VAR, raising=False)
+    # /etc/onyx/onyx.toml is absent in test environments; absence is silent.
+    assert _DemoSettings().demo_host == "localhost"
+
+
+def test_explicit_missing_path_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(ONYX_CONFIG_FILE_ENV_VAR, str(tmp_path / "nope.toml"))
+    with pytest.raises(FileNotFoundError):
+        _DemoSettings()
+
+
+def test_malformed_file_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _use_toml(monkeypatch, tmp_path, "[demo\nhost = ")
+    with pytest.raises(ValueError, match="Malformed Onyx config file"):
+        _DemoSettings()
+
+
+def test_document_is_memoized_per_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    path = _use_toml(monkeypatch, tmp_path, '[demo]\nhost = "first"\n')
+    assert _DemoSettings().demo_host == "first"
+    path.write_text('[demo]\nhost = "second"\n')
+    # Same path: the parsed document is reused, so the edit is not picked up.
+    assert _DemoSettings().demo_host == "first"
+    clear_toml_document_cache()
+    assert _DemoSettings().demo_host == "second"
+
+
+# --- schema guardrails --------------------------------------------------------
+
+
+def test_bare_field_is_rejected() -> None:
+    from pydantic import Field
+
+    with pytest.raises(TypeError, match="must be declared with onyx_field"):
+
+        class _Bad(OnyxBaseSettings):
+            oops: str = Field(default="x")
+
+
+def test_duplicate_toml_path_is_rejected() -> None:
+    with pytest.raises(TypeError, match="both map to TOML path"):
+
+        class _Bad(OnyxBaseSettings):
+            one: str = onyx_field(default="", toml="a.b", description="d")
+            two: str = onyx_field(default="", toml="a.b", description="d")
+
+
+def test_toml_path_nested_under_a_value_is_rejected() -> None:
+    with pytest.raises(TypeError, match="nests under"):
+
+        class _Bad(OnyxBaseSettings):
+            parent: str = onyx_field(default="", toml="a.b", description="d")
+            child: str = onyx_field(default="", toml="a.b.c", description="d")

--- a/backend/tests/unit/shared_configs/test_settings_facade.py
+++ b/backend/tests/unit/shared_configs/test_settings_facade.py
@@ -1,0 +1,125 @@
+"""Guards the shared_configs.configs facade against drifting from its schema.
+
+The facade re-exports every SharedSettings field under its historical constant
+name. That duplication is deliberate — it keeps the hundreds of
+``from shared_configs.configs import X`` call sites and their types intact —
+but nothing in Python makes the two lists stay in step, so these tests do.
+"""
+
+import ast
+import importlib
+from pathlib import Path
+
+import pytest
+
+from shared_configs import configs
+from shared_configs.settings import SharedSettings
+from shared_configs.settings_base import (
+    ONYX_CONFIG_FILE_DISABLED,
+    ONYX_CONFIG_FILE_ENV_VAR,
+    clear_toml_document_cache,
+    env_names_of,
+)
+
+FACADE_PATH = Path(configs.__file__)
+
+
+@pytest.fixture(autouse=True)
+def _no_config_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    clear_toml_document_cache()
+    monkeypatch.setenv(ONYX_CONFIG_FILE_ENV_VAR, ONYX_CONFIG_FILE_DISABLED)
+
+
+def _facade_settings_exports() -> dict[str, str]:
+    """{CONSTANT_NAME: settings_field} for each `X = _settings.y` assignment."""
+    tree = ast.parse(FACADE_PATH.read_text(encoding="utf-8"))
+    exports: dict[str, str] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        value = node.value
+        if (
+            isinstance(target, ast.Name)
+            and isinstance(value, ast.Attribute)
+            and isinstance(value.value, ast.Name)
+            and value.value.id == "_settings"
+        ):
+            exports[target.id] = value.attr
+    return exports
+
+
+def test_every_settings_field_is_re_exported() -> None:
+    """A new SharedSettings field must gain a facade constant.
+
+    Without this, a field can be added to the schema, documented in the config
+    template, and still be dead: no call site can reach it.
+    """
+    exported_fields = set(_facade_settings_exports().values())
+    missing = sorted(set(SharedSettings.model_fields) - exported_fields)
+    assert not missing, (
+        f"SharedSettings fields with no constant in {FACADE_PATH.name}: {missing}. "
+        f"Add `NAME = _settings.{missing[0]}` there."
+    )
+
+
+def test_no_facade_constant_references_a_dropped_field() -> None:
+    unknown = sorted(
+        f
+        for f in _facade_settings_exports().values()
+        if f not in SharedSettings.model_fields
+    )
+    assert not unknown, f"facade reads fields SharedSettings no longer has: {unknown}"
+
+
+def test_exported_constants_match_the_settings_values() -> None:
+    """Catches a copy-paste that wires a constant to the wrong field."""
+    settings = SharedSettings()
+    for constant, field in _facade_settings_exports().items():
+        assert getattr(configs, constant) == getattr(settings, field), (
+            f"{constant} does not match _settings.{field}"
+        )
+
+
+def test_env_var_names_stay_upper_snake() -> None:
+    """The env surface is derived from field names, so they must be legal."""
+    for name, field in SharedSettings.model_fields.items():
+        for env_name in env_names_of(name, field):
+            assert env_name.isupper() and env_name.replace("_", "").isalnum(), (
+                f"{name} exposes an unusable env var name: {env_name!r}"
+            )
+
+
+def test_reload_seam_rereads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`monkeypatch.setenv` + `importlib.reload` must still work.
+
+    Many existing tests configure the backend this way; building the settings
+    object at facade module scope is what preserves it.
+    """
+    monkeypatch.setenv("MODEL_SERVER_PORT", "4321")
+    reloaded = importlib.reload(configs)
+    try:
+        assert reloaded.MODEL_SERVER_PORT == 4321
+        # Unset fields still derive from it.
+        assert reloaded.INDEXING_MODEL_SERVER_PORT == 4321
+    finally:
+        monkeypatch.delenv("MODEL_SERVER_PORT")
+        importlib.reload(configs)
+
+
+def test_env_still_beats_toml_after_reload(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_file = tmp_path / "onyx.toml"
+    config_file.write_text("[model_server]\nport = 5555\n")
+    monkeypatch.setenv(ONYX_CONFIG_FILE_ENV_VAR, str(config_file))
+    clear_toml_document_cache()
+    try:
+        assert importlib.reload(configs).MODEL_SERVER_PORT == 5555
+        monkeypatch.setenv("MODEL_SERVER_PORT", "6666")
+        assert importlib.reload(configs).MODEL_SERVER_PORT == 6666
+    finally:
+        monkeypatch.delenv("MODEL_SERVER_PORT", raising=False)
+        monkeypatch.setenv(ONYX_CONFIG_FILE_ENV_VAR, ONYX_CONFIG_FILE_DISABLED)
+        clear_toml_document_cache()
+        importlib.reload(configs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
     "litellm[google]==1.93.0",
     "openai==2.38.0",
     "pydantic==2.12.5",
+    # Shared so the TOML config service (shared_configs/settings_base.py) is
+    # importable by the model_server image too, not just the backend.
+    "pydantic-settings==2.14.2",
     # Shared so structured JSON logging (LOG_FORMAT=json) works in the
     # model_server image too, not just the backend.
     "python-json-logger==4.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4100,7 +4100,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -4111,7 +4111,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -4138,9 +4138,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -4151,7 +4151,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -4268,6 +4268,7 @@ dependencies = [
     { name = "prometheus-client" },
     { name = "prometheus-fastapi-instrumentator" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "python-json-logger" },
     { name = "sentry-sdk" },
     { name = "tenacity" },
@@ -4443,6 +4444,7 @@ requires-dist = [
     { name = "prometheus-client", specifier = ">=0.21.1" },
     { name = "prometheus-fastapi-instrumentator", specifier = "==8.0.2" },
     { name = "pydantic", specifier = "==2.12.5" },
+    { name = "pydantic-settings", specifier = "==2.14.2" },
     { name = "python-json-logger", specifier = "==4.1.0" },
     { name = "sentry-sdk", specifier = "==2.14.0" },
     { name = "tenacity", specifier = "==9.1.2" },
@@ -4948,7 +4950,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -6597,8 +6599,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## What

Adds a typed config loader that reads settings from a TOML file, and migrates `shared_configs` onto it. Precedence is **env var > TOML > hardcoded default**, so every existing deployment keeps its current behavior with no action.

This is part 1: the loader core plus one migrated module. Other config modules follow separately.

An alternative take on #13448.

## How

**`shared_configs/settings_base.py`** — the loader. Stays importable by the model server: stdlib and pydantic only, never `onyx.*`.

Fields are declared with `onyx_field()`, which makes the TOML path, the env names, and the description mandatory and typed:

```python
model_server_port: int = onyx_field(
    default=9000,
    toml="model_server.port",
    description="Port of the inference model server.",
)
```

`__pydantic_init_subclass__` rejects, at class-creation time: a raw pydantic `Field`, two fields on the same TOML path, and a path that nests under a value.

**The env surface is exactly what the schema declares** — the aliases when `env=` is given, else the field name uppercased. `populate_by_name` is off, so an aliased field can not also be read under its field name. Without this, renaming a field to keep its legacy env name silently adds a second, undocumented operator knob.

**Blank env values keep their legacy meaning, per field.** Most legacy reads were `os.environ.get(X) or default`, so a blank falls through to TOML or the default. The few reads where a blank meant `False` declare `blank_is_falsy=True`. This is per-field, not a global mode.

**`configs.py` stays a facade** of module-level constants. The hundreds of `from shared_configs.configs import X` call sites and the `monkeypatch.setenv` + `importlib.reload` test seam keep working unchanged. The duplication between schema and facade is guarded by a test rather than left to review.

**`scripts/env_inventory.py` now reads `OnyxBaseSettings` declarations.** Without this the drift gate goes blind the moment a config module migrates, and a new env var could land unbaselined. **The baseline file is unchanged by this PR**: 480 tunables, none added, none lost.

## Verification

- **Equivalence vs `main`, 89 env scenarios**: `{'OK': 73, 'EXPECTED': 16, 'REGRESSION': 0}`. Every scenario where `main` did not crash produces byte-identical exports — no accepted normalizations. The 16 are all cases where `main` raised `ValueError: invalid literal for int() with base 10: ''` on a blank numeric env var; the loader now reports a clear validation error instead.
- **Drift gate**: `env drift gate OK — 480 undocumented operator-facing tunables, all baselined.` Verified it still bites by injecting a probe field.
- **Tests**: `backend/tests/unit/shared_configs` 52 passed. Full `backend/tests/unit` suite shows no new failures; the EE license failures are pre-existing and flaky on `main` at the same rate.
- `pre-commit` clean on all touched files.

## Tests

- `test_settings_base.py` — precedence, data-aware `default_factory`, per-field blank handling, legacy bool coercion (`FOO=1` stays `False`), comma lists, alias priority, config-file resolution, and the schema guardrails.
- `test_settings_facade.py` — AST-parses `configs.py` and asserts every `SharedSettings` field has a matching constant wired to the right field, plus the reload seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a TOML‑backed, typed config loader and migrates `shared_configs` to it while preserving precedence (env > TOML > default). Replaces ad‑hoc `os.environ` reads with a schema (`OnyxBaseSettings` + `onyx_field`) for explicit TOML paths and env aliases; disabling the model server now sets all hosts to "disabled", and blank numeric/env values that used to crash now return clear validation errors.

**Review notes**
- `shared_configs/settings_base.py`: loader core (env/TOML/default precedence, per‑field blank handling, aliasing, `ONYX_CONFIG_FILE` resolution with `disabled`, memoized parse) and schema guardrails (reject bare `Field`, duplicate/nested TOML paths).
- `shared_configs/settings.py`: typed schema for shared settings; normalization (e.g., `log_format`), sentinel host when model server is disabled; defaults preserved via factories where needed.
- `shared_configs/configs.py`: constants facade over a module‑scoped `_settings` to keep `from shared_configs.configs import X` and the `monkeypatch.setenv` + `importlib.reload` seam intact.
- `scripts/env_inventory.py`: AST visitor inventories `OnyxBaseSettings`/`onyx_field` declarations (incl. alias priority and custom annotation type mapping); baseline remains unchanged.
- Tests cover precedence, legacy coercions, per‑field blank rules, TOML resolution/memoization, alias priority, and facade parity. Added `pydantic-settings` to `pyproject.toml` and `backend/requirements/*`.

**Rollout/migration**
- No action required: existing env vars keep working. Optionally place `/etc/onyx/onyx.toml` or set `ONYX_CONFIG_FILE` to a path; set `ONYX_CONFIG_FILE=disabled` to force env‑only. A non‑existent explicit path fails fast.
- Ensure `pydantic-settings` is available in backend and model server images.

<sup>Written for commit da5aa6937b959587e7eef25ca3a66f0fce01c1db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

