### PR TITLE
perf(ods): format Terraform files concurrently in ods fmt tf

### DIFF
--- a/tools/ods/cmd/fmt.go
+++ b/tools/ods/cmd/fmt.go
@@ -70,16 +70,17 @@ func runFmtTerraform(args []string, check bool) {
 		log.Fatalf("Cannot collect Terraform files: %v", err)
 	}
 
+	results, errs := terraform.FormatFiles(files, !check)
+
 	var changed []string
 	var failed bool
-	for _, file := range files {
-		res, err := terraform.FormatFile(file, !check)
-		if err != nil {
+	for i, file := range files {
+		if err := errs[i]; err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %v\n", relativeTo(root, file), err)
 			failed = true
 			continue
 		}
-		if res.Changed {
+		if results[i].Changed {
 			changed = append(changed, relativeTo(root, file))
 		}
 	}

--- a/tools/ods/internal/terraform/format.go
+++ b/tools/ods/internal/terraform/format.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"runtime"
+	"sync"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -14,6 +16,30 @@ import (
 type FormatResult struct {
 	Path    string
 	Changed bool
+}
+
+// FormatFiles formats every file concurrently, bounded by GOMAXPROCS, and
+// returns one result per input file in the same order as files. Each file is
+// parsed and rewritten independently, so there is no reason to pay for that
+// work one file at a time.
+func FormatFiles(files []string, write bool) ([]FormatResult, []error) {
+	results := make([]FormatResult, len(files))
+	errs := make([]error, len(files))
+
+	sem := make(chan struct{}, runtime.GOMAXPROCS(0))
+	var wg sync.WaitGroup
+	for i, file := range files {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int, file string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			results[i], errs[i] = FormatFile(file, write)
+		}(i, file)
+	}
+	wg.Wait()
+
+	return results, errs
 }
 
 // FormatFile canonicalises one Terraform file.


### PR DESCRIPTION
## Summary
- `ods fmt tf` took ~110-120ms vs `terraform fmt`'s ~60ms; profiling showed the format phase (parsing + rewriting each `.tf` file via `hclsyntax`/`hclwrite`) ran serially even though every file is independent.
- Added `terraform.FormatFiles`, which runs `FormatFile` over a bounded worker pool (`GOMAXPROCS`), and switched `cmd/fmt.go` to use it.
- On this repo's 41 `.tf` files, the format phase dropped from ~47ms to ~20ms, bringing `ods fmt tf --check` down to ~60-70ms — on par with `terraform fmt`.

Note: a further ~30-40ms of fixed per-invocation overhead comes from `cmd/root.go` statically linking every subcommand (e.g. `ods audit`'s `osv-scalibr`/`grpc` deps) into the single binary, so `init()` cost is paid on every `ods` command regardless of which one runs. That's a separate, larger restructuring and is intentionally out of scope here.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/terraform/... ./cmd/...` (one pre-existing, unrelated failure in `TestReleaseCloud_pushFailureRollsBackLocalTag`, confirmed present on `main` too)
- [x] `pre-commit run --files tools/ods/cmd/fmt.go tools/ods/internal/terraform/format.go`
- [x] Manually timed `ods fmt tf --check` before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Formats Terraform files concurrently in `ods fmt tf` to match `terraform fmt` performance. Previously each file formatted serially; now a worker pool bounded by `GOMAXPROCS` formats files in parallel with the same output.

- Adds `terraform.FormatFiles(files, write)` that runs `FormatFile` concurrently and returns results/errors aligned to input order.
- Updates `cmd/fmt.go` to use `FormatFiles`; CLI flags, output, and check mode behavior are unchanged.
- On this repo (41 `.tf` files), format phase drops ~47ms → ~20ms; `ods fmt tf --check` now ~60–70ms, on par with `terraform fmt`.
- No migration required; expect higher parallel CPU usage during formatting.

<sup>Written for commit 55a3b6258e2cc6513b83dd9807cac049989637c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

