### PR TITLE
test(integration): fail collection if an integration test mocks

### DIFF
--- a/backend/tests/external_dependency_unit/db/test_tenant_provisioning_rollback.py
+++ b/backend/tests/external_dependency_unit/db/test_tenant_provisioning_rollback.py
@@ -1,24 +1,34 @@
 """
-Integration tests for tenant provisioning rollback behavior.
+Tenant provisioning rollback behavior, against a real database.
 
 Tests the fix for the drop_schema bug where:
 1. isidentifier() rejected valid UUID tenant IDs (with hyphens)
 2. SQL syntax was broken (%(schema_name)s instead of proper identifier handling)
 
 This test verifies the full flow: provisioning failure → rollback → schema cleanup.
+Provisioning has to fail partway through for a rollback to happen at all, and no
+API can ask it to, so the failure is injected here rather than driven end to end.
 """
 
 import uuid
 from unittest.mock import MagicMock, patch
 
+import pytest
 from sqlalchemy import text
 
 from ee.onyx.server.tenants.schema_management import (
     create_schema_if_not_exists,
     drop_schema,
 )
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_shared_schema
 from shared_configs.configs import TENANT_ID_PREFIX
+
+
+@pytest.fixture(autouse=True)
+def _engine() -> None:
+    """These tests open their own sessions, so they never pull in the suite's
+    db_session fixture that would otherwise initialize the engine."""
+    SqlEngine.init_engine(pool_size=5, max_overflow=2)
 
 
 def _schema_exists(schema_name: str) -> bool:

--- a/backend/tests/external_dependency_unit/discord_bot/test_discord_bot_cloud_mode.py
+++ b/backend/tests/external_dependency_unit/discord_bot/test_discord_bot_cloud_mode.py
@@ -1,0 +1,35 @@
+"""Discord bot behavior that differs between cloud and self-hosted mode.
+
+Both checks read the MULTI_TENANT flag at call time from the module that uses it,
+so the flag is patched here rather than driven from the environment.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+def test_cannot_create_bot_config_in_cloud_mode() -> None:
+    """Bot config creation is blocked in cloud mode."""
+    with patch("onyx.server.manage.discord_bot.api.MULTI_TENANT", True):
+        from onyx.error_handling.exceptions import OnyxError
+        from onyx.server.manage.discord_bot.api import _check_bot_config_api_access
+
+        with pytest.raises(OnyxError) as exc_info:
+            _check_bot_config_api_access()
+
+        assert exc_info.value.status_code == 403
+        assert "Cloud" in str(exc_info.value.detail)
+
+
+def test_bot_token_from_env_only_in_cloud() -> None:
+    """Bot token comes from env var in cloud mode, ignores DB."""
+    from onyx.onyxbot.discord.utils import get_bot_token
+
+    with (
+        patch("onyx.onyxbot.discord.utils.DISCORD_BOT_TOKEN", "env_token"),
+        patch("onyx.onyxbot.discord.utils.MULTI_TENANT", True),
+    ):
+        result = get_bot_token()
+
+    assert result == "env_token"

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1,8 +1,10 @@
+import ast
 import os
 import platform
 import shutil
 import subprocess
 from collections.abc import Callable, Generator
+from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
@@ -521,6 +523,78 @@ def document_builder(admin_user: DATestUser) -> DocumentBuilderType:
         return docs
 
     return _document_builder
+
+
+_INTEGRATION_DIR = Path(__file__).parent
+
+
+def _imports_mock(source: str) -> bool:
+    """Report whether the module imports unittest.mock, in any spelling.
+
+    Parsed rather than pattern-matched so that a docstring quoting the rule is
+    not mistaken for a violation, and so that a parenthesized import still
+    counts. It does not follow ``import unittest`` to a later ``unittest.mock``
+    attribute access; the check is a signpost, not a sandbox.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        # pytest reports the syntax error itself; nothing useful to add here.
+        return False
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(alias.name == "unittest.mock" for alias in node.names):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            if node.module == "unittest.mock":
+                return True
+            if node.module == "unittest" and any(
+                alias.name == "mock" for alias in node.names
+            ):
+                return True
+    return False
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Fail collection if an integration test mocks the code under test.
+
+    Integration tests are the black-box tier: they drive the product through its
+    real API and assert on observable behavior. Reaching inside with
+    ``unittest.mock`` turns them into external-dependency-unit tests wearing the
+    wrong hat, and that used to be caught only by a reviewer noticing the import.
+    """
+    offenders: set[str] = set()
+    checked: set[Path] = set()
+
+    for item in items:
+        path = getattr(item, "path", None)
+        if path is None or path in checked:
+            continue
+        checked.add(path)
+
+        try:
+            rel = path.relative_to(_INTEGRATION_DIR).as_posix()
+        except ValueError:
+            continue
+
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if _imports_mock(source):
+            offenders.add(rel)
+
+    if offenders:
+        listed = "\n".join(f"  tests/integration/{name}" for name in sorted(offenders))
+        raise pytest.UsageError(
+            "Integration tests must not import unittest.mock — they drive the "
+            "product through its real API and cannot mock it:\n"
+            f"{listed}\n"
+            "Move the test to backend/tests/external_dependency_unit/ (where "
+            "mocking is allowed and functions are called directly), or rewrite "
+            "it to assert on observable API behavior."
+        )
 
 
 def pytest_runtest_logstart(

--- a/backend/tests/integration/multitenant_tests/discord_bot/test_discord_bot_multitenant.py
+++ b/backend/tests/integration/multitenant_tests/discord_bot/test_discord_bot_multitenant.py
@@ -4,7 +4,6 @@ These tests ensure tenant isolation and prevent data leakage between tenants.
 Tests follow the multi-tenant integration test pattern using API client.
 """
 
-from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -21,34 +20,6 @@ from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser
-
-
-class TestBotConfigIsolationCloudMode:
-    """Tests for bot config isolation in cloud mode."""
-
-    def test_cannot_create_bot_config_in_cloud_mode(self) -> None:
-        """Bot config creation is blocked in cloud mode."""
-        with patch("onyx.server.manage.discord_bot.api.MULTI_TENANT", True):
-            from onyx.error_handling.exceptions import OnyxError
-            from onyx.server.manage.discord_bot.api import _check_bot_config_api_access
-
-            with pytest.raises(OnyxError) as exc_info:
-                _check_bot_config_api_access()
-
-            assert exc_info.value.status_code == 403
-            assert "Cloud" in str(exc_info.value.detail)
-
-    def test_bot_token_from_env_only_in_cloud(self) -> None:
-        """Bot token comes from env var in cloud mode, ignores DB."""
-        from onyx.onyxbot.discord.utils import get_bot_token
-
-        with (
-            patch("onyx.onyxbot.discord.utils.DISCORD_BOT_TOKEN", "env_token"),
-            patch("onyx.onyxbot.discord.utils.MULTI_TENANT", True),
-        ):
-            result = get_bot_token()
-
-        assert result == "env_token"
 
 
 class TestGuildRegistrationIsolation:


### PR DESCRIPTION
## Problem

Integration tests are the black-box tier: they drive the product through its real API and assert on observable behavior. `backend/AGENTS.md` says so — "We cannot mock anything in these tests."

Nothing enforced it. A test could `from unittest.mock import patch`, reach inside the code under test, and the only thing standing in the way was a reviewer noticing the import.

## Change

A `pytest_collection_modifyitems` hook in `backend/tests/integration/conftest.py` fails collection when a collected integration test imports `unittest.mock`. It lists the offending files and says what to do about them:

```
ERROR: Integration tests must not import unittest.mock — they drive the product
through its real API and cannot mock it:
  tests/integration/tests/personas/test_persona_creation.py
Move the test to backend/tests/external_dependency_unit/ (where mocking is allowed
and functions are called directly), or rewrite it to assert on observable API behavior.
```

The hook parses each test module with `ast` rather than matching text. It catches `import unittest.mock`, `from unittest.mock import ...`, and `from unittest import mock`, including when the import list is parenthesized across lines, and it does not misread a docstring or comment that quotes the rule. A false positive is the worse failure here, because it blocks a legitimate test and tells the author to move it — wrong advice.

The check does not follow `import unittest` to a later `unittest.mock.patch(...)`, and `monkeypatch` and `importlib` also get past it. It is a signpost, not a sandbox.

## Existing offenders

Two, and both are moved rather than exempted — neither drove an API to begin with:

- **`test_tenant_provisioning_rollback.py`** patched `setup_tenant` to fail partway through, because no API can ask provisioning to roll back. Moved to `external_dependency_unit/db/`, next to the shard suites that already create and drop tenant schemas. It needs the engine initialized explicitly, since it opens its own sessions and so never pulls in the suite's `db_session` fixture.
- **`TestBotConfigIsolationCloudMode`** patched the `MULTI_TENANT` flag and called `_check_bot_config_api_access` / `get_bot_token` directly. Extracted to `external_dependency_unit/discord_bot/test_discord_bot_cloud_mode.py`. The rest of `test_discord_bot_multitenant.py` is genuinely black-box and stays put.

**There is no allowlist** — nothing is left to exempt, so the check has no escape hatch to grow.

Neither move needs a CI change: `pr-external-dependency-unit-tests.yml` shards by discovering top-level directories, and both targets are existing ones. `pr-integration-tests.yml` runs `multitenant_tests` as a single job.

## Tests

- Both moved files pass in their new tier — 4 passed.
- Full `tests/integration` tree collects clean: 1627 tests, no violations. (`tests/craft/k8s` is excluded; its `pytest_plugins` collection error is pre-existing and unrelated — confirmed by re-running with these changes stashed.)
- Injecting `from unittest.mock import patch` into an integration test makes collection fail with the message above, exit code 4.
- The parser was checked against 12 cases: every import spelling, plain and parenthesized, indented inside a function, and the near misses — docstring, comment, string constant, bare `import unittest`, unparseable file.
- `pre-commit` clean on all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
