### PR TITLE
refactor(ods): use fastwalk for recursive directory walks

### DIFF
--- a/tools/ods/cmd/install_skill.go
+++ b/tools/ods/cmd/install_skill.go
@@ -2,11 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/charlievieth/fastwalk"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 	"github.com/spf13/cobra"
 )
@@ -192,7 +194,9 @@ func installManualSkills(cmd *cobra.Command, source string, copyMode bool) error
 }
 
 func copySkill(srcDir, dstDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d os.DirEntry, err error) error {
+	// fastwalk visits a directory before its children, so each destination
+	// directory exists by the time its entries are copied.
+	return fastwalk.Walk(nil, srcDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/tools/ods/cmd/trace.go
+++ b/tools/ods/cmd/trace.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,7 +13,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
+	"github.com/charlievieth/fastwalk"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -277,15 +280,21 @@ func downloadTraceArtifacts(runID string, project string) (string, error) {
 // findTraces recursively finds all trace.zip files under a directory.
 func findTraces(root string) ([]string, error) {
 	var traces []string
-	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	// fastwalk runs the callback on several goroutines, so guard the slice.
+	var mu sync.Mutex
+	err := fastwalk.Walk(nil, root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() && info.Name() == "trace.zip" {
+		if !d.IsDir() && d.Name() == "trace.zip" {
+			mu.Lock()
 			traces = append(traces, path)
+			mu.Unlock()
 		}
 		return nil
 	})
+	// Walk order is non-deterministic, so sort for a stable trace list.
+	sort.Strings(traces)
 	return traces, err
 }
 
@@ -293,11 +302,13 @@ func findTraces(root string) ([]string, error) {
 // Expects: destDir/{artifact-dir}/{test-dir}/trace.zip
 func findTraceInfos(destDir, runID string) ([]traceInfo, error) {
 	var traces []traceInfo
-	err := filepath.Walk(destDir, func(path string, info os.FileInfo, err error) error {
+	// fastwalk runs the callback on several goroutines, so guard the slice.
+	var mu sync.Mutex
+	err := fastwalk.Walk(nil, destDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() || info.Name() != "trace.zip" {
+		if d.IsDir() || d.Name() != "trace.zip" {
 			return nil
 		}
 
@@ -311,11 +322,13 @@ func findTraceInfos(destDir, runID string) ([]traceInfo, error) {
 			testDir = parts[1]
 		}
 
+		mu.Lock()
 		traces = append(traces, traceInfo{
 			Path:    path,
 			Project: extractProject(artifactDir, runID),
 			TestDir: testDir,
 		})
+		mu.Unlock()
 		return nil
 	})
 
@@ -324,7 +337,10 @@ func findTraceInfos(destDir, runID string) ([]traceInfo, error) {
 		if pi != pj {
 			return pi < pj
 		}
-		return traces[i].TestDir < traces[j].TestDir
+		if traces[i].TestDir != traces[j].TestDir {
+			return traces[i].TestDir < traces[j].TestDir
+		}
+		return traces[i].Path < traces[j].Path
 	})
 
 	return traces, err

--- a/tools/ods/cmd/web.go
+++ b/tools/ods/cmd/web.go
@@ -12,8 +12,10 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/charlievieth/fastwalk"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -239,7 +241,9 @@ func libNeedsBuild(pkgDir string) (bool, string) {
 // directories named in excludeDirs and hidden entries.
 func newestMtime(root string, excludeDirs map[string]bool) (time.Time, error) {
 	var newest time.Time
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+	// fastwalk runs the callback on several goroutines, so guard the running max.
+	var mu sync.Mutex
+	err := fastwalk.Walk(nil, root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -254,9 +258,11 @@ func newestMtime(root string, excludeDirs map[string]bool) (time.Time, error) {
 		if err != nil {
 			return err
 		}
+		mu.Lock()
 		if info.ModTime().After(newest) {
 			newest = info.ModTime()
 		}
+		mu.Unlock()
 		return nil
 	})
 	return newest, err

--- a/tools/ods/go.mod
+++ b/tools/ods/go.mod
@@ -3,6 +3,7 @@ module github.com/onyx-dot-app/onyx/tools/ods
 go 1.26.4
 
 require (
+	github.com/charlievieth/fastwalk v1.0.14
 	github.com/gdamore/tcell/v2 v2.13.8
 	github.com/google/osv-scalibr v0.4.6-0.20260612031204-164402d9140e
 	github.com/google/osv-scanner/v2 v2.4.0

--- a/tools/ods/go.sum
+++ b/tools/ods/go.sum
@@ -63,6 +63,8 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/charlievieth/fastwalk v1.0.14 h1:3Eh5uaFGwHZd8EGwTjJnSpBkfwfsak9h6ICgnWlhAyg=
+github.com/charlievieth/fastwalk v1.0.14/go.mod h1:diVcUreiU1aQ4/Wu3NbxxH4/KYdKpLDojrQ1Bb2KgNY=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=

--- a/tools/ods/internal/audit/actions.go
+++ b/tools/ods/internal/audit/actions.go
@@ -31,8 +31,10 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/charlievieth/fastwalk"
 	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
 	"github.com/google/osv-scalibr/extractor/filesystem"
 	"github.com/google/osv-scalibr/extractor/filesystem/misc/githubactions"
@@ -197,7 +199,9 @@ func extractCompositeActions(ext filesystem.Extractor, root string) ([]actionRef
 	}
 
 	var refs []actionRef
-	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+	// fastwalk runs the callback on several goroutines, so guard the slice.
+	var mu sync.Mutex
+	err := fastwalk.Walk(nil, dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -234,12 +238,22 @@ func extractCompositeActions(ext filesystem.Extractor, root string) ([]actionRef
 			log.Warnf("Skipping composite action %s: %v", manifest, err)
 			return nil
 		}
+		mu.Lock()
 		refs = append(refs, rs...)
+		mu.Unlock()
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
+	// Walk order is non-deterministic; sort so dedupeRefs always keeps the same
+	// manifest for an action used by more than one composite.
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].Manifest != refs[j].Manifest {
+			return refs[i].Manifest < refs[j].Manifest
+		}
+		return refs[i].Name+"@"+refs[i].Ref < refs[j].Name+"@"+refs[j].Ref
+	})
 	return refs, nil
 }
 

--- a/tools/ods/internal/lazyimports/lazyimports.go
+++ b/tools/ods/internal/lazyimports/lazyimports.go
@@ -2,12 +2,15 @@ package lazyimports
 
 import (
 	"bufio"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 
+	"github.com/charlievieth/fastwalk"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
@@ -225,12 +228,23 @@ func collectPythonFiles(startPoints []string, backendDir string) ([]string, erro
 		}
 
 		if info.IsDir() {
-			err := filepath.Walk(absPath, func(path string, info os.FileInfo, err error) error {
+			// fastwalk runs the callback on several goroutines, so guard the slice.
+			var mu sync.Mutex
+			err := fastwalk.Walk(nil, absPath, func(path string, d fs.DirEntry, err error) error {
 				if err != nil {
 					return nil // Skip files with errors
 				}
-				if !info.IsDir() && isValidPythonFile(path) {
+				if d.IsDir() {
+					// isValidPythonFile rejects these anyway; pruning avoids the descent.
+					if _, ignored := ignoreDirectories[d.Name()]; ignored || d.Name() == "tests" {
+						return filepath.SkipDir
+					}
+					return nil
+				}
+				if isValidPythonFile(path) {
+					mu.Lock()
 					collected = append(collected, path)
+					mu.Unlock()
 				}
 				return nil
 			})
@@ -244,6 +258,8 @@ func collectPythonFiles(startPoints []string, backendDir string) ([]string, erro
 		}
 	}
 
+	// Walk order is non-deterministic, so sort for stable violation output.
+	sort.Strings(collected)
 	return collected, nil
 }
 


### PR DESCRIPTION
## Summary

Prefer [`github.com/charlievieth/fastwalk`](https://github.com/charlievieth/fastwalk) over `filepath.Walk` / `filepath.WalkDir` everywhere the walk is recursive and targets a real filesystem. fastwalk reads directories in parallel, so it is much faster on large trees like `backend/`.

Sites converted (all in `tools/ods`):

| File | Function |
| --- | --- |
| `internal/lazyimports/lazyimports.go` | `collectPythonFiles` |
| `internal/audit/actions.go` | `extractCompositeActions` |
| `cmd/install_skill.go` | `copySkill` |
| `cmd/web.go` | `newestMtime` |
| `cmd/trace.go` | `findTraces`, `findTraceInfos` |

The one remaining `fs.WalkDir` (`cli/internal/deploy/deployfiles/sync_test.go`) walks an embedded FS, which fastwalk cannot read. The other `os.ReadDir` calls list a single directory, so fastwalk does not apply.

## Notes

- fastwalk runs the callback on several goroutines. Each site now guards its shared accumulator with a mutex.
- Walk order is no longer deterministic. The sites whose order reaches the user (lazy-import violations, trace lists, composite action manifests) sort their results.
- `collectPythonFiles` now prunes ignored directories (`.venv`, `__pycache__`, `tests`, ...) with `SkipDir` instead of descending into them and rejecting each file. Same result, less work.
- `copySkill` stays correct because fastwalk visits a directory before its children, so each destination directory exists before its entries are copied.

## Test plan

- `go build ./... && go vet ./...` pass.
- `go test -race ./internal/lazyimports/ ./internal/audit/` pass.
- `go test ./...` — the failures in `internal/git` and `cmd` are pre-existing in this sandbox (git commit signing has no SSH key); they fail identically on a clean tree.
- `pre-commit run --files ...` passes, including `golangci-lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches recursive real-filesystem walks in `tools/ods` from `filepath.Walk`/`filepath.WalkDir` to `github.com/charlievieth/fastwalk` for faster scans on large trees. Old behavior was serial and ordered; new behavior runs in parallel with non-deterministic order, so user-facing results are now explicitly sorted.

- Converts recursive walks in `internal/lazyimports`, `internal/audit`, and `cmd` (`install_skill`, `trace`, `web`); keeps the embedded-FS `fs.WalkDir` unchanged.
- Adds dependency `github.com/charlievieth/fastwalk` to `go.mod`.
- Protects shared accumulators with `sync.Mutex`; `copySkill` remains correct because fastwalk pre-visits directories before children.
- Sorts outputs for determinism where users see order (lazy-import violations, trace lists, composite action manifests); adds path tie-breakers as needed.
- Prunes ignored Python directories with `filepath.SkipDir` (e.g., `.venv`, `__pycache__`, `tests`) to avoid unnecessary descent.

<sup>Written for commit 03d57b280884042a59889b5625bdffb4f9ddf0dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

