### PR TITLE
chore(tracing): migrate the Langfuse client to v4

### DIFF
--- a/backend/onyx/tracing/dynamic_processor.py
+++ b/backend/onyx/tracing/dynamic_processor.py
@@ -60,17 +60,19 @@ def _build_langfuse_processor(config: LangfuseConfig) -> TracingProcessor:
     from onyx import __version__
     from onyx.tracing.langfuse_tracing_processor import LangfuseTracingProcessor
 
-    # The Langfuse SDK reads LANGFUSE_HOST from the env in some paths; keep it in
-    # sync (and cleared when no host is configured) to avoid a stale value.
-    if config.host:
-        os.environ["LANGFUSE_HOST"] = config.host
-    else:
-        os.environ.pop("LANGFUSE_HOST", None)
+    # The SDK resolves the URL as base_url -> LANGFUSE_BASE_URL -> host ->
+    # LANGFUSE_HOST. Pass base_url and keep both env names in sync (cleared when
+    # no host is configured) so a stale env value cannot override the config.
+    for env_name in ("LANGFUSE_BASE_URL", "LANGFUSE_HOST"):
+        if config.host:
+            os.environ[env_name] = config.host
+        else:
+            os.environ.pop(env_name, None)
 
     client = Langfuse(
         public_key=config.public_key,
         secret_key=config.secret_key,
-        host=config.host or None,
+        base_url=config.host or None,
         release=__version__,
     )
     return LangfuseTracingProcessor(client=client)

--- a/backend/onyx/tracing/langfuse_tracing_processor.py
+++ b/backend/onyx/tracing/langfuse_tracing_processor.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import logging
 import threading
+from contextlib import AbstractContextManager, nullcontext
 from datetime import datetime
 from typing import Any, Optional, Union
 
-from langfuse import Langfuse
+from langfuse import Langfuse, propagate_attributes
 from langfuse._client.span import LangfuseObservationWrapper
 
 from onyx.tracing.flows import IMAGE_FLOWS
@@ -58,6 +59,9 @@ class LangfuseTracingProcessor(TracingProcessor):
         self._first_input: dict[str, Any] = {}
         self._last_output: dict[str, Any] = {}
         self._trace_metadata: dict[str, dict[str, Any]] = {}
+        # Correlating attributes (user, session, trace name) re-applied to every
+        # observation. See _propagated().
+        self._trace_attributes: dict[str, dict[str, Any]] = {}
         # Langfuse IDs for thread-safe parent linking via trace_context
         self._langfuse_trace_ids: dict[
             str, str
@@ -75,6 +79,36 @@ class LangfuseTracingProcessor(TracingProcessor):
 
             self._client = get_client()
         return self._client
+
+    @staticmethod
+    def _build_trace_attributes(name: str, metadata: dict[str, Any]) -> dict[str, Any]:
+        """Build the correlating attributes for a trace.
+
+        Session and user are promoted out of metadata so they reach the dedicated
+        Langfuse facets, not just the metadata blob.
+        """
+        session_id = metadata.get("chat_session_id")
+        user_id = metadata.get("user_id")
+        attributes: dict[str, Any] = {"trace_name": name}
+        if session_id:
+            attributes["session_id"] = str(session_id)
+        if user_id:
+            attributes["user_id"] = str(user_id)
+        if metadata:
+            attributes["metadata"] = metadata
+        return attributes
+
+    @staticmethod
+    def _propagated(attributes: dict[str, Any] | None) -> AbstractContextManager[Any]:
+        """Apply a trace's correlating attributes to the observation created inside.
+
+        Re-applied per observation, not held open for the trace: Onyx links
+        observations by explicit id across threads, so an enclosing context would
+        not reach them.
+        """
+        if not attributes:
+            return nullcontext()
+        return propagate_attributes(**attributes)
 
     def _mask_if_enabled(self, data: Any) -> Any:
         """Apply masking to data if masking is enabled."""
@@ -138,26 +172,17 @@ class LangfuseTracingProcessor(TracingProcessor):
             trace_meta = trace.export() or {}
             metadata = trace_meta.get("metadata") or {}
 
-            # Create a root span which implicitly creates a Langfuse trace
-            # The span name becomes the trace name in Langfuse UI
-            # In Langfuse SDK v3, use start_observation instead of start_span
-            langfuse_span = client.start_observation(
-                name=trace.name,
-            )
+            trace_attributes = self._build_trace_attributes(trace.name, metadata)
 
-            # Promote first-class Langfuse fields out of metadata so they
-            # populate the dedicated UI facets (Sessions, Users) rather than
-            # only the metadata JSON blob.
-            session_id = metadata.get("chat_session_id")
-            user_id = metadata.get("user_id")
-            langfuse_span.update_trace(
-                name=trace.name,
-                session_id=session_id if session_id else None,
-                user_id=str(user_id) if user_id else None,
-                metadata=metadata if metadata else None,
-            )
+            # Create a root span which implicitly creates a Langfuse trace.
+            # The span name becomes the trace name in Langfuse UI.
+            with self._propagated(trace_attributes):
+                langfuse_span = client.start_observation(
+                    name=trace.name,
+                )
 
             with self._lock:
+                self._trace_attributes[trace.trace_id] = trace_attributes
                 if metadata:
                     self._trace_metadata[trace.trace_id] = metadata
                 self._trace_spans[trace.trace_id] = langfuse_span
@@ -178,6 +203,7 @@ class LangfuseTracingProcessor(TracingProcessor):
             with self._lock:
                 langfuse_span = self._trace_spans.pop(trace.trace_id, None)
                 self._trace_metadata.pop(trace.trace_id, None)
+                self._trace_attributes.pop(trace.trace_id, None)
                 self._langfuse_trace_ids.pop(trace.trace_id, None)  # Clean up trace ID
                 self._langfuse_span_ids.pop(
                     trace.trace_id, None
@@ -214,6 +240,7 @@ class LangfuseTracingProcessor(TracingProcessor):
             # Get Langfuse IDs and metadata under lock for thread-safe access
             with self._lock:
                 trace_metadata = self._trace_metadata.get(span.trace_id)
+                trace_attributes = self._trace_attributes.get(span.trace_id)
                 langfuse_trace_id = self._langfuse_trace_ids.get(span.trace_id)
                 # Get parent's Langfuse span ID
                 if span.parent_id is not None:
@@ -229,11 +256,11 @@ class LangfuseTracingProcessor(TracingProcessor):
                     span.span_id,
                 )
                 # Fall back to creating an orphan span
-                # In Langfuse SDK v3, use start_observation instead of start_span
                 client = self._get_client()
-                langfuse_span = client.start_observation(
-                    name=data.type if hasattr(data, "type") else "unknown",
-                )
+                with self._propagated(trace_attributes):
+                    langfuse_span = client.start_observation(
+                        name=data.type if hasattr(data, "type") else "unknown",
+                    )
                 with self._lock:
                     self._spans[span.span_id] = langfuse_span
                     self._langfuse_span_ids[span.span_id] = langfuse_span.id
@@ -249,42 +276,42 @@ class LangfuseTracingProcessor(TracingProcessor):
                 trace_context["parent_span_id"] = parent_langfuse_id
 
             # Create spans using trace_context (thread-safe ID-based approach)
-            # In Langfuse SDK v3, use start_observation with as_type parameter
-            if isinstance(data, GenerationSpanData):
-                langfuse_span = client.start_observation(  # ty: ignore[no-matching-overload]
-                    trace_context=trace_context,
-                    name=self._get_generation_name(data),
-                    as_type="generation",
-                    metadata=trace_metadata,
-                    model=data.model,
-                    model_parameters=self._get_model_parameters(data),
-                )
-            elif isinstance(data, FunctionSpanData):
-                langfuse_span = client.start_observation(
-                    trace_context=trace_context,
-                    name=data.name,
-                    as_type="tool",
-                    metadata=trace_metadata,
-                )
-            elif isinstance(data, AgentSpanData):
-                langfuse_span = client.start_observation(
-                    trace_context=trace_context,
-                    name=data.name,
-                    as_type="agent",
-                    metadata={
-                        **(trace_metadata or {}),
-                        "tools": data.tools,
-                        "handoffs": data.handoffs,
-                        "output_type": data.output_type,
-                    },
-                )
-            else:
-                langfuse_span = client.start_observation(
-                    trace_context=trace_context,
-                    name=data.type if hasattr(data, "type") else "unknown",
-                    as_type="span",
-                    metadata=trace_metadata,
-                )
+            with self._propagated(trace_attributes):
+                if isinstance(data, GenerationSpanData):
+                    langfuse_span = client.start_observation(  # ty: ignore[no-matching-overload]
+                        trace_context=trace_context,
+                        name=self._get_generation_name(data),
+                        as_type="generation",
+                        metadata=trace_metadata,
+                        model=data.model,
+                        model_parameters=self._get_model_parameters(data),
+                    )
+                elif isinstance(data, FunctionSpanData):
+                    langfuse_span = client.start_observation(
+                        trace_context=trace_context,
+                        name=data.name,
+                        as_type="tool",
+                        metadata=trace_metadata,
+                    )
+                elif isinstance(data, AgentSpanData):
+                    langfuse_span = client.start_observation(
+                        trace_context=trace_context,
+                        name=data.name,
+                        as_type="agent",
+                        metadata={
+                            **(trace_metadata or {}),
+                            "tools": data.tools,
+                            "handoffs": data.handoffs,
+                            "output_type": data.output_type,
+                        },
+                    )
+                else:
+                    langfuse_span = client.start_observation(
+                        trace_context=trace_context,
+                        name=data.type if hasattr(data, "type") else "unknown",
+                        as_type="span",
+                        metadata=trace_metadata,
+                    )
 
             with self._lock:
                 self._spans[span.span_id] = langfuse_span

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -1353,9 +1353,9 @@ langchain-protocol==0.0.15 \
 langdetect==1.0.9 \
     --hash=sha256:cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0
     # via unstructured
-langfuse==3.10.0 \
-    --hash=sha256:7a9254103da50cabcf46a7e7ae9d2cf1f8267f09b6036abdb4a9c6f2f3d15104 \
-    --hash=sha256:c7c10607c6fe560990d0973566afd3c5513f7ff97cc31691af72711ad5441d8c
+langfuse==4.14.4 \
+    --hash=sha256:48c4bdefc290f61a42881b8048a904ab6b81d37e02496473166836e71ee0ab3a \
+    --hash=sha256:78692a1d4785a8c255bf6ea967e673e1ee30ce078d646e7b5f7ff44549d45cce
 langsmith==0.8.18 \
     --hash=sha256:32dde9c0e67e053e0fb738921fc8ced768af7b8fa83d7a0e3fd63597cf8776dd \
     --hash=sha256:3940183349993faef48e6c7d08e4822ee9cefd906b362d0e3c2d650314d2f282
@@ -1815,7 +1815,6 @@ openai==2.38.0 \
     --hash=sha256:ec6661c57b2dcc47414a767e6e3335c7ed3d19c9696999283a3c82e95c756a3c
     # via
     #   exa-py
-    #   langfuse
     #   litellm
     #   onyx
 openapi-pydantic==0.5.1 \
@@ -2697,7 +2696,6 @@ requests==2.33.0 \
     #   hubspot-api-client
     #   jira
     #   kubernetes
-    #   langfuse
     #   langsmith
     #   markitdown
     #   matrix-client

--- a/backend/tests/unit/onyx/tracing/test_langfuse_tracing_processor.py
+++ b/backend/tests/unit/onyx/tracing/test_langfuse_tracing_processor.py
@@ -1,8 +1,9 @@
 """Unit tests for LangfuseTracingProcessor metadata handling."""
 
 from collections.abc import Mapping
+from contextlib import nullcontext
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -27,11 +28,20 @@ def _make_client_with_observation() -> tuple[MagicMock, MagicMock]:
     return client, observation
 
 
+def _make_span(trace_id: str, span_id: str) -> MagicMock:
+    span = MagicMock()
+    span.trace_id = trace_id
+    span.span_id = span_id
+    span.parent_id = None
+    span.span_data = GenerationSpanData(model="gpt-4")
+    return span
+
+
 def test_on_trace_start_promotes_user_id_and_session_id() -> None:
-    """user_id and chat_session_id in metadata must be passed as first-class
-    fields on update_trace so Langfuse populates the Users and Sessions views.
+    """user_id and chat_session_id must ride on the observation as first-class
+    correlating attributes so Langfuse populates the Users and Sessions views.
     """
-    client, observation = _make_client_with_observation()
+    client, _ = _make_client_with_observation()
     processor = LangfuseTracingProcessor(client=client)
 
     metadata = {
@@ -39,39 +49,70 @@ def test_on_trace_start_promotes_user_id_and_session_id() -> None:
         "chat_session_id": "session-xyz",
         "user_id": "user-42",
     }
-    processor.on_trace_start(_make_trace(metadata))
+    with patch(
+        "onyx.tracing.langfuse_tracing_processor.propagate_attributes"
+    ) as propagate:
+        propagate.return_value = nullcontext()
+        processor.on_trace_start(_make_trace(metadata))
 
-    observation.update_trace.assert_called_once()
-    kwargs = observation.update_trace.call_args.kwargs
+    propagate.assert_called_once()
+    kwargs = propagate.call_args.kwargs
     assert kwargs["user_id"] == "user-42"
     assert kwargs["session_id"] == "session-xyz"
-    assert kwargs["name"] == "run_llm_loop"
+    assert kwargs["trace_name"] == "run_llm_loop"
     assert kwargs["metadata"] == metadata
 
 
-def test_on_trace_start_user_id_missing_passes_none() -> None:
-    """Anonymous / unattributed traces still update successfully with user_id=None."""
-    client, observation = _make_client_with_observation()
+def test_on_trace_start_omits_missing_user_id() -> None:
+    """Anonymous / unattributed traces still start, just without a user."""
+    client, _ = _make_client_with_observation()
     processor = LangfuseTracingProcessor(client=client)
 
     metadata = {"tenant_id": "tenant-abc", "chat_session_id": "session-xyz"}
-    processor.on_trace_start(_make_trace(metadata))
+    with patch(
+        "onyx.tracing.langfuse_tracing_processor.propagate_attributes"
+    ) as propagate:
+        propagate.return_value = nullcontext()
+        processor.on_trace_start(_make_trace(metadata))
 
-    kwargs = observation.update_trace.call_args.kwargs
-    assert kwargs["user_id"] is None
+    kwargs = propagate.call_args.kwargs
+    assert "user_id" not in kwargs
     assert kwargs["session_id"] == "session-xyz"
 
 
 def test_on_trace_start_coerces_non_string_user_id() -> None:
     """User ids that arrive as ints (e.g. from User.id) are coerced to strings."""
-    client, observation = _make_client_with_observation()
+    client, _ = _make_client_with_observation()
     processor = LangfuseTracingProcessor(client=client)
 
     metadata = {"chat_session_id": "session-xyz", "user_id": 7}
-    processor.on_trace_start(_make_trace(metadata))
+    with patch(
+        "onyx.tracing.langfuse_tracing_processor.propagate_attributes"
+    ) as propagate:
+        propagate.return_value = nullcontext()
+        processor.on_trace_start(_make_trace(metadata))
 
-    kwargs = observation.update_trace.call_args.kwargs
-    assert kwargs["user_id"] == "7"
+    assert propagate.call_args.kwargs["user_id"] == "7"
+
+
+def test_child_spans_repeat_the_trace_attributes() -> None:
+    """Correlating attributes only reach observations created inside the
+    propagation block, so every child observation must re-apply them.
+    """
+    client, _ = _make_client_with_observation()
+    processor = LangfuseTracingProcessor(client=client)
+
+    metadata = {"chat_session_id": "session-xyz", "user_id": "user-42"}
+    with patch(
+        "onyx.tracing.langfuse_tracing_processor.propagate_attributes"
+    ) as propagate:
+        propagate.return_value = nullcontext()
+        processor.on_trace_start(_make_trace(metadata))
+        processor.on_span_start(_make_span("trace-123", "span-1"))
+
+    assert propagate.call_count == 2
+    assert propagate.call_args.kwargs["session_id"] == "session-xyz"
+    assert propagate.call_args.kwargs["user_id"] == "user-42"
 
 
 def test_calculate_cost_prices_cache_creation_at_write_rate() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ backend = [
     "sendgrid==6.12.5",
     "exa_py==1.15.4",
     "braintrust==0.3.9",
-    "langfuse==3.10.0",
+    "langfuse==4.14.4",
     "nest_asyncio==1.6.0",
     "openinference-instrumentation==0.1.42",
     "opentelemetry-proto>=1.42.1",

--- a/uv.lock
+++ b/uv.lock
@@ -3157,23 +3157,21 @@ sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2
 
 [[package]]
 name = "langfuse"
-version = "3.10.0"
+version = "4.14.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
     { name = "httpx" },
-    { name = "openai" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "packaging" },
     { name = "pydantic" },
-    { name = "requests" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/97/bacdac633511a1c9895d9e3b1720c3d008a0f5d7d5c0e058d8cf79040773/langfuse-3.10.0.tar.gz", hash = "sha256:7a9254103da50cabcf46a7e7ae9d2cf1f8267f09b6036abdb4a9c6f2f3d15104", size = 220516, upload-time = "2025-11-14T12:15:56.839Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/3f/d3387db1f472d2fd4b5de40eb6abedc2f59c9da2224e9d0a79d054a90b81/langfuse-4.14.4.tar.gz", hash = "sha256:48c4bdefc290f61a42881b8048a904ab6b81d37e02496473166836e71ee0ab3a", size = 389680, upload-time = "2026-08-11T17:03:20.472Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/05/343e8fa3e5d48035422e1385105aeb986130d3de3264ec732c890dab2d16/langfuse-3.10.0-py3-none-any.whl", hash = "sha256:c7c10607c6fe560990d0973566afd3c5513f7ff97cc31691af72711ad5441d8c", size = 390745, upload-time = "2025-11-14T12:15:54.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/1b/a198adc52aa4ffd0886ca0d4e9bb97d45f4f326db206d2395bac67677f5d/langfuse-4.14.4-py3-none-any.whl", hash = "sha256:78692a1d4785a8c255bf6ea967e673e1ee30ce078d646e7b5f7ff44549d45cce", size = 688351, upload-time = "2026-08-11T17:03:21.881Z" },
 ]
 
 [[package]]
@@ -4100,7 +4098,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -4111,7 +4109,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -4138,9 +4136,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -4151,7 +4149,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -4489,7 +4487,7 @@ backend = [
     { name = "jira", specifier = "==3.10.5" },
     { name = "kubernetes", specifier = "==31.0.0" },
     { name = "langchain-core", specifier = "==1.3.3" },
-    { name = "langfuse", specifier = "==3.10.0" },
+    { name = "langfuse", specifier = "==4.14.4" },
     { name = "libpass", specifier = "==1.9.3" },
     { name = "lxml", specifier = "==6.1.1" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx", "xls"], specifier = "==0.1.2" },
@@ -4948,7 +4946,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -6597,8 +6595,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Description

Upgrades the Langfuse SDK from 3.10.0 to 4.14.4 and migrates our tracing processor to the v4 API.

This is not a version bump. Langfuse v4 removes `observation.update_trace()`, which is the only
call we used to attach the trace name, session id, user id and metadata. Bumping the pin alone
does not fail loudly — `on_trace_start` catches the resulting `AttributeError` *after* creating
the root observation but *before* recording it in `_trace_spans` / `_langfuse_trace_ids`. Every
later span then fails its parent lookup and is emitted as an orphan. The result is tracing that
still appears to run while producing unusable data:

| | observations | trace ids | session + user |
|---|---|---|---|
| v4 SDK, before this change | 2 (root lost) | 2 — tree broken | 0 |
| v4 SDK, after this change | 3 | 1 — tree intact | 3 |

v4 replaces the trace-level fields with correlating attributes carried on each observation.
`propagate_attributes` sets them, but it only reaches observations created inside its block, and
we link observations by explicit id so research agents can run in parallel threads. A single
enclosing context therefore would not reach them. Each observation re-applies the attributes as
it is created, which also puts session and user on cost-bearing children — what the v4
aggregation queries need.

Second fix in the same area: the client now passes `base_url` rather than `host`. v4 resolves the
server URL as `base_url` → `LANGFUSE_BASE_URL` → `host` → `LANGFUSE_HOST`, so a stale
`LANGFUSE_BASE_URL` in the environment would silently override the host an admin sets in the
panel. Both environment names are now kept in sync, and cleared when no host is configured.

The bump is isolated. Every langfuse 4.x requirement was already satisfied by our existing pins,
so the lock moved langfuse and nothing else.

Checked and needing no change: we never call `client.api`, and use no datasets, experiments,
evaluators, scores or prompts, so the v4 API namespace renames and the `run_experiment` change do
not apply. The `/test` credential check hits `GET /api/public/projects` directly, still current in
v4. v4's new default span filtering drops nothing, since every span we emit is created through the
Langfuse client and the backend has no other OpenTelemetry instrumentation. There is no JavaScript
Langfuse SDK in the repo.

Note for self-hosted deployments: the v4 client does not require a Langfuse v4 server. Trace
ingestion works against a v3 server (3.63.0 or newer); only the v2 observations and metrics APIs
need a v4 server, and we do not call them.

## How Has This Been Tested?

- `backend/tests/unit/onyx/tracing` — 40 pass. The three `update_trace` tests were rewritten for
  the new path, plus a new test asserting child observations re-apply the attributes.
- `backend/tests/unit` — 8555 pass. The 19 failures are byte-identical to a clean `origin/main`
  run on the same base (license claim/reclaim and process isolation), so none come from this PR.
- `backend/tests/external_dependency_unit/tracing` — 25 pass; its 2 failures also occur on a clean
  tree and come from local environment configuration.
- `ty` and all pre-commit hooks pass, including the lock and requirements export checks.
- Drove the real processor through the real v4 SDK with a capture exporter in place of the network:
  3 observations, a single trace id, session and user on all 3, cost and token usage preserved.
  The same harness on the pre-change code produces the 2-orphan result in the table above.
- Measured the per-observation cost of re-applying attributes at ~26 µs, against an LLM call
  measured in hundreds of milliseconds. Also confirmed `start_observation` does not make its span
  current, so `propagate_attributes` cannot write onto an unrelated active span.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates tracing to `langfuse` v4 to restore intact trace trees and user/session correlation. Previously on v4, update_trace raised, the root observation was dropped, and child spans were emitted as orphans; now we propagate correlating attributes on every observation and keep parent links via explicit IDs.

- Replace update_trace with v4 correlating attributes: build trace_name, session_id, user_id, and metadata, and apply via propagate_attributes per observation (root and children).
- Persist trace attributes in the processor and re-apply them for child spans, including those created in other threads, using trace_context for parent linking.
- Initialize the client with base_url and keep LANGFUSE_BASE_URL and LANGFUSE_HOST in sync with config; clear both when no host is set to avoid stale env overrides.
- Dependency bump isolated to `langfuse`; update pins in requirements, pyproject, and lockfile; no changes to datasets/experiments/evaluators/scores/prompts usage.
- Server compatibility: v4 client ingests traces against Langfuse server v3.63.0+; no server upgrade required for current usage.
- Tests updated for v4 behavior; no functional changes outside tracing.

<sup>Written for commit 3cdb148a3e133b13b3592b436287bbb596c71ee4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


