### PR TITLE
fix(web): accept @dnd-kit/sortable v9 and v10 as opal peers

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -138,7 +138,7 @@
       "peerDependencies": {
         "@dnd-kit/core": "^6.0.0",
         "@dnd-kit/modifiers": "^7.0.0 || ^8.0.0",
-        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/sortable": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "@dnd-kit/utilities": "^3.0.0",
         "@radix-ui/react-dialog": "^1.0.0",
         "@radix-ui/react-popover": "^1.0.0",

--- a/web/lib/opal/package.json
+++ b/web/lib/opal/package.json
@@ -76,7 +76,7 @@
   "peerDependencies": {
     "@dnd-kit/core": "^6.0.0",
     "@dnd-kit/modifiers": "^7.0.0 || ^8.0.0",
-    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/sortable": "^8.0.0 || ^9.0.0 || ^10.0.0",
     "@dnd-kit/utilities": "^3.0.0",
     "@radix-ui/react-dialog": "^1.0.0",
     "@radix-ui/react-popover": "^1.0.0",


### PR DESCRIPTION
## Problem

`bun install` in `web/` prints:

```
warn: incorrect peer dependency "@dnd-kit/sortable@10.0.0"
```

`web/package.json` depends on `@dnd-kit/sortable@^10.0.0`, but `web/lib/opal/package.json` still declares the peer as `^8.0.0`. Bun resolves a single copy (10.0.0) and warns that it does not satisfy Opal's range.

## Change

Widen the Opal peer range to `^8.0.0 || ^9.0.0 || ^10.0.0`.

Opal uses only `useSortable`, `SortableContext`, `verticalListSortingStrategy`, `arrayMove`, and `sortableKeyboardCoordinates` (`TableRow.tsx`, `TableBody.tsx`, `hooks/useDraggableRows.ts`). These APIs do not change across v8, v9, and v10. The v10 peer on `@dnd-kit/core@^6.3.0` is satisfied by the installed 6.3.1.

`@onyx-ai/opal` is published to npm, so the peer range is a compatibility contract for external consumers, not only for this repo. A range keeps consumers on v8 or v9 working. This also matches the `@dnd-kit/modifiers` peer on the line above.

Only the declared range changes. `web/node_modules` still holds exactly one copy of `@dnd-kit/sortable`.

## Testing

- `bun install --frozen-lockfile` in `web/` completes with no warnings. It printed the warning before this change.
- `bun run build` in `web/lib/opal` succeeds.
- `tsc --noEmit` reports no dnd-kit errors. Pre-existing errors in `*.test.tsx` and `*.stories.tsx` are unrelated and present before this change.
- `pre-commit run --files web/lib/opal/package.json web/bun.lock` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts `@dnd-kit/sortable` v9 and v10 as peers of `@onyx-ai/opal` to remove Bun’s incorrect peer warning. Previously the peer was `^8.0.0`, which warned with `10.0.0`; now the peer is `^8.0.0 || ^9.0.0 || ^10.0.0`, and installs are clean with no runtime change.

- Change only updates the peer range in `web/lib/opal/package.json` (lock updated). No source changes.
- The used `@dnd-kit/sortable` APIs (`useSortable`, `SortableContext`, `verticalListSortingStrategy`, `arrayMove`, `sortableKeyboardCoordinates`) are stable across v8–v10; `@dnd-kit/core` peer remains `^6.0.0` and is satisfied.
- No migration required. `@onyx-ai/opal` consumers on v8/v9/v10 remain compatible, and `bun install --frozen-lockfile` no longer warns.

<sup>Written for commit b30f91d1978564787425b153a5250c630ef67e39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

