### PR TITLE
fix(scim): carry the tenant in the SCIM token

### DIFF
--- a/backend/ee/onyx/server/enterprise_settings/api.py
+++ b/backend/ee/onyx/server/enterprise_settings/api.py
@@ -301,7 +301,11 @@ def create_scim_token(
     revokes all previous tokens. The raw token value is returned exactly once
     in the response; it cannot be retrieved again.
     """
-    raw_token, hashed_token, token_display = generate_scim_token()
+    # The tenant is baked into the token so the IdP's later SCIM calls, which
+    # carry nothing but this bearer token, resolve to the right workspace.
+    raw_token, hashed_token, token_display = generate_scim_token(
+        get_current_tenant_id()
+    )
     token = dal.create_token(
         name=body.name,
         hashed_token=hashed_token,

--- a/backend/ee/onyx/server/scim/auth.py
+++ b/backend/ee/onyx/server/scim/auth.py
@@ -9,7 +9,9 @@ Onyx UI. This module provides:
     and returns the raw value, its SHA-256 hash, and a display suffix.
 
 Token format: ``onyx_scim_<random>`` where ``<random>`` is 48 bytes of
-URL-safe base64 from ``secrets.token_urlsafe``.
+URL-safe base64 from ``secrets.token_urlsafe``. Under multi-tenancy the
+tenant is embedded as ``onyx_scim_<tenant>.<random>``, matching API keys and
+PATs — see ``generate_scim_token``.
 
 The hash is stored in the ``scim_token`` table; the raw value is shown to
 the admin exactly once at creation time.
@@ -17,14 +19,17 @@ the admin exactly once at creation time.
 
 import hashlib
 import secrets
+from urllib.parse import quote
 
 from fastapi import Depends, Request
 from sqlalchemy.orm import Session
 
 from ee.onyx.db.scim import ScimDAL
+from onyx.auth.constants import SCIM_TOKEN_LENGTH, SCIM_TOKEN_PREFIX
 from onyx.auth.utils import get_hashed_bearer_token_from_request
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import ScimToken
+from shared_configs.configs import MULTI_TENANT
 
 
 class ScimAuthError(Exception):
@@ -41,23 +46,33 @@ class ScimAuthError(Exception):
         super().__init__(detail)
 
 
-SCIM_TOKEN_PREFIX = "onyx_scim_"
-SCIM_TOKEN_LENGTH = 48
-
-
 def _hash_scim_token(token: str) -> str:
     """SHA-256 hash a SCIM token. No salt needed — tokens are random."""
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 
-def generate_scim_token() -> tuple[str, str, str]:
+def generate_scim_token(tenant_id: str | None = None) -> tuple[str, str, str]:
     """Generate a new SCIM bearer token.
+
+    Under multi-tenancy the tenant is embedded in the token as
+    ``onyx_scim_<tenant>.<random>``, the same shape API keys and PATs use
+    (``generate_api_key``). An IdP presents only this bearer token, so the
+    tenant-tracking middleware has nothing else to resolve the workspace
+    from; without it every SCIM request falls back to the default schema.
 
     Returns:
         A tuple of ``(raw_token, hashed_token, token_display)`` where
         ``token_display`` is a masked version showing only the last 4 chars.
     """
-    raw_token = SCIM_TOKEN_PREFIX + secrets.token_urlsafe(SCIM_TOKEN_LENGTH)
+    if not MULTI_TENANT or not tenant_id:
+        raw_token = SCIM_TOKEN_PREFIX + secrets.token_urlsafe(SCIM_TOKEN_LENGTH)
+    else:
+        encoded_tenant = quote(tenant_id)
+        raw_token = (
+            f"{SCIM_TOKEN_PREFIX}{encoded_tenant}."
+            f"{secrets.token_urlsafe(SCIM_TOKEN_LENGTH)}"
+        )
+
     hashed_token = _hash_scim_token(raw_token)
     token_display = SCIM_TOKEN_PREFIX + "****" + raw_token[-4:]
     return raw_token, hashed_token, token_display

--- a/backend/onyx/auth/constants.py
+++ b/backend/onyx/auth/constants.py
@@ -9,6 +9,11 @@ API_KEY_LENGTH = 192
 PAT_PREFIX = "onyx_pat_"
 PAT_LENGTH = 192
 
+# SCIM constants. Defined here rather than in `ee` so that tenant extraction in
+# `onyx.auth.utils` can recognise a SCIM token without importing from `ee`.
+SCIM_TOKEN_PREFIX = "onyx_scim_"
+SCIM_TOKEN_LENGTH = 48
+
 # Shared header constants
 API_KEY_HEADER_NAME = "Authorization"
 API_KEY_HEADER_ALTERNATIVE_NAME = "X-Onyx-Authorization"

--- a/backend/onyx/auth/utils.py
+++ b/backend/onyx/auth/utils.py
@@ -12,6 +12,7 @@ from onyx.auth.constants import (
     BEARER_PREFIX,
     DEPRECATED_API_KEY_PREFIX,
     PAT_PREFIX,
+    SCIM_TOKEN_PREFIX,
 )
 
 
@@ -97,14 +98,15 @@ def _extract_tenant_from_bearer_token(
 
 
 def extract_tenant_from_auth_header(request: Request) -> str | None:
-    """Extract tenant ID from API key or PAT header.
+    """Extract tenant ID from an API key, PAT, or SCIM token header.
 
-    Unified function for extracting tenant from any bearer token (API key or PAT).
+    Unified function for extracting tenant from any bearer token.
     Checks all known token prefixes in order.
 
     Returns:
         Tenant ID if found, else None
     """
     return _extract_tenant_from_bearer_token(
-        request, [API_KEY_PREFIX, DEPRECATED_API_KEY_PREFIX, PAT_PREFIX]
+        request,
+        [API_KEY_PREFIX, DEPRECATED_API_KEY_PREFIX, PAT_PREFIX, SCIM_TOKEN_PREFIX],
     )

--- a/backend/tests/unit/onyx/server/scim/test_auth.py
+++ b/backend/tests/unit/onyx/server/scim/test_auth.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -9,6 +9,7 @@ from ee.onyx.server.scim.auth import (
     generate_scim_token,
     verify_scim_token,
 )
+from onyx.auth.utils import extract_tenant_from_auth_header
 
 
 class TestGenerateScimToken:
@@ -35,6 +36,53 @@ class TestGenerateScimToken:
     def test_tokens_are_unique(self) -> None:
         tokens = {generate_scim_token()[0] for _ in range(10)}
         assert len(tokens) == 10
+
+
+class TestScimTokenTenantResolution:
+    """An IdP sends nothing but the bearer token, so the token itself has to
+    carry the tenant. Without it every SCIM call on cloud resolved to the
+    default schema and the tier gate rejected it as non-Enterprise.
+    """
+
+    TENANT = "tenant_abc123"
+
+    def _request(self, auth_header: str) -> MagicMock:
+        request = MagicMock()
+        request.headers = {"Authorization": auth_header}
+        return request
+
+    @patch("ee.onyx.server.scim.auth.MULTI_TENANT", True)
+    def test_multi_tenant_token_embeds_tenant(self) -> None:
+        raw, _, _ = generate_scim_token(self.TENANT)
+        assert raw.startswith(f"{SCIM_TOKEN_PREFIX}{self.TENANT}.")
+
+    @patch("ee.onyx.server.scim.auth.MULTI_TENANT", True)
+    def test_tenant_round_trips_through_auth_header(self) -> None:
+        raw, _, _ = generate_scim_token(self.TENANT)
+        assert (
+            extract_tenant_from_auth_header(self._request(f"Bearer {raw}"))
+            == self.TENANT
+        )
+
+    @patch("ee.onyx.server.scim.auth.MULTI_TENANT", True)
+    def test_hash_covers_the_whole_token(self) -> None:
+        raw, hashed, _ = generate_scim_token(self.TENANT)
+        assert hashed == _hash_scim_token(raw)
+
+    @patch("ee.onyx.server.scim.auth.MULTI_TENANT", True)
+    def test_verify_accepts_tenant_bearing_token(self) -> None:
+        raw, _, _ = generate_scim_token(self.TENANT)
+        token = MagicMock()
+        token.is_active = True
+        dal = MagicMock()
+        dal.get_token_by_hash.return_value = token
+        assert verify_scim_token(self._request(f"Bearer {raw}"), dal) is token
+
+    @patch("ee.onyx.server.scim.auth.MULTI_TENANT", False)
+    def test_self_hosted_token_keeps_the_untenanted_format(self) -> None:
+        raw, _, _ = generate_scim_token(self.TENANT)
+        assert "." not in raw
+        assert extract_tenant_from_auth_header(self._request(f"Bearer {raw}")) is None
 
 
 class TestHashScimToken:


### PR DESCRIPTION
## Description

SCIM provisioning does not work on multi-tenant cloud. Every SCIM request is refused with `402 FEATURE_NOT_AVAILABLE` and `required_tier: enterprise`, whatever the tenant's plan.

An IdP sends nothing but its bearer token. A SCIM token was `onyx_scim_<random>` and held no tenant, so `extract_tenant_from_auth_header` could not recognise it. Tenant tracking then fell back to the default `public` schema. The tier gate runs as middleware, ahead of the `verify_scim_token` dependency, so it asked whether `public` is Enterprise. It never is.

You can reproduce this today with no credentials at all:

```
$ curl -s https://cloud.onyx.app/api/scim/v2/Users
{"error_code":"FEATURE_NOT_AVAILABLE","detail":"This feature requires the Enterprise plan.","required_tier":"enterprise"}
```

This change embeds the tenant in the token, the way API keys and PATs already do (`generate_api_key`): `onyx_scim_<tenant>.<random>`. `SCIM_TOKEN_PREFIX` and `SCIM_TOKEN_LENGTH` move to `onyx/auth/constants.py`, because CE tenant extraction needs them and cannot import from `ee`.

Note for review: adding the prefix to the extraction list alone does **not** fix this. The parser splits on `.`, and `secrets.token_urlsafe` emits no `.`, so the old format can never yield a tenant. The token format had to change.

### Scope

- Self-hosted is unchanged. The `not MULTI_TENANT` branch keeps the old format, and the tenant middleware is not registered there.
- Cloud admins must regenerate their SCIM token. Tokens minted before this carry no tenant. Nothing regresses, because no cloud token ever worked.
- Routing is a separate defect. The cloud VirtualServer has no `/scim` route, so `/scim/v2` still returns 404 until that lands (onyx-infra#765, private repo). `/api/scim/v2` works after this PR.

### Known, not addressed here

- The tier gate reports an authentication failure as a billing failure (402, not 401). Unauthenticated SCIM discovery probes still get 402.
- The admin SCIM page shows the token but never the base URL, and the docs give a URL that does not work on cloud.

## How Has This Been Tested?

- New unit tests in `backend/tests/unit/onyx/server/scim/test_auth.py` cover the round trip: generate a token under multi-tenancy, then recover the tenant from the auth header. They also cover hashing, verification, and the unchanged self-hosted format.
- Drove the real middleware helper `_get_tenant_id_from_request` directly. A new token resolves to its tenant. An old-format token resolves to `public`, which reproduces the bug. `verify_scim_token` still authenticates the new token.
- Full `backend/tests/unit` run: 8356 passed. The 19 failures are pre-existing on `main` (license reclaim, process isolation, license API). I confirmed this by stashing the change and re-running.
- `pre-commit` is clean on every touched file (ty, ruff, lazy imports).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
