### PR TITLE
fix(llm): fall back to `reasoning` field for OpenAI-compatible providers

### DIFF
--- a/backend/onyx/llm/model_response.py
+++ b/backend/onyx/llm/model_response.py
@@ -220,7 +220,11 @@ def from_litellm_model_response_stream(
     delta_data: dict[str, Any] = choice_data.get("delta") or {}
     parsed_delta = Delta(
         content=delta_data.get("content"),
-        reasoning_content=delta_data.get("reasoning_content"),
+        # Some OpenAI-compatible providers (e.g. recent vLLM versions) return
+        # reasoning under `reasoning` instead of `reasoning_content`.
+        reasoning_content=(
+            delta_data.get("reasoning_content") or delta_data.get("reasoning")
+        ),
         thinking_blocks=_parse_thinking_blocks(delta_data.get("thinking_blocks")),
         tool_calls=_parse_delta_tool_calls(delta_data.get("tool_calls")),
     )
@@ -257,7 +261,11 @@ def from_litellm_model_response(
         content=message_data.get("content"),
         role=message_data.get("role", "assistant"),
         tool_calls=parsed_tool_calls if parsed_tool_calls else None,
-        reasoning_content=message_data.get("reasoning_content"),
+        # Some OpenAI-compatible providers (e.g. recent vLLM versions) return
+        # reasoning under `reasoning` instead of `reasoning_content`.
+        reasoning_content=(
+            message_data.get("reasoning_content") or message_data.get("reasoning")
+        ),
         thinking_blocks=_parse_thinking_blocks(message_data.get("thinking_blocks")),
     )
 

--- a/backend/tests/unit/onyx/llm/test_model_response.py
+++ b/backend/tests/unit/onyx/llm/test_model_response.py
@@ -101,6 +101,26 @@ def _build_reasoning_payload() -> dict:
     }
 
 
+def _build_reasoning_field_payload() -> dict:
+    # Some OpenAI-compatible providers (e.g. recent vLLM versions) return
+    # reasoning under `reasoning` instead of `reasoning_content`.
+    return {
+        "id": "chatcmpl-c2a25682-5715-4ca2-84a9-061498f79627",
+        "created": 1762544538,
+        "model": "gpt-5",
+        "object": "chat.completion.chunk",
+        "choices": [
+            {
+                "finish_reason": None,
+                "index": 0,
+                "delta": {
+                    "reasoning": " variations",
+                },
+            }
+        ],
+    }
+
+
 def _build_finish_reason_payload() -> tuple[dict, dict]:
     base_chunk = {
         "id": "chatcmpl-2b136068-c6fb-4af1-97d5-d2c9d84cd52b",
@@ -207,6 +227,48 @@ def _build_non_streaming_response_payload() -> dict:
     }
 
 
+def _build_non_streaming_reasoning_content_payload() -> dict:
+    return {
+        "id": "chatcmpl-reasoning-content",
+        "created": 1234567891,
+        "model": "gpt-4",
+        "object": "chat.completion",
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "index": 0,
+                "message": {
+                    "content": "Hello, world!",
+                    "role": "assistant",
+                    "reasoning_content": "thinking it through",
+                },
+            }
+        ],
+    }
+
+
+def _build_non_streaming_reasoning_field_payload() -> dict:
+    # Some OpenAI-compatible providers (e.g. recent vLLM versions) return
+    # reasoning under `reasoning` instead of `reasoning_content`.
+    return {
+        "id": "chatcmpl-reasoning-field",
+        "created": 1234567892,
+        "model": "gpt-4",
+        "object": "chat.completion",
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "index": 0,
+                "message": {
+                    "content": "Hello, world!",
+                    "role": "assistant",
+                    "reasoning": "thinking it through",
+                },
+            }
+        ],
+    }
+
+
 def _build_non_streaming_tool_call_payload() -> dict:
     return {
         "id": "chatcmpl-xyz789",
@@ -258,6 +320,16 @@ def test_from_litellm_model_response_stream_parses_tool_calls() -> None:
 def test_from_litellm_model_response_stream_preserves_reasoning_content() -> None:
     response = from_litellm_model_response_stream(
         _make_stream_double(_build_reasoning_payload())
+    )
+
+    assert response.choice.delta.content is None
+    assert response.choice.delta.reasoning_content == " variations"
+    assert response.choice.finish_reason is None
+
+
+def test_from_litellm_model_response_stream_falls_back_to_reasoning_field() -> None:
+    response = from_litellm_model_response_stream(
+        _make_stream_double(_build_reasoning_field_payload())
     )
 
     assert response.choice.delta.content is None
@@ -342,6 +414,22 @@ def test_from_litellm_model_response_parses_basic_message() -> None:
     assert response.choice.message.content == "Hello, world!"
     assert response.choice.message.role == "assistant"
     assert response.choice.message.tool_calls is None
+
+
+def test_from_litellm_model_response_preserves_reasoning_content() -> None:
+    response = from_litellm_model_response(
+        _make_response_double(_build_non_streaming_reasoning_content_payload())
+    )
+
+    assert response.choice.message.reasoning_content == "thinking it through"
+
+
+def test_from_litellm_model_response_falls_back_to_reasoning_field() -> None:
+    response = from_litellm_model_response(
+        _make_response_double(_build_non_streaming_reasoning_field_payload())
+    )
+
+    assert response.choice.message.reasoning_content == "thinking it through"
 
 
 def test_from_litellm_model_response_parses_tool_calls() -> None:


### PR DESCRIPTION
## Problem

For OpenAI-compatible Chat Completions providers, reasoning text returned under the `reasoning` key (rather than `reasoning_content`) is silently discarded. Recent vLLM versions return reasoning this way:

- Streaming: `choices[].delta.reasoning`
- Non-streaming: `choices[].message.reasoning`

Onyx's LiteLLM response parsing only reads `reasoning_content`, so for these providers the final answer is stored correctly but `chat_message.reasoning_tokens` stays `NULL` and the reasoning text is lost.

## Root cause

`backend/onyx/llm/model_response.py`:
- `from_litellm_model_response_stream` builds the streaming `Delta` with `reasoning_content=delta_data.get("reasoning_content")`
- `from_litellm_model_response` builds the non-streaming `Message` with `reasoning_content=message_data.get("reasoning_content")`

Neither falls back to the `reasoning` key, so responses that only populate `reasoning` are dropped.

## Fix

At both call sites, fall back to the `reasoning` key when `reasoning_content` is absent:

```python
reasoning_content=(
    delta_data.get("reasoning_content") or delta_data.get("reasoning")
)
```
and equivalently for `message_data` in the non-streaming path. This is a minimal, backward-compatible change — providers that already send `reasoning_content` are unaffected.

## Testing

Added regression tests in `backend/tests/unit/onyx/llm/test_model_response.py` covering both the legacy `reasoning_content` key and the new `reasoning` key, for both the streaming and non-streaming parsing paths.

Ran the full test file locally:

```
11 passed
```

Also ran `ruff check` and `ruff format --check` on the changed files — both clean.

Fixes #14039

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves reasoning for OpenAI-compatible Chat Completions that return it under `reasoning` instead of `reasoning_content`. Previously this reasoning was dropped and `chat_message.reasoning_tokens` stayed NULL; now both streaming and non-streaming parsing fall back to `reasoning`.

- Updates the two parsing paths to use `reasoning_content or reasoning`.
- Backward compatible; providers already sending `reasoning_content` are unchanged.
- Adds unit tests covering both keys in streaming and non-streaming paths.

<sup>Written for commit 36bbbcd7e6b098bb090e8d6fce5d41c96a772659. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

