### PR TITLE
feat(connector-stability): stuck capability run recovery

### DIFF
--- a/backend/alembic/versions/77962d18fd41_add_run_id_to_credential_capability_.py
+++ b/backend/alembic/versions/77962d18fd41_add_run_id_to_credential_capability_.py
@@ -1,0 +1,33 @@
+"""add run_id to credential_capability_report
+
+The id of the run attempt that owns the row's lifecycle mark. Terminal writes
+from the check-runner task are fenced on it, so a superseded attempt can never
+mislabel its successor's row. NULL means no attempt owns the row (recorder
+writes and pre-migration rows); the fenced writers never match NULL.
+
+Revision ID: 77962d18fd41
+Revises: 34fe28843029
+Create Date: 2026-08-31 17:30:10.799949
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "77962d18fd41"
+down_revision = "34fe28843029"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "credential_capability_report",
+        sa.Column("run_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("credential_capability_report", "run_id")

--- a/backend/onyx/background/celery/apps/primary.py
+++ b/backend/onyx/background/celery/apps/primary.py
@@ -362,6 +362,7 @@ celery_app.autodiscover_tasks(
             "onyx.background.celery.tasks.vespa",
             "onyx.background.celery.tasks.llm_model_update",
             "onyx.background.celery.tasks.user_file_processing",
+            "onyx.background.celery.tasks.capability_checks",
         ]
     )
 )

--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -114,6 +114,15 @@ beat_task_templates: list[dict] = [
         },
     },
     {
+        "name": "check-for-stale-capability-runs",
+        "task": OnyxCeleryTask.CHECK_FOR_STALE_CAPABILITY_RUNS,
+        "schedule": timedelta(minutes=10),
+        "options": {
+            "priority": OnyxCeleryPriority.LOW,
+            "expires": BEAT_EXPIRES_DEFAULT,
+        },
+    },
+    {
         "name": "check-for-index-attempt-cleanup",
         "task": OnyxCeleryTask.CHECK_FOR_INDEX_ATTEMPT_CLEANUP,
         "schedule": timedelta(minutes=30),

--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -120,6 +120,9 @@ beat_task_templates: list[dict] = [
         "options": {
             "priority": OnyxCeleryPriority.LOW,
             "expires": BEAT_EXPIRES_DEFAULT,
+            # Gated tenants may still hold dead RUNNING marks to retire.
+            "skip_gated": False,
+            "work_gated": True,
         },
     },
     {

--- a/backend/onyx/background/celery/tasks/capability_checks/tasks.py
+++ b/backend/onyx/background/celery/tasks/capability_checks/tasks.py
@@ -3,9 +3,9 @@
 The run task is enqueued by the capability-check trigger endpoint after it
 marks the scope's row RUNNING, and writes through the unconditional upsert: a
 granular run is the freshest truth and replaces whatever is stored (see the
-accessors' writer model). A crashed or expired run leaves its row RUNNING; the
-beat sweep retires such marks to FAILED_TO_RUN once they outlive their
-source's run ceiling.
+accessors' writer model). A run that fails gracefully records FAILED_TO_RUN
+itself; only hard kills and expired tasks leave their row RUNNING for the beat
+sweep to retire once the mark outlives its source's run ceiling.
 """
 
 from typing import Any
@@ -23,6 +23,7 @@ from onyx.connectors.models import InputType
 from onyx.db.connector import fetch_connector_by_id
 from onyx.db.credential_capability import (
     get_sources_with_running_capability_runs,
+    mark_capability_run_failed,
     mark_stale_capability_runs_failed,
     upsert_completed_capability_report,
 )
@@ -44,6 +45,10 @@ def run_capability_checks_task(
     tenant_id: str | None,
 ) -> None:
     """Runs every capability check for the scope and stores the report."""
+    # Setup reads use a short-lived session: the probes below can run for
+    # hours, and an open transaction would hold its connection and read locks
+    # for the whole run. ``credential`` stays readable after the close because
+    # its columns are already loaded.
     with get_session_with_current_tenant() as db_session:
         credential = fetch_credential_by_id(credential_id, db_session)
         if credential is None:
@@ -67,34 +72,46 @@ def run_capability_checks_task(
             input_type = connector.input_type
             if config is None:
                 config = connector.connector_specific_config
+    try:
         report = generate_capability_report(
-            db_session,
             credential,
             connector_specific_config=config,
             connector_id=connector_id,
             input_type=input_type,
             trigger=CapabilityCheckTrigger.MANUAL,
         )
-        upsert_completed_capability_report(
-            db_session,
-            credential_id=credential_id,
-            connector_id=connector_id,
-            source=credential.source,
-            trigger=CapabilityCheckTrigger.MANUAL,
-            report=report,
-            connector_config_hash=(
-                compute_connector_config_hash(config)
-                if connector_id is not None
-                else None
-            ),
-        )
-        # The accessors leave the transaction to the caller.
-        db_session.commit()
+        with get_session_with_current_tenant() as db_session:
+            upsert_completed_capability_report(
+                db_session,
+                credential_id=credential_id,
+                connector_id=connector_id,
+                source=credential.source,
+                trigger=CapabilityCheckTrigger.MANUAL,
+                report=report,
+                connector_config_hash=(
+                    compute_connector_config_hash(config)
+                    if connector_id is not None
+                    else None
+                ),
+            )
+            # The accessors leave the transaction to the caller.
+            db_session.commit()
+    except Exception:
+        # The worker is alive, so record the failure now: without this the
+        # scope would read RUNNING until the sweep's staleness window expires.
+        # Hard kills still rely on the sweep.
+        with get_session_with_current_tenant() as db_session:
+            mark_capability_run_failed(
+                db_session,
+                credential_id=credential_id,
+                connector_id=connector_id,
+            )
+            db_session.commit()
+        raise
 
 
 @shared_task(  # ty: ignore[invalid-argument-type]
     name=OnyxCeleryTask.CHECK_FOR_STALE_CAPABILITY_RUNS,
-    soft_time_limit=300,
     bind=True,
 )
 def check_for_stale_capability_runs(

--- a/backend/onyx/background/celery/tasks/capability_checks/tasks.py
+++ b/backend/onyx/background/celery/tasks/capability_checks/tasks.py
@@ -1,11 +1,11 @@
 """Celery tasks for the granular capability check runs.
 
-The run task is enqueued by the capability-check trigger endpoint after it
-marks the scope's row RUNNING, and writes through the unconditional upsert: a
-granular run is the freshest truth and replaces whatever is stored (see the
-accessors' writer model). A run that fails gracefully records FAILED_TO_RUN
-itself; only hard kills and expired tasks leave their row RUNNING for the beat
-sweep to retire once the mark outlives its source's run ceiling.
+The run task is enqueued by the capability-check trigger endpoint after it marks
+the scope's row RUNNING, and writes through the unconditional upsert: a granular
+run is the freshest truth and replaces whatever is stored (see the accessors'
+writer model). A run that fails gracefully records FAILED_TO_RUN itself; only
+hard kills and expired tasks leave their row RUNNING for the beat sweep to
+retire once the mark outlives its source's run ceiling.
 """
 
 from typing import Any
@@ -58,8 +58,8 @@ def run_capability_checks_task(
     try:
         # Setup reads use a short-lived session: the probes below can run for
         # hours, and an open transaction would hold its connection and read
-        # locks for the whole run. ``credential`` stays readable after the
-        # close because its columns are already loaded.
+        # locks for the whole run. ``credential`` stays readable after the close
+        # because its columns are already loaded.
         with get_session_with_current_tenant() as db_session:
             credential = fetch_credential_by_id(credential_id, db_session)
             if credential is None:
@@ -115,9 +115,9 @@ def run_capability_checks_task(
                 f"(run {run_id}, tenant {tenant_id})."
             )
     except Exception:
-        # The worker is alive, so record the failure now: without this the
-        # scope would read RUNNING until the sweep's staleness window expires.
-        # Hard kills still rely on the sweep.
+        # The worker is alive, so record the failure now: without this the scope
+        # would read RUNNING until the sweep's staleness window expires. Hard
+        # kills still rely on the sweep.
         with get_session_with_current_tenant() as db_session:
             mark_capability_run_failed(
                 db_session,
@@ -143,8 +143,8 @@ def check_for_stale_capability_runs(
     A sweep rather than lazy recovery at trigger time: a re-trigger immediately
     re-marks the scope RUNNING, so only a sweep can surface FAILED_TO_RUN to a
     polling client without user action. A run that is merely slow and completes
-    after being retired overwrites FAILED_TO_RUN with its report (the
-    completion write is unconditional), so mislabeling self-heals.
+    after being retired overwrites FAILED_TO_RUN with its report (the completion
+    write is unconditional), so mislabeling self-heals.
     """
     with get_session_with_current_tenant() as db_session:
         for source in get_sources_with_running_capability_runs(db_session):

--- a/backend/onyx/background/celery/tasks/capability_checks/tasks.py
+++ b/backend/onyx/background/celery/tasks/capability_checks/tasks.py
@@ -9,6 +9,7 @@ sweep to retire once the mark outlives its source's run ceiling.
 """
 
 from typing import Any
+from uuid import UUID
 
 from celery import Task, shared_task
 
@@ -43,8 +44,17 @@ def run_capability_checks_task(
     connector_id: int | None,
     connector_specific_config: dict[str, Any] | None,
     tenant_id: str | None,
+    # Serialized UUID; None only for tasks enqueued before the fence deployed,
+    # which write unfenced (the legacy semantics they were enqueued under).
+    run_id: str | None = None,
 ) -> None:
-    """Runs every capability check for the scope and stores the report."""
+    """Runs every capability check for the scope and stores the report.
+
+    Terminal writes are fenced on ``run_id``: if this attempt was retired and
+    the scope re-triggered, both the completion and the failure write no-op
+    instead of mislabeling the successor's row.
+    """
+    parsed_run_id = UUID(run_id) if run_id is not None else None
     # Setup reads use a short-lived session: the probes below can run for
     # hours, and an open transaction would hold its connection and read locks
     # for the whole run. ``credential`` stays readable after the close because
@@ -81,7 +91,7 @@ def run_capability_checks_task(
             trigger=CapabilityCheckTrigger.MANUAL,
         )
         with get_session_with_current_tenant() as db_session:
-            upsert_completed_capability_report(
+            completed_row = upsert_completed_capability_report(
                 db_session,
                 credential_id=credential_id,
                 connector_id=connector_id,
@@ -93,9 +103,16 @@ def run_capability_checks_task(
                     if connector_id is not None
                     else None
                 ),
+                run_id=parsed_run_id,
             )
             # The accessors leave the transaction to the caller.
             db_session.commit()
+        if completed_row is None:
+            task_logger.info(
+                f"Discarded a superseded capability run's completion for "
+                f"credential {credential_id}, connector {connector_id} "
+                f"(run {run_id}, tenant {tenant_id})."
+            )
     except Exception:
         # The worker is alive, so record the failure now: without this the
         # scope would read RUNNING until the sweep's staleness window expires.
@@ -105,6 +122,7 @@ def run_capability_checks_task(
                 db_session,
                 credential_id=credential_id,
                 connector_id=connector_id,
+                run_id=parsed_run_id,
             )
             db_session.commit()
         raise

--- a/backend/onyx/background/celery/tasks/capability_checks/tasks.py
+++ b/backend/onyx/background/celery/tasks/capability_checks/tasks.py
@@ -1,10 +1,11 @@
-"""Celery task running the granular capability checks for one scope.
+"""Celery tasks for the granular capability check runs.
 
-Enqueued by the capability-check trigger endpoint after it marks the scope's row
-RUNNING. Writes through the unconditional upsert: a granular run is the freshest
-truth and replaces whatever is stored (see the accessors' writer model). A
-task-level crash leaves the row RUNNING; the mark's staleness bound un-blocks
-re-triggering.
+The run task is enqueued by the capability-check trigger endpoint after it
+marks the scope's row RUNNING, and writes through the unconditional upsert: a
+granular run is the freshest truth and replaces whatever is stored (see the
+accessors' writer model). A crashed or expired run leaves its row RUNNING; the
+beat sweep retires such marks to FAILED_TO_RUN once they outlive their
+source's run ceiling.
 """
 
 from typing import Any
@@ -14,10 +15,17 @@ from celery import Task, shared_task
 from onyx.background.celery.apps.app_base import task_logger
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.connectors.capability_checks.models import compute_connector_config_hash
-from onyx.connectors.capability_checks.runner import generate_capability_report
+from onyx.connectors.capability_checks.runner import (
+    capability_check_run_stale_after,
+    generate_capability_report,
+)
 from onyx.connectors.models import InputType
 from onyx.db.connector import fetch_connector_by_id
-from onyx.db.credential_capability import upsert_completed_capability_report
+from onyx.db.credential_capability import (
+    get_sources_with_running_capability_runs,
+    mark_stale_capability_runs_failed,
+    upsert_completed_capability_report,
+)
 from onyx.db.credentials import fetch_credential_by_id
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import CapabilityCheckTrigger
@@ -80,5 +88,39 @@ def run_capability_checks_task(
                 else None
             ),
         )
+        # The accessors leave the transaction to the caller.
+        db_session.commit()
+
+
+@shared_task(  # ty: ignore[invalid-argument-type]
+    name=OnyxCeleryTask.CHECK_FOR_STALE_CAPABILITY_RUNS,
+    soft_time_limit=300,
+    bind=True,
+)
+def check_for_stale_capability_runs(
+    self: Task,  # noqa: ARG001
+    *,
+    tenant_id: str,
+) -> None:
+    """Retires RUNNING marks that outlived their source's run ceiling.
+
+    A sweep rather than lazy recovery at trigger time: a re-trigger immediately
+    re-marks the scope RUNNING, so only a sweep can surface FAILED_TO_RUN to a
+    polling client without user action. A run that is merely slow and completes
+    after being retired overwrites FAILED_TO_RUN with its report (the
+    completion write is unconditional), so mislabeling self-heals.
+    """
+    with get_session_with_current_tenant() as db_session:
+        for source in get_sources_with_running_capability_runs(db_session):
+            retired = mark_stale_capability_runs_failed(
+                db_session,
+                source=source,
+                stale_after=capability_check_run_stale_after(source),
+            )
+            if retired:
+                task_logger.info(
+                    f"Retired {retired} stale capability run(s) for source "
+                    f"{source.value} to FAILED_TO_RUN (tenant {tenant_id})."
+                )
         # The accessors leave the transaction to the caller.
         db_session.commit()

--- a/backend/onyx/background/celery/tasks/capability_checks/tasks.py
+++ b/backend/onyx/background/celery/tasks/capability_checks/tasks.py
@@ -55,34 +55,35 @@ def run_capability_checks_task(
     instead of mislabeling the successor's row.
     """
     parsed_run_id = UUID(run_id) if run_id is not None else None
-    # Setup reads use a short-lived session: the probes below can run for
-    # hours, and an open transaction would hold its connection and read locks
-    # for the whole run. ``credential`` stays readable after the close because
-    # its columns are already loaded.
-    with get_session_with_current_tenant() as db_session:
-        credential = fetch_credential_by_id(credential_id, db_session)
-        if credential is None:
-            # Deleted since the trigger; its report rows cascaded with it.
-            task_logger.info(
-                f"Skipping capability checks for deleted credential "
-                f"{credential_id} (tenant {tenant_id})."
-            )
-            return
-        input_type: InputType | None = None
-        config = connector_specific_config
-        if connector_id is not None:
-            connector = fetch_connector_by_id(connector_id, db_session)
-            if connector is None:
-                # Deleted since the trigger; its report row cascaded with it.
+    try:
+        # Setup reads use a short-lived session: the probes below can run for
+        # hours, and an open transaction would hold its connection and read
+        # locks for the whole run. ``credential`` stays readable after the
+        # close because its columns are already loaded.
+        with get_session_with_current_tenant() as db_session:
+            credential = fetch_credential_by_id(credential_id, db_session)
+            if credential is None:
+                # Deleted since the trigger; its report rows cascaded with it.
                 task_logger.info(
-                    f"Skipping capability checks for deleted connector "
-                    f"{connector_id} (tenant {tenant_id})."
+                    f"Skipping capability checks for deleted credential "
+                    f"{credential_id} (tenant {tenant_id})."
                 )
                 return
-            input_type = connector.input_type
-            if config is None:
-                config = connector.connector_specific_config
-    try:
+            input_type: InputType | None = None
+            config = connector_specific_config
+            if connector_id is not None:
+                connector = fetch_connector_by_id(connector_id, db_session)
+                if connector is None:
+                    # Deleted since the trigger; its report row cascaded with
+                    # it.
+                    task_logger.info(
+                        f"Skipping capability checks for deleted connector "
+                        f"{connector_id} (tenant {tenant_id})."
+                    )
+                    return
+                input_type = connector.input_type
+                if config is None:
+                    config = connector.connector_specific_config
         report = generate_capability_report(
             credential,
             connector_specific_config=config,

--- a/backend/onyx/background/celery/tasks/capability_checks/tasks.py
+++ b/backend/onyx/background/celery/tasks/capability_checks/tasks.py
@@ -45,7 +45,7 @@ def run_capability_checks_task(
     connector_specific_config: dict[str, Any] | None,
     tenant_id: str | None,
     # Serialized UUID; None only for tasks enqueued before the fence deployed,
-    # which write unfenced (the legacy semantics they were enqueued under).
+    # whose terminal writes then match only their own pre-migration NULL marks.
     run_id: str | None = None,
 ) -> None:
     """Runs every capability check for the scope and stores the report.

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -683,6 +683,7 @@ class OnyxCeleryTask:
 
     # Credential capability checks (granular runs of the registered checks)
     RUN_CAPABILITY_CHECKS = "run_capability_checks"
+    CHECK_FOR_STALE_CAPABILITY_RUNS = "check_for_stale_capability_runs"
 
     # chat retention
     CHECK_TTL_MANAGEMENT_TASK = "check_ttl_management_task"

--- a/backend/onyx/connectors/capability_checks/runner.py
+++ b/backend/onyx/connectors/capability_checks/runner.py
@@ -1,11 +1,12 @@
 import time
 from collections.abc import Sequence
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from onyx.configs.constants import DocumentSource
 from onyx.connectors.capability_checks.models import (
     CapabilityCheck,
     CapabilityCheckContext,
@@ -45,12 +46,6 @@ logger = setup_logger()
 # forever. Known-slow probes override it via
 # ``CapabilityCheck.timeout_seconds``.
 CAPABILITY_CHECK_TIMEOUT_SECONDS = 600
-
-# Crude ceiling on one run's legitimate wall time: checks run sequentially and
-# no source registers more than a handful, so a RUNNING mark older than this is
-# a crashed or expired run and stops blocking re-triggers. Stuck-run recovery
-# will replace it with a per-scope ceiling derived from the actual checks.
-CAPABILITY_CHECK_RUN_STALENESS_SECONDS = 6 * CAPABILITY_CHECK_TIMEOUT_SECONDS
 
 _SKIP_NEEDS_INSTANCE_MESSAGE = (
     "Requires a connector instance -- will re-run automatically when the "
@@ -186,6 +181,32 @@ def _execute_check(
             duration_ms=elapsed_ms(),
         )
     return _CheckOutcome(status=CapabilityCheckStatus.PASSED, duration_ms=elapsed_ms())
+
+
+def capability_check_run_ceiling_seconds(source: DocumentSource) -> int:
+    """Upper bound on one run's legitimate execution time, in seconds.
+
+    Checks run sequentially and mirrored checks (one check surfaced under
+    several capabilities) execute once, so the bound sums the distinct
+    per-check hang guards. One extra default guard covers the work outside any
+    check's guard: connector instantiation can itself probe the source.
+    """
+    timeout_by_check_id = {
+        check.check_id: check.timeout_seconds or CAPABILITY_CHECK_TIMEOUT_SECONDS
+        for check in get_capability_checks(source)
+    }
+    return int(CAPABILITY_CHECK_TIMEOUT_SECONDS + sum(timeout_by_check_id.values()))
+
+
+def capability_check_run_stale_after(source: DocumentSource) -> timedelta:
+    """Age past which a RUNNING mark is a dead run, not a slow one.
+
+    The mark is set at trigger time, so a legitimate run's wall clock is queue
+    wait plus execution; the task expiry bounds the wait at one execution
+    ceiling, leaving two ceilings in total. Both the re-trigger guard and the
+    stale-run sweep use this cutoff.
+    """
+    return timedelta(seconds=2 * capability_check_run_ceiling_seconds(source))
 
 
 def run_capability_checks(

--- a/backend/onyx/connectors/capability_checks/runner.py
+++ b/backend/onyx/connectors/capability_checks/runner.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from pydantic import BaseModel
-from sqlalchemy.orm import Session
 
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.capability_checks.models import (
@@ -32,6 +31,8 @@ from onyx.connectors.source_operations import (
     SourceOperations,
     get_source_operations_class,
 )
+from onyx.db.credentials import fetch_credential_by_id
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import CapabilityCheckTrigger
 from onyx.db.models import Credential
 from onyx.utils.credential_audit import emit_credential_access
@@ -267,8 +268,46 @@ def run_capability_checks(
     return results
 
 
+def _instantiate_connector_isolated(
+    *,
+    source: DocumentSource,
+    input_type: InputType | None,
+    connector_specific_config: dict[str, Any],
+    credential_id: int,
+) -> tuple[BaseConnector, dict[str, Any]]:
+    """Instantiates the connector on a session owned by the calling thread.
+
+    ``run_with_timeout`` abandons its thread on timeout while the thread keeps
+    executing, and instantiation can write: ``load_credentials`` may return
+    refreshed tokens, which ``backend_update_credential_json`` persists with a
+    commit. Owning the session and the credential instance here keeps an
+    abandoned thread from committing through state the caller still uses.
+    Returns the connector and the credential material as loaded after
+    instantiation, so a refreshed token reaches checks instead of the caller's
+    pre-refresh copy.
+    """
+    with get_session_with_current_tenant() as db_session:
+        credential = fetch_credential_by_id(credential_id, db_session)
+        if credential is None:
+            raise RuntimeError(
+                f"Credential {credential_id} was deleted while the run was in flight."
+            )
+        connector = instantiate_connector(
+            db_session=db_session,
+            source=source,
+            input_type=input_type,
+            connector_specific_config=connector_specific_config,
+            credential=credential,
+        )
+        credential_json = (
+            credential.credential_json.get_value(apply_mask=False)
+            if credential.credential_json
+            else {}
+        )
+        return connector, credential_json
+
+
 def generate_capability_report(
-    db_session: Session,
     credential: Credential,
     connector_specific_config: dict[str, Any] | None = None,
     connector_id: int | None = None,
@@ -285,6 +324,7 @@ def generate_capability_report(
     instance-requiring checks instead (see ``_missing_instance_outcome``).
     Unlike ``validate_ccpair_for_user``, no source is exempted: MOCK_CONNECTOR
     must run so integration tests can exercise the full pipeline.
+    ``credential`` may be a detached instance; only loaded columns are read.
     """
     source = credential.source
     checks = get_capability_checks(source)
@@ -300,19 +340,19 @@ def generate_capability_report(
         connector_specific_config if connector_specific_config is not None else {}
     )
     connector: BaseConnector | None = None
+    fresh_credential_json: dict[str, Any] | None = None
     instantiation_error: Exception | None = None
     try:
         # Under the guard the run ceiling budgets for it: construction and
         # ``load_credentials`` can probe the source with no timeout of their
         # own, and the stale-run sweep trusts the ceiling.
-        connector = run_with_timeout(
+        connector, fresh_credential_json = run_with_timeout(
             CAPABILITY_CHECK_TIMEOUT_SECONDS,
-            instantiate_connector,
-            db_session=db_session,
+            _instantiate_connector_isolated,
             source=source,
             input_type=input_type,
             connector_specific_config=instantiation_config,
-            credential=credential,
+            credential_id=credential.id,
         )
     except Exception as e:
         # A config-less probe construction fails routinely and stays a skip; a
@@ -338,18 +378,25 @@ def generate_capability_report(
         )
 
     if credential.credential_json:
-        # Distinct decrypt site from ``instantiate_connector``'s paths (which
-        # may not have decrypted at all when instantiation fails). Audit is
-        # best-effort and never raises.
+        # Audits the run's own decrypt of the material (the isolated
+        # instantiation's post-load read, or the fallback below), a distinct
+        # site from ``instantiate_connector``'s paths. Best-effort, never
+        # raises.
         emit_credential_access(
             credential_type="connector",
             provider=str(source),
             row_id=credential.id,
         )
+    # The isolated instantiation reports the material as loaded after a
+    # possible token refresh; the caller's copy is the pre-refresh fallback.
     credential_json = (
-        credential.credential_json.get_value(apply_mask=False)
-        if credential.credential_json
-        else {}
+        fresh_credential_json
+        if fresh_credential_json is not None
+        else (
+            credential.credential_json.get_value(apply_mask=False)
+            if credential.credential_json
+            else {}
+        )
     )
     context = CapabilityCheckContext(
         source=source,

--- a/backend/onyx/connectors/capability_checks/runner.py
+++ b/backend/onyx/connectors/capability_checks/runner.py
@@ -188,8 +188,9 @@ def capability_check_run_ceiling_seconds(source: DocumentSource) -> int:
 
     Checks run sequentially and mirrored checks (one check surfaced under
     several capabilities) execute once, so the bound sums the distinct
-    per-check hang guards. One extra default guard covers the work outside any
-    check's guard: connector instantiation can itself probe the source.
+    per-check hang guards, plus the default guard connector instantiation runs
+    under (it can itself probe the source; ``generate_capability_report``
+    enforces that guard).
     """
     timeout_by_check_id = {
         check.check_id: check.timeout_seconds or CAPABILITY_CHECK_TIMEOUT_SECONDS
@@ -301,7 +302,12 @@ def generate_capability_report(
     connector: BaseConnector | None = None
     instantiation_error: Exception | None = None
     try:
-        connector = instantiate_connector(
+        # Under the guard the run ceiling budgets for it: construction and
+        # ``load_credentials`` can probe the source with no timeout of their
+        # own, and the stale-run sweep trusts the ceiling.
+        connector = run_with_timeout(
+            CAPABILITY_CHECK_TIMEOUT_SECONDS,
+            instantiate_connector,
             db_session=db_session,
             source=source,
             input_type=input_type,

--- a/backend/onyx/connectors/capability_checks/runner.py
+++ b/backend/onyx/connectors/capability_checks/runner.py
@@ -188,10 +188,10 @@ def capability_check_run_ceiling_seconds(source: DocumentSource) -> int:
     """Upper bound on one run's legitimate execution time, in seconds.
 
     Checks run sequentially and mirrored checks (one check surfaced under
-    several capabilities) execute once, so the bound sums the distinct
-    per-check hang guards, plus the default guard connector instantiation runs
-    under (it can itself probe the source; ``generate_capability_report``
-    enforces that guard).
+    several capabilities) execute once, so the bound sums the distinct per-check
+    hang guards, plus the default guard connector instantiation runs under (it
+    can itself probe the source; ``generate_capability_report`` enforces that
+    guard).
     """
     timeout_by_check_id = {
         check.check_id: check.timeout_seconds or CAPABILITY_CHECK_TIMEOUT_SECONDS
@@ -323,8 +323,8 @@ def generate_capability_report(
     When a supplied config fails to instantiate, the failure is surfaced on
     instance-requiring checks instead (see ``_missing_instance_outcome``).
     Unlike ``validate_ccpair_for_user``, no source is exempted: MOCK_CONNECTOR
-    must run so integration tests can exercise the full pipeline.
-    ``credential`` may be a detached instance; only loaded columns are read.
+    must run so integration tests can exercise the full pipeline. ``credential``
+    may be a detached instance; only loaded columns are read.
     """
     source = credential.source
     checks = get_capability_checks(source)
@@ -387,8 +387,8 @@ def generate_capability_report(
             provider=str(source),
             row_id=credential.id,
         )
-    # The isolated instantiation reports the material as loaded after a
-    # possible token refresh; the caller's copy is the pre-refresh fallback.
+    # The isolated instantiation reports the material as loaded after a possible
+    # token refresh; the caller's copy is the pre-refresh fallback.
     credential_json = (
         fresh_credential_json
         if fresh_credential_json is not None

--- a/backend/onyx/db/credential_capability.py
+++ b/backend/onyx/db/credential_capability.py
@@ -9,8 +9,10 @@ Two writer classes share these rows, with fixed precedence: granular named-check
 runs write through ``upsert_completed_capability_report`` and replace whatever
 is stored (latest-only truth); the coarse blocking-validation recorder writes
 through the ``unless_granular`` variant and never replaces a granular report.
-``mark_capability_report_running`` belongs to the check-runner lifecycle: it
-flags a run in flight while the last completed report stays readable.
+``mark_capability_report_running`` and ``mark_stale_capability_runs_failed``
+belong to the check-runner lifecycle: the mark flags a run in flight while the
+last completed report stays readable, and the sweep retires marks that outlived
+their run ceiling to FAILED_TO_RUN.
 """
 
 from datetime import datetime, timedelta
@@ -252,6 +254,57 @@ def mark_capability_run_failed(
         )
     )
     db_session.execute(stmt)
+
+
+def get_sources_with_running_capability_runs(
+    db_session: Session,
+) -> list[DocumentSource]:
+    """Returns the distinct sources holding a row currently marked RUNNING."""
+    stmt = (
+        select(CredentialCapabilityReportRow.source)
+        .where(
+            CredentialCapabilityReportRow.run_status
+            == CapabilityReportRunStatus.RUNNING
+        )
+        .distinct()
+    )
+    return list(db_session.scalars(stmt).all())
+
+
+def mark_stale_capability_runs_failed(
+    db_session: Session,
+    *,
+    source: DocumentSource,
+    stale_after: timedelta,
+) -> int:
+    """Retires dead runs: RUNNING rows older than ``stale_after`` turn
+    FAILED_TO_RUN.
+
+    Only the lifecycle fields change; the stored report (the last completed
+    run) stays readable. The cutoff is evaluated by Postgres against statement
+    time, mirroring the mark's guard, so a scope re-marked concurrently is
+    never retired. Returns the number of rows retired.
+    """
+    stmt = (
+        update(CredentialCapabilityReportRow)
+        .where(
+            CredentialCapabilityReportRow.source == source,
+            CredentialCapabilityReportRow.run_status
+            == CapabilityReportRunStatus.RUNNING,
+            or_(
+                CredentialCapabilityReportRow.run_started_at.is_(None),
+                CredentialCapabilityReportRow.run_started_at
+                < func.statement_timestamp() - stale_after,
+            ),
+        )
+        .values(
+            run_status=CapabilityReportRunStatus.FAILED_TO_RUN,
+            # Model ``onupdate`` does not apply to bulk updates.
+            time_updated=func.statement_timestamp(),
+        )
+    )
+    result = db_session.execute(stmt)
+    return int(result.rowcount)  # ty: ignore[unresolved-attribute]
 
 
 def get_capability_report_row(

--- a/backend/onyx/db/credential_capability.py
+++ b/backend/onyx/db/credential_capability.py
@@ -12,8 +12,8 @@ through the ``unless_granular`` variant and never replaces a granular report or
 disturbs a run in flight. ``mark_capability_report_running`` and
 ``mark_stale_capability_runs_failed`` belong to the check-runner lifecycle: the
 mark claims the row for a fresh run attempt (``run_id``) while the last
-completed report stays readable, and the sweep retires marks that outlived
-their run ceiling to FAILED_TO_RUN. The attempt's terminal writes are fenced on
+completed report stays readable, and the sweep retires marks that outlived their
+run ceiling to FAILED_TO_RUN. The attempt's terminal writes are fenced on
 ``run_id``, so a superseded attempt can never mislabel its successor's row; the
 sweep preserves ``run_id`` when retiring, so the same attempt's late completion
 still lands (the self-heal for a run that was merely slow).
@@ -164,9 +164,9 @@ def upsert_completed_capability_report(
     compiles to a conditional UPDATE (never an insert) and lands only while the
     stored ``run_id`` still matches, so a superseded attempt's completion is
     discarded instead of mislabeling its successor's row. Retirement preserves
-    ``run_id``, so the same attempt's late completion still lands (the
-    self-heal for a run that was merely slow). Returns None when the fence
-    discarded the write.
+    ``run_id``, so the same attempt's late completion still lands (the self-heal
+    for a run that was merely slow). Returns None when the fence discarded the
+    write.
 
     Without ``run_id`` (tasks enqueued before the fence deployed) the write is
     unfenced and always returns the row.
@@ -223,10 +223,9 @@ def upsert_completed_capability_report_unless_granular(
     read-then-decide here would race a concurrent granular write; Postgres
     evaluates the guard against the stored row atomically, so a granular report
     can never be replaced by this coarse write (the no-clobber rule). A row
-    marked RUNNING is likewise left alone: this coarse signal is a strict
-    subset of the granular run in flight, and overwriting the mark would strand
-    that attempt's fenced completion. Returns None when the stored row was
-    preserved.
+    marked RUNNING is likewise left alone: this coarse signal is a strict subset
+    of the granular run in flight, and overwriting the mark would strand that
+    attempt's fenced completion. Returns None when the stored row was preserved.
     """
     return _upsert_row(
         db_session,
@@ -303,11 +302,11 @@ def mark_capability_run_failed(
     """Retires the scope's RUNNING mark to FAILED_TO_RUN; the report survives.
 
     For runs that verifiably will not happen (the trigger endpoint's failed
-    enqueue) and for a failing task's own exit write: FAILED_TO_RUN is the
-    truth pollers should read, and it does not block re-marking, so the scope
-    stays immediately re-triggerable. Guarded on RUNNING so a completion that
-    raced this write is never clobbered; with ``run_id`` also fenced to the
-    caller's attempt, so a superseded attempt cannot fail-mark its successor.
+    enqueue) and for a failing task's own exit write: FAILED_TO_RUN is the truth
+    pollers should read, and it does not block re-marking, so the scope stays
+    immediately re-triggerable. Guarded on RUNNING so a completion that raced
+    this write is never clobbered; with ``run_id`` also fenced to the caller's
+    attempt, so a superseded attempt cannot fail-mark its successor.
     """
     where = [
         CredentialCapabilityReportRow.credential_id == credential_id,
@@ -352,12 +351,12 @@ def mark_stale_capability_runs_failed(
     """Retires dead runs: RUNNING rows older than ``stale_after`` turn
     FAILED_TO_RUN.
 
-    Only the lifecycle fields change; the stored report (the last completed
-    run) stays readable, and ``run_id`` is preserved so a retired attempt that
-    was merely slow can still land its fenced completion (the self-heal). The
-    cutoff is evaluated by Postgres against statement time, mirroring the
-    mark's guard, so a scope re-marked concurrently is never retired. Returns
-    the number of rows retired.
+    Only the lifecycle fields change; the stored report (the last completed run)
+    stays readable, and ``run_id`` is preserved so a retired attempt that was
+    merely slow can still land its fenced completion (the self-heal). The cutoff
+    is evaluated by Postgres against statement time, mirroring the mark's guard,
+    so a scope re-marked concurrently is never retired. Returns the number of
+    rows retired.
     """
     stmt = (
         update(CredentialCapabilityReportRow)

--- a/backend/onyx/db/credential_capability.py
+++ b/backend/onyx/db/credential_capability.py
@@ -8,17 +8,31 @@ resolve to one row instead of racing an insert.
 Two writer classes share these rows, with fixed precedence: granular named-check
 runs write through ``upsert_completed_capability_report`` and replace whatever
 is stored (latest-only truth); the coarse blocking-validation recorder writes
-through the ``unless_granular`` variant and never replaces a granular report.
-``mark_capability_report_running`` and ``mark_stale_capability_runs_failed``
-belong to the check-runner lifecycle: the mark flags a run in flight while the
-last completed report stays readable, and the sweep retires marks that outlived
-their run ceiling to FAILED_TO_RUN.
+through the ``unless_granular`` variant and never replaces a granular report or
+disturbs a run in flight. ``mark_capability_report_running`` and
+``mark_stale_capability_runs_failed`` belong to the check-runner lifecycle: the
+mark claims the row for a fresh run attempt (``run_id``) while the last
+completed report stays readable, and the sweep retires marks that outlived
+their run ceiling to FAILED_TO_RUN. The attempt's terminal writes are fenced on
+``run_id``, so a superseded attempt can never mislabel its successor's row; the
+sweep preserves ``run_id`` when retiring, so the same attempt's late completion
+still lands (the self-heal for a run that was merely slow).
 """
 
 from datetime import datetime, timedelta
 from typing import Any, TypedDict
+from uuid import UUID, uuid4
 
-from sqlalchemy import ColumnElement, func, literal_column, or_, select, text, update
+from sqlalchemy import (
+    ColumnElement,
+    and_,
+    func,
+    literal_column,
+    or_,
+    select,
+    text,
+    update,
+)
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
@@ -47,7 +61,15 @@ class _CapabilityReportValues(TypedDict, total=False):
     connector_config_hash: str | None
     run_status: CapabilityReportRunStatus
     run_started_at: ColumnElement[datetime]
+    run_id: UUID | None
     time_updated: ColumnElement[datetime]
+
+
+def _connector_scope_clause(connector_id: int | None) -> ColumnElement[bool]:
+    """WHERE clause selecting the scope's row within one credential."""
+    if connector_id is None:
+        return CredentialCapabilityReportRow.connector_id.is_(None)
+    return CredentialCapabilityReportRow.connector_id == connector_id
 
 
 def _scope_conflict_kwargs(connector_id: int | None) -> dict[str, Any]:
@@ -134,18 +156,54 @@ def upsert_completed_capability_report(
     trigger: CapabilityCheckTrigger,
     report: CredentialCapabilityReport,
     connector_config_hash: str | None = None,
-) -> CredentialCapabilityReportRow:
-    """Writes a finished report onto the scope's row (latest-only replace)."""
-    row = _upsert_row(
-        db_session,
-        credential_id=credential_id,
-        connector_id=connector_id,
-        values=_completed_values(
-            connector_id, source, trigger, report, connector_config_hash
-        ),
+    run_id: UUID | None = None,
+) -> CredentialCapabilityReportRow | None:
+    """Writes a finished report onto the scope's row (latest-only replace).
+
+    With ``run_id`` the write is fenced to the attempt that claimed the row: it
+    compiles to a conditional UPDATE (never an insert) and lands only while the
+    stored ``run_id`` still matches, so a superseded attempt's completion is
+    discarded instead of mislabeling its successor's row. Retirement preserves
+    ``run_id``, so the same attempt's late completion still lands (the
+    self-heal for a run that was merely slow). Returns None when the fence
+    discarded the write.
+
+    Without ``run_id`` (tasks enqueued before the fence deployed) the write is
+    unfenced and always returns the row.
+    """
+    values = _completed_values(
+        connector_id, source, trigger, report, connector_config_hash
     )
-    assert row is not None, "An unguarded upsert always returns the row."
-    return row
+    if run_id is None:
+        row = _upsert_row(
+            db_session,
+            credential_id=credential_id,
+            connector_id=connector_id,
+            values=values,
+        )
+        assert row is not None, "An unguarded upsert always returns the row."
+        return row
+    stamped: _CapabilityReportValues = {
+        **values,
+        # Mirrors ``_upsert_row``: model ``onupdate`` does not apply here.
+        "time_updated": func.statement_timestamp(),
+    }
+    stmt = (
+        update(CredentialCapabilityReportRow)
+        .where(
+            CredentialCapabilityReportRow.credential_id == credential_id,
+            _connector_scope_clause(connector_id),
+            # The fence. A NULL stored ``run_id`` (recorder write, legacy row)
+            # never matches: an attempt that lost the row cannot write back.
+            CredentialCapabilityReportRow.run_id == run_id,
+        )
+        .values(**stamped)
+        .returning(CredentialCapabilityReportRow)
+    )
+    # ``populate_existing``: see ``_upsert_row``.
+    return db_session.scalars(
+        stmt, execution_options={"populate_existing": True}
+    ).one_or_none()
 
 
 def upsert_completed_capability_report_unless_granular(
@@ -164,18 +222,29 @@ def upsert_completed_capability_report_unless_granular(
     CONFLICT DO UPDATE ... WHERE <stored report is not granular>``. A
     read-then-decide here would race a concurrent granular write; Postgres
     evaluates the guard against the stored row atomically, so a granular report
-    can never be replaced by this coarse write (the no-clobber rule). Returns
-    None when the stored report was preserved.
+    can never be replaced by this coarse write (the no-clobber rule). A row
+    marked RUNNING is likewise left alone: this coarse signal is a strict
+    subset of the granular run in flight, and overwriting the mark would strand
+    that attempt's fenced completion. Returns None when the stored row was
+    preserved.
     """
     return _upsert_row(
         db_session,
         credential_id=credential_id,
         connector_id=connector_id,
-        values=_completed_values(
-            connector_id, source, trigger, report, connector_config_hash
-        ),
+        values={
+            **_completed_values(
+                connector_id, source, trigger, report, connector_config_hash
+            ),
+            # No run attempt owns a recorder write.
+            "run_id": None,
+        },
         # The "unless": evaluated by Postgres inside the upsert, not here.
-        update_where=_STORED_REPORT_IS_NOT_GRANULAR,
+        update_where=and_(
+            _STORED_REPORT_IS_NOT_GRANULAR,
+            CredentialCapabilityReportRow.run_status
+            != CapabilityReportRunStatus.RUNNING,
+        ),
     )
 
 
@@ -195,8 +264,9 @@ def mark_capability_report_running(
     blocks the mark only while it is RUNNING with a start time newer than
     ``active_within`` ago, evaluated atomically by Postgres so concurrent
     triggers cannot double-mark. A RUNNING mark older than the bound is a
-    crashed or expired run and is replaced. Returns None when an active run
-    blocked the mark.
+    crashed or expired run and is replaced. The mark stamps a fresh ``run_id``
+    claiming the row for this attempt; the attempt's terminal writes are fenced
+    on it. Returns None when an active run blocked the mark.
     """
     return _upsert_row(
         db_session,
@@ -209,6 +279,7 @@ def mark_capability_report_running(
             # Statement time, not ``now()``: the run starts now, not when the
             # caller's transaction began.
             "run_started_at": func.statement_timestamp(),
+            "run_id": uuid4(),
         },
         update_where=or_(
             CredentialCapabilityReportRow.run_status
@@ -227,26 +298,27 @@ def mark_capability_run_failed(
     *,
     credential_id: int,
     connector_id: int | None,
+    run_id: UUID | None = None,
 ) -> None:
     """Retires the scope's RUNNING mark to FAILED_TO_RUN; the report survives.
 
     For runs that verifiably will not happen (the trigger endpoint's failed
-    enqueue): FAILED_TO_RUN is the truth pollers should read, and it does not
-    block re-marking, so the scope stays immediately re-triggerable. Guarded on
-    RUNNING so a completion that raced this write is never clobbered.
+    enqueue) and for a failing task's own exit write: FAILED_TO_RUN is the
+    truth pollers should read, and it does not block re-marking, so the scope
+    stays immediately re-triggerable. Guarded on RUNNING so a completion that
+    raced this write is never clobbered; with ``run_id`` also fenced to the
+    caller's attempt, so a superseded attempt cannot fail-mark its successor.
     """
+    where = [
+        CredentialCapabilityReportRow.credential_id == credential_id,
+        _connector_scope_clause(connector_id),
+        CredentialCapabilityReportRow.run_status == CapabilityReportRunStatus.RUNNING,
+    ]
+    if run_id is not None:
+        where.append(CredentialCapabilityReportRow.run_id == run_id)
     stmt = (
         update(CredentialCapabilityReportRow)
-        .where(
-            CredentialCapabilityReportRow.credential_id == credential_id,
-            (
-                CredentialCapabilityReportRow.connector_id.is_(None)
-                if connector_id is None
-                else CredentialCapabilityReportRow.connector_id == connector_id
-            ),
-            CredentialCapabilityReportRow.run_status
-            == CapabilityReportRunStatus.RUNNING,
-        )
+        .where(*where)
         .values(
             run_status=CapabilityReportRunStatus.FAILED_TO_RUN,
             # Model ``onupdate`` does not apply to bulk updates.
@@ -281,9 +353,11 @@ def mark_stale_capability_runs_failed(
     FAILED_TO_RUN.
 
     Only the lifecycle fields change; the stored report (the last completed
-    run) stays readable. The cutoff is evaluated by Postgres against statement
-    time, mirroring the mark's guard, so a scope re-marked concurrently is
-    never retired. Returns the number of rows retired.
+    run) stays readable, and ``run_id`` is preserved so a retired attempt that
+    was merely slow can still land its fenced completion (the self-heal). The
+    cutoff is evaluated by Postgres against statement time, mirroring the
+    mark's guard, so a scope re-marked concurrently is never retired. Returns
+    the number of rows retired.
     """
     stmt = (
         update(CredentialCapabilityReportRow)

--- a/backend/onyx/db/credential_capability.py
+++ b/backend/onyx/db/credential_capability.py
@@ -168,21 +168,23 @@ def upsert_completed_capability_report(
     for a run that was merely slow). Returns None when the fence discarded the
     write.
 
-    Without ``run_id`` (tasks enqueued before the fence deployed) the write is
-    unfenced and always returns the row.
+    Without ``run_id`` (tasks enqueued before the fence deployed) the write
+    lands only on a row whose stored ``run_id`` is NULL: pre-migration marks are
+    all NULL, so a legacy task still completes normally, but a row reclaimed by
+    a post-deploy attempt is untouchable. The fence is therefore unconditional,
+    with no transition-window exception.
     """
     values = _completed_values(
         connector_id, source, trigger, report, connector_config_hash
     )
     if run_id is None:
-        row = _upsert_row(
+        return _upsert_row(
             db_session,
             credential_id=credential_id,
             connector_id=connector_id,
             values=values,
+            update_where=CredentialCapabilityReportRow.run_id.is_(None),
         )
-        assert row is not None, "An unguarded upsert always returns the row."
-        return row
     stamped: _CapabilityReportValues = {
         **values,
         # Mirrors ``_upsert_row``: model ``onupdate`` does not apply here.
@@ -305,16 +307,21 @@ def mark_capability_run_failed(
     enqueue) and for a failing task's own exit write: FAILED_TO_RUN is the truth
     pollers should read, and it does not block re-marking, so the scope stays
     immediately re-triggerable. Guarded on RUNNING so a completion that raced
-    this write is never clobbered; with ``run_id`` also fenced to the caller's
-    attempt, so a superseded attempt cannot fail-mark its successor.
+    this write is never clobbered, and fenced to the caller's attempt so a
+    superseded attempt cannot fail-mark its successor. ``run_id`` None is the
+    legacy-task fence: it matches only a stored NULL (a pre-migration mark),
+    mirroring the completion writer.
     """
     where = [
         CredentialCapabilityReportRow.credential_id == credential_id,
         _connector_scope_clause(connector_id),
         CredentialCapabilityReportRow.run_status == CapabilityReportRunStatus.RUNNING,
+        (
+            CredentialCapabilityReportRow.run_id.is_(None)
+            if run_id is None
+            else CredentialCapabilityReportRow.run_id == run_id
+        ),
     ]
-    if run_id is not None:
-        where.append(CredentialCapabilityReportRow.run_id == run_id)
     stmt = (
         update(CredentialCapabilityReportRow)
         .where(*where)

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2141,6 +2141,10 @@ class CredentialCapabilityReportRow(Base):
     run_started_at: Mapped[datetime.datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    # The run attempt owning the lifecycle mark; the task's terminal writes are
+    # fenced on it. NULL: no attempt owns the row (recorder writes, legacy
+    # rows), which no fenced write can match. Never searched on, so no index.
+    run_id: Mapped[UUID | None] = mapped_column(PGUUID(as_uuid=True), nullable=True)
     time_created: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/onyx/server/documents/credential_capabilities.py
+++ b/backend/onyx/server/documents/credential_capabilities.py
@@ -47,12 +47,15 @@ from onyx.db.enums import CapabilityCheckTrigger, CapabilityReportRunStatus, Per
 from onyx.db.models import CredentialCapabilityReportRow, User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.server.utils_vector_db import require_vector_db
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
-router = APIRouter(prefix="/manage")
+# Lite (no vector DB) has no connectors, so there is nothing to probe or
+# report, and the celery machinery the trigger relies on is absent there.
+router = APIRouter(prefix="/manage", dependencies=[Depends(require_vector_db)])
 
 
 class CapabilityReportSnapshot(BaseModel):

--- a/backend/onyx/server/documents/credential_capabilities.py
+++ b/backend/onyx/server/documents/credential_capabilities.py
@@ -53,8 +53,8 @@ from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
-# Lite (no vector DB) has no connectors, so there is nothing to probe or
-# report, and the celery machinery the trigger relies on is absent there.
+# Lite (no vector DB) has no connectors, so there is nothing to probe or report,
+# and the celery machinery the trigger relies on is absent there.
 router = APIRouter(prefix="/manage", dependencies=[Depends(require_vector_db)])
 
 
@@ -231,8 +231,8 @@ def trigger_capability_check(
             queue=OnyxCeleryQueues.CAPABILITY_CHECKS,
             priority=OnyxCeleryPriority.HIGH,
             # Queue wait is bounded by one execution ceiling; the staleness
-            # cutoff above allows for both, so an expired task never strands
-            # the scope.
+            # cutoff above allows for both, so an expired task never strands the
+            # scope.
             expires=capability_check_run_ceiling_seconds(credential.source),
         )
     except Exception:

--- a/backend/onyx/server/documents/credential_capabilities.py
+++ b/backend/onyx/server/documents/credential_capabilities.py
@@ -6,7 +6,7 @@ here gates connector creation or indexing, and check failures are report
 content, never an HTTP error.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends
@@ -23,7 +23,8 @@ from onyx.configs.constants import (
 )
 from onyx.connectors.capability_checks.models import CredentialCapabilityReport
 from onyx.connectors.capability_checks.runner import (
-    CAPABILITY_CHECK_RUN_STALENESS_SECONDS,
+    capability_check_run_ceiling_seconds,
+    capability_check_run_stale_after,
 )
 from onyx.db.connector import fetch_connector_by_id
 from onyx.db.connector_credential_pair import (
@@ -190,7 +191,7 @@ def trigger_capability_check(
         connector_id=request.connector_id,
         source=credential.source,
         trigger=CapabilityCheckTrigger.MANUAL,
-        active_within=timedelta(seconds=CAPABILITY_CHECK_RUN_STALENESS_SECONDS),
+        active_within=capability_check_run_stale_after(credential.source),
     )
     if row is None:
         # An unexpired run is in flight; return its row without re-enqueueing.
@@ -221,9 +222,10 @@ def trigger_capability_check(
             ),
             queue=OnyxCeleryQueues.CAPABILITY_CHECKS,
             priority=OnyxCeleryPriority.HIGH,
-            # The queued run and its RUNNING mark go stale together, so an
-            # expired task never strands an unmarkable scope.
-            expires=CAPABILITY_CHECK_RUN_STALENESS_SECONDS,
+            # Queue wait is bounded by one execution ceiling; the staleness
+            # cutoff above allows for both, so an expired task never strands
+            # the scope.
+            expires=capability_check_run_ceiling_seconds(credential.source),
         )
     except Exception:
         # The 503 handler logs no traceback, so record the cause here (broker

--- a/backend/onyx/server/documents/credential_capabilities.py
+++ b/backend/onyx/server/documents/credential_capabilities.py
@@ -212,6 +212,8 @@ def trigger_capability_check(
             )
         return CapabilityReportSnapshot.from_row(standing)
     snapshot = CapabilityReportSnapshot.from_row(row)
+    run_id = row.run_id
+    assert run_id is not None, "The RUNNING mark always stamps a run_id."
     # Commit before enqueueing so the worker can only observe the RUNNING mark.
     db_session.commit()
     try:
@@ -222,6 +224,9 @@ def trigger_capability_check(
                 connector_id=request.connector_id,
                 connector_specific_config=request.connector_specific_config,
                 tenant_id=get_current_tenant_id(),
+                # The attempt's fence: the task's terminal writes land only
+                # while this id still owns the row.
+                run_id=str(run_id),
             ),
             queue=OnyxCeleryQueues.CAPABILITY_CHECKS,
             priority=OnyxCeleryPriority.HIGH,
@@ -244,6 +249,7 @@ def trigger_capability_check(
             db_session,
             credential_id=credential_id,
             connector_id=request.connector_id,
+            run_id=run_id,
         )
         db_session.commit()
         raise OnyxError(

--- a/backend/tests/external_dependency_unit/db/test_credential_capability.py
+++ b/backend/tests/external_dependency_unit/db/test_credential_capability.py
@@ -386,8 +386,9 @@ def test_sweep_retires_only_stale_running_rows(db_session: Session) -> None:
     GITLAB rather than SLACK: committed rows from other suites never use it, so
     the retired-row count is deterministic.
     """
-    # Precondition. Four scopes: a stale run over a previous report, a fresh
-    # run, a RUNNING mark with a NULL start, and a completed report.
+    # Precondition.
+    # Four scopes: a stale run over a previous report, a fresh run, a RUNNING
+    # mark with a NULL start, and a completed report.
     stale_pair = make_cc_pair(db_session, source=DocumentSource.GITLAB, commit=False)
     fresh_pair = make_cc_pair(db_session, source=DocumentSource.GITLAB, commit=False)
     null_start_pair = make_cc_pair(
@@ -444,7 +445,8 @@ def test_sweep_retires_only_stale_running_rows(db_session: Session) -> None:
         db_session, source=DocumentSource.GITLAB, stale_after=timedelta(hours=1)
     )
 
-    # Postcondition. The backdated mark and the NULL-start mark both retire.
+    # Postcondition.
+    # The backdated mark and the NULL-start mark both retire.
     assert retired == 2
     db_session.expire_all()
     retired_row = get_capability_report_row(db_session, stale_pair.credential_id, None)
@@ -484,7 +486,8 @@ def test_sources_with_running_runs_lists_each_source_once(
     db_session: Session,
 ) -> None:
     """Verifies the sweep's work list: distinct sources with a RUNNING row."""
-    # Precondition. Two GITHUB scopes RUNNING, one GITLAB scope COMPLETED.
+    # Precondition.
+    # Two GITHUB scopes RUNNING, one GITLAB scope COMPLETED.
     for pair in (
         make_cc_pair(db_session, source=DocumentSource.GITHUB, commit=False),
         make_cc_pair(db_session, source=DocumentSource.GITHUB, commit=False),
@@ -652,7 +655,8 @@ def test_fenced_completion_self_heals_a_retired_run(db_session: Session) -> None
     Verifies the fence preserves the self-heal: retirement keeps the attempt's
     ``run_id``, so a run that was merely slow still lands its completion.
     """
-    # Precondition. A RUNNING attempt, backdated and retired by the sweep.
+    # Precondition.
+    # A RUNNING attempt, backdated and retired by the sweep.
     cc_pair = make_cc_pair(db_session, source=DocumentSource.GITLAB, commit=False)
     credential_id = cc_pair.credential_id
     marked = mark_capability_report_running(
@@ -684,8 +688,9 @@ def test_fenced_completion_self_heals_a_retired_run(db_session: Session) -> None
         run_id=run_id,
     )
 
-    # Postcondition. The retired row still belonged to this attempt, so the
-    # fenced write lands and FAILED_TO_RUN heals to the real report.
+    # Postcondition.
+    # The retired row still belonged to this attempt, so the fenced write lands
+    # and FAILED_TO_RUN heals to the real report.
     assert completed is not None
     assert completed.run_status == CapabilityReportRunStatus.COMPLETED
     assert completed.report is not None
@@ -697,10 +702,11 @@ def test_fenced_terminal_writes_cannot_touch_a_successor_attempt(
     db_session: Session,
 ) -> None:
     """
-    Verifies the fence itself: once the scope is reclaimed by a new attempt,
-    the superseded attempt's completion and failure writes are discarded.
+    Verifies the fence itself: once the scope is reclaimed by a new attempt, the
+    superseded attempt's completion and failure writes are discarded.
     """
-    # Precondition. A stale RUNNING attempt reclaimed by a fresh one.
+    # Precondition.
+    # A stale RUNNING attempt reclaimed by a fresh one.
     cc_pair = make_cc_pair(db_session, source=DocumentSource.GITLAB, commit=False)
     credential_id = cc_pair.credential_id
     old = mark_capability_report_running(
@@ -744,8 +750,9 @@ def test_fenced_terminal_writes_cannot_touch_a_successor_attempt(
         run_id=old_run_id,
     )
 
-    # Postcondition. Both writes no-op: the successor still owns the row and
-    # still reads as an in-flight run with no report.
+    # Postcondition.
+    # Both writes no-op: the successor still owns the row and still reads as an
+    # in-flight run with no report.
     assert completed is None
     db_session.expire_all()
     row = get_capability_report_row(db_session, credential_id, None)
@@ -759,8 +766,8 @@ def test_fenced_terminal_writes_cannot_touch_a_successor_attempt(
 def test_unless_granular_preserves_a_running_row(db_session: Session) -> None:
     """
     Verifies the recorder guard: a blocking validation that lands mid-run must
-    not overwrite the RUNNING mark, or the attempt's fenced completion would
-    be stranded.
+    not overwrite the RUNNING mark, or the attempt's fenced completion would be
+    stranded.
     """
     # Precondition.
     cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
@@ -802,8 +809,9 @@ def test_recorder_write_clears_the_attempt_id(db_session: Session) -> None:
     stored ``run_id`` is nulled, and NULL is fail-closed against the previous
     attempt's late fenced completion.
     """
-    # Precondition. A retired attempt whose report-less row the recorder may
-    # overwrite (not granular, not RUNNING).
+    # Precondition.
+    # A retired attempt whose report-less row the recorder may overwrite (not
+    # granular, not RUNNING).
     cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
     credential_id = cc_pair.credential_id
     marked = mark_capability_report_running(

--- a/backend/tests/external_dependency_unit/db/test_credential_capability.py
+++ b/backend/tests/external_dependency_unit/db/test_credential_capability.py
@@ -22,8 +22,10 @@ from onyx.connectors.capability_checks.models import (
 from onyx.db.credential_capability import (
     get_capability_report_row,
     get_capability_report_rows_for_source,
+    get_sources_with_running_capability_runs,
     mark_capability_report_running,
     mark_capability_run_failed,
+    mark_stale_capability_runs_failed,
     upsert_completed_capability_report,
     upsert_completed_capability_report_unless_granular,
 )
@@ -37,10 +39,11 @@ def _report(
     connector_id: int | None = None,
     check_id: str = "slack_token_auth",
     is_fallback: bool = False,
+    source: DocumentSource = DocumentSource.SLACK,
 ) -> CredentialCapabilityReport:
     return CredentialCapabilityReport(
         credential_id=credential_id,
-        source=DocumentSource.SLACK,
+        source=source,
         connector_id=connector_id,
         checked_at=datetime.now(timezone.utc),
         trigger=CapabilityCheckTrigger.MANUAL,
@@ -363,6 +366,147 @@ def test_failed_run_mark_only_retires_running_rows(db_session: Session) -> None:
     row = get_capability_report_row(db_session, credential_id, None)
     assert row is not None
     assert row.run_status == CapabilityReportRunStatus.COMPLETED
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_sweep_retires_only_stale_running_rows(db_session: Session) -> None:
+    """
+    Verifies the FAILED_TO_RUN writer: only RUNNING rows past the cutoff turn,
+    the stored report survives, and fresh or completed rows are untouched.
+
+    GITLAB rather than SLACK: committed rows from other suites never use it, so
+    the retired-row count is deterministic.
+    """
+    # Precondition. Four scopes: a stale run over a previous report, a fresh
+    # run, a RUNNING mark with a NULL start, and a completed report.
+    stale_pair = make_cc_pair(db_session, source=DocumentSource.GITLAB, commit=False)
+    fresh_pair = make_cc_pair(db_session, source=DocumentSource.GITLAB, commit=False)
+    null_start_pair = make_cc_pair(
+        db_session, source=DocumentSource.GITLAB, commit=False
+    )
+    completed_pair = make_cc_pair(
+        db_session, source=DocumentSource.GITLAB, commit=False
+    )
+    upsert_completed_capability_report(
+        db_session,
+        credential_id=stale_pair.credential_id,
+        connector_id=None,
+        source=DocumentSource.GITLAB,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        report=_report(
+            stale_pair.credential_id,
+            check_id="previous",
+            source=DocumentSource.GITLAB,
+        ),
+    )
+    for pair in (stale_pair, fresh_pair, null_start_pair):
+        marked = mark_capability_report_running(
+            db_session,
+            credential_id=pair.credential_id,
+            connector_id=None,
+            source=DocumentSource.GITLAB,
+            trigger=CapabilityCheckTrigger.MANUAL,
+            active_within=timedelta(hours=1),
+        )
+        assert marked is not None
+    stale_row = get_capability_report_row(db_session, stale_pair.credential_id, None)
+    assert stale_row is not None
+    stale_row.run_started_at = datetime.now(timezone.utc) - timedelta(hours=3)
+    db_session.flush()
+    # No writer leaves RUNNING with a NULL start, but the schema represents it
+    # and the sweep must retire it as stale; craft it directly.
+    null_start_row = get_capability_report_row(
+        db_session, null_start_pair.credential_id, None
+    )
+    assert null_start_row is not None
+    null_start_row.run_started_at = None
+    db_session.flush()
+    upsert_completed_capability_report(
+        db_session,
+        credential_id=completed_pair.credential_id,
+        connector_id=None,
+        source=DocumentSource.GITLAB,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        report=_report(completed_pair.credential_id, source=DocumentSource.GITLAB),
+    )
+
+    # Under test.
+    retired = mark_stale_capability_runs_failed(
+        db_session, source=DocumentSource.GITLAB, stale_after=timedelta(hours=1)
+    )
+
+    # Postcondition. The backdated mark and the NULL-start mark both retire.
+    assert retired == 2
+    db_session.expire_all()
+    retired_row = get_capability_report_row(db_session, stale_pair.credential_id, None)
+    assert retired_row is not None
+    assert retired_row.run_status == CapabilityReportRunStatus.FAILED_TO_RUN
+    assert retired_row.report is not None
+    assert retired_row.report["check_results"][0]["check_id"] == "previous"
+    null_start_row = get_capability_report_row(
+        db_session, null_start_pair.credential_id, None
+    )
+    assert null_start_row is not None
+    assert null_start_row.run_status == CapabilityReportRunStatus.FAILED_TO_RUN
+    fresh_row = get_capability_report_row(db_session, fresh_pair.credential_id, None)
+    assert fresh_row is not None
+    assert fresh_row.run_status == CapabilityReportRunStatus.RUNNING
+    completed_row = get_capability_report_row(
+        db_session, completed_pair.credential_id, None
+    )
+    assert completed_row is not None
+    assert completed_row.run_status == CapabilityReportRunStatus.COMPLETED
+
+    # Under test and postcondition (a retired scope re-triggers immediately).
+    remarked = mark_capability_report_running(
+        db_session,
+        credential_id=stale_pair.credential_id,
+        connector_id=None,
+        source=DocumentSource.GITLAB,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        active_within=timedelta(hours=1),
+    )
+    assert remarked is not None
+    assert remarked.run_status == CapabilityReportRunStatus.RUNNING
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_sources_with_running_runs_lists_each_source_once(
+    db_session: Session,
+) -> None:
+    """Verifies the sweep's work list: distinct sources with a RUNNING row."""
+    # Precondition. Two GITHUB scopes RUNNING, one GITLAB scope COMPLETED.
+    for pair in (
+        make_cc_pair(db_session, source=DocumentSource.GITHUB, commit=False),
+        make_cc_pair(db_session, source=DocumentSource.GITHUB, commit=False),
+    ):
+        marked = mark_capability_report_running(
+            db_session,
+            credential_id=pair.credential_id,
+            connector_id=None,
+            source=DocumentSource.GITHUB,
+            trigger=CapabilityCheckTrigger.MANUAL,
+            active_within=timedelta(hours=1),
+        )
+        assert marked is not None
+    completed_pair = make_cc_pair(
+        db_session, source=DocumentSource.GITLAB, commit=False
+    )
+    upsert_completed_capability_report(
+        db_session,
+        credential_id=completed_pair.credential_id,
+        connector_id=None,
+        source=DocumentSource.GITLAB,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        report=_report(completed_pair.credential_id, source=DocumentSource.GITLAB),
+    )
+
+    # Under test.
+    sources = get_sources_with_running_capability_runs(db_session)
+
+    # Postcondition.
+    assert sources.count(DocumentSource.GITHUB) == 1
+    assert DocumentSource.GITLAB not in sources
 
 
 @pytest.mark.usefixtures("tenant_context")

--- a/backend/tests/external_dependency_unit/db/test_credential_capability.py
+++ b/backend/tests/external_dependency_unit/db/test_credential_capability.py
@@ -91,6 +91,8 @@ def test_upsert_inserts_then_replaces(db_session: Session) -> None:
     )
 
     # Postcondition.
+    assert first is not None
+    assert second is not None
     assert second.id == first.id
     row = get_capability_report_row(db_session, credential_id, None)
     assert row is not None
@@ -131,6 +133,8 @@ def test_credential_and_connector_scopes_coexist(db_session: Session) -> None:
     )
 
     # Postcondition.
+    assert credential_scope is not None
+    assert connector_scope is not None
     assert credential_scope.id != connector_scope.id
     fetched_credential_scope = get_capability_report_row(
         db_session, credential_id, None
@@ -191,6 +195,7 @@ def test_mark_running_preserves_report_and_completion_keeps_start_time(
         trigger=CapabilityCheckTrigger.MANUAL,
         report=_report(credential_id, check_id="fresh"),
     )
+    assert completed is not None
     assert completed.run_status == CapabilityReportRunStatus.COMPLETED
     assert completed.run_started_at == running.run_started_at
     assert completed.report is not None
@@ -270,6 +275,8 @@ def test_mark_running_replaces_a_stale_running_mark(db_session: Session) -> None
         active_within=timedelta(hours=1),
     )
     assert stale is not None
+    stale_run_id = stale.run_id
+    assert stale_run_id is not None
     stale_started_at = datetime.now(timezone.utc) - timedelta(hours=2)
     stale.run_started_at = stale_started_at
     db_session.flush()
@@ -284,10 +291,12 @@ def test_mark_running_replaces_a_stale_running_mark(db_session: Session) -> None
         active_within=timedelta(hours=1),
     )
 
-    # Postcondition.
+    # Postcondition. The replacement is a new attempt: fresh start, fresh id.
     assert remarked is not None
     assert remarked.run_started_at is not None
     assert remarked.run_started_at > stale_started_at
+    assert remarked.run_id is not None
+    assert remarked.run_id != stale_run_id
 
 
 @pytest.mark.usefixtures("tenant_context")
@@ -635,6 +644,210 @@ def test_unless_granular_inserts_and_replaces_fallback_reports(
     assert replaced.trigger == CapabilityCheckTrigger.INDEXING_ATTEMPT
     assert replaced.report is not None
     assert replaced.report["check_results"][0]["check_id"] == "second"
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_fenced_completion_self_heals_a_retired_run(db_session: Session) -> None:
+    """
+    Verifies the fence preserves the self-heal: retirement keeps the attempt's
+    ``run_id``, so a run that was merely slow still lands its completion.
+    """
+    # Precondition. A RUNNING attempt, backdated and retired by the sweep.
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.GITLAB, commit=False)
+    credential_id = cc_pair.credential_id
+    marked = mark_capability_report_running(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.GITLAB,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        active_within=timedelta(hours=1),
+    )
+    assert marked is not None
+    run_id = marked.run_id
+    assert run_id is not None
+    marked.run_started_at = datetime.now(timezone.utc) - timedelta(hours=3)
+    db_session.flush()
+    retired = mark_stale_capability_runs_failed(
+        db_session, source=DocumentSource.GITLAB, stale_after=timedelta(hours=1)
+    )
+    assert retired == 1
+
+    # Under test.
+    completed = upsert_completed_capability_report(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.GITLAB,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        report=_report(credential_id, check_id="slow", source=DocumentSource.GITLAB),
+        run_id=run_id,
+    )
+
+    # Postcondition. The retired row still belonged to this attempt, so the
+    # fenced write lands and FAILED_TO_RUN heals to the real report.
+    assert completed is not None
+    assert completed.run_status == CapabilityReportRunStatus.COMPLETED
+    assert completed.report is not None
+    assert completed.report["check_results"][0]["check_id"] == "slow"
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_fenced_terminal_writes_cannot_touch_a_successor_attempt(
+    db_session: Session,
+) -> None:
+    """
+    Verifies the fence itself: once the scope is reclaimed by a new attempt,
+    the superseded attempt's completion and failure writes are discarded.
+    """
+    # Precondition. A stale RUNNING attempt reclaimed by a fresh one.
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.GITLAB, commit=False)
+    credential_id = cc_pair.credential_id
+    old = mark_capability_report_running(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.GITLAB,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        active_within=timedelta(hours=1),
+    )
+    assert old is not None
+    old_run_id = old.run_id
+    assert old_run_id is not None
+    old.run_started_at = datetime.now(timezone.utc) - timedelta(hours=3)
+    db_session.flush()
+    successor = mark_capability_report_running(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.GITLAB,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        active_within=timedelta(hours=1),
+    )
+    assert successor is not None
+    successor_run_id = successor.run_id
+
+    # Under test.
+    completed = upsert_completed_capability_report(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.GITLAB,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        report=_report(credential_id, check_id="old", source=DocumentSource.GITLAB),
+        run_id=old_run_id,
+    )
+    mark_capability_run_failed(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        run_id=old_run_id,
+    )
+
+    # Postcondition. Both writes no-op: the successor still owns the row and
+    # still reads as an in-flight run with no report.
+    assert completed is None
+    db_session.expire_all()
+    row = get_capability_report_row(db_session, credential_id, None)
+    assert row is not None
+    assert row.run_status == CapabilityReportRunStatus.RUNNING
+    assert row.run_id == successor_run_id
+    assert row.report is None
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_unless_granular_preserves_a_running_row(db_session: Session) -> None:
+    """
+    Verifies the recorder guard: a blocking validation that lands mid-run must
+    not overwrite the RUNNING mark, or the attempt's fenced completion would
+    be stranded.
+    """
+    # Precondition.
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
+    credential_id = cc_pair.credential_id
+    marked = mark_capability_report_running(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        active_within=timedelta(hours=1),
+    )
+    assert marked is not None
+    run_id = marked.run_id
+
+    # Under test.
+    result = upsert_completed_capability_report_unless_granular(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.CC_PAIR_VALIDATION,
+        report=_report(credential_id, check_id="fallback", is_fallback=True),
+    )
+
+    # Postcondition.
+    assert result is None
+    db_session.expire_all()
+    row = get_capability_report_row(db_session, credential_id, None)
+    assert row is not None
+    assert row.run_status == CapabilityReportRunStatus.RUNNING
+    assert row.run_id == run_id
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_recorder_write_clears_the_attempt_id(db_session: Session) -> None:
+    """
+    Verifies a landing recorder write leaves no attempt owning the row: the
+    stored ``run_id`` is nulled, and NULL is fail-closed against the previous
+    attempt's late fenced completion.
+    """
+    # Precondition. A retired attempt whose report-less row the recorder may
+    # overwrite (not granular, not RUNNING).
+    cc_pair = make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
+    credential_id = cc_pair.credential_id
+    marked = mark_capability_report_running(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        active_within=timedelta(hours=1),
+    )
+    assert marked is not None
+    old_run_id = marked.run_id
+    assert old_run_id is not None
+    mark_capability_run_failed(
+        db_session, credential_id=credential_id, connector_id=None, run_id=old_run_id
+    )
+
+    # Under test.
+    recorded = upsert_completed_capability_report_unless_granular(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.CC_PAIR_VALIDATION,
+        report=_report(credential_id, check_id="fallback", is_fallback=True),
+    )
+    late_completion = upsert_completed_capability_report(
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        source=DocumentSource.SLACK,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        report=_report(credential_id, check_id="late"),
+        run_id=old_run_id,
+    )
+
+    # Postcondition.
+    assert recorded is not None
+    assert recorded.run_id is None
+    assert late_completion is None
+    row = get_capability_report_row(db_session, credential_id, None)
+    assert row is not None
+    assert row.report is not None
+    assert row.report["check_results"][0]["check_id"] == "fallback"
 
 
 @pytest.mark.usefixtures("tenant_context")

--- a/backend/tests/external_dependency_unit/db/test_credential_capability.py
+++ b/backend/tests/external_dependency_unit/db/test_credential_capability.py
@@ -194,6 +194,7 @@ def test_mark_running_preserves_report_and_completion_keeps_start_time(
         source=DocumentSource.SLACK,
         trigger=CapabilityCheckTrigger.MANUAL,
         report=_report(credential_id, check_id="fresh"),
+        run_id=running.run_id,
     )
     assert completed is not None
     assert completed.run_status == CapabilityReportRunStatus.COMPLETED
@@ -326,7 +327,10 @@ def test_failed_run_mark_is_truthful_and_retriggerable(db_session: Session) -> N
 
     # Under test.
     mark_capability_run_failed(
-        db_session, credential_id=credential_id, connector_id=None
+        db_session,
+        credential_id=credential_id,
+        connector_id=None,
+        run_id=marked.run_id,
     )
 
     # Postcondition.
@@ -760,6 +764,75 @@ def test_fenced_terminal_writes_cannot_touch_a_successor_attempt(
     assert row.run_status == CapabilityReportRunStatus.RUNNING
     assert row.run_id == successor_run_id
     assert row.report is None
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_legacy_writes_match_only_unowned_rows(db_session: Session) -> None:
+    """
+    Verifies the transition fence: a pre-fence task (no ``run_id``) still lands
+    its terminal writes on its own pre-migration NULL mark, but cannot touch a
+    row claimed by a post-deploy attempt.
+    """
+    # Precondition.
+    # Two RUNNING marks; one crafted to look pre-migration.
+    legacy_pair = make_cc_pair(db_session, source=DocumentSource.GITLAB, commit=False)
+    claimed_pair = make_cc_pair(db_session, source=DocumentSource.GITLAB, commit=False)
+    for pair in (legacy_pair, claimed_pair):
+        marked = mark_capability_report_running(
+            db_session,
+            credential_id=pair.credential_id,
+            connector_id=None,
+            source=DocumentSource.GITLAB,
+            trigger=CapabilityCheckTrigger.MANUAL,
+            active_within=timedelta(hours=1),
+        )
+        assert marked is not None
+    legacy_row = get_capability_report_row(db_session, legacy_pair.credential_id, None)
+    assert legacy_row is not None
+    # Pre-migration marks carry no attempt id; craft one directly.
+    legacy_row.run_id = None
+    db_session.flush()
+
+    # Under test.
+    legacy_completion = upsert_completed_capability_report(
+        db_session,
+        credential_id=legacy_pair.credential_id,
+        connector_id=None,
+        source=DocumentSource.GITLAB,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        report=_report(
+            legacy_pair.credential_id, check_id="legacy", source=DocumentSource.GITLAB
+        ),
+    )
+    crossing_completion = upsert_completed_capability_report(
+        db_session,
+        credential_id=claimed_pair.credential_id,
+        connector_id=None,
+        source=DocumentSource.GITLAB,
+        trigger=CapabilityCheckTrigger.MANUAL,
+        report=_report(
+            claimed_pair.credential_id,
+            check_id="crossing",
+            source=DocumentSource.GITLAB,
+        ),
+    )
+    mark_capability_run_failed(
+        db_session, credential_id=claimed_pair.credential_id, connector_id=None
+    )
+
+    # Postcondition.
+    # The legacy write lands on its own NULL mark; both legacy writes against
+    # the claimed row no-op.
+    assert legacy_completion is not None
+    assert legacy_completion.run_status == CapabilityReportRunStatus.COMPLETED
+    assert crossing_completion is None
+    db_session.expire_all()
+    claimed_row = get_capability_report_row(
+        db_session, claimed_pair.credential_id, None
+    )
+    assert claimed_row is not None
+    assert claimed_row.run_status == CapabilityReportRunStatus.RUNNING
+    assert claimed_row.report is None
 
 
 @pytest.mark.usefixtures("tenant_context")

--- a/backend/tests/integration/tests/capability_checks/test_capability_check_run.py
+++ b/backend/tests/integration/tests/capability_checks/test_capability_check_run.py
@@ -12,7 +12,12 @@ from typing import Any
 
 from sqlalchemy import update
 
-from onyx.configs.constants import DocumentSource
+from onyx.background.celery.versioned_apps.client import app as client_app
+from onyx.configs.constants import (
+    DocumentSource,
+    OnyxCeleryPriority,
+    OnyxCeleryTask,
+)
 from onyx.connectors.capabilities import CredentialCapability
 from onyx.connectors.capability_checks.models import (
     CapabilityCheckStatus,
@@ -23,6 +28,7 @@ from onyx.db.credential_capability import mark_capability_report_running
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import CapabilityCheckTrigger, CapabilityReportRunStatus
 from onyx.db.models import CredentialCapabilityReportRow
+from shared_configs.contextvars import get_current_tenant_id
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.connector import ConnectorManager
@@ -46,10 +52,13 @@ def _report_url(credential_id: int) -> str:
     return f"{API_SERVER_URL}/manage/admin/credential/{credential_id}/capability-report"
 
 
-def _poll_until_completed(
-    credential_id: int, connector_id: int | None, headers: dict[str, str]
+def _poll_until_run_status(
+    credential_id: int,
+    connector_id: int | None,
+    headers: dict[str, str],
+    run_status: CapabilityReportRunStatus,
 ) -> dict[str, Any]:
-    """Polls the report GET until the run completes; the FE will do the same."""
+    """Polls the report GET until the run reaches ``run_status``, FE-style."""
     params = {} if connector_id is None else {"connector_id": connector_id}
     deadline = time.monotonic() + _RUN_COMPLETION_TIMEOUT_SECONDS
     while time.monotonic() < deadline:
@@ -58,15 +67,12 @@ def _poll_until_completed(
         )
         response.raise_for_status()
         snapshot = response.json()
-        if (
-            snapshot is not None
-            and snapshot["run_status"] == CapabilityReportRunStatus.COMPLETED.value
-        ):
+        if snapshot is not None and snapshot["run_status"] == run_status.value:
             return snapshot
         time.sleep(0.5)
     raise AssertionError(
-        f"Capability check run for credential {credential_id} did not complete "
-        f"within {_RUN_COMPLETION_TIMEOUT_SECONDS}s."
+        f"Capability check run for credential {credential_id} did not reach "
+        f"{run_status.value} within {_RUN_COMPLETION_TIMEOUT_SECONDS}s."
     )
 
 
@@ -90,7 +96,9 @@ def test_credential_scoped_run_completes_and_persists_a_report(
     assert accepted["trigger"] == CapabilityCheckTrigger.MANUAL.value
     assert accepted["run_started_at"] is not None
     assert accepted["report"] is None
-    completed = _poll_until_completed(credential.id, None, admin_user.headers)
+    completed = _poll_until_run_status(
+        credential.id, None, admin_user.headers, CapabilityReportRunStatus.COMPLETED
+    )
     assert completed["connector_config_hash"] is None
     report = completed["report"]
     assert report["connector_id"] is None
@@ -130,7 +138,12 @@ def test_connector_scoped_run_carries_the_config_hash(admin_user: DATestUser) ->
     # Postcondition.
     response.raise_for_status()
     assert response.json()["connector_id"] == connector.id
-    completed = _poll_until_completed(credential.id, connector.id, admin_user.headers)
+    completed = _poll_until_run_status(
+        credential.id,
+        connector.id,
+        admin_user.headers,
+        CapabilityReportRunStatus.COMPLETED,
+    )
     assert completed["connector_id"] == connector.id
     assert completed["connector_config_hash"] is not None
     assert completed["report"]["connector_id"] == connector.id
@@ -206,7 +219,9 @@ def test_stale_running_mark_is_replaced_and_the_run_proceeds(
     response.raise_for_status()
     snapshot = response.json()
     assert datetime.fromisoformat(snapshot["run_started_at"]) > stale_started_at
-    _poll_until_completed(credential.id, None, admin_user.headers)
+    _poll_until_run_status(
+        credential.id, None, admin_user.headers, CapabilityReportRunStatus.COMPLETED
+    )
 
 
 def test_config_without_connector_id_is_invalid_input(admin_user: DATestUser) -> None:
@@ -286,3 +301,62 @@ def test_trigger_requires_connector_management_permission(
     response = client.post(_check_url(1), json={}, headers=basic_user.headers)
     assert response.status_code == 403
     assert response.json()["error_code"] == "INSUFFICIENT_PERMISSIONS"
+
+
+def test_sweep_retires_a_dead_run_and_retrigger_recovers(
+    admin_user: DATestUser,
+) -> None:
+    # Precondition. A completed report, then a RUNNING mark backdated past any
+    # derived ceiling: a run that died without a trace.
+    credential = CredentialManager.create(
+        source=DocumentSource.MOCK_CONNECTOR, user_performing_action=admin_user
+    )
+    response = client.post(
+        _check_url(credential.id), json={}, headers=admin_user.headers
+    )
+    response.raise_for_status()
+    _poll_until_run_status(
+        credential.id, None, admin_user.headers, CapabilityReportRunStatus.COMPLETED
+    )
+    with get_session_with_current_tenant() as db_session:
+        row = mark_capability_report_running(
+            db_session,
+            credential_id=credential.id,
+            connector_id=None,
+            source=DocumentSource.MOCK_CONNECTOR,
+            trigger=CapabilityCheckTrigger.MANUAL,
+            active_within=timedelta(hours=1),
+        )
+        assert row is not None
+        db_session.execute(
+            update(CredentialCapabilityReportRow)
+            .where(CredentialCapabilityReportRow.id == row.id)
+            .values(run_started_at=datetime.now(timezone.utc) - timedelta(days=30))
+        )
+        db_session.commit()
+
+    # Under test. The sweep the beat schedule fires every ten minutes.
+    client_app.send_task(
+        OnyxCeleryTask.CHECK_FOR_STALE_CAPABILITY_RUNS,
+        kwargs=dict(tenant_id=get_current_tenant_id()),
+        priority=OnyxCeleryPriority.LOW,
+        expires=300,
+    )
+
+    # Postcondition. The dead run surfaces as FAILED_TO_RUN with the previous
+    # report still readable, and a re-trigger recovers the scope.
+    retired = _poll_until_run_status(
+        credential.id,
+        None,
+        admin_user.headers,
+        CapabilityReportRunStatus.FAILED_TO_RUN,
+    )
+    assert retired["report"] is not None
+    response = client.post(
+        _check_url(credential.id), json={}, headers=admin_user.headers
+    )
+    response.raise_for_status()
+    assert response.json()["run_status"] == CapabilityReportRunStatus.RUNNING.value
+    _poll_until_run_status(
+        credential.id, None, admin_user.headers, CapabilityReportRunStatus.COMPLETED
+    )

--- a/backend/tests/integration/tests/capability_checks/test_capability_check_run.py
+++ b/backend/tests/integration/tests/capability_checks/test_capability_check_run.py
@@ -306,8 +306,9 @@ def test_trigger_requires_connector_management_permission(
 def test_sweep_retires_a_dead_run_and_retrigger_recovers(
     admin_user: DATestUser,
 ) -> None:
-    # Precondition. A completed report, then a RUNNING mark backdated past any
-    # derived ceiling: a run that died without a trace.
+    # Precondition.
+    # A completed report, then a RUNNING mark backdated past any derived
+    # ceiling: a run that died without a trace.
     credential = CredentialManager.create(
         source=DocumentSource.MOCK_CONNECTOR, user_performing_action=admin_user
     )
@@ -315,9 +316,10 @@ def test_sweep_retires_a_dead_run_and_retrigger_recovers(
         _check_url(credential.id), json={}, headers=admin_user.headers
     )
     response.raise_for_status()
-    _poll_until_run_status(
+    completed = _poll_until_run_status(
         credential.id, None, admin_user.headers, CapabilityReportRunStatus.COMPLETED
     )
+    assert completed["report"] is not None
     with get_session_with_current_tenant() as db_session:
         row = mark_capability_report_running(
             db_session,
@@ -335,7 +337,8 @@ def test_sweep_retires_a_dead_run_and_retrigger_recovers(
         )
         db_session.commit()
 
-    # Under test. The sweep the beat schedule fires every ten minutes.
+    # Under test.
+    # The sweep the beat schedule fires every ten minutes.
     client_app.send_task(
         OnyxCeleryTask.CHECK_FOR_STALE_CAPABILITY_RUNS,
         kwargs=dict(tenant_id=get_current_tenant_id()),
@@ -343,15 +346,18 @@ def test_sweep_retires_a_dead_run_and_retrigger_recovers(
         expires=300,
     )
 
-    # Postcondition. The dead run surfaces as FAILED_TO_RUN with the previous
-    # report still readable, and a re-trigger recovers the scope.
+    # Postcondition.
+    # The dead run surfaces as FAILED_TO_RUN with the previous report preserved
+    # unchanged, and a re-trigger recovers the scope. Nothing runs between the
+    # two reads (the dead mark was crafted directly, with no task behind it), so
+    # equality is deterministic.
     retired = _poll_until_run_status(
         credential.id,
         None,
         admin_user.headers,
         CapabilityReportRunStatus.FAILED_TO_RUN,
     )
-    assert retired["report"] is not None
+    assert retired["report"] == completed["report"]
     response = client.post(
         _check_url(credential.id), json={}, headers=admin_user.headers
     )

--- a/backend/tests/unit/onyx/connectors/capability_checks/test_generate_capability_report.py
+++ b/backend/tests/unit/onyx/connectors/capability_checks/test_generate_capability_report.py
@@ -58,7 +58,8 @@ def _patch_runner_environment(
 ) -> MagicMock:
     """Stubs registry lookup and connector construction around the orchestrator.
 
-    Returns the ``instantiate_connector`` mock for call-shape assertions.
+    Returns the ``_instantiate_connector_isolated`` mock for call-shape
+    assertions.
     """
     monkeypatch.setattr(
         runner_module,
@@ -66,11 +67,12 @@ def _patch_runner_environment(
         MagicMock(return_value=MagicMock()),
     )
     # The instantiated connector must satisfy ``CapabilityCheckContext``'s
-    # isinstance validation, hence the spec.
-    instantiate = MagicMock(return_value=MagicMock(spec=BaseConnector))
+    # isinstance validation, hence the spec. The helper also returns the
+    # credential material as loaded on its own session.
+    instantiate = MagicMock(return_value=(MagicMock(spec=BaseConnector), {}))
     if instantiate_error is not None:
         instantiate.side_effect = instantiate_error
-    monkeypatch.setattr(runner_module, "instantiate_connector", instantiate)
+    monkeypatch.setattr(runner_module, "_instantiate_connector_isolated", instantiate)
     monkeypatch.setattr(
         runner_module, "get_capability_checks", MagicMock(return_value=checks)
     )
@@ -89,19 +91,17 @@ def test_configless_run_attempts_empty_config_instantiation(
     # Precondition.
     check = _CallableCheck(MagicMock(return_value=None), check_id="instance_check")
     instantiate = _patch_runner_environment(monkeypatch, [check])
-    db_session = MagicMock()
     credential = _make_credential()
 
     # Under test.
-    report = generate_capability_report(db_session, credential)
+    report = generate_capability_report(credential)
 
     # Postcondition.
     instantiate.assert_called_once_with(
-        db_session=db_session,
         source=DocumentSource.GITHUB,
         input_type=None,
         connector_specific_config={},
-        credential=credential,
+        credential_id=7,
     )
     assert report.credential_id == 7
     assert report.source == DocumentSource.GITHUB
@@ -136,7 +136,7 @@ def test_instantiation_failure_still_runs_credential_only_checks(
     )
 
     # Under test.
-    report = generate_capability_report(MagicMock(), _make_credential())
+    report = generate_capability_report(_make_credential())
 
     # Postcondition.
     statuses = {result.check_id: result.status for result in report.check_results}
@@ -161,7 +161,7 @@ def test_instantiation_failure_degrades_to_skip(
     )
 
     # Under test.
-    report = generate_capability_report(MagicMock(), _make_credential())
+    report = generate_capability_report(_make_credential())
 
     # Postcondition.
     assert report.check_results[0].status == CapabilityCheckStatus.SKIPPED
@@ -184,7 +184,6 @@ def test_supplied_config_instantiation_failure_is_surfaced(
 
     # Under test.
     report = generate_capability_report(
-        MagicMock(),
         _make_credential(),
         connector_specific_config={"channels": ["general"]},
         connector_id=42,
@@ -213,7 +212,6 @@ def test_real_config_unlocks_config_requiring_checks(
 
     # Under test.
     report = generate_capability_report(
-        MagicMock(),
         _make_credential(),
         connector_specific_config=connector_specific_config,
         connector_id=42,
@@ -263,7 +261,6 @@ def test_registered_gateway_is_constructed_and_reaches_checks(
 
     # Under test.
     generate_capability_report(
-        MagicMock(),
         _make_credential(),
         connector_specific_config=connector_specific_config,
     )
@@ -291,7 +288,7 @@ def test_unregistered_source_gets_no_gateway(
     _patch_runner_environment(monkeypatch, [check])
 
     # Under test.
-    generate_capability_report(MagicMock(), _make_credential())
+    generate_capability_report(_make_credential())
 
     # Postcondition.
     assert seen_contexts[0].source_operations is None
@@ -314,7 +311,7 @@ def test_report_decrypt_emits_a_credential_audit_event(
     credential.credential_json.get_value.return_value = {"token": "x"}
 
     # Under test.
-    generate_capability_report(MagicMock(), credential)
+    generate_capability_report(credential)
 
     # Postcondition.
     emit.assert_called_once_with(
@@ -335,7 +332,7 @@ def test_empty_credential_decrypts_nothing_and_emits_no_audit(
     monkeypatch.setattr(runner_module, "emit_credential_access", emit)
 
     # Under test.
-    generate_capability_report(MagicMock(), _make_credential())
+    generate_capability_report(_make_credential())
 
     # Postcondition.
     emit.assert_not_called()
@@ -357,7 +354,7 @@ def test_hung_instantiation_is_bounded_and_surfaces_indeterminate(
 
     # Under test.
     report = generate_capability_report(
-        MagicMock(), _make_credential(), connector_specific_config={"repo": "onyx"}
+        _make_credential(), connector_specific_config={"repo": "onyx"}
     )
 
     # Postcondition. The supplied-config timeout surfaces on the

--- a/backend/tests/unit/onyx/connectors/capability_checks/test_generate_capability_report.py
+++ b/backend/tests/unit/onyx/connectors/capability_checks/test_generate_capability_report.py
@@ -1,3 +1,4 @@
+import time
 from collections.abc import Callable
 from unittest.mock import MagicMock
 
@@ -338,3 +339,29 @@ def test_empty_credential_decrypts_nothing_and_emits_no_audit(
 
     # Postcondition.
     emit.assert_not_called()
+
+
+def test_hung_instantiation_is_bounded_and_surfaces_indeterminate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verifies the instantiation guard: a hang cannot outlive its budget.
+
+    The run ceiling budgets one default guard for instantiation, and the
+    stale-run sweep trusts that ceiling, so the guard must be enforced.
+    """
+    # Precondition. Construction blocks far past the shrunken guard.
+    check = _CallableCheck(MagicMock(return_value=None), check_id="instance_check")
+    instantiate = _patch_runner_environment(monkeypatch, [check])
+    instantiate.side_effect = lambda **_kwargs: time.sleep(0.5)
+    monkeypatch.setattr(runner_module, "CAPABILITY_CHECK_TIMEOUT_SECONDS", 0.05)
+
+    # Under test.
+    report = generate_capability_report(
+        MagicMock(), _make_credential(), connector_specific_config={"repo": "onyx"}
+    )
+
+    # Postcondition. The supplied-config timeout surfaces on the
+    # instance-requiring check as INDETERMINATE, per the check contract.
+    (result,) = report.check_results
+    assert result.status == CapabilityCheckStatus.INDETERMINATE
+    assert result.error_type == "TimeoutError"

--- a/backend/tests/unit/onyx/connectors/capability_checks/test_generate_capability_report.py
+++ b/backend/tests/unit/onyx/connectors/capability_checks/test_generate_capability_report.py
@@ -346,7 +346,8 @@ def test_hung_instantiation_is_bounded_and_surfaces_indeterminate(
     The run ceiling budgets one default guard for instantiation, and the
     stale-run sweep trusts that ceiling, so the guard must be enforced.
     """
-    # Precondition. Construction blocks far past the shrunken guard.
+    # Precondition.
+    # Construction blocks far past the shrunken guard.
     check = _CallableCheck(MagicMock(return_value=None), check_id="instance_check")
     instantiate = _patch_runner_environment(monkeypatch, [check])
     instantiate.side_effect = lambda **_kwargs: time.sleep(0.5)
@@ -357,8 +358,9 @@ def test_hung_instantiation_is_bounded_and_surfaces_indeterminate(
         _make_credential(), connector_specific_config={"repo": "onyx"}
     )
 
-    # Postcondition. The supplied-config timeout surfaces on the
-    # instance-requiring check as INDETERMINATE, per the check contract.
+    # Postcondition.
+    # The supplied-config timeout surfaces on the instance-requiring check as
+    # INDETERMINATE, per the check contract.
     (result,) = report.check_results
     assert result.status == CapabilityCheckStatus.INDETERMINATE
     assert result.error_type == "TimeoutError"

--- a/backend/tests/unit/onyx/connectors/capability_checks/test_run_ceiling.py
+++ b/backend/tests/unit/onyx/connectors/capability_checks/test_run_ceiling.py
@@ -1,0 +1,55 @@
+"""Unit tests for the derived capability-run ceilings."""
+
+from datetime import timedelta
+
+import pytest
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.capabilities import CredentialCapability
+from onyx.connectors.capability_checks import runner
+from onyx.connectors.capability_checks.models import (
+    CapabilityCheck,
+    CapabilityCheckContext,
+)
+
+
+class _StubCheck(CapabilityCheck):
+    def run(self, context: CapabilityCheckContext) -> None:  # noqa: ARG002
+        raise AssertionError("Ceiling math must not execute checks.")
+
+
+def test_ceiling_sums_distinct_guards_once_plus_instantiation_slack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Precondition. Two capabilities mirror one check (a single execution at
+    # run time), plus one check on the default hang guard.
+    checks = [
+        _StubCheck(
+            capability=CredentialCapability.DOC_PERMISSION_SYNC,
+            check_id="mirrored",
+            display_name="Mirrored",
+            timeout_seconds=100,
+        ),
+        _StubCheck(
+            capability=CredentialCapability.EXTERNAL_GROUP_SYNC,
+            check_id="mirrored",
+            display_name="Mirrored",
+            timeout_seconds=100,
+        ),
+        _StubCheck(
+            capability=CredentialCapability.INDEXING,
+            check_id="default_guard",
+            display_name="Default guard",
+        ),
+    ]
+    monkeypatch.setattr(runner, "get_capability_checks", lambda _source: checks)
+
+    # Under test.
+    ceiling = runner.capability_check_run_ceiling_seconds(DocumentSource.SLACK)
+    stale_after = runner.capability_check_run_stale_after(DocumentSource.SLACK)
+
+    # Postcondition. One slack unit for instantiation, the mirrored guard
+    # counted once, and one default guard; staleness allows queue wait plus
+    # execution.
+    assert ceiling == 2 * runner.CAPABILITY_CHECK_TIMEOUT_SECONDS + 100
+    assert stale_after == timedelta(seconds=2 * ceiling)

--- a/backend/tests/unit/onyx/connectors/capability_checks/test_run_ceiling.py
+++ b/backend/tests/unit/onyx/connectors/capability_checks/test_run_ceiling.py
@@ -21,8 +21,9 @@ class _StubCheck(CapabilityCheck):
 def test_ceiling_sums_distinct_guards_once_plus_instantiation_slack(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Precondition. Two capabilities mirror one check (a single execution at
-    # run time), plus one check on the default hang guard.
+    # Precondition.
+    # Two capabilities mirror one check (a single execution at run time), plus
+    # one check on the default hang guard.
     checks = [
         _StubCheck(
             capability=CredentialCapability.DOC_PERMISSION_SYNC,
@@ -48,8 +49,8 @@ def test_ceiling_sums_distinct_guards_once_plus_instantiation_slack(
     ceiling = runner.capability_check_run_ceiling_seconds(DocumentSource.SLACK)
     stale_after = runner.capability_check_run_stale_after(DocumentSource.SLACK)
 
-    # Postcondition. One slack unit for instantiation, the mirrored guard
-    # counted once, and one default guard; staleness allows queue wait plus
-    # execution.
+    # Postcondition.
+    # One slack unit for instantiation, the mirrored guard counted once, and one
+    # default guard; staleness allows queue wait plus execution.
     assert ceiling == 2 * runner.CAPABILITY_CHECK_TIMEOUT_SECONDS + 100
     assert stale_after == timedelta(seconds=2 * ceiling)


### PR DESCRIPTION
## Description

Third of the three PRs (endpoints, trigger + task, recovery), follows #14053. A capability run that crashes or expires leaves its row RUNNING; until now only the re-trigger guard's crude 1h constant un-bricked it, and nothing ever told a polling client the run died. This PR resolves the plan's open decision (lazy recovery at POST time vs a beat sweep) in favor of the sweep: a re-trigger immediately re-marks the scope RUNNING, so lazy recovery could never surface FAILED_TO_RUN to a poller; only a sweep makes a dead run visible without user action.

- The sweep writer, mark_stale_capability_runs_failed, retires RUNNING rows older than their cutoff via one bulk UPDATE that touches only the lifecycle fields, so the stored report (the last completed run) stays readable. The cutoff is evaluated by Postgres at statement time, mirroring the mark's guard, so a concurrently re-marked scope is never retired.
- A run that fails gracefully writes FAILED_TO_RUN itself (the task's except path) and re-raises, so pollers see the failure immediately instead of waiting out the staleness window; only hard kills and expired tasks are left for the sweep.
- check_for_stale_capability_runs sweeps every 10 minutes (beat, LOW priority, default celery queue on the primary worker), iterating only the sources that currently have a RUNNING row.
- Derived ceiling replaces 9b's crude 6x600s constant: capability_check_run_ceiling_seconds(source) = sum of the distinct per-check hang guards (mirrored checks execute once, so they count once) plus one default guard for the un-guarded work around checks (connector instantiation can itself probe the source).
- Staleness cutoff = 2x the ceiling: the RUNNING mark is set at trigger time, queue wait is bounded by the task expiry (now one ceiling), execution by another. POST's re-trigger guard and the task expires= both use the derived values; for a single-check source this tightens re-triggering from 1h to 40min, and many-check sources get an honest larger bound instead of a false one.
- Retirement self-heals: a run that was merely slow and completes after being retired overwrites FAILED_TO_RUN with its report, because the completion write is unconditional.
- A retired scope is immediately re-triggerable (FAILED_TO_RUN passes the guard), and the row is a signal for the FE to stop polling and offer a re-run.
- Connector instantiation runs on a session owned by the guarded thread: run_with_timeout abandons its thread on timeout, and instantiation can commit a credential token refresh (google_drive, gmail, linear), so an abandoned thread must not share the caller's session. The post-refresh credential material is what reaches the checks.
- The task no longer holds one transaction across the run: setup reads close their session before the probes start (probes can run up to the ceiling, and an open transaction holds its pooled connection and read locks), and the report upsert opens its own.

## How Has This Been Tested?

- Tests: unit tests for the ceiling arithmetic (mirrored-once + slack) and the enforced instantiation guard; accessor tests for selective retirement (stale retired with report preserved, fresh RUNNING and COMPLETED untouched, retired scope re-marks) and the distinct-source work list; integration e2e of the full loop: completed report -> backdated dead RUNNING mark -> sweep via the real broker -> GET shows failed_to_run with the previous report unchanged -> re-trigger runs to completion.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers stuck capability check runs so pollers see terminal states instead of dead `RUNNING` rows. Old behavior left crashed or expired runs `RUNNING` behind a crude 1h guard; new behavior derives per-source run ceilings, records failures on task exceptions, and sweeps stale `RUNNING` marks to `FAILED_TO_RUN`.

- Adds the `check_for_stale_capability_runs` beat task (every 10 minutes, LOW priority) and loads `onyx.background.celery.tasks.capability_checks` in the primary app.
- Derives per-source run bounds (`capability_check_run_ceiling_seconds`, `capability_check_run_stale_after`) and uses them in the trigger POST and task expiry.
- Stamps a fresh `run_id` per attempt; completion and failure writes are fenced on it, so a superseded attempt can't mislabel its successor, and retirement preserves it so slow runs can self-heal.
- Instantiates connectors on an isolated session under a timeout, so refreshed tokens reach checks; task exceptions mark `FAILED_TO_RUN` immediately, while hard kills rely on the sweep.
- Capability endpoints now depend on `require_vector_db`, so Lite skips them; GET can return `FAILED_TO_RUN` with the last report intact, and POST is allowed right after retirement.

**Migration**
- Adds a nullable `run_id` column to `credential_capability_report`; no backfill needed.

**Rollout**
- Ensure the primary worker runs beat and the default queue so the sweep executes.
- Watch logs for "Retired N stale capability run(s) for source …" to confirm recovery is active.

<sup>Written for commit 870537cf6b03a68cd6c2967aabda484e80795f76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


