### PR TITLE
fix(tools): respect max_llm_chunks in WebSearchTool to avoid token overflow

### DIFF
--- a/backend/onyx/tools/models.py
+++ b/backend/onyx/tools/models.py
@@ -156,6 +156,8 @@ class DynamicSchemaInfo(BaseModel):
 class WebSearchToolOverrideKwargs(BaseModel):
     # To know what citation number to start at for constructing the string to the LLM
     starting_citation_num: int
+    # Number of chunks (token approx) to include in the string to the LLM
+    max_llm_chunks: int | None = MAX_CHUNKS_FED_TO_CHAT
 
 
 class OpenURLToolOverrideKwargs(BaseModel):

--- a/backend/onyx/tools/tool_implementations/web_search/web_search_tool.py
+++ b/backend/onyx/tools/tool_implementations/web_search/web_search_tool.py
@@ -345,7 +345,7 @@ class WebSearchTool(Tool[WebSearchToolOverrideKwargs]):
             docs_str, citation_mapping = convert_inference_sections_to_llm_string(
                 top_sections=inference_sections,
                 citation_start=override_kwargs.starting_citation_num,
-                limit=None,  # Already truncated
+                limit=override_kwargs.max_llm_chunks,
                 include_source_type=False,
                 include_link=True,
             )

--- a/backend/tests/unit/onyx/tools/tool_implementations/websearch/test_web_search_tool_run.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/websearch/test_web_search_tool_run.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
@@ -159,3 +160,27 @@ class TestWebSearchToolRunQueryCoercion:
 
         assert "No valid" in str(exc_info.value)
         cast(MagicMock, mock_provider.search).assert_not_called()
+
+    def test_max_llm_chunks_limits_sections_fed_to_llm(self) -> None:
+        """override_kwargs.max_llm_chunks caps the number of results in llm_facing_response."""
+        mock_provider = MagicMock()
+        mock_provider.supports_site_filter = False
+        mock_provider.search.return_value = [
+            _make_result(title=f"Result {i}", link=f"https://example.com/{i}")
+            for i in range(10)
+        ]
+        tool = _make_tool(mock_provider)
+        placement = Placement(turn_index=0, tab_index=0)
+        override_kwargs = WebSearchToolOverrideKwargs(
+            starting_citation_num=1,
+            max_llm_chunks=3,
+        )
+
+        response = tool.run(
+            placement=placement,
+            override_kwargs=override_kwargs,
+            queries=["test query"],
+        )
+
+        parsed_llm_response = json.loads(response.llm_facing_response)
+        assert len(parsed_llm_response["results"]) == 3


### PR DESCRIPTION
### Summary
Adds `max_llm_chunks` limit to `WebSearchToolOverrideKwargs` and applies it when converting inference sections to LLM string in `WebSearchTool.run()`.

### Problem
While internal `SearchTool` respects `max_llm_chunks` (defaulting to `MAX_CHUNKS_FED_TO_CHAT`), `WebSearchTool` passed `limit=None` into `convert_inference_sections_to_llm_string`. This bypassed the configured `MAX_CHUNKS_FED_TO_CHAT` setting and fed all returned snippets to the LLM context, which can cause context window overflow on models with smaller limits.

### Changes
1. Added `max_llm_chunks: int | None = MAX_CHUNKS_FED_TO_CHAT` to `WebSearchToolOverrideKwargs`.
2. Passed `limit=override_kwargs.max_llm_chunks` to `convert_inference_sections_to_llm_string` in `WebSearchTool.run()`.
3. Added a regression unit test in `test_web_search_tool_run.py` to ensure `max_llm_chunks` properly truncates sections fed to the LLM.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect `max_llm_chunks` in `WebSearchTool` to prevent LLM context overflow. Previously `WebSearchTool` always sent all snippets to the LLM; now it caps sections using `override_kwargs.max_llm_chunks` (defaulting to `MAX_CHUNKS_FED_TO_CHAT`), matching `SearchTool`.

- Add `max_llm_chunks` to `WebSearchToolOverrideKwargs` and pass it as `limit` to `convert_inference_sections_to_llm_string`.
- Add a regression test to ensure the LLM-facing response truncates to the configured limit.
- Migration: if you relied on unlimited snippets, set `override_kwargs.max_llm_chunks=None` when invoking `WebSearchTool.run()`.

<sup>Written for commit 7b74a41c4d9c015f6b2dc44f1531fe2758e75e42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

