### PR TITLE
feat(groups): tag managers in the group member list

### DIFF
--- a/web/src/views/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/EditGroupPage.tsx
@@ -19,7 +19,7 @@ import {
   SvgMinusCircle,
   SvgPlusCircle,
   SvgSimpleLoader,
-  SvgShield,
+  SvgUserShield,
 } from "@opal/icons";
 import { markdown } from "@opal/utils";
 import IconButton from "@/refresh-components/buttons/IconButton";
@@ -36,7 +36,7 @@ import { useSettings } from "@/lib/settings/hooks";
 import { Tier } from "@/lib/settings/types";
 import { tierAtLeast } from "@/lib/tiers";
 import type { MemberRow, TokenRateLimitDisplay } from "./interfaces";
-import { baseColumns, memberTableColumns, tc, PAGE_SIZE } from "./shared";
+import { makeBaseColumns, memberTableColumns, tc, PAGE_SIZE } from "./shared";
 import {
   renameGroup,
   updateGroup,
@@ -287,7 +287,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
 
   const memberColumns = useMemo(
     () => [
-      ...baseColumns,
+      ...makeBaseColumns((row) => managerIds.has(row.id ?? row.email)),
       tc.actions({
         showSorting: false,
         showColumnVisibility: false,
@@ -302,7 +302,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
             <div className="flex items-center gap-1">
               {canManage && (
                 <IconButton
-                  icon={isPending ? SvgSimpleLoader : SvgShield}
+                  icon={isPending ? SvgSimpleLoader : SvgUserShield}
                   tertiary
                   transient={isManager}
                   disabled={!isPersisted || isPending || isOwnManager}

--- a/web/src/views/admin/GroupsPage/shared.tsx
+++ b/web/src/views/admin/GroupsPage/shared.tsx
@@ -51,18 +51,6 @@ const ACCOUNT_TYPE_ICONS: Partial<Record<AccountType, IconFunctionComponent>> =
 // Column renderers
 // ---------------------------------------------------------------------------
 
-function renderNameColumn(_searchValue: unknown, row: MemberRow) {
-  const { email, personal_name } = row;
-  return (
-    <Content
-      sizePreset="main-ui"
-      variant="section"
-      title={personal_name ?? email}
-      description={personal_name ? email : undefined}
-    />
-  );
-}
-
 function renderAccountTypeColumn(_value: unknown, row: MemberRow) {
   const Icon =
     (row.account_type && ACCOUNT_TYPE_ICONS[row.account_type]) || SvgUser;
@@ -84,35 +72,55 @@ function renderAccountTypeColumn(_value: unknown, row: MemberRow) {
 
 export const tc = createTableColumns<MemberRow>();
 
-export const baseColumns = [
-  tc.qualifier(),
+// `isManager` is optional — only the group edit page knows who manages a group.
+function nameColumn(isManager?: (row: MemberRow) => boolean) {
   // Search/sort by a name+email composite so service accounts — whose email is a
   // "Service Account" placeholder — are findable by their API-key name.
-  tc.column((row) => [row.personal_name, row.email].filter(Boolean).join(" "), {
-    id: "name",
-    header: "Name",
-    weight: 25,
-    cell: renderNameColumn,
-  }),
-  tc.column("api_key_display", {
-    header: "",
-    weight: 15,
-    enableSorting: false,
-    cell: (value) =>
-      value ? (
-        <Text as="span" secondaryBody text03>
-          {value}
-        </Text>
-      ) : null,
-  }),
-  tc.column("account_type", {
-    header: "Account Type",
-    weight: 15,
-    cell: renderAccountTypeColumn,
-  }),
-];
+  return tc.column(
+    (row) => [row.personal_name, row.email].filter(Boolean).join(" "),
+    {
+      id: "name",
+      header: "Name",
+      weight: 25,
+      cell: (_searchValue, row) => (
+        <Content
+          sizePreset="main-ui"
+          variant="section"
+          title={row.personal_name ?? row.email}
+          description={row.personal_name ? row.email : undefined}
+          tag={
+            isManager?.(row) ? { title: "Manager", color: "blue" } : undefined
+          }
+        />
+      ),
+    }
+  );
+}
+
+export function makeBaseColumns(isManager?: (row: MemberRow) => boolean) {
+  return [
+    tc.qualifier(),
+    nameColumn(isManager),
+    tc.column("api_key_display", {
+      header: "",
+      weight: 15,
+      enableSorting: false,
+      cell: (value) =>
+        value ? (
+          <Text as="span" secondaryBody text03>
+            {value}
+          </Text>
+        ) : null,
+    }),
+    tc.column("account_type", {
+      header: "Account Type",
+      weight: 15,
+      cell: renderAccountTypeColumn,
+    }),
+  ];
+}
 
 export const memberTableColumns = [
-  ...baseColumns,
+  ...makeBaseColumns(),
   tc.actions({ showSorting: false }),
 ];


### PR DESCRIPTION
## Description

- Group managers now show a blue **Manager** tag beside their name in the member list on the group edit page.
- The make-manager action uses a user-scoped shield icon, so it no longer reads as a generic security control.

## How Has This Been Tested?

Manually verified in the admin UI: the tag appears and clears as a member is made a manager and revoked. Type check and lint pass locally.
<img width="944" height="750" alt="Screenshot 2026-08-21 at 11 45 28 AM" src="https://github.com/user-attachments/assets/943ed49e-d812-4588-b3fd-c5764a2e49db" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
