### PR TITLE
fix(auth): log the IdP's response when the authorization code exchange fails

### DIFF
--- a/backend/onyx/auth/oidc_client.py
+++ b/backend/onyx/auth/oidc_client.py
@@ -6,6 +6,7 @@ be replayed against another provider's callback (OIDC mix-up defense)."""
 
 from urllib.parse import unquote, urlsplit
 
+import httpx
 from httpx_oauth.clients.openid import BASE_SCOPES, OpenID
 from httpx_oauth.exceptions import GetIdEmailError
 from httpx_oauth.oauth2 import GetAccessTokenError
@@ -14,18 +15,34 @@ from onyx.utils.logger import format_error_for_logging, setup_logger
 
 logger = setup_logger()
 
-_TOKEN_ERROR_BODY_SNIPPET_CHARS = 1000
+_TOKEN_ERROR_SNIPPET_CHARS = 1000
+# RFC 6749 token error fields. Anything else in the body (or a non-JSON body)
+# can reflect request material or carry PII, so it is never logged verbatim.
+_OAUTH_ERROR_FIELDS = ("error", "error_description", "error_uri")
+
+
+def _error_body_summary(response: httpx.Response) -> str:
+    try:
+        payload = response.json()
+    except Exception:
+        return f"unparseable body ({len(response.content)} bytes)"
+    if not isinstance(payload, dict):
+        return f"non-object JSON body ({len(response.content)} bytes)"
+    fields = {k: payload[k] for k in _OAUTH_ERROR_FIELDS if k in payload}
+    if not fields:
+        return f"no RFC 6749 error fields (keys={sorted(payload)[:10]})"
+    return repr(fields)
 
 
 def log_token_exchange_failure(error: GetAccessTokenError) -> None:
     """The IdP names the rejection (invalid_grant, invalid_client, ...) only in
     the token response body, which must stay out of the client-facing error.
     A malformed non-error response is the token payload itself, so only an
-    error body is safe to log."""
+    error body is summarized."""
     detail = format_error_for_logging(error)
     if error.response is not None and error.response.is_error:
-        body = error.response.text[:_TOKEN_ERROR_BODY_SNIPPET_CHARS]
-        detail = f"{detail} response={body!r}"
+        summary = _error_body_summary(error.response)[:_TOKEN_ERROR_SNIPPET_CHARS]
+        detail = f"{detail} response={summary}"
     logger.warning("Token exchange with the IdP failed: %s", detail)
 
 

--- a/backend/onyx/auth/oidc_client.py
+++ b/backend/onyx/auth/oidc_client.py
@@ -1,13 +1,32 @@
-"""Hardened OIDC client for multi-IdP SSO. Two guarantees on top of the
-stock client: the email claim is trusted only when the IdP marks it
-verified, and the discovery document's issuer must own the configured
-discovery URL, so one provider's tokens cannot be replayed against another
-provider's callback (OIDC mix-up defense)."""
+"""Hardened OIDC client for multi-IdP SSO, plus the logging of token-exchange
+failures. Two guarantees on top of the stock client: the email claim is
+trusted only when the IdP marks it verified, and the discovery document's
+issuer must own the configured discovery URL, so one provider's tokens cannot
+be replayed against another provider's callback (OIDC mix-up defense)."""
 
 from urllib.parse import unquote, urlsplit
 
 from httpx_oauth.clients.openid import BASE_SCOPES, OpenID
 from httpx_oauth.exceptions import GetIdEmailError
+from httpx_oauth.oauth2 import GetAccessTokenError
+
+from onyx.utils.logger import format_error_for_logging, setup_logger
+
+logger = setup_logger()
+
+_TOKEN_ERROR_BODY_SNIPPET_CHARS = 1000
+
+
+def log_token_exchange_failure(error: GetAccessTokenError) -> None:
+    """The IdP names the rejection (invalid_grant, invalid_client, ...) only in
+    the token response body, which must stay out of the client-facing error.
+    A malformed non-error response is the token payload itself, so only an
+    error body is safe to log."""
+    detail = format_error_for_logging(error)
+    if error.response is not None and error.response.is_error:
+        body = error.response.text[:_TOKEN_ERROR_BODY_SNIPPET_CHARS]
+        detail = f"{detail} response={body!r}"
+    logger.warning("Token exchange with the IdP failed: %s", detail)
 
 
 class OpenIDConfigurationIssuerMismatch(ValueError):

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -76,6 +76,7 @@ from onyx.auth.mobile_sso.sso_completion import (
     complete_mobile_sso,
     is_mobile_sso,
 )
+from onyx.auth.oidc_client import log_token_exchange_failure
 from onyx.auth.pat import get_hashed_pat_from_request
 from onyx.auth.permissions import has_global_permission
 from onyx.auth.pkce import generate_pkce_pair
@@ -2926,7 +2927,8 @@ def get_oauth_router(
                 token = await oauth_client.get_access_token(
                     code, callback_redirect_url, code_verifier
                 )
-            except GetAccessTokenError:
+            except GetAccessTokenError as e:
+                log_token_exchange_failure(e)
                 return build_error_response(
                     OnyxError(
                         OnyxErrorCode.VALIDATION_ERROR,

--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -27,7 +27,7 @@ from httpx_oauth.clients.openid import BASE_SCOPES
 from httpx_oauth.oauth2 import BaseOAuth2, GetAccessTokenError
 from sqlalchemy.orm import Session
 
-from onyx.auth.oidc_client import VerifiedEmailOpenID
+from onyx.auth.oidc_client import VerifiedEmailOpenID, log_token_exchange_failure
 from onyx.auth.sso_tenant_token import (
     SSO_TENANT_TOKEN_PARAM,
     decode_sso_tenant_token,
@@ -484,6 +484,7 @@ async def oidc_login_callback_for_provider(
         try:
             token = await client.get_access_token(code, redirect_uri, code_verifier)
         except GetAccessTokenError as e:
+            log_token_exchange_failure(e)
             raise OnyxError(
                 OnyxErrorCode.VALIDATION_ERROR,
                 "Authorization code exchange failed",

--- a/backend/tests/unit/onyx/auth/test_verified_email_openid_client.py
+++ b/backend/tests/unit/onyx/auth/test_verified_email_openid_client.py
@@ -296,6 +296,17 @@ def test_exchange_failure_never_logs_non_error_body() -> None:
     assert "Invalid JSON content" in detail
 
 
+def test_exchange_failure_summarizes_non_oauth_error_body() -> None:
+    # A proxy's HTML error page may reflect request material, so never log it raw.
+    error = GetAccessTokenError(
+        "Server error '502 Bad Gateway' for url 'https://idp/token'",
+        httpx.Response(502, text="<html>secret-echo</html>"),
+    )
+    detail = _exchange_log_detail(error)
+    assert "secret-echo" not in detail
+    assert "unparseable body" in detail
+
+
 def test_exchange_failure_without_response_logs_message_only() -> None:
     detail = _exchange_log_detail(GetAccessTokenError("connection failed"))
     assert detail == "connection failed"

--- a/backend/tests/unit/onyx/auth/test_verified_email_openid_client.py
+++ b/backend/tests/unit/onyx/auth/test_verified_email_openid_client.py
@@ -6,12 +6,15 @@ not own the configured endpoint."""
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from httpx_oauth.exceptions import GetIdEmailError
+from httpx_oauth.oauth2 import GetAccessTokenError
 
 from onyx.auth.oidc_client import (
     OpenIDConfigurationIssuerMismatch,
     VerifiedEmailOpenID,
+    log_token_exchange_failure,
     validate_issuer_owns_config_url,
 )
 
@@ -261,3 +264,38 @@ def test_encoded_dot_segments_rejected(encoded: str) -> None:
             "https://idp.example.com/oidc",
             f"https://idp.example.com/oidc/{encoded}/evil/.well-known/openid-configuration",
         )
+
+
+def _exchange_log_detail(error: GetAccessTokenError) -> str:
+    with patch("onyx.auth.oidc_client.logger") as mock_logger:
+        log_token_exchange_failure(error)
+    ((_, detail), _kwargs) = mock_logger.warning.call_args
+    return str(detail)
+
+
+def test_exchange_failure_logs_error_body_on_one_line() -> None:
+    error = GetAccessTokenError(
+        "Client error '400 Bad Request' for url 'https://idp/token'\n"
+        "For more information check: https://developer.mozilla.org",
+        httpx.Response(400, text='{"error":"invalid_grant"}'),
+    )
+    detail = _exchange_log_detail(error)
+    assert "invalid_grant" in detail
+    assert "400 Bad Request" in detail
+    assert "\n" not in detail
+
+
+def test_exchange_failure_never_logs_non_error_body() -> None:
+    # A malformed 2xx raises the same error type carrying the token payload.
+    error = GetAccessTokenError(
+        "Invalid JSON content",
+        httpx.Response(200, text='{"access_token":"live-token"}'),
+    )
+    detail = _exchange_log_detail(error)
+    assert "live-token" not in detail
+    assert "Invalid JSON content" in detail
+
+
+def test_exchange_failure_without_response_logs_message_only() -> None:
+    detail = _exchange_log_detail(GetAccessTokenError("connection failed"))
+    assert detail == "connection failed"


### PR DESCRIPTION
## Description

SSO logins that die at the token exchange log only "Authorization code exchange failed". The IdP's actual rejection (invalid_grant vs invalid_client vs redirect_uri mismatch) lives in the token response body and was swallowed, so these failures are undiagnosable from server logs (hit this triaging a v4.6.0 upgrade report from the community).

Fix: a shared `log_token_exchange_failure` helper logs the exchange error on one line with the error response body, truncated and repr-quoted, called from both catch sites (multi-provider OIDC callback and the generic OAuth router). The body is logged only for error statuses: a malformed 2xx raises the same `GetAccessTokenError` carrying the live token payload, which must never reach logs. Client-facing error detail is unchanged.

## How Has This Been Tested?

- Unit tests added for the helper: error body logged one-line, non-error (2xx) body suppressed, no-response transport case. `pytest -xv` on the three affected auth/OIDC test files: 80 passed.
- ruff format check and project-wide ty check clean.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check