### PR TITLE
chore(craft): add storybook coverage for craft apps admin components

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -20,6 +20,8 @@ on:
       - "web/.storybook/**"
       - "web/src/app/craft/components/tool-cards/**"
       - "web/src/app/craft/components/approvals/**"
+      - "web/src/app/craft/v1/apps/admin/**"
+      - "web/src/views/admin/ExternalAppsPage/**"
       - "web/package.json"
       - "web/bun.lock"
 permissions:

--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -16,6 +16,7 @@ const config: StorybookConfig = {
     "../src/refresh-components/**/*.stories.@(ts|tsx)",
     "../src/sections/**/*.stories.@(ts|tsx)",
     "../src/app/craft/**/*.stories.@(ts|tsx)",
+    "../src/views/**/*.stories.@(ts|tsx)",
   ],
   addons: [
     getAbsolutePath("@storybook/addon-themes"),

--- a/web/src/app/craft/v1/apps/admin/AddAppCatalogModal.stories.tsx
+++ b/web/src/app/craft/v1/apps/admin/AddAppCatalogModal.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import AddAppCatalogModal from "@/app/craft/v1/apps/admin/AddAppCatalogModal";
+import type { BuiltInExternalAppDescriptor } from "@/app/craft/v1/apps/registry";
+
+function descriptor(
+  app_type: BuiltInExternalAppDescriptor["app_type"],
+  name: string
+): BuiltInExternalAppDescriptor {
+  return {
+    app_type,
+    name,
+    upstream_url_patterns: [],
+    auth_template: {},
+    required_org_credential_fields: [],
+    setup_instructions: "",
+    actions: [],
+  };
+}
+
+const meta: Meta<typeof AddAppCatalogModal> = {
+  title: "Apps/Craft/Admin/Add App Catalog",
+  component: AddAppCatalogModal,
+  args: {
+    onClose: () => {},
+    onPickProvider: () => {},
+    onPickCustom: () => {},
+    descriptors: [
+      descriptor("SLACK", "Slack"),
+      descriptor("GOOGLE_DRIVE", "Google Drive"),
+      descriptor("GMAIL", "Gmail"),
+      descriptor("LINEAR", "Linear"),
+      descriptor("GITHUB", "GitHub"),
+      descriptor("NOTION", "Notion"),
+    ],
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AddAppCatalogModal>;
+
+export const WithProviders: Story = {};
+
+/** Every built-in already configured — only the custom-app path remains. */
+export const AllProvidersConfigured: Story = {
+  args: { descriptors: [] },
+};

--- a/web/src/views/admin/ExternalAppsPage/IntegrationCard.stories.tsx
+++ b/web/src/views/admin/ExternalAppsPage/IntegrationCard.stories.tsx
@@ -9,7 +9,7 @@ const APP: ConfiguredIntegration = {
   isCustom: false,
   logo: SvgSlack,
   name: "Slack",
-  facts: ["7 actions", "2 skills"],
+  facts: ["7 actions", "2 custom skills"],
   warnings: [],
   enabled: true,
   toggleEnabled: async () => {},
@@ -51,7 +51,7 @@ export const CustomApp: Story = {
       isCustom: true,
       logo: SvgPlug,
       name: "Internal billing API",
-      facts: ["2 upstream patterns", "org credentials set", "1 skill"],
+      facts: ["2 upstream patterns", "org credentials set", "1 custom skill"],
     },
   },
 };
@@ -76,7 +76,7 @@ export const OnyxManaged: Story = {
   args: {
     integration: {
       ...APP,
-      facts: ["provided by Onyx", "7 actions", "no skills"],
+      facts: ["provided by Onyx", "7 actions", "no custom skills"],
       remove: null,
     },
   },

--- a/web/src/views/admin/ExternalAppsPage/IntegrationCard.stories.tsx
+++ b/web/src/views/admin/ExternalAppsPage/IntegrationCard.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SvgSlack } from "@opal/logos";
+import { SvgPlug } from "@opal/icons";
+import IntegrationCard from "@/views/admin/ExternalAppsPage/IntegrationCard";
+import type { ConfiguredIntegration } from "@/views/admin/ExternalAppsPage/interfaces";
+
+const APP: ConfiguredIntegration = {
+  key: "app-1",
+  isCustom: false,
+  logo: SvgSlack,
+  name: "Slack",
+  facts: ["7 actions", "2 skills"],
+  warnings: [],
+  enabled: true,
+  toggleEnabled: async () => {},
+  edit: () => {},
+  remove: { run: async () => {}, retainedCustomSkillCount: 2 },
+};
+
+const meta: Meta<typeof IntegrationCard> = {
+  title: "Apps/Craft/Admin/Integration Card",
+  component: IntegrationCard,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="w-[820px]">
+        <Story />
+      </div>
+    ),
+  ],
+  args: { integration: APP },
+};
+
+export default meta;
+type Story = StoryObj<typeof IntegrationCard>;
+
+/** Hover the row to reveal the switch's scope label and the ⋯ menu holds
+ * Edit and Delete. */
+export const EnabledApp: Story = {};
+
+/** Off rows dim their content; controls keep full opacity. */
+export const DisabledApp: Story = {
+  args: { integration: { ...APP, enabled: false } },
+};
+
+export const CustomApp: Story = {
+  args: {
+    integration: {
+      ...APP,
+      key: "app-2",
+      isCustom: true,
+      logo: SvgPlug,
+      name: "Internal billing API",
+      facts: ["2 upstream patterns", "org credentials set", "1 skill"],
+    },
+  },
+};
+
+export const InvalidSkillWarning: Story = {
+  args: { integration: { ...APP, warnings: ["invalid skill"] } },
+};
+
+/** Orphaned provider: no descriptor, so the menu offers Delete only. */
+export const OrphanedProvider: Story = {
+  args: {
+    integration: {
+      ...APP,
+      warnings: ["invalid skill", "provider unavailable"],
+      edit: null,
+    },
+  },
+};
+
+/** Onyx-managed built-in: editable policies, never deletable. */
+export const OnyxManaged: Story = {
+  args: {
+    integration: {
+      ...APP,
+      facts: ["provided by Onyx", "7 actions", "no skills"],
+      remove: null,
+    },
+  },
+};
+
+/** MCP server row: tool facts, policy editing only, no delete. */
+export const McpServer: Story = {
+  args: {
+    integration: {
+      ...APP,
+      key: "mcp-1",
+      logo: SvgPlug,
+      name: "Atlassian",
+      facts: ["31 tools"],
+      remove: null,
+    },
+  },
+};
+
+/** No available actions: the ⋯ trigger renders disabled to keep alignment. */
+export const NoActions: Story = {
+  args: { integration: { ...APP, edit: null, remove: null } },
+};


### PR DESCRIPTION
## Description

Part 3/3 of the Craft apps admin redesign stack (#14049 → #14045 → #14050). Based on #14045.

Adds Storybook coverage for the redesigned admin components:

- `IntegrationCard` — 8 stories covering the state matrix: enabled, disabled (dimmed), custom tag, invalid-skill warning, orphaned provider (both warning chips, delete-only menu), Onyx-managed (no delete), MCP server, and no-actions (disabled ⋯ trigger). The hover-revealed scope label is previewable interactively.
- `AddAppCatalogModal` — full catalog and all-providers-configured states.
- Extends the Storybook glob to `src/views/**` — admin views were not scanned at all before, so this opens Storybook to future admin-page components (the one repo-level side effect worth review).

## How Has This Been Tested?

- Booted `bun run storybook` and screenshotted representative stories through the iframe — all render correctly.
- `pre-commit` (oxfmt, oxlint, TypeScript) green.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check