### PR TITLE
feat(admin): JWT auth settings on the Security & Hardening page

### DIFF
--- a/backend/onyx/server/security/api.py
+++ b/backend/onyx/server/security/api.py
@@ -64,6 +64,14 @@ def get_security_settings_endpoint(
     return get_security_settings()
 
 
+@admin_router.get("/pinned-fields")
+def get_pinned_fields_endpoint(
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+) -> list[str]:
+    """Fields currently pinned by env vars, so the UI can lock their inputs."""
+    return sorted(env_pinned_active_fields())
+
+
 @admin_router.put("")
 async def put_security_settings_endpoint(
     request: Request,

--- a/backend/tests/external_dependency_unit/server/security/test_security_settings_put.py
+++ b/backend/tests/external_dependency_unit/server/security/test_security_settings_put.py
@@ -26,7 +26,10 @@ from onyx.key_value_store.factory import get_kv_store
 from onyx.key_value_store.interface import KvKeyNotFoundError
 from onyx.server.security import api as security_api
 from onyx.server.security import store as security_store
-from onyx.server.security.api import put_security_settings_endpoint
+from onyx.server.security.api import (
+    get_pinned_fields_endpoint,
+    put_security_settings_endpoint,
+)
 from onyx.server.security.models import SecuritySettingsOverrides
 from onyx.server.security.store import (
     _build_env_defaults,
@@ -459,3 +462,12 @@ def test_put_rejects_jwt_key_url_failing_ssrf_policy(
     with pytest.raises(OnyxError) as exc_info:
         _put({"jwt_public_key_url": "https://127.0.0.1/keys"})
     assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
+
+
+def test_pinned_fields_endpoint_reflects_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(security_store._cfg, "JWT_EXPECTED_AUDIENCE", "env-aud")
+    monkeypatch.setattr(security_store._cfg, "JWT_EXPECTED_ISSUER", None)
+    monkeypatch.setattr(security_store._cfg, "JWT_PUBLIC_KEY_URL", None)
+    assert get_pinned_fields_endpoint(_PLACEHOLDER_USER) == ["jwt_expected_audience"]

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -20,6 +20,7 @@ export const SWR_KEYS = {
   customAnalyticsScript: "/api/enterprise-settings/custom-analytics-script",
   authType: "/api/auth/type",
   adminSecuritySettings: "/api/admin/security",
+  adminSecurityPinnedFields: "/api/admin/security/pinned-fields",
   incognitoAvailability: "/api/chat/incognito-availability",
   adminSsoProviders: "/api/admin/sso/provider",
   adminSsoProviderTypes: "/api/admin/sso/provider-type",

--- a/web/src/views/admin/SecurityHardeningPage.tsx
+++ b/web/src/views/admin/SecurityHardeningPage.tsx
@@ -146,9 +146,10 @@ export default function SecurityHardeningPage() {
       SWR_KEYS.adminSecuritySettings,
       errorHandlingFetcher
     );
-  const { data: pinnedFields, isLoading: pinnedFieldsLoading } = useSWR<
-    string[]
-  >(SWR_KEYS.adminSecurityPinnedFields, errorHandlingFetcher);
+  const { data: pinnedFields } = useSWR<string[]>(
+    SWR_KEYS.adminSecurityPinnedFields,
+    errorHandlingFetcher
+  );
 
   // Local state mirrors the loaded settings. We save on every committed change.
   const [draft, setDraft] = useState<SecuritySettings | null>(null);
@@ -205,7 +206,9 @@ export default function SecurityHardeningPage() {
           const fresh = await mutate<SecuritySettings>(
             SWR_KEYS.adminSecuritySettings
           );
-          if (fresh) setDraft(fresh);
+          // Re-checked after the await: an edit queued during the fetch owns
+          // the draft now.
+          if (fresh && savesQueued.current === 1) setDraft(fresh);
         }
       } catch {
         // If revalidation also fails (e.g. network down), the optimistic
@@ -244,7 +247,7 @@ export default function SecurityHardeningPage() {
     [doSave]
   );
 
-  if (settingsLoading || pinnedFieldsLoading || !draft) {
+  if (settingsLoading || !draft) {
     return (
       <SettingsLayouts.Root>
         <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
@@ -447,8 +450,9 @@ export default function SecurityHardeningPage() {
             </Card>
           )}
 
-          {/* External JWT auth (single-tenant only) */}
-          {!isMultiTenant && (
+          {/* External JWT auth (single-tenant only). Absent while the
+              pinned state is unknown, editability must never fail open. */}
+          {!isMultiTenant && pinnedFields && (
             <Card border="solid" rounding="lg">
               <Section>
                 <Content
@@ -463,7 +467,7 @@ export default function SecurityHardeningPage() {
                   description="JWKS or PEM endpoint used to verify token signatures. Leave empty to disable JWT authentication."
                   value={draft.jwt_public_key_url ?? ""}
                   placeholder="https://idp.example.com/.well-known/jwks.json"
-                  pinned={pinnedFields?.includes("jwt_public_key_url") ?? false}
+                  pinned={pinnedFields.includes("jwt_public_key_url")}
                   onCommit={(value) =>
                     saveSettings({ jwt_public_key_url: value || null })
                   }
@@ -474,9 +478,7 @@ export default function SecurityHardeningPage() {
                   description="Reject tokens whose aud claim does not match. Empty disables the check."
                   value={draft.jwt_expected_audience ?? ""}
                   placeholder="onyx"
-                  pinned={
-                    pinnedFields?.includes("jwt_expected_audience") ?? false
-                  }
+                  pinned={pinnedFields.includes("jwt_expected_audience")}
                   onCommit={(value) =>
                     saveSettings({ jwt_expected_audience: value || null })
                   }
@@ -487,9 +489,7 @@ export default function SecurityHardeningPage() {
                   description="Reject tokens whose iss claim does not match. Empty disables the check."
                   value={draft.jwt_expected_issuer ?? ""}
                   placeholder="https://idp.example.com"
-                  pinned={
-                    pinnedFields?.includes("jwt_expected_issuer") ?? false
-                  }
+                  pinned={pinnedFields.includes("jwt_expected_issuer")}
                   onCommit={(value) =>
                     saveSettings({ jwt_expected_issuer: value || null })
                   }

--- a/web/src/views/admin/SecurityHardeningPage.tsx
+++ b/web/src/views/admin/SecurityHardeningPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import useSWR, { mutate } from "swr";
 import { useAuthTypeMetadata } from "@/lib/auth/hooks";
 import { errorHandlingFetcher } from "@/lib/fetcher";
@@ -20,7 +20,7 @@ import {
   SettingsLayouts,
   toast,
 } from "@opal/layouts";
-import { Card, Switch } from "@opal/components";
+import { Card, InputTypeIn, Switch } from "@opal/components";
 import { markdown } from "@opal/utils";
 import type { RichStr } from "@opal/types";
 import type {
@@ -66,6 +66,69 @@ function ToggleRow({
   );
 }
 
+interface JwtTextRowProps {
+  title: string | RichStr;
+  description: string | RichStr;
+  value: string;
+  placeholder: string;
+  pinned: boolean;
+  onCommit: (value: string) => Promise<void>;
+}
+
+function JwtTextRow({
+  title,
+  description,
+  value,
+  placeholder,
+  pinned,
+  onCommit,
+}: JwtTextRowProps) {
+  const [text, setText] = useState(value);
+  // The revision bump resyncs after a commit settles even when `value` did not
+  // move, e.g. a failed clear where the optimistic patch drops nulls. A focused
+  // field is being edited, so the resync waits for the next blur.
+  const [revision, setRevision] = useState(0);
+  const [focused, setFocused] = useState(false);
+  // Commit only text the user typed this focus. A frozen unedited field must
+  // not overwrite a value that moved underneath it (another tab, env change).
+  const dirty = useRef(false);
+  useEffect(() => {
+    if (!focused) setText(value);
+  }, [value, revision, focused]);
+  return (
+    <InputVertical
+      title={title}
+      description={pinned ? "Pinned by an environment variable." : description}
+      withLabel
+    >
+      <InputTypeIn
+        value={text}
+        placeholder={placeholder}
+        variant={pinned ? "readOnly" : "primary"}
+        onChange={(e) => {
+          dirty.current = true;
+          setText(e.target.value);
+        }}
+        onFocus={() => {
+          dirty.current = false;
+          setFocused(true);
+        }}
+        onBlur={async () => {
+          setFocused(false);
+          const next = text.trim();
+          if (pinned || !dirty.current || next === value) return;
+          dirty.current = false;
+          await onCommit(next);
+          setRevision((r) => r + 1);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") e.currentTarget.blur();
+        }}
+      />
+    </InputVertical>
+  );
+}
+
 export default function SecurityHardeningPage() {
   const isMultiTenant = NEXT_PUBLIC_CLOUD_ENABLED;
   const { authTypeMetadata, isLoading: authTypeLoading } =
@@ -83,8 +146,11 @@ export default function SecurityHardeningPage() {
       SWR_KEYS.adminSecuritySettings,
       errorHandlingFetcher
     );
+  const { data: pinnedFields, isLoading: pinnedFieldsLoading } = useSWR<
+    string[]
+  >(SWR_KEYS.adminSecurityPinnedFields, errorHandlingFetcher);
 
-  // Local state mirrors the loaded settings; we save on every change.
+  // Local state mirrors the loaded settings. We save on every committed change.
   const [draft, setDraft] = useState<SecuritySettings | null>(null);
   const [domainInput, setDomainInput] = useState("");
   // The "Restrict Email Domains" toggle has no backing field — restriction is
@@ -92,22 +158,20 @@ export default function SecurityHardeningPage() {
   // and reveal the (still empty) input before typing the first domain. It stays
   // independent of `draft` so unrelated saves don't collapse the open input.
   const [forceShowDomains, setForceShowDomains] = useState(false);
+  // Saves are serialized through a promise chain: overlapping PUTs cannot
+  // exist. Only the last queued save adopts the server response, so a
+  // mid-queue response never erases a later edit's optimistic state (which
+  // full-value fields like the domain list read back at click time).
+  const saveQueue = useRef<Promise<void>>(Promise.resolve());
+  const savesQueued = useRef(0);
 
   useEffect(() => {
-    if (settings) setDraft(settings);
+    // Queued saves own the draft, their optimistic state must survive a cache
+    // update landing mid-queue.
+    if (settings && savesQueued.current === 0) setDraft(settings);
   }, [settings]);
 
-  const saveSettings = useCallback(async (updates: SecuritySettingsUpdate) => {
-    // Optimistically reflect concrete changes for snappy toggles. A `null`
-    // clears an override; its resolved env default only arrives with the PUT
-    // response, so we leave the current value in place rather than guess.
-    setDraft((prev) => {
-      if (!prev) return prev;
-      const concrete = Object.fromEntries(
-        Object.entries(updates).filter(([, value]) => value != null)
-      ) as Partial<SecuritySettings>;
-      return { ...prev, ...concrete };
-    });
+  const doSave = useCallback(async (updates: SecuritySettingsUpdate) => {
     try {
       const response = await fetch(SWR_KEYS.adminSecuritySettings, {
         method: "PUT",
@@ -125,20 +189,24 @@ export default function SecurityHardeningPage() {
       // PUT returns the new effective settings — adopt them as the source of
       // truth so the UI matches what was actually persisted/merged.
       const effective: SecuritySettings = await response.json();
-      setDraft(effective);
-      await mutate(SWR_KEYS.adminSecuritySettings, effective, {
-        revalidate: false,
-      });
+      if (savesQueued.current === 1) {
+        setDraft(effective);
+        await mutate(SWR_KEYS.adminSecuritySettings, effective, {
+          revalidate: false,
+        });
+      }
       toast.success("Security settings updated");
     } catch (error) {
       // Re-sync from the server (the source of truth) rather than a possibly
       // stale local snapshot — a late failure must not clobber other edits
       // that may have succeeded while this request was in flight.
       try {
-        const fresh = await mutate<SecuritySettings>(
-          SWR_KEYS.adminSecuritySettings
-        );
-        if (fresh) setDraft(fresh);
+        if (savesQueued.current === 1) {
+          const fresh = await mutate<SecuritySettings>(
+            SWR_KEYS.adminSecuritySettings
+          );
+          if (fresh) setDraft(fresh);
+        }
       } catch {
         // If revalidation also fails (e.g. network down), the optimistic
         // update stays until the next successful SWR refresh (e.g. focus).
@@ -151,7 +219,32 @@ export default function SecurityHardeningPage() {
     }
   }, []);
 
-  if (settingsLoading || !draft) {
+  const saveSettings = useCallback(
+    (updates: SecuritySettingsUpdate) => {
+      // Applied at enqueue so a full-value edit (the domain list) reads every
+      // queued change off `draft`. A null keeps the current value, its env
+      // default only arrives with the PUT response.
+      setDraft((prev) => {
+        if (!prev) return prev;
+        const concrete = Object.fromEntries(
+          Object.entries(updates).filter(([, value]) => value != null)
+        ) as Partial<SecuritySettings>;
+        return { ...prev, ...concrete };
+      });
+      savesQueued.current += 1;
+      const run = saveQueue.current
+        .then(() => doSave(updates))
+        .finally(() => {
+          savesQueued.current -= 1;
+        });
+      // doSave never rejects, the catch keeps the chain alive regardless.
+      saveQueue.current = run.catch(() => undefined);
+      return run;
+    },
+    [doSave]
+  );
+
+  if (settingsLoading || pinnedFieldsLoading || !draft) {
     return (
       <SettingsLayouts.Root>
         <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
@@ -348,6 +441,57 @@ export default function SecurityHardeningPage() {
                     void saveSettings({
                       password_require_special_char: checked,
                     })
+                  }
+                />
+              </Section>
+            </Card>
+          )}
+
+          {/* External JWT auth (single-tenant only) */}
+          {!isMultiTenant && (
+            <Card border="solid" rounding="lg">
+              <Section>
+                <Content
+                  title="External JWT Authentication"
+                  description="Accept RS256 bearer tokens signed by your identity provider. Values set by environment variables are pinned and cannot be edited here."
+                  sizePreset="main-ui"
+                  variant="section"
+                />
+
+                <JwtTextRow
+                  title="Public Key URL"
+                  description="JWKS or PEM endpoint used to verify token signatures. Leave empty to disable JWT authentication."
+                  value={draft.jwt_public_key_url ?? ""}
+                  placeholder="https://idp.example.com/.well-known/jwks.json"
+                  pinned={pinnedFields?.includes("jwt_public_key_url") ?? false}
+                  onCommit={(value) =>
+                    saveSettings({ jwt_public_key_url: value || null })
+                  }
+                />
+
+                <JwtTextRow
+                  title="Expected Audience"
+                  description="Reject tokens whose aud claim does not match. Empty disables the check."
+                  value={draft.jwt_expected_audience ?? ""}
+                  placeholder="onyx"
+                  pinned={
+                    pinnedFields?.includes("jwt_expected_audience") ?? false
+                  }
+                  onCommit={(value) =>
+                    saveSettings({ jwt_expected_audience: value || null })
+                  }
+                />
+
+                <JwtTextRow
+                  title="Expected Issuer"
+                  description="Reject tokens whose iss claim does not match. Empty disables the check."
+                  value={draft.jwt_expected_issuer ?? ""}
+                  placeholder="https://idp.example.com"
+                  pinned={
+                    pinnedFields?.includes("jwt_expected_issuer") ?? false
+                  }
+                  onCommit={(value) =>
+                    saveSettings({ jwt_expected_issuer: value || null })
                   }
                 />
               </Section>

--- a/web/src/views/admin/SecurityHardeningPage.tsx
+++ b/web/src/views/admin/SecurityHardeningPage.tsx
@@ -20,7 +20,7 @@ import {
   SettingsLayouts,
   toast,
 } from "@opal/layouts";
-import { Card, InputTypeIn, Switch } from "@opal/components";
+import { Card, InputTypeIn, Switch, Text } from "@opal/components";
 import { markdown } from "@opal/utils";
 import type { RichStr } from "@opal/types";
 import type {
@@ -95,16 +95,27 @@ function JwtTextRow({
   useEffect(() => {
     if (!focused) setText(value);
   }, [value, revision, focused]);
+
+  if (pinned) {
+    // An input promises editability. A pinned value is display-only.
+    return (
+      <InputVertical
+        title={title}
+        description="Pinned by an environment variable."
+        withLabel
+      >
+        <Text font="main-ui-body" color="text-03">
+          {value}
+        </Text>
+      </InputVertical>
+    );
+  }
+
   return (
-    <InputVertical
-      title={title}
-      description={pinned ? "Pinned by an environment variable." : description}
-      withLabel
-    >
+    <InputVertical title={title} description={description} withLabel>
       <InputTypeIn
         value={text}
         placeholder={placeholder}
-        variant={pinned ? "readOnly" : "primary"}
         onChange={(e) => {
           dirty.current = true;
           setText(e.target.value);
@@ -116,7 +127,7 @@ function JwtTextRow({
         onBlur={async () => {
           setFocused(false);
           const next = text.trim();
-          if (pinned || !dirty.current || next === value) return;
+          if (!dirty.current || next === value) return;
           dirty.current = false;
           await onCommit(next);
           setRevision((r) => r + 1);


### PR DESCRIPTION
## Description

Final PR of the JWT settings stack (on #14153): the admin UI for the DB-backed JWT auth settings.

- New "External JWT Authentication" card on Security & Hardening (single-tenant, like the page's other auth sections): Public Key URL, Expected Audience, Expected Issuer. Text fields commit on blur or Enter through the page's existing partial PUT, empty clears the override.
- GET /admin/security/pinned-fields tells the UI which fields an env var pins. A pinned field renders as static text with a "Pinned by an environment variable" note (an input promises editability), and the card renders only once the pinned state is known (fail closed).
- Save flow hardening that fell out of review: saves are serialized through a promise chain, only the last queued save adopts the server response, the optimistic patch applies at enqueue, and fields commit only user-typed text (focus and dirty guards). Applies to the whole page, closes a pre-existing out-of-order-response race.



![after](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/pr-14155/v2-after-editable.png)

**with `JWT_EXPECTED_AUDIENCE` env-pinned** (static text, no input):

![pinned](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/pr-14155/v2-after-pinned.png)

## How Has This Been Tested?

- Live in a real browser against an isolated scratch stack: card renders, saves land with the success toast, an SSRF-blocked URL surfaces the backend INVALID_INPUT toast and reverts, an env-pinned audience renders as static text with the env value winning, and lifting the pin shows the seeded value editable (the retirement path).
- Pinned-fields endpoint test added to the external-dependency suite; 32 security unit tests pass; tsc and ty clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check