### PR TITLE
refactor(ods): replace logrus with a log/slog wrapper

### DIFF
--- a/tools/ods/cmd/audit.go
+++ b/tools/ods/cmd/audit.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"os"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/audit"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 // AuditOptions holds options for the audit command.

--- a/tools/ods/cmd/audit_ignore.go
+++ b/tools/ods/cmd/audit_ignore.go
@@ -5,10 +5,10 @@ import (
 	"os/exec"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/audit"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/tui"
 )

--- a/tools/ods/cmd/audit_ignore_add.go
+++ b/tools/ods/cmd/audit_ignore_add.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/audit"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
 )
 

--- a/tools/ods/cmd/audit_image.go
+++ b/tools/ods/cmd/audit_image.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"os"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/audit"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 // AuditImageOptions holds options for the `ods audit image` command.

--- a/tools/ods/cmd/backend.go
+++ b/tools/ods/cmd/backend.go
@@ -10,9 +10,9 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/portutil"
 )

--- a/tools/ods/cmd/check_lazy_imports.go
+++ b/tools/ods/cmd/check_lazy_imports.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"os"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/lazyimports"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 // NewCheckLazyImportsCommand creates the check-lazy-imports command.
@@ -65,4 +65,3 @@ func runCheckLazyImports(providedPaths []string) {
 
 	log.Info("✅ All lazy modules are properly imported!")
 }
-

--- a/tools/ods/cmd/cherry-pick.go
+++ b/tools/ods/cmd/cherry-pick.go
@@ -9,11 +9,11 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/release"
 )
@@ -123,7 +123,7 @@ func runCherryPick(cmd *cobra.Command, args []string, opts *CherryPickOptions) {
 	}
 
 	if opts.DryRun {
-		log.Warning("=== DRY RUN MODE: No remote operations will be performed ===")
+		log.Warn("=== DRY RUN MODE: No remote operations will be performed ===")
 	}
 
 	// Save the current branch to switch back later
@@ -354,7 +354,7 @@ func runCherryPickDispatch(args []string, opts *CherryPickOptions) {
 	}
 
 	if opts.DryRun {
-		log.Warning("=== DRY RUN MODE: No workflow will be dispatched ===")
+		log.Warn("=== DRY RUN MODE: No workflow will be dispatched ===")
 	}
 
 	// Resolve any PR numbers (e.g. "1234") to their merge commit SHAs

--- a/tools/ods/cmd/compose.go
+++ b/tools/ods/cmd/compose.go
@@ -7,10 +7,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/docker"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 )
 

--- a/tools/ods/cmd/db_drop.go
+++ b/tools/ods/cmd/db_drop.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"regexp"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/docker"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/postgres"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
 )

--- a/tools/ods/cmd/db_dump.go
+++ b/tools/ods/cmd/db_dump.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/docker"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/postgres"
 )

--- a/tools/ods/cmd/db_migrate.go
+++ b/tools/ods/cmd/db_migrate.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/alembic"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 // MigrateOptions holds common options for migration commands.

--- a/tools/ods/cmd/db_restore.go
+++ b/tools/ods/cmd/db_restore.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/docker"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/postgres"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"

--- a/tools/ods/cmd/deploy_common.go
+++ b/tools/ods/cmd/deploy_common.go
@@ -7,9 +7,8 @@ import (
 	"sort"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/config"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
 )

--- a/tools/ods/cmd/deploy_edge.go
+++ b/tools/ods/cmd/deploy_edge.go
@@ -3,11 +3,11 @@ package cmd
 import (
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/config"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
 )
 
@@ -81,7 +81,7 @@ func deployEdge(opts *DeployEdgeOptions) {
 	)
 
 	if opts.DryRun {
-		log.Warning("=== DRY RUN MODE: tag push and workflow dispatch will be skipped (read-only gh and git fetch still run) ===")
+		log.Warn("=== DRY RUN MODE: tag push and workflow dispatch will be skipped (read-only gh and git fetch still run) ===")
 	}
 
 	if !opts.Yes {

--- a/tools/ods/cmd/deploy_wiki.go
+++ b/tools/ods/cmd/deploy_wiki.go
@@ -3,11 +3,11 @@ package cmd
 import (
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/config"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
 )
 
@@ -87,7 +87,7 @@ func deployWiki(opts *DeployWikiOptions) {
 	)
 
 	if opts.DryRun {
-		log.Warning("=== DRY RUN MODE: workflow dispatches will be skipped ===")
+		log.Warn("=== DRY RUN MODE: workflow dispatches will be skipped ===")
 	}
 
 	versionTag := "nightly-latest-" + time.Now().UTC().Format("20060102")

--- a/tools/ods/cmd/desktop.go
+++ b/tools/ods/cmd/desktop.go
@@ -10,9 +10,9 @@ import (
 	"sort"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 )
 

--- a/tools/ods/cmd/dev_into.go
+++ b/tools/ods/cmd/dev_into.go
@@ -4,9 +4,9 @@ import (
 	"os"
 	"os/exec"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 )
 

--- a/tools/ods/cmd/dev_rebuild.go
+++ b/tools/ods/cmd/dev_rebuild.go
@@ -4,8 +4,9 @@ import (
 	"os"
 	"os/exec"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 func newDevRebuildCommand() *cobra.Command {

--- a/tools/ods/cmd/dev_stop.go
+++ b/tools/ods/cmd/dev_stop.go
@@ -4,9 +4,9 @@ import (
 	"os/exec"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 )
 

--- a/tools/ods/cmd/dev_tunnel.go
+++ b/tools/ods/cmd/dev_tunnel.go
@@ -7,9 +7,9 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 )
 

--- a/tools/ods/cmd/dev_up.go
+++ b/tools/ods/cmd/dev_up.go
@@ -9,9 +9,9 @@ import (
 	"runtime"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 )
 

--- a/tools/ods/cmd/env.go
+++ b/tools/ods/cmd/env.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/docker"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
 )

--- a/tools/ods/cmd/fmt.go
+++ b/tools/ods/cmd/fmt.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/terraform"
 )

--- a/tools/ods/cmd/generate_compose.go
+++ b/tools/ods/cmd/generate_compose.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 
 	"github.com/sergi/go-diff/diffmatchpatch"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/composegen"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/deployfilessync"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 )
 

--- a/tools/ods/cmd/lint.go
+++ b/tools/ods/cmd/lint.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/terraform"
 )

--- a/tools/ods/cmd/logs.go
+++ b/tools/ods/cmd/logs.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 // LogsOptions holds options for the logs command.

--- a/tools/ods/cmd/openapi.go
+++ b/tools/ods/cmd/openapi.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/openapi"
 )
 
@@ -200,4 +200,3 @@ func runOpenAPIAll(opts *OpenAPIOptions) {
 
 	log.Info("Generation completed successfully")
 }
-

--- a/tools/ods/cmd/pull.go
+++ b/tools/ods/cmd/pull.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 // PullOptions holds options for the pull command.

--- a/tools/ods/cmd/release_cloud.go
+++ b/tools/ods/cmd/release_cloud.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/release"
 )

--- a/tools/ods/cmd/release_opal.go
+++ b/tools/ods/cmd/release_opal.go
@@ -5,10 +5,10 @@ import (
 	"os/exec"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/release"
 )

--- a/tools/ods/cmd/root.go
+++ b/tools/ods/cmd/root.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/docker"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 var (
@@ -30,13 +30,10 @@ func NewRootCommand() *cobra.Command {
 		Run:   rootCmd,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if opts.Debug {
-				log.SetLevel(log.DebugLevel)
+				log.SetLevel(log.LevelDebug)
 			} else {
-				log.SetLevel(log.InfoLevel)
+				log.SetLevel(log.LevelInfo)
 			}
-			log.SetFormatter(&log.TextFormatter{
-				DisableTimestamp: true,
-			})
 			docker.SetProjectFlags(opts.Project)
 		},
 		Version: fmt.Sprintf("%s\ncommit %s", Version, Commit),

--- a/tools/ods/cmd/run-ci.go
+++ b/tools/ods/cmd/run-ci.go
@@ -6,10 +6,10 @@ import (
 	"os/exec"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
 )
 
@@ -87,7 +87,7 @@ func runCI(cmd *cobra.Command, args []string, opts *RunCIOptions) {
 	log.Debugf("Running CI for PR: %s", prNumber)
 
 	if opts.DryRun {
-		log.Warning("=== DRY RUN MODE: No remote operations will be performed ===")
+		log.Warn("=== DRY RUN MODE: No remote operations will be performed ===")
 	}
 
 	// Save the current branch to switch back later

--- a/tools/ods/cmd/screenshot_diff.go
+++ b/tools/ods/cmd/screenshot_diff.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/imgdiff"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/s3"
 )
 

--- a/tools/ods/cmd/trace.go
+++ b/tools/ods/cmd/trace.go
@@ -16,10 +16,10 @@ import (
 	"sync"
 
 	"github.com/charlievieth/fastwalk"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/tui"
 )

--- a/tools/ods/cmd/web.go
+++ b/tools/ods/cmd/web.go
@@ -16,9 +16,9 @@ import (
 	"time"
 
 	"github.com/charlievieth/fastwalk"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 )
 

--- a/tools/ods/cmd/whois.go
+++ b/tools/ods/cmd/whois.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/kube"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 var safeIdentifier = regexp.MustCompile(`^[a-zA-Z0-9_\-]+$`)

--- a/tools/ods/go.mod
+++ b/tools/ods/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/jmelahman/tag v0.5.2
 	github.com/ossf/osv-schema/bindings/go v0.0.0-20260424063704-83285ce2a866
 	github.com/sergi/go-diff v1.4.0
-	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	google.golang.org/protobuf v1.36.11
@@ -118,6 +117,7 @@ require (
 	github.com/saferwall/pe v1.6.4 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
+	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/spdx/gordf v0.0.0-20250128162952-000978ccd6fb // indirect
 	github.com/spdx/tools-golang v0.5.7 // indirect

--- a/tools/ods/internal/alembic/alembic.go
+++ b/tools/ods/internal/alembic/alembic.go
@@ -8,9 +8,8 @@ import (
 	"runtime"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/docker"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/postgres"
 )

--- a/tools/ods/internal/audit/actions.go
+++ b/tools/ods/internal/audit/actions.go
@@ -39,9 +39,9 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem"
 	"github.com/google/osv-scalibr/extractor/filesystem/misc/githubactions"
 	"github.com/google/osv-scalibr/purl"
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/version"
 )

--- a/tools/ods/internal/audit/audit.go
+++ b/tools/ods/internal/audit/audit.go
@@ -12,8 +12,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 )
 

--- a/tools/ods/internal/audit/ignore.go
+++ b/tools/ods/internal/audit/ignore.go
@@ -7,8 +7,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/s3"
 )
 

--- a/tools/ods/internal/audit/image.go
+++ b/tools/ods/internal/audit/image.go
@@ -6,10 +6,10 @@ import (
 	"io"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/google/osv-scanner/v2/pkg/models"
 	"github.com/google/osv-scanner/v2/pkg/osvscanner"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 // ImageOptions configures a container image audit run.

--- a/tools/ods/internal/git/git.go
+++ b/tools/ods/internal/git/git.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 // PushHookHintDelay is how long a push with hooks enabled runs before HintAfter
@@ -48,7 +48,7 @@ func GetCurrentBranch() (string, error) {
 func RunCommand(args ...string) error {
 	log.Debugf("Running: git %s", strings.Join(args, " "))
 	cmd := exec.Command("git", args...)
-	if log.IsLevelEnabled(log.DebugLevel) {
+	if log.Enabled(log.LevelDebug) {
 		cmd.Stdout = os.Stdout
 	}
 	cmd.Stderr = os.Stderr
@@ -71,7 +71,7 @@ func RunCommandVerboseOnError(args ...string) error {
 	}
 
 	// Print output on success only if debug is enabled
-	if log.IsLevelEnabled(log.DebugLevel) && len(output) > 0 {
+	if log.Enabled(log.LevelDebug) && len(output) > 0 {
 		fmt.Print(string(output))
 	}
 	return nil

--- a/tools/ods/internal/kube/kube.go
+++ b/tools/ods/internal/kube/kube.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 // Cluster holds the connection info for a Kubernetes cluster.

--- a/tools/ods/internal/lazyimports/lazyimports.go
+++ b/tools/ods/internal/lazyimports/lazyimports.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 
 	"github.com/charlievieth/fastwalk"
-	log "github.com/sirupsen/logrus"
 
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 )
 

--- a/tools/ods/internal/log/log.go
+++ b/tools/ods/internal/log/log.go
@@ -1,0 +1,142 @@
+// Package log provides printf-style logging on top of the standard library
+// log/slog package. Output goes to stderr as "LEVEL message", with color when
+// stderr is a terminal.
+package log
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+)
+
+// Levels mirror the slog levels so callers do not need to import log/slog.
+const (
+	LevelDebug = slog.LevelDebug
+	LevelInfo  = slog.LevelInfo
+	LevelWarn  = slog.LevelWarn
+	LevelError = slog.LevelError
+)
+
+var (
+	level  = new(slog.LevelVar)
+	logger = slog.New(newHandler(os.Stderr, level))
+)
+
+// SetLevel sets the minimum level to log.
+func SetLevel(l slog.Level) {
+	level.Set(l)
+}
+
+// Enabled reports whether messages at the given level are logged.
+func Enabled(l slog.Level) bool {
+	return logger.Enabled(context.Background(), l)
+}
+
+func Debugf(format string, args ...any) { output(LevelDebug, fmt.Sprintf(format, args...)) }
+func Info(args ...any)                  { output(LevelInfo, fmt.Sprint(args...)) }
+func Infof(format string, args ...any)  { output(LevelInfo, fmt.Sprintf(format, args...)) }
+func Warn(args ...any)                  { output(LevelWarn, fmt.Sprint(args...)) }
+func Warnf(format string, args ...any)  { output(LevelWarn, fmt.Sprintf(format, args...)) }
+func Error(args ...any)                 { output(LevelError, fmt.Sprint(args...)) }
+func Errorf(format string, args ...any) { output(LevelError, fmt.Sprintf(format, args...)) }
+
+// Fatal logs at error level and exits with status 1.
+func Fatal(args ...any) {
+	output(LevelError, fmt.Sprint(args...))
+	os.Exit(1)
+}
+
+// Fatalf logs at error level and exits with status 1.
+func Fatalf(format string, args ...any) {
+	output(LevelError, fmt.Sprintf(format, args...))
+	os.Exit(1)
+}
+
+func output(l slog.Level, msg string) {
+	logger.Log(context.Background(), l, msg)
+}
+
+// handler renders records as "LEVEL message" without a timestamp. Attributes
+// are appended as key=value pairs.
+type handler struct {
+	mu    *sync.Mutex
+	out   io.Writer
+	level slog.Leveler
+	color bool
+	attrs []slog.Attr
+}
+
+func newHandler(out *os.File, level slog.Leveler) *handler {
+	return &handler{mu: &sync.Mutex{}, out: out, level: level, color: isTerminal(out)}
+}
+
+func isTerminal(f *os.File) bool {
+	info, err := f.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
+}
+
+func (h *handler) Enabled(_ context.Context, l slog.Level) bool {
+	return l >= h.level.Level()
+}
+
+func (h *handler) Handle(_ context.Context, r slog.Record) error {
+	var b strings.Builder
+	b.WriteString(h.label(r.Level))
+	b.WriteByte(' ')
+	b.WriteString(r.Message)
+	for _, a := range h.attrs {
+		writeAttr(&b, a)
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		writeAttr(&b, a)
+		return true
+	})
+	b.WriteByte('\n')
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, err := io.WriteString(h.out, b.String())
+	return err
+}
+
+func (h *handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	next := *h
+	next.attrs = append(append([]slog.Attr{}, h.attrs...), attrs...)
+	return &next
+}
+
+// WithGroup is unused; groups are ignored.
+func (h *handler) WithGroup(string) slog.Handler { return h }
+
+func (h *handler) label(l slog.Level) string {
+	name := map[slog.Level]string{
+		LevelDebug: "DEBUG",
+		LevelInfo:  "INFO ",
+		LevelWarn:  "WARN ",
+		LevelError: "ERROR",
+	}[l]
+	if name == "" {
+		name = l.String()
+	}
+	if !h.color {
+		return name
+	}
+	code := map[slog.Level]string{
+		LevelDebug: "37",
+		LevelInfo:  "36",
+		LevelWarn:  "33",
+		LevelError: "31",
+	}[l]
+	if code == "" {
+		return name
+	}
+	return "\x1b[" + code + "m" + name + "\x1b[0m"
+}
+
+func writeAttr(b *strings.Builder, a slog.Attr) {
+	fmt.Fprintf(b, " %s=%v", a.Key, a.Value.Any())
+}

--- a/tools/ods/internal/openapi/openapi.go
+++ b/tools/ods/internal/openapi/openapi.go
@@ -8,8 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	log "github.com/sirupsen/logrus"
-
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 )
 
@@ -146,4 +145,3 @@ func GenerateAll(schemaPath string, clientOutputDir string) error {
 	}
 	return RunScript(args)
 }
-

--- a/tools/ods/internal/paths/paths.go
+++ b/tools/ods/internal/paths/paths.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 // GitRoot returns the root directory of the current git repository.

--- a/tools/ods/internal/portutil/portutil.go
+++ b/tools/ods/internal/portutil/portutil.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 // IsAvailable reports whether the given TCP port can be bound on the host.

--- a/tools/ods/internal/prompt/prompt.go
+++ b/tools/ods/internal/prompt/prompt.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 // reader is the input reader, can be replaced for testing

--- a/tools/ods/internal/release/check.go
+++ b/tools/ods/internal/release/check.go
@@ -7,9 +7,8 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 // stableTagRe matches a well-formed stable tag (vX.Y.Z, no pre-release

--- a/tools/ods/internal/release/cloud.go
+++ b/tools/ods/internal/release/cloud.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"regexp"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 // cloudTagRe matches a well-formed cloud tag and captures its base version

--- a/tools/ods/internal/release/version.go
+++ b/tools/ods/internal/release/version.go
@@ -12,9 +12,8 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 // bareSemverRe matches a bare X.Y.Z version (no leading v). Leading zeroes are

--- a/tools/ods/internal/s3/fetch.go
+++ b/tools/ods/internal/s3/fetch.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 // S3URL represents a parsed S3 URL.

--- a/tools/ods/internal/s3/put.go
+++ b/tools/ods/internal/s3/put.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"os/exec"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 // PutFile uploads a single local file to an S3 object using the AWS CLI.

--- a/tools/ods/internal/s3/sync.go
+++ b/tools/ods/internal/s3/sync.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"os/exec"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/log"
 )
 
 // SyncDown downloads an S3 prefix to a local directory using AWS CLI.


### PR DESCRIPTION
## Description

Removes the direct `github.com/sirupsen/logrus` dependency from `tools/ods` in favor of the standard library `log/slog`.

- Adds `tools/ods/internal/log`: a small printf-style wrapper over `log/slog`. It keeps the API the call sites already used (`Info`, `Infof`, `Debugf`, `Warnf`, `Errorf`, `Fatal`, `Fatalf`) and adds `SetLevel` / `Enabled`.
- Its `slog.Handler` prints `LEVEL message` to stderr with no timestamp — the same shape as the old `TextFormatter{DisableTimestamp: true}` — and colors the level when stderr is a terminal.
- Moves all 55 call sites to the new package. `log.Warning` becomes `log.Warn`, and `log.IsLevelEnabled(log.DebugLevel)` becomes `log.Enabled(log.LevelDebug)`.
- `cmd/root.go` no longer needs `SetFormatter`; the handler has no timestamp by default.
- `go mod tidy` moves logrus to `// indirect` (osv-scanner still pulls it in).

`internal/audit/osv.go` already used `log/slog` directly to configure the osv-scanner logger and is unchanged.

## How Has This Been Tested?

- `go build ./...`, `go vet ./...`, and `golangci-lint` (via pre-commit) pass.
- `go test ./...` passes, except `internal/git`, which fails in my container for an unrelated reason: `git commit` cannot sign (`Couldn't load public key /root/.ssh/id_rsa.pub`).
- Ran `ods env` and `ods --debug logs` to check level filtering, color, and the debug gating in `internal/git`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace direct `github.com/sirupsen/logrus` usage in `tools/ods` with a small wrapper over standard library `log/slog` to reduce dependencies and keep output stable. Old behavior: `logrus` text formatter without timestamps. New behavior: `tools/ods/internal/log` prints `LEVEL message` to stderr without timestamps, with TTY color; call-site API remains printf-style. Side effects: `log.Warning` becomes `log.Warn`; `IsLevelEnabled` becomes `Enabled`; `cmd/root.go` no longer sets a formatter.

- Introduces `tools/ods/internal/log` with `Info`, `Infof`, `Debugf`, `Warn`, `Warnf`, `Errorf`, `Fatal`, `Fatalf`, and `SetLevel`/`Enabled`. Output matches old shape and adds level coloring when stderr is a terminal.
- Updates all call sites. Replace `log.Warning` with `log.Warn` and `log.IsLevelEnabled(log.DebugLevel)` with `log.Enabled(log.LevelDebug)`.
- Simplifies `cmd/root.go` to only set `LevelDebug` or `LevelInfo`; removes `SetFormatter`.
- Moves `github.com/sirupsen/logrus` to an indirect dependency (still required by `osv-scanner`); `internal/audit/osv.go` remains unchanged.

<sup>Written for commit 4e6c81e462160d54fbdf23e531ecdd79e94fdd73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

