### PR TITLE
feat(chat): narrow-screen response carousel drives the implicit pick

### DIFF
--- a/web/src/app/app/message/MultiModelPanel.tsx
+++ b/web/src/app/app/message/MultiModelPanel.tsx
@@ -4,7 +4,7 @@ import { useCallback } from "react";
 import { Button } from "@opal/components";
 import { Text } from "@opal/components";
 import { ContentAction } from "@opal/layouts";
-import { SvgEyeOff, SvgX } from "@opal/icons";
+import { SvgChevronLeft, SvgChevronRight, SvgEyeOff, SvgX } from "@opal/icons";
 import { getModelIcon } from "@/lib/languageModels";
 import AgentMessage, {
   AgentMessageProps,
@@ -50,6 +50,17 @@ export interface MultiModelPanelProps {
   isGenerating?: boolean;
   /** Whether a send is in flight, which disables preferred selection */
   selectionDisabled?: boolean;
+  /** Narrow-carousel nav to the previous model, flanking the header left */
+  carouselPrev?: CarouselNeighbor;
+  /** Narrow-carousel nav to the next model, flanking the header right */
+  carouselNext?: CarouselNeighbor;
+}
+
+export interface CarouselNeighbor {
+  provider: string;
+  modelName: string;
+  displayName: string;
+  onClick: () => void;
 }
 
 /**
@@ -82,6 +93,8 @@ export default function MultiModelPanel({
   errorDetails,
   isGenerating,
   selectionDisabled,
+  carouselPrev,
+  carouselNext,
 }: MultiModelPanelProps) {
   const ModelIcon = getModelIcon(provider, modelName);
 
@@ -180,14 +193,50 @@ export default function MultiModelPanel({
     <div className={headerClassName}>{headerContent}</div>
   );
 
+  // Narrow-carousel header row: prev/next model nav flanks the model pill.
+  const headerWithNav =
+    carouselPrev || carouselNext ? (
+      // raw-ok: nav row around a flex-1 min-w-0 pill slot, grow semantics no Section width preset can express
+      <div className="flex items-center gap-1">
+        {carouselPrev ? (
+          <Button
+            prominence="tertiary"
+            icon={getModelIcon(carouselPrev.provider, carouselPrev.modelName)}
+            rightIcon={SvgChevronLeft}
+            onClick={carouselPrev.onClick}
+            tooltip={carouselPrev.displayName}
+            aria-label={`Show the ${carouselPrev.displayName} response`}
+          />
+        ) : null}
+        {/* raw-ok: flex-1 slot for the pill inside the nav row, no layout primitive exposes a bare grow wrapper */}
+        <div className="flex-1 min-w-0">{header}</div>
+        {carouselNext ? (
+          <Button
+            prominence="tertiary"
+            icon={SvgChevronRight}
+            rightIcon={getModelIcon(
+              carouselNext.provider,
+              carouselNext.modelName
+            )}
+            onClick={carouselNext.onClick}
+            tooltip={carouselNext.displayName}
+            aria-label={`Show the ${carouselNext.displayName} response`}
+          />
+        ) : null}
+      </div>
+    ) : (
+      header
+    );
+
   // Hidden/collapsed panel — just the header row
   if (isHidden) {
-    return header;
+    return headerWithNav;
   }
 
   return (
+    // raw-ok: panel column, min-w-0 shrink semantics no Section width preset provides
     <div className="flex flex-col gap-3 min-w-0 rounded-16">
-      {header}
+      {headerWithNav}
       {errorMessage ? (
         <div className="p-4">
           <ErrorBanner

--- a/web/src/app/app/message/MultiModelResponseView.tsx
+++ b/web/src/app/app/message/MultiModelResponseView.tsx
@@ -140,14 +140,22 @@ export default function MultiModelResponseView({
   const deselectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // True while the reverse animation is playing (deselect → back to equal panels)
   const [selectionExiting, setSelectionExiting] = useState(false);
+  // Measures the root container so the layout can drop to the one-at-a-time
+  // carousel when the panels can't all fit side by side.
+  const [containerW, setContainerW] = useState(0);
+  const [rootEl, setRootEl] = useState<HTMLDivElement | null>(null);
+
   // Measures the overflow-hidden carousel container for responsive preferred-panel sizing.
   const [trackContainerW, setTrackContainerW] = useState(0);
   const trackContainerElRef = useRef<HTMLDivElement | null>(null);
   const [trackContainerEl, setTrackContainerEl] =
     useState<HTMLDivElement | null>(null);
+  // Also feeds the container-width measurement: every layout branch must keep
+  // containerW live, or a resize can never switch back to the carousel.
   const trackContainerRef = useCallback((el: HTMLDivElement | null) => {
     trackContainerElRef.current = el;
     setTrackContainerEl(el);
+    setRootEl(el);
   }, []);
 
   // Measures the preferred panel's height to cap non-preferred panels in selection mode.
@@ -170,10 +178,6 @@ export default function MultiModelResponseView({
     []
   );
 
-  // Measures the root container so the layout can drop to the one-at-a-time
-  // carousel when the panels can't all fit side by side.
-  const [containerW, setContainerW] = useState(0);
-  const [rootEl, setRootEl] = useState<HTMLDivElement | null>(null);
   useLayoutEffect(() => {
     if (!rootEl) return;
     const ro = new ResizeObserver(([entry]) => {
@@ -248,6 +252,18 @@ export default function MultiModelResponseView({
     [responses, hiddenPanels]
   );
 
+  // One-at-a-time carousel when the panels can't all fit side by side. Narrow
+  // width outranks selection mode, so picking or clearing a preference never
+  // swaps the carousel out from under the user.
+  const requiredSideBySideW =
+    visibleResponses.length * MIN_PANEL_W +
+    (visibleResponses.length - 1) * PANEL_GAP;
+  const showNarrowCarousel =
+    !readOnly &&
+    visibleResponses.length > 1 &&
+    containerW > 0 &&
+    containerW < requiredSideBySideW;
+
   const toggleVisibility = useCallback(
     (modelIndex: number) => {
       setHiddenPanels((prev) => {
@@ -289,7 +305,7 @@ export default function MultiModelResponseView({
       // When switching preferred within selection mode, panels are already
       // capped and the track just slides — no height changes to worry about.
       const alreadyInSelection = preferredIndex !== null;
-      if (!alreadyInSelection) {
+      if (!alreadyInSelection && !showNarrowCarousel) {
         const scrollContainer = trackContainerElRef.current?.closest(
           "[data-chat-scroll]"
         ) as HTMLElement | null;
@@ -335,6 +351,7 @@ export default function MultiModelResponseView({
       selectionDisabled,
       responses,
       preferredIndex,
+      showNarrowCarousel,
       parentMessage,
       currentSessionId,
       updateSessionMessageTree,
@@ -345,7 +362,27 @@ export default function MultiModelResponseView({
   // preferred_response_id. The SetPreferredResponseRequest model doesn't
   // accept null. A backend endpoint for clearing preference would be needed
   // if deselect should persist across reloads.
+  const clearPreferredInTree = useCallback(() => {
+    if (!parentMessage || !currentSessionId) return;
+    const tree = useChatSessionStore
+      .getState()
+      .sessions.get(currentSessionId)?.messageTree;
+    const updated =
+      tree && applyPreferredResponse(tree, parentMessage.nodeId, null);
+    if (updated) {
+      updateSessionMessageTree(currentSessionId, updated);
+    }
+  }, [parentMessage, currentSessionId, updateSessionMessageTree]);
+
   const handleDeselectPreferred = useCallback(() => {
+    // The carousel keeps every card in place, so the chip just toggles off.
+    // None of the selection layout's exit choreography applies.
+    if (showNarrowCarousel) {
+      setPreferredIndex(null);
+      clearPreferredInTree();
+      return;
+    }
+
     const scrollContainer = trackContainerElRef.current?.closest(
       "[data-chat-scroll]"
     ) as HTMLElement | null;
@@ -406,26 +443,9 @@ export default function MultiModelResponseView({
         restoreScroll();
       }
 
-      // Clear preferredResponseId in the local tree so the next send assumes
-      // a preference again
-      if (parentMessage && currentSessionId) {
-        const tree = useChatSessionStore
-          .getState()
-          .sessions.get(currentSessionId)?.messageTree;
-        const updated =
-          tree && applyPreferredResponse(tree, parentMessage.nodeId, null);
-        if (updated) {
-          updateSessionMessageTree(currentSessionId, updated);
-        }
-      }
+      clearPreferredInTree();
     }, 450);
-  }, [
-    parentMessage,
-    currentSessionId,
-    updateSessionMessageTree,
-    preferredIndex,
-    hiddenPanels,
-  ]);
+  }, [showNarrowCarousel, clearPreferredInTree, preferredIndex, hiddenPanels]);
 
   // Clear preferred selection when generation starts
   // Reset selection state when generation restarts
@@ -463,9 +483,12 @@ export default function MultiModelResponseView({
   // Use the selection layout once a preferred response has been chosen, even
   // after deselect. Only fall through to generation layout before the first
   // selection or during active streaming. The read-only (shared) view stays in
-  // generation layout so every response is shown equal-width.
+  // generation layout so every response is shown equal-width. The narrow
+  // carousel outranks it: at carousel widths a preference only moves the chip.
   const showSelectionMode =
-    !readOnly && (isActivelySelected || hasEnteredSelection);
+    !readOnly &&
+    !showNarrowCarousel &&
+    (isActivelySelected || hasEnteredSelection);
 
   // Trigger the slide-out animation one frame after a preferred panel is selected.
   // Uses isActivelySelected (not showSelectionMode) so re-selecting after a
@@ -479,20 +502,15 @@ export default function MultiModelResponseView({
     return () => cancelAnimationFrame(raf);
   }, [isActivelySelected]);
 
-  // One-at-a-time carousel when the panels can't all fit side by side (the
-  // spec's smaller-screen layout). Starts on the first model, the right-most
-  // panel in the side-by-side layout.
-  const requiredSideBySideW =
-    visibleResponses.length * MIN_PANEL_W +
-    (visibleResponses.length - 1) * PANEL_GAP;
-  const showNarrowCarousel =
-    !readOnly &&
-    !showSelectionMode &&
-    visibleResponses.length > 1 &&
-    containerW > 0 &&
-    containerW < requiredSideBySideW;
+  // Carousel starts on the preferred card when a preference exists, else the
+  // first model (the right-most side-by-side panel).
   const lastCarouselPos = Math.max(0, visibleResponses.length - 1);
-  const [carouselPos, setCarouselPos] = useState(lastCarouselPos);
+  const preferredCarouselPos = visibleResponses.findIndex(
+    (r) => r.modelIndex === preferredIndex
+  );
+  const [carouselPos, setCarouselPos] = useState(
+    preferredCarouselPos !== -1 ? preferredCarouselPos : lastCarouselPos
+  );
   const clampedCarouselPos = Math.min(carouselPos, lastCarouselPos);
   const currentCarouselResponse = visibleResponses[clampedCarouselPos];
 

--- a/web/src/app/app/message/MultiModelResponseView.tsx
+++ b/web/src/app/app/message/MultiModelResponseView.tsx
@@ -15,7 +15,10 @@ import { RegenerationFactory } from "@/app/app/message/messageComponents/AgentMe
 import MultiModelPanel from "@/app/app/message/MultiModelPanel";
 import { MultiModelResponse } from "@/app/app/message/interfaces";
 import { setPreferredResponse } from "@/app/app/services/lib";
-import { applyPreferredResponse } from "@/app/app/message/multiModel";
+import {
+  applyPreferredResponse,
+  setMostVisibleResponseId,
+} from "@/app/app/message/multiModel";
 import { useChatSessionStore } from "@/app/app/stores/useChatSessionStore";
 import { cn } from "@opal/utils";
 
@@ -51,8 +54,10 @@ const GEN_PANEL_W_2 = 720; // 2 panels side-by-side
 const GEN_PANEL_W_3 = 436; // 3 panels side-by-side
 // Gap between panels — matches CSS gap-6 (24px)
 const PANEL_GAP = 24;
-// Minimum panel width before horizontal scroll kicks in
+// Minimum panel width. Below it the interactive layout drops to the carousel, the shared view scrolls
 const MIN_PANEL_W = 300;
+// Gap between full-width cards in the narrow carousel (from Figma)
+const NARROW_CAROUSEL_GAP = 4;
 
 /**
  * Renders N model responses side-by-side with two layout modes:
@@ -97,13 +102,34 @@ export default function MultiModelResponseView({
     preferredIndexFromTree
   );
   // Re-sync when the preference lands after mount (session hydration, or the
-  // implicit pick made at send time). Clearing is owned by the deselect flow's
-  // animation, so only non-null values sync in.
+  // implicit pick made at send time), scrolling an off-screen pick into view.
+  // Deselect's animation owns clearing, so only non-null values sync in.
   useEffect(() => {
-    if (preferredIndexFromTree != null) {
-      setPreferredIndex(preferredIndexFromTree);
+    if (preferredIndexFromTree == null) return;
+    setPreferredIndex(preferredIndexFromTree);
+    if (!mountedRef.current) return;
+    const el = panelElsRef.current.get(preferredIndexFromTree);
+    // Scroll only the chat container. scrollIntoView would also scroll the
+    // carousel's overflow-hidden track, permanently offsetting its transform
+    // centering (see BuildMessageList and CommandMenu for the same choice).
+    const scroller = el?.closest("[data-chat-scroll]") as HTMLElement | null;
+    if (!el || !scroller) return;
+    const elRect = el.getBoundingClientRect();
+    const scRect = scroller.getBoundingClientRect();
+    if (elRect.bottom < scRect.top || elRect.top > scRect.bottom) {
+      scroller.scrollTo({
+        top: scroller.scrollTop + elRect.top - scRect.top - 16,
+        behavior: "smooth",
+      });
     }
   }, [preferredIndexFromTree]);
+  // Declared after the sync effect so its mount run still sees false and
+  // skips the scroll for a preference that was already set at mount.
+  const mountedRef = useRef(false);
+  useEffect(() => {
+    mountedRef.current = true;
+  }, []);
+  const parentNodeId = parentMessage?.nodeId;
   const [hiddenPanels, setHiddenPanels] = useState<Set<number>>(new Set());
   // Controls animation: false = panels at start position, true = panels at peek position
   const [selectionEntered, setSelectionEntered] = useState(
@@ -130,8 +156,33 @@ export default function MultiModelResponseView({
   >(null);
   const [preferredPanelEl, setPreferredPanelEl] =
     useState<HTMLDivElement | null>(null);
-  // Refs to each panel wrapper for height animation on deselect
+  // Refs to each panel wrapper: deselect height animation, overflow capping,
+  // and the late-pick scroll all read this map.
   const panelElsRef = useRef<Map<number, HTMLDivElement>>(new Map());
+  const setPanelEl = useCallback(
+    (modelIndex: number, el: HTMLDivElement | null) => {
+      if (el) {
+        panelElsRef.current.set(modelIndex, el);
+      } else {
+        panelElsRef.current.delete(modelIndex);
+      }
+    },
+    []
+  );
+
+  // Measures the root container so the layout can drop to the one-at-a-time
+  // carousel when the panels can't all fit side by side.
+  const [containerW, setContainerW] = useState(0);
+  const [rootEl, setRootEl] = useState<HTMLDivElement | null>(null);
+  useLayoutEffect(() => {
+    if (!rootEl) return;
+    const ro = new ResizeObserver(([entry]) => {
+      setContainerW(entry?.contentRect.width ?? 0);
+    });
+    ro.observe(rootEl);
+    setContainerW(rootEl.offsetWidth);
+    return () => ro.disconnect();
+  }, [rootEl]);
 
   // Tracks which non-preferred panels overflow the preferred height cap.
   // Measured via useLayoutEffect after maxHeight is applied to the DOM —
@@ -428,6 +479,33 @@ export default function MultiModelResponseView({
     return () => cancelAnimationFrame(raf);
   }, [isActivelySelected]);
 
+  // One-at-a-time carousel when the panels can't all fit side by side (the
+  // spec's smaller-screen layout). Starts on the first model, the right-most
+  // panel in the side-by-side layout.
+  const requiredSideBySideW =
+    visibleResponses.length * MIN_PANEL_W +
+    (visibleResponses.length - 1) * PANEL_GAP;
+  const showNarrowCarousel =
+    !readOnly &&
+    !showSelectionMode &&
+    visibleResponses.length > 1 &&
+    containerW > 0 &&
+    containerW < requiredSideBySideW;
+  const lastCarouselPos = Math.max(0, visibleResponses.length - 1);
+  const [carouselPos, setCarouselPos] = useState(lastCarouselPos);
+  const clampedCarouselPos = Math.min(carouselPos, lastCarouselPos);
+  const currentCarouselResponse = visibleResponses[clampedCarouselPos];
+
+  // Feed the send path's response-in-view rule from the carousel position.
+  const currentCarouselMessageId = currentCarouselResponse?.messageId ?? null;
+  useEffect(() => {
+    if (readOnly || parentNodeId == null || !showNarrowCarousel) return;
+    if (currentCarouselMessageId != null) {
+      setMostVisibleResponseId(parentNodeId, currentCarouselMessageId);
+    }
+    return () => setMostVisibleResponseId(parentNodeId, null);
+  }, [readOnly, parentNodeId, showNarrowCarousel, currentCarouselMessageId]);
+
   // Build panel props — isHidden reflects actual hidden state
   const buildPanelProps = useCallback(
     (response: MultiModelResponse, isNonPreferred: boolean) => ({
@@ -557,11 +635,7 @@ export default function MultiModelResponseView({
               <div
                 key={r.modelIndex}
                 ref={(el) => {
-                  if (el) {
-                    panelElsRef.current.set(r.modelIndex, el);
-                  } else {
-                    panelElsRef.current.delete(r.modelIndex);
-                  }
+                  setPanelEl(r.modelIndex, el);
                   if (isPref) setPreferredPanelEl(el);
                 }}
                 style={{
@@ -594,19 +668,83 @@ export default function MultiModelResponseView({
     );
   }
 
+  if (showNarrowCarousel) {
+    // ── Narrow Carousel Layout (one response in view) ──
+    // Full-width cards with off-canvas neighbors, per the mobile design. The
+    // current card's header carries the prev/next model nav.
+    const prevResponse =
+      clampedCarouselPos > 0
+        ? visibleResponses[clampedCarouselPos - 1]
+        : undefined;
+    const nextResponse =
+      clampedCarouselPos < lastCarouselPos
+        ? visibleResponses[clampedCarouselPos + 1]
+        : undefined;
+    const prevNav = prevResponse
+      ? {
+          provider: prevResponse.provider,
+          modelName: prevResponse.modelName,
+          displayName: prevResponse.displayName,
+          onClick: () => setCarouselPos(clampedCarouselPos - 1),
+        }
+      : undefined;
+    const nextNav = nextResponse
+      ? {
+          provider: nextResponse.provider,
+          modelName: nextResponse.modelName,
+          displayName: nextResponse.displayName,
+          onClick: () => setCarouselPos(clampedCarouselPos + 1),
+        }
+      : undefined;
+    return (
+      <div ref={setRootEl} className="w-full overflow-hidden">
+        {/* raw-ok: transform-driven carousel track matching the sibling selection-layout track. Section's inline gap/width styles fight the px-precise animated geometry */}
+        <div
+          className="flex items-start"
+          style={{
+            gap: `${NARROW_CAROUSEL_GAP}px`,
+            transform: `translateX(-${
+              clampedCarouselPos * (containerW + NARROW_CAROUSEL_GAP)
+            }px)`,
+            transition: "transform 0.45s cubic-bezier(0.2, 0, 0, 1)",
+          }}
+        >
+          {visibleResponses.map((r, i) => {
+            const isCurrent = i === clampedCarouselPos;
+            return (
+              <div
+                key={r.modelIndex}
+                ref={(el) => setPanelEl(r.modelIndex, el)}
+                style={{ width: `${containerW}px`, flexShrink: 0 }}
+              >
+                <MultiModelPanel
+                  {...buildPanelProps(r, false)}
+                  carouselPrev={isCurrent ? prevNav : undefined}
+                  carouselNext={isCurrent ? nextNav : undefined}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
   // ── Generation Layout (equal panels side-by-side) ──
   // Panel width based on number of visible (non-hidden) panels.
   const panelWidth =
     visibleResponses.length <= 2 ? GEN_PANEL_W_2 : GEN_PANEL_W_3;
 
   return (
-    <div className="overflow-x-auto">
+    <div ref={setRootEl} className="overflow-x-auto">
+      {/* raw-ok: equal-width panel row whose children carry px min/max widths, outside Section's rem spacing steps */}
       <div className="flex gap-6 items-start justify-center w-full">
         {responses.map((r) => {
           const isHidden = hiddenPanels.has(r.modelIndex);
           return (
             <div
               key={r.modelIndex}
+              ref={(el) => setPanelEl(r.modelIndex, el)}
               style={
                 isHidden
                   ? {

--- a/web/src/app/app/message/MultiModelResponseView.tsx
+++ b/web/src/app/app/message/MultiModelResponseView.tsx
@@ -253,12 +253,18 @@ export default function MultiModelResponseView({
     [responses, hiddenPanels]
   );
 
-  // One-at-a-time carousel below the small-screen breakpoint, one step above
-  // the sidebar collapse so it lands before the page chrome swaps. It also
-  // outranks selection mode, a preference change never swaps it out.
+  // Carousel below the small-screen breakpoint (one step above the sidebar
+  // collapse) and whenever the column cannot fit every panel side by side.
+  // Outranks selection mode, a preference change never swaps it out.
   const { isSmallScreen } = useScreenSize();
+  const requiredSideBySideW =
+    visibleResponses.length * MIN_PANEL_W +
+    (visibleResponses.length - 1) * PANEL_GAP;
   const showNarrowCarousel =
-    !readOnly && visibleResponses.length > 1 && containerW > 0 && isSmallScreen;
+    !readOnly &&
+    visibleResponses.length > 1 &&
+    containerW > 0 &&
+    (isSmallScreen || containerW < requiredSideBySideW);
 
   const toggleVisibility = useCallback(
     (modelIndex: number) => {

--- a/web/src/app/app/message/MultiModelResponseView.tsx
+++ b/web/src/app/app/message/MultiModelResponseView.tsx
@@ -20,6 +20,7 @@ import {
   setMostVisibleResponseId,
 } from "@/app/app/message/multiModel";
 import { useChatSessionStore } from "@/app/app/stores/useChatSessionStore";
+import useScreenSize from "@/hooks/useScreenSize";
 import { cn } from "@opal/utils";
 
 export interface MultiModelResponseViewProps {
@@ -252,17 +253,12 @@ export default function MultiModelResponseView({
     [responses, hiddenPanels]
   );
 
-  // One-at-a-time carousel when the panels can't all fit side by side. Narrow
-  // width outranks selection mode, so picking or clearing a preference never
-  // swaps the carousel out from under the user.
-  const requiredSideBySideW =
-    visibleResponses.length * MIN_PANEL_W +
-    (visibleResponses.length - 1) * PANEL_GAP;
+  // One-at-a-time carousel below the small-screen breakpoint, one step above
+  // the sidebar collapse so it lands before the page chrome swaps. It also
+  // outranks selection mode, a preference change never swaps it out.
+  const { isSmallScreen } = useScreenSize();
   const showNarrowCarousel =
-    !readOnly &&
-    visibleResponses.length > 1 &&
-    containerW > 0 &&
-    containerW < requiredSideBySideW;
+    !readOnly && visibleResponses.length > 1 && containerW > 0 && isSmallScreen;
 
   const toggleVisibility = useCallback(
     (modelIndex: number) => {
@@ -490,6 +486,25 @@ export default function MultiModelResponseView({
     !showNarrowCarousel &&
     (isActivelySelected || hasEnteredSelection);
 
+  // Crossing between layouts swaps instantly, a short fade covers the swap.
+  // In-layout animations (select, switch, deselect) are untouched.
+  const layoutKind = showSelectionMode
+    ? "selection"
+    : showNarrowCarousel
+      ? "carousel"
+      : "row";
+  const layoutKindRef = useRef(layoutKind);
+  useEffect(() => {
+    if (layoutKindRef.current === layoutKind) return;
+    layoutKindRef.current = layoutKind;
+    if (readOnly || !rootEl) return;
+    const anim = rootEl.animate([{ opacity: 0.5 }, { opacity: 1 }], {
+      duration: 150,
+      easing: "ease-out",
+    });
+    return () => anim.cancel();
+  }, [layoutKind, rootEl, readOnly]);
+
   // Trigger the slide-out animation one frame after a preferred panel is selected.
   // Uses isActivelySelected (not showSelectionMode) so re-selecting after a
   // deselect still triggers the animation.
@@ -511,6 +526,13 @@ export default function MultiModelResponseView({
   const [carouselPos, setCarouselPos] = useState(
     preferredCarouselPos !== -1 ? preferredCarouselPos : lastCarouselPos
   );
+  // The track transform animates only for arrow navigation. Entry snaps and
+  // resizes reposition instantly so crossing the break never plays a slide.
+  const [carouselSliding, setCarouselSliding] = useState(false);
+  const navToCarouselPos = useCallback((pos: number) => {
+    setCarouselSliding(true);
+    setCarouselPos(pos);
+  }, []);
   // Breaking into the carousel keeps continuity with the wide layout: land on
   // the preferred card when one exists, else keep the last carousel position.
   const wasNarrowRef = useRef(showNarrowCarousel);
@@ -734,7 +756,7 @@ export default function MultiModelResponseView({
           provider: prevResponse.provider,
           modelName: prevResponse.modelName,
           displayName: prevResponse.displayName,
-          onClick: () => setCarouselPos(clampedCarouselPos - 1),
+          onClick: () => navToCarouselPos(clampedCarouselPos - 1),
         }
       : undefined;
     const nextNav = nextResponse
@@ -742,7 +764,7 @@ export default function MultiModelResponseView({
           provider: nextResponse.provider,
           modelName: nextResponse.modelName,
           displayName: nextResponse.displayName,
-          onClick: () => setCarouselPos(clampedCarouselPos + 1),
+          onClick: () => navToCarouselPos(clampedCarouselPos + 1),
         }
       : undefined;
     return (
@@ -755,7 +777,13 @@ export default function MultiModelResponseView({
             transform: `translateX(-${
               clampedCarouselPos * (containerW + NARROW_CAROUSEL_GAP)
             }px)`,
-            transition: "transform 0.45s cubic-bezier(0.2, 0, 0, 1)",
+            transition: carouselSliding
+              ? "transform 0.45s cubic-bezier(0.2, 0, 0, 1)"
+              : "none",
+          }}
+          onTransitionEnd={(e) => {
+            if (e.target === e.currentTarget && e.propertyName === "transform")
+              setCarouselSliding(false);
           }}
         >
           {visibleResponses.map((r, i) => {

--- a/web/src/app/app/message/MultiModelResponseView.tsx
+++ b/web/src/app/app/message/MultiModelResponseView.tsx
@@ -511,6 +511,16 @@ export default function MultiModelResponseView({
   const [carouselPos, setCarouselPos] = useState(
     preferredCarouselPos !== -1 ? preferredCarouselPos : lastCarouselPos
   );
+  // Breaking into the carousel keeps continuity with the wide layout: land on
+  // the preferred card when one exists, else keep the last carousel position.
+  const wasNarrowRef = useRef(showNarrowCarousel);
+  useEffect(() => {
+    const entered = showNarrowCarousel && !wasNarrowRef.current;
+    wasNarrowRef.current = showNarrowCarousel;
+    if (entered && preferredCarouselPos !== -1) {
+      setCarouselPos(preferredCarouselPos);
+    }
+  }, [showNarrowCarousel, preferredCarouselPos]);
   const clampedCarouselPos = Math.min(carouselPos, lastCarouselPos);
   const currentCarouselResponse = visibleResponses[clampedCarouselPos];
 
@@ -589,10 +599,25 @@ export default function MultiModelResponseView({
         ? Math.min(trackContainerW - 2 * (PEEK_W + PANEL_GAP), GEN_PANEL_W_2)
         : GEN_PANEL_W_2;
 
+    // Uniform width shrinks with the container so the deselected track never
+    // overflows and clips headers at mid widths.
+    const uniformPanelW = Math.max(
+      MIN_PANEL_W,
+      Math.min(
+        SELECTION_PANEL_W,
+        trackContainerW > 0
+          ? (trackContainerW -
+              hiddenPanels.size * HIDDEN_PANEL_W -
+              (n - 1) * PANEL_GAP) /
+              (visibleResponses.length || 1)
+          : SELECTION_PANEL_W
+      )
+    );
+
     const selectionWidths = responses.map((r, i) => {
       if (hiddenPanels.has(r.modelIndex)) return HIDDEN_PANEL_W;
       if (i === preferredIdx) return dynamicPrefW;
-      return SELECTION_PANEL_W;
+      return uniformPanelW;
     });
 
     const panelLeftEdges = selectionWidths.reduce<number[]>((acc, w, i) => {
@@ -603,12 +628,12 @@ export default function MultiModelResponseView({
     const preferredCenterInTrack =
       panelLeftEdges[preferredIdx]! + selectionWidths[preferredIdx]! / 2;
 
-    // Start position: hidden panels at HIDDEN_PANEL_W, visible at SELECTION_PANEL_W
+    // Start position: hidden panels at HIDDEN_PANEL_W, visible at uniformPanelW
     const uniformTrackW =
       responses.reduce(
         (sum, r) =>
           sum +
-          (hiddenPanels.has(r.modelIndex) ? HIDDEN_PANEL_W : SELECTION_PANEL_W),
+          (hiddenPanels.has(r.modelIndex) ? HIDDEN_PANEL_W : uniformPanelW),
         0
       ) +
       (n - 1) * PANEL_GAP;
@@ -646,7 +671,7 @@ export default function MultiModelResponseView({
             const isPref = r.modelIndex === preferredIndex;
             const isNonPref = !isHidden && !isPref && preferredIndex !== null;
             const finalW = selectionWidths[i]!;
-            const startW = isHidden ? HIDDEN_PANEL_W : SELECTION_PANEL_W;
+            const startW = isHidden ? HIDDEN_PANEL_W : uniformPanelW;
             const capped = isNonPref && preferredPanelHeight != null;
             const overflows = capped && overflowingPanels.has(r.modelIndex);
             return (

--- a/web/src/app/app/message/MultiModelResponseView.tsx
+++ b/web/src/app/app/message/MultiModelResponseView.tsx
@@ -689,7 +689,7 @@ export default function MultiModelResponseView({
                       ? "width 0.45s cubic-bezier(0.2, 0, 0, 1)"
                       : "none",
                   maxHeight: capped ? preferredPanelHeight : undefined,
-                  overflow: capped ? "hidden" : undefined,
+                  overflow: "clip",
                   ...(overflows
                     ? {
                         maskImage:
@@ -700,7 +700,13 @@ export default function MultiModelResponseView({
                     : {}),
                 }}
               >
-                <div className={cn(isNonPref && "opacity-50")}>
+                {/* Content is laid out at the final width so the wrapper's
+                    width animation reveals it instead of rewrapping text
+                    every frame, which reads as content pouring in. */}
+                <div
+                  style={{ width: `${finalW}px` }}
+                  className={cn(isNonPref && "opacity-50")}
+                >
                   <MultiModelPanel {...buildPanelProps(r, isNonPref)} />
                 </div>
               </div>

--- a/web/src/app/app/message/__tests__/multiModel.test.ts
+++ b/web/src/app/app/message/__tests__/multiModel.test.ts
@@ -159,6 +159,34 @@ describe("chooseImplicitPreferred", () => {
     );
   });
 
+  it("prefers the response in view over the prior turn's model", () => {
+    const tree = new Map<number, Message>();
+    const first = buildTurn(tree, ["gemini-3", "gpt-5"], {
+      preferredModel: "gemini-3",
+    });
+    const second = buildTurn(tree, ["gemini-3", "gpt-5"], {
+      parent: first.responses[0],
+    });
+    const turn = getUnresolvedMultiModelTurn(chainOf(tree), tree)!;
+    expect(
+      chooseImplicitPreferred(
+        chainOf(tree),
+        tree,
+        turn,
+        second.responses[1]!.messageId!
+      )
+    ).toBe(second.responses[1]);
+  });
+
+  it("ignores a visible id that matches no candidate", () => {
+    const tree = new Map<number, Message>();
+    const { responses } = buildTurn(tree, ["gemini-3", "gpt-5"]);
+    const turn = getUnresolvedMultiModelTurn(chainOf(tree), tree)!;
+    expect(chooseImplicitPreferred(chainOf(tree), tree, turn, 999999)).toBe(
+      responses[1]
+    );
+  });
+
   it("never assumes an errored response", () => {
     const tree = new Map<number, Message>();
     const { responses } = buildTurn(tree, [

--- a/web/src/app/app/message/multiModel.ts
+++ b/web/src/app/app/message/multiModel.ts
@@ -107,17 +107,42 @@ function findPriorPreferredModel(
   );
 }
 
-// The response a send assumes as preferred: the prior turn's preferred model
-// when it answered this turn too, else the first model (right-most panel,
-// last child). Errored responses can't continue the chain, never assumed.
+// The response in view per turn (user message nodeId), written by the panel
+// view's narrow-screen carousel and read at send time. An entry exists only
+// while the carousel shows one response at a time.
+const mostVisibleResponseByTurn = new Map<number, number>();
+
+export function setMostVisibleResponseId(
+  userNodeId: number,
+  responseMessageId: number | null
+): void {
+  if (responseMessageId == null) {
+    mostVisibleResponseByTurn.delete(userNodeId);
+  } else {
+    mostVisibleResponseByTurn.set(userNodeId, responseMessageId);
+  }
+}
+
+export function getMostVisibleResponseId(userNodeId: number): number | null {
+  return mostVisibleResponseByTurn.get(userNodeId) ?? null;
+}
+
+// The response a send assumes as preferred: the response in view on narrow
+// screens, else the prior turn's preferred model when it answered this turn
+// too, else the first model (right-most, last child). Errors never assumed.
 export function chooseImplicitPreferred(
   chain: Message[],
   messageTree: Map<number, Message>,
-  turn: UnresolvedMultiModelTurn
+  turn: UnresolvedMultiModelTurn,
+  visibleResponseId: number | null = null
 ): Message | null {
   const candidates = turn.responses.filter(
     (r) => r.type === "assistant" && r.messageId != null
   );
+  if (visibleResponseId != null) {
+    const visible = candidates.find((r) => r.messageId === visibleResponseId);
+    if (visible) return visible;
+  }
   const priorModel = findPriorPreferredModel(
     chain,
     messageTree,

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -10,6 +10,7 @@ import {
 import {
   applyPreferredResponse,
   chooseImplicitPreferred,
+  getMostVisibleResponseId,
   getMultiModelChildren,
   getUnresolvedMultiModelTurn,
 } from "@/app/app/message/multiModel";
@@ -664,7 +665,8 @@ export default function useChatController({
           ? chooseImplicitPreferred(
               currentHistory,
               currentMessageTreeLocal,
-              unresolvedTurn
+              unresolvedTurn,
+              getMostVisibleResponseId(unresolvedTurn.userMessage.nodeId)
             )
           : null;
         if (


### PR DESCRIPTION
## Description

Part of [ENG-4318](https://linear.app/onyx-app/issue/ENG-4318/multi-llm-improvements), stacked on #14067. Implements the [smaller-screen design](https://www.figma.com/design/BV9tfqwS0GjTIJP7ki6Qux/Search---Chat---Tools?node-id=5557-231742&t=aEEu6tItE1jOVrYT-1):

- When the panels can't all fit side by side, the turn renders a one-response carousel: a full-width card with prev/next model nav flanking its header, sliding between models. This replaces the clipped horizontal-scroll fallback.
- The card in view at send time becomes the implicit preferred, ahead of the prior-turn-model and first-model rules. The carousel's position drives this directly, no visibility heuristics.
- A preference that lands on a panel scrolled out of view scrolls the chat container to it (spec: "scroll in view if not in view"). Only the chat scroller moves, so the selection carousel's transform centering is never disturbed.

Hidden panels render as header-strip cards inside the carousel, fixed in the stacked #14075.

## How Has This Been Tested?

<img width="2098" height="1660" alt="2026-08-24 17 03 31" src="https://github.com/user-attachments/assets/7e2571b1-e58e-40d0-8fe4-7b886fcf01da" />
<img width="1734" height="1660" alt="2026-08-24 17 03 45" src="https://github.com/user-attachments/assets/e3d9af29-a6d5-442a-98e2-7c28cc7d4de8" />


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

