### PR TITLE
feat(llm): enforce per-model reasoning caps, defaults, and temperature defaults

### DIFF
--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from sqlalchemy import delete, or_, select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session, load_only, selectinload
@@ -330,6 +332,7 @@ def upsert_llm_provider(
                 max_input_tokens=model_config.max_input_tokens,
                 display_name=model_config.display_name,
                 custom_display_name=model_config.custom_display_name,
+                model_settings=model_config.provided_model_settings(),
             )
         else:
             insert_new_model_configuration__no_commit(
@@ -341,6 +344,7 @@ def upsert_llm_provider(
                 max_input_tokens=model_config.max_input_tokens,
                 display_name=model_config.display_name,
                 custom_display_name=model_config.custom_display_name,
+                model_settings=model_config.provided_model_settings(),
             )
 
     # Make sure the relationship table stays up to date
@@ -1164,6 +1168,7 @@ def insert_new_model_configuration__no_commit(
     max_input_tokens: int | None,
     display_name: str | None,
     custom_display_name: str | None = None,
+    model_settings: dict[str, Any] | None = None,
 ) -> int | None:
     result = db_session.execute(
         insert(ModelConfiguration)
@@ -1175,6 +1180,7 @@ def insert_new_model_configuration__no_commit(
             display_name=display_name,
             custom_display_name=custom_display_name,
             supports_image_input=LLMModelFlowType.VISION in supported_flows,
+            **(model_settings or {}),
         )
         .on_conflict_do_nothing()
         .returning(ModelConfiguration.id)
@@ -1203,6 +1209,7 @@ def update_model_configuration__no_commit(
     max_input_tokens: int | None,
     display_name: str | None,
     custom_display_name: str | None = None,
+    model_settings: dict[str, Any] | None = None,
 ) -> None:
     result = db_session.execute(
         update(ModelConfiguration)
@@ -1212,6 +1219,7 @@ def update_model_configuration__no_commit(
             display_name=display_name,
             custom_display_name=custom_display_name,
             supports_image_input=LLMModelFlowType.VISION in supported_flows,
+            **(model_settings or {}),
         )
         .where(ModelConfiguration.id == model_configuration_id)
         .returning(ModelConfiguration)

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from sqlalchemy import delete, or_, select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session, load_only, selectinload
@@ -24,6 +22,7 @@ from onyx.db.models import LLMProvider as LLMProviderModel
 from onyx.db.models import Tool as ToolModel
 from onyx.db.persona import get_raw_personas_for_user
 from onyx.db.user_group import assert_not_shared_with_default_group
+from onyx.llm.models import ReasoningEffort
 from onyx.llm.utils import model_supports_image_input
 from onyx.llm.well_known_providers.auto_update_models import LLMRecommendations
 from onyx.server.manage.embedding.models import (
@@ -325,16 +324,24 @@ def upsert_llm_provider(
 
         existing = existing_by_name.get(model_config.name)
         if existing:
-            # Validate what the row ends up with, not just what was sent.
-            model_settings = model_config.provided_model_settings()
-            ensure_default_within_max(
-                model_settings.get(
-                    "reasoning_effort_default", existing.reasoning_effort_default
-                ),
-                model_settings.get(
-                    "reasoning_effort_max", existing.reasoning_effort_max
-                ),
+            # An omitted field keeps the stored value. Validate the merged
+            # policy, not just what was sent.
+            merged_reasoning_max = (
+                model_config.reasoning_effort_max
+                if model_config.reasoning_effort_max_provided
+                else existing.reasoning_effort_max
             )
+            merged_reasoning_default = (
+                model_config.reasoning_effort_default
+                if model_config.reasoning_effort_default_provided
+                else existing.reasoning_effort_default
+            )
+            merged_temperature = (
+                model_config.temperature_default
+                if model_config.temperature_default_provided
+                else existing.temperature_default
+            )
+            ensure_default_within_max(merged_reasoning_default, merged_reasoning_max)
             update_model_configuration__no_commit(
                 db_session=db_session,
                 model_configuration_id=existing.id,
@@ -343,7 +350,9 @@ def upsert_llm_provider(
                 max_input_tokens=model_config.max_input_tokens,
                 display_name=model_config.display_name,
                 custom_display_name=model_config.custom_display_name,
-                model_settings=model_settings,
+                reasoning_effort_max=merged_reasoning_max,
+                reasoning_effort_default=merged_reasoning_default,
+                temperature_default=merged_temperature,
             )
         else:
             insert_new_model_configuration__no_commit(
@@ -355,7 +364,9 @@ def upsert_llm_provider(
                 max_input_tokens=model_config.max_input_tokens,
                 display_name=model_config.display_name,
                 custom_display_name=model_config.custom_display_name,
-                model_settings=model_config.provided_model_settings(),
+                reasoning_effort_max=model_config.reasoning_effort_max,
+                reasoning_effort_default=model_config.reasoning_effort_default,
+                temperature_default=model_config.temperature_default,
             )
 
     # Make sure the relationship table stays up to date
@@ -1179,7 +1190,9 @@ def insert_new_model_configuration__no_commit(
     max_input_tokens: int | None,
     display_name: str | None,
     custom_display_name: str | None = None,
-    model_settings: dict[str, Any] | None = None,
+    reasoning_effort_max: ReasoningEffort | None = None,
+    reasoning_effort_default: ReasoningEffort | None = None,
+    temperature_default: float | None = None,
 ) -> int | None:
     result = db_session.execute(
         insert(ModelConfiguration)
@@ -1191,7 +1204,9 @@ def insert_new_model_configuration__no_commit(
             display_name=display_name,
             custom_display_name=custom_display_name,
             supports_image_input=LLMModelFlowType.VISION in supported_flows,
-            **(model_settings or {}),
+            reasoning_effort_max=reasoning_effort_max,
+            reasoning_effort_default=reasoning_effort_default,
+            temperature_default=temperature_default,
         )
         .on_conflict_do_nothing()
         .returning(ModelConfiguration.id)
@@ -1220,7 +1235,9 @@ def update_model_configuration__no_commit(
     max_input_tokens: int | None,
     display_name: str | None,
     custom_display_name: str | None = None,
-    model_settings: dict[str, Any] | None = None,
+    reasoning_effort_max: ReasoningEffort | None = None,
+    reasoning_effort_default: ReasoningEffort | None = None,
+    temperature_default: float | None = None,
 ) -> None:
     result = db_session.execute(
         update(ModelConfiguration)
@@ -1230,7 +1247,9 @@ def update_model_configuration__no_commit(
             display_name=display_name,
             custom_display_name=custom_display_name,
             supports_image_input=LLMModelFlowType.VISION in supported_flows,
-            **(model_settings or {}),
+            reasoning_effort_max=reasoning_effort_max,
+            reasoning_effort_default=reasoning_effort_default,
+            temperature_default=temperature_default,
         )
         .where(ModelConfiguration.id == model_configuration_id)
         .returning(ModelConfiguration)

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -34,6 +34,7 @@ from onyx.server.manage.llm.models import (
     LLMProviderUpsertRequest,
     LLMProviderView,
     SyncModelEntry,
+    ensure_default_within_max,
 )
 from onyx.utils.logger import setup_logger
 from shared_configs.enums import EmbeddingProvider
@@ -324,6 +325,16 @@ def upsert_llm_provider(
 
         existing = existing_by_name.get(model_config.name)
         if existing:
+            # Validate what the row ends up with, not just what was sent.
+            model_settings = model_config.provided_model_settings()
+            ensure_default_within_max(
+                model_settings.get(
+                    "reasoning_effort_default", existing.reasoning_effort_default
+                ),
+                model_settings.get(
+                    "reasoning_effort_max", existing.reasoning_effort_max
+                ),
+            )
             update_model_configuration__no_commit(
                 db_session=db_session,
                 model_configuration_id=existing.id,
@@ -332,7 +343,7 @@ def upsert_llm_provider(
                 max_input_tokens=model_config.max_input_tokens,
                 display_name=model_config.display_name,
                 custom_display_name=model_config.custom_display_name,
-                model_settings=model_config.provided_model_settings(),
+                model_settings=model_settings,
             )
         else:
             insert_new_model_configuration__no_commit(

--- a/backend/onyx/llm/factory.py
+++ b/backend/onyx/llm/factory.py
@@ -21,6 +21,7 @@ from onyx.db.models import LLMProvider as LLMProviderModel
 from onyx.db.models import Persona, SearchSettings, User
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.interfaces import LLM, LlmRequestPolicy
+from onyx.llm.models import ReasoningEffort
 from onyx.llm.multi_llm import LitellmLLM
 from onyx.llm.override_models import LLMOverride
 from onyx.llm.utils import (
@@ -31,7 +32,7 @@ from onyx.llm.well_known_providers.constants import (
     PROVIDERS_WITH_SPECIAL_API_KEY_HANDLING,
 )
 from onyx.natural_language_processing.utils import get_tokenizer
-from onyx.server.manage.llm.models import LLMProviderView
+from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
 from onyx.utils.headers import build_llm_extra_headers
 from onyx.utils.logger import setup_logger
 
@@ -64,13 +65,13 @@ def _build_provider_extra_headers(
     return {}
 
 
-def _get_model_configured_max_input_tokens(
+def _get_model_configuration(
     llm_provider: LLMProviderView,
     model_name: str,
-) -> int | None:
+) -> ModelConfigurationView | None:
     for model_configuration in llm_provider.model_configurations:
         if model_configuration.name == model_name:
-            return model_configuration.max_input_tokens
+            return model_configuration
     return None
 
 
@@ -177,7 +178,7 @@ def get_llm_for_persona(
         and not persona.default_model_configuration_id
     ):
         return get_default_llm(
-            temperature=temperature_override or GEN_AI_TEMPERATURE,
+            temperature=temperature_override,
             additional_headers=additional_headers,
             policy_fn=policy_fn,
         )
@@ -192,11 +193,7 @@ def get_llm_for_persona(
         )
         if resolved is None:
             return get_default_llm(
-                temperature=(
-                    temperature_override
-                    if temperature_override is not None
-                    else GEN_AI_TEMPERATURE
-                ),
+                temperature=temperature_override,
                 additional_headers=additional_headers,
                 policy_fn=policy_fn,
             )
@@ -218,7 +215,7 @@ def get_llm_for_persona(
                 provider_model.name,
             )
             return get_default_llm(
-                temperature=temperature_override or GEN_AI_TEMPERATURE,
+                temperature=temperature_override,
                 additional_headers=additional_headers,
                 policy_fn=policy_fn,
             )
@@ -347,8 +344,11 @@ def llm_from_provider(
     additional_headers: dict[str, str] | None = None,
     policy_fn: Callable[[str], LlmRequestPolicy] | None = None,
 ) -> LLM:
-    configured_max_input_tokens = _get_model_configured_max_input_tokens(
+    model_configuration = _get_model_configuration(
         llm_provider=llm_provider, model_name=model_name
+    )
+    configured_max_input_tokens = (
+        model_configuration.max_input_tokens if model_configuration else None
     )
     model_kwargs = _build_model_kwargs(
         provider=llm_provider.provider,
@@ -361,6 +361,11 @@ def llm_from_provider(
             llm_provider=llm_provider, model_name=model_name
         )
     )
+    # An explicit temperature is a session override and wins. Otherwise fall
+    # back to the admin's per-model default, then to GEN_AI_TEMPERATURE in
+    # get_llm.
+    if temperature is None and model_configuration:
+        temperature = model_configuration.temperature_default
     # Resolved here, not at the call site: the caller hands policy as a
     # provider-keyed function because it cannot know which provider wins.
     policy = policy_fn(llm_provider.provider) if policy_fn else None
@@ -379,6 +384,14 @@ def llm_from_provider(
         model_kwargs=model_kwargs,
         policy_headers=policy.headers if policy else None,
         policy_model_kwargs=policy.model_kwargs if policy else None,
+        reasoning_effort_default=(
+            model_configuration.reasoning_effort_default
+            if model_configuration
+            else None
+        ),
+        reasoning_effort_max=(
+            model_configuration.reasoning_effort_max if model_configuration else None
+        ),
     )
 
 
@@ -447,6 +460,8 @@ def get_llm(
     model_kwargs: dict[str, Any] | None = None,
     policy_headers: dict[str, str] | None = None,
     policy_model_kwargs: dict[str, Any] | None = None,
+    reasoning_effort_default: ReasoningEffort | None = None,
+    reasoning_effort_max: ReasoningEffort | None = None,
 ) -> LLM:
     if temperature is None:
         temperature = GEN_AI_TEMPERATURE
@@ -482,6 +497,8 @@ def get_llm(
         extra_headers=extra_headers,
         model_kwargs=merged_model_kwargs,
         max_input_tokens=max_input_tokens,
+        reasoning_effort_default=reasoning_effort_default,
+        reasoning_effort_max=reasoning_effort_max,
     )
 
 

--- a/backend/onyx/llm/factory.py
+++ b/backend/onyx/llm/factory.py
@@ -361,9 +361,7 @@ def llm_from_provider(
             llm_provider=llm_provider, model_name=model_name
         )
     )
-    # An explicit temperature is a session override and wins. Otherwise fall
-    # back to the admin's per-model default, then to GEN_AI_TEMPERATURE in
-    # get_llm.
+    # Session override wins, else the model default, else GEN_AI_TEMPERATURE.
     if temperature is None and model_configuration:
         temperature = model_configuration.temperature_default
     # Resolved here, not at the call site: the caller hands policy as a

--- a/backend/onyx/llm/interfaces.py
+++ b/backend/onyx/llm/interfaces.py
@@ -40,6 +40,10 @@ class LLMConfig(BaseModel):
     deployment_name: str | None = None
     custom_config: dict[str, str] | None = None
     max_input_tokens: int
+    # Admin-configured per-model reasoning policy. Carried here so it applies to
+    # every invoke path, not just chat. See resolve_reasoning_effort.
+    reasoning_effort_default: ReasoningEffort | None = None
+    reasoning_effort_max: ReasoningEffort | None = None
     # This disables the "model_" protected namespace for pydantic
     model_config = {"protected_namespaces": ()}
 

--- a/backend/onyx/llm/interfaces.py
+++ b/backend/onyx/llm/interfaces.py
@@ -40,8 +40,7 @@ class LLMConfig(BaseModel):
     deployment_name: str | None = None
     custom_config: dict[str, str] | None = None
     max_input_tokens: int
-    # Admin-configured per-model reasoning policy. Carried here so it applies to
-    # every invoke path, not just chat. See resolve_reasoning_effort.
+    # Here rather than in the chat loop, so every invoke path gets it.
     reasoning_effort_default: ReasoningEffort | None = None
     reasoning_effort_max: ReasoningEffort | None = None
     # This disables the "model_" protected namespace for pydantic

--- a/backend/onyx/llm/models.py
+++ b/backend/onyx/llm/models.py
@@ -67,6 +67,52 @@ def parse_user_selectable_reasoning_effort(value: str) -> ReasoningEffort:
     return effort
 
 
+# Ascending order of how much thinking each level asks for. AUTO has no rank:
+# it names a deferred choice, not an amount, so callers resolve it first.
+_REASONING_EFFORT_RANK: dict[ReasoningEffort, int] = {
+    ReasoningEffort.OFF: 0,
+    ReasoningEffort.LOW: 1,
+    ReasoningEffort.MEDIUM: 2,
+    ReasoningEffort.HIGH: 3,
+    ReasoningEffort.XHIGH: 4,
+}
+
+
+def reasoning_effort_exceeds(effort: ReasoningEffort, cap: ReasoningEffort) -> bool:
+    """Whether `effort` asks for more thinking than `cap` allows."""
+    return _REASONING_EFFORT_RANK[effort] > _REASONING_EFFORT_RANK[cap]
+
+
+def resolve_reasoning_effort(
+    requested: ReasoningEffort,
+    default: ReasoningEffort | None,
+    maximum: ReasoningEffort | None,
+) -> ReasoningEffort:
+    """Settle a request against the admin's per-model default and cap.
+
+    Sources are tried in order and the first concrete one wins, so inserting
+    another tier later (a per-user default, say) is a one-line change. The cap
+    is applied last and unconditionally, which is what makes it a cap: no
+    client, stale UI, or direct API call can get past it.
+
+    AUTO must be concretized before clamping. It maps to medium downstream
+    (see OPENAI_REASONING_EFFORT), so an unresolved AUTO under a cap of LOW
+    would quietly ask for more than the cap allows.
+    """
+    for candidate in (requested, default):
+        if candidate is not None and candidate != ReasoningEffort.AUTO:
+            effort = candidate
+            break
+    else:
+        if maximum is None:
+            return ReasoningEffort.AUTO
+        effort = ReasoningEffort.MEDIUM
+
+    if maximum is not None and reasoning_effort_exceeds(effort, maximum):
+        return maximum
+    return effort
+
+
 # OpenAI reasoning effort mapping
 # Note: OpenAI API does not support "auto" - valid values are: none, minimal, low, medium, high, xhigh
 OPENAI_REASONING_EFFORT: dict[ReasoningEffort, str] = {

--- a/backend/onyx/llm/models.py
+++ b/backend/onyx/llm/models.py
@@ -67,8 +67,7 @@ def parse_user_selectable_reasoning_effort(value: str) -> ReasoningEffort:
     return effort
 
 
-# Ascending order of how much thinking each level asks for. AUTO has no rank:
-# it names a deferred choice, not an amount, so callers resolve it first.
+# AUTO has no rank: it defers a choice rather than naming an amount.
 _REASONING_EFFORT_RANK: dict[ReasoningEffort, int] = {
     ReasoningEffort.OFF: 0,
     ReasoningEffort.LOW: 1,
@@ -90,14 +89,11 @@ def resolve_reasoning_effort(
 ) -> ReasoningEffort:
     """Settle a request against the admin's per-model default and cap.
 
-    Sources are tried in order and the first concrete one wins, so inserting
-    another tier later (a per-user default, say) is a one-line change. The cap
-    is applied last and unconditionally, which is what makes it a cap: no
-    client, stale UI, or direct API call can get past it.
+    Ordered chain, first concrete source wins, so another tier (a per-user
+    default) is a one-line insert. The cap applies last and unconditionally.
 
-    AUTO must be concretized before clamping. It maps to medium downstream
-    (see OPENAI_REASONING_EFFORT), so an unresolved AUTO under a cap of LOW
-    would quietly ask for more than the cap allows.
+    AUTO is concretized before clamping because it maps to medium downstream,
+    which would quietly exceed a cap of LOW.
     """
     for candidate in (requested, default):
         if candidate is not None and candidate != ReasoningEffort.AUTO:

--- a/backend/onyx/llm/models.py
+++ b/backend/onyx/llm/models.py
@@ -95,10 +95,10 @@ def resolve_reasoning_effort(
     AUTO is concretized before clamping because it maps to medium downstream,
     which would quietly exceed a cap of LOW.
     """
-    for candidate in (requested, default):
-        if candidate is not None and candidate != ReasoningEffort.AUTO:
-            effort = candidate
-            break
+    if requested != ReasoningEffort.AUTO:
+        effort = requested
+    elif default is not None and default != ReasoningEffort.AUTO:
+        effort = default
     else:
         if maximum is None:
             return ReasoningEffort.AUTO

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -57,6 +57,7 @@ from onyx.llm.models import (
     OPENAI_REASONING_EFFORT,
     NamedToolChoice,
     ToolChoiceOptions,
+    resolve_reasoning_effort,
 )
 from onyx.llm.request_context import get_llm_mock_response
 from onyx.llm.utils import build_litellm_passthrough_kwargs
@@ -412,6 +413,8 @@ class LitellmLLM(LLM):
         extra_headers: dict[str, str] | None = None,
         extra_body: dict | None = LITELLM_EXTRA_BODY,
         model_kwargs: dict[str, Any] | None = None,
+        reasoning_effort_default: ReasoningEffort | None = None,
+        reasoning_effort_max: ReasoningEffort | None = None,
     ):
         # Timeout in seconds for each socket read operation (i.e., max time between
         # receiving data chunks/tokens). This is NOT a total request timeout - a
@@ -431,6 +434,8 @@ class LitellmLLM(LLM):
         self._custom_llm_provider = custom_llm_provider
         self._max_input_tokens = max_input_tokens
         self._custom_config = custom_config
+        self._reasoning_effort_default = reasoning_effort_default
+        self._reasoning_effort_max = reasoning_effort_max
 
         self._api_surface = resolve_api_surface(model_provider, custom_config)
 
@@ -704,6 +709,15 @@ class LitellmLLM(LLM):
 
         if stream and not is_vertex_model_rejecting_stream_options:
             optional_kwargs["stream_options"] = {"include_usage": True}
+
+        # Settle the caller's request against the admin's per-model policy
+        # before anything reads it, so every branch below and the tracing
+        # record all see the same effort the provider will.
+        reasoning_effort = resolve_reasoning_effort(
+            reasoning_effort,
+            self.config.reasoning_effort_default,
+            self.config.reasoning_effort_max,
+        )
 
         # Note, there is a reasoning_effort parameter in LiteLLM but it is completely jank and does not work for any
         # of the major providers. Not setting it sets it to OFF.
@@ -1030,6 +1044,8 @@ class LitellmLLM(LLM):
             deployment_name=self._deployment_name,
             custom_config=self._custom_config,
             max_input_tokens=self._max_input_tokens,
+            reasoning_effort_default=self._reasoning_effort_default,
+            reasoning_effort_max=self._reasoning_effort_max,
         )
 
     def _uses_isolated_client(self) -> bool:

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -710,9 +710,8 @@ class LitellmLLM(LLM):
         if stream and not is_vertex_model_rejecting_stream_options:
             optional_kwargs["stream_options"] = {"include_usage": True}
 
-        # Settle the caller's request against the admin's per-model policy
-        # before anything reads it, so every branch below and the tracing
-        # record all see the same effort the provider will.
+        # Settle before anything reads it, so every branch below and tracing
+        # see the same effort the provider will.
         reasoning_effort = resolve_reasoning_effort(
             reasoning_effort,
             self.config.reasoning_effort_default,

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -37,13 +37,30 @@ if TYPE_CHECKING:
 
 T = TypeVar("T", "LLMProviderDescriptor", "LLMProviderView", "VisionProviderResponse")
 
-# Admin-controlled per-model settings, as they are named on both the upsert
-# request and the model_configuration row.
+# Named identically on the upsert request and the model_configuration row.
 MODEL_SETTINGS_FIELDS = (
     "reasoning_effort_max",
     "reasoning_effort_default",
     "temperature_default",
 )
+
+
+def ensure_default_within_max(
+    default: ReasoningEffort | None, maximum: ReasoningEffort | None
+) -> None:
+    """Reject a policy whose default the cap would immediately override.
+
+    Pass the values that end up STORED, not just those a request carried.
+    """
+    if (
+        default is not None
+        and maximum is not None
+        and reasoning_effort_exceeds(default, maximum)
+    ):
+        raise OnyxError(
+            OnyxErrorCode.BAD_REQUEST,
+            "reasoning_effort_default cannot exceed reasoning_effort_max",
+        )
 
 
 class CustomProviderOption(BaseModel):
@@ -233,8 +250,7 @@ class ModelConfigurationUpsertRequest(BaseModel):
     @field_validator("reasoning_effort_max", "reasoning_effort_default", mode="before")
     @classmethod
     def _validate_reasoning_effort(cls, value: Any) -> Any:
-        # AUTO has no rank and would break the clamp, and an unset column
-        # already means AUTO. Enums are checked too, not just strings.
+        # AUTO has no rank and an unset column already means it. Enums too.
         if value is None:
             return value
         try:
@@ -256,26 +272,14 @@ class ModelConfigurationUpsertRequest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_default_within_max(self) -> "ModelConfigurationUpsertRequest":
-        if (
-            self.reasoning_effort_default is not None
-            and self.reasoning_effort_max is not None
-            and reasoning_effort_exceeds(
-                self.reasoning_effort_default, self.reasoning_effort_max
-            )
-        ):
-            raise OnyxError(
-                OnyxErrorCode.BAD_REQUEST,
-                "reasoning_effort_default cannot exceed reasoning_effort_max",
-            )
+        ensure_default_within_max(
+            self.reasoning_effort_default, self.reasoning_effort_max
+        )
         return self
 
     def provided_model_settings(self) -> dict[str, Any]:
-        """The admin settings this request actually carried.
-
-        An omitted field must leave the stored value alone, so absent is kept
-        distinct from an explicit null. Without this, any client that predates
-        these fields would clear an admin's cap on its next provider save.
-        """
+        """The settings this request carried. Absent stays distinct from an
+        explicit null, so an older client cannot clear an admin's cap."""
         return {
             field: getattr(self, field)
             for field in MODEL_SETTINGS_FIELDS
@@ -318,9 +322,8 @@ class ModelConfigurationView(BaseModel):
     # supports_reasoning: an empty list on a reasoning model means the model
     # takes no effort parameter. The model picker offers exactly these.
     supported_reasoning_efforts: list[ReasoningEffort] = Field(default_factory=list)
-    # Admin policy for this model. Null means unset, so nothing is imposed.
-    # supported_reasoning_efforts answers what the model can do, these answer
-    # what an admin permits of it.
+    # supported_reasoning_efforts is what the model can do, these are what the
+    # admin permits of it. Null means unset.
     reasoning_effort_max: ReasoningEffort | None = None
     reasoning_effort_default: ReasoningEffort | None = None
     temperature_default: float | None = None

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from onyx.db.enums import LLMModelFlowType
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.llm.api_surfaces import resolve_api_surface
 from onyx.llm.constants import DYNAMIC_LLM_PROVIDERS
 from onyx.llm.model_capabilities import (
@@ -18,7 +20,11 @@ from onyx.llm.model_capabilities import (
 from onyx.llm.model_capabilities import (
     model_identity_names as resolve_model_identity_names,
 )
-from onyx.llm.models import ReasoningEffort
+from onyx.llm.models import (
+    ReasoningEffort,
+    parse_user_selectable_reasoning_effort,
+    reasoning_effort_exceeds,
+)
 from onyx.server.manage.llm.utils import (
     extract_vendor_from_model_name,
     filter_model_configurations,
@@ -30,6 +36,14 @@ if TYPE_CHECKING:
     from onyx.db.models import ModelConfiguration as ModelConfigurationModel
 
 T = TypeVar("T", "LLMProviderDescriptor", "LLMProviderView", "VisionProviderResponse")
+
+# Admin-controlled per-model settings, as they are named on both the upsert
+# request and the model_configuration row.
+MODEL_SETTINGS_FIELDS = (
+    "reasoning_effort_max",
+    "reasoning_effort_default",
+    "temperature_default",
+)
 
 
 class CustomProviderOption(BaseModel):
@@ -212,6 +226,61 @@ class ModelConfigurationUpsertRequest(BaseModel):
     supports_reasoning: bool | None = None
     display_name: str | None = None  # For dynamic providers, from source API
     custom_display_name: str | None = None  # Admin-specified override
+    reasoning_effort_max: ReasoningEffort | None = None
+    reasoning_effort_default: ReasoningEffort | None = None
+    temperature_default: float | None = None
+
+    @field_validator("reasoning_effort_max", "reasoning_effort_default", mode="before")
+    @classmethod
+    def _validate_reasoning_effort(cls, value: Any) -> Any:
+        # AUTO has no rank and would break the clamp, and an unset column
+        # already means AUTO. Enums are checked too, not just strings.
+        if value is None:
+            return value
+        try:
+            return parse_user_selectable_reasoning_effort(
+                value.value if isinstance(value, ReasoningEffort) else value
+            )
+        except ValueError as e:
+            raise OnyxError(OnyxErrorCode.BAD_REQUEST, str(e))
+
+    @field_validator("temperature_default")
+    @classmethod
+    def _validate_temperature(cls, value: float | None) -> float | None:
+        if value is not None and not 0 <= value <= 2:
+            raise OnyxError(
+                OnyxErrorCode.BAD_REQUEST,
+                f"temperature_default must be between 0 and 2, got {value}",
+            )
+        return value
+
+    @model_validator(mode="after")
+    def _validate_default_within_max(self) -> "ModelConfigurationUpsertRequest":
+        if (
+            self.reasoning_effort_default is not None
+            and self.reasoning_effort_max is not None
+            and reasoning_effort_exceeds(
+                self.reasoning_effort_default, self.reasoning_effort_max
+            )
+        ):
+            raise OnyxError(
+                OnyxErrorCode.BAD_REQUEST,
+                "reasoning_effort_default cannot exceed reasoning_effort_max",
+            )
+        return self
+
+    def provided_model_settings(self) -> dict[str, Any]:
+        """The admin settings this request actually carried.
+
+        An omitted field must leave the stored value alone, so absent is kept
+        distinct from an explicit null. Without this, any client that predates
+        these fields would clear an admin's cap on its next provider save.
+        """
+        return {
+            field: getattr(self, field)
+            for field in MODEL_SETTINGS_FIELDS
+            if field in self.model_fields_set
+        }
 
     @classmethod
     def from_model(
@@ -228,6 +297,9 @@ class ModelConfigurationUpsertRequest(BaseModel):
             ),
             display_name=model_configuration_model.display_name,
             custom_display_name=model_configuration_model.custom_display_name,
+            reasoning_effort_max=model_configuration_model.reasoning_effort_max,
+            reasoning_effort_default=model_configuration_model.reasoning_effort_default,
+            temperature_default=model_configuration_model.temperature_default,
         )
 
 
@@ -246,6 +318,12 @@ class ModelConfigurationView(BaseModel):
     # supports_reasoning: an empty list on a reasoning model means the model
     # takes no effort parameter. The model picker offers exactly these.
     supported_reasoning_efforts: list[ReasoningEffort] = Field(default_factory=list)
+    # Admin policy for this model. Null means unset, so nothing is imposed.
+    # supported_reasoning_efforts answers what the model can do, these answer
+    # what an admin permits of it.
+    reasoning_effort_max: ReasoningEffort | None = None
+    reasoning_effort_default: ReasoningEffort | None = None
+    temperature_default: float | None = None
     # True when this is the provider's recommended default model.
     is_recommended_default: bool = False
     display_name: str | None = None
@@ -323,6 +401,9 @@ class ModelConfigurationView(BaseModel):
                     )
                 ),
                 supported_reasoning_efforts=reasoning_efforts,
+                reasoning_effort_max=model_configuration_model.reasoning_effort_max,
+                reasoning_effort_default=model_configuration_model.reasoning_effort_default,
+                temperature_default=model_configuration_model.temperature_default,
                 display_name=model_configuration_model.display_name,
                 custom_display_name=model_configuration_model.custom_display_name,
                 provider_display_name=None,  # Not needed for dynamic providers
@@ -384,6 +465,9 @@ class ModelConfigurationView(BaseModel):
                 )
             ),
             supported_reasoning_efforts=reasoning_efforts,
+            reasoning_effort_max=model_configuration_model.reasoning_effort_max,
+            reasoning_effort_default=model_configuration_model.reasoning_effort_default,
+            temperature_default=model_configuration_model.temperature_default,
             # Populate display fields from parsed model name
             display_name=display_name,
             custom_display_name=model_configuration_model.custom_display_name,

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -37,13 +37,6 @@ if TYPE_CHECKING:
 
 T = TypeVar("T", "LLMProviderDescriptor", "LLMProviderView", "VisionProviderResponse")
 
-# Named identically on the upsert request and the model_configuration row.
-MODEL_SETTINGS_FIELDS = (
-    "reasoning_effort_max",
-    "reasoning_effort_default",
-    "temperature_default",
-)
-
 
 def ensure_default_within_max(
     default: ReasoningEffort | None, maximum: ReasoningEffort | None
@@ -277,14 +270,19 @@ class ModelConfigurationUpsertRequest(BaseModel):
         )
         return self
 
-    def provided_model_settings(self) -> dict[str, Any]:
-        """The settings this request carried. Absent stays distinct from an
-        explicit null, so an older client cannot clear an admin's cap."""
-        return {
-            field: getattr(self, field)
-            for field in MODEL_SETTINGS_FIELDS
-            if field in self.model_fields_set
-        }
+    # Provided distinguishes an omitted field from an explicit null, so an
+    # older client that omits the settings cannot clear an admin's cap.
+    @property
+    def reasoning_effort_max_provided(self) -> bool:
+        return "reasoning_effort_max" in self.model_fields_set
+
+    @property
+    def reasoning_effort_default_provided(self) -> bool:
+        return "reasoning_effort_default" in self.model_fields_set
+
+    @property
+    def temperature_default_provided(self) -> bool:
+        return "temperature_default" in self.model_fields_set
 
     @classmethod
     def from_model(

--- a/backend/tests/unit/onyx/llm/test_model_settings_resolution.py
+++ b/backend/tests/unit/onyx/llm/test_model_settings_resolution.py
@@ -1,0 +1,245 @@
+"""Guards the admin per-model reasoning cap, defaults, and temperature default."""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from onyx.error_handling.exceptions import OnyxError
+from onyx.llm.models import ReasoningEffort, UserMessage, resolve_reasoning_effort
+from onyx.llm.multi_llm import LitellmLLM
+from onyx.server.manage.llm.models import ModelConfigurationUpsertRequest
+
+_SENTINEL = object()
+
+
+def _make_llm(
+    reasoning_effort_default: ReasoningEffort | None = None,
+    reasoning_effort_max: ReasoningEffort | None = None,
+    temperature: float | None = None,
+    model_name: str = "gpt-5.1",
+    model_provider: str = "openai",
+) -> LitellmLLM:
+    return LitellmLLM(
+        api_key="test-key",
+        model_provider=model_provider,
+        model_name=model_name,
+        max_input_tokens=100000,
+        temperature=temperature,
+        reasoning_effort_default=reasoning_effort_default,
+        reasoning_effort_max=reasoning_effort_max,
+    )
+
+
+def _sent_kwargs(llm: LitellmLLM, effort: ReasoningEffort) -> dict[str, Any]:
+    """Run one completion and return the kwargs that reached the provider."""
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return _SENTINEL
+
+    with patch("onyx.llm.litellm_singleton.litellm.completion", side_effect=completion):
+        llm._completion(
+            prompt=[UserMessage(content="hello")],
+            tools=None,
+            tool_choice=None,
+            stream=False,
+            parallel_tool_calls=False,
+            reasoning_effort=effort,
+        )
+    assert len(calls) == 1
+    return calls[0]
+
+
+def _effort_sent(kwargs: dict[str, Any]) -> str:
+    """The effort an OpenAI-style request actually asked for."""
+    return kwargs["reasoning"]["effort"]
+
+
+class TestResolveReasoningEffort:
+    """The resolution itself, independent of any provider wire format."""
+
+    @pytest.mark.parametrize(
+        "requested,default,maximum,expected",
+        [
+            # Nothing configured: the request passes through untouched.
+            (ReasoningEffort.AUTO, None, None, ReasoningEffort.AUTO),
+            (ReasoningEffort.HIGH, None, None, ReasoningEffort.HIGH),
+            # An admin default only fills in for an unpinned request.
+            (ReasoningEffort.AUTO, ReasoningEffort.HIGH, None, ReasoningEffort.HIGH),
+            (ReasoningEffort.LOW, ReasoningEffort.HIGH, None, ReasoningEffort.LOW),
+            # The cap wins over a session override, which is the whole point.
+            (ReasoningEffort.XHIGH, None, ReasoningEffort.LOW, ReasoningEffort.LOW),
+            (
+                ReasoningEffort.HIGH,
+                None,
+                ReasoningEffort.MEDIUM,
+                ReasoningEffort.MEDIUM,
+            ),
+            # ...and over the admin's own default, if they disagree.
+            (
+                ReasoningEffort.AUTO,
+                ReasoningEffort.XHIGH,
+                ReasoningEffort.MEDIUM,
+                ReasoningEffort.MEDIUM,
+            ),
+            # Under the cap, nothing is touched.
+            (ReasoningEffort.LOW, None, ReasoningEffort.HIGH, ReasoningEffort.LOW),
+            # OFF is a real cap, not an absence of one.
+            (ReasoningEffort.XHIGH, None, ReasoningEffort.OFF, ReasoningEffort.OFF),
+            # OFF is also a real request, and survives a permissive cap.
+            (ReasoningEffort.OFF, ReasoningEffort.HIGH, None, ReasoningEffort.OFF),
+        ],
+    )
+    def test_resolution_matrix(
+        self,
+        requested: ReasoningEffort,
+        default: ReasoningEffort | None,
+        maximum: ReasoningEffort | None,
+        expected: ReasoningEffort,
+    ) -> None:
+        assert resolve_reasoning_effort(requested, default, maximum) == expected
+
+    @pytest.mark.parametrize(
+        "maximum,expected",
+        [
+            (ReasoningEffort.LOW, ReasoningEffort.LOW),
+            (ReasoningEffort.OFF, ReasoningEffort.OFF),
+            (ReasoningEffort.HIGH, ReasoningEffort.MEDIUM),
+            (ReasoningEffort.XHIGH, ReasoningEffort.MEDIUM),
+        ],
+    )
+    def test_auto_is_concretized_before_clamping(
+        self, maximum: ReasoningEffort, expected: ReasoningEffort
+    ) -> None:
+        """AUTO means medium downstream, so a cap below medium must bind it.
+
+        Left as AUTO, a cap of LOW would be violated by the AUTO->medium
+        mapping in OPENAI_REASONING_EFFORT.
+        """
+        assert resolve_reasoning_effort(ReasoningEffort.AUTO, None, maximum) == expected
+
+    def test_auto_stays_auto_without_a_cap(self) -> None:
+        """No cap means no reason to force a choice the provider can make."""
+        assert (
+            resolve_reasoning_effort(ReasoningEffort.AUTO, None, None)
+            is ReasoningEffort.AUTO
+        )
+
+
+class TestEffortReachesTheProvider:
+    """The resolved effort is what gets sent, not the requested one."""
+
+    def test_cap_binds_a_session_override(self) -> None:
+        llm = _make_llm(reasoning_effort_max=ReasoningEffort.LOW)
+        assert _effort_sent(_sent_kwargs(llm, ReasoningEffort.XHIGH)) == "low"
+
+    def test_default_applies_when_unpinned(self) -> None:
+        llm = _make_llm(reasoning_effort_default=ReasoningEffort.HIGH)
+        assert _effort_sent(_sent_kwargs(llm, ReasoningEffort.AUTO)) == "high"
+
+    def test_session_override_beats_the_default(self) -> None:
+        llm = _make_llm(reasoning_effort_default=ReasoningEffort.HIGH)
+        assert _effort_sent(_sent_kwargs(llm, ReasoningEffort.LOW)) == "low"
+
+    def test_auto_under_a_low_cap_does_not_leak_medium(self) -> None:
+        """The trap this design exists to avoid."""
+        llm = _make_llm(reasoning_effort_max=ReasoningEffort.LOW)
+        assert _effort_sent(_sent_kwargs(llm, ReasoningEffort.AUTO)) == "low"
+
+    def test_unset_policy_changes_nothing(self) -> None:
+        llm = _make_llm()
+        assert _effort_sent(_sent_kwargs(llm, ReasoningEffort.HIGH)) == "high"
+
+    def test_off_cap_omits_reasoning_entirely(self) -> None:
+        """OFF is the one level that drops the parameter rather than lowering it."""
+        llm = _make_llm(reasoning_effort_max=ReasoningEffort.OFF)
+        kwargs = _sent_kwargs(llm, ReasoningEffort.XHIGH)
+        for key in ("reasoning", "thinking", "output_config", "reasoning_effort"):
+            assert key not in kwargs
+
+
+class TestProvidedModelSettings:
+    """An omitted field must not clear a stored setting."""
+
+    def test_omitted_settings_are_not_written(self) -> None:
+        """The rolling-deploy case: a client predating these fields saves a
+        provider, and the admin's cap must survive it."""
+        request = ModelConfigurationUpsertRequest(name="gpt-5.1", is_visible=True)
+        assert request.provided_model_settings() == {}
+
+    def test_explicit_null_clears(self) -> None:
+        """Distinct from omission: this is an admin resetting to auto."""
+        request = ModelConfigurationUpsertRequest(
+            name="gpt-5.1", is_visible=True, reasoning_effort_max=None
+        )
+        assert request.provided_model_settings() == {"reasoning_effort_max": None}
+
+    def test_only_carried_fields_are_returned(self) -> None:
+        request = ModelConfigurationUpsertRequest(
+            name="gpt-5.1",
+            is_visible=True,
+            reasoning_effort_max=ReasoningEffort.HIGH,
+        )
+        assert request.provided_model_settings() == {
+            "reasoning_effort_max": ReasoningEffort.HIGH
+        }
+
+
+class TestUpsertValidation:
+    """Rejections happen at the API boundary, via OnyxError."""
+
+    @pytest.mark.parametrize("auto", ["auto", ReasoningEffort.AUTO])
+    def test_auto_is_not_storable(self, auto: object) -> None:
+        """AUTO has no rank, so storing it would make the clamp raise later.
+        The enum form matters: a programmatic caller can reach this directly."""
+        with pytest.raises(OnyxError):
+            ModelConfigurationUpsertRequest(
+                name="gpt-5.1", is_visible=True, reasoning_effort_max=auto
+            )
+
+    def test_unknown_effort_rejected(self) -> None:
+        with pytest.raises(OnyxError):
+            ModelConfigurationUpsertRequest(
+                name="gpt-5.1", is_visible=True, reasoning_effort_default="extreme"
+            )
+
+    @pytest.mark.parametrize("temperature", [-0.1, 2.1])
+    def test_temperature_out_of_range_rejected(self, temperature: float) -> None:
+        with pytest.raises(OnyxError):
+            ModelConfigurationUpsertRequest(
+                name="gpt-5.1", is_visible=True, temperature_default=temperature
+            )
+
+    def test_default_above_max_rejected(self) -> None:
+        with pytest.raises(OnyxError):
+            ModelConfigurationUpsertRequest(
+                name="gpt-5.1",
+                is_visible=True,
+                reasoning_effort_max=ReasoningEffort.LOW,
+                reasoning_effort_default=ReasoningEffort.HIGH,
+            )
+
+    def test_default_equal_to_max_allowed(self) -> None:
+        request = ModelConfigurationUpsertRequest(
+            name="gpt-5.1",
+            is_visible=True,
+            reasoning_effort_max=ReasoningEffort.LOW,
+            reasoning_effort_default=ReasoningEffort.LOW,
+        )
+        assert request.reasoning_effort_default is ReasoningEffort.LOW
+
+
+class TestTemperatureDefault:
+    """Temperature resolves at construction, where temperature already flows."""
+
+    def test_explicit_temperature_is_kept(self) -> None:
+        assert (
+            _make_llm(temperature=0.25, model_name="gpt-4o").config.temperature == 0.25
+        )
+
+    def test_reasoning_models_still_pin_temperature_to_one(self) -> None:
+        """The existing pin sits above admin policy and is unchanged."""
+        llm = _make_llm(temperature=0.25)
+        assert _sent_kwargs(llm, ReasoningEffort.HIGH)["temperature"] == 1

--- a/backend/tests/unit/onyx/llm/test_model_settings_resolution.py
+++ b/backend/tests/unit/onyx/llm/test_model_settings_resolution.py
@@ -166,28 +166,31 @@ class TestEffortReachesTheProvider:
 class TestProvidedModelSettings:
     """An omitted field must not clear a stored setting."""
 
-    def test_omitted_settings_are_not_written(self) -> None:
+    def test_omitted_settings_are_not_provided(self) -> None:
         """The rolling-deploy case: a client predating these fields saves a
         provider, and the admin's cap must survive it."""
         request = ModelConfigurationUpsertRequest(name="gpt-5.1", is_visible=True)
-        assert request.provided_model_settings() == {}
+        assert not request.reasoning_effort_max_provided
+        assert not request.reasoning_effort_default_provided
+        assert not request.temperature_default_provided
 
-    def test_explicit_null_clears(self) -> None:
+    def test_explicit_null_is_provided(self) -> None:
         """Distinct from omission: this is an admin resetting to auto."""
         request = ModelConfigurationUpsertRequest(
             name="gpt-5.1", is_visible=True, reasoning_effort_max=None
         )
-        assert request.provided_model_settings() == {"reasoning_effort_max": None}
+        assert request.reasoning_effort_max_provided
+        assert request.reasoning_effort_max is None
+        assert not request.reasoning_effort_default_provided
 
-    def test_only_carried_fields_are_returned(self) -> None:
+    def test_set_value_is_provided(self) -> None:
         request = ModelConfigurationUpsertRequest(
             name="gpt-5.1",
             is_visible=True,
             reasoning_effort_max=ReasoningEffort.HIGH,
         )
-        assert request.provided_model_settings() == {
-            "reasoning_effort_max": ReasoningEffort.HIGH
-        }
+        assert request.reasoning_effort_max_provided
+        assert request.reasoning_effort_max is ReasoningEffort.HIGH
 
 
 class TestUpsertValidation:
@@ -231,23 +234,30 @@ class TestUpsertValidation:
         stored_default = ReasoningEffort.HIGH
         incoming = ModelConfigurationUpsertRequest(
             name="gpt-5.1", is_visible=True, reasoning_effort_max=ReasoningEffort.LOW
-        ).provided_model_settings()
+        )
+        merged_default = (
+            incoming.reasoning_effort_default
+            if incoming.reasoning_effort_default_provided
+            else stored_default
+        )
 
         with pytest.raises(OnyxError):
-            ensure_default_within_max(
-                incoming.get("reasoning_effort_default", stored_default),
-                incoming.get("reasoning_effort_max", None),
-            )
+            ensure_default_within_max(merged_default, incoming.reasoning_effort_max)
 
     def test_merged_policy_accepts_a_consistent_partial_update(self) -> None:
         stored_default = ReasoningEffort.LOW
         incoming = ModelConfigurationUpsertRequest(
             name="gpt-5.1", is_visible=True, reasoning_effort_max=ReasoningEffort.HIGH
-        ).provided_model_settings()
+        )
+        merged_default = (
+            incoming.reasoning_effort_default
+            if incoming.reasoning_effort_default_provided
+            else stored_default
+        )
 
         ensure_default_within_max(
-            incoming.get("reasoning_effort_default", stored_default),
-            incoming.get("reasoning_effort_max", None),
+            merged_default,
+            incoming.reasoning_effort_max,
         )
 
     def test_default_equal_to_max_allowed(self) -> None:

--- a/backend/tests/unit/onyx/llm/test_model_settings_resolution.py
+++ b/backend/tests/unit/onyx/llm/test_model_settings_resolution.py
@@ -8,7 +8,10 @@ import pytest
 from onyx.error_handling.exceptions import OnyxError
 from onyx.llm.models import ReasoningEffort, UserMessage, resolve_reasoning_effort
 from onyx.llm.multi_llm import LitellmLLM
-from onyx.server.manage.llm.models import ModelConfigurationUpsertRequest
+from onyx.server.manage.llm.models import (
+    ModelConfigurationUpsertRequest,
+    ensure_default_within_max,
+)
 
 _SENTINEL = object()
 
@@ -220,6 +223,32 @@ class TestUpsertValidation:
                 reasoning_effort_max=ReasoningEffort.LOW,
                 reasoning_effort_default=ReasoningEffort.HIGH,
             )
+
+    def test_merged_policy_is_what_gets_validated(self) -> None:
+        """A partial update lowering only the cap must still be checked against
+        the default already stored, or the row ends up with a default the cap
+        silently overrides."""
+        stored_default = ReasoningEffort.HIGH
+        incoming = ModelConfigurationUpsertRequest(
+            name="gpt-5.1", is_visible=True, reasoning_effort_max=ReasoningEffort.LOW
+        ).provided_model_settings()
+
+        with pytest.raises(OnyxError):
+            ensure_default_within_max(
+                incoming.get("reasoning_effort_default", stored_default),
+                incoming.get("reasoning_effort_max", None),
+            )
+
+    def test_merged_policy_accepts_a_consistent_partial_update(self) -> None:
+        stored_default = ReasoningEffort.LOW
+        incoming = ModelConfigurationUpsertRequest(
+            name="gpt-5.1", is_visible=True, reasoning_effort_max=ReasoningEffort.HIGH
+        ).provided_model_settings()
+
+        ensure_default_within_max(
+            incoming.get("reasoning_effort_default", stored_default),
+            incoming.get("reasoning_effort_max", None),
+        )
 
     def test_default_equal_to_max_allowed(self) -> None:
         request = ModelConfigurationUpsertRequest(

--- a/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
@@ -681,6 +681,9 @@ def _make_model_config(
     max_input_tokens: int | None = None,
     is_visible: bool = True,
     supports_image_input: bool | None = None,
+    reasoning_effort_max: ReasoningEffort | None = None,
+    reasoning_effort_default: ReasoningEffort | None = None,
+    temperature_default: float | None = None,
 ) -> MagicMock:
     """Build a minimal mock ModelConfiguration DB row."""
     mc = MagicMock()
@@ -690,6 +693,9 @@ def _make_model_config(
     mc.is_visible = is_visible
     mc.supports_image_input = supports_image_input
     mc.custom_display_name = None
+    mc.reasoning_effort_max = reasoning_effort_max
+    mc.reasoning_effort_default = reasoning_effort_default
+    mc.temperature_default = temperature_default
     mc.llm_model_flow_types = (
         flow_types if flow_types is not None else [LLMModelFlowType.CHAT]
     )


### PR DESCRIPTION
## Description

Makes the per-model settings columns actually do something. An admin can cap how much reasoning a model does and set the level and temperature it starts from. A chat session override resolves against the admin default and is then clamped to the admin max.

The clamp runs at inference time in `_completion`, so it covers every invoke path: normal chat, deep research, and per-model instances in multi-model runs. Sources are tried in order and the cap is applied last and unconditionally, so no stale client or direct API call can exceed it.

AUTO is concretized before clamping. It maps to medium downstream, so left alone a cap of low would be silently violated.

Two bugs found while building this and fixed here:

- The per-model temperature default was dead on the main chat path. `get_llm_for_persona` passed `temperature_override or GEN_AI_TEMPERATURE`, so an explicit value always arrived and the fallback never fired. The `or` also turned an explicit override of `0.0` into the global value.
- An older client omitting these fields on a provider save would clear an admin's stored cap. The upsert now distinguishes an omitted field from an explicit null.

Stacked on #14069 for the columns.

## How Has This Been Tested?

- 32 new tests in `backend/tests/unit/onyx/llm/test_model_settings_resolution.py`: the full resolution matrix, AUTO concretization against each cap, OFF as both a cap and a request, the effort that actually reaches the provider, upsert validation rejections, and the omitted-vs-null distinction.
- Proved the tests fail on unfixed code: with the resolution call removed from `_completion`, exactly the four behavioral tests fail. Restored and green.
- `pytest backend/tests/unit/onyx/{llm,chat,server/manage}`: 1293 passed.
- Full backend unit suite: 8537 passed, 19 failed. The same 19 fail with this branch stashed (license reclaim, process isolation), so they are pre-existing on this base.
- `ty check` from the repo root: All checks passed. `ruff format --check`: 8 files already formatted.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
