### PR TITLE
feat(auth): move JWT auth settings to DB-backed security settings

### DIFF
--- a/backend/alembic/versions/e7c00417d1e5_add_jwt_auth_columns_to_security_.py
+++ b/backend/alembic/versions/e7c00417d1e5_add_jwt_auth_columns_to_security_.py
@@ -1,0 +1,37 @@
+"""add jwt auth columns to security settings
+
+Revision ID: e7c00417d1e5
+Revises: 28bb08137807
+Create Date: 2026-08-21 12:27:35.945589
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e7c00417d1e5"
+down_revision = "28bb08137807"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "security_settings",
+        sa.Column("jwt_public_key_url", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "security_settings",
+        sa.Column("jwt_expected_audience", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "security_settings",
+        sa.Column("jwt_expected_issuer", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("security_settings", "jwt_expected_issuer")
+    op.drop_column("security_settings", "jwt_expected_audience")
+    op.drop_column("security_settings", "jwt_public_key_url")

--- a/backend/onyx/auth/jwt.py
+++ b/backend/onyx/auth/jwt.py
@@ -22,6 +22,7 @@ from onyx.server.security.store import (
     get_security_settings,
 )
 from onyx.utils.logger import setup_logger
+from onyx.utils.url import SSRFException, ssrf_safe_get
 
 logger = setup_logger()
 
@@ -38,12 +39,19 @@ class PublicKeyFormat(Enum):
 @lru_cache(maxsize=8)
 def _fetch_public_key_payload(
     public_key_url: str,
+    operator_pinned: bool,
 ) -> tuple[str | dict[str, Any], PublicKeyFormat] | None:
-    """Fetch and cache the raw JWT verification material."""
+    """Fetch and cache the raw JWT verification material. A DB-origin URL is
+    admin-aimed, so its fetch validates every redirect hop and pins the
+    resolved IP against DNS rebinding. An env-pinned URL is operator
+    config-as-code and fetched as-is."""
     try:
-        response = requests.get(public_key_url)
+        if operator_pinned:
+            response = requests.get(public_key_url)
+        else:
+            response = ssrf_safe_get(public_key_url)
         response.raise_for_status()
-    except requests.RequestException as exc:
+    except (requests.RequestException, SSRFException, ValueError) as exc:
         logger.error("Failed to fetch JWT public key: %s", str(exc))
         return None
     content_type = response.headers.get("Content-Type", "").lower()
@@ -73,9 +81,11 @@ def _fetch_public_key_payload(
     return body, PublicKeyFormat.PEM
 
 
-def get_public_key(token: str, public_key_url: str) -> RSAPublicKey | str | None:
+def get_public_key(
+    token: str, public_key_url: str, operator_pinned: bool
+) -> RSAPublicKey | str | None:
     """Return the concrete public key used to verify the provided JWT token."""
-    payload = _fetch_public_key_payload(public_key_url)
+    payload = _fetch_public_key_payload(public_key_url, operator_pinned)
     if payload is None:
         logger.error("Failed to retrieve public key payload")
         return None
@@ -142,7 +152,8 @@ async def verify_jwt_token(token: str) -> dict[str, Any] | None:
 
     # A DB-origin URL is admin-aimed and must satisfy the outbound SSRF policy.
     # An env-pinned value is operator config-as-code, trusted as before.
-    if "jwt_public_key_url" not in env_pinned_active_fields():
+    operator_pinned = "jwt_public_key_url" in env_pinned_active_fields()
+    if not operator_pinned:
         try:
             validate_idp_url(settings.jwt_public_key_url, field="jwt_public_key_url")
         except UnsafeSSOUrl as e:
@@ -150,7 +161,7 @@ async def verify_jwt_token(token: str) -> dict[str, Any] | None:
             return None
 
     for attempt in range(_PUBLIC_KEY_FETCH_ATTEMPTS):
-        public_key = get_public_key(token, settings.jwt_public_key_url)
+        public_key = get_public_key(token, settings.jwt_public_key_url, operator_pinned)
         if public_key is None:
             logger.error("Unable to resolve a public key for JWT verification")
             if attempt < _PUBLIC_KEY_FETCH_ATTEMPTS - 1:

--- a/backend/onyx/auth/jwt.py
+++ b/backend/onyx/auth/jwt.py
@@ -17,6 +17,7 @@ from jwt import decode as jwt_decode
 from jwt.algorithms import RSAAlgorithm  # ty: ignore[possibly-missing-import]
 
 from onyx.auth.sso_url_guard import UnsafeSSOUrl, validate_idp_url
+from onyx.server.security.models import outbound_ssrf_params
 from onyx.server.security.store import (
     env_pinned_active_fields,
     get_security_settings,
@@ -40,6 +41,7 @@ class PublicKeyFormat(Enum):
 def _fetch_public_key_payload(
     public_key_url: str,
     operator_pinned: bool,
+    allow_private_network: bool,
 ) -> tuple[str | dict[str, Any], PublicKeyFormat] | None:
     """Fetch and cache the raw JWT verification material. A DB-origin URL is
     admin-aimed, so its fetch validates every redirect hop and pins the
@@ -49,7 +51,11 @@ def _fetch_public_key_payload(
         if operator_pinned:
             response = requests.get(public_key_url)
         else:
-            response = ssrf_safe_get(public_key_url)
+            # Mirrors the PUT-time check: the configured SSRF level decides
+            # whether private endpoints are reachable.
+            response = ssrf_safe_get(
+                public_key_url, allow_private_network=allow_private_network
+            )
         response.raise_for_status()
     except (requests.RequestException, SSRFException, ValueError) as exc:
         logger.error("Failed to fetch JWT public key: %s", str(exc))
@@ -82,10 +88,15 @@ def _fetch_public_key_payload(
 
 
 def get_public_key(
-    token: str, public_key_url: str, operator_pinned: bool
+    token: str,
+    public_key_url: str,
+    operator_pinned: bool,
+    allow_private_network: bool,
 ) -> RSAPublicKey | str | None:
     """Return the concrete public key used to verify the provided JWT token."""
-    payload = _fetch_public_key_payload(public_key_url, operator_pinned)
+    payload = _fetch_public_key_payload(
+        public_key_url, operator_pinned, allow_private_network
+    )
     if payload is None:
         logger.error("Failed to retrieve public key payload")
         return None
@@ -161,7 +172,12 @@ async def verify_jwt_token(token: str) -> dict[str, Any] | None:
             return None
 
     for attempt in range(_PUBLIC_KEY_FETCH_ATTEMPTS):
-        public_key = get_public_key(token, settings.jwt_public_key_url, operator_pinned)
+        public_key = get_public_key(
+            token,
+            settings.jwt_public_key_url,
+            operator_pinned,
+            outbound_ssrf_params(settings.ssrf_protection_level).allow_private_network,
+        )
         if public_key is None:
             logger.error("Unable to resolve a public key for JWT verification")
             if attempt < _PUBLIC_KEY_FETCH_ATTEMPTS - 1:

--- a/backend/onyx/auth/jwt.py
+++ b/backend/onyx/auth/jwt.py
@@ -16,11 +16,7 @@ from jwt import (
 from jwt import decode as jwt_decode
 from jwt.algorithms import RSAAlgorithm  # ty: ignore[possibly-missing-import]
 
-from onyx.configs.app_configs import (
-    JWT_EXPECTED_AUDIENCE,
-    JWT_EXPECTED_ISSUER,
-    JWT_PUBLIC_KEY_URL,
-)
+from onyx.server.security.store import get_security_settings
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -34,15 +30,14 @@ class PublicKeyFormat(Enum):
     PEM = "pem"
 
 
-@lru_cache()
-def _fetch_public_key_payload() -> tuple[str | dict[str, Any], PublicKeyFormat] | None:
+# Keyed on the URL so a runtime settings change takes effect without a restart.
+@lru_cache(maxsize=8)
+def _fetch_public_key_payload(
+    public_key_url: str,
+) -> tuple[str | dict[str, Any], PublicKeyFormat] | None:
     """Fetch and cache the raw JWT verification material."""
-    if JWT_PUBLIC_KEY_URL is None:
-        logger.error("JWT_PUBLIC_KEY_URL is not set")
-        return None
-
     try:
-        response = requests.get(JWT_PUBLIC_KEY_URL)
+        response = requests.get(public_key_url)
         response.raise_for_status()
     except requests.RequestException as exc:
         logger.error("Failed to fetch JWT public key: %s", str(exc))
@@ -74,9 +69,9 @@ def _fetch_public_key_payload() -> tuple[str | dict[str, Any], PublicKeyFormat] 
     return body, PublicKeyFormat.PEM
 
 
-def get_public_key(token: str) -> RSAPublicKey | str | None:
+def get_public_key(token: str, public_key_url: str) -> RSAPublicKey | str | None:
     """Return the concrete public key used to verify the provided JWT token."""
-    payload = _fetch_public_key_payload()
+    payload = _fetch_public_key_payload(public_key_url)
     if payload is None:
         logger.error("Failed to retrieve public key payload")
         return None
@@ -136,8 +131,13 @@ def _resolve_public_key_from_jwks(
 
 
 async def verify_jwt_token(token: str) -> dict[str, Any] | None:
+    settings = get_security_settings()
+    if settings.jwt_public_key_url is None:
+        logger.error("JWT public key URL is not configured")
+        return None
+
     for attempt in range(_PUBLIC_KEY_FETCH_ATTEMPTS):
-        public_key = get_public_key(token)
+        public_key = get_public_key(token, settings.jwt_public_key_url)
         if public_key is None:
             logger.error("Unable to resolve a public key for JWT verification")
             if attempt < _PUBLIC_KEY_FETCH_ATTEMPTS - 1:
@@ -152,9 +152,9 @@ async def verify_jwt_token(token: str) -> dict[str, Any] | None:
                 token,
                 public_key,
                 algorithms=["RS256"],
-                audience=JWT_EXPECTED_AUDIENCE,
-                issuer=JWT_EXPECTED_ISSUER,
-                options={"verify_aud": JWT_EXPECTED_AUDIENCE is not None},
+                audience=settings.jwt_expected_audience,
+                issuer=settings.jwt_expected_issuer,
+                options={"verify_aud": settings.jwt_expected_audience is not None},
             )
         except (
             InvalidAudienceError,

--- a/backend/onyx/auth/jwt.py
+++ b/backend/onyx/auth/jwt.py
@@ -16,7 +16,11 @@ from jwt import (
 from jwt import decode as jwt_decode
 from jwt.algorithms import RSAAlgorithm  # ty: ignore[possibly-missing-import]
 
-from onyx.server.security.store import get_security_settings
+from onyx.auth.sso_url_guard import UnsafeSSOUrl, validate_idp_url
+from onyx.server.security.store import (
+    env_pinned_active_fields,
+    get_security_settings,
+)
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -135,6 +139,15 @@ async def verify_jwt_token(token: str) -> dict[str, Any] | None:
     if settings.jwt_public_key_url is None:
         logger.error("JWT public key URL is not configured")
         return None
+
+    # A DB-origin URL is admin-aimed and must satisfy the outbound SSRF policy.
+    # An env-pinned value is operator config-as-code, trusted as before.
+    if "jwt_public_key_url" not in env_pinned_active_fields():
+        try:
+            validate_idp_url(settings.jwt_public_key_url, field="jwt_public_key_url")
+        except UnsafeSSOUrl as e:
+            logger.error("JWT public key URL rejected: %s", e)
+            return None
 
     for attempt in range(_PUBLIC_KEY_FETCH_ATTEMPTS):
         public_key = get_public_key(token, settings.jwt_public_key_url)

--- a/backend/onyx/auth/jwt.py
+++ b/backend/onyx/auth/jwt.py
@@ -17,7 +17,7 @@ from jwt import decode as jwt_decode
 from jwt.algorithms import RSAAlgorithm  # ty: ignore[possibly-missing-import]
 
 from onyx.auth.sso_url_guard import UnsafeSSOUrl, validate_idp_url
-from onyx.server.security.models import outbound_ssrf_params
+from onyx.server.security.models import OutboundSSRFParams, outbound_ssrf_params
 from onyx.server.security.store import (
     env_pinned_active_fields,
     get_security_settings,
@@ -42,6 +42,8 @@ def _fetch_public_key_payload(
     public_key_url: str,
     operator_pinned: bool,
     allow_private_network: bool,
+    block_loopback_and_link_local: bool,
+    block_link_local_only: bool,
 ) -> tuple[str | dict[str, Any], PublicKeyFormat] | None:
     """Fetch and cache the raw JWT verification material. A DB-origin URL is
     admin-aimed, so its fetch validates every redirect hop and pins the
@@ -54,7 +56,10 @@ def _fetch_public_key_payload(
             # Mirrors the PUT-time check: the configured SSRF level decides
             # whether private endpoints are reachable.
             response = ssrf_safe_get(
-                public_key_url, allow_private_network=allow_private_network
+                public_key_url,
+                allow_private_network=allow_private_network,
+                block_loopback_and_link_local=block_loopback_and_link_local,
+                block_link_local_only=block_link_local_only,
             )
         response.raise_for_status()
     except (requests.RequestException, SSRFException, ValueError) as exc:
@@ -91,11 +96,15 @@ def get_public_key(
     token: str,
     public_key_url: str,
     operator_pinned: bool,
-    allow_private_network: bool,
+    ssrf_params: OutboundSSRFParams,
 ) -> RSAPublicKey | str | None:
     """Return the concrete public key used to verify the provided JWT token."""
     payload = _fetch_public_key_payload(
-        public_key_url, operator_pinned, allow_private_network
+        public_key_url,
+        operator_pinned,
+        ssrf_params.allow_private_network,
+        ssrf_params.block_loopback_and_link_local,
+        ssrf_params.block_link_local_only,
     )
     if payload is None:
         logger.error("Failed to retrieve public key payload")
@@ -176,7 +185,7 @@ async def verify_jwt_token(token: str) -> dict[str, Any] | None:
             token,
             settings.jwt_public_key_url,
             operator_pinned,
-            outbound_ssrf_params(settings.ssrf_protection_level).allow_private_network,
+            outbound_ssrf_params(settings.ssrf_protection_level),
         )
         if public_key is None:
             logger.error("Unable to resolve a public key for JWT verification")

--- a/backend/onyx/auth/jwt.py
+++ b/backend/onyx/auth/jwt.py
@@ -55,11 +55,14 @@ def _fetch_public_key_payload(
         else:
             # Mirrors the PUT-time check: the configured SSRF level decides
             # whether private endpoints are reachable.
+            # https_only holds across redirect hops, so no hop can downgrade
+            # the key fetch to plaintext.
             response = ssrf_safe_get(
                 public_key_url,
                 allow_private_network=allow_private_network,
                 block_loopback_and_link_local=block_loopback_and_link_local,
                 block_link_local_only=block_link_local_only,
+                https_only=True,
             )
         response.raise_for_status()
     except (requests.RequestException, SSRFException, ValueError) as exc:

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -100,7 +100,6 @@ from onyx.configs.app_configs import (
     DEV_MODE,
     EMAIL_CONFIGURED,
     INTEGRATION_TESTS_MODE,
-    JWT_PUBLIC_KEY_URL,
     REDIS_AUTH_KEY_PREFIX,
     REQUIRE_EMAIL_VERIFICATION,
     SESSION_EXPIRE_TIME_SECONDS,
@@ -2058,7 +2057,7 @@ async def _check_for_saml_and_jwt(
     async_db_session: AsyncSession,
 ) -> User | None:
     # If user is None, check for JWT in Authorization header
-    if user is None and JWT_PUBLIC_KEY_URL is not None:
+    if user is None and get_security_settings().jwt_public_key_url is not None:
         auth_header = request.headers.get("Authorization")
         if auth_header and auth_header.startswith("Bearer "):
             token = auth_header[len("Bearer ") :].strip()

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4794,6 +4794,15 @@ class SecuritySettings(Base):
     password_require_special_char: Mapped[bool | None] = mapped_column(
         Boolean, nullable=True, default=None
     )
+    jwt_public_key_url: Mapped[str | None] = mapped_column(
+        String, nullable=True, default=None
+    )
+    jwt_expected_audience: Mapped[str | None] = mapped_column(
+        String, nullable=True, default=None
+    )
+    jwt_expected_issuer: Mapped[str | None] = mapped_column(
+        String, nullable=True, default=None
+    )
     __table_args__ = (
         CheckConstraint("id = true", name="ck_security_settings_singleton"),
         # Only catches min > max when both are explicitly overridden; the

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -157,6 +157,7 @@ from onyx.server.query_and_chat.query_backend import admin_router as admin_query
 from onyx.server.query_and_chat.query_backend import basic_router as query_router
 from onyx.server.saml_multi import router as saml_multi_router
 from onyx.server.security.api import admin_router as security_admin_router
+from onyx.server.security.store import seed_jwt_settings_from_env
 from onyx.server.settings.api import admin_router as settings_admin_router
 from onyx.server.settings.api import basic_router as settings_router
 from onyx.server.sso_discovery import router as sso_discovery_router
@@ -406,6 +407,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
             # api_server has the mount the migration job lacks, so this is where it
             # runs. No-op unless AUTH_TYPE=saml with no SAML row yet.
             seed_saml_provider_from_conf_dir(db_session)
+            # No-op when env is unset or the row already matches.
+            seed_jwt_settings_from_env()
             # set up the file store (e.g. create bucket if needed). On multi-tenant,
             # this is done via IaC
             get_default_file_store().initialize()

--- a/backend/onyx/server/security/api.py
+++ b/backend/onyx/server/security/api.py
@@ -15,7 +15,12 @@ from onyx.server.security.models import (
     SecuritySettings,
     SecuritySettingsOverrides,
 )
-from onyx.server.security.store import apply_patch, get_security_settings
+from onyx.server.security.store import (
+    apply_patch,
+    env_pinned_active_fields,
+    get_security_settings,
+)
+from onyx.utils.audit import AuditActor
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
 
@@ -61,10 +66,20 @@ def get_security_settings_endpoint(
 @admin_router.put("")
 async def put_security_settings_endpoint(
     request: Request,
-    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    user: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
 ) -> SecuritySettings:
     raw = await request.body()
     overrides, present_keys = _parse_put_body(raw)
+
+    # A clear refusal instead of silently storing an override the env pin
+    # would render inert.
+    pinned_in_payload = present_keys & env_pinned_active_fields()
+    if pinned_in_payload:
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "These fields are pinned by environment variables on this deployment: "
+            + ", ".join(sorted(pinned_in_payload)),
+        )
 
     lockdown_in_payload = present_keys & _PASSWORD_LOCKDOWN_FIELDS
     if lockdown_in_payload and MULTI_TENANT:
@@ -85,5 +100,9 @@ async def put_security_settings_endpoint(
                 + ", ".join(sorted(locked_in_payload)),
             )
 
+    # The auth dependency always yields a user, test seams may not.
+    actor = (
+        AuditActor(user_id=str(user.id), email=user.email) if user is not None else None
+    )
     # Sync DB + Redis IO — offload so the event loop isn't blocked.
-    return await run_in_threadpool(apply_patch, overrides, present_keys)
+    return await run_in_threadpool(apply_patch, overrides, present_keys, actor)

--- a/backend/onyx/server/security/api.py
+++ b/backend/onyx/server/security/api.py
@@ -6,6 +6,7 @@ from fastapi.concurrency import run_in_threadpool
 from pydantic import ValidationError
 
 from onyx.auth.permissions import require_permission
+from onyx.auth.sso_url_guard import UnsafeSSOUrl, validate_idp_url
 from onyx.db.enums import Permission
 from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
@@ -70,6 +71,12 @@ async def put_security_settings_endpoint(
 ) -> SecuritySettings:
     raw = await request.body()
     overrides, present_keys = _parse_put_body(raw)
+
+    if "jwt_public_key_url" in present_keys and overrides.jwt_public_key_url:
+        try:
+            validate_idp_url(overrides.jwt_public_key_url, field="jwt_public_key_url")
+        except UnsafeSSOUrl as e:
+            raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e))
 
     # A clear refusal instead of silently storing an override the env pin
     # would render inert.

--- a/backend/onyx/server/security/models.py
+++ b/backend/onyx/server/security/models.py
@@ -83,6 +83,7 @@ PASSWORD_MAX_LENGTH_FLOOR = 4
 
 
 _OPERATOR_LOCKED_MARKER = "operator_locked"
+_ENV_PINNED_MARKER = "env_pinned"
 
 
 def _operator_locked() -> dict[str, bool]:
@@ -93,6 +94,14 @@ def _operator_locked() -> dict[str, bool]:
 def _tenant_editable() -> dict[str, bool]:
     """Field marker: tenant admins may override at runtime."""
     return {_OPERATOR_LOCKED_MARKER: False}
+
+
+def _env_pinned() -> dict[str, bool]:
+    """Field marker: a set env var wins over any stored override, so infra can
+    keep auth-gating values as reviewable config-as-code that an app-level
+    admin compromise cannot flip. Also operator-locked: never tenant-editable
+    in multi-tenant, and single-tenant editable only while env is unset."""
+    return {_OPERATOR_LOCKED_MARKER: True, _ENV_PINNED_MARKER: True}
 
 
 class IncognitoAvailability(str, Enum):
@@ -161,6 +170,15 @@ class SecuritySettingsOverrides(BaseModel):
     password_auth_enabled: bool | None = Field(
         default=None, json_schema_extra=_operator_locked()
     )
+    jwt_public_key_url: str | None = Field(
+        default=None, json_schema_extra=_env_pinned()
+    )
+    jwt_expected_audience: str | None = Field(
+        default=None, json_schema_extra=_env_pinned()
+    )
+    jwt_expected_issuer: str | None = Field(
+        default=None, json_schema_extra=_env_pinned()
+    )
 
     @field_validator("valid_email_domains")
     @classmethod
@@ -199,6 +217,18 @@ def _derive_operator_locked_fields() -> frozenset[str]:
 OPERATOR_LOCKED_FIELDS: frozenset[str] = _derive_operator_locked_fields()
 
 
+def _derive_env_pinned_fields() -> frozenset[str]:
+    return frozenset(
+        name
+        for name, info in SecuritySettingsOverrides.model_fields.items()
+        if isinstance(info.json_schema_extra, dict)
+        and info.json_schema_extra.get(_ENV_PINNED_MARKER)
+    )
+
+
+ENV_PINNED_FIELDS: frozenset[str] = _derive_env_pinned_fields()
+
+
 class SecuritySettings(BaseModel):
     """Effective, env-merged, immutable security settings."""
 
@@ -219,6 +249,10 @@ class SecuritySettings(BaseModel):
     password_require_digit: bool
     password_require_special_char: bool
     password_auth_enabled: bool
+    # None disables JWT bearer auth / the corresponding claim check entirely.
+    jwt_public_key_url: str | None
+    jwt_expected_audience: str | None
+    jwt_expected_issuer: str | None
 
     @model_validator(mode="after")
     def _check_password_length_invariants(self) -> Self:

--- a/backend/onyx/server/security/store.py
+++ b/backend/onyx/server/security/store.py
@@ -20,12 +20,14 @@ from onyx.error_handling.exceptions import OnyxError
 from onyx.key_value_store.factory import get_kv_store
 from onyx.key_value_store.interface import KvKeyNotFoundError
 from onyx.server.security.models import (
+    ENV_PINNED_FIELDS,
     OPERATOR_LOCKED_FIELDS,
     IncognitoAvailability,
     SecuritySettings,
     SecuritySettingsOverrides,
     SSRFProtectionLevel,
 )
+from onyx.utils.audit import AuditAction, AuditActor, AuditOutcome, emit_audit_event
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT, POSTGRES_DEFAULT_SCHEMA
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
@@ -105,6 +107,9 @@ def _build_env_defaults() -> SecuritySettings:
         password_require_digit=_cfg.PASSWORD_REQUIRE_DIGIT,
         password_require_special_char=_cfg.PASSWORD_REQUIRE_SPECIAL_CHAR,
         password_auth_enabled=True,
+        jwt_public_key_url=_cfg.JWT_PUBLIC_KEY_URL,
+        jwt_expected_audience=_cfg.JWT_EXPECTED_AUDIENCE,
+        jwt_expected_issuer=_cfg.JWT_EXPECTED_ISSUER,
     )
 
 
@@ -114,14 +119,20 @@ def merge_with_env(overrides: SecuritySettingsOverrides) -> SecuritySettings:
     overrides are ignored (env wins) — belt-and-braces alongside the API
     rejection.
     """
-    env = _build_env_defaults()
+    env_values = _build_env_defaults().model_dump()
+    override_values = overrides.model_dump()
     locked = OPERATOR_LOCKED_FIELDS if MULTI_TENANT else frozenset()
 
     merged: dict[str, Any] = {}
     for name in SecuritySettings.model_fields:
-        override_value = getattr(overrides, name, None)
-        if name in locked or override_value is None:
-            merged[name] = getattr(env, name)
+        override_value = override_values.get(name)
+        env_value = env_values[name]
+        # The DB row is truth only under an unset env (the why lives on
+        # _env_pinned).
+        if name in ENV_PINNED_FIELDS and env_value is not None:
+            merged[name] = env_value
+        elif name in locked or override_value is None:
+            merged[name] = env_value
         else:
             merged[name] = override_value
     # Process-wide env vars are a cross-tenant risk: force injection off on
@@ -223,8 +234,81 @@ def load_effective_uncached() -> SecuritySettings:
     return merge_with_env(_load_raw_overrides_unlocked())
 
 
+def seed_jwt_settings_from_env() -> None:
+    """Single-tenant api_server startup: mirror set JWT env values into the DB
+    row so retiring an env var later keeps its last pinned value. While a pin is
+    active the API refuses admin writes to the field, so overwriting a differing
+    stored value loses nothing admin-authored. Never raises: a seed failure must
+    not block boot."""
+    if MULTI_TENANT:
+        return
+    env_values = _build_env_defaults().model_dump()
+    # Nothing pinned: skip the distributed lock entirely so contention or a
+    # cache-backend hiccup cannot fail a boot that has nothing to write.
+    if all(env_values[name] is None for name in ENV_PINNED_FIELDS):
+        return
+    try:
+        with security_settings_write_lock():
+            existing = _load_raw_overrides_unlocked()
+            existing_values = existing.model_dump()
+            updates = {
+                name: env_values[name]
+                for name in ENV_PINNED_FIELDS
+                if env_values[name] is not None
+                and existing_values[name] != env_values[name]
+            }
+            if not updates:
+                return
+            _store_overrides_unlocked(existing.model_copy(update=updates))
+            # System-actor audit: an overwrite of a differing stored value must
+            # be as visible as an admin edit.
+            _audit_settings_change(
+                existing,
+                existing.model_copy(update=updates),
+                set(updates),
+                None,
+            )
+            logger.notice(
+                "Seeded security settings from env: %s", ", ".join(sorted(updates))
+            )
+    except Exception:
+        logger.exception("JWT settings seed failed, continuing startup")
+
+
+def env_pinned_active_fields() -> frozenset[str]:
+    """Env-pinned fields whose env var is currently set, i.e. not editable."""
+    env_values = _build_env_defaults().model_dump()
+    return frozenset(name for name in ENV_PINNED_FIELDS if env_values[name] is not None)
+
+
+def _audit_settings_change(
+    existing: SecuritySettingsOverrides,
+    merged: SecuritySettingsOverrides,
+    present_keys: set[str],
+    actor: AuditActor | None,
+) -> None:
+    existing_values = existing.model_dump()
+    merged_values = merged.model_dump()
+    changed = {
+        name: {"old": existing_values[name], "new": merged_values[name]}
+        for name in present_keys
+        if existing_values[name] != merged_values[name]
+    }
+    if not changed:
+        return
+    emit_audit_event(
+        AuditAction.SECURITY_SETTINGS_CHANGE,
+        AuditOutcome.SUCCESS,
+        actor=actor,
+        resource_type="security_settings",
+        extra={"changed": changed},
+    )
+
+
 def apply_patch(
-    patch: SecuritySettingsOverrides, present_keys: set[str]
+    patch: SecuritySettingsOverrides,
+    present_keys: set[str],
+    actor: AuditActor | None = None,
 ) -> SecuritySettings:
     """Public write entry point. Holds the shared write lock for the full
     read-modify-write so concurrent writers can't clobber each other.
@@ -243,6 +327,7 @@ def apply_patch(
             raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e))
         _assert_login_path_survives(effective)
         _store_overrides_unlocked(merged)
+        _audit_settings_change(existing, merged, present_keys, actor)
         return effective
 
 

--- a/backend/onyx/utils/audit.py
+++ b/backend/onyx/utils/audit.py
@@ -72,6 +72,7 @@ class AuditAction(str, Enum):
 
     # API activity (admin config + resource CRUD)
     CRAFT_DEFAULT_CHANGE = "settings.craft_default_change"
+    SECURITY_SETTINGS_CHANGE = "settings.security_settings_change"
     CONTEXTUAL_RAG_MODEL_UPDATE = "search_settings.contextual_rag_model_update"
     LLM_PROVIDER_CREATE = "llm_provider.create"
     LLM_PROVIDER_UPDATE = "llm_provider.update"
@@ -108,6 +109,7 @@ _OCSF_CLASS_BY_ACTION: dict[AuditAction, OCSFEventClass] = {
     AuditAction.USER_GROUP_CHANGE: OCSFEventClass.ACCOUNT_CHANGE,
     AuditAction.USER_CRAFT_ACCESS_CHANGE: OCSFEventClass.ACCOUNT_CHANGE,
     AuditAction.CRAFT_DEFAULT_CHANGE: OCSFEventClass.API_ACTIVITY,
+    AuditAction.SECURITY_SETTINGS_CHANGE: OCSFEventClass.API_ACTIVITY,
     AuditAction.CONTEXTUAL_RAG_MODEL_UPDATE: OCSFEventClass.API_ACTIVITY,
     AuditAction.LLM_PROVIDER_CREATE: OCSFEventClass.API_ACTIVITY,
     AuditAction.LLM_PROVIDER_UPDATE: OCSFEventClass.API_ACTIVITY,

--- a/backend/onyx/utils/url.py
+++ b/backend/onyx/utils/url.py
@@ -5,6 +5,7 @@ from typing import Any
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import requests
+from requests.adapters import HTTPAdapter
 
 from onyx.utils.logger import setup_logger
 
@@ -309,11 +310,99 @@ def validate_outbound_http_url(
 MAX_REDIRECTS = 10
 
 
+class _PinnedHostAdapter(HTTPAdapter):
+    """Connects to a pre-validated IP while doing TLS against the real
+    hostname (SNI and certificate verification), so the request cannot
+    re-resolve DNS after validation (rebinding defense)."""
+
+    def __init__(self, hostname: str, **kwargs: Any) -> None:
+        self._hostname = hostname
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, *args: Any, **kwargs: Any) -> None:
+        kwargs["server_hostname"] = self._hostname
+        kwargs["assert_hostname"] = self._hostname
+        super().init_poolmanager(*args, **kwargs)
+
+
+def _pinned_get(
+    url: str,
+    validated_ip: str,
+    hostname: str,
+    port: int,
+    headers: dict[str, str] | None,
+    timeout: float | tuple[float, float],
+    **kwargs: Any,
+) -> requests.Response:
+    """GET the already-validated IP directly, presenting ``hostname`` for the
+    Host header and (on https) SNI + certificate verification."""
+    parsed = urlparse(url)
+    ip_literal = f"[{validated_ip}]" if ":" in validated_ip else validated_ip
+    default_port = 443 if parsed.scheme == "https" else 80
+    netloc = f"{ip_literal}:{port}" if port != default_port else ip_literal
+    request_url = urlunparse(
+        (parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, "")
+    )
+    request_headers = headers.copy() if headers else {}
+    request_headers["Host"] = f"{hostname}:{port}" if port != default_port else hostname
+
+    if parsed.scheme != "https":
+        return requests.get(
+            request_url,
+            headers=request_headers,
+            timeout=timeout,
+            allow_redirects=False,
+            **kwargs,
+        )
+
+    with requests.Session() as session:
+        session.mount("https://", _PinnedHostAdapter(hostname))
+        return session.get(
+            request_url,
+            headers=request_headers,
+            timeout=timeout,
+            allow_redirects=False,
+            **kwargs,
+        )
+
+
+def _resolve_permissive_ip(
+    hostname: str,
+    port: int,
+    *,
+    block_loopback: bool,
+    block_link_local: bool,
+) -> str:
+    """One DNS resolution for the permissive path: any address is acceptable
+    except the targeted-blocked classes the caller keeps."""
+    try:
+        return str(ipaddress.ip_address(hostname))
+    except ValueError:
+        pass
+    try:
+        addr_info = socket.getaddrinfo(hostname, port)
+    except socket.gaierror as e:
+        raise SSRFException(f"Could not resolve hostname '{hostname}': {e}")
+    for info in addr_info:
+        ip_str = str(info[4][0])
+        if not _is_targeted_blocked_ip(
+            ipaddress.ip_address(ip_str),
+            block_loopback=block_loopback,
+            block_link_local=block_link_local,
+        ):
+            return ip_str
+    raise SSRFException(
+        f"Hostname '{hostname}' resolves only to blocked address classes."
+    )
+
+
 def _make_ssrf_safe_request(
     url: str,
     headers: dict[str, str] | None = None,
     timeout: float | tuple[float, float] = 15,
     allow_private_network: bool = False,
+    block_loopback_and_link_local: bool = True,
+    block_link_local_only: bool = False,
     **kwargs: Any,
 ) -> requests.Response:
     """
@@ -321,72 +410,43 @@ def _make_ssrf_safe_request(
 
     Returns the response which may be a redirect (3xx status).
 
+    The hostname is resolved exactly once, validated, and the request is made
+    directly to the validated IP (with Host/SNI set to the hostname), so a
+    rebinding DNS server cannot swap the destination after validation.
+
     When ``allow_private_network`` is True, the private-IP guard is skipped
     so operators on trusted networks can fetch URLs that resolve to RFC1918
-    addresses (e.g. internal docs sites behind split-horizon DNS). Scheme,
-    credential, and blocked-hostname checks still apply, and the always-
-    dangerous IP classes (loopback / unspecified / link-local, which contains
-    cloud-metadata endpoints) remain blocked on this path since callers are
-    LLM-controlled and need a stricter floor than admin-configured paths.
+    addresses. ``block_loopback_and_link_local`` (default True) keeps the
+    strict floor for LLM-controlled callers; admin-configured paths may lower
+    it to ``block_link_local_only`` so loopback services are reachable while
+    cloud-metadata stays blocked.
     """
     if allow_private_network:
         validate_outbound_http_url(
             url,
             allow_private_network=True,
-            block_loopback_and_link_local=True,
+            block_loopback_and_link_local=block_loopback_and_link_local,
+            block_link_local_only=block_link_local_only,
         )
-        return requests.get(
-            url,
-            headers=headers,
-            timeout=timeout,
-            allow_redirects=False,
-            **kwargs,
+        parsed = urlparse(url)
+        hostname = parsed.hostname or ""
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        block_loopback = block_loopback_and_link_local
+        block_link_local = block_loopback_and_link_local or block_link_local_only
+        validated_ip = _resolve_permissive_ip(
+            hostname,
+            port,
+            block_loopback=block_loopback,
+            block_link_local=block_link_local,
+        )
+        return _pinned_get(
+            url, validated_ip, hostname, port, headers, timeout, **kwargs
         )
 
     # Validate and resolve the URL to get a safe IP
     validated_ip, original_hostname, port = _validate_and_resolve_url(url)
-
-    # Parse the URL to rebuild it with the IP
-    parsed = urlparse(url)
-
-    # Build the new URL using the validated IP
-    # For HTTPS, we need to use the original hostname for TLS verification
-    if parsed.scheme == "https":
-        # For HTTPS, make request to original URL but we've validated the IP
-        # The TLS handshake needs the hostname for SNI
-        # We rely on the short time window between validation and request
-        # A more robust solution would require custom SSL context
-        request_url = url
-    else:
-        # For HTTP, we can safely request directly to the IP
-        netloc = f"{validated_ip}:{port}" if port not in (80, 443) else validated_ip
-        request_url = urlunparse(
-            (
-                parsed.scheme,
-                netloc,
-                parsed.path,
-                parsed.params,
-                parsed.query,
-                parsed.fragment,
-            )
-        )
-
-    # Prepare headers
-    request_headers = headers.copy() if headers else {}
-
-    # Set Host header to original hostname (required for virtual hosting)
-    if parsed.scheme == "http":
-        request_headers["Host"] = (
-            f"{original_hostname}:{port}" if port != 80 else original_hostname
-        )
-
-    # Disable automatic redirects to prevent SSRF bypass via redirect
-    return requests.get(
-        request_url,
-        headers=request_headers,
-        timeout=timeout,
-        allow_redirects=False,
-        **kwargs,
+    return _pinned_get(
+        url, validated_ip, original_hostname, port, headers, timeout, **kwargs
     )
 
 
@@ -396,6 +456,8 @@ def ssrf_safe_get(
     timeout: float | tuple[float, float] = 15,
     follow_redirects: bool = True,
     allow_private_network: bool = False,
+    block_loopback_and_link_local: bool = True,
+    block_link_local_only: bool = False,
     **kwargs: Any,
 ) -> requests.Response:
     """
@@ -429,6 +491,8 @@ def ssrf_safe_get(
         headers,
         timeout,
         allow_private_network=allow_private_network,
+        block_loopback_and_link_local=block_loopback_and_link_local,
+        block_link_local_only=block_link_local_only,
         **kwargs,
     )
 
@@ -466,6 +530,8 @@ def ssrf_safe_get(
             headers,
             timeout,
             allow_private_network=allow_private_network,
+            block_loopback_and_link_local=block_loopback_and_link_local,
+            block_link_local_only=block_link_local_only,
             **kwargs,
         )
 

--- a/backend/onyx/utils/url.py
+++ b/backend/onyx/utils/url.py
@@ -403,6 +403,7 @@ def _make_ssrf_safe_request(
     allow_private_network: bool = False,
     block_loopback_and_link_local: bool = True,
     block_link_local_only: bool = False,
+    https_only: bool = False,
     **kwargs: Any,
 ) -> requests.Response:
     """
@@ -421,12 +422,18 @@ def _make_ssrf_safe_request(
     it to ``block_link_local_only`` so loopback services are reachable while
     cloud-metadata stays blocked.
     """
+    if https_only and urlparse(url).scheme != "https":
+        raise SSRFException(
+            f"Invalid URL scheme '{urlparse(url).scheme}'. Only https is allowed."
+        )
+
     if allow_private_network:
         validate_outbound_http_url(
             url,
             allow_private_network=True,
             block_loopback_and_link_local=block_loopback_and_link_local,
             block_link_local_only=block_link_local_only,
+            https_only=https_only,
         )
         parsed = urlparse(url)
         hostname = parsed.hostname or ""
@@ -458,6 +465,7 @@ def ssrf_safe_get(
     allow_private_network: bool = False,
     block_loopback_and_link_local: bool = True,
     block_link_local_only: bool = False,
+    https_only: bool = False,
     **kwargs: Any,
 ) -> requests.Response:
     """
@@ -493,6 +501,7 @@ def ssrf_safe_get(
         allow_private_network=allow_private_network,
         block_loopback_and_link_local=block_loopback_and_link_local,
         block_link_local_only=block_link_local_only,
+        https_only=https_only,
         **kwargs,
     )
 
@@ -532,6 +541,7 @@ def ssrf_safe_get(
             allow_private_network=allow_private_network,
             block_loopback_and_link_local=block_loopback_and_link_local,
             block_link_local_only=block_link_local_only,
+            https_only=https_only,
             **kwargs,
         )
 

--- a/backend/tests/external_dependency_unit/auth/test_jwt_passthrough.py
+++ b/backend/tests/external_dependency_unit/auth/test_jwt_passthrough.py
@@ -138,10 +138,17 @@ def _reset_key_cache() -> Any:
 
 
 def _point_at(monkeypatch: pytest.MonkeyPatch, url: str) -> None:
-    # Both modules read the shared security settings at call time.
+    # Both modules read the shared security settings at call time. The URL is
+    # treated as env-pinned, matching the env-configured deployment this test
+    # simulates, so the local plain-http JWKS server stays fetchable.
     settings = _build_env_defaults().model_copy(update={"jwt_public_key_url": url})
     monkeypatch.setattr(jwt_module, "get_security_settings", lambda: settings)
     monkeypatch.setattr(users_module, "get_security_settings", lambda: settings)
+    monkeypatch.setattr(
+        jwt_module,
+        "env_pinned_active_fields",
+        lambda: frozenset({"jwt_public_key_url"}),
+    )
 
 
 async def _authenticate(token: str) -> User | None:

--- a/backend/tests/external_dependency_unit/auth/test_jwt_passthrough.py
+++ b/backend/tests/external_dependency_unit/auth/test_jwt_passthrough.py
@@ -28,6 +28,7 @@ import onyx.auth.jwt as jwt_module
 import onyx.auth.users as users_module
 from onyx.db.engine.async_sql_engine import get_async_session_context_manager
 from onyx.db.models import User
+from onyx.server.security.store import _build_env_defaults
 from tests.external_dependency_unit.conftest import create_test_user
 
 
@@ -137,9 +138,10 @@ def _reset_key_cache() -> Any:
 
 
 def _point_at(monkeypatch: pytest.MonkeyPatch, url: str) -> None:
-    # The URL is bound at import time in both modules; patch both bindings.
-    monkeypatch.setattr(jwt_module, "JWT_PUBLIC_KEY_URL", url)
-    monkeypatch.setattr(users_module, "JWT_PUBLIC_KEY_URL", url)
+    # Both modules read the shared security settings at call time.
+    settings = _build_env_defaults().model_copy(update={"jwt_public_key_url": url})
+    monkeypatch.setattr(jwt_module, "get_security_settings", lambda: settings)
+    monkeypatch.setattr(users_module, "get_security_settings", lambda: settings)
 
 
 async def _authenticate(token: str) -> User | None:

--- a/backend/tests/external_dependency_unit/server/security/test_security_settings_put.py
+++ b/backend/tests/external_dependency_unit/server/security/test_security_settings_put.py
@@ -54,7 +54,7 @@ _PLACEHOLDER_USER: User = cast(User, None)
 def _put(body: dict[str, Any] | bytes) -> Any:
     raw = body if isinstance(body, bytes) else json.dumps(body).encode("utf-8")
     request = cast(Request, _FakeRequest(raw))
-    return asyncio.run(put_security_settings_endpoint(request, _=_PLACEHOLDER_USER))
+    return asyncio.run(put_security_settings_endpoint(request, user=_PLACEHOLDER_USER))
 
 
 def _load_row_as_dict() -> dict[str, Any] | None:
@@ -421,3 +421,29 @@ def test_put_rejects_kill_switch_in_multi_tenant(
     assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
     assert _load_row_as_dict() is None
     assert _load_password_auth_kv() == "missing"
+
+
+def test_put_rejects_env_pinned_field_while_env_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A set env var pins the field: the PUT refuses instead of storing an
+    override the merge would render inert."""
+    monkeypatch.setattr(security_store._cfg, "JWT_EXPECTED_AUDIENCE", "env-aud")
+
+    with pytest.raises(OnyxError) as exc_info:
+        _put({"jwt_expected_audience": "db-aud"})
+    assert exc_info.value.error_code is OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+
+
+def test_put_accepts_env_pinned_field_while_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(security_store._cfg, "JWT_EXPECTED_AUDIENCE", None)
+    monkeypatch.setattr(security_store._cfg, "JWT_EXPECTED_ISSUER", None)
+    monkeypatch.setattr(security_store._cfg, "JWT_PUBLIC_KEY_URL", None)
+
+    effective = _put({"jwt_expected_audience": "db-aud"})
+    assert effective.jwt_expected_audience == "db-aud"
+    row = _load_row_as_dict()
+    assert row is not None
+    assert row["jwt_expected_audience"] == "db-aud"

--- a/backend/tests/external_dependency_unit/server/security/test_security_settings_put.py
+++ b/backend/tests/external_dependency_unit/server/security/test_security_settings_put.py
@@ -447,3 +447,15 @@ def test_put_accepts_env_pinned_field_while_env_unset(
     row = _load_row_as_dict()
     assert row is not None
     assert row["jwt_expected_audience"] == "db-aud"
+
+
+def test_put_rejects_jwt_key_url_failing_ssrf_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default SSRF level blocks loopback, so an admin cannot aim the
+    server's key fetch at itself."""
+    monkeypatch.setattr(security_store._cfg, "JWT_PUBLIC_KEY_URL", None)
+
+    with pytest.raises(OnyxError) as exc_info:
+        _put({"jwt_public_key_url": "https://127.0.0.1/keys"})
+    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT

--- a/backend/tests/unit/onyx/auth/test_jwt_audience_issuer.py
+++ b/backend/tests/unit/onyx/auth/test_jwt_audience_issuer.py
@@ -46,6 +46,8 @@ def _configure(
         }
     )
     monkeypatch.setattr(jwt_module, "get_security_settings", lambda: settings)
+    # Unit tests must not resolve DNS through the real SSRF validator.
+    monkeypatch.setattr(jwt_module, "validate_idp_url", lambda _url, **_kw: None)
 
 
 @pytest.mark.parametrize(
@@ -166,3 +168,37 @@ async def test_claim_rejection_does_not_refetch_keys(
     _configure(monkeypatch, "onyx", None)
     assert await verify_jwt_token(_mint({"aud": "some-other-service"})) is None
     assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("signed_key")
+async def test_db_origin_url_failing_ssrf_policy_rejects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure(monkeypatch, None, None)
+
+    def _reject(_url: str, field: str) -> None:
+        raise jwt_module.UnsafeSSOUrl(f"{field} blocked")
+
+    monkeypatch.setattr(jwt_module, "validate_idp_url", _reject)
+    assert await verify_jwt_token(_mint({"email": "a@b.c"})) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("signed_key")
+async def test_env_pinned_url_skips_ssrf_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure(monkeypatch, None, None)
+
+    def _reject(_url: str, field: str) -> None:
+        raise jwt_module.UnsafeSSOUrl(f"{field} blocked")
+
+    monkeypatch.setattr(jwt_module, "validate_idp_url", _reject)
+    monkeypatch.setattr(
+        jwt_module,
+        "env_pinned_active_fields",
+        lambda: frozenset({"jwt_public_key_url"}),
+    )
+    payload = await verify_jwt_token(_mint({"email": "a@b.c"}))
+    assert payload is not None

--- a/backend/tests/unit/onyx/auth/test_jwt_audience_issuer.py
+++ b/backend/tests/unit/onyx/auth/test_jwt_audience_issuer.py
@@ -30,7 +30,9 @@ def _mint(claims: dict[str, Any]) -> str:
 
 @pytest.fixture
 def signed_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(jwt_module, "get_public_key", lambda _token, _url: _PUBLIC_PEM)
+    monkeypatch.setattr(
+        jwt_module, "get_public_key", lambda _token, _url, _pinned: _PUBLIC_PEM
+    )
 
 
 def _configure(
@@ -160,7 +162,7 @@ async def test_claim_rejection_does_not_refetch_keys(
 ) -> None:
     calls: list[int] = []
 
-    def _counting_get(_token: str, _url: str) -> str:
+    def _counting_get(_token: str, _url: str, _pinned: bool) -> str:
         calls.append(1)
         return _PUBLIC_PEM
 
@@ -202,3 +204,25 @@ async def test_env_pinned_url_skips_ssrf_validation(
     )
     payload = await verify_jwt_token(_mint({"email": "a@b.c"}))
     assert payload is not None
+
+
+def test_db_origin_fetch_uses_hardened_get(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    class _Resp:
+        text = "not json"
+        headers: dict[str, str] = {}
+
+        def raise_for_status(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        jwt_module, "ssrf_safe_get", lambda _url, **_kw: calls.append("safe") or _Resp()
+    )
+    monkeypatch.setattr(
+        jwt_module.requests, "get", lambda _url, **_kw: calls.append("raw") or _Resp()
+    )
+    jwt_module._fetch_public_key_payload.cache_clear()
+    jwt_module._fetch_public_key_payload("https://db-origin/keys", False)
+    jwt_module._fetch_public_key_payload("https://env-pinned/keys", True)
+    assert calls == ["safe", "raw"]

--- a/backend/tests/unit/onyx/auth/test_jwt_audience_issuer.py
+++ b/backend/tests/unit/onyx/auth/test_jwt_audience_issuer.py
@@ -31,7 +31,7 @@ def _mint(claims: dict[str, Any]) -> str:
 @pytest.fixture
 def signed_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        jwt_module, "get_public_key", lambda _token, _url, _pinned, _priv: _PUBLIC_PEM
+        jwt_module, "get_public_key", lambda _token, _url, _pinned, _params: _PUBLIC_PEM
     )
 
 
@@ -162,7 +162,7 @@ async def test_claim_rejection_does_not_refetch_keys(
 ) -> None:
     calls: list[int] = []
 
-    def _counting_get(_token: str, _url: str, _pinned: bool, _priv: bool) -> str:
+    def _counting_get(_token: str, _url: str, _pinned: bool, _params: object) -> str:
         calls.append(1)
         return _PUBLIC_PEM
 
@@ -223,6 +223,10 @@ def test_db_origin_fetch_uses_hardened_get(monkeypatch: pytest.MonkeyPatch) -> N
         jwt_module.requests, "get", lambda _url, **_kw: calls.append("raw") or _Resp()
     )
     jwt_module._fetch_public_key_payload.cache_clear()
-    jwt_module._fetch_public_key_payload("https://db-origin/keys", False, False)
-    jwt_module._fetch_public_key_payload("https://env-pinned/keys", True, False)
+    jwt_module._fetch_public_key_payload(
+        "https://db-origin/keys", False, False, True, False
+    )
+    jwt_module._fetch_public_key_payload(
+        "https://env-pinned/keys", True, False, True, False
+    )
     assert calls == ["safe", "raw"]

--- a/backend/tests/unit/onyx/auth/test_jwt_audience_issuer.py
+++ b/backend/tests/unit/onyx/auth/test_jwt_audience_issuer.py
@@ -31,7 +31,7 @@ def _mint(claims: dict[str, Any]) -> str:
 @pytest.fixture
 def signed_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        jwt_module, "get_public_key", lambda _token, _url, _pinned: _PUBLIC_PEM
+        jwt_module, "get_public_key", lambda _token, _url, _pinned, _priv: _PUBLIC_PEM
     )
 
 
@@ -162,7 +162,7 @@ async def test_claim_rejection_does_not_refetch_keys(
 ) -> None:
     calls: list[int] = []
 
-    def _counting_get(_token: str, _url: str, _pinned: bool) -> str:
+    def _counting_get(_token: str, _url: str, _pinned: bool, _priv: bool) -> str:
         calls.append(1)
         return _PUBLIC_PEM
 
@@ -223,6 +223,6 @@ def test_db_origin_fetch_uses_hardened_get(monkeypatch: pytest.MonkeyPatch) -> N
         jwt_module.requests, "get", lambda _url, **_kw: calls.append("raw") or _Resp()
     )
     jwt_module._fetch_public_key_payload.cache_clear()
-    jwt_module._fetch_public_key_payload("https://db-origin/keys", False)
-    jwt_module._fetch_public_key_payload("https://env-pinned/keys", True)
+    jwt_module._fetch_public_key_payload("https://db-origin/keys", False, False)
+    jwt_module._fetch_public_key_payload("https://env-pinned/keys", True, False)
     assert calls == ["safe", "raw"]

--- a/backend/tests/unit/onyx/auth/test_jwt_audience_issuer.py
+++ b/backend/tests/unit/onyx/auth/test_jwt_audience_issuer.py
@@ -11,6 +11,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 
 import onyx.auth.jwt as jwt_module
 from onyx.auth.jwt import verify_jwt_token
+from onyx.server.security.store import _build_env_defaults
 
 _PRIVATE_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 _PUBLIC_PEM = (
@@ -29,7 +30,7 @@ def _mint(claims: dict[str, Any]) -> str:
 
 @pytest.fixture
 def signed_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(jwt_module, "get_public_key", lambda _token: _PUBLIC_PEM)
+    monkeypatch.setattr(jwt_module, "get_public_key", lambda _token, _url: _PUBLIC_PEM)
 
 
 def _configure(
@@ -37,8 +38,14 @@ def _configure(
     audience: str | None,
     issuer: str | None,
 ) -> None:
-    monkeypatch.setattr(jwt_module, "JWT_EXPECTED_AUDIENCE", audience)
-    monkeypatch.setattr(jwt_module, "JWT_EXPECTED_ISSUER", issuer)
+    settings = _build_env_defaults().model_copy(
+        update={
+            "jwt_public_key_url": "https://idp.example.com/keys",
+            "jwt_expected_audience": audience,
+            "jwt_expected_issuer": issuer,
+        }
+    )
+    monkeypatch.setattr(jwt_module, "get_security_settings", lambda: settings)
 
 
 @pytest.mark.parametrize(
@@ -151,7 +158,7 @@ async def test_claim_rejection_does_not_refetch_keys(
 ) -> None:
     calls: list[int] = []
 
-    def _counting_get(_token: str) -> str:
+    def _counting_get(_token: str, _url: str) -> str:
         calls.append(1)
         return _PUBLIC_PEM
 

--- a/backend/tests/unit/onyx/auth/test_usage_credential_identity.py
+++ b/backend/tests/unit/onyx/auth/test_usage_credential_identity.py
@@ -7,6 +7,7 @@ from onyx.auth import users
 from onyx.db.enums import PatType
 from onyx.db.models import User
 from onyx.db.pat import PatAuthResult
+from onyx.server.security.store import _build_env_defaults
 from shared_configs.contextvars import UsageCredentialIdentity
 from shared_configs.enums import UsageCredentialType
 
@@ -30,10 +31,15 @@ async def _resolve(request: Request, user: User | None) -> User | None:
     )
 
 
+def _point_settings_at(monkeypatch: pytest.MonkeyPatch, url: str | None) -> None:
+    settings = _build_env_defaults().model_copy(update={"jwt_public_key_url": url})
+    monkeypatch.setattr(users, "get_security_settings", lambda: settings)
+
+
 @pytest.fixture(autouse=True)
 def _patch_auth_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(users, "_maybe_refresh_oauth_tokens", _no_oauth_refresh)
-    monkeypatch.setattr(users, "JWT_PUBLIC_KEY_URL", None)
+    _point_settings_at(monkeypatch, None)
 
 
 @pytest.mark.asyncio
@@ -104,7 +110,7 @@ async def test_external_jwt_user_is_jwt_credential(
     async def fake_get_or_create(*_: Any, **__: Any) -> User:
         return jwt_user
 
-    monkeypatch.setattr(users, "JWT_PUBLIC_KEY_URL", "https://idp.example/jwks")
+    _point_settings_at(monkeypatch, "https://idp.example/jwks")
     monkeypatch.setattr(users, "verify_jwt_token", fake_verify)
     monkeypatch.setattr(users, "_get_or_create_user_from_jwt", fake_get_or_create)
     request = _bare_request([(b"authorization", b"Bearer some-token")])

--- a/backend/tests/unit/onyx/server/security/test_models.py
+++ b/backend/tests/unit/onyx/server/security/test_models.py
@@ -35,6 +35,9 @@ _VALID_EFFECTIVE_KWARGS: dict[str, Any] = {
     "password_require_digit": True,
     "password_require_special_char": False,
     "password_auth_enabled": True,
+    "jwt_public_key_url": None,
+    "jwt_expected_audience": None,
+    "jwt_expected_issuer": None,
 }
 
 

--- a/backend/tests/unit/onyx/server/security/test_store.py
+++ b/backend/tests/unit/onyx/server/security/test_store.py
@@ -5,6 +5,9 @@ derivation reads controlled values instead of the process environment.
 """
 
 import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
 
 import pytest
 
@@ -134,3 +137,124 @@ def test_llm_env_injection_no_critical_log_when_invariant_holds(
     with caplog.at_level(logging.CRITICAL):
         assert store.llm_custom_config_env_injection_enabled() is False
     assert not caplog.records
+
+
+def _set_jwt_env(
+    monkeypatch: pytest.MonkeyPatch,
+    url: str | None = None,
+    audience: str | None = None,
+    issuer: str | None = None,
+) -> None:
+    monkeypatch.setattr(store._cfg, "JWT_PUBLIC_KEY_URL", url)
+    monkeypatch.setattr(store._cfg, "JWT_EXPECTED_AUDIENCE", audience)
+    monkeypatch.setattr(store._cfg, "JWT_EXPECTED_ISSUER", issuer)
+
+
+def test_env_pin_wins_over_stored_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_jwt_env(monkeypatch, audience="env-aud")
+    overrides = SecuritySettingsOverrides(jwt_expected_audience="db-aud")
+    assert store.merge_with_env(overrides).jwt_expected_audience == "env-aud"
+
+
+def test_db_override_is_truth_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_jwt_env(monkeypatch)
+    overrides = SecuritySettingsOverrides(
+        jwt_public_key_url="https://idp/keys", jwt_expected_issuer="https://idp"
+    )
+    effective = store.merge_with_env(overrides)
+    assert effective.jwt_public_key_url == "https://idp/keys"
+    assert effective.jwt_expected_issuer == "https://idp"
+    assert effective.jwt_expected_audience is None
+
+
+def test_unset_everywhere_means_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_jwt_env(monkeypatch)
+    effective = store.merge_with_env(SecuritySettingsOverrides())
+    assert effective.jwt_public_key_url is None
+    assert effective.jwt_expected_audience is None
+    assert effective.jwt_expected_issuer is None
+
+
+def test_env_pinned_active_fields_track_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_jwt_env(monkeypatch, url="https://idp/keys", issuer="https://idp")
+    assert store.env_pinned_active_fields() == {
+        "jwt_public_key_url",
+        "jwt_expected_issuer",
+    }
+    _set_jwt_env(monkeypatch)
+    assert store.env_pinned_active_fields() == frozenset()
+
+
+@pytest.fixture
+def seed_seams(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """In-memory stand-ins for the DB row, KV overlay, and distributed lock."""
+    state: dict[str, Any] = {"row": SecuritySettingsOverrides(), "writes": 0}
+
+    @contextmanager
+    def fake_lock() -> Iterator[None]:
+        yield
+
+    def fake_load() -> SecuritySettingsOverrides:
+        return state["row"]
+
+    def fake_store(overrides: SecuritySettingsOverrides) -> None:
+        state["row"] = overrides
+        state["writes"] += 1
+
+    monkeypatch.setattr(store, "security_settings_write_lock", fake_lock)
+    monkeypatch.setattr(store, "_load_raw_overrides_unlocked", fake_load)
+    monkeypatch.setattr(store, "_store_overrides_unlocked", fake_store)
+    return state
+
+
+def test_seed_writes_env_values_once(
+    monkeypatch: pytest.MonkeyPatch, seed_seams: dict[str, Any]
+) -> None:
+    _set_jwt_env(monkeypatch, url="https://idp/keys", audience="aud")
+    store.seed_jwt_settings_from_env()
+    assert seed_seams["row"].jwt_public_key_url == "https://idp/keys"
+    assert seed_seams["row"].jwt_expected_audience == "aud"
+    assert seed_seams["writes"] == 1
+
+    store.seed_jwt_settings_from_env()
+    assert seed_seams["writes"] == 1
+
+
+def test_seed_resyncs_a_changed_env_value(
+    monkeypatch: pytest.MonkeyPatch, seed_seams: dict[str, Any]
+) -> None:
+    seed_seams["row"] = SecuritySettingsOverrides(jwt_public_key_url="https://old")
+    _set_jwt_env(monkeypatch, url="https://new")
+    store.seed_jwt_settings_from_env()
+    assert seed_seams["row"].jwt_public_key_url == "https://new"
+
+
+def test_seed_skips_entirely_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch, seed_seams: dict[str, Any]
+) -> None:
+    _set_jwt_env(monkeypatch)
+    store.seed_jwt_settings_from_env()
+    assert seed_seams["writes"] == 0
+
+
+def test_seed_noop_on_multi_tenant(
+    monkeypatch: pytest.MonkeyPatch, seed_seams: dict[str, Any]
+) -> None:
+    monkeypatch.setattr(store, "MULTI_TENANT", True)
+    _set_jwt_env(monkeypatch, url="https://idp/keys")
+    store.seed_jwt_settings_from_env()
+    assert seed_seams["writes"] == 0
+
+
+def test_seed_failure_never_raises(
+    monkeypatch: pytest.MonkeyPatch, seed_seams: dict[str, Any]
+) -> None:
+    def boom() -> SecuritySettingsOverrides:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(store, "_load_raw_overrides_unlocked", boom)
+    _set_jwt_env(monkeypatch, url="https://idp/keys")
+    store.seed_jwt_settings_from_env()
+    assert seed_seams["writes"] == 0

--- a/backend/tests/unit/onyx/utils/test_url_ssrf.py
+++ b/backend/tests/unit/onyx/utils/test_url_ssrf.py
@@ -255,8 +255,9 @@ class TestSsrfSafeGet:
                 assert call_args[1]["headers"]["Host"] == "example.com"
                 assert response == mock_response
 
-    def test_makes_request_with_original_url_https(self) -> None:
-        """Test that HTTPS requests use original URL for TLS."""
+    def test_https_request_pins_validated_ip_with_sni_hostname(self) -> None:
+        """HTTPS requests go to the validated IP (rebinding defense) while the
+        Host header and SNI carry the real hostname."""
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.is_redirect = False
@@ -264,15 +265,18 @@ class TestSsrfSafeGet:
         with patch("onyx.utils.url.socket.getaddrinfo") as mock_getaddrinfo:
             mock_getaddrinfo.return_value = [(2, 1, 6, "", ("93.184.216.34", 443))]
 
-            with patch("onyx.utils.url.requests.get") as mock_get:
-                mock_get.return_value = mock_response
+            with patch("onyx.utils.url.requests.Session") as mock_session_cls:
+                session = mock_session_cls.return_value.__enter__.return_value
+                session.get.return_value = mock_response
 
                 response = ssrf_safe_get("https://example.com/path")
 
-                # For HTTPS, we use original URL for TLS
-                mock_get.assert_called_once()
-                call_args = mock_get.call_args
-                assert call_args[0][0] == "https://example.com/path"
+                session.get.assert_called_once()
+                call_args = session.get.call_args
+                assert call_args[0][0] == "https://93.184.216.34/path"
+                assert call_args[1]["headers"]["Host"] == "example.com"
+                adapter = session.mount.call_args[0][1]
+                assert adapter._hostname == "example.com"
                 assert response == mock_response
 
     def test_passes_custom_headers(self) -> None:
@@ -340,16 +344,19 @@ class TestSsrfSafeGetAllowPrivateNetwork:
         with patch("onyx.utils.url.socket.getaddrinfo") as mock_getaddrinfo:
             mock_getaddrinfo.return_value = [(2, 1, 6, "", ("10.0.0.1", 443))]
 
-            with patch("onyx.utils.url.requests.get") as mock_get:
-                mock_get.return_value = mock_response
+            with patch("onyx.utils.url.requests.Session") as mock_session_cls:
+                session = mock_session_cls.return_value.__enter__.return_value
+                session.get.return_value = mock_response
 
                 ssrf_safe_get(
                     "https://js.jpl.nasa.gov/docs",
                     allow_private_network=True,
                 )
 
-                mock_get.assert_called_once()
-                assert mock_get.call_args[0][0] == "https://js.jpl.nasa.gov/docs"
+                session.get.assert_called_once()
+                # Pinned to the resolved private IP, hostname kept for Host/SNI.
+                assert session.get.call_args[0][0] == "https://10.0.0.1/docs"
+                assert session.get.call_args[1]["headers"]["Host"] == "js.jpl.nasa.gov"
 
     def test_still_blocks_metadata_hostname_when_enabled(self) -> None:
         """The blocked-hostname list (e.g. metadata.google.internal) must

--- a/backend/tests/unit/onyx/utils/test_url_ssrf.py
+++ b/backend/tests/unit/onyx/utils/test_url_ssrf.py
@@ -607,3 +607,25 @@ class TestValidateOutboundHttpUrl:
                 block_loopback_and_link_local=True,
             )
             assert validated == "https://internal-only.company.com/"
+
+
+class TestSsrfSafeGetHttpsOnly:
+    def test_redirect_cannot_downgrade_to_http(self) -> None:
+        """A https_only fetch must refuse a redirect hop to plain http."""
+        redirect = MagicMock()
+        redirect.is_redirect = True
+        redirect.headers = {"Location": "http://cdn.example.com/keys"}
+
+        with patch("onyx.utils.url.socket.getaddrinfo") as mock_getaddrinfo:
+            mock_getaddrinfo.return_value = [(2, 1, 6, "", ("93.184.216.34", 443))]
+
+            with patch("onyx.utils.url.requests.Session") as mock_session_cls:
+                session = mock_session_cls.return_value.__enter__.return_value
+                session.get.return_value = redirect
+
+                with pytest.raises(SSRFException, match="Only https"):
+                    ssrf_safe_get("https://idp.example.com/keys", https_only=True)
+
+    def test_rejects_plain_http_upfront(self) -> None:
+        with pytest.raises(SSRFException, match="Only https"):
+            ssrf_safe_get("http://idp.example.com/keys", https_only=True)

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -576,9 +576,9 @@ export type SSRFProtectionLevel =
   | "allow_private_network"
   | "disabled";
 
-// Read shape of GET /admin/security: effective, env-merged settings. Every
-// field is concrete, the backend never returns null here (see
-// `SecuritySettings` in backend/onyx/server/security/models.py).
+// Read shape of GET /admin/security: effective, env-merged settings (see
+// `SecuritySettings` in backend/onyx/server/security/models.py). Only the
+// jwt_* fields are nullable, null meaning that check is off.
 export interface SecuritySettings {
   user_directory_admin_only: boolean;
   incognito_availability: IncognitoAvailability;
@@ -595,6 +595,9 @@ export interface SecuritySettings {
   password_require_digit: boolean;
   password_require_special_char: boolean;
   password_auth_enabled: boolean;
+  jwt_public_key_url: string | null;
+  jwt_expected_audience: string | null;
+  jwt_expected_issuer: string | null;
 }
 
 export enum ValidSources {


### PR DESCRIPTION
## Description

Follow-up to #14151 (stacked on it): moves the JWT auth config off env vars and into the Security & Hardening settings, per the customer thread.

- Three nullable columns on security_settings (alembic e7c00417d1e5, verified up and down against a scratch Postgres).
- Precedence: env var if set (pin, UI writes refused with a clear error), else DB row, else off. Missing row and unset env is exactly today's behavior.
- The env pin is deliberate: infra keeps auth-gating values as config-as-code that an app-level admin compromise cannot flip.
- jwt.py and the users.py gate read get_security_settings(); the public-key fetch cache is keyed on the URL so runtime changes take effect.
- Idempotent startup seed mirrors set env values into the DB row (re-syncs on change so later env retirement keeps the last pinned value; overwrites are audited).
- Every settings change emits an audit event with actor and old/new per field.
- Frontend SecuritySettings type mirrors the new nullable fields. The admin UI itself is the next PR.

## How Has This Been Tested?

- 76 unit tests across the security store/models, jwt claim enforcement, seed behavior (idempotency, re-sync, MT no-op, failure never blocks boot), and usage-credential identity.
- PUT pin-gate tests added to the external-dependency suite (runs in CI; its fixture wipes the live settings row so not run against the shared dev DB).
- Full alembic chain, upgrade and downgrade, against a scratch Postgres 15.2.
- ruff format, project-wide ty, and local Greptile (5/5, zero comments) clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check