### PR TITLE
fix(auth): bind the tenant when sending a verification email

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1,3 +1,4 @@
+import contextvars
 import hashlib
 import os
 import random
@@ -1409,23 +1410,39 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         # marks the account verified, and the log stream is a wider audience
         # than the intended email channel.
         logger.notice("Verification requested for user %s", user.id)
-        user_count = await get_user_count()
+
+        # This endpoint is unauthenticated, so the request resolves to the
+        # default schema. On multi-tenant that schema owns neither the user rows
+        # nor the branding the email is built from, and the audit event reads
+        # the tenant off the contextvar, so bind the address's own workspace.
+        tenant_id: str = fetch_ee_implementation_or_noop(
+            "onyx.db.user_tenant_mapping",
+            "get_tenant_id_for_email",
+            POSTGRES_DEFAULT_SCHEMA,
+        )(user.email)
+        contextvar_token: contextvars.Token[str | None] = (
+            CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
+        )
         try:
+            user_count = await get_user_count()
             send_user_verification_email(
                 user.email, token, new_organization=user_count == 1
             )
+            emit_audit_event(
+                AuditAction.EMAIL_VERIFY,
+                AuditOutcome.SUCCESS,
+                actor=AuditActor(user_id=str(user.id), email=user.email),
+            )
         except Exception as e:
-            logger.error("Failed to send verification email to %s: %s", user.email, e)
+            # The count, the branding lookup and the SMTP call all land here,
+            # so on-call needs the traceback to tell which one broke.
+            logger.exception("Failed to send verification email to %s", user.email)
             raise OnyxError(
                 OnyxErrorCode.SERVICE_UNAVAILABLE,
                 "Failed to send the verification email.",
             ) from e
-
-        emit_audit_event(
-            AuditAction.EMAIL_VERIFY,
-            AuditOutcome.SUCCESS,
-            actor=AuditActor(user_id=str(user.id), email=user.email),
-        )
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(contextvar_token)
 
     @log_function_time(print_only=True)
     async def authenticate(

--- a/backend/tests/unit/onyx/auth/test_verification_email_tenant_context.py
+++ b/backend/tests/unit/onyx/auth/test_verification_email_tenant_context.py
@@ -1,0 +1,89 @@
+"""Unit tests for tenant binding in UserManager.on_after_request_verify.
+
+The hook serves an unauthenticated request, so it names the workspace itself.
+Everything it touches (the user count, the branding the email body is built
+from, the audit event) is per-tenant, and the binding is undone even when the
+send fails.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from onyx.auth.users import UserManager
+from onyx.error_handling.exceptions import OnyxError
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
+TENANT_ID = "tenant_0d1c9d5e"
+
+
+@pytest.mark.asyncio
+@patch("onyx.auth.users.emit_audit_event")
+@patch("onyx.auth.users.send_user_verification_email")
+@patch("onyx.auth.users.get_user_count", new_callable=AsyncMock)
+@patch("onyx.auth.users.fetch_ee_implementation_or_noop")
+@patch("onyx.auth.users.get_security_settings")
+@patch("onyx.auth.users.verify_email_domain")
+@patch("onyx.auth.users.EMAIL_CONFIGURED", True)
+async def test_on_after_request_verify_binds_address_owner_tenant(
+    _mock_verify_domain: MagicMock,
+    mock_settings: MagicMock,
+    mock_fetch: MagicMock,
+    mock_count: AsyncMock,
+    mock_send: MagicMock,
+    mock_audit: MagicMock,
+) -> None:
+    mock_settings.return_value = MagicMock(valid_email_domains=[])
+    mock_fetch.return_value = lambda _email: TENANT_ID
+    seen: list[str | None] = []
+
+    def record(*_args: object, **_kwargs: object) -> int:
+        seen.append(CURRENT_TENANT_ID_CONTEXTVAR.get())
+        return 1
+
+    mock_count.side_effect = record
+    mock_send.side_effect = record
+    mock_audit.side_effect = record
+    manager = UserManager(MagicMock())
+
+    await manager.on_after_request_verify(
+        MagicMock(id="u-1", email="user@example.com"), token="tok", request=None
+    )
+
+    assert seen == [TENANT_ID, TENANT_ID, TENANT_ID]
+    # Single-tenant resolves through the same call, so pin the noop default.
+    mock_fetch.assert_called_once_with(
+        "onyx.db.user_tenant_mapping",
+        "get_tenant_id_for_email",
+        POSTGRES_DEFAULT_SCHEMA,
+    )
+
+
+@pytest.mark.asyncio
+@patch("onyx.auth.users.send_user_verification_email")
+@patch("onyx.auth.users.get_user_count", new_callable=AsyncMock)
+@patch("onyx.auth.users.fetch_ee_implementation_or_noop")
+@patch("onyx.auth.users.get_security_settings")
+@patch("onyx.auth.users.verify_email_domain")
+@patch("onyx.auth.users.EMAIL_CONFIGURED", True)
+async def test_on_after_request_verify_resets_tenant_after_send_failure(
+    _mock_verify_domain: MagicMock,
+    mock_settings: MagicMock,
+    mock_fetch: MagicMock,
+    mock_count: AsyncMock,
+    mock_send: MagicMock,
+) -> None:
+    mock_settings.return_value = MagicMock(valid_email_domains=[])
+    mock_fetch.return_value = lambda _email: TENANT_ID
+    mock_count.return_value = 1
+    mock_send.side_effect = RuntimeError("smtp down")
+    manager = UserManager(MagicMock())
+    before: str | None = CURRENT_TENANT_ID_CONTEXTVAR.get()
+
+    with pytest.raises(OnyxError):
+        await manager.on_after_request_verify(
+            MagicMock(id="u-1", email="user@example.com"), token="tok", request=None
+        )
+
+    assert CURRENT_TENANT_ID_CONTEXTVAR.get() == before


### PR DESCRIPTION
## Description

**Bug.** `POST /auth/request-verify-token` returns 500 and sends no verification email. On cloud that hit 205 of 387 requests over 8 days, a flat 47-65% every day back to 07-29 (Loki retention). 538 distinct users hit it, 168 of whom never got a single successful send in the window.

**Why.** The endpoint is unauthenticated, so `tenant_tracking` resolves it to the default schema by design, and `on_after_request_verify` ran there. On multi-tenant that schema holds only catalog tables. There is no `user` table, so `get_user_count()` raised `UndefinedTableError` before the send was attempted. The send is no safer: the email body reads the application name through `get_kv_store()`, which the default schema also lacks. `get_security_settings` documents this same hazard and guards it, the enterprise settings store does not.

**Fix.** Resolve the workspace from the address and bind `CURRENT_TENANT_ID_CONTEXTVAR` for the whole hook, matching `on_after_register` and `authenticate`. The audit event moves inside the binding so it stops recording `tenant_id: public`.

Introduced in #4351, which added the `get_user_count()` call for the `first_user=true` link param.

Accepted: this repeats the `get_tenant_id_for_email` lookup `get_by_email` already did, as `authenticate` also does. Avoiding it means overriding `request_verify`.

## How Has This Been Tested?

Two unit tests in `test_verification_email_tenant_context.py`. The first asserts the count, the send and the audit event all observe the tenant. Stashing the fix makes it fail, with the audit line recording `"tenant_id": "public"`. The second asserts the contextvar is restored when the send raises.

`backend/tests/unit/onyx/auth/` 390 passed, 1 skipped. `ty check` clean project-wide, `ruff format --check` clean, pre-commit clean on both files.

Not yet exercised against live cloud. The production evidence above is read-only Loki and Postgres inspection of the failure, not of the fix.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
