### PR TITLE
chore: bump sandbox opencode to 1.18.19 (message-ID rollover fix)

### DIFF
--- a/backend/onyx/server/features/build/sandbox/image/Dockerfile
+++ b/backend/onyx/server/features/build/sandbox/image/Dockerfile
@@ -48,7 +48,7 @@ FROM ${BASE_IMAGE_REGISTRY}/library/python:3.13-slim@sha256:f82c96458eedc847b233
 # the image.
 ARG ENABLE_SKILLS=true
 ARG ENABLE_BROWSER=true
-ARG OPENCODE_VERSION=1.18.13
+ARG OPENCODE_VERSION=1.18.19
 ARG AGENT_BROWSER_VERSION=0.31.1
 
 # firewall-init.sh needs: iptables (egress lockdown), ca-certificates (trust

--- a/docs/craft/sandbox/image-and-spinup.md
+++ b/docs/craft/sandbox/image-and-spinup.md
@@ -57,7 +57,7 @@ installs opencode via its own install script with the `--version` flag
 so the build is at least reproducible:
 
 ```dockerfile
-ARG OPENCODE_VERSION=1.18.13
+ARG OPENCODE_VERSION=1.18.19
 RUN curl -fsSL https://opencode.ai/install \
     | bash -s -- --version "${OPENCODE_VERSION}" --no-modify-path
 ```


### PR DESCRIPTION
## Description

opencode encodes message IDs with a 48-bit timestamp prefix that wrapped on 2026-08-14 11:19:55 UTC. In opencode <= 1.18.14, the prompt loop picks the "latest" message by lexicographic ID comparison, so any session with pre-wrap history silently ignores new prompts: the user message persists, the loop logs `step=0` -> `exiting loop`, and no assistant message is generated. We saw this live on managed_services tenant_dev (session `995a7fb3`), whose sandbox pins 1.18.13.

Upstream fixed this in 1.18.15 (anomalyco/opencode#40990: order messages by `time.created`, gate loop exit on `parentID`). This bumps the sandbox image pin to 1.18.19, the latest release. Wedged sessions recover on their own once their sandbox re-provisions with the new image; the message data in sqlite is intact.

Also updates the matching snippet in `docs/craft/sandbox/image-and-spinup.md`.

## How Has This Been Tested?

Root cause verified on the live tenant_dev sandbox: stored ID hex prefixes match the wrap math exactly (`msg_ff7de04af001` pre-wrap vs `msg_0207f26e7001` post-wrap), and v1.18.15+ no longer contains the vulnerable `lastUser.id < lastAssistant.id` exit check. Sandbox image build with the new pin is exercised by CI.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps sandbox `opencode` to 1.18.19 to fix the message-ID rollover that caused the prompt loop to exit early. Previously (<=1.18.14) sessions with pre-wrap history ignored new prompts and produced no assistant reply; 1.18.15+ orders messages by creation time and gates loop exit on parentID.

- Change: set `OPENCODE_VERSION=1.18.19` in the sandbox Dockerfile and mirror the version in docs.
- Rollout: re-provision sandboxes to pick up the new image; wedged sessions resume automatically; no data migration required.

<sup>Written for commit 8f5a1f82e6ed51200ecf3baf69e917401a8ea6e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

