### PR TITLE
feat(ods): print the deployment run URL after `ods release cloud`

### DIFF
--- a/tools/ods/cmd/deploy_common.go
+++ b/tools/ods/cmd/deploy_common.go
@@ -15,12 +15,20 @@ import (
 )
 
 const (
+	// The repo whose deployment.yml builds images on tag pushes, shared by the
+	// deploy and release commands.
+	onyxRepo               = "onyx-dot-app/onyx"
+	deploymentWorkflowFile = "deployment.yml"
+
 	// Polling configuration shared by the deploy subcommands. The "discover"
 	// phase polls fast for a short window because a run usually appears within
 	// seconds of pushing the tag / dispatching the workflow.
 	runDiscoveryInterval = 5 * time.Second
 	runDiscoveryTimeout  = 2 * time.Minute
 	runProgressInterval  = 30 * time.Second
+
+	// Build runs typically take 20-30 minutes.
+	buildPollTimeout = 60 * time.Minute
 )
 
 // resolveDeployTarget returns the deploy target repo and workflow to use,

--- a/tools/ods/cmd/deploy_edge.go
+++ b/tools/ods/cmd/deploy_edge.go
@@ -12,12 +12,9 @@ import (
 )
 
 const (
-	onyxRepo               = "onyx-dot-app/onyx"
-	deploymentWorkflowFile = "deployment.yml"
-	edgeTagName            = "edge"
+	edgeTagName = "edge"
 
-	// Build runs typically take 20-30 minutes; deploys are much shorter.
-	buildPollTimeout  = 60 * time.Minute
+	// Deploys are much shorter than the builds they follow.
 	deployPollTimeout = 30 * time.Minute
 )
 

--- a/tools/ods/cmd/release_cloud.go
+++ b/tools/ods/cmd/release_cloud.go
@@ -130,9 +130,9 @@ func releaseCloud(opts *ReleaseCloudOptions) (string, error) {
 	return tag, nil
 }
 
-// announceCloudRun looks up the deployment.yml run triggered by pushing tag
-// and prints its URL. The lookup is best-effort: the tag is already pushed and
-// the build runs regardless, so failures only warn.
+// announceCloudRun looks up the deployment.yml run triggered by pushing tag and
+// prints its URL. The lookup is best-effort: the tag is already pushed and the
+// build runs regardless, so failures only warn.
 func announceCloudRun(tag string) {
 	log.Info("Looking up the deployment run...")
 	run, err := waitForNewRun(onyxRepo, deploymentWorkflowFile, "push", tag, 0)

--- a/tools/ods/cmd/release_cloud.go
+++ b/tools/ods/cmd/release_cloud.go
@@ -41,6 +41,10 @@ for the same base, starting at 0.
 
 Pushing the tag triggers deployment.yml, which builds the cloud images.
 
+After the push, the command looks up the triggered deployment run via the gh
+CLI and prints its URL. The lookup is best-effort: if gh is missing or the
+run cannot be found, the release still succeeds.
+
 Example usage:
 
     $ ods release cloud
@@ -50,7 +54,12 @@ Example usage:
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return releaseCloud(opts)
+			tag, err := releaseCloud(opts)
+			if err != nil || tag == "" {
+				return err
+			}
+			announceCloudRun(tag)
+			return nil
 		},
 	}
 
@@ -63,15 +72,18 @@ Example usage:
 	return cmd
 }
 
-func releaseCloud(opts *ReleaseCloudOptions) error {
+// releaseCloud computes and pushes the next cloud tag. It returns the pushed
+// tag name, or an empty string when nothing was pushed (dry run, declined
+// prompt, or any failure).
+func releaseCloud(opts *ReleaseCloudOptions) (string, error) {
 	if opts.Version != "" && !bareSemverRe.MatchString(opts.Version) {
-		return fmt.Errorf("--version must be X.Y.Z with no leading v, got %q", opts.Version)
+		return "", fmt.Errorf("--version must be X.Y.Z with no leading v, got %q", opts.Version)
 	}
 
 	// Deployment tags must be cut against origin's current state.
 	log.Info("Fetching main and cloud tags from origin...")
 	if err := git.RunCommand("fetch", "--quiet", "--force", "origin", "+refs/heads/main:refs/remotes/origin/main"); err != nil {
-		return fmt.Errorf("failed to fetch origin/main: %w", err)
+		return "", fmt.Errorf("failed to fetch origin/main: %w", err)
 	}
 	// Best-effort: a failure here only leaves the counter stale, which is safe.
 	// If the computed tag already exists on origin, the push (which is never
@@ -82,29 +94,29 @@ func releaseCloud(opts *ReleaseCloudOptions) error {
 
 	sha, err := resolveCommit(opts.Ref)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	tag, err := computeCloudTag(sha, opts.Version)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	if opts.DryRun {
 		log.Warnf("[DRY RUN] Would tag %.10s as %s and push", sha, tag)
 		fmt.Println(tag)
-		return nil
+		return "", nil
 	}
 
 	if !opts.Yes {
 		if !prompt.Confirm(fmt.Sprintf("Tag %.10s as %s and push to trigger the cloud build? (Y/n): ", sha, tag)) {
 			log.Info("Exiting...")
-			return nil
+			return "", nil
 		}
 	}
 
 	if err := git.RunCommand("tag", tag, sha); err != nil {
-		return fmt.Errorf("failed to create tag %s: %w", tag, err)
+		return "", fmt.Errorf("failed to create tag %s: %w", tag, err)
 	}
 	if err := git.PushTag(tag, false, opts.Verify); err != nil {
 		// Roll back the local tag so the command stays retryable after a failed
@@ -112,10 +124,25 @@ func releaseCloud(opts *ReleaseCloudOptions) error {
 		if delErr := git.RunCommand("tag", "-d", tag); delErr != nil {
 			log.Warnf("Also failed to delete local tag %s; remove it before retrying: %v", tag, delErr)
 		}
-		return fmt.Errorf("failed to push tag %s: %w", tag, err)
+		return "", fmt.Errorf("failed to push tag %s: %w", tag, err)
 	}
 	log.Infof("Pushed %s; deployment.yml will build the cloud images.", tag)
-	return nil
+	return tag, nil
+}
+
+// announceCloudRun looks up the deployment.yml run triggered by pushing tag
+// and prints its URL. The lookup is best-effort: the tag is already pushed and
+// the build runs regardless, so failures only warn.
+func announceCloudRun(tag string) {
+	log.Info("Looking up the deployment run...")
+	run, err := waitForNewRun(onyxRepo, deploymentWorkflowFile, "push", tag, 0)
+	if err != nil {
+		log.Warnf("Could not find the deployment run for %s: %v", tag, err)
+		log.Warnf("Find it at https://github.com/%s/actions/workflows/%s", onyxRepo, deploymentWorkflowFile)
+		return
+	}
+	log.Infof("Deployment run: %s", run.URL)
+	fmt.Println(run.URL)
 }
 
 // computeCloudTag returns the next cloud tag for commitSHA. The base version is

--- a/tools/ods/cmd/release_cloud_test.go
+++ b/tools/ods/cmd/release_cloud_test.go
@@ -32,10 +32,14 @@ package cmd
 //
 // Command states (releaseCloud):
 //
-//	E1 dry run                               -> prints tag, creates nothing     TestReleaseCloud_dryRunCreatesNothing
-//	E2 real run                              -> tag on origin at origin/main    TestReleaseCloud_tagsOriginMainHead
-//	E3 push rejected by origin               -> local tag rolled back           TestReleaseCloud_pushFailureRollsBackLocalTag
-//	E4 counter tag only on origin            -> fetched, counter continues      TestReleaseCloud_fetchesRemoteOnlyCounterTags
+//	E1 dry run                               -> prints tag, creates nothing,
+//	                                            returns no pushed tag           TestReleaseCloud_dryRunCreatesNothing
+//	E2 real run                              -> tag on origin at origin/main,
+//	                                            tag name returned               TestReleaseCloud_tagsOriginMainHead
+//	E3 push rejected by origin               -> local tag rolled back,
+//	                                            returns no pushed tag           TestReleaseCloud_pushFailureRollsBackLocalTag
+//	E4 counter tag only on origin            -> fetched, counter continues,
+//	                                            tag name returned               TestReleaseCloud_fetchesRemoteOnlyCounterTags
 //	E5 --version with leading zeroes         -> rejected before any git work    TestReleaseCloud_rejectsLeadingZeroVersion
 
 import (
@@ -280,11 +284,14 @@ func TestReleaseCloud_dryRunCreatesNothing(t *testing.T) {
 	repo := setupReleaseBranchRepo(t)
 
 	// Under test.
-	err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", DryRun: true, Yes: true})
+	tag, err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", DryRun: true, Yes: true})
 
 	// Postcondition.
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "" {
+		t.Errorf("dry run must return no pushed tag, got %q", tag)
 	}
 	if tagExistsIn(repo.work, "v4.6.0-cloud.0") || tagExistsIn(repo.origin, "v4.6.0-cloud.0") {
 		t.Error("dry run must not create the tag")
@@ -296,11 +303,14 @@ func TestReleaseCloud_tagsOriginMainHead(t *testing.T) {
 	repo := setupReleaseBranchRepo(t)
 
 	// Under test.
-	err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", Yes: true})
+	tag, err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", Yes: true})
 
 	// Postcondition.
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v4.6.0-cloud.0" {
+		t.Errorf("expected pushed tag v4.6.0-cloud.0, got %q", tag)
 	}
 	taggedSHA := gitIn(t, repo.origin, "rev-parse", "refs/tags/v4.6.0-cloud.0^{commit}")
 	if taggedSHA != repo.postCutSHA {
@@ -318,11 +328,14 @@ func TestReleaseCloud_fetchesRemoteOnlyCounterTags(t *testing.T) {
 	gitIn(t, repo.work, "tag", "-d", "v4.6.0-cloud.3")
 
 	// Under test.
-	err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", Yes: true})
+	tag, err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", Yes: true})
 
 	// Postcondition.
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v4.6.0-cloud.4" {
+		t.Errorf("expected pushed tag v4.6.0-cloud.4, got %q", tag)
 	}
 	if !tagExistsIn(repo.origin, "v4.6.0-cloud.4") {
 		t.Error("expected v4.6.0-cloud.4 on origin")
@@ -336,7 +349,7 @@ func TestReleaseCloud_rejectsLeadingZeroVersion(t *testing.T) {
 
 	// Under test and postcondition.
 	for _, version := range []string{"04.6.0", "4.06.0", "4.6.00"} {
-		err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", Version: version, DryRun: true, Yes: true})
+		_, err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", Version: version, DryRun: true, Yes: true})
 		if err == nil || !strings.Contains(err.Error(), "--version must be X.Y.Z") {
 			t.Errorf("expected validation error for %q, got %v", version, err)
 		}
@@ -352,11 +365,14 @@ func TestReleaseCloud_pushFailureRollsBackLocalTag(t *testing.T) {
 	}
 
 	// Under test.
-	err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", Yes: true})
+	tag, err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", Yes: true})
 
 	// Postcondition.
 	if err == nil || !strings.Contains(err.Error(), "failed to push") {
 		t.Errorf("expected push failure, got %v", err)
+	}
+	if tag != "" {
+		t.Errorf("failed push must return no pushed tag, got %q", tag)
 	}
 	if tagExistsIn(repo.work, "v4.6.0-cloud.0") {
 		t.Error("local tag must be rolled back after a failed push")


### PR DESCRIPTION
## Description

- After pushing the tag, look up the deployment.yml run it triggered (gh run list by workflow + tag name) and print its URL.
- Best-effort: if gh is missing or the run is not found, warn and exit 0; the release itself already succeeded.
- releaseCloud now returns the pushed tag; the gh lookup lives in the cobra RunE, so the tests stay git-only.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prints the GitHub Actions deployment run URL after `ods release cloud` pushes a tag, so operators can jump to the build. Previously the command exited after the push; now it best-effort finds the `deployment.yml` run via `gh` and prints its URL without affecting the release if lookup fails.

- `releaseCloud` now returns the pushed tag (string) or an empty string when nothing was pushed (dry run, declined prompt, or failure); the `gh` lookup runs in the Cobra `RunE`.
- Lookup is best-effort: if `gh` is missing or no run is found, we warn, succeed, and print a fallback link to the workflow list.
- Shared constants for repo/workflow (`onyx-dot-app/onyx`, `deployment.yml`) and `buildPollTimeout` moved to `deploy_common.go`; duplicates removed from `deploy_edge.go`.
- Tests updated to assert the returned tag and preserve git-only behavior (no `gh` dependency).

<sup>Written for commit 071e671726d9b19c52135d89f2c5a6af1ec684d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


