### PR TITLE
feat(scim): drive the login email from the emails attribute

### DIFF
--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -32,6 +32,7 @@ from ee.onyx.server.scim.auth import ScimAuthError, verify_scim_token
 from ee.onyx.server.scim.filtering import parse_scim_filter
 from ee.onyx.server.scim.models import (
     SCIM_LIST_RESPONSE_SCHEMA,
+    ScimEmail,
     ScimError,
     ScimGroupMember,
     ScimGroupResource,
@@ -249,9 +250,8 @@ _ENTRA_TOMBSTONE_PREFIX = re.compile(r"[0-9a-f]{32}", re.IGNORECASE)
 def _is_entra_tombstone_rename(current_email: str, new_email: str) -> bool:
     """Whether *new_email* is Entra's soft-delete rename of *current_email*.
 
-    Entra syncs the objectId-prefixed UPN as userName when a user is
-    soft-deleted. Writing it over the email would orphan the account, so
-    callers keep the email and only record the userName on the mapping.
+    Entra syncs objectId-prefixed values for soft-deleted users. Writing one
+    over the email would orphan the account, so callers keep the email.
     """
     match = _ENTRA_TOMBSTONE_PREFIX.match(new_email)
     return (
@@ -260,9 +260,9 @@ def _is_entra_tombstone_rename(current_email: str, new_email: str) -> bool:
 
 
 def _is_privileged_account(user: User) -> bool:
-    """Whether *user* must stay outside a rename's reach, as source or target.
+    """Whether *user* must stay outside an email move's reach, as source or target.
 
-    SSO login associates by email, so the first login for a renamed account's
+    SSO login associates by email, so the first login for a moved account's
     new address claims it. Provisioning only ever grants basic access, so a
     token must not move an admin or group-manager account — nor adopt one,
     which would put it under IdP control.
@@ -270,8 +270,8 @@ def _is_privileged_account(user: User) -> bool:
     return user_is_admin(user) or user.is_group_manager
 
 
-class _UsernameChange(NamedTuple):
-    """Outcome of a userName change: the account to update, the email to set
+class _EmailChange(NamedTuple):
+    """Outcome of an email change: the account to update, the email to set
     (None = keep the current one), and whether adoption freed a seat."""
 
     user: User
@@ -279,57 +279,91 @@ class _UsernameChange(NamedTuple):
     seat_freed: bool = False
 
 
-def _apply_username_change(
+def _primary_email(emails: list[ScimEmail]) -> str | None:
+    """The primary (or first) email value, None when absent or blank."""
+    if not emails:
+        return None
+    primary = next((e for e in emails if e.primary), emails[0])
+    return primary.value.strip() or None
+
+
+def _primary_email_or_error(
+    emails: list[ScimEmail],
+) -> str | None | ScimJSONResponse:
+    """Like ``_primary_email``, but a carried-yet-blank value is a 400.
+
+    Persisting a blank list while keeping the login email would make GET
+    report an address that no longer matches the account.
+    """
+    value = _primary_email(emails)
+    if value is None and emails:
+        return _scim_error_response(400, "emails must carry a non-empty value")
+    return value
+
+
+def _validate_username_change(
     dal: ScimDAL, user: User, requested_username: str
-) -> _UsernameChange | ScimJSONResponse:
-    """Apply a userName change, resolving it to the account it describes.
+) -> ScimJSONResponse | None:
+    """Reject a blank userName (400) or one another mapping holds (409).
 
-    Beyond a plain rename, four cases are handled:
-
-    - An Entra soft-delete tombstone userName never overwrites the email.
-    - A rename onto another SCIM-managed account's address is a conflict (409).
-    - A rename onto an address an unmanaged STANDARD account already owns
-      adopts that account (mirror of the POST adoption path): the mapping
-      moves to it and the stale source account is deactivated. Without this,
-      an IdP restoring a user whose address was re-claimed via SSO login
-      retries the collision error forever. Only STANDARD targets qualify:
-      EXT_PERM shadows fall through so ``reconcile_user_email__no_commit``
-      merges them into the renamed user, and BOT / service / anonymous
-      accounts must never come under IdP control.
-    - A rename of an admin or group manager, or onto one (adoption would
-      hand the token control of the target), is rejected (403).
+    userName is a matching attribute, never the login email, so a valid
+    change only needs to be recordable on the mapping (the unique index
+    would reject a duplicate at the write).
     """
     if not requested_username:
         return _scim_error_response(400, "userName must not be empty")
-
-    if requested_username.lower() == user.email.lower():
-        return _UsernameChange(user, requested_username)
-
-    if _is_entra_tombstone_rename(user.email, requested_username):
-        logger.info(
-            "SCIM userName for %s is an Entra soft-delete tombstone; keeping email",
-            user.email,
-        )
-        return _UsernameChange(user, None)
-
-    # A userName another mapping holds is a conflict even when that mapping's
-    # email has diverged from it (the unique index would reject the write).
     holder = dal.get_user_mapping_by_scim_username(requested_username)
     if holder and holder.user_id != user.id:
         return _scim_error_response(
             409, f"User with userName {requested_username} already exists"
         )
+    return None
 
-    other = dal.get_user_by_email(requested_username)
+
+def _apply_email_change(
+    dal: ScimDAL, user: User, requested_email: str
+) -> _EmailChange | ScimJSONResponse:
+    """Apply an email change, resolving it to the account it describes.
+
+    The email comes from the SCIM ``emails`` attribute, never from userName,
+    and callers only invoke this on a changed address. Beyond a plain change:
+
+    - An Entra soft-delete tombstone value never overwrites the email.
+    - A change onto another SCIM-managed account's address is a conflict (409).
+    - A change onto an address an unmanaged STANDARD account already owns
+      adopts that account (mirror of the POST adoption path): the mapping
+      moves to it and the stale source account is deactivated. Without this,
+      an IdP restoring a user whose address was re-claimed via SSO login
+      retries the collision error forever. Only STANDARD targets qualify:
+      EXT_PERM shadows fall through so ``reconcile_user_email__no_commit``
+      merges them into the changed user, and BOT / service / anonymous
+      accounts must never come under IdP control.
+    - A move of an admin or group manager account is rejected (403).
+    """
+    if _is_entra_tombstone_rename(user.email, requested_email):
+        logger.info(
+            "SCIM email for %s is an Entra soft-delete tombstone; keeping email",
+            user.email,
+        )
+        return _EmailChange(user, None)
+
+    other = dal.get_user_by_email(requested_email)
     if other and other.id != user.id:
         if dal.get_user_mapping_by_user_id(other.id):
             return _scim_error_response(
-                409, f"User with email {requested_username} already exists"
+                409, f"User with email {requested_email} already exists"
             )
         if other.account_type == AccountType.STANDARD:
             if _is_privileged_account(other):
                 return _scim_error_response(
                     403, "Cannot adopt an admin or group manager account"
+                )
+            # Adoption deactivates the source. An inactive privileged source
+            # (deprovisioned, then restored elsewhere) may be adopted away,
+            # but an active one must not be disabled through this side door.
+            if user.is_active and _is_privileged_account(user):
+                return _scim_error_response(
+                    403, "Cannot move an admin or group manager address"
                 )
             mapping = dal.get_user_mapping_by_user_id(user.id)
             if mapping:
@@ -337,18 +371,19 @@ def _apply_username_change(
             seat_freed = user_counts_toward_seats(user)
             dal.deactivate_user(user)
             logger.info(
-                "SCIM rename to %s adopted the existing account; deactivated stale %s",
-                requested_username,
+                "SCIM email change to %s adopted the existing account; "
+                "deactivated stale %s",
+                requested_email,
                 user.email,
             )
-            return _UsernameChange(other, None, seat_freed)
+            return _EmailChange(other, None, seat_freed)
 
     if _is_privileged_account(user):
         return _scim_error_response(
             403, "Cannot move an admin or group manager address"
         )
 
-    return _UsernameChange(user, requested_username)
+    return _EmailChange(user, requested_email)
 
 
 # Unique constraints a concurrent provisioning race can trip: the email, the
@@ -414,21 +449,20 @@ def _sync_and_commit_or_conflict(
     return None
 
 
-def _patch_sets_username(operations: list[ScimPatchOperation]) -> bool:
-    """Whether a PATCH carries a userName value, by path or path-less resource.
+def _patch_sets_attr(operations: list[ScimPatchOperation], attr: str) -> bool:
+    """Whether a PATCH carries *attr*, by path or path-less resource value.
 
-    Mirrors ``_apply_user_replace``: path-less values may carry userName under
-    any key casing (``extra="allow"``), so inspect the dumped keys, not the
-    canonical field.
+    Mirrors ``_apply_user_replace``: path-less values may carry attributes
+    under any key casing (``extra="allow"``), so inspect the dumped keys, not
+    the canonical field. Filtered paths like ``emails[...]`` count as set.
     """
     for op in operations:
         path = (op.path or "").lower()
-        if path == "username":
+        if path == attr or path.startswith(f"{attr}["):
             return True
         if not path and isinstance(op.value, ScimPatchResourceValue):
             if any(
-                key.lower() == "username"
-                for key in op.value.model_dump(exclude_unset=True)
+                key.lower() == attr for key in op.value.model_dump(exclude_unset=True)
             ):
                 return True
     return False
@@ -686,11 +720,16 @@ def create_user(
     dal = ScimDAL(db_session)
     dal.update_token_last_used(_token.id)
 
-    email = user_resource.userName.strip()
-    if not email:
+    scim_username = user_resource.userName.strip()
+    if not scim_username:
         return _scim_error_response(400, "userName must not be empty")
+    # The login email comes from the emails attribute. userName is only the
+    # matching attribute and merely seeds the email when emails is absent.
+    seed_email = _primary_email_or_error(user_resource.emails)
+    if isinstance(seed_email, ScimJSONResponse):
+        return seed_email
+    email = seed_email or scim_username
     external_id: str | None = user_resource.externalId
-    scim_username: str = email
     fields: ScimMappingFields = _fields_from_resource(user_resource)
 
     # A mapping already provisioned under this userName is a conflict even when
@@ -835,10 +874,23 @@ def replace_user(
     user = result
 
     scim_username = user_resource.userName.strip()
-    resolved = _apply_username_change(dal, user, scim_username)
-    if isinstance(resolved, ScimJSONResponse):
-        return resolved
-    user, new_email, seat_freed = resolved
+    error = _validate_username_change(dal, user, scim_username)
+    if error:
+        return error
+
+    # A full replace without emails keeps the address. Passing the current
+    # email through still re-runs reconciliation (EXT_PERM shadow merging).
+    put_email = _primary_email_or_error(user_resource.emails)
+    if isinstance(put_email, ScimJSONResponse):
+        return put_email
+    requested_email = put_email or user.email
+    new_email: str | None = requested_email
+    seat_freed = False
+    if requested_email.lower() != user.email.lower():
+        resolved = _apply_email_change(dal, user, requested_email)
+        if isinstance(resolved, ScimJSONResponse):
+            return resolved
+        user, new_email, seat_freed = resolved
 
     # Handle activation (need seat check) / deactivation. Promoting a shadow
     # EXT_PERM_USER also consumes a seat, so self-heal any that the IdP
@@ -935,17 +987,34 @@ def patch_user(
         return _scim_error_response(e.status, e.detail)
 
     requested_username = patched.userName.strip()
-    # Resolve a rename only when the PATCH itself carried userName. A patch
-    # that touches other fields must not act on a stored scim_username that
-    # has drifted from the email.
-    sets_username = _patch_sets_username(patch_request.Operations)
+    # Act only on attributes the PATCH itself carried. A patch touching other
+    # fields must not act on stored values that have drifted.
+    sets_username = _patch_sets_attr(patch_request.Operations, "username")
+    if sets_username:
+        error = _validate_username_change(dal, user, requested_username)
+        if error:
+            return error
+
+    sets_emails = _patch_sets_attr(patch_request.Operations, "emails")
     new_email: str | None = None
     seat_freed = False
-    if sets_username:
-        resolved = _apply_username_change(dal, user, requested_username)
-        if isinstance(resolved, ScimJSONResponse):
-            return resolved
-        user, new_email, seat_freed = resolved
+    if sets_emails:
+        patched_email = _primary_email_or_error(patched.emails)
+        if isinstance(patched_email, ScimJSONResponse):
+            return patched_email
+        # Act only when the ops changed the primary value. A filtered update
+        # of a secondary entry must not move the login email to a drifted
+        # stored primary.
+        prior_primary = _primary_email(current.emails) or user.email
+        if (
+            patched_email
+            and patched_email.lower() != prior_primary.lower()
+            and patched_email.lower() != user.email.lower()
+        ):
+            resolved = _apply_email_change(dal, user, patched_email)
+            if isinstance(resolved, ScimJSONResponse):
+                return resolved
+            user, new_email, seat_freed = resolved
 
     # Apply changes back to the DB model. A seat is consumed when the user
     # becomes active (reactivation) or when a shadow EXT_PERM_USER is promoted
@@ -978,12 +1047,7 @@ def patch_user(
         dal,
         requested_username,
         user,
-        # Unlike PUT, PATCH skips an unchanged address: PUT's pass-through is
-        # what re-runs email reconciliation (EXT_PERM shadow merging) on a
-        # full replace.
-        email=(
-            new_email if new_email and new_email.lower() != user.email.lower() else None
-        ),
+        email=new_email,
         is_active=patched.active if patched.active != user.is_active else None,
         personal_name=personal_name,
         account_type=AccountType.STANDARD if promote else None,
@@ -1007,10 +1071,10 @@ def patch_user(
         manager=ent_data.get("manager", cf.manager),
         given_name=patched.name.givenName if patched.name else cf.given_name,
         family_name=patched.name.familyName if patched.name else cf.family_name,
+        # Persist emails only when the PATCH carried them. patched.emails is
+        # otherwise the response-side fallback, which must not become stored.
         scim_emails_json=(
-            serialize_emails(patched.emails)
-            if patched.emails is not None
-            else cf.scim_emails_json
+            serialize_emails(patched.emails) if sets_emails else cf.scim_emails_json
         ),
     )
 

--- a/backend/ee/onyx/server/scim/models.py
+++ b/backend/ee/onyx/server/scim/models.py
@@ -192,7 +192,25 @@ class ScimPatchResourceValue(BaseModel):
     meta: ScimMeta | None = None
 
 
-ScimPatchValue = str | bool | list[ScimGroupMember] | ScimPatchResourceValue | None
+class ScimPatchEmailValue(ScimEmail):
+    """Email entry in an explicit-path PATCH value.
+
+    extra="forbid" keeps the union deterministic: member entries carry keys
+    this model rejects (display), so they fall through to ScimGroupMember,
+    while standard email entries parse losslessly here.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+
+ScimPatchValue = (
+    str
+    | bool
+    | list[ScimPatchEmailValue]
+    | list[ScimGroupMember]
+    | ScimPatchResourceValue
+    | None
+)
 
 
 class ScimPatchOperation(BaseModel):

--- a/backend/ee/onyx/server/scim/patch.py
+++ b/backend/ee/onyx/server/scim/patch.py
@@ -17,11 +17,12 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, TypeVar
+
+from pydantic import BaseModel, ValidationError
 
 from ee.onyx.server.scim.models import (
     SCIM_ENTERPRISE_USER_SCHEMA,
-    ScimGroupMember,
     ScimGroupResource,
     ScimPatchOperation,
     ScimPatchOperationType,
@@ -32,6 +33,8 @@ from ee.onyx.server.scim.models import (
 
 logger = logging.getLogger(__name__)
 
+_ResourceT = TypeVar("_ResourceT", bound=BaseModel)
+
 # Lowercased enterprise extension URN for case-insensitive matching
 _ENTERPRISE_URN_LOWER = SCIM_ENTERPRISE_USER_SCHEMA.lower()
 
@@ -39,7 +42,7 @@ _ENTERPRISE_URN_LOWER = SCIM_ENTERPRISE_USER_SCHEMA.lower()
 #   emails[primary eq true].value  (Okta)
 #   emails[type eq "work"].value   (Azure AD / Entra ID)
 _EMAIL_FILTER_RE = re.compile(
-    r"^emails\[.+\]\.value$",
+    r'^emails\[(\w+)\s+eq\s+"?([^"\]]+)"?\]\.value$',
     re.IGNORECASE,
 )
 
@@ -87,6 +90,18 @@ class ScimPatchError(Exception):
         self.detail = detail
         self.status = status
         super().__init__(detail)
+
+
+def _validate_patched(model: type[_ResourceT], data: dict[str, Any]) -> _ResourceT:
+    """Rebuild the patched resource, surfacing bad values as a 400.
+
+    A value the union mis-shapes (e.g. an emails entry with unknown keys)
+    only fails here, and the IdP sent it, so it is a client error.
+    """
+    try:
+        return model.model_validate(data)
+    except ValidationError as e:
+        raise ScimPatchError(f"Invalid PATCH value: {e.errors()[0]['msg']}") from e
 
 
 @dataclass
@@ -137,7 +152,7 @@ def apply_user_patch(
             )
 
     ctx.data["name"] = ctx.name_data
-    return ScimUserResource.model_validate(ctx.data), ctx.ent_data
+    return _validate_patched(ScimUserResource, ctx.data), ctx.ent_data
 
 
 def _apply_user_replace(
@@ -219,8 +234,10 @@ def _set_user_field(
     elif path == "emails":
         if isinstance(value, list):
             ctx.data["emails"] = value
-    elif _EMAIL_FILTER_RE.match(path):
-        _update_primary_email(ctx.data, value)
+    elif email_filter := _EMAIL_FILTER_RE.match(path):
+        _update_filtered_email(
+            ctx.data, email_filter.group(1), email_filter.group(2), value
+        )
     elif path.startswith(_ENTERPRISE_URN_LOWER):
         _set_enterprise_field(path, value, ctx.ent_data)
     elif not strict:
@@ -229,15 +246,31 @@ def _set_user_field(
         raise ScimPatchError(f"Unsupported path '{path}' for User PATCH")
 
 
-def _update_primary_email(data: dict[str, Any], value: ScimPatchValue) -> None:
-    """Update the primary email entry via an email filter path."""
+def _update_filtered_email(
+    data: dict[str, Any], attr: str, literal: str, value: ScimPatchValue
+) -> None:
+    """Update the email entry an ``emails[<attr> eq <literal>].value`` path names.
+
+    A type filter targets the matching typed entry so it cannot move a
+    different primary entry. An unmatched filter appends: primary for a
+    primary filter, a non-primary typed entry otherwise (unless it is the
+    only entry, which must stay resolvable as the account email).
+    """
     emails: list[dict] = data.get("emails") or []
+    attr = attr.lower()
     for email_entry in emails:
-        if email_entry.get("primary"):
+        matches = (
+            str(email_entry.get("primary")).lower() == literal.lower()
+            if attr == "primary"
+            else str(email_entry.get(attr)).lower() == literal.lower()
+        )
+        if matches:
             email_entry["value"] = value
             break
     else:
-        emails.append({"value": value, "type": "work", "primary": True})
+        entry_type = literal if attr == "type" else "work"
+        primary = attr == "primary" or not emails
+        emails.append({"value": value, "type": entry_type, "primary": primary})
     data["emails"] = emails
 
 
@@ -254,6 +287,13 @@ def _to_dict(value: ScimPatchValue) -> dict | None:
     return None
 
 
+def _ent_str(value: Any, attr: str) -> str | None:
+    """Enterprise extension values must be strings, so anything else is a 400."""
+    if value is None or isinstance(value, str):
+        return value
+    raise ScimPatchError(f"Invalid value for enterprise attribute '{attr}'")
+
+
 def _set_enterprise_field(
     path: str,
     value: ScimPatchValue,
@@ -266,11 +306,11 @@ def _set_enterprise_field(
         d = _to_dict(value)
         if d is not None:
             if "department" in d:
-                ent_data["department"] = d["department"]
+                ent_data["department"] = _ent_str(d["department"], "department")
             if "manager" in d:
                 mgr = d["manager"]
                 if isinstance(mgr, dict):
-                    ent_data["manager"] = mgr.get("value")
+                    ent_data["manager"] = _ent_str(mgr.get("value"), "manager")
         return
 
     # Dotted URN path, e.g. "urn:...:user:department"
@@ -280,7 +320,7 @@ def _set_enterprise_field(
     elif suffix == "manager":
         d = _to_dict(value)
         if d is not None:
-            ent_data["manager"] = d.get("value")
+            ent_data["manager"] = _ent_str(d.get("value"), "manager")
         elif isinstance(value, str):
             ent_data["manager"] = value
     else:
@@ -333,7 +373,7 @@ def apply_group_patch(
             )
 
     data["members"] = current_members
-    group = ScimGroupResource.model_validate(data)
+    group = _validate_patched(ScimGroupResource, data)
     return group, added_ids, removed_ids
 
 
@@ -369,9 +409,7 @@ def _apply_group_replace(
     _set_group_field(path, op.value, data, ignored_paths)
 
 
-def _members_to_dicts(
-    value: str | bool | list[ScimGroupMember] | ScimPatchResourceValue | None,
-) -> list[dict]:
+def _members_to_dicts(value: ScimPatchValue) -> list[dict]:
     """Convert a member list value to a list of dicts for internal processing."""
     if not isinstance(value, list):
         raise ScimPatchError("Replace members requires a list value")

--- a/backend/ee/onyx/server/scim/providers/base.py
+++ b/backend/ee/onyx/server/scim/providers/base.py
@@ -113,7 +113,10 @@ class ScimProvider(ABC):
                 schemas.append(SCIM_ENTERPRISE_USER_SCHEMA)
 
         name = self.build_scim_name(user, f)
-        emails = _deserialize_emails(f.scim_emails_json, username)
+        # The emails fallback is the login email, not the userName. Reporting
+        # the userName would let a GET-then-PUT IdP feed it back as an email
+        # change and re-couple the two.
+        emails = _deserialize_emails(f.scim_emails_json, user.email)
 
         resource = ScimUserResource(
             schemas=schemas,
@@ -181,7 +184,9 @@ class ScimProvider(ABC):
         )
 
 
-def _deserialize_emails(stored_json: str | None, username: str) -> list[ScimEmail]:
+def _deserialize_emails(
+    stored_json: str | None, fallback_email: str
+) -> list[ScimEmail]:
     """Deserialize stored email entries or build a default work email."""
     if stored_json:
         try:
@@ -192,7 +197,7 @@ def _deserialize_emails(stored_json: str | None, username: str) -> list[ScimEmai
             logger.warning(
                 "Corrupt scim_emails_json, falling back to default: %s", stored_json
             )
-    return [ScimEmail(value=username, type="work", primary=True)]
+    return [ScimEmail(value=fallback_email, type="work", primary=True)]
 
 
 def serialize_emails(emails: list[ScimEmail]) -> str | None:

--- a/backend/tests/unit/onyx/server/scim/test_entra.py
+++ b/backend/tests/unit/onyx/server/scim/test_entra.py
@@ -372,7 +372,7 @@ class TestEntraUserLifecycle:
             department="Engineering",
             given_name="Test",
             family_name="User",
-            scim_emails_json='[{"value": "test@example.com", "type": "work", "primary": true}]',
+            scim_emails_json=None,
         )
 
     def test_patch_user_remove_external_id(
@@ -486,7 +486,7 @@ class TestEntraUserLifecycle:
             department="Marketing",
             given_name="Test",
             family_name="User",
-            scim_emails_json='[{"value": "test@example.com", "type": "work", "primary": true}]',
+            scim_emails_json=None,
         )
 
     def test_replace_user_includes_enterprise_schema(

--- a/backend/tests/unit/onyx/server/scim/test_patch.py
+++ b/backend/tests/unit/onyx/server/scim/test_patch.py
@@ -297,6 +297,41 @@ class TestApplyUserPatch:
         assert result.emails[0].value == "new@example.com"
         assert result.emails[0].primary is True
 
+    def test_type_filter_updates_matching_entry(self) -> None:
+        """emails[type eq "work"].value targets the work entry, not the primary."""
+        user = ScimUserResource(
+            userName="u@example.com",
+            emails=[
+                ScimEmail(value="home@example.com", type="home", primary=True),
+                ScimEmail(value="work@example.com", type="work", primary=False),
+            ],
+        )
+
+        result, _ = apply_user_patch(
+            [_replace_op('emails[type eq "work"].value', "new-work@example.com")], user
+        )
+
+        assert result.emails[0].value == "home@example.com"
+        assert result.emails[0].primary is True
+        assert result.emails[1].value == "new-work@example.com"
+
+    def test_type_filter_appends_when_unmatched(self) -> None:
+        """An unmatched type filter adds a non-primary entry of that type."""
+        user = ScimUserResource(
+            userName="u@example.com",
+            emails=[ScimEmail(value="home@example.com", type="home", primary=True)],
+        )
+
+        result, _ = apply_user_patch(
+            [_replace_op('emails[type eq "work"].value', "work@example.com")], user
+        )
+
+        assert result.emails[0].value == "home@example.com"
+        assert result.emails[0].primary is True
+        assert result.emails[1].value == "work@example.com"
+        assert result.emails[1].type == "work"
+        assert result.emails[1].primary is False
+
     def test_enterprise_urn_department_path(self) -> None:
         """Dotted enterprise URN path should set department in ent_data."""
         user = _make_user()

--- a/backend/tests/unit/onyx/server/scim/test_providers.py
+++ b/backend/tests/unit/onyx/server/scim/test_providers.py
@@ -129,7 +129,7 @@ class TestOktaProvider:
         assert result.displayName is None
 
     def test_build_user_resource_scim_username_preserves_case(self) -> None:
-        """When scim_username is set, userName and emails use original case."""
+        """userName keeps the IdP's case, emails reports the login email."""
         provider = OktaProvider()
         user = _make_mock_user(email="alice@example.com")
         result = provider.build_user_resource(
@@ -137,7 +137,7 @@ class TestOktaProvider:
         )
 
         assert result.userName == "Alice@Example.com"
-        assert result.emails[0].value == "Alice@Example.com"
+        assert result.emails[0].value == "alice@example.com"
 
     def test_build_user_resource_scim_username_none_falls_back(self) -> None:
         """When scim_username is None, userName falls back to user.email."""

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -20,6 +20,7 @@ from ee.onyx.server.scim.api import (
     replace_user,
 )
 from ee.onyx.server.scim.models import (
+    ScimEmail,
     ScimMappingFields,
     ScimName,
     ScimPatchOperation,
@@ -1017,7 +1018,8 @@ class TestEmailCasePreservation:
 
         resource = parse_scim_user(result, status=201)
         assert resource.userName == "Alice@Example.COM"
-        assert resource.emails[0].value == "Alice@Example.COM"
+        # emails reports the login email, which the user model lowercases.
+        assert resource.emails[0].value == "alice@example.com"
 
     def test_get_preserves_username_case(
         self,
@@ -1045,7 +1047,8 @@ class TestEmailCasePreservation:
 
         resource = parse_scim_user(result)
         assert resource.userName == "Alice@Example.COM"
-        assert resource.emails[0].value == "Alice@Example.COM"
+        # emails reports the login email, not the provisioned userName.
+        assert resource.emails[0].value == "alice@example.com"
 
 
 class TestSeatLock:
@@ -1085,20 +1088,33 @@ class TestSeatLock:
 _TOMBSTONE_HEX = "283405f5083e4780b861a7d42f2522c2"
 
 
-def _rename_patch(username: str, active: bool | None = None) -> ScimPatchRequest:
-    value: dict[str, object] = {"userName": username}
+def _emails(value: str) -> list[ScimEmail]:
+    return [ScimEmail(value=value, type="work", primary=True)]
+
+
+def _user_patch(
+    username: str | None = None,
+    active: bool | None = None,
+    email: str | None = None,
+) -> ScimPatchRequest:
+    value: dict[str, object] = {}
+    if username is not None:
+        value["userName"] = username
     if active is not None:
         value["active"] = active
+    if email is not None:
+        value["emails"] = [e.model_dump(exclude_none=True) for e in _emails(email)]
     return ScimPatchRequest(
         Operations=[ScimPatchOperation(op=ScimPatchOperationType.REPLACE, value=value)]
     )
 
 
 class TestEntraTombstoneRename:
-    """Entra syncs a soft-deleted user's objectId-prefixed UPN as userName.
-    The email must survive; only the mapping records what the IdP sent."""
+    """Entra syncs objectId-prefixed values for soft-deleted users. A
+    tombstoned emails value never overwrites the account email, and the
+    mapping still records exactly what the IdP sent."""
 
-    def test_put_tombstone_keeps_email(
+    def test_put_tombstone_username_never_touches_email(
         self,
         mock_db_session: MagicMock,
         mock_token: MagicMock,
@@ -1120,14 +1136,14 @@ class TestEntraTombstoneRename:
         resource = parse_scim_user(result)
         assert resource.userName == tombstone
         _, kwargs = mock_dal.update_user.call_args
-        assert kwargs["email"] is None
+        assert kwargs["email"] == "ralf@mane.com"
         assert kwargs["is_active"] is False
         assert (
             mock_dal.sync_user_external_id.call_args.kwargs["scim_username"]
             == tombstone
         )
 
-    def test_patch_tombstone_keeps_email(
+    def test_put_tombstone_email_keeps_email(
         self,
         mock_db_session: MagicMock,
         mock_token: MagicMock,
@@ -1136,11 +1152,39 @@ class TestEntraTombstoneRename:
     ) -> None:
         user = make_db_user(email="ralf@mane.com", is_active=True)
         mock_dal.get_user.return_value = user
-        tombstone = f"{_TOMBSTONE_HEX}ralf@mane.com"
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(
+                userName="ralf@mane.com",
+                active=False,
+                emails=_emails(f"{_TOMBSTONE_HEX}ralf@mane.com"),
+            ),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        _, kwargs = mock_dal.update_user.call_args
+        assert kwargs["email"] is None
+        assert kwargs["is_active"] is False
+
+    def test_patch_tombstone_email_keeps_email(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        user = make_db_user(email="ralf@mane.com", is_active=True)
+        mock_dal.get_user.return_value = user
 
         result = patch_user(
             user_id=str(user.id),
-            patch_request=_rename_patch(tombstone, active=False),
+            patch_request=_user_patch(
+                active=False, email=f"{_TOMBSTONE_HEX}ralf@mane.com"
+            ),
             _token=mock_token,
             provider=provider,
             db_session=mock_db_session,
@@ -1158,7 +1202,7 @@ class TestEntraTombstoneRename:
         mock_dal: MagicMock,
         provider: ScimProvider,
     ) -> None:
-        """Deprovisioning an admin must not trip the privileged-rename guard."""
+        """Deprovisioning an admin must not trip the privileged-move guard."""
         user = make_db_user(
             email="admin@mane.com",
             is_active=True,
@@ -1177,9 +1221,9 @@ class TestEntraTombstoneRename:
 
         parse_scim_user(result)
         _, kwargs = mock_dal.update_user.call_args
-        assert kwargs["email"] is None
+        assert kwargs["is_active"] is False
 
-    def test_put_hex_prefix_of_other_address_is_real_rename(
+    def test_put_hex_prefix_of_other_address_is_real_email_change(
         self,
         mock_db_session: MagicMock,
         mock_token: MagicMock,
@@ -1189,11 +1233,13 @@ class TestEntraTombstoneRename:
         """A hex prefix only counts as a tombstone of the CURRENT email."""
         user = make_db_user(email="ralf@mane.com", is_active=True)
         mock_dal.get_user.return_value = user
-        renamed = f"{_TOMBSTONE_HEX}other@mane.com"
+        changed = f"{_TOMBSTONE_HEX}other@mane.com"
 
         result = replace_user(
             user_id=str(user.id),
-            user_resource=make_scim_user(userName=renamed, active=True),
+            user_resource=make_scim_user(
+                userName="ralf@mane.com", active=True, emails=_emails(changed)
+            ),
             _token=mock_token,
             provider=provider,
             db_session=mock_db_session,
@@ -1201,12 +1247,357 @@ class TestEntraTombstoneRename:
 
         parse_scim_user(result)
         _, kwargs = mock_dal.update_user.call_args
-        assert kwargs["email"] == renamed
+        assert kwargs["email"] == changed
 
 
-class TestRenameCollisionAdoption:
-    """A rename onto an address that an unmanaged account already owns adopts
-    that account (mirror of the POST adoption path) instead of failing."""
+class TestUsernameDecoupling:
+    """userName is a matching attribute: it records on the mapping and never
+    moves the login email. The email follows the emails attribute."""
+
+    def test_put_username_only_rename_keeps_email(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        user = make_db_user(email="old@mane.com", is_active=True)
+        mock_dal.get_user.return_value = user
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(userName="renamed@mane.com", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        resource = parse_scim_user(result)
+        _, kwargs = mock_dal.update_user.call_args
+        assert kwargs["email"] == "old@mane.com"
+        assert (
+            mock_dal.sync_user_external_id.call_args.kwargs["scim_username"]
+            == "renamed@mane.com"
+        )
+        # The response must report the login email, or a GET-then-PUT IdP
+        # would feed the userName back as an email change.
+        assert resource.emails[0].value == "old@mane.com"
+
+    def test_patch_secondary_email_update_keeps_login_email(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """A filtered update of a secondary entry must not move the login
+        email to a drifted stored primary."""
+        user = make_db_user(email="current@mane.com", is_active=True)
+        drifted_owner = make_db_user(email="stale@mane.com", is_active=True)
+        mapping = make_user_mapping(
+            user_id=user.id,
+            scim_emails_json=(
+                '[{"value": "stale@mane.com", "type": "home", "primary": true},'
+                ' {"value": "work@mane.com", "type": "work", "primary": false}]'
+            ),
+        )
+        mock_dal.get_user.return_value = user
+        mock_dal.get_user_by_email.return_value = drifted_owner
+        mock_dal.get_user_mapping_by_user_id.side_effect = lambda uid: (
+            mapping if uid == user.id else None
+        )
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REPLACE,
+                    path='emails[type eq "work"].value',
+                    value="new-work@mane.com",
+                )
+            ]
+        )
+
+        result = patch_user(
+            user_id=str(user.id),
+            patch_request=patch_req,
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        mock_dal.reassign_user_mapping.assert_not_called()
+        mock_dal.deactivate_user.assert_not_called()
+        args, kwargs = mock_dal.update_user.call_args
+        assert args[0] is user
+        assert kwargs["email"] is None
+        fields = mock_dal.sync_user_external_id.call_args.kwargs["fields"]
+        assert "new-work@mane.com" in (fields.scim_emails_json or "")
+
+    def test_patch_explicit_emails_path_updates_email(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """A list value on an explicit emails path must parse as emails."""
+        user = make_db_user(email="old@mane.com", is_active=True)
+        mock_dal.get_user.return_value = user
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REPLACE,
+                    path="emails",
+                    value=[{"value": "new@mane.com", "type": "work", "primary": True}],
+                )
+            ]
+        )
+
+        result = patch_user(
+            user_id=str(user.id),
+            patch_request=patch_req,
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        _, kwargs = mock_dal.update_user.call_args
+        assert kwargs["email"] == "new@mane.com"
+
+    def test_patch_malformed_manager_value_returns_400(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """A non-string enterprise manager value is a 400, not a 500."""
+        user = make_db_user(email="old@mane.com", is_active=True)
+        mock_dal.get_user.return_value = user
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REPLACE,
+                    value={
+                        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
+                            "manager": {"value": ["bad"]}
+                        }
+                    },
+                )
+            ]
+        )
+
+        result = patch_user(
+            user_id=str(user.id),
+            patch_request=patch_req,
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 400)
+
+    def test_patch_malformed_emails_value_returns_400(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """A value that cannot rebuild a valid user resource is a 400."""
+        user = make_db_user(email="old@mane.com", is_active=True)
+        mock_dal.get_user.return_value = user
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REPLACE,
+                    path="emails",
+                    value=[{"value": "new@mane.com", "display": "New"}],
+                )
+            ]
+        )
+
+        result = patch_user(
+            user_id=str(user.id),
+            patch_request=patch_req,
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 400)
+
+    def test_blank_emails_value_returns_400(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """A carried emails list with only blank values must not persist."""
+        user = make_db_user(email="old@mane.com", is_active=True)
+        mock_dal.get_user.return_value = user
+
+        put_result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(
+                userName="old@mane.com", active=True, emails=_emails("   ")
+            ),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+        assert_scim_error(put_result, 400)
+
+        patch_result = patch_user(
+            user_id=str(user.id),
+            patch_request=_user_patch(active=False, email="   "),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+        assert_scim_error(patch_result, 400)
+
+    def test_put_email_change_follows_emails_attribute(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        user = make_db_user(email="old@mane.com", is_active=True)
+        mock_dal.get_user.return_value = user
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(
+                userName="old@mane.com",
+                active=True,
+                emails=_emails("new@mane.com"),
+            ),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        _, kwargs = mock_dal.update_user.call_args
+        assert kwargs["email"] == "new@mane.com"
+
+    def test_create_seeds_email_from_primary_email(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        with patch(
+            "ee.onyx.server.scim.api._check_seat_availability", return_value=None
+        ):
+            result = create_user(
+                user_resource=make_scim_user(
+                    userName="upn@corp.onmicrosoft.com",
+                    emails=_emails("person@mane.com"),
+                ),
+                _token=mock_token,
+                provider=provider,
+                db_session=mock_db_session,
+            )
+
+        parse_scim_user(result, status=201)
+        created = mock_dal.add_user.call_args[0][0]
+        assert created.email == "person@mane.com"
+        assert (
+            mock_dal.create_user_mapping.call_args.kwargs["scim_username"]
+            == "upn@corp.onmicrosoft.com"
+        )
+
+    def test_patch_username_in_any_key_casing_records_mapping(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """Path-less values carry userName under any casing (extra='allow')."""
+        user = make_db_user(email="ralf@mane.com", is_active=True)
+        mock_dal.get_user.return_value = user
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REPLACE,
+                    value={"UserName": "Renamed@mane.com", "active": True},
+                )
+            ]
+        )
+
+        result = patch_user(
+            user_id=str(user.id),
+            patch_request=patch_req,
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        assert (
+            mock_dal.sync_user_external_id.call_args.kwargs["scim_username"]
+            == "Renamed@mane.com"
+        )
+
+    def test_put_rename_onto_provisioned_username_returns_409(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """A userName another mapping already holds conflicts even when that
+        mapping's account email has diverged from it."""
+        user = make_db_user(email="old@mane.com", is_active=True)
+        mock_dal.get_user.return_value = user
+        mock_dal.get_user_mapping_by_scim_username.return_value = make_user_mapping(
+            user_id=uuid4(), scim_username="Taken@mane.com"
+        )
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(userName="taken@mane.com", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 409)
+        mock_dal.update_user.assert_not_called()
+
+    def test_put_blank_username_returns_400(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """A whitespace-only userName must not blank the mapping or email."""
+        user = make_db_user(email="old@mane.com", is_active=True)
+        mock_dal.get_user.return_value = user
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(userName="   ", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 400)
+        mock_dal.update_user.assert_not_called()
+
+
+class TestEmailCollisionResolution:
+    """Emails-driven changes onto owned addresses resolve by adoption for
+    unmanaged STANDARD accounts, 409 for managed ones, and 409 for races."""
 
     def _stale_and_clean(
         self, mock_dal: MagicMock, **stale_kwargs: object
@@ -1234,7 +1625,11 @@ class TestRenameCollisionAdoption:
 
         result = replace_user(
             user_id=str(stale.id),
-            user_resource=make_scim_user(userName="ralf@mane.com", active=True),
+            user_resource=make_scim_user(
+                userName="ralf@mane.com",
+                active=True,
+                emails=_emails("ralf@mane.com"),
+            ),
             _token=mock_token,
             provider=provider,
             db_session=mock_db_session,
@@ -1259,7 +1654,9 @@ class TestRenameCollisionAdoption:
 
         result = patch_user(
             user_id=str(stale.id),
-            patch_request=_rename_patch("ralf@mane.com", active=True),
+            patch_request=_user_patch(
+                username="ralf@mane.com", active=True, email="ralf@mane.com"
+            ),
             _token=mock_token,
             provider=provider,
             db_session=mock_db_session,
@@ -1270,27 +1667,34 @@ class TestRenameCollisionAdoption:
         mock_dal.reassign_user_mapping.assert_called_once_with(stale_mapping, clean.id)
         mock_dal.deactivate_user.assert_called_once_with(stale)
 
-    def test_patch_username_in_any_key_casing_still_resolves(
+    @patch("ee.onyx.server.scim.api._check_seat_availability")
+    def test_put_adoption_swap_is_seat_neutral(
         self,
+        mock_seats: MagicMock,
         mock_db_session: MagicMock,
         mock_token: MagicMock,
         mock_dal: MagicMock,
         provider: ScimProvider,
     ) -> None:
-        """Path-less values carry userName under any casing (extra='allow')."""
-        stale, clean, stale_mapping = self._stale_and_clean(mock_dal)
-        patch_req = ScimPatchRequest(
-            Operations=[
-                ScimPatchOperation(
-                    op=ScimPatchOperationType.REPLACE,
-                    value={"UserName": "ralf@mane.com", "active": True},
-                )
-            ]
+        """Deactivating the active source frees the seat the adopted inactive
+        target needs, so a tenant at capacity must not 403."""
+        mock_seats.return_value = "No seats"
+        stale = make_db_user(email="old@mane.com", is_active=True)
+        clean = make_db_user(email="ralf@mane.com", is_active=False)
+        stale_mapping = make_user_mapping(user_id=stale.id)
+        mock_dal.get_user.return_value = stale
+        mock_dal.get_user_by_email.return_value = clean
+        mock_dal.get_user_mapping_by_user_id.side_effect = lambda uid: (
+            stale_mapping if uid == stale.id else None
         )
 
-        result = patch_user(
+        result = replace_user(
             user_id=str(stale.id),
-            patch_request=patch_req,
+            user_resource=make_scim_user(
+                userName="ralf@mane.com",
+                active=True,
+                emails=_emails("ralf@mane.com"),
+            ),
             _token=mock_token,
             provider=provider,
             db_session=mock_db_session,
@@ -1298,7 +1702,216 @@ class TestRenameCollisionAdoption:
 
         resource = parse_scim_user(result)
         assert resource.id == str(clean.id)
-        mock_dal.reassign_user_mapping.assert_called_once_with(stale_mapping, clean.id)
+        mock_seats.assert_not_called()
+
+    @patch("ee.onyx.server.scim.api._check_seat_availability")
+    def test_put_adoption_of_ext_perm_source_still_checks_seats(
+        self,
+        mock_seats: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """An active EXT_PERM source holds no seat, so its deactivation frees
+        none and reactivating the adopted target must still be checked."""
+        mock_seats.return_value = "No seats"
+        stale = make_db_user(
+            email="old@mane.com",
+            is_active=True,
+            account_type=AccountType.EXT_PERM_USER,
+        )
+        clean = make_db_user(email="ralf@mane.com", is_active=False)
+        mock_dal.get_user.return_value = stale
+        mock_dal.get_user_by_email.return_value = clean
+        mock_dal.get_user_mapping_by_user_id.return_value = None
+
+        result = replace_user(
+            user_id=str(stale.id),
+            user_resource=make_scim_user(
+                userName="ralf@mane.com",
+                active=True,
+                emails=_emails("ralf@mane.com"),
+            ),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 403)
+        mock_seats.assert_called_once()
+
+    def test_put_email_change_onto_mapped_account_returns_409(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        user = make_db_user(email="old@mane.com")
+        other = make_db_user(email="taken@mane.com")
+        mock_dal.get_user.return_value = user
+        mock_dal.get_user_by_email.return_value = other
+        mock_dal.get_user_mapping_by_user_id.side_effect = lambda uid: (
+            make_user_mapping(user_id=uid) if uid == other.id else None
+        )
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(
+                userName="old@mane.com",
+                active=True,
+                emails=_emails("taken@mane.com"),
+            ),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 409)
+
+    def test_put_email_change_onto_bot_is_not_adopted(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """System accounts must never come under IdP control via adoption."""
+        user = make_db_user(email="old@mane.com", is_active=True)
+        bot = make_db_user(email="bot@mane.com", account_type=AccountType.BOT)
+        mock_dal.get_user.return_value = user
+        mock_dal.get_user_by_email.return_value = bot
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(
+                userName="old@mane.com", active=True, emails=_emails("bot@mane.com")
+            ),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        mock_dal.reassign_user_mapping.assert_not_called()
+        mock_dal.deactivate_user.assert_not_called()
+        args, _ = mock_dal.update_user.call_args
+        assert args[0] is user
+
+    def test_put_email_change_onto_ext_perm_shadow_stays_a_change(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """EXT_PERM shadows are merged by email reconciliation, not adopted."""
+        user = make_db_user(email="old@mane.com", is_active=True)
+        shadow = make_db_user(
+            email="ralf@mane.com", account_type=AccountType.EXT_PERM_USER
+        )
+        mock_dal.get_user.return_value = user
+        mock_dal.get_user_by_email.return_value = shadow
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(
+                userName="old@mane.com", active=True, emails=_emails("ralf@mane.com")
+            ),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        mock_dal.reassign_user_mapping.assert_not_called()
+        mock_dal.deactivate_user.assert_not_called()
+        args, kwargs = mock_dal.update_user.call_args
+        assert args[0] is user
+        assert kwargs["email"] == "ralf@mane.com"
+
+    def test_put_adoption_allowed_for_admin_source(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """Adoption is not a move of the privileged account itself."""
+        stale, clean, _ = self._stale_and_clean(
+            mock_dal,
+            effective_permissions=[Permission.FULL_ADMIN_PANEL_ACCESS.value],
+        )
+
+        result = replace_user(
+            user_id=str(stale.id),
+            user_resource=make_scim_user(
+                userName="ralf@mane.com",
+                active=True,
+                emails=_emails("ralf@mane.com"),
+            ),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        resource = parse_scim_user(result)
+        assert resource.id == str(clean.id)
+        mock_dal.deactivate_user.assert_called_once_with(stale)
+
+    @patch("ee.onyx.server.scim.api.is_unique_violation", return_value=True)
+    def test_put_rename_reconcile_race_returns_409(
+        self,
+        mock_is_unique: MagicMock,  # noqa: ARG002
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """The email reconcile inside update_user can autoflush a concurrent
+        change into a unique violation. It must return 409, not 500."""
+        user = make_db_user(email="old@mane.com", is_active=True)
+        mock_dal.get_user.return_value = user
+        mock_dal.update_user.side_effect = IntegrityError("dup", {}, Exception())
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(
+                userName="old@mane.com", active=True, emails=_emails("new@mane.com")
+            ),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 409)
+
+    @patch("ee.onyx.server.scim.api.is_unique_violation", return_value=True)
+    def test_put_rename_commit_race_returns_409(
+        self,
+        mock_is_unique: MagicMock,  # noqa: ARG002
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """A concurrent change can slip past the lookups and hit a unique
+        index at commit. It must return a clean 409, not a 500."""
+        user = make_db_user(email="old@mane.com", is_active=True)
+        mock_dal.get_user.return_value = user
+        mock_dal.commit.side_effect = IntegrityError("dup", {}, Exception())
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(userName="new@mane.com", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 409)
+        mock_dal.rollback.assert_called_once()
 
     def test_patch_without_username_op_never_resolves_a_rename(
         self,
@@ -1307,8 +1920,8 @@ class TestRenameCollisionAdoption:
         mock_dal: MagicMock,
         provider: ScimProvider,
     ) -> None:
-        """A PATCH that does not touch userName must not act on a stored
-        scim_username that has drifted from the email (no adoption, no 409)."""
+        """A PATCH that does not touch userName or emails must not act on
+        stored values that have drifted (no adoption, no 409)."""
         user = make_db_user(email="current@mane.com", is_active=True)
         drifted_owner = make_db_user(email="drifted@mane.com", is_active=True)
         mapping = make_user_mapping(user_id=user.id, scim_username="drifted@mane.com")
@@ -1344,312 +1957,14 @@ class TestRenameCollisionAdoption:
         # collision row would re-collide on its email fallback.
         assert mock_dal.sync_user_external_id.call_args.kwargs["scim_username"] is None
 
-    def test_put_adoption_allowed_for_admin_source(
-        self,
-        mock_db_session: MagicMock,
-        mock_token: MagicMock,
-        mock_dal: MagicMock,
-        provider: ScimProvider,
-    ) -> None:
-        """Adoption is not a rename of the privileged account — allow it."""
-        stale, clean, _ = self._stale_and_clean(
-            mock_dal,
-            effective_permissions=[Permission.FULL_ADMIN_PANEL_ACCESS.value],
-        )
 
-        result = replace_user(
-            user_id=str(stale.id),
-            user_resource=make_scim_user(userName="ralf@mane.com", active=True),
-            _token=mock_token,
-            provider=provider,
-            db_session=mock_db_session,
-        )
-
-        resource = parse_scim_user(result)
-        assert resource.id == str(clean.id)
-        mock_dal.deactivate_user.assert_called_once_with(stale)
-
-    @patch("ee.onyx.server.scim.api._check_seat_availability")
-    def test_put_adoption_swap_is_seat_neutral(
-        self,
-        mock_seats: MagicMock,
-        mock_db_session: MagicMock,
-        mock_token: MagicMock,
-        mock_dal: MagicMock,
-        provider: ScimProvider,
-    ) -> None:
-        """Deactivating the active source frees the seat the adopted inactive
-        target needs, so a tenant at capacity must not 403."""
-        mock_seats.return_value = "No seats"
-        stale = make_db_user(email="old@mane.com", is_active=True)
-        clean = make_db_user(email="ralf@mane.com", is_active=False)
-        stale_mapping = make_user_mapping(user_id=stale.id)
-        mock_dal.get_user.return_value = stale
-        mock_dal.get_user_by_email.return_value = clean
-        mock_dal.get_user_mapping_by_user_id.side_effect = lambda uid: (
-            stale_mapping if uid == stale.id else None
-        )
-
-        result = replace_user(
-            user_id=str(stale.id),
-            user_resource=make_scim_user(userName="ralf@mane.com", active=True),
-            _token=mock_token,
-            provider=provider,
-            db_session=mock_db_session,
-        )
-
-        resource = parse_scim_user(result)
-        assert resource.id == str(clean.id)
-        mock_seats.assert_not_called()
-
-    @patch("ee.onyx.server.scim.api._check_seat_availability")
-    def test_put_adoption_of_ext_perm_source_still_checks_seats(
-        self,
-        mock_seats: MagicMock,
-        mock_db_session: MagicMock,
-        mock_token: MagicMock,
-        mock_dal: MagicMock,
-        provider: ScimProvider,
-    ) -> None:
-        """An active EXT_PERM source holds no seat, so its deactivation frees
-        none and reactivating the adopted target must still be checked."""
-        mock_seats.return_value = "No seats"
-        stale = make_db_user(
-            email="old@mane.com",
-            is_active=True,
-            account_type=AccountType.EXT_PERM_USER,
-        )
-        clean = make_db_user(email="ralf@mane.com", is_active=False)
-        mock_dal.get_user.return_value = stale
-        mock_dal.get_user_by_email.return_value = clean
-        mock_dal.get_user_mapping_by_user_id.return_value = None
-
-        result = replace_user(
-            user_id=str(stale.id),
-            user_resource=make_scim_user(userName="ralf@mane.com", active=True),
-            _token=mock_token,
-            provider=provider,
-            db_session=mock_db_session,
-        )
-
-        assert_scim_error(result, 403)
-        mock_seats.assert_called_once()
-
-    def test_put_blank_username_returns_400(
-        self,
-        mock_db_session: MagicMock,
-        mock_token: MagicMock,
-        mock_dal: MagicMock,
-        provider: ScimProvider,
-    ) -> None:
-        """A whitespace-only userName must not blank the email or mapping."""
-        user = make_db_user(email="old@mane.com", is_active=True)
-        mock_dal.get_user.return_value = user
-
-        result = replace_user(
-            user_id=str(user.id),
-            user_resource=make_scim_user(userName="   ", active=True),
-            _token=mock_token,
-            provider=provider,
-            db_session=mock_db_session,
-        )
-
-        assert_scim_error(result, 400)
-        mock_dal.update_user.assert_not_called()
-
-    def test_put_rename_onto_provisioned_username_returns_409(
-        self,
-        mock_db_session: MagicMock,
-        mock_token: MagicMock,
-        mock_dal: MagicMock,
-        provider: ScimProvider,
-    ) -> None:
-        """A userName another mapping already holds conflicts even when that
-        mapping's account email has diverged from it."""
-        user = make_db_user(email="old@mane.com", is_active=True)
-        mock_dal.get_user.return_value = user
-        mock_dal.get_user_mapping_by_scim_username.return_value = make_user_mapping(
-            user_id=uuid4(), scim_username="Taken@mane.com"
-        )
-
-        result = replace_user(
-            user_id=str(user.id),
-            user_resource=make_scim_user(userName="taken@mane.com", active=True),
-            _token=mock_token,
-            provider=provider,
-            db_session=mock_db_session,
-        )
-
-        assert_scim_error(result, 409)
-        mock_dal.update_user.assert_not_called()
-
-    @patch("ee.onyx.server.scim.api.is_unique_violation", return_value=True)
-    def test_put_rename_reconcile_race_returns_409(
-        self,
-        mock_is_unique: MagicMock,  # noqa: ARG002
-        mock_db_session: MagicMock,
-        mock_token: MagicMock,
-        mock_dal: MagicMock,
-        provider: ScimProvider,
-    ) -> None:
-        """The email reconcile inside update_user can autoflush a concurrent
-        rename into a unique violation. It must return 409, not 500."""
-        user = make_db_user(email="old@mane.com", is_active=True)
-        mock_dal.get_user.return_value = user
-        mock_dal.update_user.side_effect = IntegrityError("dup", {}, Exception())
-
-        result = replace_user(
-            user_id=str(user.id),
-            user_resource=make_scim_user(userName="new@mane.com", active=True),
-            _token=mock_token,
-            provider=provider,
-            db_session=mock_db_session,
-        )
-
-        assert_scim_error(result, 409)
-
-    @patch("ee.onyx.server.scim.api.is_unique_violation", return_value=True)
-    def test_put_rename_commit_race_returns_409(
-        self,
-        mock_is_unique: MagicMock,  # noqa: ARG002
-        mock_db_session: MagicMock,
-        mock_token: MagicMock,
-        mock_dal: MagicMock,
-        provider: ScimProvider,
-    ) -> None:
-        """A concurrent rename can slip past the lookup and hit the unique
-        index at commit. It must return a clean 409, not a 500."""
-        user = make_db_user(email="old@mane.com", is_active=True)
-        mock_dal.get_user.return_value = user
-        mock_dal.commit.side_effect = IntegrityError("dup", {}, Exception())
-
-        result = replace_user(
-            user_id=str(user.id),
-            user_resource=make_scim_user(userName="new@mane.com", active=True),
-            _token=mock_token,
-            provider=provider,
-            db_session=mock_db_session,
-        )
-
-        assert_scim_error(result, 409)
-        mock_dal.rollback.assert_called_once()
-
-    def test_put_rename_onto_mapped_bot_returns_409(
-        self,
-        mock_db_session: MagicMock,
-        mock_token: MagicMock,
-        mock_dal: MagicMock,
-        provider: ScimProvider,
-    ) -> None:
-        """A mapped collision is a conflict no matter the account type."""
-        user = make_db_user(email="old@mane.com")
-        bot = make_db_user(email="bot@mane.com", account_type=AccountType.BOT)
-        mock_dal.get_user.return_value = user
-        mock_dal.get_user_by_email.return_value = bot
-        mock_dal.get_user_mapping_by_user_id.side_effect = lambda uid: (
-            make_user_mapping(user_id=uid) if uid == bot.id else None
-        )
-
-        result = replace_user(
-            user_id=str(user.id),
-            user_resource=make_scim_user(userName="bot@mane.com", active=True),
-            _token=mock_token,
-            provider=provider,
-            db_session=mock_db_session,
-        )
-
-        assert_scim_error(result, 409)
-
-    def test_put_rename_onto_bot_account_is_not_adopted(
-        self,
-        mock_db_session: MagicMock,
-        mock_token: MagicMock,
-        mock_dal: MagicMock,
-        provider: ScimProvider,
-    ) -> None:
-        """System accounts must never come under IdP control via adoption."""
-        user = make_db_user(email="old@mane.com", is_active=True)
-        bot = make_db_user(email="bot@mane.com", account_type=AccountType.BOT)
-        mock_dal.get_user.return_value = user
-        mock_dal.get_user_by_email.return_value = bot
-
-        result = replace_user(
-            user_id=str(user.id),
-            user_resource=make_scim_user(userName="bot@mane.com", active=True),
-            _token=mock_token,
-            provider=provider,
-            db_session=mock_db_session,
-        )
-
-        parse_scim_user(result)
-        mock_dal.reassign_user_mapping.assert_not_called()
-        mock_dal.deactivate_user.assert_not_called()
-        args, _ = mock_dal.update_user.call_args
-        assert args[0] is user
-
-    def test_put_rename_onto_ext_perm_shadow_stays_a_rename(
-        self,
-        mock_db_session: MagicMock,
-        mock_token: MagicMock,
-        mock_dal: MagicMock,
-        provider: ScimProvider,
-    ) -> None:
-        """EXT_PERM shadows are merged by email reconciliation, not adopted."""
-        user = make_db_user(email="old@mane.com", is_active=True)
-        shadow = make_db_user(
-            email="ralf@mane.com", account_type=AccountType.EXT_PERM_USER
-        )
-        mock_dal.get_user.return_value = user
-        mock_dal.get_user_by_email.return_value = shadow
-
-        result = replace_user(
-            user_id=str(user.id),
-            user_resource=make_scim_user(userName="ralf@mane.com", active=True),
-            _token=mock_token,
-            provider=provider,
-            db_session=mock_db_session,
-        )
-
-        parse_scim_user(result)
-        mock_dal.reassign_user_mapping.assert_not_called()
-        mock_dal.deactivate_user.assert_not_called()
-        args, kwargs = mock_dal.update_user.call_args
-        assert args[0] is user
-        assert kwargs["email"] == "ralf@mane.com"
-
-    def test_put_rename_onto_scim_managed_account_returns_409(
-        self,
-        mock_db_session: MagicMock,
-        mock_token: MagicMock,
-        mock_dal: MagicMock,
-        provider: ScimProvider,
-    ) -> None:
-        user = make_db_user(email="old@mane.com")
-        other = make_db_user(email="taken@mane.com")
-        mock_dal.get_user.return_value = user
-        mock_dal.get_user_by_email.return_value = other
-        mock_dal.get_user_mapping_by_user_id.side_effect = lambda uid: (
-            make_user_mapping(user_id=uid) if uid == other.id else None
-        )
-
-        result = replace_user(
-            user_id=str(user.id),
-            user_resource=make_scim_user(userName="taken@mane.com", active=True),
-            _token=mock_token,
-            provider=provider,
-            db_session=mock_db_session,
-        )
-
-        assert_scim_error(result, 409)
-
-
-class TestPrivilegedRename:
+class TestPrivilegedEmailMove:
     """A SCIM token must not move an admin or group-manager account onto a
-    different address — the address could then be claimed via first login —
-    nor adopt one via rename collision, which would put it under IdP
+    different address (SSO associates by email, so the new address's first
+    login would claim it), nor adopt one, which would put it under IdP
     control."""
 
-    def test_put_admin_rename_returns_403(
+    def test_put_admin_email_move_returns_403(
         self,
         mock_db_session: MagicMock,
         mock_token: MagicMock,
@@ -1664,7 +1979,11 @@ class TestPrivilegedRename:
 
         result = replace_user(
             user_id=str(user.id),
-            user_resource=make_scim_user(userName="moved@mane.com", active=True),
+            user_resource=make_scim_user(
+                userName="admin@mane.com",
+                active=True,
+                emails=_emails("moved@mane.com"),
+            ),
             _token=mock_token,
             provider=provider,
             db_session=mock_db_session,
@@ -1673,7 +1992,7 @@ class TestPrivilegedRename:
         assert_scim_error(result, 403)
         mock_dal.update_user.assert_not_called()
 
-    def test_patch_group_manager_rename_returns_403(
+    def test_patch_group_manager_email_move_returns_403(
         self,
         mock_db_session: MagicMock,
         mock_token: MagicMock,
@@ -1685,7 +2004,7 @@ class TestPrivilegedRename:
 
         result = patch_user(
             user_id=str(user.id),
-            patch_request=_rename_patch("moved@mane.com"),
+            patch_request=_user_patch(email="moved@mane.com"),
             _token=mock_token,
             provider=provider,
             db_session=mock_db_session,
@@ -1694,7 +2013,7 @@ class TestPrivilegedRename:
         assert_scim_error(result, 403)
         mock_dal.update_user.assert_not_called()
 
-    def test_put_rename_onto_admin_account_returns_403(
+    def test_put_email_change_onto_admin_account_returns_403(
         self,
         mock_db_session: MagicMock,
         mock_token: MagicMock,
@@ -1712,7 +2031,11 @@ class TestPrivilegedRename:
 
         result = replace_user(
             user_id=str(user.id),
-            user_resource=make_scim_user(userName="admin@mane.com", active=True),
+            user_resource=make_scim_user(
+                userName="old@mane.com",
+                active=True,
+                emails=_emails("admin@mane.com"),
+            ),
             _token=mock_token,
             provider=provider,
             db_session=mock_db_session,
@@ -1723,7 +2046,7 @@ class TestPrivilegedRename:
         mock_dal.deactivate_user.assert_not_called()
         mock_dal.update_user.assert_not_called()
 
-    def test_patch_rename_onto_group_manager_returns_403(
+    def test_patch_email_change_onto_group_manager_returns_403(
         self,
         mock_db_session: MagicMock,
         mock_token: MagicMock,
@@ -1737,7 +2060,7 @@ class TestPrivilegedRename:
 
         result = patch_user(
             user_id=str(user.id),
-            patch_request=_rename_patch("manager@mane.com"),
+            patch_request=_user_patch(email="manager@mane.com"),
             _token=mock_token,
             provider=provider,
             db_session=mock_db_session,
@@ -1748,7 +2071,73 @@ class TestPrivilegedRename:
         mock_dal.deactivate_user.assert_not_called()
         mock_dal.update_user.assert_not_called()
 
-    def test_put_admin_without_rename_is_allowed(
+    def test_put_adoption_of_active_privileged_source_returns_403(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """Adoption must not deactivate an active admin through the side door.
+        An inactive privileged source (the deprovisioned-then-restored case)
+        may still be adopted away."""
+        source = make_db_user(
+            email="old@mane.com",
+            is_active=True,
+            effective_permissions=[Permission.FULL_ADMIN_PANEL_ACCESS.value],
+        )
+        clean = make_db_user(email="ralf@mane.com", is_active=True)
+        mock_dal.get_user.return_value = source
+        mock_dal.get_user_by_email.return_value = clean
+
+        result = replace_user(
+            user_id=str(source.id),
+            user_resource=make_scim_user(
+                userName="old@mane.com",
+                active=True,
+                emails=_emails("ralf@mane.com"),
+            ),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 403)
+        mock_dal.deactivate_user.assert_not_called()
+        mock_dal.reassign_user_mapping.assert_not_called()
+
+    def test_put_admin_username_rename_is_allowed(
+        self,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """userName only records on the mapping, so renaming an admin is allowed."""
+        user = make_db_user(
+            email="admin@mane.com",
+            is_active=True,
+            effective_permissions=[Permission.FULL_ADMIN_PANEL_ACCESS.value],
+        )
+        mock_dal.get_user.return_value = user
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(userName="renamed@mane.com", active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        _, kwargs = mock_dal.update_user.call_args
+        assert kwargs["email"] == "admin@mane.com"
+        assert (
+            mock_dal.sync_user_external_id.call_args.kwargs["scim_username"]
+            == "renamed@mane.com"
+        )
+
+    def test_put_admin_without_email_change_is_allowed(
         self,
         mock_db_session: MagicMock,
         mock_token: MagicMock,


### PR DESCRIPTION
## Description

Step 2 of SCIM identity decoupling (stacked on #14097).

- userName writes only record on the mapping (blank 400, holder conflict 409). Renaming an admin's userName is now allowed since it no longer moves the email.
- The login email follows the `emails` attribute (primary or first value) through the existing change machinery: tombstone guard, mapped-collision 409, unmanaged-STANDARD adoption with seat netting, privileged-move 403. Create seeds the email from the primary email, falling back to userName.
- PATCH acts on emails only when the operation carried them and persists `scim_emails_json` only then. Responses report the login email as the emails fallback, never the userName, so GET-then-PUT cannot re-couple the two.
- Hardening surfaced by review: explicit-path emails lists parse correctly (previously coerced to group members and 500d), malformed PATCH values and non-string enterprise fields return 400, and `emails[...]` filter paths update the entry the filter names instead of always the primary.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check