### PR TITLE
fix(llm): preserve provider prefix in reasoning fallback

### DIFF
--- a/backend/onyx/llm/model_capabilities.py
+++ b/backend/onyx/llm/model_capabilities.py
@@ -395,9 +395,9 @@ def model_is_reasoning_model(model_name: str, model_provider: str) -> bool:
 
         # Fallback for newer models missing from the local model map
         full_model_name = (
-            f"{model_provider}/{model_name}"
-            if model_provider not in model_name
-            else model_name
+            model_name
+            if model_name.startswith(f"{model_provider}/")
+            else f"{model_provider}/{model_name}"
         )
         return _litellm_supports_reasoning(full_model_name)
 

--- a/backend/tests/unit/onyx/llm/test_model_is_reasoning.py
+++ b/backend/tests/unit/onyx/llm/test_model_is_reasoning.py
@@ -153,3 +153,27 @@ def test_probe_results_are_tenant_scoped(monkeypatch: pytest.MonkeyPatch) -> Non
         ("tenant_a", "fakeprov/shared-name-model"),
         ("tenant_b", "fakeprov/shared-name-model"),
     ]
+
+
+def test_reasoning_fallback_uses_provider_prefix_not_substring(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A provider substring inside a custom model name must not suppress its prefix."""
+    calls = []
+
+    def fake_supports_reasoning(model: str) -> bool:
+        calls.append(model)
+        return False
+
+    monkeypatch.setattr(
+        model_capabilities, "_litellm_supports_reasoning", fake_supports_reasoning
+    )
+    monkeypatch.setattr(model_capabilities, "_LITELLM_SUPPORTS_REASONING_CACHE", {})
+
+    model_is_reasoning_model("my-openai-compatible-model", "openai")
+    model_is_reasoning_model("openai/gpt-4o", "openai")
+
+    assert calls == [
+        "openai/my-openai-compatible-model",
+        "openai/gpt-4o",
+    ]


### PR DESCRIPTION
## Summary

- construct the LiteLLM model ID with a provider prefix unless the model name already starts with that exact prefix
- add regression coverage for custom model names containing the provider string and already-prefixed model names

## Why

The previous substring check could omit the provider prefix for names such as `my-openai-compatible-model`, causing the reasoning capability fallback to query LiteLLM with the wrong model ID.

## Validation

- `uv run --python /opt/homebrew/bin/python3.12 --group dev pytest -q backend/tests/unit/onyx/llm/test_model_is_reasoning.py backend/tests/unit/onyx/llm/test_model_map.py`
- `ruff check` and `ruff format --check` on changed files
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the provider prefix when constructing `litellm` model IDs in the reasoning fallback so model resolution is correct. Previously we dropped the prefix if the model name contained the provider string; now we only skip prepending when the name starts with "{provider}/".

- Update `model_is_reasoning_model` to check `startswith(f"{provider}/")` before calling `_litellm_supports_reasoning`.
- Add regression tests for names with provider substrings and already-prefixed names.
- No configuration or migration changes.

<sup>Written for commit af715e4f7efc5a998e0d9d977749e2e9b94ef637. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

