### PR TITLE
refactor(mcp): isolate OAuth SDK integration

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -115,12 +115,12 @@ from onyx.server.features.mcp.models import (
 from onyx.server.features.mcp.oauth import (
     REQUESTED_SCOPE,
     MCPReauthenticationRequired,
+    complete_mcp_oauth_authorization,
     make_oauth_provider,
 )
 from onyx.server.features.mcp.oauth_flow import (
     OAuthAlreadyAuthenticated,
     OAuthAuthorizationRedirect,
-    complete_mcp_oauth_flow,
     mcp_oauth_attempt_store,
     start_auto_discovery_oauth_flow,
     start_known_provider_oauth_flow,
@@ -966,7 +966,7 @@ async def process_oauth_callback(
             "MCP OAuth client registration changed while authorization was pending.",
         )
 
-    await complete_mcp_oauth_flow(
+    await complete_mcp_oauth_authorization(
         flow,
         mcp_server,
         client_info,

--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -201,40 +201,11 @@ def _absolute_token_expiry(tokens: OAuthToken) -> float | None:
     return time.time() + tokens.expires_in - TOKEN_EXPIRY_BUFFER_SECONDS
 
 
-async def _refresh_mcp_oauth_token_if_expired(
-    mcp_server: MCPServer,
-    connection_config_id: int,
-) -> str | None:
-    """Refresh an SSE-transport MCP server's OAuth token via the same
-    `OAuthClientProvider`/`OnyxTokenStorage` every other MCP OAuth path uses
-    (see `make_oauth_provider`) — the SDK's own httpx.Auth refresh can't run
-    over an open SSE stream, so this drives the provider's refresh step
-    directly instead of the full httpx.Auth flow. That gets client-auth-method
-    handling (`client_secret_basic` vs. `client_secret_post`) and token
-    persistence for free, instead of a second implementation to keep in sync.
-
-    Returns the `Authorization` header to use now, or `None` with no opinion
-    (no refresh token / client info) — caller falls back to its own header.
-    Raises on failure; caller treats that as non-fatal.
-    """
-    provider = make_oauth_provider(
-        mcp_server,
-        connection_config_id,
-        None,
-    )
-    tokens = await provider.refresh_access_token_if_expired()
-    if tokens is None:
-        return None
-    return f"{tokens.token_type} {tokens.access_token}"
-
-
 def refresh_mcp_oauth_token_if_expired(
     mcp_server: MCPServer,
     connection_config_id: int,
 ) -> str | None:
-    """Sync entry point for `_refresh_mcp_oauth_token_if_expired`, single-flighted
-    per connection-config row (via `cache_shared_lock`) so two racing refreshes
-    can't redeem — and burn — the same rotating refresh token.
+    """Refresh an MCP OAuth token, single-flighted per connection config.
 
     On contention the loser waits out the in-flight refresh (the wait outlasts a
     refresh POST) and returns the winner's freshly persisted header. Only if the
@@ -249,9 +220,17 @@ def refresh_mcp_oauth_token_if_expired(
             wait_for_lock_s=_REFRESH_LOCK_WAIT_S,
             logger=logger,
         ):
-            return run_async_sync_no_cancel(
-                _refresh_mcp_oauth_token_if_expired(mcp_server, connection_config_id)
+            provider = make_oauth_provider(
+                mcp_server,
+                connection_config_id,
+                None,
             )
+            tokens = run_async_sync_no_cancel(
+                provider.refresh_access_token_if_expired()
+            )
+            if tokens is None:
+                return None
+            return f"{tokens.token_type} {tokens.access_token}"
     except MCPRefreshSuperseded:
         logger.info("mcp_token_refresh.superseded config_id=%s", connection_config_id)
         return _persisted_auth_header(connection_config_id)

--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -52,6 +52,7 @@ from onyx.server.features.mcp.credentials import (
     mcp_token_expired,
 )
 from onyx.server.features.mcp.models import (
+    MCPOAuthFlowState,
     MCPOAuthKeys,
     MCPPendingOAuthAuthorization,
     merge_mcp_headers,
@@ -212,10 +213,6 @@ async def _refresh_mcp_oauth_token_if_expired(
     handling (`client_secret_basic` vs. `client_secret_post`) and token
     persistence for free, instead of a second implementation to keep in sync.
 
-    Uses private SDK methods (`_initialize`/`_refresh_token`/
-    `_handle_refresh_response`) since there's no public "refresh if needed"
-    API — may need adjusting on MCP SDK upgrades.
-
     Returns the `Authorization` header to use now, or `None` with no opinion
     (no refresh token / client info) — caller falls back to its own header.
     Raises on failure; caller treats that as non-fatal.
@@ -225,39 +222,10 @@ async def _refresh_mcp_oauth_token_if_expired(
         connection_config_id,
         None,
     )
-    context = provider.context
-    await provider._initialize()
-
-    if not context.can_refresh_token():
+    tokens = await provider.refresh_access_token_if_expired()
+    if tokens is None:
         return None
-
-    if context.is_token_valid():
-        # Valid (no persisted expiry also reads as valid), or a racing call
-        # already refreshed it — hand back the current header either way.
-        current_tokens = context.current_tokens
-        assert current_tokens is not None  # implied by can_refresh_token()
-        return f"{current_tokens.token_type} {current_tokens.access_token}"
-
-    refresh_request = await provider._refresh_token()
-    async with mcp_ssrf_httpx_client_factory(
-        timeout=httpx.Timeout(_REFRESH_POST_TIMEOUT_S)
-    ) as client:
-        response = await client.send(refresh_request)
-
-    if not await provider._handle_refresh_response(response):
-        raise RuntimeError(
-            f"MCP OAuth refresh failed for server '{mcp_server.name}' "
-            f"(config {connection_config_id}): {response.status_code}"
-        )
-
-    logger.info(
-        "Refreshed SSE MCP OAuth token for server '%s' (config %s)",
-        mcp_server.name,
-        connection_config_id,
-    )
-    new_tokens = context.current_tokens
-    assert new_tokens is not None  # set by _handle_refresh_response on success
-    return f"{new_tokens.token_type} {new_tokens.access_token}"
+    return f"{tokens.token_type} {tokens.access_token}"
 
 
 def refresh_mcp_oauth_token_if_expired(
@@ -670,6 +638,49 @@ class OAuthAuthorizationRequired(Exception):
         self.authorization = authorization
 
 
+def _authorization_handoffs(
+    error: BaseException,
+) -> list[OAuthAuthorizationRequired]:
+    if isinstance(error, OAuthAuthorizationRequired):
+        return [error]
+    if isinstance(error, BaseExceptionGroup):
+        return [
+            handoff
+            for nested_error in error.exceptions
+            for handoff in _authorization_handoffs(nested_error)
+        ]
+    return []
+
+
+async def run_with_authorization_handoff(
+    operation: Awaitable[object],
+) -> MCPPendingOAuthAuthorization | None:
+    """Run one SDK operation, returning its resumable browser handoff.
+
+    AnyIO may wrap the control signal in nested exception groups. A group that
+    also contains a real failure is still a failure; only a single, otherwise
+    clean handoff is converted into a normal result.
+    """
+    try:
+        await operation
+    except OAuthAuthorizationRequired as error:
+        return error.authorization
+    except ExceptionGroup as error:
+        matching_errors, unexpected_errors = error.split(OAuthAuthorizationRequired)
+        if unexpected_errors is not None:
+            raise unexpected_errors
+        if matching_errors is None:
+            raise error
+        handoffs = _authorization_handoffs(matching_errors)
+        if len(handoffs) != 1:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "MCP OAuth discovery produced multiple authorization redirects.",
+            )
+        return handoffs[0].authorization
+    return None
+
+
 class OnyxOAuthClientProvider(OAuthClientProvider):
     """MCP SDK provider with an optional resumable browser handoff.
 
@@ -831,6 +842,46 @@ class OnyxOAuthClientProvider(OAuthClientProvider):
         else:
             await storage.set_tokens(tokens)
         return tokens
+
+    async def refresh_access_token_if_expired(self) -> OAuthToken | None:
+        """Drive the SDK refresh step used outside its HTTPX auth generator."""
+        await self._initialize()
+        context = self.context
+        if not context.can_refresh_token():
+            return None
+        if context.is_token_valid():
+            # A racing call may already have persisted a fresh token.
+            current_tokens = context.current_tokens
+            if current_tokens is None:
+                raise RuntimeError(
+                    "MCP OAuth SDK reported a valid token without token data."
+                )
+            return current_tokens
+
+        refresh_request = await self._refresh_token()
+        async with mcp_ssrf_httpx_client_factory(
+            timeout=httpx.Timeout(_REFRESH_POST_TIMEOUT_S)
+        ) as client:
+            response = await client.send(refresh_request)
+        if not await self._handle_refresh_response(response):
+            raise RuntimeError(
+                "MCP OAuth refresh failed for server "
+                f"'{self.refresh_log_context['mcp_server_name']}' "
+                f"(config {self.refresh_log_context['connection_config_id']}): "
+                f"{response.status_code}"
+            )
+
+        logger.info(
+            "Refreshed SSE MCP OAuth token for server '%s' (config %s)",
+            self.refresh_log_context["mcp_server_name"],
+            self.refresh_log_context["connection_config_id"],
+        )
+        refreshed_tokens = context.current_tokens
+        if refreshed_tokens is None:
+            raise RuntimeError(
+                "MCP OAuth SDK reported a successful refresh without token data."
+            )
+        return refreshed_tokens
 
     def _refresh_log_fields(self, **fields: Any) -> dict[str, Any]:
         log_fields: dict[str, Any] = {
@@ -1002,3 +1053,35 @@ def make_oauth_provider(
     if known_metadata is not None:
         provider.context.oauth_metadata = known_metadata
     return provider
+
+
+async def complete_mcp_oauth_authorization(
+    flow: MCPOAuthFlowState,
+    mcp_server: MCPServer,
+    client_information: OAuthClientInformationFull,
+    authorization_code: str,
+) -> None:
+    """Restore one persisted attempt and complete it through the MCP SDK."""
+    provider = make_oauth_provider(
+        mcp_server,
+        flow.connection_config_id,
+        mcp_server.admin_connection_config_id,
+        load_stored_tokens=False,
+        expected_connection_headers_fingerprint=flow.connection_headers_fingerprint,
+        expected_client_information_fingerprint=(flow.client_information_fingerprint),
+    )
+    context = provider.context
+    if flow.server_snapshot.provider_mode is MCPOAuthProviderMode.AUTO_DISCOVERY:
+        context.protected_resource_metadata = flow.protected_resource_metadata
+        context.oauth_metadata = flow.oauth_metadata
+        context.auth_server_url = flow.authorization_server_url
+        context.protocol_version = flow.protocol_version
+    context.client_metadata.scope = flow.scope
+    context.client_metadata.redirect_uris = [flow.redirect_uri]
+    context.client_info = client_information
+
+    await provider.complete_authorization_code_exchange(
+        authorization_code,
+        flow.code_verifier,
+        resource=str(flow.resource) if flow.resource else None,
+    )

--- a/backend/onyx/server/features/mcp/oauth_flow.py
+++ b/backend/onyx/server/features/mcp/oauth_flow.py
@@ -20,7 +20,7 @@ from onyx.auth.oauth_token_manager import (
     build_oauth_authorization_url,
 )
 from onyx.cache.factory import get_cache_backend
-from onyx.db.enums import MCPOAuthProviderMode, MCPTransport
+from onyx.db.enums import MCPTransport
 from onyx.db.models import MCPServer
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -44,9 +44,8 @@ from onyx.server.features.mcp.models import (
 from onyx.server.features.mcp.oauth import (
     OAUTH_HTTP_TIMEOUT_SECONDS,
     MCPClientRegistrationConflict,
-    OAuthAuthorizationRequired,
-    OnyxOAuthClientProvider,
     make_oauth_provider,
+    run_with_authorization_handoff,
 )
 from onyx.server.features.mcp.ssrf import (
     mcp_oauth_challenge_httpx_client_factory,
@@ -179,39 +178,6 @@ def validate_mcp_oauth_flow_configuration(
         )
 
 
-def _restore_mcp_oauth_context(
-    flow: MCPOAuthFlowState,
-    context: OAuthContext,
-    client_information: OAuthClientInformationFull,
-) -> None:
-    """Apply a persisted attempt at the SDK boundary used for completion."""
-    if flow.server_snapshot.provider_mode is MCPOAuthProviderMode.AUTO_DISCOVERY:
-        context.protected_resource_metadata = flow.protected_resource_metadata
-        context.oauth_metadata = flow.oauth_metadata
-        context.auth_server_url = flow.authorization_server_url
-        context.protocol_version = flow.protocol_version
-    context.client_metadata.scope = flow.scope
-    context.client_metadata.redirect_uris = [flow.redirect_uri]
-    context.client_info = client_information
-
-
-def _make_completion_provider(
-    flow: MCPOAuthFlowState,
-    mcp_server: MCPServer,
-    client_information: OAuthClientInformationFull,
-) -> OnyxOAuthClientProvider:
-    provider = make_oauth_provider(
-        mcp_server,
-        flow.connection_config_id,
-        mcp_server.admin_connection_config_id,
-        load_stored_tokens=False,
-        expected_connection_headers_fingerprint=(flow.connection_headers_fingerprint),
-        expected_client_information_fingerprint=(flow.client_information_fingerprint),
-    )
-    _restore_mcp_oauth_context(flow, provider.context, client_information)
-    return provider
-
-
 def mcp_oauth_attempt_store() -> AuthorizationAttemptStore[MCPOAuthFlowState]:
     return AuthorizationAttemptStore(
         get_cache_backend(),
@@ -219,48 +185,6 @@ def mcp_oauth_attempt_store() -> AuthorizationAttemptStore[MCPOAuthFlowState]:
         payload_type=MCPOAuthFlowState,
         ttl_seconds=MCP_OAUTH_FLOW_TTL_SECONDS,
     )
-
-
-def _authorization_handoffs(
-    error: Exception,
-) -> list[OAuthAuthorizationRequired] | None:
-    if isinstance(error, OAuthAuthorizationRequired):
-        return [error]
-    if isinstance(error, ExceptionGroup):
-        handoffs: list[OAuthAuthorizationRequired] = []
-        for nested_error in error.exceptions:
-            nested_handoffs = _authorization_handoffs(nested_error)
-            if nested_handoffs is None:
-                return None
-            handoffs.extend(nested_handoffs)
-        return handoffs
-    return None
-
-
-def _authorization_handoff_from_error(
-    error: Exception,
-) -> OAuthAuthorizationRequired:
-    handoffs = _authorization_handoffs(error)
-    if handoffs is None:
-        raise error
-    if len(handoffs) != 1:
-        raise OnyxError(
-            OnyxErrorCode.INVALID_INPUT,
-            "MCP OAuth discovery produced multiple authorization redirects.",
-        )
-    return handoffs[0]
-
-
-def _authorization_redirect_from_group(
-    error: ExceptionGroup,
-) -> OAuthAuthorizationRedirect:
-    matching_errors, unexpected_errors = error.split(OAuthAuthorizationRequired)
-    if unexpected_errors is not None:
-        raise unexpected_errors
-    assert matching_errors is not None
-    authorization_required = _authorization_handoff_from_error(matching_errors)
-    authorization = authorization_required.authorization
-    return OAuthAuthorizationRedirect(authorization.authorization_url)
 
 
 async def _start_oauth_from_well_known_metadata(
@@ -406,18 +330,18 @@ async def _start_auto_discovery_oauth_flow_once(
     try:
         async with asyncio.timeout(OAUTH_HTTP_TIMEOUT_SECONDS):
             try:
-                await initialize_mcp_client(
-                    mcp_server.server_url,
-                    connection_headers=oauth_connection_headers,
-                    transport=probe_transport,
-                    auth=oauth_provider,
+                authorization = await run_with_authorization_handoff(
+                    initialize_mcp_client(
+                        mcp_server.server_url,
+                        connection_headers=oauth_connection_headers,
+                        transport=probe_transport,
+                        auth=oauth_provider,
+                    )
                 )
-            except OAuthAuthorizationRequired as authorization_required:
-                return OAuthAuthorizationRedirect(
-                    authorization_required.authorization.authorization_url
-                )
-            except ExceptionGroup as error:
-                return _authorization_redirect_from_group(error)
+                if authorization is not None:
+                    return OAuthAuthorizationRedirect(authorization.authorization_url)
+            except (ExceptionGroup, OnyxError):
+                raise
             except Exception as error:
                 if _client_registration_conflict(error) is not None:
                     raise
@@ -434,18 +358,15 @@ async def _start_auto_discovery_oauth_flow_once(
             if use_authenticated_connection or oauth_provider.context.is_token_valid():
                 return OAuthAlreadyAuthenticated()
 
-            try:
-                await _start_oauth_from_well_known_metadata(
+            authorization = await run_with_authorization_handoff(
+                _start_oauth_from_well_known_metadata(
                     oauth_provider,
                     mcp_server.server_url,
                     oauth_connection_headers,
                 )
-            except OAuthAuthorizationRequired as authorization_required:
-                return OAuthAuthorizationRedirect(
-                    authorization_required.authorization.authorization_url
-                )
-            except ExceptionGroup as error:
-                return _authorization_redirect_from_group(error)
+            )
+            if authorization is not None:
+                return OAuthAuthorizationRedirect(authorization.authorization_url)
     except TimeoutError as error:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
@@ -502,17 +423,3 @@ async def start_auto_discovery_oauth_flow(
                 "Concurrent MCP client registration won; retrying OAuth discovery"
             )
     raise AssertionError("OAuth discovery retry loop exhausted")
-
-
-async def complete_mcp_oauth_flow(
-    flow: MCPOAuthFlowState,
-    mcp_server: MCPServer,
-    client_information: OAuthClientInformationFull,
-    authorization_code: str,
-) -> None:
-    provider = _make_completion_provider(flow, mcp_server, client_information)
-    await provider.complete_authorization_code_exchange(
-        authorization_code,
-        flow.code_verifier,
-        resource=str(flow.resource) if flow.resource else None,
-    )

--- a/backend/tests/integration/common_utils/cimd_oauth.py
+++ b/backend/tests/integration/common_utils/cimd_oauth.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from pydantic import BaseModel
 
 
-class CimdHttpsEndpoint(BaseModel):
+class OAuthHttpsEndpoint(BaseModel):
     origin: str
     ca_file: Path
 

--- a/backend/tests/integration/tests/mcp_oauth/conftest.py
+++ b/backend/tests/integration/tests/mcp_oauth/conftest.py
@@ -10,8 +10,10 @@ import sys
 import threading
 import time
 from collections.abc import Generator
+from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from urllib.parse import urlparse
 
 import httpx
 import pytest
@@ -25,8 +27,8 @@ from fastapi.testclient import TestClient
 from onyx.server.features.mcp import api as mcp_api
 from onyx.server.features.mcp import client_metadata
 from tests.integration.common_utils.cimd_oauth import (
-    CimdHttpsEndpoint,
     CimdOAuthTestServices,
+    OAuthHttpsEndpoint,
 )
 
 NGINX_COMMAND = "nginx"
@@ -122,6 +124,7 @@ def _nginx_config(
     certificate_path: Path,
     key_path: Path,
     upstream_port: int,
+    location_prefix: str,
 ) -> str:
     return f"""
 pid {directory / "nginx.pid"};
@@ -134,14 +137,67 @@ http {{
         ssl_certificate {certificate_path};
         ssl_certificate_key {key_path};
 
-        location /api/ {{
-            rewrite ^/api/(.*)$ /$1 break;
-            proxy_pass http://127.0.0.1:{upstream_port};
+        location {location_prefix} {{
+            proxy_pass http://127.0.0.1:{upstream_port}/;
             proxy_set_header Host $host;
         }}
     }}
 }}
 """
+
+
+@contextmanager
+def _https_proxy(
+    *,
+    upstream_port: int,
+    location_prefix: str,
+    directory_name: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Generator[OAuthHttpsEndpoint, None, None]:
+    public_host = "127.0.0.1"
+    https_port = _available_port()
+    directory = tmp_path_factory.mktemp(directory_name)
+    certificate_path, key_path = _write_certificate(directory, public_host)
+    config_path = directory / "nginx.conf"
+    config_path.write_text(
+        _nginx_config(
+            directory,
+            https_port,
+            certificate_path,
+            key_path,
+            upstream_port,
+            location_prefix,
+        ),
+        encoding="utf-8",
+    )
+    log_path = directory / "nginx.log"
+    log_file = log_path.open("wb")
+    try:
+        process = subprocess.Popen(
+            [NGINX_COMMAND, "-c", str(config_path), "-g", "daemon off;"],
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+        )
+    except OSError as error:
+        log_file.close()
+        raise RuntimeError(f"Failed to start Nginx: {error}") from error
+
+    try:
+        try:
+            _wait_for_port(public_host, https_port, process)
+        except (RuntimeError, TimeoutError) as error:
+            log_file.flush()
+            logs = log_path.read_text(encoding="utf-8", errors="replace")
+            raise RuntimeError(
+                f"Nginx failed during startup: {error}\n{logs}"
+            ) from error
+        yield OAuthHttpsEndpoint(
+            origin=f"https://{public_host}:{https_port}",
+            ca_file=certificate_path,
+        )
+    finally:
+        _stop_process(process)
+        log_file.close()
 
 
 @pytest.fixture(scope="session")
@@ -173,76 +229,31 @@ def cimd_api_server(
 def cimd_https_endpoint(
     cimd_api_server: int,
     tmp_path_factory: pytest.TempPathFactory,
-) -> Generator[CimdHttpsEndpoint, None, None]:
-    public_host = "127.0.0.1"
-    https_port = _available_port()
-    directory = tmp_path_factory.mktemp("mcp-cimd-tls")
-    certificate_path, key_path = _write_certificate(directory, public_host)
-    config_path = directory / "nginx.conf"
-    config_path.write_text(
-        _nginx_config(
-            directory,
-            https_port,
-            certificate_path,
-            key_path,
-            cimd_api_server,
-        ),
-        encoding="utf-8",
-    )
-    log_path = directory / "nginx.log"
-    log_file = log_path.open("wb")
-    try:
-        process = subprocess.Popen(
-            [NGINX_COMMAND, "-c", str(config_path), "-g", "daemon off;"],
-            stdout=log_file,
-            stderr=subprocess.STDOUT,
-        )
-    except OSError as error:
-        log_file.close()
-        raise RuntimeError(f"Failed to start Nginx: {error}") from error
-
+) -> Generator[OAuthHttpsEndpoint, None, None]:
     web_domain_patch = pytest.MonkeyPatch()
     try:
-        try:
-            _wait_for_port(public_host, https_port, process)
-        except (RuntimeError, TimeoutError) as error:
-            log_file.flush()
-            logs = log_path.read_text(encoding="utf-8", errors="replace")
-            raise RuntimeError(
-                f"Nginx failed during startup: {error}\n{logs}"
-            ) from error
-        origin = f"https://{public_host}:{https_port}"
-        web_domain_patch.setattr(mcp_api, "WEB_DOMAIN", origin)
-        web_domain_patch.setattr(client_metadata, "WEB_DOMAIN", origin)
-
-        metadata_url = f"{origin}/api/mcp/oauth/client-metadata"
-        deadline = time.monotonic() + STARTUP_TIMEOUT_SECONDS
-        while time.monotonic() < deadline:
-            try:
-                response = httpx.get(
-                    metadata_url,
-                    verify=str(certificate_path),
-                    timeout=1,
-                )
-                if response.status_code == 200:
-                    break
-            except httpx.HTTPError:
-                time.sleep(0.1)
-        else:
-            log_file.flush()
-            logs = log_path.read_text(encoding="utf-8", errors="replace")
-            raise RuntimeError(f"CIMD HTTPS endpoint did not start:\n{logs}")
-
-        yield CimdHttpsEndpoint(origin=origin, ca_file=certificate_path)
+        with _https_proxy(
+            upstream_port=cimd_api_server,
+            location_prefix="/api/",
+            directory_name="mcp-cimd-tls",
+            tmp_path_factory=tmp_path_factory,
+        ) as endpoint:
+            web_domain_patch.setattr(mcp_api, "WEB_DOMAIN", endpoint.origin)
+            web_domain_patch.setattr(client_metadata, "WEB_DOMAIN", endpoint.origin)
+            response = httpx.get(
+                f"{endpoint.origin}/api/mcp/oauth/client-metadata",
+                verify=str(endpoint.ca_file),
+                timeout=10,
+            )
+            response.raise_for_status()
+            yield endpoint
     finally:
         web_domain_patch.undo()
-        _stop_process(process)
-        log_file.close()
 
 
 @pytest.fixture(scope="module")
 def cimd_oauth_services(
-    cimd_https_endpoint: CimdHttpsEndpoint,
+    cimd_https_endpoint: OAuthHttpsEndpoint,
     tmp_path_factory: pytest.TempPathFactory,
 ) -> Generator[CimdOAuthTestServices, None, None]:
     oidc_port = _available_port()
@@ -303,3 +314,32 @@ def cimd_oauth_services(
         _stop_process(oidc_process)
         mcp_log.close()
         oidc_log.close()
+
+
+@pytest.fixture(scope="module")
+def known_provider_https_endpoint(
+    cimd_oauth_services: CimdOAuthTestServices,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Generator[OAuthHttpsEndpoint, None, None]:
+    oidc_port = urlparse(cimd_oauth_services.oidc_issuer).port
+    if oidc_port is None:
+        raise RuntimeError("Mock OIDC issuer has no port")
+
+    ssl_patch = pytest.MonkeyPatch()
+    try:
+        with _https_proxy(
+            upstream_port=oidc_port,
+            location_prefix="/",
+            directory_name="mcp-known-provider-tls",
+            tmp_path_factory=tmp_path_factory,
+        ) as endpoint:
+            ssl_patch.setenv("SSL_CERT_FILE", str(endpoint.ca_file))
+            response = httpx.get(
+                f"{endpoint.origin}/healthz",
+                verify=str(endpoint.ca_file),
+                timeout=10,
+            )
+            response.raise_for_status()
+            yield endpoint
+    finally:
+        ssl_patch.undo()

--- a/backend/tests/integration/tests/mcp_oauth/test_mcp_oauth_cimd_integration.py
+++ b/backend/tests/integration/tests/mcp_oauth/test_mcp_oauth_cimd_integration.py
@@ -1,5 +1,6 @@
-"""Verify CIMD-only OAuth through Onyx API endpoints and a protected MCP server."""
+"""Verify OAuth through Onyx API endpoints and a protected MCP server."""
 
+import ssl
 from urllib.parse import parse_qs, urlparse
 
 import httpx
@@ -13,6 +14,7 @@ from onyx.db.enums import (
 from tests.integration.common_utils.cimd_oauth import (
     CimdOAuthTestServices,
     MockOidcStatus,
+    OAuthHttpsEndpoint,
 )
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
@@ -25,8 +27,69 @@ from tests.integration.common_utils.test_models import (
 )
 
 MCP_SERVER_NAME = "integration-mcp-cimd"
+KNOWN_PROVIDER_SERVER_NAME = "integration-mcp-known-provider"
 RETURN_PATH = "/admin/actions/mcp"
 MCP_TOOL_NAME = "tool_0"
+
+
+def _create_oauth_mcp_server(
+    services: CimdOAuthTestServices,
+    user: DATestUser,
+    *,
+    name: str,
+    provider_mode: MCPOAuthProviderMode,
+    authorization_endpoint: str | None = None,
+    token_endpoint: str | None = None,
+) -> int:
+    request: dict[str, object] = {
+        "name": name,
+        "description": f"{provider_mode.value} OAuth integration server",
+        "server_url": services.mcp_server_url,
+        "transport": MCPTransport.STREAMABLE_HTTP.value,
+        "auth_type": MCPAuthenticationType.OAUTH.value,
+        "auth_performer": MCPAuthenticationPerformer.PER_USER.value,
+        "oauth_provider_mode": provider_mode.value,
+        "is_public": True,
+    }
+    if provider_mode is MCPOAuthProviderMode.KNOWN_PROVIDER:
+        if authorization_endpoint is None or token_endpoint is None:
+            raise ValueError("Known-provider test endpoints are required")
+        request.update(
+            {
+                "oauth_client_id": services.client_metadata_url,
+                "oauth_authorization_endpoint": authorization_endpoint,
+                "oauth_token_endpoint": token_endpoint,
+                "oauth_scopes_override": ["mcp:use"],
+            }
+        )
+
+    response = client.post(
+        f"{API_SERVER_URL}/admin/mcp/servers/create",
+        json=request,
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+    response.raise_for_status()
+    return int(response.json()["server_id"])
+
+
+def _delete_mcp_server(server_id: int, user: DATestUser) -> None:
+    response = client.delete(
+        f"{API_SERVER_URL}/admin/mcp/server/{server_id}",
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+    response.raise_for_status()
+
+
+def _available_tool_names(server_id: int, user: DATestUser) -> set[str]:
+    response = client.get(
+        f"{API_SERVER_URL}/admin/mcp/server/{server_id}/tools",
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+    response.raise_for_status()
+    return {tool["name"] for tool in response.json()["tools"]}
 
 
 def _connect_oauth(
@@ -56,6 +119,8 @@ def _start_oauth_flow(
     services: CimdOAuthTestServices,
     *,
     force_reauthentication: bool,
+    authorization_endpoint: str | None = None,
+    verify: ssl.SSLContext | bool = True,
 ) -> dict[str, list[str]]:
     connect_body = _connect_oauth(
         server_id,
@@ -65,12 +130,14 @@ def _start_oauth_flow(
     assert connect_body["status"] == "authorization_required"
     assert connect_body["redirect_url"] == RETURN_PATH
     oauth_url = str(connect_body["authorization_url"])
-    assert oauth_url.startswith(f"{services.oidc_issuer}/authorize?")
+    expected_endpoint = authorization_endpoint or f"{services.oidc_issuer}/authorize"
+    assert oauth_url.startswith(f"{expected_endpoint}?")
 
     authorization_response = httpx.get(
         oauth_url,
         follow_redirects=False,
         timeout=10,
+        verify=verify,
     )
     assert authorization_response.status_code == 302
     callback_url = authorization_response.headers["location"]
@@ -131,23 +198,12 @@ def test_mcp_oauth_cimd_only_flow(
     assert discovery_response.json()["client_id_metadata_document_supported"] is True
     assert "registration_endpoint" not in discovery_response.json()
 
-    create_response = client.post(
-        f"{API_SERVER_URL}/admin/mcp/servers/create",
-        json={
-            "name": MCP_SERVER_NAME,
-            "description": "CIMD-only OAuth integration server",
-            "server_url": cimd_oauth_services.mcp_server_url,
-            "transport": MCPTransport.STREAMABLE_HTTP.value,
-            "auth_type": MCPAuthenticationType.OAUTH.value,
-            "auth_performer": MCPAuthenticationPerformer.PER_USER.value,
-            "oauth_provider_mode": MCPOAuthProviderMode.AUTO_DISCOVERY.value,
-            "is_public": True,
-        },
-        headers=admin_user.headers,
-        cookies=admin_user.cookies,
+    server_id = _create_oauth_mcp_server(
+        cimd_oauth_services,
+        admin_user,
+        name=MCP_SERVER_NAME,
+        provider_mode=MCPOAuthProviderMode.AUTO_DISCOVERY,
     )
-    create_response.raise_for_status()
-    server_id = int(create_response.json()["server_id"])
     persona: DATestPersona | None = None
 
     try:
@@ -190,14 +246,7 @@ def test_mcp_oauth_cimd_only_flow(
         assert authenticated_connect["authorization_url"] is None
         assert authenticated_connect["redirect_url"] == RETURN_PATH
 
-        tools_response = client.get(
-            f"{API_SERVER_URL}/admin/mcp/server/{server_id}/tools",
-            headers=admin_user.headers,
-            cookies=admin_user.cookies,
-        )
-        tools_response.raise_for_status()
-        tool_names = {tool["name"] for tool in tools_response.json()["tools"]}
-        assert MCP_TOOL_NAME in tool_names
+        assert MCP_TOOL_NAME in _available_tool_names(server_id, admin_user)
 
         db_tools_response = client.get(
             f"{API_SERVER_URL}/admin/mcp/server/{server_id}/db-tools",
@@ -255,9 +304,48 @@ def test_mcp_oauth_cimd_only_flow(
     finally:
         if persona is not None:
             assert PersonaManager.delete(persona, admin_user)
-        delete_response = client.delete(
-            f"{API_SERVER_URL}/admin/mcp/server/{server_id}",
-            headers=admin_user.headers,
-            cookies=admin_user.cookies,
+        _delete_mcp_server(server_id, admin_user)
+
+
+def test_mcp_oauth_known_provider_flow(
+    cimd_oauth_services: CimdOAuthTestServices,
+    known_provider_https_endpoint: OAuthHttpsEndpoint,
+    admin_user: DATestUser,
+) -> None:
+    authorization_endpoint = f"{known_provider_https_endpoint.origin}/authorize"
+    token_endpoint = f"{known_provider_https_endpoint.origin}/token"
+    server_id = _create_oauth_mcp_server(
+        cimd_oauth_services,
+        admin_user,
+        name=KNOWN_PROVIDER_SERVER_NAME,
+        provider_mode=MCPOAuthProviderMode.KNOWN_PROVIDER,
+        authorization_endpoint=authorization_endpoint,
+        token_endpoint=token_endpoint,
+    )
+
+    try:
+        callback = _start_oauth_flow(
+            server_id,
+            admin_user,
+            cimd_oauth_services,
+            force_reauthentication=False,
+            authorization_endpoint=authorization_endpoint,
+            verify=ssl.create_default_context(
+                cafile=str(known_provider_https_endpoint.ca_file)
+            ),
         )
-        delete_response.raise_for_status()
+        _complete_oauth_callback(callback, admin_user)
+
+        authenticated_connect = _connect_oauth(
+            server_id,
+            admin_user,
+            force_reauthentication=False,
+        )
+        assert authenticated_connect == {
+            "status": "already_authenticated",
+            "authorization_url": None,
+            "redirect_url": RETURN_PATH,
+        }
+        assert MCP_TOOL_NAME in _available_tool_names(server_id, admin_user)
+    finally:
+        _delete_mcp_server(server_id, admin_user)

--- a/backend/tests/integration/tests/mcp_oauth/test_mcp_oauth_cimd_integration.py
+++ b/backend/tests/integration/tests/mcp_oauth/test_mcp_oauth_cimd_integration.py
@@ -324,15 +324,16 @@ def test_mcp_oauth_known_provider_flow(
     )
 
     try:
+        tls_context = ssl.create_default_context(
+            cafile=str(known_provider_https_endpoint.ca_file)
+        )
         callback = _start_oauth_flow(
             server_id,
             admin_user,
             cimd_oauth_services,
             force_reauthentication=False,
             authorization_endpoint=authorization_endpoint,
-            verify=ssl.create_default_context(
-                cafile=str(known_provider_https_endpoint.ca_file)
-            ),
+            verify=tls_context,
         )
         _complete_oauth_callback(callback, admin_user)
 
@@ -342,10 +343,22 @@ def test_mcp_oauth_known_provider_flow(
             force_reauthentication=False,
         )
         assert authenticated_connect == {
+            "server_id": server_id,
             "status": "already_authenticated",
             "authorization_url": None,
             "redirect_url": RETURN_PATH,
         }
+
+        reauthentication_callback = _start_oauth_flow(
+            server_id,
+            admin_user,
+            cimd_oauth_services,
+            force_reauthentication=True,
+            authorization_endpoint=authorization_endpoint,
+            verify=tls_context,
+        )
+        _complete_oauth_callback(reauthentication_callback, admin_user)
+
         assert MCP_TOOL_NAME in _available_tool_names(server_id, admin_user)
     finally:
         _delete_mcp_server(server_id, admin_user)

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_known_provider_flow.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_known_provider_flow.py
@@ -198,7 +198,7 @@ def test_completion_uses_configured_provider_context_and_sdk_exchange(
     )
 
     asyncio.run(
-        oauth_flow.complete_mcp_oauth_flow(
+        oauth.complete_mcp_oauth_authorization(
             flow,
             _server(),
             _client_information(),

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_callback.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_callback.py
@@ -162,7 +162,7 @@ def test_auto_discovery_callback_dispatches_claimed_flow(
         monkeypatch, server, flow
     )
     complete_flow = AsyncMock()
-    monkeypatch.setattr(api, "complete_mcp_oauth_flow", complete_flow)
+    monkeypatch.setattr(api, "complete_mcp_oauth_authorization", complete_flow)
     response = asyncio.run(
         api.process_oauth_callback(
             _request(state=_STATE, code="authorization-code"),
@@ -191,7 +191,7 @@ def test_callback_rejects_server_configuration_changed_after_authorization(
     server.server_url = "https://replacement.example.com/mcp"
     user, db_session, _, _ = _install_callback_dependencies(monkeypatch, server, flow)
     complete_flow = AsyncMock()
-    monkeypatch.setattr(api, "complete_mcp_oauth_flow", complete_flow)
+    monkeypatch.setattr(api, "complete_mcp_oauth_authorization", complete_flow)
 
     with pytest.raises(OnyxError, match="server configuration changed"):
         asyncio.run(
@@ -235,7 +235,7 @@ def test_callback_rechecks_server_authorization_before_exchanging_code(
     monkeypatch.setattr(api, "user_can_access_mcp_server", lambda *_args: False)
     monkeypatch.setattr(api, "can_manage_mcp_server", lambda *_args: False)
     complete_flow = AsyncMock()
-    monkeypatch.setattr(api, "complete_mcp_oauth_flow", complete_flow)
+    monkeypatch.setattr(api, "complete_mcp_oauth_authorization", complete_flow)
 
     with pytest.raises(OnyxError) as exc_info:
         asyncio.run(
@@ -261,7 +261,7 @@ def test_callback_allows_server_manager_without_server_access(
     monkeypatch.setattr(api, "user_can_access_mcp_server", lambda *_args: False)
     monkeypatch.setattr(api, "can_manage_mcp_server", lambda *_args: True)
     complete_flow = AsyncMock()
-    monkeypatch.setattr(api, "complete_mcp_oauth_flow", complete_flow)
+    monkeypatch.setattr(api, "complete_mcp_oauth_authorization", complete_flow)
 
     asyncio.run(
         api.process_oauth_callback(
@@ -310,7 +310,7 @@ def test_provider_denial_claims_flow_without_exchanging_code(
     flow = _flow(server)
     user, db_session, _, _ = _install_callback_dependencies(monkeypatch, server, flow)
     complete_flow = AsyncMock()
-    monkeypatch.setattr(api, "complete_mcp_oauth_flow", complete_flow)
+    monkeypatch.setattr(api, "complete_mcp_oauth_authorization", complete_flow)
 
     with pytest.raises(OnyxError, match="denied or failed"):
         asyncio.run(
@@ -348,7 +348,7 @@ def test_callback_rejects_a_stale_client_registration(
         ),
     )
     complete_flow = AsyncMock()
-    monkeypatch.setattr(api, "complete_mcp_oauth_flow", complete_flow)
+    monkeypatch.setattr(api, "complete_mcp_oauth_authorization", complete_flow)
 
     with pytest.raises(OnyxError, match="client registration changed"):
         asyncio.run(

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_flow.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_flow.py
@@ -546,12 +546,12 @@ def test_reverse_order_completions_restore_their_own_registration(
         exchanges.append(exchange)
         return provider
 
-    monkeypatch.setattr(oauth_flow, "make_oauth_provider", make_provider)
+    monkeypatch.setattr(oauth, "make_oauth_provider", make_provider)
     first_flow = _flow("first-state", client_id="first-registration")
     second_flow = _flow("second-state", client_id="second-registration")
 
     asyncio.run(
-        oauth_flow.complete_mcp_oauth_flow(
+        oauth.complete_mcp_oauth_authorization(
             second_flow,
             cast(MCPServer, _server()),
             _client_information("second-registration"),
@@ -559,7 +559,7 @@ def test_reverse_order_completions_restore_their_own_registration(
         )
     )
     asyncio.run(
-        oauth_flow.complete_mcp_oauth_flow(
+        oauth.complete_mcp_oauth_authorization(
             first_flow,
             cast(MCPServer, _server()),
             _client_information("first-registration"),


### PR DESCRIPTION
## Description

### Why this is needed

PR #14123 makes MCP OAuth resumable, but the remaining implementation still spreads MCP SDK details across both the OAuth adapter and the higher-level flow coordinator. Authorization handoff exceptions are decoded in multiple places, callback completion rebuilds SDK state outside the adapter, and runtime refresh calls private SDK methods from general application code.

This makes the flow harder to understand and increases the number of places that may need to change when the MCP SDK changes.

### What changed

This PR makes oauth.py the boundary for MCP SDK behavior while leaving oauth_flow.py responsible for Onyx orchestration.

- Authorization handoffs, including nested exception groups, are converted into one explicit result through a shared path. Real failures are still propagated instead of being hidden as redirects.
- Known-provider and auto-discovery callbacks now use one completion function that restores the saved SDK context and performs the authorization-code exchange.
- Private SDK refresh methods are called only inside the Onyx SDK provider. The surrounding refresh code asks the provider for a usable token without depending on SDK internals.
- The redundant callback wrapper and duplicated exception-unwrapping helpers are removed.

### Why this design

The MCP SDK should continue to own MCP discovery, token requests, and protocol behavior. Onyx only needs a narrow adapter that can pause SDK authorization for a browser redirect and resume it during the callback. Keeping those details together makes the higher-level flow easier to follow and limits the impact of future SDK changes.

This is an organizational refactor. It does not change OAuth state storage, callback validation, token persistence, timeout behavior, or refresh policy. The existing two-file layout remains because the responsibilities are now clear without a larger package split.

This is PR 3 in the stack and is based on PR #14123.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes all MCP OAuth SDK interaction in `oauth.py` to reduce coupling and keep orchestration in `oauth_flow.py`. Old behavior spread refresh, handoff decoding, and completion across modules and used private SDK calls; new behavior consolidates these behind the SDK boundary without changing runtime semantics.

- Highlights
  - `refresh_mcp_oauth_token_if_expired(...)` now uses `OnyxOAuthClientProvider.refresh_access_token_if_expired()` under the existing single-flight lock; no app-level private SDK calls remain.
  - `run_with_authorization_handoff(...)` in `oauth.py` unwraps exactly one resumable handoff from nested exception groups; `oauth_flow.py` uses it for probe and auto-discovery.
  - Callback completion goes through `oauth.complete_mcp_oauth_authorization(...)`; `api.py` calls this for known-provider and discovery flows.
  - Test infra adds a reusable HTTPS reverse proxy and renames `CimdHttpsEndpoint` to `OAuthHttpsEndpoint`; integration tests add known-provider OAuth over TLS, cover reauthentication, and verify tools are available post-auth.

- Migration
  - Replace `oauth_flow.complete_mcp_oauth_flow(...)` with `oauth.complete_mcp_oauth_authorization(...)`.
  - Use `oauth.run_with_authorization_handoff(...)` instead of manual exception decoding when starting flows.

<sup>Written for commit e50ade5ff801cf6eef2aa23b3b8dd7a9ed1e56f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

