### PR TITLE
feat(scim): match users by provisioned userName, not account email

### DIFF
--- a/backend/alembic/versions/28bb08137807_backfill_scim_username_and_add_unique_.py
+++ b/backend/alembic/versions/28bb08137807_backfill_scim_username_and_add_unique_.py
@@ -1,0 +1,81 @@
+"""backfill scim_username and add unique index
+
+Revision ID: 28bb08137807
+Revises: 06a38a307492
+Create Date: 2026-08-19 13:07:33.600011
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "28bb08137807"
+down_revision = "06a38a307492"
+branch_labels = None
+depends_on = None
+
+_mapping = sa.table(
+    "scim_user_mapping",
+    sa.column("id", sa.Integer),
+    sa.column("user_id", sa.Uuid),
+    sa.column("scim_username", sa.String),
+)
+
+_user = sa.table(
+    "user",
+    sa.column("id", sa.Uuid),
+    sa.column("email", sa.String),
+)
+
+
+def upgrade() -> None:
+    # Null case-insensitive duplicates among the provisioned values (keeping
+    # the oldest row) before the backfill, so a derived value never displaces
+    # a provisioned one. Nulled rows keep matching by email via the coalesce.
+    keepers = (
+        sa.select(sa.func.min(_mapping.c.id).label("keep_id"))
+        .where(_mapping.c.scim_username.is_not(None))
+        .group_by(sa.func.lower(_mapping.c.scim_username))
+        .subquery()
+    )
+    op.execute(
+        _mapping.update()
+        .where(
+            _mapping.c.scim_username.is_not(None),
+            _mapping.c.id.not_in(sa.select(keepers.c.keep_id)),
+        )
+        .values(scim_username=None)
+    )
+
+    # Rows provisioned before scim_username was recorded are seeded from the
+    # email, which held the userName. Provisioned values are skipped, and
+    # emails are unique lowercase (ensure_lowercase_email), so no collisions.
+    taken = _mapping.alias("taken")
+    op.execute(
+        _mapping.update()
+        .where(
+            _mapping.c.scim_username.is_(None),
+            _mapping.c.user_id == _user.c.id,
+            ~sa.exists(
+                sa.select(1).where(
+                    sa.func.lower(taken.c.scim_username) == sa.func.lower(_user.c.email)
+                )
+            ),
+        )
+        .values(scim_username=_user.c.email)
+    )
+
+    op.create_index(
+        "uq_scim_user_mapping_scim_username_lower",
+        "scim_user_mapping",
+        [sa.text("lower(scim_username)")],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_scim_user_mapping_scim_username_lower",
+        table_name="scim_user_mapping",
+    )

--- a/backend/ee/onyx/db/scim.py
+++ b/backend/ee/onyx/db/scim.py
@@ -165,6 +165,16 @@ class ScimDAL(DAL):
             select(ScimUserMapping).where(ScimUserMapping.user_id == user_id)
         )
 
+    def get_user_mapping_by_scim_username(
+        self, scim_username: str
+    ) -> ScimUserMapping | None:
+        """Look up a user mapping by the provisioned userName (case-insensitive)."""
+        return self._session.scalar(
+            select(ScimUserMapping).where(
+                func.lower(ScimUserMapping.scim_username) == scim_username.lower()
+            )
+        )
+
     def list_user_mappings(
         self,
         start_index: int = 1,
@@ -302,11 +312,12 @@ class ScimDAL(DAL):
         if scim_filter:
             attr = scim_filter.attribute.lower()
             if attr == "username":
-                # arg-type: fastapi-users types User.email as str, not a column expression
-                # assignment: union return type widens but query is still Select[tuple[User]]
+                # userName matches the provisioned userName, so IdP matching
+                # survives the email diverging from it (identity decoupling).
+                # Legacy mappings without one fall back to the email.
                 query = _apply_scim_string_op(
                     query,
-                    User.email,  # ty: ignore[invalid-argument-type]
+                    func.coalesce(ScimUserMapping.scim_username, User.email),
                     scim_filter,
                 )
             elif attr == "active":

--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -299,6 +299,9 @@ def _apply_username_change(
     - A rename of an admin or group manager, or onto one (adoption would
       hand the token control of the target), is rejected (403).
     """
+    if not requested_username:
+        return _scim_error_response(400, "userName must not be empty")
+
     if requested_username.lower() == user.email.lower():
         return _UsernameChange(user, requested_username)
 
@@ -308,6 +311,14 @@ def _apply_username_change(
             user.email,
         )
         return _UsernameChange(user, None)
+
+    # A userName another mapping holds is a conflict even when that mapping's
+    # email has diverged from it (the unique index would reject the write).
+    holder = dal.get_user_mapping_by_scim_username(requested_username)
+    if holder and holder.user_id != user.id:
+        return _scim_error_response(
+            409, f"User with userName {requested_username} already exists"
+        )
 
     other = dal.get_user_by_email(requested_username)
     if other and other.id != user.id:
@@ -338,6 +349,69 @@ def _apply_username_change(
         )
 
     return _UsernameChange(user, requested_username)
+
+
+# Unique constraints a concurrent provisioning race can trip: the email, the
+# provisioned userName, and the one-mapping-per-user key (adoption races).
+_PROVISIONING_RACE_CONSTRAINTS = (
+    "ix_user_email",
+    "uq_scim_user_mapping_scim_username_lower",
+    "scim_user_mapping_user_id_key",
+)
+
+
+def _update_user_or_conflict(
+    dal: ScimDAL,
+    requested_username: str,
+    user: User,
+    **updates: object,
+) -> ScimJSONResponse | None:
+    """Update the user, turning a uniqueness race into a SCIM 409.
+
+    An email change reconciles rows keyed by the address, which autoflushes
+    the pending rename and can hit the email unique index there.
+    """
+    try:
+        dal.update_user(user, **updates)  # ty: ignore[invalid-argument-type]
+    except IntegrityError as e:
+        dal.rollback()
+        if any(is_unique_violation(e, c) for c in _PROVISIONING_RACE_CONSTRAINTS):
+            return _scim_error_response(
+                409, f"User with userName {requested_username} already exists"
+            )
+        raise
+    return None
+
+
+def _sync_and_commit_or_conflict(
+    dal: ScimDAL,
+    user_id: UUID,
+    external_id: str | None,
+    scim_username: str | None,
+    fields: ScimMappingFields,
+    requested_username: str,
+) -> ScimJSONResponse | None:
+    """Sync the mapping and commit, turning a uniqueness race into a SCIM 409.
+
+    A rename can slip past the non-locking lookups and hit a unique index at
+    the sync's autoflush or at commit, so both run inside one guard.
+    """
+    try:
+        dal.sync_user_external_id(
+            user_id,
+            external_id,
+            scim_username=scim_username,
+            fields=fields,
+        )
+        dal.commit()
+    except IntegrityError as e:
+        dal.rollback()
+        if any(is_unique_violation(e, c) for c in _PROVISIONING_RACE_CONSTRAINTS):
+            return _scim_error_response(
+                409, f"User with userName {requested_username} already exists"
+            )
+        raise
+    return None
 
 
 def _patch_sets_username(operations: list[ScimPatchOperation]) -> bool:
@@ -385,10 +459,12 @@ def _assign_default_groups_or_error(
         assign_user_to_default_groups__no_commit(db_session, user, is_admin=is_admin)
     except Exception as e:
         dal.rollback()
-        # Only the duplicate-email race is an expected, benign 409. Every other
-        # failure — including non-email integrity errors — stays a 500 so real
-        # backend faults aren't masked as "already exists".
-        if isinstance(e, IntegrityError) and is_unique_violation(e, "ix_user_email"):
+        # Only provisioning races are expected, benign 409s. Every other
+        # failure stays a 500 so real backend faults aren't masked as
+        # "already exists".
+        if isinstance(e, IntegrityError) and any(
+            is_unique_violation(e, c) for c in _PROVISIONING_RACE_CONSTRAINTS
+        ):
             logger.info(
                 "SCIM user %s already exists (concurrent provisioning); returning 409",
                 email,
@@ -611,13 +687,21 @@ def create_user(
     dal.update_token_last_used(_token.id)
 
     email = user_resource.userName.strip()
-
-    # Check for existing user — if they exist but aren't SCIM-managed yet,
-    # link them to the IdP rather than rejecting with 409.
+    if not email:
+        return _scim_error_response(400, "userName must not be empty")
     external_id: str | None = user_resource.externalId
-    scim_username: str = user_resource.userName.strip()
+    scim_username: str = email
     fields: ScimMappingFields = _fields_from_resource(user_resource)
 
+    # A mapping already provisioned under this userName is a conflict even when
+    # its account email has diverged from it (identity decoupling).
+    if dal.get_user_mapping_by_scim_username(scim_username):
+        return _scim_error_response(
+            409, f"User with userName {scim_username} already exists"
+        )
+
+    # A user that exists but isn't SCIM-managed yet is linked to the IdP
+    # rather than rejected with 409.
     existing_user = dal.get_user_by_email(email)
     if existing_user:
         existing_mapping = dal.get_user_mapping_by_user_id(existing_user.id)
@@ -769,13 +853,17 @@ def replace_user(
 
     personal_name = _scim_name_to_str(user_resource.name)
 
-    dal.update_user(
+    error = _update_user_or_conflict(
+        dal,
+        scim_username,
         user,
         email=new_email,
         is_active=user_resource.active,
         personal_name=personal_name,
         account_type=AccountType.STANDARD if promote else None,
     )
+    if error:
+        return error
 
     # Reconcile default-group membership on reactivation or promotion — a
     # promoted shadow user is now a real account and needs the Basic group.
@@ -788,14 +876,11 @@ def replace_user(
 
     new_external_id = user_resource.externalId
     fields = _fields_from_resource(user_resource)
-    dal.sync_user_external_id(
-        user.id,
-        new_external_id,
-        scim_username=scim_username,
-        fields=fields,
+    error = _sync_and_commit_or_conflict(
+        dal, user.id, new_external_id, scim_username, fields, scim_username
     )
-
-    dal.commit()
+    if error:
+        return error
 
     return _scim_resource_response(
         provider.build_user_resource(
@@ -853,9 +938,10 @@ def patch_user(
     # Resolve a rename only when the PATCH itself carried userName. A patch
     # that touches other fields must not act on a stored scim_username that
     # has drifted from the email.
+    sets_username = _patch_sets_username(patch_request.Operations)
     new_email: str | None = None
     seat_freed = False
-    if _patch_sets_username(patch_request.Operations):
+    if sets_username:
         resolved = _apply_username_change(dal, user, requested_username)
         if isinstance(resolved, ScimJSONResponse):
             return resolved
@@ -876,8 +962,9 @@ def patch_user(
         if seat_error:
             return _scim_error_response(403, seat_error)
 
-    # Track the scim_username — if userName was patched, update it
-    new_scim_username = requested_username or None
+    # Record the userName on the mapping only when the PATCH carried it. A
+    # nulled collision row must not re-collide via its email fallback.
+    new_scim_username = requested_username if sets_username else None
 
     # If displayName was explicitly patched (different from the original), use
     # it as personal_name directly.  Otherwise, derive from name components.
@@ -887,7 +974,9 @@ def patch_user(
     else:
         personal_name = _scim_name_to_str(patched.name)
 
-    dal.update_user(
+    error = _update_user_or_conflict(
+        dal,
+        requested_username,
         user,
         # Unlike PUT, PATCH skips an unchanged address: PUT's pass-through is
         # what re-runs email reconciliation (EXT_PERM shadow merging) on a
@@ -899,6 +988,8 @@ def patch_user(
         personal_name=personal_name,
         account_type=AccountType.STANDARD if promote else None,
     )
+    if error:
+        return error
 
     # Reconcile default-group membership on reactivation or promotion — a
     # promoted shadow user is now a real account and needs the Basic group.
@@ -923,21 +1014,18 @@ def patch_user(
         ),
     )
 
-    dal.sync_user_external_id(
-        user.id,
-        patched.externalId,
-        scim_username=new_scim_username,
-        fields=fields,
+    error = _sync_and_commit_or_conflict(
+        dal, user.id, patched.externalId, new_scim_username, fields, requested_username
     )
-
-    dal.commit()
+    if error:
+        return error
 
     return _scim_resource_response(
         provider.build_user_resource(
             user,
             patched.externalId,
             groups=dal.get_user_groups(user.id),
-            scim_username=new_scim_username,
+            scim_username=new_scim_username or current_scim_username,
             fields=fields,
         )
     )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -6850,6 +6850,13 @@ class ScimUserMapping(Base):
     """Maps SCIM externalId from the IdP to an Onyx User."""
 
     __tablename__ = "scim_user_mapping"
+    __table_args__ = (
+        Index(
+            "uq_scim_user_mapping_scim_username_lower",
+            text("lower(scim_username)"),
+            unique=True,
+        ),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     external_id: Mapped[str | None] = mapped_column(

--- a/backend/tests/external_dependency_unit/db/conftest.py
+++ b/backend/tests/external_dependency_unit/db/conftest.py
@@ -15,14 +15,46 @@ import pytest
 from sqlalchemy.orm import Session
 
 from ee.onyx.db.scim import ScimDAL
-from onyx.db.models import ScimToken, UserGroup
+from onyx.db.models import ScimToken, ScimUserMapping, User, UserGroup
+from tests.external_dependency_unit.conftest import create_test_user
 from tests.external_dependency_unit.db.shard_test_utils import temporary_database
+
+ScimUserFactory = Callable[[str | None], tuple[User, ScimUserMapping]]
 
 
 @pytest.fixture
 def scim_dal(db_session: Session) -> ScimDAL:
     """A ScimDAL backed by the real test database session."""
     return ScimDAL(db_session)
+
+
+@pytest.fixture
+def scim_user_factory(
+    db_session: Session,
+) -> Generator[ScimUserFactory, None, None]:
+    """Factory for (user, mapping) pairs, cleaned up after the test."""
+    created: list[tuple[User, ScimUserMapping]] = []
+
+    def _create(scim_username: str | None) -> tuple[User, ScimUserMapping]:
+        user = create_test_user(
+            db_session, f"scim_user_{uuid4().hex[:8]}", assign_default_group=False
+        )
+        mapping = ScimUserMapping(
+            external_id=f"ext-{uuid4().hex[:12]}",
+            user_id=user.id,
+            scim_username=scim_username,
+        )
+        db_session.add(mapping)
+        db_session.flush()
+        created.append((user, mapping))
+        return user, mapping
+
+    yield _create
+
+    for user, mapping in created:
+        db_session.delete(mapping)
+        db_session.delete(user)
+    db_session.commit()
 
 
 @pytest.fixture

--- a/backend/tests/external_dependency_unit/db/test_scim_username_matching.py
+++ b/backend/tests/external_dependency_unit/db/test_scim_username_matching.py
@@ -1,0 +1,66 @@
+"""SCIM matching keys off the provisioned userName, not the account email.
+
+Verifies the identity-decoupling matching semantics against a real database:
+the userName filter matches ``scim_user_mapping.scim_username`` (falling back
+to the email for legacy mappings), and the mapping lookup used by the
+create-path conflict check is case-insensitive.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from ee.onyx.db.scim import ScimDAL
+from ee.onyx.server.scim.filtering import ScimFilter, ScimFilterOperator
+from tests.external_dependency_unit.db.conftest import ScimUserFactory
+
+
+def _username_filter(value: str) -> ScimFilter:
+    return ScimFilter(
+        attribute="userName", operator=ScimFilterOperator.EQUAL, value=value
+    )
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_username_filter_matches_provisioned_username(
+    scim_dal: ScimDAL, scim_user_factory: ScimUserFactory
+) -> None:
+    """When scim_username diverges from the email, the filter follows it."""
+    provisioned = f"Provisioned.{uuid4().hex[:8]}@Example.COM"
+    user, _ = scim_user_factory(provisioned)
+
+    by_username, total = scim_dal.list_users(
+        _username_filter(provisioned.lower()), 1, 10
+    )
+    assert total == 1
+    assert by_username[0][0].id == user.id
+
+    by_email, total = scim_dal.list_users(_username_filter(user.email), 1, 10)
+    assert total == 0
+    assert by_email == []
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_username_filter_falls_back_to_email(
+    scim_dal: ScimDAL, scim_user_factory: ScimUserFactory
+) -> None:
+    """Legacy mappings without a scim_username still match by email."""
+    user, _ = scim_user_factory(None)
+
+    results, total = scim_dal.list_users(_username_filter(user.email.upper()), 1, 10)
+    assert total == 1
+    assert results[0][0].id == user.id
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_get_user_mapping_by_scim_username_is_case_insensitive(
+    scim_dal: ScimDAL, scim_user_factory: ScimUserFactory
+) -> None:
+    provisioned = f"Cased.{uuid4().hex[:8]}@Example.COM"
+    user, _ = scim_user_factory(provisioned)
+
+    found = scim_dal.get_user_mapping_by_scim_username(provisioned.lower())
+    assert found is not None
+    assert found.user_id == user.id
+
+    assert scim_dal.get_user_mapping_by_scim_username(f"missing-{uuid4().hex}") is None

--- a/backend/tests/unit/onyx/server/scim/conftest.py
+++ b/backend/tests/unit/onyx/server/scim/conftest.py
@@ -60,6 +60,7 @@ def mock_dal() -> Generator[MagicMock, None, None]:
         dal.get_user_by_email.return_value = None
         dal.get_user_mapping_by_user_id.return_value = None
         dal.get_user_mapping_by_external_id.return_value = None
+        dal.get_user_mapping_by_scim_username.return_value = None
         dal.list_users.return_value = ([], 0)
         # Group defaults
         dal.get_group.return_value = None

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -248,6 +248,30 @@ class TestCreateUser:
         mock_dal.create_user_mapping.assert_called_once()
         mock_dal.commit.assert_called_once()
 
+    def test_duplicate_scim_username_returns_409(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """A userName already provisioned conflicts even when its account
+        email has diverged from it."""
+        mock_dal.get_user_by_email.return_value = None
+        mock_dal.get_user_mapping_by_scim_username.return_value = make_user_mapping(
+            scim_username="New@Example.com"
+        )
+
+        result = create_user(
+            user_resource=make_scim_user(userName="new@example.com"),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 409)
+        mock_dal.add_user.assert_not_called()
+
     @patch("ee.onyx.server.scim.api._check_seat_availability", return_value=None)
     def test_duplicate_scim_managed_email_returns_409(
         self,
@@ -1316,6 +1340,9 @@ class TestRenameCollisionAdoption:
         assert args[0] is user
         assert kwargs["email"] is None
         assert kwargs["is_active"] is False
+        # The mapping's userName must not be rewritten either, or a nulled
+        # collision row would re-collide on its email fallback.
+        assert mock_dal.sync_user_external_id.call_args.kwargs["scim_username"] is None
 
     def test_put_adoption_allowed_for_admin_source(
         self,
@@ -1407,6 +1434,105 @@ class TestRenameCollisionAdoption:
 
         assert_scim_error(result, 403)
         mock_seats.assert_called_once()
+
+    def test_put_blank_username_returns_400(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """A whitespace-only userName must not blank the email or mapping."""
+        user = make_db_user(email="old@mane.com", is_active=True)
+        mock_dal.get_user.return_value = user
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(userName="   ", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 400)
+        mock_dal.update_user.assert_not_called()
+
+    def test_put_rename_onto_provisioned_username_returns_409(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """A userName another mapping already holds conflicts even when that
+        mapping's account email has diverged from it."""
+        user = make_db_user(email="old@mane.com", is_active=True)
+        mock_dal.get_user.return_value = user
+        mock_dal.get_user_mapping_by_scim_username.return_value = make_user_mapping(
+            user_id=uuid4(), scim_username="Taken@mane.com"
+        )
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(userName="taken@mane.com", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 409)
+        mock_dal.update_user.assert_not_called()
+
+    @patch("ee.onyx.server.scim.api.is_unique_violation", return_value=True)
+    def test_put_rename_reconcile_race_returns_409(
+        self,
+        mock_is_unique: MagicMock,  # noqa: ARG002
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """The email reconcile inside update_user can autoflush a concurrent
+        rename into a unique violation. It must return 409, not 500."""
+        user = make_db_user(email="old@mane.com", is_active=True)
+        mock_dal.get_user.return_value = user
+        mock_dal.update_user.side_effect = IntegrityError("dup", {}, Exception())
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(userName="new@mane.com", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 409)
+
+    @patch("ee.onyx.server.scim.api.is_unique_violation", return_value=True)
+    def test_put_rename_commit_race_returns_409(
+        self,
+        mock_is_unique: MagicMock,  # noqa: ARG002
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """A concurrent rename can slip past the lookup and hit the unique
+        index at commit. It must return a clean 409, not a 500."""
+        user = make_db_user(email="old@mane.com", is_active=True)
+        mock_dal.get_user.return_value = user
+        mock_dal.commit.side_effect = IntegrityError("dup", {}, Exception())
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(userName="new@mane.com", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 409)
+        mock_dal.rollback.assert_called_once()
 
     def test_put_rename_onto_mapped_bot_returns_409(
         self,


### PR DESCRIPTION
## Description

Step 1 of SCIM identity decoupling (follow-up to #14074). The IdP's userName stops being an alias of the account email for matching purposes.

- The userName filter matches the mapping's stored `scim_username`, falling back to the email for legacy rows.
- Create and rename paths 409 on a userName another mapping already holds, and uniqueness races surface as 409 instead of 500 (email, userName, and one-mapping-per-user constraints).
- Blank userName returns 400.
- Migration backfills `scim_username` from the account email (provisioned values win over derived ones) and adds a case-insensitive unique index, mirrored in the model.

Verified live on a migrated throwaway Postgres, including the backfill/dedupe ordering on seeded dirty data.

Step 2 (userName writes stop touching the email, email driven by the `emails` attribute) follows on top of this.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check