### PR TITLE
fix(gitbook): handle rate limits and fail loudly on page errors

### DIFF
--- a/backend/onyx/connectors/gitbook/connector.py
+++ b/backend/onyx/connectors/gitbook/connector.py
@@ -7,6 +7,11 @@ import requests
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE, REQUEST_TIMEOUT_SECONDS
 from onyx.configs.constants import DocumentSource
+from onyx.connectors.cross_connector_utils.rate_limit_wrapper import rl_requests
+from onyx.connectors.exceptions import (
+    CredentialExpiredError,
+    InsufficientPermissionsError,
+)
 from onyx.connectors.interfaces import (
     GenerateDocumentsOutput,
     LoadConnector,
@@ -37,9 +42,16 @@ class GitbookApiClient:
         }
 
         url = urljoin(GITBOOK_API_BASE, endpoint.lstrip("/"))
-        response = requests.get(
+        # rl_requests waits and retries on 429 (honoring Retry-After)
+        response = rl_requests.get(
             url, headers=headers, params=params, timeout=REQUEST_TIMEOUT_SECONDS
         )
+        if response.status_code == 401:
+            raise CredentialExpiredError("GitBook access token is invalid or expired")
+        if response.status_code == 403:
+            raise InsufficientPermissionsError(
+                "GitBook access token lacks permission for this content"
+            )
         response.raise_for_status()
         return response.json()
 
@@ -483,9 +495,23 @@ class GitbookConnector(LoadConnector, PollConnector):
                     if end and last_modified > end:
                         continue
 
-                current_batch.append(
-                    _convert_page_to_document(self.client, self.space_id, page)
-                )
+                try:
+                    document = _convert_page_to_document(
+                        self.client, self.space_id, page
+                    )
+                except requests.HTTPError as e:
+                    status = e.response.status_code if e.response is not None else None
+                    # only link/group pages without fetchable content 404; any
+                    # other error must fail the run rather than drop pages
+                    if status == 404:
+                        logger.warning(
+                            "Skipping GitBook page %s: no fetchable content (HTTP 404)",
+                            page.get("id"),
+                        )
+                        continue
+                    raise
+
+                current_batch.append(document)
 
                 if len(current_batch) >= self.batch_size:
                     yield current_batch


### PR DESCRIPTION
## Description

Stacked on #14085 (2/3).

Three ways a GitBook sync could silently lose documents:

- A 429 mid-sync failed the run with a bare `HTTPError` and no retry.
- A revoked/invalid token surfaced as an opaque per-page failure.
- Link/group pages without fetchable content 404 and killed the run.

Changes:

- `GitbookApiClient.get` goes through the shared rate-limit wrapper (`rl_requests`), which waits on 429 and honors `Retry-After`.
- 401 raises `CredentialExpiredError`; 403 raises `InsufficientPermissionsError`.
- Only 404 pages are skipped, with a warning. Every other per-page error propagates and fails the run, so an index attempt can no longer report success with pages missing. This also protects pruning (which enumerates live ids via `load_from_state`) from deleting documents for silently skipped pages.

## How Has This Been Tested?

- Live run against a GitBook space: all pages index unchanged.
- Verified a bad token raises `CredentialExpiredError` against the live API.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
GitBook syncs now handle API rate limits and fail loudly on per-page errors to prevent silent document loss. Before: 429s aborted runs without retry, invalid tokens surfaced as opaque per-page failures, and 404s killed the run; now: GETs use `rl_requests`, 401/403 raise specific errors, and only 404 pages are skipped with a warning.

- Routes all GETs through `rl_requests` (waits on 429 and honors Retry-After).
- Raises CredentialExpiredError on 401 and InsufficientPermissionsError on 403.
- Skips only 404 pages with a warning; re-raises other per-page HTTP errors to fail the run.
- Protects pruning from deleting documents after silently skipped pages.
- No config or migration changes.

<sup>Written for commit 121031fd520dff54c578001dce536cdda2bd2bb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

