### PR TITLE
feat(sso): domain verification and login UI for cloud OIDC SSO

### DIFF
--- a/web/src/app/auth/login/LoginPage.tsx
+++ b/web/src/app/auth/login/LoginPage.tsx
@@ -2,6 +2,7 @@
 
 import { AuthTypeMetadata } from "@/lib/auth/types";
 import LoginText from "@/app/auth/login/LoginText";
+import CloudSSOSignIn from "@/app/auth/login/CloudSSOSignIn";
 import ProviderSignInButton from "@/app/auth/login/ProviderSignInButton";
 import { SignInButton, EmailPasswordForm } from "@/lib/auth/components";
 import { NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED } from "@/lib/constants";
@@ -48,11 +49,12 @@ export default function LoginPage({
         <div className="w-full justify-center flex flex-col gap-6">
           <LoginText />
           {authUrl && authTypeMetadata && (
-            <>
-              <SignInButton authorizeUrl={authUrl} />
-              <AuthLayouts.OrSeparator />
-            </>
+            <SignInButton authorizeUrl={authUrl} />
           )}
+          <CloudSSOSignIn nextUrl={effectiveNextUrl} />
+          <AuthLayouts.OrSeparator />
+          {/* Password sign-in is never hidden on cloud: it is the only route
+              that does not need a workspace resolved first. */}
           <EmailPasswordForm
             label="submit"
             shouldVerify={true}

--- a/web/src/lib/admin-routes.ts
+++ b/web/src/lib/admin-routes.ts
@@ -417,8 +417,8 @@ export const ADMIN_ROUTES = {
     requiredTier: null,
     visibleWhen: null,
   },
-  // Hidden on cloud until cloud login can use these providers. Business tier gates
-  // having *multiple* providers, inside the page itself, not reaching it.
+  // Business tier gates having *multiple* providers, inside the page itself,
+  // not reaching it.
   SSO_PROVIDERS: {
     path: "/admin/sso-providers",
     icon: SvgUserKey,
@@ -427,7 +427,7 @@ export const ADMIN_ROUTES = {
     requiredPermission: Permission.FULL_ADMIN_PANEL_ACCESS,
     section: "Organization",
     requiredTier: null,
-    visibleWhen: (f: FeatureFlags) => !f.enableCloud,
+    visibleWhen: null,
   },
 
   // ── Usage ─────────────────────────────────────────────────────────

--- a/web/src/lib/sso/svc.ts
+++ b/web/src/lib/sso/svc.ts
@@ -1,5 +1,6 @@
 import { SWR_KEYS } from "@/lib/swr-keys";
 import type { SSOProviderOption, SSOProviderType } from "@/lib/auth/types";
+import { FetchError, parseErrorDetail } from "@/lib/fetcher";
 import {
   SSOProviderCreateRequest,
   SSOProviderResponse,
@@ -8,14 +9,8 @@ import {
 
 const JSON_HEADERS = { "Content-Type": "application/json" };
 
-async function errorDetail(response: Response): Promise<string> {
-  try {
-    return (await response.json()).detail ?? "Request failed";
-  } catch {
-    return "Request failed";
-  }
-}
-
+// FetchError carries the status the shared SWR guard reads to stop retrying and
+// send an expired session to the login page.
 async function ssoRequest<T>(
   url: string,
   method: string,
@@ -26,7 +21,10 @@ async function ssoRequest<T>(
     headers: JSON_HEADERS,
     body: JSON.stringify(body),
   });
-  if (!response.ok) throw new Error(await errorDetail(response));
+  if (!response.ok) {
+    const detail = await parseErrorDetail(response, "Request failed");
+    throw new FetchError(detail, response.status, { detail });
+  }
   return response.json();
 }
 

--- a/web/src/lib/sso/svc.ts
+++ b/web/src/lib/sso/svc.ts
@@ -86,3 +86,33 @@ export function setSSOProviderEnabled(
     { enabled }
   );
 }
+
+export interface SSOLoginDomainStatus {
+  domain: string;
+  verified: boolean;
+  // The TXT record to publish. Unset once the domain is verified.
+  record_host?: string | null;
+  record_value?: string | null;
+}
+
+export interface SSOLoginDomains {
+  domains: SSOLoginDomainStatus[];
+}
+
+export function fetchDomainRecords(
+  domains: string[]
+): Promise<SSOLoginDomains> {
+  return ssoRequest<SSOLoginDomains>(
+    `${SWR_KEYS.adminSsoDomains}/records`,
+    "POST",
+    { domains }
+  );
+}
+
+export function verifyDomainViaDns(domain: string): Promise<SSOLoginDomains> {
+  return ssoRequest<SSOLoginDomains>(
+    `${SWR_KEYS.adminSsoDomains}/verify-dns`,
+    "POST",
+    { domain }
+  );
+}

--- a/web/src/lib/sso/svc.ts
+++ b/web/src/lib/sso/svc.ts
@@ -90,6 +90,9 @@ export function setSSOProviderEnabled(
 export interface SSOLoginDomainStatus {
   domain: string;
   verified: boolean;
+  // Whether the provider holding this domain is saved. Verifying needs a saved
+  // claim, so the record shows first and verifying unlocks on save.
+  claimed: boolean;
   // The TXT record to publish. Unset once the domain is verified.
   record_host?: string | null;
   record_value?: string | null;

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -23,6 +23,12 @@ export const SWR_KEYS = {
   incognitoAvailability: "/api/chat/incognito-availability",
   adminSsoProviders: "/api/admin/sso/provider",
   adminSsoProviderTypes: "/api/admin/sso/provider-type",
+  adminSsoDomains: "/api/admin/sso/domain",
+  // Cache key for the POST /records lookup, keyed by the domains being configured.
+  adminSsoDomainRecords: (domains: string[]) => [
+    "sso-domain-records",
+    ...domains,
+  ],
 
   // ── Agents / Personas ─────────────────────────────────────────────────────
   personas: "/api/persona",

--- a/web/src/sections/modals/sso/SSODomainVerification.tsx
+++ b/web/src/sections/modals/sso/SSODomainVerification.tsx
@@ -18,15 +18,13 @@ interface SSODomainVerificationProps {
   domains: string[];
 }
 
-function RecordRow({
-  label,
-  value,
-  copyable,
-}: {
+interface RecordRowProps {
   label: string;
   value: string;
   copyable?: boolean;
-}) {
+}
+
+function RecordRow({ label, value, copyable }: RecordRowProps) {
   const group = useId();
   const row = (
     <Section
@@ -59,15 +57,13 @@ function RecordRow({
   return copyable ? <Hoverable.Root group={group}>{row}</Hoverable.Root> : row;
 }
 
-function DomainCard({
-  status,
-  busy,
-  onVerify,
-}: {
+interface DomainCardProps {
   status: SSOLoginDomainStatus;
   busy: boolean;
   onVerify: () => void;
-}) {
+}
+
+function DomainCard({ status, busy, onVerify }: DomainCardProps) {
   return (
     <Card border="solid" rounding="lg">
       <Section flexDirection="column" alignItems="stretch" height="fit" gap={3}>

--- a/web/src/sections/modals/sso/SSODomainVerification.tsx
+++ b/web/src/sections/modals/sso/SSODomainVerification.tsx
@@ -121,8 +121,13 @@ function DomainCard({
               <Button
                 prominence="secondary"
                 onClick={onVerify}
-                disabled={busy}
+                disabled={busy || !status.claimed}
                 icon={busy ? SvgSimpleLoader : undefined}
+                tooltip={
+                  status.claimed
+                    ? undefined
+                    : "Save the provider with this domain first."
+                }
               >
                 Verify domain
               </Button>
@@ -135,7 +140,8 @@ function DomainCard({
 }
 
 // Cloud only: a domain routes no one until the workspace proves ownership with a
-// DNS TXT record. Records populate before the provider is saved, so setup is one pass.
+// DNS TXT record. The record shows for an unsaved domain so it can be published
+// early, but verifying it needs the saved claim the backend checks against.
 export default function SSODomainVerification({
   domains,
 }: SSODomainVerificationProps) {

--- a/web/src/sections/modals/sso/SSODomainVerification.tsx
+++ b/web/src/sections/modals/sso/SSODomainVerification.tsx
@@ -18,6 +18,8 @@ interface SSODomainVerificationProps {
   domains: string[];
 }
 
+// Both stay plain text: the label is interpolated into a "label: " prefix, and
+// the value is copied verbatim into the reader's DNS record.
 interface RecordRowProps {
   label: string;
   value: string;
@@ -141,7 +143,7 @@ function DomainCard({ status, busy, onVerify }: DomainCardProps) {
 export default function SSODomainVerification({
   domains,
 }: SSODomainVerificationProps) {
-  const { data, mutate, isLoading } = useSWR<SSOLoginDomains>(
+  const { data, mutate, isLoading, error } = useSWR<SSOLoginDomains>(
     domains.length > 0 ? SWR_KEYS.adminSsoDomainRecords(domains) : null,
     () => fetchDomainRecords(domains)
   );
@@ -171,7 +173,26 @@ export default function SSODomainVerification({
       withLabel
     >
       <Section flexDirection="column" alignItems="stretch" height="fit" gap={3}>
-        {isLoading && rows.length === 0 ? (
+        {error && rows.length === 0 ? (
+          // Without the records there is nothing to publish, so say so and offer
+          // the retry rather than rendering an empty section.
+          <Card border="solid" rounding="lg">
+            <Section
+              flexDirection="row"
+              alignItems="center"
+              justifyContent="between"
+              height="fit"
+              gap={2}
+            >
+              <Text font="main-ui-body" color="text-03" as="span">
+                We couldn&apos;t load the DNS records.
+              </Text>
+              <Button prominence="secondary" onClick={() => void mutate()}>
+                Try again
+              </Button>
+            </Section>
+          </Card>
+        ) : isLoading && rows.length === 0 ? (
           <Section flexDirection="row" alignItems="center" height="fit" gap={2}>
             <SvgSimpleLoader className="text-text-03" />
             <Text font="main-ui-body" color="text-03">

--- a/web/src/sections/modals/sso/SSODomainVerification.tsx
+++ b/web/src/sections/modals/sso/SSODomainVerification.tsx
@@ -155,8 +155,10 @@ export default function SSODomainVerification({
     setBusyDomain(domain);
     try {
       await verifyDomainViaDns(domain);
-      await mutate();
       toast.success(`${domain} verified`);
+      // The backend already persisted the verification, so a failed refresh is
+      // not a failed verification. The next load picks up the new state.
+      await mutate().catch(() => undefined);
     } catch (exc) {
       toast.error(exc instanceof Error ? exc.message : String(exc));
     } finally {

--- a/web/src/sections/modals/sso/SSODomainVerification.tsx
+++ b/web/src/sections/modals/sso/SSODomainVerification.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useId, useState } from "react";
+import useSWR from "swr";
+import { Button, Card, CopyButton, Tag, Text } from "@opal/components";
+import { Hoverable } from "@opal/core";
+import { InputVertical, Section, toast } from "@opal/layouts";
+import { SvgSimpleLoader } from "@opal/icons";
+import {
+  fetchDomainRecords,
+  verifyDomainViaDns,
+  type SSOLoginDomains,
+  type SSOLoginDomainStatus,
+} from "@/lib/sso/svc";
+import { SWR_KEYS } from "@/lib/swr-keys";
+
+interface SSODomainVerificationProps {
+  domains: string[];
+}
+
+function RecordRow({
+  label,
+  value,
+  copyable,
+}: {
+  label: string;
+  value: string;
+  copyable?: boolean;
+}) {
+  const group = useId();
+  const row = (
+    <Section
+      flexDirection="row"
+      alignItems="center"
+      justifyContent="between"
+      height="fit"
+      gap={2}
+      padding={2}
+      className={
+        copyable ? "transition-colors hover:bg-background-tint-02" : undefined
+      }
+    >
+      <div className="min-w-0 break-all">
+        <Text font="main-ui-body" color="text-03" as="span">
+          {`${label}: `}
+        </Text>
+        <Text font="main-ui-mono" color="text-04" as="span">
+          {value}
+        </Text>
+      </div>
+      {copyable && (
+        <Hoverable.Item group={group} variant="appear-on-hover">
+          <CopyButton getCopyText={() => value} size="sm" />
+        </Hoverable.Item>
+      )}
+    </Section>
+  );
+
+  return copyable ? <Hoverable.Root group={group}>{row}</Hoverable.Root> : row;
+}
+
+function DomainCard({
+  status,
+  busy,
+  onVerify,
+}: {
+  status: SSOLoginDomainStatus;
+  busy: boolean;
+  onVerify: () => void;
+}) {
+  return (
+    <Card border="solid" rounding="lg">
+      <Section flexDirection="column" alignItems="stretch" height="fit" gap={3}>
+        <Section
+          flexDirection="row"
+          justifyContent="between"
+          alignItems="center"
+          height="fit"
+          gap={2}
+        >
+          <Text font="main-ui-action" color="text-05" as="span">
+            {status.domain}
+          </Text>
+          <Tag
+            color={status.verified ? "green" : "amber"}
+            title={status.verified ? "Verified" : "Pending"}
+          />
+        </Section>
+
+        {status.verified ? (
+          <Text font="secondary-body" color="text-03" as="span">
+            This domain signs its users in automatically.
+          </Text>
+        ) : (
+          <>
+            <Text font="secondary-body" color="text-03" as="span">
+              Add this TXT record at your DNS provider, then verify.
+            </Text>
+            <Card border="solid" rounding="md" padding={0}>
+              <Section
+                flexDirection="column"
+                alignItems="stretch"
+                height="fit"
+                gap={0}
+                className="[&>*+*]:border-t [&>*+*]:border-border-01"
+              >
+                <RecordRow label="Type" value="TXT" />
+                {status.record_host && (
+                  <RecordRow label="Name" value={status.record_host} copyable />
+                )}
+                {status.record_value && (
+                  <RecordRow
+                    label="Value"
+                    value={status.record_value}
+                    copyable
+                  />
+                )}
+              </Section>
+            </Card>
+            <Section flexDirection="row" justifyContent="end" height="fit">
+              <Button
+                prominence="secondary"
+                onClick={onVerify}
+                disabled={busy}
+                icon={busy ? SvgSimpleLoader : undefined}
+              >
+                Verify domain
+              </Button>
+            </Section>
+          </>
+        )}
+      </Section>
+    </Card>
+  );
+}
+
+// Cloud only: a domain routes no one until the workspace proves ownership with a
+// DNS TXT record. Records populate before the provider is saved, so setup is one pass.
+export default function SSODomainVerification({
+  domains,
+}: SSODomainVerificationProps) {
+  const { data, mutate, isLoading } = useSWR<SSOLoginDomains>(
+    domains.length > 0 ? SWR_KEYS.adminSsoDomainRecords(domains) : null,
+    () => fetchDomainRecords(domains)
+  );
+  const [busyDomain, setBusyDomain] = useState<string | null>(null);
+
+  if (domains.length === 0) return null;
+
+  async function verify(domain: string) {
+    setBusyDomain(domain);
+    try {
+      await verifyDomainViaDns(domain);
+      await mutate();
+      toast.success(`${domain} verified`);
+    } catch (exc) {
+      toast.error(exc instanceof Error ? exc.message : String(exc));
+    } finally {
+      setBusyDomain(null);
+    }
+  }
+
+  const rows = data?.domains ?? [];
+
+  return (
+    <InputVertical
+      title="Domain verification"
+      description="A domain signs your workspace's users in automatically only after you verify you own it. Add the DNS record below, then verify."
+      withLabel
+    >
+      <Section flexDirection="column" alignItems="stretch" height="fit" gap={3}>
+        {isLoading && rows.length === 0 ? (
+          <Section flexDirection="row" alignItems="center" height="fit" gap={2}>
+            <SvgSimpleLoader className="text-text-03" />
+            <Text font="main-ui-body" color="text-03">
+              Loading…
+            </Text>
+          </Section>
+        ) : (
+          rows.map((status) => (
+            <DomainCard
+              key={status.domain}
+              status={status}
+              busy={busyDomain === status.domain}
+              onVerify={() => verify(status.domain)}
+            />
+          ))
+        )}
+      </Section>
+    </InputVertical>
+  );
+}

--- a/web/src/sections/modals/sso/SSODomainVerification.tsx
+++ b/web/src/sections/modals/sso/SSODomainVerification.tsx
@@ -173,9 +173,10 @@ export default function SSODomainVerification({
       withLabel
     >
       <Section flexDirection="column" alignItems="stretch" height="fit" gap={3}>
-        {error && rows.length === 0 ? (
-          // Without the records there is nothing to publish, so say so and offer
-          // the retry rather than rendering an empty section.
+        {/* Sits above the rows rather than replacing them: a failed refresh
+            keeps the last rows, and showing them as current would hide that
+            their verified state is no longer known. */}
+        {error && (
           <Card border="solid" rounding="lg">
             <Section
               flexDirection="row"
@@ -185,14 +186,17 @@ export default function SSODomainVerification({
               gap={2}
             >
               <Text font="main-ui-body" color="text-03" as="span">
-                We couldn&apos;t load the DNS records.
+                {rows.length > 0
+                  ? "We couldn't refresh these records, so they may be out of date."
+                  : "We couldn't load the DNS records."}
               </Text>
               <Button prominence="secondary" onClick={() => void mutate()}>
                 Try again
               </Button>
             </Section>
           </Card>
-        ) : isLoading && rows.length === 0 ? (
+        )}
+        {isLoading && rows.length === 0 ? (
           <Section flexDirection="row" alignItems="center" height="fit" gap={2}>
             <SvgSimpleLoader className="text-text-03" />
             <Text font="main-ui-body" color="text-03">

--- a/web/src/sections/modals/sso/SSODomainVerification.tsx
+++ b/web/src/sections/modals/sso/SSODomainVerification.tsx
@@ -156,9 +156,26 @@ export default function SSODomainVerification({
     try {
       await verifyDomainViaDns(domain);
       toast.success(`${domain} verified`);
-      // The backend already persisted the verification, so a failed refresh is
-      // not a failed verification. The next load picks up the new state.
-      await mutate().catch(() => undefined);
+      // The backend persisted it, so apply the result locally before asking for
+      // a refresh. A failed refresh then cannot report success as a failure or
+      // leave the row sitting on its old pending state.
+      await mutate(
+        (current) =>
+          current && {
+            domains: current.domains.map((row) =>
+              row.domain === domain
+                ? {
+                    ...row,
+                    verified: true,
+                    claimed: true,
+                    record_host: null,
+                    record_value: null,
+                  }
+                : row
+            ),
+          },
+        { revalidate: true, rollbackOnError: false }
+      ).catch(() => undefined);
     } catch (exc) {
       toast.error(exc instanceof Error ? exc.message : String(exc));
     } finally {

--- a/web/src/sections/modals/sso/SSOProviderModal.tsx
+++ b/web/src/sections/modals/sso/SSOProviderModal.tsx
@@ -3,10 +3,16 @@
 import { useState } from "react";
 import { Form, Formik, useField } from "formik";
 import * as Yup from "yup";
-import { Button, InputTags, type TagItem, Text } from "@opal/components";
-import { SvgCopy, SvgSimpleLoader } from "@opal/icons";
-import { InputErrorText, InputVertical, toast } from "@opal/layouts";
-import { cn } from "@opal/utils";
+import {
+  Button,
+  Card,
+  CopyButton,
+  InputTags,
+  type TagItem,
+  Text,
+} from "@opal/components";
+import { SvgSimpleLoader } from "@opal/icons";
+import { InputErrorText, InputVertical, Section, toast } from "@opal/layouts";
 import type {
   SSOProviderCreateRequest,
   SSOProviderResponse,
@@ -16,9 +22,9 @@ import type {
 import { useSupportedSSOProviderTypes } from "@/lib/sso/hooks";
 import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 import { createSSOProvider, updateSSOProvider } from "@/lib/sso/svc";
+import SSODomainVerification from "@/sections/modals/sso/SSODomainVerification";
 import {
   CONFIG_FIELDS_BY_TYPE,
-  copyRedirectUri,
   CREATABLE_SSO_PROVIDER_TYPES,
   SSO_PROVIDER_DETAILS,
   type SSOConfigField,
@@ -404,12 +410,12 @@ export function SSOProviderModal({ provider, onSaved }: SSOProviderModalProps) {
                     title={
                       NEXT_PUBLIC_CLOUD_ENABLED
                         ? "Allowed Email Domains"
-                        : "Allowed Email Domains (Optional)"
+                        : "Allowed Email Domains (Recommended)"
                     }
                     description={
                       NEXT_PUBLIC_CLOUD_ENABLED
                         ? "Only emails in these domains may sign in through this provider."
-                        : "Only emails in these domains may sign in through this provider. Empty allows any."
+                        : "Only emails in these domains may sign in through this provider. Recommended, but you can leave it empty to allow any."
                     }
                     withLabel
                   >
@@ -420,30 +426,38 @@ export function SSOProviderModal({ provider, onSaved }: SSOProviderModalProps) {
                     />
                   </InputVertical>
 
+                  {NEXT_PUBLIC_CLOUD_ENABLED && (
+                    <SSODomainVerification
+                      domains={values.allowed_email_domains}
+                    />
+                  )}
+
                   {provider?.redirect_uri && (
                     <InputVertical
                       title={redirectLabel}
                       description="Register this URL in your IdP as the callback."
                       withLabel
                     >
-                      <div
-                        className={cn(
-                          "flex items-start justify-between gap-2 rounded-12 border border-border-03 bg-background-neutral-02 p-3"
-                        )}
-                      >
-                        <Text font="secondary-body" color="text-04" as="p">
-                          {provider.redirect_uri}
-                        </Text>
-                        <Button
-                          icon={SvgCopy}
-                          prominence="tertiary"
-                          size="sm"
-                          tooltip={`Copy ${redirectLabel}`}
-                          onClick={() => {
-                            void copyRedirectUri(provider.redirect_uri);
-                          }}
-                        />
-                      </div>
+                      <Card border="solid" rounding="md">
+                        <Section
+                          flexDirection="row"
+                          alignItems="center"
+                          justifyContent="between"
+                          height="fit"
+                          gap={2}
+                        >
+                          <div className="min-w-0 break-all">
+                            <Text font="main-ui-mono" color="text-04" as="span">
+                              {provider.redirect_uri}
+                            </Text>
+                          </div>
+                          <CopyButton
+                            getCopyText={() => provider.redirect_uri}
+                            size="sm"
+                            tooltip={`Copy ${redirectLabel}`}
+                          />
+                        </Section>
+                      </Card>
                     </InputVertical>
                   )}
                 </Modal.Body>


### PR DESCRIPTION
## Description

The user-visible half of the cloud SSO stack. Stacks on #13939.

- Domain verification in the provider modal: each domain gets a card with its TXT record (Type / Name / Value, copy on hover) and a Verify action.
- Verify is offered only once the domain is saved, since the backend verifies against a saved claim. The record still shows beforehand so it can be published early.
- Mounts the SSO buttons on the login page and the providers entry in the admin nav, which is what turns the feature on for cloud.

Cloud only. Self-hosted keeps the allowlist as recommended-but-optional and sees no verification UI.

## How Has This Been Tested?

Live against a multi-tenant cloud backend: verification cards render, Verify is enabled for a saved domain and disabled for an unsaved one with a "Save the provider with this domain first." tooltip.

| Before | After |
|---|---|
| <img width="1512" height="803" alt="sso-before" src="https://github.com/user-attachments/assets/f3053a72-c389-4549-825e-237c885775d5" /> | <img width="1512" height="803" alt="sso-after" src="https://github.com/user-attachments/assets/bc02939c-4f0e-4bbe-a6c1-710559623de5" /> |

## Additional Options
- [x] Override Linear Check
- [ ] This PR should be cherry-picked into the current release branch
