### PR TITLE
feat(slack): add feedback button visibility option

### DIFF
--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4288,6 +4288,7 @@ class ChannelConfig(TypedDict):
     # If empty list, follow up with no tags
     follow_up_tags: NotRequired[list[str]]
     show_continue_in_web_ui: NotRequired[bool]  # defaults to False
+    remove_feedback_buttons: NotRequired[bool]  # defaults to False
     disabled: NotRequired[bool]  # defaults to False
 
 

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -158,6 +158,7 @@ def _build_ephemeral_publication_block(
             answer_filters=channel_conf.get("answer_filters"),
             follow_up_tags=channel_conf.get("follow_up_tags"),
             show_continue_in_web_ui=channel_conf.get("show_continue_in_web_ui", False),
+            remove_feedback_buttons=channel_conf.get("remove_feedback_buttons", False),
         )
     )
 
@@ -505,7 +506,14 @@ def build_slack_response_blocks(
 
     ai_feedback_block: list[Block] = []
 
-    if answer.message_id is not None and not skip_ai_feedback:
+    remove_feedback_buttons = bool(
+        channel_conf and channel_conf.get("remove_feedback_buttons", False)
+    )
+    if (
+        answer.message_id is not None
+        and not skip_ai_feedback
+        and not remove_feedback_buttons
+    ):
         ai_feedback_block.append(
             _build_qa_feedback_block(
                 message_id=answer.message_id,

--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -55,9 +55,16 @@ def send_msg_ack_to_user(details: SlackMessageInfo, client: WebClient) -> None:
 
 
 def schedule_feedback_reminder(
-    details: SlackMessageInfo, include_followup: bool, client: WebClient
+    details: SlackMessageInfo,
+    include_followup: bool,
+    client: WebClient,
+    feedback_enabled: bool,
 ) -> str | None:
     logger = setup_logger(extra={SLACK_CHANNEL_ID: details.channel_to_respond})
+
+    if not feedback_enabled:
+        logger.info("Scheduled feedback reminder disabled for channel...")
+        return None
 
     if not ONYX_BOT_FEEDBACK_REMINDER:
         logger.info("Scheduled feedback reminder disabled...")

--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -1127,7 +1127,12 @@ def process_message(
         )
 
         feedback_reminder_id = schedule_feedback_reminder(
-            details=details, client=client.web_client, include_followup=follow_up
+            details=details,
+            client=client.web_client,
+            include_followup=follow_up,
+            feedback_enabled=not slack_channel_config.channel_config.get(
+                "remove_feedback_buttons", False
+            ),
         )
 
         failed = handle_message(

--- a/backend/onyx/onyxbot/slack/models.py
+++ b/backend/onyx/onyxbot/slack/models.py
@@ -68,6 +68,7 @@ class ActionValuesEphemeralMessageChannelConfig(BaseModel):
     )
     follow_up_tags: list[str] | None
     show_continue_in_web_ui: bool
+    remove_feedback_buttons: bool = False
 
 
 class ActionValuesEphemeralMessage(BaseModel):

--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -330,6 +330,7 @@ class SlackChannelConfigCreationRequest(BaseModel):
     respond_to_bots: bool = False
     is_ephemeral: bool = False
     show_continue_in_web_ui: bool = False
+    remove_feedback_buttons: bool = False
     enable_auto_filters: bool = False
     # If no team members, assume respond in the channel to everyone
     respond_member_group_list: list[str] = Field(default_factory=list)

--- a/backend/onyx/server/manage/slack_bot.py
+++ b/backend/onyx/server/manage/slack_bot.py
@@ -99,6 +99,10 @@ def _form_channel_config(
         slack_channel_config_creation_request.show_continue_in_web_ui
     )
 
+    channel_config["remove_feedback_buttons"] = (
+        slack_channel_config_creation_request.remove_feedback_buttons
+    )
+
     channel_config["respond_to_bots"] = (
         slack_channel_config_creation_request.respond_to_bots
     )

--- a/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
@@ -1,12 +1,22 @@
+import json
 from datetime import datetime
 
 import pytest
 import pytz
 import timeago
+from slack_sdk.models.blocks import Block
 
+from onyx.chat.models import ChatBasicResponse
 from onyx.configs.constants import DocumentSource
 from onyx.context.search.models import SavedSearchDoc
-from onyx.onyxbot.slack.blocks import _build_sources_blocks
+from onyx.onyxbot.slack.blocks import _build_sources_blocks, build_slack_response_blocks
+from onyx.onyxbot.slack.constants import (
+    DISLIKE_BLOCK_ACTION_ID,
+    FOLLOWUP_BUTTON_ACTION_ID,
+    LIKE_BLOCK_ACTION_ID,
+    SHOW_EVERYONE_ACTION_ID,
+)
+from onyx.onyxbot.slack.models import SlackMessageInfo, ThreadMessage
 
 
 def _make_saved_doc(
@@ -35,6 +45,98 @@ def _make_saved_doc(
         relevance_explanation=None,
         is_internet=False,
     )
+
+
+def _make_answer() -> ChatBasicResponse:
+    return ChatBasicResponse(
+        answer="An answer",
+        answer_citationless="An answer",
+        top_documents=[],
+        error_msg=None,
+        message_id=42,
+        citation_info=[],
+    )
+
+
+def _make_message_info() -> SlackMessageInfo:
+    return SlackMessageInfo(
+        thread_messages=[ThreadMessage(message="A question?")],
+        channel_to_respond="C123",
+        msg_to_respond="123.456",
+        thread_to_respond="123.456",
+        sender_id="U123",
+        email="user@example.com",
+        bypass_filters=False,
+        is_slash_command=False,
+        is_bot_dm=False,
+    )
+
+
+def _get_action_ids(blocks: list[Block]) -> set[str]:
+    return {
+        element["action_id"]
+        for block in blocks
+        for element in block.to_dict().get("elements", [])
+        if "action_id" in element
+    }
+
+
+def test_build_slack_response_blocks_removes_feedback_buttons_when_configured() -> None:
+    blocks = build_slack_response_blocks(
+        answer=_make_answer(),
+        message_info=_make_message_info(),
+        channel_conf={
+            "channel_name": "general",
+            "follow_up_tags": [],
+            "remove_feedback_buttons": True,
+        },
+        feedback_reminder_id=None,
+    )
+
+    action_ids = _get_action_ids(blocks)
+
+    assert LIKE_BLOCK_ACTION_ID not in action_ids
+    assert DISLIKE_BLOCK_ACTION_ID not in action_ids
+    assert FOLLOWUP_BUTTON_ACTION_ID in action_ids
+
+
+def test_build_slack_response_blocks_keeps_feedback_buttons_by_default() -> None:
+    blocks = build_slack_response_blocks(
+        answer=_make_answer(),
+        message_info=_make_message_info(),
+        channel_conf={"channel_name": "general"},
+        feedback_reminder_id=None,
+    )
+
+    action_ids = _get_action_ids(blocks)
+
+    assert LIKE_BLOCK_ACTION_ID in action_ids
+    assert DISLIKE_BLOCK_ACTION_ID in action_ids
+
+
+def test_ephemeral_publication_preserves_remove_feedback_buttons_setting() -> None:
+    blocks = build_slack_response_blocks(
+        answer=_make_answer(),
+        message_info=_make_message_info(),
+        channel_conf={
+            "channel_name": "general",
+            "is_ephemeral": True,
+            "remove_feedback_buttons": True,
+        },
+        feedback_reminder_id=None,
+        offer_ephemeral_publication=True,
+        skip_ai_feedback=True,
+    )
+
+    publish_button = next(
+        element
+        for block in blocks
+        for element in block.to_dict().get("elements", [])
+        if element.get("action_id") == SHOW_EVERYONE_ACTION_ID
+    )
+    action_value = json.loads(publish_button["value"])
+
+    assert action_value["channel_conf"]["remove_feedback_buttons"] is True
 
 
 def test_build_sources_blocks_formats_naive_timestamp(

--- a/backend/tests/unit/onyx/onyxbot/test_slack_feedback_reminder.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_feedback_reminder.py
@@ -1,0 +1,41 @@
+from unittest.mock import MagicMock
+
+import pytest
+from slack_sdk import WebClient
+
+from onyx.onyxbot.slack.handlers.handle_message import schedule_feedback_reminder
+from onyx.onyxbot.slack.models import SlackMessageInfo, ThreadMessage
+
+
+def _make_message_info() -> SlackMessageInfo:
+    return SlackMessageInfo(
+        thread_messages=[ThreadMessage(message="A question?")],
+        channel_to_respond="C123",
+        msg_to_respond="123.456",
+        thread_to_respond="123.456",
+        sender_id="U123",
+        email="user@example.com",
+        bypass_filters=False,
+        is_slash_command=False,
+        is_bot_dm=False,
+    )
+
+
+def test_feedback_reminder_is_not_scheduled_when_feedback_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "onyx.onyxbot.slack.handlers.handle_message.ONYX_BOT_FEEDBACK_REMINDER",
+        10,
+    )
+    client = MagicMock(spec=WebClient)
+
+    reminder_id = schedule_feedback_reminder(
+        details=_make_message_info(),
+        include_followup=False,
+        client=client,
+        feedback_enabled=False,
+    )
+
+    assert reminder_id is None
+    assert client.mock_calls == []

--- a/backend/tests/unit/onyx/server/manage/test_slack_channel_config.py
+++ b/backend/tests/unit/onyx/server/manage/test_slack_channel_config.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.server.manage.models import (
+    SlackBotResponseType,
+    SlackChannelConfigCreationRequest,
+)
+from onyx.server.manage.slack_bot import _form_channel_config
+
+
+def test_form_channel_config_preserves_remove_feedback_buttons(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "onyx.server.manage.slack_bot.validate_channel_name",
+        lambda **_: "general",
+    )
+    request = SlackChannelConfigCreationRequest(
+        slack_bot_id=1,
+        channel_name="general",
+        response_type=SlackBotResponseType.CITATIONS,
+        remove_feedback_buttons=True,
+    )
+
+    channel_config = _form_channel_config(
+        db_session=MagicMock(spec=Session),
+        slack_channel_config_creation_request=request,
+        current_slack_channel_config_id=None,
+    )
+
+    assert channel_config["remove_feedback_buttons"] is True
+
+
+def test_form_channel_config_defaults_remove_feedback_buttons_to_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "onyx.server.manage.slack_bot.validate_channel_name",
+        lambda **_: "general",
+    )
+    request = SlackChannelConfigCreationRequest(
+        slack_bot_id=1,
+        channel_name="general",
+        response_type=SlackBotResponseType.CITATIONS,
+    )
+
+    channel_config = _form_channel_config(
+        db_session=MagicMock(spec=Session),
+        slack_channel_config_creation_request=request,
+        current_slack_channel_config_id=None,
+    )
+
+    assert channel_config["remove_feedback_buttons"] is False

--- a/web/src/app/admin/bots/[bot-id]/__tests__/lib.test.ts
+++ b/web/src/app/admin/bots/[bot-id]/__tests__/lib.test.ts
@@ -1,0 +1,36 @@
+import { createSlackChannelConfig } from "../lib";
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test("includes the feedback-button preference in channel configuration requests", async () => {
+  const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({
+    ok: true,
+  } as Response);
+  const creationRequest = {
+    slack_bot_id: 1,
+    document_sets: [],
+    persona_id: null,
+    enable_auto_filters: false,
+    channel_name: "general",
+    answer_validity_check_enabled: false,
+    questionmark_prefilter_enabled: false,
+    respond_tag_only: false,
+    is_ephemeral: false,
+    respond_to_bots: false,
+    show_continue_in_web_ui: true,
+    remove_feedback_buttons: true,
+    respond_member_group_list: [],
+    usePersona: false,
+    response_type: "citations" as const,
+    standard_answer_categories: [],
+    disabled: false,
+  };
+
+  await createSlackChannelConfig(creationRequest);
+
+  const [, requestInit] = fetchSpy.mock.calls[0]!;
+  const requestBody = JSON.parse(requestInit?.body as string);
+  expect(requestBody.remove_feedback_buttons).toBe(true);
+});

--- a/web/src/app/admin/bots/[bot-id]/__tests__/lib.test.ts
+++ b/web/src/app/admin/bots/[bot-id]/__tests__/lib.test.ts
@@ -30,7 +30,16 @@ test("includes the feedback-button preference in channel configuration requests"
 
   await createSlackChannelConfig(creationRequest);
 
-  const [, requestInit] = fetchSpy.mock.calls[0]!;
-  const requestBody = JSON.parse(requestInit?.body as string);
+  expect(fetchSpy).toHaveBeenCalledTimes(1);
+  const requestCall = fetchSpy.mock.calls[0];
+  expect(requestCall).toBeDefined();
+  if (!requestCall) {
+    throw new Error("Expected fetch to be called");
+  }
+  const [, requestInit] = requestCall;
+  if (!requestInit) {
+    throw new Error("Expected fetch request options");
+  }
+  const requestBody = JSON.parse(requestInit.body as string);
   expect(requestBody.remove_feedback_buttons).toBe(true);
 });

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigCreationForm.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigCreationForm.tsx
@@ -88,6 +88,9 @@ export const SlackChannelConfigCreationForm = ({
           show_continue_in_web_ui:
             existingSlackChannelConfig?.channel_config
               ?.show_continue_in_web_ui ?? !isUpdate,
+          remove_feedback_buttons:
+            existingSlackChannelConfig?.channel_config
+              ?.remove_feedback_buttons ?? false,
           enable_auto_filters:
             existingSlackChannelConfig?.enable_auto_filters || false,
           respond_member_group_list:
@@ -136,6 +139,7 @@ export const SlackChannelConfigCreationForm = ({
           respond_to_bots: Yup.boolean().required(),
           is_ephemeral: Yup.boolean().required(),
           show_continue_in_web_ui: Yup.boolean().required(),
+          remove_feedback_buttons: Yup.boolean().required(),
           enable_auto_filters: Yup.boolean().required(),
           respond_member_group_list: Yup.array().of(Yup.string()).required(),
           still_need_help_enabled: Yup.boolean().required(),

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
@@ -487,6 +487,12 @@ export function SlackChannelConfigFormFields({
               />
 
               <CheckboxField
+                name="remove_feedback_buttons"
+                label="Remove the 'Helpful' and 'Not helpful' buttons after bot response."
+                tooltip="If set, OnyxBot responses will not include feedback buttons or send feedback reminders"
+              />
+
+              <CheckboxField
                 name="still_need_help_enabled"
                 onChange={(checked: boolean) => {
                   setFieldValue("still_need_help_enabled", checked);

--- a/web/src/app/admin/bots/[bot-id]/lib.ts
+++ b/web/src/app/admin/bots/[bot-id]/lib.ts
@@ -13,6 +13,7 @@ interface SlackChannelConfigCreationRequest {
   is_ephemeral: boolean;
   respond_to_bots: boolean;
   show_continue_in_web_ui: boolean;
+  remove_feedback_buttons: boolean;
   respond_member_group_list: string[];
   follow_up_tags?: string[];
   usePersona: boolean;
@@ -44,6 +45,7 @@ const buildRequestBodyFromCreationRequest = (
     respond_to_bots: creationRequest.respond_to_bots,
     is_ephemeral: creationRequest.is_ephemeral,
     show_continue_in_web_ui: creationRequest.show_continue_in_web_ui,
+    remove_feedback_buttons: creationRequest.remove_feedback_buttons,
     enable_auto_filters: creationRequest.enable_auto_filters,
     respond_member_group_list: creationRequest.is_ephemeral
       ? []

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -484,6 +484,7 @@ export interface ChannelConfig {
   respond_to_bots?: boolean;
   is_ephemeral?: boolean;
   show_continue_in_web_ui?: boolean;
+  remove_feedback_buttons?: boolean;
   respond_member_group_list?: string[];
   answer_filters?: AnswerFilterOption[];
   follow_up_tags?: string[];


### PR DESCRIPTION
﻿## Summary

Adds a per-configuration Slack option to remove the Helpful and Not helpful buttons from bot responses.

The option appears under General Configuration and applies to both default and channel-specific Slack configurations.

## Why

Some Slack workspaces do not want end users to see response feedback controls. The existing feedback reminder could also direct users to buttons that were not visible, so reminders are disabled with the option.

## What changed

- Added the checkbox: `Remove the 'Helpful' and 'Not helpful' buttons after bot response.`
- Added the `remove_feedback_buttons` setting to the frontend and backend configuration contracts.
- Persisted the setting in the existing JSON channel configuration, with a false default for existing configurations.
- Suppressed only the Helpful and Not helpful action block when enabled.
- Preserved the setting through ephemeral response actions and response rebuilding.
- Skipped scheduled feedback reminders when feedback buttons are disabled.
- Kept citations, follow-up controls, Web UI controls, feedback endpoints, and existing feedback data unchanged.
- Added regression tests for request serialization, configuration persistence, response rendering, default compatibility, reminders, and ephemeral payloads.
- No database migration is required.

## Compatibility

Existing configurations continue to show feedback buttons because a missing setting is treated as false. The setting affects responses created after the configuration is saved. Existing Slack messages are unchanged.

## Verification

Passed:

- 10 focused backend tests
- 288 OnyxBot unit tests
- Frontend request serialization test
- Targeted Python type checks
- TypeScript type check
- Targeted Ruff, Oxlint, and Oxfmt checks
- `git diff --check`

Environment limitations:

- The complete backend unit suite cannot collect on Windows because an unrelated test calls POSIX-only `os.geteuid()`.
- The complete frontend suite had 1 unrelated date-based failure and 1,131 passing tests.
- The repository pre-commit run is blocked by existing Windows and WSL tool limitations, including the Unix-only ripsecrets hook.

## Contributor note

This PR is submitted from the contributor fork `sahil-sharma-50/onyx`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses #14010 by adding a per-channel Slack option to hide the Helpful/Not helpful buttons on bot responses and skip feedback reminders. Previously those buttons and reminders were always on; now channels can disable them, and existing messages remain unchanged.

**Notes for review**
- Adds `remove_feedback_buttons` to backend and web channel config; default is false, persisted in JSON `channel_config`; no database migration.
- Admin Slack Channel Config form adds a checkbox; create/update requests include `remove_feedback_buttons`, with a web test verifying the request body.
- Slack blocks builder omits the AI feedback action block when enabled; citations and follow-up controls are unchanged; ephemeral publish actions preserve the flag.
- Feedback reminders respect the setting: `schedule_feedback_reminder` now takes `feedback_enabled`, and the listener passes `not remove_feedback_buttons`.
- Compatibility: missing field is treated as false; setting applies to new responses after save.

<sup>Written for commit 015a08601de64078a1c8fd2c9a66d6b5e926876b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->






## Tracking issue

- #14010



## Additional Options

- [x] [Optional] Override Linear Check
