### PR TITLE
fix(terraform): allow aws 6.x on postgres, which is already running there

### DIFF
--- a/deployment/terraform/modules/aws/postgres/versions.tf
+++ b/deployment/terraform/modules/aws/postgres/versions.tf
@@ -3,8 +3,11 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.100"
+      source = "hashicorp/aws"
+      # Widened like s3: an internal stack has been running this module against
+      # aws 6.x, so 6.x support is observed rather than assumed. vpc and eks
+      # stay on 5.x -- vpc until its flow log migrates off log_group_name.
+      version = ">= 5.100, < 7.0"
     }
   }
 }


### PR DESCRIPTION
## Description

Third and final constraint adjustment, and this one is backed by data rather than inference.

Repointing our internal stacks at `tf-v1.0.1` surfaced a second root that cannot resolve: `managed-services-shards` requires `aws >= 5.0`, locks **6.57.1**, and consumes the `postgres` module. With `postgres` pinned to `~> 5.100`, `terraform init` fails outright.

Instead of guessing again at which modules "might" be wanted on 6.x — the mistake in #14080 — I enumerated which roots consume which published modules and what each one locks:

| Root | Locked aws | Modules consumed |
|---|---|---|
| 4 × `internal-tools/*` | **6.55.0** | `s3` |
| `managed-services-shards` | **6.57.1** | `postgres` |
| `agent-wiki-infra` | 5.100.0 | eks, opensearch, postgres, redis, s3, vpc |
| `multi-tenant` | 5.100.0 | opensearch |
| customer stacks | 5.100.0 | via the composition |

Exactly two modules are consumed by a 6.x root: `s3` (done in #14083) and `postgres` (this PR). Everything else is only ever consumed at 5.100.0, so it keeps the tighter pin.

**Why this is better evidence than #14080 had.** Review there rightly pushed back that `terraform validate` cannot see provider-side conditional validation, so "validates under 6.x" is weak. This does not rely on that: those roots have been running these modules against aws 6.x in production all along, because the local module copies carried no `versions.tf` and simply inherited the root's provider version. 6.x support is observed, not inferred.

`vpc` and `eks` stay pinned. `vpc` cannot move until its flow log migrates off `log_group_name`, removed in provider 6.0.

## How Has This Been Tested?

`postgres`, `s3` and `vpc` all pass `terraform validate`; pre-commit is green.

The real test is the consuming side: with this change, all six internal roots that were failing to resolve now init and produce plans byte-identical to the ones they produce today against the local module copies. That verification lives in the corresponding infra PR.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows `hashicorp/aws` 6.x in the postgres module by widening the provider constraint from ~> 5.100 to >= 5.100, < 7.0. This resolves terraform init failures for roots locked to 6.x (e.g., managed-services-shards on 6.57.1) that consume this module.

- Evidence: internal stacks have been running this module on 6.x via local copies; with this change, affected roots init and produce byte-identical plans; validate and pre-commit pass.
- Scope: only postgres is widened; vpc and eks remain on 5.x (vpc blocked by the log_group_name removal in provider 6.0). No migration required.

<sup>Written for commit 84bc12644fa9625a602a972b58ec6f1df1dc4e7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

