### PR TITLE
feat(craft): expose credential placeholder keys on external app admin response

### DIFF
--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -47,7 +47,7 @@ class SkillExternalAppDependencyState:
     ready: bool
 
 
-def _placeholders_in_template(auth_template: dict[str, Any]) -> set[str]:
+def placeholders_in_template(auth_template: dict[str, Any]) -> set[str]:
     placeholders: set[str] = set()
     for value in auth_template.values():
         if isinstance(value, str):
@@ -63,7 +63,7 @@ def required_user_credential_keys(
     references in `auth_template` values not pre-filled by
     `organization_credentials`."""
     return sorted(
-        _placeholders_in_template(auth_template) - organization_credentials.keys()
+        placeholders_in_template(auth_template) - organization_credentials.keys()
     )
 
 

--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -22,6 +22,7 @@ from onyx.db.external_app import (
     get_external_apps,
     get_skills_for_external_app,
     get_user_credentials_by_app_id,
+    placeholders_in_template,
     replace_custom_skill_associations__no_commit,
     required_user_credential_keys,
     update_external_app,
@@ -95,6 +96,9 @@ def _to_admin_response(
         auth_template={} if managed else app.auth_template,
         organization_credentials=(
             {} if managed else app.organization_credentials.get_value(apply_mask=True)
+        ),
+        credential_placeholder_keys=(
+            [] if managed else sorted(placeholders_in_template(app.auth_template))
         ),
         enabled=app.enabled,
         actions=action_policy_views(app.app_type, stored),

--- a/backend/onyx/server/features/build/external_apps/models.py
+++ b/backend/onyx/server/features/build/external_apps/models.py
@@ -79,9 +79,7 @@ class ExternalAppAdminResponse(BaseModel):
     upstream_url_patterns: list[str]
     auth_template: dict[str, Any]
     organization_credentials: dict[str, Any]
-    # Sorted `{placeholder}` names in the auth-template values. The backend owns
-    # the placeholder grammar; clients compare against `organization_credentials`
-    # keys to tell org-covered from user-supplied credentials.
+    # Sorted `{placeholder}` names in the auth-template values.
     credential_placeholder_keys: list[str]
     enabled: bool
     # The merged per-action policy view (built-in apps; empty for custom).

--- a/backend/onyx/server/features/build/external_apps/models.py
+++ b/backend/onyx/server/features/build/external_apps/models.py
@@ -79,6 +79,10 @@ class ExternalAppAdminResponse(BaseModel):
     upstream_url_patterns: list[str]
     auth_template: dict[str, Any]
     organization_credentials: dict[str, Any]
+    # Sorted `{placeholder}` names in the auth-template values. The backend owns
+    # the placeholder grammar; clients compare against `organization_credentials`
+    # keys to tell org-covered from user-supplied credentials.
+    credential_placeholder_keys: list[str]
     enabled: bool
     # The merged per-action policy view (built-in apps; empty for custom).
     actions: list[ActionPolicyView]


### PR DESCRIPTION
## Description

Part 1/3 of the Craft apps admin redesign stack (#14049 → #14045 → #14050).

Exposes `credential_placeholder_keys` on `ExternalAppAdminResponse`: the sorted `{placeholder}` names from the app's auth template, computed with the backend's own placeholder grammar (`placeholders_in_template`, previously private `_placeholders_in_template`). For Onyx-managed apps the field is blanked like the rest of the hidden config.

This lets the admin UI (#14045) describe a custom app's credential setup (none / org-covered / per-user) without mirroring the backend's placeholder regex. Additive API change; no migration.

## How Has This Been Tested?

- `ty` and `ruff` via pre-commit.
- Consumed and asserted by the frontend tests in #14045.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check