### PR TITLE
feat(connector-stability): POST capability check trigger + runner task

### DIFF
--- a/backend/onyx/background/celery/apps/heavy.py
+++ b/backend/onyx/background/celery/apps/heavy.py
@@ -134,6 +134,7 @@ celery_app.autodiscover_tasks(
             # Sandbox tasks (file sync, cleanup; build feature)
             "onyx.background.celery.tasks.build",
             "onyx.background.celery.tasks.hierarchyfetching",
+            "onyx.background.celery.tasks.capability_checks",
         ]
     )
 )

--- a/backend/onyx/background/celery/tasks/capability_checks/tasks.py
+++ b/backend/onyx/background/celery/tasks/capability_checks/tasks.py
@@ -1,0 +1,84 @@
+"""Celery task running the granular capability checks for one scope.
+
+Enqueued by the capability-check trigger endpoint after it marks the scope's
+row RUNNING. Writes through the unconditional upsert: a granular run is the
+freshest truth and replaces whatever is stored (see the accessors' writer
+model). A task-level crash leaves the row RUNNING; the mark's staleness bound
+un-blocks re-triggering.
+"""
+
+from typing import Any
+
+from celery import Task, shared_task
+
+from onyx.background.celery.apps.app_base import task_logger
+from onyx.configs.constants import OnyxCeleryTask
+from onyx.connectors.capability_checks.models import compute_connector_config_hash
+from onyx.connectors.capability_checks.runner import generate_capability_report
+from onyx.connectors.models import InputType
+from onyx.db.connector import fetch_connector_by_id
+from onyx.db.credential_capability import upsert_completed_capability_report
+from onyx.db.credentials import fetch_credential_by_id
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import CapabilityCheckTrigger
+
+
+@shared_task(  # ty: ignore[invalid-argument-type]
+    name=OnyxCeleryTask.RUN_CAPABILITY_CHECKS,
+    bind=True,
+)
+def run_capability_checks_task(
+    self: Task,  # noqa: ARG001
+    *,
+    credential_id: int,
+    connector_id: int | None,
+    connector_specific_config: dict[str, Any] | None,
+    tenant_id: str | None,
+) -> None:
+    """Runs every capability check for the scope and stores the report."""
+    with get_session_with_current_tenant() as db_session:
+        credential = fetch_credential_by_id(credential_id, db_session)
+        if credential is None:
+            # Deleted since the trigger; its report rows cascaded with it.
+            task_logger.info(
+                f"Skipping capability checks for deleted credential "
+                f"{credential_id} (tenant {tenant_id})."
+            )
+            return
+        input_type: InputType | None = None
+        config = connector_specific_config
+        if connector_id is not None:
+            connector = fetch_connector_by_id(connector_id, db_session)
+            if connector is None:
+                # Deleted since the trigger; its report row cascaded with it.
+                task_logger.info(
+                    f"Skipping capability checks for deleted connector "
+                    f"{connector_id} (tenant {tenant_id})."
+                )
+                return
+            input_type = connector.input_type
+            if config is None:
+                config = connector.connector_specific_config
+        report = generate_capability_report(
+            db_session,
+            credential,
+            connector_specific_config=config,
+            connector_id=connector_id,
+            input_type=input_type,
+            trigger=CapabilityCheckTrigger.MANUAL,
+        )
+        upsert_completed_capability_report(
+            db_session,
+            credential_id=credential_id,
+            connector_id=connector_id,
+            source=credential.source,
+            trigger=CapabilityCheckTrigger.MANUAL,
+            report=report,
+            connector_config_hash=(
+                compute_connector_config_hash(config)
+                if connector_id is not None
+                else None
+            ),
+        )
+        # The accessors leave the transaction to the caller.
+        db_session.commit()

--- a/backend/onyx/background/celery/tasks/capability_checks/tasks.py
+++ b/backend/onyx/background/celery/tasks/capability_checks/tasks.py
@@ -1,10 +1,10 @@
 """Celery task running the granular capability checks for one scope.
 
-Enqueued by the capability-check trigger endpoint after it marks the scope's
-row RUNNING. Writes through the unconditional upsert: a granular run is the
-freshest truth and replaces whatever is stored (see the accessors' writer
-model). A task-level crash leaves the row RUNNING; the mark's staleness bound
-un-blocks re-triggering.
+Enqueued by the capability-check trigger endpoint after it marks the scope's row
+RUNNING. Writes through the unconditional upsert: a granular run is the freshest
+truth and replaces whatever is stored (see the accessors' writer model). A
+task-level crash leaves the row RUNNING; the mark's staleness bound un-blocks
+re-triggering.
 """
 
 from typing import Any

--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -177,6 +177,7 @@ def _collect_queue_metrics(redis_celery: Redis) -> list[Metric]:
         "index_attempt_cleanup_queue_length": OnyxCeleryQueues.INDEX_ATTEMPT_CLEANUP,
         "chat_ttl_deletion_queue_length": OnyxCeleryQueues.CHAT_TTL_DELETION,
         "csv_generation_queue_length": OnyxCeleryQueues.CSV_GENERATION,
+        "capability_checks_queue_length": OnyxCeleryQueues.CAPABILITY_CHECKS,
         "user_file_processing_queue_length": OnyxCeleryQueues.USER_FILE_PROCESSING,
         "user_file_project_sync_queue_length": OnyxCeleryQueues.USER_FILE_PROJECT_SYNC,
         "user_file_delete_queue_length": OnyxCeleryQueues.USER_FILE_DELETE,
@@ -977,6 +978,9 @@ def monitor_celery_queues_helper(
     n_csv_generation = celery_get_queue_length(
         OnyxCeleryQueues.CSV_GENERATION, r_celery
     )
+    n_capability_checks = celery_get_queue_length(
+        OnyxCeleryQueues.CAPABILITY_CHECKS, r_celery
+    )
     n_monitoring = celery_get_queue_length(OnyxCeleryQueues.MONITORING, r_celery)
     n_sandbox = celery_get_queue_length(OnyxCeleryQueues.SANDBOX, r_celery)
     n_opensearch_migration = celery_get_queue_length(
@@ -1012,6 +1016,7 @@ def monitor_celery_queues_helper(
         f"checkpoint_cleanup={n_checkpoint_cleanup} "
         f"index_attempt_cleanup={n_index_attempt_cleanup} "
         f"csv_generation={n_csv_generation} "
+        f"capability_checks={n_capability_checks} "
         f"monitoring={n_monitoring} "
         f"sandbox={n_sandbox} "
         f"opensearch_migration={n_opensearch_migration} "

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -462,6 +462,9 @@ class OnyxCeleryQueues:
     CONNECTOR_EXTERNAL_GROUP_SYNC = "connector_external_group_sync"
     CONNECTOR_HIERARCHY_FETCHING = "connector_hierarchy_fetching"
     CSV_GENERATION = "csv_generation"
+    # Manual credential capability check runs; probes may legitimately hang up
+    # to their per-check guard, so they live with the long-running work.
+    CAPABILITY_CHECKS = "capability_checks"
 
     # Chat retention (TTL) hard-deletion queue, consumed by the light worker.
     # Kept off the primary "celery" queue so cleanup never starves check_for_indexing.
@@ -677,6 +680,9 @@ class OnyxCeleryTask:
     CONNECTOR_HIERARCHY_FETCHING_TASK = "connector_hierarchy_fetching_task"
     DOCUMENT_BY_CC_PAIR_CLEANUP_TASK = "document_by_cc_pair_cleanup_task"
     DOCUMENT_INDEX_METADATA_SYNC_TASK = "document_index_metadata_sync_task"
+
+    # Credential capability checks (granular runs of the registered checks)
+    RUN_CAPABILITY_CHECKS = "run_capability_checks"
 
     # chat retention
     CHECK_TTL_MANAGEMENT_TASK = "check_ttl_management_task"

--- a/backend/onyx/connectors/capability_checks/models.py
+++ b/backend/onyx/connectors/capability_checks/models.py
@@ -142,8 +142,11 @@ class CredentialCapabilityReport(BaseModel):
 
 
 def compute_connector_config_hash(config: dict[str, Any] | None) -> str | None:
-    """sha256 of the canonical config JSON a report ran with; the staleness
-    signal. Shared by every report writer so stored hashes stay comparable."""
+    """Returns the sha256 of the canonical config JSON a report ran with.
+
+    This is the staleness signal, shared by every report writer so stored
+    hashes stay comparable.
+    """
     if config is None:
         return None
     canonical = json.dumps(config, sort_keys=True, separators=(",", ":"))

--- a/backend/onyx/connectors/capability_checks/models.py
+++ b/backend/onyx/connectors/capability_checks/models.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from datetime import datetime
@@ -137,6 +139,15 @@ class CredentialCapabilityReport(BaseModel):
     trigger: CapabilityCheckTrigger
     verdicts: dict[CredentialCapability, CapabilityVerdict]
     check_results: list[CapabilityCheckResult]
+
+
+def compute_connector_config_hash(config: dict[str, Any] | None) -> str | None:
+    """sha256 of the canonical config JSON a report ran with; the staleness
+    signal. Shared by every report writer so stored hashes stay comparable."""
+    if config is None:
+        return None
+    canonical = json.dumps(config, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
 
 
 def aggregate_capability_verdict(

--- a/backend/onyx/connectors/capability_checks/models.py
+++ b/backend/onyx/connectors/capability_checks/models.py
@@ -144,8 +144,8 @@ class CredentialCapabilityReport(BaseModel):
 def compute_connector_config_hash(config: dict[str, Any] | None) -> str | None:
     """Returns the sha256 of the canonical config JSON a report ran with.
 
-    This is the staleness signal, shared by every report writer so stored
-    hashes stay comparable.
+    This is the staleness signal, shared by every report writer so stored hashes
+    stay comparable.
     """
     if config is None:
         return None

--- a/backend/onyx/connectors/capability_checks/recorder.py
+++ b/backend/onyx/connectors/capability_checks/recorder.py
@@ -11,8 +11,6 @@ eagerly imports every migrated connector's check module) or the runner (which
 imports ``factory``).
 """
 
-import hashlib
-import json
 from datetime import datetime, timezone
 from typing import Any
 
@@ -26,6 +24,7 @@ from onyx.connectors.capability_checks.models import (
     CredentialCapability,
     CredentialCapabilityReport,
     compute_capability_verdicts,
+    compute_connector_config_hash,
 )
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.db.credential_capability import (
@@ -94,14 +93,6 @@ def _synthesize_results(
     return results
 
 
-def _connector_config_hash(config: dict[str, Any] | None) -> str | None:
-    """sha256 of the canonical config JSON; the staleness signal."""
-    if config is None:
-        return None
-    canonical = json.dumps(config, sort_keys=True, separators=(",", ":"))
-    return hashlib.sha256(canonical.encode()).hexdigest()
-
-
 def record_blocking_validation_outcome(
     *,
     credential_id: int,
@@ -139,7 +130,9 @@ def record_blocking_validation_outcome(
                 source=source,
                 trigger=trigger,
                 report=report,
-                connector_config_hash=_connector_config_hash(connector_specific_config),
+                connector_config_hash=compute_connector_config_hash(
+                    connector_specific_config
+                ),
             )
             # The accessors leave the transaction to the caller, and the session
             # context manager closes without committing.

--- a/backend/onyx/connectors/capability_checks/runner.py
+++ b/backend/onyx/connectors/capability_checks/runner.py
@@ -46,6 +46,12 @@ logger = setup_logger()
 # ``CapabilityCheck.timeout_seconds``.
 CAPABILITY_CHECK_TIMEOUT_SECONDS = 600
 
+# Crude ceiling on one run's legitimate wall time: checks run sequentially and
+# no source registers more than a handful, so a RUNNING mark older than this is
+# a crashed or expired run and stops blocking re-triggers. Stuck-run recovery
+# will replace it with a per-scope ceiling derived from the actual checks.
+CAPABILITY_CHECK_RUN_STALENESS_SECONDS = 6 * CAPABILITY_CHECK_TIMEOUT_SECONDS
+
 _SKIP_NEEDS_INSTANCE_MESSAGE = (
     "Requires a connector instance -- will re-run automatically when the "
     "connector is instantiated."

--- a/backend/onyx/db/credential_capability.py
+++ b/backend/onyx/db/credential_capability.py
@@ -211,6 +211,8 @@ def mark_capability_report_running(
         update_where=or_(
             CredentialCapabilityReportRow.run_status
             != CapabilityReportRunStatus.RUNNING,
+            # Defensive: no writer leaves RUNNING with a NULL start, but the
+            # schema can represent it and it must read as stale, not active.
             CredentialCapabilityReportRow.run_started_at.is_(None),
             CredentialCapabilityReportRow.run_started_at
             < func.statement_timestamp() - active_within,
@@ -218,18 +220,18 @@ def mark_capability_report_running(
     )
 
 
-def clear_capability_run_start(
+def mark_capability_run_failed(
     db_session: Session,
     *,
     credential_id: int,
     connector_id: int | None,
 ) -> None:
-    """Nulls the scope's run start time: the RUNNING mark never became a run.
+    """Retires the scope's RUNNING mark to FAILED_TO_RUN; the report survives.
 
-    For the failed-enqueue path: the mark cannot be reverted (the upsert
-    already replaced the previous run state), but a NULL start time already
-    reads as stale to the re-trigger guard, so the scope stays immediately
-    re-triggerable.
+    For runs that verifiably will not happen (the trigger endpoint's failed
+    enqueue): FAILED_TO_RUN is the truth pollers should read, and it does not
+    block re-marking, so the scope stays immediately re-triggerable. Guarded
+    on RUNNING so a completion that raced this write is never clobbered.
     """
     stmt = (
         update(CredentialCapabilityReportRow)
@@ -244,7 +246,7 @@ def clear_capability_run_start(
             == CapabilityReportRunStatus.RUNNING,
         )
         .values(
-            run_started_at=None,
+            run_status=CapabilityReportRunStatus.FAILED_TO_RUN,
             # Model ``onupdate`` does not apply to bulk updates.
             time_updated=func.statement_timestamp(),
         )

--- a/backend/onyx/db/credential_capability.py
+++ b/backend/onyx/db/credential_capability.py
@@ -16,7 +16,7 @@ flags a run in flight while the last completed report stays readable.
 from datetime import datetime, timedelta
 from typing import Any, TypedDict
 
-from sqlalchemy import ColumnElement, func, literal_column, or_, select, text
+from sqlalchemy import ColumnElement, func, literal_column, or_, select, text, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
@@ -216,6 +216,40 @@ def mark_capability_report_running(
             < func.statement_timestamp() - active_within,
         ),
     )
+
+
+def clear_capability_run_start(
+    db_session: Session,
+    *,
+    credential_id: int,
+    connector_id: int | None,
+) -> None:
+    """Nulls the scope's run start time: the RUNNING mark never became a run.
+
+    For the failed-enqueue path: the mark cannot be reverted (the upsert
+    already replaced the previous run state), but a NULL start time already
+    reads as stale to the re-trigger guard, so the scope stays immediately
+    re-triggerable.
+    """
+    stmt = (
+        update(CredentialCapabilityReportRow)
+        .where(
+            CredentialCapabilityReportRow.credential_id == credential_id,
+            (
+                CredentialCapabilityReportRow.connector_id.is_(None)
+                if connector_id is None
+                else CredentialCapabilityReportRow.connector_id == connector_id
+            ),
+            CredentialCapabilityReportRow.run_status
+            == CapabilityReportRunStatus.RUNNING,
+        )
+        .values(
+            run_started_at=None,
+            # Model ``onupdate`` does not apply to bulk updates.
+            time_updated=func.statement_timestamp(),
+        )
+    )
+    db_session.execute(stmt)
 
 
 def get_capability_report_row(

--- a/backend/onyx/db/credential_capability.py
+++ b/backend/onyx/db/credential_capability.py
@@ -13,7 +13,7 @@ through the ``unless_granular`` variant and never replaces a granular report.
 flags a run in flight while the last completed report stays readable.
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, TypedDict
 
 from sqlalchemy import ColumnElement, func, literal_column, or_, select, text
@@ -184,12 +184,19 @@ def mark_capability_report_running(
     connector_id: int | None,
     source: DocumentSource,
     trigger: CapabilityCheckTrigger,
-) -> CredentialCapabilityReportRow:
-    """Flags the scope's row RUNNING with a fresh start time.
+    active_within: timedelta,
+) -> CredentialCapabilityReportRow | None:
+    """Flags the scope's row RUNNING unless an unexpired run already is.
 
-    The previous COMPLETED ``report`` stays readable while the run is in flight.
+    The previous COMPLETED ``report`` stays readable while the run is in
+    flight. The guard compiles into ``ON CONFLICT DO UPDATE ... WHERE``: a
+    stored row blocks the mark only while it is RUNNING with a start time newer
+    than ``active_within`` ago, evaluated atomically by Postgres so concurrent
+    triggers cannot double-mark. A RUNNING mark older than the bound is a
+    crashed or expired run and is replaced. Returns None when an active run
+    blocked the mark.
     """
-    row = _upsert_row(
+    return _upsert_row(
         db_session,
         credential_id=credential_id,
         connector_id=connector_id,
@@ -201,9 +208,14 @@ def mark_capability_report_running(
             # caller's transaction began.
             "run_started_at": func.statement_timestamp(),
         },
+        update_where=or_(
+            CredentialCapabilityReportRow.run_status
+            != CapabilityReportRunStatus.RUNNING,
+            CredentialCapabilityReportRow.run_started_at.is_(None),
+            CredentialCapabilityReportRow.run_started_at
+            < func.statement_timestamp() - active_within,
+        ),
     )
-    assert row is not None, "An unguarded upsert always returns the row."
-    return row
 
 
 def get_capability_report_row(

--- a/backend/onyx/db/credential_capability.py
+++ b/backend/onyx/db/credential_capability.py
@@ -188,10 +188,10 @@ def mark_capability_report_running(
 ) -> CredentialCapabilityReportRow | None:
     """Flags the scope's row RUNNING unless an unexpired run already is.
 
-    The previous COMPLETED ``report`` stays readable while the run is in
-    flight. The guard compiles into ``ON CONFLICT DO UPDATE ... WHERE``: a
-    stored row blocks the mark only while it is RUNNING with a start time newer
-    than ``active_within`` ago, evaluated atomically by Postgres so concurrent
+    The previous COMPLETED ``report`` stays readable while the run is in flight.
+    The guard compiles into ``ON CONFLICT DO UPDATE ... WHERE``: a stored row
+    blocks the mark only while it is RUNNING with a start time newer than
+    ``active_within`` ago, evaluated atomically by Postgres so concurrent
     triggers cannot double-mark. A RUNNING mark older than the bound is a
     crashed or expired run and is replaced. Returns None when an active run
     blocked the mark.
@@ -230,8 +230,8 @@ def mark_capability_run_failed(
 
     For runs that verifiably will not happen (the trigger endpoint's failed
     enqueue): FAILED_TO_RUN is the truth pollers should read, and it does not
-    block re-marking, so the scope stays immediately re-triggerable. Guarded
-    on RUNNING so a completion that raced this write is never clobbered.
+    block re-marking, so the scope stays immediately re-triggerable. Guarded on
+    RUNNING so a completion that raced this write is never clobbered.
     """
     stmt = (
         update(CredentialCapabilityReportRow)

--- a/backend/onyx/server/documents/credential_capabilities.py
+++ b/backend/onyx/server/documents/credential_capabilities.py
@@ -46,7 +46,10 @@ from onyx.db.enums import CapabilityCheckTrigger, CapabilityReportRunStatus, Per
 from onyx.db.models import CredentialCapabilityReportRow, User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id
+
+logger = setup_logger()
 
 router = APIRouter(prefix="/manage")
 
@@ -139,10 +142,20 @@ def trigger_capability_check(
     the staleness bound makes this a no-op returning the standing row. A
     connector-scoped trigger requires the pairing to be visible to the caller.
     """
-    # GATE 2 for ``allow_scope``: the user-filtered fetch is the visibility
-    # check, and an unknown credential is indistinguishable from an
-    # inaccessible one.
+    # GATE 2 for ``allow_scope``, mirroring the report reads: credential
+    # visibility authorizes the credential scope; pairing visibility authorizes
+    # the connector scope on its own, so a pairing manager triggers its run
+    # even when the credential is outside their credential visibility. An
+    # unknown credential is indistinguishable from an inaccessible one.
+    pairing_visible = request.connector_id is not None and _connector_pairing_visible(
+        db_session, request.connector_id, credential_id, user
+    )
     credential = fetch_credential_by_id_for_user(credential_id, user, db_session)
+    if credential is None and pairing_visible:
+        # The run needs the credential row itself; the unfiltered fetch also
+        # keeps an unknown credential a 404 for global managers, whose pairing
+        # shortcut checks nothing.
+        credential = fetch_credential_by_id(credential_id, db_session)
     if credential is None:
         raise OnyxError(
             OnyxErrorCode.CREDENTIAL_NOT_FOUND,
@@ -156,12 +169,10 @@ def trigger_capability_check(
         )
     if request.connector_id is not None:
         connector = fetch_connector_by_id(request.connector_id, db_session)
-        # GATE 2 for the connector scope, mirroring the report reads: one
-        # shape for missing and inaccessible, so neither connector existence
-        # nor pairing membership leaks. The source check stays behind it.
-        if connector is None or not _connector_pairing_visible(
-            db_session, request.connector_id, credential_id, user
-        ):
+        # One shape for missing and inaccessible, so neither connector
+        # existence nor pairing membership leaks. The source check stays
+        # behind it.
+        if connector is None or not pairing_visible:
             raise OnyxError(
                 OnyxErrorCode.CONNECTOR_NOT_FOUND,
                 f"Connector {request.connector_id} does not exist or is not "
@@ -216,6 +227,13 @@ def trigger_capability_check(
             expires=CAPABILITY_CHECK_RUN_STALENESS_SECONDS,
         )
     except Exception:
+        # The 503 handler logs no traceback, so record the cause here (broker
+        # down and a bad task payload must stay distinguishable in the logs).
+        logger.exception(
+            "Capability check enqueue failed for credential %s, connector %s.",
+            credential_id,
+            request.connector_id,
+        )
         # No run was enqueued: FAILED_TO_RUN is the truth pollers should read,
         # and it does not block an immediate re-trigger.
         mark_capability_run_failed(

--- a/backend/onyx/server/documents/credential_capabilities.py
+++ b/backend/onyx/server/documents/credential_capabilities.py
@@ -1,9 +1,9 @@
 """API over stored credential capability reports.
 
 The blocking-validation recorder and the granular check-runner task write the
-rows; these endpoints read them and trigger runs. Reports are advisory:
-nothing here gates connector creation or indexing, and check failures are
-report content, never an HTTP error.
+rows; these endpoints read them and trigger runs. Reports are advisory: nothing
+here gates connector creation or indexing, and check failures are report
+content, never an HTTP error.
 """
 
 from datetime import datetime, timedelta
@@ -118,8 +118,8 @@ class CapabilityCheckRunRequest(BaseModel):
     not-yet-saved edit) and is only meaningful with ``connector_id``.
     """
 
-    # Both fields are optional, so a typoed field name would otherwise
-    # silently select the wrong scope.
+    # Both fields are optional, so a typoed field name would otherwise silently
+    # select the wrong scope.
     model_config = ConfigDict(extra="forbid")
 
     connector_id: int | None = None
@@ -144,9 +144,9 @@ def trigger_capability_check(
     """
     # GATE 2 for ``allow_scope``, mirroring the report reads: credential
     # visibility authorizes the credential scope; pairing visibility authorizes
-    # the connector scope on its own, so a pairing manager triggers its run
-    # even when the credential is outside their credential visibility. An
-    # unknown credential is indistinguishable from an inaccessible one.
+    # the connector scope on its own, so a pairing manager triggers its run even
+    # when the credential is outside their credential visibility. An unknown
+    # credential is indistinguishable from an inaccessible one.
     pairing_visible = request.connector_id is not None and _connector_pairing_visible(
         db_session, request.connector_id, credential_id, user
     )
@@ -169,9 +169,8 @@ def trigger_capability_check(
         )
     if request.connector_id is not None:
         connector = fetch_connector_by_id(request.connector_id, db_session)
-        # One shape for missing and inaccessible, so neither connector
-        # existence nor pairing membership leaks. The source check stays
-        # behind it.
+        # One shape for missing and inaccessible, so neither connector existence
+        # nor pairing membership leaks. The source check stays behind it.
         if connector is None or not pairing_visible:
             raise OnyxError(
                 OnyxErrorCode.CONNECTOR_NOT_FOUND,
@@ -200,8 +199,8 @@ def trigger_capability_check(
         )
         if standing is None:
             # The blocking row vanished between the two statements: the
-            # credential (or the paired connector) was deleted concurrently
-            # and its report rows cascaded away.
+            # credential (or the paired connector) was deleted concurrently and
+            # its report rows cascaded away.
             raise OnyxError(
                 OnyxErrorCode.CREDENTIAL_NOT_FOUND,
                 f"Credential {credential_id} or its paired connector was "

--- a/backend/onyx/server/documents/credential_capabilities.py
+++ b/backend/onyx/server/documents/credential_capabilities.py
@@ -131,7 +131,8 @@ def trigger_capability_check(
 
     Accepted-style: the run happens on a worker and the caller polls the GET;
     the previous report stays readable meanwhile. A run already RUNNING within
-    the staleness bound makes this a no-op returning the standing row.
+    the staleness bound makes this a no-op returning the standing row. A
+    connector-scoped trigger requires the pairing to be visible to the caller.
     """
     # GATE 2 for ``allow_scope``: the user-filtered fetch is the visibility
     # check, and an unknown credential is indistinguishable from an
@@ -150,10 +151,16 @@ def trigger_capability_check(
         )
     if request.connector_id is not None:
         connector = fetch_connector_by_id(request.connector_id, db_session)
-        if connector is None:
+        # GATE 2 for the connector scope, mirroring the report reads: one
+        # shape for missing and inaccessible, so neither connector existence
+        # nor pairing membership leaks. The source check stays behind it.
+        if connector is None or not _connector_pairing_visible(
+            db_session, request.connector_id, credential_id, user
+        ):
             raise OnyxError(
                 OnyxErrorCode.CONNECTOR_NOT_FOUND,
-                f"Connector {request.connector_id} does not exist.",
+                f"Connector {request.connector_id} does not exist or is not "
+                "accessible.",
             )
         if connector.source != credential.source:
             raise OnyxError(

--- a/backend/onyx/server/documents/credential_capabilities.py
+++ b/backend/onyx/server/documents/credential_capabilities.py
@@ -31,10 +31,10 @@ from onyx.db.connector_credential_pair import (
     get_connector_credential_pairs_for_user,
 )
 from onyx.db.credential_capability import (
-    clear_capability_run_start,
     get_capability_report_row,
     get_capability_report_rows_for_source,
     mark_capability_report_running,
+    mark_capability_run_failed,
 )
 from onyx.db.credentials import (
     fetch_credential_by_id,
@@ -187,7 +187,15 @@ def trigger_capability_check(
         standing = get_capability_report_row(
             db_session, credential_id, request.connector_id
         )
-        assert standing is not None, "The mark is only blocked by an existing row."
+        if standing is None:
+            # The blocking row vanished between the two statements: the
+            # credential (or the paired connector) was deleted concurrently
+            # and its report rows cascaded away.
+            raise OnyxError(
+                OnyxErrorCode.CREDENTIAL_NOT_FOUND,
+                f"Credential {credential_id} or its paired connector was "
+                "deleted while the request was in flight.",
+            )
         return CapabilityReportSnapshot.from_row(standing)
     snapshot = CapabilityReportSnapshot.from_row(row)
     # Commit before enqueueing so the worker can only observe the RUNNING mark.
@@ -208,9 +216,9 @@ def trigger_capability_check(
             expires=CAPABILITY_CHECK_RUN_STALENESS_SECONDS,
         )
     except Exception:
-        # No run was enqueued, so the fresh mark must not block re-triggering
-        # for the whole staleness bound.
-        clear_capability_run_start(
+        # No run was enqueued: FAILED_TO_RUN is the truth pollers should read,
+        # and it does not block an immediate re-trigger.
+        mark_capability_run_failed(
             db_session,
             credential_id=credential_id,
             connector_id=request.connector_id,

--- a/backend/onyx/server/documents/credential_capabilities.py
+++ b/backend/onyx/server/documents/credential_capabilities.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import has_global_permission, require_permission
@@ -31,6 +31,7 @@ from onyx.db.connector_credential_pair import (
     get_connector_credential_pairs_for_user,
 )
 from onyx.db.credential_capability import (
+    clear_capability_run_start,
     get_capability_report_row,
     get_capability_report_rows_for_source,
     mark_capability_report_running,
@@ -114,6 +115,10 @@ class CapabilityCheckRunRequest(BaseModel):
     not-yet-saved edit) and is only meaningful with ``connector_id``.
     """
 
+    # Both fields are optional, so a typoed field name would otherwise
+    # silently select the wrong scope.
+    model_config = ConfigDict(extra="forbid")
+
     connector_id: int | None = None
     connector_specific_config: dict[str, Any] | None = None
 
@@ -187,20 +192,34 @@ def trigger_capability_check(
     snapshot = CapabilityReportSnapshot.from_row(row)
     # Commit before enqueueing so the worker can only observe the RUNNING mark.
     db_session.commit()
-    client_app.send_task(
-        OnyxCeleryTask.RUN_CAPABILITY_CHECKS,
-        kwargs=dict(
+    try:
+        client_app.send_task(
+            OnyxCeleryTask.RUN_CAPABILITY_CHECKS,
+            kwargs=dict(
+                credential_id=credential_id,
+                connector_id=request.connector_id,
+                connector_specific_config=request.connector_specific_config,
+                tenant_id=get_current_tenant_id(),
+            ),
+            queue=OnyxCeleryQueues.CAPABILITY_CHECKS,
+            priority=OnyxCeleryPriority.HIGH,
+            # The queued run and its RUNNING mark go stale together, so an
+            # expired task never strands an unmarkable scope.
+            expires=CAPABILITY_CHECK_RUN_STALENESS_SECONDS,
+        )
+    except Exception:
+        # No run was enqueued, so the fresh mark must not block re-triggering
+        # for the whole staleness bound.
+        clear_capability_run_start(
+            db_session,
             credential_id=credential_id,
             connector_id=request.connector_id,
-            connector_specific_config=request.connector_specific_config,
-            tenant_id=get_current_tenant_id(),
-        ),
-        queue=OnyxCeleryQueues.CAPABILITY_CHECKS,
-        priority=OnyxCeleryPriority.HIGH,
-        # The queued run and its RUNNING mark go stale together, so an expired
-        # task never strands an unmarkable scope.
-        expires=CAPABILITY_CHECK_RUN_STALENESS_SECONDS,
-    )
+        )
+        db_session.commit()
+        raise OnyxError(
+            OnyxErrorCode.SERVICE_UNAVAILABLE,
+            "Could not enqueue the capability check run; try again shortly.",
+        )
     return snapshot
 
 

--- a/backend/onyx/server/documents/credential_capabilities.py
+++ b/backend/onyx/server/documents/credential_capabilities.py
@@ -1,19 +1,31 @@
-"""Read-only API over stored credential capability reports.
+"""API over stored credential capability reports.
 
-The blocking-validation recorder writes these rows today; the granular
-check-runner task will write them too once it exists. Reports are advisory:
-nothing here gates connector creation or indexing.
+The blocking-validation recorder and the granular check-runner task write the
+rows; these endpoints read them and trigger runs. Reports are advisory:
+nothing here gates connector creation or indexing, and check failures are
+report content, never an HTTP error.
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta
+from typing import Any
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import has_global_permission, require_permission
-from onyx.configs.constants import DocumentSource
+from onyx.background.celery.versioned_apps.client import app as client_app
+from onyx.configs.constants import (
+    DocumentSource,
+    OnyxCeleryPriority,
+    OnyxCeleryQueues,
+    OnyxCeleryTask,
+)
 from onyx.connectors.capability_checks.models import CredentialCapabilityReport
+from onyx.connectors.capability_checks.runner import (
+    CAPABILITY_CHECK_RUN_STALENESS_SECONDS,
+)
+from onyx.db.connector import fetch_connector_by_id
 from onyx.db.connector_credential_pair import (
     get_connector_credential_pair_for_user,
     get_connector_credential_pairs_for_user,
@@ -21,6 +33,7 @@ from onyx.db.connector_credential_pair import (
 from onyx.db.credential_capability import (
     get_capability_report_row,
     get_capability_report_rows_for_source,
+    mark_capability_report_running,
 )
 from onyx.db.credentials import (
     fetch_credential_by_id,
@@ -32,6 +45,7 @@ from onyx.db.enums import CapabilityCheckTrigger, CapabilityReportRunStatus, Per
 from onyx.db.models import CredentialCapabilityReportRow, User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from shared_configs.contextvars import get_current_tenant_id
 
 router = APIRouter(prefix="/manage")
 
@@ -90,6 +104,97 @@ def _connector_pairing_visible(
         )
         is not None
     )
+
+
+class CapabilityCheckRunRequest(BaseModel):
+    """Body of the trigger endpoint: which scope to run against.
+
+    Both fields absent is the config-less credential-scoped run.
+    ``connector_specific_config`` overrides the connector's stored config (a
+    not-yet-saved edit) and is only meaningful with ``connector_id``.
+    """
+
+    connector_id: int | None = None
+    connector_specific_config: dict[str, Any] | None = None
+
+
+@router.post("/admin/credential/{credential_id}/capability-check")
+def trigger_capability_check(
+    credential_id: int,
+    request: CapabilityCheckRunRequest,
+    user: User = Depends(
+        require_permission(Permission.MANAGE_CONNECTORS, allow_scope=True)
+    ),
+    db_session: Session = Depends(get_session),
+) -> CapabilityReportSnapshot:
+    """Marks the scope RUNNING, enqueues the check run, and returns the row.
+
+    Accepted-style: the run happens on a worker and the caller polls the GET;
+    the previous report stays readable meanwhile. A run already RUNNING within
+    the staleness bound makes this a no-op returning the standing row.
+    """
+    # GATE 2 for ``allow_scope``: the user-filtered fetch is the visibility
+    # check, and an unknown credential is indistinguishable from an
+    # inaccessible one.
+    credential = fetch_credential_by_id_for_user(credential_id, user, db_session)
+    if credential is None:
+        raise OnyxError(
+            OnyxErrorCode.CREDENTIAL_NOT_FOUND,
+            f"Credential {credential_id} does not exist or is not accessible.",
+        )
+    if request.connector_specific_config is not None and request.connector_id is None:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "connector_specific_config requires connector_id: the "
+            "credential-scoped run is config-less by definition.",
+        )
+    if request.connector_id is not None:
+        connector = fetch_connector_by_id(request.connector_id, db_session)
+        if connector is None:
+            raise OnyxError(
+                OnyxErrorCode.CONNECTOR_NOT_FOUND,
+                f"Connector {request.connector_id} does not exist.",
+            )
+        if connector.source != credential.source:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                f"Connector {request.connector_id} is a "
+                f"{connector.source.value} connector; credential "
+                f"{credential_id} is for {credential.source.value}.",
+            )
+    row = mark_capability_report_running(
+        db_session,
+        credential_id=credential_id,
+        connector_id=request.connector_id,
+        source=credential.source,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        active_within=timedelta(seconds=CAPABILITY_CHECK_RUN_STALENESS_SECONDS),
+    )
+    if row is None:
+        # An unexpired run is in flight; return its row without re-enqueueing.
+        standing = get_capability_report_row(
+            db_session, credential_id, request.connector_id
+        )
+        assert standing is not None, "The mark is only blocked by an existing row."
+        return CapabilityReportSnapshot.from_row(standing)
+    snapshot = CapabilityReportSnapshot.from_row(row)
+    # Commit before enqueueing so the worker can only observe the RUNNING mark.
+    db_session.commit()
+    client_app.send_task(
+        OnyxCeleryTask.RUN_CAPABILITY_CHECKS,
+        kwargs=dict(
+            credential_id=credential_id,
+            connector_id=request.connector_id,
+            connector_specific_config=request.connector_specific_config,
+            tenant_id=get_current_tenant_id(),
+        ),
+        queue=OnyxCeleryQueues.CAPABILITY_CHECKS,
+        priority=OnyxCeleryPriority.HIGH,
+        # The queued run and its RUNNING mark go stale together, so an expired
+        # task never strands an unmarkable scope.
+        expires=CAPABILITY_CHECK_RUN_STALENESS_SECONDS,
+    )
+    return snapshot
 
 
 @router.get("/admin/credential/{credential_id}/capability-report")

--- a/backend/onyx/server/metrics/indexing_pipeline.py
+++ b/backend/onyx/server/metrics/indexing_pipeline.py
@@ -58,6 +58,7 @@ _QUEUE_LABEL_MAP: dict[str, str] = {
     OnyxCeleryQueues.CHECKPOINT_CLEANUP: "checkpoint_cleanup",
     OnyxCeleryQueues.INDEX_ATTEMPT_CLEANUP: "index_attempt_cleanup",
     OnyxCeleryQueues.CSV_GENERATION: "csv_generation",
+    OnyxCeleryQueues.CAPABILITY_CHECKS: "capability_checks",
     OnyxCeleryQueues.USER_FILE_PROCESSING: "user_file_processing",
     OnyxCeleryQueues.USER_FILE_PROJECT_SYNC: "user_file_project_sync",
     OnyxCeleryQueues.USER_FILE_DELETE: "user_file_delete",

--- a/backend/scripts/dev_run_background_jobs.py
+++ b/backend/scripts/dev_run_background_jobs.py
@@ -84,7 +84,7 @@ def run_jobs() -> None:
         "--loglevel=INFO",
         "--hostname=heavy@%n",
         "-Q",
-        "connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation,sandbox",
+        "connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation,sandbox,capability_checks",
     ]
 
     cmd_worker_monitoring = [

--- a/backend/supervisord.conf
+++ b/backend/supervisord.conf
@@ -55,7 +55,7 @@ stopasgroup=true
 [program:celery_worker_heavy]
 command=celery -A onyx.background.celery.versioned_apps.heavy worker
     --hostname=heavy@%%n
-    -Q connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation,sandbox,connector_hierarchy_fetching
+    -Q connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation,sandbox,connector_hierarchy_fetching,capability_checks
 stdout_logfile=/var/log/celery_worker_heavy.log
 stdout_logfile_maxbytes=16MB
 redirect_stderr=true

--- a/backend/tests/external_dependency_unit/db/test_credential_capability.py
+++ b/backend/tests/external_dependency_unit/db/test_credential_capability.py
@@ -20,6 +20,7 @@ from onyx.connectors.capability_checks.models import (
     CredentialCapabilityReport,
 )
 from onyx.db.credential_capability import (
+    clear_capability_run_start,
     get_capability_report_row,
     get_capability_report_rows_for_source,
     mark_capability_report_running,
@@ -284,6 +285,46 @@ def test_mark_running_replaces_a_stale_running_mark(db_session: Session) -> None
     assert remarked is not None
     assert remarked.run_started_at is not None
     assert remarked.run_started_at > stale_started_at
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_cleared_run_start_reads_as_stale(db_session: Session) -> None:
+    """Verifies the failed-enqueue fixup: a NULL start unblocks re-marking."""
+    # Precondition.
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
+    credential_id = cc_pair.credential_id
+    marked = mark_capability_report_running(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        active_within=timedelta(hours=1),
+    )
+    assert marked is not None
+
+    # Under test.
+    clear_capability_run_start(
+        db_session, credential_id=credential_id, connector_id=None
+    )
+
+    # Postcondition. The row stays RUNNING but reads as stale: re-marking
+    # succeeds immediately instead of waiting out the bound.
+    db_session.expire_all()
+    row = get_capability_report_row(db_session, credential_id, None)
+    assert row is not None
+    assert row.run_status == CapabilityReportRunStatus.RUNNING
+    assert row.run_started_at is None
+    remarked = mark_capability_report_running(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        active_within=timedelta(hours=1),
+    )
+    assert remarked is not None
+    assert remarked.run_started_at is not None
 
 
 @pytest.mark.usefixtures("tenant_context")

--- a/backend/tests/external_dependency_unit/db/test_credential_capability.py
+++ b/backend/tests/external_dependency_unit/db/test_credential_capability.py
@@ -20,10 +20,10 @@ from onyx.connectors.capability_checks.models import (
     CredentialCapabilityReport,
 )
 from onyx.db.credential_capability import (
-    clear_capability_run_start,
     get_capability_report_row,
     get_capability_report_rows_for_source,
     mark_capability_report_running,
+    mark_capability_run_failed,
     upsert_completed_capability_report,
     upsert_completed_capability_report_unless_granular,
 )
@@ -288,11 +288,19 @@ def test_mark_running_replaces_a_stale_running_mark(db_session: Session) -> None
 
 
 @pytest.mark.usefixtures("tenant_context")
-def test_cleared_run_start_reads_as_stale(db_session: Session) -> None:
-    """Verifies the failed-enqueue fixup: a NULL start unblocks re-marking."""
-    # Precondition.
+def test_failed_run_mark_is_truthful_and_retriggerable(db_session: Session) -> None:
+    """Verifies the failed-enqueue fixup: the mark retires to FAILED_TO_RUN."""
+    # Precondition. A completed report, then a RUNNING mark over it.
     cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
     credential_id = cc_pair.credential_id
+    upsert_completed_capability_report(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        report=_report(credential_id, check_id="previous"),
+    )
     marked = mark_capability_report_running(
         db_session,
         credential_id=credential_id,
@@ -304,17 +312,19 @@ def test_cleared_run_start_reads_as_stale(db_session: Session) -> None:
     assert marked is not None
 
     # Under test.
-    clear_capability_run_start(
+    mark_capability_run_failed(
         db_session, credential_id=credential_id, connector_id=None
     )
 
-    # Postcondition. The row stays RUNNING but reads as stale: re-marking
-    # succeeds immediately instead of waiting out the bound.
+    # Postcondition. Pollers read FAILED_TO_RUN with the previous report
+    # preserved, and re-marking succeeds immediately instead of waiting out
+    # the bound.
     db_session.expire_all()
     row = get_capability_report_row(db_session, credential_id, None)
     assert row is not None
-    assert row.run_status == CapabilityReportRunStatus.RUNNING
-    assert row.run_started_at is None
+    assert row.run_status == CapabilityReportRunStatus.FAILED_TO_RUN
+    assert row.report is not None
+    assert row.report["check_results"][0]["check_id"] == "previous"
     remarked = mark_capability_report_running(
         db_session,
         credential_id=credential_id,
@@ -324,7 +334,34 @@ def test_cleared_run_start_reads_as_stale(db_session: Session) -> None:
         active_within=timedelta(hours=1),
     )
     assert remarked is not None
-    assert remarked.run_started_at is not None
+    assert remarked.run_status == CapabilityReportRunStatus.RUNNING
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_failed_run_mark_only_retires_running_rows(db_session: Session) -> None:
+    """Verifies the guard: a completion that raced the mark is not clobbered."""
+    # Precondition.
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
+    credential_id = cc_pair.credential_id
+    upsert_completed_capability_report(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        report=_report(credential_id),
+    )
+
+    # Under test.
+    mark_capability_run_failed(
+        db_session, credential_id=credential_id, connector_id=None
+    )
+
+    # Postcondition.
+    db_session.expire_all()
+    row = get_capability_report_row(db_session, credential_id, None)
+    assert row is not None
+    assert row.run_status == CapabilityReportRunStatus.COMPLETED
 
 
 @pytest.mark.usefixtures("tenant_context")

--- a/backend/tests/external_dependency_unit/db/test_credential_capability.py
+++ b/backend/tests/external_dependency_unit/db/test_credential_capability.py
@@ -6,7 +6,7 @@ commits (the accessors leave the transaction to the caller), so every test's
 rows roll back when its session closes.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy.orm import Session
@@ -168,9 +168,11 @@ def test_mark_running_preserves_report_and_completion_keeps_start_time(
         connector_id=None,
         source=DocumentSource.SLACK,
         trigger=CapabilityCheckTrigger.MANUAL,
+        active_within=timedelta(hours=1),
     )
 
     # Postcondition.
+    assert running is not None
     assert running.run_status == CapabilityReportRunStatus.RUNNING
     assert running.run_started_at is not None
     assert running.report is not None
@@ -204,11 +206,84 @@ def test_mark_running_creates_the_row_when_none_exists(db_session: Session) -> N
         connector_id=None,
         source=DocumentSource.SLACK,
         trigger=CapabilityCheckTrigger.CREDENTIAL_CREATED,
+        active_within=timedelta(hours=1),
     )
 
     # Postcondition.
+    assert row is not None
     assert row.run_status == CapabilityReportRunStatus.RUNNING
     assert row.report is None
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_mark_running_blocks_while_a_run_is_active(db_session: Session) -> None:
+    """Verifies the re-trigger guard: an unexpired RUNNING mark wins."""
+    # Precondition.
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
+    credential_id = cc_pair.credential_id
+    first = mark_capability_report_running(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        active_within=timedelta(hours=1),
+    )
+    assert first is not None
+    first_started_at = first.run_started_at
+
+    # Under test.
+    second = mark_capability_report_running(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        active_within=timedelta(hours=1),
+    )
+
+    # Postcondition.
+    assert second is None
+    # Reload from the DB rather than trusting the identity map.
+    db_session.expire_all()
+    row = get_capability_report_row(db_session, credential_id, None)
+    assert row is not None
+    assert row.run_started_at == first_started_at
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_mark_running_replaces_a_stale_running_mark(db_session: Session) -> None:
+    """Verifies the staleness bound: a crashed run's old mark is replaced."""
+    # Precondition.
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
+    credential_id = cc_pair.credential_id
+    stale = mark_capability_report_running(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        active_within=timedelta(hours=1),
+    )
+    assert stale is not None
+    stale_started_at = datetime.now(timezone.utc) - timedelta(hours=2)
+    stale.run_started_at = stale_started_at
+    db_session.flush()
+
+    # Under test.
+    remarked = mark_capability_report_running(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        active_within=timedelta(hours=1),
+    )
+
+    # Postcondition.
+    assert remarked is not None
+    assert remarked.run_started_at is not None
+    assert remarked.run_started_at > stale_started_at
 
 
 @pytest.mark.usefixtures("tenant_context")

--- a/backend/tests/external_dependency_unit/db/test_credential_capability.py
+++ b/backend/tests/external_dependency_unit/db/test_credential_capability.py
@@ -290,7 +290,8 @@ def test_mark_running_replaces_a_stale_running_mark(db_session: Session) -> None
 @pytest.mark.usefixtures("tenant_context")
 def test_failed_run_mark_is_truthful_and_retriggerable(db_session: Session) -> None:
     """Verifies the failed-enqueue fixup: the mark retires to FAILED_TO_RUN."""
-    # Precondition. A completed report, then a RUNNING mark over it.
+    # Precondition.
+    # A completed report, then a RUNNING mark over it.
     cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
     credential_id = cc_pair.credential_id
     upsert_completed_capability_report(
@@ -316,9 +317,9 @@ def test_failed_run_mark_is_truthful_and_retriggerable(db_session: Session) -> N
         db_session, credential_id=credential_id, connector_id=None
     )
 
-    # Postcondition. Pollers read FAILED_TO_RUN with the previous report
-    # preserved, and re-marking succeeds immediately instead of waiting out
-    # the bound.
+    # Postcondition.
+    # Pollers read FAILED_TO_RUN with the previous report preserved, and
+    # re-marking succeeds immediately instead of waiting out the bound.
     db_session.expire_all()
     row = get_capability_report_row(db_session, credential_id, None)
     assert row is not None

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -146,7 +146,7 @@ _CELERY_WORKER_PROGRAMS: list[tuple[str, str]] = [
     (
         "heavy",
         "connector_pruning,connector_doc_permissions_sync,"
-        "connector_external_group_sync,csv_generation,sandbox",
+        "connector_external_group_sync,csv_generation,sandbox,capability_checks",
     ),
     ("docprocessing", "docprocessing,port"),
     (

--- a/backend/tests/integration/tests/capability_checks/test_capability_check_run.py
+++ b/backend/tests/integration/tests/capability_checks/test_capability_check_run.py
@@ -1,0 +1,266 @@
+"""Integration tests for the capability-check trigger endpoint and its task.
+
+MOCK_CONNECTOR is the target source: the runner deliberately exempts no source,
+and the mock connector needs no external service on these paths (a config-less
+run cannot construct it, and a connector-scoped run fails fast against a closed
+local port), so runs complete deterministically without real probes.
+"""
+
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import update
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.capabilities import CredentialCapability
+from onyx.connectors.capability_checks.models import (
+    CapabilityCheckStatus,
+    CapabilityVerdict,
+)
+from onyx.connectors.models import InputType
+from onyx.db.credential_capability import mark_capability_report_running
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import CapabilityCheckTrigger, CapabilityReportRunStatus
+from onyx.db.models import CredentialCapabilityReportRow
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.connector import ConnectorManager
+from tests.integration.common_utils.managers.credential import CredentialManager
+from tests.integration.common_utils.test_models import DATestUser
+
+_MOCK_CONFIG: dict[str, Any] = {
+    "mock_server_host": "localhost",
+    # A closed local port: instantiation fails fast without leaving the host.
+    "mock_server_port": 9,
+}
+
+_RUN_COMPLETION_TIMEOUT_SECONDS = 60
+
+
+def _check_url(credential_id: int) -> str:
+    return f"{API_SERVER_URL}/manage/admin/credential/{credential_id}/capability-check"
+
+
+def _report_url(credential_id: int) -> str:
+    return f"{API_SERVER_URL}/manage/admin/credential/{credential_id}/capability-report"
+
+
+def _poll_until_completed(
+    credential_id: int, connector_id: int | None, headers: dict[str, str]
+) -> dict[str, Any]:
+    """Polls the report GET until the run completes; the FE will do the same."""
+    params = {} if connector_id is None else {"connector_id": connector_id}
+    deadline = time.monotonic() + _RUN_COMPLETION_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        response = client.get(
+            _report_url(credential_id), params=params, headers=headers
+        )
+        response.raise_for_status()
+        snapshot = response.json()
+        if (
+            snapshot is not None
+            and snapshot["run_status"] == CapabilityReportRunStatus.COMPLETED.value
+        ):
+            return snapshot
+        time.sleep(0.5)
+    raise AssertionError(
+        f"Capability check run for credential {credential_id} did not complete "
+        f"within {_RUN_COMPLETION_TIMEOUT_SECONDS}s."
+    )
+
+
+def test_credential_scoped_run_completes_and_persists_a_report(
+    admin_user: DATestUser,
+) -> None:
+    # Precondition.
+    credential = CredentialManager.create(
+        source=DocumentSource.MOCK_CONNECTOR, user_performing_action=admin_user
+    )
+
+    # Under test.
+    response = client.post(
+        _check_url(credential.id), json={}, headers=admin_user.headers
+    )
+
+    # Postcondition.
+    response.raise_for_status()
+    accepted = response.json()
+    assert accepted["run_status"] == CapabilityReportRunStatus.RUNNING.value
+    assert accepted["trigger"] == CapabilityCheckTrigger.MANUAL.value
+    assert accepted["run_started_at"] is not None
+    assert accepted["report"] is None
+    completed = _poll_until_completed(credential.id, None, admin_user.headers)
+    assert completed["connector_config_hash"] is None
+    report = completed["report"]
+    assert report["connector_id"] is None
+    assert report["trigger"] == CapabilityCheckTrigger.MANUAL.value
+    assert report["check_results"]
+    # Config-less: the mock connector cannot be constructed, so every
+    # instance-requiring check skips rather than probing anything.
+    assert all(
+        result["status"] == CapabilityCheckStatus.SKIPPED.value
+        for result in report["check_results"]
+    )
+    indexing_verdict = report["verdicts"][CredentialCapability.INDEXING.value]
+    assert indexing_verdict == CapabilityVerdict.SKIPPED.value
+
+
+def test_connector_scoped_run_carries_the_config_hash(admin_user: DATestUser) -> None:
+    # Precondition.
+    credential = CredentialManager.create(
+        source=DocumentSource.MOCK_CONNECTOR, user_performing_action=admin_user
+    )
+    connector = ConnectorManager.create(
+        source=DocumentSource.MOCK_CONNECTOR,
+        # The mock connector is checkpoint-based and rejects the manager's
+        # LOAD_STATE default at instantiation.
+        input_type=InputType.POLL,
+        connector_specific_config=_MOCK_CONFIG,
+        user_performing_action=admin_user,
+    )
+
+    # Under test.
+    response = client.post(
+        _check_url(credential.id),
+        json={"connector_id": connector.id},
+        headers=admin_user.headers,
+    )
+
+    # Postcondition.
+    response.raise_for_status()
+    assert response.json()["connector_id"] == connector.id
+    completed = _poll_until_completed(credential.id, connector.id, admin_user.headers)
+    assert completed["connector_id"] == connector.id
+    assert completed["connector_config_hash"] is not None
+    assert completed["report"]["connector_id"] == connector.id
+
+
+def test_second_trigger_while_a_run_is_active_is_a_noop(
+    admin_user: DATestUser,
+) -> None:
+    # Precondition. Seed an active RUNNING mark directly: a real run on the
+    # mock source completes too fast to race against.
+    credential = CredentialManager.create(
+        source=DocumentSource.MOCK_CONNECTOR, user_performing_action=admin_user
+    )
+    with get_session_with_current_tenant() as db_session:
+        row = mark_capability_report_running(
+            db_session,
+            credential_id=credential.id,
+            connector_id=None,
+            source=DocumentSource.MOCK_CONNECTOR,
+            trigger=CapabilityCheckTrigger.MANUAL,
+            active_within=timedelta(hours=1),
+        )
+        assert row is not None
+        started_at = row.run_started_at
+        db_session.commit()
+    assert started_at is not None
+
+    # Under test.
+    response = client.post(
+        _check_url(credential.id), json={}, headers=admin_user.headers
+    )
+
+    # Postcondition.
+    response.raise_for_status()
+    snapshot = response.json()
+    assert snapshot["run_status"] == CapabilityReportRunStatus.RUNNING.value
+    assert datetime.fromisoformat(snapshot["run_started_at"]) == started_at
+
+
+def test_stale_running_mark_is_replaced_and_the_run_proceeds(
+    admin_user: DATestUser,
+) -> None:
+    # Precondition. An hours-old RUNNING mark: a crashed or expired run.
+    credential = CredentialManager.create(
+        source=DocumentSource.MOCK_CONNECTOR, user_performing_action=admin_user
+    )
+    stale_started_at = datetime.now(timezone.utc) - timedelta(hours=2)
+    with get_session_with_current_tenant() as db_session:
+        row = mark_capability_report_running(
+            db_session,
+            credential_id=credential.id,
+            connector_id=None,
+            source=DocumentSource.MOCK_CONNECTOR,
+            trigger=CapabilityCheckTrigger.MANUAL,
+            active_within=timedelta(hours=1),
+        )
+        assert row is not None
+        db_session.execute(
+            update(CredentialCapabilityReportRow)
+            .where(CredentialCapabilityReportRow.id == row.id)
+            .values(run_started_at=stale_started_at)
+        )
+        db_session.commit()
+
+    # Under test.
+    response = client.post(
+        _check_url(credential.id), json={}, headers=admin_user.headers
+    )
+
+    # Postcondition.
+    response.raise_for_status()
+    snapshot = response.json()
+    assert datetime.fromisoformat(snapshot["run_started_at"]) > stale_started_at
+    _poll_until_completed(credential.id, None, admin_user.headers)
+
+
+def test_config_without_connector_id_is_invalid_input(admin_user: DATestUser) -> None:
+    # Precondition.
+    credential = CredentialManager.create(
+        source=DocumentSource.MOCK_CONNECTOR, user_performing_action=admin_user
+    )
+
+    # Under test.
+    response = client.post(
+        _check_url(credential.id),
+        json={"connector_specific_config": {"mock_server_host": "localhost"}},
+        headers=admin_user.headers,
+    )
+
+    # Postcondition.
+    assert response.status_code == 400
+    assert response.json()["error_code"] == "INVALID_INPUT"
+
+
+def test_connector_source_mismatch_is_invalid_input(admin_user: DATestUser) -> None:
+    # Precondition.
+    credential = CredentialManager.create(
+        source=DocumentSource.MOCK_CONNECTOR, user_performing_action=admin_user
+    )
+    file_connector = ConnectorManager.create(
+        source=DocumentSource.FILE, user_performing_action=admin_user
+    )
+
+    # Under test.
+    response = client.post(
+        _check_url(credential.id),
+        json={"connector_id": file_connector.id},
+        headers=admin_user.headers,
+    )
+
+    # Postcondition.
+    assert response.status_code == 400
+    assert response.json()["error_code"] == "INVALID_INPUT"
+
+
+def test_unknown_credential_maps_to_credential_not_found(
+    admin_user: DATestUser,
+) -> None:
+    # Under test.
+    response = client.post(_check_url(999_999_999), json={}, headers=admin_user.headers)
+
+    # Postcondition.
+    assert response.status_code == 404
+    assert response.json()["error_code"] == "CREDENTIAL_NOT_FOUND"
+
+
+def test_trigger_requires_connector_management_permission(
+    basic_user: DATestUser,
+) -> None:
+    # Under test and postcondition.
+    response = client.post(_check_url(1), json={}, headers=basic_user.headers)
+    assert response.status_code == 403
+    assert response.json()["error_code"] == "INSUFFICIENT_PERMISSIONS"

--- a/backend/tests/integration/tests/capability_checks/test_capability_check_run.py
+++ b/backend/tests/integration/tests/capability_checks/test_capability_check_run.py
@@ -257,6 +257,26 @@ def test_unknown_credential_maps_to_credential_not_found(
     assert response.json()["error_code"] == "CREDENTIAL_NOT_FOUND"
 
 
+def test_unknown_connector_maps_to_connector_not_found(
+    admin_user: DATestUser,
+) -> None:
+    # Precondition.
+    credential = CredentialManager.create(
+        source=DocumentSource.MOCK_CONNECTOR, user_performing_action=admin_user
+    )
+
+    # Under test.
+    response = client.post(
+        _check_url(credential.id),
+        json={"connector_id": 999_999_999},
+        headers=admin_user.headers,
+    )
+
+    # Postcondition.
+    assert response.status_code == 404
+    assert response.json()["error_code"] == "CONNECTOR_NOT_FOUND"
+
+
 def test_trigger_requires_connector_management_permission(
     basic_user: DATestUser,
 ) -> None:

--- a/backend/tests/integration/tests/capability_checks/test_capability_check_run.py
+++ b/backend/tests/integration/tests/capability_checks/test_capability_check_run.py
@@ -139,8 +139,9 @@ def test_connector_scoped_run_carries_the_config_hash(admin_user: DATestUser) ->
 def test_second_trigger_while_a_run_is_active_is_a_noop(
     admin_user: DATestUser,
 ) -> None:
-    # Precondition. Seed an active RUNNING mark directly: a real run on the
-    # mock source completes too fast to race against.
+    # Precondition.
+    # Seed an active RUNNING mark directly: a real run on the mock source
+    # completes too fast to race against.
     credential = CredentialManager.create(
         source=DocumentSource.MOCK_CONNECTOR, user_performing_action=admin_user
     )
@@ -173,7 +174,8 @@ def test_second_trigger_while_a_run_is_active_is_a_noop(
 def test_stale_running_mark_is_replaced_and_the_run_proceeds(
     admin_user: DATestUser,
 ) -> None:
-    # Precondition. An hours-old RUNNING mark: a crashed or expired run.
+    # Precondition.
+    # An hours-old RUNNING mark: a crashed or expired run.
     credential = CredentialManager.create(
         source=DocumentSource.MOCK_CONNECTOR, user_performing_action=admin_user
     )

--- a/backend/tests/integration/tests/capability_checks/test_capability_report_scoped_visibility.py
+++ b/backend/tests/integration/tests/capability_checks/test_capability_report_scoped_visibility.py
@@ -405,3 +405,80 @@ def test_scoped_manager_cannot_trigger_foreign_pairings(
     accepted = response.json()
     assert accepted["run_status"] == CapabilityReportRunStatus.RUNNING.value
     assert accepted["connector_id"] == in_group_connector.id
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Scoped group managers are enterprise only",
+)
+def test_managed_pairing_is_triggerable_without_credential_visibility(
+    admin_user: DATestUser,
+) -> None:
+    # Precondition. An admin-created credential paired into the manager's
+    # managed group: the trigger-side mirror of the read test above. The
+    # credential filter is creator-only for scoped managers, so only pairing
+    # visibility can admit the run.
+    suffix = uuid4().hex[:8]
+    manager = UserManager.create(name=f"trigger_manager_{suffix}")
+    managed_group = UserGroupManager.create(
+        name=f"trigger_managed_{suffix}",
+        user_ids=[manager.id],
+        cc_pair_ids=[],
+        user_performing_action=admin_user,
+    )
+    UserGroupManager.wait_for_sync(
+        user_groups_to_check=[managed_group],
+        user_performing_action=admin_user,
+    )
+    set_manager_response = UserGroupManager.set_manager(
+        user_group=managed_group,
+        user=manager,
+        is_manager=True,
+        user_performing_action=admin_user,
+    )
+    assert set_manager_response.status_code == 200
+    # Group edits mark the group as syncing; cc-pair creation refuses to
+    # relate a group mid-sync, so wait again before pairing.
+    UserGroupManager.wait_for_sync(
+        user_groups_to_check=[managed_group],
+        user_performing_action=admin_user,
+    )
+    credential = CredentialManager.create(
+        source=DocumentSource.MOCK_CONNECTOR,
+        admin_public=True,
+        curator_public=False,
+        groups=[],
+        user_performing_action=admin_user,
+    )
+    connector = ConnectorManager.create(
+        source=DocumentSource.MOCK_CONNECTOR,
+        input_type=InputType.POLL,
+        connector_specific_config=_MOCK_CONFIG,
+        user_performing_action=admin_user,
+    )
+    CCPairManager.create(
+        connector_id=connector.id,
+        credential_id=credential.id,
+        access_type=AccessType.PRIVATE,
+        groups=[managed_group.id],
+        user_performing_action=admin_user,
+    )
+
+    # Under test and postcondition. Pairing visibility alone authorizes the
+    # connector-scoped trigger; the credential-scoped trigger stays gated on
+    # credential visibility and reads as inaccessible.
+    response = client.post(
+        _check_url(credential.id),
+        json={"connector_id": connector.id},
+        headers=manager.headers,
+    )
+    response.raise_for_status()
+    accepted = response.json()
+    assert accepted["run_status"] == CapabilityReportRunStatus.RUNNING.value
+    assert accepted["connector_id"] == connector.id
+    credential_scope_response = client.post(
+        _check_url(credential.id), json={}, headers=manager.headers
+    )
+    assert credential_scope_response.status_code == 404
+    error_code = credential_scope_response.json()["error_code"]
+    assert error_code == "CREDENTIAL_NOT_FOUND"

--- a/backend/tests/integration/tests/capability_checks/test_capability_report_scoped_visibility.py
+++ b/backend/tests/integration/tests/capability_checks/test_capability_report_scoped_visibility.py
@@ -22,7 +22,12 @@ from onyx.connectors.capability_checks.recorder import (
     record_blocking_validation_outcome,
 )
 from onyx.connectors.models import InputType
-from onyx.db.enums import AccessType, CapabilityCheckTrigger, Permission
+from onyx.db.enums import (
+    AccessType,
+    CapabilityCheckTrigger,
+    CapabilityReportRunStatus,
+    Permission,
+)
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
@@ -33,6 +38,12 @@ from tests.integration.common_utils.managers.user_group import UserGroupManager
 from tests.integration.common_utils.test_models import DATestUser, DATestUserGroup
 
 _CONNECTOR_CONFIG: dict[str, Any] = {"channels": ["general"]}
+
+_MOCK_CONFIG: dict[str, Any] = {
+    "mock_server_host": "localhost",
+    # A closed local port: instantiation fails fast without leaving the host.
+    "mock_server_port": 9,
+}
 
 _REPORTS_FOR_SOURCE_URL = f"{API_SERVER_URL}/manage/admin/credential/capability-reports"
 
@@ -95,6 +106,10 @@ def _get_report(
     )
     response.raise_for_status()
     return response.json()
+
+
+def _check_url(credential_id: int) -> str:
+    return f"{API_SERVER_URL}/manage/admin/credential/{credential_id}/capability-check"
 
 
 @pytest.mark.skipif(
@@ -286,3 +301,107 @@ def test_managed_pairing_is_readable_without_credential_visibility(
     listing_response.raise_for_status()
     listed_connector_ids = {row["connector_id"] for row in listing_response.json()}
     assert connector.id in listed_connector_ids
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Scoped group managers are enterprise only",
+)
+def test_scoped_manager_cannot_trigger_foreign_pairings(
+    admin_user: DATestUser,
+) -> None:
+    # Precondition. Mirrors the read test on the trigger side, on the mock
+    # source so the one legitimately enqueued run needs no external service.
+    suffix = uuid4().hex[:8]
+    manager = UserManager.create(name=f"trigger_manager_{suffix}")
+    managed_group = UserGroupManager.create(
+        name=f"trigger_managed_{suffix}",
+        user_ids=[manager.id],
+        cc_pair_ids=[],
+        user_performing_action=admin_user,
+    )
+    foreign_group = UserGroupManager.create(
+        name=f"trigger_foreign_{suffix}",
+        user_ids=[],
+        cc_pair_ids=[],
+        user_performing_action=admin_user,
+    )
+    UserGroupManager.wait_for_sync(
+        user_groups_to_check=[managed_group, foreign_group],
+        user_performing_action=admin_user,
+    )
+    set_manager_response = UserGroupManager.set_manager(
+        user_group=managed_group,
+        user=manager,
+        is_manager=True,
+        user_performing_action=admin_user,
+    )
+    assert set_manager_response.status_code == 200
+    # Group edits mark the group as syncing; cc-pair creation refuses to
+    # relate a group mid-sync, so wait again before pairing.
+    UserGroupManager.wait_for_sync(
+        user_groups_to_check=[managed_group, foreign_group],
+        user_performing_action=admin_user,
+    )
+    credential = CredentialManager.create(
+        source=DocumentSource.MOCK_CONNECTOR,
+        admin_public=True,
+        curator_public=False,
+        groups=[],
+        user_performing_action=manager,
+    )
+    in_group_connector = ConnectorManager.create(
+        source=DocumentSource.MOCK_CONNECTOR,
+        input_type=InputType.POLL,
+        connector_specific_config=_MOCK_CONFIG,
+        user_performing_action=admin_user,
+    )
+    foreign_connector = ConnectorManager.create(
+        source=DocumentSource.MOCK_CONNECTOR,
+        input_type=InputType.POLL,
+        connector_specific_config=_MOCK_CONFIG,
+        user_performing_action=admin_user,
+    )
+    orphan_connector = ConnectorManager.create(
+        source=DocumentSource.MOCK_CONNECTOR,
+        input_type=InputType.POLL,
+        connector_specific_config=_MOCK_CONFIG,
+        user_performing_action=admin_user,
+    )
+    CCPairManager.create(
+        connector_id=in_group_connector.id,
+        credential_id=credential.id,
+        access_type=AccessType.PRIVATE,
+        groups=[managed_group.id],
+        user_performing_action=admin_user,
+    )
+    CCPairManager.create(
+        connector_id=foreign_connector.id,
+        credential_id=credential.id,
+        access_type=AccessType.PRIVATE,
+        groups=[foreign_group.id],
+        user_performing_action=admin_user,
+    )
+
+    # Under test and postcondition. Hidden pairings reject with the same shape
+    # as a nonexistent connector, and nothing gets marked RUNNING.
+    for connector_id in (foreign_connector.id, orphan_connector.id):
+        response = client.post(
+            _check_url(credential.id),
+            json={"connector_id": connector_id},
+            headers=manager.headers,
+        )
+        assert response.status_code == 404
+        assert response.json()["error_code"] == "CONNECTOR_NOT_FOUND"
+        assert _get_report(credential.id, connector_id, admin_user) is None
+
+    # The manager's own group's pairing triggers normally.
+    response = client.post(
+        _check_url(credential.id),
+        json={"connector_id": in_group_connector.id},
+        headers=manager.headers,
+    )
+    response.raise_for_status()
+    accepted = response.json()
+    assert accepted["run_status"] == CapabilityReportRunStatus.RUNNING.value
+    assert accepted["connector_id"] == in_group_connector.id

--- a/backend/tests/integration/tests/capability_checks/test_capability_report_scoped_visibility.py
+++ b/backend/tests/integration/tests/capability_checks/test_capability_report_scoped_visibility.py
@@ -313,34 +313,15 @@ def test_scoped_manager_cannot_trigger_foreign_pairings(
     # Precondition. Mirrors the read test on the trigger side, on the mock
     # source so the one legitimately enqueued run needs no external service.
     suffix = uuid4().hex[:8]
-    manager = UserManager.create(name=f"trigger_manager_{suffix}")
-    managed_group = UserGroupManager.create(
-        name=f"trigger_managed_{suffix}",
-        user_ids=[manager.id],
-        cc_pair_ids=[],
-        user_performing_action=admin_user,
-    )
+    manager, managed_group = _bootstrap_scoped_manager(admin_user, suffix)
     foreign_group = UserGroupManager.create(
-        name=f"trigger_foreign_{suffix}",
+        name=f"foreign_group_{suffix}",
         user_ids=[],
         cc_pair_ids=[],
         user_performing_action=admin_user,
     )
     UserGroupManager.wait_for_sync(
-        user_groups_to_check=[managed_group, foreign_group],
-        user_performing_action=admin_user,
-    )
-    set_manager_response = UserGroupManager.set_manager(
-        user_group=managed_group,
-        user=manager,
-        is_manager=True,
-        user_performing_action=admin_user,
-    )
-    assert set_manager_response.status_code == 200
-    # Group edits mark the group as syncing; cc-pair creation refuses to
-    # relate a group mid-sync, so wait again before pairing.
-    UserGroupManager.wait_for_sync(
-        user_groups_to_check=[managed_group, foreign_group],
+        user_groups_to_check=[foreign_group],
         user_performing_action=admin_user,
     )
     credential = CredentialManager.create(
@@ -419,30 +400,7 @@ def test_managed_pairing_is_triggerable_without_credential_visibility(
     # credential filter is creator-only for scoped managers, so only pairing
     # visibility can admit the run.
     suffix = uuid4().hex[:8]
-    manager = UserManager.create(name=f"trigger_manager_{suffix}")
-    managed_group = UserGroupManager.create(
-        name=f"trigger_managed_{suffix}",
-        user_ids=[manager.id],
-        cc_pair_ids=[],
-        user_performing_action=admin_user,
-    )
-    UserGroupManager.wait_for_sync(
-        user_groups_to_check=[managed_group],
-        user_performing_action=admin_user,
-    )
-    set_manager_response = UserGroupManager.set_manager(
-        user_group=managed_group,
-        user=manager,
-        is_manager=True,
-        user_performing_action=admin_user,
-    )
-    assert set_manager_response.status_code == 200
-    # Group edits mark the group as syncing; cc-pair creation refuses to
-    # relate a group mid-sync, so wait again before pairing.
-    UserGroupManager.wait_for_sync(
-        user_groups_to_check=[managed_group],
-        user_performing_action=admin_user,
-    )
+    manager, managed_group = _bootstrap_scoped_manager(admin_user, suffix)
     credential = CredentialManager.create(
         source=DocumentSource.MOCK_CONNECTOR,
         admin_public=True,

--- a/backend/tests/integration/tests/capability_checks/test_capability_report_scoped_visibility.py
+++ b/backend/tests/integration/tests/capability_checks/test_capability_report_scoped_visibility.py
@@ -310,8 +310,9 @@ def test_managed_pairing_is_readable_without_credential_visibility(
 def test_scoped_manager_cannot_trigger_foreign_pairings(
     admin_user: DATestUser,
 ) -> None:
-    # Precondition. Mirrors the read test on the trigger side, on the mock
-    # source so the one legitimately enqueued run needs no external service.
+    # Precondition.
+    # Mirrors the read test on the trigger side, on the mock source so the one
+    # legitimately enqueued run needs no external service.
     suffix = uuid4().hex[:8]
     manager, managed_group = _bootstrap_scoped_manager(admin_user, suffix)
     foreign_group = UserGroupManager.create(
@@ -364,8 +365,9 @@ def test_scoped_manager_cannot_trigger_foreign_pairings(
         user_performing_action=admin_user,
     )
 
-    # Under test and postcondition. Hidden pairings reject with the same shape
-    # as a nonexistent connector, and nothing gets marked RUNNING.
+    # Under test and postcondition.
+    # Hidden pairings reject with the same shape as a nonexistent connector, and
+    # nothing gets marked RUNNING.
     for connector_id in (foreign_connector.id, orphan_connector.id):
         response = client.post(
             _check_url(credential.id),
@@ -395,10 +397,11 @@ def test_scoped_manager_cannot_trigger_foreign_pairings(
 def test_managed_pairing_is_triggerable_without_credential_visibility(
     admin_user: DATestUser,
 ) -> None:
-    # Precondition. An admin-created credential paired into the manager's
-    # managed group: the trigger-side mirror of the read test above. The
-    # credential filter is creator-only for scoped managers, so only pairing
-    # visibility can admit the run.
+    # Precondition.
+    # An admin-created credential paired into the manager's managed group: the
+    # trigger-side mirror of the read test above. The credential filter is
+    # creator-only for scoped managers, so only pairing visibility can admit the
+    # run.
     suffix = uuid4().hex[:8]
     manager, managed_group = _bootstrap_scoped_manager(admin_user, suffix)
     credential = CredentialManager.create(
@@ -422,9 +425,10 @@ def test_managed_pairing_is_triggerable_without_credential_visibility(
         user_performing_action=admin_user,
     )
 
-    # Under test and postcondition. Pairing visibility alone authorizes the
-    # connector-scoped trigger; the credential-scoped trigger stays gated on
-    # credential visibility and reads as inaccessible.
+    # Under test and postcondition.
+    # Pairing visibility alone authorizes the connector-scoped trigger; the
+    # credential-scoped trigger stays gated on credential visibility and reads
+    # as inaccessible.
     response = client.post(
         _check_url(credential.id),
         json={"connector_id": connector.id},

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
@@ -73,7 +73,7 @@ spec:
               {{- end }}
               "--hostname=heavy@%n",
               "-Q",
-              "connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation,sandbox,connector_hierarchy_fetching",
+              "connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation,sandbox,connector_hierarchy_fetching,capability_checks",
             ]
           ports:
             - name: metrics


### PR DESCRIPTION
## Description

Adds the first way to run granular capability checks: POST + the Celery task together (a POST stub with no task would violate the no-shims rule). Second of three PRs, on top of the read-only endpoints PR #14028; the third #14054 replaces the crude staleness constant with real stuck-run recovery. Check failures are report content, never HTTP errors: nothing here gates connector creation or indexing.

- POST /manage/admin/credential/{credential_id}/capability-check, body {connector_id?, connector_specific_config?}: marks the scope RUNNING, enqueues the run, returns the row immediately. Callers poll the existing GET; the previous report stays readable during the run.
- Re-trigger guard is atomic: the staleness bound is a new required active_within param on mark_capability_report_running (which had zero callers), compiled into ON CONFLICT DO UPDATE ... WHERE like the recorder's no-clobber guard, so concurrent POSTs cannot double-mark. A RUNNING mark older than the bound is a crashed or expired run and gets replaced, so nothing can permanently brick re-triggering.
- CAPABILITY_CHECK_RUN_STALENESS_SECONDS = 6 x the 600s per-check guard; the Celery expires= is the same value, so a queued task and its RUNNING mark go stale together.
- The task loads connector config server-side when the body omits it, runs generate_capability_report, and writes through the UNCONDITIONAL upsert (granular runs replace whatever is stored; the recorder's guarded variant is unchanged). Task owns its transaction. A failed enqueue retires the fresh mark to FAILED_TO_RUN (mark_capability_run_failed, guarded on RUNNING so a racing completion is never clobbered) and returns 503 with the cause logged: no task exists, so the mark must not read RUNNING, and the scope stays immediately re-triggerable. A task crash still leaves the row RUNNING; the recovery PR's sweep retires those.
- New capability_checks queue on the heavy worker (probes may hang up to the per-check guard, so they cannot share the light worker), registered in supervisord, helm, the dev script, the integration conftest, and both queue-monitoring lists.
- Connector-scoped triggers are authorized by pairing visibility alone, mirroring the read endpoints: a pairing manager triggers runs for pairings in their managed groups even when the credential is outside their credential visibility, and missing and inaccessible connectors share one 404 shape so neither existence nor membership leaks.
- Validations: missing credential -> 404 CREDENTIAL_NOT_FOUND, missing connector -> CONNECTOR_NOT_FOUND, connector-source mismatch -> INVALID_INPUT, config without connector_id -> INVALID_INPUT (credential-scoped runs are config-less by definition; keeps the hash-pairing invariant), concurrent credential/connector deletion between the guard and the no-op read -> 404, not a 500.
- compute_connector_config_hash moved from the recorder to capability_checks/models.py so both writer classes hash configs identically.

## How Has This Been Tested?

- Tests: accessor tests for the guard (active mark blocks, stale mark replaced); integration round-trips against MOCK_CONNECTOR, which completes deterministically with no external service (config-less runs cannot construct it; connector-scoped runs fail fast on a closed local port); EE scoped-manager coverage (foreign and orphan pairings 404 without marking anything, managed pairings trigger normally, and a managed pairing triggers without credential visibility).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a POST endpoint to trigger granular connector capability checks plus a Celery task that runs them asynchronously, so callers start a run, poll GET for completion, and read failures from the report instead of HTTP errors. Previously this API was read-only.

- Marks the requested scope RUNNING and enqueues `run_capability_checks` on the `capability_checks` queue with HIGH priority and an expires equal to the staleness bound; commits before enqueueing so workers only see RUNNING.
- The re-trigger guard allows only one active run per scope: an unexpired RUNNING mark returns the standing row without re-enqueueing, while stale or NULL-start marks are replaced.
- A failed enqueue retires the fresh mark to FAILED_TO_RUN, returns 503, and keeps the scope immediately re-triggerable.
- Requires MANAGE_CONNECTORS (scoped allowed); connector-scoped runs need pairing visibility, with hidden or unknown connectors returning CONNECTOR_NOT_FOUND, source mismatch or config without connector_id returning INVALID_INPUT, and unknown or inaccessible credentials returning CREDENTIAL_NOT_FOUND.
- The task loads connector config server-side when omitted, runs all checks, computes and stores `connector_config_hash` for connector-scoped runs, and upserts the completed report; deleted connectors or credentials are logged and skipped.
- `CAPABILITY_CHECK_RUN_STALENESS_SECONDS` equals 6x the per-check timeout and matches the task's expires, so a stale queue item never strands a RUNNING mark.
- Added the `capability_checks` queue to heavy worker startup, Helm, supervisord, and dev scripts, plus queue-length metrics and heavy app logging; centralized `compute_connector_config_hash`.

**Rollout**
- Ensure the heavy worker consumes the `capability_checks` queue before enabling the endpoint.

<sup>Written for commit 1618a1982dec1c730d9aed88b9dfd0cb9a1970d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


