### PR TITLE
fix(mcp): extend OAuth authorization window

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -126,9 +126,9 @@ from onyx.server.features.mcp.models import (
     merge_mcp_headers,
 )
 from onyx.server.features.mcp.oauth import (
-    OAUTH_WAIT_SECONDS,
+    OAUTH_OPERATION_TIMEOUT_SECONDS,
+    OAUTH_USER_AUTHORIZATION_TIMEOUT_SECONDS,
     REQUESTED_SCOPE,
-    STATE_TTL_SECONDS,
     UNUSED_RETURN_PATH,
     MCPOauthState,
     _absolute_token_expiry,
@@ -878,7 +878,7 @@ async def _connect_oauth(
         redis_client.set(
             state_key,
             state_obj.model_dump_json(),
-            ex=STATE_TTL_SECONDS,
+            ex=OAUTH_USER_AUTHORIZATION_TIMEOUT_SECONDS,
         )
 
         oauth_url = build_oauth_authorization_url(
@@ -1062,7 +1062,7 @@ async def process_oauth_callback(
 
     # Unblock the callback_handler in the asyncio background task
     r.rpush(key_code(user_id, state), json.dumps({"code": code, "state": state}))
-    r.expire(key_code(user_id, state), OAUTH_WAIT_SECONDS)
+    r.expire(key_code(user_id, state), OAUTH_OPERATION_TIMEOUT_SECONDS)
 
     admin_config = mcp_server.admin_connection_config
     if admin_config is None:
@@ -1077,7 +1077,10 @@ async def process_oauth_callback(
     loop = asyncio.get_running_loop()
     tokens_raw = await loop.run_in_executor(
         None,
-        lambda: r.blpop([key_tokens(str(admin_config_id))], timeout=OAUTH_WAIT_SECONDS),
+        lambda: r.blpop(
+            [key_tokens(str(admin_config_id))],
+            timeout=OAUTH_OPERATION_TIMEOUT_SECONDS,
+        ),
     )
     if tokens_raw is None:
         raise HTTPException(status_code=400, detail="No tokens found")

--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -29,6 +29,9 @@ from mcp.shared.auth import (
     OAuthToken,
 )
 from pydantic import AnyUrl, BaseModel, ValidationError
+from redis.exceptions import BusyLoadingError
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import TimeoutError as RedisTimeoutError
 from sqlalchemy.orm import Session
 
 from onyx.auth.oauth_token_manager import ensure_offline_access_auth_params
@@ -961,10 +964,23 @@ def make_oauth_provider(
             OAUTH_USER_AUTHORIZATION_TIMEOUT_SECONDS
         )
         code_payload_raw: bytes | None = None
+        redis_error_active = False
         while code_payload_raw is None:
-            code_payload_raw = await cast(
-                Awaitable[bytes | None], async_redis.lpop(tenant_key)
-            )
+            try:
+                code_payload_raw = await cast(
+                    Awaitable[bytes | None], async_redis.lpop(tenant_key)
+                )
+            except (BusyLoadingError, RedisConnectionError, RedisTimeoutError) as e:
+                if not redis_error_active:
+                    logger.warning(
+                        "Transient Redis error while waiting for MCP OAuth callback",
+                        exc_info=e,
+                    )
+                redis_error_active = True
+            else:
+                if redis_error_active:
+                    logger.info("Redis recovered while waiting for MCP OAuth callback")
+                redis_error_active = False
             remaining_seconds = deadline - asyncio.get_running_loop().time()
             if code_payload_raw is None and remaining_seconds <= 0:
                 break

--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -87,8 +87,10 @@ _REFRESH_LOCK_WAIT_S = _REFRESH_POST_TIMEOUT_S + 5.0
 _REFRESH_LOCK_LEASE_S = 60.0
 
 
-STATE_TTL_SECONDS = 60 * 5  # 5 minutes
-OAUTH_WAIT_SECONDS = 30  # Give the user 30 seconds to complete the OAuth flow
+# Machine-to-machine OAuth work should fail promptly, while the browser flow
+# must leave enough time for sign-in, consent, and MFA.
+OAUTH_OPERATION_TIMEOUT_SECONDS = 30
+OAUTH_USER_AUTHORIZATION_TIMEOUT_SECONDS = 10 * 60
 UNUSED_RETURN_PATH = "unused_path"
 
 
@@ -153,7 +155,7 @@ async def _run_until_oauth_redirect(
         # Wait until the SDK either produces a consent URL or completes without
         # one because the connection is already authenticated. Bound the wait in
         # case the MCP server does neither.
-        async with asyncio.timeout(OAUTH_WAIT_SECONDS):
+        async with asyncio.timeout(OAUTH_OPERATION_TIMEOUT_SECONDS):
             done, _ = await asyncio.wait(
                 [operation_task, redirect_future],
                 return_when=asyncio.FIRST_COMPLETED,
@@ -681,7 +683,10 @@ class OnyxTokenStorage(TokenStorage):
         if self.alt_config_id:
             r = get_redis_client()
             r.rpush(key_tokens(str(self.alt_config_id)), tokens.model_dump_json())
-            r.expire(key_tokens(str(self.alt_config_id)), OAUTH_WAIT_SECONDS)
+            r.expire(
+                key_tokens(str(self.alt_config_id)),
+                OAUTH_OPERATION_TIMEOUT_SECONDS,
+            )
 
     async def discard_persisted_tokens(
         self, redeemed_refresh_token: str | None
@@ -926,7 +931,11 @@ def make_oauth_provider(
             is_admin=admin_config_id is not None,
             state=state,
         )
-        r.set(key_state(user_id), state_obj.model_dump_json(), ex=STATE_TTL_SECONDS)
+        r.set(
+            key_state(user_id),
+            state_obj.model_dump_json(),
+            ex=OAUTH_USER_AUTHORIZATION_TIMEOUT_SECONDS,
+        )
         if authorization_url_callback is None:
             raise RuntimeError("OAuth authorization URL callback is not configured")
         await authorization_url_callback(auth_url)
@@ -942,11 +951,12 @@ def make_oauth_provider(
         # Block on Redis for (code, state). BLPOP returns (key, value).
         key = key_code(user_id, state_obj.state)
 
-        # requests CAN block here for up to a minute if the user doesn't resolve the OAuth flow
-        # Run the blocking blpop operation in a thread pool to avoid blocking the event loop
+        # Run the blocking operation in a thread pool so the user can complete
+        # sign-in, consent, and MFA without blocking the event loop.
         loop = asyncio.get_running_loop()
         pop = await loop.run_in_executor(
-            None, lambda: r.blpop([key], timeout=OAUTH_WAIT_SECONDS)
+            None,
+            lambda: r.blpop([key], timeout=OAUTH_USER_AUTHORIZATION_TIMEOUT_SECONDS),
         )
         # TODO(evan): gracefully handle "user says no"
         if not pop:

--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 import time
 from collections.abc import Awaitable, Callable
-from typing import Any, TypedDict
+from typing import Any, TypedDict, cast
 from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 
@@ -43,7 +43,7 @@ from onyx.db.mcp import (
 from onyx.db.models import MCPConnectionConfig, MCPServer
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.redis.redis_pool import get_redis_client
+from onyx.redis.redis_pool import get_async_redis_connection, get_redis_client
 from onyx.server.features.mcp.client import initialize_mcp_client
 from onyx.server.features.mcp.client_metadata import (
     mcp_oauth_redirect_uri,
@@ -90,7 +90,8 @@ _REFRESH_LOCK_LEASE_S = 60.0
 # Machine-to-machine OAuth work should fail promptly, while the browser flow
 # must leave enough time for sign-in, consent, and MFA.
 OAUTH_OPERATION_TIMEOUT_SECONDS = 30
-OAUTH_USER_AUTHORIZATION_TIMEOUT_SECONDS = 10 * 60
+OAUTH_USER_AUTHORIZATION_TIMEOUT_SECONDS = 5 * 60
+OAUTH_CALLBACK_POLL_INTERVAL_SECONDS = 1.0
 UNUSED_RETURN_PATH = "unused_path"
 
 
@@ -942,27 +943,40 @@ def make_oauth_provider(
 
     async def callback_handler() -> tuple[str, str | None]:
         r = get_redis_client()
-        # Wait up to TTL for the code published by the /oauth/callback route
-        state = r.get(key_state(user_id))
-        if not state:
+        # Wait up to TTL for the code published by the /oauth/callback route.
+        stored_state = r.get(key_state(user_id))
+        if not stored_state:
             raise RuntimeError("No pending OAuth state for user")
-        state_obj = MCPOauthState.model_validate_json(state)
+        state_obj = MCPOauthState.model_validate_json(stored_state)
 
-        # Block on Redis for (code, state). BLPOP returns (key, value).
+        # Wait for the callback route to publish the authorization code.
         key = key_code(user_id, state_obj.state)
 
-        # Run the blocking operation in a thread pool so the user can complete
-        # sign-in, consent, and MFA without blocking the event loop.
-        loop = asyncio.get_running_loop()
-        pop = await loop.run_in_executor(
-            None,
-            lambda: r.blpop([key], timeout=OAUTH_USER_AUTHORIZATION_TIMEOUT_SECONDS),
+        # Poll with short nonblocking reads. A blocking Redis command would
+        # reserve either an executor thread or a shared Redis connection for
+        # the entire human authorization window.
+        async_redis = await get_async_redis_connection()
+        tenant_key = f"{r.tenant_id}:{key}"
+        deadline = asyncio.get_running_loop().time() + (
+            OAUTH_USER_AUTHORIZATION_TIMEOUT_SECONDS
         )
+        code_payload_raw: bytes | None = None
+        while code_payload_raw is None:
+            code_payload_raw = await cast(
+                Awaitable[bytes | None], async_redis.lpop(tenant_key)
+            )
+            remaining_seconds = deadline - asyncio.get_running_loop().time()
+            if code_payload_raw is None and remaining_seconds <= 0:
+                break
+            if code_payload_raw is None:
+                await asyncio.sleep(
+                    min(OAUTH_CALLBACK_POLL_INTERVAL_SECONDS, remaining_seconds)
+                )
         # TODO(evan): gracefully handle "user says no"
-        if not pop:
+        if code_payload_raw is None:
             raise RuntimeError("Timed out waiting for OAuth callback")
 
-        code_payload = MCPOAuthCodePayload.model_validate_json(pop[1])
+        code_payload = MCPOAuthCodePayload.model_validate_json(code_payload_raw)
         if code_payload.state != state_obj.state:
             raise RuntimeError("Invalid state in OAuth callback")
 

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 import httpx
 import pytest
+from redis.exceptions import ConnectionError as RedisConnectionError
 
 from onyx.db.enums import (
     MCPAuthenticationPerformer,
@@ -23,6 +24,9 @@ from onyx.server.features.mcp.models import (
     MCPUserOAuthConnectRequest,
 )
 from onyx.server.features.mcp.ssrf import _OAuthChallengeTransport
+
+_TEST_OAUTH_STATE = "test-state"
+_TEST_OAUTH_CODE = "test-code"
 
 
 def _install_discovery_responses(
@@ -159,6 +163,67 @@ def _connect(
             force_reauthentication=force_reauthentication,
         )
     )
+
+
+def _oauth_callback_payload() -> bytes:
+    return (
+        oauth.MCPOAuthCodePayload(
+            code=_TEST_OAUTH_CODE,
+            state=_TEST_OAUTH_STATE,
+        )
+        .model_dump_json()
+        .encode()
+    )
+
+
+def _setup_browser_oauth_flow(
+    monkeypatch: pytest.MonkeyPatch,
+    async_redis: MagicMock,
+) -> tuple[
+    Callable[[str], Awaitable[None]],
+    Callable[[], Awaitable[tuple[str, str | None]]],
+    MagicMock,
+]:
+    user_id = str(uuid4())
+    state_data = oauth.MCPOauthState(
+        server_id=42,
+        return_path="/admin/actions/mcp",
+        is_admin=True,
+        state=_TEST_OAUTH_STATE,
+    )
+    redis_client = MagicMock()
+    redis_client.tenant_id = "test-tenant"
+    redis_client.get.return_value = state_data.model_dump_json()
+    monkeypatch.setattr(oauth, "get_redis_client", lambda: redis_client)
+    monkeypatch.setattr(
+        oauth,
+        "get_async_redis_connection",
+        AsyncMock(return_value=async_redis),
+    )
+
+    provider = oauth.make_oauth_provider(
+        mcp_server=cast(MCPServer, _server()),
+        user_id=user_id,
+        return_path="/admin/actions/mcp",
+        connection_config_id=101,
+        admin_config_id=100,
+        authorization_url_callback=AsyncMock(),
+    )
+    redirect_handler = provider.context.redirect_handler
+    callback_handler = provider.context.callback_handler
+    assert redirect_handler is not None
+    assert callback_handler is not None
+    return redirect_handler, callback_handler, redis_client
+
+
+async def _complete_browser_oauth_flow(
+    redirect_handler: Callable[[str], Awaitable[None]],
+    callback_handler: Callable[[], Awaitable[tuple[str, str | None]]],
+) -> tuple[str, str | None]:
+    await redirect_handler(
+        f"https://accounts.example.com/oauth?state={_TEST_OAUTH_STATE}"
+    )
+    return await callback_handler()
 
 
 def test_challenge_redirect_skips_well_known_fallback(
@@ -310,67 +375,75 @@ def test_oauth_redirect_wait_is_bounded_and_cancels_probe(
     assert probe_cancelled
 
 
-def test_browser_oauth_polls_without_holding_redis_connection(
+def test_browser_oauth_callback_outlives_machine_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    user_id = str(uuid4())
-    state = "test-state"
-    state_data = oauth.MCPOauthState(
-        server_id=42,
-        return_path="/admin/actions/mcp",
-        is_admin=True,
-        state=state,
-    )
-    redis_client = MagicMock()
-    redis_client.tenant_id = "test-tenant"
-    redis_client.get.return_value = state_data.model_dump_json()
     async_redis = MagicMock()
-    callback_payload = (
-        oauth.MCPOAuthCodePayload(code="test-code", state=state)
-        .model_dump_json()
-        .encode()
+    first_poll_at: float | None = None
+
+    async def callback_after_operation_timeout(_key: str) -> bytes | None:
+        nonlocal first_poll_at
+        now = asyncio.get_running_loop().time()
+        if first_poll_at is None:
+            first_poll_at = now
+        if now - first_poll_at > 2 * oauth.OAUTH_OPERATION_TIMEOUT_SECONDS:
+            return _oauth_callback_payload()
+        return None
+
+    async_redis.lpop = AsyncMock(side_effect=callback_after_operation_timeout)
+    monkeypatch.setattr(oauth, "OAUTH_OPERATION_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(oauth, "OAUTH_CALLBACK_POLL_INTERVAL_SECONDS", 0.005)
+    redirect_handler, callback_handler, redis_client = _setup_browser_oauth_flow(
+        monkeypatch, async_redis
     )
-    async_redis.lpop = AsyncMock(side_effect=[None, callback_payload])
-    monkeypatch.setattr(oauth, "get_redis_client", lambda: redis_client)
-    monkeypatch.setattr(
-        oauth,
-        "get_async_redis_connection",
-        AsyncMock(return_value=async_redis),
+
+    callback_result = asyncio.run(
+        _complete_browser_oauth_flow(redirect_handler, callback_handler)
+    )
+
+    assert redis_client.set.call_args.kwargs["ex"] == 5 * 60
+    assert callback_result == (_TEST_OAUTH_CODE, _TEST_OAUTH_STATE)
+    assert async_redis.lpop.await_count >= 2
+    async_redis.blpop.assert_not_called()
+
+
+def test_browser_oauth_callback_retries_transient_redis_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async_redis = MagicMock()
+    async_redis.lpop = AsyncMock(
+        side_effect=[
+            RedisConnectionError("transient test failure"),
+            _oauth_callback_payload(),
+        ]
     )
     monkeypatch.setattr(oauth, "OAUTH_CALLBACK_POLL_INTERVAL_SECONDS", 0)
-    authorization_url_callback = AsyncMock()
-
-    provider = oauth.make_oauth_provider(
-        mcp_server=cast(MCPServer, _server()),
-        user_id=user_id,
-        return_path="/admin/actions/mcp",
-        connection_config_id=101,
-        admin_config_id=100,
-        authorization_url_callback=authorization_url_callback,
+    redirect_handler, callback_handler, _ = _setup_browser_oauth_flow(
+        monkeypatch, async_redis
     )
-    redirect_handler = provider.context.redirect_handler
-    callback_handler = provider.context.callback_handler
-    assert redirect_handler is not None
-    assert callback_handler is not None
 
-    async def complete_browser_flow() -> tuple[str, str | None]:
-        await redirect_handler(f"https://accounts.example.com/oauth?state={state}")
-        return await callback_handler()
+    callback_result = asyncio.run(
+        _complete_browser_oauth_flow(redirect_handler, callback_handler)
+    )
 
-    callback_result = asyncio.run(complete_browser_flow())
-    assert redis_client.set.call_args.kwargs["ex"] == 5 * 60
-    assert callback_result == ("test-code", state)
+    assert callback_result == (_TEST_OAUTH_CODE, _TEST_OAUTH_STATE)
     assert async_redis.lpop.await_count == 2
-    assert async_redis.blpop.call_count == 0
 
+
+def test_browser_oauth_callback_times_out_at_authorization_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async_redis = MagicMock()
     async_redis.lpop = AsyncMock(return_value=None)
     monkeypatch.setattr(oauth, "OAUTH_USER_AUTHORIZATION_TIMEOUT_SECONDS", 0)
-
-    async def time_out_browser_flow() -> None:
-        await callback_handler()
+    monkeypatch.setattr(oauth, "OAUTH_OPERATION_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(oauth, "OAUTH_CALLBACK_POLL_INTERVAL_SECONDS", 0)
+    redirect_handler, callback_handler, _ = _setup_browser_oauth_flow(
+        monkeypatch, async_redis
+    )
 
     with pytest.raises(RuntimeError, match="Timed out waiting for OAuth callback"):
-        asyncio.run(time_out_browser_flow())
+        asyncio.run(_complete_browser_oauth_flow(redirect_handler, callback_handler))
     async_redis.lpop.assert_awaited_once()
 
 

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
@@ -310,7 +310,7 @@ def test_oauth_redirect_wait_is_bounded_and_cancels_probe(
     assert probe_cancelled
 
 
-def test_browser_oauth_outlives_machine_operation_timeout(
+def test_browser_oauth_polls_without_holding_redis_connection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     user_id = str(uuid4())
@@ -322,23 +322,22 @@ def test_browser_oauth_outlives_machine_operation_timeout(
         state=state,
     )
     redis_client = MagicMock()
+    redis_client.tenant_id = "test-tenant"
     redis_client.get.return_value = state_data.model_dump_json()
+    async_redis = MagicMock()
     callback_payload = (
-        oauth.key_code(user_id, state).encode(),
         oauth.MCPOAuthCodePayload(code="test-code", state=state)
         .model_dump_json()
-        .encode(),
+        .encode()
     )
-
-    def deliver_callback_after_operation_window(
-        _keys: list[str], timeout: int
-    ) -> tuple[bytes, bytes] | None:
-        if timeout <= oauth.OAUTH_OPERATION_TIMEOUT_SECONDS:
-            return None
-        return callback_payload
-
-    redis_client.blpop.side_effect = deliver_callback_after_operation_window
+    async_redis.lpop = AsyncMock(side_effect=[None, callback_payload])
     monkeypatch.setattr(oauth, "get_redis_client", lambda: redis_client)
+    monkeypatch.setattr(
+        oauth,
+        "get_async_redis_connection",
+        AsyncMock(return_value=async_redis),
+    )
+    monkeypatch.setattr(oauth, "OAUTH_CALLBACK_POLL_INTERVAL_SECONDS", 0)
     authorization_url_callback = AsyncMock()
 
     provider = oauth.make_oauth_provider(
@@ -359,8 +358,20 @@ def test_browser_oauth_outlives_machine_operation_timeout(
         return await callback_handler()
 
     callback_result = asyncio.run(complete_browser_flow())
-    assert redis_client.set.call_args.kwargs["ex"] == 10 * 60
+    assert redis_client.set.call_args.kwargs["ex"] == 5 * 60
     assert callback_result == ("test-code", state)
+    assert async_redis.lpop.await_count == 2
+    assert async_redis.blpop.call_count == 0
+
+    async_redis.lpop = AsyncMock(return_value=None)
+    monkeypatch.setattr(oauth, "OAUTH_USER_AUTHORIZATION_TIMEOUT_SECONDS", 0)
+
+    async def time_out_browser_flow() -> None:
+        await callback_handler()
+
+    with pytest.raises(RuntimeError, match="Timed out waiting for OAuth callback"):
+        asyncio.run(time_out_browser_flow())
+    async_redis.lpop.assert_awaited_once()
 
 
 def test_probe_failure_after_token_refresh_is_not_treated_as_connected(

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
@@ -301,13 +301,63 @@ def test_oauth_redirect_wait_is_bounded_and_cancels_probe(
         raise RuntimeError("unreachable")
 
     monkeypatch.setattr(oauth, "initialize_mcp_client", initialize_forever)
-    monkeypatch.setattr(oauth, "OAUTH_WAIT_SECONDS", 0.01)
+    monkeypatch.setattr(oauth, "OAUTH_OPERATION_TIMEOUT_SECONDS", 0.01)
 
     with pytest.raises(OnyxError, match="Timed out waiting"):
         _connect(server)
 
     assert probe_started.is_set()
     assert probe_cancelled
+
+
+def test_browser_oauth_uses_user_authorization_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = str(uuid4())
+    state = "test-state"
+    state_data = oauth.MCPOauthState(
+        server_id=42,
+        return_path="/admin/actions/mcp",
+        is_admin=True,
+        state=state,
+    )
+    redis_client = MagicMock()
+    redis_client.get.return_value = state_data.model_dump_json()
+    redis_client.blpop.return_value = (
+        oauth.key_code(user_id, state).encode(),
+        oauth.MCPOAuthCodePayload(code="test-code", state=state)
+        .model_dump_json()
+        .encode(),
+    )
+    monkeypatch.setattr(oauth, "get_redis_client", lambda: redis_client)
+    authorization_url_callback = AsyncMock()
+
+    provider = oauth.make_oauth_provider(
+        mcp_server=cast(MCPServer, _server()),
+        user_id=user_id,
+        return_path="/admin/actions/mcp",
+        connection_config_id=101,
+        admin_config_id=100,
+        authorization_url_callback=authorization_url_callback,
+    )
+    redirect_handler = provider.context.redirect_handler
+    callback_handler = provider.context.callback_handler
+    assert redirect_handler is not None
+    assert callback_handler is not None
+
+    async def complete_browser_flow() -> tuple[str, str | None]:
+        await redirect_handler(f"https://accounts.example.com/oauth?state={state}")
+        return await callback_handler()
+
+    callback_result = asyncio.run(complete_browser_flow())
+    assert redis_client.set.call_args.kwargs["ex"] == (
+        oauth.OAUTH_USER_AUTHORIZATION_TIMEOUT_SECONDS
+    )
+
+    assert callback_result == ("test-code", state)
+    assert redis_client.blpop.call_args.kwargs["timeout"] == (
+        oauth.OAUTH_USER_AUTHORIZATION_TIMEOUT_SECONDS
+    )
 
 
 def test_probe_failure_after_token_refresh_is_not_treated_as_connected(

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_connect.py
@@ -310,7 +310,7 @@ def test_oauth_redirect_wait_is_bounded_and_cancels_probe(
     assert probe_cancelled
 
 
-def test_browser_oauth_uses_user_authorization_timeout(
+def test_browser_oauth_outlives_machine_operation_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     user_id = str(uuid4())
@@ -323,12 +323,21 @@ def test_browser_oauth_uses_user_authorization_timeout(
     )
     redis_client = MagicMock()
     redis_client.get.return_value = state_data.model_dump_json()
-    redis_client.blpop.return_value = (
+    callback_payload = (
         oauth.key_code(user_id, state).encode(),
         oauth.MCPOAuthCodePayload(code="test-code", state=state)
         .model_dump_json()
         .encode(),
     )
+
+    def deliver_callback_after_operation_window(
+        _keys: list[str], timeout: int
+    ) -> tuple[bytes, bytes] | None:
+        if timeout <= oauth.OAUTH_OPERATION_TIMEOUT_SECONDS:
+            return None
+        return callback_payload
+
+    redis_client.blpop.side_effect = deliver_callback_after_operation_window
     monkeypatch.setattr(oauth, "get_redis_client", lambda: redis_client)
     authorization_url_callback = AsyncMock()
 
@@ -350,14 +359,8 @@ def test_browser_oauth_uses_user_authorization_timeout(
         return await callback_handler()
 
     callback_result = asyncio.run(complete_browser_flow())
-    assert redis_client.set.call_args.kwargs["ex"] == (
-        oauth.OAUTH_USER_AUTHORIZATION_TIMEOUT_SECONDS
-    )
-
+    assert redis_client.set.call_args.kwargs["ex"] == 10 * 60
     assert callback_result == ("test-code", state)
-    assert redis_client.blpop.call_args.kwargs["timeout"] == (
-        oauth.OAUTH_USER_AUTHORIZATION_TIMEOUT_SECONDS
-    )
 
 
 def test_probe_failure_after_token_refresh_is_not_treated_as_connected(


### PR DESCRIPTION
## Description

Extends the MCP OAuth browser authorization window from 30 seconds to 5 minutes so users have enough time to complete sign-in, consent, and MFA.

The previous shared timeout treated human authorization like a machine-to-machine operation, causing otherwise valid callbacks to fail when users took longer than 30 seconds. This change separates the timing policies: pending browser state and callback waits remain valid for 5 minutes, while OAuth discovery and token-exchange coordination continue to fail promptly after 30 seconds.

The browser callback uses short asynchronous Redis polls instead of a blocking wait. Pending authorization flows therefore hold neither an executor thread nor a Redis connection throughout the human authorization window.

Adds focused coverage for the five-minute state lifetime, delayed callback availability, nonblocking polling, and timeout behavior.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the MCP OAuth browser authorization window from 30 seconds to 5 minutes and switches the callback wait to non‑blocking async polling with transient Redis error retries. Human authorization now has up to 5 minutes; discovery and token exchange still time out after 30 seconds.

- Introduces OAUTH_USER_AUTHORIZATION_TIMEOUT_SECONDS (5m) for browser flows and OAUTH_OPERATION_TIMEOUT_SECONDS (30s) for machine operations; replaces STATE_TTL_SECONDS/OAUTH_WAIT_SECONDS and adds OAUTH_CALLBACK_POLL_INTERVAL_SECONDS.
- Stores pending browser state with a 5m Redis TTL; replaces callback BLPOP with async LPOP polling via get_async_redis_connection, retrying BusyLoadingError/ConnectionError/TimeoutError until the 5m deadline; keeps 30s for SDK consent URL wait, the code handoff key expiry, and tokens BLPOP.
- Adds tests for non‑blocking polling, transient Redis recovery, and that the browser flow outlives the operation timeout with a 5m state TTL.
- No config or migration required; operational changes are longer Redis retention for pending states and no long‑held Redis connection or executor thread during authorization.

<sup>Written for commit 099cc187a0708580a587540a7c6084b773203780. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

