### PR TITLE
perf(docker): install only the Playwright headless shell

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -111,8 +111,12 @@ COPY --from=builder \
     /usr/local/bin/playwright \
     /usr/local/bin/
 
-# Install the Chromium browser used by Playwright and its OS-level runtime libraries. Must run after
+# Install the Chromium build used by Playwright and its OS-level runtime libraries. Must run after
 # the site-packages copy above so the playwright CLI is available.
+#
+# `--only-shell` installs the headless shell and skips the full headed Chromium build (~364 MB). Every
+# launch site in the backend passes headless=True with no channel, so Playwright picks the shell.
+# Remove the flag if a call site ever needs a headed browser or a branded channel.
 #
 # perl-base is part of the base Python Debian image but not needed for Onyx functionality; it is
 # removed for CVE surface reduction (requires --allow-remove-essential). It must be removed AFTER the
@@ -121,7 +125,7 @@ COPY --from=builder \
 # chromium runtime libs (libnss3, libnspr4, etc.) that autoremove swept up in the cascade. The
 # runtime image stays perl-free from here on.
 RUN ln -s /usr/local/bin/supervisord /usr/bin/supervisord && \
-    playwright install chromium && \
+    playwright install --only-shell chromium && \
     playwright install-deps chromium && \
     apt-get remove -y --allow-remove-essential perl-base && \
     apt-get autoremove -y && \


### PR DESCRIPTION
## What

`backend/Dockerfile` ran `playwright install chromium`, which installs **two** browser builds into `/app/.cache/ms-playwright/`:

| Build | Size |
| --- | --- |
| `chromium-1208` (full, headed) | 364 MB |
| `chromium_headless_shell-1208` | 254 MB |

Both Playwright launch sites in the backend pass `headless=True` with no `channel=`:

- `backend/onyx/utils/playwright_fetch.py:85`
- `backend/onyx/connectors/highspot/utils.py:37`

Playwright resolves that to the headless shell. The full headed build was installed on every image and never started — confirmed live in the image: the spawned process was `chrome-headless-shell`.

## Change

One flag: `playwright install --only-shell chromium`. Supported on the pinned Playwright 1.58.

## Result

**−364 MB uncompressed** on `onyxdotapp/onyx-backend:edge` (3.19 GB → ~2.83 GB). No behavior change — verified inside the image that a headless render works on the identical Chromium 145.0.7632.6.

The Dockerfile comment records why the flag is there, so a future call site that needs a headed browser or a branded channel knows to drop it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs only the Playwright headless shell in the backend image to drop the unused full Chromium build. Old behavior installed both via `playwright install chromium`; new behavior uses `playwright install --only-shell chromium`, reducing image size by ~364 MB with no behavior change.

- Both backend launch sites run headless with no channel, so `playwright` already resolves to the shell.
- Required if you need a headed browser or a branded channel later: remove `--only-shell` in the Dockerfile to restore the full build.
- Verified on pinned `playwright` 1.58; headless render works on the same Chromium 145.0.7632.6.

<sup>Written for commit 196c17ed500296c0076b2e120f195864f6f6b164. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

