### PR TITLE
feat(terraform): add the Azure postgres module

### DIFF
--- a/deployment/terraform/modules/azure/postgres/main.tf
+++ b/deployment/terraform/modules/azure/postgres/main.tf
@@ -1,0 +1,261 @@
+locals {
+  create_private_dns_zone = var.private_dns_zone_id == null
+  private_dns_zone_id     = local.create_private_dns_zone ? azurerm_private_dns_zone.this[0].id : var.private_dns_zone_id
+
+  password_auth_enabled = !var.entra_authentication_only
+
+  # Alerts share one evaluation shape, chosen to match the AWS modules: sample
+  # every 5 minutes over a 15-minute window, so a single spike does not page.
+  alert_frequency   = "PT5M"
+  alert_window_size = "PT15M"
+  metric_namespace  = "Microsoft.DBforPostgreSQL/flexibleServers"
+}
+
+# A server joined to a virtual network resolves only through a private DNS
+# zone, and Azure requires the zone name to end in this suffix.
+resource "azurerm_private_dns_zone" "this" {
+  count = local.create_private_dns_zone ? 1 : 0
+
+  name                = "${var.name}.private.postgres.database.azure.com"
+  resource_group_name = var.resource_group_name
+  tags                = var.tags
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "this" {
+  count = local.create_private_dns_zone ? 1 : 0
+
+  name                  = "${var.name}-dns-link"
+  resource_group_name   = var.resource_group_name
+  private_dns_zone_name = azurerm_private_dns_zone.this[0].name
+  virtual_network_id    = var.virtual_network_id
+  registration_enabled  = false
+  tags                  = var.tags
+}
+
+resource "azurerm_postgresql_flexible_server" "this" {
+  name                = var.name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  version             = var.engine_version
+  sku_name            = var.sku_name
+  zone                = var.zone
+
+  storage_mb        = var.storage_gb * 1024
+  storage_tier      = var.storage_tier
+  auto_grow_enabled = var.auto_grow_enabled
+
+  # Joining the delegated subnet is what keeps the server off the public
+  # internet. Stating it outright as well means the server never depends on
+  # Azure defaulting the flag the way we expect.
+  public_network_access_enabled = false
+  delegated_subnet_id           = var.delegated_subnet_id
+  private_dns_zone_id           = local.private_dns_zone_id
+
+  administrator_login    = local.password_auth_enabled ? var.username : null
+  administrator_password = local.password_auth_enabled ? var.password : null
+
+  backup_retention_days        = var.backup_retention_days
+  geo_redundant_backup_enabled = var.geo_redundant_backup_enabled
+
+  dynamic "authentication" {
+    for_each = var.enable_entra_authentication ? [1] : []
+    content {
+      active_directory_auth_enabled = true
+      password_auth_enabled         = local.password_auth_enabled
+      tenant_id                     = var.tenant_id
+    }
+  }
+
+  dynamic "high_availability" {
+    for_each = var.high_availability_enabled ? [1] : []
+    content {
+      mode = var.high_availability_mode
+    }
+  }
+
+  dynamic "maintenance_window" {
+    for_each = var.maintenance_window != null ? [var.maintenance_window] : []
+    content {
+      day_of_week  = maintenance_window.value.day_of_week
+      start_hour   = maintenance_window.value.start_hour
+      start_minute = maintenance_window.value.start_minute
+    }
+  }
+
+  tags = var.tags
+
+  # Guardrail, same as the AWS postgres module: this server holds production
+  # data. A change Azure cannot make in place fails here rather than silently
+  # replacing the server with an empty one. A real migration is done
+  # deliberately with this guard removed.
+  lifecycle {
+    prevent_destroy = true
+
+    # Azure hands back the zone it picked, and the standby's zone with it.
+    # Neither can be changed without moving the server, so an unset variable
+    # must not read as "move it back".
+    ignore_changes = [zone, high_availability[0].standby_availability_zone]
+  }
+
+  depends_on = [azurerm_private_dns_zone_virtual_network_link.this]
+}
+
+# Without this an Entra-only server has no administrator: password logins are
+# off and no Entra principal has been granted access, so nobody can connect to
+# bootstrap the roles a workload identity needs.
+resource "azurerm_postgresql_flexible_server_active_directory_administrator" "this" {
+  count = var.enable_entra_authentication && var.entra_administrator_object_id != null ? 1 : 0
+
+  server_name         = azurerm_postgresql_flexible_server.this.name
+  resource_group_name = var.resource_group_name
+  tenant_id           = var.tenant_id
+  object_id           = var.entra_administrator_object_id
+  principal_name      = var.entra_administrator_principal_name
+  principal_type      = var.entra_administrator_principal_type
+}
+
+resource "azurerm_postgresql_flexible_server_database" "this" {
+  name      = var.db_name
+  server_id = azurerm_postgresql_flexible_server.this.id
+  charset   = "UTF8"
+  collation = "en_US.utf8"
+
+  # Dropping the database drops everything in it, and Azure gives no way back.
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "cpu" {
+  name                = "${var.name}-cpu-high"
+  resource_group_name = var.resource_group_name
+  scopes              = [azurerm_postgresql_flexible_server.this.id]
+  description         = "PostgreSQL ${var.name} CPU utilisation high"
+  severity            = 2
+  frequency           = local.alert_frequency
+  window_size         = local.alert_window_size
+  tags                = var.tags
+
+  criteria {
+    metric_namespace = local.metric_namespace
+    metric_name      = "cpu_percent"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.cpu_alarm_threshold
+  }
+
+  dynamic "action" {
+    for_each = var.action_group_ids
+    content {
+      action_group_id = action.value
+    }
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "memory" {
+  name                = "${var.name}-memory-high"
+  resource_group_name = var.resource_group_name
+  scopes              = [azurerm_postgresql_flexible_server.this.id]
+  description         = "PostgreSQL ${var.name} memory utilisation high"
+  severity            = 2
+  frequency           = local.alert_frequency
+  window_size         = local.alert_window_size
+  tags                = var.tags
+
+  criteria {
+    metric_namespace = local.metric_namespace
+    metric_name      = "memory_percent"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.memory_alarm_threshold
+  }
+
+  dynamic "action" {
+    for_each = var.action_group_ids
+    content {
+      action_group_id = action.value
+    }
+  }
+}
+
+# A full data volume wedges the writer. Auto-grow usually gets there first, but
+# it stops at the largest size Azure offers.
+resource "azurerm_monitor_metric_alert" "storage" {
+  name                = "${var.name}-storage-high"
+  resource_group_name = var.resource_group_name
+  scopes              = [azurerm_postgresql_flexible_server.this.id]
+  description         = "PostgreSQL ${var.name} storage nearly full"
+  severity            = 1
+  frequency           = local.alert_frequency
+  window_size         = local.alert_window_size
+  tags                = var.tags
+
+  criteria {
+    metric_namespace = local.metric_namespace
+    metric_name      = "storage_percent"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.storage_alarm_threshold
+  }
+
+  dynamic "action" {
+    for_each = var.action_group_ids
+    content {
+      action_group_id = action.value
+    }
+  }
+}
+
+# A task holding a session across an external call, or a request-cancel leak,
+# saturates the pool and new pods then fail to start.
+resource "azurerm_monitor_metric_alert" "connections" {
+  name                = "${var.name}-connections-high"
+  resource_group_name = var.resource_group_name
+  scopes              = [azurerm_postgresql_flexible_server.this.id]
+  description         = "PostgreSQL ${var.name} connection count high"
+  severity            = 2
+  frequency           = local.alert_frequency
+  window_size         = local.alert_window_size
+  tags                = var.tags
+
+  criteria {
+    metric_namespace = local.metric_namespace
+    metric_name      = "active_connections"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.connections_alarm_threshold
+  }
+
+  dynamic "action" {
+    for_each = var.action_group_ids
+    content {
+      action_group_id = action.value
+    }
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "iops" {
+  name                = "${var.name}-iops-high"
+  resource_group_name = var.resource_group_name
+  scopes              = [azurerm_postgresql_flexible_server.this.id]
+  description         = "PostgreSQL ${var.name} consuming most of its provisioned IOPS"
+  severity            = 2
+  frequency           = local.alert_frequency
+  window_size         = local.alert_window_size
+  tags                = var.tags
+
+  criteria {
+    metric_namespace = local.metric_namespace
+    metric_name      = "disk_iops_consumed_percentage"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.iops_alarm_threshold
+  }
+
+  dynamic "action" {
+    for_each = var.action_group_ids
+    content {
+      action_group_id = action.value
+    }
+  }
+}

--- a/deployment/terraform/modules/azure/postgres/outputs.tf
+++ b/deployment/terraform/modules/azure/postgres/outputs.tf
@@ -1,0 +1,40 @@
+output "server_id" {
+  description = "Resource ID of the flexible server"
+  value       = azurerm_postgresql_flexible_server.this.id
+}
+
+output "server_name" {
+  description = "Name of the flexible server"
+  value       = azurerm_postgresql_flexible_server.this.name
+}
+
+output "fqdn" {
+  description = "Private hostname of the server. Resolves only from networks linked to the private DNS zone."
+  value       = azurerm_postgresql_flexible_server.this.fqdn
+}
+
+output "port" {
+  description = "Port the server listens on"
+  value       = 5432
+}
+
+output "db_name" {
+  description = "Name of the database created on the server"
+  value       = azurerm_postgresql_flexible_server_database.this.name
+}
+
+output "username" {
+  description = "Administrator login, null when password authentication is off"
+  value       = azurerm_postgresql_flexible_server.this.administrator_login
+  sensitive   = true
+}
+
+output "private_dns_zone_id" {
+  description = "Resource ID of the private DNS zone the server resolves through"
+  value       = local.private_dns_zone_id
+}
+
+output "entra_administrator_object_id" {
+  description = "Object ID of the Entra database administrator, null when none was configured"
+  value       = try(azurerm_postgresql_flexible_server_active_directory_administrator.this[0].object_id, null)
+}

--- a/deployment/terraform/modules/azure/postgres/tests/postgres.tftest.hcl
+++ b/deployment/terraform/modules/azure/postgres/tests/postgres.tftest.hcl
@@ -1,0 +1,352 @@
+# Plans the module against a mocked provider, so these run without an Azure
+# subscription or credentials. Run with `terraform test` from the module directory.
+
+mock_provider "azurerm" {}
+
+variables {
+  name                = "onyx-postgres-prod"
+  resource_group_name = "onyx-rg"
+  location            = "eastus"
+  delegated_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/onyx-vnet/subnets/onyx-postgres"
+  virtual_network_id  = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/onyx-vnet"
+  password            = "not-a-real-password"
+}
+
+run "defaults" {
+  command = plan
+
+  assert {
+    condition     = azurerm_postgresql_flexible_server.this.storage_mb == 131072
+    error_message = "storage_gb should be converted to the MB the provider wants."
+  }
+
+  assert {
+    condition     = azurerm_private_dns_zone.this[0].name == "onyx-postgres-prod.private.postgres.database.azure.com"
+    error_message = "Azure requires the private DNS zone name to end in .private.postgres.database.azure.com."
+  }
+
+  assert {
+    condition     = azurerm_postgresql_flexible_server.this.delegated_subnet_id != null
+    error_message = "The server must join the delegated subnet so it has no public endpoint."
+  }
+
+  assert {
+    condition     = length(azurerm_postgresql_flexible_server.this.high_availability) == 0
+    error_message = "High availability is opt-in because it roughly doubles cost."
+  }
+
+  assert {
+    condition     = length(azurerm_postgresql_flexible_server.this.authentication) == 0
+    error_message = "Entra ID authentication is opt-in, matching the AWS module's IAM auth."
+  }
+
+  assert {
+    condition     = azurerm_postgresql_flexible_server.this.administrator_login == "psqladmin"
+    error_message = "Password authentication is on by default, so the admin login should be set."
+  }
+}
+
+run "all_five_alerts_exist_and_stay_silent" {
+  command = plan
+
+  assert {
+    condition     = length(azurerm_monitor_metric_alert.cpu.action) == 0
+    error_message = "With no action group the alerts must exist but notify nothing, the same as the AWS modules."
+  }
+
+  assert {
+    condition     = azurerm_monitor_metric_alert.storage.criteria[0].metric_name == "storage_percent"
+    error_message = "The AWS module's free-storage floor maps onto Azure's percent-used metric."
+  }
+
+  assert {
+    condition     = azurerm_monitor_metric_alert.storage.severity == 1
+    error_message = "A full data volume wedges the writer, so it should outrank the other alerts."
+  }
+
+  assert {
+    condition     = azurerm_monitor_metric_alert.iops.criteria[0].metric_name == "disk_iops_consumed_percentage"
+    error_message = "IOPS should alert against the provisioned limit, not an absolute count."
+  }
+}
+
+run "an_action_group_wires_every_alert" {
+  command = plan
+
+  variables {
+    action_group_ids = ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Insights/actionGroups/onyx-pager"]
+  }
+
+  assert {
+    condition = alltrue([
+      length(azurerm_monitor_metric_alert.cpu.action) == 1,
+      length(azurerm_monitor_metric_alert.memory.action) == 1,
+      length(azurerm_monitor_metric_alert.storage.action) == 1,
+      length(azurerm_monitor_metric_alert.connections.action) == 1,
+      length(azurerm_monitor_metric_alert.iops.action) == 1,
+    ])
+    error_message = "Every alert should route to the supplied action group."
+  }
+}
+
+run "entra_only_drops_the_password_login" {
+  command = plan
+
+  variables {
+    enable_entra_authentication        = true
+    entra_authentication_only          = true
+    tenant_id                          = "00000000-0000-0000-0000-000000000000"
+    password                           = null
+    entra_administrator_object_id      = "11111111-1111-1111-1111-111111111111"
+    entra_administrator_principal_name = "onyx-db-admins"
+    entra_administrator_principal_type = "Group"
+  }
+
+  assert {
+    condition     = length(azurerm_postgresql_flexible_server_active_directory_administrator.this) == 1
+    error_message = "An Entra-only server needs an Entra administrator, or nobody can connect to it."
+  }
+
+  # administrator_login is Optional+Computed, so a null reads as unknown until
+  # apply. The authentication block below is what actually turns password
+  # logins off, and it is knowable at plan time.
+  assert {
+    condition     = one(azurerm_postgresql_flexible_server.this.authentication).password_auth_enabled == false
+    error_message = "entra_authentication_only must turn password authentication off on the server."
+  }
+
+  assert {
+    condition     = one(azurerm_postgresql_flexible_server.this.authentication).active_directory_auth_enabled == true
+    error_message = "Entra ID authentication should be on."
+  }
+}
+
+run "high_availability_is_zone_redundant" {
+  command = plan
+
+  variables {
+    high_availability_enabled = true
+  }
+
+  assert {
+    condition     = one(azurerm_postgresql_flexible_server.this.high_availability).mode == "ZoneRedundant"
+    error_message = "The standby should default to a second zone."
+  }
+}
+
+run "an_existing_dns_zone_is_reused" {
+  command = plan
+
+  variables {
+    private_dns_zone_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/privateDnsZones/existing.private.postgres.database.azure.com"
+  }
+
+  assert {
+    condition     = length(azurerm_private_dns_zone.this) == 0
+    error_message = "Supplying a zone must not create a second one."
+  }
+
+  assert {
+    condition     = length(azurerm_private_dns_zone_virtual_network_link.this) == 0
+    error_message = "The caller owns the link for a zone they supplied."
+  }
+}
+
+run "no_entra_administrator_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(azurerm_postgresql_flexible_server_active_directory_administrator.this) == 0
+    error_message = "A password-authenticated server needs no Entra administrator."
+  }
+}
+
+run "rejects_a_server_that_would_have_no_password" {
+  command = plan
+
+  variables {
+    password = null
+  }
+
+  expect_failures = [var.password]
+}
+
+run "rejects_entra_only_with_nobody_able_to_log_in" {
+  command = plan
+
+  variables {
+    enable_entra_authentication = true
+    entra_authentication_only   = true
+    tenant_id                   = "00000000-0000-0000-0000-000000000000"
+    password                    = null
+  }
+
+  expect_failures = [var.entra_authentication_only]
+}
+
+run "rejects_a_half_specified_entra_administrator" {
+  command = plan
+
+  variables {
+    enable_entra_authentication   = true
+    tenant_id                     = "00000000-0000-0000-0000-000000000000"
+    entra_administrator_object_id = "11111111-1111-1111-1111-111111111111"
+  }
+
+  expect_failures = [var.entra_administrator_principal_name]
+}
+
+run "accepts_a_storage_tier_azure_offers" {
+  command = plan
+
+  variables {
+    storage_tier = "P30"
+  }
+
+  assert {
+    condition     = azurerm_postgresql_flexible_server.this.storage_tier == "P30"
+    error_message = "A valid tier should reach the server."
+  }
+}
+
+run "rejects_a_storage_tier_azure_does_not_offer" {
+  command = plan
+
+  variables {
+    storage_tier = "P12"
+  }
+
+  expect_failures = [var.storage_tier]
+}
+
+run "the_server_states_that_it_has_no_public_endpoint" {
+  command = plan
+
+  assert {
+    condition     = azurerm_postgresql_flexible_server.this.public_network_access_enabled == false
+    error_message = "The server should never depend on Azure defaulting this flag the way we expect."
+  }
+}
+
+run "a_tier_can_be_raised_at_the_largest_sizes" {
+  command = plan
+
+  # Raising the tier to buy IOPS is the documented feature, and it applies at
+  # the top of the range too.
+  variables {
+    storage_gb   = 8192
+    storage_tier = "P70"
+  }
+
+  assert {
+    condition     = azurerm_postgresql_flexible_server.this.storage_tier == "P70"
+    error_message = "A raised tier should reach the server rather than being refused."
+  }
+}
+
+run "rejects_a_tier_below_the_size_default" {
+  command = plan
+
+  variables {
+    storage_gb   = 512
+    storage_tier = "P10"
+  }
+
+  expect_failures = [var.storage_tier]
+}
+
+run "accepts_the_high_tier_at_the_size_that_carries_it" {
+  command = plan
+
+  variables {
+    storage_gb   = 8192
+    storage_tier = "P60"
+  }
+
+  assert {
+    condition     = azurerm_postgresql_flexible_server.this.storage_tier == "P60"
+    error_message = "P60 is the tier the 8192 GiB volume carries."
+  }
+}
+
+run "rejects_backup_retention_below_the_flexible_server_floor" {
+  command = plan
+
+  variables {
+    backup_retention_days = 3
+  }
+
+  expect_failures = [var.backup_retention_days]
+}
+
+run "rejects_a_storage_size_azure_does_not_offer" {
+  command = plan
+
+  variables {
+    storage_gb = 100
+  }
+
+  expect_failures = [var.storage_gb]
+}
+
+run "rejects_high_availability_on_a_burstable_sku" {
+  command = plan
+
+  variables {
+    sku_name                  = "B_Standard_B2s"
+    high_availability_enabled = true
+  }
+
+  expect_failures = [var.high_availability_enabled]
+}
+
+run "rejects_entra_only_without_entra" {
+  command = plan
+
+  # password is cleared so the only rule left to break is the one this run is
+  # about, rather than the unrelated "password would be discarded" rule.
+  variables {
+    entra_authentication_only = true
+    password                  = null
+  }
+
+  expect_failures = [var.entra_authentication_only]
+}
+
+run "rejects_a_password_that_would_be_discarded" {
+  command = plan
+
+  # The administrator is supplied so that the only rule left to break is the
+  # one about the password.
+  variables {
+    enable_entra_authentication        = true
+    entra_authentication_only          = true
+    tenant_id                          = "00000000-0000-0000-0000-000000000000"
+    password                           = "not-a-real-password"
+    entra_administrator_object_id      = "11111111-1111-1111-1111-111111111111"
+    entra_administrator_principal_name = "onyx-db-admins"
+    entra_administrator_principal_type = "Group"
+  }
+
+  expect_failures = [var.password]
+}
+
+run "rejects_entra_without_a_tenant" {
+  command = plan
+
+  variables {
+    enable_entra_authentication = true
+  }
+
+  expect_failures = [var.tenant_id]
+}
+
+run "rejects_backup_retention_azure_would_reject" {
+  command = plan
+
+  variables {
+    backup_retention_days = 0
+  }
+
+  expect_failures = [var.backup_retention_days]
+}

--- a/deployment/terraform/modules/azure/postgres/variables.tf
+++ b/deployment/terraform/modules/azure/postgres/variables.tf
@@ -1,0 +1,350 @@
+variable "name" {
+  type        = string
+  description = "Name of the flexible server and the resources named after it"
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$", var.name))
+    error_message = "name must be 3-63 characters of lowercase letters, digits and hyphens, and must start and end with a letter or digit."
+  }
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group that holds the server"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region, for example \"eastus\""
+}
+
+variable "db_name" {
+  type        = string
+  description = "Name of the database created on the server"
+  default     = "postgres"
+}
+
+variable "engine_version" {
+  type        = string
+  description = "PostgreSQL major version"
+  default     = "17"
+}
+
+# Azure sizes a flexible server by SKU name rather than by an instance class.
+# The prefix picks the tier: B is burstable, GP is general purpose, MO is
+# memory optimised.
+variable "sku_name" {
+  type        = string
+  description = "Flexible server SKU, for example \"GP_Standard_D2ds_v5\". B-prefixed SKUs are burstable and cannot run zone-redundant high availability."
+  default     = "GP_Standard_D2ds_v5"
+
+  validation {
+    condition     = can(regex("^(B|GP|MO)_", var.sku_name))
+    error_message = "sku_name must start with B_, GP_ or MO_ (for example \"GP_Standard_D2ds_v5\")."
+  }
+}
+
+# Azure allows only a fixed ladder of storage sizes, unlike the arbitrary GiB
+# the AWS module accepts. Picking a value off the ladder fails at apply, so it
+# is rejected here instead.
+variable "storage_gb" {
+  type        = number
+  description = "Storage size in GiB. Azure allows only these steps, and storage can grow but never shrink."
+  default     = 128
+
+  validation {
+    condition     = contains([32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384], var.storage_gb)
+    error_message = "storage_gb must be one of: 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384 (the sizes Azure offers in whole GiB). Azure's largest size is not a whole number of GiB and is not reachable through this variable."
+  }
+}
+
+variable "storage_tier" {
+  type        = string
+  description = "Performance tier for the storage. Null takes the default that Azure pairs with storage_gb. Raising it buys IOPS without buying capacity."
+  default     = null
+
+  validation {
+    condition     = var.storage_tier == null || contains(["P4", "P6", "P10", "P15", "P20", "P30", "P40", "P50", "P60", "P70", "P80"], coalesce(var.storage_tier, "P4"))
+    error_message = "storage_tier must be one of the tiers Azure offers: P4, P6, P10, P15, P20, P30, P40, P50, P60, P70, P80."
+  }
+
+  # Each storage size carries a default tier, and the documented feature is
+  # raising it to buy IOPS without buying capacity. Going below the default is
+  # what Azure refuses, so that is what is checked here. No ceiling is asserted:
+  # which of the higher tiers a given size accepts is not something this module
+  # can state confidently, and rejecting a valid configuration is worse than
+  # letting Azure be the one to refuse an invalid one.
+  validation {
+    # try() keeps a tier that is not a tier at all from erroring here; the rule
+    # above is the one that reports that.
+    condition = var.storage_tier == null || try(index(
+      ["P4", "P6", "P10", "P15", "P20", "P30", "P40", "P50", "P60", "P70", "P80"],
+      coalesce(var.storage_tier, "P4"),
+      ) >= index(
+      ["P4", "P6", "P10", "P15", "P20", "P30", "P40", "P50", "P60", "P70", "P80"],
+      lookup({
+        "32"    = "P4"
+        "64"    = "P6"
+        "128"   = "P10"
+        "256"   = "P15"
+        "512"   = "P20"
+        "1024"  = "P30"
+        "2048"  = "P40"
+        "4096"  = "P50"
+        "8192"  = "P60"
+        "16384" = "P70"
+      }, tostring(var.storage_gb), "P4"),
+    ), true)
+    error_message = "storage_tier is below the tier this storage_gb starts at. A size can be raised to a higher tier to buy IOPS, but not lowered below its own default."
+  }
+}
+
+# The AWS module takes a storage ceiling; Azure only offers a switch, and grows
+# the volume in steps on its own.
+variable "auto_grow_enabled" {
+  type        = bool
+  description = "Let Azure grow the storage volume as it fills. There is no ceiling to set, unlike the AWS module's max_storage_gb."
+  default     = true
+}
+
+variable "delegated_subnet_id" {
+  type        = string
+  description = "Subnet delegated to Microsoft.DBforPostgreSQL/flexibleServers. The server joins the virtual network and gets no public endpoint."
+}
+
+variable "virtual_network_id" {
+  type        = string
+  description = "Virtual network linked to the private DNS zone, so clients in it resolve the server's private name"
+}
+
+variable "private_dns_zone_id" {
+  type        = string
+  description = "Existing private DNS zone to use. Null creates one named \"<name>.private.postgres.database.azure.com\"."
+  default     = null
+}
+
+variable "username" {
+  type        = string
+  description = "Administrator login. Ignored when password authentication is disabled."
+  default     = "psqladmin"
+  sensitive   = true
+}
+
+variable "password" {
+  type        = string
+  description = "Administrator password. Ignored when password authentication is disabled."
+  default     = null
+  sensitive   = true
+
+  validation {
+    condition     = var.password == null || !var.entra_authentication_only
+    error_message = "password cannot be set when entra_authentication_only is true: the server accepts no password logins and the value would be discarded."
+  }
+
+  # The mirror of the rule above. Password logins are on unless the caller turns
+  # them off, and Azure rejects a server created with them on and no password.
+  validation {
+    condition     = var.password != null || var.entra_authentication_only
+    error_message = "password must be set unless entra_authentication_only is true. Azure rejects a server that accepts password logins but has no administrator password."
+  }
+}
+
+variable "enable_entra_authentication" {
+  type        = bool
+  description = "Accept Microsoft Entra ID logins. This is the analogue of the AWS module's IAM database authentication, and is what lets a workload identity reach the database without a password."
+  default     = false
+}
+
+variable "entra_authentication_only" {
+  type        = bool
+  description = "Turn off password logins so Entra ID is the only way in. Requires enable_entra_authentication."
+  default     = false
+
+  validation {
+    condition     = !var.entra_authentication_only || var.enable_entra_authentication
+    error_message = "entra_authentication_only requires enable_entra_authentication to be true."
+  }
+
+  validation {
+    condition     = !var.entra_authentication_only || var.entra_administrator_object_id != null
+    error_message = "entra_authentication_only requires entra_administrator_object_id, otherwise the server accepts no password logins and has no Entra administrator either, leaving nobody able to connect."
+  }
+}
+
+# Turning off password logins without naming an Entra administrator leaves a
+# server nobody can connect to, so the module creates one.
+variable "entra_administrator_object_id" {
+  type        = string
+  description = "Object ID of the Entra principal to make database administrator. Required when entra_authentication_only is true, so that somebody can still log in."
+  default     = null
+}
+
+variable "entra_administrator_principal_name" {
+  type        = string
+  description = "Display name of the Entra administrator, for example a user principal name or a group name"
+  default     = null
+
+  validation {
+    condition     = (var.entra_administrator_object_id == null) == (var.entra_administrator_principal_name == null)
+    error_message = "entra_administrator_object_id and entra_administrator_principal_name must be set together."
+  }
+}
+
+variable "entra_administrator_principal_type" {
+  type        = string
+  description = "What kind of Entra principal the administrator is"
+  default     = "ServicePrincipal"
+
+  validation {
+    condition     = contains(["User", "Group", "ServicePrincipal"], var.entra_administrator_principal_type)
+    error_message = "entra_administrator_principal_type must be one of: User, Group, ServicePrincipal."
+  }
+}
+
+variable "tenant_id" {
+  type        = string
+  description = "Entra ID tenant that owns the administrator identities. Required when enable_entra_authentication is true."
+  default     = null
+
+  validation {
+    condition     = !var.enable_entra_authentication || var.tenant_id != null
+    error_message = "tenant_id must be set when enable_entra_authentication is true."
+  }
+}
+
+variable "high_availability_enabled" {
+  type        = bool
+  description = "Run a standby in a second zone. Roughly doubles cost. Not available on burstable (B_) SKUs."
+  default     = false
+
+  validation {
+    condition     = !var.high_availability_enabled || !startswith(var.sku_name, "B_")
+    error_message = "Zone-redundant high availability is not offered on burstable SKUs. Move to a GP_ or MO_ SKU first."
+  }
+}
+
+variable "high_availability_mode" {
+  type        = string
+  description = "ZoneRedundant puts the standby in another zone and survives a zone outage. SameZone only survives a node failure, and is the fallback in regions with no zones."
+  default     = "ZoneRedundant"
+
+  validation {
+    condition     = contains(["ZoneRedundant", "SameZone"], var.high_availability_mode)
+    error_message = "high_availability_mode must be ZoneRedundant or SameZone."
+  }
+}
+
+variable "backup_retention_days" {
+  type        = number
+  description = "Days to retain automated backups"
+  default     = 7
+
+  validation {
+    condition     = var.backup_retention_days >= 7 && var.backup_retention_days <= 35
+    error_message = "backup_retention_days must be between 7 and 35. Flexible Server has no shorter retention, and unlike AWS backups cannot be turned off."
+  }
+}
+
+variable "geo_redundant_backup_enabled" {
+  type        = bool
+  description = "Copy backups to the paired region. Can only be set when the server is created."
+  default     = false
+}
+
+variable "maintenance_window" {
+  type = object({
+    day_of_week  = number
+    start_hour   = number
+    start_minute = number
+  })
+  description = "Weekly maintenance window in UTC, with Sunday as day 0. Null lets Azure choose."
+  default     = null
+
+  validation {
+    condition = var.maintenance_window == null || (
+      var.maintenance_window.day_of_week >= 0 && var.maintenance_window.day_of_week <= 6 &&
+      var.maintenance_window.start_hour >= 0 && var.maintenance_window.start_hour <= 23 &&
+      var.maintenance_window.start_minute >= 0 && var.maintenance_window.start_minute <= 59
+    )
+    error_message = "maintenance_window needs day_of_week 0-6, start_hour 0-23 and start_minute 0-59."
+  }
+}
+
+variable "zone" {
+  type        = string
+  description = "Availability zone for the primary. Null lets Azure choose. Changing it after creation moves the server."
+  default     = null
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to the server and its alerts"
+  default     = {}
+}
+
+# --- Alerts ------------------------------------------------------------------
+# Same shape as the AWS modules: the alerts always exist, and stay silent until
+# a caller supplies somewhere to send them.
+
+variable "action_group_ids" {
+  type        = list(string)
+  description = "Monitor action groups to notify. Empty = alerts exist but notify nothing."
+  default     = []
+}
+
+variable "cpu_alarm_threshold" {
+  type        = number
+  description = "cpu_percent threshold"
+  default     = 80
+
+  validation {
+    condition     = var.cpu_alarm_threshold > 0 && var.cpu_alarm_threshold <= 100
+    error_message = "cpu_alarm_threshold must be between 0 and 100 (percentage)."
+  }
+}
+
+# Azure reports memory and storage as percentages used, where the AWS module
+# alarms on bytes free. The thresholds are therefore inverted, not translated.
+variable "memory_alarm_threshold" {
+  type        = number
+  description = "memory_percent threshold. The AWS module alarms on free bytes; Azure publishes percent used."
+  default     = 85
+
+  validation {
+    condition     = var.memory_alarm_threshold > 0 && var.memory_alarm_threshold <= 100
+    error_message = "memory_alarm_threshold must be between 0 and 100 (percentage)."
+  }
+}
+
+variable "storage_alarm_threshold" {
+  type        = number
+  description = "storage_percent threshold. Matches the AWS module's floor of 15% free."
+  default     = 85
+
+  validation {
+    condition     = var.storage_alarm_threshold > 0 && var.storage_alarm_threshold <= 100
+    error_message = "storage_alarm_threshold must be between 0 and 100 (percentage)."
+  }
+}
+
+variable "connections_alarm_threshold" {
+  type        = number
+  description = "active_connections threshold. Size it against the server's real max_connections, which scales with the SKU."
+  default     = 500
+
+  validation {
+    condition     = var.connections_alarm_threshold > 0
+    error_message = "connections_alarm_threshold must be greater than 0."
+  }
+}
+
+variable "iops_alarm_threshold" {
+  type        = number
+  description = "disk_iops_consumed_percentage threshold. Azure publishes IOPS against the provisioned limit, which is more useful than the AWS module's absolute ReadIOPS count."
+  default     = 90
+
+  validation {
+    condition     = var.iops_alarm_threshold > 0 && var.iops_alarm_threshold <= 100
+    error_message = "iops_alarm_threshold must be between 0 and 100 (percentage)."
+  }
+}

--- a/deployment/terraform/modules/azure/postgres/versions.tf
+++ b/deployment/terraform/modules/azure/postgres/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/deployment/terraform/modules/azure/storage/main.tf
+++ b/deployment/terraform/modules/azure/storage/main.tf
@@ -1,0 +1,126 @@
+locals {
+  # With no allowlist the account stays reachable from any network and access
+  # is gated on Entra ID alone, which is how the AWS s3 module behaves when no
+  # bucket policy is set. Supplying either list flips the account to deny-first.
+  restrict_network = length(var.allowed_subnet_ids) > 0 || length(var.allowed_source_ips) > 0
+
+  # A management policy with no rules is rejected, so only create one when at
+  # least one rule applies.
+  has_lifecycle_rules = var.enable_versioning || var.expiration_days > 0 || var.transition_to_cool
+}
+
+resource "azurerm_storage_account" "this" {
+  name                = var.storage_account_name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  # Premium block blob is its own account kind. Leaving this at StorageV2 makes
+  # Azure reject the account outright when the caller asks for Premium.
+  account_kind             = var.account_tier == "Premium" ? "BlockBlobStorage" : "StorageV2"
+  account_tier             = var.account_tier
+  account_replication_type = var.account_replication_type
+
+  https_traffic_only_enabled    = true
+  min_tls_version               = var.min_tls_version
+  public_network_access_enabled = var.public_network_access_enabled
+  shared_access_key_enabled     = var.shared_access_key_enabled
+
+  # The pair of settings that keep blobs from ever being served anonymously.
+  allow_nested_items_to_be_public = false
+  default_to_oauth_authentication = true
+
+  tags = var.tags
+
+  blob_properties {
+    versioning_enabled = var.enable_versioning
+
+    dynamic "delete_retention_policy" {
+      for_each = var.blob_soft_delete_days > 0 ? [1] : []
+      content {
+        days = var.blob_soft_delete_days
+      }
+    }
+
+    dynamic "container_delete_retention_policy" {
+      for_each = var.container_soft_delete_days > 0 ? [1] : []
+      content {
+        days = var.container_soft_delete_days
+      }
+    }
+  }
+
+  dynamic "network_rules" {
+    for_each = local.restrict_network ? [1] : []
+    content {
+      default_action             = "Deny"
+      bypass                     = var.network_rules_bypass
+      virtual_network_subnet_ids = var.allowed_subnet_ids
+      ip_rules                   = var.allowed_source_ips
+    }
+  }
+}
+
+resource "azurerm_storage_container" "this" {
+  name                  = var.container_name
+  storage_account_id    = azurerm_storage_account.this.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_management_policy" "this" {
+  count              = local.has_lifecycle_rules ? 1 : 0
+  storage_account_id = azurerm_storage_account.this.id
+
+  dynamic "rule" {
+    for_each = var.enable_versioning ? [1] : []
+    content {
+      name    = "noncurrent-version-expiration"
+      enabled = true
+
+      filters {
+        blob_types = ["blockBlob"]
+      }
+
+      actions {
+        version {
+          delete_after_days_since_creation = var.noncurrent_expiration_days
+        }
+      }
+    }
+  }
+
+  dynamic "rule" {
+    for_each = var.expiration_days > 0 ? [1] : []
+    content {
+      name    = "object-expiration"
+      enabled = true
+
+      filters {
+        blob_types = ["blockBlob"]
+      }
+
+      actions {
+        base_blob {
+          delete_after_days_since_modification_greater_than = var.expiration_days
+        }
+      }
+    }
+  }
+
+  dynamic "rule" {
+    for_each = var.transition_to_cool ? [1] : []
+    content {
+      name    = "transition-to-cool"
+      enabled = true
+
+      filters {
+        blob_types = ["blockBlob"]
+      }
+
+      actions {
+        base_blob {
+          tier_to_cool_after_days_since_modification_greater_than = var.transition_to_cool_days
+        }
+      }
+    }
+  }
+}

--- a/deployment/terraform/modules/azure/storage/outputs.tf
+++ b/deployment/terraform/modules/azure/storage/outputs.tf
@@ -1,0 +1,25 @@
+output "storage_account_id" {
+  description = "Resource ID of the storage account. Role assignments and flow log destinations take this."
+  value       = azurerm_storage_account.this.id
+}
+
+output "storage_account_name" {
+  description = "Name of the storage account. Set this as AZURE_STORAGE_ACCOUNT_NAME."
+  value       = azurerm_storage_account.this.name
+}
+
+output "primary_blob_endpoint" {
+  description = "Blob service endpoint. Set this as AZURE_STORAGE_ACCOUNT_URL."
+  value       = azurerm_storage_account.this.primary_blob_endpoint
+}
+
+output "container_name" {
+  description = "Name of the file store container. Set this as AZURE_FILE_STORE_CONTAINER_NAME."
+  value       = azurerm_storage_container.this.name
+}
+
+output "primary_access_key" {
+  description = "Shared access key, null unless shared_access_key_enabled is true. Onyx uses workload identity and does not need it."
+  value       = var.shared_access_key_enabled ? azurerm_storage_account.this.primary_access_key : null
+  sensitive   = true
+}

--- a/deployment/terraform/modules/azure/storage/tests/storage.tftest.hcl
+++ b/deployment/terraform/modules/azure/storage/tests/storage.tftest.hcl
@@ -1,0 +1,266 @@
+# Plans the module against a mocked provider, so these run without an Azure
+# subscription or credentials. Run with `terraform test` from the module directory.
+
+mock_provider "azurerm" {}
+
+variables {
+  storage_account_name = "onyxfilestoreprod"
+  resource_group_name  = "onyx-rg"
+  location             = "eastus"
+}
+
+run "defaults_are_private_and_keyless" {
+  command = plan
+
+  assert {
+    condition     = azurerm_storage_account.this.shared_access_key_enabled == false
+    error_message = "Onyx authenticates with workload identity, so shared keys should be off by default."
+  }
+
+  assert {
+    condition     = azurerm_storage_account.this.allow_nested_items_to_be_public == false
+    error_message = "Blobs must never be servable anonymously."
+  }
+
+  assert {
+    condition     = azurerm_storage_account.this.default_to_oauth_authentication == true
+    error_message = "The account should default to Entra ID authentication."
+  }
+
+  assert {
+    condition     = azurerm_storage_container.this.container_access_type == "private"
+    error_message = "The file store container must be private."
+  }
+
+  assert {
+    condition     = azurerm_storage_account.this.min_tls_version == "TLS1_2"
+    error_message = "The account should refuse TLS below 1.2."
+  }
+}
+
+run "no_allowlist_leaves_the_account_open_to_the_network" {
+  command = plan
+
+  assert {
+    condition     = length(azurerm_storage_account.this.network_rules) == 0
+    error_message = "With no allowlist the account is gated on Entra ID alone, matching how the AWS s3 module behaves with no bucket policy."
+  }
+}
+
+run "an_allowlist_flips_the_account_to_deny_first" {
+  command = plan
+
+  variables {
+    allowed_subnet_ids = ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/onyx-vnet/subnets/onyx-aks"]
+  }
+
+  assert {
+    condition     = one(azurerm_storage_account.this.network_rules).default_action == "Deny"
+    error_message = "Supplying an allowlist must deny everything else."
+  }
+
+  assert {
+    condition     = contains(one(azurerm_storage_account.this.network_rules).bypass, "AzureServices")
+    error_message = "AzureServices must stay exempt or Monitor and Backup lose access."
+  }
+}
+
+run "default_lifecycle_rules" {
+  command = plan
+
+  assert {
+    condition     = length(azurerm_storage_management_policy.this[0].rule) == 2
+    error_message = "Versioning and cool-tiering are on by default; blob expiry is not."
+  }
+
+  assert {
+    condition     = contains(azurerm_storage_management_policy.this[0].rule[*].name, "noncurrent-version-expiration")
+    error_message = "Non-current versions should expire by default."
+  }
+
+  assert {
+    condition     = contains(azurerm_storage_management_policy.this[0].rule[*].name, "transition-to-cool")
+    error_message = "Blobs should tier to Cool by default."
+  }
+}
+
+run "expiry_adds_a_third_rule" {
+  command = plan
+
+  variables {
+    expiration_days = 365
+  }
+
+  assert {
+    condition     = length(azurerm_storage_management_policy.this[0].rule) == 3
+    error_message = "Setting expiration_days should add the object-expiration rule."
+  }
+}
+
+run "no_rules_means_no_policy" {
+  command = plan
+
+  variables {
+    enable_versioning  = false
+    transition_to_cool = false
+    expiration_days    = 0
+  }
+
+  assert {
+    condition     = length(azurerm_storage_management_policy.this) == 0
+    error_message = "Azure rejects a management policy with no rules, so the module must not create one."
+  }
+}
+
+run "premium_uses_the_account_kind_azure_requires" {
+  command = plan
+
+  variables {
+    account_tier             = "Premium"
+    account_replication_type = "ZRS"
+    transition_to_cool       = false
+  }
+
+  assert {
+    condition     = azurerm_storage_account.this.account_kind == "BlockBlobStorage"
+    error_message = "Premium block blob is its own account kind; StorageV2 would be rejected outright."
+  }
+}
+
+run "standard_stays_on_storage_v2" {
+  command = plan
+
+  assert {
+    condition     = azurerm_storage_account.this.account_kind == "StorageV2"
+    error_message = "Standard accounts should stay on StorageV2."
+  }
+}
+
+run "rejects_premium_with_replication_it_cannot_have" {
+  command = plan
+
+  variables {
+    account_tier             = "Premium"
+    account_replication_type = "GRS"
+    transition_to_cool       = false
+  }
+
+  expect_failures = [var.account_replication_type]
+}
+
+run "rejects_cool_tiering_on_premium" {
+  command = plan
+
+  # Premium block blob accounts have no Cool tier, so the rule Azure would
+  # receive is one it rejects.
+  variables {
+    account_tier             = "Premium"
+    account_replication_type = "ZRS"
+  }
+
+  expect_failures = [var.transition_to_cool]
+}
+
+run "rejects_a_bypass_of_none_alongside_anything_else" {
+  command = plan
+
+  variables {
+    network_rules_bypass = ["None", "AzureServices"]
+  }
+
+  expect_failures = [var.network_rules_bypass]
+}
+
+run "accepts_a_bypass_of_none_on_its_own" {
+  command = plan
+
+  variables {
+    network_rules_bypass = ["None"]
+    allowed_subnet_ids   = ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/onyx-vnet/subnets/onyx-aks"]
+  }
+
+  assert {
+    condition     = contains(one(azurerm_storage_account.this.network_rules).bypass, "None")
+    error_message = "None on its own is a valid way to exempt nothing."
+  }
+}
+
+run "rejects_consecutive_hyphens_in_the_container_name" {
+  command = plan
+
+  variables {
+    container_name = "onyx--file-store"
+  }
+
+  expect_failures = [var.container_name]
+}
+
+run "rejects_a_container_name_that_is_too_short" {
+  command = plan
+
+  variables {
+    container_name = "ab"
+  }
+
+  expect_failures = [var.container_name]
+}
+
+run "rejects_a_container_name_ending_in_a_hyphen" {
+  command = plan
+
+  variables {
+    container_name = "onyx-file-store-"
+  }
+
+  expect_failures = [var.container_name]
+}
+
+run "rejects_a_retired_tls_version" {
+  command = plan
+
+  variables {
+    min_tls_version = "TLS1_0"
+  }
+
+  expect_failures = [var.min_tls_version]
+}
+
+run "rejects_a_name_azure_would_reject" {
+  command = plan
+
+  variables {
+    storage_account_name = "Onyx-File-Store"
+  }
+
+  expect_failures = [var.storage_account_name]
+}
+
+run "rejects_a_name_that_is_too_long" {
+  command = plan
+
+  variables {
+    storage_account_name = "onyxfilestoreproductioneastus"
+  }
+
+  expect_failures = [var.storage_account_name]
+}
+
+run "rejects_a_host_prefix_azure_would_reject" {
+  command = plan
+
+  variables {
+    allowed_source_ips = ["203.0.113.7/32"]
+  }
+
+  expect_failures = [var.allowed_source_ips]
+}
+
+run "rejects_an_invalid_bypass" {
+  command = plan
+
+  variables {
+    network_rules_bypass = ["AzureServices", "Everything"]
+  }
+
+  expect_failures = [var.network_rules_bypass]
+}

--- a/deployment/terraform/modules/azure/storage/variables.tf
+++ b/deployment/terraform/modules/azure/storage/variables.tf
@@ -1,0 +1,204 @@
+variable "storage_account_name" {
+  type        = string
+  description = "Name of the storage account. Must be globally unique across Azure."
+
+  validation {
+    condition     = can(regex("^[a-z0-9]{3,24}$", var.storage_account_name))
+    error_message = "storage_account_name must be 3-24 characters of lowercase letters and digits only (Azure limit). Hyphens and uppercase are not allowed."
+  }
+}
+
+variable "container_name" {
+  type        = string
+  description = "Blob container that holds the Onyx file store. Maps to AZURE_FILE_STORE_CONTAINER_NAME."
+  default     = "onyx-file-store"
+
+  # Azure rejects consecutive hyphens, and anything shorter than three
+  # characters. The pattern allows at most one hyphen between runs of
+  # alphanumerics, which is the rule Azure actually applies; the length check is
+  # separate because folding 3-63 into the same expression obscures it.
+  validation {
+    condition = (
+      length(var.container_name) >= 3 &&
+      length(var.container_name) <= 63 &&
+      can(regex("^[a-z0-9](-?[a-z0-9])+$", var.container_name))
+    )
+    error_message = "container_name must be 3-63 characters of lowercase letters, digits and single hyphens, must start and end with a letter or digit, and cannot contain consecutive hyphens."
+  }
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group that holds the storage account"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region, for example \"eastus\""
+}
+
+variable "account_replication_type" {
+  type        = string
+  description = "Replication for the account. ZRS spreads copies across zones in one region, which is the closest match to how the AWS modules treat S3. LRS is cheaper but single-zone. Premium offers only LRS and ZRS."
+  default     = "ZRS"
+
+  validation {
+    condition     = contains(["LRS", "ZRS", "GRS", "RAGRS", "GZRS", "RAGZRS"], var.account_replication_type)
+    error_message = "account_replication_type must be one of: LRS, ZRS, GRS, RAGRS, GZRS, RAGZRS."
+  }
+
+  validation {
+    condition     = var.account_tier != "Premium" || contains(["LRS", "ZRS"], var.account_replication_type)
+    error_message = "Premium block blob accounts support only LRS and ZRS replication."
+  }
+}
+
+variable "account_tier" {
+  type        = string
+  description = "Performance tier. Standard is correct for a document file store; Premium is for low-latency block blob workloads."
+  default     = "Standard"
+
+  validation {
+    condition     = contains(["Standard", "Premium"], var.account_tier)
+    error_message = "account_tier must be Standard or Premium."
+  }
+}
+
+# Onyx authenticates to Blob with DefaultAzureCredential, so the account does
+# not need shared keys. Leaving them off means a leaked key cannot exist.
+variable "shared_access_key_enabled" {
+  type        = bool
+  description = "Allow authenticating with the account's shared keys. Off by default: Onyx uses workload identity, and callers that need a key can set AZURE_STORAGE_ACCOUNT_KEY only after turning this on. Set storage_use_azuread = true on the azurerm provider so Terraform itself does not reach for a key either."
+  default     = false
+}
+
+variable "enable_versioning" {
+  type        = bool
+  description = "Keep previous versions of overwritten blobs"
+  default     = true
+}
+
+variable "blob_soft_delete_days" {
+  type        = number
+  description = "Days a deleted blob stays recoverable. 0 disables soft delete."
+  default     = 7
+
+  validation {
+    condition     = var.blob_soft_delete_days >= 0 && var.blob_soft_delete_days <= 365
+    error_message = "blob_soft_delete_days must be between 0 (disabled) and 365 (Azure limit)."
+  }
+}
+
+variable "container_soft_delete_days" {
+  type        = number
+  description = "Days a deleted container stays recoverable. 0 disables soft delete."
+  default     = 7
+
+  validation {
+    condition     = var.container_soft_delete_days >= 0 && var.container_soft_delete_days <= 365
+    error_message = "container_soft_delete_days must be between 0 (disabled) and 365 (Azure limit)."
+  }
+}
+
+variable "noncurrent_expiration_days" {
+  type        = number
+  description = "Days to retain non-current blob versions. Only applies when enable_versioning is true."
+  default     = 90
+
+  validation {
+    condition     = var.noncurrent_expiration_days > 0
+    error_message = "noncurrent_expiration_days must be greater than 0."
+  }
+}
+
+variable "expiration_days" {
+  type        = number
+  description = "Days after which current blobs are deleted. 0 disables expiry."
+  default     = 0
+
+  validation {
+    condition     = var.expiration_days >= 0
+    error_message = "expiration_days must be 0 (disabled) or a positive number of days."
+  }
+}
+
+variable "transition_to_cool" {
+  type        = bool
+  description = "Move blobs to the Cool access tier once they stop being modified. Not available on Premium: block blob accounts have no Cool tier."
+  default     = true
+
+  validation {
+    condition     = !var.transition_to_cool || var.account_tier != "Premium"
+    error_message = "transition_to_cool is not available on Premium: block blob accounts have no Cool tier, and Azure rejects the lifecycle rule. Set transition_to_cool = false alongside account_tier = \"Premium\"."
+  }
+}
+
+# Azure has no equivalent of S3 Intelligent-Tiering, so the AWS modules'
+# 7-day transition does not carry over: Cool bills a minimum of 30 days per
+# blob, and moving earlier costs more than it saves.
+variable "transition_to_cool_days" {
+  type        = number
+  description = "Days since last modification before a blob moves to the Cool tier. Below 30 the early-deletion charge outweighs the storage saving."
+  default     = 30
+
+  validation {
+    condition     = var.transition_to_cool_days >= 1
+    error_message = "transition_to_cool_days must be at least 1."
+  }
+}
+
+variable "allowed_subnet_ids" {
+  type        = list(string)
+  description = "Subnets allowed to reach the account. Each needs the Microsoft.Storage service endpoint. Leaving this and allowed_source_ips empty keeps the account reachable from any network and gated on Entra ID alone."
+  default     = []
+}
+
+variable "allowed_source_ips" {
+  type        = list(string)
+  description = "Public IPv4 addresses or CIDR ranges allowed to reach the account."
+  default     = []
+
+  validation {
+    condition     = alltrue([for ip in var.allowed_source_ips : !can(regex("/(3[12])$", ip))])
+    error_message = "Azure rejects /31 and /32 in storage network rules. Write a single address without a prefix length."
+  }
+}
+
+variable "network_rules_bypass" {
+  type        = list(string)
+  description = "Azure platform paths exempted from the network rules. AzureServices is what lets Monitor, Backup and the portal reach the account."
+  default     = ["AzureServices"]
+
+  validation {
+    condition     = alltrue([for b in var.network_rules_bypass : contains(["AzureServices", "Logging", "Metrics", "None"], b)])
+    error_message = "network_rules_bypass entries must be one of: AzureServices, Logging, Metrics, None."
+  }
+
+  validation {
+    condition     = !contains(var.network_rules_bypass, "None") || length(var.network_rules_bypass) == 1
+    error_message = "None means no exemptions at all, so it cannot be combined with AzureServices, Logging or Metrics."
+  }
+}
+
+variable "public_network_access_enabled" {
+  type        = bool
+  description = "Allow the account's public endpoint to be reached at all. Set false only when every consumer goes through a private endpoint, otherwise the cluster loses access."
+  default     = true
+}
+
+variable "min_tls_version" {
+  type        = string
+  description = "Minimum TLS version accepted by the account. Only TLS1_2 is accepted: Azure retired the older versions for storage."
+  default     = "TLS1_2"
+
+  validation {
+    condition     = var.min_tls_version == "TLS1_2"
+    error_message = "min_tls_version must be TLS1_2. Azure retired TLS 1.0 and 1.1 for storage, so the older values only produce a setting the platform will not honour."
+  }
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to the storage account"
+  default     = {}
+}

--- a/deployment/terraform/modules/azure/storage/versions.tf
+++ b/deployment/terraform/modules/azure/storage/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION
> **Stacked PR 3 of 7.** Each PR targets the branch below it, so GitHub retargets the next one to `main` as each merges. Review and merge bottom-up.
>
> 1. #14099 — `vnet`, network, subnets, NAT gateway
> 2. #14100 — `storage`, storage account + container
> 3. #14101 — `postgres`, flexible server + alerts **← this PR**
> 4. #14102 — `redis`, cache + private endpoint
> 5. #14103 — `aks`, cluster + workload identity
> 6. #14104 — `waf`, regional WAF policy
> 7. #14105 — `onyx`, composition + README

## Description

Mirrors `deployment/terraform/modules/aws/postgres`: a private database server, one database on it, and the same five alerts, silent until a caller supplies somewhere to send them.

The server always joins a delegated subnet, so it has no public endpoint. That also means it resolves only through a private DNS zone, which the module creates and links to the virtual network unless the caller supplies one.

Where the interface has to differ from the AWS module:

- **Storage comes off a fixed ladder of sizes** rather than an arbitrary GiB count, so an off-ladder value is rejected here instead of at apply. Azure offers auto-grow as a switch with no ceiling, replacing `max_storage_gb`.
- **Memory and storage alerts are inverted.** Azure publishes percent used where CloudWatch publishes bytes free, so the AWS module's free-storage floor of 15% becomes a `storage_percent` ceiling of 85. IOPS alerts against the provisioned limit, which is more useful than an absolute count.
- **Zone-redundant high availability replaces multi-AZ**, and Azure does not offer it on burstable SKUs. The module rejects that combination rather than letting apply fail.
- **Backups cannot be turned off**; the retention floor is one day, not zero.

Entra ID authentication is the analogue of RDS IAM auth, and is what will let a workload identity reach the database without a password once the `aks` module lands. `prevent_destroy` guards the server and the database, matching AWS.

## How Has This Been Tested?

```
cd deployment/terraform/modules/azure/postgres
terraform init -backend=false && terraform test
# Success! 12 passed, 0 failed.
```

The suite covers the GiB-to-MB conversion, the private DNS zone name Azure requires, the Entra-only path dropping password logins, and six input validations — including the storage-ladder and burstable-plus-HA combinations that would otherwise only fail at apply.

`terraform validate` and the repo's terraform hooks pass. Not applied against a live subscription.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

## Changes from review (greptile)

- **A password is now required** unless `entra_authentication_only` is set. The default path left password authentication on with a null password, which Azure rejects at create.
- **Entra-only mode now provisions a database administrator.** Turning password logins off without one left a server nobody could connect to, so there was no way to bootstrap the roles a workload identity needs. Added `azurerm_postgresql_flexible_server_active_directory_administrator` plus the three variables it needs, and a validation that refuses Entra-only without one.
- **`storage_tier` validated against the tiers Azure offers.** The regex accepted `P2`, `P12` and `P99`, none of which exist.

Tests: 12 → 18.

## Round 2

- **`storage_tier` is now validated against `storage_gb`, not just against the global tier list.** Each size starts at its own default tier and can only be raised within a set list; P60 and above exist only for the 8192 and 16384 GiB volumes. A tier that is valid on its own could still be one Azure refuses at that size.
- **`public_network_access_enabled = false` is now stated outright** rather than left to Azure defaulting it for a VNet-integrated server. I checked the provider accepts it alongside `delegated_subnet_id`.
- **`backup_retention_days` floor raised to 7.** Flexible Server has no shorter retention; 1–6 passed validation and failed the plan.
- **Dropped `32768` from the storage sizes.** Azure's largest volume is 33553408 MB, not `32768 * 1024`, so that entry produced a value the provider rejects.
- **Test isolation fix:** `rejects_entra_only_without_entra` inherited a password, so two rules fired and the run did not prove what it claimed.

Tests: 18 → 23.

## Round 3

- **The storage-tier rule no longer asserts a ceiling.** greptile was right that the capacity-specific allowlist rejected valid configurations — `8192` with `P70` among them. I did not take the suggested edit, because it still asserts ceilings (`"8192" = ["P60", "P70"]` excludes `P80`) that I cannot verify any better than the ones it replaces.

  Instead the rule now checks only what I am confident about: a size cannot go **below** its own default tier. Raising the tier to buy IOPS is the documented feature, so no upper bound is asserted at all. Under-constraining costs a little catch; over-constraining rejects deployments that would have worked, which is worse in a published module.

  One nuance worth noting: `index()` throws rather than failing validation when handed a value that is not in the list, so a bogus tier like `P12` produced a function error instead of a clean message. It is wrapped in `try()` so the tier-list rule reports that case.

Tests: 23 (one rewritten from a rejection case into an acceptance case).
