### PR TITLE
feat(chat): sticky panel headers and whole-card response selection

### DIFF
--- a/web/src/app/app/message/MultiModelPanel.tsx
+++ b/web/src/app/app/message/MultiModelPanel.tsx
@@ -105,9 +105,18 @@ export default function MultiModelPanel({
     !selectionDisabled &&
     !readOnly;
 
-  const handlePanelClick = useCallback(() => {
-    if (canSelect) onSelect();
-  }, [canSelect, onSelect]);
+  // Whole-card select. Interactive descendants keep their own behavior, and a
+  // click that ends a text selection never counts as a pick.
+  const handleCardClick = useCallback(
+    (e: React.MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.closest('button, a, [role="button"], input, textarea, select'))
+        return;
+      if (window.getSelection()?.toString()) return;
+      onSelect();
+    },
+    [onSelect]
+  );
 
   const headerClassName = cn(
     "rounded-12 transition-colors",
@@ -135,6 +144,7 @@ export default function MultiModelPanel({
               </div>
             ) : undefined
           ) : (
+            // raw-ok: ContentAction rightChildren slot row, Section's inline gap/padding fight the px-2 chip alignment
             <div className="flex items-center gap-1 px-2">
               {isPreferred && (
                 <>
@@ -156,6 +166,20 @@ export default function MultiModelPanel({
                     />
                   )}
                 </>
+              )}
+              {canSelect && (
+                <span className="opacity-0 group-hover/mm-panel:opacity-100 no-hover:opacity-100 transition-opacity">
+                  <Button
+                    prominence="tertiary"
+                    size="sm"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onSelect();
+                    }}
+                  >
+                    Select This Response
+                  </Button>
+                </span>
               )}
               {!isPreferred && (
                 <Button
@@ -184,8 +208,8 @@ export default function MultiModelPanel({
       role="button"
       tabIndex={0}
       aria-label={`Select the ${displayName} response`}
-      onKeyDown={clickOnKeyDown(handlePanelClick)}
-      onClick={handlePanelClick}
+      onKeyDown={clickOnKeyDown(onSelect)}
+      onClick={onSelect}
     >
       {headerContent}
     </div>
@@ -234,9 +258,19 @@ export default function MultiModelPanel({
   }
 
   return (
-    // raw-ok: panel column, min-w-0 shrink semantics no Section width preset provides
-    <div className="flex flex-col gap-3 min-w-0 rounded-16">
-      {headerWithNav}
+    // oxlint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- raw-ok: panel column with min-w-0 shrink semantics no Section preset provides, and the card click is a pointer-only convenience while the header carries the focusable role=button
+    <div
+      className={cn(
+        "group/mm-panel flex flex-col gap-3 min-w-0 rounded-16 transition-colors",
+        canSelect && "cursor-pointer hover:bg-background-tint-01"
+      )}
+      onClick={canSelect ? handleCardClick : undefined}
+    >
+      {/* Sticky keeps the model and select affordance in view while the
+          response scrolls. The solid backdrop stops body text showing through. */}
+      <div className="sticky top-0 z-10 bg-background-neutral-00 rounded-12">
+        {headerWithNav}
+      </div>
       {errorMessage ? (
         <div className="p-4">
           <ErrorBanner

--- a/web/src/app/app/message/MultiModelResponseView.tsx
+++ b/web/src/app/app/message/MultiModelResponseView.tsx
@@ -76,6 +76,9 @@ const NARROW_CAROUSEL_GAP = 4;
  *
  * Hidden panels render as a compact header-only strip at `HIDDEN_PANEL_W` in
  * both modes and are excluded from layout width calculations.
+ *
+ * Horizontal clipping uses `overflow-x: clip`, never `hidden`: clip creates no
+ * scrollport, so the panels' sticky headers keep binding to the chat scroller.
  */
 export default function MultiModelResponseView({
   responses,
@@ -259,10 +262,11 @@ export default function MultiModelResponseView({
   const { isSmallScreen } = useScreenSize();
   const requiredSideBySideW =
     visibleResponses.length * MIN_PANEL_W +
-    (visibleResponses.length - 1) * PANEL_GAP;
+    hiddenPanels.size * HIDDEN_PANEL_W +
+    (responses.length - 1) * PANEL_GAP;
   const showNarrowCarousel =
     !readOnly &&
-    visibleResponses.length > 1 &&
+    responses.length > 1 &&
     containerW > 0 &&
     (isSmallScreen || containerW < requiredSideBySideW);
 
@@ -408,7 +412,7 @@ export default function MultiModelResponseView({
         if (to <= from) return;
         // Lock current height, remove maxHeight cap, then animate
         el.style.maxHeight = `${from}px`;
-        el.style.overflow = "hidden";
+        el.style.overflow = "clip";
         const anim = el.animate(
           [{ maxHeight: `${from}px` }, { maxHeight: `${to}px` }],
           {
@@ -525,8 +529,8 @@ export default function MultiModelResponseView({
 
   // Carousel starts on the preferred card when a preference exists, else the
   // first model (the right-most side-by-side panel).
-  const lastCarouselPos = Math.max(0, visibleResponses.length - 1);
-  const preferredCarouselPos = visibleResponses.findIndex(
+  const lastCarouselPos = Math.max(0, responses.length - 1);
+  const preferredCarouselPos = responses.findIndex(
     (r) => r.modelIndex === preferredIndex
   );
   const [carouselPos, setCarouselPos] = useState(
@@ -550,10 +554,15 @@ export default function MultiModelResponseView({
     }
   }, [showNarrowCarousel, preferredCarouselPos]);
   const clampedCarouselPos = Math.min(carouselPos, lastCarouselPos);
-  const currentCarouselResponse = visibleResponses[clampedCarouselPos];
+  const currentCarouselResponse = responses[clampedCarouselPos];
 
   // Feed the send path's response-in-view rule from the carousel position.
-  const currentCarouselMessageId = currentCarouselResponse?.messageId ?? null;
+  // A hidden card in view never becomes the implicit pick.
+  const currentCarouselMessageId =
+    currentCarouselResponse &&
+    !hiddenPanels.has(currentCarouselResponse.modelIndex)
+      ? (currentCarouselResponse.messageId ?? null)
+      : null;
   useEffect(() => {
     if (readOnly || parentNodeId == null || !showNarrowCarousel) return;
     if (currentCarouselMessageId != null) {
@@ -673,7 +682,7 @@ export default function MultiModelResponseView({
     return (
       <div
         ref={trackContainerRef}
-        className="w-full overflow-hidden"
+        className="w-full overflow-x-clip"
         style={
           isActivelySelected
             ? {
@@ -750,12 +759,10 @@ export default function MultiModelResponseView({
     // Full-width cards with off-canvas neighbors, per the mobile design. The
     // current card's header carries the prev/next model nav.
     const prevResponse =
-      clampedCarouselPos > 0
-        ? visibleResponses[clampedCarouselPos - 1]
-        : undefined;
+      clampedCarouselPos > 0 ? responses[clampedCarouselPos - 1] : undefined;
     const nextResponse =
       clampedCarouselPos < lastCarouselPos
-        ? visibleResponses[clampedCarouselPos + 1]
+        ? responses[clampedCarouselPos + 1]
         : undefined;
     const prevNav = prevResponse
       ? {
@@ -774,7 +781,7 @@ export default function MultiModelResponseView({
         }
       : undefined;
     return (
-      <div ref={setRootEl} className="w-full overflow-hidden">
+      <div ref={setRootEl} className="w-full overflow-x-clip">
         {/* raw-ok: transform-driven carousel track matching the sibling selection-layout track. Section's inline gap/width styles fight the px-precise animated geometry */}
         <div
           className="flex items-start"
@@ -792,7 +799,7 @@ export default function MultiModelResponseView({
               setCarouselSliding(false);
           }}
         >
-          {visibleResponses.map((r, i) => {
+          {responses.map((r, i) => {
             const isCurrent = i === clampedCarouselPos;
             return (
               <div
@@ -819,9 +826,15 @@ export default function MultiModelResponseView({
     visibleResponses.length <= 2 ? GEN_PANEL_W_2 : GEN_PANEL_W_3;
 
   return (
-    <div ref={setRootEl} className="overflow-x-auto">
+    <div
+      ref={setRootEl}
+      // The interactive row renders only when everything fits (the carousel
+      // absorbs overflow). The shared view has no carousel and scrolls.
+      className={cn(readOnly ? "overflow-x-auto" : "overflow-x-clip")}
+    >
       {/* raw-ok: equal-width panel row whose children carry px min/max widths, outside Section's rem spacing steps */}
-      <div className="flex gap-6 items-start justify-center w-full">
+      {/* Safe centering start-aligns on overflow so the scroll fallback can reach the leading hidden strip */}
+      <div className="flex gap-6 items-start justify-center-safe w-full">
         {responses.map((r) => {
           const isHidden = hiddenPanels.has(r.modelIndex);
           return (


### PR DESCRIPTION
## Description

Part of [ENG-4318](https://linear.app/onyx-app/issue/ENG-4318/multi-llm-improvements), stacked on #14068. Per the [hover design](https://www.figma.com/design/BV9tfqwS0GjTIJP7ki6Qux/Search---Chat---Tools?node-id=5136-191710&t=aEEu6tItE1jOVrYT-1):

- Panel headers are sticky against the chat scroller, so the model name and select affordance stay in view while a response scrolls. The overflow ancestors switch from `hidden`/`auto` to `clip`, which clips without creating a scrollport, so sticky keeps binding to the chat container.
- Hovering a selectable card tints it and reveals "Select This Response" in the header.
- The click target is the whole card: any click that is not on an interactive element and does not end a text selection picks the response. The header stays the keyboard-accessible `role=button`.

## How Has This Been Tested?

<img width="2816" height="1890" alt="2026-08-25 12 23 01" src="https://github.com/user-attachments/assets/d86d5104-eb1d-42d6-b5bc-3e754d188b84" />


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check
