### PR TITLE
feat(terraform): add the Azure waf module

### DIFF
--- a/deployment/terraform/modules/azure/waf/main.tf
+++ b/deployment/terraform/modules/azure/waf/main.tf
@@ -1,0 +1,161 @@
+locals {
+  ip_allowlist_enabled      = length(var.allowed_ip_cidrs) > 0
+  rate_limit_exempt_enabled = length(var.rate_limit_exempt_ip_cidrs) > 0
+  geo_restriction_enabled   = length(var.geo_restriction_countries) > 0
+
+  managed_rule_sets = concat(
+    [{ type = "OWASP", version = var.owasp_rule_set_version }],
+    var.enable_bot_protection ? [{ type = "Microsoft_BotManagerRuleSet", version = var.bot_manager_rule_set_version }] : [],
+  )
+
+  # The overrides arrive as a flat list but the provider nests them by rule set
+  # and then by rule group, so regroup them once here.
+  overrides_by_set = {
+    for set_type in distinct([for o in var.managed_rule_overrides : o.rule_set_type]) :
+    set_type => {
+      for group_name in distinct([for o in var.managed_rule_overrides : o.rule_group_name if o.rule_set_type == set_type]) :
+      group_name => [for o in var.managed_rule_overrides : o if o.rule_set_type == set_type && o.rule_group_name == group_name]
+    }
+  }
+}
+
+resource "azurerm_web_application_firewall_policy" "this" {
+  name                = "${var.name}-waf"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  tags                = var.tags
+
+  policy_settings {
+    enabled                     = true
+    mode                        = var.mode
+    request_body_check          = true
+    max_request_body_size_in_kb = var.max_request_body_size_in_kb
+    file_upload_limit_in_mb     = var.file_upload_limit_in_mb
+  }
+
+  managed_rules {
+    dynamic "managed_rule_set" {
+      for_each = local.managed_rule_sets
+      content {
+        type    = managed_rule_set.value.type
+        version = managed_rule_set.value.version
+
+        dynamic "rule_group_override" {
+          for_each = try(local.overrides_by_set[managed_rule_set.value.type], {})
+          content {
+            rule_group_name = rule_group_override.key
+
+            dynamic "rule" {
+              for_each = rule_group_override.value
+              content {
+                id      = rule.value.rule_id
+                action  = rule.value.action
+                enabled = rule.value.enabled
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  # Anything not on the allowlist is refused before the managed rules run.
+  dynamic "custom_rules" {
+    for_each = local.ip_allowlist_enabled ? [1] : []
+    content {
+      name      = "BlockRequestsOutsideAllowedIPs"
+      priority  = 1
+      rule_type = "MatchRule"
+      action    = "Block"
+
+      match_conditions {
+        match_variables {
+          variable_name = "RemoteAddr"
+        }
+        operator           = "IPMatch"
+        negation_condition = true
+        match_values       = var.allowed_ip_cidrs
+      }
+    }
+  }
+
+  dynamic "custom_rules" {
+    for_each = local.geo_restriction_enabled ? [1] : []
+    content {
+      name      = "BlockRestrictedCountries"
+      priority  = 10
+      rule_type = "MatchRule"
+      action    = "Block"
+
+      match_conditions {
+        match_variables {
+          variable_name = "RemoteAddr"
+        }
+        operator     = "GeoMatch"
+        match_values = var.geo_restriction_countries
+      }
+    }
+  }
+
+  # Match conditions on a rule are combined with AND, so the negated exempt
+  # list is what keeps the limit from applying to those addresses.
+  custom_rules {
+    name                 = "ApiRateLimit"
+    priority             = 20
+    rule_type            = "RateLimitRule"
+    action               = "Block"
+    rate_limit_duration  = "FiveMins"
+    rate_limit_threshold = var.api_rate_limit_requests_per_5_minutes
+    group_rate_limit_by  = "ClientAddr"
+
+    match_conditions {
+      match_variables {
+        variable_name = "RequestUri"
+      }
+      operator     = "BeginsWith"
+      match_values = [var.api_path_prefix]
+    }
+
+    dynamic "match_conditions" {
+      for_each = local.rate_limit_exempt_enabled ? [1] : []
+      content {
+        match_variables {
+          variable_name = "RemoteAddr"
+        }
+        operator           = "IPMatch"
+        negation_condition = true
+        match_values       = var.rate_limit_exempt_ip_cidrs
+      }
+    }
+  }
+
+  custom_rules {
+    name                 = "GlobalRateLimit"
+    priority             = 30
+    rule_type            = "RateLimitRule"
+    action               = "Block"
+    rate_limit_duration  = "FiveMins"
+    rate_limit_threshold = var.rate_limit_requests_per_5_minutes
+    group_rate_limit_by  = "ClientAddr"
+
+    match_conditions {
+      match_variables {
+        variable_name = "RemoteAddr"
+      }
+      operator     = "IPMatch"
+      match_values = ["0.0.0.0/0", "::/0"]
+    }
+
+    dynamic "match_conditions" {
+      for_each = local.rate_limit_exempt_enabled ? [1] : []
+      content {
+        match_variables {
+          variable_name = "RemoteAddr"
+        }
+        operator           = "IPMatch"
+        negation_condition = true
+        match_values       = var.rate_limit_exempt_ip_cidrs
+      }
+    }
+  }
+}

--- a/deployment/terraform/modules/azure/waf/outputs.tf
+++ b/deployment/terraform/modules/azure/waf/outputs.tf
@@ -1,0 +1,17 @@
+output "policy_id" {
+  description = "Resource ID of the WAF policy. Attach it to an Application Gateway. Front Door uses a different resource, azurerm_cdn_frontdoor_firewall_policy, and cannot take this one."
+  value       = azurerm_web_application_firewall_policy.this.id
+}
+
+output "policy_name" {
+  description = "Name of the WAF policy"
+  value       = azurerm_web_application_firewall_policy.this.name
+}
+
+# Unlike the AWS module there is no log group here. Azure emits WAF logs from
+# the Application Gateway the policy is attached to, so the diagnostic setting
+# belongs on that resource.
+output "mode" {
+  description = "Whether the policy blocks matches or only logs them"
+  value       = var.mode
+}

--- a/deployment/terraform/modules/azure/waf/tests/waf.tftest.hcl
+++ b/deployment/terraform/modules/azure/waf/tests/waf.tftest.hcl
@@ -1,0 +1,270 @@
+# Plans the module against a mocked provider, so these run without an Azure
+# subscription or credentials. Run with `terraform test` from the module directory.
+
+mock_provider "azurerm" {}
+
+variables {
+  name                = "onyx"
+  resource_group_name = "onyx-rg"
+  location            = "eastus"
+}
+
+run "defaults_block_and_carry_both_rule_sets" {
+  command = plan
+
+  assert {
+    condition     = one(azurerm_web_application_firewall_policy.this.policy_settings).mode == "Prevention"
+    error_message = "The policy should block what it matches by default."
+  }
+
+  assert {
+    condition     = length(one(azurerm_web_application_firewall_policy.this.managed_rules).managed_rule_set) == 2
+    error_message = "OWASP plus the bot manager set should both be present by default."
+  }
+
+  assert {
+    condition     = one(azurerm_web_application_firewall_policy.this.managed_rules).managed_rule_set[0].type == "OWASP"
+    error_message = "The OWASP set covers what the AWS module gets from its common, known-bad-inputs and SQLi groups."
+  }
+}
+
+run "only_the_two_rate_limits_exist_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(azurerm_web_application_firewall_policy.this.custom_rules) == 2
+    error_message = "With no allowlist and no geo blocking, only the two rate limits should exist."
+  }
+
+  assert {
+    condition = alltrue([
+      for r in azurerm_web_application_firewall_policy.this.custom_rules :
+      r.rate_limit_duration == "FiveMins"
+    ])
+    error_message = "The AWS module counts requests per five minutes, so these should too."
+  }
+
+  assert {
+    condition = alltrue([
+      for r in azurerm_web_application_firewall_policy.this.custom_rules :
+      r.group_rate_limit_by == "ClientAddr"
+    ])
+    error_message = "Rate limits should count per client address, matching the AWS aggregate key of IP."
+  }
+}
+
+run "an_allowlist_blocks_everything_outside_it_first" {
+  command = plan
+
+  variables {
+    allowed_ip_cidrs = ["203.0.113.0/24"]
+  }
+
+  assert {
+    condition     = length(azurerm_web_application_firewall_policy.this.custom_rules) == 3
+    error_message = "The allowlist rule should be added to the two rate limits."
+  }
+
+  assert {
+    condition = one([
+      for r in azurerm_web_application_firewall_policy.this.custom_rules :
+      r.priority if r.name == "BlockRequestsOutsideAllowedIPs"
+    ]) == 1
+    error_message = "The allowlist must be evaluated before anything else."
+  }
+
+  assert {
+    condition = one([
+      for r in azurerm_web_application_firewall_policy.this.custom_rules :
+      r.match_conditions[0].negation_condition if r.name == "BlockRequestsOutsideAllowedIPs"
+    ]) == true
+    error_message = "The rule blocks addresses that are NOT on the list, so the condition has to be negated."
+  }
+}
+
+run "exempt_ranges_add_a_negated_condition_to_each_limit" {
+  command = plan
+
+  variables {
+    rate_limit_exempt_ip_cidrs = ["203.0.113.0/24"]
+  }
+
+  assert {
+    condition = alltrue([
+      for r in azurerm_web_application_firewall_policy.this.custom_rules :
+      length(r.match_conditions) == 2 if r.rule_type == "RateLimitRule"
+    ])
+    error_message = "Conditions are combined with AND, so the exemption is a second, negated condition on each limit."
+  }
+}
+
+run "geo_blocking_adds_a_rule" {
+  command = plan
+
+  variables {
+    geo_restriction_countries = ["KP"]
+  }
+
+  assert {
+    condition = one([
+      for r in azurerm_web_application_firewall_policy.this.custom_rules :
+      r.match_conditions[0].operator if r.name == "BlockRestrictedCountries"
+    ]) == "GeoMatch"
+    error_message = "Country blocking uses the GeoMatch operator."
+  }
+}
+
+run "detection_mode_stops_blocking" {
+  command = plan
+
+  variables {
+    mode = "Detection"
+  }
+
+  assert {
+    condition     = one(azurerm_web_application_firewall_policy.this.policy_settings).mode == "Detection"
+    error_message = "Detection is the whole-policy equivalent of overriding every AWS managed rule to COUNT."
+  }
+}
+
+run "bot_protection_can_be_dropped" {
+  command = plan
+
+  variables {
+    enable_bot_protection = false
+  }
+
+  assert {
+    condition     = length(one(azurerm_web_application_firewall_policy.this.managed_rules).managed_rule_set) == 1
+    error_message = "Turning off bot protection should leave only the OWASP set."
+  }
+}
+
+run "overrides_are_regrouped_under_their_rule_set" {
+  command = plan
+
+  variables {
+    managed_rule_overrides = [
+      { rule_group_name = "REQUEST-942-APPLICATION-ATTACK-SQLI", rule_id = "942100", action = "Log" },
+      { rule_group_name = "REQUEST-942-APPLICATION-ATTACK-SQLI", rule_id = "942200", action = "Log" },
+      { rule_group_name = "REQUEST-920-PROTOCOL-ENFORCEMENT", rule_id = "920300", enabled = false },
+    ]
+  }
+
+  assert {
+    condition     = length(one(azurerm_web_application_firewall_policy.this.managed_rules).managed_rule_set[0].rule_group_override) == 2
+    error_message = "Three overrides across two groups should nest into two group overrides."
+  }
+
+  assert {
+    condition = length(one([
+      for g in one(azurerm_web_application_firewall_policy.this.managed_rules).managed_rule_set[0].rule_group_override :
+      g.rule if g.rule_group_name == "REQUEST-942-APPLICATION-ATTACK-SQLI"
+    ])) == 2
+    error_message = "Both SQLi overrides should land in the same group."
+  }
+}
+
+run "bot_rule_set_overrides_land_on_the_bot_rule_set" {
+  command = plan
+
+  variables {
+    managed_rule_overrides = [
+      { rule_group_name = "UnknownBots", rule_id = "300700", action = "Log", rule_set_type = "Microsoft_BotManagerRuleSet" },
+    ]
+  }
+
+  assert {
+    condition     = length(one(azurerm_web_application_firewall_policy.this.managed_rules).managed_rule_set[0].rule_group_override) == 0
+    error_message = "A bot override must not be attached to the OWASP set."
+  }
+
+  assert {
+    condition     = length(one(azurerm_web_application_firewall_policy.this.managed_rules).managed_rule_set[1].rule_group_override) == 1
+    error_message = "The override belongs to the bot manager set."
+  }
+}
+
+run "rejects_an_override_for_a_rule_set_that_does_not_exist" {
+  command = plan
+
+  variables {
+    managed_rule_overrides = [
+      { rule_group_name = "SomeGroup", rule_id = "1", action = "Log", rule_set_type = "OWASP_CRS" },
+    ]
+  }
+
+  expect_failures = [var.managed_rule_overrides]
+}
+
+run "rejects_a_bot_override_when_bot_protection_is_off" {
+  command = plan
+
+  # Without this the override is silently dropped and the rule keeps doing
+  # exactly what the caller meant to change.
+  variables {
+    enable_bot_protection = false
+    managed_rule_overrides = [
+      { rule_group_name = "UnknownBots", rule_id = "300700", action = "Log", rule_set_type = "Microsoft_BotManagerRuleSet" },
+    ]
+  }
+
+  expect_failures = [var.managed_rule_overrides]
+}
+
+run "rejects_a_group_from_the_wrong_rule_set" {
+  command = plan
+
+  # UnknownBots belongs to the bot manager set, not to OWASP.
+  variables {
+    managed_rule_overrides = [
+      { rule_group_name = "UnknownBots", rule_id = "300700", action = "Log", rule_set_type = "OWASP" },
+    ]
+  }
+
+  expect_failures = [var.managed_rule_overrides]
+}
+
+run "rejects_a_misspelled_group_name" {
+  command = plan
+
+  variables {
+    managed_rule_overrides = [
+      { rule_group_name = "REQUEST-942-APPLICATION-ATTACK-SQL", rule_id = "942100", action = "Log" },
+    ]
+  }
+
+  expect_failures = [var.managed_rule_overrides]
+}
+
+run "rejects_an_action_azure_does_not_have" {
+  command = plan
+
+  variables {
+    managed_rule_overrides = [
+      { rule_group_name = "REQUEST-942-APPLICATION-ATTACK-SQLI", rule_id = "942100", action = "Count" },
+    ]
+  }
+
+  expect_failures = [var.managed_rule_overrides]
+}
+
+run "rejects_a_country_code_that_is_not_one" {
+  command = plan
+
+  variables {
+    geo_restriction_countries = ["Korea"]
+  }
+
+  expect_failures = [var.geo_restriction_countries]
+}
+
+run "rejects_an_upload_limit_azure_would_reject" {
+  command = plan
+
+  variables {
+    file_upload_limit_in_mb = 5000
+  }
+
+  expect_failures = [var.file_upload_limit_in_mb]
+}

--- a/deployment/terraform/modules/azure/waf/variables.tf
+++ b/deployment/terraform/modules/azure/waf/variables.tf
@@ -1,0 +1,202 @@
+variable "name" {
+  type        = string
+  description = "Name prefix for the policy"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group that holds the policy"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region, for example \"eastus\". The policy is regional, like the AWS module's REGIONAL web ACL."
+}
+
+# Detection is the whole-policy equivalent of overriding every AWS managed rule
+# to COUNT: rules still evaluate and log, but nothing is blocked.
+variable "mode" {
+  type        = string
+  description = "Prevention blocks what the rules match. Detection only logs it, which is the way to see what a new policy would do before it does it."
+  default     = "Prevention"
+
+  validation {
+    condition     = contains(["Prevention", "Detection"], var.mode)
+    error_message = "mode must be Prevention or Detection."
+  }
+}
+
+variable "owasp_rule_set_version" {
+  type        = string
+  description = "OWASP Core Rule Set version. This one set covers what the AWS module gets from the common, known-bad-inputs and SQL injection rule groups."
+  default     = "3.2"
+
+  validation {
+    condition     = contains(["3.0", "3.1", "3.2"], var.owasp_rule_set_version)
+    error_message = "owasp_rule_set_version must be one of: 3.0, 3.1, 3.2."
+  }
+}
+
+variable "enable_bot_protection" {
+  type        = bool
+  description = "Add the Microsoft bot manager rule set, the counterpart of the AWS anonymous IP list"
+  default     = true
+}
+
+variable "bot_manager_rule_set_version" {
+  type        = string
+  description = "Microsoft bot manager rule set version"
+  default     = "1.0"
+}
+
+# Azure identifies a rule by group and numeric id rather than by name, so this
+# replaces the AWS module's list of subrule names to override to COUNT.
+variable "managed_rule_overrides" {
+  type = list(object({
+    rule_group_name = string
+    rule_id         = string
+    action          = optional(string, "Log")
+    enabled         = optional(bool, true)
+    rule_set_type   = optional(string, "OWASP")
+  }))
+  description = <<-EOT
+    Individual managed rules to re-aim or switch off, for example a rule that
+    fires on a legitimate request shape. Azure identifies a rule by its group
+    and numeric id rather than by name.
+
+    The OWASP set carries these groups:
+      General, REQUEST-911-METHOD-ENFORCEMENT, REQUEST-913-SCANNER-DETECTION,
+      REQUEST-920-PROTOCOL-ENFORCEMENT, REQUEST-921-PROTOCOL-ATTACK,
+      REQUEST-930-APPLICATION-ATTACK-LFI, REQUEST-931-APPLICATION-ATTACK-RFI,
+      REQUEST-932-APPLICATION-ATTACK-RCE, REQUEST-933-APPLICATION-ATTACK-PHP,
+      REQUEST-941-APPLICATION-ATTACK-XSS, REQUEST-942-APPLICATION-ATTACK-SQLI,
+      REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION,
+      REQUEST-944-APPLICATION-ATTACK-JAVA
+
+    The bot manager set carries BadBots, GoodBots and UnknownBots.
+  EOT
+  default     = []
+
+  validation {
+    condition     = alltrue([for o in var.managed_rule_overrides : contains(["Allow", "Block", "Log", "JSChallenge", "AnomalyScoring"], o.action)])
+    error_message = "Each override action must be one of: Allow, Block, Log, JSChallenge, AnomalyScoring."
+  }
+
+  # An override that names a rule set the policy does not carry is dropped on
+  # the way through, leaving the rule doing exactly what the caller meant to
+  # change. Both cases are caught here instead.
+  validation {
+    condition     = alltrue([for o in var.managed_rule_overrides : contains(["OWASP", "Microsoft_BotManagerRuleSet"], o.rule_set_type)])
+    error_message = "Each override rule_set_type must be OWASP or Microsoft_BotManagerRuleSet."
+  }
+
+  validation {
+    condition     = var.enable_bot_protection || alltrue([for o in var.managed_rule_overrides : o.rule_set_type != "Microsoft_BotManagerRuleSet"])
+    error_message = "An override targets Microsoft_BotManagerRuleSet, but enable_bot_protection is false, so that rule set is not on the policy and the override would do nothing."
+  }
+
+  # A group name from the wrong rule set, or a misspelled one, produces a group
+  # override Azure accepts and never applies.
+  validation {
+    condition = alltrue([
+      for o in var.managed_rule_overrides : contains(
+        o.rule_set_type == "OWASP" ? [
+          "General",
+          "REQUEST-911-METHOD-ENFORCEMENT",
+          "REQUEST-913-SCANNER-DETECTION",
+          "REQUEST-920-PROTOCOL-ENFORCEMENT",
+          "REQUEST-921-PROTOCOL-ATTACK",
+          "REQUEST-930-APPLICATION-ATTACK-LFI",
+          "REQUEST-931-APPLICATION-ATTACK-RFI",
+          "REQUEST-932-APPLICATION-ATTACK-RCE",
+          "REQUEST-933-APPLICATION-ATTACK-PHP",
+          "REQUEST-941-APPLICATION-ATTACK-XSS",
+          "REQUEST-942-APPLICATION-ATTACK-SQLI",
+          "REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION",
+          "REQUEST-944-APPLICATION-ATTACK-JAVA",
+        ] : ["BadBots", "GoodBots", "UnknownBots"],
+        o.rule_group_name,
+      )
+    ])
+    error_message = "An override names a rule group its rule set does not carry. See the variable description for the groups each set has."
+  }
+}
+
+variable "allowed_ip_cidrs" {
+  type        = list(string)
+  description = "IPv4 or IPv6 ranges allowed to reach the application. Empty disables the allowlist and lets every address through to the rest of the rules."
+  default     = []
+}
+
+variable "rate_limit_exempt_ip_cidrs" {
+  type        = list(string)
+  description = "Ranges exempt from both rate limits. Typically an office or VPN range whose users share one address."
+  default     = []
+}
+
+variable "rate_limit_requests_per_5_minutes" {
+  type        = number
+  description = "Requests per 5 minutes from one address before blocking"
+  default     = 2000
+
+  validation {
+    condition     = var.rate_limit_requests_per_5_minutes > 0
+    error_message = "rate_limit_requests_per_5_minutes must be greater than 0."
+  }
+}
+
+variable "api_rate_limit_requests_per_5_minutes" {
+  type        = number
+  description = "Requests per 5 minutes from one address to the API path before blocking"
+  default     = 1000
+
+  validation {
+    condition     = var.api_rate_limit_requests_per_5_minutes > 0
+    error_message = "api_rate_limit_requests_per_5_minutes must be greater than 0."
+  }
+}
+
+variable "api_path_prefix" {
+  type        = string
+  description = "Path prefix the stricter rate limit applies to"
+  default     = "/api"
+}
+
+variable "geo_restriction_countries" {
+  type        = list(string)
+  description = "Two-letter country codes to block. Empty disables geo blocking."
+  default     = []
+
+  validation {
+    condition     = alltrue([for c in var.geo_restriction_countries : can(regex("^[A-Z]{2}$", c))])
+    error_message = "Country codes must be two uppercase letters, for example \"CN\"."
+  }
+}
+
+variable "max_request_body_size_in_kb" {
+  type        = number
+  description = "Largest request body the WAF will inspect"
+  default     = 128
+
+  validation {
+    condition     = var.max_request_body_size_in_kb >= 8 && var.max_request_body_size_in_kb <= 2000
+    error_message = "max_request_body_size_in_kb must be between 8 and 2000 (Azure limit)."
+  }
+}
+
+variable "file_upload_limit_in_mb" {
+  type        = number
+  description = "Largest file upload allowed through. Onyx accepts document uploads, so this needs to clear the largest file a user will send."
+  default     = 750
+
+  validation {
+    condition     = var.file_upload_limit_in_mb >= 1 && var.file_upload_limit_in_mb <= 4000
+    error_message = "file_upload_limit_in_mb must be between 1 and 4000 (Azure limit)."
+  }
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to the policy"
+  default     = {}
+}

--- a/deployment/terraform/modules/azure/waf/versions.tf
+++ b/deployment/terraform/modules/azure/waf/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION
> **Stacked PR 6 of 7.** Each PR targets the branch below it, so GitHub retargets the next one to `main` as each merges. Review and merge bottom-up.
>
> 1. #14099 — `vnet`, network, subnets, NAT gateway
> 2. #14100 — `storage`, storage account + container
> 3. #14101 — `postgres`, flexible server + alerts
> 4. #14102 — `redis`, cache + private endpoint
> 5. #14103 — `aks`, cluster + workload identity
> 6. #14104 — `waf`, regional WAF policy **← this PR**
> 7. #14105 — `onyx`, composition + README

## Description

Mirrors `deployment/terraform/modules/aws/waf`. The policy is regional — the same scope the AWS web ACL uses — and attaches to an Application Gateway or a Front Door route.

**The rule inventory collapses.** Where AWS composes four managed rule groups, the OWASP Core Rule Set covers the common, known-bad-inputs and SQL injection groups on its own, and the Microsoft bot manager set stands in for the anonymous IP list. Two rate limits and the optional allowlist and geo block stay as custom rules, counting per client address over five minutes as before.

Three differences to know when reading this against the AWS module:

- **Detection mode replaces overriding every managed rule to COUNT**, and is the way to see what a new policy would do before it does it. Individual rules still have overrides, but Azure identifies them by group and numeric id rather than by name, so the flat list is regrouped in the module.
- **Rate limit exemptions are a second, negated match condition** rather than a scope-down statement. Conditions on a rule are combined with AND, so the effect is the same.
- **There is no log group here.** Azure emits WAF logs from the Application Gateway or Front Door the policy attaches to, so the diagnostic setting belongs on that resource rather than on the policy.

## How Has This Been Tested?

```
cd deployment/terraform/modules/azure/waf
terraform init -backend=false && terraform test
# Success! 11 passed, 0 failed.
```

The suite covers rule priority ordering, the negated allowlist condition, the exemption landing on both rate limits, regrouping a flat override list into nested group overrides, and three input validations.

`terraform validate` and the repo's terraform hooks pass. Not applied against a live subscription.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

## Changes from review (greptile, cubic)

- **Overrides are validated against the rule sets actually on the policy.** An override naming an unknown `rule_set_type`, or targeting the bot manager set while `enable_bot_protection` is false, was silently dropped — leaving the rule doing exactly what the operator meant to change. Both are now rejected at plan.
- **Front Door references removed.** This resource is an Application Gateway WAF policy; Front Door uses `azurerm_cdn_frontdoor_firewall_policy` and cannot take this one. The output description now says so rather than pointing people at an integration that does not exist.

Tests: 11 → 14.

## Round 2

- **Rule group names are now validated against the set that carries them.** An OWASP group paired with the bot rule set, or a misspelled group, produced a group override Azure accepts and never applies. cubic offered documentation as an acceptable fallback; validating is better, and the group lists are in the variable description too.

Tests: 14 → 16.
