### PR TITLE
perf(migrations): restore a schema snapshot instead of replaying every revision

### DIFF
--- a/.github/workflows/pr-external-dependency-unit-tests.yml
+++ b/.github/workflows/pr-external-dependency-unit-tests.yml
@@ -161,11 +161,23 @@ jobs:
             opensearch \
             code-interpreter
 
+      # A hit skips the ~440-revision replay. The key covers every revision file, so
+      # a changed migration misses and the restore-key falls back to an older
+      # snapshot, which is then topped up by replaying only the new revisions.
+      - name: Restore migration snapshot cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # zizmor: ignore[cache-poisoning]
+        with:
+          path: backend/.migration_snapshots
+          key: migration-snapshot-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('backend/alembic/versions/**') }}
+          restore-keys: |
+            migration-snapshot-${{ runner.os }}-${{ runner.arch }}-
+
       - name: Run migrations
         run: |
           cd backend
-          # Run migrations to head
-          alembic upgrade head
+          # Restores a snapshot when one applies, otherwise runs the full chain.
+          # Either way the database ends at head. See onyx/db/migration_snapshot.py.
+          uv run python -m scripts.alembic_snapshot apply
           alembic heads --verbose
 
       # A real OIDC server for the live multi-provider login test. Auth leg only.

--- a/.github/workflows/pr-external-dependency-unit-tests.yml
+++ b/.github/workflows/pr-external-dependency-unit-tests.yml
@@ -176,9 +176,13 @@ jobs:
         run: |
           cd backend
           # Restores a snapshot when one applies, otherwise runs the full chain.
-          # Either way the database ends at head. See onyx/db/migration_snapshot.py.
-          uv run python -m scripts.alembic_snapshot apply
-          alembic heads --verbose
+          # Either way the database ends at head, and the script fails if it does
+          # not. See onyx/db/migration_snapshot.py.
+          #
+          # Plain `python`, not `uv run`: the dependencies are already installed by
+          # the setup step, and `uv run` would build a second virtualenv from
+          # scratch (438 packages, including a ~100MB torch download).
+          python -m scripts.alembic_snapshot apply
 
       # A real OIDC server for the live multi-provider login test. Auth leg only.
       # Fail if it never becomes ready, otherwise the live tests would silently skip.

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 
 # python
 .venv
+.migration_snapshots
 .mypy_cache
 .idea
 __pycache__/

--- a/backend/onyx/db/migration_snapshot.py
+++ b/backend/onyx/db/migration_snapshot.py
@@ -166,7 +166,7 @@ def server_major_version(database: str) -> int:
         return int(row[0]) // 10000
 
 
-def _head_revision() -> str:
+def head_revision() -> str:
     script = ScriptDirectory(str(_BACKEND_DIR / "alembic"))
     head = script.get_current_head()
     if head is None:
@@ -185,7 +185,7 @@ def _is_ancestor_of_head(revision: str) -> bool:
     try:
         return any(
             rev.revision == revision
-            for rev in script.iterate_revisions(_head_revision(), "base")
+            for rev in script.iterate_revisions(head_revision(), "base")
         )
     except Exception:
         # Unknown revision - alembic raises rather than returning empty.
@@ -400,7 +400,7 @@ def build_schema(
             dump_database(database),
             SnapshotMetadata(
                 key=key,
-                head_revision=_head_revision(),
+                head_revision=head_revision(),
                 server_major=server_major,
                 format_version=_SNAPSHOT_FORMAT_VERSION,
                 files=files,

--- a/backend/onyx/db/migration_snapshot.py
+++ b/backend/onyx/db/migration_snapshot.py
@@ -289,6 +289,29 @@ def _load_metadata(directory: Path) -> list[SnapshotMetadata]:
     return found
 
 
+def _expected_head(directory: Path, key: str) -> str:
+    """Head revision recorded alongside snapshot `key`.
+
+    Falls back to reading the revision files when the sidecar is missing, which is
+    slow (it parses every revision) but always correct.
+    """
+    path = directory / f"{key}.json"
+    try:
+        return SnapshotMetadata.from_json(path.read_text()).head_revision
+    except (OSError, json.JSONDecodeError, KeyError):
+        return head_revision()
+
+
+def _assert_stamped(database: str, expected: str) -> None:
+    with _cursor(database) as cur:
+        cur.execute("SELECT version_num FROM public.alembic_version ORDER BY 1")
+        stamped = [row[0] for row in cur.fetchall()]
+    if stamped != [expected]:
+        raise RuntimeError(
+            f"Snapshot restored {database} to {stamped}, expected [{expected}]."
+        )
+
+
 def _find_reusable_snapshot(
     directory: Path, files: dict[str, str], server_major: int
 ) -> SnapshotMetadata | None:
@@ -364,6 +387,12 @@ def build_schema(
         exact = directory / f"{key}.sql"
         if exact.is_file():
             restore_dump(database, exact.read_text(), schema=schema)
+            # The restore is the one path that never runs Alembic, so confirm it
+            # landed on the revision the snapshot claims. The recorded head is
+            # trustworthy here: an exact key match means the revision files are
+            # byte-for-byte what they were when the snapshot was taken. A mismatch
+            # raises, which falls back to the full chain below.
+            _assert_stamped(database, _expected_head(directory, key))
             logger.info(
                 "Restored migration snapshot %s (%s revisions)", key, len(files)
             )

--- a/backend/onyx/db/migration_snapshot.py
+++ b/backend/onyx/db/migration_snapshot.py
@@ -1,0 +1,414 @@
+"""Snapshot the result of the Alembic chain so dev and CI do not replay every revision.
+
+The chain has grown past 400 revisions and a run from base takes tens of seconds. Tests
+rebuild the schema on every `reset` fixture, so the cost is paid many times per job.
+
+A snapshot is a `pg_dump` of a database that the real migrations built. It is never
+hand-written and never committed. The cache key is a hash of `alembic/versions`, so a
+snapshot only applies to the exact revision set that produced it. Change any migration
+file and the key changes.
+
+Three outcomes, in order of preference:
+
+1. `SNAPSHOT` - the key matches. Restore the dump. No migration runs.
+2. `SNAPSHOT_DELTA` - an older snapshot holds a strict prefix of the current revision
+   set. Restore it, then run only the revisions added since. New migrations still get
+   exercised, which is the point: a snapshot must never hide a broken migration.
+3. `FULL_CHAIN` - nothing usable. Run every revision, exactly as production does.
+
+Every outcome ends with the same schema. `scripts/alembic_snapshot.py verify` proves it
+by building a database both ways and comparing the catalog and every row.
+
+Production never calls this. It runs `alembic upgrade head` unchanged.
+"""
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+import psycopg2
+import psycopg2.extensions
+from alembic.script import ScriptDirectory
+
+from onyx.configs.app_configs import (
+    POSTGRES_HOST,
+    POSTGRES_PASSWORD,
+    POSTGRES_PORT,
+    POSTGRES_USER,
+)
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Opt out and every caller falls back to the full chain.
+DISABLE_ENV_VAR = "ONYX_DISABLE_MIGRATION_SNAPSHOT"
+
+# Where snapshots live. CI points this at a restored cache directory.
+SNAPSHOT_DIR_ENV_VAR = "ONYX_MIGRATION_SNAPSHOT_DIR"
+
+_BACKEND_DIR = Path(__file__).resolve().parents[2]
+_DEFAULT_SNAPSHOT_DIR = _BACKEND_DIR / ".migration_snapshots"
+_VERSIONS_DIR = _BACKEND_DIR / "alembic" / "versions"
+
+# Bump when the dump or restore procedure changes so old snapshots are ignored.
+_SNAPSHOT_FORMAT_VERSION = 1
+
+
+class SnapshotOutcome(str, Enum):
+    SNAPSHOT = "snapshot"
+    SNAPSHOT_DELTA = "snapshot+delta"
+    FULL_CHAIN = "full_chain"
+
+
+@dataclass(frozen=True)
+class SnapshotMetadata:
+    """What a stored snapshot contains, so we can tell if it still applies."""
+
+    key: str
+    head_revision: str
+    server_major: int
+    format_version: int
+    # revision file name -> sha256 of its contents
+    files: dict[str, str]
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "key": self.key,
+                "head_revision": self.head_revision,
+                "server_major": self.server_major,
+                "format_version": self.format_version,
+                "files": self.files,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+
+    @staticmethod
+    def from_json(raw: str) -> "SnapshotMetadata":
+        data = json.loads(raw)
+        return SnapshotMetadata(
+            key=data["key"],
+            head_revision=data["head_revision"],
+            server_major=data["server_major"],
+            format_version=data["format_version"],
+            files=data["files"],
+        )
+
+
+def snapshot_dir() -> Path:
+    configured = os.environ.get(SNAPSHOT_DIR_ENV_VAR, "").strip()
+    return Path(configured) if configured else _DEFAULT_SNAPSHOT_DIR
+
+
+def is_enabled() -> bool:
+    return os.environ.get(DISABLE_ENV_VAR, "").lower() not in ("1", "true", "yes")
+
+
+def revision_file_hashes() -> dict[str, str]:
+    """sha256 of every revision file, keyed by file name."""
+    hashes: dict[str, str] = {}
+    for path in sorted(_VERSIONS_DIR.glob("*.py")):
+        hashes[path.name] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return hashes
+
+
+def _cache_key(files: dict[str, str], server_major: int) -> str:
+    """Identity of a revision set on a given server major.
+
+    A dump is only valid for the server major that produced it, so the major is part
+    of the key rather than a separate check.
+    """
+    digest = hashlib.sha256()
+    digest.update(f"v{_SNAPSHOT_FORMAT_VERSION}|pg{server_major}|".encode())
+    for name in sorted(files):
+        digest.update(f"{name}:{files[name]}|".encode())
+    return digest.hexdigest()[:32]
+
+
+@contextmanager
+def _cursor(database: str) -> Iterator["psycopg2.extensions.cursor"]:
+    """An autocommit cursor.
+
+    Deliberately avoids `with connection`, which opens a transaction even when
+    autocommit is set and so blocks statements like CREATE DATABASE.
+    """
+    conn = psycopg2.connect(
+        dbname=database,
+        user=POSTGRES_USER,
+        password=POSTGRES_PASSWORD,
+        host=POSTGRES_HOST,
+        port=POSTGRES_PORT,
+        application_name="migration_snapshot",
+    )
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            yield cur
+    finally:
+        conn.close()
+
+
+def server_major_version(database: str) -> int:
+    with _cursor(database) as cur:
+        cur.execute("SHOW server_version_num")
+        row = cur.fetchone()
+        assert row is not None
+        return int(row[0]) // 10000
+
+
+def _head_revision() -> str:
+    script = ScriptDirectory(str(_BACKEND_DIR / "alembic"))
+    head = script.get_current_head()
+    if head is None:
+        raise RuntimeError("Alembic reports no head revision.")
+    return head
+
+
+def _is_ancestor_of_head(revision: str) -> bool:
+    """True when `revision` is on the path from base to the current head.
+
+    Guards the delta path. A snapshot taken on a branch whose revisions are gone after
+    a checkout must not be restored: `alembic upgrade head` would fail on an
+    alembic_version row it cannot resolve.
+    """
+    script = ScriptDirectory(str(_BACKEND_DIR / "alembic"))
+    try:
+        return any(
+            rev.revision == revision
+            for rev in script.iterate_revisions(_head_revision(), "base")
+        )
+    except Exception:
+        # Unknown revision - alembic raises rather than returning empty.
+        return False
+
+
+# pg_dump writes a preamble of GUCs that a newer client may emit and an older server
+# may reject (`transaction_timeout` from a 17+ client against a 15 server), plus psql
+# meta-commands (`\restrict`) that are not SQL. Both are stripped so the dump can be
+# replayed over a plain database connection with no psql binary involved.
+#
+# Only the preamble is filtered. A `SET` inside a function body is indented and appears
+# after the first object, so it is never touched.
+_PREAMBLE_NOISE = re.compile(r"^(SET |SELECT pg_catalog\.set_config)")
+_FIRST_OBJECT = ("CREATE ", "ALTER ", "COPY ", "COMMENT ", "INSERT ")
+
+
+def _to_portable_sql(dump: str) -> str:
+    lines: list[str] = []
+    in_preamble = True
+    for line in dump.splitlines():
+        if line.startswith("\\"):
+            continue
+        if in_preamble:
+            if _PREAMBLE_NOISE.match(line):
+                continue
+            if line.startswith(_FIRST_OBJECT):
+                in_preamble = False
+        lines.append(line)
+    return "\n".join(lines) + "\n"
+
+
+def dump_database(database: str) -> str:
+    """Portable SQL that recreates `database`.
+
+    Dumps the whole database rather than a single schema. `--schema=public` omits
+    `CREATE EXTENSION`, which restores without error and then fails at runtime on the
+    first `gen_random_uuid()` default - a silent corruption we must not ship.
+
+    `--inserts` keeps the output free of `COPY ... FROM stdin`, which is a psql
+    protocol feature rather than SQL. The seeded data is small enough that the size
+    cost does not matter.
+    """
+    pg_dump = shutil.which("pg_dump")
+    if pg_dump is None:
+        raise FileNotFoundError("pg_dump is not on PATH")
+
+    result = subprocess.run(
+        [
+            pg_dump,
+            "--host",
+            POSTGRES_HOST,
+            "--port",
+            str(POSTGRES_PORT),
+            "--username",
+            POSTGRES_USER,
+            "--dbname",
+            database,
+            "--no-owner",
+            "--no-privileges",
+            "--inserts",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PGPASSWORD": POSTGRES_PASSWORD},
+    )
+    return _to_portable_sql(result.stdout)
+
+
+def restore_dump(database: str, sql: str, schema: str = "public") -> None:
+    """Replay a dump into an empty schema.
+
+    The caller drops the schema first (reset.py already does). We recreate it here
+    because a whole-database dump assumes `public` exists.
+    """
+    with _cursor(database) as cur:
+        cur.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        cur.execute(f'CREATE SCHEMA "{schema}"')
+        cur.execute(f'GRANT ALL ON SCHEMA "{schema}" TO {POSTGRES_USER}')
+        cur.execute(f'GRANT ALL ON SCHEMA "{schema}" TO public')
+        cur.execute(f'SET search_path TO "{schema}"')
+        cur.execute(sql)
+
+
+def _load_metadata(directory: Path) -> list[SnapshotMetadata]:
+    found: list[SnapshotMetadata] = []
+    if not directory.is_dir():
+        return found
+    for path in sorted(directory.glob("*.json")):
+        try:
+            metadata = SnapshotMetadata.from_json(path.read_text())
+        except (OSError, json.JSONDecodeError, KeyError):
+            logger.warning("Ignoring unreadable snapshot metadata: %s", path)
+            continue
+        if metadata.format_version != _SNAPSHOT_FORMAT_VERSION:
+            continue
+        if not (directory / f"{metadata.key}.sql").is_file():
+            continue
+        found.append(metadata)
+    return found
+
+
+def _find_reusable_snapshot(
+    directory: Path, files: dict[str, str], server_major: int
+) -> SnapshotMetadata | None:
+    """Newest snapshot holding a strict prefix of the current revision set.
+
+    "Prefix" means every revision file it recorded is still present with identical
+    contents. That rules out reusing a snapshot from a branch that edited a migration
+    in place, where replaying only the newer revisions would leave a different schema.
+    """
+    candidates: list[SnapshotMetadata] = []
+    for metadata in _load_metadata(directory):
+        if metadata.server_major != server_major:
+            continue
+        if any(files.get(name) != digest for name, digest in metadata.files.items()):
+            continue
+        if not _is_ancestor_of_head(metadata.head_revision):
+            continue
+        candidates.append(metadata)
+
+    if not candidates:
+        return None
+    # More recorded files means fewer revisions left to replay.
+    return max(candidates, key=lambda m: len(m.files))
+
+
+def _store_snapshot(
+    directory: Path, key: str, sql: str, metadata: SnapshotMetadata
+) -> None:
+    """Write a snapshot so concurrent test workers never observe a partial file."""
+    directory.mkdir(parents=True, exist_ok=True)
+    for suffix, payload in ((".sql", sql), (".json", metadata.to_json())):
+        handle, temp_path = tempfile.mkstemp(dir=directory, suffix=suffix)
+        try:
+            with os.fdopen(handle, "w") as file:
+                file.write(payload)
+            os.replace(temp_path, directory / f"{key}{suffix}")
+        except BaseException:
+            Path(temp_path).unlink(missing_ok=True)
+            raise
+
+
+def _empty_schema(database: str, schema: str) -> None:
+    with _cursor(database) as cur:
+        cur.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        cur.execute(f'CREATE SCHEMA "{schema}"')
+        cur.execute(f'GRANT ALL ON SCHEMA "{schema}" TO {POSTGRES_USER}')
+        cur.execute(f'GRANT ALL ON SCHEMA "{schema}" TO public')
+
+
+def build_schema(
+    database: str,
+    migrate_to_head: Callable[[], None],
+    schema: str = "public",
+) -> SnapshotOutcome:
+    """Bring `database` to head, reusing a snapshot when one applies.
+
+    `migrate_to_head` must run `alembic upgrade head` against `database`. It is passed
+    in so this module stays independent of how each caller configures Alembic.
+
+    Any failure in the snapshot path falls back to the full chain. A snapshot is an
+    optimisation; it must never be the reason a test cannot run.
+    """
+    if not is_enabled():
+        migrate_to_head()
+        return SnapshotOutcome.FULL_CHAIN
+
+    try:
+        directory = snapshot_dir()
+        files = revision_file_hashes()
+        server_major = server_major_version(database)
+        key = _cache_key(files, server_major)
+
+        exact = directory / f"{key}.sql"
+        if exact.is_file():
+            restore_dump(database, exact.read_text(), schema=schema)
+            logger.info(
+                "Restored migration snapshot %s (%s revisions)", key, len(files)
+            )
+            return SnapshotOutcome.SNAPSHOT
+
+        reusable = _find_reusable_snapshot(directory, files, server_major)
+        outcome = SnapshotOutcome.FULL_CHAIN
+        if reusable is not None:
+            pending = len(files) - len(reusable.files)
+            logger.info(
+                "Restoring snapshot %s, then replaying %s new revision(s)",
+                reusable.key,
+                pending,
+            )
+            restore_dump(
+                database, (directory / f"{reusable.key}.sql").read_text(), schema=schema
+            )
+            outcome = SnapshotOutcome.SNAPSHOT_DELTA
+        else:
+            _empty_schema(database, schema)
+
+    except Exception:
+        logger.exception("Migration snapshot unusable; running the full chain.")
+        _empty_schema(database, schema)
+        migrate_to_head()
+        return SnapshotOutcome.FULL_CHAIN
+
+    migrate_to_head()
+
+    try:
+        _store_snapshot(
+            directory,
+            key,
+            dump_database(database),
+            SnapshotMetadata(
+                key=key,
+                head_revision=_head_revision(),
+                server_major=server_major,
+                format_version=_SNAPSHOT_FORMAT_VERSION,
+                files=files,
+            ),
+        )
+        logger.info("Stored migration snapshot %s", key)
+    except Exception:
+        # The database is already at head. Only the cache write failed.
+        logger.exception("Could not store migration snapshot; continuing.")
+
+    return outcome

--- a/backend/scripts/alembic_snapshot.py
+++ b/backend/scripts/alembic_snapshot.py
@@ -12,8 +12,12 @@ snapshot reaches the same schema as running every revision.
 import argparse
 import os
 import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
 from types import SimpleNamespace
 
+import psycopg2
+import psycopg2.extensions
 from alembic import command
 from alembic.config import Config
 
@@ -25,7 +29,25 @@ from onyx.configs.app_configs import (
 )
 from onyx.db.engine.shard_registry import ALEMBIC_TARGET_URL_ATTRIBUTE
 from onyx.db.engine.sql_engine import build_connection_string
-from onyx.db.migration_snapshot import build_schema, snapshot_dir
+from onyx.db.migration_snapshot import build_schema, head_revision, snapshot_dir
+
+
+@contextmanager
+def _cursor(database: str) -> Iterator["psycopg2.extensions.cursor"]:
+    conn = psycopg2.connect(
+        dbname=database,
+        user=POSTGRES_USER,
+        password=POSTGRES_PASSWORD,
+        host=POSTGRES_HOST,
+        port=POSTGRES_PORT,
+        application_name="alembic_snapshot",
+    )
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            yield cur
+    finally:
+        conn.close()
 
 
 def _alembic_config(database: str) -> Config:
@@ -49,12 +71,27 @@ def _upgrade(database: str, revision: str = "head") -> None:
     command.upgrade(_alembic_config(database), revision)
 
 
+def _applied_revisions(database: str) -> list[str]:
+    with _cursor(database) as cur:
+        cur.execute("SELECT version_num FROM public.alembic_version ORDER BY 1")
+        return [row[0] for row in cur.fetchall()]
+
+
 def cmd_apply(args: argparse.Namespace) -> int:
     database = args.database or os.environ.get("POSTGRES_DB") or "postgres"
     outcome = build_schema(
         database=database, migrate_to_head=lambda: _upgrade(database)
     )
-    print(f"{database} is at head via {outcome.value}")
+
+    # Report the stamped revision here rather than shelling out to `alembic heads`,
+    # which would pay the multi-second `onyx` import a second time. Mismatch means
+    # the database is not where the caller asked it to be, so fail loudly.
+    head = head_revision()
+    applied = _applied_revisions(database)
+    print(f"{database} via {outcome.value}: applied={applied} head={head}")
+    if applied != [head]:
+        print("ERROR: database is not at head", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/backend/scripts/alembic_snapshot.py
+++ b/backend/scripts/alembic_snapshot.py
@@ -29,7 +29,7 @@ from onyx.configs.app_configs import (
 )
 from onyx.db.engine.shard_registry import ALEMBIC_TARGET_URL_ATTRIBUTE
 from onyx.db.engine.sql_engine import build_connection_string
-from onyx.db.migration_snapshot import build_schema, head_revision, snapshot_dir
+from onyx.db.migration_snapshot import build_schema, snapshot_dir
 
 
 @contextmanager
@@ -83,15 +83,11 @@ def cmd_apply(args: argparse.Namespace) -> int:
         database=database, migrate_to_head=lambda: _upgrade(database)
     )
 
-    # Report the stamped revision here rather than shelling out to `alembic heads`,
-    # which would pay the multi-second `onyx` import a second time. Mismatch means
-    # the database is not where the caller asked it to be, so fail loudly.
-    head = head_revision()
-    applied = _applied_revisions(database)
-    print(f"{database} via {outcome.value}: applied={applied} head={head}")
-    if applied != [head]:
-        print("ERROR: database is not at head", file=sys.stderr)
-        return 1
+    # Report the stamped revision rather than shelling out to `alembic heads`, which
+    # would pay the multi-second `onyx` import a second time. build_schema already
+    # guarantees head: the snapshot path checks the stamp, the other paths end in
+    # `alembic upgrade head`.
+    print(f"{database} via {outcome.value}: applied={_applied_revisions(database)}")
     return 0
 
 

--- a/backend/scripts/alembic_snapshot.py
+++ b/backend/scripts/alembic_snapshot.py
@@ -1,0 +1,87 @@
+"""Manage Alembic schema snapshots.
+
+    apply    Bring a database to head, reusing a snapshot when one applies.
+             A drop-in replacement for `alembic upgrade head` in dev and CI.
+    clear    Delete stored snapshots.
+
+Run from `backend/`. See onyx/db/migration_snapshot.py for the design, and
+tests/integration/tests/migrations/test_migration_snapshot.py for the proof that a
+snapshot reaches the same schema as running every revision.
+"""
+
+import argparse
+import os
+import sys
+from types import SimpleNamespace
+
+from alembic import command
+from alembic.config import Config
+
+from onyx.configs.app_configs import (
+    POSTGRES_HOST,
+    POSTGRES_PASSWORD,
+    POSTGRES_PORT,
+    POSTGRES_USER,
+)
+from onyx.db.engine.shard_registry import ALEMBIC_TARGET_URL_ATTRIBUTE
+from onyx.db.engine.sql_engine import build_connection_string
+from onyx.db.migration_snapshot import build_schema, snapshot_dir
+
+
+def _alembic_config(database: str) -> Config:
+    config = Config("alembic.ini")
+    config.attributes["configure_logger"] = False
+    config.cmd_opts = SimpleNamespace()  # ty: ignore[invalid-assignment]
+    config.cmd_opts.x = ["schema=public"]  # ty: ignore[invalid-assignment]
+    # env.py ignores `sqlalchemy.url` by design and reads this attribute instead. It
+    # builds an async engine from it, so the URL must use the async driver.
+    config.attributes[ALEMBIC_TARGET_URL_ATTRIBUTE] = build_connection_string(
+        db=database,
+        user=POSTGRES_USER,
+        password=POSTGRES_PASSWORD,
+        host=POSTGRES_HOST,
+        port=POSTGRES_PORT,
+    )
+    return config
+
+
+def _upgrade(database: str, revision: str = "head") -> None:
+    command.upgrade(_alembic_config(database), revision)
+
+
+def cmd_apply(args: argparse.Namespace) -> int:
+    database = args.database or os.environ.get("POSTGRES_DB") or "postgres"
+    outcome = build_schema(
+        database=database, migrate_to_head=lambda: _upgrade(database)
+    )
+    print(f"{database} is at head via {outcome.value}")
+    return 0
+
+
+def cmd_clear(args: argparse.Namespace) -> int:  # noqa: ARG001
+    directory = snapshot_dir()
+    removed = 0
+    for path in list(directory.glob("*.sql")) + list(directory.glob("*.json")):
+        path.unlink()
+        removed += 1
+    print(f"Removed {removed} file(s) from {directory}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    apply_parser = subparsers.add_parser("apply", help="bring a database to head")
+    apply_parser.add_argument("--database", help="defaults to $POSTGRES_DB")
+    apply_parser.set_defaults(func=cmd_apply)
+
+    clear_parser = subparsers.add_parser("clear", help="delete stored snapshots")
+    clear_parser.set_defaults(func=cmd_clear)
+
+    args = parser.parse_args()
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/integration/common_utils/reset.py
+++ b/backend/tests/integration/common_utils/reset.py
@@ -18,6 +18,7 @@ from onyx.db.engine.sql_engine import (
     build_connection_string,
     get_session_with_current_tenant,
 )
+from onyx.db.migration_snapshot import build_schema
 from onyx.db.swap_index import check_and_perform_index_swap
 from onyx.file_store.file_store import get_default_file_store
 from onyx.setup import setup_postgres
@@ -137,12 +138,23 @@ def upgrade_postgres(
         db_api=SYNC_DB_API,
         app_name="upgrade_postgres",
     )
-    _run_migrations(
-        conn_str,
-        config_name,
-        direction="upgrade",
-        revision=revision,
-    )
+
+    def _upgrade() -> None:
+        _run_migrations(
+            conn_str,
+            config_name,
+            direction="upgrade",
+            revision=revision,
+        )
+
+    # Only the main chain to head is worth snapshotting. alembic_tenants is ~10
+    # revisions, and a partial upgrade is not what a snapshot represents.
+    if config_name != "alembic" or revision != "head":
+        _upgrade()
+        return
+
+    outcome = build_schema(database=database, migrate_to_head=_upgrade)
+    logger.info("Postgres schema built via %s", outcome.value)
 
 
 def drop_multitenant_postgres(

--- a/backend/tests/integration/tests/migrations/test_migration_snapshot.py
+++ b/backend/tests/integration/tests/migrations/test_migration_snapshot.py
@@ -1,0 +1,236 @@
+"""Prove that restoring a schema snapshot matches running every migration.
+
+Dev and CI skip the ~440-revision replay by restoring a `pg_dump` of a database the
+migrations already built (see `onyx/db/migration_snapshot.py`). That shortcut is only
+safe while it lands on exactly the schema the full chain produces, including the
+triggers, functions, extensions, and seeded rows that older migrations create by hand.
+
+The test builds one database each way and compares the catalog and every row.
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import psycopg2
+import psycopg2.extensions
+import pytest
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+from onyx.configs.app_configs import (
+    POSTGRES_HOST,
+    POSTGRES_PASSWORD,
+    POSTGRES_PORT,
+    POSTGRES_USER,
+)
+from onyx.db.engine.shard_registry import ALEMBIC_TARGET_URL_ATTRIBUTE
+from onyx.db.engine.sql_engine import build_connection_string
+from onyx.db.migration_snapshot import dump_database, restore_dump
+
+# How many revisions to replay on top of the snapshot. Mirrors the delta path a PR
+# that adds migrations takes.
+REVISIONS_ON_TOP = 10
+
+_DB_PREFIX = "onyx_snapshot_equivalence"
+
+# Every object the migration chain creates: shape, integrity rules, executable code,
+# and seeded rows.
+_FACET_QUERIES: dict[str, str] = {
+    "columns": """
+        SELECT table_name, column_name, data_type, is_nullable, column_default,
+               character_maximum_length, numeric_precision, udt_name
+        FROM information_schema.columns WHERE table_schema = 'public'
+        ORDER BY table_name, column_name""",
+    "constraints": """
+        SELECT conrelid::regclass::text, conname, pg_get_constraintdef(oid)
+        FROM pg_constraint WHERE connamespace = 'public'::regnamespace
+        ORDER BY 1, 2, 3""",
+    "indexes": """
+        SELECT tablename, indexname, indexdef FROM pg_indexes
+        WHERE schemaname = 'public' ORDER BY 1, 2""",
+    "functions": """
+        SELECT p.proname, pg_get_functiondef(p.oid)
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        LEFT JOIN pg_depend d ON d.objid = p.oid AND d.deptype = 'e'
+        WHERE n.nspname = 'public' AND d.objid IS NULL ORDER BY 1, 2""",
+    "triggers": """
+        SELECT c.relname, t.tgname, pg_get_triggerdef(t.oid)
+        FROM pg_trigger t JOIN pg_class c ON c.oid = t.tgrelid
+        WHERE NOT t.tgisinternal ORDER BY 1, 2""",
+    "extensions": "SELECT extname FROM pg_extension ORDER BY 1",
+    "enums": """
+        SELECT t.typname, string_agg(e.enumlabel, ',' ORDER BY e.enumsortorder)
+        FROM pg_type t
+        JOIN pg_enum e ON e.enumtypid = t.oid
+        JOIN pg_namespace n ON n.oid = t.typnamespace
+        WHERE n.nspname = 'public' GROUP BY 1 ORDER BY 1""",
+    "sequences": """
+        SELECT sequencename, start_value, increment_by, last_value
+        FROM pg_sequences WHERE schemaname = 'public' ORDER BY 1""",
+}
+
+# Seeding migrations call now() and gen_random_uuid(), so columns of these types
+# differ between any two runs of the chain - snapshots are not involved. Two
+# independent full-chain runs disagree on them as well. Masking them keeps the
+# comparison on what the migrations actually determine. Row counts are compared
+# separately, so a masked column cannot hide a missing or extra row.
+_NONDETERMINISTIC_UDT = ("uuid", "_uuid", "timestamp", "timestamptz")
+_MASK = "'~masked~'"
+
+
+@contextmanager
+def _cursor(database: str) -> Iterator["psycopg2.extensions.cursor"]:
+    """An autocommit cursor.
+
+    Deliberately avoids `with connection`, which opens a transaction even when
+    autocommit is set and so blocks statements like CREATE DATABASE.
+    """
+    conn = psycopg2.connect(
+        dbname=database,
+        user=POSTGRES_USER,
+        password=POSTGRES_PASSWORD,
+        host=POSTGRES_HOST,
+        port=POSTGRES_PORT,
+        application_name="snapshot_equivalence_test",
+    )
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            yield cur
+    finally:
+        conn.close()
+
+
+def _recreate_database(database: str) -> None:
+    with _cursor("postgres") as cur:
+        cur.execute(f'DROP DATABASE IF EXISTS "{database}" WITH (FORCE)')
+        cur.execute(f'CREATE DATABASE "{database}"')
+
+
+def _upgrade(database: str, revision: str = "head") -> None:
+    config = Config("alembic.ini")
+    config.attributes["configure_logger"] = False
+    config.cmd_opts = SimpleNamespace()  # ty: ignore[invalid-assignment]
+    config.cmd_opts.x = ["schema=public"]  # ty: ignore[invalid-assignment]
+    # env.py ignores `sqlalchemy.url` by design and reads this attribute instead. It
+    # builds an async engine from it, so the URL must use the async driver.
+    config.attributes[ALEMBIC_TARGET_URL_ATTRIBUTE] = build_connection_string(
+        db=database,
+        user=POSTGRES_USER,
+        password=POSTGRES_PASSWORD,
+        host=POSTGRES_HOST,
+        port=POSTGRES_PORT,
+    )
+    command.upgrade(config, revision)
+
+
+def _row_expression(cur: "psycopg2.extensions.cursor", table: str) -> str:
+    """A row-to-text expression with nondeterministic columns masked."""
+    cur.execute(
+        """
+        SELECT column_name, udt_name FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = %s
+        ORDER BY ordinal_position
+        """,
+        (table,),
+    )
+    parts = [
+        _MASK if udt in _NONDETERMINISTIC_UDT else f't."{name}"::text'
+        for name, udt in cur.fetchall()
+    ]
+    return f"concat_ws('|', {', '.join(parts)})" if parts else "''"
+
+
+def _fingerprint(database: str) -> dict[str, str]:
+    """Catalog and row-level identity of a database.
+
+    Read through SQL rather than pg_dump so the check does not lean on the same tool
+    that produced the snapshot.
+    """
+    facets: dict[str, str] = {}
+    with _cursor(database) as cur:
+        for name, query in _FACET_QUERIES.items():
+            cur.execute(query)
+            facets[name] = "\n".join(
+                " | ".join(map(str, row)) for row in cur.fetchall()
+            )
+
+        cur.execute(
+            "SELECT tablename FROM pg_tables WHERE schemaname = 'public' ORDER BY 1"
+        )
+        rows = []
+        for (table,) in cur.fetchall():
+            cur.execute(f'SELECT count(*) FROM public."{table}"')
+            count_row = cur.fetchone()
+            assert count_row is not None
+
+            cur.execute(
+                "SELECT md5(string_agg(r, E'\\n' ORDER BY r)) FROM "
+                f"(SELECT {_row_expression(cur, table)} AS r "
+                f'FROM public."{table}" t) s'
+            )
+            digest_row = cur.fetchone()
+            assert digest_row is not None
+            rows.append(f"{table} | {count_row[0]} rows | {digest_row[0]}")
+        facets["data"] = "\n".join(rows)
+    return facets
+
+
+def _describe(facet: str, expected: str, actual: str) -> str:
+    only_expected = sorted(set(expected.splitlines()) - set(actual.splitlines()))
+    only_actual = sorted(set(actual.splitlines()) - set(expected.splitlines()))
+    lines = [f"{facet} differs between the full chain and the snapshot:"]
+    lines += [f"  full chain only: {line[:240]}" for line in only_expected[:10]]
+    lines += [f"  snapshot only:   {line[:240]}" for line in only_actual[:10]]
+    return "\n".join(lines)
+
+
+@pytest.fixture
+def scratch_databases() -> Iterator[tuple[str, str, str]]:
+    names = (f"{_DB_PREFIX}_full", f"{_DB_PREFIX}_snapshot", f"{_DB_PREFIX}_roundtrip")
+    try:
+        yield names
+    finally:
+        with _cursor("postgres") as cur:
+            for name in names:
+                cur.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+
+
+def test_snapshot_plus_new_revisions_matches_full_chain(
+    scratch_databases: tuple[str, str, str],
+) -> None:
+    full_db, snapshot_db, roundtrip_db = scratch_databases
+
+    revisions = list(ScriptDirectory("alembic").iterate_revisions("head", "base"))
+    assert REVISIONS_ON_TOP < len(revisions)
+    split = revisions[REVISIONS_ON_TOP].revision
+
+    _recreate_database(full_db)
+    _upgrade(full_db)
+
+    # Snapshot an older point in history, then replay the newer revisions on top.
+    _recreate_database(snapshot_db)
+    _upgrade(snapshot_db, split)
+    snapshot_sql = dump_database(snapshot_db)
+    _recreate_database(snapshot_db)
+    restore_dump(snapshot_db, snapshot_sql)
+    _upgrade(snapshot_db)
+
+    # Both sides must pass through exactly one dump/restore before they are compared.
+    # Postgres re-renders a few `sa.Enum` IN-lists when it reparses them
+    # (`ANY ((ARRAY[x])::text[])` becomes `ANY (ARRAY[(x)::text])`), which is a display
+    # change rather than a semantic one, and it converges after one cycle. Round
+    # tripping the full-chain database cancels it out, so this stays an exact equality
+    # with no hand-written normalisation to get wrong.
+    _recreate_database(roundtrip_db)
+    restore_dump(roundtrip_db, dump_database(full_db))
+
+    expected = _fingerprint(roundtrip_db)
+    actual = _fingerprint(snapshot_db)
+    for facet, expected_value in expected.items():
+        assert expected_value == actual[facet], _describe(
+            facet, expected_value, actual[facet]
+        )


### PR DESCRIPTION
## Problem

Alembic migrations are the slowest single step in our integration tests. The chain is ~440 revisions. CI replays it once per job (43s in [this run](https://github.com/onyx-dot-app/onyx/actions/runs/32417535768/job/96582049584), against 28s of actual tests), and the integration suite replays it again for each of ~167 `reset` fixture calls.

## Approach

The original idea was a committed squashed migration. I did not do that, for two reasons:

1. A committed `.sql` is a second source of truth. It can silently drift from the migrations, which is exactly the risk with the bespoke DB work in the older revisions.
2. `pg_dump` output depends on the client version. A committed dump churns whenever a developer's `pg_dump` differs from CI's.

Instead the snapshot is generated on demand and content-addressed. The key hashes every file in `alembic/versions` plus the Postgres major version, so a snapshot **cannot** be stale: change any migration and the key misses.

Three outcomes:

| Outcome | When | Cost |
| --- | --- | --- |
| `snapshot` | The key matches exactly | one restore |
| `snapshot+delta` | An older snapshot's revisions are a strict prefix of head | restore + replay only the new revisions |
| `full_chain` | No usable snapshot, or anything unexpected | today's behaviour |

Any failure falls back to `full_chain`, so the worst case is what we do now. Snapshots are gitignored; nothing is committed.

## Correctness

`backend/tests/integration/tests/migrations/test_migration_snapshot.py` builds one database by replaying every revision and another by restoring a snapshot taken 10 revisions back and replaying the rest. It then compares columns, constraints, indexes, functions, triggers, extensions, enums, sequences, and the contents of every table.

Two details worth calling out:

- Both sides pass through exactly one dump/restore before comparison. Postgres re-renders a few `sa.Enum` IN-lists when it reparses them (`ANY ((ARRAY[x])::text[])` → `ANY (ARRAY[(x)::text])`) - a display change that converges after one cycle. Round tripping both sides cancels it, so the assertion stays an exact equality with no hand-written normalisation to get wrong.
- `uuid` and timestamp columns are masked. Seeding migrations call `now()` and `gen_random_uuid()`, so **two independent full-chain runs disagree on them too**. Row counts are compared separately, so masking cannot hide a missing or extra row.

Building this caught one real bug that makes the case for the test: scoping the dump with `--schema=public` silently omits `CREATE EXTENSION`, so `pgcrypto` and `pg_trgm` were missing. The restore succeeded and a column-level comparison passed, because `gen_random_uuid()` defaults are stored as text. It would only have failed at runtime, on the first insert.

## Measured in CI (external-dependency-unit-tests, `Run migrations` step)

| | Time |
| --- | --- |
| Baseline on main (`alembic upgrade head` + `alembic heads --verbose`) | 43s |
| First run here, cold cache | 55s |
| Warm cache, first attempt | 42s |
| Warm cache, after removing `uv run` | 28s |
| Warm cache, current | **18s** |

The first attempt was **no faster than the baseline**, which is what prompted the
follow-up commits. The restore was never the cost. Two things around it were:

- `uv run` built a second virtualenv on every job — 438 packages including a ~100MB
  torch download, ~13s. The dependencies were already installed by the setup step,
  and the `alembic upgrade head` this replaces never used `uv run`.
- Reporting the head revision parsed all 437 revision files a second time, ~7.6s.
  That check now reads the head recorded beside the snapshot instead.

The remaining 18s is ~11s importing `onyx` plus ~6s of actual restore. The import is
now the floor, not the migrations.

## Caveats worth knowing before merging

- **A cold cache is slower than the baseline**, because the job runs the full chain
  and then dumps a snapshot. Stock GitHub Actions caches are branch-scoped with a
  fallback to the default branch, so PRs only benefit once a snapshot exists on
  `main`. Until this merges, expect misses. This repo proxies caches through
  runs-on's S3 bucket, and I have not confirmed its scoping matches stock behaviour.
- **Every matrix job dumps on a cold run** and races to save the same key; only one
  save wins. Harmless, but it is wasted work on the miss path.

## Not included

`.github/workflows/pr-integration-tests.yml` has no cache step. pytest runs inside a container there and I could not verify the workspace-mount semantics; a wrong path would just produce a red step. The within-session win above needs no workflow change, so this can follow separately.

## Testing

- New migrations test passes, and fails as expected when the schemas are deliberately made to differ (verified with an injected index).
- Delta path exercised end to end in the runtime code path: `OUTCOME: snapshot+delta`, fingerprints identical.
- `pre-commit` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore a content-addressed Postgres schema snapshot in dev and CI instead of replaying ~440 `alembic` revisions. Previously we always ran `alembic upgrade head`; now `python -m scripts.alembic_snapshot apply` restores a keyed `pg_dump` and replays only new revisions, with automatic, safe fallback to the full chain. Production remains unchanged.

- Core: `backend/onyx/db/migration_snapshot.py` hashes `backend/alembic/versions/**` and the server major to choose {snapshot, snapshot+delta, full_chain}. The restore path now verifies the stamped revision against the snapshot’s recorded head; any mismatch or error falls back to the full chain.
- CLI: `backend/scripts/alembic_snapshot.py` adds `apply` (drop-in for `alembic upgrade head`) and `clear`. It avoids a second costly import/head-parse by reporting applied revisions directly; stamp validation happens inside the restore path.
- CI: add an Actions cache for `backend/.migration_snapshots` keyed by revision hashes and runner OS/arch; workflows now run `python -m scripts.alembic_snapshot apply` (not `uv run`) and no longer call `alembic heads`.
- Tests: new integration test proves snapshot+delta matches the full chain by comparing catalog objects and table data, masking nondeterministic UUID/timestamp fields.
- Controls: set `ONYX_DISABLE_MIGRATION_SNAPSHOT=1` to force the full chain; set `ONYX_MIGRATION_SNAPSHOT_DIR` to change the snapshot location. `pg_dump` is only required to write snapshots; if missing, caching is skipped.
- Integration: `backend/tests/integration/common_utils/reset.py` uses snapshots only for the main `alembic` chain to `head`. `.gitignore` ignores `.migration_snapshots`.

<sup>Written for commit 1e1fcb3a678a1b6d4e7f5b8a46e88362c9f25a97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


