### PR TITLE
fix(pre-commit): stop ripsecrets flagging non-secrets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -217,8 +217,12 @@ repos:
           # ripsecrets joins every pattern into one regex and runs it over the
           # whole file, so `^`/`$` anchor to the start and end of the file, not
           # a line -- an anchored pattern here silently matches nothing.
+          # `\b` keeps the prefix a real token start: without it the pattern
+          # matches inside words, e.g. the "sk-" in "celery-task-meta-<uuid>".
+          # The capture group makes ripsecrets test the key body for
+          # randomness, which drops placeholders like "sk-test-key-0000...".
           - --additional-pattern
-          - sk-[A-Za-z0-9_\-]{20,}
+          - \bsk-([A-Za-z0-9_\-]{20,})
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: d0e12caebb2ab0ee8bf98181c8bfe9702bca103d


### PR DESCRIPTION
## Problem

`ripsecrets` fails at HEAD on 7 lines. None of them is a secret.

#14079 removed the `^`/`$` anchors from the additional `sk-` pattern. The anchors were wrong — ripsecrets joins every pattern into one regex and runs it over the whole file, so they anchored to the file, not a line, and the pattern matched nothing. Un-anchoring made the pattern live for the first time, and it is too loose:

1. **No left boundary.** It matches inside words. `celery-ta`**`sk-`**`meta-dd32ded3-…` is a comment about a Celery result key. That is 3 of the 7 hits, in `backend/onyx/redis/`.
2. **No capture group.** ripsecrets tests capturing groups for randomness before it reports a match. Without one, placeholders are reported like real keys: `sk-test-key-000…`, `sk-brand-new-key-123456`, `sk-tf-acc-fake-key-rotated`.

## Fix

    \bsk-([A-Za-z0-9_\-]{20,})

`\b` requires a real token start, so `task-meta` no longer matches. The capture group is deliberate: it hands the key body to the randomness test, so low-entropy placeholders drop out on their own. No per-line `pragma: allowlist secret` comments and no `.secretsignore` entries are needed.

## Verification

Ran against the hook's own `ripsecrets` binary:

- All 7 reported lines pass, and `ripsecrets --all-files` passes.
- Detection is not weakened. Real key shapes are still caught — `sk-` + 48 chars and the `sk-proj-` form — including bare as a call argument, where no built-in pattern fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens the `ripsecrets` additional `sk-` pattern to stop false positives in pre-commit. Old: `sk-[A-Za-z0-9_\-]{20,}` matched inside words and skipped entropy checks. New: `\bsk-([A-Za-z0-9_\-]{20,})` enforces a token boundary and captures the key body so randomness is tested.

- Updates `.pre-commit-config.yaml`; no `.secretsignore` or per-line allowlists needed.
- Verification: `pre-commit run ripsecrets --all-files` passes at HEAD; detection of real keys remains (e.g., `sk-` + 48 chars and `sk-proj-...`).

<sup>Written for commit 7ba0e10f1250c78bf46c674b6471e8eb1b4e1045. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

