### PR TITLE
feat(connector-stability): read-only credential capability report endpoints

### DIFF
--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -72,6 +72,9 @@ from onyx.server.auth_check import check_router_auth
 from onyx.server.documents.cc_pair import router as cc_pair_router
 from onyx.server.documents.connector import router as connector_router
 from onyx.server.documents.credential import router as credential_router
+from onyx.server.documents.credential_capabilities import (
+    router as credential_capabilities_router,
+)
 from onyx.server.documents.document import router as document_router
 from onyx.server.documents.standard_oauth import router as standard_oauth_router
 from onyx.server.documents.targeted_reindex import router as targeted_reindex_router
@@ -535,6 +538,9 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_router_with_global_prefix_prepended(application, admin_router)
     include_router_with_global_prefix_prepended(application, connector_router)
     include_router_with_global_prefix_prepended(application, credential_router)
+    include_router_with_global_prefix_prepended(
+        application, credential_capabilities_router
+    )
     include_router_with_global_prefix_prepended(application, input_prompt_router)
     include_router_with_global_prefix_prepended(application, admin_input_prompt_router)
     include_router_with_global_prefix_prepended(application, cc_pair_router)

--- a/backend/onyx/server/documents/credential_capabilities.py
+++ b/backend/onyx/server/documents/credential_capabilities.py
@@ -75,13 +75,12 @@ def _connector_pairing_visible(
 
     Global managers see every pairing, including failed-creation orphans whose
     cc-pair was never created (a support surface). Scoped managers see only
-    pairings within their managed scope: the read filter (``get_editable=False``)
-    would admit every public and sync pair, and is skipped outright for
-    READ_CONNECTORS holders, so it must not authorize report internals.
+    pairings within their managed scope: the read filter
+    (``get_editable=False``) would admit every public and sync pair, and is
+    skipped outright for READ_CONNECTORS holders, so it must not authorize
+    report internals.
     """
-    if has_global_permission(user, Permission.MANAGE_CONNECTORS):
-        return True
-    return (
+    return has_global_permission(user, Permission.MANAGE_CONNECTORS) or (
         get_connector_credential_pair_for_user(
             db_session,
             connector_id=connector_id,
@@ -175,15 +174,17 @@ def list_capability_reports_for_source(
                 processing_mode=None,
             )
         }
-    rows = []
-    for row in get_capability_report_rows_for_source(db_session, source):
+
+    def is_visible(row: CredentialCapabilityReportRow) -> bool:
         if row.connector_id is None:
-            visible = row.credential_id in visible_credential_ids
-        else:
-            visible = (
-                visible_pairings is None
-                or (row.connector_id, row.credential_id) in visible_pairings
-            )
-        if visible:
-            rows.append(row)
-    return [CapabilityReportSnapshot.from_row(row) for row in rows]
+            return row.credential_id in visible_credential_ids
+        return (
+            visible_pairings is None
+            or (row.connector_id, row.credential_id) in visible_pairings
+        )
+
+    return [
+        CapabilityReportSnapshot.from_row(row)
+        for row in get_capability_report_rows_for_source(db_session, source)
+        if is_visible(row)
+    ]

--- a/backend/onyx/server/documents/credential_capabilities.py
+++ b/backend/onyx/server/documents/credential_capabilities.py
@@ -1,0 +1,116 @@
+"""Read-only API over stored credential capability reports.
+
+The blocking-validation recorder writes these rows today; the granular
+check-runner task will write them too once it exists. Reports are advisory:
+nothing here gates connector creation or indexing.
+"""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from onyx.auth.permissions import require_permission
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.capability_checks.models import CredentialCapabilityReport
+from onyx.db.credential_capability import (
+    get_capability_report_row,
+    get_capability_report_rows_for_source,
+)
+from onyx.db.credentials import (
+    fetch_credential_by_id_for_user,
+    fetch_credentials_by_source_for_user,
+)
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import CapabilityCheckTrigger, CapabilityReportRunStatus, Permission
+from onyx.db.models import CredentialCapabilityReportRow, User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+
+router = APIRouter(prefix="/manage")
+
+
+class CapabilityReportSnapshot(BaseModel):
+    """One stored report row; ``report`` is the last completed run's content."""
+
+    credential_id: int
+    connector_id: int | None
+    source: DocumentSource
+    trigger: CapabilityCheckTrigger
+    run_status: CapabilityReportRunStatus
+    run_started_at: datetime | None
+    connector_config_hash: str | None
+    report: CredentialCapabilityReport | None
+    time_updated: datetime
+
+    @classmethod
+    def from_row(cls, row: CredentialCapabilityReportRow) -> "CapabilityReportSnapshot":
+        return cls(
+            credential_id=row.credential_id,
+            connector_id=row.connector_id,
+            source=row.source,
+            trigger=row.trigger,
+            run_status=row.run_status,
+            run_started_at=row.run_started_at,
+            connector_config_hash=row.connector_config_hash,
+            report=(
+                CredentialCapabilityReport.model_validate(row.report)
+                if row.report is not None
+                else None
+            ),
+            time_updated=row.time_updated,
+        )
+
+
+@router.get("/admin/credential/{credential_id}/capability-report")
+def get_capability_report(
+    credential_id: int,
+    connector_id: int | None = None,
+    user: User = Depends(
+        require_permission(Permission.MANAGE_CONNECTORS, allow_scope=True)
+    ),
+    db_session: Session = Depends(get_session),
+) -> CapabilityReportSnapshot | None:
+    """Returns the stored report row for one scope, or None before any run.
+
+    ``connector_id`` selects the connector-scoped row; without it the
+    config-less credential-scoped row is returned.
+    """
+    # GATE 2 for ``allow_scope``: the user-filtered fetch is the visibility
+    # check, and an unknown credential is indistinguishable from an
+    # inaccessible one.
+    credential = fetch_credential_by_id_for_user(credential_id, user, db_session)
+    if credential is None:
+        raise OnyxError(
+            OnyxErrorCode.CREDENTIAL_NOT_FOUND,
+            f"Credential {credential_id} does not exist or is not accessible.",
+        )
+    row = get_capability_report_row(db_session, credential_id, connector_id)
+    return CapabilityReportSnapshot.from_row(row) if row is not None else None
+
+
+@router.get("/admin/credential/capability-reports")
+def list_capability_reports_for_source(
+    source: DocumentSource,
+    user: User = Depends(
+        require_permission(Permission.MANAGE_CONNECTORS, allow_scope=True)
+    ),
+    db_session: Session = Depends(get_session),
+) -> list[CapabilityReportSnapshot]:
+    """Returns the report rows for a source's visible credentials, newest first."""
+    # GATE 2 for ``allow_scope``: only rows of credentials the caller can see,
+    # via the same user-filtered fetch the credential listings use.
+    visible_credential_ids = {
+        credential.id
+        for credential in fetch_credentials_by_source_for_user(
+            db_session=db_session,
+            user=user,
+            document_source=source,
+        )
+    }
+    return [
+        CapabilityReportSnapshot.from_row(row)
+        for row in get_capability_report_rows_for_source(db_session, source)
+        if row.credential_id in visible_credential_ids
+    ]

--- a/backend/onyx/server/documents/credential_capabilities.py
+++ b/backend/onyx/server/documents/credential_capabilities.py
@@ -23,6 +23,7 @@ from onyx.db.credential_capability import (
     get_capability_report_rows_for_source,
 )
 from onyx.db.credentials import (
+    fetch_credential_by_id,
     fetch_credential_by_id_for_user,
     fetch_credentials_by_source_for_user,
 )
@@ -107,11 +108,23 @@ def get_capability_report(
     config-less credential-scoped row is returned. A connector-scoped row the
     caller may not see reads as absent.
     """
-    # GATE 2 for ``allow_scope``: the user-filtered fetch is the visibility
-    # check, and an unknown credential is indistinguishable from an
-    # inaccessible one.
-    credential = fetch_credential_by_id_for_user(credential_id, user, db_session)
-    if credential is None:
+    # GATE 2 for ``allow_scope``: credential visibility authorizes the
+    # credential scope; pairing visibility authorizes the connector scope on its
+    # own, so a pairing manager reads its report even when the credential is
+    # outside their credential visibility (admin-created for a scoped manager,
+    # another user's private credential for a global one). An unknown credential
+    # is indistinguishable from an inaccessible one.
+    pairing_visible = connector_id is not None and _connector_pairing_visible(
+        db_session, connector_id, credential_id, user
+    )
+    credential_visible = (
+        fetch_credential_by_id_for_user(credential_id, user, db_session) is not None
+    )
+    if not credential_visible and (
+        # The global-manager pairing shortcut checks nothing, so the unfiltered
+        # fetch keeps an unknown credential a 404 for them too.
+        not pairing_visible or fetch_credential_by_id(credential_id, db_session) is None
+    ):
         raise OnyxError(
             OnyxErrorCode.CREDENTIAL_NOT_FOUND,
             f"Credential {credential_id} does not exist or is not accessible.",
@@ -119,9 +132,7 @@ def get_capability_report(
     row = get_capability_report_row(db_session, credential_id, connector_id)
     if row is None:
         return None
-    if connector_id is not None and not _connector_pairing_visible(
-        db_session, connector_id, credential_id, user
-    ):
+    if connector_id is not None and not pairing_visible:
         # Same shape as no row at all: pairing existence must not leak.
         return None
     return CapabilityReportSnapshot.from_row(row)
@@ -135,9 +146,13 @@ def list_capability_reports_for_source(
     ),
     db_session: Session = Depends(get_session),
 ) -> list[CapabilityReportSnapshot]:
-    """Returns the report rows for a source's visible credentials, newest first."""
-    # GATE 2 for ``allow_scope``: only rows of credentials the caller can see,
-    # via the same user-filtered fetch the credential listings use.
+    """Returns the source's report rows visible to the caller, newest first."""
+    # GATE 2 for ``allow_scope``, mirroring the single-report endpoint:
+    # credential-scoped rows follow credential visibility (the same
+    # user-filtered fetch the credential listings use); connector-scoped rows
+    # are pairing outcomes and follow pairing visibility alone, so a pairing
+    # manager sees them even when the credential is outside their credential
+    # visibility.
     visible_credential_ids = {
         credential.id
         for credential in fetch_credentials_by_source_for_user(
@@ -146,14 +161,8 @@ def list_capability_reports_for_source(
             document_source=source,
         )
     }
-    rows = [
-        row
-        for row in get_capability_report_rows_for_source(db_session, source)
-        if row.credential_id in visible_credential_ids
-    ]
-    # GATE 2 for the connector scope, mirroring the single-report endpoint:
-    # scoped managers only see connector rows for pairings they manage (the
-    # read filter would admit every public and sync pair).
+    # None: every pairing is visible (global managers, orphan rows included).
+    visible_pairings: set[tuple[int, int]] | None = None
     if not has_global_permission(user, Permission.MANAGE_CONNECTORS):
         visible_pairings = {
             (pair.connector_id, pair.credential_id)
@@ -166,10 +175,15 @@ def list_capability_reports_for_source(
                 processing_mode=None,
             )
         }
-        rows = [
-            row
-            for row in rows
-            if row.connector_id is None
-            or (row.connector_id, row.credential_id) in visible_pairings
-        ]
+    rows = []
+    for row in get_capability_report_rows_for_source(db_session, source):
+        if row.connector_id is None:
+            visible = row.credential_id in visible_credential_ids
+        else:
+            visible = (
+                visible_pairings is None
+                or (row.connector_id, row.credential_id) in visible_pairings
+            )
+        if visible:
+            rows.append(row)
     return [CapabilityReportSnapshot.from_row(row) for row in rows]

--- a/backend/onyx/server/documents/credential_capabilities.py
+++ b/backend/onyx/server/documents/credential_capabilities.py
@@ -11,9 +11,13 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from onyx.auth.permissions import require_permission
+from onyx.auth.permissions import has_global_permission, require_permission
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.capability_checks.models import CredentialCapabilityReport
+from onyx.db.connector_credential_pair import (
+    get_connector_credential_pair_for_user,
+    get_connector_credential_pairs_for_user,
+)
 from onyx.db.credential_capability import (
     get_capability_report_row,
     get_capability_report_rows_for_source,
@@ -63,6 +67,29 @@ class CapabilityReportSnapshot(BaseModel):
         )
 
 
+def _connector_pairing_visible(
+    db_session: Session, connector_id: int, credential_id: int, user: User
+) -> bool:
+    """GATE 2 for the connector scope: pairing outcomes are cc-pair data.
+
+    Global managers see every pairing, including failed-creation orphans whose
+    cc-pair was never created (a support surface). Scoped managers see only
+    pairings inside groups they belong to, per the cc-pair read filter.
+    """
+    if has_global_permission(user, Permission.MANAGE_CONNECTORS):
+        return True
+    return (
+        get_connector_credential_pair_for_user(
+            db_session,
+            connector_id=connector_id,
+            credential_id=credential_id,
+            user=user,
+            get_editable=False,
+        )
+        is not None
+    )
+
+
 @router.get("/admin/credential/{credential_id}/capability-report")
 def get_capability_report(
     credential_id: int,
@@ -75,7 +102,8 @@ def get_capability_report(
     """Returns the stored report row for one scope, or None before any run.
 
     ``connector_id`` selects the connector-scoped row; without it the
-    config-less credential-scoped row is returned.
+    config-less credential-scoped row is returned. A connector-scoped row the
+    caller may not see reads as absent.
     """
     # GATE 2 for ``allow_scope``: the user-filtered fetch is the visibility
     # check, and an unknown credential is indistinguishable from an
@@ -87,7 +115,14 @@ def get_capability_report(
             f"Credential {credential_id} does not exist or is not accessible.",
         )
     row = get_capability_report_row(db_session, credential_id, connector_id)
-    return CapabilityReportSnapshot.from_row(row) if row is not None else None
+    if row is None:
+        return None
+    if connector_id is not None and not _connector_pairing_visible(
+        db_session, connector_id, credential_id, user
+    ):
+        # Same shape as no row at all: pairing existence must not leak.
+        return None
+    return CapabilityReportSnapshot.from_row(row)
 
 
 @router.get("/admin/credential/capability-reports")
@@ -109,8 +144,29 @@ def list_capability_reports_for_source(
             document_source=source,
         )
     }
-    return [
-        CapabilityReportSnapshot.from_row(row)
+    rows = [
+        row
         for row in get_capability_report_rows_for_source(db_session, source)
         if row.credential_id in visible_credential_ids
     ]
+    # GATE 2 for the connector scope, mirroring the single-report endpoint:
+    # scoped managers only see connector rows for pairings in their groups.
+    if not has_global_permission(user, Permission.MANAGE_CONNECTORS):
+        visible_pairings = {
+            (pair.connector_id, pair.credential_id)
+            for pair in get_connector_credential_pairs_for_user(
+                db_session=db_session,
+                user=user,
+                get_editable=False,
+                source=source,
+                # Every pairing counts as visibility truth, whatever its mode.
+                processing_mode=None,
+            )
+        }
+        rows = [
+            row
+            for row in rows
+            if row.connector_id is None
+            or (row.connector_id, row.credential_id) in visible_pairings
+        ]
+    return [CapabilityReportSnapshot.from_row(row) for row in rows]

--- a/backend/onyx/server/documents/credential_capabilities.py
+++ b/backend/onyx/server/documents/credential_capabilities.py
@@ -70,11 +70,13 @@ class CapabilityReportSnapshot(BaseModel):
 def _connector_pairing_visible(
     db_session: Session, connector_id: int, credential_id: int, user: User
 ) -> bool:
-    """GATE 2 for the connector scope: pairing outcomes are cc-pair data.
+    """GATE 2 for the connector scope: pairing outcomes are management data.
 
     Global managers see every pairing, including failed-creation orphans whose
     cc-pair was never created (a support surface). Scoped managers see only
-    pairings inside groups they belong to, per the cc-pair read filter.
+    pairings within their managed scope: the read filter (``get_editable=False``)
+    would admit every public and sync pair, and is skipped outright for
+    READ_CONNECTORS holders, so it must not authorize report internals.
     """
     if has_global_permission(user, Permission.MANAGE_CONNECTORS):
         return True
@@ -84,7 +86,7 @@ def _connector_pairing_visible(
             connector_id=connector_id,
             credential_id=credential_id,
             user=user,
-            get_editable=False,
+            get_editable=True,
         )
         is not None
     )
@@ -150,14 +152,15 @@ def list_capability_reports_for_source(
         if row.credential_id in visible_credential_ids
     ]
     # GATE 2 for the connector scope, mirroring the single-report endpoint:
-    # scoped managers only see connector rows for pairings in their groups.
+    # scoped managers only see connector rows for pairings they manage (the
+    # read filter would admit every public and sync pair).
     if not has_global_permission(user, Permission.MANAGE_CONNECTORS):
         visible_pairings = {
             (pair.connector_id, pair.credential_id)
             for pair in get_connector_credential_pairs_for_user(
                 db_session=db_session,
                 user=user,
-                get_editable=False,
+                get_editable=True,
                 source=source,
                 # Every pairing counts as visibility truth, whatever its mode.
                 processing_mode=None,

--- a/backend/tests/integration/tests/capability_checks/test_capability_report_endpoints.py
+++ b/backend/tests/integration/tests/capability_checks/test_capability_report_endpoints.py
@@ -35,7 +35,9 @@ def _report_url(credential_id: int) -> str:
 def _seed_report_row(
     credential_id: int, connector_id: int, source: DocumentSource
 ) -> None:
-    """Writes one connector-scoped row the way the production blocking paths do."""
+    """
+    Writes one connector-scoped row the way the production blocking paths do.
+    """
     record_blocking_validation_outcome(
         credential_id=credential_id,
         connector_id=connector_id,
@@ -94,9 +96,10 @@ def test_scopes_without_rows_return_null(admin_user: DATestUser) -> None:
         source=DocumentSource.SLACK, user_performing_action=admin_user
     )
 
-    # Under test and postcondition. The recorder only writes connector-scoped
-    # rows, so both the credential scope and an unwritten connector scope read
-    # back as null rather than an error.
+    # Under test and postcondition.
+    # The recorder only writes connector-scoped rows, so both the credential
+    # scope and an unwritten connector scope read back as null rather than an
+    # error.
     for params in ({}, {"connector_id": 999_999_999}):
         response = client.get(
             _report_url(credential.id), params=params, headers=admin_user.headers

--- a/backend/tests/integration/tests/capability_checks/test_capability_report_endpoints.py
+++ b/backend/tests/integration/tests/capability_checks/test_capability_report_endpoints.py
@@ -1,0 +1,173 @@
+"""Integration tests for the read-only credential capability report endpoints.
+
+``INTEGRATION_TESTS_MODE`` disables the blocking-validation recorder hooks, so
+these tests seed rows by invoking the recorder directly, then read them back
+through the API the way the frontend will.
+"""
+
+from typing import Any
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.capabilities import CredentialCapability
+from onyx.connectors.capability_checks.models import (
+    CapabilityCheckStatus,
+    CapabilityVerdict,
+)
+from onyx.connectors.capability_checks.recorder import (
+    record_blocking_validation_outcome,
+)
+from onyx.db.enums import CapabilityCheckTrigger, CapabilityReportRunStatus
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.connector import ConnectorManager
+from tests.integration.common_utils.managers.credential import CredentialManager
+from tests.integration.common_utils.test_models import DATestUser
+
+_CONNECTOR_CONFIG: dict[str, Any] = {"channels": ["general"]}
+
+_REPORTS_FOR_SOURCE_URL = f"{API_SERVER_URL}/manage/admin/credential/capability-reports"
+
+
+def _report_url(credential_id: int) -> str:
+    return f"{API_SERVER_URL}/manage/admin/credential/{credential_id}/capability-report"
+
+
+def _seed_report_row(
+    credential_id: int, connector_id: int, source: DocumentSource
+) -> None:
+    """Writes one connector-scoped row the way the production blocking paths do."""
+    record_blocking_validation_outcome(
+        credential_id=credential_id,
+        connector_id=connector_id,
+        source=source,
+        trigger=CapabilityCheckTrigger.CC_PAIR_VALIDATION,
+        error=None,
+        perm_sync_validated=False,
+        connector_specific_config=_CONNECTOR_CONFIG,
+    )
+
+
+def test_connector_scoped_report_round_trips(admin_user: DATestUser) -> None:
+    # Precondition.
+    credential = CredentialManager.create(
+        source=DocumentSource.SLACK, user_performing_action=admin_user
+    )
+    connector = ConnectorManager.create(
+        source=DocumentSource.SLACK,
+        connector_specific_config=_CONNECTOR_CONFIG,
+        user_performing_action=admin_user,
+    )
+    _seed_report_row(credential.id, connector.id, DocumentSource.SLACK)
+
+    # Under test.
+    response = client.get(
+        _report_url(credential.id),
+        params={"connector_id": connector.id},
+        headers=admin_user.headers,
+    )
+
+    # Postcondition.
+    response.raise_for_status()
+    snapshot = response.json()
+    assert snapshot["credential_id"] == credential.id
+    assert snapshot["connector_id"] == connector.id
+    assert snapshot["source"] == DocumentSource.SLACK.value
+    assert snapshot["trigger"] == CapabilityCheckTrigger.CC_PAIR_VALIDATION.value
+    assert snapshot["run_status"] == CapabilityReportRunStatus.COMPLETED.value
+    assert snapshot["connector_config_hash"] is not None
+    report = snapshot["report"]
+    assert report["credential_id"] == credential.id
+    indexing_verdict = report["verdicts"][CredentialCapability.INDEXING.value]
+    assert indexing_verdict == CapabilityVerdict.PASSED.value
+    (settings_result,) = [
+        result
+        for result in report["check_results"]
+        if result["check_id"] == "slack_connector_settings"
+    ]
+    assert settings_result["is_fallback"] is True
+    assert settings_result["status"] == CapabilityCheckStatus.PASSED.value
+
+
+def test_scopes_without_rows_return_null(admin_user: DATestUser) -> None:
+    # Precondition.
+    credential = CredentialManager.create(
+        source=DocumentSource.SLACK, user_performing_action=admin_user
+    )
+
+    # Under test and postcondition. The recorder only writes connector-scoped
+    # rows, so both the credential scope and an unwritten connector scope read
+    # back as null rather than an error.
+    for params in ({}, {"connector_id": 999_999_999}):
+        response = client.get(
+            _report_url(credential.id), params=params, headers=admin_user.headers
+        )
+        response.raise_for_status()
+        assert response.json() is None
+
+
+def test_unknown_credential_maps_to_credential_not_found(
+    admin_user: DATestUser,
+) -> None:
+    # Under test.
+    response = client.get(_report_url(999_999_999), headers=admin_user.headers)
+
+    # Postcondition.
+    assert response.status_code == 404
+    assert response.json()["error_code"] == "CREDENTIAL_NOT_FOUND"
+
+
+def test_reports_require_connector_management_permission(
+    basic_user: DATestUser,
+) -> None:
+    # Under test and postcondition.
+    for url, params in (
+        (_report_url(1), {}),
+        (_REPORTS_FOR_SOURCE_URL, {"source": DocumentSource.SLACK.value}),
+    ):
+        response = client.get(url, params=params, headers=basic_user.headers)
+        assert response.status_code == 403
+        assert response.json()["error_code"] == "INSUFFICIENT_PERMISSIONS"
+
+
+def test_list_for_source_returns_visible_rows_newest_first(
+    admin_user: DATestUser,
+) -> None:
+    # Precondition.
+    slack_connector = ConnectorManager.create(
+        source=DocumentSource.SLACK,
+        connector_specific_config=_CONNECTOR_CONFIG,
+        user_performing_action=admin_user,
+    )
+    file_connector = ConnectorManager.create(
+        source=DocumentSource.FILE, user_performing_action=admin_user
+    )
+    older = CredentialManager.create(
+        source=DocumentSource.SLACK, user_performing_action=admin_user
+    )
+    newer = CredentialManager.create(
+        source=DocumentSource.SLACK, user_performing_action=admin_user
+    )
+    other_source = CredentialManager.create(
+        source=DocumentSource.FILE, user_performing_action=admin_user
+    )
+    _seed_report_row(older.id, slack_connector.id, DocumentSource.SLACK)
+    _seed_report_row(newer.id, slack_connector.id, DocumentSource.SLACK)
+    _seed_report_row(other_source.id, file_connector.id, DocumentSource.FILE)
+
+    # Under test.
+    response = client.get(
+        _REPORTS_FOR_SOURCE_URL,
+        params={"source": DocumentSource.SLACK.value},
+        headers=admin_user.headers,
+    )
+
+    # Postcondition.
+    response.raise_for_status()
+    rows = response.json()
+    assert all(row["source"] == DocumentSource.SLACK.value for row in rows)
+    credential_ids = [row["credential_id"] for row in rows]
+    assert other_source.id not in credential_ids
+    assert newer.id in credential_ids
+    assert older.id in credential_ids
+    # Rows from other tests may interleave; only relative order is pinned.
+    assert credential_ids.index(newer.id) < credential_ids.index(older.id)

--- a/backend/tests/integration/tests/capability_checks/test_capability_report_scoped_visibility.py
+++ b/backend/tests/integration/tests/capability_checks/test_capability_report_scoped_visibility.py
@@ -1,0 +1,178 @@
+"""EE-only visibility tests: connector-scoped reports are cc-pair data.
+
+A scoped group manager reaches the report endpoints via ``allow_scope`` GATE 1
+and passes the credential gate only for credentials they own. The connector
+scope needs its own GATE 2: without it, the caller-picked ``connector_id``
+would surface pairing outcomes (verdicts, probe errors, config hash) from
+groups the caller does not belong to. Failed-creation orphan rows (no cc-pair
+was ever created) stay a global-manager support surface.
+"""
+
+import os
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.capability_checks.recorder import (
+    record_blocking_validation_outcome,
+)
+from onyx.connectors.models import InputType
+from onyx.db.enums import AccessType, CapabilityCheckTrigger
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.cc_pair import CCPairManager
+from tests.integration.common_utils.managers.connector import ConnectorManager
+from tests.integration.common_utils.managers.credential import CredentialManager
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.managers.user_group import UserGroupManager
+from tests.integration.common_utils.test_models import DATestUser
+
+_CONNECTOR_CONFIG: dict[str, Any] = {"channels": ["general"]}
+
+_REPORTS_FOR_SOURCE_URL = f"{API_SERVER_URL}/manage/admin/credential/capability-reports"
+
+
+def _seed_report_row(credential_id: int, connector_id: int) -> None:
+    """Writes one connector-scoped row the way the production blocking paths do."""
+    record_blocking_validation_outcome(
+        credential_id=credential_id,
+        connector_id=connector_id,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.CC_PAIR_VALIDATION,
+        error=None,
+        perm_sync_validated=False,
+        connector_specific_config=_CONNECTOR_CONFIG,
+    )
+
+
+def _get_report(
+    credential_id: int, connector_id: int, user: DATestUser
+) -> dict[str, Any] | None:
+    response = client.get(
+        f"{API_SERVER_URL}/manage/admin/credential/{credential_id}/capability-report",
+        params={"connector_id": connector_id},
+        headers=user.headers,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Scoped group managers are enterprise only",
+)
+def test_scoped_manager_sees_only_their_groups_pairings(
+    admin_user: DATestUser,
+) -> None:
+    # Precondition. A scoped manager owning a credential probed against three
+    # connectors: one paired inside their group, one paired in a foreign
+    # group, and one whose pairing was never created (failed-creation orphan).
+    # Run-unique names keep re-runs against a shared DB collision-free.
+    suffix = uuid4().hex[:8]
+    manager = UserManager.create(name=f"scoped_manager_{suffix}")
+    managed_group = UserGroupManager.create(
+        name=f"managed_group_{suffix}",
+        user_ids=[manager.id],
+        cc_pair_ids=[],
+        user_performing_action=admin_user,
+    )
+    foreign_group = UserGroupManager.create(
+        name=f"foreign_group_{suffix}",
+        user_ids=[],
+        cc_pair_ids=[],
+        user_performing_action=admin_user,
+    )
+    UserGroupManager.wait_for_sync(
+        user_groups_to_check=[managed_group, foreign_group],
+        user_performing_action=admin_user,
+    )
+    set_manager_response = UserGroupManager.set_manager(
+        user_group=managed_group,
+        user=manager,
+        is_manager=True,
+        user_performing_action=admin_user,
+    )
+    assert set_manager_response.status_code == 200
+    # Group edits mark the group as syncing; cc-pair creation refuses to
+    # relate a group mid-sync, so wait again before pairing.
+    UserGroupManager.wait_for_sync(
+        user_groups_to_check=[managed_group, foreign_group],
+        user_performing_action=admin_user,
+    )
+    credential = CredentialManager.create(
+        source=DocumentSource.SLACK,
+        # The admin-side assertions read the same credential; the scoped path
+        # only needs ownership.
+        admin_public=True,
+        curator_public=False,
+        groups=[],
+        user_performing_action=manager,
+    )
+    # POLL: the Slack connector is checkpoint-based and pairing rejects the
+    # manager's LOAD_STATE default at connector instantiation.
+    in_group_connector = ConnectorManager.create(
+        source=DocumentSource.SLACK,
+        input_type=InputType.POLL,
+        connector_specific_config=_CONNECTOR_CONFIG,
+        user_performing_action=admin_user,
+    )
+    foreign_connector = ConnectorManager.create(
+        source=DocumentSource.SLACK,
+        input_type=InputType.POLL,
+        connector_specific_config=_CONNECTOR_CONFIG,
+        user_performing_action=admin_user,
+    )
+    orphan_connector = ConnectorManager.create(
+        source=DocumentSource.SLACK,
+        input_type=InputType.POLL,
+        connector_specific_config=_CONNECTOR_CONFIG,
+        user_performing_action=admin_user,
+    )
+    CCPairManager.create(
+        connector_id=in_group_connector.id,
+        credential_id=credential.id,
+        access_type=AccessType.PRIVATE,
+        groups=[managed_group.id],
+        user_performing_action=admin_user,
+    )
+    CCPairManager.create(
+        connector_id=foreign_connector.id,
+        credential_id=credential.id,
+        access_type=AccessType.PRIVATE,
+        groups=[foreign_group.id],
+        user_performing_action=admin_user,
+    )
+    for connector_id in (
+        in_group_connector.id,
+        foreign_connector.id,
+        orphan_connector.id,
+    ):
+        _seed_report_row(credential.id, connector_id)
+
+    # Under test and postcondition. The manager sees only their group's
+    # pairing; hidden pairings read as absent, like rows that never existed.
+    assert _get_report(credential.id, in_group_connector.id, manager) is not None
+    assert _get_report(credential.id, foreign_connector.id, manager) is None
+    assert _get_report(credential.id, orphan_connector.id, manager) is None
+
+    # The per-source listing applies the same gate.
+    response = client.get(
+        _REPORTS_FOR_SOURCE_URL,
+        params={"source": DocumentSource.SLACK.value},
+        headers=manager.headers,
+    )
+    response.raise_for_status()
+    listed_connector_ids = {row["connector_id"] for row in response.json()}
+    assert in_group_connector.id in listed_connector_ids
+    assert foreign_connector.id not in listed_connector_ids
+    assert orphan_connector.id not in listed_connector_ids
+
+    # Global managers are unaffected, the orphan included (support surface).
+    for connector_id in (
+        in_group_connector.id,
+        foreign_connector.id,
+        orphan_connector.id,
+    ):
+        assert _get_report(credential.id, connector_id, admin_user) is not None

--- a/backend/tests/integration/tests/capability_checks/test_capability_report_scoped_visibility.py
+++ b/backend/tests/integration/tests/capability_checks/test_capability_report_scoped_visibility.py
@@ -4,12 +4,11 @@ A scoped group manager reaches the report endpoints via ``allow_scope`` GATE 1.
 GATE 2 splits by scope: the credential scope follows credential visibility
 (creator-only for scoped managers), while the connector scope follows pairing
 visibility alone, bound to the caller's MANAGED scope -- read visibility would
-surface pairing outcomes (verdicts, probe errors, config hash) from every
-public or sync pairing, and is skipped entirely for READ_CONNECTORS holders.
-Pairing visibility does not require credential visibility: whoever manages the
-pairing may read its outcomes, as on the cc-pair detail endpoint.
-Failed-creation orphan rows (no cc-pair was ever created) stay a
-global-manager support surface.
+surface pairing outcomes (verdicts, probe errors, config hash) from every public
+or sync pairing, and is skipped entirely for READ_CONNECTORS holders. Pairing
+visibility does not require credential visibility: whoever manages the pairing
+may read its outcomes, as on the cc-pair detail endpoint. Failed-creation orphan
+rows (no cc-pair was ever created) stay a global-manager support surface.
 """
 
 import os
@@ -31,15 +30,50 @@ from tests.integration.common_utils.managers.connector import ConnectorManager
 from tests.integration.common_utils.managers.credential import CredentialManager
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.managers.user_group import UserGroupManager
-from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.common_utils.test_models import DATestUser, DATestUserGroup
 
 _CONNECTOR_CONFIG: dict[str, Any] = {"channels": ["general"]}
 
 _REPORTS_FOR_SOURCE_URL = f"{API_SERVER_URL}/manage/admin/credential/capability-reports"
 
 
+def _bootstrap_scoped_manager(
+    admin_user: DATestUser, suffix: str
+) -> tuple[DATestUser, DATestUserGroup]:
+    """
+    Creates a scoped manager and their managed group, synced and ready to pair.
+    """
+    manager = UserManager.create(name=f"scoped_manager_{suffix}")
+    managed_group = UserGroupManager.create(
+        name=f"managed_group_{suffix}",
+        user_ids=[manager.id],
+        cc_pair_ids=[],
+        user_performing_action=admin_user,
+    )
+    UserGroupManager.wait_for_sync(
+        user_groups_to_check=[managed_group],
+        user_performing_action=admin_user,
+    )
+    set_manager_response = UserGroupManager.set_manager(
+        user_group=managed_group,
+        user=manager,
+        is_manager=True,
+        user_performing_action=admin_user,
+    )
+    assert set_manager_response.status_code == 200
+    # Group edits mark the group as syncing; cc-pair creation refuses to relate
+    # a group mid-sync, so wait again before pairing.
+    UserGroupManager.wait_for_sync(
+        user_groups_to_check=[managed_group],
+        user_performing_action=admin_user,
+    )
+    return manager, managed_group
+
+
 def _seed_report_row(credential_id: int, connector_id: int) -> None:
-    """Writes one connector-scoped row the way the production blocking paths do."""
+    """
+    Writes one connector-scoped row the way the production blocking paths do.
+    """
     record_blocking_validation_outcome(
         credential_id=credential_id,
         connector_id=connector_id,
@@ -70,19 +104,14 @@ def _get_report(
 def test_scoped_manager_sees_only_their_groups_pairings(
     admin_user: DATestUser,
 ) -> None:
-    # Precondition. A scoped manager owning a credential probed against four
-    # connectors: paired in their managed group, paired in a foreign group,
-    # paired publicly (read-visible to everyone, managed by nobody here), and
-    # never successfully paired (failed-creation orphan).
-    # Run-unique names keep re-runs against a shared DB collision-free.
+    # Precondition.
+    # A scoped manager owning a credential probed against four connectors:
+    # paired in their managed group, paired in a foreign group, paired publicly
+    # (read-visible to everyone, managed by nobody here), and never successfully
+    # paired (failed-creation orphan). Run-unique names keep re-runs against a
+    # shared DB collision-free.
     suffix = uuid4().hex[:8]
-    manager = UserManager.create(name=f"scoped_manager_{suffix}")
-    managed_group = UserGroupManager.create(
-        name=f"managed_group_{suffix}",
-        user_ids=[manager.id],
-        cc_pair_ids=[],
-        user_performing_action=admin_user,
-    )
+    manager, managed_group = _bootstrap_scoped_manager(admin_user, suffix)
     foreign_group = UserGroupManager.create(
         name=f"foreign_group_{suffix}",
         user_ids=[],
@@ -90,20 +119,7 @@ def test_scoped_manager_sees_only_their_groups_pairings(
         user_performing_action=admin_user,
     )
     UserGroupManager.wait_for_sync(
-        user_groups_to_check=[managed_group, foreign_group],
-        user_performing_action=admin_user,
-    )
-    set_manager_response = UserGroupManager.set_manager(
-        user_group=managed_group,
-        user=manager,
-        is_manager=True,
-        user_performing_action=admin_user,
-    )
-    assert set_manager_response.status_code == 200
-    # Group edits mark the group as syncing; cc-pair creation refuses to
-    # relate a group mid-sync, so wait again before pairing.
-    UserGroupManager.wait_for_sync(
-        user_groups_to_check=[managed_group, foreign_group],
+        user_groups_to_check=[foreign_group],
         user_performing_action=admin_user,
     )
     credential = CredentialManager.create(
@@ -169,9 +185,10 @@ def test_scoped_manager_sees_only_their_groups_pairings(
     for connector_id in (in_group_connector.id, *hidden_connector_ids):
         _seed_report_row(credential.id, connector_id)
 
-    # Under test and postcondition. The manager sees only the pairing they
-    # manage; everything else -- foreign group, public (merely read-visible),
-    # orphan -- reads as absent, like rows that never existed.
+    # Under test and postcondition.
+    # The manager sees only the pairing they manage; everything else -- foreign
+    # group, public (merely read-visible), orphan -- reads as absent, like rows
+    # that never existed.
     assert _get_report(credential.id, in_group_connector.id, manager) is not None
     for connector_id in hidden_connector_ids:
         assert _get_report(credential.id, connector_id, manager) is None
@@ -188,9 +205,9 @@ def test_scoped_manager_sees_only_their_groups_pairings(
     for connector_id in hidden_connector_ids:
         assert connector_id not in listed_connector_ids
 
-    # A global grant that only implies READ_CONNECTORS (which skips the
-    # cc-pair read filter entirely) must not widen the gate: read visibility
-    # is not management scope.
+    # A global grant that only implies READ_CONNECTORS (which skips the cc-pair
+    # read filter entirely) must not widen the gate: read visibility is not
+    # management scope.
     UserGroupManager.wait_for_sync(
         user_groups_to_check=[managed_group],
         user_performing_action=admin_user,
@@ -218,35 +235,13 @@ def test_scoped_manager_sees_only_their_groups_pairings(
 def test_managed_pairing_is_readable_without_credential_visibility(
     admin_user: DATestUser,
 ) -> None:
-    # Precondition. An admin-created credential paired into the manager's
-    # managed group. The credential filter is creator-only for scoped
-    # managers (``admin_public`` notwithstanding), so the credential itself
-    # is invisible to them; only pairing visibility can admit its report.
+    # Precondition.
+    # An admin-created credential paired into the manager's managed group. The
+    # credential filter is creator-only for scoped managers (``admin_public``
+    # notwithstanding), so the credential itself is invisible to them; only
+    # pairing visibility can admit its report.
     suffix = uuid4().hex[:8]
-    manager = UserManager.create(name=f"scoped_manager_{suffix}")
-    managed_group = UserGroupManager.create(
-        name=f"managed_group_{suffix}",
-        user_ids=[manager.id],
-        cc_pair_ids=[],
-        user_performing_action=admin_user,
-    )
-    UserGroupManager.wait_for_sync(
-        user_groups_to_check=[managed_group],
-        user_performing_action=admin_user,
-    )
-    set_manager_response = UserGroupManager.set_manager(
-        user_group=managed_group,
-        user=manager,
-        is_manager=True,
-        user_performing_action=admin_user,
-    )
-    assert set_manager_response.status_code == 200
-    # Group edits mark the group as syncing; cc-pair creation refuses to
-    # relate a group mid-sync, so wait again before pairing.
-    UserGroupManager.wait_for_sync(
-        user_groups_to_check=[managed_group],
-        user_performing_action=admin_user,
-    )
+    manager, managed_group = _bootstrap_scoped_manager(admin_user, suffix)
     credential = CredentialManager.create(
         source=DocumentSource.SLACK,
         admin_public=True,
@@ -269,9 +264,10 @@ def test_managed_pairing_is_readable_without_credential_visibility(
     )
     _seed_report_row(credential.id, connector.id)
 
-    # Under test and postcondition. Pairing visibility alone authorizes the
-    # connector-scoped read; the credential scope stays gated on credential
-    # visibility and reads as inaccessible.
+    # Under test and postcondition.
+    # Pairing visibility alone authorizes the connector-scoped read; the
+    # credential scope stays gated on credential visibility and reads as
+    # inaccessible.
     assert _get_report(credential.id, connector.id, manager) is not None
     credential_scope_response = client.get(
         f"{API_SERVER_URL}/manage/admin/credential/{credential.id}/capability-report",

--- a/backend/tests/integration/tests/capability_checks/test_capability_report_scoped_visibility.py
+++ b/backend/tests/integration/tests/capability_checks/test_capability_report_scoped_visibility.py
@@ -1,11 +1,12 @@
-"""EE-only visibility tests: connector-scoped reports are cc-pair data.
+"""EE-only visibility tests: connector-scoped reports are management data.
 
 A scoped group manager reaches the report endpoints via ``allow_scope`` GATE 1
 and passes the credential gate only for credentials they own. The connector
-scope needs its own GATE 2: without it, the caller-picked ``connector_id``
-would surface pairing outcomes (verdicts, probe errors, config hash) from
-groups the caller does not belong to. Failed-creation orphan rows (no cc-pair
-was ever created) stay a global-manager support surface.
+scope needs its own GATE 2 bound to the caller's MANAGED scope: read
+visibility would surface pairing outcomes (verdicts, probe errors, config
+hash) from every public or sync pairing, and is skipped entirely for
+READ_CONNECTORS holders. Failed-creation orphan rows (no cc-pair was ever
+created) stay a global-manager support surface.
 """
 
 import os
@@ -19,7 +20,7 @@ from onyx.connectors.capability_checks.recorder import (
     record_blocking_validation_outcome,
 )
 from onyx.connectors.models import InputType
-from onyx.db.enums import AccessType, CapabilityCheckTrigger
+from onyx.db.enums import AccessType, CapabilityCheckTrigger, Permission
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
@@ -66,9 +67,10 @@ def _get_report(
 def test_scoped_manager_sees_only_their_groups_pairings(
     admin_user: DATestUser,
 ) -> None:
-    # Precondition. A scoped manager owning a credential probed against three
-    # connectors: one paired inside their group, one paired in a foreign
-    # group, and one whose pairing was never created (failed-creation orphan).
+    # Precondition. A scoped manager owning a credential probed against four
+    # connectors: paired in their managed group, paired in a foreign group,
+    # paired publicly (read-visible to everyone, managed by nobody here), and
+    # never successfully paired (failed-creation orphan).
     # Run-unique names keep re-runs against a shared DB collision-free.
     suffix = uuid4().hex[:8]
     manager = UserManager.create(name=f"scoped_manager_{suffix}")
@@ -130,6 +132,12 @@ def test_scoped_manager_sees_only_their_groups_pairings(
         connector_specific_config=_CONNECTOR_CONFIG,
         user_performing_action=admin_user,
     )
+    public_connector = ConnectorManager.create(
+        source=DocumentSource.SLACK,
+        input_type=InputType.POLL,
+        connector_specific_config=_CONNECTOR_CONFIG,
+        user_performing_action=admin_user,
+    )
     CCPairManager.create(
         connector_id=in_group_connector.id,
         credential_id=credential.id,
@@ -144,18 +152,26 @@ def test_scoped_manager_sees_only_their_groups_pairings(
         groups=[foreign_group.id],
         user_performing_action=admin_user,
     )
-    for connector_id in (
-        in_group_connector.id,
+    CCPairManager.create(
+        connector_id=public_connector.id,
+        credential_id=credential.id,
+        access_type=AccessType.PUBLIC,
+        user_performing_action=admin_user,
+    )
+    hidden_connector_ids = (
         foreign_connector.id,
+        public_connector.id,
         orphan_connector.id,
-    ):
+    )
+    for connector_id in (in_group_connector.id, *hidden_connector_ids):
         _seed_report_row(credential.id, connector_id)
 
-    # Under test and postcondition. The manager sees only their group's
-    # pairing; hidden pairings read as absent, like rows that never existed.
+    # Under test and postcondition. The manager sees only the pairing they
+    # manage; everything else -- foreign group, public (merely read-visible),
+    # orphan -- reads as absent, like rows that never existed.
     assert _get_report(credential.id, in_group_connector.id, manager) is not None
-    assert _get_report(credential.id, foreign_connector.id, manager) is None
-    assert _get_report(credential.id, orphan_connector.id, manager) is None
+    for connector_id in hidden_connector_ids:
+        assert _get_report(credential.id, connector_id, manager) is None
 
     # The per-source listing applies the same gate.
     response = client.get(
@@ -166,13 +182,27 @@ def test_scoped_manager_sees_only_their_groups_pairings(
     response.raise_for_status()
     listed_connector_ids = {row["connector_id"] for row in response.json()}
     assert in_group_connector.id in listed_connector_ids
-    assert foreign_connector.id not in listed_connector_ids
-    assert orphan_connector.id not in listed_connector_ids
+    for connector_id in hidden_connector_ids:
+        assert connector_id not in listed_connector_ids
+
+    # A global grant that only implies READ_CONNECTORS (which skips the
+    # cc-pair read filter entirely) must not widen the gate: read visibility
+    # is not management scope.
+    UserGroupManager.wait_for_sync(
+        user_groups_to_check=[managed_group],
+        user_performing_action=admin_user,
+    )
+    set_permissions_response = UserGroupManager.set_permissions(
+        user_group=managed_group,
+        permissions=[Permission.MANAGE_DOCUMENT_SETS.value],
+        user_performing_action=admin_user,
+    )
+    assert set_permissions_response.status_code == 200
+    assert Permission.READ_CONNECTORS.value in UserManager.get_permissions(manager)
+    assert _get_report(credential.id, in_group_connector.id, manager) is not None
+    for connector_id in hidden_connector_ids:
+        assert _get_report(credential.id, connector_id, manager) is None
 
     # Global managers are unaffected, the orphan included (support surface).
-    for connector_id in (
-        in_group_connector.id,
-        foreign_connector.id,
-        orphan_connector.id,
-    ):
+    for connector_id in (in_group_connector.id, *hidden_connector_ids):
         assert _get_report(credential.id, connector_id, admin_user) is not None

--- a/backend/tests/integration/tests/capability_checks/test_capability_report_scoped_visibility.py
+++ b/backend/tests/integration/tests/capability_checks/test_capability_report_scoped_visibility.py
@@ -1,12 +1,15 @@
 """EE-only visibility tests: connector-scoped reports are management data.
 
-A scoped group manager reaches the report endpoints via ``allow_scope`` GATE 1
-and passes the credential gate only for credentials they own. The connector
-scope needs its own GATE 2 bound to the caller's MANAGED scope: read
-visibility would surface pairing outcomes (verdicts, probe errors, config
-hash) from every public or sync pairing, and is skipped entirely for
-READ_CONNECTORS holders. Failed-creation orphan rows (no cc-pair was ever
-created) stay a global-manager support surface.
+A scoped group manager reaches the report endpoints via ``allow_scope`` GATE 1.
+GATE 2 splits by scope: the credential scope follows credential visibility
+(creator-only for scoped managers), while the connector scope follows pairing
+visibility alone, bound to the caller's MANAGED scope -- read visibility would
+surface pairing outcomes (verdicts, probe errors, config hash) from every
+public or sync pairing, and is skipped entirely for READ_CONNECTORS holders.
+Pairing visibility does not require credential visibility: whoever manages the
+pairing may read its outcomes, as on the cc-pair detail endpoint.
+Failed-creation orphan rows (no cc-pair was ever created) stay a
+global-manager support surface.
 """
 
 import os
@@ -206,3 +209,84 @@ def test_scoped_manager_sees_only_their_groups_pairings(
     # Global managers are unaffected, the orphan included (support surface).
     for connector_id in (in_group_connector.id, *hidden_connector_ids):
         assert _get_report(credential.id, connector_id, admin_user) is not None
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Scoped group managers are enterprise only",
+)
+def test_managed_pairing_is_readable_without_credential_visibility(
+    admin_user: DATestUser,
+) -> None:
+    # Precondition. An admin-created credential paired into the manager's
+    # managed group. The credential filter is creator-only for scoped
+    # managers (``admin_public`` notwithstanding), so the credential itself
+    # is invisible to them; only pairing visibility can admit its report.
+    suffix = uuid4().hex[:8]
+    manager = UserManager.create(name=f"scoped_manager_{suffix}")
+    managed_group = UserGroupManager.create(
+        name=f"managed_group_{suffix}",
+        user_ids=[manager.id],
+        cc_pair_ids=[],
+        user_performing_action=admin_user,
+    )
+    UserGroupManager.wait_for_sync(
+        user_groups_to_check=[managed_group],
+        user_performing_action=admin_user,
+    )
+    set_manager_response = UserGroupManager.set_manager(
+        user_group=managed_group,
+        user=manager,
+        is_manager=True,
+        user_performing_action=admin_user,
+    )
+    assert set_manager_response.status_code == 200
+    # Group edits mark the group as syncing; cc-pair creation refuses to
+    # relate a group mid-sync, so wait again before pairing.
+    UserGroupManager.wait_for_sync(
+        user_groups_to_check=[managed_group],
+        user_performing_action=admin_user,
+    )
+    credential = CredentialManager.create(
+        source=DocumentSource.SLACK,
+        admin_public=True,
+        curator_public=False,
+        groups=[],
+        user_performing_action=admin_user,
+    )
+    connector = ConnectorManager.create(
+        source=DocumentSource.SLACK,
+        input_type=InputType.POLL,
+        connector_specific_config=_CONNECTOR_CONFIG,
+        user_performing_action=admin_user,
+    )
+    CCPairManager.create(
+        connector_id=connector.id,
+        credential_id=credential.id,
+        access_type=AccessType.PRIVATE,
+        groups=[managed_group.id],
+        user_performing_action=admin_user,
+    )
+    _seed_report_row(credential.id, connector.id)
+
+    # Under test and postcondition. Pairing visibility alone authorizes the
+    # connector-scoped read; the credential scope stays gated on credential
+    # visibility and reads as inaccessible.
+    assert _get_report(credential.id, connector.id, manager) is not None
+    credential_scope_response = client.get(
+        f"{API_SERVER_URL}/manage/admin/credential/{credential.id}/capability-report",
+        headers=manager.headers,
+    )
+    assert credential_scope_response.status_code == 404
+    error_code = credential_scope_response.json()["error_code"]
+    assert error_code == "CREDENTIAL_NOT_FOUND"
+
+    # The per-source listing admits the managed pairing's row the same way.
+    listing_response = client.get(
+        _REPORTS_FOR_SOURCE_URL,
+        params={"source": DocumentSource.SLACK.value},
+        headers=manager.headers,
+    )
+    listing_response.raise_for_status()
+    listed_connector_ids = {row["connector_id"] for row in listing_response.json()}
+    assert connector.id in listed_connector_ids


### PR DESCRIPTION
## Description

Adds the read-only API over the `credential_capability_report` rows the blocking-validation recorder has been writing since #13971. No writes, no gating: reports stay advisory. First of three PRs (next one adds POST + the check-runner Celery task together).

- `GET /manage/admin/credential/{credential_id}/capability-report?connector_id=` returns the stored row for one scope (connector_id omitted = the config-less credential-scoped row). This is the FE polling target.
- `GET /manage/admin/credential/capability-reports?source=` returns the source's rows visible to the caller, newest first.
- Response is a `CapabilityReportSnapshot`: row metadata (`run_status`, `trigger`, `connector_config_hash`, `run_started_at`, `time_updated`) plus the stored report re-validated into `CredentialCapabilityReport`, so consumers get a typed shape instead of raw JSONB.
- Auth mirrors the admin credential reads: `require_permission(MANAGE_CONNECTORS, allow_scope=True)`. GATE 2 splits by scope: credential-scoped reads use the same user-filtered credential fetches the credential listings use (unknown and inaccessible are both 404 `CREDENTIAL_NOT_FOUND`); connector-scoped reads are authorized by pairing visibility alone (scoped managers: pairings in their managed groups; global managers: every pairing, failed-creation orphans included), independent of credential visibility. A hidden pairing reads as null, same as no row.
- A scope with no row returns 200 null rather than 404: "no report yet" is the normal state for most scopes and is what the future FE keys its auto-run on.

## How Has This Been Tested?

- Integration tests seed rows by calling the recorder directly (`INTEGRATION_TESTS_MODE` disables its hooks) and read them back through the API: round-trip, null scopes, 404, 403 for basic users, source-filtered ordering, and EE scoped-manager visibility (managed vs foreign/public/orphan pairings, READ_CONNECTORS not widening the gate, a managed pairing readable without credential visibility).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds read-only endpoints to fetch stored credential capability reports so the UI can poll advisory results. Previously these reports were not available via API; now they can be retrieved per credential or per source without changing write paths or gating behavior.

- Endpoints
  - GET /manage/admin/credential/{credential_id}/capability-report[?connector_id=]: returns a snapshot or null. Unknown/inaccessible credentials return 404 CREDENTIAL_NOT_FOUND. For connector-scoped rows, hidden pairings read as null for scoped managers; global managers see all rows, including orphaned ones.
  - GET /manage/admin/credential/capability-reports?source=: returns snapshots for all visible credentials of the source, newest first, with the same connector-scope visibility gate.
- Response
  - CapabilityReportSnapshot includes credential_id, connector_id, source, run_status, trigger, run_started_at, connector_config_hash, time_updated, and a validated CredentialCapabilityReport (typed, not raw JSONB).
- Auth and visibility
  - Requires MANAGE_CONNECTORS (allow_scope=True). Basic users get 403. Credential visibility matches existing listings; connector-scoped rows apply a second gate: scoped managers see only pairings they manage; global managers see everything.

<sup>Written for commit 1819639ce8929180d7c789c7cc0d285f18f5f14c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


