### PR TITLE
feat(ods): add impersonate command for single-tenant deployments

### DIFF
--- a/tools/ods/cmd/impersonate.go
+++ b/tools/ods/cmd/impersonate.go
@@ -1,0 +1,245 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/impersonate"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/kube"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
+)
+
+const defaultNamespace = "onyx"
+
+// impersonateFlags are shared by every impersonate subcommand.
+type impersonateFlags struct {
+	cluster   string
+	region    string
+	namespace string
+	ctx       string
+	host      string
+}
+
+// NewImpersonateCommand creates the parent impersonate command.
+func NewImpersonateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "impersonate",
+		Short: "Mint, list, and revoke sessions on a single-tenant deployment",
+		Long: `Impersonate a user on a single-tenant Kubernetes customer deployment.
+
+Single tenant has no UI impersonation flow, so support access means writing a
+session token into Redis. This runs a Python payload inside the customer's
+api-server pod, which already holds the Redis and database credentials plus
+network reach into the VPC. No AWS console or redis-cli is needed.
+
+Everything you do while impersonating persists as that user. Use the shortest
+usable TTL and revoke when you finish.
+
+Select the cluster either directly:
+
+  ods impersonate mint --email admin@customer.com -C gearbox-prod -R us-east-1
+
+or through a KUBE_CTX_* environment variable, as ods whois does:
+
+  export KUBE_CTX_GEARBOX="<cluster> <region> <namespace>"
+  ods impersonate list -c gearbox`,
+	}
+
+	cmd.AddCommand(NewImpersonateMintCommand())
+	cmd.AddCommand(NewImpersonateListCommand())
+	cmd.AddCommand(NewImpersonateRevokeCommand())
+
+	return cmd
+}
+
+// addImpersonateFlags registers the cluster selection flags on a subcommand.
+func addImpersonateFlags(cmd *cobra.Command, f *impersonateFlags) {
+	cmd.Flags().StringVarP(&f.cluster, "cluster", "C", "", "EKS cluster name")
+	cmd.Flags().StringVarP(&f.region, "region", "R", "", "AWS region (required with --cluster)")
+	cmd.Flags().StringVarP(&f.namespace, "namespace", "n", defaultNamespace, "Kubernetes namespace")
+	cmd.Flags().StringVarP(&f.ctx, "context", "c", "", "cluster context name (maps to KUBE_CTX_<NAME> env var)")
+	cmd.Flags().StringVar(&f.host, "host", "", "customer URL, used in the printed steps")
+}
+
+// connect resolves the target cluster and finds a ready api-server pod. The
+// resolved cluster is always logged, so the target is never silent.
+func (f *impersonateFlags) connect() (*kube.Cluster, string) {
+	var c *kube.Cluster
+	switch {
+	case f.cluster != "" && f.region != "":
+		c = &kube.Cluster{Name: f.cluster, Region: f.region, Namespace: f.namespace}
+	case f.cluster != "" || f.region != "":
+		log.Fatal("--cluster and --region go together")
+	case f.ctx != "":
+		c = clusterFromEnv(f.ctx)
+	default:
+		log.Fatal("Select a cluster with --cluster/--region or with --context")
+	}
+
+	if err := c.EnsureContext(); err != nil {
+		log.Fatalf("Failed to ensure cluster context: %v", err)
+	}
+
+	log.Infof("Cluster: %s (%s), namespace %s", c.Name, c.Region, c.Namespace)
+	pod, err := c.FindPod(impersonate.APIServerPod)
+	if err != nil {
+		log.Fatalf("Failed to find api-server pod: %v", err)
+	}
+	log.Debugf("Using pod: %s", pod)
+
+	return c, pod
+}
+
+// operatorEmail identifies who minted a token, for the audit marker.
+func operatorEmail() string {
+	out, err := exec.Command("git", "config", "user.email").Output()
+	if email := strings.TrimSpace(string(out)); err == nil && email != "" {
+		return email
+	}
+	if user := os.Getenv("USER"); user != "" {
+		return user
+	}
+	return "unknown"
+}
+
+// NewImpersonateMintCommand creates the impersonate mint subcommand.
+func NewImpersonateMintCommand() *cobra.Command {
+	var f impersonateFlags
+	var ttl time.Duration
+	var yes bool
+
+	cmd := &cobra.Command{
+		Use:   "mint",
+		Short: "Write a session token for a user and print its cookie value",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			email, _ := cmd.Flags().GetString("email")
+			c, pod := f.connect()
+
+			if !yes && !prompt.Confirm(fmt.Sprintf("\nMint a session for %s on %s? [Y/n] ", email, c.Name)) {
+				log.Info("Aborted.")
+				return
+			}
+
+			result, err := impersonate.Mint(c, pod, email, int(ttl.Seconds()), operatorEmail())
+			if err != nil {
+				log.Fatalf("Failed to mint session: %v", err)
+			}
+			printMintResult(result, f.host)
+		},
+	}
+
+	addImpersonateFlags(cmd, &f)
+	cmd.Flags().String("email", "", "user to impersonate")
+	cmd.Flags().DurationVar(&ttl, "ttl", time.Hour, "session lifetime")
+	cmd.Flags().BoolVar(&yes, "yes", false, "skip the confirmation prompt")
+	_ = cmd.MarkFlagRequired("email")
+
+	return cmd
+}
+
+func printMintResult(result *impersonate.Result, host string) {
+	if host == "" {
+		host = "https://<customer>.onyx.app"
+	}
+	host = strings.TrimSuffix(host, "/")
+
+	fmt.Printf("\nMinted a session for %s (role: %s)\n", result.Email, result.Role)
+	fmt.Printf("  expires at : %s\n", result.ExpiresAt)
+	fmt.Println("  cookie     : fastapiusersauth")
+	fmt.Printf("  value      : %s\n\n", result.Token)
+
+	fmt.Println("To use it:")
+	fmt.Printf("  1. Open %s/api/settings - this avoids the SSO redirect loop.\n", host)
+	fmt.Println("  2. In the devtools console, run:")
+	fmt.Printf("     document.cookie = %q\n", fmt.Sprintf("fastapiusersauth=%s; path=/", result.Token))
+	fmt.Printf("  3. Go to %s/chat\n\n", host)
+
+	fmt.Println("Everything you do persists as this user. Revoke when you finish:")
+	fmt.Printf("  ods impersonate revoke --token %s\n\n", result.Token)
+}
+
+// NewImpersonateListCommand creates the impersonate list subcommand.
+func NewImpersonateListCommand() *cobra.Command {
+	var f impersonateFlags
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List every session token on the deployment",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			c, pod := f.connect()
+
+			result, err := impersonate.List(c, pod)
+			if err != nil {
+				log.Fatalf("Failed to list sessions: %v", err)
+			}
+			if len(result.Sessions) == 0 {
+				fmt.Println("No session tokens found.")
+				return
+			}
+
+			fmt.Println()
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			_, _ = fmt.Fprintln(w, "EMAIL\tSTATUS\tTTL\tIMPERSONATED BY")
+			_, _ = fmt.Fprintln(w, "-----\t------\t---\t---------------")
+			for _, s := range result.Sessions {
+				ttl := "-"
+				if s.TTLSeconds >= 0 {
+					ttl = (time.Duration(s.TTLSeconds) * time.Second).String()
+				}
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", s.Email, s.Status, ttl, s.ImpersonatedBy)
+			}
+			_ = w.Flush()
+		},
+	}
+
+	addImpersonateFlags(cmd, &f)
+
+	return cmd
+}
+
+// NewImpersonateRevokeCommand creates the impersonate revoke subcommand.
+func NewImpersonateRevokeCommand() *cobra.Command {
+	var f impersonateFlags
+	var includeReal bool
+
+	cmd := &cobra.Command{
+		Use:   "revoke",
+		Short: "Delete a minted session, or every impersonation session for a user",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			email, _ := cmd.Flags().GetString("email")
+			token, _ := cmd.Flags().GetString("token")
+			if email == "" && token == "" {
+				log.Fatal("revoke needs --email or --token")
+			}
+
+			c, pod := f.connect()
+
+			result, err := impersonate.Revoke(c, pod, email, token, includeReal)
+			if err != nil {
+				log.Fatalf("Failed to revoke sessions: %v", err)
+			}
+
+			log.Infof("Revoked %d session(s).", result.Deleted)
+			if email != "" && result.Deleted == 0 {
+				log.Info("No impersonation sessions matched. Pass --include-real-sessions to drop the user's own sessions too.")
+			}
+		},
+	}
+
+	addImpersonateFlags(cmd, &f)
+	cmd.Flags().String("email", "", "revoke this user's impersonation sessions")
+	cmd.Flags().String("token", "", "revoke this specific token")
+	cmd.Flags().BoolVar(&includeReal, "include-real-sessions", false, "also drop the user's own logins")
+
+	return cmd
+}

--- a/tools/ods/cmd/root.go
+++ b/tools/ods/cmd/root.go
@@ -65,6 +65,7 @@ func NewRootCommand() *cobra.Command {
 	cmd.AddCommand(NewWebCommand())
 	cmd.AddCommand(NewLatestStableTagCommand())
 	cmd.AddCommand(NewWhoisCommand())
+	cmd.AddCommand(NewImpersonateCommand())
 	cmd.AddCommand(NewTraceCommand())
 	cmd.AddCommand(NewInstallSkillCommand())
 	cmd.AddCommand(NewReleaseCommand())

--- a/tools/ods/internal/impersonate/impersonate.go
+++ b/tools/ods/internal/impersonate/impersonate.go
@@ -1,0 +1,113 @@
+// Package impersonate mints, lists, and revokes session tokens on a single-tenant
+// deployment by running an embedded Python payload inside the api-server pod.
+//
+// The payload imports nothing from onyx: customers run older images whose module
+// paths differ from main. It uses the pod's env vars with redis and psycopg2, and
+// writes a token that satisfies both session formats -- readers before July 2026
+// take "sub" and ignore the rest, later ones parse issued_at/expires_at.
+package impersonate
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/kube"
+)
+
+//go:embed impersonate.py
+var embeddedScript string
+
+// resultSentinel prefixes the payload's single result line, so onyx logging on
+// stdout around it is ignored.
+const resultSentinel = "__ONYX_IMPERSONATE_RESULT__"
+
+// APIServerPod is the pod substring the payload runs on.
+const APIServerPod = "api-server"
+
+// Session is one entry in the pod's Redis session store.
+type Session struct {
+	Token          string `json:"token"`
+	Sub            string `json:"sub"`
+	Email          string `json:"email"`
+	Status         string `json:"status"`
+	TTLSeconds     int    `json:"ttl_seconds"`
+	ExpiresAt      string `json:"expires_at"`
+	ImpersonatedBy string `json:"impersonated_by"`
+}
+
+// Result is the payload's response. Only the fields for the request's command are set.
+type Result struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error"`
+
+	// mint
+	Token     string `json:"token"`
+	Email     string `json:"email"`
+	UserID    string `json:"user_id"`
+	Role      string `json:"role"`
+	ExpiresAt string `json:"expires_at"`
+
+	// list
+	Sessions []Session `json:"sessions"`
+
+	// revoke
+	Deleted int      `json:"deleted"`
+	Tokens  []string `json:"tokens"`
+}
+
+// run ships the payload to the pod and parses its sentinel line.
+func run(c *kube.Cluster, pod string, request map[string]any) (*Result, error) {
+	encoded, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode request: %w", err)
+	}
+
+	stdout, err := c.ExecOnPodWithStdin(pod, embeddedScript, "python", "-", string(encoded))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, line := range strings.Split(stdout, "\n") {
+		if !strings.HasPrefix(line, resultSentinel) {
+			continue
+		}
+		var result Result
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, resultSentinel)), &result); err != nil {
+			return nil, fmt.Errorf("failed to decode result: %w", err)
+		}
+		if !result.OK {
+			return nil, fmt.Errorf("%s", result.Error)
+		}
+		return &result, nil
+	}
+
+	return nil, fmt.Errorf("the api-server pod returned no result:\n%s", strings.TrimSpace(stdout))
+}
+
+// Mint writes a new session token for the given user and returns its cookie value.
+func Mint(c *kube.Cluster, pod, email string, ttlSeconds int, operator string) (*Result, error) {
+	return run(c, pod, map[string]any{
+		"command":     "mint",
+		"email":       email,
+		"ttl_seconds": ttlSeconds,
+		"operator":    operator,
+	})
+}
+
+// List returns every session token currently in Redis.
+func List(c *kube.Cluster, pod string) (*Result, error) {
+	return run(c, pod, map[string]any{"command": "list"})
+}
+
+// Revoke deletes a single token, or every impersonation session for an email.
+// Set includeRealSessions to also drop the user's own logins.
+func Revoke(c *kube.Cluster, pod, email, token string, includeRealSessions bool) (*Result, error) {
+	return run(c, pod, map[string]any{
+		"command":               "revoke",
+		"email":                 email,
+		"token":                 token,
+		"include_real_sessions": includeRealSessions,
+	})
+}

--- a/tools/ods/internal/impersonate/impersonate.py
+++ b/tools/ods/internal/impersonate/impersonate.py
@@ -1,0 +1,209 @@
+"""Runs inside a customer api-server pod, fed to `python -` on stdin.
+
+Takes one argv: a JSON request blob. Writes one sentinel-prefixed JSON line
+to stdout. Embedded into the ods binary by impersonate.go.
+"""
+
+import json
+import os
+import secrets
+import sys
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import psycopg2
+import redis
+from psycopg2 import sql
+
+# Deliberately imports nothing from onyx: this runs against whatever image the
+# customer is on, and onyx module paths move between releases. Only the env vars,
+# the key prefix, and the token JSON shape are relied on, and those are stable.
+RESULT_SENTINEL = "__ONYX_IMPERSONATE_RESULT__"
+AUTH_KEY_PREFIX = "fastapi_users_token:"
+SCAN_COUNT = 1000
+
+
+def _schema() -> str:
+    return os.environ.get("POSTGRES_DEFAULT_SCHEMA") or "public"
+
+
+def _redis_client() -> "redis.Redis[Any]":
+    kwargs: dict[str, Any] = {
+        "host": os.environ.get("REDIS_HOST") or "localhost",
+        "port": int(os.environ.get("REDIS_PORT") or 6379),
+        "db": int(os.environ.get("REDIS_DB_NUMBER") or 0),
+        "password": os.environ.get("REDIS_PASSWORD") or None,
+        "decode_responses": True,
+    }
+    if (os.environ.get("REDIS_SSL") or "").lower() == "true":
+        kwargs["ssl"] = True
+        kwargs["ssl_cert_reqs"] = os.environ.get("REDIS_SSL_CERT_REQS") or "none"
+        ca_certs = os.environ.get("REDIS_SSL_CA_CERTS")
+        if ca_certs:
+            kwargs["ssl_ca_certs"] = ca_certs
+    return redis.Redis(**kwargs)
+
+
+def _pg_connect() -> Any:
+    return psycopg2.connect(
+        host=os.environ.get("POSTGRES_HOST") or "127.0.0.1",
+        port=os.environ.get("POSTGRES_PORT") or "5432",
+        user=os.environ.get("POSTGRES_USER") or "postgres",
+        password=os.environ.get("POSTGRES_PASSWORD") or "",
+        dbname=os.environ.get("POSTGRES_DB") or "postgres",
+    )
+
+
+def _classify(payload: dict[str, Any]) -> str:
+    """Mirrors onyx.auth.session_tokens without importing it, for both formats."""
+    if payload.get("logged_out_at"):
+        return "terminated"
+    if not payload.get("sub"):
+        return "malformed"
+
+    expires_at = payload.get("expires_at")
+    if not expires_at:
+        # Pre-July-2026 tokens carry no expiry; the Redis TTL is their lifetime.
+        return "active"
+    try:
+        if datetime.fromisoformat(expires_at) <= datetime.now(timezone.utc):
+            return "expired"
+    except ValueError:
+        return "malformed"
+    return "active"
+
+
+def _scan_sessions(redis_client: "redis.Redis[Any]") -> list[dict[str, Any]]:
+    """Reads every session token, with its status, remaining TTL, and payload."""
+    sessions: list[dict[str, Any]] = []
+    for key in redis_client.scan_iter(AUTH_KEY_PREFIX + "*", count=SCAN_COUNT):
+        raw_value = redis_client.get(key)
+        if raw_value is None:
+            continue
+
+        try:
+            payload = json.loads(raw_value)
+        except json.JSONDecodeError:
+            payload = {}
+
+        sessions.append(
+            {
+                "token": key[len(AUTH_KEY_PREFIX) :],
+                "sub": payload.get("sub"),
+                "status": _classify(payload),
+                "ttl_seconds": redis_client.ttl(key),
+                "expires_at": payload.get("expires_at"),
+                "impersonated_by": payload.get("impersonated_by"),
+            }
+        )
+    return sessions
+
+
+def _resolve_emails(subs: list[str]) -> dict[str, str]:
+    if not subs:
+        return {}
+
+    query = sql.SQL('SELECT id, email FROM {}."user" WHERE id::text = ANY(%s)').format(
+        sql.Identifier(_schema())
+    )
+    with _pg_connect() as conn, conn.cursor() as cur:
+        cur.execute(query, (subs,))
+        return {str(row[0]): row[1] for row in cur.fetchall()}
+
+
+def _lookup_user(email: str) -> tuple[str, str, str] | None:
+    """Returns (id, email, role), matched case-insensitively like get_user_by_email."""
+    query = sql.SQL(
+        'SELECT id, email, role FROM {}."user" WHERE lower(email) = lower(%s)'
+    ).format(sql.Identifier(_schema()))
+    with _pg_connect() as conn, conn.cursor() as cur:
+        cur.execute(query, (email,))
+        row = cur.fetchone()
+        return (str(row[0]), row[1], str(row[2])) if row else None
+
+
+def _mint(request: dict[str, Any]) -> dict[str, Any]:
+    email = str(request["email"])
+    ttl_seconds = int(request["ttl_seconds"])
+
+    found = _lookup_user(email)
+    if found is None:
+        return {"ok": False, "error": "No user found with email " + email}
+    user_id, actual_email, role = found
+
+    now = datetime.now(timezone.utc)
+    expires_at = now + timedelta(seconds=ttl_seconds)
+    # A superset of both formats. Readers before July 2026 take "sub" and ignore
+    # the rest; later ones parse the timestamps and drop the unknown marker.
+    payload = {
+        "sub": user_id,
+        "tenant_id": _schema(),
+        "issued_at": now.isoformat(),
+        "expires_at": expires_at.isoformat(),
+        "impersonated_by": request["operator"],
+    }
+
+    token = secrets.token_urlsafe()
+    # TTL matches the logical expiry exactly. Newer deployments would add an hour
+    # of grace on top; skipping it keeps the token dead on time on older ones.
+    _redis_client().set(AUTH_KEY_PREFIX + token, json.dumps(payload), ex=ttl_seconds)
+    return {
+        "ok": True,
+        "token": token,
+        "email": actual_email,
+        "user_id": user_id,
+        "role": role,
+        "expires_at": expires_at.isoformat(),
+    }
+
+
+def _list(_request: dict[str, Any]) -> dict[str, Any]:
+    sessions = _scan_sessions(_redis_client())
+    emails = _resolve_emails([s["sub"] for s in sessions if s["sub"]])
+    for session in sessions:
+        session["email"] = emails.get(session["sub"] or "", "<unknown>")
+    return {"ok": True, "sessions": sessions}
+
+
+def _revoke(request: dict[str, Any]) -> dict[str, Any]:
+    token = request.get("token")
+    include_real_sessions = bool(request.get("include_real_sessions"))
+
+    redis_client = _redis_client()
+    if token:
+        deleted = redis_client.delete(AUTH_KEY_PREFIX + str(token))
+        return {"ok": True, "deleted": int(deleted), "tokens": [token]}
+
+    email = str(request["email"])
+    found = _lookup_user(email)
+    if found is None:
+        return {"ok": False, "error": "No user found with email " + email}
+    user_id = found[0]
+
+    revoked: list[str] = []
+    for session in _scan_sessions(redis_client):
+        if session["sub"] != user_id:
+            continue
+        if not include_real_sessions and not session["impersonated_by"]:
+            continue
+        redis_client.delete(AUTH_KEY_PREFIX + session["token"])
+        revoked.append(session["token"])
+
+    return {"ok": True, "deleted": len(revoked), "tokens": revoked}
+
+
+def main() -> int:
+    request = json.loads(sys.argv[1])
+    command = request["command"]
+
+    handlers = {"mint": _mint, "list": _list, "revoke": _revoke}
+    try:
+        result = handlers[command](request)
+    except Exception as e:
+        result = {"ok": False, "error": type(e).__name__ + ": " + str(e)}
+
+    print(RESULT_SENTINEL + json.dumps(result))
+    return 0 if result.get("ok") else 1
+
+
+sys.exit(main())

--- a/tools/ods/internal/kube/kube.go
+++ b/tools/ods/internal/kube/kube.go
@@ -88,3 +88,23 @@ func (c *Cluster) ExecOnPod(pod string, command ...string) (string, error) {
 
 	return stdout.String(), nil
 }
+
+// ExecOnPodWithStdin runs a command on a pod, feeding stdin to it, and returns its
+// stdout. Used to pipe a script into an interpreter without quoting it into argv.
+func (c *Cluster) ExecOnPodWithStdin(pod string, stdin string, command ...string) (string, error) {
+	args := append(c.kubectlArgs(), "exec", "-i", pod, "--")
+	args = append(args, command...)
+	log.Debugf("Running: kubectl %s", strings.Join(args, " "))
+
+	cmd := exec.Command("kubectl", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdin = strings.NewReader(stdin)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("kubectl exec failed: %w\n%s", err, stderr.String())
+	}
+
+	return stdout.String(), nil
+}


### PR DESCRIPTION
Single tenant has no UI impersonation flow, so support access meant a manual Redis cookie procedure: read REDIS_PASSWORD out of the api-server pod, open the ElastiCache console because no pod ships redis-cli, then hand-write a token.

`ods impersonate` does this through the api-server pod, which already holds the Redis and database credentials plus network reach into the VPC. It has three subcommands: mint, list, and revoke.

The in-pod payload imports nothing from onyx. Customers run older images whose module paths differ from main, so it uses the pod's env vars with redis and psycopg2 instead. The token it writes satisfies both session formats: readers before onyx/auth/session_tokens.py (added in #13015) take "sub" and ignore the rest, later ones parse issued_at/expires_at.

Minted tokens carry an impersonated_by marker, which revoke uses to drop only tool-minted sessions and leave the customer's own logins alone. The TTL defaults to one hour rather than the seven days the manual procedure used.

Adds ExecOnPodWithStdin to the kube package, so the payload pipes into python rather than being quoted into argv.

## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ods impersonate` to mint, list, and revoke single‑tenant session tokens by running a Python payload in the api-server pod, replacing the manual ElastiCache/redis-cli process. Previously support copied Redis credentials and hand‑wrote a 7‑day token; now the tool mints a 1‑hour token by default and marks it with `impersonated_by`, with revoke targeting only tool‑minted sessions unless overridden.

- Subcommands: `mint --email <addr> [--ttl <dur>]`, `list`, and `revoke [--token <t>] [--email <addr>] [--include-real-sessions]`. Cluster selection uses `--cluster/--region` or `--context` (maps to `KUBE_CTX_*`).
- The in‑pod script uses `redis` and `psycopg2` via env vars, imports nothing from Onyx, and runs on the api‑server pod. No AWS console or `redis-cli` required.
- Minted tokens are compatible with both session formats: they include `sub` and also `issued_at`/`expires_at`; TTL in Redis matches the logical expiry exactly.
- `list` shows email, status (active/expired/terminated/malformed), remaining TTL, and `impersonated_by`.
- Adds `kube.ExecOnPodWithStdin` to feed the embedded script to `python -` during `kubectl exec`; existing `kube` APIs are unchanged.

<sup>Written for commit d24dfbc6b0775df026880fe226e40f5d92403d94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

