### PR TITLE
chore(helm): bump code-interpreter subchart to 0.4.6

### DIFF
--- a/deployment/helm/charts/onyx/Chart.lock
+++ b/deployment/helm/charts/onyx/Chart.lock
@@ -22,6 +22,6 @@ dependencies:
   version: 5.4.0
 - name: code-interpreter
   repository: https://onyx-dot-app.github.io/python-sandbox/
-  version: 0.4.3
-digest: sha256:b81d4ee9a0217f0cdc7f50ad84cb41c9961acd399f04f7e9e1cff2eb56a92b95
-generated: "2026-07-06T13:06:08.827988-07:00"
+  version: 0.4.6
+digest: sha256:9921b46a454cead472303a75a0c0c109691fabb2468739ecc51429f731314792
+generated: "2026-08-17T11:23:15.803513-07:00"

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.16
+version: 0.8.17
 appVersion: latest
 annotations:
   category: Productivity
@@ -76,6 +76,6 @@ dependencies:
     repository: https://charts.min.io/
     condition: minio.enabled
   - name: code-interpreter
-    version: 0.4.3
+    version: 0.4.6
     repository: https://onyx-dot-app.github.io/python-sandbox/
     condition: codeInterpreter.enabled


### PR DESCRIPTION
## Description

Bumps the `code-interpreter` subchart from 0.4.3 to 0.4.6 so Onyx picks up
executor pod `ownerReferences` (onyx-dot-app/python-sandbox#73).

Executor pods (`code-exec-*`, `code-session-*`) were created with no
`ownerReferences`, because the code-interpreter service creates them directly
through the Kubernetes client rather than through a controller. Two effects:

- Monitoring cannot distinguish these short-lived pods from long-lived
  workloads, so they raise alerts that ephemeral pods should not raise. This was
  reported by a self-hosted deployment whose alerting excludes owned pods.
- Nothing garbage-collects pods the service leaks. Our own values file already
  notes this: "parent OOMs leak spawned code-exec pods".

The subchart now gives each executor pod an `ownerReference` to the
code-interpreter Deployment, which fixes both.

The whole chart delta from 0.4.3 to 0.4.6 is that one change (+45 lines across
Chart.yaml, README.md, deployment.yaml, role.yaml, values.yaml). No other
subchart behaviour changes in this range.

This changes the pin in `Chart.yaml`, the regenerated `Chart.lock`, and the onyx
chart's own `version` (0.8.16 -> 0.8.17). The vendored `charts/*.tgz` are
gitignored build artifacts and are not committed.

The onyx chart version bump is required, not cosmetic: `helm-chart-releases.yml`
will not overwrite an already-published version, and 0.8.16 is already
published. Reusing it would merge this change but never release it.

## Effects on a deployed cluster

- The code-interpreter ServiceAccount gains `get` on `apps/deployments`, scoped
  to the release namespace. It needs this to read its own Deployment and build
  the reference.
- The Deployment gains two environment variables: its own namespace via the
  downward API, and its Deployment name.
- Deleting the code-interpreter Deployment now cascades to in-flight executor
  pods. This is the intended cleanup.

Gated on `codeInterpreter.kubernetesExecutor.setOwnerReferences`, default true.

## Depends on

The `onyxdotapp/code-interpreter` image must be rebuilt before this has any
effect. The newest published image is 0.4.4 (June 23); the build workflow only
runs on `workflow_dispatch`, so 0.4.5 and 0.4.6 were never built. Until then the
older image simply ignores the new environment variables, so merging this early
is a no-op rather than a breakage.

Note that Onyx does not override `image.tag`, so deployments run `latest` with
`pullPolicy: Always`. Rebuilding the image therefore also delivers the 0.4.5
application changes (reportlab and svglib, python-sandbox#64).

## How Has This Been Tested?

- `helm dependency update` resolves 0.4.6 and regenerates `Chart.lock`.
- `helm template` against `ci/ct-values.yaml` with `codeInterpreter.enabled=true`
  renders the new `KUBERNETES_OWN_NAMESPACE` and `KUBERNETES_OWNER_DEPLOYMENT_NAME`
  environment variables and the new `apps/deployments: get` rule, and reports the
  subchart as `code-interpreter-0.4.6`.
- Upstream python-sandbox#73 is merged with all checks green, and includes unit
  coverage for owner resolution and its fallback paths.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
