### PR TITLE
feat(chat): show each response's own model on the Retry button

### DIFF
--- a/web/lib/opal/src/components/buttons/open-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/open-button/components.tsx
@@ -28,13 +28,13 @@ import { ChevronIcon } from "@opal/components/buttons/chevron";
 /**
  * Content props — a discriminated union on `foldable` that enforces:
  *
- * - `foldable: true`  → `icon` and `children` are required (icon stays visible,
- *                        label + chevron fold away)
- * - `foldable?: false` → at least one of `icon` or `children` must be provided
+ * - `foldable: boolean` → `icon` and `children` are required (icon stays
+ *                          visible, label + chevron fold away when true)
+ * - `foldable?: false`  → at least one of `icon` or `children` must be provided
  */
 type OpenButtonContentProps =
   | {
-      foldable: true;
+      foldable: boolean;
       icon: IconFunctionComponent;
       children: string | RichStr;
     }

--- a/web/src/app/app/message/messageComponents/MessageToolbar.tsx
+++ b/web/src/app/app/message/messageComponents/MessageToolbar.tsx
@@ -7,9 +7,11 @@ import { OnyxDocument } from "@/lib/search/interfaces";
 import { TooltipGroup } from "@/components/tooltip/CustomTooltip";
 import {
   useChatSessionStore,
+  useCurrentMessageTree,
   useDocumentSidebarVisible,
   useSelectedNodeForDocDisplay,
 } from "@/app/app/stores/useChatSessionStore";
+import { messageModelName } from "@/app/app/message/multiModel";
 import { convertMarkdownTablesToTsv } from "@/app/app/message/copyingUtils";
 import { getTextContent } from "@/app/app/services/packetUtils";
 import { removeThinkingTokens } from "@/app/app/services/thinkingTokens";
@@ -143,6 +145,25 @@ export default function MessageToolbar({
   citations,
   documentMap,
 }: MessageToolbarProps) {
+  // The message's own model. chatState carries the globally selected model,
+  // so per-response attribution must come from the message node itself.
+  const messageTree = useCurrentMessageTree();
+  const ownModelName = useMemo(() => {
+    const msg = messageTree?.get(nodeId);
+    return msg ? (messageModelName(msg) ?? undefined) : undefined;
+  }, [messageTree, nodeId]);
+  // More than one model in the session (multi-model turns, or a model switch
+  // between turns) keeps the Retry label expanded so responses stay attributed.
+  const distinctModelsUsed = useMemo(() => {
+    if (!messageTree) return 0;
+    const names = new Set<string>();
+    messageTree.forEach((m) => {
+      const name = messageModelName(m);
+      if (name) names.add(name);
+    });
+    return names.size;
+  }, [messageTree]);
+
   // Incognito responses take no feedback: votes would persist reviewable
   // signal tied to a chat hidden from the owner's surfaces. The session's
   // pinned flag keeps suppression on while exit clears the live toggle.
@@ -331,20 +352,47 @@ export default function MessageToolbar({
               llmManager && (
                 <div data-testid="AgentMessage/regenerate">
                   <ModelSelector
-                    value={findModelConfigId(
-                      llmManager.llmProviders,
-                      llmManager.currentLlm.provider,
-                      currentModelName ?? llmManager.currentLlm.modelName
-                    )}
+                    value={
+                      // The response's model may live under a different
+                      // provider than the global selection, so resolve it
+                      // across all providers, by raw or display name.
+                      ownModelName
+                        ? (llmManager.llmProviders
+                            ?.flatMap((p) => p.model_configurations)
+                            .find(
+                              (m) =>
+                                m.name === ownModelName ||
+                                m.effectiveDisplayName === ownModelName
+                            )?.id ?? null)
+                        : findModelConfigId(
+                            llmManager.llmProviders,
+                            llmManager.currentLlm.provider,
+                            currentModelName ?? llmManager.currentLlm.modelName
+                          )
+                    }
                     renderTrigger={() => {
                       const rawName =
-                        currentModelName ?? llmManager!.currentLlm.modelName;
+                        ownModelName ??
+                        currentModelName ??
+                        llmManager!.currentLlm.modelName;
                       const mc = llmManager!.llmProviders
                         ?.flatMap((p) => p.model_configurations)
-                        .find((m) => m.name === rawName);
+                        .find(
+                          (m) =>
+                            m.name === rawName ||
+                            m.effectiveDisplayName === rawName
+                        );
                       const displayName = mc?.effectiveDisplayName ?? rawName;
-                      return (
-                        <OpenButton icon={SvgRefreshCw} foldable>
+                      return distinctModelsUsed > 1 ? (
+                        <OpenButton icon={SvgRefreshCw} tooltip="Retry with">
+                          {displayName}
+                        </OpenButton>
+                      ) : (
+                        <OpenButton
+                          icon={SvgRefreshCw}
+                          tooltip="Retry with"
+                          foldable
+                        >
                           {displayName}
                         </OpenButton>
                       );

--- a/web/src/app/app/message/messageComponents/MessageToolbar.tsx
+++ b/web/src/app/app/message/messageComponents/MessageToolbar.tsx
@@ -12,6 +12,7 @@ import {
   useSelectedNodeForDocDisplay,
 } from "@/app/app/stores/useChatSessionStore";
 import { messageModelName } from "@/app/app/message/multiModel";
+import { useDistinctModelsUsed } from "@/lib/multiModel/hooks";
 import { convertMarkdownTablesToTsv } from "@/app/app/message/copyingUtils";
 import { getTextContent } from "@/app/app/services/packetUtils";
 import { removeThinkingTokens } from "@/app/app/services/thinkingTokens";
@@ -152,17 +153,7 @@ export default function MessageToolbar({
     const msg = messageTree?.get(nodeId);
     return msg ? (messageModelName(msg) ?? undefined) : undefined;
   }, [messageTree, nodeId]);
-  // More than one model in the session (multi-model turns, or a model switch
-  // between turns) keeps the Retry label expanded so responses stay attributed.
-  const distinctModelsUsed = useMemo(() => {
-    if (!messageTree) return 0;
-    const names = new Set<string>();
-    messageTree.forEach((m) => {
-      const name = messageModelName(m);
-      if (name) names.add(name);
-    });
-    return names.size;
-  }, [messageTree]);
+  const distinctModelsUsed = useDistinctModelsUsed();
 
   // Incognito responses take no feedback: votes would persist reviewable
   // signal tied to a chat hidden from the owner's surfaces. The session's
@@ -383,15 +374,11 @@ export default function MessageToolbar({
                             m.effectiveDisplayName === rawName
                         );
                       const displayName = mc?.effectiveDisplayName ?? rawName;
-                      return distinctModelsUsed > 1 ? (
-                        <OpenButton icon={SvgRefreshCw} tooltip="Retry with">
-                          {displayName}
-                        </OpenButton>
-                      ) : (
+                      return (
                         <OpenButton
                           icon={SvgRefreshCw}
                           tooltip="Retry with"
-                          foldable
+                          foldable={distinctModelsUsed <= 1}
                         >
                           {displayName}
                         </OpenButton>

--- a/web/src/app/app/message/multiModel.ts
+++ b/web/src/app/app/message/multiModel.ts
@@ -14,6 +14,13 @@ import { MultiModelResponse } from "@/app/app/message/interfaces";
  * resolution. Pass an empty map when the provider list is unavailable (e.g. the
  * read-only shared view). `getModelIcon` then falls back to the model name.
  */
+// The model that produced a message. Error responses carry the model that
+// failed, so they count for attribution too.
+export function messageModelName(msg: Message): string | null {
+  if (msg.type !== "assistant" && msg.type !== "error") return null;
+  return msg.overridden_model || msg.modelDisplayName || null;
+}
+
 export function getMultiModelResponses(
   userMessage: Message,
   messageTree: Map<number, Message>,

--- a/web/src/lib/multiModel/hooks.ts
+++ b/web/src/lib/multiModel/hooks.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useMemo } from "react";
+import { useCurrentMessageTree } from "@/app/app/stores/useChatSessionStore";
+import { messageModelName } from "@/app/app/message/multiModel";
+
+// Distinct models that produced a response anywhere in the current session,
+// counting multi-model turns and model switches between turns. Surfaces that
+// attribute responses to a model (e.g. the Retry label) stay expanded above 1.
+export function useDistinctModelsUsed(): number {
+  const messageTree = useCurrentMessageTree();
+  return useMemo(() => {
+    if (!messageTree) return 0;
+    const names = new Set<string>();
+    messageTree.forEach((m) => {
+      const name = messageModelName(m);
+      if (name) names.add(name);
+    });
+    return names.size;
+  }, [messageTree]);
+}


### PR DESCRIPTION
## Description

Part of [ENG-4318](https://linear.app/onyx-app/issue/ENG-4318/multi-llm-improvements), independent of the selection stack. Per the [Figma](https://www.figma.com/design/BV9tfqwS0GjTIJP7ki6Qux/Search---Chat---Tools?node-id=6465-369597&t=aEEu6tItE1jOVrYT-1):

- When the session used more than one model (multi-LLM turns, or switching models between turns), the footer Retry button stays expanded with the model name and a "Retry with" tooltip, so it is clear which model generated which response. Single-model sessions keep the fold-on-hover icon.
- Fixes the trigger showing the globally selected model for every panel: it now reads the message node's own model, so each response is attributed to the model that produced it.

## How Has This Been Tested?

Live on dev in a mixed-model session: each response's Retry shows its own model (Haiku panel shows Haiku, an Opus turn shows Opus), expanded without hover. Regeneration behavior unchanged.

| Before | After |
|---|---|
| <img alt="before: folded retry icon" src="https://github.com/user-attachments/assets/84b9f00e-b683-4604-a6d7-8232cdad2085" /> | <img alt="after: retry expanded with the response model" src="https://github.com/user-attachments/assets/880c9518-0253-488c-bfad-255aca7655e2" /> |
| Retry is a bare icon, hover reveals the globally selected model regardless of which model answered | Retry stays expanded with the response's own model |

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check
