### PR TITLE
feat(ods): move cloud release under `ods deploy cloud`, add --attach

### DIFF
--- a/tools/ods/cmd/deploy.go
+++ b/tools/ods/cmd/deploy.go
@@ -5,14 +5,15 @@ import (
 )
 
 // NewDeployCommand creates the parent `ods deploy` command. Subcommands hang
-// off it (e.g. `ods deploy edge`) and represent ad-hoc deployment workflows.
+// off it (e.g. `ods deploy cloud`) and represent deployment workflows.
 func NewDeployCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deploy",
-		Short: "Trigger ad-hoc deployments",
-		Long:  "Trigger ad-hoc deployments to Onyx-managed environments.",
+		Short: "Trigger deployments",
+		Long:  "Trigger deployments to Onyx-managed environments.",
 	}
 
+	cmd.AddCommand(NewDeployCloudCommand())
 	cmd.AddCommand(NewDeployEdgeCommand())
 	cmd.AddCommand(NewDeployWikiCommand())
 

--- a/tools/ods/cmd/deploy_cloud.go
+++ b/tools/ods/cmd/deploy_cloud.go
@@ -63,7 +63,10 @@ Example usage:
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if opts.Attach != "" {
+			// Changed, not a non-empty value: an empty tag (e.g. an unset shell
+			// variable) must fail validation here, never fall through to the
+			// cut-and-push flow below.
+			if cmd.Flags().Changed("attach") {
 				// Attach mode is watch-only; every other flag configures the
 				// cut-and-push flow and signals a misunderstanding.
 				for _, name := range []string{"ref", "version", "dry-run", "yes", "verify", "no-watch"} {

--- a/tools/ods/cmd/deploy_cloud.go
+++ b/tools/ods/cmd/deploy_cloud.go
@@ -71,7 +71,7 @@ Example usage:
 						return fmt.Errorf("--attach cannot be combined with --%s", name)
 					}
 				}
-				if !cloudTagRe.MatchString(opts.Attach) {
+				if !release.IsCloudTag(opts.Attach) {
 					return fmt.Errorf("%q is not a cloud tag (expected vX.Y.Z-cloud.N)", opts.Attach)
 				}
 				return watchCloudRelease(opts.Attach)

--- a/tools/ods/cmd/deploy_cloud.go
+++ b/tools/ods/cmd/deploy_cloud.go
@@ -11,19 +11,20 @@ import (
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/release"
 )
 
-// ReleaseCloudOptions holds options for the release cloud command.
-type ReleaseCloudOptions struct {
+// DeployCloudOptions holds options for the deploy cloud command.
+type DeployCloudOptions struct {
 	Ref     string
 	Version string
 	DryRun  bool
 	Yes     bool
 	Verify  bool
 	NoWatch bool
+	Attach  string
 }
 
-// NewReleaseCloudCommand creates the `ods release cloud` command.
-func NewReleaseCloudCommand() *cobra.Command {
-	opts := &ReleaseCloudOptions{}
+// NewDeployCloudCommand creates the `ods deploy cloud` command.
+func NewDeployCloudCommand() *cobra.Command {
+	opts := &DeployCloudOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "cloud",
@@ -42,22 +43,40 @@ Pushing the tag triggers deployment.yml, which builds the cloud images.
 After the push, the command prints the URL of that deployment run, waits for
 it to finish, and then prints the URL of the version bump PR that the infra
 repo opens for the new tag. All of this is read-only polling through the gh
-CLI: Ctrl-C is safe at any point (the tag is already pushed). Pass --no-watch
-to print the run URL and exit immediately.
+CLI: Ctrl-C is safe at any point (the tag is already pushed), and
+--attach <tag> re-attaches later. Pass --no-watch to print the run URL and
+exit immediately.
+
+With --attach, nothing is cut or pushed: the command only watches the given
+tag's existing pipeline. This also works for releases that already finished.
 
 To validate an existing tag instead of cutting one, see "ods release --check".
 
 Example usage:
 
-    $ ods release cloud
-    $ ods release cloud --dry-run
-    $ ods release cloud --ref 1a2b3c4d
-    $ ods release cloud --version 5.0.0
-    $ ods release cloud --no-watch`,
+    $ ods deploy cloud
+    $ ods deploy cloud --dry-run
+    $ ods deploy cloud --ref 1a2b3c4d
+    $ ods deploy cloud --version 5.0.0
+    $ ods deploy cloud --no-watch
+    $ ods deploy cloud --attach v4.7.0-cloud.3`,
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			tag, err := releaseCloud(opts)
+			if opts.Attach != "" {
+				// Attach mode is watch-only; every other flag configures the
+				// cut-and-push flow and signals a misunderstanding.
+				for _, name := range []string{"ref", "version", "dry-run", "yes", "verify", "no-watch"} {
+					if cmd.Flags().Changed(name) {
+						return fmt.Errorf("--attach cannot be combined with --%s", name)
+					}
+				}
+				if !cloudTagRe.MatchString(opts.Attach) {
+					return fmt.Errorf("%q is not a cloud tag (expected vX.Y.Z-cloud.N)", opts.Attach)
+				}
+				return watchCloudRelease(opts.Attach)
+			}
+			tag, err := deployCloud(opts)
 			if err != nil || tag == "" {
 				return err
 			}
@@ -65,7 +84,7 @@ Example usage:
 				announceCloudRun(tag)
 				return nil
 			}
-			log.Info("Watching the release; Ctrl-C is safe, the tag is already pushed.")
+			log.Infof("Watching the release; Ctrl-C is safe, re-attach with: ods deploy cloud --attach %s", tag)
 			return watchCloudRelease(tag)
 		},
 	}
@@ -76,14 +95,15 @@ Example usage:
 	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip the confirmation prompt")
 	cmd.Flags().BoolVar(&opts.Verify, "verify", false, "Run pre-push hooks when pushing the tag; they are skipped by default")
 	cmd.Flags().BoolVar(&opts.NoWatch, "no-watch", false, "Print the deployment run URL and exit instead of watching for the bump PR")
+	cmd.Flags().StringVar(&opts.Attach, "attach", "", "Watch an already-pushed cloud tag's build and bump PR; cuts nothing")
 
 	return cmd
 }
 
-// releaseCloud computes and pushes the next cloud tag. It returns the pushed
+// deployCloud computes and pushes the next cloud tag. It returns the pushed
 // tag name, or an empty string when nothing was pushed (dry run, declined
 // prompt, or any failure).
-func releaseCloud(opts *ReleaseCloudOptions) (string, error) {
+func deployCloud(opts *DeployCloudOptions) (string, error) {
 	if opts.Version != "" && !release.IsBareVersion(opts.Version) {
 		return "", fmt.Errorf("--version must be X.Y.Z with no leading v, got %q", opts.Version)
 	}

--- a/tools/ods/cmd/deploy_cloud_test.go
+++ b/tools/ods/cmd/deploy_cloud_test.go
@@ -12,7 +12,7 @@ package cmd
 //	E4 counter tag only on origin            -> fetched, counter continues,
 //	                                            tag name returned               TestDeployCloud_fetchesRemoteOnlyCounterTags
 //	E5 --version with leading zeroes         -> rejected before any git work    TestDeployCloud_rejectsLeadingZeroVersion
-//	E6 --attach with malformed tag           -> rejected before any gh work     TestDeployCloud_attachRejectsMalformedTag
+//	E6 --attach with malformed or empty tag  -> rejected before any gh work     TestDeployCloud_attachRejectsMalformedTag
 //	E7 --attach with a cut-flow flag         -> rejected before any gh work     TestDeployCloud_attachRejectsCutFlowFlags
 
 import (
@@ -65,9 +65,9 @@ func TestDeployCloud_tagsOriginMainHead(t *testing.T) {
 }
 
 func TestDeployCloud_fetchesRemoteOnlyCounterTags(t *testing.T) {
-	// Precondition: a counter tag another developer pushed but this clone never
-	// fetched. Computing from local tags alone would mint a colliding
-	// v4.6.0-cloud.3.
+	// Precondition.
+	// A counter tag another developer pushed but this clone never fetched.
+	// Computing from local tags alone would mint a colliding v4.6.0-cloud.3.
 	repo := gittest.SetupReleaseBranchRepo(t)
 	gittest.Git(t, repo.Work, "tag", "v4.6.0-cloud.3", repo.PostCutSHA)
 	gittest.Git(t, repo.Work, "push", "--quiet", "origin", "v4.6.0-cloud.3")
@@ -89,8 +89,9 @@ func TestDeployCloud_fetchesRemoteOnlyCounterTags(t *testing.T) {
 }
 
 func TestDeployCloud_rejectsLeadingZeroVersion(t *testing.T) {
-	// Precondition: SemVer 2.0.0 item 2 forbids leading zeroes in numeric
-	// identifiers; such an override must never become a tag.
+	// Precondition.
+	// SemVer 2.0.0 item 2 forbids leading zeroes in numeric identifiers; such
+	// an override must never become a tag.
 	gittest.SetupReleaseBranchRepo(t)
 
 	// Under test and postcondition.
@@ -103,23 +104,26 @@ func TestDeployCloud_rejectsLeadingZeroVersion(t *testing.T) {
 }
 
 func TestDeployCloud_attachRejectsMalformedTag(t *testing.T) {
-	// Under test: leading zeroes are invalid per SemVer 2.0.0 item 2, so this
-	// must fail validation, not reach the gh-backed watcher.
-	cmd := NewDeployCloudCommand()
-	cmd.SetOut(io.Discard)
-	cmd.SetErr(io.Discard)
-	cmd.SetArgs([]string{"--attach", "v4.7.0-cloud.01"})
-	err := cmd.Execute()
-
-	// Postcondition.
-	if err == nil || !strings.Contains(err.Error(), "is not a cloud tag") {
-		t.Errorf("expected cloud tag validation error, got %v", err)
+	// Under test and postcondition.
+	// Leading zeroes are invalid per SemVer 2.0.0 item 2, and an explicit empty
+	// tag (e.g. an unset shell variable) must fail validation instead of
+	// falling through to the cut flow. Neither may reach the gh-backed watcher.
+	for _, tag := range []string{"v4.7.0-cloud.01", ""} {
+		cmd := NewDeployCloudCommand()
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		cmd.SetArgs([]string{"--attach", tag})
+		err := cmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), "is not a cloud tag") {
+			t.Errorf("expected cloud tag validation error for %q, got %v", tag, err)
+		}
 	}
 }
 
 func TestDeployCloud_attachRejectsCutFlowFlags(t *testing.T) {
-	// Under test and postcondition: the malformed tag keeps a regressed clash
-	// check from reaching the gh-backed watcher.
+	// Under test and postcondition.
+	// The malformed tag keeps a regressed clash check from reaching the
+	// gh-backed watcher.
 	for _, flag := range []string{"--ref=abc", "--version=5.0.0", "--dry-run", "--yes", "--verify", "--no-watch"} {
 		cmd := NewDeployCloudCommand()
 		cmd.SetOut(io.Discard)
@@ -133,7 +137,8 @@ func TestDeployCloud_attachRejectsCutFlowFlags(t *testing.T) {
 }
 
 func TestDeployCloud_pushFailureRollsBackLocalTag(t *testing.T) {
-	// Precondition: origin rejects every push.
+	// Precondition.
+	// Origin rejects every push.
 	repo := gittest.SetupReleaseBranchRepo(t)
 	hook := filepath.Join(repo.Origin, "hooks", "pre-receive")
 	if err := os.WriteFile(hook, []byte("#!/bin/sh\nexit 1\n"), 0755); err != nil {

--- a/tools/ods/cmd/deploy_cloud_test.go
+++ b/tools/ods/cmd/deploy_cloud_test.go
@@ -1,17 +1,17 @@
 package cmd
 
-// Command states for releaseCloud. Tag computation and validation are tested
+// Command states for deployCloud. Tag computation and validation are tested
 // in internal/release; these tests pin the command-level flow.
 //
 //	E1 dry run                               -> prints tag, creates nothing,
-//	                                            returns no pushed tag           TestReleaseCloud_dryRunCreatesNothing
+//	                                            returns no pushed tag           TestDeployCloud_dryRunCreatesNothing
 //	E2 real run                              -> tag on origin at origin/main,
-//	                                            tag name returned               TestReleaseCloud_tagsOriginMainHead
+//	                                            tag name returned               TestDeployCloud_tagsOriginMainHead
 //	E3 push rejected by origin               -> local tag rolled back,
-//	                                            returns no pushed tag           TestReleaseCloud_pushFailureRollsBackLocalTag
+//	                                            returns no pushed tag           TestDeployCloud_pushFailureRollsBackLocalTag
 //	E4 counter tag only on origin            -> fetched, counter continues,
-//	                                            tag name returned               TestReleaseCloud_fetchesRemoteOnlyCounterTags
-//	E5 --version with leading zeroes         -> rejected before any git work    TestReleaseCloud_rejectsLeadingZeroVersion
+//	                                            tag name returned               TestDeployCloud_fetchesRemoteOnlyCounterTags
+//	E5 --version with leading zeroes         -> rejected before any git work    TestDeployCloud_rejectsLeadingZeroVersion
 
 import (
 	"os"
@@ -22,12 +22,12 @@ import (
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/gittest"
 )
 
-func TestReleaseCloud_dryRunCreatesNothing(t *testing.T) {
+func TestDeployCloud_dryRunCreatesNothing(t *testing.T) {
 	// Precondition.
 	repo := gittest.SetupReleaseBranchRepo(t)
 
 	// Under test.
-	tag, err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", DryRun: true, Yes: true})
+	tag, err := deployCloud(&DeployCloudOptions{Ref: "origin/main", DryRun: true, Yes: true})
 
 	// Postcondition.
 	if err != nil {
@@ -41,12 +41,12 @@ func TestReleaseCloud_dryRunCreatesNothing(t *testing.T) {
 	}
 }
 
-func TestReleaseCloud_tagsOriginMainHead(t *testing.T) {
+func TestDeployCloud_tagsOriginMainHead(t *testing.T) {
 	// Precondition.
 	repo := gittest.SetupReleaseBranchRepo(t)
 
 	// Under test.
-	tag, err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", Yes: true})
+	tag, err := deployCloud(&DeployCloudOptions{Ref: "origin/main", Yes: true})
 
 	// Postcondition.
 	if err != nil {
@@ -61,7 +61,7 @@ func TestReleaseCloud_tagsOriginMainHead(t *testing.T) {
 	}
 }
 
-func TestReleaseCloud_fetchesRemoteOnlyCounterTags(t *testing.T) {
+func TestDeployCloud_fetchesRemoteOnlyCounterTags(t *testing.T) {
 	// Precondition: a counter tag another developer pushed but this clone never
 	// fetched. Computing from local tags alone would mint a colliding
 	// v4.6.0-cloud.3.
@@ -71,7 +71,7 @@ func TestReleaseCloud_fetchesRemoteOnlyCounterTags(t *testing.T) {
 	gittest.Git(t, repo.Work, "tag", "-d", "v4.6.0-cloud.3")
 
 	// Under test.
-	tag, err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", Yes: true})
+	tag, err := deployCloud(&DeployCloudOptions{Ref: "origin/main", Yes: true})
 
 	// Postcondition.
 	if err != nil {
@@ -85,21 +85,21 @@ func TestReleaseCloud_fetchesRemoteOnlyCounterTags(t *testing.T) {
 	}
 }
 
-func TestReleaseCloud_rejectsLeadingZeroVersion(t *testing.T) {
+func TestDeployCloud_rejectsLeadingZeroVersion(t *testing.T) {
 	// Precondition: SemVer 2.0.0 item 2 forbids leading zeroes in numeric
 	// identifiers; such an override must never become a tag.
 	gittest.SetupReleaseBranchRepo(t)
 
 	// Under test and postcondition.
 	for _, version := range []string{"04.6.0", "4.06.0", "4.6.00"} {
-		_, err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", Version: version, DryRun: true, Yes: true})
+		_, err := deployCloud(&DeployCloudOptions{Ref: "origin/main", Version: version, DryRun: true, Yes: true})
 		if err == nil || !strings.Contains(err.Error(), "--version must be X.Y.Z") {
 			t.Errorf("expected validation error for %q, got %v", version, err)
 		}
 	}
 }
 
-func TestReleaseCloud_pushFailureRollsBackLocalTag(t *testing.T) {
+func TestDeployCloud_pushFailureRollsBackLocalTag(t *testing.T) {
 	// Precondition: origin rejects every push.
 	repo := gittest.SetupReleaseBranchRepo(t)
 	hook := filepath.Join(repo.Origin, "hooks", "pre-receive")
@@ -108,7 +108,7 @@ func TestReleaseCloud_pushFailureRollsBackLocalTag(t *testing.T) {
 	}
 
 	// Under test.
-	tag, err := releaseCloud(&ReleaseCloudOptions{Ref: "origin/main", Yes: true})
+	tag, err := deployCloud(&DeployCloudOptions{Ref: "origin/main", Yes: true})
 
 	// Postcondition.
 	if err == nil || !strings.Contains(err.Error(), "failed to push") {

--- a/tools/ods/cmd/deploy_cloud_test.go
+++ b/tools/ods/cmd/deploy_cloud_test.go
@@ -12,8 +12,11 @@ package cmd
 //	E4 counter tag only on origin            -> fetched, counter continues,
 //	                                            tag name returned               TestDeployCloud_fetchesRemoteOnlyCounterTags
 //	E5 --version with leading zeroes         -> rejected before any git work    TestDeployCloud_rejectsLeadingZeroVersion
+//	E6 --attach with malformed tag           -> rejected before any gh work     TestDeployCloud_attachRejectsMalformedTag
+//	E7 --attach with a cut-flow flag         -> rejected before any gh work     TestDeployCloud_attachRejectsCutFlowFlags
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -95,6 +98,36 @@ func TestDeployCloud_rejectsLeadingZeroVersion(t *testing.T) {
 		_, err := deployCloud(&DeployCloudOptions{Ref: "origin/main", Version: version, DryRun: true, Yes: true})
 		if err == nil || !strings.Contains(err.Error(), "--version must be X.Y.Z") {
 			t.Errorf("expected validation error for %q, got %v", version, err)
+		}
+	}
+}
+
+func TestDeployCloud_attachRejectsMalformedTag(t *testing.T) {
+	// Under test: leading zeroes are invalid per SemVer 2.0.0 item 2, so this
+	// must fail validation, not reach the gh-backed watcher.
+	cmd := NewDeployCloudCommand()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--attach", "v4.7.0-cloud.01"})
+	err := cmd.Execute()
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "is not a cloud tag") {
+		t.Errorf("expected cloud tag validation error, got %v", err)
+	}
+}
+
+func TestDeployCloud_attachRejectsCutFlowFlags(t *testing.T) {
+	// Under test and postcondition: the malformed tag keeps a regressed clash
+	// check from reaching the gh-backed watcher.
+	for _, flag := range []string{"--ref=abc", "--version=5.0.0", "--dry-run", "--yes", "--verify", "--no-watch"} {
+		cmd := NewDeployCloudCommand()
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		cmd.SetArgs([]string{"--attach", "not-a-tag", flag})
+		err := cmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), "--attach cannot be combined with") {
+			t.Errorf("expected flag clash error for %s, got %v", flag, err)
 		}
 	}
 }

--- a/tools/ods/cmd/deploy_cloud_watch.go
+++ b/tools/ods/cmd/deploy_cloud_watch.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -28,6 +29,10 @@ const (
 	bumpPRDiscoveryTimeout = 20 * time.Minute
 	bumpPRPollInterval     = 15 * time.Second
 )
+
+// cloudTagRe matches complete cloud release tags. It mirrors the validation in
+// the bump workflow.
+var cloudTagRe = regexp.MustCompile(`^v\d+\.\d+\.\d+-cloud\.\d+$`)
 
 // watchCloudRelease follows the release pipeline of an already-pushed cloud
 // tag: the deployment.yml build, then the bump PR that the dispatched bump

--- a/tools/ods/cmd/deploy_cloud_watch.go
+++ b/tools/ods/cmd/deploy_cloud_watch.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
-	"regexp"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -29,10 +28,6 @@ const (
 	bumpPRDiscoveryTimeout = 20 * time.Minute
 	bumpPRPollInterval     = 15 * time.Second
 )
-
-// cloudTagRe matches complete cloud release tags. It mirrors the validation in
-// the bump workflow.
-var cloudTagRe = regexp.MustCompile(`^v\d+\.\d+\.\d+-cloud\.\d+$`)
 
 // watchCloudRelease follows the release pipeline of an already-pushed cloud
 // tag: the deployment.yml build, then the bump PR that the dispatched bump

--- a/tools/ods/cmd/release.go
+++ b/tools/ods/cmd/release.go
@@ -23,7 +23,7 @@ func NewReleaseCommand() *cobra.Command {
 With --check, no tag is cut. Instead the command validates an existing release
 tag:
 
-  - A cloud tag (vX.Y.Z-cloud.N) must be the tag "ods release cloud" would
+  - A cloud tag (vX.Y.Z-cloud.N) must be the tag "ods deploy cloud" would
     have computed: its commit is on origin/main, its base matches the release
     branches, and its counter is one past the previous counter for that base.
   - A stable tag (vX.Y.Z) must sit on origin/release/vX.Y, its patch must be
@@ -63,7 +63,6 @@ Example usage:
 	cmd.Flags().StringVar(&ref, "ref", "HEAD", "Tag to check, or a commit-ish that a single release tag points at")
 
 	cmd.AddCommand(NewReleaseOpalCommand())
-	cmd.AddCommand(NewReleaseCloudCommand())
 
 	return cmd
 }

--- a/tools/ods/internal/release/check_test.go
+++ b/tools/ods/internal/release/check_test.go
@@ -6,7 +6,7 @@ package release
 //
 // Cloud tag states:
 //
-//	K1 tag just cut by `ods release cloud`   -> valid                          TestCheckTag_freshCloudTagPasses
+//	K1 tag just cut by `ods deploy cloud`   -> valid                          TestCheckTag_freshCloudTagPasses
 //	K2 base disagrees with release branches  -> error naming both bases        TestCheckTag_wrongCloudBaseErrors
 //	K3 counter skipped (cloud.1 without .0)  -> out-of-sequence error          TestCheckTag_skippedCounterErrors
 //	K4 counter superseded by a newer tag     -> out-of-sequence error          TestCheckTag_supersededCounterErrors
@@ -45,7 +45,7 @@ import (
 )
 
 func TestCheckTag_freshCloudTagPasses(t *testing.T) {
-	// Precondition: the tag `ods release cloud` would cut for the post-cut
+	// Precondition: the tag `ods deploy cloud` would cut for the post-cut
 	// commit, pushed to origin.
 	repo := gittest.SetupReleaseBranchRepo(t)
 	gittest.Git(t, repo.Work, "tag", "v4.6.0-cloud.0", repo.PostCutSHA)

--- a/tools/ods/internal/release/cloud.go
+++ b/tools/ods/internal/release/cloud.go
@@ -15,6 +15,11 @@ import (
 var cloudTagRe = regexp.MustCompile(
 	`^(v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))-cloud\.(0|[1-9]\d*)$`)
 
+// IsCloudTag reports whether s is a complete cloud tag, e.g. "v4.7.0-cloud.3".
+func IsCloudTag(s string) bool {
+	return cloudTagRe.MatchString(s)
+}
+
 // ComputeCloudTag returns the next cloud tag for commitSHA. The base version
 // is "v" + overrideVersion when given, else one minor past the newest release
 // branch on origin that does not contain the commit; the counter is one past


### PR DESCRIPTION
## Description

- `ods release cloud` becomes `ods deploy cloud`, alongside deploy edge/wiki; `ods release` keeps opal only. Files and identifiers renamed to match (`deploy_cloud.go`, `deployCloud`, `TestDeployCloud_*`).
- The `ods release watch` command is replaced by `ods deploy cloud --attach <tag>`: watch-only re-attach to an already-pushed tag, cuts nothing, also works for finished releases.
- `--attach` requires an explicit tag (removing the bounded run-history scan flagged in review) and cannot be combined with the cut-flow flags.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
