### PR TITLE
feat(ods): add `ods audit --quiet` for exit-code-only runs

### DIFF
--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -423,12 +423,12 @@ vulnerabilities. With no selector flags, all sources are audited.
 
 Accepted advisories are suppressed via an allowlist fetched from S3 at runtime
 (`s3://onyx-internal-tools/audit/ignores.json` by default), so a release can be
-unblocked without a code change. The command exits non-zero when an unignored
-finding at or above `--fail-on` (default `critical`) remains, which is how it
-gates deploys.
+unblocked without a code change. The command exits `1` when an unignored finding
+at or above `--fail-on` (default `critical`) remains, which is how it gates
+deploys, and `2` when the audit could not complete.
 
 ```shell
-ods audit [--web] [--python] [--dependabot] [--format text[,json][,sarif]] [--fail-on critical|high|moderate|low] [--ignore-url s3://...]
+ods audit [--web] [--python] [--dependabot] [--format text[,json][,sarif]] [--fail-on critical|high|moderate|low] [--ignore-url s3://...] [--quiet]
 ```
 
 `--format` takes a comma-separated list. The machine-readable formats (`json`,
@@ -440,6 +440,12 @@ when the gate fails, a runbook explaining how to resolve or suppress each
 finding) to the terminal. A lone format always goes to stdout, so
 `--format=sarif > audit.sarif` is unchanged. At most one machine-readable format
 may be requested.
+
+`--quiet` (`-q`) writes nothing at all — no report, no warnings — and reports the
+verdict through the exit code only. Use it when a script wants the verdict and
+not the text, e.g. a pre-push hook or a shell condition. It overrides `--format`.
+The two failure codes stay distinct under `--quiet`, so a caller can tell a
+failed gate (`1`) from a failed run (`2`).
 
 **Examples:**
 
@@ -455,6 +461,9 @@ ods audit --python --format=sarif > audit.sarif
 
 # SARIF to a file for upload, readable report to the log (used by CI gates)
 ods audit --format=sarif,text > audit.sarif
+
+# Exit code only, no output (scripts and hooks)
+if ! ods audit --quiet; then echo "audit gate failed"; fi
 ```
 
 #### Managing the allowlist

--- a/tools/ods/cmd/audit.go
+++ b/tools/ods/cmd/audit.go
@@ -1,12 +1,20 @@
 package cmd
 
 import (
+	"io"
 	"os"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/audit"
+)
+
+// Exit codes for the audit commands. Callers that only want the verdict (see
+// --quiet) use these to tell a failed gate apart from a failed run.
+const (
+	exitAuditFindings = 1 // unignored findings at or above --fail-on
+	exitAuditError    = 2 // the audit could not complete
 )
 
 // AuditOptions holds options for the audit command.
@@ -18,6 +26,7 @@ type AuditOptions struct {
 	Format     string
 	FailOn     string
 	IgnoreURL  string
+	Quiet      bool
 }
 
 // NewAuditCommand creates the `ods audit` command.
@@ -35,8 +44,8 @@ open GitHub Dependabot security alerts, and the GitHub Actions pinned in
 all sources are audited. Accepted advisories are suppressed via an allowlist
 fetched from S3 at runtime, so releases can be unblocked without a code change.
 
-Exits non-zero when an unignored finding at or above --fail-on remains, which is
-how it gates deploys.`,
+Exits 1 when an unignored finding at or above --fail-on remains, which is how it
+gates deploys, and 2 when the audit could not complete.`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			runAudit(opts)
@@ -50,6 +59,7 @@ how it gates deploys.`,
 	cmd.Flags().StringVar(&opts.Format, "format", "text", "Output format(s), comma-separated: text, json, sarif (e.g. sarif,text)")
 	cmd.Flags().StringVar(&opts.FailOn, "fail-on", "critical", "Minimum severity that fails the audit: critical, high, moderate, or low")
 	cmd.Flags().StringVar(&opts.IgnoreURL, "ignore-url", audit.DefaultIgnoreURL, "S3 URL of the advisory allowlist")
+	cmd.Flags().BoolVarP(&opts.Quiet, "quiet", "q", false, "Write nothing; report the verdict through the exit code only")
 
 	cmd.AddCommand(newAuditImageCommand())
 	cmd.AddCommand(newAuditIgnoreCommand())
@@ -57,10 +67,26 @@ how it gates deploys.`,
 	return cmd
 }
 
+// auditWriters returns the report streams for an audit run. When quiet is set
+// it also silences every logger the audit path writes through — logrus and
+// osv-scanner's slog handler — so the run produces no output at all and only
+// the exit code carries the verdict.
+func auditWriters(quiet bool) (stdout, stderr io.Writer) {
+	if !quiet {
+		return os.Stdout, os.Stderr
+	}
+	log.SetOutput(io.Discard)
+	audit.SilenceLogger()
+	return io.Discard, io.Discard
+}
+
 func runAudit(opts *AuditOptions) {
+	stdout, stderr := auditWriters(opts.Quiet)
+
 	failOn := audit.ParseSeverity(opts.FailOn)
 	if failOn == audit.SeverityUnknown {
-		log.Fatalf("Invalid --fail-on %q (want critical, high, moderate, or low)", opts.FailOn)
+		log.Errorf("Invalid --fail-on %q (want critical, high, moderate, or low)", opts.FailOn)
+		os.Exit(exitAuditError)
 	}
 
 	result, err := audit.Run(audit.Options{
@@ -71,15 +97,16 @@ func runAudit(opts *AuditOptions) {
 		Format:     opts.Format,
 		FailOn:     failOn,
 		IgnoreURL:  opts.IgnoreURL,
-		Stdout:     os.Stdout,
-		Stderr:     os.Stderr,
+		Stdout:     stdout,
+		Stderr:     stderr,
 	})
 	if err != nil {
-		log.Fatalf("Audit failed: %v", err)
+		log.Errorf("Audit failed: %v", err)
+		os.Exit(exitAuditError)
 	}
 
 	if len(result.Blocking) > 0 {
 		log.Errorf("%d finding(s) at or above %s severity must be resolved or suppressed", len(result.Blocking), failOn)
-		os.Exit(1)
+		os.Exit(exitAuditFindings)
 	}
 }

--- a/tools/ods/cmd/audit_image.go
+++ b/tools/ods/cmd/audit_image.go
@@ -14,6 +14,7 @@ type AuditImageOptions struct {
 	Format    string
 	FailOn    string
 	IgnoreURL string
+	Quiet     bool
 }
 
 // newAuditImageCommand creates the `ods audit image` subcommand.
@@ -39,8 +40,8 @@ feed a SARIF upload and still print a readable report to the log:
 
   ods audit image "$IMAGE" --format=sarif,text > image-audit.sarif
 
-Exits non-zero when an unignored finding at or above --fail-on remains, which is
-how it gates deploys.`,
+Exits 1 when an unignored finding at or above --fail-on remains, which is how it
+gates deploys, and 2 when the audit could not complete.`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			runAuditImage(args[0], opts)
@@ -50,14 +51,18 @@ how it gates deploys.`,
 	cmd.Flags().StringVar(&opts.Format, "format", "text", "Output format(s), comma-separated: text, json, sarif (e.g. sarif,text)")
 	cmd.Flags().StringVar(&opts.FailOn, "fail-on", "critical", "Minimum severity that fails the audit: critical, high, moderate, or low")
 	cmd.Flags().StringVar(&opts.IgnoreURL, "ignore-url", audit.DefaultIgnoreURL, "S3 URL of the advisory allowlist")
+	cmd.Flags().BoolVarP(&opts.Quiet, "quiet", "q", false, "Write nothing; report the verdict through the exit code only")
 
 	return cmd
 }
 
 func runAuditImage(ref string, opts *AuditImageOptions) {
+	stdout, stderr := auditWriters(opts.Quiet)
+
 	failOn := audit.ParseSeverity(opts.FailOn)
 	if failOn == audit.SeverityUnknown {
-		log.Fatalf("Invalid --fail-on %q (want critical, high, moderate, or low)", opts.FailOn)
+		log.Errorf("Invalid --fail-on %q (want critical, high, moderate, or low)", opts.FailOn)
+		os.Exit(exitAuditError)
 	}
 
 	result, err := audit.RunImage(audit.ImageOptions{
@@ -65,15 +70,16 @@ func runAuditImage(ref string, opts *AuditImageOptions) {
 		Format:    opts.Format,
 		FailOn:    failOn,
 		IgnoreURL: opts.IgnoreURL,
-		Stdout:    os.Stdout,
-		Stderr:    os.Stderr,
+		Stdout:    stdout,
+		Stderr:    stderr,
 	})
 	if err != nil {
-		log.Fatalf("Image audit failed: %v", err)
+		log.Errorf("Image audit failed: %v", err)
+		os.Exit(exitAuditError)
 	}
 
 	if len(result.Blocking) > 0 {
 		log.Errorf("%d finding(s) at or above %s severity must be resolved or suppressed", len(result.Blocking), failOn)
-		os.Exit(1)
+		os.Exit(exitAuditFindings)
 	}
 }

--- a/tools/ods/cmd/audit_test.go
+++ b/tools/ods/cmd/audit_test.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TestAuditWritersDefault(t *testing.T) {
+	stdout, stderr := auditWriters(false)
+	if stdout != io.Writer(os.Stdout) || stderr != io.Writer(os.Stderr) {
+		t.Fatalf("auditWriters(false) = %v, %v; want os.Stdout, os.Stderr", stdout, stderr)
+	}
+}
+
+// Quiet must silence the report streams and logrus, so a run writes nothing and
+// only the exit code reports the verdict.
+func TestAuditWritersQuiet(t *testing.T) {
+	prev := log.StandardLogger().Out
+	t.Cleanup(func() { log.SetOutput(prev) })
+
+	var logged bytes.Buffer
+	log.SetOutput(&logged)
+
+	stdout, stderr := auditWriters(true)
+	if stdout != io.Discard || stderr != io.Discard {
+		t.Fatalf("auditWriters(true) = %v, %v; want io.Discard twice", stdout, stderr)
+	}
+
+	log.Warnf("allowlist fetch failed")
+	log.Errorf("1 finding(s) must be resolved")
+	if logged.Len() != 0 {
+		t.Fatalf("quiet run logged %q; want nothing", logged.String())
+	}
+}
+
+func TestAuditQuietFlagRegistered(t *testing.T) {
+	audit := NewAuditCommand()
+	if f := audit.Flags().Lookup("quiet"); f == nil || f.Shorthand != "q" {
+		t.Fatalf("ods audit is missing a --quiet/-q flag")
+	}
+
+	image, _, err := audit.Find([]string{"image"})
+	if err != nil {
+		t.Fatalf("finding `ods audit image`: %v", err)
+	}
+	if f := image.Flags().Lookup("quiet"); f == nil || f.Shorthand != "q" {
+		t.Fatalf("ods audit image is missing a --quiet/-q flag")
+	}
+}

--- a/tools/ods/internal/audit/osv.go
+++ b/tools/ods/internal/audit/osv.go
@@ -2,6 +2,7 @@ package audit
 
 import (
 	"errors"
+	"io"
 	"log/slog"
 	"os"
 	"strconv"
@@ -19,6 +20,12 @@ func init() {
 	// to stdout via our own reporters. Warn+ keeps routine Info scan chatter out
 	// and never collides with a --format=json/sarif report on stdout.
 	osvscanner.SetLogger(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+}
+
+// SilenceLogger drops everything osv-scanner logs. Used by the --quiet gate,
+// where only the exit code is meaningful.
+func SilenceLogger() {
+	osvscanner.SetLogger(slog.NewTextHandler(io.Discard, nil))
 }
 
 // osvBaseURL is the canonical OSV.dev vulnerability page prefix.


### PR DESCRIPTION
## What

`ods audit --quiet` (`-q`) writes nothing — no report, no warnings — and reports the verdict through the exit code only. The same flag is on `ods audit image`.

Quiet silences all three output paths the audit uses: the rendered report (`Stdout`/`Stderr` become `io.Discard`), our logrus warnings, and osv-scanner's slog handler (new `audit.SilenceLogger`).

## Exit codes

To keep `--quiet` useful, the two failure modes are now distinct:

- `1` — unignored findings at or above `--fail-on` (unchanged)
- `2` — the audit could not complete (was `1` via `log.Fatalf`)

CI only checks for non-zero, so the gate behavior in `.github/workflows/audit.yml` does not change.

## Test

`cmd/audit_test.go` covers the writer selection, the logrus silencing, and the flag registration on both commands. The one failing test in `tools/ods/cmd` (`TestReleaseCloud_pushFailureRollsBackLocalTag`) fails on the base commit too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--quiet` (`-q`) to `ods audit` and `ods audit image` to run exit-code-only audits that emit no output. Separates failure modes: findings still exit 1; audit errors now exit 2 (was 1), so callers can distinguish a failed gate from a failed run.

- `--quiet` silences stdout/stderr, `logrus` warnings, and the `osv-scanner` logger via `audit.SilenceLogger`. It overrides `--format`.
- Exit codes: 1 = unignored findings at/above `--fail-on`; 2 = audit could not complete. Update any scripts that relied on 1 for run errors; CI gates that only check non-zero are unchanged.
- Tests cover writer selection, logger silencing, and flag registration on both commands.

<sup>Written for commit ca6c38af6f2f41cb88c93381d5b04b9a29b6d33b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

