### PR TITLE
feat(web): admin caps and defaults in the session model pane

### DIFF
--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -1074,7 +1074,11 @@ export default function useChatController({
             : modelOverride
               ? (modelOverride.modelConfigurationId ?? undefined)
               : (llmManager.currentLlm.modelConfigurationId ?? undefined),
-          temperature: llmManager.temperature || undefined,
+          // Only a chosen temperature is sent, zero included. Without one the
+          // backend resolves the admin default, then GEN_AI_TEMPERATURE.
+          temperature: llmManager.hasTemperatureOverride
+            ? llmManager.temperature
+            : undefined,
           deepResearch,
           enabledToolIds:
             disabledToolIds && activeAgent
@@ -1468,6 +1472,7 @@ export default function useChatController({
       filterManager.timeRange,
       llmManager.currentLlm,
       llmManager.temperature,
+      llmManager.hasTemperatureOverride,
       // Others that affect logic
       activeAgent,
       availableAgents,

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -433,7 +433,7 @@ export interface LlmManager {
   updateImageFilesPresent: (present: boolean) => void;
   activeAgent: MinimalAgent | null;
   maxTemperature: number;
-  /** False when `temperature` is just a fallback, not a user's choice. */
+  /** True only when an override was set locally or is stored on the session. */
   hasTemperatureOverride: boolean;
   llmProviders: LLMProviderDescriptor[] | undefined;
   isLoadingProviders: boolean;
@@ -913,7 +913,7 @@ export function useLlmManager(
       return;
     }
 
-    if (currentChatSession?.current_temperature_override) {
+    if (currentChatSession?.current_temperature_override != null) {
       setTemperature(currentChatSession.current_temperature_override);
     } else if (
       activeAgent?.tools.some((tool) => tool.in_code_tool_id === SEARCH_TOOL_ID)
@@ -1007,8 +1007,7 @@ export function useLlmManager(
     updateImageFilesPresent,
     activeAgent: activeAgent ?? null,
     maxTemperature,
-    // Covers the window where the user just moved the slider and the session
-    // write has not landed yet.
+    // Covers a slider choice the session snapshot does not yet reflect.
     hasTemperatureOverride:
       temperatureExplicitlySet ||
       currentChatSession?.current_temperature_override != null,

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -913,6 +913,11 @@ export function useLlmManager(
       return;
     }
 
+    // A local slider choice outranks the snapshot, which may not reflect the
+    // write yet. The flag is a dep so a session switch, which resets it,
+    // re-runs this sync for the new session.
+    if (temperatureExplicitlySet) return;
+
     if (currentChatSession?.current_temperature_override != null) {
       setTemperature(currentChatSession.current_temperature_override);
     } else if (
@@ -927,6 +932,7 @@ export function useLlmManager(
     currentChatSession,
     llmProviders,
     user?.preferences?.default_model,
+    temperatureExplicitlySet,
   ]);
 
   const updateTemperature = (temperature: number) => {

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -433,6 +433,8 @@ export interface LlmManager {
   updateImageFilesPresent: (present: boolean) => void;
   activeAgent: MinimalAgent | null;
   maxTemperature: number;
+  /** False when `temperature` is just a fallback, not a user's choice. */
+  hasTemperatureOverride: boolean;
   llmProviders: LLMProviderDescriptor[] | undefined;
   isLoadingProviders: boolean;
   hasAnyProvider: boolean;
@@ -1005,6 +1007,11 @@ export function useLlmManager(
     updateImageFilesPresent,
     activeAgent: activeAgent ?? null,
     maxTemperature,
+    // Covers the window where the user just moved the slider and the session
+    // write has not landed yet.
+    hasTemperatureOverride:
+      temperatureExplicitlySet ||
+      currentChatSession?.current_temperature_override != null,
     llmProviders,
     isLoadingProviders:
       isLoadingAllProviders ||

--- a/web/src/lib/languageModels/options.ts
+++ b/web/src/lib/languageModels/options.ts
@@ -31,6 +31,10 @@ export interface LLMOption {
   supportsReasoning?: boolean;
   /** See ModelConfiguration.supported_reasoning_efforts. */
   supportedReasoningEfforts?: ReasoningEffortOverride[];
+  /** See ModelConfiguration.reasoning_effort_max. */
+  reasoningEffortMax?: ReasoningEffortOverride | null;
+  reasoningEffortDefault?: ReasoningEffortOverride | null;
+  temperatureDefault?: number | null;
   supportsImageInput?: boolean;
 }
 
@@ -122,6 +126,9 @@ export function buildLlmOptions(
           version: mc.version || null,
           supportsReasoning: mc.supports_reasoning || false,
           supportedReasoningEfforts: mc.supported_reasoning_efforts,
+          reasoningEffortMax: mc.reasoning_effort_max,
+          reasoningEffortDefault: mc.reasoning_effort_default,
+          temperatureDefault: mc.temperature_default,
           supportsImageInput: mc.supports_image_input || false,
         });
       });

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -33,19 +33,19 @@ import {
 } from "@/lib/languageModels/options";
 import { ReasoningEffortOverride } from "@/lib/languageModels/types";
 import {
+  ADMIN_LIMITED_SETTING_TOOLTIP,
   ALL_REASONING_STOPS,
   PaneSlider,
   REASONING_STOP_LABELS,
   SettingRow,
   UNKNOWN_CONTEXT_TOOLTIP,
+  UNSET_REASONING_STOP,
   UNSUPPORTED_SETTING_TOOLTIP,
+  cappedReasoningStop,
   formatContextWindow,
   maxReasoningStop,
   reasoningStopIndex,
 } from "@/sections/model-selector/setting-controls";
-
-const ADMIN_LIMITED_SETTING_TOOLTIP =
-  "Your admin limits this model to a lower reasoning level.";
 import { useCurrentAgentLLMProviders } from "@/lib/languageModels/hooks";
 import { useUser } from "@/providers/UserProvider";
 import { useSettings } from "@/lib/settings/hooks";
@@ -59,7 +59,7 @@ export interface TemperatureManager {
   temperature: number;
   updateTemperature: (value: number) => void;
   maxTemperature: number;
-  /** False when `temperature` is just a fallback, not a user's choice. */
+  /** True only when an override was set locally or is stored on the session. */
   hasTemperatureOverride: boolean;
 }
 
@@ -114,9 +114,18 @@ export function useModelDetailManagers(
   ]);
 }
 
-/** Highest stop this model supports, as a slider index. */
-function maxSupportedReasoningStop(option: LLMOption): number {
-  return maxReasoningStop(option.supportedReasoningEfforts);
+/** Where the slider parks on open: the session's own choice, else the admin
+ *  default, bounded by the selected model's slider maximum. */
+function initialTemperature(
+  option: LLMOption,
+  manager: TemperatureManager | undefined
+): number {
+  const sessionTemperature = manager?.temperature ?? 0.5;
+  if (manager?.hasTemperatureOverride) return sessionTemperature;
+  return Math.min(
+    option.temperatureDefault ?? sessionTemperature,
+    manager?.maxTemperature ?? 2
+  );
 }
 
 /** Fixed-height scroll box: the popover clips overflow instead of scrolling. */
@@ -152,13 +161,14 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
   const temperatureManager = managers.temperature;
   const reasoningManager = managers.reasoning;
   const temperatureEnabled = !option.supportsReasoning && !!temperatureManager;
+  const capabilityStop = maxReasoningStop(option.supportedReasoningEfforts);
+  // The admin cap further limits which stops users may request.
+  const maxSupportedStop = cappedReasoningStop(
+    capabilityStop,
+    option.reasoningEffortMax
+  );
   // A reasoning model with no supported levels takes no effort parameter at
   // all (e.g. o1-mini), so the row stays disabled.
-  const capabilityStop = maxSupportedReasoningStop(option);
-  // An admin cap narrows what the model can do to what users may request.
-  const adminCapStop = reasoningStopIndex(option.reasoningEffortMax);
-  const maxSupportedStop =
-    adminCapStop >= 0 ? Math.min(capabilityStop, adminCapStop) : capabilityStop;
   const reasoningEnabled =
     option.supportsReasoning && !!reasoningManager && maxSupportedStop >= 0;
 
@@ -168,24 +178,18 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
   const clampStop = (stop: number) =>
     Math.max(0, Math.min(stop, maxSupportedStop));
 
-  // The manager always reports a concrete number, so the admin default is only
-  // reachable by asking whether the session actually pinned one.
+  // temperature is always concrete, so the override flag decides when the
+  // admin default applies.
   const [localTemperature, setLocalTemperature] = useState(() =>
-    temperatureManager?.hasTemperatureOverride
-      ? temperatureManager.temperature
-      : (option.temperatureDefault ?? temperatureManager?.temperature ?? 0.5)
+    initialTemperature(option, temperatureManager)
   );
   // A stored level the model doesn't support (e.g. xhigh after switching
   // models) displays clamped to the highest supported stop.
-  const storedStop = ALL_REASONING_STOPS.indexOf(
-    reasoningManager?.reasoningEffort ??
-      option.reasoningEffortDefault ??
-      "medium"
+  const storedStop = reasoningStopIndex(
+    reasoningManager?.reasoningEffort ?? option.reasoningEffortDefault
   );
   const [localEffortStop, setLocalEffortStop] = useState(
-    clampStop(
-      storedStop === -1 ? ALL_REASONING_STOPS.indexOf("medium") : storedStop
-    )
+    clampStop(storedStop >= 0 ? storedStop : UNSET_REASONING_STOP)
   );
 
   const displayTemperature = temperatureEnabled ? localTemperature : 1;

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -41,7 +41,11 @@ import {
   UNSUPPORTED_SETTING_TOOLTIP,
   formatContextWindow,
   maxReasoningStop,
+  reasoningStopIndex,
 } from "@/sections/model-selector/setting-controls";
+
+const ADMIN_LIMITED_SETTING_TOOLTIP =
+  "Your admin limits this model to a lower reasoning level.";
 import { useCurrentAgentLLMProviders } from "@/lib/languageModels/hooks";
 import { useUser } from "@/providers/UserProvider";
 import { useSettings } from "@/lib/settings/hooks";
@@ -55,6 +59,8 @@ export interface TemperatureManager {
   temperature: number;
   updateTemperature: (value: number) => void;
   maxTemperature: number;
+  /** False when `temperature` is just a fallback, not a user's choice. */
+  hasTemperatureOverride: boolean;
 }
 
 export interface ReasoningManager {
@@ -148,7 +154,11 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
   const temperatureEnabled = !option.supportsReasoning && !!temperatureManager;
   // A reasoning model with no supported levels takes no effort parameter at
   // all (e.g. o1-mini), so the row stays disabled.
-  const maxSupportedStop = maxSupportedReasoningStop(option);
+  const capabilityStop = maxSupportedReasoningStop(option);
+  // An admin cap narrows what the model can do to what users may request.
+  const adminCapStop = reasoningStopIndex(option.reasoningEffortMax);
+  const maxSupportedStop =
+    adminCapStop >= 0 ? Math.min(capabilityStop, adminCapStop) : capabilityStop;
   const reasoningEnabled =
     option.supportsReasoning && !!reasoningManager && maxSupportedStop >= 0;
 
@@ -158,13 +168,19 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
   const clampStop = (stop: number) =>
     Math.max(0, Math.min(stop, maxSupportedStop));
 
-  const [localTemperature, setLocalTemperature] = useState(
-    temperatureManager?.temperature ?? 0.5
+  // The manager always reports a concrete number, so the admin default is only
+  // reachable by asking whether the session actually pinned one.
+  const [localTemperature, setLocalTemperature] = useState(() =>
+    temperatureManager?.hasTemperatureOverride
+      ? temperatureManager.temperature
+      : (option.temperatureDefault ?? temperatureManager?.temperature ?? 0.5)
   );
   // A stored level the model doesn't support (e.g. xhigh after switching
   // models) displays clamped to the highest supported stop.
   const storedStop = ALL_REASONING_STOPS.indexOf(
-    reasoningManager?.reasoningEffort ?? "medium"
+    reasoningManager?.reasoningEffort ??
+      option.reasoningEffortDefault ??
+      "medium"
   );
   const [localEffortStop, setLocalEffortStop] = useState(
     clampStop(
@@ -299,7 +315,11 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
                 >
                   <Disabled
                     disabled={reasoningEnabled && index > maxSupportedStop}
-                    tooltip={UNSUPPORTED_SETTING_TOOLTIP}
+                    tooltip={
+                      index > capabilityStop
+                        ? UNSUPPORTED_SETTING_TOOLTIP
+                        : ADMIN_LIMITED_SETTING_TOOLTIP
+                    }
                     tooltipSide="top"
                   >
                     <Text

--- a/web/src/sections/model-selector/setting-controls.tsx
+++ b/web/src/sections/model-selector/setting-controls.tsx
@@ -36,6 +36,12 @@ export const UNSUPPORTED_SETTING_TOOLTIP =
 export const UNKNOWN_CONTEXT_TOOLTIP =
   "Context size is not available for this model. Chats still apply a token limit automatically.";
 
+export const ADMIN_LIMITED_SETTING_TOOLTIP =
+  "Your admin limits this model to a lower reasoning level.";
+
+/** Where an unset reasoning setting parks: the backend resolves AUTO to medium. */
+export const UNSET_REASONING_STOP = ALL_REASONING_STOPS.indexOf("medium");
+
 /** Highest supported stop. Nothing from an older backend means the base set. */
 export function maxReasoningStop(
   supported: ReasoningEffortOverride[] | undefined
@@ -51,6 +57,15 @@ export function reasoningStopIndex(
   effort: ReasoningEffortOverride | null | undefined
 ): number {
   return effort ? ALL_REASONING_STOPS.indexOf(effort) : -1;
+}
+
+/** Highest stop a user may request: model capability, narrowed by the admin cap. */
+export function cappedReasoningStop(
+  capabilityStop: number,
+  cap: ReasoningEffortOverride | null | undefined
+): number {
+  const capStop = reasoningStopIndex(cap);
+  return capStop >= 0 ? Math.min(capabilityStop, capStop) : capabilityStop;
 }
 
 export function formatContextWindow(tokens: number): string {


### PR DESCRIPTION
## Description

Makes the chat model selector honor the per-model admin settings from #14131 (merged).

- The reasoning slider is bounded by the admin's max level. Stops above the cap grey out with a "Your admin limits this model to a lower reasoning level" tooltip.
- A session with no explicit override opens at the admin's default reasoning level and default temperature. An explicit per-session choice still wins, and `LlmManager` gains `hasTemperatureOverride` so an admin default cannot stomp it.
- The chat request now carries a temperature only when the user chose one. Without a choice the backend resolves the admin default, then `GEN_AI_TEMPERATURE`. The old code always sent the frontend's placeholder, which silently disabled the admin temperature default and dropped an explicit choice of 0.
- Fixes a session refresh resetting a stored temperature override of 0, and a stale snapshot clobbering a just-made slider choice while its write was in flight.

## How Has This Been Tested?

- `bun run types:check` clean on every touched file.
- Local Greptile loop to 5/5 with zero comments, twice consecutively, plus two independent review agents over the diff. Four real defects found and fixed.
- Manually exercised live: saved a High cap on Claude Opus 5 via the admin modal, verified the pane greys XHigh with the admin tooltip and clamps the slider, then reverted the cap.

| Before: XHigh selectable above the cap | After: clamped at High with the admin tooltip |
|---|---|
| ![before](https://github.com/user-attachments/assets/449bdc8a-d2cb-458a-bf8b-9bd03150d3b8) | ![after](https://github.com/user-attachments/assets/4b209cb4-f5b9-4606-94f2-02e1411a5b07) |

Both screenshots taken with the same saved admin cap (max High) on Claude Opus 5, attempting to select XHigh.


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

