### PR TITLE
test(salesforce): use an http URL to exercise the HTTPS rejection

### DIFF
--- a/backend/tests/external_dependency_unit/server/documents/test_salesforce_standard_oauth_real_dependencies.py
+++ b/backend/tests/external_dependency_unit/server/documents/test_salesforce_standard_oauth_real_dependencies.py
@@ -235,8 +235,9 @@ def test_salesforce_standard_oauth_invalid_domain_and_disabled_config(
             standard_oauth.oauth_authorize(
                 request=_request(
                     {
+                        # http:// so the URL parses and the HTTPS check rejects it.
                         "salesforce_my_domain_url": (
-                            "danswer-dev-ed.develop.my.salesforce.com"
+                            "http://danswer-dev-ed.develop.my.salesforce.com"
                         )
                     }
                 ),

--- a/backend/tests/unit/onyx/connectors/salesforce/test_salesforce_oauth_credentials.py
+++ b/backend/tests/unit/onyx/connectors/salesforce/test_salesforce_oauth_credentials.py
@@ -101,6 +101,7 @@ def test_salesforce_my_domain_url_accepts_canonical_hosts(
 @pytest.mark.parametrize(
     "url",
     [
+        "acme.my.salesforce.com",
         "http://acme.my.salesforce.com",
         "https://my.salesforce.com",
         "https://salesforce.com",


### PR DESCRIPTION
## Description

`test_salesforce_standard_oauth_invalid_domain_and_disabled_config` is red on main (last two main runs). It asserts "Salesforce URL must use HTTPS" for the scheme-less input `danswer-dev-ed.develop.my.salesforce.com`, but pydantic URL parsing rejects scheme-less values first with "Salesforce URL is invalid", so the assertion can never match.

- Test input now uses `http://` so it exercises the HTTPS branch it asserts.
- The unit rejection table gains the scheme-less case, so parser-level rejection of bare domains stays covered.

No production code changes.

## How Has This Been Tested?

- Validator probed directly: scheme-less raises "Salesforce URL is invalid", `http://` raises "Salesforce URL must use HTTPS".
- Unit suite for the rejection table: 51 passed. `ruff` clean.
- The external-dependency shard verifies end to end in CI (local run blocked by dev DB schema drift unrelated to this change).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
