### PR TITLE
fix: Jira poll windows skip updates in non-UTC timezones

### DIFF
--- a/backend/onyx/connectors/jira/connector.py
+++ b/backend/onyx/connectors/jira/connector.py
@@ -2,7 +2,7 @@ import copy
 import json
 import os
 from collections.abc import Callable, Generator, Iterable, Iterator
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any
 
 import requests
@@ -714,19 +714,13 @@ class JiraConnector(
     def _get_jql_query(
         self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch
     ) -> str:
-        """Get the JQL query based on configuration and time range
+        """JQL for the configured project/query plus the poll window.
 
-        If a custom JQL query is provided, it will be used and combined with time constraints.
-        Otherwise, the query will be constructed based on project key (if provided).
+        Unquoted epoch-ms so Jira does not reinterpret naive datetimes in the
+        API user's profile timezone.
+        https://support.atlassian.com/jira-software-cloud/docs/jql-fields/#Updated
         """
-        start_date_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime(
-            "%Y-%m-%d %H:%M"
-        )
-        end_date_str = datetime.fromtimestamp(end, tz=timezone.utc).strftime(
-            "%Y-%m-%d %H:%M"
-        )
-
-        time_jql = f"updated >= '{start_date_str}' AND updated <= '{end_date_str}'"
+        time_jql = f"updated >= {int(start * 1000)} AND updated <= {int(end * 1000)}"
 
         # If custom JQL query is provided, use it and combine with time constraints
         if self.jql_query:

--- a/backend/tests/unit/onyx/connectors/jira/test_jira_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/jira/test_jira_checkpointing.py
@@ -141,22 +141,21 @@ def test_load_credentials(jira_connector: JiraConnector) -> None:
 
 
 def test_get_jql_query_with_project(jira_connector: JiraConnector) -> None:
-    """Test JQL query generation with project specified"""
+    """Poll windows are unquoted epoch-ms, not naive datetimes."""
     start = datetime(2023, 1, 1, tzinfo=timezone.utc).timestamp()
     end = datetime(2023, 1, 2, tzinfo=timezone.utc).timestamp()
 
     query = jira_connector._get_jql_query(start, end)
 
-    # Check that the project part and time part are both in the query
     assert f'project = "{jira_connector.jira_project}"' in query
-    assert "updated >= '2023-01-01 00:00'" in query
-    assert "updated <= '2023-01-02 00:00'" in query
+    assert f"updated >= {int(start * 1000)}" in query
+    assert f"updated <= {int(end * 1000)}" in query
+    assert "2023-01-01 00:00" not in query
     assert " AND " in query
 
 
 def test_get_jql_query_without_project(jira_base_url: str) -> None:
-    """Test JQL query generation without project specified"""
-    # Create connector without project key
+    """Poll windows stay epoch-ms when no project key is set."""
     connector = JiraConnector(jira_base_url=jira_base_url)
 
     start = datetime(2023, 1, 1, tzinfo=timezone.utc).timestamp()
@@ -164,10 +163,10 @@ def test_get_jql_query_without_project(jira_base_url: str) -> None:
 
     query = connector._get_jql_query(start, end)
 
-    # Check that only time part is in the query
     assert "project =" not in query
-    assert "updated >= '2023-01-01 00:00'" in query
-    assert "updated <= '2023-01-02 00:00'" in query
+    assert f"updated >= {int(start * 1000)}" in query
+    assert f"updated <= {int(end * 1000)}" in query
+    assert "2023-01-01 00:00" not in query
 
 
 def test_load_from_checkpoint_happy_path(


### PR DESCRIPTION
## Description

Jira JQL treats quoted datetime strings as the searching user's timezone, not UTC. The connector was sending UTC-formatted poll windows, so accounts behind UTC queried the future: short polls returned 0 issues, the attempt still succeeded, and the window advanced so recent updates were skipped.

Use unquoted epoch milliseconds for `updated` bounds. That form is absolute time in JQL (Cloud, Gov, Server/DC since Jira 4.0) and does not depend on REST v2 vs v3.

Existing gaps still need a re-index; this only stops new ones.

## How Has This Been Tested?

- `uv run pytest -xv backend/tests/unit/onyx/connectors/jira/test_jira_checkpointing.py`
- Unit tests now assert poll windows are unquoted epoch-ms, not naive `yyyy-MM-dd HH:mm` strings

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Jira poll windows by using absolute epoch-millisecond bounds instead of quoted UTC datetimes. Previously, Jira interpreted quoted datetimes in the user’s timezone, so users behind UTC queried the future, short polls returned 0 issues, and checkpoints advanced, skipping updates.

- Build JQL as: updated >= {start_ms} AND updated <= {end_ms}; works across Jira Cloud/Gov/Server/DC and is independent of REST v2/v3.
- Update unit tests to assert epoch-ms bounds; remove expectations for naive datetime strings.
- No config changes. Existing gaps are not backfilled—run a re-index if you need to recover missed updates.

<sup>Written for commit 942a4996fe0e72e7819655f82d93d371b2c29b82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

