### PR TITLE
fix(web): resolve "Could not resolve provider" in IndexSettings and ChatPreferences

### DIFF
--- a/web/src/lib/languageModels/hooks.ts
+++ b/web/src/lib/languageModels/hooks.ts
@@ -354,8 +354,10 @@ export function useLlmDefaults(): LlmDefaults {
       if (!llmProviders || !raw) return null;
       const provider = llmProviders.find((p) => p.id === raw.provider_id);
       if (!provider) return null;
-      if (!provider.name) return null;
-      return { providerName: provider.name, modelName: raw.model_name };
+      return {
+        providerName: provider.name || provider.provider,
+        modelName: raw.model_name,
+      };
     },
     [llmProviders]
   );

--- a/web/src/views/admin/ChatPreferencesPage.tsx
+++ b/web/src/views/admin/ChatPreferencesPage.tsx
@@ -20,6 +20,7 @@ import InputTextAreaField from "@/refresh-components/form/InputTextAreaField";
 import { InputTextArea, InputTypeIn } from "@opal/components";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import ModelSelector from "@/sections/model-selector/ModelSelector";
+import type { LLMOption } from "@/lib/languageModels/options";
 import { useAdminLLMProviders } from "@/lib/languageModels/hooks";
 import {
   SvgAddLines,
@@ -680,14 +681,12 @@ export default function ChatPreferencesPage() {
   }, [llmProviders, defaultChatNaming]);
 
   const handleChatNamingModelChange = useCallback(
-    async ({
-      modelName,
-      providerName,
-    }: {
-      modelName: string;
-      providerName: string | null;
-    }) => {
-      const provider = llmProviders?.find((p) => p.name === providerName);
+    async (option: LLMOption) => {
+      const provider = llmProviders?.find((p) =>
+        p.model_configurations.some(
+          (mc) => mc.id === option.modelConfigurationId
+        )
+      );
       if (!provider) {
         toast.error("Could not resolve provider");
         return;
@@ -698,7 +697,7 @@ export default function ChatPreferencesPage() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             provider_id: provider.id,
-            model_name: modelName,
+            model_name: option.modelName,
           }),
         });
         if (!response.ok) {
@@ -1039,11 +1038,9 @@ export default function ChatPreferencesPage() {
                   )}
                   <ModelSelector
                     value={chatNamingModelConfigId}
+                    providerOptions={llmProviders}
                     onChange={(opt) =>
-                      void handleChatNamingModelChange({
-                        modelName: opt.modelName,
-                        providerName: opt.name,
-                      })
+                      void handleChatNamingModelChange(opt)
                     }
                   />
                 </div>

--- a/web/src/views/admin/IndexSettingsPage/index.tsx
+++ b/web/src/views/admin/IndexSettingsPage/index.tsx
@@ -87,6 +87,7 @@ import {
 import { useLlmDefaults } from "@/lib/languageModels/hooks";
 import useFilter from "@/hooks/useFilter";
 import ModelSelector from "@/sections/model-selector/ModelSelector";
+import type { LLMOption } from "@/lib/languageModels/options";
 import type { RichStr } from "@opal/types";
 import { ProviderCredentialsModal } from "@/views/admin/IndexSettingsPage/modals";
 import ReindexProgressBanner from "@/views/admin/IndexSettingsPage/ReindexProgressBanner";
@@ -731,14 +732,12 @@ export default function IndexSettingsPage() {
    * embeddings of already-indexed documents.
    */
   const handleCaptioningModelChange = useCallback(
-    async ({
-      modelName,
-      providerName,
-    }: {
-      modelName: string;
-      providerName: string | null;
-    }) => {
-      const provider = llmProviders?.find((p) => p.name === providerName);
+    async (option: LLMOption) => {
+      const provider = llmProviders?.find((p) =>
+        p.model_configurations.some(
+          (mc) => mc.id === option.modelConfigurationId
+        )
+      );
       if (!provider) {
         toast.error("Could not resolve provider");
         return;
@@ -749,7 +748,7 @@ export default function IndexSettingsPage() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             provider_id: provider.id,
-            model_name: modelName,
+            model_name: option.modelName,
           }),
         });
         if (!response.ok) {
@@ -772,7 +771,12 @@ export default function IndexSettingsPage() {
   const captioningModelConfigId = useMemo(() => {
     if (!defaultVision?.modelName || !llmProviders) return null;
     for (const p of llmProviders) {
-      if (p.name !== defaultVision.providerName) continue;
+      if (
+        p.name !== defaultVision.providerName &&
+        p.provider !== defaultVision.providerName
+      ) {
+        continue;
+      }
       const mc = p.model_configurations.find(
         (m) => m.name === defaultVision.modelName
       );
@@ -1751,13 +1755,11 @@ export default function IndexSettingsPage() {
                                 >
                                   <ModelSelector
                                     value={captioningModelConfigId}
+                                    providerOptions={llmProviders}
                                     disabled={!imageProcessingEnabled}
                                     requiresImageInput
                                     onChange={(opt) =>
-                                      void handleCaptioningModelChange({
-                                        modelName: opt.modelName,
-                                        providerName: opt.name,
-                                      })
+                                      void handleCaptioningModelChange(opt)
                                     }
                                   />
                                 </InputHorizontal>


### PR DESCRIPTION
### Summary
Fixes an issue where choosing models in **Index Settings (Captioning LLM)** and **Chat Preferences (Chat Naming Model)** fails with toast error: `Could not resolve provider`.

### Root Cause
1. In `IndexSettingsPage` and `ChatPreferencesPage`, `<ModelSelector>` was rendered without `providerOptions={llmProviders}`. Consequently, `ModelSelector` queried the persona/agent endpoint (`/api/llm/persona/{id}/providers`) while the change handlers matched against the page-level providers.
2. The change handlers searched for providers by display name (`llmProviders?.find((p) => p.name === providerName)`). For unnamed or standard OpenAI-compatible providers where `p.name` is `null` in the DB, `opt.name` is passed as `""`. The comparison `null === ""` fails.
3. In `web/src/lib/languageModels/hooks.ts` (`useLlmDefaults`), `if (!provider.name) return null;` discarded providers without an explicit display name.

### Changes
- Passed `providerOptions={llmProviders}` to `<ModelSelector>` in both `IndexSettingsPage` and `ChatPreferencesPage`.
- Updated `handleCaptioningModelChange` and `handleChatNamingModelChange` to find providers by `modelConfigurationId` directly from `LLMOption`.
- In `IndexSettingsPage`, added fallback to matching `p.provider` (slug) in addition to `p.name`.
- In `useLlmDefaults` (`hooks.ts`), used `provider.name || provider.provider` to support providers without custom display names.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes provider resolution when selecting models in Index Settings (Captioning LLM) and Chat Preferences (Chat Naming Model). Previously, saving often failed with “Could not resolve provider” because the selector and handlers used different provider sources and matched by display name; now selection resolves by model configuration ID and supports providers without a display name.

- Passes `providerOptions={llmProviders}` to `ModelSelector` on both pages to keep the provider list consistent.
- Finds the provider via `modelConfigurationId` from `LLMOption` and saves using `provider_id` + `model_name`.
- Accepts providers without display names by using `provider.name || provider.provider`, and falls back to slug when mapping current defaults.
- Minor UI change: when a provider has no display name, its slug may appear in settings. No migration required.

<sup>Written for commit 86c470d10faa8aaeedf509e073a7afcdf69c6f73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

