### PR TITLE
fix(celery): stop false duplicate/missing errors in monitor_process_memory

### DIFF
--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -1028,6 +1028,36 @@ def _get_cmdline_for_process(process: psutil.Process) -> str | None:
         return None
 
 
+def _match_supervisor_processes(
+    process_cmdlines: dict[int, str],
+    process_type_mapping: dict[str, str],
+) -> tuple[dict[int, str], list[str]]:
+    """Match running processes against known supervisor-managed process
+    cmdline signatures.
+
+    Returns the pid -> process_type mapping for successfully matched
+    processes, plus a list of human-readable warnings for any process
+    whose type was already matched by another pid (e.g. a signature that's
+    a substring of more than one running process' cmdline).
+    """
+    supervisor_processes: dict[int, str] = {}
+    duplicate_warnings: list[str] = []
+
+    for pid, cmdline in process_cmdlines.items():
+        for process_name, process_type in process_type_mapping.items():
+            if process_name in cmdline:
+                if process_type in supervisor_processes.values():
+                    duplicate_warnings.append(
+                        f"Duplicate process type for type {process_type} with cmd {cmdline} with pid={pid}."
+                    )
+                    continue
+
+                supervisor_processes[pid] = process_type
+                break
+
+    return supervisor_processes, duplicate_warnings
+
+
 @shared_task(  # ty: ignore[invalid-argument-type]
     name=OnyxCeleryTask.MONITOR_PROCESS_MEMORY,
     ignore_result=True,
@@ -1060,42 +1090,43 @@ def monitor_process_memory(self: Task, *, tenant_id: str) -> None:  # noqa: ARG0
         return
 
     try:
-        # Get all supervisor-managed processes
-        supervisor_processes: dict[int, str] = {}
-
-        # Map cmd line elements to more readable process names
+        # Map cmd line elements to more readable process names.
+        # Keep in sync with the `command=`/`--hostname=` entries in
+        # backend/supervisord.conf. The beat signature must be specific
+        # enough to not also match the watchdog or log-redirect-handler
+        # processes, whose cmdlines reference celery_beat.log / the beat
+        # program name and would otherwise be misidentified as duplicates.
         process_type_mapping = {
             "--hostname=primary": "primary",
             "--hostname=light": "light",
             "--hostname=heavy": "heavy",
-            "--hostname=indexing": "indexing",
+            "--hostname=docprocessing": "docprocessing",
+            "--hostname=user_file_processing": "user_file_processing",
+            "--hostname=scheduled_tasks": "scheduled_tasks",
+            "--hostname=docfetching": "docfetching",
             "--hostname=monitoring": "monitoring",
-            "beat": "beat",
+            "versioned_apps.beat beat": "beat",
             "slack/listener.py": "slack",
         }
 
         # Find all python processes that are likely celery workers
+        process_cmdlines: dict[int, str] = {}
         for proc in psutil.process_iter():
             cmdline = _get_cmdline_for_process(proc)
-            if not cmdline:
-                continue
+            if cmdline:
+                process_cmdlines[proc.pid] = cmdline
 
-            # Match supervisor-managed processes
-            for process_name, process_type in process_type_mapping.items():
-                if process_name in cmdline:
-                    if process_type in supervisor_processes.values():
-                        task_logger.error(
-                            f"Duplicate process type for type {process_type} with cmd {cmdline} with pid={proc.pid}."
-                        )
-                        continue
+        supervisor_processes, duplicate_warnings = _match_supervisor_processes(
+            process_cmdlines, process_type_mapping
+        )
+        for warning in duplicate_warnings:
+            task_logger.error(warning)
 
-                    supervisor_processes[proc.pid] = process_type
-                    break
-
-        if len(supervisor_processes) != len(process_type_mapping):
-            task_logger.error(
-                f"Missing processes: {set(process_type_mapping.keys()).symmetric_difference(supervisor_processes.values())}"
-            )
+        missing_process_types = set(process_type_mapping.values()) - set(
+            supervisor_processes.values()
+        )
+        if missing_process_types:
+            task_logger.error(f"Missing processes: {missing_process_types}")
 
         # Log memory usage for each process
         for pid, process_type in supervisor_processes.items():

--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -1058,6 +1058,26 @@ def _match_supervisor_processes(
     return supervisor_processes, duplicate_warnings
 
 
+# Map cmd line elements to more readable process names.
+# Keep in sync with the `command=`/`--hostname=` entries in
+# backend/supervisord.conf. The beat signature must be specific
+# enough to not also match the watchdog or log-redirect-handler
+# processes, whose cmdlines reference celery_beat.log / the beat
+# program name and would otherwise be misidentified as duplicates.
+SUPERVISOR_PROCESS_TYPE_MAPPING = {
+    "--hostname=primary": "primary",
+    "--hostname=light": "light",
+    "--hostname=heavy": "heavy",
+    "--hostname=docprocessing": "docprocessing",
+    "--hostname=user_file_processing": "user_file_processing",
+    "--hostname=scheduled_tasks": "scheduled_tasks",
+    "--hostname=docfetching": "docfetching",
+    "--hostname=monitoring": "monitoring",
+    "versioned_apps.beat beat": "beat",
+    "slack/listener.py": "slack",
+}
+
+
 @shared_task(  # ty: ignore[invalid-argument-type]
     name=OnyxCeleryTask.MONITOR_PROCESS_MEMORY,
     ignore_result=True,
@@ -1090,24 +1110,7 @@ def monitor_process_memory(self: Task, *, tenant_id: str) -> None:  # noqa: ARG0
         return
 
     try:
-        # Map cmd line elements to more readable process names.
-        # Keep in sync with the `command=`/`--hostname=` entries in
-        # backend/supervisord.conf. The beat signature must be specific
-        # enough to not also match the watchdog or log-redirect-handler
-        # processes, whose cmdlines reference celery_beat.log / the beat
-        # program name and would otherwise be misidentified as duplicates.
-        process_type_mapping = {
-            "--hostname=primary": "primary",
-            "--hostname=light": "light",
-            "--hostname=heavy": "heavy",
-            "--hostname=docprocessing": "docprocessing",
-            "--hostname=user_file_processing": "user_file_processing",
-            "--hostname=scheduled_tasks": "scheduled_tasks",
-            "--hostname=docfetching": "docfetching",
-            "--hostname=monitoring": "monitoring",
-            "versioned_apps.beat beat": "beat",
-            "slack/listener.py": "slack",
-        }
+        process_type_mapping = SUPERVISOR_PROCESS_TYPE_MAPPING
 
         # Find all python processes that are likely celery workers
         process_cmdlines: dict[int, str] = {}

--- a/backend/tests/unit/background/celery/test_monitoring_tasks.py
+++ b/backend/tests/unit/background/celery/test_monitoring_tasks.py
@@ -3,6 +3,7 @@ monitor_process_memory.
 """
 
 from onyx.background.celery.tasks.monitoring.tasks import (
+    SUPERVISOR_PROCESS_TYPE_MAPPING,
     _match_supervisor_processes,
 )
 
@@ -29,19 +30,6 @@ LOG_REDIRECT_CMDLINE = (
 )
 SLACK_CMDLINE = "python onyx/onyxbot/slack/listener.py"
 
-CURRENT_PROCESS_TYPE_MAPPING = {
-    "--hostname=primary": "primary",
-    "--hostname=light": "light",
-    "--hostname=heavy": "heavy",
-    "--hostname=docprocessing": "docprocessing",
-    "--hostname=user_file_processing": "user_file_processing",
-    "--hostname=scheduled_tasks": "scheduled_tasks",
-    "--hostname=docfetching": "docfetching",
-    "--hostname=monitoring": "monitoring",
-    "versioned_apps.beat beat": "beat",
-    "slack/listener.py": "slack",
-}
-
 
 def test_matches_each_process_exactly_once() -> None:
     process_cmdlines = {
@@ -52,7 +40,7 @@ def test_matches_each_process_exactly_once() -> None:
     }
 
     supervisor_processes, duplicate_warnings = _match_supervisor_processes(
-        process_cmdlines, CURRENT_PROCESS_TYPE_MAPPING
+        process_cmdlines, SUPERVISOR_PROCESS_TYPE_MAPPING
     )
 
     assert supervisor_processes == {
@@ -77,7 +65,7 @@ def test_beat_watchdog_and_log_redirect_do_not_false_match_as_beat() -> None:
     }
 
     supervisor_processes, duplicate_warnings = _match_supervisor_processes(
-        process_cmdlines, CURRENT_PROCESS_TYPE_MAPPING
+        process_cmdlines, SUPERVISOR_PROCESS_TYPE_MAPPING
     )
 
     assert supervisor_processes == {1: "beat"}
@@ -93,7 +81,7 @@ def test_genuine_duplicate_is_still_reported() -> None:
     }
 
     supervisor_processes, duplicate_warnings = _match_supervisor_processes(
-        process_cmdlines, CURRENT_PROCESS_TYPE_MAPPING
+        process_cmdlines, SUPERVISOR_PROCESS_TYPE_MAPPING
     )
 
     assert supervisor_processes == {1: "primary"}

--- a/backend/tests/unit/background/celery/test_monitoring_tasks.py
+++ b/backend/tests/unit/background/celery/test_monitoring_tasks.py
@@ -1,0 +1,101 @@
+"""Unit tests for the supervisor-managed process matching logic used by
+monitor_process_memory.
+"""
+
+from onyx.background.celery.tasks.monitoring.tasks import (
+    _match_supervisor_processes,
+)
+
+# Real command lines, taken directly from the `[program:...]` entries in
+# backend/supervisord.conf, with process-manager-added suffixes (e.g.
+# `@%n` hostname expansion) approximated with a literal host id.
+PRIMARY_CMDLINE = (
+    "celery -A onyx.background.celery.versioned_apps.primary worker "
+    "--hostname=primary@host -Q celery"
+)
+DOCPROCESSING_CMDLINE = (
+    "celery -A onyx.background.celery.versioned_apps.docprocessing worker "
+    "--hostname=docprocessing@host -Q docprocessing,port"
+)
+BEAT_CMDLINE = "celery -A onyx.background.celery.versioned_apps.beat beat"
+BEAT_WATCHDOG_CMDLINE = (
+    "python -m onyx.utils.supervisord_watchdog "
+    "--conf /etc/supervisor/conf.d/supervisord.conf "
+    '--key "onyx:celery:beat:heartbeat" --program celery_beat'
+)
+LOG_REDIRECT_CMDLINE = (
+    "tail -qF /var/log/celery_beat.log /var/log/celery_worker_primary.log "
+    "/var/log/supervisord_watchdog_celery_beat.log"
+)
+SLACK_CMDLINE = "python onyx/onyxbot/slack/listener.py"
+
+CURRENT_PROCESS_TYPE_MAPPING = {
+    "--hostname=primary": "primary",
+    "--hostname=light": "light",
+    "--hostname=heavy": "heavy",
+    "--hostname=docprocessing": "docprocessing",
+    "--hostname=user_file_processing": "user_file_processing",
+    "--hostname=scheduled_tasks": "scheduled_tasks",
+    "--hostname=docfetching": "docfetching",
+    "--hostname=monitoring": "monitoring",
+    "versioned_apps.beat beat": "beat",
+    "slack/listener.py": "slack",
+}
+
+
+def test_matches_each_process_exactly_once() -> None:
+    process_cmdlines = {
+        1: PRIMARY_CMDLINE,
+        2: DOCPROCESSING_CMDLINE,
+        3: BEAT_CMDLINE,
+        4: SLACK_CMDLINE,
+    }
+
+    supervisor_processes, duplicate_warnings = _match_supervisor_processes(
+        process_cmdlines, CURRENT_PROCESS_TYPE_MAPPING
+    )
+
+    assert supervisor_processes == {
+        1: "primary",
+        2: "docprocessing",
+        3: "beat",
+        4: "slack",
+    }
+    assert duplicate_warnings == []
+
+
+def test_beat_watchdog_and_log_redirect_do_not_false_match_as_beat() -> None:
+    # Regression test: previously, the bare "beat" substring also matched
+    # the beat watchdog (cmdline references "celery_beat") and the
+    # log-redirect-handler (cmdline references celery_beat.log), which were
+    # then logged as duplicate "beat" processes even though only one real
+    # celery beat process was running.
+    process_cmdlines = {
+        1: BEAT_CMDLINE,
+        2: BEAT_WATCHDOG_CMDLINE,
+        3: LOG_REDIRECT_CMDLINE,
+    }
+
+    supervisor_processes, duplicate_warnings = _match_supervisor_processes(
+        process_cmdlines, CURRENT_PROCESS_TYPE_MAPPING
+    )
+
+    assert supervisor_processes == {1: "beat"}
+    assert duplicate_warnings == []
+
+
+def test_genuine_duplicate_is_still_reported() -> None:
+    # If the same process type is somehow started twice, that's still a
+    # real condition worth flagging.
+    process_cmdlines = {
+        1: PRIMARY_CMDLINE,
+        2: PRIMARY_CMDLINE,
+    }
+
+    supervisor_processes, duplicate_warnings = _match_supervisor_processes(
+        process_cmdlines, CURRENT_PROCESS_TYPE_MAPPING
+    )
+
+    assert supervisor_processes == {1: "primary"}
+    assert len(duplicate_warnings) == 1
+    assert "Duplicate process type for type primary" in duplicate_warnings[0]


### PR DESCRIPTION
Fixes #13979

`monitor_process_memory`'s `process_type_mapping` is out of sync with `backend/supervisord.conf`, and its matching logic has two independent bugs:

1. **False "duplicate" for beat.** The bare `"beat"` substring also matches the beat watchdog's cmdline (`--program celery_beat`) and `log-redirect-handler`'s cmdline (`/var/log/celery_beat.log`, `/var/log/supervisord_watchdog_celery_beat.log`), so both get logged as duplicate `beat` processes even though there's only one real `celery beat` process.
2. **Always-wrong "missing processes".** `--hostname=indexing` hasn't existed since that worker was renamed to `docprocessing`, and `docfetching`/`user_file_processing`/`scheduled_tasks` were never in the mapping at all. On top of that, the check compared mapping *keys* (e.g. `"--hostname=primary"`) against matched process *values* (e.g. `"primary"`) via `symmetric_difference` — these never overlap by construction, so the "Missing processes" error fired every single run with a garbage set.

## Fix

- Extracted the matching into `_match_supervisor_processes()` so it's testable independent of `psutil.process_iter()`.
- Updated `process_type_mapping` to match every process currently defined in `backend/supervisord.conf` (added `docprocessing`, `user_file_processing`, `scheduled_tasks`, `docfetching`; dropped the stale `indexing` entry).
- Tightened the beat signature to `"versioned_apps.beat beat"`, which only matches the actual `celery -A onyx.background.celery.versioned_apps.beat beat` command, not the watchdog or log-tail processes.
- Fixed the missing-process check to diff expected vs. matched process *types* (`set(mapping.values()) - set(matched.values())`) instead of keys vs. values.

## Testing

Added `backend/tests/unit/background/celery/test_monitoring_tasks.py` covering:
- normal matching against realistic per-worker cmdlines
- the beat/watchdog/log-redirect false-duplicate regression, using cmdlines taken directly from `backend/supervisord.conf`
- that a genuine duplicate (same process type running twice) is still reported

I wasn't able to build a full local Python 3.13 env in this sandbox (a transitive dependency, `chonkie`, fails to build its C extension against the available MSVC toolchain — unrelated to this change), so I couldn't run `pytest` here directly. Instead I verified the exact matching logic (copied verbatim) in an isolated script against cmdlines taken straight from `backend/supervisord.conf`:

- **RED** (old logic): flags 2 false "duplicate beat" warnings and reports a nonsensical "missing processes" set built from `symmetric_difference` of keys vs. values.
- **GREEN** (new logic): 0 duplicate warnings, 0 missing processes, all 10 currently-defined supervisor processes matched correctly.

Also ran `ruff check` and `ruff format --check` against the changed files — both clean (there's one pre-existing, unrelated formatting deviation elsewhere in the file around `monitor_celery_queues`, left untouched).

Happy to add coverage elsewhere or adjust the mapping if `discord_bot` should also be tracked — I kept this scoped to fixing the existing mismatch rather than expanding what's monitored.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops false “duplicate beat” and bogus “missing processes” errors in `monitor_process_memory` by syncing the supervisor mapping and fixing the matcher. Previously, a bare “beat” matched watchdog/log-tail processes and the missing-process check compared keys vs. values; now we match only supervisor-defined processes, use a specific beat signature, and compare expected vs. matched process types. Genuine duplicates still raise an error; memory logging is unchanged.

- Updates and exports `SUPERVISOR_PROCESS_TYPE_MAPPING` to match `backend/supervisord.conf` (adds `docprocessing`, `user_file_processing`, `scheduled_tasks`, `docfetching`; removes `indexing`), and tightens the beat signature to `versioned_apps.beat beat`. Tests import the constant to prevent drift.
- Extracts `_match_supervisor_processes()` and uses it in the task.
- Fixes missing-process detection by diffing process types instead of mapping keys vs. matched values.
- Adds unit tests covering normal matching, the beat false-duplicate regression, and real duplicates.

<sup>Written for commit 250d6f4a5a9f1eba4fe13bec46d11e9b2a2320c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

