### PR TITLE
fix(terraform): relax the provider pin on modules that work with aws 6.x

### DIFF
--- a/deployment/terraform/modules/aws/opensearch/versions.tf
+++ b/deployment/terraform/modules/aws/opensearch/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.100"
+      version = ">= 5.100, < 7.0"
     }
   }
 }

--- a/deployment/terraform/modules/aws/postgres/versions.tf
+++ b/deployment/terraform/modules/aws/postgres/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.100"
+      version = ">= 5.100, < 7.0"
     }
   }
 }

--- a/deployment/terraform/modules/aws/redis/versions.tf
+++ b/deployment/terraform/modules/aws/redis/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.100"
+      version = ">= 5.100, < 7.0"
     }
   }
 }

--- a/deployment/terraform/modules/aws/s3/versions.tf
+++ b/deployment/terraform/modules/aws/s3/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.100"
+      version = ">= 5.100, < 7.0"
     }
   }
 }

--- a/deployment/terraform/modules/aws/vpc/versions.tf
+++ b/deployment/terraform/modules/aws/vpc/versions.tf
@@ -3,7 +3,9 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
+      source = "hashicorp/aws"
+      # Pinned to 5.x: aws_flow_log.log_group_name was removed in provider 6.0.
+      # Migrate the flow log to log_destination before relaxing this.
       version = "~> 5.100"
     }
   }

--- a/deployment/terraform/modules/aws/waf/versions.tf
+++ b/deployment/terraform/modules/aws/waf/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.100"
+      version = ">= 5.100, < 7.0"
     }
   }
 }


### PR DESCRIPTION
## Description

Follow-up to #14047. That PR added a `versions.tf` to each published module — necessary, because without one a standalone consumer resolved aws 6.x and the `vpc` and `eks` modules failed to validate. But it pinned **every** module to `~> 5.100`, which is too tight.

A caller already on aws 6.x cannot consume any of these modules at all, because `~> 5.100` and `~> 6.0` have no overlap:

```
Finding hashicorp/aws versions matching "~> 5.100, ~> 6.0"...
Error: no available releases match the given constraints
```

This surfaced while repointing our internal stacks at `tf-v1.0.0`: four of them run aws `~> 6.0` and consume the `s3` module, and `terraform init` fails outright.

I validated each module against aws 6.x. Five pass, so they move to `>= 5.100, < 7.0`:

| Module | aws 6.x | Constraint |
|---|---|---|
| `s3`, `waf`, `redis`, `postgres`, `opensearch` | validates | `>= 5.100, < 7.0` |
| `vpc` | **fails** — `aws_flow_log.log_group_name` was removed in provider 6.0 | stays `~> 5.100`, reason recorded inline |
| `eks` | not tested | stays `~> 5.100` |

Migrating `vpc`'s flow log from `log_group_name` to `log_destination` would let it relax too, but that changes a live resource and belongs in its own change.

## How Has This Been Tested?

Both directions, since the risk here is symmetric — the fix must unblock 6.x callers without moving anyone already on 5.x:

**A 6.x caller now resolves** (previously an error):
```
- Finding hashicorp/aws versions matching ">= 5.100.0, ~> 6.0, < 7.0.0"...
- Installed hashicorp/aws v6.60.0
```

**An existing consumer does not move.** A root using `vpc` and `s3` together — the shape every managed deployment has — still lands on the version it runs today:
```
- Finding hashicorp/aws versions matching ">= 5.0.0, >= 5.100.0, ~> 5.100, < 7.0.0"...
- Installed hashicorp/aws v5.100.0
```

All 8 modules pass `terraform validate`, and the full pre-commit suite is green.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relaxes the `hashicorp/aws` provider pin for modules that validate on AWS provider 6.x, unblocking 6.x callers while keeping incompatible modules pinned. Previously all modules were pinned to `~> 5.100`, which prevented any 6.x consumer from using them.

- `s3`, `waf`, `redis`, `postgres`, `opensearch`: change provider constraint to `>= 5.100, < 7.0` to allow 6.x while remaining compatible with 5.x.
- `vpc`: remains `~> 5.100` with an inline note; `aws_flow_log.log_group_name` was removed in provider 6.0.
- `eks`: remains `~> 5.100` (not yet validated on 6.x).
- Resolution behavior: roots on 6.x now install 6.x with these modules; roots using `vpc` still resolve to 5.100; existing 5.x consumers do not move.
- Required action for 6.x with `vpc`: migrate flow logs from `log_group_name` to `log_destination` before relaxing the pin.

<sup>Written for commit 0b5fdeb94ad7ac987cb595570be667b16f5c6859. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

