### PR TITLE
fix(usage): never block chat on legacy cost budget periods

### DIFF
--- a/backend/alembic/versions/f54501f1435a_normalize_legacy_cost_budget_periods.py
+++ b/backend/alembic/versions/f54501f1435a_normalize_legacy_cost_budget_periods.py
@@ -1,13 +1,11 @@
 """normalize legacy cost budget periods
 
 Cost budgets only support daily/weekly/monthly (24/168/720h) periods, but rows
-written before that restriction can hold any whole-day period. Enforcement skips
-such rows, so snap them to the nearest supported period to keep them active.
+can hold any whole-day period. Enforcement skips unsupported rows, so snap them
+to the nearest supported period to keep them active.
 
 Revision ID: f54501f1435a
 Revises: df90f43d9ab2
-Create Date: 2026-08-18 10:22:40.535792
-
 """
 
 import sqlalchemy as sa

--- a/backend/alembic/versions/f54501f1435a_normalize_legacy_cost_budget_periods.py
+++ b/backend/alembic/versions/f54501f1435a_normalize_legacy_cost_budget_periods.py
@@ -1,0 +1,56 @@
+"""normalize legacy cost budget periods
+
+Cost budgets only support daily/weekly/monthly (24/168/720h) periods, but rows
+written before that restriction can hold any whole-day period. Enforcement skips
+such rows, so snap them to the nearest supported period to keep them active.
+
+Revision ID: f54501f1435a
+Revises: df90f43d9ab2
+Create Date: 2026-08-18 10:22:40.535792
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f54501f1435a"
+down_revision = "df90f43d9ab2"
+branch_labels = None
+depends_on = None
+
+DAILY_HOURS = 24
+WEEKLY_HOURS = 168
+MONTHLY_HOURS = 720
+# Midpoints between the supported periods, so each row snaps to its nearest one.
+DAILY_WEEKLY_MIDPOINT = (DAILY_HOURS + WEEKLY_HOURS) // 2
+WEEKLY_MONTHLY_MIDPOINT = (WEEKLY_HOURS + MONTHLY_HOURS) // 2
+
+token_rate_limit_table = sa.table(
+    "token_rate_limit",
+    sa.column("period_hours", sa.Integer),
+    sa.column("cost_budget_cents", sa.Numeric),
+)
+
+
+def upgrade() -> None:
+    period = token_rate_limit_table.c.period_hours
+    op.execute(
+        sa.update(token_rate_limit_table)
+        .where(
+            token_rate_limit_table.c.cost_budget_cents.is_not(None),
+            period.not_in([DAILY_HOURS, WEEKLY_HOURS, MONTHLY_HOURS]),
+        )
+        .values(
+            period_hours=sa.case(
+                (period < DAILY_WEEKLY_MIDPOINT, DAILY_HOURS),
+                (period < WEEKLY_MONTHLY_MIDPOINT, WEEKLY_HOURS),
+                else_=MONTHLY_HOURS,
+            )
+        )
+    )
+
+
+def downgrade() -> None:
+    # Lossy normalization; the original periods cannot be restored.
+    pass

--- a/backend/alembic/versions/f54501f1435a_normalize_legacy_cost_budget_periods.py
+++ b/backend/alembic/versions/f54501f1435a_normalize_legacy_cost_budget_periods.py
@@ -50,5 +50,5 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Lossy normalization; the original periods cannot be restored.
+    # Lossy normalization. The original periods cannot be restored.
     pass

--- a/backend/alembic/versions/f54501f1435a_normalize_legacy_cost_budget_periods.py
+++ b/backend/alembic/versions/f54501f1435a_normalize_legacy_cost_budget_periods.py
@@ -2,7 +2,8 @@
 
 Cost budgets only support daily/weekly/monthly (24/168/720h) periods, but rows
 can hold any whole-day period. Enforcement skips unsupported rows, so snap them
-to the nearest supported period to keep them active.
+to the nearest supported period to keep them active. A row carrying both budgets
+shares period_hours, so its token window moves with it.
 
 Revision ID: f54501f1435a
 Revises: df90f43d9ab2
@@ -20,7 +21,7 @@ depends_on = None
 DAILY_HOURS = 24
 WEEKLY_HOURS = 168
 MONTHLY_HOURS = 720
-# Midpoints between the supported periods, so each row snaps to its nearest one.
+# Each row snaps to its nearest supported period.
 DAILY_WEEKLY_MIDPOINT = (DAILY_HOURS + WEEKLY_HOURS) // 2
 WEEKLY_MONTHLY_MIDPOINT = (WEEKLY_HOURS + MONTHLY_HOURS) // 2
 

--- a/backend/ee/onyx/server/query_and_chat/token_limit.py
+++ b/backend/ee/onyx/server/query_and_chat/token_limit.py
@@ -13,6 +13,7 @@ from onyx.db.token_limit import (
 )
 from onyx.db.user_usage import (
     TokenUsageBucket,
+    cost_budget_limits,
     get_cost_window_start,
     get_group_cost_cents_buckets_since,
     get_group_token_buckets_since,
@@ -75,13 +76,11 @@ def _user_is_rate_limited(user_id: UUID) -> None:
             token_reset = _token_budget_reset(user_rate_limits, user_usage)
 
         cost_reset: datetime | None = None
-        cost_limits = [
-            limit for limit in user_rate_limits if limit.cost_budget_cents is not None
-        ]
+        cost_limits = cost_budget_limits(user_rate_limits)
         if cost_limits:
-            cost_cutoff = get_cost_window_start(
-                datetime.now(timezone.utc),
-                max(limit.period_hours for limit in cost_limits),
+            now = datetime.now(timezone.utc)
+            cost_cutoff = min(
+                get_cost_window_start(now, limit.period_hours) for limit in cost_limits
             )
             cost_buckets = get_user_cost_cents_buckets_since(
                 db_session, str(user_id), cost_cutoff
@@ -126,13 +125,11 @@ def _user_is_rate_limited_by_group(user_id: UUID) -> None:
             )
 
         group_cost_usage: dict[int, list[tuple[datetime, float]]] = {}
-        cost_limits = [
-            limit for limit in all_rate_limits if limit.cost_budget_cents is not None
-        ]
+        cost_limits = cost_budget_limits(all_rate_limits)
         if cost_limits:
-            cost_cutoff = get_cost_window_start(
-                datetime.now(timezone.utc),
-                max(limit.period_hours for limit in cost_limits),
+            now = datetime.now(timezone.utc)
+            cost_cutoff = min(
+                get_cost_window_start(now, limit.period_hours) for limit in cost_limits
             )
             group_cost_usage = get_group_cost_cents_buckets_since(
                 db_session, user_group_ids, cost_cutoff

--- a/backend/ee/onyx/server/query_and_chat/token_limit.py
+++ b/backend/ee/onyx/server/query_and_chat/token_limit.py
@@ -13,8 +13,8 @@ from onyx.db.token_limit import (
 )
 from onyx.db.user_usage import (
     TokenUsageBucket,
+    cost_budget_fetch_cutoff,
     cost_budget_limits,
-    get_cost_window_start,
     get_group_cost_cents_buckets_since,
     get_group_token_buckets_since,
     get_user_cost_cents_buckets_since,
@@ -78,9 +78,8 @@ def _user_is_rate_limited(user_id: UUID) -> None:
         cost_reset: datetime | None = None
         cost_limits = cost_budget_limits(user_rate_limits)
         if cost_limits:
-            now = datetime.now(timezone.utc)
-            cost_cutoff = min(
-                get_cost_window_start(now, limit.period_hours) for limit in cost_limits
+            cost_cutoff = cost_budget_fetch_cutoff(
+                datetime.now(timezone.utc), cost_limits
             )
             cost_buckets = get_user_cost_cents_buckets_since(
                 db_session, str(user_id), cost_cutoff
@@ -127,9 +126,8 @@ def _user_is_rate_limited_by_group(user_id: UUID) -> None:
         group_cost_usage: dict[int, list[tuple[datetime, float]]] = {}
         cost_limits = cost_budget_limits(all_rate_limits)
         if cost_limits:
-            now = datetime.now(timezone.utc)
-            cost_cutoff = min(
-                get_cost_window_start(now, limit.period_hours) for limit in cost_limits
+            cost_cutoff = cost_budget_fetch_cutoff(
+                datetime.now(timezone.utc), cost_limits
             )
             group_cost_usage = get_group_cost_cents_buckets_since(
                 db_session, user_group_ids, cost_cutoff

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -31,6 +31,8 @@ COST_BUDGET_PERIOD_ERROR = "Cost budget periods must be whole UTC days"
 COST_BUDGET_PERIOD_HOURS = {24, 168, 720}
 _INVALID_COST_BUDGET_WARNING_TTL_SECONDS = 5 * 60
 _invalid_cost_budget_warning_lock = RLock()
+# Keyed by the raw contextvar value, not get_current_tenant_id, which raises when
+# the contextvar is unset (non-request callers). A warn path must never raise.
 _invalid_cost_budget_warning_cache: TTLCache[tuple[str | None, int, int], None] = (
     TTLCache(maxsize=10_000, ttl=_INVALID_COST_BUDGET_WARNING_TTL_SECONDS)
 )
@@ -105,6 +107,13 @@ def get_cost_window_start(now: datetime, period_hours: int) -> datetime:
     if period_hours == 168:
         return current_bucket - timedelta(days=current_bucket.weekday())
     return current_bucket.replace(day=1)
+
+
+def cost_budget_fetch_cutoff(
+    now: datetime, cost_limits: Sequence[TokenRateLimit]
+) -> datetime:
+    """Earliest window start across the limits, so one fetch covers every window."""
+    return min(get_cost_window_start(now, limit.period_hours) for limit in cost_limits)
 
 
 def get_token_window_reset(now: datetime, period_hours: int) -> datetime:

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -57,6 +57,26 @@ def _get_cost_period_seconds(period_hours: int) -> int:
     return period_seconds
 
 
+def cost_budget_limits(rate_limits: Sequence[TokenRateLimit]) -> list[TokenRateLimit]:
+    """Limits that carry an enforceable cost budget. Rows written before the
+    daily/weekly/monthly restriction can hold any whole-day period; those are
+    skipped with a warning because a bad stored row must never block requests."""
+    valid: list[TokenRateLimit] = []
+    for rate_limit in rate_limits:
+        if rate_limit.cost_budget_cents is None:
+            continue
+        if rate_limit.period_hours not in COST_BUDGET_PERIOD_HOURS:
+            logger.warning(
+                "Skipping cost budget on token_rate_limit id=%s: "
+                "unsupported period_hours=%s",
+                rate_limit.id,
+                rate_limit.period_hours,
+            )
+            continue
+        valid.append(rate_limit)
+    return valid
+
+
 def get_cost_window_start(now: datetime, period_hours: int) -> datetime:
     """Start of the current fixed UTC cost-budget period."""
     _get_cost_period_seconds(period_hours)
@@ -342,11 +362,15 @@ def get_usage_reset_window_start(
 ) -> datetime:
     """Return the earliest bucket included by any applicable limit."""
     window_starts = [get_window_start(now, USER_USAGE_BUCKET_SECONDS)]
-    for rate_limit in rate_limits:
-        if rate_limit.token_budget is not None:
-            window_starts.append(get_token_window_start(now, rate_limit.period_hours))
-        if rate_limit.cost_budget_cents is not None:
-            window_starts.append(get_cost_window_start(now, rate_limit.period_hours))
+    window_starts.extend(
+        get_token_window_start(now, rate_limit.period_hours)
+        for rate_limit in rate_limits
+        if rate_limit.token_budget is not None
+    )
+    window_starts.extend(
+        get_cost_window_start(now, rate_limit.period_hours)
+        for rate_limit in cost_budget_limits(rate_limits)
+    )
     return min(window_starts)
 
 

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -84,9 +84,7 @@ def _warn_for_invalid_cost_budget_period(rate_limit: TokenRateLimit) -> None:
 
 
 def cost_budget_limits(rate_limits: Sequence[TokenRateLimit]) -> list[TokenRateLimit]:
-    """Limits that carry an enforceable cost budget. Rows written before the
-    daily/weekly/monthly restriction can hold any whole-day period; those are
-    skipped with a warning because a bad stored row must never block requests."""
+    """Return enforceable cost limits and warn about unsupported stored periods."""
     valid: list[TokenRateLimit] = []
     for rate_limit in rate_limits:
         if rate_limit.cost_budget_cents is None:

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -7,8 +7,10 @@ from collections import defaultdict
 from collections.abc import Iterator, Sequence
 from datetime import datetime, timedelta
 from math import ceil
+from threading import RLock
 from typing import Any, cast
 
+from cachetools import TTLCache
 from pydantic import BaseModel
 from sqlalchemy import delete, func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -18,6 +20,7 @@ from sqlalchemy.orm import Session
 from onyx.db.models import TokenRateLimit, User, User__UserGroup, UserUsage
 from onyx.utils.datetime import datetime_to_utc, get_window_start
 from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
 logger = setup_logger()
 
@@ -26,6 +29,11 @@ USER_USAGE_BUCKET_HOURS = USER_USAGE_BUCKET_SECONDS // (60 * 60)
 TOKEN_BUDGET_PERIOD_ERROR = "Token budget periods must be whole UTC days"
 COST_BUDGET_PERIOD_ERROR = "Cost budget periods must be whole UTC days"
 COST_BUDGET_PERIOD_HOURS = {24, 168, 720}
+_INVALID_COST_BUDGET_WARNING_TTL_SECONDS = 5 * 60
+_invalid_cost_budget_warning_lock = RLock()
+_invalid_cost_budget_warning_cache: TTLCache[tuple[str | None, int, int], None] = (
+    TTLCache(maxsize=10_000, ttl=_INVALID_COST_BUDGET_WARNING_TTL_SECONDS)
+)
 # Not email-shaped on purpose: it can never collide with a real address.
 DELETED_USER_EXPORT_EMAIL = "(deleted user)"
 _CONFLICT_COLS = ["user_id", "window_start", "model", "flow", "provider", "incognito"]
@@ -57,6 +65,24 @@ def _get_cost_period_seconds(period_hours: int) -> int:
     return period_seconds
 
 
+def _warn_for_invalid_cost_budget_period(rate_limit: TokenRateLimit) -> None:
+    cache_key = (
+        CURRENT_TENANT_ID_CONTEXTVAR.get(),
+        rate_limit.id,
+        rate_limit.period_hours,
+    )
+    with _invalid_cost_budget_warning_lock:
+        if cache_key in _invalid_cost_budget_warning_cache:
+            return
+        _invalid_cost_budget_warning_cache[cache_key] = None
+
+    logger.warning(
+        "Skipping cost budget on token_rate_limit id=%s: unsupported period_hours=%s",
+        rate_limit.id,
+        rate_limit.period_hours,
+    )
+
+
 def cost_budget_limits(rate_limits: Sequence[TokenRateLimit]) -> list[TokenRateLimit]:
     """Limits that carry an enforceable cost budget. Rows written before the
     daily/weekly/monthly restriction can hold any whole-day period; those are
@@ -66,12 +92,7 @@ def cost_budget_limits(rate_limits: Sequence[TokenRateLimit]) -> list[TokenRateL
         if rate_limit.cost_budget_cents is None:
             continue
         if rate_limit.period_hours not in COST_BUDGET_PERIOD_HOURS:
-            logger.warning(
-                "Skipping cost budget on token_rate_limit id=%s: "
-                "unsupported period_hours=%s",
-                rate_limit.id,
-                rate_limit.period_hours,
-            )
+            _warn_for_invalid_cost_budget_period(rate_limit)
             continue
         valid.append(rate_limit)
     return valid

--- a/backend/onyx/server/features/usage/api.py
+++ b/backend/onyx/server/features/usage/api.py
@@ -25,6 +25,7 @@ from onyx.db.token_limit import (
     fetch_user_group_token_rate_limits,
 )
 from onyx.db.user_usage import (
+    cost_budget_fetch_cutoff,
     cost_budget_limits,
     get_cost_window_reset,
     get_cost_window_start,
@@ -125,9 +126,7 @@ def _user_cost_budget(db_session: Session, user_id: str) -> EffectiveCostBudget 
     user_rls = fetch_all_user_token_rate_limits(db_session, enabled_only=True)
     user_cost_rls = cost_budget_limits(user_rls)
     if user_cost_rls:
-        fetch_cutoff = min(
-            get_cost_window_start(now, rl.period_hours) for rl in user_cost_rls
-        )
+        fetch_cutoff = cost_budget_fetch_cutoff(now, user_cost_rls)
         _add_from_limits(
             user_cost_rls,
             get_user_cost_cents_buckets_since(db_session, user_id, fetch_cutoff),
@@ -136,9 +135,7 @@ def _user_cost_budget(db_session: Session, user_id: str) -> EffectiveCostBudget 
     global_rls = fetch_all_global_token_rate_limits(db_session, enabled_only=True)
     global_cost_rls = cost_budget_limits(global_rls)
     if global_cost_rls:
-        fetch_cutoff = min(
-            get_cost_window_start(now, rl.period_hours) for rl in global_cost_rls
-        )
+        fetch_cutoff = cost_budget_fetch_cutoff(now, global_cost_rls)
         _add_from_limits(
             global_cost_rls,
             get_total_cost_cents_buckets_since(db_session, fetch_cutoff),
@@ -168,21 +165,24 @@ def _group_cost_budget_candidate(
     if not group_limits:
         return None
 
-    cost_rls = cost_budget_limits([rl for rls in group_limits.values() for rl in rls])
+    cost_limits_by_group = {
+        group_id: cost_budget_limits(rls) for group_id, rls in group_limits.items()
+    }
+    cost_rls = [rl for rls in cost_limits_by_group.values() for rl in rls]
     if not cost_rls:
         return None
 
     # One batched query for every group's cost buckets, then window in Python.
-    fetch_cutoff = min(get_cost_window_start(now, rl.period_hours) for rl in cost_rls)
+    fetch_cutoff = cost_budget_fetch_cutoff(now, cost_rls)
     buckets = get_group_cost_cents_buckets_since(
         db_session, list(group_limits.keys()), fetch_cutoff
     )
 
     most_permissive: EffectiveCostBudget | None = None
-    for group_id, limits in group_limits.items():
+    for group_id, limits in cost_limits_by_group.items():
         group_buckets = buckets.get(group_id, [])
         group_binding: EffectiveCostBudget | None = None
-        for rl in cost_budget_limits(limits):
+        for rl in limits:
             if rl.cost_budget_cents is None:
                 continue
             cutoff = get_cost_window_start(now, rl.period_hours)

--- a/backend/onyx/server/features/usage/api.py
+++ b/backend/onyx/server/features/usage/api.py
@@ -25,6 +25,7 @@ from onyx.db.token_limit import (
     fetch_user_group_token_rate_limits,
 )
 from onyx.db.user_usage import (
+    cost_budget_limits,
     get_cost_window_reset,
     get_cost_window_start,
     get_group_cost_cents_buckets_since,
@@ -122,7 +123,7 @@ def _user_cost_budget(db_session: Session, user_id: str) -> EffectiveCostBudget 
             )
 
     user_rls = fetch_all_user_token_rate_limits(db_session, enabled_only=True)
-    user_cost_rls = [rl for rl in user_rls if rl.cost_budget_cents is not None]
+    user_cost_rls = cost_budget_limits(user_rls)
     if user_cost_rls:
         fetch_cutoff = min(
             get_cost_window_start(now, rl.period_hours) for rl in user_cost_rls
@@ -133,7 +134,7 @@ def _user_cost_budget(db_session: Session, user_id: str) -> EffectiveCostBudget 
         )
 
     global_rls = fetch_all_global_token_rate_limits(db_session, enabled_only=True)
-    global_cost_rls = [rl for rl in global_rls if rl.cost_budget_cents is not None]
+    global_cost_rls = cost_budget_limits(global_rls)
     if global_cost_rls:
         fetch_cutoff = min(
             get_cost_window_start(now, rl.period_hours) for rl in global_cost_rls
@@ -167,12 +168,7 @@ def _group_cost_budget_candidate(
     if not group_limits:
         return None
 
-    cost_rls = [
-        rl
-        for rls in group_limits.values()
-        for rl in rls
-        if rl.cost_budget_cents is not None
-    ]
+    cost_rls = cost_budget_limits([rl for rls in group_limits.values() for rl in rls])
     if not cost_rls:
         return None
 
@@ -186,7 +182,7 @@ def _group_cost_budget_candidate(
     for group_id, limits in group_limits.items():
         group_buckets = buckets.get(group_id, [])
         group_binding: EffectiveCostBudget | None = None
-        for rl in limits:
+        for rl in cost_budget_limits(limits):
             if rl.cost_budget_cents is None:
                 continue
             cutoff = get_cost_window_start(now, rl.period_hours)

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -15,6 +15,7 @@ from onyx.db.models import TokenRateLimit, User
 from onyx.db.token_limit import fetch_all_global_token_rate_limits
 from onyx.db.user_usage import (
     TokenUsageBucket,
+    cost_budget_fetch_cutoff,
     cost_budget_limits,
     earliest_window_reset,
     get_cost_window_reset,
@@ -86,9 +87,8 @@ def _user_is_rate_limited_by_global() -> None:
         cost_reset: datetime | None = None
         cost_limits = cost_budget_limits(global_rate_limits)
         if cost_limits:
-            now = datetime.now(timezone.utc)
-            cost_cutoff = min(
-                get_cost_window_start(now, rl.period_hours) for rl in cost_limits
+            cost_cutoff = cost_budget_fetch_cutoff(
+                datetime.now(timezone.utc), cost_limits
             )
             cost_buckets = get_total_cost_cents_buckets_since(db_session, cost_cutoff)
             cost_reset = _cost_budget_reset(global_rate_limits, cost_buckets)

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -15,6 +15,7 @@ from onyx.db.models import TokenRateLimit, User
 from onyx.db.token_limit import fetch_all_global_token_rate_limits
 from onyx.db.user_usage import (
     TokenUsageBucket,
+    cost_budget_limits,
     earliest_window_reset,
     get_cost_window_reset,
     get_cost_window_start,
@@ -83,9 +84,7 @@ def _user_is_rate_limited_by_global() -> None:
             token_reset = _token_budget_reset(global_rate_limits, global_usage)
 
         cost_reset: datetime | None = None
-        cost_limits = [
-            rl for rl in global_rate_limits if rl.cost_budget_cents is not None
-        ]
+        cost_limits = cost_budget_limits(global_rate_limits)
         if cost_limits:
             now = datetime.now(timezone.utc)
             cost_cutoff = min(
@@ -170,7 +169,7 @@ def _cost_budget_reset(
     """The latest fixed reset among the exceeded cost budgets, or None."""
     now = datetime.now(timezone.utc)
     resets: list[datetime] = []
-    for rate_limit in rate_limits:
+    for rate_limit in cost_budget_limits(rate_limits):
         budget = rate_limit.cost_budget_cents
         if budget is None:
             continue

--- a/backend/tests/unit/ee/onyx/server/query_and_chat/test_ee_cost_period_hardening.py
+++ b/backend/tests/unit/ee/onyx/server/query_and_chat/test_ee_cost_period_hardening.py
@@ -8,7 +8,6 @@ import pytest
 import ee.onyx.server.query_and_chat.token_limit as ee_token_limit
 from onyx.configs.constants import TokenRateLimitScope
 from onyx.db.models import TokenRateLimit
-from onyx.db.user_usage import get_cost_window_start
 
 
 class _SessionCtx:
@@ -17,6 +16,13 @@ class _SessionCtx:
 
     def __exit__(self, *args: object) -> None:
         return None
+
+
+@pytest.fixture(autouse=True)
+def _stub_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        ee_token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+    )
 
 
 class _FixedDatetime(datetime):
@@ -43,9 +49,6 @@ def _over_budget_buckets(*_a: object) -> list[tuple[datetime, float]]:
 
 def test_user_path_skips_legacy_period(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        ee_token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
-    )
-    monkeypatch.setattr(
         ee_token_limit,
         "fetch_all_user_token_rate_limits",
         lambda **_: [_cost_limit(period_hours=2136)],
@@ -60,9 +63,6 @@ def test_user_path_skips_legacy_period(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_group_path_skips_legacy_period(monkeypatch: pytest.MonkeyPatch) -> None:
     limit = _cost_limit(period_hours=2136)
     limit.scope = TokenRateLimitScope.USER_GROUP
-    monkeypatch.setattr(
-        ee_token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
-    )
     monkeypatch.setattr(
         ee_token_limit, "fetch_user_group_token_rate_limits", lambda *_: {1: [limit]}
     )
@@ -89,9 +89,6 @@ def test_user_path_fetch_cutoff_covers_every_window(
 
     monkeypatch.setattr(ee_token_limit, "datetime", _FixedDatetime)
     monkeypatch.setattr(
-        ee_token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
-    )
-    monkeypatch.setattr(
         ee_token_limit,
         "fetch_all_user_token_rate_limits",
         lambda **_: [weekly, monthly],
@@ -102,10 +99,7 @@ def test_user_path_fetch_cutoff_covers_every_window(
 
     ee_token_limit._user_is_rate_limited(uuid4())
 
-    now = _FixedDatetime.now(timezone.utc)
-    assert captured == [
-        min(get_cost_window_start(now, 168), get_cost_window_start(now, 720))
-    ]
+    assert captured == [datetime(2026, 7, 27, tzinfo=timezone.utc)]
 
 
 def test_group_path_fetch_cutoff_covers_every_window(
@@ -124,9 +118,6 @@ def test_group_path_fetch_cutoff_covers_every_window(
 
     monkeypatch.setattr(ee_token_limit, "datetime", _FixedDatetime)
     monkeypatch.setattr(
-        ee_token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
-    )
-    monkeypatch.setattr(
         ee_token_limit,
         "fetch_user_group_token_rate_limits",
         lambda *_: {1: [weekly, monthly]},
@@ -137,7 +128,4 @@ def test_group_path_fetch_cutoff_covers_every_window(
 
     ee_token_limit._user_is_rate_limited_by_group(uuid4())
 
-    now = _FixedDatetime.now(timezone.utc)
-    assert captured == [
-        min(get_cost_window_start(now, 168), get_cost_window_start(now, 720))
-    ]
+    assert captured == [datetime(2026, 7, 27, tzinfo=timezone.utc)]

--- a/backend/tests/unit/ee/onyx/server/query_and_chat/test_ee_cost_period_hardening.py
+++ b/backend/tests/unit/ee/onyx/server/query_and_chat/test_ee_cost_period_hardening.py
@@ -110,3 +110,38 @@ def test_user_path_fetch_cutoff_covers_every_window(
     assert captured == [
         min(get_cost_window_start(now, 168), get_cost_window_start(now, 720))
     ]
+
+
+def test_group_path_fetch_cutoff_covers_every_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    weekly, monthly = _cost_limit(period_hours=168), _cost_limit(period_hours=720)
+    weekly.scope = TokenRateLimitScope.USER_GROUP
+    monthly.scope = TokenRateLimitScope.USER_GROUP
+    captured: list[datetime] = []
+
+    def _capture_cutoff(
+        _db: object, _group_ids: object, cutoff: datetime
+    ) -> dict[int, list[tuple[datetime, float]]]:
+        captured.append(cutoff)
+        return {}
+
+    monkeypatch.setattr(ee_token_limit, "datetime", _FixedDatetime)
+    monkeypatch.setattr(
+        ee_token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+    )
+    monkeypatch.setattr(
+        ee_token_limit,
+        "fetch_user_group_token_rate_limits",
+        lambda *_: {1: [weekly, monthly]},
+    )
+    monkeypatch.setattr(
+        ee_token_limit, "get_group_cost_cents_buckets_since", _capture_cutoff
+    )
+
+    ee_token_limit._user_is_rate_limited_by_group(uuid4())
+
+    now = _FixedDatetime.now(timezone.utc)
+    assert captured == [
+        min(get_cost_window_start(now, 168), get_cost_window_start(now, 720))
+    ]

--- a/backend/tests/unit/ee/onyx/server/query_and_chat/test_ee_cost_period_hardening.py
+++ b/backend/tests/unit/ee/onyx/server/query_and_chat/test_ee_cost_period_hardening.py
@@ -1,6 +1,4 @@
-"""EE user/group cost-budget paths: legacy stored periods (any whole-day value,
-possible on rows written before the daily/weekly/monthly restriction) must be
-skipped, and the usage fetch cutoff must cover every valid limit's window."""
+"""EE cost-budget paths skip unsupported periods and fetch every valid window."""
 
 from datetime import datetime, timezone, tzinfo
 from uuid import uuid4
@@ -22,8 +20,7 @@ class _SessionCtx:
 
 
 class _FixedDatetime(datetime):
-    """2026-08-01 is a Saturday: the weekly window (Mon 07-27) starts before the
-    monthly window (08-01), so a max-period cutoff would under-fetch weekly usage."""
+    """The fixed month starts on Saturday, after the weekly window starts."""
 
     @classmethod
     def now(cls, tz: tzinfo | None = None) -> "_FixedDatetime":

--- a/backend/tests/unit/ee/onyx/server/query_and_chat/test_ee_cost_period_hardening.py
+++ b/backend/tests/unit/ee/onyx/server/query_and_chat/test_ee_cost_period_hardening.py
@@ -2,8 +2,7 @@
 possible on rows written before the daily/weekly/monthly restriction) must be
 skipped, and the usage fetch cutoff must cover every valid limit's window."""
 
-from datetime import datetime, timezone
-from typing import Any
+from datetime import datetime, timezone, tzinfo
 from uuid import uuid4
 
 import pytest
@@ -27,7 +26,7 @@ class _FixedDatetime(datetime):
     monthly window (08-01), so a max-period cutoff would under-fetch weekly usage."""
 
     @classmethod
-    def now(cls, tz: Any = None) -> "_FixedDatetime":
+    def now(cls, tz: tzinfo | None = None) -> "_FixedDatetime":
         return cls(2026, 8, 1, 12, tzinfo=tz or timezone.utc)
 
 

--- a/backend/tests/unit/ee/onyx/server/query_and_chat/test_ee_cost_period_hardening.py
+++ b/backend/tests/unit/ee/onyx/server/query_and_chat/test_ee_cost_period_hardening.py
@@ -1,0 +1,112 @@
+"""EE user/group cost-budget paths: legacy stored periods (any whole-day value,
+possible on rows written before the daily/weekly/monthly restriction) must be
+skipped, and the usage fetch cutoff must cover every valid limit's window."""
+
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+import ee.onyx.server.query_and_chat.token_limit as ee_token_limit
+from onyx.configs.constants import TokenRateLimitScope
+from onyx.db.models import TokenRateLimit
+from onyx.db.user_usage import get_cost_window_start
+
+
+class _SessionCtx:
+    def __enter__(self) -> object:
+        return object()
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+class _FixedDatetime(datetime):
+    """2026-08-01 is a Saturday: the weekly window (Mon 07-27) starts before the
+    monthly window (08-01), so a max-period cutoff would under-fetch weekly usage."""
+
+    @classmethod
+    def now(cls, tz: Any = None) -> "_FixedDatetime":
+        return cls(2026, 8, 1, 12, tzinfo=tz or timezone.utc)
+
+
+def _cost_limit(period_hours: int, cost_budget_cents: float = 100.0) -> TokenRateLimit:
+    return TokenRateLimit(
+        enabled=True,
+        token_budget=None,
+        cost_budget_cents=cost_budget_cents,
+        period_hours=period_hours,
+        scope=TokenRateLimitScope.USER,
+    )
+
+
+def _over_budget_buckets(*_a: object) -> list[tuple[datetime, float]]:
+    return [(datetime.now(timezone.utc), 10.0**9)]
+
+
+def test_user_path_skips_legacy_period(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        ee_token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+    )
+    monkeypatch.setattr(
+        ee_token_limit,
+        "fetch_all_user_token_rate_limits",
+        lambda **_: [_cost_limit(period_hours=2136)],
+    )
+    monkeypatch.setattr(
+        ee_token_limit, "get_user_cost_cents_buckets_since", _over_budget_buckets
+    )
+
+    ee_token_limit._user_is_rate_limited(uuid4())  # skipped, no raise
+
+
+def test_group_path_skips_legacy_period(monkeypatch: pytest.MonkeyPatch) -> None:
+    limit = _cost_limit(period_hours=2136)
+    limit.scope = TokenRateLimitScope.USER_GROUP
+    monkeypatch.setattr(
+        ee_token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+    )
+    monkeypatch.setattr(
+        ee_token_limit, "fetch_user_group_token_rate_limits", lambda *_: {1: [limit]}
+    )
+    monkeypatch.setattr(
+        ee_token_limit,
+        "get_group_cost_cents_buckets_since",
+        lambda *_: {1: _over_budget_buckets()},
+    )
+
+    ee_token_limit._user_is_rate_limited_by_group(uuid4())  # skipped, no raise
+
+
+def test_user_path_fetch_cutoff_covers_every_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    weekly, monthly = _cost_limit(period_hours=168), _cost_limit(period_hours=720)
+    captured: list[datetime] = []
+
+    def _capture_cutoff(
+        _db: object, _user: object, cutoff: datetime
+    ) -> list[tuple[datetime, float]]:
+        captured.append(cutoff)
+        return []
+
+    monkeypatch.setattr(ee_token_limit, "datetime", _FixedDatetime)
+    monkeypatch.setattr(
+        ee_token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+    )
+    monkeypatch.setattr(
+        ee_token_limit,
+        "fetch_all_user_token_rate_limits",
+        lambda **_: [weekly, monthly],
+    )
+    monkeypatch.setattr(
+        ee_token_limit, "get_user_cost_cents_buckets_since", _capture_cutoff
+    )
+
+    ee_token_limit._user_is_rate_limited(uuid4())
+
+    now = _FixedDatetime.now(timezone.utc)
+    assert captured == [
+        min(get_cost_window_start(now, 168), get_cost_window_start(now, 720))
+    ]

--- a/backend/tests/unit/onyx/db/test_user_usage.py
+++ b/backend/tests/unit/onyx/db/test_user_usage.py
@@ -5,6 +5,7 @@ session like tenant usage. Read-path helpers still run against in-memory SQLite
 seeded with ORM inserts."""
 
 import datetime
+import logging
 import sqlite3
 from collections.abc import Generator
 from typing import cast
@@ -25,6 +26,7 @@ from onyx.db.user_usage import (
     DELETED_USER_EXPORT_EMAIL,
     TokenUsageBucket,
     UserUsageByDay,
+    cost_budget_limits,
     get_cost_window_start,
     get_group_cost_cents_since,
     get_group_token_buckets_since,
@@ -586,3 +588,29 @@ def test_usage_reset_window_start_skips_legacy_cost_period() -> None:
     assert get_usage_reset_window_start(now, [legacy]) == datetime.datetime(
         2026, 8, 12, tzinfo=datetime.timezone.utc
     )
+
+
+def test_invalid_cost_period_warning_is_rate_limited(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from onyx.configs.constants import TokenRateLimitScope
+
+    legacy = TokenRateLimit(
+        id=2_136_000_001,
+        enabled=True,
+        token_budget=None,
+        cost_budget_cents=100.0,
+        period_hours=2136,
+        scope=TokenRateLimitScope.GLOBAL,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        assert cost_budget_limits([legacy]) == []
+        assert cost_budget_limits([legacy]) == []
+
+    warnings = [
+        record
+        for record in caplog.records
+        if "Skipping cost budget" in record.getMessage()
+    ]
+    assert len(warnings) == 1

--- a/backend/tests/unit/onyx/db/test_user_usage.py
+++ b/backend/tests/unit/onyx/db/test_user_usage.py
@@ -572,9 +572,7 @@ class TestGroupCostSince:
 
 
 def test_usage_reset_window_start_skips_legacy_cost_period() -> None:
-    """A stored cost period outside the supported calendar set (possible on rows
-    written before the daily/weekly/monthly restriction) must not fail the reset
-    window computation — the cost window is simply not widened by that row."""
+    """An unsupported stored cost period does not widen the reset window."""
     from onyx.configs.constants import TokenRateLimitScope
 
     now = datetime.datetime(2026, 8, 12, 15, tzinfo=datetime.timezone.utc)

--- a/backend/tests/unit/onyx/db/test_user_usage.py
+++ b/backend/tests/unit/onyx/db/test_user_usage.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
+from cachetools import TTLCache
 from sqlalchemy import Table, create_engine, event, text
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
@@ -21,7 +22,13 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Session, sessionmaker
 
-from onyx.db.models import TokenRateLimit, User__UserGroup, UserUsage
+import onyx.db.user_usage as user_usage_module
+from onyx.db.models import (
+    TokenRateLimit,
+    TokenRateLimitScope,
+    User__UserGroup,
+    UserUsage,
+)
 from onyx.db.user_usage import (
     DELETED_USER_EXPORT_EMAIL,
     TokenUsageBucket,
@@ -572,9 +579,7 @@ class TestGroupCostSince:
 
 
 def test_usage_reset_window_start_skips_legacy_cost_period() -> None:
-    """An unsupported stored cost period does not widen the reset window."""
-    from onyx.configs.constants import TokenRateLimitScope
-
+    """An unsupported stored cost period is skipped instead of raising."""
     now = datetime.datetime(2026, 8, 12, 15, tzinfo=datetime.timezone.utc)
     legacy = TokenRateLimit(
         enabled=True,
@@ -589,12 +594,15 @@ def test_usage_reset_window_start_skips_legacy_cost_period() -> None:
 
 
 def test_invalid_cost_period_warning_is_rate_limited(
-    caplog: pytest.LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from onyx.configs.constants import TokenRateLimitScope
-
+    monkeypatch.setattr(
+        user_usage_module,
+        "_invalid_cost_budget_warning_cache",
+        TTLCache(maxsize=10, ttl=300),
+    )
     legacy = TokenRateLimit(
-        id=2_136_000_001,
+        id=1,
         enabled=True,
         token_budget=None,
         cost_budget_cents=100.0,

--- a/backend/tests/unit/onyx/db/test_user_usage.py
+++ b/backend/tests/unit/onyx/db/test_user_usage.py
@@ -20,7 +20,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Session, sessionmaker
 
-from onyx.db.models import User__UserGroup, UserUsage
+from onyx.db.models import TokenRateLimit, User__UserGroup, UserUsage
 from onyx.db.user_usage import (
     DELETED_USER_EXPORT_EMAIL,
     TokenUsageBucket,
@@ -33,6 +33,7 @@ from onyx.db.user_usage import (
     get_total_cost_cents_since,
     get_total_token_buckets_since,
     get_usage_export,
+    get_usage_reset_window_start,
     get_user_cost_cents_buckets_since,
     get_user_cost_cents_in_window,
     get_user_cost_cents_since,
@@ -566,3 +567,22 @@ class TestGroupCostSince:
         assert get_group_token_buckets_since(session, [10], window) == {
             10: [TokenUsageBucket(window_start=window, tokens=125)]
         }
+
+
+def test_usage_reset_window_start_skips_legacy_cost_period() -> None:
+    """A stored cost period outside the supported calendar set (possible on rows
+    written before the daily/weekly/monthly restriction) must not fail the reset
+    window computation — the cost window is simply not widened by that row."""
+    from onyx.configs.constants import TokenRateLimitScope
+
+    now = datetime.datetime(2026, 8, 12, 15, tzinfo=datetime.timezone.utc)
+    legacy = TokenRateLimit(
+        enabled=True,
+        token_budget=None,
+        cost_budget_cents=100.0,
+        period_hours=2136,
+        scope=TokenRateLimitScope.GLOBAL,
+    )
+    assert get_usage_reset_window_start(now, [legacy]) == datetime.datetime(
+        2026, 8, 12, tzinfo=datetime.timezone.utc
+    )

--- a/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
@@ -637,9 +637,7 @@ def test_budget_reflects_group_cost_limit(
 def test_budget_ignores_legacy_cost_period(
     db_session: Session, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A stored cost period outside the supported calendar set (possible on rows
-    written before the daily/weekly/monthly restriction) must not fail the
-    endpoint — the row is excluded from the effective budget."""
+    """The usage endpoint excludes an unsupported stored cost period."""
     from onyx.db.models import TokenRateLimitScope
 
     caller = str(uuid4())

--- a/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
@@ -24,6 +24,7 @@ from onyx.db.models import (
     ModelCostOverride,
     TokenRateLimit,
     TokenRateLimit__UserGroup,
+    TokenRateLimitScope,
     User__UserGroup,
     UserUsage,
 )
@@ -507,7 +508,6 @@ class TestGetModelPricePerMillion:
 def test_budget_reflects_user_cost_limit(
     db_session: Session, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from onyx.db.models import TokenRateLimitScope
 
     caller = str(uuid4())
     _seed_current_window(db_session, caller)  # records 1.25c of cost
@@ -538,7 +538,6 @@ def test_budget_reflects_user_cost_limit(
 def test_budget_reflects_global_cost_limit(
     db_session: Session, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from onyx.db.models import TokenRateLimitScope
 
     caller = str(uuid4())
     other = str(uuid4())
@@ -607,7 +606,6 @@ def test_available_model_prices_lists_priced_models(
 def test_budget_reflects_group_cost_limit(
     db_session: Session, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from onyx.db.models import TokenRateLimitScope
 
     caller = str(uuid4())
     _seed_current_window(db_session, caller)  # records 1.25c of cost
@@ -638,7 +636,6 @@ def test_budget_ignores_legacy_cost_period(
     db_session: Session, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The usage endpoint excludes an unsupported stored cost period."""
-    from onyx.db.models import TokenRateLimitScope
 
     caller = str(uuid4())
     _seed_current_window(db_session, caller)

--- a/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
@@ -632,3 +632,32 @@ def test_budget_reflects_group_cost_limit(
     )
     assert body["budget_cents"] == pytest.approx(100.0)
     assert body["budget_remaining_cents"] == pytest.approx(98.75)  # 100 - 1.25
+
+
+def test_budget_ignores_legacy_cost_period(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stored cost period outside the supported calendar set (possible on rows
+    written before the daily/weekly/monthly restriction) must not fail the
+    endpoint — the row is excluded from the effective budget."""
+    from onyx.db.models import TokenRateLimitScope
+
+    caller = str(uuid4())
+    _seed_current_window(db_session, caller)
+    db_session.add(
+        TokenRateLimit(
+            enabled=True,
+            token_budget=None,
+            cost_budget_cents=100.0,
+            period_hours=2136,
+            scope=TokenRateLimitScope.USER,
+        )
+    )
+    db_session.commit()
+    monkeypatch.setattr(
+        "onyx.server.features.usage.api.fetch_default_llm_model", lambda _db: None
+    )
+
+    resp = TestClient(_make_app(db_session, _StubUser(caller))).get("/user/usage")
+    assert resp.status_code == 200
+    assert resp.json()["budget_cents"] is None

--- a/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
@@ -605,8 +605,7 @@ class TestTokenRateLimitArgsValidation:
 
 
 class TestLegacyCostPeriodHardening:
-    """Rows written before the daily/weekly/monthly restriction can hold any
-    whole-day period. Enforcement must skip them, never fail the chat gate."""
+    """Unsupported stored cost periods do not fail the chat gate."""
 
     def _patch_global(
         self,

--- a/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
@@ -602,3 +602,60 @@ class TestTokenRateLimitArgsValidation:
 
         args = TokenRateLimitArgs(enabled=True, token_budget=1000, period_hours=24)
         assert args.token_budget == 1000 and args.cost_budget_cents is None
+
+
+class TestLegacyCostPeriodHardening:
+    """Rows written before the daily/weekly/monthly restriction can hold any
+    whole-day period. Enforcement must skip them, never fail the chat gate."""
+
+    def _patch_global(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        limits: list[TokenRateLimit],
+        cost_total: float,
+    ) -> None:
+        monkeypatch.setattr(
+            token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+        )
+        monkeypatch.setattr(
+            token_limit, "fetch_all_global_token_rate_limits", lambda **_: limits
+        )
+        monkeypatch.setattr(
+            token_limit,
+            "get_total_cost_cents_buckets_since",
+            lambda *_: _recent_cost_buckets(cost_total),
+        )
+
+    def test_legacy_period_row_never_blocks(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        legacy = _cost_limit(
+            500.0, TokenRateLimitScope.GLOBAL, period_hours=2136, token_budget=None
+        )
+        self._patch_global(monkeypatch, [legacy], 600.0)
+
+        token_limit._user_is_rate_limited_by_global()  # skipped, no raise
+
+    def test_valid_limit_enforced_alongside_legacy_row(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        legacy = _cost_limit(
+            10**9, TokenRateLimitScope.GLOBAL, period_hours=2136, token_budget=None
+        )
+        valid = _cost_limit(
+            500.0, TokenRateLimitScope.GLOBAL, period_hours=24, token_budget=None
+        )
+        self._patch_global(monkeypatch, [legacy, valid], 600.0)
+
+        with pytest.raises(OnyxError) as ei:
+            token_limit._user_is_rate_limited_by_global()
+        _assert_cost_reset(ei.value, TokenRateLimitScope.GLOBAL)
+
+    def test_cost_budget_reset_skips_legacy_period(self) -> None:
+        legacy = _cost_limit(
+            100.0, TokenRateLimitScope.USER, period_hours=2136, token_budget=None
+        )
+        assert (
+            token_limit._cost_budget_reset([legacy], _recent_cost_buckets(10**9))
+            is None
+        )


### PR DESCRIPTION
## Description

Cost budgets only accept daily/weekly/monthly periods (24/168/720h) since #13922, but rows written before that restriction can hold any whole-day period. The enforcement path raised `ValueError("Cost budget periods must be daily, weekly, or monthly")` on such rows. The global handler turned that into a 400 on every `send-chat-message`, a total chat outage for the tenant (hit in cloud on 8/17).

Fix:

- `cost_budget_limits()` filters cost limits to supported periods at every enforcement and display site. An invalid stored row is skipped with a warning instead of failing the request.
- New migration snaps legacy cost-budget periods to the nearest supported period, so those limits stay active instead of being skipped.
- The EE user/group paths fetched cost buckets from `get_cost_window_start(max(period_hours))`. With fixed calendar windows, a monthly window can start after a weekly one, which under-fetched weekly usage. They now use the earliest window start across limits, matching the global path.

## How Has This Been Tested?

- New unit tests reproduce the outage (global, EE user, EE group, usage API, reset window). All fail on the old code and pass now.
- `pytest` on the four affected unit test files: 79 passed.
- `ruff format --check`, `ty check`: clean.
- Migration UPDATE semantics verified against a scratch database (2136h to 720, 48h to 24, 300h to 168, valid and token-only rows untouched).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
