### PR TITLE
fix(health): report not-ready when the request threadpool is saturated

### DIFF
--- a/backend/ee/onyx/server/middleware/tenant_tracking.py
+++ b/backend/ee/onyx/server/middleware/tenant_tracking.py
@@ -43,7 +43,10 @@ def add_api_server_tenant_id_middleware(
         to use elsewhere.
         """
         try:
-            if request.url.path in TENANT_RESOLUTION_SKIP_PATHS:
+            # Strip the prefix first: with APP_API_PREFIX set these arrive as
+            # /<prefix>/health, which would otherwise miss the skip list and
+            # send probes through the Redis session lookup.
+            if strip_api_prefix(request.url.path) in TENANT_RESOLUTION_SKIP_PATHS:
                 CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA)
                 return await call_next(request)
 

--- a/backend/ee/onyx/server/middleware/tenant_tracking.py
+++ b/backend/ee/onyx/server/middleware/tenant_tracking.py
@@ -25,7 +25,9 @@ from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
 # Unauthenticated, non-tenant-scoped endpoints (LB/Prometheus probes, API docs),
 # so tenant resolution is skipped for them.
-TENANT_RESOLUTION_SKIP_PATHS = frozenset({"/health", "/metrics", "/openapi.json"})
+TENANT_RESOLUTION_SKIP_PATHS = frozenset(
+    {"/health", "/health/live", "/metrics", "/openapi.json"}
+)
 
 
 def add_api_server_tenant_id_middleware(

--- a/backend/onyx/server/auth_check.py
+++ b/backend/onyx/server/auth_check.py
@@ -26,8 +26,10 @@ PUBLIC_ENDPOINT_SPECS = [
     ("/redoc", {"GET", "HEAD"}),
     # should always be callable, will just return 401 if not authenticated
     ("/me", {"GET"}),
-    # just returns 200 to validate that the server is up
+    # readiness: 200 while the server can serve traffic, 503 when saturated
     ("/health", {"GET"}),
+    # liveness: just returns 200 to validate that the process is up
+    ("/health/live", {"GET"}),
     # just returns auth type, needs to be accessible before the user is logged
     # in to determine what flow to give the user
     ("/auth/type", {"GET"}),

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -95,6 +95,14 @@ _UNREADY_AFTER_SECONDS = 10.0
 # Tracks when the threadpool was first observed saturated, so brief queueing
 # under bursty load does not flip readiness. Only ever touched from the event
 # loop inside `healthcheck`, with no await between the read and the write.
+#
+# The window is sampled at probe frequency, not observed continuously, so a pool
+# that drains and re-saturates between two probes reads as continuously
+# saturated. Accepted: readiness is reversible, so the next healthy sample
+# restores the pod one interval later. Restarting the streak on a large sample
+# gap would be worse — any probe interval above the threshold would then never
+# accumulate a streak, and Compose probes every 30s. Fixing it properly needs a
+# background sampler, which is not worth an always-on loop per process.
 _SATURATED_SINCE: float | None = None
 
 # Probes can hit /health many times a second, so log only when readiness

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -96,6 +96,12 @@ _UNREADY_AFTER_SECONDS = 10.0
 # loop inside `healthcheck`, with no await between the read and the write.
 _SATURATED_SINCE: float | None = None
 
+# Probes can hit /health many times a second, so log only when readiness
+# changes. Logging every not-ready probe would flood the log with one line per
+# probe per replica, and add synchronous I/O exactly when the server is already
+# out of capacity.
+_REPORTED_NOT_READY = False
+
 
 def _threadpool_saturation() -> tuple[bool, dict[str, float]]:
     """Report whether the sync-endpoint threadpool has no capacity left.
@@ -125,12 +131,15 @@ async def healthcheck() -> StatusResponse[dict[str, float]]:
     the pool it is measuring, adding load exactly when there is none to spare,
     and would queue rather than answer. Liveness lives at /health/live.
     """
-    global _SATURATED_SINCE
+    global _SATURATED_SINCE, _REPORTED_NOT_READY
 
     saturated, depth = _threadpool_saturation()
     now = time.monotonic()
 
     if not saturated:
+        if _REPORTED_NOT_READY:
+            logger.notice("Threadpool recovered; reporting ready again")
+            _REPORTED_NOT_READY = False
         _SATURATED_SINCE = None
         return StatusResponse(success=True, message="ok", data=depth)
 
@@ -141,14 +150,17 @@ async def healthcheck() -> StatusResponse[dict[str, float]]:
     if saturated_for < _UNREADY_AFTER_SECONDS:
         return StatusResponse(success=True, message="ok", data=depth)
 
-    logger.warning(
-        "Threadpool saturated for %.1fs (%s/%s tokens borrowed, %s waiting); "
-        "reporting not ready",
-        saturated_for,
-        depth["threadpool_borrowed_tokens"],
-        depth["threadpool_total_tokens"],
-        depth["threadpool_tasks_waiting"],
-    )
+    if not _REPORTED_NOT_READY:
+        logger.warning(
+            "Threadpool saturated for %.1fs (%s/%s tokens borrowed, %s waiting); "
+            "reporting not ready",
+            saturated_for,
+            depth["threadpool_borrowed_tokens"],
+            depth["threadpool_total_tokens"],
+            depth["threadpool_tasks_waiting"],
+        )
+        _REPORTED_NOT_READY = True
+
     raise OnyxError(
         OnyxErrorCode.SERVICE_UNAVAILABLE,
         f"Request threadpool saturated for {saturated_for:.1f}s "

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -1,8 +1,10 @@
 import concurrent.futures
 import re
 import threading
+import time
 
 import requests
+from anyio import to_thread
 from cachetools import TTLCache
 from fastapi import APIRouter, HTTPException, Response
 from fastapi.concurrency import run_in_threadpool
@@ -18,6 +20,8 @@ from onyx.configs.constants import (
 from onyx.db.auth import get_user_count
 from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.sso_provider import fetch_sso_providers, sso_authorize_path
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.manage.models import (
     AllVersions,
     AuthConfigResponse,
@@ -27,7 +31,10 @@ from onyx.server.manage.models import (
 )
 from onyx.server.models import StatusResponse
 from onyx.server.security.store import get_security_settings
+from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
+
+logger = setup_logger()
 
 router = APIRouter()
 
@@ -77,8 +84,86 @@ def _fetch_sso_provider_options() -> list[SSOProviderOption]:
         return options
 
 
+# Readiness thresholds. The server reports not-ready once every threadpool token
+# is borrowed AND at least this many requests are queued for a thread, for this
+# long. Bursty load queues briefly, so neither condition alone is a problem.
+# Constants until a deployment needs to tune them.
+_UNREADY_QUEUE_DEPTH = 1
+_UNREADY_AFTER_SECONDS = 10.0
+
+# Tracks when the threadpool was first observed saturated, so brief queueing
+# under bursty load does not flip readiness. Only ever touched from the event
+# loop inside `healthcheck`, with no await between the read and the write.
+_SATURATED_SINCE: float | None = None
+
+
+def _threadpool_saturation() -> tuple[bool, dict[str, float]]:
+    """Report whether the sync-endpoint threadpool has no capacity left.
+
+    Must be called from the event loop — the limiter is per-loop.
+    """
+    stats = to_thread.current_default_thread_limiter().statistics()
+    depth = {
+        "threadpool_total_tokens": stats.total_tokens,
+        "threadpool_borrowed_tokens": stats.borrowed_tokens,
+        "threadpool_tasks_waiting": stats.tasks_waiting,
+    }
+    saturated = (
+        stats.borrowed_tokens >= stats.total_tokens
+        and stats.tasks_waiting >= _UNREADY_QUEUE_DEPTH
+    )
+    return saturated, depth
+
+
 @router.get("/health", tags=PUBLIC_API_TAGS)
-async def healthcheck() -> StatusResponse:
+async def healthcheck() -> StatusResponse[dict[str, float]]:
+    """Readiness probe. Wire this to readinessProbe and to load balancers.
+
+    Sync endpoints run in the anyio threadpool, so a saturated pool means the
+    server cannot serve real traffic even though the event loop still turns.
+    This handler stays async on purpose: a sync handler would borrow a token of
+    the pool it is measuring, adding load exactly when there is none to spare,
+    and would queue rather than answer. Liveness lives at /health/live.
+    """
+    global _SATURATED_SINCE
+
+    saturated, depth = _threadpool_saturation()
+    now = time.monotonic()
+
+    if not saturated:
+        _SATURATED_SINCE = None
+        return StatusResponse(success=True, message="ok", data=depth)
+
+    if _SATURATED_SINCE is None:
+        _SATURATED_SINCE = now
+
+    saturated_for = now - _SATURATED_SINCE
+    if saturated_for < _UNREADY_AFTER_SECONDS:
+        return StatusResponse(success=True, message="ok", data=depth)
+
+    logger.warning(
+        "Threadpool saturated for %.1fs (%s/%s tokens borrowed, %s waiting); "
+        "reporting not ready",
+        saturated_for,
+        depth["threadpool_borrowed_tokens"],
+        depth["threadpool_total_tokens"],
+        depth["threadpool_tasks_waiting"],
+    )
+    raise OnyxError(
+        OnyxErrorCode.SERVICE_UNAVAILABLE,
+        f"Request threadpool saturated for {saturated_for:.1f}s "
+        f"({depth['threadpool_tasks_waiting']:.0f} requests queued)",
+    )
+
+
+@router.get("/health/live", tags=PUBLIC_API_TAGS)
+async def liveness() -> StatusResponse:
+    """Liveness probe. Answers only "is this process still running".
+
+    Deliberately checks nothing else. Liveness failures restart the container,
+    and saturation is load-induced and correlated across replicas, so gating
+    restarts on it would turn a slowdown into an outage. Use /health for that.
+    """
     return StatusResponse(success=True, message="ok")
 
 

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -8,6 +8,7 @@ from anyio import to_thread
 from cachetools import TTLCache
 from fastapi import APIRouter, HTTPException, Response
 from fastapi.concurrency import run_in_threadpool
+from fastapi.responses import JSONResponse
 
 from onyx import __version__
 from onyx.auth.users import anonymous_user_enabled, user_needs_to_be_verified
@@ -21,7 +22,7 @@ from onyx.db.auth import get_user_count
 from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.sso_provider import fetch_sso_providers, sso_authorize_path
 from onyx.error_handling.error_codes import OnyxErrorCode
-from onyx.error_handling.exceptions import OnyxError
+from onyx.error_handling.exceptions import OnyxError, onyx_error_to_json_response
 from onyx.server.manage.models import (
     AllVersions,
     AuthConfigResponse,
@@ -121,8 +122,10 @@ def _threadpool_saturation() -> tuple[bool, dict[str, float]]:
     return saturated, depth
 
 
-@router.get("/health", tags=PUBLIC_API_TAGS)
-async def healthcheck() -> StatusResponse[dict[str, float]]:
+# response_model=None only disables schema inference for the Response union
+# below. It does not declare a response model.
+@router.get("/health", tags=PUBLIC_API_TAGS, response_model=None)
+async def healthcheck() -> StatusResponse[dict[str, float]] | JSONResponse:
     """Readiness probe. Wire this to readinessProbe and to load balancers.
 
     Sync endpoints run in the anyio threadpool, so a saturated pool means the
@@ -161,10 +164,15 @@ async def healthcheck() -> StatusResponse[dict[str, float]]:
         )
         _REPORTED_NOT_READY = True
 
-    raise OnyxError(
-        OnyxErrorCode.SERVICE_UNAVAILABLE,
-        f"Request threadpool saturated for {saturated_for:.1f}s "
-        f"({depth['threadpool_tasks_waiting']:.0f} requests queued)",
+    # Returned rather than raised: the global OnyxError handler logs every 5xx,
+    # which would put one line per probe per replica back in the log. The
+    # response body and status are identical either way.
+    return onyx_error_to_json_response(
+        OnyxError(
+            OnyxErrorCode.SERVICE_UNAVAILABLE,
+            f"Request threadpool saturated for {saturated_for:.1f}s "
+            f"({depth['threadpool_tasks_waiting']:.0f} requests queued)",
+        )
     )
 
 

--- a/backend/tests/unit/ee/onyx/server/middleware/test_tenant_tracking.py
+++ b/backend/tests/unit/ee/onyx/server/middleware/test_tenant_tracking.py
@@ -31,6 +31,16 @@ def test_custom_api_prefix_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
     assert tenant_tracking._is_path_allowed("/v2/chat") is False
 
 
+@pytest.mark.parametrize("path", ["/health", "/health/live", "/metrics"])
+def test_probe_paths_skip_tenant_resolution_under_api_prefix(
+    monkeypatch: pytest.MonkeyPatch, path: str
+) -> None:
+    """Probes must never reach the Redis session lookup, prefixed or not."""
+    monkeypatch.setattr(api_prefix, "APP_API_PREFIX", "v2")
+    stripped = api_prefix.strip_api_prefix(f"/v2{path}")
+    assert stripped in tenant_tracking.TENANT_RESOLUTION_SKIP_PATHS
+
+
 @pytest.mark.asyncio
 @patch(f"{MODULE}.retrieve_auth_token_data_from_bearer")
 @patch(f"{MODULE}.retrieve_auth_token_data_from_redis")

--- a/backend/tests/unit/onyx/server/manage/test_health_readiness.py
+++ b/backend/tests/unit/onyx/server/manage/test_health_readiness.py
@@ -13,10 +13,12 @@ from onyx.server.manage import get_state
 
 @pytest.fixture(autouse=True)
 def reset_saturation_latch() -> Iterator[None]:
-    """The latch is module state, so clear it around every test."""
+    """The latches are module state, so clear them around every test."""
     get_state._SATURATED_SINCE = None
+    get_state._REPORTED_NOT_READY = False
     yield
     get_state._SATURATED_SINCE = None
+    get_state._REPORTED_NOT_READY = False
 
 
 def _limiter(borrowed: float, total: float, waiting: int) -> MagicMock:
@@ -97,6 +99,27 @@ def test_recovery_between_samples_restarts_the_timer() -> None:
 
     assert response.success is True
     assert get_state._SATURATED_SINCE == 200.0
+
+
+def test_not_ready_is_logged_once_per_streak() -> None:
+    """Probes are frequent, so only readiness changes may write to the log."""
+    with patch.object(get_state, "logger") as mock_logger:
+        _healthcheck(borrowed=40, total=40, waiting=5, now=100.0)
+        for offset in range(3):
+            with pytest.raises(OnyxError):
+                _healthcheck(
+                    borrowed=40,
+                    total=40,
+                    waiting=5,
+                    now=100.0 + get_state._UNREADY_AFTER_SECONDS + offset,
+                )
+
+        assert mock_logger.warning.call_count == 1
+
+        _healthcheck(borrowed=0, total=40, waiting=0, now=200.0)
+        _healthcheck(borrowed=0, total=40, waiting=0, now=201.0)
+
+        assert mock_logger.notice.call_count == 1
 
 
 def test_liveness_stays_up_while_saturated() -> None:

--- a/backend/tests/unit/onyx/server/manage/test_health_readiness.py
+++ b/backend/tests/unit/onyx/server/manage/test_health_readiness.py
@@ -5,9 +5,9 @@ from collections.abc import Iterator
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastapi.responses import JSONResponse
 
 from onyx.error_handling.error_codes import OnyxErrorCode
-from onyx.error_handling.exceptions import OnyxError
 from onyx.server.manage import get_state
 
 
@@ -33,7 +33,7 @@ def _limiter(borrowed: float, total: float, waiting: int) -> MagicMock:
 
 def _healthcheck(
     borrowed: float, total: float, waiting: int, now: float
-) -> get_state.StatusResponse[dict[str, float]]:
+) -> get_state.StatusResponse[dict[str, float]] | JSONResponse:
     """Run the readiness handler against a fixed pool state and clock."""
     with (
         patch.object(
@@ -46,8 +46,17 @@ def _healthcheck(
         return asyncio.run(get_state.healthcheck())
 
 
+def _ready(
+    borrowed: float, total: float, waiting: int, now: float
+) -> get_state.StatusResponse[dict[str, float]]:
+    """Run the readiness handler and assert it reported ready."""
+    response = _healthcheck(borrowed, total, waiting, now)
+    assert not isinstance(response, JSONResponse)
+    return response
+
+
 def test_idle_pool_is_ready() -> None:
-    response = _healthcheck(borrowed=0, total=40, waiting=0, now=100.0)
+    response = _ready(borrowed=0, total=40, waiting=0, now=100.0)
 
     assert response.success is True
     assert response.data == {
@@ -59,7 +68,7 @@ def test_idle_pool_is_ready() -> None:
 
 def test_fully_borrowed_pool_with_empty_queue_is_ready() -> None:
     """Every thread busy is normal. Only a backed-up queue means saturation."""
-    response = _healthcheck(borrowed=40, total=40, waiting=0, now=100.0)
+    response = _ready(borrowed=40, total=40, waiting=0, now=100.0)
 
     assert response.success is True
     assert get_state._SATURATED_SINCE is None
@@ -67,7 +76,7 @@ def test_fully_borrowed_pool_with_empty_queue_is_ready() -> None:
 
 def test_brief_saturation_does_not_flip_readiness() -> None:
     """A single saturated sample starts the timer but still reports ready."""
-    response = _healthcheck(borrowed=40, total=40, waiting=5, now=100.0)
+    response = _ready(borrowed=40, total=40, waiting=5, now=100.0)
 
     assert response.success is True
     assert get_state._SATURATED_SINCE == 100.0
@@ -76,16 +85,17 @@ def test_brief_saturation_does_not_flip_readiness() -> None:
 def test_sustained_saturation_reports_not_ready() -> None:
     _healthcheck(borrowed=40, total=40, waiting=5, now=100.0)
 
-    with pytest.raises(OnyxError) as err:
-        _healthcheck(
-            borrowed=40,
-            total=40,
-            waiting=5,
-            now=100.0 + get_state._UNREADY_AFTER_SECONDS,
-        )
+    response = _healthcheck(
+        borrowed=40,
+        total=40,
+        waiting=5,
+        now=100.0 + get_state._UNREADY_AFTER_SECONDS,
+    )
 
-    assert err.value.error_code == OnyxErrorCode.SERVICE_UNAVAILABLE
-    assert err.value.status_code == 503
+    # Returned, not raised, so the global handler does not log every probe.
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 503
+    assert OnyxErrorCode.SERVICE_UNAVAILABLE.code in bytes(response.body).decode()
 
 
 def test_recovery_between_samples_restarts_the_timer() -> None:
@@ -95,7 +105,7 @@ def test_recovery_between_samples_restarts_the_timer() -> None:
     assert get_state._SATURATED_SINCE is None
 
     # Long past the original window, but this is a fresh saturation streak.
-    response = _healthcheck(borrowed=40, total=40, waiting=5, now=200.0)
+    response = _ready(borrowed=40, total=40, waiting=5, now=200.0)
 
     assert response.success is True
     assert get_state._SATURATED_SINCE == 200.0
@@ -106,13 +116,12 @@ def test_not_ready_is_logged_once_per_streak() -> None:
     with patch.object(get_state, "logger") as mock_logger:
         _healthcheck(borrowed=40, total=40, waiting=5, now=100.0)
         for offset in range(3):
-            with pytest.raises(OnyxError):
-                _healthcheck(
-                    borrowed=40,
-                    total=40,
-                    waiting=5,
-                    now=100.0 + get_state._UNREADY_AFTER_SECONDS + offset,
-                )
+            _healthcheck(
+                borrowed=40,
+                total=40,
+                waiting=5,
+                now=100.0 + get_state._UNREADY_AFTER_SECONDS + offset,
+            )
 
         assert mock_logger.warning.call_count == 1
 
@@ -125,13 +134,12 @@ def test_not_ready_is_logged_once_per_streak() -> None:
 def test_liveness_stays_up_while_saturated() -> None:
     """Liveness must never fail on load, or saturation restarts every replica."""
     _healthcheck(borrowed=40, total=40, waiting=5, now=100.0)
-    with pytest.raises(OnyxError):
-        _healthcheck(
-            borrowed=40,
-            total=40,
-            waiting=5,
-            now=100.0 + get_state._UNREADY_AFTER_SECONDS,
-        )
+    _healthcheck(
+        borrowed=40,
+        total=40,
+        waiting=5,
+        now=100.0 + get_state._UNREADY_AFTER_SECONDS,
+    )
 
     response = asyncio.run(get_state.liveness())
 

--- a/backend/tests/unit/onyx/server/manage/test_health_readiness.py
+++ b/backend/tests/unit/onyx/server/manage/test_health_readiness.py
@@ -1,0 +1,115 @@
+"""Unit tests for the /health readiness and /health/live liveness endpoints."""
+
+import asyncio
+from collections.abc import Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.manage import get_state
+
+
+@pytest.fixture(autouse=True)
+def reset_saturation_latch() -> Iterator[None]:
+    """The latch is module state, so clear it around every test."""
+    get_state._SATURATED_SINCE = None
+    yield
+    get_state._SATURATED_SINCE = None
+
+
+def _limiter(borrowed: float, total: float, waiting: int) -> MagicMock:
+    limiter = MagicMock()
+    limiter.statistics.return_value = MagicMock(
+        borrowed_tokens=borrowed,
+        total_tokens=total,
+        tasks_waiting=waiting,
+    )
+    return limiter
+
+
+def _healthcheck(
+    borrowed: float, total: float, waiting: int, now: float
+) -> get_state.StatusResponse[dict[str, float]]:
+    """Run the readiness handler against a fixed pool state and clock."""
+    with (
+        patch.object(
+            get_state.to_thread,
+            "current_default_thread_limiter",
+            return_value=_limiter(borrowed, total, waiting),
+        ),
+        patch.object(get_state.time, "monotonic", return_value=now),
+    ):
+        return asyncio.run(get_state.healthcheck())
+
+
+def test_idle_pool_is_ready() -> None:
+    response = _healthcheck(borrowed=0, total=40, waiting=0, now=100.0)
+
+    assert response.success is True
+    assert response.data == {
+        "threadpool_total_tokens": 40,
+        "threadpool_borrowed_tokens": 0,
+        "threadpool_tasks_waiting": 0,
+    }
+
+
+def test_fully_borrowed_pool_with_empty_queue_is_ready() -> None:
+    """Every thread busy is normal. Only a backed-up queue means saturation."""
+    response = _healthcheck(borrowed=40, total=40, waiting=0, now=100.0)
+
+    assert response.success is True
+    assert get_state._SATURATED_SINCE is None
+
+
+def test_brief_saturation_does_not_flip_readiness() -> None:
+    """A single saturated sample starts the timer but still reports ready."""
+    response = _healthcheck(borrowed=40, total=40, waiting=5, now=100.0)
+
+    assert response.success is True
+    assert get_state._SATURATED_SINCE == 100.0
+
+
+def test_sustained_saturation_reports_not_ready() -> None:
+    _healthcheck(borrowed=40, total=40, waiting=5, now=100.0)
+
+    with pytest.raises(OnyxError) as err:
+        _healthcheck(
+            borrowed=40,
+            total=40,
+            waiting=5,
+            now=100.0 + get_state._UNREADY_AFTER_SECONDS,
+        )
+
+    assert err.value.error_code == OnyxErrorCode.SERVICE_UNAVAILABLE
+    assert err.value.status_code == 503
+
+
+def test_recovery_between_samples_restarts_the_timer() -> None:
+    """A healthy sample clears the latch, so the grace window starts over."""
+    _healthcheck(borrowed=40, total=40, waiting=5, now=100.0)
+    _healthcheck(borrowed=10, total=40, waiting=0, now=105.0)
+    assert get_state._SATURATED_SINCE is None
+
+    # Long past the original window, but this is a fresh saturation streak.
+    response = _healthcheck(borrowed=40, total=40, waiting=5, now=200.0)
+
+    assert response.success is True
+    assert get_state._SATURATED_SINCE == 200.0
+
+
+def test_liveness_stays_up_while_saturated() -> None:
+    """Liveness must never fail on load, or saturation restarts every replica."""
+    _healthcheck(borrowed=40, total=40, waiting=5, now=100.0)
+    with pytest.raises(OnyxError):
+        _healthcheck(
+            borrowed=40,
+            total=40,
+            waiting=5,
+            now=100.0 + get_state._UNREADY_AFTER_SECONDS,
+        )
+
+    response = asyncio.run(get_state.liveness())
+
+    assert response.success is True

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.17
+version: 0.8.18
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -20,17 +20,16 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
-    - kind: added
-      description: The chart is now also published as an OCI artifact at
-        `oci://ghcr.io/onyx-dot-app/charts/onyx`. Install it with
-        `helm install onyx oci://ghcr.io/onyx-dot-app/charts/onyx --version <version>`.
-        The existing repository at https://onyx-dot-app.github.io/onyx keeps working
-        and stays the default install path; no action is needed to keep using it.
     - kind: changed
-      description: Chart tarballs are now attached to GitHub releases
-        (`helm/onyx-<version>`) instead of being committed to the gh-pages branch.
-        `helm repo add` and `helm install` are unaffected — only the download URL
-        behind index.yaml changed.
+      description: The api server `/health` endpoint now reports not-ready (503)
+        while its request threadpool stays saturated, so a wedged pod leaves the
+        Service. It previously returned 200 in that state. Move `/health` off any
+        `livenessProbe` you configured — saturation is load-induced and hits every
+        replica at once, so restarting on it turns a slowdown into an outage.
+    - kind: added
+      description: New api server endpoint `/health/live` reports only that the
+        process runs. Use it for `livenessProbe`, and keep `/health` for
+        `readinessProbe`. `values.yaml` documents both under `api`.
 dependencies:
   # Helm uses the first condition path that exists: `postgresqlOperator.enabled`
   # is unset by default, so this falls through to `postgresql.enabled`. Set it

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -574,11 +574,22 @@ api:
       cpu: 3000m
       memory: 3Gi
 
-  # Optional health probes
+  # Optional health probes.
+  #
+  # Match the path to the probe. /health reports not-ready once the request
+  # threadpool is saturated, which is what should pull a pod out of the Service.
+  # /health/live only reports that the process is up. Do NOT put /health on the
+  # liveness probe: saturation is load-induced and hits every replica at once,
+  # so restarting on it turns a slowdown into an outage.
+  #
   # Example:
   # readinessProbe:
   #   httpGet:
   #     path: /health
+  #     port: api-server-port
+  # livenessProbe:
+  #   httpGet:
+  #     path: /health/live
   #     port: api-server-port
   startupProbe: {}
   readinessProbe: {}


### PR DESCRIPTION
## Problem

`/health` returned 200 while the app was unhealthy.

The endpoint is `async`, so it runs on the event loop and answers in microseconds regardless of server state. Every sync (`def`) endpoint instead runs in the anyio threadpool sized in `main.py`. When that pool fills and requests queue, the server can serve no real traffic — but `/health` never touches the pool, so every probe still reported success.

## Change

**`/health` is now the readiness signal.** It reads the limiter and returns 503 once every token is borrowed *and* requests keep queueing, continuously for 10s. Both conditions are needed: a fully borrowed pool with an empty queue is normal, and bursty load queues briefly. The response body carries the pool numbers on the success path too.

It stays `async` on purpose. A sync handler would borrow a token of the pool it is measuring — adding load exactly when there is none to spare — and would queue rather than answer, turning a clear 503 into a hang that only the prober's timeout catches.

**`/health/live` is new, for liveness.** It checks nothing but that the process runs. Saturation is load-induced and correlated across replicas, so gating restarts on it would turn a slowdown into an outage.

`/health` keeps its path, so existing deployments get the fixed signal with no manifest change.

Thresholds are constants in `get_state.py`, not env vars — there is no evidence yet that anyone needs to tune them.

## Not changed

The Compose healthcheck still uses `/health`. Compose never restarts on `unhealthy` (`restart: unless-stopped` acts on exit), and there is no load balancer to pull the container from, so the reported health status is the operator-visible signal — which is precisely what should go red when the server is wedged.

## Verification

Unit tests in `test_health_readiness.py` cover idle, fully-borrowed-but-draining, brief saturation, sustained saturation, recovery resetting the grace window, and liveness holding while readiness is down.

Verified live against a dev server by saturating the pool with concurrent requests to `/versions` (a sync endpoint):

```
t=16s live=200 | ...borrowed_tokens:40.0,"tasks_waiting":1569.0}  HTTP:200
t=18s live=200 | {"error_code":"SERVICE_UNAVAILABLE","detail":"Request threadpool saturated for 13.6s (1627 requests queued)"}  HTTP:503
t=24s live=200 | {"error_code":"SERVICE_UNAVAILABLE","detail":"Request threadpool saturated for 22.3s (2383 requests queued)"}  HTTP:503
```

`/health/live` stayed 200 throughout. An earlier run with intermittent load never tripped the 503 — the pool drained between samples and reset the latch, which is the flap suppression behaving as intended.

## Operator note

Anyone who wired `/health` to a `livenessProbe` should move to `/health/live`, or load spikes will become restart storms. The chart ships no probes by default (`startupProbe`/`readinessProbe`/`livenessProbe` are all `{}`); `values.yaml` now documents which path belongs on which probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report not-ready (503) from `/health` when the request threadpool stays saturated for 10s, and add `/health/live` that always returns 200. Previously `/health` always returned 200 on the event loop, masking replicas that could not serve sync traffic.

- Readiness: `/health` stays async; reports not-ready once all tokens are borrowed and a queue persists for 10s; success responses include threadpool stats; sampling occurs at probe cadence and resets on a healthy sample.
- Logging/errors: log only transitions into/out of not-ready; return the 503 directly to avoid per-probe 5xx logs from the global handler.
- Probes/routing: allow unauthenticated GET to `/health` and `/health/live`; skip tenant resolution for both and strip `APP_API_PREFIX` first so probes never hit Redis-backed session lookup.
- Helm: chart bumped to 0.8.18; Artifact Hub “changes” updated to document the health endpoint behavior; `values.yaml` clarifies `/health` for readiness and `/health/live` for liveness; no default probe values changed.

- Required action: if you used `/health` for liveness, move it to `/health/live`. Keep readiness on `/health`.

<sup>Written for commit 95c0b5d0f99c65b07bebdc6f26bef4bf3918770e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

