### PR TITLE
fix(llm): exclude hidden models when falling back to search for vision models

### DIFF
--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -464,8 +464,9 @@ def fetch_existing_tools(db_session: Session, tool_ids: list[int]) -> list[ToolM
 def fetch_existing_models(
     db_session: Session,
     flow_types: list[LLMModelFlowType],
+    only_visible: bool = False,
 ) -> list[ModelConfiguration]:
-    models = (
+    stmt = (
         select(ModelConfiguration)
         .join(LLMModelFlow)
         .where(LLMModelFlow.llm_model_flow_type.in_(flow_types))
@@ -475,7 +476,10 @@ def fetch_existing_models(
         )
     )
 
-    return list(db_session.scalars(models).all())
+    if only_visible:
+        stmt = stmt.where(ModelConfiguration.is_visible.is_(True))
+
+    return list(db_session.scalars(stmt).all())
 
 
 def fetch_existing_llm_providers(

--- a/backend/onyx/llm/factory.py
+++ b/backend/onyx/llm/factory.py
@@ -285,6 +285,7 @@ def get_default_llm_with_vision(
         models = fetch_existing_models(
             db_session=db_session,
             flow_types=[LLMModelFlowType.VISION, LLMModelFlowType.CHAT],
+            only_visible=True,
         )
 
         if not models:

--- a/backend/tests/unit/onyx/llm/test_vision_model_selection_logging.py
+++ b/backend/tests/unit/onyx/llm/test_vision_model_selection_logging.py
@@ -7,7 +7,7 @@ Verifies that operators get clear feedback about:
 3. When no vision-capable model exists at all
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 from onyx.llm.factory import get_default_llm_with_vision
 
@@ -86,13 +86,18 @@ def test_warns_when_default_model_lacks_vision(
 @patch(f"{_FACTORY}.logger")
 def test_warns_when_no_models_exist(
     mock_logger: MagicMock,
-    mock_fetch_models: MagicMock,  # noqa: ARG001
+    mock_fetch_models: MagicMock,
     mock_fetch_default: MagicMock,  # noqa: ARG001
     mock_session: MagicMock,  # noqa: ARG001
 ) -> None:
     result = get_default_llm_with_vision()
 
     assert result is None
+    mock_fetch_models.assert_called_once_with(
+        db_session=mock_session.return_value.__enter__.return_value,
+        flow_types=[ANY, ANY],
+        only_visible=True,
+    )
     mock_logger.warning.assert_called_once()
     log_msg = mock_logger.warning.call_args[0][0]
     assert "no llm models" in log_msg.lower()


### PR DESCRIPTION
### Summary
Adds an `only_visible: bool = False` parameter to `fetch_existing_models()` and enables it in `get_default_llm_with_vision()`.

### Problem
When searching across all LLM providers for fallback vision-capable models (e.g. for image captioning during document indexing), `fetch_existing_models()` returned all model configurations including hidden / auto-generated internal models (`is_visible=False`). This could cause the pipeline to select an internal unlisted model rather than an administrator-configured visible model.

### Solution
1. Added `only_visible: bool = False` to `fetch_existing_models()` in `backend/onyx/db/llm.py`.
2. Passed `only_visible=True` from `get_default_llm_with_vision()` in `backend/onyx/llm/factory.py`.
3. Updated unit tests in `test_vision_model_selection_logging.py`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude hidden LLM models from vision fallback selection to avoid picking internal/unlisted configurations. Previously the fallback searched all models and could choose a hidden auto-generated model; now it filters to visible models only, so the pipeline prefers administrator-configured models. Other callers of model fetch remain unchanged.

- Added `only_visible: bool = False` to `fetch_existing_models()`; set `only_visible=True` in `get_default_llm_with_vision()`.
- Kept the default parameter to avoid behavior changes for other call sites.
- Extended unit tests to assert the visible-only query and preserve warning logs when no models exist.

<sup>Written for commit 2267d7b258bd115d95db47aecd5d529ae27c9cab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

