### PR TITLE
fix(scim): refuse rename adoption of privileged accounts

### DIFF
--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -260,11 +260,12 @@ def _is_entra_tombstone_rename(current_email: str, new_email: str) -> bool:
 
 
 def _is_privileged_account(user: User) -> bool:
-    """Whether renaming *user* must be refused.
+    """Whether *user* must stay outside a rename's reach, as source or target.
 
     SSO login associates by email, so the first login for a renamed account's
     new address claims it. Provisioning only ever grants basic access, so a
-    token must not move an admin or group-manager account.
+    token must not move an admin or group-manager account — nor adopt one,
+    which would put it under IdP control.
     """
     return user_is_admin(user) or user.is_group_manager
 
@@ -295,7 +296,8 @@ def _apply_username_change(
       EXT_PERM shadows fall through so ``reconcile_user_email__no_commit``
       merges them into the renamed user, and BOT / service / anonymous
       accounts must never come under IdP control.
-    - A rename of an admin or group manager is rejected (403).
+    - A rename of an admin or group manager, or onto one (adoption would
+      hand the token control of the target), is rejected (403).
     """
     if requested_username.lower() == user.email.lower():
         return _UsernameChange(user, requested_username)
@@ -314,6 +316,10 @@ def _apply_username_change(
                 409, f"User with email {requested_username} already exists"
             )
         if other.account_type == AccountType.STANDARD:
+            if _is_privileged_account(other):
+                return _scim_error_response(
+                    403, "Cannot adopt an admin or group manager account"
+                )
             mapping = dal.get_user_mapping_by_user_id(user.id)
             if mapping:
                 dal.reassign_user_mapping(mapping, other.id)

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -1519,7 +1519,9 @@ class TestRenameCollisionAdoption:
 
 class TestPrivilegedRename:
     """A SCIM token must not move an admin or group-manager account onto a
-    different address — the address could then be claimed via first login."""
+    different address — the address could then be claimed via first login —
+    nor adopt one via rename collision, which would put it under IdP
+    control."""
 
     def test_put_admin_rename_returns_403(
         self,
@@ -1564,6 +1566,60 @@ class TestPrivilegedRename:
         )
 
         assert_scim_error(result, 403)
+        mock_dal.update_user.assert_not_called()
+
+    def test_put_rename_onto_admin_account_returns_403(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """Adoption must not hand the IdP control of a privileged account."""
+        user = make_db_user(email="old@mane.com")
+        admin = make_db_user(
+            email="admin@mane.com",
+            effective_permissions=[Permission.FULL_ADMIN_PANEL_ACCESS.value],
+        )
+        mock_dal.get_user.return_value = user
+        mock_dal.get_user_by_email.return_value = admin
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(userName="admin@mane.com", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 403)
+        mock_dal.reassign_user_mapping.assert_not_called()
+        mock_dal.deactivate_user.assert_not_called()
+        mock_dal.update_user.assert_not_called()
+
+    def test_patch_rename_onto_group_manager_returns_403(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        user = make_db_user(email="old@mane.com")
+        manager = make_db_user(email="manager@mane.com", is_group_manager=True)
+        mock_dal.get_user.return_value = user
+        mock_dal.get_user_by_email.return_value = manager
+
+        result = patch_user(
+            user_id=str(user.id),
+            patch_request=_rename_patch("manager@mane.com"),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 403)
+        mock_dal.reassign_user_mapping.assert_not_called()
+        mock_dal.deactivate_user.assert_not_called()
         mock_dal.update_user.assert_not_called()
 
     def test_put_admin_without_rename_is_allowed(


### PR DESCRIPTION
## Description

Follow-up to #14074, from the Greptile P1 on #14093.

Bug: a SCIM rename collision onto an unmanaged privileged STANDARD account adopted it — the mapping moved to the admin/group-manager account, handing the IdP token control of its profile and active state. The privilege guard only checked the rename source.

Fix: `_apply_username_change` refuses adoption with 403 when `_is_privileged_account(other)`, mirroring the source-side guard.

Cherry-picks to v4.6 via the release automation after merge. #14093 must merge first — the guard modifies adoption code that reaches release/v4.6 through it.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check