### PR TITLE
feat(terraform): add the Azure aks module

### DIFF
--- a/deployment/terraform/modules/azure/aks/main.tf
+++ b/deployment/terraform/modules/azure/aks/main.tf
@@ -1,0 +1,317 @@
+locals {
+  # AKS requires the system pool inline on the cluster, so "main" is handled
+  # separately from every other pool.
+  main_pool = var.node_pools["main"]
+
+  gpu_node_pool = var.enable_gpu_node_pool ? {
+    gpu = {
+      vm_size         = var.gpu_node_vm_size
+      min_count       = 1
+      max_count       = 1
+      os_disk_size_gb = 100
+      os_disk_type    = "Managed"
+      node_labels     = { "onyx.app/gpu" = "true" }
+      node_taints     = ["nvidia.com/gpu=true:NoSchedule"]
+      zones           = []
+      mode            = "User"
+    }
+  } : {}
+
+  sandbox_node_pool = var.enable_sandbox_node_pool ? {
+    sandbox = {
+      vm_size         = var.sandbox_node_vm_size
+      min_count       = var.sandbox_node_min_count
+      max_count       = var.sandbox_node_max_count
+      os_disk_size_gb = var.sandbox_node_disk_size_gb
+      os_disk_type    = "Managed"
+      node_labels     = { "onyx.app/workload" = "sandbox" }
+      node_taints     = ["workload=sandbox:NoSchedule"]
+      zones           = []
+      mode            = "User"
+    }
+  } : {}
+
+  additional_node_pools = merge(
+    {
+      for key, pool in var.node_pools : key => pool
+      if key != "main" && (key != "index" || var.index_node_pool_enabled)
+    },
+    local.gpu_node_pool,
+    local.sandbox_node_pool,
+  )
+
+  # Setting the DNS service address from the service range removes the chance
+  # of picking one outside it, which AKS rejects.
+  dns_service_ip = var.dns_service_ip != null ? var.dns_service_ip : cidrhost(var.service_cidr, 10)
+
+  # AKS rotates a pool through a spare name when a property changes. The name
+  # must be a valid pool name and unique across the cluster, so truncating the
+  # key is not enough: two keys sharing six characters would collide. A digest
+  # of the full key makes it unique.
+  rotation_names = {
+    for key in concat(["main"], keys(local.additional_node_pools)) :
+    key => substr("${substr(key, 0, 6)}${substr(sha1(key), 0, 6)}", 0, 12)
+  }
+
+  workload_identity_enabled = length(var.storage_account_ids) > 0
+
+  workload_service_account_names = distinct(concat(
+    [var.workload_service_account_name],
+    var.additional_workload_service_account_names,
+  ))
+
+  workload_service_account_subjects = {
+    for name in local.workload_service_account_names :
+    name => "system:serviceaccount:${var.workload_service_account_namespace}:${name}"
+  }
+
+  # Azure caps a federated credential name at 120 characters, and a namespace
+  # and a service account name can each be 63. Truncating alone would let two
+  # long names collide, so a digest of the full subject goes on the end.
+  federated_credential_names = {
+    for name, subject in local.workload_service_account_subjects :
+    name => "${substr("${var.workload_service_account_namespace}-${name}", 0, 100)}-${substr(sha1(subject), 0, 8)}"
+  }
+}
+
+resource "azurerm_kubernetes_cluster" "this" {
+  name                = var.cluster_name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  dns_prefix          = var.cluster_name
+  kubernetes_version  = var.kubernetes_version
+  sku_tier            = var.sku_tier
+
+  private_cluster_enabled           = var.private_cluster_enabled
+  azure_policy_enabled              = var.azure_policy_enabled
+  role_based_access_control_enabled = true
+
+  # The pair that makes workload identity work. The issuer is the trust anchor
+  # the federated credentials below point at.
+  oidc_issuer_enabled       = true
+  workload_identity_enabled = true
+
+  # This pool is always the system pool, so it takes no mode argument.
+  default_node_pool {
+    name    = "main"
+    vm_size = local.main_pool.vm_size
+
+    auto_scaling_enabled = true
+    min_count            = local.main_pool.min_count
+    max_count            = local.main_pool.max_count
+
+    os_disk_size_gb = local.main_pool.os_disk_size_gb
+    os_disk_type    = local.main_pool.os_disk_type
+    node_labels     = local.main_pool.node_labels
+    zones           = local.main_pool.zones
+    vnet_subnet_id  = var.subnet_id
+
+    # Without a name to rotate through, changing a property of the system pool
+    # replaces the whole cluster instead of the pool.
+    temporary_name_for_rotation = local.rotation_names["main"]
+
+    tags = var.tags
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin      = "azure"
+    network_plugin_mode = var.network_plugin_mode
+    network_policy      = var.network_policy
+    network_data_plane  = var.network_policy == "cilium" ? "cilium" : null
+    pod_cidr            = var.network_plugin_mode == "overlay" ? var.pod_cidr : null
+    service_cidr        = var.service_cidr
+    dns_service_ip      = local.dns_service_ip
+    outbound_type       = var.outbound_type
+    load_balancer_sku   = "standard"
+  }
+
+  storage_profile {
+    disk_driver_enabled         = true
+    file_driver_enabled         = true
+    blob_driver_enabled         = false
+    snapshot_controller_enabled = true
+  }
+
+  dynamic "api_server_access_profile" {
+    for_each = length(var.api_server_authorized_ip_ranges) > 0 ? [1] : []
+    content {
+      authorized_ip_ranges = var.api_server_authorized_ip_ranges
+    }
+  }
+
+  dynamic "azure_active_directory_role_based_access_control" {
+    for_each = length(var.entra_rbac_admin_group_object_ids) > 0 ? [1] : []
+    content {
+      admin_group_object_ids = var.entra_rbac_admin_group_object_ids
+      azure_rbac_enabled     = var.entra_rbac_enabled
+    }
+  }
+
+  dynamic "oms_agent" {
+    for_each = var.log_analytics_workspace_id != null ? [1] : []
+    content {
+      log_analytics_workspace_id      = var.log_analytics_workspace_id
+      msi_auth_for_monitoring_enabled = true
+    }
+  }
+
+  tags = var.tags
+
+  lifecycle {
+    # AKS reports the node count the autoscaler settled on. Treating that as
+    # drift would fight the autoscaler on every apply.
+    ignore_changes = [default_node_pool[0].node_count]
+  }
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "this" {
+  for_each = local.additional_node_pools
+
+  name                  = each.key
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.this.id
+  vm_size               = each.value.vm_size
+  mode                  = each.value.mode
+
+  auto_scaling_enabled = true
+  min_count            = each.value.min_count
+  max_count            = each.value.max_count
+
+  os_disk_size_gb = each.value.os_disk_size_gb
+  os_disk_type    = each.value.os_disk_type
+  node_labels     = each.value.node_labels
+  node_taints     = each.value.node_taints
+  zones           = each.value.zones
+  vnet_subnet_id  = var.subnet_id
+
+  temporary_name_for_rotation = local.rotation_names[each.key]
+
+  tags = var.tags
+
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+}
+
+# --- Workload identity -------------------------------------------------------
+
+resource "azurerm_user_assigned_identity" "workload" {
+  count = local.workload_identity_enabled ? 1 : 0
+
+  name                = "${var.cluster_name}-workload"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  tags                = var.tags
+}
+
+# One credential per service account. The subject is the same
+# system:serviceaccount:<namespace>:<name> string the AWS module puts in an
+# IRSA trust policy; Azure matches it against the cluster's OIDC issuer.
+resource "azurerm_federated_identity_credential" "workload" {
+  for_each = local.workload_identity_enabled ? local.workload_service_account_subjects : {}
+
+  name                      = local.federated_credential_names[each.key]
+  user_assigned_identity_id = azurerm_user_assigned_identity.workload[0].id
+  audience                  = ["api://AzureADTokenExchange"]
+  issuer                    = azurerm_kubernetes_cluster.this.oidc_issuer_url
+  subject                   = each.value
+}
+
+# Counted rather than keyed by account id. The ids normally come from a storage
+# module in the same apply, so they are not known at plan time, and a for_each
+# over unknown keys fails the plan outright.
+resource "azurerm_role_assignment" "workload_storage" {
+  count = local.workload_identity_enabled ? length(var.storage_account_ids) : 0
+
+  scope                = var.storage_account_ids[count.index]
+  role_definition_name = var.storage_role_definition_name
+  principal_id         = azurerm_user_assigned_identity.workload[0].principal_id
+  principal_type       = "ServicePrincipal"
+
+  # The identity is created in this same apply, and Entra does not always have
+  # the service principal replicated by the time the assignment is made. Without
+  # this the apply fails with a transient PrincipalNotFound.
+  skip_service_principal_aad_check = true
+}
+
+# Created before the service account below, which cannot exist without it. The
+# documented Helm install then targets this namespace rather than making its own.
+resource "kubernetes_namespace" "workload" {
+  count = local.workload_identity_enabled && var.create_workload_service_account && var.create_workload_namespace ? 1 : 0
+
+  metadata {
+    name = var.workload_service_account_namespace
+  }
+
+  depends_on = [azurerm_kubernetes_cluster.this]
+}
+
+resource "kubernetes_service_account" "workload" {
+  count = local.workload_identity_enabled && var.create_workload_service_account ? 1 : 0
+
+  depends_on = [azurerm_kubernetes_cluster.this]
+
+  metadata {
+    name = var.workload_service_account_name
+    # Reading the name back off the namespace is what orders this after it.
+    namespace = var.create_workload_namespace ? kubernetes_namespace.workload[0].metadata[0].name : var.workload_service_account_namespace
+
+    annotations = {
+      "azure.workload.identity/client-id" = azurerm_user_assigned_identity.workload[0].client_id
+    }
+
+    # Without this label the webhook does not project a token into the pod, and
+    # the identity is never used.
+    labels = {
+      "azure.workload.identity/use" = "true"
+    }
+  }
+}
+
+# --- Cluster add-ons ---------------------------------------------------------
+
+resource "kubernetes_storage_class" "premium" {
+  count = var.create_premium_storage_class ? 1 : 0
+
+  metadata {
+    name = var.premium_storage_class_name
+    annotations = var.premium_storage_class_is_default ? {
+      "storageclass.kubernetes.io/is-default-class" = "true"
+    } : {}
+  }
+
+  storage_provisioner = "disk.csi.azure.com"
+  reclaim_policy      = "Delete"
+  # A disk is created in one zone, so binding has to wait until the scheduler
+  # has picked the node that will use it.
+  volume_binding_mode    = "WaitForFirstConsumer"
+  allow_volume_expansion = true
+
+  parameters = {
+    skuName = "Premium_LRS"
+  }
+
+  depends_on = [azurerm_kubernetes_cluster.this]
+}
+
+resource "azurerm_monitor_diagnostic_setting" "this" {
+  count = var.log_analytics_workspace_id != null ? 1 : 0
+
+  name                       = "${var.cluster_name}-diagnostics"
+  target_resource_id         = azurerm_kubernetes_cluster.this.id
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+
+  dynamic "enabled_log" {
+    for_each = var.control_plane_log_categories
+    content {
+      category = enabled_log.value
+    }
+  }
+
+  enabled_metric {
+    category = "AllMetrics"
+  }
+}

--- a/deployment/terraform/modules/azure/aks/outputs.tf
+++ b/deployment/terraform/modules/azure/aks/outputs.tf
@@ -1,0 +1,86 @@
+output "cluster_id" {
+  description = "Resource ID of the cluster"
+  value       = azurerm_kubernetes_cluster.this.id
+}
+
+output "cluster_name" {
+  description = "Name of the cluster"
+  value       = azurerm_kubernetes_cluster.this.name
+}
+
+# A private cluster leaves fqdn empty and publishes private_fqdn instead, so
+# taking only the first returns nothing usable for the private case.
+output "cluster_fqdn" {
+  description = "API server hostname. For a private cluster this is the private name, which resolves only from inside the network."
+  value       = coalesce(azurerm_kubernetes_cluster.this.fqdn, azurerm_kubernetes_cluster.this.private_fqdn)
+}
+
+# The trust anchor for federated credentials, the same role the OIDC provider
+# plays for IRSA on AWS.
+output "oidc_issuer_url" {
+  description = "OIDC issuer URL of the cluster"
+  value       = azurerm_kubernetes_cluster.this.oidc_issuer_url
+}
+
+output "node_resource_group" {
+  description = "Resource group AKS creates for the cluster's own infrastructure. Node disks and load balancers land here, not in the cluster's resource group."
+  value       = azurerm_kubernetes_cluster.this.node_resource_group
+}
+
+output "kubelet_identity_object_id" {
+  description = "Object ID of the kubelet identity, for granting nodes access to a container registry"
+  value       = try(azurerm_kubernetes_cluster.this.kubelet_identity[0].object_id, null)
+}
+
+output "workload_identity_client_id" {
+  description = "Client ID of the workload identity, which annotates the service account. Pods must also carry the azure.workload.identity/use label, which this module cannot set for them: without it the webhook projects no token. Null when no storage account was supplied."
+  value       = try(azurerm_user_assigned_identity.workload[0].client_id, null)
+}
+
+output "workload_identity_principal_id" {
+  description = "Principal ID of the workload identity, for granting it further roles"
+  value       = try(azurerm_user_assigned_identity.workload[0].principal_id, null)
+}
+
+output "workload_service_account_subjects" {
+  description = "Kubernetes service account subjects the workload identity trusts"
+  value       = local.workload_identity_enabled ? values(local.workload_service_account_subjects) : []
+}
+
+output "node_pool_names" {
+  description = "Names of every node pool on the cluster, including the system pool"
+  value       = concat(["main"], sort(keys(local.additional_node_pools)))
+}
+
+output "kube_config_raw" {
+  description = "kubeconfig for the cluster"
+  value       = azurerm_kubernetes_cluster.this.kube_config_raw
+  sensitive   = true
+}
+
+output "host" {
+  description = "API server address, for configuring the kubernetes and helm providers"
+  value       = try(azurerm_kubernetes_cluster.this.kube_config[0].host, null)
+  sensitive   = true
+}
+
+output "cluster_ca_certificate" {
+  description = "Cluster CA certificate, base64 encoded, for configuring the kubernetes and helm providers"
+  value       = try(azurerm_kubernetes_cluster.this.kube_config[0].cluster_ca_certificate, null)
+  sensitive   = true
+}
+
+# This module creates Kubernetes objects, so whoever calls it has to be able to
+# configure the kubernetes provider against the cluster it just made. These are
+# the remaining pieces that takes.
+output "client_certificate" {
+  description = "Client certificate, base64 encoded. Empty when local accounts are disabled and only Entra ID logins are accepted."
+  value       = try(azurerm_kubernetes_cluster.this.kube_config[0].client_certificate, null)
+  sensitive   = true
+}
+
+output "client_key" {
+  description = "Client key, base64 encoded. Empty when local accounts are disabled and only Entra ID logins are accepted."
+  value       = try(azurerm_kubernetes_cluster.this.kube_config[0].client_key, null)
+  sensitive   = true
+}

--- a/deployment/terraform/modules/azure/aks/tests/aks.tftest.hcl
+++ b/deployment/terraform/modules/azure/aks/tests/aks.tftest.hcl
@@ -1,0 +1,518 @@
+# Plans the module against mocked providers, so these run without an Azure
+# subscription or a cluster. Run with `terraform test` from the module directory.
+
+mock_provider "azurerm" {}
+mock_provider "kubernetes" {}
+
+variables {
+  cluster_name        = "onyx-prod"
+  resource_group_name = "onyx-rg"
+  location            = "eastus"
+  subnet_id           = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/onyx-vnet/subnets/onyx-aks"
+
+  # The module now refuses a public API server that no range restricts, so every
+  # case below has to say what it wants. This is the ordinary answer.
+  api_server_authorized_ip_ranges = ["203.0.113.0/24"]
+}
+
+run "defaults" {
+  command = plan
+
+  assert {
+    condition     = azurerm_kubernetes_cluster.this.oidc_issuer_enabled == true
+    error_message = "Workload identity needs the OIDC issuer on."
+  }
+
+  assert {
+    condition     = azurerm_kubernetes_cluster.this.workload_identity_enabled == true
+    error_message = "Workload identity is how a pod reaches storage without a key."
+  }
+
+  assert {
+    condition     = one(azurerm_kubernetes_cluster.this.default_node_pool).temporary_name_for_rotation == local.rotation_names["main"]
+    error_message = "Without a rotation name, changing a system pool property replaces the whole cluster."
+  }
+
+  assert {
+    condition     = one(azurerm_kubernetes_cluster.this.network_profile).outbound_type == "userAssignedNATGateway"
+    error_message = "Egress should use the NAT gateway the vnet module puts on the subnet, so it keeps one address."
+  }
+
+  # network_policy is Optional+Computed, so a null reads as unknown until apply.
+  # The plugin mode below is set outright, and the rejects_cilium_without_overlay
+  # case covers the constraint that actually matters.
+  assert {
+    condition     = one(azurerm_kubernetes_cluster.this.network_profile).network_plugin_mode == "overlay"
+    error_message = "Overlay keeps pod addresses out of the subnet, so the subnet only has to hold nodes."
+  }
+}
+
+run "dns_service_ip_is_derived_from_the_service_range" {
+  command = plan
+
+  assert {
+    condition     = one(azurerm_kubernetes_cluster.this.network_profile).dns_service_ip == "172.16.0.10"
+    error_message = "The DNS service address should be taken from service_cidr so it cannot fall outside it."
+  }
+}
+
+run "dns_service_ip_follows_a_changed_service_range" {
+  command = plan
+
+  variables {
+    service_cidr = "10.240.0.0/16"
+  }
+
+  assert {
+    condition     = one(azurerm_kubernetes_cluster.this.network_profile).dns_service_ip == "10.240.0.10"
+    error_message = "Changing service_cidr must move the DNS service address with it."
+  }
+}
+
+run "index_pool_runs_by_default" {
+  command = plan
+
+  assert {
+    condition     = contains(keys(azurerm_kubernetes_cluster_node_pool.this), "index")
+    error_message = "Azure has no managed OpenSearch, so the document index runs in the cluster by default."
+  }
+
+  assert {
+    condition     = contains(azurerm_kubernetes_cluster_node_pool.this["index"].node_taints, "document-index=true:NoSchedule")
+    error_message = "The index pool must be tainted so only the index lands on it."
+  }
+}
+
+run "index_pool_can_be_turned_off" {
+  command = plan
+
+  variables {
+    index_node_pool_enabled = false
+  }
+
+  assert {
+    condition     = length(azurerm_kubernetes_cluster_node_pool.this) == 0
+    error_message = "Turning the index pool off should leave only the system pool."
+  }
+}
+
+run "optional_pools_are_tainted_and_labelled" {
+  command = plan
+
+  variables {
+    enable_gpu_node_pool     = true
+    enable_sandbox_node_pool = true
+  }
+
+  assert {
+    condition     = length(azurerm_kubernetes_cluster_node_pool.this) == 3
+    error_message = "index, gpu and sandbox should all be present."
+  }
+
+  assert {
+    condition     = contains(azurerm_kubernetes_cluster_node_pool.this["gpu"].node_taints, "nvidia.com/gpu=true:NoSchedule")
+    error_message = "Only pods that tolerate the GPU taint should land on the GPU pool."
+  }
+
+  assert {
+    condition     = azurerm_kubernetes_cluster_node_pool.this["sandbox"].node_labels["onyx.app/workload"] == "sandbox"
+    error_message = "Sandbox pods select their pool by label."
+  }
+}
+
+run "no_storage_account_means_no_identity" {
+  command = plan
+
+  assert {
+    condition     = length(azurerm_user_assigned_identity.workload) == 0
+    error_message = "Nothing to grant means nothing to create, matching the AWS module."
+  }
+
+  assert {
+    condition     = length(azurerm_federated_identity_credential.workload) == 0
+    error_message = "No identity means no federated credentials."
+  }
+
+  assert {
+    condition     = length(kubernetes_service_account.workload) == 0
+    error_message = "No identity means no service account to annotate."
+  }
+}
+
+run "a_storage_account_federates_the_service_account" {
+  command = plan
+
+  variables {
+    storage_account_ids = ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Storage/storageAccounts/onyxfilestore"]
+  }
+
+  assert {
+    condition     = length(azurerm_federated_identity_credential.workload) == 1
+    error_message = "One credential per service account."
+  }
+
+  assert {
+    condition     = azurerm_federated_identity_credential.workload["onyx-workload-access"].subject == "system:serviceaccount:onyx:onyx-workload-access"
+    error_message = "The subject is the same system:serviceaccount string the AWS module puts in an IRSA trust policy."
+  }
+
+  assert {
+    condition     = azurerm_federated_identity_credential.workload["onyx-workload-access"].audience[0] == "api://AzureADTokenExchange"
+    error_message = "Azure only exchanges tokens for this audience."
+  }
+
+  # Counted, not keyed by id: the ids normally arrive from a storage module in
+  # the same apply and are unknown at plan time. The onyx composition's tests
+  # are what exercise that case, since only there are the ids actually unknown.
+  assert {
+    condition     = azurerm_role_assignment.workload_storage[0].role_definition_name == "Storage Blob Data Contributor"
+    error_message = "The identity should get blob data access on the account, and nothing wider."
+  }
+
+  assert {
+    condition     = kubernetes_service_account.workload[0].metadata[0].labels["azure.workload.identity/use"] == "true"
+    error_message = "Without this label the webhook never projects a token into the pod."
+  }
+}
+
+run "every_supplied_storage_account_gets_a_role_assignment" {
+  command = plan
+
+  variables {
+    storage_account_ids = [
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Storage/storageAccounts/onyxfilestore",
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Storage/storageAccounts/onyxuploads",
+    ]
+  }
+
+  assert {
+    condition     = length(azurerm_role_assignment.workload_storage) == 2
+    error_message = "One role assignment per storage account."
+  }
+
+  assert {
+    condition     = length(azurerm_federated_identity_credential.workload) == 1
+    error_message = "More accounts does not mean more service accounts."
+  }
+}
+
+run "the_namespace_is_created_before_the_service_account" {
+  command = plan
+
+  variables {
+    storage_account_ids = ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Storage/storageAccounts/onyxfilestore"]
+  }
+
+  assert {
+    condition     = length(kubernetes_namespace.workload) == 1
+    error_message = "On a fresh cluster nothing else has made the namespace, and the service account cannot exist without it."
+  }
+
+  assert {
+    condition     = kubernetes_namespace.workload[0].metadata[0].name == "onyx"
+    error_message = "The namespace created should be the one the service account lives in."
+  }
+}
+
+run "the_namespace_can_be_left_to_something_else" {
+  command = plan
+
+  variables {
+    storage_account_ids       = ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Storage/storageAccounts/onyxfilestore"]
+    create_workload_namespace = false
+  }
+
+  assert {
+    condition     = length(kubernetes_namespace.workload) == 0
+    error_message = "A caller whose namespace already exists should not have a second one created."
+  }
+
+  assert {
+    condition     = length(kubernetes_service_account.workload) == 1
+    error_message = "The service account is still created either way."
+  }
+}
+
+run "no_identity_means_no_namespace" {
+  command = plan
+
+  assert {
+    condition     = length(kubernetes_namespace.workload) == 0
+    error_message = "With no storage account there is no service account, so there is nothing to make a namespace for."
+  }
+}
+
+run "additional_service_accounts_are_federated_but_not_created" {
+  command = plan
+
+  variables {
+    storage_account_ids                       = ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Storage/storageAccounts/onyxfilestore"]
+    additional_workload_service_account_names = ["onyx-sandbox-proxy"]
+  }
+
+  assert {
+    condition     = length(azurerm_federated_identity_credential.workload) == 2
+    error_message = "A chart-created service account still needs its own credential."
+  }
+
+  assert {
+    condition     = length(kubernetes_service_account.workload) == 1
+    error_message = "The module creates only its own service account; the chart owns the others."
+  }
+}
+
+run "the_storage_class_is_not_default_unless_asked" {
+  command = plan
+
+  assert {
+    condition     = length(kubernetes_storage_class.premium[0].metadata[0].annotations) == 0
+    error_message = "AKS already ships a default class, so marking a second one would leave the cluster with two."
+  }
+
+  assert {
+    condition     = kubernetes_storage_class.premium[0].volume_binding_mode == "WaitForFirstConsumer"
+    error_message = "A managed disk is created in one zone, so binding has to wait for the scheduler."
+  }
+}
+
+run "no_workspace_means_no_diagnostics" {
+  command = plan
+
+  assert {
+    condition     = length(azurerm_monitor_diagnostic_setting.this) == 0
+    error_message = "Control plane logs need somewhere to go."
+  }
+}
+
+run "rotation_names_are_unique_and_valid_pool_names" {
+  command = plan
+
+  variables {
+    enable_gpu_node_pool     = true
+    enable_sandbox_node_pool = true
+  }
+
+  assert {
+    condition = alltrue([
+      for name in values(local.rotation_names) : can(regex("^[a-z][a-z0-9]{0,11}$", name))
+    ])
+    error_message = "A rotation name has to be a valid AKS pool name: at most 12 characters, starting with a lowercase letter."
+  }
+
+  assert {
+    condition     = length(distinct(values(local.rotation_names))) == length(local.rotation_names)
+    error_message = "Two pools sharing a rotation name would collide when either rotates."
+  }
+}
+
+run "pools_sharing_a_prefix_still_get_distinct_rotation_names" {
+  command = plan
+
+  # Truncating the key alone would give both of these the same rotation name.
+  variables {
+    node_pools = {
+      main    = { vm_size = "Standard_D8ds_v5" }
+      workera = { vm_size = "Standard_D8ds_v5" }
+      workerb = { vm_size = "Standard_D8ds_v5" }
+    }
+    index_node_pool_enabled = false
+  }
+
+  assert {
+    condition     = length(distinct(values(local.rotation_names))) == 3
+    error_message = "Pools whose names share their first six characters must still get distinct rotation names."
+  }
+}
+
+run "the_role_assignment_survives_directory_replication_lag" {
+  command = plan
+
+  variables {
+    storage_account_ids = ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Storage/storageAccounts/onyxfilestore"]
+  }
+
+  assert {
+    condition     = azurerm_role_assignment.workload_storage[0].skip_service_principal_aad_check == true
+    error_message = "The identity is created in the same apply, so Entra may not have replicated it when the assignment is made."
+  }
+}
+
+run "a_long_namespace_still_produces_a_valid_credential_name" {
+  command = plan
+
+  # Azure caps a federated credential name at 120 characters, and a namespace
+  # and a service account name can each be 63.
+  variables {
+    storage_account_ids                = ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Storage/storageAccounts/onyxfilestore"]
+    workload_service_account_namespace = "onyx-production-workloads-with-a-deliberately-long-namespace-nm"
+    workload_service_account_name       = "onyx-workload-access-with-a-deliberately-long-service-account-n"
+  }
+
+  assert {
+    condition = alltrue([
+      for n in values(local.federated_credential_names) : length(n) <= 120
+    ])
+    error_message = "A federated credential name must fit inside Azure's 120-character limit."
+  }
+
+  assert {
+    condition     = length(distinct(values(local.federated_credential_names))) == length(local.federated_credential_names)
+    error_message = "Truncated names must stay distinct."
+  }
+}
+
+run "rejects_a_pool_named_after_another_pools_rotation_name" {
+  command = plan
+
+  # "mainb28b7a" is the rotation name generated for the "main" pool.
+  variables {
+    node_pools = {
+      main       = { vm_size = "Standard_D8ds_v5" }
+      mainb28b7a = { vm_size = "Standard_D8ds_v5" }
+    }
+    index_node_pool_enabled = false
+  }
+
+  expect_failures = [var.node_pools]
+}
+
+run "rejects_an_open_control_plane" {
+  command = plan
+
+  variables {
+    api_server_authorized_ip_ranges = []
+  }
+
+  expect_failures = [var.allow_unrestricted_api_server_access]
+}
+
+run "an_open_control_plane_can_be_asked_for_explicitly" {
+  command = plan
+
+  variables {
+    api_server_authorized_ip_ranges     = []
+    allow_unrestricted_api_server_access = true
+  }
+
+  assert {
+    condition     = length(azurerm_kubernetes_cluster.this.api_server_access_profile) == 0
+    error_message = "With no ranges there is no access profile to write."
+  }
+}
+
+run "a_private_cluster_needs_no_ranges" {
+  command = plan
+
+  variables {
+    api_server_authorized_ip_ranges = []
+    private_cluster_enabled         = true
+  }
+
+  assert {
+    condition     = azurerm_kubernetes_cluster.this.private_cluster_enabled == true
+    error_message = "A private API server is the other way to satisfy the rule."
+  }
+}
+
+run "rejects_taints_on_the_system_pool" {
+  command = plan
+
+  # AKS accepts no taints on the system pool, and the provider has no argument
+  # to pass them through, so silently dropping them would be worse.
+  variables {
+    node_pools = {
+      main = {
+        vm_size     = "Standard_D8ds_v5"
+        node_taints = ["dedicated=onyx:NoSchedule"]
+      }
+    }
+  }
+
+  expect_failures = [var.node_pools]
+}
+
+run "rejects_a_private_cluster_with_authorized_ranges" {
+  command = plan
+
+  variables {
+    private_cluster_enabled        = true
+    api_server_authorized_ip_ranges = ["203.0.113.0/24"]
+  }
+
+  expect_failures = [var.private_cluster_enabled]
+}
+
+run "rejects_cilium_without_overlay" {
+  command = plan
+
+  variables {
+    network_policy      = "cilium"
+    network_plugin_mode = null
+  }
+
+  expect_failures = [var.network_policy]
+}
+
+run "rejects_node_pools_without_a_system_pool" {
+  command = plan
+
+  variables {
+    node_pools = {
+      workers = {
+        vm_size = "Standard_D8ds_v5"
+      }
+    }
+  }
+
+  expect_failures = [var.node_pools]
+}
+
+run "rejects_a_pool_name_azure_would_reject" {
+  command = plan
+
+  variables {
+    node_pools = {
+      main               = { vm_size = "Standard_D8ds_v5" }
+      document-index-pool = { vm_size = "Standard_E8ds_v5" }
+    }
+  }
+
+  expect_failures = [var.node_pools]
+}
+
+run "rejects_a_pool_whose_max_is_below_its_min" {
+  command = plan
+
+  variables {
+    node_pools = {
+      main = {
+        vm_size   = "Standard_D8ds_v5"
+        min_count = 5
+        max_count = 2
+      }
+    }
+  }
+
+  expect_failures = [var.node_pools]
+}
+
+run "rejects_azure_rbac_with_nobody_to_administer_it" {
+  command = plan
+
+  variables {
+    entra_rbac_enabled = true
+  }
+
+  expect_failures = [var.entra_rbac_enabled]
+}
+
+run "rejects_an_unknown_log_category" {
+  command = plan
+
+  variables {
+    log_analytics_workspace_id   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.OperationalInsights/workspaces/onyx-logs"
+    control_plane_log_categories = ["kube-apiserver", "authenticator"]
+  }
+
+  expect_failures = [var.control_plane_log_categories]
+}

--- a/deployment/terraform/modules/azure/aks/variables.tf
+++ b/deployment/terraform/modules/azure/aks/variables.tf
@@ -1,0 +1,386 @@
+variable "cluster_name" {
+  type        = string
+  description = "Name of the cluster"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group that holds the cluster"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region, for example \"eastus\""
+}
+
+variable "kubernetes_version" {
+  type        = string
+  description = "Kubernetes version for the control plane. Move one minor at a time."
+  default     = "1.33"
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "Subnet the nodes join"
+}
+
+variable "sku_tier" {
+  type        = string
+  description = "Control plane tier. Free carries no uptime SLA; Standard does. Premium adds long-term support."
+  default     = "Standard"
+
+  validation {
+    condition     = contains(["Free", "Standard", "Premium"], var.sku_tier)
+    error_message = "sku_tier must be Free, Standard or Premium."
+  }
+}
+
+variable "private_cluster_enabled" {
+  type        = bool
+  description = "Give the API server a private endpoint only. Reaching it then needs a host inside the network, a VPN or Azure Bastion."
+  default     = false
+
+  validation {
+    condition     = !var.private_cluster_enabled || length(var.api_server_authorized_ip_ranges) == 0
+    error_message = "api_server_authorized_ip_ranges only applies to a public API server, so it cannot be combined with private_cluster_enabled."
+  }
+}
+
+variable "api_server_authorized_ip_ranges" {
+  type        = list(string)
+  description = "CIDR ranges allowed to reach the public API server. This is the analogue of the AWS module's cluster_endpoint_public_access_cidrs."
+  default     = []
+}
+
+# Leaving the control plane open has to be something a caller writes down, not
+# something they get by not reading. The rule lives on this variable rather than
+# on the two it reads, because validations that reference each other form a
+# cycle Terraform rejects.
+variable "allow_unrestricted_api_server_access" {
+  type        = bool
+  description = "Accept a public API server reachable from any address. Only for throwaway clusters; set api_server_authorized_ip_ranges or private_cluster_enabled instead."
+  default     = false
+
+  validation {
+    condition     = var.allow_unrestricted_api_server_access || var.private_cluster_enabled || length(var.api_server_authorized_ip_ranges) > 0
+    error_message = "A public API server with no authorized ranges is reachable from every address on the internet. Set api_server_authorized_ip_ranges, or private_cluster_enabled, or allow_unrestricted_api_server_access to record that the exposure is intended."
+  }
+}
+
+# --- Networking --------------------------------------------------------------
+
+variable "network_plugin_mode" {
+  type        = string
+  description = "Overlay gives pods addresses from pod_cidr rather than from the subnet, so the subnet only has to be large enough for nodes. Null puts pod addresses in the subnet, which needs a much larger one."
+  default     = "overlay"
+
+  validation {
+    condition     = var.network_plugin_mode == null || var.network_plugin_mode == "overlay"
+    error_message = "network_plugin_mode must be \"overlay\" or null."
+  }
+}
+
+variable "pod_cidr" {
+  type        = string
+  description = "Address range pods draw from in overlay mode. Must not overlap the virtual network."
+  default     = "192.168.0.0/16"
+}
+
+variable "service_cidr" {
+  type        = string
+  description = "Address range for Kubernetes service IPs. Must not overlap the virtual network or pod_cidr."
+  default     = "172.16.0.0/16"
+}
+
+variable "dns_service_ip" {
+  type        = string
+  description = "Address of the in-cluster DNS service. Null takes the tenth address of service_cidr, which is what removes the chance of setting one outside it."
+  default     = null
+}
+
+# Off by default for the same reason as the AWS module: a cluster that has
+# carried inert NetworkPolicies picks up enforcement the moment this is turned
+# on, and whatever those policies say takes effect at once.
+variable "network_policy" {
+  type        = string
+  description = "NetworkPolicy engine. Null leaves existing policies inert. Cilium is the current recommendation and needs overlay mode."
+  default     = null
+
+  validation {
+    condition     = var.network_policy == null || contains(["azure", "calico", "cilium"], var.network_policy)
+    error_message = "network_policy must be one of: azure, calico, cilium, or null to leave enforcement off."
+  }
+
+  validation {
+    condition     = var.network_policy != "cilium" || var.network_plugin_mode == "overlay"
+    error_message = "The cilium data plane requires network_plugin_mode = \"overlay\"."
+  }
+}
+
+# The vnet module attaches a NAT gateway to the node subnet so egress keeps one
+# address. Taking that path means AKS must not manage outbound itself.
+variable "outbound_type" {
+  type        = string
+  description = "How nodes reach the internet. userAssignedNATGateway uses the NAT gateway already on the subnet and keeps egress on a stable address. loadBalancer lets AKS manage it, and the addresses can change."
+  default     = "userAssignedNATGateway"
+
+  validation {
+    condition     = contains(["loadBalancer", "userAssignedNATGateway", "userDefinedRouting", "managedNATGateway"], var.outbound_type)
+    error_message = "outbound_type must be one of: loadBalancer, userAssignedNATGateway, userDefinedRouting, managedNATGateway."
+  }
+}
+
+# --- Node pools --------------------------------------------------------------
+
+# The "main" pool becomes the cluster's system pool, which AKS requires inline
+# and will not let you delete. Every other key becomes a pool of its own.
+variable "node_pools" {
+  type = map(object({
+    vm_size         = optional(string, "Standard_D8ds_v5")
+    min_count       = optional(number, 1)
+    max_count       = optional(number, 5)
+    os_disk_size_gb = optional(number, 100)
+    os_disk_type    = optional(string, "Managed")
+    node_labels     = optional(map(string), {})
+    node_taints     = optional(list(string), [])
+    zones           = optional(list(string), [])
+    mode            = optional(string, "User")
+  }))
+  description = "Node pools keyed by name. The \"main\" key is the system pool."
+  default = {
+    main = {
+      vm_size   = "Standard_D8ds_v5"
+      min_count = 1
+      max_count = 5
+    }
+    # Onyx runs its document index in-cluster on Azure, because Azure has no
+    # managed OpenSearch. This pool is the one the index lands on.
+    index = {
+      vm_size         = "Standard_E8ds_v5"
+      min_count       = 1
+      max_count       = 1
+      os_disk_size_gb = 512
+      node_labels     = { "onyx.app/workload" = "document-index" }
+      node_taints     = ["document-index=true:NoSchedule"]
+    }
+  }
+
+  validation {
+    condition     = contains(keys(var.node_pools), "main")
+    error_message = "node_pools must contain a \"main\" key; AKS requires a system pool and will not let it be removed."
+  }
+
+  validation {
+    condition     = alltrue([for k in keys(var.node_pools) : can(regex("^[a-z][a-z0-9]{0,11}$", k))])
+    error_message = "Node pool names must be 1-12 characters, start with a lowercase letter, and contain only lowercase letters and digits (Azure limit)."
+  }
+
+  validation {
+    condition     = alltrue([for p in var.node_pools : p.max_count >= p.min_count])
+    error_message = "Every node pool needs max_count greater than or equal to min_count."
+  }
+
+  validation {
+    condition     = length(try(var.node_pools["main"].node_taints, [])) == 0
+    error_message = "The \"main\" pool becomes the cluster's system pool, and AKS accepts no taints on it. Move the workloads that need a taint to a pool of their own."
+  }
+
+  # A pool named the same as another pool's rotation name would break the
+  # rotation. The injected gpu and sandbox keys are always considered, so the
+  # answer does not change with the flags that enable them.
+  validation {
+    condition = length(setintersection(
+      toset(concat(keys(var.node_pools), ["gpu", "sandbox"])),
+      toset([for k in concat(keys(var.node_pools), ["gpu", "sandbox"]) : substr("${substr(k, 0, 6)}${substr(sha1(k), 0, 6)}", 0, 12)]),
+    )) == 0
+    error_message = "A node pool is named the same as another pool's generated rotation name, which would break rotation for that pool. Rename it."
+  }
+}
+
+variable "index_node_pool_enabled" {
+  type        = bool
+  description = "Create the document-index node pool. On by default, unlike the AWS module: Azure has no managed OpenSearch, so the index runs in the cluster."
+  default     = true
+}
+
+variable "enable_gpu_node_pool" {
+  type        = bool
+  description = "Create a tainted GPU pool for the embedding model server. AKS installs the driver and the device plugin itself, so nothing extra has to be deployed into the cluster."
+  default     = false
+
+  validation {
+    condition     = !var.enable_gpu_node_pool || !contains(keys(var.node_pools), "gpu")
+    error_message = "enable_gpu_node_pool adds a pool under the key \"gpu\", which node_pools already defines. Rename yours so the GPU pool does not replace it."
+  }
+}
+
+variable "gpu_node_vm_size" {
+  type        = string
+  description = "VM size for the GPU pool. Standard_NC4as_T4_v3 carries one NVIDIA T4, which is enough for the embedding model."
+  default     = "Standard_NC4as_T4_v3"
+}
+
+variable "enable_sandbox_node_pool" {
+  type        = bool
+  description = "Create a tainted pool for Craft sandbox workloads"
+  default     = false
+
+  validation {
+    condition     = !var.enable_sandbox_node_pool || !contains(keys(var.node_pools), "sandbox")
+    error_message = "enable_sandbox_node_pool adds a pool under the key \"sandbox\", which node_pools already defines. Rename yours so the sandbox pool does not replace it."
+  }
+}
+
+variable "sandbox_node_vm_size" {
+  type        = string
+  description = "VM size for the Craft sandbox pool"
+  default     = "Standard_D8ds_v5"
+}
+
+variable "sandbox_node_min_count" {
+  type        = number
+  description = "Minimum nodes in the Craft sandbox pool"
+  default     = 1
+}
+
+variable "sandbox_node_max_count" {
+  type        = number
+  description = "Maximum nodes in the Craft sandbox pool"
+  default     = 7
+}
+
+variable "sandbox_node_disk_size_gb" {
+  type        = number
+  description = "OS disk for Craft sandbox nodes. Size it so ephemeral storage is not what limits scheduling: each sandbox pod reserves about 5.5 GiB, so allow that per pod plus room for the image cache."
+  default     = 200
+
+  validation {
+    condition     = var.sandbox_node_disk_size_gb >= 30
+    error_message = "sandbox_node_disk_size_gb must be at least 30 GiB; the OS image and container cache leave too little ephemeral storage for even one sandbox pod below that."
+  }
+}
+
+# --- Workload identity -------------------------------------------------------
+# Azure federates a managed identity to a Kubernetes service account rather
+# than assuming a role from an OIDC subject, so this is the shape IRSA takes
+# here. The cluster's OIDC issuer is the trust anchor either way.
+
+variable "storage_account_ids" {
+  type        = list(string)
+  description = "Storage accounts the workload identity may read and write. Empty creates no identity, no role assignment and no service account."
+  default     = []
+}
+
+variable "storage_role_definition_name" {
+  type        = string
+  description = "Built-in role granted on each storage account. Storage Blob Data Contributor covers reading, writing and deleting blobs, and nothing else."
+  default     = "Storage Blob Data Contributor"
+}
+
+variable "workload_service_account_namespace" {
+  type        = string
+  description = "Namespace of the service account the workload identity federates to"
+  default     = "onyx"
+}
+
+variable "workload_service_account_name" {
+  type        = string
+  description = "Service account the workload identity federates to. The module creates it, annotated with the identity's client id."
+  default     = "onyx-workload-access"
+}
+
+variable "additional_workload_service_account_names" {
+  type        = list(string)
+  description = "Further service accounts in the same namespace that may use the identity. Use this for chart-created workloads such as <release>-sandbox-proxy. The module federates them but does not create them."
+  default     = []
+}
+
+# A service account cannot be created before its namespace exists, and on a
+# fresh cluster nothing has made it yet: the Helm release that would is
+# installed after Terraform finishes.
+variable "create_workload_namespace" {
+  type        = bool
+  description = "Create the namespace the workload service account lives in. Turn this off only when something else creates it before Terraform runs."
+  default     = true
+}
+
+variable "create_workload_service_account" {
+  type        = bool
+  description = "Create the service account named by workload_service_account_name. Turn this off when the Helm chart already creates it, and the module will only federate the identity to it."
+  default     = true
+}
+
+# --- Cluster add-ons ---------------------------------------------------------
+
+variable "create_premium_storage_class" {
+  type        = bool
+  description = "Create a Premium SSD storage class that binds on first use and can be expanded"
+  default     = true
+}
+
+variable "premium_storage_class_name" {
+  type        = string
+  description = "Name of the storage class the module creates"
+  default     = "onyx-premium"
+}
+
+# AKS already ships a class marked default, so marking a second one leaves the
+# cluster with two and Kubernetes picks between them unpredictably. Take the
+# existing default out of the running before turning this on.
+variable "premium_storage_class_is_default" {
+  type        = bool
+  description = "Mark the created storage class as the cluster default. Only safe once the class AKS ships has had its default annotation removed."
+  default     = false
+}
+
+variable "azure_policy_enabled" {
+  type        = bool
+  description = "Run the Azure Policy add-on, which reports and can enforce policy on cluster resources"
+  default     = false
+}
+
+variable "log_analytics_workspace_id" {
+  type        = string
+  description = "Workspace that receives control plane logs and container insights. Null sends neither."
+  default     = null
+}
+
+# Retention lives on the workspace here, not on the setting, which is why there
+# is no retention variable to match the AWS module's.
+variable "control_plane_log_categories" {
+  type        = list(string)
+  description = "Control plane log categories to send to the workspace"
+  default     = ["kube-apiserver", "kube-audit", "kube-controller-manager", "kube-scheduler", "cluster-autoscaler"]
+
+  validation {
+    condition = alltrue([for c in var.control_plane_log_categories : contains([
+      "kube-apiserver", "kube-audit", "kube-audit-admin", "kube-controller-manager",
+      "kube-scheduler", "cluster-autoscaler", "cloud-controller-manager", "guard", "csi-azuredisk-controller",
+      "csi-azurefile-controller", "csi-snapshot-controller",
+    ], c)])
+    error_message = "Each entry must be a category AKS publishes, such as kube-apiserver, kube-audit, kube-controller-manager, kube-scheduler or cluster-autoscaler."
+  }
+}
+
+variable "entra_rbac_admin_group_object_ids" {
+  type        = list(string)
+  description = "Entra ID groups granted cluster admin. Empty leaves Kubernetes RBAC on its own with local accounts."
+  default     = []
+}
+
+variable "entra_rbac_enabled" {
+  type        = bool
+  description = "Authorise Kubernetes actions through Azure RBAC rather than only through Kubernetes RBAC. Needs entra_rbac_admin_group_object_ids."
+  default     = false
+
+  validation {
+    condition     = !var.entra_rbac_enabled || length(var.entra_rbac_admin_group_object_ids) > 0
+    error_message = "entra_rbac_enabled needs at least one group in entra_rbac_admin_group_object_ids, otherwise nobody can administer the cluster."
+  }
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to the cluster and its pools"
+  default     = {}
+}

--- a/deployment/terraform/modules/azure/aks/versions.tf
+++ b/deployment/terraform/modules/azure/aks/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.37"
+    }
+  }
+}


### PR DESCRIPTION
> **Stacked PR 5 of 7.** Each PR targets the branch below it, so GitHub retargets the next one to `main` as each merges. Review and merge bottom-up.
>
> 1. #14099 — `vnet`, network, subnets, NAT gateway
> 2. #14100 — `storage`, storage account + container
> 3. #14101 — `postgres`, flexible server + alerts
> 4. #14102 — `redis`, cache + private endpoint
> 5. #14103 — `aks`, cluster + workload identity **← this PR**
> 6. #14104 — `waf`, regional WAF policy
> 7. #14105 — `onyx`, composition + README

## Description

Mirrors `deployment/terraform/modules/aws/eks`. This is the module that needed design rather than translation, because **IRSA has no direct analogue**.

Where AWS assumes a role from an OIDC subject, Azure federates a managed identity to a Kubernetes service account. The subject string is identical — `system:serviceaccount:<namespace>:<name>` — and the cluster's OIDC issuer is the trust anchor either way, so the interface stays close: hand the module a list of storage accounts and it creates the identity, the federated credentials, the role assignments and the annotated service account, or creates none of them when the list is empty.

**Three pieces of the AWS module disappear because AKS does the work itself:**

- The cluster autoscaler is part of a node pool rather than a Helm release, so the supplementary `volumeattachments` ClusterRole the AWS module has to patch in is not needed.
- AKS installs the GPU driver and device plugin for an N-series pool, so the NVIDIA device plugin Helm release goes away — and with it the `helm` provider.
- The disk and file CSI drivers ship with the cluster.

Two defaults worth reading closely:

- **Egress goes through the NAT gateway the `vnet` module puts on the subnet**, so it keeps one address. Bringing a subnet without one means setting `outbound_type` to `loadBalancer`.
- **The index node pool is on by default**, unlike the AWS module's vespa pool. Azure has no managed OpenSearch, so the document index runs in the cluster.

The storage class the module creates is **not** marked default: AKS already ships one, and a second would leave the cluster with two.

## How Has This Been Tested?

```
cd deployment/terraform/modules/azure/aks
terraform init -backend=false && terraform test
# Success! 19 passed, 0 failed.
```

The suite covers workload identity end to end (identity, federated credential subject and audience, role assignment scope, the `azure.workload.identity/use` label without which the webhook never projects a token), the node pool taints and labels, deriving the DNS service address from `service_cidr`, and seven input validations.

**The composition at the top of this stack caught a real defect here** that unit-level tests could not: `azurerm_role_assignment` originally used `for_each` over the storage account IDs, which are unknown at plan time when they come from a storage module in the same apply. That fails `terraform plan` outright on any greenfield deployment. It is now counted instead, and PR 7's suite is what exercises the unknown-value case.

`terraform validate` and the repo's terraform hooks pass. Not applied against a live subscription.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

## Changes from review (greptile, cubic)

- **Taints on the system pool are now rejected** rather than silently dropped.
- **A public API server with no authorized ranges is now refused.** You must set `api_server_authorized_ip_ranges`, or `private_cluster_enabled`, or the new `allow_unrestricted_api_server_access` to record that the exposure is intended. This is a behaviour change: the module previously built an open control plane by default.
- **Rotation names can no longer collide.** `substr(key, 0, 6) + "rotate"` gave two pools sharing six characters the same name, and a pool named `mainrotate` collided with the system pool's. Now derived from a digest of the full key, with tests covering both cases.
- **`skip_service_principal_aad_check = true`** on the storage role assignment, so the apply does not fail with a transient `PrincipalNotFound` before Entra has replicated the identity it just created.

Tests: 19 → 26.

<details><summary>greptile's suggested fix for the system pool taints could not work</summary>

The finding was correct — the value was being dropped. But the suggested patch adds `node_taints` to `default_node_pool`, and that argument does not exist on that block in azurerm 4.x (`only_critical_addons_enabled` is the only taint-adjacent field). Applying it would fail `terraform validate`. AKS accepts no arbitrary taints on the system pool at all, so the honest fix is cubic's: refuse the input rather than accept and ignore it.
</details>

## Round 2

- **A pool named after another pool's generated rotation name is now rejected.** The digest made accidental collisions vanishingly unlikely, but a deliberate one was still possible and would break rotation for that pool. The injected `gpu` and `sandbox` keys are always considered, so the answer does not change with the flags that enable them.
- **Federated credential names are bounded to Azure's 120-character limit**, with a digest of the full subject appended so long namespace and service-account names stay distinct after truncation rather than colliding.
- **The service account now `depends_on` the cluster.** On a fresh apply it was the first call against the cluster's API with nothing ordering it after the cluster itself.
- **`cluster_fqdn` falls back to `private_fqdn`.** A private cluster leaves `fqdn` empty, so the output returned nothing usable for a mode the module supports.
- **Documented that the pod label is the chart's job** on the `workload_identity_client_id` output — the webhook projects no token without it, and this module cannot set it on someone else's pods.

Tests: 26 → 28.

## Round 3

- **The workload namespace is now created before the service account.** greptile caught this on the composition PR, but the fix belongs here. On a first deployment the module created `onyx-workload-access` in the `onyx` namespace before anything had made that namespace — the Helm release that would is installed *after* Terraform finishes, so the apply failed with a namespace-not-found error. A real apply-blocker on every greenfield deployment.

  The module now creates the namespace, and the service account reads its name back off that resource so the ordering is implicit rather than a `depends_on`. `create_workload_namespace = false` opts out when something else owns it.

Tests: 28 → 31.
