### PR TITLE
feat(ods): watch the cloud release build and print the bump PR

### DIFF
--- a/tools/ods/cmd/deploy_common.go
+++ b/tools/ods/cmd/deploy_common.go
@@ -27,8 +27,9 @@ const (
 	runDiscoveryTimeout  = 2 * time.Minute
 	runProgressInterval  = 30 * time.Second
 
-	// Build runs typically take 20-30 minutes.
-	buildPollTimeout = 60 * time.Minute
+	// Build runs typically take 15-30 minutes. The ceiling is hang detection:
+	// the workflow runs staged jobs that each get up to 90 minutes.
+	buildPollTimeout = 120 * time.Minute
 )
 
 // resolveDeployTarget returns the deploy target repo and workflow to use,

--- a/tools/ods/cmd/release_cloud.go
+++ b/tools/ods/cmd/release_cloud.go
@@ -21,6 +21,7 @@ type ReleaseCloudOptions struct {
 	DryRun  bool
 	Yes     bool
 	Verify  bool
+	NoWatch bool
 }
 
 // NewReleaseCloudCommand creates the `ods release cloud` command.
@@ -41,16 +42,19 @@ for the same base, starting at 0.
 
 Pushing the tag triggers deployment.yml, which builds the cloud images.
 
-After the push, the command looks up the triggered deployment run via the gh
-CLI and prints its URL. The lookup is best-effort: if gh is missing or the
-run cannot be found, the release still succeeds.
+After the push, the command prints the URL of that deployment run, waits for
+it to finish, and then prints the URL of the version bump PR that the infra
+repo opens for the new tag. All of this is read-only polling through the gh
+CLI: Ctrl-C is safe at any point (the tag is already pushed). Pass --no-watch
+to print the run URL and exit immediately.
 
 Example usage:
 
     $ ods release cloud
     $ ods release cloud --dry-run
     $ ods release cloud --ref 1a2b3c4d
-    $ ods release cloud --version 5.0.0`,
+    $ ods release cloud --version 5.0.0
+    $ ods release cloud --no-watch`,
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -58,8 +62,12 @@ Example usage:
 			if err != nil || tag == "" {
 				return err
 			}
-			announceCloudRun(tag)
-			return nil
+			if opts.NoWatch {
+				announceCloudRun(tag)
+				return nil
+			}
+			log.Info("Watching the release; Ctrl-C is safe, the tag is already pushed.")
+			return watchCloudRelease(tag)
 		},
 	}
 
@@ -68,6 +76,7 @@ Example usage:
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Compute and print the tag but don't tag or push")
 	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip the confirmation prompt")
 	cmd.Flags().BoolVar(&opts.Verify, "verify", false, "Run pre-push hooks when pushing the tag; they are skipped by default")
+	cmd.Flags().BoolVar(&opts.NoWatch, "no-watch", false, "Print the deployment run URL and exit instead of watching for the bump PR")
 
 	return cmd
 }

--- a/tools/ods/cmd/release_watch.go
+++ b/tools/ods/cmd/release_watch.go
@@ -18,9 +18,14 @@ const (
 	// The bump workflow opens its PR from the branch bump-version/<tag>.
 	bumpPRBranchPrefix = "bump-version/"
 
+	// The deployment.yml job that sends the new-cloud-image dispatch; its
+	// success means the bump workflow was triggered.
+	dispatchJobName = "dispatch-cloud-deployment"
+
 	// The bump workflow usually opens the PR within a few minutes of the
-	// dispatch at the end of the build; its own timeout is 15 minutes.
-	bumpPRDiscoveryTimeout = 10 * time.Minute
+	// dispatch at the end of the build. The window covers its 15-minute job
+	// timeout plus runner queue delay.
+	bumpPRDiscoveryTimeout = 20 * time.Minute
 	bumpPRPollInterval     = 15 * time.Second
 )
 
@@ -30,6 +35,9 @@ const (
 // interrupting or re-running it is always safe.
 func watchCloudRelease(tag string) error {
 	log.Info("Looking up the deployment run...")
+	// A cloud tag is unique per push and never reused, so any run on this
+	// branch is the right one. A prior-run-id floor above 0 would also break
+	// re-attaching to runs that started before newer releases.
 	run, err := waitForNewRun(onyxRepo, deploymentWorkflowFile, "push", tag, 0)
 	if err != nil {
 		return fmt.Errorf(
@@ -40,15 +48,26 @@ func watchCloudRelease(tag string) error {
 	fmt.Println(run.URL)
 
 	// A failed or timed-out run does not always mean no PR: the dispatch job
-	// can succeed while an unrelated job fails, and the bump workflow can also
-	// be dispatched manually. Check once for the PR before giving up.
+	// can succeed while an unrelated job fails. Whether that job succeeded
+	// decides if a PR is worth waiting for.
 	if buildErr := waitForRunCompletion(onyxRepo, run.DatabaseID, buildPollTimeout, "build"); buildErr != nil {
 		log.Warnf("Deployment run did not succeed: %v", buildErr)
-		pr, err := findBumpPR(tag)
-		if err != nil || pr == nil {
+		dispatched, err := dispatchJobSucceeded(run.DatabaseID)
+		if err != nil {
+			log.Warnf("Could not check the bump dispatch job: %v", err)
 			return buildErr
 		}
-		log.Warn("A bump PR exists anyway; review the run before approving.")
+		if !dispatched {
+			log.Warn("The bump dispatch has not succeeded, so a bump PR is not expected.")
+			return buildErr
+		}
+		log.Info("The bump dispatch succeeded; waiting for the bump PR...")
+		pr, err := waitForBumpPR(tag)
+		if err != nil {
+			log.Warnf("Bump PR lookup failed: %v", err)
+			return buildErr
+		}
+		log.Warn("The deployment run did not succeed; review it before approving.")
 		log.Infof("Bump PR: %s", pr.URL)
 		fmt.Println(pr.URL)
 		return nil
@@ -81,6 +100,39 @@ func waitForBumpPR(tag string) (*pullRequest, error) {
 		}
 		time.Sleep(bumpPRPollInterval)
 	}
+}
+
+// dispatchJobSucceeded reports whether the run's bump dispatch job concluded
+// successfully. A job that is missing, skipped, or still running counts as
+// not dispatched.
+func dispatchJobSucceeded(runID int64) (bool, error) {
+	cmd := exec.Command(
+		"gh", "run", "view", fmt.Sprintf("%d", runID),
+		"-R", onyxRepo,
+		"--json", "jobs",
+	)
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return false, fmt.Errorf("gh run view failed: %w: %s", err, string(exitErr.Stderr))
+		}
+		return false, fmt.Errorf("gh run view failed: %w", err)
+	}
+	var run struct {
+		Jobs []struct {
+			Name       string `json:"name"`
+			Conclusion string `json:"conclusion"`
+		} `json:"jobs"`
+	}
+	if err := json.Unmarshal(output, &run); err != nil {
+		return false, fmt.Errorf("failed to parse gh run view output: %w", err)
+	}
+	for _, job := range run.Jobs {
+		if job.Name == dispatchJobName {
+			return job.Conclusion == "success", nil
+		}
+	}
+	return false, nil
 }
 
 // pullRequest is a partial representation of a gh pr list JSON entry.

--- a/tools/ods/cmd/release_watch.go
+++ b/tools/ods/cmd/release_watch.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// Mirrors the CLOUD_DEPLOYMENT_REPO repo variable that deployment.yml's
+	// dispatch-cloud-deployment job sends the new-cloud-image dispatch to.
+	cloudDeploymentRepo = "onyx-dot-app/onyx-infra"
+	// The workflow in cloudDeploymentRepo that opens the version bump PR.
+	bumpWorkflowFile = "bump-cloud-version.yml"
+	// The bump workflow opens its PR from the branch bump-version/<tag>.
+	bumpPRBranchPrefix = "bump-version/"
+
+	// The bump workflow usually opens the PR within a few minutes of the
+	// dispatch at the end of the build; its own timeout is 15 minutes.
+	bumpPRDiscoveryTimeout = 10 * time.Minute
+	bumpPRPollInterval     = 15 * time.Second
+)
+
+// watchCloudRelease follows the release pipeline of an already-pushed cloud
+// tag: the deployment.yml build, then the bump PR that the dispatched bump
+// workflow opens in the infra repo. Everything here is read-only polling, so
+// interrupting or re-running it is always safe.
+func watchCloudRelease(tag string) error {
+	log.Info("Looking up the deployment run...")
+	run, err := waitForNewRun(onyxRepo, deploymentWorkflowFile, "push", tag, 0)
+	if err != nil {
+		return fmt.Errorf(
+			"could not find the deployment run for %s (see https://github.com/%s/actions/workflows/%s): %w",
+			tag, onyxRepo, deploymentWorkflowFile, err)
+	}
+	log.Infof("Deployment run: %s", run.URL)
+	fmt.Println(run.URL)
+
+	// A failed or timed-out run does not always mean no PR: the dispatch job
+	// can succeed while an unrelated job fails, and the bump workflow can also
+	// be dispatched manually. Check once for the PR before giving up.
+	if buildErr := waitForRunCompletion(onyxRepo, run.DatabaseID, buildPollTimeout, "build"); buildErr != nil {
+		log.Warnf("Deployment run did not succeed: %v", buildErr)
+		pr, err := findBumpPR(tag)
+		if err != nil || pr == nil {
+			return buildErr
+		}
+		log.Warn("A bump PR exists anyway; review the run before approving.")
+		log.Infof("Bump PR: %s", pr.URL)
+		fmt.Println(pr.URL)
+		return nil
+	}
+
+	log.Info("Build completed; waiting for the bump PR...")
+	pr, err := waitForBumpPR(tag)
+	if err != nil {
+		return fmt.Errorf("%w; check https://github.com/%s/actions/workflows/%s", err, cloudDeploymentRepo, bumpWorkflowFile)
+	}
+	log.Infof("Bump PR ready for approval: %s", pr.URL)
+	fmt.Println(pr.URL)
+	return nil
+}
+
+// waitForBumpPR polls until the bump PR for tag exists or the discovery
+// timeout fires.
+func waitForBumpPR(tag string) (*pullRequest, error) {
+	deadline := time.Now().Add(bumpPRDiscoveryTimeout)
+	for {
+		pr, err := findBumpPR(tag)
+		if err != nil {
+			return nil, err
+		}
+		if pr != nil {
+			return pr, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("no bump PR for %s appeared within %s", tag, bumpPRDiscoveryTimeout)
+		}
+		time.Sleep(bumpPRPollInterval)
+	}
+}
+
+// pullRequest is a partial representation of a gh pr list JSON entry.
+type pullRequest struct {
+	Number int    `json:"number"`
+	State  string `json:"state"`
+	URL    string `json:"url"`
+}
+
+// findBumpPR returns the bump PR for tag, or nil when none exists yet. Bump
+// branches are bot-owned with one branch per tag, so the head-branch filter
+// identifies the PR exactly.
+func findBumpPR(tag string) (*pullRequest, error) {
+	cmd := exec.Command(
+		"gh", "pr", "list",
+		"-R", cloudDeploymentRepo,
+		"--head", bumpPRBranchPrefix+tag,
+		"--state", "all",
+		"--json", "number,state,url",
+	)
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("gh pr list failed: %w: %s", err, string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("gh pr list failed: %w", err)
+	}
+	var prs []pullRequest
+	if err := json.Unmarshal(output, &prs); err != nil {
+		return nil, fmt.Errorf("failed to parse gh pr list output: %w", err)
+	}
+	if len(prs) == 0 {
+		return nil, nil
+	}
+	return &prs[0], nil
+}

--- a/tools/ods/cmd/release_watch.go
+++ b/tools/ods/cmd/release_watch.go
@@ -68,8 +68,7 @@ func watchCloudRelease(tag string) error {
 			return buildErr
 		}
 		log.Warn("The deployment run did not succeed; review it before approving.")
-		log.Infof("Bump PR: %s", pr.URL)
-		fmt.Println(pr.URL)
+		announceBumpPR(pr)
 		return nil
 	}
 
@@ -78,13 +77,26 @@ func watchCloudRelease(tag string) error {
 	if err != nil {
 		return fmt.Errorf("%w; check https://github.com/%s/actions/workflows/%s", err, cloudDeploymentRepo, bumpWorkflowFile)
 	}
-	log.Infof("Bump PR ready for approval: %s", pr.URL)
-	fmt.Println(pr.URL)
+	announceBumpPR(pr)
 	return nil
 }
 
-// waitForBumpPR polls until the bump PR for tag exists or the discovery
-// timeout fires.
+// announceBumpPR prints the bump PR, wording the log line by PR state: a
+// re-attached watch can find a PR that was already merged or closed.
+func announceBumpPR(pr *pullRequest) {
+	switch pr.State {
+	case "MERGED":
+		log.Infof("Bump PR already merged: %s", pr.URL)
+	case "CLOSED":
+		log.Warnf("Bump PR was closed without merging: %s", pr.URL)
+	default:
+		log.Infof("Bump PR ready for approval: %s", pr.URL)
+	}
+	fmt.Println(pr.URL)
+}
+
+// waitForBumpPR polls until the bump PR for tag exists or the discovery timeout
+// fires.
 func waitForBumpPR(tag string) (*pullRequest, error) {
 	deadline := time.Now().Add(bumpPRDiscoveryTimeout)
 	for {
@@ -103,8 +115,8 @@ func waitForBumpPR(tag string) (*pullRequest, error) {
 }
 
 // dispatchJobSucceeded reports whether the run's bump dispatch job concluded
-// successfully. A job that is missing, skipped, or still running counts as
-// not dispatched.
+// successfully. A job that is missing, skipped, or still running counts as not
+// dispatched.
 func dispatchJobSucceeded(runID int64) (bool, error) {
 	cmd := exec.Command(
 		"gh", "run", "view", fmt.Sprintf("%d", runID),


### PR DESCRIPTION
## Description

- `ods release cloud` now follows the deployment run to completion and prints the onyx-infra bump PR (head bump-version/<tag>) once it exists, for approval. `--no-watch` restores print-URL-and-exit.
- A PR is reported even when the run conclusion is failure, with a warning: the dispatch job can succeed while an unrelated job fails (true for `v4.7.0-cloud.0`'s actual run).
- Everything after the push is read-only `gh` polling, so Ctrl-C is safe at any point.

## How Has This Been Tested?



## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Watches the cloud release build and prints the onyx‑infra bump PR for the pushed tag. Previously it printed only the deployment run URL and exited; pass `--no-watch` to restore that behavior.

- Default now logs the deployment run URL, waits for completion (up to 120m), then prints the bump PR from `bump-version/<tag>` in `onyx-dot-app/onyx-infra`.
- Reports a bump PR even if the run fails, with a warning, because the dispatch may succeed while another job fails.
- Polls via `gh`; PR discovery every 15s up to 20m; safe to interrupt at any time.
- Migration: CI/scripts expecting immediate exit must pass `--no-watch`.

<sup>Written for commit 348ad7b73e5239d233a808eaf8b22ead1b0ef2ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
