### PR TITLE
refactor(health): move the readiness check to /health/ready

### DIFF
--- a/backend/ee/onyx/server/middleware/tenant_tracking.py
+++ b/backend/ee/onyx/server/middleware/tenant_tracking.py
@@ -26,7 +26,7 @@ from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 # Unauthenticated, non-tenant-scoped endpoints (LB/Prometheus probes, API docs),
 # so tenant resolution is skipped for them.
 TENANT_RESOLUTION_SKIP_PATHS = frozenset(
-    {"/health", "/health/live", "/metrics", "/openapi.json"}
+    {"/health", "/health/ready", "/metrics", "/openapi.json"}
 )
 
 

--- a/backend/onyx/server/auth_check.py
+++ b/backend/onyx/server/auth_check.py
@@ -26,10 +26,10 @@ PUBLIC_ENDPOINT_SPECS = [
     ("/redoc", {"GET", "HEAD"}),
     # should always be callable, will just return 401 if not authenticated
     ("/me", {"GET"}),
-    # readiness: 200 while the server can serve traffic, 503 when saturated
-    ("/health", {"GET"}),
     # liveness: just returns 200 to validate that the process is up
-    ("/health/live", {"GET"}),
+    ("/health", {"GET"}),
+    # readiness: 200 while the server can serve traffic, 503 when saturated
+    ("/health/ready", {"GET"}),
     # just returns auth type, needs to be accessible before the user is logged
     # in to determine what flow to give the user
     ("/auth/type", {"GET"}),

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -94,7 +94,7 @@ _UNREADY_AFTER_SECONDS = 10.0
 
 # Tracks when the threadpool was first observed saturated, so brief queueing
 # under bursty load does not flip readiness. Only ever touched from the event
-# loop inside `healthcheck`, with no await between the read and the write.
+# loop inside `readiness`, with no await between the read and the write.
 #
 # The window is sampled at probe frequency, not observed continuously, so a pool
 # that drains and re-saturates between two probes reads as continuously
@@ -105,7 +105,7 @@ _UNREADY_AFTER_SECONDS = 10.0
 # background sampler, which is not worth an always-on loop per process.
 _SATURATED_SINCE: float | None = None
 
-# Probes can hit /health many times a second, so log only when readiness
+# Probes can hit /health/ready many times a second, so log only when readiness
 # changes. Logging every not-ready probe would flood the log with one line per
 # probe per replica, and add synchronous I/O exactly when the server is already
 # out of capacity.
@@ -132,15 +132,15 @@ def _threadpool_saturation() -> tuple[bool, dict[str, float]]:
 
 # response_model=None only disables schema inference for the Response union
 # below. It does not declare a response model.
-@router.get("/health", tags=PUBLIC_API_TAGS, response_model=None)
-async def healthcheck() -> StatusResponse[dict[str, float]] | JSONResponse:
+@router.get("/health/ready", tags=PUBLIC_API_TAGS, response_model=None)
+async def readiness() -> StatusResponse[dict[str, float]] | JSONResponse:
     """Readiness probe. Wire this to readinessProbe and to load balancers.
 
     Sync endpoints run in the anyio threadpool, so a saturated pool means the
     server cannot serve real traffic even though the event loop still turns.
     This handler stays async on purpose: a sync handler would borrow a token of
     the pool it is measuring, adding load exactly when there is none to spare,
-    and would queue rather than answer. Liveness lives at /health/live.
+    and would queue rather than answer. Liveness lives at /health.
     """
     global _SATURATED_SINCE, _REPORTED_NOT_READY
 
@@ -184,13 +184,14 @@ async def healthcheck() -> StatusResponse[dict[str, float]] | JSONResponse:
     )
 
 
-@router.get("/health/live", tags=PUBLIC_API_TAGS)
-async def liveness() -> StatusResponse:
+@router.get("/health", tags=PUBLIC_API_TAGS)
+async def healthcheck() -> StatusResponse:
     """Liveness probe. Answers only "is this process still running".
 
     Deliberately checks nothing else. Liveness failures restart the container,
     and saturation is load-induced and correlated across replicas, so gating
-    restarts on it would turn a slowdown into an outage. Use /health for that.
+    restarts on it would turn a slowdown into an outage. Use /health/ready for
+    that.
     """
     return StatusResponse(success=True, message="ok")
 

--- a/backend/tests/unit/ee/onyx/server/middleware/test_tenant_tracking.py
+++ b/backend/tests/unit/ee/onyx/server/middleware/test_tenant_tracking.py
@@ -31,7 +31,7 @@ def test_custom_api_prefix_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
     assert tenant_tracking._is_path_allowed("/v2/chat") is False
 
 
-@pytest.mark.parametrize("path", ["/health", "/health/live", "/metrics"])
+@pytest.mark.parametrize("path", ["/health", "/health/ready", "/metrics"])
 def test_probe_paths_skip_tenant_resolution_under_api_prefix(
     monkeypatch: pytest.MonkeyPatch, path: str
 ) -> None:

--- a/backend/tests/unit/onyx/server/manage/test_health_readiness.py
+++ b/backend/tests/unit/onyx/server/manage/test_health_readiness.py
@@ -1,4 +1,4 @@
-"""Unit tests for the /health readiness and /health/live liveness endpoints."""
+"""Unit tests for the /health/ready readiness and /health liveness endpoints."""
 
 import asyncio
 from collections.abc import Iterator
@@ -31,7 +31,7 @@ def _limiter(borrowed: float, total: float, waiting: int) -> MagicMock:
     return limiter
 
 
-def _healthcheck(
+def _readiness(
     borrowed: float, total: float, waiting: int, now: float
 ) -> get_state.StatusResponse[dict[str, float]] | JSONResponse:
     """Run the readiness handler against a fixed pool state and clock."""
@@ -43,14 +43,14 @@ def _healthcheck(
         ),
         patch.object(get_state.time, "monotonic", return_value=now),
     ):
-        return asyncio.run(get_state.healthcheck())
+        return asyncio.run(get_state.readiness())
 
 
 def _ready(
     borrowed: float, total: float, waiting: int, now: float
 ) -> get_state.StatusResponse[dict[str, float]]:
     """Run the readiness handler and assert it reported ready."""
-    response = _healthcheck(borrowed, total, waiting, now)
+    response = _readiness(borrowed, total, waiting, now)
     assert not isinstance(response, JSONResponse)
     return response
 
@@ -83,9 +83,9 @@ def test_brief_saturation_does_not_flip_readiness() -> None:
 
 
 def test_sustained_saturation_reports_not_ready() -> None:
-    _healthcheck(borrowed=40, total=40, waiting=5, now=100.0)
+    _readiness(borrowed=40, total=40, waiting=5, now=100.0)
 
-    response = _healthcheck(
+    response = _readiness(
         borrowed=40,
         total=40,
         waiting=5,
@@ -100,8 +100,8 @@ def test_sustained_saturation_reports_not_ready() -> None:
 
 def test_recovery_between_samples_restarts_the_timer() -> None:
     """A healthy sample clears the latch, so the grace window starts over."""
-    _healthcheck(borrowed=40, total=40, waiting=5, now=100.0)
-    _healthcheck(borrowed=10, total=40, waiting=0, now=105.0)
+    _readiness(borrowed=40, total=40, waiting=5, now=100.0)
+    _readiness(borrowed=10, total=40, waiting=0, now=105.0)
     assert get_state._SATURATED_SINCE is None
 
     # Long past the original window, but this is a fresh saturation streak.
@@ -114,9 +114,9 @@ def test_recovery_between_samples_restarts_the_timer() -> None:
 def test_not_ready_is_logged_once_per_streak() -> None:
     """Probes are frequent, so only readiness changes may write to the log."""
     with patch.object(get_state, "logger") as mock_logger:
-        _healthcheck(borrowed=40, total=40, waiting=5, now=100.0)
+        _readiness(borrowed=40, total=40, waiting=5, now=100.0)
         for offset in range(3):
-            _healthcheck(
+            _readiness(
                 borrowed=40,
                 total=40,
                 waiting=5,
@@ -125,22 +125,22 @@ def test_not_ready_is_logged_once_per_streak() -> None:
 
         assert mock_logger.warning.call_count == 1
 
-        _healthcheck(borrowed=0, total=40, waiting=0, now=200.0)
-        _healthcheck(borrowed=0, total=40, waiting=0, now=201.0)
+        _readiness(borrowed=0, total=40, waiting=0, now=200.0)
+        _readiness(borrowed=0, total=40, waiting=0, now=201.0)
 
         assert mock_logger.notice.call_count == 1
 
 
 def test_liveness_stays_up_while_saturated() -> None:
     """Liveness must never fail on load, or saturation restarts every replica."""
-    _healthcheck(borrowed=40, total=40, waiting=5, now=100.0)
-    _healthcheck(
+    _readiness(borrowed=40, total=40, waiting=5, now=100.0)
+    _readiness(
         borrowed=40,
         total=40,
         waiting=5,
         now=100.0 + get_state._UNREADY_AFTER_SECONDS,
     )
 
-    response = asyncio.run(get_state.liveness())
+    response = asyncio.run(get_state.healthcheck())
 
     assert response.success is True

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.18
+version: 0.8.19
 appVersion: latest
 annotations:
   category: Productivity
@@ -21,15 +21,16 @@ annotations:
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
     - kind: changed
-      description: The api server `/health` endpoint now reports not-ready (503)
-        while its request threadpool stays saturated, so a wedged pod leaves the
-        Service. It previously returned 200 in that state. Move `/health` off any
-        `livenessProbe` you configured — saturation is load-induced and hits every
-        replica at once, so restarting on it turns a slowdown into an outage.
-    - kind: added
-      description: New api server endpoint `/health/live` reports only that the
-        process runs. Use it for `livenessProbe`, and keep `/health` for
-        `readinessProbe`. `values.yaml` documents both under `api`.
+      description: The api server `/health` endpoint is a plain liveness probe
+        again — 200 whenever the process runs — as it was before 0.8.18. The
+        readiness check that reports 503 on a saturated request threadpool moved
+        to the new `/health/ready` endpoint. Point `readinessProbe` at
+        `/health/ready`, and keep `livenessProbe` on `/health` — saturation is
+        load-induced and hits every replica at once, so restarting on it turns a
+        slowdown into an outage. `values.yaml` documents both under `api`.
+    - kind: removed
+      description: The api server `/health/live` endpoint added in 0.8.18 is gone.
+        Use `/health` for `livenessProbe` instead.
 dependencies:
   # Helm uses the first condition path that exists: `postgresqlOperator.enabled`
   # is unset by default, so this falls through to `postgresql.enabled`. Set it

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -576,20 +576,20 @@ api:
 
   # Optional health probes.
   #
-  # Match the path to the probe. /health reports not-ready once the request
+  # Match the path to the probe. /health/ready reports not-ready once the request
   # threadpool is saturated, which is what should pull a pod out of the Service.
-  # /health/live only reports that the process is up. Do NOT put /health on the
+  # /health only reports that the process is up. Do NOT put /health/ready on the
   # liveness probe: saturation is load-induced and hits every replica at once,
   # so restarting on it turns a slowdown into an outage.
   #
   # Example:
   # readinessProbe:
   #   httpGet:
-  #     path: /health
+  #     path: /health/ready
   #     port: api-server-port
   # livenessProbe:
   #   httpGet:
-  #     path: /health/live
+  #     path: /health
   #     port: api-server-port
   startupProbe: {}
   readinessProbe: {}


### PR DESCRIPTION
## Summary

#14052 changed the meaning of `/health`: it became a readiness probe that returns 503 while the request threadpool stays saturated, and liveness moved to a new `/health/live`. That repoints a path many deployments already probe — every compose healthcheck, Kubernetes manifest, and load balancer pointing at `/health` had to move to `/health/live` to keep the old behavior.

This keeps `/health` as the trivial 200 liveness probe it has always been, and serves the readiness check from a new `/health/ready` instead. The saturation logic and thresholds are unchanged; only the paths move.

| Path | Before this PR (0.8.18) | After |
| --- | --- | --- |
| `/health` | readiness (503 when saturated) | liveness (always 200) |
| `/health/live` | liveness | removed |
| `/health/ready` | — | readiness (503 when saturated) |

## Changes

- `backend/onyx/server/manage/get_state.py` — readiness handler now serves `/health/ready`; `/health` is the plain liveness handler again.
- `backend/onyx/server/auth_check.py` — public endpoint specs updated for both paths.
- `backend/ee/onyx/server/middleware/tenant_tracking.py` — tenant-resolution skip list updated. The API-prefix stripping fix from #14052 is untouched.
- `deployment/helm/charts/onyx/` — chart bumped to 0.8.19; changelog documents the move, and the probe examples put `readinessProbe` on `/health/ready` and `livenessProbe` on `/health`.

## Upgrade note

0.8.18 is already released, so the chart carries `changed` and `removed` entries. Anyone who moved `livenessProbe` to `/health/live` for 0.8.18 should point it back at `/health`.

## Testing

`uv run pytest backend/tests/unit/onyx/server/manage/test_health_readiness.py backend/tests/unit/ee/onyx/server/middleware/test_tenant_tracking.py` — 16 passed. The readiness unit tests from #14052 carry over with the handler renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore liveness at /health (always 200) and move readiness (503 when the request threadpool is saturated) to /health/ready; remove /health/live to avoid breaking existing probes that already target /health.

- Updated server routes: readiness now at /health/ready, liveness at /health; saturation logic and thresholds are unchanged. Public endpoint specs and tenant-resolution skip list include the new path. Unit tests renamed to match.
- Helm: bump chart to 0.8.19 and update examples to use readinessProbe=/health/ready and livenessProbe=/health.
- Migration: if you switched liveness to /health/live in 0.8.18, point it back to /health; point readiness to /health/ready. Update any Kubernetes, Docker Compose, or load balancer health checks accordingly.

<sup>Written for commit 5f043f3342cb4abe0e535d1c3971759e61fdebd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

