### PR TITLE
fix(terraform-provider): replace role with group_ids for API keys

### DIFF
--- a/terraform-provider-onyx/README.md
+++ b/terraform-provider-onyx/README.md
@@ -25,14 +25,15 @@ Generated per-resource docs live in [`docs/`](./docs/).
 
 ## Authentication
 
-The provider needs an **admin-role API key** (or an unrestricted PAT created by an admin
-user). Create one in the Onyx admin panel (*API Keys*) or via the API:
+The provider needs an API key in the seeded **Admin** group (or an unrestricted PAT created
+by an admin user). Create one in the Onyx admin panel (*API Keys*) or via the API — pass the
+Admin group id, since a key with no group has no admin permissions:
 
 ```bash
 curl -X POST https://your-onyx/api/admin/api-key \
   -H "Cookie: fastapiusersauth=<admin session>" \
   -H "Content-Type: application/json" \
-  -d '{"name": "terraform", "role": "admin"}'
+  -d '{"name": "terraform", "group_ids": [<admin group id>]}'
 ```
 
 This first key is inherently chicken-and-egg: it must exist before Terraform can run, so

--- a/terraform-provider-onyx/docs/index.md
+++ b/terraform-provider-onyx/docs/index.md
@@ -28,7 +28,7 @@ variable "onyx_api_key" {
 # Credentials can also come from ONYX_SERVER_URL / ONYX_API_KEY env vars.
 provider "onyx" {
   endpoint = "https://onyx.internal.example.com"
-  api_key  = var.onyx_api_key # an admin-role API key ("on_...")
+  api_key  = var.onyx_api_key # an API key in the Admin group ("on_...")
 }
 ```
 
@@ -37,6 +37,6 @@ provider "onyx" {
 
 ### Optional
 
-- `api_key` (String, Sensitive) Admin-role Onyx API key (`on_...`) or unrestricted personal access token (`onyx_pat_...`). May also be set via the `ONYX_API_KEY` environment variable.
+- `api_key` (String, Sensitive) Onyx API key (`on_...`) in the seeded `Admin` group, or unrestricted personal access token (`onyx_pat_...`). May also be set via the `ONYX_API_KEY` environment variable.
 - `api_prefix` (String) Path prefix the API is served under, defaults to `/api` (the web proxy). Set to `""` when talking directly to the backend (e.g. `http://localhost:8080`). May also be set via the `ONYX_API_PREFIX` environment variable.
 - `endpoint` (String) Onyx server origin, e.g. `https://cloud.onyx.app` or `http://localhost:3000`. May also be set via the `ONYX_SERVER_URL` environment variable.

--- a/terraform-provider-onyx/docs/resources/api_key.md
+++ b/terraform-provider-onyx/docs/resources/api_key.md
@@ -16,7 +16,7 @@ An Onyx API key. The key material is returned by the API exactly once at creatio
 # A key for an internal integration. The key material is in
 # onyx_api_key.ingest.api_key (sensitive, state-only).
 resource "onyx_api_key" "ingest" {
-  name = "ingest-pipeline"
+  name      = "ingest-pipeline"
   group_ids = [3]
 }
 ```

--- a/terraform-provider-onyx/docs/resources/api_key.md
+++ b/terraform-provider-onyx/docs/resources/api_key.md
@@ -17,7 +17,7 @@ An Onyx API key. The key material is returned by the API exactly once at creatio
 # onyx_api_key.ingest.api_key (sensitive, state-only).
 resource "onyx_api_key" "ingest" {
   name = "ingest-pipeline"
-  role = "basic"
+  group_ids = [3]
 }
 ```
 
@@ -27,7 +27,7 @@ resource "onyx_api_key" "ingest" {
 ### Optional
 
 - `name` (String) Display name for the key.
-- `role` (String) Role of the service account backing the key: `basic`, `admin`, `curator`, `global_curator`, or `limited`.
+- `group_ids` (Set of Number) Ids of the user groups the backing service account belongs to. The key resolves the union of those groups' permissions. Omit for a key with no group permissions. This replaces the whole group set on every apply.
 
 ### Read-Only
 

--- a/terraform-provider-onyx/docs/resources/api_key.md
+++ b/terraform-provider-onyx/docs/resources/api_key.md
@@ -16,8 +16,9 @@ An Onyx API key. The key material is returned by the API exactly once at creatio
 # A key for an internal integration. The key material is in
 # onyx_api_key.ingest.api_key (sensitive, state-only).
 resource "onyx_api_key" "ingest" {
-  name      = "ingest-pipeline"
-  group_ids = [3]
+  name = "ingest-pipeline"
+  # Group ids are assigned per deployment; look yours up in the admin UI.
+  group_ids = [var.ingest_group_id]
 }
 ```
 

--- a/terraform-provider-onyx/docs/resources/api_key.md
+++ b/terraform-provider-onyx/docs/resources/api_key.md
@@ -13,11 +13,15 @@ An Onyx API key. The key material is returned by the API exactly once at creatio
 ## Example Usage
 
 ```terraform
+variable "ingest_group_id" {
+  type        = number
+  description = "Id of an existing Onyx user group; ids are assigned per deployment."
+}
+
 # A key for an internal integration. The key material is in
 # onyx_api_key.ingest.api_key (sensitive, state-only).
 resource "onyx_api_key" "ingest" {
-  name = "ingest-pipeline"
-  # Group ids are assigned per deployment; look yours up in the admin UI.
+  name      = "ingest-pipeline"
   group_ids = [var.ingest_group_id]
 }
 ```

--- a/terraform-provider-onyx/examples/provider/provider.tf
+++ b/terraform-provider-onyx/examples/provider/provider.tf
@@ -14,5 +14,5 @@ variable "onyx_api_key" {
 # Credentials can also come from ONYX_SERVER_URL / ONYX_API_KEY env vars.
 provider "onyx" {
   endpoint = "https://onyx.internal.example.com"
-  api_key  = var.onyx_api_key # an admin-role API key ("on_...")
+  api_key  = var.onyx_api_key # an API key in the Admin group ("on_...")
 }

--- a/terraform-provider-onyx/examples/resources/onyx_api_key/resource.tf
+++ b/terraform-provider-onyx/examples/resources/onyx_api_key/resource.tf
@@ -2,5 +2,5 @@
 # onyx_api_key.ingest.api_key (sensitive, state-only).
 resource "onyx_api_key" "ingest" {
   name = "ingest-pipeline"
-  role = "basic"
+  group_ids = [3]
 }

--- a/terraform-provider-onyx/examples/resources/onyx_api_key/resource.tf
+++ b/terraform-provider-onyx/examples/resources/onyx_api_key/resource.tf
@@ -1,6 +1,7 @@
 # A key for an internal integration. The key material is in
 # onyx_api_key.ingest.api_key (sensitive, state-only).
 resource "onyx_api_key" "ingest" {
-  name      = "ingest-pipeline"
-  group_ids = [3]
+  name = "ingest-pipeline"
+  # Group ids are assigned per deployment; look yours up in the admin UI.
+  group_ids = [var.ingest_group_id]
 }

--- a/terraform-provider-onyx/examples/resources/onyx_api_key/resource.tf
+++ b/terraform-provider-onyx/examples/resources/onyx_api_key/resource.tf
@@ -1,7 +1,11 @@
+variable "ingest_group_id" {
+  type        = number
+  description = "Id of an existing Onyx user group; ids are assigned per deployment."
+}
+
 # A key for an internal integration. The key material is in
 # onyx_api_key.ingest.api_key (sensitive, state-only).
 resource "onyx_api_key" "ingest" {
-  name = "ingest-pipeline"
-  # Group ids are assigned per deployment; look yours up in the admin UI.
+  name      = "ingest-pipeline"
   group_ids = [var.ingest_group_id]
 }

--- a/terraform-provider-onyx/examples/resources/onyx_api_key/resource.tf
+++ b/terraform-provider-onyx/examples/resources/onyx_api_key/resource.tf
@@ -1,6 +1,6 @@
 # A key for an internal integration. The key material is in
 # onyx_api_key.ingest.api_key (sensitive, state-only).
 resource "onyx_api_key" "ingest" {
-  name = "ingest-pipeline"
+  name      = "ingest-pipeline"
   group_ids = [3]
 }

--- a/terraform-provider-onyx/internal/client/api_key.go
+++ b/terraform-provider-onyx/internal/client/api_key.go
@@ -7,20 +7,26 @@ import (
 )
 
 // APIKeyArgs mirrors APIKeyArgs (backend/onyx/server/api_key/models.py).
+// GroupIDs must never be nil — it marshals to JSON null, which the backend rejects with a 422.
 type APIKeyArgs struct {
-	Name *string `json:"name"`
-	Role string  `json:"role"`
+	Name     *string `json:"name"`
+	GroupIDs []int64 `json:"group_ids"`
 }
 
-// APIKeyDescriptor mirrors the backend model. APIKey (the plaintext
-// credential) is only present in create/regenerate responses.
+// UserGroupInfo mirrors UserGroupInfo (backend/onyx/server/models.py).
+type UserGroupInfo struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+// APIKeyDescriptor mirrors the backend model; APIKey (plaintext) is set only on create/regenerate.
 type APIKeyDescriptor struct {
-	APIKeyID      int64   `json:"api_key_id"`
-	APIKeyDisplay string  `json:"api_key_display"`
-	APIKey        *string `json:"api_key"`
-	APIKeyName    *string `json:"api_key_name"`
-	APIKeyRole    string  `json:"api_key_role"`
-	UserID        string  `json:"user_id"`
+	APIKeyID      int64           `json:"api_key_id"`
+	APIKeyDisplay string          `json:"api_key_display"`
+	APIKey        *string         `json:"api_key"`
+	APIKeyName    *string         `json:"api_key_name"`
+	Groups        []UserGroupInfo `json:"groups"`
+	UserID        string          `json:"user_id"`
 }
 
 // CreateAPIKey creates an API key. The response carries the plaintext key —
@@ -61,7 +67,7 @@ func (c *Client) GetAPIKey(ctx context.Context, id int64) (*APIKeyDescriptor, er
 	}
 }
 
-// UpdateAPIKey updates an API key's name and role.
+// UpdateAPIKey updates an API key's name and group membership.
 func (c *Client) UpdateAPIKey(ctx context.Context, id int64, args APIKeyArgs) (*APIKeyDescriptor, error) {
 	var desc APIKeyDescriptor
 	path := fmt.Sprintf("/admin/api-key/%d", id)

--- a/terraform-provider-onyx/internal/client/api_key.go
+++ b/terraform-provider-onyx/internal/client/api_key.go
@@ -7,10 +7,18 @@ import (
 )
 
 // APIKeyArgs mirrors APIKeyArgs (backend/onyx/server/api_key/models.py).
-// GroupIDs must never be nil — it marshals to JSON null, which the backend rejects with a 422.
 type APIKeyArgs struct {
 	Name     *string `json:"name"`
 	GroupIDs []int64 `json:"group_ids"`
+}
+
+// normalized returns args safe to send: a nil GroupIDs marshals to JSON null,
+// which the backend rejects with a 422 rather than reading as "no groups".
+func (a APIKeyArgs) normalized() APIKeyArgs {
+	if a.GroupIDs == nil {
+		a.GroupIDs = []int64{}
+	}
+	return a
 }
 
 // UserGroupInfo mirrors UserGroupInfo (backend/onyx/server/models.py).
@@ -33,7 +41,7 @@ type APIKeyDescriptor struct {
 // the only time it is ever returned.
 func (c *Client) CreateAPIKey(ctx context.Context, args APIKeyArgs) (*APIKeyDescriptor, error) {
 	var desc APIKeyDescriptor
-	if err := c.doJSON(ctx, http.MethodPost, "/admin/api-key", args, &desc); err != nil {
+	if err := c.doJSON(ctx, http.MethodPost, "/admin/api-key", args.normalized(), &desc); err != nil {
 		return nil, err
 	}
 	return &desc, nil
@@ -71,7 +79,7 @@ func (c *Client) GetAPIKey(ctx context.Context, id int64) (*APIKeyDescriptor, er
 func (c *Client) UpdateAPIKey(ctx context.Context, id int64, args APIKeyArgs) (*APIKeyDescriptor, error) {
 	var desc APIKeyDescriptor
 	path := fmt.Sprintf("/admin/api-key/%d", id)
-	if err := c.doJSON(ctx, http.MethodPatch, path, args, &desc); err != nil {
+	if err := c.doJSON(ctx, http.MethodPatch, path, args.normalized(), &desc); err != nil {
 		return nil, err
 	}
 	return &desc, nil

--- a/terraform-provider-onyx/internal/client/api_key_test.go
+++ b/terraform-provider-onyx/internal/client/api_key_test.go
@@ -11,7 +11,7 @@ const apiKeyJSON = `{
 	"api_key_display": "on_****abcd",
 	"api_key": "on_full_secret_key",
 	"api_key_name": "terraform",
-	"api_key_role": "admin",
+	"groups": [{"id": 3, "name": "Admin"}],
 	"user_id": "9b9284a6-16b5-4a3c-bfa4-lol"
 }`
 
@@ -19,7 +19,7 @@ func strPtr(s string) *string { return &s }
 
 func TestCreateAPIKey(t *testing.T) {
 	c, captured := newTestServer(t, http.StatusOK, apiKeyJSON)
-	desc, err := c.CreateAPIKey(context.Background(), APIKeyArgs{Name: strPtr("terraform"), Role: "admin"})
+	desc, err := c.CreateAPIKey(context.Background(), APIKeyArgs{Name: strPtr("terraform"), GroupIDs: []int64{3}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,7 +27,8 @@ func TestCreateAPIKey(t *testing.T) {
 		t.Errorf("got %s %s, want POST /admin/api-key", captured.Method, captured.Path)
 	}
 	body := bodyAsMap(t, captured.Body)
-	if body["name"] != "terraform" || body["role"] != "admin" {
+	groups, _ := body["group_ids"].([]any)
+	if body["name"] != "terraform" || len(groups) != 1 || groups[0] != float64(3) {
 		t.Errorf("unexpected body: %s", captured.Body)
 	}
 	if desc.APIKeyID != 7 || desc.APIKey == nil || *desc.APIKey != "on_full_secret_key" {
@@ -37,7 +38,7 @@ func TestCreateAPIKey(t *testing.T) {
 
 func TestCreateAPIKeyNullName(t *testing.T) {
 	c, captured := newTestServer(t, http.StatusOK, apiKeyJSON)
-	if _, err := c.CreateAPIKey(context.Background(), APIKeyArgs{Role: "basic"}); err != nil {
+	if _, err := c.CreateAPIKey(context.Background(), APIKeyArgs{GroupIDs: []int64{}}); err != nil {
 		t.Fatal(err)
 	}
 	body := bodyAsMap(t, captured.Body)
@@ -55,7 +56,7 @@ func TestGetAPIKeyScansList(t *testing.T) {
 	if captured.Method != http.MethodGet || captured.Path != "/admin/api-key" {
 		t.Errorf("got %s %s, want GET /admin/api-key", captured.Method, captured.Path)
 	}
-	if desc.APIKeyRole != "admin" {
+	if len(desc.Groups) != 1 || desc.Groups[0].ID != 3 {
 		t.Errorf("unexpected descriptor: %+v", desc)
 	}
 
@@ -66,11 +67,39 @@ func TestGetAPIKeyScansList(t *testing.T) {
 
 func TestUpdateAPIKey(t *testing.T) {
 	c, captured := newTestServer(t, http.StatusOK, apiKeyJSON)
-	if _, err := c.UpdateAPIKey(context.Background(), 7, APIKeyArgs{Name: strPtr("renamed"), Role: "basic"}); err != nil {
+	if _, err := c.UpdateAPIKey(context.Background(), 7, APIKeyArgs{Name: strPtr("renamed"), GroupIDs: []int64{3}}); err != nil {
 		t.Fatal(err)
 	}
 	if captured.Method != http.MethodPatch || captured.Path != "/admin/api-key/7" {
 		t.Errorf("got %s %s, want PATCH /admin/api-key/7", captured.Method, captured.Path)
+	}
+}
+
+// A nil (vs empty) group_ids marshals to JSON null, which the backend rejects with a 422.
+func TestAPIKeyArgsAlwaysSendGroupIDs(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		call func(*Client) error
+	}{
+		{"create", func(c *Client) error {
+			_, err := c.CreateAPIKey(context.Background(), APIKeyArgs{GroupIDs: []int64{}})
+			return err
+		}},
+		{"update", func(c *Client) error {
+			_, err := c.UpdateAPIKey(context.Background(), 7, APIKeyArgs{GroupIDs: []int64{}})
+			return err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, captured := newTestServer(t, http.StatusOK, apiKeyJSON)
+			if err := tc.call(c); err != nil {
+				t.Fatal(err)
+			}
+			value, present := bodyAsMap(t, captured.Body)["group_ids"]
+			if !present || value == nil {
+				t.Errorf("group_ids must serialize as a list, body: %s", captured.Body)
+			}
+		})
 	}
 }
 

--- a/terraform-provider-onyx/internal/client/api_key_test.go
+++ b/terraform-provider-onyx/internal/client/api_key_test.go
@@ -75,18 +75,19 @@ func TestUpdateAPIKey(t *testing.T) {
 	}
 }
 
-// A nil (vs empty) group_ids marshals to JSON null, which the backend rejects with a 422.
+// Args with no GroupIDs set: nil marshals to JSON null, which the backend rejects
+// with a 422 instead of reading as "no groups".
 func TestAPIKeyArgsAlwaysSendGroupIDs(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		call func(*Client) error
 	}{
 		{"create", func(c *Client) error {
-			_, err := c.CreateAPIKey(context.Background(), APIKeyArgs{GroupIDs: []int64{}})
+			_, err := c.CreateAPIKey(context.Background(), APIKeyArgs{})
 			return err
 		}},
 		{"update", func(c *Client) error {
-			_, err := c.UpdateAPIKey(context.Background(), 7, APIKeyArgs{GroupIDs: []int64{}})
+			_, err := c.UpdateAPIKey(context.Background(), 7, APIKeyArgs{})
 			return err
 		}},
 	} {

--- a/terraform-provider-onyx/internal/provider/api_key_resource.go
+++ b/terraform-provider-onyx/internal/provider/api_key_resource.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/onyx-dot-app/onyx/terraform-provider-onyx/internal/client"
 )
@@ -35,10 +34,29 @@ type apiKeyResource struct {
 type apiKeyResourceModel struct {
 	ID            types.String `tfsdk:"id"`
 	Name          types.String `tfsdk:"name"`
-	Role          types.String `tfsdk:"role"`
+	GroupIDs      types.Set    `tfsdk:"group_ids"`
 	APIKey        types.String `tfsdk:"api_key"`
 	APIKeyDisplay types.String `tfsdk:"api_key_display"`
 	UserID        types.String `tfsdk:"user_id"`
+}
+
+// groupIDsFromDescriptor always returns a known (non-null) set, even for zero groups.
+func groupIDsFromDescriptor(desc *client.APIKeyDescriptor) (types.Set, diag.Diagnostics) {
+	ids := make([]attr.Value, 0, len(desc.Groups))
+	for _, group := range desc.Groups {
+		ids = append(ids, types.Int64Value(group.ID))
+	}
+	return types.SetValue(types.Int64Type, ids)
+}
+
+// groupIDsToArgs: a null or unknown set becomes `[]`, which clears the key's groups.
+func groupIDsToArgs(ctx context.Context, set types.Set) ([]int64, diag.Diagnostics) {
+	ids := []int64{}
+	if set.IsNull() || set.IsUnknown() {
+		return ids, nil
+	}
+	diags := set.ElementsAs(ctx, &ids, false)
+	return ids, diags
 }
 
 func (r *apiKeyResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -63,15 +81,12 @@ func (r *apiKeyResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Optional:            true,
 				MarkdownDescription: "Display name for the key.",
 			},
-			"role": schema.StringAttribute{
-				Optional: true,
-				Computed: true,
-				Default:  stringdefault.StaticString("basic"),
-				MarkdownDescription: "Role of the service account backing the key: `basic`, `admin`, " +
-					"`curator`, `global_curator`, or `limited`.",
-				Validators: []validator.String{
-					stringvalidator.OneOf("basic", "admin", "curator", "global_curator", "limited"),
-				},
+			"group_ids": schema.SetAttribute{
+				Optional:    true,
+				ElementType: types.Int64Type,
+				MarkdownDescription: "Ids of the user groups the backing service account belongs to. The " +
+					"key resolves the union of those groups' permissions. Omit for a key with no group " +
+					"permissions. This replaces the whole group set on every apply.",
 			},
 			"api_key": schema.StringAttribute{
 				Computed:  true,
@@ -111,9 +126,15 @@ func (r *apiKeyResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	groupIDs, diags := groupIDsToArgs(ctx, plan.GroupIDs)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	desc, err := r.client.CreateAPIKey(ctx, client.APIKeyArgs{
-		Name: plan.Name.ValueStringPointer(),
-		Role: plan.Role.ValueString(),
+		Name:     plan.Name.ValueStringPointer(),
+		GroupIDs: groupIDs,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create Onyx API key", err.Error())
@@ -150,11 +171,20 @@ func (r *apiKeyResource) Read(ctx context.Context, req resource.ReadRequest, res
 	}
 
 	state.Name = types.StringPointerValue(desc.APIKeyName)
-	state.Role = types.StringValue(desc.APIKeyRole)
 	state.APIKeyDisplay = types.StringValue(desc.APIKeyDisplay)
 	state.UserID = types.StringValue(desc.UserID)
-	// state.APIKey is carried forward: the plaintext key is never returned
-	// after creation, so prior state is the only source of truth.
+
+	// Terraform treats null and an empty set as different; only overwrite group_ids when
+	// the API actually reports groups, or a no-group key drifts null → [].
+	if len(desc.Groups) > 0 || !state.GroupIDs.IsNull() {
+		groupIDs, diags := groupIDsFromDescriptor(desc)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		state.GroupIDs = groupIDs
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -171,9 +201,15 @@ func (r *apiKeyResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
+	groupIDs, diags := groupIDsToArgs(ctx, plan.GroupIDs)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	desc, err := r.client.UpdateAPIKey(ctx, id, client.APIKeyArgs{
-		Name: plan.Name.ValueStringPointer(),
-		Role: plan.Role.ValueString(),
+		Name:     plan.Name.ValueStringPointer(),
+		GroupIDs: groupIDs,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to update Onyx API key", err.Error())

--- a/terraform-provider-onyx/internal/provider/api_key_resource_test.go
+++ b/terraform-provider-onyx/internal/provider/api_key_resource_test.go
@@ -12,20 +12,27 @@ import (
 )
 
 func TestAccAPIKeyResource(t *testing.T) {
+	// Configs are built before PreCheck runs, so bootstrap here to get a real group id.
+	testAccPreCheck(t)
+	adminGroupID := strconv.FormatInt(testAccAdminGroupID(t), 10)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckAPIKeyDestroyed(t),
 		Steps: []resource.TestStep{
 			{
-				Config: `
+				Config: fmt.Sprintf(`
 resource "onyx_api_key" "test" {
-  name = "tf-acc-test-key"
+  name      = "tf-acc-test-key"
+  group_ids = [%s]
 }
-`,
+`, adminGroupID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("onyx_api_key.test", "id"),
 					resource.TestCheckResourceAttr("onyx_api_key.test", "name", "tf-acc-test-key"),
+					resource.TestCheckResourceAttr("onyx_api_key.test", "group_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttr("onyx_api_key.test", "group_ids.*", adminGroupID),
 					resource.TestCheckResourceAttrSet("onyx_api_key.test", "api_key"),
 					resource.TestCheckResourceAttrSet("onyx_api_key.test", "api_key_display"),
 					resource.TestCheckResourceAttrSet("onyx_api_key.test", "user_id"),
@@ -39,15 +46,30 @@ resource "onyx_api_key" "test" {
 				ImportStateVerifyIgnore: []string{"api_key"},
 			},
 			{
+				Config: fmt.Sprintf(`
+resource "onyx_api_key" "test" {
+  name      = "tf-acc-test-key-renamed"
+  group_ids = [%s]
+}
+`, adminGroupID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("onyx_api_key.test", "name", "tf-acc-test-key-renamed"),
+					// Update replaces the whole group set, so a rename must not drop it.
+					resource.TestCheckResourceAttr("onyx_api_key.test", "group_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttr("onyx_api_key.test", "group_ids.*", adminGroupID),
+					// In-place update: key material must survive a name change.
+					resource.TestCheckResourceAttrSet("onyx_api_key.test", "api_key"),
+				),
+			},
+			{
 				Config: `
 resource "onyx_api_key" "test" {
   name = "tf-acc-test-key-renamed"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("onyx_api_key.test", "name", "tf-acc-test-key-renamed"),
-					// In-place update: key material must survive a name change.
-					resource.TestCheckResourceAttrSet("onyx_api_key.test", "api_key"),
+					// Dropping group_ids clears the groups rather than leaving them.
+					resource.TestCheckResourceAttr("onyx_api_key.test", "group_ids.#", "0"),
 				),
 			},
 		},

--- a/terraform-provider-onyx/internal/provider/api_key_resource_test.go
+++ b/terraform-provider-onyx/internal/provider/api_key_resource_test.go
@@ -26,7 +26,6 @@ resource "onyx_api_key" "test" {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("onyx_api_key.test", "id"),
 					resource.TestCheckResourceAttr("onyx_api_key.test", "name", "tf-acc-test-key"),
-					resource.TestCheckResourceAttr("onyx_api_key.test", "role", "basic"),
 					resource.TestCheckResourceAttrSet("onyx_api_key.test", "api_key"),
 					resource.TestCheckResourceAttrSet("onyx_api_key.test", "api_key_display"),
 					resource.TestCheckResourceAttrSet("onyx_api_key.test", "user_id"),
@@ -36,21 +35,18 @@ resource "onyx_api_key" "test" {
 				ResourceName:      "onyx_api_key.test",
 				ImportState:       true,
 				ImportStateVerify: true,
-				// The plaintext key is returned exactly once at creation and
-				// can never be re-read, so the imported state has it null.
+				// plaintext key is write-once and never re-read, so import leaves it null
 				ImportStateVerifyIgnore: []string{"api_key"},
 			},
 			{
 				Config: `
 resource "onyx_api_key" "test" {
   name = "tf-acc-test-key-renamed"
-  role = "limited"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("onyx_api_key.test", "name", "tf-acc-test-key-renamed"),
-					resource.TestCheckResourceAttr("onyx_api_key.test", "role", "limited"),
-					// In-place update: key material must survive name/role changes.
+					// In-place update: key material must survive a name change.
 					resource.TestCheckResourceAttrSet("onyx_api_key.test", "api_key"),
 				),
 			},

--- a/terraform-provider-onyx/internal/provider/provider.go
+++ b/terraform-provider-onyx/internal/provider/provider.go
@@ -54,8 +54,9 @@ func (p *onyxProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp 
 			"api_key": schema.StringAttribute{
 				Optional:  true,
 				Sensitive: true,
-				MarkdownDescription: "Admin-role Onyx API key (`on_...`) or unrestricted personal access token " +
-					"(`onyx_pat_...`). May also be set via the `ONYX_API_KEY` environment variable.",
+				MarkdownDescription: "Onyx API key (`on_...`) in the seeded `Admin` group, or unrestricted " +
+					"personal access token (`onyx_pat_...`). May also be set via the `ONYX_API_KEY` " +
+					"environment variable.",
 			},
 			"api_prefix": schema.StringAttribute{
 				Optional: true,
@@ -120,7 +121,8 @@ func (p *onyxProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 		resp.Diagnostics.AddError(
 			"Missing Onyx API key",
 			"Set the provider's api_key attribute or the ONYX_API_KEY environment variable. "+
-				"Create an admin-role API key in the Onyx admin panel (or via POST /admin/api-key).",
+				"Create an API key in the Onyx admin panel, assigned to the Admin group "+
+				"(or via POST /admin/api-key with group_ids set to the Admin group's id).",
 		)
 	}
 	if resp.Diagnostics.HasError() {

--- a/terraform-provider-onyx/internal/provider/provider_test.go
+++ b/terraform-provider-onyx/internal/provider/provider_test.go
@@ -128,9 +128,15 @@ func bootstrapAPIKey(serverURL, apiPrefix string) (string, error) {
 		return "", fmt.Errorf("login succeeded but no %q cookie was returned", cookieName)
 	}
 
-	keyBody, _ := json.Marshal(map[string]string{
-		"name": "terraform-provider-acceptance-tests",
-		"role": "admin",
+	// permissions come from group membership now — must join the seeded "Admin" group.
+	// A `role` field silently yields a group-less key that 403s on every admin route.
+	adminGroupID, err := findAdminGroupID(httpClient, base, sessionCookie)
+	if err != nil {
+		return "", err
+	}
+	keyBody, _ := json.Marshal(map[string]any{
+		"name":      "terraform-provider-acceptance-tests",
+		"group_ids": []int64{adminGroupID},
 	})
 	keyReq, err := http.NewRequest(http.MethodPost, base+"/admin/api-key", bytes.NewReader(keyBody))
 	if err != nil {
@@ -158,4 +164,37 @@ func bootstrapAPIKey(serverURL, apiPrefix string) (string, error) {
 		return "", fmt.Errorf("API key creation response did not include the key material")
 	}
 	return *descriptor.APIKey, nil
+}
+
+// findAdminGroupID looks up the seeded "Admin" group — hidden from the default listing
+// unless include_default=true.
+func findAdminGroupID(httpClient *http.Client, base string, sessionCookie *http.Cookie) (int64, error) {
+	req, err := http.NewRequest(http.MethodGet, base+"/manage/admin/user-group?include_default=true", nil)
+	if err != nil {
+		return 0, err
+	}
+	req.AddCookie(sessionCookie)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("user group listing request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return 0, fmt.Errorf("user group listing failed with HTTP %d", resp.StatusCode)
+	}
+
+	var groups []struct {
+		ID   int64  `json:"id"`
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&groups); err != nil {
+		return 0, err
+	}
+	for _, group := range groups {
+		if group.Name == "Admin" {
+			return group.ID, nil
+		}
+	}
+	return 0, fmt.Errorf("no seeded \"Admin\" group found; has the seed_default_groups migration run?")
 }

--- a/terraform-provider-onyx/internal/provider/provider_test.go
+++ b/terraform-provider-onyx/internal/provider/provider_test.go
@@ -30,6 +30,8 @@ var (
 	bootstrapOnce   sync.Once
 	bootstrapKey    string
 	bootstrapKeyErr error
+	// 0 means unresolved — real ids come from a sequence starting at 1.
+	bootstrapAdminGroupID int64
 )
 
 func envOr(key, fallback string) string {
@@ -69,6 +71,29 @@ func testAccPreCheck(t *testing.T) {
 	t.Setenv("ONYX_SERVER_URL", serverURL)
 	t.Setenv("ONYX_API_KEY", bootstrapKey)
 	t.Setenv("ONYX_API_PREFIX", testAccAPIPrefix())
+}
+
+// testAccAdminGroupID returns the seeded "Admin" group id, the one group that
+// exists on any deployment. Must run after testAccPreCheck.
+func testAccAdminGroupID(t *testing.T) int64 {
+	t.Helper()
+	if bootstrapAdminGroupID != 0 {
+		return bootstrapAdminGroupID
+	}
+	if bootstrapKey == "" {
+		t.Fatal("testAccAdminGroupID called before testAccPreCheck")
+	}
+	// Only reached when ONYX_TF_ACC_API_KEY short-circuited the bootstrap.
+	base := strings.TrimRight(testAccServerURL(), "/")
+	if p := strings.Trim(testAccAPIPrefix(), "/"); p != "" {
+		base += "/" + p
+	}
+	id, err := findAdminGroupID(&http.Client{Timeout: 30 * time.Second}, base, nil, bootstrapKey)
+	if err != nil {
+		t.Fatalf("failed to resolve the Admin group id: %v", err)
+	}
+	bootstrapAdminGroupID = id
+	return id
 }
 
 // testAccClient returns an API client for pre/post-condition checks.
@@ -130,10 +155,11 @@ func bootstrapAPIKey(serverURL, apiPrefix string) (string, error) {
 
 	// permissions come from group membership now — must join the seeded "Admin" group.
 	// A `role` field silently yields a group-less key that 403s on every admin route.
-	adminGroupID, err := findAdminGroupID(httpClient, base, sessionCookie)
+	adminGroupID, err := findAdminGroupID(httpClient, base, sessionCookie, "")
 	if err != nil {
 		return "", err
 	}
+	bootstrapAdminGroupID = adminGroupID
 	keyBody, _ := json.Marshal(map[string]any{
 		"name":      "terraform-provider-acceptance-tests",
 		"group_ids": []int64{adminGroupID},
@@ -167,13 +193,18 @@ func bootstrapAPIKey(serverURL, apiPrefix string) (string, error) {
 }
 
 // findAdminGroupID looks up the seeded "Admin" group — hidden from the default listing
-// unless include_default=true.
-func findAdminGroupID(httpClient *http.Client, base string, sessionCookie *http.Cookie) (int64, error) {
+// unless include_default=true. Auth is by cookie during bootstrap, by API key after.
+func findAdminGroupID(httpClient *http.Client, base string, sessionCookie *http.Cookie, apiKey string) (int64, error) {
 	req, err := http.NewRequest(http.MethodGet, base+"/manage/admin/user-group?include_default=true", nil)
 	if err != nil {
 		return 0, err
 	}
-	req.AddCookie(sessionCookie)
+	if sessionCookie != nil {
+		req.AddCookie(sessionCookie)
+	}
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
 
 	resp, err := httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
## Description

- Changed API key creation from role-based to group-based permission assignment, since the system no longer supports roles
- Added a `group_ids` attribute to `onyx_api_key`; the old `role` attribute is removed entirely (not deprecated — nothing depends on it yet)
- Updated docs, examples, and error messages to reference the seeded "Admin" group instead of the old role-based language

## How Has This Been Tested?

- `go build`, `go vet`, `gofmt`, and the full unit test suite (`go test ./...`) all pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check