### PR TITLE
chore(gha): remove unnecessary `alembic heads --verbose`

### DIFF
--- a/.github/workflows/pr-external-dependency-unit-tests.yml
+++ b/.github/workflows/pr-external-dependency-unit-tests.yml
@@ -158,11 +158,9 @@ jobs:
             code-interpreter
 
       - name: Run migrations
+        working-directory: backend
         run: |
-          cd backend
-          # Run migrations to head
           alembic upgrade head
-          alembic heads --verbose
 
       # A real OIDC server for the live multi-provider login test. Auth leg only.
       # Fail if it never becomes ready, otherwise the live tests would silently skip.


### PR DESCRIPTION
## Description

https://github.com/onyx-dot-app/onyx/pull/14135 found this `alembic heads --verbose` imports `onyx` which takes ~12s in CI ( :vomiting_face: ) and is only used for debugging, so we can safely remove.

## How Has This Been Tested?

Captured by existing

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes `alembic heads --verbose` from the `pr-external-dependency-unit-tests` workflow and sets `working-directory: backend` for the migration step. Previously we ran `alembic upgrade head` followed by a verbose heads listing that imported `onyx` and added ~12s in CI; now we only run the upgrade, preserving migration behavior while reducing CI time.

<sup>Written for commit 33e124e3855e05935614ae840cff6182e9e29dd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

