### PR TITLE
docs(skills): require `ods audit` before merging Dependabot PRs

### DIFF
--- a/.cursor/skills/merge-dependabot-prs/SKILL.md
+++ b/.cursor/skills/merge-dependabot-prs/SKILL.md
@@ -107,13 +107,14 @@ exits non-zero on an unignored finding at or above `--fail-on`
 tree**, so the PR branch must be checked out — a run on `main` says nothing
 about the bump.
 
-If it exits non-zero:
+**If it exits non-zero, stop.** Don't enqueue, and don't try to work out whether
+the finding came from this bump or was already on `main` — that comparison costs
+a second audit run and can classify a new finding as pre-existing. Report the
+advisory ids and let the user say how to proceed. This holds whichever way the
+audit is invoked, so a quieter output mode doesn't change the procedure.
 
-- **The bump introduced the finding** — don't enqueue. Report it with the
-  advisory id and ask the user how to proceed.
-- **The finding is pre-existing** (also present on `main`) — say so, and ask
-  whether to enqueue anyway or suppress first. Never suppress on your own:
-  `ods audit ignore add` writes a shared S3 allowlist that gates every deploy.
+Never suppress on your own: `ods audit ignore add` writes a shared S3 allowlist
+that gates every deploy.
 
 Then, once clean:
 

--- a/.cursor/skills/merge-dependabot-prs/SKILL.md
+++ b/.cursor/skills/merge-dependabot-prs/SKILL.md
@@ -108,7 +108,7 @@ tree**, so the PR branch must be checked out — a run on `main` says nothing
 about the bump.
 
 **If it exits non-zero, STOP.** Don't enqueue and don't try to work out whether
-the finding came from this bump or was already on `main` Report the advisory ids
+the finding came from this bump or was already on `main`. Report the advisory ids
 and let the user say how to proceed.
 
 Then, once clean:

--- a/.cursor/skills/merge-dependabot-prs/SKILL.md
+++ b/.cursor/skills/merge-dependabot-prs/SKILL.md
@@ -107,14 +107,9 @@ exits non-zero on an unignored finding at or above `--fail-on`
 tree**, so the PR branch must be checked out — a run on `main` says nothing
 about the bump.
 
-**If it exits non-zero, stop.** Don't enqueue, and don't try to work out whether
-the finding came from this bump or was already on `main` — that comparison costs
-a second audit run and can classify a new finding as pre-existing. Report the
-advisory ids and let the user say how to proceed. This holds whichever way the
-audit is invoked, so a quieter output mode doesn't change the procedure.
-
-Never suppress on your own: `ods audit ignore add` writes a shared S3 allowlist
-that gates every deploy.
+**If it exits non-zero, STOP.** Don't enqueue and don't try to work out whether
+the finding came from this bump or was already on `main` Report the advisory ids
+and let the user say how to proceed.
 
 Then, once clean:
 

--- a/.cursor/skills/merge-dependabot-prs/SKILL.md
+++ b/.cursor/skills/merge-dependabot-prs/SKILL.md
@@ -9,11 +9,11 @@ description: >
   Use when the user asks to merge, clean up, clear out, or land Dependabot (or
   similar bot-authored) PRs.
 license: MIT
-compatibility: Requires git, pre-commit, uv, bun, and gh (GitHub CLI) authenticated with write access to onyx-dot-app/onyx.
+compatibility: Requires git, pre-commit, uv, bun, ods (the repo venv's devtools script), and gh (GitHub CLI) authenticated with write access to onyx-dot-app/onyx.
 metadata:
   author: jmelahman
-  version: "1.0"
-allowed-tools: Bash(gh:*), Bash(git:*), Bash(pre-commit:*), Bash(bun install:*)
+  version: "1.1"
+allowed-tools: Bash(gh:*), Bash(git:*), Bash(pre-commit:*), Bash(bun install:*), Bash(ods audit:*)
 ---
 
 # Merge Dependabot PRs
@@ -58,9 +58,18 @@ same package, or a manual bump PR overlapping a bot one.
 ## 2. Triage into buckets, confirm the plan
 
 These PRs aren't in a rush. Wait for every check to complete — required and
-advisory alike (e.g. `storybook-build` on `web/**` changes, which never gates
-the queue but pages Slack if broken post-merge) — and treat any red check as
-a failure to classify, never as noise to skip.
+advisory alike — and treat any red check as a failure to classify, never as
+noise to skip. Two advisory checks matter here even though the queue ignores
+them:
+
+- `storybook-build` (`pr-storybook-build.yml`) on `web/**` changes — never
+  gates the queue, but pages Slack if broken post-merge.
+- `audit` (`audit.yml`) — runs on every lockfile, `pyproject.toml`,
+  `.github/workflows/**`, and `tools/ods/**` change, so it runs on almost every
+  Dependabot PR. Treat it as **required for this skill**: a Dependabot PR does
+  not get enqueued while `audit` is red. A red `audit` means the bump either
+  pulled in a vulnerable version or landed next to one, and merging it ships
+  the finding.
 
 - **Green & ready** — every check completed and passing, advisory included.
 - **Failing — mechanical** — only a generated/lock file wasn't regenerated
@@ -80,7 +89,33 @@ in per PR.
 
 Summarize buckets and proposed actions, confirm with `AskUserQuestion`, then act.
 
-## 3. Green: approve and enqueue
+## 3. Green: audit, approve, enqueue
+
+Run `ods audit` on the PR's code before you enqueue it. CI's `audit` job covers
+this, but it is skipped when the PR touches no audited path, and it is advisory
+in the queue — so confirm it yourself for every Dependabot PR.
+
+```bash
+gh pr checkout <pr>
+source .venv/bin/activate   # ods ships in the repo venv
+ods audit --fail-on=critical
+```
+
+`ods audit` scans `bun.lock` and `uv.lock` plus open Dependabot alerts, and
+exits non-zero on an unignored finding at or above `--fail-on`
+([tools/ods/README.md](../../../tools/ods/README.md)). It reads the **working
+tree**, so the PR branch must be checked out — a run on `main` says nothing
+about the bump.
+
+If it exits non-zero:
+
+- **The bump introduced the finding** — don't enqueue. Report it with the
+  advisory id and ask the user how to proceed.
+- **The finding is pre-existing** (also present on `main`) — say so, and ask
+  whether to enqueue anyway or suppress first. Never suppress on your own:
+  `ods audit ignore add` writes a shared S3 allowlist that gates every deploy.
+
+Then, once clean:
 
 ```bash
 gh pr review <pr> --approve


### PR DESCRIPTION
## Summary

The `merge-dependabot-prs` skill enqueued PRs on CI status alone. The `audit` job (`.github/workflows/audit.yml`) is not a required check, so a red audit never blocked a merge — and the job is skipped entirely when a PR touches no audited path.

This adds `ods audit` as an explicit gate in the skill.

## Changes

- **Step 2 (triage)** — `audit` is now listed next to `storybook-build` as an advisory check the skill treats as **required**. A Dependabot PR is not enqueued while `audit` is red.
- **Step 3** — retitled "Green: audit, approve, enqueue". Adds a local `ods audit --fail-on=critical` run before `gh pr review`/`gh pr merge`, with `gh pr checkout` first, since `ods audit` reads the working tree. Splits a non-zero exit into bump-introduced (don't enqueue) vs. pre-existing (ask). Self-service suppression is forbidden — `ods audit ignore add` writes the shared S3 allowlist that gates every deploy.
- **Frontmatter** — `ods` added to `compatibility`, `Bash(ods audit:*)` to `allowed-tools`, version `1.0` → `1.1`.

No workflow or code changes; `audit` stays non-blocking on presubmit for everyone else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require `ods audit` before approving/enqueuing Dependabot PRs in the `merge-dependabot-prs` skill so vulnerable bumps don’t merge. Previously the skill relied on CI’s advisory `audit` job, so red or skipped audits didn’t block.

- Treat `audit` as required for this skill (listed with `storybook-build` in triage); do not enqueue while `audit` is red.
- Before `gh pr review`/`gh pr merge`, check out the PR branch and run `ods audit --fail-on=critical`; `ods` runs from the repo venv.
- On any audit failure: stop and do not enqueue; do not compare against `main`, and never add ignores from the skill.
- Frontmatter: add `ods` to compatibility, allow `Bash(ods audit:*)`, bump version to `1.1`.
- No workflow/CI changes; `audit` remains non-blocking outside this skill.

<sup>Written for commit da6a13f6fc01d1dcd3ab68c0e031fac346d4b982. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

