### PR TITLE
test: scope the integration-test chromium download to web_search

### DIFF
--- a/backend/tests/integration/common_utils/playwright_browser.py
+++ b/backend/tests/integration/common_utils/playwright_browser.py
@@ -1,0 +1,28 @@
+"""Chromium download for the suites that crawl the web.
+
+Two suites launch Playwright: `tests/web_search` (OnyxWebCrawler's fallback)
+and `tests/pruning` (the WEB connector). Every other suite must not pay the
+download, so each of those two opts in from its own conftest.
+"""
+
+import os
+import platform
+import subprocess
+
+
+def install_chromium_headless_shell() -> None:
+    """Download the chromium headless shell.
+
+    The devcontainer ships the apt deps; download the browser here so the
+    version tracks the lockfile's playwright-python. `--only-shell` skips the
+    179 MB full build: both consumers launch headless with no channel, so they
+    use the 106 MB headless shell. Playwright has no ubuntu26.04 build yet, so
+    pin to the binary-compatible 24.04 build.
+    """
+    machine = platform.machine().lower()
+    pw_arch = "x64" if machine in ("x86_64", "amd64") else "arm64"
+    env = os.environ.copy()
+    env["PLAYWRIGHT_HOST_PLATFORM_OVERRIDE"] = f"ubuntu24.04-{pw_arch}"
+    subprocess.run(
+        ["playwright", "install", "--only-shell", "chromium"], env=env, check=True
+    )

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1,7 +1,5 @@
 import ast
 import os
-import platform
-import shutil
 import subprocess
 from collections.abc import Callable, Generator
 from pathlib import Path
@@ -126,26 +124,6 @@ def _run_migrations() -> None:
         os.path.join(BACKEND_DIR, cfg.get_main_option("script_location") or "alembic"),
     )
     command.upgrade(cfg, "head")
-
-
-@pytest.fixture(scope="session", autouse=True)
-def _install_playwright(_run_migrations: None) -> None:  # noqa: ARG001
-    # web_search tests exercise OnyxWebCrawler's Playwright fallback. The
-    # devcontainer ships the apt deps; download the chromium binary here so
-    # the version tracks the lockfile's playwright-python. Playwright has no
-    # ubuntu26.04 build yet, so pin to the binary-compatible 24.04 build.
-    # Skipped in onyx-lite (no web_search) and where Playwright isn't on PATH.
-    if os.getenv("DISABLE_VECTOR_DB", "false").lower() == "true":
-        return
-
-    if shutil.which("playwright") is None:
-        return
-
-    machine = platform.machine().lower()
-    pw_arch = "x64" if machine in ("x86_64", "amd64") else "arm64"
-    env = os.environ.copy()
-    env["PLAYWRIGHT_HOST_PLATFORM_OVERRIDE"] = f"ubuntu24.04-{pw_arch}"
-    subprocess.run(["playwright", "install", "chromium"], env=env, check=True)
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -317,7 +295,6 @@ def _start_celery_workers(
 def _test_client(
     initialize_db: None,  # noqa: ARG001
     _start_celery_workers: None,  # noqa: ARG001
-    _install_playwright: None,  # noqa: ARG001
 ) -> Generator[TestClient, None, None]:
     # In-process api_server. Use the versioned dispatcher so MT / EE
     # builds get ee.onyx.main.get_application — that's the one that

--- a/backend/tests/integration/tests/craft/conftest.py
+++ b/backend/tests/integration/tests/craft/conftest.py
@@ -78,12 +78,6 @@ def _test_client() -> Generator[httpx.Client, None, None]:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _install_playwright() -> None:
-    """No-op override: craft API-boundary tests don't use playwright."""
-    return None
-
-
-@pytest.fixture(scope="session", autouse=True)
 def _start_celery_workers() -> Generator[None, None, None]:
     """No-op override: the deployed ``background`` worker runs the celery tasks."""
     yield None

--- a/backend/tests/integration/tests/craft/k8s/conftest.py
+++ b/backend/tests/integration/tests/craft/k8s/conftest.py
@@ -60,12 +60,6 @@ def _run_migrations() -> None:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _install_playwright() -> None:
-    """No-op override; this suite does not use browser automation."""
-    return None
-
-
-@pytest.fixture(scope="session", autouse=True)
 def initialize_db() -> None:
     """No-op override; sandbox fixtures initialize SQLAlchemy explicitly."""
     return None

--- a/backend/tests/integration/tests/pruning/conftest.py
+++ b/backend/tests/integration/tests/pruning/conftest.py
@@ -1,4 +1,4 @@
-"""Fixtures for the web search integration suite."""
+"""Fixtures for the pruning integration suite."""
 
 import pytest
 
@@ -9,5 +9,5 @@ from tests.integration.common_utils.playwright_browser import (
 
 @pytest.fixture(scope="session", autouse=True)
 def _install_playwright() -> None:
-    """These tests exercise OnyxWebCrawler's Playwright fallback."""
+    """test_web_pruning indexes with the WEB connector, which uses Playwright."""
     install_chromium_headless_shell()

--- a/backend/tests/integration/tests/web_search/conftest.py
+++ b/backend/tests/integration/tests/web_search/conftest.py
@@ -1,0 +1,26 @@
+"""Fixtures for the web search integration suite."""
+
+import os
+import platform
+import subprocess
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _install_playwright() -> None:
+    # These tests exercise OnyxWebCrawler's Playwright fallback. The
+    # devcontainer ships the apt deps; download the browser here so the
+    # version tracks the lockfile's playwright-python. This is the only
+    # integration suite that needs a browser, so the download stays here.
+    # `--only-shell` skips the 179 MB full build: OnyxWebCrawler launches
+    # headless with no channel, so it uses the 106 MB headless shell.
+    # Playwright has no ubuntu26.04 build yet, so pin to the
+    # binary-compatible 24.04 build.
+    machine = platform.machine().lower()
+    pw_arch = "x64" if machine in ("x86_64", "amd64") else "arm64"
+    env = os.environ.copy()
+    env["PLAYWRIGHT_HOST_PLATFORM_OVERRIDE"] = f"ubuntu24.04-{pw_arch}"
+    subprocess.run(
+        ["playwright", "install", "--only-shell", "chromium"], env=env, check=True
+    )


### PR DESCRIPTION
## Problem

`_install_playwright` in `backend/tests/integration/conftest.py` was `scope="session", autouse=True`. It ran once per pytest session, so it ran in every CI matrix job. Each job is a fresh `docker run --rm`, so the download never persisted.

The fixture downloaded 285 MB: a 179 MB full Chromium build and a 106 MB headless shell. Only one test directory uses a browser: `tests/integration/tests/web_search`.

The matrix has 46 test dirs plus 5 connector dirs. A pull request runs 51 jobs, a merge group or tag runs 102. That is about 14 GB of downloads per pull request run to serve one job.

## Change

- Move the fixture into `backend/tests/integration/tests/web_search/conftest.py`, where it stays session-scoped and autouse for that directory only.
- Add `--only-shell` to `playwright install chromium`. `OnyxWebCrawler` launches Playwright headless with no channel (`backend/onyx/utils/playwright_fetch.py:85`), so it uses the headless shell and never the full build.
- Drop the `DISABLE_VECTOR_DB` and `shutil.which("playwright")` guards. The onyx-lite lane only runs `tests/integration/tests/no_vectordb`, and `playwright==1.58.0` is a pinned backend dependency, so neither guard can fire now.
- Delete the no-op overrides in `tests/craft/conftest.py` and `tests/craft/k8s/conftest.py`, which are dead once the fixture is opt-in.

`PLAYWRIGHT_HOST_PLATFORM_OVERRIDE` stays. Playwright 1.58 has no Ubuntu 26.04 build and the devcontainer base is Ubuntu 26.04.

## Result

50 of 51 pull request jobs download nothing. The remaining job downloads 106 MB, not 285 MB.

## Tests

No new tests — this changes test setup, not product behavior. CI is the verification: `web_search` must still pass, and the other jobs must pass and start faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes integration-test Chromium downloads to only the suites that use Playwright and installs the headless shell. Previously a session-autouse fixture ran in every job and fetched 285 MB; now only `web_search` and `pruning` download the 106 MB shell, reducing CI time and bandwidth.

- Remove the global `_install_playwright` from `backend/tests/integration/conftest.py` (and its `_test_client` dependency).
- Add `install_chromium_headless_shell()` in `backend/tests/integration/common_utils/playwright_browser.py`; opt in from `tests/integration/tests/web_search/conftest.py` and `tests/integration/tests/pruning/conftest.py` via session-autouse fixtures.
- Use `playwright install --only-shell chromium`; both suites run headless with no channel.
- Keep `PLAYWRIGHT_HOST_PLATFORM_OVERRIDE` pinned to `ubuntu24.04-{arch}` for the Ubuntu 26.04 base image.
- Drop dead guards (`DISABLE_VECTOR_DB`, `shutil.which("playwright")`) and delete no-op overrides in `tests/integration/tests/craft/` and `tests/integration/tests/craft/k8s/`.

<sup>Written for commit 5469a20c8b7ecc561371e2de8f402bc7e658f0f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

