### PR TITLE
feat(groups): show default groups to admins, members-only

### DIFF
--- a/backend/ee/onyx/db/document_set.py
+++ b/backend/ee/onyx/db/document_set.py
@@ -15,6 +15,7 @@ from onyx.db.models import (
     User__UserGroup,
     UserGroup,
 )
+from onyx.db.user_group import assert_not_shared_with_default_group
 
 
 def make_doc_set_private(
@@ -23,6 +24,8 @@ def make_doc_set_private(
     group_ids: list[int] | None,
     db_session: Session,
 ) -> None:
+    assert_not_shared_with_default_group(db_session, group_ids or [])
+
     db_session.query(DocumentSet__User).filter(
         DocumentSet__User.document_set_id == document_set_id
     ).delete(synchronize_session="fetch")

--- a/backend/ee/onyx/db/mcp.py
+++ b/backend/ee/onyx/db/mcp.py
@@ -3,6 +3,7 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from onyx.db.models import MCPServer__User, MCPServer__UserGroup
+from onyx.db.user_group import assert_not_shared_with_default_group
 
 
 def make_mcp_server_private(
@@ -20,6 +21,7 @@ def make_mcp_server_private(
             db_session.add(MCPServer__User(mcp_server_id=server_id, user_id=user_id))
 
     if group_ids is not None:
+        assert_not_shared_with_default_group(db_session, group_ids)
         db_session.query(MCPServer__UserGroup).filter(
             MCPServer__UserGroup.mcp_server_id == server_id
         ).delete(synchronize_session="fetch")

--- a/backend/ee/onyx/db/persona.py
+++ b/backend/ee/onyx/db/persona.py
@@ -13,6 +13,7 @@ from onyx.db.persona import (
     mark_persona_user_files_for_sync,
     resolve_desired_user_shares,
 )
+from onyx.db.user_group import assert_not_shared_with_default_group
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 
@@ -55,6 +56,8 @@ def _apply_persona_group_share_diff(
         .all()
     )
     existing_by_group = {row.user_group_id: row for row in existing_rows}
+
+    assert_not_shared_with_default_group(db_session, list(desired_shares))
 
     for group_id, row in existing_by_group.items():
         if group_id not in desired_shares:

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -14,6 +14,7 @@ from ee.onyx.server.user_group.models import (
 from onyx.auth.permissions import (
     NON_TOGGLEABLE_PERMISSIONS,
     get_effective_permissions,
+    has_global_permission,
     has_permission,
     resolve_effective_permissions,
 )
@@ -582,6 +583,8 @@ def add_users_to_user_group(
         )
 
     _check_user_group_is_modifiable(db_user_group)
+    # gate here too: the no-op early return below skips update_user_group's copy
+    _assert_default_group_update_allowed(user, db_user_group, attaching_cc_pairs=False)
 
     current_user_ids = [user.id for user in db_user_group.users]
     current_user_ids_set = set(current_user_ids)
@@ -633,6 +636,31 @@ def _assert_no_privilege_amplification(
             OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
             "You can't add members to a group that grants permissions you don't "
             "hold: " + ", ".join(sorted(permission.value for permission in excess)),
+        )
+
+
+def _assert_default_group_update_allowed(
+    user: User,
+    db_user_group: UserGroup,
+    *,
+    attaching_cc_pairs: bool,
+) -> None:
+    """Members are all a default group has, and only a full admin may change them. Lives
+    here because both write paths reach it, and because connectors ride in the same PATCH
+    payload as membership — there is no group-side connector route to guard, unlike agents
+    and document sets."""
+    if not db_user_group.is_default:
+        return
+
+    if not has_global_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS):
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "Only administrators can change the membership of a default system group.",
+        )
+    if attaching_cc_pairs:
+        raise OnyxError(
+            OnyxErrorCode.CONFLICT,
+            "A default system group holds only members, so it can't take connectors.",
         )
 
 
@@ -736,6 +764,9 @@ def update_user_group(
 
     current_cc_pair_ids = set(_current_cc_pair_ids(db_user_group))
     requested_cc_pair_ids = set(user_group_update.cc_pair_ids)
+    _assert_default_group_update_allowed(
+        user, db_user_group, attaching_cc_pairs=bool(requested_cc_pair_ids)
+    )
     _assert_group_update_within_scope(
         db_session,
         user,

--- a/backend/ee/onyx/server/token_rate_limits/api.py
+++ b/backend/ee/onyx/server/token_rate_limits/api.py
@@ -192,8 +192,9 @@ def _authorize_group_token_rate_limit_write(
     allows many-to-many; defensively, if a limit ever spans groups (a mutation hits all of them),
     require the caller to manage every one, not just the group_id in the URL.
 
-    A default group carries no limits, so this path refuses it outright."""
-    assert_group_config_is_editable(db_session, group_id, "set token limits on")
+    A default group carries no limits, so this path refuses it outright — but only after
+    the scope gate, or the conflict would tell an out-of-scope caller which ids are
+    default groups."""
     assert_within_scope(
         user,
         db_session,
@@ -202,6 +203,7 @@ def _authorize_group_token_rate_limit_write(
         requested_group_ids=[group_id],
         is_non_public=True,
     )
+    assert_group_config_is_editable(db_session, group_id, "set token limits on")
     try:
         scope, group_ids = get_token_rate_limit_scope_and_group_ids(
             db_session, rate_limit_id

--- a/backend/ee/onyx/server/token_rate_limits/api.py
+++ b/backend/ee/onyx/server/token_rate_limits/api.py
@@ -23,7 +23,10 @@ from onyx.db.token_limit import (
     insert_user_token_rate_limit,
     update_token_rate_limit,
 )
-from onyx.db.user_group import assert_group_config_is_editable
+from onyx.db.user_group import (
+    assert_group_config_is_editable,
+    assert_groups_config_are_editable,
+)
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.query_and_chat.token_limit import (
@@ -215,7 +218,8 @@ def _authorize_group_token_rate_limit_write(
             OnyxErrorCode.NOT_FOUND, "Token rate limit not found for this group."
         )
     # Defensive: no current path attaches a limit to >1 group, but the schema allows it. If one
-    # ever did, the mutation would hit all of them, so require the caller to manage every one.
+    # ever did, the mutation would hit all of them, so require the caller to manage every one —
+    # and none of them to be a default group, which the URL's id alone wouldn't catch.
     assert_within_scope(
         user,
         db_session,
@@ -224,6 +228,7 @@ def _authorize_group_token_rate_limit_write(
         requested_group_ids=group_ids,
         is_non_public=True,
     )
+    assert_groups_config_are_editable(db_session, group_ids, "set token limits on")
 
 
 # Separate from the shared by-id routes so this route's require_permission caps a scoped

--- a/backend/ee/onyx/server/token_rate_limits/api.py
+++ b/backend/ee/onyx/server/token_rate_limits/api.py
@@ -23,6 +23,7 @@ from onyx.db.token_limit import (
     insert_user_token_rate_limit,
     update_token_rate_limit,
 )
+from onyx.db.user_group import assert_group_config_is_editable
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.query_and_chat.token_limit import (
@@ -169,6 +170,7 @@ def create_group_token_limit_settings(
         requested_group_ids=[group_id],
         is_non_public=True,
     )
+    assert_group_config_is_editable(db_session, group_id, "set a token limit on")
     rate_limit_display = TokenRateLimitDisplay.from_db(
         insert_user_group_token_rate_limit(
             db_session=db_session,
@@ -188,7 +190,10 @@ def _authorize_group_token_rate_limit_write(
     limit must belong to it — so a global/per-user id or another group's limit can't be reached
     through this path. No current path attaches a limit to more than one group, but the schema
     allows many-to-many; defensively, if a limit ever spans groups (a mutation hits all of them),
-    require the caller to manage every one, not just the group_id in the URL."""
+    require the caller to manage every one, not just the group_id in the URL.
+
+    A default group carries no limits, so this path refuses it outright."""
+    assert_group_config_is_editable(db_session, group_id, "set token limits on")
     assert_within_scope(
         user,
         db_session,

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -60,6 +60,7 @@ from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission, PermissionAuthority
 from onyx.db.models import User
 from onyx.db.persona import fetch_persona_by_id_for_user, get_personas_by_ids
+from onyx.db.user_group import assert_group_config_is_editable
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.security.store import get_security_settings
@@ -117,6 +118,7 @@ def list_user_groups(
                 ),
                 is_user_groups_admin=is_user_groups_admin,
                 is_full_admin=is_full_admin,
+                is_default=user_group.is_default,
             ),
         )
         for user_group in user_groups
@@ -183,6 +185,9 @@ def set_user_group_permissions(
     group = fetch_user_group(db_session, user_group_id)
     if group is None:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "User group not found")
+    assert_group_config_is_editable(
+        db_session, user_group_id, "change the permissions of"
+    )
 
     non_toggleable = [p for p in request.permissions if p in NON_TOGGLEABLE_PERMISSIONS]
     if non_toggleable:
@@ -232,9 +237,7 @@ def rename_user_group_endpoint(
 ) -> UserGroup:
     # GATE 2: rename's DB fn takes no user and re-reads nothing, so gate here.
     assert_manages_group(user, db_session, group_id=rename_request.id)
-    group = fetch_user_group(db_session, rename_request.id)
-    if group and group.is_default:
-        raise OnyxError(OnyxErrorCode.CONFLICT, "Cannot rename a default system group.")
+    assert_group_config_is_editable(db_session, rename_request.id, "rename")
     try:
         return UserGroup.from_model(
             rename_user_group(
@@ -265,6 +268,9 @@ def patch_user_group_incognito(
 ) -> UserGroup:
     """Only meaningful while the security setting is groups-only, but always
     storable so admins can stage membership before flipping the mode."""
+    assert_group_config_is_editable(
+        db_session, user_group_id, "change incognito access on"
+    )
     try:
         return UserGroup.from_model(
             set_user_group_incognito(
@@ -330,9 +336,7 @@ def delete_user_group(
     _: User = Depends(require_permission(Permission.MANAGE_USER_GROUPS)),
     db_session: Session = Depends(get_session),
 ) -> None:
-    group = fetch_user_group(db_session, user_group_id)
-    if group and group.is_default:
-        raise OnyxError(OnyxErrorCode.CONFLICT, "Cannot delete a default system group.")
+    assert_group_config_is_editable(db_session, user_group_id, "delete")
     try:
         prepare_user_group_for_deletion(db_session, user_group_id)
     except ValueError as e:
@@ -360,6 +364,7 @@ def update_group_agents(
 
     if fetch_user_group(db_session, user_group_id) is None:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "User group not found")
+    assert_group_config_is_editable(db_session, user_group_id, "share agents with")
 
     attach_ids = set(request.added_agent_ids)
     detach_ids = set(request.removed_agent_ids)
@@ -430,6 +435,9 @@ def update_group_document_sets(
 
     if fetch_user_group(db_session, user_group_id) is None:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "User group not found")
+    assert_group_config_is_editable(
+        db_session, user_group_id, "share document sets with"
+    )
 
     attach_ids = set(request.added_document_set_ids)
     detach_ids = set(request.removed_document_set_ids)
@@ -510,6 +518,7 @@ def set_group_manager(
     # a scoped manager may only (de)assign managers within a group they manage — so
     # a manager can delegate within their own group but not beyond it.
     assert_manages_group(user, db_session, group_id=user_group_id)
+    assert_group_config_is_editable(db_session, user_group_id, "assign a manager on")
     try:
         if request.is_manager:
             make_group_manager(db_session, request.user_id, user_group_id)

--- a/backend/onyx/auth/permission_projection.py
+++ b/backend/onyx/auth/permission_projection.py
@@ -193,6 +193,7 @@ def custom_skill_permissions(
 
 class UserGroupPermissions(TypedDict):
     manage: bool
+    manage_members: bool
     delete: bool
     edit_permissions: bool
     edit_token_limits: bool
@@ -202,18 +203,28 @@ USER_GROUP_ACTIONS: frozenset[str] = frozenset(UserGroupPermissions.__annotation
 
 
 def user_group_permissions(
-    *, can_manage: bool, is_user_groups_admin: bool, is_full_admin: bool
+    *,
+    can_manage: bool,
+    is_user_groups_admin: bool,
+    is_full_admin: bool,
+    is_default: bool,
 ) -> dict[str, bool]:
-    """User group affordance map. ``manage`` (rename, membership, assign agents, set
+    """User group affordance map. ``manage`` (rename, assign agents/document sets, set
     manager) and ``edit_token_limits`` are the per-group ``manages_group`` decision — group
     in the manager's managed set, or global MANAGE_USER_GROUPS. A scoped manager gets full
     token-limit CRUD for groups they manage: every token route (read/create/update/delete)
     now admits scope. ``delete`` needs global MANAGE_USER_GROUPS (its route has no
-    ``allow_scope``). ``edit_permissions`` is FULL_ADMIN (the permission-toggle route)."""
+    ``allow_scope``). ``edit_permissions`` is FULL_ADMIN (the permission-toggle route).
+
+    A seeded default group (Admin/Basic) has members and nothing else, so it keeps only
+    ``manage_members``, and only for a full admin — mirroring the routes, where every other
+    write raises CONFLICT."""
+    is_editable = can_manage and not is_default
     result: UserGroupPermissions = {
-        "manage": can_manage,
-        "delete": is_user_groups_admin,
-        "edit_permissions": is_full_admin,
-        "edit_token_limits": can_manage,
+        "manage": is_editable,
+        "manage_members": is_full_admin if is_default else can_manage,
+        "delete": is_user_groups_admin and not is_default,
+        "edit_permissions": is_full_admin and not is_default,
+        "edit_token_limits": is_editable,
     }
     return cast(dict[str, bool], result)

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -39,6 +39,7 @@ from onyx.db.scoped_permissions import (
     scoped_group_ids_subquery,
     within_managed_scope_clause,
 )
+from onyx.db.user_group import assert_not_shared_with_default_group
 from onyx.server.models import StatusResponse
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
@@ -717,6 +718,8 @@ def _relate_groups_to_cc_pair__no_commit(
 ) -> None:
     if not user_group_ids:
         return
+
+    assert_not_shared_with_default_group(db_session, user_group_ids)
 
     for group_id in user_group_ids:
         db_session.add(

--- a/backend/onyx/db/credentials.py
+++ b/backend/onyx/db/credentials.py
@@ -15,6 +15,7 @@ from onyx.db.models import (
     DocumentByConnectorCredentialPair,
     User,
 )
+from onyx.db.user_group import assert_not_shared_with_default_group
 from onyx.server.documents.models import CredentialBase
 from onyx.utils.logger import setup_logger
 
@@ -63,6 +64,8 @@ def _relate_credential_to_user_groups__no_commit(
     credential_id: int,
     user_group_ids: list[int],
 ) -> None:
+    assert_not_shared_with_default_group(db_session, user_group_ids)
+
     credential_user_groups = [
         Credential__UserGroup(
             credential_id=credential_id,

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -21,6 +21,7 @@ from onyx.db.models import (
 from onyx.db.models import LLMProvider as LLMProviderModel
 from onyx.db.models import Tool as ToolModel
 from onyx.db.persona import get_raw_personas_for_user
+from onyx.db.user_group import assert_not_shared_with_default_group
 from onyx.llm.utils import model_supports_image_input
 from onyx.llm.well_known_providers.auto_update_models import LLMRecommendations
 from onyx.server.manage.embedding.models import (
@@ -43,6 +44,8 @@ def update_group_llm_provider_relationships__no_commit(
     group_ids: list[int] | None,
     db_session: Session,
 ) -> None:
+    assert_not_shared_with_default_group(db_session, group_ids or [])
+
     # Delete existing relationships
     db_session.query(LLMProvider__UserGroup).filter(
         LLMProvider__UserGroup.llm_provider_id == llm_provider_id

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -891,6 +891,9 @@ def _transfer_persona_ownership(
         # as soon as its sync worker runs.
         if group.is_up_for_deletion:
             raise ValueError("New owner group is being deleted")
+        # Basic/Admin ownership would make the whole org a co-owner; that's what public is
+        if group.is_default:
+            raise ValueError("A default system group can't own an agent")
         if group.id == prev_owner_group_id:
             raise ValueError("This group already owns the agent")
         persona.owner_group_id = group.id

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -68,6 +68,7 @@ from onyx.db.scoped_permissions import (
     scoped_group_ids_subquery,
     within_managed_scope_clause,
 )
+from onyx.db.user_group import assert_not_shared_with_default_group
 from onyx.db.utils import is_fk_violation
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -585,6 +586,7 @@ def replace_skill_shares(
         _flush_shares(db_session, "One or more user share targets do not exist.")
 
     if group_shares is not None:
+        assert_not_shared_with_default_group(db_session, list(group_shares))
         db_session.execute(
             delete(Skill__UserGroup).where(Skill__UserGroup.skill_id == skill.id)
         )

--- a/backend/onyx/db/user_group.py
+++ b/backend/onyx/db/user_group.py
@@ -24,8 +24,25 @@ def assert_group_config_is_editable(
     """Membership is the only thing a default group has, so every other write is refused.
     ``action`` completes "Cannot {action} a default system group.". A missing group falls
     through to the caller's own NOT_FOUND."""
-    group = db_session.scalar(select(UserGroup).where(UserGroup.id == user_group_id))
-    if group is not None and group.is_default:
+    assert_groups_config_are_editable(db_session, [user_group_id], action)
+
+
+def assert_groups_config_are_editable(
+    db_session: Session, user_group_ids: Collection[int], action: str
+) -> None:
+    """Batch form for a caller holding several ids — one query rather than one per id."""
+    if not user_group_ids:
+        return
+
+    is_default_present = db_session.scalar(
+        select(UserGroup.id)
+        .where(
+            UserGroup.id.in_(user_group_ids),
+            UserGroup.is_default.is_(True),
+        )
+        .limit(1)
+    )
+    if is_default_present is not None:
         raise OnyxError(
             OnyxErrorCode.CONFLICT, f"Cannot {action} a default system group."
         )

--- a/backend/onyx/db/user_group.py
+++ b/backend/onyx/db/user_group.py
@@ -1,0 +1,55 @@
+"""Invariants for the seeded default groups (Admin/Basic).
+
+A default group holds members and nothing else: no connectors, document sets, agents,
+skills, providers or limits, and its name and permission grant are fixed at seed time.
+
+Lives in Community Edition even though group management is Enterprise: the groups are
+seeded by a core migration and the resource-sharing paths that must refuse them are core
+code. ``ee/onyx/db/user_group.py`` holds the management operations.
+"""
+
+from collections.abc import Collection
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.db.models import UserGroup
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+
+
+def assert_group_config_is_editable(
+    db_session: Session, user_group_id: int, action: str
+) -> None:
+    """Membership is the only thing a default group has, so every other write is refused.
+    ``action`` completes "Cannot {action} a default system group.". A missing group falls
+    through to the caller's own NOT_FOUND."""
+    group = db_session.scalar(select(UserGroup).where(UserGroup.id == user_group_id))
+    if group is not None and group.is_default:
+        raise OnyxError(
+            OnyxErrorCode.CONFLICT, f"Cannot {action} a default system group."
+        )
+
+
+def assert_not_shared_with_default_group(
+    db_session: Session, group_ids: Collection[int]
+) -> None:
+    """Keep a default group empty of everything but members, from any resource's own side.
+    Basic holds the whole org and Admin every admin, so sharing with one is really "make
+    this public", which every resource already expresses with its own public flag."""
+    if not group_ids:
+        return
+
+    default_names = db_session.scalars(
+        select(UserGroup.name).where(
+            UserGroup.id.in_(group_ids),
+            UserGroup.is_default.is_(True),
+        )
+    ).all()
+    if default_names:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Cannot share with the default system group(s): "
+            + ", ".join(sorted(default_names))
+            + ". Make the resource public instead.",
+        )

--- a/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
+++ b/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
@@ -1254,8 +1254,10 @@ def test_user_group_projection_matches_gates(db_session: Session) -> None:
             is_full_admin=has_global_permission(
                 actor, Permission.FULL_ADMIN_PANEL_ACCESS
             ),
+            is_default=False,
         )
         assert tags["manage"] == manage_enforced, actor.email
+        assert tags["manage_members"] == manage_enforced, actor.email
         assert tags["delete"] == _route_admits(delete_user_group, "_", actor), (
             actor.email
         )
@@ -1277,8 +1279,10 @@ def test_user_group_projection_matches_gates(db_session: Session) -> None:
         is_full_admin=has_global_permission(
             in_scope, Permission.FULL_ADMIN_PANEL_ACCESS
         ),
+        is_default=False,
     ) == {
         "manage": True,
+        "manage_members": True,
         "delete": False,
         "edit_permissions": False,
         # scoped manager now fully manages its group's token limits
@@ -1295,18 +1299,64 @@ def test_user_group_projection_matches_gates(db_session: Session) -> None:
         is_full_admin=has_global_permission(
             groups_admin, Permission.FULL_ADMIN_PANEL_ACCESS
         ),
+        is_default=False,
     ) == {
         "manage": True,
+        "manage_members": True,
         "delete": True,
         "edit_permissions": False,
         "edit_token_limits": True,
     }
 
 
+def test_default_user_group_projection_is_membership_only(db_session: Session) -> None:
+    """A seeded default group keeps exactly one affordance — manage_members, and only for
+    a full admin. Everything else is denied, matching the CONFLICT the routes raise."""
+    default_group = UserGroup(name=f"proj-default-{uuid4().hex[:12]}", is_default=True)
+    db_session.add(default_group)
+    db_session.flush()
+
+    groups_admin = create_test_user(db_session, "proj-ug-default-groupsadmin")
+    groups_admin.effective_permissions = [Permission.MANAGE_USER_GROUPS.value]
+    admin = create_test_user(db_session, "proj-ug-default-admin", is_admin=True)
+    db_session.commit()
+
+    def _tags(actor: User) -> dict[str, bool]:
+        return user_group_permissions(
+            can_manage=manages_group(actor, db_session, group_id=default_group.id),
+            is_user_groups_admin=has_global_permission(
+                actor, Permission.MANAGE_USER_GROUPS
+            ),
+            is_full_admin=has_global_permission(
+                actor, Permission.FULL_ADMIN_PANEL_ACCESS
+            ),
+            is_default=True,
+        )
+
+    assert _tags(admin) == {
+        "manage": False,
+        "manage_members": True,
+        "delete": False,
+        "edit_permissions": False,
+        "edit_token_limits": False,
+    }
+    # global MANAGE_USER_GROUPS is not enough — default groups are full-admin only
+    assert _tags(groups_admin) == {
+        "manage": False,
+        "manage_members": False,
+        "delete": False,
+        "edit_permissions": False,
+        "edit_token_limits": False,
+    }
+
+
 def test_user_group_key_coverage() -> None:
     assert set(
         user_group_permissions(
-            can_manage=True, is_user_groups_admin=True, is_full_admin=True
+            can_manage=True,
+            is_user_groups_admin=True,
+            is_full_admin=True,
+            is_default=False,
         )
     ) == set(USER_GROUP_ACTIONS)
 

--- a/backend/tests/integration/tests/permissions_membership/test_manage_user_groups.py
+++ b/backend/tests/integration/tests/permissions_membership/test_manage_user_groups.py
@@ -322,3 +322,44 @@ def test_holder_can_still_add_users_to_an_ordinary_group(
     )
     assert resp.status_code == 200, resp.text
     assert holder_user.id in {user["id"] for user in resp.json()["users"]}
+
+
+def test_holder_cannot_touch_the_basic_group(
+    permission_admin_user: DATestUser,
+    holder_user: DATestUser,
+) -> None:
+    """Basic grants only BASIC_ACCESS, so the amplification check above can't be what
+    stops the holder — the default-group gate is. The affordance map agrees, which is
+    what keeps the groups page from listing Admin/Basic for them."""
+    basic = UserGroupManager.get_default(
+        user_performing_action=permission_admin_user, name="Basic"
+    )
+
+    listed = next(
+        group
+        for group in UserGroupManager.get_all(holder_user, include_default=True)
+        if group.id == basic.id
+    )
+    assert not any(listed.permissions.values()), listed.permissions
+
+    patched = call_endpoint(
+        "PATCH",
+        f"/manage/admin/user-group/{basic.id}",
+        {
+            "user_ids": [user.id for user in basic.users],
+            "cc_pair_ids": [cc_pair.id for cc_pair in basic.cc_pairs],
+        },
+        holder_user.headers,
+        holder_user.cookies,
+    )
+    assert patched.status_code == 403, patched.text
+
+    # holder is already in Basic, so this is add-users' no-op path: still gated, not 200
+    added = call_endpoint(
+        "POST",
+        f"/manage/admin/user-group/{basic.id}/add-users",
+        {"user_ids": [holder_user.id]},
+        holder_user.headers,
+        holder_user.cookies,
+    )
+    assert added.status_code == 403, added.text

--- a/backend/tests/integration/tests/usergroup/test_default_group_read_only.py
+++ b/backend/tests/integration/tests/usergroup/test_default_group_read_only.py
@@ -1,0 +1,220 @@
+"""The seeded default groups (Admin/Basic) are visible, hold members and nothing else,
+and only a full admin may change that membership.
+
+The list endpoint still returns them to any READ_USER_GROUPS holder that asks — the
+service-account picker relies on that — so "full admins only" rides on the ``permissions``
+map the client filters on, plus the route guards asserted below.
+"""
+
+import os
+from uuid import uuid4
+
+import pytest
+
+from onyx.configs.constants import DocumentSource
+from onyx.db.enums import Permission
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.managers.user_group import UserGroupManager
+from tests.integration.common_utils.test_models import DATestUser
+
+ENTERPRISE_SKIP = pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="User group tests are enterprise only",
+)
+
+GROUP_URL = f"{API_SERVER_URL}/manage/admin/user-group"
+TOKEN_LIMIT_URL = f"{API_SERVER_URL}/admin/token-rate-limits"
+
+
+@ENTERPRISE_SKIP
+def test_default_groups_are_listed_only_when_requested(admin_user: DATestUser) -> None:
+    without_default = UserGroupManager.get_all(user_performing_action=admin_user)
+    assert not [group for group in without_default if group.is_default]
+
+    with_default = UserGroupManager.get_all(
+        user_performing_action=admin_user, include_default=True
+    )
+    default_names = {group.name for group in with_default if group.is_default}
+    assert {"Admin", "Basic"} <= default_names, default_names
+
+
+@ENTERPRISE_SKIP
+def test_default_group_affordances_are_membership_only(admin_user: DATestUser) -> None:
+    """Whole-map equality: a new action defaulting to True must fail here rather than
+    quietly render a control the routes reject."""
+    for name in ("Admin", "Basic"):
+        group = UserGroupManager.get_default(
+            user_performing_action=admin_user, name=name
+        )
+        assert group.permissions == {
+            "manage": False,
+            "manage_members": True,
+            "delete": False,
+            "edit_permissions": False,
+            "edit_token_limits": False,
+        }, name
+
+
+@ENTERPRISE_SKIP
+def test_default_group_rejects_every_non_membership_write(
+    admin_user: DATestUser,
+) -> None:
+    group = UserGroupManager.get_default(
+        user_performing_action=admin_user, name="Basic"
+    )
+    headers = admin_user.headers
+
+    writes = {
+        "rename": client.patch(
+            f"{GROUP_URL}/rename",
+            json={"id": group.id, "name": "Renamed"},
+            headers=headers,
+        ),
+        "permissions": client.put(
+            f"{GROUP_URL}/{group.id}/permissions",
+            json={"permissions": [Permission.MANAGE_LLMS.value]},
+            headers=headers,
+        ),
+        "incognito": client.patch(
+            f"{GROUP_URL}/{group.id}/incognito",
+            json={"enabled": True},
+            headers=headers,
+        ),
+        "agents": client.patch(
+            f"{GROUP_URL}/{group.id}/agents",
+            json={"added_agent_ids": [], "removed_agent_ids": []},
+            headers=headers,
+        ),
+        "document_sets": client.patch(
+            f"{GROUP_URL}/{group.id}/document-sets",
+            json={"added_document_set_ids": [], "removed_document_set_ids": []},
+            headers=headers,
+        ),
+        "manager": client.put(
+            f"{GROUP_URL}/{group.id}/manager",
+            json={"user_id": admin_user.id, "is_manager": True},
+            headers=headers,
+        ),
+        # a default group holds no connectors, so any id here is refused
+        "connectors": client.patch(
+            f"{GROUP_URL}/{group.id}",
+            json={
+                "user_ids": [user.id for user in group.users],
+                "cc_pair_ids": [999999],
+            },
+            headers=headers,
+        ),
+        "delete": client.delete(f"{GROUP_URL}/{group.id}", headers=headers),
+        # token limits live on their own router, so they need their own guard
+        "token_limit_create": client.post(
+            f"{TOKEN_LIMIT_URL}/user-group/{group.id}",
+            json={"enabled": True, "token_budget": 1000, "period_hours": 24},
+            headers=headers,
+        ),
+        "token_limit_update": client.put(
+            f"{TOKEN_LIMIT_URL}/user-group/{group.id}/rate-limit/999999",
+            json={"enabled": False, "token_budget": 1, "period_hours": 24},
+            headers=headers,
+        ),
+        "token_limit_delete": client.delete(
+            f"{TOKEN_LIMIT_URL}/user-group/{group.id}/rate-limit/999999",
+            headers=headers,
+        ),
+    }
+    for action, response in writes.items():
+        assert response.status_code == 409, f"{action}: {response.text}"
+
+    unchanged = UserGroupManager.get_default(
+        user_performing_action=admin_user, name="Basic"
+    )
+    assert unchanged.name == "Basic"
+    assert unchanged.manager_ids == []
+    assert unchanged.incognito_enabled is False
+
+
+@ENTERPRISE_SKIP
+def test_admin_can_add_and_remove_default_group_members(
+    admin_user: DATestUser,
+) -> None:
+    """Signup already puts every user in Basic, so Admin is the group that exercises both
+    directions, and its grant makes the effect observable on the member."""
+    member = UserManager.create(name=f"default-group-member-{uuid4().hex[:8]}")
+    group = UserGroupManager.get_default(
+        user_performing_action=admin_user, name="Admin"
+    )
+
+    added = client.post(
+        f"{GROUP_URL}/{group.id}/add-users",
+        json={"user_ids": [member.id]},
+        headers=admin_user.headers,
+    )
+    assert added.status_code == 200, added.text
+    assert Permission.FULL_ADMIN_PANEL_ACCESS.value in UserManager.get_permissions(
+        member
+    )
+
+    group = UserGroupManager.get_default(
+        user_performing_action=admin_user, name="Admin"
+    )
+    assert member.id in {user.id for user in group.users}
+
+    removed = client.patch(
+        f"{GROUP_URL}/{group.id}",
+        json={
+            "user_ids": [user.id for user in group.users if user.id != member.id],
+            "cc_pair_ids": [cc_pair.id for cc_pair in group.cc_pairs],
+        },
+        headers=admin_user.headers,
+    )
+    assert removed.status_code == 200, removed.text
+
+    group = UserGroupManager.get_default(
+        user_performing_action=admin_user, name="Admin"
+    )
+    assert member.id not in {user.id for user in group.users}
+    assert Permission.FULL_ADMIN_PANEL_ACCESS.value not in UserManager.get_permissions(
+        member
+    )
+
+
+@ENTERPRISE_SKIP
+def test_resources_cannot_be_shared_with_a_default_group(
+    admin_user: DATestUser,
+) -> None:
+    """Every resource can pick its own share targets, so the group page isn't the only way
+    something could land on a default group. Credentials and document sets stand in for the
+    shared guard that connectors, agents, LLM providers, MCP servers and skills all use."""
+    basic = UserGroupManager.get_default(
+        user_performing_action=admin_user, name="Basic"
+    )
+
+    credential = client.post(
+        f"{API_SERVER_URL}/manage/credential",
+        json={
+            "credential_json": {"token": "x"},
+            "admin_public": False,
+            "source": DocumentSource.FILE.value,
+            "name": f"default-group-cred-{uuid4().hex[:8]}",
+            "groups": [basic.id],
+        },
+        headers=admin_user.headers,
+    )
+    assert credential.status_code == 400, credential.text
+    assert "Basic" in credential.text
+
+    document_set = client.post(
+        f"{API_SERVER_URL}/manage/admin/document-set",
+        json={
+            "name": f"default-group-docset-{uuid4().hex[:8]}",
+            "description": "",
+            "cc_pair_ids": [],
+            "is_public": False,
+            "users": [],
+            "groups": [basic.id],
+        },
+        headers=admin_user.headers,
+    )
+    assert document_set.status_code == 400, document_set.text
+    assert "Basic" in document_set.text

--- a/backend/tests/integration/tests/usergroup/test_default_group_read_only.py
+++ b/backend/tests/integration/tests/usergroup/test_default_group_read_only.py
@@ -15,6 +15,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.db.enums import Permission
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.managers.user_group import UserGroupManager
 from tests.integration.common_utils.test_models import DATestUser
@@ -204,12 +205,15 @@ def test_resources_cannot_be_shared_with_a_default_group(
     assert credential.status_code == 400, credential.text
     assert "Basic" in credential.text
 
+    # a real connector, or the route rejects the set for being empty before it ever
+    # reaches the share guard
+    cc_pair = CCPairManager.create_from_scratch(user_performing_action=admin_user)
     document_set = client.post(
         f"{API_SERVER_URL}/manage/admin/document-set",
         json={
             "name": f"default-group-docset-{uuid4().hex[:8]}",
             "description": "",
-            "cc_pair_ids": [],
+            "cc_pair_ids": [cc_pair.id],
             "is_public": False,
             "users": [],
             "groups": [basic.id],

--- a/backend/tests/unit/ee/onyx/db/test_user_group_audit.py
+++ b/backend/tests/unit/ee/onyx/db/test_user_group_audit.py
@@ -29,6 +29,7 @@ def _make_db_session(
     existing_user_ids: list[Any], existing_cc_pair_ids: list[int]
 ) -> MagicMock:
     group = MagicMock()
+    group.is_default = False
     group.users = [MagicMock(id=uid) for uid in existing_user_ids]
     group.cc_pairs = [MagicMock(id=cid) for cid in existing_cc_pair_ids]
     db_session = MagicMock()

--- a/web/src/hooks/useGroups.ts
+++ b/web/src/hooks/useGroups.ts
@@ -5,7 +5,6 @@ import { errorHandlingFetcher } from "@/lib/fetcher";
 import { UserGroup } from "@/lib/types";
 import { useSettings } from "@/lib/settings/hooks";
 import { SWR_KEYS } from "@/lib/swr-keys";
-import { buildApiPath } from "@/lib/urlBuilder";
 
 /**
  * Fetches all user groups in the organization.
@@ -45,7 +44,7 @@ export default function useGroups(includeDefault = false) {
     !settings.isLoading && settings.enterprise !== null;
 
   const url = includeDefault
-    ? buildApiPath(SWR_KEYS.adminUserGroups, { include_default: true })
+    ? SWR_KEYS.adminUserGroupsWithDefault
     : SWR_KEYS.adminUserGroups;
 
   const { data, error, isLoading } = useSWR<UserGroup[]>(

--- a/web/src/lib/permissions/resource-actions.ts
+++ b/web/src/lib/permissions/resource-actions.ts
@@ -28,7 +28,13 @@ export const RESOURCE_ACTIONS = {
   Action: ["edit", "delete", "toggle", "authenticate"],
   MCPServer: ["edit", "delete", "authenticate", "manage_status"],
   CustomSkill: ["edit", "manage_access", "delete", "publish"],
-  UserGroup: ["manage", "delete", "edit_permissions", "edit_token_limits"],
+  UserGroup: [
+    "manage",
+    "manage_members",
+    "delete",
+    "edit_permissions",
+    "edit_token_limits",
+  ],
 } as const;
 
 export type ResourceName = keyof typeof RESOURCE_ACTIONS;

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -128,6 +128,8 @@ export const SWR_KEYS = {
 
   // ── Groups ────────────────────────────────────────────────────────────────
   adminUserGroups: "/api/manage/admin/user-group",
+  adminUserGroupsWithDefault:
+    "/api/manage/admin/user-group?include_default=true",
   shareableGroups: "/api/manage/user-groups/minimal",
   userGroupPermissions: (groupId: number) =>
     `/api/manage/admin/user-group/${groupId}/permissions`,

--- a/web/src/views/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/EditGroupPage.tsx
@@ -47,6 +47,7 @@ import {
   saveTokenLimits,
   saveGroupPermissions,
   setGroupManager,
+  refreshGroupLists,
 } from "./svc";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import SharedGroupResources from "@/views/admin/GroupsPage/SharedGroupResources";
@@ -266,7 +267,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
       setPendingManagerIds((prev) => new Set(prev).add(userId));
       try {
         await setGroupManager(groupId, userId, makeManager);
-        await mutate(SWR_KEYS.adminUserGroupsWithDefault);
+        await refreshGroupLists(mutate);
         toast.success(makeManager ? "Manager assigned" : "Manager revoked");
       } catch (err) {
         console.error("Failed to update manager:", err);
@@ -452,7 +453,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
       initialAgentIdsRef.current = selectedAgentIds;
       initialDocSetIdsRef.current = selectedDocSetIds;
 
-      mutate(SWR_KEYS.adminUserGroupsWithDefault);
+      refreshGroupLists(mutate);
       mutate(SWR_KEYS.userGroupTokenRateLimit(groupId));
       if (canEditPermissions) {
         mutate(SWR_KEYS.userGroupPermissions(groupId));
@@ -473,7 +474,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     setIsDeleting(true);
     try {
       await deleteGroup(groupId);
-      mutate(SWR_KEYS.adminUserGroupsWithDefault);
+      refreshGroupLists(mutate);
       toast.success(`Group "${group?.name}" deleted`);
       router.push("/admin/groups");
     } catch (e) {

--- a/web/src/views/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/EditGroupPage.tsx
@@ -4,7 +4,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import useSWR, { useSWRConfig } from "swr";
 import useGroupMemberCandidates from "./useGroupMemberCandidates";
-import { Button, Card, Divider, Switch, Table } from "@opal/components";
+import {
+  Button,
+  Card,
+  Divider,
+  MessageCard,
+  Switch,
+  Table,
+} from "@opal/components";
 import { IllustrationContent, InputHorizontal, toast } from "@opal/layouts";
 import {
   SvgUsers,
@@ -76,12 +83,16 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     data: groups,
     isLoading: groupLoading,
     error: groupError,
-  } = useSWR<UserGroup[]>(SWR_KEYS.adminUserGroups, errorHandlingFetcher, {
-    refreshInterval: (latestData) => {
-      const g = latestData?.find((g) => g.id === groupId);
-      return g && !g.is_up_to_date ? 5000 : 0;
-    },
-  });
+  } = useSWR<UserGroup[]>(
+    SWR_KEYS.adminUserGroupsWithDefault,
+    errorHandlingFetcher,
+    {
+      refreshInterval: (latestData) => {
+        const g = latestData?.find((g) => g.id === groupId);
+        return g && !g.is_up_to_date ? 5000 : 0;
+      },
+    }
+  );
 
   const group = useMemo(
     () => groups?.find((g) => g.id === groupId) ?? null,
@@ -89,9 +100,11 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
   );
 
   const canManage = can(group, "manage");
+  const canManageMembers = can(group, "manage_members");
   const canDelete = can(group, "delete");
   const canEditPermissions = can(group, "edit_permissions");
   const canEditTokenLimits = can(group, "edit_token_limits");
+  const isDefaultGroup = group?.is_default ?? false;
 
   const isSyncing = group != null && !group.is_up_to_date;
 
@@ -253,7 +266,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
       setPendingManagerIds((prev) => new Set(prev).add(userId));
       try {
         await setGroupManager(groupId, userId, makeManager);
-        await mutate(SWR_KEYS.adminUserGroups);
+        await mutate(SWR_KEYS.adminUserGroupsWithDefault);
         toast.success(makeManager ? "Manager assigned" : "Manager revoked");
       } catch (err) {
         console.error("Failed to update manager:", err);
@@ -278,7 +291,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
         showSorting: false,
         showColumnVisibility: false,
         cell: (row: MemberRow) => {
-          if (!canManage) return null;
+          if (!canManageMembers) return null;
           const userId = row.id ?? row.email;
           const isManager = managerIds.has(userId);
           const isPersisted = persistedMemberIds.has(userId);
@@ -286,26 +299,28 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
           const isOwnManager = isOwnManagerRow(userId);
           return (
             <div className="flex items-center gap-1">
-              <IconButton
-                icon={isPending ? SvgSimpleLoader : SvgShield}
-                tertiary
-                transient={isManager}
-                disabled={!isPersisted || isPending || isOwnManager}
-                aria-label={isManager ? "Revoke manager" : "Make manager"}
-                tooltip={
-                  !isPersisted
-                    ? "Save the group before assigning a manager"
-                    : isOwnManager
-                      ? "You can't revoke your own manager access"
-                      : isManager
-                        ? "Revoke manager"
-                        : "Make manager"
-                }
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleToggleManager(userId, !isManager);
-                }}
-              />
+              {canManage && (
+                <IconButton
+                  icon={isPending ? SvgSimpleLoader : SvgShield}
+                  tertiary
+                  transient={isManager}
+                  disabled={!isPersisted || isPending || isOwnManager}
+                  aria-label={isManager ? "Revoke manager" : "Make manager"}
+                  tooltip={
+                    !isPersisted
+                      ? "Save the group before assigning a manager"
+                      : isOwnManager
+                        ? "You can't revoke your own manager access"
+                        : isManager
+                          ? "Revoke manager"
+                          : "Make manager"
+                  }
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleToggleManager(userId, !isManager);
+                  }}
+                />
+              )}
               <IconButton
                 icon={SvgMinusCircle}
                 tertiary
@@ -334,6 +349,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
       persistedMemberIds,
       pendingManagerIds,
       canManage,
+      canManageMembers,
     ]
   );
 
@@ -377,8 +393,8 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     }
 
     // Re-fetch group to check sync status before saving
-    const freshGroups = await fetch(SWR_KEYS.adminUserGroups).then((r) =>
-      r.json()
+    const freshGroups = await fetch(SWR_KEYS.adminUserGroupsWithDefault).then(
+      (r) => r.json()
     );
     const freshGroup = freshGroups.find((g: UserGroup) => g.id === groupId);
     if (freshGroup && !freshGroup.is_up_to_date) {
@@ -392,26 +408,28 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     setIsSubmitting(true);
     try {
       // Rename if name changed
-      if (group && trimmed !== group.name) {
+      if (canManage && group && trimmed !== group.name) {
         await renameGroup(group.id, trimmed);
       }
 
       // Update members and cc_pairs
       await updateGroup(groupId, selectedUserIds, selectedCcPairIds);
 
-      // Update agent sharing (add/remove this group from changed agents)
-      await updateAgentGroupSharing(
-        groupId,
-        initialAgentIdsRef.current,
-        selectedAgentIds
-      );
+      if (canManage) {
+        // Update agent sharing (add/remove this group from changed agents)
+        await updateAgentGroupSharing(
+          groupId,
+          initialAgentIdsRef.current,
+          selectedAgentIds
+        );
 
-      // Update document set sharing (add/remove this group from changed doc sets)
-      await updateDocSetGroupSharing(
-        groupId,
-        initialDocSetIdsRef.current,
-        selectedDocSetIds
-      );
+        // Update document set sharing (add/remove this group from changed doc sets)
+        await updateDocSetGroupSharing(
+          groupId,
+          initialDocSetIdsRef.current,
+          selectedDocSetIds
+        );
+      }
 
       // Group-scoped create/update/delete routes admit a group admin, so their full save
       // (including PUT/DELETE of existing limits) is authorized.
@@ -426,7 +444,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
 
       // Last: granting incognito access must not outlive a save that then
       // fails, which would report an error while members already had it.
-      if (group && incognitoEnabled !== group.incognito_enabled) {
+      if (canManage && group && incognitoEnabled !== group.incognito_enabled) {
         await setGroupIncognito(groupId, incognitoEnabled);
       }
 
@@ -434,7 +452,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
       initialAgentIdsRef.current = selectedAgentIds;
       initialDocSetIdsRef.current = selectedDocSetIds;
 
-      mutate(SWR_KEYS.adminUserGroups);
+      mutate(SWR_KEYS.adminUserGroupsWithDefault);
       mutate(SWR_KEYS.userGroupTokenRateLimit(groupId));
       if (canEditPermissions) {
         mutate(SWR_KEYS.userGroupPermissions(groupId));
@@ -455,7 +473,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     setIsDeleting(true);
     try {
       await deleteGroup(groupId);
-      mutate(SWR_KEYS.adminUserGroups);
+      mutate(SWR_KEYS.adminUserGroupsWithDefault);
       toast.success(`Group "${group?.name}" deleted`);
       router.push("/admin/groups");
     } catch (e) {
@@ -466,8 +484,9 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     }
   }
 
-  // 404 state
-  if (!isLoading && !error && !group) {
+  // 404 state: a group the caller can't act on reads as absent, so a deep link to a
+  // default group as a non-full-admin lands here — matching the list, which hides it.
+  if (!isLoading && !error && !canManageMembers) {
     return (
       <SettingsLayouts.Root>
         <SettingsLayouts.Header
@@ -496,7 +515,9 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
       </Button>
       <Button
         onClick={handleSave}
-        disabled={!groupName.trim() || isSubmitting || isSyncing || !canManage}
+        disabled={
+          !groupName.trim() || isSubmitting || isSyncing || !canManageMembers
+        }
         tooltip={
           isSyncing
             ? "Document embeddings are being updated due to recent changes to this group."
@@ -529,6 +550,14 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
 
           {!isLoading && !error && group && (
             <>
+              {isDefaultGroup && (
+                <MessageCard
+                  variant="info"
+                  title="System group"
+                  description="Onyx manages this group. Members are the only thing it holds, and the only thing you can change."
+                />
+              )}
+
               {/* Group Name */}
               <Section
                 gap={2}
@@ -542,6 +571,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                 <InputTypeIn
                   placeholder="Name your group"
                   value={groupName}
+                  variant={canManage ? "primary" : "readOnly"}
                   onChange={(e) => setGroupName(e.target.value)}
                 />
               </Section>
@@ -580,7 +610,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                       Done
                     </Button>
                   ) : (
-                    canManage && (
+                    canManageMembers && (
                       <Button
                         prominence="tertiary"
                         icon={SvgPlusCircle}
@@ -638,24 +668,29 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                 />
               )}
 
-              <SharedGroupResources
-                selectedCcPairIds={selectedCcPairIds}
-                onCcPairIdsChange={setSelectedCcPairIds}
-                selectedDocSetIds={selectedDocSetIds}
-                onDocSetIdsChange={setSelectedDocSetIds}
-                selectedAgentIds={selectedAgentIds}
-                onAgentIdsChange={setSelectedAgentIds}
-                attachedAgents={group?.personas}
-              />
+              {/* a default group has no sharing, limits or incognito to show */}
+              {canManage && (
+                <>
+                  <SharedGroupResources
+                    selectedCcPairIds={selectedCcPairIds}
+                    onCcPairIdsChange={setSelectedCcPairIds}
+                    selectedDocSetIds={selectedDocSetIds}
+                    onDocSetIdsChange={setSelectedDocSetIds}
+                    selectedAgentIds={selectedAgentIds}
+                    onAgentIdsChange={setSelectedAgentIds}
+                    attachedAgents={group?.personas}
+                  />
 
-              <TokenLimitSection
-                limits={tokenLimits}
-                onLimitsChange={setTokenLimits}
-                disabled={!isEnterpriseTier || !canEditTokenLimits}
-                disabledTooltip={tokenLimitsDisabledTooltip}
-              />
+                  <TokenLimitSection
+                    limits={tokenLimits}
+                    onLimitsChange={setTokenLimits}
+                    disabled={!isEnterpriseTier || !canEditTokenLimits}
+                    disabledTooltip={tokenLimitsDisabledTooltip}
+                  />
+                </>
+              )}
 
-              {showIncognitoField && (
+              {canManage && showIncognitoField && (
                 <Card border="solid" rounding="lg">
                   <Section alignItems="start" height="fit">
                     <InputHorizontal

--- a/web/src/views/admin/GroupsPage/GroupCard.tsx
+++ b/web/src/views/admin/GroupsPage/GroupCard.tsx
@@ -27,14 +27,15 @@ function GroupCard({ group }: GroupCardProps) {
   const { mutate } = useSWRConfig();
   const builtIn = isBuiltInGroup(group);
   const isAdmin = group.name === "Admin";
-  const isBasic = group.name === "Basic";
   const isSyncing = !group.is_up_to_date;
+  // a default group has only members, so no `manage` — `manage_members` still opens it
   const canManage = can(group, "manage");
+  const canManageMembers = can(group, "manage_members");
 
   async function handleRename(newName: string) {
     try {
       await renameGroup(group.id, newName);
-      mutate(SWR_KEYS.adminUserGroups);
+      mutate(SWR_KEYS.adminUserGroupsWithDefault);
       toast.success(`Group renamed to "${newName}"`);
     } catch (e) {
       console.error("Failed to rename group:", e);
@@ -51,11 +52,9 @@ function GroupCard({ group }: GroupCardProps) {
           description={buildGroupDescription(group)}
           sizePreset="main-content"
           variant="section"
-          tag={isBasic ? { title: "Default" } : undefined}
-          editable={!builtIn && !isSyncing && canManage}
-          onTitleChange={
-            !builtIn && !isSyncing && canManage ? handleRename : undefined
-          }
+          tag={builtIn ? { title: "Default" } : undefined}
+          editable={!isSyncing && canManage}
+          onTitleChange={!isSyncing && canManage ? handleRename : undefined}
           rightChildren={
             <Section flexDirection="row" alignItems="start" gap={0}>
               <div className="py-1">
@@ -65,7 +64,7 @@ function GroupCard({ group }: GroupCardProps) {
                   )}
                 </Text>
               </div>
-              {canManage && (
+              {canManageMembers && (
                 <Button
                   icon={SvgChevronRight}
                   prominence="tertiary"

--- a/web/src/views/admin/GroupsPage/GroupCard.tsx
+++ b/web/src/views/admin/GroupsPage/GroupCard.tsx
@@ -13,7 +13,7 @@ import {
   buildGroupDescription,
   formatMemberCount,
 } from "./utils";
-import { renameGroup } from "./svc";
+import { refreshGroupLists, renameGroup } from "./svc";
 import { useSWRConfig } from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { can } from "@/lib/permissions/resource-actions";
@@ -35,7 +35,7 @@ function GroupCard({ group }: GroupCardProps) {
   async function handleRename(newName: string) {
     try {
       await renameGroup(group.id, newName);
-      mutate(SWR_KEYS.adminUserGroupsWithDefault);
+      await refreshGroupLists(mutate);
       toast.success(`Group renamed to "${newName}"`);
     } catch (e) {
       console.error("Failed to rename group:", e);

--- a/web/src/views/admin/GroupsPage/index.tsx
+++ b/web/src/views/admin/GroupsPage/index.tsx
@@ -35,12 +35,17 @@ function GroupsPage() {
     data: groups,
     error,
     isLoading,
-  } = useSWR<UserGroup[]>(SWR_KEYS.adminUserGroups, errorHandlingFetcher);
+  } = useSWR<UserGroup[]>(
+    SWR_KEYS.adminUserGroupsWithDefault,
+    errorHandlingFetcher
+  );
 
   // The list is READ_USER_GROUPS-scoped (implied by MANAGE_LLMS etc.), so filter to
   // manageable groups — else a read-only holder sees groups with no open action.
+  // `manage_members` is the broadest action, and the only one a default group keeps —
+  // so this also hides Admin/Basic from non-full-admins.
   const manageableGroups = useMemo(
-    () => (groups ?? []).filter((group) => can(group, "manage")),
+    () => (groups ?? []).filter((group) => can(group, "manage_members")),
     [groups]
   );
 

--- a/web/src/views/admin/GroupsPage/svc.ts
+++ b/web/src/views/admin/GroupsPage/svc.ts
@@ -1,8 +1,21 @@
 /** API helpers for the Groups pages. */
 
+import type { ScopedMutator } from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 
 const USER_GROUP_URL = SWR_KEYS.adminUserGroups;
+
+/**
+ * Refresh both group-list caches. These pages read the include_default key, but the users
+ * and connector pages read the plain one, so a rename, membership edit or delete has to
+ * reach both or they keep serving a stale name or a group that no longer exists.
+ */
+async function refreshGroupLists(mutate: ScopedMutator): Promise<void> {
+  await Promise.all([
+    mutate(SWR_KEYS.adminUserGroups),
+    mutate(SWR_KEYS.adminUserGroupsWithDefault),
+  ]);
+}
 
 // Logs an unparseable body — without it a proxy's HTML 502 is indistinguishable from a
 // clean API error at the call site.
@@ -303,6 +316,7 @@ async function setGroupManager(
 }
 
 export {
+  refreshGroupLists,
   renameGroup,
   createGroup,
   updateGroup,

--- a/web/tests/e2e/admin/groups/GroupsAdminPage.ts
+++ b/web/tests/e2e/admin/groups/GroupsAdminPage.ts
@@ -160,6 +160,21 @@ export class GroupsAdminPage {
     return this.page.getByRole("button", { name: "Delete Group" });
   }
 
+  /** The banner shown on a default (Admin/Basic) group. */
+  get systemGroupNotice(): Locator {
+    return this.page.getByText("System group", { exact: true });
+  }
+
+  /** Header of the group-permissions section (full admin, custom groups only). */
+  get permissionsSectionHeader(): Locator {
+    return this.page.getByText("Group Permissions", { exact: true });
+  }
+
+  /** Header of the shared-resources section (custom groups only). */
+  get sharedResourcesSectionHeader(): Locator {
+    return this.page.getByText("Shared with This Group", { exact: true });
+  }
+
   /** Enter add-members mode on the edit page. */
   async startAddingMembers() {
     await this.addMembersButton.click();

--- a/web/tests/e2e/admin/groups/groups.spec.ts
+++ b/web/tests/e2e/admin/groups/groups.spec.ts
@@ -48,7 +48,6 @@ async function withApiContext(
 // ---------------------------------------------------------------------------
 
 test.describe("Groups page — layout", () => {
-  let adminGroupId: number;
   let basicGroupId: number;
   let layoutGroupId: number;
   const layoutGroupName = uniqueGroupName("layout");
@@ -61,11 +60,8 @@ test.describe("Groups page — layout", () => {
       if (!adminGroup || !basicGroup) {
         throw new Error("Default Admin/Basic groups not found");
       }
-      adminGroupId = adminGroup.id;
       basicGroupId = basicGroup.id;
 
-      // Create a custom group so the list is non-empty (default groups are
-      // excluded from the API response by default).
       layoutGroupId = await api.createUserGroup(layoutGroupName);
       await api.waitForGroupSync(layoutGroupId);
     });
@@ -87,12 +83,37 @@ test.describe("Groups page — layout", () => {
     await expect(groupsPage.newGroupButton).toBeVisible();
   });
 
-  test.skip("shows built-in groups (Admin, Basic)", async ({ groupsPage }) => {
-    // TODO: Enable once default groups are shown via include_default=true
+  test("shows built-in groups (Admin, Basic)", async ({ groupsPage }) => {
     await groupsPage.goto();
 
     await groupsPage.expectGroupVisible("Admin");
     await groupsPage.expectGroupVisible("Basic");
+  });
+
+  test("built-in groups open read-only, with membership still editable", async ({
+    groupsPage,
+  }) => {
+    await groupsPage.gotoEdit(basicGroupId);
+
+    await expect(groupsPage.groupNameInput).toHaveValue("Basic");
+    await expect(groupsPage.groupNameInput).toHaveAttribute("readonly", "");
+    await expect(groupsPage.systemGroupNotice).toBeVisible();
+
+    await expect(groupsPage.addMembersButton).toBeVisible();
+    await expect(groupsPage.saveButton).toBeEnabled();
+
+    await expect(groupsPage.deleteGroupButton).toHaveCount(0);
+    await expect(groupsPage.permissionsSectionHeader).toHaveCount(0);
+    await expect(groupsPage.sharedResourcesSectionHeader).toHaveCount(0);
+  });
+
+  test("custom groups keep the full edit surface", async ({ groupsPage }) => {
+    await groupsPage.gotoEdit(layoutGroupId);
+
+    await expect(groupsPage.groupNameInput).not.toHaveAttribute("readonly", "");
+    await expect(groupsPage.systemGroupNotice).toHaveCount(0);
+    await expect(groupsPage.deleteGroupButton).toBeVisible();
+    await expect(groupsPage.sharedResourcesSectionHeader).toBeVisible();
   });
 
   test("search filters groups by name", async ({ groupsPage, api }) => {


### PR DESCRIPTION
## Description

- Admin and Basic now appear on the groups page for full admins; every other role still never sees them.
- A default group is read-only apart from its members, and only a full admin can add or remove those.
- Every group route now refuses what the UI hides — rename, permissions, incognito, agent/document-set sharing, manager assignment, token limits and delete.
- A default group can no longer be picked as a share target from a resource's own side either (connectors, credentials, document sets, agents, skills, LLM providers, MCP servers, agent ownership), which no UI offered but the API allowed.

## How Has This Been Tested?

Added 6 integration tests (affordance map, every rejected write, membership add/remove, cross-resource sharing), extended the permission-projection contract test, and added 3 Playwright specs including the previously-skipped built-in-groups test. Lint, types and the Jest suite pass locally, but the DB-backed and Playwright suites still need a CI run — no live stack was available in this workspace.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the seeded default groups (Admin, Basic) on the groups page for full admins and makes them members-only. Previously hidden and writable via API, default groups now allow only full admins to add/remove members; all other writes are refused and resources cannot share to them.

- UI: Reads `?include_default=true` via `SWR_KEYS.adminUserGroupsWithDefault`, filters by `manage_members` so only full admins see/open Admin/Basic, and shows a “System group” notice on edit. Disables rename, sharing (agents/document sets/connectors), incognito, and token limits; non‑admin deep links render as not found. Adds `refreshGroupLists` to keep both group-list caches in sync.
- Permissions and API: Permission projection adds `manage_members`; on default groups `manage`, `delete`, `edit_permissions`, and `edit_token_limits` are false, while `manage_members` is full‑admin only. Routes now gate default-group writes consistently: rename, delete, permission toggles, incognito, agent/document‑set sharing, manager assignment, CC‑pair attachment, and group token‑limit create/update/delete return 409; only full admins may change membership. A shared CE helper in `onyx/db/user_group.py` rejects sharing any resource with default groups (connectors, credentials, document sets, agents, skills, LLM providers, MCP servers) and blocks default‑group agent ownership; invalid shares return 400.

- Tests: Extend the permission‑projection contract (including `manage_members` and default‑group behavior) and add integration/e2e coverage for visibility, read‑only UI, and write refusals. Fix a unit test by pinning `is_default=False` on a mocked group and update the document‑set share test to use a real connector.

<sup>Written for commit 22dfbc401c23945f5cc6f300f6716cc15c5d854c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



