### PR TITLE
ci: run one model server for integration tests

### DIFF
--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -319,6 +319,10 @@ jobs:
           EOF
           fi
 
+      # NOTE: only `inference_model_server` runs. `indexing_model_server` is the
+      # same image with the same routes (INDEXING_ONLY only changes the log
+      # request-id prefix), so the tests point both hosts at the one container
+      # and skip a second load of the embedding model.
       - name: Start Docker containers
         run: |
           cd deployment/docker_compose
@@ -328,8 +332,7 @@ jobs:
             opensearch \
             cache \
             minio \
-            inference_model_server \
-            indexing_model_server
+            inference_model_server
         id: start_docker
 
       - name: Start Mock Services
@@ -401,7 +404,7 @@ jobs:
               -e OPENSEARCH_HOST=opensearch \
               -e REDIS_HOST=cache \
               -e MODEL_SERVER_HOST=inference_model_server \
-              -e INDEXING_MODEL_SERVER_HOST=indexing_model_server \
+              -e INDEXING_MODEL_SERVER_HOST=inference_model_server \
               -e S3_ENDPOINT_URL=http://minio:9000 \
               -e S3_AWS_ACCESS_KEY_ID=minioadmin \
               -e S3_AWS_SECRET_ACCESS_KEY=minioadmin \
@@ -589,6 +592,8 @@ jobs:
         with:
           ecr-registry: ${{ vars.ECR_REGISTRY }}
 
+      # NOTE: `indexing_model_server` is intentionally not started. See the
+      # integration-tests job above.
       - name: Start Docker containers for multi-tenant tests
         env:
           ECR_CACHE: ${{ env.RUNS_ON_ECR_CACHE }}
@@ -610,8 +615,7 @@ jobs:
             opensearch \
             cache \
             minio \
-            inference_model_server \
-            indexing_model_server
+            inference_model_server
         id: start_docker_multi_tenant
 
       - name: Install Python deps and generate OpenAPI client
@@ -640,7 +644,7 @@ jobs:
             -e OPENSEARCH_HOST=opensearch \
             -e REDIS_HOST=cache \
             -e MODEL_SERVER_HOST=inference_model_server \
-            -e INDEXING_MODEL_SERVER_HOST=indexing_model_server \
+            -e INDEXING_MODEL_SERVER_HOST=inference_model_server \
             -e S3_ENDPOINT_URL=http://minio:9000 \
             -e S3_AWS_ACCESS_KEY_ID=minioadmin \
             -e S3_AWS_SECRET_ACCESS_KEY=minioadmin \


### PR DESCRIPTION
## Summary

The `integration-tests` and `multitenant-tests` jobs started both `inference_model_server` and `indexing_model_server`. Only one is needed.

Both services use the same image and register the same routers. `INDEXING_ONLY=True` changes only the log request-id prefix (`INF` -> `IDX`, `backend/model_server/main.py:136`) and the client-side retry timing (`backend/onyx/natural_language_processing/search_nlp_models.py:93`). No route is gated on it. The second container only loaded the embedding model a second time.

## Changes

- Drop `indexing_model_server` from the compose `up` list in both jobs.
- Set `INDEXING_MODEL_SERVER_HOST=inference_model_server` on both test runners.

The model server is still required: the default search settings use a local model (`nomic-ai/nomic-embed-text-v1`, no provider), so ingestion and search both make real embedding calls.

`INDEX_BATCH_SIZE` is the only other variable unique to the indexing service. It is unset in CI.

## Result

One less container and one less model load per matrix job on the 4-cpu ARM runners.

## Test plan

- `zizmor`, actionlint, and YAML lint pass.
- The CI run on this PR exercises the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run only one model server in CI integration and multi-tenant tests to remove a redundant container and duplicate model load. Previously both `inference_model_server` and `indexing_model_server` ran; now only `inference_model_server` runs with no behavior change.

- Point `INDEXING_MODEL_SERVER_HOST` to `inference_model_server` in both jobs.
- `INDEXING_ONLY` does not gate routes; it only affects log request-id prefixes and client retry timing. Embeddings load once.
- The model server remains required because default search uses a local embedding model.
- Expected effect: fewer containers and faster start on ARM runners, with unchanged test behavior.

<sup>Written for commit ab86b56f852b905bd741b365cd5080b9d42db39a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

