### PR TITLE
feat(chat): implicit preferred-response selection for multi-model chat

### DIFF
--- a/web/src/app/app/message/MultiModelPanel.tsx
+++ b/web/src/app/app/message/MultiModelPanel.tsx
@@ -48,6 +48,8 @@ export interface MultiModelPanelProps {
   errorDetails?: Record<string, any> | null;
   /** Whether any model is still streaming — disables preferred selection */
   isGenerating?: boolean;
+  /** Whether a send is in flight, which disables preferred selection */
+  selectionDisabled?: boolean;
 }
 
 /**
@@ -79,10 +81,16 @@ export default function MultiModelPanel({
   errorStackTrace,
   errorDetails,
   isGenerating,
+  selectionDisabled,
 }: MultiModelPanelProps) {
   const ModelIcon = getModelIcon(provider, modelName);
 
-  const canSelect = !isHidden && !isPreferred && !isGenerating && !readOnly;
+  const canSelect =
+    !isHidden &&
+    !isPreferred &&
+    !isGenerating &&
+    !selectionDisabled &&
+    !readOnly;
 
   const handlePanelClick = useCallback(() => {
     if (canSelect) onSelect();

--- a/web/src/app/app/message/MultiModelResponseView.tsx
+++ b/web/src/app/app/message/MultiModelResponseView.tsx
@@ -15,6 +15,7 @@ import { RegenerationFactory } from "@/app/app/message/messageComponents/AgentMe
 import MultiModelPanel from "@/app/app/message/MultiModelPanel";
 import { MultiModelResponse } from "@/app/app/message/interfaces";
 import { setPreferredResponse } from "@/app/app/services/lib";
+import { applyPreferredResponse } from "@/app/app/message/multiModel";
 import { useChatSessionStore } from "@/app/app/stores/useChatSessionStore";
 import { cn } from "@opal/utils";
 
@@ -78,11 +79,9 @@ export default function MultiModelResponseView({
   onHiddenPanelsChange,
   readOnly = false,
 }: MultiModelResponseViewProps) {
-  // preferredIndex mirrors the tree's preferred_response_id. When a preferred
-  // response is picked the backend also points latest_child at it, so this
-  // marks the response the flow continued through. A turn the user never
-  // picked from (e.g. a final multi-model turn) has no preference and stays
-  // unhighlighted.
+  // preferredIndex mirrors the tree's preferred_response_id, which the backend
+  // pairs with latest_child: it marks the response the flow continued through.
+  // A turn never picked from (e.g. a final multi-model turn) stays unhighlighted.
   const preferredIndexFromTree = useMemo(() => {
     if (parentMessage?.preferredResponseId == null) return null;
     const match = responses.find(
@@ -261,10 +260,6 @@ export default function MultiModelResponseView({
       const response = responses.find((r) => r.modelIndex === modelIndex);
       if (!response) return;
 
-      // Persist preferred response + sync `latestChildNodeId`. Backend's
-      // `set_preferred_response` updates `latest_child_message_id`; if the
-      // frontend chain walk disagrees, the next follow-up fails with
-      // "not on the latest mainline".
       if (parentMessage?.messageId && response.messageId && currentSessionId) {
         setPreferredResponse(parentMessage.messageId, response.messageId).catch(
           (err) => console.error("Failed to persist preferred response:", err)
@@ -273,17 +268,10 @@ export default function MultiModelResponseView({
         const tree = useChatSessionStore
           .getState()
           .sessions.get(currentSessionId)?.messageTree;
-        if (tree) {
-          const userMsg = tree.get(parentMessage.nodeId);
-          if (userMsg) {
-            const updated = new Map(tree);
-            updated.set(parentMessage.nodeId, {
-              ...userMsg,
-              preferredResponseId: response.messageId,
-              latestChildNodeId: response.nodeId,
-            });
-            updateSessionMessageTree(currentSessionId, updated);
-          }
+        const updated =
+          tree && applyPreferredResponse(tree, parentMessage.nodeId, response);
+        if (updated) {
+          updateSessionMessageTree(currentSessionId, updated);
         }
       }
     },
@@ -362,21 +350,16 @@ export default function MultiModelResponseView({
         restoreScroll();
       }
 
-      // Clear preferredResponseId in the local tree so input bar re-gates
+      // Clear preferredResponseId in the local tree so the next send assumes
+      // a preference again
       if (parentMessage && currentSessionId) {
         const tree = useChatSessionStore
           .getState()
           .sessions.get(currentSessionId)?.messageTree;
-        if (tree) {
-          const userMsg = tree.get(parentMessage.nodeId);
-          if (userMsg) {
-            const updated = new Map(tree);
-            updated.set(parentMessage.nodeId, {
-              ...userMsg,
-              preferredResponseId: undefined,
-            });
-            updateSessionMessageTree(currentSessionId, updated);
-          }
+        const updated =
+          tree && applyPreferredResponse(tree, parentMessage.nodeId, null);
+        if (updated) {
+          updateSessionMessageTree(currentSessionId, updated);
         }
       }
     }, 450);

--- a/web/src/app/app/message/MultiModelResponseView.tsx
+++ b/web/src/app/app/message/MultiModelResponseView.tsx
@@ -78,18 +78,29 @@ export default function MultiModelResponseView({
   onHiddenPanelsChange,
   readOnly = false,
 }: MultiModelResponseViewProps) {
-  // Initialize preferredIndex from the backend's preferred_response_id. When a
-  // preferred response is picked the backend also points latest_child at it, so
-  // this marks the response the flow continued through. A turn the user never
+  // preferredIndex mirrors the tree's preferred_response_id. When a preferred
+  // response is picked the backend also points latest_child at it, so this
+  // marks the response the flow continued through. A turn the user never
   // picked from (e.g. a final multi-model turn) has no preference and stays
   // unhighlighted.
-  const [preferredIndex, setPreferredIndex] = useState<number | null>(() => {
+  const preferredIndexFromTree = useMemo(() => {
     if (parentMessage?.preferredResponseId == null) return null;
     const match = responses.find(
       (r) => r.messageId === parentMessage.preferredResponseId
     );
     return match?.modelIndex ?? null;
-  });
+  }, [parentMessage?.preferredResponseId, responses]);
+  const [preferredIndex, setPreferredIndex] = useState<number | null>(
+    preferredIndexFromTree
+  );
+  // Re-sync when the preference lands after mount (session hydration, or the
+  // implicit pick made at send time). Clearing is owned by the deselect flow's
+  // animation, so only non-null values sync in.
+  useEffect(() => {
+    if (preferredIndexFromTree != null) {
+      setPreferredIndex(preferredIndexFromTree);
+    }
+  }, [preferredIndexFromTree]);
   const [hiddenPanels, setHiddenPanels] = useState<Set<number>>(new Set());
   // Controls animation: false = panels at start position, true = panels at peek position
   const [selectionEntered, setSelectionEntered] = useState(

--- a/web/src/app/app/message/MultiModelResponseView.tsx
+++ b/web/src/app/app/message/MultiModelResponseView.tsx
@@ -29,6 +29,9 @@ export interface MultiModelResponseViewProps {
   onMessageSelection?: (nodeId: number) => void;
   /** Called whenever the set of hidden panel indices changes */
   onHiddenPanelsChange?: (hidden: Set<number>) => void;
+  // Blocks picking while a send is in flight, so an explicit pick can't race
+  // the send's preference write and strand it off the backend mainline.
+  selectionDisabled?: boolean;
   /**
    * Read-only mode for the shared view: every response stays equal-width and
    * fully visible (no selection carousel), select/hide interactions are
@@ -77,6 +80,7 @@ export default function MultiModelResponseView({
   otherMessagesCanSwitchTo,
   onMessageSelection,
   onHiddenPanelsChange,
+  selectionDisabled = false,
   readOnly = false,
 }: MultiModelResponseViewProps) {
   // preferredIndex mirrors the tree's preferred_response_id, which the backend
@@ -221,7 +225,7 @@ export default function MultiModelResponseView({
 
   const handleSelectPreferred = useCallback(
     (modelIndex: number) => {
-      if (isGenerating) return;
+      if (isGenerating || selectionDisabled) return;
 
       // Cancel any pending deselect animation so it doesn't overwrite this selection
       if (deselectTimeoutRef.current !== null) {
@@ -277,6 +281,7 @@ export default function MultiModelResponseView({
     },
     [
       isGenerating,
+      selectionDisabled,
       responses,
       preferredIndex,
       parentMessage,
@@ -455,11 +460,13 @@ export default function MultiModelResponseView({
       errorStackTrace: response.errorStackTrace,
       errorDetails: response.errorDetails,
       isGenerating,
+      selectionDisabled,
     }),
     [
       preferredIndex,
       hiddenPanels,
       readOnly,
+      selectionDisabled,
       handleSelectPreferred,
       handleDeselectPreferred,
       toggleVisibility,

--- a/web/src/app/app/message/__tests__/multiModel.test.ts
+++ b/web/src/app/app/message/__tests__/multiModel.test.ts
@@ -21,8 +21,8 @@ function buildMessage(overrides: Partial<Message>): Message {
   };
 }
 
-// Builds a multi-model turn: one assistant response per entry of `models`,
-// in panel layout order (first model last).
+// Builds a multi-model turn: one response per entry of `models`, in panel
+// layout order (first model last).
 function buildTurn(
   tree: Map<number, Message>,
   models: (string | { model: string; type: "error" })[],
@@ -64,9 +64,7 @@ function buildTurn(
 
 // The production chain walk, so tests exercise the same traversal onSubmit
 // feeds the helpers.
-function chainOf(tree: Map<number, Message>): Message[] {
-  return getLatestMessageChain(tree);
-}
+const chainOf = getLatestMessageChain;
 
 beforeEach(() => {
   nextNodeId = 1;

--- a/web/src/app/app/message/__tests__/multiModel.test.ts
+++ b/web/src/app/app/message/__tests__/multiModel.test.ts
@@ -1,0 +1,175 @@
+import { Message } from "@/app/app/interfaces";
+import {
+  chooseImplicitPreferred,
+  getMultiModelChildren,
+  getUnresolvedMultiModelTurn,
+} from "@/app/app/message/multiModel";
+
+let nextNodeId = 1;
+
+function buildMessage(overrides: Partial<Message>): Message {
+  return {
+    nodeId: nextNodeId++,
+    message: "",
+    type: "assistant",
+    files: [],
+    toolCall: null,
+    parentNodeId: null,
+    packets: [],
+    ...overrides,
+  };
+}
+
+// Builds a multi-model turn: one assistant response per entry of `models`,
+// in panel layout order (first model last).
+function buildTurn(
+  tree: Map<number, Message>,
+  models: (string | { model: string; type: "error" })[],
+  options: { parent?: Message; preferredModel?: string } = {}
+): { userMessage: Message; responses: Message[] } {
+  const userMessage = buildMessage({
+    type: "user",
+    parentNodeId: options.parent?.nodeId ?? null,
+    messageId: nextNodeId * 100,
+  });
+  const responses = models.map((entry) => {
+    const model = typeof entry === "string" ? entry : entry.model;
+    return buildMessage({
+      type: typeof entry === "string" ? "assistant" : "error",
+      parentNodeId: userMessage.nodeId,
+      messageId: nextNodeId * 100,
+      overridden_model: model,
+      modelDisplayName: model,
+    });
+  });
+  userMessage.childrenNodeIds = responses.map((r) => r.nodeId);
+  const preferred = responses.find(
+    (r) => r.overridden_model === options.preferredModel
+  );
+  userMessage.preferredResponseId = preferred?.messageId ?? null;
+  userMessage.latestChildNodeId =
+    preferred?.nodeId ?? responses.at(-1)?.nodeId ?? null;
+  tree.set(userMessage.nodeId, userMessage);
+  responses.forEach((r) => tree.set(r.nodeId, r));
+  return { userMessage, responses };
+}
+
+function chainOf(tree: Map<number, Message>): Message[] {
+  return Array.from(tree.values());
+}
+
+beforeEach(() => {
+  nextNodeId = 1;
+});
+
+describe("getMultiModelChildren", () => {
+  it("returns model-tagged assistant and error children in order", () => {
+    const tree = new Map<number, Message>();
+    const { userMessage, responses } = buildTurn(tree, [
+      "gpt-5",
+      { model: "claude-opus-5", type: "error" },
+    ]);
+    expect(getMultiModelChildren(userMessage, tree)).toEqual(responses);
+  });
+
+  it("ignores turns without two model-tagged children", () => {
+    const tree = new Map<number, Message>();
+    const userMessage = buildMessage({ type: "user" });
+    const regenerated = [
+      buildMessage({ type: "assistant", parentNodeId: userMessage.nodeId }),
+      buildMessage({ type: "assistant", parentNodeId: userMessage.nodeId }),
+    ];
+    userMessage.childrenNodeIds = regenerated.map((r) => r.nodeId);
+    tree.set(userMessage.nodeId, userMessage);
+    regenerated.forEach((r) => tree.set(r.nodeId, r));
+    expect(getMultiModelChildren(userMessage, tree)).toBeNull();
+  });
+});
+
+describe("getUnresolvedMultiModelTurn", () => {
+  it("finds the last turn when no preferred response is set", () => {
+    const tree = new Map<number, Message>();
+    const { userMessage, responses } = buildTurn(tree, [
+      "gpt-5",
+      "claude-opus-5",
+    ]);
+    const turn = getUnresolvedMultiModelTurn(chainOf(tree), tree);
+    expect(turn?.userMessage).toBe(userMessage);
+    expect(turn?.responses).toEqual(responses);
+  });
+
+  it("returns null once a preferred response exists", () => {
+    const tree = new Map<number, Message>();
+    buildTurn(tree, ["gpt-5", "claude-opus-5"], {
+      preferredModel: "gpt-5",
+    });
+    expect(getUnresolvedMultiModelTurn(chainOf(tree), tree)).toBeNull();
+  });
+
+  it("returns null for single-model turns", () => {
+    const tree = new Map<number, Message>();
+    buildTurn(tree, ["gpt-5"]);
+    expect(getUnresolvedMultiModelTurn(chainOf(tree), tree)).toBeNull();
+  });
+});
+
+describe("chooseImplicitPreferred", () => {
+  it("keeps the model preferred in the previous turn", () => {
+    const tree = new Map<number, Message>();
+    const first = buildTurn(tree, ["gemini-3", "gpt-5"], {
+      preferredModel: "gemini-3",
+    });
+    const second = buildTurn(tree, ["gemini-3", "gpt-5"], {
+      parent: first.responses[0],
+    });
+    const turn = getUnresolvedMultiModelTurn(chainOf(tree), tree)!;
+    expect(chooseImplicitPreferred(chainOf(tree), tree, turn)).toBe(
+      second.responses[0]
+    );
+  });
+
+  it("falls back to the first model (last child) without a prior preference", () => {
+    const tree = new Map<number, Message>();
+    const { responses } = buildTurn(tree, ["gemini-3", "gpt-5"]);
+    const turn = getUnresolvedMultiModelTurn(chainOf(tree), tree)!;
+    expect(chooseImplicitPreferred(chainOf(tree), tree, turn)).toBe(
+      responses[1]
+    );
+  });
+
+  it("falls back to the first model when the prior model did not answer this turn", () => {
+    const tree = new Map<number, Message>();
+    const first = buildTurn(tree, ["gemini-3", "gpt-5"], {
+      preferredModel: "gemini-3",
+    });
+    const second = buildTurn(tree, ["claude-opus-5", "gpt-5"], {
+      parent: first.responses[0],
+    });
+    const turn = getUnresolvedMultiModelTurn(chainOf(tree), tree)!;
+    expect(chooseImplicitPreferred(chainOf(tree), tree, turn)).toBe(
+      second.responses[1]
+    );
+  });
+
+  it("never assumes an errored response", () => {
+    const tree = new Map<number, Message>();
+    const { responses } = buildTurn(tree, [
+      "gemini-3",
+      { model: "gpt-5", type: "error" },
+    ]);
+    const turn = getUnresolvedMultiModelTurn(chainOf(tree), tree)!;
+    expect(chooseImplicitPreferred(chainOf(tree), tree, turn)).toBe(
+      responses[0]
+    );
+  });
+
+  it("returns null when every response errored", () => {
+    const tree = new Map<number, Message>();
+    buildTurn(tree, [
+      { model: "gemini-3", type: "error" },
+      { model: "gpt-5", type: "error" },
+    ]);
+    const turn = getUnresolvedMultiModelTurn(chainOf(tree), tree)!;
+    expect(chooseImplicitPreferred(chainOf(tree), tree, turn)).toBeNull();
+  });
+});

--- a/web/src/app/app/message/__tests__/multiModel.test.ts
+++ b/web/src/app/app/message/__tests__/multiModel.test.ts
@@ -4,6 +4,7 @@ import {
   getMultiModelChildren,
   getUnresolvedMultiModelTurn,
 } from "@/app/app/message/multiModel";
+import { getLatestMessageChain } from "@/app/app/services/messageTree";
 
 let nextNodeId = 1;
 
@@ -49,13 +50,22 @@ function buildTurn(
   userMessage.preferredResponseId = preferred?.messageId ?? null;
   userMessage.latestChildNodeId =
     preferred?.nodeId ?? responses.at(-1)?.nodeId ?? null;
+  if (options.parent) {
+    options.parent.childrenNodeIds = [
+      ...(options.parent.childrenNodeIds ?? []),
+      userMessage.nodeId,
+    ];
+    options.parent.latestChildNodeId = userMessage.nodeId;
+  }
   tree.set(userMessage.nodeId, userMessage);
   responses.forEach((r) => tree.set(r.nodeId, r));
   return { userMessage, responses };
 }
 
+// The production chain walk, so tests exercise the same traversal onSubmit
+// feeds the helpers.
 function chainOf(tree: Map<number, Message>): Message[] {
-  return Array.from(tree.values());
+  return getLatestMessageChain(tree);
 }
 
 beforeEach(() => {

--- a/web/src/app/app/message/multiModel.ts
+++ b/web/src/app/app/message/multiModel.ts
@@ -83,6 +83,30 @@ export function getUnresolvedMultiModelTurn(
   return responses ? { userMessage: lastUserMsg, responses } : null;
 }
 
+// The model of the most recent preferred response before `excludeNodeId`'s
+// turn, or null when no earlier turn has a preference.
+function findPriorPreferredModel(
+  chain: Message[],
+  messageTree: Map<number, Message>,
+  excludeNodeId: number
+): string | null {
+  const priorUserMsg = [...chain]
+    .reverse()
+    .find(
+      (m) =>
+        m.type === "user" &&
+        m.nodeId !== excludeNodeId &&
+        m.preferredResponseId != null
+    );
+  if (!priorUserMsg) return null;
+  const priorPreferred = (priorUserMsg.childrenNodeIds ?? [])
+    .map((id) => messageTree.get(id))
+    .find((child) => child?.messageId === priorUserMsg.preferredResponseId);
+  return (
+    priorPreferred?.overridden_model || priorPreferred?.modelDisplayName || null
+  );
+}
+
 // The response a send assumes as preferred: the prior turn's preferred model
 // when it answered this turn too, else the first model (right-most panel,
 // last child). Errored responses can't continue the chain, never assumed.
@@ -94,30 +118,39 @@ export function chooseImplicitPreferred(
   const candidates = turn.responses.filter(
     (r) => r.type === "assistant" && r.messageId != null
   );
-  if (candidates.length === 0) return null;
+  const priorModel = findPriorPreferredModel(
+    chain,
+    messageTree,
+    turn.userMessage.nodeId
+  );
+  const match = priorModel
+    ? candidates.find(
+        (r) => (r.overridden_model || r.modelDisplayName) === priorModel
+      )
+    : undefined;
+  return match ?? candidates.at(-1) ?? null;
+}
 
-  for (let i = chain.length - 1; i >= 0; i--) {
-    const msg = chain[i];
-    if (
-      !msg ||
-      msg.type !== "user" ||
-      msg.nodeId === turn.userMessage.nodeId ||
-      msg.preferredResponseId == null
-    ) {
-      continue;
-    }
-    const priorPreferred = (msg.childrenNodeIds ?? [])
-      .map((id) => messageTree.get(id))
-      .find((child) => child?.messageId === msg.preferredResponseId);
-    const priorModel =
-      priorPreferred?.overridden_model || priorPreferred?.modelDisplayName;
-    if (!priorModel) continue;
-    const match = candidates.find(
-      (r) => (r.overridden_model || r.modelDisplayName) === priorModel
-    );
-    if (match) return match;
-    break;
-  }
-
-  return candidates[candidates.length - 1] ?? null;
+// preferredResponseId and latestChildNodeId move together, as in the backend's
+// set_preferred_response. A disagreeing local chain walk breaks the next send.
+// Null clears the preference and leaves the chain tip alone.
+export function applyPreferredResponse(
+  tree: Map<number, Message>,
+  userNodeId: number,
+  response: Pick<Message, "messageId" | "nodeId"> | null
+): Map<number, Message> | null {
+  const userMsg = tree.get(userNodeId);
+  if (!userMsg) return null;
+  const updated = new Map(tree);
+  updated.set(
+    userNodeId,
+    response
+      ? {
+          ...userMsg,
+          preferredResponseId: response.messageId,
+          latestChildNodeId: response.nodeId,
+        }
+      : { ...userMsg, preferredResponseId: undefined }
+  );
+  return updated;
 }

--- a/web/src/app/app/message/multiModel.ts
+++ b/web/src/app/app/message/multiModel.ts
@@ -1,19 +1,6 @@
 import { Message } from "@/app/app/interfaces";
 import { MultiModelResponse } from "@/app/app/message/interfaces";
 
-/**
- * Group a user message's sibling assistant responses into multi-model panels.
- *
- * A multi-model turn is a user message with 2+ assistant/error children that
- * each carry a model name (`modelDisplayName` or `overridden_model`). That
- * metadata is what distinguishes a real multi-model turn from a plain
- * regeneration, which also produces sibling assistant messages. Returns null
- * when the message isn't a multi-model turn.
- *
- * `modelProviderLookup` maps a model identifier → provider slug for icon
- * resolution. Pass an empty map when the provider list is unavailable (e.g. the
- * read-only shared view). `getModelIcon` then falls back to the model name.
- */
 // The model that produced a message. Error responses carry the model that
 // failed, so they count for attribution too.
 export function messageModelName(msg: Message): string | null {
@@ -21,25 +8,37 @@ export function messageModelName(msg: Message): string | null {
   return msg.overridden_model || msg.modelDisplayName || null;
 }
 
+// Model-tagged children (2+) of a multi-model turn, in layout order. The
+// model metadata distinguishes a real multi-model turn from a plain
+// regeneration. Null when the message isn't a multi-model turn.
+export function getMultiModelChildren(
+  userMessage: Message,
+  messageTree: Map<number, Message>
+): Message[] | null {
+  const childIds = userMessage.childrenNodeIds ?? [];
+  if (childIds.length < 2) return null;
+
+  const multiModelChildren = childIds
+    .map((id) => messageTree.get(id))
+    .filter(
+      (msg): msg is Message =>
+        msg !== undefined &&
+        (msg.type === "assistant" || msg.type === "error") &&
+        Boolean(msg.modelDisplayName || msg.overridden_model)
+    );
+  return multiModelChildren.length >= 2 ? multiModelChildren : null;
+}
+
+// Group a user message's sibling responses into multi-model panels.
+// `modelProviderLookup` maps model → provider slug for icons and may be
+// empty (e.g. the shared view). `getModelIcon` then falls back to the name.
 export function getMultiModelResponses(
   userMessage: Message,
   messageTree: Map<number, Message>,
   modelProviderLookup: Map<string, string>
 ): MultiModelResponse[] | null {
-  const childIds = userMessage.childrenNodeIds ?? [];
-  if (childIds.length < 2) return null;
-
-  const assistantChildren = childIds
-    .map((id) => messageTree.get(id))
-    .filter(
-      (msg): msg is Message =>
-        msg !== undefined && (msg.type === "assistant" || msg.type === "error")
-    );
-
-  const multiModelChildren = assistantChildren.filter(
-    (msg) => msg.modelDisplayName || msg.overridden_model
-  );
-  if (multiModelChildren.length < 2) return null;
+  const multiModelChildren = getMultiModelChildren(userMessage, messageTree);
+  if (!multiModelChildren) return null;
 
   return multiModelChildren.map((msg, idx): MultiModelResponse => {
     const modelVersion =
@@ -65,4 +64,60 @@ export function getMultiModelResponses(
       errorDetails: isError ? msg.errorDetails : null,
     };
   });
+}
+
+export interface UnresolvedMultiModelTurn {
+  userMessage: Message;
+  responses: Message[];
+}
+
+// The multi-model turn a new message would continue from, when the user
+// never picked a preferred response. `chain` is the tree's latest chain.
+export function getUnresolvedMultiModelTurn(
+  chain: Message[],
+  messageTree: Map<number, Message>
+): UnresolvedMultiModelTurn | null {
+  const lastUserMsg = [...chain].reverse().find((m) => m.type === "user");
+  if (!lastUserMsg || lastUserMsg.preferredResponseId != null) return null;
+  const responses = getMultiModelChildren(lastUserMsg, messageTree);
+  return responses ? { userMessage: lastUserMsg, responses } : null;
+}
+
+// The response a send assumes as preferred: the prior turn's preferred model
+// when it answered this turn too, else the first model (right-most panel,
+// last child). Errored responses can't continue the chain, never assumed.
+export function chooseImplicitPreferred(
+  chain: Message[],
+  messageTree: Map<number, Message>,
+  turn: UnresolvedMultiModelTurn
+): Message | null {
+  const candidates = turn.responses.filter(
+    (r) => r.type === "assistant" && r.messageId != null
+  );
+  if (candidates.length === 0) return null;
+
+  for (let i = chain.length - 1; i >= 0; i--) {
+    const msg = chain[i];
+    if (
+      !msg ||
+      msg.type !== "user" ||
+      msg.nodeId === turn.userMessage.nodeId ||
+      msg.preferredResponseId == null
+    ) {
+      continue;
+    }
+    const priorPreferred = (msg.childrenNodeIds ?? [])
+      .map((id) => messageTree.get(id))
+      .find((child) => child?.messageId === msg.preferredResponseId);
+    const priorModel =
+      priorPreferred?.overridden_model || priorPreferred?.modelDisplayName;
+    if (!priorModel) continue;
+    const match = candidates.find(
+      (r) => (r.overridden_model || r.modelDisplayName) === priorModel
+    );
+    if (match) return match;
+    break;
+  }
+
+  return candidates[candidates.length - 1] ?? null;
 }

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -8,6 +8,7 @@ import {
   updateLlmOverrideForChatSession,
 } from "@/app/app/services/lib";
 import {
+  applyPreferredResponse,
   chooseImplicitPreferred,
   getMultiModelChildren,
   getUnresolvedMultiModelTurn,
@@ -425,7 +426,7 @@ export default function useChatController({
       let currentHistory = getLatestMessageChain(currentMessageTreeLocal);
       let lastMessage = currentHistory[currentHistory.length - 1];
 
-      // A multi-model turn whose chain-tip panel errored still has usable
+      // A multi-model turn whose chain-tip panel errored can still have usable
       // siblings. Keep the turn so the implicit-preferred pick below can
       // continue the chain through a successful sibling.
       const errorTurnUserMsg =
@@ -651,18 +652,19 @@ export default function useChatController({
       // Sending into an unresolved multi-model turn must not block: assume a
       // preference, persist it, and continue the chain from it. An explicit
       // pick already set preferredResponseId, making this a no-op.
-      let implicitPreferred: Message | null = null;
-      let implicitPreferredPersist: Promise<Response> | null = null;
-      let implicitPreferredRevert: (() => void) | null = null;
+      let implicitPreference: {
+        message: Message;
+        persist: Promise<Response | null>;
+        revert: () => void;
+      } | null = null;
       if (!regenerationRequest && !messageToResend) {
-        const chain = getLatestMessageChain(currentMessageTreeLocal);
         const unresolvedTurn = getUnresolvedMultiModelTurn(
-          chain,
+          currentHistory,
           currentMessageTreeLocal
         );
         const chosen = unresolvedTurn
           ? chooseImplicitPreferred(
-              chain,
+              currentHistory,
               currentMessageTreeLocal,
               unresolvedTurn
             )
@@ -672,37 +674,42 @@ export default function useChatController({
           chosen?.messageId != null &&
           unresolvedTurn.userMessage.messageId != null
         ) {
-          implicitPreferred = chosen;
-          implicitPreferredPersist = setPreferredResponse(
-            unresolvedTurn.userMessage.messageId,
-            chosen.messageId
-          );
           // Mirror into the local tree so the panel marks the selection and
-          // the chain walk below continues through the chosen response.
-          currentMessageTreeLocal = new Map(currentMessageTreeLocal);
-          currentMessageTreeLocal.set(unresolvedTurn.userMessage.nodeId, {
-            ...unresolvedTurn.userMessage,
-            preferredResponseId: chosen.messageId,
-            latestChildNodeId: chosen.nodeId,
-          });
-          // A failed PUT must undo the mirror, or the turn reads resolved
+          // the chain walk below continues through the chosen response. A
+          // failed PUT must undo the mirror, or the turn reads resolved
           // locally, retries skip the PUT, and the send's parent stays off
           // the backend mainline until a reload.
           const originalUserMessage = unresolvedTurn.userMessage;
-          implicitPreferredRevert = () => {
-            currentMessageTreeLocal = new Map(currentMessageTreeLocal);
-            currentMessageTreeLocal.set(
-              originalUserMessage.nodeId,
-              originalUserMessage
-            );
-            updateSessionMessageTree(frozenSessionId, currentMessageTreeLocal);
+          implicitPreference = {
+            message: chosen,
+            persist: setPreferredResponse(
+              unresolvedTurn.userMessage.messageId,
+              chosen.messageId
+            ).catch(() => null),
+            revert: () => {
+              currentMessageTreeLocal = new Map(currentMessageTreeLocal);
+              currentMessageTreeLocal.set(
+                originalUserMessage.nodeId,
+                originalUserMessage
+              );
+              updateSessionMessageTree(
+                frozenSessionId,
+                currentMessageTreeLocal
+              );
+            },
           };
+          currentMessageTreeLocal =
+            applyPreferredResponse(
+              currentMessageTreeLocal,
+              originalUserMessage.nodeId,
+              chosen
+            ) ?? currentMessageTreeLocal;
         }
       }
 
       let parentMessage =
         messageToResendParent ||
-        implicitPreferred ||
+        implicitPreference?.message ||
         (currMessageHistory.length > 0
           ? currMessageHistory[currMessageHistory.length - 1]
           : null) ||
@@ -982,11 +989,11 @@ export default function useChatController({
         await llmManager.persistOverrides(currChatSessionId);
 
         // The send's mainline walk must see the assumed preference. An
-        // unconfirmed write would 400 with "not on the latest mainline".
-        if (implicitPreferredPersist) {
-          const res = await implicitPreferredPersist.catch(() => null);
+        // unconfirmed write can 400 with "not on the latest mainline".
+        if (implicitPreference) {
+          const res = await implicitPreference.persist;
           if (!res?.ok) {
-            implicitPreferredRevert?.();
+            implicitPreference.revert();
             const data = res ? await res.json().catch(() => ({})) : {};
             throw new Error(
               data.detail ?? "Failed to set the preferred response"

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -4,8 +4,13 @@ import {
   buildChatUrl,
   getAvailableContextTokens,
   nameChatSession,
+  setPreferredResponse,
   updateLlmOverrideForChatSession,
 } from "@/app/app/services/lib";
+import {
+  chooseImplicitPreferred,
+  getUnresolvedMultiModelTurn,
+} from "@/app/app/message/multiModel";
 import { getMaxSelectedDocumentTokens } from "@/lib/projects/svc";
 import { DEFAULT_CONTEXT_TOKENS } from "@/lib/constants";
 import { StreamStopInfo } from "@/lib/search/interfaces";
@@ -626,8 +631,48 @@ export default function useChatController({
           ? currentHistory.slice(0, messageToResendIndex)
           : currentHistory;
 
+      // Sending into an unresolved multi-model turn must not block: assume a
+      // preference, persist it, and continue the chain from it. An explicit
+      // pick already set preferredResponseId, making this a no-op.
+      let implicitPreferred: Message | null = null;
+      let implicitPreferredPersist: Promise<Response> | null = null;
+      if (!regenerationRequest && !messageToResend) {
+        const chain = getLatestMessageChain(currentMessageTreeLocal);
+        const unresolvedTurn = getUnresolvedMultiModelTurn(
+          chain,
+          currentMessageTreeLocal
+        );
+        const chosen = unresolvedTurn
+          ? chooseImplicitPreferred(
+              chain,
+              currentMessageTreeLocal,
+              unresolvedTurn
+            )
+          : null;
+        if (
+          unresolvedTurn &&
+          chosen?.messageId != null &&
+          unresolvedTurn.userMessage.messageId != null
+        ) {
+          implicitPreferred = chosen;
+          implicitPreferredPersist = setPreferredResponse(
+            unresolvedTurn.userMessage.messageId,
+            chosen.messageId
+          );
+          // Mirror into the local tree so the panel marks the selection and
+          // the chain walk below continues through the chosen response.
+          currentMessageTreeLocal = new Map(currentMessageTreeLocal);
+          currentMessageTreeLocal.set(unresolvedTurn.userMessage.nodeId, {
+            ...unresolvedTurn.userMessage,
+            preferredResponseId: chosen.messageId,
+            latestChildNodeId: chosen.nodeId,
+          });
+        }
+      }
+
       let parentMessage =
         messageToResendParent ||
+        implicitPreferred ||
         (currMessageHistory.length > 0
           ? currMessageHistory[currMessageHistory.length - 1]
           : null) ||
@@ -905,6 +950,18 @@ export default function useChatController({
         // selections. A failed write surfaces as a chat error and the next
         // send re-persists.
         await llmManager.persistOverrides(currChatSessionId);
+
+        // The send's mainline walk must see the assumed preference. An
+        // unconfirmed write would 400 with "not on the latest mainline".
+        if (implicitPreferredPersist) {
+          const res = await implicitPreferredPersist;
+          if (!res.ok) {
+            const data = await res.json().catch(() => ({}));
+            throw new Error(
+              data.detail ?? "Failed to set the preferred response"
+            );
+          }
+        }
 
         const lastSuccessfulMessageId = getLastSuccessfulMessageId(
           currentMessageTreeLocal

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -696,11 +696,16 @@ export default function useChatController({
               if (live && live.preferredResponseId !== chosen.messageId) {
                 return;
               }
-              currentMessageTreeLocal = new Map(currentMessageTreeLocal);
-              currentMessageTreeLocal.set(
+              // Clear only the preference so the retry re-runs the PUT. The
+              // chain tip stays on the assumed response, keeping the failed
+              // follow-up reachable in the rendered chat.
+              const reverted = applyPreferredResponse(
+                currentMessageTreeLocal,
                 originalUserMessage.nodeId,
-                originalUserMessage
+                null
               );
+              if (!reverted) return;
+              currentMessageTreeLocal = reverted;
               updateSessionMessageTree(
                 frozenSessionId,
                 currentMessageTreeLocal

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -687,6 +687,15 @@ export default function useChatController({
               chosen.messageId
             ).catch(() => null),
             revert: () => {
+              // A newer explicit pick may have replaced the assumption while
+              // the PUT was in flight. Never clobber it with this snapshot.
+              const live = useChatSessionStore
+                .getState()
+                .sessions.get(frozenSessionId)
+                ?.messageTree?.get(originalUserMessage.nodeId);
+              if (live && live.preferredResponseId !== chosen.messageId) {
+                return;
+              }
               currentMessageTreeLocal = new Map(currentMessageTreeLocal);
               currentMessageTreeLocal.set(
                 originalUserMessage.nodeId,

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -9,6 +9,7 @@ import {
 } from "@/app/app/services/lib";
 import {
   chooseImplicitPreferred,
+  getMultiModelChildren,
   getUnresolvedMultiModelTurn,
 } from "@/app/app/message/multiModel";
 import { getMaxSelectedDocumentTokens } from "@/lib/projects/svc";
@@ -424,11 +425,27 @@ export default function useChatController({
       let currentHistory = getLatestMessageChain(currentMessageTreeLocal);
       let lastMessage = currentHistory[currentHistory.length - 1];
 
+      // A multi-model turn whose chain-tip panel errored still has usable
+      // siblings. Keep the turn so the implicit-preferred pick below can
+      // continue the chain through a successful sibling.
+      const errorTurnUserMsg =
+        lastMessage?.type === "error" && lastMessage.parentNodeId != null
+          ? currentMessageTreeLocal.get(lastMessage.parentNodeId)
+          : undefined;
+      const errorTurnHasUsableSibling = errorTurnUserMsg
+        ? (getMultiModelChildren(
+            errorTurnUserMsg,
+            currentMessageTreeLocal
+          )?.some((m) => m.type === "assistant" && m.messageId != null) ??
+          false)
+        : false;
+
       if (
         lastMessage &&
         lastMessage.type === "error" &&
         !messageIdToResend &&
-        !regenerationRequest
+        !regenerationRequest &&
+        !errorTurnHasUsableSibling
       ) {
         const newMessageTree = new Map(currentMessageTreeLocal);
         const parentNodeId = lastMessage.parentNodeId;
@@ -636,6 +653,7 @@ export default function useChatController({
       // pick already set preferredResponseId, making this a no-op.
       let implicitPreferred: Message | null = null;
       let implicitPreferredPersist: Promise<Response> | null = null;
+      let implicitPreferredRevert: (() => void) | null = null;
       if (!regenerationRequest && !messageToResend) {
         const chain = getLatestMessageChain(currentMessageTreeLocal);
         const unresolvedTurn = getUnresolvedMultiModelTurn(
@@ -667,6 +685,18 @@ export default function useChatController({
             preferredResponseId: chosen.messageId,
             latestChildNodeId: chosen.nodeId,
           });
+          // A failed PUT must undo the mirror, or the turn reads resolved
+          // locally, retries skip the PUT, and the send's parent stays off
+          // the backend mainline until a reload.
+          const originalUserMessage = unresolvedTurn.userMessage;
+          implicitPreferredRevert = () => {
+            currentMessageTreeLocal = new Map(currentMessageTreeLocal);
+            currentMessageTreeLocal.set(
+              originalUserMessage.nodeId,
+              originalUserMessage
+            );
+            updateSessionMessageTree(frozenSessionId, currentMessageTreeLocal);
+          };
         }
       }
 
@@ -954,9 +984,10 @@ export default function useChatController({
         // The send's mainline walk must see the assumed preference. An
         // unconfirmed write would 400 with "not on the latest mainline".
         if (implicitPreferredPersist) {
-          const res = await implicitPreferredPersist;
-          if (!res.ok) {
-            const data = await res.json().catch(() => ({}));
+          const res = await implicitPreferredPersist.catch(() => null);
+          if (!res?.ok) {
+            implicitPreferredRevert?.();
+            const data = res ? await res.json().catch(() => ({})) : {};
             throw new Error(
               data.detail ?? "Failed to set the preferred response"
             );

--- a/web/src/hooks/useMultiModelChat.ts
+++ b/web/src/hooks/useMultiModelChat.ts
@@ -118,7 +118,9 @@ export default function useMultiModelChat(
         if (base.some((m) => llmOptionKey(m) === llmOptionKey(model))) {
           return base;
         }
-        return [...base, model];
+        // Prepend so pills grow right-to-left: the first model keeps the
+        // right-most pill and panel, and is the implicit-preferred default.
+        return [model, ...base];
       });
     },
     [currentLlmModel]

--- a/web/src/sections/chat/ChatUI.tsx
+++ b/web/src/sections/chat/ChatUI.tsx
@@ -15,6 +15,7 @@ import { SelectedModel } from "@/sections/model-selector/MultiModelSelector";
 import { buildModelProviderLookup } from "@/lib/languageModels/options";
 import DynamicBottomSpacer from "@/components/chat/DynamicBottomSpacer";
 import {
+  useCurrentChatState,
   useCurrentMessageHistory,
   useCurrentMessageTree,
   useLoadingError,
@@ -88,6 +89,7 @@ const ChatUI = React.memo(
     const messageTree = useCurrentMessageTree();
     const error = useUncaughtError();
     const loadError = useLoadingError();
+    const chatState = useCurrentChatState();
     // Stable fallbacks to avoid changing prop identities on each render
     const emptyDocs = useMemo<OnyxDocument[]>(() => [], []);
     const emptyChildrenIds = useMemo<number[]>(() => [], []);
@@ -228,6 +230,7 @@ const ChatUI = React.memo(
                         parentMessage?.childrenNodeIds ?? emptyChildrenIds
                       }
                       onMessageSelection={onMessageSelection}
+                      selectionDisabled={chatState !== "input"}
                     />
                   )}
                 </div>

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -91,7 +91,6 @@ export interface AppInputBarProps {
   toggleDeepResearch: () => void;
   isMultiModelActive?: boolean;
   disabled: boolean;
-  awaitingPreferredSelection?: boolean;
   ref?: React.Ref<AppInputBarHandle>;
   // Side panel tab reading
   tabReadingEnabled?: boolean;
@@ -117,7 +116,6 @@ const AppInputBar = React.memo(
     isMultiModelActive,
     setPresentingDocument,
     disabled,
-    awaitingPreferredSelection = false,
     ref,
     tabReadingEnabled,
     currentTabUrl,
@@ -369,7 +367,6 @@ const AppInputBar = React.memo(
     const combinedSettingsData = useSettings();
 
     const prevChatStateRef = useRef(chatState);
-    const prevAwaitingRef = useRef(awaitingPreferredSelection);
     const prevRenderCompleteRef = useRef(latestMessageRenderComplete);
 
     useEffect(() => {
@@ -378,16 +375,10 @@ const AppInputBar = React.memo(
       // gate, a queued follow-up fires while the smooth-streaming
       // typewriter is still flushing the prior answer.
       const wasReady =
-        prevChatStateRef.current === "input" &&
-        !prevAwaitingRef.current &&
-        prevRenderCompleteRef.current;
-      const isReady =
-        chatState === "input" &&
-        !awaitingPreferredSelection &&
-        latestMessageRenderComplete;
+        prevChatStateRef.current === "input" && prevRenderCompleteRef.current;
+      const isReady = chatState === "input" && latestMessageRenderComplete;
 
       prevChatStateRef.current = chatState;
-      prevAwaitingRef.current = awaitingPreferredSelection;
       prevRenderCompleteRef.current = latestMessageRenderComplete;
 
       if (!wasReady && isReady && queuedMessages.length > 0) {
@@ -400,7 +391,6 @@ const AppInputBar = React.memo(
       }
     }, [
       chatState,
-      awaitingPreferredSelection,
       latestMessageRenderComplete,
       queuedMessages,
       removeCurrentQueuedMessage,
@@ -792,16 +782,14 @@ const AppInputBar = React.memo(
             icon={
               isClassifying
                 ? SvgSimpleLoader
-                : (chatState !== "input" || awaitingPreferredSelection) &&
-                    message.trim()
+                : chatState !== "input" && message.trim()
                   ? SvgArrowUp
                   : chatState === "streaming" || isVoicePlaybackControllable
                     ? SvgStop
                     : SvgArrowUp
             }
             onClick={() => {
-              const canSubmitNormally =
-                chatState === "input" && !awaitingPreferredSelection;
+              const canSubmitNormally = chatState === "input";
               if (!canSubmitNormally && message.trim()) {
                 if (queuedMessages.length < MAX_QUEUED_MESSAGES) {
                   enqueueCurrentMessage(message.trim());
@@ -829,7 +817,6 @@ const AppInputBar = React.memo(
         <QueuedMessageBar
           messages={queuedMessages}
           highlightedIndex={queueNav.highlightedIndex}
-          awaitingPreferredSelection={awaitingPreferredSelection}
           onDiscard={removeCurrentQueuedMessage}
           onHighlight={queueNav.setHighlightedIndex}
         />
@@ -965,9 +952,7 @@ const AppInputBar = React.memo(
                           !(event.nativeEvent as any).isComposing
                         ) {
                           event.preventDefault();
-                          const canSubmitNormally =
-                            chatState === "input" &&
-                            !awaitingPreferredSelection;
+                          const canSubmitNormally = chatState === "input";
                           if (canSubmitNormally) {
                             if (
                               message &&

--- a/web/src/sections/input/BaseInputBar.tsx
+++ b/web/src/sections/input/BaseInputBar.tsx
@@ -274,7 +274,6 @@ const BaseInputBar = memo(
             <QueuedMessageBar
               messages={queue}
               highlightedIndex={queueNav.highlightedIndex}
-              awaitingPreferredSelection={false}
               onDiscard={(index) => onRemoveQueuedMessage?.(index)}
               onHighlight={queueNav.setHighlightedIndex}
             />

--- a/web/src/sections/input/QueuedMessageBar.stories.tsx
+++ b/web/src/sections/input/QueuedMessageBar.stories.tsx
@@ -28,7 +28,6 @@ const meta: Meta<typeof QueuedMessageBar> = {
   args: {
     messages: SAMPLE_MESSAGES,
     highlightedIndex: null,
-    awaitingPreferredSelection: false,
     onDiscard: (index: number) => console.log("onDiscard", index),
     onHighlight: (index: number | null) => console.log("onHighlight", index),
   },
@@ -43,16 +42,6 @@ export const Default: Story = {};
 export const Highlighted: Story = {
   args: {
     highlightedIndex: 1,
-  },
-};
-
-/**
- * When the chat is waiting for the user to pick a response, the head of the
- * queue shows a "Select a response to continue" label instead.
- */
-export const AwaitingPreferredSelection: Story = {
-  args: {
-    awaitingPreferredSelection: true,
   },
 };
 
@@ -74,7 +63,6 @@ function InteractiveDemo() {
     <QueuedMessageBar
       messages={messages}
       highlightedIndex={highlightedIndex}
-      awaitingPreferredSelection={false}
       onHighlight={setHighlightedIndex}
       onDiscard={(index) => {
         setMessages((prev) => prev.filter((_, i) => i !== index));

--- a/web/src/sections/input/QueuedMessageBar.tsx
+++ b/web/src/sections/input/QueuedMessageBar.tsx
@@ -6,7 +6,6 @@ import { QueuedMessage } from "@/app/app/interfaces";
 interface QueuedMessageBarProps {
   messages: readonly QueuedMessage[];
   highlightedIndex: number | null;
-  awaitingPreferredSelection: boolean;
   onDiscard: (index: number) => void;
   onHighlight: (index: number | null) => void;
 }
@@ -14,7 +13,6 @@ interface QueuedMessageBarProps {
 function QueuedMessageBar({
   messages,
   highlightedIndex,
-  awaitingPreferredSelection,
   onDiscard,
   onHighlight,
 }: QueuedMessageBarProps) {
@@ -31,8 +29,6 @@ function QueuedMessageBar({
         <div className="flex flex-col gap-1 pb-1.5">
           {messages.map((item, index) => {
             const isHighlighted = highlightedIndex === index;
-            const showAwaitingLabel = awaitingPreferredSelection && index === 0;
-            const showEditLabel = isHighlighted && !showAwaitingLabel;
 
             return (
               <div
@@ -63,14 +59,7 @@ function QueuedMessageBar({
                     {item.text}
                   </Text>
                 </div>
-                {showAwaitingLabel && (
-                  <div className="shrink-0 whitespace-nowrap">
-                    <Text font="secondary-body" color="text-02">
-                      Select a response to continue
-                    </Text>
-                  </div>
-                )}
-                {showEditLabel && (
+                {isHighlighted && (
                   <div className="shrink-0 whitespace-nowrap flex items-center gap-0.5">
                     <span className="translate-y-[1.5px] text-text-02 text-[0.7rem]">
                       ↵

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -429,32 +429,6 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     return () => window.removeEventListener("pagehide", handlePageHide);
   }, [incognitoEnabled, currentChatSessionId]);
 
-  // Block input when the last turn is multi-model and the user hasn't
-  // selected a preferred response yet. Without a selection, it's ambiguous
-  // which model's response should be used as context for the next message.
-  const awaitingPreferredSelection = useMemo(() => {
-    if (!messageTree || currentChatState !== "input") return false;
-    // Find the last user message in the history
-    const lastUserMsg = [...messageHistory]
-      .reverse()
-      .find((m) => m.type === "user");
-    if (!lastUserMsg) return false;
-    const childIds = lastUserMsg.childrenNodeIds ?? [];
-    if (childIds.length < 2) return false;
-    // Check if children are multi-model (have modelDisplayName)
-    const multiModelChildren = childIds
-      .map((id) => messageTree.get(id))
-      .filter(
-        (m) =>
-          m &&
-          (m.type === "assistant" || m.type === "error") &&
-          (m.modelDisplayName || m.overridden_model)
-      );
-    if (multiModelChildren.length < 2) return false;
-    // Check if a preferred response has been set on this user message
-    return lastUserMsg.preferredResponseId == null;
-  }, [messageHistory, messageTree, currentChatState]);
-
   // Determine anchor: second-to-last message (last user message before current response)
   const anchorMessage = messageHistory.at(-2) ?? messageHistory[0];
   const anchorNodeId = anchorMessage?.nodeId;
@@ -1127,7 +1101,6 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                             onboardingState.currentStep !==
                               OnboardingStep.Complete)
                         }
-                        awaitingPreferredSelection={awaitingPreferredSelection}
                       />
                       <div
                         className={cn(


### PR DESCRIPTION
## Description

Part of [ENG-4318](https://linear.app/onyx-app/issue/ENG-4318/multi-llm-improvements): sending after a multi-model turn no longer blocks behind "Select a response to continue". The send assumes a preferred response and marks it so the user can correct it:

1. An explicit click always wins (unchanged).
2. Else keep the previous turn's preferred model, when it answered this turn.
3. Else pick the first model. Pills now grow right-to-left so the first model keeps the right-most pill and panel ([Figma](https://www.figma.com/design/BV9tfqwS0GjTIJP7ki6Qux/Search---Chat---Tools?node-id=5136-191253&t=aEEu6tItE1jOVrYT-1)).

The assumption persists through the existing `set-preferred-response` PUT before the send, so the backend mainline continues through the chosen response. Also fixes `preferredIndex` never re-syncing after session hydration, dedupes the turn-detection logic into `multiModel.ts`, and stops the last-message error cleanup from deleting a multi-model turn that still has a successful sibling.

Viewport-aware selection on small screens and scroll-into-view are follow-up PRs.

## How Has This Been Tested?

Jest unit tests for the selection helpers. Live on dev: verified in the DB that `preferred_response_id` and the parent chain land on the assumed response for all three priorities.

| Before | After |
|---|---|
| <img alt="before: send blocked behind selection notice" src="https://github.com/user-attachments/assets/3016a10d-ab6e-4f98-9e92-0df28dc712d1" /> | <img alt="after: implicit selection on send" src="https://github.com/user-attachments/assets/7b4d1f6b-4578-4859-b33a-f2346123398d" /> |
| Send blocked, message queues behind the notice | Message sends immediately, assumed response marked "Preferred Response" |
| <img alt="before: pills append right" src="https://github.com/user-attachments/assets/a08432e9-3bbd-47f1-89dd-a074d684886e" /> | <img alt="after: pills prepend left" src="https://github.com/user-attachments/assets/b2230bb1-c39d-43dd-821a-7cebc5ae312f" /> |
| New models append to the right | New models prepend, first model stays right-most |

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check
