### PR TITLE
fix(craft): connect-app card matches the transcript it sits in

### DIFF
--- a/web/lib/opal/src/layouts/content/ContentMd.tsx
+++ b/web/lib/opal/src/layouts/content/ContentMd.tsx
@@ -49,6 +49,9 @@ interface ContentMdProps {
   /** Optional description text below the title. */
   description?: string | RichStr;
 
+  /** Font used for the description. */
+  descriptionFont?: TextFont;
+
   /**
    * Slot for a control/action (e.g. an input) rendered to the right of the
    * title and description on desktop, and stacked between them on narrow
@@ -142,6 +145,7 @@ function ContentMd({
   icon: Icon,
   title,
   description,
+  descriptionFont = "secondary-body",
   rightChildren,
   descriptionMaxLines,
   editable,
@@ -311,7 +315,7 @@ function ContentMd({
           }
         >
           <Text
-            font="secondary-body"
+            font={descriptionFont}
             color="text-03"
             as="p"
             maxLines={descriptionMaxLines}

--- a/web/lib/opal/src/layouts/content/components.tsx
+++ b/web/lib/opal/src/layouts/content/components.tsx
@@ -17,7 +17,7 @@ import {
   ContentMd,
   type ContentMdProps,
 } from "@opal/layouts/content/ContentMd";
-import type { TagProps } from "@opal/components";
+import type { TagProps, TextFont } from "@opal/components";
 import type { ColorTypes, IconFunctionComponent, RichStr } from "@opal/types";
 import { widthVariants } from "@opal/shared";
 import type { ExtremaSizeVariants } from "@opal/types";
@@ -118,6 +118,8 @@ type MdContentProps = ContentBaseProps & {
   tag?: TagProps;
   /** Slot for a control rendered to the right (desktop) / between title and description (mobile). See ContentMd. */
   rightChildren?: React.ReactNode;
+  /** Font used for the description. */
+  descriptionFont?: TextFont;
 };
 
 /** ContentSm does not support descriptions or inline editing. */

--- a/web/src/app/craft/components/setup-requests/SetupCard.tsx
+++ b/web/src/app/craft/components/setup-requests/SetupCard.tsx
@@ -4,7 +4,6 @@ import { useEffect, useRef, useState } from "react";
 import { useSWRConfig } from "swr";
 
 import { Button, Text } from "@opal/components";
-import { Content } from "@opal/layouts";
 import { cn } from "@opal/utils";
 import {
   ConnectAppDecision,
@@ -193,21 +192,21 @@ export default function SetupCard({
         <div
           data-testid="setup-card"
           className={cn(
-            "rounded-08 border bg-background-neutral-00 p-3 transition-colors",
+            "rounded-08 border-[0.5px] px-3 py-2 transition-colors",
             connected ? "border-status-success-03" : "border-status-error-03"
           )}
         >
-          <Content
-            sizePreset="secondary"
-            variant="body"
-            icon={Logo}
-            color={connected ? "muted" : "danger"}
-            title={
-              connected
+          <div className="flex min-w-0 items-center gap-1.5">
+            <Logo className="size-4 shrink-0" />
+            <Text
+              font="main-ui-action"
+              color={connected ? undefined : "text-03"}
+            >
+              {connected
                 ? `${appName} connected.`
-                : `Skipped connecting ${appName}.`
-            }
-          />
+                : `Skipped connecting ${appName}.`}
+            </Text>
+          </div>
         </div>
       </CometEdge>
     );
@@ -217,17 +216,17 @@ export default function SetupCard({
     <CometEdge active settled={false} tone="info" speedSeconds={3.6}>
       <div
         data-testid="setup-card"
-        className="rounded-08 border border-status-info-03 bg-background-neutral-00 p-3 flex flex-col gap-2"
+        className="rounded-08 border-[0.5px] border-status-info-03 px-3 py-2 flex flex-col gap-2"
       >
-        <Content
-          sizePreset="main-ui"
-          variant="section"
-          icon={Logo}
-          title={`Connect ${appName}`}
-          description={
-            reason ?? `The agent needs ${appName} to continue this task.`
-          }
-        />
+        <div className="flex flex-col gap-1.5">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <Logo className="size-4 shrink-0" />
+            <Text font="main-ui-action">{`Connect ${appName}`}</Text>
+          </div>
+          <Text as="p" font="main-ui-muted" color="text-03">
+            {reason ?? `The agent needs ${appName} to continue this task.`}
+          </Text>
+        </div>
         {error && (
           <Text font="secondary-body" color="text-03">
             {error}

--- a/web/src/app/craft/components/setup-requests/SetupCard.tsx
+++ b/web/src/app/craft/components/setup-requests/SetupCard.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useSWRConfig } from "swr";
 
 import { Button, Text } from "@opal/components";
+import { Content } from "@opal/layouts";
 import { cn } from "@opal/utils";
 import {
   ConnectAppDecision,
@@ -218,15 +219,16 @@ export default function SetupCard({
         data-testid="setup-card"
         className="rounded-08 border-[0.5px] border-status-info-03 px-3 py-2 flex flex-col gap-2"
       >
-        <div className="flex flex-col gap-1.5">
-          <div className="flex min-w-0 items-center gap-1.5">
-            <Logo className="size-4 shrink-0" />
-            <Text font="main-ui-action">{`Connect ${appName}`}</Text>
-          </div>
-          <Text as="p" font="main-ui-muted" color="text-03">
-            {reason ?? `The agent needs ${appName} to continue this task.`}
-          </Text>
-        </div>
+        <Content
+          sizePreset="main-ui"
+          variant="section"
+          icon={Logo}
+          title={`Connect ${appName}`}
+          description={
+            reason ?? `The agent needs ${appName} to continue this task.`
+          }
+          descriptionFont="main-ui-muted"
+        />
         {error && (
           <Text font="secondary-body" color="text-03">
             {error}


### PR DESCRIPTION
## Description

The connect-app card did not match the transcript it renders in. It drew a
white `background-neutral-00` surface against a transparent transcript, and it
set its reason text at 12px where the surrounding cards use 14px. It read as a
foreign element rather than one more row in the column.

This aligns it with the skill card and the other cards in Craft:

- Drop the white background so the card sits on the transcript surface.
- Adopt the shared box: `px-3 py-2` and a `0.5px` border, so consecutive cards
  line up instead of stepping in and out.
- Lift the reason text to the shared 14/400.

`Content` from `@opal/layouts` is replaced with explicit `Text` nodes. Its
`variant="section"` preset pins the description to 12px and gives no way to opt
out, which is what produced the size mismatch. The icon, the title, the reason,
and all user-visible copy are unchanged.

## How Has This Been Tested?

before:
<img width="833" height="304" alt="Screenshot 2026-08-20 at 10 15 18" src="https://github.com/user-attachments/assets/26b86a3f-db78-4116-b519-05c02bcf22e9" />


After:
<img width="830" height="204" alt="Screenshot 2026-08-20 at 10 13 18" src="https://github.com/user-attachments/assets/831fd792-b952-450b-abbc-430dbe2afe6e" />

- `bun run test src/app/craft/components/setup-requests/SetupCard.test.tsx` — 1
  test, passing.
- `pre-commit run --files web/src/app/craft/components/setup-requests/SetupCard.tsx`
  — oxfmt, oxlint, and the TypeScript type check all pass.
- Verified in the browser on a local cluster: checked the pending, connected,
  and skipped states, and confirmed the card's box now aligns with the skill
  card above it in the same transcript.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Craft connect-app SetupCard with its transcript. Previously the card drew a white surface and used 12px reason text; now it inherits the transcript surface, uses shared px-3/py-2 with a 0.5px border to match the skill card, and renders the reason at 14/400.

- Adds optional `descriptionFont` to `@opal/layouts` `ContentMd` (and its components); the pending state uses it to keep the shared Content layout while matching transcript typography.
- Settled (connected/skipped) row uses a lightweight icon + `Text` line; copy and state logic are unchanged; borders remain status-driven.
- Backward-compatible API addition; no migration required. Verify visual parity across pending, connected, and skipped.

<sup>Written for commit 1933fc85fa8b6e8371226155a4ce963ce9ddf436. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



