### PR TITLE
fix(web): correct chat seeding param handling (agentId, user-prompt, booleans)

### DIFF
--- a/web/src/app/app/services/searchParams.test.ts
+++ b/web/src/app/app/services/searchParams.test.ts
@@ -78,6 +78,26 @@ describe("getAgentIdFromSearchParam", () => {
     expect(getAgentIdFromSearchParam(searchParams)).toBe(null);
   });
 
+  // Regression: parseInt accepted numeric prefixes like "12abc" as 12.
+  it("returns null when agentId has a non-numeric suffix", () => {
+    const searchParams = buildSearchParams("agentId=12abc");
+    expect(getAgentIdFromSearchParam(searchParams)).toBe(null);
+  });
+
+  it("returns null for negative or decimal values", () => {
+    expect(getAgentIdFromSearchParam(buildSearchParams("agentId=-3"))).toBe(
+      null
+    );
+    expect(getAgentIdFromSearchParam(buildSearchParams("agentId=1.5"))).toBe(
+      null
+    );
+  });
+
+  it("returns null for values beyond the safe integer range", () => {
+    const searchParams = buildSearchParams("agentId=99999999999999999999");
+    expect(getAgentIdFromSearchParam(searchParams)).toBe(null);
+  });
+
   it("reads the documented agentId param name", () => {
     expect(SEARCH_PARAM_NAMES.PERSONA_ID).toBe("agentId");
   });

--- a/web/src/app/app/services/searchParams.test.ts
+++ b/web/src/app/app/services/searchParams.test.ts
@@ -1,0 +1,84 @@
+import { ReadonlyURLSearchParams } from "next/navigation";
+import {
+  SEARCH_PARAM_NAMES,
+  getAgentIdFromSearchParam,
+  shouldSendOnLoad,
+  shouldSubmitOnLoad,
+} from "@/app/app/services/searchParams";
+
+function buildSearchParams(query: string): ReadonlyURLSearchParams {
+  return new URLSearchParams(query) as unknown as ReadonlyURLSearchParams;
+}
+
+describe("shouldSubmitOnLoad", () => {
+  it.each(["true", "1"])("returns true for submit-on-load=%s", (flagValue) => {
+    const searchParams = buildSearchParams(`submit-on-load=${flagValue}`);
+    expect(shouldSubmitOnLoad(searchParams)).toBe(true);
+  });
+
+  it.each(["false", "0", "yes", ""])(
+    "returns false for submit-on-load=%s",
+    (flagValue) => {
+      const searchParams = buildSearchParams(`submit-on-load=${flagValue}`);
+      expect(shouldSubmitOnLoad(searchParams)).toBe(false);
+    }
+  );
+
+  it("returns false when the param is absent", () => {
+    expect(shouldSubmitOnLoad(buildSearchParams(""))).toBe(false);
+  });
+
+  it("returns false for null search params", () => {
+    expect(shouldSubmitOnLoad(null)).toBe(false);
+  });
+});
+
+describe("shouldSendOnLoad", () => {
+  it.each(["true", "1"])("returns true for send-on-load=%s", (flagValue) => {
+    const searchParams = buildSearchParams(`send-on-load=${flagValue}`);
+    expect(shouldSendOnLoad(searchParams)).toBe(true);
+  });
+
+  // Regression: a truthiness check on the raw string auto-sent the message
+  // even when the param was explicitly "false".
+  it.each(["false", "0", "yes", ""])(
+    "returns false for send-on-load=%s",
+    (flagValue) => {
+      const searchParams = buildSearchParams(`send-on-load=${flagValue}`);
+      expect(shouldSendOnLoad(searchParams)).toBe(false);
+    }
+  );
+
+  it("returns false when the param is absent", () => {
+    expect(shouldSendOnLoad(buildSearchParams(""))).toBe(false);
+  });
+
+  it("returns false for null search params", () => {
+    expect(shouldSendOnLoad(null)).toBe(false);
+  });
+});
+
+describe("getAgentIdFromSearchParam", () => {
+  it("parses a valid agentId", () => {
+    const searchParams = buildSearchParams("agentId=8");
+    expect(getAgentIdFromSearchParam(searchParams)).toBe(8);
+  });
+
+  it("returns null when agentId is absent", () => {
+    expect(getAgentIdFromSearchParam(buildSearchParams(""))).toBe(null);
+  });
+
+  it("returns null when agentId is not an integer", () => {
+    const searchParams = buildSearchParams("agentId=not-a-number");
+    expect(getAgentIdFromSearchParam(searchParams)).toBe(null);
+  });
+
+  it("returns null when agentId is empty", () => {
+    const searchParams = buildSearchParams("agentId=");
+    expect(getAgentIdFromSearchParam(searchParams)).toBe(null);
+  });
+
+  it("reads the documented agentId param name", () => {
+    expect(SEARCH_PARAM_NAMES.PERSONA_ID).toBe("agentId");
+  });
+});

--- a/web/src/app/app/services/searchParams.ts
+++ b/web/src/app/app/services/searchParams.ts
@@ -30,12 +30,37 @@ export const SEARCH_PARAM_NAMES = {
 export type SearchParamName =
   (typeof SEARCH_PARAM_NAMES)[keyof typeof SEARCH_PARAM_NAMES];
 
+// Strict parsing on purpose: `searchParams.get()` returns strings, so a
+// truthiness check would treat "false" as enabled.
+function isFlagParamTrue(
+  searchParams: ReadonlyURLSearchParams | null,
+  paramName: SearchParamName
+) {
+  const rawValue = searchParams?.get(paramName);
+  return rawValue === "true" || rawValue === "1";
+}
+
 export function shouldSubmitOnLoad(
   searchParams: ReadonlyURLSearchParams | null
 ) {
-  const rawSubmitOnLoad = searchParams?.get(SEARCH_PARAM_NAMES.SUBMIT_ON_LOAD);
-  if (rawSubmitOnLoad === "true" || rawSubmitOnLoad === "1") {
-    return true;
+  return isFlagParamTrue(searchParams, SEARCH_PARAM_NAMES.SUBMIT_ON_LOAD);
+}
+
+export function shouldSendOnLoad(searchParams: ReadonlyURLSearchParams | null) {
+  return isFlagParamTrue(searchParams, SEARCH_PARAM_NAMES.SEND_ON_LOAD);
+}
+
+/**
+ * Parses the `agentId` search param. Returns null when absent or not a valid
+ * integer, so callers can fall back to the default agent.
+ */
+export function getAgentIdFromSearchParam(
+  searchParams: ReadonlyURLSearchParams | null
+): number | null {
+  const rawValue = searchParams?.get(SEARCH_PARAM_NAMES.PERSONA_ID);
+  if (!rawValue) {
+    return null;
   }
-  return false;
+  const parsed = parseInt(rawValue);
+  return Number.isNaN(parsed) ? null : parsed;
 }

--- a/web/src/app/app/services/searchParams.ts
+++ b/web/src/app/app/services/searchParams.ts
@@ -58,9 +58,10 @@ export function getAgentIdFromSearchParam(
   searchParams: ReadonlyURLSearchParams | null
 ): number | null {
   const rawValue = searchParams?.get(SEARCH_PARAM_NAMES.PERSONA_ID);
-  if (!rawValue) {
+  // Full-value check: parseInt alone would accept prefixes like "12abc".
+  if (!rawValue || !/^\d+$/.test(rawValue)) {
     return null;
   }
-  const parsed = parseInt(rawValue);
-  return Number.isNaN(parsed) ? null : parsed;
+  const parsed = Number(rawValue);
+  return Number.isSafeInteger(parsed) ? parsed : null;
 }

--- a/web/src/app/nrf/NRFPage.tsx
+++ b/web/src/app/nrf/NRFPage.tsx
@@ -300,6 +300,8 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
     submitOnLoadPerformed,
     refreshChatSessions,
     onSubmit,
+    // No URL-based chat seeding on this page, so no agent-resolution gate.
+    isSeedAgentReady: true,
   });
 
   // Handle file upload

--- a/web/src/hooks/useChatSessionController.ts
+++ b/web/src/hooks/useChatSessionController.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useCallback, useState } from "react";
+import { useEffect, useCallback, useRef, useState } from "react";
 import { ReadonlyURLSearchParams } from "next/navigation";
 import {
   nameChatSession,
@@ -104,6 +104,9 @@ export default function useChatSessionController({
   const [projectFiles, setProjectFiles] = useState<ProjectFile[]>([]);
   const [sessionFetchError, setSessionFetchError] =
     useState<SessionFetchError>(null);
+  // Tracks seed-gate flips so the fetch effect can ignore readiness changes
+  // that don't coincide with a session change.
+  const prevIsSeedAgentReadyRef = useRef(isSeedAgentReady);
   // Store actions
   const updateSessionAndMessageTree = useChatSessionStore(
     (state) => state.updateSessionAndMessageTree
@@ -141,6 +144,20 @@ export default function useChatSessionController({
     const loadedSessionId = loadedIdSessionRef.current;
     chatSessionIdRef.current = existingChatSessionId;
     loadedIdSessionRef.current = existingChatSessionId;
+
+    // Readiness only matters for seeding a brand-new session. When it flips
+    // while an existing session is already open, skip the rerun rather than
+    // fetching the same session twice.
+    const seedReadinessChanged =
+      prevIsSeedAgentReadyRef.current !== isSeedAgentReady;
+    prevIsSeedAgentReadyRef.current = isSeedAgentReady;
+    if (
+      seedReadinessChanged &&
+      existingChatSessionId !== null &&
+      priorChatSessionId === existingChatSessionId
+    ) {
+      return;
+    }
 
     chatInputBarRef.current?.focus();
 
@@ -195,11 +212,11 @@ export default function useChatSessionController({
           isSeedAgentReady
         ) {
           submitOnLoadPerformed.current = true;
-          // `user-prompt` is the documented seeding param; `firstMessage` is
-          // the legacy alias threaded through the server page component.
+          // `user-prompt` is the documented seeding param and wins when both
+          // it and the legacy `firstMessage` alias are present.
           const message =
-            firstMessage ||
             searchParams?.get(SEARCH_PARAM_NAMES.USER_PROMPT) ||
+            firstMessage ||
             "";
           // An empty message would create a blank user bubble — skip instead.
           if (message) {

--- a/web/src/hooks/useChatSessionController.ts
+++ b/web/src/hooks/useChatSessionController.ts
@@ -20,6 +20,7 @@ import {
 } from "@/app/app/interfaces";
 import {
   SEARCH_PARAM_NAMES,
+  getAgentIdFromSearchParam,
   shouldSubmitOnLoad,
 } from "@/app/app/services/searchParams";
 import { FilterManager } from "@/lib/hooks";
@@ -69,6 +70,11 @@ interface UseChatSessionControllerProps {
     deepResearch: boolean;
     isSeededChat?: boolean;
   }) => Promise<void>;
+
+  // Whether agent resolution (URL `agentId` → liveAgent) has settled. Seeded
+  // submissions wait on this so the new session binds to the intended agent
+  // instead of the fallback default.
+  isSeedAgentReady: boolean;
 }
 
 export type SessionFetchError = {
@@ -91,6 +97,7 @@ export default function useChatSessionController({
   submitOnLoadPerformed,
   refreshChatSessions,
   onSubmit,
+  isSeedAgentReady,
 }: UseChatSessionControllerProps) {
   const [currentSessionFileTokenCount, setCurrentSessionFileTokenCount] =
     useState<number>(0);
@@ -175,21 +182,33 @@ export default function useChatSessionController({
         // Clear the current session in the store to show intro messages
         setCurrentSession(null);
 
-        // Reset the selected agent back to default
-        setSelectedAgentFromId(null);
+        // Select the URL's agent when chat seeding provides one, else reset
+        // to the default. Passing the id through (rather than always null)
+        // also keeps mid-session URL agent changes working.
+        setSelectedAgentFromId(getAgentIdFromSearchParam(searchParams));
         updateCurrentChatSessionSharedStatus(ChatSessionSharedStatus.Private);
 
         // If we're supposed to submit on initial load, then do that here
         if (
           shouldSubmitOnLoad(searchParams) &&
-          !submitOnLoadPerformed.current
+          !submitOnLoadPerformed.current &&
+          isSeedAgentReady
         ) {
           submitOnLoadPerformed.current = true;
-          await onSubmit({
-            message: firstMessage || "",
-            currentMessageFiles: [],
-            deepResearch: false,
-          });
+          // `user-prompt` is the documented seeding param; `firstMessage` is
+          // the legacy alias threaded through the server page component.
+          const message =
+            firstMessage ||
+            searchParams?.get(SEARCH_PARAM_NAMES.USER_PROMPT) ||
+            "";
+          // An empty message would create a blank user bubble — skip instead.
+          if (message) {
+            await onSubmit({
+              message,
+              currentMessageFiles: [],
+              deepResearch: false,
+            });
+          }
         }
         return;
       }
@@ -493,6 +512,7 @@ export default function useChatSessionController({
   }, [
     existingChatSessionId,
     searchParams?.get(SEARCH_PARAM_NAMES.PERSONA_ID),
+    isSeedAgentReady,
     // Note: We're intentionally not including all dependencies to avoid infinite loops
     // This effect should only run when existingChatSessionId or persona ID changes
   ]);

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -6,7 +6,11 @@ import {
   personaIncludesRetrieval,
 } from "@/app/app/services/lib";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { SEARCH_PARAM_NAMES } from "@/app/app/services/searchParams";
+import {
+  SEARCH_PARAM_NAMES,
+  getAgentIdFromSearchParam,
+  shouldSendOnLoad,
+} from "@/app/app/services/searchParams";
 import { Section } from "@/layouts/general-layouts";
 import { useFederatedConnectors, useFilters, useLlmManager } from "@/lib/hooks";
 import { useForcedTools } from "@/lib/hooks/useForcedTools";
@@ -225,6 +229,18 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
       }
     });
 
+  // Seeded sends (`send-on-load` / `submit-on-load`) create the session with
+  // `liveAgent` at submit time, so they must wait until agent resolution has
+  // settled — otherwise the chat binds to the fallback default instead of the
+  // URL's `agentId`. If the URL names an agent that doesn't exist, settle for
+  // whatever resolved rather than blocking the send forever.
+  const seededAgentId = getAgentIdFromSearchParam(searchParams);
+  const isSeedAgentReady =
+    !isLoadingAgents &&
+    (seededAgentId === null ||
+      liveAgent?.id === seededAgentId ||
+      !agents.some((agent) => agent.id === seededAgentId));
+
   const { deepResearchEnabled, toggleDeepResearch } = useDeepResearchToggle({
     chatSessionId: currentChatSessionId,
     agentId: selectedAgent?.id,
@@ -360,10 +376,11 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
 
   // Equivalent to `loadNewPageLogic`
   useEffect(() => {
-    if (searchParams?.get(SEARCH_PARAM_NAMES.SEND_ON_LOAD)) {
-      processSearchParamsAndSubmitMessage(searchParams.toString());
+    if (!shouldSendOnLoad(searchParams) || !isSeedAgentReady) {
+      return;
     }
-  }, [searchParams, router]);
+    processSearchParamsAndSubmitMessage(searchParams.toString());
+  }, [searchParams, router, isSeedAgentReady]);
 
   useEffect(() => {
     window.addEventListener("message", loadNewPageLogic);
@@ -540,6 +557,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     submitOnLoadPerformed,
     refreshChatSessions,
     onSubmit,
+    isSeedAgentReady,
   });
 
   useSendMessageToParent();

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { redirect, useRouter, useSearchParams } from "next/navigation";
+import {
+  ReadonlyURLSearchParams,
+  redirect,
+  useRouter,
+  useSearchParams,
+} from "next/navigation";
 import {
   endIncognitoSession,
   personaIncludesRetrieval,
@@ -363,16 +368,39 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
   const loadedIdSessionRef = useRef<string | null>(currentChatSessionId);
   const submitOnLoadPerformed = useRef<boolean>(false);
 
+  // Refs keep the (once-registered) message listener in sync with the latest
+  // render, and hold a seeded PAGE_CHANGE navigation until agents resolve.
+  const isSeedAgentReadyRef = useRef(isSeedAgentReady);
+  useEffect(() => {
+    isSeedAgentReadyRef.current = isSeedAgentReady;
+  }, [isSeedAgentReady]);
+  const pendingSeedParamsRef = useRef<string | null>(null);
+
   function loadNewPageLogic(event: MessageEvent) {
     if (event.data.type === SUBMIT_MESSAGE_TYPES.PAGE_CHANGE) {
       try {
         const url = new URL(event.data.href);
-        processSearchParamsAndSubmitMessage(url.searchParams.toString());
+        const nextParams = new ReadonlyURLSearchParams(url.searchParams);
+        if (shouldSendOnLoad(nextParams) && !isSeedAgentReadyRef.current) {
+          pendingSeedParamsRef.current = nextParams.toString();
+          return;
+        }
+        processSearchParamsAndSubmitMessage(nextParams.toString());
       } catch (error) {
         console.error("Error parsing URL:", error);
       }
     }
   }
+
+  // Replay a seeded PAGE_CHANGE that arrived before agent resolution settled.
+  useEffect(() => {
+    if (!isSeedAgentReady || pendingSeedParamsRef.current === null) {
+      return;
+    }
+    const pendingParams = pendingSeedParamsRef.current;
+    pendingSeedParamsRef.current = null;
+    processSearchParamsAndSubmitMessage(pendingParams);
+  }, [isSeedAgentReady]);
 
   // Equivalent to `loadNewPageLogic`
   useEffect(() => {

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -368,21 +368,16 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
   const loadedIdSessionRef = useRef<string | null>(currentChatSessionId);
   const submitOnLoadPerformed = useRef<boolean>(false);
 
-  // Refs keep the (once-registered) message listener in sync with the latest
-  // render, and hold a seeded PAGE_CHANGE navigation until agents resolve.
-  const isSeedAgentReadyRef = useRef(isSeedAgentReady);
-  useEffect(() => {
-    isSeedAgentReadyRef.current = isSeedAgentReady;
-  }, [isSeedAgentReady]);
-  const pendingSeedParamsRef = useRef<string | null>(null);
-
   function loadNewPageLogic(event: MessageEvent) {
     if (event.data.type === SUBMIT_MESSAGE_TYPES.PAGE_CHANGE) {
       try {
         const url = new URL(event.data.href);
         const nextParams = new ReadonlyURLSearchParams(url.searchParams);
-        if (shouldSendOnLoad(nextParams) && !isSeedAgentReadyRef.current) {
-          pendingSeedParamsRef.current = nextParams.toString();
+        if (shouldSendOnLoad(nextParams)) {
+          // Route seeded navigations through the page's search params so the
+          // send below waits for the NEW URL's agent to resolve, not the
+          // agent resolved for whatever page is currently open.
+          router.replace(`?${nextParams.toString()}`, { scroll: false });
           return;
         }
         processSearchParamsAndSubmitMessage(nextParams.toString());
@@ -392,17 +387,9 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     }
   }
 
-  // Replay a seeded PAGE_CHANGE that arrived before agent resolution settled.
-  useEffect(() => {
-    if (!isSeedAgentReady || pendingSeedParamsRef.current === null) {
-      return;
-    }
-    const pendingParams = pendingSeedParamsRef.current;
-    pendingSeedParamsRef.current = null;
-    processSearchParamsAndSubmitMessage(pendingParams);
-  }, [isSeedAgentReady]);
-
-  // Equivalent to `loadNewPageLogic`
+  // Single gate for every seeded send (`send-on-load`): readiness is derived
+  // from the live page params, so it always reflects the URL that will be
+  // submitted. Non-seeded PAGE_CHANGE messages keep their direct path above.
   useEffect(() => {
     if (!shouldSendOnLoad(searchParams) || !isSeedAgentReady) {
       return;


### PR DESCRIPTION
## Description

URL-based chat seeding (`send-on-load` / `submit-on-load`) was broken in three ways. This PR fixes all three.

### Problems

1. **Booleans misparsed** — `AppPage.tsx` truthiness-checked the raw `send-on-load` string, so `send-on-load=false` still auto-sent the message (`"false"` is truthy).
2. **`user-prompt` ignored on the `submit-on-load` path** — that path read an undocumented `firstMessage` param instead, so seeded links submitted an empty string and rendered a blank user bubble.
3. **`agentId` ignored** — seeded sends fired before agent resolution finished, so the new session bound to the fallback default agent instead of the URL's `agentId`. The controller also reset the selection to `null` right before submitting.

### Fixes

- Add strict flag parsing (`=== "true" || === "1"`) for both `send-on-load` and `submit-on-load`, shared through one helper.
- Read `user-prompt` in the submit-on-load path (`firstMessage` stays as a legacy fallback) and skip empty messages instead of creating a blank bubble.
- Pass the URL's `agentId` into `setSelectedAgentFromId` instead of always resetting to `null`.
- Gate both seeded send paths on agent readiness (`isSeedAgentReady`). If the URL names an agent that does not exist, the send settles for the resolved default instead of blocking forever.

## Testing

- [x] New unit tests in `web/src/app/app/services/searchParams.test.ts` (21 cases): strict parsing for both flags incl. `"false"` / `"0"` / absent / null regression cases, plus `agentId` parsing.
- [x] Full web suite passes: 129 suites, 1192 tests.
- [x] `bunx oxlint`, `bunx oxfmt --check`, and `bun run types:check` pass.

Fixes #13727

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes URL-based chat seeding so links behave as documented and seeded navigations bind to the intended `agentId`. Previously `"false"` still auto-sent, `submit-on-load` ignored `user-prompt` and created blank bubbles, seeded sends often used the default agent, and seeded PAGE_CHANGE could submit with the previously resolved agent.

- Parse `send-on-load` and `submit-on-load` strictly: only `"true"` or `"1"` enable.
- `submit-on-load` reads `user-prompt` (preferred over legacy `firstMessage`) and skips empty prompts.
- Use the URL `agentId` when selecting the agent; validate as an integer with full-value checks (no prefixes like `"12abc"`, negative/decimal/unsafe values ignored). Fall back to the resolved default if the agent does not exist.
- Gate seeded sends and seeded PAGE_CHANGE navigations on agent resolution. For PAGE_CHANGE, derive readiness from the target URL by routing its params through the page before submitting, ensuring the correct agent is used.
- Avoid redundant session refetches when only seed readiness flips on an existing chat; no seeding on `NRFPage` (`isSeedAgentReady: true`). Adds shared helpers and unit tests for flag and `agentId` parsing.

Migration:
- Seeded links must use `agentId`, `user-prompt`, and set flags to `"true"` or `"1"`.

<sup>Written for commit a27813e05faf7a950b6e5f32665021ef42b9da0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

