### PR TITLE
feat(db): add chat_message request params column

### DIFF
--- a/backend/alembic/versions/06a38a307492_add_chat_message_request_params.py
+++ b/backend/alembic/versions/06a38a307492_add_chat_message_request_params.py
@@ -1,0 +1,27 @@
+"""add chat message request params
+
+Revision ID: 06a38a307492
+Revises: dd55634b8532
+Create Date: 2026-08-19 10:15:51.474747
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "06a38a307492"
+down_revision = "dd55634b8532"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chat_message",
+        sa.Column("request_params", postgresql.JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("chat_message", "request_params")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -3300,6 +3300,11 @@ class ChatMessage(Base):
     # The display name of the model that generated this assistant message
     model_display_name: Mapped[str | None] = mapped_column(String, nullable=True)
 
+    # Requested reasoning effort plus the kwargs actually sent to the provider.
+    request_params: Mapped[dict[str, Any] | None] = mapped_column(
+        postgresql.JSONB(), nullable=True
+    )
+
     # What does this message contain
     reasoning_tokens: Mapped[str | None] = mapped_column(Text, nullable=True)
     message: Mapped[str] = mapped_column(Text)


### PR DESCRIPTION
## Description

Adds a nullable `request_params` JSONB column to `chat_message`, to store the request parameters that actually produced an assistant message.

The goal is showing users the model, reasoning level, and temperature behind a given response in the chat UI. Capture and display land in follow-ups. Nothing writes or reads the column yet, so this is behavior-neutral. Existing messages stay NULL and read as unknown.

The column follows `citations` and `files` on the same table: JSONB, no schema enforced on the row. It sits next to the other per-message attribution fields, `model_display_name` and `reasoning_tokens`.

Stacked on #14069 only because its alembic revision chains onto that one, which keeps the standard tree at a single head. There is no other dependency.

## How Has This Been Tested?

- `alembic upgrade head` then `alembic downgrade -1` against a throwaway database, confirming the column appears as nullable jsonb and then drops. The shared dev database was not touched.
- `alembic heads` returns a single head across both revisions.
- `ruff format --check` on all changed files: 3 files already formatted.
- `ty check` from the repo root: All checks passed.
- `pytest backend/tests/unit/onyx/llm backend/tests/unit/onyx/chat backend/tests/unit/onyx/server/manage`: 1197 passed.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
