### PR TITLE
feat(terraform): add the Azure redis module

### DIFF
--- a/deployment/terraform/modules/azure/redis/main.tf
+++ b/deployment/terraform/modules/azure/redis/main.tf
@@ -1,0 +1,184 @@
+locals {
+  create_private_dns_zone = var.enable_private_endpoint && var.private_dns_zone_id == null
+  private_dns_zone_id     = local.create_private_dns_zone ? azurerm_private_dns_zone.this[0].id : var.private_dns_zone_id
+
+  # A cache behind a private endpoint has no reason to answer on its public
+  # hostname, so that is the default unless the caller says otherwise.
+  public_network_access_enabled = var.public_network_access_enabled != null ? var.public_network_access_enabled : !var.enable_private_endpoint
+
+  alert_frequency   = "PT5M"
+  alert_window_size = "PT15M"
+  metric_namespace  = "Microsoft.Cache/redis"
+}
+
+resource "azurerm_redis_cache" "this" {
+  name                = var.name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  sku_name = var.sku_name
+  family   = var.family
+  capacity = var.capacity
+  zones    = var.zones
+
+  minimum_tls_version           = var.minimum_tls_version
+  non_ssl_port_enabled          = false
+  public_network_access_enabled = local.public_network_access_enabled
+
+  access_keys_authentication_enabled = var.access_keys_enabled
+
+  redis_configuration {
+    maxmemory_policy                        = var.maxmemory_policy
+    active_directory_authentication_enabled = var.enable_entra_authentication
+  }
+
+  tags = var.tags
+}
+
+resource "azurerm_private_dns_zone" "this" {
+  count = local.create_private_dns_zone ? 1 : 0
+
+  name                = "privatelink.redis.cache.windows.net"
+  resource_group_name = var.resource_group_name
+  tags                = var.tags
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "this" {
+  count = local.create_private_dns_zone ? 1 : 0
+
+  name                  = "${var.name}-dns-link"
+  resource_group_name   = var.resource_group_name
+  private_dns_zone_name = azurerm_private_dns_zone.this[0].name
+  virtual_network_id    = var.virtual_network_id
+  registration_enabled  = false
+  tags                  = var.tags
+}
+
+resource "azurerm_private_endpoint" "this" {
+  count = var.enable_private_endpoint ? 1 : 0
+
+  name                = "${var.name}-pe"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  subnet_id           = var.private_endpoint_subnet_id
+  tags                = var.tags
+
+  private_service_connection {
+    name                           = "${var.name}-psc"
+    private_connection_resource_id = azurerm_redis_cache.this.id
+    subresource_names              = ["redisCache"]
+    is_manual_connection           = false
+  }
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [local.private_dns_zone_id]
+  }
+}
+
+# Memory is the failure mode that actually takes a broker down: keys that never
+# expire climb to the limit, eviction cannot free anything, and Redis starts
+# rejecting writes, at which point the whole Celery fleet crashloops at once.
+resource "azurerm_monitor_metric_alert" "memory_high" {
+  name                = "${var.name}-memory-high"
+  resource_group_name = var.resource_group_name
+  scopes              = [azurerm_redis_cache.this.id]
+  description         = "Redis ${var.name} memory usage high"
+  severity            = 2
+  frequency           = local.alert_frequency
+  window_size         = local.alert_window_size
+  tags                = var.tags
+
+  criteria {
+    metric_namespace = local.metric_namespace
+    metric_name      = "usedmemorypercentage"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.memory_high_threshold_percent
+  }
+
+  dynamic "action" {
+    for_each = var.action_group_ids
+    content {
+      action_group_id = action.value
+    }
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "memory_critical" {
+  name                = "${var.name}-memory-critical"
+  resource_group_name = var.resource_group_name
+  scopes              = [azurerm_redis_cache.this.id]
+  description         = "Redis ${var.name} memory usage critical, writes may be rejected"
+  severity            = 1
+  frequency           = local.alert_frequency
+  window_size         = local.alert_window_size
+  tags                = var.tags
+
+  criteria {
+    metric_namespace = local.metric_namespace
+    metric_name      = "usedmemorypercentage"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.memory_critical_threshold_percent
+  }
+
+  dynamic "action" {
+    for_each = var.action_group_ids
+    content {
+      action_group_id = action.value
+    }
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "server_load" {
+  name                = "${var.name}-server-load-high"
+  resource_group_name = var.resource_group_name
+  scopes              = [azurerm_redis_cache.this.id]
+  description         = "Redis ${var.name} server thread saturated"
+  severity            = 2
+  frequency           = local.alert_frequency
+  window_size         = local.alert_window_size
+  tags                = var.tags
+
+  criteria {
+    metric_namespace = local.metric_namespace
+    metric_name      = "serverLoad"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.server_load_threshold_percent
+  }
+
+  dynamic "action" {
+    for_each = var.action_group_ids
+    content {
+      action_group_id = action.value
+    }
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "evicted_keys" {
+  name                = "${var.name}-evicted-keys"
+  resource_group_name = var.resource_group_name
+  scopes              = [azurerm_redis_cache.this.id]
+  description         = "Redis ${var.name} is evicting keys, which for a Celery broker means dropped tasks"
+  severity            = 1
+  frequency           = local.alert_frequency
+  window_size         = local.alert_window_size
+  tags                = var.tags
+
+  criteria {
+    metric_namespace = local.metric_namespace
+    metric_name      = "evictedkeys"
+    aggregation      = "Total"
+    operator         = "GreaterThan"
+    threshold        = var.evicted_keys_threshold
+  }
+
+  dynamic "action" {
+    for_each = var.action_group_ids
+    content {
+      action_group_id = action.value
+    }
+  }
+}

--- a/deployment/terraform/modules/azure/redis/outputs.tf
+++ b/deployment/terraform/modules/azure/redis/outputs.tf
@@ -1,0 +1,33 @@
+output "cache_id" {
+  description = "Resource ID of the cache"
+  value       = azurerm_redis_cache.this.id
+}
+
+output "hostname" {
+  description = "Hostname of the cache. Behind a private endpoint this resolves to a private address from networks linked to the DNS zone."
+  value       = azurerm_redis_cache.this.hostname
+}
+
+output "ssl_port" {
+  description = "TLS port. The non-TLS port is disabled."
+  value       = azurerm_redis_cache.this.ssl_port
+}
+
+# The AWS module takes an auth token as an input; Azure generates the keys and
+# offers no way to set them, so the credential comes back out of the module.
+output "primary_access_key" {
+  description = "Generated primary access key, null when access keys are disabled"
+  value       = var.access_keys_enabled ? azurerm_redis_cache.this.primary_access_key : null
+  sensitive   = true
+}
+
+output "secondary_access_key" {
+  description = "Generated secondary access key, for rotating without downtime"
+  value       = var.access_keys_enabled ? azurerm_redis_cache.this.secondary_access_key : null
+  sensitive   = true
+}
+
+output "private_dns_zone_id" {
+  description = "Resource ID of the private DNS zone the cache resolves through, null when no private endpoint is used"
+  value       = local.private_dns_zone_id
+}

--- a/deployment/terraform/modules/azure/redis/tests/redis.tftest.hcl
+++ b/deployment/terraform/modules/azure/redis/tests/redis.tftest.hcl
@@ -1,0 +1,243 @@
+# Plans the module against a mocked provider, so these run without an Azure
+# subscription or credentials. Run with `terraform test` from the module directory.
+
+mock_provider "azurerm" {}
+
+variables {
+  name                       = "onyx-redis-prod"
+  resource_group_name        = "onyx-rg"
+  location                   = "eastus"
+  private_endpoint_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/onyx-vnet/subnets/onyx-private-endpoints"
+  virtual_network_id         = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/onyx-vnet"
+}
+
+run "defaults_are_private_and_tls_only" {
+  command = plan
+
+  assert {
+    condition     = azurerm_redis_cache.this.non_ssl_port_enabled == false
+    error_message = "The cache must not answer on the plaintext port."
+  }
+
+  assert {
+    condition     = azurerm_redis_cache.this.minimum_tls_version == "1.2"
+    error_message = "The cache should refuse TLS below 1.2."
+  }
+
+  assert {
+    condition     = azurerm_redis_cache.this.public_network_access_enabled == false
+    error_message = "A cache behind a private endpoint has no reason to answer on its public hostname."
+  }
+
+  assert {
+    condition     = length(azurerm_private_endpoint.this) == 1
+    error_message = "The private endpoint should be created by default."
+  }
+
+  assert {
+    condition     = one(azurerm_private_endpoint.this[0].private_service_connection).subresource_names[0] == "redisCache"
+    error_message = "The private endpoint must target the cache subresource."
+  }
+}
+
+run "default_size_matches_the_aws_module" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      azurerm_redis_cache.this.sku_name == "Standard",
+      azurerm_redis_cache.this.family == "C",
+      azurerm_redis_cache.this.capacity == 3,
+    ])
+    error_message = "Standard C3 is 6 GB with a replica, the size the AWS module defaults to."
+  }
+}
+
+run "four_alerts_exist_and_stay_silent" {
+  command = plan
+
+  assert {
+    condition     = length(azurerm_monitor_metric_alert.memory_high.action) == 0
+    error_message = "With no action group the alerts must exist but notify nothing."
+  }
+
+  assert {
+    condition     = azurerm_monitor_metric_alert.evicted_keys.criteria[0].metric_name == "evictedkeys"
+    error_message = "Azure exposes no swap metric, so evictions replace the AWS swap alarm."
+  }
+
+  assert {
+    condition     = azurerm_monitor_metric_alert.evicted_keys.criteria[0].aggregation == "Total"
+    error_message = "Evictions are a count over the window, not an average."
+  }
+
+  assert {
+    condition     = azurerm_monitor_metric_alert.server_load.criteria[0].metric_name == "serverLoad"
+    error_message = "Redis runs commands on one thread, so server load is the meaningful CPU signal."
+  }
+}
+
+run "disabling_the_private_endpoint_reopens_public_access" {
+  command = plan
+
+  variables {
+    enable_private_endpoint = false
+  }
+
+  assert {
+    condition     = azurerm_redis_cache.this.public_network_access_enabled == true
+    error_message = "Without a private endpoint the cache has to be reachable somehow."
+  }
+
+  assert {
+    condition     = length(azurerm_private_endpoint.this) == 0
+    error_message = "No private endpoint should be created."
+  }
+
+  assert {
+    condition     = length(azurerm_private_dns_zone.this) == 0
+    error_message = "The private DNS zone only exists to serve the private endpoint."
+  }
+}
+
+run "an_existing_dns_zone_is_reused" {
+  command = plan
+
+  variables {
+    private_dns_zone_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/privateDnsZones/privatelink.redis.cache.windows.net"
+  }
+
+  assert {
+    condition     = length(azurerm_private_dns_zone.this) == 0
+    error_message = "privatelink.redis.cache.windows.net is a fixed name, so a second cache in the group must reuse the first one's zone."
+  }
+}
+
+run "reusing_a_dns_zone_needs_no_virtual_network" {
+  command = plan
+
+  # The virtual network is only used to link a zone the module creates. A
+  # caller who brings their own zone has already linked it.
+  variables {
+    virtual_network_id  = null
+    private_dns_zone_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/privateDnsZones/privatelink.redis.cache.windows.net"
+  }
+
+  assert {
+    condition     = length(azurerm_private_endpoint.this) == 1
+    error_message = "The private endpoint should still be created."
+  }
+
+  assert {
+    condition     = length(azurerm_private_dns_zone_virtual_network_link.this) == 0
+    error_message = "There is no zone of our own to link."
+  }
+}
+
+run "rejects_a_private_endpoint_with_no_dns_anywhere" {
+  command = plan
+
+  variables {
+    virtual_network_id  = null
+    private_dns_zone_id = null
+  }
+
+  expect_failures = [var.enable_private_endpoint]
+}
+
+run "rejects_a_critical_threshold_below_the_warning_one" {
+  command = plan
+
+  variables {
+    memory_high_threshold_percent     = 90
+    memory_critical_threshold_percent = 80
+  }
+
+  expect_failures = [var.memory_critical_threshold_percent]
+}
+
+run "rejects_a_fractional_capacity" {
+  command = plan
+
+  variables {
+    capacity = 2.5
+  }
+
+  expect_failures = [var.capacity]
+}
+
+run "rejects_a_cache_nothing_can_reach" {
+  command = plan
+
+  # No private endpoint and no public hostname means every Redis-dependent
+  # workload fails at runtime rather than at plan.
+  variables {
+    enable_private_endpoint       = false
+    public_network_access_enabled = false
+  }
+
+  expect_failures = [var.public_network_access_enabled]
+}
+
+run "rejects_a_family_that_does_not_match_the_tier" {
+  command = plan
+
+  variables {
+    sku_name = "Premium"
+    family   = "C"
+  }
+
+  expect_failures = [var.family]
+}
+
+run "rejects_a_capacity_outside_the_family" {
+  command = plan
+
+  variables {
+    sku_name = "Premium"
+    family   = "P"
+    capacity = 6
+  }
+
+  expect_failures = [var.capacity]
+}
+
+run "rejects_zones_on_a_tier_that_cannot_use_them" {
+  command = plan
+
+  variables {
+    zones = ["1", "2"]
+  }
+
+  expect_failures = [var.zones]
+}
+
+run "rejects_turning_off_every_way_in" {
+  command = plan
+
+  variables {
+    access_keys_enabled = false
+  }
+
+  expect_failures = [var.access_keys_enabled]
+}
+
+run "rejects_a_private_endpoint_with_nowhere_to_put_it" {
+  command = plan
+
+  variables {
+    private_endpoint_subnet_id = null
+  }
+
+  expect_failures = [var.enable_private_endpoint]
+}
+
+run "rejects_an_unknown_eviction_policy" {
+  command = plan
+
+  variables {
+    maxmemory_policy = "evict-everything"
+  }
+
+  expect_failures = [var.maxmemory_policy]
+}

--- a/deployment/terraform/modules/azure/redis/variables.tf
+++ b/deployment/terraform/modules/azure/redis/variables.tf
@@ -1,0 +1,243 @@
+variable "name" {
+  type        = string
+  description = "Name of the cache and the resources named after it"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$", var.name))
+    error_message = "name must be 2-63 characters of letters, digits and hyphens, and must start and end with a letter or digit."
+  }
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group that holds the cache"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region, for example \"eastus\""
+}
+
+# Azure sizes a cache by tier, family and capacity rather than by an instance
+# type. Standard C3 is 6 GB with a replica, which is the size the AWS module
+# defaults to.
+variable "sku_name" {
+  type        = string
+  description = "Cache tier. Basic has no replica and no SLA. Standard adds a replica. Premium adds zone redundancy, persistence and clustering."
+  default     = "Standard"
+
+  validation {
+    condition     = contains(["Basic", "Standard", "Premium"], var.sku_name)
+    error_message = "sku_name must be Basic, Standard or Premium."
+  }
+}
+
+variable "family" {
+  type        = string
+  description = "SKU family. C goes with Basic and Standard, P goes with Premium."
+  default     = "C"
+
+  validation {
+    condition     = contains(["C", "P"], var.family)
+    error_message = "family must be C or P."
+  }
+
+  validation {
+    condition     = (var.sku_name == "Premium") == (var.family == "P")
+    error_message = "Premium uses family P; Basic and Standard use family C."
+  }
+}
+
+variable "capacity" {
+  type        = number
+  description = "Size within the family. C0 is 250 MB, C1 1 GB, C2 2.5 GB, C3 6 GB, C4 13 GB, C5 26 GB, C6 53 GB. P1 is 6 GB, P2 13 GB, P3 26 GB, P4 53 GB, P5 120 GB."
+  default     = 3
+
+  validation {
+    condition     = floor(var.capacity) == var.capacity
+    error_message = "capacity must be a whole number: the sizes are discrete steps, not a scale."
+  }
+
+  validation {
+    condition     = var.family != "C" || (var.capacity >= 0 && var.capacity <= 6)
+    error_message = "capacity must be between 0 and 6 for family C."
+  }
+
+  validation {
+    condition     = var.family != "P" || (var.capacity >= 1 && var.capacity <= 5)
+    error_message = "capacity must be between 1 and 5 for family P."
+  }
+}
+
+variable "zones" {
+  type        = list(string)
+  description = "Availability zones to spread the cache across. Only Premium offers this."
+  default     = []
+
+  validation {
+    condition     = length(var.zones) == 0 || var.sku_name == "Premium"
+    error_message = "Only the Premium tier can be spread across availability zones."
+  }
+}
+
+variable "minimum_tls_version" {
+  type        = string
+  description = "Minimum TLS version the cache accepts"
+  default     = "1.2"
+
+  validation {
+    condition     = contains(["1.0", "1.1", "1.2"], var.minimum_tls_version)
+    error_message = "minimum_tls_version must be one of: 1.0, 1.1, 1.2."
+  }
+}
+
+# The AWS module takes an auth token as an input. Azure generates the access
+# keys itself and offers no way to set them, so they come back as outputs
+# instead. That removes the need for a caller to invent and store a password.
+variable "access_keys_enabled" {
+  type        = bool
+  description = "Allow authenticating with the cache's generated access keys. Turn this off only once every client authenticates with Entra ID."
+  default     = true
+
+  validation {
+    condition     = var.access_keys_enabled || var.enable_entra_authentication
+    error_message = "Turning off access keys leaves no way to authenticate unless enable_entra_authentication is true."
+  }
+}
+
+variable "enable_entra_authentication" {
+  type        = bool
+  description = "Accept Microsoft Entra ID logins. This is the analogue of the AWS module's IAM authentication."
+  default     = false
+}
+
+variable "maxmemory_policy" {
+  type        = string
+  description = "What the cache does when it reaches its memory limit. Onyx uses Redis as a Celery broker, where an eviction silently drops a queued task, so watch the eviction alert if you move off the default."
+  default     = "volatile-lru"
+
+  validation {
+    condition = contains([
+      "noeviction", "allkeys-lru", "volatile-lru", "allkeys-random",
+      "volatile-random", "volatile-ttl", "allkeys-lfu", "volatile-lfu",
+    ], var.maxmemory_policy)
+    error_message = "maxmemory_policy must be one of: noeviction, allkeys-lru, volatile-lru, allkeys-random, volatile-random, volatile-ttl, allkeys-lfu, volatile-lfu."
+  }
+}
+
+variable "enable_private_endpoint" {
+  type        = bool
+  description = "Reach the cache over a private endpoint instead of its public hostname"
+  default     = true
+
+  validation {
+    condition     = !var.enable_private_endpoint || var.private_endpoint_subnet_id != null
+    error_message = "enable_private_endpoint requires private_endpoint_subnet_id."
+  }
+
+  validation {
+    condition     = !var.enable_private_endpoint || var.private_dns_zone_id != null || var.virtual_network_id != null
+    error_message = "enable_private_endpoint requires virtual_network_id so the private DNS zone can be linked to it, unless private_dns_zone_id points at a zone that is already linked."
+  }
+}
+
+variable "private_endpoint_subnet_id" {
+  type        = string
+  description = "Subnet that holds the private endpoint. It needs private_endpoint_network_policies set to Disabled."
+  default     = null
+}
+
+variable "virtual_network_id" {
+  type        = string
+  description = "Virtual network linked to the private DNS zone, so clients in it resolve the cache's private address"
+  default     = null
+}
+
+# privatelink.redis.cache.windows.net is a fixed name shared by every cache in
+# a resource group, so a second module in the same group must be handed the
+# zone the first one made rather than creating its own.
+variable "private_dns_zone_id" {
+  type        = string
+  description = "Existing privatelink.redis.cache.windows.net zone to use. Null creates one."
+  default     = null
+}
+
+variable "public_network_access_enabled" {
+  type        = bool
+  description = "Allow the cache's public hostname to be reached. Null follows enable_private_endpoint: private endpoint on means public access off."
+  default     = null
+
+  validation {
+    condition     = var.enable_private_endpoint || var.public_network_access_enabled != false
+    error_message = "Turning off both the private endpoint and public network access leaves a cache nothing can reach. Keep enable_private_endpoint on, or allow public access."
+  }
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to the cache and its alerts"
+  default     = {}
+}
+
+# --- Alerts ------------------------------------------------------------------
+
+variable "action_group_ids" {
+  type        = list(string)
+  description = "Monitor action groups to notify. Empty = alerts exist but notify nothing."
+  default     = []
+}
+
+variable "memory_high_threshold_percent" {
+  type        = number
+  description = "usedmemorypercentage warning threshold"
+  default     = 80
+
+  validation {
+    condition     = var.memory_high_threshold_percent > 0 && var.memory_high_threshold_percent <= 100
+    error_message = "memory_high_threshold_percent must be between 0 and 100."
+  }
+}
+
+variable "memory_critical_threshold_percent" {
+  type        = number
+  description = "usedmemorypercentage critical threshold. Near this the cache starts evicting or rejecting writes, and the Celery fleet goes with it."
+  default     = 90
+
+  validation {
+    condition     = var.memory_critical_threshold_percent > 0 && var.memory_critical_threshold_percent <= 100
+    error_message = "memory_critical_threshold_percent must be between 0 and 100."
+  }
+
+  validation {
+    condition     = var.memory_critical_threshold_percent >= var.memory_high_threshold_percent
+    error_message = "memory_critical_threshold_percent must be at least memory_high_threshold_percent, otherwise the critical alert fires before the warning one."
+  }
+}
+
+# Redis runs its commands on one thread, so server load is the meaningful CPU
+# signal, the same reason the AWS module alarms on EngineCPUUtilization rather
+# than host CPU.
+variable "server_load_threshold_percent" {
+  type        = number
+  description = "serverLoad threshold, the share of time the Redis server thread spent busy"
+  default     = 90
+
+  validation {
+    condition     = var.server_load_threshold_percent > 0 && var.server_load_threshold_percent <= 100
+    error_message = "server_load_threshold_percent must be between 0 and 100."
+  }
+}
+
+# Azure exposes no swap metric, so this replaces the AWS module's swap alarm.
+# It catches the same failure one step later: memory pressure that has started
+# costing data.
+variable "evicted_keys_threshold" {
+  type        = number
+  description = "Evictions per window before alerting. Zero alerts on the first eviction, which for a Celery broker means a dropped task."
+  default     = 0
+
+  validation {
+    condition     = var.evicted_keys_threshold >= 0
+    error_message = "evicted_keys_threshold must be 0 or greater."
+  }
+}

--- a/deployment/terraform/modules/azure/redis/versions.tf
+++ b/deployment/terraform/modules/azure/redis/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION
> **Stacked PR 4 of 7.** Each PR targets the branch below it, so GitHub retargets the next one to `main` as each merges. Review and merge bottom-up.
>
> 1. #14099 — `vnet`, network, subnets, NAT gateway
> 2. #14100 — `storage`, storage account + container
> 3. #14101 — `postgres`, flexible server + alerts
> 4. #14102 — `redis`, cache + private endpoint **← this PR**
> 5. #14103 — `aks`, cluster + workload identity
> 6. #14104 — `waf`, regional WAF policy
> 7. #14105 — `onyx`, composition + README

## Description

Mirrors `deployment/terraform/modules/aws/redis`: a private cache with the same four alerts, silent until a caller supplies somewhere to send them.

**The credential direction is reversed.** The AWS module takes an auth token as an input; Azure generates the access keys itself and offers no way to set them, so they come back as outputs. A caller no longer has to invent and store a password for the cache.

Other differences worth knowing when reading this against the AWS module:

- **Size is a tier, family and capacity** rather than an instance type. Standard C3 is 6 GB with a replica, matching the AWS default. Family and capacity have to agree with the tier, and only Premium can be spread across zones, so those combinations are rejected here rather than at apply.
- **Access is over a private endpoint by default**, which also turns the cache's public hostname off. That replaces the AWS module's security group.
- **Azure exposes no swap metric**, so the eviction count replaces the swap alarm. It catches the same memory pressure one step later, at the point it starts costing data: for a Celery broker an eviction is a dropped task.

Entra ID authentication is the analogue of the AWS module's IAM auth.

## How Has This Been Tested?

```
cd deployment/terraform/modules/azure/redis
terraform init -backend=false && terraform test
# Success! 11 passed, 0 failed.
```

The suite covers the TLS-only private defaults, the size mapping back to the AWS default, the four alerts, what turning the private endpoint off does, and six input validations.

`terraform validate` and the repo's terraform hooks pass. Not applied against a live subscription.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

## Changes from review (greptile, cubic)

- **`virtual_network_id` is only required when the module creates the DNS zone.** A caller reusing an existing zone has already linked it, so demanding the network rejected a configuration that was complete. Split into two validations so each error names the thing actually missing.
- **`memory_critical_threshold_percent` must be at least `memory_high_threshold_percent`**, otherwise the critical alert fires before the warning and the severities read backwards.

Tests: 11 → 14.

## Round 2

- **A fractional `capacity` is now rejected.** The sizes are discrete steps, and `2.5` passed the range checks before failing at the provider.
- **A cache nothing can reach is now rejected.** Setting `enable_private_endpoint = false` and `public_network_access_enabled = false` together left no network path at all — the cache was created and every Redis-dependent workload failed later at runtime.

Tests: 14 → 16.
