### PR TITLE
feat(craft): propose_scheduled_task tool

### DIFF
--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -203,6 +203,12 @@ _OPENCODE_CONNECT_APP_PLUGIN_PATH = "/workspace/opencode-plugins/connect-app.ts"
 _OPENCODE_TURN_BUDGET_PLUGIN_PATH = "/workspace/opencode-plugins/turn-budget.ts"
 # Surfaces the `webapp` tool (start/status/logs/restart); always on.
 _OPENCODE_WEBAPP_PLUGIN_PATH = "/workspace/opencode-plugins/webapp.ts"
+# Surfaces the no-op `propose_scheduled_task` tool; always on. Unlike
+# connect_app it needs no permission interception: the persisted tool call is
+# what the approval card is built from.
+_OPENCODE_SCHEDULED_TASK_PROPOSAL_PLUGIN_PATH = (
+    "/workspace/opencode-plugins/scheduled-task-proposal.ts"
+)
 _MUTABLE_SANDBOX_IMAGE_TAGS = {"latest", "beta", "edge"}
 
 # In-container opencode-history archive builder: reuses the sandbox_daemon
@@ -850,6 +856,7 @@ class DockerSandboxManager(SandboxManager):
                 _OPENCODE_CONNECT_APP_PLUGIN_PATH,
                 _OPENCODE_TURN_BUDGET_PLUGIN_PATH,
                 _OPENCODE_WEBAPP_PLUGIN_PATH,
+                _OPENCODE_SCHEDULED_TASK_PROPOSAL_PLUGIN_PATH,
             ]
             if SANDBOX_PROXY_HOST:
                 plugins.append(_OPENCODE_SESSION_TAG_PLUGIN_PATH)

--- a/backend/onyx/server/features/build/sandbox/image/opencode-plugins/scheduled-task-proposal.ts
+++ b/backend/onyx/server/features/build/sandbox/image/opencode-plugins/scheduled-task-proposal.ts
@@ -1,0 +1,111 @@
+// A `propose_scheduled_task` tool the agent calls to suggest a recurring task.
+// It creates nothing. The completed tool call persists into the build message,
+// the api-server renders an approval card from it, and creating the real task
+// happens only when the user approves (see the proposals decision endpoint).
+//
+// Unlike `connect-app.ts` this does NOT call `context.ask`: parking the turn
+// would cap the user's review at SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS (180s),
+// and a permission answer cannot carry the user's edits back to the agent.
+// The tool returns immediately and the turn ends normally.
+//
+// Module resolution: this file lives in /workspace/opencode-plugins, which has
+// no node_modules, so a bare runtime `import` of the SDK can't resolve. The type
+// import is erased; the `tool` helper is loaded at runtime by absolute path from
+// opencode's bundled SDK (same approach as the other plugins here).
+
+import type { Plugin } from "@opencode-ai/plugin";
+import type { tool as ToolFactory } from "@opencode-ai/plugin/tool";
+
+const SDK_TOOL_PATHS = [
+  "/home/sandbox/.opencode/node_modules/@opencode-ai/plugin/dist/tool.js",
+  "/home/sandbox/.config/opencode/node_modules/@opencode-ai/plugin/dist/tool.js",
+];
+
+async function loadToolFactory(): Promise<typeof ToolFactory> {
+  for (const path of SDK_TOOL_PATHS) {
+    try {
+      return (await import(path)).tool;
+    } catch {
+      continue;
+    }
+  }
+  throw new Error("could not resolve the @opencode-ai/plugin tool helper");
+}
+
+export const ScheduledTaskProposal: Plugin = async () => {
+  const tool = await loadToolFactory();
+
+  return {
+    tool: {
+      propose_scheduled_task: tool({
+        description:
+          "Propose a recurring scheduled task for the user to approve. " +
+          "This does NOT create the task: it shows the user a card they " +
+          "review, edit, and approve themselves. Call it once, then continue " +
+          "and tell the user you have proposed it. Do not wait for a decision, " +
+          "do not ask whether they approved, do not claim the task exists, and " +
+          "do not call this again for the same request. The user may change any " +
+          "field before approving, so describe what you proposed rather than " +
+          "what will run. The prompt runs later with no chat history, so it must " +
+          "be self-contained.",
+        args: {
+          name: tool.schema
+            .string()
+            .describe("Short label for the task, e.g. 'Weekday backlog digest'"),
+          prompt: tool.schema
+            .string()
+            .describe(
+              "The instruction to run on each fire. Must stand alone: it runs " +
+                "in a fresh session with none of this conversation's context."
+            ),
+          schedule_mode: tool.schema
+            .enum(["interval", "daily_weekly"])
+            .describe(
+              "'interval' repeats every N minutes/hours. 'daily_weekly' runs " +
+                "at a time of day on chosen weekdays. No other mode is supported."
+            ),
+          interval_unit: tool.schema
+            .enum(["minutes", "hours"])
+            .optional()
+            .describe("interval mode only"),
+          interval_every: tool.schema
+            .number()
+            .int()
+            .min(1)
+            .optional()
+            .describe(
+              "interval mode only. Max 59 for minutes and 23 for hours; use a " +
+                "larger unit instead of exceeding those."
+            ),
+          time_of_day: tool.schema
+            .string()
+            .optional()
+            .describe(
+              "daily_weekly mode only. 24-hour HH:MM in the USER'S LOCAL time. " +
+                "Never convert to UTC; the app does that when they approve."
+            ),
+          weekdays: tool.schema
+            .array(tool.schema.number().int().min(0).max(6))
+            .optional()
+            .describe(
+              "daily_weekly mode only. 0 is Sunday through 6 is Saturday. " +
+                "Omit or leave empty for every day."
+            ),
+        },
+        async execute() {
+          // Deliberately inert. The args are what matter: they persist with the
+          // tool call and seed the approval card.
+          return (
+            "Proposal shown to the user for review. They may edit any field " +
+            "before approving, so the final task may differ from what you " +
+            "proposed. Nothing is scheduled yet and you will not be told the " +
+            "outcome in this turn. Tell the user you have proposed it and that " +
+            "it will run once they approve the card."
+          );
+        },
+      }),
+    },
+  };
+};
+
+export default ScheduledTaskProposal;

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -181,6 +181,12 @@ _OPENCODE_CONNECT_APP_PLUGIN_PATH = "/workspace/opencode-plugins/connect-app.ts"
 _OPENCODE_TURN_BUDGET_PLUGIN_PATH = "/workspace/opencode-plugins/turn-budget.ts"
 # Surfaces the `webapp` tool (start/status/logs/restart); always on.
 _OPENCODE_WEBAPP_PLUGIN_PATH = "/workspace/opencode-plugins/webapp.ts"
+# Surfaces the no-op `propose_scheduled_task` tool; always on. Unlike
+# connect_app it needs no permission interception: the persisted tool call is
+# what the approval card is built from.
+_OPENCODE_SCHEDULED_TASK_PROPOSAL_PLUGIN_PATH = (
+    "/workspace/opencode-plugins/scheduled-task-proposal.ts"
+)
 
 
 _PROXY_RESOLVE_RETRY_ATTEMPTS = 5
@@ -1113,6 +1119,7 @@ class KubernetesSandboxManager(SandboxManager):
                         _OPENCODE_CONNECT_APP_PLUGIN_PATH,
                         _OPENCODE_TURN_BUDGET_PLUGIN_PATH,
                         _OPENCODE_WEBAPP_PLUGIN_PATH,
+                        _OPENCODE_SCHEDULED_TASK_PROPOSAL_PLUGIN_PATH,
                         _OPENCODE_SESSION_TAG_PLUGIN_PATH,
                     ],
                 )

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -87,6 +87,10 @@ _PERMISSIONS_TEMPLATE: dict[str, Any] = {
     # Connect-app tool: a no-op tool the agent calls to request connecting an
     # external app it isn't set up for.
     "connect_app": "ask",
+    # Scheduled-task proposal tool: a no-op tool that only records a proposal
+    # for the user to approve. "allow" rather than "ask" because it creates
+    # nothing; the approval happens on the card, not in the turn.
+    "propose_scheduled_task": "allow",
 }
 
 _TMP_EXTERNAL_DIRECTORY_RULES: dict[str, str] = {

--- a/backend/onyx/server/features/build/scheduled_tasks/proposals.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/proposals.py
@@ -1,0 +1,42 @@
+"""Shared vocabulary for agent-proposed scheduled tasks.
+
+A proposal has no table of its own. The agent's ``propose_scheduled_task``
+call already persists its arguments into ``build_message.message_metadata``
+(see ``streaming.persist_sandbox_event``), so the transcript row IS the
+proposal. Approving one records the decision back onto that same row under
+``PROPOSAL_ANNOTATION_KEY``.
+
+Constants only: this module is imported by both the db layer and the API
+layer, so it must stay free of either.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+# Tool name declared by opencode-plugins/scheduled-task-proposal.ts. Matched
+# against ``message_metadata["_meta"]["toolName"]``, never ``title``: the raw
+# name only survives in ``_meta`` (``_tool_title`` maps unknown tools to
+# "Running tool").
+PROPOSAL_TOOL_NAME = "propose_scheduled_task"
+
+# Top-level key holding our decision annotation. Namespaced so it cannot
+# collide with the ACP packet fields the rest of the metadata mirrors.
+PROPOSAL_ANNOTATION_KEY = "onyxProposal"
+
+
+class ProposalDecision(str, Enum):
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+
+
+class ProposalOutcome(str, Enum):
+    """What a decision request actually did.
+
+    ALREADY_DECIDED is not an error: a card restored from an old transcript
+    can be stale, and the caller needs to reconcile rather than to fail.
+    """
+
+    CREATED = "CREATED"
+    REJECTED = "REJECTED"
+    ALREADY_DECIDED = "ALREADY_DECIDED"

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_proposal_persistence.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_proposal_persistence.py
@@ -1,0 +1,131 @@
+"""The scheduled-task proposal card is rendered from the persisted tool call,
+and its approval is recorded back onto that same message. Both rest on one
+property of existing code: a completed tool call persists its arguments and
+its raw tool name into ``build_message.message_metadata``.
+
+These tests pin that property through the real emitter and the real
+persistence path, so the design fails loudly here rather than silently in the
+UI if either changes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.db.models import BuildMessage, BuildSession
+from onyx.server.features.build.sandbox.event_schema import ToolCallProgress
+from onyx.server.features.build.sandbox.opencode.serve_client import (
+    _emit_tool_events,
+    _TurnState,
+)
+from onyx.server.features.build.session.streaming import (
+    BuildStreamingState,
+    persist_sandbox_event,
+)
+
+PROPOSAL_TOOL = "propose_scheduled_task"
+
+
+# What opencode publishes for a completed call to the proposal tool.
+def _completed_part(args: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "callID": "call_proposal_1",
+        "tool": PROPOSAL_TOOL,
+        "state": {"status": "completed", "input": args},
+    }
+
+
+def _proposal_args() -> dict[str, Any]:
+    return {
+        "name": "Weekday backlog digest",
+        "prompt": "Check my Linear backlog and summarise what moved.",
+        "schedule": {
+            "mode": "daily_weekly",
+            "time_of_day": "09:00",
+            "weekdays": [1, 2, 3, 4, 5],
+        },
+    }
+
+
+def test_emitter_carries_tool_name_and_args() -> None:
+    """The raw tool name rides in ``_meta``, not ``title``.
+
+    ``_tool_title`` maps unknown tools to "Running tool", so anything matching
+    on the title would never fire for a plugin-declared tool.
+    """
+    args = _proposal_args()
+    events = list(
+        _emit_tool_events(_completed_part(args), _TurnState(session_id="oc-session"))
+    )
+    progress = [e for e in events if isinstance(e, ToolCallProgress)]
+    assert progress, "a completed part must emit a ToolCallProgress"
+
+    dumped = progress[-1].model_dump(mode="json", by_alias=True, exclude_none=False)
+    assert dumped["_meta"]["toolName"] == PROPOSAL_TOOL
+    assert dumped["title"] != PROPOSAL_TOOL
+    assert dumped["rawInput"] == args
+    assert dumped["toolCallId"] == "call_proposal_1"
+
+
+def test_completed_tool_call_persists_args_and_tool_name(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session: BuildSession,
+) -> None:
+    """The proposal's contents reach Postgres without any new schema."""
+    args = _proposal_args()
+    events = list(
+        _emit_tool_events(_completed_part(args), _TurnState(session_id="oc-session"))
+    )
+    progress = [e for e in events if isinstance(e, ToolCallProgress)][-1]
+
+    state = BuildStreamingState(turn_index=0)
+    persist_sandbox_event(db_session, build_session.id, state, progress)
+    db_session.commit()
+
+    stored = (
+        db_session.execute(
+            select(BuildMessage).where(BuildMessage.session_id == build_session.id)
+        )
+        .scalars()
+        .all()
+    )
+    tool_calls = [
+        m for m in stored if m.message_metadata.get("type") == "tool_call_progress"
+    ]
+    assert len(tool_calls) == 1
+
+    metadata = tool_calls[0].message_metadata
+    assert metadata["_meta"]["toolName"] == PROPOSAL_TOOL
+    assert metadata["rawInput"] == args
+    assert metadata["toolCallId"] == "call_proposal_1"
+
+
+def test_pending_tool_call_does_not_persist(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session: BuildSession,
+) -> None:
+    """Only terminal calls persist, so the card never renders a half-made
+    proposal from a call still in flight."""
+    part = _completed_part(_proposal_args())
+    part["state"]["status"] = "pending"
+    for event in _emit_tool_events(part, _TurnState(session_id="oc-session")):
+        persist_sandbox_event(
+            db_session, build_session.id, BuildStreamingState(turn_index=0), event
+        )
+    db_session.commit()
+
+    stored = (
+        db_session.execute(
+            select(BuildMessage).where(BuildMessage.session_id == build_session.id)
+        )
+        .scalars()
+        .all()
+    )
+    assert [
+        m for m in stored if m.message_metadata.get("type") == "tool_call_progress"
+    ] == []

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_opencode_config.py
@@ -201,6 +201,20 @@ def test_base_config_keeps_sandbox_permissions_and_plugins() -> None:
     "config",
     [build_opencode_base_config(), build_provider_opencode_config(_gateway())],
 )
+def test_proposal_tool_is_allowed_not_asked(config: dict[str, Any]) -> None:
+    """The proposal tool must not be permission-gated.
+
+    Gating it "ask" like connect_app would park the turn on the user's review,
+    which caps it at the 180s approval timeout. Approval happens on the card
+    instead, so the tool itself just runs.
+    """
+    assert config["permission"]["propose_scheduled_task"] == "allow"
+
+
+@pytest.mark.parametrize(
+    "config",
+    [build_opencode_base_config(), build_provider_opencode_config(_gateway())],
+)
 def test_start_webapp_script_is_write_protected(config: dict[str, Any]) -> None:
     permissions = config["permission"]
     assert isinstance(permissions, dict)


### PR DESCRIPTION
## Description

Adds `propose_scheduled_task`, an opencode tool the agent calls to suggest a
recurring task to the user. This is the first piece of chat-driven scheduled
task creation; on its own it changes no user-visible behaviour.

The tool creates nothing. It is deliberately inert: the value is the completed
tool call, which persists its arguments into `build_message.message_metadata`.
A later PR renders an approval card from that record, and creating the real
task happens only when the user approves.

Two design points worth review:

**It returns immediately rather than calling `context.ask`.** The `connect_app`
tool parks the turn on a permission prompt, which is wrong here for two
reasons. It would cap the user's review at the 180s approval timeout, and a
permission answer is a yes or no, so it cannot carry back the edits the user
makes to the proposed name, prompt, or schedule. The permission is therefore
`allow`, not `ask`.

**Times are the user's local time.** The tool asks for `HH:MM` local and tells
the agent never to convert to UTC, because only the client knows the offset.
The conversion to the UTC cron the backend stores happens at approval.

`proposals.py` holds the shared vocabulary (tool name, annotation key, decision
and outcome enums) and is deliberately dependency-free so both the API layer
and the DB layer can import it without a cycle.

## How Has This Been Tested?

- `uv run pytest backend/tests/unit/onyx/server/features/craft/sandbox/test_opencode_config.py`
  — 19 tests passing, covering the new permission entry in both the pod-wide
  base config and the per-session config.
- `pre-commit run --files <the 7 changed files>` — ty, ruff, ruff format, lazy
  imports, and oxlint all pass.
- `backend/tests/external_dependency_unit/craft/test_scheduled_task_proposal_persistence.py`
  is added here but was **not** run on this branch: the local dev Postgres is 9
  revisions behind `main`, so the fixtures fail before reaching the assertions.
  This is pre-existing schema drift, unrelated to this change. The two tests
  pin the property the whole design rests on, through the real emitter and the
  real persistence path: a completed tool call persists its arguments and its
  raw tool name, and a pending one persists nothing. The tool name rides in
  `_meta.toolName` rather than `title`, which falls back to "Running tool" for
  plugin-declared tools. Please confirm they pass in CI.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces an inert `propose_scheduled_task` tool the agent uses to suggest recurring tasks; a completed call persists its args into the build message for a later approval card. No task is created and there is no user-visible change yet.

- Plugin `scheduled-task-proposal.ts` exposes `propose_scheduled_task`, returns immediately (no `context.ask`), and is permission `allow` to avoid 180s turn parking and to let the user edit fields on the approval card.
- Times are user-local (HH:MM). UTC conversion happens only on approval.
- Wired into both Docker and Kubernetes sandbox plugin lists; always on.
- Shared constants in `backend/onyx/server/features/build/scheduled_tasks/proposals.py` define the tool name, annotation key, and decision/outcome enums for DB/API use without deps.
- Persistence relies on completed tool calls carrying `_meta.toolName` and `rawInput`; pending calls do not persist. Tests cover this and the permission config.
- No schema or migration changes. The proposal is the transcript row (`build_message.message_metadata`), with the decision recorded under `onyxProposal`. Uses `@opencode-ai/plugin` (tool helper loaded from the bundled SDK).

<sup>Written for commit 4fe97d5e48facbab56e96faa40de1e772216e00a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

