### PR TITLE
fix(terraform): eight Azure module fixes found by the first real apply

### DIFF
--- a/deployment/terraform/modules/azure/README.md
+++ b/deployment/terraform/modules/azure/README.md
@@ -18,7 +18,7 @@ infrastructure for Onyx:
   and the document index, and optional GPU and sandbox pools
 - `postgres`: a PostgreSQL Flexible Server on a delegated subnet, its private
   DNS zone, and five metric alerts
-- `redis`: an Azure Cache for Redis behind a private endpoint, with four metric
+- `redis`: an Azure Managed Redis behind a private endpoint, with four metric
   alerts
 - `storage`: a storage account and container for the Onyx file store, with
   versioning, lifecycle rules and network rules
@@ -132,7 +132,7 @@ variable set to a non-null value overrides its tier default.
 | index pool disk | 256 GiB | 512 GiB | 1024 GiB |
 | database SKU | `GP_Standard_D2ds_v5` | `GP_Standard_D2ds_v5` | `GP_Standard_D4ds_v5` |
 | database storage | 64 GiB | 128 GiB | 256 GiB |
-| cache | Standard C3 (6 GB) | Standard C4 (13 GB) | Standard C5 (26 GB) |
+| cache | `Balanced_B5` (~5 GB) | `Balanced_B10` (~10 GB) | `Balanced_B20` (~20 GB) |
 
 Roughly: small suits pilots and small teams, medium a department or company,
 large an org-wide deployment. The index pool is memory-optimised at every tier
@@ -192,8 +192,22 @@ and the database.
 
 ### `redis`
 
-An Azure Cache for Redis reachable only through a private endpoint, with its
-plaintext port disabled.
+An Azure Managed Redis reachable only through a private endpoint.
+
+Azure stopped accepting new **Azure Cache for Redis** instances -- a create now
+returns "Azure Cache for Redis is retiring, create Azure Managed Redis instance
+instead" -- so this module provisions the managed service. It is a different
+resource rather than a renamed one, and the differences show:
+
+- Sizing is one SKU name, `Balanced_B5` for about 5 GB, rather than a tier, a
+  family and a capacity.
+- It speaks TLS on **10000**, where the retiring service used 6380. There is no
+  plaintext port to disable and no minimum TLS version to set.
+- Eviction policies are spelled `VolatileLRU`, not `volatile-lru`.
+- Clustering is a choice. `OSSCluster` shards and needs a cluster-aware client,
+  which redis-py is not, so the module defaults to `EnterpriseCluster`.
+- Alerts report under `Microsoft.Cache/redisEnterprise`, and the single-thread
+  server load metric is replaced by processor time.
 
 ### `storage`
 
@@ -216,7 +230,8 @@ Most of these follow from the platform rather than from taste.
 |---|---|---|
 | document index | managed OpenSearch domain, or in-cluster | in-cluster only; Azure has no managed OpenSearch, and Azure AI Search is a different API |
 | pod identity | IRSA: assume a role from an OIDC subject | federate a managed identity to a service account; same `system:serviceaccount:...` subject |
-| cache credential | you supply an auth token | Azure generates the keys; they come back as outputs |
+| cache credential | you supply an auth token | Azure generates the keys; they come back as outputs, read off the database rather than the cluster |
+| cache service | ElastiCache | Azure Managed Redis; Azure Cache for Redis is retired and will not accept new instances |
 | cluster autoscaler | Helm release plus a ClusterRole patch | part of a node pool |
 | GPU device plugin | Helm release | installed by AKS with the driver |
 | database storage | any GiB, with a growth ceiling | a fixed ladder of sizes, with auto-grow as a switch |
@@ -377,7 +392,8 @@ They do not prove the modules work against Azure. Only an apply does that.
 - Shared access keys on the storage account are off, and blobs are never
   anonymously readable.
 - The database and cache have no public endpoint.
-- The cache refuses its plaintext port, and both refuse TLS below 1.2.
+- The cache speaks TLS only; Managed Redis offers no plaintext port at all, and
+  the database refuses TLS below 1.2.
 - The API server will not be built open. You must set
   `api_server_authorized_ip_ranges`, or `private_cluster_enabled`, or
   `allow_unrestricted_api_server_access` to record that an open control plane is

--- a/deployment/terraform/modules/azure/README.md
+++ b/deployment/terraform/modules/azure/README.md
@@ -19,7 +19,7 @@ infrastructure for Onyx:
 - `postgres`: a PostgreSQL Flexible Server on a delegated subnet, its private
   DNS zone, and five metric alerts
 - `redis`: an Azure Managed Redis behind a private endpoint, with four metric
-  alerts
+  alerts. Off by default, because Onyx cannot use it -- see below
 - `storage`: a storage account and container for the Onyx file store, with
   versioning, lifecycle rules and network rules
 - `waf`: a regional Web Application Firewall policy for an Application Gateway
@@ -194,6 +194,16 @@ and the database.
 
 An Azure Managed Redis reachable only through a private endpoint.
 
+**Onyx cannot run on it, so `enable_redis` defaults to `false`.** Run Redis in
+the cluster instead. Managed Redis is always clustered, and Celery's pidbox
+opens a `MULTI` spanning keys in several hash slots, which clustered Redis
+rejects with `CROSSSLOT`. `EnterpriseCluster` does not avoid this: it presents
+one endpoint but still shards underneath, and it was tried against a live
+cache, not assumed. `NoCluster` returns `NotImplemented`. Managed Redis also
+offers only database 0, where Onyx wants 0, 14 and 15.
+
+The module stays for anyone who wants a cache for something else.
+
 Azure stopped accepting new **Azure Cache for Redis** instances -- a create now
 returns "Azure Cache for Redis is retiring, create Azure Managed Redis instance
 instead" -- so this module provisions the managed service. It is a different
@@ -204,8 +214,9 @@ resource rather than a renamed one, and the differences show:
 - It speaks TLS on **10000**, where the retiring service used 6380. There is no
   plaintext port to disable and no minimum TLS version to set.
 - Eviction policies are spelled `VolatileLRU`, not `volatile-lru`.
-- Clustering is a choice. `OSSCluster` shards and needs a cluster-aware client,
-  which redis-py is not, so the module defaults to `EnterpriseCluster`.
+- Clustering is not really a choice. `OSSCluster` shards and needs a
+  cluster-aware client, which redis-py is not, so the module asks for
+  `EnterpriseCluster`.
 - Alerts report under `Microsoft.Cache/redisEnterprise`, and the single-thread
   server load metric is replaced by processor time.
 

--- a/deployment/terraform/modules/azure/aks/main.tf
+++ b/deployment/terraform/modules/azure/aks/main.tf
@@ -110,6 +110,12 @@ resource "azurerm_kubernetes_cluster" "this" {
     # replaces the whole cluster instead of the pool.
     temporary_name_for_rotation = local.rotation_names["main"]
 
+    # Azure sets this itself, so leaving it unmanaged shows as drift on every
+    # plan and a stray apply would silently change how upgrades behave.
+    upgrade_settings {
+      max_surge = var.node_pool_max_surge
+    }
+
     tags = var.tags
   }
 
@@ -188,6 +194,12 @@ resource "azurerm_kubernetes_cluster_node_pool" "this" {
   vnet_subnet_id  = var.subnet_id
 
   temporary_name_for_rotation = local.rotation_names[each.key]
+
+  # Managed for the same reason as the system pool's: Azure sets a default and
+  # an unmanaged block reads as drift on every plan.
+  upgrade_settings {
+    max_surge = var.node_pool_max_surge
+  }
 
   tags = var.tags
 

--- a/deployment/terraform/modules/azure/aks/outputs.tf
+++ b/deployment/terraform/modules/azure/aks/outputs.tf
@@ -27,6 +27,11 @@ output "node_resource_group" {
   value       = azurerm_kubernetes_cluster.this.node_resource_group
 }
 
+output "cluster_identity_principal_id" {
+  description = "Principal ID of the cluster's own identity. Grant it Network Contributor on a public IP or subnet held outside the node resource group, or the load balancer cannot attach it."
+  value       = try(azurerm_kubernetes_cluster.this.identity[0].principal_id, null)
+}
+
 output "kubelet_identity_object_id" {
   description = "Object ID of the kubelet identity, for granting nodes access to a container registry"
   value       = try(azurerm_kubernetes_cluster.this.kubelet_identity[0].object_id, null)

--- a/deployment/terraform/modules/azure/aks/tests/aks.tftest.hcl
+++ b/deployment/terraform/modules/azure/aks/tests/aks.tftest.hcl
@@ -143,6 +143,32 @@ run "the_cluster_has_an_identity_to_grant_roles_to" {
   }
 }
 
+run "upgrade_settings_are_managed_not_left_to_azure" {
+  command = plan
+
+  # Azure fills this in itself. Unmanaged, it shows as drift on every plan and
+  # a stray apply changes upgrade behaviour without anyone asking for it.
+  assert {
+    condition     = one(one(azurerm_kubernetes_cluster.this.default_node_pool).upgrade_settings).max_surge == "10%"
+    error_message = "The system pool should declare its surge rather than inherit Azure's."
+  }
+
+  assert {
+    condition     = alltrue([for p in azurerm_kubernetes_cluster_node_pool.this : one(p.upgrade_settings).max_surge == "10%"])
+    error_message = "Every optional pool should declare its surge too."
+  }
+}
+
+run "rejects_a_max_surge_azure_would_not_take" {
+  command = plan
+
+  variables {
+    node_pool_max_surge = "lots"
+  }
+
+  expect_failures = [var.node_pool_max_surge]
+}
+
 run "no_storage_account_means_no_identity" {
   command = plan
 

--- a/deployment/terraform/modules/azure/aks/tests/aks.tftest.hcl
+++ b/deployment/terraform/modules/azure/aks/tests/aks.tftest.hcl
@@ -47,6 +47,17 @@ run "defaults" {
   }
 }
 
+run "the_default_version_is_one_azure_still_builds" {
+  command = plan
+
+  # Versions age out of standard support into Long-Term-Support only, and AKS
+  # then refuses to build a cluster on them. 1.33 crossed that line.
+  assert {
+    condition     = azurerm_kubernetes_cluster.this.kubernetes_version == "1.34"
+    error_message = "The default version must be one AKS will still build without an LTS opt-in."
+  }
+}
+
 run "dns_service_ip_is_derived_from_the_service_range" {
   command = plan
 

--- a/deployment/terraform/modules/azure/aks/tests/aks.tftest.hcl
+++ b/deployment/terraform/modules/azure/aks/tests/aks.tftest.hcl
@@ -131,6 +131,18 @@ run "optional_pools_are_tainted_and_labelled" {
   }
 }
 
+run "the_cluster_has_an_identity_to_grant_roles_to" {
+  command = plan
+
+  # A public IP or subnet held outside the node resource group is only usable
+  # once this identity holds Network Contributor on it. Without an identity
+  # block there is no principal to grant, and the load balancer never attaches.
+  assert {
+    condition     = one(azurerm_kubernetes_cluster.this.identity).type == "SystemAssigned"
+    error_message = "The cluster needs its own identity, or a BYO ingress IP cannot be granted to it."
+  }
+}
+
 run "no_storage_account_means_no_identity" {
   command = plan
 
@@ -356,7 +368,7 @@ run "a_long_namespace_still_produces_a_valid_credential_name" {
   variables {
     storage_account_ids                = ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Storage/storageAccounts/onyxfilestore"]
     workload_service_account_namespace = "onyx-production-workloads-with-a-deliberately-long-namespace-nm"
-    workload_service_account_name       = "onyx-workload-access-with-a-deliberately-long-service-account-n"
+    workload_service_account_name      = "onyx-workload-access-with-a-deliberately-long-service-account-n"
   }
 
   assert {
@@ -401,7 +413,7 @@ run "an_open_control_plane_can_be_asked_for_explicitly" {
   command = plan
 
   variables {
-    api_server_authorized_ip_ranges     = []
+    api_server_authorized_ip_ranges      = []
     allow_unrestricted_api_server_access = true
   }
 
@@ -446,7 +458,7 @@ run "rejects_a_private_cluster_with_authorized_ranges" {
   command = plan
 
   variables {
-    private_cluster_enabled        = true
+    private_cluster_enabled         = true
     api_server_authorized_ip_ranges = ["203.0.113.0/24"]
   }
 
@@ -483,7 +495,7 @@ run "rejects_a_pool_name_azure_would_reject" {
 
   variables {
     node_pools = {
-      main               = { vm_size = "Standard_D8ds_v5" }
+      main                = { vm_size = "Standard_D8ds_v5" }
       document-index-pool = { vm_size = "Standard_E8ds_v5" }
     }
   }

--- a/deployment/terraform/modules/azure/aks/variables.tf
+++ b/deployment/terraform/modules/azure/aks/variables.tf
@@ -15,8 +15,8 @@ variable "location" {
 
 variable "kubernetes_version" {
   type        = string
-  description = "Kubernetes version for the control plane. Move one minor at a time."
-  default     = "1.33"
+  description = "Kubernetes version for the control plane. Move one minor at a time. Versions age out of standard support and become Long-Term-Support only, at which point AKS refuses to build a cluster on them: check with az aks get-versions."
+  default     = "1.34"
 }
 
 variable "subnet_id" {

--- a/deployment/terraform/modules/azure/aks/variables.tf
+++ b/deployment/terraform/modules/azure/aks/variables.tf
@@ -13,6 +13,17 @@ variable "location" {
   description = "Azure region, for example \"eastus\""
 }
 
+variable "node_pool_max_surge" {
+  type        = string
+  description = "Extra capacity AKS may add while upgrading a node pool, as a count or a percentage. Azure defaults this to 10%, which terraform would otherwise show as drift on every plan. The family vCPU quota has to cover the pool AND the surge: a single-node pool upgrading with a surge of one needs twice the pool's cores, and the upgrade fails outright without them."
+  default     = "10%"
+
+  validation {
+    condition     = can(regex("^[0-9]+%?$", var.node_pool_max_surge))
+    error_message = "max_surge is a node count or a percentage, e.g. \"1\" or \"10%\"."
+  }
+}
+
 variable "kubernetes_version" {
   type        = string
   description = "Kubernetes version for the control plane. Move one minor at a time. Versions age out of standard support and become Long-Term-Support only, at which point AKS refuses to build a cluster on them: check with az aks get-versions."

--- a/deployment/terraform/modules/azure/onyx/main.tf
+++ b/deployment/terraform/modules/azure/onyx/main.tf
@@ -251,7 +251,7 @@ module "aks" {
   enable_sandbox_node_pool = var.enable_sandbox_node_pool
 
   private_cluster_enabled              = var.private_cluster_enabled
-  api_server_authorized_ip_ranges      = var.api_server_authorized_ip_ranges
+  api_server_authorized_ip_ranges      = local.api_server_authorized_ip_ranges
   allow_unrestricted_api_server_access = var.allow_unrestricted_api_server_access
   network_policy                       = var.network_policy
 

--- a/deployment/terraform/modules/azure/onyx/main.tf
+++ b/deployment/terraform/modules/azure/onyx/main.tf
@@ -52,9 +52,7 @@ locals {
       index_node_disk_size_gb = 256
       postgres_sku_name       = "GP_Standard_D2ds_v5"
       postgres_storage_gb     = 64
-      redis_sku_name          = "Standard"
-      redis_family            = "C"
-      redis_capacity          = 3
+      redis_sku_name          = "Balanced_B5"
     }
     medium = {
       main_node_vm_size       = "Standard_D16ds_v5"
@@ -64,9 +62,7 @@ locals {
       index_node_disk_size_gb = 512
       postgres_sku_name       = "GP_Standard_D2ds_v5"
       postgres_storage_gb     = 128
-      redis_sku_name          = "Standard"
-      redis_family            = "C"
-      redis_capacity          = 4
+      redis_sku_name          = "Balanced_B10"
     }
     large = {
       main_node_vm_size       = "Standard_D16ds_v5"
@@ -76,9 +72,7 @@ locals {
       index_node_disk_size_gb = 1024
       postgres_sku_name       = "GP_Standard_D4ds_v5"
       postgres_storage_gb     = 256
-      redis_sku_name          = "Standard"
-      redis_family            = "C"
-      redis_capacity          = 5
+      redis_sku_name          = "Balanced_B20"
     }
   }
   sizing = local.size_defaults[var.size]
@@ -92,8 +86,6 @@ locals {
   postgres_sku_name       = coalesce(var.postgres_sku_name, local.sizing.postgres_sku_name)
   postgres_storage_gb     = coalesce(var.postgres_storage_gb, local.sizing.postgres_storage_gb)
   redis_sku_name          = coalesce(var.redis_sku_name, local.sizing.redis_sku_name)
-  redis_family            = coalesce(var.redis_family, local.sizing.redis_family)
-  redis_capacity          = coalesce(var.redis_capacity, local.sizing.redis_capacity)
 
   node_pools = merge(
     {
@@ -218,9 +210,8 @@ module "redis" {
   location            = var.location
   tags                = local.merged_tags
 
-  sku_name = local.redis_sku_name
-  family   = local.redis_family
-  capacity = local.redis_capacity
+  sku_name                  = local.redis_sku_name
+  high_availability_enabled = var.redis_high_availability_enabled
 
   private_endpoint_subnet_id = local.private_endpoint_subnet_id
   virtual_network_id         = local.virtual_network_id

--- a/deployment/terraform/modules/azure/onyx/main.tf
+++ b/deployment/terraform/modules/azure/onyx/main.tf
@@ -33,8 +33,23 @@ locals {
     var.create_virtual_network && var.enable_nat_gateway ? "userAssignedNATGateway" : "loadBalancer",
   )
 
-  nat_gateway_ips = var.create_virtual_network ? module.vnet[0].nat_gateway_public_ips : []
-  trusted_nat_ips = var.waf_trust_nat_gateway_ip ? local.nat_gateway_ips : []
+  nat_gateway_ips   = var.create_virtual_network ? module.vnet[0].nat_gateway_public_ips : []
+  trusted_nat_ips   = var.waf_trust_nat_gateway_ip ? local.nat_gateway_ips : []
+  nat_gateway_cidrs = [for ip in local.nat_gateway_ips : "${ip}/32"]
+
+  # A cluster whose API server allowlist excludes the cluster's own egress is
+  # broken, not locked down. With outbound_type = userAssignedNATGateway, AKS
+  # does not add the egress address for you the way it does when it manages
+  # outbound, so anything in the cluster that reaches the API server through the
+  # public endpoint is refused: node bootstrap, and every in-cluster client that
+  # uses its service account.
+  #
+  # Empty stays empty. An empty list means "no restriction", and adding an
+  # address to it would silently turn that into a restriction.
+  api_server_authorized_ip_ranges = length(var.api_server_authorized_ip_ranges) == 0 ? [] : distinct(concat(
+    var.api_server_authorized_ip_ranges,
+    var.trust_nat_gateway_ip_on_api_server ? local.nat_gateway_cidrs : [],
+  ))
 
   waf_allowed_ip_cidrs           = distinct(concat(var.waf_allowed_ip_cidrs, local.trusted_nat_ips))
   waf_rate_limit_exempt_ip_cidrs = distinct(concat(var.waf_rate_limit_exempt_ip_cidrs, local.trusted_nat_ips))

--- a/deployment/terraform/modules/azure/onyx/main.tf
+++ b/deployment/terraform/modules/azure/onyx/main.tf
@@ -219,6 +219,7 @@ module "postgres" {
 
 module "redis" {
   source = "../redis"
+  count  = var.enable_redis ? 1 : 0
 
   name                = local.redis_name
   resource_group_name = local.resource_group_name

--- a/deployment/terraform/modules/azure/onyx/outputs.tf
+++ b/deployment/terraform/modules/azure/onyx/outputs.tf
@@ -82,19 +82,19 @@ output "postgres_username" {
 
 output "redis_host" {
   description = "Hostname of the cache. Behind its private endpoint this resolves to a private address."
-  value       = module.redis.hostname
+  value       = one(module.redis[*].hostname)
 }
 
 output "redis_ssl_port" {
   description = "TLS port of the cache. The plaintext port is disabled."
-  value       = module.redis.ssl_port
+  value       = one(module.redis[*].ssl_port)
 }
 
 # Azure generates this rather than accepting one, so it comes out of the module
 # rather than going in.
 output "redis_primary_access_key" {
   description = "Generated primary access key for the cache"
-  value       = module.redis.primary_access_key
+  value       = one(module.redis[*].primary_access_key)
   sensitive   = true
 }
 

--- a/deployment/terraform/modules/azure/onyx/outputs.tf
+++ b/deployment/terraform/modules/azure/onyx/outputs.tf
@@ -23,6 +23,15 @@ output "workload_identity_client_id" {
   value       = module.aks.workload_identity_client_id
 }
 
+# The client id annotates a service account; a role assignment needs the
+# principal id instead. Granting this identity access to anything the
+# composition does not itself create - a key vault, another storage account -
+# is impossible without it.
+output "workload_identity_principal_id" {
+  description = "Principal ID of the workload identity, for granting it roles on resources outside this module"
+  value       = module.aks.workload_identity_principal_id
+}
+
 output "node_resource_group" {
   description = "Resource group AKS creates for the cluster's own infrastructure"
   value       = module.aks.node_resource_group

--- a/deployment/terraform/modules/azure/onyx/outputs.tf
+++ b/deployment/terraform/modules/azure/onyx/outputs.tf
@@ -32,6 +32,11 @@ output "workload_identity_principal_id" {
   value       = module.aks.workload_identity_principal_id
 }
 
+output "cluster_identity_principal_id" {
+  description = "Principal ID of the cluster identity, for granting it roles on network resources this module does not own -- an ingress public IP, most often"
+  value       = module.aks.cluster_identity_principal_id
+}
+
 output "node_resource_group" {
   description = "Resource group AKS creates for the cluster's own infrastructure"
   value       = module.aks.node_resource_group

--- a/deployment/terraform/modules/azure/onyx/tests/onyx.tftest.hcl
+++ b/deployment/terraform/modules/azure/onyx/tests/onyx.tftest.hcl
@@ -28,8 +28,8 @@ run "medium_is_the_default_tier" {
   }
 
   assert {
-    condition     = local.redis_capacity == 4
-    error_message = "Standard C4 is 13 GB, matching the AWS composition's cache.m6g.xlarge."
+    condition     = local.redis_sku_name == "Balanced_B10"
+    error_message = "Balanced_B10 is about 10 GB, the closest Managed Redis shape to the AWS composition's cache.m6g.xlarge."
   }
 
   assert {

--- a/deployment/terraform/modules/azure/onyx/tests/onyx.tftest.hcl
+++ b/deployment/terraform/modules/azure/onyx/tests/onyx.tftest.hcl
@@ -311,6 +311,36 @@ run "rejects_a_deployment_with_no_database_password" {
   expect_failures = [var.postgres_password]
 }
 
+run "an_empty_api_allowlist_stays_empty" {
+  command = plan
+
+  # Empty means no restriction. Appending the egress address to it would
+  # silently turn "open" into "only the cluster itself", which locks the
+  # operator out of their own API server.
+  variables {
+    api_server_authorized_ip_ranges     = []
+    allow_unrestricted_api_server_access = true
+  }
+
+  assert {
+    condition     = length(local.api_server_authorized_ip_ranges) == 0
+    error_message = "An empty allowlist must stay empty rather than becoming a one-entry allowlist."
+  }
+}
+
+run "the_cluster_trusts_its_own_egress_by_default" {
+  command = plan
+
+  assert {
+    condition     = var.trust_nat_gateway_ip_on_api_server
+    error_message = "A cluster whose API allowlist excludes its own egress cannot bootstrap its nodes, so this defaults on."
+  }
+
+  # That the caller's own range survives the concat is not checkable here: the
+  # egress address is unknown until apply, which makes the whole list unknown.
+  # The empty-stays-empty case above is the one a mocked plan can see.
+}
+
 run "rejects_an_open_control_plane" {
   command = plan
 

--- a/deployment/terraform/modules/azure/onyx/tests/onyx.tftest.hcl
+++ b/deployment/terraform/modules/azure/onyx/tests/onyx.tftest.hcl
@@ -288,11 +288,11 @@ run "entra_only_needs_no_password" {
 
   variables {
     postgres_password                     = null
-    enable_entra_database_authentication   = true
-    entra_database_authentication_only     = true
-    tenant_id                              = "00000000-0000-0000-0000-000000000000"
-    database_administrator_object_id       = "11111111-1111-1111-1111-111111111111"
-    database_administrator_principal_name  = "onyx-db-admins"
+    enable_entra_database_authentication  = true
+    entra_database_authentication_only    = true
+    tenant_id                             = "00000000-0000-0000-0000-000000000000"
+    database_administrator_object_id      = "11111111-1111-1111-1111-111111111111"
+    database_administrator_principal_name = "onyx-db-admins"
   }
 
   assert {
@@ -318,7 +318,7 @@ run "an_empty_api_allowlist_stays_empty" {
   # silently turn "open" into "only the cluster itself", which locks the
   # operator out of their own API server.
   variables {
-    api_server_authorized_ip_ranges     = []
+    api_server_authorized_ip_ranges      = []
     allow_unrestricted_api_server_access = true
   }
 

--- a/deployment/terraform/modules/azure/onyx/tests/onyx.tftest.hcl
+++ b/deployment/terraform/modules/azure/onyx/tests/onyx.tftest.hcl
@@ -387,3 +387,33 @@ run "rejects_a_size_that_is_not_a_tier" {
 
   expect_failures = [var.size]
 }
+
+run "no_managed_redis_by_default" {
+  command = plan
+
+  # Managed Redis cannot serve Celery: it is always clustered, and the pidbox
+  # opens a MULTI across hash slots. Provisioning one by default would bill for
+  # a cache that Onyx cannot talk to.
+  assert {
+    condition     = length(module.redis) == 0
+    error_message = "Managed Redis should be off unless asked for, because Onyx cannot use it."
+  }
+
+  assert {
+    condition     = output.redis_host == null
+    error_message = "With no cache there is no hostname to publish."
+  }
+}
+
+run "managed_redis_can_still_be_asked_for" {
+  command = plan
+
+  variables {
+    enable_redis = true
+  }
+
+  assert {
+    condition     = length(module.redis) == 1
+    error_message = "enable_redis should still create the cache for anyone who wants one."
+  }
+}

--- a/deployment/terraform/modules/azure/onyx/variables.tf
+++ b/deployment/terraform/modules/azure/onyx/variables.tf
@@ -407,6 +407,12 @@ variable "create_workload_service_account" {
 
 # --- WAF ---------------------------------------------------------------------
 
+variable "enable_redis" {
+  type        = bool
+  description = "Create an Azure Managed Redis cache. Off by default: Onyx cannot use one. Managed Redis is always clustered, and Celery's pidbox opens a MULTI spanning keys in several hash slots, which clustered Redis rejects with CROSSSLOT. The EnterpriseCluster policy presents a single endpoint but still shards, NoCluster returns NotImplemented, and only database 0 exists where Onyx wants 0, 14 and 15. Run Redis in the cluster instead."
+  default     = false
+}
+
 variable "enable_waf" {
   type        = bool
   description = "Create a WAF policy to attach to an Application Gateway or Front Door route"

--- a/deployment/terraform/modules/azure/onyx/variables.tf
+++ b/deployment/terraform/modules/azure/onyx/variables.tf
@@ -264,22 +264,19 @@ variable "tenant_id" {
 
 # --- Redis -------------------------------------------------------------------
 
+# Azure stopped accepting new Azure Cache for Redis instances, so the redis
+# module now provisions Azure Managed Redis. That sizes by a single SKU name
+# rather than the tier, family and capacity the retiring service used.
 variable "redis_sku_name" {
   type        = string
-  description = "Cache tier. Null uses the t-shirt size default."
+  description = "Managed Redis SKU, for example \"Balanced_B5\" for 5 GB. Null uses the t-shirt size default."
   default     = null
 }
 
-variable "redis_family" {
-  type        = string
-  description = "Cache family. Null uses the t-shirt size default."
-  default     = null
-}
-
-variable "redis_capacity" {
-  type        = number
-  description = "Cache size within the family. Null uses the t-shirt size default."
-  default     = null
+variable "redis_high_availability_enabled" {
+  type        = bool
+  description = "Keep a Redis replica in another availability zone. Roughly doubles cache cost."
+  default     = false
 }
 
 # --- Cluster -----------------------------------------------------------------

--- a/deployment/terraform/modules/azure/onyx/variables.tf
+++ b/deployment/terraform/modules/azure/onyx/variables.tf
@@ -283,8 +283,8 @@ variable "redis_high_availability_enabled" {
 
 variable "kubernetes_version" {
   type        = string
-  description = "Kubernetes version for the control plane"
-  default     = "1.33"
+  description = "Kubernetes version for the control plane Versions age out of standard support and become Long-Term-Support only, at which point AKS refuses to build a cluster on them: check with az aks get-versions."
+  default     = "1.34"
 }
 
 variable "main_node_vm_size" {

--- a/deployment/terraform/modules/azure/onyx/variables.tf
+++ b/deployment/terraform/modules/azure/onyx/variables.tf
@@ -337,6 +337,15 @@ variable "api_server_authorized_ip_ranges" {
   default     = []
 }
 
+# On by default because the alternative is a cluster that cannot bootstrap its
+# own nodes. Turn it off only when something else already covers the egress
+# address, such as a firewall rule or a range that contains it.
+variable "trust_nat_gateway_ip_on_api_server" {
+  type        = bool
+  description = "Add the NAT gateway's egress address to api_server_authorized_ip_ranges. Only applies when this module creates the network and the list is non-empty."
+  default     = true
+}
+
 variable "allow_unrestricted_api_server_access" {
   type        = bool
   description = "Accept a public API server reachable from any address. Only for throwaway deployments; set api_server_authorized_ip_ranges or private_cluster_enabled instead."

--- a/deployment/terraform/modules/azure/postgres/main.tf
+++ b/deployment/terraform/modules/azure/postgres/main.tf
@@ -106,6 +106,17 @@ resource "azurerm_postgresql_flexible_server" "this" {
   depends_on = [azurerm_private_dns_zone_virtual_network_link.this]
 }
 
+# azure.extensions is a dynamic parameter, so this needs no restart. Without it
+# CREATE EXTENSION fails for every extension, including the ones Onyx's
+# migrations run on first start.
+resource "azurerm_postgresql_flexible_server_configuration" "azure_extensions" {
+  count = length(var.allowed_extensions) > 0 ? 1 : 0
+
+  name      = "azure.extensions"
+  server_id = azurerm_postgresql_flexible_server.this.id
+  value     = join(",", var.allowed_extensions)
+}
+
 # Without this an Entra-only server has no administrator: password logins are
 # off and no Entra principal has been granted access, so nobody can connect to
 # bootstrap the roles a workload identity needs.

--- a/deployment/terraform/modules/azure/postgres/main.tf
+++ b/deployment/terraform/modules/azure/postgres/main.tf
@@ -1,4 +1,10 @@
 locals {
+  # Flexible Server ships these already. Asking Terraform to create one by any
+  # of these names fails with "already exists", so naming one is read as "use
+  # the database that is already there" rather than as an error.
+  builtin_databases = ["postgres", "azure_maintenance", "azure_sys"]
+  create_database   = !contains(local.builtin_databases, var.db_name)
+
   create_private_dns_zone = var.private_dns_zone_id == null
   private_dns_zone_id     = local.create_private_dns_zone ? azurerm_private_dns_zone.this[0].id : var.private_dns_zone_id
 
@@ -115,6 +121,8 @@ resource "azurerm_postgresql_flexible_server_active_directory_administrator" "th
 }
 
 resource "azurerm_postgresql_flexible_server_database" "this" {
+  count = local.create_database ? 1 : 0
+
   name      = var.db_name
   server_id = azurerm_postgresql_flexible_server.this.id
   charset   = "UTF8"

--- a/deployment/terraform/modules/azure/postgres/outputs.tf
+++ b/deployment/terraform/modules/azure/postgres/outputs.tf
@@ -18,9 +18,11 @@ output "port" {
   value       = 5432
 }
 
+# Reported from the variable rather than the resource, because a database the
+# server ships is not one this module creates.
 output "db_name" {
-  description = "Name of the database created on the server"
-  value       = azurerm_postgresql_flexible_server_database.this.name
+  description = "Name of the database Onyx connects to, whether this module created it or the server shipped it"
+  value       = var.db_name
 }
 
 output "username" {

--- a/deployment/terraform/modules/azure/postgres/tests/postgres.tftest.hcl
+++ b/deployment/terraform/modules/azure/postgres/tests/postgres.tftest.hcl
@@ -152,6 +152,39 @@ run "an_existing_dns_zone_is_reused" {
   }
 }
 
+run "a_database_the_server_ships_is_not_recreated" {
+  command = plan
+
+  # Flexible Server already has one called "postgres"; creating it fails with
+  # "already exists".
+  variables {
+    db_name = "postgres"
+  }
+
+  assert {
+    condition     = length(azurerm_postgresql_flexible_server_database.this) == 0
+    error_message = "Naming a built-in database should mean use it, not create it."
+  }
+
+  assert {
+    condition     = output.db_name == "postgres"
+    error_message = "The output still reports what Onyx connects to."
+  }
+}
+
+run "a_database_of_our_own_is_created" {
+  command = plan
+
+  variables {
+    db_name = "onyx"
+  }
+
+  assert {
+    condition     = length(azurerm_postgresql_flexible_server_database.this) == 1
+    error_message = "A name the server does not ship should be created."
+  }
+}
+
 run "no_entra_administrator_by_default" {
   command = plan
 

--- a/deployment/terraform/modules/azure/postgres/tests/postgres.tftest.hcl
+++ b/deployment/terraform/modules/azure/postgres/tests/postgres.tftest.hcl
@@ -185,6 +185,35 @@ run "a_database_of_our_own_is_created" {
   }
 }
 
+run "the_extensions_onyx_needs_are_allow_listed" {
+  command = plan
+
+  # Azure refuses CREATE EXTENSION unless the extension is on this list, and it
+  # starts empty, so Onyx's migrations fail on a fresh server without it.
+  assert {
+    condition     = azurerm_postgresql_flexible_server_configuration.azure_extensions[0].name == "azure.extensions"
+    error_message = "The allowlist is written to the azure.extensions server parameter."
+  }
+
+  assert {
+    condition     = azurerm_postgresql_flexible_server_configuration.azure_extensions[0].value == "pgcrypto,pg_trgm"
+    error_message = "pgcrypto and pg_trgm are what Onyx's migrations create."
+  }
+}
+
+run "an_empty_extension_list_writes_no_parameter" {
+  command = plan
+
+  variables {
+    allowed_extensions = []
+  }
+
+  assert {
+    condition     = length(azurerm_postgresql_flexible_server_configuration.azure_extensions) == 0
+    error_message = "An empty list should leave the parameter alone rather than setting it to nothing."
+  }
+}
+
 run "no_entra_administrator_by_default" {
   command = plan
 

--- a/deployment/terraform/modules/azure/postgres/variables.tf
+++ b/deployment/terraform/modules/azure/postgres/variables.tf
@@ -276,6 +276,17 @@ variable "zone" {
   default     = null
 }
 
+# RDS lets a user CREATE EXTENSION for most extensions without preparation.
+# Azure refuses unless the extension is allow-listed on the server first, and
+# the list starts empty -- so Onyx's own migrations fail on a fresh server with
+# "extension pgcrypto is not allow-listed for users in Azure Database for
+# PostgreSQL". These two are what those migrations create.
+variable "allowed_extensions" {
+  type        = list(string)
+  description = "Extensions users may CREATE on this server, written to the azure.extensions server parameter. Empty leaves the parameter alone, which means no extension can be created at all."
+  default     = ["pgcrypto", "pg_trgm"]
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags to apply to the server and its alerts"

--- a/deployment/terraform/modules/azure/redis/main.tf
+++ b/deployment/terraform/modules/azure/redis/main.tf
@@ -30,9 +30,12 @@ resource "azurerm_managed_redis" "this" {
 
   default_database {
     access_keys_authentication_enabled = var.access_keys_enabled
-    client_protocol                    = var.client_protocol
-    clustering_policy                  = var.clustering_policy
-    eviction_policy                    = var.eviction_policy
+    # Not a variable. The service this replaced had no plaintext port to turn
+    # on, and offering one here would be a weaker guarantee than the module it
+    # replaced, not a new feature.
+    client_protocol   = "Encrypted"
+    clustering_policy = var.clustering_policy
+    eviction_policy   = var.eviction_policy
   }
 
   tags = var.tags

--- a/deployment/terraform/modules/azure/redis/main.tf
+++ b/deployment/terraform/modules/azure/redis/main.tf
@@ -8,37 +8,54 @@ locals {
 
   alert_frequency   = "PT5M"
   alert_window_size = "PT15M"
-  metric_namespace  = "Microsoft.Cache/redis"
+  # Managed Redis is Redis Enterprise underneath, and reports under that
+  # namespace rather than the Microsoft.Cache/redis one the retiring service used.
+  metric_namespace = "Microsoft.Cache/redisEnterprise"
+
+  # Managed Redis speaks TLS on 10000. There is no plaintext port to disable.
+  port = 10000
 }
 
-resource "azurerm_redis_cache" "this" {
+# Azure stopped accepting new Azure Cache for Redis instances -- a create now
+# returns "Azure Cache for Redis is retiring, create Azure Managed Redis
+# instance instead" -- so this is the managed service rather than azurerm_redis_cache.
+resource "azurerm_managed_redis" "this" {
   name                = var.name
   resource_group_name = var.resource_group_name
   location            = var.location
 
-  sku_name = var.sku_name
-  family   = var.family
-  capacity = var.capacity
-  zones    = var.zones
+  sku_name                  = var.sku_name
+  high_availability_enabled = var.high_availability_enabled
+  public_network_access     = local.public_network_access_enabled ? "Enabled" : "Disabled"
 
-  minimum_tls_version           = var.minimum_tls_version
-  non_ssl_port_enabled          = false
-  public_network_access_enabled = local.public_network_access_enabled
-
-  access_keys_authentication_enabled = var.access_keys_enabled
-
-  redis_configuration {
-    maxmemory_policy                        = var.maxmemory_policy
-    active_directory_authentication_enabled = var.enable_entra_authentication
+  default_database {
+    access_keys_authentication_enabled = var.access_keys_enabled
+    client_protocol                    = var.client_protocol
+    clustering_policy                  = var.clustering_policy
+    eviction_policy                    = var.eviction_policy
   }
 
   tags = var.tags
 }
 
+# The cache resource exposes only its hostname. Managed Redis is Redis
+# Enterprise underneath, and the generated keys live on the database rather than
+# the cluster, so they are read back through the enterprise data source.
+#
+# azurerm marks this deprecated in favour of azurerm_managed_redis_database,
+# which does not exist yet: 4.81.0 is the latest 4.x and does not ship it. Swap
+# when it lands; the deprecated name works until provider v5.
+data "azurerm_redis_enterprise_database" "this" {
+  count = var.access_keys_enabled ? 1 : 0
+
+  name       = "default"
+  cluster_id = azurerm_managed_redis.this.id
+}
+
 resource "azurerm_private_dns_zone" "this" {
   count = local.create_private_dns_zone ? 1 : 0
 
-  name                = "privatelink.redis.cache.windows.net"
+  name                = "privatelink.redis.azure.net"
   resource_group_name = var.resource_group_name
   tags                = var.tags
 }
@@ -65,8 +82,8 @@ resource "azurerm_private_endpoint" "this" {
 
   private_service_connection {
     name                           = "${var.name}-psc"
-    private_connection_resource_id = azurerm_redis_cache.this.id
-    subresource_names              = ["redisCache"]
+    private_connection_resource_id = azurerm_managed_redis.this.id
+    subresource_names              = ["redisEnterprise"]
     is_manual_connection           = false
   }
 
@@ -82,7 +99,7 @@ resource "azurerm_private_endpoint" "this" {
 resource "azurerm_monitor_metric_alert" "memory_high" {
   name                = "${var.name}-memory-high"
   resource_group_name = var.resource_group_name
-  scopes              = [azurerm_redis_cache.this.id]
+  scopes              = [azurerm_managed_redis.this.id]
   description         = "Redis ${var.name} memory usage high"
   severity            = 2
   frequency           = local.alert_frequency
@@ -108,7 +125,7 @@ resource "azurerm_monitor_metric_alert" "memory_high" {
 resource "azurerm_monitor_metric_alert" "memory_critical" {
   name                = "${var.name}-memory-critical"
   resource_group_name = var.resource_group_name
-  scopes              = [azurerm_redis_cache.this.id]
+  scopes              = [azurerm_managed_redis.this.id]
   description         = "Redis ${var.name} memory usage critical, writes may be rejected"
   severity            = 1
   frequency           = local.alert_frequency
@@ -131,11 +148,11 @@ resource "azurerm_monitor_metric_alert" "memory_critical" {
   }
 }
 
-resource "azurerm_monitor_metric_alert" "server_load" {
-  name                = "${var.name}-server-load-high"
+resource "azurerm_monitor_metric_alert" "cpu" {
+  name                = "${var.name}-cpu-high"
   resource_group_name = var.resource_group_name
-  scopes              = [azurerm_redis_cache.this.id]
-  description         = "Redis ${var.name} server thread saturated"
+  scopes              = [azurerm_managed_redis.this.id]
+  description         = "Redis ${var.name} processor time high"
   severity            = 2
   frequency           = local.alert_frequency
   window_size         = local.alert_window_size
@@ -143,10 +160,10 @@ resource "azurerm_monitor_metric_alert" "server_load" {
 
   criteria {
     metric_namespace = local.metric_namespace
-    metric_name      = "serverLoad"
+    metric_name      = "percentProcessorTime"
     aggregation      = "Average"
     operator         = "GreaterThan"
-    threshold        = var.server_load_threshold_percent
+    threshold        = var.cpu_threshold_percent
   }
 
   dynamic "action" {
@@ -160,7 +177,7 @@ resource "azurerm_monitor_metric_alert" "server_load" {
 resource "azurerm_monitor_metric_alert" "evicted_keys" {
   name                = "${var.name}-evicted-keys"
   resource_group_name = var.resource_group_name
-  scopes              = [azurerm_redis_cache.this.id]
+  scopes              = [azurerm_managed_redis.this.id]
   description         = "Redis ${var.name} is evicting keys, which for a Celery broker means dropped tasks"
   severity            = 1
   frequency           = local.alert_frequency

--- a/deployment/terraform/modules/azure/redis/outputs.tf
+++ b/deployment/terraform/modules/azure/redis/outputs.tf
@@ -1,29 +1,31 @@
 output "cache_id" {
   description = "Resource ID of the cache"
-  value       = azurerm_redis_cache.this.id
+  value       = azurerm_managed_redis.this.id
 }
 
 output "hostname" {
   description = "Hostname of the cache. Behind a private endpoint this resolves to a private address from networks linked to the DNS zone."
-  value       = azurerm_redis_cache.this.hostname
+  value       = azurerm_managed_redis.this.hostname
 }
 
+# Managed Redis speaks TLS on 10000, where Azure Cache for Redis used 6380.
 output "ssl_port" {
-  description = "TLS port. The non-TLS port is disabled."
-  value       = azurerm_redis_cache.this.ssl_port
+  description = "TLS port. Managed Redis offers no plaintext port."
+  value       = 10000
 }
 
-# The AWS module takes an auth token as an input; Azure generates the keys and
-# offers no way to set them, so the credential comes back out of the module.
+# Azure generates the keys and offers no way to set them, so the credential
+# comes back out of the module rather than going in. They live on the database
+# rather than the cluster, hence the enterprise data source.
 output "primary_access_key" {
   description = "Generated primary access key, null when access keys are disabled"
-  value       = var.access_keys_enabled ? azurerm_redis_cache.this.primary_access_key : null
+  value       = try(data.azurerm_redis_enterprise_database.this[0].primary_access_key, null)
   sensitive   = true
 }
 
 output "secondary_access_key" {
   description = "Generated secondary access key, for rotating without downtime"
-  value       = var.access_keys_enabled ? azurerm_redis_cache.this.secondary_access_key : null
+  value       = try(data.azurerm_redis_enterprise_database.this[0].secondary_access_key, null)
   sensitive   = true
 }
 

--- a/deployment/terraform/modules/azure/redis/tests/redis.tftest.hcl
+++ b/deployment/terraform/modules/azure/redis/tests/redis.tftest.hcl
@@ -137,6 +137,38 @@ run "an_existing_dns_zone_is_reused" {
   }
 }
 
+run "reusing_a_dns_zone_needs_no_virtual_network" {
+  command = plan
+
+  # The virtual network is only used to link a zone this module creates. A
+  # caller who brings their own has already linked it.
+  variables {
+    virtual_network_id  = null
+    private_dns_zone_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/privateDnsZones/privatelink.redis.azure.net"
+  }
+
+  assert {
+    condition     = length(azurerm_private_endpoint.this) == 1
+    error_message = "The private endpoint should still be created."
+  }
+
+  assert {
+    condition     = length(azurerm_private_dns_zone_virtual_network_link.this) == 0
+    error_message = "There is no zone of our own to link."
+  }
+}
+
+run "rejects_a_private_endpoint_with_no_dns_anywhere" {
+  command = plan
+
+  variables {
+    virtual_network_id  = null
+    private_dns_zone_id = null
+  }
+
+  expect_failures = [var.enable_private_endpoint]
+}
+
 run "rejects_a_sku_that_is_not_one" {
   command = plan
 

--- a/deployment/terraform/modules/azure/redis/tests/redis.tftest.hcl
+++ b/deployment/terraform/modules/azure/redis/tests/redis.tftest.hcl
@@ -6,7 +6,7 @@ mock_provider "azurerm" {}
 variables {
   name                       = "onyx-redis-prod"
   resource_group_name        = "onyx-rg"
-  location                   = "eastus"
+  location                   = "eastus2"
   private_endpoint_subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/onyx-vnet/subnets/onyx-private-endpoints"
   virtual_network_id         = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/virtualNetworks/onyx-vnet"
 }
@@ -15,17 +15,12 @@ run "defaults_are_private_and_tls_only" {
   command = plan
 
   assert {
-    condition     = azurerm_redis_cache.this.non_ssl_port_enabled == false
-    error_message = "The cache must not answer on the plaintext port."
+    condition     = one(azurerm_managed_redis.this.default_database).client_protocol == "Encrypted"
+    error_message = "Managed Redis has no plaintext port, and the client protocol should say so."
   }
 
   assert {
-    condition     = azurerm_redis_cache.this.minimum_tls_version == "1.2"
-    error_message = "The cache should refuse TLS below 1.2."
-  }
-
-  assert {
-    condition     = azurerm_redis_cache.this.public_network_access_enabled == false
+    condition     = azurerm_managed_redis.this.public_network_access == "Disabled"
     error_message = "A cache behind a private endpoint has no reason to answer on its public hostname."
   }
 
@@ -35,21 +30,28 @@ run "defaults_are_private_and_tls_only" {
   }
 
   assert {
-    condition     = one(azurerm_private_endpoint.this[0].private_service_connection).subresource_names[0] == "redisCache"
-    error_message = "The private endpoint must target the cache subresource."
+    condition     = one(azurerm_private_endpoint.this[0].private_service_connection).subresource_names[0] == "redisEnterprise"
+    error_message = "Managed Redis is Redis Enterprise underneath, so that is the private endpoint subresource."
   }
 }
 
-run "default_size_matches_the_aws_module" {
+run "a_plain_redis_client_can_talk_to_it" {
+  command = plan
+
+  # OSSCluster shards and needs a cluster-aware client. Onyx reaches Redis
+  # through redis-py as a Celery broker, which is not one.
+  assert {
+    condition     = one(azurerm_managed_redis.this.default_database).clustering_policy == "EnterpriseCluster"
+    error_message = "The single-endpoint mode is what ordinary Redis clients can use."
+  }
+}
+
+run "default_size" {
   command = plan
 
   assert {
-    condition = alltrue([
-      azurerm_redis_cache.this.sku_name == "Standard",
-      azurerm_redis_cache.this.family == "C",
-      azurerm_redis_cache.this.capacity == 3,
-    ])
-    error_message = "Standard C3 is 6 GB with a replica, the size the AWS module defaults to."
+    condition     = azurerm_managed_redis.this.sku_name == "Balanced_B5"
+    error_message = "Balanced_B5 is about 5 GB, the closest shape to what the AWS module defaults to."
   }
 }
 
@@ -62,18 +64,45 @@ run "four_alerts_exist_and_stay_silent" {
   }
 
   assert {
-    condition     = azurerm_monitor_metric_alert.evicted_keys.criteria[0].metric_name == "evictedkeys"
-    error_message = "Azure exposes no swap metric, so evictions replace the AWS swap alarm."
+    condition     = azurerm_monitor_metric_alert.memory_high.criteria[0].metric_namespace == "Microsoft.Cache/redisEnterprise"
+    error_message = "Managed Redis reports under the Redis Enterprise namespace, not the retiring service's."
+  }
+
+  assert {
+    condition     = azurerm_monitor_metric_alert.cpu.criteria[0].metric_name == "percentProcessorTime"
+    error_message = "Redis Enterprise reports processor time rather than the single-thread server load the old service exposed."
   }
 
   assert {
     condition     = azurerm_monitor_metric_alert.evicted_keys.criteria[0].aggregation == "Total"
     error_message = "Evictions are a count over the window, not an average."
   }
+}
+
+run "keys_are_read_off_the_database_not_the_cluster" {
+  command = plan
 
   assert {
-    condition     = azurerm_monitor_metric_alert.server_load.criteria[0].metric_name == "serverLoad"
-    error_message = "Redis runs commands on one thread, so server load is the meaningful CPU signal."
+    condition     = length(data.azurerm_redis_enterprise_database.this) == 1
+    error_message = "The cache resource exposes only a hostname, so the keys come from the database."
+  }
+}
+
+run "keys_can_be_turned_off_for_entra_only_access" {
+  command = plan
+
+  variables {
+    access_keys_enabled = false
+  }
+
+  assert {
+    condition     = one(azurerm_managed_redis.this.default_database).access_keys_authentication_enabled == false
+    error_message = "Turning keys off should reach the database configuration."
+  }
+
+  assert {
+    condition     = length(data.azurerm_redis_enterprise_database.this) == 0
+    error_message = "With keys off there is nothing to read."
   }
 }
 
@@ -85,7 +114,7 @@ run "disabling_the_private_endpoint_reopens_public_access" {
   }
 
   assert {
-    condition     = azurerm_redis_cache.this.public_network_access_enabled == true
+    condition     = azurerm_managed_redis.this.public_network_access == "Enabled"
     error_message = "Without a private endpoint the cache has to be reachable somehow."
   }
 
@@ -93,56 +122,61 @@ run "disabling_the_private_endpoint_reopens_public_access" {
     condition     = length(azurerm_private_endpoint.this) == 0
     error_message = "No private endpoint should be created."
   }
-
-  assert {
-    condition     = length(azurerm_private_dns_zone.this) == 0
-    error_message = "The private DNS zone only exists to serve the private endpoint."
-  }
 }
 
 run "an_existing_dns_zone_is_reused" {
   command = plan
 
   variables {
-    private_dns_zone_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/privateDnsZones/privatelink.redis.cache.windows.net"
+    private_dns_zone_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/privateDnsZones/privatelink.redis.azure.net"
   }
 
   assert {
     condition     = length(azurerm_private_dns_zone.this) == 0
-    error_message = "privatelink.redis.cache.windows.net is a fixed name, so a second cache in the group must reuse the first one's zone."
+    error_message = "privatelink.redis.azure.net is a fixed name, so a second cache in the group must reuse the first one's zone."
   }
 }
 
-run "reusing_a_dns_zone_needs_no_virtual_network" {
+run "rejects_a_sku_that_is_not_one" {
   command = plan
 
-  # The virtual network is only used to link a zone the module creates. A
-  # caller who brings their own zone has already linked it.
   variables {
-    virtual_network_id  = null
-    private_dns_zone_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/onyx-rg/providers/Microsoft.Network/privateDnsZones/privatelink.redis.cache.windows.net"
+    sku_name = "Standard_C3"
   }
 
-  assert {
-    condition     = length(azurerm_private_endpoint.this) == 1
-    error_message = "The private endpoint should still be created."
-  }
-
-  assert {
-    condition     = length(azurerm_private_dns_zone_virtual_network_link.this) == 0
-    error_message = "There is no zone of our own to link."
-  }
+  expect_failures = [var.sku_name]
 }
 
-run "rejects_a_private_endpoint_with_no_dns_anywhere" {
+run "rejects_a_redis_style_eviction_policy" {
+  command = plan
+
+  # Redis Enterprise spells these differently: VolatileLRU, not volatile-lru.
+  variables {
+    eviction_policy = "volatile-lru"
+  }
+
+  expect_failures = [var.eviction_policy]
+}
+
+run "rejects_an_unknown_clustering_policy" {
   command = plan
 
   variables {
-    virtual_network_id  = null
-    private_dns_zone_id = null
+    clustering_policy = "Sharded"
   }
 
-  expect_failures = [var.enable_private_endpoint]
+  expect_failures = [var.clustering_policy]
+}
+
+run "rejects_a_cache_nothing_can_reach" {
+  command = plan
+
+  variables {
+    enable_private_endpoint       = false
+    public_network_access_enabled = false
+  }
+
+  expect_failures = [var.public_network_access_enabled]
 }
 
 run "rejects_a_critical_threshold_below_the_warning_one" {
@@ -154,90 +188,4 @@ run "rejects_a_critical_threshold_below_the_warning_one" {
   }
 
   expect_failures = [var.memory_critical_threshold_percent]
-}
-
-run "rejects_a_fractional_capacity" {
-  command = plan
-
-  variables {
-    capacity = 2.5
-  }
-
-  expect_failures = [var.capacity]
-}
-
-run "rejects_a_cache_nothing_can_reach" {
-  command = plan
-
-  # No private endpoint and no public hostname means every Redis-dependent
-  # workload fails at runtime rather than at plan.
-  variables {
-    enable_private_endpoint       = false
-    public_network_access_enabled = false
-  }
-
-  expect_failures = [var.public_network_access_enabled]
-}
-
-run "rejects_a_family_that_does_not_match_the_tier" {
-  command = plan
-
-  variables {
-    sku_name = "Premium"
-    family   = "C"
-  }
-
-  expect_failures = [var.family]
-}
-
-run "rejects_a_capacity_outside_the_family" {
-  command = plan
-
-  variables {
-    sku_name = "Premium"
-    family   = "P"
-    capacity = 6
-  }
-
-  expect_failures = [var.capacity]
-}
-
-run "rejects_zones_on_a_tier_that_cannot_use_them" {
-  command = plan
-
-  variables {
-    zones = ["1", "2"]
-  }
-
-  expect_failures = [var.zones]
-}
-
-run "rejects_turning_off_every_way_in" {
-  command = plan
-
-  variables {
-    access_keys_enabled = false
-  }
-
-  expect_failures = [var.access_keys_enabled]
-}
-
-run "rejects_a_private_endpoint_with_nowhere_to_put_it" {
-  command = plan
-
-  variables {
-    private_endpoint_subnet_id = null
-  }
-
-  expect_failures = [var.enable_private_endpoint]
-}
-
-run "rejects_an_unknown_eviction_policy" {
-  command = plan
-
-  variables {
-    maxmemory_policy = "evict-everything"
-  }
-
-  expect_failures = [var.maxmemory_policy]
 }

--- a/deployment/terraform/modules/azure/redis/tests/redis.tftest.hcl
+++ b/deployment/terraform/modules/azure/redis/tests/redis.tftest.hcl
@@ -179,6 +179,31 @@ run "rejects_a_sku_that_is_not_one" {
   expect_failures = [var.sku_name]
 }
 
+run "rejects_a_family_spliced_to_the_wrong_letter" {
+  command = plan
+
+  # Each family has its own letter. Balanced uses B, so Balanced_C3 is two
+  # families spliced together rather than a size.
+  variables {
+    sku_name = "Balanced_C3"
+  }
+
+  expect_failures = [var.sku_name]
+}
+
+run "accepts_each_family_with_its_own_letter" {
+  command = plan
+
+  variables {
+    sku_name = "MemoryOptimized_M10"
+  }
+
+  assert {
+    condition     = azurerm_managed_redis.this.sku_name == "MemoryOptimized_M10"
+    error_message = "A correctly paired SKU should reach the resource."
+  }
+}
+
 run "rejects_a_redis_style_eviction_policy" {
   command = plan
 

--- a/deployment/terraform/modules/azure/redis/variables.tf
+++ b/deployment/terraform/modules/azure/redis/variables.tf
@@ -27,9 +27,13 @@ variable "sku_name" {
   description = "Managed Redis SKU, for example \"Balanced_B5\" for 5 GB. The number is roughly the memory in GB."
   default     = "Balanced_B5"
 
+  # Each family uses its own letter, so the letter and the family have to agree:
+  # Balanced_C3 is not a size, it is two families spliced together. Checking the
+  # pairing catches that without pinning an exact SKU list that goes stale every
+  # time Azure adds a size.
   validation {
-    condition     = can(regex("^(Balanced|MemoryOptimized|ComputeOptimized|FlashOptimized)_[A-Z][0-9]+$", var.sku_name))
-    error_message = "sku_name must look like Balanced_B5, MemoryOptimized_M10, ComputeOptimized_X3 or FlashOptimized_A250."
+    condition     = can(regex("^(Balanced_B|MemoryOptimized_M|ComputeOptimized_X|FlashOptimized_A)[0-9]+$", var.sku_name))
+    error_message = "sku_name must pair the family with its own letter: Balanced_B*, MemoryOptimized_M*, ComputeOptimized_X* or FlashOptimized_A* (for example Balanced_B5)."
   }
 }
 

--- a/deployment/terraform/modules/azure/redis/variables.tf
+++ b/deployment/terraform/modules/azure/redis/variables.tf
@@ -15,114 +15,79 @@ variable "resource_group_name" {
 
 variable "location" {
   type        = string
-  description = "Azure region, for example \"eastus\""
+  description = "Azure region, for example \"eastus2\""
 }
 
-# Azure sizes a cache by tier, family and capacity rather than by an instance
-# type. Standard C3 is 6 GB with a replica, which is the size the AWS module
-# defaults to.
+# Azure Managed Redis sizes by a single SKU name rather than the tier, family
+# and capacity that Azure Cache for Redis used. The prefix picks the shape:
+# Balanced is the general purpose one, MemoryOptimized trades vCPU for RAM,
+# ComputeOptimized does the reverse, FlashOptimized puts colder keys on NVMe.
 variable "sku_name" {
   type        = string
-  description = "Cache tier. Basic has no replica and no SLA. Standard adds a replica. Premium adds zone redundancy, persistence and clustering."
-  default     = "Standard"
+  description = "Managed Redis SKU, for example \"Balanced_B5\" for 5 GB. The number is roughly the memory in GB."
+  default     = "Balanced_B5"
 
   validation {
-    condition     = contains(["Basic", "Standard", "Premium"], var.sku_name)
-    error_message = "sku_name must be Basic, Standard or Premium."
+    condition     = can(regex("^(Balanced|MemoryOptimized|ComputeOptimized|FlashOptimized)_[A-Z][0-9]+$", var.sku_name))
+    error_message = "sku_name must look like Balanced_B5, MemoryOptimized_M10, ComputeOptimized_X3 or FlashOptimized_A250."
   }
 }
 
-variable "family" {
-  type        = string
-  description = "SKU family. C goes with Basic and Standard, P goes with Premium."
-  default     = "C"
-
-  validation {
-    condition     = contains(["C", "P"], var.family)
-    error_message = "family must be C or P."
-  }
-
-  validation {
-    condition     = (var.sku_name == "Premium") == (var.family == "P")
-    error_message = "Premium uses family P; Basic and Standard use family C."
-  }
-}
-
-variable "capacity" {
-  type        = number
-  description = "Size within the family. C0 is 250 MB, C1 1 GB, C2 2.5 GB, C3 6 GB, C4 13 GB, C5 26 GB, C6 53 GB. P1 is 6 GB, P2 13 GB, P3 26 GB, P4 53 GB, P5 120 GB."
-  default     = 3
-
-  validation {
-    condition     = floor(var.capacity) == var.capacity
-    error_message = "capacity must be a whole number: the sizes are discrete steps, not a scale."
-  }
-
-  validation {
-    condition     = var.family != "C" || (var.capacity >= 0 && var.capacity <= 6)
-    error_message = "capacity must be between 0 and 6 for family C."
-  }
-
-  validation {
-    condition     = var.family != "P" || (var.capacity >= 1 && var.capacity <= 5)
-    error_message = "capacity must be between 1 and 5 for family P."
-  }
-}
-
-variable "zones" {
-  type        = list(string)
-  description = "Availability zones to spread the cache across. Only Premium offers this."
-  default     = []
-
-  validation {
-    condition     = length(var.zones) == 0 || var.sku_name == "Premium"
-    error_message = "Only the Premium tier can be spread across availability zones."
-  }
-}
-
-variable "minimum_tls_version" {
-  type        = string
-  description = "Minimum TLS version the cache accepts"
-  default     = "1.2"
-
-  validation {
-    condition     = contains(["1.0", "1.1", "1.2"], var.minimum_tls_version)
-    error_message = "minimum_tls_version must be one of: 1.0, 1.1, 1.2."
-  }
-}
-
-# The AWS module takes an auth token as an input. Azure generates the access
-# keys itself and offers no way to set them, so they come back as outputs
-# instead. That removes the need for a caller to invent and store a password.
-variable "access_keys_enabled" {
+variable "high_availability_enabled" {
   type        = bool
-  description = "Allow authenticating with the cache's generated access keys. Turn this off only once every client authenticates with Entra ID."
-  default     = true
-
-  validation {
-    condition     = var.access_keys_enabled || var.enable_entra_authentication
-    error_message = "Turning off access keys leaves no way to authenticate unless enable_entra_authentication is true."
-  }
-}
-
-variable "enable_entra_authentication" {
-  type        = bool
-  description = "Accept Microsoft Entra ID logins. This is the analogue of the AWS module's IAM authentication."
+  description = "Keep a replica in another availability zone. Roughly doubles cost, and is what makes the cache survive a zone failure."
   default     = false
 }
 
-variable "maxmemory_policy" {
+# Managed Redis speaks TLS on 10000 and offers no plaintext port, so there is no
+# equivalent of the old non_ssl_port_enabled or minimum_tls_version.
+variable "client_protocol" {
   type        = string
-  description = "What the cache does when it reaches its memory limit. Onyx uses Redis as a Celery broker, where an eviction silently drops a queued task, so watch the eviction alert if you move off the default."
-  default     = "volatile-lru"
+  description = "Encrypted speaks TLS. Plaintext exists for clients that cannot, and should not be used outside a private network."
+  default     = "Encrypted"
+
+  validation {
+    condition     = contains(["Encrypted", "Plaintext"], var.client_protocol)
+    error_message = "client_protocol must be Encrypted or Plaintext."
+  }
+}
+
+# OSSCluster shards across nodes and needs a cluster-aware client. Onyx uses
+# Redis as a Celery broker through redis-py, which is not, so the single-endpoint
+# mode is the compatible default.
+variable "clustering_policy" {
+  type        = string
+  description = "EnterpriseCluster presents one endpoint and works with ordinary Redis clients. OSSCluster shards and requires a cluster-aware client."
+  default     = "EnterpriseCluster"
+
+  validation {
+    condition     = contains(["EnterpriseCluster", "OSSCluster"], var.clustering_policy)
+    error_message = "clustering_policy must be EnterpriseCluster or OSSCluster."
+  }
+}
+
+# Redis Enterprise names these differently from Redis itself: VolatileLRU rather
+# than volatile-lru.
+variable "eviction_policy" {
+  type        = string
+  description = "What the cache does at its memory limit. Onyx uses Redis as a Celery broker, where an eviction silently drops a queued task, so watch the eviction alert if you move off the default."
+  default     = "VolatileLRU"
 
   validation {
     condition = contains([
-      "noeviction", "allkeys-lru", "volatile-lru", "allkeys-random",
-      "volatile-random", "volatile-ttl", "allkeys-lfu", "volatile-lfu",
-    ], var.maxmemory_policy)
-    error_message = "maxmemory_policy must be one of: noeviction, allkeys-lru, volatile-lru, allkeys-random, volatile-random, volatile-ttl, allkeys-lfu, volatile-lfu."
+      "NoEviction", "AllKeysLRU", "AllKeysLFU", "AllKeysRandom",
+      "VolatileLRU", "VolatileLFU", "VolatileRandom", "VolatileTTL",
+    ], var.eviction_policy)
+    error_message = "eviction_policy must be one of: NoEviction, AllKeysLRU, AllKeysLFU, AllKeysRandom, VolatileLRU, VolatileLFU, VolatileRandom, VolatileTTL."
   }
+}
+
+# Azure generates the access keys and offers no way to set them, so they come
+# back as outputs rather than going in as a variable.
+variable "access_keys_enabled" {
+  type        = bool
+  description = "Allow authenticating with the generated access keys. Turn this off only once every client authenticates with Entra ID through an access policy assignment."
+  default     = true
 }
 
 variable "enable_private_endpoint" {
@@ -131,13 +96,8 @@ variable "enable_private_endpoint" {
   default     = true
 
   validation {
-    condition     = !var.enable_private_endpoint || var.private_endpoint_subnet_id != null
+    condition     = !var.enable_private_endpoint || (var.private_endpoint_subnet_id != null && var.virtual_network_id != null) || (!var.enable_private_endpoint)
     error_message = "enable_private_endpoint requires private_endpoint_subnet_id."
-  }
-
-  validation {
-    condition     = !var.enable_private_endpoint || var.private_dns_zone_id != null || var.virtual_network_id != null
-    error_message = "enable_private_endpoint requires virtual_network_id so the private DNS zone can be linked to it, unless private_dns_zone_id points at a zone that is already linked."
   }
 }
 
@@ -153,12 +113,12 @@ variable "virtual_network_id" {
   default     = null
 }
 
-# privatelink.redis.cache.windows.net is a fixed name shared by every cache in
-# a resource group, so a second module in the same group must be handed the
-# zone the first one made rather than creating its own.
+# privatelink.redis.azure.net is a fixed name shared by every managed cache in a
+# resource group, so a second module in the same group must be handed the zone
+# the first one made rather than creating its own.
 variable "private_dns_zone_id" {
   type        = string
-  description = "Existing privatelink.redis.cache.windows.net zone to use. Null creates one."
+  description = "Existing privatelink.redis.azure.net zone to use. Null creates one."
   default     = null
 }
 
@@ -214,23 +174,17 @@ variable "memory_critical_threshold_percent" {
   }
 }
 
-# Redis runs its commands on one thread, so server load is the meaningful CPU
-# signal, the same reason the AWS module alarms on EngineCPUUtilization rather
-# than host CPU.
-variable "server_load_threshold_percent" {
+variable "cpu_threshold_percent" {
   type        = number
-  description = "serverLoad threshold, the share of time the Redis server thread spent busy"
+  description = "percentProcessorTime threshold. Redis Enterprise reports processor time rather than the single-thread server load the old service exposed."
   default     = 90
 
   validation {
-    condition     = var.server_load_threshold_percent > 0 && var.server_load_threshold_percent <= 100
-    error_message = "server_load_threshold_percent must be between 0 and 100."
+    condition     = var.cpu_threshold_percent > 0 && var.cpu_threshold_percent <= 100
+    error_message = "cpu_threshold_percent must be between 0 and 100."
   }
 }
 
-# Azure exposes no swap metric, so this replaces the AWS module's swap alarm.
-# It catches the same failure one step later: memory pressure that has started
-# costing data.
 variable "evicted_keys_threshold" {
   type        = number
   description = "Evictions per window before alerting. Zero alerts on the first eviction, which for a Celery broker means a dropped task."

--- a/deployment/terraform/modules/azure/redis/variables.tf
+++ b/deployment/terraform/modules/azure/redis/variables.tf
@@ -39,19 +39,6 @@ variable "high_availability_enabled" {
   default     = false
 }
 
-# Managed Redis speaks TLS on 10000 and offers no plaintext port, so there is no
-# equivalent of the old non_ssl_port_enabled or minimum_tls_version.
-variable "client_protocol" {
-  type        = string
-  description = "Encrypted speaks TLS. Plaintext exists for clients that cannot, and should not be used outside a private network."
-  default     = "Encrypted"
-
-  validation {
-    condition     = contains(["Encrypted", "Plaintext"], var.client_protocol)
-    error_message = "client_protocol must be Encrypted or Plaintext."
-  }
-}
-
 # OSSCluster shards across nodes and needs a cluster-aware client. Onyx uses
 # Redis as a Celery broker through redis-py, which is not, so the single-endpoint
 # mode is the compatible default.
@@ -96,8 +83,16 @@ variable "enable_private_endpoint" {
   default     = true
 
   validation {
-    condition     = !var.enable_private_endpoint || (var.private_endpoint_subnet_id != null && var.virtual_network_id != null) || (!var.enable_private_endpoint)
+    condition     = !var.enable_private_endpoint || var.private_endpoint_subnet_id != null
     error_message = "enable_private_endpoint requires private_endpoint_subnet_id."
+  }
+
+  # The virtual network is only used to link a zone this module creates. A
+  # caller reusing an existing zone has already linked it, so demanding the
+  # network there rejects a configuration that is complete.
+  validation {
+    condition     = !var.enable_private_endpoint || var.private_dns_zone_id != null || var.virtual_network_id != null
+    error_message = "enable_private_endpoint requires virtual_network_id so the private DNS zone can be linked to it, unless private_dns_zone_id points at a zone that is already linked."
   }
 }
 

--- a/deployment/terraform/modules/azure/vnet/outputs.tf
+++ b/deployment/terraform/modules/azure/vnet/outputs.tf
@@ -14,8 +14,10 @@ output "address_space" {
 }
 
 output "subnet_ids" {
-  description = "Subnet resource IDs, keyed by the same names as the subnets variable"
+  description = "Subnet resource IDs, keyed by the same names as the subnets variable. Available once any NAT gateway associations exist, so a consumer that needs egress in place does not race them."
   value       = { for key, subnet in azurerm_subnet.this : key => subnet.id }
+
+  depends_on = [azurerm_subnet_nat_gateway_association.this]
 }
 
 output "subnet_address_prefixes" {
@@ -25,9 +27,19 @@ output "subnet_address_prefixes" {
 
 # Convenience outputs for the subnets the other modules expect. Null when the
 # caller replaced the default subnet map and dropped that key.
+#
+# The AKS one waits on the NAT gateway associations. A cluster created with
+# outbound_type = userAssignedNATGateway is rejected outright if its subnet has
+# no gateway attached yet, and nothing else orders the two: the cluster depends
+# on the subnet, the association depends on the subnet, so Terraform is free to
+# run them at the same time. Making the id itself arrive late is what serialises
+# them, and it does so for every consumer rather than asking each one to
+# remember a depends_on.
 output "aks_subnet_id" {
-  description = "Resource ID of the AKS subnet"
+  description = "Resource ID of the AKS subnet, available once any NAT gateway association on it exists"
   value       = try(azurerm_subnet.this["aks"].id, null)
+
+  depends_on = [azurerm_subnet_nat_gateway_association.this]
 }
 
 output "postgres_subnet_id" {


### PR DESCRIPTION
## Description

Eight fixes to the Azure Terraform modules, all found by applying them against a real Azure subscription for the first time -- and then by running Onyx on what came out. None is visible to the mocked test suites, because none of them is about what Terraform generates — they are about what Azure does with it.

**Order AKS after the NAT gateway association.** A cluster created with `outbound_type = userAssignedNATGateway` is rejected outright if its subnet has no gateway attached yet:

```
SubnetNotAssociatedWithNATGateway: Subnet '...onyx-aks' must have a NAT gateway
associated for outbound connection.
```

Nothing ordered the two — the cluster depends on the subnet, the association depends on the subnet, so Terraform was free to create them at the same time, and on a real apply it did. The subnet id outputs now wait on the associations, which serialises it for every consumer rather than asking each one to remember a `depends_on`.

**Expose the workload identity's principal id.** The composition published the identity's *client* id, which annotates a service account, but not its *principal* id, which is what a role assignment takes. Granting that identity access to anything the composition does not itself create — a key vault, a second storage account, a registry — was therefore impossible from outside without reaching into the aks module.

**Move the redis module to Azure Managed Redis.** Azure no longer accepts new Azure Cache for Redis instances:

```
BadRequest: Azure Cache for Redis is retiring, create Azure Managed Redis
instance instead.
```

So the module provisioned a service that could not be provisioned. `azurerm_managed_redis` is a different resource rather than a renamed one, and the differences all surface in the interface — see the breaking-change note below.

**Default to a Kubernetes version AKS still builds.** 1.33 has aged out of standard support into Long-Term-Support only, and AKS refuses to build on an LTS-only version unless the cluster opts into LTS first (`K8sVersionNotSupported`). Now 1.34, with the description saying where the line is and how to check, since this recurs each time a version ages out.

**Stop recreating built-in databases.** PostgreSQL Flexible Server ships a database called `postgres`, so asking Terraform to create one by that name failed with "already exists" — and `postgres` was the module default, which means **the default configuration could not apply at all**. Naming a database the server ships is now read as "use the one that is there".

**Expose the AKS cluster identity.** A `LoadBalancer` service can point at a public IP the cluster does not own, which is how an ingress address survives a chart reinstall. AKS attaches such an IP only if the *cluster* identity holds Network Contributor on it, and the module published the kubelet and workload identities but not that one, so the grant could not be written. Until it was, the service sat pending on `PublicIP from annotation azure-pip-name doesn't exist` -- which reads like the address is missing rather than unreachable. (The grant also has to be on the resource group, not the IP: AKS reads public IPs at the group's network provider scope.)

**Stop provisioning a Redis that Onyx cannot use.** This one is the reason the composition no longer creates a cache by default.

Azure Managed Redis is always clustered. Celery's pidbox opens a `MULTI` spanning keys in several hash slots, and clustered Redis rejects that with `CROSSSLOT`, so every worker fails to start. `EnterpriseCluster` does not avoid it -- it presents one endpoint but still shards underneath, which I confirmed against the live cache rather than taking from the docs. `NoCluster` returns `NotImplemented`. And only database 0 exists, where Onyx wants 0, 14 and 15.

So Azure offers no managed Redis that Onyx can run on: Cache for Redis refuses new instances, and Managed Redis cannot serve Celery. `enable_redis` now defaults to `false` and Redis runs in the cluster, which the chart already supports. The module stays for anyone who wants a cache for something else. The README claimed `EnterpriseCluster` made the cache usable; that claim is corrected.

**Declare the node pool upgrade settings.** Azure fills in `max_surge` itself, so an unmanaged block showed as drift on every plan -- terraform wanted to delete a setting nobody had set -- and a stray apply would have quietly changed how upgrades behave.

Declaring it also puts the number where a reader will find it, which matters more than it looks. The family vCPU quota has to cover the pool and its surge at once: a single-node pool surging by one needs twice the pool's cores, and without them the upgrade fails outright rather than degrading. That is how a cluster ends up unable to leave a Kubernetes version it has aged out of -- which is the state the first Azure deployment is in today, and is now written down in the infra root rather than discovered later.

## How Has This Been Tested?

**Mocked plans:** 153 passing across all seven modules, up from 137.

```
vnet 12 | storage 20 | postgres 27 | redis 17 | aks 35 | waf 16 | onyx 26
```

The two new assertions were mutation-tested: flipping the identity block and flipping the `enable_redis` default each fail exactly the test that covers them.

**Against real Azure**, in a subscription created for this (`onyx-azure-dev`, eastus2). Everything in the composition is now built and verified there: resource group, virtual network with four subnets and a NAT gateway, storage account with its container and lifecycle policy, PostgreSQL Flexible Server with its database and five alerts, **Managed Redis**, an AKS 1.34 cluster with its system pool, the namespace, service account and storage class inside it, the workload identity with its federated credential and role assignment, and the WAF policy.

Both caveats from the first version of this description have now settled, and one of them resolved the opposite way to what it predicted:

- The **index node pool does not converge.** `Standard_E4ds_v7` boots, completes OS provisioning, and then the VM agent never reports, so no extension provisions and the node never joins. Reproduced on a clean create, with no SKU restrictions and quota available. This is an Azure-side problem rather than a module one, and it needs a support ticket; the module is unchanged. The cluster runs with the index pool disabled and OpenSearch on the system pool.
- The **Managed Redis alert metric names** are moot for the default path now that no cache is created unless asked for. They remain the documented Redis Enterprise names.

**Onyx itself now runs on this.** All sixteen pods are healthy, including all seven Celery workers, migrations ran against Azure PostgreSQL, and the app answers on a public address through the ingress.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

**BREAKING CHANGE:** `redis_family` and `redis_capacity` are replaced by a single `redis_sku_name` (`Balanced_B5` for about 5 GB). Managed Redis also speaks TLS on **10000** rather than 6380, spells eviction policies differently (`VolatileLRU`, not `volatile-lru`), exposes no access keys on the resource — they come from the database — and reports under `Microsoft.Cache/redisEnterprise`, where server load is replaced by processor time.

This breaks nobody: Azure will not create the old resource, so no deployment can exist on it.

---

## Changes from review (greptile, cubic)

- **Restored the shared-DNS path in the redis module.** The private endpoint validation demanded `virtual_network_id` whenever it was enabled, even when the caller supplied an existing `private_dns_zone_id`. The network is only used to link a zone this module *creates*, so reusing an already-linked zone had a complete configuration rejected. **This was a regression** — the same rule was fixed on the previous module and my rewrite reintroduced it. Now two validations so each error names what is actually missing, with a test so it does not come back a third time.
- **Removed the plaintext option.** `client_protocol` accepted `Plaintext`. The service this replaced had no plaintext port to enable, so offering one was a weaker guarantee than the module it replaced rather than a new capability. The protocol is now fixed at `Encrypted`.
- **Updated the README**, which still described Azure Cache for Redis, its C3/C4/C5 sizes and port 6380 throughout — the sizing table, the module section, the AWS comparison table and the security notes.

Tests: 140 → 142.


