### PR TITLE
refactor(oauth): share authorization attempts across OAuth flows

### DIFF
--- a/backend/onyx/cache/interface.py
+++ b/backend/onyx/cache/interface.py
@@ -81,12 +81,27 @@ class CacheBackend(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def getdel(self, key: str) -> bytes | None:
+        """Atomically return and remove an unexpired value."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def set(
         self,
         key: str,
         value: str | bytes | int | float,
         ex: int | None = None,
     ) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def set_if_absent(
+        self,
+        key: str,
+        value: str | bytes | int | float,
+        ex: int | None = None,
+    ) -> bool:
+        """Set a value only if no unexpired value uses the key."""
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/backend/onyx/cache/postgres_backend.py
+++ b/backend/onyx/cache/postgres_backend.py
@@ -163,6 +163,27 @@ class PostgresCacheBackend(CacheBackend):
             return None
         return bytes(value)
 
+    def getdel(self, key: str) -> bytes | None:
+        from onyx.db.engine.sql_engine import get_session_with_tenant
+
+        stmt = (
+            delete(CacheStore)
+            .where(
+                CacheStore.key == key,
+                or_(
+                    CacheStore.expires_at.is_(None),
+                    CacheStore.expires_at > func.now(),
+                ),
+            )
+            .returning(CacheStore.value)
+        )
+        with get_session_with_tenant(tenant_id=self._tenant_id) as session:
+            value = session.execute(stmt).scalar_one_or_none()
+            session.commit()
+        if value is None:
+            return None
+        return bytes(value)
+
     def set(
         self,
         key: str,
@@ -188,6 +209,38 @@ class PostgresCacheBackend(CacheBackend):
         with get_session_with_tenant(tenant_id=self._tenant_id) as session:
             session.execute(stmt)
             session.commit()
+
+    def set_if_absent(
+        self,
+        key: str,
+        value: str | bytes | int | float,
+        ex: int | None = None,
+    ) -> bool:
+        from onyx.db.engine.sql_engine import get_session_with_tenant
+
+        value_bytes = _to_bytes(value)
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=ex)
+            if ex is not None
+            else None
+        )
+        stmt = (
+            pg_insert(CacheStore)
+            .values(key=key, value=value_bytes, expires_at=expires_at)
+            .on_conflict_do_update(
+                index_elements=[CacheStore.key],
+                set_={"value": value_bytes, "expires_at": expires_at},
+                where=(
+                    CacheStore.expires_at.is_not(None)
+                    & (CacheStore.expires_at <= func.now())
+                ),
+            )
+            .returning(CacheStore.key)
+        )
+        with get_session_with_tenant(tenant_id=self._tenant_id) as session:
+            stored_key = session.execute(stmt).scalar_one_or_none()
+            session.commit()
+        return stored_key is not None
 
     def delete(self, key: str) -> None:
         from onyx.db.engine.sql_engine import get_session_with_tenant

--- a/backend/onyx/cache/redis_backend.py
+++ b/backend/onyx/cache/redis_backend.py
@@ -55,6 +55,9 @@ class RedisCacheBackend(CacheBackend):
     def get(self, key: str) -> bytes | None:
         return self._r.get(key)
 
+    def getdel(self, key: str) -> bytes | None:
+        return self._r.getdel(key)
+
     def set(
         self,
         key: str,
@@ -62,6 +65,14 @@ class RedisCacheBackend(CacheBackend):
         ex: int | None = None,
     ) -> None:
         self._r.set(key, value, ex=ex)
+
+    def set_if_absent(
+        self,
+        key: str,
+        value: str | bytes | int | float,
+        ex: int | None = None,
+    ) -> bool:
+        return bool(self._r.set(key, value, ex=ex, nx=True))
 
     def delete(self, key: str) -> None:
         self._r.delete(key)

--- a/backend/onyx/oauth/authorization_attempt.py
+++ b/backend/onyx/oauth/authorization_attempt.py
@@ -102,7 +102,7 @@ class AuthorizationAttemptStore(Generic[PayloadT]):
             attempt.namespace != self._namespace
             or attempt.owner_id != owner_id
             or not secrets.compare_digest(attempt.state, state)
-            or attempt.is_expired(datetime.now(timezone.utc))
+            or attempt.expires_at <= datetime.now(timezone.utc)
         ):
             raise _invalid_attempt_error()
         return attempt

--- a/backend/onyx/oauth/authorization_attempt.py
+++ b/backend/onyx/oauth/authorization_attempt.py
@@ -1,0 +1,122 @@
+import hashlib
+import re
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Generic, cast
+
+from pydantic import ValidationError
+
+from onyx.cache.interface import CacheBackend
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.oauth.models import AuthorizationAttempt, PayloadT
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_NAMESPACE_PATTERN = re.compile(r"^[a-z][a-z0-9_-]*$")
+_KEY_PREFIX = "oauth:authorization_attempt:v1"
+_INVALID_ATTEMPT_MESSAGE = "Invalid or expired OAuth authorization attempt"
+MAX_AUTHORIZATION_ATTEMPT_TTL_SECONDS = 10 * 60
+
+
+class AuthorizationAttemptStore(Generic[PayloadT]):
+    """Stores typed OAuth attempts in a tenant-scoped cache."""
+
+    def __init__(
+        self,
+        cache: CacheBackend,
+        *,
+        namespace: str,
+        payload_type: type[PayloadT],
+        ttl_seconds: int,
+    ) -> None:
+        if not _NAMESPACE_PATTERN.fullmatch(namespace) or len(namespace) > 64:
+            raise ValueError("OAuth attempt namespace is invalid")
+        if not 0 < ttl_seconds <= MAX_AUTHORIZATION_ATTEMPT_TTL_SECONDS:
+            raise ValueError(
+                "OAuth attempt TTL must be between 1 and "
+                f"{MAX_AUTHORIZATION_ATTEMPT_TTL_SECONDS} seconds"
+            )
+
+        self._cache = cache
+        self._namespace = namespace
+        self._attempt_type = cast(
+            type[AuthorizationAttempt[PayloadT]],
+            AuthorizationAttempt.__class_getitem__(payload_type),
+        )
+        self._ttl_seconds = ttl_seconds
+
+    def store(
+        self,
+        *,
+        owner_id: str,
+        payload: PayloadT,
+        state: str | None = None,
+    ) -> AuthorizationAttempt[PayloadT]:
+        """Persist a new attempt.
+
+        When supplied, ``state`` must come from a cryptographically secure
+        generator. Its entropy cannot be established through format validation.
+        """
+        expires_at = datetime.now(timezone.utc) + timedelta(seconds=self._ttl_seconds)
+        attempt = self._attempt_type(
+            namespace=self._namespace,
+            owner_id=owner_id,
+            state=state if state is not None else generate_authorization_state(),
+            expires_at=expires_at,
+            payload=payload,
+        )
+        stored = self._cache.set_if_absent(
+            self._key(attempt.owner_id, attempt.state),
+            attempt.model_dump_json(),
+            ex=self._ttl_seconds,
+        )
+        if not stored:
+            raise OnyxError(
+                OnyxErrorCode.CONFLICT,
+                "An OAuth authorization attempt already uses this state",
+            )
+        return attempt
+
+    def consume(
+        self,
+        *,
+        owner_id: str,
+        state: str,
+    ) -> AuthorizationAttempt[PayloadT]:
+        stored = self._cache.getdel(self._key(owner_id, state))
+        if stored is None:
+            raise _invalid_attempt_error()
+
+        try:
+            attempt = self._attempt_type.model_validate_json(stored)
+        except (ValidationError, ValueError, TypeError) as error:
+            logger.warning(
+                "Rejected malformed OAuth authorization attempt (%s)",
+                type(error).__name__,
+            )
+            raise _invalid_attempt_error() from error
+
+        if (
+            attempt.namespace != self._namespace
+            or attempt.owner_id != owner_id
+            or not secrets.compare_digest(attempt.state, state)
+            or attempt.is_expired(datetime.now(timezone.utc))
+        ):
+            raise _invalid_attempt_error()
+        return attempt
+
+    def _key(self, owner_id: str, state: str) -> str:
+        owner_hash = hashlib.sha256(owner_id.encode()).hexdigest()
+        state_hash = hashlib.sha256(state.encode()).hexdigest()
+        return f"{_KEY_PREFIX}:{self._namespace}:{owner_hash}:{state_hash}"
+
+
+def generate_authorization_state() -> str:
+    """Generate a 256-bit, URL-safe OAuth state value."""
+    return secrets.token_urlsafe(32)
+
+
+def _invalid_attempt_error() -> OnyxError:
+    return OnyxError(OnyxErrorCode.INVALID_INPUT, _INVALID_ATTEMPT_MESSAGE)

--- a/backend/onyx/oauth/models.py
+++ b/backend/onyx/oauth/models.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Generic, TypeVar
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
@@ -21,6 +20,3 @@ class AuthorizationAttempt(BaseModel, Generic[PayloadT]):
     state: str = Field(pattern=r"^[A-Za-z0-9_-]{22,1024}$")
     expires_at: AwareDatetime
     payload: PayloadT
-
-    def is_expired(self, now: datetime) -> bool:
-        return self.expires_at <= now

--- a/backend/onyx/oauth/models.py
+++ b/backend/onyx/oauth/models.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+from typing import Generic, TypeVar
+
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
+
+PayloadT = TypeVar("PayloadT", bound=BaseModel)
+
+
+class AuthorizationAttempt(BaseModel, Generic[PayloadT]):
+    """One pending authorization request for an authenticated user.
+
+    Payloads can contain identifiers, protocol context, and short-lived
+    transaction secrets such as PKCE verifiers. They must not contain long-lived
+    credentials or provider client secrets.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    namespace: str = Field(min_length=1, max_length=64)
+    owner_id: str = Field(min_length=1, max_length=256)
+    state: str = Field(pattern=r"^[A-Za-z0-9_-]{22,1024}$")
+    expires_at: AwareDatetime
+    payload: PayloadT
+
+    def is_expired(self, now: datetime) -> bool:
+        return self.expires_at <= now

--- a/backend/onyx/server/documents/standard_oauth.py
+++ b/backend/onyx/server/documents/standard_oauth.py
@@ -1,12 +1,13 @@
-import uuid
 from typing import Annotated, cast
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from fastapi import APIRouter, Depends, Query, Request
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
 from onyx.auth.pkce import generate_pkce_pair
+from onyx.cache.factory import get_cache_backend
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.interfaces import OAuthConnector
@@ -16,18 +17,21 @@ from onyx.db.enums import Permission
 from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.redis.redis_pool import get_redis_client
+from onyx.oauth.authorization_attempt import (
+    AuthorizationAttemptStore,
+    generate_authorization_state,
+)
 from onyx.server.documents.models import CredentialBase
 from onyx.utils.logger import setup_logger
 from onyx.utils.subclasses import find_all_subclasses_in_package
-from shared_configs.contextvars import get_current_tenant_id
+from onyx.utils.url import sanitize_next_url
 
 logger = setup_logger()
 
 router = APIRouter(prefix="/connector/oauth")
 
-_OAUTH_STATE_KEY_FMT = "oauth_state:{state}"
 _OAUTH_STATE_EXPIRATION_SECONDS = 10 * 60
+_OAUTH_ATTEMPT_NAMESPACE_PREFIX = "connector"
 
 # Cache for OAuth connectors, populated at module load time
 _OAUTH_CONNECTORS: dict[DocumentSource, type[OAuthConnector]] = {}
@@ -58,8 +62,15 @@ def _get_additional_kwargs(
     additional_kwargs_dict = {
         k: v for k, v in request.query_params.items() if k not in args_to_ignore
     }
+    _validate_additional_kwargs(connector_cls, additional_kwargs_dict)
+    return additional_kwargs_dict
+
+
+def _validate_additional_kwargs(
+    connector_cls: type[OAuthConnector], additional_kwargs: dict[str, str]
+) -> None:
     try:
-        connector_cls.AdditionalOauthKwargs(**additional_kwargs_dict)
+        connector_cls.AdditionalOauthKwargs(**additional_kwargs)
     except ValidationError as error:
         messages = {
             str(item["msg"]).removeprefix("Value error, ")
@@ -68,13 +79,101 @@ def _get_additional_kwargs(
         detail = "Invalid OAuth configuration: " + "; ".join(sorted(messages))
         raise OnyxError(OnyxErrorCode.VALIDATION_ERROR, detail) from error
 
-    return additional_kwargs_dict
 
+class _ConnectorOAuthAttemptPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
 
-class OAuthState(BaseModel):
-    desired_return_url: str
+    desired_return_path: str
     additional_kwargs: dict[str, str]
     code_verifier: str | None = None
+
+    @field_validator("desired_return_path")
+    @classmethod
+    def validate_return_path(cls, value: str) -> str:
+        if sanitize_next_url(value) != value or any(
+            not character.isprintable() for character in value
+        ):
+            raise ValueError("OAuth return path must be a local application path")
+        return value
+
+
+def _authorization_attempt_store(
+    source: DocumentSource,
+) -> AuthorizationAttemptStore[_ConnectorOAuthAttemptPayload]:
+    return AuthorizationAttemptStore(
+        get_cache_backend(),
+        namespace=f"{_OAUTH_ATTEMPT_NAMESPACE_PREFIX}-{source.value}",
+        payload_type=_ConnectorOAuthAttemptPayload,
+        ttl_seconds=_OAUTH_STATE_EXPIRATION_SECONDS,
+    )
+
+
+def _attempt_payload(
+    desired_return_url: str,
+    additional_kwargs: dict[str, str],
+    code_verifier: str | None,
+) -> _ConnectorOAuthAttemptPayload:
+    try:
+        return_url = urlsplit(desired_return_url)
+    except ValueError as error:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "OAuth return URL is invalid",
+        ) from error
+
+    if return_url.scheme or return_url.netloc:
+        try:
+            web_domain = urlsplit(WEB_DOMAIN)
+            return_origin = (
+                return_url.scheme.lower(),
+                (return_url.hostname or "").lower(),
+                return_url.port
+                or (443 if return_url.scheme.lower() == "https" else 80),
+            )
+            web_origin = (
+                web_domain.scheme.lower(),
+                (web_domain.hostname or "").lower(),
+                web_domain.port
+                or (443 if web_domain.scheme.lower() == "https" else 80),
+            )
+        except ValueError as error:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "OAuth return URL is invalid",
+            ) from error
+        if return_origin != web_origin or (
+            return_url.username is not None or return_url.password is not None
+        ):
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "OAuth return URL must use the Onyx application origin",
+            )
+        desired_return_url = urlunsplit(
+            ("", "", return_url.path or "/", return_url.query, return_url.fragment)
+        )
+
+    try:
+        return _ConnectorOAuthAttemptPayload(
+            desired_return_path=desired_return_url,
+            additional_kwargs=additional_kwargs,
+            code_verifier=code_verifier,
+        )
+    except ValidationError as error:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "OAuth return path must be a local application path",
+        ) from error
+
+
+def _return_path_with_credential(return_path: str, credential_id: int) -> str:
+    parsed = urlsplit(return_path)
+    query = [
+        (key, value)
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if key != "credentialId"
+    ]
+    query.append(("credentialId", str(credential_id)))
+    return urlunsplit(("", "", parsed.path, urlencode(query), parsed.fragment))
 
 
 class AuthorizeResponse(BaseModel):
@@ -99,11 +198,10 @@ def oauth_authorize(
     request: Request,
     source: DocumentSource,
     desired_return_url: Annotated[str | None, Query()] = None,
-    _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
 ) -> AuthorizeResponse:
     """Initiates the OAuth flow by redirecting to the provider's auth page"""
 
-    tenant_id = get_current_tenant_id()
     connector_cls = _get_enabled_oauth_connector(source)
     base_url = WEB_DOMAIN
 
@@ -112,27 +210,25 @@ def oauth_authorize(
     )
 
     if not desired_return_url:
-        desired_return_url = f"{base_url}/admin/connectors/{source}?step=0"
-
+        desired_return_url = f"/admin/connectors/{source}?step=0"
     code_verifier = None
     code_challenge = None
     if connector_cls.supports_pkce:
         code_verifier, code_challenge = generate_pkce_pair()
+    payload = _attempt_payload(
+        desired_return_url,
+        additional_kwargs,
+        code_verifier,
+    )
 
-    state = str(uuid.uuid4())
+    state = generate_authorization_state()
     redirect_url = connector_cls.oauth_authorization_url(
         base_url, state, additional_kwargs, code_challenge
     )
-    oauth_state = OAuthState(
-        desired_return_url=desired_return_url,
-        additional_kwargs=additional_kwargs,
-        code_verifier=code_verifier,
-    )
-    redis_client = get_redis_client(tenant_id=tenant_id)
-    redis_client.set(
-        _OAUTH_STATE_KEY_FMT.format(state=state),
-        oauth_state.model_dump_json(),
-        ex=_OAUTH_STATE_EXPIRATION_SECONDS,
+    _authorization_attempt_store(source).store(
+        owner_id=str(user.id),
+        state=state,
+        payload=payload,
     )
 
     return AuthorizeResponse(redirect_url=redirect_url)
@@ -152,44 +248,35 @@ def oauth_callback(
 ) -> CallbackResponse:
     """Handles the OAuth callback and exchanges the code for tokens"""
     connector_cls = _get_enabled_oauth_connector(source)
-
-    redis_client = get_redis_client()
-    oauth_state_bytes = redis_client.getdel(_OAUTH_STATE_KEY_FMT.format(state=state))
-    if not oauth_state_bytes:
+    attempt = _authorization_attempt_store(source).consume(
+        owner_id=str(user.id),
+        state=state,
+    )
+    _validate_additional_kwargs(connector_cls, attempt.payload.additional_kwargs)
+    if connector_cls.supports_pkce and not attempt.payload.code_verifier:
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, "Invalid OAuth state")
-    try:
-        oauth_state = OAuthState.model_validate_json(oauth_state_bytes)
-    except ValidationError as error:
-        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "Invalid OAuth state") from error
 
-    base_url = WEB_DOMAIN
     token_info = connector_cls.oauth_code_to_token(
-        base_url,
+        WEB_DOMAIN,
         code,
-        oauth_state.additional_kwargs,
-        oauth_state.code_verifier,
+        attempt.payload.additional_kwargs,
+        attempt.payload.code_verifier,
     )
-
-    credential_data = CredentialBase(
-        credential_json=token_info,
-        admin_public=True,
-        source=source,
-        name=f"{source.title()} OAuth Credential",
-    )
-
     credential = create_credential(
-        credential_data=credential_data,
+        credential_data=CredentialBase(
+            credential_json=token_info,
+            admin_public=True,
+            source=source,
+            name=f"{source.title()} OAuth Credential",
+        ),
         user=user,
         db_session=db_session,
     )
-
-    # Preserve existing query parameters in the requested return URL.
-    sep = "&" if "?" in oauth_state.desired_return_url else "?"
-    return CallbackResponse(
-        redirect_url=(
-            f"{oauth_state.desired_return_url}{sep}credentialId={credential.id}"
-        )
+    return_path = _return_path_with_credential(
+        attempt.payload.desired_return_path,
+        credential.id,
     )
+    return CallbackResponse(redirect_url=f"{WEB_DOMAIN.rstrip('/')}{return_path}")
 
 
 class OAuthAdditionalKwargDescription(BaseModel):

--- a/backend/tests/external_dependency_unit/cache/test_postgres_cache_backend.py
+++ b/backend/tests/external_dependency_unit/cache/test_postgres_cache_backend.py
@@ -36,11 +36,42 @@ class TestKV:
     def test_get_missing(self, pg_cache: PostgresCacheBackend) -> None:
         assert pg_cache.get(_key()) is None
 
+    def test_getdel_is_one_time(self, pg_cache: PostgresCacheBackend) -> None:
+        k = _key()
+        pg_cache.set(k, b"one-time")
+
+        assert pg_cache.getdel(k) == b"one-time"
+        assert pg_cache.getdel(k) is None
+
+    def test_getdel_rejects_expired_value(self, pg_cache: PostgresCacheBackend) -> None:
+        k = _key()
+        pg_cache.set(k, b"expired", ex=0)
+
+        assert pg_cache.getdel(k) is None
+
     def test_set_overwrite(self, pg_cache: PostgresCacheBackend) -> None:
         k = _key()
         pg_cache.set(k, b"first")
         pg_cache.set(k, b"second")
         assert pg_cache.get(k) == b"second"
+
+    def test_set_if_absent_does_not_overwrite(
+        self, pg_cache: PostgresCacheBackend
+    ) -> None:
+        k = _key()
+
+        assert pg_cache.set_if_absent(k, b"first", ex=10)
+        assert not pg_cache.set_if_absent(k, b"second", ex=10)
+        assert pg_cache.get(k) == b"first"
+
+    def test_set_if_absent_replaces_expired_value(
+        self, pg_cache: PostgresCacheBackend
+    ) -> None:
+        k = _key()
+        pg_cache.set(k, b"expired", ex=0)
+
+        assert pg_cache.set_if_absent(k, b"replacement", ex=10)
+        assert pg_cache.get(k) == b"replacement"
 
     def test_set_string_value(self, pg_cache: PostgresCacheBackend) -> None:
         k = _key()

--- a/backend/tests/external_dependency_unit/server/documents/test_salesforce_standard_oauth_real_dependencies.py
+++ b/backend/tests/external_dependency_unit/server/documents/test_salesforce_standard_oauth_real_dependencies.py
@@ -3,13 +3,13 @@
 from typing import Any
 from unittest.mock import MagicMock
 from urllib.parse import parse_qs, urlencode, urlsplit
-from uuid import UUID
 
 import pytest
 from fastapi import Request
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+from onyx.auth.pkce import compute_s256_challenge
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import (
     get_oauth_callback_uri,
@@ -19,11 +19,8 @@ from onyx.connectors.salesforce import connector as salesforce_connector
 from onyx.connectors.salesforce.models import SalesforceAuthenticationMethod
 from onyx.db.models import Credential
 from onyx.error_handling.exceptions import OnyxError
-from onyx.redis.redis_pool import get_redis_client
 from onyx.server.documents import standard_oauth
-from onyx.server.documents.standard_oauth import OAuthState
 from onyx.utils.sensitive import SensitiveValue
-from shared_configs.contextvars import get_current_tenant_id
 from tests.external_dependency_unit.conftest import create_test_user, delete_test_user
 
 _CLIENT_ID = "salesforce-edu-client"
@@ -33,19 +30,17 @@ _INSTANCE_URL = "https://na123.salesforce.com"
 _AUTHORIZATION_CODE = "salesforce-edu-authorization-code"
 _ACCESS_TOKEN = "salesforce-edu-access-token"
 _REFRESH_TOKEN = "salesforce-edu-refresh-token"
-_RETURN_URL = "https://onyx.example/admin/connectors/salesforce?step=0"
-_STATE_KEY_PREFIX = "oauth_state:"
-_INVALID_STATE = UUID("00000000-0000-0000-0000-000000000005")
+_RETURN_PATH = "/admin/connectors/salesforce?step=0"
 
 
-def _request(query_params: dict[str, str]) -> Request:
+def _request(query_params: dict[str, str] | None = None) -> Request:
     return Request(
         {
             "type": "http",
             "method": "GET",
             "path": "/connector/oauth/authorize/salesforce",
             "headers": [],
-            "query_string": urlencode(query_params).encode(),
+            "query_string": urlencode(query_params or {}).encode(),
         }
     )
 
@@ -73,14 +68,6 @@ def _configure_salesforce_oauth(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     return token_request
 
 
-def _state_key(state: str) -> str:
-    return f"{_STATE_KEY_PREFIX}{state}"
-
-
-def _raw_tenant_state_key(state: str) -> str:
-    return f"{get_current_tenant_id()}:{_state_key(state)}"
-
-
 def _credential_json(credential: Credential) -> dict[str, Any]:
     assert isinstance(credential.credential_json, SensitiveValue)
     return credential.credential_json.get_value(apply_mask=False)
@@ -93,9 +80,7 @@ def test_salesforce_standard_oauth_real_redis_postgres_flow(
 ) -> None:
     token_request = _configure_salesforce_oauth(monkeypatch)
     admin_user = create_test_user(db_session, "salesforce_oauth_admin", is_admin=True)
-    redis_client = get_redis_client()
     credential_id: int | None = None
-    state: str | None = None
 
     try:
         details = standard_oauth.oauth_details(
@@ -115,13 +100,13 @@ def test_salesforce_standard_oauth_real_redis_postgres_flow(
             }
         ]
 
-        authorize_response = standard_oauth.oauth_authorize(
+        authorize_result = standard_oauth.oauth_authorize(
             request=_request({"salesforce_my_domain_url": _MY_DOMAIN_URL}),
             source=DocumentSource.SALESFORCE,
-            desired_return_url=_RETURN_URL,
-            _=admin_user,
+            desired_return_url=_RETURN_PATH,
+            user=admin_user,
         )
-        authorization_url = urlsplit(authorize_response.redirect_url)
+        authorization_url = urlsplit(authorize_result.redirect_url)
         authorization_query = parse_qs(authorization_url.query)
         state = authorization_query["state"][0]
 
@@ -138,16 +123,7 @@ def test_salesforce_standard_oauth_real_redis_postgres_flow(
             )
         ]
 
-        stored_bytes = redis_client.raw_client.get(_raw_tenant_state_key(state))
-        assert isinstance(stored_bytes, bytes)
-        stored_state = OAuthState.model_validate_json(stored_bytes)
-        assert stored_state.desired_return_url == _RETURN_URL
-        assert stored_state.additional_kwargs == {
-            "salesforce_my_domain_url": _MY_DOMAIN_URL
-        }
-        assert stored_state.code_verifier
-
-        callback_response = standard_oauth.oauth_callback(
+        callback_result = standard_oauth.oauth_callback(
             source=DocumentSource.SALESFORCE,
             code=_AUTHORIZATION_CODE,
             state=state,
@@ -155,7 +131,11 @@ def test_salesforce_standard_oauth_real_redis_postgres_flow(
             user=admin_user,
         )
         credential_id = int(
-            parse_qs(urlsplit(callback_response.redirect_url).query)["credentialId"][0]
+            parse_qs(urlsplit(callback_result.redirect_url).query)["credentialId"][0]
+        )
+        assert callback_result.redirect_url == (
+            f"{standard_oauth.WEB_DOMAIN.rstrip('/')}{_RETURN_PATH}"
+            f"&credentialId={credential_id}"
         )
         db_session.expire_all()
         credential = db_session.get(Credential, credential_id)
@@ -177,7 +157,6 @@ def test_salesforce_standard_oauth_real_redis_postgres_flow(
             {"credential_id": credential_id},
         ).scalar_one()
         assert _ACCESS_TOKEN not in str(encrypted_value)
-        assert redis_client.raw_client.get(_raw_tenant_state_key(state)) is None
 
         request_data = token_request.call_args.kwargs["data"]
         assert set(request_data) == {
@@ -193,7 +172,10 @@ def test_salesforce_standard_oauth_real_redis_postgres_flow(
         assert request_data["client_id"] == _CLIENT_ID
         assert request_data["client_secret"] == _CLIENT_SECRET
         assert request_data["redirect_uri"] == authorization_query["redirect_uri"][0]
-        assert request_data["code_verifier"] == stored_state.code_verifier
+        assert (
+            compute_s256_challenge(request_data["code_verifier"])
+            == authorization_query["code_challenge"][0]
+        )
         assert token_request.call_args.kwargs["log_request_data"] is False
 
         with pytest.raises(OnyxError, match="Invalid OAuth state"):
@@ -206,8 +188,6 @@ def test_salesforce_standard_oauth_real_redis_postgres_flow(
             )
         token_request.assert_called_once()
     finally:
-        if state is not None:
-            redis_client.delete(_state_key(state))
         if credential_id is not None:
             credential = db_session.get(Credential, credential_id)
             if credential is not None:
@@ -225,12 +205,8 @@ def test_salesforce_standard_oauth_invalid_domain_and_disabled_config(
     admin_user = create_test_user(
         db_session, "salesforce_oauth_disabled_admin", is_admin=True
     )
-    redis_client = get_redis_client()
-    invalid_state_key = _state_key(str(_INVALID_STATE))
-    redis_client.delete(invalid_state_key)
 
     try:
-        monkeypatch.setattr(standard_oauth.uuid, "uuid4", lambda: _INVALID_STATE)
         with pytest.raises(OnyxError, match="Salesforce URL must use HTTPS"):
             standard_oauth.oauth_authorize(
                 request=_request(
@@ -242,13 +218,9 @@ def test_salesforce_standard_oauth_invalid_domain_and_disabled_config(
                     }
                 ),
                 source=DocumentSource.SALESFORCE,
-                desired_return_url=_RETURN_URL,
-                _=admin_user,
+                desired_return_url=_RETURN_PATH,
+                user=admin_user,
             )
-        assert (
-            redis_client.raw_client.get(_raw_tenant_state_key(str(_INVALID_STATE)))
-            is None
-        )
 
         monkeypatch.setattr(salesforce_connector, "SALESFORCE_CLIENT_SECRET", None)
         monkeypatch.setattr(salesforce_auth, "SALESFORCE_CLIENT_SECRET", None)
@@ -262,14 +234,9 @@ def test_salesforce_standard_oauth_invalid_domain_and_disabled_config(
             standard_oauth.oauth_authorize(
                 request=_request({"salesforce_my_domain_url": _MY_DOMAIN_URL}),
                 source=DocumentSource.SALESFORCE,
-                desired_return_url=_RETURN_URL,
-                _=admin_user,
+                desired_return_url=_RETURN_PATH,
+                user=admin_user,
             )
-        assert (
-            redis_client.raw_client.get(_raw_tenant_state_key(str(_INVALID_STATE)))
-            is None
-        )
     finally:
-        redis_client.delete(invalid_state_key)
         delete_test_user(db_session, admin_user)
         db_session.commit()

--- a/backend/tests/external_dependency_unit/server/documents/test_salesforce_standard_oauth_real_dependencies.py
+++ b/backend/tests/external_dependency_unit/server/documents/test_salesforce_standard_oauth_real_dependencies.py
@@ -178,7 +178,9 @@ def test_salesforce_standard_oauth_real_redis_postgres_flow(
         )
         assert token_request.call_args.kwargs["log_request_data"] is False
 
-        with pytest.raises(OnyxError, match="Invalid OAuth state"):
+        with pytest.raises(
+            OnyxError, match="Invalid or expired OAuth authorization attempt"
+        ):
             standard_oauth.oauth_callback(
                 source=DocumentSource.SALESFORCE,
                 code=_AUTHORIZATION_CODE,

--- a/backend/tests/unit/fakes.py
+++ b/backend/tests/unit/fakes.py
@@ -38,6 +38,10 @@ class FakeCache(CacheBackend):
     def get(self, key: str) -> bytes | None:
         return self.store.get(key)
 
+    def getdel(self, key: str) -> bytes | None:
+        self.expiries.pop(key, None)
+        return self.store.pop(key, None)
+
     def set(
         self,
         key: str,
@@ -47,6 +51,17 @@ class FakeCache(CacheBackend):
         self.store[key] = value if isinstance(value, bytes) else str(value).encode()
         if ex is not None:
             self.expiries[key] = ex
+
+    def set_if_absent(
+        self,
+        key: str,
+        value: str | bytes | int | float,
+        ex: int | None = None,
+    ) -> bool:
+        if key in self.store:
+            return False
+        self.set(key, value, ex=ex)
+        return True
 
     def delete(self, key: str) -> None:
         self.store.pop(key, None)

--- a/backend/tests/unit/onyx/cache/test_redis_backend.py
+++ b/backend/tests/unit/onyx/cache/test_redis_backend.py
@@ -94,3 +94,21 @@ def test_redis_cache_lock_extend_translates_lock_not_owned_error() -> None:
 
     with pytest.raises(CacheLockLostError):
         lock.extend(30.0)
+
+
+def test_redis_cache_getdel_delegates_atomic_consume() -> None:
+    redis_client = MagicMock(spec=TenantRedisClient)
+    redis_client.getdel.return_value = b"value"
+    backend = RedisCacheBackend(redis_client)
+
+    assert backend.getdel("attempt") == b"value"
+    redis_client.getdel.assert_called_once_with("attempt")
+
+
+def test_redis_cache_set_if_absent_uses_atomic_set() -> None:
+    redis_client = MagicMock(spec=TenantRedisClient)
+    redis_client.set.return_value = True
+    backend = RedisCacheBackend(redis_client)
+
+    assert backend.set_if_absent("attempt", b"value", ex=300)
+    redis_client.set.assert_called_once_with("attempt", b"value", ex=300, nx=True)

--- a/backend/tests/unit/onyx/chat/test_stop_signal_checker.py
+++ b/backend/tests/unit/onyx/chat/test_stop_signal_checker.py
@@ -29,6 +29,9 @@ class _MemoryCacheBackend(CacheBackend):
     def get(self, key: str) -> bytes | None:
         return self._store.get(key)
 
+    def getdel(self, key: str) -> bytes | None:
+        return self._store.pop(key, None)
+
     def set(
         self,
         key: str,
@@ -39,6 +42,17 @@ class _MemoryCacheBackend(CacheBackend):
             self._store[key] = value
         else:
             self._store[key] = str(value).encode()
+
+    def set_if_absent(
+        self,
+        key: str,
+        value: str | bytes | int | float,
+        ex: int | None = None,
+    ) -> bool:
+        if key in self._store:
+            return False
+        self.set(key, value, ex=ex)
+        return True
 
     def delete(self, key: str) -> None:
         self._store.pop(key, None)

--- a/backend/tests/unit/onyx/federated_connectors/test_oauth_utils.py
+++ b/backend/tests/unit/onyx/federated_connectors/test_oauth_utils.py
@@ -28,6 +28,9 @@ class _MemoryCacheBackend(CacheBackend):
     def get(self, key: str) -> bytes | None:
         return self._store.get(key)
 
+    def getdel(self, key: str) -> bytes | None:
+        return self._store.pop(key, None)
+
     def set(
         self,
         key: str,
@@ -39,6 +42,17 @@ class _MemoryCacheBackend(CacheBackend):
             self._store[key] = value
         else:
             self._store[key] = str(value).encode()
+
+    def set_if_absent(
+        self,
+        key: str,
+        value: str | bytes | int | float,
+        ex: int | None = None,
+    ) -> bool:
+        if key in self._store:
+            return False
+        self.set(key, value, ex=ex)
+        return True
 
     def delete(self, key: str) -> None:
         self._store.pop(key, None)

--- a/backend/tests/unit/onyx/oauth/test_authorization_attempt.py
+++ b/backend/tests/unit/onyx/oauth/test_authorization_attempt.py
@@ -1,0 +1,235 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pydantic import BaseModel, ConfigDict
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.oauth.authorization_attempt import AuthorizationAttemptStore
+from onyx.oauth.models import AuthorizationAttempt
+from tests.unit.fakes import FakeCache
+
+_STATE_ONE = "a" * 43
+_STATE_TWO = "b" * 43
+
+
+class _Payload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    target_id: int
+
+
+class _WrongPayload(BaseModel):
+    unexpected: bool
+
+
+def _store(
+    cache: FakeCache, namespace: str = "mcp"
+) -> AuthorizationAttemptStore[_Payload]:
+    return AuthorizationAttemptStore(
+        cache,
+        namespace=namespace,
+        payload_type=_Payload,
+        ttl_seconds=300,
+    )
+
+
+def test_store_generates_isolated_one_time_attempts() -> None:
+    cache = FakeCache()
+    store = _store(cache)
+
+    first = store.store(owner_id="user-1", payload=_Payload(target_id=1))
+    second = store.store(owner_id="user-1", payload=_Payload(target_id=2))
+
+    assert first.state != second.state
+    assert set(cache.expiries.values()) == {300}
+    assert all(
+        key.startswith("oauth:authorization_attempt:v1:mcp:") for key in cache.store
+    )
+    assert all(
+        component not in key
+        for key in cache.store
+        for component in ("user-1", first.state, second.state)
+    )
+    assert store.consume(owner_id="user-1", state=second.state) == second
+    assert store.consume(owner_id="user-1", state=first.state) == first
+    with pytest.raises(OnyxError) as error:
+        store.consume(owner_id="user-1", state=first.state)
+    assert error.value.error_code is OnyxErrorCode.INVALID_INPUT
+
+
+def test_attempt_is_bound_to_namespace_owner_and_state() -> None:
+    cache = FakeCache()
+    mcp_store = _store(cache)
+    connector_store = _store(cache, namespace="connector")
+    attempt = mcp_store.store(
+        owner_id="user-1",
+        state=_STATE_ONE,
+        payload=_Payload(target_id=1),
+    )
+
+    for store, owner_id, state in (
+        (connector_store, "user-1", attempt.state),
+        (mcp_store, "user-2", attempt.state),
+        (mcp_store, "user-1", _STATE_TWO),
+    ):
+        with pytest.raises(OnyxError, match="Invalid or expired"):
+            store.consume(owner_id=owner_id, state=state)
+
+    assert mcp_store.consume(owner_id="user-1", state=attempt.state) == attempt
+
+
+def test_same_state_is_isolated_between_owners() -> None:
+    store = _store(FakeCache())
+    first = store.store(
+        owner_id="user-1",
+        state=_STATE_ONE,
+        payload=_Payload(target_id=1),
+    )
+    second = store.store(
+        owner_id="user-2",
+        state=_STATE_ONE,
+        payload=_Payload(target_id=2),
+    )
+
+    assert store.consume(owner_id="user-2", state=second.state) == second
+    assert store.consume(owner_id="user-1", state=first.state) == first
+
+
+def test_attempt_supports_unicode_owner_id() -> None:
+    store = _store(FakeCache())
+    attempt = store.store(owner_id="用户-1", payload=_Payload(target_id=1))
+
+    assert store.consume(owner_id="用户-1", state=attempt.state) == attempt
+
+
+def test_store_does_not_overwrite_duplicate_state() -> None:
+    store = _store(FakeCache())
+    first = store.store(
+        owner_id="user-1",
+        state=_STATE_ONE,
+        payload=_Payload(target_id=1),
+    )
+
+    with pytest.raises(OnyxError) as error:
+        store.store(
+            owner_id="user-1",
+            state=_STATE_ONE,
+            payload=_Payload(target_id=2),
+        )
+
+    assert error.value.error_code is OnyxErrorCode.CONFLICT
+    assert store.consume(owner_id="user-1", state=_STATE_ONE) == first
+
+
+def test_consume_rejects_malformed_or_wrong_payload_and_removes_it() -> None:
+    cache = FakeCache()
+    store = _store(cache)
+    store.store(
+        owner_id="user-1",
+        state=_STATE_ONE,
+        payload=_Payload(target_id=1),
+    )
+    malformed_key = next(iter(cache.store))
+    cache.store[malformed_key] = b"not-json"
+
+    store.store(
+        owner_id="user-1",
+        state=_STATE_TWO,
+        payload=_Payload(target_id=1),
+    )
+    wrong_payload_key = next(key for key in cache.store if key != malformed_key)
+    cache.store[wrong_payload_key] = (
+        AuthorizationAttempt[_WrongPayload](
+            namespace="mcp",
+            owner_id="user-1",
+            state=_STATE_TWO,
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+            payload=_WrongPayload(unexpected=True),
+        )
+        .model_dump_json()
+        .encode()
+    )
+
+    for state in (_STATE_ONE, _STATE_TWO):
+        with pytest.raises(OnyxError, match="Invalid or expired"):
+            store.consume(owner_id="user-1", state=state)
+
+    assert malformed_key not in cache.store
+    assert wrong_payload_key not in cache.store
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("namespace", "connector"),
+        ("owner_id", "user-2"),
+        ("state", _STATE_TWO),
+    ],
+)
+def test_consume_rejects_and_removes_tampered_envelope(
+    field: str,
+    value: str,
+) -> None:
+    cache = FakeCache()
+    store = _store(cache)
+    attempt = store.store(
+        owner_id="user-1",
+        state=_STATE_ONE,
+        payload=_Payload(target_id=1),
+    )
+    key = next(iter(cache.store))
+    cache.store[key] = (
+        attempt.model_copy(update={field: value}).model_dump_json().encode()
+    )
+
+    with pytest.raises(OnyxError, match="Invalid or expired"):
+        store.consume(owner_id="user-1", state=_STATE_ONE)
+    with pytest.raises(OnyxError, match="Invalid or expired"):
+        store.consume(owner_id="user-1", state=_STATE_ONE)
+
+
+def test_consume_rejects_expired_attempt_after_atomic_removal() -> None:
+    cache = FakeCache()
+    store = _store(cache)
+    attempt = store.store(owner_id="user-1", payload=_Payload(target_id=1))
+    key = next(iter(cache.store))
+    cache.store[key] = (
+        attempt.model_copy(
+            update={"expires_at": datetime.now(timezone.utc) - timedelta(seconds=1)}
+        )
+        .model_dump_json()
+        .encode()
+    )
+
+    with pytest.raises(OnyxError, match="Invalid or expired"):
+        store.consume(owner_id="user-1", state=attempt.state)
+    with pytest.raises(OnyxError, match="Invalid or expired"):
+        store.consume(owner_id="user-1", state=attempt.state)
+
+
+@pytest.mark.parametrize("namespace", ["", "MCP", "mcp:oauth", "-mcp", "x" * 65])
+def test_store_rejects_invalid_namespace(namespace: str) -> None:
+    with pytest.raises(ValueError, match="namespace"):
+        _store(FakeCache(), namespace=namespace)
+
+
+@pytest.mark.parametrize("ttl_seconds", [0, 601])
+def test_store_rejects_out_of_range_ttl(ttl_seconds: int) -> None:
+    with pytest.raises(ValueError, match="TTL"):
+        AuthorizationAttemptStore(
+            FakeCache(),
+            namespace="mcp",
+            payload_type=_Payload,
+            ttl_seconds=ttl_seconds,
+        )
+
+
+@pytest.mark.parametrize("state", ["", "x", "invalid.state.with.dots"])
+def test_store_rejects_invalid_caller_state(state: str) -> None:
+    with pytest.raises(ValueError):
+        _store(FakeCache()).store(
+            owner_id="user-1",
+            state=state,
+            payload=_Payload(target_id=1),
+        )

--- a/backend/tests/unit/onyx/server/documents/test_standard_connector_oauth_pkce.py
+++ b/backend/tests/unit/onyx/server/documents/test_standard_connector_oauth_pkce.py
@@ -1,9 +1,11 @@
+import json
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
 from fastapi import Request
+from pydantic import Field
 from sqlalchemy.orm import Session
 
 from onyx.auth.pkce import compute_s256_challenge, generate_pkce_pair
@@ -13,9 +15,8 @@ from onyx.connectors.interfaces import OAuthConnector
 from onyx.connectors.linear.connector import LinearConnector
 from onyx.db.models import User
 from onyx.error_handling.exceptions import OnyxError
-from onyx.redis.tenant_redis_client import TenantRedisClient
 from onyx.server.documents import standard_oauth
-from onyx.server.documents.standard_oauth import OAuthState
+from tests.unit.fakes import FakeCache
 
 
 class DisabledOAuthConnector(OAuthConnector):
@@ -53,6 +54,9 @@ class DisabledOAuthConnector(OAuthConnector):
 class PKCEOAuthConnector(OAuthConnector):
     supports_pkce = True
 
+    class AdditionalOauthKwargs(OAuthConnector.AdditionalOauthKwargs):
+        instance: str = Field(default="default", min_length=1)
+
     @classmethod
     def oauth_id(cls) -> DocumentSource:
         return DocumentSource.LINEAR
@@ -78,8 +82,26 @@ class PKCEOAuthConnector(OAuthConnector):
         return {"access_token": "token"}
 
 
+class OtherOAuthConnector(PKCEOAuthConnector):
+    supports_pkce = False
+
+    @classmethod
+    def oauth_id(cls) -> DocumentSource:
+        return DocumentSource.SALESFORCE
+
+
 def _request(query_string: bytes = b"") -> Request:
     return Request({"type": "http", "query_string": query_string})
+
+
+def _user(user_id: str = "user-1") -> User:
+    return cast(User, SimpleNamespace(id=user_id))
+
+
+def _configure_cache(monkeypatch: pytest.MonkeyPatch) -> FakeCache:
+    cache = FakeCache()
+    monkeypatch.setattr(standard_oauth, "get_cache_backend", lambda: cache)
+    return cache
 
 
 def test_pkce_generator_uses_s256() -> None:
@@ -88,42 +110,39 @@ def test_pkce_generator_uses_s256() -> None:
     assert compute_s256_challenge(code_verifier) == code_challenge
 
 
-def test_authorize_stores_verifier_and_passes_challenge(
+def test_authorize_passes_pkce_challenge(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    redis_client = MagicMock()
+    _configure_cache(monkeypatch)
     authorization_url = MagicMock(return_value="https://provider.example/authorize")
     monkeypatch.setattr(
         standard_oauth,
         "_discover_oauth_connectors",
         lambda: {DocumentSource.LINEAR: PKCEOAuthConnector},
     )
-    monkeypatch.setattr(standard_oauth, "get_redis_client", lambda **_: redis_client)
     monkeypatch.setattr(
         standard_oauth, "generate_pkce_pair", lambda: ("verifier", "challenge")
     )
+    monkeypatch.setattr(standard_oauth, "WEB_DOMAIN", "https://onyx.example")
     monkeypatch.setattr(
         PKCEOAuthConnector, "oauth_authorization_url", authorization_url
     )
 
-    response = standard_oauth.oauth_authorize(
+    result = standard_oauth.oauth_authorize(
         request=_request(),
         source=DocumentSource.LINEAR,
-        desired_return_url="https://onyx.example/return",
-        _=cast(User, object()),
+        desired_return_url="/admin/connectors/linear?step=0",
+        user=_user(),
     )
 
-    assert response.redirect_url == "https://provider.example/authorize"
-    stored_state = OAuthState.model_validate_json(redis_client.set.call_args.args[1])
-    assert stored_state.code_verifier == "verifier"
-    authorization_url.assert_called_once()
+    assert result.redirect_url == "https://provider.example/authorize"
     assert authorization_url.call_args.args[3] == "challenge"
 
 
 def test_authorize_skips_pkce_for_existing_connector(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    redis_client = MagicMock()
+    _configure_cache(monkeypatch)
     authorization_url = MagicMock(return_value="https://linear.app/oauth/authorize")
     generate_pkce_pair_mock = MagicMock()
     monkeypatch.setattr(
@@ -131,40 +150,63 @@ def test_authorize_skips_pkce_for_existing_connector(
         "_discover_oauth_connectors",
         lambda: {DocumentSource.LINEAR: LinearConnector},
     )
-    monkeypatch.setattr(standard_oauth, "get_redis_client", lambda **_: redis_client)
     monkeypatch.setattr(standard_oauth, "generate_pkce_pair", generate_pkce_pair_mock)
     monkeypatch.setattr(LinearConnector, "oauth_authorization_url", authorization_url)
 
     standard_oauth.oauth_authorize(
         request=_request(),
         source=DocumentSource.LINEAR,
-        desired_return_url="https://onyx.example/return",
-        _=cast(User, object()),
+        desired_return_url="/admin/connectors/linear",
+        user=_user(),
     )
 
     generate_pkce_pair_mock.assert_not_called()
-    stored_state = OAuthState.model_validate_json(redis_client.set.call_args.args[1])
-    assert stored_state.code_verifier is None
     assert authorization_url.call_args.args[3] is None
 
 
-def test_callback_consumes_state_and_passes_verifier(
+def test_authorize_does_not_persist_attempt_when_provider_url_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    oauth_state = OAuthState(
-        desired_return_url="https://onyx.example/return",
-        additional_kwargs={"instance": "example"},
-        code_verifier="verifier",
+    cache = _configure_cache(monkeypatch)
+    monkeypatch.setattr(
+        standard_oauth,
+        "_discover_oauth_connectors",
+        lambda: {DocumentSource.LINEAR: LinearConnector},
     )
-    redis_client = MagicMock()
-    redis_client.getdel.return_value = oauth_state.model_dump_json().encode()
+    monkeypatch.setattr(
+        LinearConnector,
+        "oauth_authorization_url",
+        MagicMock(side_effect=ValueError("invalid provider configuration")),
+    )
+
+    with pytest.raises(ValueError, match="invalid provider configuration"):
+        standard_oauth.oauth_authorize(
+            request=_request(),
+            source=DocumentSource.LINEAR,
+            desired_return_url="/return",
+            user=_user(),
+        )
+
+    assert cache.store == {}
+
+
+def test_callback_consumes_owned_attempt_and_passes_stored_verifier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_cache(monkeypatch)
     code_to_token = MagicMock(return_value={"access_token": "token"})
+    authorization_url = MagicMock(return_value="https://provider.example/authorize")
     monkeypatch.setattr(
         standard_oauth,
         "_discover_oauth_connectors",
         lambda: {DocumentSource.LINEAR: PKCEOAuthConnector},
     )
-    monkeypatch.setattr(standard_oauth, "get_redis_client", lambda: redis_client)
+    monkeypatch.setattr(
+        standard_oauth, "generate_pkce_pair", lambda: ("verifier", "challenge")
+    )
+    monkeypatch.setattr(
+        PKCEOAuthConnector, "oauth_authorization_url", authorization_url
+    )
     monkeypatch.setattr(PKCEOAuthConnector, "oauth_code_to_token", code_to_token)
     monkeypatch.setattr(
         standard_oauth,
@@ -172,16 +214,25 @@ def test_callback_consumes_state_and_passes_verifier(
         lambda **_: SimpleNamespace(id=7),
     )
 
-    response = standard_oauth.oauth_callback(
+    standard_oauth.oauth_authorize(
+        request=_request(b"instance=example"),
+        source=DocumentSource.LINEAR,
+        desired_return_url="/return?existing=1#section",
+        user=_user(),
+    )
+    state = authorization_url.call_args.args[1]
+
+    result = standard_oauth.oauth_callback(
         source=DocumentSource.LINEAR,
         code="authorization-code",
-        state="state-id",
+        state=state,
         db_session=cast(Session, object()),
-        user=cast(User, object()),
+        user=_user(),
     )
 
-    assert response.redirect_url == "https://onyx.example/return?credentialId=7"
-    redis_client.getdel.assert_called_once_with("oauth_state:state-id")
+    assert result.redirect_url == (
+        f"{standard_oauth.WEB_DOMAIN}/return?existing=1&credentialId=7#section"
+    )
     code_to_token.assert_called_once_with(
         standard_oauth.WEB_DOMAIN,
         "authorization-code",
@@ -190,33 +241,218 @@ def test_callback_consumes_state_and_passes_verifier(
     )
 
 
-def test_callback_rejects_consumed_state(monkeypatch: pytest.MonkeyPatch) -> None:
-    redis_client = MagicMock()
-    redis_client.getdel.return_value = None
+def test_callback_is_bound_to_the_initiating_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_cache(monkeypatch)
+    authorization_url = MagicMock(return_value="https://linear.app/oauth/authorize")
+    code_to_token = MagicMock(return_value={"access_token": "token"})
+    create_credential_mock = MagicMock(return_value=SimpleNamespace(id=7))
+    monkeypatch.setattr(
+        standard_oauth,
+        "_discover_oauth_connectors",
+        lambda: {DocumentSource.LINEAR: LinearConnector},
+    )
+    monkeypatch.setattr(LinearConnector, "oauth_authorization_url", authorization_url)
+    monkeypatch.setattr(LinearConnector, "oauth_code_to_token", code_to_token)
+    monkeypatch.setattr(standard_oauth, "create_credential", create_credential_mock)
+
+    standard_oauth.oauth_authorize(
+        request=_request(),
+        source=DocumentSource.LINEAR,
+        desired_return_url="/return",
+        user=_user("user-1"),
+    )
+    state = authorization_url.call_args.args[1]
+
+    with pytest.raises(OnyxError, match="Invalid or expired"):
+        standard_oauth.oauth_callback(
+            source=DocumentSource.LINEAR,
+            code="authorization-code",
+            state=state,
+            db_session=cast(Session, object()),
+            user=_user("user-2"),
+        )
+    code_to_token.assert_not_called()
+    create_credential_mock.assert_not_called()
+
+    result = standard_oauth.oauth_callback(
+        source=DocumentSource.LINEAR,
+        code="authorization-code",
+        state=state,
+        db_session=cast(Session, object()),
+        user=_user("user-1"),
+    )
+    assert result.redirect_url == f"{standard_oauth.WEB_DOMAIN}/return?credentialId=7"
+
+
+def test_callback_through_wrong_source_does_not_consume_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_cache(monkeypatch)
+    authorization_url = MagicMock(return_value="https://linear.app/oauth/authorize")
+    linear_code_to_token = MagicMock(return_value={"access_token": "token"})
+    other_code_to_token = MagicMock(return_value={"access_token": "other"})
+    monkeypatch.setattr(
+        standard_oauth,
+        "_discover_oauth_connectors",
+        lambda: {
+            DocumentSource.LINEAR: LinearConnector,
+            DocumentSource.SALESFORCE: OtherOAuthConnector,
+        },
+    )
+    monkeypatch.setattr(LinearConnector, "oauth_authorization_url", authorization_url)
+    monkeypatch.setattr(LinearConnector, "oauth_code_to_token", linear_code_to_token)
+    monkeypatch.setattr(OtherOAuthConnector, "oauth_code_to_token", other_code_to_token)
+    monkeypatch.setattr(
+        standard_oauth,
+        "create_credential",
+        lambda **_: SimpleNamespace(id=7),
+    )
+
+    standard_oauth.oauth_authorize(
+        request=_request(),
+        source=DocumentSource.LINEAR,
+        desired_return_url="/return",
+        user=_user(),
+    )
+    state = authorization_url.call_args.args[1]
+
+    with pytest.raises(OnyxError, match="Invalid or expired"):
+        standard_oauth.oauth_callback(
+            source=DocumentSource.SALESFORCE,
+            code="authorization-code",
+            state=state,
+            db_session=cast(Session, object()),
+            user=_user(),
+        )
+    other_code_to_token.assert_not_called()
+
+    result = standard_oauth.oauth_callback(
+        source=DocumentSource.LINEAR,
+        code="authorization-code",
+        state=state,
+        db_session=cast(Session, object()),
+        user=_user(),
+    )
+    assert result.redirect_url == f"{standard_oauth.WEB_DOMAIN}/return?credentialId=7"
+    linear_code_to_token.assert_called_once()
+
+
+def test_callback_revalidates_stored_connector_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = _configure_cache(monkeypatch)
+    authorization_url = MagicMock(return_value="https://provider.example/authorize")
+    code_to_token = MagicMock(return_value={"access_token": "token"})
     monkeypatch.setattr(
         standard_oauth,
         "_discover_oauth_connectors",
         lambda: {DocumentSource.LINEAR: PKCEOAuthConnector},
     )
-    monkeypatch.setattr(standard_oauth, "get_redis_client", lambda: redis_client)
+    monkeypatch.setattr(
+        standard_oauth, "generate_pkce_pair", lambda: ("verifier", "challenge")
+    )
+    monkeypatch.setattr(
+        PKCEOAuthConnector, "oauth_authorization_url", authorization_url
+    )
+    monkeypatch.setattr(PKCEOAuthConnector, "oauth_code_to_token", code_to_token)
 
-    with pytest.raises(OnyxError, match="Invalid OAuth state"):
+    standard_oauth.oauth_authorize(
+        request=_request(b"instance=example"),
+        source=DocumentSource.LINEAR,
+        desired_return_url="/return",
+        user=_user(),
+    )
+    state = authorization_url.call_args.args[1]
+    key = next(iter(cache.store))
+    stored_attempt = json.loads(cache.store[key])
+    stored_attempt["payload"]["additional_kwargs"]["instance"] = ""
+    cache.store[key] = json.dumps(stored_attempt).encode()
+
+    with pytest.raises(OnyxError, match="Invalid OAuth configuration"):
         standard_oauth.oauth_callback(
             source=DocumentSource.LINEAR,
             code="authorization-code",
-            state="consumed-state",
+            state=state,
             db_session=cast(Session, object()),
-            user=cast(User, object()),
+            user=_user(),
+        )
+    code_to_token.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "return_path",
+    [
+        "https://attacker.example/return",
+        "//attacker.example/return",
+        "/\\attacker.example/redirect",
+        "/safe\nredirect",
+    ],
+)
+def test_authorize_rejects_non_local_return_path(
+    monkeypatch: pytest.MonkeyPatch,
+    return_path: str,
+) -> None:
+    _configure_cache(monkeypatch)
+    monkeypatch.setattr(
+        standard_oauth,
+        "_discover_oauth_connectors",
+        lambda: {DocumentSource.LINEAR: PKCEOAuthConnector},
+    )
+
+    with pytest.raises(OnyxError, match="OAuth return"):
+        standard_oauth.oauth_authorize(
+            request=_request(),
+            source=DocumentSource.LINEAR,
+            desired_return_url=return_path,
+            user=_user(),
         )
 
 
-def test_tenant_redis_getdel_prefixes_key() -> None:
-    raw_client = MagicMock()
-    raw_client.getdel.return_value = b"value"
-    redis_client = TenantRedisClient("tenant", raw_client)
+def test_callback_normalizes_same_origin_return_and_replaces_credential_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_cache(monkeypatch)
+    authorization_url = MagicMock(return_value="https://linear.app/oauth/authorize")
+    monkeypatch.setattr(
+        standard_oauth,
+        "_discover_oauth_connectors",
+        lambda: {DocumentSource.LINEAR: LinearConnector},
+    )
+    monkeypatch.setattr(LinearConnector, "oauth_authorization_url", authorization_url)
+    monkeypatch.setattr(
+        LinearConnector,
+        "oauth_code_to_token",
+        MagicMock(return_value={"access_token": "token"}),
+    )
+    monkeypatch.setattr(
+        standard_oauth,
+        "create_credential",
+        lambda **_: SimpleNamespace(id=7),
+    )
+    monkeypatch.setattr(standard_oauth, "WEB_DOMAIN", "https://onyx.example")
 
-    assert redis_client.getdel("oauth_state:state-id") == b"value"
-    raw_client.getdel.assert_called_once_with("tenant:oauth_state:state-id")
+    standard_oauth.oauth_authorize(
+        request=_request(),
+        source=DocumentSource.LINEAR,
+        desired_return_url=(
+            "https://onyx.example/return?step=0&credentialId=999#setup"
+        ),
+        user=_user(),
+    )
+    state = authorization_url.call_args.args[1]
+
+    result = standard_oauth.oauth_callback(
+        source=DocumentSource.LINEAR,
+        code="authorization-code",
+        state=state,
+        db_session=cast(Session, object()),
+        user=_user(),
+    )
+    assert result.redirect_url == (
+        "https://onyx.example/return?step=0&credentialId=7#setup"
+    )
 
 
 def test_oauth_details_reports_manual_capability_when_oauth_is_disabled(
@@ -290,8 +526,8 @@ def test_disabled_oauth_connector_rejects_authorize(
         standard_oauth.oauth_authorize(
             request=_request(),
             source=DocumentSource.LINEAR,
-            desired_return_url="https://onyx.example/return",
-            _=cast(User, object()),
+            desired_return_url="/return",
+            user=_user(),
         )
 
 
@@ -304,7 +540,7 @@ def test_disabled_oauth_connector_rejects_callback(
         standard_oauth.oauth_callback(
             source=DocumentSource.LINEAR,
             code="authorization-code",
-            state="state-id",
+            state="a" * 43,
             db_session=cast(Session, object()),
-            user=cast(User, object()),
+            user=_user(),
         )

--- a/backend/tests/unit/sandbox_proxy/test_approval_cache.py
+++ b/backend/tests/unit/sandbox_proxy/test_approval_cache.py
@@ -22,6 +22,9 @@ class _MemoryCache(CacheBackend):
     def get(self, key: str) -> bytes | None:
         return self.values.get(key)
 
+    def getdel(self, key: str) -> bytes | None:
+        return self.values.pop(key, None)
+
     def set(
         self,
         key: str,
@@ -31,6 +34,17 @@ class _MemoryCache(CacheBackend):
         self.values[key] = str(value).encode()
         if ex is not None:
             self.expire(key, ex)
+
+    def set_if_absent(
+        self,
+        key: str,
+        value: str | bytes | int | float,
+        ex: int | None = None,
+    ) -> bool:
+        if key in self.values:
+            return False
+        self.set(key, value, ex=ex)
+        return True
 
     def expire(self, key: str, seconds: int) -> None:
         self.expirations.append((key, seconds))

--- a/web/src/lib/connectors/oauth.test.ts
+++ b/web/src/lib/connectors/oauth.test.ts
@@ -21,10 +21,14 @@ test("surfaces the backend OAuth validation error", async () => {
   Object.defineProperty(globalThis, "window", {
     configurable: true,
     value: {
-      location: { href: "http://localhost:3000/admin/connectors/salesforce" },
+      location: {
+        pathname: "/admin/connectors/salesforce",
+        search: "?step=0",
+        hash: "#setup",
+      },
     },
   });
-  jest.spyOn(global, "fetch").mockResolvedValue({
+  const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue({
     ok: false,
     json: jest.fn().mockResolvedValue({ detail: SALESFORCE_URL_ERROR }),
   } as unknown as Response);
@@ -38,5 +42,10 @@ test("surfaces the backend OAuth validation error", async () => {
   expect(consoleError).toHaveBeenCalledWith(
     expect.stringContaining(ValidSources.Salesforce),
     expect.any(Error)
+  );
+  expect(fetchMock).toHaveBeenCalledWith(
+    expect.stringContaining(
+      "desired_return_url=%2Fadmin%2Fconnectors%2Fsalesforce%3Fstep%3D0%23setup"
+    )
   );
 });

--- a/web/src/lib/connectors/oauth.ts
+++ b/web/src/lib/connectors/oauth.ts
@@ -17,7 +17,7 @@ export async function getConnectorOauthRedirectUrl(
 ): Promise<string> {
   try {
     const queryParams = new URLSearchParams({
-      desired_return_url: window.location.href,
+      desired_return_url: `${window.location.pathname}${window.location.search}${window.location.hash}`,
       ...additional_kwargs,
     });
     const response = await fetch(


### PR DESCRIPTION
## Description

### Why this is needed

OAuth authorization starts in one request and finishes later in a browser callback. During that gap, the server must remember who started the flow, where to return them, and—when PKCE is used—the secret verifier needed to finish safely.

That temporary state must work across API replicas, expire automatically, and be usable only once. The connector flow did not have one shared mechanism with all of those guarantees, which made concurrent callbacks and multi-replica deployments harder to reason about.

### How it works

This PR adds a small, shared authorization-attempt store backed by Onyx's configured cache. Each attempt:

- has an opaque, collision-safe state value;
- is scoped to the tenant, OAuth flow, and initiating user;
- expires after a short time; and
- is claimed atomically, so only one callback can complete it.

The connector OAuth flow is the first consumer. Its PKCE verifier now stays on the server instead of in the browser, and its callback verifies the initiating user before using the attempt. The cache gains the two standard atomic operations needed to support this with either Redis or PostgreSQL.

### Why this design

The reusable part of OAuth is the authorization-attempt lifecycle—not provider-specific requests, token mapping, or credential storage. Keeping that boundary narrow gives later MCP, external-app, federated-connector, and action OAuth flows the same safety guarantees without forcing their different domain logic into one large framework.

Starting with connectors keeps this foundation reviewable and proves it with a complete, smaller consumer. PR #14123 builds directly on it for the more involved MCP flow.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
