### PR TITLE
fix(terraform): widen only s3, not every module that happened to validate

### DIFF
--- a/deployment/terraform/modules/aws/opensearch/versions.tf
+++ b/deployment/terraform/modules/aws/opensearch/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.100, < 7.0"
+      version = "~> 5.100"
     }
   }
 }

--- a/deployment/terraform/modules/aws/postgres/versions.tf
+++ b/deployment/terraform/modules/aws/postgres/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.100, < 7.0"
+      version = "~> 5.100"
     }
   }
 }

--- a/deployment/terraform/modules/aws/redis/versions.tf
+++ b/deployment/terraform/modules/aws/redis/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.100, < 7.0"
+      version = "~> 5.100"
     }
   }
 }

--- a/deployment/terraform/modules/aws/s3/versions.tf
+++ b/deployment/terraform/modules/aws/s3/versions.tf
@@ -3,7 +3,11 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
+      source = "hashicorp/aws"
+      # Widened so callers already on aws 6.x can consume this module. Only s3
+      # is widened: it has no provider-side conditional validation, and it is
+      # the module 6.x callers actually need. The others stay on 5.x until
+      # something needs them there and can be tested against a real plan.
       version = ">= 5.100, < 7.0"
     }
   }

--- a/deployment/terraform/modules/aws/waf/versions.tf
+++ b/deployment/terraform/modules/aws/waf/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.100, < 7.0"
+      version = "~> 5.100"
     }
   }
 }


### PR DESCRIPTION
## Description

Narrows #14080, which widened five modules to `>= 5.100, < 7.0`.

Review there raised that aws 6.x might require `auth_token_update_strategy` alongside `auth_token` on elasticache. Checking the 6.x schema directly, that specific claim does not hold — both are optional:

```
auth_token:                 required=False optional=True
auth_token_update_strategy: required=False optional=True
```

But the underlying point does hold, and it is worth acting on. `terraform validate` cannot see provider-side conditional validation, so **"validates under aws 6.x" is weaker evidence than "works under aws 6.x"** — and #14080 leaned on the former as though it were the latter, across five modules at once.

So this keeps the widening where it is needed and backs it out everywhere else:

| Module | Constraint | Why |
|---|---|---|
| `s3` | `>= 5.100, < 7.0` | The module 6.x callers actually need, and it has no conditional provider validation |
| `waf`, `redis`, `postgres`, `opensearch` | back to `~> 5.100` | Nothing needs them on 6.x today, so widening buys risk for no benefit |
| `vpc`, `eks` | `~> 5.100` | Unchanged. `vpc` cannot move until its flow log migrates off `log_group_name` |

A widened constraint is only a permission, not a behaviour change — but it is a permission a future caller can act on, and I would rather not publish 6.x support for modules nobody has run on 6.x.

## How Has This Been Tested?

Both directions, unchanged from #14080:

- a root pinning `~> 6.0` with the `s3` module resolves to **aws 6.60.0** — the case that motivated the original change
- a root using `vpc` and `s3` together still resolves to **aws 5.100.0**, so existing consumers do not move

All 8 modules pass `terraform validate`; pre-commit is green.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts `hashicorp/aws` 6.x support to the S3 module and reverts other modules to 5.x. This avoids publishing untested 6.x behavior; `terraform validate` cannot catch provider-side conditional validation.

**Changes**
- Constraints: `s3` → `>= 5.100, < 7.0`; `waf`, `redis`, `postgres`, `opensearch` → `~> 5.100`.
- Resolution checks: a root on `~> 6.0` with `s3` resolves to `hashicorp/aws` 6.60.0; a root using `vpc` + `s3` stays on `hashicorp/aws` 5.100.0.

<sup>Written for commit af4ef8d53c5f8b618e0934c02fd46cb9e12042f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

