### PR TITLE
feat(db): add per-model reasoning and temperature settings columns

### DIFF
--- a/backend/alembic/versions/dd55634b8532_add_per_model_llm_settings.py
+++ b/backend/alembic/versions/dd55634b8532_add_per_model_llm_settings.py
@@ -1,0 +1,38 @@
+"""add per model llm settings
+
+Revision ID: dd55634b8532
+Revises: 4d93b0fd5ca8
+Create Date: 2026-08-18 17:15:03.559998
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "dd55634b8532"
+down_revision = "4d93b0fd5ca8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Unbounded VARCHAR, as reasoning_effort_override on chat_session already
+    # does, so adding an effort level stays a code change.
+    op.add_column(
+        "model_configuration",
+        sa.Column("reasoning_effort_max", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "model_configuration",
+        sa.Column("reasoning_effort_default", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "model_configuration",
+        sa.Column("temperature_default", sa.Float(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("model_configuration", "temperature_default")
+    op.drop_column("model_configuration", "reasoning_effort_default")
+    op.drop_column("model_configuration", "reasoning_effort_max")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -3672,6 +3672,25 @@ class ModelConfiguration(Base):
     # over both display_name and the LiteLLM-derived name everywhere in the UI.
     custom_display_name: Mapped[str | None] = mapped_column(String, nullable=True)
 
+    # Never store AUTO in either column, an unset value already means AUTO.
+    reasoning_effort_max: Mapped[ReasoningEffort | None] = mapped_column(
+        Enum(
+            ReasoningEffort,
+            native_enum=False,
+            values_callable=lambda x: [e.value for e in x],
+        ),
+        nullable=True,
+    )
+    reasoning_effort_default: Mapped[ReasoningEffort | None] = mapped_column(
+        Enum(
+            ReasoningEffort,
+            native_enum=False,
+            values_callable=lambda x: [e.value for e in x],
+        ),
+        nullable=True,
+    )
+    temperature_default: Mapped[float | None] = mapped_column(Float, nullable=True)
+
     llm_provider: Mapped["LLMProvider"] = relationship(
         "LLMProvider",
         back_populates="model_configurations",


### PR DESCRIPTION
## Description

Adds storage for admin-configured per-model LLM settings. Three nullable columns on `model_configuration`: `reasoning_effort_max`, `reasoning_effort_default`, and `temperature_default`.

Nothing reads them yet. A follow-up wires them into the request path, where a chat session's reasoning override resolves against the default and then clamps to the max. Because every column is nullable and unread, this change is behavior-neutral on its own.

The two effort columns store as strings via a non-native enum, matching `chat_session.reasoning_effort_override` from #13377. No Postgres enum type, so adding an effort level later stays a code change instead of a migration.

## How Has This Been Tested?

- `alembic upgrade head` then `alembic downgrade -1` against a throwaway database, confirming the three columns appear and then drop. The shared dev database was not touched.
- `alembic heads` returns a single head.
- `ruff format --check` on all changed files: 3 files already formatted.
- `ty check` from the repo root: All checks passed.
- `pytest backend/tests/unit/onyx/llm backend/tests/unit/onyx/chat backend/tests/unit/onyx/server/manage`: 1197 passed.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
