### PR TITLE
perf(compose): poll healthchecks faster during startup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,7 @@ repos:
               |docker-compose\.prod-no-letsencrypt\.yml
               |docker-compose\.onyx-lite\.yml
               |docker-compose\.craft\.yml
+              |docker-compose\.dev\.yml
               |env\.template
               |env\.prod\.template
               |env\.nginx\.template

--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/docker-compose.dev.yml
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/docker-compose.dev.yml
@@ -1,6 +1,14 @@
 # Docker Compose Override for Development/Testing
 # This file exposes service ports for development and testing purposes.
 #
+# It also shortens the time `up --wait` needs to notice a service is healthy.
+# The base healthchecks poll on a 10-30s interval, so the first probe lands long
+# after the service is actually ready. `start_interval` polls every 1-5s until
+# the first success, then docker reverts to the base `interval`. This keeps the
+# base compose files compatible with older docker; `start_interval` needs
+# Compose 2.20.2+ and Docker Engine 25.0+, and older versions fail hard rather
+# than ignore it.
+#
 # Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --wait
 #
@@ -26,10 +34,18 @@ services:
         limits:
           cpus: "${API_SERVER_CPU_LIMIT:-0}"
           memory: "${API_SERVER_MEM_LIMIT:-0}"
+    healthcheck:
+      # 2s rather than 1s: the probe starts a python interpreter, and it runs
+      # against a container that may still be applying alembic migrations.
+      start_interval: 2s
 
   background:
     build:
       target: dev
+
+  web_server:
+    healthcheck:
+      start_interval: 1s
 
   # Uncomment the block below to enable the MCP server for Onyx.
   # mcp_server:
@@ -39,6 +55,11 @@ services:
   relational_db:
     ports:
       - "${POSTGRES_HOST_PORT:-5432}:5432"
+    healthcheck:
+      # The base healthcheck has no start_period, so one is needed here for
+      # start_interval to apply at all.
+      start_period: 30s
+      start_interval: 1s
 
   opensearch:
     ports:
@@ -52,6 +73,20 @@ services:
   inference_model_server:
     ports:
       - "${MODEL_SERVER_HOST_PORT:-9000}:9000"
+    healthcheck:
+      # 5s: on a cold cache this polls for as long as the HuggingFace download
+      # takes, so keep the probe rate low.
+      start_interval: 5s
+
+  indexing_model_server:
+    healthcheck:
+      start_interval: 5s
+
+  nginx:
+    healthcheck:
+      # nginx only starts once api_server and web_server report healthy, so a
+      # full 30s interval here lands at the very end of the startup chain.
+      start_interval: 1s
 
   cache:
     ports:
@@ -63,6 +98,11 @@ services:
     ports:
       - "${MINIO_API_HOST_PORT:-9004}:9000"
       - "${MINIO_CONSOLE_HOST_PORT:-9005}:9001"
+    healthcheck:
+      # The base healthcheck has no start_period, so one is needed here for
+      # start_interval to apply at all.
+      start_period: 30s
+      start_interval: 1s
 
   code-interpreter:
     ports:

--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -1,6 +1,14 @@
 # Docker Compose Override for Development/Testing
 # This file exposes service ports for development and testing purposes.
 #
+# It also shortens the time `up --wait` needs to notice a service is healthy.
+# The base healthchecks poll on a 10-30s interval, so the first probe lands long
+# after the service is actually ready. `start_interval` polls every 1-5s until
+# the first success, then docker reverts to the base `interval`. This keeps the
+# base compose files compatible with older docker; `start_interval` needs
+# Compose 2.20.2+ and Docker Engine 25.0+, and older versions fail hard rather
+# than ignore it.
+#
 # Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --wait
 #
@@ -26,10 +34,18 @@ services:
         limits:
           cpus: "${API_SERVER_CPU_LIMIT:-0}"
           memory: "${API_SERVER_MEM_LIMIT:-0}"
+    healthcheck:
+      # 2s rather than 1s: the probe starts a python interpreter, and it runs
+      # against a container that may still be applying alembic migrations.
+      start_interval: 2s
 
   background:
     build:
       target: dev
+
+  web_server:
+    healthcheck:
+      start_interval: 1s
 
   # Uncomment the block below to enable the MCP server for Onyx.
   # mcp_server:
@@ -39,6 +55,11 @@ services:
   relational_db:
     ports:
       - "${POSTGRES_HOST_PORT:-5432}:5432"
+    healthcheck:
+      # The base healthcheck has no start_period, so one is needed here for
+      # start_interval to apply at all.
+      start_period: 30s
+      start_interval: 1s
 
   opensearch:
     ports:
@@ -52,6 +73,20 @@ services:
   inference_model_server:
     ports:
       - "${MODEL_SERVER_HOST_PORT:-9000}:9000"
+    healthcheck:
+      # 5s: on a cold cache this polls for as long as the HuggingFace download
+      # takes, so keep the probe rate low.
+      start_interval: 5s
+
+  indexing_model_server:
+    healthcheck:
+      start_interval: 5s
+
+  nginx:
+    healthcheck:
+      # nginx only starts once api_server and web_server report healthy, so a
+      # full 30s interval here lands at the very end of the startup chain.
+      start_interval: 1s
 
   cache:
     ports:
@@ -63,6 +98,11 @@ services:
     ports:
       - "${MINIO_API_HOST_PORT:-9004}:9000"
       - "${MINIO_CONSOLE_HOST_PORT:-9005}:9001"
+    healthcheck:
+      # The base healthcheck has no start_period, so one is needed here for
+      # start_interval to apply at all.
+      start_period: 30s
+      start_interval: 1s
 
   code-interpreter:
     ports:

--- a/deployment/docker_compose/docker-compose.multitenant-dev.yml
+++ b/deployment/docker_compose/docker-compose.multitenant-dev.yml
@@ -140,6 +140,9 @@ services:
       # Generous start_period so that `docker compose up --wait` does not flag
       # the container unhealthy while alembic migrations run on a fresh DB.
       start_period: 600s
+      # Poll every 2s until the first success, so a fast boot is not rounded up
+      # to the 30s interval. Docker reverts to `interval` once healthy.
+      start_interval: 2s
 
   background:
     image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
@@ -504,6 +507,11 @@ services:
       interval: 30s
       timeout: 20s
       retries: 3
+      # MinIO is ready a few seconds after start, but the 30s interval delays
+      # the first probe. start_interval polls every second until the first
+      # success, so `up --wait` does not block for a full interval.
+      start_period: 30s
+      start_interval: 1s
 
   cache:
     image: ${BASE_IMAGE_REGISTRY:-docker.io}/library/redis:7.4-alpine


### PR DESCRIPTION
## Problem

Docker probes a healthcheck on its `interval` starting from the first check. `start_period` does **not** change this — it only stops early failures from counting toward `retries`. So a service that is actually ready in ~3s still reports healthy only when the first interval elapses.

MinIO was the worst offender in CI: `interval: 30s` on a service that is ready almost immediately, so `docker compose up --wait` blocked a full 30s on it.

## Fix

Set `start_interval`, which makes docker poll at that rate while the container is still in `starting`, then revert to `interval` once healthy.

| service | interval | start_interval |
| --- | --- | --- |
| minio | 30s | 1s |
| relational_db | 10s | 1s |
| web_server | 30s | 1s |
| nginx | 30s | 1s |
| api_server | 30s | 2s |
| inference_model_server | 20s | 5s |
| indexing_model_server | 20s | 5s |

`api_server` and the model servers poll slower because their probe starts a Python interpreter, and they can stay in `starting` for a long time (alembic migrations, HuggingFace downloads).

`minio` and `relational_db` also needed a `start_period` added — without one there is no start window for `start_interval` to apply to.

## Why the overlay and not the base compose files

`start_interval` needs Compose 2.20.2+ and Docker Engine 25.0+. Older versions **fail hard** rather than ignore it:

- Compose < 2.20.2: `Additional property start_interval is not allowed`
- Compose >= 2.20.2 with Engine < 25.0: `can't set healthcheck.start_interval as feature require Docker Engine 1.25 or later`

That would break self-hosters on e.g. Ubuntu 22.04's packaged Docker 24.x. So the settings live in `docker-compose.dev.yml`, which nearly every CI job already stacks on (`-f docker-compose.yml -f docker-compose.dev.yml`), plus `docker-compose.multitenant-dev.yml`, which CI runs standalone. `docker-compose.yml`, `prod.yml` and `prod-no-letsencrypt.yml` are unchanged, so the public deployment path keeps working on any Docker version.

The airgap playwright jobs do not stack the dev overlay, but `docker-compose.airgap-test.yml` already overrides those healthchecks to a 5s interval, so they are unaffected.

## Testing

Config-only change; no Docker daemon available in the dev container to time a real `up --wait`. YAML parses, `pre-commit` passes on both files, and the effect should show up in the "Start Docker containers" step of the integration and playwright jobs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Poll healthchecks faster during startup in dev/CI Compose overlays to shorten `docker compose up --wait`. Previously Docker waited a full healthcheck interval before the first probe; now `start_interval` polls every 1–5s while a container is starting, then reverts to the existing `interval`.

- Apply in `deployment/docker_compose/docker-compose.dev.yml`, `deployment/docker_compose/docker-compose.multitenant-dev.yml`, and the embedded overlay at `cli/internal/deploy/deployfiles/embedded/docker_compose/docker-compose.dev.yml`; base and prod stacks are unchanged.
- Add `start_period` for `minio` and `relational_db` so `start_interval` takes effect; use 1–5s `start_interval` per service based on probe cost.
- Update `pre-commit` config to include `docker-compose.dev.yml` in the `docker-compose-sync` trigger, keeping the embedded overlay in sync.
- Requires Compose 2.20.2+ and Docker Engine 25.0+; older Docker fails on `start_interval`, which is why this stays in the dev overlays.
- CI should start faster; airgap playwright jobs are unaffected because they already override healthchecks. No migration or developer action required.

<sup>Written for commit 3bf750ed36acee238398604960356449dea61ce6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

