### PR TITLE
fix(llm): let the backend decide which reasoning levels a model offers

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -819,7 +819,7 @@ def run_llm_loop(
             msg.message_type == MessageType.USER and msg.image_files
             for msg in simple_chat_history
         ) and not model_supports_image_input(
-            llm.config.model_name, llm.config.model_provider
+            llm.config.model_name, llm.config.model_provider, llm.config.deployment_name
         )
         tool_choice: ToolChoiceOptions = ToolChoiceOptions.AUTO
         # Initialize gathered_documents with project files if present

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -874,7 +874,9 @@ def translate_history_to_llm_format(
     supports_image_input = True
     if any(msg.message_type == MessageType.USER and msg.image_files for msg in history):
         supports_image_input = model_supports_image_input(
-            llm_config.model_name, llm_config.model_provider
+            llm_config.model_name,
+            llm_config.model_provider,
+            llm_config.deployment_name,
         )
 
     # Per-request image cap (provider-aware). When the cap is enforced and
@@ -1029,7 +1031,9 @@ def translate_history_to_llm_format(
 
     # Apply model-specific formatting when translating to LLM format (e.g. OpenAI
     # reasoning models need CODE_BLOCK_MARKDOWN prefix for correct markdown generation)
-    if model_needs_formatting_reenabled(llm_config.model_name):
+    if model_needs_formatting_reenabled(
+        llm_config.model_name, llm_config.deployment_name
+    ):
         for i, m in enumerate(messages):
             if isinstance(m, SystemMessage):
                 messages[i] = SystemMessage(

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -907,7 +907,9 @@ def update_default_vision_provider(
     if provider is None:
         raise ValueError(f"LLM Provider with id={provider_id} does not exist")
 
-    if not model_supports_image_input(vision_model, provider.provider):
+    if not model_supports_image_input(
+        vision_model, provider.provider, provider.deployment_name
+    ):
         raise ValueError(
             f"Model '{vision_model}' for provider '{provider.provider} does not support image input"
         )

--- a/backend/onyx/llm/factory.py
+++ b/backend/onyx/llm/factory.py
@@ -258,7 +258,9 @@ def get_default_llm_with_vision(
         default_model = fetch_default_vision_model(db_session)
         if default_model:
             if model_supports_image_input(
-                default_model.name, default_model.llm_provider.provider
+                default_model.name,
+                default_model.llm_provider.provider,
+                default_model.llm_provider.deployment_name,
             ):
                 logger.info(
                     "Using default vision model: %s (provider=%s)",
@@ -308,7 +310,9 @@ def get_default_llm_with_vision(
     )
 
     for model in sorted_models:
-        if model_supports_image_input(model.name, model.llm_provider.provider):
+        if model_supports_image_input(
+            model.name, model.llm_provider.provider, model.llm_provider.deployment_name
+        ):
             logger.info(
                 "Using fallback vision model: %s (provider=%s)",
                 model.name,

--- a/backend/onyx/llm/model_capabilities.py
+++ b/backend/onyx/llm/model_capabilities.py
@@ -514,15 +514,9 @@ def is_openai_registry_model_name(model_name: str) -> bool:
 _ANTHROPIC_MODEL_TIERS = ("opus", "sonnet", "haiku", "fable", "mythos")
 _ANTHROPIC_VERSION_PATTERN = r"\d+(?:[.-]\d+)?"
 
-# Starting with Claude Opus 4.7, Anthropic requires the adaptive thinking API
-# (thinking.type.adaptive + output_config.effort) in place of the legacy
-# thinking.type.enabled + budget_tokens, and rejects any non-default sampling
-# parameter (temperature/top_p/top_k) with a 400 invalid_request_error. Every
-# later model — Opus 4.8, the Claude 5 line (fable/mythos/sonnet), and beyond —
-# inherits both behaviors, so we gate on the parsed model version rather than an
-# explicit list. This lets new releases be handled without a code change, and
-# avoids relying on LiteLLM's drop_params (unreliable here, since AnthropicConfig
-# still advertises temperature as supported).
+# Claude Opus 4.7+ (and later releases by version) requires adaptive thinking
+# and rejects a non-default temperature with a 400. Version-gated, not listed,
+# so new releases need no code change. LiteLLM's drop_params can't help here.
 _ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION = (4, 7)
 
 # Extended thinking landed in Claude 3.7. Parsing the version off the name
@@ -591,6 +585,13 @@ def anthropic_omits_sampling_params(model_name: str) -> bool:
     )
 
 
+def model_identity_names(model_name: str, deployment_name: str | None) -> list[str]:
+    """Every string that could carry a model's identity: model_name, plus a
+    custom provider's deployment alias when set (e.g. Azure AI Foundry, where
+    the alias is the string actually sent to LiteLLM)."""
+    return [name for name in (model_name, deployment_name) if name]
+
+
 class ReasoningParamStyle(str, Enum):
     """The shape of the reasoning parameters a model accepts."""
 
@@ -640,10 +641,9 @@ def resolve_reasoning_param_style(
     return ReasoningParamStyle.LITELLM_EFFORT
 
 
-# Styles that carry XHIGH to the provider. Everywhere else it is indistinct:
-# LiteLLM's per-provider mappings reject it (Gemini) or silently drop it
-# (gpt-5.x rejects "xhigh" as a reasoning_effort value), and Anthropic's legacy
-# budget for XHIGH equals HIGH's.
+# Styles that carry XHIGH to the provider. Elsewhere it's indistinct from HIGH:
+# LiteLLM's per-provider mappings reject or silently drop it, and Anthropic's
+# legacy budget for XHIGH equals HIGH's.
 _XHIGH_REASONING_STYLES = frozenset(
     {ReasoningParamStyle.OPENAI, ReasoningParamStyle.ANTHROPIC_ADAPTIVE}
 )

--- a/backend/onyx/llm/model_capabilities.py
+++ b/backend/onyx/llm/model_capabilities.py
@@ -13,6 +13,8 @@ import copy
 import re
 import threading
 import time
+from collections.abc import Sequence
+from enum import Enum
 from functools import lru_cache
 from typing import Any, cast
 
@@ -21,7 +23,9 @@ from onyx.configs.model_configs import (
     GEN_AI_MODEL_FALLBACK_MAX_TOKENS,
     GEN_AI_NUM_RESERVED_OUTPUT_TOKENS,
 )
+from onyx.llm.api_surfaces import OPENAI_COMPATIBLE_SURFACES, LlmApiSurface
 from onyx.llm.constants import BEDROCK_MODEL_TOKEN_LIMITS, LlmProviderNames
+from onyx.llm.models import ReasoningEffort
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id
 
@@ -475,3 +479,201 @@ def is_true_openai_model(model_provider: str, model_name: str) -> bool:
             model_name,
         )
         return False
+
+
+def is_openai_registry_model_name(model_name: str) -> bool:
+    """Name-only OpenAI-registry check, with any gateway vendor prefix removed.
+
+    Aggregators address models as "vendor/model" ("openai/gpt-5.1"), so the raw
+    name never matches the registry. Unlike `is_true_openai_model` this asks
+    only "whose model is this", not "do we reach it over OpenAI's own API" —
+    keep the two apart, since the latter also decides responses-API routing.
+    """
+    base_model_name = model_name.split("/")[-1]
+    if not base_model_name:
+        return False
+
+    try:
+        model_map = get_model_map()
+        if f"{LlmProviderNames.OPENAI}/{base_model_name}" in model_map:
+            return True
+        entry = model_map.get(base_model_name)
+        return bool(entry) and entry.get("litellm_provider") == LlmProviderNames.OPENAI
+    except Exception:
+        logger.exception("Failed to check %s against the OpenAI registry", model_name)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Reasoning effort
+# ---------------------------------------------------------------------------
+
+# Named tiers spanning Claude's naming schemes, including the Claude 5 line whose
+# version digit can precede or follow the tier ("claude-sonnet-5" vs
+# "claude-5-sonnet").
+_ANTHROPIC_MODEL_TIERS = ("opus", "sonnet", "haiku", "fable", "mythos")
+_ANTHROPIC_VERSION_PATTERN = r"\d+(?:[.-]\d+)?"
+
+# Starting with Claude Opus 4.7, Anthropic requires the adaptive thinking API
+# (thinking.type.adaptive + output_config.effort) in place of the legacy
+# thinking.type.enabled + budget_tokens, and rejects any non-default sampling
+# parameter (temperature/top_p/top_k) with a 400 invalid_request_error. Every
+# later model — Opus 4.8, the Claude 5 line (fable/mythos/sonnet), and beyond —
+# inherits both behaviors, so we gate on the parsed model version rather than an
+# explicit list. This lets new releases be handled without a code change, and
+# avoids relying on LiteLLM's drop_params (unreliable here, since AnthropicConfig
+# still advertises temperature as supported).
+_ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION = (4, 7)
+
+# Extended thinking landed in Claude 3.7. Parsing the version off the name
+# keeps aliased deployments (gateways, custom model names) reasoning even when
+# the litellm registry doesn't recognize the string.
+_ANTHROPIC_THINKING_MIN_VERSION = (3, 7)
+
+
+def parse_anthropic_model_version(model_name: str) -> tuple[int, int] | None:
+    """Extract the (major, minor) version from a Claude model name.
+
+    Handles the naming variants that reach LiteLLM: tier-first
+    ("claude-opus-4-8"), version-first ("claude-4-8-opus"), dot-separated
+    ("claude-opus-4.8"), the named Claude 5 tiers ("claude-fable-5",
+    "claude-5-sonnet"), legacy names ("claude-3-5-sonnet-20241022"), and
+    provider-prefixed / date-snapshot forms. Returns None when the name is not a
+    Claude model or carries no parseable version.
+    """
+    name = model_name.lower()
+    if "claude" not in name:
+        return None
+    # Drop any provider prefix (e.g. "anthropic/", "bedrock/anthropic.").
+    name = name[name.index("claude") :]
+    # Drop date/snapshot suffixes ("@20260101", "-20241022") so their digits
+    # can't be mistaken for a version.
+    name = name.split("@")[0]
+    name = re.sub(r"\d{6,}", "", name)
+
+    tier = next((t for t in _ANTHROPIC_MODEL_TIERS if t in name), None)
+    if tier is not None:
+        # The version can sit on either side of the tier depending on scheme.
+        match = re.search(
+            rf"{tier}[.-]?({_ANTHROPIC_VERSION_PATTERN})", name
+        ) or re.search(rf"({_ANTHROPIC_VERSION_PATTERN})[.-]?{tier}", name)
+        version_str = match.group(1) if match else None
+    else:
+        match = re.search(_ANTHROPIC_VERSION_PATTERN, name)
+        version_str = match.group(0) if match else None
+
+    if not version_str:
+        return None
+    parts = re.split(r"[.-]", version_str)
+    major = int(parts[0])
+    minor = int(parts[1]) if len(parts) > 1 else 0
+    return (major, minor)
+
+
+def _anthropic_meets_version(model_name: str, min_version: tuple[int, int]) -> bool:
+    version = parse_anthropic_model_version(model_name)
+    return version is not None and version >= min_version
+
+
+def anthropic_uses_adaptive_thinking(model_name: str) -> bool:
+    return _anthropic_meets_version(
+        model_name, _ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION
+    )
+
+
+def anthropic_supports_thinking(model_name: str) -> bool:
+    return _anthropic_meets_version(model_name, _ANTHROPIC_THINKING_MIN_VERSION)
+
+
+def anthropic_omits_sampling_params(model_name: str) -> bool:
+    return _anthropic_meets_version(
+        model_name, _ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION
+    )
+
+
+class ReasoningParamStyle(str, Enum):
+    """The shape of the reasoning parameters a model accepts."""
+
+    # reasoning={"effort": ..., "summary": "auto"} — OpenAI's own wire format,
+    # and the one OpenAI-shaped gateways translate from.
+    OPENAI = "openai"
+    # thinking={"type": "adaptive"} + output_config={"effort": ...}
+    ANTHROPIC_ADAPTIVE = "anthropic_adaptive"
+    # thinking={"type": "enabled", "budget_tokens": ...}
+    ANTHROPIC_BUDGET = "anthropic_budget"
+    # reasoning_effort=..., mapped per provider by LiteLLM.
+    LITELLM_EFFORT = "litellm_effort"
+
+
+def resolve_reasoning_param_style(
+    model_provider: str,
+    model_names: Sequence[str],
+    api_surface: LlmApiSurface | None,
+) -> ReasoningParamStyle:
+    """Pick the reasoning wire format for a model.
+
+    Custom providers (e.g. Azure AI Foundry) may carry the model identity only
+    in the deployment alias, so callers pass every name that could identify the
+    model.
+    """
+    openai_compatible_surface = api_surface in OPENAI_COMPATIBLE_SURFACES
+    is_claude_model = any("claude" in name.lower() for name in model_names)
+
+    # An OpenAI model reached over OpenAI's own API, and one reached through a
+    # gateway that speaks OpenAI, take the same parameters. So does Claude
+    # behind such a gateway: the format follows the surface, not the vendor.
+    # LiteLLM drops thinking/output_config as unsupported on an openai surface,
+    # so a gateway only ever sees reasoning.effort — it translates from there.
+    if any(is_true_openai_model(model_provider, name) for name in model_names):
+        return ReasoningParamStyle.OPENAI
+    if openai_compatible_surface and (
+        is_claude_model
+        or any(is_openai_registry_model_name(name) for name in model_names)
+    ):
+        return ReasoningParamStyle.OPENAI
+
+    if is_claude_model:
+        if any(anthropic_uses_adaptive_thinking(name) for name in model_names):
+            return ReasoningParamStyle.ANTHROPIC_ADAPTIVE
+        return ReasoningParamStyle.ANTHROPIC_BUDGET
+
+    return ReasoningParamStyle.LITELLM_EFFORT
+
+
+# Styles that carry XHIGH to the provider. Everywhere else it is indistinct:
+# LiteLLM's per-provider mappings reject it (Gemini) or silently drop it
+# (gpt-5.x rejects "xhigh" as a reasoning_effort value), and Anthropic's legacy
+# budget for XHIGH equals HIGH's.
+_XHIGH_REASONING_STYLES = frozenset(
+    {ReasoningParamStyle.OPENAI, ReasoningParamStyle.ANTHROPIC_ADAPTIVE}
+)
+
+
+def supported_reasoning_efforts(
+    model_provider: str,
+    model_names: Sequence[str],
+    api_surface: LlmApiSurface | None,
+) -> list[ReasoningEffort]:
+    """The effort levels a reasoning model tells apart, in ascending order.
+
+    Callers gate on their own reasoning-support answer first; this only narrows
+    the range. An empty list means the model reasons but takes no effort
+    parameter at all.
+
+    The chat request builder (`onyx.llm.multi_llm`) and the model picker both
+    read this, so a greyed-out slider stop and a dropped request parameter can
+    never disagree.
+    """
+    if any(openai_model_rejects_reasoning_effort(name) for name in model_names):
+        return []
+
+    style = resolve_reasoning_param_style(model_provider, model_names, api_surface)
+    efforts = [
+        ReasoningEffort.OFF,
+        ReasoningEffort.LOW,
+        ReasoningEffort.MEDIUM,
+        ReasoningEffort.HIGH,
+    ]
+    if style in _XHIGH_REASONING_STYLES:
+        efforts.append(ReasoningEffort.XHIGH)
+    return efforts

--- a/backend/onyx/llm/model_capabilities.py
+++ b/backend/onyx/llm/model_capabilities.py
@@ -504,6 +504,13 @@ def is_openai_registry_model_name(model_name: str) -> bool:
         return False
 
 
+def openai_chat_variant_rejects_reasoning(model_name: str) -> bool:
+    """True for the GPT-5 "-chat" registry variants, which reject reasoning
+    params on every surface despite being reasoning models (an OpenAI bug).
+    Registry-gated so a name merely containing "-chat" doesn't false-positive."""
+    return "-chat" in model_name and is_openai_registry_model_name(model_name)
+
+
 # ---------------------------------------------------------------------------
 # Reasoning effort
 # ---------------------------------------------------------------------------
@@ -660,9 +667,9 @@ def supported_reasoning_efforts(
     the range. An empty list means the model reasons but takes no effort
     parameter at all.
 
-    The chat request builder (`onyx.llm.multi_llm`) and the model picker both
-    read this, so a greyed-out slider stop and a dropped request parameter can
-    never disagree.
+    Both this function and the chat request builder (`onyx.llm.multi_llm`)
+    derive their answer from `resolve_reasoning_param_style`, so a greyed-out
+    slider stop and a dropped request parameter should never disagree.
     """
     if any(openai_model_rejects_reasoning_effort(name) for name in model_names):
         return []

--- a/backend/onyx/llm/model_capabilities.py
+++ b/backend/onyx/llm/model_capabilities.py
@@ -671,7 +671,11 @@ def supported_reasoning_efforts(
     derive their answer from `resolve_reasoning_param_style`, so a greyed-out
     slider stop and a dropped request parameter should never disagree.
     """
-    if any(openai_model_rejects_reasoning_effort(name) for name in model_names):
+    if any(
+        openai_model_rejects_reasoning_effort(name)
+        or openai_chat_variant_rejects_reasoning(name)
+        for name in model_names
+    ):
         return []
 
     style = resolve_reasoning_param_style(model_provider, model_names, api_surface)

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -694,7 +694,7 @@ class LitellmLLM(LLM):
         # LiteLLM's drop_params is not reliable here because the upstream
         # provider config can still claim the param is supported.
         # https://github.com/BerriAI/litellm/issues/26444
-        # TODO(litellm): Consider removing this once the above is resolved,
+        # TODO(acaprau): Consider removing this once the above is resolved,
         # although this assumes users have upgraded their litellm if relevant.
         omits_sampling_params = any(
             anthropic_omits_sampling_params(name) for name in model_identity_names

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -594,7 +594,7 @@ class LitellmLLM(LLM):
             self.config.model_name, self.config.deployment_name
         )
         is_claude_model = any("claude" in name.lower() for name in model_identity_names)
-        is_qwen_model = "qwen" in self.config.model_name.lower()
+        is_qwen_model = any("qwen" in name.lower() for name in model_identity_names)
         uses_adaptive_thinking = any(
             anthropic_uses_adaptive_thinking(name) for name in model_identity_names
         )
@@ -689,9 +689,9 @@ class LitellmLLM(LLM):
             tool_choice = None
 
         # Temperature
-        # Some models reject any non-default sampling parameter (e.g. Claude
-        # Opus 4.7/4.8 return a 400 invalid_request_error if temperature is set
-        # to anything). For those models we must omit the param entirely —
+        # Some models (e.g. Claude Opus 4.7/4.8) reject a non-default
+        # temperature with a 400 invalid_request_error. For those models we
+        # must omit the param entirely.
         # LiteLLM's drop_params is not reliable here because the upstream
         # provider config can still claim the param is supported.
         # https://github.com/BerriAI/litellm/issues/26444

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -46,6 +46,9 @@ from onyx.llm.model_capabilities import (
     openai_model_rejects_reasoning_effort,
     resolve_reasoning_param_style,
 )
+from onyx.llm.model_capabilities import (
+    model_identity_names as resolve_model_identity_names,
+)
 from onyx.llm.model_response import ModelResponse, ModelResponseStream, Usage
 from onyx.llm.models import (
     ANTHROPIC_ADAPTIVE_REASONING_EFFORT,
@@ -587,14 +590,9 @@ class LitellmLLM(LLM):
         #########################
         # Flags that modify the final arguments
         #########################
-        # Custom providers (e.g. Azure AI Foundry) may carry the model identity
-        # only in the deployment alias, which is also the string actually sent
-        # to LiteLLM — so model detection must consider both names.
-        model_identity_names = [
-            name
-            for name in (self.config.model_name, self.config.deployment_name)
-            if name
-        ]
+        model_identity_names = resolve_model_identity_names(
+            self.config.model_name, self.config.deployment_name
+        )
         is_claude_model = any("claude" in name.lower() for name in model_identity_names)
         is_qwen_model = "qwen" in self.config.model_name.lower()
         uses_adaptive_thinking = any(

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -43,6 +43,7 @@ from onyx.llm.model_capabilities import (
     anthropic_uses_adaptive_thinking,
     is_true_openai_model,
     model_is_reasoning_model,
+    openai_chat_variant_rejects_reasoning,
     openai_model_rejects_reasoning_effort,
     resolve_reasoning_param_style,
 )
@@ -621,9 +622,9 @@ class LitellmLLM(LLM):
         # Some Vertex Anthropic models reject stream_options. Reasoning params
         # are sent regardless: a provider that rejects one answers with a 400
         # naming the kwarg, which the retry ladder below strips.
-        is_vertex_model_rejecting_stream_options = (
-            is_vertex_ai
-            and _is_vertex_model_rejecting_stream_options(self.config.model_name)
+        is_vertex_model_rejecting_stream_options = is_vertex_ai and any(
+            _is_vertex_model_rejecting_stream_options(name)
+            for name in model_identity_names
         )
 
         #########################
@@ -737,7 +738,10 @@ class LitellmLLM(LLM):
                     # OpenAI API does not accept reasoning params for GPT 5 chat
                     # models (neither reasoning nor reasoning_effort are accepted)
                     # even though they are reasoning models (bug in OpenAI)
-                    send_reasoning = "-chat" not in model
+                    send_reasoning = not any(
+                        openai_chat_variant_rejects_reasoning(name)
+                        for name in model_identity_names
+                    )
                 if send_reasoning:
                     optional_kwargs["reasoning"] = openai_style_reasoning
 
@@ -788,9 +792,6 @@ class LitellmLLM(LLM):
                             "type": "enabled",
                             "budget_tokens": budget_tokens,
                         }
-
-                # LiteLLM just does some mapping like this anyway but is incomplete for Anthropic
-                optional_kwargs.pop("reasoning_effort", None)
 
             else:
                 # Hope for the best from LiteLLM

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -1037,7 +1037,12 @@ class LitellmLLM(LLM):
         """Providers whose sync calls need a fresh per-call HTTPHandler instead of
         litellm's shared module_level_client (see threading notes in invoke())."""
         return (
-            is_true_openai_model(self.config.model_provider, self.config.model_name)
+            any(
+                is_true_openai_model(self.config.model_provider, name)
+                for name in resolve_model_identity_names(
+                    self.config.model_name, self.config.deployment_name
+                )
+            )
             or self.config.model_provider == LlmProviderNames.ANTHROPIC
         )
 

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -1,6 +1,5 @@
 import copy
 import os
-import re
 import time
 from collections.abc import Iterator
 from contextlib import AbstractContextManager, contextmanager, nullcontext
@@ -38,9 +37,14 @@ from onyx.llm.interfaces import (
     ToolChoice,
 )
 from onyx.llm.model_capabilities import (
+    ReasoningParamStyle,
+    anthropic_omits_sampling_params,
+    anthropic_supports_thinking,
+    anthropic_uses_adaptive_thinking,
     is_true_openai_model,
     model_is_reasoning_model,
     openai_model_rejects_reasoning_effort,
+    resolve_reasoning_param_style,
 )
 from onyx.llm.model_response import ModelResponse, ModelResponseStream, Usage
 from onyx.llm.models import (
@@ -84,22 +88,6 @@ _VERTEX_ANTHROPIC_MODELS_REJECTING_STREAM_OPTIONS = (
     "claude-opus-4-8",
 )
 
-# Starting with Claude Opus 4.7, Anthropic requires the adaptive thinking API
-# (thinking.type.adaptive + output_config.effort) in place of the legacy
-# thinking.type.enabled + budget_tokens, and rejects any non-default sampling
-# parameter (temperature/top_p/top_k) with a 400 invalid_request_error. Every
-# later model — Opus 4.8, the Claude 5 line (fable/mythos/sonnet), and beyond —
-# inherits both behaviors, so we gate on the parsed model version rather than an
-# explicit list. This lets new releases be handled without a code change, and
-# avoids relying on LiteLLM's drop_params (unreliable here, since AnthropicConfig
-# still advertises temperature as supported).
-_ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION = (4, 7)
-
-# Extended thinking landed in Claude 3.7. Parsing the version off the name
-# keeps aliased deployments (gateways, custom model names) reasoning even when
-# the litellm registry doesn't recognize the string.
-_ANTHROPIC_THINKING_MIN_VERSION = (3, 7)
-
 # Best-effort tuning kwargs, never worth failing a chat over. _completion
 # retries provider rejections without them: reasoning keys first, then all.
 # Semantics-changing keys (tools, tool_choice, messages) are never stripped.
@@ -142,13 +130,6 @@ def _rejection_names_strippable_kwargs(error: Exception, strippable: set[str]) -
         for key in strippable
         for alias in _KWARG_ERROR_ALIASES.get(key, (key,))
     )
-
-
-# Named tiers spanning Claude's naming schemes, including the Claude 5 line whose
-# version digit can precede or follow the tier ("claude-sonnet-5" vs
-# "claude-5-sonnet").
-_ANTHROPIC_MODEL_TIERS = ("opus", "sonnet", "haiku", "fable", "mythos")
-_ANTHROPIC_VERSION_PATTERN = r"\d+(?:[.-]\d+)?"
 
 
 class LLMTimeoutError(Exception):
@@ -388,66 +369,6 @@ def _is_vertex_model_rejecting_stream_options(model_name: str) -> bool:
     )
 
 
-def _parse_anthropic_model_version(model_name: str) -> tuple[int, int] | None:
-    """Extract the (major, minor) version from a Claude model name.
-
-    Handles the naming variants that reach LiteLLM: tier-first
-    ("claude-opus-4-8"), version-first ("claude-4-8-opus"), dot-separated
-    ("claude-opus-4.8"), the named Claude 5 tiers ("claude-fable-5",
-    "claude-5-sonnet"), legacy names ("claude-3-5-sonnet-20241022"), and
-    provider-prefixed / date-snapshot forms. Returns None when the name is not a
-    Claude model or carries no parseable version.
-    """
-    name = model_name.lower()
-    if "claude" not in name:
-        return None
-    # Drop any provider prefix (e.g. "anthropic/", "bedrock/anthropic.").
-    name = name[name.index("claude") :]
-    # Drop date/snapshot suffixes ("@20260101", "-20241022") so their digits
-    # can't be mistaken for a version.
-    name = name.split("@")[0]
-    name = re.sub(r"\d{6,}", "", name)
-
-    tier = next((t for t in _ANTHROPIC_MODEL_TIERS if t in name), None)
-    if tier is not None:
-        # The version can sit on either side of the tier depending on scheme.
-        match = re.search(
-            rf"{tier}[.-]?({_ANTHROPIC_VERSION_PATTERN})", name
-        ) or re.search(rf"({_ANTHROPIC_VERSION_PATTERN})[.-]?{tier}", name)
-        version_str = match.group(1) if match else None
-    else:
-        match = re.search(_ANTHROPIC_VERSION_PATTERN, name)
-        version_str = match.group(0) if match else None
-
-    if not version_str:
-        return None
-    parts = re.split(r"[.-]", version_str)
-    major = int(parts[0])
-    minor = int(parts[1]) if len(parts) > 1 else 0
-    return (major, minor)
-
-
-def _anthropic_meets_version(model_name: str, min_version: tuple[int, int]) -> bool:
-    version = _parse_anthropic_model_version(model_name)
-    return version is not None and version >= min_version
-
-
-def _anthropic_uses_adaptive_thinking(model_name: str) -> bool:
-    return _anthropic_meets_version(
-        model_name, _ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION
-    )
-
-
-def _anthropic_supports_thinking(model_name: str) -> bool:
-    return _anthropic_meets_version(model_name, _ANTHROPIC_THINKING_MIN_VERSION)
-
-
-def _anthropic_omits_sampling_params(model_name: str) -> bool:
-    return _anthropic_meets_version(
-        model_name, _ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION
-    )
-
-
 def _env_injection_enabled() -> bool:
     # Deferred import: the security store pulls in the DB layer, which this
     # module must not import at module load.
@@ -677,14 +598,14 @@ class LitellmLLM(LLM):
         is_claude_model = any("claude" in name.lower() for name in model_identity_names)
         is_qwen_model = "qwen" in self.config.model_name.lower()
         uses_adaptive_thinking = any(
-            _anthropic_uses_adaptive_thinking(name) for name in model_identity_names
+            anthropic_uses_adaptive_thinking(name) for name in model_identity_names
         )
-        anthropic_supports_thinking = any(
-            _anthropic_supports_thinking(name) for name in model_identity_names
+        model_supports_anthropic_thinking = any(
+            anthropic_supports_thinking(name) for name in model_identity_names
         )
         is_reasoning = (
             uses_adaptive_thinking
-            or anthropic_supports_thinking
+            or model_supports_anthropic_thinking
             or any(
                 model_is_reasoning_model(name, self.config.model_provider)
                 for name in model_identity_names
@@ -778,7 +699,7 @@ class LitellmLLM(LLM):
         # TODO(litellm): Consider removing this once the above is resolved,
         # although this assumes users have upgraded their litellm if relevant.
         omits_sampling_params = any(
-            _anthropic_omits_sampling_params(name) for name in model_identity_names
+            anthropic_omits_sampling_params(name) for name in model_identity_names
         )
         if not omits_sampling_params:
             optional_kwargs["temperature"] = 1 if is_reasoning else self._temperature
@@ -798,24 +719,30 @@ class LitellmLLM(LLM):
                 "effort": OPENAI_REASONING_EFFORT[reasoning_effort],
                 "summary": "auto",
             }
+            reasoning_style = resolve_reasoning_param_style(
+                self.config.model_provider,
+                model_identity_names,
+                self._api_surface,
+            )
 
-            if is_openai_model:
-                # OpenAI API does not accept reasoning params for GPT 5 chat models
-                # (neither reasoning nor reasoning_effort are accepted)
-                # even though they are reasoning models (bug in OpenAI)
-                if "-chat" not in model:
+            if reasoning_style is ReasoningParamStyle.OPENAI:
+                if is_claude_model:
+                    # Only a gateway routes Claude here, and it still translates
+                    # to Anthropic, so the signed-thinking-block constraint
+                    # described below applies to these requests too.
+                    send_reasoning = not _prompt_contains_tool_call_history(prompt)
+                else:
+                    # OpenAI API does not accept reasoning params for GPT 5 chat
+                    # models (neither reasoning nor reasoning_effort are accepted)
+                    # even though they are reasoning models (bug in OpenAI)
+                    send_reasoning = "-chat" not in model
+                if send_reasoning:
                     optional_kwargs["reasoning"] = openai_style_reasoning
 
-            elif is_claude_model and is_openai_compatible_proxy:
-                # Wire format follows the API surface, not the model vendor.
-                # LiteLLM drops thinking/output_config as unsupported on an
-                # openai surface, so a gateway only sees reasoning.effort.
-                # The gateway still translates to Anthropic, so the tool-call
-                # constraint below applies here too.
-                if not _prompt_contains_tool_call_history(prompt):
-                    optional_kwargs["reasoning"] = openai_style_reasoning
-
-            elif is_claude_model:
+            elif reasoning_style in (
+                ReasoningParamStyle.ANTHROPIC_ADAPTIVE,
+                ReasoningParamStyle.ANTHROPIC_BUDGET,
+            ):
                 # Anthropic requires every assistant message with tool_use
                 # blocks to start with a thinking block that carries a
                 # cryptographic signature.  We don't preserve those blocks
@@ -825,7 +752,7 @@ class LitellmLLM(LLM):
                 # (notably Bedrock).
                 has_tool_call_history = _prompt_contains_tool_call_history(prompt)
 
-                if uses_adaptive_thinking:
+                if reasoning_style is ReasoningParamStyle.ANTHROPIC_ADAPTIVE:
                     # Newer Anthropic models (Claude Opus 4.7+) reject
                     # thinking.type.enabled — they require the adaptive
                     # thinking config with output_config.effort.
@@ -873,7 +800,9 @@ class LitellmLLM(LLM):
                     optional_kwargs["reasoning_effort"] = reasoning_effort.value
                 elif reasoning_effort is ReasoningEffort.XHIGH:
                     # Provider mappings behind litellm's reasoning_effort are
-                    # uneven (Gemini raises on xhigh), clamp to high.
+                    # uneven (Gemini raises on xhigh), clamp to high. The model
+                    # picker greys the level out for these models, so reaching
+                    # here means a stored override outliving a model switch.
                     optional_kwargs["reasoning_effort"] = ReasoningEffort.HIGH.value
                 else:
                     optional_kwargs["reasoning_effort"] = ReasoningEffort.MEDIUM.value

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -713,7 +713,10 @@ class LitellmLLM(LLM):
             is_reasoning
             # The default of this parameter not set is surprisingly not the equivalent of an Auto but is actually Off
             and reasoning_effort != ReasoningEffort.OFF
-            and not openai_model_rejects_reasoning_effort(self.config.model_name)
+            and not any(
+                openai_model_rejects_reasoning_effort(name)
+                for name in model_identity_names
+            )
         ):
             openai_style_reasoning = {
                 "effort": OPENAI_REASONING_EFFORT[reasoning_effort],

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -611,8 +611,9 @@ class LitellmLLM(LLM):
         )
         # All OpenAI models will use responses API for consistency
         # Responses API is needed to get reasoning packets from OpenAI models
-        is_openai_model = is_true_openai_model(
-            self.config.model_provider, self.config.model_name
+        is_openai_model = any(
+            is_true_openai_model(self.config.model_provider, name)
+            for name in model_identity_names
         )
         is_ollama = self._model_provider == LlmProviderNames.OLLAMA_CHAT
         is_mistral = self._model_provider == LlmProviderNames.MISTRAL

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -20,6 +20,7 @@ from onyx.llm.interfaces import LLM, LLMUserIdentity
 from onyx.llm.model_capabilities import (
     get_max_input_tokens,
     litellm_thinks_model_supports_image_input,
+    model_identity_names,
 )
 from onyx.llm.model_response import ModelResponse
 from onyx.llm.models import LLMErrorInfo, UserMessage
@@ -567,8 +568,13 @@ def get_max_input_tokens_from_llm_provider(
     )
 
 
-def model_supports_image_input(model_name: str, model_provider: str) -> bool:
-    # First, try to read an explicit configuration from the model_configuration table
+def model_supports_image_input(
+    model_name: str,
+    model_provider: str,
+    deployment_name: str | None = None,
+) -> bool:
+    # First, try to read an explicit configuration from the model_configuration
+    # table, keyed by the admin's configured row name (not the deployment alias).
     try:
         with get_session_with_current_tenant() as db_session:
             model_config = db_session.scalar(
@@ -595,11 +601,18 @@ def model_supports_image_input(model_name: str, model_provider: str) -> bool:
             e,
         )
 
-    # Fallback to looking up the model in the litellm model_cost dict
-    return litellm_thinks_model_supports_image_input(model_name, model_provider)
+    # Fallback to looking up the model in the litellm model_cost dict. A
+    # custom provider (e.g. Azure AI Foundry) may carry the real model
+    # identity only in the deployment alias.
+    return any(
+        litellm_thinks_model_supports_image_input(name, model_provider)
+        for name in model_identity_names(model_name, deployment_name)
+    )
 
 
-def model_needs_formatting_reenabled(model_name: str) -> bool:
+def model_needs_formatting_reenabled(
+    model_name: str, deployment_name: str | None = None
+) -> bool:
     # See https://simonwillison.net/tags/markdown/ for context on why this is needed
     # for OpenAI reasoning models to have correct markdown generation
 
@@ -614,7 +627,7 @@ def model_needs_formatting_reenabled(model_name: str) -> bool:
         + r")(?:$|[\s\-/])"
     )
 
-    if re.search(pattern, model_name):
-        return True
-
-    return False
+    return any(
+        re.search(pattern, name)
+        for name in model_identity_names(model_name, deployment_name)
+    )

--- a/backend/onyx/llm/well_known_providers/llm_provider_options.py
+++ b/backend/onyx/llm/well_known_providers/llm_provider_options.py
@@ -3,12 +3,16 @@ import pathlib
 import threading
 import time
 
+from onyx.llm.api_surfaces import resolve_api_surface
 from onyx.llm.constants import (
     PROVIDER_DISPLAY_NAMES,
     WELL_KNOWN_PROVIDER_NAMES,
     LlmProviderNames,
 )
-from onyx.llm.model_capabilities import get_max_input_tokens
+from onyx.llm.model_capabilities import (
+    get_max_input_tokens,
+    supported_reasoning_efforts,
+)
 from onyx.llm.utils import model_supports_image_input
 from onyx.llm.well_known_providers.auto_update_models import LLMRecommendations
 from onyx.llm.well_known_providers.auto_update_service import (
@@ -289,6 +293,12 @@ def model_configurations_for_provider(
             is_recommended_default=model_name == default_model_name,
             max_input_tokens=get_max_input_tokens(model_name, provider_name),
             supports_image_input=model_supports_image_input(model_name, provider_name),
+            # No provider row exists yet, so the surface is the provider default.
+            supported_reasoning_efforts=supported_reasoning_efforts(
+                provider_name,
+                [model_name],
+                resolve_api_surface(provider_name, None),
+            ),
             display_name=display_name_by_name.get(model_name),
         )
         for model_name in model_names

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -295,8 +295,9 @@ class ModelConfigurationView(BaseModel):
                 supports_image_input=(
                     LLMModelFlowType.VISION
                     in model_configuration_model.llm_model_flow_types
-                    or litellm_thinks_model_supports_image_input(
-                        model_configuration_model.name, provider_name
+                    or any(
+                        litellm_thinks_model_supports_image_input(name, provider_name)
+                        for name in model_identity_names
                     )
                 ),
                 # Prefer the stored REASONING flow; fall back to the LiteLLM
@@ -356,8 +357,9 @@ class ModelConfigurationView(BaseModel):
                 True
                 if LLMModelFlowType.VISION
                 in model_configuration_model.llm_model_flow_types
-                else litellm_thinks_model_supports_image_input(
-                    model_configuration_model.name, provider_name
+                else any(
+                    litellm_thinks_model_supports_image_input(name, provider_name)
+                    for name in model_identity_names
                 )
             ),
             # Prefer the stored REASONING flow; fall back to LiteLLM-based

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -86,6 +86,7 @@ class LLMProviderDescriptor(BaseModel):
             provider,
             use_stored_display_name=llm_provider_model.custom_config is not None,
             custom_config=llm_provider_model.custom_config,
+            deployment_name=llm_provider_model.deployment_name,
         )
         default_model = fetch_default_model_for_provider(provider)
         for model_configuration in model_configurations:
@@ -194,6 +195,7 @@ class LLMProviderView(LLMProvider):
                 provider,
                 use_stored_display_name=llm_provider_model.custom_config is not None,
                 custom_config=llm_provider_model.custom_config,
+                deployment_name=llm_provider_model.deployment_name,
             ),
         )
 
@@ -256,12 +258,19 @@ class ModelConfigurationView(BaseModel):
         provider_name: str,
         use_stored_display_name: bool = False,
         custom_config: dict[str, str] | None = None,
+        deployment_name: str | None = None,
     ) -> "ModelConfigurationView":
+        # A custom provider's model identity may live only in the deployment
+        # alias, the string LiteLLM actually receives. Mirrors multi_llm.py's
+        # model_identity_names so the picker matches the request builder.
+        model_identity_names = [
+            name for name in (model_configuration_model.name, deployment_name) if name
+        ]
         # The admin's chosen wire protocol decides which reasoning parameters
         # reach the model, so it decides which effort levels are selectable.
         reasoning_efforts = supported_reasoning_efforts(
             provider_name,
-            [model_configuration_model.name],
+            model_identity_names,
             resolve_api_surface(provider_name, custom_config),
         )
 

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -14,6 +14,9 @@ from onyx.llm.model_capabilities import (
     model_is_reasoning_model,
     supported_reasoning_efforts,
 )
+from onyx.llm.model_capabilities import (
+    model_identity_names as resolve_model_identity_names,
+)
 from onyx.llm.models import ReasoningEffort
 from onyx.server.manage.llm.utils import (
     extract_vendor_from_model_name,
@@ -260,12 +263,9 @@ class ModelConfigurationView(BaseModel):
         custom_config: dict[str, str] | None = None,
         deployment_name: str | None = None,
     ) -> "ModelConfigurationView":
-        # A custom provider's model identity may live only in the deployment
-        # alias, the string LiteLLM actually receives. Mirrors multi_llm.py's
-        # model_identity_names so the picker matches the request builder.
-        model_identity_names = [
-            name for name in (model_configuration_model.name, deployment_name) if name
-        ]
+        model_identity_names = resolve_model_identity_names(
+            model_configuration_model.name, deployment_name
+        )
         # The admin's chosen wire protocol decides which reasoning parameters
         # reach the model, so it decides which effort levels are selectable.
         reasoning_efforts = supported_reasoning_efforts(

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -9,6 +9,7 @@ from onyx.db.enums import LLMModelFlowType
 from onyx.llm.api_surfaces import resolve_api_surface
 from onyx.llm.constants import DYNAMIC_LLM_PROVIDERS
 from onyx.llm.model_capabilities import (
+    anthropic_supports_thinking,
     get_max_input_tokens,
     litellm_thinks_model_supports_image_input,
     model_is_reasoning_model,
@@ -300,12 +301,16 @@ class ModelConfigurationView(BaseModel):
                         for name in model_identity_names
                     )
                 ),
-                # Prefer the stored REASONING flow; fall back to the LiteLLM
-                # cost map, then a substring heuristic on model name/display
-                # name for models LiteLLM doesn't know.
+                # Prefer the stored flow, then the Claude version parse, then
+                # the LiteLLM cost map, then a name/display-name substring
+                # heuristic. Mirrors multi_llm.py's is_reasoning.
                 supports_reasoning=(
                     LLMModelFlowType.REASONING
                     in model_configuration_model.llm_model_flow_types
+                    or any(
+                        anthropic_supports_thinking(name)
+                        for name in model_identity_names
+                    )
                     or any(
                         model_is_reasoning_model(name, provider_name)
                         for name in model_identity_names
@@ -364,11 +369,15 @@ class ModelConfigurationView(BaseModel):
                     for name in model_identity_names
                 )
             ),
-            # Prefer the stored REASONING flow; fall back to LiteLLM-based
-            # detection for legacy rows that were saved before the flow existed.
+            # Prefer the stored flow, then the Claude version parse, then
+            # LiteLLM-based detection for legacy rows saved before the flow
+            # existed. Mirrors multi_llm.py's is_reasoning.
             supports_reasoning=(
                 LLMModelFlowType.REASONING
                 in model_configuration_model.llm_model_flow_types
+                or any(
+                    anthropic_supports_thinking(name) for name in model_identity_names
+                )
                 or any(
                     model_is_reasoning_model(name, provider_name)
                     for name in model_identity_names

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -310,9 +310,11 @@ class ModelConfigurationView(BaseModel):
                         model_is_reasoning_model(name, provider_name)
                         for name in model_identity_names
                     )
-                    or is_reasoning_model(
-                        model_configuration_model.name,
-                        model_configuration_model.display_name or "",
+                    or any(
+                        is_reasoning_model(
+                            name, model_configuration_model.display_name or ""
+                        )
+                        for name in model_identity_names
                     )
                 ),
                 supported_reasoning_efforts=reasoning_efforts,

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -305,8 +305,9 @@ class ModelConfigurationView(BaseModel):
                 supports_reasoning=(
                     LLMModelFlowType.REASONING
                     in model_configuration_model.llm_model_flow_types
-                    or model_is_reasoning_model(
-                        model_configuration_model.name, provider_name
+                    or any(
+                        model_is_reasoning_model(name, provider_name)
+                        for name in model_identity_names
                     )
                     or is_reasoning_model(
                         model_configuration_model.name,
@@ -364,8 +365,9 @@ class ModelConfigurationView(BaseModel):
             supports_reasoning=(
                 LLMModelFlowType.REASONING
                 in model_configuration_model.llm_model_flow_types
-                or model_is_reasoning_model(
-                    model_configuration_model.name, provider_name
+                or any(
+                    model_is_reasoning_model(name, provider_name)
+                    for name in model_identity_names
                 )
             ),
             supported_reasoning_efforts=reasoning_efforts,

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -6,12 +6,15 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar
 from pydantic import BaseModel, Field, field_validator
 
 from onyx.db.enums import LLMModelFlowType
+from onyx.llm.api_surfaces import resolve_api_surface
 from onyx.llm.constants import DYNAMIC_LLM_PROVIDERS
 from onyx.llm.model_capabilities import (
     get_max_input_tokens,
     litellm_thinks_model_supports_image_input,
     model_is_reasoning_model,
+    supported_reasoning_efforts,
 )
+from onyx.llm.models import ReasoningEffort
 from onyx.server.manage.llm.utils import (
     extract_vendor_from_model_name,
     filter_model_configurations,
@@ -82,6 +85,7 @@ class LLMProviderDescriptor(BaseModel):
             llm_provider_model.model_configurations,
             provider,
             use_stored_display_name=llm_provider_model.custom_config is not None,
+            custom_config=llm_provider_model.custom_config,
         )
         default_model = fetch_default_model_for_provider(provider)
         for model_configuration in model_configurations:
@@ -189,6 +193,7 @@ class LLMProviderView(LLMProvider):
                 llm_provider_model.model_configurations,
                 provider,
                 use_stored_display_name=llm_provider_model.custom_config is not None,
+                custom_config=llm_provider_model.custom_config,
             ),
         )
 
@@ -231,6 +236,10 @@ class ModelConfigurationView(BaseModel):
     configured_max_input_tokens: int | None = Field(default=None, exclude=True)
     supports_image_input: bool
     supports_reasoning: bool = False
+    # Effort levels this model tells apart, ascending. Read alongside
+    # supports_reasoning: an empty list on a reasoning model means the model
+    # takes no effort parameter. The model picker offers exactly these.
+    supported_reasoning_efforts: list[ReasoningEffort] = Field(default_factory=list)
     # True when this is the provider's recommended default model.
     is_recommended_default: bool = False
     display_name: str | None = None
@@ -246,7 +255,16 @@ class ModelConfigurationView(BaseModel):
         model_configuration_model: "ModelConfigurationModel",
         provider_name: str,
         use_stored_display_name: bool = False,
+        custom_config: dict[str, str] | None = None,
     ) -> "ModelConfigurationView":
+        # The admin's chosen wire protocol decides which reasoning parameters
+        # reach the model, so it decides which effort levels are selectable.
+        reasoning_efforts = supported_reasoning_efforts(
+            provider_name,
+            [model_configuration_model.name],
+            resolve_api_surface(provider_name, custom_config),
+        )
+
         # For dynamic providers (OpenRouter, Bedrock, Ollama) and custom-config
         # providers, use the display_name stored in DB. Skip LiteLLM parsing.
         if (
@@ -286,6 +304,7 @@ class ModelConfigurationView(BaseModel):
                         model_configuration_model.display_name or "",
                     )
                 ),
+                supported_reasoning_efforts=reasoning_efforts,
                 display_name=model_configuration_model.display_name,
                 custom_display_name=model_configuration_model.custom_display_name,
                 provider_display_name=None,  # Not needed for dynamic providers
@@ -340,6 +359,7 @@ class ModelConfigurationView(BaseModel):
                     model_configuration_model.name, provider_name
                 )
             ),
+            supported_reasoning_efforts=reasoning_efforts,
             # Populate display fields from parsed model name
             display_name=display_name,
             custom_display_name=model_configuration_model.custom_display_name,

--- a/backend/onyx/server/manage/llm/utils.py
+++ b/backend/onyx/server/manage/llm/utils.py
@@ -271,6 +271,7 @@ def filter_model_configurations(
     model_configurations: list,
     provider: str,
     use_stored_display_name: bool = False,
+    custom_config: dict[str, str] | None = None,
 ) -> list:
     """Filter out obsolete and dated duplicate models from configurations.
 
@@ -279,6 +280,8 @@ def filter_model_configurations(
         provider: The provider name (e.g., "openai", "anthropic")
         use_stored_display_name: If True, prefer the display_name stored in the
             DB over LiteLLM enrichments. Set for custom-config providers.
+        custom_config: The provider's custom config, which for a gateway holds
+            the admin-selected API surface.
 
     Returns:
         List of ModelConfigurationView objects with obsolete/duplicate models removed
@@ -299,7 +302,7 @@ def filter_model_configurations(
             continue
         filtered_configs.append(
             ModelConfigurationView.from_model(
-                model_configuration, provider, use_stored_display_name
+                model_configuration, provider, use_stored_display_name, custom_config
             )
         )
 

--- a/backend/onyx/server/manage/llm/utils.py
+++ b/backend/onyx/server/manage/llm/utils.py
@@ -308,9 +308,9 @@ def filter_model_configurations(
             ModelConfigurationView.from_model(
                 model_configuration,
                 provider,
-                use_stored_display_name,
-                custom_config,
-                deployment_name,
+                use_stored_display_name=use_stored_display_name,
+                custom_config=custom_config,
+                deployment_name=deployment_name,
             )
         )
 

--- a/backend/onyx/server/manage/llm/utils.py
+++ b/backend/onyx/server/manage/llm/utils.py
@@ -272,6 +272,7 @@ def filter_model_configurations(
     provider: str,
     use_stored_display_name: bool = False,
     custom_config: dict[str, str] | None = None,
+    deployment_name: str | None = None,
 ) -> list:
     """Filter out obsolete and dated duplicate models from configurations.
 
@@ -282,6 +283,9 @@ def filter_model_configurations(
             DB over LiteLLM enrichments. Set for custom-config providers.
         custom_config: The provider's custom config, which for a gateway holds
             the admin-selected API surface.
+        deployment_name: The provider-level deployment alias (e.g. Azure AI
+            Foundry), which is the string actually sent to LiteLLM when a
+            model's own name doesn't carry its identity.
 
     Returns:
         List of ModelConfigurationView objects with obsolete/duplicate models removed
@@ -302,7 +306,11 @@ def filter_model_configurations(
             continue
         filtered_configs.append(
             ModelConfigurationView.from_model(
-                model_configuration, provider, use_stored_display_name, custom_config
+                model_configuration,
+                provider,
+                use_stored_display_name,
+                custom_config,
+                deployment_name,
             )
         )
 

--- a/backend/tests/integration/tests/llm_provider/test_llm_provider.py
+++ b/backend/tests/integration/tests/llm_provider/test_llm_provider.py
@@ -4,11 +4,14 @@ from typing import Any
 import httpx
 import pytest
 
+from onyx.llm.api_surfaces import resolve_api_surface
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.model_capabilities import (
     get_max_input_tokens,
     litellm_thinks_model_supports_image_input,
+    model_identity_names,
     model_is_reasoning_model,
+    supported_reasoning_efforts,
 )
 from onyx.llm.model_name_parser import parse_litellm_model_name
 from onyx.llm.well_known_providers.llm_provider_options import (
@@ -75,6 +78,14 @@ def assert_response_is_equivalent(
                 req.name, provider_name
             ),
             "supports_reasoning": model_is_reasoning_model(req.name, provider_name),
+            "supported_reasoning_efforts": [
+                effort.value
+                for effort in supported_reasoning_efforts(
+                    provider_name,
+                    model_identity_names(req.name, None),
+                    resolve_api_surface(provider_name, None),
+                )
+            ],
             "is_recommended_default": req.name
             == fetch_default_model_for_provider(provider_name),
             "display_name": display_name,

--- a/backend/tests/unit/onyx/llm/test_llm_utils_deployment_alias.py
+++ b/backend/tests/unit/onyx/llm/test_llm_utils_deployment_alias.py
@@ -1,0 +1,38 @@
+"""Unit tests for `onyx.llm.utils` helpers that must consider a custom
+provider's deployment alias, not just the stored model name, when resolving
+model identity (e.g. Azure AI Foundry, where the alias is the string
+actually sent to LiteLLM).
+"""
+
+from onyx.llm.utils import model_needs_formatting_reenabled, model_supports_image_input
+
+
+def test_model_supports_image_input_via_deployment_alias() -> None:
+    """The model row's own name is opaque; only the deployment alias reveals
+    a real vision-capable model. This is what the live chat path
+    (llm_step.py, llm_loop.py) checks before dropping images from history."""
+    assert (
+        model_supports_image_input(
+            "friendly-deploy-8", "azure", deployment_name="gpt-5.1"
+        )
+        is True
+    )
+
+
+def test_model_supports_image_input_false_without_alias() -> None:
+    """Without the alias, an opaque name correctly resolves to no vision
+    support rather than silently guessing."""
+    assert model_supports_image_input("friendly-deploy-8", "azure") is False
+
+
+def test_model_needs_formatting_reenabled_via_deployment_alias() -> None:
+    """Same identity gap: the reasoning-model markdown-formatting fix must
+    also fire when the real model name lives only in the deployment alias."""
+    assert (
+        model_needs_formatting_reenabled("friendly-deploy-9", deployment_name="gpt-5.1")
+        is True
+    )
+
+
+def test_model_needs_formatting_reenabled_false_without_alias() -> None:
+    assert model_needs_formatting_reenabled("friendly-deploy-9") is False

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -30,7 +30,6 @@ from onyx.llm.multi_llm import (
     LitellmLLM,
     LLMTimeoutError,
     _consume_stream_with_timeout,
-    _parse_anthropic_model_version,
     temporary_env_and_lock,
 )
 
@@ -619,52 +618,6 @@ def test_keeps_temperature_for_older_sonnet_models(model_name: str) -> None:
         assert "temperature" in kwargs
 
 
-@pytest.mark.parametrize(
-    "model_name, expected",
-    [
-        # Tier-first, hyphenated
-        ("claude-opus-4-8", (4, 8)),
-        ("claude-opus-4-7", (4, 7)),
-        ("claude-sonnet-4-6", (4, 6)),
-        ("claude-sonnet-4-5", (4, 5)),
-        # Tier-first, dot-separated
-        ("claude-opus-4.8", (4, 8)),
-        ("claude-opus-4.7", (4, 7)),
-        # Version-first (litellm_proxy / reversed schemes)
-        ("claude-4-8-opus", (4, 8)),
-        ("claude-4.8-opus", (4, 8)),
-        ("claude-4-7-opus", (4, 7)),
-        ("claude-4.7-opus", (4, 7)),
-        # Claude 5 named tiers, version digit on either side
-        ("claude-sonnet-5", (5, 0)),
-        ("claude-5-sonnet", (5, 0)),
-        ("claude-fable-5", (5, 0)),
-        ("claude-5-fable", (5, 0)),
-        ("claude-mythos-5", (5, 0)),
-        ("claude-5-mythos", (5, 0)),
-        ("claude-opus-5", (5, 0)),
-        ("claude-5-opus", (5, 0)),
-        # Date/snapshot suffixes stripped
-        ("claude-opus-4-8@20260101", (4, 8)),
-        ("claude-sonnet-5@20260203", (5, 0)),
-        ("claude-opus-4-5@20251101", (4, 5)),
-        ("claude-3-5-sonnet-20241022", (3, 5)),
-        # Legacy naming
-        ("claude-3-7-sonnet", (3, 7)),
-        # Provider-prefixed
-        ("anthropic/claude-opus-4-8", (4, 8)),
-        ("bedrock/anthropic.claude-opus-4-7", (4, 7)),
-        # Non-Claude models parse to None
-        ("gpt-5.2", None),
-        ("gemini-2.5-pro", None),
-    ],
-)
-def test_parse_anthropic_model_version(
-    model_name: str, expected: tuple[int, int] | None
-) -> None:
-    assert _parse_anthropic_model_version(model_name) == expected
-
-
 @pytest.mark.parametrize("model_name", VERTEX_OPUS_MODELS_REJECTING_STREAM_OPTIONS)
 def test_vertex_stream_omits_stream_options(model_name: str) -> None:
     llm = LitellmLLM(
@@ -766,6 +719,57 @@ def test_claude_via_openai_compatible_proxy_uses_reasoning_param() -> None:
         assert kwargs["reasoning"] == {"effort": "high", "summary": "auto"}
         assert "thinking" not in kwargs
         assert "output_config" not in kwargs
+
+
+@pytest.mark.parametrize("api_mode", ["chat_completions", "responses"])
+def test_openai_via_openai_compatible_proxy_reaches_xhigh(api_mode: str) -> None:
+    """An OpenAI model behind a gateway is still an OpenAI model: it takes the
+    OpenAI reasoning param, and xhigh reaches it instead of being clamped to
+    high by the LiteLLM fallback."""
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.BIFROST,
+        model_name="openai/gpt-5.1",
+        api_base="https://gateway.example/v1",
+        max_input_tokens=200000,
+        custom_config={"bifrost_api_mode": api_mode},
+    )
+
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages, reasoning_effort=ReasoningEffort.XHIGH))
+
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["reasoning"] == {"effort": "xhigh", "summary": "auto"}
+        assert "reasoning_effort" not in kwargs
+
+
+def test_gateway_chat_alias_only_silences_openai_models() -> None:
+    """The "-chat" rule is an OpenAI quirk (their chat models reject reasoning
+    params). A Claude alias that happens to contain it must still reason."""
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.BIFROST,
+        model_name="anthropic/claude-sonnet-4-5-chat",
+        api_base="https://gateway.example/v1",
+        max_input_tokens=200000,
+        custom_config={"bifrost_api_mode": "chat_completions"},
+    )
+
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages, reasoning_effort=ReasoningEffort.HIGH))
+
+        assert mock_completion.call_args.kwargs["reasoning"] == {
+            "effort": "high",
+            "summary": "auto",
+        }
 
 
 def test_aliased_claude_model_still_reasons() -> None:

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -2506,6 +2506,35 @@ def test_required_tool_choice_downgraded_to_auto(
         assert kwargs["tool_choice"] == ToolChoiceOptions.AUTO
 
 
+def test_qwen_only_in_deployment_name_downgrades_tool_choice() -> None:
+    """is_qwen_model must also check deployment_name, same identity gap as
+    is_claude_model above it. A Qwen model reachable only by alias must
+    still get the required->auto downgrade or the provider 400s."""
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.LITELLM_PROXY,
+        model_name="foundry-deploy-3",
+        deployment_name="qwen/qwen3.7-plus",
+        max_input_tokens=32000,
+    )
+
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Weather in NYC?")]
+        list(
+            llm.stream(
+                messages,
+                tools=_TOOL_CHOICE_DOWNGRADE_TOOLS,
+                tool_choice=ToolChoiceOptions.REQUIRED,
+            )
+        )
+
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["tool_choice"] == ToolChoiceOptions.AUTO
+
+
 def test_required_tool_choice_preserved_for_other_models(
     default_multi_llm: LitellmLLM,
 ) -> None:

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -1339,6 +1339,36 @@ def test_azure_openai_model_uses_httphandler_client() -> None:
         assert isinstance(kwargs["client"], HTTPHandler)
 
 
+def test_openai_only_in_deployment_name_gets_isolated_client() -> None:
+    """_uses_isolated_client() must also check deployment_name: an Azure
+    Foundry model identified solely by its alias still needs the per-call
+    HTTPHandler, or it silently rejoins litellm's shared connection pool."""
+    from litellm import HTTPHandler
+
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.AZURE,
+        model_name="foundry-deploy-5",
+        deployment_name="gpt-5.1",
+        api_base="https://my-resource.openai.azure.us",
+        api_version="2025-03-01-preview",
+        max_input_tokens=get_max_input_tokens(
+            model_provider=LlmProviderNames.AZURE,
+            model_name="foundry-deploy-5",
+        ),
+    )
+
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages))
+
+        mock_completion.assert_called_once()
+        kwargs = mock_completion.call_args.kwargs
+        assert isinstance(kwargs["client"], HTTPHandler)
+
+
 def test_temporary_env_cleanup(monkeypatch: pytest.MonkeyPatch) -> None:
     # Assign some environment variables
     EXPECTED_ENV_VARS = {

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -524,6 +524,35 @@ def test_claude_only_in_deployment_name_omits_temperature_and_reasons() -> None:
         assert kwargs["output_config"] == {"effort": "high"}
 
 
+def test_openai_only_in_deployment_name_uses_responses_bridge() -> None:
+    # is_openai_model must also check deployment_name: an Azure Foundry model
+    # identified only by its alias must still route through the responses
+    # bridge (and get the api-version override), not the plain chat surface.
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.AZURE,
+        model_name="foundry-deploy-4",
+        deployment_name="gpt-5.1",
+        api_base="https://my-resource.openai.azure.us",
+        api_version="2025-03-01-preview",
+        max_input_tokens=get_max_input_tokens(
+            model_provider=LlmProviderNames.AZURE,
+            model_name="foundry-deploy-4",
+        ),
+    )
+
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages, reasoning_effort=ReasoningEffort.HIGH))
+
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["model"] == "azure/responses/gpt-5.1"
+        assert kwargs["api_version"] is None
+        assert kwargs["reasoning"]["effort"] == "high"
+
+
 @pytest.mark.parametrize(
     "model_name",
     [

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -978,6 +978,38 @@ def test_reasoning_effort_sent_for_o1() -> None:
         assert kwargs["reasoning"]["effort"] == "medium"
 
 
+def test_o1_mini_only_in_deployment_name_omits_reasoning_effort() -> None:
+    """The o1-mini/o1-preview rejection guard is name-only by design and must
+    consider the deployment alias too, not just model_name. Same identity
+    gap as test_claude_only_in_deployment_name_omits_temperature_and_reasons."""
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.AZURE,
+        model_name="foundry-deploy-2",
+        deployment_name="o1-mini",
+        api_base="https://my-resource.openai.azure.us",
+        api_version="2025-03-01-preview",
+        max_input_tokens=get_max_input_tokens(
+            model_provider=LlmProviderNames.AZURE,
+            model_name="foundry-deploy-2",
+        ),
+    )
+
+    with (
+        patch("litellm.completion") as mock_completion,
+        patch("onyx.llm.multi_llm.model_is_reasoning_model", return_value=True),
+        patch("onyx.llm.multi_llm.is_true_openai_model", return_value=True),
+    ):
+        mock_completion.return_value = []
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages, reasoning_effort=ReasoningEffort.AUTO))
+
+        kwargs = mock_completion.call_args.kwargs
+        assert "reasoning" not in kwargs
+        assert "reasoning_effort" not in kwargs
+
+
 def test_user_identity_metadata_enabled(default_multi_llm: LitellmLLM) -> None:
     with (
         patch("litellm.completion") as mock_completion,

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -996,16 +996,13 @@ def test_o1_mini_only_in_deployment_name_omits_reasoning_effort() -> None:
         ),
     )
 
-    with (
-        patch("litellm.completion") as mock_completion,
-        patch("onyx.llm.multi_llm.model_is_reasoning_model", return_value=True),
-        patch("onyx.llm.multi_llm.is_true_openai_model", return_value=True),
-    ):
+    with patch("litellm.completion") as mock_completion:
         mock_completion.return_value = []
         messages: LanguageModelInput = [UserMessage(content="Hi")]
         list(llm.stream(messages, reasoning_effort=ReasoningEffort.AUTO))
 
         kwargs = mock_completion.call_args.kwargs
+        assert kwargs["temperature"] == 1  # confirms is_reasoning resolved True
         assert "reasoning" not in kwargs
         assert "reasoning_effort" not in kwargs
 

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -872,6 +872,56 @@ def test_openai_chat_omits_reasoning_params() -> None:
         assert mock_is_openai.called
 
 
+def test_chat_variant_only_in_deployment_name_omits_reasoning() -> None:
+    """The "-chat" guard reads the wire string (deployment_name takes
+    priority), so a real gpt-5-chat model hidden behind an opaque alias
+    must still have reasoning omitted or OpenAI 400s it."""
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.AZURE,
+        model_name="gpt-5-chat",
+        deployment_name="prod-deploy-1",
+        api_base="https://my-resource.openai.azure.us",
+        max_input_tokens=get_max_input_tokens(
+            model_provider=LlmProviderNames.AZURE, model_name="gpt-5-chat"
+        ),
+    )
+
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages, reasoning_effort=ReasoningEffort.HIGH))
+
+        kwargs = mock_completion.call_args.kwargs
+        assert "reasoning" not in kwargs
+
+
+def test_coincidental_chat_alias_does_not_silence_reasoning() -> None:
+    """A deployment alias merely containing "-chat" (not a real gpt-5-chat
+    registry model) must not silently suppress reasoning for a model that
+    otherwise supports it."""
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.AZURE,
+        model_name="gpt-5.1",
+        deployment_name="prod-chat-1",
+        api_base="https://my-resource.openai.azure.us",
+        max_input_tokens=get_max_input_tokens(
+            model_provider=LlmProviderNames.AZURE, model_name="gpt-5.1"
+        ),
+    )
+
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages, reasoning_effort=ReasoningEffort.HIGH))
+
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["reasoning"]["effort"] == "high"
+
+
 def _azure_llm(model_name: str, api_version: str | None) -> LitellmLLM:
     return LitellmLLM(
         api_key="test_key",

--- a/backend/tests/unit/onyx/llm/test_reasoning_capabilities.py
+++ b/backend/tests/unit/onyx/llm/test_reasoning_capabilities.py
@@ -219,6 +219,15 @@ def test_models_rejecting_reasoning_effort_support_no_levels(model_name: str) ->
     assert supported_reasoning_efforts(LlmProviderNames.AZURE, [model_name], None) == []
 
 
+@pytest.mark.parametrize("model_name", ["gpt-5-chat-latest", "gpt-5.1-chat-latest"])
+def test_chat_variants_support_no_levels(model_name: str) -> None:
+    """The request builder drops every reasoning param for GPT-5 "-chat"
+    registry variants, so the picker must offer no levels either."""
+    assert (
+        supported_reasoning_efforts(LlmProviderNames.OPENAI, [model_name], None) == []
+    )
+
+
 def test_model_identity_taken_from_any_name() -> None:
     """Custom providers can carry the model identity only in the deployment
     alias, so every candidate name is considered."""

--- a/backend/tests/unit/onyx/llm/test_reasoning_capabilities.py
+++ b/backend/tests/unit/onyx/llm/test_reasoning_capabilities.py
@@ -1,0 +1,230 @@
+import pytest
+
+from onyx.llm.api_surfaces import LlmApiSurface
+from onyx.llm.constants import LlmProviderNames
+from onyx.llm.model_capabilities import (
+    ReasoningParamStyle,
+    is_openai_registry_model_name,
+    parse_anthropic_model_version,
+    resolve_reasoning_param_style,
+    supported_reasoning_efforts,
+)
+from onyx.llm.models import ReasoningEffort
+
+CHAT_COMPLETIONS = LlmApiSurface.OPENAI_CHAT_COMPLETIONS
+RESPONSES = LlmApiSurface.OPENAI_RESPONSES
+
+
+@pytest.mark.parametrize(
+    "model_name, expected",
+    [
+        # Tier-first, hyphenated
+        ("claude-opus-4-8", (4, 8)),
+        ("claude-opus-4-7", (4, 7)),
+        ("claude-sonnet-4-6", (4, 6)),
+        ("claude-sonnet-4-5", (4, 5)),
+        # Tier-first, dot-separated
+        ("claude-opus-4.8", (4, 8)),
+        ("claude-opus-4.7", (4, 7)),
+        # Version-first (litellm_proxy / reversed schemes)
+        ("claude-4-8-opus", (4, 8)),
+        ("claude-4.8-opus", (4, 8)),
+        ("claude-4-7-opus", (4, 7)),
+        ("claude-4.7-opus", (4, 7)),
+        # Claude 5 named tiers, version digit on either side
+        ("claude-sonnet-5", (5, 0)),
+        ("claude-5-sonnet", (5, 0)),
+        ("claude-fable-5", (5, 0)),
+        ("claude-5-fable", (5, 0)),
+        ("claude-mythos-5", (5, 0)),
+        ("claude-5-mythos", (5, 0)),
+        ("claude-opus-5", (5, 0)),
+        ("claude-5-opus", (5, 0)),
+        # Date/snapshot suffixes stripped
+        ("claude-opus-4-8@20260101", (4, 8)),
+        ("claude-sonnet-5@20260203", (5, 0)),
+        ("claude-opus-4-5@20251101", (4, 5)),
+        ("claude-3-5-sonnet-20241022", (3, 5)),
+        # Legacy naming
+        ("claude-3-7-sonnet", (3, 7)),
+        # Provider-prefixed
+        ("anthropic/claude-opus-4-8", (4, 8)),
+        ("bedrock/anthropic.claude-opus-4-7", (4, 7)),
+        # Bedrock inference profiles carry a region prefix and a version suffix
+        ("us.anthropic.claude-opus-4-7-20260101-v1:0", (4, 7)),
+        ("global.anthropic.claude-opus-4-8-20260301-v1:0", (4, 8)),
+        ("anthropic.claude-sonnet-4-20250514-v1:0", (4, 0)),
+        # Non-Claude models parse to None
+        ("gpt-5.2", None),
+        ("gemini-2.5-pro", None),
+    ],
+)
+def test_parse_anthropic_model_version(
+    model_name: str, expected: tuple[int, int] | None
+) -> None:
+    assert parse_anthropic_model_version(model_name) == expected
+
+
+@pytest.mark.parametrize(
+    "model_name, expected",
+    [
+        ("gpt-5.1", True),
+        ("o3", True),
+        # Aggregators address models as "vendor/model"
+        ("openai/gpt-5.1", True),
+        ("openai/o3", True),
+        ("anthropic/claude-opus-4-7", False),
+        ("google/gemini-3-pro", False),
+        ("llama3.1", False),
+        ("", False),
+    ],
+)
+def test_is_openai_registry_model_name(model_name: str, expected: bool) -> None:
+    assert is_openai_registry_model_name(model_name) is expected
+
+
+@pytest.mark.parametrize(
+    "provider, model_name, api_surface, expected_style",
+    [
+        # OpenAI reached over OpenAI's own API.
+        (LlmProviderNames.OPENAI, "gpt-5.1", None, ReasoningParamStyle.OPENAI),
+        (LlmProviderNames.AZURE, "gpt-5.1", None, ReasoningParamStyle.OPENAI),
+        (
+            LlmProviderNames.LITELLM_PROXY,
+            "gpt-5.1",
+            None,
+            ReasoningParamStyle.OPENAI,
+        ),
+        # OpenAI behind a gateway that speaks OpenAI, under either mode.
+        (
+            LlmProviderNames.BIFROST,
+            "openai/gpt-5.1",
+            CHAT_COMPLETIONS,
+            ReasoningParamStyle.OPENAI,
+        ),
+        (
+            LlmProviderNames.BIFROST,
+            "openai/gpt-5.1",
+            RESPONSES,
+            ReasoningParamStyle.OPENAI,
+        ),
+        (
+            LlmProviderNames.OPENAI_COMPATIBLE,
+            "gpt-5.1",
+            CHAT_COMPLETIONS,
+            ReasoningParamStyle.OPENAI,
+        ),
+        # Claude behind such a gateway: format follows the surface, not the vendor.
+        (
+            LlmProviderNames.BIFROST,
+            "anthropic/claude-opus-4-7",
+            CHAT_COMPLETIONS,
+            ReasoningParamStyle.OPENAI,
+        ),
+        # Native Anthropic, on both sides of the adaptive-thinking cutover.
+        (
+            LlmProviderNames.ANTHROPIC,
+            "claude-opus-4-7",
+            None,
+            ReasoningParamStyle.ANTHROPIC_ADAPTIVE,
+        ),
+        (
+            LlmProviderNames.BEDROCK,
+            "us.anthropic.claude-opus-4-7-20260101-v1:0",
+            None,
+            ReasoningParamStyle.ANTHROPIC_ADAPTIVE,
+        ),
+        (
+            LlmProviderNames.ANTHROPIC,
+            "claude-3-7-sonnet",
+            None,
+            ReasoningParamStyle.ANTHROPIC_BUDGET,
+        ),
+        (
+            LlmProviderNames.BEDROCK,
+            "anthropic.claude-sonnet-4-20250514-v1:0",
+            None,
+            ReasoningParamStyle.ANTHROPIC_BUDGET,
+        ),
+        # Everything else falls back to LiteLLM's own mapping.
+        (
+            LlmProviderNames.VERTEX_AI,
+            "gemini-3-pro",
+            None,
+            ReasoningParamStyle.LITELLM_EFFORT,
+        ),
+        (
+            LlmProviderNames.BIFROST,
+            "google/gemini-3-pro",
+            CHAT_COMPLETIONS,
+            ReasoningParamStyle.LITELLM_EFFORT,
+        ),
+        (
+            LlmProviderNames.OPENROUTER,
+            "openai/gpt-5.1",
+            None,
+            ReasoningParamStyle.LITELLM_EFFORT,
+        ),
+    ],
+)
+def test_resolve_reasoning_param_style(
+    provider: str,
+    model_name: str,
+    api_surface: LlmApiSurface | None,
+    expected_style: ReasoningParamStyle,
+) -> None:
+    assert (
+        resolve_reasoning_param_style(provider, [model_name], api_surface)
+        == expected_style
+    )
+
+
+@pytest.mark.parametrize(
+    "provider, model_name, api_surface, xhigh_supported",
+    [
+        (LlmProviderNames.OPENAI, "gpt-5.1", None, True),
+        # The bug this replaced: an OpenAI model behind Bifrost was treated as
+        # an unknown model, so xhigh was clamped away and greyed out.
+        (LlmProviderNames.BIFROST, "openai/gpt-5.1", CHAT_COMPLETIONS, True),
+        (LlmProviderNames.BIFROST, "anthropic/claude-opus-4-7", CHAT_COMPLETIONS, True),
+        (LlmProviderNames.ANTHROPIC, "claude-opus-4-7", None, True),
+        (LlmProviderNames.BEDROCK, "us.anthropic.claude-opus-4-8-v1:0", None, True),
+        # Legacy Anthropic budgets make xhigh indistinguishable from high.
+        (LlmProviderNames.ANTHROPIC, "claude-3-7-sonnet", None, False),
+        # LiteLLM's per-provider mappings reject or drop xhigh.
+        (LlmProviderNames.VERTEX_AI, "gemini-3-pro", None, False),
+        (LlmProviderNames.OPENROUTER, "openai/gpt-5.1", None, False),
+    ],
+)
+def test_supported_reasoning_efforts(
+    provider: str,
+    model_name: str,
+    api_surface: LlmApiSurface | None,
+    xhigh_supported: bool,
+) -> None:
+    efforts = supported_reasoning_efforts(provider, [model_name], api_surface)
+    assert efforts[:4] == [
+        ReasoningEffort.OFF,
+        ReasoningEffort.LOW,
+        ReasoningEffort.MEDIUM,
+        ReasoningEffort.HIGH,
+    ]
+    assert (ReasoningEffort.XHIGH in efforts) is xhigh_supported
+
+
+@pytest.mark.parametrize("model_name", ["o1-mini", "o1-preview", "o1-mini-2024-09-12"])
+def test_models_rejecting_reasoning_effort_support_no_levels(model_name: str) -> None:
+    """These models reason but take no effort parameter on any surface, so the
+    picker must offer nothing rather than a slider that changes nothing."""
+    assert supported_reasoning_efforts(LlmProviderNames.AZURE, [model_name], None) == []
+
+
+def test_model_identity_taken_from_any_name() -> None:
+    """Custom providers can carry the model identity only in the deployment
+    alias, so every candidate name is considered."""
+    assert (
+        resolve_reasoning_param_style(
+            LlmProviderNames.VERTEX_AI, ["prod-alias", "claude-opus-4-7"], None
+        )
+        is ReasoningParamStyle.ANTHROPIC_ADAPTIVE
+    )

--- a/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
@@ -10,6 +10,7 @@ These tests verify the flow plumbing:
 from unittest.mock import MagicMock, patch
 
 from onyx.db.enums import LLMModelFlowType
+from onyx.llm.models import ReasoningEffort
 from onyx.server.manage.llm.models import (
     LLMProviderDescriptor,
     ModelConfigurationUpsertRequest,
@@ -438,6 +439,40 @@ class TestLLMProviderDescriptorRecommendedDefault:
         assert all(
             not m.is_recommended_default for m in descriptor.model_configurations
         )
+
+
+class TestSupportedReasoningEfforts:
+    """The picker offers exactly the levels the request builder can deliver, so
+    the view has to resolve them from the provider and its wire protocol."""
+
+    def test_openai_model_behind_a_gateway_offers_xhigh(self) -> None:
+        """Bifrost addresses models as "vendor/model". Reading the vendor off
+        the name is what keeps xhigh available here."""
+        view = ModelConfigurationView.from_model(
+            _make_model_config(name="openai/gpt-5.1", display_name="GPT-5.1"),
+            "bifrost",
+            custom_config={"bifrost_api_mode": "chat_completions"},
+        )
+
+        assert ReasoningEffort.XHIGH in view.supported_reasoning_efforts
+
+    def test_unknown_gateway_model_stops_at_high(self) -> None:
+        """LiteLLM's fallback mapping clamps xhigh, so it must not be offered."""
+        view = ModelConfigurationView.from_model(
+            _make_model_config(name="google/gemini-3-pro", display_name="Gemini 3 Pro"),
+            "bifrost",
+            custom_config={"bifrost_api_mode": "chat_completions"},
+        )
+
+        assert view.supported_reasoning_efforts[-1] is ReasoningEffort.HIGH
+
+    def test_static_provider_branch_populates_efforts(self) -> None:
+        """The LiteLLM-enriched branch answers too, not just the dynamic one."""
+        view = ModelConfigurationView.from_model(
+            _make_model_config(name="gpt-5.1", display_name=None), "openai"
+        )
+
+        assert ReasoningEffort.XHIGH in view.supported_reasoning_efforts
 
 
 def _make_model_config(

--- a/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
@@ -270,6 +270,24 @@ class TestModelConfigurationViewReasoningFallback:
 
         assert view.supports_reasoning is True
 
+    def test_unregistered_claude_alias_reasons_via_version_parse(self) -> None:
+        """A Claude deployment alias that misses both LiteLLM's registry and
+        the substring heuristic must still resolve True via the version
+        parse multi_llm.py's request builder already relies on."""
+        mc = _make_model_config(
+            name="foundry-deploy-10",
+            display_name="Foundry Deploy 10",
+            flow_types=[LLMModelFlowType.CHAT],
+        )
+
+        view = ModelConfigurationView.from_model(
+            mc,
+            self.DYNAMIC_PROVIDER,
+            deployment_name="prod-deployment-claude-5-opus",
+        )
+
+        assert view.supports_reasoning is True
+
 
 # ModelConfigurationView.from_model — static provider branch
 
@@ -416,6 +434,45 @@ class TestModelConfigurationViewFromModelStatic:
             )
 
         assert view.supports_image_input is True
+
+    def test_unregistered_claude_alias_reasons_via_version_parse(self) -> None:
+        """Same gap as the dynamic branch's version above: a Claude alias
+        LiteLLM's registry and model_is_reasoning_model both miss (patched
+        False here) must still resolve True via the version parse."""
+        mc = _make_model_config(
+            name="foundry-deploy-11",
+            display_name=None,
+            flow_types=[LLMModelFlowType.CHAT],
+        )
+
+        with (
+            patch(
+                "onyx.server.manage.llm.models.get_max_input_tokens",
+                return_value=128000,
+            ),
+            patch(
+                "onyx.server.manage.llm.models.model_is_reasoning_model",
+                return_value=False,
+            ),
+            patch(
+                "onyx.llm.model_name_parser.parse_litellm_model_name",
+            ) as mock_parse,
+        ):
+            mock_parsed = MagicMock()
+            mock_parsed.display_name = mc.name
+            mock_parsed.provider_display_name = self.STATIC_PROVIDER
+            mock_parsed.vendor = None
+            mock_parsed.version = None
+            mock_parsed.region = None
+            mock_parse.return_value = mock_parsed
+
+            view = ModelConfigurationView.from_model(
+                mc,
+                self.STATIC_PROVIDER,
+                deployment_name="prod-deployment-claude-5-opus",
+            )
+
+        assert view.supports_reasoning is True
 
     def _patched_static_view(
         self,

--- a/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
@@ -440,6 +440,29 @@ class TestLLMProviderDescriptorRecommendedDefault:
             not m.is_recommended_default for m in descriptor.model_configurations
         )
 
+    def test_threads_provider_deployment_name_into_filter(self) -> None:
+        # The provider row's deployment alias must reach
+        # filter_model_configurations, or a model whose identity lives only
+        # in that alias would silently lose its resolved reasoning efforts.
+        provider_model = self._provider_model("azure")
+        provider_model.deployment_name = "gpt-5.1"
+        provider_model.model_configurations = []
+
+        with (
+            patch(
+                "onyx.server.manage.llm.models.filter_model_configurations",
+                return_value=[],
+            ) as mock_filter,
+            patch(
+                "onyx.llm.well_known_providers.llm_provider_options."
+                "fetch_default_model_for_provider",
+                return_value=None,
+            ),
+        ):
+            LLMProviderDescriptor.from_model(provider_model)
+
+        assert mock_filter.call_args.kwargs["deployment_name"] == "gpt-5.1"
+
 
 class TestSupportedReasoningEfforts:
     """The picker offers exactly the levels the request builder can deliver, so
@@ -470,6 +493,19 @@ class TestSupportedReasoningEfforts:
         """The LiteLLM-enriched branch answers too, not just the dynamic one."""
         view = ModelConfigurationView.from_model(
             _make_model_config(name="gpt-5.1", display_name=None), "openai"
+        )
+
+        assert ReasoningEffort.XHIGH in view.supported_reasoning_efforts
+
+    def test_deployment_alias_reveals_openai_family_and_xhigh(self) -> None:
+        """A custom provider (e.g. Azure AI Foundry) may carry the model
+        identity only in the deployment alias, while the model row's own
+        name is an opaque label. Mirrors the request builder's
+        model_identity_names handling in multi_llm.py."""
+        view = ModelConfigurationView.from_model(
+            _make_model_config(name="foundry-deploy-1", display_name="Deploy 1"),
+            "azure",
+            deployment_name="gpt-5.1",
         )
 
         assert ReasoningEffort.XHIGH in view.supported_reasoning_efforts

--- a/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
@@ -237,6 +237,21 @@ class TestModelConfigurationViewReasoningFallback:
 
         assert view.supports_reasoning is False
 
+    def test_deployment_alias_reveals_reasoning_support(self) -> None:
+        """The model row's own name is opaque; only the deployment alias,
+        left unpatched here, is what the real registry recognizes."""
+        mc = _make_model_config(
+            name="friendly-deploy-3",
+            display_name="Friendly Deploy",
+            flow_types=[LLMModelFlowType.CHAT],
+        )
+
+        view = ModelConfigurationView.from_model(
+            mc, self.DYNAMIC_PROVIDER, deployment_name="gpt-5.1"
+        )
+
+        assert view.supports_reasoning is True
+
 
 # ModelConfigurationView.from_model — static provider branch
 
@@ -310,6 +325,42 @@ class TestModelConfigurationViewFromModelStatic:
         view = self._patched_static_view(mc, model_is_reasoning=False)
 
         assert view.supports_reasoning is False
+
+    def test_deployment_alias_reveals_reasoning_support(self) -> None:
+        """The model row's own name is opaque; only the deployment alias
+        (model_is_reasoning_model left unpatched) is what the registry knows."""
+        mc = _make_model_config(
+            name="foundry-deploy-3",
+            display_name=None,
+            flow_types=[LLMModelFlowType.CHAT],
+        )
+
+        with (
+            patch(
+                "onyx.server.manage.llm.models.get_max_input_tokens",
+                return_value=128000,
+            ),
+            patch(
+                "onyx.server.manage.llm.models.litellm_thinks_model_supports_image_input",
+                return_value=False,
+            ),
+            patch(
+                "onyx.llm.model_name_parser.parse_litellm_model_name",
+            ) as mock_parse,
+        ):
+            mock_parsed = MagicMock()
+            mock_parsed.display_name = mc.name
+            mock_parsed.provider_display_name = self.STATIC_PROVIDER
+            mock_parsed.vendor = None
+            mock_parsed.version = None
+            mock_parsed.region = None
+            mock_parse.return_value = mock_parsed
+
+            view = ModelConfigurationView.from_model(
+                mc, self.STATIC_PROVIDER, deployment_name="gpt-5.1"
+            )
+
+        assert view.supports_reasoning is True
 
     def _patched_static_view(
         self,

--- a/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
@@ -170,6 +170,24 @@ class TestModelConfigurationViewVisionFallback:
 
         assert view.supports_image_input is False
 
+    def test_deployment_alias_reveals_vision_support(self) -> None:
+        """The model row's own name is opaque; only the deployment alias,
+        left unpatched here, is what the real cost map recognizes."""
+        mc = _make_model_config(
+            name="friendly-deploy-6",
+            display_name="Friendly Deploy",
+            flow_types=[LLMModelFlowType.CHAT],
+        )
+
+        view = ModelConfigurationView.from_model(
+            mc,
+            self.CUSTOM_CONFIG_PROVIDER,
+            use_stored_display_name=True,
+            deployment_name="gpt-5.1",
+        )
+
+        assert view.supports_image_input is True
+
 
 # ModelConfigurationView.from_model — reasoning fallback (dynamic providers)
 
@@ -361,6 +379,43 @@ class TestModelConfigurationViewFromModelStatic:
             )
 
         assert view.supports_reasoning is True
+
+    def test_deployment_alias_reveals_vision_support(self) -> None:
+        """The model row's own name is opaque; only the deployment alias
+        (litellm_thinks_model_supports_image_input left unpatched) is what
+        the cost map recognizes."""
+        mc = _make_model_config(
+            name="foundry-deploy-7",
+            display_name=None,
+            flow_types=[LLMModelFlowType.CHAT],
+        )
+
+        with (
+            patch(
+                "onyx.server.manage.llm.models.get_max_input_tokens",
+                return_value=128000,
+            ),
+            patch(
+                "onyx.server.manage.llm.models.model_is_reasoning_model",
+                return_value=False,
+            ),
+            patch(
+                "onyx.llm.model_name_parser.parse_litellm_model_name",
+            ) as mock_parse,
+        ):
+            mock_parsed = MagicMock()
+            mock_parsed.display_name = mc.name
+            mock_parsed.provider_display_name = self.STATIC_PROVIDER
+            mock_parsed.vendor = None
+            mock_parsed.version = None
+            mock_parsed.region = None
+            mock_parse.return_value = mock_parsed
+
+            view = ModelConfigurationView.from_model(
+                mc, self.STATIC_PROVIDER, deployment_name="gpt-5.1"
+            )
+
+        assert view.supports_image_input is True
 
     def _patched_static_view(
         self,

--- a/web/src/lib/languageModels/options.ts
+++ b/web/src/lib/languageModels/options.ts
@@ -1,6 +1,9 @@
 import type { FunctionComponent } from "react";
 import type { IconProps } from "@opal/types";
-import { LLMProviderDescriptor } from "@/lib/languageModels/types";
+import {
+  LLMProviderDescriptor,
+  ReasoningEffortOverride,
+} from "@/lib/languageModels/types";
 import { getModelIcon, getProvider } from "@/lib/languageModels";
 import { AGGREGATOR_PROVIDERS } from "@/lib/languageModels/svc";
 
@@ -26,6 +29,8 @@ export interface LLMOption {
   region?: string | null;
   version?: string | null;
   supportsReasoning?: boolean;
+  /** See ModelConfiguration.supported_reasoning_efforts. */
+  supportedReasoningEfforts?: ReasoningEffortOverride[];
   supportsImageInput?: boolean;
 }
 
@@ -116,6 +121,7 @@ export function buildLlmOptions(
           region: mc.region || null,
           version: mc.version || null,
           supportsReasoning: mc.supports_reasoning || false,
+          supportedReasoningEfforts: mc.supported_reasoning_efforts,
           supportsImageInput: mc.supports_image_input || false,
         });
       });

--- a/web/src/lib/languageModels/types.ts
+++ b/web/src/lib/languageModels/types.ts
@@ -19,6 +19,12 @@ export interface ModelConfiguration {
   max_input_tokens: number | null;
   supports_image_input: boolean;
   supports_reasoning: boolean;
+  /**
+   * Effort levels this model tells apart, ascending, as resolved by the
+   * backend that builds the request. Absent from an older backend, in which
+   * case the picker falls back to the levels every reasoning model supports.
+   */
+  supported_reasoning_efforts?: ReasoningEffortOverride[];
   /** Display-only metadata surfaced in the model picker (Nebius TokenFactory). */
   quantization?: string | null;
   country_code?: string | null;

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -101,41 +101,20 @@ const REASONING_STOP_LABELS: Record<ReasoningEffortOverride, string> = {
   xhigh: "XHigh",
 };
 
-/** Providers whose models can be true OpenAI models (responses API). */
-const TRUE_OPENAI_PROVIDERS = new Set(["openai", "azure", "litellm_proxy"]);
-
 /**
- * Approximates the backend's _parse_anthropic_model_version. Segments longer
- * than two digits are date snapshots, not minor versions, and parse as 0.
+ * Index of the highest stop the model supports. The backend resolves this from
+ * the same code that builds the request, so the slider can never offer a level
+ * the request would drop. An older backend sends nothing, so fall back to the
+ * levels every reasoning model supports.
  */
-function anthropicModelVersion(modelName: string): [number, number] | null {
-  const name = modelName.toLowerCase();
-  const claudeIndex = name.indexOf("claude");
-  if (claudeIndex === -1) return null;
-  const match = name.slice(claudeIndex).match(/\d+(?:[.-]\d+)?/);
-  if (!match) return null;
-  const parts = match[0].split(/[.-]/);
-  if (!parts[0]) return null;
-  const minor = parts[1] && parts[1].length <= 2 ? parseInt(parts[1], 10) : 0;
-  return [parseInt(parts[0], 10), minor];
-}
-
-/**
- * Display-side mirror of the backend capability checks: xhigh is supported by
- * true OpenAI models and by Anthropic adaptive-thinking models (Claude >= 4.7,
- * matching _anthropic_uses_adaptive_thinking). The backend clamps unsupported
- * levels or strips rejected reasoning params and retries, so an imperfect
- * match here degrades gracefully.
- */
-function modelSupportsXhigh(option: LLMOption): boolean {
-  const openAiXhigh =
-    TRUE_OPENAI_PROVIDERS.has(option.provider) &&
-    /^(gpt-|o\d)/i.test(option.modelName);
-  const claudeVersion = anthropicModelVersion(option.modelName);
-  const anthropicXhigh =
-    claudeVersion !== null &&
-    (claudeVersion[0] > 4 || (claudeVersion[0] === 4 && claudeVersion[1] >= 7));
-  return openAiXhigh || anthropicXhigh;
+function maxSupportedReasoningStop(option: LLMOption): number {
+  const supported = option.supportedReasoningEfforts;
+  if (!supported) return BASE_REASONING_STOPS.length - 1;
+  let maxStop = -1;
+  supported.forEach((effort) => {
+    maxStop = Math.max(maxStop, ALL_REASONING_STOPS.indexOf(effort));
+  });
+  return maxStop;
 }
 
 function formatContextWindow(tokens: number): string {
@@ -292,16 +271,17 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
   const temperatureManager = managers.temperature;
   const reasoningManager = managers.reasoning;
   const temperatureEnabled = !option.supportsReasoning && !!temperatureManager;
-  const reasoningEnabled = option.supportsReasoning && !!reasoningManager;
+  // A reasoning model with no supported levels takes no effort parameter at
+  // all (e.g. o1-mini), so the row stays disabled.
+  const maxSupportedStop = maxSupportedReasoningStop(option);
+  const reasoningEnabled =
+    option.supportsReasoning && !!reasoningManager && maxSupportedStop >= 0;
 
-  // Supported stops are always a prefix of ALL_REASONING_STOPS. The slider
-  // spans all stops for uniform geometry and clamps input to the max
-  // supported index.
-  const maxSupportedStop =
-    (modelSupportsXhigh(option)
-      ? ALL_REASONING_STOPS.length
-      : BASE_REASONING_STOPS.length) - 1;
-  const clampStop = (stop: number) => Math.min(stop, maxSupportedStop);
+  // The slider spans all stops for uniform geometry and clamps input to the
+  // max supported index. The lower bound keeps the disabled no-levels case on
+  // a valid stop.
+  const clampStop = (stop: number) =>
+    Math.max(0, Math.min(stop, maxSupportedStop));
 
   const [localTemperature, setLocalTemperature] = useState(
     temperatureManager?.temperature ?? 0.5

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -110,11 +110,10 @@ const REASONING_STOP_LABELS: Record<ReasoningEffortOverride, string> = {
 function maxSupportedReasoningStop(option: LLMOption): number {
   const supported = option.supportedReasoningEfforts;
   if (!supported) return BASE_REASONING_STOPS.length - 1;
-  let maxStop = -1;
-  supported.forEach((effort) => {
-    maxStop = Math.max(maxStop, ALL_REASONING_STOPS.indexOf(effort));
-  });
-  return maxStop;
+  return Math.max(
+    -1,
+    ...supported.map((effort) => ALL_REASONING_STOPS.indexOf(effort))
+  );
 }
 
 function formatContextWindow(tokens: number): string {


### PR DESCRIPTION
## Description

**Bug:** the reasoning-effort picker and the actual LLM request could disagree about what a model supports — a level shown as available that the request silently dropped, or vice versa, with no error. Most visible for OpenAI models behind gateways (Bifrost) and providers using a deployment alias (Azure AI Foundry), where the model's row name and the string LiteLLM actually receives can differ.

**Fix:** `resolve_reasoning_param_style()` + `supported_reasoning_efforts()` are now the single source of truth for reasoning-effort capability, used by both the request builder and the picker API — a greyed-out slider stop and a dropped request parameter can no longer disagree. `model_identity_names()` makes every capability check (reasoning, vision, OpenAI routing, gateway "-chat" rejection, HTTP client isolation, Qwen tool-choice, markdown formatting) consider both the model name and any deployment alias, not just one.

Driving this to a clean review, Greptile/codex/code-review found 8 more real bugs in the same family, including a live chat-flow bug that silently dropped images for alias-only vision models, and reasoning silently suppressed by a deployment alias merely containing "-chat". Every fix has a regression test proven to fail on the prior code.

No schema migrations — backportable.

## How Has This Been Tested?

- Full backend unit suite: 8378 passed, 18 pre-existing failures (license reclaim, censoring, craft sandbox — unrelated files, reproduce identically on origin/main).
- Every one of the 9 bug fixes has a dedicated regression test verified to fail against the pre-fix code and pass after (shown inline in each commit).
- **Live-tested on dev1** (DB migrated to head first): configured a real Azure `gpt-5` deployment under an opaque model row name (`prod-deploy-test-1`, no relation to "gpt-5" in the name). Confirmed via the live `/api/admin/llm/provider` response that `supports_reasoning`, `supported_reasoning_efforts` (including `xhigh`), and `supports_image_input` all resolve identically to the same underlying model configured under its real name. Sent a real chat message through it with reasoning enabled; the response streamed back real reasoning content from Azure, and the backend log confirmed the responses-API bridge routing engaged (the Azure api-version-override log line only fires when `is_openai_model` resolves `True`) — proving the `is_openai_model`/deployment-alias fix end-to-end against a live provider, not mocks.
- **Live-tested Bifrost on dev1**: confirmed via the live `/api/llm/provider` response that dev1's Bifrost-routed Claude models resolve `supported_reasoning_efforts` including `xhigh`. Set the chat UI's Reasoning Level to XHigh for `anthropic/claude-opus-5` via Bifrost (slider fully selectable, not greyed out) and sent a real message; it streamed back genuine reasoning content, and the backend log confirmed the request routed through Bifrost. dev1's only configured Bifrost models are Anthropic, so this exercises the `ANTHROPIC_ADAPTIVE` style through a gateway, not the `OPENAI`-style object specifically through Bifrost — that OpenAI-behind-gateway dispatch is instead live-verified via the Azure path above (same `is_openai_model`/`resolve_reasoning_param_style` code) plus the unit test suite.
- Not live-tested: an actual image-upload round trip (vision fix verified live only via the capability API response + unit tests).

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backends now decide which reasoning-effort levels each model offers and the UI reflects that. Previously, OpenAI models behind OpenAI‑compatible gateways hid XHigh and requests clamped it to High; now XHigh reaches those models, and models that accept no effort parameter expose no levels (e.g., `o1-mini`, `o1-preview`, and GPT‑5 `-chat` variants).

- Adds `resolve_reasoning_param_style()` and `supported_reasoning_efforts()` to pick the reasoning wire format (`OPENAI` / `ANTHROPIC_ADAPTIVE` / `ANTHROPIC_BUDGET` / `LITELLM_EFFORT`) from provider, model name(s), and API surface; XHigh is available only for `OPENAI` and `ANTHROPIC_ADAPTIVE`; GPT‑5 `-chat` variants return no levels and omit reasoning params.
- Sends OpenAI and Claude behind OpenAI‑compatible gateways using the OpenAI `reasoning` object; registry‑gates the `-chat` omission so only true GPT‑5‑chat variants drop reasoning.
- Treats `deployment_name` as part of model identity for reasoning efforts, `supports_reasoning`, image support, markdown formatting re‑enable, Qwen tool‑choice downgrade, OpenAI responses‑API routing and per‑call HTTP client isolation, and Vertex stream‑options guard.
- Populates `supported_reasoning_efforts` in provider setup and `ModelConfigurationView`; the web picker consumes this field to clamp/disable the slider and removes TypeScript heuristics; older web builds fall back when it is absent.
- Tests cover providers, gateways, Bedrock inference profiles, Vertex, and OpenRouter; verify XHigh through gateways, `-chat` variants exposing no levels and omitting reasoning, alias‑only identity resolving capability and routing, and provider integrations asserting `supported_reasoning_efforts`.

<sup>Written for commit 96e64b0072a68ced835cceaf87e3540693e9a10d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

