### PR TITLE
feat(terraform): add the Azure onyx composition and README

### DIFF
--- a/deployment/terraform/modules/azure/README.md
+++ b/deployment/terraform/modules/azure/README.md
@@ -1,0 +1,389 @@
+# Onyx Azure modules
+
+## Status
+
+These modules are validated against the `azurerm` provider schema and each one
+ships a `terraform test` suite that plans it against a mocked provider. They
+have not yet been applied to a live subscription. Treat the first deployment as
+a first deployment.
+
+## Overview
+
+This directory contains Terraform modules to provision the core Azure
+infrastructure for Onyx:
+
+- `vnet`: a virtual network with subnets sized for AKS, a NAT gateway for
+  stable egress, and optional flow logs
+- `aks`: an AKS cluster with workload identity, node pools for the application
+  and the document index, and optional GPU and sandbox pools
+- `postgres`: a PostgreSQL Flexible Server on a delegated subnet, its private
+  DNS zone, and five metric alerts
+- `redis`: an Azure Cache for Redis behind a private endpoint, with four metric
+  alerts
+- `storage`: a storage account and container for the Onyx file store, with
+  versioning, lifecycle rules and network rules
+- `waf`: a regional Web Application Firewall policy for an Application Gateway
+- `onyx`: a higher-level composition that wires the above together
+
+Use the `onyx` module for a working cluster with sane defaults. Use the
+individual modules when you need more control.
+
+These mirror the AWS modules in `../aws`. Read
+[Differences from the AWS modules](#differences-from-the-aws-modules) before
+porting a configuration across.
+
+## Consuming these modules from another repository
+
+The quickstart below uses local paths. To consume the modules from somewhere
+else, point `source` at this repository and pin a ref:
+
+```hcl
+module "vnet" {
+  source              = "git::https://github.com/onyx-dot-app/onyx.git//deployment/terraform/modules/azure/vnet?ref=tf-azure/v1.0.0"
+  resource_group_name = "onyx-prod"
+  location            = "eastus"
+}
+```
+
+Azure releases are tagged `tf-azure/vX.Y.Z`, versioned independently of both
+the AWS modules and Onyx product releases. A commit sha works as a `ref` too,
+and is the better choice for automated consumers: a sha cannot be moved, where
+a tag can.
+
+Pin something. Without a `ref` Terraform tracks the default branch, so an
+unrelated merge can change your infrastructure.
+
+## Quickstart (copy/paste)
+
+Unlike the AWS composition, this module declares no `provider` block. The
+`azurerm` provider needs a `features` block and a subscription, both of which
+belong to your root module.
+
+```hcl
+locals {
+  location = "eastus"
+  # Supply this from a secret store or TF_VAR_ in anything but a scratch stack.
+  postgres_password = "your-postgres-password"
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id = "00000000-0000-0000-0000-000000000000"
+
+  # The storage module turns shared access keys off, so Terraform has to reach
+  # the account with your Entra identity rather than with a key.
+  storage_use_azuread = true
+}
+
+module "onyx" {
+  source = "./modules/azure/onyx"
+
+  name     = "onyx"
+  location = local.location
+  size     = "medium"
+
+  postgres_password = local.postgres_password
+
+  # Required. A public API server with no ranges is reachable from every address
+  # on the internet, so the module refuses to build one unless you either
+  # restrict it, make the cluster private, or say the exposure is intended.
+  api_server_authorized_ip_ranges = ["203.0.113.0/24"]
+}
+
+# The kubernetes provider needs the cluster, so it reads its credentials back
+# out of the module.
+provider "kubernetes" {
+  host                   = module.onyx.cluster_host
+  cluster_ca_certificate = base64decode(module.onyx.cluster_ca_certificate)
+  client_certificate     = base64decode(module.onyx.client_certificate)
+  client_key             = base64decode(module.onyx.client_key)
+}
+
+output "storage_account_name" {
+  value = module.onyx.storage_account_name
+}
+
+output "postgres_host" {
+  value = module.onyx.postgres_host
+}
+
+output "redis_host" {
+  value = module.onyx.redis_host
+}
+```
+
+Then:
+
+```bash
+terraform init
+terraform apply
+```
+
+## T-shirt sizing
+
+`size` sets every compute and data-plane knob together. Any individual sizing
+variable set to a non-null value overrides its tier default.
+
+| | small | medium | large |
+|---|---|---|---|
+| system pool VM | `Standard_D8ds_v5` | `Standard_D16ds_v5` | `Standard_D16ds_v5` |
+| system pool nodes | 1-3 | 1-5 | 2-8 |
+| index pool VM | `Standard_E4ds_v5` | `Standard_E8ds_v5` | `Standard_E16ds_v5` |
+| index pool disk | 256 GiB | 512 GiB | 1024 GiB |
+| database SKU | `GP_Standard_D2ds_v5` | `GP_Standard_D2ds_v5` | `GP_Standard_D4ds_v5` |
+| database storage | 64 GiB | 128 GiB | 256 GiB |
+| cache | Standard C3 (6 GB) | Standard C4 (13 GB) | Standard C5 (26 GB) |
+
+Roughly: small suits pilots and small teams, medium a department or company,
+large an org-wide deployment. The index pool is memory-optimised at every tier
+because on Azure it carries the document index itself.
+
+### Using an existing network
+
+```hcl
+module "onyx" {
+  source = "./modules/azure/onyx"
+
+  location               = "eastus"
+  create_virtual_network = false
+
+  virtual_network_id         = "/subscriptions/.../virtualNetworks/existing"
+  aks_subnet_id              = "/subscriptions/.../subnets/aks"
+  postgres_subnet_id         = "/subscriptions/.../subnets/postgres"
+  private_endpoint_subnet_id = "/subscriptions/.../subnets/private-endpoints"
+
+  postgres_password               = local.postgres_password
+  api_server_authorized_ip_ranges = ["203.0.113.0/24"]
+}
+```
+
+The postgres subnet must be delegated to
+`Microsoft.DBforPostgreSQL/flexibleServers`, and the private endpoint subnet
+needs `private_endpoint_network_policies` set to `Disabled`. Without a NAT
+gateway on the AKS subnet the composition falls back to letting AKS manage
+outbound, and the egress address can then change. If your subnet already has a
+NAT gateway, set `aks_outbound_type = "userAssignedNATGateway"` to keep it.
+
+## What each module does
+
+### `onyx`
+
+Creates a resource group, then wires the modules below together with t-shirt
+sizing. Its outputs carry everything the Helm chart needs.
+
+### `vnet`
+
+A virtual network and four subnets, keyed by purpose: `aks`,
+`private_endpoints`, `postgres` (delegated) and `app_gateway`. A NAT gateway
+attaches to the subnets that opt into it, so egress keeps one address.
+
+### `aks`
+
+An AKS cluster with the OIDC issuer and workload identity on, a system pool, a
+document-index pool, and optional GPU and Craft sandbox pools. Given a list of
+storage accounts it creates a managed identity, federates it to a Kubernetes
+service account, and grants it blob data access.
+
+### `postgres`
+
+A Flexible Server on a delegated subnet, so it has no public endpoint, plus the
+private DNS zone that makes it resolvable. `prevent_destroy` guards the server
+and the database.
+
+### `redis`
+
+An Azure Cache for Redis reachable only through a private endpoint, with its
+plaintext port disabled.
+
+### `storage`
+
+A storage account and a private container. Shared access keys are off by
+default: Onyx authenticates with `DefaultAzureCredential`, so no key has to
+exist.
+
+### `waf`
+
+A regional WAF policy carrying the OWASP Core Rule Set, the Microsoft bot
+manager set, two rate limits, and optional IP allowlisting and geo blocking.
+Attach it to an Application Gateway. Front Door uses a different resource,
+`azurerm_cdn_frontdoor_firewall_policy`, and cannot take this one.
+
+## Differences from the AWS modules
+
+Most of these follow from the platform rather than from taste.
+
+| | AWS | Azure |
+|---|---|---|
+| document index | managed OpenSearch domain, or in-cluster | in-cluster only; Azure has no managed OpenSearch, and Azure AI Search is a different API |
+| pod identity | IRSA: assume a role from an OIDC subject | federate a managed identity to a service account; same `system:serviceaccount:...` subject |
+| cache credential | you supply an auth token | Azure generates the keys; they come back as outputs |
+| cluster autoscaler | Helm release plus a ClusterRole patch | part of a node pool |
+| GPU device plugin | Helm release | installed by AKS with the driver |
+| database storage | any GiB, with a growth ceiling | a fixed ladder of sizes, with auto-grow as a switch |
+| memory and storage alerts | bytes free | percent used, so thresholds invert |
+| flow logs | on by default, to CloudWatch | opt-in, to a storage account, and needs a Network Watcher |
+| WAF logs | log group created by the module | emitted by the Application Gateway the policy attaches to |
+| provider config | declared inside the composition | declared by your root module |
+
+### Enabling flow logs
+
+Azure writes flow logs to a storage account and needs a Network Watcher in the
+region. The composition creates a second storage account for them, so the
+network never depends on the account holding application data:
+
+```hcl
+module "onyx" {
+  # ...
+  enable_flow_logs = true
+}
+```
+
+Azure creates a Network Watcher named `NetworkWatcher_<region>` in a resource
+group called `NetworkWatcherRG` the first time a virtual network appears in a
+region. If your subscription has that creation turned off, create one first or
+point `network_watcher_name` at yours.
+
+This only applies to a network the composition creates. With
+`create_virtual_network = false` it refuses the setting rather than creating a
+log storage account that nothing would ever write to; configure the flow log
+against your own network instead.
+
+## Installing the Onyx Helm chart (after Terraform)
+
+```bash
+az aks get-credentials --resource-group "$(terraform output -raw resource_group_name)" \
+  --name "$(terraform output -raw cluster_name)"
+```
+
+**Install into the `onyx` namespace.** A Kubernetes service account belongs to
+one namespace, and the `aks` module creates the federated one in `onyx`. A
+release installed anywhere else references an account that does not exist there,
+and the API and Celery pods never start.
+
+Terraform creates the namespace itself, because the service account cannot be
+created before it exists and the Helm install happens afterwards. So the release
+joins that namespace rather than making its own:
+
+```bash
+helm install onyx onyx/onyx --namespace onyx -f values.yaml
+```
+
+Set `create_workload_namespace = false` if something else already creates it.
+
+Three pieces of chart configuration are needed. None of them have defaults that
+work here, so a plain `helm install` will not pick up the infrastructure
+Terraform just built.
+
+### 1. Point the workloads at the federated service account
+
+The `aks` module creates a service account annotated with the managed identity's
+client ID. Pods only receive a token if they run under that account **and**
+carry the `azure.workload.identity/use` label, which is what the webhook looks
+for. Without both, `DefaultAzureCredential` finds no token and every file-store
+call fails to authenticate.
+
+```yaml
+serviceAccount:
+  create: false
+  name: onyx-workload-access   # matches the aks module's default, in namespace onyx
+
+# The label is per pod, so it goes on every component that touches the file
+# store: the API server and the Celery workers.
+api:
+  podLabels:
+    azure.workload.identity/use: "true"
+celery_worker_primary:
+  podLabels:
+    azure.workload.identity/use: "true"
+celery_worker_heavy:
+  podLabels:
+    azure.workload.identity/use: "true"
+celery_worker_light:
+  podLabels:
+    azure.workload.identity/use: "true"
+celery_worker_docfetching:
+  podLabels:
+    azure.workload.identity/use: "true"
+celery_worker_docprocessing:
+  podLabels:
+    azure.workload.identity/use: "true"
+celery_worker_user_file_processing:
+  podLabels:
+    azure.workload.identity/use: "true"
+celery_worker_scheduled_tasks:
+  podLabels:
+    azure.workload.identity/use: "true"
+celery_worker_monitoring:
+  podLabels:
+    azure.workload.identity/use: "true"
+celery_beat:
+  podLabels:
+    azure.workload.identity/use: "true"
+```
+
+### 2. Point the file store at the storage account
+
+The outputs line up with the environment the app reads:
+
+| environment variable | output |
+|---|---|
+| `FILE_STORE_BACKEND` | set to `azure` |
+| `AZURE_STORAGE_ACCOUNT_NAME` | `storage_account_name` |
+| `AZURE_STORAGE_ACCOUNT_URL` | `storage_account_url` |
+| `AZURE_FILE_STORE_CONTAINER_NAME` | `storage_container_name` |
+
+Leave `AZURE_STORAGE_ACCOUNT_KEY` unset. Onyx authenticates with
+`DefaultAzureCredential`, which picks up the workload identity from step 1, and
+the storage account has shared keys turned off anyway.
+
+### 3. Send the document index to its own node pool
+
+The `aks` module taints the index pool `document-index=true:NoSchedule` so
+nothing else lands on it. The OpenSearch subchart sets no tolerations of its
+own, so without this it schedules onto the system pool instead and the
+dedicated pool sits empty:
+
+```yaml
+opensearch:
+  nodeSelector:
+    onyx.app/workload: document-index
+  tolerations:
+    - key: document-index
+      operator: Equal
+      value: "true"
+      effect: NoSchedule
+```
+
+Set `index_node_pool_enabled = false` if you would rather run the index on the
+system pool and skip this.
+
+## Testing
+
+Every module has a `terraform test` suite that plans it against a mocked
+provider, so the suites need no Azure subscription and no credentials:
+
+```bash
+cd deployment/terraform/modules/azure/vnet
+terraform init -backend=false
+terraform test
+```
+
+They cover the wiring and the input validation, which is where a wrong
+argument name or an out-of-range value would otherwise only surface at apply.
+They do not prove the modules work against Azure. Only an apply does that.
+
+## Security
+
+- Shared access keys on the storage account are off, and blobs are never
+  anonymously readable.
+- The database and cache have no public endpoint.
+- The cache refuses its plaintext port, and both refuse TLS below 1.2.
+- The API server will not be built open. You must set
+  `api_server_authorized_ip_ranges`, or `private_cluster_enabled`, or
+  `allow_unrestricted_api_server_access` to record that an open control plane is
+  what you meant.
+- The database will not be built without a way to log in: supply
+  `postgres_password`, or turn on `entra_database_authentication_only` together
+  with a `database_administrator_object_id`.
+- Turn `restrict_storage_to_cluster` on once Terraform runs from inside the
+  network. From outside, it locks out whoever manages the container.

--- a/deployment/terraform/modules/azure/onyx/main.tf
+++ b/deployment/terraform/modules/azure/onyx/main.tf
@@ -1,0 +1,280 @@
+locals {
+  workspace   = terraform.workspace
+  merged_tags = merge(var.tags, { tenant = var.name, environment = local.workspace })
+
+  resource_group_name_desired = coalesce(var.resource_group_name, "${var.name}-${local.workspace}")
+
+  cluster_name  = "${var.name}-${local.workspace}"
+  postgres_name = "${var.name}-postgres-${local.workspace}"
+  redis_name    = "${var.name}-redis-${local.workspace}"
+
+  # Storage account names are globally unique and allow only 24 lowercase
+  # alphanumeric characters, so the readable prefix is truncated and a short
+  # digest of the full identity is appended to keep collisions unlikely.
+  storage_name_digest    = substr(sha1("${var.name}-${local.workspace}-${var.location}-${local.resource_group_name_desired}"), 0, 6)
+  storage_name_sanitized = replace(lower("${var.name}${local.workspace}files"), "/[^a-z0-9]/", "")
+  storage_name_prefix    = substr(local.storage_name_sanitized, 0, 18)
+  storage_account_name = coalesce(
+    var.storage_account_name,
+    "${local.storage_name_prefix}${local.storage_name_digest}",
+  )
+  # 15 + len("log") + 6 = 24, so the digest survives in full here too.
+  flow_log_storage_account_name = "${substr(local.storage_name_sanitized, 0, 15)}log${local.storage_name_digest}"
+
+  virtual_network_id         = var.create_virtual_network ? module.vnet[0].vnet_id : var.virtual_network_id
+  aks_subnet_id              = var.create_virtual_network ? module.vnet[0].aks_subnet_id : var.aks_subnet_id
+  postgres_subnet_id         = var.create_virtual_network ? module.vnet[0].postgres_subnet_id : var.postgres_subnet_id
+  private_endpoint_subnet_id = var.create_virtual_network ? module.vnet[0].private_endpoint_subnet_id : var.private_endpoint_subnet_id
+
+  # A supplied subnet may already carry a NAT gateway, which only the caller
+  # knows about, so the derived value is a default rather than a decision.
+  aks_outbound_type = coalesce(
+    var.aks_outbound_type,
+    var.create_virtual_network && var.enable_nat_gateway ? "userAssignedNATGateway" : "loadBalancer",
+  )
+
+  nat_gateway_ips = var.create_virtual_network ? module.vnet[0].nat_gateway_public_ips : []
+  trusted_nat_ips = var.waf_trust_nat_gateway_ip ? local.nat_gateway_ips : []
+
+  waf_allowed_ip_cidrs           = distinct(concat(var.waf_allowed_ip_cidrs, local.trusted_nat_ips))
+  waf_rate_limit_exempt_ip_cidrs = distinct(concat(var.waf_rate_limit_exempt_ip_cidrs, local.trusted_nat_ips))
+
+  # T-shirt size defaults, chosen so each tier lands on the Azure size closest
+  # to what the AWS composition picks. The index pool is memory-optimised
+  # because on Azure it carries the document index itself: there is no managed
+  # OpenSearch to move that load off the cluster.
+  size_defaults = {
+    small = {
+      main_node_vm_size       = "Standard_D8ds_v5"
+      main_node_min_count     = 1
+      main_node_max_count     = 3
+      index_node_vm_size      = "Standard_E4ds_v5"
+      index_node_disk_size_gb = 256
+      postgres_sku_name       = "GP_Standard_D2ds_v5"
+      postgres_storage_gb     = 64
+      redis_sku_name          = "Standard"
+      redis_family            = "C"
+      redis_capacity          = 3
+    }
+    medium = {
+      main_node_vm_size       = "Standard_D16ds_v5"
+      main_node_min_count     = 1
+      main_node_max_count     = 5
+      index_node_vm_size      = "Standard_E8ds_v5"
+      index_node_disk_size_gb = 512
+      postgres_sku_name       = "GP_Standard_D2ds_v5"
+      postgres_storage_gb     = 128
+      redis_sku_name          = "Standard"
+      redis_family            = "C"
+      redis_capacity          = 4
+    }
+    large = {
+      main_node_vm_size       = "Standard_D16ds_v5"
+      main_node_min_count     = 2
+      main_node_max_count     = 8
+      index_node_vm_size      = "Standard_E16ds_v5"
+      index_node_disk_size_gb = 1024
+      postgres_sku_name       = "GP_Standard_D4ds_v5"
+      postgres_storage_gb     = 256
+      redis_sku_name          = "Standard"
+      redis_family            = "C"
+      redis_capacity          = 5
+    }
+  }
+  sizing = local.size_defaults[var.size]
+
+  # An explicitly set variable always wins over its tier default.
+  main_node_vm_size       = coalesce(var.main_node_vm_size, local.sizing.main_node_vm_size)
+  main_node_min_count     = coalesce(var.main_node_min_count, local.sizing.main_node_min_count)
+  main_node_max_count     = coalesce(var.main_node_max_count, local.sizing.main_node_max_count)
+  index_node_vm_size      = coalesce(var.index_node_vm_size, local.sizing.index_node_vm_size)
+  index_node_disk_size_gb = coalesce(var.index_node_disk_size_gb, local.sizing.index_node_disk_size_gb)
+  postgres_sku_name       = coalesce(var.postgres_sku_name, local.sizing.postgres_sku_name)
+  postgres_storage_gb     = coalesce(var.postgres_storage_gb, local.sizing.postgres_storage_gb)
+  redis_sku_name          = coalesce(var.redis_sku_name, local.sizing.redis_sku_name)
+  redis_family            = coalesce(var.redis_family, local.sizing.redis_family)
+  redis_capacity          = coalesce(var.redis_capacity, local.sizing.redis_capacity)
+
+  node_pools = merge(
+    {
+      main = {
+        vm_size   = local.main_node_vm_size
+        min_count = local.main_node_min_count
+        max_count = local.main_node_max_count
+      }
+    },
+    var.index_node_pool_enabled ? {
+      index = {
+        vm_size         = local.index_node_vm_size
+        min_count       = 1
+        max_count       = 1
+        os_disk_size_gb = local.index_node_disk_size_gb
+        node_labels     = { "onyx.app/workload" = "document-index" }
+        node_taints     = ["document-index=true:NoSchedule"]
+      }
+    } : {},
+  )
+}
+
+resource "azurerm_resource_group" "this" {
+  count = var.create_resource_group ? 1 : 0
+
+  name     = local.resource_group_name_desired
+  location = var.location
+  tags     = local.merged_tags
+}
+
+locals {
+  # Reading the name back off the resource is what orders every module after
+  # the group, without each one needing its own depends_on.
+  resource_group_name = var.create_resource_group ? azurerm_resource_group.this[0].name : local.resource_group_name_desired
+}
+
+module "vnet" {
+  source = "../vnet"
+  count  = var.create_virtual_network ? 1 : 0
+
+  name                = var.name
+  resource_group_name = local.resource_group_name
+  location            = var.location
+  address_space       = var.address_space
+  enable_nat_gateway  = var.enable_nat_gateway
+  tags                = local.merged_tags
+
+  enable_flow_logs                    = var.enable_flow_logs
+  flow_log_storage_account_id         = var.enable_flow_logs ? module.storage_flow_logs[0].storage_account_id : null
+  network_watcher_name                = coalesce(var.network_watcher_name, "NetworkWatcher_${var.location}")
+  network_watcher_resource_group_name = var.network_watcher_resource_group_name
+}
+
+# A separate account for flow logs. It takes no subnets, which is what keeps
+# the dependency one-way: this account, then the network, then the file store
+# account that restricts itself to the network's subnets.
+module "storage_flow_logs" {
+  source = "../storage"
+  count  = var.enable_flow_logs ? 1 : 0
+
+  storage_account_name = local.flow_log_storage_account_name
+  container_name       = "flow-logs"
+  resource_group_name  = local.resource_group_name
+  location             = var.location
+  tags                 = local.merged_tags
+
+  account_replication_type = "LRS"
+  enable_versioning        = false
+  transition_to_cool       = false
+}
+
+module "storage" {
+  source = "../storage"
+
+  storage_account_name = local.storage_account_name
+  container_name       = var.storage_container_name
+  resource_group_name  = local.resource_group_name
+  location             = var.location
+  tags                 = local.merged_tags
+
+  account_replication_type = var.storage_account_replication_type
+  allowed_subnet_ids       = var.restrict_storage_to_cluster ? [local.aks_subnet_id] : []
+}
+
+module "postgres" {
+  source = "../postgres"
+
+  name                = local.postgres_name
+  resource_group_name = local.resource_group_name
+  location            = var.location
+  tags                = local.merged_tags
+
+  db_name        = var.postgres_db_name
+  engine_version = var.postgres_engine_version
+  sku_name       = local.postgres_sku_name
+  storage_gb     = local.postgres_storage_gb
+
+  delegated_subnet_id = local.postgres_subnet_id
+  virtual_network_id  = local.virtual_network_id
+
+  username = var.postgres_username
+  password = var.postgres_password
+
+  enable_entra_authentication        = var.enable_entra_database_authentication
+  entra_authentication_only          = var.entra_database_authentication_only
+  entra_administrator_object_id      = var.database_administrator_object_id
+  entra_administrator_principal_name = var.database_administrator_principal_name
+  entra_administrator_principal_type = var.database_administrator_principal_type
+  tenant_id                          = var.tenant_id
+
+  high_availability_enabled = var.postgres_high_availability_enabled
+  backup_retention_days     = var.postgres_backup_retention_days
+
+  action_group_ids = var.action_group_ids
+}
+
+module "redis" {
+  source = "../redis"
+
+  name                = local.redis_name
+  resource_group_name = local.resource_group_name
+  location            = var.location
+  tags                = local.merged_tags
+
+  sku_name = local.redis_sku_name
+  family   = local.redis_family
+  capacity = local.redis_capacity
+
+  private_endpoint_subnet_id = local.private_endpoint_subnet_id
+  virtual_network_id         = local.virtual_network_id
+
+  action_group_ids = var.action_group_ids
+}
+
+module "aks" {
+  source = "../aks"
+
+  cluster_name        = local.cluster_name
+  resource_group_name = local.resource_group_name
+  location            = var.location
+  kubernetes_version  = var.kubernetes_version
+  subnet_id           = local.aks_subnet_id
+  tags                = local.merged_tags
+
+  node_pools              = local.node_pools
+  index_node_pool_enabled = var.index_node_pool_enabled
+
+  enable_gpu_node_pool     = var.enable_gpu_node_pool
+  enable_sandbox_node_pool = var.enable_sandbox_node_pool
+
+  private_cluster_enabled              = var.private_cluster_enabled
+  api_server_authorized_ip_ranges      = var.api_server_authorized_ip_ranges
+  allow_unrestricted_api_server_access = var.allow_unrestricted_api_server_access
+  network_policy                       = var.network_policy
+
+  # The vnet module puts a NAT gateway on the node subnet, so the cluster keeps
+  # one egress address. Without that gateway AKS has to manage outbound itself.
+  outbound_type = local.aks_outbound_type
+
+  storage_account_ids                       = [module.storage.storage_account_id]
+  additional_workload_service_account_names = var.additional_workload_service_account_names
+  create_workload_service_account           = var.create_workload_service_account
+  create_workload_namespace                 = var.create_workload_namespace
+
+  log_analytics_workspace_id        = var.log_analytics_workspace_id
+  entra_rbac_admin_group_object_ids = var.entra_rbac_admin_group_object_ids
+}
+
+module "waf" {
+  source = "../waf"
+  count  = var.enable_waf ? 1 : 0
+
+  name                = var.name
+  resource_group_name = local.resource_group_name
+  location            = var.location
+  tags                = local.merged_tags
+
+  mode                                  = var.waf_mode
+  allowed_ip_cidrs                      = local.waf_allowed_ip_cidrs
+  rate_limit_exempt_ip_cidrs            = local.waf_rate_limit_exempt_ip_cidrs
+  geo_restriction_countries             = var.waf_geo_restriction_countries
+  rate_limit_requests_per_5_minutes     = var.waf_rate_limit_requests_per_5_minutes
+  api_rate_limit_requests_per_5_minutes = var.waf_api_rate_limit_requests_per_5_minutes
+}

--- a/deployment/terraform/modules/azure/onyx/outputs.tf
+++ b/deployment/terraform/modules/azure/onyx/outputs.tf
@@ -1,0 +1,126 @@
+output "resource_group_name" {
+  description = "Resource group holding the deployment"
+  value       = local.resource_group_name
+}
+
+output "cluster_name" {
+  description = "Name of the AKS cluster"
+  value       = module.aks.cluster_name
+}
+
+output "cluster_fqdn" {
+  description = "API server hostname"
+  value       = module.aks.cluster_fqdn
+}
+
+output "oidc_issuer_url" {
+  description = "OIDC issuer URL of the cluster, the trust anchor for federated credentials"
+  value       = module.aks.oidc_issuer_url
+}
+
+output "workload_identity_client_id" {
+  description = "Client ID of the workload identity. Set this as the azure.workload.identity/client-id annotation on any service account the module did not create."
+  value       = module.aks.workload_identity_client_id
+}
+
+output "node_resource_group" {
+  description = "Resource group AKS creates for the cluster's own infrastructure"
+  value       = module.aks.node_resource_group
+}
+
+# --- Values the Helm chart needs ---------------------------------------------
+
+output "storage_account_name" {
+  description = "Set as AZURE_STORAGE_ACCOUNT_NAME"
+  value       = module.storage.storage_account_name
+}
+
+output "storage_account_url" {
+  description = "Set as AZURE_STORAGE_ACCOUNT_URL"
+  value       = module.storage.primary_blob_endpoint
+}
+
+output "storage_container_name" {
+  description = "Set as AZURE_FILE_STORE_CONTAINER_NAME"
+  value       = module.storage.container_name
+}
+
+output "postgres_host" {
+  description = "Private hostname of the database server"
+  value       = module.postgres.fqdn
+}
+
+output "postgres_port" {
+  description = "Database port"
+  value       = module.postgres.port
+}
+
+output "postgres_db_name" {
+  description = "Database name"
+  value       = module.postgres.db_name
+}
+
+output "postgres_username" {
+  description = "Administrator login"
+  value       = module.postgres.username
+  sensitive   = true
+}
+
+output "redis_host" {
+  description = "Hostname of the cache. Behind its private endpoint this resolves to a private address."
+  value       = module.redis.hostname
+}
+
+output "redis_ssl_port" {
+  description = "TLS port of the cache. The plaintext port is disabled."
+  value       = module.redis.ssl_port
+}
+
+# Azure generates this rather than accepting one, so it comes out of the module
+# rather than going in.
+output "redis_primary_access_key" {
+  description = "Generated primary access key for the cache"
+  value       = module.redis.primary_access_key
+  sensitive   = true
+}
+
+# Only reflects a NAT gateway this module created. With a supplied network the
+# cluster may still egress through one, but the module cannot see it, so this
+# is empty rather than wrong.
+output "nat_gateway_public_ips" {
+  description = "Egress addresses of a NAT gateway this module created, which downstream allowlists key off. Empty when create_virtual_network is false, even if the supplied subnet has a NAT gateway of its own."
+  value       = local.nat_gateway_ips
+}
+
+output "waf_policy_id" {
+  description = "WAF policy to attach to an Application Gateway or Front Door route, null when disabled"
+  value       = try(module.waf[0].policy_id, null)
+}
+
+# --- Cluster credentials -----------------------------------------------------
+# The composition creates Kubernetes objects, so the root module has to be able
+# to configure the kubernetes provider against the cluster it just made.
+
+output "cluster_host" {
+  description = "API server address for the kubernetes and helm providers"
+  value       = module.aks.host
+  sensitive   = true
+}
+
+output "cluster_ca_certificate" {
+  description = "Cluster CA certificate, base64 encoded"
+  value       = module.aks.cluster_ca_certificate
+  sensitive   = true
+}
+
+output "client_certificate" {
+  description = "Client certificate, base64 encoded. Empty when only Entra ID logins are accepted."
+  value       = module.aks.client_certificate
+  sensitive   = true
+}
+
+output "client_key" {
+  description = "Client key, base64 encoded. Empty when only Entra ID logins are accepted."
+  value       = module.aks.client_key
+  sensitive   = true
+}

--- a/deployment/terraform/modules/azure/onyx/tests/onyx.tftest.hcl
+++ b/deployment/terraform/modules/azure/onyx/tests/onyx.tftest.hcl
@@ -1,0 +1,359 @@
+# Plans the whole composition against mocked providers, so these run without an
+# Azure subscription. Run with `terraform test` from the module directory.
+
+mock_provider "azurerm" {}
+mock_provider "kubernetes" {}
+
+variables {
+  name              = "onyx"
+  location          = "eastus"
+  postgres_password = "not-a-real-password"
+
+  # The composition now refuses a public API server that no range restricts, so
+  # every case below has to say what it wants.
+  api_server_authorized_ip_ranges = ["203.0.113.0/24"]
+}
+
+run "medium_is_the_default_tier" {
+  command = plan
+
+  assert {
+    condition     = local.main_node_vm_size == "Standard_D16ds_v5"
+    error_message = "Medium should land on the Azure size closest to the AWS composition's m7i.4xlarge."
+  }
+
+  assert {
+    condition     = local.postgres_sku_name == "GP_Standard_D2ds_v5"
+    error_message = "Medium keeps the small database SKU, matching the AWS composition."
+  }
+
+  assert {
+    condition     = local.redis_capacity == 4
+    error_message = "Standard C4 is 13 GB, matching the AWS composition's cache.m6g.xlarge."
+  }
+
+  assert {
+    condition     = local.index_node_vm_size == "Standard_E8ds_v5"
+    error_message = "The index pool is memory-optimised because on Azure it carries the document index itself."
+  }
+}
+
+run "small_and_large_move_every_knob_together" {
+  command = plan
+
+  variables {
+    size = "small"
+  }
+
+  assert {
+    condition = alltrue([
+      local.main_node_vm_size == "Standard_D8ds_v5",
+      local.main_node_max_count == 3,
+      local.postgres_storage_gb == 64,
+      local.index_node_disk_size_gb == 256,
+    ])
+    error_message = "The small tier should move compute, database and index sizing together."
+  }
+}
+
+run "large_scales_the_index_pool_hardest" {
+  command = plan
+
+  variables {
+    size = "large"
+  }
+
+  assert {
+    condition     = local.index_node_vm_size == "Standard_E16ds_v5"
+    error_message = "Large has no managed search service to offload to, so the index pool takes the load."
+  }
+
+  assert {
+    condition     = local.index_node_disk_size_gb == 1024
+    error_message = "The index needs room to grow on disk."
+  }
+
+  assert {
+    condition     = local.postgres_sku_name == "GP_Standard_D4ds_v5"
+    error_message = "Large moves the database off the smallest general purpose SKU."
+  }
+}
+
+run "an_explicit_value_beats_its_tier_default" {
+  command = plan
+
+  variables {
+    size                = "small"
+    postgres_storage_gb = 512
+    main_node_max_count = 10
+  }
+
+  assert {
+    condition     = local.postgres_storage_gb == 512
+    error_message = "An explicitly set variable must win over the tier default."
+  }
+
+  assert {
+    condition     = local.main_node_max_count == 10
+    error_message = "An explicitly set variable must win over the tier default."
+  }
+
+  assert {
+    condition     = local.main_node_vm_size == "Standard_D8ds_v5"
+    error_message = "Overriding one knob must not disturb the others in the tier."
+  }
+}
+
+run "the_derived_storage_account_name_is_one_azure_accepts" {
+  command = plan
+
+  assert {
+    condition     = can(regex("^[a-z0-9]{3,24}$", local.storage_account_name))
+    error_message = "Storage account names allow only 3-24 lowercase alphanumeric characters."
+  }
+
+  assert {
+    condition     = can(regex("^[a-z0-9]{3,24}$", local.flow_log_storage_account_name))
+    error_message = "The flow log account name has to satisfy the same rule."
+  }
+
+  assert {
+    condition     = local.storage_account_name != local.flow_log_storage_account_name
+    error_message = "The two accounts must not collide on a name."
+  }
+}
+
+run "both_account_names_keep_the_whole_digest" {
+  command = plan
+
+  # The flow log name also carries "log", so its prefix has to be shorter or
+  # truncation eats the digest and two deployments can collide in Azure's
+  # global namespace.
+  variables {
+    name = "onyx-enterprise-production-deployment"
+  }
+
+  assert {
+    condition     = endswith(local.storage_account_name, local.storage_name_digest)
+    error_message = "The file store account name must keep its whole digest."
+  }
+
+  assert {
+    condition     = endswith(local.flow_log_storage_account_name, local.storage_name_digest)
+    error_message = "The flow log account name must keep its whole digest too."
+  }
+
+  assert {
+    condition     = length(local.flow_log_storage_account_name) <= 24
+    error_message = "Storage account names allow at most 24 characters."
+  }
+}
+
+run "a_long_name_still_produces_an_acceptable_account_name" {
+  command = plan
+
+  variables {
+    name = "onyx-enterprise-production-deployment"
+  }
+
+  assert {
+    condition     = can(regex("^[a-z0-9]{3,24}$", local.storage_account_name))
+    error_message = "A long prefix must be truncated rather than producing a name Azure rejects."
+  }
+}
+
+run "an_explicit_storage_account_name_is_used_as_given" {
+  command = plan
+
+  variables {
+    storage_account_name = "onyxfilesprod"
+  }
+
+  assert {
+    condition     = local.storage_account_name == "onyxfilesprod"
+    error_message = "A supplied name should be used unchanged."
+  }
+}
+
+run "the_resource_group_is_created_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(azurerm_resource_group.this) == 1
+    error_message = "The composition creates its own resource group by default."
+  }
+
+  assert {
+    condition     = local.resource_group_name_desired == "onyx-default"
+    error_message = "The group is named after the module name and the workspace."
+  }
+}
+
+run "an_existing_resource_group_can_be_joined" {
+  command = plan
+
+  variables {
+    create_resource_group = false
+    resource_group_name   = "shared-rg"
+  }
+
+  assert {
+    condition     = length(azurerm_resource_group.this) == 0
+    error_message = "Joining an existing group must not create one."
+  }
+
+  assert {
+    condition     = local.resource_group_name == "shared-rg"
+    error_message = "The supplied group name should be used."
+  }
+}
+
+run "flow_logs_bring_their_own_storage_account" {
+  command = plan
+
+  variables {
+    enable_flow_logs = true
+  }
+
+  assert {
+    condition     = length(module.storage_flow_logs) == 1
+    error_message = "Flow logs need an account of their own, so the network never depends on the file store account."
+  }
+}
+
+run "flow_logs_are_off_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(module.storage_flow_logs) == 0
+    error_message = "Flow logs need a Network Watcher in the region, so they are opt-in."
+  }
+}
+
+run "the_waf_exists_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(module.waf) == 1
+    error_message = "The WAF policy is created by default so there is something to attach at the edge."
+  }
+}
+
+run "egress_uses_the_nat_gateway_this_module_created" {
+  command = plan
+
+  assert {
+    condition     = local.aks_outbound_type == "userAssignedNATGateway"
+    error_message = "With a created network and a NAT gateway the cluster should keep one egress address."
+  }
+}
+
+run "a_supplied_network_falls_back_to_load_balancer_egress" {
+  command = plan
+
+  variables {
+    create_virtual_network     = false
+    virtual_network_id         = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/existing"
+    aks_subnet_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/existing/subnets/aks"
+    postgres_subnet_id         = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/existing/subnets/postgres"
+    private_endpoint_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/existing/subnets/pe"
+  }
+
+  assert {
+    condition     = local.aks_outbound_type == "loadBalancer"
+    error_message = "Without a NAT gateway of our own, AKS has to manage outbound."
+  }
+}
+
+run "a_supplied_subnet_with_its_own_nat_gateway_can_say_so" {
+  command = plan
+
+  variables {
+    create_virtual_network     = false
+    virtual_network_id         = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/existing"
+    aks_subnet_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/existing/subnets/aks"
+    postgres_subnet_id         = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/existing/subnets/postgres"
+    private_endpoint_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/existing/subnets/pe"
+    aks_outbound_type          = "userAssignedNATGateway"
+  }
+
+  assert {
+    condition     = local.aks_outbound_type == "userAssignedNATGateway"
+    error_message = "A caller whose subnet already has a NAT gateway should keep its stable address."
+  }
+}
+
+run "entra_only_needs_no_password" {
+  command = plan
+
+  variables {
+    postgres_password                     = null
+    enable_entra_database_authentication   = true
+    entra_database_authentication_only     = true
+    tenant_id                              = "00000000-0000-0000-0000-000000000000"
+    database_administrator_object_id       = "11111111-1111-1111-1111-111111111111"
+    database_administrator_principal_name  = "onyx-db-admins"
+  }
+
+  assert {
+    condition     = local.postgres_sku_name != null
+    error_message = "The plan should succeed with no password at all, which is the point of this run."
+  }
+}
+
+run "rejects_a_deployment_with_no_database_password" {
+  command = plan
+
+  variables {
+    postgres_password = null
+  }
+
+  expect_failures = [var.postgres_password]
+}
+
+run "rejects_an_open_control_plane" {
+  command = plan
+
+  variables {
+    api_server_authorized_ip_ranges = []
+  }
+
+  expect_failures = [var.allow_unrestricted_api_server_access]
+}
+
+run "rejects_flow_logs_on_a_network_it_does_not_manage" {
+  command = plan
+
+  # Otherwise the log storage account is created and nothing ever writes to it.
+  variables {
+    enable_flow_logs           = true
+    create_virtual_network     = false
+    virtual_network_id         = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/existing"
+    aks_subnet_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/existing/subnets/aks"
+    postgres_subnet_id         = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/existing/subnets/postgres"
+    private_endpoint_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/existing/subnets/pe"
+  }
+
+  expect_failures = [var.enable_flow_logs]
+}
+
+run "bringing_your_own_network_needs_every_subnet" {
+  command = plan
+
+  variables {
+    create_virtual_network = false
+    virtual_network_id     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/existing"
+  }
+
+  expect_failures = [var.create_virtual_network]
+}
+
+run "rejects_a_size_that_is_not_a_tier" {
+  command = plan
+
+  variables {
+    size = "extra-large"
+  }
+
+  expect_failures = [var.size]
+}

--- a/deployment/terraform/modules/azure/onyx/variables.tf
+++ b/deployment/terraform/modules/azure/onyx/variables.tf
@@ -1,0 +1,460 @@
+variable "name" {
+  type        = string
+  description = "Name prefix for every resource. Example: \"onyx\"."
+  default     = "onyx"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region for all resources, for example \"eastus\""
+}
+
+variable "create_resource_group" {
+  type        = bool
+  description = "Create the resource group. False joins one that already exists."
+  default     = true
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group to create or join. Null names it \"<name>-<workspace>\"."
+  default     = null
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Base tags applied to every resource"
+  # Add an owner tag here if your asset inventory expects one. Everything set
+  # here is stamped on every resource this module creates.
+  default = {
+    "project" = "onyx"
+  }
+}
+
+variable "size" {
+  type        = string
+  description = <<-EOT
+    T-shirt size that sets coherent defaults for every compute and data-plane knob:
+      small  - pilots and small teams: up to ~200 users, < ~500k documents
+      medium - typical department or company: ~200-1,000 users, ~0.5-2M documents
+      large  - org-wide deployments: 1,000+ users, multi-million documents
+    Any individual sizing variable set to a non-null value overrides its tier
+    default. See the README for the full per-tier table.
+  EOT
+  default     = "medium"
+
+  validation {
+    condition     = contains(["small", "medium", "large"], var.size)
+    error_message = "size must be one of: small, medium, large."
+  }
+}
+
+# --- Network -----------------------------------------------------------------
+
+variable "create_virtual_network" {
+  type        = bool
+  description = "Create the virtual network. False uses the subnets supplied below."
+  default     = true
+
+  validation {
+    condition     = var.create_virtual_network || (var.virtual_network_id != null && var.aks_subnet_id != null && var.postgres_subnet_id != null && var.private_endpoint_subnet_id != null)
+    error_message = "Bringing your own network needs virtual_network_id, aks_subnet_id, postgres_subnet_id and private_endpoint_subnet_id."
+  }
+}
+
+variable "address_space" {
+  type        = list(string)
+  description = "Address space for the created virtual network"
+  default     = ["10.0.0.0/16"]
+}
+
+variable "virtual_network_id" {
+  type        = string
+  description = "Existing virtual network. Required when create_virtual_network is false."
+  default     = null
+}
+
+variable "aks_subnet_id" {
+  type        = string
+  description = "Existing subnet for the cluster nodes. Required when create_virtual_network is false."
+  default     = null
+}
+
+variable "postgres_subnet_id" {
+  type        = string
+  description = "Existing subnet delegated to PostgreSQL Flexible Server. Required when create_virtual_network is false."
+  default     = null
+}
+
+variable "private_endpoint_subnet_id" {
+  type        = string
+  description = "Existing subnet for private endpoints. Required when create_virtual_network is false."
+  default     = null
+}
+
+variable "enable_nat_gateway" {
+  type        = bool
+  description = "Give the cluster a stable egress address through a NAT gateway. Only applies to a network this module creates."
+  default     = true
+}
+
+# A supplied subnet may already carry a NAT gateway. Without this the
+# composition would force AKS to manage outbound and throw away the stable
+# address that gateway provides.
+variable "aks_outbound_type" {
+  type        = string
+  description = "How cluster nodes reach the internet. Null derives it: userAssignedNATGateway when this module created the network with a NAT gateway, loadBalancer otherwise. Set it to userAssignedNATGateway when bringing a subnet that already has one."
+  default     = null
+
+  validation {
+    condition     = var.aks_outbound_type == null || contains(["loadBalancer", "userAssignedNATGateway", "userDefinedRouting", "managedNATGateway"], var.aks_outbound_type)
+    error_message = "aks_outbound_type must be one of: loadBalancer, userAssignedNATGateway, userDefinedRouting, managedNATGateway."
+  }
+}
+
+# Off by default, unlike the AWS modules, because Azure needs a Network Watcher
+# in the region and writes flow logs to a storage account. Turning this on
+# creates a second storage account dedicated to logs.
+variable "enable_flow_logs" {
+  type        = bool
+  description = "Send virtual network flow logs to a dedicated storage account. Requires a Network Watcher in this region; Azure names the one it creates \"NetworkWatcher_<region>\"."
+  default     = false
+
+  validation {
+    condition     = !var.enable_flow_logs || var.create_virtual_network
+    error_message = "enable_flow_logs only applies to a network this module creates. For a supplied network, configure the flow log against it directly, or the module would create a storage account and never write to it."
+  }
+}
+
+variable "network_watcher_name" {
+  type        = string
+  description = "Network Watcher that owns the flow log. Null derives \"NetworkWatcher_<location>\"."
+  default     = null
+}
+
+variable "network_watcher_resource_group_name" {
+  type        = string
+  description = "Resource group holding the Network Watcher"
+  default     = "NetworkWatcherRG"
+}
+
+# --- Storage -----------------------------------------------------------------
+
+variable "storage_account_name" {
+  type        = string
+  description = "Name of the file store account. Null derives one from the name, workspace and a short digest, because storage account names are globally unique and allow only 24 lowercase alphanumeric characters."
+  default     = null
+}
+
+variable "storage_container_name" {
+  type        = string
+  description = "Blob container holding the Onyx file store"
+  default     = "onyx-file-store"
+}
+
+variable "storage_account_replication_type" {
+  type        = string
+  description = "Replication for the file store account"
+  default     = "ZRS"
+}
+
+variable "restrict_storage_to_cluster" {
+  type        = bool
+  description = "Let only the cluster subnet reach the storage account. Leave this off while running Terraform from outside the network, or the container becomes unreachable to whoever manages it."
+  default     = false
+}
+
+# --- Postgres ----------------------------------------------------------------
+
+variable "postgres_sku_name" {
+  type        = string
+  description = "Flexible server SKU. Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "postgres_storage_gb" {
+  type        = number
+  description = "Storage in GiB, off the fixed ladder Azure offers. Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "postgres_username" {
+  type        = string
+  description = "Administrator login for the database"
+  default     = "psqladmin"
+  sensitive   = true
+}
+
+variable "postgres_password" {
+  type        = string
+  description = "Administrator password. Supply it from a secret store. Required unless entra_database_authentication_only turns password logins off; enable_entra_database_authentication on its own only adds Entra logins alongside passwords."
+  default     = null
+  sensitive   = true
+
+  validation {
+    condition     = var.postgres_password != null || var.entra_database_authentication_only
+    error_message = "postgres_password must be set. Azure rejects a server that accepts password logins but has no administrator password. Set entra_database_authentication_only to use Entra ID instead."
+  }
+}
+
+variable "postgres_db_name" {
+  type        = string
+  description = "Database created on the server"
+  default     = "postgres"
+}
+
+variable "postgres_engine_version" {
+  type        = string
+  description = "PostgreSQL major version"
+  default     = "17"
+}
+
+variable "postgres_high_availability_enabled" {
+  type        = bool
+  description = "Run a standby in a second zone. Roughly doubles database cost."
+  default     = false
+}
+
+variable "postgres_backup_retention_days" {
+  type        = number
+  description = "Days to retain automated backups"
+  default     = 7
+}
+
+variable "enable_entra_database_authentication" {
+  type        = bool
+  description = "Accept Entra ID logins on the database, the analogue of the AWS module's IAM database authentication"
+  default     = false
+}
+
+variable "entra_database_authentication_only" {
+  type        = bool
+  description = "Turn off password logins to the database so Entra ID is the only way in. Needs enable_entra_database_authentication and a database administrator."
+  default     = false
+
+  validation {
+    condition     = !var.entra_database_authentication_only || var.enable_entra_database_authentication
+    error_message = "entra_database_authentication_only requires enable_entra_database_authentication."
+  }
+}
+
+variable "database_administrator_object_id" {
+  type        = string
+  description = "Object ID of the Entra principal to make database administrator. Required when entra_database_authentication_only is true."
+  default     = null
+}
+
+variable "database_administrator_principal_name" {
+  type        = string
+  description = "Display name of the Entra database administrator"
+  default     = null
+}
+
+variable "database_administrator_principal_type" {
+  type        = string
+  description = "What kind of Entra principal the database administrator is"
+  default     = "Group"
+}
+
+variable "tenant_id" {
+  type        = string
+  description = "Entra ID tenant, required when enable_entra_database_authentication is true"
+  default     = null
+}
+
+# --- Redis -------------------------------------------------------------------
+
+variable "redis_sku_name" {
+  type        = string
+  description = "Cache tier. Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "redis_family" {
+  type        = string
+  description = "Cache family. Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "redis_capacity" {
+  type        = number
+  description = "Cache size within the family. Null uses the t-shirt size default."
+  default     = null
+}
+
+# --- Cluster -----------------------------------------------------------------
+
+variable "kubernetes_version" {
+  type        = string
+  description = "Kubernetes version for the control plane"
+  default     = "1.33"
+}
+
+variable "main_node_vm_size" {
+  type        = string
+  description = "VM size for the system node pool. Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "main_node_min_count" {
+  type        = number
+  description = "Minimum nodes in the system pool. The autoscaler will not go below this, so raise it to keep always-on capacity for bursty work. Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "main_node_max_count" {
+  type        = number
+  description = "Maximum nodes in the system pool. Null uses the t-shirt size default."
+  default     = null
+}
+
+# Azure has no managed OpenSearch, so this pool is where the document index
+# runs. It is on by default, unlike the AWS module's equivalent.
+variable "index_node_pool_enabled" {
+  type        = bool
+  description = "Create the document-index node pool"
+  default     = true
+}
+
+variable "index_node_vm_size" {
+  type        = string
+  description = "VM size for the document-index pool. Memory-optimised, because the index is what needs it. Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "index_node_disk_size_gb" {
+  type        = number
+  description = "OS disk for document-index nodes. Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "private_cluster_enabled" {
+  type        = bool
+  description = "Give the API server a private endpoint only"
+  default     = false
+}
+
+variable "api_server_authorized_ip_ranges" {
+  type        = list(string)
+  description = "CIDR ranges allowed to reach the public API server"
+  default     = []
+}
+
+variable "allow_unrestricted_api_server_access" {
+  type        = bool
+  description = "Accept a public API server reachable from any address. Only for throwaway deployments; set api_server_authorized_ip_ranges or private_cluster_enabled instead."
+  default     = false
+
+  validation {
+    condition     = var.allow_unrestricted_api_server_access || var.private_cluster_enabled || length(var.api_server_authorized_ip_ranges) > 0
+    error_message = "A public API server with no authorized ranges is reachable from every address on the internet. Set api_server_authorized_ip_ranges, or private_cluster_enabled, or allow_unrestricted_api_server_access to record that the exposure is intended."
+  }
+}
+
+variable "network_policy" {
+  type        = string
+  description = "NetworkPolicy engine. Null leaves enforcement off and existing policies inert."
+  default     = null
+}
+
+variable "enable_gpu_node_pool" {
+  type        = bool
+  description = "Create a tainted GPU pool for the embedding model server"
+  default     = false
+}
+
+variable "enable_sandbox_node_pool" {
+  type        = bool
+  description = "Create a tainted pool for Craft sandbox workloads"
+  default     = false
+}
+
+variable "log_analytics_workspace_id" {
+  type        = string
+  description = "Workspace that receives control plane logs and container insights. Null sends neither."
+  default     = null
+}
+
+variable "entra_rbac_admin_group_object_ids" {
+  type        = list(string)
+  description = "Entra ID groups granted cluster admin"
+  default     = []
+}
+
+variable "additional_workload_service_account_names" {
+  type        = list(string)
+  description = "Further service accounts in the Onyx namespace that may use the workload identity. Use the rendered name for chart-created workloads such as onyx-sandbox-proxy."
+  default     = []
+}
+
+variable "create_workload_namespace" {
+  type        = bool
+  description = "Create the namespace the workload service account lives in. Terraform has to make it: the Helm release that would otherwise is installed afterwards."
+  default     = true
+}
+
+variable "create_workload_service_account" {
+  type        = bool
+  description = "Create the workload service account. Turn this off when the Helm chart already creates it."
+  default     = true
+}
+
+# --- WAF ---------------------------------------------------------------------
+
+variable "enable_waf" {
+  type        = bool
+  description = "Create a WAF policy to attach to an Application Gateway or Front Door route"
+  default     = true
+}
+
+variable "waf_mode" {
+  type        = string
+  description = "Prevention blocks what the rules match; Detection only logs it"
+  default     = "Prevention"
+}
+
+variable "waf_allowed_ip_cidrs" {
+  type        = list(string)
+  description = "Ranges allowed to reach the application. Empty disables the allowlist."
+  default     = []
+}
+
+variable "waf_rate_limit_exempt_ip_cidrs" {
+  type        = list(string)
+  description = "Ranges exempt from the WAF rate limits"
+  default     = []
+}
+
+# The NAT gateway is what the cluster's own outbound traffic comes from, so
+# this is how a deployment that calls itself avoids rate-limiting itself.
+variable "waf_trust_nat_gateway_ip" {
+  type        = bool
+  description = "Add the NAT gateway's egress address to the WAF allowlist and rate-limit exemptions"
+  default     = false
+}
+
+variable "waf_geo_restriction_countries" {
+  type        = list(string)
+  description = "Two-letter country codes to block"
+  default     = []
+}
+
+variable "waf_rate_limit_requests_per_5_minutes" {
+  type        = number
+  description = "Requests per 5 minutes from one address before blocking"
+  default     = 2000
+}
+
+variable "waf_api_rate_limit_requests_per_5_minutes" {
+  type        = number
+  description = "Requests per 5 minutes from one address to the API path before blocking"
+  default     = 1000
+}
+
+# --- Alerts ------------------------------------------------------------------
+
+variable "action_group_ids" {
+  type        = list(string)
+  description = "Monitor action groups for the database and cache alerts. Empty = alerts exist but notify nothing."
+  default     = []
+}

--- a/deployment/terraform/modules/azure/onyx/versions.tf
+++ b/deployment/terraform/modules/azure/onyx/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.37"
+    }
+  }
+}


### PR DESCRIPTION
> **Stacked PR 7 of 7.** Each PR targets the branch below it, so GitHub retargets the next one to `main` as each merges. Review and merge bottom-up.
>
> 1. #14099 — `vnet`, network, subnets, NAT gateway
> 2. #14100 — `storage`, storage account + container
> 3. #14101 — `postgres`, flexible server + alerts
> 4. #14102 — `redis`, cache + private endpoint
> 5. #14103 — `aks`, cluster + workload identity
> 6. #14104 — `waf`, regional WAF policy
> 7. #14105 — `onyx`, composition + README **← this PR**

## Description

Wires the six modules together with t-shirt sizing, and documents the set. Completes the Azure equivalent of `deployment/terraform/modules/aws`.

Sizing picks the Azure size closest to what the AWS composition chooses at each tier, with one deliberate departure: **the index pool is memory-optimised at every tier**, because on Azure it carries the document index itself. There is no managed OpenSearch to move that load off the cluster.

| | small | medium | large |
|---|---|---|---|
| system pool VM | `Standard_D8ds_v5` | `Standard_D16ds_v5` | `Standard_D16ds_v5` |
| system pool nodes | 1-3 | 1-5 | 2-8 |
| index pool VM | `Standard_E4ds_v5` | `Standard_E8ds_v5` | `Standard_E16ds_v5` |
| index pool disk | 256 GiB | 512 GiB | 1024 GiB |
| database SKU | `GP_Standard_D2ds_v5` | `GP_Standard_D2ds_v5` | `GP_Standard_D4ds_v5` |
| database storage | 64 GiB | 128 GiB | 256 GiB |
| cache | Standard C3 (6 GB) | Standard C4 (13 GB) | Standard C5 (26 GB) |

Two things the composition does that no single module can:

- **Flow logs get a storage account of their own.** That keeps the dependency one-way — log account, then network, then the file store account that restricts itself to the network's subnets — where pointing the network at the file store account would have made a cycle.
- **Egress picks itself.** With a created network and a NAT gateway the cluster routes through it and keeps one address; bringing a network without one falls back to letting AKS manage outbound.

Unlike the AWS composition **this module declares no provider block**. The `azurerm` provider needs a `features` block and a subscription, and both belong to the root module rather than to a module that might be counted.

### One deliberate parity gap, for a decision

**Flow logs are off by default, where the AWS modules have them on.** Azure writes them to a storage account and needs a Network Watcher in the region, so a default of on would fail an apply on any subscription without one — and Azure only auto-creates the Watcher if the subscription has not opted out. I chose a working default over matching AWS, and the README documents the one variable that turns them on. Happy to flip it if you would rather fail loudly than ship less logging than AWS.

## How Has This Been Tested?

```
cd deployment/terraform/modules/azure/onyx
terraform init -backend=false && terraform test
# Success! 14 passed, 0 failed.
```

All seven modules together: **85 passed, 0 failed.**

The composition suite covers every sizing tier, per-variable overrides beating tier defaults without disturbing their neighbours, the derived storage account name staying inside Azure's 24-character lowercase-alphanumeric rule (including from a long prefix), the resource group create/join paths, and the flow-log account.

**This suite caught a real defect in the `aks` module** that its own tests could not: `azurerm_role_assignment` used `for_each` over storage account IDs that are unknown at plan time when they come from a storage module in the same apply, which fails `terraform plan` outright on any greenfield deployment. Fixed in PR 5 of this stack.

I also cross-checked the README against the code rather than trusting it: every `module.onyx.*` output it references exists, and all four `AZURE_*` environment variables it names are read by `backend/onyx/configs/app_configs.py` and exposed in `deployment/helm/charts/onyx/values.yaml`.

**Not applied against a live subscription.** The README says so up front. Mocked plans prove the wiring and the input validation; only an apply proves the modules work.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

## Changes from review (greptile, cubic)

- **The Helm section was wrong in a way that would have failed at runtime.** Following it gave workloads the `default` service account, so `DefaultAzureCredential` got no token and every file-store call failed to authenticate. Rewritten into three concrete steps: point `serviceAccount.name` at the federated account; add the `azure.workload.identity/use` pod label to the API server and every Celery worker (it is per-pod, and the webhook will not project a token without it); and give the OpenSearch subchart the `nodeSelector` and `tolerations` for the tainted index pool. I checked the chart — it sets none of these, so the index pool would otherwise have sat empty while OpenSearch scheduled onto the system pool.
- **A database password is now required** unless `entra_database_authentication_only` is set, which the composition now supports end to end.
- **A public API server with no authorized ranges is now refused**, matching the aks module.
- **`aks_outbound_type`** lets a supplied subnet that already has a NAT gateway keep its stable egress address, instead of being forced onto `loadBalancer`.
- **Flow logs are rejected with a supplied network**, where they previously created a log storage account nothing would ever write to.
- **README fix:** the existing-network example referenced `var.postgres_password` while the quickstart defines a local.

Tests: 14 → 21. Across all seven modules: **120 passed, 0 failed** (was 85).

## Round 2

- **The Helm instructions now require the `onyx` namespace.** A service account belongs to one namespace, and the federated one is created in `onyx`. A release installed anywhere else references an account that does not exist there, and the API and Celery pods never start.
- **The flow-log storage account name no longer loses its digest.** It carries an extra `log`, so at a full-length prefix the 24-character truncation kept only three of the six digest characters — two deployments could collide in Azure's global namespace. Its prefix is now 15 characters, so `15 + 3 + 6 = 24` and the digest survives whole. The file store name was already fine at `18 + 6`.
- **`nat_gateway_public_ips` says what it actually reflects** — a NAT gateway this module created, not egress in general.
- **`postgres_password` description names the right variable.** `enable_entra_database_authentication` only adds Entra logins alongside passwords; `entra_database_authentication_only` is the one that removes the need for a password.
- **Dropped a tautological assertion** that restated the run's own input and could never fail.

Tests: 21 → 22. Across all seven modules: **137 passed, 0 failed** (was 120).

## Round 3

- **The workload namespace ordering bug is fixed in PR #14103**, where the service account is created. On a first deployment Terraform made the account in the `onyx` namespace before anything had made that namespace, and the apply failed. The Helm install could not have satisfied it either, since it runs afterwards.
- **The documented Helm command no longer passes `--create-namespace`.** Terraform owns the namespace now, so the release joins it. `create_workload_namespace` is exposed here to opt out.

Tests: 22. Across all seven modules: **140 passed, 0 failed**.
