### PR TITLE
build(web): run the web image on bun 1.4 instead of node

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ ARG BASE_IMAGE_REGISTRY=docker.io
 
 # bun + node binary sources. Pinned via the registry prefix in their own stages because buildx
 # rejects variable expansion directly in `COPY --from=` -- the ARG is only expandable in a FROM.
-FROM ${BASE_IMAGE_REGISTRY}/oven/bun:1@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS bun_source
+FROM ${BASE_IMAGE_REGISTRY}/oven/bun:1.4.0@sha256:5ff609364c049b54eb0ff560ec96319729a972078ef2c755d758f0c6ef89c2d6 AS bun_source
 FROM ${BASE_IMAGE_REGISTRY}/library/node:24.16.0-trixie-slim@sha256:05c08ce4291e9a58f59456a7985176defb12cdd42271f35ff81a3e167ea61d4c AS node_source
 
 FROM ${BASE_IMAGE_REGISTRY}/library/ubuntu:26.04@sha256:cc925e589b7543b910fea57a240468940003fbfc0515245a495dd0ad8fe7cef1

--- a/.github/actions/dhi-base-images/action.yml
+++ b/.github/actions/dhi-base-images/action.yml
@@ -1,7 +1,7 @@
 name: "Docker Hardened Image bases"
 description: >-
-  Logs in to dhi.io and exports the build args that point web/Dockerfile and
-  backend/Dockerfile.model_server at the pinned Docker Hardened Images (DHI).
+  Logs in to dhi.io and exports the build args that point web/Dockerfile (bun) and
+  backend/Dockerfile.model_server (python) at the pinned Docker Hardened Images (DHI).
   Both Dockerfiles default to public Docker Hub images, so without DHI credentials
   (fork pull requests) this action exports nothing and the defaults apply.
 inputs:
@@ -40,14 +40,17 @@ runs:
 
     # Single source of truth for the DHI digests. Refresh one with:
     # docker buildx imagetools inspect <image reference>
+    # TODO: pin the two bun images by digest once they are read from a DHI-authenticated
+    # host; the catalog tops out at bun 1.3.14, so `1-debian13` picks up 1.4 when published.
     - name: Export DHI build args
       if: steps.creds.outputs.available == 'true'
       shell: bash
       run: |
         {
-          echo "DHI_NODE_BUILD_ARGS<<EOF"
-          echo "NODE_BUILDER_IMAGE=dhi.io/node:24-debian13-dev@sha256:25a83f18150669e9ce3c9437327add4d75ae4ea26cbdb5e8747b66d3b74a567a"
-          echo "NODE_RUNTIME_IMAGE=dhi.io/node:24-debian13@sha256:805278f24c1146c6d3c96577b6256f8f97c43196fff88315fe3291a1ce118ddd"
+          echo "DHI_BUN_BUILD_ARGS<<EOF"
+          echo "BUN_BUILDER_IMAGE=dhi.io/bun:1-debian13-dev"
+          echo "BUN_RUNTIME_IMAGE=dhi.io/bun:1-debian13"
+          echo "RUNTIME_USER=nonroot"
           echo "EOF"
           echo "DHI_PYTHON_BUILD_ARGS<<EOF"
           echo "PYTHON_BUILDER_IMAGE=dhi.io/python:3.13-debian13-dev@sha256:7933d16e50454c39bca6e935027166d5e5b05c6c03383dc2f58e8fe6e2440b7d"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -382,7 +382,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2 # zizmor: ignore[cache-poisoning]
         with:
-          bun-version: "1.3.13"
+          bun-version: "1.4.0"
 
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b # zizmor: ignore[impostor-commit]
@@ -545,7 +545,7 @@ jobs:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_TOKEN }}
 
-      # web/Dockerfile defaults to the public Node bases. Release builds ship on the
+      # web/Dockerfile defaults to the public bun bases. Release builds ship on the
       # hardened DHI equivalents, passed as build args below.
       - name: Resolve Docker Hardened Image bases
         uses: ./.github/actions/dhi-base-images
@@ -563,8 +563,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ONYX_VERSION=${{ github.ref_name }}
-            ${{ env.DHI_NODE_BUILD_ARGS }}
-            NODE_OPTIONS=--max-old-space-size=8192
+            ${{ env.DHI_BUN_BUILD_ARGS }}
           cache-from: |
             type=registry,ref=${{ env.REGISTRY_IMAGE }}:edge
             type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
@@ -627,7 +626,7 @@ jobs:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_TOKEN }}
 
-      # web/Dockerfile defaults to the public Node bases. Release builds ship on the
+      # web/Dockerfile defaults to the public bun bases. Release builds ship on the
       # hardened DHI equivalents, passed as build args below.
       - name: Resolve Docker Hardened Image bases
         uses: ./.github/actions/dhi-base-images
@@ -645,8 +644,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ONYX_VERSION=${{ github.ref_name }}
-            ${{ env.DHI_NODE_BUILD_ARGS }}
-            NODE_OPTIONS=--max-old-space-size=8192
+            ${{ env.DHI_BUN_BUILD_ARGS }}
           cache-from: |
             type=registry,ref=${{ env.REGISTRY_IMAGE }}:edge
             type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
@@ -801,7 +799,7 @@ jobs:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_TOKEN }}
 
-      # web/Dockerfile defaults to the public Node bases. Release builds ship on the
+      # web/Dockerfile defaults to the public bun bases. Release builds ship on the
       # hardened DHI equivalents, passed as build args below.
       - name: Resolve Docker Hardened Image bases
         uses: ./.github/actions/dhi-base-images
@@ -819,7 +817,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ONYX_VERSION=${{ github.ref_name }}
-            ${{ env.DHI_NODE_BUILD_ARGS }}
+            ${{ env.DHI_BUN_BUILD_ARGS }}
             NEXT_PUBLIC_CLOUD_ENABLED=true
             WEB_FRAME_PROTECTION_ENABLED=false
             NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.POSTHOG_KEY }}
@@ -829,7 +827,6 @@ jobs:
             NEXT_PUBLIC_GTM_ENABLED=true
             NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED=true
             NEXT_PUBLIC_INCLUDE_ERROR_POPUP_SUPPORT_LINK=true
-            NODE_OPTIONS=--max-old-space-size=8192
             SENTRY_RELEASE=${{ github.sha }}
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -893,7 +890,7 @@ jobs:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_TOKEN }}
 
-      # web/Dockerfile defaults to the public Node bases. Release builds ship on the
+      # web/Dockerfile defaults to the public bun bases. Release builds ship on the
       # hardened DHI equivalents, passed as build args below.
       - name: Resolve Docker Hardened Image bases
         uses: ./.github/actions/dhi-base-images
@@ -911,7 +908,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ONYX_VERSION=${{ github.ref_name }}
-            ${{ env.DHI_NODE_BUILD_ARGS }}
+            ${{ env.DHI_BUN_BUILD_ARGS }}
             NEXT_PUBLIC_CLOUD_ENABLED=true
             WEB_FRAME_PROTECTION_ENABLED=false
             NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.POSTHOG_KEY }}
@@ -921,7 +918,6 @@ jobs:
             NEXT_PUBLIC_GTM_ENABLED=true
             NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED=true
             NEXT_PUBLIC_INCLUDE_ERROR_POPUP_SUPPORT_LINK=true
-            NODE_OPTIONS=--max-old-space-size=8192
             SENTRY_RELEASE=${{ github.sha }}
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/pr-desktop-build.yml
+++ b/.github/workflows/pr-desktop-build.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2 # zizmor: ignore[cache-poisoning]
         with:
-          bun-version: "1.3.13"
+          bun-version: "1.4.0"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9

--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2 # zizmor: ignore[cache-poisoning] test-only workflow; no deploy artifacts
         with:
-          bun-version: "1.3.13"
+          bun-version: "1.4.0"
 
       - name: Install node dependencies
         working-directory: ./web

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -198,7 +198,7 @@ jobs:
         with:
           ecr-registry: ${{ vars.ECR_REGISTRY }}
 
-      # web/Dockerfile defaults to the public Node bases. CI builds ship on the hardened
+      # web/Dockerfile defaults to the public bun bases. CI builds ship on the hardened
       # DHI equivalents, passed as build args below.
       - name: Resolve Docker Hardened Image bases
         uses: ./.github/actions/dhi-base-images
@@ -222,7 +222,7 @@ jobs:
           sbom: false
           build-args: |
             BASE_IMAGE_REGISTRY=${{ env.BASE_IMAGE_REGISTRY }}
-            ${{ env.DHI_NODE_BUILD_ARGS }}
+            ${{ env.DHI_BUN_BUILD_ARGS }}
             SKIP_TYPE_CHECK=1
           cache-from: |
             type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:web-cache-${{ github.event.pull_request.head.sha || github.sha }}
@@ -505,7 +505,7 @@ jobs:
       - name: Setup bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2 # zizmor: ignore[cache-poisoning] ephemeral runners; no release artifacts
         with:
-          bun-version: "1.3.13"
+          bun-version: "1.4.0"
 
       - name: Install node dependencies
         working-directory: ./web
@@ -686,7 +686,7 @@ jobs:
       - name: Setup bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2 # zizmor: ignore[cache-poisoning] ephemeral runners; no release artifacts
         with:
-          bun-version: "1.3.13"
+          bun-version: "1.4.0"
 
       - name: Install node dependencies
         working-directory: ./web
@@ -844,7 +844,7 @@ jobs:
       - name: Setup bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2 # zizmor: ignore[cache-poisoning] ephemeral runners; no release artifacts
         with:
-          bun-version: "1.3.13"
+          bun-version: "1.4.0"
 
       - name: Install node dependencies
         working-directory: ./web

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2 # zizmor: ignore[cache-poisoning]
         with:
-          bun-version: "1.3.13"
+          bun-version: "1.4.0"
       - name: Install node dependencies
         working-directory: ./web
         run: bun install --frozen-lockfile

--- a/.github/workflows/pr-storybook-build.yml
+++ b/.github/workflows/pr-storybook-build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.13"
+          bun-version: "1.4.0"
 
       - name: Cache bun install cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.13"
+          bun-version: "1.4.0"
 
       - name: Pull Vercel Environment Information
         run: bunx ${{ env.VERCEL_CLI }} pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/release-opal.yml
+++ b/.github/workflows/release-opal.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2 # zizmor: ignore[cache-poisoning]
         with:
-          bun-version: "1.3.13"
+          bun-version: "1.4.0"
 
       - name: Configure npm registry
         run: |

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.13"
+          bun-version: "1.4.0"
 
       - name: Install dependencies
         working-directory: web

--- a/backend/onyx/server/features/build/sandbox/image/Dockerfile
+++ b/backend/onyx/server/features/build/sandbox/image/Dockerfile
@@ -12,7 +12,7 @@ ARG BASE_IMAGE_REGISTRY=docker.io
 # bun binary source. Pinned via the registry prefix in its own stage because
 # buildx rejects variable expansion directly in `COPY --from=` — the ARG is
 # only expandable in a FROM.
-FROM ${BASE_IMAGE_REGISTRY}/oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS bun_source
+FROM ${BASE_IMAGE_REGISTRY}/oven/bun:1.4.0@sha256:5ff609364c049b54eb0ff560ec96319729a972078ef2c755d758f0c6ef89c2d6 AS bun_source
 
 # Node.js source. The final image is Python-based, but the sandbox still needs
 # Node/npm/npx for MCP commands and skill-runtime packages.

--- a/docs/craft/sandbox/image-and-spinup.md
+++ b/docs/craft/sandbox/image-and-spinup.md
@@ -16,7 +16,7 @@ Related files:
 
 ## SHA-pinned base + helper images
 
-`python:3.13-slim`, `node:24-trixie-slim`, and `oven/bun:1.3.14` are
+`python:3.13-slim`, `node:24-trixie-slim`, and `oven/bun:1.4.0` are
 SHA-pinned in the Dockerfile (`@sha256:...`). Same precedent as
 `backend/Dockerfile` and `web/Dockerfile`. Bump via:
 
@@ -45,7 +45,7 @@ the sandbox's credential surface.
 We used to `curl -fsSL https://bun.sh/install | bash` at image-build
 time. That hit the public internet on every uncached layer rebuild and
 made builds vulnerable to bun.sh availability. The bun binary is now
-copied out of `oven/bun:<version>` (same pattern as `web/Dockerfile:15-16`).
+copied out of `oven/bun:<version>`.
 
 `BUN_VERSION` and the COPY tag must be kept in sync.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "onyx",
   "version": "0.0.0-private",
   "private": true,
-  "packageManager": "bun@1.3.13",
+  "packageManager": "bun@1.4.0",
   "workspaces": ["widget", "examples/widget", "desktop"],
   "devDependencies": {
     "@typescript/native-preview": "^7.0.0-dev.20260707.2"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,22 +3,21 @@
 # DHI overrides below carry their own registry (dhi.io), which the cache does not serve.
 ARG BASE_IMAGE_REGISTRY=docker.io
 
-# Node bases. The defaults are the public Debian slim images, so a plain `docker build` needs
+# Bun bases -- bun is both the package manager and the JS runtime here; the image ships no
+# Node.js. The defaults are the public Debian slim images, so a plain `docker build` needs
 # no extra registry access. CI overrides both with the matching Docker Hardened Images from
 # dhi.io, which need a Docker account with DHI catalog access.
 # Refresh a digest with: docker buildx imagetools inspect <image reference>
-ARG NODE_BUILDER_IMAGE=${BASE_IMAGE_REGISTRY}/library/node:24-trixie-slim@sha256:0711b541c1c33a8a530ac4f0d391baa9a15b3d804695b1b24a47daa5fb60e74d
-ARG NODE_RUNTIME_IMAGE=${BASE_IMAGE_REGISTRY}/library/node:24-trixie-slim@sha256:0711b541c1c33a8a530ac4f0d391baa9a15b3d804695b1b24a47daa5fb60e74d
+ARG BUN_BUILDER_IMAGE=${BASE_IMAGE_REGISTRY}/oven/bun:1.4.0-slim@sha256:e0ee68d16ccb9927bf02aa7dd8fd4bf3369ee6d46da04faa72b05ce8bfd135f6
+ARG BUN_RUNTIME_IMAGE=${BASE_IMAGE_REGISTRY}/oven/bun:1.4.0-slim@sha256:e0ee68d16ccb9927bf02aa7dd8fd4bf3369ee6d46da04faa72b05ce8bfd135f6
 
-# bun binary source, in its own stage because buildx only expands the registry ARG in a FROM,
-# not in `COPY --from=`. Use the glibc (Debian) build so it runs on the glibc node images.
-FROM ${BASE_IMAGE_REGISTRY}/oven/bun:1@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS bun_source
+# Non-root user of the runtime base. The public oven/bun image ships `bun` (uid 1000); the
+# DHI runtime ships `nonroot` (uid 65532), so CI overrides this along with the base images.
+ARG RUNTIME_USER=bun
 
-# Build stage. Needs a root user plus a shell and npm/npx, which both the default slim image
-# and the DHI "-dev" variant provide.
-FROM ${NODE_BUILDER_IMAGE} AS builder
-COPY --from=bun_source /usr/local/bin/bun /usr/local/bin/bun
-COPY --from=bun_source /usr/local/bin/bunx /usr/local/bin/bunx
+# Build stage. Needs a root user plus a shell, which both the default slim image and the
+# DHI "-dev" variant provide.
+FROM ${BUN_BUILDER_IMAGE} AS builder
 WORKDIR /app
 
 # Copy package files + the full opal AND shared workspace sources so their `prepare`
@@ -89,25 +88,22 @@ ENV NEXT_PUBLIC_RECAPTCHA_SITE_KEY=${NEXT_PUBLIC_RECAPTCHA_SITE_KEY}
 ARG SENTRY_RELEASE
 ENV SENTRY_RELEASE=${SENTRY_RELEASE}
 
-# Add NODE_OPTIONS argument
-ARG NODE_OPTIONS
-
 ARG SKIP_TYPE_CHECK
 ENV SKIP_TYPE_CHECK=${SKIP_TYPE_CHECK}
 
 # SENTRY_AUTH_TOKEN is injected via BuildKit secret mount so it is never written
 # to any image layer, build cache, or registry manifest.
-# Use NODE_OPTIONS in the build command
 RUN --mount=type=secret,id=sentry_auth_token \
     if [ -f /run/secrets/sentry_auth_token ]; then \
         export SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)"; \
     fi && \
-    NODE_OPTIONS="${NODE_OPTIONS}" npx next build
+    bun run build
 
-# Runtime stage. Runs as the non-root `node` user (uid 1000), which both the default slim
-# image and the DHI runtime variant ship. The DHI variant is near-distroless: no shell or
-# package manager, so keep this stage free of RUN instructions.
-FROM ${NODE_RUNTIME_IMAGE} AS runner
+# Runtime stage. Runs as the non-root user of the base image (see RUNTIME_USER). The DHI
+# variant is near-distroless: no shell or package manager, so keep this stage free of RUN
+# instructions.
+FROM ${BUN_RUNTIME_IMAGE} AS runner
+ARG RUNTIME_USER
 
 LABEL com.onyx.maintainer="founders@onyx.app"
 LABEL com.onyx.description="This image is the web/frontend container of Onyx which \
@@ -124,13 +120,13 @@ WORKDIR /app
 # Disable automatic telemetry collection
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# `/app` is root-owned, so re-own build artifacts to `node` on copy.
-COPY --from=builder --chown=node:node /app/public ./public
+# `/app` is root-owned, so re-own build artifacts to the runtime user on copy.
+COPY --from=builder --chown=${RUNTIME_USER}:${RUNTIME_USER} /app/public ./public
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --chown=node:node /app/.next/standalone ./
-COPY --from=builder --chown=node:node /app/.next/static ./.next/static
+COPY --from=builder --chown=${RUNTIME_USER}:${RUNTIME_USER} /app/.next/standalone ./
+COPY --from=builder --chown=${RUNTIME_USER}:${RUNTIME_USER} /app/.next/static ./.next/static
 
 # Environment variables must be redefined at run time
 # NOTE: if you add something here, make sure to add it to the builder as well
@@ -194,9 +190,13 @@ ENV ONYX_VERSION=${ONYX_VERSION}
 # name only — breaking loopback healthchecks. Force 0.0.0.0 instead.
 ENV HOSTNAME="0.0.0.0"
 
-# Don't run production as root. The DHI runtime already defaults to this user; the default
-# slim image does not.
-USER node
+# Don't run production as root. The DHI runtime already defaults to its non-root user; the
+# public oven/bun image does not.
+USER ${RUNTIME_USER}
 
-# The DHI runtime image sets no default ENTRYPOINT, so invoke node explicitly.
-CMD ["node", "server.js"]
+# Clear the base ENTRYPOINT (the public oven/bun image sets a wrapper script) so the command
+# below runs as written on every base.
+ENTRYPOINT []
+
+# Next.js standalone server, run by bun.
+CMD ["bun", "server.js"]


### PR DESCRIPTION
## What

Bun is already the package manager for the frontend. This makes it the runtime too — the web image builds and runs on bun and ships no Node.js — and moves every bun pin to 1.4.0.

`web/Dockerfile`:

- Builder and runner bases are `oven/bun:1.4.0-slim` (digest-pinned). The `bun_source` stage and the `COPY` of the bun/bunx binaries are gone.
- `npx next build` → `bun run build`; `CMD ["node", "server.js"]` → `CMD ["bun", "server.js"]`, with `ENTRYPOINT []` so the public image's wrapper script cannot change how the command runs.
- New `ARG RUNTIME_USER` drives `USER` and the `COPY --chown`: the public image ships `bun` (uid 1000), the hardened image ships `nonroot` (65532).
- `ARG NODE_OPTIONS` is dropped. Bun has no equivalent of `--max-old-space-size`; JSC grows its heap on demand.

CI and pins:

- `dhi-base-images` exports `BUN_BUILDER_IMAGE` / `BUN_RUNTIME_IMAGE` / `RUNTIME_USER=nonroot` as `DHI_BUN_BUILD_ARGS`.
- `bun-version` 1.3.13 → 1.4.0 in all 9 workflows, `packageManager` → `bun@1.4.0`, and the `oven/bun` pins in the devcontainer and the sandbox image → 1.4.0.

## Open items

1. **The DHI bun bases are pinned by tag, not digest.** `dhi.io/bun` needs authentication, so the digests must be read on a host with DHI access: `docker buildx imagetools inspect dhi.io/bun:1-debian13-dev` and `...:1-debian13`. A `TODO` marks the spot.
2. **The DHI catalog tops out at bun 1.3.14**, so CI images run 1.3.14 until Docker publishes 1.4. The `1-debian13` tag picks it up on its own; a digest pin will not.

## Test

Verified against a local bun 1.4.0 build:

- `bun install --frozen-lockfile` passes on the committed `bun.lock`, no changes.
- `bun run build` produces the standalone output.
- `bun server.js` serves the standalone app (`/auth/login` → 200).
- `prek` passes on every changed file.

One thing to watch on the first `deployment.yml` run: `next build` under bun spawns one worker per CPU, and 23 workers OOM-killed the build in a 12 GB dev container (fine at 4 CPUs). CI builders are larger, but the memory headroom is worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the web image on Bun 1.4 and remove Node.js, aligning the runtime with our package manager and simplifying the container. Previously we built with `npx next build` and ran `node server.js`; now we build with `bun run build` and run `bun server.js`.

- Web image bases use `oven/bun:1.4.0-slim` for both builder and runtime; the image no longer ships Node.
- Runtime command and entrypoint: `ENTRYPOINT []` and `CMD ["bun","server.js"]` to avoid wrapper scripts altering execution.
- New `RUNTIME_USER` build arg controls file ownership and `USER` (`bun` in public images, `nonroot` in DHI runtime).
- Drop `NODE_OPTIONS`; Bun/JSC has no `--max-old-space-size` equivalent. Watch initial `next build` memory usage; Bun may spawn many workers.
- CI/tooling pins Bun to 1.4.0 across workflows, `packageManager`, devcontainer, and the sandbox image.
- DHI action now exports `DHI_BUN_BUILD_ARGS` (`BUN_BUILDER_IMAGE`, `BUN_RUNTIME_IMAGE`, `RUNTIME_USER`). If any workflow still uses `DHI_NODE_BUILD_ARGS`, update it.
- DHI Bun bases are tag-pinned (`1-debian13[-dev]`) until 1.4 lands in the catalog; CI may run 1.3.14 temporarily. A TODO tracks digest pinning.

<sup>Written for commit 6bb2cab3acc437482980c5b39097bf0bd2679d09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

