### PR TITLE
feat(ods): gate Go coverage against a committed baseline

### DIFF
--- a/.github/workflows/pr-golang-tests.yml
+++ b/.github/workflows/pr-golang-tests.yml
@@ -55,3 +55,45 @@ jobs:
 
       - run: go test -race ./...
         working-directory: ${{ matrix.modules }}
+
+  # A module opts into the coverage gate by committing a .coverage-baseline.yaml.
+  detect-coverage-modules:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      modules: ${{ steps.set-modules.outputs.modules }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+      - id: set-modules
+        run: echo "modules=$(find . -name '.coverage-baseline.yaml' -exec dirname {} \; | jq -Rc '[.,inputs]')" >> "$GITHUB_OUTPUT"
+
+  coverage:
+    needs: detect-coverage-modules
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        modules: ${{ fromJSON(needs.detect-coverage-modules.outputs.modules) }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # zizmor: ignore[cache-poisoning]
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
+
+      - name: Build ods
+        run: go build -o "${RUNNER_TEMP}/ods" .
+        working-directory: tools/ods
+
+      # Fails when a package drops below the floor recorded in its baseline.
+      # Raise the floors after adding tests with `ods coverage <suite> --update`.
+      - name: Check coverage against the baseline
+        env:
+          MODULE: ${{ matrix.modules }}
+        run: |
+          "${RUNNER_TEMP}/ods" coverage "${MODULE}" --check

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -150,6 +150,13 @@ verification is necessary) over any other type of test.
 
 Tests are parallelized at a directory level.
 
+Careful: these tests call `reset_all()`, which wipes Postgres and the file store for the current
+project. Do not point them at data you want to keep.
+
+`ods test integration` runs `backend/tests/integration/tests`, the same set CI shards. The sibling
+directories need a setup of their own, so give a path to run one, for example
+`ods test backend/tests/integration/multitenant_tests`.
+
 When writing integration tests, make sure to check the root `conftest.py` for useful fixtures + the `backend/tests/integration/common_utils` directory for utilities. Prefer (if one exists), calling the appropriate Manager
 class in the utils over directly calling the APIs with a library like `requests`. Prefer using fixtures rather than
 calling the utilities directly (e.g. do NOT create admin users with

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -91,6 +91,15 @@ Write the migration manually and place it in the file that alembic creates when 
 Run pytest through `uv run` from the repo root — no venv activation needed (`uv run` uses the
 lockfile-pinned environment and creates/syncs `.venv` as needed).
 
+`ods test` is the shorter form of every command in this section. It picks the suite from a name
+or a path, supplies `.vscode/.env` where the suite needs it, and passes the rest to pytest:
+
+```bash
+ods test unit                                   # the whole suite
+ods test backend/tests/unit/onyx/test_foo.py    # one file
+ods test external -k some_name                  # arguments reach pytest
+```
+
 There are 4 main types of tests within Onyx:
 
 ### Model choice for tests that make real LLM calls

--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -76,7 +76,8 @@ Web is different: web uses **Tailwind's default step scale**, where `p-6` = step
 ## Tests
 
 - Runner: `jest-expo`. Tests live in `__tests__/` (`src/**/__tests__/**/*.test.ts?(x)`). Gate with
-  `bun run typecheck`, `bun run lint`, `bunx jest`.
+  `bun run typecheck`, `bun run lint`, `bunx jest`. From any directory, `ods test mobile` runs the
+  same jest suite and installs `mobile/node_modules` first if it is missing.
 - **Import jest globals from `@jest/globals`** (`describe/it/expect/jest/beforeEach`) — the TS config
   carries no ambient test types. Put all imports first, then `jest.mock(...)` (babel hoists the mock;
   this also satisfies `import/first`).

--- a/tools/ods/.coverage-baseline.yaml
+++ b/tools/ods/.coverage-baseline.yaml
@@ -1,0 +1,31 @@
+# Minimum statement coverage per package, in percent.
+#
+# `ods coverage <suite> --check` fails when a package drops below its floor,
+# which is how CI keeps coverage from regressing. Raise the floors after adding
+# tests with `ods coverage <suite> --update`.
+#
+# Generated file: do not edit by hand.
+total: 26.3
+packages:
+  .: 0
+  cmd: 6.3
+  internal/alembic: 0
+  internal/audit: 55.6
+  internal/composegen: 96.8
+  internal/config: 0
+  internal/coverage: 78
+  internal/deployfilessync: 79.1
+  internal/docker: 25.3
+  internal/git: 28.5
+  internal/imgdiff: 68.2
+  internal/kube: 0
+  internal/lazyimports: 58.3
+  internal/openapi: 0
+  internal/paths: 0
+  internal/portutil: 75
+  internal/postgres: 0
+  internal/prompt: 0
+  internal/s3: 0
+  internal/testsuite: 92.5
+  internal/tui: 43.3
+  internal/version: 100

--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -272,6 +272,15 @@ need credentials read `.vscode/.env`, which is created from
 `.vscode/env_template.txt` on first use. Enterprise Edition features are on by
 default; use `--no-ee` to turn them off.
 
+A bare `ods test integration` runs `backend/tests/integration/tests`, which is
+what CI shards. The sibling directories under `backend/tests/integration` each
+need a setup of their own — `multitenant_tests` a multi-tenant deployment,
+`connector_job_tests` connector credentials — so give a path to run one.
+
+**Careful:** the integration suite calls `reset_all()`, which wipes Postgres and
+the file store for the current project. Do not point it at data you want to
+keep.
+
 **Examples:**
 
 ```shell

--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -315,6 +315,67 @@ ods test tools/ods/internal/testsuite
 ods test cli/internal/tui/viewport_test.go::TestAddUserMessage
 ```
 
+### `coverage` - Measure Go Coverage Against a Baseline
+
+Measure Go statement coverage per package and hold it against a committed
+baseline, so coverage can go up but not down.
+
+```shell
+ods coverage <suite|module-dir> [flags]
+```
+
+The baseline is a `.coverage-baseline.yaml` at the module root recording each
+package's floor. `--check` fails when a package drops below its floor, which is
+what `pr-golang-tests.yml` runs on every PR. After adding tests, `--update`
+raises the floors.
+
+Coverage is measured per package with `go test -coverprofile`, so a package's
+number counts only its own tests. That is a number the package's owner can act
+on; a cross-package `-coverpkg` total would credit a package for statements its
+own tests never assert on.
+
+Only the Go suites (`ods`, `cli`, `terraform`) are supported. The backend and
+web suites have no coverage tooling yet.
+
+**Flags:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--check` | `false` | Fail when a package drops below its baseline floor |
+| `--update` | `false` | Rewrite the baseline from this run |
+| `--profile` | | Keep the coverage profile at this path (for `go tool cover`) |
+| `--tolerance` | `0.1` | Percentage points a package may drop below its floor without failing |
+
+**Examples:**
+
+```shell
+# Report where each package stands
+ods coverage ods
+
+# Fail on a regression (what CI runs)
+ods coverage ods --check
+
+# Record today's numbers as the new floors
+ods coverage ods --update
+
+# Keep the profile and browse the uncovered lines
+ods coverage ods --profile /tmp/cover.out
+go tool cover -html=/tmp/cover.out
+```
+
+#### Raising the baseline
+
+The gate never fails on an improvement, so a baseline goes stale as tests are
+added. `ods coverage ods` reports how many packages have risen; commit the gain
+with `--update` so the new level becomes the floor.
+
+A module opts into the CI gate by committing a baseline, so `cli` and
+`terraform-provider-onyx` join by running `ods coverage <suite> --update` once.
+
+Floors are rounded down to one decimal, and a package may sit `--tolerance`
+below its floor without failing. That absorbs the jitter from suites that depend
+on ports or timing; a real regression is far larger.
+
 ### `dev` - Devcontainer Management
 
 Manage the Onyx devcontainer. Also available as `ods dc`.

--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -265,12 +265,20 @@ later arguments go to the underlying runner.
 | `web` | `jest` | jest | no |
 | `e2e` | `playwright`, `pw` | playwright | full deployment |
 | `mobile` | | jest-expo | no |
+| `ods` | | go test | no |
+| `cli` | | go test | no |
+| `terraform` | `tf` | go test | no |
 | `backend` | `py` | pytest | any other `backend/tests` path |
 
 Backend suites run from `backend/`, so `backend/pytest.ini` applies. Suites that
 need credentials read `.vscode/.env`, which is created from
 `.vscode/env_template.txt` on first use. Enterprise Edition features are on by
 default; use `--no-ee` to turn them off.
+
+The Go suites cover the repo's three Go modules. They run with `-race`, the same
+as `pr-golang-tests.yml`. `go test` takes packages rather than files, so a file
+argument runs the package that holds it, and `<file>::<TestName>` becomes a
+`-run` filter.
 
 A bare `ods test integration` runs `backend/tests/integration/tests`, which is
 what CI shards. The sibling directories under `backend/tests/integration` each
@@ -300,6 +308,11 @@ ods test external --parallel
 
 # Web end-to-end tests
 ods test e2e chat
+
+# Go modules
+ods test ods
+ods test tools/ods/internal/testsuite
+ods test cli/internal/tui/viewport_test.go::TestAddUserMessage
 ```
 
 ### `dev` - Devcontainer Management

--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -244,6 +244,55 @@ ods web lint
 ods web test --watch
 ```
 
+### `test` - Run Tests
+
+Run any test suite in the repo without changing directories or remembering
+which runner applies.
+
+```shell
+ods test <suite|path> [args...]
+```
+
+The first argument is a suite name or a path inside a suite. A path selects the
+suite that covers it, so you can pass a file straight from your editor. All
+later arguments go to the underlying runner.
+
+| Suite | Aliases | Runner | Needs services |
+| --- | --- | --- | --- |
+| `unit` | `u` | pytest | no |
+| `external` | `edu`, `ext` | pytest | Postgres, Redis, OpenSearch, MinIO |
+| `integration` | `int` | pytest | full deployment |
+| `web` | `jest` | jest | no |
+| `e2e` | `playwright`, `pw` | playwright | full deployment |
+| `mobile` | | jest-expo | no |
+| `backend` | `py` | pytest | any other `backend/tests` path |
+
+Backend suites run from `backend/`, so `backend/pytest.ini` applies. Suites that
+need credentials read `.vscode/.env`, which is created from
+`.vscode/env_template.txt` on first use. Enterprise Edition features are on by
+default; use `--no-ee` to turn them off.
+
+**Examples:**
+
+```shell
+# Run a whole suite
+ods test unit
+
+# Run one file, or one test
+ods test backend/tests/unit/onyx/utils/test_vespa_tasks.py
+ods test backend/tests/unit/onyx/utils/test_vespa_tasks.py::test_monitor
+
+# Forward arguments to the runner
+ods test unit -k some_name
+ods test web --watch
+
+# Run a backend suite in parallel (pytest-xdist)
+ods test external --parallel
+
+# Web end-to-end tests
+ods test e2e chat
+```
+
 ### `dev` - Devcontainer Management
 
 Manage the Onyx devcontainer. Also available as `ods dc`.

--- a/tools/ods/cmd/backend.go
+++ b/tools/ods/cmd/backend.go
@@ -138,20 +138,8 @@ func runBackendService(name, module, port string, opts *BackendOptions) {
 
 	svcCmd := exec.Command("uv", uvicornArgs...)
 	svcCmd.Dir = backendDir
-	svcCmd.Stdout = os.Stdout
-	svcCmd.Stderr = os.Stderr
-	svcCmd.Stdin = os.Stdin
 	svcCmd.Env = mergedEnv
-
-	if err := svcCmd.Run(); err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			if code := exitErr.ExitCode(); code != -1 {
-				os.Exit(code)
-			}
-		}
-		log.Fatalf("Failed to run %s: %v", name, err)
-	}
+	runChild(svcCmd, name)
 }
 
 // eeEnvDefaults returns env entries for EE and license enforcement settings.

--- a/tools/ods/cmd/coverage.go
+++ b/tools/ods/cmd/coverage.go
@@ -1,0 +1,224 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/coverage"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/testsuite"
+)
+
+// CoverageOptions holds options for the coverage command.
+type CoverageOptions struct {
+	Check     bool
+	Update    bool
+	Profile   string
+	Tolerance float64
+}
+
+// NewCoverageCommand creates a command that measures statement coverage for a
+// Go suite and compares it against the committed baseline.
+func NewCoverageCommand() *cobra.Command {
+	opts := &CoverageOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "coverage <suite|module-dir>",
+		Short: "Measure Go test coverage and hold it against a baseline",
+		Long:  coverageHelpDescription(),
+		Args:  cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) > 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return goSuiteNames(), cobra.ShellCompDirectiveNoFileComp
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			runCoverage(args[0], opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.Check, "check", false, "Fail when a package drops below its baseline floor")
+	cmd.Flags().BoolVar(&opts.Update, "update", false, "Rewrite the baseline from this run")
+	cmd.Flags().StringVar(&opts.Profile, "profile", "", "Keep the coverage profile at this path (for `go tool cover`)")
+	cmd.Flags().Float64Var(&opts.Tolerance, "tolerance", coverage.DefaultTolerance,
+		"Percentage points a package may drop below its floor without failing")
+
+	return cmd
+}
+
+func runCoverage(suiteName string, opts *CoverageOptions) {
+	if opts.Check && opts.Update {
+		log.Fatal("--check and --update do the opposite of each other; pass only one")
+	}
+
+	root, err := paths.GitRoot()
+	if err != nil {
+		log.Fatalf("Failed to find git root: %v", err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("Failed to determine the working directory: %v", err)
+	}
+
+	suite := goSuite(root, cwd, suiteName)
+	moduleDir := filepath.Join(root, suite.Dir)
+
+	profilePath, cleanup := profileTarget(opts.Profile)
+	defer cleanup()
+
+	log.Infof("Measuring %s coverage...", suite.Name)
+	profile, err := coverage.Run(coverage.RunOptions{
+		ModuleDir:   moduleDir,
+		ProfilePath: profilePath,
+		Args:        suite.DefaultArgs,
+		Stdout:      os.Stdout,
+		Stderr:      os.Stderr,
+	})
+	var exitErr *coverage.ExitError
+	if errors.As(err, &exitErr) {
+		// The tests failed, and their output is already on the terminal.
+		// Coverage from a failed run is not worth reporting.
+		os.Exit(exitErr.Code)
+	}
+	if err != nil {
+		log.Fatalf("Failed to measure coverage: %v", err)
+	}
+
+	baselinePath := coverage.BaselinePath(moduleDir)
+
+	if opts.Update {
+		writeBaseline(baselinePath, profile)
+		return
+	}
+
+	baseline, err := coverage.LoadBaseline(baselinePath)
+	if errors.Is(err, os.ErrNotExist) {
+		if opts.Check {
+			log.Fatalf("No baseline at %s. Create one with: ods coverage %s --update", baselinePath, suite.Name)
+		}
+		log.Warnf("No baseline at %s; create one with: ods coverage %s --update", baselinePath, suite.Name)
+		baseline = nil
+	} else if err != nil {
+		log.Fatalf("Failed to read the baseline: %v", err)
+	}
+
+	report := coverage.Compare(profile, baseline, opts.Tolerance)
+	if err := coverage.WriteReport(os.Stdout, report); err != nil {
+		log.Fatalf("Failed to write the report: %v", err)
+	}
+
+	if profilePath == opts.Profile {
+		log.Infof("Coverage profile written to %s", profilePath)
+		log.Infof("Browse it with: go tool cover -html=%s", profilePath)
+	}
+
+	if improvements := report.Improvements(); len(improvements) > 0 {
+		log.Infof("%d package(s) rose above the baseline. Lock the gain in with: ods coverage %s --update",
+			len(improvements), suite.Name)
+	}
+
+	if !opts.Check {
+		return
+	}
+	regressions := report.Regressions()
+	if len(regressions) == 0 {
+		log.Infof("Coverage holds at or above the baseline in %s", baselinePath)
+		return
+	}
+	for _, regression := range regressions {
+		log.Errorf("%s fell to %.1f%%, below its %.1f%% floor", regression.Package, regression.Percent, regression.Floor)
+	}
+	log.Fatalf("Coverage regressed in %d package(s). Add tests, or justify the drop and run: ods coverage %s --update",
+		len(regressions), suite.Name)
+}
+
+func writeBaseline(baselinePath string, profile *coverage.Profile) {
+	baseline := coverage.NewBaseline(profile)
+	if err := baseline.Save(baselinePath); err != nil {
+		log.Fatalf("Failed to write the baseline: %v", err)
+	}
+	// Report the floor that was recorded, not the raw measurement, so the
+	// number here matches the file.
+	log.Infof("Wrote %s with a %.1f%% total coverage floor across %d packages",
+		baselinePath, baseline.Total, len(baseline.Packages))
+}
+
+// profileTarget resolves where the coverage profile is written. Without an
+// explicit path it goes to a temporary file that is removed afterwards.
+func profileTarget(requested string) (string, func()) {
+	if requested != "" {
+		return requested, func() {}
+	}
+	dir, err := os.MkdirTemp("", "ods-coverage")
+	if err != nil {
+		log.Fatalf("Failed to create a temporary directory: %v", err)
+	}
+	return filepath.Join(dir, "coverage.out"), func() { _ = os.RemoveAll(dir) }
+}
+
+// goSuite resolves a Go suite from a suite name or a module directory, reusing
+// the routing `ods test` uses. Accepting a directory lets CI pass the module it
+// is iterating over without a second name-to-path table.
+//
+// Coverage is wired up for the Go modules only; the backend and web suites have
+// no coverage tooling yet.
+func goSuite(root, cwd, target string) *testsuite.Suite {
+	suite, args, err := testsuite.Resolve(root, cwd, []string{target})
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+	if suite.Runner != testsuite.RunnerGo {
+		log.Fatalf("Coverage is not wired up for the %s suite yet (Go suites: %s)",
+			suite.Name, strings.Join(goSuiteNames(), ", "))
+	}
+	// Coverage is measured for a whole module, since a baseline covers every
+	// package in it. A path pointing deeper would silently measure less.
+	if len(args) > 0 && args[0] != "./..." {
+		log.Fatalf("Coverage runs a whole module; %q points inside %s. Use: ods coverage %s",
+			target, suite.Dir, suite.Name)
+	}
+	return suite
+}
+
+func goSuiteNames() []string {
+	var names []string
+	for _, suite := range testsuite.All() {
+		if suite.Runner == testsuite.RunnerGo {
+			names = append(names, suite.Name)
+		}
+	}
+	return names
+}
+
+func coverageHelpDescription() string {
+	var b strings.Builder
+	b.WriteString(`Measure Go statement coverage and hold it against a committed baseline.
+
+The baseline is a ` + coverage.BaselineFile + ` at the module root recording each
+package's floor. --check fails when a package drops below its floor, which is how
+CI keeps coverage from regressing. After adding tests, --update raises the floors.
+
+Coverage is per package: a package's number counts only its own tests, so it is a
+number that package's owner can act on.
+
+Examples:
+  ods coverage ods                  # report where each package stands
+  ods coverage ods --check          # fail on a regression (what CI runs)
+  ods coverage ods --update         # record today's numbers as the new floors
+  ods coverage ods --profile /tmp/cover.out
+
+Go suites:`)
+	for _, suite := range testsuite.All() {
+		if suite.Runner == testsuite.RunnerGo {
+			fmt.Fprintf(&b, "\n  %-12s %s", suite.Name, suite.Short)
+		}
+	}
+	return b.String()
+}

--- a/tools/ods/cmd/exec.go
+++ b/tools/ods/cmd/exec.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// runChild runs a wrapped tool with our stdio attached and does not return on
+// failure. The child's exit code becomes ours, so shell chains and CI see the
+// underlying tool's result, and stderr the child already printed is not
+// repeated. label names the tool in the message used when the process could
+// not be started at all.
+func runChild(c *exec.Cmd, label string) {
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	c.Stdin = os.Stdin
+
+	if err := c.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			if code := exitErr.ExitCode(); code != -1 {
+				os.Exit(code)
+			}
+		}
+		log.Fatalf("Failed to run %s: %v", label, err)
+	}
+}

--- a/tools/ods/cmd/root.go
+++ b/tools/ods/cmd/root.go
@@ -54,6 +54,7 @@ func NewRootCommand() *cobra.Command {
 	cmd.AddCommand(NewDeployCommand())
 	cmd.AddCommand(NewOpenAPICommand())
 	cmd.AddCommand(NewComposeCommand())
+	cmd.AddCommand(NewCoverageCommand())
 	cmd.AddCommand(NewGenerateComposeCommand())
 	cmd.AddCommand(NewEnvCommand())
 	cmd.AddCommand(NewLogsCommand())

--- a/tools/ods/cmd/root.go
+++ b/tools/ods/cmd/root.go
@@ -60,6 +60,7 @@ func NewRootCommand() *cobra.Command {
 	cmd.AddCommand(NewPullCommand())
 	cmd.AddCommand(NewRunCICommand())
 	cmd.AddCommand(NewScreenshotDiffCommand())
+	cmd.AddCommand(NewTestCommand())
 	cmd.AddCommand(NewDesktopCommand())
 	cmd.AddCommand(NewDevCommand())
 	cmd.AddCommand(NewWebCommand())

--- a/tools/ods/cmd/test.go
+++ b/tools/ods/cmd/test.go
@@ -106,11 +106,12 @@ func runPytestSuite(root string, suite *testsuite.Suite, suiteArgs []string, opt
 	if opts.Parallel {
 		pytestArgs = append(pytestArgs, "-n", "auto")
 	}
-	if len(suiteArgs) > 0 {
-		pytestArgs = append(pytestArgs, suiteArgs...)
-	} else {
-		pytestArgs = append(pytestArgs, suite.Target)
+	// The target goes first so that a user argument for the same option still
+	// wins. Without one, pytest would collect from all of backend/.
+	if !testsuite.HasTarget(suiteArgs) {
+		pytestArgs = append(pytestArgs, suite.DefaultTarget())
 	}
+	pytestArgs = append(pytestArgs, suiteArgs...)
 
 	envVars := eeEnvDefaults(opts.NoEE)
 	if suite.NeedsBackendEnv {
@@ -120,6 +121,9 @@ func runPytestSuite(root string, suite *testsuite.Suite, suiteArgs []string, opt
 	}
 
 	suiteDir := filepath.Join(root, suite.Dir)
+	if suite.Caution != "" {
+		log.Warnf("Careful: %s", suite.Caution)
+	}
 	log.Infof("Running %s tests...", suite.Name)
 	log.Debugf("Running in %s: uv %v", suiteDir, pytestArgs)
 
@@ -186,6 +190,9 @@ func testHelpDescription() string {
 The first argument is a suite name or a path inside a suite. A path picks the
 suite that covers it, so you can pass a file straight from an editor. Every
 later argument goes to the underlying runner.
+
+Careful: the integration suite calls reset_all(), which wipes Postgres and the
+file store for this project. Do not point it at data you want to keep.
 
 Examples:
   ods test unit

--- a/tools/ods/cmd/test.go
+++ b/tools/ods/cmd/test.go
@@ -78,6 +78,8 @@ func runTest(cmd *cobra.Command, args []string, opts *TestOptions) {
 		runJestSuite(root, suite, suiteArgs)
 	case testsuite.RunnerPlaywright:
 		runPlaywrightSuite(root, suite, suiteArgs)
+	case testsuite.RunnerGo:
+		runGoSuite(root, suite, suiteArgs)
 	default:
 		log.Fatalf("Suite %s has no runner", suite.Name)
 	}
@@ -131,6 +133,25 @@ func runPytestSuite(root string, suite *testsuite.Suite, suiteArgs []string, opt
 	pytestCmd.Dir = suiteDir
 	pytestCmd.Env = mergeEnv(os.Environ(), envVars)
 	runChild(pytestCmd, "pytest")
+}
+
+// runGoSuite runs a Go module's tests from the module directory, which is where
+// go test resolves its "./..." package patterns.
+func runGoSuite(root string, suite *testsuite.Suite, suiteArgs []string) {
+	goArgs := []string{"test"}
+	goArgs = append(goArgs, suite.DefaultArgs...)
+	if !testsuite.HasTarget(suiteArgs) {
+		goArgs = append(goArgs, suite.DefaultTarget())
+	}
+	goArgs = append(goArgs, suiteArgs...)
+
+	suiteDir := filepath.Join(root, suite.Dir)
+	log.Infof("Running %s tests...", suite.Name)
+	log.Debugf("Running in %s: go %v", suiteDir, goArgs)
+
+	goCmd := exec.Command("go", goArgs...)
+	goCmd.Dir = suiteDir
+	runChild(goCmd, "go test")
 }
 
 func runJestSuite(root string, suite *testsuite.Suite, suiteArgs []string) {
@@ -201,6 +222,8 @@ Examples:
   ods test external --parallel
   ods test web -- --watch
   ods test web/tests/e2e/chat.spec.ts
+  ods test ods
+  ods test tools/ods/internal/testsuite
 
 Suites:`
 

--- a/tools/ods/cmd/test.go
+++ b/tools/ods/cmd/test.go
@@ -1,0 +1,210 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/testsuite"
+)
+
+// TestOptions holds options for the test command.
+type TestOptions struct {
+	NoEE     bool
+	Parallel bool
+}
+
+// NewTestCommand creates a command that runs any of the repo's test suites.
+func NewTestCommand() *cobra.Command {
+	opts := &TestOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "test [suite|path] [args...]",
+		Short: "Run tests for any suite in the repo",
+		Long:  testHelpDescription(),
+		Args:  cobra.ArbitraryArgs,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) > 0 {
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+			return testsuite.Names(), cobra.ShellCompDirectiveNoFileComp
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			runTest(cmd, args, opts)
+		},
+	}
+	// Stop parsing at the first positional so flags meant for pytest, jest, or
+	// playwright reach them instead of cobra.
+	cmd.Flags().SetInterspersed(false)
+
+	cmd.Flags().BoolVar(&opts.NoEE, "no-ee", false, "Disable Enterprise Edition features (enabled by default)")
+	cmd.Flags().BoolVarP(&opts.Parallel, "parallel", "p", false, "Run pytest suites in parallel (pytest-xdist -n auto)")
+
+	return cmd
+}
+
+func runTest(cmd *cobra.Command, args []string, opts *TestOptions) {
+	root, err := paths.GitRoot()
+	if err != nil {
+		log.Fatalf("Failed to find git root: %v", err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("Failed to determine the working directory: %v", err)
+	}
+
+	suite, suiteArgs, err := testsuite.Resolve(root, cwd, args)
+	if errors.Is(err, testsuite.ErrNoArgs) {
+		_ = cmd.Help()
+		os.Exit(1)
+	}
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	suiteArgs = dropSeparator(suiteArgs)
+
+	switch suite.Runner {
+	case testsuite.RunnerPytest:
+		runPytestSuite(root, suite, suiteArgs, opts)
+	case testsuite.RunnerJest:
+		runJestSuite(root, suite, suiteArgs)
+	case testsuite.RunnerPlaywright:
+		runPlaywrightSuite(root, suite, suiteArgs)
+	default:
+		log.Fatalf("Suite %s has no runner", suite.Name)
+	}
+}
+
+// dropSeparator removes the first "--" from the arguments. Writing it is habit
+// for anyone used to `bun run` or `npm test`, and it can land either before or
+// after a path. No runner we wrap wants a literal "--", which pytest would
+// read as a target rather than a separator.
+func dropSeparator(args []string) []string {
+	for i, arg := range args {
+		if arg == "--" {
+			return append(args[:i:i], args[i+1:]...)
+		}
+	}
+	return args
+}
+
+// runPytestSuite runs a backend suite from the backend directory, so that
+// backend/pytest.ini applies. Credentials come from .vscode/.env the same way
+// `ods backend` supplies them, which also creates that file from the template
+// on first use.
+func runPytestSuite(root string, suite *testsuite.Suite, suiteArgs []string, opts *TestOptions) {
+	pytestArgs := []string{"run", "pytest"}
+	pytestArgs = append(pytestArgs, suite.DefaultArgs...)
+	if opts.Parallel {
+		pytestArgs = append(pytestArgs, "-n", "auto")
+	}
+	if len(suiteArgs) > 0 {
+		pytestArgs = append(pytestArgs, suiteArgs...)
+	} else {
+		pytestArgs = append(pytestArgs, suite.Target)
+	}
+
+	envVars := eeEnvDefaults(opts.NoEE)
+	if suite.NeedsBackendEnv {
+		envFile := ensureBackendEnvFile(root)
+		envVars = append(loadBackendEnvFile(envFile), envVars...)
+		log.Debugf("Applied %d env vars from %s (shell takes precedence)", len(envVars), envFile)
+	}
+
+	suiteDir := filepath.Join(root, suite.Dir)
+	log.Infof("Running %s tests...", suite.Name)
+	log.Debugf("Running in %s: uv %v", suiteDir, pytestArgs)
+
+	pytestCmd := exec.Command("uv", pytestArgs...)
+	pytestCmd.Dir = suiteDir
+	pytestCmd.Env = mergeEnv(os.Environ(), envVars)
+	runChild(pytestCmd, "pytest")
+}
+
+func runJestSuite(root string, suite *testsuite.Suite, suiteArgs []string) {
+	runBunScript(root, suite, "test", suiteArgs)
+}
+
+func runPlaywrightSuite(root string, suite *testsuite.Suite, suiteArgs []string) {
+	// The playwright script, never bunx, so the pinned version is the one that
+	// runs. See web/AGENTS.md.
+	runBunScript(root, suite, "playwright", suiteArgs)
+}
+
+// runBunScript runs a package.json script for a bun-based suite, after making
+// sure the suite's dependencies are installed.
+func runBunScript(root string, suite *testsuite.Suite, script string, suiteArgs []string) {
+	suiteDir := filepath.Join(root, suite.Dir)
+	if suite.Dir == "web" {
+		// Reuses the dependency and workspace-library checks `ods web` runs.
+		suiteDir = prepareWebDir()
+	} else {
+		ensureNodeModules(suiteDir)
+	}
+
+	bunArgs := []string{"run", script}
+	if len(suiteArgs) > 0 {
+		// bun requires "--" to forward arguments to the underlying script.
+		bunArgs = append(bunArgs, "--")
+		bunArgs = append(bunArgs, suiteArgs...)
+	}
+
+	log.Infof("Running %s tests...", suite.Name)
+	log.Debugf("Running in %s: bun %v", suiteDir, bunArgs)
+
+	bunCmd := exec.Command("bun", bunArgs...)
+	bunCmd.Dir = suiteDir
+	runChild(bunCmd, "bun")
+}
+
+// ensureNodeModules installs dependencies for a bun package that has none yet.
+// Suites outside web/ have no lockfile stamp to compare against, so this only
+// covers the empty case.
+func ensureNodeModules(dir string) {
+	entries, err := os.ReadDir(filepath.Join(dir, "node_modules"))
+	if err == nil && len(entries) > 0 {
+		return
+	}
+
+	log.Infof("node_modules missing in %s, running bun install...", dir)
+	installCmd := exec.Command("bun", "install")
+	installCmd.Dir = dir
+	runChild(installCmd, "bun install")
+}
+
+func testHelpDescription() string {
+	description := `Run tests for any suite in the repo.
+
+The first argument is a suite name or a path inside a suite. A path picks the
+suite that covers it, so you can pass a file straight from an editor. Every
+later argument goes to the underlying runner.
+
+Examples:
+  ods test unit
+  ods test backend/tests/unit/onyx/test_foo.py::test_bar
+  ods test unit -- -k some_name
+  ods test external --parallel
+  ods test web -- --watch
+  ods test web/tests/e2e/chat.spec.ts
+
+Suites:`
+
+	var b strings.Builder
+	b.WriteString(description)
+	for _, suite := range testsuite.All() {
+		names := suite.Name
+		if len(suite.Aliases) > 0 {
+			names += ", " + strings.Join(suite.Aliases, ", ")
+		}
+		fmt.Fprintf(&b, "\n  %-28s %s", names, suite.Short)
+	}
+	return b.String()
+}

--- a/tools/ods/cmd/web.go
+++ b/tools/ods/cmd/web.go
@@ -46,7 +46,9 @@ func NewWebCommand() *cobra.Command {
 	return cmd
 }
 
-func runWebScript(args []string) {
+// prepareWebDir returns the web directory once its dependencies and workspace
+// library builds are current.
+func prepareWebDir() string {
 	webDir, err := webDir()
 	if err != nil {
 		log.Fatalf("Failed to find web directory: %v", err)
@@ -56,16 +58,17 @@ func runWebScript(args []string) {
 		log.Infof("%s, running bun install --frozen-lockfile...", reason)
 		installCmd := exec.Command("bun", "install", "--frozen-lockfile")
 		installCmd.Dir = webDir
-		installCmd.Stdout = os.Stdout
-		installCmd.Stderr = os.Stderr
-		installCmd.Stdin = os.Stdin
-		if err := installCmd.Run(); err != nil {
-			log.Fatalf("Failed to run bun install: %v", err)
-		}
+		runChild(installCmd, "bun install")
 		writeLockStamp(webDir)
 	}
 
 	ensureWorkspaceLibsBuilt(webDir)
+
+	return webDir
+}
+
+func runWebScript(args []string) {
+	webDir := prepareWebDir()
 
 	scriptName := args[0]
 	scriptArgs := args[1:]
@@ -83,21 +86,7 @@ func runWebScript(args []string) {
 
 	webCmd := exec.Command("bun", bunArgs...)
 	webCmd.Dir = webDir
-	webCmd.Stdout = os.Stdout
-	webCmd.Stderr = os.Stderr
-	webCmd.Stdin = os.Stdin
-
-	if err := webCmd.Run(); err != nil {
-		// For wrapped commands, preserve the child process's exit code and
-		// avoid duplicating already-printed stderr output.
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			if code := exitErr.ExitCode(); code != -1 {
-				os.Exit(code)
-			}
-		}
-		log.Fatalf("Failed to run bun: %v", err)
-	}
+	runChild(webCmd, "bun")
 }
 
 // lockStampName is the file inside node_modules recording the sha256 of the

--- a/tools/ods/internal/coverage/baseline.go
+++ b/tools/ods/internal/coverage/baseline.go
@@ -1,0 +1,96 @@
+package coverage
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// BaselineFile is the name of the committed baseline, kept at the root of the
+// module it describes.
+const BaselineFile = ".coverage-baseline.yaml"
+
+// baselineHeader is written above the generated content so a reader of the file
+// knows how it is maintained.
+const baselineHeader = `# Minimum statement coverage per package, in percent.
+#
+# ` + "`ods coverage <suite> --check`" + ` fails when a package drops below its floor,
+# which is how CI keeps coverage from regressing. Raise the floors after adding
+# tests with ` + "`ods coverage <suite> --update`" + `.
+#
+# Generated file: do not edit by hand.
+`
+
+// Baseline is the committed coverage floor for a module.
+type Baseline struct {
+	// Total is the floor for the module as a whole.
+	Total float64 `yaml:"total"`
+	// Packages maps a module-relative package path to its floor.
+	Packages map[string]float64 `yaml:"packages"`
+}
+
+// BaselinePath returns the baseline path for a module directory.
+func BaselinePath(moduleDir string) string {
+	return filepath.Join(moduleDir, BaselineFile)
+}
+
+// LoadBaseline reads a baseline from disk.
+func LoadBaseline(path string) (*Baseline, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var baseline Baseline
+	if err := yaml.Unmarshal(data, &baseline); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if baseline.Packages == nil {
+		baseline.Packages = map[string]float64{}
+	}
+	return &baseline, nil
+}
+
+// NewBaseline builds a baseline from a measured profile. Every percentage is
+// rounded down to one decimal, so a floor is never above what the run actually
+// achieved and re-running the same tests cannot fail the check.
+func NewBaseline(profile *Profile) *Baseline {
+	baseline := &Baseline{
+		Total:    floorPercent(profile.Total()),
+		Packages: make(map[string]float64, len(profile.Packages)),
+	}
+	for _, pkg := range profile.Packages {
+		baseline.Packages[pkg.Package] = floorPercent(pkg.Percent())
+	}
+	return baseline
+}
+
+// Save writes the baseline to disk. yaml.v3 sorts map keys, so the output is
+// stable across runs and diffs stay readable.
+func (b *Baseline) Save(path string) error {
+	var body bytes.Buffer
+	body.WriteString(baselineHeader)
+
+	encoder := yaml.NewEncoder(&body)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(b); err != nil {
+		return fmt.Errorf("encode baseline: %w", err)
+	}
+	if err := encoder.Close(); err != nil {
+		return fmt.Errorf("encode baseline: %w", err)
+	}
+
+	if err := os.WriteFile(path, body.Bytes(), 0644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// floorPercent rounds a percentage down to one decimal place.
+func floorPercent(percent float64) float64 {
+	return math.Floor(percent*10) / 10
+}

--- a/tools/ods/internal/coverage/baseline_test.go
+++ b/tools/ods/internal/coverage/baseline_test.go
@@ -1,0 +1,111 @@
+package coverage
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewBaseline_roundsFloorsDown(t *testing.T) {
+	// 2/3 is 66.66...%, which must not become a 66.7% floor the same run
+	// would then fail against.
+	baseline := NewBaseline(profileOf(map[string][2]int{"cmd": {2, 3}}))
+
+	if got := baseline.Packages["cmd"]; got != 66.6 {
+		t.Fatalf("expected a 66.6 floor, got %v", got)
+	}
+}
+
+// The floor a run records must always pass a check of that same run.
+func TestNewBaseline_isSelfConsistent(t *testing.T) {
+	profile := profileOf(map[string][2]int{
+		"cmd":            {2, 3},
+		"internal/audit": {1, 7},
+		"internal/empty": {0, 0},
+	})
+
+	report := Compare(profile, NewBaseline(profile), 0)
+
+	if got := len(report.Regressions()); got != 0 {
+		t.Fatalf("a fresh baseline must not fail its own run, got %d regressions", got)
+	}
+}
+
+func TestBaseline_saveAndLoadRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), BaselineFile)
+	original := NewBaseline(profileOf(map[string][2]int{"cmd": {1, 4}, "internal/audit": {1, 2}}))
+
+	if err := original.Save(path); err != nil {
+		t.Fatalf("failed to save the baseline: %v", err)
+	}
+	loaded, err := LoadBaseline(path)
+	if err != nil {
+		t.Fatalf("failed to load the baseline: %v", err)
+	}
+
+	if loaded.Total != original.Total {
+		t.Fatalf("expected total %v, got %v", original.Total, loaded.Total)
+	}
+	if len(loaded.Packages) != len(original.Packages) {
+		t.Fatalf("expected %d packages, got %d", len(original.Packages), len(loaded.Packages))
+	}
+	for name, floor := range original.Packages {
+		if loaded.Packages[name] != floor {
+			t.Fatalf("expected %s at %v, got %v", name, floor, loaded.Packages[name])
+		}
+	}
+}
+
+func TestBaseline_saveIsDeterministic(t *testing.T) {
+	dir := t.TempDir()
+	baseline := NewBaseline(profileOf(map[string][2]int{
+		"cmd": {1, 4}, "internal/audit": {1, 2}, "internal/tui": {3, 4},
+	}))
+
+	first := filepath.Join(dir, "first.yaml")
+	second := filepath.Join(dir, "second.yaml")
+	if err := baseline.Save(first); err != nil {
+		t.Fatalf("failed to save the baseline: %v", err)
+	}
+	if err := baseline.Save(second); err != nil {
+		t.Fatalf("failed to save the baseline: %v", err)
+	}
+
+	// A baseline that reorders between runs would show up as a diff on every
+	// update, so key order has to be stable.
+	firstData := readFile(t, first)
+	if firstData != readFile(t, second) {
+		t.Fatal("expected two saves of the same baseline to be byte-identical")
+	}
+	if !strings.Contains(firstData, "# Minimum statement coverage") {
+		t.Fatalf("expected the explanatory header, got:\n%s", firstData)
+	}
+}
+
+func TestLoadBaseline_missingFileReportsNotExist(t *testing.T) {
+	_, err := LoadBaseline(filepath.Join(t.TempDir(), BaselineFile))
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected a not-exist error, got %v", err)
+	}
+}
+
+func TestLoadBaseline_rejectsMalformedYAML(t *testing.T) {
+	path := filepath.Join(t.TempDir(), BaselineFile)
+	if err := os.WriteFile(path, []byte("total: [not a number\n"), 0644); err != nil {
+		t.Fatalf("failed to write the fixture: %v", err)
+	}
+
+	if _, err := LoadBaseline(path); err == nil {
+		t.Fatal("expected an error for malformed YAML")
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+	return string(data)
+}

--- a/tools/ods/internal/coverage/check.go
+++ b/tools/ods/internal/coverage/check.go
@@ -1,0 +1,133 @@
+package coverage
+
+import "sort"
+
+// DefaultTolerance is how far below its floor a package may sit without failing
+// the check, in percentage points. Statement coverage is deterministic for
+// deterministic tests, but a few suites depend on ports or timing, so a small
+// allowance keeps the gate from flagging noise as a regression.
+const DefaultTolerance = 0.1
+
+// Status is the verdict for one package.
+type Status string
+
+const (
+	// StatusOK means coverage held at or above the floor.
+	StatusOK Status = "ok"
+	// StatusImproved means coverage rose above the floor, so the baseline is
+	// now stale and can be raised.
+	StatusImproved Status = "improved"
+	// StatusRegressed means coverage fell below the floor. This fails the check.
+	StatusRegressed Status = "regressed"
+	// StatusNew means the package has no floor yet.
+	StatusNew Status = "new"
+	// StatusRemoved means the baseline names a package the run did not report.
+	StatusRemoved Status = "removed"
+)
+
+// Result is the comparison of one package against its floor.
+type Result struct {
+	// Package is the module-relative package path, or "total" for the module.
+	Package string
+	// Percent is the coverage measured by this run. It is meaningless when
+	// Status is StatusRemoved.
+	Percent float64
+	// Floor is the baseline value. It is meaningless when Status is StatusNew.
+	Floor  float64
+	Status Status
+}
+
+// Report is the outcome of comparing a profile against a baseline.
+type Report struct {
+	// Total compares the module as a whole.
+	Total Result
+	// Packages compares each package, sorted by package path.
+	Packages []Result
+	// Tolerance is the allowance the comparison used, in percentage points.
+	Tolerance float64
+}
+
+// Compare checks a measured profile against a baseline. A nil baseline reports
+// every package as new, which is what a first run sees.
+func Compare(profile *Profile, baseline *Baseline, tolerance float64) *Report {
+	report := &Report{
+		Packages:  make([]Result, 0, len(profile.Packages)),
+		Tolerance: tolerance,
+	}
+
+	if baseline == nil {
+		baseline = &Baseline{Packages: map[string]float64{}}
+		report.Total = Result{Package: "total", Percent: profile.Total(), Status: StatusNew}
+	} else {
+		report.Total = compareOne("total", profile.Total(), baseline.Total, true, tolerance)
+	}
+
+	seen := make(map[string]bool, len(profile.Packages))
+	for _, pkg := range profile.Packages {
+		seen[pkg.Package] = true
+		floor, hasFloor := baseline.Packages[pkg.Package]
+		report.Packages = append(report.Packages, compareOne(pkg.Package, pkg.Percent(), floor, hasFloor, tolerance))
+	}
+
+	// A package in the baseline but not in the run was deleted or renamed.
+	// Report it so the stale row gets cleaned up, but do not fail on it.
+	for name, floor := range baseline.Packages {
+		if !seen[name] {
+			report.Packages = append(report.Packages, Result{
+				Package: name,
+				Floor:   floor,
+				Status:  StatusRemoved,
+			})
+		}
+	}
+
+	sort.Slice(report.Packages, func(i, j int) bool {
+		return report.Packages[i].Package < report.Packages[j].Package
+	})
+	return report
+}
+
+func compareOne(name string, percent, floor float64, hasFloor bool, tolerance float64) Result {
+	result := Result{Package: name, Percent: percent, Floor: floor}
+	switch {
+	case !hasFloor:
+		result.Status = StatusNew
+	case percent < floor-tolerance:
+		result.Status = StatusRegressed
+	case percent > floor+tolerance:
+		result.Status = StatusImproved
+	default:
+		result.Status = StatusOK
+	}
+	return result
+}
+
+// Regressions returns the packages that fell below their floor, plus the module
+// total when it regressed. An empty result means the check passes.
+func (r *Report) Regressions() []Result {
+	var out []Result
+	if r.Total.Status == StatusRegressed {
+		out = append(out, r.Total)
+	}
+	for _, pkg := range r.Packages {
+		if pkg.Status == StatusRegressed {
+			out = append(out, pkg)
+		}
+	}
+	return out
+}
+
+// Improvements returns the packages that rose above their floor, plus the
+// module total when it improved. These are what `--update` would record.
+func (r *Report) Improvements() []Result {
+	var out []Result
+	if r.Total.Status == StatusImproved {
+		out = append(out, r.Total)
+	}
+	for _, pkg := range r.Packages {
+		if pkg.Status == StatusImproved {
+			out = append(out, pkg)
+		}
+	}
+	return out
+}

--- a/tools/ods/internal/coverage/check_test.go
+++ b/tools/ods/internal/coverage/check_test.go
@@ -1,0 +1,130 @@
+package coverage
+
+import "testing"
+
+func profileOf(percents map[string][2]int) *Profile {
+	profile := &Profile{}
+	for name, counts := range percents {
+		profile.Packages = append(profile.Packages, PackageCoverage{
+			Package: name,
+			Covered: counts[0],
+			Total:   counts[1],
+		})
+	}
+	return profile
+}
+
+func statusOf(t *testing.T, report *Report, pkg string) Status {
+	t.Helper()
+	for _, result := range report.Packages {
+		if result.Package == pkg {
+			return result.Status
+		}
+	}
+	t.Fatalf("package %q missing from the report", pkg)
+	return ""
+}
+
+func TestCompare_regressionBelowFloor(t *testing.T) {
+	profile := profileOf(map[string][2]int{"cmd": {1, 4}}) // 25%
+	baseline := &Baseline{Total: 50, Packages: map[string]float64{"cmd": 50}}
+
+	report := Compare(profile, baseline, DefaultTolerance)
+
+	if got := statusOf(t, report, "cmd"); got != StatusRegressed {
+		t.Fatalf("expected a regression, got %q", got)
+	}
+	if got := len(report.Regressions()); got != 2 {
+		t.Fatalf("expected the package and the total to regress, got %d", got)
+	}
+}
+
+func TestCompare_holdingAtTheFloorPasses(t *testing.T) {
+	profile := profileOf(map[string][2]int{"cmd": {1, 2}}) // 50%
+	baseline := &Baseline{Total: 50, Packages: map[string]float64{"cmd": 50}}
+
+	report := Compare(profile, baseline, DefaultTolerance)
+
+	if got := statusOf(t, report, "cmd"); got != StatusOK {
+		t.Fatalf("expected ok, got %q", got)
+	}
+	if got := len(report.Regressions()); got != 0 {
+		t.Fatalf("expected no regressions, got %d", got)
+	}
+}
+
+// A drop inside the tolerance is noise, not a regression, so it must not fail
+// the gate.
+func TestCompare_dropInsideToleranceIsNotARegression(t *testing.T) {
+	profile := profileOf(map[string][2]int{"cmd": {999, 1000}}) // 99.9%
+	baseline := &Baseline{Total: 99.9, Packages: map[string]float64{"cmd": 100}}
+
+	report := Compare(profile, baseline, DefaultTolerance)
+
+	if got := statusOf(t, report, "cmd"); got != StatusOK {
+		t.Fatalf("expected the 0.1 drop tolerated, got %q", got)
+	}
+}
+
+func TestCompare_improvementIsReported(t *testing.T) {
+	profile := profileOf(map[string][2]int{"cmd": {3, 4}}) // 75%
+	baseline := &Baseline{Total: 50, Packages: map[string]float64{"cmd": 50}}
+
+	report := Compare(profile, baseline, DefaultTolerance)
+
+	if got := statusOf(t, report, "cmd"); got != StatusImproved {
+		t.Fatalf("expected an improvement, got %q", got)
+	}
+	if got := len(report.Improvements()); got != 2 {
+		t.Fatalf("expected the package and the total to improve, got %d", got)
+	}
+	if got := len(report.Regressions()); got != 0 {
+		t.Fatalf("an improvement must not fail the check, got %d regressions", got)
+	}
+}
+
+// A package added without tests has no floor. It is reported so it gets a floor,
+// but it cannot fail a check it was never measured for.
+func TestCompare_newPackageDoesNotFail(t *testing.T) {
+	profile := profileOf(map[string][2]int{"internal/new": {0, 10}})
+	baseline := &Baseline{Total: 0, Packages: map[string]float64{}}
+
+	report := Compare(profile, baseline, DefaultTolerance)
+
+	if got := statusOf(t, report, "internal/new"); got != StatusNew {
+		t.Fatalf("expected new, got %q", got)
+	}
+	if got := len(report.Regressions()); got != 0 {
+		t.Fatalf("expected no regressions, got %d", got)
+	}
+}
+
+func TestCompare_removedPackageIsReportedNotFailed(t *testing.T) {
+	profile := profileOf(map[string][2]int{"cmd": {1, 2}})
+	baseline := &Baseline{Total: 50, Packages: map[string]float64{"cmd": 50, "internal/gone": 90}}
+
+	report := Compare(profile, baseline, DefaultTolerance)
+
+	if got := statusOf(t, report, "internal/gone"); got != StatusRemoved {
+		t.Fatalf("expected removed, got %q", got)
+	}
+	if got := len(report.Regressions()); got != 0 {
+		t.Fatalf("a deleted package must not fail the check, got %d", got)
+	}
+}
+
+func TestCompare_noBaselineMarksEverythingNew(t *testing.T) {
+	profile := profileOf(map[string][2]int{"cmd": {1, 2}})
+
+	report := Compare(profile, nil, DefaultTolerance)
+
+	if got := statusOf(t, report, "cmd"); got != StatusNew {
+		t.Fatalf("expected new, got %q", got)
+	}
+	if report.Total.Status != StatusNew {
+		t.Fatalf("expected the total new, got %q", report.Total.Status)
+	}
+	if got := len(report.Regressions()); got != 0 {
+		t.Fatalf("expected no regressions, got %d", got)
+	}
+}

--- a/tools/ods/internal/coverage/profile.go
+++ b/tools/ods/internal/coverage/profile.go
@@ -1,0 +1,170 @@
+// Package coverage measures Go statement coverage per package and compares it
+// against a committed baseline, so test coverage can only go up.
+package coverage
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// PackageCoverage holds the statement counts for one package.
+type PackageCoverage struct {
+	// Package is the package path relative to the module root, e.g.
+	// "internal/audit". The module root itself is ".".
+	Package string
+	// Covered is the number of statements run at least once.
+	Covered int
+	// Total is the number of statements in the package.
+	Total int
+}
+
+// Percent returns the covered fraction as a percentage. A package with no
+// statements counts as fully covered, matching `go tool cover`.
+func (p PackageCoverage) Percent() float64 {
+	if p.Total == 0 {
+		return 100
+	}
+	return float64(p.Covered) / float64(p.Total) * 100
+}
+
+// Profile is the parsed result of a `go test -coverprofile` run.
+type Profile struct {
+	// Packages is sorted by package path.
+	Packages []PackageCoverage
+}
+
+// Total returns the coverage percentage across every package.
+func (p Profile) Total() float64 {
+	var covered, total int
+	for _, pkg := range p.Packages {
+		covered += pkg.Covered
+		total += pkg.Total
+	}
+	if total == 0 {
+		return 100
+	}
+	return float64(covered) / float64(total) * 100
+}
+
+// block identifies one coverage block. The same block can appear more than once
+// in a profile, so blocks are merged by this key before counting.
+type block struct {
+	pkg  string
+	span string
+}
+
+// ParseProfile reads a coverage profile and aggregates it per package. Package
+// paths are made relative to modulePath.
+//
+// Profile lines look like:
+//
+//	example.com/m/internal/audit/osv.go:25.64,27.42 2 0
+//
+// which is <file>:<startLine>.<startCol>,<endLine>.<endCol> <statements> <count>.
+func ParseProfile(r io.Reader, modulePath string) (*Profile, error) {
+	counts := make(map[block]int)
+	stmts := make(map[block]int)
+
+	scanner := bufio.NewScanner(r)
+	// Coverage lines are short, but raise the limit so a long import path
+	// cannot truncate a profile into a wrong number.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for lineNo := 1; scanner.Scan(); lineNo++ {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "mode:") {
+			continue
+		}
+
+		b, numStmts, count, err := parseProfileLine(line, modulePath)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", lineNo, err)
+		}
+
+		stmts[b] = numStmts
+		counts[b] += count
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read coverage profile: %w", err)
+	}
+
+	byPkg := make(map[string]*PackageCoverage)
+	for b, numStmts := range stmts {
+		pkg, ok := byPkg[b.pkg]
+		if !ok {
+			pkg = &PackageCoverage{Package: b.pkg}
+			byPkg[b.pkg] = pkg
+		}
+		pkg.Total += numStmts
+		if counts[b] > 0 {
+			pkg.Covered += numStmts
+		}
+	}
+
+	profile := &Profile{Packages: make([]PackageCoverage, 0, len(byPkg))}
+	for _, pkg := range byPkg {
+		profile.Packages = append(profile.Packages, *pkg)
+	}
+	sort.Slice(profile.Packages, func(i, j int) bool {
+		return profile.Packages[i].Package < profile.Packages[j].Package
+	})
+	return profile, nil
+}
+
+// ParseProfileFile parses the coverage profile at the given path.
+func ParseProfileFile(profilePath, modulePath string) (*Profile, error) {
+	f, err := os.Open(profilePath)
+	if err != nil {
+		return nil, fmt.Errorf("open coverage profile: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	return ParseProfile(f, modulePath)
+}
+
+func parseProfileLine(line, modulePath string) (block, int, int, error) {
+	fields := strings.Fields(line)
+	if len(fields) != 3 {
+		return block{}, 0, 0, fmt.Errorf("expected 3 fields, got %d: %q", len(fields), line)
+	}
+
+	sep := strings.LastIndex(fields[0], ":")
+	if sep < 0 {
+		return block{}, 0, 0, fmt.Errorf("missing block position: %q", line)
+	}
+
+	numStmts, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return block{}, 0, 0, fmt.Errorf("invalid statement count: %q", line)
+	}
+	count, err := strconv.Atoi(fields[2])
+	if err != nil {
+		return block{}, 0, 0, fmt.Errorf("invalid execution count: %q", line)
+	}
+
+	file := fields[0][:sep]
+	return block{
+		pkg:  relativePackage(path.Dir(file), modulePath),
+		span: fields[0],
+	}, numStmts, count, nil
+}
+
+// relativePackage converts a full import path into a path relative to the
+// module root. Paths outside the module are returned unchanged.
+func relativePackage(importPath, modulePath string) string {
+	if modulePath == "" || importPath == modulePath {
+		if importPath == modulePath {
+			return "."
+		}
+		return importPath
+	}
+	if rel, ok := strings.CutPrefix(importPath, modulePath+"/"); ok {
+		return rel
+	}
+	return importPath
+}

--- a/tools/ods/internal/coverage/profile_test.go
+++ b/tools/ods/internal/coverage/profile_test.go
@@ -1,0 +1,111 @@
+package coverage
+
+import (
+	"strings"
+	"testing"
+)
+
+const modulePath = "example.com/m"
+
+func TestParseProfile_aggregatesPerPackage(t *testing.T) {
+	profile := mustParse(t, `mode: set
+example.com/m/internal/audit/osv.go:1.1,2.2 3 1
+example.com/m/internal/audit/report.go:1.1,2.2 1 0
+example.com/m/cmd/root.go:1.1,2.2 4 1
+`)
+
+	if len(profile.Packages) != 2 {
+		t.Fatalf("expected 2 packages, got %d", len(profile.Packages))
+	}
+	// Sorted by package path, so cmd comes first.
+	if got := profile.Packages[0].Package; got != "cmd" {
+		t.Fatalf("expected cmd first, got %q", got)
+	}
+	if got := profile.Packages[1].Package; got != "internal/audit" {
+		t.Fatalf("expected internal/audit second, got %q", got)
+	}
+
+	audit := profile.Packages[1]
+	if audit.Covered != 3 || audit.Total != 4 {
+		t.Fatalf("expected 3/4 statements, got %d/%d", audit.Covered, audit.Total)
+	}
+	if got := audit.Percent(); got != 75 {
+		t.Fatalf("expected 75%%, got %v", got)
+	}
+}
+
+func TestParseProfile_totalSpansPackages(t *testing.T) {
+	profile := mustParse(t, `mode: set
+example.com/m/cmd/root.go:1.1,2.2 1 1
+example.com/m/internal/audit/osv.go:1.1,2.2 3 0
+`)
+
+	if got := profile.Total(); got != 25 {
+		t.Fatalf("expected 25%%, got %v", got)
+	}
+}
+
+// A block can appear more than once when several test binaries cover the same
+// package. Counting it twice would inflate the total, so blocks merge by span.
+func TestParseProfile_mergesRepeatedBlocks(t *testing.T) {
+	profile := mustParse(t, `mode: set
+example.com/m/cmd/root.go:1.1,2.2 2 0
+example.com/m/cmd/root.go:1.1,2.2 2 1
+`)
+
+	pkg := profile.Packages[0]
+	if pkg.Total != 2 {
+		t.Fatalf("expected the repeated block counted once, got %d statements", pkg.Total)
+	}
+	if pkg.Covered != 2 {
+		t.Fatalf("expected the block covered by the second run, got %d", pkg.Covered)
+	}
+}
+
+func TestParseProfile_moduleRootIsDot(t *testing.T) {
+	profile := mustParse(t, `mode: set
+example.com/m/main.go:1.1,2.2 1 1
+`)
+
+	if got := profile.Packages[0].Package; got != "." {
+		t.Fatalf("expected the module root as %q, got %q", ".", got)
+	}
+}
+
+func TestParseProfile_rejectsMalformedLine(t *testing.T) {
+	_, err := ParseProfile(strings.NewReader("mode: set\nexample.com/m/cmd/root.go:1.1,2.2 2\n"), modulePath)
+	if err == nil {
+		t.Fatal("expected an error for a line with too few fields")
+	}
+	if !strings.Contains(err.Error(), "line 2") {
+		t.Fatalf("expected the line number in the error, got %v", err)
+	}
+}
+
+func TestParseProfile_emptyProfileIsFullyCovered(t *testing.T) {
+	profile := mustParse(t, "mode: set\n")
+
+	if len(profile.Packages) != 0 {
+		t.Fatalf("expected no packages, got %d", len(profile.Packages))
+	}
+	// Matches `go tool cover`, which reports a package with no statements as
+	// covered rather than as a 0% failure.
+	if got := profile.Total(); got != 100 {
+		t.Fatalf("expected 100%%, got %v", got)
+	}
+}
+
+func TestPackageCoverage_percentOfNoStatements(t *testing.T) {
+	if got := (PackageCoverage{}).Percent(); got != 100 {
+		t.Fatalf("expected 100%%, got %v", got)
+	}
+}
+
+func mustParse(t *testing.T, profile string) *Profile {
+	t.Helper()
+	parsed, err := ParseProfile(strings.NewReader(profile), modulePath)
+	if err != nil {
+		t.Fatalf("failed to parse the profile: %v", err)
+	}
+	return parsed
+}

--- a/tools/ods/internal/coverage/report.go
+++ b/tools/ods/internal/coverage/report.go
@@ -1,0 +1,53 @@
+package coverage
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+)
+
+// WriteReport renders a report as an aligned table. Packages with no floor yet
+// show a blank floor column rather than a misleading zero.
+func WriteReport(w io.Writer, report *Report) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+
+	if _, err := fmt.Fprintln(tw, "PACKAGE\tCOVERAGE\tFLOOR\t"); err != nil {
+		return err
+	}
+	for _, pkg := range report.Packages {
+		if err := writeRow(tw, pkg); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprint(tw, strings.Repeat("-", 8)+"\t"+strings.Repeat("-", 8)+"\t"+strings.Repeat("-", 8)+"\t\n"); err != nil {
+		return err
+	}
+	if err := writeRow(tw, report.Total); err != nil {
+		return err
+	}
+
+	return tw.Flush()
+}
+
+func writeRow(w io.Writer, result Result) error {
+	percent := fmt.Sprintf("%.1f%%", result.Percent)
+	floor := fmt.Sprintf("%.1f%%", result.Floor)
+	note := ""
+
+	switch result.Status {
+	case StatusNew:
+		floor = "-"
+		note = "new"
+	case StatusRemoved:
+		percent = "-"
+		note = "removed"
+	case StatusRegressed:
+		note = fmt.Sprintf("REGRESSED by %.1f", result.Floor-result.Percent)
+	case StatusImproved:
+		note = fmt.Sprintf("+%.1f", result.Percent-result.Floor)
+	}
+
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", result.Package, percent, floor, note)
+	return err
+}

--- a/tools/ods/internal/coverage/report_test.go
+++ b/tools/ods/internal/coverage/report_test.go
@@ -1,0 +1,55 @@
+package coverage
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWriteReport_showsEachStatus(t *testing.T) {
+	profile := profileOf(map[string][2]int{
+		"cmd":            {1, 4}, // 25%, below its 50 floor
+		"internal/audit": {3, 4}, // 75%, above its 50 floor
+		"internal/new":   {1, 2}, // no floor
+	})
+	baseline := &Baseline{
+		Total:    50,
+		Packages: map[string]float64{"cmd": 50, "internal/audit": 50, "internal/gone": 90},
+	}
+
+	var out strings.Builder
+	if err := WriteReport(&out, Compare(profile, baseline, DefaultTolerance)); err != nil {
+		t.Fatalf("failed to write the report: %v", err)
+	}
+	report := out.String()
+
+	for _, want := range []string{
+		"PACKAGE", "COVERAGE", "FLOOR",
+		"REGRESSED by 25.0", // cmd
+		"+25.0",             // internal/audit
+		"new",               // internal/new
+		"removed",           // internal/gone
+		"total",
+	} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("expected %q in the report:\n%s", want, report)
+		}
+	}
+}
+
+// A package with no floor must not show a 0.0% floor, which would read as a
+// real threshold rather than an absent one.
+func TestWriteReport_newPackageHasNoFloorValue(t *testing.T) {
+	var out strings.Builder
+	report := Compare(profileOf(map[string][2]int{"internal/new": {1, 3}}), nil, DefaultTolerance)
+	if err := WriteReport(&out, report); err != nil {
+		t.Fatalf("failed to write the report: %v", err)
+	}
+
+	// The only percentage on the row is the measured one; the floor is "-".
+	if got := strings.Count(out.String(), "%"); got != 2 {
+		t.Fatalf("expected one percentage per row, got %d:\n%s", got, out.String())
+	}
+	if !strings.Contains(out.String(), "33.3%") {
+		t.Fatalf("expected the measured coverage:\n%s", out.String())
+	}
+}

--- a/tools/ods/internal/coverage/run.go
+++ b/tools/ods/internal/coverage/run.go
@@ -1,0 +1,97 @@
+package coverage
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ExitError reports that the test run itself failed, carrying the exit code so
+// the caller can hand the underlying tool's result back to the shell.
+type ExitError struct {
+	Code int
+}
+
+func (e *ExitError) Error() string {
+	return fmt.Sprintf("go test exited with code %d", e.Code)
+}
+
+// RunOptions configures a coverage run.
+type RunOptions struct {
+	// ModuleDir is the directory holding the module's go.mod. go test runs
+	// here, which is where its "./..." pattern resolves.
+	ModuleDir string
+	// ProfilePath is where the coverage profile is written.
+	ProfilePath string
+	// Args are extra arguments for go test, such as "-race".
+	Args []string
+	// Stdout and Stderr receive the test output. A nil value discards it.
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// Run executes the module's tests with coverage enabled and parses the profile.
+//
+// Coverage is measured per package with `go test -coverprofile`, so a package's
+// number counts only its own tests. That is the number a package owner can act
+// on; a cross-package `-coverpkg` total would credit a package for statements
+// its own tests never assert on.
+func Run(opts RunOptions) (*Profile, error) {
+	modulePath, err := ModulePath(opts.ModuleDir)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(opts.ProfilePath), 0755); err != nil {
+		return nil, fmt.Errorf("create profile directory: %w", err)
+	}
+
+	args := []string{"test"}
+	args = append(args, opts.Args...)
+	args = append(args, "-coverprofile="+opts.ProfilePath, "./...")
+
+	cmd := exec.Command("go", args...)
+	cmd.Dir = opts.ModuleDir
+	cmd.Stdout = opts.Stdout
+	cmd.Stderr = opts.Stderr
+
+	runErr := cmd.Run()
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) && exitErr.ExitCode() != -1 {
+			return nil, &ExitError{Code: exitErr.ExitCode()}
+		}
+		return nil, fmt.Errorf("run go test: %w", runErr)
+	}
+
+	return ParseProfileFile(opts.ProfilePath, modulePath)
+}
+
+// ModulePath reads the module path from the go.mod in dir. Coverage profiles
+// name packages by full import path; the module path is what turns those into
+// the short, module-relative names used in the baseline.
+func ModulePath(dir string) (string, error) {
+	goMod := filepath.Join(dir, "go.mod")
+	f, err := os.Open(goMod)
+	if err != nil {
+		return "", fmt.Errorf("open %s: %w", goMod, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if path, ok := strings.CutPrefix(line, "module "); ok {
+			return strings.TrimSpace(path), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("read %s: %w", goMod, err)
+	}
+	return "", fmt.Errorf("no module declaration in %s", goMod)
+}

--- a/tools/ods/internal/coverage/run_test.go
+++ b/tools/ods/internal/coverage/run_test.go
@@ -1,0 +1,49 @@
+package coverage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeGoMod(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(contents), 0644); err != nil {
+		t.Fatalf("failed to write go.mod: %v", err)
+	}
+	return dir
+}
+
+func TestModulePath_readsTheModuleLine(t *testing.T) {
+	dir := writeGoMod(t, "module example.com/m/tools/ods\n\ngo 1.26.4\n")
+
+	path, err := ModulePath(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "example.com/m/tools/ods" {
+		t.Fatalf("expected the module path, got %q", path)
+	}
+}
+
+func TestModulePath_missingGoMod(t *testing.T) {
+	if _, err := ModulePath(t.TempDir()); err == nil {
+		t.Fatal("expected an error when go.mod is missing")
+	}
+}
+
+func TestModulePath_noModuleDeclaration(t *testing.T) {
+	dir := writeGoMod(t, "go 1.26.4\n")
+
+	if _, err := ModulePath(dir); err == nil {
+		t.Fatal("expected an error when go.mod declares no module")
+	}
+}
+
+func TestExitError_reportsTheCode(t *testing.T) {
+	err := &ExitError{Code: 2}
+	if got := err.Error(); got != "go test exited with code 2" {
+		t.Fatalf("unexpected message: %q", got)
+	}
+}

--- a/tools/ods/internal/testsuite/testsuite.go
+++ b/tools/ods/internal/testsuite/testsuite.go
@@ -299,6 +299,12 @@ func relocateArg(root, cwd string, suite *Suite, arg string) []string {
 	}
 	repoPath, ok := repoRelative(root, cwd, arg)
 	if !ok {
+		// The path may still be relative to the suite directory, which is
+		// where the runner starts. pytest and jest read it that way on their
+		// own; go test needs a "./" prefix, so shape it here.
+		if rel, ok := suiteRelative(root, suite, arg); ok {
+			return runnerTarget(root, suite, rel)
+		}
 		return []string{arg}
 	}
 	// A path outside this suite is left alone, so the runner reports it
@@ -311,6 +317,19 @@ func relocateArg(root, cwd string, suite *Suite, arg string) []string {
 		return []string{arg}
 	}
 	return runnerTarget(root, suite, path(rel))
+}
+
+// suiteRelative reports whether arg names a path inside the suite's working
+// directory, and returns it relative to that directory. Any node id is kept.
+func suiteRelative(root string, suite *Suite, arg string) (string, bool) {
+	filePart := stripNodeID(arg)
+	if filePart == "" || filepath.IsAbs(filePart) {
+		return "", false
+	}
+	if _, err := os.Stat(filepath.Join(root, suite.Dir, filePart)); err != nil {
+		return "", false
+	}
+	return path(filePart) + arg[len(filePart):], true
 }
 
 // suiteForPath returns the suite whose prefix is the longest match for a

--- a/tools/ods/internal/testsuite/testsuite.go
+++ b/tools/ods/internal/testsuite/testsuite.go
@@ -1,0 +1,312 @@
+// Package testsuite maps a suite name or a file path onto the test runner that
+// knows how to execute it. The repo has four runners (pytest, jest for web,
+// jest for mobile, playwright) with different working directories and
+// arguments; this package holds the routing table and the pure logic that
+// picks an entry from it.
+package testsuite
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Runner identifies the tool that executes a suite.
+type Runner string
+
+const (
+	RunnerPytest     Runner = "pytest"
+	RunnerJest       Runner = "jest"
+	RunnerPlaywright Runner = "playwright"
+)
+
+// ErrNoArgs is returned when no suite or path was given.
+var ErrNoArgs = errors.New("no suite or path given")
+
+// Suite describes one test suite and how to run it.
+type Suite struct {
+	// Name is the canonical name accepted on the command line.
+	Name string
+	// Aliases are alternate names accepted on the command line.
+	Aliases []string
+	// Runner is the tool that executes this suite.
+	Runner Runner
+	// Dir is the working directory for the runner, relative to the git root.
+	Dir string
+	// Target is the suite's root test path, relative to Dir. It doubles as
+	// the default argument for pytest and as the prefix used to infer the
+	// suite from a path.
+	Target string
+	// NeedsBackendEnv marks suites that need credentials from .vscode/.env.
+	NeedsBackendEnv bool
+	// DefaultArgs are passed to the runner before any user arguments, so a
+	// user argument for the same option still wins.
+	DefaultArgs []string
+	// Short is the one-line description shown in help output.
+	Short string
+}
+
+// Prefix returns the suite's test path relative to the git root.
+func (s *Suite) Prefix() string {
+	return path(s.Dir, s.Target)
+}
+
+// suites is the routing table. Order here is the order shown in help.
+var suites = []Suite{
+	{
+		Name:    "unit",
+		Aliases: []string{"u"},
+		Runner:  RunnerPytest,
+		Dir:     "backend",
+		Target:  "tests/unit",
+		Short:   "Backend unit tests (no services needed)",
+	},
+	{
+		Name:            "external",
+		Aliases:         []string{"edu", "ext"},
+		Runner:          RunnerPytest,
+		Dir:             "backend",
+		Target:          "tests/external_dependency_unit",
+		NeedsBackendEnv: true,
+		// Match CI, which leaves nightly-only tests to the nightly workflow.
+		DefaultArgs: []string{"-m", "not nightly"},
+		Short:       "External dependency unit tests (needs Postgres, Redis, OpenSearch, MinIO)",
+	},
+	{
+		Name:            "integration",
+		Aliases:         []string{"int"},
+		Runner:          RunnerPytest,
+		Dir:             "backend",
+		Target:          "tests/integration",
+		NeedsBackendEnv: true,
+		Short:           "Backend integration tests (needs a full Onyx deployment)",
+	},
+	{
+		Name:    "web",
+		Aliases: []string{"jest"},
+		Runner:  RunnerJest,
+		Dir:     "web",
+		Short:   "Web unit and component tests (jest)",
+	},
+	{
+		Name:    "e2e",
+		Aliases: []string{"playwright", "pw"},
+		Runner:  RunnerPlaywright,
+		Dir:     "web",
+		Target:  "tests/e2e",
+		Short:   "Web end-to-end tests (needs a full Onyx deployment)",
+	},
+	{
+		Name:   "mobile",
+		Runner: RunnerJest,
+		Dir:    "mobile",
+		Short:  "Mobile tests (jest-expo)",
+	},
+	{
+		Name:            "backend",
+		Aliases:         []string{"py"},
+		Runner:          RunnerPytest,
+		Dir:             "backend",
+		Target:          "tests",
+		NeedsBackendEnv: true,
+		Short:           "Any other backend/tests path (daily, regression, api, ...)",
+	},
+}
+
+// All returns every suite, in help order.
+func All() []Suite {
+	out := make([]Suite, len(suites))
+	copy(out, suites)
+	return out
+}
+
+// Names returns every accepted suite name, without aliases, in help order.
+func Names() []string {
+	names := make([]string, 0, len(suites))
+	for i := range suites {
+		names = append(names, suites[i].Name)
+	}
+	return names
+}
+
+// byName looks up a suite by its canonical name or one of its aliases.
+func byName(name string) *Suite {
+	for i := range suites {
+		if suites[i].Name == name {
+			return &suites[i]
+		}
+		for _, alias := range suites[i].Aliases {
+			if alias == name {
+				return &suites[i]
+			}
+		}
+	}
+	return nil
+}
+
+// Resolve picks the suite for args. The first argument is either a suite name,
+// an alias, or a path inside a suite. Paths are rewritten relative to the
+// suite's working directory, which is where the runner is started, and the
+// remaining arguments pass through untouched.
+//
+// root is the git root. cwd is the caller's working directory, so that a path
+// typed relative to it (for example inside backend/) resolves correctly.
+func Resolve(root, cwd string, args []string) (*Suite, []string, error) {
+	if len(args) == 0 {
+		return nil, nil, ErrNoArgs
+	}
+
+	first := args[0]
+
+	if suite := byName(first); suite != nil {
+		return suite, relocate(root, cwd, suite, args[1:]), nil
+	}
+
+	repoPath, ok := repoRelative(root, cwd, first)
+	if !ok {
+		return nil, nil, fmt.Errorf("%q is neither a suite name nor an existing path (suites: %s)",
+			first, strings.Join(Names(), ", "))
+	}
+
+	suite := suiteForPath(repoPath)
+	if suite == nil {
+		return nil, nil, fmt.Errorf("no test suite covers %q (suites: %s)",
+			first, strings.Join(Names(), ", "))
+	}
+
+	target, err := filepath.Rel(suite.Dir, repoPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to place %q inside %s: %w", first, suite.Dir, err)
+	}
+
+	// The first argument is always rewritten: it is known to be a target, so
+	// the bare-word caution that applies to later arguments is not needed.
+	rest := relocate(root, cwd, suite, args[1:])
+	return suite, append([]string{path(target)}, rest...), nil
+}
+
+// relocate rewrites arguments that name an existing path into paths relative
+// to the suite's working directory, which is where the runner starts.
+// Everything else — flags, their values, playwright test-name filters — passes
+// through untouched.
+func relocate(root, cwd string, suite *Suite, args []string) []string {
+	out := make([]string, 0, len(args))
+	for _, arg := range args {
+		out = append(out, relocateArg(root, cwd, suite, arg))
+	}
+	return out
+}
+
+func relocateArg(root, cwd string, suite *Suite, arg string) string {
+	if !looksLikePath(arg) {
+		return arg
+	}
+	repoPath, ok := repoRelative(root, cwd, arg)
+	if !ok {
+		return arg
+	}
+	// A path outside this suite is left alone, so the runner reports it
+	// rather than us silently pointing somewhere else.
+	if !underPrefix(stripNodeID(repoPath), suite.Dir) {
+		return arg
+	}
+	rel, err := filepath.Rel(suite.Dir, repoPath)
+	if err != nil {
+		return arg
+	}
+	return path(rel)
+}
+
+// suiteForPath returns the suite whose prefix is the longest match for a
+// repo-relative path. Longest wins so that web/tests/e2e resolves to the e2e
+// suite rather than to web.
+func suiteForPath(repoPath string) *Suite {
+	matches := make([]*Suite, 0, 2)
+	for i := range suites {
+		if underPrefix(repoPath, suites[i].Prefix()) {
+			matches = append(matches, &suites[i])
+		}
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+	sort.SliceStable(matches, func(a, b int) bool {
+		return len(matches[a].Prefix()) > len(matches[b].Prefix())
+	})
+	return matches[0]
+}
+
+// underPrefix reports whether repoPath is prefix itself or sits below it.
+func underPrefix(repoPath, prefix string) bool {
+	return repoPath == prefix || strings.HasPrefix(repoPath, prefix+"/")
+}
+
+// repoRelative turns a user-supplied path into a slash-separated path relative
+// to the git root, reporting false when it does not point at anything real.
+// The path is tried against the working directory first, then against the git
+// root, so both "tests/unit" from inside backend/ and "backend/tests/unit"
+// from anywhere work.
+func repoRelative(root, cwd, arg string) (string, bool) {
+	filePart := stripNodeID(arg)
+	if filePart == "" {
+		return "", false
+	}
+
+	candidates := []string{}
+	if filepath.IsAbs(filePart) {
+		candidates = append(candidates, filePart)
+	} else {
+		candidates = append(candidates,
+			filepath.Join(cwd, filePart),
+			filepath.Join(root, filePart),
+		)
+	}
+
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(root, candidate)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			continue
+		}
+		// Re-attach the node id, if any, now that the file part is anchored.
+		rel = path(rel) + arg[len(filePart):]
+		return rel, true
+	}
+	return "", false
+}
+
+// looksLikePath reports whether an argument is shaped like a path worth
+// rewriting: it has more than one segment, or carries a pytest node id.
+//
+// A single bare word is deliberately excluded even when a file by that name
+// exists. Such a word is far more often a flag value (`-k web`, a playwright
+// test-name filter) than a target, and when it really is a target it is
+// already relative to the caller's directory, so rewriting it would only
+// change a path that already works.
+func looksLikePath(arg string) bool {
+	if strings.HasPrefix(arg, "-") {
+		return false
+	}
+	return strings.ContainsAny(arg, `/\`) || strings.Contains(arg, "::")
+}
+
+// stripNodeID drops the trailing "::test_name" of a pytest node id, leaving
+// the part that exists on disk.
+func stripNodeID(arg string) string {
+	if idx := strings.Index(arg, "::"); idx >= 0 {
+		return arg[:idx]
+	}
+	return arg
+}
+
+// path joins segments and normalizes to forward slashes, which is what both
+// the runners and the prefix table expect.
+func path(segments ...string) string {
+	joined := filepath.Join(segments...)
+	return filepath.ToSlash(joined)
+}

--- a/tools/ods/internal/testsuite/testsuite.go
+++ b/tools/ods/internal/testsuite/testsuite.go
@@ -1,8 +1,7 @@
 // Package testsuite maps a suite name or a file path onto the test runner that
-// knows how to execute it. The repo has four runners (pytest, jest for web,
-// jest for mobile, playwright) with different working directories and
-// arguments; this package holds the routing table and the pure logic that
-// picks an entry from it.
+// knows how to execute it. The repo has four runners (pytest, jest, playwright,
+// go test) with different working directories and arguments; this package holds
+// the routing table and the pure logic that picks an entry from it.
 package testsuite
 
 import (
@@ -21,6 +20,7 @@ const (
 	RunnerPytest     Runner = "pytest"
 	RunnerJest       Runner = "jest"
 	RunnerPlaywright Runner = "playwright"
+	RunnerGo         Runner = "go"
 )
 
 // ErrNoArgs is returned when no suite or path was given.
@@ -127,6 +127,32 @@ var suites = []Suite{
 		Short:  "Mobile tests (jest-expo)",
 	},
 	{
+		Name:    "ods",
+		Runner:  RunnerGo,
+		Dir:     "tools/ods",
+		Default: "./...",
+		// -race matches pr-golang-tests.yml, which runs every Go module.
+		DefaultArgs: []string{"-race"},
+		Short:       "Tests for this tool (go)",
+	},
+	{
+		Name:        "cli",
+		Runner:      RunnerGo,
+		Dir:         "cli",
+		Default:     "./...",
+		DefaultArgs: []string{"-race"},
+		Short:       "Onyx CLI tests (go)",
+	},
+	{
+		Name:        "terraform",
+		Aliases:     []string{"tf"},
+		Runner:      RunnerGo,
+		Dir:         "terraform-provider-onyx",
+		Default:     "./...",
+		DefaultArgs: []string{"-race"},
+		Short:       "Terraform provider tests (go)",
+	},
+	{
 		Name:            "backend",
 		Aliases:         []string{"py"},
 		Runner:          RunnerPytest,
@@ -206,7 +232,37 @@ func Resolve(root, cwd string, args []string) (*Suite, []string, error) {
 	// The first argument is always rewritten: it is known to be a target, so
 	// the bare-word caution that applies to later arguments is not needed.
 	rest := relocate(root, cwd, suite, args[1:])
-	return suite, append([]string{path(target)}, rest...), nil
+	return suite, append(runnerTarget(root, suite, path(target)), rest...), nil
+}
+
+// runnerTarget shapes a suite-relative path into what the runner accepts.
+// pytest, jest, and playwright all take paths. go test takes packages, so a
+// file becomes the directory that holds it, and a node id becomes a -run
+// filter, which keeps "<file>::<test>" working across every suite.
+func runnerTarget(root string, suite *Suite, rel string) []string {
+	if suite.Runner != RunnerGo {
+		return []string{rel}
+	}
+
+	file := stripNodeID(rel)
+	pkg := goPackage(root, suite, file)
+	if name := strings.TrimPrefix(rel[len(file):], "::"); name != "" {
+		return []string{pkg, "-run", "^" + name + "$"}
+	}
+	return []string{pkg}
+}
+
+// goPackage turns a suite-relative path into the "./..." pattern go test
+// accepts. Go tests one package at a time, so a file argument runs the package
+// that holds it.
+func goPackage(root string, suite *Suite, rel string) string {
+	if info, err := os.Stat(filepath.Join(root, suite.Dir, rel)); err == nil && !info.IsDir() {
+		rel = filepath.Dir(rel)
+	}
+	if rel == "." || rel == "" {
+		return "./..."
+	}
+	return "./" + path(rel)
 }
 
 // HasTarget reports whether args already name a test target. It takes the
@@ -232,29 +288,29 @@ func HasTarget(args []string) bool {
 func relocate(root, cwd string, suite *Suite, args []string) []string {
 	out := make([]string, 0, len(args))
 	for _, arg := range args {
-		out = append(out, relocateArg(root, cwd, suite, arg))
+		out = append(out, relocateArg(root, cwd, suite, arg)...)
 	}
 	return out
 }
 
-func relocateArg(root, cwd string, suite *Suite, arg string) string {
+func relocateArg(root, cwd string, suite *Suite, arg string) []string {
 	if !looksLikePath(arg) {
-		return arg
+		return []string{arg}
 	}
 	repoPath, ok := repoRelative(root, cwd, arg)
 	if !ok {
-		return arg
+		return []string{arg}
 	}
 	// A path outside this suite is left alone, so the runner reports it
 	// rather than us silently pointing somewhere else.
 	if !underPrefix(stripNodeID(repoPath), suite.Dir) {
-		return arg
+		return []string{arg}
 	}
 	rel, err := filepath.Rel(suite.Dir, repoPath)
 	if err != nil {
-		return arg
+		return []string{arg}
 	}
-	return path(rel)
+	return runnerTarget(root, suite, path(rel))
 }
 
 // suiteForPath returns the suite whose prefix is the longest match for a

--- a/tools/ods/internal/testsuite/testsuite.go
+++ b/tools/ods/internal/testsuite/testsuite.go
@@ -36,10 +36,17 @@ type Suite struct {
 	Runner Runner
 	// Dir is the working directory for the runner, relative to the git root.
 	Dir string
-	// Target is the suite's root test path, relative to Dir. It doubles as
-	// the default argument for pytest and as the prefix used to infer the
-	// suite from a path.
+	// Target is the suite's root test path, relative to Dir. It is the prefix
+	// used to infer the suite from a path, and the default argument for
+	// pytest unless Default overrides it.
 	Target string
+	// Default overrides Target as the argument used when the caller gives no
+	// path. Set it where the suite root holds more than a plain run should
+	// take on.
+	Default string
+	// Caution is a one-line warning printed before the suite runs. Set it
+	// where a run changes state outside the test process.
+	Caution string
 	// NeedsBackendEnv marks suites that need credentials from .vscode/.env.
 	NeedsBackendEnv bool
 	// DefaultArgs are passed to the runner before any user arguments, so a
@@ -52,6 +59,14 @@ type Suite struct {
 // Prefix returns the suite's test path relative to the git root.
 func (s *Suite) Prefix() string {
 	return path(s.Dir, s.Target)
+}
+
+// DefaultTarget returns the path to run when the caller gives no path.
+func (s *Suite) DefaultTarget() string {
+	if s.Default != "" {
+		return s.Default
+	}
+	return s.Target
 }
 
 // suites is the routing table. Order here is the order shown in help.
@@ -76,12 +91,18 @@ var suites = []Suite{
 		Short:       "External dependency unit tests (needs Postgres, Redis, OpenSearch, MinIO)",
 	},
 	{
-		Name:            "integration",
-		Aliases:         []string{"int"},
-		Runner:          RunnerPytest,
-		Dir:             "backend",
-		Target:          "tests/integration",
+		Name:    "integration",
+		Aliases: []string{"int"},
+		Runner:  RunnerPytest,
+		Dir:     "backend",
+		Target:  "tests/integration",
+		// A bare run covers what CI shards. The sibling directories need a
+		// setup of their own — multitenant_tests a multi-tenant deployment,
+		// connector_job_tests connector credentials — so they are reachable
+		// by path but are not part of a plain `ods test integration`.
+		Default:         "tests/integration/tests",
 		NeedsBackendEnv: true,
+		Caution:         "these tests call reset_all(), which wipes Postgres and the file store for this project",
 		Short:           "Backend integration tests (needs a full Onyx deployment)",
 	},
 	{
@@ -186,6 +207,22 @@ func Resolve(root, cwd string, args []string) (*Suite, []string, error) {
 	// the bare-word caution that applies to later arguments is not needed.
 	rest := relocate(root, cwd, suite, args[1:])
 	return suite, append([]string{path(target)}, rest...), nil
+}
+
+// HasTarget reports whether args already name a test target. It takes the
+// suite-relative arguments returned by Resolve, where a target always carries a
+// path separator or a node id.
+//
+// Callers need this because pytest with no target collects from its working
+// directory. For a backend suite that is the whole of backend/, so
+// `ods test unit -k foo` would reach every backend test, integration included.
+func HasTarget(args []string) bool {
+	for _, arg := range args {
+		if looksLikePath(arg) {
+			return true
+		}
+	}
+	return false
 }
 
 // relocate rewrites arguments that name an existing path into paths relative

--- a/tools/ods/internal/testsuite/testsuite_test.go
+++ b/tools/ods/internal/testsuite/testsuite_test.go
@@ -334,3 +334,64 @@ func TestSuitePrefixes(t *testing.T) {
 		}
 	}
 }
+
+func TestHasTarget(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "no args", args: nil, want: false},
+		{name: "flags only", args: []string{"-k", "web"}, want: false},
+		{name: "long flag only", args: []string{"--collect-only"}, want: false},
+		{name: "directory", args: []string{"tests/unit/onyx"}, want: true},
+		{name: "file", args: []string{"tests/unit/onyx/test_foo.py"}, want: true},
+		{name: "node id", args: []string{"tests/unit/test_foo.py::test_bar"}, want: true},
+		{name: "target after a flag", args: []string{"-x", "tests/unit/onyx"}, want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HasTarget(tc.args); got != tc.want {
+				t.Errorf("HasTarget(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSuiteDefaultTargets(t *testing.T) {
+	want := map[string]string{
+		"unit":     "tests/unit",
+		"external": "tests/external_dependency_unit",
+		// Narrower than the prefix: the sibling directories under
+		// tests/integration need a setup a plain run does not provide.
+		"integration": "tests/integration/tests",
+		"web":         "",
+		"e2e":         "tests/e2e",
+		"mobile":      "",
+		"backend":     "tests",
+	}
+	for _, suite := range All() {
+		if got := suite.DefaultTarget(); got != want[suite.Name] {
+			t.Errorf("%s default target = %q, want %q", suite.Name, got, want[suite.Name])
+		}
+	}
+}
+
+// A narrowed default must not narrow inference: a path under a sibling
+// directory still resolves to the suite that owns it.
+func TestResolveReachesPathsOutsideTheDefaultTarget(t *testing.T) {
+	root := newRepo(t, "backend/tests/integration/multitenant_tests/test_tenant.py")
+
+	suite, args, err := Resolve(root, root, []string{"backend/tests/integration/multitenant_tests/test_tenant.py"})
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if suite.Name != "integration" {
+		t.Fatalf("suite = %q, want integration", suite.Name)
+	}
+	want := []string{"tests/integration/multitenant_tests/test_tenant.py"}
+	if len(args) != 1 || args[0] != want[0] {
+		t.Errorf("args = %v, want %v", args, want)
+	}
+}

--- a/tools/ods/internal/testsuite/testsuite_test.go
+++ b/tools/ods/internal/testsuite/testsuite_test.go
@@ -1,0 +1,336 @@
+package testsuite
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// newRepo builds a temp directory holding the paths a caller might name, so
+// Resolve's existence checks have something real to stat.
+func newRepo(t *testing.T, paths ...string) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, p := range paths {
+		full := filepath.Join(root, filepath.FromSlash(p))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func TestResolveByName(t *testing.T) {
+	cases := []struct {
+		arg  string
+		want string
+	}{
+		{"unit", "unit"},
+		{"u", "unit"},
+		{"external", "external"},
+		{"edu", "external"},
+		{"ext", "external"},
+		{"integration", "integration"},
+		{"int", "integration"},
+		{"web", "web"},
+		{"jest", "web"},
+		{"e2e", "e2e"},
+		{"playwright", "e2e"},
+		{"pw", "e2e"},
+		{"mobile", "mobile"},
+		{"backend", "backend"},
+		{"py", "backend"},
+	}
+
+	root := t.TempDir()
+	for _, tc := range cases {
+		t.Run(tc.arg, func(t *testing.T) {
+			suite, rest, err := Resolve(root, root, []string{tc.arg})
+			if err != nil {
+				t.Fatalf("Resolve(%q) failed: %v", tc.arg, err)
+			}
+			if suite.Name != tc.want {
+				t.Fatalf("Resolve(%q) = %q, want %q", tc.arg, suite.Name, tc.want)
+			}
+			if len(rest) != 0 {
+				t.Fatalf("expected no remaining args, got %v", rest)
+			}
+		})
+	}
+}
+
+func TestResolveByPath(t *testing.T) {
+	cases := []struct {
+		name       string
+		file       string
+		arg        string
+		wantSuite  string
+		wantTarget string
+	}{
+		{
+			name:       "backend unit file",
+			file:       "backend/tests/unit/onyx/test_foo.py",
+			arg:        "backend/tests/unit/onyx/test_foo.py",
+			wantSuite:  "unit",
+			wantTarget: "tests/unit/onyx/test_foo.py",
+		},
+		{
+			name:       "backend unit directory",
+			file:       "backend/tests/unit/onyx/test_foo.py",
+			arg:        "backend/tests/unit",
+			wantSuite:  "unit",
+			wantTarget: "tests/unit",
+		},
+		{
+			name:       "external dependency unit",
+			file:       "backend/tests/external_dependency_unit/db/test_bar.py",
+			arg:        "backend/tests/external_dependency_unit/db/test_bar.py",
+			wantSuite:  "external",
+			wantTarget: "tests/external_dependency_unit/db/test_bar.py",
+		},
+		{
+			name:       "integration",
+			file:       "backend/tests/integration/tests/test_baz.py",
+			arg:        "backend/tests/integration/tests/test_baz.py",
+			wantSuite:  "integration",
+			wantTarget: "tests/integration/tests/test_baz.py",
+		},
+		{
+			name:       "other backend path falls back to the backend suite",
+			file:       "backend/tests/daily/connectors/test_daily.py",
+			arg:        "backend/tests/daily/connectors/test_daily.py",
+			wantSuite:  "backend",
+			wantTarget: "tests/daily/connectors/test_daily.py",
+		},
+		{
+			name:       "web source test",
+			file:       "web/src/lib/foo.test.ts",
+			arg:        "web/src/lib/foo.test.ts",
+			wantSuite:  "web",
+			wantTarget: "src/lib/foo.test.ts",
+		},
+		{
+			// The case a plain prefix map gets wrong: web/tests/e2e is also
+			// under web, and the longer prefix has to win.
+			name:       "e2e spec beats the web suite",
+			file:       "web/tests/e2e/chat.spec.ts",
+			arg:        "web/tests/e2e/chat.spec.ts",
+			wantSuite:  "e2e",
+			wantTarget: "tests/e2e/chat.spec.ts",
+		},
+		{
+			name:       "mobile test",
+			file:       "mobile/src/components/__tests__/foo.test.tsx",
+			arg:        "mobile/src/components/__tests__/foo.test.tsx",
+			wantSuite:  "mobile",
+			wantTarget: "src/components/__tests__/foo.test.tsx",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := newRepo(t, tc.file)
+			suite, rest, err := Resolve(root, root, []string{tc.arg})
+			if err != nil {
+				t.Fatalf("Resolve(%q) failed: %v", tc.arg, err)
+			}
+			if suite.Name != tc.wantSuite {
+				t.Fatalf("suite = %q, want %q", suite.Name, tc.wantSuite)
+			}
+			if !reflect.DeepEqual(rest, []string{tc.wantTarget}) {
+				t.Fatalf("args = %v, want [%q]", rest, tc.wantTarget)
+			}
+		})
+	}
+}
+
+func TestResolvePathRelativeToWorkingDirectory(t *testing.T) {
+	root := newRepo(t, "backend/tests/unit/onyx/test_foo.py")
+	cwd := filepath.Join(root, "backend")
+
+	suite, rest, err := Resolve(root, cwd, []string{"tests/unit/onyx/test_foo.py"})
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if suite.Name != "unit" {
+		t.Fatalf("suite = %q, want unit", suite.Name)
+	}
+	if !reflect.DeepEqual(rest, []string{"tests/unit/onyx/test_foo.py"}) {
+		t.Fatalf("args = %v", rest)
+	}
+}
+
+// A bare filename is still a target when it is the suite selector, so it has
+// to be anchored even though the same word would be left alone later in the
+// argument list.
+func TestResolveBareFilenameAsSelector(t *testing.T) {
+	root := newRepo(t, "backend/tests/unit/onyx/test_foo.py")
+	cwd := filepath.Join(root, "backend", "tests", "unit", "onyx")
+
+	suite, rest, err := Resolve(root, cwd, []string{"test_foo.py"})
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if suite.Name != "unit" {
+		t.Fatalf("suite = %q, want unit", suite.Name)
+	}
+	if !reflect.DeepEqual(rest, []string{"tests/unit/onyx/test_foo.py"}) {
+		t.Fatalf("args = %v", rest)
+	}
+}
+
+func TestResolveKeepsPytestNodeID(t *testing.T) {
+	root := newRepo(t, "backend/tests/unit/onyx/test_foo.py")
+
+	suite, rest, err := Resolve(root, root, []string{"backend/tests/unit/onyx/test_foo.py::test_bar"})
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if suite.Name != "unit" {
+		t.Fatalf("suite = %q, want unit", suite.Name)
+	}
+	if !reflect.DeepEqual(rest, []string{"tests/unit/onyx/test_foo.py::test_bar"}) {
+		t.Fatalf("args = %v", rest)
+	}
+}
+
+// A named suite followed by a path is the form most people reach for, and the
+// path still has to be rewritten relative to the suite directory or the runner
+// cannot find it.
+func TestResolveRewritesPathsAfterASuiteName(t *testing.T) {
+	root := newRepo(t,
+		"backend/tests/unit/onyx/test_foo.py",
+		"web/src/lib/foo.test.ts",
+	)
+
+	t.Run("pytest", func(t *testing.T) {
+		suite, rest, err := Resolve(root, root, []string{"unit", "backend/tests/unit/onyx/test_foo.py"})
+		if err != nil {
+			t.Fatalf("Resolve failed: %v", err)
+		}
+		if suite.Name != "unit" {
+			t.Fatalf("suite = %q, want unit", suite.Name)
+		}
+		if !reflect.DeepEqual(rest, []string{"tests/unit/onyx/test_foo.py"}) {
+			t.Fatalf("args = %v", rest)
+		}
+	})
+
+	t.Run("jest", func(t *testing.T) {
+		suite, rest, err := Resolve(root, root, []string{"web", "web/src/lib/foo.test.ts"})
+		if err != nil {
+			t.Fatalf("Resolve failed: %v", err)
+		}
+		if !reflect.DeepEqual(rest, []string{"src/lib/foo.test.ts"}) {
+			t.Fatalf("args = %v", rest)
+		}
+		_ = suite
+	})
+
+	t.Run("flag values are left alone", func(t *testing.T) {
+		_, rest, err := Resolve(root, root, []string{"unit", "-k", "web", "--tb=short"})
+		if err != nil {
+			t.Fatalf("Resolve failed: %v", err)
+		}
+		// "web" is a suite name and a real directory, but as a -k value it
+		// must survive untouched.
+		if !reflect.DeepEqual(rest, []string{"-k", "web", "--tb=short"}) {
+			t.Fatalf("args = %v", rest)
+		}
+	})
+
+	t.Run("several paths after a suite name", func(t *testing.T) {
+		_, rest, err := Resolve(root, root, []string{
+			"unit",
+			"backend/tests/unit/onyx/test_foo.py",
+			"backend/tests/unit/onyx",
+		})
+		if err != nil {
+			t.Fatalf("Resolve failed: %v", err)
+		}
+		want := []string{"tests/unit/onyx/test_foo.py", "tests/unit/onyx"}
+		if !reflect.DeepEqual(rest, want) {
+			t.Fatalf("args = %v, want %v", rest, want)
+		}
+	})
+
+	t.Run("path outside the suite is left for the runner to report", func(t *testing.T) {
+		_, rest, err := Resolve(root, root, []string{"unit", "web/src/lib/foo.test.ts"})
+		if err != nil {
+			t.Fatalf("Resolve failed: %v", err)
+		}
+		if !reflect.DeepEqual(rest, []string{"web/src/lib/foo.test.ts"}) {
+			t.Fatalf("args = %v", rest)
+		}
+	})
+}
+
+func TestResolvePassesThroughRemainingArgs(t *testing.T) {
+	root := t.TempDir()
+
+	suite, rest, err := Resolve(root, root, []string{"unit", "-k", "some_name", "--count=3"})
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if suite.Name != "unit" {
+		t.Fatalf("suite = %q, want unit", suite.Name)
+	}
+	if !reflect.DeepEqual(rest, []string{"-k", "some_name", "--count=3"}) {
+		t.Fatalf("args = %v", rest)
+	}
+}
+
+func TestResolveErrors(t *testing.T) {
+	t.Run("no args", func(t *testing.T) {
+		root := t.TempDir()
+		if _, _, err := Resolve(root, root, nil); !errors.Is(err, ErrNoArgs) {
+			t.Fatalf("err = %v, want ErrNoArgs", err)
+		}
+	})
+
+	t.Run("unknown suite", func(t *testing.T) {
+		root := t.TempDir()
+		_, _, err := Resolve(root, root, []string{"bogus"})
+		if err == nil {
+			t.Fatal("expected an error for an unknown suite")
+		}
+		// The message has to name the alternatives, since that is the only
+		// discovery path a mistyped suite gets.
+		for _, name := range Names() {
+			if !strings.Contains(err.Error(), name) {
+				t.Fatalf("error %q does not mention suite %q", err, name)
+			}
+		}
+	})
+
+	t.Run("path outside every suite", func(t *testing.T) {
+		root := newRepo(t, "docs/readme.md")
+		_, _, err := Resolve(root, root, []string{"docs/readme.md"})
+		if err == nil {
+			t.Fatal("expected an error for a path no suite covers")
+		}
+	})
+}
+
+func TestSuitePrefixes(t *testing.T) {
+	want := map[string]string{
+		"unit":        "backend/tests/unit",
+		"external":    "backend/tests/external_dependency_unit",
+		"integration": "backend/tests/integration",
+		"web":         "web",
+		"e2e":         "web/tests/e2e",
+		"mobile":      "mobile",
+		"backend":     "backend/tests",
+	}
+	for _, suite := range All() {
+		if got := suite.Prefix(); got != want[suite.Name] {
+			t.Fatalf("%s prefix = %q, want %q", suite.Name, got, want[suite.Name])
+		}
+	}
+}

--- a/tools/ods/internal/testsuite/testsuite_test.go
+++ b/tools/ods/internal/testsuite/testsuite_test.go
@@ -44,6 +44,10 @@ func TestResolveByName(t *testing.T) {
 		{"playwright", "e2e"},
 		{"pw", "e2e"},
 		{"mobile", "mobile"},
+		{"ods", "ods"},
+		{"cli", "cli"},
+		{"terraform", "terraform"},
+		{"tf", "terraform"},
 		{"backend", "backend"},
 		{"py", "backend"},
 	}
@@ -326,12 +330,91 @@ func TestSuitePrefixes(t *testing.T) {
 		"web":         "web",
 		"e2e":         "web/tests/e2e",
 		"mobile":      "mobile",
+		"ods":         "tools/ods",
+		"cli":         "cli",
+		"terraform":   "terraform-provider-onyx",
 		"backend":     "backend/tests",
 	}
 	for _, suite := range All() {
 		if got := suite.Prefix(); got != want[suite.Name] {
 			t.Fatalf("%s prefix = %q, want %q", suite.Name, got, want[suite.Name])
 		}
+	}
+}
+
+// go test takes packages, not files, so a Go suite shapes its targets
+// differently from the path-based runners.
+func TestResolveGoTargets(t *testing.T) {
+	root := newRepo(t,
+		"tools/ods/main.go",
+		"tools/ods/cmd/web_test.go",
+		"tools/ods/internal/testsuite/testsuite_test.go",
+		"cli/internal/tui/tui_test.go",
+	)
+
+	cases := []struct {
+		name      string
+		args      []string
+		wantSuite string
+		want      []string
+	}{
+		{
+			name:      "package directory",
+			args:      []string{"tools/ods/internal/testsuite"},
+			wantSuite: "ods",
+			want:      []string{"./internal/testsuite"},
+		},
+		{
+			name:      "file runs its package",
+			args:      []string{"tools/ods/internal/testsuite/testsuite_test.go"},
+			wantSuite: "ods",
+			want:      []string{"./internal/testsuite"},
+		},
+		{
+			name:      "module root",
+			args:      []string{"tools/ods"},
+			wantSuite: "ods",
+			want:      []string{"./..."},
+		},
+		{
+			name:      "node id becomes a run filter",
+			args:      []string{"tools/ods/cmd/web_test.go::TestWebDir"},
+			wantSuite: "ods",
+			want:      []string{"./cmd", "-run", "^TestWebDir$"},
+		},
+		{
+			name:      "path after a suite name",
+			args:      []string{"ods", "tools/ods/cmd"},
+			wantSuite: "ods",
+			want:      []string{"./cmd"},
+		},
+		{
+			name:      "a second module",
+			args:      []string{"cli/internal/tui"},
+			wantSuite: "cli",
+			want:      []string{"./internal/tui"},
+		},
+		{
+			name:      "flags pass through",
+			args:      []string{"ods", "-run", "TestResolve", "-v"},
+			wantSuite: "ods",
+			want:      []string{"-run", "TestResolve", "-v"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			suite, args, err := Resolve(root, root, tc.args)
+			if err != nil {
+				t.Fatalf("Resolve(%v) failed: %v", tc.args, err)
+			}
+			if suite.Name != tc.wantSuite {
+				t.Fatalf("suite = %q, want %q", suite.Name, tc.wantSuite)
+			}
+			if !reflect.DeepEqual(args, tc.want) {
+				t.Errorf("args = %v, want %v", args, tc.want)
+			}
+		})
 	}
 }
 
@@ -369,6 +452,9 @@ func TestSuiteDefaultTargets(t *testing.T) {
 		"web":         "",
 		"e2e":         "tests/e2e",
 		"mobile":      "",
+		"ods":         "./...",
+		"cli":         "./...",
+		"terraform":   "./...",
 		"backend":     "tests",
 	}
 	for _, suite := range All() {

--- a/tools/ods/internal/testsuite/testsuite_test.go
+++ b/tools/ods/internal/testsuite/testsuite_test.go
@@ -395,6 +395,18 @@ func TestResolveGoTargets(t *testing.T) {
 			want:      []string{"./internal/tui"},
 		},
 		{
+			name:      "path relative to the module",
+			args:      []string{"ods", "internal/testsuite"},
+			wantSuite: "ods",
+			want:      []string{"./internal/testsuite"},
+		},
+		{
+			name:      "node id relative to the module",
+			args:      []string{"cli", "internal/tui/tui_test.go::TestChat"},
+			wantSuite: "cli",
+			want:      []string{"./internal/tui", "-run", "^TestChat$"},
+		},
+		{
 			name:      "flags pass through",
 			args:      []string{"ods", "-run", "TestResolve", "-v"},
 			wantSuite: "ods",

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -648,3 +648,7 @@ export function useToast() { ... }
 - Run an e2e test with the repo-pinned Playwright: `cd web && bun run playwright <TEST_NAME>`
   (the `playwright` script expands to `playwright test`; avoid `bunx`/`npx`, which can silently
   fetch an unpinned version).
+- `ods test` runs either suite from any directory and keeps the pinned Playwright:
+  `ods test web` / `ods test e2e <TEST_NAME>`. A path picks the suite for you, so
+  `ods test web/src/lib/foo.test.ts` runs jest and `ods test web/tests/e2e/chat.spec.ts` runs
+  Playwright. Arguments after the first go to the runner.


### PR DESCRIPTION
## What

`ods coverage <suite|module-dir>` measures Go statement coverage per package and holds it against
a committed baseline, so coverage can go up but not down.

```bash
ods coverage ods            # report where each package stands
ods coverage ods --check    # fail on a regression (what CI runs)
ods coverage ods --update   # record today's numbers as the new floors
ods coverage ods --profile /tmp/cover.out   # then: go tool cover -html=/tmp/cover.out
```

Stacked on #14017, which adds `ods test` and the `internal/testsuite` routing this reuses. That PR
reserved `ods coverage` as a follow-up; this is it, for the Go modules. The backend and web suites
have no coverage tooling yet, and `ods coverage unit` says so rather than guessing.

## Baseline

`tools/ods/.coverage-baseline.yaml`, at **26.3% total** across 22 packages. Where the gaps are:

| Package | Coverage |
| --- | --- |
| internal/version | 100.0% |
| internal/composegen | 96.8% |
| internal/testsuite | 92.5% |
| internal/deployfilessync | 79.1% |
| internal/coverage | 78.1% |
| internal/portutil | 75.0% |
| internal/imgdiff | 68.2% |
| internal/lazyimports | 58.3% |
| internal/audit | 55.6% |
| internal/tui | 43.3% |
| internal/git | 28.5% |
| internal/docker | 25.3% |
| **cmd** | **6.3%** |
| alembic, config, kube, openapi, paths, postgres, prompt, s3, *(main)* | 0.0% |

## CI

`pr-golang-tests.yml` gains a `coverage` job. A module opts into the gate by committing a
baseline, so `cli` and `terraform-provider-onyx` join by running `ods coverage <suite> --update`
once — no workflow change needed.

## Design

**Coverage is per package.** A package's number counts only its own tests, via
`go test -coverprofile`. That is a number the package's owner can act on; a cross-package
`-coverpkg` total would credit a package for statements its own tests never assert on.

**A fresh baseline always passes its own run.** Floors round *down* to one decimal, and a package
may sit `--tolerance` (default 0.1pp) below its floor without failing. Together that absorbs the
jitter from suites that depend on ports or timing — about 3 statements in `cmd`. A real regression
is far larger. `TestNewBaseline_isSelfConsistent` pins this.

**Improvements never fail the build.** The gate only catches drops; it reports how many packages
rose and points at `--update`. The alternative — failing until the baseline is refreshed —
ratchets automatically but conflicts on the baseline file every time two PRs add tests. Easy to
flip later if the softer version lets the baseline go stale.

**A new package cannot fail a check it was never measured for**, and a deleted package is reported
for cleanup rather than failing.

**A failed test run records nothing.** `go test` still writes a profile when tests fail, so
coverage from a failed run would be both wrong and quietly recordable. `--update` and `--check`
both exit with the test run's own code instead.

Logic lives in `internal/coverage`; `cmd/coverage.go` is cobra glue only.

## Testing

`internal/coverage` is unit tested at 78.1%: profile parsing (per-package aggregation, repeated
block merging, the module root, malformed lines, the empty profile), baseline round-trip,
deterministic byte-identical output, floor rounding, self-consistency, and every comparison verdict
(regressed, ok-at-the-floor, drop-inside-tolerance, improved, new, removed, no-baseline).

Exercised live end to end:

```
ods coverage ods --update        → wrote the baseline at 26.3%
ods coverage ods --check         → holds, exit 0
  with a floor hand-raised to 70 → "internal/audit  55.6%  70.0%  REGRESSED by 14.4", exit 1
  with a failing test run        → exits with go test's code, records nothing
ods coverage ./tools/ods --check → same as the suite name (what CI passes)
ods coverage tools/ods/internal/audit → rejected, points at the module
ods coverage unit                → rejected, lists the Go suites
ods coverage ods --check --update → rejected
```

`go test -race ./...` passes, `go mod tidy` is clean (no new dependencies), and pre-commit is green
including zizmor, actionlint, and golangci-lint.

## Note

`internal/git` and `cmd` tests fail on any machine with `commit.gpgsign=true` and no signing key —
their fixtures build real commits. This reproduces unchanged at `main`, but it now bites harder,
since `ods coverage` correctly refuses to baseline a failed run. Fixing the fixtures to set
`commit.gpgsign=false` locally is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates Go statement coverage per package against a committed baseline via `ods coverage`, and enforces it in CI for modules that opt in. Previously coverage wasn’t checked; now `--check` fails when any package drops below its floor, while improvements never fail.

- CI: `.github/workflows/pr-golang-tests.yml` adds `detect-coverage-modules` and `coverage` jobs; any module with `.coverage-baseline.yaml` is checked.
- New CLI: `ods coverage <suite|module-dir> [--check|--update] [--profile PATH] [--tolerance 0.1]`. Per-package coverage uses `go test -coverprofile`; failed test runs return the test exit code and do not record coverage.
- Baseline: committed at `tools/ods/.coverage-baseline.yaml` (26.3% total). Floors round down to one decimal; a `0.1` pp tolerance avoids flaky failures. New or removed packages are reported but do not fail the gate.
- Migration: to opt in additional Go modules (e.g., `cli`, `terraform-provider-onyx`), run `ods coverage <suite> --update` once and commit the baseline.

<sup>Written for commit 9e8c9c68209471c36ac5987bd908c885b6728f36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

