### PR TITLE
fix: prune unowned hierarchy nodes on connector delete

### DIFF
--- a/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
+++ b/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
@@ -43,6 +43,7 @@ from onyx.db.enums import (
     SyncStatus,
     SyncType,
 )
+from onyx.db.hierarchy import cleanup_unowned_hierarchy_nodes
 from onyx.db.index_attempt import delete_index_attempts, get_recent_attempts_for_cc_pair
 from onyx.db.permission_sync_attempt import (
     delete_doc_permission_sync_attempts__no_commit,
@@ -60,6 +61,11 @@ from onyx.redis.redis_connector import RedisConnector
 from onyx.redis.redis_connector_delete import (
     RedisConnectorDelete,
     RedisConnectorDeletePayload,
+)
+from onyx.redis.redis_hierarchy import (
+    HierarchyNodeCacheEntry,
+    cache_hierarchy_nodes_batch,
+    evict_hierarchy_nodes_from_cache,
 )
 from onyx.redis.redis_pool import get_redis_client, get_redis_replica_client
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
@@ -409,7 +415,7 @@ def try_generate_document_cc_pair_cleanup_tasks(
 def monitor_connector_deletion_taskset(
     tenant_id: str,
     key_bytes: bytes,
-    r: TenantRedisClient,  # noqa: ARG001
+    r: TenantRedisClient,
 ) -> None:
     fence_key = key_bytes.decode("utf-8")
     cc_pair_id_str = RedisConnector.get_id_from_fence_key(fence_key)
@@ -523,6 +529,7 @@ def monitor_connector_deletion_taskset(
             # Store IDs before potentially expiring cc_pair
             connector_id_to_delete = cc_pair.connector_id
             credential_id_to_delete = cc_pair.credential_id
+            source = cc_pair.connector.source
 
             # Explicitly delete document by connector credential pair records before deleting the connector
             # This is needed because connector_id is a primary key in that table and cascading deletes won't work
@@ -545,6 +552,13 @@ def monitor_connector_deletion_taskset(
                 connector_id=connector_id_to_delete,
                 credential_id=credential_id_to_delete,
             )
+            # Join rows cascade off the cc_pair; drop nodes no other connector still owns.
+            db_session.flush()
+            deleted_raw_ids, reparented_nodes = cleanup_unowned_hierarchy_nodes(
+                db_session=db_session,
+                source=source,
+                commit=False,
+            )
             # if there are no credentials left, delete the connector
             connector = fetch_connector_by_id(
                 db_session=db_session,
@@ -560,6 +574,30 @@ def monitor_connector_deletion_taskset(
                 )
                 db_session.delete(connector)
             db_session.commit()
+
+            try:
+                if deleted_raw_ids:
+                    evict_hierarchy_nodes_from_cache(r, source, deleted_raw_ids)
+                if reparented_nodes:
+                    cache_hierarchy_nodes_batch(
+                        r,
+                        source,
+                        [
+                            HierarchyNodeCacheEntry.from_db_model(node)
+                            for node in reparented_nodes
+                        ],
+                    )
+            except Exception:
+                task_logger.exception(
+                    "Connector deletion - failed to update hierarchy node cache: "
+                    f"cc_pair={cc_pair_id}"
+                )
+            if deleted_raw_ids or reparented_nodes:
+                task_logger.info(
+                    f"Connector deletion hierarchy cleanup: cc_pair={cc_pair_id} "
+                    f"nodes_deleted={len(deleted_raw_ids)} "
+                    f"nodes_reparented={len(reparented_nodes)}"
+                )
 
             update_sync_record_status(
                 db_session=db_session,

--- a/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
+++ b/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
@@ -62,11 +62,7 @@ from onyx.redis.redis_connector_delete import (
     RedisConnectorDelete,
     RedisConnectorDeletePayload,
 )
-from onyx.redis.redis_hierarchy import (
-    HierarchyNodeCacheEntry,
-    cache_hierarchy_nodes_batch,
-    evict_hierarchy_nodes_from_cache,
-)
+from onyx.redis.redis_hierarchy import invalidate_hierarchy_cache_for_source
 from onyx.redis.redis_pool import get_redis_client, get_redis_replica_client
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
 from onyx.redis.tenant_redis_client import TenantRedisClient
@@ -575,24 +571,17 @@ def monitor_connector_deletion_taskset(
                 db_session.delete(connector)
             db_session.commit()
 
-            try:
-                if deleted_raw_ids:
-                    evict_hierarchy_nodes_from_cache(r, source, deleted_raw_ids)
-                if reparented_nodes:
-                    cache_hierarchy_nodes_batch(
-                        r,
-                        source,
-                        [
-                            HierarchyNodeCacheEntry.from_db_model(node)
-                            for node in reparented_nodes
-                        ],
-                    )
-            except Exception:
-                task_logger.exception(
-                    "Connector deletion - failed to update hierarchy node cache: "
-                    f"cc_pair={cc_pair_id}"
-                )
             if deleted_raw_ids or reparented_nodes:
+                for attempt in range(3):
+                    try:
+                        invalidate_hierarchy_cache_for_source(r, source)
+                        break
+                    except Exception:
+                        if attempt == 2:
+                            task_logger.exception(
+                                "Connector deletion - failed to invalidate hierarchy node cache: "
+                                f"cc_pair={cc_pair_id}"
+                            )
                 task_logger.info(
                     f"Connector deletion hierarchy cleanup: cc_pair={cc_pair_id} "
                     f"nodes_deleted={len(deleted_raw_ids)} "

--- a/backend/onyx/background/celery/tasks/hierarchyfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/hierarchyfetching/tasks.py
@@ -41,10 +41,7 @@ from onyx.db.connector_credential_pair import (
 )
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import AccessType, ConnectorCredentialPairStatus
-from onyx.db.hierarchy import (
-    upsert_hierarchy_node_cc_pair_entries,
-    upsert_hierarchy_nodes_batch,
-)
+from onyx.db.hierarchy import persist_hierarchy_nodes_for_cc_pair
 from onyx.db.models import ConnectorCredentialPair
 from onyx.redis.redis_hierarchy import (
     HierarchyNodeCacheEntry,
@@ -312,20 +309,13 @@ def _run_hierarchy_extraction(
         if not node_batch:
             return 0
 
-        upserted_nodes = upsert_hierarchy_nodes_batch(
+        upserted_nodes = persist_hierarchy_nodes_for_cc_pair(
             db_session=db_session,
             nodes=node_batch,
             source=source,
-            commit=True,
-            is_connector_public=is_connector_public,
-        )
-
-        upsert_hierarchy_node_cc_pair_entries(
-            db_session=db_session,
-            hierarchy_node_ids=[n.id for n in upserted_nodes],
             connector_id=cc_pair.connector_id,
             credential_id=cc_pair.credential_id,
-            commit=True,
+            is_connector_public=is_connector_public,
         )
 
         # Cache in Redis for fast ancestor resolution

--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -56,9 +56,8 @@ from onyx.db.enums import (
     SyncType,
 )
 from onyx.db.hierarchy import (
-    delete_orphaned_hierarchy_nodes,
+    cleanup_unowned_hierarchy_nodes,
     remove_stale_hierarchy_node_cc_pair_entries,
-    reparent_orphaned_hierarchy_nodes,
     update_document_parent_hierarchy_nodes,
     upsert_hierarchy_node_cc_pair_entries,
     upsert_hierarchy_nodes_batch,
@@ -737,12 +736,7 @@ def connector_pruning_generator_task(
                 live_hierarchy_node_ids=live_node_ids,
                 commit=True,
             )
-            deleted_raw_ids = delete_orphaned_hierarchy_nodes(
-                db_session=db_session,
-                source=source,
-                commit=True,
-            )
-            reparented_nodes = reparent_orphaned_hierarchy_nodes(
+            deleted_raw_ids, reparented_nodes = cleanup_unowned_hierarchy_nodes(
                 db_session=db_session,
                 source=source,
                 commit=True,

--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -57,10 +57,9 @@ from onyx.db.enums import (
 )
 from onyx.db.hierarchy import (
     cleanup_unowned_hierarchy_nodes,
+    persist_hierarchy_nodes_for_cc_pair,
     remove_stale_hierarchy_node_cc_pair_entries,
     update_document_parent_hierarchy_nodes,
-    upsert_hierarchy_node_cc_pair_entries,
-    upsert_hierarchy_nodes_batch,
 )
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import HierarchyNode as DBHierarchyNode
@@ -633,24 +632,15 @@ def connector_pruning_generator_task(
 
             upserted_nodes: list[DBHierarchyNode] = []
             if extraction_result.hierarchy_nodes:
-                upserted_nodes = upsert_hierarchy_nodes_batch(
+                upserted_nodes = persist_hierarchy_nodes_for_cc_pair(
                     db_session=db_session,
                     nodes=extraction_result.hierarchy_nodes,
                     source=source,
-                    commit=False,
-                    is_connector_public=is_connector_public,
-                )
-
-                upsert_hierarchy_node_cc_pair_entries(
-                    db_session=db_session,
-                    hierarchy_node_ids=[n.id for n in upserted_nodes],
                     connector_id=connector_id,
                     credential_id=credential_id,
+                    is_connector_public=is_connector_public,
                     commit=False,
                 )
-
-                # Single commit so the FK reference in the join table can never
-                # outrun the parent hierarchy_node insert.
                 db_session.commit()
 
                 cache_entries = [

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -65,10 +65,7 @@ from onyx.db.enums import (
     IndexingStatus,
     IndexModelStatus,
 )
-from onyx.db.hierarchy import (
-    upsert_hierarchy_node_cc_pair_entries,
-    upsert_hierarchy_nodes_batch,
-)
+from onyx.db.hierarchy import persist_hierarchy_nodes_for_cc_pair
 from onyx.db.index_attempt import (
     create_index_attempt_error,
     get_index_attempt,
@@ -1023,20 +1020,13 @@ def cache_and_upsert_hierarchy_nodes(
         hierarchy_node_batch
     )
     with get_session_with_current_tenant() as db_session:
-        upserted_nodes = upsert_hierarchy_nodes_batch(
+        upserted_nodes = persist_hierarchy_nodes_for_cc_pair(
             db_session=db_session,
             nodes=hierarchy_node_batch_cleaned,
             source=db_connector.source,
-            commit=True,
-            is_connector_public=is_connector_public,
-        )
-
-        upsert_hierarchy_node_cc_pair_entries(
-            db_session=db_session,
-            hierarchy_node_ids=[n.id for n in upserted_nodes],
             connector_id=db_connector.id,
             credential_id=db_credential.id,
-            commit=True,
+            is_connector_public=is_connector_public,
         )
 
         # Cache in Redis for fast ancestor resolution during doc processing

--- a/backend/onyx/background/indexing/run_targeted_reindex.py
+++ b/backend/onyx/background/indexing/run_targeted_reindex.py
@@ -33,10 +33,7 @@ from onyx.connectors.models import (
 )
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
 from onyx.db.enums import AccessType
-from onyx.db.hierarchy import (
-    upsert_hierarchy_node_cc_pair_entries,
-    upsert_hierarchy_nodes_batch,
-)
+from onyx.db.hierarchy import persist_hierarchy_nodes_for_cc_pair
 from onyx.db.models import (
     ConnectorCredentialPair,
     IndexAttempt,
@@ -199,19 +196,13 @@ def _persist_hierarchy_nodes(
     back to "source-type root" until the next full crawl.
     """
     sanitized = sanitize_hierarchy_nodes_for_postgres(nodes)
-    upserted = upsert_hierarchy_nodes_batch(
+    upserted = persist_hierarchy_nodes_for_cc_pair(
         db_session=db_session,
         nodes=sanitized,
         source=cc_pair.connector.source,
-        commit=True,
-        is_connector_public=cc_pair.access_type == AccessType.PUBLIC,
-    )
-    upsert_hierarchy_node_cc_pair_entries(
-        db_session=db_session,
-        hierarchy_node_ids=[n.id for n in upserted],
         connector_id=cc_pair.connector.id,
         credential_id=cc_pair.credential.id,
-        commit=True,
+        is_connector_public=cc_pair.access_type == AccessType.PUBLIC,
     )
     cache_hierarchy_nodes_batch(
         redis_client=get_redis_client(tenant_id=tenant_id),

--- a/backend/onyx/db/hierarchy.py
+++ b/backend/onyx/db/hierarchy.py
@@ -823,6 +823,43 @@ def upsert_hierarchy_node_cc_pair_entries(
         db_session.flush()
 
 
+def persist_hierarchy_nodes_for_cc_pair(
+    db_session: Session,
+    nodes: list[PydanticHierarchyNode],
+    source: DocumentSource,
+    connector_id: int,
+    credential_id: int,
+    is_connector_public: bool = False,
+    commit: bool = True,
+) -> list[HierarchyNode]:
+    """Upsert nodes and their cc_pair ownership links in one transaction.
+
+    Orphan cleanup deletes nodes with no join-table row. The node insert and
+    ownership insert must commit together so a concurrent cleanup cannot
+    remove a node before its link exists.
+    """
+    if not nodes:
+        return []
+
+    upserted = upsert_hierarchy_nodes_batch(
+        db_session=db_session,
+        nodes=nodes,
+        source=source,
+        commit=False,
+        is_connector_public=is_connector_public,
+    )
+    upsert_hierarchy_node_cc_pair_entries(
+        db_session=db_session,
+        hierarchy_node_ids=[n.id for n in upserted],
+        connector_id=connector_id,
+        credential_id=credential_id,
+        commit=False,
+    )
+    if commit:
+        db_session.commit()
+    return upserted
+
+
 def remove_stale_hierarchy_node_cc_pair_entries(
     db_session: Session,
     connector_id: int,

--- a/backend/onyx/db/hierarchy.py
+++ b/backend/onyx/db/hierarchy.py
@@ -909,8 +909,8 @@ def reparent_orphaned_hierarchy_nodes(
 ) -> list[HierarchyNode]:
     """Re-parent hierarchy nodes whose parent_id is NULL to the SOURCE node.
 
-    After pruning deletes stale nodes, their former children get parent_id=NULL
-    via the SET NULL cascade. This function points them back to the SOURCE root.
+    After parent nodes are deleted, former children get parent_id=NULL via
+    SET NULL. This points them back to the SOURCE root.
 
     Returns the reparented HierarchyNode objects (with updated parent_id)
     so callers can refresh downstream caches.
@@ -937,3 +937,24 @@ def reparent_orphaned_hierarchy_nodes(
         db_session.flush()
 
     return orphans
+
+
+def cleanup_unowned_hierarchy_nodes(
+    db_session: Session,
+    source: DocumentSource,
+    commit: bool = True,
+) -> tuple[list[str], list[HierarchyNode]]:
+    """Delete nodes with no remaining cc_pair links; reparent leftover children.
+
+    SOURCE roots are kept. Call after join-table rows for a cc_pair are gone
+    (cc_pair delete CASCADE, or prune's stale-entry removal).
+
+    Returns (deleted raw_node_ids, reparented nodes) for cache updates.
+    """
+    deleted_raw_ids = delete_orphaned_hierarchy_nodes(db_session, source, commit=False)
+    reparented_nodes = reparent_orphaned_hierarchy_nodes(
+        db_session, source, commit=False
+    )
+    if commit:
+        db_session.commit()
+    return deleted_raw_ids, reparented_nodes

--- a/backend/onyx/redis/redis_hierarchy.py
+++ b/backend/onyx/redis/redis_hierarchy.py
@@ -228,6 +228,22 @@ def evict_hierarchy_nodes_from_cache(
     redis_client.hdel(raw_id_key, *raw_node_ids)
 
 
+def invalidate_hierarchy_cache_for_source(
+    redis_client: TenantRedisClient,
+    source: DocumentSource,
+) -> None:
+    """Drop all cached ancestor mappings for a source.
+
+    Next ancestor lookup refreshes from Postgres. Use after source-wide
+    node deletes or reparents so stale parent chains cannot be served.
+    """
+    redis_client.delete(
+        _cache_key(source),
+        _raw_id_cache_key(source),
+        _source_node_key(source),
+    )
+
+
 def get_node_id_from_raw_id(
     redis_client: TenantRedisClient,
     source: DocumentSource,

--- a/backend/tests/external_dependency_unit/celery/test_connector_deletion_hierarchy_nodes.py
+++ b/backend/tests/external_dependency_unit/celery/test_connector_deletion_hierarchy_nodes.py
@@ -1,0 +1,199 @@
+"""Connector deletion drops cc_pair join rows, then cleanup_unowned_hierarchy_nodes
+deletes nodes no remaining connector owns. SOURCE roots stay; shared nodes stay."""
+
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import HierarchyNode as PydanticHierarchyNode
+from onyx.connectors.models import InputType
+from onyx.db.connector_credential_pair import (
+    delete_connector_credential_pair__no_commit,
+)
+from onyx.db.enums import AccessType, ConnectorCredentialPairStatus, HierarchyNodeType
+from onyx.db.hierarchy import (
+    cleanup_unowned_hierarchy_nodes,
+    ensure_source_node_exists,
+    get_all_hierarchy_nodes_for_source,
+    get_hierarchy_node_by_raw_id,
+    upsert_hierarchy_node_cc_pair_entries,
+    upsert_hierarchy_nodes_batch,
+)
+from onyx.db.models import (
+    Connector,
+    ConnectorCredentialPair,
+    Credential,
+    HierarchyNodeByConnectorCredentialPair,
+)
+from onyx.db.models import HierarchyNode as DBHierarchyNode
+
+TEST_SOURCE = DocumentSource.GURU
+SHARED_NODE_ID = "shared-folder"
+UNIQUE_NODE_ID = "unique-folder"
+
+
+def _create_cc_pair(db_session: Session) -> ConnectorCredentialPair:
+    connector = Connector(
+        name=f"Test {TEST_SOURCE.value} Connector {uuid4().hex[:8]}",
+        source=TEST_SOURCE,
+        input_type=InputType.LOAD_STATE,
+        connector_specific_config={},
+    )
+    db_session.add(connector)
+    db_session.flush()
+
+    credential = Credential(
+        source=TEST_SOURCE,
+        credential_json={},
+        admin_public=True,
+    )
+    db_session.add(credential)
+    db_session.flush()
+    db_session.expire(credential)
+
+    cc_pair = ConnectorCredentialPair(
+        connector_id=connector.id,
+        credential_id=credential.id,
+        name=f"Test {TEST_SOURCE.value} CC Pair",
+        status=ConnectorCredentialPairStatus.ACTIVE,
+        access_type=AccessType.PUBLIC,
+    )
+    db_session.add(cc_pair)
+    db_session.commit()
+    db_session.refresh(cc_pair)
+    return cc_pair
+
+
+def _cleanup_test_data(db_session: Session) -> None:
+    test_connector_ids_q = db_session.query(Connector.id).filter(
+        Connector.source == TEST_SOURCE,
+        Connector.name.like("Test %"),
+    )
+    db_session.query(HierarchyNodeByConnectorCredentialPair).filter(
+        HierarchyNodeByConnectorCredentialPair.connector_id.in_(test_connector_ids_q)
+    ).delete(synchronize_session="fetch")
+    db_session.query(DBHierarchyNode).filter(
+        DBHierarchyNode.source == TEST_SOURCE
+    ).delete()
+    db_session.flush()
+
+    credential_ids = [
+        row[0]
+        for row in db_session.query(ConnectorCredentialPair.credential_id)
+        .filter(ConnectorCredentialPair.connector_id.in_(test_connector_ids_q))
+        .all()
+    ]
+    db_session.query(ConnectorCredentialPair).filter(
+        ConnectorCredentialPair.connector_id.in_(test_connector_ids_q)
+    ).delete(synchronize_session="fetch")
+    db_session.query(Connector).filter(
+        Connector.source == TEST_SOURCE,
+        Connector.name.like("Test %"),
+    ).delete(synchronize_session="fetch")
+    if credential_ids:
+        db_session.query(Credential).filter(Credential.id.in_(credential_ids)).delete(
+            synchronize_session="fetch"
+        )
+    db_session.commit()
+
+
+def _folder_node(raw_node_id: str) -> PydanticHierarchyNode:
+    return PydanticHierarchyNode(
+        raw_node_id=raw_node_id,
+        raw_parent_id=None,
+        display_name=raw_node_id,
+        node_type=HierarchyNodeType.FOLDER,
+    )
+
+
+def _delete_cc_pair_and_cleanup(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> tuple[list[str], list[DBHierarchyNode]]:
+    """Same order as connector deletion: cc_pair CASCADE, then orphan cleanup."""
+    source = cc_pair.connector.source
+    delete_connector_credential_pair__no_commit(
+        db_session,
+        cc_pair.connector_id,
+        cc_pair.credential_id,
+    )
+    db_session.flush()
+    return cleanup_unowned_hierarchy_nodes(
+        db_session=db_session, source=source, commit=True
+    )
+
+
+def test_deleting_last_connector_of_source_removes_unowned_nodes(
+    db_session: Session,
+) -> None:
+    _cleanup_test_data(db_session)
+    source_node = ensure_source_node_exists(db_session, TEST_SOURCE, commit=True)
+    cc_pair = _create_cc_pair(db_session)
+
+    upserted = upsert_hierarchy_nodes_batch(
+        db_session=db_session,
+        nodes=[_folder_node(SHARED_NODE_ID), _folder_node(UNIQUE_NODE_ID)],
+        source=TEST_SOURCE,
+        commit=True,
+        is_connector_public=False,
+    )
+    upsert_hierarchy_node_cc_pair_entries(
+        db_session=db_session,
+        hierarchy_node_ids=[n.id for n in upserted],
+        connector_id=cc_pair.connector_id,
+        credential_id=cc_pair.credential_id,
+        commit=True,
+    )
+
+    deleted_raw_ids, _reparented = _delete_cc_pair_and_cleanup(db_session, cc_pair)
+
+    assert set(deleted_raw_ids) == {SHARED_NODE_ID, UNIQUE_NODE_ID}
+    remaining = get_all_hierarchy_nodes_for_source(db_session, TEST_SOURCE)
+    assert {n.id for n in remaining} == {source_node.id}
+    assert get_hierarchy_node_by_raw_id(db_session, SHARED_NODE_ID, TEST_SOURCE) is None
+    assert get_hierarchy_node_by_raw_id(db_session, UNIQUE_NODE_ID, TEST_SOURCE) is None
+
+    _cleanup_test_data(db_session)
+
+
+def test_deleting_connector_keeps_nodes_still_owned_by_another(
+    db_session: Session,
+) -> None:
+    _cleanup_test_data(db_session)
+    ensure_source_node_exists(db_session, TEST_SOURCE, commit=True)
+    cc_pair_1 = _create_cc_pair(db_session)
+    cc_pair_2 = _create_cc_pair(db_session)
+
+    upserted = upsert_hierarchy_nodes_batch(
+        db_session=db_session,
+        nodes=[_folder_node(SHARED_NODE_ID), _folder_node(UNIQUE_NODE_ID)],
+        source=TEST_SOURCE,
+        commit=True,
+        is_connector_public=False,
+    )
+    by_raw_id = {n.raw_node_id: n.id for n in upserted}
+    upsert_hierarchy_node_cc_pair_entries(
+        db_session=db_session,
+        hierarchy_node_ids=list(by_raw_id.values()),
+        connector_id=cc_pair_1.connector_id,
+        credential_id=cc_pair_1.credential_id,
+        commit=True,
+    )
+    upsert_hierarchy_node_cc_pair_entries(
+        db_session=db_session,
+        hierarchy_node_ids=[by_raw_id[SHARED_NODE_ID]],
+        connector_id=cc_pair_2.connector_id,
+        credential_id=cc_pair_2.credential_id,
+        commit=True,
+    )
+
+    deleted_raw_ids, _reparented = _delete_cc_pair_and_cleanup(db_session, cc_pair_1)
+
+    assert deleted_raw_ids == [UNIQUE_NODE_ID]
+    assert get_hierarchy_node_by_raw_id(db_session, UNIQUE_NODE_ID, TEST_SOURCE) is None
+    assert (
+        get_hierarchy_node_by_raw_id(db_session, SHARED_NODE_ID, TEST_SOURCE)
+        is not None
+    )
+
+    _cleanup_test_data(db_session)

--- a/backend/tests/external_dependency_unit/celery/test_connector_deletion_hierarchy_nodes.py
+++ b/backend/tests/external_dependency_unit/celery/test_connector_deletion_hierarchy_nodes.py
@@ -1,5 +1,6 @@
 """Connector deletion drops cc_pair join rows, then cleanup_unowned_hierarchy_nodes
-deletes nodes no remaining connector owns. SOURCE roots stay; shared nodes stay."""
+deletes nodes no remaining connector owns. SOURCE roots stay; shared nodes stay.
+Node persist and ownership links commit together so cleanup cannot delete a live node."""
 
 from uuid import uuid4
 
@@ -17,6 +18,7 @@ from onyx.db.hierarchy import (
     ensure_source_node_exists,
     get_all_hierarchy_nodes_for_source,
     get_hierarchy_node_by_raw_id,
+    persist_hierarchy_nodes_for_cc_pair,
     upsert_hierarchy_node_cc_pair_entries,
     upsert_hierarchy_nodes_batch,
 )
@@ -191,6 +193,36 @@ def test_deleting_connector_keeps_nodes_still_owned_by_another(
 
     assert deleted_raw_ids == [UNIQUE_NODE_ID]
     assert get_hierarchy_node_by_raw_id(db_session, UNIQUE_NODE_ID, TEST_SOURCE) is None
+    assert (
+        get_hierarchy_node_by_raw_id(db_session, SHARED_NODE_ID, TEST_SOURCE)
+        is not None
+    )
+
+    _cleanup_test_data(db_session)
+
+
+def test_persisted_nodes_survive_source_wide_orphan_cleanup(
+    db_session: Session,
+) -> None:
+    """Ownership links commit with the node, so orphan cleanup must keep it."""
+    _cleanup_test_data(db_session)
+    ensure_source_node_exists(db_session, TEST_SOURCE, commit=True)
+    cc_pair = _create_cc_pair(db_session)
+
+    persist_hierarchy_nodes_for_cc_pair(
+        db_session=db_session,
+        nodes=[_folder_node(SHARED_NODE_ID)],
+        source=TEST_SOURCE,
+        connector_id=cc_pair.connector_id,
+        credential_id=cc_pair.credential_id,
+        is_connector_public=False,
+        commit=True,
+    )
+
+    deleted_raw_ids, _reparented = cleanup_unowned_hierarchy_nodes(
+        db_session, TEST_SOURCE, commit=True
+    )
+    assert SHARED_NODE_ID not in deleted_raw_ids
     assert (
         get_hierarchy_node_by_raw_id(db_session, SHARED_NODE_ID, TEST_SOURCE)
         is not None


### PR DESCRIPTION
## Description

When a connector is deleted, hierarchy nodes that no remaining connector still owns are now deleted. Previously those nodes were only cleaned up if another connector of the same source later pruned.

SOURCE roots are kept. Nodes still referenced by another connector of the same source are kept. Redis ancestor-cache entries for deleted/reparented nodes are updated after the Postgres commit.

## How Has This Been Tested?

External dependency unit tests for:
- last connector of a source: unowned nodes are deleted, SOURCE root remains
- shared node still owned by another connector: unique nodes are deleted, shared nodes remain

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deletes hierarchy nodes no connector still owns when a connector is removed, and invalidates the source’s hierarchy cache. Previously these nodes lingered until a later prune; now deletion prunes immediately while keeping SOURCE roots and nodes shared by another connector of the same source.

- Connector deletion flushes, runs cleanup of unowned nodes, commits, then invalidates the Redis hierarchy cache for the source with retry; failures are logged and do not block deletion.
- New helper consolidations: cleanup_unowned_hierarchy_nodes (delete unowned nodes, reparent orphans to SOURCE root, return deleted/reparented) and persist_hierarchy_nodes_for_cc_pair (atomically upsert nodes and cc_pair links to avoid cleanup races). Call sites in hierarchy fetching, pruning, docfetching, and targeted reindex now use these.
- Behavior guarantees: only nodes without any cc_pair links are removed; SOURCE roots are preserved; children of deleted nodes are reparented to the SOURCE root.
- Tests cover deleting the last connector of a source, preserving nodes shared with another connector, and ensuring atomic persist survives orphan cleanup.

<sup>Written for commit 7fd265efb362d95f4e996d864629a492e6f80ff7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

