### PR TITLE
fix(llm): close abandoned streams for non-isolated providers

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -148,13 +148,36 @@ class LLMRateLimitError(Exception):
     """
 
 
+def _close_stream(response: Any) -> None:
+    """Best-effort close a LiteLLM stream and its underlying completion_stream.
+
+    Abandoned streams can keep checked-out HTTP connections alive. Closing the
+    underlying iterator returns those connections to the pool.
+    """
+    try:
+        completion_stream = getattr(response, "completion_stream", None)
+    except Exception:
+        return
+
+    if completion_stream is None:
+        return
+
+    close = getattr(completion_stream, "close", None)
+    if close is None:
+        return
+
+    try:
+        close()
+    except Exception as e:
+        logger.debug("Failed to close LLM stream: %s", e)
+
+
 def _consume_stream_with_timeout(stream: Any, total_timeout: float | None) -> list[Any]:
     """Drain a litellm stream, capping total wall-clock time when set.
 
     The socket read timeout only bounds the gap between packets, so keepalive
-    pings defeat it; this caps the whole call. On breach we raise — never close,
-    since litellm 1.93.0 exposes only async ``aclose`` — which frees the thread;
-    GC releases the connection.
+    pings defeat it; this caps the whole call. On breach we raise. The caller
+    must close the stream, for example via ``_close_stream``.
     """
     if total_timeout is None:
         return list(stream)
@@ -1106,6 +1129,7 @@ class LitellmLLM(LLM):
             read_timeout = min(read_timeout, max(1, int(total_timeout_override)))
 
         client = None
+        stream_response: Any = None
         if self._uses_isolated_client():
             client = HTTPHandler(timeout=read_timeout)
 
@@ -1151,6 +1175,7 @@ class LitellmLLM(LLM):
 
             return model_response
         finally:
+            _close_stream(stream_response)
             if client is not None:
                 client.close()
 
@@ -1216,6 +1241,7 @@ class LitellmLLM(LLM):
         #    - Per-request HTTPHandler eliminates cross-thread interference
         for attempt in range(max_attempts):
             client = None
+            response: Any = None
             if self._uses_isolated_client():
                 client = HTTPHandler(timeout=timeout_override or self._timeout)
 
@@ -1258,6 +1284,7 @@ class LitellmLLM(LLM):
                     max_attempts,
                 )
             finally:
+                _close_stream(response)
                 if client is not None:
                     client.close()
 

--- a/backend/tests/unit/onyx/llm/test_multi_llm_stream_retry.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm_stream_retry.py
@@ -1,9 +1,11 @@
-from collections.abc import Iterator
+from collections.abc import Generator, Iterator
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 from litellm.exceptions import Timeout as LiteLLMTimeout
 
+from onyx.llm.constants import LlmProviderNames
 from onyx.llm.interfaces import LanguageModelInput
 from onyx.llm.model_response import Delta, ModelResponseStream, StreamingChoice
 from onyx.llm.models import UserMessage
@@ -88,3 +90,49 @@ def test_stream_does_not_retry_after_first_chunk() -> None:
 
     assert fake_llm._completion.call_count == 1
     mock_logger.warning.assert_not_called()
+
+
+def test_stream_closes_non_isolated_stream_on_abandon() -> None:
+    """Regression test for onyx-dot-app/onyx#13743.
+
+    Non-isolated providers do not get a per-request HTTPHandler, so the stream
+    must be closed when the generator is abandoned. Otherwise checked-out
+    connections stay in the shared pool until it is exhausted.
+    """
+
+    class FakeStream:
+        def __init__(self, completion_stream: Any):
+            self.completion_stream = completion_stream
+
+        def __iter__(self) -> Iterator[Any]:
+            return iter(self.completion_stream)
+
+    llm = LitellmLLM(
+        api_key="test_key",
+        model_provider=LlmProviderNames.BEDROCK,
+        model_name="anthropic.claude-3-sonnet",
+        max_input_tokens=100_000,
+    )
+
+    completion_stream = MagicMock()
+    completion_stream.__iter__ = MagicMock(
+        return_value=iter([object(), object(), object()])
+    )
+    fake_stream = FakeStream(completion_stream)
+
+    with (
+        patch("litellm.completion", return_value=fake_stream) as mock_completion,
+        patch(
+            "onyx.llm.model_response.from_litellm_model_response_stream",
+            return_value=_make_stream_response("hello"),
+        ),
+    ):
+        gen = cast(
+            Generator[ModelResponseStream, None, None],
+            llm.stream(prompt=_make_prompt()),
+        )
+        next(gen)
+        gen.close()
+
+    mock_completion.assert_called_once()
+    completion_stream.close.assert_called_once()


### PR DESCRIPTION
Stream and invoke now close the LiteLLM stream in their finally blocks, not just the per-request HTTPHandler. This prevents connection-pool exhaustion when callers abandon generators for providers like Bedrock that use the shared client.

Fixes onyx-dot-app/onyx#13743