### PR TITLE
fix(opal): allow SettingsRoot to grow with content and prevent blank overflow scroll

### DIFF
--- a/web/lib/opal/src/layouts/settings/components.tsx
+++ b/web/lib/opal/src/layouts/settings/components.tsx
@@ -21,10 +21,10 @@ const widthClasses: Record<
   Extract<SizeVariants, "sm" | "md" | "lg" | "full">,
   string
 > = {
-  sm: "w-[min(var(--app-container-sm),100%)]",
-  md: "w-[min(var(--app-container-md),100%)]",
-  lg: "w-[min(var(--app-container-lg),100%)]",
-  full: "w-(--app-container-full)",
+  sm: "min-w-0 w-[min(var(--app-container-sm),100%)]",
+  md: "min-w-0 w-[min(var(--app-container-md),100%)]",
+  lg: "min-w-0 w-[min(var(--app-container-lg),100%)]",
+  full: "min-w-0 w-(--app-container-full)",
 };
 
 interface SettingsRootProps extends WithoutStyles<
@@ -44,7 +44,7 @@ function SettingsRoot({ width = "md", ...props }: SettingsRootProps) {
       id="page-wrapper-scroll-container"
       className="w-full h-full flex flex-col items-center overflow-y-auto"
     >
-      <div className={cn("h-full", widthClasses[width])}>
+      <div className={cn("min-h-full", widthClasses[width])}>
         <div {...props} />
       </div>
     </div>


### PR DESCRIPTION
### Summary
Fixes an issue in `SettingsLayouts.Root` where scrolling down on long settings pages (such as Index Settings) causes the container to scroll past the end of actual content into an extra viewport of blank space.

### Root Cause
In `web/lib/opal/src/layouts/settings/components.tsx`, the inner container inside `SettingsRoot` had `h-full` (100% fixed height of the parent scroll viewport). Because its children (`Header` + `Body`) overflow, the browser calculates the total scrollable height as `child height (100vh) + overflow content height`, creating a phantom blank screen below the content.
In addition, `widthClasses` lacked `min-w-0`, preventing flex children from shrinking appropriately.

### Changes
- Changed `h-full` to `min-h-full` in `SettingsRoot` so the container expands naturally with its content.
- Added `min-w-0` to all entries in `widthClasses`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a blank extra scroll viewport on long settings pages by letting `SettingsRoot` grow with its content. Previously the inner container used a fixed 100% height and scrolled past the content; now it uses min-height and ensures flex children can shrink.

**Notes for reviewers**
- Replace `h-full` with `min-h-full` in the `SettingsRoot` inner container so scroll height matches content.
- Add `min-w-0` to all `widthClasses` entries to allow proper shrinking in flex layouts and avoid horizontal overflow.
- Verify long pages (e.g., Index Settings) no longer show blank space at the bottom and that `sm`, `md`, `lg`, and `full` widths render as before.

<sup>Written for commit d405cd4b87850562a8f462af0d7f13f025bb8918. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

