### PR TITLE
fix(indexing): only warn about missing vision LLM when the batch has images

### DIFF
--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -749,7 +749,7 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
         llm = get_default_llm_with_vision()
 
     if not llm:
-        if get_image_extraction_and_analysis_enabled():
+        if get_image_extraction_and_analysis_enabled() and has_image_section:
             logger.warning(
                 "Image analysis is enabled but no vision-capable LLM is "
                 "available — images will not be summarized. Configure a "


### PR DESCRIPTION
Closes #13978.

`process_image_sections()` sets `llm = None` when a batch has no `ImageSection`
(`not has_image_section`), but the "no vision-capable LLM is available" warning
only checked whether image analysis is globally enabled. So a text-only indexing
batch logged that warning on every run, even though there were no images to
summarize.

Change the warning condition to also require `has_image_section`, so it only fires
when a batch actually contains images but no vision LLM can process them.

I could not run the onyx backend test suite locally (it needs the full Django/Celery
stack); the change is a one-line condition guarded by a value already computed in
this function. Happy to add a regression test if the repo has a pattern for testing
this module — I didn't find an existing test for `process_image_sections`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits the "no vision-capable LLM available" warning in `process_image_sections` to batches that actually contain images. Previously, text-only batches emitted this warning whenever image analysis was enabled.

- Verify `has_image_section` is true only when the batch includes an `ImageSection`.
- Confirm the warning still logs when image analysis is enabled, images are present, and no vision-capable LLM is configured.
- No runtime or indexing behavior changes; this only reduces noisy logs.

<sup>Written for commit 389e5296c2f89d485a9b4e15da4096daad71f547. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

