### PR TITLE
feat(sso): add the verified login-domain catalog

### DIFF
--- a/backend/alembic_tenants/versions/a754e4f72e60_add_tenant_sso_domain_routing.py
+++ b/backend/alembic_tenants/versions/a754e4f72e60_add_tenant_sso_domain_routing.py
@@ -1,0 +1,45 @@
+"""add tenant sso domain routing
+
+Revision ID: a754e4f72e60
+Revises: 8f3d2c7b91ae
+Create Date: 2026-08-06 17:01:52.971034
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a754e4f72e60"
+down_revision = "8f3d2c7b91ae"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tenant_sso_domain",
+        sa.Column("tenant_id", sa.String(), nullable=False),
+        sa.Column("domain", sa.String(), nullable=False),
+        sa.Column("verified_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("tenant_id", "domain"),
+        schema="public",
+    )
+    # Only one workspace may hold a domain as verified. Pending claims may overlap.
+    op.create_index(
+        "uq_tenant_sso_domain_verified",
+        "tenant_sso_domain",
+        ["domain"],
+        unique=True,
+        schema="public",
+        postgresql_where=sa.text("verified_at IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_tenant_sso_domain_verified",
+        table_name="tenant_sso_domain",
+        schema="public",
+    )
+    op.drop_table("tenant_sso_domain", schema="public")

--- a/backend/ee/onyx/db/tenant_sso_domain.py
+++ b/backend/ee/onyx/db/tenant_sso_domain.py
@@ -22,7 +22,7 @@ from sqlalchemy.exc import IntegrityError
 
 from onyx.db.engine.sql_engine import get_catalog_session, get_session_with_tenant
 from onyx.db.models import TenantSSODomain
-from onyx.db.sso_provider import enabled_provider_domains
+from onyx.db.sso_provider import enabled_provider_domains, normalize_email_domains
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
@@ -31,10 +31,15 @@ from shared_configs.configs import MULTI_TENANT
 logger = setup_logger()
 
 
+def _catalog_key(domain: str) -> str:
+    """Keys are stored lowercase and trimmed, so raw input cannot miss a claim."""
+    return domain.strip().lower()
+
+
 def _email_domain(email: str) -> str | None:
     """The normalized domain of an address, or None when it has none."""
     _, _, domain = email.rpartition("@")
-    return domain.strip().lower() or None
+    return _catalog_key(domain) or None
 
 
 def lookup_tenant_id_for_email_domain(email: str) -> str | None:
@@ -94,7 +99,7 @@ def claim_email_domains(tenant_id: str, domains: list[str]) -> None:
     if not MULTI_TENANT:
         return
 
-    wanted = {domain.strip().lower() for domain in domains if domain.strip()}
+    wanted = set(normalize_email_domains(domains))
 
     with get_catalog_session() as db_session:
         held = set(
@@ -147,7 +152,10 @@ def is_claimed_domain(tenant_id: str, domain: str) -> bool:
     if not MULTI_TENANT:
         return False
     with get_catalog_session() as db_session:
-        return db_session.get(TenantSSODomain, (tenant_id, domain)) is not None
+        return (
+            db_session.get(TenantSSODomain, (tenant_id, _catalog_key(domain)))
+            is not None
+        )
 
 
 def mark_domain_verified(tenant_id: str, domain: str) -> None:
@@ -157,7 +165,7 @@ def mark_domain_verified(tenant_id: str, domain: str) -> None:
         return
 
     with get_catalog_session() as db_session:
-        row = db_session.get(TenantSSODomain, (tenant_id, domain))
+        row = db_session.get(TenantSSODomain, (tenant_id, _catalog_key(domain)))
         if row is None:
             raise OnyxError(
                 OnyxErrorCode.NOT_FOUND, "This workspace has not claimed that domain."
@@ -182,7 +190,7 @@ def mark_domain_unverified(tenant_id: str, domain: str) -> None:
         return
 
     with get_catalog_session() as db_session:
-        row = db_session.get(TenantSSODomain, (tenant_id, domain))
+        row = db_session.get(TenantSSODomain, (tenant_id, _catalog_key(domain)))
         if row is None or row.verified_at is None:
             return
         row.verified_at = None

--- a/backend/ee/onyx/db/tenant_sso_domain.py
+++ b/backend/ee/onyx/db/tenant_sso_domain.py
@@ -1,0 +1,198 @@
+"""Email-domain routing for the cloud login page.
+
+Someone signing in for the first time has no account and no membership row, so
+nothing about them names a workspace. Their address domain does, once an admin
+has declared it on a provider and proven the workspace controls it. Those
+declarations live in per-tenant tables that cannot be read before a workspace is
+known, so they are projected here, into the one catalog every login request can
+reach.
+
+A domain only routes once it is verified. Declaring a domain records a pending
+claim. The workspace proves control by publishing a DNS TXT record for the
+domain. Until then the domain routes nowhere, so a workspace cannot pull
+addresses on a domain it has not shown it owns. Several workspaces may hold the
+same domain pending, but only one can verify it.
+"""
+
+import datetime
+from typing import NamedTuple
+
+from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
+
+from onyx.db.engine.sql_engine import get_catalog_session, get_session_with_tenant
+from onyx.db.models import TenantSSODomain
+from onyx.db.sso_provider import enabled_provider_domains
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.utils.logger import setup_logger
+from shared_configs.configs import MULTI_TENANT
+
+logger = setup_logger()
+
+
+def _email_domain(email: str) -> str | None:
+    """The normalized domain of an address, or None when it has none."""
+    _, _, domain = email.rpartition("@")
+    return domain.strip().lower() or None
+
+
+def lookup_tenant_id_for_email_domain(email: str) -> str | None:
+    """Workspace an address routes to on its domain alone, for someone who has
+    no account yet. Only verified domains route."""
+    if not MULTI_TENANT:
+        return None
+
+    domain = _email_domain(email)
+    if not domain:
+        return None
+
+    with get_catalog_session() as db_session:
+        return db_session.scalar(
+            select(TenantSSODomain.tenant_id).where(
+                TenantSSODomain.domain == domain,
+                TenantSSODomain.verified_at.isnot(None),
+            )
+        )
+
+
+def is_email_domain_verified(tenant_id: str, email: str) -> bool:
+    """Whether this workspace has proven control of the address's domain.
+
+    A tenant-controlled IdP can assert any address, so a login through one is
+    trusted to provision or move a membership only for a domain the workspace
+    has verified. An address whose domain this workspace has not verified
+    returns False.
+    """
+    if not MULTI_TENANT:
+        return False
+
+    domain = _email_domain(email)
+    if not domain:
+        return False
+
+    with get_catalog_session() as db_session:
+        return (
+            db_session.scalar(
+                select(TenantSSODomain.tenant_id).where(
+                    TenantSSODomain.tenant_id == tenant_id,
+                    TenantSSODomain.domain == domain,
+                    TenantSSODomain.verified_at.isnot(None),
+                )
+            )
+            is not None
+        )
+
+
+def claim_email_domains(tenant_id: str, domains: list[str]) -> None:
+    """Record this workspace's pending claim on the domains it declares, and drop
+    any it no longer claims.
+
+    A claim does not route until verified. A domain that stays claimed keeps its
+    verification, so re-saving a provider never un-verifies a domain.
+    """
+    if not MULTI_TENANT:
+        return
+
+    wanted = {domain.strip().lower() for domain in domains if domain.strip()}
+
+    with get_catalog_session() as db_session:
+        held = set(
+            db_session.scalars(
+                select(TenantSSODomain.domain).where(
+                    TenantSSODomain.tenant_id == tenant_id
+                )
+            ).all()
+        )
+
+        released = held - wanted
+        if released:
+            db_session.execute(
+                delete(TenantSSODomain).where(
+                    TenantSSODomain.tenant_id == tenant_id,
+                    TenantSSODomain.domain.in_(released),
+                )
+            )
+
+        for domain in wanted - held:
+            db_session.add(TenantSSODomain(tenant_id=tenant_id, domain=domain))
+
+        db_session.commit()
+
+
+class LoginDomainRecord(NamedTuple):
+    domain: str
+    verified: bool
+
+
+def list_login_domains(tenant_id: str) -> list[LoginDomainRecord]:
+    """The workspace's claimed domains and whether each is verified."""
+    if not MULTI_TENANT:
+        return []
+
+    with get_catalog_session() as db_session:
+        rows = db_session.execute(
+            select(TenantSSODomain.domain, TenantSSODomain.verified_at).where(
+                TenantSSODomain.tenant_id == tenant_id
+            )
+        ).all()
+
+    return [
+        LoginDomainRecord(domain=domain, verified=verified_at is not None)
+        for domain, verified_at in rows
+    ]
+
+
+def is_claimed_domain(tenant_id: str, domain: str) -> bool:
+    if not MULTI_TENANT:
+        return False
+    with get_catalog_session() as db_session:
+        return db_session.get(TenantSSODomain, (tenant_id, domain)) is not None
+
+
+def mark_domain_verified(tenant_id: str, domain: str) -> None:
+    """Flag a claimed domain verified so it starts routing. Raises if another
+    workspace already verified it, which the partial-unique index enforces."""
+    if not MULTI_TENANT:
+        return
+
+    with get_catalog_session() as db_session:
+        row = db_session.get(TenantSSODomain, (tenant_id, domain))
+        if row is None:
+            raise OnyxError(
+                OnyxErrorCode.NOT_FOUND, "This workspace has not claimed that domain."
+            )
+        if row.verified_at is not None:
+            return
+        row.verified_at = datetime.datetime.now(datetime.timezone.utc)
+        try:
+            db_session.commit()
+        except IntegrityError as e:
+            db_session.rollback()
+            raise OnyxError(
+                OnyxErrorCode.DUPLICATE_RESOURCE,
+                "Another workspace has already verified this domain.",
+            ) from e
+
+
+def mark_domain_unverified(tenant_id: str, domain: str) -> None:
+    """Drop a domain's verification so it stops routing. The scheduled re-check
+    calls this when the domain's TXT proof is no longer resolvable."""
+    if not MULTI_TENANT:
+        return
+
+    with get_catalog_session() as db_session:
+        row = db_session.get(TenantSSODomain, (tenant_id, domain))
+        if row is None or row.verified_at is None:
+            return
+        row.verified_at = None
+        db_session.commit()
+
+
+def reproject_tenant_login_domains(tenant_id: str) -> None:
+    """Re-project one workspace's enabled-provider domains into the catalog, so a
+    disable or a domain removal stops routing even if the on-save projection
+    failed. A domain that stays claimed keeps its verification."""
+    with get_session_with_tenant(tenant_id=tenant_id) as db_session:
+        domains = enabled_provider_domains(db_session)
+    claim_email_domains(tenant_id, sorted(domains))

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5587,6 +5587,37 @@ class TenantAnonymousUserPath(PublicBase):
     )
 
 
+class TenantSSODomain(PublicBase):
+    """Email domain to workspace, so the cloud login page can route someone who
+    has no account yet. Projected from each provider's allowed_email_domains,
+    which is per-tenant and therefore unreadable before a workspace is known.
+
+    A row only routes once `verified_at` is set: a workspace proves control of
+    the domain by publishing a DNS TXT record for it before strangers on the
+    domain are routed in and auto-provisioned.
+    """
+
+    __tablename__ = "tenant_sso_domain"
+    __table_args__ = (
+        # Only one workspace can hold a domain as VERIFIED. Several may hold it
+        # pending (unverified), so a squatter's pending claim cannot block the
+        # real owner from verifying and taking it.
+        Index(
+            "uq_tenant_sso_domain_verified",
+            "domain",
+            unique=True,
+            postgresql_where=text("verified_at IS NOT NULL"),
+        ),
+        {"schema": "public"},
+    )
+
+    tenant_id: Mapped[str] = mapped_column(String, primary_key=True, nullable=False)
+    domain: Mapped[str] = mapped_column(String, primary_key=True, nullable=False)
+    verified_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+
 # Lifetime invite counter per tenant. Incremented atomically on every
 # invite reservation; never decremented — removals do not free quota, so
 # loops of invite → remove → invite cannot bypass the trial cap.

--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -183,9 +183,8 @@ def validate_sso_provider_name(name: str) -> None:
 
 
 def is_valid_email_domain(domain: str) -> bool:
-    """A domain is a routing key and, on cloud, an email recipient (the
-    verification code goes to a role mailbox there), so it must be a
-    syntactically valid mail domain before it is stored."""
+    """A domain is a routing key and the boundary for which addresses may sign
+    in, so it must be a syntactically valid mail domain before it is stored."""
     try:
         validate_email(f"x@{domain}", check_deliverability=False)
     except EmailNotValidError:
@@ -204,6 +203,15 @@ def fetch_sso_providers(
     if enabled_only:
         stmt = stmt.where(SSOProvider.enabled.is_(True))
     return list(db_session.scalars(stmt).all())
+
+
+def enabled_provider_domains(db_session: Session) -> set[str]:
+    """Every email domain across the workspace's enabled SSO providers."""
+    return {
+        domain
+        for provider in fetch_sso_providers(db_session, enabled_only=True)
+        for domain in provider.allowed_email_domains
+    }
 
 
 def fetch_sso_provider_by_name(


### PR DESCRIPTION
## Description

Data layer for cloud SSO email-domain routing. Dormant on its own: nothing calls these helpers until the next PR in the stack.

- New `tenant_sso_domain` table (public schema) mapping a verified email domain to a workspace, so cloud login can resolve a first-time SSO user who has no account and no membership row yet.
- Composite PK `(tenant_id, domain)` plus a partial unique index on `domain WHERE verified_at IS NOT NULL`, so only one workspace can verify a given domain.
- Catalog helpers: claim, list, verify, unverify, re-project.
- `enabled_provider_domains` on `sso_provider`.

A claim does not route until it is verified. Multi-tenant only, no-ops on self-hosted.

Stack: this PR -> #13939 (DNS verification + routing) -> UI.

## How Has This Been Tested?


## Additional Options
- [x] Override Linear Check
- [ ] This PR should be cherry-picked into the current release branch