### PR TITLE
fix(web): skip redundant updateGroup when group members and connectors are unchanged

### DIFF
--- a/web/src/views/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/EditGroupPage.tsx
@@ -51,6 +51,12 @@ import { can } from "@/lib/permissions/resource-actions";
 const HOURS_PER_DAY = 24;
 const addModeColumns = memberTableColumns;
 
+function setsEqual<T>(a: T[], b: T[]): boolean {
+  if (a.length !== b.length) return false;
+  const setB = new Set(b);
+  return a.every((item) => setB.has(item));
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -150,6 +156,8 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
   const [isDeleting, setIsDeleting] = useState(false);
   const [initialized, setInitialized] = useState(false);
   const [isAddingMembers, setIsAddingMembers] = useState(false);
+  const initialUserIdsRef = useRef<string[]>([]);
+  const initialCcPairIdsRef = useRef<number[]>([]);
   const initialAgentIdsRef = useRef<number[]>([]);
   const initialDocSetIdsRef = useRef<number[]>([]);
 
@@ -171,8 +179,12 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
   useEffect(() => {
     if (group && !initialized) {
       setGroupName(group.name);
-      setSelectedUserIds(group.users.map((u) => u.id));
-      setSelectedCcPairIds(group.cc_pairs.map((cc) => cc.id));
+      const userIds = group.users.map((u) => u.id);
+      setSelectedUserIds(userIds);
+      initialUserIdsRef.current = userIds;
+      const ccPairIds = group.cc_pairs.map((cc) => cc.id);
+      setSelectedCcPairIds(ccPairIds);
+      initialCcPairIdsRef.current = ccPairIds;
       const docSetIds = group.document_sets.map((ds) => ds.id);
       setSelectedDocSetIds(docSetIds);
       initialDocSetIdsRef.current = docSetIds;
@@ -396,8 +408,15 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
         await renameGroup(group.id, trimmed);
       }
 
-      // Update members and cc_pairs
-      await updateGroup(groupId, selectedUserIds, selectedCcPairIds);
+      // Update members and cc_pairs only if changed
+      const membersOrConnectorsChanged =
+        !setsEqual(selectedUserIds, initialUserIdsRef.current) ||
+        !setsEqual(selectedCcPairIds, initialCcPairIdsRef.current);
+      if (membersOrConnectorsChanged) {
+        await updateGroup(groupId, selectedUserIds, selectedCcPairIds);
+        initialUserIdsRef.current = selectedUserIds;
+        initialCcPairIdsRef.current = selectedCcPairIds;
+      }
 
       // Update agent sharing (add/remove this group from changed agents)
       await updateAgentGroupSharing(


### PR DESCRIPTION
### Summary
Skips calling `updateGroup(groupId, selectedUserIds, selectedCcPairIds)` in `EditGroupPage` when neither members nor connector pairs have changed.

### Problem
Previously, saving a group (e.g. just renaming it or updating agent/docset sharing) would always invoke `updateGroup`. This triggered an unnecessary backend mutation and triggered background group permission sync tasks in Celery/Vespa even when the member/connector composition was completely unchanged.

### Solution
Track `initialUserIdsRef` and `initialCcPairIdsRef` and only call `updateGroup` if the user or CC pair sets differ from their initial state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip redundant group updates in EditGroupPage to reduce unnecessary backend work. Previously, saving a group always called updateGroup; now it only runs when members or connector pairs changed, avoiding needless mutations and permission sync tasks.

- Add a setsEqual helper and store initial user and cc pair IDs in refs on load.
- Call updateGroup only when selected IDs differ from the initial sets; keep renameGroup and agent/docset sharing updates unchanged.
- Update the refs after a successful member/connector update to prevent re-sending on subsequent saves.

<sup>Written for commit 2f6842308728e40359467df4012b92246f80c2bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

