### PR TITLE
docs(terraform): explain how to consume the AWS modules by ref

### DIFF
--- a/deployment/terraform/modules/aws/README.md
+++ b/deployment/terraform/modules/aws/README.md
@@ -17,6 +17,26 @@ These are the same modules Onyx runs for its own managed deployments. The manage
 deployments add operational wiring on top (alert routing, secret management, log
 aggregation) but provision the underlying AWS infrastructure from exactly this code.
 
+## Consuming these modules from another repository
+
+The quickstart below uses local paths. To consume the modules from somewhere
+else, point `source` at this repository and pin a ref:
+
+```hcl
+module "vpc" {
+  source   = "git::https://github.com/onyx-dot-app/onyx.git//deployment/terraform/modules/aws/vpc?ref=tf/v1.0.2"
+  vpc_name = "onyx-vpc"
+}
+```
+
+Releases are tagged `tf/vX.Y.Z`, versioned independently of Onyx product
+releases. A commit sha works as a `ref` too, and is the better choice for
+automated consumers: a sha cannot be moved, where a tag can. Terraform clones
+the whole repository either way, so there is no meaningful speed difference.
+
+Pin something. Without a `ref` Terraform tracks the default branch, so an
+unrelated merge can change your infrastructure.
+
 ## Quickstart (copy/paste)
 The snippet below shows a minimal working example that:
 - Sets up providers


### PR DESCRIPTION
## Description

The modules README only ever showed local `./modules/aws/...` paths, but these modules are now consumed from other repositories — onyx-infra pins them, and self-hosters can too. Nothing documented the git source form or the versioning scheme.

Adds a short section covering:

- the `git::https://...//deployment/terraform/modules/aws/<module>?ref=...` form
- the `tf/vX.Y.Z` tag scheme, versioned independently of product releases
- that a commit sha is the better pin for automated consumers, because a sha cannot be moved where a tag can
- that omitting `ref` tracks the default branch, so an unrelated merge can change your infrastructure

The tag naming follows what this repo already does for other components (`cli/v0.1.x`, `ods/v0.9.x`).

Worth recording, since it came up in review: the slash in `tf/v1.0.2` survives the `ref` query parameter fine. A slash tag, a full sha and a 12-character sha all resolve. Pinning a sha costs a little more time (45s against 39s on a cold init) with an identical 295MB clone, because Terraform clones the whole repository either way.

## How Has This Been Tested?

Documentation only. The forms it describes were each verified against the real repository with `terraform init`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents how to consume the AWS Terraform modules by Git `source` with a pinned `ref`, so external repos can use and version these modules without drift.

- Use `source = "git::https://github.com/onyx-dot-app/onyx.git//deployment/terraform/modules/aws/<module>?ref=..."` when consuming from another repository.
- Tags follow `tf/vX.Y.Z`, versioned independently of product releases.
- Prefer pinning a commit SHA in `ref`; a tag can move.
- Always pin a `ref`; omitting it tracks the default branch and can change your infrastructure.

<sup>Written for commit f3bfd75448cab8ac952f901ce89fd3fe22b86bf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

