### PR TITLE
feat(web): model settings popover in the LLM provider modal

### DIFF
--- a/web/lib/opal/src/layouts/content/ContentMd.tsx
+++ b/web/lib/opal/src/layouts/content/ContentMd.tsx
@@ -257,7 +257,15 @@ function ContentMd({
               color="inherit"
               maxLines={titleMaxLines}
               title={toPlainString(title)}
-              onClick={editable ? startEditing : undefined}
+              onClick={
+                editable
+                  ? // Starting an edit must not double as a click on the parent row.
+                    (e: React.MouseEvent) => {
+                      e.stopPropagation();
+                      startEditing();
+                    }
+                  : undefined
+              }
             >
               {title}
             </Text>

--- a/web/lib/opal/src/layouts/content/ContentMd.tsx
+++ b/web/lib/opal/src/layouts/content/ContentMd.tsx
@@ -10,7 +10,7 @@ import SvgXOctagon from "@opal/icons/x-octagon";
 import type { IconFunctionComponent, RichStr } from "@opal/types";
 import { toPlainString } from "@opal/components/text/InlineMarkdown";
 import { cn } from "@opal/utils";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useImperativeHandle } from "react";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -39,6 +39,10 @@ interface ContentMdPresetConfig {
   descriptionIndent: string;
 }
 
+export interface ContentMdEditHandle {
+  startEditing: () => void;
+}
+
 interface ContentMdProps {
   /** Optional icon component. */
   icon?: IconFunctionComponent;
@@ -61,6 +65,12 @@ interface ContentMdProps {
 
   /** Enable inline editing of the title. */
   editable?: boolean;
+
+  /** Hide the built-in pencil, for callers that trigger editing externally. */
+  hideEditButton?: boolean;
+
+  /** Handle for starting a title edit from an external control. */
+  editHandle?: React.Ref<ContentMdEditHandle>;
 
   /** Called when the user commits an edit. */
   onTitleChange?: (newTitle: string) => void;
@@ -152,6 +162,8 @@ function ContentMd({
   titleMaxLines,
   sizePreset = "main-ui",
   ref,
+  hideEditButton,
+  editHandle,
 }: ContentMdProps) {
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState(toPlainString(title));
@@ -168,6 +180,7 @@ function ContentMd({
     setEditValue(toPlainString(title));
     setEditing(true);
   }
+  useImperativeHandle(editHandle, () => ({ startEditing }), [title]);
 
   function commit() {
     const value = editValue.trim();
@@ -277,7 +290,7 @@ function ContentMd({
 
           {tag && <Tag {...tag} />}
 
-          {editable && !editing && (
+          {editable && !editing && !hideEditButton && (
             <div
               className={cn(
                 "opal-content-md-edit-button",

--- a/web/lib/opal/src/layouts/content/ContentMd.tsx
+++ b/web/lib/opal/src/layouts/content/ContentMd.tsx
@@ -182,6 +182,12 @@ function ContentMd({
   }
   useImperativeHandle(editHandle, () => ({ startEditing }), [title]);
 
+  // Starting an edit must not double as a click on the parent row.
+  function handleTitleClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    startEditing();
+  }
+
   function commit() {
     const value = editValue.trim();
     if (value !== toPlainString(title)) onTitleChange?.(value);
@@ -257,15 +263,7 @@ function ContentMd({
               color="inherit"
               maxLines={titleMaxLines}
               title={toPlainString(title)}
-              onClick={
-                editable
-                  ? // Starting an edit must not double as a click on the parent row.
-                    (e: React.MouseEvent) => {
-                      e.stopPropagation();
-                      startEditing();
-                    }
-                  : undefined
-              }
+              onClick={editable ? handleTitleClick : undefined}
             >
               {title}
             </Text>

--- a/web/lib/opal/src/layouts/content/ContentMd.tsx
+++ b/web/lib/opal/src/layouts/content/ContentMd.tsx
@@ -66,10 +66,8 @@ interface ContentMdProps {
   /** Enable inline editing of the title. */
   editable?: boolean;
 
-  /** Hide the built-in pencil, for callers that trigger editing externally. */
-  hideEditButton?: boolean;
-
-  /** Handle for starting a title edit from an external control. */
+  /** Handle for starting a title edit from an external control. Setting it
+   *  hides the built-in pencil. */
   editHandle?: React.Ref<ContentMdEditHandle>;
 
   /** Called when the user commits an edit. */
@@ -162,7 +160,6 @@ function ContentMd({
   titleMaxLines,
   sizePreset = "main-ui",
   ref,
-  hideEditButton,
   editHandle,
 }: ContentMdProps) {
   const [editing, setEditing] = useState(false);
@@ -296,7 +293,7 @@ function ContentMd({
 
           {tag && <Tag {...tag} />}
 
-          {editable && !editing && !hideEditButton && (
+          {editable && !editing && editHandle == null && (
             <div
               className={cn(
                 "opal-content-md-edit-button",

--- a/web/lib/opal/src/layouts/content/components.tsx
+++ b/web/lib/opal/src/layouts/content/components.tsx
@@ -55,10 +55,8 @@ interface ContentBaseProps {
   /** Enable inline editing of the title. */
   editable?: boolean;
 
-  /** Hide the built-in pencil, for callers that trigger editing externally. */
-  hideEditButton?: boolean;
-
-  /** Handle for starting a title edit from an external control. */
+  /** Handle for starting a title edit from an external control. Setting it
+   *  hides the built-in pencil. */
   editHandle?: React.Ref<ContentMdEditHandle>;
 
   /** Called when the user commits an edit. */

--- a/web/lib/opal/src/layouts/content/components.tsx
+++ b/web/lib/opal/src/layouts/content/components.tsx
@@ -15,6 +15,7 @@ import {
 } from "@opal/layouts/content/ContentLg";
 import {
   ContentMd,
+  type ContentMdEditHandle,
   type ContentMdProps,
 } from "@opal/layouts/content/ContentMd";
 import type { TagProps } from "@opal/components";
@@ -53,6 +54,12 @@ interface ContentBaseProps {
 
   /** Enable inline editing of the title. */
   editable?: boolean;
+
+  /** Hide the built-in pencil, for callers that trigger editing externally. */
+  hideEditButton?: boolean;
+
+  /** Handle for starting a title edit from an external control. */
+  editHandle?: React.Ref<ContentMdEditHandle>;
 
   /** Called when the user commits an edit. */
   onTitleChange?: (newTitle: string) => void;

--- a/web/src/lib/languageModels/cache.ts
+++ b/web/src/lib/languageModels/cache.ts
@@ -1,5 +1,7 @@
 import { ScopedMutator } from "swr";
+import { toast } from "@opal/layouts";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import { setDefaultLlmModel } from "@/lib/languageModels/svc";
 
 const PERSONA_PROVIDER_ENDPOINT_PATTERN =
   /^\/api\/llm\/persona\/\d+\/providers$/;
@@ -15,4 +17,19 @@ export async function refreshLlmProviderCaches(
         typeof key === "string" && PERSONA_PROVIDER_ENDPOINT_PATTERN.test(key)
     ),
   ]);
+}
+
+export async function setDefaultLlmModelAndRefresh(
+  providerId: number,
+  modelName: string,
+  mutate: ScopedMutator
+): Promise<void> {
+  try {
+    await setDefaultLlmModel(providerId, modelName);
+    await refreshLlmProviderCaches(mutate);
+    toast.success("Default model updated successfully!");
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "Unknown error";
+    toast.error(`Failed to set default model: ${message}`);
+  }
 }

--- a/web/src/lib/languageModels/index.ts
+++ b/web/src/lib/languageModels/index.ts
@@ -149,8 +149,8 @@ const DEFAULT_ENTRY: ProviderEntry = {
   Modal: CustomModal,
 };
 
-// Providers that don't use custom_config themselves — if custom_config is
-// present it means the provider was originally created via CustomModal.
+// Providers that don't use custom_config themselves, so a non-empty
+// custom_config means the provider was originally created via CustomModal.
 const CUSTOM_CONFIG_OVERRIDES = new Set<string>([
   LLMProviderName.OPENAI,
   LLMProviderName.ANTHROPIC,
@@ -168,8 +168,8 @@ export function getProvider(
     companyName: providerName,
   };
 
-  // An empty custom_config means the backend stored a default, not that the
-  // provider came from the custom form.
+  // An empty custom_config carries no signal of origin. Only a non-empty map
+  // marks a provider created via the custom form.
   const customConfig = existingProvider?.custom_config;
   if (
     customConfig != null &&

--- a/web/src/lib/languageModels/index.ts
+++ b/web/src/lib/languageModels/index.ts
@@ -168,8 +168,12 @@ export function getProvider(
     companyName: providerName,
   };
 
+  // An empty custom_config means the backend stored a default, not that the
+  // provider came from the custom form.
+  const customConfig = existingProvider?.custom_config;
   if (
-    existingProvider?.custom_config != null &&
+    customConfig != null &&
+    Object.keys(customConfig).length > 0 &&
     CUSTOM_CONFIG_OVERRIDES.has(providerName)
   ) {
     return { ...entry, Modal: CustomModal };

--- a/web/src/lib/languageModels/types.ts
+++ b/web/src/lib/languageModels/types.ts
@@ -25,7 +25,8 @@ export interface ModelConfiguration {
    * case the picker falls back to the levels every reasoning model supports.
    */
   supported_reasoning_efforts?: ReasoningEffortOverride[];
-  /** Admin policy: what is permitted, vs what the model can do above. */
+  /** What the admin permits or defaults, distinct from
+   *  supported_reasoning_efforts (what the model can do). Null means unset. */
   reasoning_effort_max?: ReasoningEffortOverride | null;
   reasoning_effort_default?: ReasoningEffortOverride | null;
   temperature_default?: number | null;

--- a/web/src/lib/languageModels/types.ts
+++ b/web/src/lib/languageModels/types.ts
@@ -25,6 +25,10 @@ export interface ModelConfiguration {
    * case the picker falls back to the levels every reasoning model supports.
    */
   supported_reasoning_efforts?: ReasoningEffortOverride[];
+  /** Admin policy: what is permitted, vs what the model can do above. */
+  reasoning_effort_max?: ReasoningEffortOverride | null;
+  reasoning_effort_default?: ReasoningEffortOverride | null;
+  temperature_default?: number | null;
   /** Display-only metadata surfaced in the model picker (Nebius TokenFactory). */
   quantization?: string | null;
   country_code?: string | null;

--- a/web/src/lib/languageModels/utils.ts
+++ b/web/src/lib/languageModels/utils.ts
@@ -163,6 +163,17 @@ export const modelSupportsImageInput = (
   return modelConfiguration?.supports_image_input || false;
 };
 
+/** Display name for form-state model rows, which do not reliably carry
+ *  effectiveDisplayName. Everything else should read that field instead. */
+export function modelDisplayName(
+  model: Pick<
+    ModelConfiguration,
+    "name" | "display_name" | "custom_display_name"
+  >
+): string {
+  return model.custom_display_name || model.display_name || model.name;
+}
+
 export function getDisplayName(
   agent: MinimalAgent,
   llmProviders: LLMProviderDescriptor[]

--- a/web/src/sections/modals/languageModels/BedrockModal.tsx
+++ b/web/src/sections/modals/languageModels/BedrockModal.tsx
@@ -17,7 +17,7 @@ import {
   useInitialValues,
   buildValidationSchema,
   BaseLLMFormValues,
-  mergeFetchedModelConfigurations,
+  withFetchedModels,
 } from "@/sections/modals/languageModels/utils";
 import { submitProvider } from "@/sections/modals/languageModels/svc";
 import { LLMProviderConfiguredSource } from "@/lib/analytics/utils";
@@ -117,15 +117,7 @@ function BedrockModalInternals({
     if (error) {
       throw new Error(error);
     }
-    // Functional form: an edit made while the fetch was in flight must not be
-    // reverted by the snapshot this handler closed over.
-    formikProps.setValues((prev) => ({
-      ...prev,
-      model_configurations: mergeFetchedModelConfigurations(
-        models,
-        prev.model_configurations
-      ),
-    }));
+    formikProps.setValues(withFetchedModels(models));
   };
 
   return (

--- a/web/src/sections/modals/languageModels/BedrockModal.tsx
+++ b/web/src/sections/modals/languageModels/BedrockModal.tsx
@@ -117,13 +117,15 @@ function BedrockModalInternals({
     if (error) {
       throw new Error(error);
     }
-    formikProps.setFieldValue(
-      "model_configurations",
-      mergeFetchedModelConfigurations(
+    // Functional form: an edit made while the fetch was in flight must not be
+    // reverted by the snapshot this handler closed over.
+    formikProps.setValues((prev) => ({
+      ...prev,
+      model_configurations: mergeFetchedModelConfigurations(
         models,
-        formikProps.values.model_configurations
-      )
-    );
+        prev.model_configurations
+      ),
+    }));
   };
 
   return (

--- a/web/src/sections/modals/languageModels/BifrostModal.tsx
+++ b/web/src/sections/modals/languageModels/BifrostModal.tsx
@@ -16,7 +16,7 @@ import {
   useInitialValues,
   buildValidationSchema,
   BaseLLMFormValues,
-  mergeFetchedModelConfigurations,
+  withFetchedModels,
 } from "@/sections/modals/languageModels/utils";
 import { submitProvider } from "@/sections/modals/languageModels/svc";
 import { LLMProviderConfiguredSource } from "@/lib/analytics/utils";
@@ -83,15 +83,7 @@ function BifrostModalInternals({
     if (error) {
       throw new Error(error);
     }
-    // Functional form: an edit made while the fetch was in flight must not be
-    // reverted by the snapshot this handler closed over.
-    formikProps.setValues((prev) => ({
-      ...prev,
-      model_configurations: mergeFetchedModelConfigurations(
-        models,
-        prev.model_configurations
-      ),
-    }));
+    formikProps.setValues(withFetchedModels(models));
   };
 
   return (

--- a/web/src/sections/modals/languageModels/BifrostModal.tsx
+++ b/web/src/sections/modals/languageModels/BifrostModal.tsx
@@ -83,13 +83,15 @@ function BifrostModalInternals({
     if (error) {
       throw new Error(error);
     }
-    formikProps.setFieldValue(
-      "model_configurations",
-      mergeFetchedModelConfigurations(
+    // Functional form: an edit made while the fetch was in flight must not be
+    // reverted by the snapshot this handler closed over.
+    formikProps.setValues((prev) => ({
+      ...prev,
+      model_configurations: mergeFetchedModelConfigurations(
         models,
-        formikProps.values.model_configurations
-      )
-    );
+        prev.model_configurations
+      ),
+    }));
   };
 
   return (

--- a/web/src/sections/modals/languageModels/CustomModal.tsx
+++ b/web/src/sections/modals/languageModels/CustomModal.tsx
@@ -9,7 +9,10 @@ import {
 } from "@/lib/languageModels/types";
 import type { ModelConfiguration } from "@/lib/languageModels/types";
 import * as Yup from "yup";
-import { useInitialValues } from "@/sections/modals/languageModels/utils";
+import {
+  clampModelSettings,
+  useInitialValues,
+} from "@/sections/modals/languageModels/utils";
 import { submitProvider } from "@/sections/modals/languageModels/svc";
 import { LLMProviderConfiguredSource } from "@/lib/analytics/utils";
 import {
@@ -273,8 +276,10 @@ export default function CustomModal({
     ),
     provider: existingLlmProvider?.provider ?? "",
     api_version: existingLlmProvider?.api_version ?? "",
-    model_configurations: existingLlmProvider?.model_configurations.map(
-      (mc) => ({
+    model_configurations: existingLlmProvider?.model_configurations.map((mc) =>
+      // Stored policy can exceed a capability that shrank since the save,
+      // and the API rejects such values on submit.
+      clampModelSettings({
         name: mc.name,
         display_name: mc.display_name ?? "",
         is_visible: mc.is_visible,

--- a/web/src/sections/modals/languageModels/CustomModal.tsx
+++ b/web/src/sections/modals/languageModels/CustomModal.tsx
@@ -115,7 +115,7 @@ function ModelConfigurationItem({
         type="number"
       />
       <ModelSettingsPopover
-        model={{ is_visible: true, effectiveDisplayName: model.name, ...model }}
+        model={model}
         onChange={(patch) => onChange({ ...model, ...patch })}
       />
       <Button

--- a/web/src/sections/modals/languageModels/CustomModal.tsx
+++ b/web/src/sections/modals/languageModels/CustomModal.tsx
@@ -300,6 +300,10 @@ export default function CustomModal({
         max_input_tokens: null,
         supports_image_input: false,
         supports_reasoning: false,
+        supported_reasoning_efforts: undefined,
+        reasoning_effort_max: null,
+        reasoning_effort_default: null,
+        temperature_default: null,
         effectiveDisplayName: "",
       },
     ],
@@ -350,7 +354,11 @@ export default function CustomModal({
             is_visible: true,
             max_input_tokens: mc.max_input_tokens ?? null,
             supports_image_input: mc.supports_image_input,
-            supports_reasoning: false,
+            supports_reasoning: mc.supports_reasoning,
+            supported_reasoning_efforts: mc.supported_reasoning_efforts,
+            reasoning_effort_max: mc.reasoning_effort_max,
+            reasoning_effort_default: mc.reasoning_effort_default,
+            temperature_default: mc.temperature_default,
             effectiveDisplayName: mc.display_name || mc.name,
           }));
 

--- a/web/src/sections/modals/languageModels/CustomModal.tsx
+++ b/web/src/sections/modals/languageModels/CustomModal.tsx
@@ -20,6 +20,7 @@ import {
   ModalWrapper,
   useApiBaseSubDescription,
 } from "@/sections/modals/languageModels/shared";
+import { ModelSettingsPopover } from "@/sections/modals/languageModels/ModelSettingsPopover";
 import { useCustomProviderNames } from "@/lib/languageModels/hooks";
 import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 import KeyValueInput, {
@@ -44,11 +45,19 @@ import { Section } from "@/layouts/general-layouts";
 
 // ─── Model Configuration List ─────────────────────────────────────────────────
 
-const MODEL_GRID_COLS = "grid-cols-[2fr_2fr_minmax(10rem,1fr)_1fr_2.25rem]";
+const MODEL_GRID_COLS =
+  "grid-cols-[2fr_2fr_minmax(10rem,1fr)_1fr_2.25rem_2.25rem]";
 
 type CustomModelConfiguration = Pick<
   ModelConfiguration,
-  "name" | "max_input_tokens" | "supports_image_input"
+  | "name"
+  | "max_input_tokens"
+  | "supports_image_input"
+  | "supports_reasoning"
+  | "supported_reasoning_efforts"
+  | "reasoning_effort_max"
+  | "reasoning_effort_default"
+  | "temperature_default"
 > & {
   display_name: string;
 };
@@ -102,6 +111,10 @@ function ModelConfigurationItem({
         }
         type="number"
       />
+      <ModelSettingsPopover
+        model={{ is_visible: true, effectiveDisplayName: model.name, ...model }}
+        onChange={(patch) => onChange({ ...model, ...patch })}
+      />
       <Button
         disabled={!canRemove}
         prominence="tertiary"
@@ -139,6 +152,7 @@ function ModelConfigurationList() {
         display_name: "",
         max_input_tokens: null,
         supports_image_input: false,
+        supports_reasoning: false,
       },
     ]);
   }
@@ -153,6 +167,7 @@ function ModelConfigurationList() {
           <Text mainUiAction>Display Name</Text>
           <Text mainUiAction>Input Type</Text>
           <Text mainUiAction>Max Tokens</Text>
+          <div aria-hidden />
           <div aria-hidden />
 
           {models.map((model, index) => (
@@ -266,6 +281,10 @@ export default function CustomModal({
         max_input_tokens: mc.max_input_tokens ?? null,
         supports_image_input: mc.supports_image_input,
         supports_reasoning: mc.supports_reasoning,
+        supported_reasoning_efforts: mc.supported_reasoning_efforts,
+        reasoning_effort_max: mc.reasoning_effort_max,
+        reasoning_effort_default: mc.reasoning_effort_default,
+        temperature_default: mc.temperature_default,
         effectiveDisplayName: mc.effectiveDisplayName,
       })
     ) ?? [

--- a/web/src/sections/modals/languageModels/LMStudioModal.tsx
+++ b/web/src/sections/modals/languageModels/LMStudioModal.tsx
@@ -64,13 +64,15 @@ function LMStudioModalInternals({
     if (data.error) {
       throw new Error(data.error);
     }
-    formikProps.setFieldValue(
-      "model_configurations",
-      mergeFetchedModelConfigurations(
+    // Functional form: an edit made while the fetch was in flight must not be
+    // reverted by the snapshot this handler closed over.
+    formikProps.setValues((prev) => ({
+      ...prev,
+      model_configurations: mergeFetchedModelConfigurations(
         data.models,
-        formikProps.values.model_configurations
-      )
-    );
+        prev.model_configurations
+      ),
+    }));
   };
 
   return (

--- a/web/src/sections/modals/languageModels/LMStudioModal.tsx
+++ b/web/src/sections/modals/languageModels/LMStudioModal.tsx
@@ -12,7 +12,7 @@ import {
   useInitialValues,
   buildValidationSchema,
   BaseLLMFormValues as BaseLLMModalValues,
-  mergeFetchedModelConfigurations,
+  withFetchedModels,
 } from "@/sections/modals/languageModels/utils";
 import { submitProvider } from "@/sections/modals/languageModels/svc";
 import { LLMProviderConfiguredSource } from "@/lib/analytics/utils";
@@ -64,15 +64,7 @@ function LMStudioModalInternals({
     if (data.error) {
       throw new Error(data.error);
     }
-    // Functional form: an edit made while the fetch was in flight must not be
-    // reverted by the snapshot this handler closed over.
-    formikProps.setValues((prev) => ({
-      ...prev,
-      model_configurations: mergeFetchedModelConfigurations(
-        data.models,
-        prev.model_configurations
-      ),
-    }));
+    formikProps.setValues(withFetchedModels(data.models));
   };
 
   return (

--- a/web/src/sections/modals/languageModels/LiteLLMProxyModal.tsx
+++ b/web/src/sections/modals/languageModels/LiteLLMProxyModal.tsx
@@ -57,13 +57,15 @@ function LiteLLMProxyModalInternals({
     if (error) {
       throw new Error(error);
     }
-    formikProps.setFieldValue(
-      "model_configurations",
-      mergeFetchedModelConfigurations(
+    // Functional form: an edit made while the fetch was in flight must not be
+    // reverted by the snapshot this handler closed over.
+    formikProps.setValues((prev) => ({
+      ...prev,
+      model_configurations: mergeFetchedModelConfigurations(
         models,
-        formikProps.values.model_configurations
-      )
-    );
+        prev.model_configurations
+      ),
+    }));
   };
 
   return (

--- a/web/src/sections/modals/languageModels/LiteLLMProxyModal.tsx
+++ b/web/src/sections/modals/languageModels/LiteLLMProxyModal.tsx
@@ -13,7 +13,7 @@ import {
   useInitialValues,
   buildValidationSchema,
   BaseLLMFormValues,
-  mergeFetchedModelConfigurations,
+  withFetchedModels,
 } from "@/sections/modals/languageModels/utils";
 import { submitProvider } from "@/sections/modals/languageModels/svc";
 import { LLMProviderConfiguredSource } from "@/lib/analytics/utils";
@@ -57,15 +57,7 @@ function LiteLLMProxyModalInternals({
     if (error) {
       throw new Error(error);
     }
-    // Functional form: an edit made while the fetch was in flight must not be
-    // reverted by the snapshot this handler closed over.
-    formikProps.setValues((prev) => ({
-      ...prev,
-      model_configurations: mergeFetchedModelConfigurations(
-        models,
-        prev.model_configurations
-      ),
-    }));
+    formikProps.setValues(withFetchedModels(models));
   };
 
   return (

--- a/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
+++ b/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
@@ -1,28 +1,31 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import { Button, Popover, Text } from "@opal/components";
+import { Button, Popover, Text, Tooltip } from "@opal/components";
 import { SvgBarChart, SvgCode, SvgSliders, SvgThermometer } from "@opal/icons";
 import { Section } from "@opal/layouts";
+import { Disabled } from "@opal/core";
+import type { IconFunctionComponent } from "@opal/types";
 import { isAnthropic } from "@/lib/languageModels/svc";
-import type {
-  ModelConfiguration,
-  ReasoningEffortOverride,
-} from "@/lib/languageModels/types";
+import type { ModelConfiguration } from "@/lib/languageModels/types";
 import {
   ALL_REASONING_STOPS,
   PaneSlider,
   REASONING_STOP_LABELS,
-  SettingRow,
   UNKNOWN_CONTEXT_TOOLTIP,
   formatContextWindow,
   maxReasoningStop,
   reasoningStopIndex,
 } from "@/sections/model-selector/setting-controls";
 
+const PINNED_TEMPERATURE_TOOLTIP =
+  "Reasoning models always run at temperature 1.";
+
 /** Where an unset slider parks: the value the backend would apply anyway. */
 const UNSET_REASONING_STOP = ALL_REASONING_STOPS.indexOf("medium");
 const UNSET_TEMPERATURE = 0;
+
+const TEMPERATURE_MARKS = ["Deterministic", "Balanced", "Creative"];
 
 export type ModelSettingsPatch = Partial<
   Pick<
@@ -36,17 +39,107 @@ interface ModelSettingsPopoverProps {
   onChange: (patch: ModelSettingsPatch) => void;
 }
 
-interface ResetToAutoProps {
-  onClick: () => void;
+interface SectionHeaderProps {
+  icon: IconFunctionComponent;
+  title: string;
+  caption: string;
+  rightValue?: string;
+  rightValueTooltip?: string;
 }
 
-function ResetToAuto({ onClick }: ResetToAutoProps) {
+/** Mock spec: 8px padding, 20px icon box, 4px gap, 2px text insets. */
+function SectionHeader({
+  icon: Icon,
+  title,
+  caption,
+  rightValue,
+  rightValueTooltip,
+}: SectionHeaderProps) {
+  // raw-ok: mock needs 2px text insets and a flex-1/min-w-0 column, and Section silences px-*
   return (
-    <Section flexDirection="row" justifyContent="end" height="auto">
-      <Button prominence="tertiary" onClick={onClick}>
-        Reset to auto
-      </Button>
-    </Section>
+    <div className="flex w-full gap-1 p-2">
+      <div className="flex size-5 shrink-0 items-center justify-center p-0.5 text-text-04">
+        <Icon size={16} />
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="flex w-full items-start gap-1">
+          <div className="flex min-h-5 min-w-0 flex-1 flex-col justify-center px-0.5">
+            <Text font="main-ui-action" color="text-04" nowrap>
+              {title}
+            </Text>
+          </div>
+          {rightValue !== undefined && (
+            <div className="flex min-h-5 items-center p-0.5">
+              <Tooltip tooltip={rightValueTooltip} side="top">
+                <Text font="secondary-mono" color="text-04" nowrap>
+                  {rightValue}
+                </Text>
+              </Tooltip>
+            </div>
+          )}
+        </div>
+        <div className="px-0.5">
+          <Text font="secondary-body" color="text-03">
+            {caption}
+          </Text>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface PolicySliderProps {
+  label: string;
+  value: number;
+  max: number;
+  step: number;
+  marks: string[];
+  activeMark: number;
+  onChange: (value: number) => void;
+}
+
+/** Mock spec: 32px left inset, 8px right, 16px label line, 28px slider. */
+function PolicySlider({
+  label,
+  value,
+  max,
+  step,
+  marks,
+  activeMark,
+  onChange,
+}: PolicySliderProps) {
+  // raw-ok: mock needs asymmetric pl-8/pr-2, and Section silences p-* utilities
+  return (
+    <div className="w-full pl-8 pr-2">
+      <div className="px-0.5">
+        <Text font="secondary-action" color="text-03" nowrap>
+          {label}
+        </Text>
+      </div>
+      <div className="p-0.5">
+        <PaneSlider
+          compact
+          value={value}
+          min={0}
+          max={max}
+          step={step}
+          onValueChange={onChange}
+          onValueCommit={onChange}
+        />
+        <div className="flex w-full items-center justify-between">
+          {marks.map((mark, index) => (
+            <Text
+              key={mark}
+              font="figure-small-value"
+              color={index === activeMark ? "text-04" : "text-02"}
+              nowrap
+            >
+              {mark}
+            </Text>
+          ))}
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -65,22 +158,33 @@ export function ModelSettingsPopover({
   const supportedStop = maxReasoningStop(model.supported_reasoning_efforts);
   // No supported levels means the model takes no effort parameter at all.
   const showReasoning = model.supports_reasoning && supportedStop >= 0;
-  // The backend pins reasoning models to 1, so a default would never apply.
-  const showTemperature = !model.supports_reasoning;
+  // The backend pins reasoning models to 1, so the control renders disabled.
+  const temperatureDisabled = model.supports_reasoning;
   const maxTemperature = isAnthropic(model.vendor ?? "", model.name) ? 1 : 2;
 
   const maxStop = reasoningStopIndex(model.reasoning_effort_max);
   const rawDefaultStop = reasoningStopIndex(model.reasoning_effort_default);
-  // Capability bounds the stored cap too, in case the model's supported levels
-  // shrank after the cap was saved.
+  // Capability bounds the stored cap too, in case it shrank after the save.
   const effectiveMaxStop = Math.min(
     maxStop >= 0 ? maxStop : supportedStop,
     supportedStop
   );
-  // Read back clamped as well as rendered clamped, so the label never advertises
-  // a level the model lost since the value was saved.
   const defaultStop =
     rawDefaultStop >= 0 ? Math.min(rawDefaultStop, effectiveMaxStop) : -1;
+
+  const reasoningMarks = ALL_REASONING_STOPS.slice(0, supportedStop + 1).map(
+    (stop) => REASONING_STOP_LABELS[stop]
+  );
+  const temperature = model.temperature_default ?? UNSET_TEMPERATURE;
+  const temperatureMark = Math.min(
+    Math.floor((temperature / maxTemperature) * TEMPERATURE_MARKS.length),
+    TEMPERATURE_MARKS.length - 1
+  );
+
+  const capabilities = [
+    model.supports_reasoning && "reasoning",
+    model.supports_image_input && "multi-modal",
+  ].filter(Boolean);
 
   function setMax(stop: number) {
     const effort = ALL_REASONING_STOPS[Math.min(stop, supportedStop)];
@@ -104,121 +208,100 @@ export function ModelSettingsPopover({
         <Button
           ref={anchorRef}
           icon={SvgSliders}
-          prominence="tertiary"
+          prominence="internal"
+          size="sm"
           tooltip="Model Settings"
           onClick={(e: React.MouseEvent) => e.stopPropagation()}
         />
       </Popover.Trigger>
-      <Popover.Content width="md" container={container} align="end">
-        <Section alignItems="stretch" height="auto" gap={1} padding={1}>
-          <Section alignItems="stretch" height="auto" gap={0} padding={1.5}>
-            <Text font="main-ui-action">
+      <Popover.Content width="fit" container={container} align="end">
+        <Section alignItems="stretch" width={17} height="auto" gap={0.25}>
+          {/* raw-ok: mock header needs 10px/8px asymmetric padding, and Section silences px-* */}
+          <div className="flex w-full flex-col justify-center px-2.5 py-2">
+            <Text font="main-ui-body" color="text-02" nowrap>
               {model.custom_display_name || model.display_name || model.name}
             </Text>
-            <Text font="secondary-body" color="text-03">
-              {model.supports_reasoning ? "Reasoning model" : "Chat model"}
+            <Text font="secondary-body" color="text-02">
+              {capabilities.length ? capabilities.join(", ") : "chat"}
             </Text>
-          </Section>
+          </div>
 
-          <SettingRow
+          <SectionHeader
             icon={SvgCode}
             title="Context Window"
-            value={
+            caption="Tokens limit for each session"
+            rightValue={
               model.max_input_tokens
                 ? formatContextWindow(model.max_input_tokens)
-                : "—"
+                : "\u2014"
             }
-            valueTooltip={
+            rightValueTooltip={
               model.max_input_tokens ? undefined : UNKNOWN_CONTEXT_TOOLTIP
             }
-            caption="How much text this model can consider at once."
           />
 
           {showReasoning && (
-            <>
-              <SettingRow
+            <Section
+              alignItems="stretch"
+              height="auto"
+              gap={0.375}
+              className="mb-1.5"
+            >
+              <SectionHeader
                 icon={SvgBarChart}
-                title="Reasoning Level, Max"
-                value={
-                  maxStop >= 0
-                    ? REASONING_STOP_LABELS[
-                        ALL_REASONING_STOPS[effectiveMaxStop]!
-                      ]
-                    : "Auto"
-                }
-                caption="The most reasoning a user can request for this model."
-              >
-                <PaneSlider
-                  value={effectiveMaxStop}
-                  min={0}
-                  max={supportedStop}
-                  step={1}
-                  onValueChange={setMax}
-                  onValueCommit={setMax}
-                />
-              </SettingRow>
-
-              <SettingRow
-                icon={SvgBarChart}
-                title="Reasoning Level, Default"
-                value={
-                  defaultStop >= 0
-                    ? REASONING_STOP_LABELS[ALL_REASONING_STOPS[defaultStop]!]
-                    : "Auto"
-                }
-                caption="Where a chat starts when the user has not chosen a level."
-              >
-                <PaneSlider
-                  value={Math.min(
-                    defaultStop >= 0 ? defaultStop : UNSET_REASONING_STOP,
-                    effectiveMaxStop
-                  )}
-                  min={0}
-                  max={effectiveMaxStop}
-                  step={1}
-                  onValueChange={setDefault}
-                  onValueCommit={setDefault}
-                />
-              </SettingRow>
-
-              <ResetToAuto
-                onClick={() =>
-                  onChange({
-                    reasoning_effort_max: null,
-                    reasoning_effort_default: null,
-                  })
-                }
+                title="Reasoning Level"
+                caption="How much thinking the model should perform before answering"
               />
-            </>
+              <PolicySlider
+                label="Max Level"
+                value={effectiveMaxStop}
+                max={supportedStop}
+                step={1}
+                marks={reasoningMarks}
+                activeMark={effectiveMaxStop}
+                onChange={setMax}
+              />
+              <PolicySlider
+                label="Default"
+                value={defaultStop >= 0 ? defaultStop : UNSET_REASONING_STOP}
+                max={effectiveMaxStop}
+                step={1}
+                marks={reasoningMarks}
+                activeMark={
+                  defaultStop >= 0 ? defaultStop : UNSET_REASONING_STOP
+                }
+                onChange={setDefault}
+              />
+            </Section>
           )}
 
-          {showTemperature && (
-            <>
-              <SettingRow
+          <Disabled
+            disabled={temperatureDisabled}
+            tooltip={PINNED_TEMPERATURE_TOOLTIP}
+            tooltipSide="top"
+          >
+            <Section
+              alignItems="stretch"
+              height="auto"
+              gap={0.375}
+              className="mb-1.5"
+            >
+              <SectionHeader
                 icon={SvgThermometer}
-                title="Temperature, Default"
-                value={
-                  model.temperature_default != null
-                    ? model.temperature_default.toFixed(1)
-                    : "Auto"
-                }
-                caption="Lower is more deterministic, higher is more creative."
-              >
-                <PaneSlider
-                  value={model.temperature_default ?? UNSET_TEMPERATURE}
-                  min={0}
-                  max={maxTemperature}
-                  step={0.1}
-                  onValueChange={(v) => onChange({ temperature_default: v })}
-                  onValueCommit={(v) => onChange({ temperature_default: v })}
-                />
-              </SettingRow>
-
-              <ResetToAuto
-                onClick={() => onChange({ temperature_default: null })}
+                title="Temperature"
+                caption="How predictable or creative the model should respond"
               />
-            </>
-          )}
+              <PolicySlider
+                label="Default"
+                value={temperatureDisabled ? 1 : temperature}
+                max={maxTemperature}
+                step={0.1}
+                marks={TEMPERATURE_MARKS}
+                activeMark={temperatureMark}
+                onChange={(v) => onChange({ temperature_default: v })}
+              />
+            </Section>
+          </Disabled>
         </Section>
       </Popover.Content>
     </Popover>

--- a/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
+++ b/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
@@ -213,94 +213,97 @@ export function ModelSettingsPopover({
         />
       </Popover.Trigger>
       <Popover.Content width="fit" align="end">
-        <Section alignItems="stretch" width={17} height="auto" gap={0.25}>
-          {/* raw-ok: mock header needs 10px/8px asymmetric padding, and Section silences px-* */}
-          <div className="flex w-full flex-col justify-center px-2.5 py-2">
-            <Text font="main-ui-body" color="text-02" nowrap>
-              {model.custom_display_name || model.display_name || model.name}
-            </Text>
-            <Text font="secondary-body" color="text-02">
-              {capabilities.length ? capabilities.join(", ") : "chat"}
-            </Text>
-          </div>
+        {/* raw-ok: scroll shell, Popover.Content clips overflow when the viewport is short */}
+        <div className="min-h-0 w-full overflow-y-auto">
+          <Section alignItems="stretch" width={17} height="auto" gap={0.25}>
+            {/* raw-ok: mock header needs 10px/8px asymmetric padding, and Section silences px-* */}
+            <div className="flex w-full flex-col justify-center px-2.5 py-2">
+              <Text font="main-ui-body" color="text-02" nowrap>
+                {model.custom_display_name || model.display_name || model.name}
+              </Text>
+              <Text font="secondary-body" color="text-02">
+                {capabilities.length ? capabilities.join(", ") : "chat"}
+              </Text>
+            </div>
 
-          <SectionHeader
-            icon={SvgCode}
-            title="Context Window"
-            caption="Tokens limit for each session"
-            rightValue={
-              model.max_input_tokens
-                ? formatContextWindow(model.max_input_tokens)
-                : "\u2014"
-            }
-            rightValueTooltip={
-              model.max_input_tokens ? undefined : UNKNOWN_CONTEXT_TOOLTIP
-            }
-          />
+            <SectionHeader
+              icon={SvgCode}
+              title="Context Window"
+              caption="Tokens limit for each session"
+              rightValue={
+                model.max_input_tokens
+                  ? formatContextWindow(model.max_input_tokens)
+                  : "\u2014"
+              }
+              rightValueTooltip={
+                model.max_input_tokens ? undefined : UNKNOWN_CONTEXT_TOOLTIP
+              }
+            />
 
-          {showReasoning && (
-            <Section
-              alignItems="stretch"
-              height="auto"
-              gap={0.375}
-              className="mb-1.5"
+            {showReasoning && (
+              <Section
+                alignItems="stretch"
+                height="auto"
+                gap={0.375}
+                className="mb-1.5"
+              >
+                <SectionHeader
+                  icon={SvgBarChart}
+                  title="Reasoning Level"
+                  caption="How much thinking the model should perform before answering"
+                />
+                <PolicySlider
+                  label="Max Level"
+                  value={effectiveMaxStop}
+                  max={supportedStop}
+                  step={1}
+                  marks={reasoningMarks}
+                  activeMark={effectiveMaxStop}
+                  onChange={setMax}
+                />
+                <PolicySlider
+                  label="Default"
+                  value={defaultStop >= 0 ? defaultStop : UNSET_REASONING_STOP}
+                  max={effectiveMaxStop}
+                  step={1}
+                  marks={reasoningMarks}
+                  activeMark={
+                    defaultStop >= 0 ? defaultStop : UNSET_REASONING_STOP
+                  }
+                  onChange={setDefault}
+                />
+              </Section>
+            )}
+
+            <Disabled
+              disabled={temperatureDisabled}
+              tooltip={PINNED_TEMPERATURE_TOOLTIP}
+              tooltipSide="top"
             >
-              <SectionHeader
-                icon={SvgBarChart}
-                title="Reasoning Level"
-                caption="How much thinking the model should perform before answering"
-              />
-              <PolicySlider
-                label="Max Level"
-                value={effectiveMaxStop}
-                max={supportedStop}
-                step={1}
-                marks={reasoningMarks}
-                activeMark={effectiveMaxStop}
-                onChange={setMax}
-              />
-              <PolicySlider
-                label="Default"
-                value={defaultStop >= 0 ? defaultStop : UNSET_REASONING_STOP}
-                max={effectiveMaxStop}
-                step={1}
-                marks={reasoningMarks}
-                activeMark={
-                  defaultStop >= 0 ? defaultStop : UNSET_REASONING_STOP
-                }
-                onChange={setDefault}
-              />
-            </Section>
-          )}
-
-          <Disabled
-            disabled={temperatureDisabled}
-            tooltip={PINNED_TEMPERATURE_TOOLTIP}
-            tooltipSide="top"
-          >
-            <Section
-              alignItems="stretch"
-              height="auto"
-              gap={0.375}
-              className="mb-1.5"
-            >
-              <SectionHeader
-                icon={SvgThermometer}
-                title="Temperature"
-                caption="How predictable or creative the model should respond"
-              />
-              <PolicySlider
-                label="Default"
-                value={temperatureDisabled ? 1 : temperature}
-                max={maxTemperature}
-                step={0.1}
-                marks={TEMPERATURE_MARKS}
-                activeMark={temperatureMark}
-                onChange={(v) => onChange({ temperature_default: v })}
-              />
-            </Section>
-          </Disabled>
-        </Section>
+              <Section
+                alignItems="stretch"
+                height="auto"
+                gap={0.375}
+                className="mb-1.5"
+              >
+                <SectionHeader
+                  icon={SvgThermometer}
+                  title="Temperature"
+                  caption="How predictable or creative the model should respond"
+                />
+                <PolicySlider
+                  label="Default"
+                  value={temperatureDisabled ? 1 : temperature}
+                  max={maxTemperature}
+                  step={0.1}
+                  marks={TEMPERATURE_MARKS}
+                  activeMark={temperatureMark}
+                  onChange={(v) => onChange({ temperature_default: v })}
+                />
+              </Section>
+            </Disabled>
+          </Section>
+        </div>
       </Popover.Content>
     </Popover>
   );

--- a/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
+++ b/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
@@ -191,8 +191,12 @@ export function ModelSettingsPopover({
     maxStop >= 0 ? Math.min(maxStop, supportedStop) : supportedStop;
   const defaultStop =
     rawDefaultStop >= 0 ? Math.min(rawDefaultStop, effectiveMaxStop) : -1;
+  // An unset default parks where the backend resolves AUTO: medium, bounded
+  // by the cap.
   const defaultSliderStop =
-    defaultStop >= 0 ? defaultStop : UNSET_REASONING_STOP;
+    defaultStop >= 0
+      ? defaultStop
+      : Math.min(UNSET_REASONING_STOP, effectiveMaxStop);
 
   const reasoningMarks = ALL_REASONING_STOPS.slice(0, supportedStop + 1).map(
     (stop) => REASONING_STOP_LABELS[stop]
@@ -295,7 +299,7 @@ export function ModelSettingsPopover({
               <PolicySlider
                 label="Default"
                 value={defaultSliderStop}
-                max={effectiveMaxStop}
+                max={supportedStop}
                 step={1}
                 marks={reasoningMarks}
                 activeMark={defaultSliderStop}

--- a/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
+++ b/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
@@ -55,9 +55,9 @@ function SectionHeader({
   rightValue,
   rightValueTooltip,
 }: SectionHeaderProps) {
-  // raw-ok: mock needs 2px text insets and a flex-1/min-w-0 column, and Section silences px-*
   return (
-    <div className="flex w-full gap-1 p-2">
+    // raw-ok: mock needs 2px text insets and a flex-1/min-w-0 column, and Section silences px-*
+    <div className="flex w-full gap-1 px-2 pb-0.5 pt-2">
       <div className="flex size-5 shrink-0 items-center justify-center p-0.5 text-text-04">
         <Icon size={16} />
       </div>
@@ -78,7 +78,8 @@ function SectionHeader({
             </div>
           )}
         </div>
-        <div className="px-0.5">
+        {/* raw-ok: flex collapses the strut so the caption sits on the font's 16px lines */}
+        <div className="flex px-0.5">
           <Text font="secondary-body" color="text-03">
             {caption}
           </Text>
@@ -111,7 +112,8 @@ function PolicySlider({
   // raw-ok: mock needs asymmetric pl-8/pr-2, and Section silences p-* utilities
   return (
     <div className="w-full pl-8 pr-2">
-      <div className="px-0.5">
+      {/* raw-ok: flex collapses the strut so the label sits on the font's 16px line */}
+      <div className="flex px-0.5">
         <Text font="secondary-action" color="text-03" nowrap>
           {label}
         </Text>
@@ -126,7 +128,8 @@ function PolicySlider({
           onValueChange={onChange}
           onValueCommit={onChange}
         />
-        <div className="flex w-full items-center justify-between">
+        {/* raw-ok: mock annotation row is a fixed 12px line inside the 28px slider */}
+        <div className="flex h-3 w-full items-center justify-between">
           {marks.map((mark, index) => (
             <Text
               key={mark}
@@ -213,97 +216,94 @@ export function ModelSettingsPopover({
         />
       </Popover.Trigger>
       <Popover.Content width="fit" align="end">
-        {/* raw-ok: scroll shell, Popover.Content clips overflow when the viewport is short */}
-        <div className="min-h-0 w-full overflow-y-auto">
-          <Section alignItems="stretch" width={17} height="auto" gap={0.25}>
-            {/* raw-ok: mock header needs 10px/8px asymmetric padding, and Section silences px-* */}
-            <div className="flex w-full flex-col justify-center px-2.5 py-2">
-              <Text font="main-ui-body" color="text-02" nowrap>
-                {model.custom_display_name || model.display_name || model.name}
-              </Text>
-              <Text font="secondary-body" color="text-02">
-                {capabilities.length ? capabilities.join(", ") : "chat"}
-              </Text>
-            </div>
+        <Section alignItems="stretch" width={17} height="auto" gap={0.25}>
+          {/* raw-ok: mock header needs 10px/8px asymmetric padding, and Section silences px-* */}
+          <div className="flex w-full flex-col justify-center px-2.5 py-2">
+            <Text font="main-ui-body" color="text-02" nowrap>
+              {model.custom_display_name || model.display_name || model.name}
+            </Text>
+            <Text font="secondary-body" color="text-02">
+              {capabilities.length ? capabilities.join(", ") : "chat"}
+            </Text>
+          </div>
 
-            <SectionHeader
-              icon={SvgCode}
-              title="Context Window"
-              caption="Tokens limit for each session"
-              rightValue={
-                model.max_input_tokens
-                  ? formatContextWindow(model.max_input_tokens)
-                  : "\u2014"
-              }
-              rightValueTooltip={
-                model.max_input_tokens ? undefined : UNKNOWN_CONTEXT_TOOLTIP
-              }
-            />
+          <SectionHeader
+            icon={SvgCode}
+            title="Context Window"
+            caption="Tokens limit for each session"
+            rightValue={
+              model.max_input_tokens
+                ? formatContextWindow(model.max_input_tokens)
+                : "\u2014"
+            }
+            rightValueTooltip={
+              model.max_input_tokens ? undefined : UNKNOWN_CONTEXT_TOOLTIP
+            }
+          />
 
-            {showReasoning && (
-              <Section
-                alignItems="stretch"
-                height="auto"
-                gap={0.375}
-                className="mb-1.5"
-              >
-                <SectionHeader
-                  icon={SvgBarChart}
-                  title="Reasoning Level"
-                  caption="How much thinking the model should perform before answering"
-                />
-                <PolicySlider
-                  label="Max Level"
-                  value={effectiveMaxStop}
-                  max={supportedStop}
-                  step={1}
-                  marks={reasoningMarks}
-                  activeMark={effectiveMaxStop}
-                  onChange={setMax}
-                />
-                <PolicySlider
-                  label="Default"
-                  value={defaultStop >= 0 ? defaultStop : UNSET_REASONING_STOP}
-                  max={effectiveMaxStop}
-                  step={1}
-                  marks={reasoningMarks}
-                  activeMark={
-                    defaultStop >= 0 ? defaultStop : UNSET_REASONING_STOP
-                  }
-                  onChange={setDefault}
-                />
-              </Section>
-            )}
-
-            <Disabled
-              disabled={temperatureDisabled}
-              tooltip={PINNED_TEMPERATURE_TOOLTIP}
-              tooltipSide="top"
+          {showReasoning && (
+            <Section
+              alignItems="stretch"
+              height="auto"
+              gap={0.375}
+              className="mb-1.5"
             >
-              <Section
-                alignItems="stretch"
-                height="auto"
-                gap={0.375}
-                className="mb-1.5"
-              >
-                <SectionHeader
-                  icon={SvgThermometer}
-                  title="Temperature"
-                  caption="How predictable or creative the model should respond"
-                />
-                <PolicySlider
-                  label="Default"
-                  value={temperatureDisabled ? 1 : temperature}
-                  max={maxTemperature}
-                  step={0.1}
-                  marks={TEMPERATURE_MARKS}
-                  activeMark={temperatureMark}
-                  onChange={(v) => onChange({ temperature_default: v })}
-                />
-              </Section>
-            </Disabled>
-          </Section>
-        </div>
+              <SectionHeader
+                icon={SvgBarChart}
+                title="Reasoning Level"
+                caption="How much thinking the model should perform before answering"
+              />
+              <PolicySlider
+                label="Max Level"
+                value={effectiveMaxStop}
+                max={supportedStop}
+                step={1}
+                marks={reasoningMarks}
+                activeMark={effectiveMaxStop}
+                onChange={setMax}
+              />
+              <PolicySlider
+                label="Default"
+                value={defaultStop >= 0 ? defaultStop : UNSET_REASONING_STOP}
+                max={effectiveMaxStop}
+                step={1}
+                marks={reasoningMarks}
+                activeMark={
+                  defaultStop >= 0 ? defaultStop : UNSET_REASONING_STOP
+                }
+                onChange={setDefault}
+              />
+            </Section>
+          )}
+
+          <Disabled
+            disabled={temperatureDisabled}
+            tooltip={PINNED_TEMPERATURE_TOOLTIP}
+            tooltipSide="top"
+          >
+            <Section
+              alignItems="stretch"
+              height="auto"
+              gap={0.375}
+              className="mb-1.5"
+            >
+              <SectionHeader
+                icon={SvgThermometer}
+                title="Temperature"
+                caption="How predictable or creative the model should respond"
+              />
+              <PolicySlider
+                label="Default"
+                value={temperatureDisabled ? 1 : temperature}
+                max={maxTemperature}
+                step={0.1}
+                marks={TEMPERATURE_MARKS}
+                activeMark={temperatureMark}
+                onChange={(v) => onChange({ temperature_default: v })}
+              />
+            </Section>
+          </Disabled>
+        </Section>
       </Popover.Content>
     </Popover>
   );

--- a/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
+++ b/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
@@ -8,6 +8,7 @@ import { Disabled } from "@opal/core";
 import type { IconFunctionComponent } from "@opal/types";
 import { isAnthropic } from "@/lib/languageModels/svc";
 import type { ModelConfiguration } from "@/lib/languageModels/types";
+import { modelDisplayName } from "@/lib/languageModels/utils";
 import {
   ALL_REASONING_STOPS,
   PaneSlider,
@@ -21,7 +22,8 @@ import {
 const PINNED_TEMPERATURE_TOOLTIP =
   "Reasoning models always run at temperature 1.";
 
-/** Where an unset slider parks: the value the backend would apply anyway. */
+/** Where an unset slider parks: the backend default (medium reasoning,
+ *  GEN_AI_TEMPERATURE for temperature). */
 const UNSET_REASONING_STOP = ALL_REASONING_STOPS.indexOf("medium");
 const UNSET_TEMPERATURE = 0;
 
@@ -34,9 +36,27 @@ export type ModelSettingsPatch = Partial<
   >
 >;
 
+/** The subset of a model configuration the popover reads. */
+export type ModelSettingsModel = Pick<
+  ModelConfiguration,
+  | "name"
+  | "display_name"
+  | "custom_display_name"
+  | "vendor"
+  | "max_input_tokens"
+  | "supports_reasoning"
+  | "supports_image_input"
+  | "supported_reasoning_efforts"
+  | "reasoning_effort_max"
+  | "reasoning_effort_default"
+  | "temperature_default"
+>;
+
 interface ModelSettingsPopoverProps {
-  model: ModelConfiguration;
+  model: ModelSettingsModel;
   onChange: (patch: ModelSettingsPatch) => void;
+  /** Reports open state so a hover-revealed trigger can stay visible. */
+  onOpenChange?: (open: boolean) => void;
 }
 
 interface SectionHeaderProps {
@@ -47,7 +67,7 @@ interface SectionHeaderProps {
   rightValueTooltip?: string;
 }
 
-/** Mock spec: 8px padding, 20px icon box, 4px gap, 2px text insets. */
+/** Mock spec: 8px padding (2px bottom), 20px icon box, 4px gap, 2px text insets. */
 function SectionHeader({
   icon: Icon,
   title,
@@ -149,8 +169,13 @@ function PolicySlider({
 export function ModelSettingsPopover({
   model,
   onChange,
+  onOpenChange,
 }: ModelSettingsPopoverProps) {
   const [open, setOpen] = useState(false);
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    onOpenChange?.(next);
+  }
 
   const supportedStop = maxReasoningStop(model.supported_reasoning_efforts);
   // No supported levels means the model takes no effort parameter at all.
@@ -162,12 +187,12 @@ export function ModelSettingsPopover({
   const maxStop = reasoningStopIndex(model.reasoning_effort_max);
   const rawDefaultStop = reasoningStopIndex(model.reasoning_effort_default);
   // Capability bounds the stored cap too, in case it shrank after the save.
-  const effectiveMaxStop = Math.min(
-    maxStop >= 0 ? maxStop : supportedStop,
-    supportedStop
-  );
+  const effectiveMaxStop =
+    maxStop >= 0 ? Math.min(maxStop, supportedStop) : supportedStop;
   const defaultStop =
     rawDefaultStop >= 0 ? Math.min(rawDefaultStop, effectiveMaxStop) : -1;
+  const defaultSliderStop =
+    defaultStop >= 0 ? defaultStop : UNSET_REASONING_STOP;
 
   const reasoningMarks = ALL_REASONING_STOPS.slice(0, supportedStop + 1).map(
     (stop) => REASONING_STOP_LABELS[stop]
@@ -181,7 +206,7 @@ export function ModelSettingsPopover({
   const capabilities = [
     model.supports_reasoning && "reasoning",
     model.supports_image_input && "multi-modal",
-  ].filter(Boolean);
+  ].filter((c): c is string => Boolean(c));
 
   function setMax(stop: number) {
     const newMaxStop = Math.min(stop, supportedStop);
@@ -202,10 +227,10 @@ export function ModelSettingsPopover({
   }
 
   return (
-    // A modal popover keeps clicks and focus inside it away from the host
-    // dialog's dismiss and focus-trap layers, without portaling into the
-    // dialog box, which gave the dialog its own scrollbar.
-    <Popover open={open} onOpenChange={setOpen} modal>
+    // modal keeps clicks and focus inside the popover away from the host
+    // dialog's dismiss and focus-trap layers. Portaling into the dialog
+    // instead would give the dialog its own scrollbar.
+    <Popover open={open} onOpenChange={handleOpenChange} modal>
       <Popover.Trigger asChild>
         <Button
           icon={SvgSliders}
@@ -220,7 +245,7 @@ export function ModelSettingsPopover({
           {/* raw-ok: mock header needs 10px/8px asymmetric padding, and Section silences px-* */}
           <div className="flex w-full flex-col justify-center px-2.5 py-2">
             <Text font="main-ui-body" color="text-02" nowrap>
-              {model.custom_display_name || model.display_name || model.name}
+              {modelDisplayName(model)}
             </Text>
             <Text font="secondary-body" color="text-02">
               {capabilities.length ? capabilities.join(", ") : "chat"}
@@ -264,13 +289,11 @@ export function ModelSettingsPopover({
               />
               <PolicySlider
                 label="Default"
-                value={defaultStop >= 0 ? defaultStop : UNSET_REASONING_STOP}
+                value={defaultSliderStop}
                 max={effectiveMaxStop}
                 step={1}
                 marks={reasoningMarks}
-                activeMark={
-                  defaultStop >= 0 ? defaultStop : UNSET_REASONING_STOP
-                }
+                activeMark={defaultSliderStop}
                 onChange={setDefault}
               />
             </Section>

--- a/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
+++ b/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
@@ -181,11 +181,13 @@ export function ModelSettingsPopover({
   ].filter(Boolean);
 
   function setMax(stop: number) {
-    const effort = ALL_REASONING_STOPS[Math.min(stop, supportedStop)];
+    const newMaxStop = Math.min(stop, supportedStop);
+    const effort = ALL_REASONING_STOPS[newMaxStop];
     if (!effort) return;
     const patch: ModelSettingsPatch = { reasoning_effort_max: effort };
-    // The API rejects a default above the max, so keep the pair consistent.
-    if (defaultStop > Math.min(stop, supportedStop)) {
+    // The API rejects a default above the max. Compare the raw stored default,
+    // not the clamped display value, so a stale higher default gets rewritten.
+    if (rawDefaultStop > newMaxStop) {
       patch.reasoning_effort_default = effort;
     }
     onChange(patch);

--- a/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
+++ b/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { Button, Popover, Text, Tooltip } from "@opal/components";
 import { SvgBarChart, SvgCode, SvgSliders, SvgThermometer } from "@opal/icons";
 import { Section } from "@opal/layouts";
@@ -148,12 +148,6 @@ export function ModelSettingsPopover({
   onChange,
 }: ModelSettingsPopoverProps) {
   const [open, setOpen] = useState(false);
-  // Portal into the dialog. Left on body, the popover sits outside the modal's
-  // focus scope and a click inside it reads as a click outside the modal.
-  const [container, setContainer] = useState<HTMLElement | null>(null);
-  const anchorRef = useCallback((el: HTMLElement | null) => {
-    setContainer(el?.closest<HTMLElement>('[role="dialog"]') ?? null);
-  }, []);
 
   const supportedStop = maxReasoningStop(model.supported_reasoning_efforts);
   // No supported levels means the model takes no effort parameter at all.
@@ -203,10 +197,12 @@ export function ModelSettingsPopover({
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    // A modal popover keeps clicks and focus inside it away from the host
+    // dialog's dismiss and focus-trap layers, without portaling into the
+    // dialog box, which gave the dialog its own scrollbar.
+    <Popover open={open} onOpenChange={setOpen} modal>
       <Popover.Trigger asChild>
         <Button
-          ref={anchorRef}
           icon={SvgSliders}
           prominence="internal"
           size="sm"
@@ -214,7 +210,7 @@ export function ModelSettingsPopover({
           onClick={(e: React.MouseEvent) => e.stopPropagation()}
         />
       </Popover.Trigger>
-      <Popover.Content width="fit" container={container} align="end">
+      <Popover.Content width="fit" align="end">
         <Section alignItems="stretch" width={17} height="auto" gap={0.25}>
           {/* raw-ok: mock header needs 10px/8px asymmetric padding, and Section silences px-* */}
           <div className="flex w-full flex-col justify-center px-2.5 py-2">

--- a/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
+++ b/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
@@ -36,7 +36,11 @@ interface ModelSettingsPopoverProps {
   onChange: (patch: ModelSettingsPatch) => void;
 }
 
-function ResetToAuto({ onClick }: { onClick: () => void }) {
+interface ResetToAutoProps {
+  onClick: () => void;
+}
+
+function ResetToAuto({ onClick }: ResetToAutoProps) {
   return (
     <Section flexDirection="row" justifyContent="end" height="auto">
       <Button prominence="tertiary" onClick={onClick}>

--- a/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
+++ b/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Button, Popover, Text } from "@opal/components";
+import { SvgBarChart, SvgCode, SvgSliders, SvgThermometer } from "@opal/icons";
+import { Section } from "@opal/layouts";
+import { isAnthropic } from "@/lib/languageModels/svc";
+import type {
+  ModelConfiguration,
+  ReasoningEffortOverride,
+} from "@/lib/languageModels/types";
+import {
+  ALL_REASONING_STOPS,
+  PaneSlider,
+  REASONING_STOP_LABELS,
+  SettingRow,
+  UNKNOWN_CONTEXT_TOOLTIP,
+  formatContextWindow,
+  maxReasoningStop,
+  reasoningStopIndex,
+} from "@/sections/model-selector/setting-controls";
+
+/** Where an unset slider parks: the value the backend would apply anyway. */
+const UNSET_REASONING_STOP = ALL_REASONING_STOPS.indexOf("medium");
+const UNSET_TEMPERATURE = 0;
+
+export type ModelSettingsPatch = Partial<
+  Pick<
+    ModelConfiguration,
+    "reasoning_effort_max" | "reasoning_effort_default" | "temperature_default"
+  >
+>;
+
+interface ModelSettingsPopoverProps {
+  model: ModelConfiguration;
+  onChange: (patch: ModelSettingsPatch) => void;
+}
+
+function ResetToAuto({ onClick }: { onClick: () => void }) {
+  return (
+    <Section flexDirection="row" justifyContent="end" height="auto">
+      <Button prominence="tertiary" onClick={onClick}>
+        Reset to auto
+      </Button>
+    </Section>
+  );
+}
+
+export function ModelSettingsPopover({
+  model,
+  onChange,
+}: ModelSettingsPopoverProps) {
+  const [open, setOpen] = useState(false);
+  // Portal into the dialog. Left on body, the popover sits outside the modal's
+  // focus scope and a click inside it reads as a click outside the modal.
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+  const anchorRef = useCallback((el: HTMLElement | null) => {
+    setContainer(el?.closest<HTMLElement>('[role="dialog"]') ?? null);
+  }, []);
+
+  const supportedStop = maxReasoningStop(model.supported_reasoning_efforts);
+  // No supported levels means the model takes no effort parameter at all.
+  const showReasoning = model.supports_reasoning && supportedStop >= 0;
+  // The backend pins reasoning models to 1, so a default would never apply.
+  const showTemperature = !model.supports_reasoning;
+  const maxTemperature = isAnthropic(model.vendor ?? "", model.name) ? 1 : 2;
+
+  const maxStop = reasoningStopIndex(model.reasoning_effort_max);
+  const rawDefaultStop = reasoningStopIndex(model.reasoning_effort_default);
+  // Capability bounds the stored cap too, in case the model's supported levels
+  // shrank after the cap was saved.
+  const effectiveMaxStop = Math.min(
+    maxStop >= 0 ? maxStop : supportedStop,
+    supportedStop
+  );
+  // Read back clamped as well as rendered clamped, so the label never advertises
+  // a level the model lost since the value was saved.
+  const defaultStop =
+    rawDefaultStop >= 0 ? Math.min(rawDefaultStop, effectiveMaxStop) : -1;
+
+  function setMax(stop: number) {
+    const effort = ALL_REASONING_STOPS[Math.min(stop, supportedStop)];
+    if (!effort) return;
+    const patch: ModelSettingsPatch = { reasoning_effort_max: effort };
+    // The API rejects a default above the max, so keep the pair consistent.
+    if (defaultStop > Math.min(stop, supportedStop)) {
+      patch.reasoning_effort_default = effort;
+    }
+    onChange(patch);
+  }
+
+  function setDefault(stop: number) {
+    const effort = ALL_REASONING_STOPS[Math.min(stop, effectiveMaxStop)];
+    if (effort) onChange({ reasoning_effort_default: effort });
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <Button
+          ref={anchorRef}
+          icon={SvgSliders}
+          prominence="tertiary"
+          tooltip="Model Settings"
+          onClick={(e: React.MouseEvent) => e.stopPropagation()}
+        />
+      </Popover.Trigger>
+      <Popover.Content width="md" container={container} align="end">
+        <Section alignItems="stretch" height="auto" gap={1} padding={1}>
+          <Section alignItems="stretch" height="auto" gap={0} padding={1.5}>
+            <Text font="main-ui-action">
+              {model.custom_display_name || model.display_name || model.name}
+            </Text>
+            <Text font="secondary-body" color="text-03">
+              {model.supports_reasoning ? "Reasoning model" : "Chat model"}
+            </Text>
+          </Section>
+
+          <SettingRow
+            icon={SvgCode}
+            title="Context Window"
+            value={
+              model.max_input_tokens
+                ? formatContextWindow(model.max_input_tokens)
+                : "—"
+            }
+            valueTooltip={
+              model.max_input_tokens ? undefined : UNKNOWN_CONTEXT_TOOLTIP
+            }
+            caption="How much text this model can consider at once."
+          />
+
+          {showReasoning && (
+            <>
+              <SettingRow
+                icon={SvgBarChart}
+                title="Reasoning Level, Max"
+                value={
+                  maxStop >= 0
+                    ? REASONING_STOP_LABELS[
+                        ALL_REASONING_STOPS[effectiveMaxStop]!
+                      ]
+                    : "Auto"
+                }
+                caption="The most reasoning a user can request for this model."
+              >
+                <PaneSlider
+                  value={effectiveMaxStop}
+                  min={0}
+                  max={supportedStop}
+                  step={1}
+                  onValueChange={setMax}
+                  onValueCommit={setMax}
+                />
+              </SettingRow>
+
+              <SettingRow
+                icon={SvgBarChart}
+                title="Reasoning Level, Default"
+                value={
+                  defaultStop >= 0
+                    ? REASONING_STOP_LABELS[ALL_REASONING_STOPS[defaultStop]!]
+                    : "Auto"
+                }
+                caption="Where a chat starts when the user has not chosen a level."
+              >
+                <PaneSlider
+                  value={Math.min(
+                    defaultStop >= 0 ? defaultStop : UNSET_REASONING_STOP,
+                    effectiveMaxStop
+                  )}
+                  min={0}
+                  max={effectiveMaxStop}
+                  step={1}
+                  onValueChange={setDefault}
+                  onValueCommit={setDefault}
+                />
+              </SettingRow>
+
+              <ResetToAuto
+                onClick={() =>
+                  onChange({
+                    reasoning_effort_max: null,
+                    reasoning_effort_default: null,
+                  })
+                }
+              />
+            </>
+          )}
+
+          {showTemperature && (
+            <>
+              <SettingRow
+                icon={SvgThermometer}
+                title="Temperature, Default"
+                value={
+                  model.temperature_default != null
+                    ? model.temperature_default.toFixed(1)
+                    : "Auto"
+                }
+                caption="Lower is more deterministic, higher is more creative."
+              >
+                <PaneSlider
+                  value={model.temperature_default ?? UNSET_TEMPERATURE}
+                  min={0}
+                  max={maxTemperature}
+                  step={0.1}
+                  onValueChange={(v) => onChange({ temperature_default: v })}
+                  onValueCommit={(v) => onChange({ temperature_default: v })}
+                />
+              </SettingRow>
+
+              <ResetToAuto
+                onClick={() => onChange({ temperature_default: null })}
+              />
+            </>
+          )}
+        </Section>
+      </Popover.Content>
+    </Popover>
+  );
+}

--- a/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
+++ b/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Button, Popover, Text, Tooltip } from "@opal/components";
 import { SvgBarChart, SvgCode, SvgSliders, SvgThermometer } from "@opal/icons";
-import { Section } from "@opal/layouts";
+import { ContentAction, Section } from "@opal/layouts";
 import { Disabled } from "@opal/core";
 import type { IconFunctionComponent } from "@opal/types";
 import { isAnthropic } from "@/lib/languageModels/svc";
@@ -67,45 +67,41 @@ interface SectionHeaderProps {
   rightValueTooltip?: string;
 }
 
-/** Mock spec: 8px padding (2px bottom), 20px icon box, 4px gap, 2px text insets. */
+/** The mock's section header is the design system's Content component, so
+ *  ContentAction renders it. Outer spacing comes from margins, Section
+ *  silences padding utilities. */
 function SectionHeader({
-  icon: Icon,
+  icon,
   title,
   caption,
   rightValue,
   rightValueTooltip,
 }: SectionHeaderProps) {
   return (
-    // raw-ok: mock needs 2px text insets and a flex-1/min-w-0 column, and Section silences px-*
-    <div className="flex w-full gap-1 px-2 pb-0.5 pt-2">
-      <div className="flex size-5 shrink-0 items-center justify-center p-0.5 text-text-04">
-        <Icon size={16} />
-      </div>
-      <div className="flex min-w-0 flex-1 flex-col">
-        <div className="flex w-full items-start gap-1">
-          <div className="flex min-h-5 min-w-0 flex-1 flex-col justify-center px-0.5">
-            <Text font="main-ui-action" color="text-04" nowrap>
-              {title}
-            </Text>
-          </div>
-          {rightValue !== undefined && (
-            <div className="flex min-h-5 items-center p-0.5">
-              <Tooltip tooltip={rightValueTooltip} side="top">
-                <Text font="secondary-mono" color="text-04" nowrap>
-                  {rightValue}
-                </Text>
-              </Tooltip>
-            </div>
-          )}
-        </div>
-        {/* raw-ok: flex collapses the strut so the caption sits on the font's 16px lines */}
-        <div className="flex px-0.5">
-          <Text font="secondary-body" color="text-03">
-            {caption}
-          </Text>
-        </div>
-      </div>
-    </div>
+    <Section
+      alignItems="stretch"
+      width="auto"
+      height="auto"
+      className="mx-2 mb-0.5 mt-2"
+    >
+      <ContentAction
+        sizePreset="main-ui"
+        variant="section"
+        icon={icon}
+        title={title}
+        description={caption}
+        padding={0}
+        rightChildren={
+          rightValue !== undefined ? (
+            <Tooltip tooltip={rightValueTooltip} side="top">
+              <Text font="secondary-mono" color="text-04" nowrap>
+                {rightValue}
+              </Text>
+            </Tooltip>
+          ) : undefined
+        }
+      />
+    </Section>
   );
 }
 
@@ -119,7 +115,8 @@ interface PolicySliderProps {
   onChange: (value: number) => void;
 }
 
-/** Mock spec: 32px left inset, 8px right, 16px label line, 28px slider. */
+/** Mock spec: 32px left inset, 8px right, 16px label line, 28px slider.
+ *  Insets are margins because Section silences padding utilities. */
 function PolicySlider({
   label,
   value,
@@ -129,16 +126,20 @@ function PolicySlider({
   activeMark,
   onChange,
 }: PolicySliderProps) {
-  // raw-ok: mock needs asymmetric pl-8/pr-2, and Section silences p-* utilities
   return (
-    <div className="w-full pl-8 pr-2">
-      {/* raw-ok: flex collapses the strut so the label sits on the font's 16px line */}
-      <div className="flex px-0.5">
+    <Section
+      alignItems="stretch"
+      width="auto"
+      height="auto"
+      gap={0}
+      className="ml-8 mr-2"
+    >
+      <Section alignItems="start" width="auto" height="auto" className="mx-0.5">
         <Text font="secondary-action" color="text-03" nowrap>
           {label}
         </Text>
-      </div>
-      <div className="p-0.5">
+      </Section>
+      <Section alignItems="stretch" height="auto" padding={0.5}>
         <PaneSlider
           compact
           value={value}
@@ -148,8 +149,7 @@ function PolicySlider({
           onValueChange={onChange}
           onValueCommit={onChange}
         />
-        {/* raw-ok: mock annotation row is a fixed 12px line inside the 28px slider */}
-        <div className="flex h-3 w-full items-center justify-between">
+        <Section flexDirection="row" justifyContent="between" height={0.75}>
           {marks.map((mark, index) => (
             <Text
               key={mark}
@@ -160,9 +160,9 @@ function PolicySlider({
               {mark}
             </Text>
           ))}
-        </div>
-      </div>
-    </div>
+        </Section>
+      </Section>
+    </Section>
   );
 }
 
@@ -242,15 +242,20 @@ export function ModelSettingsPopover({
       </Popover.Trigger>
       <Popover.Content width="fit" align="end">
         <Section alignItems="stretch" width={17} height="auto" gap={0.25}>
-          {/* raw-ok: mock header needs 10px/8px asymmetric padding, and Section silences px-* */}
-          <div className="flex w-full flex-col justify-center px-2.5 py-2">
+          <Section
+            alignItems="start"
+            width="auto"
+            height="auto"
+            gap={0}
+            className="mx-2.5 my-2"
+          >
             <Text font="main-ui-body" color="text-02" nowrap>
               {modelDisplayName(model)}
             </Text>
             <Text font="secondary-body" color="text-02">
               {capabilities.length ? capabilities.join(", ") : "chat"}
             </Text>
-          </div>
+          </Section>
 
           <SectionHeader
             icon={SvgCode}

--- a/web/src/sections/modals/languageModels/NebiusTokenfactoryModal.tsx
+++ b/web/src/sections/modals/languageModels/NebiusTokenfactoryModal.tsx
@@ -15,7 +15,7 @@ import {
   useInitialValues,
   buildValidationSchema,
   BaseLLMFormValues,
-  mergeFetchedModelConfigurations,
+  withFetchedModels,
 } from "@/sections/modals/languageModels/utils";
 import { submitProvider } from "@/sections/modals/languageModels/svc";
 import { LLMProviderConfiguredSource } from "@/lib/analytics/utils";
@@ -59,15 +59,7 @@ function NebiusTokenfactoryModalInternals({
     if (error) {
       throw new Error(error);
     }
-    // Functional form: an edit made while the fetch was in flight must not be
-    // reverted by the snapshot this handler closed over.
-    formikProps.setValues((prev) => ({
-      ...prev,
-      model_configurations: mergeFetchedModelConfigurations(
-        models,
-        prev.model_configurations
-      ),
-    }));
+    formikProps.setValues(withFetchedModels(models));
   };
 
   // When editing a saved provider, the models load from the DB without the
@@ -86,13 +78,7 @@ function NebiusTokenfactoryModalInternals({
     })
       .then(({ models }) => {
         if (models.length > 0) {
-          formikProps.setValues((prev) => ({
-            ...prev,
-            model_configurations: mergeFetchedModelConfigurations(
-              models,
-              prev.model_configurations
-            ),
-          }));
+          formikProps.setValues(withFetchedModels(models));
         }
       })
       .catch(() => undefined);

--- a/web/src/sections/modals/languageModels/NebiusTokenfactoryModal.tsx
+++ b/web/src/sections/modals/languageModels/NebiusTokenfactoryModal.tsx
@@ -59,13 +59,15 @@ function NebiusTokenfactoryModalInternals({
     if (error) {
       throw new Error(error);
     }
-    formikProps.setFieldValue(
-      "model_configurations",
-      mergeFetchedModelConfigurations(
+    // Functional form: an edit made while the fetch was in flight must not be
+    // reverted by the snapshot this handler closed over.
+    formikProps.setValues((prev) => ({
+      ...prev,
+      model_configurations: mergeFetchedModelConfigurations(
         models,
-        formikProps.values.model_configurations
-      )
-    );
+        prev.model_configurations
+      ),
+    }));
   };
 
   // When editing a saved provider, the models load from the DB without the
@@ -84,13 +86,13 @@ function NebiusTokenfactoryModalInternals({
     })
       .then(({ models }) => {
         if (models.length > 0) {
-          setFieldValue(
-            "model_configurations",
-            mergeFetchedModelConfigurations(
+          formikProps.setValues((prev) => ({
+            ...prev,
+            model_configurations: mergeFetchedModelConfigurations(
               models,
-              formikProps.values.model_configurations
-            )
-          );
+              prev.model_configurations
+            ),
+          }));
         }
       })
       .catch(() => undefined);

--- a/web/src/sections/modals/languageModels/OllamaModal.tsx
+++ b/web/src/sections/modals/languageModels/OllamaModal.tsx
@@ -14,7 +14,7 @@ import {
   useInitialValues,
   buildValidationSchema,
   BaseLLMFormValues,
-  mergeFetchedModelConfigurations,
+  withFetchedModels,
 } from "@/sections/modals/languageModels/utils";
 import { submitProvider } from "@/sections/modals/languageModels/svc";
 import { LLMProviderConfiguredSource } from "@/lib/analytics/utils";
@@ -81,15 +81,7 @@ function OllamaModalInternals({
     if (error) {
       throw new Error(error);
     }
-    // Functional form: an edit made while the fetch was in flight must not be
-    // reverted by the snapshot this handler closed over.
-    formikProps.setValues((prev) => ({
-      ...prev,
-      model_configurations: mergeFetchedModelConfigurations(
-        models,
-        prev.model_configurations
-      ),
-    }));
+    formikProps.setValues(withFetchedModels(models));
   };
 
   return (

--- a/web/src/sections/modals/languageModels/OllamaModal.tsx
+++ b/web/src/sections/modals/languageModels/OllamaModal.tsx
@@ -81,13 +81,15 @@ function OllamaModalInternals({
     if (error) {
       throw new Error(error);
     }
-    formikProps.setFieldValue(
-      "model_configurations",
-      mergeFetchedModelConfigurations(
+    // Functional form: an edit made while the fetch was in flight must not be
+    // reverted by the snapshot this handler closed over.
+    formikProps.setValues((prev) => ({
+      ...prev,
+      model_configurations: mergeFetchedModelConfigurations(
         models,
-        formikProps.values.model_configurations
-      )
-    );
+        prev.model_configurations
+      ),
+    }));
   };
 
   return (

--- a/web/src/sections/modals/languageModels/OpenAICompatibleModal.tsx
+++ b/web/src/sections/modals/languageModels/OpenAICompatibleModal.tsx
@@ -59,13 +59,15 @@ function OpenAICompatibleModalInternals({
     if (error) {
       throw new Error(error);
     }
-    formikProps.setFieldValue(
-      "model_configurations",
-      mergeFetchedModelConfigurations(
+    // Functional form: an edit made while the fetch was in flight must not be
+    // reverted by the snapshot this handler closed over.
+    formikProps.setValues((prev) => ({
+      ...prev,
+      model_configurations: mergeFetchedModelConfigurations(
         models,
-        formikProps.values.model_configurations
-      )
-    );
+        prev.model_configurations
+      ),
+    }));
   };
 
   return (

--- a/web/src/sections/modals/languageModels/OpenAICompatibleModal.tsx
+++ b/web/src/sections/modals/languageModels/OpenAICompatibleModal.tsx
@@ -13,7 +13,7 @@ import {
   useInitialValues,
   buildValidationSchema,
   BaseLLMFormValues,
-  mergeFetchedModelConfigurations,
+  withFetchedModels,
 } from "@/sections/modals/languageModels/utils";
 import { submitProvider } from "@/sections/modals/languageModels/svc";
 import { LLMProviderConfiguredSource } from "@/lib/analytics/utils";
@@ -59,15 +59,7 @@ function OpenAICompatibleModalInternals({
     if (error) {
       throw new Error(error);
     }
-    // Functional form: an edit made while the fetch was in flight must not be
-    // reverted by the snapshot this handler closed over.
-    formikProps.setValues((prev) => ({
-      ...prev,
-      model_configurations: mergeFetchedModelConfigurations(
-        models,
-        prev.model_configurations
-      ),
-    }));
+    formikProps.setValues(withFetchedModels(models));
   };
 
   return (

--- a/web/src/sections/modals/languageModels/OpenRouterModal.tsx
+++ b/web/src/sections/modals/languageModels/OpenRouterModal.tsx
@@ -13,7 +13,7 @@ import {
   useInitialValues,
   buildValidationSchema,
   BaseLLMFormValues,
-  mergeFetchedModelConfigurations,
+  withFetchedModels,
 } from "@/sections/modals/languageModels/utils";
 import { submitProvider } from "@/sections/modals/languageModels/svc";
 import { LLMProviderConfiguredSource } from "@/lib/analytics/utils";
@@ -57,15 +57,7 @@ function OpenRouterModalInternals({
     if (error) {
       throw new Error(error);
     }
-    // Functional form: an edit made while the fetch was in flight must not be
-    // reverted by the snapshot this handler closed over.
-    formikProps.setValues((prev) => ({
-      ...prev,
-      model_configurations: mergeFetchedModelConfigurations(
-        fetched,
-        prev.model_configurations
-      ),
-    }));
+    formikProps.setValues(withFetchedModels(fetched));
   };
 
   return (

--- a/web/src/sections/modals/languageModels/OpenRouterModal.tsx
+++ b/web/src/sections/modals/languageModels/OpenRouterModal.tsx
@@ -57,13 +57,15 @@ function OpenRouterModalInternals({
     if (error) {
       throw new Error(error);
     }
-    formikProps.setFieldValue(
-      "model_configurations",
-      mergeFetchedModelConfigurations(
+    // Functional form: an edit made while the fetch was in flight must not be
+    // reverted by the snapshot this handler closed over.
+    formikProps.setValues((prev) => ({
+      ...prev,
+      model_configurations: mergeFetchedModelConfigurations(
         fetched,
-        formikProps.values.model_configurations
-      )
-    );
+        prev.model_configurations
+      ),
+    }));
   };
 
   return (

--- a/web/src/sections/modals/languageModels/PortkeyModal.tsx
+++ b/web/src/sections/modals/languageModels/PortkeyModal.tsx
@@ -18,7 +18,7 @@ import {
   useInitialValues,
   buildValidationSchema,
   BaseLLMFormValues,
-  mergeFetchedModelConfigurations,
+  withFetchedModels,
 } from "@/sections/modals/languageModels/utils";
 import { submitProvider } from "@/sections/modals/languageModels/svc";
 import { LLMProviderConfiguredSource } from "@/lib/analytics/utils";
@@ -110,15 +110,7 @@ function PortkeyModalInternals({
     if (error) {
       throw new Error(error);
     }
-    // Functional form: an edit made while the fetch was in flight must not be
-    // reverted by the snapshot this handler closed over.
-    setValues((prev) => ({
-      ...prev,
-      model_configurations: mergeFetchedModelConfigurations(
-        models,
-        prev.model_configurations
-      ),
-    }));
+    setValues(withFetchedModels(models));
   };
 
   // Refetch once on open so an edit's picker matches the "add" view.
@@ -134,13 +126,7 @@ function PortkeyModalInternals({
     })
       .then(({ models }) => {
         if (models.length > 0) {
-          setValues((prev) => ({
-            ...prev,
-            model_configurations: mergeFetchedModelConfigurations(
-              models,
-              prev.model_configurations
-            ),
-          }));
+          setValues(withFetchedModels(models));
         }
       })
       .catch(() => undefined);

--- a/web/src/sections/modals/languageModels/PortkeyModal.tsx
+++ b/web/src/sections/modals/languageModels/PortkeyModal.tsx
@@ -84,7 +84,7 @@ function PortkeyModalInternals({
   isOnboarding,
 }: PortkeyModalInternalsProps) {
   const formikProps = useFormikContext<PortkeyModalValues>();
-  const { setFieldValue, values } = formikProps;
+  const { setFieldValue, setValues, values } = formikProps;
 
   const mode =
     (values.custom_config?.[PORTKEY_API_MODE_KEY] as
@@ -110,10 +110,15 @@ function PortkeyModalInternals({
     if (error) {
       throw new Error(error);
     }
-    setFieldValue(
-      "model_configurations",
-      mergeFetchedModelConfigurations(models, values.model_configurations)
-    );
+    // Functional form: an edit made while the fetch was in flight must not be
+    // reverted by the snapshot this handler closed over.
+    setValues((prev) => ({
+      ...prev,
+      model_configurations: mergeFetchedModelConfigurations(
+        models,
+        prev.model_configurations
+      ),
+    }));
   };
 
   // Refetch once on open so an edit's picker matches the "add" view.
@@ -129,10 +134,13 @@ function PortkeyModalInternals({
     })
       .then(({ models }) => {
         if (models.length > 0) {
-          setFieldValue(
-            "model_configurations",
-            mergeFetchedModelConfigurations(models, values.model_configurations)
-          );
+          setValues((prev) => ({
+            ...prev,
+            model_configurations: mergeFetchedModelConfigurations(
+              models,
+              prev.model_configurations
+            ),
+          }));
         }
       })
       .catch(() => undefined);

--- a/web/src/sections/modals/languageModels/shared.tsx
+++ b/web/src/sections/modals/languageModels/shared.tsx
@@ -39,8 +39,8 @@ import {
   ModelSettingsPopover,
   type ModelSettingsPatch,
 } from "@/sections/modals/languageModels/ModelSettingsPopover";
-import { setDefaultLlmModel } from "@/lib/languageModels/svc";
-import { refreshLlmProviderCaches } from "@/lib/languageModels/cache";
+import { setDefaultLlmModelAndRefresh } from "@/lib/languageModels/cache";
+import { modelDisplayName } from "@/lib/languageModels/utils";
 import { useAdminLLMProviders } from "@/lib/languageModels/hooks";
 import { useSWRConfig } from "swr";
 import {
@@ -541,10 +541,9 @@ interface ModelRowProps {
  * A single selectable model row.
  *
  * The row is a clickable `<div role="button">` rather than a real `<button>`,
- * because the `editable` title renders its own nested edit `<button>` — and a
- * `<button>` inside a `<button>` is invalid HTML that triggers a React
- * hydration error. Rendering the row as a div keeps the inline rename pencil a
- * real, keyboard-accessible button while preserving the original look and feel.
+ * because it hosts real action buttons (rename, settings, set as default) and
+ * a `<button>` inside a `<button>` is invalid HTML that triggers a React
+ * hydration error.
  *
  * This mirrors `LineItemButton`'s internals (Stateful → Container →
  * ContentAction) but with a typeless `Interactive.Container`, which renders a
@@ -560,8 +559,10 @@ function ModelRow({
   onSetDefaultModel,
 }: ModelRowProps) {
   const editHandle = useRef<ContentMdEditHandle>(null);
-  const displayName =
-    model.custom_display_name || model.display_name || model.name;
+  // Keeps the hover-revealed actions visible while the settings popover,
+  // which is portaled outside the row, is open.
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const displayName = modelDisplayName(model);
   // In auto mode every model is shown, so the row is always "selected" and the
   // visibility toggle is disabled.
   const isSelected = isAutoMode || model.is_visible;
@@ -582,7 +583,11 @@ function ModelRow({
     : undefined;
 
   return (
-    <Hoverable.Root group="model-row" data-model-name={model.name}>
+    <Hoverable.Root
+      group="model-row"
+      interaction={settingsOpen ? "hover" : "rest"}
+      data-model-name={model.name}
+    >
       <Interactive.Stateful
         variant="select-heavy"
         state={isSelected ? "selected" : "empty"}
@@ -623,37 +628,28 @@ function ModelRow({
                 >
                   {modelRightChildren(model)}
                   <Hoverable.Item group="model-row" variant="appear-on-hover">
-                    <Button
-                      icon={SvgEdit}
-                      prominence="internal"
-                      size="sm"
-                      tooltip="Rename"
-                      onClick={(e: React.MouseEvent) => {
-                        e.stopPropagation();
-                        editHandle.current?.startEditing();
-                      }}
-                    />
-                  </Hoverable.Item>
-                  <Hoverable.Item group="model-row" variant="appear-on-hover">
-                    <ModelSettingsPopover
-                      model={model}
-                      onChange={onSettingsChange}
-                    />
-                  </Hoverable.Item>
-                  {isDefaultModel ? (
-                    <Text
-                      secondaryAction
-                      nowrap
-                      className="px-1.5 py-1 text-action-selection-05"
+                    <OpalSection
+                      flexDirection="row"
+                      width="fit"
+                      height="auto"
+                      gap={1}
                     >
-                      Default Model
-                    </Text>
-                  ) : (
-                    onSetDefaultModel && (
-                      <Hoverable.Item
-                        group="model-row"
-                        variant="appear-on-hover"
-                      >
+                      <Button
+                        icon={SvgEdit}
+                        prominence="internal"
+                        size="sm"
+                        tooltip="Rename"
+                        onClick={(e: React.MouseEvent) => {
+                          e.stopPropagation();
+                          editHandle.current?.startEditing();
+                        }}
+                      />
+                      <ModelSettingsPopover
+                        model={model}
+                        onChange={onSettingsChange}
+                        onOpenChange={setSettingsOpen}
+                      />
+                      {!isDefaultModel && onSetDefaultModel && (
                         <Button
                           prominence="internal"
                           size="sm"
@@ -664,8 +660,17 @@ function ModelRow({
                         >
                           Set as Default
                         </Button>
-                      </Hoverable.Item>
-                    )
+                      )}
+                    </OpalSection>
+                  </Hoverable.Item>
+                  {isDefaultModel && (
+                    <Text
+                      secondaryAction
+                      nowrap
+                      className="px-1.5 py-1 text-action-selection-05"
+                    >
+                      Default Model
+                    </Text>
                   )}
                 </OpalSection>
               }
@@ -742,14 +747,7 @@ export function ModelSelectionField({
 
   async function setDefaultModel(modelName: string) {
     if (providerId == null) return;
-    try {
-      await setDefaultLlmModel(providerId, modelName);
-      await refreshLlmProviderCaches(mutate);
-      toast.success("Default model updated successfully!");
-    } catch (e) {
-      const message = e instanceof Error ? e.message : "Unknown error";
-      toast.error(`Failed to set default model: ${message}`);
-    }
+    await setDefaultLlmModelAndRefresh(providerId, modelName, mutate);
   }
 
   function setCustomDisplayName(modelName: string, value: string | undefined) {
@@ -835,6 +833,10 @@ export function ModelSelectionField({
                 isFoldable && !isExpanded
                   ? displayModels.slice(0, FOLD_THRESHOLD)
                   : displayModels;
+              const defaultModelName =
+                providerId != null && defaultText?.provider_id === providerId
+                  ? defaultText.model_name
+                  : undefined;
 
               return (
                 <>
@@ -852,11 +854,7 @@ export function ModelSelectionField({
                       onSettingsChange={(patch) =>
                         setModelSettings(model.name, patch)
                       }
-                      isDefaultModel={
-                        providerId != null &&
-                        defaultText?.provider_id === providerId &&
-                        defaultText?.model_name === model.name
-                      }
+                      isDefaultModel={model.name === defaultModelName}
                       onSetDefaultModel={
                         providerId != null && model.is_visible
                           ? () => void setDefaultModel(model.name)

--- a/web/src/sections/modals/languageModels/shared.tsx
+++ b/web/src/sections/modals/languageModels/shared.tsx
@@ -764,21 +764,18 @@ export function ModelSelectionField({
   function handleToggleAutoMode(nextIsAutoMode: boolean) {
     formikProps.setFieldValue("is_auto_mode", nextIsAutoMode);
     if (nextIsAutoMode) {
-      // Auto mode restores the snapshot's visibility, but unsaved renames and
-      // settings are edits the toggle has no business discarding.
-      const currentByName = new Map(models.map((m) => [m.name, m]));
+      // Auto mode restores only the snapshot's visibility. Unsaved edits and
+      // models discovered after mount survive the toggle.
+      const originalByName = new Map(
+        originalModelsRef.current.map((m) => [m.name, m])
+      );
       formikProps.setFieldValue(
         "model_configurations",
-        originalModelsRef.current.map((original) => {
-          const current = currentByName.get(original.name);
-          if (!current) return original;
-          return {
-            ...original,
-            custom_display_name: current.custom_display_name,
-            reasoning_effort_max: current.reasoning_effort_max,
-            reasoning_effort_default: current.reasoning_effort_default,
-            temperature_default: current.temperature_default,
-          };
+        models.map((current) => {
+          const original = originalByName.get(current.name);
+          return original
+            ? { ...current, is_visible: original.is_visible }
+            : current;
         })
       );
     }

--- a/web/src/sections/modals/languageModels/shared.tsx
+++ b/web/src/sections/modals/languageModels/shared.tsx
@@ -22,7 +22,7 @@ import InputSelect from "@/refresh-components/inputs/InputSelect";
 import PasswordInputTypeInField from "@/refresh-components/form/PasswordInputTypeInField";
 import { Switch } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Button, TextButton } from "@opal/components";
 import { BaseLLMFormValues } from "@/sections/modals/languageModels/utils";
 import type { RichStr } from "@opal/types";
 import { Section } from "@/layouts/general-layouts";
@@ -39,6 +39,10 @@ import {
   ModelSettingsPopover,
   type ModelSettingsPatch,
 } from "@/sections/modals/languageModels/ModelSettingsPopover";
+import { setDefaultLlmModel } from "@/lib/languageModels/svc";
+import { refreshLlmProviderCaches } from "@/lib/languageModels/cache";
+import { useAdminLLMProviders } from "@/lib/languageModels/hooks";
+import { useSWRConfig } from "swr";
 import {
   SvgArrowExchange,
   SvgChevronDown,
@@ -526,9 +530,11 @@ function modelRightChildren(model: ModelConfiguration): React.ReactNode {
 interface ModelRowProps {
   model: ModelConfiguration;
   isAutoMode: boolean;
+  isDefaultModel: boolean;
   onToggleVisibility: (visible: boolean) => void;
   onRename: (value: string | undefined) => void;
   onSettingsChange: (patch: ModelSettingsPatch) => void;
+  onSetDefaultModel?: () => void;
 }
 
 /**
@@ -547,9 +553,11 @@ interface ModelRowProps {
 function ModelRow({
   model,
   isAutoMode,
+  isDefaultModel,
   onToggleVisibility,
   onRename,
   onSettingsChange,
+  onSetDefaultModel,
 }: ModelRowProps) {
   const editHandle = useRef<ContentMdEditHandle>(null);
   const displayName =
@@ -632,6 +640,27 @@ function ModelRow({
                       onChange={onSettingsChange}
                     />
                   </Hoverable.Item>
+                  {isDefaultModel ? (
+                    <Text secondaryAction text03>
+                      Default Model
+                    </Text>
+                  ) : (
+                    onSetDefaultModel && (
+                      <Hoverable.Item
+                        group="model-row"
+                        variant="appear-on-hover"
+                      >
+                        <TextButton
+                          onClick={(e: React.MouseEvent) => {
+                            e.stopPropagation();
+                            onSetDefaultModel();
+                          }}
+                        >
+                          Default Model
+                        </TextButton>
+                      </Hoverable.Item>
+                    )
+                  )}
                 </OpalSection>
               }
               editable
@@ -662,6 +691,9 @@ export function ModelSelectionField({
   emptyMessage,
 }: ModelSelectionFieldProps) {
   const formikProps = useFormikContext<BaseLLMFormValues>();
+  const { mutate } = useSWRConfig();
+  const { defaultText } = useAdminLLMProviders();
+  const providerId = formikProps.values.id;
   const [newModelName, setNewModelName] = useState("");
   const [isExpanded, setIsExpanded] = useState(false);
   // When the auto-update toggle is hidden, auto mode should have no effect —
@@ -700,6 +732,18 @@ export function ModelSelectionField({
       m.name === modelName ? { ...m, ...patch } : m
     );
     formikProps.setFieldValue("model_configurations", updated);
+  }
+
+  async function setDefaultModel(modelName: string) {
+    if (providerId == null) return;
+    try {
+      await setDefaultLlmModel(providerId, modelName);
+      await refreshLlmProviderCaches(mutate);
+      toast.success("Default model updated successfully!");
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Unknown error";
+      toast.error(`Failed to set default model: ${message}`);
+    }
   }
 
   function setCustomDisplayName(modelName: string, value: string | undefined) {
@@ -804,6 +848,16 @@ export function ModelSelectionField({
                       }
                       onSettingsChange={(patch) =>
                         setModelSettings(model.name, patch)
+                      }
+                      isDefaultModel={
+                        providerId != null &&
+                        defaultText?.provider_id === providerId &&
+                        defaultText?.model_name === model.name
+                      }
+                      onSetDefaultModel={
+                        providerId != null && model.is_visible
+                          ? () => void setDefaultModel(model.name)
+                          : undefined
                       }
                     />
                   ))}

--- a/web/src/sections/modals/languageModels/shared.tsx
+++ b/web/src/sections/modals/languageModels/shared.tsx
@@ -569,11 +569,15 @@ function ModelRow({
   const toggleVisibility = isAutoMode
     ? undefined
     : () => onToggleVisibility(!model.is_visible);
+  // A click that blurs and commits an inline rename reaches the row after the
+  // edit input unmounts, so the input's presence is sampled at pointerdown.
+  const renamingAtPointerDown = useRef(false);
   // The row is clickable, but it also hosts real buttons (rename, settings).
   // Their clicks, including ones the browser synthesizes from Enter, must not
   // toggle the model.
   const toggleFromRow = toggleVisibility
     ? (e: React.MouseEvent) => {
+        if (renamingAtPointerDown.current) return;
         const interactive = (e.target as HTMLElement).closest(
           'button, input, textarea, [contenteditable="true"]'
         );
@@ -591,6 +595,10 @@ function ModelRow({
       <Interactive.Stateful
         variant="select-heavy"
         state={isSelected ? "selected" : "empty"}
+        onPointerDownCapture={(e: React.PointerEvent) => {
+          renamingAtPointerDown.current =
+            e.currentTarget.querySelector("input") != null;
+        }}
         onClick={toggleFromRow}
         role={toggleVisibility ? "button" : undefined}
         tabIndex={toggleVisibility ? 0 : undefined}

--- a/web/src/sections/modals/languageModels/shared.tsx
+++ b/web/src/sections/modals/languageModels/shared.tsx
@@ -693,9 +693,22 @@ export function ModelSelectionField({
   function handleToggleAutoMode(nextIsAutoMode: boolean) {
     formikProps.setFieldValue("is_auto_mode", nextIsAutoMode);
     if (nextIsAutoMode) {
+      // Auto mode restores the snapshot's visibility, but unsaved renames and
+      // settings are edits the toggle has no business discarding.
+      const currentByName = new Map(models.map((m) => [m.name, m]));
       formikProps.setFieldValue(
         "model_configurations",
-        originalModelsRef.current
+        originalModelsRef.current.map((original) => {
+          const current = currentByName.get(original.name);
+          if (!current) return original;
+          return {
+            ...original,
+            custom_display_name: current.custom_display_name,
+            reasoning_effort_max: current.reasoning_effort_max,
+            reasoning_effort_default: current.reasoning_effort_default,
+            temperature_default: current.temperature_default,
+          };
+        })
       );
     }
   }

--- a/web/src/sections/modals/languageModels/shared.tsx
+++ b/web/src/sections/modals/languageModels/shared.tsx
@@ -685,7 +685,6 @@ function ModelRow({
                 </OpalSection>
               }
               editable
-              hideEditButton
               editHandle={editHandle}
               onTitleChange={(newTitle) => onRename(newTitle || undefined)}
               padding={0}

--- a/web/src/sections/modals/languageModels/shared.tsx
+++ b/web/src/sections/modals/languageModels/shared.tsx
@@ -5,7 +5,7 @@ import { Formik, Form, useFormikContext } from "formik";
 import type { FormikConfig } from "formik";
 import { cn } from "@opal/utils";
 import { markdown } from "@opal/utils";
-import { Interactive } from "@opal/core";
+import { Hoverable, Interactive } from "@opal/core";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/lib/settings/types";
 import { useAgents } from "@/lib/agents/hooks";
@@ -32,8 +32,13 @@ import {
   InputHorizontal,
   InputPadder,
   InputVertical,
+  Section as OpalSection,
   toast,
 } from "@opal/layouts";
+import {
+  ModelSettingsPopover,
+  type ModelSettingsPatch,
+} from "@/sections/modals/languageModels/ModelSettingsPopover";
 import {
   SvgArrowExchange,
   SvgChevronDown,
@@ -521,6 +526,7 @@ interface ModelRowProps {
   isAutoMode: boolean;
   onToggleVisibility: (visible: boolean) => void;
   onRename: (value: string | undefined) => void;
+  onSettingsChange: (patch: ModelSettingsPatch) => void;
 }
 
 /**
@@ -541,6 +547,7 @@ function ModelRow({
   isAutoMode,
   onToggleVisibility,
   onRename,
+  onSettingsChange,
 }: ModelRowProps) {
   const displayName =
     model.custom_display_name || model.display_name || model.name;
@@ -550,18 +557,31 @@ function ModelRow({
   const toggleVisibility = isAutoMode
     ? undefined
     : () => onToggleVisibility(!model.is_visible);
+  // The row is clickable, but it also hosts real buttons (rename, settings).
+  // Their clicks, including ones the browser synthesizes from Enter, must not
+  // toggle the model.
+  const toggleFromRow = toggleVisibility
+    ? (e: React.MouseEvent) => {
+        if ((e.target as HTMLElement).closest("button")) return;
+        toggleVisibility();
+      }
+    : undefined;
 
   return (
-    <div data-model-name={model.name}>
+    <Hoverable.Root group="model-row" data-model-name={model.name}>
       <Interactive.Stateful
         variant="select-heavy"
         state={isSelected ? "selected" : "empty"}
-        onClick={toggleVisibility}
+        onClick={toggleFromRow}
         role={toggleVisibility ? "button" : undefined}
         tabIndex={toggleVisibility ? 0 : undefined}
         onKeyDown={
           toggleVisibility
             ? (e: React.KeyboardEvent) => {
+                // Only the row itself. React bubbles events from portaled
+                // children too, so a key inside the settings popover would
+                // otherwise toggle the model.
+                if (e.target !== e.currentTarget) return;
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
                   toggleVisibility();
@@ -579,7 +599,22 @@ function ModelRow({
               icon={() => <Checkbox checked={isSelected} />}
               title={displayName}
               description={buildModelDescription(model)}
-              rightChildren={modelRightChildren(model)}
+              rightChildren={
+                <OpalSection
+                  flexDirection="row"
+                  width="fit"
+                  height="auto"
+                  gap={1}
+                >
+                  {modelRightChildren(model)}
+                  <Hoverable.Item group="model-row" variant="appear-on-hover">
+                    <ModelSettingsPopover
+                      model={model}
+                      onChange={onSettingsChange}
+                    />
+                  </Hoverable.Item>
+                </OpalSection>
+              }
               editable
               onTitleChange={(newTitle) => onRename(newTitle || undefined)}
               padding={0}
@@ -587,7 +622,7 @@ function ModelRow({
           </div>
         </Interactive.Container>
       </Interactive.Stateful>
-    </div>
+    </Hoverable.Root>
   );
 }
 
@@ -635,6 +670,13 @@ export function ModelSelectionField({
   function setVisibility(modelName: string, visible: boolean) {
     const updated = models.map((m) =>
       m.name === modelName ? { ...m, is_visible: visible } : m
+    );
+    formikProps.setFieldValue("model_configurations", updated);
+  }
+
+  function setModelSettings(modelName: string, patch: ModelSettingsPatch) {
+    const updated = models.map((m) =>
+      m.name === modelName ? { ...m, ...patch } : m
     );
     formikProps.setFieldValue("model_configurations", updated);
   }
@@ -725,6 +767,9 @@ export function ModelSelectionField({
                       }
                       onRename={(value) =>
                         setCustomDisplayName(model.name, value)
+                      }
+                      onSettingsChange={(patch) =>
+                        setModelSettings(model.name, patch)
                       }
                     />
                   ))}

--- a/web/src/sections/modals/languageModels/shared.tsx
+++ b/web/src/sections/modals/languageModels/shared.tsx
@@ -22,7 +22,7 @@ import InputSelect from "@/refresh-components/inputs/InputSelect";
 import PasswordInputTypeInField from "@/refresh-components/form/PasswordInputTypeInField";
 import { Switch } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
-import { Button, TextButton } from "@opal/components";
+import { Button } from "@opal/components";
 import { BaseLLMFormValues } from "@/sections/modals/languageModels/utils";
 import type { RichStr } from "@opal/types";
 import { Section } from "@/layouts/general-layouts";
@@ -641,7 +641,11 @@ function ModelRow({
                     />
                   </Hoverable.Item>
                   {isDefaultModel ? (
-                    <Text secondaryAction text03>
+                    <Text
+                      secondaryAction
+                      nowrap
+                      className="px-1.5 py-1 text-action-selection-05"
+                    >
                       Default Model
                     </Text>
                   ) : (
@@ -650,14 +654,16 @@ function ModelRow({
                         group="model-row"
                         variant="appear-on-hover"
                       >
-                        <TextButton
+                        <Button
+                          prominence="internal"
+                          size="sm"
                           onClick={(e: React.MouseEvent) => {
                             e.stopPropagation();
                             onSetDefaultModel();
                           }}
                         >
-                          Default Model
-                        </TextButton>
+                          Set as Default
+                        </Button>
                       </Hoverable.Item>
                     )
                   )}

--- a/web/src/sections/modals/languageModels/shared.tsx
+++ b/web/src/sections/modals/languageModels/shared.tsx
@@ -55,6 +55,8 @@ import {
 import SvgOnyxLogo from "@opal/logos/onyx-logo";
 import { Card, EmptyMessageCard } from "@opal/components";
 import { ContentAction } from "@opal/layouts";
+import type { ContentMdEditHandle } from "@opal/layouts/content/ContentMd";
+import { SvgEdit } from "@opal/icons";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
 import useUsers from "@/hooks/useUsers";
 import { Modal } from "@opal/components";
@@ -549,6 +551,7 @@ function ModelRow({
   onRename,
   onSettingsChange,
 }: ModelRowProps) {
+  const editHandle = useRef<ContentMdEditHandle>(null);
   const displayName =
     model.custom_display_name || model.display_name || model.name;
   // In auto mode every model is shown, so the row is always "selected" and the
@@ -562,7 +565,10 @@ function ModelRow({
   // toggle the model.
   const toggleFromRow = toggleVisibility
     ? (e: React.MouseEvent) => {
-        if ((e.target as HTMLElement).closest("button")) return;
+        const interactive = (e.target as HTMLElement).closest(
+          'button, input, textarea, [contenteditable="true"]'
+        );
+        if (interactive) return;
         toggleVisibility();
       }
     : undefined;
@@ -591,11 +597,12 @@ function ModelRow({
         }
       >
         <Interactive.Container width="full" size="fit" rounding="md">
-          <div className="w-full p-2">
+          <div className="w-full p-1.5">
             <ContentAction
               color="interactive"
               variant="section"
               sizePreset="main-ui"
+              center
               icon={() => <Checkbox checked={isSelected} />}
               title={displayName}
               description={buildModelDescription(model)}
@@ -608,6 +615,18 @@ function ModelRow({
                 >
                   {modelRightChildren(model)}
                   <Hoverable.Item group="model-row" variant="appear-on-hover">
+                    <Button
+                      icon={SvgEdit}
+                      prominence="internal"
+                      size="sm"
+                      tooltip="Rename"
+                      onClick={(e: React.MouseEvent) => {
+                        e.stopPropagation();
+                        editHandle.current?.startEditing();
+                      }}
+                    />
+                  </Hoverable.Item>
+                  <Hoverable.Item group="model-row" variant="appear-on-hover">
                     <ModelSettingsPopover
                       model={model}
                       onChange={onSettingsChange}
@@ -616,6 +635,8 @@ function ModelRow({
                 </OpalSection>
               }
               editable
+              hideEditButton
+              editHandle={editHandle}
               onTitleChange={(newTitle) => onRename(newTitle || undefined)}
               padding={0}
             />

--- a/web/src/sections/modals/languageModels/shared.tsx
+++ b/web/src/sections/modals/languageModels/shared.tsx
@@ -596,8 +596,10 @@ function ModelRow({
         variant="select-heavy"
         state={isSelected ? "selected" : "empty"}
         onPointerDownCapture={(e: React.PointerEvent) => {
+          // Scoped to the title row: the checkbox also owns a hidden input.
           renamingAtPointerDown.current =
-            e.currentTarget.querySelector("input") != null;
+            e.currentTarget.querySelector(".opal-content-md-title-row input") !=
+            null;
         }}
         onClick={toggleFromRow}
         role={toggleVisibility ? "button" : undefined}

--- a/web/src/sections/modals/languageModels/utils.ts
+++ b/web/src/sections/modals/languageModels/utils.ts
@@ -5,7 +5,10 @@ import {
   type ModelConfiguration,
   type ReasoningEffortOverride,
 } from "@/lib/languageModels/types";
-import { ALL_REASONING_STOPS } from "@/sections/model-selector/setting-controls";
+import {
+  ALL_REASONING_STOPS,
+  maxReasoningStop,
+} from "@/sections/model-selector/setting-controls";
 import * as Yup from "yup";
 import { useWellKnownLLMProvider } from "@/lib/languageModels/hooks";
 
@@ -138,13 +141,12 @@ export function clampModelSettings<
     | "reasoning_effort_default"
   >,
 >(model: T): T {
-  const supported = model.supported_reasoning_efforts;
-  if (!supported || supported.length === 0) return model;
-  const highest = supported[supported.length - 1]!;
-  const rank = (effort: ReasoningEffortOverride) =>
-    ALL_REASONING_STOPS.indexOf(effort);
+  const highestIndex = maxReasoningStop(model.supported_reasoning_efforts);
+  if (highestIndex < 0) return model;
   const bound = (effort: ReasoningEffortOverride | null | undefined) =>
-    effort && rank(effort) > rank(highest) ? highest : effort;
+    effort && ALL_REASONING_STOPS.indexOf(effort) > highestIndex
+      ? ALL_REASONING_STOPS[highestIndex]
+      : effort;
   return {
     ...model,
     reasoning_effort_max: bound(model.reasoning_effort_max),
@@ -156,10 +158,13 @@ export function clampModelSettings<
 
 /**
  * Merges a freshly-fetched model list with the current form state so that
- * refreshing the model list does not clobber the user's selections.
+ * refreshing the model list does not clobber the user's selections. Call it
+ * from a functional `setValues` so a fetch that lands late cannot revert edits
+ * made while it was in flight.
  *
  * - If the form has no models yet (first fetch / onboarding), the fetched
- *   list is returned as-is so each provider's own default `is_visible` applies.
+ *   list is used with only settings clamped, so each provider's own default
+ *   `is_visible` applies.
  * - Otherwise, models that already exist in the form keep their prior unsaved
  *   edits (visibility, rename, admin settings), and newly-discovered models are
  *   added unselected so the user can opt-in explicitly.
@@ -170,10 +175,9 @@ export function mergeFetchedModelConfigurations(
 ): ModelConfiguration[] {
   if (existing.length === 0) return fetched.map(clampModelSettings);
   const priorByName = new Map(existing.map((m) => [m.name, m]));
-  return fetched.map((fetchedModel) => {
-    const model = clampModelSettings(fetchedModel);
+  return fetched.map((model) => {
     const prior = priorByName.get(model.name);
-    if (!prior) return { ...model, is_visible: false };
+    if (!prior) return clampModelSettings({ ...model, is_visible: false });
     // Unsaved edits live only in form state, so a refetch has to carry them.
     return clampModelSettings({
       ...model,
@@ -183,6 +187,19 @@ export function mergeFetchedModelConfigurations(
       reasoning_effort_default: prior.reasoning_effort_default,
       temperature_default: prior.temperature_default,
     });
+  });
+}
+
+/** Functional `setValues` updater applying {@link mergeFetchedModelConfigurations}. */
+export function withFetchedModels<
+  T extends { model_configurations: ModelConfiguration[] },
+>(fetched: ModelConfiguration[]) {
+  return (prev: T): T => ({
+    ...prev,
+    model_configurations: mergeFetchedModelConfigurations(
+      fetched,
+      prev.model_configurations
+    ),
   });
 }
 

--- a/web/src/sections/modals/languageModels/utils.ts
+++ b/web/src/sections/modals/languageModels/utils.ts
@@ -44,6 +44,7 @@ export function useInitialValues(
     wellKnownLLMProvider?.recommended_default_model?.name;
 
   return {
+    id: existingLlmProvider?.id,
     provider: existingLlmProvider?.provider ?? providerName,
     name: isOnboarding
       ? providerName
@@ -113,6 +114,7 @@ export function buildValidationSchema(
 
 /** Base form values that all provider forms share. */
 export interface BaseLLMFormValues {
+  id?: number;
   name?: string;
   api_key?: string;
   api_base?: string;

--- a/web/src/sections/modals/languageModels/utils.ts
+++ b/web/src/sections/modals/languageModels/utils.ts
@@ -3,7 +3,9 @@ import {
   type LLMProviderView,
   type WellKnownLLMProviderDescriptor,
   type ModelConfiguration,
+  type ReasoningEffortOverride,
 } from "@/lib/languageModels/types";
+import { ALL_REASONING_STOPS } from "@/sections/model-selector/setting-controls";
 import * as Yup from "yup";
 import { useWellKnownLLMProvider } from "@/lib/languageModels/hooks";
 
@@ -21,7 +23,7 @@ function buildModelConfigurations(
   wellKnownModels.forEach((m) => modelMap.set(m.name, m));
   existingModels.forEach((m) => modelMap.set(m.name, m));
 
-  return Array.from(modelMap.values());
+  return Array.from(modelMap.values()).map(clampModelSettings);
 }
 
 /** Shared initial values for all LLM provider forms (both onboarding and admin). */
@@ -125,6 +127,22 @@ export interface BaseLLMFormValues {
   custom_config?: Record<string, string>;
 }
 
+/** Bound stored policy by current capability, which can shrink after a save. */
+function clampModelSettings(model: ModelConfiguration): ModelConfiguration {
+  const supported = model.supported_reasoning_efforts;
+  if (!supported || supported.length === 0) return model;
+  const highest = supported[supported.length - 1]!;
+  const rank = (effort: ReasoningEffortOverride) =>
+    ALL_REASONING_STOPS.indexOf(effort);
+  const bound = (effort: ReasoningEffortOverride | null | undefined) =>
+    effort && rank(effort) > rank(highest) ? highest : effort;
+  return {
+    ...model,
+    reasoning_effort_max: bound(model.reasoning_effort_max),
+    reasoning_effort_default: bound(model.reasoning_effort_default),
+  };
+}
+
 // ─── mergeFetchedModelConfigurations ──────────────────────────────────────
 
 /**
@@ -133,19 +151,29 @@ export interface BaseLLMFormValues {
  *
  * - If the form has no models yet (first fetch / onboarding), the fetched
  *   list is returned as-is so each provider's own default `is_visible` applies.
- * - Otherwise, models that already exist in the form keep their prior
- *   `is_visible` value, and newly-discovered models are added unselected so
- *   the user can opt-in explicitly.
+ * - Otherwise, models that already exist in the form keep their prior unsaved
+ *   edits (visibility, rename, admin settings), and newly-discovered models are
+ *   added unselected so the user can opt-in explicitly.
  */
 export function mergeFetchedModelConfigurations(
   fetched: ModelConfiguration[],
   existing: ModelConfiguration[]
 ): ModelConfiguration[] {
-  if (existing.length === 0) return fetched;
+  if (existing.length === 0) return fetched.map(clampModelSettings);
   const priorByName = new Map(existing.map((m) => [m.name, m]));
-  return fetched.map((model) => {
+  return fetched.map((fetchedModel) => {
+    const model = clampModelSettings(fetchedModel);
     const prior = priorByName.get(model.name);
-    return { ...model, is_visible: prior ? prior.is_visible : false };
+    if (!prior) return { ...model, is_visible: false };
+    // Unsaved edits live only in form state, so a refetch has to carry them.
+    return clampModelSettings({
+      ...model,
+      is_visible: prior.is_visible,
+      custom_display_name: prior.custom_display_name,
+      reasoning_effort_max: prior.reasoning_effort_max,
+      reasoning_effort_default: prior.reasoning_effort_default,
+      temperature_default: prior.temperature_default,
+    });
   });
 }
 

--- a/web/src/sections/modals/languageModels/utils.ts
+++ b/web/src/sections/modals/languageModels/utils.ts
@@ -130,7 +130,14 @@ export interface BaseLLMFormValues {
 }
 
 /** Bound stored policy by current capability, which can shrink after a save. */
-function clampModelSettings(model: ModelConfiguration): ModelConfiguration {
+export function clampModelSettings<
+  T extends Pick<
+    ModelConfiguration,
+    | "supported_reasoning_efforts"
+    | "reasoning_effort_max"
+    | "reasoning_effort_default"
+  >,
+>(model: T): T {
   const supported = model.supported_reasoning_efforts;
   if (!supported || supported.length === 0) return model;
   const highest = supported[supported.length - 1]!;

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -32,6 +32,16 @@ import {
   llmOptionKey,
 } from "@/lib/languageModels/options";
 import { ReasoningEffortOverride } from "@/lib/languageModels/types";
+import {
+  ALL_REASONING_STOPS,
+  PaneSlider,
+  REASONING_STOP_LABELS,
+  SettingRow,
+  UNKNOWN_CONTEXT_TOOLTIP,
+  UNSUPPORTED_SETTING_TOOLTIP,
+  formatContextWindow,
+  maxReasoningStop,
+} from "@/sections/model-selector/setting-controls";
 import { useCurrentAgentLLMProviders } from "@/lib/languageModels/hooks";
 import { useUser } from "@/providers/UserProvider";
 import { useSettings } from "@/lib/settings/hooks";
@@ -98,56 +108,13 @@ export function useModelDetailManagers(
   ]);
 }
 
-const BASE_REASONING_STOPS: ReasoningEffortOverride[] = [
-  "off",
-  "low",
-  "medium",
-  "high",
-];
-
-/** Every stop the slider renders. Unsupported stops are greyed, never hidden. */
-const ALL_REASONING_STOPS: ReasoningEffortOverride[] = [
-  ...BASE_REASONING_STOPS,
-  "xhigh",
-];
-
-const REASONING_STOP_LABELS: Record<ReasoningEffortOverride, string> = {
-  off: "Off",
-  low: "Low",
-  medium: "Medium",
-  high: "High",
-  xhigh: "XHigh",
-};
-
-/**
- * Index of the highest stop the model supports. The backend resolves this from
- * the same code that builds the request, so the slider can never offer a level
- * the request would drop. An older backend sends nothing, so fall back to the
- * levels every reasoning model supports.
- */
+/** Highest stop this model supports, as a slider index. */
 function maxSupportedReasoningStop(option: LLMOption): number {
-  const supported = option.supportedReasoningEfforts;
-  if (!supported) return BASE_REASONING_STOPS.length - 1;
-  return Math.max(
-    -1,
-    ...supported.map((effort) => ALL_REASONING_STOPS.indexOf(effort))
-  );
-}
-
-function formatContextWindow(tokens: number): string {
-  if (tokens >= 1_000_000)
-    return `${(tokens / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
-  return tokens >= 1000 ? `${Math.round(tokens / 1000)}K` : `${tokens}`;
+  return maxReasoningStop(option.supportedReasoningEfforts);
 }
 
 /** Fixed-height scroll box: the popover clips overflow instead of scrolling. */
 const DETAIL_PANE_HEIGHT_CLASS = "h-[352px]";
-
-const SLIDER_THUMB_CLASS =
-  "block size-3 rounded-full bg-background-neutral-00 shadow-[0_0_2px_1px_rgba(0,0,0,0.15)] focus:outline-none";
-const SLIDER_TRACK_CLASS =
-  "h-1.5 w-full overflow-hidden rounded bg-background-tint-02";
-const SLIDER_FILL_CLASS = "h-full bg-theme-primary-05";
 
 function EmptyIconSlot(props: IconProps) {
   return <div {...(props as any)} />;
@@ -167,120 +134,11 @@ function selectionIcon(selected: boolean): IconFunctionComponent {
   return selected ? SelectedCheckIcon : EmptyIconSlot;
 }
 
-interface PaneSliderProps {
-  value: number;
-  min: number;
-  max: number;
-  step: number;
-  disabled?: boolean;
-  onValueChange: (value: number) => void;
-  onValueCommit: (value: number) => void;
-}
-
-function PaneSlider({
-  value,
-  min,
-  max,
-  step,
-  disabled,
-  onValueChange,
-  onValueCommit,
-}: PaneSliderProps) {
-  return (
-    <SliderPrimitive.Root
-      className="relative flex h-7 w-full cursor-pointer touch-none select-none items-center"
-      value={[value]}
-      min={min}
-      max={max}
-      step={step}
-      disabled={disabled}
-      onValueChange={(vals) => vals[0] !== undefined && onValueChange(vals[0])}
-      onValueCommit={(vals) => vals[0] !== undefined && onValueCommit(vals[0])}
-    >
-      <SliderPrimitive.Track
-        className={cn(SLIDER_TRACK_CLASS, "relative grow")}
-      >
-        <SliderPrimitive.Range className={cn(SLIDER_FILL_CLASS, "absolute")} />
-      </SliderPrimitive.Track>
-      <SliderPrimitive.Thumb className={SLIDER_THUMB_CLASS} />
-    </SliderPrimitive.Root>
-  );
-}
-
-interface SettingRowProps {
-  icon: IconFunctionComponent;
-  title: string;
-  value?: string;
-  /** Shown when hovering the value readout. */
-  valueTooltip?: string;
-  caption: string;
-  disabled?: boolean;
-  /** Shown when hovering the row while disabled. */
-  disabledTooltip?: string;
-  children?: React.ReactNode;
-}
-
-function SettingRow({
-  icon: Icon,
-  title,
-  value,
-  valueTooltip,
-  caption,
-  disabled = false,
-  disabledTooltip,
-  children,
-}: SettingRowProps) {
-  return (
-    <Disabled disabled={disabled} tooltip={disabledTooltip} tooltipSide="top">
-      <Section
-        alignItems="stretch"
-        height="auto"
-        gap={0}
-        padding={1.5}
-        className="rounded-08"
-      >
-        <Section
-          flexDirection="row"
-          justifyContent="between"
-          height="auto"
-          gap={2}
-        >
-          <Section flexDirection="row" width="fit" height="auto" gap={2}>
-            <Section width={1.25} height={1.25} className="text-text-04">
-              <Icon size={16} />
-            </Section>
-            <Text font="main-ui-action">{title}</Text>
-          </Section>
-          {value !== undefined && (
-            <Tooltip tooltip={valueTooltip} side="top">
-              <Text font="secondary-mono" color="text-04">
-                {value}
-              </Text>
-            </Tooltip>
-          )}
-        </Section>
-        {children}
-        <Section alignItems="stretch" height="auto" className="mt-2">
-          <Text font="secondary-body" color="text-03">
-            {caption}
-          </Text>
-        </Section>
-      </Section>
-    </Disabled>
-  );
-}
-
 interface ModelDetailPaneProps {
   option: LLMOption;
   managers: ModelDetailManagers;
   onBack: () => void;
 }
-
-const UNSUPPORTED_SETTING_TOOLTIP =
-  "Modifying this setting is not supported for this model.";
-
-const UNKNOWN_CONTEXT_TOOLTIP =
-  "Context size is not available for this model. Chats still apply a token limit automatically.";
 
 function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
   // Backend pins temperature to 1 (or omits it) for reasoning models, so

--- a/web/src/sections/model-selector/setting-controls.tsx
+++ b/web/src/sections/model-selector/setting-controls.tsx
@@ -71,6 +71,8 @@ interface PaneSliderProps {
   max: number;
   step: number;
   disabled?: boolean;
+  /** 16px-tall variant matching the mock's popover sliders. */
+  compact?: boolean;
   onValueChange: (value: number) => void;
   onValueCommit: (value: number) => void;
 }
@@ -81,12 +83,16 @@ export function PaneSlider({
   max,
   step,
   disabled,
+  compact,
   onValueChange,
   onValueCommit,
 }: PaneSliderProps) {
   return (
     <SliderPrimitive.Root
-      className="relative flex h-7 w-full cursor-pointer touch-none select-none items-center"
+      className={cn(
+        "relative flex w-full cursor-pointer touch-none select-none items-center",
+        compact ? "h-4" : "h-7"
+      )}
       value={[value]}
       min={min}
       max={max}

--- a/web/src/sections/model-selector/setting-controls.tsx
+++ b/web/src/sections/model-selector/setting-controls.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import * as SliderPrimitive from "@radix-ui/react-slider";
+import { Text, Tooltip } from "@opal/components";
+import { Section } from "@opal/layouts";
+import { cn } from "@opal/utils";
+import type { IconFunctionComponent } from "@opal/types";
+import { Disabled } from "@opal/core";
+import { ReasoningEffortOverride } from "@/lib/languageModels/types";
+
+/** The levels every reasoning model supports, in ascending order. */
+export const BASE_REASONING_STOPS: ReasoningEffortOverride[] = [
+  "off",
+  "low",
+  "medium",
+  "high",
+];
+
+/** Every stop the slider renders. Unsupported stops are greyed, never hidden. */
+export const ALL_REASONING_STOPS: ReasoningEffortOverride[] = [
+  ...BASE_REASONING_STOPS,
+  "xhigh",
+];
+
+export const REASONING_STOP_LABELS: Record<ReasoningEffortOverride, string> = {
+  off: "Off",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "XHigh",
+};
+
+export const UNSUPPORTED_SETTING_TOOLTIP =
+  "Modifying this setting is not supported for this model.";
+
+export const UNKNOWN_CONTEXT_TOOLTIP =
+  "Context size is not available for this model. Chats still apply a token limit automatically.";
+
+/** Highest supported stop. Nothing from an older backend means the base set. */
+export function maxReasoningStop(
+  supported: ReasoningEffortOverride[] | undefined
+): number {
+  if (!supported) return BASE_REASONING_STOPS.length - 1;
+  return Math.max(
+    -1,
+    ...supported.map((effort) => ALL_REASONING_STOPS.indexOf(effort))
+  );
+}
+
+export function reasoningStopIndex(
+  effort: ReasoningEffortOverride | null | undefined
+): number {
+  return effort ? ALL_REASONING_STOPS.indexOf(effort) : -1;
+}
+
+export function formatContextWindow(tokens: number): string {
+  if (tokens >= 1_000_000)
+    return `${(tokens / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+  return tokens >= 1000 ? `${Math.round(tokens / 1000)}K` : `${tokens}`;
+}
+
+const SLIDER_THUMB_CLASS =
+  "block size-3 rounded-full bg-background-neutral-00 shadow-[0_0_2px_1px_rgba(0,0,0,0.15)] focus:outline-none";
+const SLIDER_TRACK_CLASS =
+  "h-1.5 w-full overflow-hidden rounded bg-background-tint-02";
+const SLIDER_FILL_CLASS = "h-full bg-theme-primary-05";
+
+interface PaneSliderProps {
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  disabled?: boolean;
+  onValueChange: (value: number) => void;
+  onValueCommit: (value: number) => void;
+}
+
+export function PaneSlider({
+  value,
+  min,
+  max,
+  step,
+  disabled,
+  onValueChange,
+  onValueCommit,
+}: PaneSliderProps) {
+  return (
+    <SliderPrimitive.Root
+      className="relative flex h-7 w-full cursor-pointer touch-none select-none items-center"
+      value={[value]}
+      min={min}
+      max={max}
+      step={step}
+      disabled={disabled}
+      onValueChange={(vals) => vals[0] !== undefined && onValueChange(vals[0])}
+      onValueCommit={(vals) => vals[0] !== undefined && onValueCommit(vals[0])}
+    >
+      <SliderPrimitive.Track
+        className={cn(SLIDER_TRACK_CLASS, "relative grow")}
+      >
+        <SliderPrimitive.Range className={cn(SLIDER_FILL_CLASS, "absolute")} />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb className={SLIDER_THUMB_CLASS} />
+    </SliderPrimitive.Root>
+  );
+}
+
+interface SettingRowProps {
+  icon: IconFunctionComponent;
+  title: string;
+  value?: string;
+  /** Shown when hovering the value readout. */
+  valueTooltip?: string;
+  caption: string;
+  disabled?: boolean;
+  /** Shown when hovering the row while disabled. */
+  disabledTooltip?: string;
+  children?: React.ReactNode;
+}
+
+export function SettingRow({
+  icon: Icon,
+  title,
+  value,
+  valueTooltip,
+  caption,
+  disabled = false,
+  disabledTooltip,
+  children,
+}: SettingRowProps) {
+  return (
+    <Disabled disabled={disabled} tooltip={disabledTooltip} tooltipSide="top">
+      <Section
+        alignItems="stretch"
+        height="auto"
+        gap={0}
+        padding={1.5}
+        className="rounded-08"
+      >
+        <Section
+          flexDirection="row"
+          justifyContent="between"
+          height="auto"
+          gap={2}
+        >
+          <Section flexDirection="row" width="fit" height="auto" gap={2}>
+            <Section width={1.25} height={1.25} className="text-text-04">
+              <Icon size={16} />
+            </Section>
+            <Text font="main-ui-action">{title}</Text>
+          </Section>
+          {value !== undefined && (
+            <Tooltip tooltip={valueTooltip} side="top">
+              <Text font="secondary-mono" color="text-04">
+                {value}
+              </Text>
+            </Tooltip>
+          )}
+        </Section>
+        {children}
+        <Section alignItems="stretch" height="auto" className="mt-2">
+          <Text font="secondary-body" color="text-03">
+            {caption}
+          </Text>
+        </Section>
+      </Section>
+    </Disabled>
+  );
+}

--- a/web/src/sections/model-selector/setting-controls.tsx
+++ b/web/src/sections/model-selector/setting-controls.tsx
@@ -9,7 +9,7 @@ import { Disabled } from "@opal/core";
 import { ReasoningEffortOverride } from "@/lib/languageModels/types";
 
 /** The levels every reasoning model supports, in ascending order. */
-export const BASE_REASONING_STOPS: ReasoningEffortOverride[] = [
+const BASE_REASONING_STOPS: ReasoningEffortOverride[] = [
   "off",
   "low",
   "medium",

--- a/web/src/views/admin/LanguageModelsPage.tsx
+++ b/web/src/views/admin/LanguageModelsPage.tsx
@@ -19,11 +19,11 @@ import { SettingsLayouts } from "@opal/layouts";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import { getProvider } from "@/lib/languageModels";
-import { refreshLlmProviderCaches } from "@/lib/languageModels/cache";
 import {
-  deleteLlmProvider,
-  setDefaultLlmModel,
-} from "@/lib/languageModels/svc";
+  refreshLlmProviderCaches,
+  setDefaultLlmModelAndRefresh,
+} from "@/lib/languageModels/cache";
+import { deleteLlmProvider } from "@/lib/languageModels/svc";
 import ModelSelector from "@/sections/model-selector/ModelSelector";
 import { ConfirmationModalLayout } from "@opal/layouts";
 import { useCreateModal } from "@opal/components";
@@ -381,15 +381,7 @@ export default function LanguageModelsPage() {
     const separatorIndex = compositeValue.indexOf(":");
     const providerId = Number(compositeValue.slice(0, separatorIndex));
     const modelName = compositeValue.slice(separatorIndex + 1);
-
-    try {
-      await setDefaultLlmModel(providerId, modelName);
-      await refreshLlmProviderCaches(mutate);
-      toast.success("Default model updated successfully!");
-    } catch (e) {
-      const message = e instanceof Error ? e.message : "Unknown error";
-      toast.error(`Failed to set default model: ${message}`);
-    }
+    await setDefaultLlmModelAndRefresh(providerId, modelName, mutate);
   }
 
   return (


### PR DESCRIPTION
## Description

Adds a Model Settings popover to each model row in the LLM provider setup modal, where an admin sets the reasoning cap, the reasoning default, and the temperature default for that model. Backend enforcement merged in #14078.

The first commit is a pure move: the slider, the setting row, and the reasoning stop constants were private to the chat model selector, and the admin side needs the same controls.

The popover offers only the levels the backend says the model distinguishes, hides the reasoning section for a reasoning model that takes no effort parameter, and disables temperature for reasoning models, which the backend pins to 1. Dragging Max below Default pulls Default down, so the pair cannot reach a state the API rejects. A stored setting is clamped by current capability on read, so a level the model lost since the save is neither shown nor resubmitted.

The model rows also gain the mock's set-as-default action: the current org default shows a Default Model tag, every other visible row gets a hover Set as Default button.

Pre-existing bugs in the surrounding code are fixed here, since the change sits on top of them:

- An unsaved model rename was discarded by a model-list refetch. The merge only carried `is_visible`.
- Eleven refetch call sites across nine provider modals merged against a Formik snapshot captured when the request started, so an edit made while a fetch was in flight was reverted. They now use the functional `setValues`.
- Pressing Enter on the rename pencil toggled the model's visibility, because the synthesized click reached the row.
- Clicking a model title to rename it also toggled the model's visibility.
- Enabling auto-update discarded unsaved edits and dropped models discovered after the modal opened.
- Custom provider models neither clamped nor persisted their settings on save.

## How Has This Been Tested?

- `bun run types:check` clean, oxfmt / oxlint / ripsecrets pass on every touched file.
- Local Greptile review loop plus two independent review agents over the full diff. Nine real defects found and fixed.
- Manually exercised live on a dev stack: popover editing, clamping, set-as-default, rename, visibility toggling, auto-update round trip.

Demo (open modal, hover actions, popover, reasoning default change):

<img width="1676" height="1700" alt="2026-08-21 10 04 06" src="https://github.com/user-attachments/assets/7eea0806-cec6-4122-8692-41f4821a396a" />


| After: provider modal | After: model settings popover |
|---|---|
| ![modal](https://github.com/user-attachments/assets/86265826-a05b-41e3-ad85-babb5ead6019) | ![popover](https://github.com/user-attachments/assets/9539d987-bd8c-440d-abb2-5780378397e9) |

Before: the modal renders plain checkbox rows with no per-model controls. The popover, the hover actions, and the Default Model tag are all new surfaces.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
