### PR TITLE
Send output_config effort even when tool-call history suppresses thinking

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -760,13 +760,22 @@ class LitellmLLM(LLM):
                     # Newer Anthropic models (Claude Opus 4.7+) reject
                     # thinking.type.enabled — they require the adaptive
                     # thinking config with output_config.effort.
+                    #
+                    # `output_config` carries no signed thinking blocks, so it
+                    # is not subject to the signed-block constraint above and
+                    # can always be sent. `thinking` itself must still be
+                    # omitted when tool-call history is present. Omitting
+                    # `thinking` does NOT disable reasoning on these models —
+                    # adaptive thinking is the API default — so without an
+                    # explicit `output_config.effort` the model silently
+                    # reasons at the API's own default ("high"), ignoring the
+                    # configured reasoning_effort on every turn after a tool
+                    # call (see #14013).
                     if not has_tool_call_history:
                         optional_kwargs["thinking"] = {"type": "adaptive"}
-                        optional_kwargs["output_config"] = {
-                            "effort": ANTHROPIC_ADAPTIVE_REASONING_EFFORT[
-                                reasoning_effort
-                            ],
-                        }
+                    optional_kwargs["output_config"] = {
+                        "effort": ANTHROPIC_ADAPTIVE_REASONING_EFFORT[reasoning_effort],
+                    }
                 else:
                     budget_tokens: int | None = ANTHROPIC_REASONING_EFFORT_BUDGET.get(
                         reasoning_effort

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -606,6 +606,87 @@ def test_claude_adaptive_thinking_uses_output_config(
         assert "budget_tokens" not in kwargs["thinking"]
 
 
+def test_claude_adaptive_thinking_sends_output_config_after_tool_call() -> None:
+    # Regression test for #14013: on adaptive-thinking Claude models,
+    # `thinking` must be omitted once the prompt contains tool-call history
+    # (Anthropic requires a signed thinking block ahead of tool_use blocks,
+    # which Onyx does not preserve), but `output_config`/effort carries no
+    # such signed block and must still be sent — otherwise the configured
+    # reasoning_effort is silently dropped and the model reasons at the API's
+    # own default ("high") on every turn following a tool call.
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.LITELLM_PROXY,
+        model_name="claude-sonnet-5",
+        max_input_tokens=get_max_input_tokens(
+            model_provider=LlmProviderNames.LITELLM_PROXY,
+            model_name="claude-sonnet-5",
+        ),
+    )
+
+    messages_with_tool_call_history: LanguageModelInput = [
+        UserMessage(content="What's the weather in SF?"),
+        AssistantMessage(
+            role="assistant",
+            content=None,
+            tool_calls=[
+                ToolCall(
+                    id="call_1",
+                    function=FunctionCall(name="get_weather", arguments="{}"),
+                )
+            ],
+        ),
+        ToolMessage(role="tool", tool_call_id="call_1", content="Sunny, 70F"),
+    ]
+
+    with (
+        patch("litellm.completion") as mock_completion,
+        patch("onyx.llm.multi_llm.model_is_reasoning_model", return_value=True),
+    ):
+        mock_completion.return_value = []
+
+        list(
+            llm.stream(
+                messages_with_tool_call_history,
+                reasoning_effort=ReasoningEffort.LOW,
+            )
+        )
+
+        kwargs = mock_completion.call_args.kwargs
+        assert "thinking" not in kwargs
+        assert kwargs["output_config"] == {"effort": "low"}
+
+
+def test_claude_adaptive_thinking_sends_both_without_tool_call_history() -> None:
+    # Regression coverage for the pre-existing, correct behavior: with no
+    # tool-call history, both `thinking` and `output_config` must still be
+    # sent together as before.
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.LITELLM_PROXY,
+        model_name="claude-sonnet-5",
+        max_input_tokens=get_max_input_tokens(
+            model_provider=LlmProviderNames.LITELLM_PROXY,
+            model_name="claude-sonnet-5",
+        ),
+    )
+
+    with (
+        patch("litellm.completion") as mock_completion,
+        patch("onyx.llm.multi_llm.model_is_reasoning_model", return_value=True),
+    ):
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages, reasoning_effort=ReasoningEffort.LOW))
+
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["thinking"] == {"type": "adaptive"}
+        assert kwargs["output_config"] == {"effort": "low"}
+
+
 def test_keeps_temperature_for_other_models(default_multi_llm: LitellmLLM) -> None:
     with patch("litellm.completion") as mock_completion:
         mock_completion.return_value = []


### PR DESCRIPTION
## Problem

On Anthropic adaptive-thinking models (Claude Sonnet 5, Opus 5), the `reasoning_effort` selected by the user or admin has no effect on any turn that follows a tool call. Since agents that use tools reason at an uncontrolled `high` effort on every turn that actually produces the final answer, this burns large amounts of extra output tokens and latency (see issue for a measured case: ~5.5k completion tokens / 5s becoming ~31k tokens / 282s for the same prompt).

## Root cause

In `backend/onyx/llm/multi_llm.py`, the `ANTHROPIC_ADAPTIVE` reasoning branch skips the whole reasoning block once the prompt contains tool-call history:

```python
if not has_tool_call_history:
    optional_kwargs["thinking"] = {"type": "adaptive"}
    optional_kwargs["output_config"] = {
        "effort": ANTHROPIC_ADAPTIVE_REASONING_EFFORT[reasoning_effort],
    }
```

The `has_tool_call_history` guard on `thinking` is correct and must stay: Anthropic requires every assistant message with `tool_use` blocks to be preceded by a signed thinking block, and Onyx does not preserve those signed blocks across turns, so re-sending `thinking` there would be invalid.

The bug is that `output_config` was nested inside the same guard, even though it carries no signed thinking blocks and isn't subject to that constraint at all. On these models, *omitting* `thinking` does not disable reasoning — adaptive thinking is the API's own default — so without an explicit `output_config.effort`, the API silently falls back to its own default effort (`high`), ignoring whatever `reasoning_effort` was configured.

## Fix

Decouple `output_config` from `thinking`: `thinking` is still omitted when tool-call history is present (preserving the signed-block guard), but `output_config`/effort is now always sent when adaptive thinking is in use, so the configured `reasoning_effort` takes effect on every turn, including the ones following a tool call.

## Testing

Added two focused unit tests in `backend/tests/unit/onyx/llm/test_multi_llm.py`:
- `test_claude_adaptive_thinking_sends_output_config_after_tool_call`: with tool-call history present, asserts `thinking` is omitted but `output_config` still reflects the configured `reasoning_effort`.
- `test_claude_adaptive_thinking_sends_both_without_tool_call_history`: regression coverage that without tool-call history, both `thinking` and `output_config` are still sent together as before.

Ran the full `test_multi_llm.py` suite (148 tests) locally — all pass. Ran `ruff check` and `ruff format` on the changed files.

Fixes #14013

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always send `output_config.effort` for Anthropic adaptive-thinking models even when tool-call history suppresses `thinking`, so the configured `reasoning_effort` applies after tool calls. Previously, those turns defaulted to the API’s `high` effort, inflating tokens and latency.

- Keeps `thinking` omitted when tool-call history is present (signed-block constraint), but moves `output_config` outside that guard.
- No change without tool-call history: both `thinking` and `output_config` are sent.
- Scope: adaptive-thinking Anthropic models only (e.g., Claude Sonnet 5, Opus 5); other models unchanged.
- Adds two unit tests covering both scenarios in `backend/tests/unit/onyx/llm/test_multi_llm.py`.

<sup>Written for commit 7479efa882a1fecb2bd1d9299c7b57214d9a691a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

