### PR TITLE
refactor(terraform): adopt the AWS modules Onyx runs in production

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -199,9 +199,23 @@ repos:
     hooks:
       - id: terraform_fmt
         files: \.tf$
+      - id: terraform_validate
+        files: ^deployment/terraform/.*\.tf$
+        args:
+          - --tf-init-args=-backend=false
 
   - repo: local
     hooks:
+      # These modules are published but stay in sync with what Onyx runs, so an
+      # internal value can travel across by accident. See the script's docstring.
+      - id: terraform-public-safe
+        name: terraform public-safe values
+        description: "Fail on internal values (account ids, keys, routable IPs) in published Terraform"
+        language: system
+        entry: python3 deployment/terraform/scripts/check_public_safe.py
+        files: ^deployment/terraform/.*\.tf$
+        stages: [pre-commit]
+
       # Regenerate the baseline with `env_inventory.py --write-baseline`.
       - id: env-drift-baseline
         name: env drift baseline

--- a/deployment/terraform/modules/aws/README.md
+++ b/deployment/terraform/modules/aws/README.md
@@ -26,7 +26,10 @@ The snippet below shows a minimal working example that:
 
 ```hcl
 locals {
-  region = "us-west-2"
+  region            = "us-west-2"
+  postgres_username = "pgusername"
+  # Supply this from a secret store or TF_VAR_ in anything but a scratch stack.
+  postgres_password = "your-postgres-password"
 }
 
 provider "aws" {
@@ -41,8 +44,8 @@ module "onyx" {
 
   region            = local.region
   name              = "onyx"            # used as a prefix and workspace-aware
-  postgres_username = "pgusername"
-  postgres_password = "your-postgres-password"
+  postgres_username = local.postgres_username
+  postgres_password = local.postgres_password
   # create_vpc    = true  # default true; set to false to use an existing VPC (see below)
 }
 
@@ -81,7 +84,7 @@ output "cluster_name" {
   value = module.onyx.cluster_name
 }
 output "postgres_connection_url" {
-  value     = "postgres://${module.onyx.postgres_username}@${module.onyx.postgres_endpoint}/${module.onyx.postgres_db_name}"
+  value     = "postgres://${local.postgres_username}:${local.postgres_password}@${module.onyx.postgres_endpoint}:${module.onyx.postgres_port}/${module.onyx.postgres_db_name}"
   sensitive = true
 }
 output "redis_connection_url" {
@@ -207,7 +210,7 @@ Inputs (common):
 - WAF controls such as `waf_allowed_ip_cidrs`, `waf_common_rule_set_count_rules`, rate limits, geo restrictions, and logging retention
 - Optional OpenSearch controls such as `enable_opensearch`, sizing, credentials, and log retention
 - `alarm_actions`: SNS topic ARNs for the CloudWatch alarms created by the data-plane modules. Empty (the default) leaves the alarms in place but notifying nothing
-- Optional extras: `enable_upload_bucket`, `enable_gpu_node`, `enable_network_policy`, `craft_enabled`
+- Optional extras: `enable_upload_bucket`, `enable_gpu_node`, `enable_network_policy`, `enable_craft`
 
 ### `vpc`
 - Builds a VPC sized for EKS with multiple private and public subnets
@@ -226,7 +229,7 @@ Inputs (common):
 Key inputs include:
 - `cluster_name`, `cluster_version` (default `1.33`)
 - `vpc_id`, `subnet_ids`
-- `public_cluster_enabled` (default true), `private_cluster_enabled` (default false)
+- `public_cluster_enabled` (default true), `private_cluster_enabled` (default true)
 - `cluster_endpoint_public_access_cidrs` (default `[]`). Empty denies all public API access. Set it when `public_cluster_enabled` is true and you need to reach the API server
 - `eks_managed_node_groups` (defaults include a main and a vespa-dedicated group with GP3 volumes)
 - `s3_bucket_names` (optional list). If set, creates an IRSA role and Kubernetes service account for S3 access

--- a/deployment/terraform/modules/aws/README.md
+++ b/deployment/terraform/modules/aws/README.md
@@ -3,15 +3,19 @@
 ## Overview
 This directory contains Terraform modules to provision the core AWS infrastructure for Onyx:
 
-- `vpc`: Creates a VPC with public/private subnets sized for EKS
-- `eks`: Provisions an Amazon EKS cluster, essential addons (EBS CSI, metrics server, cluster autoscaler), and optional IRSA for S3 access
-- `postgres`: Creates an Amazon RDS for PostgreSQL instance and returns a connection URL
-- `redis`: Creates an ElastiCache for Redis replication group
-- `s3`: Creates an S3 bucket and locks access to a provided S3 VPC endpoint
-- `opensearch`: Creates an Amazon OpenSearch domain for managed search workloads
+- `vpc`: Creates a VPC with public/private subnets sized for EKS, an optional S3 gateway endpoint, and VPC flow logs
+- `eks`: Provisions an Amazon EKS cluster, essential addons (EBS CSI, metrics server, cluster autoscaler), and optional IRSA for S3 and RDS access
+- `postgres`: Creates an Amazon RDS for PostgreSQL instance, CloudWatch alarms, and returns a connection URL
+- `redis`: Creates an ElastiCache for Redis replication group with CloudWatch alarms
+- `s3`: Creates an S3 bucket with versioning, encryption, lifecycle rules, and a scoped bucket policy
+- `opensearch`: Creates an Amazon OpenSearch domain for managed search workloads, with CloudWatch alarms
 - `onyx`: A higher-level composition that wires the above modules together for a complete, opinionated stack
 
 Use the `onyx` module if you want a working EKS + Postgres + Redis + S3 stack with sane defaults. Use the individual modules if you need more granular control.
+
+These are the same modules Onyx runs for its own managed deployments. The managed
+deployments add operational wiring on top (alert routing, secret management, log
+aggregation) but provision the underlying AWS infrastructure from exactly this code.
 
 ## Quickstart (copy/paste)
 The snippet below shows a minimal working example that:
@@ -195,13 +199,19 @@ Inputs (common):
 - `name` (default `onyx`), `region` (default `us-west-2`), `tags`
 - `size` (`small`/`medium`/`large`, default `medium`) — see "T-shirt sizing" above — plus per-setting overrides (`main_node_*`, `vespa_node_*`, `postgres_instance_type`, `postgres_storage_gb`, `redis_instance_type`, `opensearch_*`)
 - `postgres_username`, `postgres_password`
+- `redis_auth_token`: required unless `enable_redis_iam_auth` is true, because the
+  Redis module enables transit encryption and AWS requires a token in that case
 - `create_vpc` (default true) or existing VPC details and `s3_vpc_endpoint_id`
 - WAF controls such as `waf_allowed_ip_cidrs`, `waf_common_rule_set_count_rules`, rate limits, geo restrictions, and logging retention
 - Optional OpenSearch controls such as `enable_opensearch`, sizing, credentials, and log retention
+- `alarm_actions`: SNS topic ARNs for the CloudWatch alarms created by the data-plane modules. Empty (the default) leaves the alarms in place but notifying nothing
+- Optional extras: `enable_upload_bucket`, `enable_gpu_node`, `enable_network_policy`, `craft_enabled`
 
 ### `vpc`
 - Builds a VPC sized for EKS with multiple private and public subnets
-- Outputs: `vpc_id`, `private_subnets`, `public_subnets`, `vpc_cidr_block`, `s3_vpc_endpoint_id`
+- Creates an S3 gateway VPC endpoint (`create_s3_vpc_endpoint`, default true)
+- Publishes VPC flow logs to CloudWatch with a minimal IAM role
+- Outputs: `vpc_id`, `private_subnets`, `public_subnets`, `vpc_cidr_block`, `nat_gateway_public_ips`, `s3_vpc_endpoint_id`
 
 ### `eks`
 - Creates the EKS cluster and node groups
@@ -213,26 +223,64 @@ Key inputs include:
 - `cluster_name`, `cluster_version` (default `1.33`)
 - `vpc_id`, `subnet_ids`
 - `public_cluster_enabled` (default true), `private_cluster_enabled` (default false)
-- `cluster_endpoint_public_access_cidrs` (optional)
+- `cluster_endpoint_public_access_cidrs` (default `[]`). Empty denies all public API access. Set it when `public_cluster_enabled` is true and you need to reach the API server
 - `eks_managed_node_groups` (defaults include a main and a vespa-dedicated group with GP3 volumes)
 - `s3_bucket_names` (optional list). If set, creates an IRSA role and Kubernetes service account for S3 access
 
 ### `postgres`
 - Amazon RDS for PostgreSQL with parameterized instance size, storage, version
 - Accepts VPC/subnets and ingress CIDRs; returns a ready-to-use connection URL
+- Creates CloudWatch alarms for CPU, freeable memory, free storage, IOPS, and
+  connection count. Set `alarm_actions` to an SNS topic ARN to be notified;
+  leave it empty and the alarms exist but notify nothing
 
 ### `redis`
 - ElastiCache for Redis (transit encryption enabled by default)
-- Supports optional `auth_token` and instance sizing
+- Supports optional `auth_token`, IAM authentication, and instance sizing
+- Creates CloudWatch alarms for memory usage, engine CPU, and swap. Set
+  `alarm_actions` to route them to SNS
 - Outputs endpoint, port, and whether SSL is enabled
 
 ### `s3`
-- Creates an S3 bucket for file storage and scopes access to the provided S3 gateway VPC endpoint
+- Creates an S3 bucket for file storage with versioning, server-side encryption
+  (`aws:kms`, or `AES256` when anonymous read is enabled), a public access block,
+  and lifecycle rules for noncurrent versions, expiration, and IA transition
+- Attaches a bucket policy only when one is needed. Access can be scoped to an S3
+  gateway VPC endpoint (`s3_vpc_endpoint_id`), and optionally to source IPs or VPCs
+  (`allow_anonymous_read` with `allowed_source_ips` / `allowed_vpc_ids`)
 
 ### `opensearch`
 - Creates an Amazon OpenSearch domain inside the VPC
 - Supports custom subnets, security groups, fine-grained access control, encryption, and CloudWatch log publishing
+- Creates CloudWatch alarms for cluster status, node count, free storage, JVM
+  memory pressure, and write-blocked indices. Set `alarm_actions` to route them to SNS
 - Outputs domain endpoints, ARN, and the managed security group ID when it creates one
+
+## Upgrading from an earlier version of these modules
+
+These modules were realigned with the versions Onyx runs in production. If you
+applied an earlier revision, note the following before your next `terraform apply`.
+
+**Renamed resources are handled for you.** The modules ship `moved` blocks that
+relabel state in place, so the plan shows moves rather than destroy/create:
+
+| Module | Old address | New address |
+|---|---|---|
+| `s3` | `aws_s3_bucket.bucket` | `aws_s3_bucket.this` |
+| `s3` | `aws_s3_bucket_policy.bucket_policy` | `aws_s3_bucket_policy.anonymous_read[0]` |
+| `vpc` | `aws_vpc_endpoint.s3` | `aws_vpc_endpoint.s3[0]` |
+| `redis` | `aws_security_group.redis_sg` | `aws_security_group.redis_sg[0]` |
+| `postgres` | `aws_db_subnet_group.this` | `aws_db_subnet_group.this[0]` |
+| `postgres` | `aws_security_group.this` | `aws_security_group.this[0]` |
+
+**Review the plan before applying.** Expect in-place updates where the new
+modules add settings the old ones did not manage:
+- `s3` now manages versioning, encryption, a public access block, and lifecycle rules
+- `vpc` now creates flow logs and their IAM role
+- `postgres`, `redis`, and `opensearch` now create CloudWatch alarms
+
+**`cluster_endpoint_public_access_cidrs` now defaults to `[]`.** If you relied on
+the previous default, set the value explicitly before applying.
 
 ## Installing the Onyx Helm chart (after Terraform)
 Once the cluster is active, deploy application workloads via Helm. You can use the chart in `deployment/helm/charts/onyx`.

--- a/deployment/terraform/modules/aws/README.md
+++ b/deployment/terraform/modules/aws/README.md
@@ -84,7 +84,7 @@ output "cluster_name" {
   value = module.onyx.cluster_name
 }
 output "postgres_connection_url" {
-  value     = "postgres://${local.postgres_username}:${local.postgres_password}@${module.onyx.postgres_endpoint}:${module.onyx.postgres_port}/${module.onyx.postgres_db_name}"
+  value     = "postgres://${urlencode(local.postgres_username)}:${urlencode(local.postgres_password)}@${module.onyx.postgres_endpoint}:${module.onyx.postgres_port}/${module.onyx.postgres_db_name}"
   sensitive = true
 }
 output "redis_connection_url" {

--- a/deployment/terraform/modules/aws/README.md
+++ b/deployment/terraform/modules/aws/README.md
@@ -81,7 +81,7 @@ output "cluster_name" {
   value = module.onyx.cluster_name
 }
 output "postgres_connection_url" {
-  value     = module.onyx.postgres_connection_url
+  value     = "postgres://${module.onyx.postgres_username}@${module.onyx.postgres_endpoint}/${module.onyx.postgres_db_name}"
   sensitive = true
 }
 output "redis_connection_url" {
@@ -191,9 +191,10 @@ module "onyx" {
 - Orchestrates `vpc`, `eks`, `postgres`, `redis`, and `s3`
 - Names resources using `name` and the current Terraform workspace
 - Exposes convenient outputs:
-  - `cluster_name`: EKS cluster name
-  - `postgres_connection_url` (sensitive): `postgres://...`
+  - `cluster_name`, `oidc_provider`, `oidc_provider_arn`, `workload_irsa_role_arn`
+  - `postgres_endpoint`, `postgres_port`, `postgres_db_name`, `postgres_username` (sensitive), `postgres_dbi_resource_id`
   - `redis_connection_url` (sensitive): hostname:port
+  - `opensearch_endpoint`, `opensearch_dashboard_endpoint`, `opensearch_domain_arn` (null unless `enable_opensearch`)
 
 Inputs (common):
 - `name` (default `onyx`), `region` (default `us-west-2`), `tags`
@@ -202,6 +203,7 @@ Inputs (common):
 - `redis_auth_token`: required unless `enable_redis_iam_auth` is true, because the
   Redis module enables transit encryption and AWS requires a token in that case
 - `create_vpc` (default true) or existing VPC details and `s3_vpc_endpoint_id`
+- `single_nat_gateway` (default false): one NAT gateway per AZ. Set true to trade AZ independence for cost
 - WAF controls such as `waf_allowed_ip_cidrs`, `waf_common_rule_set_count_rules`, rate limits, geo restrictions, and logging retention
 - Optional OpenSearch controls such as `enable_opensearch`, sizing, credentials, and log retention
 - `alarm_actions`: SNS topic ARNs for the CloudWatch alarms created by the data-plane modules. Empty (the default) leaves the alarms in place but notifying nothing
@@ -278,9 +280,16 @@ modules add settings the old ones did not manage:
 - `s3` now manages versioning, encryption, a public access block, and lifecycle rules
 - `vpc` now creates flow logs and their IAM role
 - `postgres`, `redis`, and `opensearch` now create CloudWatch alarms
+- `postgres` now manages `multi_az` (default false). If you enabled a standby
+  outside Terraform, set `multi_az = true` before applying or the standby is removed
+- `eks` now enables the private API endpoint by default (`private_cluster_enabled`).
+  This is additive and does not remove public access
 
 **`cluster_endpoint_public_access_cidrs` now defaults to `[]`.** If you relied on
 the previous default, set the value explicitly before applying.
+
+**The Craft sandbox node group's key changed** from `craft_sandbox` to `sandbox`.
+A `moved` block handles the relabel, so the group is not recreated.
 
 ## Installing the Onyx Helm chart (after Terraform)
 Once the cluster is active, deploy application workloads via Helm. You can use the chart in `deployment/helm/charts/onyx`.

--- a/deployment/terraform/modules/aws/README.md
+++ b/deployment/terraform/modules/aws/README.md
@@ -84,7 +84,7 @@ output "cluster_name" {
   value = module.onyx.cluster_name
 }
 output "postgres_connection_url" {
-  value     = "postgres://${urlencode(local.postgres_username)}:${urlencode(local.postgres_password)}@${module.onyx.postgres_endpoint}:${module.onyx.postgres_port}/${module.onyx.postgres_db_name}"
+  value     = "postgres://${urlencode(local.postgres_username)}:${urlencode(local.postgres_password)}@${module.onyx.postgres_address}:${module.onyx.postgres_port}/${module.onyx.postgres_db_name}"
   sensitive = true
 }
 output "redis_connection_url" {

--- a/deployment/terraform/modules/aws/README.md
+++ b/deployment/terraform/modules/aws/README.md
@@ -199,7 +199,7 @@ module "onyx" {
 Inputs (common):
 - `name` (default `onyx`), `region` (default `us-west-2`), `tags`
 - `size` (`small`/`medium`/`large`, default `medium`) — see "T-shirt sizing" above — plus per-setting overrides (`main_node_*`, `vespa_node_*`, `postgres_instance_type`, `postgres_storage_gb`, `redis_instance_type`, `opensearch_*`)
-- `postgres_username`, `postgres_password`
+- `postgres_username`, `postgres_password`, `postgres_multi_az`
 - `redis_auth_token`: required unless `enable_redis_iam_auth` is true, because the
   Redis module enables transit encryption and AWS requires a token in that case
 - `create_vpc` (default true) or existing VPC details and `s3_vpc_endpoint_id`
@@ -219,7 +219,9 @@ Inputs (common):
 - Creates the EKS cluster and node groups
 - Enables addons: EBS CSI driver, metrics server, cluster autoscaler
 - Optionally configures IRSA for S3 access to specified buckets
-- Outputs: `cluster_name`, `cluster_endpoint`, `cluster_certificate_authority_data`, `s3_access_role_arn` (if created)
+- Outputs: `cluster_name`, `cluster_endpoint`, `cluster_certificate_authority_data`,
+  `oidc_provider`, `oidc_provider_arn`, `cluster_security_group_id`, `node_security_group_id`,
+  and `workload_irsa_role_arn` / `workload_irsa_service_account_subjects` when `s3_bucket_names` is set
 
 Key inputs include:
 - `cluster_name`, `cluster_version` (default `1.33`)
@@ -280,8 +282,9 @@ modules add settings the old ones did not manage:
 - `s3` now manages versioning, encryption, a public access block, and lifecycle rules
 - `vpc` now creates flow logs and their IAM role
 - `postgres`, `redis`, and `opensearch` now create CloudWatch alarms
-- `postgres` now manages `multi_az` (default false). If you enabled a standby
-  outside Terraform, set `multi_az = true` before applying or the standby is removed
+- `postgres` now manages Multi-AZ (default false). If you enabled a standby
+  outside Terraform, set `postgres_multi_az = true` on the `onyx` module (or
+  `multi_az` on the `postgres` module) before applying, or the standby is removed
 - `eks` now enables the private API endpoint by default (`private_cluster_enabled`).
   This is additive and does not remove public access
 

--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -17,27 +17,65 @@ locals {
     "system:serviceaccount:${var.irsa_service_account_namespace}:${service_account_name}"
   ]
 
-  # Optional dedicated node group for sandbox pods (nodeSelector/toleration below).
+  # Optional dedicated GPU node group for the embedding model server.
+  # Tainted so ONLY pods that tolerate nvidia.com/gpu (the model pod) land here,
+  # and uses the EKS NVIDIA accelerated AMI which ships the GPU driver + runtime.
+  gpu_node_groups = var.enable_gpu_node ? {
+    gpu = {
+      name           = "gpu-node-group"
+      instance_types = var.gpu_node_instance_types
+      ami_type       = "AL2023_x86_64_NVIDIA"
+      min_size       = 1
+      max_size       = 1
+      labels = {
+        "onyx.app/gpu" = "true"
+      }
+      taints = [
+        {
+          key    = "nvidia.com/gpu"
+          value  = "true"
+          effect = "NO_SCHEDULE"
+        }
+      ]
+      block_device_mappings = {
+        xvda = {
+          device_name = "/dev/xvda"
+          ebs = {
+            volume_size           = 100
+            volume_type           = "gp3"
+            encrypted             = true
+            delete_on_termination = true
+            iops                  = 3000
+            throughput            = 125
+          }
+        }
+      }
+    }
+  } : {}
+
+  # Optional dedicated Craft sandbox node group. Sandbox pods pin here
+  # via nodeSelector onyx.app/workload=sandbox + toleration of the workload taint.
   # IMDSv2 hop-limit 1 blocks sandboxed containers from the node metadata service.
-  craft_sandbox_node_groups = var.enable_craft ? {
-    craft_sandbox = {
+  # The root disk is sized via craft_sandbox_node_disk_size_gb so ephemeral-storage
+  # stops being the binding scheduling dimension (each sandbox pod reserves ~5.5Gi
+  # eph; the AMI default ~20Gi caps a node at ~3 sandboxes vs ~7 by CPU).
+  craft_sandbox_node_groups = var.craft_enabled ? {
+    sandbox = {
       name           = "sandbox-node-group"
       instance_types = var.craft_sandbox_node_instance_types
       min_size       = var.craft_sandbox_node_min_size
       max_size       = var.craft_sandbox_node_max_size
       desired_size   = var.craft_sandbox_node_desired_size
-      # Keep the sandbox nodes on the upstream shared node security group only.
-      # Attaching the EKS primary cluster SG as well puts two
-      # kubernetes.io/cluster/<name>-tagged SGs on the same nodes, which breaks
-      # tag-based discovery in controllers such as AWS Load Balancer Controller.
       labels = {
         "onyx.app/workload" = "sandbox"
       }
-      taints = [{
-        key    = "workload"
-        value  = "sandbox"
-        effect = "NO_SCHEDULE"
-      }]
+      taints = [
+        {
+          key    = "workload"
+          value  = "sandbox"
+          effect = "NO_SCHEDULE"
+        }
+      ]
       metadata_options = {
         http_endpoint               = "enabled"
         http_tokens                 = "required"
@@ -51,13 +89,13 @@ locals {
             volume_type           = "gp3"
             encrypted             = true
             delete_on_termination = true
+            iops                  = 3000
+            throughput            = 125
           }
         }
       }
-      # cluster-autoscaler auto-discovery tags (inert unless cluster-autoscaler
-      # runs in the cluster). min_size stays >= 1 so the group never scales to
-      # zero: scaling back up from zero would also require node-template
-      # label/taint tags, which are not set here.
+      # cluster-autoscaler auto-discovery: tag the node group's ASG so demand
+      # beyond min_size adds nodes (and scales back down when idle).
       tags = {
         "k8s.io/cluster-autoscaler/enabled"             = "true"
         "k8s.io/cluster-autoscaler/${var.cluster_name}" = "owned"
@@ -84,13 +122,29 @@ module "eks" {
   cluster_enabled_log_types              = var.cluster_enabled_log_types
   cloudwatch_log_group_retention_in_days = var.cloudwatch_log_group_retention_in_days
 
+  # Opt-in per cluster: adopts the VPC CNI addon and turns on NetworkPolicy
+  # enforcement. Off by default so existing clusters' NetworkPolicies stay
+  # inert (the cloud cluster has legacy policies of unknown effect).
+  cluster_addons = var.enable_network_policy ? {
+    vpc-cni = {
+      # Pin to the cluster's running CNI so adoption only flips enableNetworkPolicy.
+      addon_version = var.vpc_cni_addon_version
+      # PRESERVE keeps out-of-band aws-node settings; OVERWRITE on create is
+      # required to adopt the previously-unmanaged addon (PRESERVE isn't valid there).
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts_on_update = "PRESERVE"
+      configuration_values = jsonencode({
+        enableNetworkPolicy = "true"
+      })
+    }
+  } : {}
+
   eks_managed_node_group_defaults = {
     ami_type = "AL2023_x86_64_STANDARD"
   }
 
-  eks_managed_node_groups = merge({
-    for k, v in var.eks_managed_node_groups : k => merge(v,
-      # (vespa group is skipped entirely when var.vespa_node_enabled is false — see the `if` at the end of this for-expression)
+  eks_managed_node_groups = {
+    for k, v in merge(var.eks_managed_node_groups, local.gpu_node_groups, local.craft_sandbox_node_groups) : k => merge(v,
       {
         instance_types = v.instance_types != null ? v.instance_types : (
           k == "main" ? var.main_node_instance_types :
@@ -106,14 +160,15 @@ module "eks" {
       k == "main" && length(var.main_node_subnet_ids) > 0 ? {
         subnet_ids = var.main_node_subnet_ids
       } : {},
-      # Scaling-bound overrides for the main node group; null keeps the map
-      # default. desired_size must be >= min_size or the EKS API rejects the
+      # Override main node group scaling bounds (defaults preserve prior behavior).
+      # Raising min_size forces the cluster-autoscaler to keep an always-on
+      # baseline. desired_size must be >= min_size or the EKS API rejects the
       # node group at creation (the upstream module defaults desired to 1 and
       # ignores changes to it after create).
       k == "main" ? {
-        min_size     = coalesce(var.main_node_min_size, v.min_size)
-        max_size     = coalesce(var.main_node_max_size, v.max_size)
-        desired_size = try(v.desired_size, coalesce(var.main_node_min_size, v.min_size))
+        min_size     = var.main_node_min_size
+        max_size     = var.main_node_max_size
+        desired_size = try(v.desired_size, var.main_node_min_size)
       } : {},
       # Disk override for the Vespa/document-index node; null keeps the map
       # default. Merge preserves any other device mappings on the group.
@@ -129,9 +184,39 @@ module "eks" {
         })
       } : {}
     ) if k != "vespa" || var.vespa_node_enabled
-  }, local.craft_sandbox_node_groups)
+  }
 
   tags = var.tags
+}
+
+# NVIDIA device plugin: advertises nvidia.com/gpu on the GPU nodes so the
+# embedding model pod can request it. Tolerates the GPU taint and only runs on
+# nodes labeled onyx.app/gpu=true. Only created when the GPU node group exists.
+resource "helm_release" "nvidia_device_plugin" {
+  count = var.enable_gpu_node ? 1 : 0
+
+  name       = "nvidia-device-plugin"
+  repository = "https://nvidia.github.io/k8s-device-plugin"
+  chart      = "nvidia-device-plugin"
+  version    = "0.17.1"
+  namespace  = "kube-system"
+
+  # Null out the chart's default Node Feature Discovery affinity (we don't run
+  # NFD, so its pci-10de / nvidia.com/gpu.present requirements exclude our node).
+  # null (not {}) is required to actually override the chart default. Pin the
+  # plugin to our labeled, tainted GPU node via nodeSelector + toleration.
+  values = [<<-YAML
+    affinity: null
+    nodeSelector:
+      onyx.app/gpu: "true"
+    tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+  YAML
+  ]
+
+  depends_on = [module.eks]
 }
 
 # https://aws.amazon.com/blogs/containers/amazon-ebs-csi-driver-is-now-generally-available-in-amazon-eks-add-ons/
@@ -200,6 +285,51 @@ module "eks_blueprints_addons" {
   enable_cluster_autoscaler           = true
 
   depends_on = [module.eks]
+}
+
+# Supplementary RBAC for the cluster-autoscaler: its chart's hardcoded
+# ClusterRole covers storageclasses/csinodes/csidrivers but NOT
+# volumeattachments (and exposes no values hook to extend it), so EBS-AZ-aware
+# scale-up fails with "cannot list volumeattachments" — a pod pending on an
+# AZ-locked volume never triggers a node in that AZ. NOTE: if these objects
+# were already created by hand on the cluster, import them before the first
+# apply:
+#   terraform import '...kubernetes_cluster_role.cluster_autoscaler_volumeattachments' onyx-cluster-autoscaler-volumeattachments
+#   terraform import '...kubernetes_cluster_role_binding.cluster_autoscaler_volumeattachments' onyx-cluster-autoscaler-volumeattachments
+resource "kubernetes_cluster_role" "cluster_autoscaler_volumeattachments" {
+  metadata {
+    name   = "onyx-cluster-autoscaler-volumeattachments"
+    labels = { "app.kubernetes.io/managed-by" = "onyx-infra" }
+  }
+
+  rule {
+    api_groups = ["storage.k8s.io"]
+    resources  = ["volumeattachments"]
+    verbs      = ["list", "watch", "get"]
+  }
+
+  depends_on = [module.eks_blueprints_addons]
+}
+
+resource "kubernetes_cluster_role_binding" "cluster_autoscaler_volumeattachments" {
+  metadata {
+    name   = "onyx-cluster-autoscaler-volumeattachments"
+    labels = { "app.kubernetes.io/managed-by" = "onyx-infra" }
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role.cluster_autoscaler_volumeattachments.metadata[0].name
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = "cluster-autoscaler-sa"
+    namespace = "kube-system"
+  }
+
+  depends_on = [module.eks_blueprints_addons]
 }
 
 # Create IAM policy for S3 access (optional)

--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -174,9 +174,9 @@ module "eks" {
       # node group at creation (the upstream module defaults desired to 1 and
       # ignores changes to it after create).
       k == "main" ? {
-        min_size     = var.main_node_min_size
-        max_size     = var.main_node_max_size
-        desired_size = try(v.desired_size, var.main_node_min_size)
+        min_size     = coalesce(var.main_node_min_size, v.min_size)
+        max_size     = coalesce(var.main_node_max_size, v.max_size)
+        desired_size = try(v.desired_size, coalesce(var.main_node_min_size, v.min_size))
       } : {},
       # Disk override for the Vespa/document-index node; null keeps the map
       # default. Merge preserves any other device mappings on the group.

--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -67,7 +67,7 @@ locals {
   # The root disk is sized via craft_sandbox_node_disk_size_gb so ephemeral-storage
   # stops being the binding scheduling dimension (each sandbox pod reserves ~5.5Gi
   # eph; the AMI default ~20Gi caps a node at ~3 sandboxes vs ~7 by CPU).
-  craft_sandbox_node_groups = var.craft_enabled ? {
+  craft_sandbox_node_groups = var.enable_craft ? {
     sandbox = {
       name           = "sandbox-node-group"
       instance_types = var.craft_sandbox_node_instance_types

--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -1,3 +1,11 @@
+# The Craft sandbox node group's map key was `craft_sandbox`; it is now
+# `sandbox`. The key is part of the upstream module's instance address, so
+# without this the group is destroyed and recreated, evicting its workloads.
+moved {
+  from = module.eks.module.eks_managed_node_group["craft_sandbox"]
+  to   = module.eks.module.eks_managed_node_group["sandbox"]
+}
+
 locals {
   s3_bucket_arns = [for name in var.s3_bucket_names : {
     bucket_arn     = "arn:aws:s3:::${name}"

--- a/deployment/terraform/modules/aws/eks/outputs.tf
+++ b/deployment/terraform/modules/aws/eks/outputs.tf
@@ -12,7 +12,7 @@ output "cluster_certificate_authority_data" {
 }
 
 output "workload_irsa_role_arn" {
-  description = "ARN of the IAM role for workloads (S3 + optional RDS)"
+  description = "ARN of the IAM role for workloads (S3 + RDS)"
   value       = local.workload_irsa_enabled ? module.irsa-workload-access[0].iam_role_arn : null
 }
 
@@ -21,24 +21,20 @@ output "workload_irsa_service_account_subjects" {
   value       = local.workload_irsa_enabled ? local.workload_irsa_service_account_subjects : []
 }
 
-output "node_security_group_id" {
-  description = "Node security group ID from the EKS module"
-  value       = module.eks.node_security_group_id
-}
-
 output "cluster_security_group_id" {
-  description = "Cluster security group ID from the EKS module"
-  value       = module.eks.cluster_security_group_id
+  value = module.eks.cluster_security_group_id
 }
 
-# Re-exported from the upstream eks module so the craft_sandbox module can
-# trust-scope its IRSA role to the cluster's OIDC provider.
-output "oidc_provider_arn" {
-  description = "EKS OIDC provider ARN (for IRSA roles)"
-  value       = module.eks.oidc_provider_arn
+output "node_security_group_id" {
+  value = module.eks.node_security_group_id
 }
 
 output "oidc_provider" {
-  description = "EKS OIDC issuer host/path (no https://)"
+  description = "OIDC provider URL (no https://) for IRSA role trust policies"
   value       = module.eks.oidc_provider
+}
+
+output "oidc_provider_arn" {
+  description = "OIDC provider ARN for IRSA role trust policies"
+  value       = module.eks.oidc_provider_arn
 }

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -285,7 +285,7 @@ variable "cloudwatch_log_group_retention_in_days" {
 
 variable "enable_network_policy" {
   type        = bool
-  description = "Adopt the VPC CNI addon and enable Kubernetes NetworkPolicy enforcement. Off by default: the addon stays unmanaged and existing NetworkPolicies remain inert. Only enable per cluster once its policies are known-safe."
+  description = "Adopt the VPC CNI addon and turn on NetworkPolicy enforcement. Updates use resolve_conflicts_on_update = PRESERVE so out-of-band aws-node settings survive; the trade-off is that a cluster whose addon already sets enableNetworkPolicy=false explicitly keeps that value, and enforcement stays off. Check the addon's configuration_values after the first apply."
   default     = false
 }
 

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -101,6 +101,11 @@ variable "craft_enabled" {
   type        = bool
   description = "Create a dedicated Craft sandbox node group (labeled onyx.app/workload=sandbox, tainted workload=sandbox:NoSchedule, IMDSv2 hop-limit 1). Opt-in per workspace."
   default     = false
+
+  validation {
+    condition     = !var.craft_enabled || !contains(keys(var.eks_managed_node_groups), "sandbox")
+    error_message = "craft_enabled injects a node group under the key \"sandbox\", which eks_managed_node_groups already defines. Rename your group so the Craft group does not replace it."
+  }
 }
 
 variable "craft_sandbox_node_instance_types" {
@@ -259,7 +264,7 @@ variable "cluster_enabled_log_types" {
 
 variable "cloudwatch_log_group_retention_in_days" {
   type        = number
-  description = "Number of days to retain EKS control plane logs in CloudWatch (0 = never expire). Default 400 = 12 months + 30-day buffer for Vanta `logs-retained-for-twelve-months-config`."
+  description = "Number of days to retain EKS control plane logs in CloudWatch (0 = never expire). Default 400 = 12 months + 30-day buffer for the common twelve-month log-retention control."
   default     = 400
 
   validation {

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -69,8 +69,8 @@ variable "main_node_subnet_ids" {
 
 variable "main_node_min_size" {
   type        = number
-  description = "Minimum number of nodes in the main node group. The cluster-autoscaler will not scale below this, so raise it to guarantee always-on baseline capacity for bursty workloads."
-  default     = 1
+  description = "Minimum number of nodes in the main node group. The cluster-autoscaler will not scale below this, so raise it to guarantee always-on baseline capacity for bursty workloads. Null keeps the node-group default."
+  default     = null
 }
 
 variable "vespa_node_disk_size_gb" {
@@ -81,14 +81,19 @@ variable "vespa_node_disk_size_gb" {
 
 variable "main_node_max_size" {
   type        = number
-  description = "Maximum number of nodes the main node group may scale up to."
-  default     = 5
+  description = "Maximum number of nodes the main node group may scale up to. Null keeps the node-group default."
+  default     = null
 }
 
 variable "enable_gpu_node" {
   type        = bool
   description = "Whether to create a dedicated, tainted GPU node group for the embedding model server. Opt-in per customer."
   default     = false
+
+  validation {
+    condition     = !var.enable_gpu_node || !contains(keys(var.eks_managed_node_groups), "gpu")
+    error_message = "enable_gpu_node injects a node group under the key \"gpu\", which eks_managed_node_groups already defines. Rename your group so the GPU group does not replace it."
+  }
 }
 
 variable "gpu_node_instance_types" {

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -28,12 +28,12 @@ variable "public_cluster_enabled" {
 variable "private_cluster_enabled" {
   type        = bool
   description = "Whether to enable private cluster access"
-  default     = false
+  default     = true
 }
 
 variable "cluster_endpoint_public_access_cidrs" {
   type        = list(string)
-  description = "List of CIDR blocks allowed to access the public EKS API endpoint"
+  description = "List of CIDR blocks allowed to access the public EKS API endpoint. Empty denies all public access; set this if public_cluster_enabled is true."
   default     = []
 }
 
@@ -41,18 +41,6 @@ variable "main_node_instance_types" {
   type        = list(string)
   description = "Instance types for the main node group"
   default     = ["m7i.4xlarge"]
-}
-
-variable "main_node_min_size" {
-  type        = number
-  description = "Minimum number of nodes in the main node group. The cluster-autoscaler will not scale below this, so raise it to guarantee always-on baseline capacity for bursty workloads. Null keeps the node-group default."
-  default     = null
-}
-
-variable "main_node_max_size" {
-  type        = number
-  description = "Maximum number of nodes the main node group may scale up to. Null keeps the node-group default."
-  default     = null
 }
 
 variable "vespa_node_enabled" {
@@ -67,12 +55,6 @@ variable "vespa_node_instance_types" {
   default     = ["m6i.2xlarge"]
 }
 
-variable "vespa_node_disk_size_gb" {
-  type        = number
-  description = "Root EBS volume (GiB) for the Vespa/document-index node. Size to the expected on-disk index; null keeps the node-group default."
-  default     = null
-}
-
 variable "vespa_node_subnet_ids" {
   type        = list(string)
   description = "Subnet IDs for the Vespa node group (must be in same AZ as Vespa PV). If not specified, uses all cluster subnets."
@@ -81,8 +63,74 @@ variable "vespa_node_subnet_ids" {
 
 variable "main_node_subnet_ids" {
   type        = list(string)
-  description = "Subnet IDs for the main node group. If not specified, uses all cluster subnets. Pin to private subnets to keep node egress on the NAT gateway IP across replacements."
+  description = "Subnet IDs for the main node group. If not specified, uses all cluster subnets. Pin to private subnets to keep node egress on the NAT EIP across replacements."
   default     = []
+}
+
+variable "main_node_min_size" {
+  type        = number
+  description = "Minimum number of nodes in the main node group. The cluster-autoscaler will not scale below this, so raise it to guarantee always-on baseline capacity for bursty workloads."
+  default     = 1
+}
+
+variable "vespa_node_disk_size_gb" {
+  type        = number
+  description = "Root EBS volume (GiB) for the Vespa/document-index node. Null keeps the node-group default."
+  default     = null
+}
+
+variable "main_node_max_size" {
+  type        = number
+  description = "Maximum number of nodes the main node group may scale up to."
+  default     = 5
+}
+
+variable "enable_gpu_node" {
+  type        = bool
+  description = "Whether to create a dedicated, tainted GPU node group for the embedding model server. Opt-in per customer."
+  default     = false
+}
+
+variable "gpu_node_instance_types" {
+  type        = list(string)
+  description = "Instance types for the GPU node group. g4dn.xlarge (1x NVIDIA T4) is sufficient for the embedding model."
+  default     = ["g4dn.xlarge"]
+}
+
+variable "craft_enabled" {
+  type        = bool
+  description = "Create a dedicated Craft sandbox node group (labeled onyx.app/workload=sandbox, tainted workload=sandbox:NoSchedule, IMDSv2 hop-limit 1). Opt-in per workspace."
+  default     = false
+}
+
+variable "craft_sandbox_node_instance_types" {
+  type        = list(string)
+  description = "Instance types for the Craft sandbox node group."
+  default     = ["m8i.2xlarge"]
+}
+
+variable "craft_sandbox_node_min_size" {
+  type        = number
+  description = "Min size of the Craft sandbox node group."
+  default     = 1
+}
+
+variable "craft_sandbox_node_max_size" {
+  type        = number
+  description = "Max size of the Craft sandbox node group (cluster-autoscaler scales between min and max)."
+  default     = 7
+}
+
+variable "craft_sandbox_node_desired_size" {
+  type        = number
+  description = "Desired size of the Craft sandbox node group."
+  default     = 1
+}
+
+variable "craft_sandbox_node_disk_size_gb" {
+  type        = number
+  description = "Root EBS volume (GiB) for Craft sandbox nodes. Size so ephemeral-storage is NOT the binding scheduling dimension: each sandbox pod reserves ~5.5Gi eph, so allow (max_sandboxes_per_node * 5.5Gi) + system/image headroom. The AMI default (~20Gi) caps a node at ~3 sandboxes despite ~7 by CPU."
+  default     = 200
 }
 
 variable "eks_managed_node_groups" {
@@ -100,7 +148,7 @@ variable "eks_managed_node_groups" {
         xvda = {
           device_name = "/dev/xvda"
           ebs = {
-            volume_size           = 50
+            volume_size           = 100
             volume_type           = "gp3"
             encrypted             = true
             delete_on_termination = true
@@ -148,47 +196,6 @@ variable "tags" {
   type        = map(string)
   description = "Tags to apply to the resources"
   default     = {}
-}
-
-variable "enable_craft" {
-  type        = bool
-  description = "Enable Craft infrastructure. Currently provisions a dedicated Craft sandbox node group (labeled onyx.app/workload=sandbox, tainted workload=sandbox:NoSchedule, IMDSv2 hop-limit 1)."
-  default     = false
-}
-
-variable "craft_sandbox_node_instance_types" {
-  type        = list(string)
-  description = "Instance types for the Craft sandbox node group."
-  default     = ["m5.large"]
-}
-
-variable "craft_sandbox_node_min_size" {
-  type        = number
-  description = "Min size of the Craft sandbox node group. Keep >= 1: cluster-autoscaler can only scale a group back up from zero with node-template label/taint ASG tags, which are not configured here, so a value of 0 would leave sandbox pods Pending after idle scale-down."
-  default     = 1
-}
-
-variable "craft_sandbox_node_max_size" {
-  type        = number
-  description = "Max size of the Craft sandbox node group (concurrency: each sandbox needs ~1 vCPU/2Gi)."
-  default     = 4
-}
-
-variable "craft_sandbox_node_desired_size" {
-  type        = number
-  description = "Desired size of the Craft sandbox node group."
-  default     = 1
-}
-
-variable "craft_sandbox_node_disk_size_gb" {
-  type        = number
-  description = "Root EBS volume (GiB) for Craft sandbox nodes. Size this relative to the instance's vCPU and the sandbox pod's ephemeral-storage request (default 5Gi/pod): a node fits min(vCPU/pod-cpu, disk/pod-eph) sandboxes, so a disk too small for the instance makes ephemeral-storage the binding dimension and caps the node far below its CPU capacity. The default suits the default m5.large; raise it if you use larger instances."
-  default     = 50
-
-  validation {
-    condition     = var.craft_sandbox_node_disk_size_gb >= 20
-    error_message = "craft_sandbox_node_disk_size_gb must be at least 20 GiB; the AL2023 AMI and OS overlay consume ~8 GiB, leaving too little ephemeral storage for even one sandbox pod (5Gi request) below that threshold."
-  }
 }
 
 variable "create_gp3_storage_class" {
@@ -252,11 +259,23 @@ variable "cluster_enabled_log_types" {
 
 variable "cloudwatch_log_group_retention_in_days" {
   type        = number
-  description = "Number of days to retain EKS control plane logs in CloudWatch (0 = never expire)"
-  default     = 30
+  description = "Number of days to retain EKS control plane logs in CloudWatch (0 = never expire). Default 400 = 12 months + 30-day buffer for Vanta `logs-retained-for-twelve-months-config`."
+  default     = 400
 
   validation {
     condition     = contains([0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653], var.cloudwatch_log_group_retention_in_days)
     error_message = "Must be a valid CloudWatch retention value (0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653)."
   }
+}
+
+variable "enable_network_policy" {
+  type        = bool
+  description = "Adopt the VPC CNI addon and enable Kubernetes NetworkPolicy enforcement. Off by default: the addon stays unmanaged and existing NetworkPolicies remain inert. Only enable per cluster once its policies are known-safe."
+  default     = false
+}
+
+variable "vpc_cni_addon_version" {
+  type        = string
+  description = "VPC CNI addon version to pin when enable_network_policy is true. Set to the cluster's currently-running version (aws eks describe-addon --addon-name vpc-cni) to avoid an unintended CNI upgrade on adoption."
+  default     = "v1.20.4-eksbuild.2"
 }

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -104,7 +104,7 @@ variable "enable_craft" {
 
   validation {
     condition     = !var.enable_craft || !contains(keys(var.eks_managed_node_groups), "sandbox")
-    error_message = "craft_enabled injects a node group under the key \"sandbox\", which eks_managed_node_groups already defines. Rename your group so the Craft group does not replace it."
+    error_message = "enable_craft injects a node group under the key \"sandbox\", which eks_managed_node_groups already defines. Rename your group so the Craft group does not replace it."
   }
 }
 
@@ -286,6 +286,6 @@ variable "enable_network_policy" {
 
 variable "vpc_cni_addon_version" {
   type        = string
-  description = "VPC CNI addon version to pin when enable_network_policy is true. Set to the cluster's currently-running version (aws eks describe-addon --cluster-name <cluster> --addon-name vpc-cni --query 'addon.addonVersion') to avoid an unintended CNI upgrade on adoption."
+  description = "VPC CNI addon version to pin when enable_network_policy is true. Set to the cluster's currently-running version (set CLUSTER_NAME, then: aws eks describe-addon --cluster-name \"$CLUSTER_NAME\" --addon-name vpc-cni --query 'addon.addonVersion') to avoid an unintended CNI upgrade on adoption."
   default     = "v1.20.4-eksbuild.2"
 }

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -97,13 +97,13 @@ variable "gpu_node_instance_types" {
   default     = ["g4dn.xlarge"]
 }
 
-variable "craft_enabled" {
+variable "enable_craft" {
   type        = bool
   description = "Create a dedicated Craft sandbox node group (labeled onyx.app/workload=sandbox, tainted workload=sandbox:NoSchedule, IMDSv2 hop-limit 1). Opt-in per workspace."
   default     = false
 
   validation {
-    condition     = !var.craft_enabled || !contains(keys(var.eks_managed_node_groups), "sandbox")
+    condition     = !var.enable_craft || !contains(keys(var.eks_managed_node_groups), "sandbox")
     error_message = "craft_enabled injects a node group under the key \"sandbox\", which eks_managed_node_groups already defines. Rename your group so the Craft group does not replace it."
   }
 }
@@ -136,6 +136,11 @@ variable "craft_sandbox_node_disk_size_gb" {
   type        = number
   description = "Root EBS volume (GiB) for Craft sandbox nodes. Size so ephemeral-storage is NOT the binding scheduling dimension: each sandbox pod reserves ~5.5Gi eph, so allow (max_sandboxes_per_node * 5.5Gi) + system/image headroom. The AMI default (~20Gi) caps a node at ~3 sandboxes despite ~7 by CPU."
   default     = 200
+
+  validation {
+    condition     = var.craft_sandbox_node_disk_size_gb >= 20
+    error_message = "craft_sandbox_node_disk_size_gb must be at least 20 GiB; the AL2023 AMI and OS overlay consume ~8 GiB, leaving too little ephemeral storage for even one sandbox pod (5Gi request) below that threshold."
+  }
 }
 
 variable "eks_managed_node_groups" {
@@ -281,6 +286,6 @@ variable "enable_network_policy" {
 
 variable "vpc_cni_addon_version" {
   type        = string
-  description = "VPC CNI addon version to pin when enable_network_policy is true. Set to the cluster's currently-running version (aws eks describe-addon --addon-name vpc-cni) to avoid an unintended CNI upgrade on adoption."
+  description = "VPC CNI addon version to pin when enable_network_policy is true. Set to the cluster's currently-running version (aws eks describe-addon --cluster-name <cluster> --addon-name vpc-cni --query 'addon.addonVersion') to avoid an unintended CNI upgrade on adoption."
   default     = "v1.20.4-eksbuild.2"
 }

--- a/deployment/terraform/modules/aws/eks/versions.tf
+++ b/deployment/terraform/modules/aws/eks/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.100"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.16"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.37"
+    }
+  }
+}

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -145,9 +145,10 @@ provider "aws" {
 module "vpc" {
   source = "../vpc"
 
-  count    = var.create_vpc ? 1 : 0
-  vpc_name = local.vpc_name
-  tags     = local.merged_tags
+  count              = var.create_vpc ? 1 : 0
+  vpc_name           = local.vpc_name
+  single_nat_gateway = var.single_nat_gateway
+  tags               = local.merged_tags
 }
 
 module "redis" {
@@ -247,7 +248,7 @@ module "eks" {
   enable_gpu_node         = var.enable_gpu_node
   gpu_node_instance_types = var.gpu_node_instance_types
 
-  craft_enabled                     = var.craft_enabled
+  craft_enabled                     = var.enable_craft
   craft_sandbox_node_instance_types = var.craft_sandbox_node_instance_types
   craft_sandbox_node_min_size       = var.craft_sandbox_node_min_size
   craft_sandbox_node_max_size       = var.craft_sandbox_node_max_size

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -1,18 +1,31 @@
 locals {
-  workspace       = terraform.workspace
-  name            = var.name
-  merged_tags     = merge(var.tags, { tenant = local.name, environment = local.workspace })
-  vpc_name        = "${var.name}-vpc-${local.workspace}"
-  cluster_name    = "${var.name}-${local.workspace}"
-  bucket_name     = "${var.name}-file-store-${local.workspace}"
-  redis_name      = "${var.name}-redis-${local.workspace}"
-  postgres_name   = "${var.name}-postgres-${local.workspace}"
-  opensearch_name = var.opensearch_domain_name != null ? var.opensearch_domain_name : "${var.name}-opensearch-${local.workspace}"
+  workspace          = terraform.workspace
+  name               = var.name
+  merged_tags        = merge(var.tags, { tenant = local.name, environment = local.workspace })
+  vpc_name           = "${var.name}-vpc-${local.workspace}"
+  cluster_name       = "${var.name}-${local.workspace}"
+  bucket_name        = "${var.name}-file-store-${local.workspace}"
+  upload_bucket_name = "${var.name}-file-uploads-${local.workspace}"
+  redis_name         = "${var.name}-redis-${local.workspace}"
+  postgres_name      = "${var.name}-postgres-${local.workspace}"
+  opensearch_name    = var.opensearch_domain_name != null ? var.opensearch_domain_name : "${var.name}-opensearch-${local.workspace}"
 
   vpc_id          = var.create_vpc ? module.vpc[0].vpc_id : var.vpc_id
   private_subnets = var.create_vpc ? module.vpc[0].private_subnets : var.private_subnets
   public_subnets  = var.create_vpc ? module.vpc[0].public_subnets : var.public_subnets
   vpc_cidr_block  = var.create_vpc ? module.vpc[0].vpc_cidr_block : var.vpc_cidr_block
+
+  trusted_vpc_nat_gateway_cidrs = var.waf_trust_vpc_nat_gateway_ips ? [
+    for ip in try(module.vpc[0].nat_gateway_public_ips, []) : "${ip}/32"
+  ] : []
+  waf_allowed_ip_cidrs = distinct(concat(
+    var.waf_allowed_ip_cidrs,
+    local.trusted_vpc_nat_gateway_cidrs,
+  ))
+  waf_rate_limit_exempt_ip_cidrs = distinct(concat(
+    var.waf_rate_limit_exempt_ip_cidrs,
+    local.trusted_vpc_nat_gateway_cidrs,
+  ))
 
   # T-shirt size defaults. Calibrated against the Onyx-managed production
   # fleet (Jul 2026): memory, not CPU, is the binding dimension on the EKS
@@ -114,10 +127,9 @@ locals {
   opensearch_ebs_throughput                = coalesce(var.opensearch_ebs_throughput, local.sizing.opensearch_ebs_throughput)
 
   # A domain's subnet count must match its AZ spread: 1 subnet without zone
-  # awareness (single-data-node tiers), 3 with it. Changing the subnet set on
-  # an existing domain REPLACES it (vpc_options is ForceNew in the provider) —
-  # see the README migration note before toggling zone awareness or size tiers
-  # on a live domain.
+  # awareness, 3 with it. Changing the subnet set on an existing domain
+  # REPLACES it (vpc_options is ForceNew in the provider). Pass
+  # opensearch_subnet_ids explicitly on a live domain.
   opensearch_subnet_ids = length(var.opensearch_subnet_ids) > 0 ? var.opensearch_subnet_ids : (
     local.opensearch_zone_awareness_enabled ? slice(local.private_subnets, 0, 3) : slice(local.private_subnets, 0, 1)
   )
@@ -147,8 +159,14 @@ module "redis" {
   ingress_cidrs = [local.vpc_cidr_block]
   tags          = local.merged_tags
 
-  # Pass Redis authentication token as a sensitive input variable
-  auth_token = var.redis_auth_token
+  # Enable IAM authentication if specified
+  enable_redis_iam_auth = var.enable_redis_iam_auth
+
+  # Caller-supplied token. Only used when IAM authentication is disabled, and
+  # required in that case because transit encryption is on by default.
+  auth_token = var.enable_redis_iam_auth ? null : var.redis_auth_token
+
+  alarm_actions = var.alarm_actions
 }
 
 module "postgres" {
@@ -161,6 +179,7 @@ module "postgres" {
   instance_type  = local.postgres_instance_type
   storage_gb     = local.postgres_storage_gb
   max_storage_gb = local.postgres_max_storage_gb
+  storage_type   = var.postgres_storage_type
 
   username            = var.postgres_username
   password            = var.postgres_password
@@ -169,6 +188,10 @@ module "postgres" {
 
   backup_retention_period = var.postgres_backup_retention_period
   backup_window           = var.postgres_backup_window
+
+  connections_alarm_threshold = var.postgres_connections_alarm_threshold
+
+  alarm_actions = var.alarm_actions
 }
 
 module "s3" {
@@ -178,35 +201,26 @@ module "s3" {
   s3_vpc_endpoint_id = var.create_vpc ? module.vpc[0].s3_vpc_endpoint_id : var.s3_vpc_endpoint_id
 }
 
+module "s3_upload" {
+  count              = var.enable_upload_bucket ? 1 : 0
+  source             = "../s3"
+  bucket_name        = local.upload_bucket_name
+  tags               = local.merged_tags
+  s3_vpc_endpoint_id = var.create_vpc ? module.vpc[0].s3_vpc_endpoint_id : var.s3_vpc_endpoint_id
+}
+
 module "eks" {
   source          = "../eks"
   cluster_name    = local.cluster_name
+  cluster_version = var.eks_cluster_version
   vpc_id          = local.vpc_id
   subnet_ids      = concat(local.private_subnets, local.public_subnets)
   tags            = local.merged_tags
-  s3_bucket_names = [local.bucket_name]
-
-  main_node_instance_types  = local.main_node_instance_types
-  main_node_min_size        = local.main_node_min_size
-  main_node_max_size        = local.main_node_max_size
-  vespa_node_enabled        = local.vespa_node_enabled
-  vespa_node_instance_types = local.vespa_node_instance_types
-  vespa_node_disk_size_gb   = local.vespa_node_disk_size_gb
+  s3_bucket_names = concat([local.bucket_name], var.enable_upload_bucket ? [local.upload_bucket_name] : [])
 
   irsa_additional_service_account_names = var.irsa_additional_service_account_names
 
-  enable_craft                      = var.enable_craft
-  craft_sandbox_node_instance_types = var.craft_sandbox_node_instance_types
-  craft_sandbox_node_min_size       = var.craft_sandbox_node_min_size
-  craft_sandbox_node_max_size       = var.craft_sandbox_node_max_size
-  craft_sandbox_node_desired_size   = var.craft_sandbox_node_desired_size
-  craft_sandbox_node_disk_size_gb   = var.craft_sandbox_node_disk_size_gb
-
-  main_node_subnet_ids = length(var.main_node_subnet_ids) > 0 ? var.main_node_subnet_ids : (
-    var.main_node_private_subnets_only ? local.private_subnets : []
-  )
-
-  # Wire RDS IAM connection for the same IRSA service account used by apps
+  # Attach RDS IAM connect policy to the same IRSA role used by S3 access
   enable_rds_iam_for_service_account = var.enable_iam_auth
   rds_db_username                    = var.postgres_username
   rds_db_connect_arn                 = var.rds_db_connect_arn
@@ -216,9 +230,37 @@ module "eks" {
   private_cluster_enabled              = var.private_cluster_enabled
   cluster_endpoint_public_access_cidrs = var.cluster_endpoint_public_access_cidrs
 
+  # Node group instance types
+  main_node_instance_types  = local.main_node_instance_types
+  vespa_node_enabled        = local.vespa_node_enabled
+  vespa_node_instance_types = local.vespa_node_instance_types
+  vespa_node_disk_size_gb   = local.vespa_node_disk_size_gb
+  vespa_node_subnet_ids     = var.vespa_node_subnet_ids
+  main_node_subnet_ids = length(var.main_node_subnet_ids) > 0 ? var.main_node_subnet_ids : (
+    var.main_node_private_subnets_only ? local.private_subnets : []
+  )
+
+  # Node group scaling bounds (defaults preserve prior behavior: min 1 / max 5)
+  main_node_min_size = local.main_node_min_size
+  main_node_max_size = local.main_node_max_size
+  # Optional dedicated GPU node group (opt-in per customer; default off)
+  enable_gpu_node         = var.enable_gpu_node
+  gpu_node_instance_types = var.gpu_node_instance_types
+
+  craft_enabled                     = var.craft_enabled
+  craft_sandbox_node_instance_types = var.craft_sandbox_node_instance_types
+  craft_sandbox_node_min_size       = var.craft_sandbox_node_min_size
+  craft_sandbox_node_max_size       = var.craft_sandbox_node_max_size
+  craft_sandbox_node_desired_size   = var.craft_sandbox_node_desired_size
+  craft_sandbox_node_disk_size_gb   = var.craft_sandbox_node_disk_size_gb
+
   # Control plane logging
   cluster_enabled_log_types              = var.eks_cluster_enabled_log_types
   cloudwatch_log_group_retention_in_days = var.eks_cloudwatch_log_group_retention_in_days
+
+  # NetworkPolicy enforcement (opt-in per cluster; default off)
+  enable_network_policy = var.enable_network_policy
+  vpc_cni_addon_version = var.vpc_cni_addon_version
 }
 
 module "waf" {
@@ -228,7 +270,9 @@ module "waf" {
   tags = local.merged_tags
 
   # WAF configuration with sensible defaults
-  allowed_ip_cidrs                      = var.waf_allowed_ip_cidrs
+  allowed_ip_cidrs                      = local.waf_allowed_ip_cidrs
+  rate_limit_exempt_ip_cidrs            = local.waf_rate_limit_exempt_ip_cidrs
+  anonymous_ip_list_count_only          = var.waf_anonymous_ip_list_count_only
   common_rule_set_count_rules           = var.waf_common_rule_set_count_rules
   rate_limit_requests_per_5_minutes     = var.waf_rate_limit_requests_per_5_minutes
   api_rate_limit_requests_per_5_minutes = var.waf_api_rate_limit_requests_per_5_minutes
@@ -261,8 +305,8 @@ module "opensearch" {
   multi_az_with_standby_enabled = local.opensearch_multi_az_with_standby_enabled
   zone_awareness_enabled        = local.opensearch_zone_awareness_enabled
   ebs_volume_size               = local.opensearch_ebs_volume_size
-  ebs_iops                      = local.opensearch_ebs_iops
   ebs_throughput                = local.opensearch_ebs_throughput
+  ebs_iops                      = local.opensearch_ebs_iops
 
   # Authentication
   internal_user_database_enabled = var.opensearch_internal_user_database_enabled
@@ -272,4 +316,8 @@ module "opensearch" {
   # Logging
   enable_logging     = var.opensearch_enable_logging
   log_retention_days = var.opensearch_log_retention_days
+
+  alarm_actions = var.alarm_actions
 }
+
+

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -249,7 +249,7 @@ module "eks" {
   enable_gpu_node         = var.enable_gpu_node
   gpu_node_instance_types = var.gpu_node_instance_types
 
-  craft_enabled                     = var.enable_craft
+  enable_craft                      = var.enable_craft
   craft_sandbox_node_instance_types = var.craft_sandbox_node_instance_types
   craft_sandbox_node_min_size       = var.craft_sandbox_node_min_size
   craft_sandbox_node_max_size       = var.craft_sandbox_node_max_size

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -181,6 +181,7 @@ module "postgres" {
   storage_gb     = local.postgres_storage_gb
   max_storage_gb = local.postgres_max_storage_gb
   storage_type   = var.postgres_storage_type
+  multi_az       = var.postgres_multi_az
 
   username            = var.postgres_username
   password            = var.postgres_password

--- a/deployment/terraform/modules/aws/onyx/outputs.tf
+++ b/deployment/terraform/modules/aws/onyx/outputs.tf
@@ -16,7 +16,7 @@ output "oidc_provider" {
 }
 
 output "workload_irsa_role_arn" {
-  description = "ARN of the IAM role for workloads (S3 + optional RDS)"
+  description = "ARN of the IAM role for workloads (S3 + RDS)"
   value       = module.eks.workload_irsa_role_arn
 }
 

--- a/deployment/terraform/modules/aws/onyx/outputs.tf
+++ b/deployment/terraform/modules/aws/onyx/outputs.tf
@@ -26,8 +26,13 @@ output "workload_irsa_service_account_subjects" {
 }
 
 output "postgres_endpoint" {
-  description = "RDS endpoint hostname"
+  description = "RDS endpoint in host:port form, as returned by AWS"
   value       = module.postgres.endpoint
+}
+
+output "postgres_address" {
+  description = "RDS hostname without the port, for callers building their own connection string"
+  value       = module.postgres.address
 }
 
 output "postgres_port" {

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -16,6 +16,12 @@ variable "create_vpc" {
   default     = true
 }
 
+variable "single_nat_gateway" {
+  type        = bool
+  description = "Route all private subnets through one NAT gateway. Cheaper, but the NAT becomes a single-AZ dependency. False provisions one per AZ."
+  default     = false
+}
+
 variable "vpc_id" {
   type        = string
   description = "ID of the VPC. Required if create_vpc is false."
@@ -309,7 +315,7 @@ variable "gpu_node_instance_types" {
   default     = ["g4dn.xlarge"]
 }
 
-variable "craft_enabled" {
+variable "enable_craft" {
   type        = bool
   description = "Create a dedicated Craft sandbox node group (labeled onyx.app/workload=sandbox, tainted workload=sandbox:NoSchedule, IMDSv2 hop-limit 1). Opt-in per workspace."
   default     = false

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -102,6 +102,12 @@ variable "postgres_storage_type" {
   default     = null
 }
 
+variable "postgres_multi_az" {
+  type        = bool
+  description = "Run an RDS standby in a second AZ. Roughly doubles database cost. Set true if a standby already exists, or Terraform removes it."
+  default     = false
+}
+
 variable "postgres_username" {
   type        = string
   description = "Username for the postgres database"

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -49,13 +49,11 @@ variable "vpc_cidr_block" {
 variable "tags" {
   type        = map(string)
   description = "Base tags applied to all AWS resources"
+  # Add an `Owner` tag here if your asset inventory expects one. Everything set
+  # here is stamped on every resource this module creates (EKS cluster + node
+  # groups/ASGs, RDS, S3, Redis, OpenSearch, WAF, VPC).
   default = {
     "project" = "onyx"
-    # Vanta reads inventory ownership from the `Owner` tag. Setting it here
-    # stamps every resource this module creates (EKS cluster + node
-    # groups/ASGs, RDS, S3, Redis, OpenSearch, WAF, VPC) so they pass the
-    # "Inventory items have active owners" test.
-    "Owner" = "justin@onyx.app"
   }
 }
 
@@ -251,7 +249,7 @@ variable "waf_enable_logging" {
 
 variable "waf_log_retention_days" {
   type        = number
-  description = "Number of days to retain WAF logs. Default 400 = 12 months + 30-day buffer for Vanta `logs-retained-for-twelve-months-config`."
+  description = "Number of days to retain WAF logs. Default 400 = 12 months + 30-day buffer for the common twelve-month log-retention control."
   default     = 400
 }
 
@@ -501,7 +499,7 @@ variable "eks_cluster_enabled_log_types" {
 
 variable "eks_cloudwatch_log_group_retention_in_days" {
   type        = number
-  description = "Number of days to retain EKS control plane logs in CloudWatch (0 = never expire). Default 400 = 12 months + 30-day buffer for Vanta `logs-retained-for-twelve-months-config`."
+  description = "Number of days to retain EKS control plane logs in CloudWatch (0 = never expire). Default 400 = 12 months + 30-day buffer for the common twelve-month log-retention control."
   default     = 400
 
   validation {

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -40,33 +40,26 @@ variable "vpc_cidr_block" {
   default     = null
 }
 
-variable "s3_vpc_endpoint_id" {
-  type        = string
-  description = "ID of an existing S3 gateway VPC endpoint when reusing an existing VPC"
-  default     = null
-
-  validation {
-    condition     = var.create_vpc || var.s3_vpc_endpoint_id != null
-    error_message = "s3_vpc_endpoint_id must be provided when create_vpc is false."
-  }
-}
-
 variable "tags" {
   type        = map(string)
   description = "Base tags applied to all AWS resources"
   default = {
     "project" = "onyx"
+    # Vanta reads inventory ownership from the `Owner` tag. Setting it here
+    # stamps every resource this module creates (EKS cluster + node
+    # groups/ASGs, RDS, S3, Redis, OpenSearch, WAF, VPC) so they pass the
+    # "Inventory items have active owners" test.
+    "Owner" = "justin@onyx.app"
   }
 }
 
 variable "size" {
   type        = string
   description = <<-EOT
-    T-shirt size that sets coherent defaults for every compute/data-plane knob
-    (EKS node groups, RDS, ElastiCache, OpenSearch). Rough guide:
-      small  — pilots and small teams: up to ~200 users, < ~500k documents
-      medium — typical department/company: ~200-1,000 users, ~0.5-2M documents
-      large  — org-wide deployments: 1,000+ users, multi-million documents
+    T-shirt size that sets coherent defaults for every compute/data-plane knob:
+      small  - pilots and small teams: up to ~200 users, < ~500k documents
+      medium - typical department/company: ~200-1,000 users, ~0.5-2M documents
+      large  - org-wide deployments: 1,000+ users, multi-million documents
     Any individual sizing variable set to a non-null value overrides its tier
     default. See the README for the full per-tier table.
   EOT
@@ -78,45 +71,10 @@ variable "size" {
   }
 }
 
-variable "main_node_instance_types" {
-  type        = list(string)
-  description = "Instance types for the main EKS node group. Null uses the t-shirt size default."
-  default     = null
-}
-
-variable "main_node_min_size" {
-  type        = number
-  description = "Minimum main node group size (autoscaler floor). Null uses the t-shirt size default."
-  default     = null
-}
-
-variable "main_node_max_size" {
-  type        = number
-  description = "Maximum main node group size. Null uses the t-shirt size default."
-  default     = null
-}
-
-variable "vespa_node_enabled" {
-  type        = bool
-  description = "Whether to create the dedicated document-index node group. Null uses the t-shirt size default (small omits it: the small chart sizing fits the index on the main node, and on fresh clusters the group's taint would leave it idle anyway)."
-  default     = null
-}
-
-variable "vespa_node_instance_types" {
-  type        = list(string)
-  description = "Instance types for the dedicated document-index (Vespa/OpenSearch STS) node group. Only relevant when running the index in-cluster. Null uses the t-shirt size default."
-  default     = null
-}
-
-variable "vespa_node_disk_size_gb" {
-  type        = number
-  description = "Root EBS volume (GiB) for the document-index node. Null uses the t-shirt size default."
-  default     = null
-}
 
 variable "postgres_instance_type" {
   type        = string
-  description = "RDS instance class. Null uses the t-shirt size default."
+  description = "RDS instance class Null uses the t-shirt size default."
   default     = null
 }
 
@@ -128,13 +86,13 @@ variable "postgres_storage_gb" {
 
 variable "postgres_max_storage_gb" {
   type        = number
-  description = "RDS storage-autoscaling ceiling in GiB. 0 disables autoscaling; null uses the t-shirt size default."
+  description = "RDS storage-autoscaling ceiling in GiB. Null or 0 disables autoscaling. Null uses the t-shirt size default."
   default     = null
 }
 
-variable "redis_instance_type" {
+variable "postgres_storage_type" {
   type        = string
-  description = "ElastiCache node type for the Redis replication group. Null uses the t-shirt size default."
+  description = "EBS storage type for the RDS instance. Null keeps the instance's existing type (fleet DBs predate this variable and run gp2)."
   default     = null
 }
 
@@ -161,25 +119,13 @@ variable "public_cluster_enabled" {
 variable "private_cluster_enabled" {
   type        = bool
   description = "Whether to enable private cluster access"
-  default     = false # Should be true for production, false for dev/staging
+  default     = true # Should be true for production, false for dev/staging
 }
 
 variable "cluster_endpoint_public_access_cidrs" {
   type        = list(string)
-  description = "CIDR blocks allowed to access the public EKS API endpoint"
+  description = "CIDR blocks allowed to access the public EKS API endpoint. Empty denies all public access; set this if public_cluster_enabled is true."
   default     = []
-}
-
-variable "main_node_subnet_ids" {
-  type        = list(string)
-  description = "Explicit subnet IDs for the main node group. Takes precedence over main_node_private_subnets_only."
-  default     = []
-}
-
-variable "main_node_private_subnets_only" {
-  type        = bool
-  description = "When true, pins the main node group to the VPC's private subnets so node egress always exits via the NAT gateway IP. Ignored if main_node_subnet_ids is set."
-  default     = false
 }
 
 variable "redis_auth_token" {
@@ -189,45 +135,10 @@ variable "redis_auth_token" {
   sensitive   = true
 }
 
-variable "enable_craft" {
-  type        = bool
-  description = "Enable Craft infrastructure. Currently provisions a dedicated, IMDSv2-hardened Craft sandbox node group (labeled/tainted for sandbox pods)."
-  default     = false
-}
-
-variable "craft_sandbox_node_instance_types" {
-  type        = list(string)
-  description = "Instance types for the Craft sandbox node group."
-  default     = ["m5.large"]
-}
-
-variable "craft_sandbox_node_min_size" {
-  type        = number
-  description = "Min size of the Craft sandbox node group. Keep >= 1: cluster-autoscaler can only scale a group back up from zero with node-template label/taint ASG tags, which are not configured here, so a value of 0 would leave sandbox pods Pending after idle scale-down."
-  default     = 1
-}
-
-variable "craft_sandbox_node_max_size" {
-  type        = number
-  description = "Max size of the Craft sandbox node group."
-  default     = 4
-}
-
-variable "craft_sandbox_node_desired_size" {
-  type        = number
-  description = "Desired size of the Craft sandbox node group."
-  default     = 1
-}
-
-variable "craft_sandbox_node_disk_size_gb" {
-  type        = number
-  description = "Root EBS volume (GiB) for Craft sandbox nodes. Size relative to the instance's vCPU and the sandbox pod's ephemeral-storage request (default 5Gi/pod). The default suits the default m5.large; raise it for larger instances."
-  default     = 50
-
-  validation {
-    condition     = var.craft_sandbox_node_disk_size_gb >= 20
-    error_message = "craft_sandbox_node_disk_size_gb must be at least 20 GiB; the AL2023 AMI and OS overlay consume ~8 GiB, leaving too little ephemeral storage for even one sandbox pod (5Gi request) below that threshold."
-  }
+variable "redis_instance_type" {
+  type        = string
+  description = "ElastiCache node type for the Redis replication group Null uses the t-shirt size default."
+  default     = null
 }
 
 variable "enable_iam_auth" {
@@ -236,10 +147,33 @@ variable "enable_iam_auth" {
   default     = false
 }
 
+variable "enable_redis_iam_auth" {
+  type        = bool
+  description = "Enable AWS IAM authentication for the Redis ElastiCache instance"
+  default     = false
+}
+
+variable "enable_upload_bucket" {
+  type        = bool
+  description = "Provision an additional S3 bucket dedicated to uploads"
+  default     = false
+}
+
 variable "irsa_additional_service_account_names" {
   type        = list(string)
   description = "Additional service accounts in the Onyx namespace that may assume the workload IRSA role. Use the rendered ServiceAccount name for chart-created workloads, such as onyx-sandbox-proxy, that also need RDS IAM auth."
   default     = []
+}
+
+variable "s3_vpc_endpoint_id" {
+  type        = string
+  description = "ID of an existing S3 gateway VPC endpoint when reusing an existing VPC"
+  default     = null
+
+  validation {
+    condition     = var.create_vpc || var.s3_vpc_endpoint_id != null
+    error_message = "s3_vpc_endpoint_id must be provided when create_vpc is false."
+  }
 }
 
 variable "rds_db_connect_arn" {
@@ -261,6 +195,12 @@ variable "waf_allowed_ip_cidrs" {
   default     = []
 }
 
+variable "waf_trust_vpc_nat_gateway_ips" {
+  type        = bool
+  description = "Add public IPs from Terraform-managed VPC NAT gateways to the WAF allowlist and rate-limit exemptions."
+  default     = false
+}
+
 variable "waf_common_rule_set_count_rules" {
   type        = list(string)
   description = "Subrules within AWSManagedRulesCommonRuleSet to override to COUNT instead of BLOCK."
@@ -271,6 +211,18 @@ variable "waf_api_rate_limit_requests_per_5_minutes" {
   type        = number
   description = "Rate limit for API requests per 5 minutes per IP address"
   default     = 1000
+}
+
+variable "waf_rate_limit_exempt_ip_cidrs" {
+  type        = list(string)
+  description = "Optional IPv4 CIDR ranges exempt from WAF rate limiting rules."
+  default     = []
+}
+
+variable "waf_anonymous_ip_list_count_only" {
+  type        = bool
+  description = "If true, set AWSManagedRulesAnonymousIpList to COUNT instead of BLOCK."
+  default     = false
 }
 
 variable "waf_geo_restriction_countries" {
@@ -287,8 +239,110 @@ variable "waf_enable_logging" {
 
 variable "waf_log_retention_days" {
   type        = number
-  description = "Number of days to retain WAF logs"
-  default     = 90
+  description = "Number of days to retain WAF logs. Default 400 = 12 months + 30-day buffer for Vanta `logs-retained-for-twelve-months-config`."
+  default     = 400
+}
+
+variable "main_node_instance_types" {
+  type        = list(string)
+  description = "Instance types for the main EKS node group Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "vespa_node_enabled" {
+  type        = bool
+  description = "Whether to create the dedicated document-index node group. Disable for customers on a managed OpenSearch domain — the group otherwise sits idle. Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "vespa_node_instance_types" {
+  type        = list(string)
+  description = "Instance types for the Vespa EKS node group Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "vespa_node_disk_size_gb" {
+  type        = number
+  description = "Root EBS volume (GiB) for the Vespa/document-index node. Null keeps the node-group default (100 GiB). Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "vespa_node_subnet_ids" {
+  type        = list(string)
+  description = "Subnet IDs for the Vespa node group (must be in same AZ as Vespa PV)"
+  default     = []
+}
+
+variable "main_node_subnet_ids" {
+  type        = list(string)
+  description = "Explicit subnet IDs for the main node group. Takes precedence over main_node_private_subnets_only."
+  default     = []
+}
+
+variable "main_node_private_subnets_only" {
+  type        = bool
+  description = "When true, pins the main node group to the VPC's private subnets so node egress always exits via the NAT EIP. Ignored if main_node_subnet_ids is set."
+  default     = false
+}
+
+variable "main_node_min_size" {
+  type        = number
+  description = "Minimum number of nodes in the main node group. The cluster-autoscaler will not scale below this, so raise it to guarantee always-on baseline capacity for bursty workloads. Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "main_node_max_size" {
+  type        = number
+  description = "Maximum number of nodes the main node group may scale up to. Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "enable_gpu_node" {
+  type        = bool
+  description = "Whether to create a dedicated, tainted GPU node group for the embedding model server. Opt-in per customer."
+  default     = false
+}
+
+variable "gpu_node_instance_types" {
+  type        = list(string)
+  description = "Instance types for the GPU node group. g4dn.xlarge (1x NVIDIA T4) is sufficient for the embedding model."
+  default     = ["g4dn.xlarge"]
+}
+
+variable "craft_enabled" {
+  type        = bool
+  description = "Create a dedicated Craft sandbox node group (labeled onyx.app/workload=sandbox, tainted workload=sandbox:NoSchedule, IMDSv2 hop-limit 1). Opt-in per workspace."
+  default     = false
+}
+
+variable "craft_sandbox_node_instance_types" {
+  type        = list(string)
+  description = "Instance types for the Craft sandbox node group."
+  default     = ["m8i.2xlarge"]
+}
+
+variable "craft_sandbox_node_min_size" {
+  type        = number
+  description = "Min size of the Craft sandbox node group."
+  default     = 1
+}
+
+variable "craft_sandbox_node_max_size" {
+  type        = number
+  description = "Max size of the Craft sandbox node group (cluster-autoscaler scales between min and max)."
+  default     = 7
+}
+
+variable "craft_sandbox_node_desired_size" {
+  type        = number
+  description = "Desired size of the Craft sandbox node group."
+  default     = 1
+}
+
+variable "craft_sandbox_node_disk_size_gb" {
+  type        = number
+  description = "Root EBS volume (GiB) for Craft sandbox nodes. Size so ephemeral-storage is not the binding scheduling dimension (~5.5Gi reserved per sandbox pod); AMI default ~20Gi caps a node at ~3 sandboxes."
+  default     = 200
 }
 
 # OpenSearch Configuration Variables
@@ -306,13 +360,13 @@ variable "opensearch_engine_version" {
 
 variable "opensearch_instance_type" {
   type        = string
-  description = "Instance type for OpenSearch data nodes. Null uses the t-shirt size default."
+  description = "Instance type for OpenSearch data nodes Null uses the t-shirt size default."
   default     = null
 }
 
 variable "opensearch_instance_count" {
   type        = number
-  description = "Number of OpenSearch data nodes. Null uses the t-shirt size default."
+  description = "Number of OpenSearch data nodes Null uses the t-shirt size default."
   default     = null
 }
 
@@ -324,37 +378,37 @@ variable "opensearch_dedicated_master_enabled" {
 
 variable "opensearch_dedicated_master_type" {
   type        = string
-  description = "Instance type for dedicated master nodes. Null uses the t-shirt size default."
+  description = "Instance type for dedicated master nodes Null uses the t-shirt size default."
   default     = null
 }
 
 variable "opensearch_multi_az_with_standby_enabled" {
   type        = bool
-  description = "Whether to enable Multi-AZ with Standby deployment. Requires zone awareness and instance_count >= 3 when true. Null uses the t-shirt size default."
+  description = "Whether to enable Multi-AZ with Standby deployment Null uses the t-shirt size default."
   default     = null
 }
 
 variable "opensearch_zone_awareness_enabled" {
   type        = bool
-  description = "Whether to spread OpenSearch data nodes across AZs. Must be false for single-data-node domains. Null uses the t-shirt size default."
-  default     = null
-}
-
-variable "opensearch_ebs_volume_size" {
-  type        = number
-  description = "EBS volume size in GiB per OpenSearch node. Null uses the t-shirt size default."
+  description = "Whether to enable zone awareness for the OpenSearch cluster Null uses the t-shirt size default."
   default     = null
 }
 
 variable "opensearch_ebs_iops" {
   type        = number
-  description = "IOPS for gp3 volumes. Null uses the t-shirt size default."
+  description = "IOPS for OpenSearch gp3/io1 volumes Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "opensearch_ebs_volume_size" {
+  type        = number
+  description = "EBS volume size in GiB per OpenSearch node Null uses the t-shirt size default."
   default     = null
 }
 
 variable "opensearch_ebs_throughput" {
   type        = number
-  description = "Throughput in MiB/s for gp3 volumes. Null uses the t-shirt size default."
+  description = "Throughput in MiB/s for gp3 volumes Null uses the t-shirt size default."
   default     = null
 }
 
@@ -401,6 +455,12 @@ variable "opensearch_subnet_ids" {
   default     = []
 }
 
+variable "postgres_connections_alarm_threshold" {
+  type        = number
+  description = "DatabaseConnections alarm threshold. Size against the instance's actual max_connections — the postgres-module default (500) is below steady-state pool usage on large clusters."
+  default     = 500
+}
+
 # RDS Backup Configuration
 variable "postgres_backup_retention_period" {
   type        = number
@@ -415,6 +475,12 @@ variable "postgres_backup_window" {
 }
 
 # EKS Control Plane Logging
+variable "eks_cluster_version" {
+  type        = string
+  description = "EKS control plane Kubernetes version for this cluster (hop one cluster at a time; see the eks module default)"
+  default     = "1.33"
+}
+
 variable "eks_cluster_enabled_log_types" {
   type        = list(string)
   description = "EKS control plane log types to enable (valid: api, audit, authenticator, controllerManager, scheduler)"
@@ -423,11 +489,29 @@ variable "eks_cluster_enabled_log_types" {
 
 variable "eks_cloudwatch_log_group_retention_in_days" {
   type        = number
-  description = "Number of days to retain EKS control plane logs in CloudWatch (0 = never expire)"
-  default     = 30
+  description = "Number of days to retain EKS control plane logs in CloudWatch (0 = never expire). Default 400 = 12 months + 30-day buffer for Vanta `logs-retained-for-twelve-months-config`."
+  default     = 400
 
   validation {
     condition     = contains([0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653], var.eks_cloudwatch_log_group_retention_in_days)
     error_message = "Must be a valid CloudWatch retention value (0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653)."
   }
+}
+
+variable "enable_network_policy" {
+  type        = bool
+  description = "Adopt the VPC CNI addon and enable Kubernetes NetworkPolicy enforcement. Off by default: the addon stays unmanaged and existing NetworkPolicies remain inert. Only enable per cluster once its policies are known-safe."
+  default     = false
+}
+
+variable "vpc_cni_addon_version" {
+  type        = string
+  description = "VPC CNI addon version to pin when enable_network_policy is true. Set to the cluster's currently-running version (aws eks describe-addon --addon-name vpc-cni) to avoid an unintended CNI upgrade on adoption."
+  default     = "v1.20.4-eksbuild.2"
+}
+
+variable "alarm_actions" {
+  type        = list(string)
+  description = "SNS topic ARNs for RDS/ElastiCache CloudWatch alarm + ok actions. Empty = infra alarms exist but notify nothing."
+  default     = []
 }

--- a/deployment/terraform/modules/aws/opensearch/main.tf
+++ b/deployment/terraform/modules/aws/opensearch/main.tf
@@ -178,6 +178,15 @@ resource "aws_opensearch_domain" "main" {
   ]
 
   lifecycle {
+    # The master password is managed out-of-band (ESO / the app secret). AWS
+    # re-validates it on ANY domain update (even a tag change) and always shows it
+    # as a diff since it can't be read back — so Terraform re-sending it turns an
+    # unrelated tag update into a hard failure whenever the stored value doesn't
+    # meet OpenSearch's current complexity rules. Ignore it here; it's set on
+    # create and rotated externally thereafter.
+    ignore_changes = [
+      advanced_security_options[0].master_user_options[0].master_user_password,
+    ]
     precondition {
       condition     = !var.internal_user_database_enabled || var.master_user_name != null
       error_message = "master_user_name is required when internal_user_database_enabled is true."
@@ -226,4 +235,115 @@ resource "aws_cloudwatch_log_resource_policy" "opensearch" {
   count           = var.enable_logging ? 1 : 0
   policy_name     = "OpenSearchService-${var.name}-Search-logs"
   policy_document = data.aws_iam_policy_document.opensearch_log_policy[0].json
+}
+
+# ----------------------------------------------------------------------------
+# CloudWatch alarms (AWS/ES). Route to alarm_actions (SNS -> PagerDuty). These
+# cover the managed-domain clusters; clusters that run OpenSearch as an in-cluster
+# pod get their disk/pod failure modes from the kube-level PrometheusRules instead.
+# ----------------------------------------------------------------------------
+
+locals {
+  os_dimensions = {
+    DomainName = var.name
+    ClientId   = data.aws_caller_identity.current.account_id
+  }
+}
+
+# Red = one or more primary shards unallocated -> data unavailable. (Yellow is
+# structural on single-node domains and is intentionally NOT alarmed.)
+resource "aws_cloudwatch_metric_alarm" "cluster_status_red" {
+  alarm_name          = "${var.name}-cluster-status-red"
+  alarm_description   = "OpenSearch ${var.name} cluster status RED — data unavailable"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ClusterStatus.red"
+  namespace           = "AWS/ES"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = 1
+  treat_missing_data  = "missing"
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.alarm_actions
+  dimensions    = local.os_dimensions
+  tags          = var.tags
+}
+
+# Writes blocked = the flood-stage / disk-full state that surfaces as
+# "IndexWriter is closed" and stalls indexing. Highest-value OpenSearch alarm.
+resource "aws_cloudwatch_metric_alarm" "cluster_index_writes_blocked" {
+  alarm_name          = "${var.name}-index-writes-blocked"
+  alarm_description   = "OpenSearch ${var.name} is blocking index writes (flood-stage / disk)"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ClusterIndexWritesBlocked"
+  namespace           = "AWS/ES"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = 1
+  treat_missing_data  = "missing"
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.alarm_actions
+  dimensions    = local.os_dimensions
+  tags          = var.tags
+}
+
+# FreeStorageSpace is reported in MB (per node); Minimum catches the fullest node,
+# which is what trips the flood-stage write block above.
+resource "aws_cloudwatch_metric_alarm" "free_storage" {
+  alarm_name          = "${var.name}-free-storage"
+  alarm_description   = "OpenSearch ${var.name} free storage low"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "FreeStorageSpace"
+  namespace           = "AWS/ES"
+  period              = 300
+  statistic           = "Minimum"
+  threshold           = var.free_storage_threshold_mb != null ? var.free_storage_threshold_mb : var.ebs_volume_size * 1024 * 0.15
+  treat_missing_data  = "missing"
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.alarm_actions
+  dimensions    = local.os_dimensions
+  tags          = var.tags
+}
+
+# Sustained JVM heap pressure -> GC thrash / node instability.
+resource "aws_cloudwatch_metric_alarm" "jvm_memory_pressure" {
+  alarm_name          = "${var.name}-jvm-memory-pressure"
+  alarm_description   = "OpenSearch ${var.name} JVM memory pressure high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "JVMMemoryPressure"
+  namespace           = "AWS/ES"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = var.jvm_memory_pressure_threshold_percent
+  treat_missing_data  = "missing"
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.alarm_actions
+  dimensions    = local.os_dimensions
+  tags          = var.tags
+}
+
+# Fewer reachable nodes than provisioned = a node dropped out of the cluster.
+resource "aws_cloudwatch_metric_alarm" "nodes" {
+  alarm_name          = "${var.name}-nodes-low"
+  alarm_description   = "OpenSearch ${var.name} has fewer nodes than expected"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "Nodes"
+  namespace           = "AWS/ES"
+  period              = 300
+  statistic           = "Minimum"
+  threshold           = var.instance_count
+  treat_missing_data  = "missing"
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.alarm_actions
+  dimensions    = local.os_dimensions
+  tags          = var.tags
 }

--- a/deployment/terraform/modules/aws/opensearch/variables.tf
+++ b/deployment/terraform/modules/aws/opensearch/variables.tf
@@ -240,3 +240,31 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "alarm_actions" {
+  description = "SNS topic ARNs to notify on CloudWatch alarm/ok. Empty = alarms exist but notify nothing."
+  type        = list(string)
+  default     = []
+}
+
+variable "jvm_memory_pressure_threshold_percent" {
+  description = "JVMMemoryPressure alarm threshold (percent)."
+  type        = number
+  default     = 90
+
+  validation {
+    condition     = var.jvm_memory_pressure_threshold_percent >= 0 && var.jvm_memory_pressure_threshold_percent <= 100
+    error_message = "jvm_memory_pressure_threshold_percent must be between 0 and 100."
+  }
+}
+
+variable "free_storage_threshold_mb" {
+  description = "FreeStorageSpace alarm floor in MB (OpenSearch reports this metric in MB). Null = 15% of ebs_volume_size."
+  type        = number
+  default     = null
+
+  validation {
+    condition     = var.free_storage_threshold_mb == null || var.free_storage_threshold_mb > 0
+    error_message = "free_storage_threshold_mb must be null or greater than 0."
+  }
+}

--- a/deployment/terraform/modules/aws/opensearch/versions.tf
+++ b/deployment/terraform/modules/aws/opensearch/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.100"
+    }
+  }
+}

--- a/deployment/terraform/modules/aws/postgres/main.tf
+++ b/deployment/terraform/modules/aws/postgres/main.tf
@@ -1,10 +1,29 @@
+# These two gained `count`, which renames them `this` -> `this[0]` in state.
+# Without these blocks Terraform plans a destroy/create of the subnet group and
+# security group of every database already using this module — and the security
+# group is attached to a live instance.
+moved {
+  from = aws_db_subnet_group.this
+  to   = aws_db_subnet_group.this[0]
+}
+
+moved {
+  from = aws_security_group.this
+  to   = aws_security_group.this[0]
+}
+
+# Skipped when the caller supplies existing networking. Joining the subnet group
+# and security groups an existing database already uses is the reliable way to
+# inherit its reachability rather than re-deriving it.
 resource "aws_db_subnet_group" "this" {
+  count      = var.db_subnet_group_name == null ? 1 : 0
   name       = "${var.identifier}-subnet-group"
   subnet_ids = var.subnet_ids
   tags       = var.tags
 }
 
 resource "aws_security_group" "this" {
+  count       = var.vpc_security_group_ids == null ? 1 : 0
   name        = "${var.identifier}-sg"
   description = "Allow PostgreSQL access"
   vpc_id      = var.vpc_id
@@ -35,14 +54,24 @@ resource "aws_db_instance" "this" {
   allocated_storage     = var.storage_gb
   max_allocated_storage = var.max_storage_gb
   storage_type          = var.storage_type
+  iops                  = var.iops
+  storage_throughput    = var.storage_throughput
   username              = var.username
-  password              = var.password
+
+  # Mutually exclusive: the provider rejects both being set.
+  password                    = var.manage_master_user_password ? null : var.password
+  manage_master_user_password = var.manage_master_user_password ? true : null
+
+  multi_az                     = var.multi_az
+  parameter_group_name         = var.parameter_group_name
+  performance_insights_enabled = var.performance_insights_enabled
+  maintenance_window           = var.maintenance_window
 
   # Enable IAM authentication for the RDS instance
   iam_database_authentication_enabled = var.enable_rds_iam_auth
 
-  db_subnet_group_name   = aws_db_subnet_group.this.name
-  vpc_security_group_ids = [aws_security_group.this.id]
+  db_subnet_group_name   = var.db_subnet_group_name != null ? var.db_subnet_group_name : aws_db_subnet_group.this[0].name
+  vpc_security_group_ids = var.vpc_security_group_ids != null ? var.vpc_security_group_ids : [aws_security_group.this[0].id]
   publicly_accessible    = false
   deletion_protection    = true
   storage_encrypted      = true
@@ -52,6 +81,15 @@ resource "aws_db_instance" "this" {
   backup_window           = var.backup_window
 
   tags = var.tags
+
+  # Guardrail: this instance holds production data. Never let Terraform
+  # destroy/replace it — a plan that would (e.g. enabling storage_encrypted on an
+  # existing unencrypted instance, which RDS can't do in place) fails here instead
+  # of silently recreating an empty DB. A real migration (snapshot -> restore into
+  # a new encrypted instance) is done deliberately with this guard removed.
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # CloudWatch alarm for CPU utilization monitoring
@@ -88,6 +126,55 @@ resource "aws_cloudwatch_metric_alarm" "read_iops" {
   period              = var.iops_alarm_period
   statistic           = "Average"
   threshold           = var.read_iops_alarm_threshold
+  treat_missing_data  = "missing"
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.alarm_actions
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.this.identifier
+  }
+
+  tags = var.tags
+}
+
+# FreeStorageSpace floor. A full data volume (WAL runaway, unpurged logs, an
+# inactive replication slot) wedges the writer. Default trips at 15% of the base
+# allocated storage.
+resource "aws_cloudwatch_metric_alarm" "free_storage" {
+  alarm_name          = "${var.identifier}-free-storage"
+  alarm_description   = "RDS free storage low for ${var.identifier}"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "FreeStorageSpace"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = var.free_storage_threshold_bytes != null ? var.free_storage_threshold_bytes : var.storage_gb * 1024 * 1024 * 1024 * 0.15
+  treat_missing_data  = "missing"
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.alarm_actions
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.this.identifier
+  }
+
+  tags = var.tags
+}
+
+# Connection count near the ceiling. A task holding a session across an external
+# call, or a request-cancel leak, saturates the pool and new pods fail startup.
+resource "aws_cloudwatch_metric_alarm" "database_connections" {
+  alarm_name          = "${var.identifier}-database-connections"
+  alarm_description   = "RDS connection count high for ${var.identifier}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "DatabaseConnections"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = var.connections_alarm_threshold
   treat_missing_data  = "missing"
 
   alarm_actions = var.alarm_actions

--- a/deployment/terraform/modules/aws/postgres/outputs.tf
+++ b/deployment/terraform/modules/aws/postgres/outputs.tf
@@ -23,3 +23,13 @@ output "dbi_resource_id" {
   description = "DB instance resource ID used for IAM auth resource ARNs"
   value       = aws_db_instance.this.resource_id
 }
+
+output "address" {
+  description = "RDS hostname without the port, for callers that build their own DSN"
+  value       = aws_db_instance.this.address
+}
+
+output "master_user_secret_arn" {
+  description = "Secrets Manager ARN of the RDS-managed master password, null unless manage_master_user_password is set"
+  value       = try(aws_db_instance.this.master_user_secret[0].secret_arn, null)
+}

--- a/deployment/terraform/modules/aws/postgres/variables.tf
+++ b/deployment/terraform/modules/aws/postgres/variables.tf
@@ -15,12 +15,6 @@ variable "instance_type" {
   default     = "db.t4g.large" # 2 vCPU and 8 GB of memory
 }
 
-variable "storage_gb" {
-  type        = number
-  description = "Initial allocated storage in GB. RDS storage can grow but never shrink."
-  default     = 20
-}
-
 variable "max_storage_gb" {
   type        = number
   description = "Upper limit in GB for RDS storage autoscaling. Null or 0 disables autoscaling."
@@ -35,8 +29,14 @@ variable "max_storage_gb" {
 
 variable "storage_type" {
   type        = string
-  description = "EBS storage type for the RDS instance. gp3 gives 3000 baseline IOPS regardless of size; older stacks created before this variable existed are on gp2."
-  default     = "gp3"
+  description = "EBS storage type for the RDS instance. Null keeps the instance's existing type (fleet DBs predate this variable and run gp2); prefer gp3 for new stacks."
+  default     = null
+}
+
+variable "storage_gb" {
+  type        = number
+  description = "Storage size in GB"
+  default     = 20
 }
 
 variable "engine_version" {
@@ -47,17 +47,20 @@ variable "engine_version" {
 
 variable "vpc_id" {
   type        = string
-  description = "VPC ID"
+  description = "VPC ID. Unused when vpc_security_group_ids is set."
+  default     = null
 }
 
 variable "subnet_ids" {
   type        = list(string)
-  description = "Subnet IDs"
+  description = "Subnet IDs. Unused when db_subnet_group_name is set."
+  default     = []
 }
 
 variable "ingress_cidrs" {
   type        = list(string)
-  description = "Ingress CIDR blocks"
+  description = "Ingress CIDR blocks. Unused when vpc_security_group_ids is set."
+  default     = []
 }
 
 variable "username" {
@@ -212,4 +215,84 @@ variable "alarm_actions" {
   type        = list(string)
   description = "List of ARNs to notify when the alarm transitions state (e.g. SNS topic ARNs)"
   default     = []
+}
+
+variable "free_storage_threshold_bytes" {
+  type        = number
+  description = "FreeStorageSpace alarm floor in bytes. Null = 15% of allocated storage_gb."
+  default     = null
+
+  validation {
+    condition     = var.free_storage_threshold_bytes == null || var.free_storage_threshold_bytes > 0
+    error_message = "free_storage_threshold_bytes must be null or greater than 0."
+  }
+}
+
+variable "connections_alarm_threshold" {
+  type        = number
+  description = "DatabaseConnections alarm threshold (count)."
+  default     = 500
+
+  validation {
+    condition     = var.connections_alarm_threshold > 0
+    error_message = "connections_alarm_threshold must be greater than 0."
+  }
+}
+
+# --- Multi-AZ / tenant-shard support -----------------------------------------
+# Added for the multi-tenant shards, which need a standby, a shared parameter
+# group, and the ability to sit inside networking that already exists.
+
+variable "multi_az" {
+  type        = bool
+  description = "Run a standby in a second AZ. Doubles cost; required for anything serving tenants."
+  default     = false
+}
+
+variable "iops" {
+  type        = number
+  description = "Provisioned IOPS for gp3/io1. Null uses the gp3 baseline for the volume size."
+  default     = null
+}
+
+variable "storage_throughput" {
+  type        = number
+  description = "Provisioned throughput (MB/s) for gp3. Null uses the gp3 baseline."
+  default     = null
+}
+
+variable "parameter_group_name" {
+  type        = string
+  description = "Existing DB parameter group. Null uses the engine default."
+  default     = null
+}
+
+variable "performance_insights_enabled" {
+  type        = bool
+  description = "Enable Performance Insights."
+  default     = false
+}
+
+variable "maintenance_window" {
+  type        = string
+  description = "Preferred maintenance window, e.g. sat:10:10-sat:10:40."
+  default     = null
+}
+
+variable "manage_master_user_password" {
+  type        = bool
+  description = "Let RDS generate and rotate the master password in Secrets Manager. Mutually exclusive with `password`."
+  default     = false
+}
+
+variable "db_subnet_group_name" {
+  type        = string
+  description = "Existing subnet group to join. Null creates one from `subnet_ids`."
+  default     = null
+}
+
+variable "vpc_security_group_ids" {
+  type        = list(string)
+  description = "Existing security groups to attach. Null creates one from `ingress_cidrs`."
+  default     = null
 }

--- a/deployment/terraform/modules/aws/postgres/variables.tf
+++ b/deployment/terraform/modules/aws/postgres/variables.tf
@@ -75,6 +75,11 @@ variable "password" {
   description = "Password for the database"
   default     = null
   sensitive   = true
+
+  validation {
+    condition     = var.password == null || !var.manage_master_user_password
+    error_message = "password cannot be set when manage_master_user_password is true: RDS generates and rotates the master password in Secrets Manager, and the supplied value would be discarded."
+  }
 }
 
 variable "tags" {

--- a/deployment/terraform/modules/aws/postgres/variables.tf
+++ b/deployment/terraform/modules/aws/postgres/variables.tf
@@ -279,6 +279,8 @@ variable "maintenance_window" {
   default     = null
 }
 
+# When true, RDS generates and rotates the master password in Secrets Manager and
+# any value passed to var.password is ignored.
 variable "manage_master_user_password" {
   type        = bool
   description = "Let RDS generate and rotate the master password in Secrets Manager. Mutually exclusive with `password`."

--- a/deployment/terraform/modules/aws/postgres/versions.tf
+++ b/deployment/terraform/modules/aws/postgres/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.100"
+    }
+  }
+}

--- a/deployment/terraform/modules/aws/redis/main.tf
+++ b/deployment/terraform/modules/aws/redis/main.tf
@@ -1,5 +1,14 @@
-# Define the Redis security group
+# The module now skips creating its own security group when the caller passes
+# security_group_ids, so the SG moved from a bare address to index 0. No-op for
+# state that is already indexed.
+moved {
+  from = aws_security_group.redis_sg
+  to   = aws_security_group.redis_sg[0]
+}
+
+# Define the Redis security group (skipped when security_group_ids is provided)
 resource "aws_security_group" "redis_sg" {
+  count       = length(var.security_group_ids) == 0 ? 1 : 0
   name        = "${var.name}-sg"
   description = "Allow inbound traffic from EKS to Redis"
   vpc_id      = var.vpc_id
@@ -37,7 +46,7 @@ resource "aws_elasticache_replication_group" "redis" {
   parameter_group_name = "default.redis7"
   engine_version       = "7.0"
   port                 = 6379
-  security_group_ids   = [aws_security_group.redis_sg.id]
+  security_group_ids   = length(var.security_group_ids) > 0 ? var.security_group_ids : [aws_security_group.redis_sg[0].id]
   subnet_group_name    = aws_elasticache_subnet_group.elasticache_subnet_group.name
 
   # Enable transit encryption (SSL/TLS)
@@ -48,6 +57,97 @@ resource "aws_elasticache_replication_group" "redis" {
 
   # Enable authentication if auth_token is provided
   # If transit_encryption_enabled is true, AWS requires an auth_token to be set.
-  auth_token = var.auth_token
+  # For IAM authentication, auth_token can be null
+  auth_token = var.enable_redis_iam_auth ? null : var.auth_token
+  tags       = var.tags
+}
+
+# The single member node's cluster id (num_cache_clusters = 1). ElastiCache
+# publishes per-node CloudWatch metrics under the CacheClusterId dimension.
+locals {
+  cache_cluster_id = tolist(aws_elasticache_replication_group.redis.member_clusters)[0]
+}
+
+# Memory is the failure mode that has actually taken clusters down: a broker
+# whose keys never expire climbs to maxmemory, evictions can't free anything, and
+# Redis starts rejecting writes -> the whole celery fleet crashloops at once.
+# DatabaseMemoryUsagePercentage is the leading indicator.
+resource "aws_cloudwatch_metric_alarm" "memory_high" {
+  alarm_name          = "${var.name}-memory-high"
+  alarm_description   = "ElastiCache ${var.name} memory usage high (warning)"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "DatabaseMemoryUsagePercentage"
+  namespace           = "AWS/ElastiCache"
+  period              = 300
+  statistic           = "Average"
+  threshold           = var.memory_high_threshold_percent
+  treat_missing_data  = "missing"
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.alarm_actions
+
+  dimensions = { CacheClusterId = local.cache_cluster_id }
+  tags       = var.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "memory_critical" {
+  alarm_name          = "${var.name}-memory-critical"
+  alarm_description   = "ElastiCache ${var.name} memory usage critical — writes may be rejected, celery fleet at risk"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "DatabaseMemoryUsagePercentage"
+  namespace           = "AWS/ElastiCache"
+  period              = 60
+  statistic           = "Average"
+  threshold           = var.memory_critical_threshold_percent
+  treat_missing_data  = "missing"
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.alarm_actions
+
+  dimensions = { CacheClusterId = local.cache_cluster_id }
+  tags       = var.tags
+}
+
+# Redis is single-threaded, so EngineCPUUtilization (the Redis engine thread) is
+# the meaningful CPU signal, not host CPUUtilization.
+resource "aws_cloudwatch_metric_alarm" "engine_cpu_high" {
+  alarm_name          = "${var.name}-engine-cpu-high"
+  alarm_description   = "ElastiCache ${var.name} Redis engine CPU high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "EngineCPUUtilization"
+  namespace           = "AWS/ElastiCache"
+  period              = 300
+  statistic           = "Average"
+  threshold           = var.engine_cpu_threshold_percent
+  treat_missing_data  = "missing"
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.alarm_actions
+
+  dimensions = { CacheClusterId = local.cache_cluster_id }
+  tags       = var.tags
+}
+
+# Swap on an in-memory store means it has overrun physical memory — always a
+# problem, precedes the memory-critical failure.
+resource "aws_cloudwatch_metric_alarm" "swap_usage" {
+  alarm_name          = "${var.name}-swap-usage"
+  alarm_description   = "ElastiCache ${var.name} is swapping — memory pressure"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "SwapUsage"
+  namespace           = "AWS/ElastiCache"
+  period              = 300
+  statistic           = "Average"
+  threshold           = var.swap_usage_threshold_bytes
+  treat_missing_data  = "missing"
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.alarm_actions
+
+  dimensions = { CacheClusterId = local.cache_cluster_id }
   tags       = var.tags
 }

--- a/deployment/terraform/modules/aws/redis/variables.tf
+++ b/deployment/terraform/modules/aws/redis/variables.tf
@@ -38,7 +38,7 @@ variable "auth_token" {
 }
 
 variable "enable_redis_iam_auth" {
-  description = "Enable IAM authentication for Redis ElastiCache"
+  description = "Omit the auth token so the replication group can be used with IAM authentication. This module does not create the ElastiCache user or user group; provision and associate those separately before enabling."
   type        = bool
   default     = false
 }

--- a/deployment/terraform/modules/aws/redis/variables.tf
+++ b/deployment/terraform/modules/aws/redis/variables.tf
@@ -31,14 +31,56 @@ variable "transit_encryption_enabled" {
 }
 
 variable "auth_token" {
-  description = "The password used to access a password protected server"
+  description = "The password used to access a password protected server. Set to null when using IAM authentication."
   type        = string
   default     = null
   sensitive   = true
+}
+
+variable "enable_redis_iam_auth" {
+  description = "Enable IAM authentication for Redis ElastiCache"
+  type        = bool
+  default     = false
 }
 
 variable "tags" {
   description = "Tags to apply to ElastiCache resources"
   type        = map(string)
   default     = {}
+}
+
+variable "security_group_ids" {
+  description = "Existing security group IDs to attach. If non-empty, the module skips creating its own SG."
+  type        = list(string)
+  default     = []
+}
+
+variable "alarm_actions" {
+  description = "SNS topic ARNs to notify on CloudWatch alarm/ok. Empty = alarms exist but notify nothing."
+  type        = list(string)
+  default     = []
+}
+
+variable "memory_high_threshold_percent" {
+  description = "DatabaseMemoryUsagePercentage warning threshold."
+  type        = number
+  default     = 80
+}
+
+variable "memory_critical_threshold_percent" {
+  description = "DatabaseMemoryUsagePercentage critical threshold — near this, Redis rejects writes."
+  type        = number
+  default     = 90
+}
+
+variable "engine_cpu_threshold_percent" {
+  description = "EngineCPUUtilization (Redis engine thread) alarm threshold."
+  type        = number
+  default     = 90
+}
+
+variable "swap_usage_threshold_bytes" {
+  description = "SwapUsage alarm threshold in bytes (default 50 MiB)."
+  type        = number
+  default     = 52428800
 }

--- a/deployment/terraform/modules/aws/redis/versions.tf
+++ b/deployment/terraform/modules/aws/redis/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.100"
+    }
+  }
+}

--- a/deployment/terraform/modules/aws/s3/main.tf
+++ b/deployment/terraform/modules/aws/s3/main.tf
@@ -1,32 +1,173 @@
-resource "aws_s3_bucket" "bucket" {
-  bucket = var.bucket_name
-  tags   = var.tags
+# When this module was promoted to the shared template (#399), the bucket
+# resource was renamed `bucket` -> `this` WITHOUT a moved block. Consumers that
+# hadn't re-applied since then still have `aws_s3_bucket.bucket` in state, so a
+# plan reads the rename as destroy-old + create-new — i.e. it would delete and
+# recreate the bucket (data loss). This relabels it in state instead. It's a
+# no-op for consumers already on the new address (the `from` isn't in their
+# state), and applies to every instance of this module (module.s3, s3_upload).
+moved {
+  from = aws_s3_bucket.bucket
+  to   = aws_s3_bucket.this
 }
 
-resource "aws_s3_bucket_policy" "bucket_policy" {
-  bucket = aws_s3_bucket.bucket.id
+# The bucket policy was renamed `bucket_policy` -> `anonymous_read` and made
+# conditional. Callers that set s3_vpc_endpoint_id (previously a required
+# input) still get a policy, so the target instance exists for them. Relabelling
+# keeps the upgrade an in-place policy update instead of destroy + create.
+moved {
+  from = aws_s3_bucket_policy.bucket_policy
+  to   = aws_s3_bucket_policy.anonymous_read[0]
+}
 
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Sid       = "AllowAccessViaVPCE",
-        Effect    = "Allow",
-        Principal = "*", # Update this to be the specific IAM roles, users, or service principals as needed
-        Action = [
-          "s3:GetObject",
-          "s3:ListBucket"
-        ],
-        Resource = [
-          aws_s3_bucket.bucket.arn,
-          "${aws_s3_bucket.bucket.arn}/*"
-        ],
-        Condition = {
-          StringEquals = {
-            "aws:SourceVpce" = var.s3_vpc_endpoint_id
-          }
-        }
+resource "aws_s3_bucket" "this" {
+  bucket        = var.bucket_name
+  force_destroy = var.force_destroy
+  tags          = var.tags
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+  versioning_configuration {
+    status = var.enable_versioning ? "Enabled" : "Suspended"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      # KMS encryption requires SigV4 signing, which anonymous requests can't provide
+      sse_algorithm     = var.allow_anonymous_read ? "AES256" : "aws:kms"
+      kms_master_key_id = var.allow_anonymous_read ? null : var.kms_key_id
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = true
+  block_public_policy     = var.block_public_policy != null ? var.block_public_policy : (var.allow_anonymous_read ? false : true)
+  ignore_public_acls      = true
+  restrict_public_buckets = var.restrict_public_buckets != null ? var.restrict_public_buckets : (var.allow_anonymous_read ? false : true)
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    id     = "noncurrent-version-expiration"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = var.noncurrent_expiration_days
+    }
+  }
+
+  dynamic "rule" {
+    for_each = var.expiration_days > 0 ? [1] : []
+    content {
+      id     = "object-expiration"
+      status = "Enabled"
+
+      expiration {
+        days = var.expiration_days
       }
-    ]
-  })
+    }
+  }
+
+  dynamic "rule" {
+    for_each = var.transition_to_ia ? [1] : []
+    content {
+      id     = "transition-to-ia"
+      status = "Enabled"
+
+      transition {
+        days          = var.transition_to_ia_days
+        storage_class = "INTELLIGENT_TIERING"
+      }
+    }
+  }
+}
+
+locals {
+  needs_bucket_policy = (var.allow_anonymous_read && (length(var.allowed_vpc_ids) > 0 || length(var.allowed_source_ips) > 0)) || length(var.s3_vpc_endpoint_id) > 0
+}
+
+data "aws_iam_policy_document" "anonymous_read" {
+  count = local.needs_bucket_policy ? 1 : 0
+
+  # Allow anonymous GetObject from allowed IPs
+  dynamic "statement" {
+    for_each = var.allow_anonymous_read && length(var.allowed_source_ips) > 0 ? [1] : []
+    content {
+      sid     = "AllowAnonymousReadFromAllowedIps"
+      effect  = "Allow"
+      actions = ["s3:GetObject"]
+      resources = [
+        "${aws_s3_bucket.this.arn}/*"
+      ]
+      principals {
+        type        = "*"
+        identifiers = ["*"]
+      }
+      condition {
+        test     = "IpAddress"
+        variable = "aws:SourceIp"
+        values   = var.allowed_source_ips
+      }
+    }
+  }
+
+  # Allow anonymous GetObject from allowed VPCs (requires VPC endpoint)
+  dynamic "statement" {
+    for_each = var.allow_anonymous_read && length(var.allowed_vpc_ids) > 0 ? [1] : []
+    content {
+      sid     = "AllowAnonymousReadFromAllowedVpcs"
+      effect  = "Allow"
+      actions = ["s3:GetObject"]
+      resources = [
+        "${aws_s3_bucket.this.arn}/*"
+      ]
+      principals {
+        type        = "*"
+        identifiers = ["*"]
+      }
+      condition {
+        test     = "StringEquals"
+        variable = "aws:SourceVpc"
+        values   = var.allowed_vpc_ids
+      }
+    }
+  }
+
+  # Allow GetObject + ListBucket via a specific S3 gateway VPC endpoint
+  dynamic "statement" {
+    for_each = length(var.s3_vpc_endpoint_id) > 0 ? [1] : []
+    content {
+      sid     = "AllowAccessViaVPCE"
+      effect  = "Allow"
+      actions = ["s3:GetObject", "s3:ListBucket"]
+      resources = [
+        aws_s3_bucket.this.arn,
+        "${aws_s3_bucket.this.arn}/*"
+      ]
+      principals {
+        type        = "*"
+        identifiers = ["*"]
+      }
+      condition {
+        test     = "StringEquals"
+        variable = "aws:SourceVpce"
+        values   = [var.s3_vpc_endpoint_id]
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "anonymous_read" {
+  count  = local.needs_bucket_policy ? 1 : 0
+  bucket = aws_s3_bucket.this.id
+  policy = data.aws_iam_policy_document.anonymous_read[0].json
 }

--- a/deployment/terraform/modules/aws/s3/outputs.tf
+++ b/deployment/terraform/modules/aws/s3/outputs.tf
@@ -1,0 +1,15 @@
+output "bucket_id" {
+  value = aws_s3_bucket.this.id
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.this.arn
+}
+
+output "bucket_name" {
+  value = aws_s3_bucket.this.bucket
+}
+
+output "bucket_regional_domain_name" {
+  value = aws_s3_bucket.this.bucket_regional_domain_name
+}

--- a/deployment/terraform/modules/aws/s3/variables.tf
+++ b/deployment/terraform/modules/aws/s3/variables.tf
@@ -1,15 +1,93 @@
 variable "bucket_name" {
-  type        = string
   description = "Name of the S3 bucket"
+  type        = string
+}
+
+variable "force_destroy" {
+  description = "Allow bucket deletion even if it contains objects"
+  type        = bool
+  default     = false
+}
+
+variable "enable_versioning" {
+  description = "Enable S3 bucket versioning"
+  type        = bool
+  default     = true
+}
+
+variable "kms_key_id" {
+  description = "Optional KMS key for bucket encryption. Defaults to AWS-managed S3 key."
+  type        = string
+  default     = null
+}
+
+variable "expiration_days" {
+  description = "Number of days after which current objects are expired. Set to 0 to disable."
+  type        = number
+  default     = 0
+}
+
+variable "noncurrent_expiration_days" {
+  description = "Number of days to retain noncurrent object versions"
+  type        = number
+  default     = 90
+}
+
+variable "transition_to_ia" {
+  description = "Whether to transition objects to Intelligent-Tiering"
+  type        = bool
+  default     = true
+}
+
+variable "transition_to_ia_days" {
+  description = "Days after which to transition objects to Intelligent-Tiering"
+  type        = number
+  default     = 7
 }
 
 variable "tags" {
+  description = "Additional tags to assign to the bucket"
   type        = map(string)
-  description = "Tags to apply to S3 resources"
   default     = {}
 }
 
+variable "allowed_vpc_ids" {
+  description = "List of VPC IDs allowed to access the bucket. Leave empty to allow all."
+  type        = list(string)
+  default     = []
+}
+
+variable "allowed_source_ips" {
+  description = "List of CIDR blocks allowed to access the bucket. Leave empty to allow all."
+  type        = list(string)
+  default     = []
+}
+
+variable "allow_anonymous_read" {
+  description = "If true, allow anonymous (unauthenticated) reads from the allowed networks."
+  type        = bool
+  default     = false
+}
+
 variable "s3_vpc_endpoint_id" {
+  description = "ID of an S3 gateway VPC endpoint allowed to access this bucket. Leave empty to skip the VPCE policy statement."
   type        = string
-  description = "ID of the S3 gateway VPC endpoint allowed to access this bucket"
+  default     = ""
+}
+
+# When non-null these override the value the public_access_block resource
+# would otherwise inherit from allow_anonymous_read. Lets a caller keep
+# anonymous-read wiring (policy + AES256) while still locking the bucket's
+# block-public-policy / restrict-public-buckets bits down at the account
+# level.
+variable "block_public_policy" {
+  description = "Override for aws_s3_bucket_public_access_block.block_public_policy. Null = derive from allow_anonymous_read."
+  type        = bool
+  default     = null
+}
+
+variable "restrict_public_buckets" {
+  description = "Override for aws_s3_bucket_public_access_block.restrict_public_buckets. Null = derive from allow_anonymous_read."
+  type        = bool
+  default     = null
 }

--- a/deployment/terraform/modules/aws/s3/variables.tf
+++ b/deployment/terraform/modules/aws/s3/variables.tf
@@ -52,13 +52,13 @@ variable "tags" {
 }
 
 variable "allowed_vpc_ids" {
-  description = "List of VPC IDs allowed to access the bucket. Leave empty to allow all."
+  description = "VPC IDs allowed anonymous read. Only used when allow_anonymous_read is true; leaving both this and allowed_source_ips empty grants nothing rather than granting everything."
   type        = list(string)
   default     = []
 }
 
 variable "allowed_source_ips" {
-  description = "List of CIDR blocks allowed to access the bucket. Leave empty to allow all."
+  description = "CIDR blocks allowed anonymous read. Only used when allow_anonymous_read is true; leaving both this and allowed_vpc_ids empty grants nothing rather than granting everything."
   type        = list(string)
   default     = []
 }

--- a/deployment/terraform/modules/aws/s3/variables.tf
+++ b/deployment/terraform/modules/aws/s3/variables.tf
@@ -16,15 +16,27 @@ variable "enable_versioning" {
 }
 
 variable "kms_key_id" {
+  # Guarded below: anonymous reads cannot use SigV4, so allow_anonymous_read
+  # forces AES256 and a KMS key would be silently dropped.
   description = "Optional KMS key for bucket encryption. Defaults to AWS-managed S3 key."
   type        = string
   default     = null
+
+  validation {
+    condition     = var.kms_key_id == "" || var.kms_key_id == null || !var.allow_anonymous_read
+    error_message = "kms_key_id cannot be combined with allow_anonymous_read: anonymous requests cannot sign with SigV4, so the bucket is forced to AES256."
+  }
 }
 
 variable "expiration_days" {
   description = "Number of days after which current objects are expired. Set to 0 to disable."
   type        = number
   default     = 0
+
+  validation {
+    condition     = var.expiration_days >= 0
+    error_message = "expiration_days must be 0 (disabled) or a positive number of days."
+  }
 }
 
 variable "noncurrent_expiration_days" {

--- a/deployment/terraform/modules/aws/s3/versions.tf
+++ b/deployment/terraform/modules/aws/s3/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.100"
+    }
+  }
+}

--- a/deployment/terraform/modules/aws/vpc/main.tf
+++ b/deployment/terraform/modules/aws/vpc/main.tf
@@ -30,7 +30,7 @@ module "vpc" {
   map_public_ip_on_launch = true
 
   enable_nat_gateway   = true
-  single_nat_gateway   = true
+  single_nat_gateway   = var.single_nat_gateway
   enable_dns_hostnames = true
 
   public_subnet_tags = {

--- a/deployment/terraform/modules/aws/vpc/main.tf
+++ b/deployment/terraform/modules/aws/vpc/main.tf
@@ -116,4 +116,8 @@ resource "aws_flow_log" "vpc_flow_log" {
   tags = merge(var.tags, {
     Name = "${var.vpc_name}-flow-logs"
   })
+
+  # Without this the flow log can be created before the role can write to
+  # CloudWatch, and delivery silently fails until the next apply.
+  depends_on = [aws_iam_role_policy.vpc_flow_logs]
 }

--- a/deployment/terraform/modules/aws/vpc/main.tf
+++ b/deployment/terraform/modules/aws/vpc/main.tf
@@ -1,3 +1,11 @@
+# The S3 gateway endpoint and its route-table lookup became conditional on
+# create_s3_vpc_endpoint, so the endpoint moved from a bare address to index 0.
+# No-op for state that is already indexed.
+moved {
+  from = aws_vpc_endpoint.s3
+  to   = aws_vpc_endpoint.s3[0]
+}
+
 # Get the availability zones for the region without requiring opt-in
 data "aws_availability_zones" "available" {
   filter {
@@ -22,7 +30,7 @@ module "vpc" {
   map_public_ip_on_launch = true
 
   enable_nat_gateway   = true
-  single_nat_gateway   = false
+  single_nat_gateway   = true
   enable_dns_hostnames = true
 
   public_subnet_tags = {
@@ -37,18 +45,75 @@ module "vpc" {
 }
 
 data "aws_route_tables" "this" {
+  count = var.create_s3_vpc_endpoint ? 1 : 0
   filter {
     name   = "vpc-id"
     values = [module.vpc.vpc_id]
   }
-
   depends_on = [module.vpc]
 }
 
 resource "aws_vpc_endpoint" "s3" {
+  count             = var.create_s3_vpc_endpoint ? 1 : 0
   vpc_id            = module.vpc.vpc_id
   service_name      = "com.amazonaws.${data.aws_region.current.name}.s3"
   vpc_endpoint_type = "Gateway"
-  route_table_ids   = data.aws_route_tables.this.ids
+  route_table_ids   = data.aws_route_tables.this[0].ids
   tags              = var.tags
+}
+
+# Create minimal IAM role for VPC Flow Logs (required by AWS)
+resource "aws_iam_role" "vpc_flow_logs" {
+  name = "${var.vpc_name}-flow-logs-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "vpc-flow-logs.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+# Attach minimal policy for CloudWatch Logs
+resource "aws_iam_role_policy" "vpc_flow_logs" {
+  name = "${var.vpc_name}-flow-logs-policy"
+  role = aws_iam_role.vpc_flow_logs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# Create VPC Flow Log directly (simpler than module's built-in)
+resource "aws_flow_log" "vpc_flow_log" {
+  iam_role_arn         = aws_iam_role.vpc_flow_logs.arn
+  log_destination_type = "cloud-watch-logs"
+  log_group_name       = "/aws/vpc/flow-logs/${var.vpc_name}"
+  traffic_type         = "ALL"
+  vpc_id               = module.vpc.vpc_id
+
+  tags = merge(var.tags, {
+    Name = "${var.vpc_name}-flow-logs"
+  })
 }

--- a/deployment/terraform/modules/aws/vpc/outputs.tf
+++ b/deployment/terraform/modules/aws/vpc/outputs.tf
@@ -10,11 +10,16 @@ output "public_subnets" {
   value = module.vpc.public_subnets
 }
 
+output "nat_gateway_public_ips" {
+  description = "Public Elastic IPs assigned to the VPC NAT gateways"
+  value       = module.vpc.nat_public_ips
+}
+
 output "vpc_cidr_block" {
   value = module.vpc.vpc_cidr_block
 }
 
 output "s3_vpc_endpoint_id" {
   description = "ID of the S3 gateway VPC endpoint created for this VPC"
-  value       = aws_vpc_endpoint.s3.id
+  value       = try(aws_vpc_endpoint.s3[0].id, null)
 }

--- a/deployment/terraform/modules/aws/vpc/variables.tf
+++ b/deployment/terraform/modules/aws/vpc/variables.tf
@@ -33,3 +33,9 @@ variable "create_s3_vpc_endpoint" {
   description = "Whether to create a gateway VPC endpoint for S3"
   default     = true
 }
+
+variable "single_nat_gateway" {
+  type        = bool
+  description = "Route all private subnets through one NAT gateway. Cheaper, but the NAT becomes a single-AZ dependency. False provisions one per AZ."
+  default     = false
+}

--- a/deployment/terraform/modules/aws/vpc/variables.tf
+++ b/deployment/terraform/modules/aws/vpc/variables.tf
@@ -27,3 +27,9 @@ variable "tags" {
   description = "Tags to apply to all VPC-related resources"
   default     = {}
 }
+
+variable "create_s3_vpc_endpoint" {
+  type        = bool
+  description = "Whether to create a gateway VPC endpoint for S3"
+  default     = true
+}

--- a/deployment/terraform/modules/aws/vpc/versions.tf
+++ b/deployment/terraform/modules/aws/vpc/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.100"
+    }
+  }
+}

--- a/deployment/terraform/modules/aws/waf/main.tf
+++ b/deployment/terraform/modules/aws/waf/main.tf
@@ -1,8 +1,9 @@
 locals {
-  name                  = var.name
-  tags                  = var.tags
-  ip_allowlist_enabled  = length(var.allowed_ip_cidrs) > 0
-  managed_rule_priority = local.ip_allowlist_enabled ? 1 : 0
+  name                      = var.name
+  tags                      = var.tags
+  ip_allowlist_enabled      = length(var.allowed_ip_cidrs) > 0
+  rate_limit_exempt_enabled = length(var.rate_limit_exempt_ip_cidrs) > 0
+  managed_rule_priority     = local.ip_allowlist_enabled ? 1 : 0
 }
 
 resource "aws_wafv2_ip_set" "allowed_ips" {
@@ -13,6 +14,18 @@ resource "aws_wafv2_ip_set" "allowed_ips" {
   scope              = "REGIONAL"
   ip_address_version = "IPV4"
   addresses          = var.allowed_ip_cidrs
+
+  tags = local.tags
+}
+
+resource "aws_wafv2_ip_set" "rate_limit_exempt_ips" {
+  count = local.rate_limit_exempt_enabled ? 1 : 0
+
+  name               = "${local.name}-rate-limit-exempt-ips"
+  description        = "IPs exempt from rate limiting for ${local.name}"
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+  addresses          = var.rate_limit_exempt_ip_cidrs
 
   tags = local.tags
 }
@@ -124,6 +137,19 @@ resource "aws_wafv2_web_acl" "main" {
       rate_based_statement {
         limit              = var.rate_limit_requests_per_5_minutes
         aggregate_key_type = "IP"
+
+        dynamic "scope_down_statement" {
+          for_each = local.rate_limit_exempt_enabled ? [1] : []
+          content {
+            not_statement {
+              statement {
+                ip_set_reference_statement {
+                  arn = aws_wafv2_ip_set.rate_limit_exempt_ips[0].arn
+                }
+              }
+            }
+          }
+        }
       }
     }
 
@@ -172,6 +198,19 @@ resource "aws_wafv2_web_acl" "main" {
       rate_based_statement {
         limit              = var.api_rate_limit_requests_per_5_minutes
         aggregate_key_type = "IP"
+
+        dynamic "scope_down_statement" {
+          for_each = local.rate_limit_exempt_enabled ? [1] : []
+          content {
+            not_statement {
+              statement {
+                ip_set_reference_statement {
+                  arn = aws_wafv2_ip_set.rate_limit_exempt_ips[0].arn
+                }
+              }
+            }
+          }
+        }
       }
     }
 
@@ -210,8 +249,18 @@ resource "aws_wafv2_web_acl" "main" {
     name     = "AWSManagedRulesAnonymousIpList"
     priority = 7 + local.managed_rule_priority
 
-    override_action {
-      none {}
+    dynamic "override_action" {
+      for_each = var.anonymous_ip_list_count_only ? [1] : []
+      content {
+        count {}
+      }
+    }
+
+    dynamic "override_action" {
+      for_each = var.anonymous_ip_list_count_only ? [] : [1]
+      content {
+        none {}
+      }
     }
 
     statement {

--- a/deployment/terraform/modules/aws/waf/variables.tf
+++ b/deployment/terraform/modules/aws/waf/variables.tf
@@ -59,6 +59,6 @@ variable "enable_logging" {
 
 variable "log_retention_days" {
   type        = number
-  description = "Number of days to retain WAF logs. Default 400 = 12 months + 30-day buffer for Vanta `logs-retained-for-twelve-months-config`."
+  description = "Number of days to retain WAF logs. Default 400 = 12 months + 30-day buffer for the common twelve-month log-retention control."
   default     = 400
 }

--- a/deployment/terraform/modules/aws/waf/variables.tf
+++ b/deployment/terraform/modules/aws/waf/variables.tf
@@ -33,6 +33,18 @@ variable "api_rate_limit_requests_per_5_minutes" {
   default     = 1000
 }
 
+variable "rate_limit_exempt_ip_cidrs" {
+  type        = list(string)
+  description = "Optional IPv4 CIDR ranges exempt from rate limiting rules. Typically office/VPN IPs sharing a single NAT."
+  default     = []
+}
+
+variable "anonymous_ip_list_count_only" {
+  type        = bool
+  description = "If true, set AWSManagedRulesAnonymousIpList to COUNT instead of BLOCK."
+  default     = false
+}
+
 variable "geo_restriction_countries" {
   type        = list(string)
   description = "List of country codes to block. Leave empty to disable geo restrictions"
@@ -47,6 +59,6 @@ variable "enable_logging" {
 
 variable "log_retention_days" {
   type        = number
-  description = "Number of days to retain WAF logs"
-  default     = 90
+  description = "Number of days to retain WAF logs. Default 400 = 12 months + 30-day buffer for Vanta `logs-retained-for-twelve-months-config`."
+  default     = 400
 }

--- a/deployment/terraform/modules/aws/waf/versions.tf
+++ b/deployment/terraform/modules/aws/waf/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.100"
+    }
+  }
+}

--- a/deployment/terraform/scripts/check_public_safe.py
+++ b/deployment/terraform/scripts/check_public_safe.py
@@ -21,7 +21,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 
-ALLOW_MARKER = "public-safe: ok"
+# Must be the whole trailing comment token: "# public-safe: okay" does not count.
+ALLOW_MARKER = re.compile(r"#\s*public-safe:\s*ok\s*$")
 
 ACCOUNT_ID = re.compile(r"(?<!\d)\d{12}(?!\d)")
 ACCESS_KEY = re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")
@@ -39,7 +40,7 @@ def _is_publishable(network: ipaddress.IPv4Network) -> bool:
 def scan(path: Path) -> list[str]:
     findings: list[str] = []
     for lineno, line in enumerate(path.read_text().splitlines(), start=1):
-        if ALLOW_MARKER in line:
+        if ALLOW_MARKER.search(line):
             continue
         try:
             shown = path.relative_to(ROOT)
@@ -74,12 +75,15 @@ def main(argv: list[str]) -> int:
         findings.extend(scan(path))
 
     if findings:
-        print("Internal values found in published Terraform modules:\n")
+        print(
+            "Internal values found in published Terraform modules:\n", file=sys.stderr
+        )
         for finding in findings:
-            print(f"  {finding}")
+            print(f"  {finding}", file=sys.stderr)
         print(
             "\nMove the value to the caller, or append '# public-safe: ok' if the "
-            "line is genuinely safe to publish."
+            "line is genuinely safe to publish.",
+            file=sys.stderr,
         )
         return 1
     return 0

--- a/deployment/terraform/scripts/check_public_safe.py
+++ b/deployment/terraform/scripts/check_public_safe.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Fail if the public Terraform modules contain values that must stay internal.
+
+These modules are published, but they are kept in sync with the infrastructure
+Onyx runs. That makes it easy to carry an internal value across by accident --
+an office IP in a variable default is the case this guard was written for.
+
+The guard looks for objective patterns only: AWS account ids, access key ids,
+and routable IPv4 CIDRs. It cannot screen for customer names, because listing
+them here would leak them; that stays a review step.
+
+Add a trailing `# public-safe: ok` comment to accept a specific line.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+ALLOW_MARKER = "public-safe: ok"
+
+ACCOUNT_ID = re.compile(r"(?<!\d)\d{12}(?!\d)")
+ACCESS_KEY = re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")
+IPV4_CIDR = re.compile(r"\b(\d{1,3}(?:\.\d{1,3}){3})/(\d{1,2})\b")
+
+
+# Ranges that are safe to ship: private, loopback, link-local, carrier NAT,
+# documentation, and the explicit "everywhere" wildcard.
+def _is_publishable(network: ipaddress.IPv4Network) -> bool:
+    if str(network) == "0.0.0.0/0":
+        return True
+    return not network.is_global
+
+
+def scan(path: Path) -> list[str]:
+    findings: list[str] = []
+    for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+        if ALLOW_MARKER in line:
+            continue
+        try:
+            shown = path.relative_to(ROOT)
+        except ValueError:
+            shown = path
+        where = f"{shown}:{lineno}"
+
+        if ACCESS_KEY.search(line):
+            findings.append(f"{where}: AWS access key id")
+
+        if ACCOUNT_ID.search(line):
+            findings.append(
+                f"{where}: 12-digit value that looks like an AWS account id"
+            )
+
+        for addr, prefix in IPV4_CIDR.findall(line):
+            try:
+                network = ipaddress.IPv4Network(f"{addr}/{prefix}", strict=False)
+            except ValueError:
+                continue
+            if not _is_publishable(network):
+                findings.append(f"{where}: routable IPv4 CIDR {addr}/{prefix}")
+    return findings
+
+
+def main(argv: list[str]) -> int:
+    paths = [Path(a) for a in argv[1:]] or sorted(ROOT.rglob("*.tf"))
+    findings: list[str] = []
+    for path in paths:
+        if path.suffix != ".tf" or ".terraform" in path.parts:
+            continue
+        findings.extend(scan(path))
+
+    if findings:
+        print("Internal values found in published Terraform modules:\n")
+        for finding in findings:
+            print(f"  {finding}")
+        print(
+            "\nMove the value to the caller, or append '# public-safe: ok' if the "
+            "line is genuinely safe to publish."
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/deployment/terraform/scripts/check_public_safe.py
+++ b/deployment/terraform/scripts/check_public_safe.py
@@ -24,16 +24,23 @@ ROOT = Path(__file__).resolve().parent.parent
 # Must be the whole trailing comment token: "# public-safe: okay" does not count.
 ALLOW_MARKER = re.compile(r"#\s*public-safe:\s*ok\s*$")
 
-ACCOUNT_ID = re.compile(r"(?<!\d)\d{12}(?!\d)")
-ACCESS_KEY = re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")
-IPV4_CIDR = re.compile(r"\b(\d{1,3}(?:\.\d{1,3}){3})/(\d{1,2})\b")
-# An internal owner email in a variable default gets stamped on every resource a
-# self-hoster creates. Kubernetes labels like `onyx.app/gpu` are not addresses.
-EMAIL = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+# One pass per line. Alternatives are ordered so the more specific pattern wins
+# at a given position; the group name selects the message.
+SUSPECT = re.compile(
+    r"(?P<access_key>\b(?:AKIA|ASIA)[0-9A-Z]{16}\b)"
+    r"|(?P<email>\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b)"
+    r"|(?P<cidr>\b\d{1,3}(?:\.\d{1,3}){3}/\d{1,2}\b)"
+    r"|(?P<account_id>(?<!\d)\d{12}(?!\d))"
+)
+
+MESSAGES = {
+    "access_key": "AWS access key id",
+    "email": "email address",
+    "account_id": "12-digit value that looks like an AWS account id",
+    "cidr": "routable IPv4 CIDR",
+}
 
 
-# Ranges that are safe to ship: private, loopback, link-local, carrier NAT,
-# documentation, and the explicit "everywhere" wildcard.
 def _is_publishable(network: ipaddress.IPv4Network) -> bool:
     if str(network) == "0.0.0.0/0":
         return True
@@ -45,31 +52,26 @@ def scan(path: Path) -> list[str]:
     for lineno, line in enumerate(path.read_text().splitlines(), start=1):
         if ALLOW_MARKER.search(line):
             continue
-        try:
-            shown = path.relative_to(ROOT)
-        except ValueError:
-            shown = path
-        where = f"{shown}:{lineno}"
 
-        findings.extend(
-            f"{where}: email address {address}" for address in EMAIL.findall(line)
-        )
+        for match in SUSPECT.finditer(line):
+            kind = match.lastgroup
+            assert kind is not None
+            value = match.group()
 
-        if ACCESS_KEY.search(line):
-            findings.append(f"{where}: AWS access key id")
+            # A private or reserved range is fine to ship; a routable one is not.
+            if kind == "cidr":
+                try:
+                    network = ipaddress.IPv4Network(value, strict=False)
+                except ValueError:
+                    continue
+                if _is_publishable(network):
+                    continue
 
-        if ACCOUNT_ID.search(line):
-            findings.append(
-                f"{where}: 12-digit value that looks like an AWS account id"
-            )
-
-        for addr, prefix in IPV4_CIDR.findall(line):
             try:
-                network = ipaddress.IPv4Network(f"{addr}/{prefix}", strict=False)
+                shown = path.relative_to(ROOT)
             except ValueError:
-                continue
-            if not _is_publishable(network):
-                findings.append(f"{where}: routable IPv4 CIDR {addr}/{prefix}")
+                shown = path
+            findings.append(f"{shown}:{lineno}: {MESSAGES[kind]} {value}".rstrip())
     return findings
 
 

--- a/deployment/terraform/scripts/check_public_safe.py
+++ b/deployment/terraform/scripts/check_public_safe.py
@@ -6,7 +6,7 @@ Onyx runs. That makes it easy to carry an internal value across by accident --
 an office IP in a variable default is the case this guard was written for.
 
 The guard looks for objective patterns only: AWS account ids, access key ids,
-and routable IPv4 CIDRs. It cannot screen for customer names, because listing
+routable IPv4 CIDRs, and email addresses. It cannot screen for customer names, because listing
 them here would leak them; that stays a review step.
 
 Add a trailing `# public-safe: ok` comment to accept a specific line.
@@ -27,6 +27,9 @@ ALLOW_MARKER = re.compile(r"#\s*public-safe:\s*ok\s*$")
 ACCOUNT_ID = re.compile(r"(?<!\d)\d{12}(?!\d)")
 ACCESS_KEY = re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")
 IPV4_CIDR = re.compile(r"\b(\d{1,3}(?:\.\d{1,3}){3})/(\d{1,2})\b")
+# An internal owner email in a variable default gets stamped on every resource a
+# self-hoster creates. Kubernetes labels like `onyx.app/gpu` are not addresses.
+EMAIL = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
 
 
 # Ranges that are safe to ship: private, loopback, link-local, carrier NAT,
@@ -47,6 +50,10 @@ def scan(path: Path) -> list[str]:
         except ValueError:
             shown = path
         where = f"{shown}:{lineno}"
+
+        findings.extend(
+            f"{where}: email address {address}" for address in EMAIL.findall(line)
+        )
 
         if ACCESS_KEY.search(line):
             findings.append(f"{where}: AWS access key id")


### PR DESCRIPTION
## Description

The AWS Terraform modules in this repo and the ones Onyx runs for its managed deployments had drifted into two independently-edited copies, kept in sync by hand. This replaces the seven primitives (`vpc`, `waf`, `redis`, `s3`, `postgres`, `opensearch`, `eks`) with the versions that are actually deployed, so the published code is the code we run.

The primitives are ported verbatim — `waf`, `postgres` and `opensearch` are byte-identical. The deviations are deliberate and small:

| Change | Why |
|---|---|
| `eks`: `cluster_endpoint_public_access_cidrs` defaults to `[]` | The previous default was an office IP. The composition always passes this explicitly, so the default was dead code. |
| `s3`, `eks`: two comments reworded | They described our own fleet rather than the module. |
| `vpc`, `redis`, `s3`: `moved` blocks | For resources that gained a `count` gate or were renamed, so existing consumers get a state relabel instead of a destroy. |
| `versions.tf` added to each primitive | Without it, standalone use resolved aws 6.x / helm 3.x, where `vpc` and `eks` fail to validate. Constraints match what the deployed stacks already run. |

The composition keeps its t-shirt sizing and gains the operational inputs the primitives now expose (`alarm_actions`, upload bucket, GPU node group, NetworkPolicy). It deliberately does **not** include the alert routing, secret management, or log aggregation wiring, which stay internal. It also keeps its own Redis wiring — the internal composition derives the auth token from the deployment name, which must not be published and would have silently overridden a self-hoster's own token.

Self-hosters upgrading get a new "Upgrading" section in the README covering the renamed addresses and the settings the new modules now manage (bucket versioning/encryption, VPC flow logs, CloudWatch alarms).

Also adds a pre-commit guard that fails on AWS account ids, access keys, and routable IPs in the published modules. It caught a second copy of the office IP in the composition while this change was being written.

## How Has This Been Tested?

**Plan-neutrality against live infrastructure.** Built a harness matching the intended end state (internal composition + these primitives), planned it against a live cluster, then ran a control with the currently-deployed primitives and diffed. Both produced `Plan: 1 to add, 14 to change, 1 to destroy`, and the plan bodies are **identical at 1,640 lines** — the only differences are warning line numbers, shifted by exactly the length of the added `moved` blocks. The pending changes are pre-existing drift in that environment, present identically either way.

**Sizing logic evaluated directly**, since `validate` does not exercise it:
- all three tiers resolve to the values documented in the README table
- per-setting overrides win over the tier default
- the storage-ceiling guard scales (`postgres_storage_gb=400` on `small` → `max` 800)
- zone awareness on → 3 subnets, off → 1 (this path had a null-condition bug, caught and fixed during review)
- an invalid `size` is rejected by the variable validation

**Static checks:** all 8 modules pass `terraform validate` (this is what surfaced the missing provider constraints), `terraform fmt` clean, full pre-commit suite green, `ty` clean on the new script, and the leak guard passes on the tree and correctly fails on planted account ids, access keys, and public IPs.

**Not covered:** no greenfield `apply` into a scratch account. Plan-verification proves this does not disturb existing state; it does not prove a from-scratch apply. Worth doing before the next release if we want to stand behind the quickstart.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts the AWS Terraform modules Onyx runs in production to remove drift and add safer defaults, validations, and provider constraints. Previous quickstart built an invalid RDS URL and could overwrite caller EKS node‑group bounds; the quickstart now uses the hostname‑only output, and EKS keeps caller bounds unless set. EKS addon updates use PRESERVE conflict resolution; if aws-node had enableNetworkPolicy=false, it stays off until you change it.

- Replaces primitives vpc/waf/redis/s3/postgres/opensearch/eks; the `onyx` composition adds the GPU node group and upload bucket, keeps `enable_craft`, exposes `postgres_multi_az`, drops the default `Owner` tag, restores the craft sandbox disk-size check, guards node‑group key collisions (`sandbox`, `gpu`), and defaults EKS to a private API with public CIDRs defaulting to [] (deny). Docs note: aws-node NetworkPolicy uses PRESERVE, so explicit false remains.
- VPC: `single_nat_gateway` is configurable (default false), optional S3 gateway endpoint, exposes NAT EIPs, fixes flow‑log dependencies. S3: defaults versioning/encryption/lifecycle, adds outputs, and validates `kms_key_id` (not with anonymous read) and `expiration_days >= 0`. Redis: optional IAM auth and existing security groups. Postgres: keeps existing `storage_type` when unset, adds `address` and master secret ARN outputs, and rejects `manage_master_user_password` with `password`. OpenSearch: ignores master password diffs and adds `alarm_actions`. WAF: rate‑limit CIDR exemptions, Anonymous IP count‑only toggle, and 400‑day log retention.
- Tooling: adds `terraform_validate`, a `terraform-public-safe` guard (fails on account IDs, access keys, routable IPv4, and emails; allow a specific line with “# public-safe: ok”), and `versions.tf` constraints (`aws ~> 5.100`, `helm ~> 2.16`, `kubernetes ~> 2.37`). Guard now scans each line once; behavior unchanged. Docs/quickstart: correct outputs, percent‑encode credentials, and build the connection URL from `postgres_address`. Plans remain neutral against live stacks.

- If using a public EKS API: set `cluster_endpoint_public_access_cidrs`; empty now denies all public access.
- If aws-node previously set enableNetworkPolicy=false: it remains; update the addon config to enable enforcement.
- If you referenced `node_security_group_id`, switch to `cluster_security_group_id` or upstream `module.eks` outputs.
- Avoid node‑group key collisions: do not predefine `sandbox` or `gpu` when `enable_craft` or `enable_gpu_node` is true.
- For RDS Multi‑AZ: set `postgres_multi_az=true` in the `onyx` module to retain an existing standby.
- Review S3 defaults and validations: confirm versioning/encryption/lifecycle; do not combine `kms_key_id` with anonymous read; keep `expiration_days >= 0`.
- Ensure Terraform and providers meet the new `versions.tf` constraints before planning/applying.

<sup>Written for commit 11120289a46fe2afc03fa5efe224c1908f54f883. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

