### PR TITLE
feat(ods): add `ods test` to run any suite in the repo

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -95,6 +95,15 @@ Write the migration manually and place it in the file that alembic creates when 
 Run pytest through `uv run` from the repo root — no venv activation needed (`uv run` uses the
 lockfile-pinned environment and creates/syncs `.venv` as needed).
 
+`ods test` is the shorter form of every command in this section. It picks the suite from a name
+or a path, supplies `.vscode/.env` where the suite needs it, and passes the rest to pytest:
+
+```bash
+ods test unit                                   # the whole suite
+ods test backend/tests/unit/onyx/test_foo.py    # one file
+ods test external -k some_name                  # arguments reach pytest
+```
+
 There are 4 main types of tests within Onyx:
 
 ### Model choice for tests that make real LLM calls
@@ -144,6 +153,13 @@ mock anything in these tests. Prefer writing integration tests (or External Depe
 verification is necessary) over any other type of test.
 
 Tests are parallelized at a directory level.
+
+Careful: these tests call `reset_all()`, which wipes Postgres and the file store for the current
+project. Do not point them at data you want to keep.
+
+`ods test integration` runs `backend/tests/integration/tests`, the same set CI shards. The sibling
+directories need a setup of their own, so give a path to run one, for example
+`ods test backend/tests/integration/multitenant_tests`.
 
 When writing integration tests, make sure to check the root `conftest.py` for useful fixtures + the `backend/tests/integration/common_utils` directory for utilities. Prefer (if one exists), calling the appropriate Manager
 class in the utils over directly calling the APIs with a library like `requests`. Prefer using fixtures rather than

--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -76,7 +76,8 @@ Web is different: web uses **Tailwind's default step scale**, where `p-6` = step
 ## Tests
 
 - Runner: `jest-expo`. Tests live in `__tests__/` (`src/**/__tests__/**/*.test.ts?(x)`). Gate with
-  `bun run typecheck`, `bun run lint`, `bunx jest`.
+  `bun run typecheck`, `bun run lint`, `bunx jest`. From any directory, `ods test mobile` runs the
+  same jest suite and installs `mobile/node_modules` first if it is missing.
 - **Import jest globals from `@jest/globals`** (`describe/it/expect/jest/beforeEach`) — the TS config
   carries no ambient test types. Put all imports first, then `jest.mock(...)` (babel hoists the mock;
   this also satisfies `import/first`).

--- a/tools/ods/.coverage-baseline.yaml
+++ b/tools/ods/.coverage-baseline.yaml
@@ -5,13 +5,15 @@
 # tests with `ods coverage <suite> --update`.
 #
 # Generated file: do not edit by hand.
-total: 36.4
+total: 37.1
 packages:
   .: 0
-  cmd: 17.1
+  cmd: 15.7
   internal/alembic: 0
   internal/audit: 55.1
   internal/auditcmd: 0
+  internal/backendenv: 92.3
+  internal/bunpkg: 80.2
   internal/childproc: 0
   internal/composegen: 96.8
   internal/config: 0
@@ -24,7 +26,7 @@ packages:
   internal/kube: 0
   internal/lazyimports: 61.2
   internal/openapi: 0
-  internal/paths: 30.3
+  internal/paths: 42.8
   internal/portutil: 75
   internal/postgres: 0
   internal/prompt: 0
@@ -32,7 +34,7 @@ packages:
   internal/release: 82.7
   internal/s3: 0
   internal/terraform: 83
-  internal/testsuite: 88.1
+  internal/testsuite: 92.5
   internal/tui: 38.8
   internal/version: 100
   odsaudit: 0

--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -246,8 +246,8 @@ ods web test --watch
 
 ### `test` - Run Tests
 
-Run the repo's test suites without changing directories or remembering which
-suite owns a file.
+Run any test suite in the repo without changing directories or remembering
+which runner applies.
 
 ```shell
 ods test <suite|path> [args...]
@@ -255,31 +255,64 @@ ods test <suite|path> [args...]
 
 The first argument is a suite name or a path inside a suite. A path selects the
 suite that covers it, so you can pass a file straight from your editor. All
-later arguments go to the suite's test runner.
+later arguments go to the underlying runner.
 
-| Suite | Aliases | Directory | Runner |
+| Suite | Aliases | Runner | Needs services |
 | --- | --- | --- | --- |
-| `ods` | | `tools/ods` | `go test` |
-| `cli` | | `cli` | `go test` |
-| `terraform` | `tf` | `terraform-provider-onyx` | `go test` |
+| `unit` | `u` | pytest | no |
+| `external` | `edu`, `ext` | pytest | Postgres, Redis, OpenSearch, MinIO |
+| `integration` | `int` | pytest | full deployment |
+| `web` | `jest` | jest | no |
+| `e2e` | `playwright`, `pw` | playwright | full deployment |
+| `mobile` | | jest-expo | no |
+| `ods` | | go test | no |
+| `cli` | | go test | no |
+| `terraform` | `tf` | go test | no |
+| `backend` | `py` | pytest | any other `backend/tests` path |
 
-The Go suites run with `-race`, the same as `pr-golang-tests.yml`. A runner that
-takes packages rather than files, such as `go test`, runs the package that holds
-a file argument. `<file>::<TestName>` runs one test.
+Backend suites run from `backend/`, so `backend/pytest.ini` applies. Suites that
+need credentials read `.vscode/.env`, which is created from
+`.vscode/env_template.txt` on first use. Enterprise Edition features are on by
+default; use `--no-ee` to turn them off.
+
+The Go suites cover the repo's three Go modules. They run with `-race`, the same
+as `pr-golang-tests.yml`. `go test` takes packages rather than files, so a file
+argument runs the package that holds it, and `<file>::<TestName>` becomes a
+`-run` filter.
+
+A bare `ods test integration` runs `backend/tests/integration/tests`, which is
+what CI shards. The sibling directories under `backend/tests/integration` each
+need a setup of their own — `multitenant_tests` a multi-tenant deployment,
+`connector_job_tests` connector credentials — so give a path to run one.
+
+**Careful:** the integration suite calls `reset_all()`, which wipes Postgres and
+the file store for the current project. Do not point it at data you want to
+keep.
 
 **Examples:**
 
 ```shell
-# Run a whole module
+# Run a whole suite
+ods test unit
+
+# Run one file, or one test
+ods test backend/tests/unit/onyx/utils/test_vespa_tasks.py
+ods test backend/tests/unit/onyx/utils/test_vespa_tasks.py::test_monitor
+
+# Forward arguments to the runner
+ods test unit -k some_name
+ods test web --watch
+
+# Run a backend suite in parallel (pytest-xdist)
+ods test external --parallel
+
+# Web end-to-end tests
+ods test e2e chat
+
+# Go modules
 ods test ods
-
-# Run one package, one file's package, or one test
 ods test tools/ods/internal/testsuite
-ods test tools/ods/internal/testsuite/testsuite_test.go
-ods test tools/ods/internal/testsuite/testsuite_test.go::TestResolveGoTargets
-
-# Forward arguments to go test
-ods test cli -run TestChat -v
+ods test cli/internal/tui/viewport_test.go::TestAddUserMessage
 ```
 
 ### `coverage` - Measure Go Coverage Against a Baseline

--- a/tools/ods/cmd/backend.go
+++ b/tools/ods/cmd/backend.go
@@ -13,6 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/childproc"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/portutil"
 )
@@ -138,20 +139,8 @@ func runBackendService(name, module, port string, opts *BackendOptions) {
 
 	svcCmd := exec.Command("uv", uvicornArgs...)
 	svcCmd.Dir = backendDir
-	svcCmd.Stdout = os.Stdout
-	svcCmd.Stderr = os.Stderr
-	svcCmd.Stdin = os.Stdin
 	svcCmd.Env = mergedEnv
-
-	if err := svcCmd.Run(); err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			if code := exitErr.ExitCode(); code != -1 {
-				os.Exit(code)
-			}
-		}
-		log.Fatalf("Failed to run %s: %v", name, err)
-	}
+	childproc.Run(svcCmd, name)
 }
 
 // eeEnvDefaults returns env entries for EE and license enforcement settings.

--- a/tools/ods/cmd/backend.go
+++ b/tools/ods/cmd/backend.go
@@ -1,18 +1,15 @@
 package cmd
 
 import (
-	"bufio"
-	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/backendenv"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/childproc"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/portutil"
@@ -115,11 +112,15 @@ func runBackendService(name, module, port string, opts *BackendOptions) {
 
 	port = resolvePort(port)
 
-	envFile := ensureBackendEnvFile(root)
-	fileVars := loadBackendEnvFile(envFile)
-
-	eeDefaults := eeEnvDefaults(opts.NoEE)
-	fileVars = append(fileVars, eeDefaults...)
+	envFile, err := backendenv.EnsureFile(root)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fileVars, err := backendenv.Load(envFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fileVars = append(fileVars, backendenv.EEDefaults(opts.NoEE)...)
 
 	backendDir := filepath.Join(root, "backend")
 
@@ -134,114 +135,11 @@ func runBackendService(name, module, port string, opts *BackendOptions) {
 	}
 	log.Debugf("Running in %s: uv %v", backendDir, uvicornArgs)
 
-	mergedEnv := mergeEnv(os.Environ(), fileVars)
+	mergedEnv := backendenv.Merge(os.Environ(), fileVars)
 	log.Debugf("Applied %d env vars from %s (shell takes precedence)", len(fileVars), envFile)
 
 	svcCmd := exec.Command("uv", uvicornArgs...)
 	svcCmd.Dir = backendDir
 	svcCmd.Env = mergedEnv
 	childproc.Run(svcCmd, name)
-}
-
-// eeEnvDefaults returns env entries for EE and license enforcement settings.
-// These are appended to the file vars so they act as defaults — shell env
-// and .env file values still take precedence via mergeEnv.
-func eeEnvDefaults(noEE bool) []string {
-	if noEE {
-		return []string{
-			"ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=false",
-		}
-	}
-	return []string{
-		"ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true",
-		"LICENSE_ENFORCEMENT_ENABLED=false",
-	}
-}
-
-// ensureBackendEnvFile copies env_template.txt to .env if .env doesn't exist.
-func ensureBackendEnvFile(root string) string {
-	vscodeDir := filepath.Join(root, ".vscode")
-	envFile := filepath.Join(vscodeDir, ".env")
-	templateFile := filepath.Join(vscodeDir, "env_template.txt")
-
-	if _, err := os.Stat(envFile); err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			log.Fatalf("Failed to stat env file %s: %v", envFile, err)
-		}
-	} else {
-		log.Debugf("Using existing env file: %s", envFile)
-		return envFile
-	}
-
-	templateData, err := os.ReadFile(templateFile)
-	if err != nil {
-		log.Fatalf("Failed to read env template %s: %v", templateFile, err)
-	}
-
-	if err := os.MkdirAll(vscodeDir, 0755); err != nil {
-		log.Fatalf("Failed to create .vscode directory: %v", err)
-	}
-
-	if err := os.WriteFile(envFile, templateData, 0644); err != nil {
-		log.Fatalf("Failed to write env file %s: %v", envFile, err)
-	}
-
-	log.Infof("Created %s from template (review and fill in <REPLACE THIS> values)", envFile)
-	return envFile
-}
-
-// mergeEnv combines shell environment with file-based defaults. Shell values
-// take precedence — file entries are only added for keys not already present.
-func mergeEnv(shellEnv, fileVars []string) []string {
-	existing := make(map[string]bool, len(shellEnv))
-	for _, entry := range shellEnv {
-		if idx := strings.Index(entry, "="); idx > 0 {
-			existing[entry[:idx]] = true
-		}
-	}
-
-	merged := make([]string, len(shellEnv))
-	copy(merged, shellEnv)
-	for _, entry := range fileVars {
-		if idx := strings.Index(entry, "="); idx > 0 {
-			key := entry[:idx]
-			if !existing[key] {
-				merged = append(merged, entry)
-			} else {
-				log.Debugf("Env var %s already set in shell, skipping .env value", key)
-			}
-		}
-	}
-	return merged
-}
-
-// loadBackendEnvFile parses a .env file into KEY=VALUE entries suitable for
-// appending to os.Environ(). Blank lines and comments are skipped.
-func loadBackendEnvFile(path string) []string {
-	f, err := os.Open(path)
-	if err != nil {
-		log.Fatalf("Failed to open env file %s: %v", path, err)
-	}
-	defer func() { _ = f.Close() }()
-
-	var envVars []string
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		if idx := strings.Index(line, "="); idx > 0 {
-			key := strings.TrimSpace(line[:idx])
-			value := strings.TrimSpace(line[idx+1:])
-			value = strings.Trim(value, `"'`)
-			envVars = append(envVars, fmt.Sprintf("%s=%s", key, value))
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		log.Fatalf("Failed to read env file %s: %v", path, err)
-	}
-
-	return envVars
 }

--- a/tools/ods/cmd/coverage.go
+++ b/tools/ods/cmd/coverage.go
@@ -225,6 +225,11 @@ func coverageSuite(root, cwd, target string) *testsuite.Suite {
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
+	// Only Go suites carry a baseline; the others have no coverage tooling
+	// here yet. Say so rather than failing later on a missing go.mod.
+	if suite.Runner != testsuite.RunnerGo {
+		log.Fatalf("Coverage covers the Go suites only; %q runs under %s", suite.Name, suite.Runner)
+	}
 	// Coverage is measured for a whole module, since a baseline covers every
 	// package in it. A path pointing deeper would silently measure less.
 	if len(args) > 0 && args[0] != "./..." {
@@ -253,6 +258,9 @@ Examples:
 
 Suites:`)
 	for _, suite := range testsuite.All() {
+		if suite.Runner != testsuite.RunnerGo {
+			continue
+		}
 		fmt.Fprintf(&b, "\n  %-12s %s", suite.Name, suite.Short)
 	}
 	return b.String()

--- a/tools/ods/cmd/desktop.go
+++ b/tools/ods/cmd/desktop.go
@@ -13,6 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/bunpkg"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 )
 
@@ -56,7 +57,7 @@ func runDesktopScript(args []string) {
 		log.Fatalf("Failed to find repo root: %v", err)
 	}
 	rootNodeModules := filepath.Join(root, "node_modules")
-	if needsInstall, reason := nodeModulesNeedsInstall(rootNodeModules); needsInstall {
+	if needsInstall, reason := bunpkg.NodeModulesNeedsInstall(rootNodeModules); needsInstall {
 		log.Infof("%s, running bun install --frozen-lockfile...", reason)
 		installCmd := exec.Command("bun", "install", "--frozen-lockfile")
 		installCmd.Dir = root

--- a/tools/ods/cmd/test.go
+++ b/tools/ods/cmd/test.go
@@ -16,11 +16,19 @@ import (
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/testsuite"
 )
 
-// NewTestCommand creates a command that runs the repo's test suites.
+// TestOptions holds options for the test command.
+type TestOptions struct {
+	NoEE     bool
+	Parallel bool
+}
+
+// NewTestCommand creates a command that runs any of the repo's test suites.
 func NewTestCommand() *cobra.Command {
+	opts := &TestOptions{}
+
 	cmd := &cobra.Command{
 		Use:   "test [suite|path] [args...]",
-		Short: "Run the repo's test suites",
+		Short: "Run tests for any suite in the repo",
 		Long:  testHelpDescription(),
 		Args:  cobra.ArbitraryArgs,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -29,16 +37,21 @@ func NewTestCommand() *cobra.Command {
 			}
 			return testsuite.Names(), cobra.ShellCompDirectiveNoFileComp
 		},
-		Run: runTest,
+		Run: func(cmd *cobra.Command, args []string) {
+			runTest(cmd, args, opts)
+		},
 	}
-	// Stop parsing at the first positional so flags meant for the test runner
-	// reach it instead of cobra.
+	// Stop parsing at the first positional so flags meant for pytest, jest, or
+	// playwright reach them instead of cobra.
 	cmd.Flags().SetInterspersed(false)
+
+	cmd.Flags().BoolVar(&opts.NoEE, "no-ee", false, "Disable Enterprise Edition features (enabled by default)")
+	cmd.Flags().BoolVarP(&opts.Parallel, "parallel", "p", false, "Run pytest suites in parallel (pytest-xdist -n auto)")
 
 	return cmd
 }
 
-func runTest(cmd *cobra.Command, args []string) {
+func runTest(cmd *cobra.Command, args []string, opts *TestOptions) {
 	root, err := paths.GitRoot()
 	if err != nil {
 		log.Fatalf("Failed to find git root: %v", err)
@@ -57,13 +70,26 @@ func runTest(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	runGoSuite(root, suite, dropSeparator(suiteArgs))
+	suiteArgs = dropSeparator(suiteArgs)
+
+	switch suite.Runner {
+	case testsuite.RunnerPytest:
+		runPytestSuite(root, suite, suiteArgs, opts)
+	case testsuite.RunnerJest:
+		runJestSuite(root, suite, suiteArgs)
+	case testsuite.RunnerPlaywright:
+		runPlaywrightSuite(root, suite, suiteArgs)
+	case testsuite.RunnerGo:
+		runGoSuite(root, suite, suiteArgs)
+	default:
+		log.Fatalf("Suite %s has no runner", suite.Name)
+	}
 }
 
 // dropSeparator removes the first "--" from the arguments. Writing it is habit
 // for anyone used to `bun run` or `npm test`, and it can land either before or
-// after a path. go test would read a literal "--" as a package pattern rather
-// than a separator.
+// after a path. No runner we wrap wants a literal "--", which pytest would
+// read as a target rather than a separator.
 func dropSeparator(args []string) []string {
 	for i, arg := range args {
 		if arg == "--" {
@@ -73,15 +99,50 @@ func dropSeparator(args []string) []string {
 	return args
 }
 
+// runPytestSuite runs a backend suite from the backend directory, so that
+// backend/pytest.ini applies. Credentials come from .vscode/.env the same way
+// `ods backend` supplies them, which also creates that file from the template
+// on first use.
+func runPytestSuite(root string, suite *testsuite.Suite, suiteArgs []string, opts *TestOptions) {
+	pytestArgs := []string{"run", "pytest"}
+	pytestArgs = append(pytestArgs, suite.DefaultArgs...)
+	if opts.Parallel {
+		pytestArgs = append(pytestArgs, "-n", "auto")
+	}
+	// The target goes first so that a user argument for the same option still
+	// wins. Without one, pytest would collect from all of backend/.
+	if !testsuite.HasTarget(suiteArgs) {
+		pytestArgs = append(pytestArgs, suite.DefaultTarget())
+	}
+	pytestArgs = append(pytestArgs, suiteArgs...)
+
+	envVars := eeEnvDefaults(opts.NoEE)
+	if suite.NeedsBackendEnv {
+		envFile := ensureBackendEnvFile(root)
+		envVars = append(loadBackendEnvFile(envFile), envVars...)
+		log.Debugf("Applied %d env vars from %s (shell takes precedence)", len(envVars), envFile)
+	}
+
+	suiteDir := filepath.Join(root, suite.Dir)
+	if suite.Caution != "" {
+		log.Warnf("Careful: %s", suite.Caution)
+	}
+	log.Infof("Running %s tests...", suite.Name)
+	log.Debugf("Running in %s: uv %v", suiteDir, pytestArgs)
+
+	pytestCmd := exec.Command("uv", pytestArgs...)
+	pytestCmd.Dir = suiteDir
+	pytestCmd.Env = mergeEnv(os.Environ(), envVars)
+	childproc.Run(pytestCmd, "pytest")
+}
+
 // runGoSuite runs a Go module's tests from the module directory, which is where
 // go test resolves its "./..." package patterns.
 func runGoSuite(root string, suite *testsuite.Suite, suiteArgs []string) {
 	goArgs := []string{"test"}
 	goArgs = append(goArgs, suite.DefaultArgs...)
-	// go test with no packages tests only the module root, so a bare run gets
-	// "./..." to cover the whole module.
 	if !testsuite.HasTarget(suiteArgs) {
-		goArgs = append(goArgs, "./...")
+		goArgs = append(goArgs, suite.DefaultTarget())
 	}
 	goArgs = append(goArgs, suiteArgs...)
 
@@ -94,21 +155,76 @@ func runGoSuite(root string, suite *testsuite.Suite, suiteArgs []string) {
 	childproc.Run(goCmd, "go test")
 }
 
+func runJestSuite(root string, suite *testsuite.Suite, suiteArgs []string) {
+	runBunScript(root, suite, "test", suiteArgs)
+}
+
+func runPlaywrightSuite(root string, suite *testsuite.Suite, suiteArgs []string) {
+	// The playwright script, never bunx, so the pinned version is the one that
+	// runs. See web/AGENTS.md.
+	runBunScript(root, suite, "playwright", suiteArgs)
+}
+
+// runBunScript runs a package.json script for a bun-based suite, after making
+// sure the suite's dependencies are installed.
+func runBunScript(root string, suite *testsuite.Suite, script string, suiteArgs []string) {
+	suiteDir := filepath.Join(root, suite.Dir)
+	if suite.Dir == "web" {
+		// Reuses the dependency and workspace-library checks `ods web` runs.
+		suiteDir = prepareWebDir()
+	} else {
+		ensureNodeModules(suiteDir)
+	}
+
+	bunArgs := []string{"run", script}
+	if len(suiteArgs) > 0 {
+		// bun requires "--" to forward arguments to the underlying script.
+		bunArgs = append(bunArgs, "--")
+		bunArgs = append(bunArgs, suiteArgs...)
+	}
+
+	log.Infof("Running %s tests...", suite.Name)
+	log.Debugf("Running in %s: bun %v", suiteDir, bunArgs)
+
+	bunCmd := exec.Command("bun", bunArgs...)
+	bunCmd.Dir = suiteDir
+	childproc.Run(bunCmd, "bun")
+}
+
+// ensureNodeModules installs dependencies for a bun package that has none yet.
+// Suites outside web/ have no lockfile stamp to compare against, so this only
+// covers the empty case.
+func ensureNodeModules(dir string) {
+	entries, err := os.ReadDir(filepath.Join(dir, "node_modules"))
+	if err == nil && len(entries) > 0 {
+		return
+	}
+
+	log.Infof("node_modules missing in %s, running bun install...", dir)
+	installCmd := exec.Command("bun", "install")
+	installCmd.Dir = dir
+	childproc.Run(installCmd, "bun install")
+}
+
 func testHelpDescription() string {
-	description := `Run the repo's test suites.
+	description := `Run tests for any suite in the repo.
 
 The first argument is a suite name or a path inside a suite. A path picks the
 suite that covers it, so you can pass a file straight from an editor. Every
-later argument goes to the suite's test runner.
+later argument goes to the underlying runner.
 
-A runner that takes packages rather than files, such as go test, runs the
-package that holds a file argument. "<file>::<TestName>" runs one test.
+Careful: the integration suite calls reset_all(), which wipes Postgres and the
+file store for this project. Do not point it at data you want to keep.
 
 Examples:
+  ods test unit
+  ods test backend/tests/unit/onyx/test_foo.py::test_bar
+  ods test unit -- -k some_name
+  ods test external --parallel
+  ods test web -- --watch
+  ods test web/tests/e2e/chat.spec.ts
   ods test ods
   ods test tools/ods/internal/testsuite
-  ods test tools/ods/internal/testsuite/testsuite_test.go::TestResolveGoTargets
-  ods test cli -run TestChat -v
 
 Suites:`
 

--- a/tools/ods/cmd/test.go
+++ b/tools/ods/cmd/test.go
@@ -11,6 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/backendenv"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/childproc"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/testsuite"
@@ -116,10 +117,17 @@ func runPytestSuite(root string, suite *testsuite.Suite, suiteArgs []string, opt
 	}
 	pytestArgs = append(pytestArgs, suiteArgs...)
 
-	envVars := eeEnvDefaults(opts.NoEE)
+	envVars := backendenv.EEDefaults(opts.NoEE)
 	if suite.NeedsBackendEnv {
-		envFile := ensureBackendEnvFile(root)
-		envVars = append(loadBackendEnvFile(envFile), envVars...)
+		envFile, err := backendenv.EnsureFile(root)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fileVars, err := backendenv.Load(envFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		envVars = append(fileVars, envVars...)
 		log.Debugf("Applied %d env vars from %s (shell takes precedence)", len(envVars), envFile)
 	}
 
@@ -132,7 +140,7 @@ func runPytestSuite(root string, suite *testsuite.Suite, suiteArgs []string, opt
 
 	pytestCmd := exec.Command("uv", pytestArgs...)
 	pytestCmd.Dir = suiteDir
-	pytestCmd.Env = mergeEnv(os.Environ(), envVars)
+	pytestCmd.Env = backendenv.Merge(os.Environ(), envVars)
 	childproc.Run(pytestCmd, "pytest")
 }
 

--- a/tools/ods/cmd/web.go
+++ b/tools/ods/cmd/web.go
@@ -19,6 +19,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/childproc"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 )
 
@@ -48,7 +49,9 @@ func NewWebCommand() *cobra.Command {
 	return cmd
 }
 
-func runWebScript(args []string) {
+// prepareWebDir returns the web directory once its dependencies and workspace
+// library builds are current.
+func prepareWebDir() string {
 	webDir, err := webDir()
 	if err != nil {
 		log.Fatalf("Failed to find web directory: %v", err)
@@ -58,16 +61,17 @@ func runWebScript(args []string) {
 		log.Infof("%s, running bun install --frozen-lockfile...", reason)
 		installCmd := exec.Command("bun", "install", "--frozen-lockfile")
 		installCmd.Dir = webDir
-		installCmd.Stdout = os.Stdout
-		installCmd.Stderr = os.Stderr
-		installCmd.Stdin = os.Stdin
-		if err := installCmd.Run(); err != nil {
-			log.Fatalf("Failed to run bun install: %v", err)
-		}
+		childproc.Run(installCmd, "bun install")
 		writeLockStamp(webDir)
 	}
 
 	ensureWorkspaceLibsBuilt(webDir)
+
+	return webDir
+}
+
+func runWebScript(args []string) {
+	webDir := prepareWebDir()
 
 	scriptName := args[0]
 	scriptArgs := args[1:]
@@ -85,21 +89,7 @@ func runWebScript(args []string) {
 
 	webCmd := exec.Command("bun", bunArgs...)
 	webCmd.Dir = webDir
-	webCmd.Stdout = os.Stdout
-	webCmd.Stderr = os.Stderr
-	webCmd.Stdin = os.Stdin
-
-	if err := webCmd.Run(); err != nil {
-		// For wrapped commands, preserve the child process's exit code and
-		// avoid duplicating already-printed stderr output.
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			if code := exitErr.ExitCode(); code != -1 {
-				os.Exit(code)
-			}
-		}
-		log.Fatalf("Failed to run bun: %v", err)
-	}
+	childproc.Run(webCmd, "bun")
 }
 
 // lockStampName is the file inside node_modules recording the sha256 of the

--- a/tools/ods/cmd/web.go
+++ b/tools/ods/cmd/web.go
@@ -1,24 +1,18 @@
 package cmd
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
-	"time"
 
-	"github.com/charlievieth/fastwalk"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/bunpkg"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/childproc"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 )
@@ -52,17 +46,17 @@ func NewWebCommand() *cobra.Command {
 // prepareWebDir returns the web directory once its dependencies and workspace
 // library builds are current.
 func prepareWebDir() string {
-	webDir, err := webDir()
+	webDir, err := paths.WebDir()
 	if err != nil {
 		log.Fatalf("Failed to find web directory: %v", err)
 	}
 
-	if needsInstall, reason := nodeModulesNeedsInstall(webDir); needsInstall {
+	if needsInstall, reason := bunpkg.NodeModulesNeedsInstall(webDir); needsInstall {
 		log.Infof("%s, running bun install --frozen-lockfile...", reason)
 		installCmd := exec.Command("bun", "install", "--frozen-lockfile")
 		installCmd.Dir = webDir
 		childproc.Run(installCmd, "bun install")
-		writeLockStamp(webDir)
+		bunpkg.WriteLockStamp(webDir)
 	}
 
 	ensureWorkspaceLibsBuilt(webDir)
@@ -92,87 +86,6 @@ func runWebScript(args []string) {
 	childproc.Run(webCmd, "bun")
 }
 
-// lockStampName is the file inside node_modules recording the sha256 of the
-// bun.lock that produced it. node_modules lives in a persistent volume in the
-// devcontainer, so it routinely outlives lockfile updates in the workspace —
-// the stamp is what lets us notice.
-const lockStampName = ".ods-bun-lock-sha256"
-
-// nodeModulesNeedsInstall reports whether bun install should be run, along with
-// a human-readable reason. Install is needed when node_modules is missing,
-// empty, or was installed from a different bun.lock than the current one.
-func nodeModulesNeedsInstall(webDir string) (bool, string) {
-	nodeModules := filepath.Join(webDir, "node_modules")
-	entries, err := os.ReadDir(nodeModules)
-	if errors.Is(err, os.ErrNotExist) {
-		return true, "node_modules not found"
-	}
-	if err != nil {
-		// Couldn't read the directory for some other reason; let bun install
-		// attempt to sort it out rather than silently skipping.
-		return true, fmt.Sprintf("could not read node_modules (%v)", err)
-	}
-	if len(entries) == 0 {
-		return true, "node_modules is empty"
-	}
-
-	lockHash, err := fileSHA256(filepath.Join(webDir, "bun.lock"))
-	if err != nil {
-		// No lockfile to compare against; nothing more we can check.
-		return false, ""
-	}
-	stamp, err := os.ReadFile(filepath.Join(nodeModules, lockStampName))
-	if err != nil || strings.TrimSpace(string(stamp)) != lockHash {
-		return true, "node_modules is stale (bun.lock changed since last install)"
-	}
-	return false, ""
-}
-
-// writeLockStamp records the current bun.lock hash after a successful install.
-// Best-effort: a failure only means the next run reinstalls, which is safe.
-//
-// The stamp is replaced via temp file + rename rather than written in place:
-// the devcontainer's node_modules volume is shared across sessions that may
-// run as different users (root agent sessions, the dev user), and an in-place
-// write to a stamp owned by the other user fails — which would silently force
-// a reinstall on every run. Rename needs only directory write permission and
-// atomically replaces the previous owner's file.
-func writeLockStamp(webDir string) {
-	lockHash, err := fileSHA256(filepath.Join(webDir, "bun.lock"))
-	if err != nil {
-		return
-	}
-	nodeModules := filepath.Join(webDir, "node_modules")
-	stampPath := filepath.Join(nodeModules, lockStampName)
-	tmp, err := os.CreateTemp(nodeModules, lockStampName+".tmp-*")
-	if err != nil {
-		log.Debugf("Failed to create stamp temp file in %s: %v", nodeModules, err)
-		return
-	}
-	_, writeErr := tmp.WriteString(lockHash + "\n")
-	// World-readable so sessions running as other users can validate it.
-	chmodErr := tmp.Chmod(0o644)
-	closeErr := tmp.Close()
-	if writeErr != nil || chmodErr != nil || closeErr != nil {
-		_ = os.Remove(tmp.Name())
-		log.Debugf("Failed to write stamp temp file %s: %v/%v/%v", tmp.Name(), writeErr, chmodErr, closeErr)
-		return
-	}
-	if err := os.Rename(tmp.Name(), stampPath); err != nil {
-		_ = os.Remove(tmp.Name())
-		log.Debugf("Failed to replace %s: %v", stampPath, err)
-	}
-}
-
-func fileSHA256(path string) (string, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", err
-	}
-	sum := sha256.Sum256(data)
-	return hex.EncodeToString(sum[:]), nil
-}
-
 // webLibPackages are the bun workspace packages whose exports point at their
 // dist/ build output. bun install links them into node_modules but never runs
 // their builds, so a fresh checkout (or an edit to their sources) leaves the
@@ -185,7 +98,7 @@ var webLibPackages = []string{"lib/shared", "lib/opal"}
 func ensureWorkspaceLibsBuilt(webDir string) {
 	for _, rel := range webLibPackages {
 		pkgDir := filepath.Join(webDir, rel)
-		needsBuild, reason := libNeedsBuild(pkgDir)
+		needsBuild, reason := bunpkg.LibNeedsBuild(pkgDir)
 		if !needsBuild {
 			continue
 		}
@@ -198,64 +111,6 @@ func ensureWorkspaceLibsBuilt(webDir string) {
 			log.Fatalf("Failed to build web/%s: %v", rel, err)
 		}
 	}
-}
-
-// libNeedsBuild reports whether a workspace library's dist/ is missing or
-// stale relative to its sources, along with a human-readable reason. The
-// staleness check compares newest mtimes, walking the package excluding its
-// build output, dependencies, and hidden entries — cheap enough (a few
-// thousand stats at most) to run before every script.
-func libNeedsBuild(pkgDir string) (bool, string) {
-	if _, err := os.Stat(pkgDir); err != nil {
-		// Not a checkout that has this package; nothing to do.
-		return false, ""
-	}
-	distNewest, err := newestMtime(filepath.Join(pkgDir, "dist"), nil)
-	if errors.Is(err, os.ErrNotExist) {
-		return true, "has no dist build"
-	}
-	if err != nil {
-		return true, fmt.Sprintf("dist is unreadable (%v)", err)
-	}
-	srcNewest, err := newestMtime(pkgDir, map[string]bool{"dist": true, "node_modules": true})
-	if err != nil {
-		return false, ""
-	}
-	if srcNewest.After(distNewest) {
-		return true, "dist build is older than its sources"
-	}
-	return false, ""
-}
-
-// newestMtime returns the newest modification time under root, skipping
-// directories named in excludeDirs and hidden entries.
-func newestMtime(root string, excludeDirs map[string]bool) (time.Time, error) {
-	var newest time.Time
-	// fastwalk runs the callback on several goroutines, so guard the running max.
-	var mu sync.Mutex
-	err := fastwalk.Walk(nil, root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		name := d.Name()
-		if path != root && (excludeDirs[name] || strings.HasPrefix(name, ".")) {
-			if d.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		info, err := d.Info()
-		if err != nil {
-			return err
-		}
-		mu.Lock()
-		if info.ModTime().After(newest) {
-			newest = info.ModTime()
-		}
-		mu.Unlock()
-		return nil
-	})
-	return newest, err
 }
 
 func webScriptNames() []string {
@@ -289,7 +144,7 @@ Examples:
 }
 
 func loadWebScripts() (map[string]string, error) {
-	webDir, err := webDir()
+	webDir, err := paths.WebDir()
 	if err != nil {
 		return nil, err
 	}
@@ -310,12 +165,4 @@ func loadWebScripts() (map[string]string, error) {
 	}
 
 	return pkg.Scripts, nil
-}
-
-func webDir() (string, error) {
-	root, err := paths.GitRoot()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(root, "web"), nil
 }

--- a/tools/ods/internal/backendenv/backendenv.go
+++ b/tools/ods/internal/backendenv/backendenv.go
@@ -1,0 +1,119 @@
+// Package backendenv handles .vscode/.env, the file the backend and its test
+// suites read their credentials from. It creates the file from the template on
+// first use, parses it, and merges it under the shell environment.
+package backendenv
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// EnsureFile returns the path to .vscode/.env, copying env_template.txt over it
+// first if it does not exist yet.
+func EnsureFile(root string) (string, error) {
+	vscodeDir := filepath.Join(root, ".vscode")
+	envFile := filepath.Join(vscodeDir, ".env")
+	templateFile := filepath.Join(vscodeDir, "env_template.txt")
+
+	if _, err := os.Stat(envFile); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("failed to stat env file %s: %w", envFile, err)
+		}
+	} else {
+		log.Debugf("Using existing env file: %s", envFile)
+		return envFile, nil
+	}
+
+	templateData, err := os.ReadFile(templateFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to read env template %s: %w", templateFile, err)
+	}
+
+	if err := os.MkdirAll(vscodeDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create .vscode directory: %w", err)
+	}
+
+	if err := os.WriteFile(envFile, templateData, 0644); err != nil {
+		return "", fmt.Errorf("failed to write env file %s: %w", envFile, err)
+	}
+
+	log.Infof("Created %s from template (review and fill in <REPLACE THIS> values)", envFile)
+	return envFile, nil
+}
+
+// Load parses a .env file into KEY=VALUE entries suitable for appending to
+// os.Environ(). Blank lines and comments are skipped.
+func Load(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open env file %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var envVars []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if idx := strings.Index(line, "="); idx > 0 {
+			key := strings.TrimSpace(line[:idx])
+			value := strings.TrimSpace(line[idx+1:])
+			value = strings.Trim(value, `"'`)
+			envVars = append(envVars, fmt.Sprintf("%s=%s", key, value))
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read env file %s: %w", path, err)
+	}
+
+	return envVars, nil
+}
+
+// Merge combines the shell environment with file-based defaults. Shell values
+// take precedence — file entries are only added for keys not already present.
+func Merge(shellEnv, fileVars []string) []string {
+	existing := make(map[string]bool, len(shellEnv))
+	for _, entry := range shellEnv {
+		if idx := strings.Index(entry, "="); idx > 0 {
+			existing[entry[:idx]] = true
+		}
+	}
+
+	merged := make([]string, len(shellEnv))
+	copy(merged, shellEnv)
+	for _, entry := range fileVars {
+		if idx := strings.Index(entry, "="); idx > 0 {
+			key := entry[:idx]
+			if !existing[key] {
+				merged = append(merged, entry)
+			} else {
+				log.Debugf("Env var %s already set in shell, skipping .env value", key)
+			}
+		}
+	}
+	return merged
+}
+
+// EEDefaults returns env entries for Enterprise Edition and license
+// enforcement. Callers append them to the file vars, so they act as defaults:
+// shell env and .env file values still win through Merge.
+func EEDefaults(noEE bool) []string {
+	if noEE {
+		return []string{
+			"ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=false",
+		}
+	}
+	return []string{
+		"ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true",
+		"LICENSE_ENFORCEMENT_ENABLED=false",
+	}
+}

--- a/tools/ods/internal/backendenv/backendenv_test.go
+++ b/tools/ods/internal/backendenv/backendenv_test.go
@@ -1,0 +1,133 @@
+package backendenv
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnsureFile(t *testing.T) {
+	t.Run("creates the file from the template", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, ".vscode", "env_template.txt"), "FOO=<REPLACE THIS>\n")
+
+		path, err := EnsureFile(root)
+		if err != nil {
+			t.Fatalf("EnsureFile failed: %v", err)
+		}
+		if want := filepath.Join(root, ".vscode", ".env"); path != want {
+			t.Fatalf("path = %q, want %q", path, want)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != "FOO=<REPLACE THIS>\n" {
+			t.Fatalf("content = %q, want the template", string(data))
+		}
+	})
+
+	t.Run("keeps an existing file", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, ".vscode", "env_template.txt"), "FOO=template\n")
+		envPath := filepath.Join(root, ".vscode", ".env")
+		writeFile(t, envPath, "FOO=mine\n")
+
+		if _, err := EnsureFile(root); err != nil {
+			t.Fatalf("EnsureFile failed: %v", err)
+		}
+		data, err := os.ReadFile(envPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != "FOO=mine\n" {
+			t.Fatalf("content = %q, want the file left alone", string(data))
+		}
+	})
+
+	t.Run("reports a missing template", func(t *testing.T) {
+		if _, err := EnsureFile(t.TempDir()); err == nil {
+			t.Fatal("expected an error when the template is missing")
+		}
+	})
+}
+
+func TestLoad(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	writeFile(t, path, `# a comment
+FOO=bar
+
+QUOTED="has spaces"
+SINGLE='single'
+SPACED = padded
+EQUALS=a=b
+=novalue
+`)
+
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	want := []string{
+		"FOO=bar",
+		`QUOTED=has spaces`,
+		"SINGLE=single",
+		"SPACED=padded",
+		"EQUALS=a=b",
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("Load = %q, want %q", got, want)
+	}
+}
+
+func TestLoadMissingFile(t *testing.T) {
+	if _, err := Load(filepath.Join(t.TempDir(), "nope")); err == nil {
+		t.Fatal("expected an error for a missing file")
+	}
+}
+
+func TestMergeShellWins(t *testing.T) {
+	shell := []string{"FOO=from-shell", "BARE"}
+	file := []string{"FOO=from-file", "NEW=from-file"}
+
+	got := Merge(shell, file)
+	want := []string{"FOO=from-shell", "BARE", "NEW=from-file"}
+	if !slices.Equal(got, want) {
+		t.Errorf("Merge = %q, want %q", got, want)
+	}
+}
+
+func TestMergeLeavesTheShellSliceAlone(t *testing.T) {
+	shell := []string{"FOO=from-shell"}
+	Merge(shell, []string{"NEW=from-file"})
+	if len(shell) != 1 || shell[0] != "FOO=from-shell" {
+		t.Errorf("shell env was modified: %q", shell)
+	}
+}
+
+func TestEEDefaults(t *testing.T) {
+	on := EEDefaults(false)
+	if !slices.Contains(on, "ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true") {
+		t.Errorf("EEDefaults(false) = %q, want EE enabled", on)
+	}
+	if !slices.Contains(on, "LICENSE_ENFORCEMENT_ENABLED=false") {
+		t.Errorf("EEDefaults(false) = %q, want license enforcement off", on)
+	}
+
+	off := EEDefaults(true)
+	if !slices.Equal(off, []string{"ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=false"}) {
+		t.Errorf("EEDefaults(true) = %q, want EE disabled only", off)
+	}
+}

--- a/tools/ods/internal/bunpkg/bunpkg.go
+++ b/tools/ods/internal/bunpkg/bunpkg.go
@@ -1,0 +1,161 @@
+// Package bunpkg reports whether a bun package's installed state is current.
+// The devcontainer keeps node_modules in a persistent volume and bun never
+// builds workspace libraries, so both routinely fall behind the sources in the
+// workspace. Commands ask here before they run anything.
+package bunpkg
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charlievieth/fastwalk"
+	log "github.com/sirupsen/logrus"
+)
+
+// lockStampName is the file inside node_modules recording the sha256 of the
+// bun.lock that produced it. node_modules lives in a persistent volume in the
+// devcontainer, so it routinely outlives lockfile updates in the workspace —
+// the stamp is what lets us notice.
+const lockStampName = ".ods-bun-lock-sha256"
+
+// NodeModulesNeedsInstall reports whether bun install should be run for the
+// package rooted at dir, along with a human-readable reason. Install is needed
+// when node_modules is missing, empty, or was installed from a different
+// bun.lock than the current one.
+func NodeModulesNeedsInstall(dir string) (bool, string) {
+	nodeModules := filepath.Join(dir, "node_modules")
+	entries, err := os.ReadDir(nodeModules)
+	if errors.Is(err, os.ErrNotExist) {
+		return true, "node_modules not found"
+	}
+	if err != nil {
+		// Couldn't read the directory for some other reason; let bun install
+		// attempt to sort it out rather than silently skipping.
+		return true, fmt.Sprintf("could not read node_modules (%v)", err)
+	}
+	if len(entries) == 0 {
+		return true, "node_modules is empty"
+	}
+
+	lockHash, err := fileSHA256(filepath.Join(dir, "bun.lock"))
+	if err != nil {
+		// No lockfile to compare against; nothing more we can check.
+		return false, ""
+	}
+	stamp, err := os.ReadFile(filepath.Join(nodeModules, lockStampName))
+	if err != nil || strings.TrimSpace(string(stamp)) != lockHash {
+		return true, "node_modules is stale (bun.lock changed since last install)"
+	}
+	return false, ""
+}
+
+// WriteLockStamp records the current bun.lock hash after a successful install.
+// Best-effort: a failure only means the next run reinstalls, which is safe.
+//
+// The stamp is replaced via temp file + rename rather than written in place:
+// the devcontainer's node_modules volume is shared across sessions that may
+// run as different users (root agent sessions, the dev user), and an in-place
+// write to a stamp owned by the other user fails — which would silently force
+// a reinstall on every run. Rename needs only directory write permission and
+// atomically replaces the previous owner's file.
+func WriteLockStamp(dir string) {
+	lockHash, err := fileSHA256(filepath.Join(dir, "bun.lock"))
+	if err != nil {
+		return
+	}
+	nodeModules := filepath.Join(dir, "node_modules")
+	stampPath := filepath.Join(nodeModules, lockStampName)
+	tmp, err := os.CreateTemp(nodeModules, lockStampName+".tmp-*")
+	if err != nil {
+		log.Debugf("Failed to create stamp temp file in %s: %v", nodeModules, err)
+		return
+	}
+	_, writeErr := tmp.WriteString(lockHash + "\n")
+	// World-readable so sessions running as other users can validate it.
+	chmodErr := tmp.Chmod(0o644)
+	closeErr := tmp.Close()
+	if writeErr != nil || chmodErr != nil || closeErr != nil {
+		_ = os.Remove(tmp.Name())
+		log.Debugf("Failed to write stamp temp file %s: %v/%v/%v", tmp.Name(), writeErr, chmodErr, closeErr)
+		return
+	}
+	if err := os.Rename(tmp.Name(), stampPath); err != nil {
+		_ = os.Remove(tmp.Name())
+		log.Debugf("Failed to replace %s: %v", stampPath, err)
+	}
+}
+
+func fileSHA256(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// LibNeedsBuild reports whether a workspace library's dist/ is missing or
+// stale relative to its sources, along with a human-readable reason. The
+// staleness check compares newest mtimes, walking the package excluding its
+// build output, dependencies, and hidden entries — cheap enough (a few
+// thousand stats at most) to run before every script.
+func LibNeedsBuild(pkgDir string) (bool, string) {
+	if _, err := os.Stat(pkgDir); err != nil {
+		// Not a checkout that has this package; nothing to do.
+		return false, ""
+	}
+	distNewest, err := newestMtime(filepath.Join(pkgDir, "dist"), nil)
+	if errors.Is(err, os.ErrNotExist) {
+		return true, "has no dist build"
+	}
+	if err != nil {
+		return true, fmt.Sprintf("dist is unreadable (%v)", err)
+	}
+	srcNewest, err := newestMtime(pkgDir, map[string]bool{"dist": true, "node_modules": true})
+	if err != nil {
+		return false, ""
+	}
+	if srcNewest.After(distNewest) {
+		return true, "dist build is older than its sources"
+	}
+	return false, ""
+}
+
+// newestMtime returns the newest modification time under root, skipping
+// directories named in excludeDirs and hidden entries.
+func newestMtime(root string, excludeDirs map[string]bool) (time.Time, error) {
+	var newest time.Time
+	// fastwalk runs the callback on several goroutines, so guard the running max.
+	var mu sync.Mutex
+	err := fastwalk.Walk(nil, root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		name := d.Name()
+		if path != root && (excludeDirs[name] || strings.HasPrefix(name, ".")) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		mu.Lock()
+		if info.ModTime().After(newest) {
+			newest = info.ModTime()
+		}
+		mu.Unlock()
+		return nil
+	})
+	return newest, err
+}

--- a/tools/ods/internal/bunpkg/bunpkg_test.go
+++ b/tools/ods/internal/bunpkg/bunpkg_test.go
@@ -1,4 +1,4 @@
-package cmd
+package bunpkg
 
 import (
 	"os"
@@ -28,8 +28,8 @@ func TestNodeModulesNeedsInstall(t *testing.T) {
 	now := time.Now()
 
 	t.Run("missing node_modules", func(t *testing.T) {
-		webDir := t.TempDir()
-		needs, reason := nodeModulesNeedsInstall(webDir)
+		dir := t.TempDir()
+		needs, reason := NodeModulesNeedsInstall(dir)
 		if !needs {
 			t.Fatal("expected install for missing node_modules")
 		}
@@ -39,11 +39,11 @@ func TestNodeModulesNeedsInstall(t *testing.T) {
 	})
 
 	t.Run("empty node_modules", func(t *testing.T) {
-		webDir := t.TempDir()
-		if err := os.Mkdir(filepath.Join(webDir, "node_modules"), 0o755); err != nil {
+		dir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(dir, "node_modules"), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		needs, reason := nodeModulesNeedsInstall(webDir)
+		needs, reason := NodeModulesNeedsInstall(dir)
 		if !needs {
 			t.Fatal("expected install for empty node_modules")
 		}
@@ -53,34 +53,34 @@ func TestNodeModulesNeedsInstall(t *testing.T) {
 	})
 
 	t.Run("populated without stamp is stale", func(t *testing.T) {
-		webDir := t.TempDir()
-		writeFile(t, filepath.Join(webDir, "bun.lock"), "lock-v1")
-		writeFile(t, filepath.Join(webDir, "node_modules", "pkg", "index.js"), "")
-		needs, _ := nodeModulesNeedsInstall(webDir)
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "bun.lock"), "lock-v1")
+		writeFile(t, filepath.Join(dir, "node_modules", "pkg", "index.js"), "")
+		needs, _ := NodeModulesNeedsInstall(dir)
 		if !needs {
 			t.Fatal("expected install when no stamp recorded")
 		}
 	})
 
 	t.Run("stamp matches lockfile", func(t *testing.T) {
-		webDir := t.TempDir()
-		writeFile(t, filepath.Join(webDir, "bun.lock"), "lock-v1")
-		writeFile(t, filepath.Join(webDir, "node_modules", "pkg", "index.js"), "")
-		writeLockStamp(webDir)
-		needs, reason := nodeModulesNeedsInstall(webDir)
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "bun.lock"), "lock-v1")
+		writeFile(t, filepath.Join(dir, "node_modules", "pkg", "index.js"), "")
+		WriteLockStamp(dir)
+		needs, reason := NodeModulesNeedsInstall(dir)
 		if needs {
 			t.Fatalf("expected no install with matching stamp, got: %q", reason)
 		}
 	})
 
 	t.Run("lockfile changed after stamp", func(t *testing.T) {
-		webDir := t.TempDir()
-		writeFile(t, filepath.Join(webDir, "bun.lock"), "lock-v1")
-		writeFile(t, filepath.Join(webDir, "node_modules", "pkg", "index.js"), "")
-		writeLockStamp(webDir)
-		writeFile(t, filepath.Join(webDir, "bun.lock"), "lock-v2")
-		setMtime(t, filepath.Join(webDir, "bun.lock"), now)
-		needs, _ := nodeModulesNeedsInstall(webDir)
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "bun.lock"), "lock-v1")
+		writeFile(t, filepath.Join(dir, "node_modules", "pkg", "index.js"), "")
+		WriteLockStamp(dir)
+		writeFile(t, filepath.Join(dir, "bun.lock"), "lock-v2")
+		setMtime(t, filepath.Join(dir, "bun.lock"), now)
+		needs, _ := NodeModulesNeedsInstall(dir)
 		if !needs {
 			t.Fatal("expected install after lockfile change")
 		}
@@ -90,25 +90,25 @@ func TestNodeModulesNeedsInstall(t *testing.T) {
 		// Sessions run as different users against the shared node_modules
 		// volume, so the previous stamp may not be writable — only
 		// replaceable via the directory. Simulate with a read-only stamp.
-		webDir := t.TempDir()
-		writeFile(t, filepath.Join(webDir, "bun.lock"), "lock-v2")
-		writeFile(t, filepath.Join(webDir, "node_modules", "pkg", "index.js"), "")
-		stampPath := filepath.Join(webDir, "node_modules", lockStampName)
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "bun.lock"), "lock-v2")
+		writeFile(t, filepath.Join(dir, "node_modules", "pkg", "index.js"), "")
+		stampPath := filepath.Join(dir, "node_modules", lockStampName)
 		writeFile(t, stampPath, "stale-hash")
 		if err := os.Chmod(stampPath, 0o444); err != nil {
 			t.Fatal(err)
 		}
-		writeLockStamp(webDir)
-		needs, reason := nodeModulesNeedsInstall(webDir)
+		WriteLockStamp(dir)
+		needs, reason := NodeModulesNeedsInstall(dir)
 		if needs {
 			t.Fatalf("expected stamp to be replaced despite read-only file, got: %q", reason)
 		}
 	})
 
 	t.Run("no lockfile skips staleness check", func(t *testing.T) {
-		webDir := t.TempDir()
-		writeFile(t, filepath.Join(webDir, "node_modules", "pkg", "index.js"), "")
-		needs, _ := nodeModulesNeedsInstall(webDir)
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "node_modules", "pkg", "index.js"), "")
+		needs, _ := NodeModulesNeedsInstall(dir)
 		if needs {
 			t.Fatal("expected no install without a lockfile to compare")
 		}
@@ -120,7 +120,7 @@ func TestLibNeedsBuild(t *testing.T) {
 	older := old.Add(-time.Hour)
 
 	t.Run("missing package is skipped", func(t *testing.T) {
-		needs, _ := libNeedsBuild(filepath.Join(t.TempDir(), "lib", "nope"))
+		needs, _ := LibNeedsBuild(filepath.Join(t.TempDir(), "lib", "nope"))
 		if needs {
 			t.Fatal("expected missing package to be skipped")
 		}
@@ -129,7 +129,7 @@ func TestLibNeedsBuild(t *testing.T) {
 	t.Run("missing dist", func(t *testing.T) {
 		pkgDir := t.TempDir()
 		writeFile(t, filepath.Join(pkgDir, "src", "index.ts"), "")
-		needs, reason := libNeedsBuild(pkgDir)
+		needs, reason := LibNeedsBuild(pkgDir)
 		if !needs {
 			t.Fatal("expected build for missing dist")
 		}
@@ -147,7 +147,7 @@ func TestLibNeedsBuild(t *testing.T) {
 		setMtime(t, src, older)
 		setMtime(t, filepath.Join(pkgDir, "src"), older)
 		setMtime(t, pkgDir, older)
-		needs, reason := libNeedsBuild(pkgDir)
+		needs, reason := LibNeedsBuild(pkgDir)
 		if needs {
 			t.Fatalf("expected no build when dist is fresh, got: %q", reason)
 		}
@@ -162,7 +162,7 @@ func TestLibNeedsBuild(t *testing.T) {
 		setMtime(t, dist, older)
 		setMtime(t, filepath.Join(pkgDir, "dist"), older)
 		setMtime(t, src, old)
-		needs, _ := libNeedsBuild(pkgDir)
+		needs, _ := LibNeedsBuild(pkgDir)
 		if !needs {
 			t.Fatal("expected build when a source is newer than dist")
 		}
@@ -179,7 +179,7 @@ func TestLibNeedsBuild(t *testing.T) {
 		setMtime(t, src, older)
 		setMtime(t, filepath.Join(pkgDir, "src"), older)
 		setMtime(t, pkgDir, older)
-		needs, reason := libNeedsBuild(pkgDir)
+		needs, reason := LibNeedsBuild(pkgDir)
 		if needs {
 			t.Fatalf("expected node_modules churn to be ignored, got: %q", reason)
 		}

--- a/tools/ods/internal/paths/paths.go
+++ b/tools/ods/internal/paths/paths.go
@@ -104,6 +104,15 @@ func BackendDir() (string, error) {
 	return filepath.Join(root, "backend"), nil
 }
 
+// WebDir returns the web directory relative to the git root.
+func WebDir() (string, error) {
+	root, err := GitRoot()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "web"), nil
+}
+
 // ResolveInBackend resolves one provided path to an absolute path inside the
 // backend directory, or fails loudly. Relative paths are tried against the
 // working directory, the backend directory, and the repository root, so the

--- a/tools/ods/internal/paths/paths_test.go
+++ b/tools/ods/internal/paths/paths_test.go
@@ -17,6 +17,34 @@ func writeFile(t *testing.T, path string) {
 	}
 }
 
+// TestRepoDirs checks the helpers that hang off the git root. The test runs
+// from its own source directory, which is always inside the checkout.
+func TestRepoDirs(t *testing.T) {
+	root, err := GitRoot()
+	if err != nil {
+		t.Fatalf("GitRoot failed: %v", err)
+	}
+	if !filepath.IsAbs(root) {
+		t.Fatalf("GitRoot = %q, want an absolute path", root)
+	}
+
+	backend, err := BackendDir()
+	if err != nil {
+		t.Fatalf("BackendDir failed: %v", err)
+	}
+	if want := filepath.Join(root, "backend"); backend != want {
+		t.Errorf("BackendDir = %q, want %q", backend, want)
+	}
+
+	web, err := WebDir()
+	if err != nil {
+		t.Fatalf("WebDir failed: %v", err)
+	}
+	if want := filepath.Join(root, "web"); web != want {
+		t.Errorf("WebDir = %q, want %q", web, want)
+	}
+}
+
 func TestResolveInBackend(t *testing.T) {
 	// Precondition.
 	// A repository-shaped tree with files inside and outside the backend

--- a/tools/ods/internal/testsuite/testsuite.go
+++ b/tools/ods/internal/testsuite/testsuite.go
@@ -1,7 +1,7 @@
-// Package testsuite maps a suite name or a file path onto the test suite that
-// owns it. The repo holds several suites, each with its own working directory
-// and test runner; this package holds the routing table and the pure logic
-// that picks an entry from it.
+// Package testsuite maps a suite name or a file path onto the test runner that
+// knows how to execute it. The repo has four runners (pytest, jest, playwright,
+// go test) with different working directories and arguments; this package holds
+// the routing table and the pure logic that picks an entry from it.
 package testsuite
 
 import (
@@ -13,6 +13,16 @@ import (
 	"strings"
 )
 
+// Runner identifies the tool that executes a suite.
+type Runner string
+
+const (
+	RunnerPytest     Runner = "pytest"
+	RunnerJest       Runner = "jest"
+	RunnerPlaywright Runner = "playwright"
+	RunnerGo         Runner = "go"
+)
+
 // ErrNoArgs is returned when no suite or path was given.
 var ErrNoArgs = errors.New("no suite or path given")
 
@@ -22,10 +32,23 @@ type Suite struct {
 	Name string
 	// Aliases are alternate names accepted on the command line.
 	Aliases []string
-	// Dir is the suite's directory, relative to the git root. It is the
-	// working directory for the test runner and the prefix used to infer the
-	// suite from a path.
+	// Runner is the tool that executes this suite.
+	Runner Runner
+	// Dir is the working directory for the runner, relative to the git root.
 	Dir string
+	// Target is the suite's root test path, relative to Dir. It is the prefix
+	// used to infer the suite from a path, and the default argument for
+	// pytest unless Default overrides it.
+	Target string
+	// Default overrides Target as the argument used when the caller gives no
+	// path. Set it where the suite root holds more than a plain run should
+	// take on.
+	Default string
+	// Caution is a one-line warning printed before the suite runs. Set it
+	// where a run changes state outside the test process.
+	Caution string
+	// NeedsBackendEnv marks suites that need credentials from .vscode/.env.
+	NeedsBackendEnv bool
 	// DefaultArgs are passed to the runner before any user arguments, so a
 	// user argument for the same option still wins.
 	DefaultArgs []string
@@ -33,27 +56,110 @@ type Suite struct {
 	Short string
 }
 
+// Prefix returns the suite's test path relative to the git root.
+func (s *Suite) Prefix() string {
+	return path(s.Dir, s.Target)
+}
+
+// DefaultTarget returns the path to run when the caller gives no path.
+func (s *Suite) DefaultTarget() string {
+	if s.Default != "" {
+		return s.Default
+	}
+	return s.Target
+}
+
 // suites is the routing table. Order here is the order shown in help.
 var suites = []Suite{
 	{
-		Name: "ods",
-		Dir:  "tools/ods",
+		Name:    "unit",
+		Aliases: []string{"u"},
+		Runner:  RunnerPytest,
+		Dir:     "backend",
+		Target:  "tests/unit",
+		Short:   "Backend unit tests (no services needed)",
+	},
+	{
+		Name:            "external",
+		Aliases:         []string{"edu", "ext"},
+		Runner:          RunnerPytest,
+		Dir:             "backend",
+		Target:          "tests/external_dependency_unit",
+		NeedsBackendEnv: true,
+		// Match CI, which leaves nightly-only tests to the nightly workflow.
+		DefaultArgs: []string{"-m", "not nightly"},
+		Short:       "External dependency unit tests (needs Postgres, Redis, OpenSearch, MinIO)",
+	},
+	{
+		Name:    "integration",
+		Aliases: []string{"int"},
+		Runner:  RunnerPytest,
+		Dir:     "backend",
+		Target:  "tests/integration",
+		// A bare run covers what CI shards. The sibling directories need a
+		// setup of their own — multitenant_tests a multi-tenant deployment,
+		// connector_job_tests connector credentials — so they are reachable
+		// by path but are not part of a plain `ods test integration`.
+		Default:         "tests/integration/tests",
+		NeedsBackendEnv: true,
+		Caution:         "these tests call reset_all(), which wipes Postgres and the file store for this project",
+		Short:           "Backend integration tests (needs a full Onyx deployment)",
+	},
+	{
+		Name:    "web",
+		Aliases: []string{"jest"},
+		Runner:  RunnerJest,
+		Dir:     "web",
+		Short:   "Web unit and component tests (jest)",
+	},
+	{
+		Name:    "e2e",
+		Aliases: []string{"playwright", "pw"},
+		Runner:  RunnerPlaywright,
+		Dir:     "web",
+		Target:  "tests/e2e",
+		Short:   "Web end-to-end tests (needs a full Onyx deployment)",
+	},
+	{
+		Name:   "mobile",
+		Runner: RunnerJest,
+		Dir:    "mobile",
+		Short:  "Mobile tests (jest-expo)",
+	},
+	{
+		Name:    "ods",
+		Runner:  RunnerGo,
+		Dir:     "tools/ods",
+		Default: "./...",
 		// -race matches pr-golang-tests.yml, which runs every Go module.
 		DefaultArgs: []string{"-race"},
-		Short:       "Tests for this tool",
+		Short:       "Tests for this tool (go)",
 	},
 	{
 		Name:        "cli",
+		Runner:      RunnerGo,
 		Dir:         "cli",
+		Default:     "./...",
 		DefaultArgs: []string{"-race"},
-		Short:       "Onyx CLI tests",
+		Short:       "Onyx CLI tests (go)",
 	},
 	{
 		Name:        "terraform",
 		Aliases:     []string{"tf"},
+		Runner:      RunnerGo,
 		Dir:         "terraform-provider-onyx",
+		Default:     "./...",
 		DefaultArgs: []string{"-race"},
-		Short:       "Terraform provider tests",
+		Short:       "Terraform provider tests (go)",
+	},
+	{
+		Name:            "backend",
+		Aliases:         []string{"py"},
+		Runner:          RunnerPytest,
+		Dir:             "backend",
+		Target:          "tests",
+		NeedsBackendEnv: true,
+		Short:           "Any other backend/tests path (daily, regression, api, ...)",
 	},
 }
 
@@ -94,7 +200,7 @@ func byName(name string) *Suite {
 // remaining arguments pass through untouched.
 //
 // root is the git root. cwd is the caller's working directory, so that a path
-// typed relative to it (for example inside tools/ods/) resolves correctly.
+// typed relative to it (for example inside backend/) resolves correctly.
 func Resolve(root, cwd string, args []string) (*Suite, []string, error) {
 	if len(args) == 0 {
 		return nil, nil, ErrNoArgs
@@ -129,11 +235,15 @@ func Resolve(root, cwd string, args []string) (*Suite, []string, error) {
 	return suite, append(runnerTarget(root, suite, path(target)), rest...), nil
 }
 
-// runnerTarget shapes a suite-relative path into what the suite's runner
-// accepts. go test takes packages rather than files, so a file becomes the
-// directory that holds it, and a "<file>::<TestName>" node id becomes a -run
-// filter.
+// runnerTarget shapes a suite-relative path into what the runner accepts.
+// pytest, jest, and playwright all take paths. go test takes packages, so a
+// file becomes the directory that holds it, and a node id becomes a -run
+// filter, which keeps "<file>::<test>" working across every suite.
 func runnerTarget(root string, suite *Suite, rel string) []string {
+	if suite.Runner != RunnerGo {
+		return []string{rel}
+	}
+
 	file := stripNodeID(rel)
 	pkg := goPackage(root, suite, file)
 	if name := strings.TrimPrefix(rel[len(file):], "::"); name != "" {
@@ -159,9 +269,9 @@ func goPackage(root string, suite *Suite, rel string) string {
 // suite-relative arguments returned by Resolve, where a target always carries a
 // path separator or a node id.
 //
-// Callers need this because a runner given no target may cover less than the
-// whole suite, so a bare run needs the suite's catch-all target — but only
-// when the caller has not already picked one.
+// Callers need this because pytest with no target collects from its working
+// directory. For a backend suite that is the whole of backend/, so
+// `ods test unit -k foo` would reach every backend test, integration included.
 func HasTarget(args []string) bool {
 	for _, arg := range args {
 		if looksLikePath(arg) {
@@ -173,7 +283,8 @@ func HasTarget(args []string) bool {
 
 // relocate rewrites arguments that name an existing path into paths relative
 // to the suite's working directory, which is where the runner starts.
-// Everything else — flags and their values — passes through untouched.
+// Everything else — flags, their values, playwright test-name filters — passes
+// through untouched.
 func relocate(root, cwd string, suite *Suite, args []string) []string {
 	out := make([]string, 0, len(args))
 	for _, arg := range args {
@@ -189,8 +300,8 @@ func relocateArg(root, cwd string, suite *Suite, arg string) []string {
 	repoPath, ok := repoRelative(root, cwd, arg)
 	if !ok {
 		// The path may still be relative to the suite directory, which is
-		// where the runner starts. go test needs a "./" prefix, so shape it
-		// here.
+		// where the runner starts. pytest and jest read it that way on their
+		// own; go test needs a "./" prefix, so shape it here.
 		if rel, ok := suiteRelative(root, suite, arg); ok {
 			return runnerTarget(root, suite, rel)
 		}
@@ -221,13 +332,13 @@ func suiteRelative(root string, suite *Suite, arg string) (string, bool) {
 	return path(filePart) + arg[len(filePart):], true
 }
 
-// suiteForPath returns the suite whose directory is the longest match for a
-// repo-relative path. Longest wins so that a suite nested inside another
-// resolves to the inner one, whatever the table holds.
+// suiteForPath returns the suite whose prefix is the longest match for a
+// repo-relative path. Longest wins so that web/tests/e2e resolves to the e2e
+// suite rather than to web.
 func suiteForPath(repoPath string) *Suite {
 	matches := make([]*Suite, 0, 2)
 	for i := range suites {
-		if underPrefix(repoPath, suites[i].Dir) {
+		if underPrefix(repoPath, suites[i].Prefix()) {
 			matches = append(matches, &suites[i])
 		}
 	}
@@ -235,7 +346,7 @@ func suiteForPath(repoPath string) *Suite {
 		return nil
 	}
 	sort.SliceStable(matches, func(a, b int) bool {
-		return len(matches[a].Dir) > len(matches[b].Dir)
+		return len(matches[a].Prefix()) > len(matches[b].Prefix())
 	})
 	return matches[0]
 }
@@ -248,8 +359,8 @@ func underPrefix(repoPath, prefix string) bool {
 // repoRelative turns a user-supplied path into a slash-separated path relative
 // to the git root, reporting false when it does not point at anything real.
 // The path is tried against the working directory first, then against the git
-// root, so both "internal/testsuite" from inside tools/ods/ and
-// "tools/ods/internal/testsuite" from anywhere work.
+// root, so both "tests/unit" from inside backend/ and "backend/tests/unit"
+// from anywhere work.
 func repoRelative(root, cwd, arg string) (string, bool) {
 	filePart := stripNodeID(arg)
 	if filePart == "" {
@@ -282,13 +393,13 @@ func repoRelative(root, cwd, arg string) (string, bool) {
 }
 
 // looksLikePath reports whether an argument is shaped like a path worth
-// rewriting: it has more than one segment, or carries a node id.
+// rewriting: it has more than one segment, or carries a pytest node id.
 //
 // A single bare word is deliberately excluded even when a file by that name
-// exists. Such a word is far more often a flag value (`-run TestFoo`) than a
-// target, and when it really is a target it is already relative to the
-// caller's directory, so rewriting it would only change a path that already
-// works.
+// exists. Such a word is far more often a flag value (`-k web`, a playwright
+// test-name filter) than a target, and when it really is a target it is
+// already relative to the caller's directory, so rewriting it would only
+// change a path that already works.
 func looksLikePath(arg string) bool {
 	if strings.HasPrefix(arg, "-") {
 		return false
@@ -296,8 +407,8 @@ func looksLikePath(arg string) bool {
 	return strings.ContainsAny(arg, `/\`) || strings.Contains(arg, "::")
 }
 
-// stripNodeID drops the trailing "::TestName" of a node id, leaving the part
-// that exists on disk.
+// stripNodeID drops the trailing "::test_name" of a pytest node id, leaving
+// the part that exists on disk.
 func stripNodeID(arg string) string {
 	if idx := strings.Index(arg, "::"); idx >= 0 {
 		return arg[:idx]
@@ -306,7 +417,7 @@ func stripNodeID(arg string) string {
 }
 
 // path joins segments and normalizes to forward slashes, which is what both
-// go test and the prefix table expect.
+// the runners and the prefix table expect.
 func path(segments ...string) string {
 	joined := filepath.Join(segments...)
 	return filepath.ToSlash(joined)

--- a/tools/ods/internal/testsuite/testsuite_test.go
+++ b/tools/ods/internal/testsuite/testsuite_test.go
@@ -31,10 +31,25 @@ func TestResolveByName(t *testing.T) {
 		arg  string
 		want string
 	}{
+		{"unit", "unit"},
+		{"u", "unit"},
+		{"external", "external"},
+		{"edu", "external"},
+		{"ext", "external"},
+		{"integration", "integration"},
+		{"int", "integration"},
+		{"web", "web"},
+		{"jest", "web"},
+		{"e2e", "e2e"},
+		{"playwright", "e2e"},
+		{"pw", "e2e"},
+		{"mobile", "mobile"},
 		{"ods", "ods"},
 		{"cli", "cli"},
 		{"terraform", "terraform"},
 		{"tf", "terraform"},
+		{"backend", "backend"},
+		{"py", "backend"},
 	}
 
 	root := t.TempDir()
@@ -54,121 +69,103 @@ func TestResolveByName(t *testing.T) {
 	}
 }
 
-// go test takes packages, not files, so targets are shaped into "./..."
-// patterns and node ids into -run filters.
-func TestResolveGoTargets(t *testing.T) {
-	root := newRepo(t,
-		"tools/ods/main.go",
-		"tools/ods/cmd/env_test.go",
-		"tools/ods/internal/testsuite/testsuite_test.go",
-		"cli/internal/tui/tui_test.go",
-		"terraform-provider-onyx/internal/provider/provider_test.go",
-	)
-
+func TestResolveByPath(t *testing.T) {
 	cases := []struct {
-		name      string
-		args      []string
-		wantSuite string
-		want      []string
+		name       string
+		file       string
+		arg        string
+		wantSuite  string
+		wantTarget string
 	}{
 		{
-			name:      "package directory",
-			args:      []string{"tools/ods/internal/testsuite"},
-			wantSuite: "ods",
-			want:      []string{"./internal/testsuite"},
+			name:       "backend unit file",
+			file:       "backend/tests/unit/onyx/test_foo.py",
+			arg:        "backend/tests/unit/onyx/test_foo.py",
+			wantSuite:  "unit",
+			wantTarget: "tests/unit/onyx/test_foo.py",
 		},
 		{
-			name:      "file runs its package",
-			args:      []string{"tools/ods/internal/testsuite/testsuite_test.go"},
-			wantSuite: "ods",
-			want:      []string{"./internal/testsuite"},
+			name:       "backend unit directory",
+			file:       "backend/tests/unit/onyx/test_foo.py",
+			arg:        "backend/tests/unit",
+			wantSuite:  "unit",
+			wantTarget: "tests/unit",
 		},
 		{
-			name:      "module root",
-			args:      []string{"tools/ods"},
-			wantSuite: "ods",
-			want:      []string{"./..."},
+			name:       "external dependency unit",
+			file:       "backend/tests/external_dependency_unit/db/test_bar.py",
+			arg:        "backend/tests/external_dependency_unit/db/test_bar.py",
+			wantSuite:  "external",
+			wantTarget: "tests/external_dependency_unit/db/test_bar.py",
 		},
 		{
-			name:      "node id becomes a run filter",
-			args:      []string{"tools/ods/cmd/env_test.go::TestGenerateEnv"},
-			wantSuite: "ods",
-			want:      []string{"./cmd", "-run", "^TestGenerateEnv$"},
+			name:       "integration",
+			file:       "backend/tests/integration/tests/test_baz.py",
+			arg:        "backend/tests/integration/tests/test_baz.py",
+			wantSuite:  "integration",
+			wantTarget: "tests/integration/tests/test_baz.py",
 		},
 		{
-			name:      "path after a suite name",
-			args:      []string{"ods", "tools/ods/cmd"},
-			wantSuite: "ods",
-			want:      []string{"./cmd"},
+			name:       "other backend path falls back to the backend suite",
+			file:       "backend/tests/daily/connectors/test_daily.py",
+			arg:        "backend/tests/daily/connectors/test_daily.py",
+			wantSuite:  "backend",
+			wantTarget: "tests/daily/connectors/test_daily.py",
 		},
 		{
-			name:      "a second module",
-			args:      []string{"cli/internal/tui"},
-			wantSuite: "cli",
-			want:      []string{"./internal/tui"},
+			name:       "web source test",
+			file:       "web/src/lib/foo.test.ts",
+			arg:        "web/src/lib/foo.test.ts",
+			wantSuite:  "web",
+			wantTarget: "src/lib/foo.test.ts",
 		},
 		{
-			name:      "a third module",
-			args:      []string{"terraform-provider-onyx/internal/provider"},
-			wantSuite: "terraform",
-			want:      []string{"./internal/provider"},
+			// The case a plain prefix map gets wrong: web/tests/e2e is also
+			// under web, and the longer prefix has to win.
+			name:       "e2e spec beats the web suite",
+			file:       "web/tests/e2e/chat.spec.ts",
+			arg:        "web/tests/e2e/chat.spec.ts",
+			wantSuite:  "e2e",
+			wantTarget: "tests/e2e/chat.spec.ts",
 		},
 		{
-			name:      "path relative to the module",
-			args:      []string{"ods", "internal/testsuite"},
-			wantSuite: "ods",
-			want:      []string{"./internal/testsuite"},
-		},
-		{
-			name:      "node id relative to the module",
-			args:      []string{"cli", "internal/tui/tui_test.go::TestChat"},
-			wantSuite: "cli",
-			want:      []string{"./internal/tui", "-run", "^TestChat$"},
-		},
-		{
-			name:      "flags pass through",
-			args:      []string{"ods", "-run", "TestResolve", "-v"},
-			wantSuite: "ods",
-			want:      []string{"-run", "TestResolve", "-v"},
-		},
-		{
-			// A path outside the named suite is left alone, so go test
-			// reports it rather than us silently pointing somewhere else.
-			name:      "path outside the suite is left for the runner to report",
-			args:      []string{"ods", "cli/internal/tui"},
-			wantSuite: "ods",
-			want:      []string{"cli/internal/tui"},
+			name:       "mobile test",
+			file:       "mobile/src/components/__tests__/foo.test.tsx",
+			arg:        "mobile/src/components/__tests__/foo.test.tsx",
+			wantSuite:  "mobile",
+			wantTarget: "src/components/__tests__/foo.test.tsx",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			suite, args, err := Resolve(root, root, tc.args)
+			root := newRepo(t, tc.file)
+			suite, rest, err := Resolve(root, root, []string{tc.arg})
 			if err != nil {
-				t.Fatalf("Resolve(%v) failed: %v", tc.args, err)
+				t.Fatalf("Resolve(%q) failed: %v", tc.arg, err)
 			}
 			if suite.Name != tc.wantSuite {
 				t.Fatalf("suite = %q, want %q", suite.Name, tc.wantSuite)
 			}
-			if !reflect.DeepEqual(args, tc.want) {
-				t.Errorf("args = %v, want %v", args, tc.want)
+			if !reflect.DeepEqual(rest, []string{tc.wantTarget}) {
+				t.Fatalf("args = %v, want [%q]", rest, tc.wantTarget)
 			}
 		})
 	}
 }
 
 func TestResolvePathRelativeToWorkingDirectory(t *testing.T) {
-	root := newRepo(t, "tools/ods/internal/testsuite/testsuite_test.go")
-	cwd := filepath.Join(root, "tools", "ods")
+	root := newRepo(t, "backend/tests/unit/onyx/test_foo.py")
+	cwd := filepath.Join(root, "backend")
 
-	suite, rest, err := Resolve(root, cwd, []string{"internal/testsuite"})
+	suite, rest, err := Resolve(root, cwd, []string{"tests/unit/onyx/test_foo.py"})
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
-	if suite.Name != "ods" {
-		t.Fatalf("suite = %q, want ods", suite.Name)
+	if suite.Name != "unit" {
+		t.Fatalf("suite = %q, want unit", suite.Name)
 	}
-	if !reflect.DeepEqual(rest, []string{"./internal/testsuite"}) {
+	if !reflect.DeepEqual(rest, []string{"tests/unit/onyx/test_foo.py"}) {
 		t.Fatalf("args = %v", rest)
 	}
 }
@@ -177,17 +174,118 @@ func TestResolvePathRelativeToWorkingDirectory(t *testing.T) {
 // to be anchored even though the same word would be left alone later in the
 // argument list.
 func TestResolveBareFilenameAsSelector(t *testing.T) {
-	root := newRepo(t, "tools/ods/internal/testsuite/testsuite_test.go")
-	cwd := filepath.Join(root, "tools", "ods", "internal", "testsuite")
+	root := newRepo(t, "backend/tests/unit/onyx/test_foo.py")
+	cwd := filepath.Join(root, "backend", "tests", "unit", "onyx")
 
-	suite, rest, err := Resolve(root, cwd, []string{"testsuite_test.go"})
+	suite, rest, err := Resolve(root, cwd, []string{"test_foo.py"})
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
-	if suite.Name != "ods" {
-		t.Fatalf("suite = %q, want ods", suite.Name)
+	if suite.Name != "unit" {
+		t.Fatalf("suite = %q, want unit", suite.Name)
 	}
-	if !reflect.DeepEqual(rest, []string{"./internal/testsuite"}) {
+	if !reflect.DeepEqual(rest, []string{"tests/unit/onyx/test_foo.py"}) {
+		t.Fatalf("args = %v", rest)
+	}
+}
+
+func TestResolveKeepsPytestNodeID(t *testing.T) {
+	root := newRepo(t, "backend/tests/unit/onyx/test_foo.py")
+
+	suite, rest, err := Resolve(root, root, []string{"backend/tests/unit/onyx/test_foo.py::test_bar"})
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if suite.Name != "unit" {
+		t.Fatalf("suite = %q, want unit", suite.Name)
+	}
+	if !reflect.DeepEqual(rest, []string{"tests/unit/onyx/test_foo.py::test_bar"}) {
+		t.Fatalf("args = %v", rest)
+	}
+}
+
+// A named suite followed by a path is the form most people reach for, and the
+// path still has to be rewritten relative to the suite directory or the runner
+// cannot find it.
+func TestResolveRewritesPathsAfterASuiteName(t *testing.T) {
+	root := newRepo(t,
+		"backend/tests/unit/onyx/test_foo.py",
+		"web/src/lib/foo.test.ts",
+	)
+
+	t.Run("pytest", func(t *testing.T) {
+		suite, rest, err := Resolve(root, root, []string{"unit", "backend/tests/unit/onyx/test_foo.py"})
+		if err != nil {
+			t.Fatalf("Resolve failed: %v", err)
+		}
+		if suite.Name != "unit" {
+			t.Fatalf("suite = %q, want unit", suite.Name)
+		}
+		if !reflect.DeepEqual(rest, []string{"tests/unit/onyx/test_foo.py"}) {
+			t.Fatalf("args = %v", rest)
+		}
+	})
+
+	t.Run("jest", func(t *testing.T) {
+		suite, rest, err := Resolve(root, root, []string{"web", "web/src/lib/foo.test.ts"})
+		if err != nil {
+			t.Fatalf("Resolve failed: %v", err)
+		}
+		if !reflect.DeepEqual(rest, []string{"src/lib/foo.test.ts"}) {
+			t.Fatalf("args = %v", rest)
+		}
+		_ = suite
+	})
+
+	t.Run("flag values are left alone", func(t *testing.T) {
+		_, rest, err := Resolve(root, root, []string{"unit", "-k", "web", "--tb=short"})
+		if err != nil {
+			t.Fatalf("Resolve failed: %v", err)
+		}
+		// "web" is a suite name and a real directory, but as a -k value it
+		// must survive untouched.
+		if !reflect.DeepEqual(rest, []string{"-k", "web", "--tb=short"}) {
+			t.Fatalf("args = %v", rest)
+		}
+	})
+
+	t.Run("several paths after a suite name", func(t *testing.T) {
+		_, rest, err := Resolve(root, root, []string{
+			"unit",
+			"backend/tests/unit/onyx/test_foo.py",
+			"backend/tests/unit/onyx",
+		})
+		if err != nil {
+			t.Fatalf("Resolve failed: %v", err)
+		}
+		want := []string{"tests/unit/onyx/test_foo.py", "tests/unit/onyx"}
+		if !reflect.DeepEqual(rest, want) {
+			t.Fatalf("args = %v, want %v", rest, want)
+		}
+	})
+
+	t.Run("path outside the suite is left for the runner to report", func(t *testing.T) {
+		_, rest, err := Resolve(root, root, []string{"unit", "web/src/lib/foo.test.ts"})
+		if err != nil {
+			t.Fatalf("Resolve failed: %v", err)
+		}
+		if !reflect.DeepEqual(rest, []string{"web/src/lib/foo.test.ts"}) {
+			t.Fatalf("args = %v", rest)
+		}
+	})
+}
+
+func TestResolvePassesThroughRemainingArgs(t *testing.T) {
+	root := t.TempDir()
+
+	suite, rest, err := Resolve(root, root, []string{"unit", "-k", "some_name", "--count=3"})
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if suite.Name != "unit" {
+		t.Fatalf("suite = %q, want unit", suite.Name)
+	}
+	if !reflect.DeepEqual(rest, []string{"-k", "some_name", "--count=3"}) {
 		t.Fatalf("args = %v", rest)
 	}
 }
@@ -216,12 +314,120 @@ func TestResolveErrors(t *testing.T) {
 	})
 
 	t.Run("path outside every suite", func(t *testing.T) {
-		root := newRepo(t, "backend/tests/unit/test_foo.py")
-		_, _, err := Resolve(root, root, []string{"backend/tests/unit/test_foo.py"})
+		root := newRepo(t, "docs/readme.md")
+		_, _, err := Resolve(root, root, []string{"docs/readme.md"})
 		if err == nil {
 			t.Fatal("expected an error for a path no suite covers")
 		}
 	})
+}
+
+func TestSuitePrefixes(t *testing.T) {
+	want := map[string]string{
+		"unit":        "backend/tests/unit",
+		"external":    "backend/tests/external_dependency_unit",
+		"integration": "backend/tests/integration",
+		"web":         "web",
+		"e2e":         "web/tests/e2e",
+		"mobile":      "mobile",
+		"ods":         "tools/ods",
+		"cli":         "cli",
+		"terraform":   "terraform-provider-onyx",
+		"backend":     "backend/tests",
+	}
+	for _, suite := range All() {
+		if got := suite.Prefix(); got != want[suite.Name] {
+			t.Fatalf("%s prefix = %q, want %q", suite.Name, got, want[suite.Name])
+		}
+	}
+}
+
+// go test takes packages, not files, so a Go suite shapes its targets
+// differently from the path-based runners.
+func TestResolveGoTargets(t *testing.T) {
+	root := newRepo(t,
+		"tools/ods/main.go",
+		"tools/ods/cmd/web_test.go",
+		"tools/ods/internal/testsuite/testsuite_test.go",
+		"cli/internal/tui/tui_test.go",
+	)
+
+	cases := []struct {
+		name      string
+		args      []string
+		wantSuite string
+		want      []string
+	}{
+		{
+			name:      "package directory",
+			args:      []string{"tools/ods/internal/testsuite"},
+			wantSuite: "ods",
+			want:      []string{"./internal/testsuite"},
+		},
+		{
+			name:      "file runs its package",
+			args:      []string{"tools/ods/internal/testsuite/testsuite_test.go"},
+			wantSuite: "ods",
+			want:      []string{"./internal/testsuite"},
+		},
+		{
+			name:      "module root",
+			args:      []string{"tools/ods"},
+			wantSuite: "ods",
+			want:      []string{"./..."},
+		},
+		{
+			name:      "node id becomes a run filter",
+			args:      []string{"tools/ods/cmd/web_test.go::TestWebDir"},
+			wantSuite: "ods",
+			want:      []string{"./cmd", "-run", "^TestWebDir$"},
+		},
+		{
+			name:      "path after a suite name",
+			args:      []string{"ods", "tools/ods/cmd"},
+			wantSuite: "ods",
+			want:      []string{"./cmd"},
+		},
+		{
+			name:      "a second module",
+			args:      []string{"cli/internal/tui"},
+			wantSuite: "cli",
+			want:      []string{"./internal/tui"},
+		},
+		{
+			name:      "path relative to the module",
+			args:      []string{"ods", "internal/testsuite"},
+			wantSuite: "ods",
+			want:      []string{"./internal/testsuite"},
+		},
+		{
+			name:      "node id relative to the module",
+			args:      []string{"cli", "internal/tui/tui_test.go::TestChat"},
+			wantSuite: "cli",
+			want:      []string{"./internal/tui", "-run", "^TestChat$"},
+		},
+		{
+			name:      "flags pass through",
+			args:      []string{"ods", "-run", "TestResolve", "-v"},
+			wantSuite: "ods",
+			want:      []string{"-run", "TestResolve", "-v"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			suite, args, err := Resolve(root, root, tc.args)
+			if err != nil {
+				t.Fatalf("Resolve(%v) failed: %v", tc.args, err)
+			}
+			if suite.Name != tc.wantSuite {
+				t.Fatalf("suite = %q, want %q", suite.Name, tc.wantSuite)
+			}
+			if !reflect.DeepEqual(args, tc.want) {
+				t.Errorf("args = %v, want %v", args, tc.want)
+			}
+		})
+	}
 }
 
 func TestHasTarget(t *testing.T) {
@@ -231,12 +437,12 @@ func TestHasTarget(t *testing.T) {
 		want bool
 	}{
 		{name: "no args", args: nil, want: false},
-		{name: "flags only", args: []string{"-run", "TestFoo"}, want: false},
-		{name: "long flag only", args: []string{"-v"}, want: false},
-		{name: "package pattern", args: []string{"./..."}, want: true},
-		{name: "package directory", args: []string{"./cmd"}, want: true},
-		{name: "run filter after a package", args: []string{"./cmd", "-run", "^TestFoo$"}, want: true},
-		{name: "target after a flag", args: []string{"-v", "./internal/testsuite"}, want: true},
+		{name: "flags only", args: []string{"-k", "web"}, want: false},
+		{name: "long flag only", args: []string{"--collect-only"}, want: false},
+		{name: "directory", args: []string{"tests/unit/onyx"}, want: true},
+		{name: "file", args: []string{"tests/unit/onyx/test_foo.py"}, want: true},
+		{name: "node id", args: []string{"tests/unit/test_foo.py::test_bar"}, want: true},
+		{name: "target after a flag", args: []string{"-x", "tests/unit/onyx"}, want: true},
 	}
 
 	for _, tc := range tests {
@@ -245,5 +451,45 @@ func TestHasTarget(t *testing.T) {
 				t.Errorf("HasTarget(%v) = %v, want %v", tc.args, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestSuiteDefaultTargets(t *testing.T) {
+	want := map[string]string{
+		"unit":     "tests/unit",
+		"external": "tests/external_dependency_unit",
+		// Narrower than the prefix: the sibling directories under
+		// tests/integration need a setup a plain run does not provide.
+		"integration": "tests/integration/tests",
+		"web":         "",
+		"e2e":         "tests/e2e",
+		"mobile":      "",
+		"ods":         "./...",
+		"cli":         "./...",
+		"terraform":   "./...",
+		"backend":     "tests",
+	}
+	for _, suite := range All() {
+		if got := suite.DefaultTarget(); got != want[suite.Name] {
+			t.Errorf("%s default target = %q, want %q", suite.Name, got, want[suite.Name])
+		}
+	}
+}
+
+// A narrowed default must not narrow inference: a path under a sibling
+// directory still resolves to the suite that owns it.
+func TestResolveReachesPathsOutsideTheDefaultTarget(t *testing.T) {
+	root := newRepo(t, "backend/tests/integration/multitenant_tests/test_tenant.py")
+
+	suite, args, err := Resolve(root, root, []string{"backend/tests/integration/multitenant_tests/test_tenant.py"})
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if suite.Name != "integration" {
+		t.Fatalf("suite = %q, want integration", suite.Name)
+	}
+	want := []string{"tests/integration/multitenant_tests/test_tenant.py"}
+	if len(args) != 1 || args[0] != want[0] {
+		t.Errorf("args = %v, want %v", args, want)
 	}
 }

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -685,3 +685,7 @@ export function useToast() { ... }
 - Run an e2e test with the repo-pinned Playwright: `cd web && bun run playwright <TEST_NAME>`
   (the `playwright` script expands to `playwright test`; avoid `bunx`/`npx`, which can silently
   fetch an unpinned version).
+- `ods test` runs either suite from any directory and keeps the pinned Playwright:
+  `ods test web` / `ods test e2e <TEST_NAME>`. A path picks the suite for you, so
+  `ods test web/src/lib/foo.test.ts` runs jest and `ods test web/tests/e2e/chat.spec.ts` runs
+  Playwright. Arguments after the first go to the runner.


### PR DESCRIPTION
## What

`ods test <suite|path> [args...]` — one entry point for every test suite in the repo.

Running tests today means knowing which of five runners applies, each with its own working
directory, env file, and argument shape:

```bash
uv run pytest -xv backend/tests/unit
uv run --env-file .vscode/.env pytest backend/tests/external_dependency_unit
cd web && bun run test
cd web && bun run playwright <TEST_NAME>
cd mobile && bunx jest
cd tools/ods && go test -race ./...
```

All of the above become:

```bash
ods test unit
ods test external
ods test web
ods test e2e <TEST_NAME>
ods test mobile
ods test ods
```

| Suite | Aliases | Runner | Needs services |
| --- | --- | --- | --- |
| `unit` | `u` | pytest | no |
| `external` | `edu`, `ext` | pytest | Postgres, Redis, OpenSearch, MinIO |
| `integration` | `int` | pytest | full deployment |
| `web` | `jest` | jest | no |
| `e2e` | `playwright`, `pw` | playwright | full deployment |
| `mobile` | | jest-expo | no |
| `ods` | | go test | no |
| `cli` | | go test | no |
| `terraform` | `tf` | go test | no |
| `backend` | `py` | pytest | any other `backend/tests` path |

## Path dispatch

The first argument can be a path instead of a suite name, so a file goes straight from an editor
to a run. Paths are rewritten relative to the runner's working directory, and longest-prefix
matching keeps `web/tests/e2e` on playwright rather than jest:

```bash
ods test backend/tests/unit/onyx/utils/test_vespa_tasks.py::test_monitor
ods test web/src/lib/clipboard.test.ts      # jest
ods test web/tests/e2e/chat.spec.ts         # playwright
ods test tools/ods/internal/testsuite       # go test
```

A path can be relative to the caller's directory, to the repo root, or to the suite directory, so
`ods test unit tests/unit/onyx` and `ods test ods internal/testsuite` both work from anywhere.

Everything after the first argument reaches the runner untouched (`-k`, `-x`, `--watch`,
`--count`). A `--` separator is accepted anywhere and dropped, since no runner we wrap wants a
literal one.

## Go suites

`ods`, `cli`, and `terraform` cover the repo's three Go modules. Each runs `go test -race`, which
matches what `pr-golang-tests.yml` already does for every `go.mod` it finds.

`go test` takes packages, not files, so a file argument runs the package that holds it. A pytest
style node id becomes a `-run` filter, which keeps one syntax across every suite:

```bash
ods test cli/internal/tui/viewport_test.go::TestAddUserMessage
# → cd cli && go test -race ./internal/tui -run ^TestAddUserMessage$
```

## pytest always gets a target

`backend/pytest.ini` sets no `testpaths`. With no positional target, pytest collects from its
working directory, which for a backend suite is all of `backend/`. The first version of this
command only supplied the suite's target when there were no other arguments, so
`ods test unit -k some_name` collected every backend test — a bare collection over `backend/`
does not finish inside a 10 minute timeout, and a matching `-k` could have reached the
integration suite.

`ods test` now always supplies the target, before the user's arguments so a repeated option still
wins. `ods test unit -k test_url_ssrf` collects 8379 and selects 63, in seconds.

## Integration default matches CI

`ods test integration` runs `backend/tests/integration/tests`, the set `pr-integration-tests.yml`
shards. The sibling directories need a setup of their own — `multitenant_tests` a multi-tenant
deployment, `connector_job_tests` connector credentials — so they stay reachable by path but are
not part of a plain run:

```bash
ods test backend/tests/integration/multitenant_tests
```

These tests call `reset_all()`, which wipes Postgres and the file store for the current project.
That is not new, but it was not written down anywhere. It is now in the command help, the README,
`backend/AGENTS.md`, and a warning line printed before the suite runs.

## Helpers moved out of cmd

`ods test` needed three groups of helpers that `cmd/backend.go` and `cmd/web.go` kept for
themselves. Each got a package, so a command file holds only its own flags and wiring:

| Package | Holds | Used by |
| --- | --- | --- |
| `internal/childproc` | runs a wrapped tool, passes its exit code up | `backend`, `web`, `test` |
| `internal/backendenv` | creates, reads, and merges `.vscode/.env`, plus the EE defaults | `backend`, `test` |
| `internal/bunpkg` | reports whether `node_modules` or a workspace library build is stale | `web`, `desktop`, `test` |

`bunpkg` is named for bun rather than for web because `ods desktop` asks the same question about
the root `node_modules`. `backendenv` returns errors instead of calling `log.Fatal`, which is what
lets it have tests. `paths.WebDir` joins `paths.BackendDir`, replacing a private copy in
`cmd/web.go`, which drops from 315 lines to 169.

A failing suite still exits non-zero without reprinting the runner's stderr.

## Notes

- Backend suites run from `backend/` so `backend/pytest.ini` applies, and reuse the `.vscode/.env`
  handling `ods backend` already has — including creating it from the template on first use.
  `external` defaults to `-m "not nightly"`, matching CI.
- Web suites reuse the dependency-staleness and workspace-library checks from `ods web`.
- `ods coverage` is deliberately not here. The backend has no coverage tooling at all today — no
  `pytest-cov`, no `.coveragerc`, no `[tool.coverage]` — so it is a follow-up that adds that
  infrastructure rather than a flag on this command.

## Testing

Dispatch logic is table-driven unit tested in `internal/testsuite`, covering suite names and
aliases, path inference for each suite, the `web` vs `web/tests/e2e` case, pytest node ids, paths
resolved relative to the caller's directory, argument passthrough, each suite's default target,
paths outside that default target, whether a target is already present, and the go package and
`-run` shaping.

Every suite was also run live, plus exit-code propagation:

```
ods test unit backend/tests/unit/onyx/utils        → 365 passed, exit 0
ods test unit -k test_url_ssrf                     → 8379 collected, 63 selected
ods test <file>::<test>                            → 1 passed
ods test web/src/lib/clipboard.test.ts             → 4 passed
ods test e2e --list                                → lists specs
ods test mobile --listTests                        → lists specs (installed node_modules first)
ods test ods internal/testsuite                    → go test -race ./internal/testsuite
ods test cli/internal/tui/viewport_test.go::Test…  → go test -race ./internal/tui -run ^…$
ods test tf                                        → ok, acceptance tests skip without TF_ACC
a failing test                                     → exit 1, printed once
```

`go test -race ./...` passes for the new packages. `cmd/web_test.go` moved to `internal/bunpkg` unchanged apart from the names; `internal/backendenv` is new coverage of the env template copy, the .env parse, and shell-wins merging. Pre-existing failures in `cmd`
(`TestReleaseCloud_pushFailureRollsBackLocalTag`) and `internal/git` reproduce unchanged at `main`
in this environment: they build fixture commits, and this checkout has `commit.gpgsign=true` with
no signing key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ods test` as a single entry point for all repo test suites (pytest, jest, Playwright, and Go). This replaces runner-specific commands with one CLI that routes by suite name or path and sets safe defaults (prevents full-backend pytest collection; narrows integration to CI’s shard set with a wipe-data warning).

- Path/suite routing via `tools/ods/internal/testsuite`: longest-prefix keeps `web/tests/e2e` on Playwright; paths resolve from CWD, repo root, or the suite dir; a bare `--` is dropped.
- Pytest: always supplies the suite target before user args; `integration` defaults to `backend/tests/integration/tests`; `--parallel` enables `pytest-xdist`; suites that need credentials read `.vscode/.env` (created on first use); EE on by default (`--no-ee` disables).
- Web/mobile: web keeps pinned Playwright via `bun run`; dependency/workspace-lib freshness checks are shared in `internal/bunpkg`; mobile installs `mobile/node_modules` if missing.
- Go: `ods`, `cli`, and `terraform` suites run `go test -race`; file targets map to their package; `<file>::<TestName>` becomes `-run ^<TestName>$`.
- Shared process/env helpers extracted to `internal` packages and reused: `internal/backendenv` (.env creation/merge + EE defaults), `internal/bunpkg` (node_modules and workspace lib staleness), `internal/childproc` (preserve child exit codes). `paths.WebDir` added; `cmd/backend.go` and `cmd/web.go` simplified.
- Docs updated (`tools/ods/README.md`, `backend/AGENTS.md`, `web/AGENTS.md`, `mobile/AGENTS.md`). `ods coverage` remains Go-only now that `testsuite` lists every suite; non-Go suites fail with a clear message, and the coverage baseline was refreshed.

<sup>Written for commit e77f29d604a90896dfde1d3b86eec0f65b6f92c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

