### PR TITLE
feat(craft): allow model switching mid-session

### DIFF
--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -793,8 +793,6 @@ export default function BuildChatPanel({
                       </Tooltip>
                     </div>
                   )}
-                  {/* Model is locked once the session starts — show the picker
-                  only before the first message. */}
                   {sessionId && session?.skillsStale && (
                     <div className="pb-2">
                       <SkillsStaleNotice
@@ -803,7 +801,10 @@ export default function BuildChatPanel({
                       />
                     </div>
                   )}
-                  {session?.isLoaded && session.messages.length === 0 && (
+                  {/* The selected model is sent with each message, so a
+                  switch applies from the next turn. Subagent transcripts
+                  cannot send, so they get no picker. */}
+                  {session?.isLoaded && !isViewingSubagent && (
                     <div className="flex justify-end pb-2">
                       <ModelPickerButton
                         selection={selectedModel}
@@ -815,7 +816,6 @@ export default function BuildChatPanel({
                             }));
                           }
                         }}
-                        disabled={isViewingSubagent}
                       />
                     </div>
                   )}


### PR DESCRIPTION
## Description

Craft locked the model once a session started: `ModelPickerButton` only rendered while `session.messages.length === 0`. The backend already applies a per-message model override (`send-message` persists it to `build_session.agent_provider/agent_model`, and the opencode prompt carries the model through the gateway), and the FE already sends the selected model with every message. This drops the render gate so the picker stays visible mid-session; a switch applies from the next turn. Subagent transcripts cannot send, so they get no picker (previously a dead `disabled` prop handled this).

## How Has This Been Tested?

- `jest src/app/craft`: 271 passed; pre-commit oxfmt / oxlint / tsc pass.
- Live on a compose craft stack built from this branch: turn 1 replied "I am onyx/1/gpt-5.6-luna", switched the picker to GPT-5.6 Terra mid-session, turn 2 replied "I am onyx/1/gpt-5.6-terra". `build_session.agent_model` updated to `1/gpt-5.6-terra`.
- Local Greptile review: two consecutive 5/5 rounds, zero comments.

| Before | After |
|---|---|
| <img width="1500" alt="before-no-picker" src="https://github.com/user-attachments/assets/3c4d5838-f19b-4688-b20a-692e72c7f08d" /> | <img width="1500" alt="after-picker-switch" src="https://github.com/user-attachments/assets/2a435ff4-a9c9-4823-9d66-c7ec69899f36" /> |

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
