### PR TITLE
fix(scim): survive Entra soft-delete tombstones and heal rename collisions

### DIFF
--- a/backend/ee/onyx/db/scim.py
+++ b/backend/ee/onyx/db/scim.py
@@ -211,6 +211,12 @@ class ScimDAL(DAL):
         mapping.external_id = external_id
         return mapping
 
+    def reassign_user_mapping(
+        self, mapping: ScimUserMapping, new_user_id: UUID
+    ) -> None:
+        """Point a SCIM mapping at a different user (rename-collision adoption)."""
+        mapping.user_id = new_user_id
+
     def delete_user_mapping(self, mapping_id: int) -> None:
         """Delete a user mapping by ID. No-op if already deleted."""
         mapping = self._session.get(ScimUserMapping, mapping_id)

--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -11,6 +11,8 @@ require a valid SCIM bearer token.
 
 from __future__ import annotations
 
+import re
+from typing import NamedTuple
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, FastAPI, Query, Request, Response
@@ -20,7 +22,11 @@ from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from ee.onyx.db.license import acquire_seat_lock, check_seat_availability
+from ee.onyx.db.license import (
+    acquire_seat_lock,
+    check_seat_availability,
+    user_counts_toward_seats,
+)
 from ee.onyx.db.scim import ScimDAL
 from ee.onyx.server.scim.auth import ScimAuthError, verify_scim_token
 from ee.onyx.server.scim.filtering import parse_scim_filter
@@ -232,6 +238,98 @@ def _is_ext_perm_user(user: User) -> bool:
     (BASIC/ADMIN) are left untouched so we never demote an admin.
     """
     return user.account_type == AccountType.EXT_PERM_USER
+
+
+# Entra ID frees a soft-deleted user's UPN by prefixing the 32-hex objectId.
+_ENTRA_TOMBSTONE_PREFIX = re.compile(r"[0-9a-f]{32}", re.IGNORECASE)
+
+
+def _is_entra_tombstone_rename(current_email: str, new_email: str) -> bool:
+    """Whether *new_email* is Entra's soft-delete rename of *current_email*.
+
+    Entra syncs the objectId-prefixed UPN as userName when a user is
+    soft-deleted. Writing it over the email would orphan the account, so
+    callers keep the email and only record the userName on the mapping.
+    """
+    match = _ENTRA_TOMBSTONE_PREFIX.match(new_email)
+    return (
+        match is not None and new_email[match.end() :].lower() == current_email.lower()
+    )
+
+
+def _is_privileged_account(user: User) -> bool:
+    """Whether renaming *user* must be refused.
+
+    SSO login associates by email, so the first login for a renamed account's
+    new address claims it. Provisioning only ever grants basic access, so a
+    token must not move an admin or group-manager account.
+    """
+    return user_is_admin(user) or user.is_group_manager
+
+
+class _UsernameChange(NamedTuple):
+    """Outcome of a userName change: the account to update, the email to set
+    (None = keep the current one), and whether adoption freed a seat."""
+
+    user: User
+    email: str | None
+    seat_freed: bool = False
+
+
+def _apply_username_change(
+    dal: ScimDAL, user: User, requested_username: str
+) -> _UsernameChange | ScimJSONResponse:
+    """Apply a userName change, resolving it to the account it describes.
+
+    Beyond a plain rename, four cases are handled:
+
+    - An Entra soft-delete tombstone userName never overwrites the email.
+    - A rename onto another SCIM-managed account's address is a conflict (409).
+    - A rename onto an address an unmanaged STANDARD account already owns
+      adopts that account (mirror of the POST adoption path): the mapping
+      moves to it and the stale source account is deactivated. Without this,
+      an IdP restoring a user whose address was re-claimed via SSO login
+      retries the collision error forever. Only STANDARD targets qualify:
+      EXT_PERM shadows fall through so ``reconcile_user_email__no_commit``
+      merges them into the renamed user, and BOT / service / anonymous
+      accounts must never come under IdP control.
+    - A rename of an admin or group manager is rejected (403).
+    """
+    if requested_username.lower() == user.email.lower():
+        return _UsernameChange(user, requested_username)
+
+    if _is_entra_tombstone_rename(user.email, requested_username):
+        logger.info(
+            "SCIM userName for %s is an Entra soft-delete tombstone; keeping email",
+            user.email,
+        )
+        return _UsernameChange(user, None)
+
+    other = dal.get_user_by_email(requested_username)
+    if other and other.id != user.id:
+        if dal.get_user_mapping_by_user_id(other.id):
+            return _scim_error_response(
+                409, f"User with email {requested_username} already exists"
+            )
+        if other.account_type == AccountType.STANDARD:
+            mapping = dal.get_user_mapping_by_user_id(user.id)
+            if mapping:
+                dal.reassign_user_mapping(mapping, other.id)
+            seat_freed = user_counts_toward_seats(user)
+            dal.deactivate_user(user)
+            logger.info(
+                "SCIM rename to %s adopted the existing account; deactivated stale %s",
+                requested_username,
+                user.email,
+            )
+            return _UsernameChange(other, None, seat_freed)
+
+    if _is_privileged_account(user):
+        return _scim_error_response(
+            403, "Cannot move an admin or group manager address"
+        )
+
+    return _UsernameChange(user, requested_username)
 
 
 def _assign_default_groups_or_error(
@@ -624,12 +722,19 @@ def replace_user(
         return result
     user = result
 
+    scim_username = user_resource.userName.strip()
+    resolved = _apply_username_change(dal, user, scim_username)
+    if isinstance(resolved, ScimJSONResponse):
+        return resolved
+    user, new_email, seat_freed = resolved
+
     # Handle activation (need seat check) / deactivation. Promoting a shadow
     # EXT_PERM_USER also consumes a seat, so self-heal any that the IdP
-    # re-syncs after being adopted while still in the shadow role.
+    # re-syncs after being adopted while still in the shadow role. An adoption
+    # that deactivated an active source is seat-neutral, so no check.
     promote = _is_ext_perm_user(user)
     is_reactivation = user_resource.active and not user.is_active
-    if user_resource.active and (is_reactivation or promote):
+    if user_resource.active and (is_reactivation or promote) and not seat_freed:
         seat_error = _check_seat_availability(dal)
         if seat_error:
             return _scim_error_response(403, seat_error)
@@ -638,7 +743,7 @@ def replace_user(
 
     dal.update_user(
         user,
-        email=user_resource.userName.strip(),
+        email=new_email,
         is_active=user_resource.active,
         personal_name=personal_name,
         account_type=AccountType.STANDARD if promote else None,
@@ -654,7 +759,6 @@ def replace_user(
             return error
 
     new_external_id = user_resource.externalId
-    scim_username = user_resource.userName.strip()
     fields = _fields_from_resource(user_resource)
     dal.sync_user_external_id(
         user.id,
@@ -717,18 +821,29 @@ def patch_user(
     except ScimPatchError as e:
         return _scim_error_response(e.status, e.detail)
 
+    requested_username = patched.userName.strip()
+    resolved = _apply_username_change(dal, user, requested_username)
+    if isinstance(resolved, ScimJSONResponse):
+        return resolved
+    user, new_email, seat_freed = resolved
+
     # Apply changes back to the DB model. A seat is consumed when the user
     # becomes active (reactivation) or when a shadow EXT_PERM_USER is promoted
-    # to a real STANDARD account on re-sync.
+    # to a real STANDARD account on re-sync. An adoption that deactivated an
+    # active source is seat-neutral, so no check.
     promote = _is_ext_perm_user(user)
     is_reactivation = patched.active and not user.is_active
-    if patched.active and (patched.active != user.is_active or promote):
+    if (
+        patched.active
+        and (patched.active != user.is_active or promote)
+        and not seat_freed
+    ):
         seat_error = _check_seat_availability(dal)
         if seat_error:
             return _scim_error_response(403, seat_error)
 
     # Track the scim_username — if userName was patched, update it
-    new_scim_username = patched.userName.strip() if patched.userName else None
+    new_scim_username = requested_username or None
 
     # If displayName was explicitly patched (different from the original), use
     # it as personal_name directly.  Otherwise, derive from name components.
@@ -740,10 +855,11 @@ def patch_user(
 
     dal.update_user(
         user,
+        # Unlike PUT, PATCH skips an unchanged address: PUT's pass-through is
+        # what re-runs email reconciliation (EXT_PERM shadow merging) on a
+        # full replace.
         email=(
-            patched.userName.strip()
-            if patched.userName.strip().lower() != user.email.lower()
-            else None
+            new_email if new_email and new_email.lower() != user.email.lower() else None
         ),
         is_active=patched.active if patched.active != user.is_active else None,
         personal_name=personal_name,

--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -38,7 +38,9 @@ from ee.onyx.server.scim.models import (
     ScimListResponse,
     ScimMappingFields,
     ScimName,
+    ScimPatchOperation,
     ScimPatchRequest,
+    ScimPatchResourceValue,
     ScimServiceProviderConfig,
     ScimUserResource,
 )
@@ -330,6 +332,26 @@ def _apply_username_change(
         )
 
     return _UsernameChange(user, requested_username)
+
+
+def _patch_sets_username(operations: list[ScimPatchOperation]) -> bool:
+    """Whether a PATCH carries a userName value, by path or path-less resource.
+
+    Mirrors ``_apply_user_replace``: path-less values may carry userName under
+    any key casing (``extra="allow"``), so inspect the dumped keys, not the
+    canonical field.
+    """
+    for op in operations:
+        path = (op.path or "").lower()
+        if path == "username":
+            return True
+        if not path and isinstance(op.value, ScimPatchResourceValue):
+            if any(
+                key.lower() == "username"
+                for key in op.value.model_dump(exclude_unset=True)
+            ):
+                return True
+    return False
 
 
 def _assign_default_groups_or_error(
@@ -822,10 +844,16 @@ def patch_user(
         return _scim_error_response(e.status, e.detail)
 
     requested_username = patched.userName.strip()
-    resolved = _apply_username_change(dal, user, requested_username)
-    if isinstance(resolved, ScimJSONResponse):
-        return resolved
-    user, new_email, seat_freed = resolved
+    # Resolve a rename only when the PATCH itself carried userName. A patch
+    # that touches other fields must not act on a stored scim_username that
+    # has drifted from the email.
+    new_email: str | None = None
+    seat_freed = False
+    if _patch_sets_username(patch_request.Operations):
+        resolved = _apply_username_change(dal, user, requested_username)
+        if isinstance(resolved, ScimJSONResponse):
+            return resolved
+        user, new_email, seat_freed = resolved
 
     # Apply changes back to the DB model. A seat is consumed when the user
     # becomes active (reactivation) or when a shadow EXT_PERM_USER is promoted

--- a/backend/tests/unit/onyx/server/scim/conftest.py
+++ b/backend/tests/unit/onyx/server/scim/conftest.py
@@ -102,6 +102,9 @@ def make_db_user(**kwargs: Any) -> MagicMock:
     user.personal_name = kwargs.get("personal_name", "Test User")
     # A bare MagicMock never equals an AccountType, so shadow detection would miss.
     user.account_type = kwargs.get("account_type", AccountType.STANDARD)
+    # Real values so privilege predicates (`in`, bool) work on the mock.
+    user.effective_permissions = kwargs.get("effective_permissions", [])
+    user.is_group_manager = kwargs.get("is_group_manager", False)
     return user
 
 

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -1246,6 +1246,77 @@ class TestRenameCollisionAdoption:
         mock_dal.reassign_user_mapping.assert_called_once_with(stale_mapping, clean.id)
         mock_dal.deactivate_user.assert_called_once_with(stale)
 
+    def test_patch_username_in_any_key_casing_still_resolves(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """Path-less values carry userName under any casing (extra='allow')."""
+        stale, clean, stale_mapping = self._stale_and_clean(mock_dal)
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REPLACE,
+                    value={"UserName": "ralf@mane.com", "active": True},
+                )
+            ]
+        )
+
+        result = patch_user(
+            user_id=str(stale.id),
+            patch_request=patch_req,
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        resource = parse_scim_user(result)
+        assert resource.id == str(clean.id)
+        mock_dal.reassign_user_mapping.assert_called_once_with(stale_mapping, clean.id)
+
+    def test_patch_without_username_op_never_resolves_a_rename(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """A PATCH that does not touch userName must not act on a stored
+        scim_username that has drifted from the email (no adoption, no 409)."""
+        user = make_db_user(email="current@mane.com", is_active=True)
+        drifted_owner = make_db_user(email="drifted@mane.com", is_active=True)
+        mapping = make_user_mapping(user_id=user.id, scim_username="drifted@mane.com")
+        mock_dal.get_user.return_value = user
+        mock_dal.get_user_by_email.return_value = drifted_owner
+        mock_dal.get_user_mapping_by_user_id.side_effect = lambda uid: (
+            mapping if uid == user.id else None
+        )
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REPLACE, path="active", value=False
+                )
+            ]
+        )
+
+        result = patch_user(
+            user_id=str(user.id),
+            patch_request=patch_req,
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        mock_dal.reassign_user_mapping.assert_not_called()
+        mock_dal.deactivate_user.assert_not_called()
+        args, kwargs = mock_dal.update_user.call_args
+        assert args[0] is user
+        assert kwargs["email"] is None
+        assert kwargs["is_active"] is False
+
     def test_put_adoption_allowed_for_admin_source(
         self,
         mock_db_session: MagicMock,

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -29,7 +29,7 @@ from ee.onyx.server.scim.models import (
 )
 from ee.onyx.server.scim.patch import ScimPatchError
 from ee.onyx.server.scim.providers.base import ScimProvider
-from onyx.db.enums import AccountType
+from onyx.db.enums import AccountType, Permission
 from tests.unit.onyx.server.scim.conftest import (
     assert_scim_error,
     make_db_user,
@@ -1055,3 +1055,468 @@ class TestSeatLock:
         """Lock id must be deterministic and differ across tenants."""
         assert seat_lock_id_for_tenant("t1") == seat_lock_id_for_tenant("t1")
         assert seat_lock_id_for_tenant("t1") != seat_lock_id_for_tenant("t2")
+
+
+# Entra ID's soft-delete rename: 32-hex objectId prefixed to the original UPN.
+_TOMBSTONE_HEX = "283405f5083e4780b861a7d42f2522c2"
+
+
+def _rename_patch(username: str, active: bool | None = None) -> ScimPatchRequest:
+    value: dict[str, object] = {"userName": username}
+    if active is not None:
+        value["active"] = active
+    return ScimPatchRequest(
+        Operations=[ScimPatchOperation(op=ScimPatchOperationType.REPLACE, value=value)]
+    )
+
+
+class TestEntraTombstoneRename:
+    """Entra syncs a soft-deleted user's objectId-prefixed UPN as userName.
+    The email must survive; only the mapping records what the IdP sent."""
+
+    def test_put_tombstone_keeps_email(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        user = make_db_user(email="ralf@mane.com", is_active=True)
+        mock_dal.get_user.return_value = user
+        tombstone = f"{_TOMBSTONE_HEX}ralf@mane.com"
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(userName=tombstone, active=False),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        resource = parse_scim_user(result)
+        assert resource.userName == tombstone
+        _, kwargs = mock_dal.update_user.call_args
+        assert kwargs["email"] is None
+        assert kwargs["is_active"] is False
+        assert (
+            mock_dal.sync_user_external_id.call_args.kwargs["scim_username"]
+            == tombstone
+        )
+
+    def test_patch_tombstone_keeps_email(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        user = make_db_user(email="ralf@mane.com", is_active=True)
+        mock_dal.get_user.return_value = user
+        tombstone = f"{_TOMBSTONE_HEX}ralf@mane.com"
+
+        result = patch_user(
+            user_id=str(user.id),
+            patch_request=_rename_patch(tombstone, active=False),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        _, kwargs = mock_dal.update_user.call_args
+        assert kwargs["email"] is None
+        assert kwargs["is_active"] is False
+
+    def test_put_tombstone_of_admin_deprovision_not_blocked(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """Deprovisioning an admin must not trip the privileged-rename guard."""
+        user = make_db_user(
+            email="admin@mane.com",
+            is_active=True,
+            effective_permissions=[Permission.FULL_ADMIN_PANEL_ACCESS.value],
+        )
+        mock_dal.get_user.return_value = user
+        tombstone = f"{_TOMBSTONE_HEX}admin@mane.com"
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(userName=tombstone, active=False),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        _, kwargs = mock_dal.update_user.call_args
+        assert kwargs["email"] is None
+
+    def test_put_hex_prefix_of_other_address_is_real_rename(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """A hex prefix only counts as a tombstone of the CURRENT email."""
+        user = make_db_user(email="ralf@mane.com", is_active=True)
+        mock_dal.get_user.return_value = user
+        renamed = f"{_TOMBSTONE_HEX}other@mane.com"
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(userName=renamed, active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        _, kwargs = mock_dal.update_user.call_args
+        assert kwargs["email"] == renamed
+
+
+class TestRenameCollisionAdoption:
+    """A rename onto an address that an unmanaged account already owns adopts
+    that account (mirror of the POST adoption path) instead of failing."""
+
+    def _stale_and_clean(
+        self, mock_dal: MagicMock, **stale_kwargs: object
+    ) -> tuple[MagicMock, MagicMock, MagicMock]:
+        stale = make_db_user(
+            email=f"{_TOMBSTONE_HEX}ralf@mane.com", is_active=False, **stale_kwargs
+        )
+        clean = make_db_user(email="ralf@mane.com", is_active=True)
+        stale_mapping = make_user_mapping(user_id=stale.id)
+        mock_dal.get_user.return_value = stale
+        mock_dal.get_user_by_email.return_value = clean
+        mock_dal.get_user_mapping_by_user_id.side_effect = lambda uid: (
+            stale_mapping if uid == stale.id else None
+        )
+        return stale, clean, stale_mapping
+
+    def test_put_adopts_unmanaged_account(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        stale, clean, stale_mapping = self._stale_and_clean(mock_dal)
+
+        result = replace_user(
+            user_id=str(stale.id),
+            user_resource=make_scim_user(userName="ralf@mane.com", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        resource = parse_scim_user(result)
+        assert resource.id == str(clean.id)
+        mock_dal.reassign_user_mapping.assert_called_once_with(stale_mapping, clean.id)
+        mock_dal.deactivate_user.assert_called_once_with(stale)
+        args, kwargs = mock_dal.update_user.call_args
+        assert args[0] is clean
+        assert kwargs["email"] is None
+
+    def test_patch_adopts_unmanaged_account(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        stale, clean, stale_mapping = self._stale_and_clean(mock_dal)
+
+        result = patch_user(
+            user_id=str(stale.id),
+            patch_request=_rename_patch("ralf@mane.com", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        resource = parse_scim_user(result)
+        assert resource.id == str(clean.id)
+        mock_dal.reassign_user_mapping.assert_called_once_with(stale_mapping, clean.id)
+        mock_dal.deactivate_user.assert_called_once_with(stale)
+
+    def test_put_adoption_allowed_for_admin_source(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """Adoption is not a rename of the privileged account — allow it."""
+        stale, clean, _ = self._stale_and_clean(
+            mock_dal,
+            effective_permissions=[Permission.FULL_ADMIN_PANEL_ACCESS.value],
+        )
+
+        result = replace_user(
+            user_id=str(stale.id),
+            user_resource=make_scim_user(userName="ralf@mane.com", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        resource = parse_scim_user(result)
+        assert resource.id == str(clean.id)
+        mock_dal.deactivate_user.assert_called_once_with(stale)
+
+    @patch("ee.onyx.server.scim.api._check_seat_availability")
+    def test_put_adoption_swap_is_seat_neutral(
+        self,
+        mock_seats: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """Deactivating the active source frees the seat the adopted inactive
+        target needs, so a tenant at capacity must not 403."""
+        mock_seats.return_value = "No seats"
+        stale = make_db_user(email="old@mane.com", is_active=True)
+        clean = make_db_user(email="ralf@mane.com", is_active=False)
+        stale_mapping = make_user_mapping(user_id=stale.id)
+        mock_dal.get_user.return_value = stale
+        mock_dal.get_user_by_email.return_value = clean
+        mock_dal.get_user_mapping_by_user_id.side_effect = lambda uid: (
+            stale_mapping if uid == stale.id else None
+        )
+
+        result = replace_user(
+            user_id=str(stale.id),
+            user_resource=make_scim_user(userName="ralf@mane.com", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        resource = parse_scim_user(result)
+        assert resource.id == str(clean.id)
+        mock_seats.assert_not_called()
+
+    @patch("ee.onyx.server.scim.api._check_seat_availability")
+    def test_put_adoption_of_ext_perm_source_still_checks_seats(
+        self,
+        mock_seats: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """An active EXT_PERM source holds no seat, so its deactivation frees
+        none and reactivating the adopted target must still be checked."""
+        mock_seats.return_value = "No seats"
+        stale = make_db_user(
+            email="old@mane.com",
+            is_active=True,
+            account_type=AccountType.EXT_PERM_USER,
+        )
+        clean = make_db_user(email="ralf@mane.com", is_active=False)
+        mock_dal.get_user.return_value = stale
+        mock_dal.get_user_by_email.return_value = clean
+        mock_dal.get_user_mapping_by_user_id.return_value = None
+
+        result = replace_user(
+            user_id=str(stale.id),
+            user_resource=make_scim_user(userName="ralf@mane.com", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 403)
+        mock_seats.assert_called_once()
+
+    def test_put_rename_onto_mapped_bot_returns_409(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """A mapped collision is a conflict no matter the account type."""
+        user = make_db_user(email="old@mane.com")
+        bot = make_db_user(email="bot@mane.com", account_type=AccountType.BOT)
+        mock_dal.get_user.return_value = user
+        mock_dal.get_user_by_email.return_value = bot
+        mock_dal.get_user_mapping_by_user_id.side_effect = lambda uid: (
+            make_user_mapping(user_id=uid) if uid == bot.id else None
+        )
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(userName="bot@mane.com", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 409)
+
+    def test_put_rename_onto_bot_account_is_not_adopted(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """System accounts must never come under IdP control via adoption."""
+        user = make_db_user(email="old@mane.com", is_active=True)
+        bot = make_db_user(email="bot@mane.com", account_type=AccountType.BOT)
+        mock_dal.get_user.return_value = user
+        mock_dal.get_user_by_email.return_value = bot
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(userName="bot@mane.com", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        mock_dal.reassign_user_mapping.assert_not_called()
+        mock_dal.deactivate_user.assert_not_called()
+        args, _ = mock_dal.update_user.call_args
+        assert args[0] is user
+
+    def test_put_rename_onto_ext_perm_shadow_stays_a_rename(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """EXT_PERM shadows are merged by email reconciliation, not adopted."""
+        user = make_db_user(email="old@mane.com", is_active=True)
+        shadow = make_db_user(
+            email="ralf@mane.com", account_type=AccountType.EXT_PERM_USER
+        )
+        mock_dal.get_user.return_value = user
+        mock_dal.get_user_by_email.return_value = shadow
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(userName="ralf@mane.com", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        mock_dal.reassign_user_mapping.assert_not_called()
+        mock_dal.deactivate_user.assert_not_called()
+        args, kwargs = mock_dal.update_user.call_args
+        assert args[0] is user
+        assert kwargs["email"] == "ralf@mane.com"
+
+    def test_put_rename_onto_scim_managed_account_returns_409(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        user = make_db_user(email="old@mane.com")
+        other = make_db_user(email="taken@mane.com")
+        mock_dal.get_user.return_value = user
+        mock_dal.get_user_by_email.return_value = other
+        mock_dal.get_user_mapping_by_user_id.side_effect = lambda uid: (
+            make_user_mapping(user_id=uid) if uid == other.id else None
+        )
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(userName="taken@mane.com", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 409)
+
+
+class TestPrivilegedRename:
+    """A SCIM token must not move an admin or group-manager account onto a
+    different address — the address could then be claimed via first login."""
+
+    def test_put_admin_rename_returns_403(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        user = make_db_user(
+            email="admin@mane.com",
+            effective_permissions=[Permission.FULL_ADMIN_PANEL_ACCESS.value],
+        )
+        mock_dal.get_user.return_value = user
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(userName="moved@mane.com", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 403)
+        mock_dal.update_user.assert_not_called()
+
+    def test_patch_group_manager_rename_returns_403(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        user = make_db_user(email="manager@mane.com", is_group_manager=True)
+        mock_dal.get_user.return_value = user
+
+        result = patch_user(
+            user_id=str(user.id),
+            patch_request=_rename_patch("moved@mane.com"),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 403)
+        mock_dal.update_user.assert_not_called()
+
+    def test_put_admin_without_rename_is_allowed(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        user = make_db_user(
+            email="admin@mane.com",
+            is_active=True,
+            effective_permissions=[Permission.FULL_ADMIN_PANEL_ACCESS.value],
+        )
+        mock_dal.get_user.return_value = user
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(userName="admin@mane.com", active=False),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        _, kwargs = mock_dal.update_user.call_args
+        assert kwargs["is_active"] is False


### PR DESCRIPTION
## Description

**The issue:** When a user is soft-deleted in Entra ID, Entra frees their UPN by renaming it to `<objectId hex, no dashes><original UPN>` (e.g. `283405f5...c2ralf.schwieger@mane.com`). Entra's provisioning service then syncs that renamed UPN to us as the SCIM userName, together with `active=false`. Our PUT/PATCH handlers wrote userName straight into `user.email`, so every deprovisioned user's account got corrupted with the hex-prefixed address.

From there it snowballs:
1. The user is later restored in Entra (or just logs in via SSO). SSO matches by email, finds nothing on the clean address, and JIT-creates a duplicate account with no history, groups, or SCIM mapping.
2. Entra tries to restore the original account: its userName lookup finds nothing (the mapped account has the tombstone email), so it PATCHes its stored target id to rename it back.
3. That PATCH fails forever: 409 because the clean email now belongs to the duplicate, or 403 for admins. Entra retries every sync cycle. Seen live on mane-staging: ~5 users stuck in this loop with hex-prefixed emails in the admin UI.

**Fix:**
- Tombstone userNames (32-hex prefix + current email) no longer overwrite the email; the mapping still records what the IdP sent and deactivation still applies. This stops the corruption at step 0.
- A rename that collides with an unmanaged STANDARD account adopts it (mirror of the POST adoption path): mapping moves, stale source is deactivated, seat check nets out the freed seat. This heals already-corrupted installs at step 3. EXT_PERM shadows still fall through to the email-reconcile merge; BOT/service accounts are never adopted; mapped collisions 409.
- Renaming an admin or group-manager account returns 403 (port of the release-branch `_is_privileged_rename` guard, which main never had), since SSO associates by email and a rename would let the new address's first login claim the account.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check