### PR TITLE
feat(groups): keep every standard user in at least one group

### DIFF
--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -61,6 +61,7 @@ from onyx.db.users import (
     assert_admin_access_survives_removal,
     assert_group_membership_survives_removal,
     fetch_users_by_ids,
+    lock_group_membership,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -959,6 +960,9 @@ def assert_group_membership_survives_deletion(
     """Deletion drops every membership, so the strand rule covers the whole roster.
     Guards the route, not prepare_user_group_for_deletion — the sync task re-runs
     that one, and raising there would wedge a scheduled deletion."""
+    # Locked first: cleanup deletes every membership, including ones added after this read.
+    lock_group_membership(db_session)
+
     member_ids: list[UUID] = [
         user_id
         for user_id in db_session.scalars(

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -60,7 +60,7 @@ from onyx.db.permissions import (
 from onyx.db.users import (
     assert_admin_access_survives_removal,
     assert_group_membership_survives_removal,
-    fetch_user_by_id,
+    fetch_users_by_ids,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -585,9 +585,8 @@ def add_users_to_user_group(
     if db_user_group is None:
         raise ValueError(f"UserGroup with id '{user_group_id}' not found")
 
-    missing_users = [
-        user_id for user_id in user_ids if fetch_user_by_id(db_session, user_id) is None
-    ]
+    found_ids = {user.id for user in fetch_users_by_ids(db_session, user_ids)}
+    missing_users = [user_id for user_id in user_ids if user_id not in found_ids]
     if missing_users:
         raise ValueError(
             f"User(s) not found: {', '.join(str(user_id) for user_id in missing_users)}"
@@ -826,14 +825,11 @@ def update_user_group(
         )
 
     if added_user_ids:
-        added_users: list[User] = []
-        missing_users: list[UUID] = []
-        for user_id in added_user_ids:
-            added_user = fetch_user_by_id(db_session, user_id)
-            if added_user is None:
-                missing_users.append(user_id)
-            else:
-                added_users.append(added_user)
+        added_users = fetch_users_by_ids(db_session, added_user_ids)
+        found_ids = {added_user.id for added_user in added_users}
+        missing_users = [
+            user_id for user_id in added_user_ids if user_id not in found_ids
+        ]
         if missing_users:
             raise ValueError(
                 f"User(s) not found: {', '.join(str(user_id) for user_id in missing_users)}"

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -26,6 +26,7 @@ from onyx.db.connector_credential_pair import (
 )
 from onyx.db.enums import (
     AccessType,
+    AccountType,
     ConnectorCredentialPairStatus,
     GrantSource,
     Permission,
@@ -56,7 +57,11 @@ from onyx.db.permissions import (
     recompute_permissions_for_group__no_commit,
     recompute_user_permissions__no_commit,
 )
-from onyx.db.users import assert_admin_access_survives_removal, fetch_user_by_id
+from onyx.db.users import (
+    assert_admin_access_survives_removal,
+    assert_group_membership_survives_removal,
+    fetch_user_by_id,
+)
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.audit import (
@@ -68,6 +73,12 @@ from onyx.utils.audit import (
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+_NON_GROUP_ACCOUNT_TYPES = (
+    AccountType.BOT,
+    AccountType.EXT_PERM_USER,
+    AccountType.ANONYMOUS,
+)
 
 
 def _cleanup_user__user_group_relationships__no_commit(
@@ -639,6 +650,21 @@ def _assert_no_privilege_amplification(
         )
 
 
+def _assert_users_can_join_groups(added_users: list[User]) -> None:
+    """Only STANDARD and SERVICE_ACCOUNT enter the group system. The picker hides
+    the rest, but the route accepts any uuid."""
+    rejected = sorted(
+        f"{added_user.email} ({added_user.account_type.value})"
+        for added_user in added_users
+        if added_user.account_type in _NON_GROUP_ACCOUNT_TYPES
+    )
+    if rejected:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "These accounts can't join a group: " + ", ".join(rejected),
+        )
+
+
 def _assert_default_group_update_allowed(
     user: User,
     db_user_group: UserGroup,
@@ -784,6 +810,9 @@ def update_user_group(
     assert_admin_access_survives_removal(
         db_session, user, user_group_id, removed_user_ids
     )
+    assert_group_membership_survives_removal(
+        db_session, user_group_id, removed_user_ids
+    )
 
     # Removing yourself drops the membership row carrying is_manager, and
     # effective_permissions is derived from group grants — so leaving can revoke the very
@@ -797,15 +826,19 @@ def update_user_group(
         )
 
     if added_user_ids:
-        missing_users = [
-            user_id
-            for user_id in added_user_ids
-            if fetch_user_by_id(db_session, user_id) is None
-        ]
+        added_users: list[User] = []
+        missing_users: list[UUID] = []
+        for user_id in added_user_ids:
+            added_user = fetch_user_by_id(db_session, user_id)
+            if added_user is None:
+                missing_users.append(user_id)
+            else:
+                added_users.append(added_user)
         if missing_users:
             raise ValueError(
                 f"User(s) not found: {', '.join(str(user_id) for user_id in missing_users)}"
             )
+        _assert_users_can_join_groups(added_users)
 
     if removed_user_ids:
         _cleanup_user__user_group_relationships__no_commit(
@@ -922,6 +955,24 @@ def rename_user_group(
 
     db_session.commit()
     return db_user_group
+
+
+def assert_group_membership_survives_deletion(
+    db_session: Session, user_group_id: int
+) -> None:
+    """Deletion drops every membership, so the strand rule covers the whole roster.
+    Guards the route, not prepare_user_group_for_deletion — the sync task re-runs
+    that one, and raising there would wedge a scheduled deletion."""
+    member_ids: list[UUID] = [
+        user_id
+        for user_id in db_session.scalars(
+            select(User__UserGroup.user_id).where(
+                User__UserGroup.user_group_id == user_group_id
+            )
+        ).all()
+        if user_id is not None
+    ]
+    assert_group_membership_survives_removal(db_session, user_group_id, member_ids)
 
 
 def prepare_user_group_for_deletion(db_session: Session, user_group_id: int) -> None:

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -582,6 +582,8 @@ def add_users_to_user_group(
     # group exists, even on the early-return path below.
     assert_manages_group(user, db_session, group_id=user_group_id)
 
+    lock_group_membership(db_session)
+
     db_user_group = fetch_user_group(db_session=db_session, user_group_id=user_group_id)
     if db_user_group is None:
         raise ValueError(f"UserGroup with id '{user_group_id}' not found")
@@ -780,6 +782,10 @@ def update_user_group(
     # Gate before any read so a non-manager can't confirm the group exists; the
     # cc_pair scope check below needs the group row and runs after.
     assert_manages_group(user, db_session, group_id=user_group_id)
+
+    # Locked before the reads below, adds included: an add that lands after a
+    # deletion's roster snapshot is wiped by its cleanup without being checked.
+    lock_group_membership(db_session)
 
     stmt = select(UserGroup).where(UserGroup.id == user_group_id)
     db_user_group = db_session.scalar(stmt)

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -6,6 +6,7 @@ from ee.onyx.db.document_set import set_document_set_group_membership__no_commit
 from ee.onyx.db.persona import update_persona_access
 from ee.onyx.db.user_group import (
     add_users_to_user_group,
+    assert_group_membership_survives_deletion,
     fetch_user_group,
     fetch_user_groups,
     fetch_user_groups_for_user,
@@ -337,6 +338,7 @@ def delete_user_group(
     db_session: Session = Depends(get_session),
 ) -> None:
     assert_group_config_is_editable(db_session, user_group_id, "delete")
+    assert_group_membership_survives_deletion(db_session, user_group_id)
     try:
         prepare_user_group_for_deletion(db_session, user_group_id)
     except ValueError as e:

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -54,6 +54,7 @@ _MAX_LISTED_STRANDED_EMAILS = 3
 # tenant-hashed so tenants don't block each other and the id can't collide with
 # the other advisory locks in the codebase
 _ADMIN_MEMBERSHIP_LOCK_NAMESPACE = "onyx_admin_membership_lock"
+_GROUP_MEMBERSHIP_LOCK_NAMESPACE = "onyx_group_membership_lock"
 
 
 def is_limited_user(user: User) -> bool:
@@ -154,25 +155,20 @@ def another_admin_survives(
     return db_session.scalar(stmt) is not None
 
 
-def _admin_membership_lock_id(tenant_id: str) -> int:
-    digest = hashlib.sha256(
-        f"{_ADMIN_MEMBERSHIP_LOCK_NAMESPACE}:{tenant_id}".encode()
-    ).digest()
+def _tenant_lock_id(namespace: str, tenant_id: str) -> int:
+    digest = hashlib.sha256(f"{namespace}:{tenant_id}".encode()).digest()
     # pg_advisory_xact_lock takes a signed 8-byte int.
     return struct.unpack("q", digest[:8])[0]
 
 
-def _lock_admin_membership(db_session: Session) -> None:
-    """Serialize admin removals tenant-wide; released on the caller's commit.
-
-    Unlocked, two admins demoting each other concurrently each read the other as
-    the surviving admin and both commit, leaving zero. The caller must delete
-    inside the same transaction so check and write are one critical section."""
+def _take_tenant_lock(db_session: Session, namespace: str) -> None:
+    """Released on the caller's commit: the caller must write in the same transaction,
+    and take the admin lock first if it takes both."""
     # Bounded wait: a wedged holder should fail fast, not hang the request.
     db_session.execute(text("SET LOCAL lock_timeout = '10s'"))
     db_session.execute(
         text("SELECT pg_advisory_xact_lock(:lock_id)"),
-        {"lock_id": _admin_membership_lock_id(get_current_tenant_id())},
+        {"lock_id": _tenant_lock_id(namespace, get_current_tenant_id())},
     )
     db_session.execute(text("SET LOCAL lock_timeout = DEFAULT"))
 
@@ -195,7 +191,7 @@ def assert_admin_access_survives_removal(
             "You can't remove yourself from the admin group. Ask another admin to do it.",
         )
 
-    _lock_admin_membership(db_session)
+    _take_tenant_lock(db_session, _ADMIN_MEMBERSHIP_LOCK_NAMESPACE)
 
     if not another_admin_survives(db_session, group_id, removed_user_ids):
         raise OnyxError(
@@ -247,6 +243,8 @@ def assert_group_membership_survives_removal(
     from group grants, so they would keep a login that can do nothing."""
     if not removed_user_ids:
         return
+
+    _take_tenant_lock(db_session, _GROUP_MEMBERSHIP_LOCK_NAMESPACE)
 
     stranded_emails = _stranded_by_removal(db_session, group_id, removed_user_ids)
     if not stranded_emails:

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -667,6 +667,21 @@ def reconcile_user_email__no_commit(
     return old_email, prior_emails
 
 
+def fetch_users_by_ids(db_session: Session, user_ids: list[UUID]) -> list[User]:
+    """Missing ids are absent from the result; callers diff to name them."""
+    if not user_ids:
+        return []
+    return list(
+        db_session.scalars(
+            select(User).where(
+                User.id.in_(user_ids)  # ty: ignore[unresolved-attribute]
+            )
+        )
+        .unique()
+        .all()
+    )
+
+
 def fetch_user_by_id(
     db_session: Session, user_id: UUID, for_update: bool = False
 ) -> User | None:

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -234,6 +234,12 @@ def _stranded_by_removal(
     )
 
 
+def lock_group_membership(db_session: Session) -> None:
+    """Take before reading the rows a removal will delete: a roster read outside the
+    lock misses a concurrent add, and two removals each see the other survive."""
+    _take_tenant_lock(db_session, _GROUP_MEMBERSHIP_LOCK_NAMESPACE)
+
+
 def assert_group_membership_survives_removal(
     db_session: Session,
     group_id: int,
@@ -244,7 +250,7 @@ def assert_group_membership_survives_removal(
     if not removed_user_ids:
         return
 
-    _take_tenant_lock(db_session, _GROUP_MEMBERSHIP_LOCK_NAMESPACE)
+    lock_group_membership(db_session)
 
     stranded_emails = _stranded_by_removal(db_session, group_id, removed_user_ids)
     if not stranded_emails:

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -53,8 +53,7 @@ _MAX_LISTED_STRANDED_EMAILS = 3
 
 # tenant-hashed so tenants don't block each other and the id can't collide with
 # the other advisory locks in the codebase
-_ADMIN_MEMBERSHIP_LOCK_NAMESPACE = "onyx_admin_membership_lock"
-_GROUP_MEMBERSHIP_LOCK_NAMESPACE = "onyx_group_membership_lock"
+_MEMBERSHIP_LOCK_NAMESPACE = "onyx_membership_lock"
 
 
 def is_limited_user(user: User) -> bool:
@@ -155,20 +154,24 @@ def another_admin_survives(
     return db_session.scalar(stmt) is not None
 
 
-def _tenant_lock_id(namespace: str, tenant_id: str) -> int:
-    digest = hashlib.sha256(f"{namespace}:{tenant_id}".encode()).digest()
+def _membership_lock_id(tenant_id: str) -> int:
+    digest = hashlib.sha256(
+        f"{_MEMBERSHIP_LOCK_NAMESPACE}:{tenant_id}".encode()
+    ).digest()
     # pg_advisory_xact_lock takes a signed 8-byte int.
     return struct.unpack("q", digest[:8])[0]
 
 
-def _take_tenant_lock(db_session: Session, namespace: str) -> None:
-    """Released on the caller's commit: the caller must write in the same transaction,
-    and take the admin lock first if it takes both."""
+def lock_group_membership(db_session: Session) -> None:
+    """One lock for every membership write, admin access included, released on the
+    caller's commit. Take it before reading state the write depends on: a stale read
+    misses a concurrent add, and two removals each see the other survive. Splitting it
+    per class would only buy a lock order to get wrong."""
     # Bounded wait: a wedged holder should fail fast, not hang the request.
     db_session.execute(text("SET LOCAL lock_timeout = '10s'"))
     db_session.execute(
         text("SELECT pg_advisory_xact_lock(:lock_id)"),
-        {"lock_id": _tenant_lock_id(namespace, get_current_tenant_id())},
+        {"lock_id": _membership_lock_id(get_current_tenant_id())},
     )
     db_session.execute(text("SET LOCAL lock_timeout = DEFAULT"))
 
@@ -191,7 +194,7 @@ def assert_admin_access_survives_removal(
             "You can't remove yourself from the admin group. Ask another admin to do it.",
         )
 
-    _take_tenant_lock(db_session, _ADMIN_MEMBERSHIP_LOCK_NAMESPACE)
+    lock_group_membership(db_session)
 
     if not another_admin_survives(db_session, group_id, removed_user_ids):
         raise OnyxError(
@@ -232,12 +235,6 @@ def _stranded_by_removal(
             .order_by(email_col)
         ).all()
     )
-
-
-def lock_group_membership(db_session: Session) -> None:
-    """Take before reading membership state a write depends on: a stale read misses a
-    concurrent add, and two removals each see the other survive."""
-    _take_tenant_lock(db_session, _GROUP_MEMBERSHIP_LOCK_NAMESPACE)
 
 
 def assert_group_membership_survives_removal(

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -49,6 +49,8 @@ logger = setup_logger()
 DEFAULT_ADMIN_GROUP_NAME = "Admin"
 DEFAULT_BASIC_GROUP_NAME = "Basic"
 
+_MAX_LISTED_STRANDED_EMAILS = 3
+
 # tenant-hashed so tenants don't block each other and the id can't collide with
 # the other advisory locks in the codebase
 _ADMIN_MEMBERSHIP_LOCK_NAMESPACE = "onyx_admin_membership_lock"
@@ -202,6 +204,64 @@ def assert_admin_access_survives_removal(
         )
 
 
+def _stranded_by_removal(
+    db_session: Session, group_id: int, removed_user_ids: list[UUID]
+) -> list[str]:
+    """Emails of the standard users this removal would leave in no group."""
+    surviving_member_ids = set(
+        db_session.scalars(
+            select(User__UserGroup.user_id)
+            .join(UserGroup, UserGroup.id == User__UserGroup.user_group_id)
+            .where(
+                User__UserGroup.user_id.in_(removed_user_ids),
+                User__UserGroup.user_group_id != group_id,
+                UserGroup.is_up_for_deletion.is_(False),
+            )
+        ).all()
+    )
+    stranded_ids = [
+        user_id for user_id in removed_user_ids if user_id not in surviving_member_ids
+    ]
+    if not stranded_ids:
+        return []
+
+    email_col: KeyedColumnElement[Any] = User.__table__.c.email
+    return list(
+        db_session.scalars(
+            select(email_col)
+            .where(
+                User.id.in_(stranded_ids),  # ty: ignore[unresolved-attribute]
+                User.account_type == AccountType.STANDARD,
+            )
+            .order_by(email_col)
+        ).all()
+    )
+
+
+def assert_group_membership_survives_removal(
+    db_session: Session,
+    group_id: int,
+    removed_user_ids: list[UUID],
+) -> None:
+    """Blocks removals that leave a standard user in no group: permissions come only
+    from group grants, so they would keep a login that can do nothing."""
+    if not removed_user_ids:
+        return
+
+    stranded_emails = _stranded_by_removal(db_session, group_id, removed_user_ids)
+    if not stranded_emails:
+        return
+
+    listed = ", ".join(stranded_emails[:_MAX_LISTED_STRANDED_EMAILS])
+    remainder = len(stranded_emails) - _MAX_LISTED_STRANDED_EMAILS
+    if remainder > 0:
+        listed = f"{listed} and {remainder} more"
+    raise OnyxError(
+        OnyxErrorCode.INVALID_INPUT,
+        f"{listed} would be left without a group. Add them to another group first.",
+    )
+
+
 def fetch_default_group(db_session: Session, name: str) -> UserGroup:
     group = db_session.scalar(
         select(UserGroup).where(UserGroup.name == name, UserGroup.is_default.is_(True))
@@ -251,6 +311,9 @@ def set_user_admin_access(
             return
         assert_admin_access_survives_removal(
             db_session, actor, admin_group.id, [target.id]
+        )
+        assert_group_membership_survives_removal(
+            db_session, admin_group.id, [target.id]
         )
         db_session.delete(membership)
 

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -235,8 +235,8 @@ def _stranded_by_removal(
 
 
 def lock_group_membership(db_session: Session) -> None:
-    """Take before reading the rows a removal will delete: a roster read outside the
-    lock misses a concurrent add, and two removals each see the other survive."""
+    """Take before reading membership state a write depends on: a stale read misses a
+    concurrent add, and two removals each see the other survive."""
     _take_tenant_lock(db_session, _GROUP_MEMBERSHIP_LOCK_NAMESPACE)
 
 

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -394,6 +394,32 @@ def list_invited_users(
     return [InvitedUserSnapshot(email=email) for email in filtered_invited_emails]
 
 
+def _snapshots_with_groups(
+    db_session: Session, accepted: list[User], slack: list[User]
+) -> tuple[list[FullUserSnapshot], list[FullUserSnapshot]]:
+    """One membership lookup for both lists. Slack users are included because bot
+    memberships predating the join gate can still exist."""
+    groups_by_user = batch_get_user_groups(
+        db_session,
+        [user.id for user in (*accepted, *slack)],
+        include_default=True,
+    )
+
+    def to_snapshot(user: User) -> FullUserSnapshot:
+        return FullUserSnapshot.from_user_model(
+            user,
+            groups=[
+                UserGroupInfo(id=gid, name=gname)
+                for gid, gname in groups_by_user.get(user.id, [])
+            ],
+            is_admin=user_is_admin(user),
+        )
+
+    return [to_snapshot(user) for user in accepted], [
+        to_snapshot(user) for user in slack
+    ]
+
+
 @router.get("/manage/users", tags=PUBLIC_API_TAGS)
 def list_all_users(
     q: str | None = None,
@@ -437,21 +463,12 @@ def list_all_users(
 
     # If any of q, accepted_page, or invited_page is None, return all users
     if accepted_page is None or invited_page is None or slack_users_page is None:
+        accepted_snapshots, slack_snapshots = _snapshots_with_groups(
+            db_session, accepted_users, slack_users
+        )
         return AllUsersResponse(
-            accepted=[
-                FullUserSnapshot.from_user_model(
-                    user,
-                    is_admin=user_is_admin(user),
-                )
-                for user in accepted_users
-            ],
-            slack_users=[
-                FullUserSnapshot.from_user_model(
-                    user,
-                    is_admin=user_is_admin(user),
-                )
-                for user in slack_users
-            ],
+            accepted=accepted_snapshots,
+            slack_users=slack_snapshots,
             invited=[InvitedUserSnapshot(email=email) for email in invited_emails],
             accepted_pages=1,
             invited_pages=1,
@@ -460,20 +477,19 @@ def list_all_users(
 
     # Otherwise, return paginated results. Slice before building snapshots so
     # only the requested page is serialized.
+    accepted_snapshots, slack_snapshots = _snapshots_with_groups(
+        db_session,
+        accepted_users[
+            accepted_page * USERS_PAGE_SIZE : (accepted_page + 1) * USERS_PAGE_SIZE
+        ],
+        slack_users[
+            slack_users_page * USERS_PAGE_SIZE : (slack_users_page + 1)
+            * USERS_PAGE_SIZE
+        ],
+    )
     return AllUsersResponse(
-        accepted=[
-            FullUserSnapshot.from_user_model(user, is_admin=user_is_admin(user))
-            for user in accepted_users[
-                accepted_page * USERS_PAGE_SIZE : (accepted_page + 1) * USERS_PAGE_SIZE
-            ]
-        ],
-        slack_users=[
-            FullUserSnapshot.from_user_model(user, is_admin=user_is_admin(user))
-            for user in slack_users[
-                slack_users_page * USERS_PAGE_SIZE : (slack_users_page + 1)
-                * USERS_PAGE_SIZE
-            ]
-        ],
+        accepted=accepted_snapshots,
+        slack_users=slack_snapshots,
         invited=[
             InvitedUserSnapshot(email=email)
             for email in invited_emails[

--- a/backend/tests/integration/tests/usergroup/test_add_users_to_group.py
+++ b/backend/tests/integration/tests/usergroup/test_add_users_to_group.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 import pytest
 
+from onyx.db.enums import AccountType
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.user import UserManager
@@ -64,3 +65,47 @@ def test_add_users_to_group_invalid_user(admin_user: DATestUser) -> None:
 
     assert response.status_code == 404
     assert "not found" in response.text.lower()
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="User group tests are enterprise only",
+)
+def test_add_users_to_group_rejects_non_group_account(admin_user: DATestUser) -> None:
+    """The picker hides bots; the route took any uuid."""
+    bot_email = f"bot-{uuid4()}@example.com"
+    UserManager.seed_non_web_user(AccountType.BOT, bot_email)
+    bot = next(
+        user
+        for user in UserManager.get_user_page(
+            user_performing_action=admin_user,
+            account_types=[AccountType.BOT],
+            page_size=100,
+        ).items
+        if user.email == bot_email
+    )
+
+    user_group: DATestUserGroup = UserGroupManager.create(
+        name="add-bot-test-group",
+        user_ids=[admin_user.id],
+        user_performing_action=admin_user,
+    )
+    UserGroupManager.wait_for_sync(
+        user_performing_action=admin_user, user_groups_to_check=[user_group]
+    )
+
+    response = client.post(
+        f"{API_SERVER_URL}/manage/admin/user-group/{user_group.id}/add-users",
+        json={"user_ids": [str(bot.id)]},
+        headers=admin_user.headers,
+    )
+
+    assert response.status_code == 400, response.text
+    assert bot_email in response.text
+
+    members = next(
+        fetched
+        for fetched in UserGroupManager.get_all(user_performing_action=admin_user)
+        if fetched.id == user_group.id
+    ).users
+    assert str(bot.id) not in {str(member.id) for member in members}

--- a/backend/tests/integration/tests/usergroup/test_group_membership_updates_user_permissions.py
+++ b/backend/tests/integration/tests/usergroup/test_group_membership_updates_user_permissions.py
@@ -1,5 +1,6 @@
 import os
 
+import httpx
 import pytest
 from sqlalchemy import update
 
@@ -11,10 +12,12 @@ from onyx.db.permissions import (
     recompute_permissions_for_group__no_commit,
     recompute_user_permissions__no_commit,
 )
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.managers.user_group import UserGroupManager
 from tests.integration.common_utils.permission_state import is_group_manager
-from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.common_utils.test_models import DATestUser, DATestUserGroup
 
 
 def _set_membership_is_manager(user_id: str, group_id: int, value: bool) -> None:
@@ -34,6 +37,16 @@ def _set_membership_is_manager(user_id: str, group_id: int, value: bool) -> None
         db_session.flush()
         recompute_user_permissions__no_commit(user_id, db_session)
         db_session.commit()
+
+
+def _set_members(
+    group_id: int, user_ids: list[str], admin_user: DATestUser
+) -> httpx.Response:
+    return client.patch(
+        f"{API_SERVER_URL}/manage/admin/user-group/{group_id}",
+        json={"user_ids": user_ids, "cc_pair_ids": []},
+        headers=admin_user.headers,
+    )
 
 
 @pytest.mark.skipif(
@@ -189,3 +202,101 @@ def test_is_group_manager_true_when_managing_any_group(
 
     _set_membership_is_manager(member.id, managed_group.id, False)
     assert is_group_manager(member.id) is False
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="User group tests are enterprise only",
+)
+def test_removing_a_users_last_group_is_rejected(admin_user: DATestUser) -> None:
+    """A new user starts in Basic, so that membership has to go first."""
+    member: DATestUser = UserManager.create()
+    group: DATestUserGroup = UserGroupManager.create(
+        name="last-group",
+        user_ids=[member.id],
+        user_performing_action=admin_user,
+    )
+    UserGroupManager.wait_for_sync(
+        user_performing_action=admin_user, user_groups_to_check=[group]
+    )
+
+    basic = UserGroupManager.get_default(
+        user_performing_action=admin_user, name="Basic"
+    )
+    response = _set_members(
+        basic.id,
+        [other.id for other in basic.users if other.id != member.id],
+        admin_user,
+    )
+    assert response.status_code == 200, response.text
+
+    # the new group is now their only one
+    response = _set_members(group.id, [], admin_user)
+    assert response.status_code == 400, response.text
+    assert member.email in response.text
+
+    still_a_member = next(
+        fetched
+        for fetched in UserGroupManager.get_all(user_performing_action=admin_user)
+        if fetched.id == group.id
+    ).users
+    assert member.id in {user.id for user in still_a_member}
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="User group tests are enterprise only",
+)
+def test_removal_allowed_while_another_group_survives(admin_user: DATestUser) -> None:
+    member: DATestUser = UserManager.create()
+    group: DATestUserGroup = UserGroupManager.create(
+        name="two-groups",
+        user_ids=[member.id],
+        user_performing_action=admin_user,
+    )
+    UserGroupManager.wait_for_sync(
+        user_performing_action=admin_user, user_groups_to_check=[group]
+    )
+
+    # basic still holds the member, so this group can let them go
+    response = _set_members(group.id, [], admin_user)
+    assert response.status_code == 200, response.text
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="User group tests are enterprise only",
+)
+def test_deleting_a_users_last_group_is_rejected(admin_user: DATestUser) -> None:
+    """Deletion drops every membership at once, so it answers to the same rule."""
+    member: DATestUser = UserManager.create()
+    group: DATestUserGroup = UserGroupManager.create(
+        name="last-group-delete",
+        user_ids=[member.id],
+        user_performing_action=admin_user,
+    )
+    UserGroupManager.wait_for_sync(
+        user_performing_action=admin_user, user_groups_to_check=[group]
+    )
+
+    basic = UserGroupManager.get_default(
+        user_performing_action=admin_user, name="Basic"
+    )
+    response = _set_members(
+        basic.id,
+        [other.id for other in basic.users if other.id != member.id],
+        admin_user,
+    )
+    assert response.status_code == 200, response.text
+
+    response = client.delete(
+        f"{API_SERVER_URL}/manage/admin/user-group/{group.id}",
+        headers=admin_user.headers,
+    )
+    assert response.status_code == 400, response.text
+    assert member.email in response.text
+
+    assert group.id in {
+        fetched.id
+        for fetched in UserGroupManager.get_all(user_performing_action=admin_user)
+    }

--- a/backend/tests/unit/ee/onyx/db/test_user_group_audit.py
+++ b/backend/tests/unit/ee/onyx/db/test_user_group_audit.py
@@ -41,7 +41,17 @@ def _make_db_session(
 
 @patch("ee.onyx.db.user_group.recompute_user_permissions__no_commit")
 @patch("ee.onyx.db.user_group._add_user__user_group_relationships__no_commit")
-@patch("ee.onyx.db.user_group.fetch_user_by_id", return_value=MagicMock())
+@patch(
+    "ee.onyx.db.user_group.fetch_users_by_ids",
+    side_effect=lambda _db_session, user_ids: [
+        MagicMock(
+            id=user_id,
+            email=f"{user_id}@example.com",
+            account_type=AccountType.STANDARD,
+        )
+        for user_id in user_ids
+    ],
+)
 @patch("ee.onyx.db.user_group._check_user_group_is_modifiable")
 def test_update_user_group_emits_on_membership_change(
     _modifiable: MagicMock,

--- a/web/src/views/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/EditGroupPage.tsx
@@ -30,6 +30,7 @@ import { InputTypeIn } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
 import { ConfirmationModalLayout } from "@opal/layouts";
 import { errorHandlingFetcher, skipRetryOnAuthError } from "@/lib/fetcher";
+import { AccountType } from "@/lib/types";
 import type { SecuritySettings, UserGroup } from "@/lib/types";
 import { useUser } from "@/providers/UserProvider";
 import { useSettings } from "@/lib/settings/hooks";
@@ -261,6 +262,15 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     [currentUserId, managerIds, pendingManagerIds]
   );
 
+  // Mirrors the backend guard. Persisted only — dropping an unsaved add strands nobody.
+  const isLastGroupMember = useCallback(
+    (row: MemberRow) =>
+      row.account_type === AccountType.STANDARD &&
+      persistedMemberIds.has(row.id ?? row.email) &&
+      row.groups.length <= 1,
+    [persistedMemberIds]
+  );
+
   // Hits its endpoint immediately (member add/remove defers to Save), then revalidates.
   const handleToggleManager = useCallback(
     async (userId: string, makeManager: boolean) => {
@@ -298,6 +308,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
           const isPersisted = persistedMemberIds.has(userId);
           const isPending = pendingManagerIds.has(userId);
           const isOwnManager = isOwnManagerRow(userId);
+          const isLastGroup = isLastGroupMember(row);
           return (
             <div className="flex items-center gap-1">
               {canManage && (
@@ -325,12 +336,14 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
               <IconButton
                 icon={SvgMinusCircle}
                 tertiary
-                disabled={isOwnManager}
+                disabled={isOwnManager || isLastGroup}
                 aria-label="Remove member"
                 tooltip={
                   isOwnManager
                     ? "You can't remove yourself while managing this group"
-                    : undefined
+                    : isLastGroup
+                      ? "This is their only group. Add them to another group first."
+                      : undefined
                 }
                 onClick={(e) => {
                   e.stopPropagation();
@@ -345,6 +358,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     [
       handleRemoveMember,
       handleToggleManager,
+      isLastGroupMember,
       isOwnManagerRow,
       managerIds,
       persistedMemberIds,
@@ -379,9 +393,31 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
         setSelectedUserIds([currentUserId, ...ids, ...hiddenMemberIds]);
         return;
       }
+      // Same rule as the remove button; add mode can't disable a checkbox, so re-select.
+      const kept = new Set(ids);
+      const strandedIds = allRows
+        .filter(
+          (row) => !kept.has(row.id ?? row.email) && isLastGroupMember(row)
+        )
+        .map((row) => row.id ?? row.email);
+      if (strandedIds.length > 0) {
+        toast.error(
+          "Some of those members would be left without a group. Add them to another group first."
+        );
+        setSelectedUserIds([...strandedIds, ...ids, ...hiddenMemberIds]);
+        return;
+      }
+
       setSelectedUserIds([...ids, ...hiddenMemberIds]);
     },
-    [initialized, hiddenMemberIds, currentUserId, isOwnManagerRow]
+    [
+      initialized,
+      hiddenMemberIds,
+      currentUserId,
+      isOwnManagerRow,
+      isLastGroupMember,
+      allRows,
+    ]
   );
 
   async function handleSave() {

--- a/web/src/views/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/EditGroupPage.tsx
@@ -399,10 +399,16 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
       }
 
       // Same rule as the remove button; add mode can't disable a checkbox, so re-select.
+      // Rows already forced above are skipped, so one row never raises two toasts.
       const strandedIds = allRows
-        .filter(
-          (row) => !kept.has(row.id ?? row.email) && isLastGroupMember(row)
-        )
+        .filter((row) => {
+          const rowId = row.id ?? row.email;
+          return (
+            !kept.has(rowId) &&
+            !forcedIds.includes(rowId) &&
+            isLastGroupMember(row)
+          );
+        })
         .map((row) => row.id ?? row.email);
       if (strandedIds.length > 0) {
         toast.error(
@@ -411,10 +417,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
         forcedIds.push(...strandedIds);
       }
 
-      // Deduped: a manager whose only group is this one satisfies both rules.
-      setSelectedUserIds(
-        Array.from(new Set([...forcedIds, ...ids, ...hiddenMemberIds]))
-      );
+      setSelectedUserIds([...forcedIds, ...ids, ...hiddenMemberIds]);
     },
     [
       initialized,

--- a/web/src/views/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/EditGroupPage.tsx
@@ -382,19 +382,23 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
   const handleSelectionChange = useCallback(
     (ids: string[]) => {
       if (!initialized) return;
+      const kept = new Set(ids);
+      // Both rules run: one deselection can strip your own row and a last-group
+      // member at once, and returning after the first leaves the other removed.
+      const forcedIds: string[] = [];
+
       // Add mode can deselect your own row, which the member list disables — it would
       // drop the membership carrying your manager role. The backend rejects it too.
       if (
         currentUserId &&
         isOwnManagerRow(currentUserId) &&
-        !ids.includes(currentUserId)
+        !kept.has(currentUserId)
       ) {
         toast.error("You can't remove yourself while managing this group");
-        setSelectedUserIds([currentUserId, ...ids, ...hiddenMemberIds]);
-        return;
+        forcedIds.push(currentUserId);
       }
+
       // Same rule as the remove button; add mode can't disable a checkbox, so re-select.
-      const kept = new Set(ids);
       const strandedIds = allRows
         .filter(
           (row) => !kept.has(row.id ?? row.email) && isLastGroupMember(row)
@@ -404,11 +408,13 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
         toast.error(
           "Some of those members would be left without a group. Add them to another group first."
         );
-        setSelectedUserIds([...strandedIds, ...ids, ...hiddenMemberIds]);
-        return;
+        forcedIds.push(...strandedIds);
       }
 
-      setSelectedUserIds([...ids, ...hiddenMemberIds]);
+      // Deduped: a manager whose only group is this one satisfies both rules.
+      setSelectedUserIds(
+        Array.from(new Set([...forcedIds, ...ids, ...hiddenMemberIds]))
+      );
     },
     [
       initialized,


### PR DESCRIPTION
## Description

- A standard user can no longer be removed from their last group. Permissions come only from group grants, so the removal left a login that could do nothing.
- The rule covers every path that drops a membership on purpose: the group editor, the **Edit user → groups** modal, the admin-access toggle, and group deletion.
- Bot, external-permission and anonymous accounts are refused when added to a group. The member picker already hid them, but the route accepted any user id.
- `GET /manage/users` now returns each user's groups. It always returned an empty list, so the member picker could not tell how many groups a user held.
- In the group editor the remove button is disabled with a reason, and add-mode deselection is refused, mirroring the backend rule.

## How Has This Been Tested?

Manually verified in the admin UI. Integration tests added to `tests/usergroup` for the blocked removal, the allowed removal, the blocked deletion, and the refused bot. Backend unit suite and lint pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
